### PR TITLE
[AMD][CI] Gate AMD tests on docker/rocm.Dockerfile changes

### DIFF
--- a/.github/workflows/pr-test-amd-rocm720.yml
+++ b/.github/workflows/pr-test-amd-rocm720.yml
@@ -185,12 +185,16 @@ jobs:
               - "python/sglang/!(multimodal_gen|kernels)/**/!(*.md)"
               - "python/sglang/kernels/!(*.md)"
               - "python/sglang/kernels/!(aot)/**/!(*.md)"
-              - "python/pyproject_rocm.toml"
               - "python/pyproject_other.toml"
               - "scripts/ci/amd/*"
               - "scripts/ci/utils/*"
               - "test/**/!(*.md)"
               - ".github/workflows/pr-test-amd-rocm720.yml"
+              # amd_ci_install_dependency.sh greps this Dockerfile at job time for
+              # AITER_COMMIT_DEFAULT and MORI_COMMIT, and rebuilds AITER / MoRI when
+              # they differ from what the CI image ships. A pin bump therefore changes
+              # what every AMD job runs even though the image is never rebuilt.
+              - "docker/rocm.Dockerfile"
             sgl_kernel:
               - "python/sglang/kernels/aot/**/!(*.md|THIRDPARTYNOTICES.txt|LICENSE)"
               - ".github/workflows/pr-test-amd-rocm720.yml"
@@ -206,7 +210,6 @@ jobs:
               - "python/sglang/kernels/ops/diffusion/**"
               - "test/registered/kernels/ops/diffusion/**"
               - "test/registered/kernels/benchmark/diffusion/**"
-              - "python/pyproject_rocm.toml"
               - "python/pyproject_other.toml"
 
   # =============================================== extra (scheduled) ====================================================

--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -180,12 +180,16 @@ jobs:
               - "python/sglang/!(multimodal_gen|kernels)/**/!(*.md)"
               - "python/sglang/kernels/!(*.md)"
               - "python/sglang/kernels/!(aot)/**/!(*.md)"
-              - "python/pyproject_rocm.toml"
               - "python/pyproject_other.toml"
               - "scripts/ci/amd/*"
               - "scripts/ci/utils/*"
               - "test/**/!(*.md)"
               - ".github/workflows/pr-test-amd.yml"
+              # amd_ci_install_dependency.sh greps this Dockerfile at job time for
+              # AITER_COMMIT_DEFAULT and MORI_COMMIT, and rebuilds AITER / MoRI when
+              # they differ from what the CI image ships. A pin bump therefore changes
+              # what every AMD job runs even though the image is never rebuilt.
+              - "docker/rocm.Dockerfile"
             sgl_kernel:
               - "python/sglang/kernels/aot/**/!(*.md|THIRDPARTYNOTICES.txt|LICENSE)"
               - ".github/workflows/pr-test-amd.yml"
@@ -201,7 +205,6 @@ jobs:
               - "python/sglang/kernels/ops/diffusion/**"
               - "test/registered/kernels/ops/diffusion/**"
               - "test/registered/kernels/benchmark/diffusion/**"
-              - "python/pyproject_rocm.toml"
               - "python/pyproject_other.toml"
 
   # =============================================== extra (scheduled) ====================================================

--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -20,6 +20,12 @@
 # At runtime use --disaggregation-transfer-backend nixl (env is wired via /etc/bash.bashrc).
 #   docker build --build-arg SGL_BRANCH=v0.5.10.post1 --build-arg GPU_ARCH=gfx950-rocm720 -t v0.5.10.post1-rocm720-mi35x -f rocm.Dockerfile .
 
+# Editing AITER_COMMIT_DEFAULT, MORI_REPO or MORI_COMMIT below also changes what
+# AMD CI runs, not just what this image builds: PR CI does not rebuild the image,
+# so scripts/ci/amd/amd_ci_install_dependency.sh greps these values out of this
+# file at job time and rebuilds AITER / MoRI in the container whenever they differ
+# from the versions the image shipped with.
+
 # Default base images
 ARG BASE_IMAGE_942="rocm/sgl-dev:rocm7-vllm-20250904"
 ARG BASE_IMAGE_942_ROCM720="rocm/pytorch:rocm7.2_ubuntu22.04_py3.10_pytorch_release_2.9.1"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Motivation

`docker/rocm.Dockerfile` is listed in `pr-test-amd-rocm720.yml`'s `on.pull_request.paths` but in **none** of the `check-changes` filters. A PR that only touches it therefore creates an AMD workflow run in which every GPU job skips — and because nothing failed, the run can report **green**.

