### PR TITLE
Fix mamba checkpoint depth under dcp

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import math
+
 from sglang.srt.dllm.config import DllmConfig
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.runtime_context import (
@@ -8,7 +10,6 @@ from sglang.srt.runtime_context import (
     get_serving,
     get_spec,
     mamba_cache_chunk_size,
-    mamba_checkpoint_grid,
     mamba_extra_buffer_enabled,
     mamba_extra_buffer_lazy_enabled,
 )
@@ -2631,9 +2632,10 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         req: Req,
     ) -> _MambaRadixCacheV2TrackEntry:
         chunk_size = mamba_cache_chunk_size()
-        # The donated depth has to be a radix node boundary, which DCP widens past
-        # chunk_size; the kernel still snapshots on the chunk_size grid.
-        checkpoint_grid = mamba_checkpoint_grid()
+        # The donated depth has to be a radix node boundary. Read the tree's own
+        # page rather than re-deriving how DCP widens it; the kernel still
+        # snapshots on the chunk_size grid.
+        checkpoint_grid = math.lcm(chunk_size, self.tree_cache.page_size)
 
         def _force_track_h(i: int) -> int:
             assert i % chunk_size == 0

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -8,6 +8,7 @@ from sglang.srt.runtime_context import (
     get_serving,
     get_spec,
     mamba_cache_chunk_size,
+    mamba_checkpoint_grid,
     mamba_extra_buffer_enabled,
     mamba_extra_buffer_lazy_enabled,
 )
@@ -2630,6 +2631,9 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         req: Req,
     ) -> _MambaRadixCacheV2TrackEntry:
         chunk_size = mamba_cache_chunk_size()
+        # The donated depth has to be a radix node boundary, which DCP widens past
+        # chunk_size; the kernel still snapshots on the chunk_size grid.
+        checkpoint_grid = mamba_checkpoint_grid()
 
         def _force_track_h(i: int) -> int:
             assert i % chunk_size == 0
@@ -2642,7 +2646,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             # to force the math calculation to retrieve the correct mamba state from h.
             return i + 1
 
-        mask = req.extend_range.length >= chunk_size
+        mask = req.extend_range.length >= checkpoint_grid
         track_index = req.mamba_ping_pong_track_buffer[req.mamba_next_track_idx].item()
         mamba_track_seqlen = -1
         if mask:
