### PR TITLE
Confine WASM module loading to configured roots

### DIFF
--- a/sgl-model-gateway/bindings/python/src/lib.rs
+++ b/sgl-model-gateway/bindings/python/src/lib.rs
@@ -450,6 +450,8 @@ struct Router {
     tcp_keepalive_secs: u64,
     #[pyo3(get)]
     enable_wasm: bool,
+    #[pyo3(get)]
+    wasm_module_roots: Vec<String>,
 }
 
 impl Router {
@@ -655,6 +657,7 @@ impl Router {
             .pool_max_idle_per_host(self.pool_max_idle_per_host)
             .tcp_keepalive_secs(self.tcp_keepalive_secs)
             .enable_wasm(self.enable_wasm)
+            .wasm_module_roots(self.wasm_module_roots.clone())
             .maybe_client_cert_and_key(
                 self.client_cert_path.as_ref(),
                 self.client_key_path.as_ref(),
@@ -761,6 +764,7 @@ impl Router {
         pool_max_idle_per_host = 500,
         tcp_keepalive_secs = 30,
         enable_wasm = false,
+        wasm_module_roots = vec![],
     ))]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -853,6 +857,7 @@ impl Router {
         pool_max_idle_per_host: usize,
         tcp_keepalive_secs: u64,
         enable_wasm: bool,
+        wasm_module_roots: Vec<String>,
     ) -> PyResult<Self> {
         let mut all_urls = worker_urls.clone();
 
@@ -959,6 +964,7 @@ impl Router {
             pool_max_idle_per_host,
             tcp_keepalive_secs,
             enable_wasm,
+            wasm_module_roots,
         })
     }
 

--- a/sgl-model-gateway/bindings/python/src/sglang_router/router_args.py
+++ b/sgl-model-gateway/bindings/python/src/sglang_router/router_args.py
@@ -176,6 +176,10 @@ class RouterArgs:
     tcp_keepalive_secs: int = 30
     # Enable WebAssembly support
     enable_wasm: bool = False
+    # Directories WASM modules may be loaded from. Required when enable_wasm is
+    # set; the router refuses to start otherwise rather than allowing a module to
+    # be loaded from anywhere on the filesystem.
+    wasm_module_roots: List[str] = dataclasses.field(default_factory=list)
 
     @staticmethod
     def add_cli_args(
@@ -765,6 +769,19 @@ class RouterArgs:
             action="store_true",
             default=RouterArgs.enable_wasm,
             help="Enable WebAssembly support",
+        )
+        backend_group.add_argument(
+            f"--{prefix}wasm-module-root",
+            dest=f"{prefix.replace('-', '_')}wasm_module_roots",
+            type=str,
+            nargs="+",
+            default=[],
+            help=(
+                "Directory WASM modules may be loaded from; repeat or pass several "
+                "to allow more than one. Required with --enable-wasm: module "
+                "registration takes a caller-supplied path, and these roots are "
+                "what confine it."
+            ),
         )
 
         # Oracle configuration

--- a/sgl-model-gateway/examples/wasm/README.md
+++ b/sgl-model-gateway/examples/wasm/README.md
@@ -56,7 +56,19 @@ All examples require:
 - Rust toolchain (latest stable)
 - `wasm32-wasip2` target: `rustup target add wasm32-wasip2`
 - `wasm-tools`: `cargo install wasm-tools`
-- sgl-model-gateway running with WASM enabled (`--enable-wasm`)
+- sgl-model-gateway running with WASM enabled, and told which directory modules
+  may be loaded from:
+
+  ```bash
+  smg launch --enable-wasm --wasm-module-root /srv/wasm-modules
+  ```
+
+  Registration accepts a caller-supplied path, so `--wasm-module-root` is what
+  confines it: a module is only accepted if it resolves to a location inside one
+  of the roots. Pass the flag more than once, or give it several directories, to
+  allow more than one. Enabling WASM without a root is refused at startup rather
+  than defaulting to "anywhere on the filesystem", so place the built
+  `.component.wasm` files under a root before registering them.
 
 ## Building All Examples
 
