### PR TITLE
feat(moe): enable DeepGEMM MoE runner on SM120 (RTX PRO 6000 / RTX 6000D)

### DIFF
--- a/docs/cookbook/autoregressive/Moonshotai/Kimi-K3.mdx
+++ b/docs/cookbook/autoregressive/Moonshotai/Kimi-K3.mdx
@@ -393,3 +393,7 @@ Decisions the preset already makes:
 <Note>
 No preset has a full serving round on final weights; the constants derive from measured single- and dual-node rounds plus a 64-GPU sweep. Validate throughput and accuracy on your workload before committing a fleet.
 </Note>
+
+#### SM120 (RTX PRO 6000 / RTX 6000D / RTX 5090)
+
+The MegaMoE presets above require **SM100/SM103 datacenter Blackwell** — DeepGEMM ships no SM120 MegaMoE kernels, and `--moe-a2a-backend megamoe` is rejected at startup on SM120/SM121 with a clear error. On SM120 GPUs, K3 MXFP4 runs on the Marlin (W4A16) runner by default (`--moe-a2a-backend none`), or opt into the DeepGEMM grouped-GEMM path (same `--moe-runner-backend deep_gemm` flag, without `--moe-a2a-backend megamoe`) once the image ships `sgl-deep-gemm>=0.1.5`, the first release with arch-12 JIT kernels and scale-factor layout transforms.

--- a/python/sglang/srt/layers/deep_gemm_wrapper/configurer.py
+++ b/python/sglang/srt/layers/deep_gemm_wrapper/configurer.py
@@ -1,4 +1,7 @@
 import logging
