### PR TITLE
[Qwen] Disable fused shared-expert gate under deep_gemm MoE backend

### DIFF
--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -67,6 +67,7 @@ from sglang.srt.layers.moe.topk import StandardTopKOutput, TopK, TopKOutputCheck
 from sglang.srt.layers.moe.utils import (
     RoutingMethodType,
     filter_moe_weight_param_global_expert,
+    get_moe_runner_backend,
     is_deepep_class_backend,
     uses_per_rank_fused_shared_slots,
 )
@@ -593,10 +594,14 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
         if get_moe_a2a_backend().is_deepep():
             return self._forward_deepep(hidden_states, forward_batch)
 
+        # deep_gemm disposes (frees) hidden_states after the routed experts run,
+        # but the deferred fused gate reads hidden_states afterwards — so keep
+        # the gate applied inside the shared expert instead of fusing it.
         use_fused_gate = (
             self.shared_expert_gate is not None
             and not use_intel_amx_backend(self.shared_expert_gate)
             and not is_npu()
+            and not get_moe_runner_backend().is_deep_gemm()
         )
 
         if hidden_states.shape[0] == 0:


### PR DESCRIPTION
## Motivation

Running MoE models that go through `Qwen2MoeSparseMoeBlock` (e.g. qwen3.6-35b-a3b, via `qwen3_5_text.py`, which imports this block from `qwen2_moe.py`) with the DeepGemm MoE runner backend errors out.

Root cause: `Qwen2MoeSparseMoeBlock.forward` defers the shared-expert gate to `fused_gate_sigmoid_mul_add(hidden_states, ...)`, which reads `hidden_states` **after** `_forward_router_experts(hidden_states)` runs. The DeepGemm MoE runner calls `dispose_tensor(hidden_states)` once it has consumed the input (`python/sglang/srt/layers/moe/moe_runner/deep_gemm.py`), so the deferred fused gate reads freed memory — a use-after-free.

## Modifications

Exclude the DeepGemm backend from the `use_fused_gate` condition in `Qwen2MoeSparseMoeBlock.forward`. With `use_fused_gate=False`, the shared expert applies the gate itself (`apply_gate=True`) before the routed experts run, and the final combine (`final_hidden_states += shared_output`) no longer reads `hidden_states` after it may have been disposed.

This mirrors the existing deepseek_v2 handling, where `dispose_tensor` is disabled during CUDA graph capture for the same reason ("the routed deep_gemm does not free hidden_states, which the shared expert reads on the alt stream", `deepseek_v2.py`).

No behavior change for other MoE runner backends (triton, flashinfer_*, cutlass, ...).

## Accuracy Tests

Verified locally on qwen3.6-35b-a3b with `--moe-runner-backend deep_gemm`: the model previously errored during forward; with this change it serves normally.

## Speed Tests and Profiling

N/A — the change only selects the non-fused shared-expert gate path when the DeepGemm backend is active; other backends are untouched.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31802230496](https://github.com/sgl-project/sglang/actions/runs/31802230496)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31802230139](https://github.com/sgl-project/sglang/actions/runs/31802230139)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->