### PR TITLE
[Perf] Publish the WAR read-done event at DSPARK verify

### DIFF
--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -506,7 +506,11 @@ class DeepseekV4AttnBackend(
 
     def shared_read_boundary(self, forward_mode: ForwardMode) -> SharedReadBoundary:
         # Breakable-graph verify rereads shared state across segments.
+        # DSPARK verify replays one full (non-breakable) graph that honors the
+        # out-graph/in-graph init contract, so the base IN_REPLAY bound holds.
         if forward_mode.is_target_verify():
+            if self.model_runner.spec_algorithm.is_dspark():
+                return SharedReadBoundary.IN_REPLAY
             return SharedReadBoundary.POST_REPLAY
         return super().shared_read_boundary(forward_mode)
 

--- a/python/sglang/srt/speculative/spec_info.py
+++ b/python/sglang/srt/speculative/spec_info.py
@@ -128,8 +128,10 @@ class SpeculativeAlgorithm(Enum):
         return self.is_dflash_family()
 
     def is_war_publish_phase(self, forward_mode) -> bool:
-        # The step's last shared-buffer-reading phase owns the WAR read-done publish.
-        if self.is_dflash_family():
+        # The step's last shared-buffer-reading phase owns the WAR read-done
+        # publish. DSPARK has no draft_extend: its draft samples inside the
+        # verify graph, so verify is that last phase.
+        if self.is_dflash_family() or self.is_dspark():
             return forward_mode.is_target_verify()
         return forward_mode.is_draft_extend_v2()
 


### PR DESCRIPTION
DSPARK has no `draft_extend` phase (its draft samples inside the verify graph), so `is_war_publish_phase()` never returned true and the scheduler's WAR barrier fell back to a coarse whole-forward wait on every decode step, capping the overlap scheduler's launch-ahead. Publish at verify like DFLASH, and let the DSv4 backend take the in-graph read-done record for DSPARK's full-graph verify (the POST_REPLAY exception exists for breakable-graph verify, which DSPARK does not use).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31775661855](https://github.com/sgl-project/sglang/actions/runs/31775661855)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31775661665](https://github.com/sgl-project/sglang/actions/runs/31775661665)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->