### PR TITLE
[Spec] Support MegaMoE for DSpark under dp attention

### DIFF
--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -286,11 +286,24 @@ def _handle_dspark(server_args: ServerArgs) -> None:
     if server_args.enable_dp_attention and server_args.dp_size > 1:
         if not server_args.enable_dp_lm_head:
             raise ValueError("DSpark with dp attention requires --enable-dp-lm-head.")
-        if not _is_npu and server_args.moe_a2a_backend != "none":
+        if not _is_npu and server_args.moe_a2a_backend not in ("none", "megamoe"):
             raise ValueError(
-                "DSpark with dp attention only supports the built-in TP MoE "
-                f"(moe_a2a_backend='none'), got {server_args.moe_a2a_backend!r}."
+                "DSpark with dp attention supports moe_a2a_backend 'none' "
+                "(built-in TP MoE) or 'megamoe', got "
+                f"{server_args.moe_a2a_backend!r}."
             )
+        if not _is_npu and server_args.moe_a2a_backend != "none":
+            from sglang.srt.speculative.ragged_verify import (
+                RaggedVerifyMode,
+                read_ragged_verify_mode,
+            )
+
+            if read_ragged_verify_mode() is not RaggedVerifyMode.STATIC:
+                raise ValueError(
+                    "DSpark with dp attention + "
+                    f"moe_a2a_backend={server_args.moe_a2a_backend!r} requires "
+                    "SGLANG_RAGGED_VERIFY_MODE=static."
+                )
         if server_args.attn_cp_size > 1:
             raise ValueError(
                 "DSpark with dp attention does not support context parallel "

--- a/test/registered/spec/dspark/test_dspark_draft_path_default.py
+++ b/test/registered/spec/dspark/test_dspark_draft_path_default.py
@@ -5,6 +5,7 @@ from sglang.srt.arg_groups.speculative_hook import (
     _handle_dspark,
     _target_checkpoint_bundles_dspark_draft,
 )
+from sglang.srt.environ import envs
 from sglang.srt.server_args import ServerArgs
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
@@ -82,6 +83,35 @@ class TestDsparkDraftPathDefaulting(CustomTestCase):
             server_args.speculative_draft_model_path,
             "deepseek-ai/some-other-dspark-draft",
         )
+
+
+class TestDsparkDpAttentionMoeA2aGate(CustomTestCase):
+    """Gate contract for DSpark + dp attention + MoE a2a backends."""
+
+    def _dp_server_args(self, *, moe_a2a_backend: str) -> ServerArgs:
+        server_args = _make_dspark_server_args(
+            model_path=_BUNDLED_MODEL_PATH, hf_config=_bundled_hf_config()
+        )
+        server_args.enable_dp_attention = True
+        server_args.enable_dp_lm_head = True
+        server_args.dp_size = 2
+        server_args.tp_size = 2
+        server_args.moe_a2a_backend = moe_a2a_backend
+        return server_args
+
+    def test_only_megamoe_is_admitted(self):
+        """Both sides of the allowlist: megamoe passes, others raise by name."""
+        with envs.SGLANG_RAGGED_VERIFY_MODE.override("static"):
+            _handle_dspark(self._dp_server_args(moe_a2a_backend="megamoe"))
+            for backend in ("deepep", "pplx"):
+                with self.assertRaisesRegex(ValueError, backend):
+                    _handle_dspark(self._dp_server_args(moe_a2a_backend=backend))
+
+    def test_a2a_backend_with_compact_verify_mode_raises(self):
+        server_args = self._dp_server_args(moe_a2a_backend="megamoe")
+        with envs.SGLANG_RAGGED_VERIFY_MODE.override("compact"):
+            with self.assertRaisesRegex(ValueError, "static"):
+                _handle_dspark(server_args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

`_handle_dspark` rejected every non-`none` `--moe-a2a-backend` when `--enable-dp-attention` is on, so DSpark could not run alongside an EP all-to-all dispatch.

The lockstep an EP dispatch needs was already in place. The DSV4-MoE draft path all-gathers `global_num_tokens` in `_fill_dp_moe_sync_metadata`, and a rank with no local generation requests still enters the draft forward via `run_idle_participation`, so every EP rank calls the MoE the same number of times per step. MegaMoE's fused kernel already accommodates the zero-token rank that produces.

## Modifications

`arg_groups/speculative_hook.py`: admit `megamoe` alongside `none`, restricted to `SGLANG_RAGGED_VERIFY_MODE=static`.

Compact ragged verify stays rejected. It agrees on a per-rank graph tier only when `_dp_tier_gather_enabled` holds, which rests on `require_mlp_tp_gather` — config-dependent under an a2a backend — so ranks could disagree on the token-keyed tier and replay different graph shapes. `deepep` and the other backends keep raising, now naming the value.

Two tests: one pins both sides of the a2a allowlist, one pins the compact-mode rejection.

## Accuracy Tests

gsm8k, 400 questions, 5-shot. Same serving config as below with only the MoE backend varied.

| arm | gsm8k |
|---|---|
| `none` (built-in TP MoE, `flashinfer_mxfp4`) | 0.9775 |
| `megamoe` (`deep_gemm`) | 0.9775 |

Identical score, 391/400 on both arms — no accuracy regression.

## Speed Tests and Profiling

DeepSeek-V4-Pro fp8 with its bundled DSpark draft (`DeepseekV4ForCausalLMDSpark`, gamma=5), aggregated on 8x GB300 across 2 nodes, TP8/DP8/EP8, `--enable-dp-attention --enable-dp-lm-head --moe-a2a-backend megamoe`. This is the MoE-draft path, so the draft itself joins the EP collectives.

Target-verify and draft-verify CUDA graphs captured on all 8 EP ranks, 25.6 s each and identical across ranks — a phase-flip barrier desync would hang or raise `unspecified launch failure` here.

ISL 8192 / OSL 1024 at concurrency 64:

| metric | value |
|---|---|
| successful requests | 640 / 640 in 615.3 s |
| total token throughput | 8642 tok/s |
| output token throughput | 959 tok/s (peak 4679) |
| TTFT mean / p50 / p99 | 3107 / 2457 / 14218 ms |
| TPOT mean / p50 / p99 | 63.0 / 67.1 / 142.4 ms |
| DSpark accept length | mean 5.21 of 6 (p10 4.65, p50 5.40, n=471) |

No CUDA, NCCL, or barrier errors during the run. There is no baseline arm, so these are absolute numbers rather than a comparison.

## Checklist

- [x] Format your code according to the Format code with pre-commit
- [x] Add unit tests
- [ ] Update documentation — no user-facing interface change
- [x] Provide accuracy and speed benchmark results
- [x] Follow the SGLang code style guidance

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31801506657](https://github.com/sgl-project/sglang/actions/runs/31801506657)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31801506455](https://github.com/sgl-project/sglang/actions/runs/31801506455)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->