### PR TITLE
ci: skip black-jupyter when no Python or notebook paths change

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Detect Rust workspace changes
+      - name: Detect Rust workspace and ratchet changes
         id: paths
         uses: dorny/paths-filter@v3
         with:
@@ -21,6 +21,18 @@ jobs:
             rust_workspace:
               - 'rust/**'
               - 'proto/sglang/runtime/v1/sglang.proto'
+              - '.github/workflows/lint.yml'
+            ratchet:
+              - 'python/sglang/**'
+              - 'scripts/lint/check_static_ratchets.py'
+              - 'scripts/lint/check_decode_bookkeeping_ownership.py'
+              - 'scripts/lint/check_global_config_read_ratchet.py'
+              - 'scripts/lint/check_legacy_global_ratchet.py'
+              - 'scripts/lint/check_module_state_ratchet.py'
+              - 'scripts/lint/check_parallel_adoption_ratchet.py'
+              - 'scripts/lint/check_server_args_mutation_ratchet.py'
+              - 'scripts/lint/test_check_*.py'
+              - '.pre-commit-config.yaml'
               - '.github/workflows/lint.yml'
 
       # Fail-fast gate: docs_new/ was renamed to docs/ (#32123). git's rename
@@ -57,8 +69,16 @@ jobs:
           workspaces: rust
           shared-key: "rust-workspace-lint"
 
+      # Ratchet gate: any output other than 'false' (including unclassified
+      # events) keeps check-static-ratchets — fail open like rust_workspace.
       - name: Run pre-commit checks
-        run: SKIP=no-commit-to-branch pre-commit run --all-files --show-diff-on-failure
+        run: |
+          skip="no-commit-to-branch"
+          if [ "${{ steps.paths.outputs.ratchet }}" = "false" ]; then
+            skip="$skip,check-static-ratchets"
+          fi
+          echo "ratchet changes: ${{ steps.paths.outputs.ratchet }}; SKIP=$skip"
+          SKIP="$skip" pre-commit run --all-files --show-diff-on-failure
 
       # Not in the rust-ext build job: its cache key covers the built .so files,
       # and a test script is not a build input. Tests take ~1s; the timeout is

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Detect Rust workspace changes
+        id: paths
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            rust_workspace:
+              - 'rust/**'
+              - 'proto/sglang/runtime/v1/sglang.proto'
+              - '.github/workflows/lint.yml'
+
       # Fail-fast gate: docs_new/ was renamed to docs/ (#32123). git's rename
       # detection silently re-adds NEW files under docs_new/ on merge without a
       # conflict, which would resurrect the directory. We check the checked-out
@@ -54,6 +64,7 @@ jobs:
       # and a test script is not a build input. Tests take ~1s; the timeout is
       # for a cold cache, which codegens the dependency graph first.
       - name: Run rust/ workspace tests
+        if: steps.paths.outputs.rust_workspace == 'true'
         run: cd rust && timeout 900 cargo test --workspace
 
       - name: Run lychee docs checks (offline references)

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Detect Rust workspace and ratchet changes
+      - name: Detect changed paths
         id: paths
         uses: dorny/paths-filter@v3
         with:
@@ -21,6 +21,12 @@ jobs:
             rust_workspace:
               - 'rust/**'
               - 'proto/sglang/runtime/v1/sglang.proto'
+              - '.github/workflows/lint.yml'
+            formatter:
+              - '**/*.py'
+              - '**/*.pyi'
+              - '**/*.ipynb'
+              - '.pre-commit-config.yaml'
               - '.github/workflows/lint.yml'
             ratchet:
               - 'python/sglang/**'
@@ -69,15 +75,20 @@ jobs:
           workspaces: rust
           shared-key: "rust-workspace-lint"
 
