### PR TITLE
test: restore GLM-4.1V nightly latency threshold

### DIFF
--- a/test/registered/eval/test_vlms_mmmu_eval.py
+++ b/test/registered/eval/test_vlms_mmmu_eval.py
@@ -47,7 +47,7 @@ MODEL_THRESHOLDS = {
     ),
     ModelLaunchSettings("unsloth/Mistral-Small-3.1-24B-Instruct-2503"): (0.30, 43.0),
     ModelLaunchSettings("XiaomiMiMo/MiMo-VL-7B-RL"): (0.28, 40.0),
-    ModelLaunchSettings("zai-org/GLM-4.1V-9B-Thinking"): (0.280, 30.4),
+    ModelLaunchSettings("zai-org/GLM-4.1V-9B-Thinking"): (0.280, 35.5),
     ModelLaunchSettings("zai-org/GLM-4.5V-FP8", extra_args=["--tp=2"]): (0.26, 140.0),
 }
 


### PR DESCRIPTION
## Summary

Restore the GLM-4.1V-9B-Thinking MMMU latency threshold from 30.4s to the previously calibrated 35.5s value.

## Root cause

The threshold was calibrated to 35.5s in a685806d using 1.2x the slowest of five nightly runs. The latency guard was then removed by the multi-model eval refactor, and #34662 accidentally restored the older 30.4s threshold together with the guard. This caused a false failure at 33.259s even though it is within the calibrated ceiling.

## Validation

- pre-commit run --files test/registered/eval/test_vlms_mmmu_eval.py
- python -m py_compile test/registered/eval/test_vlms_mmmu_eval.py
- git diff --check

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31771134439](https://github.com/sgl-project/sglang/actions/runs/31771134439)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31771134271](https://github.com/sgl-project/sglang/actions/runs/31771134271)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->