### PR TITLE
[HiSparse] Fix copy_cache_planned_kernel grid sizing for prefetch replay

### DIFF
--- a/python/sglang/kernels/jit/csrc/hisparse.cuh
+++ b/python/sglang/kernels/jit/csrc/hisparse.cuh
@@ -835,9 +835,10 @@ void load_cache_to_device_buffer(
 }
 
 // Copy-only swap-in for shared-index skip layers: replays the anchor's recorded
-// miss plan (no hit detection / LRU; the anchor's slot table stays valid). The
-// small fixed grid (num_blocks) keeps the SM footprint low while overlapping
-// compute on a side stream. SkipIO is the same probe as in the fused kernel.
+// miss plan (no hit detection / LRU; the anchor's slot table stays valid).
+// Launched with one block per request (see copy_cache_planned below) so its
+// parallelism scales with the batch instead of a fixed grid. SkipIO is the
+// same probe as in the fused kernel.
 template <int BLOCK_SIZE, bool IsMLA, bool IsDsv4Layout, bool SkipIO>
 __global__ __launch_bounds__(BLOCK_SIZE, 1) void copy_cache_planned_kernel(
     const int64_t* __restrict__ miss_src_locs,
@@ -850,44 +851,38 @@ __global__ __launch_bounds__(BLOCK_SIZE, 1) void copy_cache_planned_kernel(
     void* __restrict__ device_buffer_v,
     int64_t plan_stride,
     int64_t item_size_bytes) {
+  // One block per request (grid = bs, same convention as
+  // load_cache_to_device_buffer_kernel), instead of round-robining a flat
+  // (request, miss) queue over a small fixed grid. The round-robin form scales
+  // its warp count with num_blocks, not with the batch, so it undersubscribes
+  // the GPU at realistic batch sizes -- see the git history of this kernel for
+  // the flat-queue version and its H200 microbenchmark note. Per-request grids
+  // give one block's worth of parallelism to every request unconditionally,
+  // matching load_cache_to_device_buffer_kernel's scaling instead of forcing
+  // the caller to size a grid for the batch.
   constexpr int NUM_WARPS = BLOCK_SIZE / WARP_SIZE;
-  const int lane_id = threadIdx.x % WARP_SIZE;
-  const int warp_global = blockIdx.x * NUM_WARPS + threadIdx.x / WARP_SIZE;
-  const int total_warps = gridDim.x * NUM_WARPS;
-  const int real = num_real_reqs[0];
+  const int bid = blockIdx.x;
+  if (bid >= num_real_reqs[0]) return;
 
-  // Warp-sized windows amortize the miss_counts loads; warps then round-robin
-  // the flattened (request, miss) space so a large sparse batch spreads over
-  // all warps (183us -> 29us at bs=100 with 2 misses/req on H200) while one
-  // request's miss burst still uses every warp.
-  int start = 0;  // flat index of the current request's first miss
-  for (int base = 0; base < real; base += WARP_SIZE) {
-    const int r_lane = base + lane_id;
-    const int cnt_lane = (r_lane < real) ? miss_counts[r_lane] : 0;
-    const int window = (real - base < WARP_SIZE) ? (real - base) : WARP_SIZE;
-    for (int j = 0; j < window; ++j) {
-      const int cnt = __shfl_sync(FULL_WARP_MASK, cnt_lane, j);
-      if (cnt == 0) continue;
-      int m0 = (warp_global - start) % total_warps;
-      if (m0 < 0) m0 += total_warps;
-      const int64_t r = base + j;
-      const int64_t* src_row = miss_src_locs + r * plan_stride;
-      const int32_t* dst_row = miss_dst_locs + r * plan_stride;
-      for (int m = m0; m < cnt; m += total_warps) {
-        // Timing probe: the plan is still walked; only the bytes stay put.
-        if constexpr (SkipIO) continue;
-        copy_miss_item<IsMLA, IsDsv4Layout>(
-            lane_id,
-            host_cache_k,
-            host_cache_v,
-            device_buffer_k,
-            device_buffer_v,
-            src_row[m],
-            static_cast<int64_t>(dst_row[m]),
-            item_size_bytes);
-      }
-      start += cnt;
-    }
+  const int lane_id = threadIdx.x % WARP_SIZE;
+  const int warp_id = threadIdx.x / WARP_SIZE;
+  const int cnt = miss_counts[bid];
+  if (cnt == 0) return;
+
+  const int64_t* src_row = miss_src_locs + static_cast<int64_t>(bid) * plan_stride;
+  const int32_t* dst_row = miss_dst_locs + static_cast<int64_t>(bid) * plan_stride;
+  for (int m = warp_id; m < cnt; m += NUM_WARPS) {
+    // Timing probe: the plan is still walked; only the bytes stay put.
+    if constexpr (SkipIO) continue;
+    copy_miss_item<IsMLA, IsDsv4Layout>(
+        lane_id,
+        host_cache_k,
+        host_cache_v,
+        device_buffer_k,
+        device_buffer_v,
+        src_row[m],
+        static_cast<int64_t>(dst_row[m]),
+        item_size_bytes);
   }
 }
 
@@ -901,7 +896,8 @@ void copy_cache_planned(
     tvm::ffi::TensorView host_cache_v,
     tvm::ffi::TensorView device_buffer_k,
     tvm::ffi::TensorView device_buffer_v,
-    int64_t num_blocks,
+    int64_t num_blocks,  // one block per request; pass the batch size (padded to the CUDA graph capture size, same as
+                         // load_cache_to_device_buffer's grid).
     int64_t item_size_bytes) {
   using namespace host;
   const int64_t plan_stride = miss_src_locs.strides()[0];

--- a/python/sglang/kernels/ops/kvcache/hisparse.py
+++ b/python/sglang/kernels/ops/kvcache/hisparse.py
@@ -253,15 +253,17 @@ def copy_cache_planned_mla(
     host_cache: torch.Tensor,
     device_buffer: torch.Tensor,
     item_size_bytes: int,
-    num_blocks: int = 4,
+    num_blocks: int = 1,
     block_size: int = 1024,
     is_dsv4_layout: bool = False,
     skip_io: bool = False,
 ) -> None:
     """Replay a recorded miss plan (host_cache -> device_buffer) for a skip layer.
 
-    IO-only, no planning; the small fixed grid keeps the SM footprint low while
-    overlapped on a side stream. The anchor's slot table stays valid (lockstep).
+    IO-only, no planning; the anchor's slot table stays valid (lockstep). Pass
+    num_blocks=num_reqs (one block per request, padded to the CUDA graph
+    capture size like load_cache_to_device_buffer's grid) so this scales with
+    the batch instead of round-robining a small fixed grid.
     """
     assert miss_src.dtype == torch.int64 and miss_dst.dtype == torch.int32
     assert miss_count.dtype == torch.int32

--- a/python/sglang/srt/managers/hisparse_coordinator.py
+++ b/python/sglang/srt/managers/hisparse_coordinator.py
@@ -289,15 +289,16 @@ class HiSparseCoordinator:
         if not self.enable_prefetch:
             return
 
-        # Small fixed grid for the copy-only kernel: low SM footprint so the
-        # copies overlap compute with little contention.
-        self._prefetch_copy_blocks = 4
         max_group_size = max(len(g) for g in self._prefetch_groups.values())
         self.prefetch_stream = device_module.Stream()
         self._prefetch_events = [device_module.Event() for _ in range(max_group_size)]
-        # Plan recorded by the current anchor, replayed by its skip layers. One
-        # buffer set suffices: the last skip layer's event wait orders the next
-        # anchor's writes after this group's copies.
+        # The anchor of a shared-index group records its miss plan once; skip
+        # layers replay it (IO-only) on the side stream through
+        # copy_cache_planned_kernel, launched with one block per request
+        # (num_blocks=num_reqs) so its parallelism scales with the batch
+        # instead of round-robining a small fixed grid over all requests.
+        # One buffer set suffices: the last skip layer's event wait orders the
+        # next anchor's writes after this group's copies.
         self._miss_src = torch.zeros(
             (max_num_req_slots, self.top_k), dtype=torch.int64, device=self.device
         )
@@ -988,7 +989,12 @@ class HiSparseCoordinator:
 
     def _run_copy_only_kernel(self, num_reqs: int, skip_layer: int) -> None:
         """Replay the anchor's recorded miss plan into a skip layer's buffers
-        (IO-only; the anchor's slot table stays valid -- lockstep layout)."""
+        (IO-only; the anchor's slot table stays valid -- lockstep layout).
+
+        One block per request (num_blocks=num_reqs): the kernel does no
+        cross-request scheduling, so its parallelism must come from the grid,
+        same convention as the fused swap-in kernel's per-request blocks.
+        """
         copy_cache_planned_mla(
             miss_src=self._miss_src[:num_reqs],
             miss_dst=self._miss_dst[:num_reqs],
@@ -997,7 +1003,7 @@ class HiSparseCoordinator:
             host_cache=self.mem_pool_host.kv_buffer[skip_layer],
             device_buffer=self.mem_pool_device.kv_buffer[skip_layer],
             item_size_bytes=self.item_size_bytes,
-            num_blocks=self._prefetch_copy_blocks,
+            num_blocks=num_reqs,
             is_dsv4_layout=self.is_dsv4_hisparse,
             skip_io=self.skip_io,
         )
@@ -1021,25 +1027,25 @@ class HiSparseCoordinator:
 
         num_reqs = req_pool_indices.size(0)
         if self._is_shared_index_layer[layer_id]:
-            # Skip layer: wait for its prefetched copy; the anchor's slot table
-            # applies (shared index + lockstep buffers).
+            # Skip layer: wait for its prefetched copy, then reuse the
+            # anchor's slot table directly (shared index + lockstep buffers).
             slot = self._prefetch_slot[layer_id]
             self._prefetch_events[slot].wait(device_module.current_stream())
             return self.top_k_device_locs_buffer[:num_reqs]
 
-        # Anchor: swap in synchronously (recording the plan), then prefetch the
-        # skip layers' copies on the side stream.
+        # Anchor: swap in synchronously (recording the plan for skip layers to
+        # replay), then prefetch the skip layers' copies on the side stream.
         group = self._prefetch_groups.get(layer_id)
         anchor_locs = self._run_swap_in_kernel(
             req_pool_indices,
             compressed_seq_lens,
             top_k_result,
             layer_id,
-            record_plan=group is not None,
+            record_plan=bool(group),
         )
         if group:
-            # Fork: the prefetch stream must observe the anchor's plan (produced
-            # on the current stream) before replaying it.
+            # Fork: the prefetch stream must observe the anchor's plan
+            # (produced on the current stream) before replaying it.
             self.prefetch_stream.wait_stream(device_module.current_stream())
             with device_module.stream(self.prefetch_stream):
                 for skip_layer in group:

--- a/test/manual/kernels/test_hisparse_prefetch.py
+++ b/test/manual/kernels/test_hisparse_prefetch.py
@@ -129,7 +129,7 @@ def test_plan_then_io_dsv4_matches_sync_swap_in() -> None:
         host_cache=replay_host,
         device_buffer=replay_dev,
         item_size_bytes=DSV4_ITEM_BYTES,
-        num_blocks=4,
+        num_blocks=1,
         is_dsv4_layout=True,
     )
     torch.cuda.synchronize()
@@ -177,7 +177,7 @@ def test_skip_io_probe_plans_without_moving_bytes() -> None:
         host_cache=probe["host_cache"],
         device_buffer=probe["device_buffer"],
         item_size_bytes=ITEM_SIZE_BYTES,
-        num_blocks=4,
+        num_blocks=nr,
     )
     torch.cuda.synchronize()
     assert torch.equal(probe["device_buffer"].cpu(), ref["device_buffer"].cpu())
@@ -261,7 +261,7 @@ def _pio_prefetch_step(
                 host_cache=host,
                 device_buffer=buffers[layer],
                 item_size_bytes=ITEM_SIZE_BYTES,
-                num_blocks=4,
+                num_blocks=_PIO_REQS,
             )
             events[layer].record(side)
     for layer in range(1, _PIO_LAYERS):

--- a/test/registered/kernels/benchmark/kvcache/bench_hisparse.py
+++ b/test/registered/kernels/benchmark/kvcache/bench_hisparse.py
@@ -166,7 +166,8 @@ def _time_planned_copy(
     batch_size: int, hot_buffer_size: int, miss_rate: float
 ) -> float:
     """Time the copy-only replay used by shared-index skip layers: one anchor
-    swap-in records a real plan, each timed round replays it (num_blocks=4)."""
+    swap-in records a real plan, each timed round replays it
+    (num_blocks=batch_size, one block per request)."""
     state = _build_inputs(batch_size, hot_buffer_size, miss_rate)
     miss_src = torch.zeros((batch_size, TOP_K), dtype=torch.int64, device=DEVICE)
     miss_dst = torch.zeros((batch_size, TOP_K), dtype=torch.int32, device=DEVICE)
@@ -203,7 +204,7 @@ def _time_planned_copy(
             host_cache=state["host_cache"],
             device_buffer=skip_layer_buffer,
             item_size_bytes=ITEM_SIZE_BYTES,
-            num_blocks=4,
+            num_blocks=batch_size,
         )
 
     run_once()

--- a/test/registered/kernels/ops/kvcache/test_hisparse.py
+++ b/test/registered/kernels/ops/kvcache/test_hisparse.py
@@ -4,6 +4,7 @@ import pytest
 import torch
 
 from sglang.kernels.ops.kvcache.hisparse import (
+    copy_cache_planned_mla,
     load_cache_to_device_buffer_dsv4_mla,
     load_cache_to_device_buffer_mla,
     transfer_cache_dsv4_mla,
@@ -101,6 +102,10 @@ def _run_kernel(
     req_pool_indices: torch.Tensor | None = None,
     num_real_reqs: int | None = None,
     output_fill_value: int = -1,
+    miss_src: torch.Tensor | None = None,
+    miss_dst: torch.Tensor | None = None,
+    miss_count: torch.Tensor | None = None,
+    skip_io: bool = False,
 ) -> torch.Tensor:
     batch_size = top_k_tokens.shape[0]
     if req_pool_indices is None:
@@ -130,6 +135,10 @@ def _run_kernel(
         page_size=1,
         block_size=256,
         num_real_reqs=torch.tensor([num_real_reqs], dtype=torch.int32, device=DEVICE),
+        miss_src=miss_src,
+        miss_dst=miss_dst,
+        miss_count=miss_count,
+        skip_io=skip_io,
     )
     torch.cuda.synchronize()
     return out
@@ -267,6 +276,87 @@ def _long_case():
     # req 0 physical locs  : slot0->9, slot1->7, slot2->3, slot3->5
     # req 0 newest slot    : slot4/newest -> token 7 at physical loc 11
     return _make_state([[9, 7, 3, 5, 11]], [[1, 4, 2, 5, -1]], [7])
+
+
+def _make_plan(num_reqs: int, num_top_k: int):
+    """Fresh miss_src/miss_dst/miss_count buffers for an anchor to record into
+    and a skip layer to replay via copy_cache_planned_mla."""
+    miss_src = torch.zeros((num_reqs, num_top_k), dtype=torch.int64, device=DEVICE)
+    miss_dst = torch.zeros((num_reqs, num_top_k), dtype=torch.int32, device=DEVICE)
+    miss_count = torch.zeros((num_reqs,), dtype=torch.int32, device=DEVICE)
+    return miss_src, miss_dst, miss_count
+
+
+def test_copy_cache_planned_replays_per_request_with_varying_miss_counts() -> None:
+    """copy_cache_planned_mla is launched with num_blocks=num_reqs (one block per
+    request) by hisparse_coordinator. Each request's miss row must land only in
+    its own row, independent of how many misses its neighbours have."""
+    state = _make_state(
+        [
+            [9, 7, 3, 5, 11],
+            [12, 10, 8, 6, 14],
+            [15, 4, 2, 1, 13],
+        ],
+        [
+            [1, 4, 2, 5, -1],
+            [0, 1, 2, 3, -1],
+            [9, 8, 7, 6, -1],
+        ],
+        [7, 4, 5],
+    )
+    top_k_tokens = torch.tensor(
+        [[4, 6, 7], [2, 6, 7], [9, 8, 7]], dtype=torch.int32, device=DEVICE
+    )
+    seq_lens = torch.tensor([8, 8, 8], dtype=torch.int32, device=DEVICE)
+    num_reqs = top_k_tokens.shape[0]
+
+    # Anchor: record the miss plan while doing the real swap-in.
+    miss_src, miss_dst, miss_count = _make_plan(num_reqs, top_k_tokens.shape[1])
+    anchor_out = _run_kernel(
+        top_k_tokens=top_k_tokens,
+        seq_lens=seq_lens,
+        miss_src=miss_src,
+        miss_dst=miss_dst,
+        miss_count=miss_count,
+        **state,
+    )
+    # newest_token = seq_len - 1 = 7 for every request below.
+    # req 0: cached {1@9, 4@7, 2@3, 5@5}; query [4, 6, 7]
+    #   -> hit(4)@7, miss(6)->evict slot0@9, newest(7)@11
+    # req 1: cached {0@12, 1@10, 2@8, 3@6}; query [2, 6, 7]
+    #   -> hit(2)@8, miss(6)->evict slot0@12, newest(7)@14
+    # req 2: cached {9@15, 8@4, 7@2, 6@1}; query [9, 8, 7]
+    #   -> hit(9)@15, hit(8)@4, newest(7)@13 (all hit/newest, 0 misses)
+    assert torch.equal(
+        anchor_out.cpu(),
+        torch.tensor([[7, 9, 11], [8, 12, 14], [15, 4, 13]], dtype=torch.int32),
+    )
+    assert torch.equal(miss_count.cpu(), torch.tensor([1, 1, 0], dtype=torch.int32))
+
+    # Skip layer: replay the plan into a fresh buffer set (one block per
+    # request), independently of the anchor's own buffers.
+    replay_host = state["host_cache"]
+    replay_buffer = torch.full(
+        (DEVICE_CACHE_SIZE, 1, KV_DIM), -1, dtype=DTYPE, device=DEVICE
+    )
+    copy_cache_planned_mla(
+        miss_src=miss_src,
+        miss_dst=miss_dst,
+        miss_count=miss_count,
+        num_real_reqs=torch.tensor([num_reqs], dtype=torch.int32, device=DEVICE),
+        host_cache=replay_host,
+        device_buffer=replay_buffer,
+        item_size_bytes=ITEM_SIZE_BYTES,
+        num_blocks=num_reqs,
+    )
+    torch.cuda.synchronize()
+
+    # Only the miss destinations got copied; every other slot stays untouched.
+    assert torch.equal(replay_buffer[9].cpu(), replay_host[6])
+    assert torch.equal(replay_buffer[12].cpu(), replay_host[6])
+    untouched = torch.full((1, KV_DIM), -1, dtype=DTYPE)
+    for loc in [7, 3, 5, 11, 10, 8, 6, 14, 15, 4, 2, 1, 13]:
+        assert torch.equal(replay_buffer[loc].cpu(), untouched)
 
 
 @pytest.mark.parametrize("seq_lens_dtype", [torch.int32, torch.int64])


### PR DESCRIPTION
## Motivation

`copy_cache_planned_kernel` (introduced in #34329, HiSparse shared-index/IndexShare prefetch) replays a shared-index anchor's recorded miss plan into each skip layer's device buffer on a side stream. It launches with a small, batch-size-independent grid (`num_blocks=4`) and round-robins all requests' misses across that fixed set of warps.

This works well at low batch size / low miss counts (the kernel's comment cites a 183us -> 29us H200 microbenchmark at bs=100 with 2 misses/req), but the total (request, miss) work grows with batch size while the grid does not. As batch size and per-request miss counts increase, the copy kernel's own wall time grows faster than the compute it's supposed to overlap. Because skip layers block on an event recorded after this kernel finishes, the anchor's compute stream ends up waiting on it — the prefetch's win shrinks and, past a few dozen concurrent requests, inverts into a regression relative to disabling prefetch entirely.

## Modifications

Switch the grid to one block per request (`num_blocks=num_reqs`), the same convention `load_cache_to_device_buffer_kernel` already uses for the anchor's own swap-in. Each block now only handles its own request's miss list (round-robin across the block's warps), instead of a global round-robin over a fixed warp count. Parallelism now scales with the batch instead of sitting behind a fixed grid size.

Files changed:
- `python/sglang/kernels/jit/csrc/hisparse.cuh`: `copy_cache_planned_kernel` rewritten to one-block-per-request scheduling.
- `python/sglang/srt/managers/hisparse_coordinator.py`: `_run_copy_only_kernel` passes `num_blocks=num_reqs` instead of a fixed constant.

This trades away one property of the old design — a single request with an unusually large miss burst could previously draw on every warp in the grid — for parallelism that scales unconditionally with batch size. In practice this tradeoff favors the new design: all blocks launch concurrently well within the GPU's SM count, and requests sharing an anchor group go through the same top-k selection / LRU eviction logic, so large per-request miss skew is uncommon.

## Accuracy Tests

No output change expected: the kernel still reads the same `miss_src`/`miss_dst`/`miss_counts` plan recorded by the anchor and performs the same per-item copy; only the block/warp assignment changed.

Added a unit test to `test/registered/kernels/ops/kvcache/test_hisparse.py` (`test_copy_cache_planned_replays_per_request_with_varying_miss_counts`) that directly exercises `copy_cache_planned_mla` with `num_blocks=num_reqs` on a 3-request batch with varying miss counts (1, 1, 0), verifying each request's miss bytes land only in its own destination slots. Ran the full `test_hisparse.py` + `test_hisparse_prefetch.py` suite on the target hardware (14 passed, 8 skipped — skips are ROCm-only cases on this CUDA box).

Also ran smoke tests (single request, greedy decoding, `temperature=0`) before each benchmark run below to confirm end-to-end output correctness under the real PD-disaggregated deployment.

## Speed Tests and Profiling

8x RTX PRO 6000 (SM120), GLM-5.2-nvfp4, TP8, PD disaggregated decode, DSA attention backend with `flashinfer_sparse_mla`, fp8_e4m3 KV cache, `top_k=2048`， 32k input，4k output. Decode steady-state gen throughput (tok/s) at fixed batch size:

| BS | sync swap-in (prefetch off) | prefetch, old grid=4 | prefetch, this PR | vs sync | vs old grid=4 |
|---|---|---|---|---|---|
| 1  | 44.84  | 45.42  | 50.09  | +11.7% | +10.3% |
| 2  | 79.00  | 69.34  | 89.46  | +13.2% | +29.0% |
| 4  | 145.08 | 103.48 | 166.10 | +14.5% | +60.5% |
| 8  | 269.87 | 150.95 | 318.79 | +18.1% | +111.2% |
| 16 | 392.70 | 188.11 | 462.51 | +17.8% | +145.8% |
| 32 | 558.33 | 218.37 | 633.26 | +13.4% | +190.0% |
| 54 | 700.74 | 223.35 | 772.35 | +10.2% | +245.8% |

With the old fixed grid, enabling prefetch is already a regression vs. disabling it starting around BS=2, and the regression grows with scale (-68% at BS=54). With this fix, prefetch is a consistent 10-18% win over synchronous swap-in across the entire batch-size range tested, with no batch-size-dependent falloff — matching the intent of #34329.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


cc @xiezhq-hermann @huangtingwei9988   (author of #34329) for review, since this changes the kernel introduced there.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #31800110112](https://github.com/sgl-project/sglang/actions/runs/31800110112)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #31800109323](https://github.com/sgl-project/sglang/actions/runs/31800109323)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->