### PR TITLE
[PD] Restore the prefill-side bootstrap/alloc_wait split dropped in #26780

### DIFF
--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -340,7 +340,6 @@ class PrefillBootstrapQueue:
         if not self.ensure_metadata_buffer(req):
             return False
 
-        req.time_stats.set_bootstrap_done_time()
         decode_prefix_len = req.disagg_kv_sender.pop_decode_prefix_len()
         num_kv_indices = len(req.origin_input_ids)
         req.start_send_idx = decode_prefix_len
@@ -452,8 +451,16 @@ class PrefillBootstrapQueue:
                     if not self.ensure_metadata_buffer(req):
                         continue  # no more metadata buffer
                     req.prefill_attempt_count += 1
-                elif not self.finalize_bootstrap(req):
-                    continue
+                else:
+                    # The rendezvous with the decode side is complete as of
+                    # now; everything after this point is local resource
+                    # acquisition. Mirrors the decode-side stamp in
+                    # DecodePreallocQueue. Not stamped on the forced-retry
+                    # path above, whose request goes on to a full optimistic
+                    # attempt and is stamped when it finalizes for real.
+                    req.time_stats.set_bootstrap_done_time()
+                    if not self.finalize_bootstrap(req):
+                        continue
                 bootstrapped_reqs.append(req)
                 indices_to_remove.add(i)
                 req.time_stats.set_wait_queue_entry_time()
@@ -526,6 +533,7 @@ class SchedulerDisaggregationPrefillMixin:
                 # Optimistic requests reserved a metadata buffer when popped, so
                 # finalize cannot fail here; if it ever does, the request stays
                 # pending and the post-forward check resolves it.
