### PR TITLE
[diffusion] Fix symbolic replicated-mode counting under torch.compile

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/attention/layer.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/layer.py
@@ -130,6 +130,22 @@ def _kv_gather_unsupported_reason(
     return None
 
 
+def _count_active_replicated_modes(
+    num_replicated_prefix: int,
+    num_replicated_suffix: int,
+    num_replicated_kv_prefix: int,
+) -> int:
+    """Count active replicated-token modes without adding symbolic booleans."""
+    return sum(
+        int(value > 0)
+        for value in (
+            num_replicated_prefix,
+            num_replicated_suffix,
+            num_replicated_kv_prefix,
+        )
+    )
+
+
 def build_varlen_mask_meta(
     key_mask: torch.Tensor,
 ) -> dict:
@@ -822,13 +838,10 @@ class USPAttention(nn.Module):
             and not effective_skip_sp
             and get_sequence_parallel_world_size() > 1
         )
-        replicated_mode_count = sum(
-            value > 0
-            for value in (
-                num_replicated_prefix,
-                num_replicated_suffix,
-                num_replicated_kv_prefix,
-            )
+        replicated_mode_count = _count_active_replicated_modes(
+            num_replicated_prefix,
+            num_replicated_suffix,
+            num_replicated_kv_prefix,
         )
         if (
             self.sp_attention_mode == "kv_gather"

--- a/python/sglang/multimodal_gen/test/unit/test_usp_attention_kv_gather.py
+++ b/python/sglang/multimodal_gen/test/unit/test_usp_attention_kv_gather.py
@@ -9,10 +9,12 @@ from sglang.multimodal_gen.runtime.layers.attention.layer import (
     UlyssesAttention,
     UlyssesAttention_VSA,
     USPAttention,
+    _count_active_replicated_modes,
     _kv_gather_unsupported_reason,
     _resolve_sp_attention_mode,
 )
 from sglang.multimodal_gen.runtime.platforms import AttentionBackendEnum
+from sglang.test.test_utils import CustomTestCase
 
 _LAYER = "sglang.multimodal_gen.runtime.layers.attention.layer"
 
@@ -342,6 +344,22 @@ class TestKVGatherCallSupport(unittest.TestCase):
             attn.sp_attention_mode_is_auto = False
             with self.assertRaisesRegex(NotImplementedError, "pre-all-to-all"):
                 attn.forward(q, q, q, qkv_pre_all_to_all=True)
+
+
+class TestReplicatedModeCountCompile(CustomTestCase):
+    def test_symbolic_shape_compiles(self):
+        def add_mode_count(x):
+            count = _count_active_replicated_modes(x.shape[0], 0, 0)
+            return x + count
+
+        compiled = torch.compile(
+            add_mode_count,
+            backend="eager",
+            fullgraph=True,
+            dynamic=True,
+        )
+        actual = compiled(torch.ones(3))
+        torch.testing.assert_close(actual, torch.full((3,), 2.0))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

`USPAttention.forward` counted active replicated-token modes with a Python `sum` over `value > 0`. Under `torch.compile`, a count derived from a dynamic shape can produce symbolic booleans, and adding those symbolic values can fail full-graph tracing even though the count is only needed for dispatch validation.

## Modifications

- Add `_count_active_replicated_modes`, converting each comparison to an integer before summing.
- Use the helper in the K/V-gather dispatch path.
- Add a dynamic-shape `torch.compile(fullgraph=True)` regression test.

## Accuracy Tests

```text
python3 -m pytest -q python/sglang/multimodal_gen/test/unit/test_usp_attention_kv_gather.py
16 passed, 14 warnings
```

`pre-commit run --files <changed files>` and `git diff --check` also pass.

## Speed Tests and Profiling

This is a compile correctness fix and does not intentionally change eager or compiled numerical results or performance.

## Checklist

- [x] Formatting and pre-commit checks pass.
- [x] Added a targeted unit test.
- [x] No documentation update is required.
- [x] No user-facing API or default changes.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31781443564](https://github.com/sgl-project/sglang/actions/runs/31781443564)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #31813967236](https://github.com/sgl-project/sglang/actions/runs/31813967236)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->