### PR TITLE
[MoonEP] MXFP4 experts for Kimi K3 on the DeepGEMM runner in symmetric memory

### DIFF
--- a/python/sglang/srt/batch_overlap/two_batch_overlap.py
+++ b/python/sglang/srt/batch_overlap/two_batch_overlap.py
@@ -27,8 +27,8 @@ from sglang.srt.layers.moe import (
 )
 from sglang.srt.layers.moe.token_dispatcher import (
     DeepEPDispatcher,
-    MoonEPDispatcher,
     MooncakeEPDispatcher,
+    MoonEPDispatcher,
     MoriEPDispatcher,
     NixlEPDispatcher,
     PplxDispatcher,

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -980,7 +980,11 @@ class Envs:
     # -1 uses MoonEP's training-safe default B = E / EP.
     SGLANG_MOONEP_NUM_PREFETCH_SLOTS = EnvInt(-1)
     SGLANG_MOONEP_TOKEN_PADDING = EnvInt(128)
+    # Decode-phase token capacity; <= 0 derives it from max_running_requests.
+    SGLANG_MOONEP_DECODE_MAX_DISPATCH_TOKENS_PER_RANK = EnvInt(-1)
     SGLANG_MOONEP_NUM_SMS = EnvInt(32)
+    # MoonEP's static shapes should be capturable; off until that is shown.
+    SGLANG_ENABLE_MOONEP_CUDA_GRAPH = EnvBool(False)
     SGLANG_PPLX_NUM_MAX_DISPATCH_TOKENS_PER_RANK = EnvInt(128)
     SGLANG_ENABLE_MOE_DEFERRED_FINALIZE = EnvBool(True)
     # DeepSeek/GLM MoE (deepseek_v2.py): quantize the (dp-gathered) MoE input

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -977,18 +977,13 @@ class Envs:
     SGLANG_NIXL_EP_BF16_DISPATCH = EnvBool(False)
     SGLANG_NIXL_EP_NUM_MAX_DISPATCH_TOKENS_PER_RANK = EnvInt(128)
     SGLANG_MOONEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK = EnvInt(128)
-    # <= 0 resolves to min(4, E / EP). MoonEP's own default is E / EP, which
-    # is a training rule and does not fit at inference scale.
+    # <= 0 resolves to min(4, E / EP).
     SGLANG_MOONEP_NUM_PREFETCH_SLOTS = EnvInt(-1)
     SGLANG_MOONEP_TOKEN_PADDING = EnvInt(128)
     # Decode-phase token capacity; <= 0 derives it from max_running_requests.
     SGLANG_MOONEP_DECODE_MAX_DISPATCH_TOKENS_PER_RANK = EnvInt(-1)
     SGLANG_MOONEP_NUM_SMS = EnvInt(32)
-    # MoonEP's static shapes should be capturable; off until that is shown.
     SGLANG_ENABLE_MOONEP_CUDA_GRAPH = EnvBool(False)
-    # Quantized experts need MoonEP's local-first VMM mapping, which upstream
-    # MoonEP does not carry yet. Off until it lands; setting it asserts that
-    # the installed MoonEP is a build that has it. BF16 does not use the pool.
     SGLANG_ENABLE_MOONEP_LOCAL_FIRST = EnvBool(False)
     SGLANG_PPLX_NUM_MAX_DISPATCH_TOKENS_PER_RANK = EnvInt(128)
     SGLANG_ENABLE_MOE_DEFERRED_FINALIZE = EnvBool(True)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -977,7 +977,8 @@ class Envs:
     SGLANG_NIXL_EP_BF16_DISPATCH = EnvBool(False)
     SGLANG_NIXL_EP_NUM_MAX_DISPATCH_TOKENS_PER_RANK = EnvInt(128)
     SGLANG_MOONEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK = EnvInt(128)
-    # -1 uses MoonEP's training-safe default B = E / EP.
+    # <= 0 resolves to min(4, E / EP). MoonEP's own default is E / EP, which
+    # is a training rule and does not fit at inference scale.
     SGLANG_MOONEP_NUM_PREFETCH_SLOTS = EnvInt(-1)
     SGLANG_MOONEP_TOKEN_PADDING = EnvInt(128)
     # Decode-phase token capacity; <= 0 derives it from max_running_requests.

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -986,6 +986,10 @@ class Envs:
     SGLANG_MOONEP_NUM_SMS = EnvInt(32)
     # MoonEP's static shapes should be capturable; off until that is shown.
     SGLANG_ENABLE_MOONEP_CUDA_GRAPH = EnvBool(False)
+    # Quantized experts need MoonEP's local-first VMM mapping, which upstream
+    # MoonEP does not carry yet. Off until it lands; setting it asserts that
+    # the installed MoonEP is a build that has it. BF16 does not use the pool.
+    SGLANG_ENABLE_MOONEP_LOCAL_FIRST = EnvBool(False)
     SGLANG_PPLX_NUM_MAX_DISPATCH_TOKENS_PER_RANK = EnvInt(128)
     SGLANG_ENABLE_MOE_DEFERRED_FINALIZE = EnvBool(True)
     # DeepSeek/GLM MoE (deepseek_v2.py): quantize the (dp-gathered) MoE input

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -397,15 +397,15 @@ class FusedMoE(torch.nn.Module):
                 f"quant_method={type(self.quant_method).__name__})."
             )
 
-        moonep_global_weight_storage = get_moe_a2a_backend().is_moonep()
-        if moonep_global_weight_storage:
-            if quant_config is not None:
-                raise NotImplementedError(
-                    "MoonEP PoC supports unquantized BF16 MoE weights only."
-                )
+        # Quantized experts instead keep the normal EP
+        # shard and are relocated into a symmetric VMM range after loading
+        moonep_global_weight_storage = (
+            get_moe_a2a_backend().is_moonep() and quant_config is None
+        )
+        if get_moe_a2a_backend().is_moonep():
             if num_fused_shared_experts != 0:
                 raise NotImplementedError(
-                    "MoonEP PoC does not support fused shared experts yet."
+                    "MoonEP does not support fused shared experts yet."
                 )
 
         self.quant_method.create_weights(

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -398,10 +398,6 @@ class FusedMoE(torch.nn.Module):
                 f"quant_method={type(self.quant_method).__name__})."
             )
 
-        # BF16 experts are stored globally -- every rank holds all E rows, so a
-        # peer's rows are simply local. Quantized experts are too many bytes for
-        # that, so they keep the normal EP shard and are relocated into a
-        # symmetric VMM range after loading (see `moonep_weights`).
         moonep_global_weight_storage = (
             get_moe_a2a_backend().is_moonep() and quant_config is None
         )
@@ -413,11 +409,6 @@ class FusedMoE(torch.nn.Module):
             if quant_config is not None and not isinstance(
                 self.quant_method, Mxfp4MoEMethod
             ):
