### PR TITLE
[PD] Move the prefill parallel-info fetch off the decode scheduler thread

### DIFF
--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -110,7 +110,7 @@ class PrefillServerInfo:
     # recompute -- no router-injected pd_rebootstrap_prefill_url needed.
     prefill_http_port: Optional[int] = None
 
-    # Pre-computed rank mapping (set by try_ensure_parallel_info on decode side)
+    # Pre-computed rank mapping (set by _publish_parallel_info on decode side)
     target_tp_rank: Optional[int] = None
     target_tp_ranks: Optional[List[int]] = None
     target_cp_ranks: Optional[List[int]] = None
@@ -257,6 +257,21 @@ class CommonKVManager(BaseKVManager):
             self.connection_lock = threading.Lock()
             self.required_prefill_response_num_table: Dict[int, int] = {}
             self.prefill_info_table: Dict[str, PrefillServerInfo] = {}
+            # Parallel-info fetches run here instead of inline on the scheduler
+            # thread; see try_ensure_parallel_info. A few workers so one
+            # unreachable bootstrap server cannot delay the fetch for other
+            # addrs (at most one fetch per addr is in flight).
+            self._parallel_info_executor = concurrent.futures.ThreadPoolExecutor(
+                max_workers=4, thread_name_prefix="pd-parallel-info"
+            )
+            # Addrs with a fetch in flight, mutated under connection_lock so
+            # repeated scheduling cycles do not queue duplicate fetches. The
+            # parallel_info_fetch_in_flight() predicate reads it without the
+            # lock: a stale answer only costs a skipped cycle or one extra call
+            # that the re-check under the lock rejects.
+            self._parallel_info_inflight: Set[str] = set()
+            # Set by a fetch thread when it hits a fatal config mismatch.
+            self._parallel_info_fatal: Optional[BaseException] = None
             self.heartbeat_failures: Dict[str, int] = {}
             self.session_pool: Dict = defaultdict(requests.Session)
             self.session_pool_lock = threading.Lock()
@@ -598,11 +613,84 @@ class CommonKVManager(BaseKVManager):
 
     def try_ensure_parallel_info(self, bootstrap_addr: str) -> bool:
         """Single non-blocking attempt to fetch and cache prefill parallel info.
-        Returns True if info is available (cached or freshly fetched)."""
-        if bootstrap_addr in self.prefill_info_table:
+        Returns True if info is available (cached or freshly fetched).
+
+        This runs on the decode scheduler's event loop, so the HTTP fetch itself
+        is handed to a background executor: a bootstrap server that stops
+        answering (rather than refusing) would otherwise stall the loop for the
+        full request timeout. Callers already treat False as "not available yet,
+        retry on a later scheduling cycle".
+        """
+        self.raise_parallel_info_error()
+
+        if self.has_parallel_info(bootstrap_addr):
             return True
 
-        info: PrefillServerInfo = None
+        with self.connection_lock:
+            # Re-check under the lock: a fetch may have published between the
+            # check above and here, and would then be repeated needlessly.
+            if bootstrap_addr in self.prefill_info_table:
+                return True
+            if bootstrap_addr in self._parallel_info_inflight:
+                return False
+            self._parallel_info_inflight.add(bootstrap_addr)
+
+        self._parallel_info_executor.submit(self._publish_parallel_info, bootstrap_addr)
+        return False
+
+    def raise_parallel_info_error(self) -> None:
+        """Re-raise, on the calling thread, a fatal error hit by a fetch thread.
+
+        A config mismatch is fatal exactly as it was when the fetch ran inline on
+        the scheduler thread, so it must not be left inside the executor. Callers
+        driving the fetch should call this once per scheduling cycle so the error
+        surfaces even if they take a path that does not fetch.
+        """
+        fatal = self._parallel_info_fatal
+        if fatal is not None:
+            raise fatal
+
+    def has_parallel_info(self, bootstrap_addr: str) -> bool:
+        """Whether parallel info for this addr is already cached. Cheap enough
+        to call on every scheduling cycle, unlike try_ensure_parallel_info which
+        may start a fetch."""
+        return bootstrap_addr in self.prefill_info_table
+
+    def parallel_info_fetch_in_flight(self, bootstrap_addr: str) -> bool:
+        """Whether a fetch for this addr has already been submitted and not
+        finished yet. Callers use this to avoid spending a retry attempt on a
+        fetch that is still running."""
+        return bootstrap_addr in self._parallel_info_inflight
+
+    def _publish_parallel_info(self, bootstrap_addr: str) -> None:
+        """Executor-thread body of try_ensure_parallel_info: fetch, validate and
+        publish the parallel info for one bootstrap addr."""
+        try:
+            info = self._fetch_parallel_info(bootstrap_addr)
+            if info is None:
+                return
+            self._check_parallel_info(info)
+            self._resolve_rank_mapping(info)
+            with self.connection_lock:
+                self.prefill_info_table[bootstrap_addr] = info
+            logger.debug(f"Prefill parallel info for [{bootstrap_addr}]: {info}")
+        except Exception as e:
+            # Config mismatches (and any unexpected error, which used to take
+            # the scheduler thread down here too) are re-raised on the scheduler
+            # thread by try_ensure_parallel_info. Log here as well so the error
+            # is never silent, even if no later call comes for this addr.
+            logger.exception(
+                f"Fatal error while fetching prefill parallel info from [{bootstrap_addr}]"
+            )
+            self._parallel_info_fatal = e
+        finally:
+            with self.connection_lock:
+                self._parallel_info_inflight.discard(bootstrap_addr)
+
+    def _fetch_parallel_info(self, bootstrap_addr: str) -> Optional[PrefillServerInfo]:
+        """Blocking HTTP fetch of one prefill server's parallel info. Returns
+        None if the bootstrap server is unreachable or answers non-200, which
+        the caller retries on a later scheduling cycle."""
         try:
             url = (
                 f"http://{bootstrap_addr}/route?"
@@ -611,18 +699,17 @@ class CommonKVManager(BaseKVManager):
             )
             response = requests.get(url, timeout=5)
             if response.status_code == 200:
-                data = response.json()
-                info = PrefillServerInfo(**data)
-            else:
-                logger.error(
-                    f"Failed to get prefill server info: {response.status_code}, {response.text}"
-                )
-                return False
+                return PrefillServerInfo(**response.json())
+            logger.error(
+                f"Failed to get prefill server info: {response.status_code}, {response.text}"
+            )
         except Exception as e:
             logger.error(f"Error fetching prefill server info from bootstrap: {e}")
-            return False
+        return None
 
-        # Sanity checks
+    def _check_parallel_info(self, info: PrefillServerInfo) -> None:
+        """Validate the prefill server config against ours. Raises RuntimeError
+        on a mismatch, which is fatal for the engine."""
         if info.page_size is not None and info.page_size != self.kv_args.page_size:
             raise RuntimeError(
                 f"Page size mismatch: prefill server has page_size={info.page_size}, "
@@ -650,11 +737,6 @@ class CommonKVManager(BaseKVManager):
                     "PD decode DCP currently requires prefill attention CP=1, "
                     f"got {info.attn_cp_size}."
                 )
-
-        self._resolve_rank_mapping(info)
-        self.prefill_info_table[bootstrap_addr] = info
-        logger.debug(f"Prefill parallel info for [{bootstrap_addr}]: {info}")
-        return True
 
     def _resolve_rank_mapping(self, info: PrefillServerInfo) -> None:
         """Compute TP/CP/PP rank mapping and store on the PrefillServerInfo object.