+from importlib.metadata import PackageNotFoundError, version as _dist_version
+
+from packaging.version import parse as _parse_version
 
 from sglang.srt.environ import envs
 from sglang.srt.utils import (
@@ -6,6 +9,7 @@ from sglang.srt.utils import (
     is_cuda,
     is_musa,
     is_sm100_supported,
+    is_sm120_supported,
 )
 
 logger = logging.getLogger(__name__)
@@ -14,12 +18,31 @@ _is_cuda = is_cuda()
 _is_musa = is_musa()
 
 
+def _is_sm120_capable_deep_gemm() -> bool:
+    """Whether the installed deep_gemm ships SM120 (desktop Blackwell) kernels.
+
+    sgl-deep-gemm >= 0.1.5 is the first release with arch-12 support (the
+    scale-factor layout transforms in ``transform_sf_into_required_layout``
+    and the sm120 JIT GEMM kernels). Earlier releases hard-fail on SM120
+    ("Unknown SF transformation" during MXFP4 weight prep, or missing sm120
+    cubins). The library's internal ``__version__`` is frozen across releases,
+    so gate on the wheel's distribution metadata instead.
+    """
+    try:
+        deep_gemm_version = _parse_version(_dist_version("sgl-deep-gemm"))
+    except PackageNotFoundError:
+        logger.warning(
+            "sgl-deep-gemm is installed from source (no distribution metadata): "
+            "cannot verify SM120 support, treating it as unsupported. Install "
+            "sgl-deep-gemm>=0.1.5 from PyPI to enable DeepGEMM on SM120."
+        )
+        return False
+    return deep_gemm_version >= _parse_version("0.1.5")
+
+
 def _compute_enable_deep_gemm():
     sm_version = get_device_sm()
     if (_is_cuda and sm_version < 90) or (_is_musa and sm_version < 31):
-        return False
-    # DeepGEMM requires TMEM/tcgen05 (SM100+datacenter), not available on SM120
-    if sm_version == 120:
         return False
     if not (_is_cuda or _is_musa):
         return False
@@ -29,11 +52,27 @@ def _compute_enable_deep_gemm():
     except ImportError:
         return False
 
+    # SM120/SM121 (RTX PRO 6000 / RTX 6000D / RTX 5090 / DGX Spark) needs
+    # sgl-deep-gemm >= 0.1.5 for the arch-12 JIT kernels and SF layout
+    # transforms. Note MegaMoE itself remains SM90/SM100-only; see
+    # ServerArgs._handle_a2a_moe for the megamoe a2a guard.
+    if is_sm120_supported() and not _is_sm120_capable_deep_gemm():
+        logger.warning(
+            "DeepGEMM is disabled on SM%d: sgl-deep-gemm < 0.1.5 has no SM120 "
+            "kernels. Upgrade to sgl-deep-gemm>=0.1.5 to enable it.",
+            sm_version,
+        )
+        return False
+
     return envs.SGLANG_ENABLE_JIT_DEEPGEMM.get()
 
 
 ENABLE_JIT_DEEPGEMM = _compute_enable_deep_gemm()
 
-DEEPGEMM_BLACKWELL = ENABLE_JIT_DEEPGEMM and is_sm100_supported()
+# SM120 uses the same packed-UE8M0 (Blackwell-style) scale layout and JIT
+# kernel family as SM100, so the UE8M0-scale paths apply to both.
+DEEPGEMM_BLACKWELL = ENABLE_JIT_DEEPGEMM and (
+    is_sm100_supported() or is_sm120_supported()
+)
 DEEPGEMM_SCALE_UE8M0 = DEEPGEMM_BLACKWELL
 DEEPGEMM_NEED_TMA_ALIGNED_SCALES = not (DEEPGEMM_SCALE_UE8M0 or _is_musa)

--- a/python/sglang/srt/layers/deep_gemm_wrapper/configurer.py
+++ b/python/sglang/srt/layers/deep_gemm_wrapper/configurer.py
@@ -1,5 +1,6 @@
 import logging
-from importlib.metadata import PackageNotFoundError, version as _dist_version
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _dist_version
 
 from packaging.version import parse as _parse_version
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -6836,6 +6836,20 @@ class ServerArgs:
         if a2a_backend == "megamoe":
             if not envs.SGLANG_OPT_FIX_MEGA_MOE_MEMORY.is_set():
                 envs.SGLANG_OPT_FIX_MEGA_MOE_MEMORY.set(True)
+            # DeepGEMM's fused MegaMoE kernels exist only for SM90 (all-FP8)
+            # and SM100/SM103 (FP8xFP4); on SM120/SM121 (RTX PRO 6000 / RTX
+            # 6000D / RTX 5090 / DGX Spark) the forward would abort inside
+            # `fp8_fp4_mega_moe` ("Unsupported architecture"), so reject the
+            # combination up front instead of crashing at load time.
+            if is_cuda() and get_device_sm() >= 120:
+                raise ValueError(
+                    "--moe-a2a-backend megamoe is not supported on SM120/SM121 "
+                    "(RTX PRO 6000 / RTX 6000D / RTX 5090 / DGX Spark): DeepGEMM "
+                    "ships no MegaMoE kernels for this architecture. Use "
+                    "--moe-a2a-backend none with --moe-runner-backend deep_gemm "
+                    "(requires sgl-deep-gemm>=0.1.5), marlin or flashinfer_mxfp4 "
+                    "instead."
+                )
 
         if a2a_backend == "deepep":
             if self.moe_runner_backend == "flashinfer_cutedsl":


### PR DESCRIPTION
## Motivation

Kimi-K3 (MXFP4 latent MoE) on SM120 GPUs (RTX PRO 6000 / RTX 6000D / RTX 5090) currently cannot use the DeepGEMM MoE runner at all: `python/sglang/srt/layers/deep_gemm_wrapper/configurer.py` hard-disables DeepGEMM on SM120, and even when bypassed, `--moe-a2a-backend megamoe` crashes inside DeepGEMM (`fp8_fp4_mega_moe` → "Unsupported architecture", since MegaMoE kernels exist only for SM90/SM100).

With `sgl-deep-gemm >= 0.1.5` (the first release shipping arch-12 JIT kernels and the `transform_sf_into_required_layout` arch-12 scale-factor branches), the non-mega DeepGEMM path (m-grouped fp8/fp4/bf16 GEMMs) is functional on SM120 — this is the same support the upstream `deepseek-ai/DeepGEMM` `nv_dev` branch provides, which vLLM consumes via their vendored pin (vllm-project/vllm#52035, fixing vllm-project/vllm#51758).

## Changes

1. **`deep_gemm_wrapper/configurer.py`**
   - Remove the hard `sm_version == 120` gate.
   - Gate SM120 on the installed wheel's distribution metadata (`sgl-deep-gemm >= 0.1.5`); the library's internal `__version__` is frozen across releases so it cannot be used. Source installs without metadata log a warning and stay disabled.
   - Extend `DEEPGEMM_BLACKWELL` / `DEEPGEMM_SCALE_UE8M0` to SM120: SM120 uses the same packed-UE8M0 (Blackwell-style) scale layout as SM100, and the runner's forward scale handling is keyed off these flags (`moe_runner/deep_gemm.py`), so they must agree with the unconditional `transform_sf_into_required_layout(recipe=(1, 32))` weight prep in `layers/quantization/mxfp4.py`.
   - Consequence (intended): with a capable wheel, `SGLANG_OPT_FP8_WO_A_GEMM` and the FP8 dense UE8M0 path also become available on SM120, mirroring the vLLM Wall-1 fix.

2. **`server_args.py`** — `--moe-a2a-backend megamoe` on SM120/SM121 now raises a clear `ValueError` at startup instead of aborting at load time inside the DeepGEMM MegaMoE kernel. MegaMoE remains SM90/SM100-only.

3. **Kimi-K3 cookbook** — documents the SM120 story (Marlin default; DeepGEMM runner opt-in with `sgl-deep-gemm>=0.1.5`; no megamoe).

## Usage

```bash
# SM120 (RTX PRO 6000 / RTX 6000D), MXFP4 models (e.g. Kimi-K3):
sglang serve --model-path moonshotai/Kimi-K3 \
  --moe-runner-backend deep_gemm --moe-a2a-backend none \
  ...
```

## Testing

- Static: python syntax; scale-layout consistency traced through `mxfp4.py` weight prep and `moe_runner/deep_gemm.py` forward paths.
- On-cluster (4x RTX 6000D, sgl-deep-gemm 0.1.5.post2): run `sglang serve` with the flags above and compare against the Marlin baseline. If the UE8M0 pack path still crashes, capture it with `DG_JIT_DEBUG=1` and report back — the DeepGEMM-side guard (sgl-project/DeepGEMM PR #75: CPU-tensor device assert + MXFP4 (1,32) SF regression test).

## Related

- deepseek-ai/DeepGEMM#372 / #403 — SM120 SF layout transform (NVFP4)
- vllm-project/vllm#51758 / #52035 — same root cause in vLLM, fixed by pinning the nv_dev DeepGEMM tip
- sgl-project/sglang#24692 — SM120 support work (DeepGEMM previously disabled)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31803855682](https://github.com/sgl-project/sglang/actions/runs/31803855682)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31803855409](https://github.com/sgl-project/sglang/actions/runs/31803855409)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->