### PR TITLE
Fix MiniMax-H3 Cache-DiT BCG warning

### DIFF
--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/minimax_h3/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/minimax_h3/stages/denoising.py
@@ -413,6 +413,11 @@ class MiniMaxH3DenoisingStage(DenoisingStage):
         current_mode = getattr(self, "_minimax_h3_cache_mode", None)
         self._minimax_h3_quality = quality
 
+        if self.server_args.enable_breakable_cuda_graph:
+            if desired_mode is not None:
+                super()._maybe_enable_cache_dit(num_inference_steps, batch)
+            return
+
         # H3 is monolithic-only, and the scheduler executes one worker batch at
         # a time. Combined with `quality` in the dynamic-batch signature, this
         # makes the process-wide hook transition safe at this batch boundary.


### PR DESCRIPTION
## Motivation

The interaction between #33827 and #34242 made the MiniMax-H3 override touch `self.transformer` before reaching the breakable-CUDA-graph warning path, causing the regression test to fail with an `AttributeError`

## Modifications

Delegate eligible breakable-CUDA-graph requests to the base implementation before changing transformer state while preserving the `quality="lossless"` behavior

## Test Plan

```bash
cd python && python3 sglang/multimodal_gen/test/run_suite.py --suite unit -k 'diffusion_bcg_padding or minimax_h3_admission'
```

All 34 tests passed

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31800314499](https://github.com/sgl-project/sglang/actions/runs/31800314499)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31800314243](https://github.com/sgl-project/sglang/actions/runs/31800314243)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->