### PR TITLE
Fix integer created_at in Responses streaming events

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -134,7 +134,7 @@ def _should_emit_normal_text_as_message(
     return True
 
 
-def _serialize_sse_event(event: Any) -> str:
+def _serialize_responses_event_data(event: Any) -> str:
     if not hasattr(event, "response"):
         return event.model_dump_json(indent=None)
 
@@ -1489,7 +1489,10 @@ class OpenAIServingResponses(OpenAIServingChat):
             sequence_number += 1
             # Get event type from the event's type field if it exists
             event_type = getattr(event, "type", "unknown")
-            return f"event: {event_type}\ndata: {_serialize_sse_event(event)}\n\n"
+            return (
+                f"event: {event_type}\n"
+                f"data: {_serialize_responses_event_data(event)}\n\n"
+            )
 
         current_content_index = 0
         current_output_index = 0
@@ -1916,7 +1919,10 @@ class OpenAIServingResponses(OpenAIServingChat):
                 event.sequence_number = sequence_number
             sequence_number += 1
             event_type = getattr(event, "type", "unknown")
-            return f"event: {event_type}\ndata: {_serialize_sse_event(event)}\n\n"
+            return (
+                f"event: {event_type}\n"
+                f"data: {_serialize_responses_event_data(event)}\n\n"
+            )
 
         # The streaming Response* event models echo ``tools`` through a
         # narrower OpenAI SDK Tool union; strip it to avoid pydantic

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -134,6 +134,16 @@ def _should_emit_normal_text_as_message(
     return True
 
 
+def _serialize_sse_event(event: Any) -> str:
+    if not hasattr(event, "response"):
+        return event.model_dump_json(indent=None)
+
+    payload = event.model_dump(mode="json")
+    # The SDK types this field as float; match SGLang's non-streaming wire format.
+    payload["response"]["created_at"] = int(payload["response"]["created_at"])
+    return orjson.dumps(payload).decode()
+
+
 class OpenAIServingResponses(OpenAIServingChat):
     """Handler for /v1/responses requests"""
 
@@ -1479,10 +1489,7 @@ class OpenAIServingResponses(OpenAIServingChat):
             sequence_number += 1
             # Get event type from the event's type field if it exists
             event_type = getattr(event, "type", "unknown")
-            return (
-                f"event: {event_type}\n"
-                f"data: {event.model_dump_json(indent=None)}\n\n"
-            )
+            return f"event: {event_type}\ndata: {_serialize_sse_event(event)}\n\n"
 
         current_content_index = 0
         current_output_index = 0
@@ -1909,10 +1916,7 @@ class OpenAIServingResponses(OpenAIServingChat):
                 event.sequence_number = sequence_number
             sequence_number += 1
             event_type = getattr(event, "type", "unknown")
-            return (
-                f"event: {event_type}\n"
-                f"data: {event.model_dump_json(indent=None)}\n\n"
-            )
+            return f"event: {event_type}\ndata: {_serialize_sse_event(event)}\n\n"
 
         # The streaming Response* event models echo ``tools`` through a
         # narrower OpenAI SDK Tool union; strip it to avoid pydantic

--- a/test/registered/unit/entrypoints/openai/test_serving_responses_stream.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_responses_stream.py
@@ -61,7 +61,19 @@ class NonHarmonyStreamTestCase(CustomTestCase):
             self.assertIn(ev, types)
         self.assertEqual(types[-1], "response.completed")
 
-        seqs = [p["sequence_number"] for p in event_payloads(events)]
+        payloads = event_payloads(events)
+        snapshot_types = {
+            "response.created",
+            "response.in_progress",
+            "response.completed",
+        }
+        for payload in payloads:
+            if payload["type"] in snapshot_types:
+                self.assertIs(
+                    type(payload["response"]["created_at"]), int, payload["type"]
+                )
+
+        seqs = [p["sequence_number"] for p in payloads]
         self.assertEqual(seqs, list(range(len(seqs))))
 
     def test_required_tool_choice_emits_function_call_events(self):


### PR DESCRIPTION
## Summary

- preserve the SDK's typed event validation while normalizing snapshot `created_at` values at final SSE serialization
- share the serializer across Harmony and non-Harmony response streams, including `response.failed`
- assert that `response.created`, `response.in_progress`, and `response.completed` carry integer timestamps on the wire

## Why

SGLang's non-streaming Responses model declares `created_at` as an integer. Streaming snapshots are wrapped in the OpenAI SDK's typed event models, whose nested `Response.created_at` field is a float, so Pydantic serializes the same timestamp with a trailing `.0`. Strict clients can therefore accept non-streaming responses but reject streaming snapshots.

Fixes #34716.

## Validation

- exact isolated reproduction with SGLang's pinned `openai==2.6.1`: all four snapshot event types serialize as floats before the helper and integers after it; a non-snapshot delta remains byte-for-byte on the existing fast path
- `black --check` on both changed files
- `ruff check --select=F401,F821,UP037` on both changed files
- `python3 -m py_compile` on both changed files
- `git diff --check`

The focused SGLang fixture could not run in the local macOS checkout because the full SGLang runtime dependency set is not installed; the regression is registered in the existing CPU CI suite.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31787385060](https://github.com/sgl-project/sglang/actions/runs/31787385060)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31787384954](https://github.com/sgl-project/sglang/actions/runs/31787384954)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->