### PR TITLE
[Fix] Bound the incremental detokenization window on a U+FFFD stream

### DIFF
--- a/python/sglang/srt/managers/detokenizer_manager.py
+++ b/python/sglang/srt/managers/detokenizer_manager.py
@@ -59,6 +59,18 @@ logger = logging.getLogger(__name__)
 # Use power of 2 values for better memory allocation.
 DETOKENIZER_MAX_STATES = int(os.environ.get("SGLANG_DETOKENIZER_MAX_STATES", 1 << 16))
 
+# How many consecutive steps the incremental-decoding offsets may stay frozen.
+# The commit gate below keeps them still while the decoded tail looks like an
+# incomplete UTF-8 character, but "ends in U+FFFD" is only a proxy for that:
+# U+FFFD is also a complete character a model can emit, and a byte-fallback
+# token decodes to one on its own. A real incomplete character is at most three
+# bytes short, so it completes within the next few tokens; a tail that still
+# looks incomplete after this many steps is output, not a pending character.
+# Committing it keeps the re-decoded window bounded -- while the offsets are
+# frozen the window grows with the output, and since it is re-decoded every
+# step the request costs O(n^2) in its own output length.
+MAX_STALLED_DECODE_STEPS = 8
+
 
 @dataclasses.dataclass
 class DecodeStatus:
@@ -70,6 +82,8 @@ class DecodeStatus:
     read_offset: int
     # Offset that's sent to tokenizer for incremental update.
     sent_offset: int = 0
+    # Consecutive steps the offsets above have stayed frozen.
+    stalled_steps: int = 0
     decoded_text_len: int = dataclasses.field(init=False)
     decoded_text_chunks: List[str] = dataclasses.field(default_factory=list)
 
@@ -377,8 +391,12 @@ class DetokenizerManager(MultiHttpWorkerDetokenizerMixin):
                 # in a prior "�" recovery step; we skip it from this step's
                 # emission so we don't double-send.
                 pending = s.sent_offset - s.decoded_text_len
-                if new_text and not new_text.endswith("�"):
-                    # Clean text: commit to decoded_text and advance offsets.
+                clean = bool(new_text) and not new_text.endswith("�")
+                if clean or s.stalled_steps >= MAX_STALLED_DECODE_STEPS:
+                    # Clean text, or a tail that has stopped looking like a
+                    # pending character: commit to decoded_text and advance
+                    # offsets so the decoded window stays bounded.
+                    s.stalled_steps = 0
                     s.append_decoded_text(new_text)
                     s.surr_offset = s.read_offset
                     s.read_offset = len(s.decode_ids)
@@ -388,6 +406,7 @@ class DetokenizerManager(MultiHttpWorkerDetokenizerMixin):
                     # Incomplete UTF-8: emit the printable prefix only; do not
                     # commit (token offsets stay so the next iteration retries
                     # with more tokens).
+                    s.stalled_steps += 1
                     printable = find_printable_text(new_text)
                     s.sent_offset = s.decoded_text_len + len(printable)
                     output_strs.append(printable[pending:] if pending else printable)