-                # Only Mxfp4MoEMethod.create_weights allocates the symmetric
-                # pool. Any other quant method would load its experts into
-                # private memory and then be routed through the same
-                # pool-reading pre-permute, failing deep inside the runner
-                # instead of here.
                 raise NotImplementedError(
                     "MoonEP supports BF16 or MXFP4 experts, got "
                     f"{type(self.quant_method).__name__}."

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -64,6 +64,7 @@ from sglang.srt.layers.quantization.compressed_tensors.schemes import (
 from sglang.srt.layers.quantization.fp8 import Fp8MoEMethod
 from sglang.srt.layers.quantization.fp8_utils import quantize_block_fp8_weight_to_mxfp4
 from sglang.srt.layers.quantization.modelopt_quant import ModelOptNvFp4FusedMoEMethod
+from sglang.srt.layers.quantization.mxfp4 import Mxfp4MoEMethod
 from sglang.srt.layers.quantization.unquant import UnquantizedFusedMoEMethod
 from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph import (
     get_tc_piecewise_forward_context,
@@ -397,8 +398,10 @@ class FusedMoE(torch.nn.Module):
                 f"quant_method={type(self.quant_method).__name__})."
             )
 
-        # Quantized experts instead keep the normal EP
-        # shard and are relocated into a symmetric VMM range after loading
+        # BF16 experts are stored globally -- every rank holds all E rows, so a
+        # peer's rows are simply local. Quantized experts are too many bytes for
+        # that, so they keep the normal EP shard and are relocated into a
+        # symmetric VMM range after loading (see `moonep_weights`).
         moonep_global_weight_storage = (
             get_moe_a2a_backend().is_moonep() and quant_config is None
         )
@@ -406,6 +409,18 @@ class FusedMoE(torch.nn.Module):
             if num_fused_shared_experts != 0:
                 raise NotImplementedError(
                     "MoonEP does not support fused shared experts yet."
+                )
+            if quant_config is not None and not isinstance(
+                self.quant_method, Mxfp4MoEMethod
+            ):
+                # Only Mxfp4MoEMethod.create_weights allocates the symmetric
+                # pool. Any other quant method would load its experts into
+                # private memory and then be routed through the same
+                # pool-reading pre-permute, failing deep inside the runner
+                # instead of here.
+                raise NotImplementedError(
+                    "MoonEP supports BF16 or MXFP4 experts, got "
+                    f"{type(self.quant_method).__name__}."
                 )
 
         self.quant_method.create_weights(

--- a/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
@@ -50,6 +50,10 @@ if TYPE_CHECKING:
         DeepEPNormalCombineInput,
         DeepEPNormalDispatchOutput,
     )
+    from sglang.srt.layers.moe.token_dispatcher.moonep import (
+        MoonEPCombineInput,
+        MoonEPDispatchOutput,
+    )
     from sglang.srt.layers.moe.token_dispatcher.standard import (
         StandardCombineInput,
         StandardDispatchOutput,
@@ -1237,6 +1241,170 @@ def post_permute_deep_gemm_to_deepep_normal(
         hidden_states=gather_out,
         topk_ids=running_state["topk_ids"],
         topk_weights=running_state["topk_weights"],
+    )
+
+
+def _moonep_m_indices(
+    cu_seqlens: torch.Tensor,
+    expert_ids: torch.Tensor,
+    all_tokens: int,
+) -> torch.Tensor:
+    """Expand MoonEP's per-group segment ends into DeepGEMM's per-row group ids.
+
+    ``cu_seqlens[g]`` is the *end* offset of group ``g`` (no leading zero), so
+    ``searchsorted(..., right=True)`` maps a row to the group that owns it and
+    naturally skips empty groups. Two kinds of rows get ``-1``, which DeepGEMM
+    skips entirely: rows past the last segment (MoonEP pads the receive buffer
+    to a static ``NvS``) and rows whose group is an unfilled prefetch slot
+    (``expert_ids`` already carries ``-1`` there).
+
+    ``expert_ids`` -- not the group index -- is the value DeepGEMM wants: it
+    indexes the leading dimension of the expert weight tensor.
+    """
+    num_groups = expert_ids.numel()
+    rows = torch.arange(all_tokens, device=cu_seqlens.device, dtype=cu_seqlens.dtype)
+    group = torch.searchsorted(cu_seqlens, rows, right=True)
+    m_indices = expert_ids[group.clamp(max=num_groups - 1)].to(torch.int32)
+    return torch.where(group < num_groups, m_indices, torch.full_like(m_indices, -1))
+
+
+@register_pre_permute("moonep", "deep_gemm")
+def pre_permute_moonep_to_deep_gemm(
+    dispatch_output: MoonEPDispatchOutput,
+    quant_info: DeepGemmMoeQuantInfo,
+    runner_config: MoeRunnerConfig,
+    running_state: dict,
+) -> DeepGemmRunnerInput:
+    """MoonEP dispatch output -> DeepGEMM m-grouped contiguous input.
+
+    Unlike the deepep/standard pre-permutes there is no scatter here: MoonEP's
+    ``dispatch`` already returns rows grouped by expert and padded to
+    ``token_padding``, which matches DeepGEMM's
+    ``get_mk_alignment_for_contiguous_layout()``. All that is left is deriving
+    ``m_indices`` and, for quantized experts, quantizing the activations.
+    """
+    hidden_states = dispatch_output.hidden_states
+    if hidden_states.ndim != 2:
+        raise ValueError(
+            f"MoonEP hidden states must be [NvS, H], got {hidden_states.shape}"
+        )
+
+    all_tokens = hidden_states.shape[0]
+    running_state["all_tokens"] = all_tokens
+    running_state["hidden_states_shape"] = hidden_states.shape
+    running_state["hidden_states_dtype"] = hidden_states.dtype
+    running_state["hidden_states_device"] = hidden_states.device
+    # Carried through because MoonEP's combine reconstructs from the plan and
+    # does not apply route weights itself -- the post-permute must.
+    running_state["route_weights_nvs"] = dispatch_output.route_weights_nvs
+    running_state["plan"] = dispatch_output.plan
+    running_state["num_tokens"] = dispatch_output.num_tokens
+
+    expert_ids = dispatch_output.expert_ids
+    if quant_info.w13_weight.dtype != torch.bfloat16:
+        # Quantized experts live in MoonEP's symmetric pool, so the duplicated
+        # ones have to be pulled in before the GEMM reads them, and the plan's
+        # global expert ids have to become pool rows. This runs here rather
+        # than in DeepEPMoE.run_moe_core because MXFP4 on DeepGEMM sets
+        # deprecate_flag, which delegates past that method entirely.
+        from sglang.srt.layers.moe.token_dispatcher import moonep_weights
+        from sglang.srt.layers.moe.token_dispatcher.moonep import MoonEPBuffer
+
+        layer_id = runner_config.layer_id
+        assert layer_id is not None, "MoonEP pre-permute needs runner_config.layer_id"
+        weight_pairs, scale_pairs = moonep_weights.prefetch_pairs(layer_id)
+        MoonEPBuffer.get_existing_buffer().prefetch_weight(
+            plan=dispatch_output.plan,
+            async_finish=False,
+            weight_pairs=weight_pairs,
+            scale_pairs=scale_pairs or None,
+            experts_to_copy=moonep_weights.expert_rows(
+                layer_id,
+                dispatch_output.plan.experts_to_copy[get_tp_group().rank_in_group],
+            ),
+        )
+        # The parameters are this rank's slice of the pool, but m_indices
+        # addresses the whole symmetric range -- a duplicated expert's rows
+        # live in another rank's chunk. Point the GEMM at the full ranges, of
+        # which the parameters are a sub-view.
+        pool = moonep_weights.get_pool()
+        quant_info.w13_weight = pool.ranges[moonep_weights.W13_WEIGHT].view(torch.int8)
+        quant_info.w2_weight = pool.ranges[moonep_weights.W2_WEIGHT].view(torch.int8)
+        quant_info.w13_scale = pool.ranges[moonep_weights.W13_SCALE].permute(0, 2, 1)
+        quant_info.w2_scale = pool.ranges[moonep_weights.W2_SCALE].permute(0, 2, 1)
+
+        expert_ids = moonep_weights.group_rows(
+            layer_id, expert_ids, runner_config.num_experts
+        )
+
+    m_indices = _moonep_m_indices(dispatch_output.cu_seqlens, expert_ids, all_tokens)
+    running_state["m_indices"] = m_indices
+
+    if quant_info.w13_weight.dtype == torch.bfloat16:
+        return DeepGemmRunnerInput(
+            hidden_states=hidden_states,
+            # Unused by the BF16 contiguous GEMM, but the field is non-optional.
+            hidden_states_scale=torch.empty(
+                (all_tokens, 1), device=hidden_states.device, dtype=torch.float32
+            ),
+            use_masked_gemm=False,
+            m_indices=m_indices,
+        )
+
+    from sglang.kernels.ops.quantization.fp8_kernel import (
+        sglang_per_token_group_quant_fp8,
+    )
+
+    block_k = quant_info.block_shape[1] if quant_info.block_shape else 128
+    running_state["mxfp8_act_gran_k"] = block_k
+    hidden_states_fp8, hidden_states_scale = sglang_per_token_group_quant_fp8(
+        hidden_states,
+        block_k,
+        column_major_scales=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
+        scale_tma_aligned=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
+        scale_ue8m0=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
+    )
+    return DeepGemmRunnerInput(
+        hidden_states=hidden_states_fp8,
+        hidden_states_scale=hidden_states_scale,
+        use_masked_gemm=False,
+        m_indices=m_indices,
+    )
+
+
+@register_post_permute("deep_gemm", "moonep")
+def post_permute_deep_gemm_to_moonep(
+    runner_output: DeepGemmRunnerOutput,
+    quant_info: DeepGemmMoeQuantInfo,
+    runner_config: MoeRunnerConfig,
+    running_state: dict,
+) -> MoonEPCombineInput:
+    """DeepGEMM output -> MoonEP combine input, still in dispatched row order.
+
+    No gather: MoonEP's ``combine`` consumes the ``[NvS, H]`` layout directly.
+
+    Rows DeepGEMM skipped (``m_indices == -1``) were never written, so they
+    still hold whatever ``torch.empty`` left behind and must be zeroed before
+    combine reduces them. Zeroing cannot be folded into the route-weight
+    multiply below, because uninitialized memory may decode to NaN and
+    ``0 * NaN`` is NaN.
+    """
+    from sglang.srt.layers.moe.token_dispatcher.moonep import MoonEPCombineInput
+
+    hidden_states = runner_output.hidden_states
+    hidden_states.masked_fill_((running_state["m_indices"] < 0).unsqueeze(-1), 0.0)
+
+    route_weights_nvs = running_state["route_weights_nvs"]
+    if route_weights_nvs is not None:
+        hidden_states.mul_(
+            route_weights_nvs.to(dtype=hidden_states.dtype).unsqueeze(-1)
+        )
+
+    return MoonEPCombineInput(
+        hidden_states=hidden_states,
+        route_weights_nvs=route_weights_nvs,
+        plan=running_state["plan"],
+        num_tokens=running_state["num_tokens"],
     )
 
 

--- a/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
@@ -1250,16 +1250,6 @@ def _moonep_m_indices(
     all_tokens: int,
 ) -> torch.Tensor:
     """Expand MoonEP's per-group segment ends into DeepGEMM's per-row group ids.
-
-    ``cu_seqlens[g]`` is the *end* offset of group ``g`` (no leading zero), so
-    ``searchsorted(..., right=True)`` maps a row to the group that owns it and
-    naturally skips empty groups. Two kinds of rows get ``-1``, which DeepGEMM
-    skips entirely: rows past the last segment (MoonEP pads the receive buffer
-    to a static ``NvS``) and rows whose group is an unfilled prefetch slot
-    (``expert_ids`` already carries ``-1`` there).
-
-    ``expert_ids`` -- not the group index -- is the value DeepGEMM wants: it
-    indexes the leading dimension of the expert weight tensor.
     """
     num_groups = expert_ids.numel()
     rows = torch.arange(all_tokens, device=cu_seqlens.device, dtype=cu_seqlens.dtype)
@@ -1283,10 +1273,6 @@ def _moonep_finalize_rows_kernel(
     offs = h_ptr + row * H + col
 
     if tl.load(m_ptr + row) < 0:
-        # DeepGEMM never wrote this row, so it still holds allocator garbage
-        # that may decode to NaN. It has to be *stored over*, not scaled --
-        # 0 * NaN is NaN. Nothing is read here, which is most of the saving:
-        # at decode these rows are the large majority of the buffer.
         tl.store(offs, tl.zeros([BLOCK], dtype=h_ptr.dtype.element_ty), mask=mask)
     elif HAS_WEIGHTS:
         x = tl.load(offs, mask=mask).to(tl.float32) * tl.load(w_ptr + row)
@@ -1299,11 +1285,6 @@ def _moonep_finalize_rows(
     route_weights_nvs: Optional[torch.Tensor],
 ) -> None:
     """Zero the rows DeepGEMM skipped and scale the rest by their route weight.
-
-    One pass instead of ``masked_fill_`` followed by ``mul_``. Both of those
-    walk the whole ``[NvS, H]`` buffer, and MoonEP's ``NvS`` is a static
-    worst case -- at K3/EP16 decode it is 22416 rows against a couple of
-    hundred live ones, which made this pair 16% of the whole decode step.
     """
     rows, hidden_size = hidden_states.shape
     BLOCK = 1024
@@ -1326,12 +1307,6 @@ def pre_permute_moonep_to_deep_gemm(
     running_state: dict,
 ) -> DeepGemmRunnerInput:
     """MoonEP dispatch output -> DeepGEMM m-grouped contiguous input.
-
-    Unlike the deepep/standard pre-permutes there is no scatter here: MoonEP's
-    ``dispatch`` already returns rows grouped by expert and padded to
-    ``token_padding``, which matches DeepGEMM's
-    ``get_mk_alignment_for_contiguous_layout()``. All that is left is deriving
-    ``m_indices`` and, for quantized experts, quantizing the activations.
     """
     hidden_states = dispatch_output.hidden_states
     if hidden_states.ndim != 2:
@@ -1344,8 +1319,6 @@ def pre_permute_moonep_to_deep_gemm(
     running_state["hidden_states_shape"] = hidden_states.shape
     running_state["hidden_states_dtype"] = hidden_states.dtype
     running_state["hidden_states_device"] = hidden_states.device
-    # Carried through because MoonEP's combine reconstructs from the plan and
-    # does not apply route weights itself -- the post-permute must.
     running_state["route_weights_nvs"] = dispatch_output.route_weights_nvs
     running_state["plan"] = dispatch_output.plan
     running_state["num_tokens"] = dispatch_output.num_tokens
@@ -1353,17 +1326,8 @@ def pre_permute_moonep_to_deep_gemm(
     from sglang.srt.layers.moe.token_dispatcher import moonep_weights
 
     expert_ids = dispatch_output.expert_ids
-    # Keyed on the pool, not on the weight dtype: the pool is what makes a row
-    # id meaningful. BF16 experts are replicated on every rank and need no
-    # remapping, and FusedMoE rejects at init the quant methods that would
-    # arrive here with quantized weights but no pool behind them.
     pool = moonep_weights.get_pool()
     if pool is not None:
-        # Quantized experts live in MoonEP's symmetric pool, so the duplicated
-        # ones have to be pulled in before the GEMM reads them, and the plan's
-        # global expert ids have to become pool rows. This runs here rather
-        # than in DeepEPMoE.run_moe_core because MXFP4 on DeepGEMM sets
-        # deprecate_flag, which delegates past that method entirely.
         from sglang.srt.layers.moe.token_dispatcher.moonep import get_moonep_num_sms
 
         layer_id = runner_config.layer_id
@@ -1376,10 +1340,6 @@ def pre_permute_moonep_to_deep_gemm(
             ),
             num_sms=get_moonep_num_sms(),
         )
-        # The parameters are this rank's slice of the pool, but m_indices
-        # addresses the whole symmetric range -- a duplicated expert's rows
-        # live in another rank's chunk. Point the GEMM at the full ranges, of
-        # which the parameters are a sub-view.
         quant_info.w13_weight = pool.ranges[moonep_weights.W13_WEIGHT].view(torch.int8)
         quant_info.w2_weight = pool.ranges[moonep_weights.W2_WEIGHT].view(torch.int8)
         quant_info.w13_scale = pool.ranges[moonep_weights.W13_SCALE].permute(0, 2, 1)
@@ -1395,7 +1355,6 @@ def pre_permute_moonep_to_deep_gemm(
     if quant_info.w13_weight.dtype == torch.bfloat16:
         return DeepGemmRunnerInput(
             hidden_states=hidden_states,
-            # Unused by the BF16 contiguous GEMM, but the field is non-optional.
             hidden_states_scale=torch.empty(
                 (all_tokens, 1), device=hidden_states.device, dtype=torch.float32
             ),
@@ -1432,14 +1391,6 @@ def post_permute_deep_gemm_to_moonep(
     running_state: dict,
 ) -> MoonEPCombineInput:
     """DeepGEMM output -> MoonEP combine input, still in dispatched row order.
-
-    No gather: MoonEP's ``combine`` consumes the ``[NvS, H]`` layout directly.
-
-    Rows DeepGEMM skipped (``m_indices == -1``) were never written, so they
-    still hold whatever ``torch.empty`` left behind and have to be stored over
-    before combine reduces them. MoonEP's ``combine`` takes
-    ``route_weights_nvs`` but only gathers it back to token-major, so the
-    multiply is ours to do; both happen in one pass over the buffer.
     """
     from sglang.srt.layers.moe.token_dispatcher.moonep import MoonEPCombineInput
 

--- a/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
@@ -1249,8 +1249,6 @@ def _moonep_m_indices(
     expert_ids: torch.Tensor,
     all_tokens: int,
 ) -> torch.Tensor:
-    """Expand MoonEP's per-group segment ends into DeepGEMM's per-row group ids.
-    """
     num_groups = expert_ids.numel()
     rows = torch.arange(all_tokens, device=cu_seqlens.device, dtype=cu_seqlens.dtype)
     group = torch.searchsorted(cu_seqlens, rows, right=True)
@@ -1284,8 +1282,6 @@ def _moonep_finalize_rows(
     m_indices: torch.Tensor,
     route_weights_nvs: Optional[torch.Tensor],
 ) -> None:
-    """Zero the rows DeepGEMM skipped and scale the rest by their route weight.
-    """
     rows, hidden_size = hidden_states.shape
     BLOCK = 1024
     _moonep_finalize_rows_kernel[(rows, triton.cdiv(hidden_size, BLOCK))](
@@ -1306,8 +1302,6 @@ def pre_permute_moonep_to_deep_gemm(
     runner_config: MoeRunnerConfig,
     running_state: dict,
 ) -> DeepGemmRunnerInput:
-    """MoonEP dispatch output -> DeepGEMM m-grouped contiguous input.
-    """
     hidden_states = dispatch_output.hidden_states
     if hidden_states.ndim != 2:
         raise ValueError(
@@ -1390,8 +1384,6 @@ def post_permute_deep_gemm_to_moonep(
     runner_config: MoeRunnerConfig,
     running_state: dict,
 ) -> MoonEPCombineInput:
-    """DeepGEMM output -> MoonEP combine input, still in dispatched row order.
-    """
     from sglang.srt.layers.moe.token_dispatcher.moonep import MoonEPCombineInput
 
     hidden_states = runner_output.hidden_states

--- a/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
@@ -1350,34 +1350,36 @@ def pre_permute_moonep_to_deep_gemm(
     running_state["plan"] = dispatch_output.plan
     running_state["num_tokens"] = dispatch_output.num_tokens
 
+    from sglang.srt.layers.moe.token_dispatcher import moonep_weights
+
     expert_ids = dispatch_output.expert_ids
-    if quant_info.w13_weight.dtype != torch.bfloat16:
+    # Keyed on the pool, not on the weight dtype: the pool is what makes a row
+    # id meaningful. BF16 experts are replicated on every rank and need no
+    # remapping, and FusedMoE rejects at init the quant methods that would
+    # arrive here with quantized weights but no pool behind them.
+    pool = moonep_weights.get_pool()
+    if pool is not None:
         # Quantized experts live in MoonEP's symmetric pool, so the duplicated
         # ones have to be pulled in before the GEMM reads them, and the plan's
         # global expert ids have to become pool rows. This runs here rather
         # than in DeepEPMoE.run_moe_core because MXFP4 on DeepGEMM sets
         # deprecate_flag, which delegates past that method entirely.
-        from sglang.srt.layers.moe.token_dispatcher import moonep_weights
-        from sglang.srt.layers.moe.token_dispatcher.moonep import MoonEPBuffer
+        from sglang.srt.layers.moe.token_dispatcher.moonep import get_moonep_num_sms
 
         layer_id = runner_config.layer_id
         assert layer_id is not None, "MoonEP pre-permute needs runner_config.layer_id"
-        weight_pairs, scale_pairs = moonep_weights.prefetch_pairs(layer_id)
-        MoonEPBuffer.get_existing_buffer().prefetch_weight(
-            plan=dispatch_output.plan,
-            async_finish=False,
-            weight_pairs=weight_pairs,
-            scale_pairs=scale_pairs or None,
-            experts_to_copy=moonep_weights.expert_rows(
+        moonep_weights.prefetch_experts(
+            layer_id,
+            moonep_weights.expert_rows(
                 layer_id,
                 dispatch_output.plan.experts_to_copy[get_tp_group().rank_in_group],
             ),
+            num_sms=get_moonep_num_sms(),
         )
         # The parameters are this rank's slice of the pool, but m_indices
         # addresses the whole symmetric range -- a duplicated expert's rows
         # live in another rank's chunk. Point the GEMM at the full ranges, of
         # which the parameters are a sub-view.
-        pool = moonep_weights.get_pool()
         quant_info.w13_weight = pool.ranges[moonep_weights.W13_WEIGHT].view(torch.int8)
         quant_info.w2_weight = pool.ranges[moonep_weights.W2_WEIGHT].view(torch.int8)
         quant_info.w13_scale = pool.ranges[moonep_weights.W13_SCALE].permute(0, 2, 1)

--- a/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
@@ -1268,6 +1268,56 @@ def _moonep_m_indices(
     return torch.where(group < num_groups, m_indices, torch.full_like(m_indices, -1))
 
 
+@triton.jit
+def _moonep_finalize_rows_kernel(
+    h_ptr,  # [rows, H] bf16, updated in place
+    w_ptr,  # [rows] fp32 route weights
+    m_ptr,  # [rows] int32 m_indices
+    H,
+    HAS_WEIGHTS: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    row = tl.program_id(0).to(tl.int64)
+    col = tl.program_id(1) * BLOCK + tl.arange(0, BLOCK)
+    mask = col < H
+    offs = h_ptr + row * H + col
+
+    if tl.load(m_ptr + row) < 0:
+        # DeepGEMM never wrote this row, so it still holds allocator garbage
+        # that may decode to NaN. It has to be *stored over*, not scaled --
+        # 0 * NaN is NaN. Nothing is read here, which is most of the saving:
+        # at decode these rows are the large majority of the buffer.
+        tl.store(offs, tl.zeros([BLOCK], dtype=h_ptr.dtype.element_ty), mask=mask)
+    elif HAS_WEIGHTS:
+        x = tl.load(offs, mask=mask).to(tl.float32) * tl.load(w_ptr + row)
+        tl.store(offs, x.to(h_ptr.dtype.element_ty), mask=mask)
+
+
+def _moonep_finalize_rows(
+    hidden_states: torch.Tensor,
+    m_indices: torch.Tensor,
+    route_weights_nvs: Optional[torch.Tensor],
+) -> None:
+    """Zero the rows DeepGEMM skipped and scale the rest by their route weight.
+
+    One pass instead of ``masked_fill_`` followed by ``mul_``. Both of those
+    walk the whole ``[NvS, H]`` buffer, and MoonEP's ``NvS`` is a static
+    worst case -- at K3/EP16 decode it is 22416 rows against a couple of
+    hundred live ones, which made this pair 16% of the whole decode step.
+    """
+    rows, hidden_size = hidden_states.shape
+    BLOCK = 1024
+    _moonep_finalize_rows_kernel[(rows, triton.cdiv(hidden_size, BLOCK))](
+        hidden_states,
+        route_weights_nvs,
+        m_indices,
+        hidden_size,
+        HAS_WEIGHTS=route_weights_nvs is not None,
+        BLOCK=BLOCK,
+        num_warps=4,
+    )
+
+
 @register_pre_permute("moonep", "deep_gemm")
 def pre_permute_moonep_to_deep_gemm(
     dispatch_output: MoonEPDispatchOutput,
@@ -1384,21 +1434,16 @@ def post_permute_deep_gemm_to_moonep(
     No gather: MoonEP's ``combine`` consumes the ``[NvS, H]`` layout directly.
 
     Rows DeepGEMM skipped (``m_indices == -1``) were never written, so they
-    still hold whatever ``torch.empty`` left behind and must be zeroed before
-    combine reduces them. Zeroing cannot be folded into the route-weight
-    multiply below, because uninitialized memory may decode to NaN and
-    ``0 * NaN`` is NaN.
+    still hold whatever ``torch.empty`` left behind and have to be stored over
+    before combine reduces them. MoonEP's ``combine`` takes
+    ``route_weights_nvs`` but only gathers it back to token-major, so the
+    multiply is ours to do; both happen in one pass over the buffer.
     """
     from sglang.srt.layers.moe.token_dispatcher.moonep import MoonEPCombineInput
 
     hidden_states = runner_output.hidden_states
-    hidden_states.masked_fill_((running_state["m_indices"] < 0).unsqueeze(-1), 0.0)
-
     route_weights_nvs = running_state["route_weights_nvs"]
-    if route_weights_nvs is not None:
-        hidden_states.mul_(
-            route_weights_nvs.to(dtype=hidden_states.dtype).unsqueeze(-1)
-        )
+    _moonep_finalize_rows(hidden_states, running_state["m_indices"], route_weights_nvs)
 
     return MoonEPCombineInput(
         hidden_states=hidden_states,

--- a/python/sglang/srt/layers/moe/token_dispatcher/moonep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/moonep.py
@@ -15,10 +15,11 @@ from sglang.srt.layers.moe.token_dispatcher.base import (
     DispatchOutput,
     DispatchOutputFormat,
 )
-from sglang.srt.layers.moe.topk import TopKOutput
-from sglang.srt.layers.moe.topk import TopKOutputChecker
+from sglang.srt.layers.moe.topk import TopKOutput, TopKOutputChecker
 from sglang.srt.layers.moe.utils import DeepEPMode
 
+
+_DECODE_TOKENS_PER_REQUEST_HEADROOM = 8
 
 _MOONEP_UNSUPPORTED_MESSAGE = (
     "MoonEP MoE A2A is recognized by SGLang, but the runtime dispatcher is not "
@@ -451,9 +452,7 @@ def run_moonep_bf16_expert(
             f"shape {cu_seqlens.shape}"
         )
     if route_weights_nvs is not None and route_weights_nvs.ndim != 1:
-        raise ValueError(
-            f"route_weights_nvs must be 1D, got {route_weights_nvs.shape}"
-        )
+        raise ValueError(f"route_weights_nvs must be 1D, got {route_weights_nvs.shape}")
 
     output = torch.empty_like(hidden_states)
     prev = 0
@@ -496,6 +495,33 @@ def run_moonep_bf16_expert(
     )
 
 
+def _resolve_decode_capacity(prefill_capacity: int) -> int | None:
+    """Token capacity for decode batches, or None to reuse the prefill one.
+
+    Decode is bounded by the number of running requests, which is orders of
+    magnitude below a prefill chunk, so giving it its own smaller buffer is
+    what keeps a decode step from running the MoE over a full chunk's worth of
+    padding. Both capacities are config-derived, so every rank picks the same
+    one without communicating.
+    """
+    override = envs.SGLANG_MOONEP_DECODE_MAX_DISPATCH_TOKENS_PER_RANK.get()
+    if override > 0:
+        capacity = override
+    else:
+        from sglang.srt.server_args import get_global_server_args
+
+        # None until the scheduler resolves it; fall back to one capacity then.
+        max_running = get_global_server_args().max_running_requests
+        if max_running is None:
+            return None
+        # Speculative decoding submits several tokens per request per step.
+        capacity = int(max_running) * _DECODE_TOKENS_PER_REQUEST_HEADROOM
+
+    token_padding = envs.SGLANG_MOONEP_TOKEN_PADDING.get()
+    capacity = -(-capacity // token_padding) * token_padding
+    return None if capacity >= prefill_capacity else capacity
+
+
 class MoonEPDispatcher(BaseDispatcher):
     """MoonEP dispatcher for the initial BF16 inference PoC."""
 
@@ -527,13 +553,38 @@ class MoonEPDispatcher(BaseDispatcher):
         self.num_max_dispatch_tokens_per_rank = (
             envs.SGLANG_MOONEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK.get()
         )
+        self.decode_max_dispatch_tokens_per_rank = _resolve_decode_capacity(
+            self.num_max_dispatch_tokens_per_rank
+        )
         self.num_prefetch_slots = None
 
     @staticmethod
     def _raise_unimplemented() -> NoReturn:
         raise NotImplementedError(_MOONEP_UNSUPPORTED_MESSAGE)
 
-    def _get_buffer(self):
+    def _phase_capacity(self) -> int:
+        """Static token capacity for the current phase.
+
+        MoonEP's buffers are statically shaped and ``dispatch`` asserts an
+        exact ``S x K`` input, so every batch is padded up to the capacity. One
+        capacity sized for prefill makes decode pay for it: at K3 a batch of 8
+        tokens would run the MoE over 16384, a ~2000x inflation.
+
+        The two capacities come from server args rather than the batch, because
+        the buffer is created collectively -- picking from a runtime token
+        count would let ranks disagree and deadlock. The phase flag is uniform
+        across the group for the same reason.
+        """
+        if self.decode_max_dispatch_tokens_per_rank is None:
+            return self.num_max_dispatch_tokens_per_rank
+
+        from sglang.srt.layers.dp_attention import get_is_extend_in_batch
+
+        if get_is_extend_in_batch():
+            return self.num_max_dispatch_tokens_per_rank
+        return self.decode_max_dispatch_tokens_per_rank
+
+    def _get_buffer(self, capacity: int | None = None):
         if self.hidden_size is None or self.num_experts is None:
             raise ValueError(
                 "MoonEPDispatcher requires hidden_size and num_experts to "
@@ -544,7 +595,9 @@ class MoonEPDispatcher(BaseDispatcher):
             hidden_size=self.hidden_size,
             router_topk=self.router_topk,
             num_experts=self.num_experts,
-            num_max_dispatch_tokens_per_rank=self.num_max_dispatch_tokens_per_rank,
+            num_max_dispatch_tokens_per_rank=(
+                self._phase_capacity() if capacity is None else capacity
+            ),
             num_prefetch_slots=self.num_prefetch_slots,
         )
 
@@ -559,9 +612,9 @@ class MoonEPDispatcher(BaseDispatcher):
         hidden_states: torch.Tensor,
         topk_ids: torch.Tensor,
         topk_weights: torch.Tensor,
+        capacity: int,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, int]:
         num_tokens = int(hidden_states.shape[0])
-        capacity = int(self.num_max_dispatch_tokens_per_rank)
         if num_tokens > capacity:
             raise ValueError(
                 "MoonEP runtime batch has more tokens than its static buffer "
@@ -587,34 +640,58 @@ class MoonEPDispatcher(BaseDispatcher):
         )
 
     def _tokens_per_expert(self, topk_ids: torch.Tensor) -> torch.Tensor:
+        """Local token count per expert.
+
+        ``torch.bincount`` would be the obvious call, but on CUDA it reads the
+        input's max back to the host to size its output, and a device-to-host
+        copy is illegal under CUDA graph capture. Scattering into a
+        fixed-length buffer keeps the whole thing on device.
+        """
         assert self.num_experts is not None
-        return torch.bincount(
-            topk_ids.reshape(-1).to(dtype=torch.int64),
-            minlength=self.num_experts,
-        ).to(dtype=torch.int32)
+        flat = topk_ids.reshape(-1).to(dtype=torch.int64)
+        counts = torch.zeros(
+            self.num_experts, dtype=torch.int32, device=topk_ids.device
+        )
+        counts.scatter_add_(0, flat, torch.ones_like(flat, dtype=torch.int32))
+        return counts
 
     def _expert_ids_from_plan(
         self,
         cu_seqlens: torch.Tensor,
         plan: Any,
     ) -> torch.Tensor:
+        """Which expert each VM group carries: its own id for the first
+        ``num_experts`` groups, the duplicated expert's id for the prefetch
+        slots after them, and -1 for groups that received no tokens.
+
+        Stays on device. The obvious loop costs one ``.item()`` per group --
+        896 host syncs per layer, ~82k per forward at K3's depth, which
+        dominates decode.
+        """
         assert self.num_experts is not None
+        num_experts = int(self.num_experts)
         num_groups = int(cu_seqlens.numel())
-        expert_ids = torch.full_like(cu_seqlens, -1)
         experts_to_copy = plan.experts_to_copy
         if experts_to_copy.ndim == 2:
             experts_to_copy = experts_to_copy[self._get_rank()]
 
-        prev = 0
-        for group_id in range(num_groups):
-            cur = int(cu_seqlens[group_id].item())
-            if cur > prev:
-                if group_id < self.num_experts:
-                    expert_ids[group_id] = group_id
-                else:
-                    expert_ids[group_id] = experts_to_copy[group_id - self.num_experts]
-            prev = cur
-        return expert_ids
+        num_slots = num_groups - num_experts
+        assert 0 <= num_slots <= int(experts_to_copy.numel()), (
+            f"MoonEP plan has {experts_to_copy.numel()} prefetch slots but "
+            f"cu_seqlens describes {num_slots}"
+        )
+        ids = torch.cat(
+            [
+                torch.arange(
+                    num_experts, device=cu_seqlens.device, dtype=cu_seqlens.dtype
+                ),
+                experts_to_copy[:num_slots].to(dtype=cu_seqlens.dtype),
+            ]
+        )
+        # cu_seqlens holds segment *ends*, so a group is live when its end
+        # moved past the previous one's.
+        starts = torch.cat([cu_seqlens.new_zeros(1), cu_seqlens[:-1]])
+        return torch.where(cu_seqlens > starts, ids, torch.full_like(ids, -1))
 
     def dispatch(
         self,
@@ -632,13 +709,17 @@ class MoonEPDispatcher(BaseDispatcher):
         if self.num_experts is None:
             raise ValueError("MoonEPDispatcher requires num_experts.")
 
+        # One capacity for both the padding and the buffer: MoonEP asserts the
+        # dispatch input matches the buffer's static S exactly.
+        capacity = self._phase_capacity()
         hidden_states, topk_ids, topk_weights, num_tokens = self._pad_to_capacity(
             hidden_states,
             topk_output.topk_ids,
             topk_output.topk_weights,
+            capacity,
         )
         tokens_per_expert = self._tokens_per_expert(topk_ids)
-        buffer = self._get_buffer()
+        buffer = self._get_buffer(capacity)
         hidden_nvsh, route_weights_nvs, cu_seqlens, plan = buffer.dispatch(
             hidden_states,
             topk_weights,
@@ -694,14 +775,42 @@ class MoonEPDispatcher(BaseDispatcher):
     def prefetch_weight(
         self,
         plan: Any,
-        weight_layout: MoonEPExpertWeightLayout,
+        weight_layout: MoonEPExpertWeightLayout | None = None,
+        layer_id: int | None = None,
     ) -> None:
+        """Fill this rank's prefetch slots with the duplicated experts.
+
+        ``weight_layout`` is the BF16 PoC form: one contiguous ``[E+B]`` block
+        per projection, indexed by global expert id. ``layer_id`` selects the
+        symmetric-memory form, where the sources are VMM ranges shared by every
+        layer and the plan's expert ids have to be remapped to rows before the
+        copy can find them.
+        """
+        assert (weight_layout is None) != (layer_id is None), (
+            "MoonEPDispatcher.prefetch_weight takes exactly one of "
+            "weight_layout or layer_id"
+        )
+        if weight_layout is not None:
+            self._get_buffer().prefetch_weight(
+                plan=plan,
+                async_finish=False,
+                full_gate_weight=weight_layout.full_gate_weight,
+                full_up_weight=weight_layout.full_up_weight,
+                full_down_weight=weight_layout.full_down_weight,
+            )
+            return
+
+        from sglang.srt.layers.moe.token_dispatcher import moonep_weights
+
+        weight_pairs, scale_pairs = moonep_weights.prefetch_pairs(layer_id)
         self._get_buffer().prefetch_weight(
             plan=plan,
             async_finish=False,
-            full_gate_weight=weight_layout.full_gate_weight,
-            full_up_weight=weight_layout.full_up_weight,
-            full_down_weight=weight_layout.full_down_weight,
+            weight_pairs=weight_pairs,
+            scale_pairs=scale_pairs or None,
+            experts_to_copy=moonep_weights.expert_rows(
+                layer_id, plan.experts_to_copy[self._get_rank()]
+            ),
         )
 
     def register_deepep_dispatch_hook(self, hook):

--- a/python/sglang/srt/layers/moe/token_dispatcher/moonep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/moonep.py
@@ -20,12 +20,6 @@ from sglang.srt.layers.moe.utils import DeepEPMode
 
 _DECODE_TOKENS_PER_REQUEST_HEADROOM = 8
 
-# MoonEP's own default is B = E / EP, which makes every expert a group GEMM
-# touches local. That is a training rule: at K3/EP16 it is 56 slots and a
-# 182 GB expert pool per rank, which does not fit. Inference only needs enough
-# slots to cover the hot experts, and overflowing B stays *correct* -- the GEMM
-# reads the owner's rows through the symmetric mapping, just slower -- so a
-# small number is safe. MoonEP's README recommends 3-4.
 _DEFAULT_PREFETCH_SLOTS = 4
 
 _MOONEP_UNSUPPORTED_MESSAGE = (
@@ -163,8 +157,6 @@ class MoonEPBuffer:
             num_prefetch_slots = envs.SGLANG_MOONEP_NUM_PREFETCH_SLOTS.get()
         num_prefetch_slots = int(num_prefetch_slots)
         if num_prefetch_slots <= 0:
-            # Never more than MoonEP's own rule -- a model with fewer local
-            # experts than the default would otherwise get useless slots.
             return min(_DEFAULT_PREFETCH_SLOTS, num_experts // num_ep_ranks)
         return MoonEPBuffer._require_positive_int(
             "num_prefetch_slots", num_prefetch_slots
@@ -510,12 +502,6 @@ def run_moonep_bf16_expert(
 
 def _resolve_decode_capacity(prefill_capacity: int) -> int | None:
     """Token capacity for decode batches, or None to reuse the prefill one.
-
-    Decode is bounded by the number of running requests, which is orders of
-    magnitude below a prefill chunk, so giving it its own smaller buffer is
-    what keeps a decode step from running the MoE over a full chunk's worth of
-    padding. Both capacities are config-derived, so every rank picks the same
-    one without communicating.
     """
     override = envs.SGLANG_MOONEP_DECODE_MAX_DISPATCH_TOKENS_PER_RANK.get()
     if override > 0:
@@ -523,11 +509,9 @@ def _resolve_decode_capacity(prefill_capacity: int) -> int | None:
     else:
         from sglang.srt.server_args import get_global_server_args
 
-        # None until the scheduler resolves it; fall back to one capacity then.
         max_running = get_global_server_args().max_running_requests
         if max_running is None:
             return None
-        # Speculative decoding submits several tokens per request per step.
         capacity = int(max_running) * _DECODE_TOKENS_PER_REQUEST_HEADROOM
 
     token_padding = envs.SGLANG_MOONEP_TOKEN_PADDING.get()
@@ -576,18 +560,6 @@ class MoonEPDispatcher(BaseDispatcher):
         raise NotImplementedError(_MOONEP_UNSUPPORTED_MESSAGE)
 
     def _phase_capacity(self) -> int:
-        """Static token capacity for the current phase.
-
-        MoonEP's buffers are statically shaped and ``dispatch`` asserts an
-        exact ``S x K`` input, so every batch is padded up to the capacity. One
-        capacity sized for prefill makes decode pay for it: at K3 a batch of 8
-        tokens would run the MoE over 16384, a ~2000x inflation.
-
-        The two capacities come from server args rather than the batch, because
-        the buffer is created collectively -- picking from a runtime token
-        count would let ranks disagree and deadlock. The phase flag is uniform
-        across the group for the same reason.
-        """
         if self.decode_max_dispatch_tokens_per_rank is None:
             return self.num_max_dispatch_tokens_per_rank
 
@@ -653,13 +625,6 @@ class MoonEPDispatcher(BaseDispatcher):
         )
 
     def _tokens_per_expert(self, topk_ids: torch.Tensor) -> torch.Tensor:
-        """Local token count per expert.
-
-        ``torch.bincount`` would be the obvious call, but on CUDA it reads the
-        input's max back to the host to size its output, and a device-to-host
-        copy is illegal under CUDA graph capture. Scattering into a
-        fixed-length buffer keeps the whole thing on device.
-        """
         assert self.num_experts is not None
         flat = topk_ids.reshape(-1).to(dtype=torch.int64)
         counts = torch.zeros(
@@ -673,14 +638,6 @@ class MoonEPDispatcher(BaseDispatcher):
         cu_seqlens: torch.Tensor,
         plan: Any,
     ) -> torch.Tensor:
-        """Which expert each VM group carries: its own id for the first
-        ``num_experts`` groups, the duplicated expert's id for the prefetch
-        slots after them, and -1 for groups that received no tokens.
-
-        Stays on device. The obvious loop costs one ``.item()`` per group --
-        896 host syncs per layer, ~82k per forward at K3's depth, which
-        dominates decode.
-        """
         assert self.num_experts is not None
         num_experts = int(self.num_experts)
         num_groups = int(cu_seqlens.numel())
@@ -701,8 +658,6 @@ class MoonEPDispatcher(BaseDispatcher):
                 experts_to_copy[:num_slots].to(dtype=cu_seqlens.dtype),
             ]
         )
-        # cu_seqlens holds segment *ends*, so a group is live when its end
-        # moved past the previous one's.
         starts = torch.cat([cu_seqlens.new_zeros(1), cu_seqlens[:-1]])
         return torch.where(cu_seqlens > starts, ids, torch.full_like(ids, -1))
 
@@ -722,8 +677,6 @@ class MoonEPDispatcher(BaseDispatcher):
         if self.num_experts is None:
             raise ValueError("MoonEPDispatcher requires num_experts.")
 
-        # One capacity for both the padding and the buffer: MoonEP asserts the
-        # dispatch input matches the buffer's static S exactly.
         capacity = self._phase_capacity()
         hidden_states, topk_ids, topk_weights, num_tokens = self._pad_to_capacity(
             hidden_states,
@@ -790,13 +743,6 @@ class MoonEPDispatcher(BaseDispatcher):
         plan: Any,
         weight_layout: MoonEPExpertWeightLayout,
     ) -> None:
-        """Fill this rank's prefetch slots with the duplicated experts.
-
-        BF16 only: ``weight_layout`` is one contiguous ``[E+B]`` block per
-        projection, indexed by global expert id. Quantized experts live in the
-        symmetric pool and are prefetched from ``pre_permute`` instead, which
-        is where the plan's expert ids get remapped to pool rows.
-        """
         self._get_buffer().prefetch_weight(
             plan=plan,
             async_finish=False,

--- a/python/sglang/srt/layers/moe/token_dispatcher/moonep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/moonep.py
@@ -501,8 +501,6 @@ def run_moonep_bf16_expert(
 
 
 def _resolve_decode_capacity(prefill_capacity: int) -> int | None:
-    """Token capacity for decode batches, or None to reuse the prefill one.
-    """
     override = envs.SGLANG_MOONEP_DECODE_MAX_DISPATCH_TOKENS_PER_RANK.get()
     if override > 0:
         capacity = override

--- a/python/sglang/srt/layers/moe/token_dispatcher/moonep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/moonep.py
@@ -189,7 +189,7 @@ class MoonEPBuffer:
         if token_padding is None:
             token_padding = envs.SGLANG_MOONEP_TOKEN_PADDING.get()
         if num_sms is None:
-            num_sms = envs.SGLANG_MOONEP_NUM_SMS.get()
+            num_sms = get_moonep_num_sms()
 
         num_ep_ranks = cls._resolve_num_ep_ranks(group)
         num_experts = cls._require_positive_int("num_experts", int(num_experts))
@@ -308,6 +308,10 @@ class MoonEPBuffer:
         for key in list(state.buffers):
             cls.destroy_buffer(key)
         state.active_key = None
+
+
+def get_moonep_num_sms() -> int:
+    return envs.SGLANG_MOONEP_NUM_SMS.get()
 
 
 def get_moonep_num_prefetch_slots(num_experts: int, num_ep_ranks: int) -> int:

--- a/python/sglang/srt/layers/moe/token_dispatcher/moonep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/moonep.py
@@ -18,8 +18,15 @@ from sglang.srt.layers.moe.token_dispatcher.base import (
 from sglang.srt.layers.moe.topk import TopKOutput, TopKOutputChecker
 from sglang.srt.layers.moe.utils import DeepEPMode
 
-
 _DECODE_TOKENS_PER_REQUEST_HEADROOM = 8
+
+# MoonEP's own default is B = E / EP, which makes every expert a group GEMM
+# touches local. That is a training rule: at K3/EP16 it is 56 slots and a
+# 182 GB expert pool per rank, which does not fit. Inference only needs enough
+# slots to cover the hot experts, and overflowing B stays *correct* -- the GEMM
+# reads the owner's rows through the symmetric mapping, just slower -- so a
+# small number is safe. MoonEP's README recommends 3-4.
+_DEFAULT_PREFETCH_SLOTS = 4
 
 _MOONEP_UNSUPPORTED_MESSAGE = (
     "MoonEP MoE A2A is recognized by SGLang, but the runtime dispatcher is not "
@@ -156,7 +163,9 @@ class MoonEPBuffer:
             num_prefetch_slots = envs.SGLANG_MOONEP_NUM_PREFETCH_SLOTS.get()
         num_prefetch_slots = int(num_prefetch_slots)
         if num_prefetch_slots <= 0:
-            return num_experts // num_ep_ranks
+            # Never more than MoonEP's own rule -- a model with fewer local
+            # experts than the default would otherwise get useless slots.
+            return min(_DEFAULT_PREFETCH_SLOTS, num_experts // num_ep_ranks)
         return MoonEPBuffer._require_positive_int(
             "num_prefetch_slots", num_prefetch_slots
         )
@@ -775,42 +784,21 @@ class MoonEPDispatcher(BaseDispatcher):
     def prefetch_weight(
         self,
         plan: Any,
-        weight_layout: MoonEPExpertWeightLayout | None = None,
-        layer_id: int | None = None,
+        weight_layout: MoonEPExpertWeightLayout,
     ) -> None:
         """Fill this rank's prefetch slots with the duplicated experts.
 
-        ``weight_layout`` is the BF16 PoC form: one contiguous ``[E+B]`` block
-        per projection, indexed by global expert id. ``layer_id`` selects the
-        symmetric-memory form, where the sources are VMM ranges shared by every
-        layer and the plan's expert ids have to be remapped to rows before the
-        copy can find them.
+        BF16 only: ``weight_layout`` is one contiguous ``[E+B]`` block per
+        projection, indexed by global expert id. Quantized experts live in the
+        symmetric pool and are prefetched from ``pre_permute`` instead, which
+        is where the plan's expert ids get remapped to pool rows.
         """
-        assert (weight_layout is None) != (layer_id is None), (
-            "MoonEPDispatcher.prefetch_weight takes exactly one of "
-            "weight_layout or layer_id"
-        )
-        if weight_layout is not None:
-            self._get_buffer().prefetch_weight(
-                plan=plan,
-                async_finish=False,
-                full_gate_weight=weight_layout.full_gate_weight,
-                full_up_weight=weight_layout.full_up_weight,
-                full_down_weight=weight_layout.full_down_weight,
-            )
-            return
-
-        from sglang.srt.layers.moe.token_dispatcher import moonep_weights
-
-        weight_pairs, scale_pairs = moonep_weights.prefetch_pairs(layer_id)
         self._get_buffer().prefetch_weight(
             plan=plan,
             async_finish=False,
-            weight_pairs=weight_pairs,
-            scale_pairs=scale_pairs or None,
-            experts_to_copy=moonep_weights.expert_rows(
-                layer_id, plan.experts_to_copy[self._get_rank()]
-            ),
+            full_gate_weight=weight_layout.full_gate_weight,
+            full_up_weight=weight_layout.full_up_weight,
+            full_down_weight=weight_layout.full_down_weight,
         )
 
     def register_deepep_dispatch_hook(self, hook):

--- a/python/sglang/srt/layers/moe/token_dispatcher/moonep_weights.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/moonep_weights.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+import logging
+import math
+from typing import Optional
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+# Sub-ranges of the pool, keyed by the attribute they end up backing. The
+# scales are named apart from the parameters because what lives here is the
+# post-transform runtime layout, not the checkpoint layout the loader fills.
+W13_WEIGHT = "w13_weight"
+W2_WEIGHT = "w2_weight"
+W13_SCALE = "w13_weight_scale_runtime"
+W2_SCALE = "w2_weight_scale_runtime"
+
+_pool: Optional[MoonEPWeightPool] = None
+
+
+class MoonEPWeightPool:
+    """Process-global symmetric ranges, sliced one block per MoE layer."""
+
+    def __init__(
+        self,
+        num_layers: int,
+        num_local_experts: int,
+        num_prefetch_slots: int,
+        ep_rank: int,
+        ep_size: int,
+        group,
+        specs: dict[str, tuple[tuple[int, ...], torch.dtype]],
+    ):
+        from moonep.buffer import create_nvl_dist_tensor
+
+        self.num_layers = num_layers
+        self.num_local_experts = num_local_experts
+        self.num_prefetch_slots = num_prefetch_slots
+        self.ep_rank = ep_rank
+        self.ep_size = ep_size
+        self.block_rows = num_local_experts + num_prefetch_slots
+        self.chunk_rows = _resolve_chunk_rows(specs, num_layers * self.block_rows)
+        self._layers: dict[int, int] = {}
+
+        self.ranges = {
+            kind: create_nvl_dist_tensor(
+                [self.chunk_rows, *trailing],
+                dtype,
+                ep_rank,
+                ep_size,
+                group=group,
+                # Rotated so this rank's chunk is at the base of the mapping.
+                # DeepGEMM's tvm_ffi bindings resolve a tensor's device from
+                # its base pointer, and the unrotated base is always rank 0's
+                # memory -- every other rank then fails the device check.
+                local_first=True,
+            )
+            for kind, (trailing, dtype) in specs.items()
+        }
+        resident = sum(t.numel() * t.element_size() for t in self.ranges.values())
+        logger.info(
+            "MoonEP: symmetric expert pool for %d layers, %d local experts + %d "
+            "prefetch slots each, chunk_rows=%d (%.1f GB resident per rank)",
+            num_layers,
+            num_local_experts,
+            num_prefetch_slots,
+            self.chunk_rows,
+            resident / ep_size / 1e9,
+        )
+
+    def layer_offset(self, layer_id: int) -> int:
+        """Rows before this layer's block. Layers are numbered by the order
+        they ask for storage, not by ``layer_id``: with pipeline parallelism a
+        rank holds an arbitrary slice of the model's layer ids, and the pool is
+        sized for what this rank actually builds."""
+        index = self._layers.get(layer_id)
+        if index is None:
+            index = len(self._layers)
+            if index >= self.num_layers:
+                raise RuntimeError(
+                    f"MoonEP expert pool was sized for {self.num_layers} layers "
+                    f"but layer {layer_id} is the {index + 1}th to ask for "
+                    "storage; the layer count derived from the model config is "
+                    "wrong for this model"
+                )
+            self._layers[layer_id] = index
+        return index * self.block_rows
+
+    def chunk_start(self, owner_rank: int) -> int:
+        """First row of ``owner_rank``'s chunk in this rank's mapping."""
+        from moonep.buffer import local_first_chunk_index
+
+        index = local_first_chunk_index(owner_rank, self.ep_rank, self.ep_size)
+        return index * self.chunk_rows
+
+    def local_view(self, kind: str, layer_id: int) -> torch.Tensor:
+        """This rank's ``[num_local_experts, ...]`` slice: what the loader
+        writes and what the parameter is bound to."""
+        start = self.chunk_start(self.ep_rank) + self.layer_offset(layer_id)
+        return self.ranges[kind][start : start + self.num_local_experts]
+
+    def slot_view(self, kind: str, layer_id: int) -> torch.Tensor:
+        """This layer's ``[num_prefetch_slots, ...]`` copy destinations."""
+        start = (
+            self.chunk_start(self.ep_rank)
+            + self.layer_offset(layer_id)
+            + self.num_local_experts
+        )
+        return self.ranges[kind][start : start + self.num_prefetch_slots]
+
+
+def _minimum_aligned_rows(trailing_shape, dtype: torch.dtype) -> int:
+    """Smallest row count whose bytes land on a VMM granularity boundary."""
+    from moonep.buffer import pad_dim0_for_alignment
+
+    return pad_dim0_for_alignment([1, *trailing_shape], dtype)
+
+
+def _resolve_chunk_rows(
+    specs: dict[str, tuple[tuple[int, ...], torch.dtype]], rows_in_use: int
+) -> int:
+    """One row count that is granularity-aligned for every range at once.
+
+    A weight and its scale must share a row indexing, so they cannot each pick
+    their own padding. A row count works for a tensor when
+    ``rows * bytes_per_row`` is a multiple of the VMM granularity, so the
+    common answer is the least common multiple of each one's minimum, rounded
+    up past the rows actually in use.
+    """
+    step = 1
+    for trailing, dtype in specs.values():
+        step = math.lcm(step, _minimum_aligned_rows(trailing, dtype))
+    return math.ceil(rows_in_use / step) * step
+
+
+def _num_moe_layers() -> int:
+    """How many layers will ask the pool for storage.
+
+    Counted from the config rather than tracked dynamically because the ranges
+    are fixed-size VMM mappings that cannot grow; ``layer_offset`` raises if
+    the count turns out to be too small.
+    """
+    from sglang.srt.runtime_context import process_model_config
+
+    config = process_model_config()
+    num_layers = int(config.num_hidden_layers)
+    first_dense = config.first_k_dense_replace or 0
+    freq = getattr(config.hf_text_config, "moe_layer_freq", 1) or 1
+    return sum(1 for i in range(num_layers) if i >= first_dense and i % freq == 0)
+
+
+def get_pool() -> Optional[MoonEPWeightPool]:
+    return _pool
+
+
+def alloc_expert_tensors(
+    layer: torch.nn.Module,
+    specs: dict[str, tuple[tuple[int, ...], torch.dtype]],
+) -> dict[str, torch.Tensor]:
+    """Per-layer views of the symmetric pool, creating it on the first call.
+
+    ``specs`` maps a sub-range name to ``(trailing_shape, dtype)`` for a single
+    expert row. Every layer must pass the same specs -- they share one
+    allocation. Collective over the EP group, so all ranks have to build their
+    layers in the same order.
+    """
+    global _pool
+
+    from sglang.srt.distributed import get_tp_group
+    from sglang.srt.layers.moe.token_dispatcher.moonep import (
+        get_moonep_num_prefetch_slots,
+    )
+
+    if _pool is None:
+        group = get_tp_group().device_group
+        ep_size = torch.distributed.get_world_size(group)
+        _pool = MoonEPWeightPool(
+            num_layers=_num_moe_layers(),
+            num_local_experts=int(layer.num_local_experts),
+            num_prefetch_slots=get_moonep_num_prefetch_slots(
+                int(layer.num_experts), ep_size
+            ),
+            ep_rank=torch.distributed.get_rank(group),
+            ep_size=ep_size,
+            group=group,
+            specs=specs,
+        )
+    elif set(specs) != set(_pool.ranges):
+        raise NotImplementedError(
+            "MoonEP places every layer's experts in one pool, so all layers "
+            f"must request the same tensors; got {sorted(specs)} after "
+            f"{sorted(_pool.ranges)}"
+        )
+
+    return {kind: _pool.local_view(kind, layer.layer_id) for kind in specs}
+
+
+def expert_rows(layer_id: int, expert_ids: torch.Tensor) -> torch.Tensor:
+    """Global expert ids -> rows of the symmetric range. Negative ids (unused
+    prefetch slots) pass through so DeepGEMM still skips them."""
+    assert _pool is not None, "MoonEP expert pool was never created"
+    epn = _pool.num_local_experts
+    # The mapping is local-first, so an owner's chunk index is relative to this
+    # rank -- row numbers differ per rank, which is fine because every consumer
+    # of them (m_indices, experts_to_copy) is computed locally.
+    owner = expert_ids // epn
+    chunk = (owner - _pool.ep_rank) % _pool.ep_size
+    rows = chunk * _pool.chunk_rows + _pool.layer_offset(layer_id) + expert_ids % epn
+    return torch.where(expert_ids < 0, expert_ids, rows).to(torch.int32)
+
+
+def group_rows(
+    layer_id: int, expert_ids: torch.Tensor, num_global_experts: int
+) -> torch.Tensor:
+    """MoonEP's per-VM-group expert ids -> rows of the symmetric range.
+
+    The first ``num_global_experts`` groups are experts addressed by global id;
+    the groups after them are this rank's prefetch slots, whose ids name the
+    *source* expert but whose tokens must read the slot the copy landed in.
+    Empty and unfilled groups keep their -1 and stay skipped.
+    """
+    assert _pool is not None, "MoonEP expert pool was never created"
+    rows = expert_rows(layer_id, expert_ids)
+    tail = expert_ids[num_global_experts:]
+    slot_base = (
+        _pool.chunk_start(_pool.ep_rank)
+        + _pool.layer_offset(layer_id)
+        + _pool.num_local_experts
+    )
+    slots = torch.arange(
+        slot_base,
+        slot_base + tail.numel(),
+        device=expert_ids.device,
+        dtype=torch.int32,
+    )
+    rows[num_global_experts:] = torch.where(tail < 0, tail.to(torch.int32), slots)
+    return rows
+
+
+def prefetch_pairs(
+    layer_id: int,
+) -> tuple[
+    list[tuple[torch.Tensor, torch.Tensor]], list[tuple[torch.Tensor, torch.Tensor]]
+]:
+    """``(weight_pairs, scale_pairs)`` for ``Buffer.prefetch_weight``.
+
+    Scales are re-tiled by the copy and so are kept apart from the weights.
+    The scale views are the *storage* orientation, which is what a byte copy
+    has to move -- see the MN-major note in the module docstring.
+    """
+    assert _pool is not None, "MoonEP expert pool was never created"
+    weights = [
+        (_pool.ranges[k], _pool.slot_view(k, layer_id)) for k in (W13_WEIGHT, W2_WEIGHT)
+    ]
+    scales = [
+        (_pool.ranges[k], _pool.slot_view(k, layer_id))
+        for k in (W13_SCALE, W2_SCALE)
+        if k in _pool.ranges
+    ]
+    return weights, scales
+
+
+def assert_resident(layer: torch.nn.Module, kind: str, tensor: torch.Tensor) -> None:
+    """Fail loudly if a post-load step swapped a pooled tensor for a private one.
+
+    SGLang's quant methods routinely rebind weights after loading, and a
+    rebind that lands outside the pool silently costs MoonEP its remote
+    readability -- prefetch would then copy from memory no peer can see.
+    """
+    assert _pool is not None, "MoonEP expert pool was never created"
+    full = _pool.ranges[kind]
+    start = full.data_ptr()
+    end = start + full.numel() * full.element_size()
+    if not (start <= tensor.data_ptr() < end):
+        raise RuntimeError(
+            f"MoonEP: layer {layer.layer_id} {kind} left the symmetric pool "
+            "after loading. Some post-load step replaced the tensor instead of "
+            "writing into it, which would make remote prefetch read private "
+            "memory."
+        )

--- a/python/sglang/srt/layers/moe/token_dispatcher/moonep_weights.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/moonep_weights.py
@@ -10,9 +10,6 @@ from sglang.srt.environ import envs
 
 logger = logging.getLogger(__name__)
 
-# Sub-ranges of the pool, keyed by the attribute they end up backing. The
-# scales are named apart from the parameters because what lives here is the
-# post-transform runtime layout, not the checkpoint layout the loader fills.
 W13_WEIGHT = "w13_weight"
 W2_WEIGHT = "w2_weight"
 W13_SCALE = "w13_weight_scale_runtime"
@@ -34,9 +31,6 @@ class MoonEPWeightPool:
         group,
         specs: dict[str, tuple[tuple[int, ...], torch.dtype]],
     ):
-        # Checked before the import, because on upstream MoonEP the symbol is
-        # simply absent and an ImportError naming it says nothing about which
-        # build to install.
         _require_moonep_local_first()
 
         from moonep.buffer import create_nvl_dist_tensor, local_first_chunk_index
@@ -68,10 +62,6 @@ class MoonEPWeightPool:
                 ep_rank,
                 ep_size,
                 group=group,
-                # Rotated so this rank's chunk is at the base of the mapping.
-                # DeepGEMM's tvm_ffi bindings resolve a tensor's device from
-                # its base pointer, and the unrotated base is always rank 0's
-                # memory -- every other rank then fails the device check.
                 local_first=True,
             )
             for kind, (trailing, dtype) in specs.items()
@@ -88,10 +78,6 @@ class MoonEPWeightPool:
         )
 
     def layer_offset(self, layer_id: int) -> int:
-        """Rows before this layer's block. Layers are numbered by the order
-        they ask for storage, not by ``layer_id``: with pipeline parallelism a
-        rank holds an arbitrary slice of the model's layer ids, and the pool is
-        sized for what this rank actually builds."""
         index = self._layers.get(layer_id)
         if index is None:
             index = len(self._layers)
@@ -106,17 +92,13 @@ class MoonEPWeightPool:
         return index * self.block_rows
 
     def chunk_start(self, owner_rank: int) -> int:
-        """First row of ``owner_rank``'s chunk in this rank's mapping."""
         return self._chunk_index[owner_rank] * self.chunk_rows
 
     def local_view(self, kind: str, layer_id: int) -> torch.Tensor:
-        """This rank's ``[num_local_experts, ...]`` slice: what the loader
-        writes and what the parameter is bound to."""
         start = self.chunk_start(self.ep_rank) + self.layer_offset(layer_id)
         return self.ranges[kind][start : start + self.num_local_experts]
 
     def slot_view(self, kind: str, layer_id: int) -> torch.Tensor:
-        """This layer's ``[num_prefetch_slots, ...]`` copy destinations."""
         start = (
             self.chunk_start(self.ep_rank)
             + self.layer_offset(layer_id)
@@ -125,7 +107,6 @@ class MoonEPWeightPool:
         return self.ranges[kind][start : start + self.num_prefetch_slots]
 
 
-# The branch carrying the local-first mapping until it lands upstream.
 _MOONEP_LOCAL_FIRST_BRANCH = (
     "https://github.com/bytedance-iaas/MoonEP/tree/"
     "jxp/update_prefetch_api_and_support_local_first"
@@ -133,19 +114,6 @@ _MOONEP_LOCAL_FIRST_BRANCH = (
 
 
 def _require_moonep_local_first() -> None:
-    """Refuse the pool unless the installed MoonEP maps local-first.
-
-    ``create_nvl_dist_tensor(local_first=...)`` and
-    ``local_first_chunk_index()`` are an in-flight MoonEP change, not in
-    ``MoonshotAI/MoonEP``. They cannot be worked around from sglang: the
-    rotation happens while the memory handles are mapped, so a tensor the
-    published mapper has already returned cannot be re-ordered. Without it the
-    range's base address is rank 0's memory on every rank, which is the device
-    DeepGEMM's tvm_ffi bindings infer.
-
-    Declared by the operator rather than probed, so a MoonEP that grows the
-    keyword without the semantics cannot silently opt itself in.
-    """
     if envs.SGLANG_ENABLE_MOONEP_LOCAL_FIRST.get():
         return
     raise RuntimeError(
@@ -161,17 +129,8 @@ def _require_moonep_local_first() -> None:
 def _check_prefetch_tiling(
     specs: dict[str, tuple[tuple[int, ...], torch.dtype]],
 ) -> None:
-    """Reject shapes MoonEP's prefetch copy cannot tile.
-
-    ``retile_for_prefetch`` views each expert as ``[128, X]`` uint8 and asserts
-    the per-expert byte count divides its tile evenly. Its own message names
-    only the byte counts, which is impossible to connect back to a model
-    dimension, and it fires on the first forward -- long after the weights are
-    loaded. Checking here fails at allocation with the dimension named.
-    """
     from moonep.prefetch import prefetch_retile_nbytes
 
-    # Rounding one byte up lands on the tile size itself.
     tile = prefetch_retile_nbytes(1)
     for kind, (trailing, dtype) in specs.items():
         per_expert = math.prod(trailing) * torch.empty(0, dtype=dtype).element_size()
@@ -187,7 +146,6 @@ def _check_prefetch_tiling(
 
 
 def _minimum_aligned_rows(trailing_shape, dtype: torch.dtype) -> int:
-    """Smallest row count whose bytes land on a VMM granularity boundary."""
     from moonep.buffer import pad_dim0_for_alignment
 
     return pad_dim0_for_alignment([1, *trailing_shape], dtype)
@@ -196,14 +154,6 @@ def _minimum_aligned_rows(trailing_shape, dtype: torch.dtype) -> int:
 def _resolve_chunk_rows(
     specs: dict[str, tuple[tuple[int, ...], torch.dtype]], rows_in_use: int
 ) -> int:
-    """One row count that is granularity-aligned for every range at once.
-
-    A weight and its scale must share a row indexing, so they cannot each pick
-    their own padding. A row count works for a tensor when
-    ``rows * bytes_per_row`` is a multiple of the VMM granularity, so the
-    common answer is the least common multiple of each one's minimum, rounded
-    up past the rows actually in use.
-    """
     step = 1
     for trailing, dtype in specs.values():
         step = math.lcm(step, _minimum_aligned_rows(trailing, dtype))
@@ -211,15 +161,6 @@ def _resolve_chunk_rows(
 
 
 def _num_moe_layers() -> int:
-    """How many layers *this rank* will ask the pool for storage.
-
-    Counted from the config rather than tracked dynamically because the ranges
-    are fixed-size VMM mappings that cannot grow. Only this rank's pipeline
-    stage is counted: with PP a rank builds an arbitrary slice of the model,
-    and a pool sized for the whole model would waste the rest. ``layer_offset``
-    raises if the count turns out to be too small, so an over-count costs
-    memory and an under-count is loud.
-    """
     from sglang.srt.distributed import get_pp_group
     from sglang.srt.distributed.utils import get_pp_indices
     from sglang.srt.runtime_context import process_model_config
@@ -252,13 +193,6 @@ def alloc_expert_tensors(
     layer: torch.nn.Module,
     specs: dict[str, tuple[tuple[int, ...], torch.dtype]],
 ) -> dict[str, torch.Tensor]:
-    """Per-layer views of the symmetric pool, creating it on the first call.
-
-    ``specs`` maps a sub-range name to ``(trailing_shape, dtype)`` for a single
-    expert row. Every layer must pass the same specs -- they share one
-    allocation. Collective over the EP group, so all ranks have to build their
-    layers in the same order.
-    """
     global _pool
 
     from sglang.srt.distributed import get_tp_group
@@ -291,13 +225,8 @@ def alloc_expert_tensors(
 
 
 def expert_rows(layer_id: int, expert_ids: torch.Tensor) -> torch.Tensor:
-    """Global expert ids -> rows of the symmetric range. Negative ids (unused
-    prefetch slots) pass through so DeepGEMM still skips them."""
     assert _pool is not None, "MoonEP expert pool was never created"
     epn = _pool.num_local_experts
-    # The mapping is local-first, so an owner's chunk index is relative to this
-    # rank -- row numbers differ per rank, which is fine because every consumer
-    # of them (m_indices, experts_to_copy) is computed locally.
     owner = expert_ids // epn
     chunk = (owner - _pool.ep_rank) % _pool.ep_size
     rows = chunk * _pool.chunk_rows + _pool.layer_offset(layer_id) + expert_ids % epn
@@ -307,13 +236,6 @@ def expert_rows(layer_id: int, expert_ids: torch.Tensor) -> torch.Tensor:
 def group_rows(
     layer_id: int, expert_ids: torch.Tensor, num_global_experts: int
 ) -> torch.Tensor:
-    """MoonEP's per-VM-group expert ids -> rows of the symmetric range.
-
-    The first ``num_global_experts`` groups are experts addressed by global id;
-    the groups after them are this rank's prefetch slots, whose ids name the
-    *source* expert but whose tokens must read the slot the copy landed in.
-    Empty and unfilled groups keep their -1 and stay skipped.
-    """
     assert _pool is not None, "MoonEP expert pool was never created"
     rows = expert_rows(layer_id, expert_ids)
     tail = expert_ids[num_global_experts:]
@@ -333,18 +255,6 @@ def group_rows(
 
 
 def prefetch_experts(layer_id: int, source_rows: torch.Tensor, num_sms: int) -> None:
-    """Copy the planned remote experts into this layer's prefetch slots.
-
-    ``Buffer.prefetch_weight`` does this for BF16, but it takes each source as
-    one ``[E+B, ...]`` block and slices the slots off the end. A symmetric
-    range cannot present that block -- ``create_nvl_dist_tensor`` pads every
-    rank's chunk up to allocation granularity, so an expert's rows and this
-    rank's slots are never adjacent. ``launch_prefetch`` takes source and
-    destination separately and is what ``prefetch_weight`` calls anyway.
-
-    ``source_rows`` are rows of the symmetric range (:func:`expert_rows`), not
-    global expert ids -- the other thing the block API assumes.
-    """
     from moonep.prefetch import launch_prefetch, retile_for_prefetch
 
     assert _pool is not None, "MoonEP expert pool was never created"
@@ -367,12 +277,6 @@ def prefetch_experts(layer_id: int, source_rows: torch.Tensor, num_sms: int) -> 
 
 
 def assert_resident(layer: torch.nn.Module, kind: str, tensor: torch.Tensor) -> None:
-    """Fail loudly if a post-load step swapped a pooled tensor for a private one.
-
-    SGLang's quant methods routinely rebind weights after loading, and a
-    rebind that lands outside the pool silently costs MoonEP its remote
-    readability -- prefetch would then copy from memory no peer can see.
-    """
     assert _pool is not None, "MoonEP expert pool was never created"
     full = _pool.ranges[kind]
     start = full.data_ptr()

--- a/python/sglang/srt/layers/moe/token_dispatcher/moonep_weights.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/moonep_weights.py
@@ -40,6 +40,7 @@ class MoonEPWeightPool:
         self.ep_rank = ep_rank
         self.ep_size = ep_size
         self.block_rows = num_local_experts + num_prefetch_slots
+        _check_prefetch_tiling(specs)
         self.chunk_rows = _resolve_chunk_rows(specs, num_layers * self.block_rows)
         self._layers: dict[int, int] = {}
 
@@ -108,6 +109,34 @@ class MoonEPWeightPool:
             + self.num_local_experts
         )
         return self.ranges[kind][start : start + self.num_prefetch_slots]
+
+
+def _check_prefetch_tiling(
+    specs: dict[str, tuple[tuple[int, ...], torch.dtype]],
+) -> None:
+    """Reject shapes MoonEP's prefetch copy cannot tile.
+
+    ``retile_for_prefetch`` views each expert as ``[128, X]`` uint8 and asserts
+    the per-expert byte count divides its tile evenly. Its own message names
+    only the byte counts, which is impossible to connect back to a model
+    dimension, and it fires on the first forward -- long after the weights are
+    loaded. Checking here fails at allocation with the dimension named.
+    """
+    from moonep.prefetch import prefetch_retile_nbytes
+
+    # Rounding one byte up lands on the tile size itself.
+    tile = prefetch_retile_nbytes(1)
+    for kind, (trailing, dtype) in specs.items():
+        per_expert = math.prod(trailing) * torch.empty(0, dtype=dtype).element_size()
+        if per_expert % tile:
+            raise ValueError(
+                f"MoonEP cannot prefetch {kind} for this model: one expert is "
+                f"{per_expert} bytes ({tuple(trailing)} x {dtype}), and the "
+                f"prefetch copy needs a multiple of {tile} "
+                f"(nearest is {prefetch_retile_nbytes(per_expert)}). This "
+                "follows from the model's hidden and intermediate sizes, so "
+                "it is not something the server can pad around."
+            )
 
 
 def _minimum_aligned_rows(trailing_shape, dtype: torch.dtype) -> int:
@@ -247,7 +276,7 @@ def prefetch_pairs(
 
     Scales are re-tiled by the copy and so are kept apart from the weights.
     The scale views are the *storage* orientation, which is what a byte copy
-    has to move -- see the MN-major note in the module docstring.
+    has to move -- see the MN-major note in this module's docstring.
     """
     assert _pool is not None, "MoonEP expert pool was never created"
     weights = [

--- a/python/sglang/srt/layers/moe/token_dispatcher/moonep_weights.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/moonep_weights.py
@@ -6,6 +6,8 @@ from typing import Optional
 
 import torch
 
+from sglang.srt.environ import envs
+
 logger = logging.getLogger(__name__)
 
 # Sub-ranges of the pool, keyed by the attribute they end up backing. The
@@ -32,6 +34,11 @@ class MoonEPWeightPool:
         group,
         specs: dict[str, tuple[tuple[int, ...], torch.dtype]],
     ):
+        # Checked before the import, because on upstream MoonEP the symbol is
+        # simply absent and an ImportError naming it says nothing about which
+        # build to install.
+        _require_moonep_local_first()
+
         from moonep.buffer import create_nvl_dist_tensor, local_first_chunk_index
 
         self.num_layers = num_layers
@@ -116,6 +123,39 @@ class MoonEPWeightPool:
             + self.num_local_experts
         )
         return self.ranges[kind][start : start + self.num_prefetch_slots]
+
+
+# The branch carrying the local-first mapping until it lands upstream.
+_MOONEP_LOCAL_FIRST_BRANCH = (
+    "https://github.com/bytedance-iaas/MoonEP/tree/"
+    "jxp/update_prefetch_api_and_support_local_first"
+)
+
+
+def _require_moonep_local_first() -> None:
+    """Refuse the pool unless the installed MoonEP maps local-first.
+
+    ``create_nvl_dist_tensor(local_first=...)`` and
+    ``local_first_chunk_index()`` are an in-flight MoonEP change, not in
+    ``MoonshotAI/MoonEP``. They cannot be worked around from sglang: the
+    rotation happens while the memory handles are mapped, so a tensor the
+    published mapper has already returned cannot be re-ordered. Without it the
+    range's base address is rank 0's memory on every rank, which is the device
+    DeepGEMM's tvm_ffi bindings infer.
+
+    Declared by the operator rather than probed, so a MoonEP that grows the
+    keyword without the semantics cannot silently opt itself in.
+    """
+    if envs.SGLANG_ENABLE_MOONEP_LOCAL_FIRST.get():
+        return
+    raise RuntimeError(
+        "MoonEP with quantized experts needs a local-first symmetric mapping "
+        "-- create_nvl_dist_tensor(local_first=...) and "
+        "local_first_chunk_index() -- which upstream MoonEP does not carry "
+        f"yet. Install a MoonEP built from {_MOONEP_LOCAL_FIRST_BRANCH} and "
+        "set SGLANG_ENABLE_MOONEP_LOCAL_FIRST=1. BF16 experts are stored on "
+        "every rank instead of pooled, and need none of this."
+    )
 
 
 def _check_prefetch_tiling(

--- a/python/sglang/srt/layers/moe/token_dispatcher/moonep_weights.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/moonep_weights.py
@@ -32,7 +32,7 @@ class MoonEPWeightPool:
         group,
         specs: dict[str, tuple[tuple[int, ...], torch.dtype]],
     ):
-        from moonep.buffer import create_nvl_dist_tensor
+        from moonep.buffer import create_nvl_dist_tensor, local_first_chunk_index
 
         self.num_layers = num_layers
         self.num_local_experts = num_local_experts
@@ -40,6 +40,16 @@ class MoonEPWeightPool:
         self.ep_rank = ep_rank
         self.ep_size = ep_size
         self.block_rows = num_local_experts + num_prefetch_slots
+        self._chunk_index = [
+            local_first_chunk_index(owner, ep_rank, ep_size) for owner in range(ep_size)
+        ]
+        if self._chunk_index != [(o - ep_rank) % ep_size for o in range(ep_size)]:
+            raise RuntimeError(
+                "MoonEP's local-first rotation is no longer "
+                "(owner_rank - local_rank) % world_size, which expert_rows "
+                f"assumes; local_first_chunk_index gives {self._chunk_index} "
+                f"on rank {ep_rank} of {ep_size}. Update expert_rows to match."
+            )
         _check_prefetch_tiling(specs)
         self.chunk_rows = _resolve_chunk_rows(specs, num_layers * self.block_rows)
         self._layers: dict[int, int] = {}
@@ -90,10 +100,7 @@ class MoonEPWeightPool:
 
     def chunk_start(self, owner_rank: int) -> int:
         """First row of ``owner_rank``'s chunk in this rank's mapping."""
-        from moonep.buffer import local_first_chunk_index
-
-        index = local_first_chunk_index(owner_rank, self.ep_rank, self.ep_size)
-        return index * self.chunk_rows
+        return self._chunk_index[owner_rank] * self.chunk_rows
 
     def local_view(self, kind: str, layer_id: int) -> torch.Tensor:
         """This rank's ``[num_local_experts, ...]`` slice: what the loader
@@ -164,19 +171,37 @@ def _resolve_chunk_rows(
 
 
 def _num_moe_layers() -> int:
-    """How many layers will ask the pool for storage.
+    """How many layers *this rank* will ask the pool for storage.
 
     Counted from the config rather than tracked dynamically because the ranges
-    are fixed-size VMM mappings that cannot grow; ``layer_offset`` raises if
-    the count turns out to be too small.
+    are fixed-size VMM mappings that cannot grow. Only this rank's pipeline
+    stage is counted: with PP a rank builds an arbitrary slice of the model,
+    and a pool sized for the whole model would waste the rest. ``layer_offset``
+    raises if the count turns out to be too small, so an over-count costs
+    memory and an under-count is loud.
     """
+    from sglang.srt.distributed import get_pp_group
+    from sglang.srt.distributed.utils import get_pp_indices
     from sglang.srt.runtime_context import process_model_config
 
     config = process_model_config()
-    num_layers = int(config.num_hidden_layers)
-    first_dense = config.first_k_dense_replace or 0
-    freq = getattr(config.hf_text_config, "moe_layer_freq", 1) or 1
-    return sum(1 for i in range(num_layers) if i >= first_dense and i % freq == 0)
+    hf_config = config.hf_text_config
+
+    if hasattr(hf_config, "moe_layer_freq") and hf_config.moe_layer_freq != 1:
+        raise NotImplementedError(
+            "MoonEP's expert pool assumes every layer from "
+            "first_k_dense_replace onwards is an MoE layer, but this model "
+            f"sets moe_layer_freq={hf_config.moe_layer_freq!r}. Counting its "
+            "MoE layers is a per-model rule and getting it wrong undersizes a "
+            "VMM mapping that cannot grow."
+        )
+
+    pp_group = get_pp_group()
+    start, end = get_pp_indices(
+        int(config.num_hidden_layers), pp_group.rank_in_group, pp_group.world_size
+    )
+    first_moe = max(start, config.first_k_dense_replace or 0)
+    return max(0, end - first_moe)
 
 
 def get_pool() -> Optional[MoonEPWeightPool]:
@@ -267,27 +292,38 @@ def group_rows(
     return rows
 
 
-def prefetch_pairs(
-    layer_id: int,
-) -> tuple[
-    list[tuple[torch.Tensor, torch.Tensor]], list[tuple[torch.Tensor, torch.Tensor]]
-]:
-    """``(weight_pairs, scale_pairs)`` for ``Buffer.prefetch_weight``.
+def prefetch_experts(layer_id: int, source_rows: torch.Tensor, num_sms: int) -> None:
+    """Copy the planned remote experts into this layer's prefetch slots.
 
-    Scales are re-tiled by the copy and so are kept apart from the weights.
-    The scale views are the *storage* orientation, which is what a byte copy
-    has to move -- see the MN-major note in this module's docstring.
+    ``Buffer.prefetch_weight`` does this for BF16, but it takes each source as
+    one ``[E+B, ...]`` block and slices the slots off the end. A symmetric
+    range cannot present that block -- ``create_nvl_dist_tensor`` pads every
+    rank's chunk up to allocation granularity, so an expert's rows and this
+    rank's slots are never adjacent. ``launch_prefetch`` takes source and
+    destination separately and is what ``prefetch_weight`` calls anyway.
+
+    ``source_rows`` are rows of the symmetric range (:func:`expert_rows`), not
+    global expert ids -- the other thing the block API assumes.
     """
+    from moonep.prefetch import launch_prefetch, retile_for_prefetch
+
     assert _pool is not None, "MoonEP expert pool was never created"
-    weights = [
-        (_pool.ranges[k], _pool.slot_view(k, layer_id)) for k in (W13_WEIGHT, W2_WEIGHT)
-    ]
-    scales = [
-        (_pool.ranges[k], _pool.slot_view(k, layer_id))
-        for k in (W13_SCALE, W2_SCALE)
-        if k in _pool.ranges
-    ]
-    return weights, scales
+    for kind in (W13_WEIGHT, W2_WEIGHT):
+        launch_prefetch(
+            _pool.ranges[kind],
+            _pool.slot_view(kind, layer_id),
+            source_rows,
+            num_sms=num_sms,
+        )
+    for kind in (W13_SCALE, W2_SCALE):
+        if kind not in _pool.ranges:
+            continue
+        launch_prefetch(
+            retile_for_prefetch(_pool.ranges[kind]),
+            retile_for_prefetch(_pool.slot_view(kind, layer_id)),
+            source_rows,
+            num_sms=num_sms,
+        )
 
 
 def assert_resident(layer: torch.nn.Module, kind: str, tensor: torch.Tensor) -> None:

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -496,11 +496,7 @@ def is_deepep_class_backend() -> bool:
     """Check if the MoE backend is DeepEP-family."""
     b = get_moe_a2a_backend()
     return (
-        b.is_deepep()
-        or b.is_moonep()
-        or b.is_mooncake()
-        or b.is_mori()
-        or b.is_pplx()
+        b.is_deepep() or b.is_moonep() or b.is_mooncake() or b.is_mori() or b.is_pplx()
     )
 
 

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -324,6 +324,52 @@ class Mxfp4Config(QuantizationConfig):
         return []
 
 
+def _maybe_alloc_moonep_expert_pool(
+    layer,
+    *,
+    intermediate_size: int,
+    hidden_size: int,
+    weight_dtype: torch.dtype,
+    mxfp4_block: int,
+) -> Optional[dict]:
+    """This layer's slice of MoonEP's symmetric expert pool, or None.
+
+    The scale entries describe DeepGEMM's *runtime* layout in storage order:
+    ``transform_sf_into_required_layout`` returns ``[E, MN, K/128]`` int32 with
+    stride ``(.., 1, MN)``, whose contiguous bytes are the transpose. Four
+    e8m0 exponents pack into one int32, so the byte count matches the
+    ``[E, MN, K/32]`` uint8 the checkpoint carries.
+    """
+    from sglang.srt.layers.moe.token_dispatcher import moonep_weights
+    from sglang.srt.layers.moe.utils import get_moe_a2a_backend
+
+    if not get_moe_a2a_backend().is_moonep():
+        return None
+
+    scale_pack = 4 * mxfp4_block  # e8m0 bytes per int32 x elements per byte
+    return moonep_weights.alloc_expert_tensors(
+        layer,
+        {
+            moonep_weights.W13_WEIGHT: (
+                (2 * intermediate_size, hidden_size // 2),
+                weight_dtype,
+            ),
+            moonep_weights.W2_WEIGHT: (
+                (hidden_size, intermediate_size // 2),
+                weight_dtype,
+            ),
+            moonep_weights.W13_SCALE: (
+                (hidden_size // scale_pack, 2 * intermediate_size),
+                torch.int32,
+            ),
+            moonep_weights.W2_SCALE: (
+                (intermediate_size // scale_pack, hidden_size),
+                torch.int32,
+            ),
+        },
+    )
+
+
 class Mxfp4MoEMethod(FusedMoEMethodBase):
 
     def __init__(
@@ -334,6 +380,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
 
         self.prefix = prefix
         self.topk_indices_dtype = None
+        self.moonep_pooled = None
         self.use_triton_kernels = get_moe_runner_backend().is_triton_kernels()
         self.with_bias = False
         self.use_flashinfer = get_moe_runner_backend().is_flashinfer_mxfp4()
@@ -464,13 +511,31 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         self.intermediate_size_per_partition = intermediate_size_per_partition_after_pad
 
         self.hidden_size = hidden_size
+
+        from sglang.srt.layers.moe.token_dispatcher import moonep_weights
+
+        # MoonEP needs every expert row readable by its peers, so the weights
+        # come from a symmetric VMM pool instead of a private allocation. The
+        # scales are pooled in their post-transform runtime layout, which
+        # process_weights_after_loading copies into rather than replacing.
+        self.moonep_pooled = _maybe_alloc_moonep_expert_pool(
+            layer,
+            intermediate_size=intermediate_size_per_partition_after_pad,
+            hidden_size=hidden_size,
+            weight_dtype=weight_dtype,
+            mxfp4_block=mxfp4_block,
+        )
+
         # Fused gate_up_proj (column parallel)
         w13_weight = torch.nn.Parameter(
-            torch.zeros(
-                layer.num_local_experts,
-                2 * intermediate_size_per_partition_after_pad,
-                hidden_size // 2,
-                dtype=weight_dtype,
+            self._expert_storage(
+                moonep_weights.W13_WEIGHT,
+                (
+                    layer.num_local_experts,
+                    2 * intermediate_size_per_partition_after_pad,
+                    hidden_size // 2,
+                ),
+                weight_dtype,
             ),
             requires_grad=False,
         )
@@ -508,11 +573,14 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
 
         # down_proj (row parallel)
         w2_weight = torch.nn.Parameter(
-            torch.zeros(
-                layer.num_local_experts,
-                hidden_size,
-                intermediate_size_per_partition_after_pad // 2,
-                dtype=weight_dtype,
+            self._expert_storage(
+                moonep_weights.W2_WEIGHT,
+                (
+                    layer.num_local_experts,
+                    hidden_size,
+                    intermediate_size_per_partition_after_pad // 2,
+                ),
+                weight_dtype,
             ),
             requires_grad=False,
         )
@@ -542,6 +610,21 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             )
             layer.register_parameter("w2_weight_bias", w2_weight_bias)
             set_weight_attrs(w2_weight_bias, extra_weight_attrs)
+
+    def _expert_storage(
+        self, kind: str, shape: tuple[int, ...], dtype: torch.dtype
+    ) -> torch.Tensor:
+        """Zeroed storage for an expert tensor, from MoonEP's symmetric pool
+        when that backend is active and a private allocation otherwise."""
+        if self.moonep_pooled is None:
+            return torch.zeros(*shape, dtype=dtype)
+
+        pooled = self.moonep_pooled[kind]
+        assert tuple(pooled.shape) == shape and pooled.dtype == dtype, (
+            f"MoonEP pool gave {kind} as {tuple(pooled.shape)}/{pooled.dtype}, "
+            f"expected {shape}/{dtype}"
+        )
+        return pooled.zero_()
 
     def process_weights_after_loading(self, layer):
         if self.use_marlin:
@@ -575,21 +658,32 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         if self.use_deep_gemm:
             from deep_gemm import transform_sf_into_required_layout
 
+            from sglang.srt.layers.moe.token_dispatcher import moonep_weights
+
             # Packed fp4 (e2m1 x2 per byte) weights: DeepGEMM expects int8.
+            # A re-view keeps the storage, which is what lets MoonEP's pooled
+            # weights survive this step.
             layer.w13_weight.data = layer.w13_weight.data.view(torch.int8)
             layer.w2_weight.data = layer.w2_weight.data.view(torch.int8)
+            if self.moonep_pooled is not None:
+                moonep_weights.assert_resident(
+                    layer, moonep_weights.W13_WEIGHT, layer.w13_weight.data
+                )
+                moonep_weights.assert_resident(
+                    layer, moonep_weights.W2_WEIGHT, layer.w2_weight.data
+                )
             # Checkpoint scales are uint8 e8m0 (biased exponents). DeepGEMM
             # SM100 needs them in packed-UE8M0 TMA-aligned MN-major layout.
             # Round-trip through fp32 is exact (values are powers of two).
-            for scale_name, weight in (
-                ("w13_weight_scale", layer.w13_weight),
-                ("w2_weight_scale", layer.w2_weight),
+            for scale_name, weight, pool_kind in (
+                ("w13_weight_scale", layer.w13_weight, moonep_weights.W13_SCALE),
+                ("w2_weight_scale", layer.w2_weight, moonep_weights.W2_SCALE),
             ):
                 scale = getattr(layer, scale_name)
                 num_experts, n, _ = scale.data.shape
                 k = weight.shape[2] * 2
                 scale_f32 = scale.data.view(torch.float8_e8m0fnu).to(torch.float32)
-                scale.data = transform_sf_into_required_layout(
+                transformed = transform_sf_into_required_layout(
                     scale_f32,
                     mn=n,
                     k=k,
@@ -597,6 +691,16 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                     num_groups=num_experts,
                     disable_ue8m0_cast=False,
                 )
+                if self.moonep_pooled is None:
+                    scale.data = transformed
+                    continue
+                # The checkpoint-layout buffer the loader filled is private
+                # memory; the runtime layout has to end up in the pool instead,
+                # so copy rather than rebind. The pooled range is stored
+                # transposed, matching the MN-major result's real byte order.
+                pooled = self.moonep_pooled[pool_kind].permute(0, 2, 1)
+                scale.data = pooled.copy_(transformed)
+                moonep_weights.assert_resident(layer, pool_kind, scale.data)
             if get_moe_a2a_backend().is_megamoe():
                 # MegaMoE consumes the same transformed sf, plus its own
                 # interleaved/UTCCP weight layout. K3 routes EVERY batch

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -333,14 +333,6 @@ def _maybe_alloc_moonep_expert_pool(
     mxfp4_block: int,
     use_deep_gemm: bool,
 ) -> Optional[dict]:
-    """This layer's slice of MoonEP's symmetric expert pool, or None.
-
-    The scale entries describe DeepGEMM's *runtime* layout in storage order:
-    ``transform_sf_into_required_layout`` returns ``[E, MN, K/128]`` int32 with
-    stride ``(.., 1, MN)``, whose contiguous bytes are the transpose. Four
-    e8m0 exponents pack into one int32, so the byte count matches the
-    ``[E, MN, K/32]`` uint8 the checkpoint carries.
-    """
     from sglang.srt.layers.moe.token_dispatcher import moonep_weights
     from sglang.srt.layers.moe.utils import get_moe_a2a_backend, get_moe_runner_backend
 
@@ -524,10 +516,6 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
 
         from sglang.srt.layers.moe.token_dispatcher import moonep_weights
 
-        # MoonEP needs every expert row readable by its peers, so the weights
-        # come from a symmetric VMM pool instead of a private allocation. The
-        # scales are pooled in their post-transform runtime layout, which
-        # process_weights_after_loading copies into rather than replacing.
         self.moonep_pooled = _maybe_alloc_moonep_expert_pool(
             layer,
             intermediate_size=intermediate_size_per_partition_after_pad,
@@ -625,8 +613,6 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
     def _expert_storage(
         self, kind: str, shape: tuple[int, ...], dtype: torch.dtype
     ) -> torch.Tensor:
-        """Zeroed storage for an expert tensor, from MoonEP's symmetric pool
-        when that backend is active and a private allocation otherwise."""
         if self.moonep_pooled is None:
             return torch.zeros(*shape, dtype=dtype)
 
@@ -672,8 +658,6 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             from sglang.srt.layers.moe.token_dispatcher import moonep_weights
 
             # Packed fp4 (e2m1 x2 per byte) weights: DeepGEMM expects int8.
-            # A re-view keeps the storage, which is what lets MoonEP's pooled
-            # weights survive this step.
             layer.w13_weight.data = layer.w13_weight.data.view(torch.int8)
             layer.w2_weight.data = layer.w2_weight.data.view(torch.int8)
             if self.moonep_pooled is not None:
@@ -705,10 +689,6 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 if self.moonep_pooled is None:
                     scale.data = transformed
                     continue
-                # The checkpoint-layout buffer the loader filled is private
-                # memory; the runtime layout has to end up in the pool instead,
-                # so copy rather than rebind. The pooled range is stored
-                # transposed, matching the MN-major result's real byte order.
                 pooled = self.moonep_pooled[pool_kind].permute(0, 2, 1)
                 scale.data = pooled.copy_(transformed)
                 moonep_weights.assert_resident(layer, pool_kind, scale.data)

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -331,6 +331,7 @@ def _maybe_alloc_moonep_expert_pool(
     hidden_size: int,
     weight_dtype: torch.dtype,
     mxfp4_block: int,
+    use_deep_gemm: bool,
 ) -> Optional[dict]:
     """This layer's slice of MoonEP's symmetric expert pool, or None.
 
@@ -341,10 +342,19 @@ def _maybe_alloc_moonep_expert_pool(
     ``[E, MN, K/32]`` uint8 the checkpoint carries.
     """
     from sglang.srt.layers.moe.token_dispatcher import moonep_weights
-    from sglang.srt.layers.moe.utils import get_moe_a2a_backend
+    from sglang.srt.layers.moe.utils import get_moe_a2a_backend, get_moe_runner_backend
 
     if not get_moe_a2a_backend().is_moonep():
         return None
+
+    if not use_deep_gemm:
+        raise NotImplementedError(
+            "MoonEP with quantized experts requires --moe-runner-backend "
+            f"deep_gemm, got '{get_moe_runner_backend().value}'. The experts "
+            "live in a symmetric range so peers can read each other's rows "
+            "over NVLink, and only the deep_gemm m-grouped contiguous GEMM "
+            "addresses rows outside this rank's own chunk."
+        )
 
     scale_pack = 4 * mxfp4_block  # e8m0 bytes per int32 x elements per byte
     return moonep_weights.alloc_expert_tensors(
@@ -524,6 +534,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             hidden_size=hidden_size,
             weight_dtype=weight_dtype,
             mxfp4_block=mxfp4_block,
+            use_deep_gemm=self.use_deep_gemm,
         )
 
         # Fused gate_up_proj (column parallel)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -6861,11 +6861,12 @@ class ServerArgs:
                 self.cuda_graph_config.decode.backend = Backend.DISABLED
                 self.cuda_graph_config.prefill.backend = Backend.DISABLED
 
-        if a2a_backend == "moonep":
+        if a2a_backend == "moonep" and not envs.SGLANG_ENABLE_MOONEP_CUDA_GRAPH.get():
             logger.warning(
-                "MoonEP MoE is enabled in experimental BF16 PoC mode. "
                 "Cuda graph is disabled while the eager MoonEP dispatch/"
-                "prefetch/compute/combine path is validated."
+                "prefetch/compute/combine path is validated. MoonEP's buffers "
+                "are statically shaped, so capture should be possible; set "
+                "SGLANG_ENABLE_MOONEP_CUDA_GRAPH=1 to try it."
             )
             self.cuda_graph_config.decode.backend = Backend.DISABLED
             self.cuda_graph_config.prefill.backend = Backend.DISABLED

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -6861,15 +6861,24 @@ class ServerArgs:
                 self.cuda_graph_config.decode.backend = Backend.DISABLED
                 self.cuda_graph_config.prefill.backend = Backend.DISABLED
 
-        if a2a_backend == "moonep" and not envs.SGLANG_ENABLE_MOONEP_CUDA_GRAPH.get():
-            logger.warning(
-                "Cuda graph is disabled while the eager MoonEP dispatch/"
-                "prefetch/compute/combine path is validated. MoonEP's buffers "
-                "are statically shaped, so capture should be possible; set "
-                "SGLANG_ENABLE_MOONEP_CUDA_GRAPH=1 to try it."
-            )
-            self.cuda_graph_config.decode.backend = Backend.DISABLED
-            self.cuda_graph_config.prefill.backend = Backend.DISABLED
+        if a2a_backend == "moonep":
+            if envs.SGLANG_JIT_DEEPGEMM_PRECOMPILE.get():
+                logger.warning(
+                    "Disabling DeepGEMM JIT pre-compilation: MoonEP's expert "
+                    "weights span the whole symmetric range, which the warmup "
+                    "pass cannot allocate. Kernels compile on first use."
+                )
+                envs.SGLANG_JIT_DEEPGEMM_PRECOMPILE.set(False)
+
+            if not envs.SGLANG_ENABLE_MOONEP_CUDA_GRAPH.get():
+                logger.warning(
+                    "Cuda graph is disabled while the eager MoonEP dispatch/"
+                    "prefetch/compute/combine path is validated. MoonEP's "
+                    "buffers are statically shaped, so capture should be "
+                    "possible; set SGLANG_ENABLE_MOONEP_CUDA_GRAPH=1 to try it."
+                )
+                self.cuda_graph_config.decode.backend = Backend.DISABLED
+                self.cuda_graph_config.prefill.backend = Backend.DISABLED
 
         if (
             self.moe_a2a_backend == "none" and is_npu()

--- a/scripts/moonep/validate_moonep_bf16_poc.py
+++ b/scripts/moonep/validate_moonep_bf16_poc.py
@@ -16,10 +16,10 @@ rank-local PyTorch reference using the same top-k and expert weights.
 from __future__ import annotations
 
 import argparse
-from enum import IntEnum, auto
 import json
 import os
 import sys
+from enum import IntEnum, auto
 from pathlib import Path
 from types import ModuleType
 from typing import NamedTuple, Protocol, TypeGuard, runtime_checkable
@@ -257,21 +257,27 @@ def main() -> None:
     # The production path should replace this with true symmetric expert-row
     # mappings whose physical storage is owned by each expert's home rank.
     torch.manual_seed(args.seed)
-    gate = torch.randn(
-        num_experts + num_prefetch_slots,
-        args.intermediate_size,
-        args.hidden_size,
-        device=device,
-        dtype=torch.bfloat16,
-    ) / 8
+    gate = (
+        torch.randn(
+            num_experts + num_prefetch_slots,
+            args.intermediate_size,
+            args.hidden_size,
+            device=device,
+            dtype=torch.bfloat16,
+        )
+        / 8
+    )
     up = torch.randn_like(gate) / 8
-    down = torch.randn(
-        num_experts + num_prefetch_slots,
-        args.hidden_size,
-        args.intermediate_size,
-        device=device,
-        dtype=torch.bfloat16,
-    ) / 8
+    down = (
+        torch.randn(
+            num_experts + num_prefetch_slots,
+            args.hidden_size,
+            args.intermediate_size,
+            device=device,
+            dtype=torch.bfloat16,
+        )
+        / 8
+    )
     gate[num_experts:].zero_()
     up[num_experts:].zero_()
     down[num_experts:].zero_()

--- a/test/registered/unit/layers/moe/test_moonep_buffer.py
+++ b/test/registered/unit/layers/moe/test_moonep_buffer.py
@@ -134,8 +134,6 @@ class TestMoonEPBuffer(unittest.TestCase):
         self.assertEqual(buffer.kwargs["S"], 384)
         self.assertEqual(buffer.kwargs["token_padding"], 32)
         self.assertEqual(buffer.kwargs["num_sms"], 18)
-        # Not E/EP (16). That is MoonEP's training rule and does not fit at
-        # inference scale; overflowing the slots stays correct, just slower.
         self.assertEqual(buffer.kwargs["B"], 4)
 
     def test_prefetch_slots_never_exceed_the_local_expert_count(self):

--- a/test/registered/unit/layers/moe/test_moonep_buffer.py
+++ b/test/registered/unit/layers/moe/test_moonep_buffer.py
@@ -110,7 +110,7 @@ class TestMoonEPBuffer(unittest.TestCase):
         )
         self.assertIs(MoonEPBuffer.get_existing_buffer(), larger_buffer)
 
-    def test_resolves_env_defaults_and_training_safe_prefetch_slots(self):
+    def test_resolves_env_defaults_and_inference_prefetch_slots(self):
         group = object()
 
         with (
@@ -134,7 +134,29 @@ class TestMoonEPBuffer(unittest.TestCase):
         self.assertEqual(buffer.kwargs["S"], 384)
         self.assertEqual(buffer.kwargs["token_padding"], 32)
         self.assertEqual(buffer.kwargs["num_sms"], 18)
-        self.assertEqual(buffer.kwargs["B"], 16)
+        # Not E/EP (16). That is MoonEP's training rule and does not fit at
+        # inference scale; overflowing the slots stays correct, just slower.
+        self.assertEqual(buffer.kwargs["B"], 4)
+
+    def test_prefetch_slots_never_exceed_the_local_expert_count(self):
+        """A model with fewer local experts than the default gets its own
+        count, not four slots it has nothing to put in."""
+        with (
+            envs.SGLANG_MOONEP_NUM_PREFETCH_SLOTS.override(-1),
+            patch.dict(sys.modules, {"moonep": _fake_moonep_module()}),
+            patch(
+                "sglang.srt.layers.moe.token_dispatcher.moonep.dist.get_world_size",
+                return_value=8,
+            ),
+        ):
+            buffer = MoonEPBuffer.get_moonep_buffer(
+                group=object(),
+                hidden_size=2048,
+                router_topk=6,
+                num_experts=16,
+            )
+
+        self.assertEqual(buffer.kwargs["B"], 2)
 
     def test_rejects_non_divisible_experts_before_allocating(self):
         with (
@@ -289,9 +311,7 @@ class TestMoonEPBf16ExpertRunner(unittest.TestCase):
         for start, end, expert in [(0, 2, 0), (2, 3, 1)]:
             x = hidden_states[start:end]
             y = torch.nn.functional.linear(
-                torch.nn.functional.silu(
-                    torch.nn.functional.linear(x, gate[expert])
-                )
+                torch.nn.functional.silu(torch.nn.functional.linear(x, gate[expert]))
                 * torch.nn.functional.linear(x, up[expert]),
                 down[expert],
             )

--- a/test/registered/unit/layers/moe/test_moonep_weights.py
+++ b/test/registered/unit/layers/moe/test_moonep_weights.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import torch
 
+from sglang.srt.environ import envs
 from sglang.srt.layers.moe.moe_runner.deep_gemm import _moonep_m_indices
 from sglang.srt.layers.moe.token_dispatcher import moonep_weights
 from sglang.srt.layers.moe.token_dispatcher.moonep_weights import (
@@ -22,22 +23,18 @@ EP_SIZE = 4
 NUM_LOCAL_EXPERTS = 4
 NUM_PREFETCH_SLOTS = 2
 NUM_LAYERS = 2
-# Two ranges, so `_resolve_chunk_rows` has to agree with itself across specs.
 SPECS = {
     moonep_weights.W13_WEIGHT: ((8, 16), torch.uint8),
     moonep_weights.W2_WEIGHT: ((4, 32), torch.uint8),
 }
-# num_layers * (num_local_experts + num_prefetch_slots), with the fake
-# allocator's granularity of one row.
 CHUNK_ROWS = 12
 
 
-def _fake_moonep(rotation=None):
-    """A MoonEP stand-in with only the surface the pool touches.
+def _local_first_enabled():
+    return envs.SGLANG_ENABLE_MOONEP_LOCAL_FIRST.override(True)
 
-    ``rotation`` overrides ``local_first_chunk_index`` so a test can present a
-    MoonEP whose mapping order is not the one ``expert_rows`` assumes.
-    """
+
+def _fake_moonep(rotation=None):
     moonep = types.ModuleType("moonep")
     buffer = types.ModuleType("moonep.buffer")
     prefetch = types.ModuleType("moonep.prefetch")
@@ -62,7 +59,7 @@ def _fake_moonep(rotation=None):
 
 class TestMoonEPPoolRows(CustomTestCase):
     def setUp(self):
-        with patch.dict(sys.modules, _fake_moonep()):
+        with patch.dict(sys.modules, _fake_moonep()), _local_first_enabled():
             self.pool = MoonEPWeightPool(
                 num_layers=NUM_LAYERS,
                 num_local_experts=NUM_LOCAL_EXPERTS,
@@ -81,8 +78,6 @@ class TestMoonEPPoolRows(CustomTestCase):
         self.assertEqual(self.pool.chunk_rows, CHUNK_ROWS)
 
     def test_expert_rows_place_each_owner_in_its_rotated_chunk(self):
-        # Rank 1's own experts are 4..7 and sit at the base of the mapping;
-        # rank 0's chunk is last, because local-first rotates by the rank.
         rows = moonep_weights.expert_rows(
             layer_id=7, expert_ids=torch.tensor([4, 5, 0, 8, 12])
         )
@@ -93,9 +88,6 @@ class TestMoonEPPoolRows(CustomTestCase):
         self.assertEqual(rows.dtype, torch.int32)
 
     def test_row_mapping_and_loader_views_agree_on_every_owner(self):
-        # `chunk_start` is what the loader writes through and `expert_rows` is
-        # what the GEMM reads through; if the two ever disagreed the weights
-        # would be loaded into one chunk and read out of another.
         first_expert = torch.tensor(
             [owner * NUM_LOCAL_EXPERTS for owner in range(EP_SIZE)]
         )
@@ -112,7 +104,6 @@ class TestMoonEPPoolRows(CustomTestCase):
         self.assertEqual(rows.tolist(), [-1, 0, -1])
 
     def test_expert_rows_offset_by_the_layers_block(self):
-        # Layers are numbered by the order they ask for storage, not by id.
         first = moonep_weights.expert_rows(layer_id=7, expert_ids=torch.tensor([4]))
         second = moonep_weights.expert_rows(layer_id=9, expert_ids=torch.tensor([4]))
         block = NUM_LOCAL_EXPERTS + NUM_PREFETCH_SLOTS
@@ -125,19 +116,38 @@ class TestMoonEPPoolRows(CustomTestCase):
         with self.assertRaisesRegex(RuntimeError, "sized for 2 layers"):
             self.pool.layer_offset(NUM_LAYERS)
 
-    def test_rejects_a_moonep_whose_rotation_expert_rows_does_not_assume(self):
-        # `expert_rows` runs the rotation in closed form, 92 layers x 2 calls
-        # per decode step; a table gather measured 1.3% of the step at K3/EP16.
-        # The price of the closed form is that MoonEP changing the rule has to
-        # be a startup error, which is what this pins.
-        with patch.dict(
-            sys.modules,
-            _fake_moonep(
-                rotation=lambda owner_rank, local_rank, world_size: (
-                    local_rank - owner_rank
+    def test_refuses_to_build_without_the_local_first_declaration(self):
+        with (
+            patch.dict(sys.modules, _fake_moonep()),
+            envs.SGLANG_ENABLE_MOONEP_LOCAL_FIRST.override(False),
+        ):
+            with self.assertRaises(RuntimeError) as caught:
+                MoonEPWeightPool(
+                    num_layers=NUM_LAYERS,
+                    num_local_experts=NUM_LOCAL_EXPERTS,
+                    num_prefetch_slots=NUM_PREFETCH_SLOTS,
+                    ep_rank=EP_RANK,
+                    ep_size=EP_SIZE,
+                    group=None,
+                    specs=SPECS,
                 )
-                % world_size
+        message = str(caught.exception)
+        self.assertIn("SGLANG_ENABLE_MOONEP_LOCAL_FIRST", message)
+        self.assertIn("local_first_chunk_index", message)
+        self.assertIn("bytedance-iaas/MoonEP", message)
+
+    def test_rejects_a_moonep_whose_rotation_expert_rows_does_not_assume(self):
+        with (
+            patch.dict(
+                sys.modules,
+                _fake_moonep(
+                    rotation=lambda owner_rank, local_rank, world_size: (
+                        local_rank - owner_rank
+                    )
+                    % world_size
+                ),
             ),
+            _local_first_enabled(),
         ):
             with self.assertRaisesRegex(RuntimeError, "local-first rotation"):
                 MoonEPWeightPool(
@@ -151,9 +161,7 @@ class TestMoonEPPoolRows(CustomTestCase):
                 )
 
     def test_rejects_a_shape_the_prefetch_copy_cannot_tile(self):
-        # The message has to name the range, not just a byte count: MoonEP's
-        # own assert fires on the first forward and says neither.
-        with patch.dict(sys.modules, _fake_moonep()):
+        with patch.dict(sys.modules, _fake_moonep()), _local_first_enabled():
             with self.assertRaisesRegex(ValueError, "w2_weight.*multiple of 128"):
                 MoonEPWeightPool(
                     num_layers=NUM_LAYERS,
@@ -167,8 +175,6 @@ class TestMoonEPPoolRows(CustomTestCase):
 
     def test_group_rows_keep_home_groups_and_remap_the_prefetch_tail(self):
         num_global_experts = EP_SIZE * NUM_LOCAL_EXPERTS
-        # The tail names the *source* expert of each copy; the tokens have to
-        # read the local slot the copy landed in, not the source.
         expert_ids = torch.cat(
             [torch.arange(num_global_experts), torch.tensor([12, -1])]
         )
@@ -183,8 +189,6 @@ class TestMoonEPPoolRows(CustomTestCase):
 
 class TestMoonEPMIndices(CustomTestCase):
     def test_empty_groups_are_skipped_and_the_tail_is_minus_one(self):
-        # Group 0 owns rows 0-1, groups 1 and 2 are empty, group 3 owns 2-4.
-        # Rows 5-6 are MoonEP's static padding past the last segment.
         m = _moonep_m_indices(
             cu_seqlens=torch.tensor([2, 2, 2, 5]),
             expert_ids=torch.tensor([5, 9, 11, 3]),
@@ -233,7 +237,6 @@ class TestMoonEPLayerCount(CustomTestCase):
         self.assertEqual(self._count(), 6)
 
     def test_counts_only_this_pipeline_stage(self):
-        # Layers 0-3 on stage 0, of which 2 and 3 are MoE; 4-7 on stage 1.
         self.assertEqual(self._count(pp_rank=0, pp_size=2), 2)
         self.assertEqual(self._count(pp_rank=1, pp_size=2), 4)
 

--- a/test/registered/unit/layers/moe/test_moonep_weights.py
+++ b/test/registered/unit/layers/moe/test_moonep_weights.py
@@ -1,0 +1,246 @@
+import sys
+import types
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.layers.moe.moe_runner.deep_gemm import _moonep_m_indices
+from sglang.srt.layers.moe.token_dispatcher import moonep_weights
+from sglang.srt.layers.moe.token_dispatcher.moonep_weights import (
+    MoonEPWeightPool,
+    _num_moe_layers,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+EP_RANK = 1
+EP_SIZE = 4
+NUM_LOCAL_EXPERTS = 4
+NUM_PREFETCH_SLOTS = 2
+NUM_LAYERS = 2
+# Two ranges, so `_resolve_chunk_rows` has to agree with itself across specs.
+SPECS = {
+    moonep_weights.W13_WEIGHT: ((8, 16), torch.uint8),
+    moonep_weights.W2_WEIGHT: ((4, 32), torch.uint8),
+}
+# num_layers * (num_local_experts + num_prefetch_slots), with the fake
+# allocator's granularity of one row.
+CHUNK_ROWS = 12
+
+
+def _fake_moonep(rotation=None):
+    """A MoonEP stand-in with only the surface the pool touches.
+
+    ``rotation`` overrides ``local_first_chunk_index`` so a test can present a
+    MoonEP whose mapping order is not the one ``expert_rows`` assumes.
+    """
+    moonep = types.ModuleType("moonep")
+    buffer = types.ModuleType("moonep.buffer")
+    prefetch = types.ModuleType("moonep.prefetch")
+
+    def create_nvl_dist_tensor(
+        chunk_shape, dtype, local_rank, world_size, group=None, local_first=False
+    ):
+        return torch.zeros(world_size * chunk_shape[0], *chunk_shape[1:], dtype=dtype)
+
+    buffer.local_first_chunk_index = rotation or (
+        lambda owner_rank, local_rank, world_size: (owner_rank - local_rank)
+        % world_size
+    )
+    buffer.create_nvl_dist_tensor = create_nvl_dist_tensor
+    buffer.pad_dim0_for_alignment = lambda shape, dtype: 1
+    prefetch.prefetch_retile_nbytes = lambda nbytes: -(-nbytes // 128) * 128
+
+    moonep.buffer = buffer
+    moonep.prefetch = prefetch
+    return {"moonep": moonep, "moonep.buffer": buffer, "moonep.prefetch": prefetch}
+
+
+class TestMoonEPPoolRows(CustomTestCase):
+    def setUp(self):
+        with patch.dict(sys.modules, _fake_moonep()):
+            self.pool = MoonEPWeightPool(
+                num_layers=NUM_LAYERS,
+                num_local_experts=NUM_LOCAL_EXPERTS,
+                num_prefetch_slots=NUM_PREFETCH_SLOTS,
+                ep_rank=EP_RANK,
+                ep_size=EP_SIZE,
+                group=None,
+                specs=SPECS,
+            )
+        moonep_weights._pool = self.pool
+
+    def tearDown(self):
+        moonep_weights._pool = None
+
+    def test_chunk_rows_cover_every_layer_block(self):
+        self.assertEqual(self.pool.chunk_rows, CHUNK_ROWS)
+
+    def test_expert_rows_place_each_owner_in_its_rotated_chunk(self):
+        # Rank 1's own experts are 4..7 and sit at the base of the mapping;
+        # rank 0's chunk is last, because local-first rotates by the rank.
+        rows = moonep_weights.expert_rows(
+            layer_id=7, expert_ids=torch.tensor([4, 5, 0, 8, 12])
+        )
+        self.assertEqual(
+            rows.tolist(),
+            [0, 1, 3 * CHUNK_ROWS, 1 * CHUNK_ROWS, 2 * CHUNK_ROWS],
+        )
+        self.assertEqual(rows.dtype, torch.int32)
+
+    def test_row_mapping_and_loader_views_agree_on_every_owner(self):
+        # `chunk_start` is what the loader writes through and `expert_rows` is
+        # what the GEMM reads through; if the two ever disagreed the weights
+        # would be loaded into one chunk and read out of another.
+        first_expert = torch.tensor(
+            [owner * NUM_LOCAL_EXPERTS for owner in range(EP_SIZE)]
+        )
+        rows = moonep_weights.expert_rows(layer_id=7, expert_ids=first_expert)
+        self.assertEqual(
+            rows.tolist(),
+            [self.pool.chunk_start(owner) for owner in range(EP_SIZE)],
+        )
+
+    def test_expert_rows_pass_negative_ids_through(self):
+        rows = moonep_weights.expert_rows(
+            layer_id=7, expert_ids=torch.tensor([-1, 4, -1])
+        )
+        self.assertEqual(rows.tolist(), [-1, 0, -1])
+
+    def test_expert_rows_offset_by_the_layers_block(self):
+        # Layers are numbered by the order they ask for storage, not by id.
+        first = moonep_weights.expert_rows(layer_id=7, expert_ids=torch.tensor([4]))
+        second = moonep_weights.expert_rows(layer_id=9, expert_ids=torch.tensor([4]))
+        block = NUM_LOCAL_EXPERTS + NUM_PREFETCH_SLOTS
+        self.assertEqual(first.tolist(), [0])
+        self.assertEqual(second.tolist(), [block])
+
+    def test_pool_refuses_more_layers_than_it_was_sized_for(self):
+        for layer_id in range(NUM_LAYERS):
+            self.pool.layer_offset(layer_id)
+        with self.assertRaisesRegex(RuntimeError, "sized for 2 layers"):
+            self.pool.layer_offset(NUM_LAYERS)
+
+    def test_rejects_a_moonep_whose_rotation_expert_rows_does_not_assume(self):
+        # `expert_rows` runs the rotation in closed form, 92 layers x 2 calls
+        # per decode step; a table gather measured 1.3% of the step at K3/EP16.
+        # The price of the closed form is that MoonEP changing the rule has to
+        # be a startup error, which is what this pins.
+        with patch.dict(
+            sys.modules,
+            _fake_moonep(
+                rotation=lambda owner_rank, local_rank, world_size: (
+                    local_rank - owner_rank
+                )
+                % world_size
+            ),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "local-first rotation"):
+                MoonEPWeightPool(
+                    num_layers=NUM_LAYERS,
+                    num_local_experts=NUM_LOCAL_EXPERTS,
+                    num_prefetch_slots=NUM_PREFETCH_SLOTS,
+                    ep_rank=EP_RANK,
+                    ep_size=EP_SIZE,
+                    group=None,
+                    specs=SPECS,
+                )
+
+    def test_rejects_a_shape_the_prefetch_copy_cannot_tile(self):
+        # The message has to name the range, not just a byte count: MoonEP's
+        # own assert fires on the first forward and says neither.
+        with patch.dict(sys.modules, _fake_moonep()):
+            with self.assertRaisesRegex(ValueError, "w2_weight.*multiple of 128"):
+                MoonEPWeightPool(
+                    num_layers=NUM_LAYERS,
+                    num_local_experts=NUM_LOCAL_EXPERTS,
+                    num_prefetch_slots=NUM_PREFETCH_SLOTS,
+                    ep_rank=EP_RANK,
+                    ep_size=EP_SIZE,
+                    group=None,
+                    specs={**SPECS, moonep_weights.W2_WEIGHT: ((4, 16), torch.uint8)},
+                )
+
+    def test_group_rows_keep_home_groups_and_remap_the_prefetch_tail(self):
+        num_global_experts = EP_SIZE * NUM_LOCAL_EXPERTS
+        # The tail names the *source* expert of each copy; the tokens have to
+        # read the local slot the copy landed in, not the source.
+        expert_ids = torch.cat(
+            [torch.arange(num_global_experts), torch.tensor([12, -1])]
+        )
+        rows = moonep_weights.group_rows(7, expert_ids, num_global_experts)
+
+        home = moonep_weights.expert_rows(7, torch.arange(num_global_experts))
+        self.assertEqual(rows[:num_global_experts].tolist(), home.tolist())
+        # slot_base = this rank's chunk + this layer's block + its own experts.
+        self.assertEqual(rows[num_global_experts].item(), NUM_LOCAL_EXPERTS)
+        self.assertEqual(rows[num_global_experts + 1].item(), -1)
+
+
+class TestMoonEPMIndices(CustomTestCase):
+    def test_empty_groups_are_skipped_and_the_tail_is_minus_one(self):
+        # Group 0 owns rows 0-1, groups 1 and 2 are empty, group 3 owns 2-4.
+        # Rows 5-6 are MoonEP's static padding past the last segment.
+        m = _moonep_m_indices(
+            cu_seqlens=torch.tensor([2, 2, 2, 5]),
+            expert_ids=torch.tensor([5, 9, 11, 3]),
+            all_tokens=7,
+        )
+        self.assertEqual(m.tolist(), [5, 5, 3, 3, 3, -1, -1])
+        self.assertEqual(m.dtype, torch.int32)
+
+    def test_rows_take_the_expert_id_not_the_group_index(self):
+        m = _moonep_m_indices(
+            cu_seqlens=torch.tensor([1, 2]),
+            expert_ids=torch.tensor([40, 41]),
+            all_tokens=2,
+        )
+        self.assertEqual(m.tolist(), [40, 41])
+
+    def test_unfilled_prefetch_slots_stay_minus_one(self):
+        m = _moonep_m_indices(
+            cu_seqlens=torch.tensor([2, 4]),
+            expert_ids=torch.tensor([5, -1]),
+            all_tokens=5,
+        )
+        self.assertEqual(m.tolist(), [5, 5, -1, -1, -1])
+
+
+class TestMoonEPLayerCount(CustomTestCase):
+    def _count(self, *, pp_rank=0, pp_size=1, hf_text_config=None):
+        model_config = SimpleNamespace(
+            num_hidden_layers=8,
+            first_k_dense_replace=2,
+            hf_text_config=hf_text_config or SimpleNamespace(),
+        )
+        with (
+            patch(
+                "sglang.srt.runtime_context.process_model_config",
+                return_value=model_config,
+            ),
+            patch(
+                "sglang.srt.distributed.get_pp_group",
+                return_value=SimpleNamespace(rank_in_group=pp_rank, world_size=pp_size),
+            ),
+        ):
+            return _num_moe_layers()
+
+    def test_counts_layers_after_the_dense_prefix(self):
+        self.assertEqual(self._count(), 6)
+
+    def test_counts_only_this_pipeline_stage(self):
+        # Layers 0-3 on stage 0, of which 2 and 3 are MoE; 4-7 on stage 1.
+        self.assertEqual(self._count(pp_rank=0, pp_size=2), 2)
+        self.assertEqual(self._count(pp_rank=1, pp_size=2), 4)
+
+    def test_refuses_a_model_whose_moe_layers_are_strided(self):
+        with self.assertRaisesRegex(NotImplementedError, "moe_layer_freq"):
+            self._count(hf_text_config=SimpleNamespace(moe_layer_freq=2))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -25,6 +25,7 @@ from sglang.srt.model_executor.cuda_graph_config import (
     CudaGraphConfig,
     Phase,
     PhaseConfig,
+    default_cuda_graph_config,
 )
 from sglang.srt.server_args import PortArgs, ServerArgs, prepare_server_args
 from sglang.srt.server_args_config_parser import ConfigArgumentMerger
@@ -1507,6 +1508,7 @@ class TestMoonEPArgs(CustomTestCase):
             moe_a2a_backend="moonep",
         )
 
+        server_args.cuda_graph_config = default_cuda_graph_config()
         server_args._handle_a2a_moe()
 
         from sglang.srt.arg_groups.overrides import resolved_view
@@ -1514,7 +1516,9 @@ class TestMoonEPArgs(CustomTestCase):
         self.assertEqual(resolved_view(server_args).moe_a2a_backend, "moonep")
         self.assertEqual(resolved_view(server_args).ep_size, server_args.tp_size)
         self.assertEqual(server_args.cuda_graph_config.decode.backend, Backend.DISABLED)
-        self.assertEqual(server_args.cuda_graph_config.prefill.backend, Backend.DISABLED)
+        self.assertEqual(
+            server_args.cuda_graph_config.prefill.backend, Backend.DISABLED
+        )
 
 
 class TestPrefillOnlyDisableKvCache(unittest.TestCase):


### PR DESCRIPTION
Stacked on [#33249](https://github.com/sgl-project/sglang/pull/33249), this PR adds initial support for MoonEP a2a backend and DeepGemm runner for MXFP4 experts K3. 
Please review the following commits:

- [Integrate with MoonEP and MXFP4 experts on the DeepGEMM runner](https://github.com/sgl-project/sglang/commit/f2d79903cf537be975383be97f2e4da91c4264ff)

Current implementation depends on MoonEP [update prefetch api and support rotating local to first](https://github.com/MoonshotAI/MoonEP/pull/32 ).

## Validation
Validated end to end on Kimi-K3, 4x GB200, TP16/EP16, MXFP4 weights. 
gsm8k test:
```
python -m sglang.test.run_eval --eval-name gsm8k --port 30000 --num-examples 500 --num-shots 5  --max-tokens 2048
Total latency: 643.858 s
Score: 0.986
Output throughput: 157.187 token/s
[METRIC] gsm8k_score=0.986 labels={"model": "Kimi-K3", "eval": "gsm8k"}
[METRIC] gsm8k_latency=643.8576721129939 labels={"model": "Kimi-K3", "eval": "gsm8k"}
```




<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33569351386](https://github.com/sgl-project/sglang/actions/runs/33569351386)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33569351091](https://github.com/sgl-project/sglang/actions/runs/33569351091)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33569351178](https://github.com/sgl-project/sglang/actions/runs/33569351178)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->