### PR TITLE
[AMD CI] follow the miles nightly-prefixed MI350 suite names

### DIFF
--- a/.github/workflows/nightly-test-amd-miles-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-miles-rocm720.yml
@@ -80,7 +80,7 @@ jobs:
           GITHUB_WORKSPACE: ${{ github.workspace }}
 
       - name: Run miles CI suite ${{ matrix.suite }}
-        timeout-minutes: 360
+        timeout-minutes: 240
         run: |
           touch "${GITHUB_WORKSPACE}/github_summary.md"
           TEST_EXIT_CODE=0

--- a/.github/workflows/nightly-test-amd-miles-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-miles-rocm720.yml
@@ -28,12 +28,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - suite: nightly-stage-c-2-gpu-mi350
+          - suite: nightly-stage-c-2-gpu
             runner: linux-mi35x-gpu-2
           # Use 8-GPU MI35X pool for 4-GPU suite.
-          - suite: nightly-stage-c-4-gpu-mi350
+          - suite: nightly-stage-c-4-gpu
             runner: linux-mi35x-gpu-8
-          - suite: nightly-stage-c-8-gpu-mi350
+          - suite: nightly-stage-c-8-gpu
             runner: linux-mi35x-gpu-8
     runs-on: ${{ matrix.runner }}
     steps:

--- a/.github/workflows/nightly-test-amd-miles-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-miles-rocm720.yml
@@ -80,7 +80,7 @@ jobs:
           GITHUB_WORKSPACE: ${{ github.workspace }}
 
       - name: Run miles CI suite ${{ matrix.suite }}
-        timeout-minutes: 120
+        timeout-minutes: 360
         run: |
           touch "${GITHUB_WORKSPACE}/github_summary.md"
           TEST_EXIT_CODE=0

--- a/.github/workflows/nightly-test-amd-miles-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-miles-rocm720.yml
@@ -80,14 +80,14 @@ jobs:
           GITHUB_WORKSPACE: ${{ github.workspace }}
 
       - name: Run miles CI suite ${{ matrix.suite }}
-        timeout-minutes: 240
+        timeout-minutes: 180
         run: |
           touch "${GITHUB_WORKSPACE}/github_summary.md"
           TEST_EXIT_CODE=0
           bash scripts/ci/amd/amd_ci_exec.sh -w /root/miles \
             -e PYTHONPATH=/root/miles:/opt/tilelang \
             -e GITHUB_STEP_SUMMARY=/sglang-checkout/github_summary.md \
-            python3 tests/ci/run_suite.py --hw rocm --suite ${{ matrix.suite }} --match-all-labels \
+            python3 tests/ci/run_suite.py --hw rocm --suite ${{ matrix.suite }} --cadence nightly \
             ${{ (github.event_name != 'workflow_dispatch' || inputs.continue_on_error) && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
           cat "${GITHUB_WORKSPACE}/github_summary.md" >> "$GITHUB_STEP_SUMMARY" || true
           exit ${TEST_EXIT_CODE}

--- a/.github/workflows/nightly-test-amd-miles-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-miles-rocm720.yml
@@ -28,12 +28,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - suite: nightly-stage-c-2-gpu
+          - suite: nightly-stage-c-2-gpu-mi350
             runner: linux-mi35x-gpu-2
           # Use 8-GPU MI35X pool for 4-GPU suite.
-          - suite: nightly-stage-c-4-gpu
+          - suite: nightly-stage-c-4-gpu-mi350
             runner: linux-mi35x-gpu-8
-          - suite: nightly-stage-c-8-gpu
+          - suite: nightly-stage-c-8-gpu-mi350
             runner: linux-mi35x-gpu-8
     runs-on: ${{ matrix.runner }}
     steps:

--- a/.github/workflows/nightly-test-amd-miles-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-miles-rocm720.yml
@@ -28,12 +28,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - suite: stage-c-2-gpu-mi350
+          - suite: nightly-stage-c-2-gpu-mi350
             runner: linux-mi35x-gpu-2
           # Use 8-GPU MI35X pool for 4-GPU suite.
-          - suite: stage-c-4-gpu-mi350
+          - suite: nightly-stage-c-4-gpu-mi350
             runner: linux-mi35x-gpu-8
-          - suite: stage-c-8-gpu-mi350
+          - suite: nightly-stage-c-8-gpu-mi350
             runner: linux-mi35x-gpu-8
     runs-on: ${{ matrix.runner }}
     steps:


### PR DESCRIPTION
Miles now uses separate suite names for nightly and per-commit ROCm CI. Update the SGLang nightly workflow to follow the new nightly-prefixed MI350 suite names:

* `stage-c-2-gpu-mi350` → `nightly-stage-c-2-gpu-mi350`
* `stage-c-4-gpu-mi350` → `nightly-stage-c-4-gpu-mi350`
* `stage-c-8-gpu-mi350` → `nightly-stage-c-8-gpu-mi350`

The per-commit `stage-c-4-gpu-mi350` suite remains unchanged and continues to run through the Miles `pr-test-rocm.yml` workflow.

Depends on radixark/miles#2480. The new suite names will be available after the next Miles image build.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31851930058](https://github.com/sgl-project/sglang/actions/runs/31851930058)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31851929904](https://github.com/sgl-project/sglang/actions/runs/31851929904)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->