--- a/test/registered/unit/managers/test_detokenizer_incremental.py
+++ b/test/registered/unit/managers/test_detokenizer_incremental.py
@@ -1,0 +1,156 @@
+"""Unit tests for DetokenizerManager incremental-decoding offsets.
+
+Pure CPU: builds the manager without __init__ (no IPC, no real tokenizer) and
+drives _decode_batch_token_id_output directly with a byte-level stub tokenizer.
+"""
+
+import unittest
+
+from sglang.srt.managers.detokenizer_manager import DetokenizerManager
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+# Lone UTF-8 continuation byte: never decodes to a character on its own, so a
+# byte-fallback vocabulary renders it as U+FFFD no matter what follows.
+STRAY_BYTE = 0x80
+# Three-byte UTF-8 sequence for U+4E2D, one byte per token.
+CJK_BYTES = (0xE4, 0xB8, 0xAD)
+TEXT_TOKEN = 256
+
+
+class _ByteFallbackTokenizer:
+    """Ids 0-255 are raw bytes, 256+ are ASCII letters.
+
+    Mirrors the part of a byte-fallback vocabulary these tests depend on:
+    undecodable bytes render as U+FFFD, and a multi-byte character only
+    appears once all of its bytes have arrived.
+    """
+
+    is_fast = True
+
+    def batch_decode(self, ids_list, skip_special_tokens=True, **kwargs):
+        return [self._decode(ids) for ids in ids_list]
+
+    @staticmethod
+    def _decode(ids):
+        buf = bytearray()
+        for i in ids:
+            if i < 256:
+                buf.append(i)
+            else:
+                buf.append(ord("a") + (i - TEXT_TOKEN) % 26)
+        return buf.decode("utf-8", errors="replace")
+
+
+def _make_manager():
+    m = DetokenizerManager.__new__(DetokenizerManager)
+    m.tokenizer = _ByteFallbackTokenizer()
+    m.vocab_size = None
+    m.decode_status = {}
+    m.disable_tokenizer_batch_decode = False
+    m.is_tool_call_parser_gpt_oss = False
+    return m
+
+
+class _Recv:
+    """The subset of BatchTokenIDOutput that the decode path reads."""
+
+    def __init__(self, rid, decode_ids, read_offset):
+        self.rids = [rid]
+        self.finished_reasons = [None]
+        self.decoded_texts = [""]
+        self.decode_ids = [list(decode_ids)]
+        self.read_offsets = [read_offset]
+        self.skip_special_tokens = [True]
+        self.spaces_between_special_tokens = [True]
+        self.no_stop_trim = [False]
+
+
+def _stream(manager, rid, prompt, steps):
+    """Drive one streaming request and return its decode status.
+
+    The scheduler sends the surrogate-context prompt tail together with the
+    first output chunk, then one event per later chunk, so the prompt is
+    context only and never part of the decoded output.
+    """
+    manager._decode_batch_token_id_output(
+        _Recv(rid, list(prompt) + list(steps[0]), len(prompt))
+    )
+    for chunk in steps[1:]:
+        manager._decode_batch_token_id_output(_Recv(rid, chunk, 0))
+    return manager.decode_status[rid]
+
+
+def _run_stray_byte_stream(n_steps, tokens_per_step):
+    """Return (re-decoded window size, decoded text) after n_steps."""
+    manager = _make_manager()
+    s = _stream(
+        manager,
+        "rid",
+        [TEXT_TOKEN] * 5,
+        [[STRAY_BYTE] * tokens_per_step] * n_steps,
+    )
+    return len(s.decode_ids) - s.surr_offset, s.get_decoded_text()
+
+
+class TestIncrementalDecodeWindow(unittest.TestCase):
+    def test_replacement_char_stream_keeps_offsets_moving(self):
+        """A stream of byte-fallback tokens must not freeze the offsets.
+
+        The commit gate treats "decoded tail ends in U+FFFD" as "the trailing
+        bytes are an incomplete character", but a byte-fallback token satisfies
+        that forever. While the offsets are frozen, decode_ids[surr_offset:]
+        grows with the output and is re-decoded on every step, so the request
+        costs O(n^2) in its own output length and the client gets no text.
+        """
+        tokens_per_step = 4
+        short_window, short_text = _run_stray_byte_stream(32, tokens_per_step)
+        long_window, long_text = _run_stray_byte_stream(256, tokens_per_step)
+
+        self.assertNotEqual(short_text, "", "no text ever reached the client")
+        self.assertNotEqual(long_text, "", "no text ever reached the client")
+
+        # The window is re-decoded every step, so it must not scale with the
+        # output length.
+        self.assertLess(
+            long_window,
+            256 * tokens_per_step // 4,
+            f"re-decoded window grew to {long_window} tokens over "
+            f"{256 * tokens_per_step} output tokens",
+        )
+        self.assertLessEqual(
+            long_window,
+            2 * short_window,
+            f"re-decoded window grew with output length: {short_window} "
+            f"tokens at 32 steps, {long_window} at 256",
+        )
+
+    def test_incomplete_character_is_still_held_back(self):
+        """The stall is what keeps a split character intact, so it must stay.
+
+        Guards the other direction of the same gate: committing on every step
+        would emit U+FFFD for the leading bytes of a multi-byte character and
+        lose the character itself.
+        """
+        manager = _make_manager()
+        s = _stream(manager, "rid", [TEXT_TOKEN], [[b] for b in CJK_BYTES])
+        self.assertEqual(s.get_decoded_text(), "中")
+
+    def test_stall_counter_resets_on_a_clean_step(self):
+        """Only *consecutive* stalls may force a commit.
+
+        A stream that stalls briefly and recovers, over and over, is normal
+        traffic: every multi-byte character stalls while its bytes arrive. If
+        those stalls accumulated across characters, a long CJK response would
+        eventually commit in the middle of one.
+        """
+        n_chars = 32
+        steps = [[b] for _ in range(n_chars) for b in CJK_BYTES]
+        manager = _make_manager()
+        s = _stream(manager, "rid", [TEXT_TOKEN], steps)
+        self.assertEqual(s.get_decoded_text(), "中" * n_chars)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes the production half of #34740, reported by @hope1262946533.

`_decode_batch_token_id_output` decides whether incremental detokenization may commit with:

```python
if new_text and not new_text.endswith("�"):
```

The intent is "the trailing bytes are an incomplete character, wait for more tokens". U+FFFD is also a complete character in its own right, and in a byte-fallback vocabulary a single byte token decodes to one, so the condition can be satisfied on every step forever. `surr_offset` is the only place the left edge of the decode window moves, and it only moves inside that branch, so the window `decode_ids[surr_offset:]` then grows with the output. It is re-decoded on every step, which makes one request cost O(n^2) in its own output length, and `find_printable_text` returns `""` for a run of U+FFFD, so the client receives nothing at all while it happens.

`SGLANG_SIMULATE_ACC_LEN` reaches this through `predict.fill_(100)` in `spec_utils.py`, but the switch is only one way in. Any real output containing U+FFFD does the same thing, which is why this PR fixes the detokenizer rather than the simulation constant.

