### PR TITLE
fix(qwen3): support DeepEP-class backends and early EPLB state

### DIFF
--- a/python/sglang/srt/models/qwen3_moe.py
+++ b/python/sglang/srt/models/qwen3_moe.py
@@ -52,6 +52,7 @@ from sglang.srt.layers.moe.topk import TopK
 from sglang.srt.layers.moe.utils import (
     RoutingMethodType,
     filter_moe_weight_param_global_expert,
+    is_deepep_class_backend,
 )
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.layers.radix_attention import RadixAttention
@@ -284,7 +285,7 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
             prefix=add_prefix("gate", prefix),
         )
 
-        if get_moe_a2a_backend().is_deepep():
+        if is_deepep_class_backend():
             # TODO: we will support tp < ep in the future
             self.ep_size = get_parallel().moe_ep_size
             self.num_experts = (
@@ -299,8 +300,7 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
     ) -> torch.Tensor:
 
         if (
-            not get_moe_a2a_backend().is_deepep()
-            and not get_moe_a2a_backend().is_mori()
+            not is_deepep_class_backend()
             and not get_moe_a2a_backend().is_ascend_fuseep()
         ):
             return self.forward_normal(hidden_states)
@@ -965,6 +965,14 @@ class Qwen3MoeForCausalLM(nn.Module):
         )
         self.logits_processor = LogitsProcessor(config)
         self.capture_aux_hidden_states = False
+        # IPC loading bypasses load_weights(), so initialize the EPLB descriptor here.
+        self.routed_experts_weights_of_layer = LazyValue(
+            lambda: {
+                layer_id: self.model.layers[layer_id].mlp.get_moe_weights()
+                for layer_id in range(self.start_layer, self.end_layer)
+                if isinstance(self.model.layers[layer_id].mlp, Qwen3MoeSparseMoeBlock)
+            }
+        )
 
         self.attn_cp_size = get_parallel().attn_cp_size
         self.attn_cp_rank = get_parallel().attn_cp_rank


### PR DESCRIPTION
## Motivation

This PR adds two model-level compatibility paths to Qwen3 MoE for Mooncake EP and EPLB.

1. Mooncake implements the DeepEP-class MoE dispatch interface, but Qwen3 only checks `get_moe_a2a_backend().is_deepep()`. As a result, Qwen3 skips the DeepEP-class setup and forward path for Mooncake. DeepSeek's shared-expert fusion work consolidated this backend policy behind `is_deepep_class_backend()` in #20089, providing the model-level precedent for treating Mooncake as DeepEP-class.
2. EPLB consumes `routed_experts_weights_of_layer` as a model interface. Qwen3 now creates that `LazyValue` during construction so IPC weight-cache loading and the normal loader expose the same descriptor before either path completes. DeepSeek V2/V4 and several other MoE models use this constructor-time lifecycle; the weight-cache lifecycle and constructor-time model state are documented in #27139. `LazyValue` still postpones collecting tensor references until the first access.

## Modifications

- Add `is_deepep_class_backend()` to Qwen3 MoE's EP-specific setup and DeepEP-style forward path. This class includes Mooncake alongside the existing DeepEP-family backends.
- Add Qwen3's `routed_experts_weights_of_layer` `LazyValue` in `Qwen3MoeForCausalLM.__init__`, while retaining the guarded `load_weights()` fallback for subclasses that bypass the parent constructor.

## Accuracy Tests

- Eight-GPU Qwen3-30B-A3B-Instruct-2507-FP8 E2E with `TP=8`, `DP=8`, `EP=8`, `--moe-a2a-backend mooncake`, `--elastic-ep-backend mooncake`, and `--enable-eplb`:
  - Completion for `The capital of France is` returned `Paris`.
  - All eight EPLB managers started and completed repeated rebalances.

## Speed Tests and Profiling

NA

## Checklist

- [x] Format code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). No focused unit test is included: the lifecycle change is a direct constructor assignment with established model precedents.
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). No user-facing documentation is needed for this model-internal compatibility fix.
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31772278899](https://github.com/sgl-project/sglang/actions/runs/31772278899)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31772278605](https://github.com/sgl-project/sglang/actions/runs/31772278605)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->