### PR TITLE
Fix rollback for partially applied source patches

### DIFF
--- a/python/sglang/srt/debug_utils/source_patcher/code_patcher.py
+++ b/python/sglang/srt/debug_utils/source_patcher/code_patcher.py
@@ -107,13 +107,19 @@ def patch_function(
 
 def _apply_specs(specs: list[PatchSpec]) -> list[PatchState]:
     states: list[PatchState] = []
-    for spec in specs:
-        target_fn: Callable[..., Any] = _resolve_target(spec.target)
-        print(f"[source_patcher] patching {spec.target}")
-        state: PatchState = patch_function(
-            target=target_fn, edits=spec.edits, preamble=spec.preamble
-        )
-        states.append(state)
+    try:
+        for spec in specs:
+            target_fn: Callable[..., Any] = _resolve_target(spec.target)
+            print(f"[source_patcher] patching {spec.target}")
+            state: PatchState = patch_function(
+                target=target_fn, edits=spec.edits, preamble=spec.preamble
+            )
+            states.append(state)
+    except Exception:
+        for state in reversed(states):
+            state.restore()
+        raise
+
     return states
 
 

--- a/python/sglang/srt/debug_utils/source_patcher/code_patcher.py
+++ b/python/sglang/srt/debug_utils/source_patcher/code_patcher.py
@@ -115,7 +115,7 @@ def _apply_specs(specs: list[PatchSpec]) -> list[PatchState]:
                 target=target_fn, edits=spec.edits, preamble=spec.preamble
             )
             states.append(state)
-    except Exception:
+    except BaseException:
         for state in reversed(states):
             state.restore()
         raise

--- a/test/registered/debug_utils/source_patcher/test_code_patcher.py
+++ b/test/registered/debug_utils/source_patcher/test_code_patcher.py
@@ -256,6 +256,32 @@ class TestCodePatcher:
 
         assert obj.greet("world") == "hello world"
 
+    def test_rolls_back_when_later_patch_fails(self, sample_module: ModuleType) -> None:
+        cls = sample_module.SampleClass
+        obj = cls()
+
+        patches = [
+            PatchSpec(
+                target=f"{SAMPLE_MODULE_NAME}.SampleClass.greet",
+                edits=[
+                    EditSpec(
+                        match='greeting = f"hello {name}"',
+                        replacement='greeting = f"partial_patched {name}"',
+                    )
+                ],
+            ),
+            PatchSpec(
+                target=f"{SAMPLE_MODULE_NAME}.NonexistentClass.method",
+                edits=[],
+            ),
+        ]
+
+        with pytest.raises((ImportError, AttributeError)):
+            with CodePatcher(patches=patches):
+                pass
+
+        assert obj.greet("world") == "hello world"
+
 
 if __name__ == "__main__":
     import sys

--- a/test/registered/debug_utils/source_patcher/test_code_patcher.py
+++ b/test/registered/debug_utils/source_patcher/test_code_patcher.py
@@ -282,6 +282,44 @@ class TestCodePatcher:
 
         assert obj.greet("world") == "hello world"
 
+    def test_rolls_back_when_later_patch_raises_base_exception(
+        self, sample_module: ModuleType, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cls = sample_module.SampleClass
+        obj = cls()
+
+        patches = [
+            PatchSpec(
+                target=f"{SAMPLE_MODULE_NAME}.SampleClass.greet",
+                edits=[
+                    EditSpec(
+                        match='greeting = f"hello {name}"',
+                        replacement='greeting = f"partial_patched {name}"',
+                    )
+                ],
+            ),
+            PatchSpec(
+                target=f"{SAMPLE_MODULE_NAME}.SampleClass.compute",
+                edits=[],
+            ),
+        ]
+
+        def resolve_target(target: str):
+            if target.endswith(".compute"):
+                raise KeyboardInterrupt
+            return _resolve_target(target)
+
+        monkeypatch.setattr(
+            "sglang.srt.debug_utils.source_patcher.code_patcher._resolve_target",
+            resolve_target,
+        )
+
+        with pytest.raises(KeyboardInterrupt):
+            with CodePatcher(patches=patches):
+                pass
+
+        assert obj.greet("world") == "hello world"
+
 
 if __name__ == "__main__":
     import sys


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

`_apply_specs()` applies patches one at a time. If a later patch fails while `CodePatcher.__enter__()` is running, the context manager is never entered and `__exit__()` cannot restore the earlier patches. This leaves partially applied patches active in the Python process.

## Modifications

- Restore already-applied patch states in reverse order when a later patch raises.
- Add a regression test covering a valid first patch followed by an unresolvable target.

## Accuracy Tests

Not applicable; this change does not affect model outputs.

Unit test result: `test/registered/debug_utils/source_patcher/test_code_patcher.py` — 14 passed.

## Speed Tests and Profiling

Not applicable; the only added work is on the patch-application failure path.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (Not applicable; no public API or configuration changes.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Not applicable; no model-output or hot-path changes.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31801712711](https://github.com/sgl-project/sglang/actions/runs/31801712711)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31801712524](https://github.com/sgl-project/sglang/actions/runs/31801712524)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->