### PR TITLE
[AMD] Fix the MoE LoRA JIT compilation on ROCm

### DIFF
--- a/python/sglang/kernels/jit/csrc/lora/moe_lora_align_kernel.cu
+++ b/python/sglang/kernels/jit/csrc/lora/moe_lora_align_kernel.cu
@@ -6,7 +6,12 @@
 
 #include <sgl_kernel/utils.cuh>
 
+#ifdef __HIP_PLATFORM_AMD__
+#include <hipcub/hipcub.hpp>
+namespace cub = hipcub;
+#else
 #include <cub/cub.cuh>
+#endif
 #include <tvm/ffi/container/tensor.h>
 
 #include <algorithm>
@@ -497,7 +502,12 @@ struct MoeLoraAlignBlockSizeKernel {
     int device_max_shared_mem;
     auto device = topk_ids.device();
     int dev_id = device.device_id;
+#ifdef __HIP_PLATFORM_AMD__
+    RuntimeDeviceCheck(
+        hipDeviceGetAttribute(&device_max_shared_mem, hipDeviceAttributeMaxSharedMemoryPerBlock, dev_id));
+#else
     RuntimeDeviceCheck(cudaDeviceGetAttribute(&device_max_shared_mem, cudaDevAttrMaxSharedMemoryPerBlockOptin, dev_id));
+#endif
     const cudaStream_t stream = LaunchKernel::resolve_device(device);
 
     int64_t padded_num_experts = ((num_experts + WARP_SIZE - 1) / WARP_SIZE) * WARP_SIZE;
@@ -529,7 +539,12 @@ struct MoeLoraAlignBlockSizeKernel {
 
       dim3 blockDim(num_thread + fill_threads);
       auto kernel = moe::moe_lora_align_block_size_small_batch_expert_kernel<scalar_t, fill_threads>;
+#ifdef __HIP_PLATFORM_AMD__
+      RuntimeDeviceCheck(hipFuncSetAttribute(
+          reinterpret_cast<const void*>(kernel), hipFuncAttributeMaxDynamicSharedMemorySize, shared_mem));
+#else
       RuntimeDeviceCheck(cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, shared_mem));
+#endif
 
       LaunchKernel(dim3(max_loras), blockDim, stream, shared_mem)(
           kernel,

--- a/python/sglang/kernels/ops/moe/fused_moe_lora_kernel.py
+++ b/python/sglang/kernels/ops/moe/fused_moe_lora_kernel.py
@@ -8,7 +8,18 @@ from sglang.srt.distributed import (
     tensor_model_parallel_all_gather,
     tensor_model_parallel_all_reduce,
 )
-from sglang.srt.utils.common import is_blackwell_supported, is_sm90_supported
+from sglang.srt.utils.common import is_blackwell_supported, is_hip, is_sm90_supported
+
+_IS_HIP = is_hip()
+
+
+# Triton's AMD backend cannot legalize pipelined FP32 async copies here. The
+# kernel loads b as c's element type, so both operands gate this.
+def _safe_num_stages(num_stages: int, *dtypes: torch.dtype) -> int:
+    if _IS_HIP and any(dtype == torch.float32 for dtype in dtypes):
+        return 1
+    return num_stages
+
 
 # Import SGLang's standard PDL support detection
 
@@ -249,7 +260,9 @@ def _fused_moe_lora_shrink(
         "BLOCK_SIZE_K": block_size_k,
         "GROUP_SIZE_M": group_size_m,
         "num_warps": num_warps,
-        "num_stages": num_stages,
+        "num_stages": _safe_num_stages(
+            num_stages, qcurr_hidden_states.dtype, a_intermediate_cache1.dtype
+        ),
         "SPLIT_K": split_k,
         "USE_GDC": use_gdc,
         "launch_pdl": use_gdc,  # triton kernel metadata
@@ -358,7 +371,9 @@ def _fused_moe_lora_expand(
         "BLOCK_SIZE_K": block_size_k,
         "GROUP_SIZE_M": group_size_m,
         "num_warps": num_warps,
-        "num_stages": num_stages,
+        "num_stages": _safe_num_stages(
+            num_stages, a_intermediate_cache1.dtype, b_intermediate_cache1.dtype
+        ),
         "SPLIT_K": split_k,  # Set split_k = 1 for expand calls
         "USE_GDC": use_gdc,
         "launch_pdl": use_gdc,  # triton kernel metadata

--- a/python/sglang/kernels/ops/moe/fused_moe_lora_kernel.py
+++ b/python/sglang/kernels/ops/moe/fused_moe_lora_kernel.py
@@ -10,13 +10,13 @@ from sglang.srt.distributed import (
 )
 from sglang.srt.utils.common import is_blackwell_supported, is_hip, is_sm90_supported
 
-_IS_HIP = is_hip()
+_is_hip = is_hip()
 
 
 # Triton's AMD backend cannot legalize pipelined FP32 async copies here. The
 # kernel loads b as c's element type, so both operands gate this.
 def _safe_num_stages(num_stages: int, *dtypes: torch.dtype) -> int:
-    if _IS_HIP and any(dtype == torch.float32 for dtype in dtypes):
+    if _is_hip and any(dtype == torch.float32 for dtype in dtypes):
         return 1
     return num_stages
 

--- a/test/registered/lora/test_fused_moe_lora_kernel.py
+++ b/test/registered/lora/test_fused_moe_lora_kernel.py
@@ -12,11 +12,12 @@ from sglang.kernels.ops.moe.fused_moe_lora_kernel import fused_moe_lora
 # ==============================================================================
 from sglang.kernels.ops.moe.moe_lora_align import moe_lora_align_block_size
 from sglang.srt.utils import set_random_seed
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 # ==============================================================================
 
 register_cuda_ci(est_time=28, stage="base-b", runner_config="1-gpu-large")
+register_amd_ci(est_time=28, stage="stage-b", runner_config="1-gpu-large-amd")
 
 
 def round_up(x, base):


### PR DESCRIPTION
Co-author-with: @JessicaJiang-123

## Motivation

`test/registered/lora/test_fused_moe_lora_kernel.py` fails all 108 of its parametrizations on ROCm, at JIT compile time, so nothing in the MoE LoRA path runs at all on AMD. Two independent causes; fixing either alone leaves the test red. This refreshes #25237, which diagnosed both but no longer applies after the kernel path, Python path and namespace moved.

**The C++ align kernel does not build.** ROCm ships hipCUB and no `cub/cub.cuh` shim, so preprocessing stops at `fatal error: 'cub/cub.cuh' file not found`. Past that, three of the four CUDA runtime symbols the launch path uses have no HIP alias in `sgl_kernel/utils.cuh`: only `cudaDeviceGetAttribute` is aliased there. `cudaFuncSetAttribute` is not just a rename, since `hipFuncSetAttribute` takes `const void*` and hipcc will not convert a typed kernel function pointer implicitly:

```text
error: no matching function for call to 'hipFuncSetAttribute'
note: candidate function not viable: no known conversion from
      'void (*)(int *__restrict, ...)' to 'const void *' for 1st argument
```

**The fused LoRA GEMM does not build for fp32.** With software pipelining on, the AMD backend cannot legalize the async copy the pipeliner emits:

```text
error: failed to legalize operation 'ttg.async_copy_global_to_local' that was explicitly marked illegal
... ConvertTritonAMDGPUToLLVM ... PassManager::run failed
```

On Triton 3.6.0, `canLoadDirectToLDS` requires the whole vector to fit one legal direct-to-LDS width, because CDNA3 and CDNA4 cannot scatter this load type. `supportsDirectToLdsLoadBitWidth` accepts `{32}` on CDNA3 and `{32, 128}` on CDNA4. For fp32 the vectorization this kernel picks puts `vec * 32` outside that set; fp16 and bf16 land on a legal `vec * 16` for the same shape, which is why exactly the 36 fp32 cases fail and the other 72 pass. At `num_stages == 1` the pipeliner emits no async copy at all.

## Modifications

Guard the CUB include and the two host-side runtime calls in `moe_lora_align_kernel.cu` on `__HIP_PLATFORM_AMD__`. The HIP branch includes `hipcub/hipcub.hpp` and aliases the `cub` namespace to `hipcub`, so the existing `cub::BlockScan` compiles unchanged, and calls `hipDeviceGetAttribute` and `hipFuncSetAttribute` directly with the kernel pointer cast to `const void*`. The CUDA include and both CUDA call sites are byte-identical in the `#else`; the diff has no deleted lines.

Add `_safe_num_stages(num_stages, *dtypes)`, returning 1 only on HIP when any operand is fp32. Both `_fused_moe_lora_shrink` and `_fused_moe_lora_expand` pass their `a` and `c` tensors: the kernel loads `b` as `c`'s element type (`cur_b_ptr = tl.load(b_ptr + slice_id).to(tl.pointer_type(c_ptr.dtype.element_ty))`) and nothing asserts the two share a dtype, so gating on the input alone would miss an fp32 `b`.

Register the test on AMD CI at `stage-b` / `1-gpu-large-amd`. The CUDA registration is untouched.

## Accuracy Tests

Ran the registered test on MI355X (gfx950) as a source overlay, from a cold, isolated SGLang, Triton and TVM-FFI cache: `108 passed in 25.54s`. A cache audit confirms ROCm `hipcc` compiled `moe_lora_align_kernel.cu` from this path into a gfx950 JIT object, and that the four fp32 artifacts were built with `num_stages=1` while the four fp16 and four bf16 kept `num_stages=3`.

That run used a ROCm 7.2 / Triton 3.6.0 / `sglang-kernel` 0.4.5 container rather than a rebuild of the pinned image, and covers gfx950 only. `_safe_num_stages` gates on HIP rather than on an architecture, which is the conservative direction: CDNA3's accepted set is a subset of CDNA4's, so narrowing to CDNA4 would leave gfx942 broken rather than fix it. I can run gfx942 too if that is wanted before merge.

## Speed Tests and Profiling

None expected. On CUDA, and on HIP for fp16 and bf16, `_safe_num_stages` returns the caller's value unchanged, and the C++ changes sit in `#ifdef` branches CUDA never compiles. The only behaviour change is that fp32 on HIP now compiles and runs unpipelined, where before it did not compile.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). No documentation change is needed for a ROCm compile fix.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31914644149](https://github.com/sgl-project/sglang/actions/runs/31914644149)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31914643980](https://github.com/sgl-project/sglang/actions/runs/31914643980)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->