@@ -79,19 +91,19 @@ curl -X POST http://localhost:3000/wasm \
     "modules": [
       {
         "name": "auth-middleware",
-        "file_path": "/path/to/wasm_guest_auth.component.wasm",
+        "file_path": "/srv/wasm-modules/wasm_guest_auth.component.wasm",
         "module_type": "Middleware",
         "attach_points": [{"Middleware": "OnRequest"}]
       },
       {
         "name": "logging-middleware",
-        "file_path": "/path/to/wasm_guest_logging.component.wasm",
+        "file_path": "/srv/wasm-modules/wasm_guest_logging.component.wasm",
         "module_type": "Middleware",
         "attach_points": [{"Middleware": "OnRequest"}, {"Middleware": "OnResponse"}]
       },
       {
         "name": "ratelimit-middleware",
-        "file_path": "/path/to/wasm_guest_ratelimit.component.wasm",
+        "file_path": "/srv/wasm-modules/wasm_guest_ratelimit.component.wasm",
         "module_type": "Middleware",
         "attach_points": [{"Middleware": "OnRequest"}]
       }

--- a/sgl-model-gateway/examples/wasm/wasm-guest-auth/README.md
+++ b/sgl-model-gateway/examples/wasm/wasm-guest-auth/README.md
@@ -22,13 +22,13 @@ This middleware validates API keys for requests to `/api` and `/v1` paths:
 cd examples/wasm-guest-auth
 ./build.sh
 
-# Deploy (replace file_path with actual path)
+# Deploy (the file must live under a --wasm-module-root directory)
 curl -X POST http://localhost:3000/wasm \
   -H "Content-Type: application/json" \
   -d '{
     "modules": [{
       "name": "auth-middleware",
-      "file_path": "/absolute/path/to/wasm_guest_auth.component.wasm",
+      "file_path": "/srv/wasm-modules/wasm_guest_auth.component.wasm",
       "module_type": "Middleware",
       "attach_points": [{"Middleware": "OnRequest"}]
     }]

--- a/sgl-model-gateway/examples/wasm/wasm-guest-logging/README.md
+++ b/sgl-model-gateway/examples/wasm/wasm-guest-logging/README.md
@@ -18,13 +18,13 @@ This middleware provides:
 cd examples/wasm-guest-logging
 ./build.sh
 
-# Deploy (replace file_path with actual path)
+# Deploy (the file must live under a --wasm-module-root directory)
 curl -X POST http://localhost:3000/wasm \
   -H "Content-Type: application/json" \
   -d '{
     "modules": [{
       "name": "logging-middleware",
-      "file_path": "/absolute/path/to/wasm_guest_logging.component.wasm",
+      "file_path": "/srv/wasm-modules/wasm_guest_logging.component.wasm",
       "module_type": "Middleware",
       "attach_points": [{"Middleware": "OnRequest"}, {"Middleware": "OnResponse"}]
     }]

--- a/sgl-model-gateway/examples/wasm/wasm-guest-ratelimit/README.md
+++ b/sgl-model-gateway/examples/wasm/wasm-guest-ratelimit/README.md
@@ -21,13 +21,13 @@ This middleware provides rate limiting:
 cd examples/wasm-guest-ratelimit
 ./build.sh
 
-# Deploy (replace file_path with actual path)
+# Deploy (the file must live under a --wasm-module-root directory)
 curl -X POST http://localhost:3000/wasm \
   -H "Content-Type: application/json" \
   -d '{
     "modules": [{
       "name": "ratelimit-middleware",
-      "file_path": "/absolute/path/to/wasm_guest_ratelimit.component.wasm",
+      "file_path": "/srv/wasm-modules/wasm_guest_ratelimit.component.wasm",
       "module_type": "Middleware",
       "attach_points": [{"Middleware": "OnRequest"}]
     }]

--- a/sgl-model-gateway/src/app_context.rs
+++ b/sgl-model-gateway/src/app_context.rs
@@ -21,7 +21,9 @@ use crate::{
     routers::router_manager::RouterManager,
     tokenizer::registry::TokenizerRegistry,
     tool_parser::ParserFactory as ToolParserFactory,
-    wasm::{config::WasmRuntimeConfig, module_manager::WasmModuleManager},
+    wasm::{
+        config::WasmRuntimeConfig, module_manager::WasmModuleManager, module_roots::ModuleRoots,
+    },
 };
 
 /// Error type for AppContext builder
@@ -57,6 +59,9 @@ pub struct AppContext {
     pub workflow_engines: Arc<OnceLock<WorkflowEngines>>,
     pub mcp_manager: Arc<OnceLock<Arc<McpManager>>>,
     pub wasm_manager: Option<Arc<WasmModuleManager>>,
+    /// Directories WASM modules may be loaded from. Present exactly when
+    /// `wasm_manager` is, so registration always has an allow-list to check against.
+    pub wasm_module_roots: Option<Arc<ModuleRoots>>,
     pub worker_service: Arc<WorkerService>,
     pub inflight_tracker: Arc<InFlightRequestTracker>,
 }
@@ -87,6 +92,7 @@ pub struct AppContextBuilder {
     workflow_engines: Option<Arc<OnceLock<WorkflowEngines>>>,
     mcp_manager: Option<Arc<OnceLock<Arc<McpManager>>>>,
     wasm_manager: Option<Arc<WasmModuleManager>>,
+    wasm_module_roots: Option<Arc<ModuleRoots>>,
 }
 
 impl AppContext {
@@ -127,6 +133,7 @@ impl AppContextBuilder {
             workflow_engines: None,
             mcp_manager: None,
             wasm_manager: None,
+            wasm_module_roots: None,
         }
     }
 
@@ -224,6 +231,17 @@ impl AppContextBuilder {
         self
     }
 
+    /// Set the module roots directly, bypassing [`RouterConfig`].
+    ///
+    /// The normal path is `with_wasm_manager`, which derives the roots from
+    /// configuration. This setter exists so that callers assembling a context by
+    /// hand — tests, chiefly — can supply roots too; without it a hand-built
+    /// context has `wasm_module_roots: None` and every registration is refused.
+    pub fn wasm_module_roots(mut self, roots: Option<Arc<ModuleRoots>>) -> Self {
+        self.wasm_module_roots = roots;
+        self
+    }
+
     pub fn build(self) -> Result<AppContext, AppContextBuildError> {
         let router_config = self
             .router_config
@@ -279,6 +297,7 @@ impl AppContextBuilder {
                 .mcp_manager
                 .ok_or(AppContextBuildError("mcp_manager"))?,
             wasm_manager: self.wasm_manager,
+            wasm_module_roots: self.wasm_module_roots,
             worker_service,
             inflight_tracker: InFlightRequestTracker::new(),
         })
@@ -512,15 +531,27 @@ impl AppContextBuilder {
     }
 
     /// Create wasm manager if enabled in config
+    ///
+    /// The module allow-list is established here, alongside the manager, so the
+    /// two cannot get out of step: if WASM is usable, registration has roots to
+    /// confine it. A missing or unreadable root aborts startup rather than
+    /// leaving module registration able to read anywhere on the filesystem.
     fn with_wasm_manager(mut self, config: &RouterConfig) -> Result<Self, String> {
-        self.wasm_manager = if config.enable_wasm {
-            Some(Arc::new(
-                WasmModuleManager::new(WasmRuntimeConfig::default())
-                    .map_err(|e| format!("Failed to initialize WASM module manager: {}", e))?,
-            ))
-        } else {
-            None
-        };
+        if !config.enable_wasm {
+            self.wasm_manager = None;
+            self.wasm_module_roots = None;
+            return Ok(self);
+        }
+
+        let roots = ModuleRoots::load(&config.wasm_module_roots)
+            .map_err(|e| format!("Failed to configure WASM module roots: {}", e))?;
+        debug!("WASM modules may be loaded from: {:?}", roots.roots());
+
+        self.wasm_manager = Some(Arc::new(
+            WasmModuleManager::new(WasmRuntimeConfig::default())
+                .map_err(|e| format!("Failed to initialize WASM module manager: {}", e))?,
+        ));
+        self.wasm_module_roots = Some(Arc::new(roots));
         Ok(self)
     }
 }

--- a/sgl-model-gateway/src/config/builder.rs
+++ b/sgl-model-gateway/src/config/builder.rs
@@ -378,6 +378,15 @@ impl RouterConfigBuilder {
         self
     }
 