@@ -1370,7 +1452,7 @@ class CommonKVReceiver(BaseKVReceiver):
             self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Failed)
             return
 
-        # Read pre-computed rank mapping from prefill_info (computed in try_ensure_parallel_info)
+        # Read pre-computed rank mapping from prefill_info (computed in _publish_parallel_info)
         self.prefill_info = self.kv_mgr.prefill_info_table[self.bootstrap_addr]
         self.target_tp_rank = self.prefill_info.target_tp_rank
         self.target_tp_ranks = self.prefill_info.target_tp_ranks

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -374,7 +374,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             str, Tuple[Tuple[int, ...], Future[Dict[str, int]]]
         ] = {}
         self._ensure_retry_count: Dict[str, int] = {}
-        self._max_ensure_retries: int = 15  # scheduling cycles
+        self._max_ensure_retries: int = 15  # parallel info fetch attempts
         self._ensure_last_attempt_time: Dict[str, float] = {}
         self._ensure_retry_interval: float = 1.0  # seconds
         # Retracted requests staged for rebootstrap while generation is paused.
@@ -922,8 +922,27 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         ready: Dict[str, List[DecodeRequest]] = {}
         remaining: List[DecodeRequest] = []
 
+        # Fetches run off this thread, so a fatal config mismatch is surfaced
+        # here rather than wherever it was hit. Checked once per cycle so no
+        # per-addr path below can mask it.
+        self.kv_manager.raise_parallel_info_error()
+
         now = time.monotonic()
         for bootstrap_addr, reqs in addr_to_reqs.items():