@@ -2659,13 +2663,13 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             # mamba radix cache to track which seqlen this mamba state should store at.
             mamba_track_seqlen_aligned = (
                 len(req.prefix_indices)
-                + (req.extend_range.length // chunk_size) * chunk_size
+                + (req.extend_range.length // checkpoint_grid) * checkpoint_grid
             )
 
             # mamba_track_fla_chunk_aligned is the aligned seqlen based on chunk_size
-            # If mamba_track_fla_chunk_aligned != mamba_track_seqlen_aligned, which can be true when
-            # page_size > chunk_size, we need to force the math calculation to retrieve the correct mamba state from h
-            # by _force_track_h()
+            # If mamba_track_fla_chunk_aligned != mamba_track_seqlen_aligned, which is true when
+            # checkpoint_grid is coarser than chunk_size, we need to force the math calculation to
+            # retrieve the correct mamba state from h by _force_track_h()
             mamba_track_fla_chunk_aligned = (
                 len(req.prefix_indices)
                 + (req.extend_range.length // chunk_size) * chunk_size

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import math
-
 from sglang.srt.dllm.config import DllmConfig
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.runtime_context import (
@@ -10,6 +8,7 @@ from sglang.srt.runtime_context import (
     get_serving,
     get_spec,
     mamba_cache_chunk_size,
+    mamba_checkpoint_grid,
     mamba_extra_buffer_enabled,
     mamba_extra_buffer_lazy_enabled,
 )
@@ -2635,7 +2634,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         # The donated depth has to be a radix node boundary. Read the tree's own
         # page rather than re-deriving how DCP widens it; the kernel still
         # snapshots on the chunk_size grid.
-        checkpoint_grid = math.lcm(chunk_size, self.tree_cache.page_size)
+        checkpoint_grid = mamba_checkpoint_grid(self.tree_cache.page_size)
 
         def _force_track_h(i: int) -> int:
             assert i % chunk_size == 0

--- a/python/sglang/srt/mem_cache/unified_cache/components/mamba_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/mamba_component.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+import math
 from collections import defaultdict
 from typing import TYPE_CHECKING, Callable, Optional, Sequence
 
@@ -38,8 +40,10 @@ from sglang.srt.mem_cache.unified_cache.components.tree_component import (
 from sglang.srt.runtime_context import (
     get_exec,
     mamba_cache_chunk_size,
-    mamba_checkpoint_grid,
 )
+
+logger = logging.getLogger(__name__)
+
 
 if TYPE_CHECKING:
     from sglang.srt.managers.schedule_batch import Req
@@ -70,7 +74,28 @@ class MambaComponent(TreeComponent):
             ), f"MambaComponent requires page_size=1 when mamba_extra_buffer is disabled, got {params.page_size}"
         super().__init__(cache, params)
         self.mamba_cache_chunk_size = mamba_cache_chunk_size()
-        self.mamba_checkpoint_grid = mamba_checkpoint_grid()
+        # params.page_size is the tree page the allocator actually uses, already
+        # widened by dcp_size, so it is the one grid a checkpoint depth can land on.
+        self.mamba_checkpoint_grid = math.lcm(
+            self.mamba_cache_chunk_size, params.page_size
+        )
+        track_interval = get_exec().mamba.mamba_track_interval
+        assert track_interval % self.mamba_checkpoint_grid == 0, (
+            f"--mamba-track-interval must be a multiple of "
+            f"{self.mamba_checkpoint_grid}, the lcm of the mamba chunk size and the "
+            f"tree page, or a decode checkpoint lands where no node can carry it. "
+            f"Got {track_interval} with page_size={params.page_size}."
+        )
+        if (
+            params.chunked_prefill_size is not None
+            and 0 < params.chunked_prefill_size < self.mamba_checkpoint_grid
+        ):
+            logger.warning(
+                "chunked_prefill_size=%s is smaller than the mamba checkpoint grid "
+                "%s, so chunked-prefill handoffs will not checkpoint at all.",
+                params.chunked_prefill_size,
+                self.mamba_checkpoint_grid,
+            )
         self.mamba_max_states_per_path = get_exec().mamba.mamba_max_states_per_path
         # HiCache state
         self._mamba_pool_host = None  # set to host mamba pool when HiCache enabled

--- a/python/sglang/srt/mem_cache/unified_cache/components/mamba_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/mamba_component.py
@@ -38,6 +38,7 @@ from sglang.srt.mem_cache.unified_cache.components.tree_component import (
 from sglang.srt.runtime_context import (
     get_exec,
     mamba_cache_chunk_size,
+    mamba_checkpoint_grid,
 )
 
 if TYPE_CHECKING:
@@ -69,6 +70,7 @@ class MambaComponent(TreeComponent):
             ), f"MambaComponent requires page_size=1 when mamba_extra_buffer is disabled, got {params.page_size}"
         super().__init__(cache, params)
         self.mamba_cache_chunk_size = mamba_cache_chunk_size()
+        self.mamba_checkpoint_grid = mamba_checkpoint_grid()
         self.mamba_max_states_per_path = get_exec().mamba.mamba_max_states_per_path
         # HiCache state
         self._mamba_pool_host = None  # set to host mamba pool when HiCache enabled
@@ -164,8 +166,8 @@ class MambaComponent(TreeComponent):
         # persistence of a new branching state is currently write-through only;
         # write-back eviction may discard the device-only state.
         aligned_seqlen = (
-            result.full_kv_hit_length // self.mamba_cache_chunk_size
-        ) * self.mamba_cache_chunk_size
+            result.full_kv_hit_length // self.mamba_checkpoint_grid
+        ) * self.mamba_checkpoint_grid
         branching_seqlen = (
             aligned_seqlen if aligned_seqlen > mamba_boundary_len else None
         )

--- a/python/sglang/srt/mem_cache/unified_cache/components/mamba_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/mamba_component.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 import math
 from collections import defaultdict
 from typing import TYPE_CHECKING, Callable, Optional, Sequence
@@ -42,9 +41,6 @@ from sglang.srt.runtime_context import (
     mamba_cache_chunk_size,
 )
 
-logger = logging.getLogger(__name__)
-
-
 if TYPE_CHECKING:
     from sglang.srt.managers.schedule_batch import Req
     from sglang.srt.mem_cache.cache_init_params import CacheInitParams
@@ -79,23 +75,6 @@ class MambaComponent(TreeComponent):
         self.mamba_checkpoint_grid = math.lcm(
             self.mamba_cache_chunk_size, params.page_size
         )
-        track_interval = get_exec().mamba.mamba_track_interval
-        assert track_interval % self.mamba_checkpoint_grid == 0, (
-            f"--mamba-track-interval must be a multiple of "
-            f"{self.mamba_checkpoint_grid}, the lcm of the mamba chunk size and the "
-            f"tree page, or a decode checkpoint lands where no node can carry it. "
-            f"Got {track_interval} with page_size={params.page_size}."
-        )
-        if (
-            params.chunked_prefill_size is not None
-            and 0 < params.chunked_prefill_size < self.mamba_checkpoint_grid
-        ):
-            logger.warning(
-                "chunked_prefill_size=%s is smaller than the mamba checkpoint grid "
-                "%s, so chunked-prefill handoffs will not checkpoint at all.",
-                params.chunked_prefill_size,
-                self.mamba_checkpoint_grid,
-            )
         self.mamba_max_states_per_path = get_exec().mamba.mamba_max_states_per_path
         # HiCache state
         self._mamba_pool_host = None  # set to host mamba pool when HiCache enabled

--- a/python/sglang/srt/mem_cache/unified_cache/components/mamba_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/mamba_component.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import math
 from collections import defaultdict
 from typing import TYPE_CHECKING, Callable, Optional, Sequence
 
@@ -39,6 +38,7 @@ from sglang.srt.mem_cache.unified_cache.components.tree_component import (
 from sglang.srt.runtime_context import (
     get_exec,
     mamba_cache_chunk_size,
+    mamba_checkpoint_grid,
 )
 
 if TYPE_CHECKING:
@@ -72,9 +72,7 @@ class MambaComponent(TreeComponent):
         self.mamba_cache_chunk_size = mamba_cache_chunk_size()
         # params.page_size is the tree page the allocator actually uses, already
         # widened by dcp_size, so it is the one grid a checkpoint depth can land on.
-        self.mamba_checkpoint_grid = math.lcm(
-            self.mamba_cache_chunk_size, params.page_size
-        )
+        self.mamba_checkpoint_grid = mamba_checkpoint_grid(params.page_size)
         self.mamba_max_states_per_path = get_exec().mamba.mamba_max_states_per_path
         # HiCache state
         self._mamba_pool_host = None  # set to host mamba pool when HiCache enabled

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -48,6 +48,7 @@ from __future__ import annotations
 
 import dataclasses
 import functools
+import math
 import os
 import sys
 from contextlib import contextmanager
@@ -1433,6 +1434,14 @@ def mamba_cache_chunk_size() -> int:
     """The caching point granularity for mamba state: ``max(the model's mamba
     chunk size, page_size)``. Cached on the config after the first call."""
     return get_server_args().mamba_cache_chunk_size
+
+
+def mamba_checkpoint_grid(tree_page: int) -> int:
+    """The granularity a donated mamba checkpoint's depth must land on so the
+    radix tree can name it. Pass the page the tree actually allocates on: DCP
+    widens it past ``mamba_cache_chunk_size``, and deriving that here would be a
+    second copy of a predicate that already lives in the cache builder."""
+    return math.lcm(mamba_cache_chunk_size(), tree_page)
 
 
 def max_speculative_num_draft_tokens() -> int | None:

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -1435,13 +1435,6 @@ def mamba_cache_chunk_size() -> int:
     return get_server_args().mamba_cache_chunk_size
 
 
-def mamba_checkpoint_grid() -> int:
-    """The granularity a donated mamba checkpoint's depth must land on so the
-    radix tree can name it: ``lcm(mamba_cache_chunk_size, tree page)``. Equal to
-    ``mamba_cache_chunk_size`` unless DCP widens the tree page."""
-    return get_server_args().mamba_checkpoint_grid
-
-
 def max_speculative_num_draft_tokens() -> int | None:
     """The largest draft-token count speculative decoding may use.
 

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -1435,6 +1435,13 @@ def mamba_cache_chunk_size() -> int:
     return get_server_args().mamba_cache_chunk_size
 
 
+def mamba_checkpoint_grid() -> int:
+    """The granularity a donated mamba checkpoint's depth must land on so the
+    radix tree can name it: ``lcm(mamba_cache_chunk_size, tree page)``. Equal to
+    ``mamba_cache_chunk_size`` unless DCP widens the tree page."""
+    return get_server_args().mamba_checkpoint_grid
+
+
 def max_speculative_num_draft_tokens() -> int | None:
     """The largest draft-token count speculative decoding may use.
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -8985,15 +8985,6 @@ class ServerArgs:
             self._mamba_cache_chunk_size = max(chunk_size, page_size)
         return self._mamba_cache_chunk_size
 
-    @property
-    def mamba_checkpoint_grid(self) -> int:
-        # A donated mamba state is only reusable at a depth the tree can name. DCP
-        # widens the page past chunk_size, so a checkpoint picked on the finer grid
-        # gets attached to a shallower node than the tokens it already covers.
-        page_size = resolved_view(self).page_size
-        tree_page = page_size * self.dcp_size if self.dcp_size > 1 else page_size
-        return math.lcm(self.mamba_cache_chunk_size, tree_page)
-
     def _check_two_batch_overlap(self):
         # With no EP a2a backend, two-batch-overlap is only valid on the non-EP
         # DP TP-MoE path (overlapping the DP all_gatherv / reduce_scatterv with

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -8985,6 +8985,15 @@ class ServerArgs:
             self._mamba_cache_chunk_size = max(chunk_size, page_size)
         return self._mamba_cache_chunk_size
 
+    @property
+    def mamba_checkpoint_grid(self) -> int:
+        # A donated mamba state is only reusable at a depth the tree can name. DCP
+        # widens the page past chunk_size, so a checkpoint picked on the finer grid
+        # gets attached to a shallower node than the tokens it already covers.
+        page_size = resolved_view(self).page_size
+        tree_page = page_size * self.dcp_size if self.dcp_size > 1 else page_size
+        return math.lcm(self.mamba_cache_chunk_size, tree_page)
+
     def _check_two_batch_overlap(self):
         # With no EP a2a backend, two-batch-overlap is only valid on the non-EP
         # DP TP-MoE path (overlapping the DP all_gatherv / reduce_scatterv with

--- a/test/registered/unit/managers/test_mamba_checkpoint_depth.py
+++ b/test/registered/unit/managers/test_mamba_checkpoint_depth.py
@@ -1,0 +1,74 @@
+"""The donated mamba checkpoint depth must land on the tree page.
+
+DCP widens the tree page past the mamba chunk grid. A checkpoint picked on the
+finer grid names a depth no radix node can carry, so it gets attached to the
+preceding node and a later request resumes from a state that already covers
+tokens past that node.
+"""
+
+import unittest
+from array import array
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import torch
+
+from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
+from sglang.srt.sampling.sampling_params import SamplingParams
+from sglang.srt.server_args import (
+    ServerArgs,
+    set_global_server_args_for_scheduler,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+CHUNK = 64
+
+
+def _track_seqlen(*, tree_page: int, prefix_len: int, extend_len: int) -> int:
+    """Run one extend through the tracker and report the donated depth."""
+    server_args = ServerArgs(model_path="dummy", page_size=CHUNK)
+    # The property would otherwise load the HF config for the dummy model.
+    server_args._mamba_cache_chunk_size = CHUNK
+    set_global_server_args_for_scheduler(server_args)
+
+    sampling_params = SamplingParams(max_new_tokens=1)
+    sampling_params.normalize(None)
+    req = Req(
+        rid="req",
+        origin_input_text="",
+        origin_input_ids=array("q", [1] * (prefix_len + extend_len)),
+        sampling_params=sampling_params,
+        vocab_size=128,
+    )
+    req.prefix_indices = torch.arange(prefix_len, dtype=torch.int64)
+    req.set_extend_range(prefix_len, prefix_len + extend_len)
+    req.mamba_ping_pong_track_buffer = torch.tensor([0, 1], dtype=torch.int64)
+    req.mamba_next_track_idx = 0
+    req.mamba_branching_seqlen = None
+
+    batch = ScheduleBatch(reqs=[req])
+    batch.tree_cache = SimpleNamespace(page_size=tree_page)
+    batch.req_to_token_pool = MagicMock()
+    batch.req_to_token_pool.get_mamba_ping_pong_other_idx.return_value = 1
+
+    batch._mamba_radix_cache_v2_req_prepare_for_extend(req)
+    return req.mamba_last_track_seqlen
+
+
+class TestMambaCheckpointDepth(unittest.TestCase):
+    def test_widened_tree_page_moves_the_donated_depth_onto_it(self):
+        # 4066 tokens past a 16384 prefix: the chunk grid would stop at 20416,
+        # which a 256-token page cannot name.
+        depth = _track_seqlen(tree_page=256, prefix_len=16384, extend_len=4066)
+        self.assertEqual(depth % 256, 0)
+        self.assertEqual(depth, 20224)
+
+    def test_unwidened_tree_page_keeps_the_chunk_grid(self):
+        depth = _track_seqlen(tree_page=CHUNK, prefix_len=16384, extend_len=4066)
+        self.assertEqual(depth, 20416)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -261,8 +261,18 @@ def _write_backup(cache, node, write_back: bool = False) -> int:
     )
 
 
-def build_fixture(cfg: CacheConfig, *, enable_kv_cache_events: bool = False):
-    """Create (tree, allocator, req_to_token_pool) from a CacheConfig."""
+def build_fixture(
+    cfg: CacheConfig,
+    *,
+    enable_kv_cache_events: bool = False,
+    tree_page_size: Optional[int] = None,
+    mamba_cache_chunk_size: Optional[int] = None,
+):
+    """Create (tree, allocator, req_to_token_pool) from a CacheConfig.
+
+    ``tree_page_size`` stands in for DCP, which widens the tree page past the
+    ``page_size`` the rest of the config still sees.
+    """
     server_args = ServerArgs(
         model_path="dummy",
         page_size=cfg.page_size,
@@ -271,7 +281,11 @@ def build_fixture(cfg: CacheConfig, *, enable_kv_cache_events: bool = False):
     # MambaRadixCache reads mamba_cache_chunk_size, whose property otherwise
     # loads the HF config for self.model_path — impossible for the dummy model.
     # Mirror the property's default for a dummy HF config: FLA_CHUNK_SIZE.
-    server_args._mamba_cache_chunk_size = max(FLA_CHUNK_SIZE, cfg.page_size)
+    server_args._mamba_cache_chunk_size = (
+        max(FLA_CHUNK_SIZE, cfg.page_size)
+        if mamba_cache_chunk_size is None
+        else mamba_cache_chunk_size
+    )
     set_global_server_args_for_scheduler(server_args)
     device = get_device()
 
@@ -372,7 +386,7 @@ def build_fixture(cfg: CacheConfig, *, enable_kv_cache_events: bool = False):
     cache_init_params = CacheInitParams(
         req_to_token_pool=req_to_token_pool,
         token_to_kv_pool_allocator=allocator,
-        page_size=cfg.page_size,
+        page_size=cfg.page_size if tree_page_size is None else tree_page_size,
         disable=False,
         sliding_window_size=cfg.sliding_window_size,
         tree_components=cfg.components,
@@ -5159,6 +5173,41 @@ class TestUnifiedMambaLRUMatchRefresh(CustomTestCase):
         order = self._mamba_lru_mru_to_lru(cache)
         self.assertIs(order[0], b1)
         self.assertGreater(order.index(a1), order.index(a2))
+
+
+class TestMambaCheckpointGrid(CustomTestCase):
+    """A donated mamba checkpoint is only reusable at a depth the tree can name.
+
+    ``tree_page_size`` simulates DCP: it widens the page the tree allocates on
+    while ``page_size`` and the mamba chunk grid stay where they are, which is
+    exactly the split that lets a checkpoint land between two node boundaries.
+    """
+
+    cfg = CacheConfig(
+        page_size=64,
+        components=(ComponentType.FULL, ComponentType.MAMBA),
+        enable_mamba_extra_buffer=True,
+        kv_size=1024,
+        max_context_len=1024,
+    )
+
+    def _grid(self, cache):
+        component = next(
+            c
+            for c in cache._components_tuple
+            if c.component_type is ComponentType.MAMBA
+        )
+        return component.mamba_checkpoint_grid
+
+    def test_grid_follows_the_widened_tree_page(self):
+        cache, _, _ = build_fixture(
+            self.cfg, tree_page_size=256, mamba_cache_chunk_size=64
+        )
+        self.assertEqual(self._grid(cache), 256)
+
+    def test_grid_is_the_chunk_size_without_widening(self):
+        cache, _, _ = build_fixture(self.cfg, mamba_cache_chunk_size=64)
+        self.assertEqual(self._grid(cache), 64)
 
 
 class TestUnifiedRadixCacheInt8MambaCheckpoint(CustomTestCase):

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -271,7 +271,9 @@ def build_fixture(
     """Create (tree, allocator, req_to_token_pool) from a CacheConfig.
 
     ``tree_page_size`` stands in for DCP, which widens the tree page past the
-    ``page_size`` the rest of the config still sees.
+    ``page_size`` the rest of the config still sees. It only reaches values
+    derived from the tree page: the allocator keeps ``cfg.page_size``, whereas
+    DCP sets the two equal, so do not read insert or match behaviour off it.
     """
     server_args = ServerArgs(
         model_path="dummy",


### PR DESCRIPTION
## Motivation

DCP sets the radix tree page to `page_size * dcp_size`, but the mamba prefill tracker still picks its checkpoint on `mamba_cache_chunk_size`. When those two grids differ, the donated state names a depth the tree cannot represent, so it gets attached to the preceding node. A later request that hits that node resumes with a recurrent state which already covers tokens beyond the node, and those tokens go through the linear attention layers a second time. On Kimi-Linear with `--dcp-size 8 --page-size 64` the state is picked at 20416 while the deepest node its key can represent is 19968, and the 448 tokens in between get double counted.

The fix picks the donation depth on `lcm(mamba_cache_chunk_size, tree page)` and leaves the kernel snapshot grid on `mamba_cache_chunk_size`. This is what makes `mamba_track_fla_chunk_aligned` differ from `mamba_track_seqlen_aligned` for the first time, so the existing `_force_track_h` path fires and the state is read from `h` at the coarser boundary. Both quantities were computed with the identical expression before, so that branch was unreachable even though its comment says it exists for a page coarser than the chunk size.

Without DCP the grid is unchanged. `mamba_cache_chunk_size` is already `max(model chunk size, page_size)` and the assert next to it guarantees one divides the other, so the lcm is itself.

This is the upstream half of the same defect as https://github.com/sgl-project/sglang/pull/34760 and https://github.com/sgl-project/sglang/pull/34780, which reject a misaligned attachment at insert time. Those checks are still worth keeping as the invariant guard. With this change they should stop firing on the DCP prefill path, and the prefix reuse they give up is retained: `cached_tokens` stays at 19968 instead of falling back to the previous chunked prefill handoff at 16384.

Only the prefill donation depth changes here. Decode tracking keeps its own `--mamba-track-interval` grid.

## Accuracy

Cold versus warm teacher forced logprob comparison across a prefix cache resume. Cold scores the full sequence on an empty cache, warm flushes, prefills the prompt alone, then scores the full sequence again. Prompt 20450 tokens, query 21504, 1503 position window starting past the resume boundary, 3 rounds per config with identical results each round.

```bash
SGLANG_ENABLE_UNIFIED_RADIX_TREE=1 python -m sglang.launch_server \
  --model-path moonshotai/Kimi-Linear-48B-A3B-Instruct --trust-remote-code \
  --tp-size 8 --dcp-size 8 --page-size 64 \
  --mamba-radix-cache-strategy extra_buffer \
  --dcp-comm-backend a2a --dcp-replicate-q-proj \
  --disable-overlap-schedule --mem-fraction-static 0.85 --port 30000
```

```
main            cached=19968 n_cmp=1503 n>0.5=4 n>2=2 max|dlp|=5.0739 first_diff_pos=20011
this PR         cached=19968 n_cmp=1503 n>0.5=2 n>2=0 max|dlp|=0.5936 first_diff_pos=20806
no dcp          cached=19968 n_cmp=1503 n>0.5=1 n>2=0 max|dlp|=0.6724
main, prompt length already aligned to the widened page
                cached=20480 n_cmp= 991 n>0.5=0 n>2=0 max|dlp|=0.4075
```

The last row is the control that isolates the cause: with a prompt whose tracked depth already lands on a widened page boundary, main is correct without any change. Measured on cea16bf229 with the same change applied.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31779881664](https://github.com/sgl-project/sglang/actions/runs/31779881664)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #31779881534](https://github.com/sgl-project/sglang/actions/runs/31779881534)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->