+    pub fn wasm_module_roots<I, S>(mut self, roots: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.config.wasm_module_roots = roots.into_iter().map(Into::into).collect();
+        self
+    }
+
     pub fn model_path<S: Into<String>>(mut self, path: S) -> Self {
         self.config.model_path = Some(path.into());
         self

--- a/sgl-model-gateway/src/config/types.rs
+++ b/sgl-model-gateway/src/config/types.rs
@@ -99,6 +99,14 @@ pub struct RouterConfig {
     /// Enable WASM support
     #[serde(default)]
     pub enable_wasm: bool,
+    /// Directories that WASM modules may be loaded from.
+    ///
+    /// Registration accepts a caller-supplied path, so this allow-list is what
+    /// confines it. At least one root is required when `enable_wasm` is set;
+    /// the gateway refuses to start otherwise rather than defaulting to
+    /// "anywhere on the filesystem".
+    #[serde(default)]
+    pub wasm_module_roots: Vec<String>,
 }
 
 /// Tokenizer cache configuration
@@ -551,6 +559,7 @@ impl Default for RouterConfig {
             ca_certificates: vec![],
             mcp_config: None,
             enable_wasm: false,
+            wasm_module_roots: Vec::new(),
             server_cert: None,
             server_key: None,
         }

--- a/sgl-model-gateway/src/core/steps/mod.rs
+++ b/sgl-model-gateway/src/core/steps/mod.rs
@@ -26,8 +26,8 @@ pub use tokenizer_registration::{
 };
 pub use wasm_module_registration::{
     create_wasm_module_registration_workflow, create_wasm_registration_workflow_data,
-    CalculateHashStep, CheckDuplicateStep, LoadWasmBytesStep, RegisterModuleStep,
-    ValidateDescriptorStep, ValidateWasmComponentStep, WasmModuleConfigRequest,
+    AcquireModuleStep, CheckDuplicateStep, RegisterModuleStep, ValidateDescriptorStep,
+    ValidateWasmComponentStep, WasmModuleConfigRequest,
 };
 pub use wasm_module_removal::{
     create_wasm_module_removal_workflow, create_wasm_removal_workflow_data, FindModuleToRemoveStep,

--- a/sgl-model-gateway/src/core/steps/wasm_module_registration.rs
+++ b/sgl-model-gateway/src/core/steps/wasm_module_registration.rs
@@ -1,8 +1,4 @@
-use std::{
-    path::{Component as PathComponent, Path},
-    sync::Arc,
-    time::Duration,
-};
+use std::{sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use sha2::{Digest, Sha256};
@@ -27,41 +23,12 @@ pub struct WasmModuleConfigRequest {
     pub descriptor: WasmModuleDescriptor,
 }
 
-/// Sensitive system directories that WASM modules cannot be loaded from.
-/// These are blocked to prevent information disclosure attacks.
-const BLOCKED_PATH_PREFIXES: &[&str] = &[
-    "/etc/",
-    "/proc/",
-    "/sys/",
-    "/dev/",
-    "/boot/",
-    "/root/",
-    "/var/log/",
-    "/var/run/",
-];
-
-/// Check if a path starts with any blocked prefix.
-/// Returns the matched prefix if found, None otherwise.
-fn find_blocked_prefix(path: &str) -> Option<&'static str> {
-    BLOCKED_PATH_PREFIXES
-        .iter()
-        .find(|&&prefix| path.starts_with(prefix))
-        .copied()
-}
-
-/// Check if a path has a .wasm extension (case-insensitive).
-fn has_wasm_extension(path: &Path) -> bool {
-    path.extension()
-        .is_some_and(|ext| ext.eq_ignore_ascii_case("wasm"))
-}
-
 /// Step 1: Validate module descriptor
 ///
-/// Validates that the module descriptor has all required fields:
-/// - Module name is not empty
-/// - File path is not empty
-/// - File exists and is readable
-/// - File size is not zero
+/// Checks the descriptor's own fields, then resolves the requested file path
+/// against the configured module roots. Confinement to those roots is the
+/// security boundary; see [`crate::wasm::module_roots`] for why an allow-list
+/// replaced the deny-list of sensitive directories that used to live here.
 pub struct ValidateDescriptorStep;
 
 #[async_trait]
@@ -70,143 +37,62 @@ impl StepExecutor<WasmRegistrationWorkflowData> for ValidateDescriptorStep {
         &self,
         context: &mut WorkflowContext<WasmRegistrationWorkflowData>,
     ) -> WorkflowResult<StepResult> {
-        let descriptor = &context.data.config.descriptor;
+        let step_id = || StepId::new("validate_descriptor");
 
-        debug!("Validating WASM module descriptor: {}", descriptor.name);
+        // Take owned copies so the shared borrow of `context.data` ends before
+        // the resolved path is written back to it.
+        let (module_name, requested_path) = {
+            let descriptor = &context.data.config.descriptor;
+            (descriptor.name.clone(), descriptor.file_path.clone())
+        };
 
-        // Validate name
-        if descriptor.name.is_empty() {
+        debug!("Validating WASM module descriptor: {}", module_name);
+
+        if module_name.is_empty() {
             return Err(WorkflowError::StepFailed {
-                step_id: StepId::new("validate_descriptor"),
+                step_id: step_id(),
                 message: "Module name cannot be empty".to_string(),
             });
         }
 
-        // Validate file path
-        if descriptor.file_path.is_empty() {
+        if requested_path.is_empty() {
             return Err(WorkflowError::StepFailed {
-                step_id: StepId::new("validate_descriptor"),
+                step_id: step_id(),
                 message: "Module file path cannot be empty".to_string(),
             });
         }
 
-        // Security: Validate path to prevent path traversal attacks
-        let path = Path::new(&descriptor.file_path);
+        let roots = context
+            .data
+            .app_context
+            .as_ref()
+            .ok_or_else(|| WorkflowError::ContextValueNotFound("app_context".to_string()))?
+            .wasm_module_roots
+            .clone()
+            .ok_or_else(|| WorkflowError::StepFailed {
+                step_id: step_id(),
+                message: "WASM module roots are not configured".to_string(),
+            })?;
 
-        // Must be an absolute path
-        if !path.is_absolute() {
-            return Err(WorkflowError::StepFailed {
-                step_id: StepId::new("validate_descriptor"),
-                message: format!(
-                    "Module file path must be absolute, got: {}",
-                    descriptor.file_path
-                ),
-            });
-        }
-
-        // Check for path traversal components (.. or symbolic links that could escape)
-        for component in path.components() {
-            match component {
-                PathComponent::ParentDir => {
-                    warn!(
-                        "Path traversal attempt detected in WASM module path: {}",
-                        descriptor.file_path
-                    );
-                    return Err(WorkflowError::StepFailed {
-                        step_id: StepId::new("validate_descriptor"),
-                        message: "Path traversal (..) not allowed in module file path".to_string(),
-                    });
-                }
-                PathComponent::CurDir => {
-                    return Err(WorkflowError::StepFailed {
-                        step_id: StepId::new("validate_descriptor"),
-                        message: "Current directory (.) not allowed in module file path"
-                            .to_string(),
-                    });
-                }
-                _ => {}
+        // One call replaces the former absolute-path check, `..`/`.` scan,
+        // deny-list, symlink re-check and existence probe. The error deliberately
+        // says nothing about where the path led; that detail is logged instead.
+        let canonical_path = roots.resolve(&requested_path).await.map_err(|error| {
+            // `?error` (Debug) so the log keeps the precise cause; the message
+            // handed back to the caller uses Display, which by construction
+            // cannot say whether the path existed. See `ModulePathError`.
+            warn!(
+                requested = %requested_path,
+                ?error,
+                "Rejected WASM module path"
+            );
+            WorkflowError::StepFailed {
+                step_id: step_id(),
+                message: error.to_string(),
             }
-        }
+        })?;
 
-        // Require .wasm extension to prevent loading arbitrary files
-        if !has_wasm_extension(path) {
-            return Err(WorkflowError::StepFailed {
-                step_id: StepId::new("validate_descriptor"),
-                message: "Module file must have .wasm extension".to_string(),
-            });
-        }
-
-        // Block access to sensitive system directories
-        if let Some(prefix) = find_blocked_prefix(&descriptor.file_path) {
-            warn!(
-                "Attempt to access blocked directory in WASM module path: {}",
-                descriptor.file_path
-            );
-            return Err(WorkflowError::StepFailed {
-                step_id: StepId::new("validate_descriptor"),
-                message: format!("Access to {} directory is not allowed", prefix),
-            });
-        }
-
-        // Check if file exists and get size
-        let metadata = tokio::fs::metadata(&descriptor.file_path)
-            .await
-            .map_err(|e| WorkflowError::StepFailed {
-                step_id: StepId::new("validate_descriptor"),
-                message: format!("Failed to access file {}: {}", descriptor.file_path, e),
-            })?;
-
-        if metadata.len() == 0 {
-            return Err(WorkflowError::StepFailed {
-                step_id: StepId::new("validate_descriptor"),
-                message: "Module file size cannot be 0".to_string(),
-            });
-        }
-
-        // Canonicalize the path to resolve symlinks and verify final location is safe
-        let canonical_path = tokio::fs::canonicalize(&descriptor.file_path)
-            .await
-            .map_err(|e| WorkflowError::StepFailed {
-                step_id: StepId::new("validate_descriptor"),
-                message: format!(
-                    "Failed to canonicalize path {}: {}",
-                    descriptor.file_path, e
-                ),
-            })?;
-
-        // Re-check blocked directories after symlink resolution
-        let canonical_str = canonical_path.to_string_lossy();
-        if let Some(prefix) = find_blocked_prefix(&canonical_str) {
-            warn!(
-                "Symlink resolved to blocked directory: {} -> {}",
-                descriptor.file_path, canonical_str
-            );
-            return Err(WorkflowError::StepFailed {
-                step_id: StepId::new("validate_descriptor"),
-                message: format!(
-                    "Path resolves to blocked directory {} (via symlink)",
-                    prefix
-                ),
-            });
-        }
-
-        // Ensure canonicalized path still has .wasm extension (symlink target check)
-        if !has_wasm_extension(&canonical_path) {
-            warn!(
-                "Symlink target is not a .wasm file: {} -> {}",
-                descriptor.file_path, canonical_str
-            );
-            return Err(WorkflowError::StepFailed {
-                step_id: StepId::new("validate_descriptor"),
-                message: "Symlink target must be a .wasm file".to_string(),
-            });
-        }
-
-        // Clone name for logging before mutable borrow
-        let module_name = descriptor.name.clone();
-
-        // Store file size in typed data
-        context.data.file_size_bytes = Some(metadata.len());
+        context.data.canonical_path = Some(canonical_path.to_string_lossy().into_owned());
 
         info!(
             "Descriptor validated successfully for module: {}",
@@ -220,60 +106,55 @@ impl StepExecutor<WasmRegistrationWorkflowData> for ValidateDescriptorStep {
     }
 }
 
-/// Step 2: Calculate SHA256 hash of the module file
+/// Step 2: Read the module and derive its size and hash
 ///
-/// Reads the file and calculates its SHA256 hash for deduplication.
-/// This step is I/O intensive and may take time for large files.
-pub struct CalculateHashStep;
+/// Hashing and loading were once separate steps, which meant the file was read
+/// twice — and the hash could, in principle, describe a different revision of
+/// the file than the bytes that were ultimately registered. Reading once and
+/// deriving both from the same buffer removes the redundant I/O and makes that
+/// disagreement impossible.
+///
+/// Streaming the hash in chunks bought nothing either: the whole file is held
+/// in memory afterwards regardless, since the bytes are what get registered.
+pub struct AcquireModuleStep;
 
 #[async_trait]
-impl StepExecutor<WasmRegistrationWorkflowData> for CalculateHashStep {
+impl StepExecutor<WasmRegistrationWorkflowData> for AcquireModuleStep {
     async fn execute(
         &self,
         context: &mut WorkflowContext<WasmRegistrationWorkflowData>,
     ) -> WorkflowResult<StepResult> {
-        let file_path = &context.data.config.descriptor.file_path;
+        let step_id = || StepId::new("acquire_module");
 
-        debug!("Calculating SHA256 hash for: {}", file_path);
+        let path = context
+            .data
+            .canonical_path
+            .clone()
+            .ok_or_else(|| WorkflowError::ContextValueNotFound("canonical_path".to_string()))?;
 
-        // Read file in chunks to handle large files efficiently
-        let mut file =
-            tokio::fs::File::open(file_path)
-                .await
-                .map_err(|e| WorkflowError::StepFailed {
-                    step_id: StepId::new("calculate_hash"),
-                    message: format!("Failed to open file {}: {}", file_path, e),
-                })?;
+        debug!("Reading WASM module from: {}", path);
 
-        let mut hasher = Sha256::new();
-        let mut buffer = vec![0u8; 1024 * 1024]; // 1MB buffer
+        let wasm_bytes = tokio::fs::read(&path)
+            .await
+            .map_err(|e| WorkflowError::StepFailed {
+                step_id: step_id(),
+                message: format!("Failed to read WASM module: {}", e),
+            })?;
 
-        loop {
-            use tokio::io::AsyncReadExt;
-            let bytes_read =
-                file.read(&mut buffer)
-                    .await
-                    .map_err(|e| WorkflowError::StepFailed {
-                        step_id: StepId::new("calculate_hash"),
-                        message: format!("Failed to read file {}: {}", file_path, e),
-                    })?;
-
-            if bytes_read == 0 {
-                break;
-            }
-
-            hasher.update(&buffer[..bytes_read]);
+        if wasm_bytes.is_empty() {
+            return Err(WorkflowError::StepFailed {
+                step_id: step_id(),
+                message: "Module file size cannot be 0".to_string(),
+            });
         }
 
-        let hash: [u8; 32] = hasher.finalize().into();
+        let hash: [u8; 32] = Sha256::digest(&wasm_bytes).into();
 
-        // Clone path for logging before mutable borrow
-        let path_for_log = file_path.clone();
-
-        // Store hash in typed data
+        context.data.file_size_bytes = Some(wasm_bytes.len() as u64);
         context.data.sha256_hash = Some(hash);
+        context.data.wasm_bytes = Some(wasm_bytes);
 
-        info!("SHA256 hash calculated for: {}", path_for_log);
+        info!("WASM module read and hashed: {}", path);
         Ok(StepResult::Success)
     }
 
@@ -340,46 +221,7 @@ impl StepExecutor<WasmRegistrationWorkflowData> for CheckDuplicateStep {
     }
 }
 
-/// Step 4: Load WASM bytes into memory
-///
-/// Reads the entire WASM file into memory for faster execution.
-/// This is an I/O operation that may take time for large files.
-pub struct LoadWasmBytesStep;
-
-#[async_trait]
-impl StepExecutor<WasmRegistrationWorkflowData> for LoadWasmBytesStep {
-    async fn execute(
-        &self,
-        context: &mut WorkflowContext<WasmRegistrationWorkflowData>,
-    ) -> WorkflowResult<StepResult> {
-        let file_path = &context.data.config.descriptor.file_path;
-
-        debug!("Loading WASM bytes from: {}", file_path);
-
-        // Clone path for logging before mutable borrow
-        let path_for_log = file_path.clone();
-
-        let wasm_bytes =
-            tokio::fs::read(file_path)
-                .await
-                .map_err(|e| WorkflowError::StepFailed {
-                    step_id: StepId::new("load_wasm_bytes"),
-                    message: format!("Failed to read WASM file {}: {}", file_path, e),
-                })?;
-
-        // Store WASM bytes in typed data
-        context.data.wasm_bytes = Some(wasm_bytes);
-
-        info!("WASM bytes loaded from: {}", path_for_log);
-        Ok(StepResult::Success)
-    }
-
-    fn is_retryable(&self, _error: &WorkflowError) -> bool {
-        true // File read errors are retryable
-    }
-}
-
-/// Step 5: Validate WASM component format
+/// Step 4: Validate WASM component format
 ///
 /// Validates that the loaded WASM bytes represent a valid component.
 /// This catches format errors early during registration rather than during execution.
@@ -436,7 +278,7 @@ impl StepExecutor<WasmRegistrationWorkflowData> for ValidateWasmComponentStep {
     }
 }
 
-/// Step 6: Register module in WasmModuleManager
+/// Step 5: Register module in WasmModuleManager
 ///
 /// Creates the WasmModule object and registers it in the manager's module map.
 /// This is the final step that makes the module available for execution.
@@ -468,6 +310,14 @@ impl StepExecutor<WasmRegistrationWorkflowData> for RegisterModuleStep {
             .ok_or_else(|| WorkflowError::ContextValueNotFound("wasm_bytes".to_string()))?
             .clone();
 
+        // Record the path the bytes actually came from, not the caller's spelling
+        // of it, so the module listing reflects what was loaded.
+        let canonical_path = context
+            .data
+            .canonical_path
+            .clone()
+            .ok_or_else(|| WorkflowError::ContextValueNotFound("canonical_path".to_string()))?;
+
         let descriptor = &context.data.config.descriptor;
 
         debug!("Registering WASM module in manager: {}", descriptor.name);
@@ -494,7 +344,7 @@ impl StepExecutor<WasmRegistrationWorkflowData> for RegisterModuleStep {
             module_uuid,
             module_meta: WasmModuleMeta {
                 name: descriptor.name.clone(),
-                file_path: descriptor.file_path.clone(),
+                file_path: canonical_path,
                 sha256_hash,
                 size_bytes: file_size_bytes,
                 created_at: now,
@@ -535,18 +385,16 @@ impl StepExecutor<WasmRegistrationWorkflowData> for RegisterModuleStep {
 /// Create WASM module registration workflow
 ///
 /// This workflow handles the complete process of registering a WASM module:
-/// - Validates the module descriptor
-/// - Calculates SHA256 hash for deduplication
+/// - Validates the descriptor and confines the path to a configured module root
+/// - Reads the module once, deriving its size and SHA256 hash from that read
 /// - Checks for duplicates
-/// - Loads WASM bytes into memory
 /// - Validates WASM component format
 /// - Registers the module in the manager
 ///
 /// Workflow configuration:
-/// - ValidateDescriptor: No retry, 5s timeout (fast validation)
-/// - CalculateHash: 3 retries, 60s timeout (I/O intensive, may need retry)
+/// - ValidateDescriptor: No retry, 5s timeout (rejects bad input; retrying cannot help)
+/// - AcquireModule: 3 retries, 60s timeout (I/O intensive, may need retry)
 /// - CheckDuplicate: No retry, 5s timeout (fast check)
-/// - LoadWasmBytes: 3 retries, 60s timeout (I/O intensive)
 /// - ValidateWasmComponent: No retry, 30s timeout (CPU intensive validation)
 /// - RegisterModule: No retry, 5s timeout (fast registration)
 pub fn create_wasm_module_registration_workflow() -> WorkflowDefinition<WasmRegistrationWorkflowData>
@@ -563,9 +411,9 @@ pub fn create_wasm_module_registration_workflow() -> WorkflowDefinition<WasmRegi
         )
         .add_step(
             StepDefinition::new(
-                "calculate_hash",
-                "Calculate SHA256 Hash",
-                Arc::new(CalculateHashStep),
+                "acquire_module",
+                "Read Module and Compute Hash",
+                Arc::new(AcquireModuleStep),
             )
             .with_retry(RetryPolicy {
                 max_attempts: 3,
@@ -583,21 +431,7 @@ pub fn create_wasm_module_registration_workflow() -> WorkflowDefinition<WasmRegi
             )
             .with_timeout(Duration::from_secs(5))
             .with_failure_action(FailureAction::FailWorkflow)
-            .depends_on(&["calculate_hash"]),
-        )
-        .add_step(
-            StepDefinition::new(
-                "load_wasm_bytes",
-                "Load WASM Bytes",
-                Arc::new(LoadWasmBytesStep),
-            )
-            .with_retry(RetryPolicy {
-                max_attempts: 3,
-                backoff: BackoffStrategy::Fixed(Duration::from_secs(1)),
-            })
-            .with_timeout(Duration::from_secs(60))
-            .with_failure_action(FailureAction::FailWorkflow)
-            .depends_on(&["check_duplicate"]),
+            .depends_on(&["acquire_module"]),
         )
         .add_step(
             StepDefinition::new(
@@ -607,7 +441,7 @@ pub fn create_wasm_module_registration_workflow() -> WorkflowDefinition<WasmRegi
             )
             .with_timeout(Duration::from_secs(30))
             .with_failure_action(FailureAction::FailWorkflow)
-            .depends_on(&["load_wasm_bytes"]),
+            .depends_on(&["check_duplicate"]),
         )
         .add_step(
             StepDefinition::new(
@@ -628,6 +462,7 @@ pub fn create_wasm_registration_workflow_data(
 ) -> WasmRegistrationWorkflowData {
     WasmRegistrationWorkflowData {
         config,
+        canonical_path: None,
         wasm_bytes: None,
         sha256_hash: None,
         file_size_bytes: None,

--- a/sgl-model-gateway/src/core/steps/workflow_data.rs
+++ b/sgl-model-gateway/src/core/steps/workflow_data.rs
@@ -316,6 +316,10 @@ impl McpWorkflowData {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WasmRegistrationWorkflowData {
     pub config: WasmModuleConfigRequest,
+    /// The requested path once resolved and confirmed to lie inside a configured
+    /// module root. Every later step reads this rather than the caller's string,
+    /// so validation and use cannot disagree about which file is meant.
+    pub canonical_path: Option<String>,
     pub wasm_bytes: Option<Vec<u8>>,
     /// SHA256 hash of the module file (32 bytes)
     pub sha256_hash: Option<[u8; 32]>,

--- a/sgl-model-gateway/src/service_discovery.rs
+++ b/sgl-model-gateway/src/service_discovery.rs
@@ -877,6 +877,7 @@ mod tests {
             mcp_manager: Arc::new(std::sync::OnceLock::new()),
             tokenizer_registry: Arc::new(crate::tokenizer::registry::TokenizerRegistry::new()),
             wasm_manager: None,
+            wasm_module_roots: None,
             worker_service: Arc::new(WorkerService::new(
                 worker_registry,
                 worker_job_queue,

--- a/sgl-model-gateway/src/wasm/mod.rs
+++ b/sgl-model-gateway/src/wasm/mod.rs
@@ -7,3 +7,6 @@ pub use smg_wasm::*;
 
 // Local HTTP API routes (depends on app-specific types)
 pub mod route;
+
+// Allow-list of directories modules may be loaded from
+pub mod module_roots;

--- a/sgl-model-gateway/src/wasm/module_roots.rs
+++ b/sgl-model-gateway/src/wasm/module_roots.rs
@@ -1,0 +1,368 @@
+//! Where WASM modules may be loaded from.
+//!
+//! Module registration takes a caller-supplied filesystem path, so it needs a
+//! rule for which paths are acceptable. That rule used to be a deny-list of
+//! sensitive system directories (`/etc/`, `/proc/`, ...) compared with
+//! `str::starts_with`. Three things were wrong with it:
+//!
+//! 1. A deny-list of sensitive directories can never be complete. The old list
+//!    did not cover `~/.ssh`, `~/.aws`, `/srv` or `/home/*` even on Linux, and
+//!    on Windows — where paths look like `C:\Windows\System32\` — it matched
+//!    nothing at all, so the control was silently inert on that platform.
+//! 2. Comparing paths as raw strings is not the same as comparing them as
+//!    paths: `/srv/modules-evil/x.wasm` textually starts with `/srv/modules`.
+//! 3. Reporting *which* rule rejected a path leaks information back to the
+//!    caller, which is precisely what the check exists to prevent.
+//!
+//! This module replaces that with an allow-list: a module must resolve to a
+//! location inside one of the configured roots. Deny-by-default means there is
+//! nothing to forget to block, and because the roots come from configuration
+//! there are no hardcoded paths to get wrong per platform.
+
+use std::path::{Path, PathBuf};
+
+use thiserror::Error;
+
+/// Directories a WASM module may be loaded from.
+///
+/// The roots are canonicalised once, when the gateway starts, so that every
+/// later comparison has both sides in the same normalised form. On Windows that
+/// form is the `\\?\C:\...` extended-length path with the on-disk casing, which
+/// is why comparing a canonicalised candidate against a raw configured string
+/// would not work.
+#[derive(Debug, Clone)]
+pub struct ModuleRoots {
+    roots: Vec<PathBuf>,
+}
+
+/// Failure to establish the roots at startup.
+#[derive(Debug, Error)]
+pub enum ModuleRootsError {
+    #[error("WASM is enabled but no module root is configured (set --wasm-module-root)")]
+    NoRootsConfigured,
+
+    #[error("configured WASM module root {path} is not usable: {source}")]
+    UnusableRoot {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+/// Why a requested module path was refused.
+///
+/// `Display` is the rendering that crosses the API boundary, so the distinction
+/// the caller must not learn is kept out of it *structurally* rather than by
+/// remembering to collapse it at each call site: [`Unavailable`] covers both
+/// "no such file" and "resolved, but outside every root", and its message
+/// interpolates nothing. Telling those two apart would turn module registration
+/// into an existence oracle for arbitrary filesystem paths — precisely the
+/// disclosure the containment check exists to prevent.
+///
+/// The cause is not discarded; it rides along in a field that only `Debug`
+/// renders, so server-side logs keep full detail.
+///
+/// [`Unavailable`]: ModulePathError::Unavailable
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum ModulePathError {
+    #[error("module file is not available at the requested path")]
+    Unavailable(Unavailability),
+
+    /// Reachable only by a file that already resolved *inside* a configured
+    /// root, so naming this case tells the caller nothing about paths it could
+    /// not already reach. Kept distinct because collapsing it would leave a
+    /// legitimate operator with no hint about a genuine mistake.
+    #[error("module file must have a .wasm extension")]
+    NotWasm,
+}
+
+/// The server-side cause behind [`ModulePathError::Unavailable`].
+///
+/// Deliberately not `Display`: giving it a user-facing rendering is exactly how
+/// the distinction would escape to the caller again. Logs read it via `Debug`.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Unavailability {
+    /// `canonicalize` failed — the path does not exist, or is not readable.
+    Unresolvable,
+    /// The path resolved to a real location, but outside every configured root.
+    OutsideRoots,
+}
+
+impl ModuleRoots {
+    /// Canonicalise the configured roots.
+    ///
+    /// Fails closed: enabling WASM without naming a root is a configuration
+    /// mistake, not permission to read the whole filesystem.
+    pub fn load(raw: &[String]) -> Result<Self, ModuleRootsError> {
+        if raw.is_empty() {
+            return Err(ModuleRootsError::NoRootsConfigured);
+        }
+
+        let roots = raw
+            .iter()
+            .map(|path| {
+                std::fs::canonicalize(path).map_err(|source| ModuleRootsError::UnusableRoot {
+                    path: path.clone(),
+                    source,
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(Self { roots })
+    }
+
+    /// Resolve a caller-supplied path to a real location inside a root.
+    ///
+    /// `canonicalize` collapses `.` and `..`, resolves symlinks and junctions,
+    /// and normalises casing and 8.3 short names. A single call therefore
+    /// subsumes the separate absolute-path check, the `..`/`.` component scan
+    /// and the post-symlink re-check that the old validation performed by hand.
+    pub async fn resolve(&self, requested: &str) -> Result<PathBuf, ModulePathError> {
+        let canonical = tokio::fs::canonicalize(requested)
+            .await
+            .map_err(|_| ModulePathError::Unavailable(Unavailability::Unresolvable))?;
+
+        if !self.contains(&canonical) {
+            return Err(ModulePathError::Unavailable(Unavailability::OutsideRoots));
+        }
+
+        if !has_wasm_extension(&canonical) {
+            return Err(ModulePathError::NotWasm);
+        }
+
+        Ok(canonical)
+    }
+
+    /// Whether an already-canonical path lies inside one of the roots.
+    ///
+    /// `Path::starts_with` compares whole path components. That is the entire
+    /// point: a textual comparison would accept `<root>-evil/x.wasm`, because
+    /// those characters really do start with `<root>`.
+    fn contains(&self, canonical: &Path) -> bool {
+        self.roots.iter().any(|root| canonical.starts_with(root))
+    }
+
+    /// The canonicalised roots, for logging and diagnostics.
+    pub fn roots(&self) -> &[PathBuf] {
+        &self.roots
+    }
+}
+
+/// Whether a path ends in `.wasm`, ignoring case.
+///
+/// This is hygiene rather than a security boundary — containment above is the
+/// boundary — but it keeps obvious mistakes from reaching the WASM compiler.
+fn has_wasm_extension(path: &Path) -> bool {
+    path.extension()
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("wasm"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    /// Lays out:
+    ///   <base>/modules/ok.wasm
+    ///   <base>/modules/sub/deep.wasm
+    ///   <base>/modules/notes.txt
+    ///   <base>/modules-evil/evil.wasm   <- sibling sharing a textual prefix
+    ///   <base>/outside.wasm
+    fn fixture() -> (TempDir, ModuleRoots) {
+        let base = TempDir::new().expect("temp dir");
+        let modules = base.path().join("modules");
+        fs::create_dir_all(modules.join("sub")).unwrap();
+        fs::create_dir_all(base.path().join("modules-evil")).unwrap();
+        fs::write(modules.join("ok.wasm"), b"\0asm").unwrap();
+        fs::write(modules.join("sub/deep.wasm"), b"\0asm").unwrap();
+        fs::write(modules.join("notes.txt"), b"hi").unwrap();
+        fs::write(base.path().join("modules-evil/evil.wasm"), b"\0asm").unwrap();
+        fs::write(base.path().join("outside.wasm"), b"\0asm").unwrap();
+
+        let roots = ModuleRoots::load(&[modules.to_string_lossy().into_owned()]).unwrap();
+        (base, roots)
+    }
+
+    #[tokio::test]
+    async fn accepts_a_module_directly_inside_a_root() {
+        let (base, roots) = fixture();
+        let path = base.path().join("modules/ok.wasm");
+        let resolved = roots.resolve(&path.to_string_lossy()).await.unwrap();
+        assert!(resolved.ends_with("ok.wasm"));
+    }
+
+    #[tokio::test]
+    async fn accepts_a_module_nested_below_a_root() {
+        let (base, roots) = fixture();
+        let path = base.path().join("modules/sub/deep.wasm");
+        assert!(roots.resolve(&path.to_string_lossy()).await.is_ok());
+    }
+
+    /// The case a textual prefix comparison gets wrong.
+    #[tokio::test]
+    async fn rejects_a_sibling_directory_sharing_a_textual_prefix() {
+        let (base, roots) = fixture();
+        let path = base.path().join("modules-evil/evil.wasm");
+        assert_eq!(
+            roots.resolve(&path.to_string_lossy()).await,
+            Err(ModulePathError::Unavailable(Unavailability::OutsideRoots))
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_an_escape_through_parent_directory_components() {
+        let (base, roots) = fixture();
+        let path = base.path().join("modules/../outside.wasm");
+        assert_eq!(
+            roots.resolve(&path.to_string_lossy()).await,
+            Err(ModulePathError::Unavailable(Unavailability::OutsideRoots))
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_a_path_outside_every_root() {
+        let (base, roots) = fixture();
+        let path = base.path().join("outside.wasm");
+        assert_eq!(
+            roots.resolve(&path.to_string_lossy()).await,
+            Err(ModulePathError::Unavailable(Unavailability::OutsideRoots))
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_a_non_wasm_file_inside_a_root() {
+        let (base, roots) = fixture();
+        let path = base.path().join("modules/notes.txt");
+        assert_eq!(
+            roots.resolve(&path.to_string_lossy()).await,
+            Err(ModulePathError::NotWasm)
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_a_path_that_does_not_exist() {
+        let (base, roots) = fixture();
+        let path = base.path().join("modules/absent.wasm");
+        assert_eq!(
+            roots.resolve(&path.to_string_lossy()).await,
+            Err(ModulePathError::Unavailable(Unavailability::Unresolvable))
+        );
+    }
+
+    /// The property the error type exists to hold: the caller cannot tell "no
+    /// such file" from "exists, but outside the roots". If these ever render
+    /// differently, module registration is an existence oracle again.
+    #[tokio::test]
+    async fn does_not_reveal_whether_a_rejected_path_exists() {
+        let (base, roots) = fixture();
+
+        let absent = roots
+            .resolve(&base.path().join("modules/absent.wasm").to_string_lossy())
+            .await
+            .unwrap_err();
+        let outside = roots
+            .resolve(&base.path().join("outside.wasm").to_string_lossy())
+            .await
+            .unwrap_err();
+
+        // The server still knows which is which...
+        assert_eq!(
+            absent,
+            ModulePathError::Unavailable(Unavailability::Unresolvable)
+        );
+        assert_eq!(
+            outside,
+            ModulePathError::Unavailable(Unavailability::OutsideRoots)
+        );
+        assert_ne!(absent, outside);
+
+        // ...but the caller is told one and the same thing.
+        assert_eq!(absent.to_string(), outside.to_string());
+    }
+
+    /// Windows counterpart to the Unix test below.
+    ///
+    /// This is the case the old deny-list never covered: containment on Windows
+    /// was untested because nothing ran there. Creating a symlink needs
+    /// `SeCreateSymbolicLinkPrivilege` (an elevated shell, or Developer Mode);
+    /// where that is unavailable the test reports why and returns, rather than
+    /// failing for a reason that has nothing to do with the code under test.
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn rejects_a_symlink_escaping_a_root() {
+        let (base, roots) = fixture();
+        let link = base.path().join("modules/escape.wasm");
+
+        if std::os::windows::fs::symlink_file(base.path().join("outside.wasm"), &link).is_err() {
+            eprintln!(
+                "skipped: creating a symlink needs Developer Mode or an elevated shell \
+                 on Windows"
+            );
+            return;
+        }
+
+        assert_eq!(
+            roots.resolve(&link.to_string_lossy()).await,
+            Err(ModulePathError::Unavailable(Unavailability::OutsideRoots))
+        );
+    }
+
+    /// A symlink inside a root that points outside it must not grant access.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn rejects_a_symlink_escaping_a_root() {
+        let (base, roots) = fixture();
+        let link = base.path().join("modules/escape.wasm");
+        std::os::unix::fs::symlink(base.path().join("outside.wasm"), &link).unwrap();
+        assert_eq!(
+            roots.resolve(&link.to_string_lossy()).await,
+            Err(ModulePathError::Unavailable(Unavailability::OutsideRoots))
+        );
+    }
+
+    #[test]
+    fn refuses_to_start_with_no_roots_configured() {
+        assert!(matches!(
+            ModuleRoots::load(&[]),
+            Err(ModuleRootsError::NoRootsConfigured)
+        ));
+    }
+
+    #[test]
+    fn refuses_to_start_when_a_root_does_not_exist() {
+        let missing = TempDir::new().unwrap().path().join("nope");
+        assert!(matches!(
+            ModuleRoots::load(&[missing.to_string_lossy().into_owned()]),
+            Err(ModuleRootsError::UnusableRoot { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn honours_every_configured_root() {
+        let base = TempDir::new().unwrap();
+        let a = base.path().join("a");
+        let b = base.path().join("b");
+        fs::create_dir_all(&a).unwrap();
+        fs::create_dir_all(&b).unwrap();
+        fs::write(a.join("x.wasm"), b"\0asm").unwrap();
+        fs::write(b.join("y.wasm"), b"\0asm").unwrap();
+
+        let roots = ModuleRoots::load(&[
+            a.to_string_lossy().into_owned(),
+            b.to_string_lossy().into_owned(),
+        ])
+        .unwrap();
+
+        assert!(roots
+            .resolve(&a.join("x.wasm").to_string_lossy())
+            .await
+            .is_ok());
+        assert!(roots
+            .resolve(&b.join("y.wasm").to_string_lossy())
+            .await
+            .is_ok());
+    }
+}

--- a/sgl-model-gateway/tests/wasm_test.rs
+++ b/sgl-model-gateway/tests/wasm_test.rs
@@ -8,7 +8,7 @@
 
 mod common;
 
-use std::{sync::Arc, time::Duration};
+use std::{path::Path, sync::Arc, time::Duration};
 
 use axum::{
     body::{to_bytes, Body},
@@ -32,6 +32,7 @@ use smg::{
             WasmModuleDescriptor, WasmModuleListResponse, WasmModuleType,
         },
         module_manager::WasmModuleManager,
+        module_roots::ModuleRoots,
     },
 };
 use tempfile::TempDir;
@@ -40,8 +41,15 @@ use tower::ServiceExt;
 use uuid::Uuid;
 
 /// Create a test AppContext with WASM manager initialized
-async fn create_test_context_with_wasm() -> Arc<AppContext> {
+async fn create_test_context_with_wasm(module_root: &Path) -> Arc<AppContext> {
     let config = RouterConfig::default();
+
+    // Modules may only be loaded from a configured root, so a hand-built context
+    // needs one too — otherwise every registration is refused before it starts.
+    let module_roots = Arc::new(
+        ModuleRoots::load(&[module_root.to_string_lossy().into_owned()])
+            .expect("Failed to load module roots"),
+    );
 
     // Initialize WASM manager first
     let wasm_manager = Arc::new(
@@ -92,6 +100,7 @@ async fn create_test_context_with_wasm() -> Arc<AppContext> {
             .workflow_engines(workflow_engines)
             .mcp_manager(mcp_manager_lock)
             .wasm_manager(Some(wasm_manager))
+            .wasm_module_roots(Some(module_roots))
             .build()
             .expect("Failed to build AppContext with WASM manager"),
     );
@@ -166,7 +175,7 @@ async fn create_test_wasm_component(temp_dir: &TempDir) -> String {
 /// Create a test app with WASM support
 async fn create_test_app_with_wasm() -> (axum::Router, Arc<AppContext>, TempDir) {
     let temp_dir = TempDir::new().expect("Failed to create temp directory");
-    let app_context = create_test_context_with_wasm().await;
+    let app_context = create_test_context_with_wasm(temp_dir.path()).await;
 
     // Create a dummy router (we only need the app for WASM endpoints)
     let router = RouterFactory::create_router(&app_context)
@@ -315,6 +324,80 @@ async fn test_wasm_api_add_module_invalid_file() {
     } else {
         panic!("Expected error result for invalid file path");
     }
+}
+
+/// POST /wasm with `file_path` and return the rejection message the client sees.
+async fn rejection_message(app: &axum::Router, file_path: &str) -> String {
+    let add_request = WasmModuleAddRequest {
+        modules: vec![WasmModuleDescriptor {
+            name: "probe".to_string(),
+            file_path: file_path.to_string(),
+            module_type: WasmModuleType::Middleware,
+            attach_points: vec![WasmModuleAttachPoint::Middleware(
+                smg::wasm::module::MiddlewareAttachPoint::OnRequest,
+            )],
+            add_result: None,
+        }],
+    };
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/wasm")
+                .header(CONTENT_TYPE, "application/json")
+                .body(Body::from(serde_json::to_string(&add_request).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let parsed: WasmModuleAddResponse = serde_json::from_slice(&body).unwrap();
+    assert_eq!(parsed.modules.len(), 1);
+
+    match parsed.modules[0].add_result.as_ref() {
+        Some(smg::wasm::module::WasmModuleAddResult::Error(message)) => message.clone(),
+        other => panic!("expected a rejection for {file_path}, got {other:?}"),
+    }
+}
+
+/// The disclosure property, asserted where it actually matters: at the HTTP
+/// boundary, not on the error type.
+///
+/// The unit test in `module_roots` pins the `Display` impl. This one pins what
+/// reaches the client, so a change at the call site — formatting the error with
+/// `{:?}`, say, or appending the resolved path — cannot reopen the leak while
+/// the unit test stays green.
+#[tokio::test]
+async fn test_wasm_api_rejection_does_not_reveal_path_existence() {
+    let (app, _app_context, temp_dir) = create_test_app_with_wasm().await;
+
+    // Exists on disk, but outside every configured root.
+    let outside_dir = TempDir::new().expect("Failed to create temp directory");
+    let outside_file = outside_dir.path().join("outside.component.wasm");
+    fs::write(&outside_file, b"\0asm\x01\0\0\0")
+        .await
+        .expect("Failed to write file outside the root");
+
+    // Inside the root, but no such file.
+    let absent_file = temp_dir.path().join("absent.component.wasm");
+
+    let absent = rejection_message(&app, &absent_file.to_string_lossy()).await;
+    let outside = rejection_message(&app, &outside_file.to_string_lossy()).await;
+
+    assert_eq!(
+        absent, outside,
+        "rejection messages differ, so a caller can probe which paths exist: \
+         absent={absent:?} outside={outside:?}"
+    );
+
+    // And neither may echo the path back.
+    assert!(
+        !absent.contains("absent.component.wasm") && !outside.contains("outside.component.wasm"),
+        "rejection message echoes the requested path back to the caller"
+    );
 }
 
 #[tokio::test]
@@ -684,6 +767,7 @@ async fn test_wasm_module_execution() {
     let config_request = WasmModuleConfigRequest { descriptor };
     let workflow_data = WasmRegistrationWorkflowData {
         config: config_request,
+        canonical_path: None,
         wasm_bytes: None,
         sha256_hash: None,
         file_size_bytes: None,


### PR DESCRIPTION
The deny-list that keeps WASM modules out of sensitive directories does nothing on Windows, and we ship a Windows wheel.

```rust
const BLOCKED_PATH_PREFIXES: &[&str] = &["/etc/", "/proc/", "/sys/", ...];
path.starts_with(prefix)
```

No Windows path starts with `/etc/`, so `C:\Windows\System32\...` goes straight through.

It's worse than incomplete. It's unreachable. I compiled those two functions verbatim and ran them natively on Windows:

```
C:\Windows\System32\config\probe.wasm     ALLOWED
C:\Users\...\AppData\Roaming\probe.wasm   ALLOWED
/etc/probe.wasm                           rejected earlier, by is_absolute

find_blocked_prefix() matched 0 of 9 cases

is_absolute("/etc/probe.wasm")   = false    has_root = true
is_absolute("C:\Windows\...")    = true     has_root = true
```

`Path::is_absolute()` needs a drive prefix on Windows, so anything that could match the list is already rejected by the absolute-path check above it, and nothing that reaches the list can ever match.

## Why not just add the Windows paths

Because the list was already leaking on Linux. It never covered `~/.ssh`, `~/.aws`, `/srv` or `/home/*`. Adding `C:\Windows\` turns *misses everything on one platform* into *misses some on both*. You can't enumerate sensitive directories.

So this swaps the primitive. A module now has to resolve inside a directory you name:

```bash
smg launch --enable-wasm --wasm-module-root /srv/wasm-modules
```

Deny-by-default leaves nothing to forget to block, and because the roots come from config there's no hardcoded path to get wrong on some platform. `--enable-wasm` without a root refuses to start rather than falling back to the whole filesystem.

Three details worth knowing:

- Containment uses `Path::starts_with`, which compares whole components. A string compare would accept `<root>-evil/x.wasm`.
- One `canonicalize()` replaces the absolute-path check, the `..`/`.` scan, both deny-list passes and the post-symlink re-check.
- Rejections no longer say whether the path existed. `Display` can't tell "no such file" from "outside the roots"; the cause goes to the log instead.

## While I was in there

Validation used to canonicalize the path and then throw the result away. The later steps re-resolved the caller's raw string when they opened the file, so validation and use could disagree about which file was meant. The canonical path now travels in the workflow data and every step reads it.

Path resolution drops from four passes to one, the file is read once instead of twice, and the workflow from six steps to five, with `CalculateHashStep` and `LoadWasmBytesStep` merging into `AcquireModuleStep`.

## Tests

12 unit tests cover containment (direct, nested, outside, multiple roots), the escapes (`..`, symlink, a sibling sharing a textual prefix), startup refusal (no roots, missing root), and that two different rejection causes render identically. One integration test asserts that last property at the HTTP boundary, so a change at the call site can't reopen the leak while the unit test stays green.

```
Linux    cargo test --lib                       404 passed
         cargo test --test wasm_test              9 passed
Windows  cargo test --lib wasm::module_roots     12 passed
```

The Windows run is native rather than WSL, and the `#[cfg(windows)]` symlink-escape test actually executed rather than skipping.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31786370843](https://github.com/sgl-project/sglang/actions/runs/31786370843)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31786370728](https://github.com/sgl-project/sglang/actions/runs/31786370728)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->