### PR TITLE
[CI] Path-gate Rust workspace tests in lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Detect Rust workspace changes
+        id: paths
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            rust_workspace:
+              - 'rust/**'
+              - 'proto/sglang/runtime/v1/sglang.proto'
+              - '.github/workflows/lint.yml'
+
       # Fail-fast gate: docs_new/ was renamed to docs/ (#32123). git's rename
       # detection silently re-adds NEW files under docs_new/ on merge without a
       # conflict, which would resurrect the directory. We check the checked-out
@@ -54,6 +64,7 @@ jobs:
       # and a test script is not a build input. Tests take ~1s; the timeout is
       # for a cold cache, which codegens the dependency graph first.
       - name: Run rust/ workspace tests
+        if: steps.paths.outputs.rust_workspace == 'true'
         run: cd rust && timeout 900 cargo test --workspace
 
       - name: Run lychee docs checks (offline references)


### PR DESCRIPTION
## Summary

- detect changes that can affect the `rust/` Cargo workspace
- run `cargo test --workspace` only for those changes
- keep the existing Rust cache and 900-second timeout unchanged

The relevant path set includes `rust/**`, the protobuf compiled by `rust/sglang-grpc/build.rs`, and the lint workflow itself. Changes to the gate therefore exercise the Cargo test path.

## Motivation

PR #34860 changed only documentation, but its lint job still spent 1m44s in `cargo test --workspace` after an exact 390 MB Rust cache restore. The tests ran in 0.47s; test-profile compilation accounted for nearly all of the step. Documentation-only and unrelated Python changes cannot affect this workspace.

## Validation

- `SKIP=no-commit-to-branch pre-commit run --files .github/workflows/lint.yml`
- YAML structure assertions for the path filter, conditional, timeout, and Cargo command
- dependency scan covering Cargo path dependencies and build-script inputs

This PR changes `.github/workflows/lint.yml`, so its own lint run is expected to execute the Rust workspace tests. After merge, a docs-only lint run should omit that step.

## CI evidence

[Lint run #31815484567](https://github.com/sgl-project/sglang/actions/runs/31815484567) passed on this PR:

- changed-path detection: less than 1 second
- pre-commit: 6m41s
- Rust workspace tests: 1m45s
- total lint job: 10m57s

Because this PR changes the gate itself, the Rust workspace tests ran and passed. For an unrelated change, the new filter overhead is less than 1 second and the 1m45s Cargo step is skipped.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31815485017](https://github.com/sgl-project/sglang/actions/runs/31815485017)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #31816640159](https://github.com/sgl-project/sglang/actions/runs/31816640159)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->