### PR TITLE
O(1) slot allocation in DecodeReqToTokenPool.alloc()

### DIFF
--- a/benchmark/scheduler/bench_decode_req_pool_alloc.py
+++ b/benchmark/scheduler/bench_decode_req_pool_alloc.py
@@ -1,0 +1,120 @@
+"""Benchmark DecodeReqToTokenPool.alloc(): head-pop vs tail-pop free_slots.
+
+Companion to the ReqToTokenPool.alloc() fix (python/sglang/srt/mem_cache/memory_pool.py):
+DecodeReqToTokenPool.alloc() (python/sglang/srt/disaggregation/decode.py) has
+the identical free_slots bookkeeping shape, used on the PD decode side to hand
+out pre-allocated + transferring + running request slots. This compares the
+old head-slicing implementation (`free_slots[:n]` / `free_slots[n:]`, O(len(free_slots)))
+against the current tail-pop implementation (O(need_size)) across a sweep of
+pool sizes and free-slot ratios, independent of batch size.
+
+Usage:
+    python benchmark/scheduler/bench_decode_req_pool_alloc.py
+"""
+
+from __future__ import annotations
+
+import time
+from statistics import mean, quantiles
+
+from sglang.srt.disaggregation.decode import DecodeReqToTokenPool
+
+
+class _FakeReq:
+    def __init__(self):
+        self.req_pool_idx = None
+        self.inflight_middle_chunks = 0
+        self.kv_committed_len = 0
+
+
+def _alloc_head_pop(pool: DecodeReqToTokenPool, need_size: int):
+    """Pre-fix behavior: O(len(free_slots)) regardless of need_size."""
+    select_index = pool.free_slots[:need_size]
+    pool.free_slots = pool.free_slots[need_size:]
+    return select_index
+
+
+def _alloc_tail_pop(pool: DecodeReqToTokenPool, need_size: int):
+    """Current behavior: O(need_size)."""
+    if need_size == 0:
+        return []
+    select_index = pool.free_slots[-need_size:]
+    del pool.free_slots[-need_size:]
+    return select_index
+
+
+def _make_pool(pool_size: int, n_free: int) -> DecodeReqToTokenPool:
+    pool = DecodeReqToTokenPool(
+        size=pool_size,
+        max_context_len=8,
+        device="cpu",
+        enable_memory_saver=False,
+        pre_alloc_size=0,
+    )
+    # free_slots is 1..pool_size; trim to leave exactly n_free free.
+    pool.free_slots = pool.free_slots[:n_free]
+    return pool
+
+
+def _time_alloc_calls(
+    alloc_fn, pool_size: int, n_free: int, batch: int, iterations: int
+) -> list[float]:
+    """Time `iterations` calls to alloc_fn, each on a freshly reset pool
+    with exactly n_free free slots, allocating `batch` slots. Returns
+    per-call latencies in nanoseconds.
+    """
+    latencies = []
+    for _ in range(iterations):
+        pool = _make_pool(pool_size, n_free)
+        t0 = time.perf_counter_ns()
+        alloc_fn(pool, batch)
+        latencies.append(time.perf_counter_ns() - t0)
+    return latencies
+
+
+def _stats(latencies_ns: list[float]) -> tuple[float, float, float]:
+    qs = quantiles(latencies_ns, n=100)
+    return mean(latencies_ns), qs[49], qs[98]
+
+
+def main() -> None:
+    pool_sizes = (256, 1024, 4096, 16384)
+    free_ratios = (0.1, 0.5, 0.9)
+    batches = (1, 4)
+    iterations = 2000
+
+    header = (
+        f"{'cell':<38s}{'old mean':>10s}{'old p50':>10s}{'old p99':>10s}"
+        f"{'new mean':>12s}{'new p50':>10s}{'new p99':>10s}{'speedup':>10s}"
+    )
+    print(header)
+    print("-" * len(header))
+
+    for pool_size in pool_sizes:
+        for ratio in free_ratios:
+            n_free = int(pool_size * ratio)
+            if n_free == 0:
+                continue
+            for batch in batches:
+                if batch > n_free:
+                    continue
+                old = _stats(
+                    _time_alloc_calls(
+                        _alloc_head_pop, pool_size, n_free, batch, iterations
+                    )
+                )
+                new = _stats(
+                    _time_alloc_calls(
+                        _alloc_tail_pop, pool_size, n_free, batch, iterations
+                    )
+                )
+                cell = f"pool={pool_size} free={n_free} batch={batch}"
+                speedup = old[0] / new[0] if new[0] > 0 else float("inf")
+                print(
+                    f"{cell:<38s}{old[0]:>10.0f}{old[1]:>10.0f}{old[2]:>10.0f}"
+                    f"{new[0]:>12.0f}{new[1]:>10.0f}{new[2]:>10.0f}{speedup:>9.1f}x"
+                )
+
+
+if __name__ == "__main__":
+    main()

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -173,8 +173,11 @@ class DecodeReqToTokenPool:
         need_size = len(reqs) - len(reusing)
         if need_size > len(self.free_slots):
             return None
