### PR TITLE
ci: path-gate static ratchet scans in lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Detect Rust workspace changes
+      - name: Detect Rust workspace and ratchet changes
         id: paths
         uses: dorny/paths-filter@v3
         with:
@@ -21,6 +21,18 @@ jobs:
             rust_workspace:
               - 'rust/**'
               - 'proto/sglang/runtime/v1/sglang.proto'
+              - '.github/workflows/lint.yml'
+            ratchet:
+              - 'python/sglang/**'
+              - 'scripts/lint/check_static_ratchets.py'
+              - 'scripts/lint/check_decode_bookkeeping_ownership.py'
+              - 'scripts/lint/check_global_config_read_ratchet.py'
+              - 'scripts/lint/check_legacy_global_ratchet.py'
+              - 'scripts/lint/check_module_state_ratchet.py'
+              - 'scripts/lint/check_parallel_adoption_ratchet.py'
+              - 'scripts/lint/check_server_args_mutation_ratchet.py'
+              - 'scripts/lint/test_check_*.py'
+              - '.pre-commit-config.yaml'
               - '.github/workflows/lint.yml'
 
       # Fail-fast gate: docs_new/ was renamed to docs/ (#32123). git's rename
@@ -57,8 +69,16 @@ jobs:
           workspaces: rust
           shared-key: "rust-workspace-lint"
 
+      # Ratchet gate: any output other than 'false' (including unclassified
+      # events) keeps check-static-ratchets — fail open like rust_workspace.
       - name: Run pre-commit checks
-        run: SKIP=no-commit-to-branch pre-commit run --all-files --show-diff-on-failure
+        run: |
+          skip="no-commit-to-branch"
+          if [ "${{ steps.paths.outputs.ratchet }}" = "false" ]; then
+            skip="$skip,check-static-ratchets"
+          fi
+          echo "ratchet changes: ${{ steps.paths.outputs.ratchet }}; SKIP=$skip"
+          SKIP="$skip" pre-commit run --all-files --show-diff-on-failure
 
       # Not in the rust-ext build job: its cache key covers the built .so files,
       # and a test script is not a build input. Tests take ~1s; the timeout is

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Detect Rust workspace changes
+        id: paths
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            rust_workspace:
+              - 'rust/**'
+              - 'proto/sglang/runtime/v1/sglang.proto'
+              - '.github/workflows/lint.yml'
+
       # Fail-fast gate: docs_new/ was renamed to docs/ (#32123). git's rename
       # detection silently re-adds NEW files under docs_new/ on merge without a
       # conflict, which would resurrect the directory. We check the checked-out
@@ -54,6 +64,7 @@ jobs:
       # and a test script is not a build input. Tests take ~1s; the timeout is
       # for a cold cache, which codegens the dependency graph first.
       - name: Run rust/ workspace tests
+        if: steps.paths.outputs.rust_workspace == 'true'
         run: cd rust && timeout 900 cargo test --workspace
 
       - name: Run lychee docs checks (offline references)


### PR DESCRIPTION
## Motivation

The lint workflow runs `pre-commit --all-files` on every PR, so the `check-static-ratchets` hook (`pass_filenames: false`) rescans the whole `python/sglang` tree even for PRs that change only docs or CI config. This is PR 2 of the lint follow-up plan, stacked on #34864 (this branch contains its commit; the diff shrinks to `lint.yml` alone once that merges).

## What changed

- Extended the existing `dorny/paths-filter@v3` step with a `ratchet` filter covering `python/sglang/**`, the ratchet aggregator and every checker module it imports, its test files, and both gate definitions (`.pre-commit-config.yaml`, `.github/workflows/lint.yml`).
- The pre-commit step builds `SKIP` conditionally: a PR touching none of those paths runs with `SKIP=no-commit-to-branch,check-static-ratchets`, and the decision is echoed in the log.
- Fail open: only a literal `'false'` output skips the check; unclassified events (push, classification failure) keep running it — same semantics as the rust-workspace gate.
- The local `check-static-ratchets` hook definition is untouched, so local pre-commit behavior is unchanged.

## Verification

- Positive path: this PR itself changes `.github/workflows/lint.yml`, which is in the filter — the lint run on this PR must show `SKIP=no-commit-to-branch` and the ratchet hook executing. Confirmed: [run 31819219123](https://github.com/sgl-project/sglang/actions/runs/31819219123) (10m05s wall) logged `ratchet changes: true; SKIP=no-commit-to-branch` with `validate static runtime ratchets` and `black-jupyter` both Passed.
- Negative path: will link a docs-only run showing `SKIP=no-commit-to-branch,check-static-ratchets` and the hook banner as Skipped (CI duration reported as evidence, not a threshold).
- Local: PyYAML structure assertions on the new filter and step; shell simulation of the SKIP logic for `true`/`false`/empty outputs; `pre-commit run --files` on the changed file passes.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31819219562](https://github.com/sgl-project/sglang/actions/runs/31819219562)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31819219544](https://github.com/sgl-project/sglang/actions/runs/31819219544)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
