### PR TITLE
[bugfix] fix prefill delayer releasing prefill before max_delay_ms

### DIFF
--- a/python/sglang/srt/managers/prefill_delayer.py
+++ b/python/sglang/srt/managers/prefill_delayer.py
@@ -249,9 +249,10 @@ class PrefillDelayer:
             # and fragment prefill into many tiny batches.
             queue_condition = False
             if self._queue_trigger_enabled and global_running_batch_max > 0:
-                queue_min_effective = min(
-                    int(global_running_batch_max * self._queue_min_ratio),
-                    global_max_prefill_bs_max,
+                # queue_min must not be capped by max_prefill_bs: the tracker
+                # high-watermark can collapse while a delay is active and end it early.
+                queue_min_effective = int(
+                    global_running_batch_max * self._queue_min_ratio
                 )
                 queue_condition = (
                     queue_min_effective > 0
@@ -268,15 +269,25 @@ class PrefillDelayer:
             )
 
             if slot_condition or queue_condition:
-                # When the "max_decode_bs - running_bs < max_prefill_bs" condition is met,
-                # the first merge_batch causes the decoding to fail to reach the maximum batch size.
-                if self.skip_first_delayer:
+                # One-shot bypass is specific to the slot-condition merge concern;
+                # the queue trigger must delay from the very first batch.
+                if self.skip_first_delayer and slot_condition:
                     self.skip_first_delayer = False
                     pass
+                elif queue_condition:
+                    # Queue-triggered delay is bounded by the wall-clock
+                    # max_delay_ms only (queue_condition is cleared once
+                    # elapsed >= max_delay_ms), not by max_delay_passes.
+                    next_state = prev_state or _State()
+                    next_state = next_state.bump_delayed_count()
+                    return _NegotiateOutput(
+                        next_state=next_state,
+                        output_allow=False,
+                        output_reason="delay",
+                        **debug_info,
+                    )
                 else:
-                    # Bound the wait like the "mixed" branch: on a saturated
-                    # engine slot_condition may never turn false, so cap the
-                    # delay by max_delay_passes.
+                    # slot condition only: cap the delay by max_delay_passes.
                     prev_delayed_count = prev_state.delayed_count if prev_state else 0
                     if prev_delayed_count < self._max_delay_passes - 1:
                         next_state = prev_state or _State()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

The prefill delayer's queue-based trigger (`--prefill-delayer-queue-min-ratio`) was releasing below-threshold prefills far earlier than the configured `--prefill-delayer-max-delay-ms` (5000ms): measured request latency was ~450-670ms instead of >5000ms, failing `test_below_threshold_hits_max_delay` ("delay released too early").

## Modifications

<!-- Detail the changes made in this pull request. -->

- `python/sglang/srt/managers/prefill_delayer.py`

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

N/A — scheduler-only change; model forward path and generated outputs are unaffected.

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

NPU (Ascend 910) end-to-end test test/registered/npu/basic_function/memory_and_scheduling/test_npu_prefill_delayer_max_delay.py (Qwen3-0.6B, --prefill-delayer-queue-min-ratio 0.8 --prefill-delayer-max-delay-ms 5000)
 Existing unit tests pass: test/registered/scheduler/test_prefill_delayer.py::TestPrefillDelayerNegotiate and test/registered/unit/managers/test_prefill_delayer_high_watermark.py (5 cases). No regression test case was added in this PR; existing suite covers the negotiation paths (can be extended on request).

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32013083847](https://github.com/sgl-project/sglang/actions/runs/32013083847)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32013083643](https://github.com/sgl-project/sglang/actions/runs/32013083643)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->