### PR TITLE
[LoRA] Add the sgl_lora MoE execution engine with JSON config resolution

### DIFF
--- a/benchmark/kernels/fused_moe_triton/common_utils.py
+++ b/benchmark/kernels/fused_moe_triton/common_utils.py
@@ -173,6 +173,14 @@ def get_model_config(
         E = config.n_routed_experts // ep_size
         topk = config.num_experts_per_tok
         intermediate_size = config.moe_intermediate_size
+    elif architecture == "InklingForConditionalGeneration":
+        # Routed experts are non-gated (relu2, one up projection). The runtime
+        # keys its config on N = intermediate_size / TP, which the gated shard
+        # width below reproduces (2 * I / TP, halved in the filename); gemm1 is
+        # therefore tuned at twice its real width while gemm2 is exact.
+        E = config.n_routed_experts // ep_size
+        topk = config.num_experts_per_tok
+        intermediate_size = config.intermediate_size
     else:
         # Default: Mixtral
         E = config.num_local_experts // ep_size

--- a/benchmark/kernels/fused_moe_triton/tune_down_moe.py
+++ b/benchmark/kernels/fused_moe_triton/tune_down_moe.py
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tune a separate ``*_down.json`` config for the fused MoE down GEMM.
+
+``tuning_fused_moe_triton.py`` times the fused pipeline under one config, so
+both GEMMs ship the gate/up winner even though their aspect ratios are
+opposite (gate/up: N = 2 x shard, K = hidden; down: N = hidden, K = shard).
+The runtime already prefers an ``E=...,N=..._down.json`` when one exists and
+only pins BLOCK_SIZE_M across the pair (one moe_align sort feeds both).
+
+This script pins the tuned gate/up config per batch size and sweeps down
+candidates that share its BLOCK_SIZE_M, timing the same fused call the main
+tuner times: the gate/up term is constant, so the argmin isolates the down
+kernel. Run it after the main tuner, pointing --gate-up-config at its output.
+"""
+
+import argparse
+import json
+import os
+import sys
+from contextlib import nullcontext
+
+import torch
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import tuning_fused_moe_triton as tuner  # noqa: E402
+from common_utils import (  # noqa: E402
+    get_configs_compute_bound,
+    get_default_batch_sizes,
+    get_model_config,
+    sort_config,
+)
+
+from sglang.srt.layers.moe.moe_runner.triton_utils import (  # noqa: E402
+    fused_moe as fused_moe_mod,
+)
+from sglang.srt.layers.moe.moe_runner.triton_utils import (  # noqa: E402
+    fused_moe_triton_config as cfg_mod,
+)
+from sglang.srt.layers.moe.moe_runner.triton_utils.fused_moe_triton_config import (  # noqa: E402
+    get_config_file_name,
+)
+from sglang.srt.server_args import (  # noqa: E402
+    ServerArgs,
+    set_global_server_args_for_scheduler,
+)
+
+_PIN = {"gate_up": None, "down": None}
+
+
+def _patched_try_get_optimal(*args, **kwargs):
+    if kwargs.get("return_down_config") or (len(args) >= 7 and args[6]):
+        return dict(_PIN["gate_up"]), (dict(_PIN["down"]), _PIN["down"]["BLOCK_SIZE_M"])
+    return dict(_PIN["gate_up"])
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--tp-size", type=int, required=True)
+    parser.add_argument("--ep-size", type=int, default=1)
+    parser.add_argument("--dtype", default="fp8_w8a8")
+    parser.add_argument("--gate-up-config", required=True,
+                        help="the main tuner's output json for this geometry")
+    parser.add_argument("--batch-sizes", type=int, nargs="*", default=None)
+    parser.add_argument("--out-dir", default=".")
+    parser.add_argument("--disable-shared-experts-fusion", action="store_true")
+    args = parser.parse_args()
+
+    server_args = ServerArgs(
+        model_path=args.model, tp_size=args.tp_size, ep_size=args.ep_size
+    )
+    # Mirror the main tuner's BenchmarkWorker.__init__: benchmark_config
+    # allocates tensors without device=, so the default device must be cuda.
+    torch.set_default_device("cuda")
+    torch.cuda.manual_seed_all(0)
+    set_global_server_args_for_scheduler(server_args)
+    model_config = get_model_config(
+        args.model, args.tp_size, args.ep_size, args.disable_shared_experts_fusion
+    )
+    E = model_config["num_experts"]
+    topk = model_config["topk"]
+    hidden_size = model_config["hidden_size"]
+    shard_intermediate_size = model_config["shard_intermediate_size"]
+    dtype = model_config["dtype"]
+    block_shape = model_config["block_shape"]
+    use_fp8_w8a8 = args.dtype == "fp8_w8a8"
+
+    gate_up = {int(k): v for k, v in json.load(open(args.gate_up_config)).items()}
+    batch_sizes = args.batch_sizes or get_default_batch_sizes()
+    space = get_configs_compute_bound()
+
+    # The fused call must resolve configs through our pin, not the override.
+    # benchmark_config also reads the tuner's module-global ``args.model``.
+    tuner.args = args
+    tuner.override_config = lambda *_a, **_k: nullcontext()
+    cfg_mod.try_get_optimal_moe_config = _patched_try_get_optimal
+    fused_moe_mod.try_get_optimal_moe_config = _patched_try_get_optimal
+
+    results = {}
+    for M in batch_sizes:
+        pinned = dict(gate_up[min(gate_up, key=lambda k: abs(k - M))])
+        block_m = pinned["BLOCK_SIZE_M"]
+        cands, seen = [], set()
+        for c in space:
+            c = dict(c)
+            c["BLOCK_SIZE_M"] = block_m  # one sort feeds both GEMMs
+            key = tuple(sorted(c.items()))
+            if key not in seen:
+                seen.add(key)
+                cands.append(c)
+        _PIN["gate_up"] = pinned
+        best, best_t = None, float("inf")
+        first_err = None
+        for cand in cands:
+            _PIN["down"] = cand
+            try:
+                t = tuner.benchmark_config(
+                    cand, M, E, shard_intermediate_size, hidden_size, topk,
+                    dtype, use_fp8_w8a8, False, False, False, False,
+                    block_shape, num_iters=10,
+                )
+            except Exception as e:
+                if first_err is None:
+                    first_err = repr(e)[:300]
+                continue
+            if t < best_t:
+                best_t, best = t, cand
+        assert best is not None, (
+            f"no down candidate compiled at M={M}; first error: {first_err}"
+        )
+        results[M] = sort_config(best)
+        print(f"M={M}: best down {results[M]} ({best_t*1e3:.1f}us)", flush=True)
+
+    name = get_config_file_name(
+        E, shard_intermediate_size // 2,
+        cfg_mod.get_config_dtype_str(dtype, use_fp8_w8a8=use_fp8_w8a8),
+        block_shape, down_moe=True,
+    )
+    path = os.path.join(args.out_dir, name)
+    json.dump(results, open(path, "w"), indent=4)
+    print(f"wrote {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/kernels/lora_moe/README.md
+++ b/benchmark/kernels/lora_moe/README.md
@@ -20,9 +20,10 @@ Four things pick what a layer executes, and they run at two different times.
    row matches, the `fallback` rows are walked the same way instead.
 2. **Provider.** Joined from two places: the matched row's `base_gemm_rows`
    (`expert_major` / `route_major`) says which row order the plan needs, and
-   `--moe-lora-base-gemm` says which vendor implements it (`cutedsl` default
-   or route-major-only `triton`). A geometry a vendor cannot admit fails at
-   attach.
+   `--moe-runner-backend lora_<vendor>` says which vendor implements it
+   (`cutedsl`, the bf16/fp8 default; `triton`; `marlin`, the nvfp4 default).
+   Triton and Marlin have no masked slab domain and run an `expert_major` row
+   on their route-major class. A geometry a vendor cannot admit fails at attach.
 3. **Tile rules.** `resolve_tiles` takes that row's rule list and drops every
    rule whose `max_rank` is below the bound rank. What survives is a ladder.
 
@@ -109,7 +110,8 @@ size instead of arguing about the fourth digit.
 
 ## Scripts here
 
-- `tune_lora_config.py` — report which shipped rows serve a model (`--check`) and emit a seed plan table whose `domain`
+- `tune_lora_config.py` — report which shipped rows serve a model for one
+  `--quant-family` (`--check`) and emit a seed plan table whose `domain`
   covers it (`--emit-seed`) into an output directory that
   `SGLANG_LORA_MOE_CONFIG_DIR` can point at directly. The seed reuses existing
   plans: validate admission and correctness on the new geometry, then tune it

--- a/benchmark/kernels/lora_moe/README.md
+++ b/benchmark/kernels/lora_moe/README.md
@@ -1,0 +1,120 @@
+# Changing the MoE LoRA config tables
+
+The file format is documented next to the tables, in
+`python/sglang/srt/lora/moe/configs/README.md`. This file is about the other
+half: how selection actually cascades, how to change a table without breaking
+a case you did not think about, and how to tell a real measurement from a
+hopeful one.
+
+Read this before editing `{arch}.plans.json` or `{arch}.tiles.json` by hand.
+
+## The cascade, in the order it runs
+
+Four things pick what a layer executes, and they run at two different times.
+
+**At weight bind (once per layer, per server):**
+
+1. **Plan row.** `resolve_plans` walks `scenarios` top to bottom and takes the
+   FIRST row whose `layout`, `phase` and `max_rank` all admit this layer. An
+   absent key is a wildcard. If the model's geometry is outside `domain`, or no
+   row matches, the `fallback` rows are walked the same way instead.
+2. **Provider.** Joined from two places: the matched row's `base_gemm_rows`
+   (`expert_major` / `route_major`) says which row order the plan needs, and
+   `--moe-lora-base-gemm` says which vendor implements it (`cutedsl` default
+   or route-major-only `triton`). A geometry a vendor cannot admit fails at
+   attach.
+3. **Tile rules.** `resolve_tiles` takes that row's rule list and drops every
+   rule whose `max_rank` is below the bound rank. What survives is a ladder.
+
+**Per forward:**
+
+4. **Tile pick.** `TileTable.config_for(num_tokens)` walks the surviving ladder
+   and takes the first rule whose `max_tokens` admits this batch.
+
+Two consequences that are easy to miss, and both have bitten:
+
+- **A rule with no `max_tokens` terminates the ladder.** Everything below it is
+  unreachable for any rank that rule survives at. `decode.per_expert`'s
+  `max_rank: 16` rule has no `max_tokens`, so at rank 16 the whole rest of the
+  ladder is dead. If you add a rule and it seems to do nothing, check whether an
+  earlier rule ends the ladder first.
+- **Ordering is the only precedence.** There is no specificity scoring. A
+  catch-all placed above a narrow rule silently wins.
+
+## Before you change a table
+
+Work out, on paper, the full cross product of (rank × tokens) the change
+touches, and which cells must be **unchanged**. You need that list twice: to
+convince yourself the edit is scoped, and to read the benchmark afterwards.
+
+`test_moe_lora_plan_tables.py` has a helper shape worth copying — resolve the
+table for several ranks and assert the whole matrix, e.g. rank 32 walking
+tiny/mid/mid/large across 4/16/32/33 tokens. Asserting the matrix catches an
+ordering mistake that asserting one cell will not.
+
+## Measuring a change
+
+Point `SGLANG_LORA_MOE_CONFIG_DIR` at a directory holding **only the file you
+are changing**. Lookup falls back per file, so a directory with just
+`gb300.tiles.json` still gets its plans from the package. Do not copy files you
+are not changing — a stale copy is worse than none.
+
+Two different questions, two different setups, do not mix them:
+
+- **"Is this candidate faster?"** — force the candidate on one row and compare
+  against the shipped table. Fine for exploring.
+- **"Does the table I am about to commit do what I claim?"** — run the actual
+  edited file against the actual old file, same tree, same flags, nothing else
+  different. This is the one that belongs in a commit message.
+
+### Reading the result
+
+**The cells your change cannot reach are the control.** If the change only
+touches tokens 17–32 at rank ≤32, then batches 1, 8 and 16 must come back flat.
+When they do, they also measure the run-to-run noise for that machine and model
+on that day, which is what makes the cell that did move interpretable. When they
+do not, something else moved — stop and find out what.
+
+A candidate that is byte-identical to the incumbent is a **self-check, not a
+test**. It should reproduce the baseline; it tells you the forcing mechanism
+works. It does not tell you the incumbent is right. Check before concluding
+anything: two rules in a shipped ladder may already hold the same values.
+
+Protocol used by every number in the campaign docs: four passes per batch size,
+median after discarding the first, batch sizes 1/8/16/32, 4096 in / 1024 out,
+`--max-loras-per-batch 4`. Noise is about ±2%, wider at batch 1. **Effects under
+about 1% cannot be resolved by this protocol** — take more passes at one batch
+size instead of arguing about the fourth digit.
+
+## Traps that have cost real time
+
+- **`SGLANG_LORA_MOE_CONFIG_DIR` also moves the base-GEMM search root.** The
+  `base_gemm/` bucket tables resolve under the same root. Lookup falls back per
+  file, so an override directory without a `base_gemm/` subtree still finds the
+  packaged ones — but check `configs/base_gemm/` before assuming a forced run
+  and its baseline used the same base-GEMM tables.
+- **Do not index rules positionally in tooling.** A script that says "rule 2 is
+  the mid-M one" breaks the moment anyone inserts a rule. Match on the
+  predicate instead.
+- **Some rules are duplicated on purpose, and nothing enforces it.** See the
+  note in `configs/README.md`. If you retune one of a duplicated pair, retune
+  the other in the same edit.
+- **Vendor and row order are different axes, and the config only holds one.**
+  `base_gemm_rows` in the table is the row order; the vendor is the server flag.
+  Changing the row order changes the memory footprint and can make a server
+  fail to start; changing the vendor does not. Measure them separately or you
+  will not know which one moved the number — an earlier sweep forced whole
+  providers and conflated the two, which is how a 30% decode result got
+  attributed to the wrong axis.
+
+## Scripts here
+
+- `tune_lora_config.py` — report which shipped rows serve a model (`--check`) and emit a seed plan table whose `domain`
+  covers it (`--emit-seed`) into an output directory that
+  `SGLANG_LORA_MOE_CONFIG_DIR` can point at directly. The seed reuses existing
+  plans: validate admission and correctness on the new geometry, then tune it
+  end to end with the campaign protocol. The former `--sweep` mode was retired.
+- `sweep_masked_gemm_configs.py` — sweep masked base-GEMM launch configs for one
+  geometry on the current device and emit the M-bucketed store.
+- `make_config_variant.py` — build a one-file override directory for a
+  forcing run, matching rows by name rather than by position.

--- a/benchmark/kernels/lora_moe/make_config_variant.py
+++ b/benchmark/kernels/lora_moe/make_config_variant.py
@@ -1,0 +1,96 @@
+"""Build a named-row override for A/B runs via SGLANG_LORA_MOE_CONFIG_DIR."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import os
+
+_REPO_ROOT = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
+_CONFIG_DIR = os.path.join(
+    _REPO_ROOT, "python", "sglang", "srt", "lora", "moe", "configs"
+)
+
+
+def _load(arch: str, kind: str) -> dict:
+    with open(os.path.join(_CONFIG_DIR, f"{arch}.{kind}.json")) as handle:
+        return json.load(handle)
+
+
+def _match_rule(rules: list[dict], spec: str) -> dict:
+    if spec == "wildcard":
+        want = {}
+    else:
+        want = {
+            key: int(value)
+            for key, value in (part.split("=") for part in spec.split(","))
+        }
+    hits = [
+        rule
+        for rule in rules
+        if {k: v for k, v in rule.items() if k != "sites"} == want
+    ]
+    if len(hits) != 1:
+        preds = [{k: v for k, v in r.items() if k != "sites"} for r in rules]
+        raise SystemExit(f"predicate {want} matched {len(hits)} of {preds}")
+    return hits[0]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("kind", choices=("tiles", "plans"))
+    parser.add_argument("--arch", required=True)
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--row", required=True, help="plan row name, exact")
+    parser.add_argument("--from-rule", help="tiles: predicate of the rule to force")
+    parser.add_argument("--drop", action="store_true", help="tiles: delete the row")
+    parser.add_argument(
+        "--base-gemm-rows",
+        choices=("expert_major", "route_major"),
+        help="plans: new base-GEMM row order for the row",
+    )
+    args = parser.parse_args()
+
+    table = copy.deepcopy(_load(args.arch, args.kind))
+    if args.kind == "tiles":
+        if args.drop == bool(args.from_rule):
+            raise SystemExit("tiles: pass exactly one of --from-rule / --drop")
+        if args.row not in table["rules"]:
+            raise SystemExit(f"no tile rules for row {args.row!r}")
+        if args.drop:
+            del table["rules"][args.row]
+            tag = "builtin"
+        else:
+            rule = _match_rule(table["rules"][args.row], args.from_rule)
+            table["rules"][args.row] = [{"sites": copy.deepcopy(rule["sites"])}]
+            tag = args.from_rule.replace("=", "").replace(",", "_")
+    else:
+        if not args.base_gemm_rows:
+            raise SystemExit("plans: --base-gemm-rows is required")
+        rows = [
+            row
+            for row in table["scenarios"] + table.get("fallback", [])
+            if row["name"] == args.row
+        ]
+        if not rows:
+            raise SystemExit(f"no plan row named {args.row!r}")
+        before = {row["base_gemm_rows"] for row in rows}
+        for row in rows:
+            row["base_gemm_rows"] = args.base_gemm_rows
+        tag = args.base_gemm_rows
+        print(f"{args.row}: {'/'.join(sorted(before))} -> {args.base_gemm_rows}")
+
+    out = os.path.join(args.out, f"{args.row}__{tag}")
+    os.makedirs(out, exist_ok=True)
+    path = os.path.join(out, f"{args.arch}.{args.kind}.json")
+    with open(path, "w") as handle:
+        json.dump(table, handle, indent=1)
+        handle.write("\n")
+    print(f"wrote {path}\n  SGLANG_LORA_MOE_CONFIG_DIR={out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/kernels/lora_moe/sweep_masked_gemm_configs.py
+++ b/benchmark/kernels/lora_moe/sweep_masked_gemm_configs.py
@@ -1,12 +1,6 @@
-"""Sweep masked base-GEMM launch configs and emit the M-bucketed JSON store.
+"""Sweep BF16/FP8 base-GEMM tiles using the target device and TP-sharded geometry.
 
-Runs the MoE LoRA providers' S2/S4 masked GEMMs over a grid of ``expected_m``
-buckets on the current device and writes the store files consumed by
-``gemm_config_store.load_config_table``.  Only buckets that beat the built-in
-heuristic by at least ``--min-gain`` get entries — sparse tables are fine,
-nearest-M covers the gaps.
-
-Run on the target device with the layer's real TP-sharded geometry.
+Emit nearest-M config overrides only for gains above --min-gain.
 """
 
 from __future__ import annotations
@@ -75,6 +69,48 @@ def _quant_info(args, device) -> MoeLoraBf16QuantInfo:
     )
 
 
+def _fp8_block_quant(weight: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize 128x128 blocks, including partial TP-shard tail blocks."""
+    e, rows, cols = weight.shape
+    block = 128
+    rb = (rows + block - 1) // block
+    cb = (cols + block - 1) // block
+    scale = torch.empty((e, rb, cb), dtype=torch.float32, device=weight.device)
+    q = torch.empty_like(weight, dtype=torch.float8_e4m3fn)
+    fmax = torch.finfo(torch.float8_e4m3fn).max
+    for i in range(rb):
+        for j in range(cb):
+            blk = weight[
+                :, i * block : (i + 1) * block, j * block : (j + 1) * block
+            ].float()
+            amax = blk.abs().amax(dim=(1, 2)).clamp(min=1e-6)
+            s = amax / fmax
+            scale[:, i, j] = s
+            q[:, i * block : (i + 1) * block, j * block : (j + 1) * block] = (
+                blk / s[:, None, None]
+            ).to(torch.float8_e4m3fn)
+    return q, scale
+
+
+def _fp8_quant_info(args, device):
+    """Build synthetic FP8 weights with FP32 block scales."""
+    from sglang.srt.lora.moe.quant_info import MoeLoraFp8QuantInfo
+
+    bf16 = _quant_info(args, device)
+    w13_q, w13_s = _fp8_block_quant(bf16.w13_weight)
+    w2_q, w2_s = _fp8_block_quant(bf16.w2_weight)
+    return MoeLoraFp8QuantInfo(
+        w13_weight=w13_q,
+        w13_scale=w13_s,
+        w2_weight=w2_q,
+        w2_scale=w2_s,
+        block_shape=(128, 128),
+        num_local_experts=args.num_local_experts,
+        intermediate_size=args.intermediate_size,
+        hidden_size=args.hidden_size,
+    )
+
+
 def _stage_times(provider, ws) -> float:
     gateup_out = torch.empty(
         provider.gateup_out_shape(ws), device="cuda", dtype=torch.bfloat16
@@ -88,7 +124,9 @@ def _stage_times(provider, ws) -> float:
     return t1 + t2
 
 
-def sweep_cutedsl(args, buckets, device) -> dict[int, dict]:
+def sweep_cutedsl(
+    args, buckets, device, provider_cls=None, quant_info=None
+) -> dict[int, dict]:
     from sglang.srt.lora.moe.base_gemm_provider.cutedsl_bf16 import (
         CuteDslBf16MaskedProvider,
     )
@@ -96,8 +134,14 @@ def sweep_cutedsl(args, buckets, device) -> dict[int, dict]:
         GroupedGemmConfig,
     )
 
-    provider = CuteDslBf16MaskedProvider(_quant_info(args, device))
-    provider._config_table = None  # sweep against the pristine heuristic
+    if provider_cls is None:
+        provider_cls = CuteDslBf16MaskedProvider
+    if quant_info is None:
+        quant_info = _quant_info(args, device)
+    provider = provider_cls(quant_info)
+    # Ignore the installed bucket selection for the heuristic baseline; tile
+    # and cluster settings already compiled (installed store or --tiles) remain.
+    provider._config_table = None
     for spec in args.tiles.split(",") if args.tiles else ():
         token_width, clusters = (int(part) for part in spec.split(":"))
         if token_width in provider._compiled:
@@ -112,8 +156,13 @@ def sweep_cutedsl(args, buckets, device) -> dict[int, dict]:
             persistent_clusters=clusters,
         )
         provider._compiled[token_width] = {}
-        provider._compile_stage(token_width, "gemm1")
-        provider._compile_stage(token_width, "gemm2")
+        try:
+            provider._compile_stage(token_width, "gemm1")
+            provider._compile_stage(token_width, "gemm2")
+        except Exception as exc:  # kernel rejects unsupported tile geometries
+            print(f"skipping tile width {token_width}: {exc}")
+            provider._compiled.pop(token_width, None)
+            provider._tile_configs.pop(token_width, None)
     torch.cuda.synchronize(device)
 
     clusters_of = {
@@ -124,16 +173,22 @@ def sweep_cutedsl(args, buckets, device) -> dict[int, dict]:
     for bucket_m in buckets:
         hidden, topk_ids = _workload(bucket_m, args, device)
         m_max = (hidden.shape[0] // 256 + 1) * 256
-        heuristic = CuteDslBf16MaskedProvider._token_width_for(
-            provider, m_max, bucket_m
-        )
+        heuristic = provider_cls._token_width_for(provider, m_max, bucket_m)
         per_width = {}
         for width in sorted(provider._compiled):
-            if m_max > width * provider._max_token_clusters:
+            max_clusters = getattr(provider, "_max_token_clusters", None)
+            if max_clusters is not None and m_max > width * max_clusters:
+                continue
+            try:
+                provider._admit_tile_width(width)
+            except ValueError:
                 continue
             provider._token_width_for = lambda m_max, expected_m, _w=width: _w
             ws = provider.prepare(hidden, topk_ids, args.top_k)
             per_width[width] = _stage_times(provider, ws)
+            # Release masked slabs before the next candidate to bound memory.
+            del ws
+            torch.cuda.empty_cache()
         del provider._token_width_for
         best = min(per_width, key=per_width.get)
         gain = 1.0 - per_width[best] / per_width[heuristic]
@@ -209,6 +264,19 @@ def _emit(provider_key, results, args, version) -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--family",
+        choices=("bf16", "fp8"),
+        default="bf16",
+        help="weight family to sweep; picks the matching providers",
+    )
+    parser.add_argument(
+        "--domain",
+        choices=("masked", "contiguous"),
+        default="masked",
+        help="base-GEMM row domain: masked (decode rows) or contiguous "
+        "(prefill rows)",
+    )
     parser.add_argument("--num-local-experts", type=int, required=True)
     parser.add_argument("--hidden-size", type=int, required=True)
     parser.add_argument("--intermediate-size", type=int, required=True)
@@ -227,11 +295,47 @@ def main() -> None:
     device = torch.device("cuda")
     buckets = [int(m) for m in args.buckets.split(",")]
     device_name = get_device_name()
-    results = sweep_cutedsl(args, buckets, device)
-    version = {"generated_on": device_name}
+    cutedsl_ver = {"generated_on": device_name}
     if cutedsl_version():
-        version["cutedsl"] = cutedsl_version()
-    _emit("cutedsl_bf16_masked", results, args, version)
+        cutedsl_ver["cutedsl"] = cutedsl_version()
+    if args.family == "bf16" and args.domain == "contiguous":
+        from sglang.srt.lora.moe.base_gemm_provider.cutedsl_bf16 import (
+            CuteDslBf16ContiguousProvider,
+        )
+
+        results = sweep_cutedsl(
+            args, buckets, device, provider_cls=CuteDslBf16ContiguousProvider
+        )
+        _emit("cutedsl_bf16_contiguous", results, args, cutedsl_ver)
+    elif args.family == "fp8" and args.domain == "contiguous":
+        from sglang.srt.lora.moe.base_gemm_provider.cutedsl_fp8 import (
+            CuteDslFp8ContiguousProvider,
+        )
+
+        results = sweep_cutedsl(
+            args,
+            buckets,
+            device,
+            provider_cls=CuteDslFp8ContiguousProvider,
+            quant_info=_fp8_quant_info(args, device),
+        )
+        _emit("cutedsl_fp8_contiguous", results, args, cutedsl_ver)
+    elif args.family == "bf16":
+        results = sweep_cutedsl(args, buckets, device)
+        _emit("cutedsl_bf16_masked", results, args, cutedsl_ver)
+    elif args.family == "fp8":
+        from sglang.srt.lora.moe.base_gemm_provider.cutedsl_fp8 import (
+            CuteDslFp8MaskedProvider,
+        )
+
+        results = sweep_cutedsl(
+            args,
+            buckets,
+            device,
+            provider_cls=CuteDslFp8MaskedProvider,
+            quant_info=_fp8_quant_info(args, device),
+        )
+        _emit("cutedsl_fp8_masked", results, args, cutedsl_ver)
 
 
 if __name__ == "__main__":

--- a/benchmark/kernels/lora_moe/sweep_masked_gemm_configs.py
+++ b/benchmark/kernels/lora_moe/sweep_masked_gemm_configs.py
@@ -1,0 +1,238 @@
+"""Sweep masked base-GEMM launch configs and emit the M-bucketed JSON store.
+
+Runs the MoE LoRA providers' S2/S4 masked GEMMs over a grid of ``expected_m``
+buckets on the current device and writes the store files consumed by
+``gemm_config_store.load_config_table``.  Only buckets that beat the built-in
+heuristic by at least ``--min-gain`` get entries — sparse tables are fine,
+nearest-M covers the gaps.
+
+Run on the target device with the layer's real TP-sharded geometry.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+
+import torch
+
+from sglang.srt.lora.moe.base_gemm_provider.gemm_config_store import (
+    config_file_name,
+    cutedsl_version,
+)
+from sglang.srt.lora.moe.quant_info import MoeLoraBf16QuantInfo
+from sglang.srt.utils import get_device_name
+
+DEFAULT_BUCKETS = "4,8,16,32,48,64,96,128,192,256,384,512"
+
+
+def _time_ms(fn, *, warmup: int, iters: int) -> float:
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    times = []
+    for _ in range(iters):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        fn()
+        end.record()
+        end.synchronize()
+        times.append(start.elapsed_time(end))
+    return statistics.median(times)
+
+
+def _workload(bucket_m: int, args, device) -> tuple[torch.Tensor, torch.Tensor]:
+    num_tokens = max(1, bucket_m * args.num_local_experts // args.top_k)
+    # Balanced routing with distinct experts per token (requires top_k <= E).
+    topk_ids = (
+        torch.arange(num_tokens * args.top_k, device=device)
+        .view(num_tokens, args.top_k)
+        .remainder(args.num_local_experts)
+        .to(torch.int32)
+    )
+    hidden = torch.randn(
+        (num_tokens, args.hidden_size), device=device, dtype=torch.bfloat16
+    )
+    return hidden, topk_ids
+
+
+def _quant_info(args, device) -> MoeLoraBf16QuantInfo:
+    shape13 = (
+        args.num_local_experts,
+        args.gate_up_slices * args.intermediate_size,
+        args.hidden_size,
+    )
+    shape2 = (args.num_local_experts, args.hidden_size, args.intermediate_size)
+    return MoeLoraBf16QuantInfo(
+        w13_weight=torch.randn(shape13, device=device, dtype=torch.bfloat16) * 0.05,
+        w2_weight=torch.randn(shape2, device=device, dtype=torch.bfloat16) * 0.05,
+        num_local_experts=args.num_local_experts,
+        intermediate_size=args.intermediate_size,
+        hidden_size=args.hidden_size,
+    )
+
+
+def _stage_times(provider, ws) -> float:
+    gateup_out = torch.empty(
+        provider.gateup_out_shape(ws), device="cuda", dtype=torch.bfloat16
+    )
+    act = torch.randn(provider.act_out_shape(ws), device="cuda", dtype=torch.bfloat16)
+    down_out = torch.empty(
+        provider.down_out_shape(ws), device="cuda", dtype=torch.bfloat16
+    )
+    t1 = _time_ms(lambda: provider.gateup(ws, gateup_out), warmup=10, iters=50)
+    t2 = _time_ms(lambda: provider.down(ws, act, down_out), warmup=10, iters=50)
+    return t1 + t2
+
+
+def sweep_cutedsl(args, buckets, device) -> dict[int, dict]:
+    from sglang.srt.lora.moe.base_gemm_provider.cutedsl_bf16 import (
+        CuteDslBf16MaskedProvider,
+    )
+    from sglang.srt.lora.moe.kernels.cutedsl.api import (
+        GroupedGemmConfig,
+    )
+
+    provider = CuteDslBf16MaskedProvider(_quant_info(args, device))
+    provider._config_table = None  # sweep against the pristine heuristic
+    for spec in args.tiles.split(",") if args.tiles else ():
+        token_width, clusters = (int(part) for part in spec.split(":"))
+        if token_width in provider._compiled:
+            print(f"tile width {token_width} is already compiled; ignoring :{clusters}")
+            continue
+        provider._tile_configs[token_width] = GroupedGemmConfig(
+            mma_tiler_mn=(provider.OUTPUT_WIDTH, token_width),
+            cluster_shape_mn=provider.CLUSTER_SHAPE_MN,
+            use_2cta_instrs=provider.USE_2CTA_INSTRS,
+            occupancy=1,
+            mma_inst_tile_k=4,
+            persistent_clusters=clusters,
+        )
+        provider._compiled[token_width] = {}
+        provider._compile_stage(token_width, "gemm1")
+        provider._compile_stage(token_width, "gemm2")
+    torch.cuda.synchronize(device)
+
+    clusters_of = {
+        width: provider._tile_configs[width].persistent_clusters
+        for width in provider._compiled
+    }
+    results: dict[int, dict] = {}
+    for bucket_m in buckets:
+        hidden, topk_ids = _workload(bucket_m, args, device)
+        m_max = (hidden.shape[0] // 256 + 1) * 256
+        heuristic = CuteDslBf16MaskedProvider._token_width_for(
+            provider, m_max, bucket_m
+        )
+        per_width = {}
+        for width in sorted(provider._compiled):
+            if m_max > width * provider._max_token_clusters:
+                continue
+            provider._token_width_for = lambda m_max, expected_m, _w=width: _w
+            ws = provider.prepare(hidden, topk_ids, args.top_k)
+            per_width[width] = _stage_times(provider, ws)
+        del provider._token_width_for
+        best = min(per_width, key=per_width.get)
+        gain = 1.0 - per_width[best] / per_width[heuristic]
+        results[bucket_m] = {
+            "heuristic": heuristic,
+            "best": best,
+            "gain": gain,
+            "times": per_width,
+            "clusters": clusters_of[best],
+            "heuristic_clusters": clusters_of[heuristic],
+        }
+    return results
+
+
+def _emit(provider_key, results, args, version) -> None:
+    # The store picks the nearest emitted bucket, so every measured bucket is
+    # written: a sub-threshold cell keeps its heuristic width instead of
+    # inheriting a neighbour's winner.
+    def _wins(row) -> bool:
+        return row["best"] != row["heuristic"] and row["gain"] >= args.min_gain
+
+    def _chosen(row) -> tuple[int, int]:
+        if _wins(row):
+            return row["best"], row["clusters"]
+        return row["heuristic"], row["heuristic_clusters"]
+
+    buckets = {
+        str(m): {"token_width": _chosen(row)[0]} for m, row in sorted(results.items())
+    }
+    winners = {str(m) for m, row in results.items() if _wins(row)}
+    name = config_file_name(
+        provider_key,
+        num_local_experts=args.num_local_experts,
+        n_gemm1=args.gate_up_slices * args.intermediate_size,
+        n_gemm2=args.hidden_size,
+        k=args.hidden_size,
+        device_name=get_device_name(),
+    )
+    print(f"\n== {provider_key} ==")
+    for m, row in sorted(results.items()):
+        marker = "*" if str(m) in winners else " "
+        print(
+            f"{marker} M={m:>4} heuristic={row['heuristic']:>5} "
+            f"best={row['best']:>5} gain={row['gain'] * 100:+.1f}% "
+            f"times={ {k: round(v, 4) for k, v in row['times'].items()} }"
+        )
+    if not winners:
+        print(
+            f"no bucket beat the heuristic by >= {args.min_gain:.0%}; "
+            f"not writing {name}"
+        )
+        return
+    payload: dict = {"version": version, "buckets": buckets}
+    payload["tiles"] = sorted(
+        (
+            {"token_width": width, "persistent_clusters": clusters}
+            for width, clusters in (_chosen(row) for row in results.values())
+        ),
+        key=lambda tile: tile["token_width"],
+    )
+    seen = set()
+    payload["tiles"] = [
+        tile
+        for tile in payload["tiles"]
+        if tile["token_width"] not in seen and not seen.add(tile["token_width"])
+    ]
+    path = os.path.join(args.output_dir, name)
+    with open(path, "w") as f:
+        json.dump(payload, f, indent=2)
+        f.write("\n")
+    print(f"wrote {path}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--num-local-experts", type=int, required=True)
+    parser.add_argument("--hidden-size", type=int, required=True)
+    parser.add_argument("--intermediate-size", type=int, required=True)
+    parser.add_argument("--gate-up-slices", type=int, default=2)
+    parser.add_argument("--top-k", type=int, required=True)
+    parser.add_argument(
+        "--buckets", default=DEFAULT_BUCKETS, help="comma-separated expected_m grid"
+    )
+    parser.add_argument(
+        "--tiles", default="", help="extra CuTeDSL candidates, e.g. '32:128,128:152'"
+    )
+    parser.add_argument("--min-gain", type=float, default=0.02)
+    parser.add_argument("--output-dir", default=".")
+    args = parser.parse_args()
+
+    device = torch.device("cuda")
+    buckets = [int(m) for m in args.buckets.split(",")]
+    device_name = get_device_name()
+    results = sweep_cutedsl(args, buckets, device)
+    version = {"generated_on": device_name}
+    if cutedsl_version():
+        version["cutedsl"] = cutedsl_version()
+    _emit("cutedsl_bf16_masked", results, args, version)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/kernels/lora_moe/tune_lora_config.py
+++ b/benchmark/kernels/lora_moe/tune_lora_config.py
@@ -1,0 +1,136 @@
+"""Check a model's MoE LoRA plan coverage, or emit a seed table for it.
+
+--check reports which shipped row serves each (layout, phase), or that the
+model falls to the serial fallback (exit code 1).
+--emit-seed writes <out>/<arch>.plans.json with the domain widened to the
+model. The seed only reuses the existing plans for the wider geometry:
+validate provider admission and correctness on that geometry before serving
+it, then benchmark it with the campaign protocol in README.md. The former
+--sweep mode was retired: it had drifted from the plan schema and was never
+re-validated.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+PACKAGED = os.path.join(REPO, "python/sglang/srt/lora/moe/configs")
+
+
+def load_geometry(model_path: str, args) -> dict:
+    """Read checkpoint geometry; gating comes from --gated, not hidden_act."""
+    cfg = json.load(open(os.path.join(model_path, "config.json")))
+    for sub in ("language_config", "text_config", "llm_config"):
+        cfg = cfg.get(sub, cfg) if isinstance(cfg.get(sub, None), dict) else cfg
+    experts = cfg.get("num_experts") or cfg.get("n_routed_experts")
+    activation = (
+        args.activation or cfg.get("hidden_act") or cfg.get("hidden_activation")
+    )
+    if activation is None:
+        raise SystemExit(
+            f"{model_path}/config.json names no hidden_act; pass --activation "
+            "(guessing it would tune the tables for the wrong kernel)"
+        )
+    return {
+        "hidden_size": cfg["hidden_size"],
+        "num_experts": experts,
+        "intermediate": cfg.get("moe_intermediate_size")
+        or cfg.get("intermediate_size"),
+        "activation": activation,
+        "is_gated": args.gated,
+    }
+
+
+def resolve_report(args, geometry) -> int:
+    sys.path.insert(0, os.path.join(REPO, "python"))
+    if args.config_dir:
+        os.environ["SGLANG_LORA_MOE_CONFIG_DIR"] = args.config_dir
+    from sglang.srt.lora.moe.activation import ActivationFn
+    from sglang.srt.lora.moe.execution_plan import (
+        architecture_for_capability,
+        resolve_plans,
+    )
+
+    e_local = geometry["num_experts"] // args.ep_size
+    fell_through = 0
+    for is_shared_outer in (False, True):
+        selected = resolve_plans(
+            architecture=architecture_for_capability(args.capability_major, 0),
+            is_shared_outer=is_shared_outer,
+            physical_rank=args.max_rank,
+            activation=ActivationFn.parse(geometry["activation"]),
+            hidden_size=geometry["hidden_size"],
+            num_local_experts=e_local,
+        )
+        layout_name = "shared" if is_shared_outer else "per_expert"
+        for phase, sel in selected.items():
+            tag = "FALLBACK" if "fallback" in sel.name else "tuned"
+            if tag == "FALLBACK":
+                fell_through += 1
+            print(f"  {layout_name:10s} {phase.value:7s} -> [{tag}] {sel.key}")
+    return 1 if fell_through else 0
+
+
+def emit_seed(args, geometry) -> str:
+    arch = "gb300" if args.capability_major >= 10 else "h200"
+    src = os.path.join(args.config_dir or PACKAGED, f"{arch}.plans.json")
+    table = json.load(open(src))
+    e_local = geometry["num_experts"] // args.ep_size
+    table["domain"]["max_hidden"] = max(
+        table["domain"]["max_hidden"], geometry["hidden_size"]
+    )
+    table["domain"]["max_local_experts"] = max(
+        table["domain"]["max_local_experts"], e_local
+    )
+    os.makedirs(args.out, exist_ok=True)
+    dst = os.path.join(args.out, f"{arch}.plans.json")
+    json.dump(table, open(dst, "w"), indent=1)
+    tiles_src = os.path.join(args.config_dir or PACKAGED, f"{arch}.tiles.json")
+    if os.path.isfile(tiles_src):
+        tiles_dst = os.path.join(args.out, f"{arch}.tiles.json")
+        json.dump(json.load(open(tiles_src)), open(tiles_dst, "w"), indent=1)
+    print(f"seed config written: {dst}")
+    return dst
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--model-path", required=True)
+    ap.add_argument("--capability-major", type=int, default=10)
+    ap.add_argument("--ep-size", type=int, default=1)
+    ap.add_argument("--tp-size", type=int, default=1)
+    ap.add_argument("--top-k", type=int, default=8)
+    ap.add_argument(
+        "--activation",
+        default=None,
+        help="override the checkpoint's hidden_act (silu, relu2)",
+    )
+    ap.add_argument(
+        "--gated",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="whether gate/up is 2x intermediate; not in any config.json",
+    )
+    ap.add_argument("--max-rank", type=int, default=32)
+    ap.add_argument("--config-dir", default=None)
+    ap.add_argument("--out", default="./tuned_config")
+    ap.add_argument("--check", action="store_true")
+    ap.add_argument("--emit-seed", action="store_true")
+    args = ap.parse_args()
+
+    geometry = load_geometry(args.model_path, args)
+    print(f"geometry: {geometry} (ep={args.ep_size})")
+    rc = 0
+    if args.check or not args.emit_seed:
+        rc = resolve_report(args, geometry)
+    if args.emit_seed:
+        emit_seed(args, geometry)
+    sys.exit(rc)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/kernels/lora_moe/tune_lora_config.py
+++ b/benchmark/kernels/lora_moe/tune_lora_config.py
@@ -1,7 +1,7 @@
 """Check a model's MoE LoRA plan coverage, or emit a seed table for it.
 
---check reports which shipped row serves each (layout, phase), or that the
-model falls to the serial fallback (exit code 1).
+--check reports which shipped row serves each (layout, phase) for the given
+--quant-family, or that the model falls to the serial fallback (exit code 1).
 --emit-seed writes <out>/<arch>.plans.json with the domain widened to the
 model. The seed only reuses the existing plans for the wider geometry:
 validate provider admission and correctness on that geometry before serving
@@ -59,6 +59,7 @@ def resolve_report(args, geometry) -> int:
     fell_through = 0
     for is_shared_outer in (False, True):
         selected = resolve_plans(
+            quant_family=args.quant_family,
             architecture=architecture_for_capability(args.capability_major, 0),
             is_shared_outer=is_shared_outer,
             physical_rank=args.max_rank,
@@ -116,6 +117,12 @@ def main() -> None:
         help="whether gate/up is 2x intermediate; not in any config.json",
     )
     ap.add_argument("--max-rank", type=int, default=32)
+    ap.add_argument(
+        "--quant-family",
+        choices=("bf16", "fp8", "nvfp4"),
+        default="bf16",
+        help="weight family whose rows --check reports",
+    )
     ap.add_argument("--config-dir", default=None)
     ap.add_argument("--out", default="./tuned_config")
     ap.add_argument("--check", action="store_true")

--- a/python/sglang/kernels/ops/moe/ep_moe_kernels.py
+++ b/python/sglang/kernels/ops/moe/ep_moe_kernels.py
@@ -897,9 +897,23 @@ def post_reorder_for_cutlass_moe(
     )
 
 
+def _check_out_buffer(tensor, shape, dtype, device, name: str) -> None:
+    if (
+        tuple(tensor.shape) != tuple(shape)
+        or tensor.dtype != dtype
+        or tensor.device != device
+        or not tensor.is_contiguous()
+    ):
+        raise ValueError(
+            f"{name} must be contiguous {dtype} {tuple(shape)} on {device}; got "
+            f"{tensor.dtype} {tuple(tensor.shape)} on {tensor.device}"
+        )
+
+
 @triton.jit
 def post_reorder_deepgemm_triton_kernel(
     down_output_ptr,
+    lora_delta_ptr,
     output_ptr,
     src2dst_ptr,
     topk_ids_ptr,
@@ -908,11 +922,14 @@ def post_reorder_deepgemm_triton_kernel(
     num_tokens,
     hidden_size,
     routed_scaling_factor: float,
+    HAS_LORA_DELTA: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
     NUM_STAGES: tl.constexpr,
 ):
     """`expert_id >= 0` includes the shared expert at num_experts (padding=-1); don't
     switch to the cutlass `!= num_local_experts` gate. routed_scaling_factor is folded into the store.
+
+    lora_delta is unweighted per pair; add it before route weights and scaling.
     """
     OutDtype = output_ptr.dtype.element_ty
 
@@ -941,6 +958,10 @@ def post_reorder_deepgemm_triton_kernel(
                 weight_scale = tl.load(token_topk_weights_ptr + idx).to(tl.float32)
                 load_ptr_offs = down_output_ptr_offs + dst_idx * hidden_size
                 in_data = tl.load(load_ptr_offs, mask=mask).to(tl.float32)
+                if HAS_LORA_DELTA:
+                    slot_idx = src_idx * topk + idx
+                    delta_ptr_offs = lora_delta_ptr + slot_idx * hidden_size + offset
+                    in_data += tl.load(delta_ptr_offs, mask=mask).to(tl.float32)
                 sum_vec += in_data * weight_scale
         sum_vec *= routed_scaling_factor
         store_ptr_offs = output_ptr_offs + src_idx * hidden_size
@@ -957,10 +978,20 @@ def post_reorder_deepgemm(
     num_tokens,
     hidden_size,
     routed_scaling_factor: float,
+    lora_delta=None,
 ):
+    if lora_delta is not None:
+        _check_out_buffer(
+            lora_delta,
+            (num_tokens, topk, hidden_size),
+            lora_delta.dtype,
+            down_output.device,
+            "lora_delta",
+        )
     grid, block_dim = _get_launch_config_2d(down_output.device, num_tokens, hidden_size)
     post_reorder_deepgemm_triton_kernel[grid](
         down_output,
+        down_output if lora_delta is None else lora_delta,
         output,
         src2dst,
         topk_ids,
@@ -969,6 +1000,7 @@ def post_reorder_deepgemm(
         num_tokens,
         hidden_size,
         float(routed_scaling_factor),
+        HAS_LORA_DELTA=lora_delta is not None,
         BLOCK_SIZE=block_dim,
         NUM_STAGES=3,
     )

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1032,6 +1032,9 @@ class Envs:
     # it to trade that away for disk (1 keeps only the most recent build).
     SGLANG_JIT_CACHE_KEEP = EnvInt(None)
 
+    # Per-file overrides for packaged MoE LoRA plans, tiles, and base GEMM configs.
+    SGLANG_LORA_MOE_CONFIG_DIR = EnvStr(None)
+
     # ===================================================================
     # Expert-parallel dispatch and MoE execution
     # ===================================================================

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -319,7 +319,11 @@ class FusedMoE(torch.nn.Module):
             get_moe_runner_backend().is_flashinfer_trtllm()
             or get_moe_runner_backend().is_flashinfer_trtllm_routed()
         )
-        self.use_deep_gemm = get_moe_runner_backend().is_deep_gemm()
+        # LoRA providers use DeepGEMM's resident weight layout and preparation.
+        self.use_deep_gemm = (
+            get_moe_runner_backend().is_deep_gemm()
+            or get_moe_runner_backend().is_lora()
+        )
 
         # flashinfer_trtllm kernel requires intermediate_size to be a multiple of 128
         # Pad the intermediate_size_per_partition if necessary

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -444,12 +444,13 @@ class FusedMoE(torch.nn.Module):
                 )
             self.moe_runner_config.inplace = False
 
+        _nvfp4_backend = getattr(
+            self.quant_method, "_moe_runner_backend", get_moe_runner_backend()
+        )
         self.should_fuse_routed_scaling_factor_in_topk = (
             (
                 isinstance(self.quant_method, ModelOptNvFp4FusedMoEMethod)
-                and not getattr(
-                    self.quant_method, "_moe_runner_backend", get_moe_runner_backend()
-                ).is_marlin()
+                and not (_nvfp4_backend.is_marlin() or _nvfp4_backend.is_lora_marlin())
             )
             or (
                 isinstance(self.quant_method, Fp8MoEMethod)

--- a/python/sglang/srt/layers/moe/moe_runner/lora.py
+++ b/python/sglang/srt/layers/moe/moe_runner/lora.py
@@ -27,7 +27,9 @@ class MoeLoraDispatchPayload(MoeQuantInfo):
     batch: MoeLoraBatch
 
 
-@register_fused_func("none", "lora")
+@register_fused_func("none", "lora_cutedsl")
+@register_fused_func("none", "lora_triton")
+@register_fused_func("none", "lora_marlin")
 def fused_experts_none_to_lora(
     dispatch_output: StandardDispatchOutput,
     quant_info: MoeLoraDispatchPayload,

--- a/python/sglang/srt/layers/moe/moe_runner/lora.py
+++ b/python/sglang/srt/layers/moe/moe_runner/lora.py
@@ -1,0 +1,37 @@
+"""Register the MoE LoRA engine as a fused MoE runner."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from sglang.srt.layers.moe.moe_runner.base import (
+    MoeQuantInfo,
+    MoeRunnerConfig,
+    register_fused_func,
+)
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.moe.token_dispatcher.standard import (
+        StandardCombineInput,
+        StandardDispatchOutput,
+    )
+    from sglang.srt.lora.moe.moe_lora_runner import MoeLoraBatch, MoeLoraRunner
+
+
+@dataclass
+class MoeLoraDispatchPayload(MoeQuantInfo):
+    """Borrowed runner and batch state carried through the quant_info slot."""
+
+    runner: MoeLoraRunner
+    batch: MoeLoraBatch
+
+
+@register_fused_func("none", "lora")
+def fused_experts_none_to_lora(
+    dispatch_output: StandardDispatchOutput,
+    quant_info: MoeLoraDispatchPayload,
+    runner_config: MoeRunnerConfig,
+) -> StandardCombineInput:
+    del runner_config
+    return quant_info.runner.run(dispatch_output, quant_info.batch)

--- a/python/sglang/srt/layers/moe/moe_runner/runner.py
+++ b/python/sglang/srt/layers/moe/moe_runner/runner.py
@@ -60,6 +60,8 @@ class MoeRunner:
             self.runner_core = AscendRunnerCore(config)
         elif runner_backend.is_triton_kernels():
             self.runner_core = TritonKernelsRunnerCore(config)
+        elif runner_backend.is_lora():
+            self.runner_core = None  # MoE LoRA only supports the fused path
         elif runner_backend.is_deep_gemm():
             self.runner_core = DeepGemmRunnerCore(config)
         elif runner_backend.is_humming():
@@ -112,8 +114,8 @@ class MoeRunner:
         else:
             raise NotImplementedError(f"Unsupported runner backend: {runner_backend}")
 
-        # Skip fused func if LoRA is enabled (LoRA requires non-fused path)
-        if not lora_enabled:
+        # Legacy LoRA needs hooks; the lora_* backends incorporate LoRA directly.
+        if not lora_enabled or runner_backend.is_lora():
             a2a_backend_name = get_moe_a2a_backend().value
             runner_backend_name = runner_backend.value
 
@@ -143,7 +145,9 @@ class MoeRunner:
     def run(
         self, dispatch_output: DispatchOutput, quant_info: MoeQuantInfo, lora_info=None
     ) -> CombineInput:
-        if self.fused_func is not None and not self.lora_enabled:
+        if self.fused_func is not None and (
+            not self.lora_enabled or self.runner_backend.is_lora()
+        ):
             return self.fused_func(dispatch_output, quant_info, self.config)
 
         assert self.runner_core is not None

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_7_1/E=256,N=128,device_name=NVIDIA_B200,dtype=fp8_w8a8,block_shape=[128, 128].json
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_7_1/E=256,N=128,device_name=NVIDIA_B200,dtype=fp8_w8a8,block_shape=[128, 128].json
@@ -1,0 +1,146 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "24": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "48": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 5
+    },
+    "64": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "96": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "128": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "256": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "512": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "1536": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "3072": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 3
+    }
+}

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_7_1/E=256,N=128,device_name=NVIDIA_B200,dtype=fp8_w8a8,block_shape=[128, 128]_down.json
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_7_1/E=256,N=128,device_name=NVIDIA_B200,dtype=fp8_w8a8,block_shape=[128, 128]_down.json
@@ -1,0 +1,146 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "24": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "48": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "64": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "96": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "128": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "256": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "512": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "1536": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "3072": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 2
+    }
+}

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_7_1/E=256,N=128,device_name=NVIDIA_B200.json
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_7_1/E=256,N=128,device_name=NVIDIA_B200.json
@@ -1,0 +1,146 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 5
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "24": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "48": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "64": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "96": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "128": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "256": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "512": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 2
+    },
+    "1536": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 8,
+        "num_stages": 2
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "3072": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 2
+    }
+}

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_7_1/E=256,N=128,device_name=NVIDIA_B200_down.json
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_7_1/E=256,N=128,device_name=NVIDIA_B200_down.json
@@ -1,0 +1,146 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "24": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "48": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "64": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "96": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "128": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "256": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "512": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 8,
+        "num_stages": 2
+    },
+    "1536": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 2
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "3072": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 2
+    }
+}

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_7_1/E=256,N=256,device_name=NVIDIA_B200.json
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_7_1/E=256,N=256,device_name=NVIDIA_B200.json
@@ -1,0 +1,146 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 5
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "24": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "48": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "64": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "96": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "128": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "256": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "512": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "1536": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "3072": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 2
+    }
+}

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_7_1/E=256,N=256,device_name=NVIDIA_B200_down.json
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_7_1/E=256,N=256,device_name=NVIDIA_B200_down.json
@@ -1,0 +1,146 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "24": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "48": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "64": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "96": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "128": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "256": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "512": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "1536": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 2
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 8,
+        "num_stages": 2
+    },
+    "3072": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 2
+    }
+}

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_7_1/E=256,N=256,device_name=NVIDIA_GB300,dtype=fp8_w8a8,block_shape=[128, 128].json
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_7_1/E=256,N=256,device_name=NVIDIA_GB300,dtype=fp8_w8a8,block_shape=[128, 128].json
@@ -1,0 +1,146 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 5
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "24": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "48": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "64": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "96": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 5
+    },
+    "128": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "256": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "512": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 5
+    },
+    "1536": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 5
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "3072": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 4
+    }
+}

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_7_1/E=256,N=256,device_name=NVIDIA_GB300,dtype=fp8_w8a8,block_shape=[128, 128]_down.json
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_7_1/E=256,N=256,device_name=NVIDIA_GB300,dtype=fp8_w8a8,block_shape=[128, 128]_down.json
@@ -1,0 +1,146 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "24": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "48": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "64": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "96": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "128": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "256": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "512": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "1536": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "3072": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 4
+    }
+}

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_7_1/E=256,N=256,device_name=NVIDIA_GB300.json
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_7_1/E=256,N=256,device_name=NVIDIA_GB300.json
@@ -1,0 +1,146 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 5
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 5
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 8,
+        "num_stages": 5
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 5
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "24": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "48": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "64": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "96": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "128": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "256": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "512": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "1536": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "3072": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 2
+    }
+}

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_7_1/E=256,N=256,device_name=NVIDIA_GB300_down.json
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_7_1/E=256,N=256,device_name=NVIDIA_GB300_down.json
@@ -1,0 +1,146 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "24": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "48": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "64": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "96": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "128": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "256": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "512": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 2
+    },
+    "1536": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "3072": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 2
+    }
+}

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_7_1/E=256,N=512,device_name=NVIDIA_GB300.json
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_7_1/E=256,N=512,device_name=NVIDIA_GB300.json
@@ -1,0 +1,146 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 5
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "24": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "48": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "64": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "96": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "128": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "256": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "512": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "1536": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "3072": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 4
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 4
+    }
+}

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_7_1/E=256,N=512,device_name=NVIDIA_GB300_down.json
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_7_1/E=256,N=512,device_name=NVIDIA_GB300_down.json
@@ -1,0 +1,146 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "24": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 5
+    },
+    "32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 5
+    },
+    "48": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "64": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "96": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "128": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "256": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "512": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "1536": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "3072": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    }
+}

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_7_1/E=512,N=128,device_name=NVIDIA_B200,dtype=fp8_w8a8,block_shape=[128, 128].json
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_7_1/E=512,N=128,device_name=NVIDIA_B200,dtype=fp8_w8a8,block_shape=[128, 128].json
@@ -1,0 +1,146 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 5
+    },
+    "24": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 5
+    },
+    "32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "48": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "64": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "96": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "128": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "256": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "512": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "1536": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 5
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 5
+    },
+    "3072": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 4
+    }
+}

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_7_1/E=512,N=128,device_name=NVIDIA_B200,dtype=fp8_w8a8,block_shape=[128, 128]_down.json
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_7_1/E=512,N=128,device_name=NVIDIA_B200,dtype=fp8_w8a8,block_shape=[128, 128]_down.json
@@ -1,0 +1,146 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 5
+    },
+    "24": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "48": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "64": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "96": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "128": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "256": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "512": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "1536": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "3072": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 2
+    }
+}

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_7_1/E=512,N=256,device_name=NVIDIA_GB300,dtype=fp8_w8a8,block_shape=[128, 128].json
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_7_1/E=512,N=256,device_name=NVIDIA_GB300,dtype=fp8_w8a8,block_shape=[128, 128].json
@@ -1,0 +1,146 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "24": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "48": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "64": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "96": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "128": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "256": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "512": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "1536": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "3072": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 4
+    }
+}

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_7_1/E=512,N=256,device_name=NVIDIA_GB300,dtype=fp8_w8a8,block_shape=[128, 128]_down.json
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_7_1/E=512,N=256,device_name=NVIDIA_GB300,dtype=fp8_w8a8,block_shape=[128, 128]_down.json
@@ -1,0 +1,146 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "24": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "48": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "64": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "96": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "128": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "256": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "512": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "1536": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "3072": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 4
+    }
+}

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -109,6 +109,7 @@ class MoeRunnerBackend(Enum):
     MARLIN = "marlin"
     HUMMING = "humming"
     EXPERIMENTAL_SGL_MARLIN = "experimental_sgl_marlin"
+    LORA = "lora"
     AITER = "aiter"
     HPC_OPS = "hpc_ops"
 
@@ -120,6 +121,9 @@ class MoeRunnerBackend(Enum):
 
     def is_deep_gemm(self):
         return self == MoeRunnerBackend.DEEP_GEMM
+
+    def is_lora(self):
+        return self == MoeRunnerBackend.LORA
 
     def is_triton(self):
         return self == MoeRunnerBackend.TRITON

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -109,7 +109,9 @@ class MoeRunnerBackend(Enum):
     MARLIN = "marlin"
     HUMMING = "humming"
     EXPERIMENTAL_SGL_MARLIN = "experimental_sgl_marlin"
-    LORA = "lora"
+    LORA_CUTEDSL = "lora_cutedsl"
+    LORA_TRITON = "lora_triton"
+    LORA_MARLIN = "lora_marlin"
     AITER = "aiter"
     HPC_OPS = "hpc_ops"
 
@@ -123,7 +125,20 @@ class MoeRunnerBackend(Enum):
         return self == MoeRunnerBackend.DEEP_GEMM
 
     def is_lora(self):
-        return self == MoeRunnerBackend.LORA
+        return self in (
+            MoeRunnerBackend.LORA_CUTEDSL,
+            MoeRunnerBackend.LORA_TRITON,
+            MoeRunnerBackend.LORA_MARLIN,
+        )
+
+    def is_lora_cutedsl(self):
+        return self == MoeRunnerBackend.LORA_CUTEDSL
+
+    def is_lora_triton(self):
+        return self == MoeRunnerBackend.LORA_TRITON
+
+    def is_lora_marlin(self):
+        return self == MoeRunnerBackend.LORA_MARLIN
 
     def is_triton(self):
         return self == MoeRunnerBackend.TRITON

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -2182,7 +2182,7 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
     def __init__(self, quant_config: ModelOptFp4Config):
         self.quant_config = quant_config
         moe_runner_backend = get_moe_runner_backend()
-        if moe_runner_backend.is_auto() and is_cuda():
+        if (moe_runner_backend.is_auto() or moe_runner_backend.is_lora()) and is_cuda():
             capability = get_device_capability()
             use_marlin_fallback = (8, 0) <= capability < (10, 0)
         else:
@@ -2429,6 +2429,12 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
         moe_runner_backend = getattr(
             self, "_moe_runner_backend", get_moe_runner_backend()
         )
+        if moe_runner_backend.is_lora():
+            if moe_runner_backend.is_lora_marlin():
+                moe_runner_backend = MoeRunnerBackend.MARLIN
+            else:
+                # A Marlin provider selected at attach will repack these weights.
+                return
         if moe_runner_backend.is_marlin():
             # Marlin supports only a single shared w1/w3 weight scale, so collapse
             # the gate/up columns to the gate scale here. Other backends keep the
@@ -2760,6 +2766,9 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
                 moe_runner_backend = MoeRunnerBackend.FLASHINFER_TRTLLM
 
         self._moe_runner_backend = moe_runner_backend
+
+        if moe_runner_backend.is_lora():
+            return
 
         if moe_runner_backend.is_flashinfer_cutedsl():
             import sglang.srt.layers.moe.moe_runner.flashinfer_cutedsl  # noqa: F401 – triggers @register_fused_func

--- a/python/sglang/srt/lora/backend/base_backend.py
+++ b/python/sglang/srt/lora/backend/base_backend.py
@@ -42,6 +42,9 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
         # Request/token caps for serving a batch from the static metadata.
         self.prefill_cuda_graph_max_bs: int | None = None
         self.prefill_cuda_graph_max_tokens: int | None = None
+        self.prefill_moe_cg_buffers: dict[str, torch.Tensor] | None = None
+        # Sequential MoE layers share one workspace, including graph scratch.
+        self.moe_lora_workspace = None
 
     def reset_batch_state(self):
         """Idle-forward counterpart of prepare_lora_batch(): clears all
@@ -195,6 +198,24 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
             f"LoRA backend {type(self).__name__} does not support the prefill CUDA graph."
         )
 
+    def init_prefill_cuda_graph_moe_buffers(self, max_num_tokens: int) -> None:
+        """Prefill needs token-sized routing buffers separate from decode."""
+        if not self.is_moe_lora:
+            return
+        self.prefill_moe_cg_buffers = {
+            "adapter_enabled": torch.zeros(
+                self.max_loras_per_batch,
+                dtype=torch.int32,
+                device=self.device,
+            ),
+            "token_lora_mapping": torch.full(
+                (max_num_tokens,),
+                -1,
+                dtype=torch.int32,
+                device=self.device,
+            ),
+        }
+
     @property
     def is_moe_lora(self) -> bool:
         return self._is_moe_lora
@@ -209,23 +230,28 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
         max_loras: int,
         compute_dtype: torch.dtype,
         moe_layer,
+        include_legacy_kernel_buffers: bool = True,
     ):
-        """Phase 1 of LoRA CUDA graph init: MoE intermediate buffers.
+        """Allocate shared graph metadata and optional legacy Triton scratch.
 
-        Called once before init_memory_pool() with a representative MoE layer
-        to extract dimensions.  All FusedMoEWithLoRA layers share the same
-        buffers since they execute sequentially during forward.
-
-        This is backend-agnostic because MoE LoRA always uses the same
-        fused Triton kernel (TritonRunnerCoreWithLoRA) regardless of which
-        dense LoRA backend is selected.
+        Metadata is refreshed in place before replay. Sequential MoE layers
+        share these buffers; the new engine allocates its own kernel scratch.
         """
+        device = moe_layer.base_layer.w13_weight.device
+        self.moe_cg_buffers = {
+            "adapter_enabled": torch.zeros(max_loras, dtype=torch.int32, device=device),
+            "token_lora_mapping": torch.full(
+                (max_bs,), -1, dtype=torch.int32, device=device
+            ),
+        }
+        if not include_legacy_kernel_buffers:
+            return
+
         base = moe_layer.base_layer
         top_k = base.top_k
         qinfo = moe_layer._quant_info
         E, N, _ = qinfo.w13_weight.shape
         hidden_dim = qinfo.w2_weight.shape[1]
-        device = qinfo.w13_weight.device
         dtype = compute_dtype
         num_experts = base.num_experts
 
@@ -236,7 +262,7 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
         ) * block_size_m
         max_num_m_blocks = (max_num_tokens_padded + block_size_m - 1) // block_size_m
 
-        self.moe_cg_buffers = {
+        legacy_buffers = {
             "intermediate_cache1": torch.empty(
                 (max_bs, top_k, N), device=device, dtype=dtype
             ),
@@ -262,7 +288,6 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
             "num_tokens_post_padded_lora": torch.empty(
                 (max_loras,), device=device, dtype=torch.int32
             ),
-            "adapter_enabled": torch.zeros(max_loras, dtype=torch.int32, device=device),
             # int64 copy of weight_indices for index_fill_(), which requires
             # LongTensor.  weight_indices itself must stay int32 because the
             # CUDA moe_lora_align kernel casts it to int32_t*.
@@ -282,10 +307,8 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
             ),
             "max_num_tokens_padded": max_num_tokens_padded,
             "max_num_m_blocks": max_num_m_blocks,
-            "token_lora_mapping": torch.full(
-                (max_bs,), -1, dtype=torch.int32, device=device
-            ),
         }
+        self.moe_cg_buffers.update(legacy_buffers)
 
     def _add_moe_lora_info(
         self, forward_batch: ForwardBatch, batch_info: LoRABatchInfo
@@ -294,8 +317,16 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
             return batch_info
 
         if batch_info.use_cuda_graph:
-            adapter_enabled = self.moe_cg_buffers["adapter_enabled"]
-            token_lora_mapping = self.moe_cg_buffers["token_lora_mapping"]
+            if batch_info is getattr(self, "prefill_cuda_graph_batch_info", None):
+                buffers = self.prefill_moe_cg_buffers
+                if buffers is None:
+                    raise RuntimeError(
+                        "prefill MoE-LoRA CUDA graph metadata was not initialized"
+                    )
+            else:
+                buffers = self.moe_cg_buffers
+            adapter_enabled = buffers["adapter_enabled"]
+            token_lora_mapping = buffers["token_lora_mapping"]
         else:
             adapter_enabled = None
             token_lora_mapping = None
@@ -376,12 +407,17 @@ def _compute_moe_lora_info_kernel(
     valid = offs < seg_len
     lora_id = tl.load(weight_indices_ptr + pid_seg)
     lora_rank = tl.load(lora_ranks_ptr + lora_id)
+    adapter_is_enabled = lora_rank > 0
     tl.store(
         adapter_enabled_ptr + lora_id,
-        (lora_rank > 0).to(tl.int32),
+        adapter_is_enabled.to(tl.int32),
         mask=pid_m == 0,
     )
-    tl.store(token_lora_mapping_ptr + seg_start + offs, lora_id, mask=valid)
+    tl.store(
+        token_lora_mapping_ptr + seg_start + offs,
+        tl.where(adapter_is_enabled, lora_id, -1),
+        mask=valid,
+    )
 
 
 def _compute_moe_lora_info(
@@ -397,6 +433,9 @@ def _compute_moe_lora_info(
         assert (
             num_tokens <= token_lora_mapping.shape[0]
         ), "num_tokens must be less than or equal to the shape of token_lora_mapping"
+        # Clear stale adapter slots in the unused part of a graph bucket.
+        if num_tokens < token_lora_mapping.shape[0]:
+            token_lora_mapping[num_tokens:].fill_(-1)
         token_lora_mapping = token_lora_mapping[:num_tokens]
     else:
         token_lora_mapping = torch.empty(
@@ -459,8 +498,12 @@ def _compute_moe_lora_info(
         torch.searchsorted(seg_indptr.to(torch.int32), token_positions, right=True) - 1
     )
 
-    token_lora_mapping = torch.index_select(
+    torch.index_select(
         weight_indices.to(torch.int32), 0, req_indices, out=token_lora_mapping
     )
+    token_lora_ranks = torch.index_select(
+        lora_ranks, 0, token_lora_mapping.to(torch.int64)
+    )
+    token_lora_mapping.masked_fill_(token_lora_ranks <= 0, -1)
 
     return adapter_enabled, token_lora_mapping

--- a/python/sglang/srt/lora/backend/base_backend.py
+++ b/python/sglang/srt/lora/backend/base_backend.py
@@ -249,9 +249,12 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
 
         base = moe_layer.base_layer
         top_k = base.top_k
-        qinfo = moe_layer._quant_info
-        E, N, _ = qinfo.w13_weight.shape
-        hidden_dim = qinfo.w2_weight.shape[1]
+        # Packed Marlin tensor shapes do not expose the logical dimensions.
+        E = int(base.num_local_experts)
+        N = (2 if base.moe_runner_config.is_gated else 1) * int(
+            base.intermediate_size_per_partition
+        )
+        hidden_dim = int(base.hidden_size)
         dtype = compute_dtype
         num_experts = base.num_experts
 

--- a/python/sglang/srt/lora/layers.py
+++ b/python/sglang/srt/lora/layers.py
@@ -949,13 +949,18 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
         self,
         base_layer: FusedMoE,
         lora_backend: BaseLoRABackend,
+        *,
+        experts_shared_outer_loras: bool = False,
+        max_lora_rank: Optional[int] = None,
     ):
         # initializes FusedMoE with its own moe_runner for base path
         super().__init__(base_layer, lora_backend)
 
         lora_backend.is_moe_lora = True
 
-        self.experts_shared_outer_loras: bool = False
+        # Match the factor layout and physical rank allocated by the memory pool.
+        self.experts_shared_outer_loras: bool = experts_shared_outer_loras
+        self._max_lora_rank = max_lora_rank
         self.lora_use_virtual_experts: bool = False
         self.quant_method = base_layer.quant_method
         self.moe_runner_config = base_layer.moe_runner_config
@@ -979,7 +984,6 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
             getattr(base_layer.moe_runner_config, "gemm1_alpha", None) is not None
         )
 
-        # Initialize triton_lora moe runner for batches with lora enabled
         from sglang.srt.layers.moe import MoeRunnerBackend
         from sglang.srt.layers.moe.moe_runner.runner import MoeRunner
         from sglang.srt.layers.moe.utils import get_moe_runner_backend
@@ -1007,8 +1011,12 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
             if isinstance(base_layer.quant_method, UnquantizedFusedMoEMethod):
                 runner_backend = MoeRunnerBackend.TRITON
 
-        # ===== TO BE REFACTORED ====
         self._lora_runner_backend = runner_backend
+        if runner_backend.is_lora():
+            self._initialize_moe_lora_execution(base_layer)
+            return
+
+        # ===== TO BE REFACTORED ====
         if runner_backend.is_experimental_sgl_trtllm():
             from sglang.srt.lora.trtllm_lora_temp.lora_layer import (
                 init_experimental_sgl_trtllm_lora,
@@ -1055,6 +1063,34 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
                 f"LoRA MoE not supported for backend {runner_backend}"
             )
 
+    def _initialize_moe_lora_execution(self, base_layer: FusedMoE) -> None:
+        """Bind plans and providers once, using the pool's factor layout and rank."""
+        from sglang.srt.lora.moe.moe_lora_runner import MoeLoraRunner
+        from sglang.srt.lora.moe.workspace import MoeLoraWorkspace
+
+        workspace = self.lora_backend.moe_lora_workspace
+        if workspace is None:
+            workspace = MoeLoraWorkspace()
+            self.lora_backend.moe_lora_workspace = workspace
+        self._moe_lora_runner = MoeLoraRunner.from_layer(
+            base_layer,
+            workspace=workspace,
+            is_shared_outer=self.experts_shared_outer_loras,
+            physical_rank=self._max_lora_rank,
+        )
+        import sglang.srt.layers.moe.moe_runner.lora  # noqa: F401
+        from sglang.srt.layers.moe import MoeRunnerBackend
+        from sglang.srt.layers.moe.moe_runner.runner import MoeRunner
+
+        self._lora_runner = MoeRunner(
+            MoeRunnerBackend.LORA,
+            base_layer.moe_runner_config,
+            lora_enabled=True,
+        )
+        # Keep dispatch, combine, and distributed reduction in the base layer.
+        self._base_run_moe_core = base_layer.run_moe_core
+        base_layer.run_moe_core = self._run_moe_core_with_lora
+
     def set_lora_info(
         self,
         gate_up_lora_a_weights: torch.Tensor,
@@ -1069,8 +1105,25 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
         self.down_lora_a_weights = down_lora_a_weights
         self.down_lora_b_weights = down_lora_b_weights
 
+    def _get_moe_lora_batch(self):
+        from sglang.srt.lora.moe.moe_lora_runner import MoeLoraBatch
+
+        batch_info = self.lora_backend.batch_info
+        moe_lora_info = batch_info.moe_lora_info
+        assert moe_lora_info is not None
+        return MoeLoraBatch(
+            gate_up_lora_a=self.gate_up_lora_a_weights,
+            gate_up_lora_b=self.gate_up_lora_b_weights,
+            down_lora_a=self.down_lora_a_weights,
+            down_lora_b=self.down_lora_b_weights,
+            token_lora_mapping=moe_lora_info.token_lora_mapping,
+            seg_indptr=moe_lora_info.seg_indptr,
+            use_cuda_graph=batch_info.use_cuda_graph,
+            is_prefill=batch_info.is_prefill,
+        )
+
     def _get_lora_info(self):
-        """Build LoRAInfo for the current batch."""
+        """Build the legacy engine's batch payload."""
         from sglang.srt.lora.lora_moe_runners import LoRAInfo
 
         batch_info = self.lora_backend.batch_info
@@ -1125,8 +1178,8 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
         1. After gate_up projection, before activation
         2. After down projection, before final reduction
         """
-        # DP-attention idle forward: no batch_info, run the base MoE path.
-        if self.lora_backend.batch_info is None:
+        # The lora_* path replaces run_moe_core inside the base forward.
+        if self.lora_backend.batch_info is None or self._lora_runner_backend.is_lora():
             return self.base_layer.forward(hidden_states, topk_output, **kwargs)
 
         # Build LoRA info for this batch
@@ -1134,6 +1187,19 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
 
         # run lora moe_runner
         return self._forward_with_lora(hidden_states, topk_output, lora_info, **kwargs)
+
+    def _run_moe_core_with_lora(self, dispatch_output):
+        from sglang.srt.layers.moe.moe_runner.lora import MoeLoraDispatchPayload
+
+        if self.lora_backend.batch_info is None:
+            return self._base_run_moe_core(dispatch_output=dispatch_output)
+        return self._lora_runner.run(
+            dispatch_output,
+            MoeLoraDispatchPayload(
+                runner=self._moe_lora_runner,
+                batch=self._get_moe_lora_batch(),
+            ),
+        )
 
     def _forward_with_lora(
         self,
@@ -1294,11 +1360,25 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
 
 
 def get_lora_layer(
-    layer: nn.Module, lora_backend: BaseLoRABackend
+    layer: nn.Module,
+    lora_backend: BaseLoRABackend,
+    *,
+    experts_shared_outer_loras: bool = False,
+    max_lora_rank: Optional[int] = None,
 ) -> BaseLayerWithLoRA:
+    if isinstance(layer, FusedMoE):
+        return FusedMoEWithLoRA(
+            layer,
+            lora_backend,
+            experts_shared_outer_loras=experts_shared_outer_loras,
+            max_lora_rank=max_lora_rank,
+        )
+    # Inkling QKVR needs custom LoRA-B slicing despite being a merged linear.
+    if getattr(layer, "is_inkling_qkvr", False):
+        return InklingQKVRLinearWithLoRA(layer, lora_backend)
+
     supported_layer_types = {
         # the order matters
-        FusedMoE: FusedMoEWithLoRA,
         ParallelLMHead: ParallelLMHeadWithLoRA,
         VocabParallelEmbedding: VocabParallelEmbeddingWithLoRA,
         ReplicatedLinear: ReplicatedLinearWithLoRA,
@@ -1307,14 +1387,9 @@ def get_lora_layer(
         ColumnParallelLinear: ColumnParallelLinearWithLoRA,
         RowParallelLinear: RowParallelLinearWithLoRA,
     }
-    # Inkling's fused qkvr needs replication-aware LoRA-B slicing (see InklingQKVRLinear);
-    # it IS a MergedColumnParallelLinear, so this must precede the isinstance loop.
-    if getattr(layer, "is_inkling_qkvr", False):
-        return InklingQKVRLinearWithLoRA(layer, lora_backend)
     for src_layer_type, lora_layer_type in supported_layer_types.items():
         if isinstance(layer, src_layer_type):  # pylint: disable=unidiomatic-typecheck
-            ret = lora_layer_type(layer, lora_backend)
-            return ret
+            return lora_layer_type(layer, lora_backend)
     raise Exception(f"No corresponding LoRA layer supported for {type(layer)}.")
 
 

--- a/python/sglang/srt/lora/layers.py
+++ b/python/sglang/srt/lora/layers.py
@@ -1079,11 +1079,10 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
             physical_rank=self._max_lora_rank,
         )
         import sglang.srt.layers.moe.moe_runner.lora  # noqa: F401
-        from sglang.srt.layers.moe import MoeRunnerBackend
         from sglang.srt.layers.moe.moe_runner.runner import MoeRunner
 
         self._lora_runner = MoeRunner(
-            MoeRunnerBackend.LORA,
+            self._lora_runner_backend,
             base_layer.moe_runner_config,
             lora_enabled=True,
         )

--- a/python/sglang/srt/lora/lora_manager.py
+++ b/python/sglang/srt/lora/lora_manager.py
@@ -103,7 +103,13 @@ class LoRAManager:
         self._experts_shared_outer_override: Optional[bool] = (
             server_args.experts_shared_outer_loras
         )
+        from sglang.srt.layers.moe.utils import get_moe_runner_backend
+
+        self.moe_lora_runner_backend = get_moe_runner_backend()
         self.lora_use_virtual_experts: bool = server_args.lora_use_virtual_experts
+        self.prefill_cuda_graph_backend: str = (
+            server_args.cuda_graph_config.prefill.backend
+        )
         self.lora_strict_loading: bool = getattr(
             server_args, "lora_strict_loading", False
         )
@@ -156,14 +162,21 @@ class LoRAManager:
         self.lora_backend.init_prefill_cuda_graph_batch_info(
             max_num_tokens=max_num_tokens
         )
+        self.lora_backend.init_prefill_cuda_graph_moe_buffers(
+            max_num_tokens=max_num_tokens
+        )
 
     @property
     def supports_prefill_cuda_graph(self) -> bool:
-        """Whether LoRA kernels can be captured into the prefill CUDA graph;
-        excludes MoE LoRA and DP attention."""
+        """Whether this LoRA configuration can enter a prefill CUDA graph."""
         return (
             self.lora_backend.supports_prefill_cuda_graph
-            and not self.lora_backend.is_moe_lora
+            # Dynamo guards in tc_piecewise reject per-batch LoRA metadata rebinds.
+            and self.prefill_cuda_graph_backend == "breakable"
+            and (
+                not self.lora_backend.is_moe_lora
+                or self.moe_lora_runner_backend.is_lora()
+            )
             and not self.enable_dp_attention
         )
 
@@ -199,7 +212,12 @@ class LoRAManager:
         )
 
     def init_cuda_graph_moe_buffers(
-        self, max_bs: int, max_loras: int, compute_dtype, moe_layer
+        self,
+        max_bs: int,
+        max_loras: int,
+        compute_dtype,
+        moe_layer,
+        include_legacy_kernel_buffers: bool = True,
     ):
         """Phase 1 of LoRA CUDA graph init: MoE intermediate buffers.
 
@@ -211,6 +229,7 @@ class LoRAManager:
             max_loras=max_loras,
             compute_dtype=compute_dtype,
             moe_layer=moe_layer,
+            include_legacy_kernel_buffers=include_legacy_kernel_buffers,
         )
 
     def create_lora_update_result(
@@ -470,6 +489,10 @@ class LoRAManager:
         )
         self.lora_backend.batch_info.has_active_lora = any(
             lora_ranks[wi] > 0 for wi in weight_indices
+        )
+        self.lora_backend.batch_info.is_prefill = (
+            forward_batch.forward_mode.is_extend()
+            and not forward_batch.forward_mode.is_cuda_graph()
         )
 
     def update_lora_info(self):
@@ -890,9 +913,9 @@ class LoRAManager:
         # Initializing memory pool with base model
         self.fetch_new_loras({None})
 
-    def set_lora_module(self, module_name, module):
+    def set_lora_module(self, module_name, module, **kwargs):
         """Wrap any module (standard or MoE) with LoRA support."""
-        lora_module = get_lora_layer(module, self.lora_backend)
+        lora_module = get_lora_layer(module, self.lora_backend, **kwargs)
         replace_submodule(self.base_model, module_name, lora_module)
         return lora_module
 
@@ -1020,12 +1043,31 @@ class LoRAManager:
                     module.initialize_lora(self.lora_backend)
                     lora_module = module
                 else:
-                    lora_module = self.set_lora_module(module_name, module)
-                    lora_module.experts_shared_outer_loras = (
-                        self.experts_shared_outer_loras
+                    lora_module = self.set_lora_module(
+                        module_name,
+                        module,
+                        experts_shared_outer_loras=self.experts_shared_outer_loras,
+                        max_lora_rank=self.max_lora_rank,
                     )
                     lora_module.lora_use_virtual_experts = self.lora_use_virtual_experts
                 self.lora_modules[layer_id][module_name] = lora_module
+
+        # The quant methods create no base runner under a lora_* backend, so an
+        # MoE layer the adapter did not wrap would fail at its first forward.
+        # (getattr: unit tests build partial managers without __init__.)
+        backend = getattr(self, "moe_lora_runner_backend", None)
+        modules = list(self.base_model.modules())
+        if (
+            backend is not None
+            and backend.is_lora()
+            and any(isinstance(module, FusedMoE) for module in modules)
+            and not any(isinstance(module, FusedMoEWithLoRA) for module in modules)
+        ):
+            raise ValueError(
+                f"--moe-runner-backend {backend.value} requires "
+                "the LoRA target modules to include gate_up_proj and down_proj; "
+                "this adapter leaves the MoE experts without a runner"
+            )
 
 
 def init_lora_cuda_graph_moe_buffers(
@@ -1057,11 +1099,18 @@ def init_lora_cuda_graph_moe_buffers(
     max_loras = get_lora().max_loras_per_batch
     for module in model.modules():
         if isinstance(module, FusedMoEWithLoRA):
+            # New engines share metadata but allocate their own kernel scratch.
+            include_legacy = not module._lora_runner_backend.is_lora()
             lora_manager.init_cuda_graph_moe_buffers(
-                max_tokens, max_loras, dtype, module
+                max_tokens,
+                max_loras,
+                dtype,
+                module,
+                include_legacy_kernel_buffers=include_legacy,
             )
             logger.info(
                 f"Pre-allocated shared MoE LoRA CUDA graph buffers "
-                f"(max_tokens={max_tokens}, max_loras={max_loras})"
+                f"(max_tokens={max_tokens}, max_loras={max_loras}, "
+                f"legacy_kernel_buffers={include_legacy})"
             )
             break

--- a/python/sglang/srt/lora/mem_pool.py
+++ b/python/sglang/srt/lora/mem_pool.py
@@ -318,9 +318,7 @@ class LoRAMemoryPool:
         return any(isinstance(m, FusedMoE) for m in base_model.modules())
 
     def _get_num_local_experts(self, base_model: torch.nn.Module) -> int:
-        """Experts owned by this rank. Equals the global count when EP is
-        off, the runner keeps global IDs, or the split isn't even (all
-        three cases fold into `moe_use_local_expert_ids == False`)."""
+        """Resident factor count; new MoE LoRA providers use EP-local factors."""
         total = self._get_num_experts(base_model)
         if not self.moe_use_local_expert_ids:
             return total

--- a/python/sglang/srt/lora/moe/__init__.py
+++ b/python/sglang/srt/lora/moe/__init__.py
@@ -1,0 +1,1 @@
+"""MoE LoRA execution plans, kernels, and base-GEMM providers."""

--- a/python/sglang/srt/lora/moe/activation.py
+++ b/python/sglang/srt/lora/moe/activation.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from enum import Enum
+
+
+class ActivationFn(str, Enum):
+
+    SILU = "silu"
+    RELU2 = "relu2"
+
+    @classmethod
+    def parse(cls, name: str) -> ActivationFn:
+        try:
+            return cls(name)
+        except ValueError:
+            raise ValueError(
+                f"activation {name!r} is not one of {tuple(fn.value for fn in cls)}"
+            ) from None

--- a/python/sglang/srt/lora/moe/base_gemm_provider/__init__.py
+++ b/python/sglang/srt/lora/moe/base_gemm_provider/__init__.py
@@ -1,12 +1,85 @@
-"""Base-MoE providers for the MoE LoRA execution engine.
+"""Lazy selection of base-MoE providers."""
 
-The seam lives in :mod:`base.py`; each provider owns its resident weight
-format, physical row domain, activation join, and finalize, and binds the
-kernels that serve it -- the in-tree CuTeDSL grouped GEMM lives in
-``moe/kernels/cutedsl``; the Triton arm runs sglang's fused_moe kernels.
+from __future__ import annotations
 
-Providers are imported explicitly by the engine rather than re-exported here,
-so importing this package pulls in no kernels.  When the second provider lands
-(FP8), replace the engine's direct import with a registry keyed on quant type
-and resident layout — see execution plan section 29.
-"""
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sglang.srt.lora.moe.base_gemm_provider.base import MoeBaseProvider
+
+logger = logging.getLogger(__name__)
+
+# The first vendor is the default for each weight family.
+VENDORS = {
+    "bf16": ("cutedsl", "triton"),
+    "fp8": ("cutedsl", "triton"),
+    "nvfp4": ("marlin",),
+}
+
+
+def select_provider_cls(
+    base_gemm_rows: str, family: str, vendor: str | None = None
+) -> type[MoeBaseProvider]:
+    """Use the family default when the requested vendor cannot serve it.
+
+    Triton and Marlin use route-major rows for either requested row order.
+    """
+    if base_gemm_rows not in ("expert_major", "route_major"):
+        raise ValueError(
+            f"unknown MoE LoRA base-GEMM row order {base_gemm_rows!r}; "
+            "expected 'expert_major' or 'route_major'"
+        )
+    vendors = VENDORS[family]
+    if vendor not in vendors:
+        if vendor is not None:
+            logger.info(
+                "MoE LoRA base-GEMM vendor %r serves no %s layers; this layer "
+                "family uses its default vendor %r",
+                vendor,
+                family,
+                vendors[0],
+            )
+        vendor = vendors[0]
+    expert_major = base_gemm_rows == "expert_major"
+    match vendor, family:
+        case "cutedsl", "bf16":
+            from sglang.srt.lora.moe.base_gemm_provider.cutedsl_bf16 import (
+                CuteDslBf16ContiguousProvider,
+                CuteDslBf16MaskedProvider,
+            )
+
+            return (
+                CuteDslBf16MaskedProvider
+                if expert_major
+                else CuteDslBf16ContiguousProvider
+            )
+        case "cutedsl", "fp8":
+            from sglang.srt.lora.moe.base_gemm_provider.cutedsl_fp8 import (
+                CuteDslFp8ContiguousProvider,
+                CuteDslFp8MaskedProvider,
+            )
+
+            return (
+                CuteDslFp8MaskedProvider
+                if expert_major
+                else CuteDslFp8ContiguousProvider
+            )
+        case "triton", "bf16":
+            from sglang.srt.lora.moe.base_gemm_provider.triton_bf16 import (
+                TritonBf16ContiguousProvider,
+            )
+
+            return TritonBf16ContiguousProvider
+        case "triton", "fp8":
+            from sglang.srt.lora.moe.base_gemm_provider.triton_fp8 import (
+                TritonFp8ContiguousProvider,
+            )
+
+            return TritonFp8ContiguousProvider
+        case "marlin", "nvfp4":
+            from sglang.srt.lora.moe.base_gemm_provider.marlin_nvfp4 import (
+                MarlinNvFp4ContiguousProvider,
+            )
+
+            return MarlinNvFp4ContiguousProvider

--- a/python/sglang/srt/lora/moe/base_gemm_provider/__init__.py
+++ b/python/sglang/srt/lora/moe/base_gemm_provider/__init__.py
@@ -1,0 +1,12 @@
+"""Base-MoE providers for the MoE LoRA execution engine.
+
+The seam lives in :mod:`base.py`; each provider owns its resident weight
+format, physical row domain, activation join, and finalize, and binds the
+kernels that serve it -- the in-tree CuTeDSL grouped GEMM lives in
+``moe/kernels/cutedsl``; the Triton arm runs sglang's fused_moe kernels.
+
+Providers are imported explicitly by the engine rather than re-exported here,
+so importing this package pulls in no kernels.  When the second provider lands
+(FP8), replace the engine's direct import with a registry keyed on quant type
+and resident layout — see execution plan section 29.
+"""

--- a/python/sglang/srt/lora/moe/base_gemm_provider/base.py
+++ b/python/sglang/srt/lora/moe/base_gemm_provider/base.py
@@ -1,0 +1,287 @@
+"""Base MoE stages with insertion points for LoRA."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING
+
+import msgspec
+import torch
+
+if TYPE_CHECKING:
+    from sglang.srt.lora.moe.route_view import RouteView
+    from sglang.srt.lora.moe.workspace import MoeLoraWorkspace
+
+
+class MoeBaseProviderContract(msgspec.Struct, frozen=True, kw_only=True):
+    key: str
+    # These two flags give the column order of the base gate/up GEMM output.
+    # The LoRA delta is always [gate | up].
+    gate_first: bool
+    interleaved: bool
+    gate_up_output_dtype: torch.dtype
+    lora_delta_dtype: torch.dtype
+    lora_activation_dtype: torch.dtype
+
+
+def expected_rows_per_expert(num_pairs: int, num_experts: int) -> int:
+    """Rounded-up mean rows per expert; use one for an empty batch."""
+    return (num_pairs - 1) // num_experts + 1 if num_pairs else 1
+
+
+def prepare_buffer(workspace, name: str, shape, *, dtype, device) -> torch.Tensor:
+    if workspace is not None:
+        return workspace.tensor(name, shape, dtype=dtype, device=device)
+    return torch.empty(shape, dtype=dtype, device=device)
+
+
+def admit_bf16_weights(quant_info) -> int:
+    """Check the BF16 weight layout once at attach; return the gate/up slices."""
+    if quant_info.intermediate_size <= 0:
+        raise ValueError("intermediate_size must be positive")
+    expected_w2 = (
+        quant_info.num_local_experts,
+        quant_info.hidden_size,
+        quant_info.intermediate_size,
+    )
+    if quant_info.w2_weight.shape != expected_w2:
+        raise ValueError(
+            f"w2_weight must be {expected_w2}, got "
+            f"{tuple(quant_info.w2_weight.shape)}"
+        )
+    if (
+        quant_info.w13_weight.ndim != 3
+        or quant_info.w13_weight.shape[0] != quant_info.num_local_experts
+        or quant_info.w13_weight.shape[2] != quant_info.hidden_size
+    ):
+        raise ValueError(
+            "w13_weight must be [num_local_experts, slices*intermediate, hidden]"
+        )
+    gateup_width = quant_info.w13_weight.shape[1]
+    if gateup_width % quant_info.intermediate_size:
+        raise ValueError(
+            "w13 output width must be an integer multiple of intermediate_size"
+        )
+    gate_up_slices = gateup_width // quant_info.intermediate_size
+    if gate_up_slices not in (1, 2):
+        raise ValueError(
+            "the BF16 providers support one non-gated slice or two gated "
+            f"gate/up slices, got {gate_up_slices}"
+        )
+    return gate_up_slices
+
+
+class MoeBaseProvider:
+    """One provider per layer; logical sizes come from quant_info."""
+
+    contract: MoeBaseProviderContract
+
+    @property
+    def num_local_experts(self) -> int:
+        return self.quant_info.num_local_experts
+
+    @property
+    def intermediate_size(self) -> int:
+        """Logical intermediate width of one TP shard."""
+        return self.quant_info.intermediate_size
+
+    @property
+    def hidden_size(self) -> int:
+        return self.quant_info.hidden_size
+
+    @property
+    def gate_up_slices(self) -> int:
+        return self._gate_up_slices
+
+    def prepare(
+        self,
+        hidden_states: torch.Tensor,
+        topk_ids: torch.Tensor,
+        top_k: int,
+        workspace: MoeLoraWorkspace | None = None,
+    ):
+        """Prepare rows with graph-stable buffers when a workspace is supplied."""
+        raise NotImplementedError
+
+    def gateup(self, row_state, out: torch.Tensor) -> None:
+        raise NotImplementedError
+
+    def release_prepared_inputs(self, row_state) -> None:
+        raise NotImplementedError
+
+    def act_with_delta(
+        self,
+        row_state,
+        gateup_out: torch.Tensor,
+        gate_up_delta: torch.Tensor | None,
+        topk_ids: torch.Tensor,
+        act_out: torch.Tensor,
+        activation_lora_input: torch.Tensor,
+        *,
+        activation: str = "silu",
+        consume_base_pdl: bool = False,
+    ) -> None:
+        raise NotImplementedError
+
+    def fused_act(
+        self,
+        row_state,
+        *,
+        activation: str,
+        base_gateup: torch.Tensor,
+        act_rows: torch.Tensor,
+        act_pairs: torch.Tensor | None,
+        routing: RouteView,
+        config: Mapping[str, int],
+        bridge_gateup: torch.Tensor | None = None,
+        b_gate_up: torch.Tensor | None = None,
+        bridge_top_k: int = 1,
+        consume_base_pdl: bool = False,
+    ) -> None:
+        raise NotImplementedError(
+            f"{self.contract.key} has no fused-act implementation"
+        )
+
+    def down(
+        self,
+        row_state,
+        act_out: torch.Tensor,
+        out: torch.Tensor,
+    ) -> None:
+        raise NotImplementedError
+
+    def finalize(
+        self,
+        row_state,
+        down_out: torch.Tensor,
+        topk_ids: torch.Tensor,
+        topk_weights: torch.Tensor,
+        routed_scaling_factor: float | None,
+        output: torch.Tensor,
+        *,
+        lora_delta: torch.Tensor | None = None,
+    ) -> None:
+        """Weight base + unweighted LoRA delta [T, K, H], then scale once."""
+        from sglang.kernels.ops.moe.ep_moe_kernels import post_reorder_deepgemm
+
+        num_tokens, hidden = output.shape
+        post_reorder_deepgemm(
+            down_out.view(-1, hidden),
+            output,
+            row_state.pair_to_row,
+            topk_ids,
+            topk_weights,
+            topk_ids.shape[1],
+            num_tokens,
+            hidden,
+            routed_scaling_factor if routed_scaling_factor is not None else 1.0,
+            lora_delta=lora_delta,
+        )
+
+    def shared_rank_finalize(
+        self,
+        row_state,
+        *,
+        down_rows: torch.Tensor,
+        bridge: torch.Tensor,
+        b_down: torch.Tensor,
+        routing: RouteView,
+        topk_weights: torch.Tensor,
+        routed_scaling_factor: float | None,
+        output: torch.Tensor,
+        token_rank: torch.Tensor,
+        config: Mapping[str, Mapping[str, int]],
+    ) -> None:
+        self._shared_rank_reduce(
+            row_state,
+            bridge=bridge,
+            routing=routing,
+            topk_weights=topk_weights,
+            routed_scaling_factor=routed_scaling_factor,
+            token_rank=token_rank,
+            config=config["reduce"],
+        )
+        self._shared_rank_tail(
+            row_state,
+            down_rows=down_rows,
+            b_down=b_down,
+            routing=routing,
+            topk_weights=topk_weights,
+            routed_scaling_factor=routed_scaling_factor,
+            output=output,
+            token_rank=token_rank,
+            config=config["tail"],
+        )
+
+    def _shared_rank_reduce(
+        self,
+        row_state,
+        *,
+        bridge: torch.Tensor,
+        routing: RouteView,
+        topk_weights: torch.Tensor,
+        routed_scaling_factor: float | None,
+        token_rank: torch.Tensor,
+        config: Mapping[str, int],
+    ) -> None:
+        from sglang.srt.lora.moe.kernels.finalize import (
+            invoke_shared_rank_reduce,
+        )
+
+        # Reads pair data only; ``row_state`` stays so every stage takes the
+        # same arguments.
+        del row_state
+        invoke_shared_rank_reduce(
+            bridge=bridge,
+            routing=routing,
+            topk_weights=topk_weights,
+            routed_scaling_factor=routed_scaling_factor,
+            token_rank=token_rank,
+            config=config,
+        )
+
+    def _shared_rank_tail(
+        self,
+        row_state,
+        *,
+        down_rows: torch.Tensor,
+        b_down: torch.Tensor,
+        routing: RouteView,
+        topk_weights: torch.Tensor,
+        routed_scaling_factor: float | None,
+        output: torch.Tensor,
+        token_rank: torch.Tensor,
+        config: Mapping[str, int],
+    ) -> None:
+        from sglang.srt.lora.moe.kernels.finalize import (
+            invoke_shared_from_scratch_finalize,
+        )
+
+        invoke_shared_from_scratch_finalize(
+            down_rows=down_rows,
+            pair_to_row=row_state.pair_to_row,
+            token_rank=token_rank,
+            b_down=b_down,
+            routing=routing,
+            topk_weights=topk_weights,
+            routed_scaling_factor=routed_scaling_factor,
+            output=output,
+            config=config,
+        )
+
+    def mapped_down_lora_a_input(
+        self,
+        row_state,
+        activation: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Sentinel mappings are uninitialized; their route blocks are skipped."""
+        return activation.view(-1, activation.shape[-1]), row_state.pair_to_row
+
+    def gateup_out_shape(self, row_state) -> tuple[int, ...]:
+        raise NotImplementedError
+
+    def act_out_shape(self, row_state) -> tuple[int, ...]:
+        raise NotImplementedError
+
+    def down_out_shape(self, row_state) -> tuple[int, ...]:
+        raise NotImplementedError

--- a/python/sglang/srt/lora/moe/base_gemm_provider/base.py
+++ b/python/sglang/srt/lora/moe/base_gemm_provider/base.py
@@ -15,13 +15,15 @@ if TYPE_CHECKING:
 
 class MoeBaseProviderContract(msgspec.Struct, frozen=True, kw_only=True):
     key: str
-    # These two flags give the column order of the base gate/up GEMM output.
-    # The LoRA delta is always [gate | up].
+    quant_info_cls: type
+    # Base output order; the LoRA delta is always [gate | up].
     gate_first: bool
     interleaved: bool
     gate_up_output_dtype: torch.dtype
     lora_delta_dtype: torch.dtype
     lora_activation_dtype: torch.dtype
+    # Fuse FP8 quantization into activation for the down GEMM.
+    act_quant_group: int | None = None
 
 
 def expected_rows_per_expert(num_pairs: int, num_experts: int) -> int:
@@ -35,8 +37,8 @@ def prepare_buffer(workspace, name: str, shape, *, dtype, device) -> torch.Tenso
     return torch.empty(shape, dtype=dtype, device=device)
 
 
-def admit_bf16_weights(quant_info) -> int:
-    """Check the BF16 weight layout once at attach; return the gate/up slices."""
+def admit_weight_layout(quant_info) -> int:
+    """Validate [E, S*I, H] / [E, H, I] weights and return S."""
     if quant_info.intermediate_size <= 0:
         raise ValueError("intermediate_size must be positive")
     expected_w2 = (
@@ -65,7 +67,7 @@ def admit_bf16_weights(quant_info) -> int:
     gate_up_slices = gateup_width // quant_info.intermediate_size
     if gate_up_slices not in (1, 2):
         raise ValueError(
-            "the BF16 providers support one non-gated slice or two gated "
+            "the base providers support one non-gated slice or two gated "
             f"gate/up slices, got {gate_up_slices}"
         )
     return gate_up_slices
@@ -119,7 +121,6 @@ class MoeBaseProvider:
         activation_lora_input: torch.Tensor,
         *,
         activation: str = "silu",
-        consume_base_pdl: bool = False,
     ) -> None:
         raise NotImplementedError
 
@@ -136,7 +137,6 @@ class MoeBaseProvider:
         bridge_gateup: torch.Tensor | None = None,
         b_gate_up: torch.Tensor | None = None,
         bridge_top_k: int = 1,
-        consume_base_pdl: bool = False,
     ) -> None:
         raise NotImplementedError(
             f"{self.contract.key} has no fused-act implementation"
@@ -178,7 +178,7 @@ class MoeBaseProvider:
             lora_delta=lora_delta,
         )
 
-    def shared_rank_finalize(
+    def shared_token_delta_finalize(
         self,
         row_state,
         *,
@@ -190,77 +190,64 @@ class MoeBaseProvider:
         routed_scaling_factor: float | None,
         output: torch.Tensor,
         token_rank: torch.Tensor,
+        token_delta: torch.Tensor,
+        token_route: RouteView,
+        delta_config: Mapping[str, int],
         config: Mapping[str, Mapping[str, int]],
     ) -> None:
-        self._shared_rank_reduce(
-            row_state,
+        """Reduce in rank space before applying the shared down-B per token."""
+        from sglang.srt.lora.moe.kernels.finalize import (
+            invoke_shared_token_delta_reduce,
+            invoke_shared_token_delta_tail,
+        )
+        from sglang.srt.lora.moe.kernels.lora_b import grouped_lora_b
+
+        invoke_shared_token_delta_reduce(
             bridge=bridge,
             routing=routing,
             topk_weights=topk_weights,
-            routed_scaling_factor=routed_scaling_factor,
             token_rank=token_rank,
             config=config["reduce"],
         )
-        self._shared_rank_tail(
-            row_state,
+        grouped_lora_b(
+            token_rank,
+            b_down,
+            token_delta,
+            token_route,
+            destination_offsets=(0,),
+            config=delta_config,
+            intermediate_top_k=1,
+        )
+        invoke_shared_token_delta_tail(
             down_rows=down_rows,
-            b_down=b_down,
+            pair_to_row=row_state.pair_to_row,
+            token_delta=token_delta,
             routing=routing,
             topk_weights=topk_weights,
             routed_scaling_factor=routed_scaling_factor,
             output=output,
-            token_rank=token_rank,
             config=config["tail"],
         )
 
-    def _shared_rank_reduce(
-        self,
-        row_state,
-        *,
-        bridge: torch.Tensor,
-        routing: RouteView,
-        topk_weights: torch.Tensor,
-        routed_scaling_factor: float | None,
-        token_rank: torch.Tensor,
-        config: Mapping[str, int],
-    ) -> None:
-        from sglang.srt.lora.moe.kernels.finalize import (
-            invoke_shared_rank_reduce,
-        )
-
-        # Reads pair data only; ``row_state`` stays so every stage takes the
-        # same arguments.
-        del row_state
-        invoke_shared_rank_reduce(
-            bridge=bridge,
-            routing=routing,
-            topk_weights=topk_weights,
-            routed_scaling_factor=routed_scaling_factor,
-            token_rank=token_rank,
-            config=config,
-        )
-
-    def _shared_rank_tail(
+    def shared_one_pass_finalize(
         self,
         row_state,
         *,
         down_rows: torch.Tensor,
+        bridge: torch.Tensor,
         b_down: torch.Tensor,
         routing: RouteView,
         topk_weights: torch.Tensor,
         routed_scaling_factor: float | None,
         output: torch.Tensor,
-        token_rank: torch.Tensor,
         config: Mapping[str, int],
     ) -> None:
-        from sglang.srt.lora.moe.kernels.finalize import (
-            invoke_shared_from_scratch_finalize,
-        )
+        from sglang.srt.lora.moe.kernels.finalize import invoke_shared_one_pass
 
-        invoke_shared_from_scratch_finalize(
+        invoke_shared_one_pass(
             down_rows=down_rows,
             pair_to_row=row_state.pair_to_row,
-            token_rank=token_rank,
+            bridge=bridge,
             b_down=b_down,
             routing=routing,
             topk_weights=topk_weights,

--- a/python/sglang/srt/lora/moe/base_gemm_provider/contiguous_row_domain.py
+++ b/python/sglang/srt/lora/moe/base_gemm_provider/contiguous_row_domain.py
@@ -10,7 +10,7 @@ import torch
 
 from sglang.srt.lora.moe.base_gemm_provider.base import (
     MoeBaseProvider,
-    admit_bf16_weights,
+    admit_weight_layout,
 )
 from sglang.srt.lora.moe.kernels.activation_delta import (
     act_delta_contiguous,
@@ -23,7 +23,7 @@ from sglang.srt.lora.moe.kernels.dispatch_contiguous import (
 from sglang.srt.lora.moe.kernels.fused_act import (
     fused_b_act_contiguous,
 )
-from sglang.srt.lora.moe.quant_info import MoeLoraBf16QuantInfo
+from sglang.srt.lora.moe.quant_info import StandardLayoutQuantInfo
 
 if TYPE_CHECKING:
     from sglang.srt.lora.moe.route_view import RouteView
@@ -31,22 +31,24 @@ if TYPE_CHECKING:
 
 
 class ContiguousRowState(msgspec.Struct, kw_only=True):
-    hidden_compact: torch.Tensor  # [m_pad_ceiling, hidden] bf16
+    hidden_compact: torch.Tensor | None  # [m_pad_ceiling, hidden], the GEMM input dtype
     seg_counts: torch.Tensor  # [E_local] int32
     seg_offsets: torch.Tensor  # [E_local + 1] int32 first row of each segment
     pair_to_row: torch.Tensor  # [num_tokens * top_k] int32 compact rows
     m_pad_ceiling: int
     retained_inputs: bool
+    # Quantized activation and scales for the down GEMM.
+    act_quant: tuple[torch.Tensor, torch.Tensor] | None = None
 
 
 class ContiguousRowDomainProvider(MoeBaseProvider):
 
-    def __init__(self, quant_info: MoeLoraBf16QuantInfo, *, m_alignment: int):
+    def __init__(self, quant_info: StandardLayoutQuantInfo, *, m_alignment: int):
         self.quant_info = quant_info
         if not isinstance(m_alignment, int) or m_alignment < 1:
             raise ValueError(f"m_alignment must be a positive int, got {m_alignment!r}")
         self._m_alignment = m_alignment
-        self._gate_up_slices = admit_bf16_weights(quant_info)
+        self._gate_up_slices = admit_weight_layout(quant_info)
 
     @property
     def m_alignment(self) -> int:
@@ -58,6 +60,8 @@ class ContiguousRowDomainProvider(MoeBaseProvider):
         topk_ids: torch.Tensor,
         top_k: int,
         workspace: MoeLoraWorkspace | None = None,
+        *,
+        fill_rows: bool = True,
     ) -> ContiguousRowState:
         num_pairs = topk_ids.numel()
         num_experts = self.quant_info.num_local_experts
@@ -85,23 +89,30 @@ class ContiguousRowDomainProvider(MoeBaseProvider):
                 dtype=torch.int32,
                 device=device,
             )
-            # First-allocation zero only: stale rows are safe, since nothing
-            # reads a padding row's output.
-            hidden_compact = workspace.tensor(
-                f"{prefix}:hidden_compact",
-                (m_pad_ceiling, hidden_states.size(1)),
-                dtype=torch.bfloat16,
-                device=device,
-                zero_on_first_allocation=True,
+            # Padding outputs are ignored, so reused padding needs no reset.
+            hidden_compact = (
+                None
+                if not fill_rows
+                else workspace.tensor(
+                    f"{prefix}:hidden_compact",
+                    (m_pad_ceiling, hidden_states.size(1)),
+                    dtype=torch.bfloat16,
+                    device=device,
+                    zero_on_first_allocation=True,
+                )
             )
         else:
             seg_counts = torch.empty(num_experts, dtype=torch.int32, device=device)
             seg_offsets = torch.empty(num_experts + 1, dtype=torch.int32, device=device)
             pair_to_row = torch.empty(num_pairs, dtype=torch.int32, device=device)
-            hidden_compact = torch.zeros(
-                (m_pad_ceiling, hidden_states.size(1)),
-                dtype=torch.bfloat16,
-                device=device,
+            hidden_compact = (
+                None
+                if not fill_rows
+                else torch.zeros(
+                    (m_pad_ceiling, hidden_states.size(1)),
+                    dtype=torch.bfloat16,
+                    device=device,
+                )
             )
         dispatch_layout_contiguous(
             hidden_states,
@@ -127,9 +138,8 @@ class ContiguousRowDomainProvider(MoeBaseProvider):
         )
 
     def release_prepared_inputs(self, row_state: ContiguousRowState) -> None:
-        # A workspace tensor must keep its address for graph replay, so this
-        # frees only an eagerly allocated buffer.
-        if row_state.retained_inputs:
+        # Workspace buffers retain their addresses for graph replay.
+        if row_state.retained_inputs or row_state.hidden_compact is None:
             return
         from sglang.srt.utils import dispose_tensor
 
@@ -145,8 +155,10 @@ class ContiguousRowDomainProvider(MoeBaseProvider):
         activation_lora_input: torch.Tensor,
         *,
         activation: str = "silu",
-        consume_base_pdl: bool = False,
+        act_quant: tuple[torch.Tensor, torch.Tensor] | None = None,
     ) -> None:
+        if act_quant is not None:
+            row_state.act_quant = act_quant
         act_delta_contiguous(
             gateup_out,
             gate_up_delta,
@@ -158,7 +170,11 @@ class ContiguousRowDomainProvider(MoeBaseProvider):
             gate_first=self.contract.gate_first,
             interleaved=self.contract.interleaved,
             activation=activation,
-            consume_base_pdl=consume_base_pdl,
+            act_quant=(
+                (*act_quant, self.contract.act_quant_group)
+                if act_quant is not None
+                else None
+            ),
         )
 
     def fused_act(
@@ -174,7 +190,6 @@ class ContiguousRowDomainProvider(MoeBaseProvider):
         bridge_gateup: torch.Tensor | None = None,
         b_gate_up: torch.Tensor | None = None,
         bridge_top_k: int = 1,
-        consume_base_pdl: bool = False,
     ) -> None:
         fused_b_act_contiguous(
             activation=activation,
@@ -190,7 +205,6 @@ class ContiguousRowDomainProvider(MoeBaseProvider):
             bridge_gateup=bridge_gateup,
             b_gate_up=b_gate_up,
             bridge_top_k=bridge_top_k,
-            consume_base_pdl=consume_base_pdl,
         )
 
     def gateup_out_shape(self, row_state: ContiguousRowState) -> tuple[int, ...]:

--- a/python/sglang/srt/lora/moe/base_gemm_provider/contiguous_row_domain.py
+++ b/python/sglang/srt/lora/moe/base_gemm_provider/contiguous_row_domain.py
@@ -1,0 +1,206 @@
+"""Routed rows packed into aligned, contiguous expert segments."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING
+
+import msgspec
+import torch
+
+from sglang.srt.lora.moe.base_gemm_provider.base import (
+    MoeBaseProvider,
+    admit_bf16_weights,
+)
+from sglang.srt.lora.moe.kernels.activation_delta import (
+    act_delta_contiguous,
+)
+from sglang.srt.lora.moe.kernels.dispatch_contiguous import (
+    contiguous_m_pad_ceiling,
+    dispatch_fill_rows_contiguous_bf16,
+    dispatch_layout_contiguous,
+)
+from sglang.srt.lora.moe.kernels.fused_act import (
+    fused_b_act_contiguous,
+)
+from sglang.srt.lora.moe.quant_info import MoeLoraBf16QuantInfo
+
+if TYPE_CHECKING:
+    from sglang.srt.lora.moe.route_view import RouteView
+    from sglang.srt.lora.moe.workspace import MoeLoraWorkspace
+
+
+class ContiguousRowState(msgspec.Struct, kw_only=True):
+    hidden_compact: torch.Tensor  # [m_pad_ceiling, hidden] bf16
+    seg_counts: torch.Tensor  # [E_local] int32
+    seg_offsets: torch.Tensor  # [E_local + 1] int32 first row of each segment
+    pair_to_row: torch.Tensor  # [num_tokens * top_k] int32 compact rows
+    m_pad_ceiling: int
+    retained_inputs: bool
+
+
+class ContiguousRowDomainProvider(MoeBaseProvider):
+
+    def __init__(self, quant_info: MoeLoraBf16QuantInfo, *, m_alignment: int):
+        self.quant_info = quant_info
+        if not isinstance(m_alignment, int) or m_alignment < 1:
+            raise ValueError(f"m_alignment must be a positive int, got {m_alignment!r}")
+        self._m_alignment = m_alignment
+        self._gate_up_slices = admit_bf16_weights(quant_info)
+
+    @property
+    def m_alignment(self) -> int:
+        return self._m_alignment
+
+    def prepare(
+        self,
+        hidden_states: torch.Tensor,
+        topk_ids: torch.Tensor,
+        top_k: int,
+        workspace: MoeLoraWorkspace | None = None,
+    ) -> ContiguousRowState:
+        num_pairs = topk_ids.numel()
+        num_experts = self.quant_info.num_local_experts
+        m_pad_ceiling = contiguous_m_pad_ceiling(
+            num_pairs, num_experts, self._m_alignment
+        )
+        device = hidden_states.device
+        if workspace is not None:
+            prefix = f"contiguous:a{self._m_alignment}"
+            seg_counts = workspace.tensor(
+                f"{prefix}:seg_counts",
+                (num_experts,),
+                dtype=torch.int32,
+                device=device,
+            )
+            seg_offsets = workspace.tensor(
+                f"{prefix}:seg_offsets",
+                (num_experts + 1,),
+                dtype=torch.int32,
+                device=device,
+            )
+            pair_to_row = workspace.tensor(
+                f"{prefix}:pair_to_row",
+                (num_pairs,),
+                dtype=torch.int32,
+                device=device,
+            )
+            # First-allocation zero only: stale rows are safe, since nothing
+            # reads a padding row's output.
+            hidden_compact = workspace.tensor(
+                f"{prefix}:hidden_compact",
+                (m_pad_ceiling, hidden_states.size(1)),
+                dtype=torch.bfloat16,
+                device=device,
+                zero_on_first_allocation=True,
+            )
+        else:
+            seg_counts = torch.empty(num_experts, dtype=torch.int32, device=device)
+            seg_offsets = torch.empty(num_experts + 1, dtype=torch.int32, device=device)
+            pair_to_row = torch.empty(num_pairs, dtype=torch.int32, device=device)
+            hidden_compact = torch.zeros(
+                (m_pad_ceiling, hidden_states.size(1)),
+                dtype=torch.bfloat16,
+                device=device,
+            )
+        dispatch_layout_contiguous(
+            hidden_states,
+            topk_ids,
+            num_experts,
+            top_k,
+            self._m_alignment,
+            seg_counts_out=seg_counts,
+            seg_offsets_out=seg_offsets,
+            pair_to_row_out=pair_to_row,
+        )
+        if hidden_compact is not None:
+            dispatch_fill_rows_contiguous_bf16(
+                hidden_states, topk_ids, pair_to_row, hidden_compact_out=hidden_compact
+            )
+        return ContiguousRowState(
+            hidden_compact=hidden_compact,
+            seg_counts=seg_counts,
+            seg_offsets=seg_offsets,
+            pair_to_row=pair_to_row,
+            m_pad_ceiling=m_pad_ceiling,
+            retained_inputs=workspace is not None,
+        )
+
+    def release_prepared_inputs(self, row_state: ContiguousRowState) -> None:
+        # A workspace tensor must keep its address for graph replay, so this
+        # frees only an eagerly allocated buffer.
+        if row_state.retained_inputs:
+            return
+        from sglang.srt.utils import dispose_tensor
+
+        dispose_tensor(row_state.hidden_compact)
+
+    def act_with_delta(
+        self,
+        row_state: ContiguousRowState,
+        gateup_out: torch.Tensor,
+        gate_up_delta: torch.Tensor | None,
+        topk_ids: torch.Tensor,
+        act_out: torch.Tensor,
+        activation_lora_input: torch.Tensor,
+        *,
+        activation: str = "silu",
+        consume_base_pdl: bool = False,
+    ) -> None:
+        act_delta_contiguous(
+            gateup_out,
+            gate_up_delta,
+            act_out,
+            activation_lora_input,
+            row_state.pair_to_row,
+            topk_ids,
+            self.num_local_experts,
+            gate_first=self.contract.gate_first,
+            interleaved=self.contract.interleaved,
+            activation=activation,
+            consume_base_pdl=consume_base_pdl,
+        )
+
+    def fused_act(
+        self,
+        row_state: ContiguousRowState,
+        *,
+        activation: str,
+        base_gateup: torch.Tensor,
+        act_rows: torch.Tensor,
+        act_pairs: torch.Tensor | None,
+        routing: RouteView,
+        config: Mapping[str, int],
+        bridge_gateup: torch.Tensor | None = None,
+        b_gate_up: torch.Tensor | None = None,
+        bridge_top_k: int = 1,
+        consume_base_pdl: bool = False,
+    ) -> None:
+        fused_b_act_contiguous(
+            activation=activation,
+            base_gateup=base_gateup,
+            act_compact=act_rows,
+            act_pairs=act_pairs,
+            pair_to_row=row_state.pair_to_row,
+            routing=routing,
+            num_local_experts=self.num_local_experts,
+            gate_first=self.contract.gate_first,
+            interleaved=self.contract.interleaved,
+            config=config,
+            bridge_gateup=bridge_gateup,
+            b_gate_up=b_gate_up,
+            bridge_top_k=bridge_top_k,
+            consume_base_pdl=consume_base_pdl,
+        )
+
+    def gateup_out_shape(self, row_state: ContiguousRowState) -> tuple[int, ...]:
+        return (
+            row_state.m_pad_ceiling,
+            self.gate_up_slices * self.quant_info.intermediate_size,
+        )
+
+    def act_out_shape(self, row_state: ContiguousRowState) -> tuple[int, ...]:
+        return (row_state.m_pad_ceiling, self.quant_info.intermediate_size)
+
+    def down_out_shape(self, row_state: ContiguousRowState) -> tuple[int, ...]:
+        return (row_state.m_pad_ceiling, self.quant_info.hidden_size)

--- a/python/sglang/srt/lora/moe/base_gemm_provider/cutedsl_bf16.py
+++ b/python/sglang/srt/lora/moe/base_gemm_provider/cutedsl_bf16.py
@@ -1,0 +1,303 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from sglang.srt.lora.moe.base_gemm_provider.base import (
+    MoeBaseProviderContract,
+    expected_rows_per_expert,
+)
+from sglang.srt.lora.moe.base_gemm_provider.contiguous_row_domain import (
+    ContiguousRowDomainProvider,
+    ContiguousRowState,
+)
+from sglang.srt.lora.moe.base_gemm_provider.cutedsl_common import CuteDslTileMixin
+from sglang.srt.lora.moe.base_gemm_provider.masked_row_domain import (
+    MaskedRowDomainProvider,
+    MaskedRowState,
+)
+from sglang.srt.lora.moe.quant_info import MoeLoraBf16QuantInfo
+
+if TYPE_CHECKING:
+    from sglang.srt.lora.moe.workspace import MoeLoraWorkspace
+
+
+class _CuteDslBf16Mixin(CuteDslTileMixin):
+    _DTYPE_TAG = "bf16"
+    WIDE_EXPECTED_M_THRESHOLD = 16
+
+    def _launch(
+        self,
+        stage: str,
+        a: torch.Tensor,
+        c: torch.Tensor,
+        row_state,
+        schedule: torch.Tensor,
+        tiles: torch.Tensor,
+    ) -> None:
+        call = self._compiled[row_state.token_width][stage]
+        # Runtime wrapping must match the compiled argument's MLIR type.
+        dyn = self._as_dynamic_cute_tensor
+        call.compiled_fn(
+            dyn(self._rows_arg(a), leading_dim=2),
+            call.b_arg,
+            dyn(self._rows_arg(c), leading_dim=2),
+            dyn(self._group_arg(row_state), leading_dim=0),
+            dyn(schedule, leading_dim=0),
+            dyn(tiles, leading_dim=0),
+            self._stream(a.device),
+        )
+
+    def gateup(self, row_state, out: torch.Tensor) -> None:
+        self._launch(
+            "gemm1",
+            self._input_rows(row_state),
+            out,
+            row_state,
+            row_state.gemm1_schedule,
+            row_state.gemm1_tiles,
+        )
+
+    def down(self, row_state, act_out: torch.Tensor, out: torch.Tensor) -> None:
+        self._launch(
+            "gemm2",
+            act_out,
+            out,
+            row_state,
+            row_state.gemm2_schedule,
+            row_state.gemm2_tiles,
+        )
+
+
+class CuteDslBf16MaskedRowState(MaskedRowState, kw_only=True):
+    token_width: int
+    gemm1_schedule: torch.Tensor
+    gemm1_tiles: torch.Tensor
+    gemm2_schedule: torch.Tensor
+    gemm2_tiles: torch.Tensor
+
+
+class CuteDslBf16MaskedProvider(_CuteDslBf16Mixin, MaskedRowDomainProvider):
+    contract = MoeBaseProviderContract(
+        key="cutedsl_bf16_masked",
+        gate_first=True,
+        interleaved=False,
+        gate_up_output_dtype=torch.bfloat16,
+        lora_delta_dtype=torch.bfloat16,
+        lora_activation_dtype=torch.bfloat16,
+    )
+
+    _ROW_MODE = "masked"
+
+    def __init__(self, quant_info: MoeLoraBf16QuantInfo):
+        super().__init__(quant_info)
+        from sglang.srt.lora.moe.kernels.cutedsl.api import prepare_masked_bf16
+        from sglang.srt.lora.moe.kernels.cutedsl.schedule_builder import (
+            build_dual_stage_schedules_masked,
+            dual_stage_schedule_capacities_masked,
+        )
+
+        self._prepare_masked_gemm = prepare_masked_bf16
+        self._build_schedules = build_dual_stage_schedules_masked
+        self._schedule_capacities = dual_stage_schedule_capacities_masked
+        self._init_tiles(quant_info)
+
+    def _prepare_dummy(self, stage: str, config):
+        weight = self._stage_weight(stage)
+        device = weight.device
+        experts, n, k = weight.shape
+        # Compile the layout with a dynamic M extent.
+        dummy_a = torch.zeros((experts, 256, k), dtype=torch.bfloat16, device=device)
+        dummy_c = torch.empty((experts, 256, n), dtype=torch.bfloat16, device=device)
+        dummy_masked = torch.zeros(experts, dtype=torch.int32, device=device)
+        return self._prepare_masked_gemm(
+            dummy_a,
+            weight,
+            dummy_c,
+            dummy_masked,
+            config=config,
+        )
+
+    @staticmethod
+    def _rows_arg(tensor: torch.Tensor) -> torch.Tensor:
+        return tensor
+
+    @staticmethod
+    def _input_rows(row_state: CuteDslBf16MaskedRowState) -> torch.Tensor:
+        return row_state.hidden_permuted
+
+    @staticmethod
+    def _group_arg(row_state: CuteDslBf16MaskedRowState) -> torch.Tensor:
+        return row_state.masked_m
+
+    def prepare(
+        self,
+        hidden_states: torch.Tensor,
+        topk_ids: torch.Tensor,
+        top_k: int,
+        workspace: MoeLoraWorkspace | None = None,
+    ) -> CuteDslBf16MaskedRowState:
+        base = super().prepare(hidden_states, topk_ids, top_k, workspace)
+        token_width = self._token_width_for(base.m_max, base.expected_m)
+        geometry = dict(
+            token_width=token_width,
+            n_gemm1=self.gate_up_slices * self.quant_info.intermediate_size,
+            n_gemm2=self.quant_info.hidden_size,
+            output_width=self.OUTPUT_WIDTH,
+            cluster_shape_mn=self.CLUSTER_SHAPE_MN,
+            use_2cta_instrs=self.USE_2CTA_INSTRS,
+        )
+        schedule_outputs = {}
+        if workspace is not None:
+            schedule_outputs = self._schedule_buffers(
+                workspace,
+                f"cutedsl_masked:tw{token_width}",
+                self._schedule_capacities(
+                    num_experts=base.masked_m.numel(), m_max=base.m_max, **geometry
+                ),
+                hidden_states.device,
+            )
+        schedule1, tiles1, schedule2, tiles2 = self._build_schedules(
+            base.masked_m, m_max=base.m_max, **geometry, **schedule_outputs
+        )
+        return CuteDslBf16MaskedRowState(
+            hidden_permuted=base.hidden_permuted,
+            masked_m=base.masked_m,
+            expected_m=base.expected_m,
+            pair_to_row=base.pair_to_row,
+            m_max=base.m_max,
+            retained_inputs=base.retained_inputs,
+            token_width=token_width,
+            gemm1_schedule=schedule1,
+            gemm1_tiles=tiles1,
+            gemm2_schedule=schedule2,
+            gemm2_tiles=tiles2,
+        )
+
+
+class CuteDslBf16ContiguousRowState(ContiguousRowState, kw_only=True):
+    token_width: int
+    gemm1_schedule: torch.Tensor
+    gemm1_tiles: torch.Tensor
+    gemm2_schedule: torch.Tensor
+    gemm2_tiles: torch.Tensor
+
+
+class CuteDslBf16ContiguousProvider(_CuteDslBf16Mixin, ContiguousRowDomainProvider):
+
+    contract = MoeBaseProviderContract(
+        key="cutedsl_bf16_contiguous",
+        gate_first=True,
+        interleaved=False,
+        gate_up_output_dtype=torch.bfloat16,
+        lora_delta_dtype=torch.bfloat16,
+        lora_activation_dtype=torch.bfloat16,
+    )
+
+    # Every compiled token width divides 128.
+    M_ALIGNMENT = 128
+
+    _ROW_MODE = "contiguous"
+
+    def __init__(self, quant_info: MoeLoraBf16QuantInfo):
+        super().__init__(quant_info, m_alignment=self.M_ALIGNMENT)
+
+        from sglang.srt.lora.moe.kernels.cutedsl.api import prepare_contiguous_bf16
+        from sglang.srt.lora.moe.kernels.cutedsl.schedule_builder import (
+            build_dual_stage_schedules_contiguous,
+            dual_stage_schedule_capacities_contiguous,
+            validate_tile_geometry_contiguous,
+        )
+
+        self._prepare_contiguous_gemm = prepare_contiguous_bf16
+        self._validate_tile_geometry = validate_tile_geometry_contiguous
+        self._build_schedules_contiguous = build_dual_stage_schedules_contiguous
+        self._schedule_capacities = dual_stage_schedule_capacities_contiguous
+
+        # Hopper prefill uses wide tiles.
+        device_capability = torch.cuda.get_device_capability(
+            quant_info.w13_weight.device
+        )
+        self._init_tiles(quant_info, drop_narrow_tile=device_capability < (10, 0))
+
+    def _admit_tile_width(self, token_width: int) -> None:
+        self._validate_tile_geometry(token_width, self._m_alignment)
+
+    def _prepare_dummy(self, stage: str, config):
+        weight = self._stage_weight(stage)
+        device = weight.device
+        num_experts, n, k = weight.shape
+        # Compile the layout with a dynamic M extent.
+        dummy_a = torch.zeros((256, k), dtype=torch.bfloat16, device=device)
+        dummy_c = torch.empty((256, n), dtype=torch.bfloat16, device=device)
+        dummy_seg = torch.zeros(num_experts + 1, dtype=torch.int32, device=device)
+        return self._prepare_contiguous_gemm(
+            dummy_a,
+            weight,
+            dummy_c,
+            dummy_seg,
+            config=config,
+        )
+
+    @staticmethod
+    def _rows_arg(tensor: torch.Tensor) -> torch.Tensor:
+        # Flat rows occupy one expert slot in the swap_ab wrapper.
+        return tensor.unsqueeze(0)
+
+    @staticmethod
+    def _input_rows(row_state: CuteDslBf16ContiguousRowState) -> torch.Tensor:
+        return row_state.hidden_compact
+
+    @staticmethod
+    def _group_arg(row_state: CuteDslBf16ContiguousRowState) -> torch.Tensor:
+        return row_state.seg_offsets
+
+    def prepare(
+        self,
+        hidden_states: torch.Tensor,
+        topk_ids: torch.Tensor,
+        top_k: int,
+        workspace: MoeLoraWorkspace | None = None,
+    ) -> CuteDslBf16ContiguousRowState:
+        base = super().prepare(hidden_states, topk_ids, top_k, workspace)
+        num_experts = self.quant_info.num_local_experts
+        # Distinct top-k experts bound each expert to one row per token.
+        max_expert_rows = max(int(hidden_states.size(0)), 1)
+        expected_m = expected_rows_per_expert(topk_ids.numel(), num_experts)
+        token_width = self._token_width_for(max_expert_rows, expected_m)
+        geometry = dict(
+            m_pad_ceiling=base.m_pad_ceiling,
+            max_expert_rows=max_expert_rows,
+            m_alignment=self._m_alignment,
+            token_width=token_width,
+            n_gemm1=self.gate_up_slices * self.quant_info.intermediate_size,
+            n_gemm2=self.quant_info.hidden_size,
+            output_width=self.OUTPUT_WIDTH,
+            cluster_shape_mn=self.CLUSTER_SHAPE_MN,
+            use_2cta_instrs=self.USE_2CTA_INSTRS,
+        )
+        schedule_outputs = {}
+        if workspace is not None:
+            schedule_outputs = self._schedule_buffers(
+                workspace,
+                f"cutedsl_contiguous:a{self._m_alignment}:tw{token_width}",
+                self._schedule_capacities(num_experts=num_experts, **geometry),
+                hidden_states.device,
+            )
+        schedule1, tiles1, schedule2, tiles2 = self._build_schedules_contiguous(
+            base.seg_counts, **geometry, **schedule_outputs
+        )
+        return CuteDslBf16ContiguousRowState(
+            hidden_compact=base.hidden_compact,
+            seg_counts=base.seg_counts,
+            seg_offsets=base.seg_offsets,
+            pair_to_row=base.pair_to_row,
+            m_pad_ceiling=base.m_pad_ceiling,
+            retained_inputs=base.retained_inputs,
+            token_width=token_width,
+            gemm1_schedule=schedule1,
+            gemm1_tiles=tiles1,
+            gemm2_schedule=schedule2,
+            gemm2_tiles=tiles2,
+        )

--- a/python/sglang/srt/lora/moe/base_gemm_provider/cutedsl_bf16.py
+++ b/python/sglang/srt/lora/moe/base_gemm_provider/cutedsl_bf16.py
@@ -81,6 +81,7 @@ class CuteDslBf16MaskedRowState(MaskedRowState, kw_only=True):
 class CuteDslBf16MaskedProvider(_CuteDslBf16Mixin, MaskedRowDomainProvider):
     contract = MoeBaseProviderContract(
         key="cutedsl_bf16_masked",
+        quant_info_cls=MoeLoraBf16QuantInfo,
         gate_first=True,
         interleaved=False,
         gate_up_output_dtype=torch.bfloat16,
@@ -188,6 +189,7 @@ class CuteDslBf16ContiguousProvider(_CuteDslBf16Mixin, ContiguousRowDomainProvid
 
     contract = MoeBaseProviderContract(
         key="cutedsl_bf16_contiguous",
+        quant_info_cls=MoeLoraBf16QuantInfo,
         gate_first=True,
         interleaved=False,
         gate_up_output_dtype=torch.bfloat16,

--- a/python/sglang/srt/lora/moe/base_gemm_provider/cutedsl_common.py
+++ b/python/sglang/srt/lora/moe/base_gemm_provider/cutedsl_common.py
@@ -1,0 +1,216 @@
+"""Shared compilation, tile selection, and launch buffers for CuTeDSL."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import msgspec
+import torch
+
+if TYPE_CHECKING:
+    from sglang.srt.lora.moe.quant_info import MoeLoraBf16QuantInfo
+    from sglang.srt.lora.moe.workspace import MoeLoraWorkspace
+
+# Cache code only: caching bound arguments would retain layer weights.
+_COMPILE_CACHE: dict[tuple, object] = {}
+
+
+class CuteDslStageCall(msgspec.Struct, frozen=True):
+    compiled_fn: object
+    b_arg: object
+
+
+class CuteDslTileMixin:
+    NARROW_TOKEN_WIDTH = 8
+    NARROW_PERSISTENT_CLUSTERS = 128
+    WIDE_TOKEN_WIDTH = 64
+    WIDE_PERSISTENT_CLUSTERS = 128
+    XWIDE_TOKEN_WIDTH = 128
+    XWIDE_PERSISTENT_CLUSTERS = 128
+    # The packed schedule supports only 1x1 clusters and 1-CTA MMA.
+    CLUSTER_SHAPE_MN = (1, 1)
+    USE_2CTA_INSTRS = False
+    OCCUPANCY = 1
+    MMA_INST_TILE_K = 4
+    WIDE_EXPECTED_M_THRESHOLD: int
+    XWIDE_EXPECTED_M_THRESHOLD = 96
+    OUTPUT_WIDTH = 128
+
+    _ROW_MODE: str
+    _DTYPE_TAG: str
+
+    def _init_tiles(
+        self, quant_info: MoeLoraBf16QuantInfo, *, drop_narrow_tile: bool = False
+    ) -> None:
+        import cuda.bindings.driver as cuda_driver
+
+        from sglang.srt.lora.moe.base_gemm_provider.gemm_config_store import (
+            cutedsl_version,
+            load_config_table,
+        )
+        from sglang.srt.lora.moe.kernels.cutedsl.api import (
+            GroupedGemmConfig,
+            as_dynamic_cute_tensor,
+        )
+        from sglang.srt.lora.moe.kernels.cutedsl.schedule_builder import (
+            MAX_EXPERTS,
+            MAX_TOKEN_CLUSTERS,
+        )
+
+        self._as_dynamic_cute_tensor = as_dynamic_cute_tensor
+        self._cu_stream = cuda_driver.CUstream
+        if quant_info.num_local_experts > MAX_EXPERTS:
+            raise ValueError(
+                f"{quant_info.num_local_experts} local experts exceed the "
+                f"direct schedule's {MAX_EXPERTS}-expert packing"
+            )
+        self._max_token_clusters = MAX_TOKEN_CLUSTERS
+
+        device = quant_info.w13_weight.device
+        # The 152-cluster choice was tuned on GB300.
+        xwide_clusters = self.XWIDE_PERSISTENT_CLUSTERS
+        if (
+            torch.cuda.get_device_capability(device) >= (10, 0)
+            and torch.cuda.get_device_properties(device).multi_processor_count == 152
+        ):
+            xwide_clusters = 152
+        tile_set = (
+            (self.NARROW_TOKEN_WIDTH, self.NARROW_PERSISTENT_CLUSTERS),
+            (self.WIDE_TOKEN_WIDTH, self.WIDE_PERSISTENT_CLUSTERS),
+            (self.XWIDE_TOKEN_WIDTH, xwide_clusters),
+        )
+        if drop_narrow_tile:
+            tile_set = tile_set[1:]
+
+        version = cutedsl_version()
+        self._config_table = load_config_table(
+            self.contract.key,
+            num_local_experts=quant_info.num_local_experts,
+            n_gemm1=self._gate_up_slices * quant_info.intermediate_size,
+            n_gemm2=quant_info.hidden_size,
+            k=quant_info.hidden_size,
+            expected_versions={"cutedsl": version} if version else None,
+        )
+        if self._config_table is not None:
+            for bucket_m, payload in self._config_table.buckets.items():
+                if "token_width" not in payload:
+                    raise ValueError(
+                        f"{self.contract.key} config bucket {bucket_m} lacks "
+                        "token_width"
+                    )
+            widths = dict(tile_set)
+            widths.update(
+                (tile.token_width, tile.persistent_clusters)
+                for tile in self._config_table.tiles
+            )
+            tile_set = tuple(sorted(widths.items()))
+
+        self._compiled: dict[int, dict[str, CuteDslStageCall]] = {}
+        self._tile_configs: dict[int, GroupedGemmConfig] = {}
+        for token_width, persistent_clusters in tile_set:
+            self._admit_tile_width(token_width)
+            config = GroupedGemmConfig(
+                mma_tiler_mn=(self.OUTPUT_WIDTH, token_width),
+                cluster_shape_mn=self.CLUSTER_SHAPE_MN,
+                use_2cta_instrs=self.USE_2CTA_INSTRS,
+                occupancy=self.OCCUPANCY,
+                mma_inst_tile_k=self.MMA_INST_TILE_K,
+                persistent_clusters=persistent_clusters,
+            )
+            self._tile_configs[token_width] = config
+            self._compiled[token_width] = {}
+            self._compile_stage(token_width, "gemm1")
+            self._compile_stage(token_width, "gemm2")
+        torch.cuda.synchronize(device)
+
+    def _admit_tile_width(self, token_width: int) -> None:
+        """Optional hook for row-layout constraints."""
+
+    def _stage_weight(self, stage: str) -> torch.Tensor:
+        if stage == "gemm1":
+            return self.quant_info.w13_weight
+        if stage == "gemm2":
+            return self.quant_info.w2_weight
+        raise ValueError(f"unknown CuTeDSL base stage {stage!r}")
+
+    def _compile_stage(self, token_width: int, stage: str) -> None:
+        if stage in self._compiled[token_width]:
+            return
+        weight = self._stage_weight(stage)
+        config = self._tile_configs[token_width]
+        device = weight.device
+        key = (
+            device.type,
+            device.index,
+            config,
+            self._ROW_MODE,
+            self._DTYPE_TAG,
+            self.quant_info.num_local_experts,
+            weight.shape[1],
+            weight.shape[2],
+        )
+        compiled_fn = _COMPILE_CACHE.get(key)
+        if compiled_fn is None:
+            prepared = self._prepare_dummy(stage, config)
+            # Load the module before graph capture with a zero-tile launch.
+            prepared.launch()
+            compiled_fn = prepared.compiled_fn
+            _COMPILE_CACHE[key] = compiled_fn
+        self._compiled[token_width][stage] = CuteDslStageCall(
+            compiled_fn=compiled_fn,
+            b_arg=self._as_dynamic_cute_tensor(weight, leading_dim=2),
+        )
+
+    def _token_width_for(self, m_max: int, expected_m: int) -> int:
+        """Widen the tuned choice if needed to fit the packed schedule."""
+        if self._config_table is not None:
+            performance_width = self._config_table.pick(expected_m)["token_width"]
+        elif expected_m >= self.XWIDE_EXPECTED_M_THRESHOLD:
+            performance_width = self.XWIDE_TOKEN_WIDTH
+        elif (
+            expected_m >= self.WIDE_EXPECTED_M_THRESHOLD
+            or self.NARROW_TOKEN_WIDTH not in self._compiled
+        ):
+            performance_width = self.WIDE_TOKEN_WIDTH
+        else:
+            performance_width = self.NARROW_TOKEN_WIDTH
+        for width in sorted(self._compiled):
+            if width >= performance_width and m_max <= width * self._max_token_clusters:
+                return width
+        widest = max(self._compiled)
+        raise ValueError(
+            f"m_max={m_max} exceeds the widest compiled tile's schedule "
+            f"packing ({widest * self._max_token_clusters})"
+        )
+
+    def _stream(self, device: torch.device):
+        return self._cu_stream(torch.cuda.current_stream(device).cuda_stream)
+
+    @staticmethod
+    def _schedule_buffers(
+        workspace: MoeLoraWorkspace,
+        prefix: str,
+        capacities: tuple[int, int],
+        device: torch.device,
+    ) -> dict[str, torch.Tensor]:
+        capacity1, capacity2 = capacities
+        return {
+            "schedule1_out": workspace.tensor(
+                f"{prefix}:gemm1_schedule",
+                (capacity1,),
+                dtype=torch.int64,
+                device=device,
+            ),
+            "tiles1_out": workspace.tensor(
+                f"{prefix}:gemm1_tiles", (1,), dtype=torch.int32, device=device
+            ),
+            "schedule2_out": workspace.tensor(
+                f"{prefix}:gemm2_schedule",
+                (capacity2,),
+                dtype=torch.int64,
+                device=device,
+            ),
+            "tiles2_out": workspace.tensor(
+                f"{prefix}:gemm2_tiles", (1,), dtype=torch.int32, device=device
+            ),
+        }

--- a/python/sglang/srt/lora/moe/base_gemm_provider/cutedsl_common.py
+++ b/python/sglang/srt/lora/moe/base_gemm_provider/cutedsl_common.py
@@ -8,7 +8,7 @@ import msgspec
 import torch
 
 if TYPE_CHECKING:
-    from sglang.srt.lora.moe.quant_info import MoeLoraBf16QuantInfo
+    from sglang.srt.lora.moe.quant_info import StandardLayoutQuantInfo
     from sglang.srt.lora.moe.workspace import MoeLoraWorkspace
 
 # Cache code only: caching bound arguments would retain layer weights.
@@ -18,6 +18,7 @@ _COMPILE_CACHE: dict[tuple, object] = {}
 class CuteDslStageCall(msgspec.Struct, frozen=True):
     compiled_fn: object
     b_arg: object
+    sf_weights: torch.Tensor | None = None
 
 
 class CuteDslTileMixin:
@@ -40,7 +41,7 @@ class CuteDslTileMixin:
     _DTYPE_TAG: str
 
     def _init_tiles(
-        self, quant_info: MoeLoraBf16QuantInfo, *, drop_narrow_tile: bool = False
+        self, quant_info: StandardLayoutQuantInfo, *, drop_narrow_tile: bool = False
     ) -> None:
         import cuda.bindings.driver as cuda_driver
 
@@ -65,6 +66,7 @@ class CuteDslTileMixin:
                 f"direct schedule's {MAX_EXPERTS}-expert packing"
             )
         self._max_token_clusters = MAX_TOKEN_CLUSTERS
+        self._bind_weights(quant_info)
 
         device = quant_info.w13_weight.device
         # The 152-cluster choice was tuned on GB300.
@@ -123,6 +125,9 @@ class CuteDslTileMixin:
             self._compile_stage(token_width, "gemm2")
         torch.cuda.synchronize(device)
 
+    def _bind_weights(self, quant_info: StandardLayoutQuantInfo) -> None:
+        """Optional hook for dtype-specific weight preparation."""
+
     def _admit_tile_width(self, token_width: int) -> None:
         """Optional hook for row-layout constraints."""
 
@@ -132,6 +137,9 @@ class CuteDslTileMixin:
         if stage == "gemm2":
             return self.quant_info.w2_weight
         raise ValueError(f"unknown CuTeDSL base stage {stage!r}")
+
+    def _stage_scale(self, stage: str) -> torch.Tensor | None:
+        return None
 
     def _compile_stage(self, token_width: int, stage: str) -> None:
         if stage in self._compiled[token_width]:
@@ -159,6 +167,7 @@ class CuteDslTileMixin:
         self._compiled[token_width][stage] = CuteDslStageCall(
             compiled_fn=compiled_fn,
             b_arg=self._as_dynamic_cute_tensor(weight, leading_dim=2),
+            sf_weights=self._stage_scale(stage),
         )
 
     def _token_width_for(self, m_max: int, expected_m: int) -> int:

--- a/python/sglang/srt/lora/moe/base_gemm_provider/cutedsl_fp8.py
+++ b/python/sglang/srt/lora/moe/base_gemm_provider/cutedsl_fp8.py
@@ -1,0 +1,441 @@
+"""CuTeDSL GEMMs using checkpoint FP8 values and FP32 block scales.
+
+Activations use group-128 quantization; GEMM outputs remain BF16 for LoRA.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from sglang.kernels.ops.quantization.fp8_kernel import (
+    sglang_per_token_group_quant_fp8,
+)
+from sglang.srt.lora.moe.base_gemm_provider.base import (
+    MoeBaseProviderContract,
+    expected_rows_per_expert,
+    prepare_buffer,
+)
+from sglang.srt.lora.moe.base_gemm_provider.contiguous_row_domain import (
+    ContiguousRowDomainProvider,
+    ContiguousRowState,
+)
+from sglang.srt.lora.moe.base_gemm_provider.cutedsl_common import CuteDslTileMixin
+from sglang.srt.lora.moe.base_gemm_provider.masked_row_domain import (
+    MaskedRowDomainProvider,
+    MaskedRowState,
+    masked_m_max,
+)
+from sglang.srt.lora.moe.kernels.dispatch_contiguous import (
+    dispatch_fill_rows_contiguous_fp8,
+)
+from sglang.srt.lora.moe.kernels.dispatch_masked import dispatch_fill_masked_fp8
+from sglang.srt.lora.moe.quant_info import MoeLoraFp8QuantInfo
+
+QUANT_GROUP = 128
+
+
+class _CuteDslFp8Mixin(CuteDslTileMixin):
+    _DTYPE_TAG = "fp8"
+    WIDE_EXPECTED_M_THRESHOLD = 32
+
+    def _bind_weights(self, quant_info: MoeLoraFp8QuantInfo) -> None:
+        self._sf_w13 = quant_info.w13_scale.contiguous()
+        self._sf_w2 = quant_info.w2_scale.contiguous()
+
+    def _stage_scale(self, stage: str) -> torch.Tensor:
+        return self._sf_w13 if stage == "gemm1" else self._sf_w2
+
+    def _launch(
+        self,
+        stage: str,
+        a_fp8: torch.Tensor,
+        sf_tokens: torch.Tensor,
+        c: torch.Tensor,
+        row_state,
+        schedule: torch.Tensor,
+        tiles: torch.Tensor,
+    ) -> None:
+        call = self._compiled[row_state.token_width][stage]
+        # Runtime wrapping must match the compiled argument's MLIR type.
+        dyn = self._as_dynamic_cute_tensor
+        call.compiled_fn(
+            dyn(self._rows_arg(a_fp8), leading_dim=2),
+            call.b_arg,
+            dyn(self._sf_arg(sf_tokens, a_fp8.shape), leading_dim=2),
+            dyn(call.sf_weights, leading_dim=2),
+            dyn(self._rows_arg(c), leading_dim=2),
+            dyn(self._group_arg(row_state), leading_dim=0),
+            dyn(schedule, leading_dim=0),
+            dyn(tiles, leading_dim=0),
+            self._stream(a_fp8.device),
+        )
+
+    @staticmethod
+    def _sf_arg(sf: torch.Tensor, rows_shape: tuple[int, ...]) -> torch.Tensor:
+        if len(rows_shape) == 3:
+            return sf.view(rows_shape[0], rows_shape[1], -1)
+        return sf.view(rows_shape[0], -1).unsqueeze(0)
+
+    def gateup(self, row_state, out: torch.Tensor) -> None:
+        self._launch(
+            "gemm1",
+            self._input_rows(row_state),
+            row_state.sf_rows,
+            out,
+            row_state,
+            row_state.gemm1_schedule,
+            row_state.gemm1_tiles,
+        )
+
+    def down(self, row_state, act_out: torch.Tensor, out: torch.Tensor) -> None:
+        act_fp8, sf_act = self._down_operands(row_state, act_out)
+        self._launch(
+            "gemm2",
+            act_fp8,
+            sf_act,
+            out,
+            row_state,
+            row_state.gemm2_schedule,
+            row_state.gemm2_tiles,
+        )
+
+
+class CuteDslFp8MaskedRowState(MaskedRowState, kw_only=True):
+    token_width: int
+    sf_rows: torch.Tensor  # [E_local, m_max, hidden // 128] fp32 group scales
+    gemm1_schedule: torch.Tensor
+    gemm1_tiles: torch.Tensor
+    gemm2_schedule: torch.Tensor
+    gemm2_tiles: torch.Tensor
+    # Only materialized activation fills these; fused-B activation stays BF16.
+    act_fp8: torch.Tensor
+    act_scale: torch.Tensor
+    act_quant_ready: bool = False
+
+
+class CuteDslFp8MaskedProvider(_CuteDslFp8Mixin, MaskedRowDomainProvider):
+    contract = MoeBaseProviderContract(
+        key="cutedsl_fp8_masked",
+        quant_info_cls=MoeLoraFp8QuantInfo,
+        gate_first=True,
+        interleaved=False,
+        gate_up_output_dtype=torch.bfloat16,
+        lora_delta_dtype=torch.bfloat16,
+        lora_activation_dtype=torch.bfloat16,
+    )
+
+    _ROW_MODE = "masked"
+
+    def __init__(self, quant_info: MoeLoraFp8QuantInfo):
+        super().__init__(quant_info)
+        from sglang.srt.lora.moe.kernels.cutedsl.api import prepare_masked_fp8
+        from sglang.srt.lora.moe.kernels.cutedsl.schedule_builder import (
+            build_dual_stage_schedules_masked,
+            dual_stage_schedule_capacities_masked,
+        )
+
+        self._prepare_masked_gemm = prepare_masked_fp8
+        self._build_schedules = build_dual_stage_schedules_masked
+        self._schedule_capacities = dual_stage_schedule_capacities_masked
+        self._init_tiles(quant_info)
+
+    def _prepare_dummy(self, stage: str, config):
+        weight, weight_sf = self._stage_weight(stage), self._stage_scale(stage)
+        device = weight.device
+        experts, n, k = weight.shape
+        dummy_a = torch.zeros(
+            (experts, 256, k), dtype=torch.float8_e4m3fn, device=device
+        )
+        dummy_sf = torch.zeros(
+            (experts, 256, k // QUANT_GROUP), dtype=torch.float32, device=device
+        )
+        dummy_c = torch.empty((experts, 256, n), dtype=torch.bfloat16, device=device)
+        dummy_masked = torch.zeros(experts, dtype=torch.int32, device=device)
+        return self._prepare_masked_gemm(
+            dummy_a,
+            weight,
+            dummy_sf,
+            weight_sf,
+            dummy_c,
+            dummy_masked,
+            config=config,
+        )
+
+    @staticmethod
+    def _rows_arg(tensor: torch.Tensor) -> torch.Tensor:
+        return tensor
+
+    @staticmethod
+    def _input_rows(row_state: CuteDslFp8MaskedRowState) -> torch.Tensor:
+        return row_state.hidden_permuted
+
+    @staticmethod
+    def _group_arg(row_state: CuteDslFp8MaskedRowState) -> torch.Tensor:
+        return row_state.masked_m
+
+    def prepare(
+        self,
+        hidden_states: torch.Tensor,
+        topk_ids: torch.Tensor,
+        top_k: int,
+        workspace=None,
+    ) -> CuteDslFp8MaskedRowState:
+        experts = self.quant_info.num_local_experts
+        k = hidden_states.size(1)
+        inter = self.quant_info.intermediate_size
+        m_max = masked_m_max(hidden_states.size(0))
+        device = hidden_states.device
+
+        def _buf(name, shape, dtype):
+            return prepare_buffer(workspace, name, shape, dtype=dtype, device=device)
+
+        masked_m = _buf("masked:masked_m", (experts,), torch.int32)
+        pair_to_row = _buf("masked:pair_to_row", (topk_ids.numel(),), torch.int32)
+        rows_fp8 = _buf("masked:rows_fp8", (experts, m_max, k), torch.float8_e4m3fn)
+        sf_rows = _buf(
+            "masked:sf_rows", (experts, m_max, k // QUANT_GROUP), torch.float32
+        )
+        act_fp8 = _buf("masked:act_fp8", (experts, m_max, inter), torch.float8_e4m3fn)
+        act_scale = _buf(
+            "masked:act_scale", (experts, m_max, inter // QUANT_GROUP), torch.float32
+        )
+        dispatch_fill_masked_fp8(
+            hidden_states,
+            topk_ids,
+            top_k,
+            masked_m_out=masked_m,
+            pair_to_row_out=pair_to_row,
+            rows_fp8_out=rows_fp8,
+            scale_out=sf_rows,
+        )
+        expected_m = expected_rows_per_expert(topk_ids.numel(), experts)
+        token_width = self._token_width_for(m_max, expected_m)
+        geometry = dict(
+            token_width=token_width,
+            n_gemm1=self.gate_up_slices * inter,
+            n_gemm2=self.quant_info.hidden_size,
+            output_width=self.OUTPUT_WIDTH,
+            cluster_shape_mn=self.CLUSTER_SHAPE_MN,
+            use_2cta_instrs=self.USE_2CTA_INSTRS,
+        )
+        schedule_outputs = {}
+        if workspace is not None:
+            schedule_outputs = self._schedule_buffers(
+                workspace,
+                f"cutedsl_masked:tw{token_width}",
+                self._schedule_capacities(num_experts=experts, m_max=m_max, **geometry),
+                device,
+            )
+        schedule1, tiles1, schedule2, tiles2 = self._build_schedules(
+            masked_m, m_max=m_max, **geometry, **schedule_outputs
+        )
+        return CuteDslFp8MaskedRowState(
+            hidden_permuted=rows_fp8,
+            masked_m=masked_m,
+            expected_m=expected_m,
+            pair_to_row=pair_to_row,
+            m_max=m_max,
+            retained_inputs=workspace is not None,
+            token_width=token_width,
+            sf_rows=sf_rows,
+            gemm1_schedule=schedule1,
+            gemm1_tiles=tiles1,
+            gemm2_schedule=schedule2,
+            gemm2_tiles=tiles2,
+            act_fp8=act_fp8,
+            act_scale=act_scale,
+        )
+
+    def act_with_delta(
+        self,
+        row_state: CuteDslFp8MaskedRowState,
+        gateup_out: torch.Tensor,
+        gate_up_delta: torch.Tensor | None,
+        topk_ids: torch.Tensor,
+        act_out: torch.Tensor,
+        activation_lora_input: torch.Tensor,
+        *,
+        activation: str = "silu",
+    ) -> None:
+        self._act_kernel(
+            gateup_out,
+            gate_up_delta,
+            act_out,
+            activation_lora_input,
+            row_state.pair_to_row,
+            topk_ids,
+            gate_first=self.contract.gate_first,
+            interleaved=self.contract.interleaved,
+            activation=activation,
+            act_quant=(row_state.act_fp8, row_state.act_scale, QUANT_GROUP),
+        )
+        row_state.act_quant_ready = True
+
+    @staticmethod
+    def _down_operands(
+        row_state: CuteDslFp8MaskedRowState, act_out: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if row_state.act_quant_ready:
+            return row_state.act_fp8, row_state.act_scale
+        # Fused-B activation needs separate quantization.
+        return sglang_per_token_group_quant_fp8(
+            act_out, QUANT_GROUP, masked_m=row_state.masked_m
+        )
+
+
+class CuteDslFp8ContiguousRowState(ContiguousRowState, kw_only=True):
+    token_width: int
+    sf_rows: torch.Tensor  # [m_pad_ceiling, hidden // 128] fp32 group scales
+    gemm1_schedule: torch.Tensor
+    gemm1_tiles: torch.Tensor
+    gemm2_schedule: torch.Tensor
+    gemm2_tiles: torch.Tensor
+
+
+class CuteDslFp8ContiguousProvider(_CuteDslFp8Mixin, ContiguousRowDomainProvider):
+    contract = MoeBaseProviderContract(
+        key="cutedsl_fp8_contiguous",
+        quant_info_cls=MoeLoraFp8QuantInfo,
+        gate_first=True,
+        interleaved=False,
+        gate_up_output_dtype=torch.bfloat16,
+        lora_delta_dtype=torch.bfloat16,
+        lora_activation_dtype=torch.bfloat16,
+    )
+
+    M_ALIGNMENT = 128
+
+    _ROW_MODE = "contiguous"
+
+    def __init__(self, quant_info: MoeLoraFp8QuantInfo):
+        super().__init__(quant_info, m_alignment=self.M_ALIGNMENT)
+        from sglang.srt.lora.moe.kernels.cutedsl.api import prepare_contiguous_fp8
+        from sglang.srt.lora.moe.kernels.cutedsl.schedule_builder import (
+            build_dual_stage_schedules_contiguous,
+            dual_stage_schedule_capacities_contiguous,
+            validate_tile_geometry_contiguous,
+        )
+
+        self._prepare_contiguous_gemm = prepare_contiguous_fp8
+        self._validate_tile_geometry = validate_tile_geometry_contiguous
+        self._build_schedules_contiguous = build_dual_stage_schedules_contiguous
+        self._schedule_capacities = dual_stage_schedule_capacities_contiguous
+        self._init_tiles(quant_info)
+
+    def _admit_tile_width(self, token_width: int) -> None:
+        self._validate_tile_geometry(token_width, self._m_alignment)
+
+    def _prepare_dummy(self, stage: str, config):
+        weight, weight_sf = self._stage_weight(stage), self._stage_scale(stage)
+        device = weight.device
+        num_experts, n, k = weight.shape
+        dummy_a = torch.zeros((256, k), dtype=torch.float8_e4m3fn, device=device)
+        dummy_sf = torch.zeros(
+            (1, 256, k // QUANT_GROUP), dtype=torch.float32, device=device
+        )
+        dummy_c = torch.empty((256, n), dtype=torch.bfloat16, device=device)
+        dummy_seg = torch.zeros(num_experts + 1, dtype=torch.int32, device=device)
+        return self._prepare_contiguous_gemm(
+            dummy_a,
+            weight,
+            dummy_sf,
+            weight_sf,
+            dummy_c,
+            dummy_seg,
+            config=config,
+        )
+
+    @staticmethod
+    def _rows_arg(tensor: torch.Tensor) -> torch.Tensor:
+        # Flat rows occupy one expert slot in the swap_ab wrapper.
+        return tensor.unsqueeze(0)
+
+    @staticmethod
+    def _input_rows(row_state: CuteDslFp8ContiguousRowState) -> torch.Tensor:
+        return row_state.hidden_compact
+
+    @staticmethod
+    def _group_arg(row_state: CuteDslFp8ContiguousRowState) -> torch.Tensor:
+        return row_state.seg_offsets
+
+    def prepare(
+        self,
+        hidden_states: torch.Tensor,
+        topk_ids: torch.Tensor,
+        top_k: int,
+        workspace=None,
+    ) -> CuteDslFp8ContiguousRowState:
+        base = super().prepare(
+            hidden_states, topk_ids, top_k, workspace, fill_rows=False
+        )
+        num_experts = self.quant_info.num_local_experts
+        hidden = hidden_states.size(1)
+        device = hidden_states.device
+        prefix = f"contiguous:a{self._m_alignment}"
+        rows_fp8 = prepare_buffer(
+            workspace,
+            f"{prefix}:rows_fp8",
+            (base.m_pad_ceiling, hidden),
+            dtype=torch.float8_e4m3fn,
+            device=device,
+        )
+        sf_rows = prepare_buffer(
+            workspace,
+            f"{prefix}:sf_rows",
+            (base.m_pad_ceiling, hidden // QUANT_GROUP),
+            dtype=torch.float32,
+            device=device,
+        )
+        dispatch_fill_rows_contiguous_fp8(
+            hidden_states,
+            topk_ids,
+            base.pair_to_row,
+            rows_fp8_out=rows_fp8,
+            scale_out=sf_rows,
+        )
+        # Distinct top-k experts bound each expert to one row per token.
+        max_expert_rows = max(int(hidden_states.size(0)), 1)
+        expected_m = expected_rows_per_expert(topk_ids.numel(), num_experts)
+        token_width = self._token_width_for(max_expert_rows, expected_m)
+        geometry = dict(
+            m_pad_ceiling=base.m_pad_ceiling,
+            max_expert_rows=max_expert_rows,
+            m_alignment=self._m_alignment,
+            token_width=token_width,
+            n_gemm1=self.gate_up_slices * self.quant_info.intermediate_size,
+            n_gemm2=self.quant_info.hidden_size,
+            output_width=self.OUTPUT_WIDTH,
+            cluster_shape_mn=self.CLUSTER_SHAPE_MN,
+            use_2cta_instrs=self.USE_2CTA_INSTRS,
+        )
+        schedule_outputs = {}
+        if workspace is not None:
+            schedule_outputs = self._schedule_buffers(
+                workspace,
+                f"cutedsl_contiguous:a{self._m_alignment}:tw{token_width}",
+                self._schedule_capacities(num_experts=num_experts, **geometry),
+                device,
+            )
+        schedule1, tiles1, schedule2, tiles2 = self._build_schedules_contiguous(
+            base.seg_counts, **geometry, **schedule_outputs
+        )
+        return CuteDslFp8ContiguousRowState(
+            hidden_compact=rows_fp8,
+            seg_counts=base.seg_counts,
+            seg_offsets=base.seg_offsets,
+            pair_to_row=base.pair_to_row,
+            m_pad_ceiling=base.m_pad_ceiling,
+            retained_inputs=base.retained_inputs,
+            token_width=token_width,
+            sf_rows=sf_rows,
+            gemm1_schedule=schedule1,
+            gemm1_tiles=tiles1,
+            gemm2_schedule=schedule2,
+            gemm2_tiles=tiles2,
+        )
+
+    @staticmethod
+    def _down_operands(
+        row_state: CuteDslFp8ContiguousRowState, act_out: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return sglang_per_token_group_quant_fp8(act_out, QUANT_GROUP)

--- a/python/sglang/srt/lora/moe/base_gemm_provider/gemm_config_store.py
+++ b/python/sglang/srt/lora/moe/base_gemm_provider/gemm_config_store.py
@@ -1,0 +1,132 @@
+"""GEMM configs keyed by provider, geometry, device, and nearest expected M."""
+
+from __future__ import annotations
+
+import functools
+import logging
+import os
+from collections.abc import Mapping
+
+import msgspec
+
+from sglang.srt.environ import envs
+
+logger = logging.getLogger(__name__)
+
+_PACKAGE_CONFIG_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "configs"
+)
+
+
+class GemmTile(msgspec.Struct, frozen=True, kw_only=True):
+    token_width: int
+    persistent_clusters: int
+
+
+class GemmConfigTable(msgspec.Struct, kw_only=True):
+    buckets: dict[int, dict[str, int]]
+    tiles: tuple[GemmTile, ...] = ()
+    version: dict[str, str] = {}
+
+    def pick(self, expected_m: int) -> dict[str, int]:
+        return self.buckets[min(self.buckets, key=lambda m: abs(m - expected_m))]
+
+
+def _validate(table: GemmConfigTable) -> None:
+    if not table.buckets:
+        raise ValueError("buckets must be non-empty")
+    for bucket_m, payload in table.buckets.items():
+        if bucket_m <= 0:
+            raise ValueError(f"bucket key {bucket_m} must be positive")
+        if not payload or any(value <= 0 for value in payload.values()):
+            raise ValueError(f"bucket {bucket_m} payload must be positive ints")
+    widths = [tile.token_width for tile in table.tiles]
+    if len(set(widths)) != len(widths):
+        raise ValueError("tiles must declare one persistent_clusters per token_width")
+    for tile in table.tiles:
+        if tile.token_width <= 0 or tile.persistent_clusters <= 0:
+            raise ValueError("tile fields must be positive")
+
+
+def config_file_name(
+    provider_key: str,
+    *,
+    num_local_experts: int,
+    n_gemm1: int,
+    n_gemm2: int,
+    k: int,
+    device_name: str,
+) -> str:
+    device = device_name.replace(" ", "_")
+    return (
+        f"provider={provider_key},E={num_local_experts},N1={n_gemm1},"
+        f"N2={n_gemm2},K={k},device_name={device}.json"
+    )
+
+
+@functools.lru_cache(maxsize=None)
+def _load(
+    path: str, expected_versions: tuple[tuple[str, str], ...]
+) -> GemmConfigTable | None:
+    if not os.path.exists(path):
+        return None
+    try:
+        with open(path, "rb") as f:
+            table = msgspec.json.decode(f.read(), type=GemmConfigTable)
+        _validate(table)
+    except (msgspec.DecodeError, ValueError) as exc:
+        logger.warning("Ignoring malformed MoE LoRA GEMM config %s: %s", path, exc)
+        return None
+    for name, expected in expected_versions:
+        recorded = table.version.get(name)
+        if recorded is not None and recorded != expected:
+            logger.warning(
+                "Ignoring MoE LoRA GEMM config %s: %s version %s does not "
+                "match installed %s",
+                path,
+                name,
+                recorded,
+                expected,
+            )
+            return None
+    logger.info("Using MoE LoRA GEMM config from %s.", path)
+    return table
+
+
+def load_config_table(
+    provider_key: str,
+    *,
+    num_local_experts: int,
+    n_gemm1: int,
+    n_gemm2: int,
+    k: int,
+    device_name: str | None = None,
+    expected_versions: Mapping[str, str] | None = None,
+) -> GemmConfigTable | None:
+    if device_name is None:
+        from sglang.srt.utils import get_device_name
+
+        device_name = get_device_name()
+    name = config_file_name(
+        provider_key,
+        num_local_experts=num_local_experts,
+        n_gemm1=n_gemm1,
+        n_gemm2=n_gemm2,
+        k=k,
+        device_name=device_name,
+    )
+    versions = tuple(sorted((expected_versions or {}).items()))
+    roots = (envs.SGLANG_LORA_MOE_CONFIG_DIR.get(), _PACKAGE_CONFIG_DIR)
+    for root in filter(None, roots):
+        path = os.path.join(root, "base_gemm", name)
+        if os.path.isfile(path):
+            return _load(path, versions)
+    return None
+
+
+def cutedsl_version() -> str | None:
+    try:
+        import cutlass
+    except ImportError:
+        return None
+    return getattr(cutlass, "__version__", None)

--- a/python/sglang/srt/lora/moe/base_gemm_provider/marlin_nvfp4.py
+++ b/python/sglang/srt/lora/moe/base_gemm_provider/marlin_nvfp4.py
@@ -1,0 +1,197 @@
+"""Marlin W4A16 GEMMs with BF16 activations in raw pair order."""
+
+from __future__ import annotations
+
+import msgspec
+import torch
+
+from sglang.srt.lora.moe.base_gemm_provider.base import MoeBaseProviderContract
+from sglang.srt.lora.moe.base_gemm_provider.contiguous_row_domain import (
+    ContiguousRowDomainProvider,
+)
+from sglang.srt.lora.moe.quant_info import MoeLoraNvFp4MarlinQuantInfo
+
+
+class MarlinNvFp4RowState(msgspec.Struct, kw_only=True):
+    hidden_states: torch.Tensor  # [num_tokens, hidden] bf16, borrowed
+    topk_ids: torch.Tensor  # [num_tokens, top_k] borrowed
+    sorted_token_ids: torch.Tensor
+    expert_ids: torch.Tensor
+    num_tokens_post_padded: torch.Tensor
+    # Per-forward locks prevent aliasing across CUDA graph pools.
+    lock_workspace: torch.Tensor
+    pair_to_row: torch.Tensor  # [num_pairs] int32 identity
+    num_pairs: int
+    num_tokens: int
+    top_k: int
+    block_size_m: int
+
+
+class MarlinNvFp4ContiguousProvider(ContiguousRowDomainProvider):
+    contract = MoeBaseProviderContract(
+        key="marlin_nvfp4_contiguous",
+        quant_info_cls=MoeLoraNvFp4MarlinQuantInfo,
+        gate_first=True,
+        interleaved=False,
+        gate_up_output_dtype=torch.bfloat16,
+        lora_delta_dtype=torch.bfloat16,
+        lora_activation_dtype=torch.bfloat16,
+    )
+
+    def __init__(self, quant_info: MoeLoraNvFp4MarlinQuantInfo):
+        # Packed weights use explicit logical sizes instead of shape admission.
+        self.quant_info = quant_info
+        self._m_alignment = 1
+        self._gate_up_slices = 2
+        from sglang.srt.layers.moe.fused_moe_triton.fused_marlin_moe import (
+            get_scalar_type,
+        )
+
+        self._scalar_type_w13 = get_scalar_type(
+            4, False, quant_info.w13_scales, quant_info.w13_global_scale
+        )
+        self._scalar_type_w2 = get_scalar_type(
+            4, False, quant_info.w2_scales, quant_info.w2_global_scale
+        )
+        # Finalize owns the router weight; the kernel only checks the stride.
+        self._unused_topk_weights = torch.zeros(
+            (1, 1), dtype=torch.float32, device=quant_info.w13_qweight.device
+        )
+
+    def prepare(
+        self,
+        hidden_states: torch.Tensor,
+        topk_ids: torch.Tensor,
+        top_k: int,
+        workspace=None,
+    ) -> MarlinNvFp4RowState:
+        from sglang.srt.layers.quantization.marlin_utils import marlin_make_workspace
+        from sglang.srt.lora.moe.kernels.align_rows import align_rows
+
+        num_tokens = hidden_states.shape[0]
+        num_experts = self.quant_info.num_local_experts
+        # fused_marlin_moe's M block size rule.
+        for block_size_m in (8, 16, 32, 48, 64):
+            if num_tokens * top_k / num_experts / block_size_m < 0.9:
+                break
+        sorted_token_ids, expert_ids, num_tokens_post_padded = align_rows(
+            topk_ids, block_size_m, num_experts
+        )
+        num_pairs = topk_ids.numel()
+        device = hidden_states.device
+        if workspace is not None:
+            # Reuse the identity map to avoid an arange launch per layer.
+            pair_to_row = workspace.iota(num_pairs, device)
+        else:
+            pair_to_row = torch.arange(num_pairs, dtype=torch.int32, device=device)
+        return MarlinNvFp4RowState(
+            hidden_states=hidden_states,
+            topk_ids=topk_ids,
+            sorted_token_ids=sorted_token_ids,
+            expert_ids=expert_ids,
+            num_tokens_post_padded=num_tokens_post_padded,
+            lock_workspace=marlin_make_workspace(device, max_blocks_per_sm=4),
+            pair_to_row=pair_to_row,
+            num_pairs=num_pairs,
+            num_tokens=num_tokens,
+            top_k=top_k,
+            block_size_m=block_size_m,
+        )
+
+    def release_prepared_inputs(self, row_state: MarlinNvFp4RowState) -> None:
+        pass
+
+    def _invoke(
+        self,
+        a: torch.Tensor,
+        out: torch.Tensor,
+        row_state: MarlinNvFp4RowState,
+        *,
+        qweight: torch.Tensor,
+        scales: torch.Tensor,
+        global_scale: torch.Tensor,
+        scalar_type,
+        top_k: int,
+        size_m: int,
+        size_n: int,
+        size_k: int,
+    ) -> None:
+        from sglang.kernels.ops.moe.moe_wna16_marlin import moe_wna16_marlin_gemm
+
+        moe_wna16_marlin_gemm(
+            a,
+            out,
+            qweight,
+            None,
+            scales,
+            global_scale,
+            None,
+            None,
+            None,
+            row_state.lock_workspace,
+            row_state.sorted_token_ids,
+            row_state.expert_ids,
+            row_state.num_tokens_post_padded,
+            self._unused_topk_weights,
+            moe_block_size=row_state.block_size_m,
+            top_k=top_k,
+            mul_topk_weights=False,
+            is_ep=False,
+            b_q_type=scalar_type,
+            size_m=size_m,
+            size_n=size_n,
+            size_k=size_k,
+            is_k_full=True,  # NVFP4 has no GPTQ act-order; K is never permuted
+            use_atomic_add=True,
+            use_fp32_reduce=True,
+            is_zp_float=False,
+        )
+
+    def gateup(self, row_state: MarlinNvFp4RowState, out: torch.Tensor) -> None:
+        qi = self.quant_info
+        self._invoke(
+            row_state.hidden_states,
+            out,
+            row_state,
+            qweight=qi.w13_qweight,
+            scales=qi.w13_scales,
+            global_scale=qi.w13_global_scale,
+            scalar_type=self._scalar_type_w13,
+            top_k=row_state.top_k,
+            size_m=row_state.num_tokens,
+            size_n=self._gate_up_slices * qi.intermediate_size,
+            size_k=qi.hidden_size,
+        )
+
+    def down(
+        self,
+        row_state: MarlinNvFp4RowState,
+        act_out: torch.Tensor,
+        out: torch.Tensor,
+    ) -> None:
+        qi = self.quant_info
+        self._invoke(
+            act_out,
+            out,
+            row_state,
+            qweight=qi.w2_qweight,
+            scales=qi.w2_scales,
+            global_scale=qi.w2_global_scale,
+            scalar_type=self._scalar_type_w2,
+            top_k=1,
+            size_m=row_state.num_pairs,
+            size_n=qi.hidden_size,
+            size_k=qi.intermediate_size,
+        )
+
+    def gateup_out_shape(self, row_state: MarlinNvFp4RowState) -> tuple[int, ...]:
+        return (
+            row_state.num_pairs,
+            self._gate_up_slices * self.quant_info.intermediate_size,
+        )
+
+    def act_out_shape(self, row_state: MarlinNvFp4RowState) -> tuple[int, ...]:
+        return (row_state.num_pairs, self.quant_info.intermediate_size)
+
+    def down_out_shape(self, row_state: MarlinNvFp4RowState) -> tuple[int, ...]:
+        return (row_state.num_pairs, self.quant_info.hidden_size)

--- a/python/sglang/srt/lora/moe/base_gemm_provider/masked_row_domain.py
+++ b/python/sglang/srt/lora/moe/base_gemm_provider/masked_row_domain.py
@@ -1,0 +1,196 @@
+"""Expert slabs [E_local, m_max, ...] with valid counts and pair mappings."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING
+
+import msgspec
+import torch
+
+from sglang.srt.lora.moe.base_gemm_provider.base import (
+    MoeBaseProvider,
+    admit_bf16_weights,
+    expected_rows_per_expert,
+    prepare_buffer,
+)
+from sglang.srt.lora.moe.quant_info import MoeLoraBf16QuantInfo
+
+if TYPE_CHECKING:
+    from sglang.srt.lora.moe.route_view import RouteView
+    from sglang.srt.lora.moe.workspace import MoeLoraWorkspace
+
+
+def masked_m_max(num_tokens: int) -> int:
+    """Use the same slab bound as the upstream masked preprocess."""
+    return (num_tokens // 256 + 1) * 256
+
+
+class MaskedRowState(msgspec.Struct, kw_only=True):
+    """``pair_to_row[t * top_k + k]`` is ``expert * m_max + offset``; a pair is
+    valid only when ``topk_ids[t, k] >= 0``.
+    """
+
+    hidden_permuted: torch.Tensor  # [E_local, m_max, hidden], the GEMM input dtype
+    masked_m: torch.Tensor  # [E_local] int32
+    expected_m: int
+    pair_to_row: torch.Tensor  # [num_tokens * top_k] int32
+    m_max: int
+    retained_inputs: bool
+
+
+class MaskedRowDomainProvider(MoeBaseProvider):
+    def __init__(self, quant_info: MoeLoraBf16QuantInfo):
+        self.quant_info = quant_info
+        self._gate_up_slices = admit_bf16_weights(quant_info)
+
+        from sglang.srt.lora.moe.kernels.activation_delta import (
+            act_delta_masked,
+        )
+        from sglang.srt.lora.moe.kernels.dispatch_masked import (
+            dispatch_fill_masked_bf16,
+        )
+
+        self._preprocess = dispatch_fill_masked_bf16
+        self._act_kernel = act_delta_masked
+
+        from sglang.srt.lora.moe.kernels.fused_act import (
+            fused_b_act_masked,
+        )
+
+        self._fused_act = fused_b_act_masked
+
+    def prepare(
+        self,
+        hidden_states: torch.Tensor,
+        topk_ids: torch.Tensor,
+        top_k: int,
+        workspace: MoeLoraWorkspace | None = None,
+    ) -> MaskedRowState:
+        num_experts = self.quant_info.num_local_experts
+        num_pairs = topk_ids.numel()
+        m_max = masked_m_max(hidden_states.size(0))
+        device = hidden_states.device
+        masked_m = prepare_buffer(
+            workspace,
+            "masked:masked_m",
+            (num_experts,),
+            dtype=torch.int32,
+            device=device,
+        )
+        pair_to_row = prepare_buffer(
+            workspace,
+            "masked:pair_to_row",
+            (num_pairs,),
+            dtype=torch.int32,
+            device=device,
+        )
+        hidden_permuted = prepare_buffer(
+            workspace,
+            "masked:hidden_permuted",
+            (num_experts, m_max, hidden_states.size(1)),
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        self._preprocess(
+            hidden_states,
+            topk_ids,
+            top_k,
+            masked_m_out=masked_m,
+            pair_to_row_out=pair_to_row,
+            rows_out=hidden_permuted,
+        )
+        return MaskedRowState(
+            hidden_permuted=hidden_permuted,
+            masked_m=masked_m,
+            expected_m=expected_rows_per_expert(num_pairs, num_experts),
+            pair_to_row=pair_to_row,
+            m_max=m_max,
+            retained_inputs=workspace is not None,
+        )
+
+    def release_prepared_inputs(self, row_state: MaskedRowState) -> None:
+        # Workspace buffers retain their addresses for graph replay.
+        if row_state.retained_inputs:
+            return
+        from sglang.srt.utils import dispose_tensor
+
+        dispose_tensor(row_state.hidden_permuted)
+
+    def act_with_delta(
+        self,
+        row_state: MaskedRowState,
+        gateup_out: torch.Tensor,
+        gate_up_delta: torch.Tensor | None,
+        topk_ids: torch.Tensor,
+        act_out: torch.Tensor,
+        activation_lora_input: torch.Tensor,
+        *,
+        activation: str = "silu",
+        consume_base_pdl: bool = False,
+    ) -> None:
+        self._act_kernel(
+            gateup_out,
+            gate_up_delta,
+            act_out,
+            activation_lora_input,
+            row_state.pair_to_row,
+            topk_ids,
+            gate_first=self.contract.gate_first,
+            interleaved=self.contract.interleaved,
+            activation=activation,
+            consume_base_pdl=consume_base_pdl,
+        )
+
+    def fused_act(
+        self,
+        row_state: MaskedRowState,
+        *,
+        activation: str,
+        base_gateup: torch.Tensor,
+        act_rows: torch.Tensor,
+        act_pairs: torch.Tensor | None,
+        routing: RouteView,
+        config: Mapping[str, int],
+        bridge_gateup: torch.Tensor | None = None,
+        b_gate_up: torch.Tensor | None = None,
+        bridge_top_k: int = 1,
+        consume_base_pdl: bool = False,
+    ) -> None:
+        self._fused_act(
+            activation=activation,
+            base_gateup=base_gateup,
+            act_masked=act_rows,
+            act_pairs=act_pairs,
+            pair_to_row=row_state.pair_to_row,
+            routing=routing,
+            num_local_experts=self.num_local_experts,
+            gate_first=self.contract.gate_first,
+            interleaved=self.contract.interleaved,
+            config=config,
+            bridge_gateup=bridge_gateup,
+            b_gate_up=b_gate_up,
+            bridge_top_k=bridge_top_k,
+            consume_base_pdl=consume_base_pdl,
+        )
+
+    def gateup_out_shape(self, row_state: MaskedRowState) -> tuple[int, ...]:
+        return (
+            self.quant_info.num_local_experts,
+            row_state.m_max,
+            self.gate_up_slices * self.quant_info.intermediate_size,
+        )
+
+    def act_out_shape(self, row_state: MaskedRowState) -> tuple[int, ...]:
+        return (
+            self.quant_info.num_local_experts,
+            row_state.m_max,
+            self.quant_info.intermediate_size,
+        )
+
+    def down_out_shape(self, row_state: MaskedRowState) -> tuple[int, ...]:
+        return (
+            self.quant_info.num_local_experts,
+            row_state.m_max,
+            self.quant_info.hidden_size,
+        )

--- a/python/sglang/srt/lora/moe/base_gemm_provider/masked_row_domain.py
+++ b/python/sglang/srt/lora/moe/base_gemm_provider/masked_row_domain.py
@@ -10,11 +10,11 @@ import torch
 
 from sglang.srt.lora.moe.base_gemm_provider.base import (
     MoeBaseProvider,
-    admit_bf16_weights,
+    admit_weight_layout,
     expected_rows_per_expert,
     prepare_buffer,
 )
-from sglang.srt.lora.moe.quant_info import MoeLoraBf16QuantInfo
+from sglang.srt.lora.moe.quant_info import StandardLayoutQuantInfo
 
 if TYPE_CHECKING:
     from sglang.srt.lora.moe.route_view import RouteView
@@ -40,9 +40,9 @@ class MaskedRowState(msgspec.Struct, kw_only=True):
 
 
 class MaskedRowDomainProvider(MoeBaseProvider):
-    def __init__(self, quant_info: MoeLoraBf16QuantInfo):
+    def __init__(self, quant_info: StandardLayoutQuantInfo):
         self.quant_info = quant_info
-        self._gate_up_slices = admit_bf16_weights(quant_info)
+        self._gate_up_slices = admit_weight_layout(quant_info)
 
         from sglang.srt.lora.moe.kernels.activation_delta import (
             act_delta_masked,
@@ -127,7 +127,6 @@ class MaskedRowDomainProvider(MoeBaseProvider):
         activation_lora_input: torch.Tensor,
         *,
         activation: str = "silu",
-        consume_base_pdl: bool = False,
     ) -> None:
         self._act_kernel(
             gateup_out,
@@ -139,7 +138,6 @@ class MaskedRowDomainProvider(MoeBaseProvider):
             gate_first=self.contract.gate_first,
             interleaved=self.contract.interleaved,
             activation=activation,
-            consume_base_pdl=consume_base_pdl,
         )
 
     def fused_act(
@@ -155,7 +153,6 @@ class MaskedRowDomainProvider(MoeBaseProvider):
         bridge_gateup: torch.Tensor | None = None,
         b_gate_up: torch.Tensor | None = None,
         bridge_top_k: int = 1,
-        consume_base_pdl: bool = False,
     ) -> None:
         self._fused_act(
             activation=activation,
@@ -171,7 +168,6 @@ class MaskedRowDomainProvider(MoeBaseProvider):
             bridge_gateup=bridge_gateup,
             b_gate_up=b_gate_up,
             bridge_top_k=bridge_top_k,
-            consume_base_pdl=consume_base_pdl,
         )
 
     def gateup_out_shape(self, row_state: MaskedRowState) -> tuple[int, ...]:

--- a/python/sglang/srt/lora/moe/base_gemm_provider/triton_bf16.py
+++ b/python/sglang/srt/lora/moe/base_gemm_provider/triton_bf16.py
@@ -1,0 +1,187 @@
+"""Triton GEMMs gather sorted token IDs and scatter into raw pair order."""
+
+from __future__ import annotations
+
+import msgspec
+import torch
+
+from sglang.srt.lora.moe.base_gemm_provider.base import MoeBaseProviderContract
+from sglang.srt.lora.moe.base_gemm_provider.contiguous_row_domain import (
+    ContiguousRowDomainProvider,
+)
+from sglang.srt.lora.moe.quant_info import MoeLoraBf16QuantInfo
+
+
+class TritonRowState(msgspec.Struct, kw_only=True):
+    hidden_states: torch.Tensor  # [num_tokens, hidden] bf16, borrowed
+    topk_ids: torch.Tensor  # [num_tokens, top_k] borrowed
+    sorted_token_ids: torch.Tensor  # [em_ceiling] int32 route ids, pad = numel
+    expert_ids: torch.Tensor  # [em_ceiling / block_m] int32 per-block expert
+    num_tokens_post_padded: torch.Tensor  # [1] int32 device scalar
+    pair_to_row: torch.Tensor  # [num_pairs] int32 identity
+    num_pairs: int
+    top_k: int
+    config: dict
+    down_config: dict | None
+
+
+class TritonBf16ContiguousProvider(ContiguousRowDomainProvider):
+    contract = MoeBaseProviderContract(
+        key="triton_bf16_contiguous",
+        gate_first=True,
+        interleaved=False,
+        gate_up_output_dtype=torch.bfloat16,
+        lora_delta_dtype=torch.bfloat16,
+        lora_activation_dtype=torch.bfloat16,
+    )
+
+    def __init__(self, quant_info: MoeLoraBf16QuantInfo):
+        # prepare() replaces parent compaction with the tuned BLOCK_SIZE_M.
+        super().__init__(quant_info, m_alignment=1)
+        # Finalize applies router weights; the launcher only checks this stride.
+        self._unused_topk_weights = torch.zeros(
+            (1, 1), dtype=torch.float32, device=quant_info.w2_weight.device
+        )
+        self._configs: dict[int, tuple[dict, dict | None]] = {}
+
+    def _config_for(self, num_tokens: int, top_k: int) -> tuple[dict, dict | None]:
+        cached = self._configs.get(num_tokens)
+        if cached is not None:
+            return cached
+        from sglang.srt.layers.moe.moe_runner.triton_utils.fused_moe_triton_config import (
+            try_get_optimal_moe_config,
+        )
+
+        config, (down_config, _max_block_m) = try_get_optimal_moe_config(
+            tuple(self.quant_info.w13_weight.shape),
+            tuple(self.quant_info.w2_weight.shape),
+            top_k,
+            None,  # bf16 configs carry no dtype suffix
+            num_tokens,
+            return_down_config=True,
+        )
+        # Both GEMMs share a sort; upstream makes their BLOCK_SIZE_M equal.
+        resolved = (dict(config), dict(down_config) if down_config else None)
+        self._configs[num_tokens] = resolved
+        return resolved
+
+    def prepare(
+        self,
+        hidden_states: torch.Tensor,
+        topk_ids: torch.Tensor,
+        top_k: int,
+        workspace=None,
+    ) -> TritonRowState:
+        from sglang.srt.layers.moe.moe_runner.triton_utils.moe_align_block_size import (
+            moe_align_block_size,
+        )
+
+        config, down_config = self._config_for(hidden_states.shape[0], top_k)
+        sorted_token_ids, expert_ids, num_tokens_post_padded = moe_align_block_size(
+            topk_ids,
+            int(config["BLOCK_SIZE_M"]),
+            self.quant_info.num_local_experts,
+            ignore_invalid_expert=True,
+        )
+        num_pairs = topk_ids.numel()
+        device = hidden_states.device
+        if workspace is not None:
+            pair_to_row = workspace.tensor(
+                "triton:pair_to_row", (num_pairs,), dtype=torch.int32, device=device
+            )
+        else:
+            pair_to_row = torch.empty(num_pairs, dtype=torch.int32, device=device)
+        torch.arange(num_pairs, dtype=torch.int32, device=device, out=pair_to_row)
+        return TritonRowState(
+            hidden_states=hidden_states,
+            topk_ids=topk_ids,
+            sorted_token_ids=sorted_token_ids,
+            expert_ids=expert_ids,
+            num_tokens_post_padded=num_tokens_post_padded,
+            pair_to_row=pair_to_row,
+            num_pairs=num_pairs,
+            top_k=top_k,
+            config=config,
+            down_config=down_config,
+        )
+
+    def release_prepared_inputs(self, row_state: TritonRowState) -> None:
+        pass
+
+    def _invoke(
+        self,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        out: torch.Tensor,
+        row_state: TritonRowState,
+        *,
+        top_k: int,
+        config: dict,
+    ) -> None:
+        import triton.language as tl
+
+        from sglang.kernels.ops.moe.fused_moe_triton_kernels import (
+            invoke_fused_moe_kernel,
+        )
+
+        invoke_fused_moe_kernel(
+            a,
+            b,
+            None,
+            out,
+            None,
+            None,
+            None,
+            self._unused_topk_weights,
+            row_state.topk_ids,
+            row_state.sorted_token_ids,
+            row_state.expert_ids,
+            row_state.num_tokens_post_padded,
+            False,
+            top_k,
+            config,
+            compute_type=tl.bfloat16,
+            use_fp8_w8a8=False,
+            use_int8_w8a8=False,
+            use_int8_w8a16=False,
+            use_int4_w4a16=False,
+            per_channel_quant=False,
+        )
+
+    def gateup(self, row_state: TritonRowState, out: torch.Tensor) -> None:
+        # GEMM1 gathers token row pair_id // top_k.
+        self._invoke(
+            row_state.hidden_states,
+            self.quant_info.w13_weight,
+            out,
+            row_state,
+            top_k=row_state.top_k,
+            config=row_state.config,
+        )
+
+    def down(
+        self,
+        row_state: TritonRowState,
+        act_out: torch.Tensor,
+        out: torch.Tensor,
+    ) -> None:
+        self._invoke(
+            act_out,
+            self.quant_info.w2_weight,
+            out,
+            row_state,
+            top_k=1,
+            config=row_state.down_config or row_state.config,
+        )
+
+    def gateup_out_shape(self, row_state: TritonRowState) -> tuple[int, ...]:
+        return (
+            row_state.num_pairs,
+            self.gate_up_slices * self.quant_info.intermediate_size,
+        )
+
+    def act_out_shape(self, row_state: TritonRowState) -> tuple[int, ...]:
+        return (row_state.num_pairs, self.quant_info.intermediate_size)
+
+    def down_out_shape(self, row_state: TritonRowState) -> tuple[int, ...]:
+        return (row_state.num_pairs, self.quant_info.hidden_size)

--- a/python/sglang/srt/lora/moe/base_gemm_provider/triton_bf16.py
+++ b/python/sglang/srt/lora/moe/base_gemm_provider/triton_bf16.py
@@ -23,11 +23,14 @@ class TritonRowState(msgspec.Struct, kw_only=True):
     top_k: int
     config: dict
     down_config: dict | None
+    # Quantized activation and scales for the down GEMM.
+    act_quant: tuple[torch.Tensor, torch.Tensor] | None = None
 
 
 class TritonBf16ContiguousProvider(ContiguousRowDomainProvider):
     contract = MoeBaseProviderContract(
         key="triton_bf16_contiguous",
+        quant_info_cls=MoeLoraBf16QuantInfo,
         gate_first=True,
         interleaved=False,
         gate_up_output_dtype=torch.bfloat16,
@@ -44,6 +47,9 @@ class TritonBf16ContiguousProvider(ContiguousRowDomainProvider):
         )
         self._configs: dict[int, tuple[dict, dict | None]] = {}
 
+    _config_dtype_tag: str | None = None
+    _config_block_shape: list[int] | None = None
+
     def _config_for(self, num_tokens: int, top_k: int) -> tuple[dict, dict | None]:
         cached = self._configs.get(num_tokens)
         if cached is not None:
@@ -56,12 +62,17 @@ class TritonBf16ContiguousProvider(ContiguousRowDomainProvider):
             tuple(self.quant_info.w13_weight.shape),
             tuple(self.quant_info.w2_weight.shape),
             top_k,
-            None,  # bf16 configs carry no dtype suffix
+            self._config_dtype_tag,
             num_tokens,
             return_down_config=True,
+            block_shape=self._config_block_shape,
         )
         # Both GEMMs share a sort; upstream makes their BLOCK_SIZE_M equal.
         resolved = (dict(config), dict(down_config) if down_config else None)
+        # Classic Triton kernels do not accept the TMA launcher's flag.
+        resolved[0].pop("USE_TMA", None)
+        if resolved[1]:
+            resolved[1].pop("USE_TMA", None)
         self._configs[num_tokens] = resolved
         return resolved
 
@@ -72,26 +83,19 @@ class TritonBf16ContiguousProvider(ContiguousRowDomainProvider):
         top_k: int,
         workspace=None,
     ) -> TritonRowState:
-        from sglang.srt.layers.moe.moe_runner.triton_utils.moe_align_block_size import (
-            moe_align_block_size,
-        )
+        from sglang.srt.lora.moe.kernels.align_rows import align_rows
 
         config, down_config = self._config_for(hidden_states.shape[0], top_k)
-        sorted_token_ids, expert_ids, num_tokens_post_padded = moe_align_block_size(
-            topk_ids,
-            int(config["BLOCK_SIZE_M"]),
-            self.quant_info.num_local_experts,
-            ignore_invalid_expert=True,
+        sorted_token_ids, expert_ids, num_tokens_post_padded = align_rows(
+            topk_ids, int(config["BLOCK_SIZE_M"]), self.quant_info.num_local_experts
         )
         num_pairs = topk_ids.numel()
         device = hidden_states.device
         if workspace is not None:
-            pair_to_row = workspace.tensor(
-                "triton:pair_to_row", (num_pairs,), dtype=torch.int32, device=device
-            )
+            # Reuse the identity map to avoid an arange launch per layer.
+            pair_to_row = workspace.iota(num_pairs, device)
         else:
-            pair_to_row = torch.empty(num_pairs, dtype=torch.int32, device=device)
-        torch.arange(num_pairs, dtype=torch.int32, device=device, out=pair_to_row)
+            pair_to_row = torch.arange(num_pairs, dtype=torch.int32, device=device)
         return TritonRowState(
             hidden_states=hidden_states,
             topk_ids=topk_ids,

--- a/python/sglang/srt/lora/moe/base_gemm_provider/triton_fp8.py
+++ b/python/sglang/srt/lora/moe/base_gemm_provider/triton_fp8.py
@@ -1,0 +1,106 @@
+"""Triton FP8 GEMMs with 128-block scales and BF16 LoRA inputs/outputs."""
+
+from __future__ import annotations
+
+import torch
+
+from sglang.srt.lora.moe.base_gemm_provider.base import MoeBaseProviderContract
+from sglang.srt.lora.moe.base_gemm_provider.triton_bf16 import (
+    TritonBf16ContiguousProvider,
+    TritonRowState,
+)
+from sglang.srt.lora.moe.quant_info import MoeLoraFp8QuantInfo
+
+
+class TritonFp8ContiguousProvider(TritonBf16ContiguousProvider):
+    contract = MoeBaseProviderContract(
+        key="triton_fp8_contiguous",
+        quant_info_cls=MoeLoraFp8QuantInfo,
+        gate_first=True,
+        interleaved=False,
+        gate_up_output_dtype=torch.bfloat16,
+        lora_delta_dtype=torch.bfloat16,
+        lora_activation_dtype=torch.bfloat16,
+        act_quant_group=128,
+    )
+
+    _config_dtype_tag = "fp8_w8a8"
+
+    def __init__(self, quant_info: MoeLoraFp8QuantInfo):
+        super().__init__(quant_info)
+        self._config_block_shape = list(quant_info.block_shape)
+
+    def _invoke_fp8(
+        self,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        b_scale: torch.Tensor,
+        out: torch.Tensor,
+        row_state: TritonRowState,
+        *,
+        top_k: int,
+        config: dict,
+        a_scale: torch.Tensor | None = None,
+    ) -> None:
+        import triton.language as tl
+
+        from sglang.kernels.ops.moe.fused_moe_triton_kernels import (
+            invoke_fused_moe_kernel,
+        )
+
+        invoke_fused_moe_kernel(
+            a,
+            b,
+            None,
+            out,
+            # Supplying scales skips the launcher's activation quantization.
+            a_scale,
+            b_scale,
+            None,
+            self._unused_topk_weights,
+            row_state.topk_ids,
+            row_state.sorted_token_ids,
+            row_state.expert_ids,
+            row_state.num_tokens_post_padded,
+            False,
+            top_k,
+            config,
+            compute_type=tl.bfloat16,
+            use_fp8_w8a8=True,
+            use_int8_w8a8=False,
+            use_int8_w8a16=False,
+            use_int4_w4a16=False,
+            per_channel_quant=False,
+            block_shape=list(self.quant_info.block_shape),
+        )
+
+    def gateup(self, row_state: TritonRowState, out: torch.Tensor) -> None:
+        self._invoke_fp8(
+            row_state.hidden_states,
+            self.quant_info.w13_weight,
+            self.quant_info.w13_scale,
+            out,
+            row_state,
+            top_k=row_state.top_k,
+            config=row_state.config,
+        )
+
+    def down(
+        self,
+        row_state: TritonRowState,
+        act_out: torch.Tensor,
+        out: torch.Tensor,
+    ) -> None:
+        a, a_scale = act_out, None
+        if row_state.act_quant is not None:
+            a, a_scale = row_state.act_quant
+        self._invoke_fp8(
+            a,
+            self.quant_info.w2_weight,
+            self.quant_info.w2_scale,
+            out,
+            row_state,
+            top_k=1,
+            config=row_state.down_config or row_state.config,
+            a_scale=a_scale,
+        )

--- a/python/sglang/srt/lora/moe/configs/README.md
+++ b/python/sglang/srt/lora/moe/configs/README.md
@@ -12,7 +12,10 @@ Architectures:
 - `gb300.*` — every SM100-family device (B200, GB200/GB300)
 - `h200.*` — SM90
 - `default.*` — served when no file covers the architecture; routes
-  everything through the conservative serial fallback
+  everything through the conservative serial fallback. Prefill fallback
+  rows stay route-major: the masked slab domain scales as
+  `local_experts x chunk tokens x hidden` (tens of GiB at real chunk
+  sizes) where route-major scales with routed pairs.
 - `base_gemm/` — M-bucketed base-GEMM launch tables (separate key space:
   provider × geometry × device, not plan rows; see its README)
 
@@ -33,10 +36,13 @@ Plans file:
 `expert_major` for the padded `[E, m_max, K]` per-expert slabs, `route_major`
 for one flat buffer of aligned per-expert segments. It is a table value
 because the surrounding stages are built for it. WHICH VENDOR implements that
-row order is not: `--moe-lora-base-gemm` picks `cutedsl` (default) or
-`triton` (route-major only, the A/B arm) at serving time. A geometry a vendor
-cannot admit fails at attach; nothing falls back silently. Do not confuse
-`base_gemm_rows`
+row order is not: the `--moe-runner-backend lora_<vendor>` name picks
+`cutedsl` (the bf16/fp8 default), `triton` (the A/B arm), or `marlin` (the
+nvfp4 default) at serving time; a vendor serving no layers of a weight family
+resolves to that family's default, logged. Triton and Marlin gather rows by
+the sort metadata and have no masked slab domain, so they run a decode row's
+`expert_major` request on their route-major class. A geometry a vendor cannot
+admit fails at attach. Do not confuse `base_gemm_rows`
 with `layout` above: that one is the ADAPTER weight layout (per-expert or
 shared-outer).
 
@@ -412,7 +418,7 @@ eager measurement would have shipped it by mistake.
 off; turning it on wins 1.8-6.8% of MoE-LoRA layer time in every cell measured,
 on both SM100 architectures and all three models, at both prefill graph buckets,
 far outside the noise floor. H200's shared rank bands 9-64
-(`prefill.shared.rank_le16`/`rank_le64`) finalize through shared-rank-reduce,
+(`prefill.shared.rank_le16`/`rank_le64`) finalize through `shared_token_delta`,
 so they have no standalone down-B stage and no into-base axis -- those rows
 are untouched.
 
@@ -448,7 +454,7 @@ tolerance of 3e-2, and each one is a near-zero output where the base and the
 delta cancel. Use a tolerance that scales with the row size, not a fixed one.
 
 H200 shared prefill, rank bands other than 16 (2026-08-20). Every sweep above
-used rank 16, which selects a shared-rank-reduce row with no into-base axis.
+used rank 16, which selects a shared-finalize row with no into-base axis.
 Two other bands keep a standalone down-B: `prefill.shared.rank_le8` for rank 8
 and below, and the unbounded `prefill.shared` above rank 64. 12 captured
 cells, each config captured twice:
@@ -466,7 +472,7 @@ All 12 cells are faster, from +1.31% to +9.76%, median +3.39%, worst noise
 floor 1.04%. These are the largest gains the epilogue gives anywhere. The gain
 falls as the rank rises, which fits: the delta buffer this removes is one row
 for each pair whatever the rank, so its cost is a larger share of a small-rank
-forward. Both rows now use the epilogue. The shared-rank-reduce bands stay
+forward. Both rows now use the epilogue. The shared-finalize bands stay
 off, because they own no separate down-B stage.
 
 Also seen, not acted on: on PER-EXPERT rows at the 2048 bucket, removing
@@ -516,7 +522,7 @@ Route builder on the H200 prefill rows (2026-08-20, added after the flip). The
 48-cell sweep above reached one prefill row only, SM100's `prefill.shared`,
 where parallel against joint was a wash: 12 cells, median +0.10%, range -0.87%
 to +1.70%. It reached no H200 prefill row at all, because that sweep used rank
-16, and rank 16 on H200 selects a shared-rank-reduce row that never used the
+16, and rank 16 on H200 selects a shared-finalize row that never used the
 joint builder. So two H200 prefill rows changed builder with no measurement. This
 closes that gap. Joint is deleted, so the comparison is parallel against
 serial:
@@ -548,7 +554,140 @@ and point `SGLANG_LORA_MOE_CONFIG_DIR` at that directory; files there take
 precedence over the packaged ones, per architecture. The seed only reuses the
 existing plans for the wider geometry: validate provider admission and
 correctness on that geometry before serving it, then benchmark it with the
-campaign protocol below.
+campaign protocol below. `--check` reports rows for one `--quant-family`.
+
+The finalize family names in the evidence below are the current ones:
+`shared_token_delta` was called `shared_token_gemm` and `shared_one_pass` was
+called `shared_mapped_reduce` while these sweeps ran (renamed 2026-09-03).
+
+Shared prefill finalize, rank 16-32 (2026-09-03). Which finalize should the
+shared-outer prefill rows use? Four arms on the same servers: prefill of 4096
+tokens per request at batch 32/16/8/1, two rounds each with the arm order
+reversed. Decode throughput and the greedy probes did not change in any cell.
+Columns where one control round hit a one-off outlier are left out.
+
+H200, change in TTFT against the then-shipped `shared_rank_reduce` row
+(`prefill.shared.rank_le16`); negative is faster:
+
+| model | shared_token_delta | shared_one_pass | materialized + into_base |
+|---|---:|---:|---:|
+| Qwen3.5-35B bf16 | -2.2% .. -2.8% | -1.5% .. -1.8% | +3.7% .. +6.4% |
+| Qwen3.5-35B FP8 | -2.6% .. -2.9% | -1.6% .. -2.1% | +2.1% .. +6.4% |
+| Inkling-Small NVFP4 (marlin) | -2.8% .. -3.5% | -0.6% .. -1.7% | +1.8% .. +4.0% |
+| Qwen3.5-397B FP8, tp 8 | -3.1% .. -3.2% | -0.1% .. -0.4% | +4.9% .. +9.3% |
+
+GB300, change in TTFT against the shipped `shared_token_delta` row
+(`prefill.shared.rank_le32`):
+
+| model | shared_rank_reduce | shared_one_pass | materialized + into_base |
+|---|---:|---:|---:|
+| Qwen3.5-35B FP8, rank 16 | +0.6% .. +2.7% | +1.0% .. +3.4% | +1.5% .. +4.4% |
+| Inkling-Small NVFP4, rank 32 | +1.4% .. +1.6% | +2.2% .. +2.5% | +1.4% .. +2.7% |
+| Qwen3.5-397B NVFP4, rank 16 | +0.1% .. +1.4% | +0.3% .. +2.0% | +1.7% .. +3.6% |
+
+`shared_token_delta` wins every cell on both architectures. The H200 rank 9-16
+row moved to it and `shared_rank_reduce` was deleted: its tail re-read the
+shared down-B once per (token, tile), and nothing else selected it. The
+rank-reduce kernel stays as the first stage of `shared_token_delta`, and
+`shared_one_pass` stays for the gb300 NVFP4 decode row, which this sweep
+did not measure. Numerics: all three shared finalizes sit within 8e-4 of an
+fp32 reference on both tables' prefill rows with the cutedsl and triton row
+orders.
+
+Shared decode finalize (2026-09-03). The same four finalizes on the shared
+decode rows, decode-heavy requests of 128 input and 256 output tokens at batch
+64/32/8/1, two rounds each with the arm order reversed. Rounds reproduce to
+within 0.1%, so decode is a far cleaner measurement than prefill. Change in
+decode tokens per second; positive is faster.
+
+H200 `decode.shared`, against the then-shipped materialized finalize:
+
+| model | shared_rank_reduce | shared_token_delta | shared_one_pass |
+|---|---:|---:|---:|
+| Qwen3.5-35B bf16 | -0.5% .. +0.9% | -7.7% .. -15.7% | +1.5% .. +2.4% |
+| Qwen3.5-35B FP8 | -0.7% .. +0.4% | -8.0% .. -16.2% | +1.4% .. +2.2% |
+| Inkling-Small NVFP4 (marlin) | -0.7% .. +0.2% | -5.8% .. -10.6% | -0.1% .. +0.6% |
+| Qwen3.5-397B FP8, tp 8 | -0.2% .. +0.3% | -3.4% .. -13.4% | +0.5% .. +2.4% |
+
+GB300, against the shipped row of each cell:
+
+| model (row, shipped finalize) | shared_rank_reduce | shared_token_delta | shared_one_pass | materialized |
+|---|---:|---:|---:|---:|
+| Qwen3.5-35B FP8 (`decode.shared`, materialized) | -1.0% .. -1.5% | -6.0% .. -14.0% | +0.7% .. +2.3% | repeat, within 0.1% |
+| Inkling-Small NVFP4 (`decode.shared.nvfp4`, mapped) | -0.1% .. -1.3% | -3.5% .. -11.7% | repeat, within 1% | -1.7% .. -5.2% |
+| Qwen3.5-397B NVFP4 (`decode.shared.nvfp4`, mapped) | -0.5% .. -1.9% | -4.9% .. -17.8% | repeat, within 0.2% | -4.9% .. -8.0% |
+| Qwen3.5-397B FP8, tp 2 (`decode.shared.fp8.e_ge512`, materialized) | not run | not run | +0.0% .. +1.4% | repeat |
+
+Decode inverts the prefill result. `shared_token_delta` pays its extra GEMM
+and token-delta pass on every step and loses 3-18%. `shared_one_pass`
+is best or tied in all eight cells, so every shared decode row now uses it:
+`decode.shared` on both tables and `decode.shared.fp8.e_ge512` moved to it,
+and the NVFP4 decode row already had it (materialized would cost that row
+2-8%). The one-pass finalize owns down-B, which leaves only down-A to overlap,
+so those rows keep `down_a`. The 512-expert FP8 cell ran at tp 2, where the
+hybrid state buffers cap running requests at 43, so it has no batch-64 point.
+
+Shared prefill finalize, every rank band (2026-09-03). The rank 16-32 sweep
+above left the rank 8 band and the bands above 32 (GB300) and 64 (H200) on
+materialized + into_base. This sweep ran the same arms at ranks 8, 64, 128 and
+256 with synthetic shared-outer adapters (N(0, 0.01) factors, the same recipe
+as the rank 16 ones), prefill 4096 tokens per request at batch 32/16/8/1, two
+rounds each. Change in TTFT against the shipped row; negative is faster.
+
+| arch | model | rank | row (shipped finalize) | shared_token_delta | shared_one_pass | materialized + into_base |
+|---|---|---:|---|---:|---:|---:|
+| H200 | Qwen3.5-35B bf16 | 8 | `prefill.shared.rank_le8` (materialized) | -6.2% .. -6.5% (bs1 -2.7%) | +5.5% .. +9.6% | shipped |
+| H200 | Inkling-Small NVFP4 | 8 | `prefill.shared.rank_le8` (materialized) | -4.3% .. -4.6% (bs1 -3.1%) | +7.4% .. +11.0% | shipped |
+| H200 | Qwen3.5-397B FP8 | 8 | `prefill.shared.rank_le8` (materialized) | -9.0% .. -9.2% (bs1 -4.3%) | +4.4% .. +9.7% | shipped |
+| H200 | Qwen3.5-35B bf16 | 64 | `prefill.shared.rank_le64` (token_delta) | shipped | +6.5% .. +9.3% | +6.7% .. +11.8% |
+| H200 | Qwen3.5-397B FP8 | 64 | `prefill.shared.rank_le64` (token_delta) | shipped | +8.4% .. +9.5% | +11.3% .. +17.3% |
+| H200 | Qwen3.5-35B bf16 | 128 | `prefill.shared` (materialized) | -5.7% .. -6.1% (bs1 -4.0%) | +10.7% .. +14.8% | shipped |
+| H200 | Inkling-Small NVFP4 | 128 | `prefill.shared` (materialized) | -3.8% .. -4.1% (bs1 -2.7%) | +13.1% .. +18.2% | shipped |
+| H200 | Qwen3.5-397B FP8 | 128 | `prefill.shared` (materialized) | -8.1% .. -8.2% (bs1 -4.8%) | +12.0% .. +17.6% | shipped |
+| H200 | Qwen3.5-35B bf16 | 256 | `prefill.shared` (materialized) | -5.3% .. -5.6% (bs1 -3.3%) | +1321% .. +1591% | shipped |
+| GB300 | Qwen3.5-35B FP8 | 8 | `prefill.shared.rank_le32` (token_delta) | shipped | +9.2% .. +12.0% | +5.1% .. +6.2% (bs1 +0.9%) |
+| GB300 | Inkling-Small NVFP4 | 8 | `prefill.shared.rank_le32` (token_delta) | shipped | +6.9% .. +7.1% | +2.2% .. +2.4% (bs1 +0.7%) |
+| GB300 | Qwen3.5-35B FP8 | 64 | `prefill.shared` (materialized) | -3.3% .. -4.3% (bs1 -0.3%) | +0.4% .. +2.8% | shipped |
+| GB300 | Inkling-Small NVFP4 | 64 | `prefill.shared` (materialized) | -2.2% .. -2.7% (bs1 -1.2%) | +1.6% .. +3.8% | shipped |
+| GB300 | Qwen3.5-35B FP8 | 128 | `prefill.shared` (materialized) | -3.5% .. -5.7% (bs1 -2.6%) | +6.2% .. +11.0% | shipped |
+| GB300 | Qwen3.5-35B FP8 | 256 | `prefill.shared` (materialized) | -5.9% .. -6.1% (bs1 -3.5%) | +618% .. +788% | shipped |
+
+`shared_token_delta` wins every band on both architectures, so every in-domain
+shared prefill row now finalizes through it: `prefill.shared.rank_le8` and
+`prefill.shared` on H200 and `prefill.shared` on GB300 moved, and they lose
+their standalone down-B stage and into-base axis with it. The out-of-domain
+fallback rows follow the same evidence rather than the pre-sweep default:
+`fallback.prefill.shared` finalizes through `shared_token_delta` in all three
+tables, and a `fallback.decode.shared` row ahead of the layout-agnostic
+`fallback.decode` gives shared-outer decode `shared_one_pass` there too
+(the per-expert fallbacks keep materialized, the only finalize a per-expert
+adapter can use). The `fallback.decode.shared` tile rule copies
+`decode.shared` on H200 and GB300 (same plan, phase and layout; only the
+domain differs) and `fallback.decode` plus the built-in one-pass tile in the
+default table, so no shipped row runs on the built-in defaults unnoticed. The one-pass prefill numbers above rank 16 are confounded: the
+prefill rows' `shared_token_delta.tail` tile is 1024 wide with 8 warps, tuned
+for the token-delta tail, and at the time both families read one shared tile
+section, so the one-pass kernel ran under it (each family now has its own
+section, `shared_token_delta` and `shared_one_pass`); so at rank 256 it
+spills a 1024 x 256 B tile (the kernel alone runs at 1.5 ms for 8192 tokens
+with a 128-wide tile). No prefill row ships it, and the decode rows use the
+128-wide tile.
+
+Shared decode finalize at the rank extremes (2026-09-03). The decode sweep
+above ran at rank 16. Same protocol at ranks 8, 128 and 256 on Qwen3.5-35B;
+change in decode tokens/s of materialized against the shipped one-pass finalize:
+
+| arch | rank | materialized vs shipped `shared_one_pass` |
+|---|---:|---:|
+| H200 bf16 | 8 | -1.6% .. -3.0% |
+| H200 bf16 | 128 | -0.7% .. +0.1% |
+| H200 bf16 | 256 | -0.2% .. -0.7% (bs8 +0.9%) |
+| GB300 FP8 | 8 | -0.5% .. -2.5% |
+| GB300 FP8 | 128 | -0.2% .. -0.7% |
+| GB300 FP8 | 256 | -0.7% .. -1.4% (bs1 +0.1%) |
+
+The one-pass finalize keeps its lead at rank 8 and ties at 128 and 256, so the
+decode rows stay on it across the whole rank range.
 
 Token route from the request segments (2026-09-03). The shared-outer token
 route, one row per token grouped by adapter slot, used to be built like the
@@ -559,7 +698,7 @@ share one slot, and the batch carries the request boundaries (`seg_indptr`).
 One program now walks the requests and writes each one's tokens in place,
 padded to whole blocks, keyed by its slot; a request without an adapter adds
 no block. Same route contract, same consumers (`token_grouped` A and the
-`shared_token_gemm` finalize). Tokens whose experts all live on other ranks
+`shared_token_delta` finalize). Tokens whose experts all live on other ranks
 are no longer dropped from the route; their rows are computed and never read.
 
 TTFT with the segment route against the histogram route, prefill 4096 tokens
@@ -569,6 +708,21 @@ per request, bs 32/16/8/1, two rounds each, H200, rank 16:
 |---|---:|---:|---:|---:|
 | Qwen3.5-35B bf16 | -1.4% | -1.4% | -1.1% | -1.2% |
 | Inkling-Small NVFP4 | -0.7% | -1.1% | -2.1% | -0.5% |
+
+Per-pair inner product on the NVFP4 decode row (2026-09-03). The gb300 NVFP4
+decode row runs `token_dense` A, `per_pair` B over its slot planes, `per_pair`
+down-A and `shared_one_pass`. A variant of both per-pair kernels on
+`tl.dot`, a 16-row tile holding one live row, was measured against the shipped
+`tl.sum` kernels on that row (128 input, 256 output tokens, bs 64/32/8/1, two
+rounds):
+
+| model | tl.sum vs tl.dot variant, decode tok/s |
+|---|---:|
+| Inkling-Small NVFP4, rank 32 | +0.5% .. +1.7% |
+| Qwen3.5-397B NVFP4, rank 16 | -0.2% .. +0.3% |
+
+The `tl.sum` kernels win or tie, so no dot variant ships: one kernel per site
+serves every raw route.
 
 Base GEMM orientation (2026-09-04). The CuTeDSL grouped GEMMs run one
 orientation: the weight on the MMA M axis and the tokens on the N axis, which

--- a/python/sglang/srt/lora/moe/configs/README.md
+++ b/python/sglang/srt/lora/moe/configs/README.md
@@ -1,0 +1,599 @@
+# MoE LoRA config files
+
+Two JSON files per device-architecture key space:
+
+- `{arch}.plans.json` — execution-plan rows, loaded by
+  `sglang/srt/lora/moe/execution_plan.py` (`load_plans`/`resolve_plans`)
+- `{arch}.tiles.json` — per-row launch-tile rules, loaded by
+  `sglang/srt/lora/moe/launch_config.py` (`resolve_tiles`)
+
+Architectures:
+
+- `gb300.*` — every SM100-family device (B200, GB200/GB300)
+- `h200.*` — SM90
+- `default.*` — served when no file covers the architecture; routes
+  everything through the conservative serial fallback
+- `base_gemm/` — M-bucketed base-GEMM launch tables (separate key space:
+  provider × geometry × device, not plan rows; see its README)
+
+Plans file:
+
+```json
+{
+  "arch": "gb300",
+  "domain": {"max_hidden": 4096, "max_local_experts": 512},
+  "scenarios": [ { "name", "layout", "phase", "max_rank", "base_gemm_rows",
+                   "plan" }, ... ],
+  "fallback":  [ ...same row shape, matched when the geometry is outside
+                 "domain" or no scenario row matches... ]
+}
+```
+
+`base_gemm_rows` is how the routed activation rows reach the base GEMM —
+`expert_major` for the padded `[E, m_max, K]` per-expert slabs, `route_major`
+for one flat buffer of aligned per-expert segments. It is a table value
+because the surrounding stages are built for it. WHICH VENDOR implements that
+row order is not: `--moe-lora-base-gemm` picks `cutedsl` (default) or
+`triton` (route-major only, the A/B arm) at serving time. A geometry a vendor
+cannot admit fails at attach; nothing falls back silently. Do not confuse
+`base_gemm_rows`
+with `layout` above: that one is the ADAPTER weight layout (per-expert or
+shared-outer).
+
+Plan selection happens ONCE, at weight bind: every selection input (layout,
+phase, pool-padded rank, geometry) is a server-lifetime constant, so
+nothing plan-shaped remains on the forward path. Rows are matched FIRST-HIT
+IN ORDER, so put more specific rows (rank bands) above catch-alls. `layout`
+("per_expert"/"shared") and `phase` ("decode"/"prefill") are exact keys
+(absent = wildcard); `max_rank` admits ranks up to its bound. Rows are
+activation-agnostic: the layer injects its own activation when the plan is
+built. That was a deliberate collapse (2026-08-16) and it retired three
+measured rows, so a ReLU2 MoE is now served by the SwiGLU winners:
+
+- shared layout, both phases: the old ReLU2 twins were byte-identical to
+  their SwiGLU rows, so nothing changed;
+- per-expert decode: same plan shape, but the ReLU2 row carried its own tile
+  set and now inherits the SwiGLU ladder (which is banded by token count,
+  where the ReLU2 row was not);
+- per-expert prefill on SM100: materially different — the retired
+  `prefill.relu2` ran the expert-major (masked) rows with an early gate/up-A
+  window and a late down-A+B window and no into-base epilogue, where the
+  per-expert prefill rows run the route-major (contiguous) rows strictly
+  serially with down-B adding into the base down output.
+
+Both are numerically correct (every provider registers relu2 for the fused
+middle); the ReLU2-tuned schedules are simply no longer served. Re-adding
+them means re-adding an `activation` predicate to the row model. `plan` carries kernel families, fusion shape, overlap windows, and
+route builder (see `build_plan` in execution_plan.py for the field list).
+Every served row is validated through the execution-plan contracts at bind
+time — a malformed row fails startup, never serves.
+
+Tiles file:
+
+```json
+{
+  "arch": "gb300",
+  "rules": {
+    "<plan row name>": [ { "max_rank", "max_tokens", "sites" }, ... ]
+  }
+}
+```
+
+The tile pick is the ONLY per-forward decision: at bind time the rank rules
+are filtered against the bound rank, and each forward takes the first rule
+whose `max_tokens` admits the batch (a rule without `max_tokens` terminates
+the ladder). `sites` holds `MoeLoraLaunchConfig` fields (per-site Triton
+tile dicts). A plan row with no rules serves the built-in heuristics.
+
+Route block size (`routing_block_size`):
+
+One aligned route serves every grouped LoRA kernel on a plan row, and its
+block is each kernel's row tile — of nothing else. The base GEMMs never read
+it (their flat buffer uses their own `m_alignment`, 128 on CuteDSL, and their
+own token-width tiles from `base_gemm/`); the fused act and finalize are
+pair-domain through `pair_to_row`. A padded slot costs masked `tl.dot` lanes
+inside whichever LoRA kernel tiles over it, and nothing anywhere else.
+
+Shipped values: decode rows 16 (their measured optimum at 1-16 pairs per
+group; also the tensor-core floor), prefill rows 32, except the H200
+shared-prefill rank bands, which carry their own winners (16-64 by rank).
+
+There USED to be a second granularity — `gate_up_a_routing_block_size`, a
+private gate/up-A list at 64 over a shared 16 — retired 2026-08-19 along
+with its dual-granularity fused builder (~500 lines). The full retirement
+matrix, three models with per-expert adapters, chunks 8k-32k, two rounds per
+arm, prefill throughput vs that split:
+
+| chunk sweep | one block of 16 | one block of 32 |
+|---|---|---|
+| Qwen3.5-35B 8k/16k/32k (H200, noise <=1.4%) | -2.4..-3.2% | +0.0..+2.0% |
+| Inkling-Small 8k/16k (GB300) | -3.1..-5.4% | -0.9..+2.1% |
+| Qwen3.5-397B 8k/16k (GB300, noise 0.4%) | -4.5..-5.7% | -1.0..+0.3% |
+
+One block of 32 is within noise of the split everywhere but two cells that
+cancel (-1.0% on 397B at 16k, +2.0% on Qwen at 32k), so the split's whole
+value was recoverable by picking the right single number. 16 — the old
+shared value — is NOT that number: gate/up-A's weight slab (2R x hidden, the
+largest K-deep panel of the four kernels) loses 4x its fetch amortization
+there. Do not "simplify" this value downward without rerunning the matrix.
+
+Occupancy is what moves the optimum — routed pairs per virtual expert,
+`tokens x top_k / (local_experts x live adapter slots)`. A 4096-token
+prefill of a 256-expert model with 4 adapters resident is 1024 groups of
+~32 pairs, not the thousands the token count suggests. The tuner sweeps
+this knob per phase end-to-end (decode scored on output throughput, prefill
+on input throughput).
+
+The SHARED-OUTER prefill rows remain the open lead: they run the opposite
+regime (4 virtual experts, ~16k pairs each, padding 0.4% of slots) and a
+kernel-level sweep on GB300 put a block of 128 at +19.6% (2k tokens) to
++26.0% (8k) over a block of 16, with no padding tax to give it back. The
+shipped rows have since moved to 32 (H200's top band to 64); the 128 cell
+has not been rerun against them.
+
+Route builder launch tiles (constants in `routing.py`, kernels in
+`kernels/routing.py`):
+
+These are module constants, not table entries and not autotuned, because
+graph capture wants one launch shape per call site. The route build is three
+kernels: count pairs per bucket, plan the blocks, then label blocks and place
+pairs. `HIST_BLOCK`/`HIST_WARPS` size the count, `SCAN_CHUNK`/`SCAN_WARPS`
+the plan, `EXPAND_BLOCK`/`EXPAND_WARPS` the place.
+
+Swept on GB300 2026-07-25 (64 points over 4 cells), then re-verified
+per-kernel on H200/B200/GB300 2026-08-19 (5 cells x 48 configs, profiler GPU
+time, noise <=1%). Decision: KEEP ALL SIX. No alternative wins everywhere.
+The plan and place tiles are minimax-optimal — every other value regresses
+7-18% in some cell — and the count tile has rivals with a ~4% better median
+that give back up to 1.9% elsewhere. A per-cell oracle would save 0.1-2.7us
+of an 8-60us build, so a per-geometry table buys nothing.
+
+MEASURE THESE WITH THE PROFILER, per kernel. CUDA events around the Python
+call cannot see them: 70-90% of that wall time is host-side launch work, and
+the first attempt at this sweep measured the shipped config 9.6% FASTER THAN
+ITSELF, and one arch's three stages each +13% while their combination went
+-3.9%. Per-kernel `self_device_time_total` has a <=1% floor.
+
+The JIT id-pass tile in `routing.py` (`block_size = 1024`, a flat map over
+pairs) was never swept; it is ~1-3us of exposure.
+
+Cost of one route build, measured on B200 2026-08-19 (16,384 pairs = 2048
+tokens at top-8, block 32, profiler GPU time per kernel):
+
+| geometry | count | plan | place | total |
+|---|---|---|---|---|
+| per-expert 128 experts x 4 adapters (513 buckets) | 4.4 | 2.3 | 4.0 | 10.7us |
+| per-expert 256 x 8 (2049 buckets) | 3.0 | 3.8 | 4.3 | 11.1us |
+| per-expert 256 x 32 (8193 buckets) | 3.0 | 8.9 | 5.1 | 16.9us |
+| shared-outer, 4 adapters (5 buckets) | 4.3 | 2.2 | 4.4 | 10.9us |
+| shared-outer, 1 adapter (2 buckets) | 12.6 | 3.1 | 12.4 | 28.1us |
+
+This is paid ONCE PER MoE LAYER per forward, not once per forward — each
+layer routes its tokens differently, so the route cannot be reused. Multiply
+by the model's MoE layer count before comparing against anything.
+
+End-to-end share, measured 2026-08-19 on B200 tp4, Qwen3.5-35B (40 MoE
+layers, top-8, 256 experts), one 8192-token prefill chunk = 65,536 pairs,
+rank-0 torch profile:
+
+| route family | builder (as then shipped) | per layer | per prefill | share of prefill |
+|---|---|---|---|---|
+| per-expert (now `prefill.per_expert`) | fused aligned | 30.4us | 1.22ms | 1.5% |
+| shared-outer (now `prefill.shared`) | joint (since deleted) | 32.7us | 1.31ms | 1.5% |
+
+Those are after the per-block counting below. Before it they were 43.7us /
+1.75ms / 2.4% and 116.4us / 4.66ms / 5.4%.
+
+Wall clock for that change, shared-outer arm, no profiler attached: prefill
+73.75 -> 70.53ms median, 4.37% faster. Four interleaved servers off/on/off/on,
+8 repeats each, and the two arms' ranges do not overlap (off floor 72.56 vs on
+ceiling 71.44), which is the only reason a 4% effect is believable here -- the
+same measurement WITH the profiler attached swung 71-100ms on one config.
+Removing 3.35ms of kernel time bought 3.22ms of wall clock.
+
+Read that before optimizing the route build. Today a shared-outer plan
+builds its two aligned views with the standard builder, the shared one forked
+onto the workspace side stream (`parallel_shared_outer`; the joint builder it
+replaced is recorded below); a per-expert plan builds one. Per-expert DECODE
+builds neither -- 8 pairs is below `FUSED_ALIGN_MIN_PAIRS`, so it runs the JIT
+id pass at 1.2us per layer.
+
+BEWARE when A/B-ing adapter counts: at batch size 1 a single request uses a
+single adapter, so `max_loras_per_batch` 1 and 4 put every pair on the SAME
+counter and measure identically (58.0 vs 58.5us here). That flatness is not
+evidence of no contention -- it is evidence the knob did nothing.
+
+Verdicts on the two leads this evidence settles:
+
+- The single-thread-block plan kernel is NOT worth fixing. It is 2.7-3.8us per
+  layer in both families, 0.13% of the step. Its 8.9us at 8193 buckets only
+  arrives with many adapters resident, which batch-1 serving never reaches.
+- Atomic contention WAS worth fixing, and is fixed: `add_counts_inline` and
+  `claim_slots_inline` in `kernels/routing.py` count a block's pairs before touching
+  global memory, so a block spends one atomic per bucket instead of one per
+  pair. Landed per-layer prefill numbers, 8192-token chunk:
+
+| kernel | before | after | |
+|---|---|---|---|
+| joint count | 58.0us | 7.9us | 7.3x |
+| joint plan | 3.8us | 2.9us | 1.3x |
+| joint place | 54.6us | 21.9us | 2.5x |
+| fused count | 21.4us | 8.0us | 2.7x |
+| fused place | 19.6us | 19.6us | no path applies |
+
+  `fused_align`'s place kernel keeps its per-pair claim: handing out individual
+  slots across 257 buckets would need 257 running sums per block, which costs
+  more than the atomics it would replace. Only the shared route, with a handful
+  of buckets, can claim per block.
+
+The per-block paths CANNOT simply replace the per-pair ones -- they pay a fixed
+cost per block, so they lose badly on small work, which is why `count_bins` and
+`CLAIM_MIN_PAIRS_PER_BUCKET` gate them on the host and both per-pair paths
+stay. Measured win factor by pairs and live adapters (above 1.00 means the
+per-block path wins):
+
+| pairs | 1 live | 2 | 4 | 8 |
+|---|---|---|---|---|
+| 65,536 | 4.78x | 2.31x | 1.27x | 1.28x |
+| 32,768 | 2.39x | 1.32x | 0.73x | 0.71x |
+| 16,384 | 1.28x | 0.72x | 0.44x | 0.45x |
+| 4,096 | 0.66x | 0.56x | 0.40x | 0.38x |
+| 512 | 0.33x | 0.32x | 0.31x | 0.38x |
+
+The crossover sits near 12,000 pairs per bucket for slot claims. Counting has
+its own bound because it wins at far lower occupancy -- 65,536 pairs over 256
+buckets is only 256 each and still gains 3.7x -- but stops paying above 512
+bins (0.47x at 2048). Both choices are made on the host from the pair and
+bucket counts, so each call site keeps one launch shape and graph capture is
+unaffected. Do NOT branch inside a kernel on a device value.
+
+What is left: the counting path is bounded at 512 bins, so a per-expert route
+with more than 511 buckets -- 256 experts with 2 or more adapter slots -- still
+counts one pair at a time. Raising `COUNT_MAX_BINS` needs 1024 measured first;
+2048 is known to lose.
+
+MEASURED AND DECLINED, so nobody re-derives it: the plan kernel's `CHUNK` is a
+flat 2048 lanes whatever the bucket count, which is 8x wider than the 257
+buckets a per-expert route has and 1024x wider than the shared route's 2.
+Narrowing it to fit does help that kernel -- at 257 buckets a 512 tile is
+1.70us against 2.10us, and at 2 buckets a 16 tile is 1.31us against 1.98us --
+but the whole win is 0.4-0.7us per layer, 0.5% of a decode step and 0.02% of
+a prefill, well under what an end-to-end A/B can resolve, so the flat 2048
+stays. (The numbers were taken on the since-deleted joint kernel, where the
+wider route also masked the narrow one's gain.) Above 1024 buckets 2048 is
+simply correct.
+
+Not a lead, and worth recording so nobody re-derives it: the padding fill's
+2D tile is `EXPAND_BLOCK x routing_block_size`, which looks like it should
+blow up registers as the block grows. It does not. Blocks 16 through 512 all
+compile with zero spills (32 registers, 56 at block 64), and 256 and 512 run
+correctly. Whatever limits the route block, it is not this kernel.
+
+Correctness coverage for the fused builder, B200 2026-08-19: differentially
+diffed against a torch reference over 21 geometries — per-expert and
+shared-outer, blocks 16-128, 513 to 8193 buckets (four scan chunks), all four
+ways a pair can be invalid, a single hot bucket, a count landing exactly on a
+block boundary, single token, top-1, and a zero-token idle rank. Each case
+checks the padded pair count, every block label including the out-of-plan -1
+tail, each bucket's real slots as a set plus its exact padding, that the
+counters came back zeroed, and that a second call agrees with the first.
+Unverified end-to-end; a shared-outer adapter on 397B or Inkling is the
+vehicle. A block of 256 exceeds shared memory for these tiles.
+
+A second retired-but-documented lead: which kernel most wants a big block is
+set by the model's shape (gate/up-A slab 2R x hidden vs down-A slab R x
+intermediate, equal at I = 2H). Our fleet is all I <= H. At a Mixtral-shaped
+4096/14336 under production geometry, down-A at 16 wastes 54-65% of what
+becomes the layer's largest LoRA kernel (0.7-1.0 ms per 8k chunk) — for such
+a model, sweep this knob first and expect a bigger winner.
+
+One caution for anyone re-deriving any of this with a kernel-level sweep:
+it measures LoRA-only percentages at whatever occupancy the harness picked,
+and both of this file's past mistakes came from that — quoting kernel wins
+without LoRA's share of the layer, and measuring at occupancies production
+never runs. Rank tiles within one stage with kernel sweeps; decide route
+values end-to-end.
+
+Some rules carry byte-identical `sites` ON PURPOSE, and nothing enforces the
+pairing — the format is deliberately raw values with no reference/alias
+mechanism. As shipped: `decode.per_expert` rules 0+1 share one config
+(rank rule and its M≤4 bucket), rules 2+3 share another (the M≤16 bucket and
+the rank-32 rule that extends the same tiles to 32 tokens), and the
+`fallback.*` rows repeat one config across all three arch files. If you
+retune one rule of such a pair, retune its twin in the same edit, or the
+"same tiles, wider window" intent silently splits. This is a fact about the
+current tuning, not an invariant — a future sweep may legitimately split a
+pair, which is why no test pins it. Editing by hand? Read
+`benchmark/kernels/lora_moe/README.md` first for the selection-cascade traps
+and the measurement protocol.
+
+Both loaders are pydantic models with `extra="forbid"`: a field this build
+does not understand aborts startup instead of silently widening a match.
+Two annotation fields are declared and ignored by selection, so tuned
+tables stay loadable: a row may carry `provenance`, and a plans file may
+carry `seeded_for` (both written by the tuner below).
+
+Every value in the shipped files is a measured sweep winner from the
+2026-08 best-config campaign (bs 1–32, 4k/1k, mlpb=4, r16/32; Qwen3.5-35B,
+Qwen3.5-397B, Inkling-Small on GB300/B200/H200).
+
+`gb300.*` keys the whole SM100 family, so what that claim rests on, exactly:
+
+- Plans, confirmed on B200 (2026-08-14, 14-arm e2e sweep, three models):
+  decode B family, split-K, row domain, overlap windows, route builder and
+  route PDL all picked the same winner as on GB300.
+- Tiles, confirmed on B200 (2026-08-17, 54-arm 4-candidate forcing sweep: the
+  per-expert decode row at r16/32/64, the per-expert prefill row and both
+  shared rows, on all three models, plus r32 at tp2 and tp8): B200 picks the
+  same winner as GB300 in every cell. Forcing the wrong tile costs up to 4.9%
+  on the rank rule and 5–26% for the built-in heuristics (the 26% is 397B
+  shared-outer at bs1), so the ladder earns its place on both dies, at every TP
+  measured.
+- The one place both dies wanted something the table did not have: at rank 32
+  the M≤16 tiles keep winning above the small-M buckets, where the ladder used
+  to fall to the wildcard row. `{"max_rank": 32}` encodes that. Confirmed on
+  two geometries: +4.4% at bs32 on 35B (committed table vs old, GB300) and
+  +2.0% on Inkling per-expert, each with the cells the rule must not touch
+  reading inside ±0.7%; and measured out to the largest batch the decode graph
+  captures — +3.5% at 64 tokens, +3.3% at 128 — which is why the rule carries
+  no `max_tokens` bound.
+- NOT measured on B200: tile values for the ≤4-token bucket, whose sites are
+  byte-identical to the rank rule's, so forcing them re-runs the incumbent
+  rather than testing it. Those inherit GB300's numbers.
+
+The gate/up A family is NOT a tuner axis, so its prefill/decode split was
+argued rather than measured until 2026-08-19. It is measured now, B200,
+Qwen3.5-35B shared-outer, one plan row flipped per arm via a config-dir
+override, base/variant interleaved over two rounds:
+
+| flip | metric | base | flipped |
+|---|---|---|---|
+| `decode.shared` -> `token_grouped` | decode tput | 5881 tok/s | 5266, **-10.5%** |
+| `prefill.shared` -> `grouped` | prefill ttft | 70.87ms | 73.45ms, **-3.6%** |
+
+Both shipped choices are right, and the control is that each variant moved only
+its own metric: the decode flip left prefill at 71.00 vs 70.87ms, the prefill
+flip left decode at 5881.8 vs 5881.1 tok/s. Note the decode loss is far larger
+than the extra route explains -- that route is only 5.5us per layer, built by
+the shared CUDA align because one row per token with one bucket per adapter
+falls under both fused thresholds. Flipping the family also forces a token-major
+gate/up bridge, and that is where the decode cost actually lives. A family flip
+is never just one stage.
+
+Provenance and the full axis inventory live in the 2026-08 campaign
+records.
+
+Down-tail sweep, 3 models x 3 architectures x 2 adapter layouts (2026-08-20).
+Instrument: one `MoeLoraRunner.run` at each model's real per-rank geometry
+(Qwen3.5-35B h2048/i128/E256/k8, Qwen3.5-397B h4096/i256 or i128/E512/k10,
+Inkling-Small h4096/i512 or i256/E256/k6), against the row `resolve_plans`
+actually selects for that arch and layout -- so an arm differs from production
+by exactly one plan field. Wall clock over batches of back-to-back calls, arm
+order rotated per repeat, first repeat discarded. Sanity: the measured layer
+time x layer count is 43-59% of the runbook's e2e prefill time, so a layer-level
+delta is worth roughly half that at e2e prefill.
+
+EAGER results are reported first because they are misleading, and the reason is
+the point. Eagerly, the DOWN_A window swings +11% to -1.7% depending on model and
+architecture -- Qwen3.5-35B loses 6-11% at <=4096 tokens everywhere, and on GB300
+at every token count. None of that survives CUDA-graph capture, which is what
+production prefill runs at the `--cuda-graph-bs-prefill` buckets: capture turns
+the fork's event record/wait into graph nodes and the overhead disappears.
+
+CAPTURED results, every config captured twice so the graph-to-graph spread is
+measured per config rather than assumed (a single capture of an identical plan
+drifted ~1%, the size of the effect). `noise` is that spread for the shipped
+config; nothing inside it means anything.
+
+| arch | model | layout | tokens | noise | DOWN_A | adopt into-base |
+|---|---|---|---:|---:|---:|---:|
+| B200 | q35 | shared | 2048 | 0.94% | -2.69% | **-5.31%** |
+| B200 | q35 | shared | 8192 | 0.67% | +0.05% | **-6.84%** |
+| B200 | q397 | shared | 2048 | 0.01% | -0.67% | **-2.62%** |
+| B200 | q397 | shared | 8192 | 0.73% | -0.76% | **-3.73%** |
+| B200 | ink | shared | 2048 | 0.11% | -0.06% | **-1.89%** |
+| B200 | ink | shared | 8192 | 0.90% | +0.03% | **-3.51%** |
+| GB300 | q35 | shared | 2048 | 0.94% | -2.65% | **-6.20%** |
+| GB300 | q35 | shared | 8192 | 0.39% | -0.30% | **-6.71%** |
+| GB300 | q397 | shared | 2048 | 0.02% | -0.40% | **-1.84%** |
+| GB300 | q397 | shared | 8192 | 0.30% | -0.40% | **-3.37%** |
+| GB300 | ink | shared | 2048 | 0.00% | -0.62% | **-2.28%** |
+| GB300 | ink | shared | 8192 | 0.21% | +0.63% | **-1.79%** |
+
+Two conclusions.
+
+**The DOWN_A window is not worth shipping.** Across 36 captured cells its effect
+runs -2.7% to +2.0% with no consistent sign by model, architecture, or token
+count, and most cells sit inside their own noise floor. The eligibility rule
+admits it so a table *can* ask for it, and the eager numbers explain why an
+eager measurement would have shipped it by mistake.
+
+**Shared-outer prefill rows should adopt `down_b_into_base`.** They ship with it
+off; turning it on wins 1.8-6.8% of MoE-LoRA layer time in every cell measured,
+on both SM100 architectures and all three models, at both prefill graph buckets,
+far outside the noise floor. H200's shared rank bands 9-64
+(`prefill.shared.rank_le16`/`rank_le64`) finalize through shared-rank-reduce,
+so they have no standalone down-B stage and no into-base axis -- those rows
+are untouched.
+
+Shared expert-major fallback row (2026-08-20). The row
+`fallback.prefill.shared` uses `expert_major` row order
+and was not in the sweep above, so it kept the epilogue off. It serves only
+out-of-domain geometry, which means hidden above 4096 or more than 512 local
+experts. Two real models land there: GLM-5.2 and full Inkling, both hidden
+6144. 16 captured cells, each config captured twice:
+
+| arch | model | 1024 | 2048 | 4096 | 8192 |
+|---|---|---:|---:|---:|---:|
+| GB300 | GLM-5.2 | +1.67% | +1.68% | +1.64% | +1.42% |
+| GB300 | Inkling | +1.02% | +1.21% | +1.38% | +0.87% |
+| B200 | GLM-5.2 | +1.23% | +1.41% | +0.69% | - |
+| B200 | Inkling | +0.34% | +0.66% | +0.87% | - |
+| H200 | GLM-5.2 | +2.03% | - | - | - |
+| H200 | Inkling | +1.40% | - | - | - |
+
+Here `+` means faster with the epilogue on. All 16 cells are faster. The range
+is +0.34% to +2.03%, the median is +1.30%, and the worst per-cell noise floor
+is 0.55%. The empty cells are a limit of the harness, not of the row: each arm
+holds its own workspace, and one expert-major slab at hidden 6144 is up to
+24.8 GB. The row now uses the epilogue in all three tables. The `default`
+table cannot reach it in serving, because the runner admits SM90 and SM100
+only, but the three tables stay aligned.
+
+The numerics check needed a new bound at this size. The epilogue rounds
+`base + delta` to BF16 one time, and the shipped path rounds the delta first.
+At hidden 6144 the largest difference was 0.125, which is one BF16 unit at the
+largest row value of 18.1. Only 9 elements of 12.6 million passed a fixed
+tolerance of 3e-2, and each one is a near-zero output where the base and the
+delta cancel. Use a tolerance that scales with the row size, not a fixed one.
+
+H200 shared prefill, rank bands other than 16 (2026-08-20). Every sweep above
+used rank 16, which selects a shared-rank-reduce row with no into-base axis.
+Two other bands keep a standalone down-B: `prefill.shared.rank_le8` for rank 8
+and below, and the unbounded `prefill.shared` above rank 64. 12 captured
+cells, each config captured twice:
+
+| rank | row | model | 2048 | 8192 |
+|---:|---|---|---:|---:|
+| 8 | prefill.shared.rank_le8 | Qwen3.5-35B | +6.63% | +9.76% |
+| 8 | prefill.shared.rank_le8 | Qwen3.5-397B | +4.38% | +7.99% |
+| 8 | prefill.shared.rank_le8 | Inkling-Small | +4.21% | +6.76% |
+| 128 | prefill.shared | Qwen3.5-35B | +2.17% | +2.40% |
+| 128 | prefill.shared | Qwen3.5-397B | +1.31% | +2.57% |
+| 128 | prefill.shared | Inkling-Small | +1.71% | +2.20% |
+
+All 12 cells are faster, from +1.31% to +9.76%, median +3.39%, worst noise
+floor 1.04%. These are the largest gains the epilogue gives anywhere. The gain
+falls as the rank rises, which fits: the delta buffer this removes is one row
+for each pair whatever the rank, so its cost is a larger share of a small-rank
+forward. Both rows now use the epilogue. The shared-rank-reduce bands stay
+off, because they own no separate down-B stage.
+
+Also seen, not acted on: on PER-EXPERT rows at the 2048 bucket, removing
+into-base measured -2.06% (B200) and -2.03% (GB300) for Qwen3.5-397B, while at
+8192 removing it costs +0.85% to +2.99%. That is a token-banded preference the
+plan table cannot express -- `max_rank` is its only predicate -- so it is a lead,
+not a change.
+
+Route-builder sweep: joint vs parallel-two-stream vs serial (2026-08-20, all
+three architectures, shared layout, the five shipped joint rows' shapes).
+Same instrument discipline as the down-tail sweep above: shipped row, captured
+graphs, every config captured twice, deltas vs the joint arm. 48 cells
+(3 models x {decode bs 1/8/16/32, prefill 2048/8192} x 3 archs; H200
+contributes decode only -- its rank-16 shared prefill row already uses the
+standard builder).
+
+- Serial two builds: clearly worse, +1% to +15% (worst at decode bs1) --
+  the joint builder was genuinely earning its keep against serial.
+- Parallel two-stream (`parallel_shared_outer`: the two standard aligned
+  builds forked on the workspace side stream): matches or beats joint.
+  20 wins / 19 washes / 9 losses; every loss <= +1.5%; decode median -0.46%
+  (mean -1.01%), prefill median -0.10%. Biggest win: Qwen3.5-397B decode bs1
+  on GB300, -7.95% of layer time (noise 0.08%) -- at E=512 the joint fused
+  chain drags 2049 buckets of label metadata for a 10-pair forward, while the
+  parallel arm's tiny builds fall through the fused-align thresholds to the
+  JIT align path. That per-route builder choice is structural to the parallel
+  form: each route picks its own builder, which one dual-headed launch cannot.
+
+Content equivalence was proven separately (bucket -> pair-set identical at
+1..8192 tokens). Two representation differences are benign by construction:
+intra-bucket pair order is atomic-claim nondeterministic even between two runs
+of the SAME builder, and the JIT align path lays sentinel blocks first where
+the fused path lays them last -- consumers skip `-1` blocks wherever they sit.
+
+e2e sanity at the runbook protocol (B200, shared layout, joint vs parallel,
+override proven to flip the resolved builder): decode moved positive in all
+eight cells -- Qwen3.5-35B +0.7..+1.3%, Qwen3.5-397B +0.5..+2.6% with the
+largest gain at bs1, exactly where the layer-level route-build win is biggest.
+Prefill flat within noise. On this evidence every shipped joint row moved to
+`parallel_shared_outer`, and the dual-headed joint machinery was deleted from
+the route kernels: `_hist`/`_scan`/`_place` are single-route (the constexpr
+NEED branches compiled to exactly these instantiations before, verified by a
+post-deletion timing spot check matching to the microsecond), and
+`_build_aligned` builds one route per call.
+
+Route builder on the H200 prefill rows (2026-08-20, added after the flip). The
+48-cell sweep above reached one prefill row only, SM100's `prefill.shared`,
+where parallel against joint was a wash: 12 cells, median +0.10%, range -0.87%
+to +1.70%. It reached no H200 prefill row at all, because that sweep used rank
+16, and rank 16 on H200 selects a shared-rank-reduce row that never used the
+joint builder. So two H200 prefill rows changed builder with no measurement. This
+closes that gap. Joint is deleted, so the comparison is parallel against
+serial:
+
+| rank | row | median | range |
+|---:|---|---:|---:|
+| 8 | prefill.shared.rank_le8 | +0.80% | +0.26% .. +1.22% |
+| 128 | prefill.shared | +0.90% | -0.18% .. +0.99% |
+
+Here `+` means parallel is faster. Parallel wins 11 of 12 cells. The one loss
+is -0.18%, inside that cell's 0.54% noise floor.
+
+The honest summary for prefill: parallel matches joint, and it beats serial by
+about 1%. Decode is where parallel gains over joint. Prefill keeps parallel
+because joint no longer exists and serial is worse, not because parallel is
+faster than what it replaced.
+
+A general lesson from this sweep and the into-base sweep: rank 16 selects a
+different row from rank 8 or rank 128 on H200. A sweep at one rank does not
+cover a table whose rows carry `max_rank`.
+
+To onboard a model whose geometry the shipped `domain`/rows do not cover:
+
+```
+python benchmark/kernels/lora_moe/tune_lora_config.py --model-path <path> --emit-seed --out <dir>
+```
+
+and point `SGLANG_LORA_MOE_CONFIG_DIR` at that directory; files there take
+precedence over the packaged ones, per architecture. The seed only reuses the
+existing plans for the wider geometry: validate provider admission and
+correctness on that geometry before serving it, then benchmark it with the
+campaign protocol below.
+
+Token route from the request segments (2026-09-03). The shared-outer token
+route, one row per token grouped by adapter slot, used to be built like the
+pair routes: a histogram over tokens keyed by slot, a scan, and a placement
+pass, three kernels plus a masking pass, every forward. That is a sort of
+something already sorted: a request's tokens are contiguous in the batch and
+share one slot, and the batch carries the request boundaries (`seg_indptr`).
+One program now walks the requests and writes each one's tokens in place,
+padded to whole blocks, keyed by its slot; a request without an adapter adds
+no block. Same route contract, same consumers (`token_grouped` A and the
+`shared_token_gemm` finalize). Tokens whose experts all live on other ranks
+are no longer dropped from the route; their rows are computed and never read.
+
+TTFT with the segment route against the histogram route, prefill 4096 tokens
+per request, bs 32/16/8/1, two rounds each, H200, rank 16:
+
+| model | bs 32 | bs 16 | bs 8 | bs 1 |
+|---|---:|---:|---:|---:|
+| Qwen3.5-35B bf16 | -1.4% | -1.4% | -1.1% | -1.2% |
+| Inkling-Small NVFP4 | -0.7% | -1.1% | -2.1% | -0.5% |
+
+Base GEMM orientation (2026-09-04). The CuTeDSL grouped GEMMs run one
+orientation: the weight on the MMA M axis and the tokens on the N axis, which
+lets the token tile go down to 8 wide (`GroupedGemmConfig.mma_tiler_mn =
+(128, token_width)`). The other orientation, tokens on M, was carried as a
+second bf16 wrapper and a `swap_ab` flag but never shipped and had no
+benchmark driver in the tree, so it was removed. The evidence at removal:
+
+- Decode: a tile floor, not a measurement. With tokens on M the MMA M tile is
+  64 or 128 rows, so an expert holding three tokens pads to 64. Tokens on N
+  take an 8-wide tile.
+- Prefill: one proxy micro-bench from the 2026-08 quant campaign, tokens on N
+  62.4 us against tokens on M 63.6 us, a tie within noise. Never re-run end
+  to end. The contiguous prefill kernel implements only the tokens-on-N
+  orientation: its segment fold adds a segment base to the token tile index
+  on the scheduler's M axis.
+- Hopper: the wrapper was kept as a fallback in case the 8-wide swapped WGMMA
+  path failed on SM90. It ships.
+
+To re-test tokens on M in a later tuning pass: branch
+`sgl-lora-v2-tokens-on-m-orientation` (commit 184981b256) holds the last tree
+with the wrapper (`grouped_gemm` in `kernels/cutedsl/api.py`, the `swap_ab`
+config field, and the `prepare_masked_bf16` branch that picked shapes and output
+major by it). The kernels still accept `swap_ab=False` for the masked row
+domain, so restoring the host side is enough to sweep decode; a prefill
+comparison would first need the contiguous segment fold written for the
+token-on-M axis. Expect decode to lose by the tile floor; the open question is
+only whether a wide prefill tile prefers tokens on M by more than the 2% seen.

--- a/python/sglang/srt/lora/moe/configs/base_gemm/README.md
+++ b/python/sglang/srt/lora/moe/configs/base_gemm/README.md
@@ -1,0 +1,31 @@
+# MoE LoRA base-GEMM launch-config store
+
+M-bucketed JSON tables consumed by `gemm_config_store.load_config_table`.
+One file per (provider, geometry, device); the provider key names the
+weight dtype, so the file name carries no separate dtype field:
+
+```
+provider={cutedsl_bf16_masked|cutedsl_bf16_contiguous},E={E_local},N1={gate_up_slices*I},N2={H},K={H},device_name={NVIDIA_...}.json
+```
+
+Payload keys are `expected_m` buckets (nearest-M lookup); each bucket payload
+carries `token_width`. The optional `tiles` list declares the tile set to
+compile at attach — one `persistent_clusters` per `token_width`. The
+optional `version` map (e.g. `{"cutedsl": "..."}`) is checked against the
+installed package; a mismatch warns and falls back to the heuristics.
+
+No file, or an invalid file, means the providers use their built-in
+heuristics — byte-identical to a build without this directory.
+
+Generate entries on the target device (do not hand-write):
+
+```
+python benchmark/kernels/lora_moe/sweep_masked_gemm_configs.py \
+    --num-local-experts <E_local> --hidden-size <H> \
+    --intermediate-size <I> --gate-up-slices 2 --top-k <K> \
+    --output-dir python/sglang/srt/lora/moe/configs/base_gemm
+```
+
+`SGLANG_LORA_MOE_CONFIG_DIR` names an override config root at load time;
+tables are read from its `base_gemm/` subdirectory (the layout
+`tune_lora_config.py --sweep` emits).

--- a/python/sglang/srt/lora/moe/configs/base_gemm/README.md
+++ b/python/sglang/srt/lora/moe/configs/base_gemm/README.md
@@ -5,7 +5,7 @@ One file per (provider, geometry, device); the provider key names the
 weight dtype, so the file name carries no separate dtype field:
 
 ```
-provider={cutedsl_bf16_masked|cutedsl_bf16_contiguous},E={E_local},N1={gate_up_slices*I},N2={H},K={H},device_name={NVIDIA_...}.json
+provider={cutedsl_bf16_masked|cutedsl_bf16_contiguous|cutedsl_fp8_masked|cutedsl_fp8_contiguous},E={E_local},N1={gate_up_slices*I},N2={H},K={H},device_name={NVIDIA_...}.json
 ```
 
 Payload keys are `expected_m` buckets (nearest-M lookup); each bucket payload

--- a/python/sglang/srt/lora/moe/configs/base_gemm/provider=cutedsl_fp8_contiguous,E=256,N1=256,N2=2048,K=2048,device_name=NVIDIA_B200.json
+++ b/python/sglang/srt/lora/moe/configs/base_gemm/provider=cutedsl_fp8_contiguous,E=256,N1=256,N2=2048,K=2048,device_name=NVIDIA_B200.json
@@ -1,0 +1,34 @@
+{
+  "version": {
+    "generated_on": "NVIDIA B200",
+    "cutedsl": "4.6.2"
+  },
+  "buckets": {
+    "16": {
+      "token_width": 16
+    },
+    "32": {
+      "token_width": 32
+    },
+    "160": {
+      "token_width": 64
+    },
+    "192": {
+      "token_width": 64
+    }
+  },
+  "tiles": [
+    {
+      "token_width": 16,
+      "persistent_clusters": 148
+    },
+    {
+      "token_width": 32,
+      "persistent_clusters": 148
+    },
+    {
+      "token_width": 64,
+      "persistent_clusters": 128
+    }
+  ]
+}

--- a/python/sglang/srt/lora/moe/configs/base_gemm/provider=cutedsl_fp8_contiguous,E=256,N1=256,N2=2048,K=2048,device_name=NVIDIA_H200.json
+++ b/python/sglang/srt/lora/moe/configs/base_gemm/provider=cutedsl_fp8_contiguous,E=256,N1=256,N2=2048,K=2048,device_name=NVIDIA_H200.json
@@ -1,0 +1,49 @@
+{
+  "version": {
+    "generated_on": "NVIDIA H200",
+    "cutedsl": "4.6.0"
+  },
+  "buckets": {
+    "16": {
+      "token_width": 16
+    },
+    "32": {
+      "token_width": 32
+    },
+    "96": {
+      "token_width": 64
+    },
+    "128": {
+      "token_width": 64
+    },
+    "160": {
+      "token_width": 64
+    },
+    "192": {
+      "token_width": 64
+    },
+    "256": {
+      "token_width": 64
+    },
+    "384": {
+      "token_width": 64
+    },
+    "512": {
+      "token_width": 64
+    }
+  },
+  "tiles": [
+    {
+      "token_width": 16,
+      "persistent_clusters": 132
+    },
+    {
+      "token_width": 32,
+      "persistent_clusters": 132
+    },
+    {
+      "token_width": 64,
+      "persistent_clusters": 128
+    }
+  ]
+}

--- a/python/sglang/srt/lora/moe/configs/base_gemm/provider=cutedsl_fp8_contiguous,E=512,N1=256,N2=4096,K=4096,device_name=NVIDIA_B200.json
+++ b/python/sglang/srt/lora/moe/configs/base_gemm/provider=cutedsl_fp8_contiguous,E=512,N1=256,N2=4096,K=4096,device_name=NVIDIA_B200.json
@@ -1,0 +1,34 @@
+{
+  "version": {
+    "generated_on": "NVIDIA B200",
+    "cutedsl": "4.6.2"
+  },
+  "buckets": {
+    "16": {
+      "token_width": 16
+    },
+    "32": {
+      "token_width": 32
+    },
+    "160": {
+      "token_width": 64
+    },
+    "192": {
+      "token_width": 64
+    }
+  },
+  "tiles": [
+    {
+      "token_width": 16,
+      "persistent_clusters": 148
+    },
+    {
+      "token_width": 32,
+      "persistent_clusters": 148
+    },
+    {
+      "token_width": 64,
+      "persistent_clusters": 128
+    }
+  ]
+}

--- a/python/sglang/srt/lora/moe/configs/base_gemm/provider=cutedsl_fp8_contiguous,E=512,N1=256,N2=4096,K=4096,device_name=NVIDIA_H200.json
+++ b/python/sglang/srt/lora/moe/configs/base_gemm/provider=cutedsl_fp8_contiguous,E=512,N1=256,N2=4096,K=4096,device_name=NVIDIA_H200.json
@@ -1,0 +1,49 @@
+{
+  "version": {
+    "generated_on": "NVIDIA H200",
+    "cutedsl": "4.6.0"
+  },
+  "buckets": {
+    "16": {
+      "token_width": 16
+    },
+    "32": {
+      "token_width": 32
+    },
+    "96": {
+      "token_width": 64
+    },
+    "128": {
+      "token_width": 64
+    },
+    "160": {
+      "token_width": 64
+    },
+    "192": {
+      "token_width": 64
+    },
+    "256": {
+      "token_width": 64
+    },
+    "384": {
+      "token_width": 64
+    },
+    "512": {
+      "token_width": 64
+    }
+  },
+  "tiles": [
+    {
+      "token_width": 16,
+      "persistent_clusters": 132
+    },
+    {
+      "token_width": 32,
+      "persistent_clusters": 132
+    },
+    {
+      "token_width": 64,
+      "persistent_clusters": 128
+    }
+  ]
+}

--- a/python/sglang/srt/lora/moe/configs/base_gemm/provider=cutedsl_fp8_masked,E=256,N1=256,N2=2048,K=2048,device_name=NVIDIA_B200.json
+++ b/python/sglang/srt/lora/moe/configs/base_gemm/provider=cutedsl_fp8_masked,E=256,N1=256,N2=2048,K=2048,device_name=NVIDIA_B200.json
@@ -1,0 +1,48 @@
+{
+  "version": {
+    "generated_on": "NVIDIA B200",
+    "cutedsl": "4.6.2"
+  },
+  "buckets": {
+    "1": {
+      "token_width": 8
+    },
+    "2": {
+      "token_width": 8
+    },
+    "8": {
+      "token_width": 16
+    },
+    "32": {
+      "token_width": 32
+    },
+    "64": {
+      "token_width": 64
+    },
+    "128": {
+      "token_width": 128
+    }
+  },
+  "tiles": [
+    {
+      "token_width": 8,
+      "persistent_clusters": 148
+    },
+    {
+      "token_width": 16,
+      "persistent_clusters": 148
+    },
+    {
+      "token_width": 32,
+      "persistent_clusters": 148
+    },
+    {
+      "token_width": 64,
+      "persistent_clusters": 148
+    },
+    {
+      "token_width": 128,
+      "persistent_clusters": 148
+    }
+  ]
+}

--- a/python/sglang/srt/lora/moe/configs/base_gemm/provider=cutedsl_fp8_masked,E=256,N1=256,N2=2048,K=2048,device_name=NVIDIA_GB300.json
+++ b/python/sglang/srt/lora/moe/configs/base_gemm/provider=cutedsl_fp8_masked,E=256,N1=256,N2=2048,K=2048,device_name=NVIDIA_GB300.json
@@ -1,0 +1,48 @@
+{
+  "version": {
+    "generated_on": "NVIDIA GB300",
+    "cutedsl": "4.6.2"
+  },
+  "buckets": {
+    "1": {
+      "token_width": 8
+    },
+    "2": {
+      "token_width": 8
+    },
+    "8": {
+      "token_width": 16
+    },
+    "32": {
+      "token_width": 32
+    },
+    "64": {
+      "token_width": 64
+    },
+    "128": {
+      "token_width": 128
+    }
+  },
+  "tiles": [
+    {
+      "token_width": 8,
+      "persistent_clusters": 152
+    },
+    {
+      "token_width": 16,
+      "persistent_clusters": 152
+    },
+    {
+      "token_width": 32,
+      "persistent_clusters": 152
+    },
+    {
+      "token_width": 64,
+      "persistent_clusters": 152
+    },
+    {
+      "token_width": 128,
+      "persistent_clusters": 152
+    }
+  ]
+}

--- a/python/sglang/srt/lora/moe/configs/base_gemm/provider=cutedsl_fp8_masked,E=256,N1=256,N2=2048,K=2048,device_name=NVIDIA_H200.json
+++ b/python/sglang/srt/lora/moe/configs/base_gemm/provider=cutedsl_fp8_masked,E=256,N1=256,N2=2048,K=2048,device_name=NVIDIA_H200.json
@@ -1,0 +1,56 @@
+{
+  "version": {
+    "generated_on": "NVIDIA H200",
+    "cutedsl": "4.6.0"
+  },
+  "buckets": {
+    "4": {
+      "token_width": 8
+    },
+    "8": {
+      "token_width": 8
+    },
+    "16": {
+      "token_width": 16
+    },
+    "32": {
+      "token_width": 32
+    },
+    "96": {
+      "token_width": 64
+    },
+    "128": {
+      "token_width": 64
+    },
+    "192": {
+      "token_width": 64
+    },
+    "256": {
+      "token_width": 64
+    },
+    "384": {
+      "token_width": 64
+    },
+    "512": {
+      "token_width": 64
+    }
+  },
+  "tiles": [
+    {
+      "token_width": 8,
+      "persistent_clusters": 128
+    },
+    {
+      "token_width": 16,
+      "persistent_clusters": 128
+    },
+    {
+      "token_width": 32,
+      "persistent_clusters": 128
+    },
+    {
+      "token_width": 64,
+      "persistent_clusters": 128
+    }
+  ]
+}

--- a/python/sglang/srt/lora/moe/configs/base_gemm/provider=cutedsl_fp8_masked,E=512,N1=256,N2=4096,K=4096,device_name=NVIDIA_B200.json
+++ b/python/sglang/srt/lora/moe/configs/base_gemm/provider=cutedsl_fp8_masked,E=512,N1=256,N2=4096,K=4096,device_name=NVIDIA_B200.json
@@ -1,0 +1,44 @@
+{
+  "version": {
+    "generated_on": "NVIDIA B200",
+    "cutedsl": "4.6.2"
+  },
+  "buckets": {
+    "1": {
+      "token_width": 8
+    },
+    "2": {
+      "token_width": 8
+    },
+    "8": {
+      "token_width": 16
+    },
+    "32": {
+      "token_width": 64
+    },
+    "64": {
+      "token_width": 64
+    },
+    "128": {
+      "token_width": 128
+    }
+  },
+  "tiles": [
+    {
+      "token_width": 8,
+      "persistent_clusters": 148
+    },
+    {
+      "token_width": 16,
+      "persistent_clusters": 148
+    },
+    {
+      "token_width": 64,
+      "persistent_clusters": 148
+    },
+    {
+      "token_width": 128,
+      "persistent_clusters": 148
+    }
+  ]
+}

--- a/python/sglang/srt/lora/moe/configs/base_gemm/provider=cutedsl_fp8_masked,E=512,N1=256,N2=4096,K=4096,device_name=NVIDIA_H200.json
+++ b/python/sglang/srt/lora/moe/configs/base_gemm/provider=cutedsl_fp8_masked,E=512,N1=256,N2=4096,K=4096,device_name=NVIDIA_H200.json
@@ -1,0 +1,41 @@
+{
+  "version": {
+    "generated_on": "NVIDIA H200",
+    "cutedsl": "4.6.0"
+  },
+  "buckets": {
+    "4": {
+      "token_width": 8
+    },
+    "8": {
+      "token_width": 8
+    },
+    "16": {
+      "token_width": 16
+    },
+    "32": {
+      "token_width": 32
+    },
+    "96": {
+      "token_width": 64
+    }
+  },
+  "tiles": [
+    {
+      "token_width": 8,
+      "persistent_clusters": 128
+    },
+    {
+      "token_width": 16,
+      "persistent_clusters": 128
+    },
+    {
+      "token_width": 32,
+      "persistent_clusters": 128
+    },
+    {
+      "token_width": 64,
+      "persistent_clusters": 128
+    }
+  ]
+}

--- a/python/sglang/srt/lora/moe/configs/base_gemm/provider=cutedsl_fp8_masked,E=512,N1=512,N2=4096,K=4096,device_name=NVIDIA_GB300.json
+++ b/python/sglang/srt/lora/moe/configs/base_gemm/provider=cutedsl_fp8_masked,E=512,N1=512,N2=4096,K=4096,device_name=NVIDIA_GB300.json
@@ -1,0 +1,44 @@
+{
+  "version": {
+    "generated_on": "NVIDIA GB300",
+    "cutedsl": "4.6.2"
+  },
+  "buckets": {
+    "1": {
+      "token_width": 8
+    },
+    "2": {
+      "token_width": 8
+    },
+    "8": {
+      "token_width": 16
+    },
+    "32": {
+      "token_width": 64
+    },
+    "64": {
+      "token_width": 64
+    },
+    "128": {
+      "token_width": 128
+    }
+  },
+  "tiles": [
+    {
+      "token_width": 8,
+      "persistent_clusters": 152
+    },
+    {
+      "token_width": 16,
+      "persistent_clusters": 152
+    },
+    {
+      "token_width": 64,
+      "persistent_clusters": 152
+    },
+    {
+      "token_width": 128,
+      "persistent_clusters": 152
+    }
+  ]
+}

--- a/python/sglang/srt/lora/moe/configs/default.plans.json
+++ b/python/sglang/srt/lora/moe/configs/default.plans.json
@@ -1,51 +1,63 @@
 {
- "arch": "default",
- "domain": {
-  "max_hidden": 0,
-  "max_local_experts": 0
- },
- "scenarios": [],
- "fallback": [
-  {
-   "name": "fallback.decode",
-   "phase": "decode",
-   "base_gemm_rows": "expert_major",
-   "plan": {
-    "gate_up_a_family": "grouped",
-    "down_a_family": "grouped",
-    "gate_up_b_family": "grouped",
-    "down_b_family": "grouped",
-    "act_family": "materialized",
-    "finalize_family": "materialized"
-   }
+  "arch": "default",
+  "domain": {
+    "max_hidden": 0,
+    "max_local_experts": 0
   },
-  {
-   "name": "fallback.prefill.per_expert",
-   "layout": "per_expert",
-   "phase": "prefill",
-   "base_gemm_rows": "route_major",
-   "plan": {
-    "gate_up_a_family": "grouped",
-    "down_a_family": "grouped",
-    "down_b_family": "grouped",
-    "act_family": "b_activation",
-    "finalize_family": "materialized",
-    "down_b_into_base": true
-   }
-  },
-  {
-   "name": "fallback.prefill.shared",
-   "layout": "shared",
-   "phase": "prefill",
-   "base_gemm_rows": "expert_major",
-   "plan": {
-    "gate_up_a_family": "grouped",
-    "down_a_family": "grouped",
-    "down_b_family": "grouped",
-    "act_family": "b_activation",
-    "finalize_family": "materialized",
-    "down_b_into_base": true
-   }
-  }
- ]
+  "scenarios": [],
+  "fallback": [
+    {
+      "name": "fallback.decode.shared",
+      "layout": "shared",
+      "phase": "decode",
+      "base_gemm_rows": "expert_major",
+      "plan": {
+        "gate_up_a_family": "grouped",
+        "down_a_family": "grouped",
+        "gate_up_b_family": "grouped",
+        "act_family": "materialized",
+        "finalize_family": "shared_one_pass"
+      }
+    },
+    {
+      "name": "fallback.decode",
+      "phase": "decode",
+      "base_gemm_rows": "expert_major",
+      "plan": {
+        "gate_up_a_family": "grouped",
+        "down_a_family": "grouped",
+        "gate_up_b_family": "grouped",
+        "down_b_family": "grouped",
+        "act_family": "materialized",
+        "finalize_family": "materialized"
+      }
+    },
+    {
+      "name": "fallback.prefill.per_expert",
+      "layout": "per_expert",
+      "phase": "prefill",
+      "base_gemm_rows": "route_major",
+      "plan": {
+        "gate_up_a_family": "grouped",
+        "down_a_family": "grouped",
+        "down_b_family": "grouped",
+        "act_family": "b_activation",
+        "finalize_family": "materialized",
+        "down_b_into_base": true
+      }
+    },
+    {
+      "name": "fallback.prefill.shared",
+      "layout": "shared",
+      "phase": "prefill",
+      "base_gemm_rows": "route_major",
+      "plan": {
+        "gate_up_a_family": "token_grouped",
+        "down_a_family": "grouped",
+        "act_family": "b_activation",
+        "finalize_family": "shared_token_delta",
+        "route_builder": "parallel_shared_outer"
+      }
+    }
+  ]
 }

--- a/python/sglang/srt/lora/moe/configs/default.plans.json
+++ b/python/sglang/srt/lora/moe/configs/default.plans.json
@@ -1,0 +1,51 @@
+{
+ "arch": "default",
+ "domain": {
+  "max_hidden": 0,
+  "max_local_experts": 0
+ },
+ "scenarios": [],
+ "fallback": [
+  {
+   "name": "fallback.decode",
+   "phase": "decode",
+   "base_gemm_rows": "expert_major",
+   "plan": {
+    "gate_up_a_family": "grouped",
+    "down_a_family": "grouped",
+    "gate_up_b_family": "grouped",
+    "down_b_family": "grouped",
+    "act_family": "materialized",
+    "finalize_family": "materialized"
+   }
+  },
+  {
+   "name": "fallback.prefill.per_expert",
+   "layout": "per_expert",
+   "phase": "prefill",
+   "base_gemm_rows": "route_major",
+   "plan": {
+    "gate_up_a_family": "grouped",
+    "down_a_family": "grouped",
+    "down_b_family": "grouped",
+    "act_family": "b_activation",
+    "finalize_family": "materialized",
+    "down_b_into_base": true
+   }
+  },
+  {
+   "name": "fallback.prefill.shared",
+   "layout": "shared",
+   "phase": "prefill",
+   "base_gemm_rows": "expert_major",
+   "plan": {
+    "gate_up_a_family": "grouped",
+    "down_a_family": "grouped",
+    "down_b_family": "grouped",
+    "act_family": "b_activation",
+    "finalize_family": "materialized",
+    "down_b_into_base": true
+   }
+  }
+ ]
+}

--- a/python/sglang/srt/lora/moe/configs/default.tiles.json
+++ b/python/sglang/srt/lora/moe/configs/default.tiles.json
@@ -1,0 +1,137 @@
+{
+ "arch": "default",
+ "rules": {
+  "fallback.decode": [
+   {
+    "sites": {
+     "b_activation": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_W": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 3,
+      "num_warps": 4
+     },
+     "down_a": {
+      "BLOCK_SIZE_K": 64,
+      "BLOCK_SIZE_N": 32,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "down_b": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "gate_up_a": {
+      "BLOCK_SIZE_K": 64,
+      "BLOCK_SIZE_N": 32,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "gate_up_b": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "routing_block_size": 16
+    }
+   }
+  ],
+  "fallback.prefill.per_expert": [
+   {
+    "sites": {
+     "b_activation": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_W": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 3,
+      "num_warps": 4
+     },
+     "down_a": {
+      "BLOCK_SIZE_K": 64,
+      "BLOCK_SIZE_N": 32,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "down_b": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "gate_up_a": {
+      "BLOCK_SIZE_K": 64,
+      "BLOCK_SIZE_N": 32,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "gate_up_b": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "routing_block_size": 16
+    }
+   }
+  ],
+  "fallback.prefill.shared": [
+   {
+    "sites": {
+     "b_activation": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_W": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 3,
+      "num_warps": 4
+     },
+     "down_a": {
+      "BLOCK_SIZE_K": 64,
+      "BLOCK_SIZE_N": 32,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "down_b": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "gate_up_a": {
+      "BLOCK_SIZE_K": 64,
+      "BLOCK_SIZE_N": 32,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "gate_up_b": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "routing_block_size": 16
+    }
+   }
+  ]
+ }
+}

--- a/python/sglang/srt/lora/moe/configs/default.tiles.json
+++ b/python/sglang/srt/lora/moe/configs/default.tiles.json
@@ -45,6 +45,55 @@
     }
    }
   ],
+  "fallback.decode.shared": [
+   {
+    "sites": {
+     "b_activation": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_W": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 3,
+      "num_warps": 4
+     },
+     "down_a": {
+      "BLOCK_SIZE_K": 64,
+      "BLOCK_SIZE_N": 32,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "down_b": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "gate_up_a": {
+      "BLOCK_SIZE_K": 64,
+      "BLOCK_SIZE_N": 32,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "gate_up_b": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "routing_block_size": 16,
+     "shared_one_pass": {
+      "BLOCK_SIZE_H": 128,
+      "num_stages": 3,
+      "num_warps": 4
+     }
+    }
+   }
+  ],
   "fallback.prefill.per_expert": [
    {
     "sites": {
@@ -129,7 +178,19 @@
       "num_stages": 2,
       "num_warps": 4
      },
-     "routing_block_size": 16
+     "routing_block_size": 16,
+     "shared_token_delta": {
+      "reduce": {
+       "BLOCK_SIZE_T": 32,
+       "num_stages": 2,
+       "num_warps": 4
+      },
+      "tail": {
+       "BLOCK_SIZE_H": 128,
+       "num_stages": 3,
+       "num_warps": 4
+      }
+     }
     }
    }
   ]

--- a/python/sglang/srt/lora/moe/configs/gb300.plans.json
+++ b/python/sglang/srt/lora/moe/configs/gb300.plans.json
@@ -1,0 +1,162 @@
+{
+ "arch": "gb300",
+ "domain": {
+  "max_hidden": 4096,
+  "max_local_experts": 512
+ },
+ "scenarios": [
+  {
+   "name": "decode.per_expert",
+   "layout": "per_expert",
+   "phase": "decode",
+   "base_gemm_rows": "expert_major",
+   "plan": {
+    "gate_up_a_family": "grouped",
+    "down_a_family": "grouped",
+    "gate_up_b_family": "per_pair",
+    "down_b_family": "per_pair",
+    "act_family": "materialized",
+    "finalize_family": "materialized",
+    "gate_up_overlap": "gate_up_a_b",
+    "down_overlap": "down_a_b"
+   }
+  },
+  {
+   "name": "prefill.per_expert.rank_le16",
+   "layout": "per_expert",
+   "phase": "prefill",
+   "base_gemm_rows": "route_major",
+   "plan": {
+    "gate_up_a_family": "grouped",
+    "down_a_family": "grouped",
+    "down_b_family": "grouped",
+    "act_family": "b_activation",
+    "finalize_family": "materialized",
+    "down_b_into_base": true
+   },
+   "max_rank": 16
+  },
+  {
+   "name": "prefill.per_expert.rank_le32",
+   "layout": "per_expert",
+   "phase": "prefill",
+   "base_gemm_rows": "route_major",
+   "plan": {
+    "gate_up_a_family": "grouped",
+    "down_a_family": "grouped",
+    "down_b_family": "grouped",
+    "act_family": "b_activation",
+    "finalize_family": "materialized",
+    "down_b_into_base": true
+   },
+   "max_rank": 32
+  },
+  {
+   "name": "prefill.per_expert",
+   "layout": "per_expert",
+   "phase": "prefill",
+   "base_gemm_rows": "route_major",
+   "plan": {
+    "gate_up_a_family": "grouped",
+    "down_a_family": "grouped",
+    "down_b_family": "grouped",
+    "act_family": "b_activation",
+    "finalize_family": "materialized",
+    "down_b_into_base": true
+   }
+  },
+  {
+   "name": "decode.shared",
+   "layout": "shared",
+   "phase": "decode",
+   "base_gemm_rows": "expert_major",
+   "plan": {
+    "gate_up_a_family": "grouped",
+    "down_a_family": "grouped",
+    "gate_up_b_family": "grouped",
+    "down_b_family": "grouped",
+    "act_family": "materialized",
+    "finalize_family": "materialized",
+    "gate_up_overlap": "gate_up_a_b",
+    "down_overlap": "down_a_b",
+    "route_builder": "parallel_shared_outer"
+   }
+  },
+  {
+   "name": "prefill.shared.rank_le32",
+   "layout": "shared",
+   "phase": "prefill",
+   "base_gemm_rows": "route_major",
+   "plan": {
+    "gate_up_a_family": "token_grouped",
+    "down_a_family": "grouped",
+    "down_b_family": "grouped",
+    "act_family": "b_activation",
+    "finalize_family": "materialized",
+    "route_builder": "parallel_shared_outer",
+    "down_b_into_base": true
+   },
+   "max_rank": 32
+  },
+  {
+   "name": "prefill.shared",
+   "layout": "shared",
+   "phase": "prefill",
+   "base_gemm_rows": "route_major",
+   "plan": {
+    "gate_up_a_family": "token_grouped",
+    "down_a_family": "grouped",
+    "down_b_family": "grouped",
+    "act_family": "b_activation",
+    "finalize_family": "materialized",
+    "route_builder": "parallel_shared_outer",
+    "down_b_into_base": true
+   }
+  }
+ ],
+ "fallback": [
+  {
+   "name": "fallback.decode",
+   "phase": "decode",
+   "base_gemm_rows": "expert_major",
+   "plan": {
+    "gate_up_a_family": "per_pair",
+    "down_a_family": "grouped",
+    "gate_up_b_family": "grouped",
+    "down_b_family": "grouped",
+    "act_family": "materialized",
+    "finalize_family": "materialized",
+    "down_overlap": "down_a_b",
+    "gate_up_overlap": "gate_up_a_b"
+   }
+  },
+  {
+   "name": "fallback.prefill.per_expert",
+   "layout": "per_expert",
+   "phase": "prefill",
+   "base_gemm_rows": "route_major",
+   "plan": {
+    "gate_up_a_family": "grouped",
+    "down_a_family": "grouped",
+    "down_b_family": "grouped",
+    "act_family": "b_activation",
+    "finalize_family": "materialized",
+    "down_b_into_base": true
+   }
+  },
+  {
+   "name": "fallback.prefill.shared",
+   "layout": "shared",
+   "phase": "prefill",
+   "base_gemm_rows": "expert_major",
+   "plan": {
+    "gate_up_a_family": "grouped",
+    "down_a_family": "grouped",
+    "down_b_family": "grouped",
+    "act_family": "b_activation",
+    "finalize_family": "materialized",
+    "down_b_into_base": true
+   }
+  }
+ ]
+}

--- a/python/sglang/srt/lora/moe/configs/gb300.plans.json
+++ b/python/sglang/srt/lora/moe/configs/gb300.plans.json
@@ -1,7 +1,7 @@
 {
  "arch": "gb300",
  "domain": {
-  "max_hidden": 4096,
+  "max_hidden": 8192,
   "max_local_experts": 512
  },
  "scenarios": [
@@ -66,6 +66,44 @@
    }
   },
   {
+   "name": "decode.shared.fp8.e_ge512",
+   "layout": "shared",
+   "phase": "decode",
+   "min_local_experts": 512,
+   "quant": [
+    "fp8"
+   ],
+   "base_gemm_rows": "expert_major",
+   "plan": {
+    "gate_up_a_family": "grouped",
+    "down_a_family": "grouped",
+    "act_family": "b_activation",
+    "finalize_family": "shared_one_pass",
+    "gate_up_overlap": "gate_up_a",
+    "down_overlap": "down_a",
+    "route_builder": "parallel_shared_outer"
+   }
+  },
+  {
+   "name": "decode.shared.nvfp4",
+   "layout": "shared",
+   "phase": "decode",
+   "quant": [
+    "nvfp4"
+   ],
+   "base_gemm_rows": "expert_major",
+   "plan": {
+    "gate_up_a_family": "token_dense",
+    "gate_up_b_family": "per_pair",
+    "down_a_family": "per_pair",
+    "act_family": "materialized",
+    "finalize_family": "shared_one_pass",
+    "gate_up_overlap": "gate_up_a_b",
+    "down_overlap": "down_a",
+    "route_builder": "standard"
+   }
+  },
+  {
    "name": "decode.shared",
    "layout": "shared",
    "phase": "decode",
@@ -74,11 +112,10 @@
     "gate_up_a_family": "grouped",
     "down_a_family": "grouped",
     "gate_up_b_family": "grouped",
-    "down_b_family": "grouped",
     "act_family": "materialized",
-    "finalize_family": "materialized",
+    "finalize_family": "shared_one_pass",
     "gate_up_overlap": "gate_up_a_b",
-    "down_overlap": "down_a_b",
+    "down_overlap": "down_a",
     "route_builder": "parallel_shared_outer"
    }
   },
@@ -90,11 +127,9 @@
    "plan": {
     "gate_up_a_family": "token_grouped",
     "down_a_family": "grouped",
-    "down_b_family": "grouped",
     "act_family": "b_activation",
-    "finalize_family": "materialized",
-    "route_builder": "parallel_shared_outer",
-    "down_b_into_base": true
+    "finalize_family": "shared_token_delta",
+    "route_builder": "parallel_shared_outer"
    },
    "max_rank": 32
   },
@@ -106,15 +141,29 @@
    "plan": {
     "gate_up_a_family": "token_grouped",
     "down_a_family": "grouped",
-    "down_b_family": "grouped",
     "act_family": "b_activation",
-    "finalize_family": "materialized",
-    "route_builder": "parallel_shared_outer",
-    "down_b_into_base": true
+    "finalize_family": "shared_token_delta",
+    "route_builder": "parallel_shared_outer"
    }
   }
  ],
  "fallback": [
+  {
+   "name": "fallback.decode.shared",
+   "layout": "shared",
+   "phase": "decode",
+   "base_gemm_rows": "expert_major",
+   "plan": {
+    "gate_up_a_family": "grouped",
+    "down_a_family": "grouped",
+    "gate_up_b_family": "grouped",
+    "act_family": "materialized",
+    "finalize_family": "shared_one_pass",
+    "gate_up_overlap": "gate_up_a_b",
+    "down_overlap": "down_a",
+    "route_builder": "parallel_shared_outer"
+   }
+  },
   {
    "name": "fallback.decode",
    "phase": "decode",
@@ -148,14 +197,13 @@
    "name": "fallback.prefill.shared",
    "layout": "shared",
    "phase": "prefill",
-   "base_gemm_rows": "expert_major",
+   "base_gemm_rows": "route_major",
    "plan": {
-    "gate_up_a_family": "grouped",
+    "gate_up_a_family": "token_grouped",
     "down_a_family": "grouped",
-    "down_b_family": "grouped",
     "act_family": "b_activation",
-    "finalize_family": "materialized",
-    "down_b_into_base": true
+    "finalize_family": "shared_token_delta",
+    "route_builder": "parallel_shared_outer"
    }
   }
  ]

--- a/python/sglang/srt/lora/moe/configs/gb300.tiles.json
+++ b/python/sglang/srt/lora/moe/configs/gb300.tiles.json
@@ -373,7 +373,12 @@
       "num_stages": 2,
       "num_warps": 4
      },
-     "routing_block_size": 16
+     "routing_block_size": 16,
+     "shared_one_pass": {
+      "BLOCK_SIZE_H": 128,
+      "num_stages": 3,
+      "num_warps": 4
+     }
     }
    }
   ],
@@ -416,7 +421,19 @@
       "num_stages": 2,
       "num_warps": 4
      },
-     "routing_block_size": 32
+     "routing_block_size": 32,
+     "shared_token_delta": {
+      "reduce": {
+       "BLOCK_SIZE_T": 32,
+       "num_stages": 2,
+       "num_warps": 4
+      },
+      "tail": {
+       "BLOCK_SIZE_H": 1024,
+       "num_stages": 2,
+       "num_warps": 8
+      }
+     }
     }
    }
   ],
@@ -459,7 +476,68 @@
       "num_stages": 2,
       "num_warps": 4
      },
-     "routing_block_size": 32
+     "routing_block_size": 32,
+     "shared_token_delta": {
+      "reduce": {
+       "BLOCK_SIZE_T": 32,
+       "num_stages": 2,
+       "num_warps": 4
+      },
+      "tail": {
+       "BLOCK_SIZE_H": 1024,
+       "num_stages": 2,
+       "num_warps": 8
+      }
+     }
+    }
+   }
+  ],
+  "fallback.decode.shared": [
+   {
+    "sites": {
+     "b_activation": {
+      "BLOCK_SIZE_K": 64,
+      "BLOCK_SIZE_W": 64,
+      "GROUP_SIZE_M": 1,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "down_a": {
+      "BLOCK_SIZE_K": 128,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 4,
+      "num_warps": 4
+     },
+     "down_b": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "gate_up_a": {
+      "BLOCK_SIZE_K": 128,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 4,
+      "num_warps": 4
+     },
+     "gate_up_b": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "routing_block_size": 16,
+     "shared_one_pass": {
+      "BLOCK_SIZE_H": 128,
+      "num_stages": 3,
+      "num_warps": 4
+     }
     }
    }
   ],
@@ -591,7 +669,117 @@
       "num_stages": 2,
       "num_warps": 4
      },
-     "routing_block_size": 32
+     "routing_block_size": 32,
+     "shared_token_delta": {
+      "reduce": {
+       "BLOCK_SIZE_T": 32,
+       "num_stages": 2,
+       "num_warps": 4
+      },
+      "tail": {
+       "BLOCK_SIZE_H": 1024,
+       "num_stages": 2,
+       "num_warps": 8
+      }
+     }
+    }
+   }
+  ],
+  "decode.shared.fp8.e_ge512": [
+   {
+    "sites": {
+     "b_activation": {
+      "BLOCK_SIZE_K": 64,
+      "BLOCK_SIZE_W": 64,
+      "GROUP_SIZE_M": 1,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "down_a": {
+      "BLOCK_SIZE_K": 128,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 4,
+      "num_warps": 4
+     },
+     "down_b": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "gate_up_a": {
+      "BLOCK_SIZE_K": 128,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 4,
+      "num_warps": 4
+     },
+     "gate_up_b": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "routing_block_size": 16,
+     "shared_one_pass": {
+      "BLOCK_SIZE_H": 128,
+      "num_stages": 3,
+      "num_warps": 4
+     }
+    }
+   }
+  ],
+  "decode.shared.nvfp4": [
+   {
+    "sites": {
+     "b_activation": {
+      "BLOCK_SIZE_K": 64,
+      "BLOCK_SIZE_W": 64,
+      "GROUP_SIZE_M": 1,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "down_a": {
+      "BLOCK_SIZE_K": 128,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 4,
+      "num_warps": 4
+     },
+     "down_b": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "gate_up_a": {
+      "BLOCK_SIZE_K": 128,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 4,
+      "num_warps": 4
+     },
+     "gate_up_b": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "routing_block_size": 16,
+     "shared_one_pass": {
+      "BLOCK_SIZE_H": 128,
+      "num_stages": 2,
+      "num_warps": 4
+     }
     }
    }
   ]

--- a/python/sglang/srt/lora/moe/configs/gb300.tiles.json
+++ b/python/sglang/srt/lora/moe/configs/gb300.tiles.json
@@ -1,0 +1,599 @@
+{
+ "arch": "gb300",
+ "rules": {
+  "decode.per_expert": [
+   {
+    "max_rank": 16,
+    "sites": {
+     "b_activation": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_W": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "down_a": {
+      "BLOCK_SIZE_K": 128,
+      "BLOCK_SIZE_N": 16,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 4,
+      "num_warps": 4
+     },
+     "down_b": {
+      "BLOCK_SIZE_K": 16,
+      "BLOCK_SIZE_N": 256,
+      "GROUP_SIZE_M": 1,
+      "num_stages": 2,
+      "num_warps": 8
+     },
+     "gate_up_a": {
+      "BLOCK_SIZE_K": 128,
+      "BLOCK_SIZE_N": 16,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 3,
+      "num_warps": 4
+     },
+     "gate_up_b": {
+      "BLOCK_SIZE_K": 16,
+      "BLOCK_SIZE_N": 128,
+      "GROUP_SIZE_M": 4,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "routing_block_size": 16
+    }
+   },
+   {
+    "max_tokens": 4,
+    "sites": {
+     "b_activation": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_W": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "down_a": {
+      "BLOCK_SIZE_K": 128,
+      "BLOCK_SIZE_N": 16,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 4,
+      "num_warps": 4
+     },
+     "down_b": {
+      "BLOCK_SIZE_K": 16,
+      "BLOCK_SIZE_N": 256,
+      "GROUP_SIZE_M": 1,
+      "num_stages": 2,
+      "num_warps": 8
+     },
+     "gate_up_a": {
+      "BLOCK_SIZE_K": 128,
+      "BLOCK_SIZE_N": 16,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 3,
+      "num_warps": 4
+     },
+     "gate_up_b": {
+      "BLOCK_SIZE_K": 16,
+      "BLOCK_SIZE_N": 128,
+      "GROUP_SIZE_M": 4,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "routing_block_size": 16
+    }
+   },
+   {
+    "max_tokens": 16,
+    "sites": {
+     "b_activation": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_W": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "down_a": {
+      "BLOCK_SIZE_K": 128,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 3,
+      "num_warps": 8
+     },
+     "down_b": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_N": 128,
+      "GROUP_SIZE_M": 1,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "gate_up_a": {
+      "BLOCK_SIZE_K": 128,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 4,
+      "num_warps": 4
+     },
+     "gate_up_b": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_N": 512,
+      "GROUP_SIZE_M": 4,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "routing_block_size": 16
+    }
+   },
+   {
+    "max_rank": 32,
+    "sites": {
+     "b_activation": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_W": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "down_a": {
+      "BLOCK_SIZE_K": 128,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 3,
+      "num_warps": 8
+     },
+     "down_b": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_N": 128,
+      "GROUP_SIZE_M": 1,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "gate_up_a": {
+      "BLOCK_SIZE_K": 128,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 4,
+      "num_warps": 4
+     },
+     "gate_up_b": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_N": 512,
+      "GROUP_SIZE_M": 4,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "routing_block_size": 16
+    }
+   },
+   {
+    "sites": {
+     "b_activation": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_W": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "down_a": {
+      "BLOCK_SIZE_K": 128,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 4,
+      "num_warps": 8
+     },
+     "down_b": {
+      "BLOCK_SIZE_K": 64,
+      "BLOCK_SIZE_N": 256,
+      "GROUP_SIZE_M": 4,
+      "num_stages": 2,
+      "num_warps": 8
+     },
+     "gate_up_a": {
+      "BLOCK_SIZE_K": 64,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 4,
+      "num_warps": 4
+     },
+     "gate_up_b": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_N": 256,
+      "GROUP_SIZE_M": 16,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "routing_block_size": 16
+    }
+   }
+  ],
+  "prefill.per_expert.rank_le16": [
+   {
+    "sites": {
+     "b_activation": {
+      "BLOCK_SIZE_K": 16,
+      "BLOCK_SIZE_W": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "down_a": {
+      "BLOCK_SIZE_K": 128,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "down_b": {
+      "BLOCK_SIZE_K": 16,
+      "BLOCK_SIZE_N": 128,
+      "GROUP_SIZE_M": 16,
+      "num_stages": 2,
+      "num_warps": 2
+     },
+     "gate_up_a": {
+      "BLOCK_SIZE_K": 64,
+      "BLOCK_SIZE_N": 16,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 3,
+      "num_warps": 2
+     },
+     "gate_up_b": {
+      "BLOCK_SIZE_K": 64,
+      "BLOCK_SIZE_N": 128,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "routing_block_size": 32
+    }
+   }
+  ],
+  "prefill.per_expert.rank_le32": [
+   {
+    "sites": {
+     "b_activation": {
+      "BLOCK_SIZE_K": 16,
+      "BLOCK_SIZE_W": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "down_a": {
+      "BLOCK_SIZE_K": 128,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "down_b": {
+      "BLOCK_SIZE_K": 16,
+      "BLOCK_SIZE_N": 128,
+      "GROUP_SIZE_M": 16,
+      "num_stages": 2,
+      "num_warps": 2
+     },
+     "gate_up_a": {
+      "BLOCK_SIZE_K": 64,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 3,
+      "num_warps": 1
+     },
+     "gate_up_b": {
+      "BLOCK_SIZE_K": 64,
+      "BLOCK_SIZE_N": 128,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "routing_block_size": 32
+    }
+   }
+  ],
+  "prefill.per_expert": [
+   {
+    "sites": {
+     "b_activation": {
+      "BLOCK_SIZE_K": 16,
+      "BLOCK_SIZE_W": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "down_a": {
+      "BLOCK_SIZE_K": 128,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "down_b": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_N": 128,
+      "GROUP_SIZE_M": 16,
+      "num_stages": 2,
+      "num_warps": 2
+     },
+     "gate_up_a": {
+      "BLOCK_SIZE_K": 64,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 3,
+      "num_warps": 1
+     },
+     "gate_up_b": {
+      "BLOCK_SIZE_K": 64,
+      "BLOCK_SIZE_N": 128,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "routing_block_size": 32
+    }
+   }
+  ],
+  "decode.shared": [
+   {
+    "sites": {
+     "b_activation": {
+      "BLOCK_SIZE_K": 64,
+      "BLOCK_SIZE_W": 64,
+      "GROUP_SIZE_M": 1,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "down_a": {
+      "BLOCK_SIZE_K": 128,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 4,
+      "num_warps": 4
+     },
+     "down_b": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "gate_up_a": {
+      "BLOCK_SIZE_K": 128,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 4,
+      "num_warps": 4
+     },
+     "gate_up_b": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "routing_block_size": 16
+    }
+   }
+  ],
+  "prefill.shared.rank_le32": [
+   {
+    "sites": {
+     "b_activation": {
+      "BLOCK_SIZE_K": 16,
+      "BLOCK_SIZE_W": 128,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 4,
+      "num_warps": 4
+     },
+     "down_a": {
+      "BLOCK_SIZE_K": 64,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 3,
+      "num_warps": 4
+     },
+     "down_b": {
+      "BLOCK_SIZE_K": 16,
+      "BLOCK_SIZE_N": 256,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 2
+     },
+     "gate_up_a": {
+      "BLOCK_SIZE_K": 128,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 4,
+      "num_warps": 4
+     },
+     "gate_up_b": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_M": 32,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "routing_block_size": 32
+    }
+   }
+  ],
+  "prefill.shared": [
+   {
+    "sites": {
+     "b_activation": {
+      "BLOCK_SIZE_K": 16,
+      "BLOCK_SIZE_W": 128,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 4,
+      "num_warps": 4
+     },
+     "down_a": {
+      "BLOCK_SIZE_K": 64,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 3,
+      "num_warps": 4
+     },
+     "down_b": {
+      "BLOCK_SIZE_K": 64,
+      "BLOCK_SIZE_N": 256,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 2
+     },
+     "gate_up_a": {
+      "BLOCK_SIZE_K": 128,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 4,
+      "num_warps": 4
+     },
+     "gate_up_b": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_M": 32,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "routing_block_size": 32
+    }
+   }
+  ],
+  "fallback.decode": [
+   {
+    "sites": {
+     "b_activation": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_W": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 3,
+      "num_warps": 4
+     },
+     "down_a": {
+      "BLOCK_SIZE_K": 64,
+      "BLOCK_SIZE_N": 32,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 4,
+      "num_warps": 4
+     },
+     "down_b": {
+      "BLOCK_SIZE_K": 16,
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 128,
+      "GROUP_SIZE_M": 1,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "gate_up_a": {
+      "BLOCK_SIZE_K": 128,
+      "BLOCK_SIZE_N": 32,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 4,
+      "num_warps": 4
+     },
+     "gate_up_b": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "routing_block_size": 16
+    }
+   }
+  ],
+  "fallback.prefill.per_expert": [
+   {
+    "sites": {
+     "b_activation": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_W": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 3,
+      "num_warps": 4
+     },
+     "down_a": {
+      "BLOCK_SIZE_K": 64,
+      "BLOCK_SIZE_N": 32,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "down_b": {
+      "BLOCK_SIZE_K": 16,
+      "BLOCK_SIZE_M": 32,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "gate_up_a": {
+      "BLOCK_SIZE_K": 64,
+      "BLOCK_SIZE_N": 32,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "gate_up_b": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_M": 32,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "routing_block_size": 32
+    }
+   }
+  ],
+  "fallback.prefill.shared": [
+   {
+    "sites": {
+     "b_activation": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_W": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 3,
+      "num_warps": 4
+     },
+     "down_a": {
+      "BLOCK_SIZE_K": 64,
+      "BLOCK_SIZE_N": 32,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "down_b": {
+      "BLOCK_SIZE_K": 16,
+      "BLOCK_SIZE_M": 32,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "gate_up_a": {
+      "BLOCK_SIZE_K": 64,
+      "BLOCK_SIZE_N": 32,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "gate_up_b": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_M": 32,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "routing_block_size": 32
+    }
+   }
+  ]
+ }
+}

--- a/python/sglang/srt/lora/moe/configs/h200.plans.json
+++ b/python/sglang/srt/lora/moe/configs/h200.plans.json
@@ -1,190 +1,200 @@
 {
- "arch": "h200",
- "domain": {
-  "max_hidden": 4096,
-  "max_local_experts": 512
- },
- "scenarios": [
-  {
-   "name": "decode.per_expert",
-   "layout": "per_expert",
-   "phase": "decode",
-   "base_gemm_rows": "expert_major",
-   "plan": {
-    "gate_up_a_family": "grouped",
-    "down_a_family": "per_pair",
-    "gate_up_b_family": "grouped",
-    "down_b_family": "grouped",
-    "act_family": "materialized",
-    "finalize_family": "materialized",
-    "gate_up_overlap": "gate_up_a_b",
-    "down_overlap": "down_a_b"
-   }
+  "arch": "h200",
+  "domain": {
+    "max_hidden": 4096,
+    "max_local_experts": 512
   },
-  {
-   "name": "prefill.per_expert.rank_le16",
-   "layout": "per_expert",
-   "phase": "prefill",
-   "base_gemm_rows": "route_major",
-   "plan": {
-    "gate_up_a_family": "grouped",
-    "down_a_family": "grouped",
-    "down_b_family": "grouped",
-    "act_family": "b_activation",
-    "finalize_family": "materialized",
-    "down_b_into_base": true,
-    "gate_up_overlap": "gate_up_a"
-   },
-   "max_rank": 16
-  },
-  {
-   "name": "prefill.per_expert.rank_le32",
-   "layout": "per_expert",
-   "phase": "prefill",
-   "base_gemm_rows": "route_major",
-   "plan": {
-    "gate_up_a_family": "grouped",
-    "down_a_family": "grouped",
-    "down_b_family": "grouped",
-    "act_family": "b_activation",
-    "finalize_family": "materialized",
-    "down_b_into_base": true
-   },
-   "max_rank": 32
-  },
-  {
-   "name": "prefill.per_expert",
-   "layout": "per_expert",
-   "phase": "prefill",
-   "base_gemm_rows": "route_major",
-   "plan": {
-    "gate_up_a_family": "grouped",
-    "down_a_family": "grouped",
-    "down_b_family": "grouped",
-    "act_family": "b_activation",
-    "finalize_family": "materialized",
-    "down_b_into_base": true
-   }
-  },
-  {
-   "name": "decode.shared",
-   "layout": "shared",
-   "phase": "decode",
-   "base_gemm_rows": "expert_major",
-   "plan": {
-    "gate_up_a_family": "grouped",
-    "down_a_family": "grouped",
-    "gate_up_b_family": "grouped",
-    "down_b_family": "grouped",
-    "act_family": "materialized",
-    "finalize_family": "materialized",
-    "gate_up_overlap": "gate_up_a_b",
-    "down_overlap": "down_a_b",
-    "route_builder": "parallel_shared_outer"
-   }
-  },
-  {
-   "name": "prefill.shared.rank_le8",
-   "layout": "shared",
-   "phase": "prefill",
-   "max_rank": 8,
-   "base_gemm_rows": "route_major",
-   "plan": {
-    "gate_up_a_family": "token_grouped",
-    "down_a_family": "grouped",
-    "down_b_family": "grouped",
-    "act_family": "b_activation",
-    "finalize_family": "materialized",
-    "route_builder": "parallel_shared_outer",
-    "down_b_into_base": true
-   }
-  },
-  {
-   "name": "prefill.shared.rank_le16",
-   "layout": "shared",
-   "phase": "prefill",
-   "max_rank": 16,
-   "base_gemm_rows": "route_major",
-   "plan": {
-    "gate_up_a_family": "token_grouped",
-    "down_a_family": "grouped",
-    "act_family": "b_activation",
-    "finalize_family": "shared_rank_reduce",
-    "gate_up_overlap": "gate_up_a"
-   }
-  },
-  {
-   "name": "prefill.shared.rank_le64",
-   "layout": "shared",
-   "phase": "prefill",
-   "max_rank": 64,
-   "base_gemm_rows": "route_major",
-   "plan": {
-    "gate_up_a_family": "token_grouped",
-    "down_a_family": "grouped",
-    "act_family": "b_activation",
-    "finalize_family": "shared_rank_reduce"
-   }
-  },
-  {
-   "name": "prefill.shared",
-   "layout": "shared",
-   "phase": "prefill",
-   "base_gemm_rows": "route_major",
-   "plan": {
-    "gate_up_a_family": "token_grouped",
-    "down_a_family": "grouped",
-    "down_b_family": "grouped",
-    "act_family": "b_activation",
-    "finalize_family": "materialized",
-    "route_builder": "parallel_shared_outer",
-    "down_b_into_base": true
-   }
-  }
- ],
- "fallback": [
-  {
-   "name": "fallback.decode",
-   "phase": "decode",
-   "base_gemm_rows": "expert_major",
-   "plan": {
-    "gate_up_a_family": "grouped",
-    "down_a_family": "grouped",
-    "gate_up_b_family": "grouped",
-    "down_b_family": "grouped",
-    "act_family": "materialized",
-    "finalize_family": "materialized",
-    "down_overlap": "down_a_b",
-    "gate_up_overlap": "gate_up_a_b"
-   }
-  },
-  {
-   "name": "fallback.prefill.per_expert",
-   "layout": "per_expert",
-   "phase": "prefill",
-   "base_gemm_rows": "route_major",
-   "plan": {
-    "gate_up_a_family": "grouped",
-    "down_a_family": "grouped",
-    "down_b_family": "grouped",
-    "act_family": "b_activation",
-    "finalize_family": "materialized",
-    "down_b_into_base": true
-   }
-  },
-  {
-   "name": "fallback.prefill.shared",
-   "layout": "shared",
-   "phase": "prefill",
-   "base_gemm_rows": "expert_major",
-   "plan": {
-    "gate_up_a_family": "grouped",
-    "down_a_family": "grouped",
-    "down_b_family": "grouped",
-    "act_family": "b_activation",
-    "finalize_family": "materialized",
-    "down_b_into_base": true
-   }
-  }
- ]
+  "scenarios": [
+    {
+      "name": "decode.per_expert",
+      "layout": "per_expert",
+      "phase": "decode",
+      "base_gemm_rows": "expert_major",
+      "plan": {
+        "gate_up_a_family": "grouped",
+        "down_a_family": "per_pair",
+        "gate_up_b_family": "grouped",
+        "down_b_family": "grouped",
+        "act_family": "materialized",
+        "finalize_family": "materialized",
+        "gate_up_overlap": "gate_up_a_b",
+        "down_overlap": "down_a_b"
+      }
+    },
+    {
+      "name": "prefill.per_expert.rank_le16",
+      "layout": "per_expert",
+      "phase": "prefill",
+      "base_gemm_rows": "route_major",
+      "plan": {
+        "gate_up_a_family": "grouped",
+        "down_a_family": "grouped",
+        "down_b_family": "grouped",
+        "act_family": "b_activation",
+        "finalize_family": "materialized",
+        "down_b_into_base": true,
+        "gate_up_overlap": "gate_up_a"
+      },
+      "max_rank": 16
+    },
+    {
+      "name": "prefill.per_expert.rank_le32",
+      "layout": "per_expert",
+      "phase": "prefill",
+      "base_gemm_rows": "route_major",
+      "plan": {
+        "gate_up_a_family": "grouped",
+        "down_a_family": "grouped",
+        "down_b_family": "grouped",
+        "act_family": "b_activation",
+        "finalize_family": "materialized",
+        "down_b_into_base": true
+      },
+      "max_rank": 32
+    },
+    {
+      "name": "prefill.per_expert",
+      "layout": "per_expert",
+      "phase": "prefill",
+      "base_gemm_rows": "route_major",
+      "plan": {
+        "gate_up_a_family": "grouped",
+        "down_a_family": "grouped",
+        "down_b_family": "grouped",
+        "act_family": "b_activation",
+        "finalize_family": "materialized",
+        "down_b_into_base": true
+      }
+    },
+    {
+      "name": "decode.shared",
+      "layout": "shared",
+      "phase": "decode",
+      "base_gemm_rows": "expert_major",
+      "plan": {
+        "gate_up_a_family": "grouped",
+        "down_a_family": "grouped",
+        "gate_up_b_family": "grouped",
+        "act_family": "materialized",
+        "finalize_family": "shared_one_pass",
+        "gate_up_overlap": "gate_up_a_b",
+        "down_overlap": "down_a",
+        "route_builder": "parallel_shared_outer"
+      }
+    },
+    {
+      "name": "prefill.shared.rank_le8",
+      "layout": "shared",
+      "phase": "prefill",
+      "max_rank": 8,
+      "base_gemm_rows": "route_major",
+      "plan": {
+        "gate_up_a_family": "token_grouped",
+        "down_a_family": "grouped",
+        "act_family": "b_activation",
+        "finalize_family": "shared_token_delta",
+        "route_builder": "parallel_shared_outer"
+      }
+    },
+    {
+      "name": "prefill.shared.rank_le16",
+      "layout": "shared",
+      "phase": "prefill",
+      "max_rank": 16,
+      "base_gemm_rows": "route_major",
+      "plan": {
+        "gate_up_a_family": "token_grouped",
+        "down_a_family": "grouped",
+        "act_family": "b_activation",
+        "finalize_family": "shared_token_delta",
+        "gate_up_overlap": "gate_up_a"
+      }
+    },
+    {
+      "name": "prefill.shared.rank_le64",
+      "layout": "shared",
+      "phase": "prefill",
+      "max_rank": 64,
+      "base_gemm_rows": "route_major",
+      "plan": {
+        "gate_up_a_family": "token_grouped",
+        "down_a_family": "grouped",
+        "act_family": "b_activation",
+        "finalize_family": "shared_token_delta"
+      }
+    },
+    {
+      "name": "prefill.shared",
+      "layout": "shared",
+      "phase": "prefill",
+      "base_gemm_rows": "route_major",
+      "plan": {
+        "gate_up_a_family": "token_grouped",
+        "down_a_family": "grouped",
+        "act_family": "b_activation",
+        "finalize_family": "shared_token_delta",
+        "route_builder": "parallel_shared_outer"
+      }
+    }
+  ],
+  "fallback": [
+    {
+      "name": "fallback.decode.shared",
+      "layout": "shared",
+      "phase": "decode",
+      "base_gemm_rows": "expert_major",
+      "plan": {
+        "gate_up_a_family": "grouped",
+        "down_a_family": "grouped",
+        "gate_up_b_family": "grouped",
+        "act_family": "materialized",
+        "finalize_family": "shared_one_pass",
+        "gate_up_overlap": "gate_up_a_b",
+        "down_overlap": "down_a",
+        "route_builder": "parallel_shared_outer"
+      }
+    },
+    {
+      "name": "fallback.decode",
+      "phase": "decode",
+      "base_gemm_rows": "expert_major",
+      "plan": {
+        "gate_up_a_family": "grouped",
+        "down_a_family": "grouped",
+        "gate_up_b_family": "grouped",
+        "down_b_family": "grouped",
+        "act_family": "materialized",
+        "finalize_family": "materialized",
+        "down_overlap": "down_a_b",
+        "gate_up_overlap": "gate_up_a_b"
+      }
+    },
+    {
+      "name": "fallback.prefill.per_expert",
+      "layout": "per_expert",
+      "phase": "prefill",
+      "base_gemm_rows": "route_major",
+      "plan": {
+        "gate_up_a_family": "grouped",
+        "down_a_family": "grouped",
+        "down_b_family": "grouped",
+        "act_family": "b_activation",
+        "finalize_family": "materialized",
+        "down_b_into_base": true
+      }
+    },
+    {
+      "name": "fallback.prefill.shared",
+      "layout": "shared",
+      "phase": "prefill",
+      "base_gemm_rows": "route_major",
+      "plan": {
+        "gate_up_a_family": "token_grouped",
+        "down_a_family": "grouped",
+        "act_family": "b_activation",
+        "finalize_family": "shared_token_delta",
+        "route_builder": "parallel_shared_outer"
+      }
+    }
+  ]
 }

--- a/python/sglang/srt/lora/moe/configs/h200.plans.json
+++ b/python/sglang/srt/lora/moe/configs/h200.plans.json
@@ -1,0 +1,190 @@
+{
+ "arch": "h200",
+ "domain": {
+  "max_hidden": 4096,
+  "max_local_experts": 512
+ },
+ "scenarios": [
+  {
+   "name": "decode.per_expert",
+   "layout": "per_expert",
+   "phase": "decode",
+   "base_gemm_rows": "expert_major",
+   "plan": {
+    "gate_up_a_family": "grouped",
+    "down_a_family": "per_pair",
+    "gate_up_b_family": "grouped",
+    "down_b_family": "grouped",
+    "act_family": "materialized",
+    "finalize_family": "materialized",
+    "gate_up_overlap": "gate_up_a_b",
+    "down_overlap": "down_a_b"
+   }
+  },
+  {
+   "name": "prefill.per_expert.rank_le16",
+   "layout": "per_expert",
+   "phase": "prefill",
+   "base_gemm_rows": "route_major",
+   "plan": {
+    "gate_up_a_family": "grouped",
+    "down_a_family": "grouped",
+    "down_b_family": "grouped",
+    "act_family": "b_activation",
+    "finalize_family": "materialized",
+    "down_b_into_base": true,
+    "gate_up_overlap": "gate_up_a"
+   },
+   "max_rank": 16
+  },
+  {
+   "name": "prefill.per_expert.rank_le32",
+   "layout": "per_expert",
+   "phase": "prefill",
+   "base_gemm_rows": "route_major",
+   "plan": {
+    "gate_up_a_family": "grouped",
+    "down_a_family": "grouped",
+    "down_b_family": "grouped",
+    "act_family": "b_activation",
+    "finalize_family": "materialized",
+    "down_b_into_base": true
+   },
+   "max_rank": 32
+  },
+  {
+   "name": "prefill.per_expert",
+   "layout": "per_expert",
+   "phase": "prefill",
+   "base_gemm_rows": "route_major",
+   "plan": {
+    "gate_up_a_family": "grouped",
+    "down_a_family": "grouped",
+    "down_b_family": "grouped",
+    "act_family": "b_activation",
+    "finalize_family": "materialized",
+    "down_b_into_base": true
+   }
+  },
+  {
+   "name": "decode.shared",
+   "layout": "shared",
+   "phase": "decode",
+   "base_gemm_rows": "expert_major",
+   "plan": {
+    "gate_up_a_family": "grouped",
+    "down_a_family": "grouped",
+    "gate_up_b_family": "grouped",
+    "down_b_family": "grouped",
+    "act_family": "materialized",
+    "finalize_family": "materialized",
+    "gate_up_overlap": "gate_up_a_b",
+    "down_overlap": "down_a_b",
+    "route_builder": "parallel_shared_outer"
+   }
+  },
+  {
+   "name": "prefill.shared.rank_le8",
+   "layout": "shared",
+   "phase": "prefill",
+   "max_rank": 8,
+   "base_gemm_rows": "route_major",
+   "plan": {
+    "gate_up_a_family": "token_grouped",
+    "down_a_family": "grouped",
+    "down_b_family": "grouped",
+    "act_family": "b_activation",
+    "finalize_family": "materialized",
+    "route_builder": "parallel_shared_outer",
+    "down_b_into_base": true
+   }
+  },
+  {
+   "name": "prefill.shared.rank_le16",
+   "layout": "shared",
+   "phase": "prefill",
+   "max_rank": 16,
+   "base_gemm_rows": "route_major",
+   "plan": {
+    "gate_up_a_family": "token_grouped",
+    "down_a_family": "grouped",
+    "act_family": "b_activation",
+    "finalize_family": "shared_rank_reduce",
+    "gate_up_overlap": "gate_up_a"
+   }
+  },
+  {
+   "name": "prefill.shared.rank_le64",
+   "layout": "shared",
+   "phase": "prefill",
+   "max_rank": 64,
+   "base_gemm_rows": "route_major",
+   "plan": {
+    "gate_up_a_family": "token_grouped",
+    "down_a_family": "grouped",
+    "act_family": "b_activation",
+    "finalize_family": "shared_rank_reduce"
+   }
+  },
+  {
+   "name": "prefill.shared",
+   "layout": "shared",
+   "phase": "prefill",
+   "base_gemm_rows": "route_major",
+   "plan": {
+    "gate_up_a_family": "token_grouped",
+    "down_a_family": "grouped",
+    "down_b_family": "grouped",
+    "act_family": "b_activation",
+    "finalize_family": "materialized",
+    "route_builder": "parallel_shared_outer",
+    "down_b_into_base": true
+   }
+  }
+ ],
+ "fallback": [
+  {
+   "name": "fallback.decode",
+   "phase": "decode",
+   "base_gemm_rows": "expert_major",
+   "plan": {
+    "gate_up_a_family": "grouped",
+    "down_a_family": "grouped",
+    "gate_up_b_family": "grouped",
+    "down_b_family": "grouped",
+    "act_family": "materialized",
+    "finalize_family": "materialized",
+    "down_overlap": "down_a_b",
+    "gate_up_overlap": "gate_up_a_b"
+   }
+  },
+  {
+   "name": "fallback.prefill.per_expert",
+   "layout": "per_expert",
+   "phase": "prefill",
+   "base_gemm_rows": "route_major",
+   "plan": {
+    "gate_up_a_family": "grouped",
+    "down_a_family": "grouped",
+    "down_b_family": "grouped",
+    "act_family": "b_activation",
+    "finalize_family": "materialized",
+    "down_b_into_base": true
+   }
+  },
+  {
+   "name": "fallback.prefill.shared",
+   "layout": "shared",
+   "phase": "prefill",
+   "base_gemm_rows": "expert_major",
+   "plan": {
+    "gate_up_a_family": "grouped",
+    "down_a_family": "grouped",
+    "down_b_family": "grouped",
+    "act_family": "b_activation",
+    "finalize_family": "materialized",
+    "down_b_into_base": true
+   }
+  }
+ ]
+}

--- a/python/sglang/srt/lora/moe/configs/h200.tiles.json
+++ b/python/sglang/srt/lora/moe/configs/h200.tiles.json
@@ -47,17 +47,17 @@
     "sites": {
      "b_activation": {
       "BLOCK_SIZE_K": 16,
-      "BLOCK_SIZE_W": 256,
+      "BLOCK_SIZE_W": 64,
       "GROUP_SIZE_M": 16,
-      "num_stages": 4,
-      "num_warps": 8
-     },
-     "down_a": {
-      "BLOCK_SIZE_K": 128,
-      "BLOCK_SIZE_N": 64,
-      "GROUP_SIZE_M": 8,
       "num_stages": 2,
       "num_warps": 4
+     },
+     "down_a": {
+      "BLOCK_SIZE_K": 64,
+      "BLOCK_SIZE_N": 16,
+      "GROUP_SIZE_M": 16,
+      "num_stages": 2,
+      "num_warps": 2
      },
      "down_b": {
       "BLOCK_SIZE_K": 16,
@@ -67,10 +67,10 @@
       "num_warps": 4
      },
      "gate_up_a": {
-      "BLOCK_SIZE_K": 64,
-      "BLOCK_SIZE_N": 16,
+      "BLOCK_SIZE_K": 128,
+      "BLOCK_SIZE_N": 32,
       "GROUP_SIZE_M": 8,
-      "num_stages": 3,
+      "num_stages": 2,
       "num_warps": 2
      },
      "gate_up_b": {
@@ -209,7 +209,12 @@
       "num_stages": 3,
       "num_warps": 8
      },
-     "routing_block_size": 16
+     "routing_block_size": 16,
+     "shared_one_pass": {
+      "BLOCK_SIZE_H": 128,
+      "num_stages": 3,
+      "num_warps": 4
+     }
     }
    }
   ],
@@ -254,17 +259,16 @@
       "num_warps": 4
      },
      "routing_block_size": 16,
-     "shared_finalize": {
+     "shared_token_delta": {
       "reduce": {
        "BLOCK_SIZE_T": 16,
        "num_stages": 2,
        "num_warps": 8
       },
       "tail": {
-       "BLOCK_SIZE_H": 512,
-       "BLOCK_SIZE_K": 16,
+       "BLOCK_SIZE_H": 1024,
        "num_stages": 2,
-       "num_warps": 2
+       "num_warps": 8
       }
      }
     }
@@ -310,7 +314,19 @@
       "num_stages": 2,
       "num_warps": 4
      },
-     "routing_block_size": 32
+     "routing_block_size": 32,
+     "shared_token_delta": {
+      "reduce": {
+       "BLOCK_SIZE_T": 16,
+       "num_stages": 2,
+       "num_warps": 8
+      },
+      "tail": {
+       "BLOCK_SIZE_H": 1024,
+       "num_stages": 2,
+       "num_warps": 8
+      }
+     }
     }
    }
   ],
@@ -355,17 +371,16 @@
       "num_warps": 4
      },
      "routing_block_size": 16,
-     "shared_finalize": {
+     "shared_token_delta": {
       "reduce": {
        "BLOCK_SIZE_T": 16,
        "num_stages": 2,
        "num_warps": 8
       },
       "tail": {
-       "BLOCK_SIZE_H": 256,
-       "BLOCK_SIZE_K": 32,
+       "BLOCK_SIZE_H": 1024,
        "num_stages": 2,
-       "num_warps": 4
+       "num_warps": 8
       }
      }
     }
@@ -411,7 +426,66 @@
       "num_stages": 2,
       "num_warps": 4
      },
-     "routing_block_size": 64
+     "routing_block_size": 64,
+     "shared_token_delta": {
+      "reduce": {
+       "BLOCK_SIZE_T": 16,
+       "num_stages": 2,
+       "num_warps": 8
+      },
+      "tail": {
+       "BLOCK_SIZE_H": 1024,
+       "num_stages": 2,
+       "num_warps": 8
+      }
+     }
+    }
+   }
+  ],
+  "fallback.decode.shared": [
+   {
+    "sites": {
+     "b_activation": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_W": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "down_a": {
+      "BLOCK_SIZE_K": 128,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 4,
+      "num_warps": 4
+     },
+     "down_b": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_N": 128,
+      "GROUP_SIZE_M": 1,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "gate_up_a": {
+      "BLOCK_SIZE_K": 128,
+      "BLOCK_SIZE_N": 32,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 3,
+      "num_warps": 4
+     },
+     "gate_up_b": {
+      "BLOCK_SIZE_K": 64,
+      "BLOCK_SIZE_N": 256,
+      "GROUP_SIZE_M": 4,
+      "num_stages": 3,
+      "num_warps": 8
+     },
+     "routing_block_size": 16,
+     "shared_one_pass": {
+      "BLOCK_SIZE_H": 128,
+      "num_stages": 3,
+      "num_warps": 4
+     }
     }
    }
   ],
@@ -543,7 +617,19 @@
       "num_stages": 2,
       "num_warps": 4
      },
-     "routing_block_size": 32
+     "routing_block_size": 32,
+     "shared_token_delta": {
+      "reduce": {
+       "BLOCK_SIZE_T": 32,
+       "num_stages": 2,
+       "num_warps": 4
+      },
+      "tail": {
+       "BLOCK_SIZE_H": 1024,
+       "num_stages": 2,
+       "num_warps": 8
+      }
+     }
     }
    }
   ]

--- a/python/sglang/srt/lora/moe/configs/h200.tiles.json
+++ b/python/sglang/srt/lora/moe/configs/h200.tiles.json
@@ -1,0 +1,551 @@
+{
+ "arch": "h200",
+ "rules": {
+  "decode.per_expert": [
+   {
+    "sites": {
+     "b_activation": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_W": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "down_a": {
+      "BLOCK_SIZE_K": 128,
+      "BLOCK_SIZE_N": 16,
+      "num_stages": 2,
+      "num_warps": 8
+     },
+     "down_b": {
+      "BLOCK_SIZE_K": 16,
+      "BLOCK_SIZE_N": 128,
+      "GROUP_SIZE_M": 1,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "gate_up_a": {
+      "BLOCK_SIZE_K": 128,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 3,
+      "num_warps": 4
+     },
+     "gate_up_b": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_N": 128,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "routing_block_size": 16
+    }
+   }
+  ],
+  "prefill.per_expert.rank_le16": [
+   {
+    "sites": {
+     "b_activation": {
+      "BLOCK_SIZE_K": 16,
+      "BLOCK_SIZE_W": 256,
+      "GROUP_SIZE_M": 16,
+      "num_stages": 4,
+      "num_warps": 8
+     },
+     "down_a": {
+      "BLOCK_SIZE_K": 128,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "down_b": {
+      "BLOCK_SIZE_K": 16,
+      "BLOCK_SIZE_N": 128,
+      "GROUP_SIZE_M": 1,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "gate_up_a": {
+      "BLOCK_SIZE_K": 64,
+      "BLOCK_SIZE_N": 16,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 3,
+      "num_warps": 2
+     },
+     "gate_up_b": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_M": 32,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "routing_block_size": 32
+    }
+   }
+  ],
+  "prefill.per_expert.rank_le32": [
+   {
+    "sites": {
+     "b_activation": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_W": 256,
+      "GROUP_SIZE_M": 16,
+      "num_stages": 4,
+      "num_warps": 4
+     },
+     "down_a": {
+      "BLOCK_SIZE_K": 128,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "down_b": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_N": 128,
+      "GROUP_SIZE_M": 1,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "gate_up_a": {
+      "BLOCK_SIZE_K": 64,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 3,
+      "num_warps": 4
+     },
+     "gate_up_b": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_M": 32,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "routing_block_size": 32
+    }
+   }
+  ],
+  "prefill.per_expert": [
+   {
+    "sites": {
+     "b_activation": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_W": 256,
+      "GROUP_SIZE_M": 16,
+      "num_stages": 4,
+      "num_warps": 4
+     },
+     "down_a": {
+      "BLOCK_SIZE_K": 128,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "down_b": {
+      "BLOCK_SIZE_K": 64,
+      "BLOCK_SIZE_N": 128,
+      "GROUP_SIZE_M": 1,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "gate_up_a": {
+      "BLOCK_SIZE_K": 64,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 3,
+      "num_warps": 4
+     },
+     "gate_up_b": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_M": 32,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "routing_block_size": 32
+    }
+   }
+  ],
+  "decode.shared": [
+   {
+    "sites": {
+     "b_activation": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_W": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "down_a": {
+      "BLOCK_SIZE_K": 128,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 4,
+      "num_warps": 4
+     },
+     "down_b": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_N": 128,
+      "GROUP_SIZE_M": 1,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "gate_up_a": {
+      "BLOCK_SIZE_K": 128,
+      "BLOCK_SIZE_N": 32,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 3,
+      "num_warps": 4
+     },
+     "gate_up_b": {
+      "BLOCK_SIZE_K": 64,
+      "BLOCK_SIZE_N": 256,
+      "GROUP_SIZE_M": 4,
+      "num_stages": 3,
+      "num_warps": 8
+     },
+     "routing_block_size": 16
+    }
+   }
+  ],
+  "prefill.shared.rank_le16": [
+   {
+    "sites": {
+     "b_activation": {
+      "BLOCK_SIZE_K": 16,
+      "BLOCK_SIZE_W": 128,
+      "GROUP_SIZE_M": 1,
+      "num_stages": 4,
+      "num_warps": 4
+     },
+     "down_a": {
+      "BLOCK_SIZE_K": 128,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 3,
+      "num_warps": 4
+     },
+     "down_b": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "gate_up_a": {
+      "BLOCK_SIZE_K": 64,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 3,
+      "num_warps": 4
+     },
+     "gate_up_b": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "routing_block_size": 16,
+     "shared_finalize": {
+      "reduce": {
+       "BLOCK_SIZE_T": 16,
+       "num_stages": 2,
+       "num_warps": 8
+      },
+      "tail": {
+       "BLOCK_SIZE_H": 512,
+       "BLOCK_SIZE_K": 16,
+       "num_stages": 2,
+       "num_warps": 2
+      }
+     }
+    }
+   }
+  ],
+  "prefill.shared.rank_le8": [
+   {
+    "sites": {
+     "b_activation": {
+      "BLOCK_SIZE_K": 16,
+      "BLOCK_SIZE_W": 64,
+      "GROUP_SIZE_M": 1,
+      "num_stages": 4,
+      "num_warps": 2
+     },
+     "down_a": {
+      "BLOCK_SIZE_K": 128,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 3,
+      "num_warps": 4
+     },
+     "down_b": {
+      "BLOCK_SIZE_K": 16,
+      "BLOCK_SIZE_M": 32,
+      "BLOCK_SIZE_N": 128,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 2
+     },
+     "gate_up_a": {
+      "BLOCK_SIZE_K": 64,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 6,
+      "num_warps": 4
+     },
+     "gate_up_b": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_M": 32,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "routing_block_size": 32
+    }
+   }
+  ],
+  "prefill.shared.rank_le64": [
+   {
+    "sites": {
+     "b_activation": {
+      "BLOCK_SIZE_K": 16,
+      "BLOCK_SIZE_W": 128,
+      "GROUP_SIZE_M": 1,
+      "num_stages": 4,
+      "num_warps": 4
+     },
+     "down_a": {
+      "BLOCK_SIZE_K": 128,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 3,
+      "num_warps": 4
+     },
+     "down_b": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "gate_up_a": {
+      "BLOCK_SIZE_K": 64,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 3,
+      "num_warps": 4
+     },
+     "gate_up_b": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "routing_block_size": 16,
+     "shared_finalize": {
+      "reduce": {
+       "BLOCK_SIZE_T": 16,
+       "num_stages": 2,
+       "num_warps": 8
+      },
+      "tail": {
+       "BLOCK_SIZE_H": 256,
+       "BLOCK_SIZE_K": 32,
+       "num_stages": 2,
+       "num_warps": 4
+      }
+     }
+    }
+   }
+  ],
+  "prefill.shared": [
+   {
+    "sites": {
+     "b_activation": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_W": 64,
+      "GROUP_SIZE_M": 1,
+      "num_stages": 4,
+      "num_warps": 4
+     },
+     "down_a": {
+      "BLOCK_SIZE_K": 128,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 3,
+      "num_warps": 4
+     },
+     "down_b": {
+      "BLOCK_SIZE_K": 64,
+      "BLOCK_SIZE_M": 64,
+      "BLOCK_SIZE_N": 128,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "gate_up_a": {
+      "BLOCK_SIZE_K": 64,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 3,
+      "num_warps": 4
+     },
+     "gate_up_b": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_M": 64,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "routing_block_size": 64
+    }
+   }
+  ],
+  "fallback.decode": [
+   {
+    "sites": {
+     "b_activation": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_W": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 3,
+      "num_warps": 4
+     },
+     "down_a": {
+      "BLOCK_SIZE_K": 64,
+      "BLOCK_SIZE_N": 32,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "down_b": {
+      "BLOCK_SIZE_K": 16,
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 128,
+      "GROUP_SIZE_M": 1,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "gate_up_a": {
+      "BLOCK_SIZE_K": 256,
+      "BLOCK_SIZE_N": 32,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 4,
+      "num_warps": 8
+     },
+     "gate_up_b": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "routing_block_size": 16
+    }
+   }
+  ],
+  "fallback.prefill.per_expert": [
+   {
+    "sites": {
+     "b_activation": {
+      "BLOCK_SIZE_K": 16,
+      "BLOCK_SIZE_W": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 3,
+      "num_warps": 8
+     },
+     "down_a": {
+      "BLOCK_SIZE_K": 64,
+      "BLOCK_SIZE_N": 32,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "down_b": {
+      "BLOCK_SIZE_K": 16,
+      "BLOCK_SIZE_M": 32,
+      "BLOCK_SIZE_N": 128,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "gate_up_a": {
+      "BLOCK_SIZE_K": 64,
+      "BLOCK_SIZE_N": 16,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 2
+     },
+     "gate_up_b": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_M": 32,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "routing_block_size": 32
+    }
+   }
+  ],
+  "fallback.prefill.shared": [
+   {
+    "sites": {
+     "b_activation": {
+      "BLOCK_SIZE_K": 16,
+      "BLOCK_SIZE_W": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 3,
+      "num_warps": 8
+     },
+     "down_a": {
+      "BLOCK_SIZE_K": 64,
+      "BLOCK_SIZE_N": 32,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "down_b": {
+      "BLOCK_SIZE_K": 16,
+      "BLOCK_SIZE_M": 32,
+      "BLOCK_SIZE_N": 128,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "gate_up_a": {
+      "BLOCK_SIZE_K": 64,
+      "BLOCK_SIZE_N": 16,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 2
+     },
+     "gate_up_b": {
+      "BLOCK_SIZE_K": 32,
+      "BLOCK_SIZE_M": 32,
+      "BLOCK_SIZE_N": 64,
+      "GROUP_SIZE_M": 8,
+      "num_stages": 2,
+      "num_warps": 4
+     },
+     "routing_block_size": 32
+    }
+   }
+  ]
+ }
+}

--- a/python/sglang/srt/lora/moe/execution_plan.py
+++ b/python/sglang/srt/lora/moe/execution_plan.py
@@ -48,6 +48,8 @@ class LoraAFamily(str, Enum):
     GROUPED = "grouped"
     PER_PAIR = "per_pair"
     TOKEN_GROUPED = "token_grouped"
+    # Shared gate/up A writes one token-domain bridge plane per adapter slot.
+    TOKEN_DENSE = "token_dense"
 
 
 class LoraBFamily(str, Enum):
@@ -62,7 +64,10 @@ class ActFamily(str, Enum):
 
 class FinalizeFamily(str, Enum):
     MATERIALIZED = "materialized"
-    SHARED_RANK_REDUCE = "shared_rank_reduce"
+    # Reduce in rank space before expanding the shared B once per token.
+    SHARED_TOKEN_DELTA = "shared_token_delta"
+    # Fuse the rank reduction, B expansion, and base reduction.
+    SHARED_ONE_PASS = "shared_one_pass"
 
 
 class GateUpOverlap(str, Enum):
@@ -116,6 +121,13 @@ class LoraASpec:
         elif self.family is LoraAFamily.PER_PAIR:
             if self.output_layout is not BridgeLayout.PAIR_MAJOR:
                 raise ValueError("per_pair A writes a pair-major bridge")
+        elif self.family is LoraAFamily.TOKEN_DENSE:
+            if self.site is not Site.GATE_UP:
+                raise ValueError("token_dense A is a gate/up-site family")
+            if not self.is_shared_outer:
+                raise ValueError("token_dense A requires shared-outer ownership")
+            if self.output_layout is not BridgeLayout.TOKEN_MAJOR:
+                raise ValueError("token_dense A writes a token-major bridge")
         else:
             if self.site is not Site.GATE_UP:
                 raise ValueError(f"{self.family.value} is a shared gate/up-A family")
@@ -128,7 +140,10 @@ class LoraASpec:
         return self
 
     def route_requirements(self) -> frozenset[RouteRequirement]:
-        if self.family is LoraAFamily.PER_PAIR:
+        if self.family in (
+            LoraAFamily.PER_PAIR,
+            LoraAFamily.TOKEN_DENSE,
+        ):
             return frozenset((_raw_requirement(self.is_shared_outer),))
         if self.family is LoraAFamily.TOKEN_GROUPED:
             return frozenset((RouteRequirement.SHARED_TOKEN_PLAN,))
@@ -178,7 +193,8 @@ class FinalizeSpec:
 
     def validate(self) -> FinalizeSpec:
         if (
-            self.family is FinalizeFamily.SHARED_RANK_REDUCE
+            self.family
+            in (FinalizeFamily.SHARED_TOKEN_DELTA, FinalizeFamily.SHARED_ONE_PASS)
             and not self.is_shared_outer
         ):
             raise ValueError(
@@ -189,8 +205,13 @@ class FinalizeSpec:
     def route_requirements(self) -> frozenset[RouteRequirement]:
         if self.family is FinalizeFamily.MATERIALIZED:
             return frozenset()
-        # The shared-rank finalizer builds its fixed top-k keys from the raw
-        # route.
+        if self.family is FinalizeFamily.SHARED_TOKEN_DELTA:
+            return frozenset(
+                (
+                    _raw_requirement(self.is_shared_outer),
+                    RouteRequirement.SHARED_TOKEN_PLAN,
+                )
+            )
         return frozenset((_raw_requirement(self.is_shared_outer),))
 
 
@@ -244,6 +265,13 @@ class MoeLoraExecutionPlan:
             and self.down_a.output_layout is not self.down_b.input_layout
         ):
             raise ValueError("down A output layout must match the down B input layout")
+        if self.gate_up_a.family is LoraAFamily.TOKEN_DENSE and (
+            self.gate_up_b is None or self.gate_up_b.family is not LoraBFamily.PER_PAIR
+        ):
+            raise ValueError(
+                "token_dense A writes one bridge plane per adapter slot; only a "
+                "standalone per_pair gate/up B selects planes"
+            )
 
         if self.gate_up_overlap is GateUpOverlap.GATE_UP_A_B and self.gate_up_b is None:
             raise ValueError(
@@ -269,23 +297,6 @@ class MoeLoraExecutionPlan:
             )
 
         return self
-
-    def is_fully_serial(self) -> bool:
-        return (
-            self.gate_up_overlap is GateUpOverlap.NONE
-            and self.down_overlap is DownOverlap.NONE
-            and self.down_a.family is LoraAFamily.GROUPED
-            # An into-base plan also runs in order, but its down B writes
-            # into the base down output. The row-domain conversions read this
-            # answer, and they must not treat an into-base plan as serial.
-            and not self.down_b_into_base
-        )
-
-    def is_fully_serial_materialized(self) -> bool:
-        return (
-            self.is_fully_serial()
-            and self.finalize.family is FinalizeFamily.MATERIALIZED
-        )
 
     def down_b_into_base_eligible(self) -> bool:
         # In-place B must wait for the base down GEMM to finish writing.
@@ -361,6 +372,9 @@ class _PlanRowModel(pydantic.BaseModel):
     layout: Literal["per_expert", "shared"] | None = None
     phase: Phase | None = None
     max_rank: int | None = None
+    min_local_experts: int | None = None
+    max_local_experts: int | None = None
+    quant: list[str] | None = None
     base_gemm_rows: Literal["expert_major", "route_major"]
     plan: _PlanSpecModel
 
@@ -440,7 +454,7 @@ def build_plan(
     gate_up_a_family = spec.gate_up_a_family
     gate_up_layout = (
         BridgeLayout.TOKEN_MAJOR
-        if gate_up_a_family is LoraAFamily.TOKEN_GROUPED
+        if gate_up_a_family in (LoraAFamily.TOKEN_GROUPED, LoraAFamily.TOKEN_DENSE)
         else BridgeLayout.PAIR_MAJOR
     )
     act_family = spec.act_family
@@ -454,7 +468,12 @@ def build_plan(
         gate_up_b=(
             None
             if consumes_gate_up_b
-            else LoraBSpec(Site.GATE_UP, spec.gate_up_b_family, False, gate_up_layout)
+            else LoraBSpec(
+                Site.GATE_UP,
+                spec.gate_up_b_family,
+                False,
+                gate_up_layout,
+            )
         ),
         act=ActSpec(act_family, activation),
         down_a=LoraASpec(
@@ -505,6 +524,7 @@ def resolve_plans(
     activation: ActivationFn,
     hidden_size: int,
     num_local_experts: int,
+    quant_family: str,
 ) -> dict[Phase, SelectedPlan]:
     table = load_plans(architecture)
     layout_name = "shared" if is_shared_outer else "per_expert"
@@ -524,6 +544,15 @@ def resolve_plans(
                 if candidate.layout in (None, layout_name)
                 and candidate.phase in (None, phase)
                 and (candidate.max_rank is None or physical_rank <= candidate.max_rank)
+                and (
+                    candidate.min_local_experts is None
+                    or num_local_experts >= candidate.min_local_experts
+                )
+                and (
+                    candidate.max_local_experts is None
+                    or num_local_experts <= candidate.max_local_experts
+                )
+                and (candidate.quant is None or quant_family in candidate.quant)
             ),
             None,
         )

--- a/python/sglang/srt/lora/moe/execution_plan.py
+++ b/python/sglang/srt/lora/moe/execution_plan.py
@@ -1,0 +1,545 @@
+"""Select and validate MoE LoRA plans without importing CUDA code."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from enum import Enum
+from functools import cache
+from typing import Literal
+
+import pydantic
+from pydantic.dataclasses import dataclass as pydantic_dataclass
+
+from sglang.srt.lora.moe.activation import ActivationFn
+
+logger = logging.getLogger(__name__)
+
+_STRICT = pydantic.ConfigDict(strict=True, extra="forbid")
+
+
+class Site(str, Enum):
+    GATE_UP = "gate_up"
+    DOWN = "down"
+
+
+class BridgeLayout(str, Enum):
+    PAIR_MAJOR = "pair_major"
+    TOKEN_MAJOR = "token_major"
+
+
+class RouteRequirement(str, Enum):
+    RAW_PER_EXPERT = "raw_per_expert"
+    RAW_SHARED_OUTER = "raw_shared_outer"
+    ALIGNED_PER_EXPERT = "aligned_per_expert"
+    ALIGNED_SHARED_OUTER = "aligned_shared_outer"
+    SHARED_TOKEN_PLAN = "shared_token_plan"
+
+
+class RouteBuilderFamily(str, Enum):
+    STANDARD = "standard"
+    # Build the shared route on the workspace side stream.
+    PARALLEL_SHARED_OUTER = "parallel_shared_outer"
+
+
+class LoraAFamily(str, Enum):
+    GROUPED = "grouped"
+    PER_PAIR = "per_pair"
+    TOKEN_GROUPED = "token_grouped"
+
+
+class LoraBFamily(str, Enum):
+    GROUPED = "grouped"
+    PER_PAIR = "per_pair"
+
+
+class ActFamily(str, Enum):
+    MATERIALIZED = "materialized"
+    B_ACTIVATION = "b_activation"
+
+
+class FinalizeFamily(str, Enum):
+    MATERIALIZED = "materialized"
+    SHARED_RANK_REDUCE = "shared_rank_reduce"
+
+
+class GateUpOverlap(str, Enum):
+    NONE = "none"
+    GATE_UP_A = "gate_up_a"
+    GATE_UP_A_B = "gate_up_a_b"
+
+
+class DownOverlap(str, Enum):
+    NONE = "none"
+    DOWN_A = "down_a"
+    DOWN_B = "down_b"
+    DOWN_A_B = "down_a_b"
+
+
+def _raw_requirement(is_shared_outer: bool) -> RouteRequirement:
+    if is_shared_outer:
+        return RouteRequirement.RAW_SHARED_OUTER
+    return RouteRequirement.RAW_PER_EXPERT
+
+
+def _aligned_requirement(is_shared_outer: bool) -> RouteRequirement:
+    if is_shared_outer:
+        return RouteRequirement.ALIGNED_SHARED_OUTER
+    return RouteRequirement.ALIGNED_PER_EXPERT
+
+
+def _check_down_bridge_layout(site: Site, layout: BridgeLayout) -> None:
+    if site is Site.DOWN and layout is BridgeLayout.TOKEN_MAJOR:
+        raise ValueError(
+            "the down bridge is inherently pair-major: each routed expert "
+            "produces a different activation"
+        )
+
+
+@pydantic_dataclass(frozen=True, slots=True, config=_STRICT)
+class LoraASpec:
+    site: Site
+    family: LoraAFamily
+    is_shared_outer: bool = False
+    output_layout: BridgeLayout = BridgeLayout.PAIR_MAJOR
+
+    def __post_init__(self) -> None:
+        self.validate()
+
+    def validate(self) -> LoraASpec:
+        _check_down_bridge_layout(self.site, self.output_layout)
+        if self.family is LoraAFamily.GROUPED:
+            if self.output_layout is not BridgeLayout.PAIR_MAJOR:
+                raise ValueError("grouped A writes a pair-major bridge")
+        elif self.family is LoraAFamily.PER_PAIR:
+            if self.output_layout is not BridgeLayout.PAIR_MAJOR:
+                raise ValueError("per_pair A writes a pair-major bridge")
+        else:
+            if self.site is not Site.GATE_UP:
+                raise ValueError(f"{self.family.value} is a shared gate/up-A family")
+            if not self.is_shared_outer:
+                raise ValueError(
+                    f"{self.family.value} requires shared-outer A ownership"
+                )
+            if self.output_layout is not BridgeLayout.TOKEN_MAJOR:
+                raise ValueError(f"{self.family.value} writes a token-major bridge")
+        return self
+
+    def route_requirements(self) -> frozenset[RouteRequirement]:
+        if self.family is LoraAFamily.PER_PAIR:
+            return frozenset((_raw_requirement(self.is_shared_outer),))
+        if self.family is LoraAFamily.TOKEN_GROUPED:
+            return frozenset((RouteRequirement.SHARED_TOKEN_PLAN,))
+        return frozenset((_aligned_requirement(self.is_shared_outer),))
+
+
+@pydantic_dataclass(frozen=True, slots=True, config=_STRICT)
+class LoraBSpec:
+    site: Site
+    family: LoraBFamily
+    is_shared_outer: bool = False
+    input_layout: BridgeLayout = BridgeLayout.PAIR_MAJOR
+
+    def __post_init__(self) -> None:
+        self.validate()
+
+    def validate(self) -> LoraBSpec:
+        _check_down_bridge_layout(self.site, self.input_layout)
+        return self
+
+    def route_requirements(self) -> frozenset[RouteRequirement]:
+        if self.family is LoraBFamily.PER_PAIR:
+            return frozenset((_raw_requirement(self.is_shared_outer),))
+        return frozenset((_aligned_requirement(self.is_shared_outer),))
+
+
+@pydantic_dataclass(frozen=True, slots=True, config=_STRICT)
+class ActSpec:
+    """B_ACTIVATION owns gate/up B and consumes the A bridge."""
+
+    family: ActFamily
+    activation: ActivationFn
+
+    def route_requirements(self) -> frozenset[RouteRequirement]:
+        if self.family is not ActFamily.B_ACTIVATION:
+            return frozenset()
+        return frozenset((_aligned_requirement(False),))
+
+
+@pydantic_dataclass(frozen=True, slots=True, config=_STRICT)
+class FinalizeSpec:
+    family: FinalizeFamily
+    is_shared_outer: bool = False
+
+    def __post_init__(self) -> None:
+        self.validate()
+
+    def validate(self) -> FinalizeSpec:
+        if (
+            self.family is FinalizeFamily.SHARED_RANK_REDUCE
+            and not self.is_shared_outer
+        ):
+            raise ValueError(
+                f"{self.family.value} requires shared-outer down-B ownership"
+            )
+        return self
+
+    def route_requirements(self) -> frozenset[RouteRequirement]:
+        if self.family is FinalizeFamily.MATERIALIZED:
+            return frozenset()
+        # The shared-rank finalizer builds its fixed top-k keys from the raw
+        # route.
+        return frozenset((_raw_requirement(self.is_shared_outer),))
+
+
+@pydantic_dataclass(frozen=True, slots=True, kw_only=True, config=_STRICT)
+class MoeLoraExecutionPlan:
+    gate_up_a: LoraASpec
+    gate_up_b: LoraBSpec | None = None
+    act: ActSpec
+    down_a: LoraASpec
+    down_b: LoraBSpec | None = None
+    finalize: FinalizeSpec
+    gate_up_overlap: GateUpOverlap = GateUpOverlap.NONE
+    down_overlap: DownOverlap = DownOverlap.NONE
+    down_b_into_base: bool = False
+    route_builder: RouteBuilderFamily = RouteBuilderFamily.STANDARD
+
+    def __post_init__(self) -> None:
+        self.validate()
+
+    def validate(self) -> MoeLoraExecutionPlan:
+        if self.gate_up_a.site is not Site.GATE_UP:
+            raise ValueError("gate_up_a must describe the gate/up site")
+        if self.gate_up_b is not None and self.gate_up_b.site is not Site.GATE_UP:
+            raise ValueError("gate_up_b must describe the gate/up site")
+        if self.down_a.site is not Site.DOWN:
+            raise ValueError("down_a must describe the down site")
+        if self.down_b is not None and self.down_b.site is not Site.DOWN:
+            raise ValueError("down_b must describe the down site")
+
+        gate_up_b_consumed = self.act.family is ActFamily.B_ACTIVATION
+        if gate_up_b_consumed == (self.gate_up_b is not None):
+            raise ValueError(
+                "gate/up B must have exactly one owner: standalone gate_up_b or the act stage"
+            )
+        down_b_consumed = self.finalize.family is not FinalizeFamily.MATERIALIZED
+        if down_b_consumed == (self.down_b is not None):
+            raise ValueError(
+                "down B must have exactly one owner: standalone down_b or finalize"
+            )
+
+        # Fused consumers inherit A's layout; standalone B must match it.
+        if (
+            self.gate_up_b is not None
+            and self.gate_up_a.output_layout is not self.gate_up_b.input_layout
+        ):
+            raise ValueError(
+                "gate/up A output layout must match the gate/up B input layout"
+            )
+        if (
+            self.down_b is not None
+            and self.down_a.output_layout is not self.down_b.input_layout
+        ):
+            raise ValueError("down A output layout must match the down B input layout")
+
+        if self.gate_up_overlap is GateUpOverlap.GATE_UP_A_B and self.gate_up_b is None:
+            raise ValueError(
+                "gate/up-A+B overlap requires standalone gate/up B; the act stage owns it"
+            )
+        if (
+            self.down_overlap
+            in (
+                DownOverlap.DOWN_B,
+                DownOverlap.DOWN_A_B,
+            )
+            and self.down_b is None
+        ):
+            raise ValueError(
+                f"{self.down_overlap.value} overlap requires standalone down B"
+            )
+
+        if self.down_b_into_base and not self.down_b_into_base_eligible():
+            raise ValueError(
+                "down-B into-base requires a standalone down-B stage and no "
+                "late overlap window (it read-modify-writes the base down "
+                "output)"
+            )
+
+        return self
+
+    def is_fully_serial(self) -> bool:
+        return (
+            self.gate_up_overlap is GateUpOverlap.NONE
+            and self.down_overlap is DownOverlap.NONE
+            and self.down_a.family is LoraAFamily.GROUPED
+            # An into-base plan also runs in order, but its down B writes
+            # into the base down output. The row-domain conversions read this
+            # answer, and they must not treat an into-base plan as serial.
+            and not self.down_b_into_base
+        )
+
+    def is_fully_serial_materialized(self) -> bool:
+        return (
+            self.is_fully_serial()
+            and self.finalize.family is FinalizeFamily.MATERIALIZED
+        )
+
+    def down_b_into_base_eligible(self) -> bool:
+        # In-place B must wait for the base down GEMM to finish writing.
+        return self.down_b is not None and self.down_overlap in (
+            DownOverlap.NONE,
+            DownOverlap.DOWN_A,
+        )
+
+    def route_requirements(self) -> frozenset[RouteRequirement]:
+        return (
+            self._requirements_of(self.gate_up_a, self.gate_up_b, self.down_a)
+            | self._down_b_route_requirements()
+        )
+
+    def _down_b_route_requirements(self) -> frozenset[RouteRequirement]:
+        # The in-place B kernel replaces the selected family and needs aligned rows.
+        if self.down_b is None:
+            return frozenset()
+        if self.down_b_into_base:
+            return frozenset((_aligned_requirement(self.down_b.is_shared_outer),))
+        return self.down_b.route_requirements()
+
+    def _requirements_of(
+        self, *stages: LoraASpec | LoraBSpec | None
+    ) -> frozenset[RouteRequirement]:
+        requirements: set[RouteRequirement] = set()
+        for stage in stages:
+            if stage is not None:
+                requirements.update(stage.route_requirements())
+        requirements.update(self.act.route_requirements())
+        requirements.update(self.finalize.route_requirements())
+        return frozenset(requirements)
+
+
+class Phase(str, Enum):
+    DECODE = "decode"
+    PREFILL = "prefill"
+
+
+class DeviceArchitecture(str, Enum):
+    H200 = "h200"
+    GB300 = "gb300"
+    DEFAULT = "default"
+
+
+def architecture_for_capability(major: int, minor: int) -> DeviceArchitecture:
+    if major == 9:
+        return DeviceArchitecture.H200
+    if major >= 10:
+        return DeviceArchitecture.GB300
+    return DeviceArchitecture.DEFAULT
+
+
+class _PlanSpecModel(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(extra="forbid")
+
+    gate_up_a_family: LoraAFamily = LoraAFamily.GROUPED
+    down_a_family: LoraAFamily = LoraAFamily.GROUPED
+    gate_up_b_family: LoraBFamily = LoraBFamily.GROUPED
+    down_b_family: LoraBFamily = LoraBFamily.GROUPED
+    act_family: ActFamily = ActFamily.MATERIALIZED
+    finalize_family: FinalizeFamily = FinalizeFamily.MATERIALIZED
+    gate_up_overlap: GateUpOverlap = GateUpOverlap.NONE
+    down_overlap: DownOverlap = DownOverlap.NONE
+    route_builder: RouteBuilderFamily = RouteBuilderFamily.STANDARD
+    down_b_into_base: bool = False
+
+
+class _PlanRowModel(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(extra="forbid")
+
+    name: str
+    layout: Literal["per_expert", "shared"] | None = None
+    phase: Phase | None = None
+    max_rank: int | None = None
+    base_gemm_rows: Literal["expert_major", "route_major"]
+    plan: _PlanSpecModel
+
+
+class _DomainModel(pydantic.BaseModel):
+    """Geometry covered by the tuned scenario rows."""
+
+    model_config = pydantic.ConfigDict(extra="forbid")
+
+    max_hidden: int | None = None
+    max_local_experts: int | None = None
+
+    def admits(self, *, hidden_size: int, num_local_experts: int) -> bool:
+        return (self.max_hidden is None or hidden_size <= self.max_hidden) and (
+            self.max_local_experts is None
+            or num_local_experts <= self.max_local_experts
+        )
+
+
+class _PlansFileModel(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(extra="forbid")
+
+    arch: DeviceArchitecture
+    domain: _DomainModel = pydantic.Field(default_factory=_DomainModel)
+    scenarios: list[_PlanRowModel] = pydantic.Field(default_factory=list)
+    fallback: list[_PlanRowModel]
+
+
+_CONFIG_DIR = os.path.join(os.path.dirname(__file__), "configs")
+
+
+def _read_table(name: str) -> dict | None:
+    from sglang.srt.environ import envs
+
+    override_dir = envs.SGLANG_LORA_MOE_CONFIG_DIR.get()
+    for directory in filter(None, (override_dir, _CONFIG_DIR)):
+        path = os.path.join(directory, name)
+        if os.path.isfile(path):
+            if directory == override_dir:
+                logger.info(
+                    "MoE LoRA table %r loaded from override dir %s", name, directory
+                )
+            with open(path) as handle:
+                return json.load(handle)
+    return None
+
+
+@cache
+def load_plans(architecture: DeviceArchitecture) -> _PlansFileModel:
+    raw = _read_table(f"{architecture.value}.plans.json")
+    if raw is None:
+        logger.warning(
+            "no MoE LoRA plan table for architecture %s; serving the "
+            "conservative default plans",
+            architecture.value,
+        )
+        raw = _read_table("default.plans.json")
+    if raw is None:
+        raise RuntimeError("MoE LoRA plan tables are missing from the package")
+    return _PlansFileModel.model_validate(raw)
+
+
+@dataclass(frozen=True, slots=True)
+class SelectedPlan:
+    key: str
+    name: str
+    base_gemm_rows: str
+    plan: MoeLoraExecutionPlan
+
+
+def build_plan(
+    spec: _PlanSpecModel,
+    *,
+    activation: ActivationFn,
+    is_shared_outer: bool,
+) -> MoeLoraExecutionPlan:
+    gate_up_a_family = spec.gate_up_a_family
+    gate_up_layout = (
+        BridgeLayout.TOKEN_MAJOR
+        if gate_up_a_family is LoraAFamily.TOKEN_GROUPED
+        else BridgeLayout.PAIR_MAJOR
+    )
+    act_family = spec.act_family
+    finalize_family = spec.finalize_family
+    consumes_gate_up_b = act_family is ActFamily.B_ACTIVATION
+    consumes_down_b = finalize_family is not FinalizeFamily.MATERIALIZED
+    plan = MoeLoraExecutionPlan(
+        gate_up_a=LoraASpec(
+            Site.GATE_UP, gate_up_a_family, is_shared_outer, gate_up_layout
+        ),
+        gate_up_b=(
+            None
+            if consumes_gate_up_b
+            else LoraBSpec(Site.GATE_UP, spec.gate_up_b_family, False, gate_up_layout)
+        ),
+        act=ActSpec(act_family, activation),
+        down_a=LoraASpec(
+            Site.DOWN,
+            spec.down_a_family,
+            False,
+            BridgeLayout.PAIR_MAJOR,
+        ),
+        down_b=(
+            None
+            if consumes_down_b
+            else LoraBSpec(
+                Site.DOWN,
+                spec.down_b_family,
+                is_shared_outer,
+                BridgeLayout.PAIR_MAJOR,
+            )
+        ),
+        finalize=FinalizeSpec(
+            finalize_family, is_shared_outer if consumes_down_b else False
+        ),
+        gate_up_overlap=spec.gate_up_overlap,
+        down_overlap=spec.down_overlap,
+        route_builder=spec.route_builder,
+        down_b_into_base=spec.down_b_into_base,
+    )
+    return plan
+
+
+@cache
+def _warn_out_of_domain(
+    architecture: DeviceArchitecture, hidden_size: int, num_local_experts: int
+) -> None:
+    logger.warning(
+        "MoE LoRA geometry (hidden=%d, local_experts=%d) is outside the tuned "
+        "domain of table %r; serving the fallback rows",
+        hidden_size,
+        num_local_experts,
+        architecture.value,
+    )
+
+
+def resolve_plans(
+    *,
+    architecture: DeviceArchitecture,
+    is_shared_outer: bool,
+    physical_rank: int,
+    activation: ActivationFn,
+    hidden_size: int,
+    num_local_experts: int,
+) -> dict[Phase, SelectedPlan]:
+    table = load_plans(architecture)
+    layout_name = "shared" if is_shared_outer else "per_expert"
+    in_domain = table.domain.admits(
+        hidden_size=hidden_size, num_local_experts=num_local_experts
+    )
+    rows = table.scenarios if in_domain else []
+    if not in_domain:
+        _warn_out_of_domain(architecture, hidden_size, num_local_experts)
+    selected: dict[Phase, SelectedPlan] = {}
+    for phase in Phase:
+        # Earlier rows take precedence, including wildcard rows.
+        row = next(
+            (
+                candidate
+                for candidate in (*rows, *table.fallback)
+                if candidate.layout in (None, layout_name)
+                and candidate.phase in (None, phase)
+                and (candidate.max_rank is None or physical_rank <= candidate.max_rank)
+            ),
+            None,
+        )
+        if row is None:
+            raise RuntimeError(
+                f"no MoE LoRA plan row matches ({layout_name}, {phase.value}) "
+                f"on {architecture.value}"
+            )
+        selected[phase] = SelectedPlan(
+            key=f"{architecture.value}.{row.name}",
+            name=row.name,
+            base_gemm_rows=row.base_gemm_rows,
+            plan=build_plan(
+                row.plan,
+                activation=activation,
+                is_shared_outer=is_shared_outer,
+            ),
+        )
+    return selected

--- a/python/sglang/srt/lora/moe/kernels/__init__.py
+++ b/python/sglang/srt/lora/moe/kernels/__init__.py
@@ -1,0 +1,1 @@
+"""MoE LoRA kernels and the CuTeDSL grouped-GEMM implementation."""

--- a/python/sglang/srt/lora/moe/kernels/activation_delta.py
+++ b/python/sglang/srt/lora/moe/kernels/activation_delta.py
@@ -1,0 +1,198 @@
+"""Add LoRA before activation and expose pair-major inputs for down-A.
+
+pair_to_row addresses either base row layout; invalid pair outputs are zero.
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+from sglang.srt.lora.moe.activation import ActivationFn
+
+
+@triton.jit
+def apply_activation(x, ACTIVATION_TYPE: tl.constexpr):
+    if ACTIVATION_TYPE == "silu":
+        return x * tl.sigmoid(x)
+    elif ACTIVATION_TYPE == "relu2":
+        value = tl.maximum(x, 0.0)
+        return value * value
+    else:
+        raise ValueError(f"unsupported activation {ACTIVATION_TYPE}")
+
+
+@triton.jit
+def _act_delta_kernel(
+    gateup_ptr,  # [rows, slices * inter] bf16, flat base rows
+    delta_ptr,  # [num_tokens, top_k, slices * inter] [gate | up]
+    act_out_ptr,  # [rows, inter] bf16, flat base rows
+    act_lora_in_ptr,  # [num_tokens, top_k, inter] bf16
+    pair_to_row_ptr,  # [num_tokens * top_k] int32
+    topk_ids_ptr,  # [num_tokens, top_k] (local ids; < 0 = invalid)
+    top_k,
+    num_local_experts,
+    inter,
+    HAS_DELTA: tl.constexpr,
+    NUM_SLICES: tl.constexpr,
+    ACTIVATION_TYPE: tl.constexpr,
+    GATE_FIRST: tl.constexpr,
+    INTERLEAVED: tl.constexpr,
+    CONSUME_BASE_PDL: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pair_idx_int32 = tl.program_id(0)
+    pair_idx = pair_idx_int32.to(tl.int64)
+
+    expert_id = tl.load(topk_ids_ptr + pair_idx)
+    valid = (expert_id >= 0) & (expert_id < num_local_experts)
+    dst_row = tl.load(pair_to_row_ptr + pair_idx, mask=valid, other=0).to(tl.int64)
+
+    total_inter = NUM_SLICES * inter
+    gateup_row = gateup_ptr + dst_row * total_inter
+    delta_row = delta_ptr + pair_idx * total_inter
+    act_out_row = act_out_ptr + dst_row * inter
+    lora_in_row = act_lora_in_ptr + pair_idx * inter
+
+    vec = tl.arange(0, BLOCK_SIZE)
+    if CONSUME_BASE_PDL:
+        # Wait just before the first read of the gate/up GEMM's output.
+        tl.extra.cuda.gdc_wait()
+    for start in tl.range(0, inter, BLOCK_SIZE):
+        offs = start + vec
+        mask = offs < inter
+
+        if NUM_SLICES == 1:
+            gate_offs = offs
+            up_offs = offs
+        elif INTERLEAVED:
+            gate_offs = 2 * offs
+            up_offs = 2 * offs + 1
+        else:
+            gate_offs = offs
+            up_offs = inter + offs
+        if not GATE_FIRST:
+            gate_offs, up_offs = up_offs, gate_offs
+
+        g = tl.load(gateup_row + gate_offs, mask=mask & valid, other=0.0).to(tl.float32)
+        if HAS_DELTA:
+            # The delta is always contiguous [gate | up].
+            dg = tl.load(delta_row + offs, mask=mask & valid, other=0.0).to(tl.float32)
+            g += dg
+        act = apply_activation(g, ACTIVATION_TYPE)
+        if NUM_SLICES == 2:
+            u = tl.load(gateup_row + up_offs, mask=mask & valid, other=0.0).to(
+                tl.float32
+            )
+            if HAS_DELTA:
+                du = tl.load(
+                    delta_row + inter + offs,
+                    mask=mask & valid,
+                    other=0.0,
+                ).to(tl.float32)
+                u += du
+            act = act * u
+        act_bf16 = act.to(act_out_ptr.dtype.element_ty)
+
+        tl.store(act_out_row + offs, act_bf16, mask=mask & valid)
+        lora_in = tl.where(valid, act, 0.0)
+        tl.store(
+            lora_in_row + offs, lora_in.to(act_lora_in_ptr.dtype.element_ty), mask=mask
+        )
+
+
+def _launch_act_delta(
+    gateup_rows: torch.Tensor,  # [rows, slices * inter] bf16, flat
+    gate_up_delta: torch.Tensor | None,  # [num_tokens, top_k, slices * inter]
+    act_out_rows: torch.Tensor,  # [rows, inter] bf16, flat
+    activation_lora_input: torch.Tensor,  # [num_tokens, top_k, inter] bf16
+    pair_to_row: torch.Tensor,  # [num_tokens * top_k] int32
+    topk_ids: torch.Tensor,  # [num_tokens, top_k]
+    *,
+    num_local_experts: int,
+    gate_first: bool,
+    interleaved: bool,
+    activation: str,
+    consume_base_pdl: bool,
+) -> None:
+    ActivationFn.parse(activation)
+    num_pairs = topk_ids.numel()
+    if num_pairs == 0:
+        return
+    inter = act_out_rows.shape[-1]
+    num_slices = gateup_rows.shape[-1] // inter
+    _act_delta_kernel[(num_pairs,)](
+        gateup_rows,
+        gate_up_delta if gate_up_delta is not None else gateup_rows,
+        act_out_rows,
+        activation_lora_input,
+        pair_to_row,
+        topk_ids,
+        topk_ids.shape[1],
+        num_local_experts,
+        inter,
+        HAS_DELTA=gate_up_delta is not None,
+        NUM_SLICES=num_slices,
+        ACTIVATION_TYPE=activation,
+        GATE_FIRST=gate_first,
+        INTERLEAVED=interleaved,
+        CONSUME_BASE_PDL=consume_base_pdl,
+        BLOCK_SIZE=512,
+        **({"launch_pdl": True} if consume_base_pdl else {}),
+    )
+
+
+def act_delta_masked(
+    gateup_output: torch.Tensor,  # [E_local, m_max, slices * inter] bf16
+    gate_up_delta: torch.Tensor | None,  # [num_tokens, top_k, slices * inter]
+    act_out: torch.Tensor,  # [E_local, m_max, inter] bf16
+    activation_lora_input: torch.Tensor,  # [num_tokens, top_k, inter] bf16
+    pair_to_row: torch.Tensor,  # [num_tokens * top_k] int32 slab rows
+    topk_ids: torch.Tensor,  # [num_tokens, top_k]
+    gate_first: bool = True,
+    interleaved: bool = False,
+    activation: str = "silu",
+    consume_base_pdl: bool = False,
+) -> None:
+    _launch_act_delta(
+        gateup_output.view(-1, gateup_output.shape[-1]),
+        gate_up_delta,
+        act_out.view(-1, act_out.shape[-1]),
+        activation_lora_input,
+        pair_to_row,
+        topk_ids,
+        num_local_experts=gateup_output.shape[0],
+        gate_first=gate_first,
+        interleaved=interleaved,
+        activation=activation,
+        consume_base_pdl=consume_base_pdl,
+    )
+
+
+def act_delta_contiguous(
+    gateup_output: torch.Tensor,  # [m_pad_ceiling, slices * inter] bf16
+    gate_up_delta: torch.Tensor | None,  # [num_tokens, top_k, slices * inter]
+    act_out: torch.Tensor,  # [m_pad_ceiling, inter] bf16
+    activation_lora_input: torch.Tensor,  # [num_tokens, top_k, inter] bf16
+    pair_to_row: torch.Tensor,  # [num_tokens * top_k] int32 COMPACT rows
+    topk_ids: torch.Tensor,  # [num_tokens, top_k]
+    num_local_experts: int,
+    gate_first: bool = True,
+    interleaved: bool = False,
+    activation: str = "silu",
+    consume_base_pdl: bool = False,
+) -> None:
+    _launch_act_delta(
+        gateup_output,
+        gate_up_delta,
+        act_out,
+        activation_lora_input,
+        pair_to_row,
+        topk_ids,
+        num_local_experts=num_local_experts,
+        gate_first=gate_first,
+        interleaved=interleaved,
+        activation=activation,
+        consume_base_pdl=consume_base_pdl,
+    )

--- a/python/sglang/srt/lora/moe/kernels/activation_delta.py
+++ b/python/sglang/srt/lora/moe/kernels/activation_delta.py
@@ -10,6 +10,7 @@ import triton
 import triton.language as tl
 
 from sglang.srt.lora.moe.activation import ActivationFn
+from sglang.srt.lora.moe.kernels.fp8_quant import quantize_fp8_groups
 
 
 @triton.jit
@@ -29,6 +30,8 @@ def _act_delta_kernel(
     delta_ptr,  # [num_tokens, top_k, slices * inter] [gate | up]
     act_out_ptr,  # [rows, inter] bf16, flat base rows
     act_lora_in_ptr,  # [num_tokens, top_k, inter] bf16
+    act_q_ptr,  # [rows, inter] fp8e4m3 (QUANT_GROUP > 0 only)
+    act_s_ptr,  # [rows, inter // QUANT_GROUP] fp32 row-major
     pair_to_row_ptr,  # [num_tokens * top_k] int32
     topk_ids_ptr,  # [num_tokens, top_k] (local ids; < 0 = invalid)
     top_k,
@@ -39,7 +42,8 @@ def _act_delta_kernel(
     ACTIVATION_TYPE: tl.constexpr,
     GATE_FIRST: tl.constexpr,
     INTERLEAVED: tl.constexpr,
-    CONSUME_BASE_PDL: tl.constexpr,
+    QUANT_GROUP: tl.constexpr,  # 0 disables the additional FP8 output.
+    WHOLE_ROW: tl.constexpr,  # Match upstream's whole-row rounding.
     BLOCK_SIZE: tl.constexpr,
 ):
     pair_idx_int32 = tl.program_id(0)
@@ -56,9 +60,6 @@ def _act_delta_kernel(
     lora_in_row = act_lora_in_ptr + pair_idx * inter
 
     vec = tl.arange(0, BLOCK_SIZE)
-    if CONSUME_BASE_PDL:
-        # Wait just before the first read of the gate/up GEMM's output.
-        tl.extra.cuda.gdc_wait()
     for start in tl.range(0, inter, BLOCK_SIZE):
         offs = start + vec
         mask = offs < inter
@@ -100,6 +101,28 @@ def _act_delta_kernel(
         tl.store(
             lora_in_row + offs, lora_in.to(act_lora_in_ptr.dtype.element_ty), mask=mask
         )
+        if QUANT_GROUP > 0:
+            # Quantize the BF16-rounded value, matching the unfused path.
+            # Admission ensures each quantization group is fully valid or masked.
+            QG: tl.constexpr = QUANT_GROUP if QUANT_GROUP > 0 else BLOCK_SIZE
+            grouped = tl.reshape(
+                tl.where(mask & valid, act_bf16.to(tl.float32), 0.0),
+                (BLOCK_SIZE // QG, QG),
+            )
+            q, scale = quantize_fp8_groups(grouped, WHOLE_ROW)
+            tl.store(
+                act_q_ptr + dst_row * inter + offs,
+                tl.reshape(q, (BLOCK_SIZE,)).to(act_q_ptr.dtype.element_ty),
+                mask=mask & valid,
+            )
+            gvec = tl.arange(0, BLOCK_SIZE // QG)
+            goffs = start // QG + gvec
+            n_groups = inter // QG
+            tl.store(
+                act_s_ptr + dst_row * n_groups + goffs,
+                scale,
+                mask=(goffs < n_groups) & valid,
+            )
 
 
 def _launch_act_delta(
@@ -114,7 +137,7 @@ def _launch_act_delta(
     gate_first: bool,
     interleaved: bool,
     activation: str,
-    consume_base_pdl: bool,
+    act_quant: tuple[torch.Tensor, torch.Tensor, int] | None = None,
 ) -> None:
     ActivationFn.parse(activation)
     num_pairs = topk_ids.numel()
@@ -122,11 +145,18 @@ def _launch_act_delta(
         return
     inter = act_out_rows.shape[-1]
     num_slices = gateup_rows.shape[-1] // inter
+    if act_quant is not None:
+        act_q, act_s, group = act_quant
+        assert inter % group == 0 and 512 % group == 0
+    else:
+        act_q, act_s, group = act_out_rows, act_out_rows, 0
     _act_delta_kernel[(num_pairs,)](
         gateup_rows,
         gate_up_delta if gate_up_delta is not None else gateup_rows,
         act_out_rows,
         activation_lora_input,
+        act_q,
+        act_s,
         pair_to_row,
         topk_ids,
         topk_ids.shape[1],
@@ -137,9 +167,9 @@ def _launch_act_delta(
         ACTIVATION_TYPE=activation,
         GATE_FIRST=gate_first,
         INTERLEAVED=interleaved,
-        CONSUME_BASE_PDL=consume_base_pdl,
+        QUANT_GROUP=group,
+        WHOLE_ROW=inter == group,
         BLOCK_SIZE=512,
-        **({"launch_pdl": True} if consume_base_pdl else {}),
     )
 
 
@@ -153,7 +183,7 @@ def act_delta_masked(
     gate_first: bool = True,
     interleaved: bool = False,
     activation: str = "silu",
-    consume_base_pdl: bool = False,
+    act_quant: tuple[torch.Tensor, torch.Tensor, int] | None = None,
 ) -> None:
     _launch_act_delta(
         gateup_output.view(-1, gateup_output.shape[-1]),
@@ -166,7 +196,7 @@ def act_delta_masked(
         gate_first=gate_first,
         interleaved=interleaved,
         activation=activation,
-        consume_base_pdl=consume_base_pdl,
+        act_quant=act_quant,
     )
 
 
@@ -181,7 +211,7 @@ def act_delta_contiguous(
     gate_first: bool = True,
     interleaved: bool = False,
     activation: str = "silu",
-    consume_base_pdl: bool = False,
+    act_quant: tuple[torch.Tensor, torch.Tensor, int] | None = None,
 ) -> None:
     _launch_act_delta(
         gateup_output,
@@ -194,5 +224,5 @@ def act_delta_contiguous(
         gate_first=gate_first,
         interleaved=interleaved,
         activation=activation,
-        consume_base_pdl=consume_base_pdl,
+        act_quant=act_quant,
     )

--- a/python/sglang/srt/lora/moe/kernels/align_rows.py
+++ b/python/sglang/srt/lora/moe/kernels/align_rows.py
@@ -1,0 +1,91 @@
+"""Align routed pairs for Triton and Marlin, dropping negative expert IDs.
+
+For one token, distinct top-k IDs allow one block per expert in a single launch.
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _align_single_token_kernel(
+    topk_ids_ptr,  # int32 [TOPK]
+    sorted_ids_ptr,  # int32 [TOPK * BLOCK_SIZE]
+    expert_ids_ptr,  # int32 [TOPK]
+    num_post_ptr,  # int32 [1]
+    TOPK: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    LANES: tl.constexpr,  # next pow2 >= TOPK
+    SLOTS: tl.constexpr,  # next pow2 >= TOPK * BLOCK_SIZE
+):
+    lane = tl.arange(0, LANES)
+    in_range = lane < TOPK
+    ids = tl.load(topk_ids_ptr + lane, mask=in_range, other=-1)
+    valid = ids >= 0
+    # Dropped lanes sort past every valid id; their ties break on lane.
+    key = tl.where(valid, ids, 2147483647)
+    before = (key[None, :] < key[:, None]) | (
+        (key[None, :] == key[:, None]) & (lane[None, :] < lane[:, None])
+    )
+    rank = tl.sum(before.to(tl.int32), axis=1)
+    n_valid = tl.sum(valid.to(tl.int32), axis=0)
+
+    # For one token, the lane is the flat pair index.
+    tl.store(expert_ids_ptr + rank, ids, mask=valid)
+    tl.store(sorted_ids_ptr + rank * BLOCK_SIZE, lane, mask=valid)
+    tl.store(
+        expert_ids_ptr + lane,
+        tl.full([LANES], -1, tl.int32),
+        mask=in_range & (lane >= n_valid),
+    )
+    # Padding uses numel (= TOPK), matching the general alignment path.
+    slot = tl.arange(0, SLOTS)
+    pad = (slot < TOPK * BLOCK_SIZE) & (
+        (slot % BLOCK_SIZE != 0) | (slot // BLOCK_SIZE >= n_valid)
+    )
+    tl.store(sorted_ids_ptr + slot, tl.full([SLOTS], TOPK, tl.int32), mask=pad)
+    tl.store(num_post_ptr, n_valid * BLOCK_SIZE)
+
+
+def moe_align_single_token(
+    topk_ids: torch.Tensor, block_size: int
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Align distinct top-k IDs for one token; accepts int32 [1, topk], topk <= 32."""
+    topk = topk_ids.shape[1]
+    device = topk_ids.device
+    sorted_ids = torch.empty((topk * block_size,), dtype=torch.int32, device=device)
+    expert_ids = torch.empty((topk,), dtype=torch.int32, device=device)
+    num_post = torch.empty((1,), dtype=torch.int32, device=device)
+    _align_single_token_kernel[(1,)](
+        topk_ids,
+        sorted_ids,
+        expert_ids,
+        num_post,
+        TOPK=topk,
+        BLOCK_SIZE=block_size,
+        LANES=triton.next_power_of_2(topk),
+        SLOTS=triton.next_power_of_2(topk * block_size),
+        num_warps=1,
+    )
+    return sorted_ids, expert_ids, num_post
+
+
+def align_rows(
+    topk_ids: torch.Tensor, block_size: int, num_experts: int
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    if (
+        topk_ids.shape[0] == 1
+        and topk_ids.shape[1] <= 32
+        and topk_ids.dtype == torch.int32
+    ):
+        return moe_align_single_token(topk_ids, block_size)
+    from sglang.srt.layers.moe.moe_runner.triton_utils.moe_align_block_size import (
+        moe_align_block_size,
+    )
+
+    return moe_align_block_size(
+        topk_ids, block_size, num_experts, ignore_invalid_expert=True
+    )

--- a/python/sglang/srt/lora/moe/kernels/cutedsl/__init__.py
+++ b/python/sglang/srt/lora/moe/kernels/cutedsl/__init__.py
@@ -1,0 +1,8 @@
+"""CuTeDSL grouped GEMM for the MoE LoRA base path: two architectures
+(``kernel_sm90_bf16`` WGMMA, ``kernel_sm100_bf16`` tcgen05), two row modes
+(masked ``[E, m_max, *]`` slabs; contiguous flat segments, whose
+``seg_offsets`` ride the ``group_m`` argument slot). ``api`` compiles and
+binds; ``schedule_builder`` writes the packed schedules and owns their ABI;
+``scheduler`` decodes them on device. The mainloops derive from the CUTLASS
+dense persistent examples and keep their NVIDIA BSD-3 headers.
+"""

--- a/python/sglang/srt/lora/moe/kernels/cutedsl/__init__.py
+++ b/python/sglang/srt/lora/moe/kernels/cutedsl/__init__.py
@@ -1,8 +1,4 @@
-"""CuTeDSL grouped GEMM for the MoE LoRA base path: two architectures
-(``kernel_sm90_bf16`` WGMMA, ``kernel_sm100_bf16`` tcgen05), two row modes
-(masked ``[E, m_max, *]`` slabs; contiguous flat segments, whose
-``seg_offsets`` ride the ``group_m`` argument slot). ``api`` compiles and
-binds; ``schedule_builder`` writes the packed schedules and owns their ABI;
-``scheduler`` decodes them on device. The mainloops derive from the CUTLASS
-dense persistent examples and keep their NVIDIA BSD-3 headers.
+"""SM90/SM100 grouped GEMMs for BF16 and FP8, with masked or contiguous rows.
+
+Mainloops derive from the CUTLASS dense persistent examples (NVIDIA BSD-3).
 """

--- a/python/sglang/srt/lora/moe/kernels/cutedsl/api.py
+++ b/python/sglang/srt/lora/moe/kernels/cutedsl/api.py
@@ -64,6 +64,63 @@ def _bf16_kernel_class_for(device: torch.device):
     )
 
 
+@cute.jit
+def grouped_gemm_fp8_swap_ab(
+    gemm_op: cutlass.Constexpr,
+    a: cute.Tensor,  # physical routed input (expert, m_max, k) e4m3
+    b: cute.Tensor,  # physical weight (expert, n_out, k) e4m3
+    sf_tokens: cute.Tensor,  # physical (expert, rows, k/128) fp32
+    sf_weights: cute.Tensor,  # physical (expert, n/128, k/128) fp32
+    c: cute.Tensor,  # physical output (expert, m_max, n_out) bf16
+    group_m: cute.Tensor,
+    direct_schedule: cute.Tensor,
+    schedule_tiles: cute.Tensor,
+    max_active_clusters: cutlass.Constexpr,
+    stream: cuda.CUstream,
+    epilogue_op: cutlass.Constexpr = lambda x: x,
+):
+    # SFA follows weights (kernel A); SFB follows tokens (kernel B).
+    weight_mke = cute.make_tensor(b.iterator, cute.select(b.layout, mode=[1, 2, 0]))
+    token_nke = cute.make_tensor(a.iterator, cute.select(a.layout, mode=[1, 2, 0]))
+    output_mne = cute.make_tensor(c.iterator, cute.select(c.layout, mode=[2, 1, 0]))
+    sfa_weights = cute.make_tensor(
+        sf_weights.iterator, cute.select(sf_weights.layout, mode=[1, 2, 0])
+    )
+    sfb_tokens = cute.make_tensor(
+        sf_tokens.iterator, cute.select(sf_tokens.layout, mode=[1, 2, 0])
+    )
+    gemm_op(
+        weight_mke,
+        token_nke,
+        sfa_weights,
+        sfb_tokens,
+        output_mne,
+        group_m,
+        direct_schedule,
+        schedule_tiles,
+        max_active_clusters,
+        stream,
+        epilogue_op,
+    )
+
+
+def _fp8_kernel_class_for(device: torch.device):
+    major, _minor = torch.cuda.get_device_capability(device)
+    if major >= 10:
+        from sglang.srt.lora.moe.kernels.cutedsl.kernel_sm100_fp8 import (
+            GroupedGemmKernelSm100Fp8,
+        )
+
+        return GroupedGemmKernelSm100Fp8
+    if major == 9:
+        from sglang.srt.lora.moe.kernels.cutedsl.kernel_sm90_fp8 import (
+            GroupedGemmKernelSm90Fp8,
+        )
+
+        return GroupedGemmKernelSm90Fp8
+    raise NotImplementedError(f"the FP8 grouped GEMM needs SM90+; device is sm{major}x")
+
+
 class GroupedGemmConfig(msgspec.Struct, frozen=True, kw_only=True):
     mma_tiler_mn: Tuple[int, int] = (64, 128)
     cluster_shape_mn: Tuple[int, int] = (1, 1)
@@ -71,9 +128,6 @@ class GroupedGemmConfig(msgspec.Struct, frozen=True, kw_only=True):
     occupancy: int = 1
     mma_inst_tile_k: int = 4
     persistent_clusters: int | None = None
-    # This flag only lets the GEMM release a later kernel. The GEMM itself
-    # does not start early against its own producer.
-    produce_pdl: bool = False
 
 
 class PreparedGroupedGemm(msgspec.Struct, kw_only=True):
@@ -126,6 +180,11 @@ def _compile_prepared(
     direct_schedule_arg = as_dynamic_cute_tensor(direct_schedule, leading_dim=0)
     schedule_tiles_arg = as_dynamic_cute_tensor(schedule_tiles, leading_dim=0)
 
+    kernel_kwargs = {}
+    if getattr(kernel_cls, "SUPPORTS_SINGLE_K_PIPELINE", False):
+        # Compile the rolling pipeline only for single-K tiles to save registers.
+        cta_tile_k = 32 * config.mma_inst_tile_k
+        kernel_kwargs["single_k_pipeline"] = problem_shape[2] <= cta_tile_k
     gemm = kernel_cls(
         acc_dtype=cutlass.Float32,
         use_2cta_instrs=config.use_2cta_instrs,
@@ -133,9 +192,9 @@ def _compile_prepared(
         cluster_shape_mn=config.cluster_shape_mn,
         mma_inst_tile_k=config.mma_inst_tile_k,
         persistent_clusters=config.persistent_clusters,
-        produce_pdl=config.produce_pdl,
         swap_ab=True,
         contiguous_segments=contiguous_segments,
+        **kernel_kwargs,
     )
     gemm.occupancy = config.occupancy
     if not gemm.can_implement(
@@ -227,6 +286,78 @@ def prepare_contiguous_bf16(
         operand_args=(
             as_dynamic_cute_tensor(a.unsqueeze(0), leading_dim=2),
             as_dynamic_cute_tensor(b, leading_dim=2),
+            as_dynamic_cute_tensor(c.unsqueeze(0), leading_dim=2),
+        ),
+        group_m_arg=as_dynamic_cute_tensor(seg_offsets, leading_dim=0),
+        direct_schedule=direct_schedule,
+        schedule_tiles=schedule_tiles,
+        device=a.device,
+    )
+
+
+def prepare_masked_fp8(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    sf_tokens: torch.Tensor,  # fp32 [E, m_max, K // 128]
+    sf_weights: torch.Tensor,  # fp32 [E, N // 128, K // 128] (checkpoint form)
+    c: torch.Tensor,
+    masked_m: torch.Tensor,
+    *,
+    config: GroupedGemmConfig,
+    direct_schedule: torch.Tensor | None = None,
+    schedule_tiles: torch.Tensor | None = None,
+) -> PreparedGroupedGemm:
+    assert sf_tokens.dtype == torch.float32 and sf_weights.dtype == torch.float32
+    experts, m_max, k = a.shape
+    n = b.shape[1]
+    return _compile_prepared(
+        kernel_cls=_fp8_kernel_class_for(a.device),
+        wrapper=grouped_gemm_fp8_swap_ab,
+        ab_dtype=cutlass.Float8E4M3FN,
+        config=config,
+        contiguous_segments=False,
+        problem_shape=(n, m_max, k, experts),
+        operand_args=(
+            as_dynamic_cute_tensor(a, leading_dim=2),
+            as_dynamic_cute_tensor(b, leading_dim=2),
+            as_dynamic_cute_tensor(sf_tokens, leading_dim=2),
+            as_dynamic_cute_tensor(sf_weights, leading_dim=2),
+            as_dynamic_cute_tensor(c, leading_dim=2),
+        ),
+        group_m_arg=as_dynamic_cute_tensor(masked_m, leading_dim=0),
+        direct_schedule=direct_schedule,
+        schedule_tiles=schedule_tiles,
+        device=a.device,
+    )
+
+
+def prepare_contiguous_fp8(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    sf_tokens: torch.Tensor,  # fp32 [1, M, K // 128]
+    sf_weights: torch.Tensor,  # fp32 [E, N // 128, K // 128] (checkpoint form)
+    c: torch.Tensor,
+    seg_offsets: torch.Tensor,
+    *,
+    config: GroupedGemmConfig,
+    direct_schedule: torch.Tensor | None = None,
+    schedule_tiles: torch.Tensor | None = None,
+) -> PreparedGroupedGemm:
+    assert sf_tokens.dtype == torch.float32 and sf_weights.dtype == torch.float32
+    m_ceil, k = a.shape
+    experts, n, _ = b.shape
+    return _compile_prepared(
+        kernel_cls=_fp8_kernel_class_for(a.device),
+        wrapper=grouped_gemm_fp8_swap_ab,
+        ab_dtype=cutlass.Float8E4M3FN,
+        config=config,
+        contiguous_segments=True,
+        problem_shape=(n, m_ceil, k, experts),
+        operand_args=(
+            as_dynamic_cute_tensor(a.unsqueeze(0), leading_dim=2),
+            as_dynamic_cute_tensor(b, leading_dim=2),
+            as_dynamic_cute_tensor(sf_tokens, leading_dim=2),
+            as_dynamic_cute_tensor(sf_weights, leading_dim=2),
             as_dynamic_cute_tensor(c.unsqueeze(0), leading_dim=2),
         ),
         group_m_arg=as_dynamic_cute_tensor(seg_offsets, leading_dim=0),

--- a/python/sglang/srt/lora/moe/kernels/cutedsl/api.py
+++ b/python/sglang/srt/lora/moe/kernels/cutedsl/api.py
@@ -1,0 +1,236 @@
+# Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Compile grouped GEMMs with dynamic row counts; providers cache the code."""
+
+from typing import Any, Tuple
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import cutlass.cute.testing as testing
+import cutlass.utils as utils
+import msgspec
+import torch
+from cutlass.cute.runtime import from_dlpack
+
+from sglang.srt.lora.moe.kernels.cutedsl.kernel_sm100_bf16 import (
+    GroupedGemmKernelSm100Bf16,
+)
+
+
+@cute.jit
+def grouped_gemm_bf16_swap_ab(
+    gemm_op: cutlass.Constexpr,
+    a: cute.Tensor,  # physical routed input (expert, m_max, k)
+    b: cute.Tensor,  # physical weight (expert, n_out, k)
+    c: cute.Tensor,  # physical output (expert, m_max, n_out)
+    group_m: cute.Tensor,
+    direct_schedule: cute.Tensor,
+    schedule_tiles: cute.Tensor,
+    max_active_clusters: cutlass.Constexpr,
+    stream: cuda.CUstream,
+    epilogue_op: cutlass.Constexpr = lambda x: x,
+):
+    # W @ X.T puts tokens on N for 8-wide tiles; C uses the transposed layout.
+    weight_mke = cute.make_tensor(b.iterator, cute.select(b.layout, mode=[1, 2, 0]))
+    token_nke = cute.make_tensor(a.iterator, cute.select(a.layout, mode=[1, 2, 0]))
+    output_mne = cute.make_tensor(c.iterator, cute.select(c.layout, mode=[2, 1, 0]))
+    gemm_op(
+        weight_mke,
+        token_nke,
+        output_mne,
+        group_m,
+        direct_schedule,
+        schedule_tiles,
+        max_active_clusters,
+        stream,
+        epilogue_op,
+    )
+
+
+def _bf16_kernel_class_for(device: torch.device):
+    major, _minor = torch.cuda.get_device_capability(device)
+    if major >= 10:
+        return GroupedGemmKernelSm100Bf16
+    if major == 9:
+        from sglang.srt.lora.moe.kernels.cutedsl.kernel_sm90_bf16 import (
+            GroupedGemmKernelSm90Bf16,
+        )
+
+        return GroupedGemmKernelSm90Bf16
+    raise NotImplementedError(
+        f"the BF16 grouped GEMM needs SM90+; device is sm{major}x"
+    )
+
+
+class GroupedGemmConfig(msgspec.Struct, frozen=True, kw_only=True):
+    mma_tiler_mn: Tuple[int, int] = (64, 128)
+    cluster_shape_mn: Tuple[int, int] = (1, 1)
+    use_2cta_instrs: bool = False
+    occupancy: int = 1
+    mma_inst_tile_k: int = 4
+    persistent_clusters: int | None = None
+    # This flag only lets the GEMM release a later kernel. The GEMM itself
+    # does not start early against its own producer.
+    produce_pdl: bool = False
+
+
+class PreparedGroupedGemm(msgspec.Struct, kw_only=True):
+    """Bound arguments retain the tensors backing their DLPack views."""
+
+    compiled_fn: Any
+    operand_args: tuple  # the wrapper's tensor operands, in its order
+    group_m_arg: cute.Tensor
+    direct_schedule_arg: cute.Tensor
+    schedule_tiles_arg: cute.Tensor
+    direct_schedule_owner: torch.Tensor
+    schedule_tiles_owner: torch.Tensor
+    stream: cuda.CUstream
+
+    def launch(self) -> None:
+        self.compiled_fn(
+            *self.operand_args,
+            self.group_m_arg,
+            self.direct_schedule_arg,
+            self.schedule_tiles_arg,
+            self.stream,
+        )
+
+
+def as_dynamic_cute_tensor(tensor: torch.Tensor, *, leading_dim: int) -> cute.Tensor:
+    """Compile-time and runtime calls must use identical layout wrapping."""
+    return from_dlpack(tensor, assumed_align=16).mark_layout_dynamic(
+        leading_dim=leading_dim
+    )
+
+
+def _compile_prepared(
+    *,
+    kernel_cls,
+    wrapper,
+    ab_dtype,
+    config: GroupedGemmConfig,
+    contiguous_segments: bool,
+    problem_shape: Tuple[int, int, int, int],
+    operand_args: tuple,
+    group_m_arg: cute.Tensor,
+    direct_schedule: torch.Tensor | None,
+    schedule_tiles: torch.Tensor | None,
+    device: torch.device,
+) -> PreparedGroupedGemm:
+    if direct_schedule is None:
+        direct_schedule = torch.zeros((1,), device=device, dtype=torch.int64)
+    if schedule_tiles is None:
+        schedule_tiles = torch.zeros((1,), device=device, dtype=torch.int32)
+    direct_schedule_arg = as_dynamic_cute_tensor(direct_schedule, leading_dim=0)
+    schedule_tiles_arg = as_dynamic_cute_tensor(schedule_tiles, leading_dim=0)
+
+    gemm = kernel_cls(
+        acc_dtype=cutlass.Float32,
+        use_2cta_instrs=config.use_2cta_instrs,
+        mma_tiler_mn=config.mma_tiler_mn,
+        cluster_shape_mn=config.cluster_shape_mn,
+        mma_inst_tile_k=config.mma_inst_tile_k,
+        persistent_clusters=config.persistent_clusters,
+        produce_pdl=config.produce_pdl,
+        swap_ab=True,
+        contiguous_segments=contiguous_segments,
+    )
+    gemm.occupancy = config.occupancy
+    if not gemm.can_implement(
+        problem_shape, ab_dtype, ab_dtype, cutlass.BFloat16, "k", "k", "m"
+    ):
+        raise testing.CantImplementError(
+            f"unsupported {getattr(ab_dtype, '__name__', ab_dtype)} "
+            f"config={config} for logical MNKL={problem_shape}"
+        )
+
+    max_active_clusters = utils.HardwareInfo().get_max_active_clusters(
+        config.cluster_shape_mn[0] * config.cluster_shape_mn[1]
+    )
+    stream = cuda.CUstream(torch.cuda.current_stream(device).cuda_stream)
+    compiled_fn = cute.compile(
+        wrapper,
+        gemm,
+        *operand_args,
+        group_m_arg,
+        direct_schedule_arg,
+        schedule_tiles_arg,
+        max_active_clusters,
+        stream,
+        lambda x: x,
+    )
+    return PreparedGroupedGemm(
+        compiled_fn=compiled_fn,
+        operand_args=operand_args,
+        group_m_arg=group_m_arg,
+        direct_schedule_arg=direct_schedule_arg,
+        schedule_tiles_arg=schedule_tiles_arg,
+        direct_schedule_owner=direct_schedule,
+        schedule_tiles_owner=schedule_tiles,
+        stream=stream,
+    )
+
+
+def prepare_masked_bf16(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    c: torch.Tensor,
+    masked_m: torch.Tensor,
+    *,
+    config: GroupedGemmConfig,
+    direct_schedule: torch.Tensor | None = None,
+    schedule_tiles: torch.Tensor | None = None,
+) -> PreparedGroupedGemm:
+    experts, m_max, k = a.shape
+    n = b.shape[1]
+    return _compile_prepared(
+        kernel_cls=_bf16_kernel_class_for(a.device),
+        wrapper=grouped_gemm_bf16_swap_ab,
+        ab_dtype=cutlass.BFloat16,
+        config=config,
+        contiguous_segments=False,
+        problem_shape=(n, m_max, k, experts),
+        operand_args=(
+            as_dynamic_cute_tensor(a, leading_dim=2),
+            as_dynamic_cute_tensor(b, leading_dim=2),
+            as_dynamic_cute_tensor(c, leading_dim=2),
+        ),
+        group_m_arg=as_dynamic_cute_tensor(masked_m, leading_dim=0),
+        direct_schedule=direct_schedule,
+        schedule_tiles=schedule_tiles,
+        device=a.device,
+    )
+
+
+def prepare_contiguous_bf16(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    c: torch.Tensor,
+    seg_offsets: torch.Tensor,
+    *,
+    config: GroupedGemmConfig,
+    direct_schedule: torch.Tensor | None = None,
+    schedule_tiles: torch.Tensor | None = None,
+) -> PreparedGroupedGemm:
+    """Use seg_offsets in the group_m slot to address flat expert segments."""
+    m_ceil, k = a.shape
+    experts, n, _ = b.shape
+    return _compile_prepared(
+        kernel_cls=_bf16_kernel_class_for(a.device),
+        wrapper=grouped_gemm_bf16_swap_ab,
+        ab_dtype=cutlass.BFloat16,
+        config=config,
+        contiguous_segments=True,
+        problem_shape=(n, m_ceil, k, experts),
+        operand_args=(
+            as_dynamic_cute_tensor(a.unsqueeze(0), leading_dim=2),
+            as_dynamic_cute_tensor(b, leading_dim=2),
+            as_dynamic_cute_tensor(c.unsqueeze(0), leading_dim=2),
+        ),
+        group_m_arg=as_dynamic_cute_tensor(seg_offsets, leading_dim=0),
+        direct_schedule=direct_schedule,
+        schedule_tiles=schedule_tiles,
+        device=a.device,
+    )

--- a/python/sglang/srt/lora/moe/kernels/cutedsl/kernel_sm100_bf16.py
+++ b/python/sglang/srt/lora/moe/kernels/cutedsl/kernel_sm100_bf16.py
@@ -1,0 +1,823 @@
+# Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from typing import Tuple, Type
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import cutlass.cute.testing as testing
+import cutlass.pipeline as pipeline
+import cutlass.utils as utils
+from cutlass.cute.nvgpu import cpasync, tcgen05
+from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
+
+from sglang.srt.lora.moe.kernels.cutedsl.scheduler import (
+    MoESchedulerParams,
+    create_moe_tile_scheduler,
+    resolve_scheduler_params_and_grid,
+)
+
+"""
+The tensors are A ``[E, m_max, K]``, B ``[E, N, K]``, C ``[E, m_max, N]`` and
+``group_m`` ``[E]``. Only ``C[e, :group_m[e]]`` holds defined values. A partial
+tile can write into the padding after those rows. No CTA starts fully outside
+an expert's valid rows.
+
+If ``contiguous_segments`` is true, the kernel reads one flat row buffer in
+place of the per-expert slabs. The ``group_m`` argument then holds
+``seg_offsets``, and the kernel adds that offset to each tile coordinate. Every
+token tile divides the segment alignment, so a partial tile stays inside its own
+segment.
+
+The mainloop and the epilogue come from CUTLASS v4.6.1
+``blackwell/kernel/dense_gemm/dense_gemm_persistent.py``.
+"""
+
+
+class GroupedGemmKernelSm100Bf16:
+    def __init__(
+        self,
+        acc_dtype: Type[cutlass.Numeric],
+        use_2cta_instrs: bool,
+        mma_tiler_mn: Tuple[int, int],
+        cluster_shape_mn: Tuple[int, int],
+        mma_inst_tile_k: int = 4,
+        persistent_clusters: int | None = None,
+        produce_pdl: bool = False,
+        swap_ab: bool = False,
+        contiguous_segments: bool = False,
+    ):
+        self.acc_dtype: Type[cutlass.Numeric] = acc_dtype
+        self.use_2cta_instrs = use_2cta_instrs
+        self.cluster_shape_mn = cluster_shape_mn
+        # The K extent here is a placeholder. _setup_attributes computes it.
+        self.mma_tiler_mn = mma_tiler_mn
+        self.mma_tiler = (*mma_tiler_mn, 1)
+        self.mma_inst_tile_k = mma_inst_tile_k
+        self.persistent_clusters = persistent_clusters
+        self.produce_pdl = produce_pdl
+        self.swap_ab = swap_ab
+        self.contiguous_segments = contiguous_segments
+        if contiguous_segments and not swap_ab:
+            raise ValueError("contiguous_segments requires swap_ab")
+        if contiguous_segments and cluster_shape_mn != (1, 1):
+            raise ValueError("contiguous_segments requires a (1, 1) cluster")
+        self.arch = "sm_100"
+
+        self.cta_group = (
+            tcgen05.CtaGroup.TWO if use_2cta_instrs else tcgen05.CtaGroup.ONE
+        )
+
+        self.occupancy = 1
+        self.epilogue_warp_id = (0, 1, 2, 3)
+        self.mma_warp_id = 4
+        self.tma_warp_id = 5
+        self.threads_per_cta = 32 * len(
+            (self.mma_warp_id, self.tma_warp_id, *self.epilogue_warp_id)
+        )
+        self.epilog_sync_bar_id = 1
+        self.tmem_alloc_sync_bar_id = 2
+
+    def _create_tiled_mma(self):
+        return utils.sm100.make_trivial_tiled_mma(
+            self.a_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.acc_dtype,
+            self.cta_group,
+            self.mma_tiler[:2],
+        )
+
+    def _setup_attributes(self):
+        tiled_mma = self._create_tiled_mma()
+
+        mma_inst_shape_k = cute.size(tiled_mma.shape_mnk, mode=[2])
+        self.mma_tiler = (
+            self.mma_tiler[0],
+            self.mma_tiler[1],
+            mma_inst_shape_k * self.mma_inst_tile_k,
+        )
+        self.cta_tile_shape_mnk = (
+            self.mma_tiler[0] // cute.size(tiled_mma.thr_id.shape),
+            self.mma_tiler[1],
+            self.mma_tiler[2],
+        )
+
+        self.cluster_layout_vmnk = cute.tiled_divide(
+            cute.make_layout((*self.cluster_shape_mn, 1)),
+            (tiled_mma.thr_id.shape,),
+        )
+
+        self.num_mcast_ctas_a = cute.size(self.cluster_layout_vmnk.shape[2])
+        self.num_mcast_ctas_b = cute.size(self.cluster_layout_vmnk.shape[1])
+        self.is_a_mcast = self.num_mcast_ctas_a > 1
+        self.is_b_mcast = self.num_mcast_ctas_b > 1
+
+        self.epi_tile = utils.sm100.compute_epilogue_tile_shape(
+            self.cta_tile_shape_mnk,
+            self.use_2cta_instrs,
+            self.c_layout,
+            self.c_dtype,
+        )
+
+        c_smem_layout = utils.sm100.make_smem_layout_epi(
+            self.c_dtype, self.c_layout, self.epi_tile, 1
+        )
+
+        self.smem_capacity = utils.get_smem_capacity_in_bytes()
+
+        self.num_acc_stage, self.num_ab_stage, self.num_c_stage = self._compute_stages(
+            tiled_mma,
+            self.mma_tiler,
+            self.a_dtype,
+            self.b_dtype,
+            self.c_dtype,
+            self.smem_capacity,
+            self.occupancy,
+            c_smem_layout,
+        )
+
+        self.a_smem_layout_staged = utils.sm100.make_smem_layout_a(
+            tiled_mma, self.mma_tiler, self.a_dtype, self.num_ab_stage
+        )
+        self.b_smem_layout_staged = utils.sm100.make_smem_layout_b(
+            tiled_mma, self.mma_tiler, self.b_dtype, self.num_ab_stage
+        )
+
+        self.c_smem_layout_staged = utils.sm100.make_smem_layout_epi(
+            self.c_dtype, self.c_layout, self.epi_tile, self.num_c_stage
+        )
+
+        self.num_tmem_alloc_cols = self._compute_num_tmem_alloc_cols(
+            tiled_mma, self.mma_tiler, self.num_acc_stage, self.arch
+        )
+
+    @cute.jit
+    def __call__(
+        self,
+        a: cute.Tensor,
+        b: cute.Tensor,
+        c: cute.Tensor,
+        group_m: cute.Tensor,
+        direct_schedule: cute.Tensor,
+        schedule_tiles: cute.Tensor,
+        max_active_clusters: cutlass.Constexpr,
+        stream: cuda.CUstream,
+        epilogue_op: cutlass.Constexpr = lambda x: x,
+    ):
+        self.a_dtype: Type[cutlass.Numeric] = a.element_type
+        self.b_dtype: Type[cutlass.Numeric] = b.element_type
+        self.c_dtype: Type[cutlass.Numeric] = c.element_type
+        self.a_major_mode = utils.LayoutEnum.from_tensor(a).mma_major_mode()
+        self.b_major_mode = utils.LayoutEnum.from_tensor(b).mma_major_mode()
+        self.c_layout = utils.LayoutEnum.from_tensor(c)
+
+        if cutlass.const_expr(self.a_dtype != self.b_dtype):
+            raise TypeError(f"Type must match: {self.a_dtype} != {self.b_dtype}")
+
+        tiled_mma = self._create_tiled_mma()
+
+        self._setup_attributes()
+
+        atom_thr_size = cute.size(tiled_mma.thr_id.shape)
+
+        a_op = utils.sm100.cluster_shape_to_tma_atom_A(
+            self.cluster_shape_mn, tiled_mma.thr_id
+        )
+        a_smem_layout = cute.slice_(self.a_smem_layout_staged, (None, None, None, 0))
+        tma_atom_a, tma_tensor_a = cute.nvgpu.make_tiled_tma_atom_A(
+            a_op,
+            a,
+            a_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+            internal_type=(
+                cutlass.TFloat32 if a.element_type is cutlass.Float32 else None
+            ),
+        )
+
+        b_op = utils.sm100.cluster_shape_to_tma_atom_B(
+            self.cluster_shape_mn, tiled_mma.thr_id
+        )
+        b_smem_layout = cute.slice_(self.b_smem_layout_staged, (None, None, None, 0))
+        tma_atom_b, tma_tensor_b = cute.nvgpu.make_tiled_tma_atom_B(
+            b_op,
+            b,
+            b_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+            internal_type=(
+                cutlass.TFloat32 if b.element_type is cutlass.Float32 else None
+            ),
+        )
+
+        a_copy_size = cute.size_in_bytes(self.a_dtype, a_smem_layout)
+        b_copy_size = cute.size_in_bytes(self.b_dtype, b_smem_layout)
+        self.num_tma_load_bytes = (a_copy_size + b_copy_size) * atom_thr_size
+
+        epi_smem_layout = cute.select(self.c_smem_layout_staged, mode=[0, 1])
+        tma_atom_c, tma_tensor_c = cpasync.make_tiled_tma_atom(
+            cpasync.CopyBulkTensorTileS2GOp(), c, epi_smem_layout, self.epi_tile
+        )
+
+        self.tile_sched_params, grid = resolve_scheduler_params_and_grid(
+            a=a,
+            c=c,
+            cta_tile_shape_mnk=self.cta_tile_shape_mnk,
+            cluster_shape_mn=self.cluster_shape_mn,
+            swap_ab=self.swap_ab,
+            contiguous_segments=self.contiguous_segments,
+            persistent_clusters=self.persistent_clusters,
+            max_active_clusters=max_active_clusters,
+        )
+
+        self.kernel(
+            tiled_mma,
+            tma_atom_a,
+            tma_tensor_a,
+            tma_atom_b,
+            tma_tensor_b,
+            tma_atom_c,
+            tma_tensor_c,
+            group_m,
+            direct_schedule,
+            schedule_tiles,
+            self.cluster_layout_vmnk,
+            self.a_smem_layout_staged,
+            self.b_smem_layout_staged,
+            self.c_smem_layout_staged,
+            self.epi_tile,
+            self.tile_sched_params,
+            epilogue_op,
+        ).launch(
+            grid=grid,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=(*self.cluster_shape_mn, 1),
+            stream=stream,
+        )
+        return
+
+    @cute.kernel
+    def kernel(
+        self,
+        tiled_mma: cute.TiledMma,
+        tma_atom_a: cute.CopyAtom,
+        mA_mkl: cute.Tensor,
+        tma_atom_b: cute.CopyAtom,
+        mB_nkl: cute.Tensor,
+        tma_atom_c: cute.CopyAtom,
+        mC_mnl: cute.Tensor,
+        group_m: cute.Tensor,
+        direct_schedule: cute.Tensor,
+        schedule_tiles: cute.Tensor,
+        cluster_layout_vmnk: cute.Layout,
+        a_smem_layout_staged: cute.ComposedLayout,
+        b_smem_layout_staged: cute.ComposedLayout,
+        c_smem_layout_staged: cute.ComposedLayout,
+        epi_tile: cute.Tile,
+        tile_sched_params: MoESchedulerParams,
+        epilogue_op: cutlass.Constexpr,
+    ):
+        warp_idx = cute.arch.warp_idx()
+        warp_idx = cute.arch.make_warp_uniform(warp_idx)
+        if cutlass.const_expr(self.produce_pdl):
+            # Start the next kernel's prologue now; its own wait still holds
+            # back the first read of this GEMM's output.
+            cute.arch.griddepcontrol_launch_dependents()
+
+        if warp_idx == self.tma_warp_id:
+            cpasync.prefetch_descriptor(tma_atom_a)
+            cpasync.prefetch_descriptor(tma_atom_b)
+            cpasync.prefetch_descriptor(tma_atom_c)
+
+        use_2cta_instrs = cute.size(tiled_mma.thr_id.shape) == 2
+
+        bidx, bidy, bidz = cute.arch.block_idx()
+        mma_tile_coord_v = bidx % cute.size(tiled_mma.thr_id.shape)
+        is_leader_cta = mma_tile_coord_v == 0
+        cta_rank_in_cluster = cute.arch.make_warp_uniform(
+            cute.arch.block_idx_in_cluster()
+        )
+        block_in_cluster_coord_vmnk = cluster_layout_vmnk.get_flat_coord(
+            cta_rank_in_cluster
+        )
+        tidx, _, _ = cute.arch.thread_idx()
+
+        @cute.struct
+        class SharedStorage:
+            ab_full_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_ab_stage * 2]
+            acc_full_mbar_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.num_acc_stage * 2
+            ]
+            tmem_dealloc_mbar: cutlass.Int64
+            tmem_holding_buf: cutlass.Int32
+
+        smem = utils.SmemAllocator()
+        storage = smem.allocate(SharedStorage)
+
+        ab_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        num_tma_producer = self.num_mcast_ctas_a + self.num_mcast_ctas_b - 1
+        ab_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, num_tma_producer
+        )
+        ab_producer, ab_consumer = pipeline.PipelineTmaUmma.create(
+            barrier_storage=storage.ab_full_mbar_ptr.data_ptr(),
+            num_stages=self.num_ab_stage,
+            producer_group=ab_pipeline_producer_group,
+            consumer_group=ab_pipeline_consumer_group,
+            tx_count=self.num_tma_load_bytes,
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        ).make_participants()
+
+        acc_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        num_acc_consumer_threads = len(self.epilogue_warp_id) * (
+            2 if use_2cta_instrs else 1
+        )
+        acc_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, num_acc_consumer_threads
+        )
+        acc_pipeline = pipeline.PipelineUmmaAsync.create(
+            barrier_storage=storage.acc_full_mbar_ptr.data_ptr(),
+            num_stages=self.num_acc_stage,
+            producer_group=acc_pipeline_producer_group,
+            consumer_group=acc_pipeline_consumer_group,
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        )
+
+        tmem_alloc_barrier = pipeline.NamedBarrier(
+            barrier_id=self.tmem_alloc_sync_bar_id,
+            num_threads=32 * len((self.mma_warp_id, *self.epilogue_warp_id)),
+        )
+        tmem = utils.TmemAllocator(
+            storage.tmem_holding_buf.ptr,
+            barrier_for_retrieve=tmem_alloc_barrier,
+            allocator_warp_id=self.epilogue_warp_id[0],
+            is_two_cta=use_2cta_instrs,
+            two_cta_tmem_dealloc_mbar_ptr=storage.tmem_dealloc_mbar.ptr,
+        )
+
+        pipeline_init_arrive(cluster_shape_mn=cluster_layout_vmnk, is_relaxed=True)
+
+        # (MMA, MMA_M, MMA_K, STAGE)
+        sA = smem.allocate_tensor(
+            element_type=self.a_dtype,
+            layout=a_smem_layout_staged.outer,
+            byte_alignment=128,
+            swizzle=a_smem_layout_staged.inner,
+        )
+        # (MMA, MMA_N, MMA_K, STAGE)
+        sB = smem.allocate_tensor(
+            element_type=self.b_dtype,
+            layout=b_smem_layout_staged.outer,
+            byte_alignment=128,
+            swizzle=b_smem_layout_staged.inner,
+        )
+
+        a_full_mcast_mask = None
+        b_full_mcast_mask = None
+        if cutlass.const_expr(self.is_a_mcast or self.is_b_mcast or use_2cta_instrs):
+            a_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=2
+            )
+            b_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=1
+            )
+
+        # (bM, bK, RestM, RestK, RestL)
+        gA_mkl = cute.local_tile(
+            mA_mkl, cute.slice_(self.mma_tiler, (None, 0, None)), (None, None, None)
+        )
+        # (bN, bK, RestN, RestK, RestL)
+        gB_nkl = cute.local_tile(
+            mB_nkl, cute.slice_(self.mma_tiler, (0, None, None)), (None, None, None)
+        )
+        # (bM, bN, RestM, RestN, RestL)
+        gC_mnl = cute.local_tile(
+            mC_mnl, cute.slice_(self.mma_tiler, (None, None, 0)), (None, None, None)
+        )
+        k_tile_cnt = cute.size(gA_mkl, mode=[3])
+
+        thr_mma = tiled_mma.get_slice(mma_tile_coord_v)
+        # (MMA, MMA_M, MMA_K, RestM, RestK, RestL)
+        tCgA = thr_mma.partition_A(gA_mkl)
+        # (MMA, MMA_N, MMA_K, RestN, RestK, RestL)
+        tCgB = thr_mma.partition_B(gB_nkl)
+        # (MMA, MMA_M, MMA_N, RestM, RestN, RestL)
+        tCgC = thr_mma.partition_C(gC_mnl)
+
+        a_cta_layout = cute.make_layout(
+            cute.slice_(cluster_layout_vmnk, (0, 0, None, 0)).shape
+        )
+        # ((atom_v, rest_v), STAGE)
+        # ((atom_v, rest_v), RestM, RestK, RestL)
+        tAsA, tAgA = cpasync.tma_partition(
+            tma_atom_a,
+            block_in_cluster_coord_vmnk[2],
+            a_cta_layout,
+            cute.group_modes(sA, 0, 3),
+            cute.group_modes(tCgA, 0, 3),
+        )
+        b_cta_layout = cute.make_layout(
+            cute.slice_(cluster_layout_vmnk, (0, None, 0, 0)).shape
+        )
+        # ((atom_v, rest_v), STAGE)
+        # ((atom_v, rest_v), RestM, RestK, RestL)
+        tBsB, tBgB = cpasync.tma_partition(
+            tma_atom_b,
+            block_in_cluster_coord_vmnk[1],
+            b_cta_layout,
+            cute.group_modes(sB, 0, 3),
+            cute.group_modes(tCgB, 0, 3),
+        )
+
+        # (MMA, MMA_M, MMA_K, STAGE)
+        tCrA = tiled_mma.make_fragment_A(sA)
+        # (MMA, MMA_N, MMA_K, STAGE)
+        tCrB = tiled_mma.make_fragment_B(sB)
+        # (MMA, MMA_M, MMA_N)
+        acc_shape = tiled_mma.partition_shape_C(self.mma_tiler[:2])
+        # (MMA, MMA_M, MMA_N, STAGE)
+        tCtAcc_fake = tiled_mma.make_fragment_C(
+            cute.append(acc_shape, self.num_acc_stage)
+        )
+
+        pipeline_init_wait(cluster_shape_mn=cluster_layout_vmnk)
+
+        tile_sched = create_moe_tile_scheduler(
+            tile_sched_params=tile_sched_params,
+            direct_schedule=direct_schedule,
+            schedule_tiles=schedule_tiles,
+            swap_ab=self.swap_ab,
+        )
+        work_tile = tile_sched.initial_work_tile_info()
+
+        if warp_idx == self.tma_warp_id:
+            while work_tile.is_valid_tile:
+                mma_tile_coord_mnl = (
+                    work_tile.tile_m_idx // cute.size(tiled_mma.thr_id.shape),
+                    work_tile.tile_n_idx,
+                    work_tile.expert_idx,
+                )
+                if cutlass.const_expr(self.swap_ab):
+                    mma_tile_coord_mnl = (
+                        work_tile.tile_n_idx // cute.size(tiled_mma.thr_id.shape),
+                        work_tile.tile_m_idx,
+                        work_tile.expert_idx,
+                    )
+                a_rest_l_coord = mma_tile_coord_mnl[2]
+                if cutlass.const_expr(self.contiguous_segments):
+                    # Flat rows use slot 0 plus seg_offsets; weights keep the expert.
+                    seg_base_tile = (
+                        group_m[work_tile.expert_idx] // self.cta_tile_shape_mnk[1]
+                    )
+                    mma_tile_coord_mnl = (
+                        mma_tile_coord_mnl[0],
+                        seg_base_tile + mma_tile_coord_mnl[1],
+                        cutlass.Int32(0),
+                    )
+                    a_rest_l_coord = work_tile.expert_idx
+
+                # ((atom_v, rest_v), RestK)
+                tAgA_slice = tAgA[(None, mma_tile_coord_mnl[0], None, a_rest_l_coord)]
+                # ((atom_v, rest_v), RestK)
+                tBgB_slice = tBgB[
+                    (None, mma_tile_coord_mnl[1], None, mma_tile_coord_mnl[2])
+                ]
+
+                ab_producer.reset()
+                peek_ab_empty_status = ab_producer.try_acquire()
+
+                for k_tile in cutlass.range(0, work_tile.k_tile_cnt, 1, unroll=1):
+                    handle = ab_producer.acquire_and_advance(peek_ab_empty_status)
+
+                    cute.copy(
+                        tma_atom_a,
+                        tAgA_slice[(None, handle.count)],
+                        tAsA[(None, handle.index)],
+                        tma_bar_ptr=handle.barrier,
+                        mcast_mask=a_full_mcast_mask,
+                    )
+                    cute.copy(
+                        tma_atom_b,
+                        tBgB_slice[(None, handle.count)],
+                        tBsB[(None, handle.index)],
+                        tma_bar_ptr=handle.barrier,
+                        mcast_mask=b_full_mcast_mask,
+                    )
+
+                    peek_ab_empty_status = cutlass.Boolean(1)
+                    if handle.count + 1 < work_tile.k_tile_cnt:
+                        peek_ab_empty_status = ab_producer.try_acquire()
+
+                work_tile = tile_sched.advance_to_next_work()
+
+            ab_producer.tail()
+
+        if warp_idx == self.mma_warp_id:
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            # (MMA, MMA_M, MMA_N, STAGE)
+            tCtAcc_base = cute.make_tensor(tmem_ptr, tCtAcc_fake.layout)
+
+            acc_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.num_acc_stage
+            )
+
+            while work_tile.is_valid_tile:
+                # (MMA, MMA_M, MMA_N)
+                tCtAcc = tCtAcc_base[(None, None, None, acc_producer_state.index)]
+
+                ab_consumer.reset()
+                peek_ab_full_status = cutlass.Boolean(1)
+                if is_leader_cta:
+                    peek_ab_full_status = ab_consumer.try_wait()
+
+                if is_leader_cta:
+                    acc_pipeline.producer_acquire(acc_producer_state)
+
+                tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
+
+                for k_tile in range(work_tile.k_tile_cnt):
+                    if is_leader_cta:
+                        handle = ab_consumer.wait_and_advance(peek_ab_full_status)
+
+                        num_kblocks = cute.size(tCrA, mode=[2])
+                        for kblk_idx in cutlass.range(num_kblocks, unroll_full=True):
+                            kblk_crd = (None, None, kblk_idx, handle.index)
+
+                            cute.gemm(
+                                tiled_mma,
+                                tCtAcc,
+                                tCrA[kblk_crd],
+                                tCrB[kblk_crd],
+                                tCtAcc,
+                            )
+                            tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+
+                        handle.release()
+
+                        peek_ab_full_status = cutlass.Boolean(1)
+                        if handle.count + 1 < work_tile.k_tile_cnt:
+                            peek_ab_full_status = ab_consumer.try_wait()
+
+                if is_leader_cta:
+                    acc_pipeline.producer_commit(acc_producer_state)
+                acc_producer_state.advance()
+
+                work_tile = tile_sched.advance_to_next_work()
+
+            acc_pipeline.producer_tail(acc_producer_state)
+
+        # (EPI_TILE_M, EPI_TILE_N, STAGE)
+        sC = smem.allocate_tensor(
+            element_type=self.c_dtype,
+            layout=c_smem_layout_staged.outer,
+            byte_alignment=128,
+            swizzle=c_smem_layout_staged.inner,
+        )
+
+        if warp_idx < self.mma_warp_id:
+            tmem.allocate(self.num_tmem_alloc_cols)
+
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            # (MMA, MMA_M, MMA_N, STAGE)
+            tCtAcc_base = cute.make_tensor(tmem_ptr, tCtAcc_fake.layout)
+
+            acc_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.num_acc_stage
+            )
+
+            c_producer_group = pipeline.CooperativeGroup(
+                pipeline.Agent.Thread,
+                32 * len(self.epilogue_warp_id),
+            )
+            c_pipeline = pipeline.PipelineTmaStore.create(
+                num_stages=self.num_c_stage, producer_group=c_producer_group
+            )
+            while work_tile.is_valid_tile:
+                mma_tile_coord_mnl = (
+                    work_tile.tile_m_idx // cute.size(tiled_mma.thr_id.shape),
+                    work_tile.tile_n_idx,
+                    work_tile.expert_idx,
+                )
+                if cutlass.const_expr(self.swap_ab):
+                    mma_tile_coord_mnl = (
+                        work_tile.tile_n_idx // cute.size(tiled_mma.thr_id.shape),
+                        work_tile.tile_m_idx,
+                        work_tile.expert_idx,
+                    )
+                if cutlass.const_expr(self.contiguous_segments):
+                    # Same segment base as the TMA warp.
+                    seg_base_tile = (
+                        group_m[work_tile.expert_idx] // self.cta_tile_shape_mnk[1]
+                    )
+                    mma_tile_coord_mnl = (
+                        mma_tile_coord_mnl[0],
+                        seg_base_tile + mma_tile_coord_mnl[1],
+                        cutlass.Int32(0),
+                    )
+                work_tile = tile_sched.advance_to_next_work()
+
+                # Valid tiles only: pipeline count also counts executed tiles.
+                num_tiles_executed = acc_consumer_state.count
+                acc_consumer_state = utils.gemm.sm100.epilogue_tma_store(
+                    self,
+                    tidx,
+                    warp_idx,
+                    tma_atom_c,
+                    tCtAcc_base,
+                    sC,
+                    tCgC,
+                    epi_tile,
+                    num_tiles_executed,
+                    epilogue_op,
+                    mma_tile_coord_mnl,
+                    acc_consumer_state,
+                    acc_pipeline,
+                    c_pipeline,
+                )
+
+            c_pipeline.producer_tail()
+
+            tmem.relinquish_alloc_permit()
+            tmem.free(tmem_ptr)
+
+    @staticmethod
+    def _compute_stages(
+        tiled_mma: cute.TiledMma,
+        mma_tiler_mnk: Tuple[int, int, int],
+        a_dtype: Type[cutlass.Numeric],
+        b_dtype: Type[cutlass.Numeric],
+        c_dtype: Type[cutlass.Numeric],
+        smem_capacity: int,
+        occupancy: int,
+        c_smem_layout: cute.Layout,
+    ) -> Tuple[int, int, int]:
+        num_acc_stage = 2
+        num_c_stage = 2
+
+        a_smem_layout_stage_one = utils.sm100.make_smem_layout_a(
+            tiled_mma, mma_tiler_mnk, a_dtype, 1
+        )
+        b_smem_layout_staged_one = utils.sm100.make_smem_layout_b(
+            tiled_mma, mma_tiler_mnk, b_dtype, 1
+        )
+
+        ab_bytes_per_stage = cute.size_in_bytes(
+            a_dtype, a_smem_layout_stage_one
+        ) + cute.size_in_bytes(b_dtype, b_smem_layout_staged_one)
+        mbar_helpers_bytes = 1024
+
+        c_bytes_per_stage = cute.size_in_bytes(c_dtype, c_smem_layout)
+        c_bytes = c_bytes_per_stage * num_c_stage
+
+        num_ab_stage = (
+            smem_capacity // occupancy - (mbar_helpers_bytes + c_bytes)
+        ) // ab_bytes_per_stage
+
+        num_c_stage += (
+            smem_capacity
+            - occupancy * ab_bytes_per_stage * num_ab_stage
+            - occupancy * (mbar_helpers_bytes + c_bytes)
+        ) // (occupancy * c_bytes_per_stage)
+        return num_acc_stage, num_ab_stage, num_c_stage
+
+    @staticmethod
+    def _compute_num_tmem_alloc_cols(
+        tiled_mma: cute.TiledMma,
+        mma_tiler: Tuple[int, int, int],
+        num_acc_stage: int,
+        arch: str,
+    ) -> int:
+        acc_shape = tiled_mma.partition_shape_C(mma_tiler[:2])
+        tCtAcc_fake = tiled_mma.make_fragment_C(cute.append(acc_shape, num_acc_stage))
+        num_tmem_alloc_cols = utils.get_num_tmem_alloc_cols(tCtAcc_fake, arch=arch)
+
+        return num_tmem_alloc_cols
+
+    def check_supported_dtypes(
+        self,
+        a_dtype: Type[cutlass.Numeric],
+        b_dtype: Type[cutlass.Numeric],
+        c_dtype: Type[cutlass.Numeric],
+    ):
+        if a_dtype is not cutlass.BFloat16 or b_dtype is not cutlass.BFloat16:
+            raise testing.CantImplementError(
+                f"the BF16 grouped GEMM takes BF16 A/B; got {a_dtype}, {b_dtype}"
+            )
+        if c_dtype is not cutlass.BFloat16:
+            raise testing.CantImplementError(f"C must be BF16; got {c_dtype}")
+        if self.acc_dtype is not cutlass.Float32:
+            raise testing.CantImplementError(
+                f"the accumulator must be FP32; got {self.acc_dtype}"
+            )
+
+    def check_mma_tiler_and_cluster_shape(self):
+        if not (
+            (not self.use_2cta_instrs and self.mma_tiler_mn[0] in [64, 128])
+            or (self.use_2cta_instrs and self.mma_tiler_mn[0] in [128, 256])
+        ):
+            raise testing.CantImplementError(
+                f"Invalid mma tiler & use_2cta_instrs: {self.mma_tiler_mn}, {self.use_2cta_instrs}"
+            )
+        valid_n_tiles = range(8, 257, 8) if self.swap_ab else range(32, 257, 32)
+        if self.mma_tiler_mn[1] not in valid_n_tiles:
+            raise testing.CantImplementError(
+                f"Invalid mma tiler N: {self.mma_tiler_mn[1]}"
+            )
+        if self.cluster_shape_mn[0] % (2 if self.use_2cta_instrs else 1) != 0:
+            raise testing.CantImplementError(
+                f"Invalid cluster shape M: {self.cluster_shape_mn[0]}"
+            )
+        is_power_of_2 = lambda x: x > 0 and (x & (x - 1)) == 0
+        if (
+            self.cluster_shape_mn[0] * self.cluster_shape_mn[1] > 16
+            or self.cluster_shape_mn[0] <= 0
+            or self.cluster_shape_mn[1] <= 0
+            or not is_power_of_2(self.cluster_shape_mn[0])
+            or not is_power_of_2(self.cluster_shape_mn[1])
+        ):
+            raise testing.CantImplementError(
+                f"Invalid cluster shape: {self.cluster_shape_mn}"
+            )
+
+    def check_tensor_alignment(
+        self,
+        m: int,
+        n: int,
+        k: int,
+        l: int,
+        a_dtype: Type[cutlass.Numeric],
+        b_dtype: Type[cutlass.Numeric],
+        c_dtype: Type[cutlass.Numeric],
+        a_major: str,
+        b_major: str,
+        c_major: str,
+    ):
+        def check_contiguous_16B_alignment(dtype, is_mode0_major, tensor_shape):
+            major_mode_idx = 0 if is_mode0_major else 1
+            num_major_elements = tensor_shape[major_mode_idx]
+            num_contiguous_elements = 16 * 8 // dtype.width
+            return num_major_elements % num_contiguous_elements == 0
+
+        if (
+            not check_contiguous_16B_alignment(a_dtype, a_major == "m", (m, k, l))
+            or not check_contiguous_16B_alignment(b_dtype, b_major == "n", (n, k, l))
+            or not check_contiguous_16B_alignment(c_dtype, c_major == "m", (m, n, l))
+        ):
+            raise testing.CantImplementError(
+                f"Invalid tensor alignment: {m}, {n}, {k}, {l}, {a_dtype}, {b_dtype}, {c_dtype}, {a_major}, {b_major}, {c_major}"
+            )
+
+    def can_implement(
+        self,
+        mnkl: Tuple[int, int, int, int],
+        a_dtype: Type[cutlass.Numeric],
+        b_dtype: Type[cutlass.Numeric],
+        c_dtype: Type[cutlass.Numeric],
+        a_major: str,
+        b_major: str,
+        c_major: str,
+    ) -> bool:
+        try:
+            self.check_supported_dtypes(a_dtype, b_dtype, c_dtype)
+            self.check_mma_tiler_and_cluster_shape()
+
+            m, n, k, l = mnkl
+            self.check_tensor_alignment(
+                m, n, k, l, a_dtype, b_dtype, c_dtype, a_major, b_major, c_major
+            )
+        except testing.CantImplementError:
+            return False
+        return True

--- a/python/sglang/srt/lora/moe/kernels/cutedsl/kernel_sm100_bf16.py
+++ b/python/sglang/srt/lora/moe/kernels/cutedsl/kernel_sm100_bf16.py
@@ -69,7 +69,6 @@ class GroupedGemmKernelSm100Bf16:
         cluster_shape_mn: Tuple[int, int],
         mma_inst_tile_k: int = 4,
         persistent_clusters: int | None = None,
-        produce_pdl: bool = False,
         swap_ab: bool = False,
         contiguous_segments: bool = False,
     ):
@@ -81,7 +80,6 @@ class GroupedGemmKernelSm100Bf16:
         self.mma_tiler = (*mma_tiler_mn, 1)
         self.mma_inst_tile_k = mma_inst_tile_k
         self.persistent_clusters = persistent_clusters
-        self.produce_pdl = produce_pdl
         self.swap_ab = swap_ab
         self.contiguous_segments = contiguous_segments
         if contiguous_segments and not swap_ab:
@@ -308,10 +306,6 @@ class GroupedGemmKernelSm100Bf16:
     ):
         warp_idx = cute.arch.warp_idx()
         warp_idx = cute.arch.make_warp_uniform(warp_idx)
-        if cutlass.const_expr(self.produce_pdl):
-            # Start the next kernel's prologue now; its own wait still holds
-            # back the first read of this GEMM's output.
-            cute.arch.griddepcontrol_launch_dependents()
 
         if warp_idx == self.tma_warp_id:
             cpasync.prefetch_descriptor(tma_atom_a)

--- a/python/sglang/srt/lora/moe/kernels/cutedsl/kernel_sm100_fp8.py
+++ b/python/sglang/srt/lora/moe/kernels/cutedsl/kernel_sm100_fp8.py
@@ -1,0 +1,609 @@
+# SPDX-License-Identifier: BSD-3-Clause
+"""SM100 FP8 GEMM derived from kernel_sm100_bf16.py.
+
+Each 128-element K partial is drained from tensor memory, scaled in FP32,
+and accumulated in registers. Software scaling preserves checkpoint values
+and permits 8-wide token tiles.
+
+Scale layouts after swap_ab: weights [N/128, K/128, E], tokens [M, K/128, E|1].
+"""
+
+from typing import Type
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import cutlass.cute.testing as testing
+import cutlass.pipeline as pipeline
+import cutlass.utils as utils
+from cutlass.cute.nvgpu import cpasync, tcgen05
+from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
+
+from sglang.srt.lora.moe.kernels.cutedsl.kernel_sm100_bf16 import (
+    GroupedGemmKernelSm100Bf16,
+)
+from sglang.srt.lora.moe.kernels.cutedsl.scheduler import (
+    create_moe_tile_scheduler,
+    resolve_scheduler_params_and_grid,
+)
+
+
+class GroupedGemmKernelSm100Fp8(GroupedGemmKernelSm100Bf16):
+    NUM_ACC_STAGES = 2
+    USE_TMA_STORE = True
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if not self.swap_ab:
+            raise ValueError("the software-scaled FP8 kernel ships swap_ab only")
+        if self.use_2cta_instrs or self.cluster_shape_mn != (1, 1):
+            raise ValueError(
+                "the software-scaled FP8 kernel ships (1, 1) single-CTA only"
+            )
+        if self.mma_tiler_mn[0] != 128 or self.mma_tiler_mn[1] > 128:
+            raise ValueError(
+                "the software-scaled FP8 kernel indexes weight scales per 128-wide "
+                "output tile and stages one column scale per epilogue thread, so "
+                f"mma_tiler_mn must be (128, <=128); got {self.mma_tiler_mn}"
+            )
+
+    def _compute_stages(self, *args, **kwargs):
+        num_acc_stage, num_ab_stage, num_c_stage = (
+            GroupedGemmKernelSm100Bf16._compute_stages(*args, **kwargs)
+        )
+        return type(self).NUM_ACC_STAGES, num_ab_stage, num_c_stage
+
+    def check_supported_dtypes(
+        self,
+        a_dtype: Type[cutlass.Numeric],
+        b_dtype: Type[cutlass.Numeric],
+        c_dtype: Type[cutlass.Numeric],
+    ):
+        if a_dtype is not cutlass.Float8E4M3FN or b_dtype is not cutlass.Float8E4M3FN:
+            raise testing.CantImplementError(
+                f"the software-scaled GEMM takes e4m3 A/B; got {a_dtype}, {b_dtype}"
+            )
+        if c_dtype is not cutlass.BFloat16:
+            raise testing.CantImplementError(f"C must be BF16; got {c_dtype}")
+        if self.acc_dtype is not cutlass.Float32:
+            raise testing.CantImplementError(
+                f"the accumulator must be FP32; got {self.acc_dtype}"
+            )
+
+    @cute.jit
+    def __call__(
+        self,
+        a: cute.Tensor,
+        b: cute.Tensor,
+        sf_a: cute.Tensor,  # weight scales [NT, KT, E] fp32
+        sf_b: cute.Tensor,  # token scales [M, KT, E|1] fp32
+        c: cute.Tensor,
+        group_m: cute.Tensor,
+        direct_schedule: cute.Tensor,
+        schedule_tiles: cute.Tensor,
+        max_active_clusters: cutlass.Constexpr,
+        stream: cuda.CUstream,
+        epilogue_op: cutlass.Constexpr = lambda x: x,
+    ):
+        self.a_dtype: Type[cutlass.Numeric] = a.element_type
+        self.b_dtype: Type[cutlass.Numeric] = b.element_type
+        self.c_dtype: Type[cutlass.Numeric] = c.element_type
+        self.a_major_mode = utils.LayoutEnum.from_tensor(a).mma_major_mode()
+        self.b_major_mode = utils.LayoutEnum.from_tensor(b).mma_major_mode()
+        self.c_layout = utils.LayoutEnum.from_tensor(c)
+
+        tiled_mma = self._create_tiled_mma()
+        self._setup_attributes()
+        # One k_tile must cover exactly one 128-element scale group.
+        if cutlass.const_expr(self.mma_tiler[2] != 128):
+            raise ValueError(
+                f"k_tile must equal the 128-element scale group; got "
+                f"{self.mma_tiler[2]} (mma_inst_tile_k={self.mma_inst_tile_k})"
+            )
+
+        a_op = utils.sm100.cluster_shape_to_tma_atom_A(
+            self.cluster_shape_mn, tiled_mma.thr_id
+        )
+        a_smem_layout = cute.slice_(self.a_smem_layout_staged, (None, None, None, 0))
+        tma_atom_a, tma_tensor_a = cute.nvgpu.make_tiled_tma_atom_A(
+            a_op,
+            a,
+            a_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+
+        b_op = utils.sm100.cluster_shape_to_tma_atom_B(
+            self.cluster_shape_mn, tiled_mma.thr_id
+        )
+        b_smem_layout = cute.slice_(self.b_smem_layout_staged, (None, None, None, 0))
+        tma_atom_b, tma_tensor_b = cute.nvgpu.make_tiled_tma_atom_B(
+            b_op,
+            b,
+            b_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+
+        a_copy_size = cute.size_in_bytes(self.a_dtype, a_smem_layout)
+        b_copy_size = cute.size_in_bytes(self.b_dtype, b_smem_layout)
+        self.num_tma_load_bytes = a_copy_size + b_copy_size
+
+        epi_smem_layout = cute.select(self.c_smem_layout_staged, mode=[0, 1])
+        tma_atom_c, tma_tensor_c = cpasync.make_tiled_tma_atom(
+            cpasync.CopyBulkTensorTileS2GOp(), c, epi_smem_layout, self.epi_tile
+        )
+
+        self.tile_sched_params, grid = resolve_scheduler_params_and_grid(
+            a=a,
+            c=c,
+            cta_tile_shape_mnk=self.cta_tile_shape_mnk,
+            cluster_shape_mn=self.cluster_shape_mn,
+            swap_ab=self.swap_ab,
+            contiguous_segments=self.contiguous_segments,
+            persistent_clusters=self.persistent_clusters,
+            max_active_clusters=max_active_clusters,
+        )
+
+        self.kernel(
+            tiled_mma,
+            tma_atom_a,
+            tma_tensor_a,
+            tma_atom_b,
+            tma_tensor_b,
+            tma_atom_c,
+            tma_tensor_c,
+            c,
+            sf_a,
+            sf_b,
+            group_m,
+            direct_schedule,
+            schedule_tiles,
+            self.cluster_layout_vmnk,
+            self.a_smem_layout_staged,
+            self.b_smem_layout_staged,
+            self.c_smem_layout_staged,
+            self.epi_tile,
+            self.tile_sched_params,
+            epilogue_op,
+        ).launch(
+            grid=grid,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=(*self.cluster_shape_mn, 1),
+            stream=stream,
+        )
+        return
+
+    @cute.kernel
+    def kernel(
+        self,
+        tiled_mma: cute.TiledMma,
+        tma_atom_a: cute.CopyAtom,
+        mA_mkl: cute.Tensor,
+        tma_atom_b: cute.CopyAtom,
+        mB_nkl: cute.Tensor,
+        tma_atom_c: cute.CopyAtom,
+        mC_mnl: cute.Tensor,
+        mC_raw: cute.Tensor,
+        sf_a: cute.Tensor,
+        sf_b: cute.Tensor,
+        group_m: cute.Tensor,
+        direct_schedule: cute.Tensor,
+        schedule_tiles: cute.Tensor,
+        cluster_layout_vmnk: cute.Layout,
+        a_smem_layout_staged: cute.ComposedLayout,
+        b_smem_layout_staged: cute.ComposedLayout,
+        c_smem_layout_staged: cute.ComposedLayout,
+        epi_tile: cute.Tile,
+        tile_sched_params,
+        epilogue_op: cutlass.Constexpr,
+    ):
+        warp_idx = cute.arch.warp_idx()
+        warp_idx = cute.arch.make_warp_uniform(warp_idx)
+
+        if warp_idx == self.tma_warp_id:
+            cpasync.prefetch_descriptor(tma_atom_a)
+            cpasync.prefetch_descriptor(tma_atom_b)
+            cpasync.prefetch_descriptor(tma_atom_c)
+
+        tidx, _, _ = cute.arch.thread_idx()
+        cta_n = self.cta_tile_shape_mnk[1]
+
+        @cute.struct
+        class SharedStorage:
+            ab_full_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_ab_stage * 2]
+            acc_full_mbar_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.num_acc_stage * 2
+            ]
+            col_scale: cute.struct.MemRange[cutlass.Float32, self.cta_tile_shape_mnk[1]]
+            tmem_dealloc_mbar: cutlass.Int64
+            tmem_holding_buf: cutlass.Int32
+
+        smem = utils.SmemAllocator()
+        storage = smem.allocate(SharedStorage)
+
+        ab_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        ab_pipeline_consumer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, 1)
+        ab_producer, ab_consumer = pipeline.PipelineTmaUmma.create(
+            barrier_storage=storage.ab_full_mbar_ptr.data_ptr(),
+            num_stages=self.num_ab_stage,
+            producer_group=ab_pipeline_producer_group,
+            consumer_group=ab_pipeline_consumer_group,
+            tx_count=self.num_tma_load_bytes,
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        ).make_participants()
+
+        acc_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        acc_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, len(self.epilogue_warp_id)
+        )
+        acc_pipeline = pipeline.PipelineUmmaAsync.create(
+            barrier_storage=storage.acc_full_mbar_ptr.data_ptr(),
+            num_stages=self.num_acc_stage,
+            producer_group=acc_pipeline_producer_group,
+            consumer_group=acc_pipeline_consumer_group,
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        )
+
+        tmem_alloc_barrier = pipeline.NamedBarrier(
+            barrier_id=self.tmem_alloc_sync_bar_id,
+            num_threads=32 * len((self.mma_warp_id, *self.epilogue_warp_id)),
+        )
+        tmem = utils.TmemAllocator(
+            storage.tmem_holding_buf.ptr,
+            barrier_for_retrieve=tmem_alloc_barrier,
+            allocator_warp_id=self.epilogue_warp_id[0],
+            is_two_cta=False,
+            two_cta_tmem_dealloc_mbar_ptr=storage.tmem_dealloc_mbar.ptr,
+        )
+
+        pipeline_init_arrive(cluster_shape_mn=cluster_layout_vmnk, is_relaxed=True)
+
+        sA = smem.allocate_tensor(
+            element_type=self.a_dtype,
+            layout=a_smem_layout_staged.outer,
+            byte_alignment=128,
+            swizzle=a_smem_layout_staged.inner,
+        )
+        sB = smem.allocate_tensor(
+            element_type=self.b_dtype,
+            layout=b_smem_layout_staged.outer,
+            byte_alignment=128,
+            swizzle=b_smem_layout_staged.inner,
+        )
+        sColScale = cute.make_tensor(
+            storage.col_scale.data_ptr(), cute.make_layout(cta_n)
+        )
+
+        gA_mkl = cute.local_tile(
+            mA_mkl, cute.slice_(self.mma_tiler, (None, 0, None)), (None, None, None)
+        )
+        gB_nkl = cute.local_tile(
+            mB_nkl, cute.slice_(self.mma_tiler, (0, None, None)), (None, None, None)
+        )
+        gC_mnl = cute.local_tile(
+            mC_mnl, cute.slice_(self.mma_tiler, (None, None, 0)), (None, None, None)
+        )
+
+        thr_mma = tiled_mma.get_slice(0)
+        tCgA = thr_mma.partition_A(gA_mkl)
+        tCgB = thr_mma.partition_B(gB_nkl)
+        tCgC = thr_mma.partition_C(gC_mnl)
+
+        a_cta_layout = cute.make_layout(
+            cute.slice_(cluster_layout_vmnk, (0, 0, None, 0)).shape
+        )
+        tAsA, tAgA = cpasync.tma_partition(
+            tma_atom_a,
+            0,
+            a_cta_layout,
+            cute.group_modes(sA, 0, 3),
+            cute.group_modes(tCgA, 0, 3),
+        )
+        b_cta_layout = cute.make_layout(
+            cute.slice_(cluster_layout_vmnk, (0, None, 0, 0)).shape
+        )
+        tBsB, tBgB = cpasync.tma_partition(
+            tma_atom_b,
+            0,
+            b_cta_layout,
+            cute.group_modes(sB, 0, 3),
+            cute.group_modes(tCgB, 0, 3),
+        )
+
+        tCrA = tiled_mma.make_fragment_A(sA)
+        tCrB = tiled_mma.make_fragment_B(sB)
+        acc_shape = tiled_mma.partition_shape_C(self.mma_tiler[:2])
+        tCtAcc_fake = tiled_mma.make_fragment_C(
+            cute.append(acc_shape, self.num_acc_stage)
+        )
+
+        pipeline_init_wait(cluster_shape_mn=cluster_layout_vmnk)
+
+        tile_sched = create_moe_tile_scheduler(
+            tile_sched_params=tile_sched_params,
+            direct_schedule=direct_schedule,
+            schedule_tiles=schedule_tiles,
+            swap_ab=self.swap_ab,
+        )
+        work_tile = tile_sched.initial_work_tile_info()
+
+        if warp_idx == self.tma_warp_id:
+            while work_tile.is_valid_tile:
+                mma_tile_coord_mnl = (
+                    work_tile.tile_n_idx,
+                    work_tile.tile_m_idx,
+                    work_tile.expert_idx,
+                )
+                a_rest_l_coord = mma_tile_coord_mnl[2]
+                if cutlass.const_expr(self.contiguous_segments):
+                    seg_base_tile = (
+                        group_m[work_tile.expert_idx] // self.cta_tile_shape_mnk[1]
+                    )
+                    mma_tile_coord_mnl = (
+                        mma_tile_coord_mnl[0],
+                        seg_base_tile + mma_tile_coord_mnl[1],
+                        cutlass.Int32(0),
+                    )
+                    a_rest_l_coord = work_tile.expert_idx
+
+                tAgA_slice = tAgA[(None, mma_tile_coord_mnl[0], None, a_rest_l_coord)]
+                tBgB_slice = tBgB[
+                    (None, mma_tile_coord_mnl[1], None, mma_tile_coord_mnl[2])
+                ]
+
+                ab_producer.reset()
+                peek_ab_empty_status = ab_producer.try_acquire()
+
+                for k_tile in cutlass.range(0, work_tile.k_tile_cnt, 1, unroll=1):
+                    handle = ab_producer.acquire_and_advance(peek_ab_empty_status)
+                    cute.copy(
+                        tma_atom_a,
+                        tAgA_slice[(None, handle.count)],
+                        tAsA[(None, handle.index)],
+                        tma_bar_ptr=handle.barrier,
+                    )
+                    cute.copy(
+                        tma_atom_b,
+                        tBgB_slice[(None, handle.count)],
+                        tBsB[(None, handle.index)],
+                        tma_bar_ptr=handle.barrier,
+                    )
+                    peek_ab_empty_status = cutlass.Boolean(1)
+                    if handle.count + 1 < work_tile.k_tile_cnt:
+                        peek_ab_empty_status = ab_producer.try_acquire()
+
+                work_tile = tile_sched.advance_to_next_work()
+
+            ab_producer.tail()
+
+        if warp_idx == self.mma_warp_id:
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            tCtAcc_base = cute.make_tensor(tmem_ptr, tCtAcc_fake.layout)
+
+            acc_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.num_acc_stage
+            )
+
+            while work_tile.is_valid_tile:
+                ab_consumer.reset()
+                peek_ab_full_status = ab_consumer.try_wait()
+
+                # Hand each 128-K partial to the epilogue warps for scaling.
+                for k_tile in range(work_tile.k_tile_cnt):
+                    tCtAcc = tCtAcc_base[(None, None, None, acc_producer_state.index)]
+                    acc_pipeline.producer_acquire(acc_producer_state)
+
+                    handle = ab_consumer.wait_and_advance(peek_ab_full_status)
+                    tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
+                    num_kblocks = cute.size(tCrA, mode=[2])
+                    for kblk_idx in cutlass.range(num_kblocks, unroll_full=True):
+                        kblk_crd = (None, None, kblk_idx, handle.index)
+                        cute.gemm(
+                            tiled_mma,
+                            tCtAcc,
+                            tCrA[kblk_crd],
+                            tCrB[kblk_crd],
+                            tCtAcc,
+                        )
+                        tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                    handle.release()
+
+                    peek_ab_full_status = cutlass.Boolean(1)
+                    if handle.count + 1 < work_tile.k_tile_cnt:
+                        peek_ab_full_status = ab_consumer.try_wait()
+
+                    acc_pipeline.producer_commit(acc_producer_state)
+                    acc_producer_state.advance()
+
+                work_tile = tile_sched.advance_to_next_work()
+
+            acc_pipeline.producer_tail(acc_producer_state)
+
+        sC = smem.allocate_tensor(
+            element_type=self.c_dtype,
+            layout=c_smem_layout_staged.outer,
+            byte_alignment=128,
+            swizzle=c_smem_layout_staged.inner,
+        )
+
+        if warp_idx < self.mma_warp_id:
+            tmem.allocate(self.num_tmem_alloc_cols)
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            tCtAcc_base = cute.make_tensor(tmem_ptr, tCtAcc_fake.layout)
+
+            acc_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.num_acc_stage
+            )
+
+            c_producer_group = pipeline.CooperativeGroup(
+                pipeline.Agent.Thread,
+                32 * len(self.epilogue_warp_id),
+            )
+            c_pipeline = pipeline.PipelineTmaStore.create(
+                num_stages=self.num_c_stage, producer_group=c_producer_group
+            )
+
+            epilog_sync_barrier = pipeline.NamedBarrier(
+                barrier_id=self.epilog_sync_bar_id,
+                num_threads=32 * len(self.epilogue_warp_id),
+            )
+
+            # Match accumulator elements to token columns for scale lookup.
+            tCgC_t = utils.gemm.sm100.transform_partitioned_tensor_layout(tCgC)
+            tCtAcc_t = utils.gemm.sm100.transform_partitioned_tensor_layout(tCtAcc_base)
+            tiled_copy_t2r, tTR_tAcc_base, tTR_rAcc = (
+                utils.gemm.sm100.epilogue_tmem_copy_and_partition(
+                    self, tidx, tCtAcc_t, tCgC_t, epi_tile, False
+                )
+            )
+            thr_copy_t2r = tiled_copy_t2r.get_slice(tidx)
+            cC = cute.make_identity_tensor(
+                (self.cta_tile_shape_mnk[0], self.cta_tile_shape_mnk[1])
+            )
+            cC_epi = cute.flat_divide(cC, epi_tile)
+            tTR_cC_epi = thr_copy_t2r.partition_D(cC_epi)
+            # ((frag), (subtile)): linear element and subtile indices.
+            tTR_cC = cute.group_modes(
+                cute.group_modes(tTR_cC_epi, 3, cute.rank(tTR_cC_epi)), 0, 3
+            )
+
+            gC_raw = cute.local_tile(
+                mC_raw,
+                cute.slice_(self.mma_tiler, (None, None, 0)),
+                (None, None, None),
+            )
+            tCgC_raw = utils.gemm.sm100.transform_partitioned_tensor_layout(
+                thr_mma.partition_C(gC_raw)
+            )
+            tCgC_epi_t2r = cute.flat_divide(tCgC_raw, epi_tile)
+            tTR_gC_partitioned = thr_copy_t2r.partition_D(tCgC_epi_t2r)
+            tTR_rC = cute.make_rmem_tensor(tTR_rAcc.shape, self.c_dtype)
+            tiled_copy_r2s, tRS_rC, tRS_sC = (
+                utils.gemm.sm100.epilogue_smem_copy_and_partition(
+                    self, tiled_copy_t2r, tTR_rC, tidx, sC
+                )
+            )
+
+            tCgC_epi = cute.flat_divide(tCgC_t, epi_tile)
+            bSG_sC, bSG_gC_partitioned = cpasync.tma_partition(
+                tma_atom_c,
+                0,
+                cute.make_layout(1),
+                cute.group_modes(sC, 0, 2),
+                cute.group_modes(tCgC_epi, 0, 2),
+            )
+
+            subtile_cnt = cute.size(tTR_cC.shape, mode=[1])
+            frag_size = cute.size(tTR_rAcc.shape)
+            tTR_rAcc_flat = cute.group_modes(tTR_rAcc, 0, cute.rank(tTR_rAcc))
+            tTR_rTotal = cute.make_rmem_tensor(
+                cute.make_layout((frag_size, subtile_cnt)), cutlass.Float32
+            )
+
+            num_tiles_executed = cutlass.Int32(0)
+            while work_tile.is_valid_tile:
+                mma_tile_coord_mnl = (
+                    work_tile.tile_n_idx,
+                    work_tile.tile_m_idx,
+                    work_tile.expert_idx,
+                )
+                weight_expert = work_tile.expert_idx
+                if cutlass.const_expr(self.contiguous_segments):
+                    seg_base_tile = (
+                        group_m[work_tile.expert_idx] // self.cta_tile_shape_mnk[1]
+                    )
+                    mma_tile_coord_mnl = (
+                        mma_tile_coord_mnl[0],
+                        seg_base_tile + mma_tile_coord_mnl[1],
+                        cutlass.Int32(0),
+                    )
+                k_tile_cnt = work_tile.k_tile_cnt
+                nt_idx = mma_tile_coord_mnl[0]
+                token_base = mma_tile_coord_mnl[1] * cta_n
+                token_rest_l = mma_tile_coord_mnl[2]
+                work_tile = tile_sched.advance_to_next_work()
+
+                for i in cutlass.range_constexpr(frag_size):
+                    for st in cutlass.range_constexpr(subtile_cnt):
+                        tTR_rTotal[(i, st)] = cutlass.Float32(0.0)
+
+                for k_tile in range(k_tile_cnt):
+                    sw = sf_a[(nt_idx, k_tile, weight_expert)]
+                    if tidx < cta_n:
+                        sColScale[tidx] = (
+                            sw * sf_b[(token_base + tidx, k_tile, token_rest_l)]
+                        )
+                    epilog_sync_barrier.arrive_and_wait()
+
+                    acc_pipeline.consumer_wait(acc_consumer_state)
+                    tTR_tAcc = tTR_tAcc_base[
+                        (None, None, None, None, None, acc_consumer_state.index)
+                    ]
+                    tTR_tAcc = cute.group_modes(tTR_tAcc, 3, cute.rank(tTR_tAcc))
+                    for st in cutlass.range_constexpr(subtile_cnt):
+                        cute.copy(
+                            tiled_copy_t2r,
+                            tTR_tAcc[(None, None, None, st)],
+                            tTR_rAcc,
+                        )
+                        for i in cutlass.range_constexpr(frag_size):
+                            col = tTR_cC[(i, st)][1]
+                            tTR_rTotal[(i, st)] = (
+                                tTR_rTotal[(i, st)] + tTR_rAcc_flat[i] * sColScale[col]
+                            )
+                    with cute.arch.elect_one():
+                        acc_pipeline.consumer_release(acc_consumer_state)
+                    acc_consumer_state.advance()
+                    epilog_sync_barrier.arrive_and_wait()
+
+                num_prev_subtiles = num_tiles_executed * subtile_cnt
+                if cutlass.const_expr(self.USE_TMA_STORE):
+                    bSG_gC = bSG_gC_partitioned[(None, None, None, *mma_tile_coord_mnl)]
+                    bSG_gC = cute.group_modes(bSG_gC, 1, cute.rank(bSG_gC))
+                    for st in cutlass.range_constexpr(subtile_cnt):
+                        for i in cutlass.range_constexpr(frag_size):
+                            tTR_rAcc_flat[i] = tTR_rTotal[(i, st)]
+                        acc_vec = tiled_copy_r2s.retile(tTR_rAcc).load()
+                        acc_vec = epilogue_op(acc_vec.to(self.c_dtype))
+                        tRS_rC.store(acc_vec)
+
+                        c_buffer = (num_prev_subtiles + st) % self.num_c_stage
+                        cute.copy(
+                            tiled_copy_r2s,
+                            tRS_rC,
+                            tRS_sC[(None, None, None, c_buffer)],
+                        )
+                        cute.arch.fence_proxy("async.shared", space="cta")
+                        epilog_sync_barrier.arrive_and_wait()
+                        if warp_idx == self.epilogue_warp_id[0]:
+                            cute.copy(
+                                tma_atom_c,
+                                bSG_sC[(None, c_buffer)],
+                                bSG_gC[(None, st)],
+                            )
+                            c_pipeline.producer_commit()
+                            c_pipeline.producer_acquire()
+                        epilog_sync_barrier.arrive_and_wait()
+                else:
+                    tTR_gC = tTR_gC_partitioned[
+                        (None, None, None, None, None, *mma_tile_coord_mnl)
+                    ]
+                    tTR_gC = cute.group_modes(tTR_gC, 3, cute.rank(tTR_gC))
+                    for st in cutlass.range_constexpr(subtile_cnt):
+                        for i in cutlass.range_constexpr(frag_size):
+                            tTR_rAcc_flat[i] = tTR_rTotal[(i, st)]
+                        acc_vec = tTR_rAcc.load()
+                        tTR_rC.store(epilogue_op(acc_vec.to(self.c_dtype)))
+                        cute.autovec_copy(tTR_rC, tTR_gC[(None, None, None, st)])
+                num_tiles_executed = num_tiles_executed + 1
+
+            c_pipeline.producer_tail()
+            tmem.relinquish_alloc_permit()
+            tmem.free(tmem_ptr)

--- a/python/sglang/srt/lora/moe/kernels/cutedsl/kernel_sm90_bf16.py
+++ b/python/sglang/srt/lora/moe/kernels/cutedsl/kernel_sm90_bf16.py
@@ -1,0 +1,825 @@
+# Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import math
+from typing import Optional, Tuple, Type
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import cutlass.utils as utils
+import cutlass.utils.hopper_helpers as sm90_utils
+from cutlass import pipeline
+from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
+
+from sglang.srt.lora.moe.kernels.cutedsl.scheduler import (
+    MoESchedulerParams,
+    create_moe_tile_scheduler,
+    resolve_scheduler_params_and_grid,
+)
+
+
+class GroupedGemmKernelSm90Bf16:
+    """Hopper grouped GEMM with the same config interface as SM100."""
+
+    def __init__(
+        self,
+        acc_dtype: Type[cutlass.Numeric],
+        use_2cta_instrs: bool,
+        mma_tiler_mn: Tuple[int, int],
+        cluster_shape_mn: Tuple[int, int],
+        mma_inst_tile_k: int = 4,
+        persistent_clusters: Optional[int] = None,
+        produce_pdl: bool = False,
+        swap_ab: bool = False,
+        contiguous_segments: bool = False,
+    ):
+        if use_2cta_instrs:
+            raise ValueError("2-CTA MMA is a tcgen05 feature; SM90 has none")
+        self.acc_dtype = acc_dtype
+        self.cluster_shape_mn = cluster_shape_mn
+        self.mma_inst_tile_k = mma_inst_tile_k
+        self.persistent_clusters = persistent_clusters
+        self.produce_pdl = produce_pdl
+        self.swap_ab = swap_ab
+        self.contiguous_segments = contiguous_segments
+        if contiguous_segments and not swap_ab:
+            raise ValueError("contiguous_segments requires swap_ab")
+        if contiguous_segments and cluster_shape_mn != (1, 1):
+            raise ValueError("contiguous_segments requires a (1, 1) cluster")
+
+        # The K extent here is a placeholder. _setup_attributes computes it.
+        self.tile_shape_mnk = (*mma_tiler_mn, 1)
+        # Upstream uses a second math warp group only for large tiles.
+        self.atom_layout_mnk = (
+            (2, 1, 1)
+            if self.tile_shape_mnk[0] > 64 and self.tile_shape_mnk[1] > 128
+            else (1, 1, 1)
+        )
+
+        self.occupancy = 1
+        self.num_dma_warp_groups = 1
+        self.num_mma_warp_groups = math.prod(self.atom_layout_mnk)
+        self.num_threads_per_warp_group = 128
+        self.threads_per_cta = (
+            self.num_dma_warp_groups + self.num_mma_warp_groups
+        ) * self.num_threads_per_warp_group
+        self.load_warp_id = 0
+        self.epi_store_warp_id = self.num_dma_warp_groups * 4
+        self.load_register_requirement = 40
+        self.mma_register_requirement = 232
+        self.smem_capacity = utils.get_smem_capacity_in_bytes("sm_90")
+        self.num_mma_threads = (
+            self.num_mma_warp_groups * self.num_threads_per_warp_group
+        )
+        self.epilog_sync_barrier = pipeline.NamedBarrier(
+            barrier_id=1, num_threads=self.num_mma_threads
+        )
+        self.buffer_align_bytes = 1024
+
+        self.tiled_mma = None
+        self.ab_stage = None
+        self.epi_stage = None
+        self.a_smem_layout_staged = None
+        self.b_smem_layout_staged = None
+        self.epi_smem_layout_staged = None
+        self.epi_tile = None
+        self.shared_storage = None
+
+    def _setup_attributes(self):
+        self.tiled_mma = sm90_utils.make_trivial_tiled_mma(
+            self.a_dtype,
+            self.b_dtype,
+            self.a_layout.sm90_mma_major_mode(),
+            self.b_layout.sm90_mma_major_mode(),
+            self.acc_dtype,
+            self.atom_layout_mnk,
+            tiler_mn=(64, self.tile_shape_mnk[1]),
+        )
+        mma_inst_shape_k = cute.size(self.tiled_mma.shape_mnk, mode=[2])
+        self.tile_shape_mnk = (
+            self.tile_shape_mnk[0],
+            self.tile_shape_mnk[1],
+            mma_inst_shape_k * self.mma_inst_tile_k,
+        )
+
+        self.cta_layout_mnk = cute.make_layout((*self.cluster_shape_mn, 1))
+        self.num_mcast_ctas_a = self.cluster_shape_mn[1]
+        self.num_mcast_ctas_b = self.cluster_shape_mn[0]
+        self.is_a_mcast = self.num_mcast_ctas_a > 1
+        self.is_b_mcast = self.num_mcast_ctas_b > 1
+
+        is_cooperative = self.atom_layout_mnk == (2, 1, 1)
+        self.epi_tile = self._sm90_compute_tile_shape_or_override(
+            self.tile_shape_mnk, self.c_dtype, is_cooperative=is_cooperative
+        )
+        self.ab_stage, self.epi_stage = self._compute_stages(
+            self.tile_shape_mnk,
+            self.a_dtype,
+            self.b_dtype,
+            self.epi_tile,
+            self.c_dtype,
+            self.smem_capacity,
+            self.occupancy,
+        )
+        (
+            self.a_smem_layout_staged,
+            self.b_smem_layout_staged,
+            self.epi_smem_layout_staged,
+        ) = self._make_smem_layouts(
+            self.tile_shape_mnk,
+            self.epi_tile,
+            self.a_dtype,
+            self.a_layout,
+            self.b_dtype,
+            self.b_layout,
+            self.ab_stage,
+            self.c_dtype,
+            self.c_layout,
+            self.epi_stage,
+        )
+
+    @cute.jit
+    def __call__(
+        self,
+        a: cute.Tensor,
+        b: cute.Tensor,
+        c: cute.Tensor,
+        group_m: cute.Tensor,
+        direct_schedule: cute.Tensor,
+        schedule_tiles: cute.Tensor,
+        max_active_clusters: cutlass.Constexpr,
+        stream: cuda.CUstream,
+        epilogue_op: cutlass.Constexpr = lambda x: x,
+    ):
+        self.a_dtype = a.element_type
+        self.b_dtype = b.element_type
+        self.c_dtype = c.element_type
+        self.a_layout = utils.LayoutEnum.from_tensor(a)
+        self.b_layout = utils.LayoutEnum.from_tensor(b)
+        self.c_layout = utils.LayoutEnum.from_tensor(c)
+        if cutlass.const_expr(self.a_dtype != self.b_dtype):
+            raise TypeError(f"Type mismatch: {self.a_dtype} != {self.b_dtype}")
+
+        self._setup_attributes()
+
+        tma_atom_a, tma_tensor_a = self._make_tma_atoms_and_tensors(
+            a,
+            self.a_smem_layout_staged,
+            (self.tile_shape_mnk[0], self.tile_shape_mnk[2]),
+            self.cluster_shape_mn[1],
+        )
+        tma_atom_b, tma_tensor_b = self._make_tma_atoms_and_tensors(
+            b,
+            self.b_smem_layout_staged,
+            (self.tile_shape_mnk[1], self.tile_shape_mnk[2]),
+            self.cluster_shape_mn[0],
+        )
+        tma_atom_c, tma_tensor_c = self._make_tma_store_atoms_and_tensors(
+            c, self.epi_smem_layout_staged, self.epi_tile
+        )
+
+        self.tile_sched_params, grid = resolve_scheduler_params_and_grid(
+            a=a,
+            c=c,
+            cta_tile_shape_mnk=self.tile_shape_mnk,
+            cluster_shape_mn=self.cluster_shape_mn,
+            swap_ab=self.swap_ab,
+            contiguous_segments=self.contiguous_segments,
+            persistent_clusters=self.persistent_clusters,
+            max_active_clusters=max_active_clusters,
+        )
+
+        @cute.struct
+        class SharedStorage:
+            mainloop_pipeline_array_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.ab_stage * 2
+            ]
+            sA: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.a_dtype, cute.cosize(self.a_smem_layout_staged)
+                ],
+                self.buffer_align_bytes,
+            ]
+            sB: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.b_dtype, cute.cosize(self.b_smem_layout_staged)
+                ],
+                self.buffer_align_bytes,
+            ]
+            sC: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.c_dtype, cute.cosize(self.epi_smem_layout_staged)
+                ],
+                self.buffer_align_bytes,
+            ]
+
+        self.shared_storage = SharedStorage
+
+        self.kernel(
+            tma_atom_a,
+            tma_tensor_a,
+            tma_atom_b,
+            tma_tensor_b,
+            tma_atom_c,
+            tma_tensor_c,
+            group_m,
+            direct_schedule,
+            schedule_tiles,
+            self.tiled_mma,
+            self.cta_layout_mnk,
+            self.a_smem_layout_staged,
+            self.b_smem_layout_staged,
+            self.epi_smem_layout_staged,
+            self.tile_sched_params,
+            epilogue_op,
+        ).launch(
+            grid=grid,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=(*self.cluster_shape_mn, 1),
+            min_blocks_per_mp=1,
+            stream=stream,
+        )
+        return
+
+    @cute.kernel
+    def kernel(
+        self,
+        tma_atom_a: cute.CopyAtom,
+        mA_mkl: cute.Tensor,
+        tma_atom_b: cute.CopyAtom,
+        mB_nkl: cute.Tensor,
+        tma_atom_c: cute.CopyAtom,
+        mC_mnl: cute.Tensor,
+        group_m: cute.Tensor,
+        direct_schedule: cute.Tensor,
+        schedule_tiles: cute.Tensor,
+        tiled_mma: cute.TiledMma,
+        cta_layout_mnk: cute.Layout,
+        a_smem_layout_staged: cute.ComposedLayout,
+        b_smem_layout_staged: cute.ComposedLayout,
+        epi_smem_layout_staged: cute.ComposedLayout,
+        tile_sched_params: MoESchedulerParams,
+        epilogue_op: cutlass.Constexpr,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        if cutlass.const_expr(self.produce_pdl):
+            # This signal starts the next kernel at entry. That kernel runs
+            # its prologue while this GEMM runs. Its griddepcontrol.wait still
+            # holds back the first read of the data that this GEMM writes.
+            cute.arch.griddepcontrol_launch_dependents()
+
+        if warp_idx == 0:
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_a)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_b)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_c)
+
+        cta_rank_in_cluster = cute.arch.make_warp_uniform(
+            cute.arch.block_idx_in_cluster()
+        )
+        cluster_coord_mnk = cta_layout_mnk.get_flat_coord(cta_rank_in_cluster)
+        a_mcast_mask = cute.make_layout_image_mask(
+            cta_layout_mnk, cluster_coord_mnk, mode=1
+        )
+        b_mcast_mask = cute.make_layout_image_mask(
+            cta_layout_mnk, cluster_coord_mnk, mode=0
+        )
+        a_mcast_mask = a_mcast_mask if self.is_a_mcast else 0
+        b_mcast_mask = b_mcast_mask if self.is_b_mcast else 0
+
+        a_smem_layout = cute.slice_(a_smem_layout_staged, (None, None, 0))
+        b_smem_layout = cute.slice_(b_smem_layout_staged, (None, None, 0))
+        tma_copy_bytes = cute.size_in_bytes(
+            self.a_dtype, a_smem_layout
+        ) + cute.size_in_bytes(self.b_dtype, b_smem_layout)
+
+        smem = utils.SmemAllocator()
+        storage = smem.allocate(self.shared_storage)
+
+        mainloop_pipeline_producer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread
+        )
+        mcast_size = self.num_mcast_ctas_a + self.num_mcast_ctas_b - 1
+        consumer_arrive_cnt = mcast_size * self.num_mma_warp_groups * 4
+        mainloop_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, consumer_arrive_cnt
+        )
+        mainloop_pipeline = pipeline.PipelineTmaAsync.create(
+            barrier_storage=storage.mainloop_pipeline_array_ptr.data_ptr(),
+            num_stages=self.ab_stage,
+            producer_group=mainloop_pipeline_producer_group,
+            consumer_group=mainloop_pipeline_consumer_group,
+            tx_count=tma_copy_bytes,
+            cta_layout_vmnk=cute.make_layout((1, *cta_layout_mnk.shape)),
+            defer_sync=True,
+        )
+        pipeline_init_arrive(cluster_shape_mn=self.cluster_shape_mn, is_relaxed=True)
+
+        sA = storage.sA.get_tensor(
+            a_smem_layout_staged.outer, swizzle=a_smem_layout_staged.inner
+        )
+        sB = storage.sB.get_tensor(
+            b_smem_layout_staged.outer, swizzle=b_smem_layout_staged.inner
+        )
+        sC = storage.sC.get_tensor(
+            epi_smem_layout_staged.outer, swizzle=epi_smem_layout_staged.inner
+        )
+
+        # (bM, bK, RestM, RestK, RestL). The L mode is the expert index.
+        gA_mkl = cute.local_tile(
+            mA_mkl,
+            cute.slice_(self.tile_shape_mnk, (None, 0, None)),
+            (None, None, None),
+        )
+        gB_nkl = cute.local_tile(
+            mB_nkl,
+            cute.slice_(self.tile_shape_mnk, (0, None, None)),
+            (None, None, None),
+        )
+        gC_mnl = cute.local_tile(
+            mC_mnl,
+            cute.slice_(self.tile_shape_mnk, (None, None, 0)),
+            (None, None, None),
+        )
+
+        a_cta_layout = cute.make_layout(cute.slice_(cta_layout_mnk, (0, None, 0)).shape)
+        tAsA, tAgA = cute.nvgpu.cpasync.tma_partition(
+            tma_atom_a,
+            cluster_coord_mnk[1],
+            a_cta_layout,
+            cute.group_modes(sA, 0, 2),
+            cute.group_modes(gA_mkl, 0, 2),
+        )
+        b_cta_layout = cute.make_layout(cute.slice_(cta_layout_mnk, (None, 0, 0)).shape)
+        tBsB, tBgB = cute.nvgpu.cpasync.tma_partition(
+            tma_atom_b,
+            cluster_coord_mnk[0],
+            b_cta_layout,
+            cute.group_modes(sB, 0, 2),
+            cute.group_modes(gB_nkl, 0, 2),
+        )
+
+        warp_group_idx = cute.arch.make_warp_uniform(
+            tidx // self.num_threads_per_warp_group
+        )
+        mma_warp_group_thread_layout = cute.make_layout(
+            self.num_mma_warp_groups, stride=self.num_threads_per_warp_group
+        )
+        thr_mma = tiled_mma.get_slice(
+            mma_warp_group_thread_layout(warp_group_idx - self.num_dma_warp_groups)
+        )
+
+        tCsA = thr_mma.partition_A(sA)
+        tCsB = thr_mma.partition_B(sB)
+        tCrA = tiled_mma.make_fragment_A(tCsA)
+        tCrB = tiled_mma.make_fragment_B(tCsB)
+        tCgC = thr_mma.partition_C(gC_mnl)
+        accumulators = cute.make_rmem_tensor(tCgC.shape[:3], self.acc_dtype)
+
+        pipeline_init_wait(cluster_shape_mn=self.cluster_shape_mn)
+
+        tile_sched = create_moe_tile_scheduler(
+            tile_sched_params=tile_sched_params,
+            direct_schedule=direct_schedule,
+            schedule_tiles=schedule_tiles,
+            swap_ab=self.swap_ab,
+        )
+        work_tile = tile_sched.initial_work_tile_info()
+
+        is_dma_warp_group = warp_group_idx < self.num_dma_warp_groups
+        if is_dma_warp_group:
+            cute.arch.setmaxregister_decrease(self.load_register_requirement)
+
+        if warp_idx == self.load_warp_id:
+            mainloop_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.ab_stage
+            )
+            while work_tile.is_valid_tile:
+                mma_tile_coord_mnl = (
+                    work_tile.tile_m_idx,
+                    work_tile.tile_n_idx,
+                    work_tile.expert_idx,
+                )
+                if cutlass.const_expr(self.swap_ab):
+                    mma_tile_coord_mnl = (
+                        work_tile.tile_n_idx,
+                        work_tile.tile_m_idx,
+                        work_tile.expert_idx,
+                    )
+                a_rest_l_coord = mma_tile_coord_mnl[2]
+                if cutlass.const_expr(self.contiguous_segments):
+                    # Flat rows use slot 0 plus seg_offsets; weights keep the expert.
+                    seg_base_tile = (
+                        group_m[work_tile.expert_idx] // self.tile_shape_mnk[1]
+                    )
+                    mma_tile_coord_mnl = (
+                        mma_tile_coord_mnl[0],
+                        seg_base_tile + mma_tile_coord_mnl[1],
+                        cutlass.Int32(0),
+                    )
+                    a_rest_l_coord = work_tile.expert_idx
+                tAgA_mkl = tAgA[(None, mma_tile_coord_mnl[0], None, a_rest_l_coord)]
+                tBgB_nkl = tBgB[
+                    (None, mma_tile_coord_mnl[1], None, mma_tile_coord_mnl[2])
+                ]
+
+                mainloop_producer_state.reset_count()
+                for k_tile in cutlass.range(0, work_tile.k_tile_cnt, 1, unroll=1):
+                    mainloop_pipeline.producer_acquire(mainloop_producer_state)
+                    cute.copy(
+                        tma_atom_a,
+                        tAgA_mkl[(None, mainloop_producer_state.count)],
+                        tAsA[(None, mainloop_producer_state.index)],
+                        tma_bar_ptr=mainloop_pipeline.producer_get_barrier(
+                            mainloop_producer_state
+                        ),
+                        mcast_mask=a_mcast_mask,
+                    )
+                    cute.copy(
+                        tma_atom_b,
+                        tBgB_nkl[(None, mainloop_producer_state.count)],
+                        tBsB[(None, mainloop_producer_state.index)],
+                        tma_bar_ptr=mainloop_pipeline.producer_get_barrier(
+                            mainloop_producer_state
+                        ),
+                        mcast_mask=b_mcast_mask,
+                    )
+                    mainloop_pipeline.producer_commit(mainloop_producer_state)
+                    mainloop_producer_state.advance()
+
+                work_tile = tile_sched.advance_to_next_work()
+            mainloop_pipeline.producer_tail(mainloop_producer_state)
+
+        if not is_dma_warp_group:
+            cute.arch.setmaxregister_increase(self.mma_register_requirement)
+
+            mainloop_consumer_read_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.ab_stage
+            )
+            mainloop_consumer_release_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.ab_stage
+            )
+            num_k_blocks = cute.size(tCrA, mode=[2])
+
+            # N=8 has only four values/thread; the helper's fixed st.matrix x4
+            # needs eight. Scale the matrix count with the tile instead.
+            num_store_matrices = min(4, max(1, self.tile_shape_mnk[1] // 4))
+            if cutlass.const_expr(self.c_dtype.width == 16):
+                copy_atom_r2s = cute.make_copy_atom(
+                    cute.nvgpu.warp.StMatrix8x8x16bOp(
+                        self.c_layout.is_m_major_c(), num_store_matrices
+                    ),
+                    self.c_dtype,
+                )
+            else:
+                copy_atom_r2s = sm90_utils.sm90_get_smem_store_op(
+                    self.c_layout, elem_ty_d=self.c_dtype, elem_ty_acc=self.acc_dtype
+                )
+            copy_atom_C = cute.make_copy_atom(
+                cute.nvgpu.warp.StMatrix8x8x16bOp(
+                    self.c_layout.is_m_major_c(), num_store_matrices
+                ),
+                self.c_dtype,
+            )
+            tiled_copy_C_Atom = cute.make_tiled_copy_C_atom(copy_atom_C, tiled_mma)
+            tiled_copy_r2s = cute.make_tiled_copy_S(copy_atom_r2s, tiled_copy_C_Atom)
+            thr_copy_r2s = tiled_copy_r2s.get_slice(
+                tidx - self.num_dma_warp_groups * self.num_threads_per_warp_group
+            )
+            tRS_sD = thr_copy_r2s.partition_D(sC)
+            tRS_rAcc = tiled_copy_r2s.retile(accumulators)
+            rD_shape = cute.shape(thr_copy_r2s.partition_S(sC))
+            tRS_rD_layout = cute.make_layout(rD_shape[:3])
+            tRS_rD = cute.make_rmem_tensor(tRS_rD_layout.shape, self.acc_dtype)
+            tRS_rD_out = cute.make_rmem_tensor(tRS_rD_layout.shape, self.c_dtype)
+            size_tRS_rD = cute.size(tRS_rD)
+
+            tma_store_producer_group = pipeline.CooperativeGroup(
+                pipeline.Agent.Thread, self.num_mma_threads
+            )
+            tma_store_pipeline = pipeline.PipelineTmaStore.create(
+                num_stages=self.epi_stage,
+                producer_group=tma_store_producer_group,
+            )
+
+            # Rotate epilogue buffers by executed tiles, not global work index.
+            num_tiles_executed = cutlass.Int32(0)
+
+            while work_tile.is_valid_tile:
+                mma_tile_coord_mnl = (
+                    work_tile.tile_m_idx,
+                    work_tile.tile_n_idx,
+                    work_tile.expert_idx,
+                )
+                if cutlass.const_expr(self.swap_ab):
+                    mma_tile_coord_mnl = (
+                        work_tile.tile_n_idx,
+                        work_tile.tile_m_idx,
+                        work_tile.expert_idx,
+                    )
+                if cutlass.const_expr(self.contiguous_segments):
+                    # Use the same flat segment offset as the DMA warp.
+                    seg_base_tile = (
+                        group_m[work_tile.expert_idx] // self.tile_shape_mnk[1]
+                    )
+                    mma_tile_coord_mnl = (
+                        mma_tile_coord_mnl[0],
+                        seg_base_tile + mma_tile_coord_mnl[1],
+                        cutlass.Int32(0),
+                    )
+                gC_mnl_slice = gC_mnl[(None, None, *mma_tile_coord_mnl)]
+
+                mainloop_consumer_read_state.reset_count()
+                mainloop_consumer_release_state.reset_count()
+                accumulators.fill(0.0)
+                tiled_mma.set(cute.nvgpu.warpgroup.Field.ACCUMULATE, True)
+                cute.nvgpu.warpgroup.fence()
+
+                # Positive, aligned K guarantees one prologue tile.
+                k_pipe_mmas = 1
+                for k_tile in cutlass.range(0, k_pipe_mmas, 1, unroll=1):
+                    mainloop_pipeline.consumer_wait(mainloop_consumer_read_state)
+                    for k_block_idx in cutlass.range_constexpr(num_k_blocks):
+                        k_block_coord = (
+                            None,
+                            None,
+                            k_block_idx,
+                            mainloop_consumer_read_state.index,
+                        )
+                        cute.gemm(
+                            tiled_mma,
+                            accumulators,
+                            tCrA[k_block_coord],
+                            tCrB[k_block_coord],
+                            accumulators,
+                        )
+                    cute.nvgpu.warpgroup.commit_group()
+                    mainloop_consumer_read_state.advance()
+
+                for k_tile in cutlass.range(
+                    k_pipe_mmas, work_tile.k_tile_cnt, 1, unroll=1
+                ):
+                    mainloop_pipeline.consumer_wait(mainloop_consumer_read_state)
+                    for k_block_idx in cutlass.range_constexpr(num_k_blocks):
+                        k_block_coord = (
+                            None,
+                            None,
+                            k_block_idx,
+                            mainloop_consumer_read_state.index,
+                        )
+                        cute.gemm(
+                            tiled_mma,
+                            accumulators,
+                            tCrA[k_block_coord],
+                            tCrB[k_block_coord],
+                            accumulators,
+                        )
+                    cute.nvgpu.warpgroup.commit_group()
+                    cute.nvgpu.warpgroup.wait_group(k_pipe_mmas)
+                    mainloop_pipeline.consumer_release(mainloop_consumer_release_state)
+                    mainloop_consumer_release_state.advance()
+                    mainloop_consumer_read_state.advance()
+
+                cute.nvgpu.warpgroup.wait_group(0)
+                for k_tile in cutlass.range(0, k_pipe_mmas, 1, unroll=1):
+                    mainloop_pipeline.consumer_release(mainloop_consumer_release_state)
+                    mainloop_consumer_release_state.advance()
+
+                tCgC_for_tma_partition = cute.zipped_divide(gC_mnl_slice, self.epi_tile)
+                bSG_sD, bSG_gD = cute.nvgpu.cpasync.tma_partition(
+                    tma_atom_c,
+                    0,
+                    cute.make_layout(1),
+                    cute.group_modes(sC, 0, 2),
+                    tCgC_for_tma_partition,
+                )
+                epi_tile_num = cute.size(tCgC_for_tma_partition, mode=[1])
+                epi_tile_shape = tCgC_for_tma_partition.shape[1]
+                epi_tile_layout = cute.make_layout(
+                    epi_tile_shape, stride=(epi_tile_shape[1], 1)
+                )
+                num_prev_epi_tiles = num_tiles_executed * epi_tile_num
+
+                for epi_idx in cutlass.range_constexpr(epi_tile_num):
+                    for epi_v in cutlass.range_constexpr(size_tRS_rD):
+                        tRS_rD[epi_v] = tRS_rAcc[epi_idx * size_tRS_rD + epi_v]
+                    acc_vec = epilogue_op(tRS_rD.load())
+                    tRS_rD_out.store(acc_vec.to(self.c_dtype))
+
+                    epi_buffer = (num_prev_epi_tiles + epi_idx) % cute.size(
+                        tRS_sD, mode=[3]
+                    )
+                    cute.copy(
+                        tiled_copy_r2s,
+                        tRS_rD_out,
+                        tRS_sD[(None, None, None, epi_buffer)],
+                    )
+                    cute.arch.fence_proxy("async.shared", space="cta")
+                    self.epilog_sync_barrier.arrive_and_wait()
+
+                    gmem_coord = epi_tile_layout.get_hier_coord(epi_idx)
+                    if warp_idx == self.epi_store_warp_id:
+                        cute.copy(
+                            tma_atom_c,
+                            bSG_sD[(None, epi_buffer)],
+                            bSG_gD[(None, gmem_coord)],
+                        )
+                        tma_store_pipeline.producer_commit()
+                        tma_store_pipeline.producer_acquire()
+                    self.epilog_sync_barrier.arrive_and_wait()
+
+                num_tiles_executed += cutlass.Int32(1)
+                work_tile = tile_sched.advance_to_next_work()
+
+            tma_store_pipeline.producer_tail()
+
+    # The host helpers below come from the upstream Hopper persistent example.
+
+    @staticmethod
+    def _compute_stages(
+        tile_shape_mnk,
+        a_dtype,
+        b_dtype,
+        epi_tile,
+        c_dtype,
+        smem_capacity,
+        occupancy,
+    ):
+        a_shape = cute.slice_(tile_shape_mnk, (None, 0, None))
+        b_shape = cute.slice_(tile_shape_mnk, (0, None, None))
+        ab_bytes_per_stage = (
+            cute.size(a_shape) * a_dtype.width // 8
+            + cute.size(b_shape) * b_dtype.width // 8
+        )
+        c_bytes_per_stage = cute.size(epi_tile) * c_dtype.width // 8
+        epi_stage = 4
+        epi_bytes = c_bytes_per_stage * epi_stage
+        mbar_helpers_bytes = 1024
+        ab_stage = (
+            smem_capacity // occupancy - (mbar_helpers_bytes + epi_bytes)
+        ) // ab_bytes_per_stage
+        return ab_stage, epi_stage
+
+    @staticmethod
+    def _sm90_compute_tile_shape_or_override(
+        tile_shape_mnk, element_type, is_cooperative=False, epi_tile_override=None
+    ):
+        if epi_tile_override is not None:
+            return epi_tile_override
+        if is_cooperative:
+            tile_m = min(128, cute.size(tile_shape_mnk, mode=[0]))
+            tile_n = min(32, cute.size(tile_shape_mnk, mode=[1]))
+            return (tile_m, tile_n)
+        n_perf = 64 if element_type.width == 8 else 32
+        tile_m = min(64, cute.size(tile_shape_mnk, mode=[0]))
+        tile_n = min(n_perf, cute.size(tile_shape_mnk, mode=[1]))
+        return (tile_m, tile_n)
+
+    @staticmethod
+    def _make_smem_layouts(
+        tile_shape_mnk,
+        epi_tile,
+        a_dtype,
+        a_layout,
+        b_dtype,
+        b_layout,
+        ab_stage,
+        c_dtype,
+        c_layout,
+        epi_stage,
+    ):
+        a_smem_shape = cute.slice_(tile_shape_mnk, (None, 0, None))
+        a_is_k_major = (
+            a_layout.sm90_mma_major_mode() == cute.nvgpu.warpgroup.OperandMajorMode.K
+        )
+        b_is_k_major = (
+            b_layout.sm90_mma_major_mode() == cute.nvgpu.warpgroup.OperandMajorMode.K
+        )
+        a_major_mode_size = tile_shape_mnk[2 if a_is_k_major else 0]
+        a_smem_layout_atom = cute.nvgpu.warpgroup.make_smem_layout_atom(
+            sm90_utils.get_smem_layout_atom(a_layout, a_dtype, a_major_mode_size),
+            a_dtype,
+        )
+        a_smem_layout_staged = cute.tile_to_shape(
+            a_smem_layout_atom,
+            cute.append(a_smem_shape, ab_stage),
+            order=(0, 1, 2) if a_is_k_major else (1, 0, 2),
+        )
+
+        b_smem_shape = cute.slice_(tile_shape_mnk, (0, None, None))
+        b_major_mode_size = tile_shape_mnk[2 if b_is_k_major else 1]
+        b_smem_layout_atom = cute.nvgpu.warpgroup.make_smem_layout_atom(
+            sm90_utils.get_smem_layout_atom(b_layout, b_dtype, b_major_mode_size),
+            b_dtype,
+        )
+        b_smem_layout_staged = cute.tile_to_shape(
+            b_smem_layout_atom,
+            cute.append(b_smem_shape, ab_stage),
+            order=(0, 1, 2) if b_is_k_major else (1, 0, 2),
+        )
+
+        c_smem_shape = epi_tile
+        c_major_mode_size = epi_tile[1] if c_layout.is_n_major_c() else epi_tile[0]
+        c_smem_layout_atom = cute.nvgpu.warpgroup.make_smem_layout_atom(
+            sm90_utils.get_smem_layout_atom(c_layout, c_dtype, c_major_mode_size),
+            c_dtype,
+        )
+        epi_smem_layout_staged = cute.tile_to_shape(
+            c_smem_layout_atom,
+            cute.append(c_smem_shape, epi_stage),
+            order=(1, 0, 2) if c_layout.is_m_major_c() else (0, 1, 2),
+        )
+        return a_smem_layout_staged, b_smem_layout_staged, epi_smem_layout_staged
+
+    @staticmethod
+    def _make_tma_store_atoms_and_tensors(tensor_c, epi_smem_layout_staged, epi_tile):
+        epi_smem_layout = cute.slice_(epi_smem_layout_staged, (None, None, 0))
+        return cute.nvgpu.cpasync.make_tiled_tma_atom(
+            cute.nvgpu.cpasync.CopyBulkTensorTileS2GOp(),
+            tensor_c,
+            epi_smem_layout,
+            epi_tile,
+        )
+
+    @staticmethod
+    def _make_tma_atoms_and_tensors(tensor, smem_layout_staged, smem_tile, mcast_dim):
+        op = (
+            cute.nvgpu.cpasync.CopyBulkTensorTileG2SOp()
+            if mcast_dim == 1
+            else cute.nvgpu.cpasync.CopyBulkTensorTileG2SMulticastOp()
+        )
+        smem_layout = cute.slice_(smem_layout_staged, (None, None, 0))
+        return cute.nvgpu.cpasync.make_tiled_tma_atom(
+            op, tensor, smem_layout, smem_tile, num_multicast=mcast_dim
+        )
+
+    def check_supported_dtypes(self, a_dtype, b_dtype, c_dtype):
+        if a_dtype not in (cutlass.Float16, cutlass.BFloat16):
+            raise TypeError(f"SM90 port supports F16/BF16 A/B; got {a_dtype}")
+        if a_dtype != b_dtype:
+            raise TypeError(f"A/B dtype mismatch: {a_dtype} vs {b_dtype}")
+        if c_dtype not in (cutlass.Float16, cutlass.BFloat16, cutlass.Float32):
+            raise TypeError(f"unsupported C dtype {c_dtype}")
+
+    def check_mma_tiler_and_cluster_shape(self):
+        if self.tile_shape_mnk[0] not in (64, 128):
+            raise ValueError("SM90 CTA tile M must be 64/128")
+        if self.tile_shape_mnk[1] not in (8, 16, 32, 64, 128, 256):
+            raise ValueError(
+                "this port validates CTA tile N in {8, 16, 32, 64, 128, "
+                "256}; WGMMA itself accepts 8..256 step 8 -- extend the "
+                "validated set before requesting other widths"
+            )
+        if math.prod(self.cluster_shape_mn) > 4:
+            raise ValueError("SM90 cluster size must be <= 4")
+        for extent in self.cluster_shape_mn:
+            if extent <= 0 or extent & (extent - 1):
+                raise ValueError(
+                    "cluster extents must be positive powers of two; got "
+                    f"{self.cluster_shape_mn}"
+                )
+
+    def check_tensor_alignment(self, problem_shape, a_major, b_major, c_major):
+        if a_major != "k" or b_major != "k":
+            raise ValueError("SM90 port requires K-major A and B")
+        m, n, k, _length = problem_shape
+        for extent, name in ((m, "M"), (n, "N"), (k, "K")):
+            if extent % 8:
+                raise ValueError(f"{name}={extent} breaks 16-byte TMA alignment")
+
+    def can_implement(
+        self, problem_shape, a_dtype, b_dtype, c_dtype, a_major, b_major, c_major
+    ) -> bool:
+        try:
+            self.check_supported_dtypes(a_dtype, b_dtype, c_dtype)
+            self.check_mma_tiler_and_cluster_shape()
+            self.check_tensor_alignment(problem_shape, a_major, b_major, c_major)
+        except (TypeError, ValueError):
+            return False
+        return True

--- a/python/sglang/srt/lora/moe/kernels/cutedsl/kernel_sm90_bf16.py
+++ b/python/sglang/srt/lora/moe/kernels/cutedsl/kernel_sm90_bf16.py
@@ -55,7 +55,6 @@ class GroupedGemmKernelSm90Bf16:
         cluster_shape_mn: Tuple[int, int],
         mma_inst_tile_k: int = 4,
         persistent_clusters: Optional[int] = None,
-        produce_pdl: bool = False,
         swap_ab: bool = False,
         contiguous_segments: bool = False,
     ):
@@ -65,7 +64,6 @@ class GroupedGemmKernelSm90Bf16:
         self.cluster_shape_mn = cluster_shape_mn
         self.mma_inst_tile_k = mma_inst_tile_k
         self.persistent_clusters = persistent_clusters
-        self.produce_pdl = produce_pdl
         self.swap_ab = swap_ab
         self.contiguous_segments = contiguous_segments
         if contiguous_segments and not swap_ab:
@@ -289,11 +287,6 @@ class GroupedGemmKernelSm90Bf16:
     ):
         tidx, _, _ = cute.arch.thread_idx()
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
-        if cutlass.const_expr(self.produce_pdl):
-            # This signal starts the next kernel at entry. That kernel runs
-            # its prologue while this GEMM runs. Its griddepcontrol.wait still
-            # holds back the first read of the data that this GEMM writes.
-            cute.arch.griddepcontrol_launch_dependents()
 
         if warp_idx == 0:
             cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_a)

--- a/python/sglang/srt/lora/moe/kernels/cutedsl/kernel_sm90_fp8.py
+++ b/python/sglang/srt/lora/moe/kernels/cutedsl/kernel_sm90_fp8.py
@@ -1,0 +1,1079 @@
+# Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import math
+from typing import Optional, Tuple, Type
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import cutlass.utils as utils
+import cutlass.utils.hopper_helpers as sm90_utils
+from cutlass import pipeline
+from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
+
+from sglang.srt.lora.moe.kernels.cutedsl.scheduler import (
+    MoESchedulerParams,
+    create_moe_tile_scheduler,
+    resolve_scheduler_params_and_grid,
+)
+
+
+class GroupedGemmKernelSm90Fp8:
+    """Hopper FP8 GEMM with software FP32 scale promotion per 128-K tile.
+
+    swap_ab puts weights on M, giving one weight scale per tile and one
+    activation scale per token. Partial sums are scaled before accumulation.
+    """
+
+    SUPPORTS_SINGLE_K_PIPELINE = True
+
+    def __init__(
+        self,
+        acc_dtype: Type[cutlass.Numeric],
+        use_2cta_instrs: bool,
+        mma_tiler_mn: Tuple[int, int],
+        cluster_shape_mn: Tuple[int, int],
+        mma_inst_tile_k: int = 4,
+        persistent_clusters: Optional[int] = None,
+        swap_ab: bool = False,
+        contiguous_segments: bool = False,
+        single_k_pipeline: bool = False,
+    ):
+        if use_2cta_instrs:
+            raise ValueError("2-CTA MMA is a tcgen05 feature; SM90 has none")
+        if not swap_ab:
+            raise ValueError("the FP8 grouped GEMM implements swap_ab only")
+        if mma_inst_tile_k != 4:
+            # 4 x k32 FP8 WGMMA steps = one 128-element scale group per tile.
+            raise ValueError("FP8 promotion pins mma_inst_tile_k to 4")
+        self.acc_dtype = acc_dtype
+        self.single_k_pipeline = single_k_pipeline
+        self.cluster_shape_mn = cluster_shape_mn
+        self.mma_inst_tile_k = mma_inst_tile_k
+        self.persistent_clusters = persistent_clusters
+        self.swap_ab = swap_ab
+        self.contiguous_segments = contiguous_segments
+        if contiguous_segments and not swap_ab:
+            raise ValueError("contiguous_segments requires swap_ab")
+        if contiguous_segments and cluster_shape_mn != (1, 1):
+            raise ValueError("contiguous_segments requires a (1, 1) cluster")
+
+        # The K extent here is a placeholder. _setup_attributes computes it.
+        self.tile_shape_mnk = (*mma_tiler_mn, 1)
+        # Upstream uses a second math warp group only for large tiles.
+        self.atom_layout_mnk = (
+            (2, 1, 1)
+            if self.tile_shape_mnk[0] > 64 and self.tile_shape_mnk[1] > 128
+            else (1, 1, 1)
+        )
+
+        self.occupancy = 1
+        self.num_dma_warp_groups = 1
+        self.num_mma_warp_groups = math.prod(self.atom_layout_mnk)
+        self.num_threads_per_warp_group = 128
+        self.threads_per_cta = (
+            self.num_dma_warp_groups + self.num_mma_warp_groups
+        ) * self.num_threads_per_warp_group
+        self.load_warp_id = 0
+        self.epi_store_warp_id = self.num_dma_warp_groups * 4
+        self.load_register_requirement = 40
+        self.mma_register_requirement = 232
+        self.smem_capacity = utils.get_smem_capacity_in_bytes("sm_90")
+        self.num_mma_threads = (
+            self.num_mma_warp_groups * self.num_threads_per_warp_group
+        )
+        self.epilog_sync_barrier = pipeline.NamedBarrier(
+            barrier_id=1, num_threads=self.num_mma_threads
+        )
+        self.buffer_align_bytes = 1024
+
+        self.tiled_mma = None
+        self.ab_stage = None
+        self.epi_stage = None
+        self.a_smem_layout_staged = None
+        self.b_smem_layout_staged = None
+        self.epi_smem_layout_staged = None
+        self.epi_tile = None
+        self.shared_storage = None
+
+    def _setup_attributes(self):
+        self.tiled_mma = sm90_utils.make_trivial_tiled_mma(
+            self.a_dtype,
+            self.b_dtype,
+            self.a_layout.sm90_mma_major_mode(),
+            self.b_layout.sm90_mma_major_mode(),
+            self.acc_dtype,
+            self.atom_layout_mnk,
+            tiler_mn=(64, self.tile_shape_mnk[1]),
+        )
+        mma_inst_shape_k = cute.size(self.tiled_mma.shape_mnk, mode=[2])
+        self.tile_shape_mnk = (
+            self.tile_shape_mnk[0],
+            self.tile_shape_mnk[1],
+            mma_inst_shape_k * self.mma_inst_tile_k,
+        )
+
+        self.cta_layout_mnk = cute.make_layout((*self.cluster_shape_mn, 1))
+        self.num_mcast_ctas_a = self.cluster_shape_mn[1]
+        self.num_mcast_ctas_b = self.cluster_shape_mn[0]
+        self.is_a_mcast = self.num_mcast_ctas_a > 1
+        self.is_b_mcast = self.num_mcast_ctas_b > 1
+
+        is_cooperative = self.atom_layout_mnk == (2, 1, 1)
+        self.epi_tile = self._sm90_compute_tile_shape_or_override(
+            self.tile_shape_mnk, self.c_dtype, is_cooperative=is_cooperative
+        )
+        self.ab_stage, self.epi_stage = self._compute_stages(
+            self.tile_shape_mnk,
+            self.a_dtype,
+            self.b_dtype,
+            self.epi_tile,
+            self.c_dtype,
+            self.smem_capacity,
+            self.occupancy,
+        )
+        (
+            self.a_smem_layout_staged,
+            self.b_smem_layout_staged,
+            self.epi_smem_layout_staged,
+        ) = self._make_smem_layouts(
+            self.tile_shape_mnk,
+            self.epi_tile,
+            self.a_dtype,
+            self.a_layout,
+            self.b_dtype,
+            self.b_layout,
+            self.ab_stage,
+            self.c_dtype,
+            self.c_layout,
+            self.epi_stage,
+        )
+
+    @cute.jit
+    def __call__(
+        self,
+        a: cute.Tensor,
+        b: cute.Tensor,
+        sfa: cute.Tensor,
+        sfb: cute.Tensor,
+        c: cute.Tensor,
+        group_m: cute.Tensor,
+        direct_schedule: cute.Tensor,
+        schedule_tiles: cute.Tensor,
+        max_active_clusters: cutlass.Constexpr,
+        stream: cuda.CUstream,
+        epilogue_op: cutlass.Constexpr = lambda x: x,
+    ):
+        self.a_dtype = a.element_type
+        self.b_dtype = b.element_type
+        self.c_dtype = c.element_type
+        self.a_layout = utils.LayoutEnum.from_tensor(a)
+        self.b_layout = utils.LayoutEnum.from_tensor(b)
+        self.c_layout = utils.LayoutEnum.from_tensor(c)
+        if cutlass.const_expr(self.a_dtype != self.b_dtype):
+            raise TypeError(f"Type mismatch: {self.a_dtype} != {self.b_dtype}")
+
+        self._setup_attributes()
+
+        tma_atom_a, tma_tensor_a = self._make_tma_atoms_and_tensors(
+            a,
+            self.a_smem_layout_staged,
+            (self.tile_shape_mnk[0], self.tile_shape_mnk[2]),
+            self.cluster_shape_mn[1],
+        )
+        tma_atom_b, tma_tensor_b = self._make_tma_atoms_and_tensors(
+            b,
+            self.b_smem_layout_staged,
+            (self.tile_shape_mnk[1], self.tile_shape_mnk[2]),
+            self.cluster_shape_mn[0],
+        )
+        tma_atom_c, tma_tensor_c = self._make_tma_store_atoms_and_tensors(
+            c, self.epi_smem_layout_staged, self.epi_tile
+        )
+
+        self.tile_sched_params, grid = resolve_scheduler_params_and_grid(
+            a=a,
+            c=c,
+            cta_tile_shape_mnk=self.tile_shape_mnk,
+            cluster_shape_mn=self.cluster_shape_mn,
+            swap_ab=self.swap_ab,
+            contiguous_segments=self.contiguous_segments,
+            persistent_clusters=self.persistent_clusters,
+            max_active_clusters=max_active_clusters,
+        )
+
+        @cute.struct
+        class SharedStorage:
+            mainloop_pipeline_array_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.ab_stage * 2
+            ]
+            sA: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.a_dtype, cute.cosize(self.a_smem_layout_staged)
+                ],
+                self.buffer_align_bytes,
+            ]
+            sB: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.b_dtype, cute.cosize(self.b_smem_layout_staged)
+                ],
+                self.buffer_align_bytes,
+            ]
+            sC: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.c_dtype, cute.cosize(self.epi_smem_layout_staged)
+                ],
+                self.buffer_align_bytes,
+            ]
+
+        self.shared_storage = SharedStorage
+
+        self.kernel(
+            tma_atom_a,
+            tma_tensor_a,
+            tma_atom_b,
+            tma_tensor_b,
+            tma_atom_c,
+            tma_tensor_c,
+            sfa,
+            sfb,
+            group_m,
+            direct_schedule,
+            schedule_tiles,
+            self.tiled_mma,
+            self.cta_layout_mnk,
+            self.a_smem_layout_staged,
+            self.b_smem_layout_staged,
+            self.epi_smem_layout_staged,
+            self.tile_sched_params,
+            epilogue_op,
+        ).launch(
+            grid=grid,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=(*self.cluster_shape_mn, 1),
+            min_blocks_per_mp=1,
+            stream=stream,
+        )
+        return
+
+    @cute.kernel
+    def kernel(
+        self,
+        tma_atom_a: cute.CopyAtom,
+        mA_mkl: cute.Tensor,
+        tma_atom_b: cute.CopyAtom,
+        mB_nkl: cute.Tensor,
+        tma_atom_c: cute.CopyAtom,
+        mC_mnl: cute.Tensor,
+        mSFA_mkl: cute.Tensor,
+        mSFB_nkl: cute.Tensor,
+        group_m: cute.Tensor,
+        direct_schedule: cute.Tensor,
+        schedule_tiles: cute.Tensor,
+        tiled_mma: cute.TiledMma,
+        cta_layout_mnk: cute.Layout,
+        a_smem_layout_staged: cute.ComposedLayout,
+        b_smem_layout_staged: cute.ComposedLayout,
+        epi_smem_layout_staged: cute.ComposedLayout,
+        tile_sched_params: MoESchedulerParams,
+        epilogue_op: cutlass.Constexpr,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+
+        if warp_idx == 0:
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_a)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_b)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_c)
+
+        cta_rank_in_cluster = cute.arch.make_warp_uniform(
+            cute.arch.block_idx_in_cluster()
+        )
+        cluster_coord_mnk = cta_layout_mnk.get_flat_coord(cta_rank_in_cluster)
+        a_mcast_mask = cute.make_layout_image_mask(
+            cta_layout_mnk, cluster_coord_mnk, mode=1
+        )
+        b_mcast_mask = cute.make_layout_image_mask(
+            cta_layout_mnk, cluster_coord_mnk, mode=0
+        )
+        a_mcast_mask = a_mcast_mask if self.is_a_mcast else 0
+        b_mcast_mask = b_mcast_mask if self.is_b_mcast else 0
+
+        a_smem_layout = cute.slice_(a_smem_layout_staged, (None, None, 0))
+        b_smem_layout = cute.slice_(b_smem_layout_staged, (None, None, 0))
+        tma_copy_bytes = cute.size_in_bytes(
+            self.a_dtype, a_smem_layout
+        ) + cute.size_in_bytes(self.b_dtype, b_smem_layout)
+
+        smem = utils.SmemAllocator()
+        storage = smem.allocate(self.shared_storage)
+
+        mainloop_pipeline_producer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread
+        )
+        mcast_size = self.num_mcast_ctas_a + self.num_mcast_ctas_b - 1
+        consumer_arrive_cnt = mcast_size * self.num_mma_warp_groups * 4
+        mainloop_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, consumer_arrive_cnt
+        )
+        mainloop_pipeline = pipeline.PipelineTmaAsync.create(
+            barrier_storage=storage.mainloop_pipeline_array_ptr.data_ptr(),
+            num_stages=self.ab_stage,
+            producer_group=mainloop_pipeline_producer_group,
+            consumer_group=mainloop_pipeline_consumer_group,
+            tx_count=tma_copy_bytes,
+            cta_layout_vmnk=cute.make_layout((1, *cta_layout_mnk.shape)),
+            defer_sync=True,
+        )
+        pipeline_init_arrive(cluster_shape_mn=self.cluster_shape_mn, is_relaxed=True)
+
+        sA = storage.sA.get_tensor(
+            a_smem_layout_staged.outer, swizzle=a_smem_layout_staged.inner
+        )
+        sB = storage.sB.get_tensor(
+            b_smem_layout_staged.outer, swizzle=b_smem_layout_staged.inner
+        )
+        sC = storage.sC.get_tensor(
+            epi_smem_layout_staged.outer, swizzle=epi_smem_layout_staged.inner
+        )
+
+        # (bM, bK, RestM, RestK, RestL). The L mode is the expert index.
+        gA_mkl = cute.local_tile(
+            mA_mkl,
+            cute.slice_(self.tile_shape_mnk, (None, 0, None)),
+            (None, None, None),
+        )
+        gB_nkl = cute.local_tile(
+            mB_nkl,
+            cute.slice_(self.tile_shape_mnk, (0, None, None)),
+            (None, None, None),
+        )
+        gC_mnl = cute.local_tile(
+            mC_mnl,
+            cute.slice_(self.tile_shape_mnk, (None, None, 0)),
+            (None, None, None),
+        )
+
+        a_cta_layout = cute.make_layout(cute.slice_(cta_layout_mnk, (0, None, 0)).shape)
+        tAsA, tAgA = cute.nvgpu.cpasync.tma_partition(
+            tma_atom_a,
+            cluster_coord_mnk[1],
+            a_cta_layout,
+            cute.group_modes(sA, 0, 2),
+            cute.group_modes(gA_mkl, 0, 2),
+        )
+        b_cta_layout = cute.make_layout(cute.slice_(cta_layout_mnk, (None, 0, 0)).shape)
+        tBsB, tBgB = cute.nvgpu.cpasync.tma_partition(
+            tma_atom_b,
+            cluster_coord_mnk[0],
+            b_cta_layout,
+            cute.group_modes(sB, 0, 2),
+            cute.group_modes(gB_nkl, 0, 2),
+        )
+
+        warp_group_idx = cute.arch.make_warp_uniform(
+            tidx // self.num_threads_per_warp_group
+        )
+        mma_warp_group_thread_layout = cute.make_layout(
+            self.num_mma_warp_groups, stride=self.num_threads_per_warp_group
+        )
+        thr_mma = tiled_mma.get_slice(
+            mma_warp_group_thread_layout(warp_group_idx - self.num_dma_warp_groups)
+        )
+
+        tCsA = thr_mma.partition_A(sA)
+        tCsB = thr_mma.partition_B(sB)
+        tCrA = tiled_mma.make_fragment_A(tCsA)
+        tCrB = tiled_mma.make_fragment_B(tCsB)
+        tCgC = thr_mma.partition_C(gC_mnl)
+        accumulators = cute.make_rmem_tensor(tCgC.shape[:3], self.acc_dtype)
+        acc_partial = cute.make_rmem_tensor(tCgC.shape[:3], self.acc_dtype)
+        # Match accumulator elements to token columns for scale lookup.
+        idC = cute.make_identity_tensor(
+            (self.tile_shape_mnk[0], self.tile_shape_mnk[1])
+        )
+        tCcC = thr_mma.partition_C(idC)
+
+        pipeline_init_wait(cluster_shape_mn=self.cluster_shape_mn)
+
+        tile_sched = create_moe_tile_scheduler(
+            tile_sched_params=tile_sched_params,
+            direct_schedule=direct_schedule,
+            schedule_tiles=schedule_tiles,
+            swap_ab=self.swap_ab,
+        )
+        work_tile = tile_sched.initial_work_tile_info()
+
+        is_dma_warp_group = warp_group_idx < self.num_dma_warp_groups
+        if is_dma_warp_group:
+            cute.arch.setmaxregister_decrease(self.load_register_requirement)
+
+        if warp_idx == self.load_warp_id:
+            mainloop_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.ab_stage
+            )
+            while work_tile.is_valid_tile:
+                mma_tile_coord_mnl = (
+                    work_tile.tile_m_idx,
+                    work_tile.tile_n_idx,
+                    work_tile.expert_idx,
+                )
+                if cutlass.const_expr(self.swap_ab):
+                    mma_tile_coord_mnl = (
+                        work_tile.tile_n_idx,
+                        work_tile.tile_m_idx,
+                        work_tile.expert_idx,
+                    )
+                a_rest_l_coord = mma_tile_coord_mnl[2]
+                if cutlass.const_expr(self.contiguous_segments):
+                    # Flat rows use slot 0 plus seg_offsets; weights keep the expert.
+                    seg_base_tile = (
+                        group_m[work_tile.expert_idx] // self.tile_shape_mnk[1]
+                    )
+                    mma_tile_coord_mnl = (
+                        mma_tile_coord_mnl[0],
+                        seg_base_tile + mma_tile_coord_mnl[1],
+                        cutlass.Int32(0),
+                    )
+                    a_rest_l_coord = work_tile.expert_idx
+                tAgA_mkl = tAgA[(None, mma_tile_coord_mnl[0], None, a_rest_l_coord)]
+                tBgB_nkl = tBgB[
+                    (None, mma_tile_coord_mnl[1], None, mma_tile_coord_mnl[2])
+                ]
+
+                mainloop_producer_state.reset_count()
+                for k_tile in cutlass.range(0, work_tile.k_tile_cnt, 1, unroll=1):
+                    mainloop_pipeline.producer_acquire(mainloop_producer_state)
+                    cute.copy(
+                        tma_atom_a,
+                        tAgA_mkl[(None, mainloop_producer_state.count)],
+                        tAsA[(None, mainloop_producer_state.index)],
+                        tma_bar_ptr=mainloop_pipeline.producer_get_barrier(
+                            mainloop_producer_state
+                        ),
+                        mcast_mask=a_mcast_mask,
+                    )
+                    cute.copy(
+                        tma_atom_b,
+                        tBgB_nkl[(None, mainloop_producer_state.count)],
+                        tBsB[(None, mainloop_producer_state.index)],
+                        tma_bar_ptr=mainloop_pipeline.producer_get_barrier(
+                            mainloop_producer_state
+                        ),
+                        mcast_mask=b_mcast_mask,
+                    )
+                    mainloop_pipeline.producer_commit(mainloop_producer_state)
+                    mainloop_producer_state.advance()
+
+                work_tile = tile_sched.advance_to_next_work()
+            mainloop_pipeline.producer_tail(mainloop_producer_state)
+
+        if not is_dma_warp_group:
+            cute.arch.setmaxregister_increase(self.mma_register_requirement)
+
+            mainloop_consumer_read_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.ab_stage
+            )
+            mainloop_consumer_release_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.ab_stage
+            )
+            num_k_blocks = cute.size(tCrA, mode=[2])
+
+            # N=8 has only four values/thread; the helper's fixed st.matrix x4
+            # needs eight. Scale the matrix count with the tile instead.
+            num_store_matrices = min(4, max(1, self.tile_shape_mnk[1] // 4))
+            if cutlass.const_expr(self.c_dtype.width == 16):
+                copy_atom_r2s = cute.make_copy_atom(
+                    cute.nvgpu.warp.StMatrix8x8x16bOp(
+                        self.c_layout.is_m_major_c(), num_store_matrices
+                    ),
+                    self.c_dtype,
+                )
+            else:
+                copy_atom_r2s = sm90_utils.sm90_get_smem_store_op(
+                    self.c_layout, elem_ty_d=self.c_dtype, elem_ty_acc=self.acc_dtype
+                )
+            copy_atom_C = cute.make_copy_atom(
+                cute.nvgpu.warp.StMatrix8x8x16bOp(
+                    self.c_layout.is_m_major_c(), num_store_matrices
+                ),
+                self.c_dtype,
+            )
+            tiled_copy_C_Atom = cute.make_tiled_copy_C_atom(copy_atom_C, tiled_mma)
+            tiled_copy_r2s = cute.make_tiled_copy_S(copy_atom_r2s, tiled_copy_C_Atom)
+            thr_copy_r2s = tiled_copy_r2s.get_slice(
+                tidx - self.num_dma_warp_groups * self.num_threads_per_warp_group
+            )
+            tRS_sD = thr_copy_r2s.partition_D(sC)
+            tRS_rAcc = tiled_copy_r2s.retile(accumulators)
+            rD_shape = cute.shape(thr_copy_r2s.partition_S(sC))
+            tRS_rD_layout = cute.make_layout(rD_shape[:3])
+            tRS_rD = cute.make_rmem_tensor(tRS_rD_layout.shape, self.acc_dtype)
+            tRS_rD_out = cute.make_rmem_tensor(tRS_rD_layout.shape, self.c_dtype)
+            size_tRS_rD = cute.size(tRS_rD)
+
+            tma_store_producer_group = pipeline.CooperativeGroup(
+                pipeline.Agent.Thread, self.num_mma_threads
+            )
+            tma_store_pipeline = pipeline.PipelineTmaStore.create(
+                num_stages=self.epi_stage,
+                producer_group=tma_store_producer_group,
+            )
+
+            # Rotate epilogue buffers by executed tiles, not global work index.
+            num_tiles_executed = cutlass.Int32(0)
+
+            # These helpers inline at trace time.
+
+            def _tile_ctx(self, work, gC_mnl, group_m):
+                coord = (work.tile_m_idx, work.tile_n_idx, work.expert_idx)
+                if cutlass.const_expr(self.swap_ab):
+                    coord = (work.tile_n_idx, work.tile_m_idx, work.expert_idx)
+                rest_l = coord[2]
+                if cutlass.const_expr(self.contiguous_segments):
+                    # Use the same flat segment offset as the DMA warp.
+                    seg_base_tile = group_m[work.expert_idx] // self.tile_shape_mnk[1]
+                    coord = (coord[0], seg_base_tile + coord[1], cutlass.Int32(0))
+                    rest_l = work.expert_idx
+                gC_slice = gC_mnl[(None, None, *coord)]
+                sfa_row_blk = (coord[0] * self.tile_shape_mnk[0]) // 128
+                token_base = coord[1] * self.tile_shape_mnk[1]
+                return gC_slice, sfa_row_blk, token_base, rest_l, coord[2]
+
+            # Add each lane's column offset to the warpgroup partition.
+            lane_col_base = (tidx % 32) % 4 * 2
+
+            def _load_scales(
+                sfa_row_blk,
+                token_base,
+                sfa_l,
+                sfb_l,
+                k_tile,
+                sfb_frag,
+                mSFA_mkl,
+                mSFB_nkl,
+                tCcC,
+                lane_col_base,
+            ):
+                sfa_s = mSFA_mkl[(sfa_row_blk, k_tile, sfa_l)]
+                for v in cutlass.range_constexpr(cute.size(sfb_frag, mode=[0])):
+                    for im in cutlass.range_constexpr(cute.size(sfb_frag, mode=[1])):
+                        for in_ in cutlass.range_constexpr(
+                            cute.size(sfb_frag, mode=[2])
+                        ):
+                            crd = (v, im, in_)
+                            sfb_frag[crd] = mSFB_nkl[
+                                (
+                                    token_base + lane_col_base + tCcC[crd][1],
+                                    k_tile,
+                                    sfb_l,
+                                )
+                            ]
+                return sfa_s
+
+            def _issue_mma(
+                acc_frag,
+                mainloop_pipeline,
+                read_state,
+                tiled_mma,
+                tCrA,
+                tCrB,
+                num_k_blocks,
+            ):
+                """Issue one K tile without draining its WGMMA group."""
+                mainloop_pipeline.consumer_wait(read_state)
+                acc_frag.fill(0.0)
+                cute.nvgpu.warpgroup.fence()
+                for k_block_idx in cutlass.range_constexpr(num_k_blocks):
+                    k_block_coord = (
+                        None,
+                        None,
+                        k_block_idx,
+                        read_state.index,
+                    )
+                    cute.gemm(
+                        tiled_mma,
+                        acc_frag,
+                        tCrA[k_block_coord],
+                        tCrB[k_block_coord],
+                        acc_frag,
+                    )
+                cute.nvgpu.warpgroup.commit_group()
+                read_state.advance()
+                return read_state
+
+            def _release_stage(mainloop_pipeline, release_state):
+                mainloop_pipeline.consumer_release(release_state)
+                release_state.advance()
+                return release_state
+
+            def _promote(acc_frag, sfa_s, sfb_frag, accumulators, tCcC):
+                # Nested coordinates pair layouts correctly; flat iteration does not.
+                # Single-K promotion overwrites the total.
+                for v in cutlass.range_constexpr(cute.size(accumulators, mode=[0])):
+                    for im in cutlass.range_constexpr(
+                        cute.size(accumulators, mode=[1])
+                    ):
+                        for in_ in cutlass.range_constexpr(
+                            cute.size(accumulators, mode=[2])
+                        ):
+                            crd = (v, im, in_)
+                            accumulators[crd] = acc_frag[crd] * (sfa_s * sfb_frag[crd])
+
+            def _epilogue(
+                self,
+                gC_slice,
+                tiles_executed,
+                tma_atom_c,
+                sC,
+                tRS_sD,
+                tRS_rAcc,
+                tRS_rD,
+                tRS_rD_out,
+                tiled_copy_r2s,
+                tma_store_pipeline,
+                warp_idx,
+                size_tRS_rD,
+                epilogue_op,
+            ):
+                tCgC_for_tma_partition = cute.zipped_divide(gC_slice, self.epi_tile)
+                bSG_sD, bSG_gD = cute.nvgpu.cpasync.tma_partition(
+                    tma_atom_c,
+                    0,
+                    cute.make_layout(1),
+                    cute.group_modes(sC, 0, 2),
+                    tCgC_for_tma_partition,
+                )
+                epi_tile_num = cute.size(tCgC_for_tma_partition, mode=[1])
+                epi_tile_shape = tCgC_for_tma_partition.shape[1]
+                epi_tile_layout = cute.make_layout(
+                    epi_tile_shape, stride=(epi_tile_shape[1], 1)
+                )
+                num_prev_epi_tiles = tiles_executed * epi_tile_num
+
+                for epi_idx in cutlass.range_constexpr(epi_tile_num):
+                    for epi_v in cutlass.range_constexpr(size_tRS_rD):
+                        tRS_rD[epi_v] = tRS_rAcc[epi_idx * size_tRS_rD + epi_v]
+                    acc_vec = epilogue_op(tRS_rD.load())
+                    tRS_rD_out.store(acc_vec.to(self.c_dtype))
+
+                    epi_buffer = (num_prev_epi_tiles + epi_idx) % cute.size(
+                        tRS_sD, mode=[3]
+                    )
+                    cute.copy(
+                        tiled_copy_r2s,
+                        tRS_rD_out,
+                        tRS_sD[(None, None, None, epi_buffer)],
+                    )
+                    cute.arch.fence_proxy("async.shared", space="cta")
+                    self.epilog_sync_barrier.arrive_and_wait()
+
+                    gmem_coord = epi_tile_layout.get_hier_coord(epi_idx)
+                    if warp_idx == self.epi_store_warp_id:
+                        cute.copy(
+                            tma_atom_c,
+                            bSG_sD[(None, epi_buffer)],
+                            bSG_gD[(None, gmem_coord)],
+                        )
+                        tma_store_pipeline.producer_commit()
+                        tma_store_pipeline.producer_acquire()
+                    self.epilog_sync_barrier.arrive_and_wait()
+
+            # Set outside helpers: handle updates cannot cross staged regions.
+            tiled_mma.set(cute.nvgpu.warpgroup.Field.ACCUMULATE, True)
+
+            if cutlass.const_expr(self.single_k_pipeline):
+                # Keep these buffers out of the multi-K path's register live ranges.
+                acc_partial2 = cute.make_fragment_like(acc_partial)
+                sfb_frag = cute.make_fragment_like(acc_partial)
+                sfb_frag2 = cute.make_fragment_like(acc_partial)
+                # Promote/store t-1 while tile t's WGMMA drains. Fixed fragment
+                # sets plus parity avoid spilling memrefs through the loop.
+                have_pending = cutlass.Boolean(False)
+                parity = cutlass.Boolean(False)
+                pend_sfa = cutlass.Float32(0.0)
+                pend_gC = gC_mnl[
+                    (None, None, cutlass.Int32(0), cutlass.Int32(0), cutlass.Int32(0))
+                ]
+                while work_tile.is_valid_tile:
+                    pend2_gC, sfa_blk0, tok0, sfal0, sfbl0 = _tile_ctx(
+                        self, work_tile, gC_mnl, group_m
+                    )
+                    pend2_sfa = cutlass.Float32(0.0)
+                    mainloop_consumer_read_state.reset_count()
+                    mainloop_consumer_release_state.reset_count()
+                    if parity:
+                        pend2_sfa = _load_scales(
+                            sfa_blk0,
+                            tok0,
+                            sfal0,
+                            sfbl0,
+                            0,
+                            sfb_frag2,
+                            mSFA_mkl,
+                            mSFB_nkl,
+                            tCcC,
+                            lane_col_base,
+                        )
+                        mainloop_consumer_read_state = _issue_mma(
+                            acc_partial2,
+                            mainloop_pipeline,
+                            mainloop_consumer_read_state,
+                            tiled_mma,
+                            tCrA,
+                            tCrB,
+                            num_k_blocks,
+                        )
+                    else:
+                        pend2_sfa = _load_scales(
+                            sfa_blk0,
+                            tok0,
+                            sfal0,
+                            sfbl0,
+                            0,
+                            sfb_frag,
+                            mSFA_mkl,
+                            mSFB_nkl,
+                            tCcC,
+                            lane_col_base,
+                        )
+                        mainloop_consumer_read_state = _issue_mma(
+                            acc_partial,
+                            mainloop_pipeline,
+                            mainloop_consumer_read_state,
+                            tiled_mma,
+                            tCrA,
+                            tCrB,
+                            num_k_blocks,
+                        )
+                    if have_pending:
+                        # Leave only the just-issued WGMMA group outstanding.
+                        cute.nvgpu.warpgroup.wait_group(1)
+                        mainloop_consumer_release_state = _release_stage(
+                            mainloop_pipeline, mainloop_consumer_release_state
+                        )
+                        if parity:
+                            _promote(
+                                acc_partial, pend_sfa, sfb_frag, accumulators, tCcC
+                            )
+                        else:
+                            _promote(
+                                acc_partial2, pend_sfa, sfb_frag2, accumulators, tCcC
+                            )
+                        _epilogue(
+                            self,
+                            pend_gC,
+                            num_tiles_executed,
+                            tma_atom_c,
+                            sC,
+                            tRS_sD,
+                            tRS_rAcc,
+                            tRS_rD,
+                            tRS_rD_out,
+                            tiled_copy_r2s,
+                            tma_store_pipeline,
+                            warp_idx,
+                            size_tRS_rD,
+                            epilogue_op,
+                        )
+                        num_tiles_executed += cutlass.Int32(1)
+                    pend_sfa = pend2_sfa
+                    pend_gC = pend2_gC
+                    have_pending = cutlass.Boolean(True)
+                    parity = ~parity
+                    work_tile = tile_sched.advance_to_next_work()
+                if have_pending:
+                    cute.nvgpu.warpgroup.wait_group(0)
+                    mainloop_consumer_release_state = _release_stage(
+                        mainloop_pipeline, mainloop_consumer_release_state
+                    )
+                    # Drain the buffer selected before the final parity flip.
+                    if parity:
+                        _promote(acc_partial, pend_sfa, sfb_frag, accumulators, tCcC)
+                    else:
+                        _promote(acc_partial2, pend_sfa, sfb_frag2, accumulators, tCcC)
+                    _epilogue(
+                        self,
+                        pend_gC,
+                        num_tiles_executed,
+                        tma_atom_c,
+                        sC,
+                        tRS_sD,
+                        tRS_rAcc,
+                        tRS_rD,
+                        tRS_rD_out,
+                        tiled_copy_r2s,
+                        tma_store_pipeline,
+                        warp_idx,
+                        size_tRS_rD,
+                        epilogue_op,
+                    )
+                    num_tiles_executed += cutlass.Int32(1)
+            else:
+                while work_tile.is_valid_tile:
+                    gC_mnl_slice, sfa_row_blk, token_base, sfa_l, sfb_l = _tile_ctx(
+                        self, work_tile, gC_mnl, group_m
+                    )
+                    mainloop_consumer_read_state.reset_count()
+                    mainloop_consumer_release_state.reset_count()
+                    accumulators.fill(0.0)
+
+                    # Hoisting scale loads ahead of the wait regresses multi-K tiles.
+                    for k_tile in cutlass.range(0, work_tile.k_tile_cnt, 1, unroll=1):
+                        mainloop_pipeline.consumer_wait(mainloop_consumer_read_state)
+                        acc_partial.fill(0.0)
+                        cute.nvgpu.warpgroup.fence()
+                        for k_block_idx in cutlass.range_constexpr(num_k_blocks):
+                            k_block_coord = (
+                                None,
+                                None,
+                                k_block_idx,
+                                mainloop_consumer_read_state.index,
+                            )
+                            cute.gemm(
+                                tiled_mma,
+                                acc_partial,
+                                tCrA[k_block_coord],
+                                tCrB[k_block_coord],
+                                acc_partial,
+                            )
+                        cute.nvgpu.warpgroup.commit_group()
+                        cute.nvgpu.warpgroup.wait_group(0)
+                        mainloop_pipeline.consumer_release(
+                            mainloop_consumer_release_state
+                        )
+                        mainloop_consumer_release_state.advance()
+                        mainloop_consumer_read_state.advance()
+
+                        sfa_s = mSFA_mkl[(sfa_row_blk, k_tile, sfa_l)]
+                        # Nested coordinates pair layouts correctly; flat iteration does not.
+                        for v in cutlass.range_constexpr(
+                            cute.size(accumulators, mode=[0])
+                        ):
+                            for im in cutlass.range_constexpr(
+                                cute.size(accumulators, mode=[1])
+                            ):
+                                for in_ in cutlass.range_constexpr(
+                                    cute.size(accumulators, mode=[2])
+                                ):
+                                    crd = (v, im, in_)
+                                    sfb_s = mSFB_nkl[
+                                        (
+                                            token_base + lane_col_base + tCcC[crd][1],
+                                            k_tile,
+                                            sfb_l,
+                                        )
+                                    ]
+                                    accumulators[crd] += acc_partial[crd] * (
+                                        sfa_s * sfb_s
+                                    )
+
+                    _epilogue(
+                        self,
+                        gC_mnl_slice,
+                        num_tiles_executed,
+                        tma_atom_c,
+                        sC,
+                        tRS_sD,
+                        tRS_rAcc,
+                        tRS_rD,
+                        tRS_rD_out,
+                        tiled_copy_r2s,
+                        tma_store_pipeline,
+                        warp_idx,
+                        size_tRS_rD,
+                        epilogue_op,
+                    )
+                    num_tiles_executed += cutlass.Int32(1)
+                    work_tile = tile_sched.advance_to_next_work()
+
+            tma_store_pipeline.producer_tail()
+
+    # The host helpers below come from the upstream Hopper persistent example.
+
+    @staticmethod
+    def _compute_stages(
+        tile_shape_mnk,
+        a_dtype,
+        b_dtype,
+        epi_tile,
+        c_dtype,
+        smem_capacity,
+        occupancy,
+    ):
+        a_shape = cute.slice_(tile_shape_mnk, (None, 0, None))
+        b_shape = cute.slice_(tile_shape_mnk, (0, None, None))
+        ab_bytes_per_stage = (
+            cute.size(a_shape) * a_dtype.width // 8
+            + cute.size(b_shape) * b_dtype.width // 8
+        )
+        c_bytes_per_stage = cute.size(epi_tile) * c_dtype.width // 8
+        epi_stage = 4
+        epi_bytes = c_bytes_per_stage * epi_stage
+        mbar_helpers_bytes = 1024
+        ab_stage = (
+            smem_capacity // occupancy - (mbar_helpers_bytes + epi_bytes)
+        ) // ab_bytes_per_stage
+        return ab_stage, epi_stage
+
+    @staticmethod
+    def _sm90_compute_tile_shape_or_override(
+        tile_shape_mnk, element_type, is_cooperative=False, epi_tile_override=None
+    ):
+        if epi_tile_override is not None:
+            return epi_tile_override
+        if is_cooperative:
+            tile_m = min(128, cute.size(tile_shape_mnk, mode=[0]))
+            tile_n = min(32, cute.size(tile_shape_mnk, mode=[1]))
+            return (tile_m, tile_n)
+        n_perf = 64 if element_type.width == 8 else 32
+        tile_m = min(64, cute.size(tile_shape_mnk, mode=[0]))
+        tile_n = min(n_perf, cute.size(tile_shape_mnk, mode=[1]))
+        return (tile_m, tile_n)
+
+    @staticmethod
+    def _make_smem_layouts(
+        tile_shape_mnk,
+        epi_tile,
+        a_dtype,
+        a_layout,
+        b_dtype,
+        b_layout,
+        ab_stage,
+        c_dtype,
+        c_layout,
+        epi_stage,
+    ):
+        a_smem_shape = cute.slice_(tile_shape_mnk, (None, 0, None))
+        a_is_k_major = (
+            a_layout.sm90_mma_major_mode() == cute.nvgpu.warpgroup.OperandMajorMode.K
+        )
+        b_is_k_major = (
+            b_layout.sm90_mma_major_mode() == cute.nvgpu.warpgroup.OperandMajorMode.K
+        )
+        a_major_mode_size = tile_shape_mnk[2 if a_is_k_major else 0]
+        a_smem_layout_atom = cute.nvgpu.warpgroup.make_smem_layout_atom(
+            sm90_utils.get_smem_layout_atom(a_layout, a_dtype, a_major_mode_size),
+            a_dtype,
+        )
+        a_smem_layout_staged = cute.tile_to_shape(
+            a_smem_layout_atom,
+            cute.append(a_smem_shape, ab_stage),
+            order=(0, 1, 2) if a_is_k_major else (1, 0, 2),
+        )
+
+        b_smem_shape = cute.slice_(tile_shape_mnk, (0, None, None))
+        b_major_mode_size = tile_shape_mnk[2 if b_is_k_major else 1]
+        b_smem_layout_atom = cute.nvgpu.warpgroup.make_smem_layout_atom(
+            sm90_utils.get_smem_layout_atom(b_layout, b_dtype, b_major_mode_size),
+            b_dtype,
+        )
+        b_smem_layout_staged = cute.tile_to_shape(
+            b_smem_layout_atom,
+            cute.append(b_smem_shape, ab_stage),
+            order=(0, 1, 2) if b_is_k_major else (1, 0, 2),
+        )
+
+        c_smem_shape = epi_tile
+        c_major_mode_size = epi_tile[1] if c_layout.is_n_major_c() else epi_tile[0]
+        c_smem_layout_atom = cute.nvgpu.warpgroup.make_smem_layout_atom(
+            sm90_utils.get_smem_layout_atom(c_layout, c_dtype, c_major_mode_size),
+            c_dtype,
+        )
+        epi_smem_layout_staged = cute.tile_to_shape(
+            c_smem_layout_atom,
+            cute.append(c_smem_shape, epi_stage),
+            order=(1, 0, 2) if c_layout.is_m_major_c() else (0, 1, 2),
+        )
+        return a_smem_layout_staged, b_smem_layout_staged, epi_smem_layout_staged
+
+    @staticmethod
+    def _make_tma_store_atoms_and_tensors(tensor_c, epi_smem_layout_staged, epi_tile):
+        epi_smem_layout = cute.slice_(epi_smem_layout_staged, (None, None, 0))
+        return cute.nvgpu.cpasync.make_tiled_tma_atom(
+            cute.nvgpu.cpasync.CopyBulkTensorTileS2GOp(),
+            tensor_c,
+            epi_smem_layout,
+            epi_tile,
+        )
+
+    @staticmethod
+    def _make_tma_atoms_and_tensors(tensor, smem_layout_staged, smem_tile, mcast_dim):
+        op = (
+            cute.nvgpu.cpasync.CopyBulkTensorTileG2SOp()
+            if mcast_dim == 1
+            else cute.nvgpu.cpasync.CopyBulkTensorTileG2SMulticastOp()
+        )
+        smem_layout = cute.slice_(smem_layout_staged, (None, None, 0))
+        return cute.nvgpu.cpasync.make_tiled_tma_atom(
+            op, tensor, smem_layout, smem_tile, num_multicast=mcast_dim
+        )
+
+    def check_supported_dtypes(self, a_dtype, b_dtype, c_dtype):
+        if a_dtype is not cutlass.Float8E4M3FN or b_dtype is not cutlass.Float8E4M3FN:
+            raise TypeError(f"the FP8 grouped GEMM takes e4m3 A/B; got {a_dtype}")
+        if c_dtype is not cutlass.BFloat16:
+            raise TypeError(f"C must be BF16; got {c_dtype}")
+
+    def check_mma_tiler_and_cluster_shape(self):
+        if self.tile_shape_mnk[0] not in (64, 128):
+            raise ValueError("SM90 CTA tile M must be 64/128")
+        if self.tile_shape_mnk[1] not in (8, 16, 32, 64, 128, 256):
+            raise ValueError(
+                "this port validates CTA tile N in {8, 16, 32, 64, 128, "
+                "256}; WGMMA itself accepts 8..256 step 8 -- extend the "
+                "validated set before requesting other widths"
+            )
+        if math.prod(self.cluster_shape_mn) > 4:
+            raise ValueError("SM90 cluster size must be <= 4")
+        for extent in self.cluster_shape_mn:
+            if extent <= 0 or extent & (extent - 1):
+                raise ValueError(
+                    "cluster extents must be positive powers of two; got "
+                    f"{self.cluster_shape_mn}"
+                )
+
+    def check_tensor_alignment(self, problem_shape, a_major, b_major, c_major):
+        if a_major != "k" or b_major != "k":
+            raise ValueError("SM90 port requires K-major A and B")
+        m, n, k, _length = problem_shape
+        for extent, name in ((m, "M"), (n, "N"), (k, "K")):
+            if extent % 8:
+                raise ValueError(f"{name}={extent} breaks 16-byte TMA alignment")
+
+    def can_implement(
+        self, problem_shape, a_dtype, b_dtype, c_dtype, a_major, b_major, c_major
+    ) -> bool:
+        try:
+            self.check_supported_dtypes(a_dtype, b_dtype, c_dtype)
+            self.check_mma_tiler_and_cluster_shape()
+            self.check_tensor_alignment(problem_shape, a_major, b_major, c_major)
+        except (TypeError, ValueError):
+            return False
+        return True

--- a/python/sglang/srt/lora/moe/kernels/cutedsl/schedule_builder.py
+++ b/python/sglang/srt/lora/moe/kernels/cutedsl/schedule_builder.py
@@ -1,0 +1,350 @@
+"""Build both GEMM schedules from the dispatcher's row counts in one launch."""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+# Shared with scheduler.py: one signed int64 per tile, leaving bit 63 clear.
+
+EXPERT_SHIFT = 0
+EXPERT_BITS = 20
+EXPERT_MASK = (1 << EXPERT_BITS) - 1
+
+TOKEN_CLUSTER_SHIFT = EXPERT_SHIFT + EXPERT_BITS
+TOKEN_CLUSTER_BITS = 22
+TOKEN_CLUSTER_MASK = (1 << TOKEN_CLUSTER_BITS) - 1
+
+OUTPUT_CLUSTER_SHIFT = TOKEN_CLUSTER_SHIFT + TOKEN_CLUSTER_BITS
+OUTPUT_CLUSTER_BITS = 21
+OUTPUT_CLUSTER_MASK = (1 << OUTPUT_CLUSTER_BITS) - 1
+
+PACKED_BITS = OUTPUT_CLUSTER_SHIFT + OUTPUT_CLUSTER_BITS
+assert PACKED_BITS == 63, PACKED_BITS
+
+MAX_EXPERTS = 1 << EXPERT_BITS
+MAX_TOKEN_CLUSTERS = 1 << TOKEN_CLUSTER_BITS
+MAX_OUTPUT_CLUSTERS = 1 << OUTPUT_CLUSTER_BITS
+
+
+@triton.jit
+def _dual_schedule_kernel(
+    masked_m_ptr,
+    schedule1_ptr,
+    tiles1_ptr,
+    schedule2_ptr,
+    tiles2_ptr,
+    token_width,
+    out_clusters1,
+    out_clusters2,
+    EXPERTS: tl.constexpr,
+    BLOCK_EXPERTS: tl.constexpr,
+    ENTRY_BLOCK: tl.constexpr,
+    TOKEN_SHIFT: tl.constexpr,
+    OUTPUT_SHIFT: tl.constexpr,
+):
+    expert = tl.program_id(0)
+    stage = tl.program_id(1)
+    out_clusters = tl.where(stage == 0, out_clusters1, out_clusters2)
+
+    offs = tl.arange(0, BLOCK_EXPERTS)
+    all_rows = tl.load(masked_m_ptr + offs, mask=offs < EXPERTS, other=0)
+    all_entries = tl.cdiv(all_rows, token_width) * out_clusters
+    begin = tl.sum(tl.where(offs < expert, all_entries, 0))
+    if expert == 0:
+        total = tl.sum(tl.where(offs < EXPERTS, all_entries, 0))
+        if stage == 0:
+            tl.store(tiles1_ptr, total)
+        else:
+            tl.store(tiles2_ptr, total)
+
+    rows = tl.load(masked_m_ptr + expert)
+    token_clusters = tl.cdiv(rows, token_width)
+    safe_tc = tl.maximum(token_clusters, 1)
+    entries = token_clusters * out_clusters
+    token_major = token_clusters > out_clusters
+    for base in range(0, entries, ENTRY_BLOCK):
+        local = base + tl.arange(0, ENTRY_BLOCK)
+        valid = local < entries
+        oc_a = local // safe_tc
+        tc_a = local - oc_a * safe_tc
+        tc_b = local // out_clusters
+        oc_b = local - tc_b * out_clusters
+        tc_i = tl.where(token_major, tc_b, tc_a)
+        oc_i = tl.where(token_major, oc_b, oc_a)
+        # Widen before shifting to preserve the upper fields.
+        packed = (
+            expert.to(tl.int64)
+            | (tc_i.to(tl.int64) << TOKEN_SHIFT)
+            | (oc_i.to(tl.int64) << OUTPUT_SHIFT)
+        )
+        if stage == 0:
+            tl.store(schedule1_ptr + begin + local, packed, mask=valid)
+        else:
+            tl.store(schedule2_ptr + begin + local, packed, mask=valid)
+
+
+def dual_stage_schedule_capacities_masked(
+    *,
+    num_experts: int,
+    m_max: int,
+    token_width: int,
+    n_gemm1: int,
+    n_gemm2: int,
+    output_width: int,
+    cluster_shape_mn: tuple[int, int] = (1, 1),
+    use_2cta_instrs: bool = False,
+) -> tuple[int, int]:
+    """CTA-tile entries require 1x1 clusters and 1-CTA MMA."""
+    if tuple(cluster_shape_mn) != (1, 1) or use_2cta_instrs:
+        raise ValueError(
+            "the packed direct schedule is emitted at CTA-tile granularity and "
+            "the device expands it by cluster_shape_mn, so only a (1, 1) "
+            "cluster with 1-CTA MMA is representable; got "
+            f"cluster_shape_mn={tuple(cluster_shape_mn)}, "
+            f"use_2cta_instrs={use_2cta_instrs}"
+        )
+    out_clusters1 = (n_gemm1 + output_width - 1) // output_width
+    out_clusters2 = (n_gemm2 + output_width - 1) // output_width
+    max_token_clusters = (m_max + token_width - 1) // token_width
+    if num_experts > MAX_EXPERTS:
+        raise ValueError(
+            f"direct schedule packs expert INDICES in "
+            f"{MAX_EXPERTS.bit_length() - 1} bits (counts up to "
+            f"{MAX_EXPERTS}); got {num_experts}"
+        )
+    if max_token_clusters > MAX_TOKEN_CLUSTERS:
+        raise ValueError(
+            f"m_max={m_max} at token width {token_width} needs "
+            f"{max_token_clusters} token clusters; the packing holds "
+            f"{MAX_TOKEN_CLUSTERS}. Admission must pick a wider tile."
+        )
+    if max(out_clusters1, out_clusters2) > MAX_OUTPUT_CLUSTERS:
+        raise ValueError(
+            f"{max(out_clusters1, out_clusters2)} output clusters exceed the "
+            f"{MAX_OUTPUT_CLUSTERS} the non-negative-word config allows"
+        )
+    # Individually valid fields can still overflow the int32 prefix sum.
+    capacity = num_experts * max_token_clusters * max(out_clusters1, out_clusters2)
+    if capacity > 2**31 - 1:
+        raise ValueError(
+            f"worst-case schedule capacity {capacity} overflows the builder's "
+            "int32 prefix arithmetic"
+        )
+    return (
+        num_experts * max_token_clusters * out_clusters1,
+        num_experts * max_token_clusters * out_clusters2,
+    )
+
+
+def validate_tile_geometry_contiguous(token_width: int, m_alignment: int) -> None:
+    """Require exact segment-base division and keep partial tiles in bounds."""
+    if not isinstance(token_width, int) or token_width < 1:
+        raise ValueError(f"token_width must be a positive int, got {token_width!r}")
+    if not isinstance(m_alignment, int) or m_alignment < 1:
+        raise ValueError(f"m_alignment must be a positive int, got {m_alignment!r}")
+    if m_alignment % token_width:
+        raise ValueError(
+            f"token tile {token_width} does not divide the segment alignment "
+            f"{m_alignment}: a partial tile could cross into the next "
+            "expert's rows"
+        )
+
+
+def dual_stage_schedule_capacities_contiguous(
+    *,
+    num_experts: int,
+    m_pad_ceiling: int,
+    max_expert_rows: int,
+    m_alignment: int,
+    token_width: int,
+    n_gemm1: int,
+    n_gemm2: int,
+    output_width: int,
+    cluster_shape_mn: tuple[int, int] = (1, 1),
+    use_2cta_instrs: bool = False,
+) -> tuple[int, int]:
+    """Bound capacity by total padded rows instead of per-expert slabs."""
+    dual_stage_schedule_capacities_masked(
+        num_experts=num_experts,
+        m_max=max_expert_rows,
+        token_width=token_width,
+        n_gemm1=n_gemm1,
+        n_gemm2=n_gemm2,
+        output_width=output_width,
+        cluster_shape_mn=cluster_shape_mn,
+        use_2cta_instrs=use_2cta_instrs,
+    )
+    validate_tile_geometry_contiguous(token_width, m_alignment)
+    if m_pad_ceiling < 0 or m_pad_ceiling % m_alignment:
+        raise ValueError(
+            f"m_pad_ceiling={m_pad_ceiling} must be a non-negative multiple "
+            f"of the segment alignment {m_alignment}"
+        )
+    total_clusters = m_pad_ceiling // token_width
+    out_clusters1 = (n_gemm1 + output_width - 1) // output_width
+    out_clusters2 = (n_gemm2 + output_width - 1) // output_width
+    capacity = total_clusters * max(out_clusters1, out_clusters2)
+    if capacity > 2**31 - 1:
+        raise ValueError(
+            f"worst-case contiguous schedule capacity {capacity} overflows "
+            "the builder's int32 prefix arithmetic"
+        )
+    return (
+        max(total_clusters * out_clusters1, 1),
+        max(total_clusters * out_clusters2, 1),
+    )
+
+
+def build_dual_stage_schedules_contiguous(
+    seg_counts: torch.Tensor,
+    *,
+    m_pad_ceiling: int,
+    max_expert_rows: int,
+    m_alignment: int,
+    token_width: int,
+    n_gemm1: int,
+    n_gemm2: int,
+    output_width: int,
+    cluster_shape_mn: tuple[int, int] = (1, 1),
+    use_2cta_instrs: bool = False,
+    schedule1_out: torch.Tensor | None = None,
+    tiles1_out: torch.Tensor | None = None,
+    schedule2_out: torch.Tensor | None = None,
+    tiles2_out: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    num_experts = seg_counts.numel()
+    capacity1, capacity2 = dual_stage_schedule_capacities_contiguous(
+        num_experts=num_experts,
+        m_pad_ceiling=m_pad_ceiling,
+        max_expert_rows=max_expert_rows,
+        m_alignment=m_alignment,
+        token_width=token_width,
+        n_gemm1=n_gemm1,
+        n_gemm2=n_gemm2,
+        output_width=output_width,
+        cluster_shape_mn=cluster_shape_mn,
+        use_2cta_instrs=use_2cta_instrs,
+    )
+    out_clusters1 = (n_gemm1 + output_width - 1) // output_width
+    out_clusters2 = (n_gemm2 + output_width - 1) // output_width
+
+    device = seg_counts.device
+    schedule1 = _schedule_output(
+        schedule1_out,
+        elements=capacity1,
+        device=device,
+    )
+    schedule2 = _schedule_output(
+        schedule2_out,
+        elements=capacity2,
+        device=device,
+    )
+    tiles1 = _tile_count_output(
+        tiles1_out,
+        device=device,
+    )
+    tiles2 = _tile_count_output(
+        tiles2_out,
+        device=device,
+    )
+    _dual_schedule_kernel[(num_experts, 2)](
+        seg_counts,
+        schedule1,
+        tiles1,
+        schedule2,
+        tiles2,
+        token_width,
+        out_clusters1,
+        out_clusters2,
+        EXPERTS=num_experts,
+        BLOCK_EXPERTS=max(triton.next_power_of_2(num_experts), 2),
+        ENTRY_BLOCK=128,
+        TOKEN_SHIFT=TOKEN_CLUSTER_SHIFT,
+        OUTPUT_SHIFT=OUTPUT_CLUSTER_SHIFT,
+    )
+    return schedule1, tiles1, schedule2, tiles2
+
+
+def _schedule_output(
+    output: torch.Tensor | None, *, elements: int, device: torch.device
+) -> torch.Tensor:
+    if output is None:
+        return torch.empty(elements, dtype=torch.int64, device=device)
+    return output
+
+
+def _tile_count_output(
+    output: torch.Tensor | None, *, device: torch.device
+) -> torch.Tensor:
+    # int32: the device compares it to an Int32 work index.
+    if output is None:
+        return torch.empty(1, dtype=torch.int32, device=device)
+    return output
+
+
+def build_dual_stage_schedules_masked(
+    masked_m: torch.Tensor,
+    *,
+    m_max: int,
+    token_width: int,
+    n_gemm1: int,
+    n_gemm2: int,
+    output_width: int,
+    cluster_shape_mn: tuple[int, int] = (1, 1),
+    use_2cta_instrs: bool = False,
+    schedule1_out: torch.Tensor | None = None,
+    tiles1_out: torch.Tensor | None = None,
+    schedule2_out: torch.Tensor | None = None,
+    tiles2_out: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    num_experts = masked_m.numel()
+    capacity1, capacity2 = dual_stage_schedule_capacities_masked(
+        num_experts=num_experts,
+        m_max=m_max,
+        token_width=token_width,
+        n_gemm1=n_gemm1,
+        n_gemm2=n_gemm2,
+        output_width=output_width,
+        cluster_shape_mn=cluster_shape_mn,
+        use_2cta_instrs=use_2cta_instrs,
+    )
+    out_clusters1 = (n_gemm1 + output_width - 1) // output_width
+    out_clusters2 = (n_gemm2 + output_width - 1) // output_width
+
+    device = masked_m.device
+    schedule1 = _schedule_output(
+        schedule1_out,
+        elements=capacity1,
+        device=device,
+    )
+    schedule2 = _schedule_output(
+        schedule2_out,
+        elements=capacity2,
+        device=device,
+    )
+    tiles1 = _tile_count_output(
+        tiles1_out,
+        device=device,
+    )
+    tiles2 = _tile_count_output(
+        tiles2_out,
+        device=device,
+    )
+    _dual_schedule_kernel[(num_experts, 2)](
+        masked_m,
+        schedule1,
+        tiles1,
+        schedule2,
+        tiles2,
+        token_width,
+        out_clusters1,
+        out_clusters2,
+        EXPERTS=num_experts,
+        BLOCK_EXPERTS=max(triton.next_power_of_2(num_experts), 2),
+        ENTRY_BLOCK=128,
+        TOKEN_SHIFT=TOKEN_CLUSTER_SHIFT,
+        OUTPUT_SHIFT=OUTPUT_CLUSTER_SHIFT,
+    )
+    return schedule1, tiles1, schedule2, tiles2

--- a/python/sglang/srt/lora/moe/kernels/cutedsl/scheduler.py
+++ b/python/sglang/srt/lora/moe/kernels/cutedsl/scheduler.py
@@ -106,10 +106,6 @@ class MoESchedulerParams:
         return self.cta_tile_shape_mnk[0] * self.cluster_shape_mn[0]
 
     @property
-    def cluster_tile_n(self) -> int:
-        return self.cta_tile_shape_mnk[1] * self.cluster_shape_mn[1]
-
-    @property
     def cta_tile_k(self) -> int:
         return self.cta_tile_shape_mnk[2]
 

--- a/python/sglang/srt/lora/moe/kernels/cutedsl/scheduler.py
+++ b/python/sglang/srt/lora/moe/kernels/cutedsl/scheduler.py
@@ -1,0 +1,349 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Persistent scheduler for the packed work list from schedule_builder."""
+
+from typing import List, Tuple
+
+import cutlass.cute as cute
+from cutlass._mlir import ir
+from cutlass.cutlass_dsl import (
+    Boolean,
+    Int32,
+    Int64,
+    Integer,
+    dsl_user_op,
+    extract_mlir_values,
+    new_from_mlir_values,
+)
+
+from sglang.srt.lora.moe.kernels.cutedsl.schedule_builder import (
+    EXPERT_MASK,
+    OUTPUT_CLUSTER_MASK,
+    OUTPUT_CLUSTER_SHIFT,
+    TOKEN_CLUSTER_MASK,
+    TOKEN_CLUSTER_SHIFT,
+)
+
+
+class MoEWorkTileInfo:
+    def __init__(
+        self,
+        expert_idx: Int32,  # -1 means invalid tile
+        tile_m_idx: Int32,
+        tile_n_idx: Int32,
+        k_tile_cnt: Int32,
+    ):
+        self.expert_idx = expert_idx
+        self.tile_m_idx = tile_m_idx
+        self.tile_n_idx = tile_n_idx
+        self.k_tile_cnt = k_tile_cnt
+
+    @property
+    def is_valid_tile(self) -> Boolean:
+        return self.expert_idx >= Int32(0)
+
+    def __extract_mlir_values__(self) -> List[ir.Value]:
+        values = extract_mlir_values(self.expert_idx)
+        values.extend(extract_mlir_values(self.tile_m_idx))
+        values.extend(extract_mlir_values(self.tile_n_idx))
+        values.extend(extract_mlir_values(self.k_tile_cnt))
+        return values
+
+    def __new_from_mlir_values__(self, values: List[ir.Value]) -> "MoEWorkTileInfo":
+        assert len(values) == 4
+        return MoEWorkTileInfo(
+            expert_idx=new_from_mlir_values(self.expert_idx, [values[0]]),
+            tile_m_idx=new_from_mlir_values(self.tile_m_idx, [values[1]]),
+            tile_n_idx=new_from_mlir_values(self.tile_n_idx, [values[2]]),
+            k_tile_cnt=new_from_mlir_values(self.k_tile_cnt, [values[3]]),
+        )
+
+
+class MoESchedulerParams:
+    def __init__(
+        self,
+        expert_shape: Tuple[
+            int | Int32, int | Int32, int | Int32
+        ],  # (expert_cnt, intermediate, hidden)
+        cta_tile_shape_mnk: Tuple[int, int, int],
+        cluster_shape_mn: Tuple[int, int],
+    ):
+        e, i, h = expert_shape
+        self.expert_cnt = e if isinstance(e, Int32) else Int32(e)
+        self.intermediate = i if isinstance(i, Int32) else Int32(i)
+        self.hidden = h if isinstance(h, Int32) else Int32(h)
+        self.cta_tile_shape_mnk = cta_tile_shape_mnk
+        self.cluster_shape_mn = cluster_shape_mn
+
+    @property
+    def cluster_tile_m(self) -> int:
+        return self.cta_tile_shape_mnk[0] * self.cluster_shape_mn[0]
+
+    @property
+    def cluster_tile_n(self) -> int:
+        return self.cta_tile_shape_mnk[1] * self.cluster_shape_mn[1]
+
+    @property
+    def cta_tile_k(self) -> int:
+        return self.cta_tile_shape_mnk[2]
+
+    def __extract_mlir_values__(self) -> List[ir.Value]:
+        values = []
+        values.extend(extract_mlir_values(self.expert_cnt))
+        values.extend(extract_mlir_values(self.intermediate))
+        values.extend(extract_mlir_values(self.hidden))
+        return values
+
+    def __new_from_mlir_values__(self, values: List[ir.Value]) -> "MoESchedulerParams":
+        assert len(values) == 3
+        return MoESchedulerParams(
+            expert_shape=(
+                new_from_mlir_values(self.expert_cnt, [values[0]]),
+                new_from_mlir_values(self.intermediate, [values[1]]),
+                new_from_mlir_values(self.hidden, [values[2]]),
+            ),
+            cta_tile_shape_mnk=self.cta_tile_shape_mnk,
+            cluster_shape_mn=self.cluster_shape_mn,
+        )
+
+    @staticmethod
+    def get_grid_shape(
+        params: "MoESchedulerParams",
+        max_active_clusters: int,
+    ) -> Tuple[int, int, int]:
+        # Device row counts determine which persistent CTAs have work.
+        return (
+            params.cluster_shape_mn[0],
+            params.cluster_shape_mn[1],
+            max_active_clusters,
+        )
+
+
+class MoEDirectPersistentTileScheduler:
+    """Decode (expert, cluster_m, cluster_n) from one int64 per tile."""
+
+    def __init__(
+        self,
+        params: MoESchedulerParams,
+        schedule: cute.Tensor,
+        schedule_tiles: cute.Tensor,
+        num_persistent_clusters: Int32,
+        current_work_linear_idx: Int32,
+        cta_id_in_cluster: cute.Coord,
+    ):
+        self.params = params
+        self.schedule = schedule
+        self.schedule_tiles = schedule_tiles
+        self.num_persistent_clusters = num_persistent_clusters
+        self._current_work_linear_idx = current_work_linear_idx
+        self.cta_id_in_cluster = cta_id_in_cluster
+
+    def __extract_mlir_values__(self) -> List[ir.Value]:
+        values = []
+        values.extend(extract_mlir_values(self.params))
+        values.extend(extract_mlir_values(self.schedule))
+        values.extend(extract_mlir_values(self.schedule_tiles))
+        values.extend(extract_mlir_values(self.num_persistent_clusters))
+        values.extend(extract_mlir_values(self._current_work_linear_idx))
+        values.extend(extract_mlir_values(self.cta_id_in_cluster))
+        return values
+
+    def __new_from_mlir_values__(
+        self, values: List[ir.Value]
+    ) -> "MoEDirectPersistentTileScheduler":
+        idx = 0
+        new_params = new_from_mlir_values(self.params, values[idx : idx + 3])
+        idx += 3
+        schedule_len = len(extract_mlir_values(self.schedule))
+        new_schedule = new_from_mlir_values(
+            self.schedule, values[idx : idx + schedule_len]
+        )
+        idx += schedule_len
+        tiles_len = len(extract_mlir_values(self.schedule_tiles))
+        new_schedule_tiles = new_from_mlir_values(
+            self.schedule_tiles, values[idx : idx + tiles_len]
+        )
+        idx += tiles_len
+        new_num_clusters = new_from_mlir_values(
+            self.num_persistent_clusters, [values[idx]]
+        )
+        idx += 1
+        new_work_idx = new_from_mlir_values(
+            self._current_work_linear_idx, [values[idx]]
+        )
+        idx += 1
+        new_cta_id = new_from_mlir_values(self.cta_id_in_cluster, values[idx : idx + 3])
+        return MoEDirectPersistentTileScheduler(
+            new_params,
+            new_schedule,
+            new_schedule_tiles,
+            new_num_clusters,
+            new_work_idx,
+            new_cta_id,
+        )
+
+    @staticmethod
+    @dsl_user_op
+    def create(
+        params: MoESchedulerParams,
+        schedule: cute.Tensor,
+        schedule_tiles: cute.Tensor,
+        block_idx: Tuple[Integer, Integer, Integer],
+        grid_dim: Tuple[Integer, Integer, Integer],
+        *,
+        loc=None,
+        ip=None,
+    ) -> "MoEDirectPersistentTileScheduler":
+        num_persistent_clusters = cute.size(grid_dim, loc=loc, ip=ip) // cute.size(
+            params.cluster_shape_mn, loc=loc, ip=ip
+        )
+        bidx, bidy, bidz = block_idx
+        return MoEDirectPersistentTileScheduler(
+            params,
+            schedule,
+            schedule_tiles,
+            Int32(num_persistent_clusters),
+            Int32(bidz),
+            (
+                Int32(bidx % params.cluster_shape_mn[0]),
+                Int32(bidy % params.cluster_shape_mn[1]),
+                Int32(0),
+            ),
+        )
+
+    @dsl_user_op
+    @cute.jit
+    def initial_work_tile_info(self, *, loc=None, ip=None) -> MoEWorkTileInfo:
+        return self._get_current_work(loc=loc, ip=ip)
+
+    @dsl_user_op
+    @cute.jit
+    def advance_to_next_work(self, *, loc=None, ip=None) -> MoEWorkTileInfo:
+        self._current_work_linear_idx += self.num_persistent_clusters
+        return self._get_current_work(loc=loc, ip=ip)
+
+    @dsl_user_op
+    @cute.jit
+    def _get_current_work(self, *, loc=None, ip=None) -> MoEWorkTileInfo:
+        work = MoEWorkTileInfo(Int32(-1), Int32(0), Int32(0), Int32(0))
+        if self._current_work_linear_idx < self.schedule_tiles[0]:
+            packed = Int64(self.schedule[self._current_work_linear_idx])
+            expert = Int32(packed & Int64(EXPERT_MASK))
+            cluster_m = Int32(
+                (packed >> Int64(TOKEN_CLUSTER_SHIFT)) & Int64(TOKEN_CLUSTER_MASK)
+            )
+            cluster_n = Int32(
+                (packed >> Int64(OUTPUT_CLUSTER_SHIFT)) & Int64(OUTPUT_CLUSTER_MASK)
+            )
+            tile_m = (
+                cluster_m * self.params.cluster_shape_mn[0]
+                + self.cta_id_in_cluster[0]  # type: ignore[index]
+            )
+            tile_n = (
+                cluster_n * self.params.cluster_shape_mn[1]
+                + self.cta_id_in_cluster[1]  # type: ignore[index]
+            )
+            k_tiles = (
+                self.params.hidden + self.params.cta_tile_k - 1
+            ) // self.params.cta_tile_k
+            work = MoEWorkTileInfo(expert, tile_m, tile_n, Int32(k_tiles))
+        return work
+
+
+def resolve_scheduler_params_and_grid(
+    *,
+    a: cute.Tensor,
+    c: cute.Tensor,
+    cta_tile_shape_mnk,
+    cluster_shape_mn,
+    swap_ab: bool,
+    contiguous_segments: bool,
+    persistent_clusters,
+    max_active_clusters,
+):
+    """Keep tokens on scheduler M, transposing tile/cluster axes under swap_ab."""
+    m_max, n, expert_cnt = c.shape
+    if contiguous_segments:
+        # Flat output has one slot; the weight retains the real expert count.
+        expert_cnt = cute.size(a.shape[2])
+    # K can be hierarchical; the scheduler needs its scalar extent.
+    k = cute.size(a.shape[1])
+    cta_tile = cta_tile_shape_mnk
+    cluster = cluster_shape_mn
+    sched_n = n
+    if swap_ab:
+        cta_tile = (
+            cta_tile_shape_mnk[1],
+            cta_tile_shape_mnk[0],
+            cta_tile_shape_mnk[2],
+        )
+        cluster = (cluster_shape_mn[1], cluster_shape_mn[0])
+        sched_n = m_max
+    params = MoESchedulerParams(
+        expert_shape=(expert_cnt, sched_n, k),
+        cta_tile_shape_mnk=cta_tile,
+        cluster_shape_mn=cluster,
+    )
+    launch_clusters = (
+        max_active_clusters if persistent_clusters is None else persistent_clusters
+    )
+    grid = MoESchedulerParams.get_grid_shape(params, launch_clusters)
+    if swap_ab:
+        grid = (cluster_shape_mn[0], cluster_shape_mn[1], launch_clusters)
+    return params, grid
+
+
+def create_moe_tile_scheduler(
+    *,
+    tile_sched_params,
+    direct_schedule: cute.Tensor,
+    schedule_tiles: cute.Tensor,
+    swap_ab: bool,
+):
+    """Restore scheduler axis order under swap_ab at trace time."""
+    scheduler_block_idx = cute.arch.block_idx()
+    scheduler_grid_dim = cute.arch.grid_dim()
+    if swap_ab:
+        scheduler_block_idx = (
+            scheduler_block_idx[1],
+            scheduler_block_idx[0],
+            scheduler_block_idx[2],
+        )
+        scheduler_grid_dim = (
+            scheduler_grid_dim[1],
+            scheduler_grid_dim[0],
+            scheduler_grid_dim[2],
+        )
+    return MoEDirectPersistentTileScheduler.create(
+        tile_sched_params,
+        direct_schedule,
+        schedule_tiles,
+        scheduler_block_idx,
+        scheduler_grid_dim,
+    )

--- a/python/sglang/srt/lora/moe/kernels/dispatch_checks.py
+++ b/python/sglang/srt/lora/moe/kernels/dispatch_checks.py
@@ -1,0 +1,21 @@
+"""Input contracts shared by the masked and contiguous row movers."""
+
+from __future__ import annotations
+
+import torch
+
+
+def check_source_rows(
+    hidden_states: torch.Tensor, topk_ids: torch.Tensor, top_k: int
+) -> None:
+    if hidden_states.dtype != torch.bfloat16:
+        raise ValueError("the row movers take BF16 [num_tokens, hidden] input")
+    if hidden_states.ndim != 2 or not hidden_states.is_contiguous():
+        raise ValueError("hidden_states must be contiguous [num_tokens, hidden]")
+    if not topk_ids.is_contiguous():
+        raise ValueError("topk_ids must be contiguous")
+    if topk_ids.numel() != hidden_states.size(0) * top_k:
+        raise ValueError(
+            f"topk_ids carries {topk_ids.numel()} pairs for "
+            f"{hidden_states.size(0)} tokens x top_k={top_k}"
+        )

--- a/python/sglang/srt/lora/moe/kernels/dispatch_checks.py
+++ b/python/sglang/srt/lora/moe/kernels/dispatch_checks.py
@@ -19,3 +19,12 @@ def check_source_rows(
             f"topk_ids carries {topk_ids.numel()} pairs for "
             f"{hidden_states.size(0)} tokens x top_k={top_k}"
         )
+
+
+def check_fp8_width(k: int) -> None:
+    # tl.arange requires power-of-two K; quantization groups have width 128.
+    if k % 128 or k & (k - 1):
+        raise ValueError(
+            f"the fp8 row movers need a power-of-two K that is a multiple of 128, "
+            f"got {k}"
+        )

--- a/python/sglang/srt/lora/moe/kernels/dispatch_contiguous.py
+++ b/python/sglang/srt/lora/moe/kernels/dispatch_contiguous.py
@@ -1,0 +1,188 @@
+"""The contiguous row movers: routed rows sorted by expert into one compact
+buffer whose segments start on aligned rows. The layout needs a launch
+sequence, because segment bases are a prefix sum over all experts; the rows
+then land in bf16.
+
+Negative expert IDs leave pair_to_row untouched; consumers must mask them.
+Atomic slot order may vary, so every stage must use the same pair_to_row map.
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+from sglang.srt.lora.moe.kernels.dispatch_checks import check_source_rows
+
+# Eight pairs per program outperformed 16/32 on 65k-pair prefill chunks.
+PAIRS_PER_PROGRAM = 8
+
+
+def contiguous_m_pad_ceiling(num_pairs: int, num_experts: int, alignment: int) -> int:
+    """Bound padded rows by allowing alignment - 1 extra rows per expert."""
+    raw = num_pairs + num_experts * (alignment - 1)
+    return -(-raw // alignment) * alignment
+
+
+@triton.jit
+def _count_slots_contiguous_kernel(
+    topk_ids_ptr,  # [num_pairs]; a value < 0 marks a pair with no expert
+    slot_out_ptr,  # [num_pairs] int32 out: slot of the pair inside its expert
+    seg_counts_ptr,  # [E_local] int32 count and cursor; the caller must zero it
+    num_pairs,
+    PAIRS_PER_PROGRAM: tl.constexpr,
+):
+    pairs = tl.program_id(0).to(tl.int64) * PAIRS_PER_PROGRAM + tl.arange(
+        0, PAIRS_PER_PROGRAM
+    )
+    in_range = pairs < num_pairs
+    experts = tl.load(topk_ids_ptr + pairs, mask=in_range, other=-1)
+    valid = in_range & (experts >= 0)
+    slots = tl.atomic_add(seg_counts_ptr + experts, 1, mask=valid)
+    tl.store(slot_out_ptr + pairs, slots, mask=valid)
+
+
+@triton.jit
+def _seg_layout_contiguous_kernel(
+    seg_counts_ptr,  # [E_local] int32 per-expert routed-pair counts
+    seg_offsets_ptr,  # [E_local + 1] int32 out: first row of each segment
+    ALIGN: tl.constexpr,
+    EXPERTS: tl.constexpr,
+    BLOCK_EXPERTS: tl.constexpr,
+):
+    offs = tl.arange(0, BLOCK_EXPERTS)
+    counts = tl.load(seg_counts_ptr + offs, mask=offs < EXPERTS, other=0)
+    aligned = ((counts + (ALIGN - 1)) // ALIGN) * ALIGN
+    inclusive = tl.cumsum(aligned, axis=0)
+    tl.store(seg_offsets_ptr + offs, inclusive - aligned, mask=offs < EXPERTS)
+    tl.store(seg_offsets_ptr + EXPERTS, tl.sum(aligned))
+
+
+@triton.jit
+def _fill_rows_contiguous_bf16_kernel(
+    input_ptr,  # [num_tokens, hidden] bf16 source rows
+    compact_ptr,  # [m_pad_ceiling, hidden] bf16, viewed flat
+    topk_ids_ptr,  # [num_pairs]
+    pair_to_row_ptr,  # [num_pairs] int32 finalized compact rows
+    hidden_size,
+    num_pairs,
+    TOPK: tl.constexpr,
+    PAIRS_PER_PROGRAM: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+):
+    # Finalize pair_to_row in a separate launch: fusing it with this copy caused
+    # out-of-bounds stores at 65536 pairs and hidden=2048.
+    lane = tl.arange(0, PAIRS_PER_PROGRAM)
+    base = tl.program_id(0).to(tl.int64) * PAIRS_PER_PROGRAM
+    pairs = base + lane
+    in_range = pairs < num_pairs
+    experts_vec = tl.load(topk_ids_ptr + pairs, mask=in_range, other=-1)
+    if tl.sum((experts_vec >= 0).to(tl.int32), axis=0) == 0:
+        return
+
+    vec = tl.arange(0, BLOCK_H)
+    for i in tl.static_range(PAIRS_PER_PROGRAM):
+        pair = base + i
+        if pair < num_pairs:
+            expert = tl.load(topk_ids_ptr + pair)
+            if expert >= 0:
+                dst = tl.load(pair_to_row_ptr + pair).to(tl.int64)
+                token = pair // TOPK
+                src = input_ptr + token * hidden_size
+                out = compact_ptr + dst * hidden_size
+                for off in tl.range(0, hidden_size, BLOCK_H):
+                    mask = off + vec < hidden_size
+                    tl.store(
+                        out + off + vec,
+                        tl.load(src + off + vec, mask=mask),
+                        mask=mask,
+                    )
+
+
+@triton.jit
+def _finalize_pair_to_row_contiguous_kernel(
+    topk_ids_ptr,  # [num_pairs]; a value < 0 marks a pair with no expert
+    pair_to_row_ptr,  # [num_pairs] int32: dense slots IN, compact rows OUT
+    seg_offsets_ptr,  # [E_local + 1] int32 first row of each segment
+    num_pairs,
+    PAIRS_PER_PROGRAM: tl.constexpr,
+):
+    base = tl.program_id(0).to(tl.int64) * PAIRS_PER_PROGRAM
+    for i in tl.static_range(PAIRS_PER_PROGRAM):
+        pair = base + i
+        if pair < num_pairs:
+            expert = tl.load(topk_ids_ptr + pair)
+            if expert >= 0:
+                slot = tl.load(pair_to_row_ptr + pair)
+                seg_base = tl.load(seg_offsets_ptr + expert)
+                tl.store(pair_to_row_ptr + pair, seg_base + slot)
+
+
+def dispatch_layout_contiguous(
+    hidden_states: torch.Tensor,
+    topk_ids: torch.Tensor,
+    num_local_experts: int,
+    top_k: int,
+    alignment: int,
+    *,
+    seg_counts_out: torch.Tensor,
+    seg_offsets_out: torch.Tensor,
+    pair_to_row_out: torch.Tensor,
+) -> None:
+    """Write compact row indices to pair_to_row; row copies run separately."""
+    check_source_rows(hidden_states, topk_ids, top_k)
+    num_pairs = topk_ids.numel()
+    pair_grid = (-(-num_pairs // PAIRS_PER_PROGRAM),)
+
+    # Clear atomic cursors on every forward, including graph replay.
+    seg_counts_out.zero_()
+    if num_pairs > 0:
+        _count_slots_contiguous_kernel[pair_grid](
+            topk_ids.view(-1),
+            pair_to_row_out,
+            seg_counts_out,
+            num_pairs,
+            PAIRS_PER_PROGRAM=PAIRS_PER_PROGRAM,
+        )
+    # Initialize offsets even for an empty batch.
+    _seg_layout_contiguous_kernel[(1,)](
+        seg_counts_out,
+        seg_offsets_out,
+        ALIGN=alignment,
+        EXPERTS=num_local_experts,
+        BLOCK_EXPERTS=max(triton.next_power_of_2(num_local_experts), 2),
+    )
+    if num_pairs > 0:
+        _finalize_pair_to_row_contiguous_kernel[pair_grid](
+            topk_ids.view(-1),
+            pair_to_row_out,
+            seg_offsets_out,
+            num_pairs,
+            PAIRS_PER_PROGRAM=PAIRS_PER_PROGRAM,
+        )
+
+
+def dispatch_fill_rows_contiguous_bf16(
+    hidden_states: torch.Tensor,
+    topk_ids: torch.Tensor,
+    pair_to_row: torch.Tensor,
+    *,
+    hidden_compact_out: torch.Tensor,
+) -> None:
+    num_tokens = hidden_states.size(0)
+    num_pairs = topk_ids.numel()
+    if num_pairs == 0:
+        return
+    check_source_rows(hidden_states, topk_ids, num_pairs // num_tokens)
+    _fill_rows_contiguous_bf16_kernel[(-(-num_pairs // PAIRS_PER_PROGRAM),)](
+        hidden_states,
+        hidden_compact_out,
+        topk_ids.view(-1),
+        pair_to_row,
+        hidden_states.size(1),
+        num_pairs,
+        TOPK=num_pairs // num_tokens,
+        PAIRS_PER_PROGRAM=PAIRS_PER_PROGRAM,
+        BLOCK_H=1024,
+    )

--- a/python/sglang/srt/lora/moe/kernels/dispatch_contiguous.py
+++ b/python/sglang/srt/lora/moe/kernels/dispatch_contiguous.py
@@ -1,7 +1,4 @@
-"""The contiguous row movers: routed rows sorted by expert into one compact
-buffer whose segments start on aligned rows. The layout needs a launch
-sequence, because segment bases are a prefix sum over all experts; the rows
-then land in bf16.
+"""Dispatch rows into aligned expert segments, optionally quantizing to FP8.
 
 Negative expert IDs leave pair_to_row untouched; consumers must mask them.
 Atomic slot order may vary, so every stage must use the same pair_to_row map.
@@ -13,7 +10,11 @@ import torch
 import triton
 import triton.language as tl
 
-from sglang.srt.lora.moe.kernels.dispatch_checks import check_source_rows
+from sglang.srt.lora.moe.kernels.dispatch_checks import (
+    check_fp8_width,
+    check_source_rows,
+)
+from sglang.srt.lora.moe.kernels.fp8_quant import quantize_fp8_groups
 
 # Eight pairs per program outperformed 16/32 on 65k-pair prefill chunks.
 PAIRS_PER_PROGRAM = 8
@@ -185,4 +186,59 @@ def dispatch_fill_rows_contiguous_bf16(
         TOPK=num_pairs // num_tokens,
         PAIRS_PER_PROGRAM=PAIRS_PER_PROGRAM,
         BLOCK_H=1024,
+    )
+
+
+@triton.jit
+def _fill_rows_contiguous_fp8_kernel(
+    input_ptr,  # bf16 [num_tokens, K] source rows
+    out_ptr,  # fp8e4m3 [m_pad_ceiling, K] contiguous
+    scale_ptr,  # fp32 [m_pad_ceiling, K // 128] contiguous
+    topk_ids_ptr,  # [num_pairs]; < 0 = padding or EP-unrouted
+    pair_to_row_ptr,  # [num_pairs] int32 finalized compact rows
+    TOPK: tl.constexpr,
+    K: tl.constexpr,
+    GROUPS: tl.constexpr,  # K // 128
+):
+    # Quantize each token once, then fan out to its routed destinations.
+    token = tl.program_id(0)
+    offs = tl.arange(0, K)
+    x = tl.load(input_ptr + token.to(tl.int64) * K + offs).to(tl.float32)
+    grouped = tl.reshape(x, (GROUPS, 128))
+    q, scale = quantize_fp8_groups(grouped, GROUPS == 1)
+    qf = tl.reshape(q, (K,)).to(out_ptr.dtype.element_ty)
+    goffs = tl.arange(0, GROUPS)
+    for j in range(TOPK):
+        pair = token * TOPK + j
+        expert = tl.load(topk_ids_ptr + pair)
+        if expert >= 0:
+            dst = tl.load(pair_to_row_ptr + pair).to(tl.int64)
+            tl.store(out_ptr + dst * K + offs, qf)
+            tl.store(scale_ptr + dst * GROUPS + goffs, scale)
+
+
+def dispatch_fill_rows_contiguous_fp8(
+    hidden_states: torch.Tensor,
+    topk_ids: torch.Tensor,
+    pair_to_row: torch.Tensor,
+    *,
+    rows_fp8_out: torch.Tensor,
+    scale_out: torch.Tensor,
+) -> None:
+    """Quantize and copy rows using the finalized pair_to_row map."""
+    num_tokens, k = hidden_states.shape
+    num_pairs = topk_ids.numel()
+    if num_pairs == 0:
+        return
+    check_source_rows(hidden_states, topk_ids, num_pairs // num_tokens)
+    check_fp8_width(k)
+    _fill_rows_contiguous_fp8_kernel[(num_tokens,)](
+        hidden_states,
+        rows_fp8_out,
+        scale_out,
+        topk_ids.view(-1),
+        pair_to_row,
+        TOPK=num_pairs // num_tokens,
+        K=k,
+        GROUPS=k // 128,
     )

--- a/python/sglang/srt/lora/moe/kernels/dispatch_masked.py
+++ b/python/sglang/srt/lora/moe/kernels/dispatch_masked.py
@@ -1,0 +1,68 @@
+"""The masked row movers: one pair-grid launch fills the ``[E, m_max, *]``
+slabs.
+
+Negative expert IDs leave pair_to_row untouched; consumers must mask them.
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+from sglang.srt.lora.moe.kernels.dispatch_checks import check_source_rows
+
+
+@triton.jit
+def _dispatch_fill_masked_bf16_kernel(
+    input_ptr,  # [num_tokens, hidden] bf16 source rows
+    gateup_input_ptr,  # [E_local, m_max, hidden] bf16 rows, viewed flat
+    topk_ids_ptr,  # [num_tokens * topk]; < 0 = padding or EP-unrouted
+    pair_to_row_ptr,  # [num_tokens * topk] int32 out; valid pairs only
+    masked_m_ptr,  # [E_local] int32 count and atomic cursor; caller zeroes it
+    m_max,
+    hidden_size,
+    TOPK: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+):
+    t = tl.program_id(0)
+    k = tl.program_id(1)
+    pair = t * TOPK + k
+    expert = tl.load(topk_ids_ptr + pair)
+    if expert >= 0:
+        slot = tl.atomic_add(masked_m_ptr + expert, 1)
+        dst = expert.to(tl.int64) * m_max + slot
+        tl.store(pair_to_row_ptr + pair, dst.to(tl.int32))
+        src = input_ptr + t.to(tl.int64) * hidden_size
+        out = gateup_input_ptr + dst * hidden_size
+        vec = tl.arange(0, BLOCK_H)
+        for off in tl.range(0, hidden_size, BLOCK_H):
+            mask = off + vec < hidden_size
+            tl.store(out + off + vec, tl.load(src + off + vec, mask=mask), mask=mask)
+
+
+def dispatch_fill_masked_bf16(
+    hidden_states: torch.Tensor,
+    topk_ids: torch.Tensor,
+    top_k: int,
+    *,
+    masked_m_out: torch.Tensor,
+    pair_to_row_out: torch.Tensor,
+    rows_out: torch.Tensor,
+) -> None:
+    check_source_rows(hidden_states, topk_ids, top_k)
+    num_tokens = hidden_states.size(0)
+    # Clear atomic cursors on every forward, including graph replay.
+    masked_m_out.zero_()
+    if num_tokens > 0:
+        _dispatch_fill_masked_bf16_kernel[(num_tokens, top_k)](
+            hidden_states,
+            rows_out,
+            topk_ids.view(-1),
+            pair_to_row_out,
+            masked_m_out,
+            rows_out.size(1),
+            hidden_states.size(1),
+            TOPK=top_k,
+            BLOCK_H=1024,
+        )

--- a/python/sglang/srt/lora/moe/kernels/dispatch_masked.py
+++ b/python/sglang/srt/lora/moe/kernels/dispatch_masked.py
@@ -1,5 +1,4 @@
-"""The masked row movers: one pair-grid launch fills the ``[E, m_max, *]``
-slabs.
+"""Dispatch rows into [expert, m_max, hidden] slabs, optionally quantizing to FP8.
 
 Negative expert IDs leave pair_to_row untouched; consumers must mask them.
 """
@@ -10,7 +9,11 @@ import torch
 import triton
 import triton.language as tl
 
-from sglang.srt.lora.moe.kernels.dispatch_checks import check_source_rows
+from sglang.srt.lora.moe.kernels.dispatch_checks import (
+    check_fp8_width,
+    check_source_rows,
+)
+from sglang.srt.lora.moe.kernels.fp8_quant import quantize_fp8_groups
 
 
 @triton.jit
@@ -65,4 +68,66 @@ def dispatch_fill_masked_bf16(
             hidden_states.size(1),
             TOPK=top_k,
             BLOCK_H=1024,
+        )
+
+
+@triton.jit
+def _dispatch_fill_masked_fp8_kernel(
+    input_ptr,  # bf16 [num_tokens, K] source rows
+    out_ptr,  # fp8e4m3 [E, m_max, K] contiguous
+    scale_ptr,  # fp32 [E, m_max, K // 128] contiguous
+    topk_ids_ptr,  # [num_tokens * top_k]; < 0 = padding or EP-unrouted
+    pair_to_row_ptr,  # [num_tokens * top_k] int32 out; valid pairs only
+    masked_m_ptr,  # [E] int32 count and atomic cursor; caller zeroes it
+    m_max,
+    TOPK: tl.constexpr,
+    K: tl.constexpr,
+    GROUPS: tl.constexpr,  # K // 128
+):
+    t = tl.program_id(0)
+    k = tl.program_id(1)
+    pair = t * TOPK + k
+    expert = tl.load(topk_ids_ptr + pair)
+    if expert < 0:
+        return
+    slot = tl.atomic_add(masked_m_ptr + expert, 1)
+    dst = expert.to(tl.int64) * m_max + slot
+    tl.store(pair_to_row_ptr + pair, dst.to(tl.int32))
+
+    offs = tl.arange(0, K)
+    x = tl.load(input_ptr + t.to(tl.int64) * K + offs).to(tl.float32)
+    grouped = tl.reshape(x, (GROUPS, 128))
+    q, scale = quantize_fp8_groups(grouped, GROUPS == 1)
+    tl.store(out_ptr + dst * K + offs, tl.reshape(q, (K,)).to(out_ptr.dtype.element_ty))
+    tl.store(scale_ptr + dst * GROUPS + tl.arange(0, GROUPS), scale)
+
+
+def dispatch_fill_masked_fp8(
+    hidden_states: torch.Tensor,
+    topk_ids: torch.Tensor,
+    top_k: int,
+    *,
+    masked_m_out: torch.Tensor,
+    pair_to_row_out: torch.Tensor,
+    rows_fp8_out: torch.Tensor,
+    scale_out: torch.Tensor,
+) -> None:
+    """Dispatch FP8 rows with FP32 scales per group of 128 values."""
+    check_source_rows(hidden_states, topk_ids, top_k)
+    num_tokens, k = hidden_states.shape
+    check_fp8_width(k)
+    masked_m_out.zero_()
+    if num_tokens > 0:
+        _dispatch_fill_masked_fp8_kernel[(num_tokens, top_k)](
+            hidden_states,
+            rows_fp8_out,
+            scale_out,
+            topk_ids.view(-1),
+            pair_to_row_out,
+            masked_m_out,
+            rows_fp8_out.size(1),
+            TOPK=top_k,
+            K=k,
+            GROUPS=k // 128,
+            num_warps=4 if k <= 4096 else 8,
         )

--- a/python/sglang/srt/lora/moe/kernels/finalize.py
+++ b/python/sglang/srt/lora/moe/kernels/finalize.py
@@ -1,7 +1,4 @@
-"""The shared-outer finalize pair: a rank-space reduction of the weighted
-bridge rows per token, then a tail that adds the one down-B product to the
-weighted base rows and scales once. Both row domains work, since the tail
-reads base rows only through ``pair_to_row``.
+"""Shared-outer down-B and weighted combine in token space.
 
 The one-pass path keeps the rank sum and delta in FP32; the staged path rounds
 them to buffer dtypes. Neither is bitwise equivalent to per-pair BF16 deltas.
@@ -17,7 +14,7 @@ import triton.language as tl
 
 from sglang.srt.lora.moe.route_view import RouteView
 
-SHARED_RANK_DEFAULT_CONFIG: dict[str, dict[str, int]] = {
+SHARED_TOKEN_DELTA_DEFAULT_CONFIG: dict[str, dict[str, int]] = {
     "reduce": {
         "BLOCK_SIZE_T": 32,
         "num_warps": 4,
@@ -25,15 +22,20 @@ SHARED_RANK_DEFAULT_CONFIG: dict[str, dict[str, int]] = {
     },
     "tail": {
         "BLOCK_SIZE_H": 128,
-        "BLOCK_SIZE_K": 32,
         "num_warps": 4,
         "num_stages": 3,
     },
 }
 
+SHARED_ONE_PASS_DEFAULT_CONFIG: dict[str, int] = {
+    "BLOCK_SIZE_H": 128,
+    "num_warps": 4,
+    "num_stages": 3,
+}
+
 
 @triton.jit
-def _shared_rank_reduce_kernel(
+def _shared_token_delta_reduce_kernel(
     bridge_ptr,
     token_rank_ptr,
     weights_ptr,
@@ -90,34 +92,28 @@ def _shared_rank_reduce_kernel(
 
 
 @triton.jit
-def _shared_from_scratch_finalize_kernel(
+def _shared_token_delta_tail_kernel(
     down_ptr,
     pair_to_row_ptr,
-    token_rank_ptr,
-    b_ptr,
+    token_delta_ptr,
     output_ptr,
     weights_ptr,
     topk_ids_ptr,
     token_lora_mapping_ptr,
     stride_dm,
     stride_dh,
-    stride_tm,
-    stride_tk,
-    stride_bg,
-    stride_bh,
-    stride_bk,
     stride_om,
     stride_oh,
     stride_wm,
     stride_wk,
+    stride_tdm,
+    stride_tdh,
     routed_scaling,
     num_local_experts: tl.constexpr,
     hidden: tl.constexpr,
-    rank: tl.constexpr,
     top_k: tl.constexpr,
     max_loras: tl.constexpr,
     block_h: tl.constexpr,
-    block_k: tl.constexpr,
 ):
     # Apply routed scaling once, after adding base and LoRA.
     token = tl.program_id(0)
@@ -145,25 +141,11 @@ def _shared_from_scratch_finalize_kernel(
 
     adapter = tl.load(token_lora_mapping_ptr + token)
     adapter_valid = (adapter >= 0) & (adapter < max_loras)
-    safe_adapter = tl.maximum(adapter, 0).to(tl.int64)
-    delta = tl.zeros((block_h,), tl.float32)
-    for k_begin in range(0, rank, block_k):
-        rank_offsets = k_begin + tl.arange(0, block_k).to(tl.int64)
-        rank_mask = rank_offsets < rank
-        x = tl.load(
-            token_rank_ptr + token64 * stride_tm + rank_offsets * stride_tk,
-            mask=adapter_valid & rank_mask,
-            other=0.0,
-        )
-        b = tl.load(
-            b_ptr
-            + safe_adapter * stride_bg
-            + h_offsets[:, None] * stride_bh
-            + rank_offsets[None, :] * stride_bk,
-            mask=adapter_valid & h_mask[:, None] & rank_mask[None, :],
-            other=0.0,
-        )
-        delta += tl.sum(b.to(tl.float32) * x[None, :].to(tl.float32), axis=1)
+    delta = tl.load(
+        token_delta_ptr + token64 * stride_tdm + h_offsets * stride_tdh,
+        mask=adapter_valid & h_mask,
+        other=0.0,
+    ).to(tl.float32)
 
     tl.store(
         output_ptr + token64 * stride_om + h_offsets * stride_oh,
@@ -174,25 +156,102 @@ def _shared_from_scratch_finalize_kernel(
     )
 
 
-def invoke_shared_rank_reduce(
+@triton.jit
+def _shared_one_pass_kernel(
+    down_ptr,  # [rows, H] provider row order, unweighted
+    pair_to_row_ptr,  # [M * top_k] raw pair -> provider row
+    bridge_ptr,  # [M * top_k, R] raw pair order, unweighted
+    weights_ptr,
+    b_ptr,  # [S, H, R]
+    topk_ids_ptr,
+    token_lora_mapping_ptr,
+    output_ptr,
+    stride_dm,
+    stride_dh,
+    stride_xm,
+    stride_xr,
+    stride_wm,
+    stride_wk,
+    stride_bs,
+    stride_bh,
+    stride_br,
+    stride_om,
+    stride_oh,
+    routed_scaling,
+    num_local_experts: tl.constexpr,
+    hidden: tl.constexpr,
+    rank: tl.constexpr,
+    top_k: tl.constexpr,
+    max_loras: tl.constexpr,
+    block_h: tl.constexpr,
+    block_r: tl.constexpr,
+):
+    """Weight and combine unweighted base and rank rows, then apply shared B."""
+    token = tl.program_id(0)
+    pid_h = tl.program_id(1)
+    token64 = token.to(tl.int64)
+    h_offsets = pid_h.to(tl.int64) * block_h + tl.arange(0, block_h).to(tl.int64)
+    h_mask = h_offsets < hidden
+    r_offsets = tl.arange(0, block_r).to(tl.int64)
+    r_mask = r_offsets < rank
+    base_acc = tl.zeros((block_h,), tl.float32)
+    rank_acc = tl.zeros((block_r,), tl.float32)
+    for k in tl.static_range(top_k):
+        pair = token64 * top_k + k
+        expert = tl.load(topk_ids_ptr + pair)
+        valid = (expert >= 0) & (expert < num_local_experts)
+        dst = tl.load(pair_to_row_ptr + pair, mask=valid, other=0).to(tl.int64)
+        weight = tl.load(
+            weights_ptr + token64 * stride_wm + k * stride_wk, mask=valid, other=0.0
+        ).to(tl.float32)
+        base = tl.load(
+            down_ptr + dst * stride_dm + h_offsets * stride_dh,
+            mask=valid & h_mask,
+            other=0.0,
+        ).to(tl.float32)
+        rank_row = tl.load(
+            bridge_ptr + pair * stride_xm + r_offsets * stride_xr,
+            mask=valid & r_mask,
+            other=0.0,
+        ).to(tl.float32)
+        base_acc += weight * base
+        rank_acc += weight * rank_row
+
+    adapter = tl.load(token_lora_mapping_ptr + token)
+    adapter_valid = (adapter >= 0) & (adapter < max_loras)
+    safe_adapter = tl.maximum(adapter, 0).to(tl.int64)
+    b = tl.load(
+        b_ptr
+        + safe_adapter * stride_bs
+        + h_offsets[:, None] * stride_bh
+        + r_offsets[None, :] * stride_br,
+        mask=adapter_valid & h_mask[:, None] & r_mask[None, :],
+        other=0.0,
+    )
+    delta = tl.sum(b.to(tl.float32) * rank_acc[None, :], axis=1)
+    tl.store(
+        output_ptr + token64 * stride_om + h_offsets * stride_oh,
+        (routed_scaling * (base_acc + tl.where(adapter_valid, delta, 0.0))).to(
+            output_ptr.dtype.element_ty
+        ),
+        mask=h_mask,
+    )
+
+
+def invoke_shared_token_delta_reduce(
     *,
     bridge: torch.Tensor,
     routing: RouteView,
     topk_weights: torch.Tensor,
-    routed_scaling_factor: float | None,
     token_rank: torch.Tensor,
     config: Mapping[str, int],
 ) -> None:
-    # This implementation applies the scaling in the tail.
-    del routed_scaling_factor
     num_tokens, top_k = routing.topk_ids.shape
     if num_tokens == 0:
         return
-    # The rank is adapter-file input, so it stays checked here.
     rank = bridge.shape[1]
-    block_r = max(16, triton.next_power_of_2(rank))
     block_t = int(config["BLOCK_SIZE_T"])
-    _shared_rank_reduce_kernel[(triton.cdiv(num_tokens, block_t),)](
+    _shared_token_delta_reduce_kernel[(triton.cdiv(num_tokens, block_t),)](
         bridge,
         token_rank,
         topk_weights,
@@ -210,18 +269,17 @@ def invoke_shared_rank_reduce(
         max_loras=routing.max_loras,
         local_expert_count=routing.num_local_experts,
         block_t=block_t,
-        block_r=block_r,
+        block_r=max(16, triton.next_power_of_2(rank)),
         num_warps=int(config["num_warps"]),
         num_stages=int(config["num_stages"]),
     )
 
 
-def invoke_shared_from_scratch_finalize(
+def invoke_shared_token_delta_tail(
     *,
     down_rows: torch.Tensor,
     pair_to_row: torch.Tensor,
-    token_rank: torch.Tensor,
-    b_down: torch.Tensor,
+    token_delta: torch.Tensor,
     routing: RouteView,
     topk_weights: torch.Tensor,
     routed_scaling_factor: float | None,
@@ -232,36 +290,80 @@ def invoke_shared_from_scratch_finalize(
     if num_tokens == 0:
         return
     hidden = down_rows.shape[-1]
-    rank = token_rank.shape[1]
     block_h = int(config["BLOCK_SIZE_H"])
-    _shared_from_scratch_finalize_kernel[(num_tokens, triton.cdiv(hidden, block_h))](
+    _shared_token_delta_tail_kernel[(num_tokens, triton.cdiv(hidden, block_h))](
         down_rows.view(-1, hidden),
         pair_to_row,
-        token_rank,
-        b_down,
+        token_delta,
         output,
         topk_weights,
         routing.topk_ids,
         routing.token_lora_mapping,
         down_rows.stride(-2),
         down_rows.stride(-1),
-        token_rank.stride(0),
-        token_rank.stride(1),
+        output.stride(0),
+        output.stride(1),
+        topk_weights.stride(0),
+        topk_weights.stride(1),
+        token_delta.stride(0),
+        token_delta.stride(1),
+        1.0 if routed_scaling_factor is None else routed_scaling_factor,
+        num_local_experts=routing.num_local_experts,
+        hidden=hidden,
+        top_k=routing.topk_ids.shape[1],
+        max_loras=routing.max_loras,
+        block_h=block_h,
+        num_warps=int(config["num_warps"]),
+        num_stages=int(config["num_stages"]),
+    )
+
+
+def invoke_shared_one_pass(
+    *,
+    down_rows: torch.Tensor,
+    pair_to_row: torch.Tensor,
+    bridge: torch.Tensor,
+    b_down: torch.Tensor,
+    routing: RouteView,
+    topk_weights: torch.Tensor,
+    routed_scaling_factor: float | None,
+    output: torch.Tensor,
+    config: Mapping[str, int],
+) -> None:
+    num_tokens, top_k = routing.topk_ids.shape
+    if num_tokens == 0:
+        return
+    hidden = down_rows.shape[-1]
+    rank = bridge.shape[-1]
+    block_h = int(config["BLOCK_SIZE_H"])
+    _shared_one_pass_kernel[(num_tokens, triton.cdiv(hidden, block_h))](
+        down_rows.view(-1, hidden),
+        pair_to_row,
+        bridge,
+        topk_weights,
+        b_down,
+        routing.topk_ids,
+        routing.token_lora_mapping,
+        output,
+        down_rows.stride(-2),
+        down_rows.stride(-1),
+        bridge.stride(0),
+        bridge.stride(1),
+        topk_weights.stride(0),
+        topk_weights.stride(1),
         b_down.stride(0),
         b_down.stride(1),
         b_down.stride(2),
         output.stride(0),
         output.stride(1),
-        topk_weights.stride(0),
-        topk_weights.stride(1),
         1.0 if routed_scaling_factor is None else routed_scaling_factor,
         num_local_experts=routing.num_local_experts,
         hidden=hidden,
         rank=rank,
-        top_k=routing.topk_ids.shape[1],
+        top_k=top_k,
         max_loras=routing.max_loras,
         block_h=block_h,
-        block_k=int(config["BLOCK_SIZE_K"]),
+        block_r=max(16, triton.next_power_of_2(rank)),
         num_warps=int(config["num_warps"]),
         num_stages=int(config["num_stages"]),
     )

--- a/python/sglang/srt/lora/moe/kernels/finalize.py
+++ b/python/sglang/srt/lora/moe/kernels/finalize.py
@@ -1,0 +1,267 @@
+"""The shared-outer finalize pair: a rank-space reduction of the weighted
+bridge rows per token, then a tail that adds the one down-B product to the
+weighted base rows and scales once. Both row domains work, since the tail
+reads base rows only through ``pair_to_row``.
+
+The one-pass path keeps the rank sum and delta in FP32; the staged path rounds
+them to buffer dtypes. Neither is bitwise equivalent to per-pair BF16 deltas.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import torch
+import triton
+import triton.language as tl
+
+from sglang.srt.lora.moe.route_view import RouteView
+
+SHARED_RANK_DEFAULT_CONFIG: dict[str, dict[str, int]] = {
+    "reduce": {
+        "BLOCK_SIZE_T": 32,
+        "num_warps": 4,
+        "num_stages": 2,
+    },
+    "tail": {
+        "BLOCK_SIZE_H": 128,
+        "BLOCK_SIZE_K": 32,
+        "num_warps": 4,
+        "num_stages": 3,
+    },
+}
+
+
+@triton.jit
+def _shared_rank_reduce_kernel(
+    bridge_ptr,
+    token_rank_ptr,
+    weights_ptr,
+    topk_ids_ptr,
+    token_lora_mapping_ptr,
+    num_tokens,
+    stride_xm,
+    stride_xk,
+    stride_tm,
+    stride_tk,
+    stride_wm,
+    stride_wk,
+    rank: tl.constexpr,
+    top_k: tl.constexpr,
+    max_loras: tl.constexpr,
+    local_expert_count: tl.constexpr,
+    block_t: tl.constexpr,
+    block_r: tl.constexpr,
+):
+    tokens = tl.program_id(0) * block_t + tl.arange(0, block_t)
+    token_mask = tokens < num_tokens
+    tokens64 = tokens.to(tl.int64)
+    rank_offsets = tl.arange(0, block_r).to(tl.int64)
+    rank_mask = rank_offsets < rank
+    adapter = tl.load(token_lora_mapping_ptr + tokens, mask=token_mask, other=-1)
+    adapter_valid = (adapter >= 0) & (adapter < max_loras)
+    acc = tl.zeros((block_t, block_r), tl.float32)
+    for k in range(top_k):
+        pairs = tokens * top_k + k
+        expert = tl.load(topk_ids_ptr + pairs, mask=token_mask, other=-1)
+        valid = (
+            token_mask & adapter_valid & (expert >= 0) & (expert < local_expert_count)
+        )
+        weight = tl.load(
+            weights_ptr + tokens64 * stride_wm + k * stride_wk,
+            mask=valid,
+            other=0.0,
+        ).to(tl.float32)
+        x = tl.load(
+            bridge_ptr
+            + pairs.to(tl.int64)[:, None] * stride_xm
+            + rank_offsets[None, :] * stride_xk,
+            mask=valid[:, None] & rank_mask[None, :],
+            other=0.0,
+        )
+        acc += weight[:, None] * x.to(tl.float32)
+    tl.store(
+        token_rank_ptr
+        + tokens64[:, None] * stride_tm
+        + rank_offsets[None, :] * stride_tk,
+        acc.to(token_rank_ptr.dtype.element_ty),
+        mask=token_mask[:, None] & rank_mask[None, :],
+    )
+
+
+@triton.jit
+def _shared_from_scratch_finalize_kernel(
+    down_ptr,
+    pair_to_row_ptr,
+    token_rank_ptr,
+    b_ptr,
+    output_ptr,
+    weights_ptr,
+    topk_ids_ptr,
+    token_lora_mapping_ptr,
+    stride_dm,
+    stride_dh,
+    stride_tm,
+    stride_tk,
+    stride_bg,
+    stride_bh,
+    stride_bk,
+    stride_om,
+    stride_oh,
+    stride_wm,
+    stride_wk,
+    routed_scaling,
+    num_local_experts: tl.constexpr,
+    hidden: tl.constexpr,
+    rank: tl.constexpr,
+    top_k: tl.constexpr,
+    max_loras: tl.constexpr,
+    block_h: tl.constexpr,
+    block_k: tl.constexpr,
+):
+    # Apply routed scaling once, after adding base and LoRA.
+    token = tl.program_id(0)
+    pid_h = tl.program_id(1)
+    token64 = token.to(tl.int64)
+    h_offsets = pid_h.to(tl.int64) * block_h + tl.arange(0, block_h).to(tl.int64)
+    h_mask = h_offsets < hidden
+    base_acc = tl.zeros((block_h,), tl.float32)
+    for k in range(top_k):
+        pair = token * top_k + k
+        expert = tl.load(topk_ids_ptr + pair)
+        valid = (expert >= 0) & (expert < num_local_experts)
+        dst = tl.load(pair_to_row_ptr + pair, mask=valid, other=0).to(tl.int64)
+        base = tl.load(
+            down_ptr + dst * stride_dm + h_offsets * stride_dh,
+            mask=valid & h_mask,
+            other=0.0,
+        ).to(tl.float32)
+        weight = tl.load(
+            weights_ptr + token64 * stride_wm + k * stride_wk,
+            mask=valid,
+            other=0.0,
+        ).to(tl.float32)
+        base_acc += weight * base
+
+    adapter = tl.load(token_lora_mapping_ptr + token)
+    adapter_valid = (adapter >= 0) & (adapter < max_loras)
+    safe_adapter = tl.maximum(adapter, 0).to(tl.int64)
+    delta = tl.zeros((block_h,), tl.float32)
+    for k_begin in range(0, rank, block_k):
+        rank_offsets = k_begin + tl.arange(0, block_k).to(tl.int64)
+        rank_mask = rank_offsets < rank
+        x = tl.load(
+            token_rank_ptr + token64 * stride_tm + rank_offsets * stride_tk,
+            mask=adapter_valid & rank_mask,
+            other=0.0,
+        )
+        b = tl.load(
+            b_ptr
+            + safe_adapter * stride_bg
+            + h_offsets[:, None] * stride_bh
+            + rank_offsets[None, :] * stride_bk,
+            mask=adapter_valid & h_mask[:, None] & rank_mask[None, :],
+            other=0.0,
+        )
+        delta += tl.sum(b.to(tl.float32) * x[None, :].to(tl.float32), axis=1)
+
+    tl.store(
+        output_ptr + token64 * stride_om + h_offsets * stride_oh,
+        (routed_scaling * (base_acc + tl.where(adapter_valid, delta, 0.0))).to(
+            output_ptr.dtype.element_ty
+        ),
+        mask=h_mask,
+    )
+
+
+def invoke_shared_rank_reduce(
+    *,
+    bridge: torch.Tensor,
+    routing: RouteView,
+    topk_weights: torch.Tensor,
+    routed_scaling_factor: float | None,
+    token_rank: torch.Tensor,
+    config: Mapping[str, int],
+) -> None:
+    # This implementation applies the scaling in the tail.
+    del routed_scaling_factor
+    num_tokens, top_k = routing.topk_ids.shape
+    if num_tokens == 0:
+        return
+    # The rank is adapter-file input, so it stays checked here.
+    rank = bridge.shape[1]
+    block_r = max(16, triton.next_power_of_2(rank))
+    block_t = int(config["BLOCK_SIZE_T"])
+    _shared_rank_reduce_kernel[(triton.cdiv(num_tokens, block_t),)](
+        bridge,
+        token_rank,
+        topk_weights,
+        routing.topk_ids,
+        routing.token_lora_mapping,
+        num_tokens,
+        bridge.stride(0),
+        bridge.stride(1),
+        token_rank.stride(0),
+        token_rank.stride(1),
+        topk_weights.stride(0),
+        topk_weights.stride(1),
+        rank=rank,
+        top_k=top_k,
+        max_loras=routing.max_loras,
+        local_expert_count=routing.num_local_experts,
+        block_t=block_t,
+        block_r=block_r,
+        num_warps=int(config["num_warps"]),
+        num_stages=int(config["num_stages"]),
+    )
+
+
+def invoke_shared_from_scratch_finalize(
+    *,
+    down_rows: torch.Tensor,
+    pair_to_row: torch.Tensor,
+    token_rank: torch.Tensor,
+    b_down: torch.Tensor,
+    routing: RouteView,
+    topk_weights: torch.Tensor,
+    routed_scaling_factor: float | None,
+    output: torch.Tensor,
+    config: Mapping[str, int],
+) -> None:
+    num_tokens = routing.topk_ids.shape[0]
+    if num_tokens == 0:
+        return
+    hidden = down_rows.shape[-1]
+    rank = token_rank.shape[1]
+    block_h = int(config["BLOCK_SIZE_H"])
+    _shared_from_scratch_finalize_kernel[(num_tokens, triton.cdiv(hidden, block_h))](
+        down_rows.view(-1, hidden),
+        pair_to_row,
+        token_rank,
+        b_down,
+        output,
+        topk_weights,
+        routing.topk_ids,
+        routing.token_lora_mapping,
+        down_rows.stride(-2),
+        down_rows.stride(-1),
+        token_rank.stride(0),
+        token_rank.stride(1),
+        b_down.stride(0),
+        b_down.stride(1),
+        b_down.stride(2),
+        output.stride(0),
+        output.stride(1),
+        topk_weights.stride(0),
+        topk_weights.stride(1),
+        1.0 if routed_scaling_factor is None else routed_scaling_factor,
+        num_local_experts=routing.num_local_experts,
+        hidden=hidden,
+        rank=rank,
+        top_k=routing.topk_ids.shape[1],
+        max_loras=routing.max_loras,
+        block_h=block_h,
+        block_k=int(config["BLOCK_SIZE_K"]),
+        num_warps=int(config["num_warps"]),
+        num_stages=int(config["num_stages"]),
+    )

--- a/python/sglang/srt/lora/moe/kernels/fp8_quant.py
+++ b/python/sglang/srt/lora/moe/kernels/fp8_quant.py
@@ -1,0 +1,35 @@
+"""FP8 E4M3 quantization matching upstream's group and whole-row kernels.
+
+Whole-row division uses fast math only on SM90; group quantization always does.
+Preserve their different scale formulas and zero handling for bytewise parity.
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+from triton.language.extra.cuda import libdevice
+
+_WHOLE_ROW_FAST_DIV = tl.constexpr(
+    torch.cuda.is_available() and torch.cuda.get_device_capability() == (9, 0)
+)
+
+
+@triton.jit
+def quantize_fp8_groups(grouped, WHOLE_ROW: tl.constexpr):
+    """Return FP32 codes and per-group scales for [groups, group_size] input."""
+    amax = tl.max(tl.abs(grouped), axis=1)
+    if WHOLE_ROW:
+        if _WHOLE_ROW_FAST_DIV:
+            scale = amax / 448.0
+            inv = tl.where(scale == 0.0, 0.0, 1.0 / scale)
+        else:
+            scale = libdevice.div_rn(amax, 448.0)
+            inv = tl.where(scale == 0.0, 0.0, libdevice.div_rn(1.0, scale))
+        q = grouped * inv[:, None]
+    else:
+        amax = tl.maximum(amax, 1e-10)
+        scale = amax * (1.0 / 448.0)
+        q = grouped * (448.0 / amax)[:, None]
+    return tl.clamp(q, -448.0, 448.0), scale

--- a/python/sglang/srt/lora/moe/kernels/fused_act.py
+++ b/python/sglang/srt/lora/moe/kernels/fused_act.py
@@ -1,0 +1,378 @@
+"""Fuse gate/up LoRA-B with activation in either base row layout.
+
+The delta stays FP32 through activation, unlike a materialized BF16 delta.
+The optional pair-major copy serves down-A kernels that cannot gather base rows.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import torch
+import triton
+import triton.language as tl
+
+from sglang.srt.lora.moe.activation import ActivationFn
+from sglang.srt.lora.moe.kernels.activation_delta import (
+    apply_activation,
+)
+from sglang.srt.lora.moe.kernels.routing import grouped_tile_coords
+from sglang.srt.lora.moe.route_view import RouteView
+
+FUSED_B_ACT_DEFAULT_CONFIG: dict[str, int] = {
+    "BLOCK_SIZE_W": 64,
+    "BLOCK_SIZE_K": 32,
+    "GROUP_SIZE_M": 8,
+    "num_warps": 4,
+    "num_stages": 3,
+}
+
+
+@triton.jit
+def _base_columns(
+    offsets,
+    width: tl.constexpr,
+    num_slices: tl.constexpr,
+    gate_first: tl.constexpr,
+    interleaved: tl.constexpr,
+):
+    if num_slices == 1:
+        return offsets, offsets
+    if interleaved:
+        gate_offsets = 2 * offsets
+        up_offsets = 2 * offsets + 1
+    else:
+        gate_offsets = offsets
+        up_offsets = width + offsets
+    if not gate_first:
+        gate_offsets, up_offsets = up_offsets, gate_offsets
+    return gate_offsets, up_offsets
+
+
+@triton.jit
+def _delta_slice(
+    bridge_ptr,
+    weight_group_ptr,
+    bridge_rows,
+    pair_mask,
+    w_offsets,
+    w_mask,
+    stride_xm,
+    stride_xk,
+    stride_wn,
+    stride_wk,
+    slice_id: tl.constexpr,
+    rank: tl.constexpr,
+    width: tl.constexpr,
+    block_m: tl.constexpr,
+    block_w: tl.constexpr,
+    block_k: tl.constexpr,
+):
+    acc = tl.zeros((block_m, block_w), tl.float32)
+    for k_begin in range(0, rank, block_k):
+        k_offsets = k_begin + tl.arange(0, block_k).to(tl.int64)
+        k_mask = k_offsets < rank
+        lhs = tl.load(
+            bridge_ptr
+            + bridge_rows[:, None] * stride_xm
+            + (slice_id * rank + k_offsets)[None, :] * stride_xk,
+            mask=pair_mask[:, None] & k_mask[None, :],
+            other=0.0,
+        )
+        rhs = tl.load(
+            weight_group_ptr
+            + (slice_id * width + w_offsets)[None, :] * stride_wn
+            + k_offsets[:, None] * stride_wk,
+            mask=k_mask[:, None] & w_mask[None, :],
+            other=0.0,
+        )
+        acc += tl.dot(lhs, rhs, out_dtype=tl.float32)
+    return acc
+
+
+@triton.jit
+def _b_act_kernel(
+    bridge_ptr,
+    b_ptr,
+    base_ptr,
+    act_rows_ptr,
+    act_pairs_ptr,
+    pair_to_row_ptr,
+    topk_ids_ptr,
+    sorted_pairs_ptr,
+    block_veids_ptr,
+    pairs_post_padded_ptr,
+    num_pairs,
+    stride_xm,
+    stride_xk,
+    stride_bg,
+    stride_bn,
+    stride_bk,
+    stride_pm,
+    stride_pn,
+    stride_am,
+    stride_an,
+    stride_qm,
+    stride_qn,
+    num_local_experts: tl.constexpr,
+    top_k: tl.constexpr,
+    width: tl.constexpr,
+    rank: tl.constexpr,
+    num_slices: tl.constexpr,
+    activation_type: tl.constexpr,
+    gate_first: tl.constexpr,
+    interleaved: tl.constexpr,
+    bridge_token_major: tl.constexpr,
+    num_m_blocks: tl.constexpr,
+    block_m: tl.constexpr,
+    block_w: tl.constexpr,
+    block_k: tl.constexpr,
+    group_m: tl.constexpr,
+    store_pair_act: tl.constexpr,
+    consume_base_pdl: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    # Keep the tile count constexpr for grouped scheduling.
+    num_w_tiles: tl.constexpr = (width + block_w - 1) // block_w
+    pid_m, pid_w = grouped_tile_coords(pid, num_w_tiles, num_m_blocks, group_m)
+    if pid_m * block_m >= tl.load(pairs_post_padded_ptr):
+        return
+
+    slots = pid_m * block_m + tl.arange(0, block_m).to(tl.int64)
+    pair_ids = tl.load(sorted_pairs_ptr + slots).to(tl.int64)
+    pair_mask = pair_ids < num_pairs
+    expert = tl.load(topk_ids_ptr + pair_ids, mask=pair_mask, other=-1)
+    base_valid = pair_mask & (expert >= 0) & (expert < num_local_experts)
+    dst_rows = tl.load(pair_to_row_ptr + pair_ids, mask=base_valid, other=0).to(
+        tl.int64
+    )
+    veid = tl.load(block_veids_ptr + pid_m).to(tl.int64)
+
+    w_offsets = pid_w * block_w + tl.arange(0, block_w).to(tl.int64)
+    w_mask = w_offsets < width
+    gate_cols, up_cols = _base_columns(
+        w_offsets,
+        width,
+        num_slices,
+        gate_first,
+        interleaved,
+    )
+
+    delta_gate = tl.zeros((block_m, block_w), tl.float32)
+    delta_up = tl.zeros((block_m, block_w), tl.float32)
+    if veid != -1:
+        bridge_rows = pair_ids // top_k if bridge_token_major else pair_ids
+        group_ptr = b_ptr + veid * stride_bg
+        delta_gate += _delta_slice(
+            bridge_ptr,
+            group_ptr,
+            bridge_rows,
+            pair_mask,
+            w_offsets,
+            w_mask,
+            stride_xm,
+            stride_xk,
+            stride_bn,
+            stride_bk,
+            slice_id=0,
+            rank=rank,
+            width=width,
+            block_m=block_m,
+            block_w=block_w,
+            block_k=block_k,
+        )
+        if num_slices == 2:
+            delta_up += _delta_slice(
+                bridge_ptr,
+                group_ptr,
+                bridge_rows,
+                pair_mask,
+                w_offsets,
+                w_mask,
+                stride_xm,
+                stride_xk,
+                stride_bn,
+                stride_bk,
+                slice_id=1,
+                rank=rank,
+                width=width,
+                block_m=block_m,
+                block_w=block_w,
+                block_k=block_k,
+            )
+
+    if consume_base_pdl:
+        # The LoRA-B tile above overlaps the base GEMM; wait just before the
+        # first read of its output.
+        tl.extra.cuda.gdc_wait()
+    base_gate = tl.load(
+        base_ptr + dst_rows[:, None] * stride_pm + gate_cols[None, :] * stride_pn,
+        mask=base_valid[:, None] & w_mask[None, :],
+        other=0.0,
+    ).to(tl.float32)
+    act = apply_activation(base_gate + delta_gate, activation_type)
+    if num_slices == 2:
+        base_up = tl.load(
+            base_ptr + dst_rows[:, None] * stride_pm + up_cols[None, :] * stride_pn,
+            mask=base_valid[:, None] & w_mask[None, :],
+            other=0.0,
+        ).to(tl.float32)
+        act = act * (base_up + delta_up)
+    value = act.to(act_rows_ptr.dtype.element_ty)
+    tl.store(
+        act_rows_ptr + dst_rows[:, None] * stride_am + w_offsets[None, :] * stride_an,
+        value,
+        mask=base_valid[:, None] & w_mask[None, :],
+    )
+    if store_pair_act:
+        # Invalid pairs must overwrite stale graph-buffer rows with zero.
+        tl.store(
+            act_pairs_ptr
+            + pair_ids[:, None] * stride_qm
+            + w_offsets[None, :] * stride_qn,
+            tl.where(base_valid[:, None], act, 0.0).to(act_pairs_ptr.dtype.element_ty),
+            mask=pair_mask[:, None] & w_mask[None, :],
+        )
+
+
+def _launch_b_act(
+    *,
+    activation: str,
+    base_rows: torch.Tensor,  # [rows, slices * width] bf16, flat
+    act_rows: torch.Tensor,  # [rows, width] bf16, flat
+    act_pairs: torch.Tensor | None,  # [num_tokens, top_k, width] or None
+    pair_to_row: torch.Tensor,  # [num_tokens * top_k] int32
+    routing: RouteView,
+    num_local_experts: int,
+    gate_first: bool,
+    interleaved: bool,
+    config: Mapping[str, int],
+    bridge_gateup: torch.Tensor,
+    b_gate_up: torch.Tensor,
+    bridge_top_k: int,
+    consume_base_pdl: bool,
+) -> None:
+    ActivationFn.parse(activation)
+    pairs = routing.topk_ids.numel()
+    if pairs == 0:
+        return
+    width = act_rows.shape[1]
+    slices = base_rows.shape[1] // width
+    rank = b_gate_up.shape[2]
+    block_w = int(config["BLOCK_SIZE_W"])
+    num_m_blocks = triton.cdiv(routing.sorted_pair_ids.numel(), routing.block_size)
+    pair_target = act_pairs.view(-1, width) if act_pairs is not None else act_rows
+    num_w_tiles = triton.cdiv(width, block_w)
+    _b_act_kernel[(num_m_blocks * num_w_tiles,)](
+        bridge_gateup,
+        b_gate_up,
+        base_rows,
+        act_rows,
+        pair_target,
+        pair_to_row,
+        routing.topk_ids,
+        routing.sorted_pair_ids,
+        routing.block_virtual_expert_ids,
+        routing.num_pairs_post_padded,
+        pairs,
+        bridge_gateup.stride(0),
+        bridge_gateup.stride(1),
+        b_gate_up.stride(0),
+        b_gate_up.stride(1),
+        b_gate_up.stride(2),
+        base_rows.stride(0),
+        base_rows.stride(1),
+        act_rows.stride(0),
+        act_rows.stride(1),
+        pair_target.stride(0),
+        pair_target.stride(1),
+        num_local_experts=num_local_experts,
+        top_k=routing.topk_ids.shape[1],
+        width=width,
+        rank=rank,
+        num_slices=slices,
+        activation_type=activation,
+        gate_first=gate_first,
+        interleaved=interleaved,
+        bridge_token_major=bridge_top_k != 1,
+        num_m_blocks=num_m_blocks,
+        block_m=routing.block_size,
+        block_w=block_w,
+        block_k=int(config["BLOCK_SIZE_K"]),
+        group_m=int(config["GROUP_SIZE_M"]),
+        store_pair_act=act_pairs is not None,
+        consume_base_pdl=consume_base_pdl,
+        num_warps=int(config["num_warps"]),
+        num_stages=int(config["num_stages"]),
+        **({"launch_pdl": True} if consume_base_pdl else {}),
+    )
+
+
+def fused_b_act_masked(
+    *,
+    activation: str,
+    base_gateup: torch.Tensor,  # [E_local, m_max, slices * inter] bf16
+    act_masked: torch.Tensor,  # [E_local, m_max, inter] bf16
+    act_pairs: torch.Tensor | None,
+    pair_to_row: torch.Tensor,  # [num_tokens * top_k] int32 slab rows
+    routing: RouteView,
+    num_local_experts: int,
+    gate_first: bool,
+    interleaved: bool,
+    config: Mapping[str, int],
+    bridge_gateup: torch.Tensor,
+    b_gate_up: torch.Tensor,
+    bridge_top_k: int = 1,
+    consume_base_pdl: bool = False,
+) -> None:
+    _launch_b_act(
+        activation=activation,
+        base_rows=base_gateup.view(-1, base_gateup.shape[-1]),
+        act_rows=act_masked.view(-1, act_masked.shape[-1]),
+        act_pairs=act_pairs,
+        pair_to_row=pair_to_row,
+        routing=routing,
+        num_local_experts=num_local_experts,
+        gate_first=gate_first,
+        interleaved=interleaved,
+        config=config,
+        bridge_gateup=bridge_gateup,
+        b_gate_up=b_gate_up,
+        bridge_top_k=bridge_top_k,
+        consume_base_pdl=consume_base_pdl,
+    )
+
+
+def fused_b_act_contiguous(
+    *,
+    activation: str,
+    base_gateup: torch.Tensor,  # [m_pad_ceiling, slices * inter] bf16
+    act_compact: torch.Tensor,  # [m_pad_ceiling, inter] bf16
+    act_pairs: torch.Tensor | None,
+    pair_to_row: torch.Tensor,  # [num_tokens * top_k] int32 COMPACT rows
+    routing: RouteView,
+    num_local_experts: int,
+    gate_first: bool,
+    interleaved: bool,
+    config: Mapping[str, int],
+    bridge_gateup: torch.Tensor,
+    b_gate_up: torch.Tensor,
+    bridge_top_k: int = 1,
+    consume_base_pdl: bool = False,
+) -> None:
+    _launch_b_act(
+        activation=activation,
+        base_rows=base_gateup,
+        act_rows=act_compact,
+        act_pairs=act_pairs,
+        pair_to_row=pair_to_row,
+        routing=routing,
+        num_local_experts=num_local_experts,
+        gate_first=gate_first,
+        interleaved=interleaved,
+        config=config,
+        bridge_gateup=bridge_gateup,
+        b_gate_up=b_gate_up,
+        bridge_top_k=bridge_top_k,
+        consume_base_pdl=consume_base_pdl,
+    )

--- a/python/sglang/srt/lora/moe/kernels/fused_act.py
+++ b/python/sglang/srt/lora/moe/kernels/fused_act.py
@@ -129,7 +129,6 @@ def _b_act_kernel(
     block_k: tl.constexpr,
     group_m: tl.constexpr,
     store_pair_act: tl.constexpr,
-    consume_base_pdl: tl.constexpr,
 ):
     pid = tl.program_id(0)
     # Keep the tile count constexpr for grouped scheduling.
@@ -201,10 +200,6 @@ def _b_act_kernel(
                 block_k=block_k,
             )
 
-    if consume_base_pdl:
-        # The LoRA-B tile above overlaps the base GEMM; wait just before the
-        # first read of its output.
-        tl.extra.cuda.gdc_wait()
     base_gate = tl.load(
         base_ptr + dst_rows[:, None] * stride_pm + gate_cols[None, :] * stride_pn,
         mask=base_valid[:, None] & w_mask[None, :],
@@ -250,7 +245,6 @@ def _launch_b_act(
     bridge_gateup: torch.Tensor,
     b_gate_up: torch.Tensor,
     bridge_top_k: int,
-    consume_base_pdl: bool,
 ) -> None:
     ActivationFn.parse(activation)
     pairs = routing.topk_ids.numel()
@@ -301,10 +295,8 @@ def _launch_b_act(
         block_k=int(config["BLOCK_SIZE_K"]),
         group_m=int(config["GROUP_SIZE_M"]),
         store_pair_act=act_pairs is not None,
-        consume_base_pdl=consume_base_pdl,
         num_warps=int(config["num_warps"]),
         num_stages=int(config["num_stages"]),
-        **({"launch_pdl": True} if consume_base_pdl else {}),
     )
 
 
@@ -323,7 +315,6 @@ def fused_b_act_masked(
     bridge_gateup: torch.Tensor,
     b_gate_up: torch.Tensor,
     bridge_top_k: int = 1,
-    consume_base_pdl: bool = False,
 ) -> None:
     _launch_b_act(
         activation=activation,
@@ -339,7 +330,6 @@ def fused_b_act_masked(
         bridge_gateup=bridge_gateup,
         b_gate_up=b_gate_up,
         bridge_top_k=bridge_top_k,
-        consume_base_pdl=consume_base_pdl,
     )
 
 
@@ -358,7 +348,6 @@ def fused_b_act_contiguous(
     bridge_gateup: torch.Tensor,
     b_gate_up: torch.Tensor,
     bridge_top_k: int = 1,
-    consume_base_pdl: bool = False,
 ) -> None:
     _launch_b_act(
         activation=activation,
@@ -374,5 +363,4 @@ def fused_b_act_contiguous(
         bridge_gateup=bridge_gateup,
         b_gate_up=b_gate_up,
         bridge_top_k=bridge_top_k,
-        consume_base_pdl=consume_base_pdl,
     )

--- a/python/sglang/srt/lora/moe/kernels/lora_a.py
+++ b/python/sglang/srt/lora/moe/kernels/lora_a.py
@@ -1,0 +1,332 @@
+"""LoRA-A projections over aligned pairs, raw pairs, or shared token rows."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING
+
+import torch
+import triton
+import triton.language as tl
+
+from sglang.srt.lora.moe.kernels.routing import (
+    grouped_tile_coords,
+    virtual_expert_ids_inline,
+)
+from sglang.srt.lora.moe.route_view import RouteView
+
+if TYPE_CHECKING:
+    from sglang.srt.lora.moe.execution_plan import LoraASpec
+
+
+@triton.jit
+def _grouped_lora_a_kernel(
+    input_ptr,
+    weight_ptr,
+    output_ptr,
+    pair_to_row_ptr,
+    sorted_pair_ids_ptr,
+    block_virtual_expert_ids_ptr,
+    num_pairs_post_padded_ptr,
+    num_input_rows,
+    num_pairs,
+    stride_im,
+    stride_ik,
+    stride_we,
+    stride_wn,
+    stride_wk,
+    stride_om,
+    stride_on,
+    TOP_K: tl.constexpr,
+    N: tl.constexpr,
+    K: tl.constexpr,
+    PAIR_INPUT: tl.constexpr,
+    USE_PAIR_TO_ROW: tl.constexpr,
+    NUM_M_BLOCKS: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    PRODUCE_PDL: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    num_pairs_post_padded = tl.load(num_pairs_post_padded_ptr)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    pid_m, pid_n = grouped_tile_coords(pid, num_pid_n, NUM_M_BLOCKS, GROUP_SIZE_M)
+    if pid_m * BLOCK_SIZE_M >= num_pairs_post_padded:
+        return
+
+    pair_slots = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M).to(tl.int64)
+    pair_ids = tl.load(sorted_pair_ids_ptr + pair_slots).to(tl.int64)
+    pair_mask = pair_ids < num_pairs
+    virtual_expert_id = tl.load(block_virtual_expert_ids_ptr + pid_m).to(tl.int64)
+    if virtual_expert_id == -1:
+        return
+
+    if USE_PAIR_TO_ROW:
+        input_rows = tl.load(
+            pair_to_row_ptr + pair_ids,
+            mask=pair_mask,
+            other=-1,
+        ).to(tl.int64)
+    elif PAIR_INPUT:
+        input_rows = pair_ids
+    else:
+        input_rows = pair_ids // TOP_K
+    input_mask = pair_mask & (input_rows >= 0) & (input_rows < num_input_rows)
+
+    n_offsets = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N).to(tl.int64)
+    n_mask = n_offsets < N
+    if PRODUCE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    for k_begin in range(0, K, BLOCK_SIZE_K):
+        k_offsets = k_begin + tl.arange(0, BLOCK_SIZE_K).to(tl.int64)
+        k_mask = k_offsets < K
+        lhs = tl.load(
+            input_ptr
+            + input_rows[:, None] * stride_im
+            + k_offsets[None, :] * stride_ik,
+            mask=input_mask[:, None] & k_mask[None, :],
+            other=0.0,
+        )
+        rhs = tl.load(
+            weight_ptr
+            + virtual_expert_id * stride_we
+            + n_offsets[None, :] * stride_wn
+            + k_offsets[:, None] * stride_wk,
+            mask=n_mask[None, :] & k_mask[:, None],
+            other=0.0,
+        )
+        accumulator += tl.dot(lhs, rhs, out_dtype=tl.float32)
+
+    tl.store(
+        output_ptr + pair_ids[:, None] * stride_om + n_offsets[None, :] * stride_on,
+        accumulator.to(output_ptr.dtype.element_ty),
+        mask=pair_mask[:, None] & n_mask[None, :],
+    )
+
+
+def grouped_lora_a(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    output: torch.Tensor,
+    routing: RouteView,
+    *,
+    config: Mapping[str, int],
+    pair_input: bool = False,
+    pair_to_row: torch.Tensor | None = None,
+    produce_pdl: bool = False,
+) -> None:
+    num_pairs = routing.topk_ids.numel()
+    if num_pairs == 0:
+        return
+
+    block_size_n = int(config["BLOCK_SIZE_N"])
+    block_size_k = int(config["BLOCK_SIZE_K"])
+    group_size_m = int(config["GROUP_SIZE_M"])
+    num_m_blocks = triton.cdiv(routing.sorted_pair_ids.numel(), routing.block_size)
+    num_n_blocks = triton.cdiv(weight.shape[1], block_size_n)
+    _grouped_lora_a_kernel[(num_m_blocks * num_n_blocks,)](
+        input,
+        weight,
+        output,
+        output if pair_to_row is None else pair_to_row,
+        routing.sorted_pair_ids,
+        routing.block_virtual_expert_ids,
+        routing.num_pairs_post_padded,
+        input.shape[0],
+        num_pairs,
+        input.stride(0),
+        input.stride(1),
+        weight.stride(0),
+        weight.stride(1),
+        weight.stride(2),
+        output.stride(0),
+        output.stride(1),
+        TOP_K=routing.topk_ids.shape[1],
+        N=weight.shape[1],
+        K=weight.shape[2],
+        PAIR_INPUT=pair_input,
+        USE_PAIR_TO_ROW=pair_to_row is not None,
+        NUM_M_BLOCKS=num_m_blocks,
+        BLOCK_SIZE_M=routing.block_size,
+        BLOCK_SIZE_N=block_size_n,
+        BLOCK_SIZE_K=block_size_k,
+        GROUP_SIZE_M=group_size_m,
+        PRODUCE_PDL=produce_pdl,
+        num_warps=int(config["num_warps"]),
+        num_stages=int(config["num_stages"]),
+    )
+
+
+@triton.jit
+def _per_pair_lora_a_kernel(
+    input_ptr,
+    weight_ptr,
+    topk_ids_ptr,
+    token_lora_mapping_ptr,
+    output_ptr,
+    num_pairs,
+    routed_expert_id_bound,
+    stride_im,
+    stride_ik,
+    stride_wg,
+    stride_wn,
+    stride_wk,
+    stride_om,
+    stride_on,
+    N: tl.constexpr,
+    K: tl.constexpr,
+    LORA_EXPERTS_PER_ADAPTER: tl.constexpr,
+    MAX_LORAS: tl.constexpr,
+    TOP_K: tl.constexpr,
+    SHARED_OUTER: tl.constexpr,
+    PAIR_INPUT: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+):
+    pair_id = tl.program_id(0)
+    pid_n = tl.program_id(1)
+    key = virtual_expert_ids_inline(
+        topk_ids_ptr,
+        token_lora_mapping_ptr,
+        pair_id,
+        pair_id < num_pairs,
+        routed_expert_id_bound,
+        LORA_EXPERTS_PER_ADAPTER=LORA_EXPERTS_PER_ADAPTER,
+        MAX_LORAS=MAX_LORAS,
+        TOP_K=TOP_K,
+        SHARED_OUTER=SHARED_OUTER,
+    )
+    valid = key != -1
+    group = tl.maximum(key, 0).to(tl.int64)
+    pair64 = pair_id.to(tl.int64)
+    input_row = pair64 if PAIR_INPUT else pair64 // TOP_K
+
+    n_offsets = pid_n.to(tl.int64) * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N).to(
+        tl.int64
+    )
+    n_mask = n_offsets < N
+    accumulator = tl.zeros((BLOCK_SIZE_N,), dtype=tl.float32)
+    for k_begin in range(0, K, BLOCK_SIZE_K):
+        k_offsets = k_begin + tl.arange(0, BLOCK_SIZE_K).to(tl.int64)
+        k_mask = k_offsets < K
+        lhs = tl.load(
+            input_ptr + input_row * stride_im + k_offsets * stride_ik,
+            mask=valid & k_mask,
+            other=0.0,
+        )
+        rhs = tl.load(
+            weight_ptr
+            + group * stride_wg
+            + n_offsets[:, None] * stride_wn
+            + k_offsets[None, :] * stride_wk,
+            mask=valid & n_mask[:, None] & k_mask[None, :],
+            other=0.0,
+        )
+        accumulator += tl.sum(rhs.to(tl.float32) * lhs[None, :].to(tl.float32), axis=1)
+
+    # B zeros sentinel destinations without reading these bridge rows.
+    tl.store(
+        output_ptr + pair64 * stride_om + n_offsets * stride_on,
+        accumulator.to(output_ptr.dtype.element_ty),
+        mask=valid & n_mask,
+    )
+
+
+def per_pair_lora_a(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    output: torch.Tensor,
+    routing: RouteView,
+    *,
+    config: Mapping[str, int],
+    pair_input: bool = False,
+) -> None:
+    num_pairs = routing.topk_ids.numel()
+    if num_pairs == 0:
+        return
+
+    block_size_n = int(config["BLOCK_SIZE_N"])
+    _per_pair_lora_a_kernel[(num_pairs, triton.cdiv(weight.shape[1], block_size_n))](
+        input,
+        weight,
+        routing.topk_ids,
+        routing.token_lora_mapping,
+        output,
+        num_pairs,
+        routing.num_local_experts,
+        input.stride(0),
+        input.stride(1),
+        weight.stride(0),
+        weight.stride(1),
+        weight.stride(2),
+        output.stride(0),
+        output.stride(1),
+        N=weight.shape[1],
+        K=weight.shape[2],
+        LORA_EXPERTS_PER_ADAPTER=routing.lora_experts_per_adapter,
+        MAX_LORAS=routing.max_loras,
+        TOP_K=routing.topk_ids.shape[1],
+        SHARED_OUTER=routing.is_shared_outer,
+        PAIR_INPUT=pair_input,
+        BLOCK_SIZE_N=block_size_n,
+        BLOCK_SIZE_K=int(config["BLOCK_SIZE_K"]),
+        num_warps=int(config["num_warps"]),
+        num_stages=int(config["num_stages"]),
+    )
+
+
+def run_lora_a(
+    spec: LoraASpec,
+    *,
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    output: torch.Tensor,
+    routing: RouteView,
+    config: Mapping[str, int],
+    pair_to_row: torch.Tensor | None = None,
+    produce_pdl: bool = False,
+) -> torch.Tensor:
+    family = spec.family.value
+    pair_input = spec.site.value == "down"
+    match family:
+        case "token_grouped":
+            grouped_lora_a(
+                input,
+                weight,
+                output,
+                routing,
+                config=config,
+                produce_pdl=produce_pdl,
+            )
+        case "grouped":
+            grouped_lora_a(
+                input,
+                weight,
+                output,
+                routing,
+                config=config,
+                pair_input=pair_input,
+                pair_to_row=pair_to_row,
+                produce_pdl=produce_pdl,
+            )
+        case "per_pair":
+            if produce_pdl:
+                raise ValueError(
+                    f"{family} A has no qualified programmatic-dependent-launch "
+                    "producer"
+                )
+            per_pair_lora_a(
+                input,
+                weight,
+                output,
+                routing,
+                config=config,
+                pair_input=pair_input,
+            )
+        case _:
+            raise NotImplementedError(f"no production LoRA-A executor for {family!r}")
+    return output

--- a/python/sglang/srt/lora/moe/kernels/lora_a.py
+++ b/python/sglang/srt/lora/moe/kernels/lora_a.py
@@ -47,7 +47,6 @@ def _grouped_lora_a_kernel(
     BLOCK_SIZE_N: tl.constexpr,
     BLOCK_SIZE_K: tl.constexpr,
     GROUP_SIZE_M: tl.constexpr,
-    PRODUCE_PDL: tl.constexpr,
 ):
     pid = tl.program_id(0)
     num_pairs_post_padded = tl.load(num_pairs_post_padded_ptr)
@@ -77,8 +76,6 @@ def _grouped_lora_a_kernel(
 
     n_offsets = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N).to(tl.int64)
     n_mask = n_offsets < N
-    if PRODUCE_PDL:
-        tl.extra.cuda.gdc_launch_dependents()
 
     accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
     for k_begin in range(0, K, BLOCK_SIZE_K):
@@ -117,7 +114,6 @@ def grouped_lora_a(
     config: Mapping[str, int],
     pair_input: bool = False,
     pair_to_row: torch.Tensor | None = None,
-    produce_pdl: bool = False,
 ) -> None:
     num_pairs = routing.topk_ids.numel()
     if num_pairs == 0:
@@ -155,7 +151,6 @@ def grouped_lora_a(
         BLOCK_SIZE_N=block_size_n,
         BLOCK_SIZE_K=block_size_k,
         GROUP_SIZE_M=group_size_m,
-        PRODUCE_PDL=produce_pdl,
         num_warps=int(config["num_warps"]),
         num_stages=int(config["num_stages"]),
     )
@@ -288,7 +283,6 @@ def run_lora_a(
     routing: RouteView,
     config: Mapping[str, int],
     pair_to_row: torch.Tensor | None = None,
-    produce_pdl: bool = False,
 ) -> torch.Tensor:
     family = spec.family.value
     pair_input = spec.site.value == "down"
@@ -300,7 +294,6 @@ def run_lora_a(
                 output,
                 routing,
                 config=config,
-                produce_pdl=produce_pdl,
             )
         case "grouped":
             grouped_lora_a(
@@ -311,14 +304,8 @@ def run_lora_a(
                 config=config,
                 pair_input=pair_input,
                 pair_to_row=pair_to_row,
-                produce_pdl=produce_pdl,
             )
         case "per_pair":
-            if produce_pdl:
-                raise ValueError(
-                    f"{family} A has no qualified programmatic-dependent-launch "
-                    "producer"
-                )
             per_pair_lora_a(
                 input,
                 weight,
@@ -326,6 +313,13 @@ def run_lora_a(
                 routing,
                 config=config,
                 pair_input=pair_input,
+            )
+        case "token_dense":
+            # Batched GEMM covers all slots; per-pair B selects the slot plane.
+            torch.matmul(
+                input,
+                weight.transpose(1, 2),
+                out=output.view(weight.shape[0], input.shape[0], weight.shape[1]),
             )
         case _:
             raise NotImplementedError(f"no production LoRA-A executor for {family!r}")

--- a/python/sglang/srt/lora/moe/kernels/lora_b.py
+++ b/python/sglang/srt/lora/moe/kernels/lora_b.py
@@ -1,0 +1,507 @@
+"""LoRA-B projections over aligned or raw pairs, including in-place down updates."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING
+
+import torch
+import triton
+import triton.language as tl
+
+from sglang.srt.lora.moe.kernels.routing import (
+    grouped_tile_coords,
+    virtual_expert_ids_inline,
+)
+from sglang.srt.lora.moe.route_view import RouteView
+
+if TYPE_CHECKING:
+    from sglang.srt.lora.moe.execution_plan import LoraBSpec
+
+
+@triton.jit
+def _grouped_lora_b_kernel(
+    bridge_ptr,
+    weight_ptr,
+    destination_ptr,
+    sorted_pair_ids_ptr,
+    block_virtual_expert_ids_ptr,
+    num_pairs_post_padded_ptr,
+    num_pairs,
+    dest_offset_0,
+    dest_offset_1,
+    stride_bm,
+    stride_bk,
+    stride_wg,
+    stride_wn,
+    stride_wk,
+    stride_dm,
+    stride_dn,
+    INTERMEDIATE_TOP_K: tl.constexpr,
+    NUM_SLICES: tl.constexpr,
+    N_PER_SLICE: tl.constexpr,
+    RANK: tl.constexpr,
+    NUM_M_BLOCKS: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    CONSUME_PDL: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    num_pairs_post_padded = tl.load(num_pairs_post_padded_ptr)
+    tiles_per_slice: tl.constexpr = (N_PER_SLICE + BLOCK_SIZE_N - 1) // BLOCK_SIZE_N
+    num_pid_n: tl.constexpr = NUM_SLICES * tiles_per_slice
+    pid_m, pid_n = grouped_tile_coords(pid, num_pid_n, NUM_M_BLOCKS, GROUP_SIZE_M)
+    if pid_m * BLOCK_SIZE_M >= num_pairs_post_padded:
+        return
+
+    slice_id = pid_n // tiles_per_slice
+    n_tile = pid_n % tiles_per_slice
+    destination_offset = tl.where(slice_id == 0, dest_offset_0, dest_offset_1).to(
+        tl.int64
+    )
+    pair_slots = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M).to(tl.int64)
+    pair_ids = tl.load(sorted_pair_ids_ptr + pair_slots).to(tl.int64)
+    pair_mask = pair_ids < num_pairs
+    group = tl.load(block_virtual_expert_ids_ptr + pid_m).to(tl.int64)
+    n_offsets = n_tile * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N).to(tl.int64)
+    n_mask = n_offsets < N_PER_SLICE
+    destination_ptrs = (
+        destination_ptr
+        + pair_ids[:, None] * stride_dm
+        + (destination_offset + n_offsets)[None, :] * stride_dn
+    )
+    store_mask = pair_mask[:, None] & n_mask[None, :]
+
+    if group == -1:
+        # Zero sentinel destinations so graph replay cannot reuse stale deltas.
+        zeros = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        tl.store(
+            destination_ptrs,
+            zeros.to(destination_ptr.dtype.element_ty),
+            mask=store_mask,
+        )
+        return
+
+    if CONSUME_PDL:
+        tl.extra.cuda.gdc_wait()
+
+    bridge_rows = pair_ids // INTERMEDIATE_TOP_K
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    for k_begin in range(0, RANK, BLOCK_SIZE_K):
+        k_offsets = k_begin + tl.arange(0, BLOCK_SIZE_K).to(tl.int64)
+        k_mask = k_offsets < RANK
+        lhs = tl.load(
+            bridge_ptr
+            + bridge_rows[:, None] * stride_bm
+            + (slice_id * RANK + k_offsets)[None, :] * stride_bk,
+            mask=pair_mask[:, None] & k_mask[None, :],
+            other=0.0,
+        )
+        rhs = tl.load(
+            weight_ptr
+            + group * stride_wg
+            + (slice_id * N_PER_SLICE + n_offsets)[None, :] * stride_wn
+            + k_offsets[:, None] * stride_wk,
+            mask=n_mask[None, :] & k_mask[:, None],
+            other=0.0,
+        )
+        accumulator += tl.dot(lhs, rhs, out_dtype=tl.float32)
+
+    tl.store(
+        destination_ptrs,
+        accumulator.to(destination_ptr.dtype.element_ty),
+        mask=store_mask,
+    )
+
+
+def grouped_lora_b(
+    bridge: torch.Tensor,
+    weight: torch.Tensor,
+    destination: torch.Tensor,
+    routing: RouteView,
+    *,
+    destination_offsets: Sequence[int],
+    config: Mapping[str, int],
+    intermediate_top_k: int = 1,
+    consume_pdl: bool = False,
+) -> None:
+    _, weight_rows, rank = weight.shape
+    num_slices = len(destination_offsets)
+    slice_width = weight_rows // num_slices
+    num_pairs = routing.topk_ids.numel()
+    if num_pairs == 0:
+        return
+    offsets = tuple(int(offset) for offset in destination_offsets)
+    block_size_n = int(config["BLOCK_SIZE_N"])
+    num_m_blocks = triton.cdiv(routing.sorted_pair_ids.numel(), routing.block_size)
+    num_pid_n = num_slices * triton.cdiv(slice_width, block_size_n)
+    _grouped_lora_b_kernel[(num_m_blocks * num_pid_n,)](
+        bridge,
+        weight,
+        destination,
+        routing.sorted_pair_ids,
+        routing.block_virtual_expert_ids,
+        routing.num_pairs_post_padded,
+        num_pairs,
+        offsets[0],
+        offsets[1] if num_slices == 2 else offsets[0],
+        bridge.stride(0),
+        bridge.stride(1),
+        weight.stride(0),
+        weight.stride(1),
+        weight.stride(2),
+        destination.stride(0),
+        destination.stride(1),
+        INTERMEDIATE_TOP_K=intermediate_top_k,
+        NUM_SLICES=num_slices,
+        N_PER_SLICE=slice_width,
+        RANK=rank,
+        NUM_M_BLOCKS=num_m_blocks,
+        BLOCK_SIZE_M=routing.block_size,
+        BLOCK_SIZE_N=block_size_n,
+        BLOCK_SIZE_K=int(config["BLOCK_SIZE_K"]),
+        GROUP_SIZE_M=int(config["GROUP_SIZE_M"]),
+        CONSUME_PDL=consume_pdl,
+        num_warps=int(config["num_warps"]),
+        num_stages=int(config["num_stages"]),
+        **({"launch_pdl": True} if consume_pdl else {}),
+    )
+
+
+@triton.jit
+def _per_pair_lora_b_kernel(
+    bridge_ptr,
+    weight_ptr,
+    destination_ptr,
+    topk_ids_ptr,
+    token_lora_mapping_ptr,
+    num_pairs,
+    routed_expert_id_bound,
+    dest_offset_0,
+    dest_offset_1,
+    stride_bs,
+    stride_bm,
+    stride_bk,
+    stride_wg,
+    stride_wn,
+    stride_wk,
+    stride_dm,
+    stride_dn,
+    INTERMEDIATE_TOP_K: tl.constexpr,
+    NUM_SLICES: tl.constexpr,
+    N_PER_SLICE: tl.constexpr,
+    RANK: tl.constexpr,
+    LORA_EXPERTS_PER_ADAPTER: tl.constexpr,
+    MAX_LORAS: tl.constexpr,
+    TOP_K: tl.constexpr,
+    SHARED_OUTER: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+):
+    # stride_bs selects an adapter plane when shared A used a batched GEMM.
+    pair_id = tl.program_id(0)
+    pid_n = tl.program_id(1)
+    tiles_per_slice: tl.constexpr = (N_PER_SLICE + BLOCK_SIZE_N - 1) // BLOCK_SIZE_N
+    slice_id = pid_n // tiles_per_slice
+    n_tile = pid_n % tiles_per_slice
+
+    key = virtual_expert_ids_inline(
+        topk_ids_ptr,
+        token_lora_mapping_ptr,
+        pair_id,
+        pair_id < num_pairs,
+        routed_expert_id_bound,
+        LORA_EXPERTS_PER_ADAPTER=LORA_EXPERTS_PER_ADAPTER,
+        MAX_LORAS=MAX_LORAS,
+        TOP_K=TOP_K,
+        SHARED_OUTER=SHARED_OUTER,
+    )
+    pair64 = pair_id.to(tl.int64)
+    destination_offset = tl.where(slice_id == 0, dest_offset_0, dest_offset_1).to(
+        tl.int64
+    )
+    n_offsets = n_tile.to(tl.int64) * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N).to(
+        tl.int64
+    )
+    n_mask = n_offsets < N_PER_SLICE
+    destination_ptrs = (
+        destination_ptr
+        + pair64 * stride_dm
+        + (destination_offset + n_offsets) * stride_dn
+    )
+
+    if key == -1:
+        # Zero invalid destinations without reading uninitialized bridge rows.
+        zeros = tl.zeros((BLOCK_SIZE_N,), dtype=tl.float32)
+        tl.store(
+            destination_ptrs,
+            zeros.to(destination_ptr.dtype.element_ty),
+            mask=n_mask,
+        )
+        return
+
+    group = key.to(tl.int64)
+    slot = group // LORA_EXPERTS_PER_ADAPTER
+    bridge_row = pair64 // INTERMEDIATE_TOP_K
+    accumulator = tl.zeros((BLOCK_SIZE_N,), dtype=tl.float32)
+    for k_begin in range(0, RANK, BLOCK_SIZE_K):
+        k_offsets = k_begin + tl.arange(0, BLOCK_SIZE_K).to(tl.int64)
+        k_mask = k_offsets < RANK
+        lhs = tl.load(
+            bridge_ptr
+            + slot * stride_bs
+            + bridge_row * stride_bm
+            + (slice_id * RANK + k_offsets) * stride_bk,
+            mask=k_mask,
+            other=0.0,
+        )
+        rhs = tl.load(
+            weight_ptr
+            + group * stride_wg
+            + (slice_id * N_PER_SLICE + n_offsets)[:, None] * stride_wn
+            + k_offsets[None, :] * stride_wk,
+            mask=n_mask[:, None] & k_mask[None, :],
+            other=0.0,
+        )
+        accumulator += tl.sum(rhs.to(tl.float32) * lhs[None, :].to(tl.float32), axis=1)
+
+    tl.store(
+        destination_ptrs,
+        accumulator.to(destination_ptr.dtype.element_ty),
+        mask=n_mask,
+    )
+
+
+def per_pair_lora_b(
+    bridge: torch.Tensor,
+    weight: torch.Tensor,
+    destination: torch.Tensor,
+    routing: RouteView,
+    *,
+    destination_offsets: Sequence[int],
+    config: Mapping[str, int],
+    intermediate_top_k: int = 1,
+) -> None:
+    _, weight_rows, rank = weight.shape
+    num_slices = len(destination_offsets)
+    slice_width = weight_rows // num_slices
+    num_pairs = routing.topk_ids.numel()
+    if num_pairs == 0:
+        return
+    offsets = tuple(int(offset) for offset in destination_offsets)
+    shared_outer = routing.is_shared_outer
+    routed_bound = routing.num_local_experts
+    block_size_n = int(config["BLOCK_SIZE_N"])
+    stride_bs = bridge.stride(0) if bridge.dim() == 3 else 0
+    _per_pair_lora_b_kernel[
+        (num_pairs, num_slices * triton.cdiv(slice_width, block_size_n))
+    ](
+        bridge,
+        weight,
+        destination,
+        routing.topk_ids,
+        routing.token_lora_mapping,
+        num_pairs,
+        routed_bound,
+        offsets[0],
+        offsets[1] if num_slices == 2 else offsets[0],
+        stride_bs,
+        bridge.stride(-2),
+        bridge.stride(-1),
+        weight.stride(0),
+        weight.stride(1),
+        weight.stride(2),
+        destination.stride(0),
+        destination.stride(1),
+        INTERMEDIATE_TOP_K=intermediate_top_k,
+        NUM_SLICES=num_slices,
+        N_PER_SLICE=slice_width,
+        RANK=rank,
+        LORA_EXPERTS_PER_ADAPTER=routing.lora_experts_per_adapter,
+        MAX_LORAS=routing.max_loras,
+        TOP_K=routing.topk_ids.shape[1],
+        SHARED_OUTER=shared_outer,
+        BLOCK_SIZE_N=block_size_n,
+        BLOCK_SIZE_K=int(config["BLOCK_SIZE_K"]),
+        num_warps=int(config["num_warps"]),
+        num_stages=int(config["num_stages"]),
+    )
+
+
+def run_lora_b(
+    spec: LoraBSpec,
+    *,
+    bridge: torch.Tensor,
+    weight: torch.Tensor,
+    destination: torch.Tensor,
+    routing: RouteView,
+    destination_offsets: Sequence[int],
+    config: Mapping[str, int],
+    intermediate_top_k: int = 1,
+    consume_pdl: bool = False,
+) -> None:
+    family = spec.family.value
+    match family:
+        case "grouped":
+            grouped_lora_b(
+                bridge,
+                weight,
+                destination,
+                routing,
+                destination_offsets=destination_offsets,
+                config=config,
+                intermediate_top_k=intermediate_top_k,
+                consume_pdl=consume_pdl,
+            )
+        case "per_pair":
+            if consume_pdl:
+                raise ValueError(
+                    f"{family} B has no qualified programmatic-dependent-launch "
+                    "consumer"
+                )
+            num_tokens = routing.topk_ids.shape[0]
+            if (
+                intermediate_top_k > 1
+                and routing.max_loras > 1
+                and bridge.shape[0] == routing.max_loras * num_tokens
+            ):
+                # A token-major bridge with one plane per slot, as the dense
+                # shared A writes it (a pair-major bridge has M * top_k rows).
+                bridge = bridge.view(routing.max_loras, num_tokens, -1)
+            per_pair_lora_b(
+                bridge,
+                weight,
+                destination,
+                routing,
+                destination_offsets=destination_offsets,
+                config=config,
+                intermediate_top_k=intermediate_top_k,
+            )
+        case _:
+            raise NotImplementedError(f"no production LoRA-B executor for {family!r}")
+
+
+@triton.jit
+def _down_b_into_base_kernel(
+    bridge_ptr,
+    weight_ptr,
+    down_rows_ptr,
+    pair_to_row_ptr,
+    sorted_pair_ids_ptr,
+    block_virtual_expert_ids_ptr,
+    num_pairs_post_padded_ptr,
+    num_pairs,
+    stride_bm,
+    stride_bk,
+    stride_wg,
+    stride_wn,
+    stride_wk,
+    stride_dm,
+    stride_dn,
+    N_HIDDEN: tl.constexpr,
+    RANK: tl.constexpr,
+    NUM_M_BLOCKS: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    num_pairs_post_padded = tl.load(num_pairs_post_padded_ptr)
+    num_pid_n: tl.constexpr = (N_HIDDEN + BLOCK_SIZE_N - 1) // BLOCK_SIZE_N
+    pid_m, pid_n = grouped_tile_coords(pid, num_pid_n, NUM_M_BLOCKS, GROUP_SIZE_M)
+    if pid_m * BLOCK_SIZE_M >= num_pairs_post_padded:
+        return
+
+    group = tl.load(block_virtual_expert_ids_ptr + pid_m).to(tl.int64)
+    if group == -1:
+        return
+
+    pair_slots = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M).to(tl.int64)
+    pair_ids = tl.load(sorted_pair_ids_ptr + pair_slots).to(tl.int64)
+    pair_mask = pair_ids < num_pairs
+    n_offsets = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N).to(tl.int64)
+    n_mask = n_offsets < N_HIDDEN
+    # Valid groups exclude sentinel pairs whose pair_to_row was never written.
+    dest_rows = tl.load(pair_to_row_ptr + pair_ids, mask=pair_mask, other=0).to(
+        tl.int64
+    )
+    destination_ptrs = (
+        down_rows_ptr + dest_rows[:, None] * stride_dm + n_offsets[None, :] * stride_dn
+    )
+    store_mask = pair_mask[:, None] & n_mask[None, :]
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    for k_begin in range(0, RANK, BLOCK_SIZE_K):
+        k_offsets = k_begin + tl.arange(0, BLOCK_SIZE_K).to(tl.int64)
+        k_mask = k_offsets < RANK
+        lhs = tl.load(
+            bridge_ptr + pair_ids[:, None] * stride_bm + k_offsets[None, :] * stride_bk,
+            mask=pair_mask[:, None] & k_mask[None, :],
+            other=0.0,
+        )
+        rhs = tl.load(
+            weight_ptr
+            + group * stride_wg
+            + n_offsets[None, :] * stride_wn
+            + k_offsets[:, None] * stride_wk,
+            mask=n_mask[None, :] & k_mask[:, None],
+            other=0.0,
+        )
+        accumulator += tl.dot(lhs, rhs, out_dtype=tl.float32)
+
+    base = tl.load(destination_ptrs, mask=store_mask, other=0.0).to(tl.float32)
+    tl.store(
+        destination_ptrs,
+        (base + accumulator).to(down_rows_ptr.dtype.element_ty),
+        mask=store_mask,
+    )
+
+
+def invoke_down_b_into_base(
+    *,
+    down_rows: torch.Tensor,
+    pair_to_row: torch.Tensor,
+    bridge: torch.Tensor,
+    b_down: torch.Tensor,
+    routing: RouteView,
+    config: Mapping[str, int],
+) -> None:
+    """Add down-B into base rows addressed by pair_to_row."""
+    num_tokens, top_k = routing.topk_ids.shape
+    pairs = num_tokens * top_k
+    hidden = down_rows.shape[1]
+    rank = bridge.shape[1]
+    if pairs == 0:
+        return
+    block_size_n = int(config["BLOCK_SIZE_N"])
+    num_m_blocks = triton.cdiv(routing.sorted_pair_ids.numel(), routing.block_size)
+    num_pid_n = triton.cdiv(hidden, block_size_n)
+    _down_b_into_base_kernel[(num_m_blocks * num_pid_n,)](
+        bridge,
+        b_down,
+        down_rows,
+        pair_to_row,
+        routing.sorted_pair_ids,
+        routing.block_virtual_expert_ids,
+        routing.num_pairs_post_padded,
+        pairs,
+        bridge.stride(0),
+        bridge.stride(1),
+        b_down.stride(0),
+        b_down.stride(1),
+        b_down.stride(2),
+        down_rows.stride(0),
+        down_rows.stride(1),
+        N_HIDDEN=hidden,
+        RANK=rank,
+        NUM_M_BLOCKS=num_m_blocks,
+        BLOCK_SIZE_M=routing.block_size,
+        BLOCK_SIZE_N=block_size_n,
+        BLOCK_SIZE_K=int(config["BLOCK_SIZE_K"]),
+        GROUP_SIZE_M=int(config["GROUP_SIZE_M"]),
+        num_warps=int(config["num_warps"]),
+        num_stages=int(config["num_stages"]),
+    )

--- a/python/sglang/srt/lora/moe/kernels/lora_b.py
+++ b/python/sglang/srt/lora/moe/kernels/lora_b.py
@@ -46,7 +46,6 @@ def _grouped_lora_b_kernel(
     BLOCK_SIZE_N: tl.constexpr,
     BLOCK_SIZE_K: tl.constexpr,
     GROUP_SIZE_M: tl.constexpr,
-    CONSUME_PDL: tl.constexpr,
 ):
     pid = tl.program_id(0)
     num_pairs_post_padded = tl.load(num_pairs_post_padded_ptr)
@@ -83,9 +82,6 @@ def _grouped_lora_b_kernel(
             mask=store_mask,
         )
         return
-
-    if CONSUME_PDL:
-        tl.extra.cuda.gdc_wait()
 
     bridge_rows = pair_ids // INTERMEDIATE_TOP_K
     accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
@@ -125,7 +121,6 @@ def grouped_lora_b(
     destination_offsets: Sequence[int],
     config: Mapping[str, int],
     intermediate_top_k: int = 1,
-    consume_pdl: bool = False,
 ) -> None:
     _, weight_rows, rank = weight.shape
     num_slices = len(destination_offsets)
@@ -163,10 +158,8 @@ def grouped_lora_b(
         BLOCK_SIZE_N=block_size_n,
         BLOCK_SIZE_K=int(config["BLOCK_SIZE_K"]),
         GROUP_SIZE_M=int(config["GROUP_SIZE_M"]),
-        CONSUME_PDL=consume_pdl,
         num_warps=int(config["num_warps"]),
         num_stages=int(config["num_stages"]),
-        **({"launch_pdl": True} if consume_pdl else {}),
     )
 
 
@@ -340,7 +333,6 @@ def run_lora_b(
     destination_offsets: Sequence[int],
     config: Mapping[str, int],
     intermediate_top_k: int = 1,
-    consume_pdl: bool = False,
 ) -> None:
     family = spec.family.value
     match family:
@@ -353,23 +345,9 @@ def run_lora_b(
                 destination_offsets=destination_offsets,
                 config=config,
                 intermediate_top_k=intermediate_top_k,
-                consume_pdl=consume_pdl,
             )
         case "per_pair":
-            if consume_pdl:
-                raise ValueError(
-                    f"{family} B has no qualified programmatic-dependent-launch "
-                    "consumer"
-                )
-            num_tokens = routing.topk_ids.shape[0]
-            if (
-                intermediate_top_k > 1
-                and routing.max_loras > 1
-                and bridge.shape[0] == routing.max_loras * num_tokens
-            ):
-                # A token-major bridge with one plane per slot, as the dense
-                # shared A writes it (a pair-major bridge has M * top_k rows).
-                bridge = bridge.view(routing.max_loras, num_tokens, -1)
+            # A [slots, tokens, 2R] bridge (token_dense A) selects planes by slot.
             per_pair_lora_b(
                 bridge,
                 weight,

--- a/python/sglang/srt/lora/moe/kernels/routing.py
+++ b/python/sglang/srt/lora/moe/kernels/routing.py
@@ -1,0 +1,397 @@
+"""Route construction kernels and shared virtual-expert indexing helpers."""
+
+from __future__ import annotations
+
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def virtual_expert_ids_inline(
+    topk_ids_ptr,
+    token_lora_mapping_ptr,
+    pair_ids,
+    pair_mask,
+    routed_expert_id_bound,
+    LORA_EXPERTS_PER_ADAPTER: tl.constexpr,
+    MAX_LORAS: tl.constexpr,
+    TOP_K: tl.constexpr,
+    SHARED_OUTER: tl.constexpr,
+):
+    token_ids = pair_ids // TOP_K
+    adapter_ids = tl.load(
+        token_lora_mapping_ptr + token_ids,
+        mask=pair_mask,
+        other=-1,
+    ).to(tl.int32)
+    routed_expert_ids = tl.load(
+        topk_ids_ptr + pair_ids,
+        mask=pair_mask,
+        other=-1,
+    ).to(tl.int32)
+    if SHARED_OUTER:
+        in_range = (routed_expert_ids >= 0) & (
+            routed_expert_ids < routed_expert_id_bound
+        )
+        lora_expert_ids = tl.where(in_range, 0, -1)
+    else:
+        lora_expert_ids = routed_expert_ids
+
+    valid = (
+        (adapter_ids >= 0)
+        & (adapter_ids < MAX_LORAS)
+        & (lora_expert_ids >= 0)
+        & (lora_expert_ids < LORA_EXPERTS_PER_ADAPTER)
+    )
+    return tl.where(valid, adapter_ids * LORA_EXPERTS_PER_ADAPTER + lora_expert_ids, -1)
+
+
+@triton.jit
+def grouped_tile_coords(
+    pid,
+    num_pid_n,
+    NUM_M_BLOCKS: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    # Group M blocks to reuse weight tiles in cache.
+    programs_per_group = GROUP_SIZE_M * num_pid_n
+    group_id = pid // programs_per_group
+    first_pid_m = group_id * GROUP_SIZE_M
+    group_size_m = min(NUM_M_BLOCKS - first_pid_m, GROUP_SIZE_M)
+    pid_m = first_pid_m + ((pid % programs_per_group) % group_size_m)
+    pid_n = (pid % programs_per_group) // group_size_m
+    return pid_m, pid_n
+
+
+@triton.jit
+def add_counts_inline(
+    counts_ptr,
+    virtual_ids,
+    mask,
+    NUM_BUCKETS: tl.constexpr,
+    BINS: tl.constexpr,
+):
+    buckets = tl.where(virtual_ids < 0, NUM_BUCKETS - 1, virtual_ids)
+    if BINS == 0:
+        tl.atomic_add(counts_ptr + buckets, 1, mask=mask)
+    else:
+        mine = tl.histogram(tl.where(mask, buckets, BINS - 1), BINS)
+        bins = tl.arange(0, BINS)
+        tl.atomic_add(counts_ptr + bins, mine, mask=(bins < NUM_BUCKETS) & (mine > 0))
+
+
+@triton.jit
+def claim_slots_inline(
+    cursor_ptr,
+    virtual_ids,
+    mask,
+    NUM_BUCKETS: tl.constexpr,
+    PER_BLOCK: tl.constexpr,
+):
+    # Per-block claims may reorder pairs within each bucket.
+    buckets = tl.where(virtual_ids < 0, NUM_BUCKETS - 1, virtual_ids)
+    if not PER_BLOCK:
+        return tl.atomic_add(cursor_ptr + buckets, 1, mask=mask)
+    slots = tl.zeros(buckets.shape, dtype=tl.int32)
+    for bucket in tl.static_range(NUM_BUCKETS):
+        mine = tl.where(mask & (buckets == bucket), 1, 0).to(tl.int32)
+        start = tl.atomic_add(cursor_ptr + bucket, tl.sum(mine))
+        slots = tl.where(mine == 1, start + tl.cumsum(mine) - mine, slots)
+    return slots
+
+
+@triton.jit
+def _build_virtual_topk_ids_kernel(
+    topk_ids_ptr,
+    token_lora_mapping_ptr,
+    virtual_topk_ids_ptr,
+    num_pairs,
+    routed_expert_id_bound,
+    LORA_EXPERTS_PER_ADAPTER: tl.constexpr,
+    MAX_LORAS: tl.constexpr,
+    TOP_K: tl.constexpr,
+    SHARED_OUTER: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pair_ids = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    pair_mask = pair_ids < num_pairs
+    virtual_ids = virtual_expert_ids_inline(
+        topk_ids_ptr,
+        token_lora_mapping_ptr,
+        pair_ids,
+        pair_mask,
+        routed_expert_id_bound,
+        LORA_EXPERTS_PER_ADAPTER=LORA_EXPERTS_PER_ADAPTER,
+        MAX_LORAS=MAX_LORAS,
+        TOP_K=TOP_K,
+        SHARED_OUTER=SHARED_OUTER,
+    )
+    tl.store(virtual_topk_ids_ptr + pair_ids, virtual_ids, mask=pair_mask)
+
+
+@triton.jit
+def _hist_kernel(
+    topk_ids_ptr,
+    token_lora_mapping_ptr,
+    counts_ptr,
+    num_pairs,
+    routed_expert_id_bound,
+    NUM_BUCKETS: tl.constexpr,
+    LORA_EXPERTS_PER_ADAPTER: tl.constexpr,
+    MAX_LORAS: tl.constexpr,
+    TOP_K: tl.constexpr,
+    SHARED_OUTER: tl.constexpr,
+    BLOCK: tl.constexpr,
+    BINS: tl.constexpr,
+    USE_PDL: tl.constexpr,
+):
+    # The previous scan (or first allocation) cleared counts.
+    pair_ids = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    pair_mask = pair_ids < num_pairs
+    add_counts_inline(
+        counts_ptr,
+        virtual_expert_ids_inline(
+            topk_ids_ptr,
+            token_lora_mapping_ptr,
+            pair_ids,
+            pair_mask,
+            routed_expert_id_bound,
+            LORA_EXPERTS_PER_ADAPTER=LORA_EXPERTS_PER_ADAPTER,
+            MAX_LORAS=MAX_LORAS,
+            TOP_K=TOP_K,
+            SHARED_OUTER=SHARED_OUTER,
+        ),
+        pair_mask,
+        NUM_BUCKETS=NUM_BUCKETS,
+        BINS=BINS,
+    )
+    if USE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
+
+
+@triton.jit
+def _scan_one(
+    counts_ptr,
+    block_cumulative_ptr,
+    cursor_ptr,
+    bucket_end_ptr,
+    padded_pairs_ptr,
+    num_buckets,
+    BLOCK_SIZE_M: tl.constexpr,
+    CHUNK: tl.constexpr,
+):
+    # Clear counts during the scan for the next replay.
+    running = 0
+    for base in range(0, num_buckets, CHUNK):
+        offsets = base + tl.arange(0, CHUNK)
+        mask = offsets < num_buckets
+        counts = tl.load(counts_ptr + offsets, mask=mask, other=0)
+        tl.store(counts_ptr + offsets, 0, mask=mask)
+        blocks = (counts + BLOCK_SIZE_M - 1) // BLOCK_SIZE_M
+        block_start = running + tl.cumsum(blocks) - blocks
+        tl.store(block_cumulative_ptr + offsets, block_start, mask=mask)
+        slot_start = block_start * BLOCK_SIZE_M
+        tl.store(cursor_ptr + offsets, slot_start, mask=mask)
+        tl.store(bucket_end_ptr + offsets, slot_start + counts, mask=mask)
+        running += tl.sum(blocks)
+    tl.store(block_cumulative_ptr + num_buckets, running)
+    tl.store(padded_pairs_ptr, running * BLOCK_SIZE_M)
+
+
+@triton.jit
+def _scan_kernel(
+    counts_ptr,
+    block_cumulative_ptr,
+    cursor_ptr,
+    bucket_end_ptr,
+    padded_pairs_ptr,
+    num_buckets,
+    BLOCK_SIZE_M: tl.constexpr,
+    CHUNK: tl.constexpr,
+    USE_PDL: tl.constexpr,
+):
+    if USE_PDL:
+        tl.extra.cuda.gdc_wait()
+        # Both place paths wait before reading scan outputs.
+        tl.extra.cuda.gdc_launch_dependents()
+    _scan_one(
+        counts_ptr,
+        block_cumulative_ptr,
+        cursor_ptr,
+        bucket_end_ptr,
+        padded_pairs_ptr,
+        num_buckets,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        CHUNK=CHUNK,
+    )
+
+
+@triton.jit
+def _label_blocks(
+    pid,
+    block_cumulative_ptr,
+    bucket_end_ptr,
+    sorted_pair_ids_ptr,
+    block_virtual_expert_ids_ptr,
+    num_blocks,
+    num_pairs,
+    NUM_BUCKETS: tl.constexpr,
+    NUM_VIRTUAL_EXPERTS: tl.constexpr,
+    BLOCK: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    SEARCH_STEPS: tl.constexpr,
+):
+    block_ids = pid * BLOCK + tl.arange(0, BLOCK)
+    block_mask = block_ids < num_blocks
+    low = tl.zeros(block_ids.shape, dtype=tl.int32)
+    high = tl.full(block_ids.shape, NUM_BUCKETS, dtype=tl.int32)
+    for _ in range(SEARCH_STEPS):
+        midpoint = (low + high) // 2
+        bound = tl.load(
+            block_cumulative_ptr + tl.minimum(midpoint + 1, NUM_BUCKETS),
+            mask=block_mask,
+            other=0,
+        )
+        take_upper = block_ids >= bound
+        low = tl.where(take_upper & (low < high), midpoint + 1, low)
+        high = tl.where(take_upper | (low >= high), high, midpoint)
+    owner = tl.minimum(low, NUM_BUCKETS - 1)
+    total_blocks = tl.load(block_cumulative_ptr + NUM_BUCKETS)
+    in_plan = block_mask & (block_ids < total_blocks)
+    tl.store(
+        block_virtual_expert_ids_ptr + block_ids,
+        tl.where(in_plan & (owner < NUM_VIRTUAL_EXPERTS), owner, -1),
+        mask=block_mask,
+    )
+    # B reads sentinel blocks too, so initialize their padding slots.
+    real_end = tl.load(bucket_end_ptr + owner, mask=in_plan, other=0)
+    slots = block_ids[:, None] * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)[None, :]
+    tl.store(
+        sorted_pair_ids_ptr + slots,
+        num_pairs,
+        mask=in_plan[:, None] & (slots >= real_end[:, None]),
+    )
+
+
+@triton.jit
+def _place_kernel(
+    topk_ids_ptr,
+    token_lora_mapping_ptr,
+    cursor_ptr,
+    bucket_end_ptr,
+    block_cumulative_ptr,
+    sorted_ptr,
+    block_ids_ptr,
+    num_blocks,
+    label_programs,
+    num_pairs,
+    routed_expert_id_bound,
+    NUM_BUCKETS: tl.constexpr,
+    NUM_VIRTUAL: tl.constexpr,
+    LORA_EXPERTS_PER_ADAPTER: tl.constexpr,
+    MAX_LORAS: tl.constexpr,
+    TOP_K: tl.constexpr,
+    SHARED_OUTER: tl.constexpr,
+    BLOCK: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    SEARCH_STEPS: tl.constexpr,
+    CLAIM_PER_BLOCK: tl.constexpr,
+    USE_PDL: tl.constexpr,
+):
+    # Low program IDs label blocks; the rest place pairs.
+    pid = tl.program_id(0)
+    if pid < label_programs:
+        if USE_PDL:
+            tl.extra.cuda.gdc_wait()
+        _label_blocks(
+            pid,
+            block_cumulative_ptr,
+            bucket_end_ptr,
+            sorted_ptr,
+            block_ids_ptr,
+            num_blocks,
+            num_pairs,
+            NUM_BUCKETS=NUM_BUCKETS,
+            NUM_VIRTUAL_EXPERTS=NUM_VIRTUAL,
+            BLOCK=BLOCK,
+            BLOCK_SIZE_M=BLOCK_SIZE_M,
+            SEARCH_STEPS=SEARCH_STEPS,
+        )
+        return
+
+    # Recompute keys while the scan runs; this needs no scan output.
+    pair_ids = (pid - label_programs) * BLOCK + tl.arange(0, BLOCK)
+    pair_mask = pair_ids < num_pairs
+    virtual_ids = virtual_expert_ids_inline(
+        topk_ids_ptr,
+        token_lora_mapping_ptr,
+        pair_ids,
+        pair_mask,
+        routed_expert_id_bound,
+        LORA_EXPERTS_PER_ADAPTER=LORA_EXPERTS_PER_ADAPTER,
+        MAX_LORAS=MAX_LORAS,
+        TOP_K=TOP_K,
+        SHARED_OUTER=SHARED_OUTER,
+    )
+    if USE_PDL:
+        # Cursors are this path's first scan dependency.
+        tl.extra.cuda.gdc_wait()
+    slots = claim_slots_inline(
+        cursor_ptr,
+        virtual_ids,
+        pair_mask,
+        NUM_BUCKETS=NUM_BUCKETS,
+        PER_BLOCK=CLAIM_PER_BLOCK,
+    )
+    tl.store(sorted_ptr + slots, pair_ids, mask=pair_mask)
+
+
+@triton.jit
+def _segment_token_route_kernel(
+    seg_indptr_ptr,  # int [S + 1]: request boundaries in token order
+    token_lora_mapping_ptr,  # int32 [M]: adapter slot per token, -1 = none
+    sorted_ptr,  # int32 [capacity]: token ids, padding = num_tokens
+    block_ids_ptr,  # int32 [capacity // BLOCK_SIZE_M]: slot per block, -1 = none
+    padded_ptr,  # int32 [1]
+    num_segments,
+    num_tokens,
+    num_blocks,
+    BLOCK_SIZE_M: tl.constexpr,
+    CHUNK: tl.constexpr,
+):
+    # Request tokens are contiguous and share one slot, so no sort is needed.
+    # Requests without an adapter contribute no blocks.
+    lanes = tl.arange(0, CHUNK)
+    offset = tl.zeros((), dtype=tl.int32)
+    for seg in range(num_segments):
+        start = tl.load(seg_indptr_ptr + seg).to(tl.int32)
+        length = tl.load(seg_indptr_ptr + seg + 1).to(tl.int32) - start
+        slot = tl.load(token_lora_mapping_ptr + start, mask=length > 0, other=-1).to(
+            tl.int32
+        )
+        active = (length > 0) & (slot >= 0)
+        padded = tl.where(
+            active, (length + BLOCK_SIZE_M - 1) // BLOCK_SIZE_M * BLOCK_SIZE_M, 0
+        )
+        for base in range(0, padded, CHUNK):
+            idx = base + lanes
+            tl.store(
+                sorted_ptr + offset + idx,
+                tl.where(idx < length, start + idx, num_tokens),
+                mask=idx < padded,
+            )
+        blocks = padded // BLOCK_SIZE_M
+        for base in range(0, blocks, CHUNK):
+            b = base + lanes
+            tl.store(
+                block_ids_ptr + offset // BLOCK_SIZE_M + b,
+                tl.zeros((CHUNK,), dtype=tl.int32) + slot,
+                mask=b < blocks,
+            )
+        offset += padded
+    for base in range(offset // BLOCK_SIZE_M, num_blocks, CHUNK):
+        b = base + lanes
+        tl.store(
+            block_ids_ptr + b, tl.full((CHUNK,), -1, tl.int32), mask=b < num_blocks
+        )
+    tl.store(padded_ptr, offset)

--- a/python/sglang/srt/lora/moe/launch_config.py
+++ b/python/sglang/srt/lora/moe/launch_config.py
@@ -13,7 +13,8 @@ from sglang.srt.lora.moe.execution_plan import (
     Site,
 )
 from sglang.srt.lora.moe.kernels.finalize import (
-    SHARED_RANK_DEFAULT_CONFIG,
+    SHARED_ONE_PASS_DEFAULT_CONFIG,
+    SHARED_TOKEN_DELTA_DEFAULT_CONFIG,
 )
 from sglang.srt.lora.moe.kernels.fused_act import (
     FUSED_B_ACT_DEFAULT_CONFIG,
@@ -66,11 +67,14 @@ class MoeLoraLaunchConfig:
     b_activation: dict[str, int] = field(
         default_factory=lambda: dict(FUSED_B_ACT_DEFAULT_CONFIG)
     )
-    shared_finalize: dict[str, dict[str, int]] = field(
+    shared_token_delta: dict[str, dict[str, int]] = field(
         default_factory=lambda: {
             name: dict(values)
-            for name, values in SHARED_RANK_DEFAULT_CONFIG.items()
+            for name, values in SHARED_TOKEN_DELTA_DEFAULT_CONFIG.items()
         }
+    )
+    shared_one_pass: dict[str, int] = field(
+        default_factory=lambda: dict(SHARED_ONE_PASS_DEFAULT_CONFIG)
     )
 
     def __post_init__(self) -> None:
@@ -96,10 +100,13 @@ class MoeLoraLaunchConfig:
                     f"{name} declares BLOCK_SIZE_M={declared}, but the aligned "
                     f"route uses routing_block_size={self.routing_block_size}"
                 )
-        if set(self.shared_finalize) != {"reduce", "tail"}:
-            raise ValueError("shared_finalize must contain exactly 'reduce' and 'tail'")
-        for name, config in self.shared_finalize.items():
-            _validate_flat_config(f"shared_finalize.{name}", config)
+        if set(self.shared_token_delta) != {"reduce", "tail"}:
+            raise ValueError(
+                "shared_token_delta must contain exactly 'reduce' and 'tail'"
+            )
+        for name, config in self.shared_token_delta.items():
+            _validate_flat_config(f"shared_token_delta.{name}", config)
+        _validate_flat_config("shared_one_pass", self.shared_one_pass)
 
     def for_a(self, site: Site) -> Mapping[str, int]:
         return self.gate_up_a if site is Site.GATE_UP else self.down_a

--- a/python/sglang/srt/lora/moe/launch_config.py
+++ b/python/sglang/srt/lora/moe/launch_config.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from dataclasses import field
+from functools import cache
+from typing import Any, Mapping
+
+import pydantic
+from pydantic.dataclasses import dataclass as pydantic_dataclass
+
+from sglang.srt.lora.moe.execution_plan import (
+    ActFamily,
+    DeviceArchitecture,
+    Site,
+)
+from sglang.srt.lora.moe.kernels.finalize import (
+    SHARED_RANK_DEFAULT_CONFIG,
+)
+from sglang.srt.lora.moe.kernels.fused_act import (
+    FUSED_B_ACT_DEFAULT_CONFIG,
+)
+
+
+def _a_default() -> dict[str, int]:
+    return {
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 4,
+        "num_stages": 2,
+    }
+
+
+def _b_default() -> dict[str, int]:
+    return {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 8,
+        "num_warps": 4,
+        "num_stages": 2,
+    }
+
+
+def _is_power_of_two(value: int) -> bool:
+    return value > 0 and value & (value - 1) == 0
+
+
+def _validate_flat_config(name: str, config: Mapping[str, int]) -> None:
+    if not config:
+        raise ValueError(f"{name} must be a non-empty launch-config mapping")
+
+
+@pydantic_dataclass(
+    frozen=True,
+    slots=True,
+    kw_only=True,
+    config=pydantic.ConfigDict(strict=True, extra="forbid"),
+)
+class MoeLoraLaunchConfig:
+    # Shared row tile for aligned LoRA kernels; independent of base-GEMM tiles.
+    routing_block_size: int = 16
+    gate_up_a: dict[str, int] = field(default_factory=_a_default)
+    gate_up_b: dict[str, int] = field(default_factory=_b_default)
+    down_a: dict[str, int] = field(default_factory=_a_default)
+    down_b: dict[str, int] = field(default_factory=_b_default)
+    b_activation: dict[str, int] = field(
+        default_factory=lambda: dict(FUSED_B_ACT_DEFAULT_CONFIG)
+    )
+    shared_finalize: dict[str, dict[str, int]] = field(
+        default_factory=lambda: {
+            name: dict(values)
+            for name, values in SHARED_RANK_DEFAULT_CONFIG.items()
+        }
+    )
+
+    def __post_init__(self) -> None:
+        # tl.dot requires a power-of-two row tile of at least 16.
+        if (
+            not _is_power_of_two(self.routing_block_size)
+            or self.routing_block_size < 16
+        ):
+            raise ValueError("routing_block_size must be a power of two >= 16")
+        for name in (
+            "gate_up_a",
+            "gate_up_b",
+            "down_a",
+            "down_b",
+            "b_activation",
+        ):
+            _validate_flat_config(name, getattr(self, name))
+        # Grouped B takes its row tile from the route, not its config section.
+        for name in ("gate_up_b", "down_b"):
+            declared = getattr(self, name).get("BLOCK_SIZE_M")
+            if declared is not None and int(declared) != self.routing_block_size:
+                raise ValueError(
+                    f"{name} declares BLOCK_SIZE_M={declared}, but the aligned "
+                    f"route uses routing_block_size={self.routing_block_size}"
+                )
+        if set(self.shared_finalize) != {"reduce", "tail"}:
+            raise ValueError("shared_finalize must contain exactly 'reduce' and 'tail'")
+        for name, config in self.shared_finalize.items():
+            _validate_flat_config(f"shared_finalize.{name}", config)
+
+    def for_a(self, site: Site) -> Mapping[str, int]:
+        return self.gate_up_a if site is Site.GATE_UP else self.down_a
+
+    def for_b(self, site: Site) -> Mapping[str, int]:
+        return self.gate_up_b if site is Site.GATE_UP else self.down_b
+
+    def for_act(self, family: ActFamily) -> Mapping[str, int]:
+        if family is ActFamily.B_ACTIVATION:
+            return self.b_activation
+        raise ValueError(f"{family.value} has no fused-act launch config")
+
+
+class _TileRuleModel(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(extra="forbid")
+
+    max_rank: int | None = None
+    max_tokens: int | None = None
+    sites: dict[str, Any] = pydantic.Field(default_factory=dict)
+
+
+class _TilesFileModel(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(extra="forbid")
+
+    arch: DeviceArchitecture
+    rules: dict[str, list[_TileRuleModel]]
+
+
+@cache
+def _load_tiles(architecture_value: str) -> _TilesFileModel | None:
+    from sglang.srt.lora.moe.execution_plan import _read_table
+
+    raw = _read_table(f"{architecture_value}.tiles.json")
+    if raw is None:
+        return None
+    return _TilesFileModel.model_validate(raw)
+
+
+class TileTable:
+    def __init__(self, rules: list[tuple[int, MoeLoraLaunchConfig]]) -> None:
+        self._rules = rules
+
+    def config_for(self, num_tokens: int) -> MoeLoraLaunchConfig:
+        for bound, config in self._rules:
+            if num_tokens <= bound:
+                return config
+        return self._rules[-1][1]
+
+
+def resolve_tiles(
+    *,
+    architecture_value: str,
+    plan_key_name: str,
+    physical_rank: int,
+) -> TileTable:
+    """Filter by rank at bind time; retain token bounds for each forward."""
+    table = _load_tiles(architecture_value)
+    rules = table.rules.get(plan_key_name) if table is not None else None
+    if not rules:
+        return TileTable([(1 << 30, MoeLoraLaunchConfig())])
+    resolved: list[tuple[int, MoeLoraLaunchConfig]] = []
+    for rule in rules:
+        if rule.max_rank is not None and physical_rank > rule.max_rank:
+            continue
+        bound = rule.max_tokens if rule.max_tokens is not None else 1 << 30
+        resolved.append((bound, MoeLoraLaunchConfig(**rule.sites)))
+        if rule.max_tokens is None:
+            break  # An unbounded rule shadows all later rules.
+    if not resolved:
+        resolved.append((1 << 30, MoeLoraLaunchConfig()))
+    return TileTable(resolved)

--- a/python/sglang/srt/lora/moe/moe_lora_runner.py
+++ b/python/sglang/srt/lora/moe/moe_lora_runner.py
@@ -1,0 +1,842 @@
+"""Execute a bound MoE LoRA plan; base-only tokens use adapter slot -1."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import msgspec
+import torch
+
+logger = logging.getLogger(__name__)
+
+from sglang.srt.lora.moe.activation import ActivationFn
+from sglang.srt.lora.moe.base_gemm_provider.base import (
+    MoeBaseProvider,
+)
+from sglang.srt.lora.moe.execution_plan import (
+    ActFamily,
+    BridgeLayout,
+    DownOverlap,
+    FinalizeFamily,
+    GateUpOverlap,
+    LoraAFamily,
+    LoraASpec,
+    LoraBFamily,
+    LoraBSpec,
+    MoeLoraExecutionPlan,
+    Phase,
+    SelectedPlan,
+    Site,
+    architecture_for_capability,
+    resolve_plans,
+)
+from sglang.srt.lora.moe.kernels.lora_a import run_lora_a
+from sglang.srt.lora.moe.kernels.lora_b import invoke_down_b_into_base, run_lora_b
+from sglang.srt.lora.moe.launch_config import (
+    MoeLoraLaunchConfig,
+    TileTable,
+    resolve_tiles,
+)
+from sglang.srt.lora.moe.quant_info import MoeLoraBf16QuantInfo
+from sglang.srt.lora.moe.route_view import RouteView
+from sglang.srt.lora.moe.routing import MoeLoraRoutes, build_routes
+from sglang.srt.lora.moe.workspace import MoeLoraWorkspace
+from sglang.srt.runtime_context import get_lora
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
+    from sglang.srt.layers.moe.token_dispatcher.standard import (
+        StandardCombineInput,
+        StandardDispatchOutput,
+    )
+
+
+@dataclass(slots=True)
+class _LoraStageState:
+    rank: torch.Tensor | None = None
+    delta: torch.Tensor | None = None
+
+
+class MoeLoraBatch(msgspec.Struct, kw_only=True):
+
+    gate_up_lora_a: torch.Tensor  # [L_cap, E_f, slices*R_phys, H]
+    gate_up_lora_b: torch.Tensor  # [L_cap, E_local, slices*I, R_phys]
+    down_lora_a: torch.Tensor  # [L_cap, E_local, R_phys, I]
+    down_lora_b: torch.Tensor  # [L_cap, E_f_down, H, R_phys]
+    token_lora_mapping: torch.Tensor  # [T] int, adapter slot per token (-1 = base)
+    seg_indptr: torch.Tensor  # [num_requests + 1] int, token boundaries per request
+    use_cuda_graph: bool = False
+    is_prefill: bool = False
+
+    @property
+    def max_loras(self) -> int:
+        return self.gate_up_lora_a.shape[0]
+
+
+class MoeLoraRunner:
+    def __init__(
+        self,
+        *,
+        providers: Mapping[str, MoeBaseProvider],
+        top_k: int,
+        routed_scaling_factor: float | None,
+        activation: ActivationFn = ActivationFn.SILU,
+        is_gated: bool = True,
+        workspace: MoeLoraWorkspace | None = None,
+    ) -> None:
+        if not providers:
+            raise ValueError("a MoE LoRA runner needs at least one provider")
+        self.providers = dict(providers)
+        geometries = {
+            (
+                provider.hidden_size,
+                provider.intermediate_size,
+                provider.num_local_experts,
+                provider.gate_up_slices,
+                provider.contract.lora_delta_dtype,
+            )
+            for provider in self.providers.values()
+        }
+        if len(geometries) != 1:
+            raise ValueError("providers of one layer must share resident geometry")
+        (
+            self.hidden_size,
+            self.intermediate_size,
+            self.num_local_experts,
+            self.gate_up_slices,
+            self.lora_delta_dtype,
+        ) = next(iter(geometries))
+        self.top_k = top_k
+        self.routed_scaling_factor = routed_scaling_factor
+        self.activation = activation
+        self.is_gated = is_gated
+        self.workspace = workspace if workspace is not None else MoeLoraWorkspace()
+        self.plans: dict[Phase, SelectedPlan] = {}
+        self.tiles: dict[Phase, TileTable] = {}
+
+    @classmethod
+    def from_layer(
+        cls,
+        base_layer: FusedMoE,
+        *,
+        workspace: MoeLoraWorkspace | None = None,
+        is_shared_outer: bool,
+        physical_rank: int,
+    ) -> MoeLoraRunner:
+        cls._admit(base_layer)
+        weight_device = base_layer.w2_weight.device
+        if weight_device.type != "cuda":
+            raise NotImplementedError("MoE LoRA requires a CUDA layer")
+        architecture = architecture_for_capability(
+            *torch.cuda.get_device_capability(weight_device)
+        )
+        config = base_layer.moe_runner_config
+        activation = ActivationFn.parse(config.activation)
+        plans = resolve_plans(
+            architecture=architecture,
+            is_shared_outer=is_shared_outer,
+            physical_rank=physical_rank,
+            activation=activation,
+            hidden_size=int(base_layer.hidden_size),
+            num_local_experts=int(base_layer.num_local_experts),
+        )
+        # The shared finalize holds a token's rank-space sum in one tile of
+        # ``next_power_of_2(rank)`` columns, swept to 256.
+        if physical_rank > 256 and any(
+            sel.plan.finalize.family is not FinalizeFamily.MATERIALIZED
+            for sel in plans.values()
+        ):
+            raise ValueError(
+                f"the shared finalize is capped at rank 256, got {physical_rank}"
+            )
+        vendor = get_lora().moe_lora_base_gemm
+        runner = cls(
+            providers={
+                rows: cls._build_provider(
+                    base_layer, base_gemm_rows=rows, vendor=vendor
+                )
+                for rows in dict.fromkeys(sel.base_gemm_rows for sel in plans.values())
+            },
+            top_k=int(config.top_k),
+            routed_scaling_factor=config.routed_scaling_factor,
+            activation=activation,
+            is_gated=bool(config.is_gated),
+            workspace=workspace,
+        )
+        for phase, sel in plans.items():
+            runner.validate_plan(sel.plan, base_gemm_rows=sel.base_gemm_rows)
+            runner.tiles[phase] = resolve_tiles(
+                architecture_value=architecture.value,
+                plan_key_name=sel.name,
+                physical_rank=physical_rank,
+            )
+        runner.plans = dict(plans)
+        return runner
+
+    @staticmethod
+    def _admit(base_layer: FusedMoE) -> None:
+        from sglang.srt.layers.moe.token_dispatcher.standard import StandardDispatcher
+        from sglang.srt.layers.quantization.unquant import UnquantizedFusedMoEMethod
+
+        if not isinstance(base_layer.quant_method, UnquantizedFusedMoEMethod):
+            raise NotImplementedError(
+                "MoE LoRA currently supports unquantized BF16 MoE only"
+            )
+        if (
+            not isinstance(base_layer.dispatcher, StandardDispatcher)
+            or base_layer.w13_weight.dtype != torch.bfloat16
+            or base_layer.w2_weight.dtype != torch.bfloat16
+        ):
+            raise NotImplementedError(
+                "MoE LoRA BF16 currently requires Standard dispatch and a "
+                "resident BF16 provider"
+            )
+
+        major, minor = torch.cuda.get_device_capability()
+        if major not in (9, 10):
+            raise NotImplementedError(
+                f"MoE LoRA BF16 supports SM90 and SM100 only; this device is "
+                f"sm{major}{minor}. Its base GEMMs are WGMMA (SM90) and "
+                "tcgen05 (SM100) kernels, and no other architecture implements "
+                "either -- SM120 included, despite reporting a higher major."
+            )
+        if base_layer.dispatcher.skip_local_expert_mapping:
+            raise NotImplementedError(
+                "MoE LoRA BF16 requires EP-local expert IDs at the runner "
+                "boundary, but this dispatcher keeps global IDs"
+            )
+        if base_layer.should_fuse_routed_scaling_factor_in_topk:
+            raise NotImplementedError(
+                "MoE LoRA BF16 applies routed scaling exactly once in its own "
+                "finalize; this layer already folds it into the top-k weights"
+            )
+        if getattr(base_layer, "with_bias", False):
+            raise NotImplementedError(
+                "MoE LoRA providers carry no expert biases; this layer has them"
+            )
+
+        config = base_layer.moe_runner_config
+        # Membership by value: `str in Enum` raises TypeError before Python 3.12.
+        supported_activation = config.activation in {fn.value for fn in ActivationFn}
+        gateup_width = base_layer.w13_weight.shape[1]
+        intermediate = base_layer.w2_weight.shape[2]
+        if gateup_width != (2 if config.is_gated else 1) * intermediate:
+            raise NotImplementedError(
+                f"resident gate/up width {gateup_width} disagrees with "
+                f"is_gated={config.is_gated} at intermediate {intermediate}"
+            )
+        if (
+            not supported_activation
+            or config.gemm1_alpha is not None
+            or config.gemm1_clamp_limit is not None
+            or config.swiglu_limit is not None
+            or config.apply_router_weight_on_input
+            or config.no_combine
+            or config.num_fused_shared_experts
+        ):
+            raise NotImplementedError(
+                "MoE LoRA BF16 supports SiLU or ReLU2 (gated or not) without "
+                "fused shared experts, with route weighting owned by finalize"
+            )
+
+    @staticmethod
+    def select_provider_cls(
+        base_gemm_rows: str,
+        vendor: str,
+    ) -> type[MoeBaseProvider]:
+        if base_gemm_rows not in ("expert_major", "route_major"):
+            raise ValueError(
+                f"unknown MoE LoRA base-GEMM row order {base_gemm_rows!r}; "
+                "expected 'expert_major' or 'route_major'"
+            )
+        if vendor == "cutedsl":
+            from sglang.srt.lora.moe.base_gemm_provider.cutedsl_bf16 import (
+                CuteDslBf16ContiguousProvider,
+                CuteDslBf16MaskedProvider,
+            )
+
+            return (
+                CuteDslBf16MaskedProvider
+                if base_gemm_rows == "expert_major"
+                else CuteDslBf16ContiguousProvider
+            )
+        if vendor == "triton":
+            if base_gemm_rows != "route_major":
+                raise ValueError(
+                    "the triton base-GEMM provider is route-major only; "
+                    f"a plan row asked for {base_gemm_rows!r}"
+                )
+            from sglang.srt.lora.moe.base_gemm_provider.triton_bf16 import (
+                TritonBf16ContiguousProvider,
+            )
+
+            return TritonBf16ContiguousProvider
+        raise ValueError(
+            f"unknown MoE LoRA base-GEMM vendor {vendor!r}; expected "
+            "'cutedsl' or 'triton'"
+        )
+
+    @classmethod
+    def _build_provider(
+        cls,
+        base_layer: FusedMoE,
+        *,
+        base_gemm_rows: str,
+        vendor: str,
+    ) -> MoeBaseProvider:
+        return cls.select_provider_cls(base_gemm_rows, vendor)(
+            MoeLoraBf16QuantInfo(
+                w13_weight=base_layer.w13_weight,
+                w2_weight=base_layer.w2_weight,
+                num_local_experts=int(base_layer.num_local_experts),
+                intermediate_size=int(base_layer.w2_weight.shape[2]),
+                hidden_size=int(base_layer.w2_weight.shape[1]),
+            )
+        )
+
+    def validate_plan(self, plan: MoeLoraExecutionPlan, *, base_gemm_rows: str) -> None:
+        provider = self.providers[base_gemm_rows]
+        plan.validate()
+        if plan.act.activation is not self.activation:
+            raise ValueError(
+                f"plan activation {plan.act.activation.value} does not match "
+                f"resident layer activation {self.activation.value}"
+            )
+        expected_slices = 2 if self.is_gated else 1
+        if provider.gate_up_slices != expected_slices:
+            raise ValueError(
+                f"provider exposes {provider.gate_up_slices} gate/up slices "
+                f"but is_gated={self.is_gated} needs {expected_slices}"
+            )
+
+    def run(
+        self,
+        dispatch_output: StandardDispatchOutput,
+        batch: MoeLoraBatch,
+    ) -> StandardCombineInput:
+        from sglang.srt.layers.moe.token_dispatcher.standard import StandardCombineInput
+        from sglang.srt.layers.moe.topk import TopKOutputChecker
+
+        phase = Phase.PREFILL if batch.is_prefill else Phase.DECODE
+        selected = self.plans[phase]
+        launch_config = self.tiles[phase].config_for(
+            dispatch_output.hidden_states.shape[0]
+        )
+
+        provider = self.providers[selected.base_gemm_rows]
+        hidden_states = dispatch_output.hidden_states
+        topk_output = dispatch_output.topk_output
+        assert TopKOutputChecker.format_is_standard(topk_output)
+        topk_ids = topk_output.topk_ids
+
+        num_tokens = hidden_states.shape[0]
+        if (
+            batch.token_lora_mapping.ndim != 1
+            or batch.token_lora_mapping.shape[0] != num_tokens
+        ):
+            raise RuntimeError(
+                "MoE LoRA token/adapter assignment does not match the MoE "
+                f"token domain: mapping has {batch.token_lora_mapping.shape[0]} rows "
+                f"but the runner received {num_tokens}. Gather/remap "
+                "assignments before MoE-DP execution."
+            )
+
+        self.workspace.begin_forward(graph_mode=batch.use_cuda_graph)
+        routes = build_routes(
+            selected.plan,
+            topk_ids=topk_ids,
+            token_lora_mapping=batch.token_lora_mapping,
+            seg_indptr=batch.seg_indptr,
+            num_local_experts=self.num_local_experts,
+            max_loras=batch.max_loras,
+            block_size=launch_config.routing_block_size,
+            workspace=self.workspace,
+        )
+
+        gate_up, base_gemm_state, gateup_out = self._run_gate_up(
+            selected.plan,
+            launch_config,
+            provider,
+            routes,
+            hidden_states,
+            topk_ids,
+            batch,
+            num_tokens,
+        )
+        act_out, down_a_input, down_a_gather, pair_to_row = self._run_act(
+            selected.plan,
+            launch_config,
+            provider,
+            routes,
+            base_gemm_state,
+            gateup_out,
+            gate_up,
+            topk_ids,
+            batch,
+            num_tokens,
+        )
+        output = self._allocate_output(
+            num_tokens=num_tokens,
+            dtype=hidden_states.dtype,
+            device=act_out.device,
+        )
+        down_out, down_rank, down_delta = self._run_down(
+            selected.plan,
+            launch_config,
+            provider,
+            routes,
+            base_gemm_state,
+            act_out,
+            down_a_input,
+            down_a_gather,
+            pair_to_row,
+            batch,
+        )
+        output = self._run_finalize(
+            selected.plan,
+            launch_config,
+            provider,
+            routes,
+            base_gemm_state,
+            output,
+            down_out,
+            down_rank,
+            down_delta,
+            topk_output,
+            batch,
+            num_tokens,
+        )
+        return StandardCombineInput(hidden_states=output)
+
+    @staticmethod
+    def _route_for_a(spec: LoraASpec, routes: MoeLoraRoutes) -> RouteView:
+        if spec.family is LoraAFamily.TOKEN_GROUPED:
+            if routes.shared_token is None:
+                raise ValueError("shared token route was not constructed")
+            return routes.shared_token
+        if spec.family is LoraAFamily.PER_PAIR:
+            return routes.raw(spec.is_shared_outer)
+        return routes.aligned(spec.is_shared_outer)
+
+    @staticmethod
+    def _route_for_b(spec: LoraBSpec, routes: MoeLoraRoutes) -> RouteView:
+        if spec.family is LoraBFamily.PER_PAIR:
+            return routes.raw(spec.is_shared_outer)
+        return routes.aligned(spec.is_shared_outer)
+
+    def _run_a(
+        self,
+        launch_config: MoeLoraLaunchConfig,
+        spec: LoraASpec,
+        input: torch.Tensor,
+        weight: torch.Tensor,
+        routes: MoeLoraRoutes,
+        name: str,
+        *,
+        pair_to_row: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        route = self._route_for_a(spec, routes)
+        num_output_rows = (
+            route.topk_ids.shape[0]
+            if spec.output_layout is BridgeLayout.TOKEN_MAJOR
+            else route.topk_ids.numel()
+        )
+        output = self.workspace.tensor(
+            f"{name}:output",
+            (num_output_rows, weight.shape[1]),
+            dtype=self.lora_delta_dtype,
+            device=input.device,
+        )
+        config = launch_config.for_a(spec.site)
+        return run_lora_a(
+            spec,
+            input=input,
+            weight=weight,
+            output=output,
+            routing=route,
+            config=config,
+            pair_to_row=pair_to_row,
+        )
+
+    def _run_b(
+        self,
+        launch_config: MoeLoraLaunchConfig,
+        spec: LoraBSpec,
+        bridge: torch.Tensor,
+        weight: torch.Tensor,
+        destination: torch.Tensor,
+        routes: MoeLoraRoutes,
+    ) -> None:
+        route = self._route_for_b(spec, routes)
+        config = launch_config.for_b(spec.site)
+        if spec.site is Site.GATE_UP:
+            width = weight.shape[1] // self.gate_up_slices
+            offsets = tuple(slice_id * width for slice_id in range(self.gate_up_slices))
+        else:
+            offsets = (0,)
+        run_lora_b(
+            spec,
+            bridge=bridge,
+            weight=weight,
+            destination=destination,
+            routing=route,
+            destination_offsets=offsets,
+            config=config,
+            intermediate_top_k=(
+                self.top_k if spec.input_layout is BridgeLayout.TOKEN_MAJOR else 1
+            ),
+        )
+
+    def _run_gate_up(
+        self,
+        plan: MoeLoraExecutionPlan,
+        launch_config: MoeLoraLaunchConfig,
+        provider: MoeBaseProvider,
+        routes: MoeLoraRoutes,
+        hidden_states: torch.Tensor,
+        topk_ids: torch.Tensor,
+        batch: MoeLoraBatch,
+        num_tokens: int,
+    ) -> tuple[_LoraStageState, object, torch.Tensor]:
+        state = _LoraStageState()
+
+        def gate_up_a() -> None:
+            state.rank = self._run_a(
+                launch_config,
+                plan.gate_up_a,
+                hidden_states,
+                batch.gate_up_lora_a.flatten(0, 1),
+                routes,
+                "gate_up_a",
+            )
+
+        def gate_up_b() -> None:
+            delta = self.workspace.tensor(
+                "gate_up_b:delta",
+                (
+                    num_tokens * self.top_k,
+                    self.gate_up_slices * self.intermediate_size,
+                ),
+                dtype=self.lora_delta_dtype,
+                device=state.rank.device,
+            )
+            self._run_b(
+                launch_config,
+                plan.gate_up_b,
+                state.rank,
+                batch.gate_up_lora_b.flatten(0, 1),
+                delta,
+                routes,
+            )
+            state.delta = delta
+
+        def base() -> tuple[object, torch.Tensor]:
+            base_gemm_state = provider.prepare(
+                hidden_states,
+                topk_ids,
+                self.top_k,
+                self.workspace,
+            )
+            gateup_out = self.workspace.tensor(
+                "base:gateup",
+                provider.gateup_out_shape(base_gemm_state),
+                dtype=provider.contract.gate_up_output_dtype,
+                device=hidden_states.device,
+            )
+            provider.gateup(base_gemm_state, gateup_out)
+            provider.release_prepared_inputs(base_gemm_state)
+            return base_gemm_state, gateup_out
+
+        if plan.gate_up_overlap is GateUpOverlap.NONE:
+            gate_up_a()
+            if plan.gate_up_b is not None:
+                gate_up_b()
+            base_gemm_state, gateup = base()
+        elif plan.gate_up_overlap is GateUpOverlap.GATE_UP_A:
+            base_gemm_state, gateup = self.workspace.run_parallel(
+                name=plan.gate_up_overlap.value,
+                device=hidden_states.device,
+                compute=base,
+                side=gate_up_a,
+            )
+            if plan.gate_up_b is not None:
+                gate_up_b()
+        else:
+
+            def gate_up_a_b() -> None:
+                gate_up_a()
+                gate_up_b()
+
+            base_gemm_state, gateup = self.workspace.run_parallel(
+                name=plan.gate_up_overlap.value,
+                device=hidden_states.device,
+                compute=base,
+                side=gate_up_a_b,
+            )
+        return state, base_gemm_state, gateup
+
+    def _run_act(
+        self,
+        plan: MoeLoraExecutionPlan,
+        launch_config: MoeLoraLaunchConfig,
+        provider: MoeBaseProvider,
+        routes: MoeLoraRoutes,
+        base_gemm_state,
+        gateup_out: torch.Tensor,
+        gate_up: _LoraStageState,
+        topk_ids: torch.Tensor,
+        batch: MoeLoraBatch,
+        num_tokens: int,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None, torch.Tensor]:
+        act_out = self.workspace.tensor(
+            "act:masked",
+            provider.act_out_shape(base_gemm_state),
+            dtype=provider.contract.lora_activation_dtype,
+            device=gateup_out.device,
+        )
+        provider_rows, pair_to_row = provider.mapped_down_lora_a_input(
+            base_gemm_state, act_out
+        )
+        # Fused B+activation can feed grouped down-A through the provider's row map.
+        exposes_pair_activation = not (
+            plan.act.family is ActFamily.B_ACTIVATION
+            and plan.down_a.family is LoraAFamily.GROUPED
+        )
+        act_pairs = (
+            self.workspace.tensor(
+                "act:pairs",
+                (num_tokens, self.top_k, provider.intermediate_size),
+                dtype=provider.contract.lora_activation_dtype,
+                device=gateup_out.device,
+            )
+            if exposes_pair_activation
+            else None
+        )
+        if plan.act.family is ActFamily.MATERIALIZED:
+            provider.act_with_delta(
+                base_gemm_state,
+                gateup_out,
+                gate_up.delta.view(
+                    num_tokens,
+                    self.top_k,
+                    provider.gate_up_slices * provider.intermediate_size,
+                ),
+                topk_ids,
+                act_out,
+                act_pairs,
+                activation=self.activation.value,
+            )
+            # Pair-major input needs no gather.
+            return act_out, act_pairs, None, pair_to_row
+
+        provider.fused_act(
+            base_gemm_state,
+            activation=self.activation.value,
+            base_gateup=gateup_out,
+            act_rows=act_out,
+            act_pairs=act_pairs,
+            routing=routes.aligned(False),
+            config=launch_config.for_act(plan.act.family),
+            bridge_gateup=gate_up.rank,
+            b_gate_up=batch.gate_up_lora_b.flatten(0, 1),
+            bridge_top_k=(
+                self.top_k
+                if plan.gate_up_a.output_layout is BridgeLayout.TOKEN_MAJOR
+                else 1
+            ),
+        )
+        if exposes_pair_activation:
+            return act_out, act_pairs, None, pair_to_row
+        # Only provider-ordered input uses pair_to_row; pair-major input must not.
+        return act_out, provider_rows, pair_to_row, pair_to_row
+
+    def _run_down(
+        self,
+        plan: MoeLoraExecutionPlan,
+        launch_config: MoeLoraLaunchConfig,
+        provider: MoeBaseProvider,
+        routes: MoeLoraRoutes,
+        base_gemm_state,
+        act_out: torch.Tensor,
+        down_a_input: torch.Tensor,
+        down_a_gather: torch.Tensor | None,
+        pair_to_row: torch.Tensor,
+        batch: MoeLoraBatch,
+    ) -> tuple[
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor | None,
+    ]:
+        state = _LoraStageState()
+
+        def down_a() -> None:
+            state.rank = self._run_a(
+                launch_config,
+                plan.down_a,
+                down_a_input.view(-1, self.intermediate_size),
+                batch.down_lora_a.flatten(0, 1),
+                routes,
+                "down_a",
+                pair_to_row=down_a_gather,
+            )
+
+        def down_b() -> None:
+            delta = self.workspace.tensor(
+                "down_b:delta",
+                (state.rank.shape[0], self.hidden_size),
+                dtype=self.lora_delta_dtype,
+                device=state.rank.device,
+            )
+            self._run_b(
+                launch_config,
+                plan.down_b,
+                state.rank,
+                batch.down_lora_b.flatten(0, 1),
+                delta,
+                routes,
+            )
+            state.delta = delta
+
+        def down_b_into_base(down_out: torch.Tensor) -> None:
+            invoke_down_b_into_base(
+                down_rows=down_out.view(-1, provider.hidden_size),
+                pair_to_row=pair_to_row,
+                bridge=state.rank,
+                b_down=batch.down_lora_b.flatten(0, 1),
+                # In-place B requires aligned rows even when the selected family is raw.
+                routing=routes.aligned(plan.down_b.is_shared_outer),
+                config=launch_config.for_b(plan.down_b.site),
+            )
+
+        def base() -> torch.Tensor:
+            down_out = self.workspace.tensor(
+                "base:down",
+                provider.down_out_shape(base_gemm_state),
+                dtype=torch.bfloat16,
+                device=act_out.device,
+            )
+            provider.down(base_gemm_state, act_out, down_out)
+            return down_out
+
+        if plan.down_overlap is DownOverlap.NONE:
+            down_a()
+            if plan.down_b_into_base:
+                down_out = base()
+                down_b_into_base(down_out)
+            else:
+                if plan.down_b is not None:
+                    down_b()
+                down_out = base()
+        elif plan.down_overlap is DownOverlap.DOWN_A:
+            down_out = self.workspace.run_parallel(
+                name=plan.down_overlap.value,
+                device=act_out.device,
+                compute=base,
+                side=down_a,
+            )
+            if plan.down_b_into_base:
+                down_b_into_base(down_out)
+            elif plan.down_b is not None:
+                down_b()
+        elif plan.down_overlap is DownOverlap.DOWN_B:
+            down_a()
+            down_out = self.workspace.run_parallel(
+                name=plan.down_overlap.value,
+                device=act_out.device,
+                compute=base,
+                side=down_b,
+            )
+        else:
+
+            def down_a_b() -> None:
+                down_a()
+                down_b()
+
+            down_out = self.workspace.run_parallel(
+                name=plan.down_overlap.value,
+                device=act_out.device,
+                compute=base,
+                side=down_a_b,
+            )
+
+        return down_out, state.rank, state.delta
+
+    def _allocate_output(
+        self,
+        *,
+        num_tokens: int,
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> torch.Tensor:
+        from sglang.srt.distributed import get_tp_group
+        from sglang.srt.distributed.device_communicators.pynccl_allocator import (
+            use_symmetric_memory,
+        )
+        from sglang.srt.layers.dp_attention import is_allocation_symmetric
+
+        with use_symmetric_memory(
+            get_tp_group(), disabled=not is_allocation_symmetric()
+        ):
+            return torch.empty(
+                (num_tokens, self.hidden_size),
+                dtype=dtype,
+                device=device,
+            )
+
+    def _run_finalize(
+        self,
+        plan: MoeLoraExecutionPlan,
+        launch_config: MoeLoraLaunchConfig,
+        provider: MoeBaseProvider,
+        routes: MoeLoraRoutes,
+        base_gemm_state,
+        output: torch.Tensor,
+        down_out: torch.Tensor,
+        down_rank: torch.Tensor,
+        down_delta: torch.Tensor | None,
+        topk_output,
+        batch: MoeLoraBatch,
+        num_tokens: int,
+    ) -> torch.Tensor:
+        if plan.finalize.family is FinalizeFamily.MATERIALIZED:
+            provider.finalize(
+                base_gemm_state,
+                down_out,
+                topk_output.topk_ids,
+                topk_output.topk_weights,
+                self.routed_scaling_factor,
+                output,
+                lora_delta=(
+                    None
+                    if plan.down_b_into_base
+                    else down_delta.view(num_tokens, self.top_k, self.hidden_size)
+                ),
+            )
+            return output
+
+        # The shared finalize applies the router weights in FP32 and rounds once.
+        if topk_output.topk_weights.dtype != torch.float32:
+            raise TypeError(
+                "topk_weights must stay FP32 until the finalize applies them"
+            )
+        provider.shared_rank_finalize(
+            base_gemm_state,
+            down_rows=down_out,
+            bridge=down_rank,
+            b_down=batch.down_lora_b.flatten(0, 1),
+            routing=routes.raw(plan.finalize.is_shared_outer),
+            topk_weights=topk_output.topk_weights,
+            routed_scaling_factor=self.routed_scaling_factor,
+            output=output,
+            token_rank=self.workspace.tensor(
+                "finalize:shared_token_rank",
+                (num_tokens, down_rank.shape[1]),
+                dtype=down_rank.dtype,
+                device=down_rank.device,
+            ),
+            config=launch_config.shared_finalize,
+        )
+        return output

--- a/python/sglang/srt/lora/moe/moe_lora_runner.py
+++ b/python/sglang/srt/lora/moe/moe_lora_runner.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -10,9 +9,9 @@ from typing import TYPE_CHECKING
 import msgspec
 import torch
 
-logger = logging.getLogger(__name__)
-
+from sglang.srt.layers.moe.utils import get_moe_runner_backend
 from sglang.srt.lora.moe.activation import ActivationFn
+from sglang.srt.lora.moe.base_gemm_provider import select_provider_cls
 from sglang.srt.lora.moe.base_gemm_provider.base import (
     MoeBaseProvider,
 )
@@ -40,11 +39,9 @@ from sglang.srt.lora.moe.launch_config import (
     TileTable,
     resolve_tiles,
 )
-from sglang.srt.lora.moe.quant_info import MoeLoraBf16QuantInfo
 from sglang.srt.lora.moe.route_view import RouteView
 from sglang.srt.lora.moe.routing import MoeLoraRoutes, build_routes
 from sglang.srt.lora.moe.workspace import MoeLoraWorkspace
-from sglang.srt.runtime_context import get_lora
 
 if TYPE_CHECKING:
     from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
@@ -115,7 +112,7 @@ class MoeLoraRunner:
         self.is_gated = is_gated
         self.workspace = workspace if workspace is not None else MoeLoraWorkspace()
         self.plans: dict[Phase, SelectedPlan] = {}
-        self.tiles: dict[Phase, TileTable] = {}
+        self.tiles: dict[str, TileTable] = {}
 
     @classmethod
     def from_layer(
@@ -126,7 +123,7 @@ class MoeLoraRunner:
         is_shared_outer: bool,
         physical_rank: int,
     ) -> MoeLoraRunner:
-        cls._admit(base_layer)
+        family = cls._admit(base_layer)
         weight_device = base_layer.w2_weight.device
         if weight_device.type != "cuda":
             raise NotImplementedError("MoE LoRA requires a CUDA layer")
@@ -142,21 +139,21 @@ class MoeLoraRunner:
             activation=activation,
             hidden_size=int(base_layer.hidden_size),
             num_local_experts=int(base_layer.num_local_experts),
+            quant_family=family,
         )
-        # The shared finalize holds a token's rank-space sum in one tile of
-        # ``next_power_of_2(rank)`` columns, swept to 256.
+        # Shared finalizers hold the rank reduction in one tile, tested up to 256.
         if physical_rank > 256 and any(
             sel.plan.finalize.family is not FinalizeFamily.MATERIALIZED
             for sel in plans.values()
         ):
             raise ValueError(
-                f"the shared finalize is capped at rank 256, got {physical_rank}"
+                f"the shared finalizes are capped at rank 256, got {physical_rank}"
             )
-        vendor = get_lora().moe_lora_base_gemm
+        vendor = get_moe_runner_backend().value.removeprefix("lora_")
         runner = cls(
             providers={
                 rows: cls._build_provider(
-                    base_layer, base_gemm_rows=rows, vendor=vendor
+                    base_layer, base_gemm_rows=rows, vendor=vendor, family=family
                 )
                 for rows in dict.fromkeys(sel.base_gemm_rows for sel in plans.values())
             },
@@ -166,9 +163,9 @@ class MoeLoraRunner:
             is_gated=bool(config.is_gated),
             workspace=workspace,
         )
-        for phase, sel in plans.items():
+        for sel in plans.values():
             runner.validate_plan(sel.plan, base_gemm_rows=sel.base_gemm_rows)
-            runner.tiles[phase] = resolve_tiles(
+            runner.tiles[sel.key] = resolve_tiles(
                 architecture_value=architecture.value,
                 plan_key_name=sel.name,
                 physical_rank=physical_rank,
@@ -177,41 +174,75 @@ class MoeLoraRunner:
         return runner
 
     @staticmethod
-    def _admit(base_layer: FusedMoE) -> None:
-        from sglang.srt.layers.moe.token_dispatcher.standard import StandardDispatcher
+    def _weight_family(base_layer: FusedMoE) -> str:
         from sglang.srt.layers.quantization.unquant import UnquantizedFusedMoEMethod
 
-        if not isinstance(base_layer.quant_method, UnquantizedFusedMoEMethod):
+        quant_method = base_layer.quant_method
+        if isinstance(quant_method, UnquantizedFusedMoEMethod):
+            if (
+                base_layer.w13_weight.dtype != torch.bfloat16
+                or base_layer.w2_weight.dtype != torch.bfloat16
+            ):
+                raise NotImplementedError(
+                    "MoE LoRA on an unquantized layer requires resident BF16 " "weights"
+                )
+            return "bf16"
+        from sglang.srt.layers.quantization.fp8 import Fp8MoEMethod
+
+        if isinstance(quant_method, Fp8MoEMethod):
+            if not quant_method.block_quant or getattr(
+                quant_method, "use_mxfp8", False
+            ):
+                raise NotImplementedError(
+                    "MoE LoRA on FP8 requires 128-block weight quantization; "
+                    "per-tensor and MXFP8 layers are unsupported"
+                )
+            if base_layer.w13_weight.dtype != torch.float8_e4m3fn:
+                raise NotImplementedError(
+                    "MoE LoRA on FP8 requires resident float8_e4m3fn weights; "
+                    "a Marlin-repacked FP8 layer is unsupported"
+                )
+            return "fp8"
+        from sglang.srt.layers.quantization.modelopt_quant import (
+            ModelOptNvFp4FusedMoEMethod,
+        )
+
+        if isinstance(quant_method, ModelOptNvFp4FusedMoEMethod):
+            return "nvfp4"
+        raise NotImplementedError(
+            "MoE LoRA supports unquantized BF16, 128-block FP8, and NVFP4 "
+            f"MoE; this layer's quant method is {type(quant_method).__name__}"
+        )
+
+    @classmethod
+    def _admit(cls, base_layer: FusedMoE) -> str:
+        from sglang.srt.layers.moe.token_dispatcher.standard import StandardDispatcher
+
+        family = cls._weight_family(base_layer)
+        if not isinstance(base_layer.dispatcher, StandardDispatcher):
             raise NotImplementedError(
-                "MoE LoRA currently supports unquantized BF16 MoE only"
-            )
-        if (
-            not isinstance(base_layer.dispatcher, StandardDispatcher)
-            or base_layer.w13_weight.dtype != torch.bfloat16
-            or base_layer.w2_weight.dtype != torch.bfloat16
-        ):
-            raise NotImplementedError(
-                "MoE LoRA BF16 currently requires Standard dispatch and a "
-                "resident BF16 provider"
+                "MoE LoRA currently requires the Standard dispatcher"
             )
 
         major, minor = torch.cuda.get_device_capability()
         if major not in (9, 10):
             raise NotImplementedError(
-                f"MoE LoRA BF16 supports SM90 and SM100 only; this device is "
+                f"MoE LoRA supports SM90 and SM100 only; this device is "
                 f"sm{major}{minor}. Its base GEMMs are WGMMA (SM90) and "
                 "tcgen05 (SM100) kernels, and no other architecture implements "
                 "either -- SM120 included, despite reporting a higher major."
             )
         if base_layer.dispatcher.skip_local_expert_mapping:
             raise NotImplementedError(
-                "MoE LoRA BF16 requires EP-local expert IDs at the runner "
+                "MoE LoRA requires EP-local expert IDs at the runner "
                 "boundary, but this dispatcher keeps global IDs"
             )
         if base_layer.should_fuse_routed_scaling_factor_in_topk:
             raise NotImplementedError(
-                "MoE LoRA BF16 applies routed scaling exactly once in its own "
-                "finalize; this layer already folds it into the top-k weights"
+                "MoE LoRA applies routed scaling exactly once in its own "
+                "finalize; this layer already folds it into the top-k weights. "
+                "Under a lora backend only ModelOpt NVFP4 does that, so those "
+                "experts need --moe-runner-backend lora_marlin"
             )
         if getattr(base_layer, "with_bias", False):
             raise NotImplementedError(
@@ -221,13 +252,6 @@ class MoeLoraRunner:
         config = base_layer.moe_runner_config
         # Membership by value: `str in Enum` raises TypeError before Python 3.12.
         supported_activation = config.activation in {fn.value for fn in ActivationFn}
-        gateup_width = base_layer.w13_weight.shape[1]
-        intermediate = base_layer.w2_weight.shape[2]
-        if gateup_width != (2 if config.is_gated else 1) * intermediate:
-            raise NotImplementedError(
-                f"resident gate/up width {gateup_width} disagrees with "
-                f"is_gated={config.is_gated} at intermediate {intermediate}"
-            )
         if (
             not supported_activation
             or config.gemm1_alpha is not None
@@ -238,46 +262,10 @@ class MoeLoraRunner:
             or config.num_fused_shared_experts
         ):
             raise NotImplementedError(
-                "MoE LoRA BF16 supports SiLU or ReLU2 (gated or not) without "
+                "MoE LoRA supports SiLU or ReLU2 (gated or not) without "
                 "fused shared experts, with route weighting owned by finalize"
             )
-
-    @staticmethod
-    def select_provider_cls(
-        base_gemm_rows: str,
-        vendor: str,
-    ) -> type[MoeBaseProvider]:
-        if base_gemm_rows not in ("expert_major", "route_major"):
-            raise ValueError(
-                f"unknown MoE LoRA base-GEMM row order {base_gemm_rows!r}; "
-                "expected 'expert_major' or 'route_major'"
-            )
-        if vendor == "cutedsl":
-            from sglang.srt.lora.moe.base_gemm_provider.cutedsl_bf16 import (
-                CuteDslBf16ContiguousProvider,
-                CuteDslBf16MaskedProvider,
-            )
-
-            return (
-                CuteDslBf16MaskedProvider
-                if base_gemm_rows == "expert_major"
-                else CuteDslBf16ContiguousProvider
-            )
-        if vendor == "triton":
-            if base_gemm_rows != "route_major":
-                raise ValueError(
-                    "the triton base-GEMM provider is route-major only; "
-                    f"a plan row asked for {base_gemm_rows!r}"
-                )
-            from sglang.srt.lora.moe.base_gemm_provider.triton_bf16 import (
-                TritonBf16ContiguousProvider,
-            )
-
-            return TritonBf16ContiguousProvider
-        raise ValueError(
-            f"unknown MoE LoRA base-GEMM vendor {vendor!r}; expected "
-            "'cutedsl' or 'triton'"
-        )
+        return family
 
     @classmethod
     def _build_provider(
@@ -286,16 +274,11 @@ class MoeLoraRunner:
         *,
         base_gemm_rows: str,
         vendor: str,
+        family: str,
     ) -> MoeBaseProvider:
-        return cls.select_provider_cls(base_gemm_rows, vendor)(
-            MoeLoraBf16QuantInfo(
-                w13_weight=base_layer.w13_weight,
-                w2_weight=base_layer.w2_weight,
-                num_local_experts=int(base_layer.num_local_experts),
-                intermediate_size=int(base_layer.w2_weight.shape[2]),
-                hidden_size=int(base_layer.w2_weight.shape[1]),
-            )
-        )
+        provider_cls = select_provider_cls(base_gemm_rows, family, vendor)
+        quant_info = provider_cls.contract.quant_info_cls.from_layer(base_layer)
+        return provider_cls(quant_info)
 
     def validate_plan(self, plan: MoeLoraExecutionPlan, *, base_gemm_rows: str) -> None:
         provider = self.providers[base_gemm_rows]
@@ -322,7 +305,7 @@ class MoeLoraRunner:
 
         phase = Phase.PREFILL if batch.is_prefill else Phase.DECODE
         selected = self.plans[phase]
-        launch_config = self.tiles[phase].config_for(
+        launch_config = self.tiles[selected.key].config_for(
             dispatch_output.hidden_states.shape[0]
         )
 
@@ -393,6 +376,7 @@ class MoeLoraRunner:
             down_a_input,
             down_a_gather,
             pair_to_row,
+            topk_ids,
             batch,
         )
         output = self._run_finalize(
@@ -417,7 +401,10 @@ class MoeLoraRunner:
             if routes.shared_token is None:
                 raise ValueError("shared token route was not constructed")
             return routes.shared_token
-        if spec.family is LoraAFamily.PER_PAIR:
+        if spec.family in (
+            LoraAFamily.PER_PAIR,
+            LoraAFamily.TOKEN_DENSE,
+        ):
             return routes.raw(spec.is_shared_outer)
         return routes.aligned(spec.is_shared_outer)
 
@@ -444,9 +431,13 @@ class MoeLoraRunner:
             if spec.output_layout is BridgeLayout.TOKEN_MAJOR
             else route.topk_ids.numel()
         )
+        shape: tuple[int, ...] = (num_output_rows, weight.shape[1])
+        if spec.family is LoraAFamily.TOKEN_DENSE:
+            # One bridge plane per resident slot; per-pair B indexes the planes.
+            shape = (route.max_loras, num_output_rows, weight.shape[1])
         output = self.workspace.tensor(
             f"{name}:output",
-            (num_output_rows, weight.shape[1]),
+            shape,
             dtype=self.lora_delta_dtype,
             device=input.device,
         )
@@ -616,6 +607,24 @@ class MoeLoraRunner:
             else None
         )
         if plan.act.family is ActFamily.MATERIALIZED:
+            quant_group = provider.contract.act_quant_group
+            act_quant = None
+            if quant_group is not None:
+                # Quantize during activation to avoid a separate down-GEMM input pass.
+                act_quant = (
+                    self.workspace.tensor(
+                        "act:quant_rows",
+                        act_out.shape,
+                        dtype=torch.float8_e4m3fn,
+                        device=gateup_out.device,
+                    ),
+                    self.workspace.tensor(
+                        "act:quant_scales",
+                        (act_out.shape[0], act_out.shape[1] // quant_group),
+                        dtype=torch.float32,
+                        device=gateup_out.device,
+                    ),
+                )
             provider.act_with_delta(
                 base_gemm_state,
                 gateup_out,
@@ -628,6 +637,7 @@ class MoeLoraRunner:
                 act_out,
                 act_pairs,
                 activation=self.activation.value,
+                **({"act_quant": act_quant} if act_quant is not None else {}),
             )
             # Pair-major input needs no gather.
             return act_out, act_pairs, None, pair_to_row
@@ -664,6 +674,7 @@ class MoeLoraRunner:
         down_a_input: torch.Tensor,
         down_a_gather: torch.Tensor | None,
         pair_to_row: torch.Tensor,
+        topk_ids: torch.Tensor,
         batch: MoeLoraBatch,
     ) -> tuple[
         torch.Tensor,
@@ -817,12 +828,33 @@ class MoeLoraRunner:
             )
             return output
 
-        # The shared finalize applies the router weights in FP32 and rounds once.
+        # Both shared finalizes apply the router weights in FP32 and round once.
         if topk_output.topk_weights.dtype != torch.float32:
             raise TypeError(
                 "topk_weights must stay FP32 until the finalize applies them"
             )
-        provider.shared_rank_finalize(
+        if plan.finalize.family is FinalizeFamily.SHARED_ONE_PASS:
+            provider.shared_one_pass_finalize(
+                base_gemm_state,
+                down_rows=down_out,
+                bridge=down_rank,
+                b_down=batch.down_lora_b.flatten(0, 1),
+                routing=routes.raw(plan.finalize.is_shared_outer),
+                topk_weights=topk_output.topk_weights,
+                routed_scaling_factor=self.routed_scaling_factor,
+                output=output,
+                config=launch_config.shared_one_pass,
+            )
+            return output
+        if routes.shared_token is None:
+            raise ValueError("shared token route was not constructed")
+        token_rank = self.workspace.tensor(
+            "finalize:shared_token_rank",
+            (num_tokens, down_rank.shape[1]),
+            dtype=down_rank.dtype,
+            device=down_rank.device,
+        )
+        provider.shared_token_delta_finalize(
             base_gemm_state,
             down_rows=down_out,
             bridge=down_rank,
@@ -831,12 +863,15 @@ class MoeLoraRunner:
             topk_weights=topk_output.topk_weights,
             routed_scaling_factor=self.routed_scaling_factor,
             output=output,
-            token_rank=self.workspace.tensor(
-                "finalize:shared_token_rank",
-                (num_tokens, down_rank.shape[1]),
-                dtype=down_rank.dtype,
+            token_rank=token_rank,
+            token_delta=self.workspace.tensor(
+                "finalize:shared_token_delta",
+                (num_tokens, self.hidden_size),
+                dtype=self.lora_delta_dtype,
                 device=down_rank.device,
             ),
-            config=launch_config.shared_finalize,
+            token_route=routes.shared_token,
+            delta_config=launch_config.for_b(Site.DOWN),
+            config=launch_config.shared_token_delta,
         )
         return output

--- a/python/sglang/srt/lora/moe/quant_info.py
+++ b/python/sglang/srt/lora/moe/quant_info.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import msgspec
+import torch
+
+
+class MoeLoraBf16QuantInfo(msgspec.Struct, kw_only=True):
+    """W13: [E, S*I, H], gate first when S=2. W2: [E, H, I]."""
+
+    w13_weight: torch.Tensor
+    w2_weight: torch.Tensor
+    num_local_experts: int
+    intermediate_size: int
+    hidden_size: int

--- a/python/sglang/srt/lora/moe/quant_info.py
+++ b/python/sglang/srt/lora/moe/quant_info.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import msgspec
 import torch
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
 
 
 class MoeLoraBf16QuantInfo(msgspec.Struct, kw_only=True):
@@ -12,3 +17,117 @@ class MoeLoraBf16QuantInfo(msgspec.Struct, kw_only=True):
     num_local_experts: int
     intermediate_size: int
     hidden_size: int
+
+    @classmethod
+    def from_layer(cls, base_layer: FusedMoE) -> MoeLoraBf16QuantInfo:
+        return cls(
+            w13_weight=base_layer.w13_weight,
+            w2_weight=base_layer.w2_weight,
+            num_local_experts=int(base_layer.num_local_experts),
+            intermediate_size=int(base_layer.w2_weight.shape[2]),
+            hidden_size=int(base_layer.w2_weight.shape[1]),
+        )
+
+
+class MoeLoraFp8QuantInfo(msgspec.Struct, kw_only=True):
+    """FP8 weights in standard layout, with FP32 inverse block scales."""
+
+    w13_weight: torch.Tensor  # [E_local, S * I, H] float8_e4m3fn
+    w13_scale: torch.Tensor  # [E_local, ceil(S*I/block_n), ceil(H/block_k)]
+    w2_weight: torch.Tensor  # [E_local, H, I] float8_e4m3fn
+    w2_scale: torch.Tensor  # [E_local, ceil(H/block_n), ceil(I/block_k)]
+    block_shape: tuple[int, int]
+    num_local_experts: int
+    intermediate_size: int
+    hidden_size: int
+
+    @classmethod
+    def from_layer(cls, base_layer: FusedMoE) -> MoeLoraFp8QuantInfo:
+        quant_info = cls(
+            w13_weight=base_layer.w13_weight,
+            w13_scale=base_layer.w13_weight_scale_inv,
+            w2_weight=base_layer.w2_weight,
+            w2_scale=base_layer.w2_weight_scale_inv,
+            block_shape=tuple(base_layer.quant_method.weight_block_size),
+            num_local_experts=int(base_layer.num_local_experts),
+            intermediate_size=int(base_layer.w2_weight.shape[2]),
+            hidden_size=int(base_layer.w2_weight.shape[1]),
+        )
+        admit_fp8_block_weights(quant_info)
+        return quant_info
+
+
+def admit_fp8_block_weights(quant_info: MoeLoraFp8QuantInfo) -> None:
+    """Validate 128x128 weight blocks and scales once when binding weights."""
+    if tuple(quant_info.block_shape) != (128, 128):
+        raise NotImplementedError(
+            f"MoE LoRA FP8 supports [128, 128] weight blocks, got "
+            f"{list(quant_info.block_shape)}"
+        )
+    for name, value in (
+        ("hidden_size", quant_info.hidden_size),
+        ("intermediate_size", quant_info.intermediate_size),
+    ):
+        if value % 128:
+            raise NotImplementedError(
+                f"MoE LoRA FP8 requires {name} % 128 == 0, got {value}"
+            )
+    for name, scale, rows, cols in (
+        (
+            "w13_scale",
+            quant_info.w13_scale,
+            quant_info.w13_weight.shape[1],
+            quant_info.hidden_size,
+        ),
+        (
+            "w2_scale",
+            quant_info.w2_scale,
+            quant_info.hidden_size,
+            quant_info.intermediate_size,
+        ),
+    ):
+        expected = (quant_info.num_local_experts, -(-rows // 128), -(-cols // 128))
+        if scale.dtype != torch.float32 or tuple(scale.shape) != expected:
+            raise ValueError(
+                f"{name} must be fp32 {list(expected)}, got {scale.dtype} "
+                f"{tuple(scale.shape)}"
+            )
+
+
+# Marlin's packed weights do not use the standard row-domain layout.
+StandardLayoutQuantInfo = MoeLoraBf16QuantInfo | MoeLoraFp8QuantInfo
+
+
+class MoeLoraNvFp4MarlinQuantInfo(msgspec.Struct, kw_only=True):
+    """Marlin W4A16: INT32 packed weights, E4M3 group-16 and FP32 global scales."""
+
+    w13_qweight: torch.Tensor
+    w2_qweight: torch.Tensor
+    w13_scales: torch.Tensor
+    w2_scales: torch.Tensor
+    w13_global_scale: torch.Tensor
+    w2_global_scale: torch.Tensor
+    num_local_experts: int
+    intermediate_size: int
+    hidden_size: int
+
+    @classmethod
+    def from_layer(cls, base_layer: FusedMoE) -> MoeLoraNvFp4MarlinQuantInfo:
+        # Load may already have repacked the weights; INT32 marks Marlin format.
+        if base_layer.w13_weight.dtype != torch.int32:
+            from sglang.srt.layers.quantization.marlin_utils_fp4 import (
+                prepare_moe_nvfp4_layer_for_marlin,
+            )
+
+            prepare_moe_nvfp4_layer_for_marlin(base_layer)
+        return cls(
+            w13_qweight=base_layer.w13_weight,
+            w2_qweight=base_layer.w2_weight,
+            w13_scales=base_layer.w13_weight_scale,
+            w2_scales=base_layer.w2_weight_scale,
+            w13_global_scale=base_layer.w13_weight_scale_2,
+            w2_global_scale=base_layer.w2_weight_scale_2,
+            num_local_experts=int(base_layer.num_local_experts),
+            intermediate_size=int(base_layer.intermediate_size_per_partition),
+            hidden_size=int(base_layer.hidden_size),
+        )

--- a/python/sglang/srt/lora/moe/route_view.py
+++ b/python/sglang/srt/lora/moe/route_view.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from enum import Enum
+
+import msgspec
+import torch
+
+
+class RouteViewKind(str, Enum):
+    RAW = "raw"
+    ALIGNED = "aligned"
+
+
+class RouteView(msgspec.Struct, frozen=True, kw_only=True):
+    view: RouteViewKind
+    block_size: int
+    topk_ids: torch.Tensor
+    token_lora_mapping: torch.Tensor
+    num_local_experts: int
+    is_shared_outer: bool
+    max_loras: int
+    maybe_sorted_pair_ids: torch.Tensor | None = None
+    maybe_block_virtual_expert_ids: torch.Tensor | None = None
+    maybe_num_pairs_post_padded: torch.Tensor | None = None
+
+    @property
+    def lora_experts_per_adapter(self) -> int:
+        return 1 if self.is_shared_outer else self.num_local_experts
+
+    @property
+    def num_virtual_experts(self) -> int:
+        return self.lora_experts_per_adapter * self.max_loras
+
+    def _require(self, value, field: str, needed: RouteViewKind):
+        if value is None:
+            raise ValueError(
+                f"route view {self.view.value!r} did not build {field}; the "
+                f"consumer must request view {needed.value!r} or derive it inline"
+            )
+        return value
+
+    @property
+    def sorted_pair_ids(self) -> torch.Tensor:
+        return self._require(
+            self.maybe_sorted_pair_ids, "sorted_pair_ids", RouteViewKind.ALIGNED
+        )
+
+    @property
+    def block_virtual_expert_ids(self) -> torch.Tensor:
+        return self._require(
+            self.maybe_block_virtual_expert_ids,
+            "block_virtual_expert_ids",
+            RouteViewKind.ALIGNED,
+        )
+
+    @property
+    def num_pairs_post_padded(self) -> torch.Tensor:
+        return self._require(
+            self.maybe_num_pairs_post_padded,
+            "num_pairs_post_padded",
+            RouteViewKind.ALIGNED,
+        )

--- a/python/sglang/srt/lora/moe/routing.py
+++ b/python/sglang/srt/lora/moe/routing.py
@@ -1,0 +1,505 @@
+"""Build raw or block-aligned routes keyed by adapter and LoRA expert."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+import triton
+
+from sglang.kernels.ops.moe.virtual_experts import (
+    _align_block_size_jit,
+)
+from sglang.srt.lora.moe.execution_plan import (
+    MoeLoraExecutionPlan,
+    RouteBuilderFamily,
+    RouteRequirement,
+)
+from sglang.srt.lora.moe.kernels.routing import (
+    _build_virtual_topk_ids_kernel,
+    _hist_kernel,
+    _place_kernel,
+    _scan_kernel,
+    _segment_token_route_kernel,
+)
+from sglang.srt.lora.moe.route_view import RouteView, RouteViewKind
+from sglang.srt.lora.moe.workspace import MoeLoraWorkspace
+
+# Use Triton beyond these crossover points; CUDA alignment also caps at 8192 buckets.
+FUSED_ALIGN_MIN_VIRTUAL_EXPERTS = 8192
+FUSED_ALIGN_MIN_PAIRS = 16384
+
+# Tuning evidence: configs/README.md.
+HIST_BLOCK = 512
+HIST_WARPS = 8
+EXPAND_BLOCK = 128
+EXPAND_WARPS = 4
+SCAN_CHUNK = 2048
+SCAN_WARPS = 4
+
+# Use in-block histograms to reduce global atomics within these limits.
+COUNT_MAX_BINS = 512
+COUNT_MIN_PAIRS = 16384
+CLAIM_MIN_PAIRS_PER_BUCKET = 12288
+
+
+def count_bins(num_buckets: int, num_pairs: int) -> int:
+    # 0 = one atomic per pair; otherwise in-block counting over 2^k bins.
+    if num_buckets >= COUNT_MAX_BINS or num_pairs < COUNT_MIN_PAIRS:
+        return 0
+    return 1 << num_buckets.bit_length()  # the extra bin holds the masked-off lanes
+
+
+def _routing_capacity(
+    num_pairs: int,
+    block_size: int,
+    num_virtual_experts: int,
+) -> int:
+    if num_pairs == 0:
+        return 0
+    max_nonempty_buckets = min(num_pairs, num_virtual_experts + 1)
+    upper_bound = num_pairs + max_nonempty_buckets * (block_size - 1)
+    return triton.cdiv(triton.cdiv(upper_bound, block_size) * block_size, 4) * 4
+
+
+def _plan_scratch(
+    workspace: MoeLoraWorkspace,
+    *,
+    prefix: str,
+    num_buckets: int,
+    capacity: int,
+    block_size: int,
+    device: torch.device,
+) -> dict[str, object]:
+    # The scan clears counts for the next replay.
+    scratch: dict[str, object] = {
+        "num_buckets": num_buckets,
+        "capacity": capacity,
+        "counts": workspace.tensor(
+            f"{prefix}:counts",
+            (num_buckets,),
+            dtype=torch.int32,
+            device=device,
+            zero_on_first_allocation=True,
+        ),
+        "block_cumulative": workspace.tensor(
+            f"{prefix}:block_cumulative",
+            (num_buckets + 1,),
+            dtype=torch.int32,
+            device=device,
+        ),
+        "cursor": workspace.tensor(
+            f"{prefix}:cursor", (num_buckets,), dtype=torch.int32, device=device
+        ),
+        "bucket_end": workspace.tensor(
+            f"{prefix}:bucket_end", (num_buckets,), dtype=torch.int32, device=device
+        ),
+        "padded_pairs": workspace.tensor(
+            f"{prefix}:padded_pairs", (1,), dtype=torch.int32, device=device
+        ),
+    }
+    scratch["sorted"] = workspace.tensor(
+        f"{prefix}:sorted", (capacity,), dtype=torch.int32, device=device
+    )
+    scratch["block_ids"] = workspace.tensor(
+        f"{prefix}:block_ids",
+        (capacity // block_size,),
+        dtype=torch.int32,
+        device=device,
+    )
+    return scratch
+
+
+def _build_aligned(
+    topk_ids: torch.Tensor,
+    token_lora_mapping: torch.Tensor,
+    *,
+    num_local_experts: int,
+    max_loras: int,
+    block_size: int,
+    workspace: MoeLoraWorkspace,
+    tensor_prefix: str,
+    is_shared_outer: bool,
+) -> RouteView:
+    from sglang.kernels.jit.utils import is_arch_support_pdl
+
+    num_pairs = topk_ids.numel()
+    name = "shared" if is_shared_outer else "per_expert"
+    virtual = max_loras if is_shared_outer else num_local_experts * max_loras
+    capacity = _routing_capacity(num_pairs, block_size, virtual)
+    if virtual + 1 >= 2**31 or capacity >= 2**31:
+        raise ValueError(
+            f"aligned routes use int32 plan math: {name} needs {virtual + 1} "
+            f"buckets and {capacity} slots, both must be < 2**31"
+        )
+    own = _plan_scratch(
+        workspace,
+        prefix=f"{tensor_prefix}:{name}",
+        num_buckets=virtual + 1,
+        capacity=capacity,
+        block_size=block_size,
+        device=topk_ids.device,
+    )
+    num_buckets = own["num_buckets"]
+    bound = num_local_experts if is_shared_outer else 0
+    experts_per_adapter = 1 if is_shared_outer else num_local_experts
+
+    use_pdl = is_arch_support_pdl()
+    pdl_kwargs = {"launch_pdl": True} if use_pdl else {}
+    _hist_kernel[(triton.cdiv(max(num_pairs, 1), HIST_BLOCK),)](
+        topk_ids,
+        token_lora_mapping,
+        own["counts"],
+        num_pairs,
+        bound,
+        NUM_BUCKETS=num_buckets,
+        LORA_EXPERTS_PER_ADAPTER=experts_per_adapter,
+        MAX_LORAS=max_loras,
+        TOP_K=topk_ids.shape[1],
+        SHARED_OUTER=is_shared_outer,
+        BLOCK=HIST_BLOCK,
+        BINS=count_bins(num_buckets, num_pairs),
+        USE_PDL=use_pdl,
+        num_warps=HIST_WARPS,
+    )
+    _scan_kernel[(1,)](
+        own["counts"],
+        own["block_cumulative"],
+        own["cursor"],
+        own["bucket_end"],
+        own["padded_pairs"],
+        num_buckets,
+        BLOCK_SIZE_M=block_size,
+        CHUNK=SCAN_CHUNK,
+        USE_PDL=use_pdl,
+        num_warps=SCAN_WARPS,
+        **pdl_kwargs,
+    )
+    num_blocks = own["capacity"] // block_size
+    label_programs = triton.cdiv(max(num_blocks, 1), EXPAND_BLOCK)
+    _place_kernel[(label_programs + triton.cdiv(max(num_pairs, 1), EXPAND_BLOCK),)](
+        topk_ids,
+        token_lora_mapping,
+        own["cursor"],
+        own["bucket_end"],
+        own["block_cumulative"],
+        own["sorted"],
+        own["block_ids"],
+        num_blocks,
+        label_programs,
+        num_pairs,
+        bound,
+        NUM_BUCKETS=num_buckets,
+        NUM_VIRTUAL=num_buckets - 1,
+        LORA_EXPERTS_PER_ADAPTER=experts_per_adapter,
+        MAX_LORAS=max_loras,
+        TOP_K=topk_ids.shape[1],
+        SHARED_OUTER=is_shared_outer,
+        BLOCK=EXPAND_BLOCK,
+        BLOCK_SIZE_M=block_size,
+        # Include the sentinel in the binary-search depth.
+        SEARCH_STEPS=num_buckets.bit_length(),
+        CLAIM_PER_BLOCK=num_pairs >= CLAIM_MIN_PAIRS_PER_BUCKET * num_buckets,
+        USE_PDL=use_pdl,
+        num_warps=EXPAND_WARPS,
+        **pdl_kwargs,
+    )
+    return RouteView(
+        view=RouteViewKind.ALIGNED,
+        block_size=block_size,
+        topk_ids=topk_ids,
+        token_lora_mapping=token_lora_mapping,
+        num_local_experts=num_local_experts,
+        is_shared_outer=is_shared_outer,
+        max_loras=max_loras,
+        maybe_sorted_pair_ids=own["sorted"],
+        maybe_block_virtual_expert_ids=own["block_ids"],
+        maybe_num_pairs_post_padded=own["padded_pairs"],
+    )
+
+
+def _build_virtual_topk_ids(
+    topk_ids: torch.Tensor,
+    token_lora_mapping: torch.Tensor,
+    num_local_experts: int,
+    max_loras: int,
+    is_shared_outer: bool = False,
+) -> torch.Tensor:
+    virtual_topk_ids = torch.empty_like(topk_ids)
+    if topk_ids.numel() == 0:
+        return virtual_topk_ids
+
+    block_size = 1024
+    _build_virtual_topk_ids_kernel[(triton.cdiv(topk_ids.numel(), block_size),)](
+        topk_ids,
+        token_lora_mapping,
+        virtual_topk_ids,
+        topk_ids.numel(),
+        num_local_experts,
+        LORA_EXPERTS_PER_ADAPTER=1 if is_shared_outer else num_local_experts,
+        MAX_LORAS=max_loras,
+        TOP_K=topk_ids.shape[1],
+        SHARED_OUTER=is_shared_outer,
+        BLOCK_SIZE=block_size,
+    )
+    return virtual_topk_ids
+
+
+def build_virtual_expert_routing(
+    topk_ids: torch.Tensor,
+    token_lora_mapping: torch.Tensor,
+    *,
+    num_local_experts: int,
+    max_loras: int,
+    block_size: int,
+    is_shared_outer: bool = False,
+    view: RouteViewKind = RouteViewKind.ALIGNED,
+    workspace: MoeLoraWorkspace | None = None,
+    tensor_prefix: str | None = None,
+) -> RouteView:
+    if view not in RouteViewKind:
+        raise ValueError(
+            f"unknown route view {view!r}; expected one of "
+            f"{tuple(kind.value for kind in RouteViewKind)}"
+        )
+    view = RouteViewKind(view)
+    common = {
+        "view": view,
+        "block_size": block_size,
+        "topk_ids": topk_ids,
+        "token_lora_mapping": token_lora_mapping,
+        "num_local_experts": num_local_experts,
+        "is_shared_outer": is_shared_outer,
+        "max_loras": max_loras,
+    }
+    lora_experts_per_adapter = 1 if is_shared_outer else num_local_experts
+    if view is RouteViewKind.RAW:
+        route = RouteView(**common)
+        return route
+
+    num_virtual = lora_experts_per_adapter * max_loras
+    if (
+        num_virtual >= FUSED_ALIGN_MIN_VIRTUAL_EXPERTS
+        or topk_ids.numel() >= FUSED_ALIGN_MIN_PAIRS
+    ):
+        route = _build_aligned(
+            topk_ids,
+            token_lora_mapping,
+            num_local_experts=num_local_experts,
+            max_loras=max_loras,
+            block_size=block_size,
+            workspace=workspace,
+            tensor_prefix=tensor_prefix,
+            is_shared_outer=is_shared_outer,
+        )
+        return route
+
+    virtual_topk_ids = _build_virtual_topk_ids(
+        topk_ids,
+        token_lora_mapping,
+        num_local_experts,
+        max_loras,
+        is_shared_outer=is_shared_outer,
+    )
+    sorted_pair_ids, block_virtual_expert_ids, num_pairs_post_padded = (
+        _align_block_size_jit(virtual_topk_ids, block_size, num_virtual)
+    )
+    route = RouteView(
+        **common,
+        maybe_sorted_pair_ids=sorted_pair_ids,
+        maybe_block_virtual_expert_ids=block_virtual_expert_ids,
+        maybe_num_pairs_post_padded=num_pairs_post_padded,
+    )
+    return route
+
+
+@dataclass(frozen=True, slots=True)
+class MoeLoraRoutes:
+    raw_per_expert: RouteView | None = None
+    raw_shared_outer: RouteView | None = None
+    aligned_per_expert: RouteView | None = None
+    aligned_shared_outer: RouteView | None = None
+    shared_token: RouteView | None = None
+
+    def raw(self, is_shared_outer: bool) -> RouteView:
+        if is_shared_outer:
+            return self._require(self.raw_shared_outer, "raw_shared_outer")
+        return self._require(self.raw_per_expert, "raw_per_expert")
+
+    def aligned(self, is_shared_outer: bool) -> RouteView:
+        if is_shared_outer:
+            return self._require(self.aligned_shared_outer, "aligned_shared_outer")
+        return self._require(self.aligned_per_expert, "aligned_per_expert")
+
+    @staticmethod
+    def _require(route: RouteView | None, field: str) -> RouteView:
+        if route is None:
+            raise ValueError(f"the execution plan did not request {field}")
+        return route
+
+
+def _build_segment_token_route(
+    *,
+    seg_indptr: torch.Tensor,
+    token_lora_mapping: torch.Tensor,
+    num_tokens: int,
+    num_local_experts: int,
+    max_loras: int,
+    block_size: int,
+    workspace: MoeLoraWorkspace,
+) -> RouteView:
+    """Pad each request segment into blocks sharing one adapter slot."""
+    num_segments = seg_indptr.shape[0] - 1
+    # Each request adds at most block_size - 1 padding rows.
+    capacity = triton.cdiv(num_tokens + num_segments * (block_size - 1), block_size)
+    capacity = triton.cdiv(capacity * block_size, 4) * 4
+    device = token_lora_mapping.device
+    sorted_ids = workspace.tensor(
+        "route:shared_token:sorted", (capacity,), dtype=torch.int32, device=device
+    )
+    block_ids = workspace.tensor(
+        "route:shared_token:block_ids",
+        (capacity // block_size,),
+        dtype=torch.int32,
+        device=device,
+    )
+    padded = workspace.tensor(
+        "route:shared_token:padded_pairs", (1,), dtype=torch.int32, device=device
+    )
+    # Represent tokens as top-1 pairs with the shared LoRA expert 0.
+    token_experts = workspace.tensor(
+        "route:shared_token_experts",
+        (num_tokens, 1),
+        dtype=torch.int32,
+        device=device,
+        zero_on_first_allocation=True,
+    )
+    _segment_token_route_kernel[(1,)](
+        seg_indptr,
+        token_lora_mapping,
+        sorted_ids,
+        block_ids,
+        padded,
+        num_segments,
+        num_tokens,
+        capacity // block_size,
+        BLOCK_SIZE_M=block_size,
+        CHUNK=256,
+        num_warps=4,
+    )
+    return RouteView(
+        view=RouteViewKind.ALIGNED,
+        block_size=block_size,
+        topk_ids=token_experts,
+        token_lora_mapping=token_lora_mapping,
+        num_local_experts=num_local_experts,
+        is_shared_outer=True,
+        max_loras=max_loras,
+        maybe_sorted_pair_ids=sorted_ids,
+        maybe_block_virtual_expert_ids=block_ids,
+        maybe_num_pairs_post_padded=padded,
+    )
+
+
+def build_routes(
+    plan: MoeLoraExecutionPlan,
+    *,
+    topk_ids: torch.Tensor,
+    token_lora_mapping: torch.Tensor,
+    seg_indptr: torch.Tensor,
+    num_local_experts: int,
+    max_loras: int,
+    block_size: int,
+    workspace: MoeLoraWorkspace,
+) -> MoeLoraRoutes:
+    requirements = plan.route_requirements()
+    values: dict[str, object] = {}
+    if RouteRequirement.RAW_PER_EXPERT in requirements:
+        values["raw_per_expert"] = build_virtual_expert_routing(
+            topk_ids,
+            token_lora_mapping,
+            num_local_experts=num_local_experts,
+            max_loras=max_loras,
+            block_size=block_size,
+            view=RouteViewKind.RAW,
+        )
+    if RouteRequirement.RAW_SHARED_OUTER in requirements:
+        values["raw_shared_outer"] = build_virtual_expert_routing(
+            topk_ids,
+            token_lora_mapping,
+            num_local_experts=num_local_experts,
+            is_shared_outer=True,
+            max_loras=max_loras,
+            block_size=block_size,
+            view=RouteViewKind.RAW,
+        )
+
+    if plan.route_builder is RouteBuilderFamily.PARALLEL_SHARED_OUTER:
+
+        def _build_per_expert() -> RouteView:
+            return build_virtual_expert_routing(
+                topk_ids,
+                token_lora_mapping,
+                num_local_experts=num_local_experts,
+                max_loras=max_loras,
+                block_size=block_size,
+                view=RouteViewKind.ALIGNED,
+                workspace=workspace,
+                tensor_prefix="route:aligned_per_expert",
+            )
+
+        def _build_shared() -> None:
+            values["aligned_shared_outer"] = build_virtual_expert_routing(
+                topk_ids,
+                token_lora_mapping,
+                num_local_experts=num_local_experts,
+                is_shared_outer=True,
+                max_loras=max_loras,
+                block_size=block_size,
+                view=RouteViewKind.ALIGNED,
+                workspace=workspace,
+                tensor_prefix="route:aligned_shared_outer",
+            )
+
+        values["aligned_per_expert"] = workspace.run_parallel(
+            name="route:parallel",
+            device=topk_ids.device,
+            compute=_build_per_expert,
+            side=_build_shared,
+        )
+    else:
+        if RouteRequirement.ALIGNED_PER_EXPERT in requirements:
+            values["aligned_per_expert"] = build_virtual_expert_routing(
+                topk_ids,
+                token_lora_mapping,
+                num_local_experts=num_local_experts,
+                max_loras=max_loras,
+                block_size=block_size,
+                view=RouteViewKind.ALIGNED,
+                workspace=workspace,
+                tensor_prefix="route:aligned_per_expert",
+            )
+        if RouteRequirement.ALIGNED_SHARED_OUTER in requirements:
+            values["aligned_shared_outer"] = build_virtual_expert_routing(
+                topk_ids,
+                token_lora_mapping,
+                num_local_experts=num_local_experts,
+                is_shared_outer=True,
+                max_loras=max_loras,
+                block_size=block_size,
+                view=RouteViewKind.ALIGNED,
+                workspace=workspace,
+                tensor_prefix="route:aligned_shared_outer",
+            )
+
+    if RouteRequirement.SHARED_TOKEN_PLAN in requirements:
+        values["shared_token"] = _build_segment_token_route(
+            seg_indptr=seg_indptr,
+            token_lora_mapping=token_lora_mapping,
+            num_tokens=topk_ids.shape[0],
+            num_local_experts=num_local_experts,
+            max_loras=max_loras,
+            block_size=block_size,
+            workspace=workspace,
+        )
+    return MoeLoraRoutes(**values)

--- a/python/sglang/srt/lora/moe/workspace.py
+++ b/python/sglang/srt/lora/moe/workspace.py
@@ -17,6 +17,7 @@ class MoeLoraWorkspace:
         self._eager_buffers: dict[
             tuple[str, torch.dtype, torch.device], torch.Tensor
         ] = {}
+        self._iota: dict[torch.device, torch.Tensor] = {}
         self._streams: dict[torch.device, torch.cuda.Stream] = {}
         self._events: dict[tuple[torch.device, str], torch.cuda.Event] = {}
         self._graph_mode = False
@@ -69,6 +70,35 @@ class MoeLoraWorkspace:
                 self._eager_buffers[key] = storage
             tensor = storage[:elements].view(resolved_shape)
         return tensor
+
+    def iota(self, n: int, device: torch.device | str) -> torch.Tensor:
+        """Return an int32 identity map [0..n), filled outside capture.
+
+        Graph mode keys the map by length so a captured pointer is never
+        freed by later growth; eager mode grows one shared buffer.
+        """
+        resolved_device = torch.device(device)
+        if self._graph_mode:
+            key = ("iota", (n,), torch.int32, resolved_device)
+            tensor = self._graph_buffers.get(key)
+            if tensor is None:
+                if self._capturing(resolved_device):
+                    raise RuntimeError(
+                        "the MoE LoRA iota buffer was not warmed before CUDA capture"
+                    )
+                tensor = torch.arange(n, dtype=torch.int32, device=resolved_device)
+                self._graph_buffers[key] = tensor
+            return tensor
+        buffer = self._iota.get(resolved_device)
+        if buffer is None or buffer.numel() < n:
+            if self._capturing(resolved_device):
+                raise RuntimeError(
+                    "the MoE LoRA iota buffer cannot grow inside CUDA capture"
+                )
+            capacity = max(n, 2 * buffer.numel() if buffer is not None else n)
+            buffer = torch.arange(capacity, dtype=torch.int32, device=resolved_device)
+            self._iota[resolved_device] = buffer
+        return buffer[:n]
 
     def side_stream(self, device: torch.device | str) -> torch.cuda.Stream:
         # Calls on one device must fork from the same stream.

--- a/python/sglang/srt/lora/moe/workspace.py
+++ b/python/sglang/srt/lora/moe/workspace.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from typing import TypeVar
+
+import torch
+
+_T = TypeVar("_T")
+
+
+class MoeLoraWorkspace:
+
+    def __init__(self) -> None:
+        self._graph_buffers: dict[
+            tuple[str, tuple[int, ...], torch.dtype, torch.device], torch.Tensor
+        ] = {}
+        self._eager_buffers: dict[
+            tuple[str, torch.dtype, torch.device], torch.Tensor
+        ] = {}
+        self._streams: dict[torch.device, torch.cuda.Stream] = {}
+        self._events: dict[tuple[torch.device, str], torch.cuda.Event] = {}
+        self._graph_mode = False
+
+    def begin_forward(self, *, graph_mode: bool) -> None:
+        self._graph_mode = bool(graph_mode)
+
+    @staticmethod
+    def _capturing(device: torch.device) -> bool:
+        return device.type == "cuda" and torch.cuda.is_current_stream_capturing()
+
+    def tensor(
+        self,
+        name: str,
+        shape: Sequence[int],
+        *,
+        dtype: torch.dtype,
+        device: torch.device | str,
+        zero_on_first_allocation: bool = False,
+    ) -> torch.Tensor:
+        # Per-forward clears belong to the caller so graphs replay them.
+        resolved_device = torch.device(device)
+        resolved_shape = tuple(int(dim) for dim in shape)
+        if self._graph_mode:
+            key = (name, resolved_shape, dtype, resolved_device)
+            tensor = self._graph_buffers.get(key)
+            if tensor is None:
+                if self._capturing(resolved_device):
+                    raise RuntimeError(
+                        "MoE LoRA workspace was not warmed before CUDA capture: "
+                        f"missing {name!r} {resolved_shape} {dtype} on "
+                        f"{resolved_device}"
+                    )
+                factory = torch.zeros if zero_on_first_allocation else torch.empty
+                tensor = factory(resolved_shape, dtype=dtype, device=resolved_device)
+                self._graph_buffers[key] = tensor
+        else:
+            key = (name, dtype, resolved_device)
+            elements = 1
+            for dimension in resolved_shape:
+                elements *= dimension
+            storage = self._eager_buffers.get(key)
+            if storage is None or storage.numel() < elements:
+                if self._capturing(resolved_device):
+                    raise RuntimeError(
+                        "an eager MoE LoRA workspace cannot grow inside " "CUDA capture"
+                    )
+                factory = torch.zeros if zero_on_first_allocation else torch.empty
+                storage = factory((elements,), dtype=dtype, device=resolved_device)
+                self._eager_buffers[key] = storage
+            tensor = storage[:elements].view(resolved_shape)
+        return tensor
+
+    def side_stream(self, device: torch.device | str) -> torch.cuda.Stream:
+        # Calls on one device must fork from the same stream.
+        resolved_device = torch.device(device)
+        stream = self._streams.get(resolved_device)
+        if stream is None:
+            if self._capturing(resolved_device):
+                raise RuntimeError(
+                    "MoE LoRA side stream was not created before CUDA capture"
+                )
+            stream = torch.cuda.Stream(device=resolved_device)
+            self._streams[resolved_device] = stream
+        return stream
+
+    def event(self, device: torch.device | str, name: str) -> torch.cuda.Event:
+        resolved_device = torch.device(device)
+        key = (resolved_device, name)
+        event = self._events.get(key)
+        if event is None:
+            if self._capturing(resolved_device):
+                raise RuntimeError(
+                    f"MoE LoRA event was not created before CUDA capture: {name}"
+                )
+            event = torch.cuda.Event()
+            self._events[key] = event
+        return event
+
+    def run_parallel(
+        self,
+        *,
+        name: str,
+        device: torch.device,
+        compute: Callable[[], _T],
+        side: Callable[[], object],
+    ) -> _T:
+        if device.type != "cuda":
+            side()
+            return compute()
+
+        current = torch.cuda.current_stream(device)
+        side_stream = self.side_stream(device)
+        ready = self.event(device, f"{name}:ready")
+        done = self.event(device, f"{name}:done")
+
+        ready.record(current)
+        side_stream.wait_event(ready)
+        with torch.cuda.stream(side_stream):
+            side()
+            done.record(side_stream)
+        result = compute()
+        current.wait_event(done)
+        return result

--- a/python/sglang/srt/lora/utils.py
+++ b/python/sglang/srt/lora/utils.py
@@ -88,6 +88,8 @@ class LoRABatchInfo:
     # Computed from Python lists in prepare_lora_batch to avoid GPU sync.
     has_active_lora: bool = False
 
+    is_prefill: bool = False
+
     # Per-request segment indptrs, shape (bs + 1,). Required by MoE virtual
     # experts which map tokens to requests regardless of the dense-LoRA
     # backend's internal segmentation.  For the triton backend these are

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -280,6 +280,7 @@ MOE_RUNNER_BACKEND_CHOICES = [
     "marlin",
     "humming",
     "experimental_sgl_marlin",
+    "lora",  # MoE LoRA runner; requires --enable-lora
     "hpc_ops",  # HPC-Ops (https://github.com/Tencent/hpc-ops), FP8 MoE on Hopper (SM90) only
     "megamoe",
 ]
@@ -3016,6 +3017,14 @@ class ServerArgs:
         "Enable virtual expert computation for MoE models. When set, the model will use virtual expert computation.",
         NS("lora"),
     ] = False
+    moe_lora_base_gemm: A[
+        str,
+        Arg(
+            help="Kernel vendor for the MoE LoRA base GEMMs.",
+            choices=["cutedsl", "triton"],
+        ),
+        NS("lora"),
+    ] = "cutedsl"
     lora_strict_loading: A[
         bool,
         Arg(
@@ -9986,6 +9995,70 @@ class ServerArgs:
 
     def check_lora_server_args(self):
         assert self.max_loras_per_batch > 0, "max_loras_per_batch must be positive"
+
+        if (
+            self.speculative_algorithm is not None
+            and self.speculative_moe_runner_backend == "lora"
+        ):
+            # Draft models have no LoRA adapters.
+            raise ValueError(
+                "--speculative-moe-runner-backend lora is not supported: the "
+                "LoRA MoE runner serves adapter traffic on the target model"
+            )
+
+        if self.moe_runner_backend == "lora":
+            # The LoRA MoE runner has no base-model-only mode of its own; it is
+            # selected per server and only ever runs on a LoRA-enabled engine.
+            if not (self.enable_lora or self.lora_paths):
+                raise ValueError(
+                    "--moe-runner-backend lora requires --enable-lora "
+                    "(or --lora-paths)"
+                )
+            # These two mirror the engine's layer-attach admission checks
+            # (unquantized BF16 experts, Standard dispatch); assert them at
+            # startup so the failure names the flag instead of surfacing as a
+            # NotImplementedError during layer construction.
+            if self.quantization is not None:
+                raise ValueError(
+                    "--moe-runner-backend lora currently supports unquantized "
+                    f"BF16 MoE only, got --quantization {self.quantization}"
+                )
+            if self.moe_a2a_backend != "none":
+                raise ValueError(
+                    "--moe-runner-backend lora requires Standard dispatch, "
+                    f"got --moe-a2a-backend {self.moe_a2a_backend}"
+                )
+            if self.ep_join_mode is not None:
+                raise ValueError(
+                    "--moe-runner-backend lora does not yet support elastic EP"
+                )
+            if self.enable_dp_attention and self.dp_size > 1:
+                raise ValueError(
+                    "--moe-runner-backend lora does not yet support DP-attention "
+                    "with dp_size > 1"
+                )
+            if (
+                self.enable_eplb
+                or self.init_expert_location != "trivial"
+                or self.ep_num_redundant_experts > 0
+            ):
+                raise ValueError(
+                    "--moe-runner-backend lora currently requires trivial expert "
+                    "placement without EPLB or redundant experts"
+                )
+            if self.enable_pdmux:
+                raise ValueError(
+                    "--moe-runner-backend lora does not yet support PD-multiplexing: "
+                    "its fused-align routing scratch is cached per "
+                    "(device, num_buckets) and is not safe under concurrent "
+                    "prefill/decode streams"
+                )
+            if self.enable_two_batch_overlap:
+                raise ValueError(
+                    "--moe-runner-backend lora does not yet support two-batch overlap: "
+                    "its batch metadata and graph-stable MoE workspace are shared "
+                    "across layers and are not safe for concurrent child forwards"
+                )
 
         # Enable LoRA if any LoRA paths are provided for backward compatibility.
         if self.lora_paths:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -280,7 +280,9 @@ MOE_RUNNER_BACKEND_CHOICES = [
     "marlin",
     "humming",
     "experimental_sgl_marlin",
-    "lora",  # MoE LoRA runner; requires --enable-lora
+    "lora_cutedsl",
+    "lora_triton",
+    "lora_marlin",
     "hpc_ops",  # HPC-Ops (https://github.com/Tencent/hpc-ops), FP8 MoE on Hopper (SM90) only
     "megamoe",
 ]
@@ -3017,14 +3019,6 @@ class ServerArgs:
         "Enable virtual expert computation for MoE models. When set, the model will use virtual expert computation.",
         NS("lora"),
     ] = False
-    moe_lora_base_gemm: A[
-        str,
-        Arg(
-            help="Kernel vendor for the MoE LoRA base GEMMs.",
-            choices=["cutedsl", "triton"],
-        ),
-        NS("lora"),
-    ] = "cutedsl"
     lora_strict_loading: A[
         bool,
         Arg(
@@ -9998,43 +9992,40 @@ class ServerArgs:
 
         if (
             self.speculative_algorithm is not None
-            and self.speculative_moe_runner_backend == "lora"
+            and self.speculative_moe_runner_backend is not None
+            and self.speculative_moe_runner_backend.startswith("lora")
         ):
             # Draft models have no LoRA adapters.
             raise ValueError(
-                "--speculative-moe-runner-backend lora is not supported: the "
+                f"--speculative-moe-runner-backend {self.speculative_moe_runner_backend} is not supported: the "
                 "LoRA MoE runner serves adapter traffic on the target model"
             )
 
-        if self.moe_runner_backend == "lora":
-            # The LoRA MoE runner has no base-model-only mode of its own; it is
-            # selected per server and only ever runs on a LoRA-enabled engine.
+        if self.moe_runner_backend.startswith("lora"):
             if not (self.enable_lora or self.lora_paths):
                 raise ValueError(
-                    "--moe-runner-backend lora requires --enable-lora "
+                    f"--moe-runner-backend {self.moe_runner_backend} requires --enable-lora "
                     "(or --lora-paths)"
                 )
-            # These two mirror the engine's layer-attach admission checks
-            # (unquantized BF16 experts, Standard dispatch); assert them at
-            # startup so the failure names the flag instead of surfacing as a
-            # NotImplementedError during layer construction.
-            if self.quantization is not None:
+            # Layer attachment checks the specific weight layout within each scheme.
+            if self.quantization not in (None, "fp8", "modelopt_fp4"):
                 raise ValueError(
-                    "--moe-runner-backend lora currently supports unquantized "
-                    f"BF16 MoE only, got --quantization {self.quantization}"
+                    f"--moe-runner-backend {self.moe_runner_backend} supports unquantized BF16, "
+                    "128-block FP8, and ModelOpt NVFP4 MoE, got "
+                    f"--quantization {self.quantization}"
                 )
             if self.moe_a2a_backend != "none":
                 raise ValueError(
-                    "--moe-runner-backend lora requires Standard dispatch, "
+                    f"--moe-runner-backend {self.moe_runner_backend} requires Standard dispatch, "
                     f"got --moe-a2a-backend {self.moe_a2a_backend}"
                 )
             if self.ep_join_mode is not None:
                 raise ValueError(
-                    "--moe-runner-backend lora does not yet support elastic EP"
+                    f"--moe-runner-backend {self.moe_runner_backend} does not yet support elastic EP"
                 )
             if self.enable_dp_attention and self.dp_size > 1:
                 raise ValueError(
-                    "--moe-runner-backend lora does not yet support DP-attention "
+                    f"--moe-runner-backend {self.moe_runner_backend} does not yet support DP-attention "
                     "with dp_size > 1"
                 )
             if (
@@ -10043,21 +10034,22 @@ class ServerArgs:
                 or self.ep_num_redundant_experts > 0
             ):
                 raise ValueError(
-                    "--moe-runner-backend lora currently requires trivial expert "
-                    "placement without EPLB or redundant experts"
+                    f"--moe-runner-backend {self.moe_runner_backend} currently requires "
+                    "trivial expert placement without EPLB or redundant experts"
                 )
             if self.enable_pdmux:
                 raise ValueError(
-                    "--moe-runner-backend lora does not yet support PD-multiplexing: "
-                    "its fused-align routing scratch is cached per "
+                    f"--moe-runner-backend {self.moe_runner_backend} does not yet support "
+                    "PD-multiplexing: its fused-align routing scratch is cached per "
                     "(device, num_buckets) and is not safe under concurrent "
                     "prefill/decode streams"
                 )
             if self.enable_two_batch_overlap:
                 raise ValueError(
-                    "--moe-runner-backend lora does not yet support two-batch overlap: "
-                    "its batch metadata and graph-stable MoE workspace are shared "
-                    "across layers and are not safe for concurrent child forwards"
+                    f"--moe-runner-backend {self.moe_runner_backend} does not yet support "
+                    "two-batch overlap: its batch metadata and graph-stable MoE "
+                    "workspace are shared across layers and are not safe for "
+                    "concurrent child forwards"
                 )
 
         # Enable LoRA if any LoRA paths are provided for backward compatibility.

--- a/test/registered/lora/test_moe_lora_execution_plan.py
+++ b/test/registered/lora/test_moe_lora_execution_plan.py
@@ -167,12 +167,12 @@ class TestFusionOwnership(unittest.TestCase):
         # exactly-one-owner rules are plan-level (tested below).
         self.assertIsNotNone(ActSpec(ActFamily.B_ACTIVATION, ActivationFn.SILU))
 
-    def test_shared_rank_finalize_requires_shared_ownership(self):
+    def test_shared_finalize_requires_shared_ownership(self):
         with self.assertRaisesRegex(ValueError, "shared-outer"):
-            FinalizeSpec(FinalizeFamily.SHARED_RANK_REDUCE)
+            FinalizeSpec(FinalizeFamily.SHARED_TOKEN_DELTA)
         self.assertTrue(
             FinalizeSpec(
-                FinalizeFamily.SHARED_RANK_REDUCE, is_shared_outer=True
+                FinalizeFamily.SHARED_TOKEN_DELTA, is_shared_outer=True
             ).is_shared_outer
         )
 
@@ -201,7 +201,7 @@ class TestWholePipelineValidation(unittest.TestCase):
                 act=ActSpec(ActFamily.B_ACTIVATION, ActivationFn.SILU),
                 down_b=None,
                 finalize=FinalizeSpec(
-                    FinalizeFamily.SHARED_RANK_REDUCE, is_shared_outer=True
+                    FinalizeFamily.SHARED_TOKEN_DELTA, is_shared_outer=True
                 ),
             ),
         )
@@ -218,7 +218,7 @@ class TestWholePipelineValidation(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "exactly one owner"):
             _plan(
                 finalize=FinalizeSpec(
-                    FinalizeFamily.SHARED_RANK_REDUCE, is_shared_outer=True
+                    FinalizeFamily.SHARED_TOKEN_DELTA, is_shared_outer=True
                 )
             )
 
@@ -252,7 +252,7 @@ class TestWholePipelineValidation(unittest.TestCase):
             _plan(
                 down_b=None,
                 finalize=FinalizeSpec(
-                    FinalizeFamily.SHARED_RANK_REDUCE, is_shared_outer=True
+                    FinalizeFamily.SHARED_TOKEN_DELTA, is_shared_outer=True
                 ),
                 down_overlap=DownOverlap.DOWN_B,
             )
@@ -330,9 +330,7 @@ class TestRouteRequirementUnion(unittest.TestCase):
     def test_shared_finalize_adds_raw_without_hiding_aligned_routes(self):
         plan = _plan(
             down_b=None,
-            finalize=FinalizeSpec(
-                FinalizeFamily.SHARED_RANK_REDUCE, is_shared_outer=True
-            ),
+            finalize=FinalizeSpec(FinalizeFamily.SHARED_ONE_PASS, is_shared_outer=True),
         )
         self.assertEqual(
             plan.route_requirements(),
@@ -344,6 +342,31 @@ class TestRouteRequirementUnion(unittest.TestCase):
             ),
         )
 
+
+class TestTokenDenseBridgeOwnership(unittest.TestCase):
+    def test_token_dense_a_requires_a_standalone_per_pair_gate_up_b(self):
+        token_dense_a = _a(
+            Site.GATE_UP, LoraAFamily.TOKEN_DENSE, True, BridgeLayout.TOKEN_MAJOR
+        )
+        _plan(
+            gate_up_a=token_dense_a,
+            gate_up_b=_b(
+                Site.GATE_UP, LoraBFamily.PER_PAIR, True, BridgeLayout.TOKEN_MAJOR
+            ),
+        )
+        with self.assertRaises(ValueError):
+            _plan(
+                gate_up_a=token_dense_a,
+                gate_up_b=_b(
+                    Site.GATE_UP, LoraBFamily.GROUPED, True, BridgeLayout.TOKEN_MAJOR
+                ),
+            )
+        with self.assertRaises(ValueError):
+            _plan(
+                gate_up_a=token_dense_a,
+                gate_up_b=None,
+                act=ActSpec(ActFamily.B_ACTIVATION, ActivationFn.SILU),
+            )
 
 
 if __name__ == "__main__":

--- a/test/registered/lora/test_moe_lora_execution_plan.py
+++ b/test/registered/lora/test_moe_lora_execution_plan.py
@@ -1,0 +1,350 @@
+"""CPU tests for the typed, whole-pipeline MoE-LoRA execution contract."""
+
+from __future__ import annotations
+
+import dataclasses
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+import pydantic
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-c-test-cpu")
+
+_SOURCE = (
+    Path(__file__).resolve().parents[3] / "python/sglang/srt/lora/moe/execution_plan.py"
+)
+_SPEC = importlib.util.spec_from_file_location("_moe_lora_execution_plan", _SOURCE)
+assert _SPEC is not None and _SPEC.loader is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = _MODULE
+_SPEC.loader.exec_module(_MODULE)
+
+ActivationFn = _MODULE.ActivationFn
+GateUpOverlap = _MODULE.GateUpOverlap
+BridgeLayout = _MODULE.BridgeLayout
+Site = _MODULE.Site
+FinalizeFamily = _MODULE.FinalizeFamily
+FinalizeSpec = _MODULE.FinalizeSpec
+DownOverlap = _MODULE.DownOverlap
+LoraAFamily = _MODULE.LoraAFamily
+LoraASpec = _MODULE.LoraASpec
+LoraBFamily = _MODULE.LoraBFamily
+LoraBSpec = _MODULE.LoraBSpec
+ActFamily = _MODULE.ActFamily
+ActSpec = _MODULE.ActSpec
+MoeLoraExecutionPlan = _MODULE.MoeLoraExecutionPlan
+RouteBuilderFamily = _MODULE.RouteBuilderFamily
+RouteRequirement = _MODULE.RouteRequirement
+
+
+def _a(
+    site: Site,
+    family: LoraAFamily = LoraAFamily.GROUPED,
+    is_shared_outer: bool = False,
+    layout: BridgeLayout = BridgeLayout.PAIR_MAJOR,
+) -> LoraASpec:
+    return LoraASpec(site, family, is_shared_outer, layout)
+
+
+def _b(
+    site: Site,
+    family: LoraBFamily = LoraBFamily.GROUPED,
+    is_shared_outer: bool = False,
+    layout: BridgeLayout = BridgeLayout.PAIR_MAJOR,
+) -> LoraBSpec:
+    return LoraBSpec(site, family, is_shared_outer, layout)
+
+
+def _plan(**changes) -> MoeLoraExecutionPlan:
+    values = {
+        "gate_up_a": _a(Site.GATE_UP),
+        "gate_up_b": _b(Site.GATE_UP),
+        "act": ActSpec(ActFamily.MATERIALIZED, ActivationFn.SILU),
+        "down_a": _a(Site.DOWN),
+        "down_b": _b(Site.DOWN),
+        "finalize": FinalizeSpec(FinalizeFamily.MATERIALIZED),
+    }
+    values.update(changes)
+    return MoeLoraExecutionPlan(**values)
+
+
+SERIAL_MATERIALIZED_REFERENCE = _plan()
+
+
+class TestFactorAndKernelSpecs(unittest.TestCase):
+    def test_specs_require_a_bool_ownership_flag(self):
+        with self.assertRaises(pydantic.ValidationError):
+            _a(Site.GATE_UP, is_shared_outer=1)  # type: ignore[arg-type]
+        with self.assertRaises(pydantic.ValidationError):
+            _b(Site.DOWN, is_shared_outer=1)  # type: ignore[arg-type]
+
+    def test_a_rejects_unqualified_family_site_ownership_and_layout(self):
+        invalid = (
+            lambda: _a(
+                Site.DOWN,
+                LoraAFamily.TOKEN_GROUPED,
+                True,
+                BridgeLayout.TOKEN_MAJOR,
+            ),
+            lambda: _a(
+                Site.GATE_UP,
+                LoraAFamily.TOKEN_GROUPED,
+                True,
+                BridgeLayout.PAIR_MAJOR,
+            ),
+            lambda: _a(
+                Site.GATE_UP,
+                LoraAFamily.GROUPED,
+                layout=BridgeLayout.TOKEN_MAJOR,
+            ),
+        )
+        for construct in invalid:
+            with self.subTest(construct=construct), self.assertRaises(ValueError):
+                construct()
+
+        # Indexed A supports both ownership modes, but requires pair-major output.
+        for site, shared in (
+            (Site.GATE_UP, False),
+            (Site.GATE_UP, True),
+            (Site.DOWN, True),
+        ):
+            with self.subTest(site=site, shared=shared):
+                spec = _a(site, LoraAFamily.PER_PAIR, shared)
+                self.assertIs(spec.output_layout, BridgeLayout.PAIR_MAJOR)
+        with self.assertRaises(ValueError):
+            _a(Site.DOWN, LoraAFamily.PER_PAIR, layout=BridgeLayout.TOKEN_MAJOR)
+
+    def test_b_rejects_down_token_layout(self):
+        with self.assertRaisesRegex(ValueError, "down bridge"):
+            _b(
+                Site.DOWN,
+                LoraBFamily.GROUPED,
+                layout=BridgeLayout.TOKEN_MAJOR,
+            )
+
+    def test_specs_require_typed_enums(self):
+        with self.assertRaises(pydantic.ValidationError):
+            LoraASpec("gate_up", LoraAFamily.GROUPED)  # type: ignore[arg-type]
+        with self.assertRaises(pydantic.ValidationError):
+            LoraBSpec(Site.GATE_UP, "grouped")  # type: ignore[arg-type]
+
+    def test_specs_reject_unknown_field_names(self):
+        with self.assertRaises(pydantic.ValidationError):
+            LoraASpec(Site.GATE_UP, LoraAFamily.GROUPED, nonsense=True)  # type: ignore
+        with self.assertRaises(pydantic.ValidationError):
+            dataclasses.replace(
+                SERIAL_MATERIALIZED_REFERENCE,
+                down_b_scater=True,  # type: ignore[call-arg]
+            )
+
+    def test_only_gate_up_a_and_down_b_may_be_shared_outer(self):
+        self.assertEqual(
+            _a(
+                Site.GATE_UP,
+                is_shared_outer=True,
+            ).is_shared_outer,
+            True,
+        )
+        self.assertEqual(
+            _b(
+                Site.DOWN,
+                is_shared_outer=True,
+            ).is_shared_outer,
+            True,
+        )
+        # The weight loader, not the plan, restricts shared-outer sites.
+        self.assertEqual(_a(Site.DOWN, is_shared_outer=True).is_shared_outer, True)
+        self.assertEqual(_b(Site.GATE_UP, is_shared_outer=True).is_shared_outer, True)
+
+
+class TestFusionOwnership(unittest.TestCase):
+    def test_ownership_lives_on_the_family_alone(self):
+        # A consuming family records nothing of the absorbed stage; the
+        # exactly-one-owner rules are plan-level (tested below).
+        self.assertIsNotNone(ActSpec(ActFamily.B_ACTIVATION, ActivationFn.SILU))
+
+    def test_shared_rank_finalize_requires_shared_ownership(self):
+        with self.assertRaisesRegex(ValueError, "shared-outer"):
+            FinalizeSpec(FinalizeFamily.SHARED_RANK_REDUCE)
+        self.assertTrue(
+            FinalizeSpec(
+                FinalizeFamily.SHARED_RANK_REDUCE, is_shared_outer=True
+            ).is_shared_outer
+        )
+
+
+class TestWholePipelineValidation(unittest.TestCase):
+    def test_reference_is_immutable_complete_and_aligned(self):
+        self.assertIs(
+            SERIAL_MATERIALIZED_REFERENCE.validate(),
+            SERIAL_MATERIALIZED_REFERENCE,
+        )
+        self.assertEqual(
+            SERIAL_MATERIALIZED_REFERENCE.route_requirements(),
+            frozenset((RouteRequirement.ALIGNED_PER_EXPERT,)),
+        )
+        with self.assertRaises(dataclasses.FrozenInstanceError):
+            SERIAL_MATERIALIZED_REFERENCE.gate_up_b = None  # type: ignore[misc]
+
+    def test_every_required_act_and_finalize_composition_constructs(self):
+        plans = (
+            _plan(
+                gate_up_b=None,
+                act=ActSpec(ActFamily.B_ACTIVATION, ActivationFn.SILU),
+            ),
+            _plan(
+                gate_up_b=None,
+                act=ActSpec(ActFamily.B_ACTIVATION, ActivationFn.SILU),
+                down_b=None,
+                finalize=FinalizeSpec(
+                    FinalizeFamily.SHARED_RANK_REDUCE, is_shared_outer=True
+                ),
+            ),
+        )
+        for plan in plans:
+            self.assertIs(plan.validate(), plan)
+
+    def test_exactly_one_stage_owner_is_required(self):
+        with self.assertRaisesRegex(ValueError, "exactly one owner"):
+            _plan(act=ActSpec(ActFamily.B_ACTIVATION, ActivationFn.SILU))
+        with self.assertRaisesRegex(ValueError, "exactly one owner"):
+            _plan(gate_up_b=None)
+        with self.assertRaises(pydantic.ValidationError):
+            _plan(down_a=None)  # required field: down A always runs standalone
+        with self.assertRaisesRegex(ValueError, "exactly one owner"):
+            _plan(
+                finalize=FinalizeSpec(
+                    FinalizeFamily.SHARED_RANK_REDUCE, is_shared_outer=True
+                )
+            )
+
+    def test_bridge_layouts_must_match_at_both_sites(self):
+        token_gate_up_a = _a(
+            Site.GATE_UP,
+            LoraAFamily.TOKEN_GROUPED,
+            True,
+            BridgeLayout.TOKEN_MAJOR,
+        )
+        with self.assertRaisesRegex(ValueError, "gate/up A output layout"):
+            _plan(gate_up_a=token_gate_up_a)
+
+        token_gate_up_b = _b(
+            Site.GATE_UP,
+            LoraBFamily.GROUPED,
+            False,
+            BridgeLayout.TOKEN_MAJOR,
+        )
+        plan = _plan(gate_up_a=token_gate_up_a, gate_up_b=token_gate_up_b)
+        self.assertIs(plan.validate(), plan)
+
+    def test_overlaps_reject_consumed_stages(self):
+        with self.assertRaisesRegex(ValueError, "gate/up-A\\+B"):
+            _plan(
+                gate_up_b=None,
+                act=ActSpec(ActFamily.B_ACTIVATION, ActivationFn.SILU),
+                gate_up_overlap=GateUpOverlap.GATE_UP_A_B,
+            )
+        with self.assertRaisesRegex(ValueError, "standalone down B"):
+            _plan(
+                down_b=None,
+                finalize=FinalizeSpec(
+                    FinalizeFamily.SHARED_RANK_REDUCE, is_shared_outer=True
+                ),
+                down_overlap=DownOverlap.DOWN_B,
+            )
+
+    def test_indexed_a_is_the_down_a_only_composition(self):
+        down_only = _plan(
+            down_a=_a(Site.DOWN, LoraAFamily.PER_PAIR),
+        )
+        self.assertEqual(
+            down_only.route_requirements(),
+            frozenset(
+                (
+                    RouteRequirement.RAW_PER_EXPERT,
+                    RouteRequirement.ALIGNED_PER_EXPERT,
+                )
+            ),
+        )
+        # An indexed gate/up-A is coherent (the kernel visits pairs at either
+        # site); only its pair-major bridge is pinned.
+        indexed_gate_up = _plan(gate_up_a=_a(Site.GATE_UP, LoraAFamily.PER_PAIR))
+        self.assertEqual(
+            indexed_gate_up.route_requirements(),
+            frozenset(
+                (RouteRequirement.RAW_PER_EXPERT, RouteRequirement.ALIGNED_PER_EXPERT)
+            ),
+        )
+
+
+class TestRouteRequirementUnion(unittest.TestCase):
+    def test_shared_token_a_and_per_expert_b_require_both_products(self):
+        plan = _plan(
+            gate_up_a=_a(
+                Site.GATE_UP,
+                LoraAFamily.TOKEN_GROUPED,
+                True,
+                BridgeLayout.TOKEN_MAJOR,
+            ),
+            gate_up_b=_b(
+                Site.GATE_UP,
+                LoraBFamily.GROUPED,
+                False,
+                BridgeLayout.TOKEN_MAJOR,
+            ),
+        )
+        self.assertEqual(
+            plan.route_requirements(),
+            frozenset(
+                (
+                    RouteRequirement.SHARED_TOKEN_PLAN,
+                    RouteRequirement.ALIGNED_PER_EXPERT,
+                )
+            ),
+        )
+
+    def test_parallel_builder_yields_both_aligned_pair_plans(self):
+        shared_down_b = _b(
+            Site.DOWN,
+            LoraBFamily.GROUPED,
+            True,
+        )
+        parallel = _plan(
+            down_b=shared_down_b,
+            route_builder=RouteBuilderFamily.PARALLEL_SHARED_OUTER,
+        )
+        self.assertEqual(
+            parallel.route_requirements(),
+            frozenset(
+                (
+                    RouteRequirement.ALIGNED_PER_EXPERT,
+                    RouteRequirement.ALIGNED_SHARED_OUTER,
+                )
+            ),
+        )
+
+    def test_shared_finalize_adds_raw_without_hiding_aligned_routes(self):
+        plan = _plan(
+            down_b=None,
+            finalize=FinalizeSpec(
+                FinalizeFamily.SHARED_RANK_REDUCE, is_shared_outer=True
+            ),
+        )
+        self.assertEqual(
+            plan.route_requirements(),
+            frozenset(
+                (
+                    RouteRequirement.ALIGNED_PER_EXPERT,
+                    RouteRequirement.RAW_SHARED_OUTER,
+                )
+            ),
+        )
+
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/lora/test_moe_lora_info.py
+++ b/test/registered/lora/test_moe_lora_info.py
@@ -56,7 +56,12 @@ def test_compute_moe_lora_info_expands_segments(use_preallocated_buffers: bool):
     )
     torch.cuda.synchronize()
 
-    expected_mapping = torch.repeat_interleave(weight_indices, seg_lens)
+    raw_mapping = torch.repeat_interleave(weight_indices, seg_lens)
+    expected_mapping = torch.where(
+        lora_ranks[raw_mapping.long()] > 0,
+        raw_mapping,
+        -1,
+    )
     expected_enabled = _expected_adapter_enabled(lora_ranks, weight_indices)
 
     torch.testing.assert_close(actual_mapping, expected_mapping)
@@ -64,6 +69,44 @@ def test_compute_moe_lora_info_expands_segments(use_preallocated_buffers: bool):
 
     if use_preallocated_buffers:
         assert actual_mapping.data_ptr() == token_lora_mapping.data_ptr()
+        assert token_lora_mapping[num_tokens:].tolist() == [-1] * 11
+
+
+@pytest.mark.parametrize(
+    ("weight_indices", "lora_ranks", "expected_mapping", "expected_enabled"),
+    [
+        ([0, 1, 2], [0, 8, 0], [-1, -1, 1, 1, 1, -1], [0, 1, 0]),
+        ([0, 2, 0], [0, 8, 0], [-1, -1, -1, -1, -1, -1], [0, 0, 0]),
+    ],
+    ids=("mixed", "all_inactive"),
+)
+def test_compute_moe_lora_info_cpu_fallback_normalizes_inactive_slots(
+    weight_indices: list[int],
+    lora_ranks: list[int],
+    expected_mapping: list[int],
+    expected_enabled: list[int],
+):
+    seg_lens = torch.tensor([2, 3, 1], dtype=torch.int32)
+    seg_indptr = torch.tensor([0, 2, 5, 6], dtype=torch.int32)
+    weight_indices_tensor = torch.tensor(weight_indices, dtype=torch.int32)
+    lora_ranks_tensor = torch.tensor(lora_ranks, dtype=torch.int32)
+    adapter_enabled = torch.full((3,), 123, dtype=torch.int32)
+    mapping_buffer = torch.full((9,), 456, dtype=torch.int32)
+
+    actual_enabled, actual_mapping = _compute_moe_lora_info(
+        6,
+        seg_indptr,
+        lora_ranks_tensor,
+        weight_indices_tensor,
+        adapter_enabled,
+        mapping_buffer,
+        max_len=int(seg_lens.max().item()),
+    )
+
+    assert actual_mapping.data_ptr() == mapping_buffer.data_ptr()
+    assert actual_mapping.tolist() == expected_mapping
+    assert actual_enabled.tolist() == expected_enabled
+    assert mapping_buffer[6:].tolist() == [-1, -1, -1]
 
 
 def test_compute_moe_lora_info_rejects_undercovered_launch():

--- a/test/registered/lora/test_moe_lora_parallel_workspace.py
+++ b/test/registered/lora/test_moe_lora_parallel_workspace.py
@@ -1,0 +1,87 @@
+"""CUDA fork/join guards for the MoE LoRA overlap workspace."""
+
+from __future__ import annotations
+
+import unittest
+
+import torch
+
+from sglang.srt.lora.moe.workspace import MoeLoraWorkspace
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=30, stage="base-b", runner_config="1-gpu-large")
+
+
+class TestMoeLoraParallelWorkspace(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("CUDA required")
+        cls.device = torch.device("cuda", torch.cuda.current_device())
+
+    def test_side_stream_is_capture_safe_and_fully_joined(self):
+        workspace = MoeLoraWorkspace()
+
+        source = torch.empty(64, dtype=torch.float32, device=self.device)
+        side_output = torch.empty_like(source)
+        compute_output = torch.empty_like(source)
+        combined = torch.empty_like(source)
+
+        def side() -> None:
+            side_output.copy_(source)
+            side_output.add_(1)
+
+        def compute() -> torch.Tensor:
+            compute_output.copy_(source)
+            compute_output.mul_(2)
+            return compute_output
+
+        def launch_twice() -> torch.Tensor:
+            # A shared runner workspace reuses region events sequentially
+            # across layers. Exercise two same-name regions in one graph.
+            for _ in range(2):
+                result = workspace.run_parallel(
+                    name="shared_region",
+                    device=self.device,
+                    compute=compute,
+                    side=side,
+                )
+            combined.copy_(result)
+            combined.add_(side_output)
+            return combined
+
+        # Stand in for the CUDA graph warm-up forwards: one eager pass
+        # creates the side stream and materializes both event handles.
+        source.fill_(3)
+        launch_twice()
+        torch.cuda.synchronize(self.device)
+
+        side_stream = workspace.side_stream(self.device)
+        ready = workspace.event(self.device, "shared_region:ready")
+        done = workspace.event(self.device, "shared_region:done")
+        self.assertNotEqual(ready.cuda_event, 0)
+        self.assertNotEqual(done.cuda_event, 0)
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            launch_twice()
+
+        for value in (3, 5, 7, 11):
+            source.fill_(value)
+            graph.replay()
+            torch.cuda.synchronize(self.device)
+            torch.testing.assert_close(
+                combined,
+                torch.full_like(combined, 3 * value + 1),
+                rtol=0,
+                atol=0,
+            )
+
+        self.assertIs(workspace.side_stream(self.device), side_stream)
+        self.assertIs(workspace.event(self.device, "shared_region:ready"), ready)
+        self.assertIs(workspace.event(self.device, "shared_region:done"), done)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/lora/test_moe_lora_route_factory.py
+++ b/test/registered/lora/test_moe_lora_route_factory.py
@@ -143,10 +143,11 @@ def _load_launch_config():
         package.__path__ = []
         packages[name] = package
     finalize = types.ModuleType("sglang.srt.lora.moe.kernels.finalize")
-    finalize.SHARED_RANK_DEFAULT_CONFIG = {
+    finalize.SHARED_TOKEN_DELTA_DEFAULT_CONFIG = {
         "reduce": {"BLOCK_SIZE_T": 16},
         "tail": {"BLOCK_SIZE_H": 16},
     }
+    finalize.SHARED_ONE_PASS_DEFAULT_CONFIG = {"BLOCK_SIZE_H": 16}
     act = types.ModuleType("sglang.srt.lora.moe.kernels.fused_act")
     act.FUSED_B_ACT_DEFAULT_CONFIG = {"BLOCK_SIZE_W": 16}
     module_name = "_host_launch_config"

--- a/test/registered/lora/test_moe_lora_route_factory.py
+++ b/test/registered/lora/test_moe_lora_route_factory.py
@@ -1,0 +1,785 @@
+"""Host-only guards for the Step-8 route-factory split-M candidate."""
+
+from __future__ import annotations
+
+import ast
+import dataclasses
+import importlib.util
+import sys
+import types
+import unittest
+from enum import Enum
+from pathlib import Path
+from unittest import mock
+
+import msgspec
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+
+def _segments_of(mapping: torch.Tensor) -> torch.Tensor:
+    """Request boundaries for a test batch: one request per token, so the
+    segment route is exercised with many short requests and the helper stays
+    free of host syncs (CUDA-graph capture forbids a device-to-host copy)."""
+    return torch.arange(mapping.numel() + 1, dtype=torch.int32, device=mapping.device)
+
+
+register_cpu_ci(est_time=3, suite="base-c-test-cpu")
+
+ROOT = Path(__file__).resolve().parents[3]
+LORA_MOE = ROOT / "python/sglang/srt/lora/moe"
+
+
+def _load_execution_plan():
+    module_name = "_route_factory_execution_plan"
+    spec = importlib.util.spec_from_file_location(
+        module_name, LORA_MOE / "execution_plan.py"
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+PLAN = _load_execution_plan()
+
+
+def _serial_materialized_reference():
+    """The simplest correct pipeline: every stage standalone, nothing fused,
+    no overlap window.  Every plan below is a departure from this one."""
+    return PLAN.MoeLoraExecutionPlan(
+        gate_up_a=PLAN.LoraASpec(
+            PLAN.Site.GATE_UP,
+            PLAN.LoraAFamily.GROUPED,
+            False,
+            PLAN.BridgeLayout.PAIR_MAJOR,
+        ),
+        gate_up_b=PLAN.LoraBSpec(
+            PLAN.Site.GATE_UP,
+            PLAN.LoraBFamily.GROUPED,
+            False,
+            PLAN.BridgeLayout.PAIR_MAJOR,
+        ),
+        act=PLAN.ActSpec(PLAN.ActFamily.MATERIALIZED, PLAN.ActivationFn.SILU),
+        down_a=PLAN.LoraASpec(
+            PLAN.Site.DOWN,
+            PLAN.LoraAFamily.GROUPED,
+            False,
+            PLAN.BridgeLayout.PAIR_MAJOR,
+        ),
+        down_b=PLAN.LoraBSpec(
+            PLAN.Site.DOWN,
+            PLAN.LoraBFamily.GROUPED,
+            False,
+            PLAN.BridgeLayout.PAIR_MAJOR,
+        ),
+        finalize=PLAN.FinalizeSpec(PLAN.FinalizeFamily.MATERIALIZED),
+    )
+
+
+SERIAL_MATERIALIZED_REFERENCE = _serial_materialized_reference()
+
+
+def _fake_segment_route(calls, prefixes=None):
+    """Stand in for build_routes' segment token-route builder: record it the
+    way the aligned-route fakes record theirs and hand back a host route."""
+
+    def build(
+        *,
+        seg_indptr,
+        token_lora_mapping,
+        num_tokens,
+        num_local_experts,
+        max_loras,
+        block_size,
+        workspace,
+    ):
+        assert seg_indptr[-1].item() == num_tokens
+        calls.append(("route:shared_token", True))
+        if prefixes is not None:
+            prefixes.append("route:shared_token")
+        # Its padded count lives under its own workspace name, like the
+        # aligned routes' do, and reads the token count back.
+        padded = workspace.tensor(
+            "route:shared_token:padded_pairs",
+            (1,),
+            dtype=torch.int32,
+            device=token_lora_mapping.device,
+        )
+        padded.fill_(num_tokens)
+        return _route(
+            torch.zeros((num_tokens, 1), dtype=torch.int32),
+            token_lora_mapping,
+            block_size=block_size,
+            padded_count=padded,
+            num_local_experts=num_local_experts,
+            max_loras=max_loras,
+            is_shared_outer=True,
+        )
+
+    return build
+
+
+def _arch_pdl(enabled: bool):
+    """Pin build_routes' architecture probe: route PDL is arch-keyed now."""
+    arch = types.ModuleType("sglang.kernels.jit.utils")
+    arch.is_arch_support_pdl = lambda: enabled
+    return mock.patch.dict(sys.modules, {arch.__name__: arch})
+
+
+def _load_launch_config():
+    package_names = (
+        "sglang",
+        "sglang.srt",
+        "sglang.srt.lora",
+        "sglang.srt.lora.moe",
+        "sglang.srt.lora.moe.base_gemm_provider",
+    )
+    packages = {}
+    for name in package_names:
+        package = types.ModuleType(name)
+        package.__path__ = []
+        packages[name] = package
+    finalize = types.ModuleType("sglang.srt.lora.moe.kernels.finalize")
+    finalize.SHARED_RANK_DEFAULT_CONFIG = {
+        "reduce": {"BLOCK_SIZE_T": 16},
+        "tail": {"BLOCK_SIZE_H": 16},
+    }
+    act = types.ModuleType("sglang.srt.lora.moe.kernels.fused_act")
+    act.FUSED_B_ACT_DEFAULT_CONFIG = {"BLOCK_SIZE_W": 16}
+    module_name = "_host_launch_config"
+    spec = importlib.util.spec_from_file_location(
+        module_name, LORA_MOE / "launch_config.py"
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    with mock.patch.dict(
+        sys.modules,
+        {
+            **packages,
+            "sglang.srt.lora.moe.execution_plan": PLAN,
+            finalize.__name__: finalize,
+            act.__name__: act,
+            module_name: module,
+        },
+    ):
+        spec.loader.exec_module(module)
+    return module
+
+
+LAUNCH = _load_launch_config()
+
+
+class _RouteViewKind(str, Enum):
+    """Stand-in for routing.RouteViewKind: these tests stub that module."""
+
+    RAW = "raw"
+    ALIGNED = "aligned"
+
+
+class _HostRouteView(msgspec.Struct, frozen=True, kw_only=True):
+    view: str
+    block_size: int
+    topk_ids: torch.Tensor
+    token_lora_mapping: torch.Tensor
+    num_local_experts: int
+    max_loras: int
+    is_shared_outer: bool = False
+    maybe_sorted_pair_ids: torch.Tensor | None = None
+    maybe_block_virtual_expert_ids: torch.Tensor | None = None
+    maybe_num_pairs_post_padded: torch.Tensor | None = None
+
+
+def _load_routing():
+    package_names = (
+        "sglang",
+        "sglang.kernels",
+        "sglang.kernels.ops",
+        "sglang.kernels.ops.moe",
+        "sglang.srt",
+        "sglang.srt.lora",
+        "sglang.srt.lora.moe",
+    )
+    packages = {}
+    for name in package_names:
+        package = types.ModuleType(name)
+        package.__path__ = []
+        packages[name] = package
+
+    fake_triton = types.ModuleType("triton")
+    fake_triton.jit = lambda function: function
+    fake_triton.cdiv = lambda value, divisor: (value + divisor - 1) // divisor
+    fake_tl = types.ModuleType("triton.language")
+    fake_triton.language = fake_tl
+
+    virtual_experts = types.ModuleType("sglang.kernels.ops.moe.virtual_experts")
+    virtual_experts._align_block_size_jit = lambda *_args, **_kwargs: None
+
+    route_view = types.ModuleType("sglang.srt.lora.moe.route_view")
+    route_view.RouteViewKind = _RouteViewKind
+    route_view.RouteView = _HostRouteView
+
+    class _Unlaunched:
+        """Every kernel a host-level test reaches has to be patched first."""
+
+        def __getitem__(self, _grid):
+            def launch(*_args, **_kwargs):
+                raise AssertionError("a kernel launched in the host sandbox")
+
+            return launch
+
+    route_kernels = types.ModuleType("sglang.srt.lora.moe.kernels.routing")
+    for kernel in (
+        "_build_virtual_topk_ids_kernel",
+        "_hist_kernel",
+        "_place_kernel",
+        "_scan_kernel",
+        "_segment_token_route_kernel",
+    ):
+        setattr(route_kernels, kernel, _Unlaunched())
+
+    # routing.py imports this for the fused builder's metadata; stub it so the
+    # loader does not depend on another test module having imported the real
+    # one first.
+    workspace = types.ModuleType("sglang.srt.lora.moe.workspace")
+    workspace.MoeLoraWorkspace = object
+
+    module_name = "_host_routing"
+    spec = importlib.util.spec_from_file_location(module_name, LORA_MOE / "routing.py")
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    with mock.patch.dict(
+        sys.modules,
+        {
+            **packages,
+            "triton": fake_triton,
+            "triton.language": fake_tl,
+            "sglang.srt.lora.moe.execution_plan": PLAN,
+            virtual_experts.__name__: virtual_experts,
+            route_view.__name__: route_view,
+            route_kernels.__name__: route_kernels,
+            workspace.__name__: workspace,
+            module_name: module,
+        },
+    ):
+        spec.loader.exec_module(module)
+    return module
+
+
+ROUTING = _load_routing()
+
+
+class _Workspace:
+    def __init__(self):
+        self.tensors: dict[str, torch.Tensor] = {}
+
+    def run_parallel(self, *, name, device, compute, side):
+        # The real CPU fallback: side first, then compute, fully joined.
+        side()
+        return compute()
+
+    def tensor(self, name, shape, *, dtype, device, **_kwargs):
+        factory = (
+            torch.zeros if _kwargs.get("zero_on_first_allocation") else torch.empty
+        )
+        value = factory(shape, dtype=dtype, device=device)
+        self.tensors[name] = value
+        return value
+
+
+class _KernelRecorder:
+    def __init__(self):
+        self.calls = []
+
+    def __getitem__(self, grid):
+        def launch(*args, **kwargs):
+            self.calls.append((grid, args, kwargs))
+
+        return launch
+
+
+def _route(
+    topk_ids: torch.Tensor,
+    token_lora_mapping: torch.Tensor,
+    *,
+    block_size: int,
+    padded_count: torch.Tensor,
+    num_local_experts: int = 2,
+    max_loras: int = 2,
+    is_shared_outer: bool = False,
+) -> _HostRouteView:
+    return _HostRouteView(
+        view="aligned",
+        block_size=block_size,
+        topk_ids=topk_ids,
+        token_lora_mapping=token_lora_mapping,
+        num_local_experts=num_local_experts,
+        max_loras=max_loras,
+        is_shared_outer=is_shared_outer,
+        maybe_sorted_pair_ids=torch.arange(2, dtype=torch.int32),
+        maybe_block_virtual_expert_ids=torch.arange(1, dtype=torch.int32),
+        maybe_num_pairs_post_padded=padded_count,
+    )
+
+
+class TestRoutePdlWiring(unittest.TestCase):
+    def test_plans_build_exactly_their_aligned_routes(self):
+        reference = SERIAL_MATERIALIZED_REFERENCE
+        shared_down = dataclasses.replace(
+            reference,
+            down_b=dataclasses.replace(reference.down_b, is_shared_outer=True),
+        )
+        shared_token = dataclasses.replace(
+            reference,
+            gate_up_a=PLAN.LoraASpec(
+                PLAN.Site.GATE_UP,
+                PLAN.LoraAFamily.TOKEN_GROUPED,
+                True,
+                PLAN.BridgeLayout.TOKEN_MAJOR,
+            ),
+            gate_up_b=dataclasses.replace(
+                reference.gate_up_b,
+                input_layout=PLAN.BridgeLayout.TOKEN_MAJOR,
+            ),
+        )
+
+        calls = []
+
+        def fake_aligned(
+            topk_ids,
+            token_lora_mapping,
+            *,
+            num_local_experts,
+            max_loras,
+            block_size,
+            view,
+            is_shared_outer=False,
+            workspace=None,
+            tensor_prefix=None,
+        ):
+            # Every route gets the SAME local expert count; only the flag
+            # differs, and it has to match the route being built.
+            self.assertEqual(num_local_experts, 2)
+            calls.append((tensor_prefix, is_shared_outer))
+            built = _route(
+                topk_ids,
+                token_lora_mapping,
+                block_size=block_size,
+                padded_count=torch.tensor([block_size], dtype=torch.int32),
+            )
+            return built
+
+        with (
+            mock.patch.object(
+                ROUTING, "build_virtual_expert_routing", side_effect=fake_aligned
+            ),
+            mock.patch.object(
+                ROUTING,
+                "_build_segment_token_route",
+                side_effect=_fake_segment_route(calls),
+            ),
+        ):
+            for plan in (reference, shared_down, shared_token):
+                ROUTING.build_routes(
+                    plan,
+                    topk_ids=torch.tensor([[0, 1]], dtype=torch.int32),
+                    token_lora_mapping=torch.tensor([0], dtype=torch.int32),
+                    seg_indptr=_segments_of(torch.tensor([0], dtype=torch.int32)),
+                    num_local_experts=2,
+                    max_loras=2,
+                    block_size=16,
+                    workspace=_Workspace(),
+                )
+
+        self.assertEqual(
+            set(calls),
+            {
+                ("route:aligned_per_expert", False),
+                ("route:aligned_shared_outer", True),
+                ("route:shared_token", True),
+            },
+        )
+
+    def test_parallel_plan_builds_both_routes_plus_the_shared_token_follow_on(self):
+        reference = SERIAL_MATERIALIZED_REFERENCE
+        plan = dataclasses.replace(
+            reference,
+            gate_up_a=PLAN.LoraASpec(
+                PLAN.Site.GATE_UP,
+                PLAN.LoraAFamily.TOKEN_GROUPED,
+                True,
+                PLAN.BridgeLayout.TOKEN_MAJOR,
+            ),
+            gate_up_b=dataclasses.replace(
+                reference.gate_up_b,
+                input_layout=PLAN.BridgeLayout.TOKEN_MAJOR,
+            ),
+            down_b=dataclasses.replace(reference.down_b, is_shared_outer=True),
+            route_builder=PLAN.RouteBuilderFamily.PARALLEL_SHARED_OUTER,
+        )
+        calls = []
+
+        def fake_route(
+            topk_ids,
+            token_lora_mapping,
+            *,
+            num_local_experts,
+            max_loras,
+            block_size,
+            view=None,
+            is_shared_outer=False,
+            workspace=None,
+            tensor_prefix=None,
+        ):
+            padded = torch.zeros(1, dtype=torch.int32)
+            padded.fill_(block_size)
+            built = _route(
+                topk_ids,
+                token_lora_mapping,
+                block_size=block_size,
+                padded_count=padded,
+            )
+            calls.append((tensor_prefix, is_shared_outer))
+            return built
+
+        with (
+            mock.patch.object(
+                ROUTING, "build_virtual_expert_routing", side_effect=fake_route
+            ),
+            mock.patch.object(
+                ROUTING,
+                "_build_segment_token_route",
+                side_effect=_fake_segment_route(calls),
+            ),
+        ):
+            ROUTING.build_routes(
+                plan,
+                topk_ids=torch.tensor([[0, 1]], dtype=torch.int32),
+                token_lora_mapping=torch.tensor([0], dtype=torch.int32),
+                seg_indptr=_segments_of(torch.tensor([0], dtype=torch.int32)),
+                num_local_experts=2,
+                max_loras=2,
+                block_size=16,
+                workspace=_Workspace(),
+            )
+
+        # The fork builds both aligned routes; the shared-token follow-on is a
+        # third standard call.
+        self.assertEqual(
+            set(calls),
+            {
+                ("route:aligned_per_expert", False),
+                ("route:aligned_shared_outer", True),
+                ("route:shared_token", True),
+            },
+        )
+
+    def _run_route(self, *, use_pdl, is_shared_outer=False):
+        recorders = [_KernelRecorder() for _ in range(3)]
+        with (
+            _arch_pdl(bool(use_pdl)),
+            mock.patch.object(ROUTING, "_hist_kernel", recorders[0]),
+            mock.patch.object(ROUTING, "_scan_kernel", recorders[1]),
+            mock.patch.object(ROUTING, "_place_kernel", recorders[2]),
+        ):
+            route = ROUTING._build_aligned(
+                torch.tensor([[0, 1]], dtype=torch.int32),
+                torch.tensor([0], dtype=torch.int32),
+                num_local_experts=2,
+                max_loras=2,
+                block_size=16,
+                workspace=_Workspace(),
+                tensor_prefix="test:route",
+                is_shared_outer=is_shared_outer,
+            )
+        return route, recorders
+
+    def test_route_launches_real_pdl_chain(self):
+        route, (hist, scan, expand) = self._run_route(use_pdl=True)
+
+        self.assertIsNotNone(route)
+        self.assertTrue(hist.calls[0][2]["USE_PDL"])
+        self.assertNotIn("launch_pdl", hist.calls[0][2])
+        for consumer in (scan, expand):
+            self.assertTrue(consumer.calls[0][2]["USE_PDL"])
+            self.assertTrue(consumer.calls[0][2]["launch_pdl"])
+
+    def test_route_pdl_off_leaves_launches_unarmed(self):
+        _, recorders = self._run_route(use_pdl=False)
+        for recorder in recorders:
+            self.assertFalse(recorder.calls[0][2]["USE_PDL"])
+            self.assertNotIn("launch_pdl", recorder.calls[0][2])
+
+    def test_kernel_dependency_operations_are_complete(self):
+        source = (LORA_MOE / "kernels" / "routing.py").read_text()
+        tree = ast.parse(source)
+        function_nodes = {
+            node.name: node for node in tree.body if isinstance(node, ast.FunctionDef)
+        }
+        functions = {name: ast.unparse(node) for name, node in function_nodes.items()}
+
+        hist = functions["_hist_kernel"]
+        scan = functions["_scan_kernel"]
+        expand = functions["_place_kernel"]
+        self.assertIn("gdc_launch_dependents", hist)
+        self.assertNotIn("gdc_wait", hist)
+        self.assertIn("gdc_wait", scan)
+        self.assertIn("gdc_launch_dependents", scan)
+        self.assertIn("gdc_wait", expand)
+        self.assertNotIn("gdc_launch_dependents", expand)
+
+        # K3 must be released before the scan body, so the place kernel's pair
+        # path can overlap scan work while still waiting before cursor
+        # consumption.
+        scan_ifs = [
+            node
+            for node in function_nodes["_scan_kernel"].body
+            if isinstance(node, ast.If)
+        ]
+        self.assertEqual(len(scan_ifs), 1)
+        self.assertEqual(ast.unparse(scan_ifs[0].test), "USE_PDL")
+        pdl_body = ast.unparse(scan_ifs[0])
+        self.assertLess(
+            pdl_body.index("gdc_wait"),
+            pdl_body.index("gdc_launch_dependents"),
+        )
+        self.assertIn("tl.program_id", expand)
+
+
+class TestSharedTokenRoute(unittest.TestCase):
+    def test_token_route_is_built_from_the_request_segments(self):
+        # The token route needs no histogram or sort: a request's tokens are
+        # contiguous and share one slot, so build_routes hands the request
+        # boundaries and the token mapping, unmasked, to the segment builder.
+        reference = SERIAL_MATERIALIZED_REFERENCE
+        shared_plan = dataclasses.replace(
+            reference,
+            gate_up_a=PLAN.LoraASpec(
+                PLAN.Site.GATE_UP,
+                PLAN.LoraAFamily.TOKEN_GROUPED,
+                True,
+                PLAN.BridgeLayout.TOKEN_MAJOR,
+            ),
+            gate_up_b=dataclasses.replace(
+                reference.gate_up_b,
+                input_layout=PLAN.BridgeLayout.TOKEN_MAJOR,
+            ),
+        )
+        topk_ids = torch.tensor([[-1, -1], [-1, 1], [0, -1]], dtype=torch.int32)
+        token_lora_mapping = torch.tensor([0, 1, 0], dtype=torch.int32)
+        seg_indptr = torch.tensor([0, 1, 2, 3], dtype=torch.int32)
+        workspace = _Workspace()
+        seen = {}
+
+        def fake_segment(**kwargs):
+            seen.update(kwargs)
+            return _route(
+                torch.zeros((3, 1), dtype=torch.int32),
+                kwargs["token_lora_mapping"],
+                block_size=kwargs["block_size"],
+                padded_count=torch.tensor([16], dtype=torch.int32),
+                num_local_experts=kwargs["num_local_experts"],
+                max_loras=kwargs["max_loras"],
+                is_shared_outer=True,
+            )
+
+        def fake_aligned(
+            topk_ids, token_lora_mapping, *, is_shared_outer=False, **kwargs
+        ):
+            built = _route(
+                topk_ids,
+                token_lora_mapping,
+                block_size=kwargs["block_size"],
+                padded_count=torch.tensor([16], dtype=torch.int32),
+            )
+            return built
+
+        with (
+            _arch_pdl(False),
+            mock.patch.object(
+                ROUTING, "build_virtual_expert_routing", side_effect=fake_aligned
+            ),
+            mock.patch.object(
+                ROUTING, "_build_segment_token_route", side_effect=fake_segment
+            ),
+        ):
+            routes = ROUTING.build_routes(
+                shared_plan,
+                topk_ids=topk_ids,
+                token_lora_mapping=token_lora_mapping,
+                seg_indptr=seg_indptr,
+                num_local_experts=2,
+                max_loras=2,
+                block_size=16,
+                workspace=workspace,
+            )
+        self.assertIs(seen["seg_indptr"], seg_indptr)
+        self.assertIs(seen["token_lora_mapping"], token_lora_mapping)
+        self.assertEqual(seen["num_tokens"], 3)
+        self.assertIsNotNone(routes.shared_token)
+
+    def test_large_shared_token_route_cannot_overwrite_retained_pair_counts(self):
+        """Every retained fused route gets its OWN workspace keys, even when the
+        per-expert and shared-outer bucket counts collide (num_local_experts=1).
+
+        The hazard is the fused builder's process-global scratch cache, which is
+        keyed by bucket count alone: two routes at the same V would share one
+        scalar, and the T-row shared-token plan would clobber the T*K-row pair
+        plan. build_virtual_expert_routing allocates per ``tensor_prefix``
+        instead, so what this has to pin is that build_routes hands every route
+        a DISTINCT prefix -- storage isolation per name is the workspace's own
+        contract.
+        """
+        reference = SERIAL_MATERIALIZED_REFERENCE
+        shared_plan = dataclasses.replace(
+            reference,
+            gate_up_a=PLAN.LoraASpec(
+                PLAN.Site.GATE_UP,
+                PLAN.LoraAFamily.TOKEN_GROUPED,
+                True,
+                PLAN.BridgeLayout.TOKEN_MAJOR,
+            ),
+            gate_up_b=dataclasses.replace(
+                reference.gate_up_b,
+                input_layout=PLAN.BridgeLayout.TOKEN_MAJOR,
+            ),
+            down_b=dataclasses.replace(
+                reference.down_b,
+                is_shared_outer=True,
+            ),
+        )
+        num_tokens = 16384
+        top_k = 8
+        topk_ids = torch.zeros((num_tokens, top_k), dtype=torch.int32)
+        token_lora_mapping = torch.zeros(num_tokens, dtype=torch.int32)
+
+        for num_local_experts in (1, 2):
+            with self.subTest(num_local_experts=num_local_experts):
+                workspace = _Workspace()
+                prefixes = []
+
+                def fake_route(
+                    route_topk_ids,
+                    route_token_lora_mapping,
+                    *,
+                    num_local_experts,
+                    max_loras,
+                    block_size,
+                    view,
+                    is_shared_outer=False,
+                    workspace=None,
+                    tensor_prefix=None,
+                ):
+                    self.assertEqual(view, "aligned")
+                    self.assertIsNotNone(workspace)
+                    prefixes.append(tensor_prefix)
+                    # Model the real allocation: one scalar per route, named.
+                    padded = workspace.tensor(
+                        f"{tensor_prefix}:padded_pairs",
+                        (1,),
+                        dtype=torch.int32,
+                        device=route_topk_ids.device,
+                    )
+                    padded.fill_(route_topk_ids.numel())
+                    built = _route(
+                        route_topk_ids,
+                        route_token_lora_mapping,
+                        block_size=block_size,
+                        padded_count=padded,
+                        num_local_experts=num_local_experts,
+                        max_loras=max_loras,
+                        is_shared_outer=is_shared_outer,
+                    )
+                    return built
+
+                with (
+                    mock.patch.object(
+                        ROUTING,
+                        "build_virtual_expert_routing",
+                        side_effect=fake_route,
+                    ),
+                    mock.patch.object(
+                        ROUTING,
+                        "_build_segment_token_route",
+                        side_effect=_fake_segment_route([], prefixes),
+                    ),
+                ):
+                    routes = ROUTING.build_routes(
+                        shared_plan,
+                        topk_ids=topk_ids,
+                        token_lora_mapping=token_lora_mapping,
+                        seg_indptr=_segments_of(token_lora_mapping),
+                        num_local_experts=num_local_experts,
+                        max_loras=2,
+                        block_size=16,
+                        workspace=workspace,
+                    )
+
+                # Distinct prefix per route is the whole guarantee.
+                self.assertEqual(
+                    set(prefixes),
+                    {
+                        "route:aligned_per_expert",
+                        "route:aligned_shared_outer",
+                        "route:shared_token",
+                    },
+                )
+                self.assertEqual(len(prefixes), len(set(prefixes)))
+
+                pair_count = num_tokens * top_k
+                self.assertEqual(
+                    routes.aligned_per_expert.maybe_num_pairs_post_padded.item(),
+                    pair_count,
+                )
+                self.assertEqual(
+                    routes.aligned_shared_outer.maybe_num_pairs_post_padded.item(),
+                    pair_count,
+                )
+                self.assertEqual(
+                    routes.shared_token.maybe_num_pairs_post_padded.item(),
+                    num_tokens,
+                )
+                # ... and the scalars are separate storage, so the T-row plan
+                # cannot have overwritten either T*K-row one.
+                pointers = {
+                    route.maybe_num_pairs_post_padded.data_ptr()
+                    for route in (
+                        routes.aligned_per_expert,
+                        routes.aligned_shared_outer,
+                        routes.shared_token,
+                    )
+                }
+                self.assertEqual(len(pointers), 3)
+
+
+class TestRunnerRouteSelectionSource(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        source = (LORA_MOE / "moe_lora_runner.py").read_text()
+        cls.tree = ast.parse(source)
+
+    def _method(self, name: str) -> ast.FunctionDef:
+        runner = next(
+            node
+            for node in self.tree.body
+            if isinstance(node, ast.ClassDef) and node.name == "MoeLoraRunner"
+        )
+        return next(
+            node
+            for node in runner.body
+            if isinstance(node, ast.FunctionDef) and node.name == name
+        )
+
+
+class TestLaunchConfigRoutePreflight(unittest.TestCase):
+    def test_subwarp_route_tile_is_rejected_at_construction(self):
+        # The grouped LoRA kernels take this value as their tl.dot row tile,
+        # so the config constructor itself rejects anything below 16.
+        with self.assertRaisesRegex(ValueError, ">= 16"):
+            LAUNCH.MoeLoraLaunchConfig(routing_block_size=8)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/lora/test_moe_lora_routing.py
+++ b/test/registered/lora/test_moe_lora_routing.py
@@ -1,0 +1,392 @@
+"""Correctness tests for SGL-LoRA virtual-expert routing."""
+
+import unittest
+
+import pytest
+import torch
+
+from sglang.srt.lora.moe.route_view import RouteViewKind
+from sglang.srt.lora.moe.routing import build_virtual_expert_routing
+from sglang.srt.lora.moe.workspace import MoeLoraWorkspace
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+
+def _serial_materialized_reference():
+    """The simplest correct pipeline: every stage standalone, nothing fused,
+    no overlap window."""
+    from sglang.srt.lora.moe.execution_plan import (
+        ActFamily,
+        ActivationFn,
+        ActSpec,
+        BridgeLayout,
+        FinalizeFamily,
+        FinalizeSpec,
+        LoraAFamily,
+        LoraASpec,
+        LoraBFamily,
+        LoraBSpec,
+        MoeLoraExecutionPlan,
+        Site,
+    )
+
+    return MoeLoraExecutionPlan(
+        gate_up_a=LoraASpec(
+            Site.GATE_UP, LoraAFamily.GROUPED, False, BridgeLayout.PAIR_MAJOR
+        ),
+        gate_up_b=LoraBSpec(
+            Site.GATE_UP,
+            LoraBFamily.GROUPED,
+            False,
+            BridgeLayout.PAIR_MAJOR,
+        ),
+        act=ActSpec(ActFamily.MATERIALIZED, ActivationFn.SILU),
+        down_a=LoraASpec(
+            Site.DOWN, LoraAFamily.GROUPED, False, BridgeLayout.PAIR_MAJOR
+        ),
+        down_b=LoraBSpec(
+            Site.DOWN, LoraBFamily.GROUPED, False, BridgeLayout.PAIR_MAJOR
+        ),
+        finalize=FinalizeSpec(FinalizeFamily.MATERIALIZED),
+    )
+
+
+register_cuda_ci(est_time=35, stage="base-b", runner_config="1-gpu-large")
+
+
+class TestMoeLoraRouting(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("CUDA required")
+        cls.device = "cuda:0"
+
+    def _build(
+        self,
+        topk_ids,
+        adapters,
+        *,
+        num_local_experts,
+        max_loras=2,
+        block_size=16,
+        dtype=torch.int32,
+        view=RouteViewKind.ALIGNED,
+    ):
+        # A real workspace, since the fused builder requires one.
+        per_expert = build_virtual_expert_routing(
+            torch.tensor(topk_ids, dtype=dtype, device=self.device),
+            torch.tensor(adapters, dtype=dtype, device=self.device),
+            num_local_experts=num_local_experts,
+            max_loras=max_loras,
+            block_size=block_size,
+            view=view,
+            workspace=MoeLoraWorkspace(),
+            tensor_prefix="test:route",
+        )
+        return per_expert
+
+    def test_narrower_views_refuse_fields_they_did_not_build(self):
+        """A view must not silently hand back a field it never computed.
+
+        The two views exist so a schedule pays only for what it reads (plan
+        section 29 R1). If an unbuilt field returned None instead of raising,
+        a consumer that requested the wrong view would pass None into a Triton
+        launch and fail far from the mistake.
+        """
+        ids, adapters = [[0, 1]], [0]
+        aligned = self._build(
+            ids, adapters, num_local_experts=2, view=RouteViewKind.ALIGNED
+        )
+        self.assertGreater(aligned.sorted_pair_ids.numel(), 0)
+        self.assertGreater(aligned.block_virtual_expert_ids.numel(), 0)
+
+        raw = self._build(ids, adapters, num_local_experts=2, view=RouteViewKind.RAW)
+        for field in ("sorted_pair_ids", "block_virtual_expert_ids"):
+            with self.assertRaisesRegex(ValueError, RouteViewKind.ALIGNED):
+                getattr(raw, field)
+        # A raw consumer fuses the key computation into its own kernel, so the
+        # sources must survive on the view.
+        self.assertEqual(raw.lora_experts_per_adapter, 2)
+        self.assertEqual(raw.token_lora_mapping.numel(), 1)
+
+    def test_unknown_view_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "unknown route view"):
+            self._build([[0, 1]], [0], num_local_experts=2, view="grouped")
+
+    def test_invalid_adapter_and_expert_ids_become_one_sentinel(self):
+        route = self._build(
+            [[-2], [-1], [3], [4], [99], [0], [0]],
+            [0, 0, 0, 0, 0, 2, 3],
+            num_local_experts=4,
+        )
+        # Only pair 2 is valid (adapter 0, expert 3 -> key 3); every other
+        # pair is invalid for a different reason -- negative expert, expert
+        # past the local count, adapter past the capacity -- and they must all
+        # collapse onto the ONE sentinel rather than distinct bad keys.
+        live_blocks = route.num_pairs_post_padded.item() // route.block_size
+        keys = route.block_virtual_expert_ids[:live_blocks].cpu().tolist()
+        self.assertIn(3, keys)
+        self.assertEqual(set(keys) - {-1}, {3})
+
+        live_blocks = route.num_pairs_post_padded.item() // route.block_size
+        live_ids = route.block_virtual_expert_ids[:live_blocks]
+        self.assertTrue(
+            bool(
+                (
+                    (live_ids == -1)
+                    | ((live_ids >= 0) & (live_ids < route.num_virtual_experts))
+                )
+                .all()
+                .item()
+            )
+        )
+
+    def test_int64_source_ids_build_an_int32_plan(self):
+        """int64 sources are accepted; the plan itself stays int32."""
+        route = self._build(
+            [[0, 3], [4, -2]],
+            [0, 1],
+            num_local_experts=4,
+            dtype=torch.int64,
+        )
+        # Adapter 0 owns experts 0 and 3 (keys 0 and 3); adapter 1's pairs are
+        # both invalid -- expert 4 is past the local count, -2 is a sentinel.
+        live_blocks = route.num_pairs_post_padded.item() // route.block_size
+        keys = route.block_virtual_expert_ids[:live_blocks].cpu().tolist()
+        self.assertEqual(set(keys) - {-1}, {0, 3})
+        self.assertEqual(route.sorted_pair_ids.dtype, torch.int32)
+        self.assertEqual(route.block_virtual_expert_ids.dtype, torch.int32)
+
+    def test_sentinel_bucket_is_included_in_capacity(self):
+        route = self._build(
+            [[0], [1], [2], [3], [0], [1], [2], [3], [-1]],
+            [0, 0, 0, 0, 1, 1, 1, 1, 0],
+            num_local_experts=4,
+            block_size=4,
+        )
+        self.assertEqual(route.num_pairs_post_padded.item(), 9 * 4)
+        self.assertGreaterEqual(route.sorted_pair_ids.numel(), 9 * 4)
+        self.assertGreaterEqual(route.block_virtual_expert_ids.numel(), 9)
+
+    def test_aligned_view_policy_boundaries(self):
+        """Pin the two-predicate align policy below, at, and above each edge.
+
+        Sited by the section 40 redo (plan section 13 rule 5): fused when
+        V >= 8192 (the JIT kernel's EPT 8->16 rung edge) OR P >= 16384 (fused
+        wins that column at every V, both timing modes). The policy constants
+        are load-bearing serving behavior; a silent change is a performance
+        regression no correctness test would catch — that exact failure
+        happened once, when a raised kernel ceiling never reached the
+        dispatch — so the values AND the edge behavior are pinned together.
+        """
+        from sglang.srt.lora.moe import routing as routing_module
+        from sglang.srt.lora.moe.route_view import RouteViewKind
+        from sglang.srt.lora.moe.routing import (
+            FUSED_ALIGN_MIN_PAIRS,
+            FUSED_ALIGN_MIN_VIRTUAL_EXPERTS,
+            build_virtual_expert_routing,
+        )
+
+        self.assertEqual(FUSED_ALIGN_MIN_VIRTUAL_EXPERTS, 8192)
+        self.assertEqual(FUSED_ALIGN_MIN_PAIRS, 16384)
+        # The JIT primitive's own ceiling (8191) is asserted where it lives, in
+        # kernels/ops/moe/virtual_experts.py; restating it here could only ever
+        # agree with itself. What guards the dispatch is the edge cases below:
+        # 8192 has to REACH the fused builder, because the JIT path cannot
+        # align it.
+
+        # (V, T, expects_fused): straddles both edges; K = 8 so P = 8 * T.
+        cases = (
+            (8160, 8, False),  # below both edges -> ID pass + JIT
+            (8192, 8, True),  # at the V edge (the EPT rung)
+            (12288, 8, True),  # kimi EP1 x 32 slots, the realistic large case
+            (1024, 2048, True),  # small V, P = 16384: the P edge
+            (1024, 1024, False),  # small V, P = 8192: below the P edge
+            (40960, 8, True),  # above the JIT ceiling: fused is the only path
+        )
+        original = routing_module._build_aligned
+        for num_virtual, num_tokens, expects_fused in cases:
+            num_local_experts = num_virtual // 32
+            with self.subTest(V=num_virtual, P=num_tokens * 8):
+                ids = torch.randint(
+                    0,
+                    num_local_experts,
+                    (num_tokens, 8),
+                    dtype=torch.int32,
+                    device=self.device,
+                )
+                slots = torch.randint(
+                    0, 32, (num_tokens,), dtype=torch.int32, device=self.device
+                )
+                calls: list[bool] = []
+                try:
+
+                    def spy(*args, **kwargs):
+                        calls.append(True)
+                        return original(*args, **kwargs)
+
+                    routing_module._build_aligned = spy
+                    route = build_virtual_expert_routing(
+                        ids,
+                        slots,
+                        num_local_experts=num_local_experts,
+                        max_loras=32,
+                        block_size=16,
+                        view=RouteViewKind.ALIGNED,
+                        workspace=MoeLoraWorkspace(),
+                        tensor_prefix="test:route",
+                    )
+                finally:
+                    routing_module._build_aligned = original
+                self.assertEqual(
+                    bool(calls),
+                    expects_fused,
+                    f"V={num_virtual}, P={num_tokens * 8} took the wrong path",
+                )
+                if expects_fused:
+                    self.assertEqual(len(calls), 1)
+                self.assertGreater(int(route.num_pairs_post_padded), 0)
+                self.assertEqual(route.sorted_pair_ids.dtype, torch.int32)
+                self.assertEqual(route.block_virtual_expert_ids.dtype, torch.int32)
+
+    def test_sentinel_blocks_isolate_invalid_pairs_on_both_align_paths(self):
+        """A5 pin-down (gate-1 packet): the sentinel-bucket contract, black-box.
+
+        Invalid pairs (base tokens, non-owned experts) ride sentinel routes.
+        The contract every LoRA kernel depends on: a block labelled ``-1``
+        never contains a valid pair, a valid pair never sits in a ``-1``
+        block, every slot inside the padded plan is a READABLE index (< P or
+        the padding value P — the stock B kernel dereferences ``-1`` blocks'
+        slots to zero-fill, which is how an uninitialized tail once caused an
+        illegal memory access), and every valid pair appears exactly once
+        under its own key's label. Checked through the dispatch on BOTH
+        policy paths — V=256 (ID pass + JIT) and V=12288 (fused) — since the
+        two implement the contract independently.
+        """
+        for num_local_experts, max_loras in ((8, 32), (384, 32)):
+            num_virtual = num_local_experts * max_loras
+            with self.subTest(V=num_virtual):
+                generator = torch.Generator(device="cpu").manual_seed(23)
+                num_tokens, top_k = 96, 8
+                topk_ids = torch.randint(
+                    -1,
+                    num_local_experts,
+                    (num_tokens, top_k),
+                    generator=generator,
+                    dtype=torch.int32,
+                ).to(self.device)
+                token_lora_mapping = torch.randint(
+                    -1,
+                    max_loras,
+                    (num_tokens,),
+                    generator=generator,
+                    dtype=torch.int32,
+                ).to(self.device)
+                route = build_virtual_expert_routing(
+                    topk_ids,
+                    token_lora_mapping,
+                    num_local_experts=num_local_experts,
+                    max_loras=max_loras,
+                    block_size=16,
+                    view=RouteViewKind.ALIGNED,
+                    workspace=MoeLoraWorkspace(),
+                    tensor_prefix="test:route",
+                )
+                num_pairs = num_tokens * top_k
+                keys = (
+                    torch.where(
+                        (token_lora_mapping[:, None] >= 0) & (topk_ids >= 0),
+                        token_lora_mapping[:, None].to(torch.int64) * num_local_experts
+                        + topk_ids.to(torch.int64),
+                        torch.tensor(-1, dtype=torch.int64, device=self.device),
+                    )
+                    .reshape(-1)
+                    .cpu()
+                )
+                num_padded = int(route.num_pairs_post_padded)
+                sorted_ids = route.sorted_pair_ids.cpu()
+                block_ids = route.block_virtual_expert_ids.cpu()
+                self.assertTrue(bool((keys == -1).any()), "case must have sentinels")
+
+                seen: dict[int, int] = {}
+                for block in range(num_padded // 16):
+                    label = int(block_ids[block])
+                    slots = sorted_ids[block * 16 : (block + 1) * 16]
+                    self.assertTrue(
+                        bool((slots <= num_pairs).all()),
+                        f"block {block} holds an unreadable slot index",
+                    )
+                    real = slots[slots < num_pairs]
+                    for pair in real.tolist():
+                        self.assertNotIn(pair, seen, "pair appears twice in the plan")
+                        seen[pair] = label
+                        if label == -1:
+                            self.assertEqual(
+                                int(keys[pair]),
+                                -1,
+                                f"valid pair {pair} placed in a sentinel block",
+                            )
+                        else:
+                            self.assertEqual(
+                                int(keys[pair]),
+                                label,
+                                f"pair {pair} in block labelled {label}",
+                            )
+                valid = {i for i in range(num_pairs) if int(keys[i]) >= 0}
+                self.assertEqual(
+                    valid,
+                    {p for p, l in seen.items() if l != -1},
+                    "every valid pair must appear exactly once under its key",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)
+
+
+def test_segment_token_route_matches_reference() -> None:
+    """The token route from request segments: each request's tokens in place,
+    padded to whole blocks and keyed by its slot; requests without an adapter
+    and empty requests add no block; leftover blocks read -1."""
+    if not torch.cuda.is_available():
+        pytest.skip("route kernels need CUDA")
+    from sglang.srt.lora.moe.routing import _build_segment_token_route
+    from sglang.srt.lora.moe.workspace import MoeLoraWorkspace
+
+    device = torch.device("cuda")
+    block = 16
+    seg_lens = [5, 0, 17, 3, 16, 2]
+    slots = [0, 2, 1, -1, 1, 0]
+    seg_indptr = torch.tensor(
+        [0] + list(torch.tensor(seg_lens).cumsum(0)), dtype=torch.int32, device=device
+    )
+    num_tokens = int(seg_indptr[-1])
+    mapping = torch.cat(
+        [torch.full((n,), s, dtype=torch.int32) for n, s in zip(seg_lens, slots)]
+    ).to(device)
+    workspace = MoeLoraWorkspace()
+    workspace.begin_forward(graph_mode=False)
+    route = _build_segment_token_route(
+        seg_indptr=seg_indptr,
+        token_lora_mapping=mapping,
+        num_tokens=num_tokens,
+        num_local_experts=4,
+        max_loras=3,
+        block_size=block,
+        workspace=workspace,
+    )
+    torch.cuda.synchronize()
+    exp_sorted, exp_blocks, start = [], [], 0
+    for n, s in zip(seg_lens, slots):
+        if n > 0 and s >= 0:
+            padded = -(-n // block) * block
+            exp_sorted += [start + i if i < n else num_tokens for i in range(padded)]
+            exp_blocks += [s] * (padded // block)
+        start += n
+    padded_total = len(exp_sorted)
+    assert int(route.maybe_num_pairs_post_padded.item()) == padded_total
+    assert route.maybe_sorted_pair_ids[:padded_total].tolist() == exp_sorted
+    blocks = route.maybe_block_virtual_expert_ids.tolist()
+    assert blocks[: len(exp_blocks)] == exp_blocks
+    assert all(b == -1 for b in blocks[len(exp_blocks) :])
+    assert route.topk_ids.shape == (num_tokens, 1) and route.is_shared_outer

--- a/test/registered/lora/test_moe_lora_schedule_builder.py
+++ b/test/registered/lora/test_moe_lora_schedule_builder.py
@@ -1,0 +1,307 @@
+"""The packed tile schedule must enumerate exactly the valid tiles.
+
+`build_dual_stage_schedules_masked` is the only producer of what the direct-schedule
+CuTeDSL GEMM treats as its work list, and a wrong schedule is SILENT
+corruption: tiles pointing at rows the GEMM considers padding, or valid rows
+never scheduled, with no device assertion anywhere. Nothing else in the suite
+covers it — the provider-level tests run one uniform-occupancy shape on SM100,
+so a ragged `masked_m`, a zero-row expert, the ABI ceilings, and the
+ordering-heuristic branch were all unguarded (gate-2 review).
+
+Triton only: no SM100 requirement, so this also runs on the H200 pod.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import torch
+
+from sglang.srt.lora.moe.kernels.cutedsl.schedule_builder import (
+    EXPERT_MASK,
+    MAX_EXPERTS,
+    MAX_OUTPUT_CLUSTERS,
+    MAX_TOKEN_CLUSTERS,
+    OUTPUT_CLUSTER_MASK,
+    OUTPUT_CLUSTER_SHIFT,
+    TOKEN_CLUSTER_MASK,
+    TOKEN_CLUSTER_SHIFT,
+    build_dual_stage_schedules_masked,
+    dual_stage_schedule_capacities_masked,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=30, stage="base-b", runner_config="1-gpu-large")
+
+
+def _decode(packed: int) -> tuple[int, int, int]:
+    """Decode with the ABI constants shared by builder and device scheduler."""
+    return (
+        packed & EXPERT_MASK,
+        (packed >> TOKEN_CLUSTER_SHIFT) & TOKEN_CLUSTER_MASK,
+        (packed >> OUTPUT_CLUSTER_SHIFT) & OUTPUT_CLUSTER_MASK,
+    )
+
+
+class TestMoeLoraScheduleBuilder(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("CUDA is required")
+        cls.device = torch.device("cuda")
+
+    def _build(self, rows, *, m_max, token_width, n_gemm1, n_gemm2, output_width=128):
+        masked_m = torch.tensor(rows, dtype=torch.int32, device=self.device)
+        return build_dual_stage_schedules_masked(
+            masked_m,
+            m_max=m_max,
+            token_width=token_width,
+            n_gemm1=n_gemm1,
+            n_gemm2=n_gemm2,
+            output_width=output_width,
+        )
+
+    def _expected_entries(self, rows, token_width, out_clusters):
+        """Every (expert, token_cluster, output_cluster) the GEMM must cover."""
+        expected = set()
+        for expert, valid in enumerate(rows):
+            for token_cluster in range((valid + token_width - 1) // token_width):
+                for output_cluster in range(out_clusters):
+                    expected.add((expert, token_cluster, output_cluster))
+        return expected
+
+    def test_ragged_occupancy_enumerates_exactly_the_valid_tiles(self):
+        """The set of scheduled tiles equals the set the row counts imply.
+
+        Ragged on purpose, including a zero-row expert (which must contribute
+        NO tiles at all — the kernel's contract is that no CTA is launched
+        wholly outside an expert's valid rows) and a partial trailing cluster.
+        """
+        rows = [5, 0, 96, 1, 129, 64]
+        token_width, output_width = 8, 128
+        n_gemm1, n_gemm2 = 512, 256
+        schedule1, tiles1, schedule2, tiles2 = self._build(
+            rows,
+            m_max=256,
+            token_width=token_width,
+            n_gemm1=n_gemm1,
+            n_gemm2=n_gemm2,
+            output_width=output_width,
+        )
+
+        for schedule, tiles, n_out in (
+            (schedule1, tiles1, n_gemm1),
+            (schedule2, tiles2, n_gemm2),
+        ):
+            out_clusters = (n_out + output_width - 1) // output_width
+            expected = self._expected_entries(rows, token_width, out_clusters)
+            count = int(tiles[0].item())
+            self.assertEqual(count, len(expected))
+            decoded = [_decode(int(v)) for v in schedule[:count].tolist()]
+            # A multiset comparison, so a duplicated tile fails even though the
+            # count would still match a set comparison.
+            self.assertEqual(len(decoded), len(set(decoded)))
+            self.assertEqual(set(decoded), expected)
+            self.assertNotIn(1, {entry[0] for entry in decoded})
+
+    def test_ordering_sweeps_the_shorter_axis_fastest(self):
+        """Consecutive entries share the longer axis; the shorter one varies.
+
+        This is the L2 rule: the operand re-read across concurrently resident
+        clusters must be the one with fewer tiles, so it stays cache-resident.
+        Both branches of the heuristic are exercised by choosing geometries
+        where token clusters are fewer, then more, than output clusters.
+        """
+        output_width = 128
+        # 2 token clusters vs 4 output clusters -> token axis is shorter.
+        _, _, schedule, tiles = self._build(
+            [16],
+            m_max=256,
+            token_width=8,
+            n_gemm1=128,
+            n_gemm2=512,
+            output_width=output_width,
+        )
+        entries = [_decode(int(v)) for v in schedule[: int(tiles[0].item())].tolist()]
+        self.assertEqual(
+            [(e[1], e[2]) for e in entries],
+            [(tc, oc) for oc in range(4) for tc in range(2)],
+        )
+
+        # 8 token clusters vs 1 output cluster -> output axis is shorter.
+        _, _, schedule, tiles = self._build(
+            [64],
+            m_max=256,
+            token_width=8,
+            n_gemm1=128,
+            n_gemm2=128,
+            output_width=output_width,
+        )
+        entries = [_decode(int(v)) for v in schedule[: int(tiles[0].item())].tolist()]
+        self.assertEqual(
+            [(e[1], e[2]) for e in entries],
+            [(tc, oc) for tc in range(8) for oc in range(1)],
+        )
+
+    def test_dual_builder_reuses_graph_outputs(self):
+        """CUDA-graph replay needs stable addresses, so the builder must write
+        into the caller's buffers instead of allocating new ones.
+        """
+        rows = [5, 0, 96, 1, 129, 64]
+        masked_m = torch.tensor(rows, dtype=torch.int32, device=self.device)
+        common = dict(m_max=256, token_width=8, output_width=128)
+        buffers = build_dual_stage_schedules_masked(
+            masked_m,
+            n_gemm1=512,
+            n_gemm2=256,
+            **common,
+        )
+        pointers = tuple(tensor.data_ptr() for tensor in buffers)
+        masked_m.copy_(
+            torch.tensor([0, 8, 17, 64, 3, 1], dtype=torch.int32, device=self.device)
+        )
+        reused = build_dual_stage_schedules_masked(
+            masked_m,
+            n_gemm1=512,
+            n_gemm2=256,
+            schedule1_out=buffers[0],
+            tiles1_out=buffers[1],
+            schedule2_out=buffers[2],
+            tiles2_out=buffers[3],
+            **common,
+        )
+        self.assertEqual(tuple(tensor.data_ptr() for tensor in reused), pointers)
+        count = int(reused[1].item())
+        expected = self._expected_entries(masked_m.cpu().tolist(), 8, 4)
+        decoded = [_decode(int(v)) for v in reused[0][:count].tolist()]
+        self.assertEqual(len(decoded), len(set(decoded)))
+        self.assertEqual(set(decoded), expected)
+
+    def test_packing_round_trips_at_the_top_of_the_output_field(self):
+        """Every representable output-cluster index survives the round trip.
+
+        The output field is the top one, ending one bit below int64's sign bit,
+        so saturating it is where a packed word would go negative. One expert
+        with one token cluster, so the entry count IS the field width; decoded
+        on device because 2^21 entries is slow as a Python list.
+        """
+        output_width = 128
+        out_clusters = MAX_OUTPUT_CLUSTERS  # indices 0 .. MAX-1
+        _, _, schedule, tiles = self._build(
+            [8],
+            m_max=8,
+            token_width=8,
+            n_gemm1=output_width,
+            n_gemm2=out_clusters * output_width,
+            output_width=output_width,
+        )
+        count = int(tiles[0].item())
+        self.assertEqual(count, out_clusters)
+        values = schedule[:count]
+        self.assertGreaterEqual(
+            int(values.min().item()), 0, "a packed word went negative"
+        )
+        zeros = torch.zeros(count, dtype=torch.int64, device=values.device)
+        expected_oc = torch.arange(count, dtype=torch.int64, device=values.device)
+        for actual, expected in (
+            (values & EXPERT_MASK, zeros),
+            ((values >> TOKEN_CLUSTER_SHIFT) & TOKEN_CLUSTER_MASK, zeros),
+            ((values >> OUTPUT_CLUSTER_SHIFT) & OUTPUT_CLUSTER_MASK, expected_oc),
+        ):
+            torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+    def test_rejects_geometry_the_packing_cannot_represent(self):
+        """The ABI ceilings are enforced, checked through the pure validator.
+
+        Through ``dual_stage_schedule_capacities_masked`` rather than the builder
+        because it takes the expert count as an int: materialising a
+        2^20-element tensor to prove 2^20 + 1 is refused would be an expensive
+        way to test nothing.
+        """
+        common = dict(token_width=8, n_gemm1=128, n_gemm2=128, output_width=128)
+        # m_max at token width 8 needs more token clusters than the field holds.
+        with self.assertRaisesRegex(ValueError, "token clusters"):
+            dual_stage_schedule_capacities_masked(
+                num_experts=4, m_max=(MAX_TOKEN_CLUSTERS + 1) * 8, **common
+            )
+        # The largest representable expert count, then one past it.
+        dual_stage_schedule_capacities_masked(
+            num_experts=MAX_EXPERTS, m_max=256, **common
+        )
+        with self.assertRaisesRegex(ValueError, "expert"):
+            dual_stage_schedule_capacities_masked(
+                num_experts=MAX_EXPERTS + 1, m_max=256, **common
+            )
+        # Fields can individually fit while the worst-case capacity overflows
+        # the kernel's int32 prefix arithmetic.
+        with self.assertRaisesRegex(ValueError, "capacity"):
+            dual_stage_schedule_capacities_masked(
+                num_experts=1024,
+                m_max=1024 * 8,
+                token_width=8,
+                n_gemm1=MAX_OUTPUT_CLUSTERS * 128,
+                n_gemm2=128,
+                output_width=128,
+            )
+        # One output cluster past the usable field width.
+        with self.assertRaisesRegex(ValueError, "output clusters"):
+            dual_stage_schedule_capacities_masked(
+                num_experts=4,
+                m_max=256,
+                token_width=8,
+                n_gemm1=128,
+                n_gemm2=(MAX_OUTPUT_CLUSTERS + 1) * 128,
+                output_width=128,
+            )
+
+    def test_rejects_nontrivial_cluster_config(self):
+        """Only a 1x1 cluster with 1-CTA MMA is representable.
+
+        The builder emits CTA-tile-granularity indices that the device expands
+        by cluster_shape_mn; any other cluster would over-enumerate silently.
+        """
+        masked_m = torch.zeros(4, dtype=torch.int32, device=self.device)
+        common = dict(
+            m_max=256, token_width=8, n_gemm1=128, n_gemm2=128, output_width=128
+        )
+        with self.assertRaisesRegex(ValueError, "cluster"):
+            build_dual_stage_schedules_masked(
+                masked_m, cluster_shape_mn=(2, 1), **common
+            )
+        with self.assertRaisesRegex(ValueError, "cluster"):
+            build_dual_stage_schedules_masked(masked_m, use_2cta_instrs=True, **common)
+
+    def test_packed_word_is_int64_and_round_trips_past_the_old_int32_fields(self):
+        """The widened ABI must survive the trip through the device buffer.
+
+        4096 output clusters against the old int32 layout's cap of 2048, so
+        this fails outright on that ABI rather than passing for a wrong reason.
+        """
+        rows = [3, 0, 7]
+        token_width, output_width = 8, 128
+        out_clusters2 = 4096
+        _schedule1, _tiles1, schedule2, tiles2 = self._build(
+            rows,
+            m_max=256,
+            token_width=token_width,
+            n_gemm1=output_width,  # 1 output cluster keeps stage 1 small
+            n_gemm2=out_clusters2 * output_width,
+            output_width=output_width,
+        )
+        self.assertEqual(schedule2.dtype, torch.int64)
+        # Packed words stay non-negative: the ABI leaves bit 63 clear so the
+        # host can read entries back without sign games.
+        self.assertGreaterEqual(int(schedule2.min().item()), 0)
+
+        entries = schedule2[: int(tiles2[0].item())].tolist()
+        self.assertEqual(
+            {_decode(int(word)) for word in entries},
+            self._expected_entries(rows, token_width, out_clusters2),
+        )
+        # Confirm the field that overflows the old layout is really exercised.
+        self.assertGreater(max(_decode(int(word))[2] for word in entries), 2047)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/lora/test_moe_lora_workspace.py
+++ b/test/registered/lora/test_moe_lora_workspace.py
@@ -1,0 +1,171 @@
+"""CPU tests for bounded MoE LoRA workspace retention."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-c-test-cpu")
+
+_SOURCE = (
+    Path(__file__).resolve().parents[3] / "python/sglang/srt/lora/moe/workspace.py"
+)
+_SPEC = importlib.util.spec_from_file_location("_moe_lora_workspace", _SOURCE)
+assert _SPEC is not None and _SPEC.loader is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = _MODULE
+_SPEC.loader.exec_module(_MODULE)
+
+MoeLoraWorkspace = _MODULE.MoeLoraWorkspace
+
+
+def test_eager_buffers_retain_only_largest_capacity_per_semantic_name():
+    workspace = MoeLoraWorkspace()
+    workspace.begin_forward(graph_mode=False)
+
+    first = workspace.tensor(
+        "rank",
+        (8, 4),
+        dtype=torch.bfloat16,
+        device="cpu",
+    )
+    smaller = workspace.tensor(
+        "rank",
+        (2, 4),
+        dtype=torch.bfloat16,
+        device="cpu",
+    )
+    assert first.untyped_storage().data_ptr() == smaller.untyped_storage().data_ptr()
+    assert first.untyped_storage().nbytes() == 8 * 4 * torch.bfloat16.itemsize
+
+    larger = workspace.tensor(
+        "rank",
+        (16, 4),
+        dtype=torch.bfloat16,
+        device="cpu",
+    )
+    assert larger.numel() == 64
+    assert larger.untyped_storage().nbytes() == 16 * 4 * torch.bfloat16.itemsize
+
+
+def test_graph_buckets_keep_exact_shapes_separate_from_eager_capacity():
+    workspace = MoeLoraWorkspace()
+    workspace.begin_forward(graph_mode=False)
+    workspace.tensor(
+        "delta",
+        (8,),
+        dtype=torch.float32,
+        device="cpu",
+    )
+
+    workspace.begin_forward(graph_mode=True)
+    graph_small = workspace.tensor(
+        "delta",
+        (4,),
+        dtype=torch.float32,
+        device="cpu",
+    )
+    graph_small_again = workspace.tensor(
+        "delta",
+        (4,),
+        dtype=torch.float32,
+        device="cpu",
+    )
+    graph_large = workspace.tensor(
+        "delta",
+        (16,),
+        dtype=torch.float32,
+        device="cpu",
+    )
+
+    assert graph_small.data_ptr() == graph_small_again.data_ptr()
+    assert graph_small.data_ptr() != graph_large.data_ptr()
+
+
+def test_zero_on_first_allocation_preserves_self_restored_eager_state():
+    workspace = MoeLoraWorkspace()
+    workspace.begin_forward(graph_mode=False)
+    counts = workspace.tensor(
+        "route_counts",
+        (8,),
+        dtype=torch.int32,
+        device="cpu",
+        zero_on_first_allocation=True,
+    )
+    assert torch.equal(counts, torch.zeros_like(counts))
+
+    # The route scan restores this invariant on device. A repeated workspace
+    # lookup must not enqueue another memset or overwrite that kernel-owned
+    # state.
+    counts.fill_(7)
+    reused = workspace.tensor(
+        "route_counts",
+        (4,),
+        dtype=torch.int32,
+        device="cpu",
+        zero_on_first_allocation=True,
+    )
+    assert reused.data_ptr() == counts.data_ptr()
+    assert torch.equal(reused, torch.full_like(reused, 7))
+
+    # Growing eager capacity allocates new storage, which does need its one
+    # initialization before the first histogram launch.
+    grown = workspace.tensor(
+        "route_counts",
+        (16,),
+        dtype=torch.int32,
+        device="cpu",
+        zero_on_first_allocation=True,
+    )
+    assert torch.equal(grown, torch.zeros_like(grown))
+
+
+def test_run_parallel_cpu_preserves_dependency_order_and_compute_result():
+    workspace = MoeLoraWorkspace()
+    order = []
+
+    def side():
+        order.append("side")
+
+    def compute():
+        order.append("compute")
+        return "result"
+
+    result = workspace.run_parallel(
+        name="cpu_order",
+        device=torch.device("cpu"),
+        compute=compute,
+        side=side,
+    )
+
+    assert result == "result"
+    assert order == ["side", "compute"]
+
+
+def test_parallel_region_state_fails_closed_when_first_used_during_capture(
+    monkeypatch,
+):
+    workspace = MoeLoraWorkspace()
+    monkeypatch.setattr(workspace, "_capturing", lambda _device: True)
+
+    with pytest.raises(
+        RuntimeError,
+        match="side stream was not created before CUDA capture",
+    ):
+        workspace.side_stream("cuda:0")
+
+    with pytest.raises(
+        RuntimeError,
+        match="event was not created before CUDA capture: missing:ready",
+    ):
+        workspace.event("cuda:0", "missing:ready")
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/test/registered/lora/test_moe_lora_workspace.py
+++ b/test/registered/lora/test_moe_lora_workspace.py
@@ -167,5 +167,22 @@ def test_parallel_region_state_fails_closed_when_first_used_during_capture(
         workspace.event("cuda:0", "missing:ready")
 
 
+def test_graph_mode_iota_keeps_its_address_when_eager_iota_grows():
+    workspace = MoeLoraWorkspace()
+    workspace.begin_forward(graph_mode=True)
+    captured = workspace.iota(8, "cpu")
+    address = captured.data_ptr()
+
+    workspace.begin_forward(graph_mode=False)
+    grown = workspace.iota(64, "cpu")
+    assert grown.numel() == 64 and int(grown[-1]) == 63
+
+    workspace.begin_forward(graph_mode=True)
+    replay = workspace.iota(8, "cpu")
+    assert replay.data_ptr() == address
+    torch.testing.assert_close(replay, torch.arange(8, dtype=torch.int32))
+    assert workspace.iota(16, "cpu").data_ptr() != address
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/lora/test_lora_manager_tied_lm_head.py
+++ b/test/registered/unit/lora/test_lora_manager_tied_lm_head.py
@@ -64,6 +64,8 @@ class TestTiedLMHeadLoRA(CustomTestCase):
         manager.base_model = model
         manager.base_hf_config = SimpleNamespace(num_hidden_layers=0)
         manager.target_modules = {"lm_head"}
+        manager.dense_target_modules = {"lm_head"}
+        manager.moe_target_modules = set()
         wrapped_lm_head = object()
 
         inkling_module = types.ModuleType("sglang.srt.models.inkling_common.dense_mlp")

--- a/test/registered/unit/lora/test_moe_lora_act_quant_fusion.py
+++ b/test/registered/unit/lora/test_moe_lora_act_quant_fusion.py
@@ -1,0 +1,84 @@
+"""The fused act+quant emits the same bf16 rows as the unfused act, and the
+same fp8 rows + scales the launcher's separate per-token-group quant would
+have produced from those bf16 rows."""
+
+import pytest
+import torch
+
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=30, stage="base-b", runner_config="1-gpu-large")
+
+from sglang.srt.lora.moe.kernels.activation_delta import act_delta_contiguous
+
+
+def _skip_unless_cuda():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+
+
+@pytest.mark.parametrize("inter", [128, 256, 384, 1152])
+@pytest.mark.parametrize("with_delta", [True, False])
+def test_fused_act_quant_matches_unfused(inter, with_delta):
+    _skip_unless_cuda()
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    num_tokens, top_k, num_experts, group = 7, 3, 8, 128
+    num_pairs = num_tokens * top_k
+
+    gateup = torch.randn(num_pairs, 2 * inter, dtype=torch.bfloat16, device=device)
+    delta = (
+        0.1
+        * torch.randn(num_tokens, top_k, 2 * inter, dtype=torch.bfloat16, device=device)
+        if with_delta
+        else None
+    )
+    topk_ids = torch.randint(
+        0, num_experts, (num_tokens, top_k), dtype=torch.int32, device=device
+    )
+    topk_ids[0, 0] = -1  # one invalid pair keeps the masking honest
+    pair_to_row = torch.arange(num_pairs, dtype=torch.int32, device=device)
+
+    def run(act_quant):
+        act = torch.zeros(num_pairs, inter, dtype=torch.bfloat16, device=device)
+        pairs = torch.zeros(
+            num_tokens, top_k, inter, dtype=torch.bfloat16, device=device
+        )
+        act_delta_contiguous(
+            gateup,
+            delta,
+            act,
+            pairs,
+            pair_to_row,
+            topk_ids,
+            num_experts,
+            act_quant=act_quant,
+        )
+        return act, pairs
+
+    ref_act, ref_pairs = run(None)
+    act_q = torch.zeros(num_pairs, inter, dtype=torch.float8_e4m3fn, device=device)
+    act_s = torch.zeros(num_pairs, inter // group, dtype=torch.float32, device=device)
+    fused_act, fused_pairs = run((act_q, act_s, group))
+
+    # The bf16 outputs are byte-identical: same kernel, extra stores only.
+    assert torch.equal(fused_act, ref_act)
+    assert torch.equal(fused_pairs, ref_pairs)
+
+    # The fp8 side matches the launcher's separate quant of the bf16 rows.
+    from sglang.kernels.ops.quantization.fp8_kernel import (
+        sglang_per_token_group_quant_fp8,
+    )
+
+    ref_q, ref_s = sglang_per_token_group_quant_fp8(ref_act, group)
+    valid_rows = (topk_ids.flatten() >= 0).nonzero(as_tuple=True)[0]
+    # Same arithmetic as the reference quantizer (amax / 448, reciprocal
+    # multiply, clamp), so codes and scales are bitwise equal.
+    assert torch.equal(act_s[valid_rows], ref_s[valid_rows])
+    assert torch.equal(
+        act_q[valid_rows].view(torch.uint8), ref_q[valid_rows].view(torch.uint8)
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/lora/test_moe_lora_b_act.py
+++ b/test/registered/unit/lora/test_moe_lora_b_act.py
@@ -1,0 +1,387 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang.srt.lora.moe.execution_plan import (
+    ActFamily,
+    ActivationFn,
+    ActSpec,
+    BridgeLayout,
+    DeviceArchitecture,
+    FinalizeFamily,
+    FinalizeSpec,
+    LoraAFamily,
+    LoraASpec,
+    LoraBFamily,
+    LoraBSpec,
+    MoeLoraExecutionPlan,
+    Phase,
+    SelectedPlan,
+    Site,
+    build_plan,
+    load_plans,
+    resolve_plans,
+)
+from sglang.srt.lora.moe.launch_config import resolve_tiles
+from sglang.test.ci.ci_register import register_cuda_ci
+
+
+def _segments_of(mapping: torch.Tensor) -> torch.Tensor:
+    """Request boundaries for a test batch: one request per token, so the
+    segment route is exercised with many short requests and the helper stays
+    free of host syncs (CUDA-graph capture forbids a device-to-host copy)."""
+    return torch.arange(mapping.numel() + 1, dtype=torch.int32, device=mapping.device)
+
+
+register_cuda_ci(est_time=150, stage="base-b", runner_config="1-gpu-large")
+
+_GB300 = DeviceArchitecture.GB300
+_H200 = DeviceArchitecture.H200
+_SWIGLU = ActivationFn.SILU
+
+
+def _menu(architecture, layout, activation=_SWIGLU):
+    """Build every plan row with the loader and builder that serving uses.
+
+    ``resolve_plans`` checks the phase and the rank, then keeps one row for
+    each phase. This helper skips those checks and returns every row.
+    """
+    table = load_plans(architecture)
+    layout_name = "shared" if layout else "per_expert"
+    return {
+        row.name: SelectedPlan(
+            key=f"{architecture.value}.{layout_name}.{row.name}",
+            name=row.name,
+            base_gemm_rows=row.base_gemm_rows,
+            plan=build_plan(row.plan, activation=activation, is_shared_outer=layout),
+        )
+        for row in (*table.scenarios, *table.fallback)
+        if row.layout in (None, layout_name)
+    }
+
+
+def _shipped_launch(architecture, sel, *, physical_rank=16, num_tokens=4096):
+    return resolve_tiles(
+        architecture_value=architecture.value,
+        plan_key_name=sel.name,
+        physical_rank=physical_rank,
+    ).config_for(num_tokens)
+
+
+def _build_plan(
+    *,
+    activation=_SWIGLU,
+    is_shared_outer=False,
+    act_family=ActFamily.MATERIALIZED,
+    down_b_into_base=False,
+) -> MoeLoraExecutionPlan:
+    pe = False
+    consumes_gate_up_b = act_family is ActFamily.B_ACTIVATION
+    return MoeLoraExecutionPlan(
+        gate_up_a=LoraASpec(
+            Site.GATE_UP,
+            LoraAFamily.GROUPED,
+            is_shared_outer,
+            BridgeLayout.PAIR_MAJOR,
+        ),
+        gate_up_b=(
+            None
+            if consumes_gate_up_b
+            else LoraBSpec(
+                Site.GATE_UP,
+                LoraBFamily.GROUPED,
+                pe,
+                BridgeLayout.PAIR_MAJOR,
+            )
+        ),
+        act=ActSpec(act_family, activation),
+        down_a=LoraASpec(Site.DOWN, LoraAFamily.GROUPED, pe, BridgeLayout.PAIR_MAJOR),
+        down_b=LoraBSpec(
+            Site.DOWN,
+            LoraBFamily.GROUPED,
+            is_shared_outer,
+            BridgeLayout.PAIR_MAJOR,
+        ),
+        finalize=FinalizeSpec(FinalizeFamily.MATERIALIZED),
+        down_b_into_base=down_b_into_base,
+    )
+
+
+class TestBActConfig:
+    def test_h200_serial_prefill_ships_it_too(self) -> None:
+        serial = _menu(_H200, False)["prefill.per_expert"]
+        assert serial.plan.act.family is ActFamily.B_ACTIVATION
+        assert serial.plan.gate_up_b is None
+        assert serial.plan.down_b_into_base is True
+        assert serial.base_gemm_rows == "route_major"
+
+    def test_decode_choices_keep_the_materialized_act(self) -> None:
+        for architecture in (_GB300, _H200):
+            for layout in (False, True):
+                for activation in (_SWIGLU, ActivationFn.RELU2):
+                    for name, choice in _menu(architecture, layout, activation).items():
+                        if not name.startswith("decode.") and name != "fallback.decode":
+                            continue
+                        assert choice.plan.act.family is ActFamily.MATERIALIZED, name
+                        assert choice.plan.gate_up_b is not None, name
+
+    def test_out_of_domain_prefill_rows_get_the_swap(self) -> None:
+        def _prefill(is_shared_outer, activation=_SWIGLU):
+            return resolve_plans(
+                architecture=_GB300,
+                is_shared_outer=is_shared_outer,
+                physical_rank=16,
+                activation=activation,
+                hidden_size=8192,  # outside the gb300 tuned domain
+                num_local_experts=256,
+            )[Phase.PREFILL]
+
+        per_expert = _prefill(False)
+        shared = _prefill(True)
+        relu2 = _prefill(False, ActivationFn.RELU2)
+        for sel in (per_expert, relu2):
+            assert sel.name == "fallback.prefill.per_expert"
+        assert shared.name == "fallback.prefill.shared"
+        # Both layouts add down-B into the base output. The epilogue finds its
+        # rows through pair_to_row, so a shared down-B factor does not prevent it.
+        # A row does not depend on the activation, so the ReLU2 row matches.
+        assert per_expert.plan.act.family is ActFamily.B_ACTIVATION
+        assert per_expert.plan.gate_up_b is None
+        assert per_expert.plan.down_b_into_base is True
+        assert per_expert.base_gemm_rows == "route_major"
+        assert shared.plan.act.family is ActFamily.B_ACTIVATION
+        assert shared.plan.gate_up_b is None
+        assert shared.plan.down_b_into_base is True
+        assert shared.base_gemm_rows == "expert_major"
+        assert relu2.plan.act.family is ActFamily.B_ACTIVATION
+        assert relu2.plan.act.activation is ActivationFn.RELU2
+        assert relu2.plan.down_b_into_base is True
+
+
+def _cutedsl_ready() -> bool:
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability() < (9, 0):
+        return False
+    try:
+        import cuda.bindings.driver  # noqa: F401
+        import cutlass  # noqa: F401
+    except Exception:
+        return False
+    return True
+
+
+cutedsl_cuda_only = pytest.mark.skipif(
+    not _cutedsl_ready(),
+    reason="the runner-level oracle runs the CuTeDSL providers",
+)
+
+_HIDDEN = 128
+_INTERMEDIATE = 128
+_RANK = 16
+_SLOTS = 2
+_TOP_K = 2
+_ROUTED_SCALING = 0.75
+
+# The b_act middle adds each pair's gate/up delta inside the FP32 activation
+# math. The shipped path writes that delta to BF16 first, then reads it back.
+# The two paths round at different points, so compare them with a tolerance.
+_B_ACT_TOLERANCE = {"atol": 1e-2, "rtol": 0.05}
+
+
+def _make_gpu_tensors(num_tokens: int, num_experts: int, device: torch.device):
+    generator = torch.Generator().manual_seed(0xB0AC + num_tokens)
+
+    def rand_bf16(shape, scale):
+        return (torch.randn(shape, generator=generator) * scale).to(torch.bfloat16)
+
+    tensors = {
+        "hidden_states": rand_bf16((num_tokens, _HIDDEN), 0.20),
+        "w13_weight": rand_bf16((num_experts, 2 * _INTERMEDIATE, _HIDDEN), 0.08),
+        "w2_weight": rand_bf16((num_experts, _HIDDEN, _INTERMEDIATE), 0.08),
+        "gate_up_lora_a": rand_bf16((_SLOTS, num_experts, 2 * _RANK, _HIDDEN), 0.15),
+        "gate_up_lora_b": rand_bf16(
+            (_SLOTS, num_experts, 2 * _INTERMEDIATE, _RANK), 0.15
+        ),
+        "down_lora_a": rand_bf16((_SLOTS, num_experts, _RANK, _INTERMEDIATE), 0.15),
+        "down_lora_b": rand_bf16((_SLOTS, num_experts, _HIDDEN, _RANK), 0.15),
+        "adapter_enabled": torch.tensor([1, 1], dtype=torch.int32),
+    }
+    # Slot 1 is a narrow adapter. Its rank padding is zero in all four
+    # factors. A batch with mixed ranks reaches the kernels in this form.
+    half = _RANK // 2
+    tensors["gate_up_lora_a"][1].view(num_experts, 2, _RANK, _HIDDEN)[
+        :, :, half:, :
+    ] = 0
+    tensors["down_lora_a"][1, :, half:, :] = 0
+    tensors["gate_up_lora_b"][1, :, :, half:] = 0
+    tensors["down_lora_b"][1, :, :, half:] = 0
+
+    scores = torch.rand((num_tokens, num_experts), generator=generator)
+    scores[: num_tokens // 2, 0] += 4.0  # one expert gets many more pairs
+    topk_ids = torch.topk(scores, _TOP_K, dim=1).indices.to(torch.int32)
+    topk_ids[0] = -1  # a token with no routed pair
+    topk_ids[5, 1] = -1  # one sentinel pair inside a token that keeps a routed pair
+    tensors["topk_ids"] = topk_ids.contiguous()
+    weights = torch.rand((num_tokens, _TOP_K), generator=generator) + 0.1
+    tensors["topk_weights"] = (weights / weights.sum(dim=1, keepdim=True)).float()
+    tensors["router_logits"] = torch.zeros(
+        (num_tokens, num_experts), dtype=torch.float32
+    )
+    return {name: tensor.to(device) for name, tensor in tensors.items()}
+
+
+def _token_lora_mapping(traffic: str, num_tokens: int) -> torch.Tensor:
+    if traffic == "active":
+        pattern = torch.tensor([0, 1], dtype=torch.int32)
+    elif traffic == "mixed":
+        pattern = torch.tensor([0, -1, 1, -1], dtype=torch.int32)
+    elif traffic == "base_only":
+        pattern = torch.tensor([-1], dtype=torch.int32)
+    else:
+        raise AssertionError(traffic)
+    return pattern.repeat(-(-num_tokens // pattern.numel()))[:num_tokens].contiguous()
+
+
+def _standalone_output_allocation(runner, *, num_tokens, dtype, device):
+    return torch.empty((num_tokens, runner.hidden_size), dtype=dtype, device=device)
+
+
+def _reference_choice():
+    """Return the serial materialized reference with the decode fallback's tiles.
+
+    The decode fallback carries a complete tuned launch config, so the swapped
+    plans can share one config. Its plan is the swept winner (indexed gate_up_a
+    plus both overlap windows), not the serial shape this reference needs, so
+    the plan is built by hand; only the row's tiles are borrowed.
+    """
+    choice = _menu(_GB300, False)["fallback.decode"]
+    assert choice.plan.act.family is ActFamily.MATERIALIZED
+    assert choice.plan.down_b_into_base is False
+    return SelectedPlan(
+        key=choice.key,
+        name=choice.name,
+        base_gemm_rows=choice.base_gemm_rows,
+        plan=_build_plan(),
+    )
+
+
+def _bind_test_menu(runner, plan, launch_config):
+    """Publish one plan as the runner's whole phase menu.
+
+    ``run`` resolves from the runner's own ``plans``/``tiles``; a test binds
+    its single plan to both phases so the batch's phase flag cannot matter.
+    """
+    selected = SelectedPlan(key="test", name="test", base_gemm_rows="test", plan=plan)
+    tiles = SimpleNamespace(config_for=lambda num_tokens: launch_config)
+    runner.plans = {Phase.PREFILL: selected, Phase.DECODE: selected}
+    runner.tiles = {Phase.PREFILL: tiles, Phase.DECODE: tiles}
+
+
+def _build_runner(plan, launch_config, base_gemm_rows: str, gpu, num_experts: int):
+    from sglang.srt.lora.moe.moe_lora_runner import MoeLoraRunner
+    from sglang.srt.lora.moe.quant_info import MoeLoraBf16QuantInfo
+
+    provider = MoeLoraRunner.select_provider_cls(base_gemm_rows, "cutedsl")(
+        MoeLoraBf16QuantInfo(
+            w13_weight=gpu["w13_weight"],
+            w2_weight=gpu["w2_weight"],
+            num_local_experts=num_experts,
+            intermediate_size=_INTERMEDIATE,
+            hidden_size=_HIDDEN,
+        )
+    )
+    runner = MoeLoraRunner(
+        providers={"test": provider},
+        top_k=_TOP_K,
+        routed_scaling_factor=_ROUTED_SCALING,
+        activation=ActivationFn.SILU,
+    )
+    runner.validate_plan(plan, base_gemm_rows="test")
+    _bind_test_menu(runner, plan, launch_config)
+    return runner
+
+
+def _run_once(runner, gpu, token_lora_mapping):
+    from sglang.srt.layers.moe.token_dispatcher.standard import StandardDispatchOutput
+    from sglang.srt.layers.moe.topk import StandardTopKOutput
+    from sglang.srt.lora.moe.moe_lora_runner import MoeLoraBatch
+
+    dispatch = StandardDispatchOutput(
+        hidden_states=gpu["hidden_states"],
+        hidden_states_scale=None,
+        topk_output=StandardTopKOutput(
+            topk_weights=gpu["topk_weights"],
+            topk_ids=gpu["topk_ids"],
+            router_logits=gpu["router_logits"],
+        ),
+    )
+    batch = MoeLoraBatch(
+        gate_up_lora_a=gpu["gate_up_lora_a"],
+        gate_up_lora_b=gpu["gate_up_lora_b"],
+        down_lora_a=gpu["down_lora_a"],
+        down_lora_b=gpu["down_lora_b"],
+        token_lora_mapping=token_lora_mapping,
+        seg_indptr=_segments_of(token_lora_mapping),
+        use_cuda_graph=False,
+        is_prefill=True,
+    )
+    return runner.run(dispatch, batch)
+
+
+@cutedsl_cuda_only
+@pytest.mark.parametrize("base_gemm_rows", ("expert_major", "route_major"))
+@pytest.mark.parametrize("into_base", (False, True))
+def test_runner_b_act_matches_the_materialized_reference(
+    base_gemm_rows: str, into_base: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Compare the serial materialized middle with the b_act middle.
+
+    Both runners use the same launch config, so only the plan changes.
+    """
+    from sglang.srt.lora.moe.moe_lora_runner import MoeLoraRunner
+
+    device = torch.device("cuda")
+    monkeypatch.setattr(
+        MoeLoraRunner, "_allocate_output", _standalone_output_allocation
+    )
+    reference_choice = _reference_choice()
+    swapped_plan = _build_plan(
+        act_family=ActFamily.B_ACTIVATION, down_b_into_base=into_base
+    )
+    assert swapped_plan.act.family is ActFamily.B_ACTIVATION
+    assert swapped_plan.gate_up_b is None
+    assert swapped_plan.down_b_into_base is into_base
+    num_tokens, num_experts = 64, 4
+    gpu = _make_gpu_tensors(num_tokens, num_experts, device)
+    shared_launch = _shipped_launch(_GB300, reference_choice)
+    reference_runner = _build_runner(
+        reference_choice.plan,
+        shared_launch,
+        "expert_major",
+        gpu,
+        num_experts,
+    )
+    b_act_runner = _build_runner(
+        swapped_plan,
+        shared_launch,
+        base_gemm_rows,
+        gpu,
+        num_experts,
+    )
+
+    for traffic in ("active", "mixed", "base_only"):
+        token_lora_mapping = _token_lora_mapping(traffic, num_tokens).to(device)
+        reference = _run_once(reference_runner, gpu, token_lora_mapping).hidden_states
+        b_act = _run_once(b_act_runner, gpu, token_lora_mapping).hidden_states
+        torch.testing.assert_close(
+            b_act,
+            reference,
+            **_B_ACT_TOLERANCE,
+            msg=f"{base_gemm_rows}: into_base={into_base} {traffic}",
+        )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/lora/test_moe_lora_b_act.py
+++ b/test/registered/unit/lora/test_moe_lora_b_act.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 import pytest
 import torch
 
+from sglang.srt.lora.moe.base_gemm_provider import select_provider_cls
 from sglang.srt.lora.moe.execution_plan import (
     ActFamily,
     ActivationFn,
@@ -123,7 +124,15 @@ class TestBActConfig:
             for layout in (False, True):
                 for activation in (_SWIGLU, ActivationFn.RELU2):
                     for name, choice in _menu(architecture, layout, activation).items():
-                        if not name.startswith("decode.") and name != "fallback.decode":
+                        if not name.startswith(("decode.", "fallback.decode")):
+                            continue
+                        if ".fp8" in name:
+                            # The expert-banded fp8 row absorbs gate/up-B into
+                            # the activation.
+                            assert (
+                                choice.plan.act.family is ActFamily.B_ACTIVATION
+                            ), name
+                            assert choice.plan.gate_up_b is None, name
                             continue
                         assert choice.plan.act.family is ActFamily.MATERIALIZED, name
                         assert choice.plan.gate_up_b is not None, name
@@ -131,11 +140,12 @@ class TestBActConfig:
     def test_out_of_domain_prefill_rows_get_the_swap(self) -> None:
         def _prefill(is_shared_outer, activation=_SWIGLU):
             return resolve_plans(
+                quant_family="bf16",
                 architecture=_GB300,
                 is_shared_outer=is_shared_outer,
                 physical_rank=16,
                 activation=activation,
-                hidden_size=8192,  # outside the gb300 tuned domain
+                hidden_size=12288,  # outside the gb300 tuned domain
                 num_local_experts=256,
             )[Phase.PREFILL]
 
@@ -145,17 +155,21 @@ class TestBActConfig:
         for sel in (per_expert, relu2):
             assert sel.name == "fallback.prefill.per_expert"
         assert shared.name == "fallback.prefill.shared"
-        # Both layouts add down-B into the base output. The epilogue finds its
-        # rows through pair_to_row, so a shared down-B factor does not prevent it.
-        # A row does not depend on the activation, so the ReLU2 row matches.
+        # The per-expert row adds down-B into the base output; the shared row
+        # consumes down-B in its shared_token_delta finalize, like every shared
+        # prefill row. A row does not depend on the activation, so the ReLU2
+        # row matches.
         assert per_expert.plan.act.family is ActFamily.B_ACTIVATION
         assert per_expert.plan.gate_up_b is None
         assert per_expert.plan.down_b_into_base is True
         assert per_expert.base_gemm_rows == "route_major"
         assert shared.plan.act.family is ActFamily.B_ACTIVATION
         assert shared.plan.gate_up_b is None
-        assert shared.plan.down_b_into_base is True
-        assert shared.base_gemm_rows == "expert_major"
+        assert shared.plan.down_b is None
+        assert shared.plan.finalize.family is FinalizeFamily.SHARED_TOKEN_DELTA
+        # Route-major keeps the fallback's scratch bounded by routed pairs;
+        # the masked slab domain grows with experts x padded chunk tokens.
+        assert shared.base_gemm_rows == "route_major"
         assert relu2.plan.act.family is ActFamily.B_ACTIVATION
         assert relu2.plan.act.activation is ActivationFn.RELU2
         assert relu2.plan.down_b_into_base is True
@@ -276,14 +290,14 @@ def _bind_test_menu(runner, plan, launch_config):
     selected = SelectedPlan(key="test", name="test", base_gemm_rows="test", plan=plan)
     tiles = SimpleNamespace(config_for=lambda num_tokens: launch_config)
     runner.plans = {Phase.PREFILL: selected, Phase.DECODE: selected}
-    runner.tiles = {Phase.PREFILL: tiles, Phase.DECODE: tiles}
+    runner.tiles = {selected.key: tiles}
 
 
 def _build_runner(plan, launch_config, base_gemm_rows: str, gpu, num_experts: int):
     from sglang.srt.lora.moe.moe_lora_runner import MoeLoraRunner
     from sglang.srt.lora.moe.quant_info import MoeLoraBf16QuantInfo
 
-    provider = MoeLoraRunner.select_provider_cls(base_gemm_rows, "cutedsl")(
+    provider = select_provider_cls(base_gemm_rows, "bf16")(
         MoeLoraBf16QuantInfo(
             w13_weight=gpu["w13_weight"],
             w2_weight=gpu["w2_weight"],

--- a/test/registered/unit/lora/test_moe_lora_bind_execution.py
+++ b/test/registered/unit/lora/test_moe_lora_bind_execution.py
@@ -5,9 +5,10 @@ from types import SimpleNamespace
 import pytest
 import torch
 
+from sglang.srt.layers.moe.utils import MoeRunnerBackend
 from sglang.srt.lora.moe.execution_plan import Phase
 from sglang.srt.lora.moe.moe_lora_runner import MoeLoraRunner
-from sglang.srt.runtime_context import get_context
+from sglang.srt.runtime_context import get_context, get_flags
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-large")
@@ -46,24 +47,24 @@ def _from_layer(
     monkeypatch.setattr(
         torch.cuda, "get_device_capability", lambda device=None: capability
     )
-    monkeypatch.setattr(MoeLoraRunner, "_admit", staticmethod(lambda layer: None))
+    monkeypatch.setattr(MoeLoraRunner, "_admit", staticmethod(lambda layer: "bf16"))
 
-    def fake_build(_base_layer, *, base_gemm_rows, vendor):
+    def fake_build(_base_layer, *, base_gemm_rows, vendor, family):
         if built is not None:
             built.append((base_gemm_rows, vendor))
         return provider_cls()
 
     monkeypatch.setattr(MoeLoraRunner, "_build_provider", staticmethod(fake_build))
-    # from_layer reads --moe-lora-base-gemm. The test therefore publishes a
-    # context that holds the shipped default. Production code then needs no
-    # fallback for a missing server.
+    # from_layer reads the published MoE runner backend; publish the engine's
+    # default name so the builds see its vendor.
     with get_context().override_server_args():
-        return MoeLoraRunner.from_layer(
-            _base_layer(),
-            workspace=object(),
-            is_shared_outer=is_shared_outer,
-            physical_rank=physical_rank,
-        )
+        with get_flags().moe.override(runner_backend=MoeRunnerBackend.LORA_CUTEDSL):
+            return MoeLoraRunner.from_layer(
+                _base_layer(),
+                workspace=object(),
+                is_shared_outer=is_shared_outer,
+                physical_rank=physical_rank,
+            )
 
 
 def test_from_layer_resolves_plans_and_builds_each_row_order_once(
@@ -75,14 +76,14 @@ def test_from_layer_resolves_plans_and_builds_each_row_order_once(
     assert built == [(rows, "cutedsl") for rows, _ in dict.fromkeys(built)]
     assert {rows for rows, _ in built} == row_orders
     assert set(runner.providers) == row_orders
-    assert set(runner.tiles) == set(runner.plans)
+    assert set(runner.tiles) == {sel.key for sel in runner.plans.values()}
 
 
 def test_phase_rows_and_tile_buckets(monkeypatch) -> None:
     runner = _from_layer(monkeypatch, capability=(10, 0))
     assert runner.plans[Phase.DECODE].base_gemm_rows == "expert_major"
     assert runner.plans[Phase.PREFILL].base_gemm_rows == "route_major"
-    decode = runner.tiles[Phase.DECODE]
+    decode = runner.tiles[runner.plans[Phase.DECODE].key]
     assert decode.config_for(4).gate_up_b["BLOCK_SIZE_N"] == 128
     assert decode.config_for(16).gate_up_b["BLOCK_SIZE_N"] == 512
     assert decode.config_for(17).gate_up_b["BLOCK_SIZE_N"] == 256
@@ -97,4 +98,4 @@ def test_plan_validation_failure_propagates(monkeypatch) -> None:
 
 
 if __name__ == "__main__":
-    pytest.main([__file__, "-v"])
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/lora/test_moe_lora_bind_execution.py
+++ b/test/registered/unit/lora/test_moe_lora_bind_execution.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang.srt.lora.moe.execution_plan import Phase
+from sglang.srt.lora.moe.moe_lora_runner import MoeLoraRunner
+from sglang.srt.runtime_context import get_context
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-large")
+
+
+class _FakeProvider:
+    hidden_size = 2048
+    intermediate_size = 768
+    num_local_experts = 256
+    gate_up_slices = 2
+    contract = SimpleNamespace(lora_delta_dtype=torch.bfloat16)
+
+
+def _base_layer(*, hidden_size=2048, num_local_experts=256):
+    return SimpleNamespace(
+        w2_weight=SimpleNamespace(
+            device=torch.device("cuda"), shape=(num_local_experts, hidden_size, 768)
+        ),
+        num_local_experts=num_local_experts,
+        hidden_size=hidden_size,
+        moe_runner_config=SimpleNamespace(
+            activation="silu", top_k=8, routed_scaling_factor=1.0, is_gated=True
+        ),
+    )
+
+
+def _from_layer(
+    monkeypatch,
+    *,
+    capability=(9, 0),
+    built=None,
+    provider_cls=_FakeProvider,
+    is_shared_outer=False,
+    physical_rank=64,
+):
+    monkeypatch.setattr(
+        torch.cuda, "get_device_capability", lambda device=None: capability
+    )
+    monkeypatch.setattr(MoeLoraRunner, "_admit", staticmethod(lambda layer: None))
+
+    def fake_build(_base_layer, *, base_gemm_rows, vendor):
+        if built is not None:
+            built.append((base_gemm_rows, vendor))
+        return provider_cls()
+
+    monkeypatch.setattr(MoeLoraRunner, "_build_provider", staticmethod(fake_build))
+    # from_layer reads --moe-lora-base-gemm. The test therefore publishes a
+    # context that holds the shipped default. Production code then needs no
+    # fallback for a missing server.
+    with get_context().override_server_args():
+        return MoeLoraRunner.from_layer(
+            _base_layer(),
+            workspace=object(),
+            is_shared_outer=is_shared_outer,
+            physical_rank=physical_rank,
+        )
+
+
+def test_from_layer_resolves_plans_and_builds_each_row_order_once(
+    monkeypatch,
+) -> None:
+    built: list[tuple[str, str]] = []
+    runner = _from_layer(monkeypatch, built=built)
+    row_orders = {sel.base_gemm_rows for sel in runner.plans.values()}
+    assert built == [(rows, "cutedsl") for rows, _ in dict.fromkeys(built)]
+    assert {rows for rows, _ in built} == row_orders
+    assert set(runner.providers) == row_orders
+    assert set(runner.tiles) == set(runner.plans)
+
+
+def test_phase_rows_and_tile_buckets(monkeypatch) -> None:
+    runner = _from_layer(monkeypatch, capability=(10, 0))
+    assert runner.plans[Phase.DECODE].base_gemm_rows == "expert_major"
+    assert runner.plans[Phase.PREFILL].base_gemm_rows == "route_major"
+    decode = runner.tiles[Phase.DECODE]
+    assert decode.config_for(4).gate_up_b["BLOCK_SIZE_N"] == 128
+    assert decode.config_for(16).gate_up_b["BLOCK_SIZE_N"] == 512
+    assert decode.config_for(17).gate_up_b["BLOCK_SIZE_N"] == 256
+
+
+def test_plan_validation_failure_propagates(monkeypatch) -> None:
+    class _NonGatedProvider(_FakeProvider):
+        gate_up_slices = 1
+
+    with pytest.raises(ValueError, match="gate/up slices"):
+        _from_layer(monkeypatch, provider_cls=_NonGatedProvider)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/test/registered/unit/lora/test_moe_lora_contiguous_row_domain.py
+++ b/test/registered/unit/lora/test_moe_lora_contiguous_row_domain.py
@@ -1,0 +1,732 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang.srt.lora.moe.base_gemm_provider.base import MoeBaseProviderContract
+from sglang.srt.lora.moe.base_gemm_provider.contiguous_row_domain import (
+    ContiguousRowDomainProvider,
+    contiguous_m_pad_ceiling,
+)
+from sglang.srt.lora.moe.execution_plan import (
+    ActivationFn,
+    DeviceArchitecture,
+    Phase,
+    SelectedPlan,
+    build_plan,
+    load_plans,
+    resolve_plans,
+)
+from sglang.srt.lora.moe.launch_config import resolve_tiles
+from sglang.srt.lora.moe.quant_info import MoeLoraBf16QuantInfo
+from sglang.srt.runtime_context import get_context
+from sglang.test.ci.ci_register import register_cuda_ci
+
+
+def _segments_of(mapping: torch.Tensor) -> torch.Tensor:
+    """Request boundaries for a test batch: one request per token, so the
+    segment route is exercised with many short requests and the helper stays
+    free of host syncs (CUDA-graph capture forbids a device-to-host copy)."""
+    return torch.arange(mapping.numel() + 1, dtype=torch.int32, device=mapping.device)
+
+
+register_cuda_ci(est_time=240, stage="base-b", runner_config="1-gpu-large")
+
+_GB300 = DeviceArchitecture.GB300
+_H200 = DeviceArchitecture.H200
+_SWIGLU = ActivationFn.SILU
+
+
+def _menu(architecture, layout, activation=_SWIGLU):
+    """Build every plan row with the loader and builder that serving uses.
+
+    ``resolve_plans`` checks the phase and the rank, then keeps one row for
+    each phase. This helper skips those checks and returns every row.
+    """
+    table = load_plans(architecture)
+    layout_name = "shared" if layout else "per_expert"
+    return {
+        row.name: SelectedPlan(
+            key=f"{architecture.value}.{layout_name}.{row.name}",
+            name=row.name,
+            base_gemm_rows=row.base_gemm_rows,
+            plan=build_plan(row.plan, activation=activation, is_shared_outer=layout),
+        )
+        for row in (*table.scenarios, *table.fallback)
+        if row.layout in (None, layout_name)
+    }
+
+
+def _choice(architecture, layout, name: str):
+    return _menu(architecture, layout)[name]
+
+
+def _shipped_launch(architecture, sel, *, physical_rank=16, num_tokens=4096):
+    return resolve_tiles(
+        architecture_value=architecture.value,
+        plan_key_name=sel.name,
+        physical_rank=physical_rank,
+    ).config_for(num_tokens)
+
+
+def _host_aligned_prefix(counts: list[int], alignment: int) -> list[int]:
+    offsets = [0]
+    for count in counts:
+        aligned = -(-count // alignment) * alignment
+        offsets.append(offsets[-1] + aligned)
+    return offsets
+
+
+class _DomainStub(ContiguousRowDomainProvider):
+    """A row domain with a contract but no GEMM engine. Only ``prepare`` runs."""
+
+    contract = MoeBaseProviderContract(
+        key="contiguous_stub",
+        gate_first=True,
+        interleaved=False,
+        gate_up_output_dtype=torch.bfloat16,
+        lora_delta_dtype=torch.bfloat16,
+        lora_activation_dtype=torch.bfloat16,
+    )
+
+
+def _stub_quant_info(num_experts: int = 4) -> MoeLoraBf16QuantInfo:
+    return MoeLoraBf16QuantInfo(
+        w13_weight=torch.zeros((num_experts, 2 * 8, 16), dtype=torch.bfloat16),
+        w2_weight=torch.zeros((num_experts, 16, 8), dtype=torch.bfloat16),
+        num_local_experts=num_experts,
+        intermediate_size=8,
+        hidden_size=16,
+    )
+
+
+class TestAlignedSegmentMath:
+    def test_ceiling_bounds_every_aligned_prefix_total(self) -> None:
+        import random
+
+        rng = random.Random(0xA11C)
+        for _ in range(64):
+            alignment = rng.choice((8, 64, 128))
+            num_experts = rng.randint(1, 32)
+            num_pairs = rng.randint(0, 4096)
+            counts = [0] * num_experts
+            for _ in range(num_pairs):
+                counts[rng.randrange(num_experts)] += 1
+            total = _host_aligned_prefix(counts, alignment)[-1]
+            ceiling = contiguous_m_pad_ceiling(num_pairs, num_experts, alignment)
+            assert total <= ceiling, (counts, alignment, total, ceiling)
+
+    def test_exact_ceiling_formula(self) -> None:
+        # ceil((P + E*(a-1)) / a) * a
+        assert contiguous_m_pad_ceiling(128, 16, 128) == 2176
+        assert contiguous_m_pad_ceiling(24, 4, 128) == 640
+        assert contiguous_m_pad_ceiling(0, 4, 128) == 512
+        assert contiguous_m_pad_ceiling(16, 2, 1) == 16
+
+
+class TestRowDomainConfig:
+    def test_prefill_ships_contiguous_providers(self) -> None:
+        # Prefill uses route-major rows. SM90 has no CuTeDSL contiguous
+        # kernel. H200 and the out-of-domain fallback therefore use the
+        # contiguous row domain. The shared fallback row has no
+        # per-expert form, so it stays on the masked provider.
+        gb300_pe = _menu(_GB300, False)
+        assert gb300_pe["prefill.per_expert"].base_gemm_rows == "route_major"
+        assert gb300_pe["fallback.prefill.per_expert"].base_gemm_rows == "route_major"
+        gb300_sh = _menu(_GB300, True)
+        assert gb300_sh["prefill.shared"].base_gemm_rows == "route_major"
+        assert gb300_sh["fallback.prefill.shared"].base_gemm_rows == "expert_major"
+        h200_pe = _menu(_H200, False)
+        assert h200_pe["prefill.per_expert"].base_gemm_rows == "route_major"
+        assert h200_pe["fallback.prefill.per_expert"].base_gemm_rows == "route_major"
+        # Every shared prefill row on H200 uses route-major rows. The
+        # shared-rank row can do so for two reasons. Its reduce works on pairs.
+        # Its tail reads the base rows through ``pair_to_row`` alone.
+        h200_sh = _menu(_H200, True)
+        assert h200_sh["prefill.shared.rank_le8"].base_gemm_rows == "route_major"
+        assert h200_sh["prefill.shared.rank_le64"].base_gemm_rows == "route_major"
+        assert h200_sh["prefill.shared"].base_gemm_rows == "route_major"
+        assert h200_sh["fallback.prefill.shared"].base_gemm_rows == "expert_major"
+
+    def test_decode_choices_never_convert(self) -> None:
+        # Every decode row uses expert-major rows. On GB300 the contiguous
+        # decode kernel is slower than the masked kernel.
+        for architecture in (_GB300, _H200):
+            for layout in (False, True):
+                for activation in (_SWIGLU, ActivationFn.RELU2):
+                    for name, choice in _menu(architecture, layout, activation).items():
+                        if not name.startswith("decode.") and name != "fallback.decode":
+                            continue
+                        assert choice.base_gemm_rows == "expert_major", name
+
+    def test_h200_large_expert_prefill_selects_the_contiguous_row_domain(self) -> None:
+        # On SM90 with many experts, the masked scratch buffer does not fit in
+        # memory. The contiguous row domain is then the only prefill
+        # choice. That row also uses the b_act middle and the down-B scatter.
+        routed = resolve_plans(
+            architecture=_H200,
+            is_shared_outer=False,
+            physical_rank=16,
+            activation=_SWIGLU,
+            hidden_size=4096,
+            num_local_experts=512,
+        )[Phase.PREFILL]
+        # rank 16 sits in the gated band, which keeps the campaign-tuned plan
+        assert routed.name == "prefill.per_expert.rank_le16"
+        assert routed.base_gemm_rows == "route_major"
+        assert not routed.plan.is_fully_serial_materialized()
+        assert routed.plan.down_b_into_base is True
+
+    def test_runner_accepts_the_contiguous_provider_keys(self) -> None:
+        from sglang.srt.lora.moe.moe_lora_runner import MoeLoraRunner
+
+        assert MoeLoraRunner.select_provider_cls("route_major", "triton") is not None
+        assert MoeLoraRunner.select_provider_cls("route_major", "cutedsl") is not None
+        with pytest.raises(ValueError, match="row order"):
+            MoeLoraRunner.select_provider_cls("cutedsl_bf16_contiguous", "cutedsl")
+        with pytest.raises(ValueError, match="vendor"):
+            MoeLoraRunner.select_provider_cls("route_major", "nosuchvendor")
+
+
+class TestCuteDslContiguousScheduleGeometry:
+    def test_token_tile_must_divide_the_segment_alignment(self) -> None:
+        from sglang.srt.lora.moe.kernels.cutedsl.schedule_builder import (
+            validate_tile_geometry_contiguous,
+        )
+
+        for width in (8, 64, 128):
+            validate_tile_geometry_contiguous(width, 128)
+        for width in (48, 96, 256):
+            with pytest.raises(ValueError, match="divide the segment alignment"):
+                validate_tile_geometry_contiguous(width, 128)
+        with pytest.raises(ValueError, match="positive"):
+            validate_tile_geometry_contiguous(0, 128)
+        with pytest.raises(ValueError, match="positive"):
+            validate_tile_geometry_contiguous(64, 0)
+
+    def test_capacity_bounds_every_actual_schedule_total(self) -> None:
+        import random
+
+        from sglang.srt.lora.moe.kernels.cutedsl.schedule_builder import (
+            dual_stage_schedule_capacities_contiguous,
+        )
+
+        rng = random.Random(0xC0DE)
+        for _ in range(64):
+            num_experts = rng.randint(1, 64)
+            num_pairs = rng.randint(0, 4096)
+            token_width = rng.choice((8, 64, 128))
+            counts = [0] * num_experts
+            for _ in range(num_pairs):
+                counts[rng.randrange(num_experts)] += 1
+            m_pad_ceiling = contiguous_m_pad_ceiling(num_pairs, num_experts, 128)
+            n_gemm1, n_gemm2 = 512, 256
+            capacity1, capacity2 = dual_stage_schedule_capacities_contiguous(
+                num_experts=num_experts,
+                m_pad_ceiling=m_pad_ceiling,
+                max_expert_rows=max(num_pairs, 1),
+                m_alignment=128,
+                token_width=token_width,
+                n_gemm1=n_gemm1,
+                n_gemm2=n_gemm2,
+                output_width=128,
+            )
+            # The builder writes cdiv(count, w) * out_clusters entries for
+            # each expert. The capacity must bound that total for any split of
+            # the counts.
+            clusters = sum(-(-count // token_width) for count in counts)
+            assert clusters * -(-n_gemm1 // 128) <= capacity1, (counts, token_width)
+            assert clusters * -(-n_gemm2 // 128) <= capacity2, (counts, token_width)
+
+    def test_capacity_scales_with_rows_not_expert_worst_case(self) -> None:
+        from sglang.srt.lora.moe.kernels.cutedsl.schedule_builder import (
+            dual_stage_schedule_capacities_contiguous,
+            dual_stage_schedule_capacities_masked,
+        )
+
+        num_experts, num_tokens, top_k, token_width = 256, 8192, 8, 64
+        num_pairs = num_tokens * top_k
+        m_pad_ceiling = contiguous_m_pad_ceiling(num_pairs, num_experts, 128)
+        contiguous1, _ = dual_stage_schedule_capacities_contiguous(
+            num_experts=num_experts,
+            m_pad_ceiling=m_pad_ceiling,
+            max_expert_rows=num_tokens,
+            m_alignment=128,
+            token_width=token_width,
+            n_gemm1=4096,
+            n_gemm2=2048,
+            output_width=128,
+        )
+        masked1, _ = dual_stage_schedule_capacities_masked(
+            num_experts=num_experts,
+            m_max=(num_tokens // 256 + 1) * 256,
+            token_width=token_width,
+            n_gemm1=4096,
+            n_gemm2=2048,
+            output_width=128,
+        )
+        assert contiguous1 * 10 < masked1
+
+    def test_rejects_unaligned_ceiling_and_bad_tiles(self) -> None:
+        from sglang.srt.lora.moe.kernels.cutedsl.schedule_builder import (
+            dual_stage_schedule_capacities_contiguous,
+        )
+
+        kwargs = dict(
+            num_experts=4,
+            max_expert_rows=64,
+            m_alignment=128,
+            n_gemm1=256,
+            n_gemm2=256,
+            output_width=128,
+        )
+        with pytest.raises(ValueError, match="multiple"):
+            dual_stage_schedule_capacities_contiguous(
+                m_pad_ceiling=130, token_width=64, **kwargs
+            )
+        with pytest.raises(ValueError, match="divide the segment alignment"):
+            dual_stage_schedule_capacities_contiguous(
+                m_pad_ceiling=512, token_width=48, **kwargs
+            )
+        # The packed-schedule checks call the masked validator.
+        with pytest.raises(ValueError, match="cluster"):
+            dual_stage_schedule_capacities_contiguous(
+                m_pad_ceiling=512,
+                token_width=64,
+                cluster_shape_mn=(2, 1),
+                **kwargs,
+            )
+
+
+class TestContiguousDomainValidation:
+    def test_rejects_invalid_alignment(self) -> None:
+        with pytest.raises(ValueError, match="m_alignment"):
+            _DomainStub(_stub_quant_info(), m_alignment=0)
+
+
+_TOP_K = 2
+_HIDDEN = 128
+_INTERMEDIATE = 128
+_PHYSICAL_RANK = 16
+_SLOTS = 2
+_ROUTED_SCALING = 0.75
+
+triton_cuda_only = pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="the contiguous S1 dispatch needs any CUDA device (plain Triton)",
+)
+
+
+def _cutedsl_ready() -> bool:
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability() < (9, 0):
+        return False
+    try:
+        import cuda.bindings.driver  # noqa: F401
+        import cutlass  # noqa: F401
+    except Exception:
+        return False
+    return True
+
+
+cutedsl_cuda_only = pytest.mark.skipif(
+    not _cutedsl_ready(),
+    reason="the vendor oracle runs the CuTeDSL providers against Triton",
+)
+
+
+@pytest.fixture
+def published_server_args():
+    # The triton vendor's config loader reads the published exec namespace.
+    with get_context().override_server_args():
+        yield
+
+
+@triton_cuda_only
+@pytest.mark.parametrize(
+    ("num_tokens", "top_k", "num_experts", "alignment"),
+    ((64, 8, 6, 128), (13, 3, 4, 8)),
+    ids=("lane-multiple-align128", "partial-tail-align8"),
+)
+def test_contiguous_dispatch_metadata_contract(
+    num_tokens: int, top_k: int, num_experts: int, alignment: int
+) -> None:
+    """Check what the dispatch stage writes.
+
+    It must build aligned segments, compact rows, and one expert label for
+    each row. The rows after the last segment must hold ``-1``.
+    """
+    device = torch.device("cuda")
+    generator = torch.Generator().manual_seed(0xC017 + num_tokens)
+    topk_ids = torch.randint(
+        0, num_experts, (num_tokens, top_k), generator=generator, dtype=torch.int32
+    )
+    topk_ids[topk_ids == 1] = 0  # expert 1 gets no pair, so its segment is empty
+    topk_ids[torch.rand((num_tokens, top_k), generator=generator) < 0.15] = -1
+    topk_ids[0] = -1  # a token with no routed pair
+    topk_ids = topk_ids.to(device)
+    hidden_states = (
+        (torch.randn((num_tokens, _HIDDEN), generator=generator) * 0.2)
+        .to(torch.bfloat16)
+        .to(device)
+    )
+
+    quant_info = MoeLoraBf16QuantInfo(
+        w13_weight=torch.zeros(
+            (num_experts, 2 * _INTERMEDIATE, _HIDDEN),
+            dtype=torch.bfloat16,
+            device=device,
+        ),
+        w2_weight=torch.zeros(
+            (num_experts, _HIDDEN, _INTERMEDIATE), dtype=torch.bfloat16, device=device
+        ),
+        num_local_experts=num_experts,
+        intermediate_size=_INTERMEDIATE,
+        hidden_size=_HIDDEN,
+    )
+    provider = _DomainStub(quant_info, m_alignment=alignment)
+    ws = provider.prepare(hidden_states, topk_ids, top_k, None)
+
+    ids = topk_ids.view(-1).cpu()
+    counts = [(ids == expert).sum().item() for expert in range(num_experts)]
+    offsets = _host_aligned_prefix(counts, alignment)
+    assert ws.seg_counts.cpu().tolist() == counts
+    assert ws.seg_offsets.cpu().tolist() == offsets
+    assert ws.m_pad_ceiling == contiguous_m_pad_ceiling(
+        ids.numel(), num_experts, alignment
+    )
+    assert offsets[-1] <= ws.m_pad_ceiling
+
+    mapping = ws.pair_to_row.cpu()
+    compact = ws.hidden_compact.cpu()
+    host_hidden = hidden_states.cpu()
+    for expert in range(num_experts):
+        pairs = (ids == expert).nonzero().flatten()
+        rows = mapping[pairs]
+        assert sorted((rows - offsets[expert]).tolist()) == list(range(len(pairs)))
+        for pair, row in zip(pairs.tolist(), rows.tolist()):
+            torch.testing.assert_close(
+                compact[row], host_hidden[pair // top_k], atol=0.0, rtol=0.0
+            )
+    assert counts[1] == 0 and offsets[2] == offsets[1]  # the empty expert
+
+    # No host code clears the layout outputs; the launch must write every
+    # count and offset. The test fills the buffers with garbage first to
+    # prove that.
+    from sglang.srt.lora.moe.kernels.dispatch_contiguous import (
+        dispatch_layout_contiguous,
+    )
+
+    dirty = {
+        "seg_counts_out": torch.full(
+            (num_experts,), 0x2BAD, dtype=torch.int32, device=device
+        ),
+        "seg_offsets_out": torch.full(
+            (num_experts + 1,), -7, dtype=torch.int32, device=device
+        ),
+        "pair_to_row_out": torch.full(
+            (ids.numel(),), 0x7FFFFFFF, dtype=torch.int32, device=device
+        ),
+    }
+    dispatch_layout_contiguous(
+        hidden_states, topk_ids, num_experts, top_k, alignment, **dirty
+    )
+    assert dirty["seg_counts_out"].cpu().tolist() == counts
+    assert dirty["seg_offsets_out"].cpu().tolist() == offsets
+
+    # Two providers with different alignments can share one workspace. Their
+    # row counts differ, so each buffer name holds the alignment.
+    from sglang.srt.lora.moe.workspace import MoeLoraWorkspace
+
+    workspace = MoeLoraWorkspace()
+    workspace.begin_forward(graph_mode=False)
+    provider.prepare(hidden_states, topk_ids, top_k, workspace)
+    names = {key[0] for key in workspace._eager_buffers}
+    for suffix in ("seg_counts", "seg_offsets", "pair_to_row"):
+        assert f"contiguous:a{alignment}:{suffix}" in names, (suffix, names)
+    assert f"contiguous:a{alignment}:hidden_compact" in names
+
+
+def _make_gpu_tensors(
+    num_tokens: int, num_experts: int, device: torch.device, *, shared: bool = False
+) -> dict[str, torch.Tensor]:
+    generator = torch.Generator().manual_seed(0xC0A7 + num_experts + num_tokens)
+
+    def rand_bf16(shape, scale):
+        return (torch.randn(shape, generator=generator) * scale).to(torch.bfloat16)
+
+    # In the shared-outer layout, each adapter has one gate/up-A factor and
+    # one down-B factor. The gate/up-B and down-A factors stay per expert.
+    gate_up_a_experts = 1 if shared else num_experts
+    down_b_experts = 1 if shared else num_experts
+    tensors = {
+        "hidden_states": rand_bf16((num_tokens, _HIDDEN), 0.20),
+        "w13_weight": rand_bf16((num_experts, 2 * _INTERMEDIATE, _HIDDEN), 0.08),
+        "w2_weight": rand_bf16((num_experts, _HIDDEN, _INTERMEDIATE), 0.08),
+        "gate_up_lora_a": rand_bf16(
+            (_SLOTS, gate_up_a_experts, 2 * _PHYSICAL_RANK, _HIDDEN), 0.15
+        ),
+        "gate_up_lora_b": rand_bf16(
+            (_SLOTS, num_experts, 2 * _INTERMEDIATE, _PHYSICAL_RANK), 0.15
+        ),
+        "down_lora_a": rand_bf16(
+            (_SLOTS, num_experts, _PHYSICAL_RANK, _INTERMEDIATE), 0.15
+        ),
+        "down_lora_b": rand_bf16(
+            (_SLOTS, down_b_experts, _HIDDEN, _PHYSICAL_RANK), 0.15
+        ),
+        "adapter_enabled": torch.tensor([1, 0], dtype=torch.int32),
+    }
+    scores = torch.rand((num_tokens, num_experts), generator=generator)
+    # Skew the routing so the expert counts are uneven. Some segments then
+    # span many blocks, and some experts get no pair.
+    scores[: num_tokens // 2, 0] += 4.0
+    topk_ids = torch.topk(scores, _TOP_K, dim=1).indices.to(torch.int32)
+    topk_ids[0] = -1  # a token with no routed pair
+    topk_ids[5, 1] = -1  # one sentinel pair inside a token that keeps a routed pair
+    tensors["topk_ids"] = topk_ids.contiguous()
+    weights = torch.rand((num_tokens, _TOP_K), generator=generator) + 0.1
+    tensors["topk_weights"] = (weights / weights.sum(dim=1, keepdim=True)).float()
+    tensors["router_logits"] = torch.zeros(
+        (num_tokens, num_experts), dtype=torch.float32
+    )
+    return {name: tensor.to(device) for name, tensor in tensors.items()}
+
+
+def _token_lora_mapping(traffic: str, num_tokens: int) -> torch.Tensor:
+    if traffic == "active":
+        return torch.zeros(num_tokens, dtype=torch.int32)
+    if traffic == "mixed":
+        pattern = torch.tensor([0, -1, -1, 0, -1, -1], dtype=torch.int32)
+        return pattern.repeat((num_tokens + pattern.numel() - 1) // pattern.numel())[
+            :num_tokens
+        ].contiguous()
+    if traffic == "base_only":
+        return torch.full((num_tokens,), -1, dtype=torch.int32)
+    raise AssertionError(f"unknown traffic pattern {traffic}")
+
+
+def _standalone_output_allocation(runner, *, num_tokens, dtype, device):
+    """Allocate the output with the eager shape and no tensor-parallel group."""
+    return torch.empty((num_tokens, runner.hidden_size), dtype=dtype, device=device)
+
+
+def _bind_test_menu(runner, plan, launch_config):
+    """Publish one plan as the runner's whole phase menu.
+
+    ``run`` resolves from the runner's own ``plans``/``tiles``; a test binds
+    its single plan to both phases so the batch's phase flag cannot matter.
+    """
+    selected = SelectedPlan(key="test", name="test", base_gemm_rows="test", plan=plan)
+    tiles = SimpleNamespace(config_for=lambda num_tokens: launch_config)
+    runner.plans = {Phase.PREFILL: selected, Phase.DECODE: selected}
+    runner.tiles = {Phase.PREFILL: tiles, Phase.DECODE: tiles}
+
+
+def _build_runner(architecture, choice, vendor: str, gpu, num_experts, layout):
+    from sglang.srt.lora.moe.moe_lora_runner import MoeLoraRunner
+
+    quant_info = MoeLoraBf16QuantInfo(
+        w13_weight=gpu["w13_weight"],
+        w2_weight=gpu["w2_weight"],
+        num_local_experts=num_experts,
+        intermediate_size=_INTERMEDIATE,
+        hidden_size=_HIDDEN,
+    )
+    # The Triton vendor has no masked domain; its route-major class runs the
+    # same plan.
+    rows = "route_major" if vendor == "triton" else choice.base_gemm_rows
+    provider = MoeLoraRunner.select_provider_cls(rows, vendor)(quant_info)
+    runner = MoeLoraRunner(
+        providers={"test": provider},
+        top_k=_TOP_K,
+        routed_scaling_factor=_ROUTED_SCALING,
+        activation=ActivationFn.SILU,
+    )
+    runner.validate_plan(choice.plan, base_gemm_rows="test")
+    _bind_test_menu(runner, choice.plan, _shipped_launch(architecture, choice))
+    return runner
+
+
+def _run_once(
+    runner, gpu, token_lora_mapping, layout, *, use_cuda_graph=False, is_prefill=True
+):
+    from sglang.srt.layers.moe.token_dispatcher.standard import StandardDispatchOutput
+    from sglang.srt.layers.moe.topk import StandardTopKOutput
+    from sglang.srt.lora.moe.moe_lora_runner import MoeLoraBatch
+
+    dispatch = StandardDispatchOutput(
+        hidden_states=gpu["hidden_states"],
+        hidden_states_scale=None,
+        topk_output=StandardTopKOutput(
+            topk_weights=gpu["topk_weights"],
+            topk_ids=gpu["topk_ids"],
+            router_logits=gpu["router_logits"],
+        ),
+    )
+    batch = MoeLoraBatch(
+        gate_up_lora_a=gpu["gate_up_lora_a"],
+        gate_up_lora_b=gpu["gate_up_lora_b"],
+        down_lora_a=gpu["down_lora_a"],
+        down_lora_b=gpu["down_lora_b"],
+        token_lora_mapping=token_lora_mapping,
+        seg_indptr=_segments_of(token_lora_mapping),
+        use_cuda_graph=use_cuda_graph,
+        is_prefill=is_prefill,
+    )
+    return runner.run(dispatch, batch)
+
+
+# The two vendors tile the same FP32 accumulation in different ways, and on a
+# decode row in different row domains, so they round the BF16 output at
+# different points. Every stage after the GEMM is the same kernel.
+_ORACLE_TOLERANCE = {"atol": 2e-2, "rtol": 0.05}
+
+# One row for each eligible plan shape, each with its own factor layout. Both
+# vendors run the same plan, so the test compares the base GEMMs alone.
+_ELIGIBLE_PLAN_PARAMS = (
+    pytest.param(_GB300, False, "fallback.decode", id="per-expert-materialized"),
+    pytest.param(_GB300, True, "prefill.shared", id="shared-outer-b-activation"),
+    pytest.param(
+        _H200,
+        True,
+        "prefill.shared.rank_le64",
+        id="shared-outer-shared-rank",
+    ),
+)
+
+
+def _oracle_setup(architecture, layout, fragment, num_tokens, num_experts, device):
+    choice = _choice(architecture, layout, fragment)
+    gpu = _make_gpu_tensors(num_tokens, num_experts, device, shared=layout == True)
+    return choice, gpu
+
+
+@cutedsl_cuda_only
+@pytest.mark.parametrize(("architecture", "layout", "fragment"), _ELIGIBLE_PLAN_PARAMS)
+def test_cutedsl_matches_the_triton_vendor(
+    architecture,
+    layout,
+    fragment: str,
+    published_server_args,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Run one plan on the CuTeDSL vendor and on the Triton vendor; compare."""
+    from sglang.srt.lora.moe.moe_lora_runner import MoeLoraRunner
+
+    device = torch.device("cuda")
+    monkeypatch.setattr(
+        MoeLoraRunner, "_allocate_output", _standalone_output_allocation
+    )
+    num_tokens, num_experts = 64, 16
+    choice, gpu = _oracle_setup(
+        architecture, layout, fragment, num_tokens, num_experts, device
+    )
+
+    triton = _build_runner(architecture, choice, "triton", gpu, num_experts, layout)
+    cutedsl = _build_runner(architecture, choice, "cutedsl", gpu, num_experts, layout)
+
+    for traffic in ("active", "mixed", "base_only"):
+        token_lora_mapping = _token_lora_mapping(traffic, num_tokens).to(device)
+        reference = _run_once(triton, gpu, token_lora_mapping, layout).hidden_states
+        actual = _run_once(cutedsl, gpu, token_lora_mapping, layout).hidden_states
+        torch.testing.assert_close(
+            actual,
+            reference,
+            **_ORACLE_TOLERANCE,
+            msg=f"cutedsl vs triton: {choice.key}, {traffic} traffic",
+        )
+        # The token with no routed pair must be exactly zero for both vendors.
+        assert actual[0].abs().max().item() == 0.0
+        assert reference[0].abs().max().item() == 0.0
+    # The vendor under test must apply the LoRA math.
+    active = _run_once(
+        cutedsl, gpu, _token_lora_mapping("active", num_tokens).to(device), layout
+    ).hidden_states
+    base_only = _run_once(
+        cutedsl, gpu, _token_lora_mapping("base_only", num_tokens).to(device), layout
+    ).hidden_states
+    assert (active - base_only).abs().max().item() > 0.02
+
+
+@cutedsl_cuda_only
+@pytest.mark.parametrize(("architecture", "layout", "fragment"), _ELIGIBLE_PLAN_PARAMS)
+def test_cutedsl_replays_in_a_real_cuda_graph(
+    architecture,
+    layout,
+    fragment: str,
+    published_server_args,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Capture the graph once, then replay it after the routing changes.
+
+    Every replay rebuilds the counts, the offsets, the labels, and the compact
+    rows in place from device memory. A change to ``topk_ids`` must reach the
+    output through the same pointers.
+    """
+    from sglang.srt.lora.moe.moe_lora_runner import MoeLoraRunner
+
+    device = torch.device("cuda")
+    monkeypatch.setattr(
+        MoeLoraRunner, "_allocate_output", _standalone_output_allocation
+    )
+    num_tokens, num_experts = 64, 16
+    choice, gpu = _oracle_setup(
+        architecture, layout, fragment, num_tokens, num_experts, device
+    )
+    triton = _build_runner(architecture, choice, "triton", gpu, num_experts, layout)
+    cutedsl = _build_runner(architecture, choice, "cutedsl", gpu, num_experts, layout)
+    token_lora_mapping = _token_lora_mapping("active", num_tokens).to(device)
+
+    for _ in range(2):  # warm the JIT and keep the graph buffers before capture
+        _run_once(cutedsl, gpu, token_lora_mapping, layout, use_cuda_graph=True)
+    torch.cuda.synchronize(device)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = _run_once(
+            cutedsl, gpu, token_lora_mapping, layout, use_cuda_graph=True
+        )
+    output = captured.hidden_states
+    output_ptr = output.data_ptr()
+
+    graph.replay()
+    torch.cuda.synchronize(device)
+    torch.testing.assert_close(
+        output,
+        _run_once(triton, gpu, token_lora_mapping, layout).hidden_states,
+        **_ORACLE_TOLERANCE,
+        msg="initial routing replay",
+    )
+
+    original_ids = gpu["topk_ids"].clone()
+    mutated = torch.where(
+        original_ids >= 0, (original_ids + 3) % num_experts, original_ids
+    ).to(torch.int32)
+    gpu["topk_ids"].copy_(mutated)
+    graph.replay()
+    torch.cuda.synchronize(device)
+    assert output.data_ptr() == output_ptr
+    torch.testing.assert_close(
+        output,
+        _run_once(triton, gpu, token_lora_mapping, layout).hidden_states,
+        **_ORACLE_TOLERANCE,
+        msg="mutated routing replay",
+    )
+
+    token_lora_mapping.fill_(-1)
+    graph.replay()
+    torch.cuda.synchronize(device)
+    torch.testing.assert_close(
+        output,
+        _run_once(
+            triton, gpu, _token_lora_mapping("base_only", num_tokens).to(device), layout
+        ).hidden_states,
+        **_ORACLE_TOLERANCE,
+        msg="base-only replay",
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/lora/test_moe_lora_contiguous_row_domain.py
+++ b/test/registered/unit/lora/test_moe_lora_contiguous_row_domain.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 import pytest
 import torch
 
+from sglang.srt.lora.moe.base_gemm_provider import select_provider_cls
 from sglang.srt.lora.moe.base_gemm_provider.base import MoeBaseProviderContract
 from sglang.srt.lora.moe.base_gemm_provider.contiguous_row_domain import (
     ContiguousRowDomainProvider,
@@ -84,6 +85,7 @@ class _DomainStub(ContiguousRowDomainProvider):
 
     contract = MoeBaseProviderContract(
         key="contiguous_stub",
+        quant_info_cls=MoeLoraBf16QuantInfo,
         gate_first=True,
         interleaved=False,
         gate_up_output_dtype=torch.bfloat16,
@@ -128,27 +130,29 @@ class TestAlignedSegmentMath:
 
 class TestRowDomainConfig:
     def test_prefill_ships_contiguous_providers(self) -> None:
-        # Prefill uses route-major rows. SM90 has no CuTeDSL contiguous
-        # kernel. H200 and the out-of-domain fallback therefore use the
-        # contiguous row domain. The shared fallback row has no
-        # per-expert form, so it stays on the masked provider.
+        # Every prefill row uses route-major rows, the fallbacks included:
+        # the masked slab domain allocates local_experts x padded-chunk-token
+        # x hidden scratch, which is unbounded exactly where the fallback
+        # serves (out-of-domain geometries -- 24.7GiB at E=256 H=6144 with an
+        # 8192-token chunk). Every vendor ships a contiguous provider, so the
+        # fallback never needs the masked domain for prefill.
         gb300_pe = _menu(_GB300, False)
         assert gb300_pe["prefill.per_expert"].base_gemm_rows == "route_major"
         assert gb300_pe["fallback.prefill.per_expert"].base_gemm_rows == "route_major"
         gb300_sh = _menu(_GB300, True)
         assert gb300_sh["prefill.shared"].base_gemm_rows == "route_major"
-        assert gb300_sh["fallback.prefill.shared"].base_gemm_rows == "expert_major"
+        assert gb300_sh["fallback.prefill.shared"].base_gemm_rows == "route_major"
         h200_pe = _menu(_H200, False)
         assert h200_pe["prefill.per_expert"].base_gemm_rows == "route_major"
         assert h200_pe["fallback.prefill.per_expert"].base_gemm_rows == "route_major"
         # Every shared prefill row on H200 uses route-major rows. The
-        # shared-rank row can do so for two reasons. Its reduce works on pairs.
-        # Its tail reads the base rows through ``pair_to_row`` alone.
+        # shared-finalize rows can do so for two reasons. Their reduce works on
+        # pairs. Their tail reads the base rows through ``pair_to_row`` alone.
         h200_sh = _menu(_H200, True)
         assert h200_sh["prefill.shared.rank_le8"].base_gemm_rows == "route_major"
         assert h200_sh["prefill.shared.rank_le64"].base_gemm_rows == "route_major"
         assert h200_sh["prefill.shared"].base_gemm_rows == "route_major"
-        assert h200_sh["fallback.prefill.shared"].base_gemm_rows == "expert_major"
+        assert h200_sh["fallback.prefill.shared"].base_gemm_rows == "route_major"
 
     def test_decode_choices_never_convert(self) -> None:
         # Every decode row uses expert-major rows. On GB300 the contiguous
@@ -157,7 +161,7 @@ class TestRowDomainConfig:
             for layout in (False, True):
                 for activation in (_SWIGLU, ActivationFn.RELU2):
                     for name, choice in _menu(architecture, layout, activation).items():
-                        if not name.startswith("decode.") and name != "fallback.decode":
+                        if not name.startswith(("decode.", "fallback.decode")):
                             continue
                         assert choice.base_gemm_rows == "expert_major", name
 
@@ -166,6 +170,7 @@ class TestRowDomainConfig:
         # memory. The contiguous row domain is then the only prefill
         # choice. That row also uses the b_act middle and the down-B scatter.
         routed = resolve_plans(
+            quant_family="bf16",
             architecture=_H200,
             is_shared_outer=False,
             physical_rank=16,
@@ -176,18 +181,18 @@ class TestRowDomainConfig:
         # rank 16 sits in the gated band, which keeps the campaign-tuned plan
         assert routed.name == "prefill.per_expert.rank_le16"
         assert routed.base_gemm_rows == "route_major"
-        assert not routed.plan.is_fully_serial_materialized()
         assert routed.plan.down_b_into_base is True
 
     def test_runner_accepts_the_contiguous_provider_keys(self) -> None:
-        from sglang.srt.lora.moe.moe_lora_runner import MoeLoraRunner
 
-        assert MoeLoraRunner.select_provider_cls("route_major", "triton") is not None
-        assert MoeLoraRunner.select_provider_cls("route_major", "cutedsl") is not None
+        assert select_provider_cls("route_major", "bf16", "triton") is not None
+        assert select_provider_cls("route_major", "bf16") is not None
         with pytest.raises(ValueError, match="row order"):
-            MoeLoraRunner.select_provider_cls("cutedsl_bf16_contiguous", "cutedsl")
-        with pytest.raises(ValueError, match="vendor"):
-            MoeLoraRunner.select_provider_cls("route_major", "nosuchvendor")
+            select_provider_cls("cutedsl_bf16_contiguous", "bf16", "cutedsl")
+        # An unlisted vendor resolves to the family default, logged.
+        assert select_provider_cls(
+            "route_major", "bf16", "nosuchvendor"
+        ) is select_provider_cls("route_major", "bf16")
 
 
 class TestCuteDslContiguousScheduleGeometry:
@@ -521,7 +526,7 @@ def _bind_test_menu(runner, plan, launch_config):
     selected = SelectedPlan(key="test", name="test", base_gemm_rows="test", plan=plan)
     tiles = SimpleNamespace(config_for=lambda num_tokens: launch_config)
     runner.plans = {Phase.PREFILL: selected, Phase.DECODE: selected}
-    runner.tiles = {Phase.PREFILL: tiles, Phase.DECODE: tiles}
+    runner.tiles = {selected.key: tiles}
 
 
 def _build_runner(architecture, choice, vendor: str, gpu, num_experts, layout):
@@ -534,10 +539,7 @@ def _build_runner(architecture, choice, vendor: str, gpu, num_experts, layout):
         intermediate_size=_INTERMEDIATE,
         hidden_size=_HIDDEN,
     )
-    # The Triton vendor has no masked domain; its route-major class runs the
-    # same plan.
-    rows = "route_major" if vendor == "triton" else choice.base_gemm_rows
-    provider = MoeLoraRunner.select_provider_cls(rows, vendor)(quant_info)
+    provider = select_provider_cls(choice.base_gemm_rows, "bf16", vendor)(quant_info)
     runner = MoeLoraRunner(
         providers={"test": provider},
         top_k=_TOP_K,
@@ -592,7 +594,7 @@ _ELIGIBLE_PLAN_PARAMS = (
         _H200,
         True,
         "prefill.shared.rank_le64",
-        id="shared-outer-shared-rank",
+        id="shared-outer-token-gemm",
     ),
 )
 

--- a/test/registered/unit/lora/test_moe_lora_down_b_into_base.py
+++ b/test/registered/unit/lora/test_moe_lora_down_b_into_base.py
@@ -1,0 +1,833 @@
+from __future__ import annotations
+
+import pathlib
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang.srt.lora.moe.execution_plan import (
+    ActFamily,
+    ActivationFn,
+    ActSpec,
+    BridgeLayout,
+    DeviceArchitecture,
+    DownOverlap,
+    FinalizeFamily,
+    FinalizeSpec,
+    LoraAFamily,
+    LoraASpec,
+    LoraBFamily,
+    LoraBSpec,
+    MoeLoraExecutionPlan,
+    Phase,
+    RouteRequirement,
+    SelectedPlan,
+    Site,
+    build_plan,
+    load_plans,
+)
+from sglang.srt.lora.moe.launch_config import resolve_tiles
+from sglang.test.ci.ci_register import register_cuda_ci
+
+
+def _segments_of(mapping: torch.Tensor) -> torch.Tensor:
+    """Request boundaries for a test batch: one request per token, so the
+    segment route is exercised with many short requests and the helper stays
+    free of host syncs (CUDA-graph capture forbids a device-to-host copy)."""
+    return torch.arange(mapping.numel() + 1, dtype=torch.int32, device=mapping.device)
+
+
+register_cuda_ci(est_time=180, stage="base-b", runner_config="1-gpu-large")
+
+_GB300 = DeviceArchitecture.GB300
+_H200 = DeviceArchitecture.H200
+_SWIGLU = ActivationFn.SILU
+
+
+def _menu(architecture, layout, activation=_SWIGLU):
+    """Build every plan row with the loader and builder that serving uses.
+
+    ``resolve_plans`` checks the phase and the rank, then keeps one row for
+    each phase. This helper skips those checks and returns every row.
+    """
+    table = load_plans(architecture)
+    layout_name = "shared" if layout else "per_expert"
+    return {
+        row.name: SelectedPlan(
+            key=f"{architecture.value}.{layout_name}.{row.name}",
+            name=row.name,
+            base_gemm_rows=row.base_gemm_rows,
+            plan=build_plan(row.plan, activation=activation, is_shared_outer=layout),
+        )
+        for row in (*table.scenarios, *table.fallback)
+        if row.layout in (None, layout_name)
+    }
+
+
+def _shipped_launch(architecture, sel, *, physical_rank=16, num_tokens=4096):
+    return resolve_tiles(
+        architecture_value=architecture.value,
+        plan_key_name=sel.name,
+        physical_rank=physical_rank,
+    ).config_for(num_tokens)
+
+
+def _build_plan(
+    *,
+    activation=_SWIGLU,
+    is_shared_outer=False,
+    finalize_family=FinalizeFamily.MATERIALIZED,
+    down_overlap=DownOverlap.NONE,
+) -> MoeLoraExecutionPlan:
+    pe = False
+    consumes_down_b = finalize_family is not FinalizeFamily.MATERIALIZED
+    return MoeLoraExecutionPlan(
+        gate_up_a=LoraASpec(
+            Site.GATE_UP,
+            LoraAFamily.GROUPED,
+            is_shared_outer,
+            BridgeLayout.PAIR_MAJOR,
+        ),
+        gate_up_b=LoraBSpec(
+            Site.GATE_UP,
+            LoraBFamily.GROUPED,
+            pe,
+            BridgeLayout.PAIR_MAJOR,
+        ),
+        act=ActSpec(ActFamily.MATERIALIZED, activation),
+        down_a=LoraASpec(Site.DOWN, LoraAFamily.GROUPED, pe, BridgeLayout.PAIR_MAJOR),
+        down_b=(
+            None
+            if consumes_down_b
+            else LoraBSpec(
+                Site.DOWN,
+                LoraBFamily.GROUPED,
+                is_shared_outer,
+                BridgeLayout.PAIR_MAJOR,
+            )
+        ),
+        finalize=FinalizeSpec(
+            finalize_family, is_shared_outer if consumes_down_b else False
+        ),
+        down_overlap=down_overlap,
+    )
+
+
+def _serial_plan():
+    return _build_plan()
+
+
+class TestDownBIntoBasePlan:
+    def test_raw_serial_plan_admits_the_flag(self) -> None:
+        plan = _serial_plan()
+        assert plan.down_b_into_base is False
+        assert plan.down_b_into_base_eligible()
+        reordered = replace(plan, down_b_into_base=True)
+        # The grouped down-B stage stays. Only its output address changes.
+        assert reordered.down_b is not None
+        assert reordered.down_b.family is LoraBFamily.GROUPED
+        assert reordered.finalize.family is FinalizeFamily.MATERIALIZED
+
+    def test_flagged_plan_leaves_the_shape_keyed_conversions(self) -> None:
+        # With the scatter, down-B writes into the base down rows. The plan is
+        # then no longer the plain serial shape.
+        plan = _serial_plan()
+        assert plan.is_fully_serial_materialized()
+        assert not replace(plan, down_b_into_base=True).is_fully_serial_materialized()
+
+    def test_flag_leaves_the_b_family_to_provider_capability(self) -> None:
+        # The provider says which down-B kernel does the scatter. The plan
+        # does not fix the down-B family.
+        indexed = replace(
+            _serial_plan(),
+            down_b=LoraBSpec(
+                Site.DOWN,
+                LoraBFamily.PER_PAIR,
+                False,
+                BridgeLayout.PAIR_MAJOR,
+            ),
+        )
+        assert replace(indexed, down_b_into_base=True).down_b_into_base is True
+
+    def test_flag_moves_the_down_b_route_to_the_aligned_view(self) -> None:
+        # A raw down-B family asks for the raw route. Under into-base that
+        # family kernel does not run, so the plan must ask for the aligned
+        # route that the into-base kernel reads. Before this rule the plan
+        # built only the raw route and the first forward failed.
+        indexed = replace(
+            _serial_plan(),
+            gate_up_a=LoraASpec(Site.GATE_UP, LoraAFamily.PER_PAIR),
+            gate_up_b=LoraBSpec(Site.GATE_UP, LoraBFamily.PER_PAIR),
+            down_a=LoraASpec(Site.DOWN, LoraAFamily.PER_PAIR),
+            down_b=LoraBSpec(
+                Site.DOWN,
+                LoraBFamily.PER_PAIR,
+                False,
+                BridgeLayout.PAIR_MAJOR,
+            ),
+        )
+        assert RouteRequirement.ALIGNED_PER_EXPERT not in indexed.route_requirements()
+        scattered = replace(indexed, down_b_into_base=True)
+        assert RouteRequirement.ALIGNED_PER_EXPERT in scattered.route_requirements()
+
+    def test_flag_requires_a_standalone_down_b(self) -> None:
+        # The shared-rank reduce consumes down-B inside finalize. There is
+        # then no separate down-B stage to move. The H200 shared row uses
+        # this form.
+        consumed = _build_plan(
+            is_shared_outer=True,
+            finalize_family=FinalizeFamily.SHARED_RANK_REDUCE,
+        )
+        assert consumed.down_b is None
+        with pytest.raises(ValueError, match="down-B into-base"):
+            replace(consumed, down_b_into_base=True)
+
+    def test_flag_rejects_the_windows_that_race_the_base_gemm(self) -> None:
+        # down-B must run after the base down GEMM writes its rows. DOWN_B and
+        # DOWN_A_B put down-B on the side stream next to the base GEMM. down-B
+        # then reads rows before the base GEMM writes them.
+        for window in (DownOverlap.DOWN_B, DownOverlap.DOWN_A_B):
+            overlapped = _build_plan(down_overlap=window)
+            with pytest.raises(ValueError, match="down-B into-base"):
+                replace(overlapped, down_b_into_base=True)
+
+    def test_flag_admits_the_down_a_window(self) -> None:
+        # DOWN_A runs down-A next to the base GEMM. It joins before down-B
+        # starts. The base rows are complete at that point, so the scatter is
+        # safe. No shipped row uses this window. The measurement showed no
+        # gain from it.
+        forked = _build_plan(down_overlap=DownOverlap.DOWN_A)
+        assert replace(forked, down_b_into_base=True).down_b_into_base is True
+
+
+def _into_base_expected(name: str, layout) -> bool:
+    """Return whether one plan row must add down-B into the base output.
+
+    The prefill rows use it. A row skips it when finalize consumes down-B.
+    No separate down-B stage then remains to move.
+    """
+    if layout != False:
+        # gb300's rank_le32 shared row copies its parent and keeps the scatter;
+        # h200's rank_le16/le64 shared rows finalize through shared_rank_reduce
+        # and are excluded.
+        return name in (
+            "prefill.shared",
+            "prefill.shared.rank_le8",
+            "prefill.shared.rank_le32",
+            "fallback.prefill.shared",
+        )
+    return name in (
+        "prefill.per_expert",
+        "prefill.per_expert.rank_le16",
+        "prefill.per_expert.rank_le32",
+        "fallback.prefill.per_expert",
+    )
+
+
+class TestDownBIntoBaseConfig:
+    def test_config_never_touches_decode_shared_or_overlapped(self) -> None:
+        cases = (
+            ("gb300_pe", _GB300, False, _SWIGLU),
+            ("h200_pe", _H200, False, _SWIGLU),
+            ("h200_sh", _H200, True, _SWIGLU),
+            ("gb300_sh", _GB300, True, _SWIGLU),
+            # A row does not depend on the activation. The ReLU2 build makes
+            # the same scatter choice for each row.
+            ("gb300_relu2", _GB300, False, ActivationFn.RELU2),
+        )
+        for name, architecture, layout, activation in cases:
+            for row_name, choice in _menu(architecture, layout, activation).items():
+                assert choice.plan.down_b_into_base is _into_base_expected(
+                    row_name, layout
+                ), (name, row_name)
+
+
+class TestProviderIntoBaseSurface:
+    def test_both_row_domains_implement_the_into_base_epilogue(self) -> None:
+        from sglang.srt.lora.moe.base_gemm_provider.contiguous_row_domain import (
+            ContiguousRowDomainProvider,
+        )
+        from sglang.srt.lora.moe.base_gemm_provider.masked_row_domain import (
+            MaskedRowDomainProvider,
+        )
+        from sglang.srt.lora.moe.quant_info import MoeLoraBf16QuantInfo
+
+        quant_info = MoeLoraBf16QuantInfo(
+            w13_weight=torch.zeros((4, 2 * 8, 16), dtype=torch.bfloat16),
+            w2_weight=torch.zeros((4, 16, 8), dtype=torch.bfloat16),
+            num_local_experts=4,
+            intermediate_size=8,
+            hidden_size=16,
+        )
+        # The into-base epilogue is a LoRA kernel, so the runner calls it.
+        # No provider wraps it: the only provider state it needs is pair_to_row,
+        # which the runner already holds from the down-A mapping.
+        from sglang.srt.lora.moe.base_gemm_provider.base import MoeBaseProvider
+
+        for cls in (
+            MaskedRowDomainProvider,
+            ContiguousRowDomainProvider,
+            MoeBaseProvider,
+        ):
+            assert not hasattr(cls, "run_down_b_into_base")
+        runner_src = (
+            pathlib.Path(__file__).resolve().parents[4]
+            / "python/sglang/srt/lora/moe/moe_lora_runner.py"
+        ).read_text()
+        assert "invoke_down_b_into_base(" in runner_src
+        # The mapping is unconditional, so no other plan field can decide
+        # whether the runner holds pair_to_row.
+        assert "= provider.mapped_down_lora_a_input(" in runner_src
+        for cls in (MaskedRowDomainProvider, ContiguousRowDomainProvider):
+            assert MaskedRowDomainProvider(quant_info).mapped_down_lora_a_input
+
+
+cuda_only = pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="the scatter kernel needs any CUDA device (plain Triton)",
+)
+
+
+def _cutedsl_ready() -> bool:
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability() < (9, 0):
+        return False
+    try:
+        import cuda.bindings.driver  # noqa: F401
+        import cutlass  # noqa: F401
+    except Exception:
+        return False
+    return True
+
+
+cutedsl_cuda_only = pytest.mark.skipif(
+    not _cutedsl_ready(),
+    reason="the runner-level oracle runs the CuTeDSL providers",
+)
+
+_HIDDEN = 128
+_INTERMEDIATE = 128
+_RANK = 16
+_SLOTS = 2
+_TOP_K = 2
+_ROUTED_SCALING = 0.75
+_ROW_POISON = 2**30  # the kernel must never read a sentinel pair's pair_to_row entry
+
+
+def _kernel_case(num_tokens: int, top_k: int, num_experts: int, seed: int):
+    generator = torch.Generator().manual_seed(seed)
+    topk_ids = torch.randint(
+        0, num_experts, (num_tokens, top_k), generator=generator, dtype=torch.int32
+    )
+    topk_ids[torch.rand((num_tokens, top_k), generator=generator) < 0.15] = -1
+    topk_ids[0] = -1  # a token with no routed pair
+    pattern = torch.tensor([0, 1, -1, 0, -1, 1], dtype=torch.int32)
+    token_lora_mapping = pattern.repeat(-(-num_tokens // pattern.numel()))[:num_tokens]
+    weights = torch.rand((num_tokens, top_k), generator=generator) + 0.1
+    topk_weights = (weights / weights.sum(dim=1, keepdim=True)).float()
+
+    pairs = num_tokens * top_k
+    bridge = (torch.randn((pairs, _RANK), generator=generator) * 0.15).to(
+        torch.bfloat16
+    )
+    b_down = (
+        torch.randn((_SLOTS * num_experts, _HIDDEN, _RANK), generator=generator) * 0.15
+    ).to(torch.bfloat16)
+    # Slot 1 is a narrow adapter. Its rank padding is zero in the bridge and
+    # in down-B. A batch with mixed ranks reaches the kernels in this form.
+    b_down.view(_SLOTS, num_experts, _HIDDEN, _RANK)[1, :, :, _RANK // 2 :] = 0
+    bridge_view = bridge.view(num_tokens, top_k, _RANK)
+    bridge_view[token_lora_mapping == 1, :, _RANK // 2 :] = 0
+    return topk_ids, token_lora_mapping, topk_weights, bridge, b_down
+
+
+def _pair_to_row_rows(topk_ids: torch.Tensor, num_experts: int, style: str, seed: int):
+    """Build the pair-to-row map of both row domains on the host."""
+    ids = topk_ids.view(-1)
+    counts = [int((ids == expert).sum()) for expert in range(num_experts)]
+    if style == "masked":
+        m_max = -(-max(counts + [1]) // 8) * 8 + 8
+        base = [expert * m_max for expert in range(num_experts)]
+        total_rows = num_experts * m_max
+    else:  # contiguous rows, with each segment aligned to 8 rows
+        alignment = 8
+        base, offset = [], 0
+        for count in counts:
+            base.append(offset)
+            offset += -(-count // alignment) * alignment
+        total_rows = max(offset, alignment)
+    pair_to_row = torch.full((ids.numel(),), _ROW_POISON, dtype=torch.int32)
+    cursor = [0] * num_experts
+    for pair, expert in enumerate(ids.tolist()):
+        if expert >= 0:
+            pair_to_row[pair] = base[expert] + cursor[expert]
+            cursor[expert] += 1
+    generator = torch.Generator().manual_seed(seed ^ 0xD05E)
+    down_rows = (torch.randn((total_rows, _HIDDEN), generator=generator) * 0.2).to(
+        torch.bfloat16
+    )
+    return pair_to_row, down_rows
+
+
+def _fp32_finalize_oracle(
+    down_rows,
+    pair_to_row,
+    bridge,
+    b_down,
+    topk_ids,
+    token_lora_mapping,
+    topk_weights,
+    num_experts,
+):
+    num_tokens, top_k = topk_ids.shape
+    out = torch.zeros((num_tokens, _HIDDEN), dtype=torch.float32)
+    for token in range(num_tokens):
+        slot = int(token_lora_mapping[token])
+        for k in range(top_k):
+            expert = int(topk_ids[token, k])
+            if expert < 0:
+                continue
+            pair = token * top_k + k
+            row = down_rows[int(pair_to_row[pair])].float()
+            if 0 <= slot < _SLOTS:
+                veid = slot * num_experts + expert
+                row = row + b_down[veid].float() @ bridge[pair].float()
+            out[token] += float(topk_weights[token, k]) * row
+    return out * _ROUTED_SCALING
+
+
+# Both launches use one config. The scatter must keep the same down-B tiling
+# as the shipped path.
+_DOWN_B_CONFIG = {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 16,
+    "GROUP_SIZE_M": 8,
+    "num_warps": 4,
+    "num_stages": 2,
+}
+
+# The scatter adds the FP32 delta to the base row, then rounds once. The
+# shipped path rounds the delta to BF16 first, then adds. The two paths round
+# at different points, so compare them with a tolerance.
+_INTO_BASE_TOLERANCE = {"atol": 1e-2, "rtol": 0.05}
+
+
+def _post_reorder(
+    down_rows, output, pair_to_row, topk_ids, topk_weights, lora_delta=None
+):
+    from sglang.kernels.ops.moe.ep_moe_kernels import post_reorder_deepgemm
+
+    num_tokens, top_k = topk_ids.shape
+    post_reorder_deepgemm(
+        down_rows,
+        output,
+        pair_to_row,
+        topk_ids,
+        topk_weights,
+        top_k,
+        num_tokens,
+        _HIDDEN,
+        _ROUTED_SCALING,
+        lora_delta=lora_delta,
+    )
+
+
+@cuda_only
+@pytest.mark.parametrize("row_domain", ("masked", "contiguous"))
+@pytest.mark.parametrize(
+    ("num_tokens", "top_k", "num_experts"),
+    ((64, 2, 4), (13, 3, 4)),
+    ids=("even", "partial"),
+)
+def test_into_base_matches_the_standalone_downb_plus_post_reorder(
+    row_domain: str, num_tokens: int, top_k: int, num_experts: int
+) -> None:
+    from sglang.srt.lora.moe.kernels.lora_b import (
+        grouped_lora_b,
+        invoke_down_b_into_base,
+    )
+    from sglang.srt.lora.moe.route_view import RouteViewKind
+    from sglang.srt.lora.moe.routing import (
+        build_virtual_expert_routing,
+    )
+
+    device = torch.device("cuda")
+    seed = 0x5CA7 + num_tokens + num_experts
+    topk_ids, token_lora_mapping, topk_weights, bridge, b_down = _kernel_case(
+        num_tokens, top_k, num_experts, seed
+    )
+    pair_to_row, down_rows = _pair_to_row_rows(topk_ids, num_experts, row_domain, seed)
+    gpu = {
+        name: tensor.to(device)
+        for name, tensor in {
+            "topk_ids": topk_ids,
+            "token_lora_mapping": token_lora_mapping,
+            "topk_weights": topk_weights,
+            "bridge": bridge,
+            "b_down": b_down,
+            "pair_to_row": pair_to_row,
+            "down_rows": down_rows,
+        }.items()
+    }
+    aligned = build_virtual_expert_routing(
+        gpu["topk_ids"],
+        gpu["token_lora_mapping"],
+        num_local_experts=num_experts,
+        max_loras=_SLOTS,
+        block_size=16,
+        view=RouteViewKind.ALIGNED,
+    )
+
+    # In the shipped path, down-B writes the LoRA delta to its own buffer.
+    # post_reorder then reads that buffer and the unchanged base rows.
+    lora_delta = torch.empty(
+        (num_tokens * top_k, _HIDDEN), dtype=torch.bfloat16, device=device
+    )
+    grouped_lora_b(
+        gpu["bridge"],
+        gpu["b_down"],
+        lora_delta,
+        aligned,
+        destination_offsets=(0,),
+        config=_DOWN_B_CONFIG,
+    )
+    reference = torch.empty((num_tokens, _HIDDEN), dtype=torch.float32, device=device)
+    _post_reorder(
+        gpu["down_rows"],
+        reference,
+        gpu["pair_to_row"],
+        gpu["topk_ids"],
+        gpu["topk_weights"],
+        lora_delta=lora_delta.view(num_tokens, top_k, _HIDDEN),
+    )
+
+    # In the scatter path, the same tiling adds the delta into a copy of the
+    # base rows. post_reorder then runs with no delta buffer.
+    scattered = gpu["down_rows"].clone()
+    invoke_down_b_into_base(
+        down_rows=scattered,
+        pair_to_row=gpu["pair_to_row"],
+        bridge=gpu["bridge"],
+        b_down=gpu["b_down"],
+        routing=aligned,
+        config=_DOWN_B_CONFIG,
+    )
+    output = torch.empty_like(reference)
+    _post_reorder(
+        scattered, output, gpu["pair_to_row"], gpu["topk_ids"], gpu["topk_weights"]
+    )
+    torch.testing.assert_close(output, reference, **_INTO_BASE_TOLERANCE)
+
+    # A row stays bitwise equal if no active LoRA pair targets it. A base-only
+    # pair and a sentinel pair add nothing. The kernel never reads their
+    # pair_to_row entries.
+    lora_active = (topk_ids.view(-1) >= 0) & (
+        token_lora_mapping.repeat_interleave(top_k) >= 0
+    )
+    touched = pair_to_row[lora_active].long()
+    untouched = torch.ones(down_rows.shape[0], dtype=torch.bool)
+    untouched[touched] = False
+    assert torch.equal(
+        scattered[untouched.to(device)], gpu["down_rows"][untouched.to(device)]
+    )
+
+    oracle = _fp32_finalize_oracle(
+        down_rows,
+        pair_to_row,
+        bridge,
+        b_down,
+        topk_ids,
+        token_lora_mapping,
+        topk_weights,
+        num_experts,
+    )
+    torch.testing.assert_close(output.cpu(), oracle, atol=1.8e-2, rtol=0.06)
+
+    # With base-only traffic, the kernel must not change any base row.
+    base_slots = torch.full_like(gpu["token_lora_mapping"], -1)
+    aligned_base = build_virtual_expert_routing(
+        gpu["topk_ids"],
+        base_slots,
+        num_local_experts=num_experts,
+        max_loras=_SLOTS,
+        block_size=16,
+        view=RouteViewKind.ALIGNED,
+    )
+    scattered_base = gpu["down_rows"].clone()
+    invoke_down_b_into_base(
+        down_rows=scattered_base,
+        pair_to_row=gpu["pair_to_row"],
+        bridge=gpu["bridge"],
+        b_down=gpu["b_down"],
+        routing=aligned_base,
+        config=_DOWN_B_CONFIG,
+    )
+    assert torch.equal(scattered_base, gpu["down_rows"])
+    # The active routing must change the rows.
+    assert (scattered - gpu["down_rows"]).abs().max().item() > 1e-3
+
+
+def test_config_rejects_a_mismatched_route_block() -> None:
+    # The grouped B kernels take their row tile from the aligned route, so a
+    # config row tuned for another BLOCK_SIZE_M must fail at table load, not
+    # silently run under the wrong tile.
+    from sglang.srt.lora.moe.launch_config import MoeLoraLaunchConfig
+
+    with pytest.raises(ValueError, match="BLOCK_SIZE_M"):
+        MoeLoraLaunchConfig(
+            routing_block_size=32,
+            down_b=dict(_DOWN_B_CONFIG),  # the config says 16, the route uses 32
+        )
+
+
+def _make_gpu_tensors(num_tokens: int, num_experts: int, device: torch.device):
+    generator = torch.Generator().manual_seed(0x5CA1 + num_tokens)
+
+    def rand_bf16(shape, scale):
+        return (torch.randn(shape, generator=generator) * scale).to(torch.bfloat16)
+
+    tensors = {
+        "hidden_states": rand_bf16((num_tokens, _HIDDEN), 0.20),
+        "w13_weight": rand_bf16((num_experts, 2 * _INTERMEDIATE, _HIDDEN), 0.08),
+        "w2_weight": rand_bf16((num_experts, _HIDDEN, _INTERMEDIATE), 0.08),
+        "gate_up_lora_a": rand_bf16((_SLOTS, num_experts, 2 * _RANK, _HIDDEN), 0.15),
+        "gate_up_lora_b": rand_bf16(
+            (_SLOTS, num_experts, 2 * _INTERMEDIATE, _RANK), 0.15
+        ),
+        "down_lora_a": rand_bf16((_SLOTS, num_experts, _RANK, _INTERMEDIATE), 0.15),
+        "down_lora_b": rand_bf16((_SLOTS, num_experts, _HIDDEN, _RANK), 0.15),
+        "adapter_enabled": torch.tensor([1, 1], dtype=torch.int32),
+    }
+    # Slot 1 is a narrow adapter. Its rank padding is zero in all four
+    # factors. A batch with mixed ranks reaches the kernels in this form.
+    half = _RANK // 2
+    tensors["gate_up_lora_a"][1].view(num_experts, 2, _RANK, _HIDDEN)[
+        :, :, half:, :
+    ] = 0
+    tensors["down_lora_a"][1, :, half:, :] = 0
+    tensors["gate_up_lora_b"][1, :, :, half:] = 0
+    tensors["down_lora_b"][1, :, :, half:] = 0
+
+    scores = torch.rand((num_tokens, num_experts), generator=generator)
+    scores[: num_tokens // 2, 0] += 4.0  # one expert gets many more pairs
+    topk_ids = torch.topk(scores, _TOP_K, dim=1).indices.to(torch.int32)
+    topk_ids[0] = -1  # a token with no routed pair
+    topk_ids[5, 1] = -1  # one sentinel pair inside a token that keeps a routed pair
+    tensors["topk_ids"] = topk_ids.contiguous()
+    weights = torch.rand((num_tokens, _TOP_K), generator=generator) + 0.1
+    tensors["topk_weights"] = (weights / weights.sum(dim=1, keepdim=True)).float()
+    tensors["router_logits"] = torch.zeros(
+        (num_tokens, num_experts), dtype=torch.float32
+    )
+    return {name: tensor.to(device) for name, tensor in tensors.items()}
+
+
+def _token_lora_mapping(traffic: str, num_tokens: int) -> torch.Tensor:
+    if traffic == "active":
+        pattern = torch.tensor([0, 1], dtype=torch.int32)
+    elif traffic == "mixed":
+        pattern = torch.tensor([0, -1, 1, -1], dtype=torch.int32)
+    elif traffic == "base_only":
+        pattern = torch.tensor([-1], dtype=torch.int32)
+    else:
+        raise AssertionError(traffic)
+    return pattern.repeat(-(-num_tokens // pattern.numel()))[:num_tokens].contiguous()
+
+
+def _standalone_output_allocation(runner, *, num_tokens, dtype, device):
+    return torch.empty((num_tokens, runner.hidden_size), dtype=dtype, device=device)
+
+
+def _into_base_pair():
+    """Return the reference plan, the scatter plan, and one launch config.
+
+    Every shipped row with the scatter also uses the b_act middle. The b_act
+    tests cover that middle. These two plans differ in the down tail alone.
+    The decode fallback row only lends its tuned launch config: its shipped
+    plan is the swept winner (indexed gate_up_a plus both overlap windows),
+    not the serial shape this comparison needs, so the plans are built by
+    hand.
+    """
+    tiles_row = _menu(_GB300, False)["fallback.decode"]
+    assert tiles_row.plan.act.family is ActFamily.MATERIALIZED
+    reference_plan = _serial_plan()
+    reordered_plan = replace(reference_plan, down_b_into_base=True)
+    assert reordered_plan.act.family is ActFamily.MATERIALIZED
+    return reference_plan, reordered_plan, _shipped_launch(_GB300, tiles_row)
+
+
+def _bind_test_menu(runner, plan, launch_config):
+    """Publish one plan as the runner's whole phase menu.
+
+    ``run`` resolves from the runner's own ``plans``/``tiles``; a test binds
+    its single plan to both phases so the batch's phase flag cannot matter.
+    """
+    selected = SelectedPlan(key="test", name="test", base_gemm_rows="test", plan=plan)
+    tiles = SimpleNamespace(config_for=lambda num_tokens: launch_config)
+    runner.plans = {Phase.PREFILL: selected, Phase.DECODE: selected}
+    runner.tiles = {Phase.PREFILL: tiles, Phase.DECODE: tiles}
+
+
+def _build_runner(plan, launch_config, base_gemm_rows: str, gpu, num_experts: int):
+    from sglang.srt.lora.moe.moe_lora_runner import MoeLoraRunner
+    from sglang.srt.lora.moe.quant_info import MoeLoraBf16QuantInfo
+
+    provider = MoeLoraRunner.select_provider_cls(base_gemm_rows, "cutedsl")(
+        MoeLoraBf16QuantInfo(
+            w13_weight=gpu["w13_weight"],
+            w2_weight=gpu["w2_weight"],
+            num_local_experts=num_experts,
+            intermediate_size=_INTERMEDIATE,
+            hidden_size=_HIDDEN,
+        )
+    )
+    runner = MoeLoraRunner(
+        providers={"test": provider},
+        top_k=_TOP_K,
+        routed_scaling_factor=_ROUTED_SCALING,
+        activation=ActivationFn.SILU,
+    )
+    runner.validate_plan(plan, base_gemm_rows="test")
+    _bind_test_menu(runner, plan, launch_config)
+    return runner
+
+
+def _run_once(runner, gpu, token_lora_mapping, *, use_cuda_graph=False):
+    from sglang.srt.layers.moe.token_dispatcher.standard import StandardDispatchOutput
+    from sglang.srt.layers.moe.topk import StandardTopKOutput
+    from sglang.srt.lora.moe.moe_lora_runner import MoeLoraBatch
+
+    dispatch = StandardDispatchOutput(
+        hidden_states=gpu["hidden_states"],
+        hidden_states_scale=None,
+        topk_output=StandardTopKOutput(
+            topk_weights=gpu["topk_weights"],
+            topk_ids=gpu["topk_ids"],
+            router_logits=gpu["router_logits"],
+        ),
+    )
+    batch = MoeLoraBatch(
+        gate_up_lora_a=gpu["gate_up_lora_a"],
+        gate_up_lora_b=gpu["gate_up_lora_b"],
+        down_lora_a=gpu["down_lora_a"],
+        down_lora_b=gpu["down_lora_b"],
+        token_lora_mapping=token_lora_mapping,
+        seg_indptr=_segments_of(token_lora_mapping),
+        use_cuda_graph=use_cuda_graph,
+        is_prefill=True,
+    )
+    return runner.run(dispatch, batch)
+
+
+def _workspace_buffer_names(runner) -> set[str]:
+    workspace = runner.workspace
+    return {key[0] for key in workspace._eager_buffers} | {
+        key[0] for key in workspace._graph_buffers
+    }
+
+
+@cutedsl_cuda_only
+@pytest.mark.parametrize("base_gemm_rows", ("expert_major", "route_major"))
+def test_runner_into_base_matches_the_materialized_reference(
+    base_gemm_rows: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Compare the shipped tail with the scatter on both providers.
+
+    The result must not depend on the row domain.
+    """
+    from sglang.srt.lora.moe.moe_lora_runner import MoeLoraRunner
+
+    device = torch.device("cuda")
+    monkeypatch.setattr(
+        MoeLoraRunner, "_allocate_output", _standalone_output_allocation
+    )
+    serial_plan, reordered_plan, launch_config = _into_base_pair()
+    num_tokens, num_experts = 64, 4
+    gpu = _make_gpu_tensors(num_tokens, num_experts, device)
+    reference_runner = _build_runner(
+        serial_plan, launch_config, "expert_major", gpu, num_experts
+    )
+    into_base_runner = _build_runner(
+        reordered_plan, launch_config, base_gemm_rows, gpu, num_experts
+    )
+
+    for traffic in ("active", "mixed", "base_only"):
+        token_lora_mapping = _token_lora_mapping(traffic, num_tokens).to(device)
+        reference = _run_once(reference_runner, gpu, token_lora_mapping).hidden_states
+        into_base = _run_once(into_base_runner, gpu, token_lora_mapping).hidden_states
+        torch.testing.assert_close(
+            into_base,
+            reference,
+            **_INTO_BASE_TOLERANCE,
+            msg=f"{base_gemm_rows}: {traffic}",
+        )
+
+    # The scatter path never allocates the pair-major delta buffer for down-B.
+    # The shipped path always allocates it.
+    assert "down_b:delta" in _workspace_buffer_names(reference_runner)
+    assert "down_b:delta" not in _workspace_buffer_names(into_base_runner)
+
+
+@cutedsl_cuda_only
+def test_into_base_pipeline_replays_correctly_in_a_real_cuda_graph(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang.srt.lora.moe.moe_lora_runner import MoeLoraRunner
+
+    device = torch.device("cuda")
+    monkeypatch.setattr(
+        MoeLoraRunner, "_allocate_output", _standalone_output_allocation
+    )
+    serial_plan, reordered_plan, launch_config = _into_base_pair()
+    num_tokens, num_experts = 64, 4
+    gpu = _make_gpu_tensors(num_tokens, num_experts, device)
+    reference_runner = _build_runner(
+        serial_plan, launch_config, "expert_major", gpu, num_experts
+    )
+    into_base_runner = _build_runner(
+        reordered_plan, launch_config, "expert_major", gpu, num_experts
+    )
+    token_lora_mapping = _token_lora_mapping("active", num_tokens).to(device)
+
+    for _ in range(2):  # warm the JIT and keep the graph buffers before capture
+        _run_once(into_base_runner, gpu, token_lora_mapping, use_cuda_graph=True)
+    torch.cuda.synchronize(device)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = _run_once(
+            into_base_runner, gpu, token_lora_mapping, use_cuda_graph=True
+        )
+    output = captured.hidden_states
+    output_ptr = output.data_ptr()
+
+    graph.replay()
+    torch.cuda.synchronize(device)
+    reference = _run_once(reference_runner, gpu, token_lora_mapping).hidden_states
+    torch.testing.assert_close(output, reference, **_INTO_BASE_TOLERANCE)
+
+    # Replay 2: every token in the batch becomes base-only.
+    token_lora_mapping.fill_(-1)
+    graph.replay()
+    torch.cuda.synchronize(device)
+    assert output.data_ptr() == output_ptr
+    reference = _run_once(reference_runner, gpu, token_lora_mapping).hidden_states
+    torch.testing.assert_close(output, reference, **_INTO_BASE_TOLERANCE)
+
+    # Replay 3: new routing and new activations arrive in the same buffers.
+    gpu["topk_ids"].copy_(gpu["topk_ids"].flip(dims=(1,)))
+    gpu["hidden_states"].copy_((gpu["hidden_states"].float() * 1.5).to(torch.bfloat16))
+    token_lora_mapping.copy_(_token_lora_mapping("mixed", num_tokens).to(device))
+    graph.replay()
+    torch.cuda.synchronize(device)
+    assert output.data_ptr() == output_ptr
+    reference = _run_once(reference_runner, gpu, token_lora_mapping).hidden_states
+    torch.testing.assert_close(output, reference, **_INTO_BASE_TOLERANCE)
+
+    assert "down_b:delta" not in _workspace_buffer_names(into_base_runner)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/lora/test_moe_lora_down_b_into_base.py
+++ b/test/registered/unit/lora/test_moe_lora_down_b_into_base.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 import pytest
 import torch
 
+from sglang.srt.lora.moe.base_gemm_provider import select_provider_cls
 from sglang.srt.lora.moe.execution_plan import (
     ActFamily,
     ActivationFn,
@@ -130,13 +131,6 @@ class TestDownBIntoBasePlan:
         assert reordered.down_b.family is LoraBFamily.GROUPED
         assert reordered.finalize.family is FinalizeFamily.MATERIALIZED
 
-    def test_flagged_plan_leaves_the_shape_keyed_conversions(self) -> None:
-        # With the scatter, down-B writes into the base down rows. The plan is
-        # then no longer the plain serial shape.
-        plan = _serial_plan()
-        assert plan.is_fully_serial_materialized()
-        assert not replace(plan, down_b_into_base=True).is_fully_serial_materialized()
-
     def test_flag_leaves_the_b_family_to_provider_capability(self) -> None:
         # The provider says which down-B kernel does the scatter. The plan
         # does not fix the down-B family.
@@ -173,12 +167,12 @@ class TestDownBIntoBasePlan:
         assert RouteRequirement.ALIGNED_PER_EXPERT in scattered.route_requirements()
 
     def test_flag_requires_a_standalone_down_b(self) -> None:
-        # The shared-rank reduce consumes down-B inside finalize. There is
-        # then no separate down-B stage to move. The H200 shared row uses
-        # this form.
+        # A shared finalize consumes down-B inside finalize. There is then
+        # no separate down-B stage to move. The shared prefill rows for rank
+        # 9-64 use this form.
         consumed = _build_plan(
             is_shared_outer=True,
-            finalize_family=FinalizeFamily.SHARED_RANK_REDUCE,
+            finalize_family=FinalizeFamily.SHARED_TOKEN_DELTA,
         )
         assert consumed.down_b is None
         with pytest.raises(ValueError, match="down-B into-base"):
@@ -209,15 +203,10 @@ def _into_base_expected(name: str, layout) -> bool:
     No separate down-B stage then remains to move.
     """
     if layout != False:
-        # gb300's rank_le32 shared row copies its parent and keeps the scatter;
-        # h200's rank_le16/le64 shared rows finalize through shared_rank_reduce
-        # and are excluded.
-        return name in (
-            "prefill.shared",
-            "prefill.shared.rank_le8",
-            "prefill.shared.rank_le32",
-            "fallback.prefill.shared",
-        )
+        # Every shared prefill row, the out-of-domain fallback included,
+        # finalizes through shared_token_delta, which consumes down-B in the
+        # finalize, so no shared row has a standalone down-B stage to move.
+        return False
     return name in (
         "prefill.per_expert",
         "prefill.per_expert.rank_le16",
@@ -667,14 +656,14 @@ def _bind_test_menu(runner, plan, launch_config):
     selected = SelectedPlan(key="test", name="test", base_gemm_rows="test", plan=plan)
     tiles = SimpleNamespace(config_for=lambda num_tokens: launch_config)
     runner.plans = {Phase.PREFILL: selected, Phase.DECODE: selected}
-    runner.tiles = {Phase.PREFILL: tiles, Phase.DECODE: tiles}
+    runner.tiles = {selected.key: tiles}
 
 
 def _build_runner(plan, launch_config, base_gemm_rows: str, gpu, num_experts: int):
     from sglang.srt.lora.moe.moe_lora_runner import MoeLoraRunner
     from sglang.srt.lora.moe.quant_info import MoeLoraBf16QuantInfo
 
-    provider = MoeLoraRunner.select_provider_cls(base_gemm_rows, "cutedsl")(
+    provider = select_provider_cls(base_gemm_rows, "bf16")(
         MoeLoraBf16QuantInfo(
             w13_weight=gpu["w13_weight"],
             w2_weight=gpu["w2_weight"],

--- a/test/registered/unit/lora/test_moe_lora_fp8_provider_numerics.py
+++ b/test/registered/unit/lora/test_moe_lora_fp8_provider_numerics.py
@@ -1,0 +1,207 @@
+"""FP8 providers against an unquantized fp32 reference.
+
+Pair-major comparison through each provider's own ``pair_to_row``, so the two row
+dispatchers' within-expert row order never enters the check. Tolerances cover
+fp8 weight + per-token-group activation rounding.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from sglang.srt.lora.moe.base_gemm_provider import select_provider_cls
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=60, stage="base-b", runner_config="1-gpu-large")
+
+_E = 4
+_H = 512
+_I = 512
+_TOPK = 2
+_T = 32
+_BLOCK = 128
+
+
+def _skip_unless_supported(vendor="cutedsl"):
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+    if vendor == "cutedsl" and torch.cuda.get_device_capability()[0] < 9:
+        pytest.skip("the FP8 CuTeDSL provider needs SM90+")
+
+
+def _block_quant(weight: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Per-[128,128]-block fp8 quant; returns (fp8 weight, fp32 inverse scale)."""
+    e, rows, cols = weight.shape
+    rb = (rows + _BLOCK - 1) // _BLOCK
+    cb = (cols + _BLOCK - 1) // _BLOCK
+    scale = torch.empty((e, rb, cb), dtype=torch.float32, device=weight.device)
+    q = torch.empty_like(weight, dtype=torch.float8_e4m3fn)
+    fmax = torch.finfo(torch.float8_e4m3fn).max
+    for i in range(rb):
+        for j in range(cb):
+            blk = weight[
+                :, i * _BLOCK : (i + 1) * _BLOCK, j * _BLOCK : (j + 1) * _BLOCK
+            ]
+            amax = blk.float().abs().amax(dim=(1, 2)).clamp(min=1e-6)
+            s = amax / fmax
+            scale[:, i, j] = s
+            q[:, i * _BLOCK : (i + 1) * _BLOCK, j * _BLOCK : (j + 1) * _BLOCK] = (
+                blk.float() / s[:, None, None]
+            ).to(torch.float8_e4m3fn)
+    return q, scale
+
+
+def _case(device):
+    g = torch.Generator(device="cpu").manual_seed(7)
+
+    def rand(*shape):
+        return (torch.randn(*shape, generator=g) * 0.05).to(torch.bfloat16).to(device)
+
+    w13 = rand(_E, 2 * _I, _H)
+    w2 = rand(_E, _H, _I)
+    hidden = rand(_T, _H)
+    topk_ids = torch.stack(
+        [torch.randperm(_E, generator=g)[:_TOPK] for _ in range(_T)]
+    ).to(device=device, dtype=torch.int32)
+    return w13, w2, hidden, topk_ids
+
+
+def _quant_info(w13, w2, scale_form="plain"):
+    """Quantize like the serving load path, and return the exact effective
+    (dequantized) weights so the reference isolates activation-quant error.
+    scale_form mirrors what each vendor's runner branch leaves on the layer:
+    'plain' = untouched
+    fp32 scales (triton)."""
+    from sglang.srt.layers.quantization.fp8_utils import block_quant_dequant
+    from sglang.srt.lora.moe.quant_info import MoeLoraFp8QuantInfo
+
+    def finalize(w_q, w_s):
+        assert scale_form == "plain"
+        eff = block_quant_dequant(w_q, w_s, [128, 128], torch.float32)
+        return w_q, w_s, eff
+
+    w13_q, w13_s, w13_eff = finalize(*_block_quant(w13))
+    w2_q, w2_s, w2_eff = finalize(*_block_quant(w2))
+    info = MoeLoraFp8QuantInfo(
+        w13_weight=w13_q,
+        w13_scale=w13_s,
+        w2_weight=w2_q,
+        w2_scale=w2_s,
+        block_shape=(128, 128),
+        num_local_experts=_E,
+        intermediate_size=_I,
+        hidden_size=_H,
+    )
+    return info, w13_eff, w2_eff
+
+
+def _valid_pairs(topk_ids):
+    flat = topk_ids.flatten()
+    return torch.nonzero(flat >= 0, as_tuple=True)[0], flat
+
+
+def _gather_pairs(slab_or_rows, pair_to_row, pair_idx):
+    rows = (
+        slab_or_rows.reshape(-1, slab_or_rows.shape[-1])
+        if slab_or_rows.ndim == 3
+        else slab_or_rows
+    )
+    return rows[pair_to_row[pair_idx].long()]
+
+
+def _rel_l2(a, b):
+    return (a - b).norm() / b.norm().clamp(min=1e-12)
+
+
+@pytest.mark.parametrize(
+    "vendor,rows",
+    [
+        ("triton", "route_major"),
+        ("cutedsl", "expert_major"),
+        ("cutedsl", "route_major"),
+    ],
+)
+def test_fp8_gateup_and_down_match_reference(vendor, rows):
+    _skip_unless_supported(vendor)
+    device = torch.device("cuda")
+    w13, w2, hidden, topk_ids = _case(device)
+    scale_form = "plain"  # every vendor serves the checkpoint bytes
+    quant_info, w13_eff, w2_eff = _quant_info(w13, w2, scale_form=scale_form)
+
+    from sglang.srt.runtime_context import get_context
+
+    provider = select_provider_cls(rows, "fp8", vendor)(quant_info)
+    with get_context().override_server_args():
+        state = provider.prepare(hidden, topk_ids, _TOPK)
+        gateup = torch.empty(
+            provider.gateup_out_shape(state), dtype=torch.bfloat16, device=device
+        )
+        provider.gateup(state, gateup)
+
+    pair_idx, flat_ids = _valid_pairs(topk_ids)
+    experts = flat_ids[pair_idx].long()
+    tokens = (pair_idx // _TOPK).long()
+    pair_to_row = state.pair_to_row
+
+    ref_gateup = torch.einsum("ph,pnh->pn", hidden[tokens].float(), w13_eff[experts])
+    got_gateup = _gather_pairs(gateup, pair_to_row, pair_idx).float()
+    assert _rel_l2(got_gateup, ref_gateup) < 4e-2
+
+    # Down over a synthetic activation scattered into the provider's layout.
+    act_pairs = (torch.randn_like(ref_gateup[:, :_I]) * 0.1).to(torch.bfloat16)
+    act = torch.zeros(
+        provider.act_out_shape(state), dtype=torch.bfloat16, device=device
+    )
+    act.reshape(-1, _I)[pair_to_row[pair_idx].long()] = act_pairs
+    down = torch.empty(
+        provider.down_out_shape(state), dtype=torch.bfloat16, device=device
+    )
+    with get_context().override_server_args():
+        provider.down(state, act, down)
+
+    ref_down = torch.einsum("pi,phi->ph", act_pairs.float(), w2_eff[experts])
+    got_down = _gather_pairs(down, pair_to_row, pair_idx).float()
+    assert _rel_l2(got_down, ref_down) < 4e-2
+
+
+def test_fp8_admission_rejects_bad_geometry():
+    _skip_unless_supported()
+    device = torch.device("cuda")
+    w13, w2, _, _ = _case(device)
+    quant_info, _, _ = _quant_info(w13, w2)
+    import msgspec
+
+    bad = msgspec.structs.replace(quant_info, block_shape=(64, 64))
+    from sglang.srt.lora.moe.quant_info import admit_fp8_block_weights
+
+    with pytest.raises(NotImplementedError, match=r"\[128, 128\]"):
+        admit_fp8_block_weights(bad)
+
+
+def test_fp8_kernel_rejects_tiles_the_scale_epilogue_cannot_index():
+    """The SM100 FP8 epilogue indexes weight scales per 128-wide output tile and
+    stages one column scale per epilogue thread (128 threads)."""
+    cutlass = pytest.importorskip("cutlass")
+    from sglang.srt.lora.moe.kernels.cutedsl.kernel_sm100_fp8 import (
+        GroupedGemmKernelSm100Fp8,
+    )
+
+    def build(mma_tiler_mn):
+        return GroupedGemmKernelSm100Fp8(
+            acc_dtype=cutlass.Float32,
+            use_2cta_instrs=False,
+            mma_tiler_mn=mma_tiler_mn,
+            cluster_shape_mn=(1, 1),
+            swap_ab=True,
+        )
+
+    build((128, 8))
+    build((128, 128))
+    for mma_tiler_mn in ((64, 128), (128, 256)):
+        with pytest.raises(ValueError, match="mma_tiler_mn"):
+            build(mma_tiler_mn)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/lora/test_moe_lora_fused_contiguous_fp8_gather.py
+++ b/test/registered/unit/lora/test_moe_lora_fused_contiguous_fp8_gather.py
@@ -1,0 +1,98 @@
+"""The fused contiguous fp8 gather must match gather-then-quant.
+
+Token-group quantization is a pure per-row function, so quantizing during the
+gather (one BF16 read per routed pair) must reproduce the reference's scales
+bitwise. Row bytes may differ by one fp8 code on rounding-boundary values
+(Triton lowers the scalar and vector reciprocals differently); the masked
+fp8 fill has the same relationship to the reference.
+"""
+
+import unittest
+
+import torch
+
+from sglang.srt.lora.moe.kernels.dispatch_contiguous import (
+    dispatch_fill_rows_contiguous_bf16,
+    dispatch_fill_rows_contiguous_fp8,
+    dispatch_layout_contiguous,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=30, stage="base-b", runner_config="1-gpu-large")
+
+
+def _reference(hidden, topk_ids, num_experts, top_k, alignment):
+    num_pairs = topk_ids.numel()
+    from sglang.srt.lora.moe.kernels.dispatch_contiguous import contiguous_m_pad_ceiling
+
+    m_pad = contiguous_m_pad_ceiling(num_pairs, num_experts, alignment)
+    device = hidden.device
+    seg_counts = torch.empty(num_experts, dtype=torch.int32, device=device)
+    seg_offsets = torch.empty(num_experts + 1, dtype=torch.int32, device=device)
+    pair_to_row = torch.empty(num_pairs, dtype=torch.int32, device=device)
+    compact = torch.zeros((m_pad, hidden.size(1)), dtype=torch.bfloat16, device=device)
+    dispatch_layout_contiguous(
+        hidden,
+        topk_ids,
+        num_experts,
+        top_k,
+        alignment,
+        seg_counts_out=seg_counts,
+        seg_offsets_out=seg_offsets,
+        pair_to_row_out=pair_to_row,
+    )
+    dispatch_fill_rows_contiguous_bf16(
+        hidden, topk_ids, pair_to_row, hidden_compact_out=compact
+    )
+    from sglang.kernels.ops.quantization.fp8_kernel import (
+        sglang_per_token_group_quant_fp8,
+    )
+
+    q_ref, s_ref = sglang_per_token_group_quant_fp8(compact, 128)
+    return pair_to_row, q_ref, s_ref, m_pad
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "needs CUDA")
+class TestFusedContiguousFp8Gather(unittest.TestCase):
+    def test_matches_gather_then_quant(self):
+        torch.manual_seed(7)
+        device = "cuda"
+        num_tokens, hidden_size, num_experts, top_k, alignment = 96, 512, 32, 6, 128
+        hidden = torch.randn(
+            (num_tokens, hidden_size), device=device, dtype=torch.bfloat16
+        )
+        topk_ids = torch.randint(
+            0, num_experts, (num_tokens, top_k), device=device, dtype=torch.int32
+        )
+        # Sentinel pairs must be skipped by both paths.
+        topk_ids[3, 1] = -1
+        topk_ids[40, 5] = -1
+
+        pair_to_row, q_ref, s_ref, m_pad = _reference(
+            hidden, topk_ids, num_experts, top_k, alignment
+        )
+        rows_fp8 = torch.empty(
+            (m_pad, hidden_size), dtype=torch.float8_e4m3fn, device=device
+        )
+        sf = torch.empty(
+            (m_pad, hidden_size // 128), dtype=torch.float32, device=device
+        )
+        dispatch_fill_rows_contiguous_fp8(
+            hidden, topk_ids, pair_to_row, rows_fp8_out=rows_fp8, scale_out=sf
+        )
+
+        real = pair_to_row[topk_ids.view(-1) >= 0].long()
+        self.assertTrue(torch.equal(sf[real], s_ref[real]))
+        delta = (
+            rows_fp8[real].view(torch.uint8).int() - q_ref[real].view(torch.uint8).int()
+        ).abs()
+        self.assertLessEqual(int(delta.max()), 1)
+        self.assertLess(
+            float((delta > 0).float().mean()),
+            0.005,
+            "more than 0.5% of bytes moved off the reference",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/lora/test_moe_lora_fused_dispatch.py
+++ b/test/registered/unit/lora/test_moe_lora_fused_dispatch.py
@@ -196,5 +196,49 @@ def test_empty_batch() -> None:
     assert torch.equal(masked, torch.zeros_like(masked))
 
 
+def test_masked_fp8_rows_match_upstream_quant() -> None:
+    """dispatch_fill_masked_fp8 writes every routed row exactly as the
+    reference per-token-group quantizer would (same amax / 448, reciprocal
+    multiply, clamp)."""
+    from sglang.kernels.ops.quantization.fp8_kernel import (
+        sglang_per_token_group_quant_fp8,
+    )
+    from sglang.srt.lora.moe.kernels.dispatch_masked import dispatch_fill_masked_fp8
+
+    num_tokens, top_k, num_experts, hidden = 16, 8, 64, 512
+    device = torch.device("cuda")
+    topk_ids = _routed_topk_ids(num_tokens, top_k, num_experts, seed=5).to(device)
+    topk_ids[0, 2] = -1  # an EP-unrouted pair writes nothing
+    hidden_states = _rand_hidden(num_tokens, hidden, seed=6).to(device)
+
+    masked, pair_to_row, _slab = _masked_buffers(
+        num_tokens, top_k, num_experts, hidden, device=device
+    )
+    m_max = (num_tokens // 256 + 1) * 256
+    rows = torch.empty(
+        (num_experts, m_max, hidden), dtype=torch.float8_e4m3fn, device=device
+    )
+    scales = torch.empty(
+        (num_experts, m_max, hidden // 128), dtype=torch.float32, device=device
+    )
+    dispatch_fill_masked_fp8(
+        hidden_states,
+        topk_ids,
+        top_k,
+        masked_m_out=masked,
+        pair_to_row_out=pair_to_row,
+        rows_fp8_out=rows,
+        scale_out=scales,
+    )
+    up_q, up_s = sglang_per_token_group_quant_fp8(hidden_states, 128)
+    real = topk_ids.view(-1) >= 0
+    tokens = torch.arange(num_tokens, device=device).repeat_interleave(top_k)[real]
+    dst = pair_to_row[real].long()
+    assert torch.equal(
+        rows.view(-1, hidden)[dst].view(torch.uint8), up_q[tokens].view(torch.uint8)
+    )
+    assert torch.equal(scales.view(-1, hidden // 128)[dst], up_s[tokens])
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/lora/test_moe_lora_fused_dispatch.py
+++ b/test/registered/unit/lora/test_moe_lora_fused_dispatch.py
@@ -1,0 +1,200 @@
+"""dispatch_fill_masked_bf16 must match the bf16 branch of moe_ep_deepgemm_preprocess;
+slot order is nondeterministic in both, so checks are order-independent invariants."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+pytest.importorskip("triton")
+
+from sglang.kernels.ops.moe.ep_moe_kernels import (  # noqa: E402
+    moe_ep_deepgemm_preprocess,
+)
+from sglang.srt.lora.moe.base_gemm_provider.base import (  # noqa: E402
+    expected_rows_per_expert,
+)
+from sglang.srt.lora.moe.kernels.dispatch_masked import (  # noqa: E402
+    dispatch_fill_masked_bf16,
+)
+from sglang.test.ci.ci_register import register_cuda_ci  # noqa: E402
+
+register_cuda_ci(est_time=15, stage="base-b", runner_config="1-gpu-large")
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="fused masked dispatch requires CUDA"
+)
+
+
+def _routed_topk_ids(
+    num_tokens: int, top_k: int, num_experts: int, *, seed: int
+) -> torch.Tensor:
+    """Distinct experts per token (the capacity invariant both kernels rely on)."""
+    generator = torch.Generator().manual_seed(seed)
+    scores = torch.rand((num_tokens, num_experts), generator=generator)
+    return torch.topk(scores, top_k, dim=1).indices.to(torch.int32)
+
+
+def _rand_hidden(num_tokens: int, hidden: int, *, seed: int) -> torch.Tensor:
+    generator = torch.Generator().manual_seed(seed)
+    return torch.randn((num_tokens, hidden), generator=generator).to(torch.bfloat16)
+
+
+def _masked_buffers(
+    num_tokens: int, top_k: int, num_experts: int, hidden: int, *, device
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    m_max = (num_tokens // 256 + 1) * 256
+    return (
+        torch.empty(num_experts, dtype=torch.int32, device=device),
+        torch.empty(num_tokens * top_k, dtype=torch.int32, device=device),
+        torch.empty((num_experts, m_max, hidden), dtype=torch.bfloat16, device=device),
+    )
+
+
+def _assert_matches_reference(
+    topk_ids: torch.Tensor,
+    hidden_states: torch.Tensor,
+    num_local_experts: int,
+    top_k: int,
+) -> None:
+    ref_masked, ref_expected, _ref_s2d, _ref_slab, ref_scale = (
+        moe_ep_deepgemm_preprocess(
+            topk_ids,
+            num_local_experts,
+            hidden_states,
+            top_k,
+            None,
+            output_dtype=torch.bfloat16,
+        )
+    )
+    masked, pair_to_row, slab = _masked_buffers(
+        hidden_states.shape[0],
+        top_k,
+        num_local_experts,
+        hidden_states.shape[1],
+        device=hidden_states.device,
+    )
+    dispatch_fill_masked_bf16(
+        hidden_states,
+        topk_ids,
+        top_k,
+        masked_m_out=masked,
+        pair_to_row_out=pair_to_row,
+        rows_out=slab,
+    )
+    assert ref_scale is None
+    assert expected_rows_per_expert(topk_ids.numel(), num_local_experts) == ref_expected
+    assert torch.equal(masked, ref_masked)
+
+    hidden = hidden_states.shape[1]
+    m_max = slab.shape[1]
+    flat_ids = topk_ids.view(-1).long()
+    valid = flat_ids >= 0
+    experts = flat_ids[valid]
+    histogram = torch.bincount(experts, minlength=num_local_experts).to(torch.int32)
+    assert torch.equal(masked, histogram)
+
+    dst = pair_to_row.long()[valid]
+    region_lo = experts * m_max
+    assert bool(torch.all(dst >= region_lo))
+    assert bool(torch.all(dst < region_lo + masked.long()[experts]))
+    assert dst.unique().numel() == dst.numel()
+
+    tokens = torch.div(
+        torch.nonzero(valid, as_tuple=True)[0], top_k, rounding_mode="floor"
+    )
+    assert torch.equal(slab.view(-1, hidden)[dst], hidden_states[tokens])
+
+
+@pytest.mark.parametrize(
+    ("num_tokens", "top_k", "num_experts", "hidden"),
+    ((8, 2, 4, 128), (192, 8, 16, 320)),
+    ids=("decode-single-block-ref", "prefill-multi-block-ref"),
+)
+def test_matches_two_kernel_composition(
+    num_tokens: int, top_k: int, num_experts: int, hidden: int
+) -> None:
+    device = torch.device("cuda")
+    topk_ids = _routed_topk_ids(num_tokens, top_k, num_experts, seed=0xD15).to(device)
+    hidden_states = _rand_hidden(num_tokens, hidden, seed=0xF111).to(device)
+    _assert_matches_reference(topk_ids, hidden_states, num_experts, top_k)
+
+
+def test_sentinel_pairs_are_skipped() -> None:
+    """-1 pairs take no slot, keep their pair_to_row entry untouched, copy nothing."""
+    device = torch.device("cuda")
+    num_tokens, top_k, num_experts, hidden = 64, 4, 8, 128
+    topk_ids = _routed_topk_ids(num_tokens, top_k, num_experts, seed=0x5E17)
+    drop = torch.rand(topk_ids.shape, generator=torch.Generator().manual_seed(7)) < 0.3
+    topk_ids[drop] = -1
+    topk_ids = topk_ids.to(device)
+    hidden_states = _rand_hidden(num_tokens, hidden, seed=0xB0B).to(device)
+    _assert_matches_reference(topk_ids, hidden_states, num_experts, top_k)
+
+    m_max = (num_tokens // 256 + 1) * 256
+    pair_to_row_out = torch.full(
+        (num_tokens * top_k,), -777, dtype=torch.int32, device=device
+    )
+    masked_m_out = torch.empty(num_experts, dtype=torch.int32, device=device)
+    gateup_input_out = torch.empty(
+        (num_experts, m_max, hidden), dtype=torch.bfloat16, device=device
+    )
+    dispatch_fill_masked_bf16(
+        hidden_states,
+        topk_ids,
+        top_k,
+        masked_m_out=masked_m_out,
+        pair_to_row_out=pair_to_row_out,
+        rows_out=gateup_input_out,
+    )
+    invalid = topk_ids.view(-1) < 0
+    assert bool(invalid.any())
+    assert bool(torch.all(pair_to_row_out[invalid] == -777))
+
+
+def test_skewed_routing_fills_one_expert() -> None:
+    """All traffic to one expert: masked_m near m_max, every other expert empty."""
+    device = torch.device("cuda")
+    num_tokens, top_k, num_experts, hidden = 250, 1, 8, 128
+    topk_ids = torch.full((num_tokens, top_k), 3, dtype=torch.int32, device=device)
+    hidden_states = _rand_hidden(num_tokens, hidden, seed=0xACE).to(device)
+    _assert_matches_reference(topk_ids, hidden_states, num_experts, top_k)
+
+    masked, pair_to_row, slab = _masked_buffers(
+        num_tokens, top_k, num_experts, hidden, device=device
+    )
+    dispatch_fill_masked_bf16(
+        hidden_states,
+        topk_ids,
+        top_k,
+        masked_m_out=masked,
+        pair_to_row_out=pair_to_row,
+        rows_out=slab,
+    )
+    counts = masked.cpu()
+    assert counts[3].item() == num_tokens
+    assert counts.sum().item() == num_tokens
+
+
+def test_empty_batch() -> None:
+    device = torch.device("cuda")
+    num_experts, top_k, hidden = 4, 2, 64
+    topk_ids = torch.empty((0, top_k), dtype=torch.int32, device=device)
+    hidden_states = torch.empty((0, hidden), dtype=torch.bfloat16, device=device)
+    masked, pair_to_row, slab = _masked_buffers(
+        0, top_k, num_experts, hidden, device=device
+    )
+    dispatch_fill_masked_bf16(
+        hidden_states,
+        topk_ids,
+        top_k,
+        masked_m_out=masked,
+        pair_to_row_out=pair_to_row,
+        rows_out=slab,
+    )
+    assert expected_rows_per_expert(0, num_experts) == 1
+    assert torch.equal(masked, torch.zeros_like(masked))
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/lora/test_moe_lora_gemm_config_store.py
+++ b/test/registered/unit/lora/test_moe_lora_gemm_config_store.py
@@ -1,0 +1,164 @@
+"""The load contract is fail-closed: any missing, malformed, or version-mismatched
+table returns ``None`` and the providers keep their built-in heuristics."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sglang.srt.environ import envs
+from sglang.srt.lora.moe.base_gemm_provider import gemm_config_store
+from sglang.srt.lora.moe.base_gemm_provider.gemm_config_store import (
+    GemmConfigTable,
+    config_file_name,
+    load_config_table,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=3, suite="base-c-test-cpu")
+
+_GEOMETRY = dict(num_local_experts=32, n_gemm1=1536, n_gemm2=7168, k=7168)
+_VALID = {
+    "version": {"cutedsl": "4.2.0", "generated_on": "GB300-152SM"},
+    "tiles": [
+        {"token_width": 64, "persistent_clusters": 128},
+        {"token_width": 128, "persistent_clusters": 152},
+    ],
+    "buckets": {
+        "8": {"token_width": 8},
+        "16": {"token_width": 64},
+        "96": {"token_width": 128},
+        "192": {"token_width": 64},
+    },
+}
+
+
+def _write(
+    tmp_path: Path, payload, *, provider_key: str = "cutedsl_bf16_masked"
+) -> Path:
+    name = config_file_name(provider_key, device_name="MOCK GPU", **_GEOMETRY)
+    (tmp_path / "base_gemm").mkdir(exist_ok=True)
+    path = tmp_path / "base_gemm" / name
+    path.write_text(payload if isinstance(payload, str) else json.dumps(payload))
+    return path
+
+
+def _load(tmp_path: Path, **overrides):
+    kwargs = dict(_GEOMETRY, device_name="MOCK GPU", **overrides)
+    with envs.SGLANG_LORA_MOE_CONFIG_DIR.override(str(tmp_path)):
+        return load_config_table("cutedsl_bf16_masked", **kwargs)
+
+
+def test_config_file_name_encodes_geometry_and_device() -> None:
+    assert config_file_name(
+        "cutedsl_bf16_masked", device_name="NVIDIA GB300", **_GEOMETRY
+    ) == (
+        "provider=cutedsl_bf16_masked,E=32,N1=1536,N2=7168,K=7168,"
+        "device_name=NVIDIA_GB300.json"
+    )
+
+
+def test_missing_file_falls_back_to_none(tmp_path: Path) -> None:
+    assert _load(tmp_path) is None
+
+
+def test_valid_table_loads_via_env_override(tmp_path: Path) -> None:
+    _write(tmp_path, _VALID)
+    table = _load(tmp_path)
+    assert table is not None
+    assert table.buckets[96] == {"token_width": 128}
+    assert tuple((t.token_width, t.persistent_clusters) for t in table.tiles) == (
+        (64, 128),
+        (128, 152),
+    )
+    assert table.version["generated_on"] == "GB300-152SM"
+
+
+def test_an_override_dir_without_the_file_inherits_the_packaged_one(
+    tmp_path: Path, monkeypatch
+) -> None:
+    # The env-override dir is a tuner output dir carrying plans/tiles only;
+    # without per-file fallback it silently disables every packaged table.
+    package, override = tmp_path / "pkg", tmp_path / "override"
+    override.mkdir()
+    package.mkdir()
+    _write(package, _VALID)
+    monkeypatch.setattr(gemm_config_store, "_PACKAGE_CONFIG_DIR", str(package))
+    table = _load(override)
+    assert table is not None
+    assert table.buckets[96] == {"token_width": 128}
+
+
+def test_nearest_m_pick() -> None:
+    table = GemmConfigTable(
+        buckets={
+            8: {"token_width": 8},
+            16: {"token_width": 64},
+            96: {"token_width": 128},
+            192: {"token_width": 64},
+        }
+    )
+    assert table.pick(1)["token_width"] == 8
+    assert table.pick(8)["token_width"] == 8
+    assert table.pick(13) is table.buckets[16]
+    assert table.pick(90) is table.buckets[96]
+    assert table.pick(150) is table.buckets[192]
+    assert table.pick(100_000) is table.buckets[192]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    (
+        "{not json",
+        {"buckets": {}},
+        {"buckets": {"eight": {"token_width": 8}}},
+        {"buckets": {"8": {"token_width": "wide"}}},
+        {"buckets": {"8": {}}},
+        {"buckets": {"-8": {"token_width": 8}}},
+        {"buckets": {"8": {"token_width": -8}}},
+        {
+            "tiles": [
+                {"token_width": 64, "persistent_clusters": 128},
+                {"token_width": 64, "persistent_clusters": 152},
+            ],
+            "buckets": {"8": {"token_width": 64}},
+        },
+        {"tiles": [{"token_width": 64}], "buckets": {"8": {"token_width": 64}}},
+    ),
+    ids=(
+        "invalid-json",
+        "empty-buckets",
+        "non-int-bucket-key",
+        "non-int-payload",
+        "empty-payload",
+        "negative-bucket-key",
+        "negative-payload",
+        "duplicate-tile-width",
+        "tile-missing-field",
+    ),
+)
+def test_malformed_files_are_rejected(tmp_path: Path, payload) -> None:
+    _write(tmp_path, payload)
+    assert _load(tmp_path) is None
+
+
+def test_version_mismatch_is_rejected(tmp_path: Path) -> None:
+    _write(tmp_path, _VALID)
+    assert _load(tmp_path, expected_versions={"cutedsl": "9.9.9"}) is None
+
+
+def test_matching_and_absent_versions_are_accepted(tmp_path: Path) -> None:
+    _write(tmp_path, _VALID)
+    assert _load(tmp_path, expected_versions={"cutedsl": "4.2.0"}) is not None
+    # Keys the file does not record are provenance-only, never a rejection.
+    stripped = dict(_VALID, version={"generated_on": "GB300-152SM"})
+    other = tmp_path / "stripped"
+    other.mkdir()
+    _write(other, stripped)
+    assert _load(other, expected_versions={"cutedsl": "4.2.0"}) is not None
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/lora/test_moe_lora_masked_fusion_source.py
+++ b/test/registered/unit/lora/test_moe_lora_masked_fusion_source.py
@@ -60,70 +60,30 @@ class _ContiguousRowStateStub(msgspec.Struct, kw_only=True):
 
 
 class TestMaskedFusionSource(unittest.TestCase):
-    def test_lora_a_to_b_pdl_has_a_complete_signal_wait_launch_chain(self):
-        # The benchmarks still use the A-to-B chain of Programmatic Dependent
-        # Launch (PDL), so the kernels must keep it. The serving runner does
-        # not use PDL. An A-to-B edge measured no better than launch order.
-        a = (KERNELS / "lora_a.py").read_text()
-        b = (KERNELS / "lora_b.py").read_text()
-        runner = (LORA_MOE / "moe_lora_runner.py").read_text()
-
-        grouped_a = _function(a, "_grouped_lora_a_kernel")
-        one_launch_b = _function(b, "_grouped_lora_b_kernel")
-        b_launcher = _function(b, "grouped_lora_b")
-        self.assertIn("gdc_launch_dependents", grouped_a)
-        self.assertIn("gdc_wait", one_launch_b)
-        self.assertLess(
-            grouped_a.index("gdc_launch_dependents"),
-            grouped_a.index("accumulator ="),
-        )
-        self.assertLess(
-            one_launch_b.index("if group == -1"),
-            one_launch_b.index("gdc_wait"),
-        )
-        self.assertIn('"launch_pdl": True', b_launcher)
-        self.assertNotIn("produce_pdl", runner)
-        self.assertNotIn("consume_pdl", runner)
-
-    def test_cutedsl_base_pdl_separates_producer_and_consumer_roles(self):
-        api = _source("cutedsl/api.py")
-        sm100 = _source("cutedsl/kernel_sm100_bf16.py")
-        sm90 = _source("cutedsl/kernel_sm90_bf16.py")
-        activation = _source("activation_delta.py")
-        act = _source("fused_act.py")
-        finalize = _source("finalize.py")
-        post_reorder = EP_MOE.read_text()
-
-        self.assertIn("produce_pdl: bool = False", api)
-        self.assertNotIn("use_pdl: bool = False", api)
-        for source in (sm100, sm90):
-            kernel = _function(source, "kernel")
-            self.assertIn("griddepcontrol_launch_dependents", kernel)
-            self.assertIn("self.produce_pdl", kernel)
-        # The base GEMM signals the kernels after it. It must not also wait
-        # on the kernel before it, so use_pdl must not read produce_pdl.
-        self.assertNotIn("use_pdl=self.produce_pdl", sm100)
-        self.assertNotIn("use_pdl=self.produce_pdl", sm90)
-
-        for source, kernel_name, launcher_name in (
-            (
-                activation,
-                "_act_delta_kernel",
-                "_launch_act_delta",
-            ),
-            (act, "_b_act_kernel", "_launch_b_act"),
+    def test_no_pdl_edges_outside_routing(self):
+        # PDL edges between stages tied in every e2e cell on all three
+        # architectures, so the A-to-B and base-to-act edges were removed
+        # outright for simplicity. Only the routing
+        # builder keeps its adjudicated PDL edge. This contract keeps the
+        # dead edges from creeping back without a fresh e2e win.
+        for name in (
+            "lora_a.py",
+            "lora_b.py",
+            "activation_delta.py",
+            "fused_act.py",
+            "cutedsl/api.py",
+            "cutedsl/kernel_sm100_bf16.py",
+            "cutedsl/kernel_sm100_fp8.py",
+            "cutedsl/kernel_sm90_bf16.py",
+            "cutedsl/kernel_sm90_fp8.py",
         ):
-            self.assertIn("gdc_wait", _function(source, kernel_name))
-            self.assertIn('"launch_pdl": True', _function(source, launcher_name))
-
-        # The combine kernel takes no PDL edge. No shipped plan row turns on
-        # the base-down to finalize handoff. The whole MoE stack shares this
-        # file, and an unused wait slows every other caller.
-        combine = _function(post_reorder, "post_reorder_deepgemm_triton_kernel")
-        self.assertNotIn("gdc_wait", combine)
-        self.assertNotIn(
-            '"launch_pdl": True', _function(post_reorder, "post_reorder_deepgemm")
-        )
+            source = _source(name)
+            self.assertNotIn("gdc_launch_dependents", source, name)
+            self.assertNotIn("gdc_wait", source, name)
+            self.assertNotIn("launch_pdl", source, name)
+            self.assertNotIn("produce_pdl", source, name)
+            self.assertNotIn("consume_base_pdl", source, name)
+        self.assertIn("USE_PDL", _source("routing.py"))
 
     def test_contiguous_cutedsl_launch_passes_no_pdl_argument(self):
         # The contiguous provider compiles no producer kernel, so its _launch
@@ -163,9 +123,8 @@ class TestMaskedFusionSource(unittest.TestCase):
         # These have one body, on the base.
         contiguous_src = _source("contiguous_row_domain.py")
         for method in (
-            "shared_rank_finalize",
-            "_shared_rank_reduce",
-            "_shared_rank_tail",
+            "shared_token_delta_finalize",
+            "shared_one_pass_finalize",
             "mapped_down_lora_a_input",
             "finalize",
             "num_local_experts",
@@ -192,18 +151,19 @@ class TestMaskedFusionSource(unittest.TestCase):
         self.assertIn("row_state.pair_to_row", body)
         self.assertNotIn("row_state.hidden_permuted", body)
         self.assertNotIn("row_state.masked_m", body)
-        # The shared-rank path is one body on the base. It reaches a physical
-        # row only through pair_to_row, and never through a masked-only field.
-        shared = _function(base, "shared_rank_finalize")
-        self.assertIn("self._shared_rank_reduce(", shared)
-        self.assertIn("self._shared_rank_tail(", shared)
-        finish = _function(base, "_shared_rank_tail")
-        self.assertNotIn("self.finalize(", finish)
-        self.assertIn("invoke_shared_from_scratch_finalize(", finish)
-        self.assertIn("down_rows=down_rows", finish)
-        self.assertIn("pair_to_row=row_state.pair_to_row", finish)
-        reduce_body = _function(base, "_shared_rank_reduce")
-        self.assertIn("del row_state", reduce_body)
+        # The shared finalizes are one body each on the base. They reach a
+        # physical row only through pair_to_row, never a masked-only field.
+        shared_bodies = [
+            _function(base, method)
+            for method in (
+                "shared_token_delta_finalize",
+                "shared_one_pass_finalize",
+            )
+        ]
+        for shared in shared_bodies:
+            self.assertNotIn("self.finalize(", shared)
+            self.assertIn("down_rows=down_rows", shared)
+            self.assertIn("pair_to_row=row_state.pair_to_row", shared)
         mapped = _function(base, "mapped_down_lora_a_input")
         # It hands back the flat row view paired with the route's pair_to_row.
         # Assert the return itself: a punctuation-level match breaks whenever
@@ -212,7 +172,7 @@ class TestMaskedFusionSource(unittest.TestCase):
             "return activation.view(-1, activation.shape[-1]), row_state.pair_to_row",
             " ".join(mapped.split()),
         )
-        for body in (shared, finish, reduce_body, mapped):
+        for body in (*shared_bodies, mapped):
             self.assertNotIn("row_state.hidden_permuted", body)
             self.assertNotIn("row_state.masked_m", body)
         self.assertNotIn("base_gemm_state.pair_to_row", runner)
@@ -287,22 +247,23 @@ class TestMaskedFusionSource(unittest.TestCase):
         self.assertEqual(offenders, [], "\n".join(offenders))
         self.assertEqual({fn.value for fn in ActivationFn}, {"silu", "relu2"})
 
-    def test_shared_rank_finalize_is_two_stage(self):
-        # The fail-closed guard lives in FinalizeSpec.validate: a
-        # SHARED_RANK_REDUCE plan row without shared-outer down-B ownership
-        # cannot construct.
+    def test_shared_token_delta_finalize_is_three_stage(self):
+        # The fail-closed guard lives in FinalizeSpec.validate: a shared
+        # finalize plan row without shared-outer down-B ownership cannot
+        # construct.
         source = _source("finalize.py")
-        # The wrapper is on the base: both row domains ran it identically.
-        wrapper = _function(_source("base.py"), "shared_rank_finalize")
-        self.assertIn("self._shared_rank_reduce(", wrapper)
-        self.assertIn("self._shared_rank_tail(", wrapper)
-        reduce_body = _function(source, "_shared_rank_reduce_kernel")
+        # The wrapper is on the base: both row domains run it identically.
+        wrapper = _function(_source("base.py"), "shared_token_delta_finalize")
+        self.assertIn("invoke_shared_token_delta_reduce(", wrapper)
+        self.assertIn("grouped_lora_b(", wrapper)
+        self.assertIn("invoke_shared_token_delta_tail(", wrapper)
+        reduce_body = _function(source, "_shared_token_delta_reduce_kernel")
         self.assertNotIn("routed_scaling", reduce_body)
-        from_scratch = _function(source, "_shared_from_scratch_finalize_kernel")
-        self.assertEqual(from_scratch.count("routed_scaling"), 2)
+        tail_body = _function(source, "_shared_token_delta_tail_kernel")
+        self.assertEqual(tail_body.count("routed_scaling"), 2)
         self.assertIn(
             "routed_scaling * (base_acc +",
-            " ".join(from_scratch.split()),
+            " ".join(tail_body.split()),
         )
 
     def test_every_shipped_plan_family_has_an_executor(self):
@@ -344,7 +305,7 @@ class TestMaskedFusionSource(unittest.TestCase):
             "num_stages",
         ):
             self.assertIn(f'"{key}"', act)
-        for key in ("BLOCK_SIZE_T", "BLOCK_SIZE_H", "BLOCK_SIZE_K"):
+        for key in ("BLOCK_SIZE_T", "BLOCK_SIZE_H"):
             self.assertIn(f'"{key}"', finalize)
         self.assertIn('"reduce"', finalize)
         self.assertIn('"tail"', finalize)
@@ -376,6 +337,7 @@ class TestMaskedFusionSource(unittest.TestCase):
         base = importlib.util.module_from_spec(base_spec)
         quant = types.ModuleType("sglang.srt.lora.moe.quant_info")
         quant.MoeLoraBf16QuantInfo = object
+        quant.StandardLayoutQuantInfo = object
         ep = types.ModuleType("sglang.kernels.ops.moe.ep_moe_kernels")
         ep.post_reorder_deepgemm = lambda *_args, **_kwargs: None
         activation = types.ModuleType("sglang.srt.lora.moe.kernels.activation_delta")
@@ -383,8 +345,8 @@ class TestMaskedFusionSource(unittest.TestCase):
         dispatch = types.ModuleType("sglang.srt.lora.moe.kernels.dispatch_masked")
         dispatch.dispatch_fill_masked_bf16 = lambda *_args, **_kwargs: None
         finalize = types.ModuleType("sglang.srt.lora.moe.kernels.finalize")
-        finalize.invoke_shared_from_scratch_finalize = lambda **_kwargs: None
-        finalize.invoke_shared_rank_reduce = lambda **_kwargs: None
+        finalize.invoke_shared_token_delta_tail = lambda **_kwargs: None
+        finalize.invoke_shared_token_delta_reduce = lambda **_kwargs: None
         act = types.ModuleType("sglang.srt.lora.moe.kernels.fused_act")
         act.fused_b_act_masked = lambda *_args, **_kwargs: None
         into_base = types.ModuleType("sglang.srt.lora.moe.kernels.lora_b")
@@ -474,6 +436,7 @@ class TestMaskedFusionSource(unittest.TestCase):
         row_module.MaskedRowState = StubWorkspace
         quant_module = types.ModuleType("sglang.srt.lora.moe.quant_info")
         quant_module.MoeLoraBf16QuantInfo = object
+        quant_module.StandardLayoutQuantInfo = object
         contiguous_module = types.ModuleType(
             "sglang.srt.lora.moe.base_gemm_provider.contiguous_row_domain"
         )

--- a/test/registered/unit/lora/test_moe_lora_masked_fusion_source.py
+++ b/test/registered/unit/lora/test_moe_lora_masked_fusion_source.py
@@ -1,0 +1,550 @@
+"""Source-level checks on the masked fusion and finalize files.
+
+These tests read the source text, so they report a broken call contract
+before anyone compiles a kernel. The Step-8 sweep checks the GPU numbers.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+import msgspec
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=3, suite="base-c-test-cpu")
+
+
+ROOT = Path(__file__).resolve().parents[4]
+LORA_MOE = ROOT / "python/sglang/srt/lora/moe"
+PROVIDER = LORA_MOE / "base_gemm_provider"
+KERNELS = LORA_MOE / "kernels"
+EP_MOE = ROOT / "python/sglang/kernels/ops/moe/ep_moe_kernels.py"
+
+
+def _source(name: str) -> str:
+    """Read a module by file name from either package.
+
+    The Triton kernels moved to moe/kernels while the providers stayed in
+    base_gemm_provider, so look in both rather than making every caller say
+    which one it means.
+    """
+    for base in (PROVIDER, KERNELS):
+        path = base / name
+        if path.exists():
+            return path.read_text()
+    raise AssertionError(f"{name!r} is in neither {PROVIDER} nor {KERNELS}")
+
+
+def _function(source: str, name: str) -> str:
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == name
+        ):
+            return ast.get_source_segment(source, node) or ""
+    raise AssertionError(f"function {name!r} not found")
+
+
+class _ContiguousRowStateStub(msgspec.Struct, kw_only=True):
+    """Providers subclass the real row state, so the stub must be a Struct too."""
+
+
+class TestMaskedFusionSource(unittest.TestCase):
+    def test_lora_a_to_b_pdl_has_a_complete_signal_wait_launch_chain(self):
+        # The benchmarks still use the A-to-B chain of Programmatic Dependent
+        # Launch (PDL), so the kernels must keep it. The serving runner does
+        # not use PDL. An A-to-B edge measured no better than launch order.
+        a = (KERNELS / "lora_a.py").read_text()
+        b = (KERNELS / "lora_b.py").read_text()
+        runner = (LORA_MOE / "moe_lora_runner.py").read_text()
+
+        grouped_a = _function(a, "_grouped_lora_a_kernel")
+        one_launch_b = _function(b, "_grouped_lora_b_kernel")
+        b_launcher = _function(b, "grouped_lora_b")
+        self.assertIn("gdc_launch_dependents", grouped_a)
+        self.assertIn("gdc_wait", one_launch_b)
+        self.assertLess(
+            grouped_a.index("gdc_launch_dependents"),
+            grouped_a.index("accumulator ="),
+        )
+        self.assertLess(
+            one_launch_b.index("if group == -1"),
+            one_launch_b.index("gdc_wait"),
+        )
+        self.assertIn('"launch_pdl": True', b_launcher)
+        self.assertNotIn("produce_pdl", runner)
+        self.assertNotIn("consume_pdl", runner)
+
+    def test_cutedsl_base_pdl_separates_producer_and_consumer_roles(self):
+        api = _source("cutedsl/api.py")
+        sm100 = _source("cutedsl/kernel_sm100_bf16.py")
+        sm90 = _source("cutedsl/kernel_sm90_bf16.py")
+        activation = _source("activation_delta.py")
+        act = _source("fused_act.py")
+        finalize = _source("finalize.py")
+        post_reorder = EP_MOE.read_text()
+
+        self.assertIn("produce_pdl: bool = False", api)
+        self.assertNotIn("use_pdl: bool = False", api)
+        for source in (sm100, sm90):
+            kernel = _function(source, "kernel")
+            self.assertIn("griddepcontrol_launch_dependents", kernel)
+            self.assertIn("self.produce_pdl", kernel)
+        # The base GEMM signals the kernels after it. It must not also wait
+        # on the kernel before it, so use_pdl must not read produce_pdl.
+        self.assertNotIn("use_pdl=self.produce_pdl", sm100)
+        self.assertNotIn("use_pdl=self.produce_pdl", sm90)
+
+        for source, kernel_name, launcher_name in (
+            (
+                activation,
+                "_act_delta_kernel",
+                "_launch_act_delta",
+            ),
+            (act, "_b_act_kernel", "_launch_b_act"),
+        ):
+            self.assertIn("gdc_wait", _function(source, kernel_name))
+            self.assertIn('"launch_pdl": True', _function(source, launcher_name))
+
+        # The combine kernel takes no PDL edge. No shipped plan row turns on
+        # the base-down to finalize handoff. The whole MoE stack shares this
+        # file, and an unused wait slows every other caller.
+        combine = _function(post_reorder, "post_reorder_deepgemm_triton_kernel")
+        self.assertNotIn("gdc_wait", combine)
+        self.assertNotIn(
+            '"launch_pdl": True', _function(post_reorder, "post_reorder_deepgemm")
+        )
+
+    def test_contiguous_cutedsl_launch_passes_no_pdl_argument(self):
+        # The contiguous provider compiles no producer kernel, so its _launch
+        # has no produce_pdl parameter. A call that passes one crashes when
+        # the prefill graph captures.
+        src = _source("cutedsl_bf16.py")
+        contiguous = src[src.index("class CuteDslBf16ContiguousProvider") :]
+        self.assertNotIn("produce_pdl=", contiguous)
+
+    def test_both_device_kernels_carry_the_contiguous_admission_and_fold(self):
+        # prepare_contiguous_bf16 picks a kernel by device capability, so the SM90
+        # kernel must check the same rules as the SM100 kernel. Both device
+        # loops must add the segment base. A loop that misses the add reads
+        # the rows of the wrong expert.
+        for name in ("cutedsl/kernel_sm100_bf16.py", "cutedsl/kernel_sm90_bf16.py"):
+            source = _source(name)
+            self.assertIn(
+                "contiguous_segments requires swap_ab",
+                source,
+            )
+            self.assertIn("contiguous_segments requires a (1, 1) cluster", source)
+            self.assertEqual(source.count("seg_base_tile + "), 2, name)
+        api = _source("cutedsl/api.py")
+        contiguous_fn = _function(api, "prepare_contiguous_bf16")
+        self.assertIn("contiguous_segments=True", contiguous_fn)
+        self.assertIn("_bf16_kernel_class_for(a.device)", contiguous_fn)
+        compile_fn = _function(api, "_compile_prepared")
+        self.assertIn("contiguous_segments=contiguous_segments", compile_fn)
+
+    def test_provider_surface_is_explicit_and_workspace_stays_opaque(self):
+        base = _source("base.py")
+        row = _source("masked_row_domain.py")
+        runner = (LORA_MOE / "moe_lora_runner.py").read_text()
+        # fused_act stays per row domain: its body differs.
+        self.assertIn("def fused_act(", base)
+        self.assertIn("def fused_act(", row)
+        # These have one body, on the base.
+        contiguous_src = _source("contiguous_row_domain.py")
+        for method in (
+            "shared_rank_finalize",
+            "_shared_rank_reduce",
+            "_shared_rank_tail",
+            "mapped_down_lora_a_input",
+            "finalize",
+            "num_local_experts",
+            "intermediate_size",
+            "hidden_size",
+            "gate_up_slices",
+        ):
+            self.assertIn(f"def {method}(", base)
+            self.assertNotIn(f"    def {method}(", row)
+            self.assertNotIn(f"    def {method}(", contiguous_src)
+        # Every fused stage has exactly one implementation, so no stage takes
+        # an implementation name and no provider enumerates or installs one.
+        for gone in (
+            "implementation: str",
+            "def supports_fused_act(",
+            "def supports_fused_finalize(",
+            "def fused_act_implementations(",
+            "def install_fused_act_implementation(",
+        ):
+            self.assertNotIn(gone, base)
+            self.assertNotIn(gone, row)
+
+        body = _function(row, "fused_act")
+        self.assertIn("row_state.pair_to_row", body)
+        self.assertNotIn("row_state.hidden_permuted", body)
+        self.assertNotIn("row_state.masked_m", body)
+        # The shared-rank path is one body on the base. It reaches a physical
+        # row only through pair_to_row, and never through a masked-only field.
+        shared = _function(base, "shared_rank_finalize")
+        self.assertIn("self._shared_rank_reduce(", shared)
+        self.assertIn("self._shared_rank_tail(", shared)
+        finish = _function(base, "_shared_rank_tail")
+        self.assertNotIn("self.finalize(", finish)
+        self.assertIn("invoke_shared_from_scratch_finalize(", finish)
+        self.assertIn("down_rows=down_rows", finish)
+        self.assertIn("pair_to_row=row_state.pair_to_row", finish)
+        reduce_body = _function(base, "_shared_rank_reduce")
+        self.assertIn("del row_state", reduce_body)
+        mapped = _function(base, "mapped_down_lora_a_input")
+        # It hands back the flat row view paired with the route's pair_to_row.
+        # Assert the return itself: a punctuation-level match breaks whenever
+        # black rewraps the line.
+        self.assertIn(
+            "return activation.view(-1, activation.shape[-1]), row_state.pair_to_row",
+            " ".join(mapped.split()),
+        )
+        for body in (shared, finish, reduce_body, mapped):
+            self.assertNotIn("row_state.hidden_permuted", body)
+            self.assertNotIn("row_state.masked_m", body)
+        self.assertNotIn("base_gemm_state.pair_to_row", runner)
+
+    def test_act_pair_store_is_optional_and_masked_store_is_unconditional(self):
+        source = _source("fused_act.py")
+        self.assertIn("ActivationFn.parse", source)
+        self.assertNotIn('("silu", "relu2")', source)
+        base_columns = _function(source, "_base_columns")
+        self.assertIn("interleaved", base_columns)
+        self.assertIn("gate_first", base_columns)
+        body = _function(source, "_b_act_kernel")
+        self.assertIn("act_rows_ptr", body)
+        self.assertIn("act_pairs_ptr", body)
+        self.assertIn("pair_to_row_ptr", body)
+        self.assertIn("tl.where(base_valid", body)
+        self.assertIn("mask=base_valid", body)
+        b_act = _function(source, "_b_act_kernel")
+        self.assertIn("store_pair_act: tl.constexpr", b_act)
+        self.assertIn("if store_pair_act:", b_act)
+        self.assertLess(
+            b_act.index("act_rows_ptr +"),
+            b_act.index("if store_pair_act:"),
+        )
+        launcher = _function(source, "_launch_b_act")
+        self.assertIn("store_pair_act=act_pairs is not None", launcher)
+
+    def test_materialized_activation_keeps_the_two_axes_independent(self):
+        """Gating and the activation function are two separate constants.
+
+        NUM_SLICES sets the gating and ACTIVATION_TYPE sets the function, so
+        all four combinations compile. One "swiglu-or-relu2" constant cannot
+        express a non-gated silu.
+        """
+        source = _source("activation_delta.py")
+        kernel = _function(source, "_act_delta_kernel")
+        launcher = _function(source, "_launch_act_delta")
+        self.assertIn("NUM_SLICES", kernel)
+        self.assertIn("ACTIVATION_TYPE", kernel)
+        self.assertIn("tl.maximum", _function(source, "apply_activation"))
+        self.assertIn("ActivationFn.parse", source)
+        self.assertNotIn('("silu", "relu2")', source)
+        # The slice count comes from the row widths, never from the activation.
+        self.assertIn("gateup_rows.shape[-1] // inter", launcher)
+
+    def test_no_module_restates_the_activation_set(self):
+        """Eight modules once held their own copy of the activation names.
+
+        A new activation then needed an edit in all eight modules. A pair of
+        names in a literal under moe/ is that copy starting again.
+        """
+        import re
+
+        from sglang.srt.lora.moe.activation import ActivationFn
+
+        moe_root = PROVIDER.parent
+        owner = moe_root / "activation.py"
+        # The pattern finds a literal that lists two of the names.
+        names = "|".join(re.escape(fn.value) for fn in ActivationFn)
+        pattern = re.compile(
+            rf"""[\(\[{{]\s*["']({names})["']\s*,\s*["']({names})["']"""
+        )
+        offenders = []
+        for path in sorted(moe_root.rglob("*.py")):
+            if path == owner:
+                continue
+            for number, line in enumerate(path.read_text().splitlines(), 1):
+                if pattern.search(line):
+                    offenders.append(
+                        f"{path.relative_to(moe_root)}:{number}: {line.strip()}"
+                    )
+        self.assertEqual(offenders, [], "\n".join(offenders))
+        self.assertEqual({fn.value for fn in ActivationFn}, {"silu", "relu2"})
+
+    def test_shared_rank_finalize_is_two_stage(self):
+        # The fail-closed guard lives in FinalizeSpec.validate: a
+        # SHARED_RANK_REDUCE plan row without shared-outer down-B ownership
+        # cannot construct.
+        source = _source("finalize.py")
+        # The wrapper is on the base: both row domains ran it identically.
+        wrapper = _function(_source("base.py"), "shared_rank_finalize")
+        self.assertIn("self._shared_rank_reduce(", wrapper)
+        self.assertIn("self._shared_rank_tail(", wrapper)
+        reduce_body = _function(source, "_shared_rank_reduce_kernel")
+        self.assertNotIn("routed_scaling", reduce_body)
+        from_scratch = _function(source, "_shared_from_scratch_finalize_kernel")
+        self.assertEqual(from_scratch.count("routed_scaling"), 2)
+        self.assertIn(
+            "routed_scaling * (base_acc +",
+            " ".join(from_scratch.split()),
+        )
+
+    def test_every_shipped_plan_family_has_an_executor(self):
+        """A plan row may only name LoRA-A/B families that run_lora_a /
+        run_lora_b execute. The 2026-09-03 kernel retirement dropped the
+        token_dense A executor while gb300's decode.shared.nvfp4 row kept
+        naming it; every shared-outer nvfp4 decode on SM100 then failed at
+        launch and no unit test noticed.
+        """
+        import glob
+        import json
+
+        lora_a = _source("lora_a.py")
+        lora_b = _source("lora_b.py")
+        rows = []
+        for path in sorted(glob.glob(str(LORA_MOE / "configs" / "*.plans.json"))):
+            table = json.load(open(path))
+            rows.extend(table.get("scenarios", []) + table.get("fallback", []))
+        self.assertGreater(len(rows), 0)
+        for row in rows:
+            plan = row["plan"]
+            for key in ("gate_up_a_family", "down_a_family"):
+                fam = plan.get(key)
+                if fam is not None:
+                    self.assertIn(f'case "{fam}":', lora_a, (row["name"], key))
+            for key in ("gate_up_b_family", "down_b_family"):
+                fam = plan.get(key)
+                if fam is not None:
+                    self.assertIn(f'case "{fam}":', lora_b, (row["name"], key))
+
+    def test_config_names_match_the_execution_contract(self):
+        act = _source("fused_act.py")
+        finalize = _source("finalize.py")
+        for key in (
+            "BLOCK_SIZE_W",
+            "BLOCK_SIZE_K",
+            "GROUP_SIZE_M",
+            "num_warps",
+            "num_stages",
+        ):
+            self.assertIn(f'"{key}"', act)
+        for key in ("BLOCK_SIZE_T", "BLOCK_SIZE_H", "BLOCK_SIZE_K"):
+            self.assertIn(f'"{key}"', finalize)
+        self.assertIn('"reduce"', finalize)
+        self.assertIn('"tail"', finalize)
+
+    def test_provider_constructs_every_builtin_capability_from_shared_constants(self):
+        """Catch missing runtime imports in the attach-time registry builder."""
+        packages = {}
+        for name in (
+            "sglang",
+            "sglang.kernels",
+            "sglang.kernels.ops",
+            "sglang.kernels.ops.moe",
+            "sglang.srt",
+            "sglang.srt.lora",
+            "sglang.srt.lora.moe",
+            "sglang.srt.lora.moe.base_gemm_provider",
+            "sglang.srt.lora.moe.kernels",
+        ):
+            package = types.ModuleType(name)
+            package.__path__ = []
+            packages[name] = package
+
+        # Load the real base. It imports only msgspec and torch, and the
+        # row domains now inherit mapped_down_lora_a_input from it, so a stub
+        # would hide the very method this test exercises.
+        base_spec = importlib.util.spec_from_file_location(
+            "sglang.srt.lora.moe.base_gemm_provider.base", PROVIDER / "base.py"
+        )
+        base = importlib.util.module_from_spec(base_spec)
+        quant = types.ModuleType("sglang.srt.lora.moe.quant_info")
+        quant.MoeLoraBf16QuantInfo = object
+        ep = types.ModuleType("sglang.kernels.ops.moe.ep_moe_kernels")
+        ep.post_reorder_deepgemm = lambda *_args, **_kwargs: None
+        activation = types.ModuleType("sglang.srt.lora.moe.kernels.activation_delta")
+        activation.act_delta_masked = lambda *_args, **_kwargs: None
+        dispatch = types.ModuleType("sglang.srt.lora.moe.kernels.dispatch_masked")
+        dispatch.dispatch_fill_masked_bf16 = lambda *_args, **_kwargs: None
+        finalize = types.ModuleType("sglang.srt.lora.moe.kernels.finalize")
+        finalize.invoke_shared_from_scratch_finalize = lambda **_kwargs: None
+        finalize.invoke_shared_rank_reduce = lambda **_kwargs: None
+        act = types.ModuleType("sglang.srt.lora.moe.kernels.fused_act")
+        act.fused_b_act_masked = lambda *_args, **_kwargs: None
+        into_base = types.ModuleType("sglang.srt.lora.moe.kernels.lora_b")
+        into_base.invoke_down_b_into_base = lambda *_args, **_kwargs: None
+
+        base_spec.loader.exec_module(base)
+        spec = importlib.util.spec_from_file_location(
+            "_cpu_masked_row_domain", PROVIDER / "masked_row_domain.py"
+        )
+        self.assertIsNotNone(spec)
+        self.assertIsNotNone(spec.loader)
+        module = importlib.util.module_from_spec(spec)
+        injected = {
+            **packages,
+            base.__name__: base,
+            quant.__name__: quant,
+            ep.__name__: ep,
+            activation.__name__: activation,
+            dispatch.__name__: dispatch,
+            finalize.__name__: finalize,
+            act.__name__: act,
+            into_base.__name__: into_base,
+        }
+        with mock.patch.dict(sys.modules, injected):
+            spec.loader.exec_module(module)
+            provider = module.MaskedRowDomainProvider(
+                SimpleNamespace(
+                    intermediate_size=8,
+                    num_local_experts=2,
+                    hidden_size=4,
+                    w2_weight=torch.empty((2, 4, 8)),
+                    w13_weight=torch.empty((2, 16, 4)),
+                )
+            )
+
+        # One callable per fused stage, bound at construction.
+        self.assertIs(provider._fused_act, act.fused_b_act_masked)
+
+        provider.contract = SimpleNamespace(lora_activation_dtype=torch.bfloat16)
+        pair_to_row = torch.tensor([2, 0, -1, 3], dtype=torch.int32)
+        workspace = module.MaskedRowState(
+            hidden_permuted=torch.empty((2, 4, 4), dtype=torch.bfloat16),
+            masked_m=torch.tensor([2, 2], dtype=torch.int32),
+            expected_m=2,
+            pair_to_row=pair_to_row,
+            m_max=4,
+            retained_inputs=True,
+        )
+        activation_rows = torch.randn((2, 4, 8), dtype=torch.bfloat16)
+        rows, pair_to_row = provider.mapped_down_lora_a_input(
+            workspace, activation_rows
+        )
+        self.assertEqual(tuple(rows.shape), (8, 8))
+        self.assertIs(pair_to_row, pair_to_row)
+        self.assertEqual(rows.data_ptr(), activation_rows.data_ptr())
+
+    def test_cutedsl_schedule_uses_the_resident_slice_count(self):
+        """A non-gated provider must not schedule a two-slice GEMM1.
+
+        The slice count comes from the width of the resident weight. A
+        non-gated silu is therefore the same case as relu2.
+        """
+
+        class StubWorkspace(msgspec.Struct, kw_only=True):
+            hidden_permuted: torch.Tensor
+            masked_m: torch.Tensor
+            expected_m: int
+            pair_to_row: torch.Tensor
+            m_max: int
+            retained_inputs: bool
+
+        class StubProvider:
+            @property
+            def gate_up_slices(self):
+                return self._gate_up_slices
+
+            def prepare(self, *_args):
+                return self._base_workspace
+
+        base_module = types.ModuleType("sglang.srt.lora.moe.base_gemm_provider.base")
+        base_module.MoeBaseProviderContract = lambda **kwargs: SimpleNamespace(**kwargs)
+        base_module.expected_rows_per_expert = lambda num_pairs, num_experts: 1
+        row_module = types.ModuleType(
+            "sglang.srt.lora.moe.base_gemm_provider.masked_row_domain"
+        )
+        row_module.MaskedRowDomainProvider = StubProvider
+        row_module.MaskedRowState = StubWorkspace
+        quant_module = types.ModuleType("sglang.srt.lora.moe.quant_info")
+        quant_module.MoeLoraBf16QuantInfo = object
+        contiguous_module = types.ModuleType(
+            "sglang.srt.lora.moe.base_gemm_provider.contiguous_row_domain"
+        )
+        contiguous_module.ContiguousRowDomainProvider = object
+        contiguous_module.ContiguousRowState = _ContiguousRowStateStub
+
+        # cutedsl_bf16 builds on the shared tile mixin. Load the real module:
+        # it imports only msgspec and torch.
+        common_spec = importlib.util.spec_from_file_location(
+            "sglang.srt.lora.moe.base_gemm_provider.cutedsl_common",
+            PROVIDER / "cutedsl_common.py",
+        )
+        common = importlib.util.module_from_spec(common_spec)
+        common_spec.loader.exec_module(common)
+        packages = {}
+        for name in (
+            "sglang",
+            "sglang.srt",
+            "sglang.srt.lora",
+            "sglang.srt.lora.moe",
+            "sglang.srt.lora.moe.base_gemm_provider",
+            "sglang.srt.lora.moe.kernels",
+        ):
+            package = types.ModuleType(name)
+            package.__path__ = []
+            packages[name] = package
+        spec = importlib.util.spec_from_file_location(
+            "_cpu_cutedsl_bf16", PROVIDER / "cutedsl_bf16.py"
+        )
+        self.assertIsNotNone(spec)
+        self.assertIsNotNone(spec.loader)
+        module = importlib.util.module_from_spec(spec)
+        with mock.patch.dict(
+            sys.modules,
+            {
+                **packages,
+                base_module.__name__: base_module,
+                row_module.__name__: row_module,
+                quant_module.__name__: quant_module,
+                contiguous_module.__name__: contiguous_module,
+                common.__name__: common,
+            },
+        ):
+            spec.loader.exec_module(module)
+
+        base = StubWorkspace(
+            hidden_permuted=torch.empty((2, 4, 8)),
+            masked_m=torch.tensor([2, 2], dtype=torch.int32),
+            expected_m=2,
+            pair_to_row=torch.arange(4, dtype=torch.int32),
+            m_max=4,
+            retained_inputs=False,
+        )
+        provider = object.__new__(module.CuteDslBf16MaskedProvider)
+        provider._base_workspace = base
+        provider.quant_info = SimpleNamespace(intermediate_size=16, hidden_size=8)
+        provider._gate_up_slices = 1
+        provider._max_token_clusters = 1024
+        provider._compiled = {8: object()}
+        provider._config_table = None
+        observed = {}
+
+        def build(masked_m, **kwargs):
+            observed.update(kwargs)
+            return (masked_m, masked_m, masked_m, masked_m)
+
+        provider._build_schedules = build
+        provider.prepare(torch.empty((4, 8)), torch.zeros((4, 1)), 1)
+        self.assertEqual(observed["n_gemm1"], 16)
+        self.assertEqual(observed["n_gemm2"], 8)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/lora/test_moe_lora_moe_runner_numerics.py
+++ b/test/registered/unit/lora/test_moe_lora_moe_runner_numerics.py
@@ -11,6 +11,7 @@ import torch.nn.functional as F
 
 from sglang.srt.layers.moe.token_dispatcher.standard import StandardDispatchOutput
 from sglang.srt.layers.moe.topk import StandardTopKOutput
+from sglang.srt.lora.moe.base_gemm_provider import select_provider_cls
 from sglang.srt.lora.moe.execution_plan import (
     ActivationFn,
     Phase,
@@ -46,7 +47,7 @@ def _bind_test_menu(runner, plan, launch_config):
     selected = SelectedPlan(key="test", name="test", base_gemm_rows="test", plan=plan)
     tiles = SimpleNamespace(config_for=lambda num_tokens: launch_config)
     runner.plans = {Phase.PREFILL: selected, Phase.DECODE: selected}
-    runner.tiles = {Phase.PREFILL: tiles, Phase.DECODE: tiles}
+    runner.tiles = {selected.key: tiles}
 
 
 def _cutedsl_ready() -> bool:
@@ -81,6 +82,7 @@ def _rand_bf16(
 
 def _resolve_execution(architecture, mode: Phase, num_tokens: int):
     selected = resolve_plans(
+        quant_family="bf16",
         architecture=architecture,
         is_shared_outer=False,
         physical_rank=_PHYSICAL_RANK,
@@ -250,7 +252,7 @@ def test_config_chosen_per_expert_swiglu_matches_fp32_reference(
     assert choice.base_gemm_rows is not None
     assert choice.plan is not None
 
-    provider_cls = MoeLoraRunner.select_provider_cls(choice.base_gemm_rows, "cutedsl")
+    provider_cls = select_provider_cls(choice.base_gemm_rows, "bf16")
     provider = provider_cls(
         MoeLoraBf16QuantInfo(
             w13_weight=gpu["w13_weight"],
@@ -331,7 +333,7 @@ def test_selected_pipeline_replays_correctly_in_a_real_cuda_graph(
     choice, launch_config = _resolve_execution(
         architecture_for_capability(*capability), mode, num_tokens
     )
-    provider = MoeLoraRunner.select_provider_cls(choice.base_gemm_rows, "cutedsl")(
+    provider = select_provider_cls(choice.base_gemm_rows, "bf16")(
         MoeLoraBf16QuantInfo(
             w13_weight=gpu["w13_weight"],
             w2_weight=gpu["w2_weight"],

--- a/test/registered/unit/lora/test_moe_lora_moe_runner_numerics.py
+++ b/test/registered/unit/lora/test_moe_lora_moe_runner_numerics.py
@@ -1,0 +1,421 @@
+"""Numerics vs a deliberate FP32 reimplementation, never a benchmark kernel;
+shared-outer layouts are covered separately at the serving boundary."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from sglang.srt.layers.moe.token_dispatcher.standard import StandardDispatchOutput
+from sglang.srt.layers.moe.topk import StandardTopKOutput
+from sglang.srt.lora.moe.execution_plan import (
+    ActivationFn,
+    Phase,
+    SelectedPlan,
+    architecture_for_capability,
+    resolve_plans,
+)
+from sglang.srt.lora.moe.launch_config import resolve_tiles
+from sglang.srt.lora.moe.moe_lora_runner import (
+    MoeLoraBatch,
+    MoeLoraRunner,
+)
+from sglang.srt.lora.moe.quant_info import MoeLoraBf16QuantInfo
+from sglang.test.ci.ci_register import register_cuda_ci
+
+
+def _segments_of(mapping: torch.Tensor) -> torch.Tensor:
+    """Request boundaries for a test batch: one request per token, so the
+    segment route is exercised with many short requests and the helper stays
+    free of host syncs (CUDA-graph capture forbids a device-to-host copy)."""
+    return torch.arange(mapping.numel() + 1, dtype=torch.int32, device=mapping.device)
+
+
+register_cuda_ci(est_time=60, stage="base-b", runner_config="1-gpu-large")
+
+
+def _bind_test_menu(runner, plan, launch_config):
+    """Publish one plan as the runner's whole phase menu.
+
+    ``run`` resolves from the runner's own ``plans``/``tiles``; a test binds
+    its single plan to both phases so the batch's phase flag cannot matter.
+    """
+    selected = SelectedPlan(key="test", name="test", base_gemm_rows="test", plan=plan)
+    tiles = SimpleNamespace(config_for=lambda num_tokens: launch_config)
+    runner.plans = {Phase.PREFILL: selected, Phase.DECODE: selected}
+    runner.tiles = {Phase.PREFILL: tiles, Phase.DECODE: tiles}
+
+
+def _cutedsl_ready() -> bool:
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability() < (9, 0):
+        return False
+    try:
+        import cuda.bindings.driver  # noqa: F401
+        import cutlass  # noqa: F401
+    except Exception:
+        return False
+    return True
+
+
+pytestmark = pytest.mark.skipif(
+    not _cutedsl_ready(), reason="the fp32 oracle runs the CuTeDSL providers"
+)
+
+_EXPERTS = 2
+_TOP_K = 2
+_HIDDEN = 128
+_INTERMEDIATE = 128
+_PHYSICAL_RANK = 16
+_SLOTS = 2
+_ROUTED_SCALING = 0.75
+
+
+def _rand_bf16(
+    shape: tuple[int, ...], *, generator: torch.Generator, scale: float
+) -> torch.Tensor:
+    return (torch.randn(shape, generator=generator) * scale).to(torch.bfloat16)
+
+
+def _resolve_execution(architecture, mode: Phase, num_tokens: int):
+    selected = resolve_plans(
+        architecture=architecture,
+        is_shared_outer=False,
+        physical_rank=_PHYSICAL_RANK,
+        activation=ActivationFn.SILU,
+        hidden_size=_HIDDEN,
+        num_local_experts=_EXPERTS,
+    )[mode]
+    launch_config = resolve_tiles(
+        architecture_value=architecture.value,
+        plan_key_name=selected.name,
+        physical_rank=_PHYSICAL_RANK,
+    ).config_for(num_tokens)
+    return selected, launch_config
+
+
+def _make_cpu_tensors(num_tokens: int) -> dict[str, torch.Tensor]:
+    generator = torch.Generator().manual_seed(0x5A17 + num_tokens)
+    tensors = {
+        "hidden_states": _rand_bf16(
+            (num_tokens, _HIDDEN), generator=generator, scale=0.20
+        ),
+        "w13_weight": _rand_bf16(
+            (_EXPERTS, 2 * _INTERMEDIATE, _HIDDEN),
+            generator=generator,
+            scale=0.08,
+        ),
+        "w2_weight": _rand_bf16(
+            (_EXPERTS, _HIDDEN, _INTERMEDIATE),
+            generator=generator,
+            scale=0.08,
+        ),
+        "gate_up_lora_a": _rand_bf16(
+            (_SLOTS, _EXPERTS, 2 * _PHYSICAL_RANK, _HIDDEN),
+            generator=generator,
+            scale=0.15,
+        ),
+        "gate_up_lora_b": _rand_bf16(
+            (_SLOTS, _EXPERTS, 2 * _INTERMEDIATE, _PHYSICAL_RANK),
+            generator=generator,
+            scale=0.15,
+        ),
+        "down_lora_a": _rand_bf16(
+            (_SLOTS, _EXPERTS, _PHYSICAL_RANK, _INTERMEDIATE),
+            generator=generator,
+            scale=0.15,
+        ),
+        "down_lora_b": _rand_bf16(
+            (_SLOTS, _EXPERTS, _HIDDEN, _PHYSICAL_RANK),
+            generator=generator,
+            scale=0.15,
+        ),
+    }
+
+    alternating_ids = torch.tensor([[0, 1], [1, 0]], dtype=torch.int32)
+    tensors["topk_ids"] = alternating_ids.repeat((num_tokens + 1) // 2, 1)[
+        :num_tokens
+    ].contiguous()
+    tensors["topk_weights"] = torch.tensor([[0.65, 0.35]], dtype=torch.float32).repeat(
+        num_tokens, 1
+    )
+    tensors["router_logits"] = torch.zeros((num_tokens, _EXPERTS), dtype=torch.float32)
+    tensors["adapter_enabled"] = torch.tensor([1, 0], dtype=torch.int32)
+    return tensors
+
+
+def _token_lora_mapping(traffic: str, num_tokens: int) -> torch.Tensor:
+    if traffic == "active":
+        return torch.zeros(num_tokens, dtype=torch.int32)
+    if traffic == "mixed":
+        # Batch preparation normalizes every inactive resident assignment
+        # to -1 before any MoE layer consumes the mapping.
+        pattern = torch.tensor([0, -1, -1, 0, -1, -1], dtype=torch.int32)
+        return pattern.repeat((num_tokens + pattern.numel() - 1) // pattern.numel())[
+            :num_tokens
+        ].contiguous()
+    if traffic == "base_only":
+        # Config choice and graph shape stay fixed while every token follows
+        # the base sentinel; one topology serves every batch.
+        return torch.full((num_tokens,), -1, dtype=torch.int32)
+    raise AssertionError(f"unknown traffic pattern {traffic}")
+
+
+def _fp32_reference(
+    tensors: dict[str, torch.Tensor], token_lora_mapping: torch.Tensor
+) -> torch.Tensor:
+    """Independent token/expert reference with no production route helpers."""
+
+    hidden_states = tensors["hidden_states"].float()
+    w13_weight = tensors["w13_weight"].float()
+    w2_weight = tensors["w2_weight"].float()
+    gate_up_lora_a = tensors["gate_up_lora_a"].float()
+    gate_up_lora_b = tensors["gate_up_lora_b"].float()
+    down_lora_a = tensors["down_lora_a"].float()
+    down_lora_b = tensors["down_lora_b"].float()
+    topk_ids = tensors["topk_ids"]
+    topk_weights = tensors["topk_weights"].float()
+    adapter_enabled = tensors["adapter_enabled"]
+
+    output = torch.zeros((hidden_states.shape[0], _HIDDEN), dtype=torch.float32)
+    for token_idx, hidden in enumerate(hidden_states):
+        slot = int(token_lora_mapping[token_idx])
+        slot_is_active = slot >= 0 and bool(adapter_enabled[slot])
+        for topk_idx in range(_TOP_K):
+            expert = int(topk_ids[token_idx, topk_idx])
+            gate_up = torch.mv(w13_weight[expert], hidden)
+            gate = gate_up[:_INTERMEDIATE]
+            up = gate_up[_INTERMEDIATE:]
+
+            if slot_is_active:
+                gate_up_a = gate_up_lora_a[slot, expert]
+                gate_up_b = gate_up_lora_b[slot, expert]
+                gate_rank = torch.mv(gate_up_a[:_PHYSICAL_RANK], hidden)
+                up_rank = torch.mv(gate_up_a[_PHYSICAL_RANK:], hidden)
+                gate = gate + torch.mv(gate_up_b[:_INTERMEDIATE], gate_rank)
+                up = up + torch.mv(gate_up_b[_INTERMEDIATE:], up_rank)
+
+            activation = F.silu(gate) * up
+            pair_output = torch.mv(w2_weight[expert], activation)
+            if slot_is_active:
+                down_rank = torch.mv(down_lora_a[slot, expert], activation)
+                pair_output = pair_output + torch.mv(
+                    down_lora_b[slot, expert], down_rank
+                )
+
+            output[token_idx].add_(
+                pair_output, alpha=float(topk_weights[token_idx, topk_idx])
+            )
+
+    return output * _ROUTED_SCALING
+
+
+def _standalone_output_allocation(
+    runner: MoeLoraRunner,
+    *,
+    num_tokens: int,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> torch.Tensor:
+    """Match eager output geometry without requiring a serving TP group."""
+
+    return torch.empty((num_tokens, runner.hidden_size), dtype=dtype, device=device)
+
+
+@pytest.mark.parametrize(
+    ("mode", "num_tokens"),
+    ((Phase.DECODE, 8), (Phase.PREFILL, 64)),
+    ids=("decode", "lab-prefill"),
+)
+def test_config_chosen_per_expert_swiglu_matches_fp32_reference(
+    monkeypatch: pytest.MonkeyPatch, mode: Phase, num_tokens: int
+) -> None:
+    device = torch.device("cuda")
+    capability = torch.cuda.get_device_capability(device)
+    if capability[0] not in (9, 10):  # the table mapper itself never raises
+        pytest.skip(f"MoE LoRA does not support SM{capability[0]}{capability[1]}")
+
+    monkeypatch.setattr(
+        MoeLoraRunner, "_allocate_output", _standalone_output_allocation
+    )
+
+    cpu = _make_cpu_tensors(num_tokens)
+    gpu = {name: tensor.to(device) for name, tensor in cpu.items()}
+
+    choice, launch_config = _resolve_execution(
+        architecture_for_capability(*capability), mode, num_tokens
+    )
+    assert choice.base_gemm_rows is not None
+    assert choice.plan is not None
+
+    provider_cls = MoeLoraRunner.select_provider_cls(choice.base_gemm_rows, "cutedsl")
+    provider = provider_cls(
+        MoeLoraBf16QuantInfo(
+            w13_weight=gpu["w13_weight"],
+            w2_weight=gpu["w2_weight"],
+            num_local_experts=_EXPERTS,
+            intermediate_size=_INTERMEDIATE,
+            hidden_size=_HIDDEN,
+        )
+    )
+    runner = MoeLoraRunner(
+        providers={"test": provider},
+        top_k=_TOP_K,
+        routed_scaling_factor=_ROUTED_SCALING,
+        activation=ActivationFn.SILU,
+    )
+    runner.validate_plan(choice.plan, base_gemm_rows="test")
+    _bind_test_menu(runner, choice.plan, launch_config)
+
+    dispatch = StandardDispatchOutput(
+        hidden_states=gpu["hidden_states"],
+        hidden_states_scale=None,
+        topk_output=StandardTopKOutput(
+            topk_weights=gpu["topk_weights"],
+            topk_ids=gpu["topk_ids"],
+            router_logits=gpu["router_logits"],
+        ),
+    )
+    references: dict[str, torch.Tensor] = {}
+    for traffic in ("active", "mixed", "base_only"):
+        cpu_slots = _token_lora_mapping(traffic, num_tokens)
+        references[traffic] = _fp32_reference(cpu, cpu_slots)
+        batch = MoeLoraBatch(
+            gate_up_lora_a=gpu["gate_up_lora_a"],
+            gate_up_lora_b=gpu["gate_up_lora_b"],
+            down_lora_a=gpu["down_lora_a"],
+            down_lora_b=gpu["down_lora_b"],
+            token_lora_mapping=cpu_slots.to(device),
+            seg_indptr=_segments_of(cpu_slots.to(device)),
+            use_cuda_graph=False,
+            is_prefill=mode is Phase.PREFILL,
+        )
+        actual = runner.run(dispatch, batch)
+        torch.testing.assert_close(
+            actual.hidden_states.detach().float().cpu(),
+            references[traffic],
+            atol=0.018,
+            rtol=0.06,
+            msg=f"{choice.key}: {traffic} traffic",
+        )
+
+    # Make the test sensitive to accidentally bypassing all LoRA math despite
+    # the unavoidable BF16-vs-FP32 comparison tolerance above.
+    assert (references["active"] - references["base_only"]).abs().max().item() > 0.02
+
+
+@pytest.mark.parametrize(
+    ("mode", "num_tokens"),
+    ((Phase.DECODE, 8), (Phase.PREFILL, 64)),
+    ids=("decode-graph", "prefill-graph"),
+)
+def test_selected_pipeline_replays_correctly_in_a_real_cuda_graph(
+    monkeypatch: pytest.MonkeyPatch, mode: Phase, num_tokens: int
+) -> None:
+    """The graph contract: routes and launches rebuild from graph-stable
+    metadata, so in-place batch mutations show through unchanged pointers."""
+    device = torch.device("cuda")
+    capability = torch.cuda.get_device_capability(device)
+    if capability[0] not in (9, 10):  # the table mapper itself never raises
+        pytest.skip(f"MoE LoRA does not support SM{capability[0]}{capability[1]}")
+    monkeypatch.setattr(
+        MoeLoraRunner, "_allocate_output", _standalone_output_allocation
+    )
+
+    cpu = _make_cpu_tensors(num_tokens)
+    gpu = {name: tensor.to(device) for name, tensor in cpu.items()}
+    token_lora_mapping = _token_lora_mapping("active", num_tokens).to(device)
+
+    choice, launch_config = _resolve_execution(
+        architecture_for_capability(*capability), mode, num_tokens
+    )
+    provider = MoeLoraRunner.select_provider_cls(choice.base_gemm_rows, "cutedsl")(
+        MoeLoraBf16QuantInfo(
+            w13_weight=gpu["w13_weight"],
+            w2_weight=gpu["w2_weight"],
+            num_local_experts=_EXPERTS,
+            intermediate_size=_INTERMEDIATE,
+            hidden_size=_HIDDEN,
+        )
+    )
+    runner = MoeLoraRunner(
+        providers={"test": provider},
+        top_k=_TOP_K,
+        routed_scaling_factor=_ROUTED_SCALING,
+        activation=ActivationFn.SILU,
+    )
+    runner.validate_plan(choice.plan, base_gemm_rows="test")
+    _bind_test_menu(runner, choice.plan, launch_config)
+    dispatch = StandardDispatchOutput(
+        hidden_states=gpu["hidden_states"],
+        hidden_states_scale=None,
+        topk_output=StandardTopKOutput(
+            topk_weights=gpu["topk_weights"],
+            topk_ids=gpu["topk_ids"],
+            router_logits=gpu["router_logits"],
+        ),
+    )
+    batch = MoeLoraBatch(
+        gate_up_lora_a=gpu["gate_up_lora_a"],
+        gate_up_lora_b=gpu["gate_up_lora_b"],
+        down_lora_a=gpu["down_lora_a"],
+        down_lora_b=gpu["down_lora_b"],
+        token_lora_mapping=token_lora_mapping,
+        seg_indptr=_segments_of(token_lora_mapping),
+        use_cuda_graph=True,
+        is_prefill=mode is Phase.PREFILL,
+    )
+
+    for _ in range(2):  # JIT + workspace graph-buffer retention before capture
+        runner.run(dispatch, batch)
+    torch.cuda.synchronize(device)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = runner.run(dispatch, batch)
+    output = captured.hidden_states
+    output_ptr = output.data_ptr()
+
+    graph.replay()
+    torch.cuda.synchronize(device)
+    torch.testing.assert_close(
+        output.detach().float().cpu(),
+        _fp32_reference(cpu, _token_lora_mapping("active", num_tokens)),
+        atol=0.018,
+        rtol=0.06,
+        msg=f"{choice.key}: active replay",
+    )
+
+    token_lora_mapping.fill_(-1)
+    graph.replay()
+    torch.cuda.synchronize(device)
+    assert output.data_ptr() == output_ptr
+    torch.testing.assert_close(
+        output.detach().float().cpu(),
+        _fp32_reference(cpu, _token_lora_mapping("base_only", num_tokens)),
+        atol=0.018,
+        rtol=0.06,
+        msg=f"{choice.key}: base-only replay",
+    )
+
+    cpu["topk_ids"] = cpu["topk_ids"].flip(dims=(1,)).contiguous()
+    cpu["hidden_states"] = (cpu["hidden_states"].float() * 1.5).to(torch.bfloat16)
+    gpu["topk_ids"].copy_(cpu["topk_ids"])
+    gpu["hidden_states"].copy_(cpu["hidden_states"])
+    token_lora_mapping.copy_(_token_lora_mapping("mixed", num_tokens).to(device))
+    graph.replay()
+    torch.cuda.synchronize(device)
+    assert output.data_ptr() == output_ptr
+    torch.testing.assert_close(
+        output.detach().float().cpu(),
+        _fp32_reference(cpu, _token_lora_mapping("mixed", num_tokens)),
+        atol=0.018,
+        rtol=0.06,
+        msg=f"{choice.key}: mutated-routing replay",
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/lora/test_moe_lora_nvfp4_provider_numerics.py
+++ b/test/registered/unit/lora/test_moe_lora_nvfp4_provider_numerics.py
@@ -1,0 +1,236 @@
+"""Marlin NVFP4 W4A16 provider against an exactly-dequantized reference.
+
+Weights are quantized here in the modelopt checkpoint format (packed e2m1
+pairs, low nibble = even index; e4m3 group-16 scales; fp32 per-expert global
+scale), repacked with the same load-path helper serving uses, and compared
+pair-major through the provider's identity ``pair_to_row``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang.srt.lora.moe.base_gemm_provider import select_provider_cls
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=60, stage="base-b", runner_config="1-gpu-large")
+
+_E = 4
+_H = 256
+_I = 128
+_TOPK = 2
+_T = 32
+
+_E2M1_VALUES = torch.tensor([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0])
+
+
+def _skip_unless_supported():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+    if torch.cuda.get_device_capability()[0] < 9:
+        pytest.skip("Marlin NVFP4 needs SM90+ here")
+
+
+def _quant_nvfp4(weight: torch.Tensor):
+    """[E, N, K] bf16 -> (packed uint8 [E,N,K/2], e4m3 [E,N,K/16], fp32 [E])
+    plus the exact dequantized weights."""
+    e, n, k = weight.shape
+    w = weight.float()
+    global_scale = (w.abs().amax(dim=(1, 2)) / (448.0 * 6.0)).clamp(min=1e-12)
+    groups = w.view(e, n, k // 16, 16)
+    amax16 = groups.abs().amax(dim=-1)
+    block_scale = (
+        (amax16 / (6.0 * global_scale[:, None, None]))
+        .clamp(min=2**-6)
+        .to(torch.float8_e4m3fn)
+    )
+    denom = block_scale.float() * global_scale[:, None, None]
+    scaled = groups / denom[..., None]
+    table = _E2M1_VALUES.to(weight.device)
+    idx = (scaled.abs().unsqueeze(-1) - table).abs().argmin(dim=-1)
+    sign = scaled < 0
+    codes = (idx | (sign.long() << 3)).to(torch.uint8).view(e, n, k)
+    packed = codes[..., 0::2] | (codes[..., 1::2] << 4)
+    dequant = (torch.where(sign, -table[idx], table[idx]) * denom[..., None]).view(
+        e, n, k
+    )
+    return packed, block_scale, global_scale, dequant
+
+
+def _fake_layer(w13, w2):
+    w13_q, w13_bs, w13_gs, w13_eff = _quant_nvfp4(w13)
+    w2_q, w2_bs, w2_gs, w2_eff = _quant_nvfp4(w2)
+    layer = SimpleNamespace(
+        w13_weight=SimpleNamespace(data=w13_q),
+        w2_weight=SimpleNamespace(data=w2_q),
+        w13_weight_scale=SimpleNamespace(data=w13_bs),
+        w2_weight_scale=SimpleNamespace(data=w2_bs),
+        w13_weight_scale_2=SimpleNamespace(data=w13_gs),
+        w2_weight_scale_2=SimpleNamespace(data=w2_gs),
+        quant_config=SimpleNamespace(group_size=16),
+        moe_runner_config=SimpleNamespace(is_gated=True),
+        num_local_experts=_E,
+        intermediate_size_per_partition=_I,
+        hidden_size=_H,
+        params_dtype=torch.bfloat16,
+    )
+    return layer, w13_eff, w2_eff
+
+
+def _marlin_quant_info(layer):
+    from sglang.srt.layers.quantization.marlin_utils_fp4 import (
+        prepare_moe_nvfp4_layer_for_marlin,
+    )
+    from sglang.srt.lora.moe.quant_info import MoeLoraNvFp4MarlinQuantInfo
+
+    prepare_moe_nvfp4_layer_for_marlin(layer)
+    # The fake layer has no quant_method: the payload comes off the repacked
+    # tensors alone, not through the legacy MarlinMoeQuantInfo accessor.
+    return MoeLoraNvFp4MarlinQuantInfo.from_layer(layer)
+
+
+def _rel_l2(a, b):
+    return (a - b).norm() / b.norm().clamp(min=1e-12)
+
+
+def test_nvfp4_marlin_gateup_and_down_match_reference():
+    _skip_unless_supported()
+    device = torch.device("cuda")
+    g = torch.Generator(device="cpu").manual_seed(11)
+
+    def rand(*shape):
+        return (torch.randn(*shape, generator=g) * 0.05).to(torch.bfloat16).to(device)
+
+    w13 = rand(_E, 2 * _I, _H)
+    w2 = rand(_E, _H, _I)
+    hidden = rand(_T, _H)
+    topk_ids = torch.stack(
+        [torch.randperm(_E, generator=g)[:_TOPK] for _ in range(_T)]
+    ).to(device=device, dtype=torch.int32)
+
+    layer, w13_eff, w2_eff = _fake_layer(w13, w2)
+    quant_info = _marlin_quant_info(layer)
+
+    from sglang.srt.runtime_context import get_context
+
+    provider_cls = select_provider_cls("route_major", "nvfp4", "marlin")
+    assert provider_cls is select_provider_cls(
+        "expert_major", "nvfp4", "marlin"
+    ), "decode must run the same route-major marlin provider"
+    provider = provider_cls(quant_info)
+
+    with get_context().override_server_args():
+        state = provider.prepare(hidden, topk_ids, _TOPK)
+        gateup = torch.zeros(
+            provider.gateup_out_shape(state), dtype=torch.bfloat16, device=device
+        )
+        provider.gateup(state, gateup)
+
+        flat_ids = topk_ids.flatten()
+        pair_idx = torch.nonzero(flat_ids >= 0, as_tuple=True)[0]
+        experts = flat_ids[pair_idx].long()
+        tokens = (pair_idx // _TOPK).long()
+
+        ref_gateup = torch.einsum(
+            "ph,pnh->pn", hidden[tokens].float(), w13_eff[experts]
+        )
+        got_gateup = gateup[pair_idx].float()
+        assert _rel_l2(got_gateup, ref_gateup) < 2e-2
+
+        act_pairs = (torch.randn_like(ref_gateup[:, :_I]) * 0.1).to(torch.bfloat16)
+        act = torch.zeros(
+            provider.act_out_shape(state), dtype=torch.bfloat16, device=device
+        )
+        act[pair_idx] = act_pairs
+        down = torch.zeros(
+            provider.down_out_shape(state), dtype=torch.bfloat16, device=device
+        )
+        provider.down(state, act, down)
+
+        ref_down = torch.einsum("pi,phi->ph", act_pairs.float(), w2_eff[experts])
+        got_down = down[pair_idx].float()
+        assert _rel_l2(got_down, ref_down) < 2e-2
+
+
+def test_single_token_align_matches_general_path_with_invalid_ids():
+    """The bs=1 one-program alignment must emit exactly what the general path
+    emits with ignore_invalid_expert=True: EP maps non-local experts to -1,
+    and those pairs get no block, no slot, and no share of num_post. With
+    every id valid it is also a drop-in for the upstream CUDA warp kernel."""
+    _skip_unless_supported()
+    from sglang.kernels.ops.moe.moe_align_single_token import (
+        moe_align_single_token as moe_align_single_token_cuda,
+    )
+    from sglang.srt.layers.moe.moe_runner.triton_utils.moe_align_block_size import (
+        moe_align_block_size,
+    )
+    from sglang.srt.lora.moe.kernels.align_rows import (
+        moe_align_single_token,
+    )
+
+    device = torch.device("cuda")
+    g = torch.Generator(device="cpu").manual_seed(7)
+    num_experts, topk = 64, 8
+    for block_size in (8, 16, 48, 256):
+        for n_invalid in (0, 3, topk):
+            ids = torch.randperm(num_experts, generator=g)[:topk]
+            if n_invalid:
+                ids[torch.randperm(topk, generator=g)[:n_invalid]] = -1
+            ids = ids.view(1, topk).to(device=device, dtype=torch.int32)
+
+            sorted_fast, experts_fast, post_fast = moe_align_single_token(
+                ids, block_size
+            )
+            sorted_ref, experts_ref, post_ref = moe_align_block_size(
+                ids, block_size, num_experts, ignore_invalid_expert=True
+            )
+
+            post = int(post_ref.item())
+            assert int(post_fast.item()) == post
+            assert torch.equal(sorted_fast[:post], sorted_ref[:post])
+            blocks = post // block_size
+            assert torch.equal(experts_fast[:blocks], experts_ref[:blocks])
+            if n_invalid == 0:
+                sorted_cuda, experts_cuda, post_cuda = moe_align_single_token_cuda(
+                    ids, block_size
+                )
+                assert torch.equal(post_fast, post_cuda)
+                assert torch.equal(sorted_fast, sorted_cuda)
+                assert torch.equal(experts_fast, experts_cuda)
+
+
+def test_align_rows_routes_by_token_count():
+    """The shared provider entry takes the one-program path for one token and
+    the general path otherwise; both must match
+    moe_align_block_size(ignore_invalid_expert=True), invalid ids included."""
+    _skip_unless_supported()
+    from sglang.srt.layers.moe.moe_runner.triton_utils.moe_align_block_size import (
+        moe_align_block_size,
+    )
+    from sglang.srt.lora.moe.kernels.align_rows import align_rows
+
+    device = torch.device("cuda")
+    g = torch.Generator(device="cpu").manual_seed(3)
+    num_experts, topk, block_size = 64, 8, 16
+    for tokens in (1, 2):
+        ids = torch.stack(
+            [torch.randperm(num_experts, generator=g)[:topk] for _ in range(tokens)]
+        )
+        ids[0, 0] = -1
+        ids = ids.to(device=device, dtype=torch.int32)
+        sorted_got, experts_got, post_got = align_rows(ids, block_size, num_experts)
+        sorted_ref, experts_ref, post_ref = moe_align_block_size(
+            ids, block_size, num_experts, ignore_invalid_expert=True
+        )
+        post = int(post_ref.item())
+        assert int(post_got.item()) == post
+        assert torch.equal(sorted_got[:post], sorted_ref[:post])
+        blocks = post // block_size
+        assert torch.equal(experts_got[:blocks], experts_ref[:blocks])
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/lora/test_moe_lora_per_pair_b.py
+++ b/test/registered/unit/lora/test_moe_lora_per_pair_b.py
@@ -185,7 +185,12 @@ def test_zero_pair_batches_return_without_launching() -> None:
     )
 
 
-def test_run_lora_b_dispatches_the_family_and_rejects_pdl() -> None:
+def test_run_lora_b_dispatches_the_family_without_a_pdl_knob() -> None:
+    # The PDL edge is hardcoded on for the grouped family and absent for
+    # per_pair (no qualified consumer); the dispatcher takes no knob.
+    import inspect
+
+    assert "consume_pdl" not in inspect.signature(run_lora_b).parameters
     device = torch.device("cuda")
     topk_ids, token_lora_mapping = _routing_case(8, 2, 8, 0x1DB3)
     _, raw = _views(topk_ids, token_lora_mapping, 8, device)
@@ -193,17 +198,6 @@ def test_run_lora_b_dispatches_the_family_and_rejects_pdl() -> None:
         "down", 16, 8, 0x1DB3, device
     )
     spec = LoraBSpec(Site.DOWN, LoraBFamily.PER_PAIR)
-    with pytest.raises(ValueError, match="programmatic-dependent-launch"):
-        run_lora_b(
-            spec,
-            bridge=bridge,
-            weight=weight,
-            destination=_destination(16, num_slices, width, device),
-            routing=raw,
-            destination_offsets=offsets,
-            config=_PER_PAIR_CONFIG,
-            consume_pdl=True,
-        )
     dispatched = _destination(16, num_slices, width, device)
     run_lora_b(
         spec,

--- a/test/registered/unit/lora/test_moe_lora_per_pair_b.py
+++ b/test/registered/unit/lora/test_moe_lora_per_pair_b.py
@@ -1,0 +1,358 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from sglang.srt.lora.moe.execution_plan import (
+    BridgeLayout,
+    LoraBFamily,
+    LoraBSpec,
+    Site,
+)
+from sglang.srt.lora.moe.kernels.lora_b import (
+    grouped_lora_b,
+    per_pair_lora_b,
+    run_lora_b,
+)
+from sglang.srt.lora.moe.route_view import RouteView, RouteViewKind
+from sglang.srt.lora.moe.routing import build_virtual_expert_routing
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=60, stage="base-b", runner_config="1-gpu-large")
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="per_pair LoRA-B needs any CUDA device"
+)
+
+_SLOTS = 2
+_RANK = 16
+_INTERMEDIATE = 96
+_HIDDEN = 128
+_POISON = 7.0
+
+_GROUPED_CONFIG = {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 16,
+    "GROUP_SIZE_M": 8,
+    "num_warps": 4,
+    "num_stages": 2,
+}
+# The per_pair family reads only these keys; BLOCK_SIZE_K matches grouped
+# so the FP32 k-tile accumulation order is identical.
+_PER_PAIR_CONFIG = {
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 16,
+    "num_warps": 4,
+    "num_stages": 2,
+}
+# Same FP32 k-tile accumulation of exact BF16 products; only within-tile
+# reduction order differs (tl.sum vs tl.dot), so allclose, not bitwise.
+_TOLERANCE = {"atol": 5e-3, "rtol": 2e-2}
+
+
+def _routing_case(num_tokens: int, top_k: int, num_experts: int, seed: int):
+    generator = torch.Generator().manual_seed(seed)
+    topk_ids = torch.randint(
+        0, num_experts, (num_tokens, top_k), generator=generator, dtype=torch.int32
+    )
+    topk_ids[torch.rand((num_tokens, top_k), generator=generator) < 0.15] = -1
+    topk_ids[0] = -1  # a token with zero routed pairs
+    pattern = torch.tensor([0, 1, -1, 0, -1, 1], dtype=torch.int32)
+    token_lora_mapping = pattern.repeat(-(-num_tokens // pattern.numel()))[:num_tokens]
+    return topk_ids, token_lora_mapping
+
+
+def _views(topk_ids, token_lora_mapping, num_experts, device):
+    kwargs = dict(
+        num_local_experts=num_experts,
+        max_loras=_SLOTS,
+        block_size=16,
+    )
+    aligned = build_virtual_expert_routing(
+        topk_ids.to(device),
+        token_lora_mapping.to(device),
+        view=RouteViewKind.ALIGNED,
+        **kwargs,
+    )
+    raw = build_virtual_expert_routing(
+        topk_ids.to(device),
+        token_lora_mapping.to(device),
+        view=RouteViewKind.RAW,
+        **kwargs,
+    )
+    return aligned, raw
+
+
+def _site_tensors(site: str, num_pairs: int, num_experts: int, seed: int, device):
+    generator = torch.Generator().manual_seed(seed)
+    groups = _SLOTS * num_experts
+    if site == "gate_up":
+        num_slices, width = 2, _INTERMEDIATE
+        offsets = (0, _INTERMEDIATE)
+    else:
+        num_slices, width = 1, _HIDDEN
+        offsets = (0,)
+    bridge = (
+        torch.randn((num_pairs, num_slices * _RANK), generator=generator) * 0.2
+    ).to(torch.bfloat16)
+    weight = (
+        torch.randn((groups, num_slices * width, _RANK), generator=generator) * 0.2
+    ).to(torch.bfloat16)
+    return bridge.to(device), weight.to(device), offsets, num_slices, width
+
+
+def _destination(num_pairs: int, num_slices: int, width: int, device):
+    return torch.full(
+        (num_pairs, num_slices * width), _POISON, dtype=torch.bfloat16, device=device
+    )
+
+
+@pytest.mark.parametrize("site", ("gate_up", "down"))
+@pytest.mark.parametrize(
+    ("num_tokens", "top_k", "num_experts"),
+    ((32, 4, 64), (13, 3, 4)),
+    ids=("sparse", "partial"),
+)
+def test_per_pair_matches_grouped_on_identical_inputs(
+    site: str, num_tokens: int, top_k: int, num_experts: int
+) -> None:
+    device = torch.device("cuda")
+    seed = 0x1DB0 + num_tokens + num_experts
+    topk_ids, token_lora_mapping = _routing_case(num_tokens, top_k, num_experts, seed)
+    aligned, raw = _views(topk_ids, token_lora_mapping, num_experts, device)
+    num_pairs = num_tokens * top_k
+    bridge, weight, offsets, num_slices, width = _site_tensors(
+        site, num_pairs, num_experts, seed, device
+    )
+
+    reference = _destination(num_pairs, num_slices, width, device)
+    grouped_lora_b(
+        bridge,
+        weight,
+        reference,
+        aligned,
+        destination_offsets=offsets,
+        config=_GROUPED_CONFIG,
+    )
+    indexed = _destination(num_pairs, num_slices, width, device)
+    # The raw view carries no aligned fields, so any aligned-metadata read
+    # would raise instead of silently depending on the sort.
+    per_pair_lora_b(
+        bridge,
+        weight,
+        indexed,
+        raw,
+        destination_offsets=offsets,
+        config=_PER_PAIR_CONFIG,
+    )
+    torch.testing.assert_close(indexed, reference, **_TOLERANCE)
+
+    # Invalid pairs (base tokens, unrouted -1 experts) must be ZERO-stored,
+    # not left at the poison: B owns every consumed destination cell.
+    pair_valid = (topk_ids.view(-1) >= 0) & (
+        token_lora_mapping.repeat_interleave(top_k) >= 0
+    )
+    invalid_rows = indexed[~pair_valid.to(device)]
+    assert invalid_rows.numel() > 0
+    assert torch.count_nonzero(invalid_rows) == 0
+    assert torch.count_nonzero(indexed[pair_valid.to(device)]) > 0
+
+
+def test_zero_pair_batches_return_without_launching() -> None:
+    device = torch.device("cuda")
+    topk_ids, token_lora_mapping = _routing_case(4, 2, 8, 0x1DB2)
+    empty = RouteView(
+        view=RouteViewKind.RAW,
+        block_size=16,
+        topk_ids=topk_ids[:0].to(device),
+        token_lora_mapping=token_lora_mapping[:0].to(device),
+        num_local_experts=8,
+        is_shared_outer=False,
+        max_loras=_SLOTS,
+    )
+    bridge, weight, offsets, num_slices, width = _site_tensors(
+        "down", 0, 8, 0x1DB2, device
+    )
+    destination = _destination(0, num_slices, width, device)
+    per_pair_lora_b(
+        bridge,
+        weight,
+        destination,
+        empty,
+        destination_offsets=offsets,
+        config=_PER_PAIR_CONFIG,
+    )
+
+
+def test_run_lora_b_dispatches_the_family_and_rejects_pdl() -> None:
+    device = torch.device("cuda")
+    topk_ids, token_lora_mapping = _routing_case(8, 2, 8, 0x1DB3)
+    _, raw = _views(topk_ids, token_lora_mapping, 8, device)
+    bridge, weight, offsets, num_slices, width = _site_tensors(
+        "down", 16, 8, 0x1DB3, device
+    )
+    spec = LoraBSpec(Site.DOWN, LoraBFamily.PER_PAIR)
+    with pytest.raises(ValueError, match="programmatic-dependent-launch"):
+        run_lora_b(
+            spec,
+            bridge=bridge,
+            weight=weight,
+            destination=_destination(16, num_slices, width, device),
+            routing=raw,
+            destination_offsets=offsets,
+            config=_PER_PAIR_CONFIG,
+            consume_pdl=True,
+        )
+    dispatched = _destination(16, num_slices, width, device)
+    run_lora_b(
+        spec,
+        bridge=bridge,
+        weight=weight,
+        destination=dispatched,
+        routing=raw,
+        destination_offsets=offsets,
+        config=_PER_PAIR_CONFIG,
+    )
+    direct = _destination(16, num_slices, width, device)
+    per_pair_lora_b(
+        bridge,
+        weight,
+        direct,
+        raw,
+        destination_offsets=offsets,
+        config=_PER_PAIR_CONFIG,
+    )
+    assert torch.equal(dispatched, direct)
+
+
+def test_graph_replay_recomputes_from_mutated_routing_content() -> None:
+    """The captured grid depends only on num_pairs; slot/expert routing is
+    pure data and must be honored at replay."""
+    device = torch.device("cuda")
+    num_tokens, top_k, num_experts = 16, 2, 8
+    topk_ids, token_lora_mapping = _routing_case(num_tokens, top_k, num_experts, 0x1DB4)
+    _, raw = _views(topk_ids, token_lora_mapping, num_experts, device)
+    num_pairs = num_tokens * top_k
+    bridge, weight, offsets, num_slices, width = _site_tensors(
+        "gate_up", num_pairs, num_experts, 0x1DB4, device
+    )
+    destination = torch.zeros(
+        (num_pairs, num_slices * width), dtype=torch.bfloat16, device=device
+    )
+
+    def launch():
+        per_pair_lora_b(
+            bridge,
+            weight,
+            destination,
+            raw,
+            destination_offsets=offsets,
+            config=_PER_PAIR_CONFIG,
+        )
+
+    launch()  # warm the JIT outside capture
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        launch()
+
+    new_topk_ids, new_token_lora_mapping = _routing_case(
+        num_tokens, top_k, num_experts, 0x1DB5
+    )
+    raw.topk_ids.copy_(new_topk_ids.to(device))
+    raw.token_lora_mapping.copy_(new_token_lora_mapping.to(device))
+    new_bridge = (
+        torch.randn(
+            (num_pairs, num_slices * _RANK),
+            generator=torch.Generator().manual_seed(0x1DB6),
+        )
+        * 0.2
+    ).to(torch.bfloat16)
+    bridge.copy_(new_bridge.to(device))
+    graph.replay()
+    torch.cuda.synchronize()
+    replayed = destination.clone()
+
+    expected = torch.zeros_like(destination)
+    per_pair_lora_b(
+        bridge,
+        weight,
+        expected,
+        raw,
+        destination_offsets=offsets,
+        config=_PER_PAIR_CONFIG,
+    )
+    assert torch.equal(replayed, expected)
+
+
+@pytest.mark.parametrize("top_k", (6, 1))
+def test_per_pair_on_slot_planes_matches_reference(top_k: int) -> None:
+    """A token-major bridge with one plane per adapter slot, as the dense
+    shared A writes it, expanded through per-expert B: matches the fp32
+    reference with an EP hole and a token without an adapter, invalid pairs
+    zeroed. Top-k 1 must select planes too (no top-k proxy for the layout)."""
+
+    device = torch.device("cuda")
+    num_tokens, slots, num_experts, rank, inter = 9, 3, 16, 32, 128
+    generator = torch.Generator().manual_seed(11)
+    topk_ids = torch.stack(
+        [
+            torch.randperm(num_experts, generator=generator)[:top_k]
+            for _ in range(num_tokens)
+        ]
+    ).to(torch.int32)
+    topk_ids[2, top_k - 1] = -1  # locally invalid expert (EP hole)
+    mapping = torch.randint(
+        0, slots, (num_tokens,), generator=generator, dtype=torch.int32
+    )
+    mapping[5] = -1  # no resident adapter
+    topk_ids, mapping = topk_ids.to(device), mapping.to(device)
+    per_expert = RouteView(
+        view=RouteViewKind.RAW,
+        block_size=16,
+        topk_ids=topk_ids,
+        token_lora_mapping=mapping,
+        num_local_experts=num_experts,
+        is_shared_outer=False,
+        max_loras=slots,
+    )
+    planes = (torch.randn(slots, num_tokens, 2 * rank, generator=generator) * 0.1).to(
+        device, torch.bfloat16
+    )
+    weight = (
+        torch.randn(slots * num_experts, 2 * inter, rank, generator=generator) * 0.1
+    ).to(device, torch.bfloat16)
+    num_pairs = num_tokens * top_k
+    reference = torch.zeros((num_pairs, 2 * inter), dtype=torch.float32, device=device)
+    planes_f, weight_f = planes.float(), weight.float()
+    for token in range(num_tokens):
+        slot = int(mapping[token])
+        for k in range(top_k):
+            expert = int(topk_ids[token, k])
+            if slot < 0 or expert < 0:
+                continue
+            block = weight_f[slot * num_experts + expert]
+            pair = token * top_k + k
+            reference[pair, :inter] = block[:inter] @ planes_f[slot, token, :rank]
+            reference[pair, inter:] = block[inter:] @ planes_f[slot, token, rank:]
+
+    per_pair_out = torch.full(
+        (num_pairs, 2 * inter), _POISON, device=device, dtype=torch.bfloat16
+    )
+    # The runner hands the planes over as [S, M, 2R]; the slot stride selects a plane.
+    run_lora_b(
+        LoraBSpec(Site.GATE_UP, LoraBFamily.PER_PAIR, False, BridgeLayout.TOKEN_MAJOR),
+        bridge=planes,
+        weight=weight,
+        destination=per_pair_out,
+        routing=per_expert,
+        destination_offsets=(0, inter),
+        config=_PER_PAIR_CONFIG,
+        intermediate_top_k=top_k,
+    )
+    torch.testing.assert_close(per_pair_out.float(), reference, atol=2e-2, rtol=2e-2)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/lora/test_moe_lora_plan_tables.py
+++ b/test/registered/unit/lora/test_moe_lora_plan_tables.py
@@ -1,0 +1,433 @@
+"""Check shipped plan/tile selection and reject malformed overrides."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from sglang.srt.environ import envs
+from sglang.srt.lora.moe import execution_plan as ep
+from sglang.srt.lora.moe import launch_config as lc
+from sglang.srt.lora.moe.execution_plan import (
+    ActFamily,
+    ActivationFn,
+    DeviceArchitecture,
+    DownOverlap,
+    FinalizeFamily,
+    GateUpOverlap,
+    LoraAFamily,
+    LoraBFamily,
+    Phase,
+    RouteBuilderFamily,
+    architecture_for_capability,
+    load_plans,
+    resolve_plans,
+)
+from sglang.srt.lora.moe.launch_config import MoeLoraLaunchConfig, resolve_tiles
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=5, stage="base-b", runner_config="1-gpu-large")
+
+_SWIGLU = ActivationFn.SILU
+_GB300 = DeviceArchitecture.GB300
+_H200 = DeviceArchitecture.H200
+
+
+def _clear_caches():
+    ep.load_plans.cache_clear()
+    lc._load_tiles.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _fresh_caches():
+    _clear_caches()
+    yield
+    _clear_caches()
+
+
+def _resolve(
+    architecture=_GB300,
+    layout=False,
+    rank=16,
+    act=_SWIGLU,
+    hidden=4096,
+    experts=256,
+):
+    return resolve_plans(
+        architecture=architecture,
+        is_shared_outer=layout,
+        physical_rank=rank,
+        activation=act,
+        hidden_size=hidden,
+        num_local_experts=experts,
+    )
+
+
+class TestSm100PerExpert:
+    def test_decode_ships_per_pair_b_grouped_a_wide_windows(self):
+        c = _resolve(rank=32, experts=512)[Phase.DECODE]
+        assert c.base_gemm_rows == "expert_major"
+        assert c.plan.gate_up_a.family is LoraAFamily.GROUPED
+        assert c.plan.gate_up_b.family is LoraBFamily.PER_PAIR
+        assert c.plan.down_a.family is LoraAFamily.GROUPED
+        assert c.plan.down_b.family is LoraBFamily.PER_PAIR
+        assert c.plan.act.family is ActFamily.MATERIALIZED
+        assert c.plan.finalize.family is FinalizeFamily.MATERIALIZED
+        assert c.plan.gate_up_overlap is GateUpOverlap.GATE_UP_A_B
+        assert c.plan.down_overlap is DownOverlap.DOWN_A_B
+        assert c.plan.route_builder is RouteBuilderFamily.STANDARD
+
+    def test_prefill_ships_serial_route_major_b_activation(self):
+        c = _resolve()[Phase.PREFILL]
+        assert c.base_gemm_rows == "route_major"
+        assert c.plan.act.family is ActFamily.B_ACTIVATION
+        assert c.plan.gate_up_b is None  # the b_activation kernel does this work
+        assert c.plan.down_b_into_base
+        assert c.plan.gate_up_overlap is GateUpOverlap.NONE
+        assert c.plan.down_overlap is DownOverlap.NONE
+
+    def test_decode_tile_ladder_is_rank_then_token_bucketed(self):
+        # gate_up_b BLOCK_SIZE_N names the tile set the table chose. The rank
+        # rules come first in the ladder, then the token rules.
+        def block_n(rank: int, tokens: int) -> int:
+            table = resolve_tiles(
+                architecture_value="gb300",
+                plan_key_name="decode.per_expert",
+                physical_rank=rank,
+            )
+            return table.config_for(tokens).gate_up_b["BLOCK_SIZE_N"]
+
+        assert block_n(16, 4) == 128
+        assert block_n(16, 4096) == 128
+        assert [block_n(32, m) for m in (4, 16, 32, 33, 128, 4096)] == [
+            128,
+            512,
+            512,
+            512,
+            512,
+            512,
+        ]
+        assert [block_n(64, m) for m in (4, 16, 17)] == [128, 512, 256]
+
+    def test_unknown_row_serves_the_default_launch_config(self):
+        table = resolve_tiles(
+            architecture_value="gb300",
+            plan_key_name="no.such.row",
+            physical_rank=16,
+        )
+        assert table.config_for(4) == MoeLoraLaunchConfig()
+
+
+class TestSm100Shared:
+    def test_decode_ships_wide_window_materialized_joint(self):
+        c = _resolve(layout=True, rank=32)[Phase.DECODE]
+        assert c.base_gemm_rows == "expert_major"
+        assert c.plan.gate_up_overlap is GateUpOverlap.GATE_UP_A_B
+        assert c.plan.down_overlap is DownOverlap.DOWN_A_B
+        assert c.plan.act.family is ActFamily.MATERIALIZED
+        assert c.plan.finalize.family is FinalizeFamily.MATERIALIZED
+        assert c.plan.gate_up_b.family is LoraBFamily.GROUPED
+        assert c.plan.down_b.family is LoraBFamily.GROUPED
+        assert c.plan.route_builder is RouteBuilderFamily.PARALLEL_SHARED_OUTER
+
+    def test_prefill_ships_token_grouped_serial(self):
+        c = _resolve(layout=True, rank=32)[Phase.PREFILL]
+        assert c.base_gemm_rows == "route_major"
+        assert c.plan.gate_up_a.family is LoraAFamily.TOKEN_GROUPED
+        assert c.plan.act.family is ActFamily.B_ACTIVATION
+        assert c.plan.route_builder is RouteBuilderFamily.PARALLEL_SHARED_OUTER
+        assert c.plan.gate_up_overlap is GateUpOverlap.NONE
+        assert c.plan.down_overlap is DownOverlap.NONE
+
+
+class TestH200:
+    def test_decode_ships_indexed_down_a_at_every_rank(self):
+        # On a real model, the indexed down-A row was faster than the retired
+        # step10 pdl_down split.
+        for rank in (8, 32, 320):
+            c = _resolve(architecture=_H200, rank=rank)[Phase.DECODE]
+            assert c.plan.down_a.family is LoraAFamily.PER_PAIR
+            assert c.base_gemm_rows == "expert_major"
+
+    def test_shared_prefill_rank_band(self):
+        # A rank-128 run on the Inkling model set the top of this rank band.
+        small = _resolve(architecture=_H200, layout=True, rank=8)[Phase.PREFILL]
+        assert small.name == "prefill.shared.rank_le8"
+        assert small.plan.finalize.family is FinalizeFamily.MATERIALIZED
+        fused = _resolve(architecture=_H200, layout=True, rank=64)[Phase.PREFILL]
+        assert fused.name == "prefill.shared.rank_le64"
+        assert fused.plan.finalize.family is FinalizeFamily.SHARED_RANK_REDUCE
+        assert fused.plan.route_builder is RouteBuilderFamily.STANDARD
+        wide = _resolve(architecture=_H200, layout=True, rank=128)[Phase.PREFILL]
+        assert wide.name == "prefill.shared"
+        assert wide.plan.finalize.family is FinalizeFamily.MATERIALIZED
+
+
+class TestResolution:
+    def test_activation_does_not_select_a_row_but_is_injected(self):
+        for architecture in (_GB300, _H200):
+            for layout in (False, True):
+                swiglu = _resolve(architecture=architecture, layout=layout)
+                relu2 = _resolve(
+                    architecture=architecture, layout=layout, act=ActivationFn.RELU2
+                )
+                assert {p: s.name for p, s in relu2.items()} == {
+                    p: s.name for p, s in swiglu.items()
+                }
+                for phase, sel in relu2.items():
+                    assert sel.plan.act.activation is ActivationFn.RELU2
+                    assert swiglu[phase].plan.act.activation is ActivationFn.SILU
+
+    def test_out_of_domain_serves_the_tuned_table_fallback(self):
+        # A geometry outside the domain still runs on tuned silicon, so the
+        # table's own fallback keeps the decode overlap the sweep measured.
+        # Only the untuned DEFAULT table stays serial.
+        selected = _resolve(hidden=8192, experts=1024)
+        decode = selected[Phase.DECODE]
+        assert decode.name == "fallback.decode"
+        assert decode.base_gemm_rows == "expert_major"
+        assert decode.plan.gate_up_overlap is GateUpOverlap.GATE_UP_A_B
+        assert decode.plan.down_overlap is DownOverlap.DOWN_A_B
+        assert selected[Phase.PREFILL].name == "fallback.prefill.per_expert"
+
+    def test_default_table_fallback_stays_serial(self):
+        # Unknown silicon gets the conservative plan: no overlap window is
+        # claimed on hardware nothing was ever measured on.
+        decode = _resolve(architecture=DeviceArchitecture.DEFAULT)[Phase.DECODE]
+        assert decode.plan.gate_up_overlap is GateUpOverlap.NONE
+        assert decode.plan.down_overlap is DownOverlap.NONE
+
+    def test_unknown_architecture_serves_the_default_table(self):
+        assert architecture_for_capability(8, 0) is DeviceArchitecture.DEFAULT
+        assert architecture_for_capability(9, 0) is _H200
+        assert architecture_for_capability(10, 3) is _GB300
+        table = load_plans(DeviceArchitecture.DEFAULT)
+        assert table.scenarios == []
+        selected = _resolve(architecture=DeviceArchitecture.DEFAULT)
+        assert selected[Phase.DECODE].name == "fallback.decode"
+        assert selected[Phase.PREFILL].name == "fallback.prefill.per_expert"
+
+    def test_every_resolvable_plan_is_a_declared_row(self):
+        # The test reads the raw table. A shared helper repeats the filter,
+        # so the test misses a filter bug.
+        for architecture in (_GB300, _H200):
+            for layout in (False, True):
+                table = load_plans(architecture)
+                layout_name = "shared" if layout else "per_expert"
+                declared = {
+                    row.name
+                    for row in (*table.scenarios, *table.fallback)
+                    if row.layout in (None, layout_name)
+                }
+                for rank in (8, 16, 64, 320):
+                    for hidden in (4096, 8192):
+                        for sel in _resolve(
+                            architecture=architecture,
+                            layout=layout,
+                            rank=rank,
+                            hidden=hidden,
+                            experts=512,
+                        ).values():
+                            assert sel.name in declared, (sel.name, declared)
+
+    def test_row_names_state_their_own_selection_criteria(self):
+        # A row named after its plan contents goes stale the moment a sweep
+        # rewrites those contents, and nothing fails. "fallback.serial" kept
+        # its name after the decode fallback gained both overlap windows, and
+        # "prefill.serial" kept its after every prefill row became serial, so
+        # the word stopped distinguishing anything. Naming a row for what
+        # selects it - phase, layout, rank bound - cannot drift from the plan,
+        # because the plan is not what the name describes.
+        for architecture in (_GB300, _H200, DeviceArchitecture.DEFAULT):
+            table = load_plans(architecture)
+            for section, is_fallback in (
+                (table.scenarios, False),
+                (table.fallback, True),
+            ):
+                for row in section:
+                    parts = ["fallback"] if is_fallback else []
+                    parts.append(row.phase.value if row.phase else "any_phase")
+                    if row.layout:
+                        parts.append(row.layout)
+                    if row.max_rank is not None:
+                        parts.append(f"rank_le{row.max_rank}")
+                    assert row.name == ".".join(parts), (
+                        architecture.value,
+                        row.name,
+                    )
+
+    def test_row_names_are_unique_within_a_table(self):
+        # The name is the tiles lookup key (resolve_tiles(plan_key_name=...)),
+        # so two rows sharing one name silently share one set of tuned tiles.
+        # Two rows did: the per-expert/route_major and shared/expert_major
+        # prefill fallbacks were both "fallback.serial_prefill".
+        for architecture in (_GB300, _H200, DeviceArchitecture.DEFAULT):
+            table = load_plans(architecture)
+            names = [row.name for row in (*table.scenarios, *table.fallback)]
+            assert len(names) == len(set(names)), (architecture.value, names)
+
+    def test_tile_rule_keys_and_plan_rows_match(self):
+        # resolve_tiles returns the built-in defaults when a key is missing,
+        # so a renamed plan row loses its tuned tiles and raises no error, and
+        # a new plan row without a rule runs the defaults under a name that
+        # looks tuned. Only the speed drops, in silence, either way.
+        for architecture in (_GB300, _H200, DeviceArchitecture.DEFAULT):
+            plans = load_plans(architecture)
+            tiles = lc._load_tiles(architecture.value)
+            if tiles is None:
+                continue
+            declared = {row.name for row in (*plans.scenarios, *plans.fallback)}
+            orphans = sorted(set(tiles.rules) - declared)
+            assert not orphans, (architecture.value, orphans)
+            missing = sorted(declared - set(tiles.rules))
+            assert not missing, (architecture.value, missing)
+
+    def test_tile_rules_carry_only_the_shared_finalize_their_row_selects(self):
+        # A section on a row whose finalize never reads it is dead weight; a
+        # missing one silently serves the built-in default tile under a row
+        # that looks tuned.
+        for architecture in DeviceArchitecture:
+            tiles = lc._load_tiles(architecture.value)
+            if tiles is None:
+                continue
+            table = load_plans(architecture)
+            family = {
+                row.name: row.plan.finalize_family
+                for row in (*table.scenarios, *table.fallback)
+            }
+            for name, rules in tiles.rules.items():
+                expected = (
+                    {"shared_finalize"}
+                    if family[name] is FinalizeFamily.SHARED_RANK_REDUCE
+                    else set()
+                )
+                for rule in rules:
+                    present = set(rule.sites) & {"shared_finalize"}
+                    assert present == expected, (architecture.value, name, present)
+
+    def test_unknown_domain_key_fails_closed(self, tmp_path):
+        # The loader once read the domain with .get(key, 1 << 30). A typo in
+        # a bound then let tuned rows serve a geometry nobody measured.
+        packaged = json.load(open(f"{ep._CONFIG_DIR}/gb300.plans.json"))
+        json.dump(packaged, open(tmp_path / "gb300.plans.json", "w"))
+        with envs.SGLANG_LORA_MOE_CONFIG_DIR.override(str(tmp_path)):
+            _clear_caches()
+            beyond = _resolve(hidden=packaged["domain"]["max_hidden"] * 2)
+            assert beyond[Phase.DECODE].name == "fallback.decode"
+
+            _clear_caches()
+            typo = json.loads(json.dumps(packaged))
+            typo["domain"]["max_hidden_size"] = typo["domain"].pop("max_hidden")
+            json.dump(typo, open(tmp_path / "gb300.plans.json", "w"))
+            with pytest.raises(ValueError):
+                _resolve()
+
+    def test_override_dir_wins(self, tmp_path):
+        packaged = json.load(open(f"{ep._CONFIG_DIR}/gb300.tiles.json"))
+        packaged["rules"]["decode.per_expert"][0]["sites"]["gate_up_a"]["num_warps"] = 8
+        json.dump(packaged, open(tmp_path / "gb300.tiles.json", "w"))
+
+        def _tiny():
+            return resolve_tiles(
+                architecture_value="gb300",
+                plan_key_name="decode.per_expert",
+                physical_rank=16,
+            ).config_for(4)
+
+        with envs.SGLANG_LORA_MOE_CONFIG_DIR.override(str(tmp_path)):
+            _clear_caches()
+            assert _tiny().gate_up_a["num_warps"] == 8
+        _clear_caches()
+        assert _tiny().gate_up_a["num_warps"] != 8
+
+    def test_malformed_plan_family_fails_closed(self, tmp_path):
+        packaged = json.load(open(f"{ep._CONFIG_DIR}/gb300.plans.json"))
+        packaged["scenarios"][0]["plan"]["gate_up_b_family"] = "no_such_kernel"
+        json.dump(packaged, open(tmp_path / "gb300.plans.json", "w"))
+        with envs.SGLANG_LORA_MOE_CONFIG_DIR.override(str(tmp_path)):
+            _clear_caches()
+            with pytest.raises(ValueError):
+                _resolve()
+
+    def test_unknown_plan_field_fails_closed(self, tmp_path):
+        # An old file can hold a retired "when" key. The loader must stop
+        # with an error, because an ignored key changes which rows match.
+        packaged = json.load(open(f"{ep._CONFIG_DIR}/gb300.plans.json"))
+        packaged["scenarios"][0]["when"] = {"activation": "swiglu"}
+        json.dump(packaged, open(tmp_path / "gb300.plans.json", "w"))
+        with envs.SGLANG_LORA_MOE_CONFIG_DIR.override(str(tmp_path)):
+            _clear_caches()
+            with pytest.raises(ValueError):
+                _resolve()
+
+    def test_unknown_row_keys_are_rejected(self, tmp_path):
+        # A table with a misspelled key is a config error, not a silent skip.
+        packaged = json.load(open(f"{ep._CONFIG_DIR}/h200.plans.json"))
+        packaged["scenarios"][0]["provenence"] = "typo"
+        json.dump(packaged, open(tmp_path / "h200.plans.json", "w"))
+        with envs.SGLANG_LORA_MOE_CONFIG_DIR.override(str(tmp_path)):
+            _clear_caches()
+            with pytest.raises(ValueError, match="provenence"):
+                _resolve(architecture=_H200, layout=True, rank=64)
+
+    def test_unknown_tile_field_fails_closed(self, tmp_path):
+        packaged = json.load(open(f"{ep._CONFIG_DIR}/gb300.tiles.json"))
+        packaged["rules"]["decode.per_expert"][0]["min_tokens"] = 1
+        json.dump(packaged, open(tmp_path / "gb300.tiles.json", "w"))
+        with envs.SGLANG_LORA_MOE_CONFIG_DIR.override(str(tmp_path)):
+            _clear_caches()
+            with pytest.raises(ValueError):
+                resolve_tiles(
+                    architecture_value="gb300",
+                    plan_key_name="decode.per_expert",
+                    physical_rank=16,
+                )
+
+    def test_unknown_tile_site_key_fails_closed(self, tmp_path):
+        # The rule-level extra="forbid" does not reach inside "sites". The
+        # launch-config class must reject an unknown key on its own.
+        packaged = json.load(open(f"{ep._CONFIG_DIR}/gb300.tiles.json"))
+        rule = packaged["rules"]["decode.per_expert"][0]
+        rule["sites"]["gate_up_bee"] = rule["sites"].pop("gate_up_b")
+        json.dump(packaged, open(tmp_path / "gb300.tiles.json", "w"))
+        with envs.SGLANG_LORA_MOE_CONFIG_DIR.override(str(tmp_path)):
+            _clear_caches()
+            with pytest.raises(ValueError, match="gate_up_bee"):
+                resolve_tiles(
+                    architecture_value="gb300",
+                    plan_key_name="decode.per_expert",
+                    physical_rank=16,
+                )
+
+
+class TestLoraMoeRunnerBackend:
+    def test_lora_backend_is_distinct_from_deep_gemm(self):
+        # One place treats the two backends alike. That place is the resident
+        # weight preparation, and it names both (FusedMoE.__init__).
+        from sglang.srt.layers.moe.utils import MoeRunnerBackend
+
+        assert MoeRunnerBackend.LORA.is_lora()
+        assert not MoeRunnerBackend.LORA.is_deep_gemm()
+        assert not MoeRunnerBackend.DEEP_GEMM.is_lora()
+        assert not MoeRunnerBackend.TRITON.is_lora()
+
+    def test_lora_backend_gets_deep_gemm_resident_weight_prep(self):
+        # LoRA providers require resident [E, N, K] weights.
+        import inspect
+
+        from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
+
+        src = inspect.getsource(FusedMoE.__init__)
+        assert "use_deep_gemm" in src and "is_lora()" in src
+
+    def test_backend_value_is_a_valid_cli_choice(self):
+        from sglang.srt.layers.moe.utils import MoeRunnerBackend
+        from sglang.srt.server_args import MOE_RUNNER_BACKEND_CHOICES
+
+        assert MoeRunnerBackend.LORA.value == "lora"
+        assert "lora" in MOE_RUNNER_BACKEND_CHOICES
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/lora/test_moe_lora_plan_tables.py
+++ b/test/registered/unit/lora/test_moe_lora_plan_tables.py
@@ -55,6 +55,7 @@ def _resolve(
     experts=256,
 ):
     return resolve_plans(
+        quant_family="bf16",
         architecture=architecture,
         is_shared_outer=layout,
         physical_rank=rank,
@@ -120,15 +121,16 @@ class TestSm100PerExpert:
 
 
 class TestSm100Shared:
-    def test_decode_ships_wide_window_materialized_joint(self):
+    def test_decode_ships_one_pass_with_the_down_a_window(self):
+        # The one-pass finalize owns down-B, so only down-A is left to overlap.
         c = _resolve(layout=True, rank=32)[Phase.DECODE]
         assert c.base_gemm_rows == "expert_major"
         assert c.plan.gate_up_overlap is GateUpOverlap.GATE_UP_A_B
-        assert c.plan.down_overlap is DownOverlap.DOWN_A_B
+        assert c.plan.down_overlap is DownOverlap.DOWN_A
         assert c.plan.act.family is ActFamily.MATERIALIZED
-        assert c.plan.finalize.family is FinalizeFamily.MATERIALIZED
+        assert c.plan.finalize.family is FinalizeFamily.SHARED_ONE_PASS
         assert c.plan.gate_up_b.family is LoraBFamily.GROUPED
-        assert c.plan.down_b.family is LoraBFamily.GROUPED
+        assert c.plan.down_b is None
         assert c.plan.route_builder is RouteBuilderFamily.PARALLEL_SHARED_OUTER
 
     def test_prefill_ships_token_grouped_serial(self):
@@ -151,17 +153,19 @@ class TestH200:
             assert c.base_gemm_rows == "expert_major"
 
     def test_shared_prefill_rank_band(self):
-        # A rank-128 run on the Inkling model set the top of this rank band.
+        # The bands differ in their A kernels and overlap windows; every band
+        # finalizes through shared_token_delta (measured at ranks 8 to 128).
         small = _resolve(architecture=_H200, layout=True, rank=8)[Phase.PREFILL]
         assert small.name == "prefill.shared.rank_le8"
-        assert small.plan.finalize.family is FinalizeFamily.MATERIALIZED
+        assert small.plan.finalize.family is FinalizeFamily.SHARED_TOKEN_DELTA
         fused = _resolve(architecture=_H200, layout=True, rank=64)[Phase.PREFILL]
         assert fused.name == "prefill.shared.rank_le64"
-        assert fused.plan.finalize.family is FinalizeFamily.SHARED_RANK_REDUCE
+        assert fused.plan.finalize.family is FinalizeFamily.SHARED_TOKEN_DELTA
         assert fused.plan.route_builder is RouteBuilderFamily.STANDARD
         wide = _resolve(architecture=_H200, layout=True, rank=128)[Phase.PREFILL]
         assert wide.name == "prefill.shared"
-        assert wide.plan.finalize.family is FinalizeFamily.MATERIALIZED
+        assert wide.plan.finalize.family is FinalizeFamily.SHARED_TOKEN_DELTA
+        assert wide.plan.down_b is None
 
 
 class TestResolution:
@@ -172,8 +176,8 @@ class TestResolution:
                 relu2 = _resolve(
                     architecture=architecture, layout=layout, act=ActivationFn.RELU2
                 )
-                assert {p: s.name for p, s in relu2.items()} == {
-                    p: s.name for p, s in swiglu.items()
+                assert {p: sel.name for p, sel in relu2.items()} == {
+                    p: sel.name for p, sel in swiglu.items()
                 }
                 for phase, sel in relu2.items():
                     assert sel.plan.act.activation is ActivationFn.RELU2
@@ -252,6 +256,12 @@ class TestResolution:
                         parts.append(row.layout)
                     if row.max_rank is not None:
                         parts.append(f"rank_le{row.max_rank}")
+                    if row.quant is not None:
+                        parts.append("_".join(row.quant))
+                    if row.min_local_experts is not None:
+                        parts.append(f"e_ge{row.min_local_experts}")
+                    if row.max_local_experts is not None:
+                        parts.append(f"e_le{row.max_local_experts}")
                     assert row.name == ".".join(parts), (
                         architecture.value,
                         row.name,
@@ -284,9 +294,13 @@ class TestResolution:
             assert not missing, (architecture.value, missing)
 
     def test_tile_rules_carry_only_the_shared_finalize_their_row_selects(self):
-        # A section on a row whose finalize never reads it is dead weight; a
-        # missing one silently serves the built-in default tile under a row
-        # that looks tuned.
+        # A row's shared finalize reads its own section. A section for the
+        # other family would be dead weight; a missing one silently serves
+        # the built-in default tile under a row that looks tuned.
+        section = {
+            FinalizeFamily.SHARED_TOKEN_DELTA: "shared_token_delta",
+            FinalizeFamily.SHARED_ONE_PASS: "shared_one_pass",
+        }
         for architecture in DeviceArchitecture:
             tiles = lc._load_tiles(architecture.value)
             if tiles is None:
@@ -297,13 +311,9 @@ class TestResolution:
                 for row in (*table.scenarios, *table.fallback)
             }
             for name, rules in tiles.rules.items():
-                expected = (
-                    {"shared_finalize"}
-                    if family[name] is FinalizeFamily.SHARED_RANK_REDUCE
-                    else set()
-                )
+                expected = {section[family[name]]} if family[name] in section else set()
                 for rule in rules:
-                    present = set(rule.sites) & {"shared_finalize"}
+                    present = set(rule.sites) & set(section.values())
                     assert present == expected, (architecture.value, name, present)
 
     def test_unknown_domain_key_fails_closed(self, tmp_path):
@@ -402,13 +412,20 @@ class TestResolution:
 
 
 class TestLoraMoeRunnerBackend:
-    def test_lora_backend_is_distinct_from_deep_gemm(self):
-        # One place treats the two backends alike. That place is the resident
-        # weight preparation, and it names both (FusedMoE.__init__).
+    def test_lora_backend_predicates_are_exclusive(self):
+        # LoRA vendors must not enter the plain vendor dispatch paths.
         from sglang.srt.layers.moe.utils import MoeRunnerBackend
 
-        assert MoeRunnerBackend.LORA.is_lora()
-        assert not MoeRunnerBackend.LORA.is_deep_gemm()
+        for backend in (
+            MoeRunnerBackend.LORA_CUTEDSL,
+            MoeRunnerBackend.LORA_TRITON,
+            MoeRunnerBackend.LORA_MARLIN,
+        ):
+            assert backend.is_lora()
+        assert not MoeRunnerBackend.LORA_TRITON.is_triton()
+        assert not MoeRunnerBackend.LORA_MARLIN.is_marlin()
+        assert MoeRunnerBackend.LORA_MARLIN.is_lora_marlin()
+        assert not MoeRunnerBackend.MARLIN.is_lora_marlin()
         assert not MoeRunnerBackend.DEEP_GEMM.is_lora()
         assert not MoeRunnerBackend.TRITON.is_lora()
 
@@ -421,12 +438,16 @@ class TestLoraMoeRunnerBackend:
         src = inspect.getsource(FusedMoE.__init__)
         assert "use_deep_gemm" in src and "is_lora()" in src
 
-    def test_backend_value_is_a_valid_cli_choice(self):
+    def test_backend_values_are_valid_cli_choices(self):
         from sglang.srt.layers.moe.utils import MoeRunnerBackend
         from sglang.srt.server_args import MOE_RUNNER_BACKEND_CHOICES
 
-        assert MoeRunnerBackend.LORA.value == "lora"
-        assert "lora" in MOE_RUNNER_BACKEND_CHOICES
+        for backend in (
+            MoeRunnerBackend.LORA_CUTEDSL,
+            MoeRunnerBackend.LORA_TRITON,
+            MoeRunnerBackend.LORA_MARLIN,
+        ):
+            assert backend.value in MOE_RUNNER_BACKEND_CHOICES
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/lora/test_moe_lora_prefill_graph_contract.py
+++ b/test/registered/unit/lora/test_moe_lora_prefill_graph_contract.py
@@ -1,0 +1,280 @@
+"""Hermetic contracts for MoE LoRA prefill CUDA-graph metadata.
+
+The production modules pull in the full scheduler, Triton, and CUDA import
+graph.  These tests compile the exact small method bodies under test from the
+source tree and provide only their narrow CPU dependencies.
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+_LORA_RUNNER = SimpleNamespace(is_lora=lambda: True)
+_OTHER_RUNNER = SimpleNamespace(is_lora=lambda: False)
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+LORA_MANAGER_PATH = REPO_ROOT / "python/sglang/srt/lora/lora_manager.py"
+BASE_BACKEND_PATH = REPO_ROOT / "python/sglang/srt/lora/backend/base_backend.py"
+
+
+def _load_class_with_members(
+    path: Path,
+    source_class: str,
+    *member_names: str,
+    namespace: dict[str, object] | None = None,
+):
+    tree = ast.parse(path.read_text())
+    class_node = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == source_class
+    )
+    members = [
+        node
+        for node in class_node.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name in member_names
+    ]
+    assert {node.name for node in members} == set(member_names)
+    test_class = ast.ClassDef(
+        name=f"_{source_class}UnderTest",
+        bases=[],
+        keywords=[],
+        body=members,
+        decorator_list=[],
+    )
+    scope = dict(namespace or {})
+    exec(
+        compile(
+            ast.fix_missing_locations(ast.Module(body=[test_class], type_ignores=[])),
+            str(path),
+            "exec",
+        ),
+        scope,
+    )
+    return scope[test_class.name]
+
+
+def _load_function(
+    path: Path,
+    function_name: str,
+    *,
+    namespace: dict[str, object] | None = None,
+):
+    tree = ast.parse(path.read_text())
+    function = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == function_name
+    )
+    scope = dict(namespace or {})
+    exec(
+        compile(
+            ast.fix_missing_locations(ast.Module(body=[function], type_ignores=[])),
+            str(path),
+            "exec",
+        ),
+        scope,
+    )
+    return scope[function_name]
+
+
+def test_moe_lora_is_the_only_moe_engine_eligible_for_prefill_graph() -> None:
+    manager_type = _load_class_with_members(
+        LORA_MANAGER_PATH,
+        "LoRAManager",
+        "supports_prefill_cuda_graph",
+    )
+    manager = manager_type()
+    manager.lora_backend = SimpleNamespace(
+        supports_prefill_cuda_graph=True,
+        is_moe_lora=True,
+    )
+    manager.enable_dp_attention = False
+    manager.prefill_cuda_graph_backend = "breakable"
+
+    manager.moe_lora_runner_backend = _LORA_RUNNER
+    assert manager.supports_prefill_cuda_graph
+
+    manager.moe_lora_runner_backend = _OTHER_RUNNER
+    assert not manager.supports_prefill_cuda_graph
+
+    manager.moe_lora_runner_backend = _LORA_RUNNER
+    manager.enable_dp_attention = True
+    assert not manager.supports_prefill_cuda_graph
+
+    manager.enable_dp_attention = False
+    manager.lora_backend.supports_prefill_cuda_graph = False
+    assert not manager.supports_prefill_cuda_graph
+
+    manager.lora_backend.supports_prefill_cuda_graph = True
+    # Only "breakable" hosts LoRA prefill graphs: "full" is decode-only and
+    # tc_piecewise breaks Dynamo guards on per-batch LoRABatchInfo rebinds.
+    for backend in ("tc_piecewise", "full", "disabled", None):
+        manager.prefill_cuda_graph_backend = backend
+        assert not manager.supports_prefill_cuda_graph
+
+    manager.prefill_cuda_graph_backend = "breakable"
+    assert manager.supports_prefill_cuda_graph
+
+
+def test_prefill_and_decode_graphs_have_independent_mapping_capacities() -> None:
+    backend_type = _load_class_with_members(
+        BASE_BACKEND_PATH,
+        "BaseLoRABackend",
+        "init_cuda_graph_moe_buffers",
+        "init_prefill_cuda_graph_moe_buffers",
+        namespace={"torch": torch},
+    )
+    backend = backend_type()
+    backend.max_loras_per_batch = 4
+    backend.device = torch.device("cpu")
+    backend.is_moe_lora = True
+    moe_layer = SimpleNamespace(
+        base_layer=SimpleNamespace(w13_weight=torch.empty(1)),
+    )
+
+    backend.init_cuda_graph_moe_buffers(
+        max_bs=3,
+        max_loras=4,
+        compute_dtype=torch.float32,
+        moe_layer=moe_layer,
+        include_legacy_kernel_buffers=False,
+    )
+    backend.init_prefill_cuda_graph_moe_buffers(max_num_tokens=37)
+
+    decode_mapping = backend.moe_cg_buffers["token_lora_mapping"]
+    prefill_mapping = backend.prefill_moe_cg_buffers["token_lora_mapping"]
+    assert decode_mapping.shape == (3,)
+    assert prefill_mapping.shape == (37,)
+    assert decode_mapping.data_ptr() != prefill_mapping.data_ptr()
+    assert torch.all(decode_mapping == -1)
+    assert torch.all(prefill_mapping == -1)
+
+
+@dataclass
+class _MoeInfo:
+    seg_indptr: torch.Tensor
+    req_to_lora: torch.Tensor
+    adapter_enabled: torch.Tensor
+    token_lora_mapping: torch.Tensor
+
+
+def test_graph_metadata_selects_prefill_buffer_by_batch_identity() -> None:
+    selected_buffers: list[torch.Tensor] = []
+
+    def _capture_compute(
+        _num_tokens,
+        _seg_indptr,
+        _lora_ranks,
+        _weight_indices,
+        adapter_enabled,
+        token_lora_mapping,
+        *,
+        max_len,
+    ):
+        del max_len
+        selected_buffers.append(token_lora_mapping)
+        return adapter_enabled, token_lora_mapping
+
+    backend_type = _load_class_with_members(
+        BASE_BACKEND_PATH,
+        "BaseLoRABackend",
+        "_add_moe_lora_info",
+        namespace={
+            "ForwardBatch": object,
+            "LoRABatchInfo": object,
+            "MoELoRABatchInfo": _MoeInfo,
+            "_compute_moe_lora_info": _capture_compute,
+            "get_batch_token_counts": lambda fb: (
+                (fb.extend_num_tokens, max(fb.extend_seq_lens_cpu))
+                if fb.forward_mode.is_extend()
+                else (fb.batch_size, 1)
+            ),
+        },
+    )
+    backend = backend_type()
+    backend.is_moe_lora = True
+    backend.moe_cg_buffers = {
+        "adapter_enabled": torch.zeros(2, dtype=torch.int32),
+        "token_lora_mapping": torch.full((2,), -1, dtype=torch.int32),
+    }
+    backend.prefill_moe_cg_buffers = {
+        "adapter_enabled": torch.zeros(2, dtype=torch.int32),
+        "token_lora_mapping": torch.full((8,), -1, dtype=torch.int32),
+    }
+    prefill_batch = SimpleNamespace(
+        use_cuda_graph=True,
+        bs=2,
+        num_segments=2,
+        seg_indptr=torch.tensor([0, 2, 5], dtype=torch.int32),
+        weight_indices=torch.tensor([0, 1], dtype=torch.int32),
+        lora_ranks=torch.tensor([16, 16], dtype=torch.int32),
+        req_seg_indptr=None,
+        req_weight_indices=None,
+    )
+    backend.prefill_cuda_graph_batch_info = prefill_batch
+    extend_mode = SimpleNamespace(
+        is_extend=lambda: True,
+        is_decode=lambda: False,
+        is_target_verify=lambda: False,
+    )
+    forward_batch = SimpleNamespace(
+        forward_mode=extend_mode,
+        extend_seq_lens_cpu=[2, 3],
+        extend_num_tokens=5,
+        batch_size=2,
+    )
+
+    backend._add_moe_lora_info(forward_batch, prefill_batch)
+    assert selected_buffers[-1] is backend.prefill_moe_cg_buffers["token_lora_mapping"]
+
+    decode_batch = SimpleNamespace(**vars(prefill_batch))
+    backend._add_moe_lora_info(forward_batch, decode_batch)
+    assert selected_buffers[-1] is backend.moe_cg_buffers["token_lora_mapping"]
+
+
+def test_smaller_replay_resets_unused_mapping_tail() -> None:
+    compute = _load_function(
+        BASE_BACKEND_PATH,
+        "_compute_moe_lora_info",
+        namespace={
+            "torch": torch,
+            # The CPU path does not invoke either dependency, but names remain
+            # present so an accidental branch change fails clearly.
+            "triton": SimpleNamespace(),
+            "_compute_moe_lora_info_kernel": None,
+        },
+    )
+    stable_mapping = torch.full((8,), 7, dtype=torch.int32)
+    adapter_enabled = torch.ones(2, dtype=torch.int32)
+
+    enabled, current_mapping = compute(
+        3,
+        torch.tensor([0, 3], dtype=torch.int32),
+        torch.tensor([16, 0], dtype=torch.int32),
+        torch.tensor([0], dtype=torch.int32),
+        adapter_enabled,
+        stable_mapping,
+        max_len=3,
+    )
+
+    assert current_mapping.data_ptr() == stable_mapping.data_ptr()
+    assert current_mapping.tolist() == [0, 0, 0]
+    assert stable_mapping[3:].tolist() == [-1, -1, -1, -1, -1]
+    assert enabled.tolist() == [1, 0]
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/lora/test_moe_lora_route_scratch.py
+++ b/test/registered/unit/lora/test_moe_lora_route_scratch.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+pytest.importorskip("triton")
+
+from sglang.srt.lora.moe.routing import (  # noqa: E402
+    _build_aligned,
+    _plan_scratch,
+)
+from sglang.srt.lora.moe.workspace import MoeLoraWorkspace  # noqa: E402
+from sglang.test.ci.ci_register import register_cuda_ci  # noqa: E402
+
+register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-large")
+
+
+def test_route_counts_are_initialized_only_on_first_allocation() -> None:
+    """Reusing count storage must not hide a missing scan-side reset."""
+    workspace = MoeLoraWorkspace()
+    first = _plan_scratch(
+        workspace,
+        prefix="route:test",
+        num_buckets=7,
+        capacity=32,
+        block_size=8,
+        device=torch.device("cpu"),
+    )
+    assert first["counts"].tolist() == [0] * 7
+
+    first["counts"].fill_(9)
+    second = _plan_scratch(
+        workspace,
+        prefix="route:test",
+        num_buckets=7,
+        capacity=32,
+        block_size=8,
+        device=torch.device("cpu"),
+    )
+
+    assert second["counts"].data_ptr() == first["counts"].data_ptr()
+    assert second["counts"].tolist() == [9] * 7
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA route kernel required")
+def test_route_scan_restores_both_count_buffers_between_calls() -> None:
+    device = torch.device("cuda")
+    workspace = MoeLoraWorkspace()
+    num_local_experts = 3
+    max_loras = 2
+    block_size = 8
+    topk_ids = torch.tensor(
+        [[0, 1], [2, 0], [1, 2], [0, 2], [2, 1], [1, 0]],
+        dtype=torch.int32,
+        device=device,
+    )
+
+    traffic = (
+        torch.tensor([0, 1, -1, 0, 1, -1], dtype=torch.int32, device=device),
+        torch.tensor([1, -1, 0, 1, -1, 0], dtype=torch.int32, device=device),
+    )
+    for token_lora_mapping in traffic:
+        for is_shared_outer in (False, True):
+            _build_aligned(
+                topk_ids,
+                token_lora_mapping,
+                num_local_experts=num_local_experts,
+                max_loras=max_loras,
+                block_size=block_size,
+                workspace=workspace,
+                tensor_prefix="route:aligned",
+                is_shared_outer=is_shared_outer,
+            )
+
+        per_expert_counts = workspace.tensor(
+            "route:aligned:per_expert:counts",
+            (num_local_experts * max_loras + 1,),
+            dtype=torch.int32,
+            device=device,
+            zero_on_first_allocation=True,
+        )
+        shared_counts = workspace.tensor(
+            "route:aligned:shared:counts",
+            (max_loras + 1,),
+            dtype=torch.int32,
+            device=device,
+            zero_on_first_allocation=True,
+        )
+
+        assert torch.count_nonzero(per_expert_counts).item() == 0
+        assert torch.count_nonzero(shared_counts).item() == 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/lora/test_moe_lora_runner_attach.py
+++ b/test/registered/unit/lora/test_moe_lora_runner_attach.py
@@ -8,6 +8,7 @@ import torch
 
 from sglang.srt.layers.moe.utils import MoeRunnerBackend
 from sglang.srt.lora.backend.base_backend import BaseLoRABackend
+from sglang.srt.lora.moe.base_gemm_provider import select_provider_cls
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-large")
@@ -18,11 +19,19 @@ class _FakeMoeLayer:
     def __init__(self, *, is_lora_runner: bool, with_quant_info: bool, device=None):
         device = device or torch.device("cpu")
         self._lora_runner_backend = (
-            MoeRunnerBackend.LORA if is_lora_runner else MoeRunnerBackend.DEEP_GEMM
+            MoeRunnerBackend.LORA_CUTEDSL
+            if is_lora_runner
+            else MoeRunnerBackend.DEEP_GEMM
         )
+        # The buffer sizing reads logical dims from the layer (quant-info
+        # tensor shapes are form-specific; Marlin payloads pack both dims).
         self.base_layer = SimpleNamespace(
             top_k=2,
             num_experts=4,
+            num_local_experts=4,
+            intermediate_size_per_partition=4,
+            hidden_size=6,
+            moe_runner_config=SimpleNamespace(is_gated=True),
             w13_weight=torch.zeros(4, 8, 6, device=device),
         )
         if with_quant_info:
@@ -194,6 +203,89 @@ class TestEngineAdmission(unittest.TestCase):
 
     def test_admits_a_supported_layer(self):
         self._admit()
+
+    def test_weight_family_of_a_bf16_layer(self):
+        from sglang.srt.lora.moe.moe_lora_runner import MoeLoraRunner
+
+        assert MoeLoraRunner._weight_family(self._base_layer()) == "bf16"
+
+    def _fp8_layer(self, *, block_quant=True, weight_dtype=torch.float8_e4m3fn):
+        from sglang.srt.layers.quantization.fp8 import Fp8MoEMethod
+
+        layer = self._base_layer()
+        quant_method = object.__new__(Fp8MoEMethod)
+        quant_method.block_quant = block_quant
+        quant_method.use_mxfp8 = False
+        quant_method.weight_block_size = [128, 128] if block_quant else None
+        layer.quant_method = quant_method
+        layer.w13_weight = layer.w13_weight.to(weight_dtype)
+        layer.w2_weight = layer.w2_weight.to(weight_dtype)
+        return layer
+
+    def test_weight_family_of_a_block_fp8_layer(self):
+        from sglang.srt.lora.moe.moe_lora_runner import MoeLoraRunner
+
+        assert MoeLoraRunner._weight_family(self._fp8_layer()) == "fp8"
+
+    def test_rejects_per_tensor_fp8(self):
+        from sglang.srt.lora.moe.moe_lora_runner import MoeLoraRunner
+
+        with self.assertRaisesRegex(NotImplementedError, "128-block"):
+            MoeLoraRunner._weight_family(self._fp8_layer(block_quant=False))
+
+    def test_rejects_marlin_repacked_fp8(self):
+        from sglang.srt.lora.moe.moe_lora_runner import MoeLoraRunner
+
+        with self.assertRaisesRegex(NotImplementedError, "float8_e4m3fn"):
+            MoeLoraRunner._weight_family(self._fp8_layer(weight_dtype=torch.bfloat16))
+
+    def test_fp8_family_selects_its_vendors(self):
+
+        for vendor, rows in (
+            ("cutedsl", "expert_major"),
+            ("cutedsl", "route_major"),
+            ("triton", "route_major"),
+            # No masked slab domain: decode plans run the route-major
+            # provider, same as the Marlin nvfp4 vendor.
+            ("triton", "expert_major"),
+        ):
+            assert select_provider_cls(rows, "fp8", vendor)
+        # DeepGEMM is no vendor: bf16 lost to CuTeDSL at every m, fp8 lost to
+        # both surviving vendors on SM90 and was inadmissible on SM100 shards.
+        # A vendor serving no fp8 layers resolves to the fp8 default.
+        for absent in ("marlin", "deepgemm"):
+            assert select_provider_cls(
+                "expert_major", "fp8", absent
+            ) is select_provider_cls("expert_major", "fp8")
+
+    def test_every_listed_vendor_resolves_and_others_fall_back_to_the_first(self):
+        """A mixed-quant model (quant-excluded BF16 sink next to NVFP4 routed
+        experts) attaches per layer: a backend whose vendor serves no layers of
+        this family resolves to the family default instead of failing."""
+        from sglang.srt.lora.moe.base_gemm_provider import VENDORS
+
+        every_vendor = {vendor for vendors in VENDORS.values() for vendor in vendors}
+        for family, vendors in VENDORS.items():
+            default = select_provider_cls("route_major", family)
+            assert default is select_provider_cls("route_major", family, vendors[0])
+            for vendor in vendors:
+                assert select_provider_cls("expert_major", family, vendor)
+            for other in every_vendor - set(vendors):
+                assert select_provider_cls("route_major", family, other) is default
+
+    def test_vendors_without_a_masked_domain_serve_expert_major_rows(self):
+        """Every decode row asks for expert_major. Triton and Marlin gather rows
+        by the sort metadata and have one domain, so the request runs on their
+        route-major class; bf16 lora_triton used to fail at attach here."""
+
+        for vendor, family in (
+            ("triton", "bf16"),
+            ("triton", "fp8"),
+            ("marlin", "nvfp4"),
+        ):
+            assert select_provider_cls(
+                "expert_major", family, vendor
+            ) is select_provider_cls("route_major", family, vendor)
 
     def test_rejects_architectures_with_neither_mma_family(self):
         """SM90 and SM100 are a closed set, not a floor: SM120 reports major 12

--- a/test/registered/unit/lora/test_moe_lora_runner_attach.py
+++ b/test/registered/unit/lora/test_moe_lora_runner_attach.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+
+from sglang.srt.layers.moe.utils import MoeRunnerBackend
+from sglang.srt.lora.backend.base_backend import BaseLoRABackend
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+
+register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-large")
+register_amd_ci(est_time=10, suite="stage-b-test-1-gpu-small-amd")
+
+
+class _FakeMoeLayer:
+    def __init__(self, *, is_lora_runner: bool, with_quant_info: bool, device=None):
+        device = device or torch.device("cpu")
+        self._lora_runner_backend = (
+            MoeRunnerBackend.LORA if is_lora_runner else MoeRunnerBackend.DEEP_GEMM
+        )
+        self.base_layer = SimpleNamespace(
+            top_k=2,
+            num_experts=4,
+            w13_weight=torch.zeros(4, 8, 6, device=device),
+        )
+        if with_quant_info:
+            self._quant_info = SimpleNamespace(
+                w13_weight=torch.zeros(4, 8, 6, device=device),
+                w2_weight=torch.zeros(4, 6, 4, device=device),
+            )
+
+
+class TestGraphBatchMetadata(unittest.TestCase):
+    """The two engine-independent buffers must exist for every engine."""
+
+    METADATA_KEYS = ("adapter_enabled", "token_lora_mapping")
+
+    def _backend(self) -> BaseLoRABackend:
+        backend = object.__new__(BaseLoRABackend)
+        backend._is_moe_lora = True
+        return backend
+
+    def test_metadata_present_without_legacy_kernel_buffers(self):
+        """Regression: skipping the whole initializer broke graph capture."""
+        backend = self._backend()
+        backend.init_cuda_graph_moe_buffers(
+            max_bs=8,
+            max_loras=4,
+            compute_dtype=torch.bfloat16,
+            # No _quant_info at all: the new engine never defines it, so the
+            # metadata path must not read layer geometry.
+            moe_layer=_FakeMoeLayer(is_lora_runner=True, with_quant_info=False),
+            include_legacy_kernel_buffers=False,
+        )
+        for key in self.METADATA_KEYS:
+            self.assertIn(key, backend.moe_cg_buffers)
+        self.assertEqual(backend.moe_cg_buffers["adapter_enabled"].shape, (4,))
+        self.assertEqual(backend.moe_cg_buffers["token_lora_mapping"].shape, (8,))
+        # Legacy kernel scratch must be absent so it does not consume budget
+        # that the KV cache would otherwise get.
+        for key in ("sorted_token_ids_lora", "expert_ids_lora", "cumsum_buffer"):
+            self.assertNotIn(key, backend.moe_cg_buffers)
+
+    def test_legacy_path_still_gets_every_buffer(self):
+        backend = self._backend()
+        backend.init_cuda_graph_moe_buffers(
+            max_bs=8,
+            max_loras=4,
+            compute_dtype=torch.bfloat16,
+            moe_layer=_FakeMoeLayer(is_lora_runner=False, with_quant_info=True),
+        )
+        for key in (
+            *self.METADATA_KEYS,
+            "sorted_token_ids_lora",
+            "expert_ids_lora",
+            "num_tokens_post_padded_lora",
+            "cumsum_buffer",
+            "token_mask",
+            "lora_ids",
+        ):
+            self.assertIn(key, backend.moe_cg_buffers)
+
+    def test_two_metadata_updates_keep_addresses_and_change_contents(self):
+        """``prepare_lora_batch`` runs OUTSIDE the captured graph while the
+        runner reads these tensors INSIDE it, so an update must write in place."""
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("CUDA required: the metadata update is Triton")
+        device = torch.device("cuda")
+        backend = self._backend()
+        backend.init_cuda_graph_moe_buffers(
+            max_bs=8,
+            max_loras=4,
+            compute_dtype=torch.bfloat16,
+            moe_layer=_FakeMoeLayer(
+                is_lora_runner=True, with_quant_info=False, device=device
+            ),
+            include_legacy_kernel_buffers=False,
+        )
+        enabled_ptr = backend.moe_cg_buffers["adapter_enabled"].data_ptr()
+        mapping_ptr = backend.moe_cg_buffers["token_lora_mapping"].data_ptr()
+
+        def update(*, weight_indices, lora_ranks, seg_lens):
+            seg_indptr = torch.tensor(
+                [0, *torch.tensor(seg_lens).cumsum(0).tolist()],
+                dtype=torch.int32,
+                device=device,
+            )
+            batch_info = SimpleNamespace(
+                use_cuda_graph=True,
+                bs=len(seg_lens),
+                num_segments=len(seg_lens),
+                seg_indptr=seg_indptr,
+                weight_indices=torch.tensor(
+                    weight_indices, dtype=torch.int32, device=device
+                ),
+                lora_ranks=torch.tensor(lora_ranks, dtype=torch.int32, device=device),
+                req_seg_indptr=None,
+                req_weight_indices=None,
+                moe_lora_info=None,
+            )
+            forward_batch = SimpleNamespace(
+                batch_size=sum(seg_lens),
+                extend_seq_lens_cpu=seg_lens,
+                extend_num_tokens=sum(seg_lens),
+                forward_mode=SimpleNamespace(
+                    is_extend=lambda: True,
+                    is_decode=lambda: False,
+                    is_target_verify=lambda: False,
+                ),
+            )
+            backend._add_moe_lora_info(forward_batch, batch_info)
+            return batch_info.moe_lora_info
+
+        # Slot 1 active (rank 16), slot 0 disabled (rank 0 = the base slot).
+        first = update(weight_indices=[1, 0], lora_ranks=[0, 16], seg_lens=[2, 2])
+        first_mapping = first.token_lora_mapping[:4].clone()
+        first_enabled = first.adapter_enabled.clone()
+
+        second = update(weight_indices=[2, 0], lora_ranks=[0, 16, 32], seg_lens=[3, 1])
+        torch.cuda.synchronize()
+
+        self.assertEqual(first.token_lora_mapping.data_ptr(), mapping_ptr)
+        self.assertEqual(second.token_lora_mapping.data_ptr(), mapping_ptr)
+        self.assertEqual(second.adapter_enabled.data_ptr(), enabled_ptr)
+        self.assertFalse(
+            torch.equal(second.token_lora_mapping[:4], first_mapping),
+            "the second assignment must actually change the mapping in place",
+        )
+        self.assertFalse(
+            torch.equal(second.adapter_enabled, first_enabled),
+            "enabling a different slot must change adapter_enabled in place",
+        )
+        self.assertEqual(int(second.adapter_enabled[2]), 1)
+        self.assertEqual(int(second.adapter_enabled[0]), 0)
+
+
+class TestEngineAdmission(unittest.TestCase):
+    def _base_layer(self, **overrides):
+        from sglang.srt.layers.moe.token_dispatcher.standard import StandardDispatcher
+        from sglang.srt.layers.quantization.unquant import UnquantizedFusedMoEMethod
+
+        quant_method = object.__new__(UnquantizedFusedMoEMethod)
+        dispatcher = object.__new__(StandardDispatcher)
+        dispatcher.skip_local_expert_mapping = overrides.get("skip_local", False)
+        return SimpleNamespace(
+            quant_method=quant_method,
+            dispatcher=dispatcher,
+            w13_weight=torch.zeros(2, 8, 4, dtype=torch.bfloat16),
+            w2_weight=torch.zeros(2, 4, 4, dtype=torch.bfloat16),
+            num_local_experts=2,
+            should_fuse_routed_scaling_factor_in_topk=overrides.get(
+                "fused_scaling", False
+            ),
+            moe_runner_config=SimpleNamespace(
+                activation=overrides.get("activation", "silu"),
+                is_gated=True,
+                gemm1_alpha=None,
+                gemm1_clamp_limit=None,
+                swiglu_limit=None,
+                apply_router_weight_on_input=False,
+                no_combine=False,
+                num_fused_shared_experts=0,
+                top_k=2,
+                routed_scaling_factor=1.0,
+            ),
+        )
+
+    def _admit(self, **overrides):
+        from sglang.srt.lora.moe.moe_lora_runner import MoeLoraRunner
+
+        MoeLoraRunner._admit(self._base_layer(**overrides))
+
+    def test_admits_a_supported_layer(self):
+        self._admit()
+
+    def test_rejects_architectures_with_neither_mma_family(self):
+        """SM90 and SM100 are a closed set, not a floor: SM120 reports major 12
+        yet has neither WGMMA nor tcgen05, so a ">= SM90" check mis-admits it."""
+        from sglang.srt.lora.moe.moe_lora_runner import MoeLoraRunner
+
+        for capability in ((8, 0), (12, 0), (11, 0)):
+            with mock.patch(
+                "torch.cuda.get_device_capability", lambda device=None: capability
+            ):
+                with self.assertRaisesRegex(NotImplementedError, "SM90 and SM100"):
+                    MoeLoraRunner._admit(self._base_layer())
+
+    def test_rejects_global_expert_id_dispatch(self):
+        with self.assertRaisesRegex(NotImplementedError, "EP-local"):
+            self._admit(skip_local=True)
+
+    def test_rejects_prefolded_routed_scaling(self):
+        """Scaling folded into top-k would be applied twice."""
+        with self.assertRaisesRegex(NotImplementedError, "routed scaling"):
+            self._admit(fused_scaling=True)
+
+    def test_rejects_unsupported_activation(self):
+        with self.assertRaisesRegex(NotImplementedError, "SiLU or ReLU2"):
+            self._admit(activation="gelu")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/lora/test_moe_lora_runtime_contract.py
+++ b/test/registered/unit/lora/test_moe_lora_runtime_contract.py
@@ -1,0 +1,426 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+import pytest
+import torch
+
+pytest.importorskip("triton")
+
+from sglang.srt.lora.moe.activation import ActivationFn  # noqa: E402
+from sglang.srt.lora.moe.execution_plan import (  # noqa: E402
+    DeviceArchitecture,
+    Phase,
+    resolve_plans,
+)
+from sglang.test.ci.ci_register import register_cuda_ci  # noqa: E402
+
+register_cuda_ci(est_time=15, stage="base-b", runner_config="1-gpu-large")
+
+if TYPE_CHECKING:
+    from sglang.srt.lora.backend.base_backend import BaseLoRABackend
+
+
+class _FakeMoeLayer:
+    def __init__(self, device: torch.device) -> None:
+        self.base_layer = SimpleNamespace(
+            w13_weight=torch.empty(1, device=device, dtype=torch.bfloat16),
+        )
+
+
+def _graph_backend(device: torch.device) -> BaseLoRABackend:
+    from sglang.srt.lora.backend.base_backend import BaseLoRABackend
+
+    backend = object.__new__(BaseLoRABackend)
+    backend._is_moe_lora = True
+    backend.device = device
+    backend.max_loras_per_batch = 4
+    backend.prefill_cuda_graph_batch_info = None
+    backend.prefill_moe_cg_buffers = None
+    backend.init_cuda_graph_moe_buffers(
+        max_bs=8,
+        max_loras=4,
+        compute_dtype=torch.bfloat16,
+        moe_layer=_FakeMoeLayer(device),
+        include_legacy_kernel_buffers=False,
+    )
+    backend.init_prefill_cuda_graph_moe_buffers(max_num_tokens=12)
+    return backend
+
+
+def _batch_info(
+    *,
+    device: torch.device,
+    weight_indices: list[int],
+    lora_ranks: list[int],
+    seg_lens: list[int],
+) -> SimpleNamespace:
+    seg_indptr = torch.tensor(
+        [0, *torch.tensor(seg_lens).cumsum(0).tolist()],
+        dtype=torch.int32,
+        device=device,
+    )
+    return SimpleNamespace(
+        use_cuda_graph=True,
+        bs=len(seg_lens),
+        num_segments=len(seg_lens),
+        seg_indptr=seg_indptr,
+        weight_indices=torch.tensor(
+            weight_indices,
+            dtype=torch.int32,
+            device=device,
+        ),
+        lora_ranks=torch.tensor(lora_ranks, dtype=torch.int32, device=device),
+        req_seg_indptr=None,
+        req_weight_indices=None,
+        moe_lora_info=None,
+    )
+
+
+def _refresh_metadata(
+    backend: BaseLoRABackend,
+    batch_info: SimpleNamespace,
+    *,
+    seg_lens: list[int],
+    is_prefill: bool,
+) -> None:
+    if is_prefill:
+        backend.prefill_cuda_graph_batch_info = batch_info
+    forward_batch = SimpleNamespace(
+        batch_size=len(seg_lens),
+        extend_seq_lens_cpu=seg_lens,
+        extend_num_tokens=sum(seg_lens),
+        forward_mode=SimpleNamespace(
+            is_extend=lambda: is_prefill,
+            is_decode=lambda: not is_prefill,
+            is_target_verify=lambda: False,
+        ),
+    )
+    backend._add_moe_lora_info(forward_batch, batch_info)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA graph required")
+def test_decode_and_prefill_metadata_refresh_through_real_graph_replay() -> None:
+    """A replay reads the new routing. The captured pointers stay the same."""
+    device = torch.device("cuda")
+    backend = _graph_backend(device)
+    decode_buffers = backend.moe_cg_buffers
+    prefill_buffers = backend.prefill_moe_cg_buffers
+    assert prefill_buffers is not None
+
+    decode_mapping_ptr = decode_buffers["token_lora_mapping"].data_ptr()
+    prefill_mapping_ptr = prefill_buffers["token_lora_mapping"].data_ptr()
+    assert decode_mapping_ptr != prefill_mapping_ptr
+
+    decode_batch = _batch_info(
+        device=device,
+        weight_indices=[1, 2, 1, 0, 2, 1, 0, 2],
+        lora_ranks=[0, 16, 32, 0],
+        seg_lens=[1] * 8,
+    )
+    prefill_batch = _batch_info(
+        device=device,
+        weight_indices=[1, 2, 0],
+        lora_ranks=[0, 16, 32, 0],
+        seg_lens=[4, 5, 3],
+    )
+    _refresh_metadata(
+        backend,
+        decode_batch,
+        seg_lens=[1] * 8,
+        is_prefill=False,
+    )
+    _refresh_metadata(
+        backend,
+        prefill_batch,
+        seg_lens=[4, 5, 3],
+        is_prefill=True,
+    )
+
+    observed_decode = torch.empty_like(decode_buffers["token_lora_mapping"])
+    observed_prefill = torch.empty_like(prefill_buffers["token_lora_mapping"])
+    observed_decode_enabled = torch.empty_like(decode_buffers["adapter_enabled"])
+    observed_prefill_enabled = torch.empty_like(prefill_buffers["adapter_enabled"])
+
+    # These copies compile the copy path before the capture. The first
+    # refresh above already compiled the metadata routing.
+    observed_decode.copy_(decode_buffers["token_lora_mapping"])
+    observed_prefill.copy_(prefill_buffers["token_lora_mapping"])
+    observed_decode_enabled.copy_(decode_buffers["adapter_enabled"])
+    observed_prefill_enabled.copy_(prefill_buffers["adapter_enabled"])
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        observed_decode.copy_(decode_buffers["token_lora_mapping"])
+        observed_prefill.copy_(prefill_buffers["token_lora_mapping"])
+        observed_decode_enabled.copy_(decode_buffers["adapter_enabled"])
+        observed_prefill_enabled.copy_(prefill_buffers["adapter_enabled"])
+
+    first_decode = observed_decode.clone()
+    first_prefill = observed_prefill.clone()
+    assert first_decode.tolist() == [1, 2, 1, -1, 2, 1, -1, 2]
+    assert first_prefill.tolist() == [
+        1,
+        1,
+        1,
+        1,
+        2,
+        2,
+        2,
+        2,
+        2,
+        -1,
+        -1,
+        -1,
+    ]
+
+    decode_batch = _batch_info(
+        device=device,
+        weight_indices=[3, 3, 0, 3],
+        lora_ranks=[0, 0, 0, 8],
+        seg_lens=[1] * 4,
+    )
+    prefill_batch.seg_indptr = torch.tensor([0, 2, 5], dtype=torch.int32, device=device)
+    prefill_batch.weight_indices = torch.tensor(
+        [3, 0], dtype=torch.int32, device=device
+    )
+    prefill_batch.lora_ranks = torch.tensor(
+        [0, 0, 0, 8], dtype=torch.int32, device=device
+    )
+    prefill_batch.bs = 2
+    prefill_batch.num_segments = 2
+    _refresh_metadata(
+        backend,
+        decode_batch,
+        seg_lens=[1] * 4,
+        is_prefill=False,
+    )
+    _refresh_metadata(
+        backend,
+        prefill_batch,
+        seg_lens=[2, 3],
+        is_prefill=True,
+    )
+
+    # The serving scheduler finishes the metadata refresh before it launches
+    # the model graph. PyTorch can replay on another stream, so the test
+    # forces that order here.
+    torch.cuda.synchronize()
+    graph.replay()
+    torch.cuda.synchronize()
+
+    assert decode_buffers["token_lora_mapping"].data_ptr() == decode_mapping_ptr
+    assert prefill_buffers["token_lora_mapping"].data_ptr() == prefill_mapping_ptr
+    assert torch.equal(observed_decode, decode_buffers["token_lora_mapping"])
+    assert torch.equal(observed_prefill, prefill_buffers["token_lora_mapping"])
+    assert torch.equal(observed_decode_enabled, decode_buffers["adapter_enabled"])
+    assert torch.equal(observed_prefill_enabled, prefill_buffers["adapter_enabled"])
+    assert not torch.equal(observed_decode, first_decode)
+    assert not torch.equal(observed_prefill, first_prefill)
+
+    # A smaller batch must clear the tail of the graph bucket. It must not
+    # keep the routes of the earlier, larger batch.
+    assert observed_decode[4:].tolist() == [-1] * 4
+    assert observed_prefill[5:].tolist() == [-1] * 7
+    assert observed_decode_enabled.tolist() == [0, 0, 0, 1]
+    assert observed_prefill_enabled.tolist() == [0, 0, 0, 1]
+    assert observed_decode.tolist() == [3, 3, -1, 3, -1, -1, -1, -1]
+    assert observed_prefill.tolist() == [
+        3,
+        3,
+        -1,
+        -1,
+        -1,
+        -1,
+        -1,
+        -1,
+        -1,
+        -1,
+        -1,
+        -1,
+    ]
+
+    # A later replay with no adapter must clear every route. The two batches
+    # above must leave nothing behind.
+    decode_batch = _batch_info(
+        device=device,
+        weight_indices=[0, 0],
+        lora_ranks=[0, 0, 0, 0],
+        seg_lens=[1, 1],
+    )
+    prefill_batch = _batch_info(
+        device=device,
+        weight_indices=[0],
+        lora_ranks=[0, 0, 0, 0],
+        seg_lens=[3],
+    )
+    _refresh_metadata(
+        backend,
+        decode_batch,
+        seg_lens=[1, 1],
+        is_prefill=False,
+    )
+    _refresh_metadata(
+        backend,
+        prefill_batch,
+        seg_lens=[3],
+        is_prefill=True,
+    )
+    torch.cuda.synchronize()
+    graph.replay()
+    torch.cuda.synchronize()
+
+    assert decode_buffers["token_lora_mapping"].data_ptr() == decode_mapping_ptr
+    assert prefill_buffers["token_lora_mapping"].data_ptr() == prefill_mapping_ptr
+    assert observed_decode.tolist() == [-1] * 8
+    assert observed_prefill.tolist() == [-1] * 12
+    assert observed_decode_enabled.tolist() == [0, 0, 0, 0]
+    assert observed_prefill_enabled.tolist() == [0, 0, 0, 0]
+
+
+class TestRunnerAdmission:
+    @pytest.fixture(autouse=True)
+    def _supported_device(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # _admit reads the real device capability; pin a supported one so these
+        # contract tests do not depend on the CI runner's GPU.
+        monkeypatch.setattr(
+            torch.cuda, "get_device_capability", lambda *args, **kwargs: (9, 0)
+        )
+
+    def test_rejects_unsupported_architecture(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            torch.cuda, "get_device_capability", lambda *args, **kwargs: (12, 0)
+        )
+        with pytest.raises(NotImplementedError, match="SM90 and SM100"):
+            self._admit()
+
+    @staticmethod
+    def _base_layer(**overrides):
+        from sglang.srt.layers.moe.token_dispatcher.standard import StandardDispatcher
+        from sglang.srt.layers.quantization.unquant import UnquantizedFusedMoEMethod
+
+        quant_method = object.__new__(UnquantizedFusedMoEMethod)
+        dispatcher = object.__new__(StandardDispatcher)
+        dispatcher.skip_local_expert_mapping = overrides.get("skip_local", False)
+        is_gated = overrides.get("is_gated", True)
+        gateup_width = overrides.get("gateup_width", (2 if is_gated else 1) * 4)
+        return SimpleNamespace(
+            quant_method=quant_method,
+            dispatcher=dispatcher,
+            w13_weight=torch.zeros(2, gateup_width, 4, dtype=torch.bfloat16),
+            w2_weight=torch.zeros(2, 4, 4, dtype=torch.bfloat16),
+            should_fuse_routed_scaling_factor_in_topk=overrides.get(
+                "fused_scaling", False
+            ),
+            moe_runner_config=SimpleNamespace(
+                activation=overrides.get("activation", "silu"),
+                is_gated=is_gated,
+                gemm1_alpha=None,
+                gemm1_clamp_limit=None,
+                swiglu_limit=None,
+                apply_router_weight_on_input=False,
+                no_combine=False,
+                num_fused_shared_experts=0,
+                top_k=2,
+                routed_scaling_factor=1.0,
+            ),
+        )
+
+    def _admit(self, **overrides) -> None:
+        from sglang.srt.lora.moe.moe_lora_runner import MoeLoraRunner
+
+        MoeLoraRunner._admit(self._base_layer(**overrides))
+
+    @pytest.mark.parametrize("activation", [fn.value for fn in ActivationFn])
+    @pytest.mark.parametrize("is_gated", [True, False])
+    def test_accepts_every_activation_crossed_with_every_gating(
+        self,
+        activation: str,
+        is_gated: bool,
+    ) -> None:
+        """Gating and the activation are independent, so every pair is valid."""
+        self._admit(activation=activation, is_gated=is_gated)
+
+    @pytest.mark.parametrize("activation", [fn.value for fn in ActivationFn])
+    @pytest.mark.parametrize("is_gated", [True, False])
+    def test_every_cell_binds_against_a_matching_provider(
+        self,
+        activation: str,
+        is_gated: bool,
+    ) -> None:
+        """Non-gated SiLU once passed _admit and then failed in validate_plan.
+
+        The old code read the gate and up slice count from the activation.
+        """
+        from sglang.srt.lora.moe.moe_lora_runner import MoeLoraRunner
+        from sglang.srt.lora.moe.quant_info import MoeLoraBf16QuantInfo
+
+        experts, hidden, inter = 4, 256, 128
+        slices = 2 if is_gated else 1
+        device = torch.device("cuda")
+        provider = MoeLoraRunner.select_provider_cls("route_major", "triton")(
+            MoeLoraBf16QuantInfo(
+                w13_weight=torch.zeros(
+                    (experts, slices * inter, hidden),
+                    device=device,
+                    dtype=torch.bfloat16,
+                ),
+                w2_weight=torch.zeros(
+                    (experts, hidden, inter), device=device, dtype=torch.bfloat16
+                ),
+                num_local_experts=experts,
+                intermediate_size=inter,
+                hidden_size=hidden,
+            )
+        )
+        runner = MoeLoraRunner(
+            providers={"route_major": provider},
+            top_k=2,
+            routed_scaling_factor=1.0,
+            activation=ActivationFn.parse(activation),
+            is_gated=is_gated,
+        )
+        selected = resolve_plans(
+            architecture=DeviceArchitecture.GB300,
+            is_shared_outer=False,
+            physical_rank=16,
+            activation=ActivationFn.parse(activation),
+            hidden_size=hidden,
+            num_local_experts=experts,
+        )[Phase.PREFILL]
+        runner.validate_plan(selected.plan, base_gemm_rows=selected.base_gemm_rows)
+
+        runner.is_gated = not is_gated
+        with pytest.raises(ValueError, match="is_gated"):
+            runner.validate_plan(selected.plan, base_gemm_rows=selected.base_gemm_rows)
+
+    @pytest.mark.parametrize(
+        ("overrides", "message"),
+        [
+            ({"skip_local": True}, "EP-local"),
+            ({"fused_scaling": True}, "routed scaling"),
+            (
+                {"activation": "gelu", "is_gated": False},
+                "SiLU or ReLU2",
+            ),
+            (
+                {"is_gated": False, "gateup_width": 8},
+                "disagrees with",
+            ),
+        ],
+    )
+    def test_rejects_unsupported_resident_contracts(
+        self,
+        overrides: dict[str, object],
+        message: str,
+    ) -> None:
+        with pytest.raises(NotImplementedError, match=message):
+            self._admit(**overrides)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/lora/test_moe_lora_runtime_contract.py
+++ b/test/registered/unit/lora/test_moe_lora_runtime_contract.py
@@ -9,6 +9,7 @@ import torch
 pytest.importorskip("triton")
 
 from sglang.srt.lora.moe.activation import ActivationFn  # noqa: E402
+from sglang.srt.lora.moe.base_gemm_provider import select_provider_cls  # noqa: E402
 from sglang.srt.lora.moe.execution_plan import (  # noqa: E402
     DeviceArchitecture,
     Phase,
@@ -307,7 +308,7 @@ class TestRunnerAdmission:
         dispatcher = object.__new__(StandardDispatcher)
         dispatcher.skip_local_expert_mapping = overrides.get("skip_local", False)
         is_gated = overrides.get("is_gated", True)
-        gateup_width = overrides.get("gateup_width", (2 if is_gated else 1) * 4)
+        gateup_width = (2 if is_gated else 1) * 4
         return SimpleNamespace(
             quant_method=quant_method,
             dispatcher=dispatcher,
@@ -362,7 +363,7 @@ class TestRunnerAdmission:
         experts, hidden, inter = 4, 256, 128
         slices = 2 if is_gated else 1
         device = torch.device("cuda")
-        provider = MoeLoraRunner.select_provider_cls("route_major", "triton")(
+        provider = select_provider_cls("route_major", "bf16", "triton")(
             MoeLoraBf16QuantInfo(
                 w13_weight=torch.zeros(
                     (experts, slices * inter, hidden),
@@ -385,6 +386,7 @@ class TestRunnerAdmission:
             is_gated=is_gated,
         )
         selected = resolve_plans(
+            quant_family="bf16",
             architecture=DeviceArchitecture.GB300,
             is_shared_outer=False,
             physical_rank=16,
@@ -406,10 +408,6 @@ class TestRunnerAdmission:
             (
                 {"activation": "gelu", "is_gated": False},
                 "SiLU or ReLU2",
-            ),
-            (
-                {"is_gated": False, "gateup_width": 8},
-                "disagrees with",
             ),
         ],
     )

--- a/test/registered/unit/lora/test_moe_lora_shared_outer_numerics.py
+++ b/test/registered/unit/lora/test_moe_lora_shared_outer_numerics.py
@@ -1,0 +1,345 @@
+"""Shared-outer decode against an independent fp32 reference.
+
+The runner-numerics suite covers per-expert layouts only, so shared-outer
+decode had no absolute check - equivalence against another engine path can
+never catch a shared misconception. This test encodes the layout's factor
+contract explicitly: the OUTER factors (gate_up-A on hidden, down-B on
+hidden) are one per adapter slot, and the INNER factors (gate_up-B and
+down-A on the intermediate dim) stay per expert, exactly as the pool shapes
+them. A harness that collapses the inner factors to one per slot reads the
+engine's correct (slot, expert) weight fetches as misattribution - that
+mistake produced a false bug report once, which is why the shapes above are
+spelled out here.
+
+Cases: distinct adapters per slot (the attribution-sensitive one), identical
+adapters in every slot (the attribution-blind case every e2e bench runs),
+a replay of the pipeline inside a real CUDA graph, and the non-gated relu2
+layout (one up projection, S = 1) that Inkling serves.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from sglang.srt.layers.moe.token_dispatcher.standard import StandardDispatchOutput
+from sglang.srt.layers.moe.topk import StandardTopKOutput
+from sglang.srt.lora.moe.execution_plan import (
+    ActivationFn,
+    Phase,
+    SelectedPlan,
+    architecture_for_capability,
+    resolve_plans,
+)
+from sglang.srt.lora.moe.launch_config import resolve_tiles
+from sglang.srt.lora.moe.moe_lora_runner import MoeLoraBatch, MoeLoraRunner
+from sglang.srt.lora.moe.quant_info import MoeLoraBf16QuantInfo
+from sglang.srt.runtime_context import get_context
+from sglang.test.ci.ci_register import register_cuda_ci
+
+
+def _segments_of(mapping: torch.Tensor) -> torch.Tensor:
+    """Request boundaries for a test batch: one request per token, so the
+    segment route is exercised with many short requests and the helper stays
+    free of host syncs (CUDA-graph capture forbids a device-to-host copy)."""
+    return torch.arange(mapping.numel() + 1, dtype=torch.int32, device=mapping.device)
+
+
+register_cuda_ci(est_time=60, stage="base-b", runner_config="1-gpu-large")
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="production MoE LoRA requires CUDA"
+)
+
+
+@pytest.fixture(autouse=True)
+def _published_server_args():
+    # The triton vendor's config loader reads the published exec namespace.
+    with get_context().override_server_args():
+        yield
+
+
+_EXPERTS = 2
+_TOP_K = 2
+_HIDDEN = 128
+_INTERMEDIATE = 128
+_PHYSICAL_RANK = 16
+_SLOTS = 2
+_ROUTED_SCALING = 0.75
+_NUM_TOKENS = 8
+
+
+def _rand_bf16(shape, *, generator, scale):
+    return (torch.randn(shape, generator=generator) * scale).to(torch.bfloat16)
+
+
+def _make_cpu_tensors(
+    identical_slots: bool = False, gated: bool = True
+) -> dict[str, torch.Tensor]:
+    generator = torch.Generator().manual_seed(0xF01D)
+    slices = 2 if gated else 1
+    tensors = {
+        "hidden_states": _rand_bf16(
+            (_NUM_TOKENS, _HIDDEN), generator=generator, scale=0.20
+        ),
+        "w13_weight": _rand_bf16(
+            (_EXPERTS, slices * _INTERMEDIATE, _HIDDEN),
+            generator=generator,
+            scale=0.08,
+        ),
+        "w2_weight": _rand_bf16(
+            (_EXPERTS, _HIDDEN, _INTERMEDIATE), generator=generator, scale=0.08
+        ),
+        # Outer factors: one per slot. Inner factors: per (slot, expert).
+        "gate_up_lora_a": _rand_bf16(
+            (_SLOTS, 1, slices * _PHYSICAL_RANK, _HIDDEN),
+            generator=generator,
+            scale=0.15,
+        ),
+        "gate_up_lora_b": _rand_bf16(
+            (_SLOTS, _EXPERTS, slices * _INTERMEDIATE, _PHYSICAL_RANK),
+            generator=generator,
+            scale=0.15,
+        ),
+        "down_lora_a": _rand_bf16(
+            (_SLOTS, _EXPERTS, _PHYSICAL_RANK, _INTERMEDIATE),
+            generator=generator,
+            scale=0.15,
+        ),
+        "down_lora_b": _rand_bf16(
+            (_SLOTS, 1, _HIDDEN, _PHYSICAL_RANK), generator=generator, scale=0.15
+        ),
+    }
+    alternating = torch.tensor([[0, 1], [1, 0]], dtype=torch.int32)
+    tensors["topk_ids"] = alternating.repeat((_NUM_TOKENS + 1) // 2, 1)[
+        :_NUM_TOKENS
+    ].contiguous()
+    tensors["topk_weights"] = torch.tensor([[0.65, 0.35]], dtype=torch.float32).repeat(
+        _NUM_TOKENS, 1
+    )
+    tensors["router_logits"] = torch.zeros((_NUM_TOKENS, _EXPERTS), dtype=torch.float32)
+    if identical_slots:
+        for name in ("gate_up_lora_a", "gate_up_lora_b", "down_lora_a", "down_lora_b"):
+            tensors[name] = (
+                tensors[name][:1]
+                .repeat(_SLOTS, *([1] * (tensors[name].ndim - 1)))
+                .contiguous()
+            )
+    tensors["adapter_enabled"] = torch.tensor([1, 1], dtype=torch.int32)
+    # Mixed traffic: two slots and base-only tokens in one batch.
+    tensors["token_lora_mapping"] = torch.tensor(
+        [0, 1, -1, 0, 1, -1, 0, 1], dtype=torch.int32
+    )
+    return tensors
+
+
+def _fp32_reference(
+    tensors: dict[str, torch.Tensor], gated: bool = True
+) -> torch.Tensor:
+    hidden_states = tensors["hidden_states"].float()
+    w13 = tensors["w13_weight"].float()
+    w2 = tensors["w2_weight"].float()
+    gua = tensors["gate_up_lora_a"].float()
+    gub = tensors["gate_up_lora_b"].float()
+    da = tensors["down_lora_a"].float()
+    db = tensors["down_lora_b"].float()
+    topk_ids = tensors["topk_ids"]
+    topk_weights = tensors["topk_weights"].float()
+    mapping = tensors["token_lora_mapping"]
+
+    output = torch.zeros((_NUM_TOKENS, _HIDDEN), dtype=torch.float32)
+    for token_idx, hidden in enumerate(hidden_states):
+        slot = int(mapping[token_idx])
+        for topk_idx in range(_TOP_K):
+            expert = int(topk_ids[token_idx, topk_idx])
+            gate_up = torch.mv(w13[expert], hidden)
+            if slot >= 0:
+                rank = torch.mv(gua[slot, 0], hidden)
+                for s in range(2 if gated else 1):
+                    cols = slice(s * _INTERMEDIATE, (s + 1) * _INTERMEDIATE)
+                    ranks = slice(s * _PHYSICAL_RANK, (s + 1) * _PHYSICAL_RANK)
+                    gate_up[cols] += torch.mv(gub[slot, expert, cols], rank[ranks])
+            if gated:
+                activation = F.silu(gate_up[:_INTERMEDIATE]) * gate_up[_INTERMEDIATE:]
+            else:
+                activation = F.relu(gate_up).square()
+            pair_output = torch.mv(w2[expert], activation)
+            if slot >= 0:
+                down_rank = torch.mv(da[slot, expert], activation)
+                pair_output = pair_output + torch.mv(db[slot, 0], down_rank)
+            output[token_idx].add_(
+                pair_output, alpha=float(topk_weights[token_idx, topk_idx])
+            )
+    return output * _ROUTED_SCALING
+
+
+def _standalone_output_allocation(runner, *, num_tokens, dtype, device):
+    return torch.empty((num_tokens, runner.hidden_size), dtype=dtype, device=device)
+
+
+def _bind_test_menu(runner, plan, launch_config):
+    """Publish one plan as the runner's whole phase menu.
+
+    ``run`` resolves from the runner's own ``plans``/``tiles``; a test binds
+    its single plan to both phases so the batch's phase flag cannot matter.
+    """
+    selected = SelectedPlan(key="test", name="test", base_gemm_rows="test", plan=plan)
+    tiles = SimpleNamespace(config_for=lambda num_tokens: launch_config)
+    runner.plans = {Phase.PREFILL: selected, Phase.DECODE: selected}
+    runner.tiles = {Phase.PREFILL: tiles, Phase.DECODE: tiles}
+
+
+def _build_runner(
+    gpu: dict[str, torch.Tensor],
+    vendor: str = "cutedsl",
+    activation: ActivationFn = ActivationFn.SILU,
+    gated: bool = True,
+):
+    device = torch.device("cuda")
+    architecture = architecture_for_capability(
+        *torch.cuda.get_device_capability(device)
+    )
+    choice = resolve_plans(
+        architecture=architecture,
+        is_shared_outer=True,
+        physical_rank=_PHYSICAL_RANK,
+        activation=activation,
+        hidden_size=_HIDDEN,
+        num_local_experts=_EXPERTS,
+    )[Phase.DECODE]
+    launch_config = resolve_tiles(
+        architecture_value=architecture.value,
+        plan_key_name=choice.name,
+        physical_rank=_PHYSICAL_RANK,
+    ).config_for(_NUM_TOKENS)
+    # The triton provider serves the route-major domain only; the plan's
+    # families run on either domain, so the same plan drives both vendors.
+    rows = "route_major" if vendor == "triton" else choice.base_gemm_rows
+    provider_cls = MoeLoraRunner.select_provider_cls(rows, vendor)
+    provider = provider_cls(
+        MoeLoraBf16QuantInfo(
+            w13_weight=gpu["w13_weight"],
+            w2_weight=gpu["w2_weight"],
+            num_local_experts=_EXPERTS,
+            intermediate_size=_INTERMEDIATE,
+            hidden_size=_HIDDEN,
+        )
+    )
+    runner = MoeLoraRunner(
+        providers={"test": provider},
+        top_k=_TOP_K,
+        routed_scaling_factor=_ROUTED_SCALING,
+        activation=activation,
+        is_gated=gated,
+    )
+    runner.validate_plan(choice.plan, base_gemm_rows="test")
+    _bind_test_menu(runner, choice.plan, launch_config)
+    return runner
+
+
+def _run_once(runner, gpu, use_cuda_graph=False):
+    dispatch = StandardDispatchOutput(
+        hidden_states=gpu["hidden_states"],
+        hidden_states_scale=None,
+        topk_output=StandardTopKOutput(
+            topk_weights=gpu["topk_weights"],
+            topk_ids=gpu["topk_ids"],
+            router_logits=gpu["router_logits"],
+        ),
+    )
+    batch = MoeLoraBatch(
+        gate_up_lora_a=gpu["gate_up_lora_a"],
+        gate_up_lora_b=gpu["gate_up_lora_b"],
+        down_lora_a=gpu["down_lora_a"],
+        down_lora_b=gpu["down_lora_b"],
+        token_lora_mapping=gpu["token_lora_mapping"],
+        seg_indptr=_segments_of(gpu["token_lora_mapping"]),
+        use_cuda_graph=use_cuda_graph,
+        is_prefill=False,
+    )
+    return runner.run(dispatch, batch)
+
+
+def _skip_unless_supported(device):
+    # The runner admits SM90 and SM100 only; the table mapper itself never raises.
+    major, minor = torch.cuda.get_device_capability(device)
+    if major not in (9, 10):
+        pytest.skip(f"MoE LoRA does not support SM{major}{minor}")
+
+
+@pytest.mark.parametrize("vendor", ("cutedsl", "triton"))
+@pytest.mark.parametrize(
+    "identical_slots", (False, True), ids=("distinct", "identical")
+)
+def test_shared_outer_decode_matches_fp32_reference(
+    monkeypatch: pytest.MonkeyPatch, identical_slots: bool, vendor: str
+) -> None:
+    device = torch.device("cuda")
+    _skip_unless_supported(device)
+    monkeypatch.setattr(
+        MoeLoraRunner, "_allocate_output", _standalone_output_allocation
+    )
+    cpu = _make_cpu_tensors(identical_slots=identical_slots)
+    gpu = {name: tensor.to(device) for name, tensor in cpu.items()}
+    reference = _fp32_reference(cpu)
+    runner = _build_runner(gpu, vendor)
+    actual = _run_once(runner, gpu).hidden_states.detach().float().cpu()
+    torch.testing.assert_close(actual, reference, atol=0.018, rtol=0.06)
+    # LoRA math must be present, not bypassed within tolerance.
+    base_only = dict(cpu)
+    base_only["token_lora_mapping"] = torch.full((_NUM_TOKENS,), -1, dtype=torch.int32)
+    assert (reference - _fp32_reference(base_only)).abs().max().item() > 0.02
+
+
+@pytest.mark.parametrize("vendor", ("cutedsl", "triton"))
+def test_shared_outer_decode_replays_in_a_cuda_graph(
+    monkeypatch: pytest.MonkeyPatch, vendor: str
+) -> None:
+    device = torch.device("cuda")
+    _skip_unless_supported(device)
+    monkeypatch.setattr(
+        MoeLoraRunner, "_allocate_output", _standalone_output_allocation
+    )
+    cpu = _make_cpu_tensors()
+    gpu = {name: tensor.to(device) for name, tensor in cpu.items()}
+    reference = _fp32_reference(cpu)
+    runner = _build_runner(gpu, vendor)
+    _run_once(runner, gpu, use_cuda_graph=True)
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = _run_once(runner, gpu, use_cuda_graph=True)
+    graph.replay()
+    torch.cuda.synchronize()
+    out = captured.hidden_states.detach().float().cpu()
+    torch.testing.assert_close(out, reference, atol=0.018, rtol=0.06)
+
+
+@pytest.mark.parametrize("vendor", ("cutedsl", "triton"))
+def test_shared_outer_relu2_non_gated_decode_matches_fp32_reference(
+    monkeypatch: pytest.MonkeyPatch, vendor: str
+) -> None:
+    """Inkling's layout: one up projection (S = 1) and relu2, real adapters."""
+    device = torch.device("cuda")
+    _skip_unless_supported(device)
+    monkeypatch.setattr(
+        MoeLoraRunner, "_allocate_output", _standalone_output_allocation
+    )
+    cpu = _make_cpu_tensors(gated=False)
+    gpu = {name: tensor.to(device) for name, tensor in cpu.items()}
+    reference = _fp32_reference(cpu, gated=False)
+    runner = _build_runner(gpu, vendor, activation=ActivationFn.RELU2, gated=False)
+    actual = _run_once(runner, gpu).hidden_states.detach().float().cpu()
+    torch.testing.assert_close(actual, reference, atol=0.018, rtol=0.06)
+    base_only = dict(cpu)
+    base_only["token_lora_mapping"] = torch.full((_NUM_TOKENS,), -1, dtype=torch.int32)
+    assert (
+        reference - _fp32_reference(base_only, gated=False)
+    ).abs().max().item() > 0.02
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/lora/test_moe_lora_shared_outer_numerics.py
+++ b/test/registered/unit/lora/test_moe_lora_shared_outer_numerics.py
@@ -27,6 +27,7 @@ import torch.nn.functional as F
 
 from sglang.srt.layers.moe.token_dispatcher.standard import StandardDispatchOutput
 from sglang.srt.layers.moe.topk import StandardTopKOutput
+from sglang.srt.lora.moe.base_gemm_provider import select_provider_cls
 from sglang.srt.lora.moe.execution_plan import (
     ActivationFn,
     Phase,
@@ -189,7 +190,7 @@ def _bind_test_menu(runner, plan, launch_config):
     selected = SelectedPlan(key="test", name="test", base_gemm_rows="test", plan=plan)
     tiles = SimpleNamespace(config_for=lambda num_tokens: launch_config)
     runner.plans = {Phase.PREFILL: selected, Phase.DECODE: selected}
-    runner.tiles = {Phase.PREFILL: tiles, Phase.DECODE: tiles}
+    runner.tiles = {selected.key: tiles}
 
 
 def _build_runner(
@@ -203,6 +204,7 @@ def _build_runner(
         *torch.cuda.get_device_capability(device)
     )
     choice = resolve_plans(
+        quant_family="bf16",
         architecture=architecture,
         is_shared_outer=True,
         physical_rank=_PHYSICAL_RANK,
@@ -215,10 +217,7 @@ def _build_runner(
         plan_key_name=choice.name,
         physical_rank=_PHYSICAL_RANK,
     ).config_for(_NUM_TOKENS)
-    # The triton provider serves the route-major domain only; the plan's
-    # families run on either domain, so the same plan drives both vendors.
-    rows = "route_major" if vendor == "triton" else choice.base_gemm_rows
-    provider_cls = MoeLoraRunner.select_provider_cls(rows, vendor)
+    provider_cls = select_provider_cls(choice.base_gemm_rows, "bf16", vendor)
     provider = provider_cls(
         MoeLoraBf16QuantInfo(
             w13_weight=gpu["w13_weight"],

--- a/test/registered/unit/lora/test_moe_lora_token_dense_a.py
+++ b/test/registered/unit/lora/test_moe_lora_token_dense_a.py
@@ -1,0 +1,56 @@
+"""The token_dense LoRA-A family: one batched GEMM over the token domain for
+every resident adapter slot, written as one bridge plane per slot."""
+
+import unittest
+
+import torch
+
+from sglang.srt.lora.moe.execution_plan import (
+    BridgeLayout,
+    LoraAFamily,
+    LoraASpec,
+    Site,
+)
+from sglang.srt.lora.moe.kernels.lora_a import run_lora_a
+from sglang.srt.lora.moe.route_view import RouteView, RouteViewKind
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-c-test-cpu")
+
+
+class TestTokenDenseLoraA(unittest.TestCase):
+    def test_matches_a_per_slot_matmul(self):
+        torch.manual_seed(0)
+        slots, tokens, hidden, rank2 = 3, 5, 16, 8
+        hidden_states = torch.randn(tokens, hidden)
+        weight = torch.randn(slots, rank2, hidden)  # shared-outer: one factor per slot
+        output = torch.empty(slots * tokens, rank2)
+        route = RouteView(
+            view=RouteViewKind.RAW,
+            block_size=16,
+            topk_ids=torch.zeros(tokens, 2, dtype=torch.int32),
+            token_lora_mapping=torch.zeros(tokens, dtype=torch.int32),
+            num_local_experts=4,
+            is_shared_outer=True,
+            max_loras=slots,
+        )
+        spec = LoraASpec(
+            Site.GATE_UP,
+            LoraAFamily.TOKEN_DENSE,
+            is_shared_outer=True,
+            output_layout=BridgeLayout.TOKEN_MAJOR,
+        )
+        out = run_lora_a(
+            spec,
+            input=hidden_states,
+            weight=weight,
+            output=output,
+            routing=route,
+            config={},
+        )
+        expected = torch.stack([hidden_states @ weight[s].T for s in range(slots)])
+        torch.testing.assert_close(out.view(slots, tokens, rank2), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -554,7 +554,7 @@ class TestLoraMoeRunnerBackendArgs(unittest.TestCase):
         # silently corrupting routes.
         server_args = ServerArgs(
             model_path="dummy",
-            moe_runner_backend="lora",
+            moe_runner_backend="lora_cutedsl",
             enable_lora=True,
             enable_pdmux=True,
         )
@@ -572,7 +572,7 @@ class TestLoraMoeRunnerBackendArgs(unittest.TestCase):
         self.assertEqual(server_args.moe_runner_backend, "auto")
 
     def test_requires_enable_lora(self):
-        server_args = ServerArgs(model_path="dummy", moe_runner_backend="lora")
+        server_args = ServerArgs(model_path="dummy", moe_runner_backend="lora_cutedsl")
 
         with self.assertRaisesRegex(ValueError, "requires --enable-lora"):
             server_args.check_lora_server_args()
@@ -580,7 +580,7 @@ class TestLoraMoeRunnerBackendArgs(unittest.TestCase):
     def test_rejects_two_batch_overlap(self):
         server_args = ServerArgs(
             model_path="dummy",
-            moe_runner_backend="lora",
+            moe_runner_backend="lora_cutedsl",
             enable_lora=True,
             enable_two_batch_overlap=True,
         )
@@ -2379,44 +2379,56 @@ class TestDcpKvEventContract(CustomTestCase):
 
 
 class TestLoraMoeRunnerBackendGuards(unittest.TestCase):
-    """Startup guards for --moe-runner-backend lora."""
+    """Startup guards for the lora_* MoE runner backends."""
 
     def test_rejects_speculative_selection(self):
         server_args = ServerArgs(
             model_path="dummy",
             speculative_algorithm="EAGLE",
-            speculative_moe_runner_backend="lora",
+            speculative_moe_runner_backend="lora_cutedsl",
         )
         with self.assertRaisesRegex(ValueError, "speculative-moe-runner-backend"):
             server_args.check_lora_server_args()
 
     def test_speculative_value_ignored_without_speculative_decoding(self):
-        # The field inherits the target runner when unset, so it reads "lora"
-        # on every LoRA server; only an actual draft model makes it meaningful.
+        # The field inherits the target runner when unset, so it reads the
+        # lora_* name on every LoRA server; only an actual draft model makes
+        # it meaningful.
         server_args = ServerArgs(
             model_path="dummy",
-            moe_runner_backend="lora",
+            moe_runner_backend="lora_cutedsl",
             enable_lora=True,
             max_lora_rank=16,
             lora_target_modules=["gate_up_proj", "down_proj"],
-            speculative_moe_runner_backend="lora",
+            speculative_moe_runner_backend="lora_cutedsl",
         )
         server_args.check_lora_server_args()
 
-    def test_rejects_quantized_moe(self):
+    def test_rejects_unsupported_quantization(self):
         server_args = ServerArgs(
             model_path="dummy",
-            moe_runner_backend="lora",
+            moe_runner_backend="lora_cutedsl",
             enable_lora=True,
-            quantization="fp8",
+            quantization="awq",
         )
         with self.assertRaisesRegex(ValueError, "unquantized"):
+            server_args.check_lora_server_args()
+
+        for quantization in (None, "fp8", "modelopt_fp4"):
+            server_args = ServerArgs(
+                model_path="dummy",
+                moe_runner_backend="lora_cutedsl",
+                enable_lora=True,
+                max_lora_rank=16,
+                lora_target_modules=["gate_up_proj", "down_proj"],
+                quantization=quantization,
+            )
             server_args.check_lora_server_args()
 
     def test_rejects_non_standard_dispatch(self):
         server_args = ServerArgs(
             model_path="dummy",
-            moe_runner_backend="lora",
+            moe_runner_backend="lora_cutedsl",
             enable_lora=True,
             moe_a2a_backend="deepep",
         )

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -546,6 +546,49 @@ class TestMambaCacheStochasticRounding(unittest.TestCase):
             server_args._handle_mamba_backend()
 
 
+class TestLoraMoeRunnerBackendArgs(unittest.TestCase):
+    def test_rejects_pdmux(self):
+        # The MoE LoRA fused-align routing scratch is cached per
+        # (device, num_buckets); PDMux runs prefill and decode concurrently on
+        # separate streams, so the combination must fail at startup instead of
+        # silently corrupting routes.
+        server_args = ServerArgs(
+            model_path="dummy",
+            moe_runner_backend="lora",
+            enable_lora=True,
+            enable_pdmux=True,
+        )
+
+        with self.assertRaisesRegex(ValueError, "PD-multiplexing"):
+            server_args.check_lora_server_args()
+
+    def test_pdmux_allowed_with_other_moe_runner_backends(self):
+        server_args = ServerArgs(
+            model_path="dummy",
+            enable_pdmux=True,
+        )
+
+        server_args.check_lora_server_args()
+        self.assertEqual(server_args.moe_runner_backend, "auto")
+
+    def test_requires_enable_lora(self):
+        server_args = ServerArgs(model_path="dummy", moe_runner_backend="lora")
+
+        with self.assertRaisesRegex(ValueError, "requires --enable-lora"):
+            server_args.check_lora_server_args()
+
+    def test_rejects_two_batch_overlap(self):
+        server_args = ServerArgs(
+            model_path="dummy",
+            moe_runner_backend="lora",
+            enable_lora=True,
+            enable_two_batch_overlap=True,
+        )
+
+        with self.assertRaisesRegex(ValueError, "two-batch overlap"):
+            server_args.check_lora_server_args()
+
+
 class TestLoadBalanceMethod(unittest.TestCase):
     def _load_balance_args(self, **kwargs):
         server_args = ServerArgs(model_path="dummy", **kwargs)
@@ -2333,6 +2376,52 @@ class TestDcpKvEventContract(CustomTestCase):
         # paged, at dcp_size.
         args = ServerArgs(model_path="dummy", tp_size=8, dcp_size=8, page_size=1)
         self.assertEqual(args.kv_event_block_size, 8)
+
+
+class TestLoraMoeRunnerBackendGuards(unittest.TestCase):
+    """Startup guards for --moe-runner-backend lora."""
+
+    def test_rejects_speculative_selection(self):
+        server_args = ServerArgs(
+            model_path="dummy",
+            speculative_algorithm="EAGLE",
+            speculative_moe_runner_backend="lora",
+        )
+        with self.assertRaisesRegex(ValueError, "speculative-moe-runner-backend"):
+            server_args.check_lora_server_args()
+
+    def test_speculative_value_ignored_without_speculative_decoding(self):
+        # The field inherits the target runner when unset, so it reads "lora"
+        # on every LoRA server; only an actual draft model makes it meaningful.
+        server_args = ServerArgs(
+            model_path="dummy",
+            moe_runner_backend="lora",
+            enable_lora=True,
+            max_lora_rank=16,
+            lora_target_modules=["gate_up_proj", "down_proj"],
+            speculative_moe_runner_backend="lora",
+        )
+        server_args.check_lora_server_args()
+
+    def test_rejects_quantized_moe(self):
+        server_args = ServerArgs(
+            model_path="dummy",
+            moe_runner_backend="lora",
+            enable_lora=True,
+            quantization="fp8",
+        )
+        with self.assertRaisesRegex(ValueError, "unquantized"):
+            server_args.check_lora_server_args()
+
+    def test_rejects_non_standard_dispatch(self):
+        server_args = ServerArgs(
+            model_path="dummy",
+            moe_runner_backend="lora",
+            enable_lora=True,
+            moe_a2a_backend="deepep",
+        )
+        with self.assertRaisesRegex(ValueError, "Standard dispatch"):
+            server_args.check_lora_server_args()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

MoE (expert-weight) LoRA serving in SGLang currently runs through the experimental TRT-LLM path (`--moe-runner-backend experimental_sgl_trtllm` + virtual experts). That path has three structural limits:

- **Blackwell-only**: the trtllm-gen kernels require SM100/120, so Hopper has no expert-LoRA path through it at all.
- **Virtual-expert routing scales with `max_loras_per_batch x num_experts`**, so multi-adapter serving degrades as slot capacity grows.
- **No prefill CUDA graphs under LoRA**, and no support for shared-outer adapter factors (gate_up A / down B shared across experts, `expert_dim=1` — the native format of several recent MoE adapters).

This PR adds a self-contained MoE-LoRA execution engine selected with `--moe-runner-backend lora`, built from a kernel/fusion/overlap sweep on GB300, B200 and H200 across three models (Qwen3.5-35B-A3B, Qwen3.5-397B-A17B, Inkling-Small; per-expert and shared-outer adapters, ranks 16/32).

## Modifications

- **Engine** (`python/sglang/srt/lora/moe/`): adapters ride the base expert GEMMs instead of the virtual-experts fused path. Providers own the base stages (prepare / gate_up / activation / down / finalize) over two row domains — masked `[E, m_max, K]` slabs for decode, flat aligned segments for prefill. LoRA deltas fuse into the stage seams: the gate_up delta lands pre-SwiGLU inside the activation kernel, down-B rides the base GEMM, finalize merges routed scaling. Per-expert and shared-outer factor layouts; routing cost scales with *active* adapters, not slot capacity.
- **Base-GEMM vendors** behind `--moe-lora-base-gemm`: `cutedsl` (default, SM90 + SM100 dual-stage packed-schedule kernels), `deepgemm`, and a route-major `triton` arm.
- **JSON config resolution** (`lora/moe/configs/{gb300,h200,default}.{plans,tiles}.json`): every kernel-family / fusion / overlap / tile decision is data, resolved per (layout, phase, activation, rank band, geometry) through ordered first-match rows with fail-closed validation — a malformed row or an unknown field aborts startup instead of silently serving a wrong plan. `SGLANG_LORA_MOE_CONFIG_DIR` points at an override root. Unknown architectures fall to a conservative serial fallback (`default.*`).
- **Prefill CUDA graphs under MoE LoRA** (breakable backend) with graph-stable LoRA workspaces, plus side-stream overlap windows for the shared-outer decode path.
- **Onboarding tuner** (`benchmark/kernels/lora_moe/tune_lora_config.py`): `--check` (CI-gateable coverage report), `--emit-seed` (serve a new geometry immediately), `--sweep` (e2e-tunes the geometry-sensitive axes and writes the winners back into the seed).
- **Guards**: the backend fails closed at startup on DP-attention with `dp_size > 1`, elastic EP, EPLB / non-trivial expert placement, non-Standard dispatch, PD-multiplexing, two-batch overlap, and speculative selection.

Nothing outside the new module changes behavior unless `--moe-runner-backend lora` is passed.

Scope: **bf16 serving path only**. FP8 and NVFP4 expert-LoRA support is a follow-up commit on this PR (not yet pushed).

## Accuracy Tests

- `test/registered/unit/lora/`: **227 passed + 12 subtests** (GB300, SM100) — config-resolution pins, kernel numerics against fp32 oracles, plan-contract validation, and prefill graph-vs-eager checks.
- Greedy-decode correctness on real adapters: against the `deepgemm` vendor the two paths are **bit-identical** (max abs delta 0, 100% token agreement). Against the legacy triton reference, adapter-row prompt-logprob deltas sit **below the no-adapter control band** on every arm (e.g. Qwen3.5-35B per-expert r16: 0.095 vs a 0.18 control band) — the engine adds no divergence beyond base-implementation bf16 noise.

## Speed Tests and Profiling

Protocol: `bench_one_batch_server`, input 4096 / output 1024, bs 1/8/16/32, `max_loras_per_batch=4` distinct resident adapters (round-robin per request), medians after first-pass discard. Baseline = the experimental TRT-LLM LoRA path at its strongest posture (virtual experts + full opt env set + prefill-graph gate lift where it applies).

### B200 (8x B200) — both engines measured on the same box, same session

Delta = ours vs TRT-LLM, **prefill % / decode %**:

| arm | bs1 | bs8 | bs16 | bs32 |
|---|---|---|---|---|
| Qwen3.5-35B per-expert r16 (TP4) | +23.9 / **+5.2** | +21.4 / **+4.5** | +20.7 / **+5.5** | +21.1 / -1.5 |
| Qwen3.5-35B shared-outer r16 (TP4) | +23.1 / **+6.9** | +16.3 / **+11.8** | +17.5 / **+11.8** | +16.7 / **+7.6** |
| Qwen3.5-397B shared-outer r16 (TP8) | -18.7 / **+4.8** | +17.8 / **+6.4** | +16.7 / **+2.7** | +16.3 / **+1.7** |
| Inkling-Small shared-outer r32 (TP4) | -25.2 / **+11.9** | +2.8 / **+7.6** | +2.9 / **+4.9** | +3.5 / **+0.9** |

Decode: ours wins 15 of 16 cells (the single loss, -1.5%, is inside the wash band). Prefill: ours wins every batched cell by 16-24% — this is the prefill-CUDA-graph gap, which the incumbent path cannot close because it cannot capture prefill graphs under LoRA. The two bs1 prefill losses are the known single-chunk case on the big-hidden models (one 4k prompt, no batching); they are negligible e2e, where 1024 decode steps dominate.

### GB300 (4x GB300, TP4)

Same delta format, ours vs TRT-LLM:

| arm | bs1 | bs8 | bs16 | bs32 |
|---|---|---|---|---|
| Qwen3.5-35B per-expert r16 | +10.4 / +3.8 | +12.4 / +3.4 | +14.4 / +4.1 | +10.9 / -1.6 |
| Qwen3.5-397B per-expert r16 | +17.4 / -2.2 | +26.6 / +0.5 | +47.1 / -2.1 | +40.5 / -1.7 |
| Inkling-Small shared-outer r32 | +14.6 / **+11.9** | +15.5 / **+7.8** | +15.9 / **+4.6** | +15.6 / **+0.5** |

These are the conservative pairing: both arms were measured at an engine commit slightly older than this branch, and a re-measurement of all 112 cells at the squashed branch came back at or above them (mean +1.4%, max +13.1%, two cells below a -2% band).

### H200 (8x H200)

The incumbent's own kernels **cannot run on Hopper** — `experimental_sgl_trtllm` dies at launch with "No supported CUDA architectures found for major versions [10, 12]". Against the only runnable incumbent (legacy engine + virtual experts on the standard triton fused-MoE path, full opt env set, fa4), on Inkling-Small: decode **+19.7 / +10.3 / +1.7 / +4.1%** at bs 1/8/16/32, prefill +1.0-1.5% at bs>=8 and -13.3% at bs1.

Against the same-node **no-LoRA base** (retention — the ceiling any LoRA path chases): Qwen3.5-35B decode 83-89%, prefill 83% at bs>=8; Qwen3.5-397B decode 76-87%, prefill 80% at bs>=8. On this architecture Qwen3.5-397B expert LoRA is servable at all only through the route-major and shared-rank paths this PR adds.

### Caveat on the Inkling decode rows

Those rows run the model's routed/shared sink expert on parallel streams **for both engines**, which is the posture the model is meant to serve in. It is an opt-in today (`SGLANG_OPT_USE_INKLING_MULTI_STREAM_OVERLAP=1`), and reaching it from this engine needs a model-side veto change that ships separately. With the sink serialized instead, our Inkling decode trails the incumbent by 8-15% — a shipping-order artifact rather than an engine gap, and exactly what that separate change removes.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
