### PR TITLE
Skip oow slot freeing under eagle

### DIFF
--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -773,7 +773,12 @@ class UnifiedRadixCache(BasePrefixCache):
             if cl is not None:
                 effective_cache_len = min(effective_cache_len, cl)
 
-        if envs.SGLANG_OPT_UNIFIED_CACHE_FREE_OUT_OF_WINDOW_SLOTS.get():
+        # swa_evicted_seqlen is a raw-token length, but under EAGLE the insert key is
+        # bigram-indexed, so SWA would carve tombstones at the wrong offset (#34653).
+        if (
+            envs.SGLANG_OPT_UNIFIED_CACHE_FREE_OUT_OF_WINDOW_SLOTS.get()
+            and not self.tree_core.is_eagle
+        ):
             for comp in self._components_tuple:
                 comp.free_out_of_window_slots(
                     req, effective_cache_len - 1, insert_params


### PR DESCRIPTION
## Motivation

#34653 flipped `SGLANG_OPT_UNIFIED_CACHE_FREE_OUT_OF_WINDOW_SLOTS` to `True`. On a hybrid SWA model with EAGLE speculative decoding this trips the pool invariant checker and kills every TP rank:

```
pool memory leak detected!
[full] total=13510080, available=13509568, evictable=8192, protected=0
[swa]  total=10808064, available=10807552, evictable=1024, protected=0
```

Root cause: in the new-leaf path, `split_pos = swa_evicted_seqlen - result.prefix_len` mixes units. `swa_evicted_seqlen` is a raw-token length while `prefix_len` is in bigram key units under EAGLE, so `split_pos` goes negative (observed `-64` with `page_size 64`) and the leaf is neither tombstoned nor split, while its SWA slots were already returned to the allocator. The tree keeps counting them as evictable, so the accounted total exceeds the pool total.

Note the blast radius is wider than the flag suggests: `registry.py` routes every hybrid SWA model to `UnifiedRadixCache` unconditionally, without `SGLANG_ENABLE_UNIFIED_RADIX_TREE`.

This gates the new default off for the EAGLE family until the unit mismatch is fixed. DSpark, DFlash, non-speculative and hybrid SSM keep the optimization, since `tree_core.is_eagle` is `params.is_eagle and MAMBA not in components`.

## Repro

8xH200, gpt-oss-120b, `--page-size 64 --chunked-prefill-size 16384`, EAGLE3 draft `lmsys/EAGLE3-gpt-oss-120b-bf16`, `bench_one_batch_server --batch-size 1 8 --input-len 8192 --output-len 512`:

| config | result |
| --- | --- |
| EAGLE3, OOW=1 | 8/8 ranks crash, leak detected |
| EAGLE3, OOW=0 | pass |
| no spec, OOW=1 | pass |

`page_size 64` is required to reproduce. At `page_size 1` the page-alignment paths are skipped entirely and the mismatch does not surface.

Nightly hit the same signature on B200: https://github.com/sgl-project/sglang/actions/runs/31710357501

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31780346451](https://github.com/sgl-project/sglang/actions/runs/31780346451)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #31781367291](https://github.com/sgl-project/sglang/actions/runs/31781367291)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->