-      # Ratchet gate: any output other than 'false' (including unclassified
-      # events) keeps check-static-ratchets — fail open like rust_workspace.
+      # Fail open: only a literal 'false' filter output skips a check;
+      # unclassified events (push, classification failure) run everything.
+      # Neither skip loses coverage: the ratchet only reads python/sglang, and
+      # black is per-file deterministic over a fully formatted tree.
       - name: Run pre-commit checks
         run: |
           skip="no-commit-to-branch"
           if [ "${{ steps.paths.outputs.ratchet }}" = "false" ]; then
             skip="$skip,check-static-ratchets"
           fi
-          echo "ratchet changes: ${{ steps.paths.outputs.ratchet }}; SKIP=$skip"
+          if [ "${{ steps.paths.outputs.formatter }}" = "false" ]; then
+            skip="$skip,black-jupyter"
+          fi
+          echo "ratchet: ${{ steps.paths.outputs.ratchet }}; formatter: ${{ steps.paths.outputs.formatter }}; SKIP=$skip"
           SKIP="$skip" pre-commit run --all-files --show-diff-on-failure
 
       # Not in the rust-ext build job: its cache key covers the built .so files,


### PR DESCRIPTION
## Motivation

`black-jupyter` under `pre-commit --all-files` takes minutes on lint CI. This is PR 3 of the lint follow-up plan, stacked on #34867 (which is stacked on #34864); the branch contains both, so the diff shrinks as they merge. The gate change itself is confined to the `formatter` filter and two added lines in the pre-commit step.

## Investigation findings

- The hook sees 5,474 files after the config's excludes (5,512 `.py` + 3 `.ipynb`; the hook's grpc-pb2 exclude currently matches nothing). No pathological files; the largest is `server_args.py` at 439 KB.
- Measured on a 16 vCPU Xeon with the hook env warm and black's cache cold: **1m11s wall / 15m39s CPU**. Immediate re-run: **2.8s**. The entire cost is parsing every file on a cold black cache — CI runners always have a cold cache (`~/.cache/black` is not persisted). The minutes-scale CI time is `~16 min CPU / 4 vCPUs on ubuntu-latest`.
- Baseline cleanliness: `pre-commit run black-jupyter --all-files` passes with **zero rewrites** on current `main`, so a tree is fully formatted iff every file is — black is per-file deterministic with no cross-file semantics.

## Why enforcement is equivalent

1. Baseline is clean (verified above), so nothing unformatted exists in the tree to silently persist.
2. A PR touching any `*.py`/`*.pyi`/`*.ipynb`, `.pre-commit-config.yaml`, or the workflow itself still runs the full unchanged command.
3. Fail open: only a literal `'false'` filter output skips the hook; unclassified events (push to main, classification failure) run everything.
4. Residual risks are self-revealing: a black version bump that would reformat the tree fails on the main-push run and on the next Python-touching PR.

Negative test (one-off, not committed): an intentionally unformatted change to a tracked `scripts/lint/*.py` file makes `SKIP=no-commit-to-branch pre-commit run black-jupyter --all-files` exit 1, and the path filter matches `**/*.py` so the gate takes the full-run branch.

## Change

- Added a `formatter` filter (`**/*.py`, `**/*.pyi`, `**/*.ipynb`, both gate definitions) to the existing paths step.
- The pre-commit step appends `black-jupyter` to `SKIP` when the filter output is `false`, echoing the decision in the log. Local pre-commit behavior is unchanged.

## Verification

- Positive path: this PR changes `.github/workflows/lint.yml`, which is in the filter — its own lint run must show `SKIP=no-commit-to-branch` with black-jupyter executing. Confirmed: [run 31819280182](https://github.com/sgl-project/sglang/actions/runs/31819280182) (11m36s wall) logged `ratchet: true; formatter: true; SKIP=no-commit-to-branch`; `black-jupyter` ran ~5m of it (consistent with the cold-cache measurement) and both hooks Passed.
- Negative path: will link a docs-only run showing `black-jupyter` skipped plus lint-job wall time before/after on `ubuntu-latest` (same runner class; local numbers above are the approximation).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31819281046](https://github.com/sgl-project/sglang/actions/runs/31819281046)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31819280379](https://github.com/sgl-project/sglang/actions/runs/31819280379)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
