### PR TITLE
[CI] Install sgl-eval in xeon (CPU) Docker image

### DIFF
--- a/docker/xeon.Dockerfile
+++ b/docker/xeon.Dockerfile
@@ -42,7 +42,9 @@ RUN source /opt/.venv/bin/activate && \
     uv pip install . && \
     cd sglang/kernels/aot && \
     cp pyproject_cpu.toml pyproject.toml && \
-    uv pip install .
+    uv pip install . && \
+    source /sgl-workspace/sglang/scripts/ci/utils/sgl_eval_ref.sh && \
+    uv pip install "$SGL_EVAL_SPEC"
 
 ENV SGLANG_USE_CPU_ENGINE=1
 ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libtcmalloc.so.4:/usr/lib/x86_64-linux-gnu/libtbbmalloc.so:/opt/.venv/lib/libiomp5.so


### PR DESCRIPTION
PR #34477 routed mmlu eval through the external `sgl-eval` CLI and added the install step to the cuda / amd / npu CI dependency scripts, but the CPU path builds its image from docker/xeon.Dockerfile, which was not updated. As a result test_mmlu_torch_compile_cpu (test/registered/cpu/test_cpu_graph.py) fails on the xeon-gnr runner with `FileNotFoundError: 'sgl-eval'`.

Install sgl-eval in the xeon image the same way the other variants do, using the shared version pin from scripts/ci/utils/sgl_eval_ref.sh so a future bump stays in sync across all CI variants.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31776932514](https://github.com/sgl-project/sglang/actions/runs/31776932514)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #31999955409](https://github.com/sgl-project/sglang/actions/runs/31999955409)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->