+                req.time_stats.set_bootstrap_done_time()
                 self.disagg_prefill_bootstrap_queue.finalize_bootstrap(req)
         if failed:
             self.waiting_queue = [
@@ -1027,6 +1035,7 @@ class SchedulerDisaggregationPrefillMixin:
                 return False
             # Metadata buffer was allocated in pop_bootstrapped before
             # the request entered the waiting queue, so finalize should not fail.
+            req.time_stats.set_bootstrap_done_time()
             assert self.disagg_prefill_bootstrap_queue.finalize_bootstrap(req)
             return True
         else:

--- a/python/sglang/srt/observability/req_time_stats.py
+++ b/python/sglang/srt/observability/req_time_stats.py
@@ -1095,6 +1095,31 @@ class SchedulerReqTimeStats(ReqTimeStatsBase):
                 bootstrap_fields = (
                     f"bootstrap_duration={self.format_duration(bootstrap_duration)}, "
                 )
+                # Second sub-phase: local resource acquisition after the
+                # rendezvous (metadata buffer slot + sender init). Mirrors the
+                # decode-side alloc_wait_duration.
+                if self.wait_queue_entry_time >= self.bootstrap_done_time:
+                    alloc_wait_duration = self.duration_between(
+                        self.bootstrap_done_time, self.wait_queue_entry_time
+                    )
+                    if SGLANG_TEST_REQUEST_TIME_STATS:
+                        assert (
+                            alloc_wait_duration >= 0
+                        ), f"alloc_wait_duration={alloc_wait_duration} < 0"
+                    bootstrap_fields += (
+                        f"alloc_wait_duration="
+                        f"{self.format_duration(alloc_wait_duration)}, "
+                    )
+                else:
+                    # Stamps out of order: with optimistic prefill the request
+                    # leaves the bootstrap queue before the rendezvous, so this
+                    # interval is not an alloc wait. Report the stamp itself
+                    # instead of dropping the sub-phase silently, so the
+                    # inversion stays visible in the log line.
+                    bootstrap_fields += (
+                        f"bootstrap_done_time="
+                        f"{self.format_wallclock(self.bootstrap_done_time)}, "
+                    )
             elif self.bootstrap_done_time > 0:
                 bootstrap_fields = f"bootstrap_done_time={self.format_wallclock(self.bootstrap_done_time)}, "
             else:

--- a/test/registered/unit/observability/test_req_time_stats.py
+++ b/test/registered/unit/observability/test_req_time_stats.py
@@ -1,4 +1,4 @@
-"""Unit tests for ReqTimeStats IPC serialization.
+"""Unit tests for ReqTimeStats IPC serialization and duration formatting.
 
 ReqTimeStatsBase.__setstate__ rebases perf_counter fields onto the receiving
 process's clock anchor. Rebasing a field that was never stamped (0.0) turns
@@ -11,6 +11,7 @@ garbage samples.
 """
 
 import pickle
+import re
 import unittest
 from unittest import mock
 
@@ -38,6 +39,86 @@ class TestSetstatePreservesUnsetTimeSentinels(CustomTestCase):
 
         self.assertEqual(hop2.prefill_finished_time, 0.0)
         self.assertAlmostEqual(hop2.wait_queue_entry_time, 123.456 - 9.0)
+
+
+class TestPrefillBootstrapSubPhases(CustomTestCase):
+    """The prefill log line splits bootstrap_queue into rendezvous + alloc wait."""
+
+    @staticmethod
+    def _prefill_stats(**kwargs):
+        stats = rts.SchedulerReqTimeStats(disagg_mode=rts.DisaggregationMode.PREFILL)
+        for name, value in kwargs.items():
+            setattr(stats, name, value)
+        return stats
+
+    @staticmethod
+    def _field(line, name):
+        match = re.search(rf"\b{name}=([0-9.]+)ms", line)
+        return None if match is None else float(match.group(1))
+
+    def test_sub_phases_reconstruct_bootstrap_queue_duration(self):
+        stats = self._prefill_stats(
+            prefill_bootstrap_queue_entry_time=100.0,
+            bootstrap_done_time=100.3,
+            wait_queue_entry_time=100.5,
+            forward_entry_time=100.6,
+            completion_time=100.9,
+        )
+
+        with mock.patch.object(rts, "SGLANG_TEST_REQUEST_TIME_STATS", True):
+            line = stats.convert_to_duration()
+
+        bootstrap = self._field(line, "bootstrap_duration")
+        alloc_wait = self._field(line, "alloc_wait_duration")
+        self.assertIsNotNone(bootstrap)
+        self.assertIsNotNone(alloc_wait)
+        self.assertAlmostEqual(bootstrap + alloc_wait, 500.0, places=2)
+
+    def test_out_of_order_stamps_report_the_stamp_not_a_duration(self):
+        # Optimistic prefill: the request leaves the bootstrap queue before the
+        # rendezvous, so wait_queue_entry_time precedes bootstrap_done_time.
+        stats = self._prefill_stats(
+            prefill_bootstrap_queue_entry_time=100.0,
+            wait_queue_entry_time=100.2,
+            bootstrap_done_time=100.4,
+            forward_entry_time=100.6,
+            completion_time=100.9,
+        )
+
+        with mock.patch.object(rts, "SGLANG_TEST_REQUEST_TIME_STATS", True):
+            line = stats.convert_to_duration()
+
+        self.assertIn("bootstrap_duration=", line)
+        self.assertNotIn("alloc_wait_duration=", line)
+        self.assertIn(
+            f"bootstrap_done_time={stats.format_wallclock(stats.bootstrap_done_time)}",
+            line,
+        )
+
+    def test_unstamped_bootstrap_done_falls_back_to_queue_duration(self):
+        # A request that fails bootstrap never observes KVPoll.WaitingForInput.
+        stats = self._prefill_stats(
+            prefill_bootstrap_queue_entry_time=100.0,
+            wait_queue_entry_time=100.5,
+            forward_entry_time=100.6,
+            completion_time=100.9,
+        )
+
+        with mock.patch.object(rts, "SGLANG_TEST_REQUEST_TIME_STATS", True):
+            line = stats.convert_to_duration()
+
+        self.assertAlmostEqual(
+            self._field(line, "bootstrap_queue_duration"), 500.0, places=2
+        )
+        self.assertNotIn("alloc_wait_duration=", line)
+
+    def test_bootstrap_done_time_is_first_write_wins(self):
+        stats = self._prefill_stats(prefill_bootstrap_queue_entry_time=100.0)
+
+        stats.set_bootstrap_done_time(200.0)
+        stats.set_bootstrap_done_time(300.0)
+
+        self.assertEqual(stats.bootstrap_done_time, 200.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

`ReqTimeStats.bootstrap_done_time` is a single field, but it is stamped at two
semantically different points on the two sides of a PD deployment.

**Decode side** — `DecodePreallocQueue.pop_preallocated()` stamps it the moment
`KVPoll.WaitingForInput` is first observed, *before* `_pre_alloc()` runs:

```python
elif poll == KVPoll.WaitingForInput:
    decode_req.waiting_for_input = True
    decode_req.req.time_stats.set_bootstrap_done_time()
```

So `prealloc_duration` decomposes into two meaningful halves, and both are
reported:

```
bootstrap_duration  = prealloc_queue_entry -> bootstrap_done   (rendezvous)
alloc_wait_duration = bootstrap_done -> transfer_queue_entry   (KV admission)
```

**Prefill side** — it is stamped inside `finalize_bootstrap()`, which runs
*after* the rendezvous has already been observed and after the metadata buffer
has been acquired:

```python
def finalize_bootstrap(self, req):
    if not self.ensure_metadata_buffer(req):
        return False
    req.time_stats.set_bootstrap_done_time()      # <-- here
    ...
    req.disagg_kv_sender.init(num_pages, req.metadata_buffer_index)
```

`finalize_bootstrap()` is called from `pop_bootstrapped()`, and
`set_wait_queue_entry_time()` is called a few statements later in the *same loop
iteration*. The interval between the two stamps is therefore a handful of
CPU-only statements — microseconds — regardless of what the request actually
waited for. Consequently:

* `bootstrap_duration` on the prefill side is, for practical purposes, the
  entire `prefill_bootstrap` interval; and
* no second field is emitted at all, so the split that exists on the decode side
  has no prefill-side counterpart.

This looks like a regression rather than a deliberate asymmetry — the prefill
side used to have both halves:

* #19009 added the prefill-side stamp directly at the `KVPoll.WaitingForInput`
  observation site, mirroring the decode side, *and* emitted the sub-phase split
  (`= bootstrap(...) + alloc_wait(...)`).
* #24521 reformatted those fields (`bootstrap_breakdown` → `bootstrap_fields`)
  and kept both.
* #26780 (optimistic prefill) relocated the stamp into the newly extracted
  `finalize_bootstrap()` — i.e. behind `ensure_metadata_buffer()` — and dropped
  the prefill-side `alloc_wait_duration` computation, so the normal path now
  emits `bootstrap_duration=` alone. (The same commit added a bare
  `bootstrap_done_time=` fallback, but only for the case where the queue-entry
  stamp itself is missing.)

The relocation also changed which sub-phase absorbs one specific wait. #19009
stamped *before* the metadata-buffer check, so a request that found no free slot
accrued that wait in `alloc_wait_duration`. With the stamp now behind
`ensure_metadata_buffer()`, the same wait accrues in `bootstrap_duration` — and
since the second field is gone there is nothing left to separate it from the
cross-machine wait.

### Why this matters

The prefill-side `prefill_bootstrap` stage (also exported as
`sglang:per_stage_req_latency_seconds{stage="prefill_bootstrap"}`) ends when the
request is popped out of `PrefillBootstrapQueue`, which by construction cannot
happen until the decode side has completed its own handshake **and** its KV
pre-allocation, since `_pre_alloc()` precedes `send_metadata()`. Concretely, the
prefill side only reaches `KVPoll.WaitingForInput` once `TransferInfo` — which
carries the decode side's freshly allocated `dst_kv_indices` — has arrived from
all `required_dst_info_num` destinations, so that transition is precisely the
"decode has allocated and told us where to write" boundary. That single number
therefore conflates at least three different waits:

1. the cross-machine rendezvous itself;
2. the decode side's memory-admission queueing (`_pre_alloc` is gated on
   `full_allocatable_tokens`, and a request that does not fit stops the
   admission loop);
3. a purely local wait: if `ensure_metadata_buffer()` finds no free slot the
   request stays in the queue and is re-polled on later scheduler iterations,
   so metadata-buffer starvation can span many iterations and is currently
   attributed entirely to "bootstrap".

When prefill-side bootstrap latency degrades under load, an operator today
cannot tell case 2 from case 3 from prefill-side telemetry — the two have
opposite remedies (decode-side capacity / `num_reserved_decode_tokens` vs.
prefill-side metadata buffer sizing).

## Modifications

Move the prefill-side stamp to the point where `KVPoll.WaitingForInput` is first
observed, mirroring the decode side, and emit the second sub-phase in the
prefill log line under the same name the decode side already uses:

```
bootstrap_duration  = bootstrap_queue_entry -> bootstrap_done   (rendezvous, i.e. waiting on decode)
alloc_wait_duration = bootstrap_done -> wait_queue_entry        (local: metadata buffer slot + sender init)
```

The stamp is added at the three sites that observe `WaitingForInput` for a
pending-bootstrap request (`pop_bootstrapped()`, and the two optimistic-prefill
finalize paths), and removed from `finalize_bootstrap()`.
`set_bootstrap_done_time()` is already first-write-wins, so re-polling a request
that could not obtain a metadata buffer does not move the stamp. All three sites
skip the stamp when `should_force_retry()` fires, so a request that goes on to a
full optimistic attempt is stamped when it finalizes for real rather than
carrying a stamp from the attempt before.

### Behaviour

No scheduling or control-flow change: this moves one timestamp and adds one log
field. `bootstrap_duration` becomes smaller (it no longer includes local
finalize work) and the difference now shows up in `alloc_wait_duration`.

Two existing prefill-side histograms are fed by the same timestamp via
`compute_and_observe_kv_transfer_metrics()` and shift accordingly:
`sglang:kv_transfer_bootstrap_ms` becomes smaller, and
`sglang:kv_transfer_alloc_ms` — which falls back to
`wait_queue_entry_time - bootstrap_done_time` whenever the backend leaves
`KVTransferMetric.alloc_latency_s` as `None`, as every in-tree backend currently
does — stops being structurally ~0 on the prefill side and starts reporting the
local acquisition wait it is named for.

With `--optimistic-prefill-attempts > 0` a request can leave the queue while
still `Bootstrapping`, so `wait_queue_entry_time` precedes the rendezvous. In
that case the interval is not an alloc wait, so instead of emitting a negative
or silently dropped field the log line reports the raw `bootstrap_done_time=`
stamp — the same field `main` already emits when the queue-entry stamp is
missing — which keeps the inversion visible.

### Tests

- `test/registered/unit/observability/test_req_time_stats.py`: four new cases in
  `TestPrefillBootstrapSubPhases` — the sub-phases reconstruct
  `bootstrap_queue_duration`; out-of-order stamps report the stamp instead of a
  duration; an unstamped `bootstrap_done_time` (bootstrap failure) still falls
  back to `bootstrap_queue_duration`; and the stamp is first-write-wins. The
  three formatter cases run with `SGLANG_TEST_REQUEST_TIME_STATS` patched on, so
  the assertion paths are exercised.
- Not yet run by me: a PD deployment smoke test with
  `--enable-request-time-stats-logging`, asserting that
  `bootstrap_duration + alloc_wait_duration` still reconstructs
  `bootstrap_queue_duration` and that `alloc_wait_duration` is no longer
  identically ~0. Happy to add or run this if a maintainer prefers it in-tree.

### Follow-up (not in this PR)

The two sub-phases are only split in the log line and in the existing
`kv_transfer_*` histograms noted above. Exporting them as their own
`per_stage_req_latency` stages would need new `RequestStage` values on both
sides and is left out to keep this change minimal.

## Accuracy Tests

Not applicable: observability only. No kernel, model forward, or numerics change
— the diff moves one timestamp and adds one formatted log field.

## Speed Tests and Profiling

Not applicable: no scheduling or control-flow change and nothing added to the
hot path. `set_bootstrap_done_time()` is called exactly once per request either
way; only its call site moves.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations) — no user-facing docs cover these log fields.
- [ ] Provide accuracy and speed benchmark results — not applicable, see above.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32818044608](https://github.com/sgl-project/sglang/actions/runs/32818044608)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32818044294](https://github.com/sgl-project/sglang/actions/runs/32818044294)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32818044535](https://github.com/sgl-project/sglang/actions/runs/32818044535)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->