Measured on the real `DetokenizerManager` driven with a gpt2 tokenizer (byte-level BPE, where id 100 also decodes to U+FFFD), 4 accepted tokens per step. `window` is the number of tokens re-decoded per step and `text_len` is the text the client would have received:

before

```
out_tokens   seconds  us/token  ratio   window  text_len
       256    0.0015       6.0      -      261         0
       512    0.0038       7.3  2.46x      517         0
      1024    0.0139      13.6  3.70x     1029         0
      2048    0.0529      25.8  3.81x     2053         0
      4096    0.1980      48.3  3.74x     4101         0
```

after

```
out_tokens   seconds  us/token  ratio   window  text_len
       256    0.0009       3.6      -       44       248
       512    0.0018       3.6  1.99x       48       500
      1024    0.0038       3.8  2.08x       56      1004
      2048    0.0076       3.7  1.99x       36      2048
      4096    0.0153       3.7  2.01x       68      4064
```

Doubling the output length multiplies the cost by 3.7x to 3.8x before and by 2.0x after, and per-token cost goes from growing (6.0 to 48.3 us) to flat (3.7 us). A stream of ordinary text tokens is unaffected in both runs: 1.6 us/token, window 4.

## Modifications

`python/sglang/srt/managers/detokenizer_manager.py`, +23-2.

Count consecutive steps that leave the offsets frozen, and commit once that count passes `MAX_STALLED_DECODE_STEPS`. A genuinely incomplete UTF-8 character is at most three bytes short, so it completes within the next few tokens; a tail that still looks incomplete after eight consecutive steps is output rather than a pending character. The counter resets on every ordinary commit, so a stream that stalls for one or two steps per multi-byte character, which is normal CJK traffic, never reaches the cap.

This keeps the window bounded by the cap instead of by the output length, so the cost is linear regardless of what the model emits.

I picked the stall bound over the two other directions in the issue because it is the one that holds for any tokenizer. Testing byte completeness properly needs a tokenizer API that reports trailing incomplete bytes, which not every backend here has, and it would still leave the window unbounded for genuinely undecodable bytes, which is the case that actually stalled.

## Accuracy Tests

Output text changes only for a stream that currently produces no text at all. At a forced commit the trailing U+FFFD is committed rather than held, which is already what the finished-request path does at end of stream.

The edge case this does not cover: if a multi-byte character is still genuinely mid-arrival at the moment the cap is reached, that one character is committed as U+FFFD and the next window starts mid-character. Reaching it takes eight consecutive stalled steps, and a real character needs at most three more bytes, so it takes a stream that is already mostly undecodable. `test_stall_counter_resets_on_a_clean_step` pins the boundary from the other side.

## Speed Tests and Profiling

The numbers above. I could not run the server-level benchmark from the issue, see the note on platforms below.

## Tests

New CPU unit test, `test/registered/unit/managers/test_detokenizer_incremental.py`, registered to `base-a-test-cpu`. It builds the manager without `__init__` and drives the real decode path with a byte-level stub tokenizer, so it needs no network, no weights and no GPU.

Reverting only the source change and keeping the test:

```
test_incomplete_character_is_still_held_back PASSED   [ 33%]
test_replacement_char_stream_keeps_offsets_moving FAILED [ 66%]
test_stall_counter_resets_on_a_clean_step PASSED      [100%]
E  AssertionError: '' == '' : no text ever reached the client
1 failed, 2 passed
```

and the same test with the fix restored:

```
test_incomplete_character_is_still_held_back PASSED   [ 33%]
test_replacement_char_stream_keeps_offsets_moving PASSED [ 66%]
test_stall_counter_resets_on_a_clean_step PASSED      [100%]
3 passed
```

The two cases that pass either way are deliberate: they guard the opposite direction, that a split multi-byte character is still held back and that brief stalls still reset, so the gate cannot be "fixed" by removing it.

`test/registered/unit/managers/test_trim_matched_stop.py` still passes.

## Platforms

Verified on macOS 15.3.1 arm64 (M4 Pro), Python 3.12, CPU only. This machine has no NVIDIA GPU, so I did not run the 8 GPU DeepSeek-V4-Pro configuration from the issue, the EAGLE or `SGLANG_SIMULATE_ACC_LEN` paths, or any GPU suite. The changed code is tokenizer-side Python that runs in the detokenizer process, and the new test is CPU only, but the end to end throughput and TTFT recovery reported in the issue is unverified by me.

Unrelated to this change, `test_numa_utils.py` fails and much of `test/registered/unit/managers/` does not import on macOS for missing Linux-only dependencies.

## Out of scope

Defect A in the issue, the hardcoded `predict.fill_(100)` in `spec_utils.py`, is untouched. A safe id is vocabulary dependent and that function has no tokenizer, so it deserves its own change.

This touches the same else branch as the open #31564, on an adjacent line. The two are independent and compose.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31802464850](https://github.com/sgl-project/sglang/actions/runs/31802464850)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31802464672](https://github.com/sgl-project/sglang/actions/runs/31802464672)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->