-        select_index = self.free_slots[:need_size]
-        self.free_slots = self.free_slots[need_size:]
+        if need_size == 0:
+            select_index = []
+        else:
+            select_index = self.free_slots[-need_size:]
+            del self.free_slots[-need_size:]
         offset = 0
         for r in reqs:
             if r.req_pool_idx is None:

--- a/test/registered/unit/disaggregation/test_decode_req_to_token_pool_alloc.py
+++ b/test/registered/unit/disaggregation/test_decode_req_to_token_pool_alloc.py
@@ -1,0 +1,89 @@
+"""Unit tests for srt/disaggregation/decode.py — DecodeReqToTokenPool.alloc().
+
+Companion to test/registered/unit/mem_cache/test_req_to_token_pool_alloc.py:
+DecodeReqToTokenPool.alloc() had the same free_slots head-slicing pattern as
+ReqToTokenPool.alloc() (see python/sglang/srt/mem_cache/memory_pool.py), fixed
+by popping from the tail instead.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+import unittest
+
+from sglang.srt.disaggregation.decode import DecodeReqToTokenPool
+from sglang.test.test_utils import CustomTestCase
+
+
+class _FakeReq:
+    """Only carries the fields DecodeReqToTokenPool.alloc() reads."""
+
+    def __init__(self, req_pool_idx=None, inflight_middle_chunks=0, kv_committed_len=0):
+        self.req_pool_idx = req_pool_idx
+        self.inflight_middle_chunks = inflight_middle_chunks
+        self.kv_committed_len = kv_committed_len
+
+
+def _make_pool(size=8, pre_alloc_size=0):
+    return DecodeReqToTokenPool(
+        size=size,
+        max_context_len=16,
+        device="cpu",
+        enable_memory_saver=False,
+        pre_alloc_size=pre_alloc_size,
+    )
+
+
+class TestDecodeReqToTokenPoolAlloc(CustomTestCase):
+    def test_alloc_exhausts_pool_then_returns_none(self):
+        pool = _make_pool(size=2, pre_alloc_size=0)
+        self.assertEqual(pool.available_size(), 2)
+
+        reqs = [_FakeReq(), _FakeReq()]
+        indices = pool.alloc(reqs)
+        self.assertEqual(len(indices), 2)
+        self.assertEqual(pool.available_size(), 0)
+
+        self.assertIsNone(pool.alloc([_FakeReq()]))
+
+    def test_alloc_free_alloc_roundtrip_no_duplicates(self):
+        pool = _make_pool(size=8, pre_alloc_size=0)
+
+        reqs = [_FakeReq() for _ in range(5)]
+        indices = pool.alloc(reqs)
+        self.assertEqual(len(indices), len(set(indices)))
+        self.assertEqual(pool.available_size(), 3)
+
+        for r in reqs:
+            pool.free(r)
+        self.assertEqual(pool.available_size(), 8)
+
+        # Every slot must be reusable and still yield no duplicates.
+        reqs2 = [_FakeReq() for _ in range(8)]
+        indices2 = pool.alloc(reqs2)
+        self.assertEqual(len(indices2), len(set(indices2)))
+        self.assertEqual(pool.available_size(), 0)
+
+    def test_alloc_with_all_reqs_reusing_is_noop_on_free_slots(self):
+        """Regression test for the `free_slots[-0:]` slicing footgun.
+
+        A naive tail-pop fix (`select_index = free_slots[-need_size:]` without
+        special-casing need_size == 0) silently drains the entire free pool
+        whenever every request in the batch is reusing its existing
+        req_pool_idx (e.g. a chunked-prefill continuation batch), because
+        `-0 == 0` and `list[-0:]` is the whole list, not `[]`.
+        """
+        pool = _make_pool(size=4, pre_alloc_size=0)
+        self.assertEqual(pool.available_size(), 4)
+
+        reusing_req = _FakeReq(req_pool_idx=1, inflight_middle_chunks=1)
+        indices = pool.alloc([reusing_req])
+
+        self.assertEqual(indices, [1])
+        self.assertEqual(pool.available_size(), 4)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`DecodeReqToTokenPool.alloc()` (`python/sglang/srt/disaggregation/decode.py`) has the same free-slot bookkeeping shape as `ReqToTokenPool.alloc()` (fixed in [#32208](https://github.com/sgl-project/sglang/pull/32208)), and the same drawback: it selects free request-slots from the **head** of `self.free_slots` and rebuilds the list from the remainder (`self.free_slots = self.free_slots[need_size:]`). CPython slicing always allocates a new list and copies the surviving `PyObject*` pointers, so this line is O(len(free_slots)) — proportional to how many free slots *remain*, not to how many are being allocated (`need_size`).

This pool is decode-side-specific to PD disaggregation: unlike plain `ReqToTokenPool`, it also carries slots for requests that are pre-allocated or mid-transfer from the prefill side (`_alloc_size = size + pre_alloc_size + 1`), so at steady state under high concurrency `free_slots` is not just pool-sized but *larger* than the running-request cap, and stays long precisely in the regime PD disaggregation is meant to help (high concurrency headroom, trickle admission per scheduler step). `alloc()` runs once per scheduler step that admits new decode-side requests, on the single-threaded scheduler process that gates GPU dispatch — so this is wasted allocation-dominated CPU cost on every scheduler iteration, worse than the non-PD case because `pre_alloc_size` inflates the pool further. `free()` is already O(1) amortized (`self.free_slots.append(...)`) and is unaffected.

## Modifications

- Pop from the **tail** of `free_slots` instead of the head (`select_index = self.free_slots[-need_size:]; del self.free_slots[-need_size:]`), which only touches the `need_size` removed elements — O(need_size) instead of O(len(free_slots)).
- Allocation order has no semantic meaning (`req_pool_idx` is an opaque row index into `req_to_token`/`req_generation`; `req_generation` already tracks reuse separately), so this is a pure performance change, not a behavior change.
- Added an explicit `need_size == 0` guard: `free_slots[-0:]` is the *entire* list, not `[]` (`-0 == 0`), so the naive tail-pop would silently drain/return the whole free pool whenever every request in a batch is reusing its slot (e.g. a chunked-prefill continuation batch on the decode side). The guard makes `select_index = []` in that case — same footgun and same fix as `ReqToTokenPool.alloc()`.
- No change to `free()`, `available_size()`, `clear()`, `write()`, or the public `free_slots` attribute's type/semantics.
- Scoped to `DecodeReqToTokenPool` only. It does not subclass `ReqToTokenPool` (it duplicates `alloc`/`free`/`clear` because of the pre-allocation semantics described above), so the `#32208` fix did not already cover it; `HybridMambaDecodeReqToTokenPool` inherits from `HybridReqToTokenPool` separately and is unaffected either way.

## Accuracy Tests

Not applicable. This is a pure Python-level bookkeeping change to which integer index is handed out from an interchangeable free-slot pool; it does not touch KV cache contents, tensor values, or model outputs.

## Speed Tests and Profiling

Added `benchmark/scheduler/bench_decode_req_pool_alloc.py`, comparing the old head-pop implementation against the new tail-pop `pool.alloc()` across a sweep of pool sizes (256–16384) and free-slot ratios (10%/50%/90%), independent of batch size.

Steady-state result (pool=16384, ~90% free / 14745 free slots, trickle admission batch of 1-4 — the regime a large `--max-running-requests` with PD pre-allocation headroom actually hits):

```
cell                            old mean   old p50   old p99    new mean   new p50   new p99   speedup
--------------------------------------------------------------------------------------------------------
pool=16384 free=14745 batch=1     28515     24625     56917         344       250      3707      82.9x
pool=16384 free=14745 batch=4     28746     24833     59412         335       250      3374      85.8x
```

Full sweep (256–16384, 10/50/90% free, batch 1 and 4) shows the same monotonic trend as the non-PD fix: speedup grows with pool size and free ratio (1.1x at pool=256/free=10% up to ~86x at pool=16384/free=90%), because the old cost is dominated by `len(free_slots)`, not `need_size`.

This is a scheduler-CPU-dispatch-overhead fix, not a GPU-kernel or network-transfer change, so no end-to-end `bench_serving.py` throughput/TTFT numbers are attached — the effect is real but only becomes visible relative to GPU compute / KV-transfer latency at very high concurrency on the decode side.

## Testing

Added `test/registered/unit/disaggregation/test_decode_req_to_token_pool_alloc.py`:

```
test_alloc_exhausts_pool_then_returns_none ... ok
test_alloc_free_alloc_roundtrip_no_duplicates ... ok
test_alloc_with_all_reqs_reusing_is_noop_on_free_slots ... ok

Ran 3 tests in 0.006s

OK
```

`test_alloc_with_all_reqs_reusing_is_noop_on_free_slots` is the regression test for the `-0` slicing footgun — confirmed it fails (`available_size()` incorrectly drops from 4 to 0) against a naive tail-pop fix without the `need_size == 0` guard, and passes against the real fix. Confirmed all three tests pass unmodified against the pre-fix head-pop implementation too (it was correct, just slow), so the suite is purely a behavior-preservation + footgun guard, not a change-detector for the performance fix itself.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31834880961](https://github.com/sgl-project/sglang/actions/runs/31834880961)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31834880676](https://github.com/sgl-project/sglang/actions/runs/31834880676)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->