[#29394](https://github.com/sgl-project/sglang/pull/29394) (a MoRI version bump) is the clearest case: its `pr-test-amd` run concluded `success` with `call-gate` ✅, `check-changes` ✅, and all 17 GPU jobs `skipped`.

This is not a rare shape. Nine commits in the last 60 days touched **only** `docker/rocm.Dockerfile`, and they are exactly the changes most likely to break ROCm:

| PR | Change |
|---|---|
| [#34364](https://github.com/sgl-project/sglang/pull/34364) | Install AITER's pinned Triton wheel in the ROCm 7.2 image |
| [#33462](https://github.com/sgl-project/sglang/pull/33462) | Bump MoRI to latest |
| [#32939](https://github.com/sgl-project/sglang/pull/32939) | Update ROCm AITER pin to `d9e5ef7` |
| [#32879](https://github.com/sgl-project/sglang/pull/32879) | Revert ROCm AITER pin to `9127c94` |
| [#31406](https://github.com/sgl-project/sglang/pull/31406) | Bump MoRI to fix a ROCm `install_dependency` build break |
| [#30942](https://github.com/sgl-project/sglang/pull/30942) | Pin `cmake==4.3.4` to fix a MoRI build break |
| [#29394](https://github.com/sgl-project/sglang/pull/29394) | Update MoRI to v1.2.1 |
| [#29986](https://github.com/sgl-project/sglang/pull/29986) | Hot-patch a transformers symlink bug |
| [#28249](https://github.com/sgl-project/sglang/pull/28249) | Update AITER commit |

The natural objection is "the CI image isn't rebuilt for a PR, so testing a Dockerfile change is pointless." That is not how the AMD runner works. `scripts/ci/amd/amd_ci_install_dependency.sh` greps the Dockerfile **at job time** and rebuilds against the pins it finds:

```202:207:scripts/ci/amd/amd_ci_install_dependency.sh
# The CI image bakes MORI at the docker/rocm.Dockerfile-pinned commit; when a PR
# bumps MORI_COMMIT the image is not rebuilt, so reinstall MORI here the same way
# the Dockerfile does. Only ENABLE_MORI=1 images ship /sgl-workspace/mori.
if docker exec ci_sglang test -d /sgl-workspace/mori; then
  MORI_REPO=$(grep -E '^[[:space:]]*ARG[[:space:]]+MORI_REPO=' docker/rocm.Dockerfile | head -n1 | sed 's/.*MORI_REPO="\([^"]*\)".*/\1/')
  MORI_COMMIT=$(grep -E '^[[:space:]]*ARG[[:space:]]+MORI_COMMIT=' docker/rocm.Dockerfile | head -n1 | sed 's/.*MORI_COMMIT="\([^"]*\)".*/\1/')
```

The same is true for `AITER_COMMIT_DEFAULT`, which drives a full AITER rebuild when it differs from the version in the image. So the one file whose changes are *guaranteed* to alter what every AMD job runs is also the one file that runs nothing.

## Modifications

Both `pr-test-amd-rocm720.yml` (the PR gate) and `pr-test-amd.yml` (the daily ROCm 7.0 shadow), kept in sync since they are near-copies:

1. **Add `docker/rocm.Dockerfile` to `main_package`**, which gates the stage-a/b/c suites. Deliberately *not* added to `sgl_kernel` / `jit_kernel` / `multimodal_gen`, so a pin bump does not also pull in the diffusion suites.

2. **Drop `python/pyproject_rocm.toml`** from the `main_package` and `multimodal_gen` filters. No file exists at that path — the ROCm build config is at `python/sglang/kernels/aot/pyproject_rocm.toml`, which is already covered by `sgl_kernel`'s `python/sglang/kernels/aot/**`, and `sgl_kernel` gates the same stage-a/b/c jobs as `main_package`. So this is dead-rule removal with no coverage change. `python/pyproject_other.toml`, which the installer really does consume, is untouched.

A second commit adds a comment at the top of `docker/rocm.Dockerfile` recording the runtime coupling above, so the next person bumping a pin knows it reaches CI immediately. It also makes this PR exercise its own fix (see below).

Note on the adjacent `python/pyproject.toml`: it is intentionally **not** added. The AMD installer replaces it (`mv python/pyproject_other.toml python/pyproject.toml`), so changes to it genuinely do not affect AMD CI.

## Verification

**Live.** Because this PR now touches `docker/rocm.Dockerfile`, its own `check-changes` job had to resolve that path through the new pattern. From [run 31773168875](https://github.com/sgl-project/sglang/actions/runs/31773168875):

```
Detected 3 changed files
##[group]Filter main_package = true
Matching files:
.github/workflows/pr-test-amd-rocm720.yml [modified]
docker/rocm.Dockerfile [modified]
```

On `main` that file matches no filter at all.

**Offline matrix.** Since this PR also edits the workflow file (which is itself in all three filter lists), the live run alone cannot prove the Dockerfile entry is what carries a Dockerfile-*only* PR. So the filter was additionally evaluated with dorny/paths-filter's real matcher (`picomatch(pattern, {dot: true})`), comparing `main` against this branch:

| changed files | `main` | this branch |
|---|---|---|
| `docker/rocm.Dockerfile` | *(none)* | **`main_package`** |
| `docker/rocm.Dockerfile` + `aiter_backend.py` | `main_package` | `main_package` |
| `docs/docs/index.mdx` | *(none)* | *(none)* |
| `python/pyproject.toml` | *(none)* | *(none)* |
| `python/pyproject_other.toml` | `main_package,multimodal_gen` | `main_package,multimodal_gen` |
| `python/sglang/kernels/aot/pyproject_rocm.toml` | `sgl_kernel` | `sgl_kernel` |
| `python/sglang/srt/layers/moe/topk.py` | `main_package` | `main_package` |
| `docker/Dockerfile`, `docker/npu.Dockerfile` | *(none)* | *(none)* |

Exactly one row changes, and the `pyproject_rocm.toml` row confirms the dead-entry removal costs no coverage.

## Capacity impact

Roughly one Dockerfile-only PR per week, each now costing one `main_package` AMD run. Against the ~92 real AMD PR runs observed in a recent 16-hour window, this is noise — and it converts a class of *false green* into real signal.

## Accuracy Tests

Not applicable — CI configuration and a Dockerfile comment; no runtime code or image content touched.

## Speed Tests and Profiling

Not applicable.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). — n/a, workflow filter change; verified live plus the offline matrix above.
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — n/a.
- [ ] Provide accuracy and speed benchmark results. — n/a.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests).
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e75fcb5c-73d8-4ea0-a554-6370193362ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e75fcb5c-73d8-4ea0-a554-6370193362ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31773168844](https://github.com/sgl-project/sglang/actions/runs/31773168844)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31773168801](https://github.com/sgl-project/sglang/actions/runs/31773168801)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->