+            # The fetch is asynchronous, so a result may have landed since the
+            # last attempt: check the cache on every cycle and let the retry
+            # interval below pace only new fetch attempts.
+            if self.kv_manager.has_parallel_info(bootstrap_addr):
+                self._clear_ensure_state(bootstrap_addr)
+                ready[bootstrap_addr] = reqs
+                continue
+
+            if self.kv_manager.parallel_info_fetch_in_flight(bootstrap_addr):
+                # An attempt is already running; waiting for it is not a new
+                # attempt, so the retry budget below still counts fetches.
+                remaining.extend(reqs)
+                continue
+
             last_attempt = self._ensure_last_attempt_time.get(bootstrap_addr)
             if last_attempt is not None and (
                 now - last_attempt < self._ensure_retry_interval
@@ -931,30 +950,38 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 remaining.extend(reqs)
                 continue
 
-            self._ensure_last_attempt_time[bootstrap_addr] = now
-
-            if self.kv_manager.try_ensure_parallel_info(bootstrap_addr):
-                if bootstrap_addr in self._ensure_retry_count:
-                    del self._ensure_retry_count[bootstrap_addr]
-                if bootstrap_addr in self._ensure_last_attempt_time:
-                    del self._ensure_last_attempt_time[bootstrap_addr]
-                ready[bootstrap_addr] = reqs
-                continue
-
-            count = self._ensure_retry_count.get(bootstrap_addr, 0) + 1
-            self._ensure_retry_count[bootstrap_addr] = count
-
+            count = self._ensure_retry_count.get(bootstrap_addr, 0)
             if count >= self._max_ensure_retries:
+                # Every attempt has finished without publishing anything: an
+                # outstanding fetch is skipped above, so reaching this point
+                # means the last one is done too. Checking the budget before
+                # spending an attempt keeps the last attempt's result from
+                # being discarded unseen.
+                if self.kv_manager.has_parallel_info(bootstrap_addr):
+                    # It published between the check at the top of this cycle
+                    # and here; the requests are fine, so do not abort them.
+                    self._clear_ensure_state(bootstrap_addr)
+                    ready[bootstrap_addr] = reqs
+                    continue
+
                 error_msg = f"Could not fetch prefill parallel info from {bootstrap_addr} after {count} attempts"
                 logger.error(error_msg)
                 for decode_req in reqs:
                     # kv_receiver may be None from a prior self.queue cleanup
                     if decode_req.kv_receiver is not None:
                         decode_req.kv_receiver.abort()
-                del self._ensure_retry_count[bootstrap_addr]
-                del self._ensure_last_attempt_time[bootstrap_addr]
-            else:
-                remaining.extend(reqs)
+                self._clear_ensure_state(bootstrap_addr)
+                continue
+
+            self._ensure_retry_count[bootstrap_addr] = count + 1
+            self._ensure_last_attempt_time[bootstrap_addr] = now
+
+            if self.kv_manager.try_ensure_parallel_info(bootstrap_addr):
+                self._clear_ensure_state(bootstrap_addr)
+                ready[bootstrap_addr] = reqs
+                continue
+
+            remaining.extend(reqs)
 
         return ready, remaining
 
@@ -999,6 +1026,11 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         for _, future in self._prefill_dp_rank_queries.values():
             future.cancel()
         self._prefill_dp_rank_queries.clear()
+
+    def _clear_ensure_state(self, bootstrap_addr: str) -> None:
+        """Drop the per-addr fetch retry bookkeeping once info is available."""
+        self._ensure_retry_count.pop(bootstrap_addr, None)
+        self._ensure_last_attempt_time.pop(bootstrap_addr, None)
 
     def _resolve_pending_reqs(self) -> None:
         """Batch-resolve prefill_dp_ranks for pending requests and initialize receivers."""

--- a/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
+++ b/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
@@ -244,9 +244,12 @@ class TestDecodeQueueCleanup(CustomTestCase):
         queue = DecodePreallocQueue.__new__(DecodePreallocQueue)
         queue._max_ensure_retries = 1
         queue._ensure_retry_interval = 0
-        queue._ensure_retry_count = {"127.0.0.1:11500": 0}
+        # Budget already spent, so this cycle takes the abort path.
+        queue._ensure_retry_count = {"127.0.0.1:11500": 1}
         queue._ensure_last_attempt_time = {}
         queue.kv_manager = MagicMock()
+        queue.kv_manager.has_parallel_info.return_value = False
+        queue.kv_manager.parallel_info_fetch_in_flight.return_value = False
         queue.kv_manager.try_ensure_parallel_info.return_value = False
 
         cleared_req = SimpleNamespace(

--- a/test/registered/unit/disaggregation/test_parallel_info_nonblocking.py
+++ b/test/registered/unit/disaggregation/test_parallel_info_nonblocking.py
@@ -1,0 +1,370 @@
+"""Unit tests for srt/disaggregation/common/conn -- non-blocking prefill
+parallel-info fetch, and the decode-side cache check that consumes it.
+
+The fetch used to run inline on the decode scheduler's event loop, so an
+unresponsive bootstrap server stalled the whole loop for the request timeout.
+These tests pin the two properties that fix relies on: the scheduler-thread call
+never waits for the network, and a config mismatch found on the fetch thread is
+still fatal for the engine.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+import concurrent.futures
+import threading
+import unittest
+from unittest.mock import MagicMock, patch
+
+from sglang.srt.disaggregation.common.conn import CommonKVManager, PrefillServerInfo
+from sglang.srt.disaggregation.decode import DecodePreallocQueue
+from sglang.test.test_utils import CustomTestCase
+
+ADDR = "10.0.0.1:8998"
+
+ROUTE_PAYLOAD = {
+    "attn_tp_size": 1,
+    "attn_cp_size": 1,
+    "dp_size": 1,
+    "pp_size": 1,
+    "page_size": 16,
+    "kv_cache_dtype": "auto",
+    "follow_bootstrap_room": False,
+}
+
+
+def _response(status_code=200, payload=None):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = dict(ROUTE_PAYLOAD if payload is None else payload)
+    resp.text = ""
+    return resp
+
+
+class TestNonBlockingParallelInfo(CustomTestCase):
+    def setUp(self):
+        self.mgr = self._make_manager()
+        self.addCleanup(self.mgr._parallel_info_executor.shutdown, wait=True)
+
+    def _make_manager(self):
+        """Lightweight manager exposing only what the fetch path touches, in the
+        style of test_register_to_bootstrap.py (CommonKVManager.__init__ needs
+        zmq and a resolved model config)."""
+        mgr = MagicMock(spec=CommonKVManager)
+        for name in (
+            "try_ensure_parallel_info",
+            "raise_parallel_info_error",
+            "has_parallel_info",
+            "_publish_parallel_info",
+            "_fetch_parallel_info",
+            "_check_parallel_info",
+        ):
+            setattr(
+                mgr, name, getattr(CommonKVManager, name).__get__(mgr, CommonKVManager)
+            )
+
+        mgr.prefill_info_table = {}
+        mgr.connection_lock = threading.Lock()
+        mgr._parallel_info_inflight = set()
+        mgr._parallel_info_fatal = None
+        # Single worker so that submitting a no-op is a FIFO barrier: see _drain.
+        mgr._parallel_info_executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="test-pd-parallel-info"
+        )
+        mgr.kv_args = MagicMock()
+        mgr.kv_args.page_size = 16
+        mgr.kv_cache_dtype_str = "auto"
+        mgr.dcp_size = 1
+        mgr.is_mla_backend = True
+        mgr.is_hybrid_mla_backend = False
+        return mgr
+
+    def _drain(self):
+        """Wait for queued fetches to finish without asserting on wall time. The
+        executor has a single worker, so a no-op that completes proves every
+        earlier task did too."""
+        self.mgr._parallel_info_executor.submit(lambda: None).result(timeout=10)
+
+    def test_cache_hit_returns_true_without_any_fetch(self):
+        self.mgr.prefill_info_table[ADDR] = PrefillServerInfo(**ROUTE_PAYLOAD)
+        with patch("sglang.srt.disaggregation.common.conn.requests.get") as mock_get:
+            self.assertTrue(self.mgr.try_ensure_parallel_info(ADDR))
+        mock_get.assert_not_called()
+
+    def test_scheduler_thread_does_not_wait_for_the_fetch(self):
+        """The core regression guard: the call returns while the HTTP request is
+        still outstanding, so a hung bootstrap server cannot stall the loop."""
+        gate = threading.Event()
+        entered = threading.Event()
+
+        def blocking_get(*args, **kwargs):
+            entered.set()
+            self.assertTrue(gate.wait(timeout=10), "fetch was never released")
+            return _response()
+
+        with patch(
+            "sglang.srt.disaggregation.common.conn.requests.get",
+            side_effect=blocking_get,
+        ):
+            self.assertFalse(self.mgr.try_ensure_parallel_info(ADDR))
+            # Returned with the fetch still in flight, nothing published yet.
+            self.assertTrue(entered.wait(timeout=10))
+            self.assertNotIn(ADDR, self.mgr.prefill_info_table)
+            self.assertFalse(self.mgr.has_parallel_info(ADDR))
+
+            gate.set()
+            self._drain()
+
+        self.assertTrue(self.mgr.has_parallel_info(ADDR))
+        self.assertEqual(self.mgr.prefill_info_table[ADDR].page_size, 16)
+        self.mgr._resolve_rank_mapping.assert_called_once()
+        self.assertEqual(self.mgr._parallel_info_inflight, set())
+
+    def test_repeated_calls_do_not_pile_up_fetches(self):
+        gate = threading.Event()
+        entered = threading.Event()
+
+        def blocking_get(*args, **kwargs):
+            entered.set()
+            self.assertTrue(gate.wait(timeout=10), "fetch was never released")
+            return _response()
+
+        with patch(
+            "sglang.srt.disaggregation.common.conn.requests.get",
+            side_effect=blocking_get,
+        ) as mock_get:
+            self.assertFalse(self.mgr.try_ensure_parallel_info(ADDR))
+            self.assertTrue(entered.wait(timeout=10))
+            for _ in range(5):
+                self.assertFalse(self.mgr.try_ensure_parallel_info(ADDR))
+            gate.set()
+            self._drain()
+
+        self.assertEqual(mock_get.call_count, 1)
+
+    def test_failed_fetch_is_retried_on_a_later_call(self):
+        with patch(
+            "sglang.srt.disaggregation.common.conn.requests.get",
+            return_value=_response(status_code=503),
+        ) as mock_get:
+            self.assertFalse(self.mgr.try_ensure_parallel_info(ADDR))
+            self._drain()
+            self.assertNotIn(ADDR, self.mgr.prefill_info_table)
+            # In-flight marker cleared, so the next cycle starts a fresh fetch.
+            self.assertEqual(self.mgr._parallel_info_inflight, set())
+
+            self.assertFalse(self.mgr.try_ensure_parallel_info(ADDR))
+            self._drain()
+
+        self.assertEqual(mock_get.call_count, 2)
+        self.assertIsNone(self.mgr._parallel_info_fatal)
+
+    def test_config_mismatch_is_reraised_on_the_caller_thread(self):
+        """A page-size mismatch used to raise directly on the scheduler thread
+        and take the engine down; it must still do so from the fetch thread."""
+        mismatched = dict(ROUTE_PAYLOAD, page_size=64)
+        with patch(
+            "sglang.srt.disaggregation.common.conn.requests.get",
+            return_value=_response(payload=mismatched),
+        ):
+            self.assertFalse(self.mgr.try_ensure_parallel_info(ADDR))
+            self._drain()
+
+            self.assertNotIn(ADDR, self.mgr.prefill_info_table)
+            with self.assertRaises(RuntimeError) as ctx:
+                self.mgr.try_ensure_parallel_info(ADDR)
+        self.assertIn("Page size mismatch", str(ctx.exception))
+
+    def test_result_landing_before_the_lock_is_not_refetched(self):
+        """A fetch thread can publish between the unlocked cache check and the
+        locked section below it; the addr must not be fetched a second time."""
+        real_lock = self.mgr.connection_lock
+        mgr = self.mgr
+
+        class PublishOnEnter:
+            """Stands in for a worker that publishes exactly at the moment the
+            caller reaches the locked section."""
+
+            def __enter__(self):
+                mgr.prefill_info_table.setdefault(
+                    ADDR, PrefillServerInfo(**ROUTE_PAYLOAD)
+                )
+                return real_lock.__enter__()
+
+            def __exit__(self, *exc_info):
+                return real_lock.__exit__(*exc_info)
+
+        self.mgr.connection_lock = PublishOnEnter()
+        try:
+            with patch(
+                "sglang.srt.disaggregation.common.conn.requests.get"
+            ) as mock_get:
+                self.assertTrue(self.mgr.try_ensure_parallel_info(ADDR))
+        finally:
+            self.mgr.connection_lock = real_lock
+
+        mock_get.assert_not_called()
+        self.assertEqual(self.mgr._parallel_info_inflight, set())
+
+
+class TestEnsurePrefillInfoConsumesAsyncResult(CustomTestCase):
+    """The retry budget must keep counting fetch attempts, not scheduling
+    cycles, and a result that lands between two cycles has to be picked up on
+    the very next cycle rather than after the retry interval expires."""
+
+    def _make_queue(self):
+        queue = MagicMock(spec=DecodePreallocQueue)
+        for name in ("_ensure_prefill_info", "_clear_ensure_state"):
+            setattr(
+                queue,
+                name,
+                getattr(DecodePreallocQueue, name).__get__(queue, DecodePreallocQueue),
+            )
+        queue._ensure_retry_count = {}
+        queue._ensure_last_attempt_time = {}
+        queue._ensure_retry_interval = 1.0
+        queue._max_ensure_retries = 15
+        queue.kv_manager = MagicMock()
+        queue.kv_manager.has_parallel_info.return_value = False
+        queue.kv_manager.parallel_info_fetch_in_flight.return_value = False
+        queue.kv_manager.try_ensure_parallel_info.return_value = False
+        return queue
+
+    def test_landed_result_is_used_on_the_next_cycle(self):
+        queue = self._make_queue()
+        reqs = [MagicMock()]
+
+        # Cycle 1: nothing cached yet, a fetch is started.
+        ready, remaining = queue._ensure_prefill_info({ADDR: reqs})
+        self.assertEqual(ready, {})
+        self.assertEqual(remaining, reqs)
+        self.assertEqual(queue._ensure_retry_count[ADDR], 1)
+
+        # Cycle 2, well within the retry interval: the fetch has landed, so the
+        # request must be admitted now instead of waiting out the interval.
+        queue.kv_manager.has_parallel_info.return_value = True
+        ready, remaining = queue._ensure_prefill_info({ADDR: reqs})
+        self.assertEqual(ready, {ADDR: reqs})
+        self.assertEqual(remaining, [])
+        self.assertNotIn(ADDR, queue._ensure_retry_count)
+        self.assertNotIn(ADDR, queue._ensure_last_attempt_time)
+
+    def test_retry_interval_still_paces_new_attempts(self):
+        queue = self._make_queue()
+        reqs = [MagicMock()]
+
+        queue._ensure_prefill_info({ADDR: reqs})
+        queue._ensure_prefill_info({ADDR: reqs})
+
+        # Second cycle is inside the interval: no second fetch attempt, and the
+        # abort counter did not advance.
+        self.assertEqual(queue.kv_manager.try_ensure_parallel_info.call_count, 1)
+        self.assertEqual(queue._ensure_retry_count[ADDR], 1)
+
+    def test_outstanding_fetch_does_not_spend_retry_attempts(self):
+        """The budget is _max_ensure_retries fetch attempts, and a fetch can now
+        outlive many scheduling cycles, so cycles spent waiting on one must not
+        consume it -- otherwise a slow server is abandoned after
+        _max_ensure_retries cycles instead of that many attempts."""
+        queue = self._make_queue()
+        queue._max_ensure_retries = 2
+        reqs = [MagicMock()]
+
+        # Cycle 1 submits the first attempt.
+        queue._ensure_prefill_info({ADDR: reqs})
+        self.assertEqual(queue._ensure_retry_count[ADDR], 1)
+
+        # The fetch is still running: many cycles pass, none of them an attempt.
+        # Each cycle is placed outside the retry interval, so only the in-flight
+        # check can keep them from spending the budget.
+        queue.kv_manager.parallel_info_fetch_in_flight.return_value = True
+        for _ in range(5):
+            queue._ensure_last_attempt_time[ADDR] -= queue._ensure_retry_interval
+            ready, remaining = queue._ensure_prefill_info({ADDR: reqs})
+            self.assertEqual(ready, {})
+            self.assertEqual(remaining, reqs)
+        self.assertEqual(queue._ensure_retry_count[ADDR], 1)
+        self.assertEqual(queue.kv_manager.try_ensure_parallel_info.call_count, 1)
+        reqs[0].kv_receiver.abort.assert_not_called()
+
+        # The fetch failed and cleared its marker; the next cycle outside the
+        # interval spends the second and final attempt -- without aborting yet,
+        # because that attempt's result is not in.
+        queue.kv_manager.parallel_info_fetch_in_flight.return_value = False
+        queue._ensure_last_attempt_time[ADDR] -= queue._ensure_retry_interval
+        queue._ensure_prefill_info({ADDR: reqs})
+        self.assertEqual(queue.kv_manager.try_ensure_parallel_info.call_count, 2)
+        self.assertEqual(queue._ensure_retry_count[ADDR], 2)
+        reqs[0].kv_receiver.abort.assert_not_called()
+
+        # That attempt is done and published nothing, so the budget is spent.
+        queue._ensure_last_attempt_time[ADDR] -= queue._ensure_retry_interval
+        queue._ensure_prefill_info({ADDR: reqs})
+        self.assertEqual(queue.kv_manager.try_ensure_parallel_info.call_count, 2)
+        reqs[0].kv_receiver.abort.assert_called_once()
+        self.assertNotIn(ADDR, queue._ensure_retry_count)
+
+    def test_result_landing_just_before_the_abort_is_honoured(self):
+        """A fetch can publish between the cache check at the top of a cycle and
+        the exhausted-budget branch at the bottom; those requests are fine and
+        must not be aborted."""
+        queue = self._make_queue()
+        queue._max_ensure_retries = 1
+        reqs = [MagicMock()]
+
+        queue._ensure_prefill_info({ADDR: reqs})
+        queue._ensure_last_attempt_time[ADDR] -= queue._ensure_retry_interval
+
+        # False at the top of the cycle, True by the time the abort is decided.
+        queue.kv_manager.has_parallel_info.side_effect = [False, True]
+        ready, remaining = queue._ensure_prefill_info({ADDR: reqs})
+
+        self.assertEqual(ready, {ADDR: reqs})
+        self.assertEqual(remaining, [])
+        reqs[0].kv_receiver.abort.assert_not_called()
+        self.assertNotIn(ADDR, queue._ensure_retry_count)
+
+    def test_fatal_fetch_error_surfaces_even_when_the_budget_is_spent(self):
+        """A config mismatch is fatal for the engine, so it must not be masked
+        by the abort path taking over on the same cycle."""
+        queue = self._make_queue()
+        queue._max_ensure_retries = 1
+        reqs = [MagicMock()]
+
+        queue._ensure_prefill_info({ADDR: reqs})
+        queue._ensure_last_attempt_time[ADDR] -= queue._ensure_retry_interval
+
+        queue.kv_manager.raise_parallel_info_error.side_effect = RuntimeError(
+            "Page size mismatch"
+        )
+        with self.assertRaises(RuntimeError):
+            queue._ensure_prefill_info({ADDR: reqs})
+        reqs[0].kv_receiver.abort.assert_not_called()
+
+    def test_last_attempt_is_not_abandoned_before_its_result(self):
+        """The abort is decided before spending an attempt, not after, so a
+        fetch that succeeds on the last allowed attempt still admits its
+        requests instead of being discarded unseen."""
+        queue = self._make_queue()
+        queue._max_ensure_retries = 1
+        reqs = [MagicMock()]
+
+        # Cycle 1 spends the only allowed attempt; nothing is aborted yet.
+        queue._ensure_prefill_info({ADDR: reqs})
+        self.assertEqual(queue._ensure_retry_count[ADDR], 1)
+        reqs[0].kv_receiver.abort.assert_not_called()
+
+        # That fetch succeeds just before the next cycle.
+        queue.kv_manager.has_parallel_info.return_value = True
+        queue._ensure_last_attempt_time[ADDR] -= queue._ensure_retry_interval
+        ready, remaining = queue._ensure_prefill_info({ADDR: reqs})
+
+        self.assertEqual(ready, {ADDR: reqs})
+        self.assertEqual(remaining, [])
+        reqs[0].kv_receiver.abort.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`CommonKVManager.try_ensure_parallel_info()` is documented as a "single
non-blocking attempt", but it performs a synchronous
`requests.get(url, timeout=5)`. It is called from the decode scheduler thread:

```
SchedulerDisaggregationDecodeMixin.process_decode_queue()
  -> DecodePreallocQueue.pop_preallocated()
    -> _resolve_pending_reqs()
      -> _ensure_prefill_info()
        -> CommonKVManager.try_ensure_parallel_info()   # requests.get(..., timeout=5)
```

So a bootstrap server that stops answering rather than refusing stalls the
entire decode loop — every running request on that instance — for the full
timeout.

The 1 s retry interval in `_ensure_prefill_info()` does not bound this.
`now = time.monotonic()` is captured once before the loop and
`_ensure_last_attempt_time[bootstrap_addr]` is stamped *before* the call, so a
5 s timeout fully absorbs the 1 s interval and attempts land essentially back to
back. With `_max_ensure_retries = 15` that is up to ~75 s of near-continuous
stall for one unreachable addr, and `addr_to_reqs` is iterated sequentially, so
K such addrs cost K × 5 s within a single scheduling cycle.

This is not a hypothetical state. The decode-side heartbeat checker evicts an
addr from the cache after `max_failures` consecutive `/health` failures:

```python
def _handle_node_failure(self, failed_bootstrap_addr: str):
    with self.connection_lock:
        ...
        self.prefill_info_table.pop(failed_bootstrap_addr, None)
```

Requests still routed to that addr then miss the cache, land in `pending_reqs`,
and the scheduler thread itself starts dialing the unreachable prefill server.

`/health_generate` passes as long as `last_receive_tstamp` advances within
`HEALTH_CHECK_TIMEOUT` (default 20 s), so a single 5 s stall only inflates ITL —
but a sustained stall exceeds the window, the decode server reports unhealthy,
and a router in front of it will pull it out of rotation while its requests are
still in flight. #20252 reports exactly that shape at scale: a prefill restart
leaves decode servers "stuck continuously retrying to connect to the downed
prefill server", their health checks time out, sglang-router removes them, and
the remaining decoders take the concentrated traffic.

#20785 already set out to fix this — its summary says `add()` becomes "a pure
cache lookup — **no network calls, no blocking**", and its background notes the
old `ensure_parallel_info()` "blocks up to 30s (5 retries × 1s sleep + 5s HTTP
timeout)". It did remove the retry loop and the `time.sleep()`. But the
remaining single 5 s GET only moved from `add()` to the `pending_reqs`
resolution path; both run on the scheduler thread.

## Modifications

Hand the HTTP fetch to a small `ThreadPoolExecutor`, mirroring the existing
`_prefill_recompute_executor` idiom in the same class:

* `try_ensure_parallel_info()` is now a cache lookup plus at most one fetch
  submission per addr, and returns `False` while a fetch is outstanding. Its
  callers already treat `False` as "not available yet, retry on a later
  scheduling cycle", so no caller contract changes.
* An in-flight set keeps repeated scheduling cycles from queueing duplicate
  fetches for the same addr. It is mutated under `connection_lock`, and the cache
  is re-checked inside that lock, so a fetch that publishes between the unlocked
  check and the locked section does not cause a redundant fetch. The
  `parallel_info_fetch_in_flight()` predicate reads the set without the lock; a
  stale answer only costs a skipped cycle or one extra call that the locked
  re-check rejects.
* The old body is split into `_fetch_parallel_info()` (the blocking GET, HTTP
  error handling unchanged — log and return no info), `_check_parallel_info()`
  (the page-size / kv-cache-dtype / DCP validations, unchanged), and
  `_publish_parallel_info()` (the executor-thread body).
* Config mismatches stay fatal. They currently raise on the scheduler thread and
  take the engine down, which is deliberate; an executor would swallow them, so
  the fetch thread logs the error and records the exception, and
  `raise_parallel_info_error()` re-raises it on the scheduler thread — both from
  `try_ensure_parallel_info()` and once per scheduling cycle in
  `_ensure_prefill_info()`, so a mismatch found on the last allowed attempt is
  not masked by the abort path taking over on that cycle.
* `_ensure_prefill_info()` gets four adjustments so its retry bookkeeping keeps
  the meaning it has today, now that a fetch can outlive a scheduling cycle:
  * it checks the cache *before* the retry-interval gate, so a result that lands
    asynchronously is consumed on the next cycle instead of waiting out the
    interval (otherwise the first request to a new addr would pay 1 s);
  * a cycle that finds a fetch still in flight does not spend a retry attempt.
    Without this, `_max_ensure_retries` would silently become "15 scheduling
    cycles" instead of "15 fetch attempts", cutting the tolerance for a slow
    bootstrap server by ~5× and making the abort message ("after N attempts")
    untrue;
  * the abort is decided *before* spending an attempt rather than after. When
    the call was blocking, the outcome of the last attempt was known in the same
    cycle; with an asynchronous fetch, aborting right after submitting the last
    attempt would discard its result unseen, so a fetch that succeeds on attempt
    15 would still lose its requests. Checking the budget first means the abort
    can only happen on a cycle where no fetch is outstanding, i.e. after all 15
    have finished. The abort therefore waits out the last attempt — up to one
    `timeout=5` later than before, and one retry interval later if the attempt
    finishes sooner than that — and the message is unchanged;
  * the abort branch re-checks the cache before discarding anything. A fetch can
    publish between the check at the top of the cycle and the abort below it, and
    those requests are fine. On `main` this could not happen — `prefill_info_table`
    was written only by this thread — so the window is one this change opens.

### Behaviour

* Steady state is unchanged: parallel info is fetched once per (decode process,
  prefill addr) — a failed fetch is retried as before — and every later call is
  the same dict lookup as today.
* First contact with a new addr no longer blocks the loop; the request is
  admitted on a later scheduling cycle instead of after a round trip.
* The retry budget is unchanged: 15 fetch attempts paced at ≥1 s apart, and all
  of them complete before the same abort message is logged. For an unresponsive
  server the wall-clock time to abort is therefore comparable to today's; the
  difference is that the scheduler is not blocked while those attempts run.
* `ThreadPoolExecutor` worker threads are joined at interpreter exit, so
  outstanding fetches can delay shutdown until they finish. There is at most one
  fetch per bootstrap addr, and `requests`' `timeout=5` bounds connect and read
  individually rather than total wall clock. This matches the existing
  `_prefill_recompute_executor` in this class.
* Not addressed here: a fetch in flight when the heartbeat checker evicts the
  same addr can still republish it afterwards. That race predates this change
  (the inline fetch raced `_handle_node_failure` on the heartbeat thread in
  exactly the same window), so it is left out to keep this change focused.

### Tests

`test/registered/unit/disaggregation/test_parallel_info_nonblocking.py` (new,
CPU-only, no sleeps — a fake fetch blocks on one `threading.Event` and signals
that it has been entered with another, a single-worker executor barrier waits for
a submission to drain, and one custom lock context covers the publish-during-lock
case):

* a cache hit returns `True` without touching the network;
* `try_ensure_parallel_info()` returns while the GET is still outstanding, and
  the info is published once the fetch completes — this is the regression guard;
* repeated calls while a fetch is in flight issue exactly one GET;
* a result published exactly at the locked section is not fetched again;
* a failed fetch (non-200) publishes nothing, clears the in-flight marker, and is
  retried by the next call;
* a page-size mismatch found on the fetch thread is re-raised as `RuntimeError`
  on the caller thread;
* `_ensure_prefill_info()` admits an addr as soon as the result lands, even
  inside the retry interval, while the interval still paces fetch attempts;
* cycles spent waiting on an outstanding fetch do not consume the retry budget;
* a fetch that succeeds on the last allowed attempt still admits its requests,
  instead of being aborted in the cycle that submitted it;
* a result that publishes between the cache check at the top of a cycle and the
  abort below it admits its requests instead of aborting them;
* a config mismatch found on the last allowed attempt still raises, rather than
  being reported as retry exhaustion.

I checked that these fail without the code they cover: making the submission
blocking again (`.result()`) fails the two non-blocking cases and stretches the
file from 12 s to 83 s as the fake fetches serialize; dropping the in-flight
skip in `_ensure_prefill_info()` fails the retry-budget case; dropping the
re-check under the lock fails the duplicate-fetch case; deciding the abort after
submitting rather than before fails the last-attempt case; dropping the cache
re-check in the abort branch fails the publish-before-abort case; dropping the
per-cycle `raise_parallel_info_error()` fails the final-attempt-mismatch case.

`test/registered/unit/disaggregation/` passes in full (163 tests).
`test_decode_queue_cleanup.py` needed two lines and one value: it mocks the KV
manager with a bare `MagicMock`, so the new predicates returned truthy mocks,
and it pre-seeds `_ensure_retry_count` at 0 with `_max_ensure_retries = 1` to
reach the abort path in a single call. Since the budget is now checked before an
attempt is spent, that seed is 1; what the test covers (a request whose
`kv_receiver` was already cleared must not crash on `.abort()`) is unchanged.

Not run by me: a multi-node PD failure smoke test (kill a prefill instance,
confirm the decode instance stays healthy and keeps serving). I do not have a
multi-node rig available; happy to add one if a maintainer prefers it in-tree.

## Accuracy Tests

Not applicable: this changes which thread an HTTP GET runs on. No model forward,
kernel, or numerics change.

## Speed Tests and Profiling

No steady-state performance change to measure: after the first fetch per
(decode process, prefill addr) the call is a dict lookup on both `main` and this
branch, and nothing is added to the per-token path. The change is to the failure
path, where the scheduler loop no longer blocks for 5 s per fetch attempt; the
quantities involved (5 s timeout, 1 s interval, 15 attempts,
`HEALTH_CHECK_TIMEOUT` = 20 s) are all in-tree constants cited above.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations) — no user-facing docs cover this internal path.
- [ ] Provide accuracy and speed benchmark results — not applicable, see above.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32809376569](https://github.com/sgl-project/sglang/actions/runs/32809376569)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32809376468](https://github.com/sgl-project/sglang/actions/runs/32809376468)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32809376582](https://github.com/sgl-project/sglang/actions/runs/32809376582)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->