### PR TITLE
[AMD] Fix AITER page-size-1 graph metadata

### DIFF
--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -1601,8 +1601,15 @@ class AiterAttnBackend(AttentionBackend):
                             kv_indices[:new_rows, :new_cols].copy_(page_indices)
                             swa_page_table = self.cuda_graph_swa_page_table
                             swa_page_table[:new_rows, :new_cols].copy_(swa_page_indices)
-                        elif self.page_size > 1:
-                            page_indices = self._transform_table_1_to_real(page_indices)
+                        else:
+                            # Unified attention always consumes a page table.
+                            # At page_size == 1, req_to_token is already in the
+                            # required format and still needs to be copied into
+                            # the graph-stable destination buffer.
+                            if self.page_size > 1:
+                                page_indices = self._transform_table_1_to_real(
+                                    page_indices
+                                )
                             new_rows = page_indices.shape[0]
                             new_cols = page_indices.shape[1]
                             kv_indices[:new_rows, :new_cols].copy_(page_indices)

--- a/test/registered/attention/test_aiter_fp8_q_unified_attention.py
+++ b/test/registered/attention/test_aiter_fp8_q_unified_attention.py
@@ -23,6 +23,7 @@ if _RUNNABLE:
         scaled_fp8_quant,
     )
     from sglang.srt.layers.attention.aiter_backend import AiterAttnBackend
+    from sglang.srt.model_executor.forward_batch_info import ForwardMode
 
 
 class _FakeKVPool:
@@ -125,6 +126,63 @@ class TestAiterFP8QUnifiedAttention(CustomTestCase):
             device=device,
         )
         return backend, layer, forward_batch, q
+
+    def test_cuda_graph_page_table_is_refreshed_for_all_page_sizes(self):
+        req_to_token = torch.tensor(
+            [
+                [0, 1, 4, 5, 8, 9, 12, 13],
+                [20, 21, 24, 25, 28, 29, 32, 33],
+            ],
+            dtype=torch.int32,
+            device="cuda",
+        )
+        req_pool_indices = torch.tensor([1, 0], dtype=torch.int32, device="cuda")
+        seq_lens = torch.tensor([4, 3], dtype=torch.int32, device="cuda")
+        max_kv_len = int(seq_lens.max().item())
+
+        for page_size in (1, 2):
+            with self.subTest(page_size=page_size):
+                backend = object.__new__(AiterAttnBackend)
+                backend.use_mla = False
+                backend.use_triton_unified_attention = True
+                backend.use_sliding_window_kv_pool = False
+                backend.max_context_len = req_to_token.shape[1]
+                backend.page_size = page_size
+                backend.req_to_token = req_to_token
+                backend.cuda_graph_page_table = torch.full(
+                    (
+                        len(req_pool_indices),
+                        req_to_token.shape[1] // page_size,
+                    ),
+                    -1,
+                    dtype=torch.int32,
+                    device="cuda",
+                )
+                backend.qo_indptr_unified_decode = torch.arange(
+                    len(req_pool_indices) + 1,
+                    dtype=torch.int32,
+                    device="cuda",
+                )
+
+                backend._apply_cuda_graph_metadata(
+                    bs=len(req_pool_indices),
+                    req_pool_indices=req_pool_indices,
+                    seq_lens=seq_lens,
+                    seq_lens_sum=int(seq_lens.sum().item()),
+                    encoder_lens=None,
+                    forward_mode=ForwardMode.DECODE,
+                    spec_info=None,
+                    seq_lens_cpu=seq_lens.cpu(),
+                    verify_tokens_per_req=None,
+                )
+
+                expected = req_to_token[req_pool_indices, :max_kv_len]
+                if page_size > 1:
+                    expected = expected[:, ::page_size] // page_size
+                actual = backend.forward_metadata.kv_indices[
+                    : len(req_pool_indices), : expected.shape[1]
+                ]
+                torch.testing.assert_close(actual, expected)
 
     def test_q_quantization_is_isolated_to_unified_attention(self):
         for branch in ("mla", "vectorized", "unified", "legacy"):


### PR DESCRIPTION
## Summary

- refresh AITER unified attention's stable CUDA Graph page-table buffer when `page_size == 1`
- preserve the existing page-index transformation for larger page sizes
- add HIP regression coverage for both token-level and paged layouts

Without this copy, non-SWA unified-attention decode replays can consume zero or stale KV indices at page size 1. This affects ROCm Mamba radix-cache configurations that use `no_buffer` while keeping CUDA Graph enabled.

## Test plan

- [x] Run `test_aiter_fp8_q_unified_attention.py` on ROCm/MI308X: 4 tests passed
- [x] Run TP4 Qwen3.5-397B GSM8K with AITER unified attention, CUDA Graph, and `no_buffer` radix cache enabled
- [x] Verify 300-sample GSM8K strict accuracy: baseline 0.9767, DFLASH 0.9667
- [x] Verify repeated 200-sample runs do not show cumulative accuracy degradation or invalid page-table reads

Made with [Cursor](https://cursor.com)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31786342776](https://github.com/sgl-project/sglang/actions/runs/31786342776)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31786342392](https://github.com/sgl-project/sglang/actions/runs/31786342392)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->