### PR TITLE
[SM12x] b12x MXFP4 MoE: align with vLLM's pin, share the arena, run W4A8

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1525,6 +1525,21 @@ class Envs:
     # Most batched requests one /generate HTTP call may expand into.
     SGLANG_MAX_BATCH_REQS_PER_HTTP_REQ = EnvInt(4096)
 
+    # ==================================================================
+    # b12x MoE runner backend (SM12x / GB10)
+    # ==================================================================
+    # Upper bound on tokens in one b12x MoE call, used to size its scratch
+    # workspace at load time. Track --chunked-prefill-size if that is raised.
+    SGLANG_B12X_MAX_TOKENS = EnvInt(4096)
+    # Drop b12x's one-CTA-per-SM pin for moe_block_size==8. Measured a 4.4%
+    # regression on GB10, so off: the pin suits the kernel it ships with.
+    SGLANG_B12X_RELAX_BLOCKS_PER_SM = EnvBool(False)
+    # Directory to import b12x from, ahead of the pip-installed one. Set this to
+    # a 0.15.3 checkout: its W4A16 kernel takes weights as tensors with static
+    # strides, where 1.2.2 passes raw pointers and rebuilds layouts at runtime.
+    # Measured 707.9 vs 875.6 us/call on DSv4-Flash decode, bit-identical output.
+    SGLANG_B12X_PATH = EnvStr("")
+
 
 envs = Envs()
 EnvField._allow_set_name = False

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1531,13 +1531,9 @@ class Envs:
     # Upper bound on tokens in one b12x MoE call, used to size its scratch
     # workspace at load time. Track --chunked-prefill-size if that is raised.
     SGLANG_B12X_MAX_TOKENS = EnvInt(4096)
-    # Drop b12x's one-CTA-per-SM pin for moe_block_size==8. Measured a 4.4%
-    # regression on GB10, so off: the pin suits the kernel it ships with.
-    SGLANG_B12X_RELAX_BLOCKS_PER_SM = EnvBool(False)
-    # Directory to import b12x from, ahead of the pip-installed one. Set this to
-    # a 0.15.3 checkout: its W4A16 kernel takes weights as tensors with static
-    # strides, where 1.2.2 passes raw pointers and rebuilds layouts at runtime.
-    # Measured 707.9 vs 875.6 us/call on DSv4-Flash decode, bit-identical output.
+    # Directory to import b12x from, ahead of the pip-installed one -- for
+    # deployments that carry the 0.15.3 tree as a directory instead of
+    # pip-installing the pinned source commit (see mxfp4_b12x_moe.py).
     SGLANG_B12X_PATH = EnvStr("")
 
 

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1531,10 +1531,6 @@ class Envs:
     # Upper bound on tokens in one b12x MoE call, used to size its scratch
     # workspace at load time. Track --chunked-prefill-size if that is raised.
     SGLANG_B12X_MAX_TOKENS = EnvInt(4096)
-    # Directory to import b12x from, ahead of the pip-installed one -- for
-    # deployments that carry the 0.15.3 tree as a directory instead of
-    # pip-installing the pinned source commit (see mxfp4_b12x_moe.py).
-    SGLANG_B12X_PATH = EnvStr("")
 
 
 envs = Envs()

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1531,6 +1531,13 @@ class Envs:
     # Upper bound on tokens in one b12x MoE call, used to size its scratch
     # workspace at load time. Track --chunked-prefill-size if that is raised.
     SGLANG_B12X_MAX_TOKENS = EnvInt(4096)
+    # b12x quant mode for the MoE, passed through verbatim. "w4a8_mx"
+    # quantizes activations to MXFP8-E4M3 in-kernel and is the recipe the
+    # official vLLM DGX Spark image runs (its recipe sets B12X_MOE_FORCE_A8=1);
+    # all of b12x's GB10 MoE tuning lives on that path. "w4a16" restores the
+    # bf16-activation frozen-plan path. Modes have different numerics --
+    # validate accuracy when changing this.
+    SGLANG_B12X_MOE_QUANT_MODE = EnvStr("w4a8_mx")
     # Compile the b12x kernels for every planned token count at load time,
     # before any CUDA graph capture. Off only defers the cost: captured decode
     # shapes are still compiled by the graph runner's pre-capture warmup runs,

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1543,8 +1543,8 @@ class Envs:
     # shapes are still compiled by the graph runner's pre-capture warmup runs,
     # and the prefill ladder then JIT-compiles on the first real chunks
     # (~80 s cold on DSv4-Flash).
-    SGLANG_B12X_WARMUP = EnvBool(True)
-    # b12x compile-cache directory, forwarded to B12X_CUTE_COMPILE_CACHE_DIR.
+    SGLANG_B12X_ENABLE_WARMUP = EnvBool(True)
+    # b12x compile-cache directory, forwarded to B12X_COMPILE_CACHE_DIR.
     # Resolved lazily so it tracks SGLANG_CACHE_DIR, which is defined below.
     SGLANG_B12X_CACHE_DIR = EnvStr(lambda: _default_cache_subdir("b12x"))
 

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1531,6 +1531,15 @@ class Envs:
     # Upper bound on tokens in one b12x MoE call, used to size its scratch
     # workspace at load time. Track --chunked-prefill-size if that is raised.
     SGLANG_B12X_MAX_TOKENS = EnvInt(4096)
+    # Compile the b12x kernels for every planned token count at load time,
+    # before any CUDA graph capture. Off only defers the cost: captured decode
+    # shapes are still compiled by the graph runner's pre-capture warmup runs,
+    # and the prefill ladder then JIT-compiles on the first real chunks
+    # (~80 s cold on DSv4-Flash).
+    SGLANG_B12X_WARMUP = EnvBool(True)
+    # b12x compile-cache directory, forwarded to B12X_CUTE_COMPILE_CACHE_DIR.
+    # Resolved lazily so it tracks SGLANG_CACHE_DIR, which is defined below.
+    SGLANG_B12X_CACHE_DIR = EnvStr(lambda: _default_cache_subdir("b12x"))
 
 
 envs = Envs()

--- a/python/sglang/srt/layers/moe/moe_runner/b12x.py
+++ b/python/sglang/srt/layers/moe/moe_runner/b12x.py
@@ -1,0 +1,127 @@
+"""b12x W4A16 fused MoE for SM120/SM121.
+
+The FlashInfer CUTLASS MXFP4 path splits one expert layer into seven launches:
+build-expert-maps, expand-input-rows, compute-strides, FC1, activation, FC2 and
+finalize. b12x fuses FC1, the gated activation and FC2 into a single kernel and
+gathers the routed rows by index instead of materializing a permuted copy, so a
+layer costs one launch instead of seven. It is also W4A16 rather than W4A8:
+activations stay bf16 instead of being quantized to MXFP8.
+
+Weights are prepared once at load time (see ``Mxfp4B12xMoEMethod``) and the
+scratch buffer is planned there too, so this module only binds views -- which is
+what makes it safe to capture in a CUDA graph.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+from sglang.srt.distributed import get_tp_group
+from sglang.srt.distributed.device_communicators.pynccl_allocator import (
+    use_symmetric_memory,
+)
+from sglang.srt.layers.dp_attention import is_allocation_symmetric
+from sglang.srt.layers.moe.moe_runner.base import (
+    MoeQuantInfo,
+    MoeRunnerConfig,
+    register_fused_func,
+)
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.moe.token_dispatcher.standard import (
+        StandardCombineInput,
+        StandardDispatchOutput,
+    )
+
+
+@dataclass
+class B12xMoeQuantInfo(MoeQuantInfo):
+    """Payload for the b12x W4A16 fused MoE.
+
+    ``experts`` owns the only copy of the expert weights: the checkpoint tensors
+    are released once it is built, so this dataclass carries none of its own.
+    """
+
+    # b12x expert-weight package, built at load time.
+    experts: Any
+    # b12x scratch plan, planned at load time.
+    plan: Any
+    # Caller-owned scratch, allocated at load time so it never lands in a CUDA
+    # graph's private memory pool.
+    scratch: torch.Tensor
+    # Set when the quant method already bound everything it needs; the two b12x
+    # generations take different arguments, so the version-specific call lives
+    # there rather than here.
+    launch: Any = None
+    # True only when expert parallelism is on: that is the only case where the
+    # dispatcher rewrites non-local experts (and padded rows) to -1, which b12x
+    # would otherwise run as garbage. At EP=1 the guard would cost five tiny
+    # kernels per layer for nothing -- torch.topk cannot produce negatives.
+    ep_guard: bool = False
+
+
+@register_fused_func("none", "b12x")
+def fused_experts_none_to_b12x(
+    dispatch_output: StandardDispatchOutput,
+    quant_info: MoeQuantInfo,
+    runner_config: MoeRunnerConfig,
+) -> StandardCombineInput:
+    """Run one expert layer through the b12x W4A16 fused kernel."""
+    from sglang.srt.layers.moe.token_dispatcher.standard import StandardCombineInput
+    from sglang.srt.layers.moe.topk import TopKOutputChecker
+
+    assert isinstance(
+        quant_info, B12xMoeQuantInfo
+    ), f"Unexpected quant_info type for b12x: {type(quant_info)}"
+    if runner_config.activation != "silu":
+        raise NotImplementedError(
+            f"b12x supports activation='silu', got {runner_config.activation!r}."
+        )
+    if runner_config.apply_router_weight_on_input:
+        raise NotImplementedError(
+            "b12x applies the router weights in the FC2 epilogue; "
+            "apply_router_weight_on_input is not supported."
+        )
+
+    x = dispatch_output.hidden_states
+    topk_output = dispatch_output.topk_output
+    if TopKOutputChecker.format_is_bypassed(topk_output):
+        topk_output = topk_output.to_standard()
+
+    with use_symmetric_memory(get_tp_group(), disabled=not is_allocation_symmetric()):
+        out = torch.empty(
+            x.shape[0], x.shape[-1], dtype=torch.bfloat16, device=x.device
+        )
+
+    # HashTopK already emits int32 ids and float32 weights, so these casts are
+    # free no-ops kept as a contract check for other topk implementations.
+    topk_ids = topk_output.topk_ids.to(torch.int32)
+    topk_weights = topk_output.topk_weights.to(torch.float32)
+    if quant_info.ep_guard:
+        # With EP the dispatcher rewrites non-local experts -- and padded rows --
+        # to -1. FlashInfer CUTLASS skips out-of-range ids; b12x instead runs
+        # them and writes ~1e4-per-element garbage into those rows.
+        invalid = topk_ids < 0
+        topk_ids = topk_ids.clamp_min(0)
+        topk_weights = topk_weights.masked_fill(invalid, 0.0)
+
+    if quant_info.launch is not None:
+        quant_info.launch(x, topk_ids, topk_weights, out)
+    else:
+        from b12x.moe import fused_moe
+
+        binding = fused_moe.bind(
+            quant_info.plan,
+            scratch=quant_info.scratch,
+            a=x,
+            experts=quant_info.experts,
+            topk_ids=topk_ids,
+            topk_weights=topk_weights,
+            output=out,
+        )
+        fused_moe.run(binding=binding)
+
+    return StandardCombineInput(hidden_states=out)

--- a/python/sglang/srt/layers/moe/moe_runner/b12x.py
+++ b/python/sglang/srt/layers/moe/moe_runner/b12x.py
@@ -50,8 +50,9 @@ class B12xMoeQuantInfo(MoeQuantInfo):
     # b12x scratch plan, planned at load time.
     plan: Any
     # Caller-owned scratch, allocated at load time so it never lands in a CUDA
-    # graph's private memory pool.
-    scratch: torch.Tensor
+    # graph's private memory pool. None on the 0.15.3 path, where everything
+    # lives in ``launch``.
+    scratch: torch.Tensor | None = None
     # Set when the quant method already bound everything it needs; the two b12x
     # generations take different arguments, so the version-specific call lives
     # there rather than here.

--- a/python/sglang/srt/layers/moe/moe_runner/b12x.py
+++ b/python/sglang/srt/layers/moe/moe_runner/b12x.py
@@ -41,22 +41,12 @@ if TYPE_CHECKING:
 class B12xMoeQuantInfo(MoeQuantInfo):
     """Payload for the b12x W4A16 fused MoE.
 
-    ``experts`` owns the only copy of the expert weights: the checkpoint tensors
-    are released once it is built, so this dataclass carries none of its own.
+    The quant method binds everything at load time (weights, scratch plan,
+    scratch arena); ``launch`` is the prepared bind-and-run closure, so this
+    dataclass carries no tensors of its own.
     """
 
-    # b12x expert-weight package, built at load time.
-    experts: Any
-    # b12x scratch plan, planned at load time.
-    plan: Any
-    # Caller-owned scratch, allocated at load time so it never lands in a CUDA
-    # graph's private memory pool. None on the 0.15.3 path, where everything
-    # lives in ``launch``.
-    scratch: torch.Tensor | None = None
-    # Set when the quant method already bound everything it needs; the two b12x
-    # generations take different arguments, so the version-specific call lives
-    # there rather than here.
-    launch: Any = None
+    launch: Any
     # True only when expert parallelism is on: that is the only case where the
     # dispatcher rewrites non-local experts (and padded rows) to -1, which b12x
     # would otherwise run as garbage. At EP=1 the guard would cost five tiny
@@ -109,20 +99,6 @@ def fused_experts_none_to_b12x(
         topk_ids = topk_ids.clamp_min(0)
         topk_weights = topk_weights.masked_fill(invalid, 0.0)
 
-    if quant_info.launch is not None:
-        quant_info.launch(x, topk_ids, topk_weights, out)
-    else:
-        from b12x.moe import fused_moe
-
-        binding = fused_moe.bind(
-            quant_info.plan,
-            scratch=quant_info.scratch,
-            a=x,
-            experts=quant_info.experts,
-            topk_ids=topk_ids,
-            topk_weights=topk_weights,
-            output=out,
-        )
-        fused_moe.run(binding=binding)
+    quant_info.launch(x, topk_ids, topk_weights, out)
 
     return StandardCombineInput(hidden_states=out)

--- a/python/sglang/srt/layers/moe/moe_runner/runner.py
+++ b/python/sglang/srt/layers/moe/moe_runner/runner.py
@@ -88,6 +88,8 @@ class MoeRunner:
             self.runner_core = None  # FlashInfer CUTLASS only supports fused path
         elif runner_backend.is_flashinfer_mxfp4():
             self.runner_core = None  # FlashInfer MXFP4 only supports fused path
+        elif runner_backend.is_b12x():
+            self.runner_core = None  # b12x only supports the fused path
             # Import flashinfer_cutlass here (not at module top, to avoid a circular
             # import) to register the flashinfer_mxfp4 fused func before the pool lookup.
             from sglang.srt.layers.moe.moe_runner import (  # noqa: F401

--- a/python/sglang/srt/layers/moe/moe_runner/runner.py
+++ b/python/sglang/srt/layers/moe/moe_runner/runner.py
@@ -88,13 +88,13 @@ class MoeRunner:
             self.runner_core = None  # FlashInfer CUTLASS only supports fused path
         elif runner_backend.is_flashinfer_mxfp4():
             self.runner_core = None  # FlashInfer MXFP4 only supports fused path
-        elif runner_backend.is_b12x():
-            self.runner_core = None  # b12x only supports the fused path
             # Import flashinfer_cutlass here (not at module top, to avoid a circular
             # import) to register the flashinfer_mxfp4 fused func before the pool lookup.
             from sglang.srt.layers.moe.moe_runner import (  # noqa: F401
                 flashinfer_cutlass,
             )
+        elif runner_backend.is_b12x():
+            self.runner_core = None  # b12x only supports the fused path
         elif runner_backend.is_cutlass():
             self.runner_core = None  # CUTLASS uses the direct cutlass_moe_fp4 path
         elif runner_backend.is_hpc_ops():

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -105,6 +105,7 @@ class MoeRunnerBackend(Enum):
     FLASHINFER_CUTLASS = "flashinfer_cutlass"
     FLASHINFER_MXFP4 = "flashinfer_mxfp4"
     FLASHINFER_CUTEDSL = "flashinfer_cutedsl"
+    B12X = "b12x"
     CUTLASS = "cutlass"
     MARLIN = "marlin"
     HUMMING = "humming"
@@ -152,6 +153,9 @@ class MoeRunnerBackend(Enum):
 
     def is_flashinfer_mxfp4(self):
         return self == MoeRunnerBackend.FLASHINFER_MXFP4
+
+    def is_b12x(self):
+        return self == MoeRunnerBackend.B12X
 
     def is_cutlass(self):
         return self == MoeRunnerBackend.CUTLASS

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -400,6 +400,13 @@ class Fp8Config(QuantizationConfig):
 
                 return Mxfp4HummingMoEMethod(fp8_method, prefix=prefix)
 
+            if self.is_fp4_experts and get_moe_runner_backend().is_b12x():
+                from sglang.srt.layers.quantization.mxfp4_b12x_moe import (
+                    Mxfp4B12xMoEMethod,
+                )
+
+                return Mxfp4B12xMoEMethod(fp8_method, prefix=prefix)
+
             if self.is_fp4_experts and get_moe_runner_backend().is_flashinfer_mxfp4():
                 # SM100 uses TRT-LLM; SM90 uses W4A16 and SM120 uses MXFP8xMXFP4.
                 if is_sm90_supported() or is_sm120_supported():

--- a/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
@@ -136,11 +136,10 @@ def _core_token_counts(max_tokens: int, tokens_per_seq: int) -> tuple[int, ...]:
     counts = set()
     batch_sizes = list(range(1, 33))
     try:
-        from sglang.srt.server_args import get_global_server_args
+        from sglang.srt.runtime_context import get_exec
 
-        decode = getattr(
-            getattr(get_global_server_args(), "cuda_graph_config", None), "decode", None
-        )
+        cg_config = get_exec().graph.cuda_graph_config
+        decode = cg_config.decode if cg_config is not None else None
         batch_sizes = list(getattr(decode, "bs", None) or batch_sizes)
     except Exception:
         # No server context (unit tests, offline use): the dense 1..32 ladder
@@ -515,12 +514,9 @@ class Mxfp4B12xMoEMethod:
         ones = torch.ones(num_experts, dtype=torch.float32, device=device)
 
         try:
-            from sglang.srt.server_args import get_global_server_args
+            from sglang.srt.runtime_context import get_spec
 
-            spec_tokens = int(
-                getattr(get_global_server_args(), "speculative_num_draft_tokens", None)
-                or 1
-            )
+            spec_tokens = int(get_spec().speculative_num_draft_tokens or 1)
         except Exception:
             spec_tokens = 1
 

--- a/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
@@ -1,0 +1,642 @@
+"""DeepSeek-V4 MXFP4 expert backend backed by the b12x W4A16 fused MoE.
+
+Same checkpoint as :mod:`mxfp4_flashinfer_cutlass_moe`, different runtime: one
+fused kernel per expert layer instead of seven, and bf16 activations instead of
+MXFP8.
+
+This uses the standalone ``b12x`` package rather than the copy vendored inside
+FlashInfer. Three things depend on that choice:
+
+* ``source_format="fp4_e8m0_k32"`` consumes the checkpoint's E8M0 K/32 block
+  scales byte for byte, so there is no scale relayout to get wrong.
+* ``swiglu_limit`` is honoured. DSv4-Flash asks for a SwiGLU clamp at 10.0 and
+  it binds on real data (gate magnitudes reach 10.1, and half the layers sit
+  within 7% of the limit), so dropping it is a correctness change, not a
+  rounding one.
+* Kernels are warmed before CUDA graph capture. b12x specializes on token
+  count only as ``size_m == 1`` vs everything else (``_m_specialization_key``
+  in its w4a16 kernel), so this is two compiles, not one per prompt length --
+  but it refuses to compile at all while a graph is being captured, which is
+  what the warm-up exists for.
+
+Install with ``pip install --no-deps b12x==1.2.2``; without ``--no-deps`` pip
+pulls a newer torch and breaks the rest of the image.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from typing import TYPE_CHECKING, Any
+
+import torch
+from torch.nn import Module
+from torch.nn.parameter import Parameter
+
+from sglang.srt.environ import envs
+from sglang.srt.utils import log_info_on_rank0
+from sglang.srt.utils.common import is_sm120_supported
+
+# Suppress TRT-LLM CUTLASS trace logs without overriding user configuration.
+os.environ.setdefault("TLLM_LOG_LEVEL", "INFO")
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.moe.token_dispatcher import CombineInput, DispatchOutput
+
+# One scratch buffer per (num_experts, k, n, top_k, device), shared by every
+# layer: they run sequentially and it is pure scratch. Allocated at load time so
+# it can never land in a CUDA graph's private memory pool -- a buffer first
+# allocated during capture is only valid inside that graph, and reusing it from
+# an un-captured forward faults.
+_B12X_SCRATCH: dict = {}
+
+# Every expert layer in the model has the same shape, so they share one weight
+# plan. That is not just a memory saving: b12x's compiled-kernel cache is keyed
+# per plan, so sharing means the warm-up below compiles each token count once
+# for the whole model instead of once per layer.
+_B12X_WEIGHT_PLANS: dict = {}
+
+
+def _select_b12x_distribution() -> None:
+    """Put the pinned b12x on sys.path ahead of whatever pip installed.
+
+    b12x 1.2.2 generalized its W4A16 kernel to also serve trellis rotation,
+    extra gating modes, expert maps and activation-amax collection. The
+    weights and scales
+    went from ``cute.Tensor`` (compile-time-static strides) to raw
+    ``cute.Pointer`` with layouts rebuilt at runtime, which costs 14 registers
+    and ~19% on this shape -- measured at 875.6 us/call against 707.9 for
+    0.15.3, same GPU, same weights, same inputs, bit-identical outputs.
+    DSv4-Flash uses none of the features that bought.
+    """
+    path = envs.SGLANG_B12X_PATH.get()
+    if not path:
+        return
+    if not os.path.isdir(os.path.join(path, "b12x")):
+        raise FileNotFoundError(f"SGLANG_B12X_PATH={path!r} has no b12x package.")
+    loaded = sys.modules.get("b12x")
+    if loaded is not None:
+        # Idempotent: this runs once per expert layer. Only a b12x already
+        # imported from somewhere else is a problem, and it is fatal -- the two
+        # generations share a module name but not an API.
+        want = os.path.realpath(path)
+        got = os.path.realpath(os.path.dirname(os.path.dirname(loaded.__file__)))
+        if want != got:
+            raise RuntimeError(
+                f"SGLANG_B12X_PATH={path!r} came too late: b12x was already "
+                f"imported from {loaded.__file__}."
+            )
+        return
+    sys.path.insert(0, path)
+
+
+def is_b12x_available() -> bool:
+    try:
+        _select_b12x_distribution()
+        import b12x  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def _b12x_is_legacy() -> bool:
+    """True for the 0.15.3-era API (``b12x.integration.tp_moe``)."""
+    import b12x  # noqa: F401
+
+    try:
+        import b12x.moe.fused_moe  # noqa: F401
+
+        return False
+    except ImportError:
+        return True
+
+
+def _b12x_max_tokens() -> int:
+    """Upper bound on tokens in a single MoE call (prefill is chunked)."""
+    return envs.SGLANG_B12X_MAX_TOKENS.get()
+
+
+def _core_token_counts(max_tokens: int, tokens_per_seq: int) -> tuple[int, ...]:
+    """Token counts to plan capacity for, and to warm kernels at.
+
+    Under CUDA graph capture b12x refuses to compile (``_require_cached``) and
+    falls back to the plan's pinned tile config, which does not fit every block
+    size -- so the launch fails outright rather than running slowly. Every token
+    count a captured graph can present must therefore have been run once
+    already. Decode graphs are captured at the configured batch sizes times the
+    speculative window; prefill is chunked, so a power-of-two ladder covers it.
+
+    Kernel compilation dedupes down to two variants (see ``_warmup``); the rest
+    of this ladder is what sizes the scratch arena.
+    """
+    counts = set()
+    batch_sizes = list(range(1, 33))
+    try:
+        from sglang.srt.server_args import get_global_server_args
+
+        decode = getattr(
+            getattr(get_global_server_args(), "cuda_graph_config", None), "decode", None
+        )
+        batch_sizes = list(getattr(decode, "bs", None) or batch_sizes)
+    except Exception:
+        # No server context (unit tests, offline use): the dense 1..32 ladder
+        # already covers every batch size a decode graph can be captured at.
+        pass
+    for bs in batch_sizes:
+        counts.add(bs * max(tokens_per_seq, 1))
+    n = 128
+    while n <= max_tokens:
+        counts.add(n)
+        n *= 2
+    counts.add(max_tokens)
+    return tuple(sorted(c for c in counts if 0 < c <= max_tokens))
+
+
+_BLOCKS_PER_SM_RELAXED = False
+
+
+def _relax_blocks_per_sm() -> None:
+    """Undo b12x's one-CTA-per-SM pin for moe_block_size==8.
+
+    b12x pins ``blocks_per_sm = 1`` whenever the routed block size is 8, to keep
+    the fused kernel's grid-barrier atomic from serializing across a wide grid.
+    Every decode token count lands on block size 8 here -- the routed fill test
+    is ``m * top_k / num_experts < 0.9 * 8``, so any m below ~308 takes it -- and
+    GB10 has 48 SMs, so the pin runs the machine at grid 48 where the unpinned
+    heuristic would pick 144.
+
+    Must run before the kernels are compiled: ``blocks_per_sm`` is part of the
+    launch bounds and therefore of b12x's kernel cache key, and b12x refuses to
+    compile during CUDA graph capture.
+    """
+    global _BLOCKS_PER_SM_RELAXED
+    if _BLOCKS_PER_SM_RELAXED:
+        return
+    from b12x.moe._shared.kernels.w4a16 import kernel as b12x_kernel
+
+    original = b12x_kernel._determine_blocks_per_sm
+
+    def _unpinned(*args, **kwargs):
+        # Route to the cta_m_blocks==1 branch, which caps at 4 rather than 1.
+        # This also picks the uses_m_block_8=False register count (143 vs 120),
+        # the more conservative of the two, so occupancy stays achievable.
+        kwargs["uses_m_block_8"] = False
+        return original(*args, **kwargs)
+
+    b12x_kernel._determine_blocks_per_sm = _unpinned
+    _BLOCKS_PER_SM_RELAXED = True
+    log_info_on_rank0(
+        logger, "b12x: dropped the one-CTA-per-SM pin for moe_block_size==8."
+    )
+
+
+def _warmup(*, plan, scratch, experts, top_k, num_experts, hidden_size, device, counts):
+    """Compile one kernel per token count, outside CUDA graph capture.
+
+    b12x refuses to compile while a graph is being captured, and falls back to
+    the plan's pinned tile config -- which does not fit every block size, so the
+    launch fails outright rather than running slowly. ``core_token_counts``
+    only declares the counts; it does not compile them. So every count a
+    captured graph can present has to be run once here, eagerly, first.
+    """
+    from b12x.moe import fused_moe
+
+    for tokens in counts:
+        a = torch.zeros(tokens, hidden_size, dtype=torch.bfloat16, device=device)
+        topk_ids = torch.arange(tokens * top_k, dtype=torch.int32, device=device)
+        topk_ids = (topk_ids % num_experts).view(tokens, top_k)
+        topk_weights = torch.full(
+            (tokens, top_k), 1.0 / top_k, dtype=torch.float32, device=device
+        )
+        out = torch.empty(tokens, hidden_size, dtype=torch.bfloat16, device=device)
+        fused_moe.run(
+            binding=fused_moe.bind(
+                plan,
+                scratch=scratch,
+                a=a,
+                experts=experts,
+                topk_ids=topk_ids,
+                topk_weights=topk_weights,
+                output=out,
+            )
+        )
+    torch.cuda.synchronize()
+
+
+_B12X_WARMED = False
+
+
+def _warmup_legacy(*, launch, top_k, num_experts, hidden_size, device, counts):
+    """Compile the 0.15.3 kernels before any CUDA graph capture."""
+    global _B12X_WARMED
+    for tokens in counts:
+        a = torch.zeros(tokens, hidden_size, dtype=torch.bfloat16, device=device)
+        ids = torch.arange(tokens * top_k, dtype=torch.int32, device=device)
+        ids = (ids % num_experts).view(tokens, top_k)
+        w = torch.full((tokens, top_k), 1.0 / top_k, dtype=torch.float32, device=device)
+        out = torch.empty(tokens, hidden_size, dtype=torch.bfloat16, device=device)
+        launch(a, ids, w, out)
+    torch.cuda.synchronize()
+    _B12X_WARMED = True
+
+
+def _legacy_prepare(*, w13, s13, w2, s2, ones):
+    """0.15.3 weight prep. Repacks in place, so the caller's tensors stay live."""
+    from b12x.integration import prepare_b12x_fp4_moe_weights
+
+    return prepare_b12x_fp4_moe_weights(
+        source_format="fp4_e8m0_k32",
+        w13_layout="up_gate",
+        w1_fp4=w13,
+        w1_blockscale=s13,
+        w1_global_scale=ones,
+        a1_gscale=ones,
+        w2_fp4=w2,
+        w2_blockscale=s2,
+        w2_global_scale=ones,
+        a2_gscale=ones,
+        activation="silu",
+        params_dtype=torch.bfloat16,
+        prepare_runtime_alphas=False,
+        prepare_w4a16=True,
+        reuse_input_storage=True,
+    )
+
+
+def _legacy_plan(
+    *, num_experts, hidden_size, intermediate, top_k, device, swiglu_limit, counts
+):
+    """0.15.3 scratch plan. Returns (plan, scratch)."""
+    from b12x.integration.tp_moe import TPMoEScratchCaps, plan_tp_moe_scratch
+
+    caps = TPMoEScratchCaps(
+        max_tokens=max(counts),
+        weight_E=num_experts,
+        k=hidden_size,
+        n=intermediate,
+        num_topk=top_k,
+        device=device,
+        dtype=torch.bfloat16,
+        core_token_counts=tuple(counts),
+        route_num_experts=0,
+        route_logits_dtype=None,
+        quant_mode="w4a16",
+        activation="silu",
+        apply_router_weight_on_input=False,
+        swiglu_limit=swiglu_limit,
+        source_format="fp4_e8m0_k32",
+        w13_layout="up_gate",
+        frozen=True,
+    )
+    plan = plan_tp_moe_scratch(caps)
+    specs = plan.scratch_specs()
+    if len(specs) != 1 or specs[0].dtype != torch.uint8:
+        raise RuntimeError(f"unexpected b12x scratch specs: {specs}")
+    scratch = torch.empty(int(specs[0].shape[0]), dtype=torch.uint8, device=device)
+    return plan, scratch
+
+
+def _legacy_launcher(*, plan, scratch, prepared, w13, s13, w2, s2, ones, swiglu_limit):
+    """Bind-and-run closure for 0.15.3, matching vLLM's call sequence."""
+    from b12x.integration.tp_moe import b12x_moe_fp4
+
+    packed = prepared.w4a16
+    w1_alphas = prepared.w1_runtime_alphas
+    w2_alphas = prepared.w2_runtime_alphas
+    if w1_alphas is None:
+        w1_alphas = ones
+    if w2_alphas is None:
+        w2_alphas = ones
+
+    def launch(a, topk_ids, topk_weights, out):
+        b12x_moe_fp4(
+            binding=plan.bind(
+                scratch=scratch,
+                a=a,
+                a1_gscale=ones,
+                w1_fp4=w13,
+                w1_blockscale=s13,
+                w1_alphas=w1_alphas,
+                a2_gscale=ones,
+                w2_fp4=w2,
+                w2_blockscale=s2,
+                w2_alphas=w2_alphas,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                output=out,
+                activation="silu",
+                quant_mode="w4a16",
+                source_format="fp4_e8m0_k32",
+                w13_layout="up_gate",
+                prepared_w4a16=packed,
+                swiglu_limit=swiglu_limit,
+            )
+        )
+
+    return launch
+
+
+def _get_weight_plan(*, num_experts: int, hidden_size: int, intermediate: int):
+    """One weight plan per shape, shared by every expert layer."""
+    from b12x.moe import fused_moe
+
+    key = (num_experts, hidden_size, intermediate)
+    plan = _B12X_WEIGHT_PLANS.get(key)
+    if plan is None:
+        plan = fused_moe.plan_weights(
+            quant_modes="w4a16",
+            source_format="fp4_e8m0_k32",
+            activation="silu",
+            params_dtype=torch.bfloat16,
+            num_experts=num_experts,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate,
+            w13_layout="up_gate",
+        )
+        _B12X_WEIGHT_PLANS[key] = plan
+    return plan
+
+
+def _get_scratch(
+    *,
+    weight_plan,
+    top_k: int,
+    device,
+    swiglu_limit,
+    tokens_per_seq,
+    experts,
+    num_experts: int,
+    hidden_size: int,
+):
+    """Plan and allocate the shared scratch buffer, once per shape."""
+    from b12x.moe import fused_moe
+
+    max_tokens = _b12x_max_tokens()
+    key = (id(weight_plan), top_k, str(device), swiglu_limit)
+    entry = _B12X_SCRATCH.get(key)
+    if entry is None:
+        if envs.SGLANG_B12X_RELAX_BLOCKS_PER_SM.get():
+            _relax_blocks_per_sm()
+        counts = _core_token_counts(max_tokens, tokens_per_seq)
+        caps = fused_moe.Caps(
+            max_tokens=max_tokens,
+            num_topk=top_k,
+            device=device,
+            weight_plan=weight_plan,
+            quant_mode="w4a16",
+            swiglu_limit=swiglu_limit,
+            core_token_counts=counts,
+            frozen=True,
+        )
+        plan = fused_moe.plan(caps)
+        scratch = torch.empty(
+            fused_moe.required_nbytes(caps), dtype=torch.uint8, device=device
+        )
+        log_info_on_rank0(
+            logger,
+            f"Compiling {len(counts)} b12x W4A16 kernels "
+            f"(token counts {counts[0]}..{counts[-1]})...",
+        )
+        _warmup(
+            plan=plan,
+            scratch=scratch,
+            experts=experts,
+            top_k=top_k,
+            num_experts=num_experts,
+            hidden_size=hidden_size,
+            device=device,
+            counts=counts,
+        )
+        entry = (plan, scratch)
+        _B12X_SCRATCH[key] = entry
+    return entry
+
+
+class Mxfp4B12xMoEMethod:
+    """b12x MXFP4 MoE: one fused W4A16 kernel per expert layer."""
+
+    def __init__(self, fp8_method, prefix: str):
+        if not is_b12x_available():
+            raise RuntimeError(
+                "The b12x MoE backend needs the b12x package: "
+                "pip install --no-deps b12x==1.2.2"
+            )
+        if not is_sm120_supported():
+            raise RuntimeError("Mxfp4B12xMoEMethod requires SM120 or SM121.")
+        self._fp8 = fp8_method
+        self.prefix = prefix
+        self._experts: Any = None
+        self._plan: Any = None
+        self._scratch: torch.Tensor | None = None
+        self._swiglu_limit: float | None = None
+        # Set on the 0.15.3 path, where the whole call is a prepared closure.
+        self._launch: Any = None
+        self._legacy_keepalive: Any = None
+        self._ep_guard = False
+
+    @property
+    def load_up_proj_weight_first(self) -> bool:
+        """Load W13 as ``[up; gate]`` -- declared to b12x as w13_layout='up_gate'."""
+        return True
+
+    def create_weights(
+        self,
+        layer: Module,
+        num_experts: int,
+        hidden_size: int,
+        intermediate_size_per_partition: int,
+        params_dtype,
+        **extra_weight_attrs,
+    ):
+        if hidden_size % 128 != 0 or intermediate_size_per_partition % 128 != 0:
+            raise ValueError(
+                "Mxfp4B12xMoEMethod requires hidden_size and "
+                "intermediate_size_per_partition to be multiples of 128 "
+                f"(got hidden={hidden_size}, "
+                f"intermediate={intermediate_size_per_partition})."
+            )
+        # Keep checkpoint scales in native E8M0: b12x consumes those bytes as-is.
+        self._fp8.create_weights(
+            layer,
+            num_experts,
+            hidden_size,
+            intermediate_size_per_partition,
+            params_dtype,
+            fp4_scale_dtype=torch.float8_e8m0fnu,
+            **extra_weight_attrs,
+        )
+
+    def create_moe_runner(self, layer: Module, moe_runner_config) -> None:
+        from sglang.srt.layers.moe.moe_runner.runner import MoeRunner
+        from sglang.srt.layers.moe.utils import MoeRunnerBackend
+
+        self.moe_runner_config = moe_runner_config
+        self._swiglu_limit = getattr(moe_runner_config, "swiglu_limit", None)
+        # -1 expert sentinels exist only under expert parallelism; resolve once
+        # so the per-forward path can skip the guard entirely at EP=1.
+        from sglang.srt.runtime_context import get_parallel
+
+        self._ep_guard = get_parallel().moe_ep_size > 1
+
+        # Register the fused func at runner construction so the FusedOpPool
+        # lookup at `MoeRunner.__init__` finds it.
+        import sglang.srt.layers.moe.moe_runner.b12x  # noqa: F401
+
+        self.runner = MoeRunner(MoeRunnerBackend.B12X, moe_runner_config)
+
+    def process_weights_after_loading(self, layer: Module) -> None:
+        # Preserve the base FP4 post-load handling.
+        self._fp8.process_weights_after_loading(layer)
+        if getattr(layer, "_mega_moe_weights_built", False):
+            return
+
+        for name in ("w13_weight_scale_inv", "w2_weight_scale_inv"):
+            scale = getattr(layer, name)
+            if scale.dtype != torch.float8_e8m0fnu:
+                raise TypeError(
+                    f"{name} must stay native E8M0: it is a hard input contract "
+                    f"of source_format='fp4_e8m0_k32'. Got {scale.dtype}."
+                )
+
+        log_info_on_rank0(
+            logger,
+            f"Preparing DSv4 MXFP4 experts for b12x W4A16 "
+            f"(layer: {self.prefix}, swiglu_limit={self._swiglu_limit})...",
+        )
+
+        device = layer.w13_weight.device
+        num_experts, two_n, k_half = layer.w13_weight.shape
+        hidden_size = k_half * 2
+        intermediate = two_n // 2
+        ones = torch.ones(num_experts, dtype=torch.float32, device=device)
+
+        try:
+            from sglang.srt.server_args import get_global_server_args
+
+            spec_tokens = int(
+                getattr(get_global_server_args(), "speculative_num_draft_tokens", None)
+                or 1
+            )
+        except Exception:
+            spec_tokens = 1
+
+        if _b12x_is_legacy():
+            # 0.15.3: one call prepares the weights in place, and the scratch
+            # plan is built straight from the shapes -- there is no separate
+            # weight plan to share between layers.
+            w13 = layer.w13_weight.data.view(torch.uint8)
+            s13 = layer.w13_weight_scale_inv.data.view(torch.uint8)
+            w2 = layer.w2_weight.data.view(torch.uint8)
+            s2 = layer.w2_weight_scale_inv.data.view(torch.uint8)
+            prepared = _legacy_prepare(w13=w13, s13=s13, w2=w2, s2=s2, ones=ones)
+            counts = _core_token_counts(_b12x_max_tokens(), spec_tokens)
+            plan, scratch = _legacy_plan(
+                num_experts=num_experts,
+                hidden_size=hidden_size,
+                intermediate=intermediate,
+                top_k=int(layer.top_k),
+                device=device,
+                swiglu_limit=self._swiglu_limit,
+                counts=counts,
+            )
+            self._launch = _legacy_launcher(
+                plan=plan,
+                scratch=scratch,
+                prepared=prepared,
+                w13=w13,
+                s13=s13,
+                w2=w2,
+                s2=s2,
+                ones=ones,
+                swiglu_limit=self._swiglu_limit,
+            )
+            # reuse_input_storage=True: the prepared package aliases these
+            # tensors, so they must stay reachable. Keep the Parameters as they
+            # are and hold our own references.
+            self._legacy_keepalive = (prepared, w13, s13, w2, s2, ones, plan, scratch)
+            # Same reason as the 1.2.2 path: b12x will not compile while a CUDA
+            # graph is being captured, so every shape a graph can present has to
+            # have run once already.
+            if not _B12X_WARMED:
+                log_info_on_rank0(
+                    logger,
+                    f"Compiling b12x 0.15.3 W4A16 kernels for {len(counts)} "
+                    f"token counts ({counts[0]}..{counts[-1]})...",
+                )
+                _warmup_legacy(
+                    launch=self._launch,
+                    top_k=int(layer.top_k),
+                    num_experts=num_experts,
+                    hidden_size=hidden_size,
+                    device=device,
+                    counts=counts,
+                )
+            layer._dsv4_mxfp4_backend = "b12x_sm12x_015"
+            return
+
+        from b12x.moe import fused_moe
+
+        weight_plan = _get_weight_plan(
+            num_experts=num_experts,
+            hidden_size=hidden_size,
+            intermediate=intermediate,
+        )
+        self._experts = fused_moe.prepare_weights(
+            plan=weight_plan,
+            params_dtype=torch.bfloat16,
+            w1_fp4=layer.w13_weight.data.view(torch.uint8),
+            w1_blockscale=layer.w13_weight_scale_inv.data.view(torch.uint8),
+            w1_global_scale=ones,
+            w2_fp4=layer.w2_weight.data.view(torch.uint8),
+            w2_blockscale=layer.w2_weight_scale_inv.data.view(torch.uint8),
+            w2_global_scale=ones,
+            a1_gscale=ones,
+            a2_gscale=ones,
+        )
+        self._plan, self._scratch = _get_scratch(
+            weight_plan=weight_plan,
+            top_k=int(layer.top_k),
+            device=device,
+            swiglu_limit=self._swiglu_limit,
+            tokens_per_seq=spec_tokens,
+            experts=self._experts,
+            num_experts=num_experts,
+            hidden_size=hidden_size,
+        )
+
+        # b12x owns the runtime weights from here on. Whether it aliased the
+        # checkpoint storage or copied it is its choice; either way nothing else
+        # reads these Parameters again.
+        def _release(param: torch.Tensor) -> Parameter:
+            return Parameter(
+                torch.empty(0, dtype=param.dtype, device=param.device),
+                requires_grad=False,
+            )
+
+        layer.w13_weight = _release(layer.w13_weight)
+        layer.w2_weight = _release(layer.w2_weight)
+        layer.w13_weight_scale_inv = _release(layer.w13_weight_scale_inv)
+        layer.w2_weight_scale_inv = _release(layer.w2_weight_scale_inv)
+        torch.cuda.empty_cache()
+
+        layer._dsv4_mxfp4_backend = "b12x_sm12x"
+
+    def apply(
+        self,
+        layer: Module,
+        dispatch_output: DispatchOutput,
+    ) -> CombineInput:
+        from sglang.srt.layers.moe.moe_runner.b12x import B12xMoeQuantInfo
+
+        quant_info = B12xMoeQuantInfo(
+            experts=self._experts,
+            plan=self._plan,
+            scratch=self._scratch,
+            launch=self._launch,
+            ep_guard=self._ep_guard,
+        )
+        return self.runner.run(dispatch_output, quant_info)

--- a/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
@@ -1,8 +1,12 @@
-"""DeepSeek-V4 MXFP4 expert backend backed by the b12x W4A16 fused MoE.
+"""DeepSeek-V4 MXFP4 expert backend backed by the b12x fused MoE.
 
 Same checkpoint as :mod:`mxfp4_flashinfer_cutlass_moe`, different runtime: one
-fused kernel per expert layer instead of seven, and bf16 activations instead of
-MXFP8.
+fused kernel per expert layer instead of seven.
+
+The quant mode is ``SGLANG_B12X_MOE_QUANT_MODE``, passed to b12x verbatim. It
+defaults to ``w4a8_mx`` (activations quantized to MXFP8-E4M3 in-kernel), the
+recipe the official vLLM DGX Spark image runs and where all of b12x's GB10 MoE
+tuning lives; ``w4a16`` keeps bf16 activations on a load-time frozen plan.
 
 This targets exactly one generation of the standalone ``b12x`` package: the
 op-registry API (``b12x.moe.fused_moe``, ``Caps -> plan() -> bind() -> run()``)
@@ -152,12 +156,14 @@ def _warmup(*, launch, top_k, num_experts, hidden_size, device, counts):
     _B12X_WARMED = True
 
 
-def _prepare_weights(*, w13, s13, w2, s2, ones, num_experts, hidden_size, intermediate):
+def _prepare_weights(
+    *, w13, s13, w2, s2, ones, num_experts, hidden_size, intermediate, quant_mode
+):
     """Weight plan + prep. Repacks in place, so the caller's tensors stay live."""
     from b12x.moe import fused_moe
 
     weight_plan = fused_moe.plan_weights(
-        quant_modes="w4a16",
+        quant_modes=quant_mode,
         source_format="fp4_e8m0_k32",
         activation="silu",
         params_dtype=torch.bfloat16,
@@ -233,7 +239,7 @@ def _plan_scratch(*, experts, top_k, device, swiglu_limit, counts):
 
 
 def _make_launcher(*, plan, scratch, experts):
-    """Bind-and-run closure, matching vLLM's call sequence."""
+    """W4A16 bind-and-run closure over the load-time frozen plan."""
     from b12x.moe import fused_moe
 
     def launch(a, topk_ids, topk_weights, out):
@@ -255,8 +261,92 @@ def _make_launcher(*, plan, scratch, experts):
     return launch
 
 
+def _plan_a8_arena(*, experts, top_k, device, swiglu_limit, counts, quant_mode):
+    """Shared arena for the W4A8 per-forward-planned path.
+
+    W4A8 selects its implementation (micro vs dynamic) and tile regime from
+    the live token count, so the plan is rebuilt per call, vLLM-style --
+    b12x's planning is host-only, allocation- and compile-free for this
+    recipe, and under full-graph capture it runs once per bucket at capture
+    time. Only the arena is fixed: sized here over the whole count ladder
+    (required_nbytes covers every bucketed count including the micro/dynamic
+    cutover), shared by every layer and every per-call plan.
+    """
+    from b12x.moe import fused_moe
+
+    from sglang.srt.runtime_context import get_resources
+
+    fingerprint = (
+        quant_mode,
+        int(top_k),
+        tuple(counts),
+        None if swiglu_limit is None else float(swiglu_limit),
+        int(experts.num_experts),
+        int(experts.hidden_size),
+        int(experts.intermediate_size),
+    )
+    buffers = get_resources().buffers
+    key = f"b12x:moe_a8_arena:{device}"
+    cached = buffers.get(key)
+    if cached is not None and cached[0] == fingerprint:
+        return cached[1]
+    caps = fused_moe.Caps(
+        max_tokens=max(counts),
+        num_topk=top_k,
+        device=device,
+        weight_plan=experts.plan,
+        core_token_counts=tuple(counts),
+        route_num_experts=0,
+        route_logits_dtype=None,
+        quant_mode=quant_mode,
+        apply_router_weight_on_input=False,
+        swiglu_limit=swiglu_limit,
+        frozen=True,
+    )
+    arena = torch.empty(
+        int(fused_moe.required_nbytes(caps)), dtype=torch.uint8, device=device
+    )
+    buffers[key] = (fingerprint, arena)
+    return arena
+
+
+def _make_launcher_a8(*, arena, experts, top_k, device, swiglu_limit, quant_mode):
+    """W4A8 bind-and-run closure; plans at the live token count per call."""
+    from b12x.moe import fused_moe
+
+    def launch(a, topk_ids, topk_weights, out):
+        m = max(1, int(a.shape[0]))
+        caps = fused_moe.Caps(
+            max_tokens=m,
+            num_topk=top_k,
+            device=device,
+            weight_plan=experts.plan,
+            core_token_counts=(m,),
+            route_num_experts=0,
+            route_logits_dtype=None,
+            quant_mode=quant_mode,
+            apply_router_weight_on_input=False,
+            swiglu_limit=swiglu_limit,
+            frozen=True,
+        )
+        plan = fused_moe.plan(caps)
+        fused_moe.run(
+            binding=plan.bind(
+                scratch=arena,
+                a=a,
+                experts=experts,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                output=out,
+                input_scales_static=True,
+            )
+        )
+
+    return launch
+
+
 class Mxfp4B12xMoEMethod:
-    """b12x MXFP4 MoE: one fused W4A16 kernel per expert layer."""
+    """b12x MXFP4 MoE: one fused kernel per expert layer."""
 
     def __init__(self, fp8_method, prefix: str):
         _require_aligned_generation()
@@ -334,9 +424,12 @@ class Mxfp4B12xMoEMethod:
                     f"of source_format='fp4_e8m0_k32'. Got {scale.dtype}."
                 )
 
+        # Passed straight to b12x. "w4a16" is the frozen-plan path; every other
+        # mode quantizes activations in-kernel and plans per call.
+        quant_mode = envs.SGLANG_B12X_MOE_QUANT_MODE.get()
         log_info_on_rank0(
             logger,
-            f"Preparing DSv4 MXFP4 experts for b12x W4A16 "
+            f"Preparing DSv4 MXFP4 experts for b12x {quant_mode} "
             f"(layer: {self.prefix}, swiglu_limit={self._swiglu_limit})...",
         )
 
@@ -366,26 +459,48 @@ class Mxfp4B12xMoEMethod:
             num_experts=num_experts,
             hidden_size=hidden_size,
             intermediate=intermediate,
+            quant_mode=quant_mode,
         )
         counts = _core_token_counts(_b12x_max_tokens(), spec_tokens)
-        plan, scratch = _plan_scratch(
-            experts=experts,
-            top_k=int(layer.top_k),
-            device=device,
-            swiglu_limit=self._swiglu_limit,
-            counts=counts,
-        )
-        self._launch = _make_launcher(plan=plan, scratch=scratch, experts=experts)
+        if quant_mode != "w4a16":
+            arena = _plan_a8_arena(
+                experts=experts,
+                top_k=int(layer.top_k),
+                device=device,
+                swiglu_limit=self._swiglu_limit,
+                counts=counts,
+                quant_mode=quant_mode,
+            )
+            self._launch = _make_launcher_a8(
+                arena=arena,
+                experts=experts,
+                top_k=int(layer.top_k),
+                device=device,
+                swiglu_limit=self._swiglu_limit,
+                quant_mode=quant_mode,
+            )
+            plan_or_arena = arena
+        else:
+            plan, scratch = _plan_scratch(
+                experts=experts,
+                top_k=int(layer.top_k),
+                device=device,
+                swiglu_limit=self._swiglu_limit,
+                counts=counts,
+            )
+            self._launch = _make_launcher(plan=plan, scratch=scratch, experts=experts)
+            plan_or_arena = (plan, scratch)
         # The prepared weights alias the checkpoint storage (REUSE_SOURCE for
-        # 128-aligned fp4_e8m0_k32), so these tensors must stay reachable. Keep
-        # the Parameters as they are and hold our own references.
-        self._keepalive = (experts, w13, s13, w2, s2, ones, plan, scratch)
+        # 128-aligned fp4_e8m0_k32; w4a8_mx repacks likewise discard the
+        # source Parameters), so these tensors must stay reachable. Keep the
+        # Parameters as they are and hold our own references.
+        self._keepalive = (experts, w13, s13, w2, s2, ones, plan_or_arena)
         # b12x will not compile while a CUDA graph is being captured, so every
         # shape a graph can present has to have run once already.
         if not _B12X_WARMED and envs.SGLANG_B12X_WARMUP.get():
             log_info_on_rank0(
                 logger,
-                f"Compiling b12x W4A16 kernels for {len(counts)} "
+                f"Compiling b12x {quant_mode} kernels for {len(counts)} "
                 f"token counts ({counts[0]}..{counts[-1]})...",
             )
             _warmup(

--- a/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
@@ -1,11 +1,11 @@
-"""DeepSeek-V4 MXFP4 expert backend backed by the b12x W4A16 fused MoE.
+"""DeepSeek-V4 MXFP4 expert backend backed by the b12x 0.15.3 W4A16 fused MoE.
 
 Same checkpoint as :mod:`mxfp4_flashinfer_cutlass_moe`, different runtime: one
 fused kernel per expert layer instead of seven, and bf16 activations instead of
 MXFP8.
 
-This uses the standalone ``b12x`` package rather than the copy vendored inside
-FlashInfer. Three things depend on that choice:
+This targets exactly one generation of the standalone ``b12x`` package: the
+0.15.3 API (``b12x.integration.tp_moe``). Three things depend on that choice:
 
 * ``source_format="fp4_e8m0_k32"`` consumes the checkpoint's E8M0 K/32 block
   scales byte for byte, so there is no scale relayout to get wrong.
@@ -13,27 +13,20 @@ FlashInfer. Three things depend on that choice:
   it binds on real data (gate magnitudes reach 10.1, and half the layers sit
   within 7% of the limit), so dropping it is a correctness change, not a
   rounding one.
-* Kernels are warmed before CUDA graph capture. b12x specializes on token
-  count only as ``size_m == 1`` vs everything else (``_m_specialization_key``
-  in its w4a16 kernel), so this is two compiles, not one per prompt length --
-  but it refuses to compile at all while a graph is being captured, which is
-  what the warm-up exists for.
+* Kernels are warmed before CUDA graph capture: b12x refuses to compile while
+  a graph is being captured and falls back to a pinned tile config that does
+  not fit every block size, so every token count a captured graph can present
+  is compiled eagerly first (see :func:`_core_token_counts`).
 
-Two b12x API generations are supported, auto-detected by import shape
-(:func:`_b12x_is_legacy`); "legacy" throughout this file names the API
-generation, not a recommendation:
+0.15.3 was never published to PyPI. Install it from the source commit whose
+MoE surface matches the released wheel::
 
-* **1.2.2** (``b12x.moe.fused_moe``) is the current PyPI release and the
-  default. Install with ``pip install --no-deps b12x==1.2.2``; without
-  ``--no-deps`` pip pulls a newer torch and breaks the rest of the image.
-* **0.15.3** (``b12x.integration``, the legacy API) was never published to
-  PyPI -- it ships only inside the dspark reference image, and 0.15.2 (the
-  last published 0.15.x) predates the ``fp4_e8m0_k32`` / ``w13_layout``
-  API this file needs -- so it can only come from a checkout
-  (``SGLANG_B12X_PATH``). At the decode working point (M=6) it is ~19%
-  *faster* per call -- see :func:`_select_b12x_distribution` -- while at
-  prefill-sized M the two generations are within noise; that decode delta
-  is why a deployment would bother.
+    pip install --no-deps "b12x @ https://github.com/local-inference-lab/b12x/archive/7dc6fb8fcc6446ea093537d1657df81985fa5f43.tar.gz"
+
+(``--no-deps``: b12x's metadata pulls a newer torch and breaks the rest of the
+image.) Later b12x generations changed the W4A16 kernels (0.20.0) and then the
+API (1.2.x); they are rejected at startup rather than silently producing
+different numerics -- see :func:`_require_015_generation`.
 """
 
 from __future__ import annotations
@@ -45,7 +38,6 @@ from typing import TYPE_CHECKING, Any
 
 import torch
 from torch.nn import Module
-from torch.nn.parameter import Parameter
 
 from sglang.srt.environ import envs
 from sglang.srt.utils import log_info_on_rank0
@@ -59,18 +51,18 @@ logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from sglang.srt.layers.moe.token_dispatcher import CombineInput, DispatchOutput
 
+_B12X_INSTALL_HINT = (
+    "pip install --no-deps 'b12x @ https://github.com/local-inference-lab/"
+    "b12x/archive/7dc6fb8fcc6446ea093537d1657df81985fa5f43.tar.gz'"
+)
+
 
 def _select_b12x_distribution() -> None:
-    """Put the pinned b12x on sys.path ahead of whatever pip installed.
+    """Put a local b12x tree on sys.path ahead of whatever pip installed.
 
-    b12x 1.2.2 generalized its W4A16 kernel to also serve trellis rotation,
-    extra gating modes, expert maps and activation-amax collection. The
-    weights and scales
-    went from ``cute.Tensor`` (compile-time-static strides) to raw
-    ``cute.Pointer`` with layouts rebuilt at runtime, which costs 14 registers
-    and ~19% on this shape -- measured at 875.6 us/call against 707.9 for
-    0.15.3, same GPU, same weights, same inputs, bit-identical outputs.
-    DSv4-Flash uses none of the features that bought.
+    For deployments that carry the 0.15.3 tree as a directory (e.g. extracted
+    from the dspark reference image) instead of pip-installing the pinned
+    source commit. Unset (the default) is a no-op.
     """
     path = envs.SGLANG_B12X_PATH.get()
     if not path:
@@ -80,7 +72,7 @@ def _select_b12x_distribution() -> None:
     loaded = sys.modules.get("b12x")
     if loaded is not None:
         # Idempotent: this runs once per expert layer. Only a b12x already
-        # imported from somewhere else is a problem, and it is fatal -- the two
+        # imported from somewhere else is a problem, and it is fatal -- the
         # generations share a module name but not an API.
         want = os.path.realpath(path)
         got = os.path.realpath(os.path.dirname(os.path.dirname(loaded.__file__)))
@@ -96,23 +88,43 @@ def _select_b12x_distribution() -> None:
 def is_b12x_available() -> bool:
     try:
         _select_b12x_distribution()
-        import b12x  # noqa: F401
+        import b12x.integration.tp_moe  # noqa: F401
 
         return True
     except ImportError:
         return False
 
 
-def _b12x_is_legacy() -> bool:
-    """True for the 0.15.3-era API (``b12x.integration.tp_moe``)."""
-    import b12x  # noqa: F401
+def _require_015_generation() -> None:
+    """Reject b12x generations other than 0.15.x, loudly and at load time.
+
+    0.20.0 rewrote the W4A16 kernels behind the same ``b12x.integration``
+    API (different numerics), and the 1.2.x line replaced the API as well
+    (``b12x.moe.fused_moe``). This backend is validated against 0.15.3 only.
+    A raw source tree without dist-info cannot be version-checked; the
+    ``fused_moe`` probe still rejects the 1.2.x line there.
+    """
+    import importlib.metadata
+
+    import b12x
 
     try:
-        import b12x.moe.fused_moe  # noqa: F401
+        import b12x.moe.fused_moe  # noqa: F401  # the 1.2.x-generation API
 
-        return False
+        has_fused_moe = True
     except ImportError:
-        return True
+        has_fused_moe = False
+    version = None
+    try:
+        version = importlib.metadata.version("b12x")
+    except importlib.metadata.PackageNotFoundError:
+        pass
+    if has_fused_moe or (version is not None and not version.startswith("0.15.")):
+        raise RuntimeError(
+            f"b12x at {b12x.__file__} (version {version or 'unknown'}) is not "
+            "the 0.15.x generation this backend is validated against. "
+            f"Install the pinned source commit: {_B12X_INSTALL_HINT}"
+        )
 
 
 def _b12x_max_tokens() -> int:
@@ -130,8 +142,8 @@ def _core_token_counts(max_tokens: int, tokens_per_seq: int) -> tuple[int, ...]:
     already. Decode graphs are captured at the configured batch sizes times the
     speculative window; prefill is chunked, so a power-of-two ladder covers it.
 
-    Kernel compilation dedupes down to two variants (see ``_warmup``); the rest
-    of this ladder is what sizes the scratch arena.
+    Each count compiles its own kernel (the startup log line counts them), and
+    the same ladder sizes the scratch arena.
     """
     counts = set()
     batch_sizes = list(range(1, 33))
@@ -155,83 +167,14 @@ def _core_token_counts(max_tokens: int, tokens_per_seq: int) -> tuple[int, ...]:
     return tuple(sorted(c for c in counts if 0 < c <= max_tokens))
 
 
-def _relax_blocks_per_sm() -> None:
-    """Undo b12x's one-CTA-per-SM pin for moe_block_size==8.
-
-    b12x pins ``blocks_per_sm = 1`` whenever the routed block size is 8, to keep
-    the fused kernel's grid-barrier atomic from serializing across a wide grid.
-    Every decode token count lands on block size 8 here -- the routed fill test
-    is ``m * top_k / num_experts < 0.9 * 8``, so any m below ~308 takes it -- and
-    GB10 has 48 SMs, so the pin runs the machine at grid 48 where the unpinned
-    heuristic would pick 144.
-
-    Must run before the kernels are compiled: ``blocks_per_sm`` is part of the
-    launch bounds and therefore of b12x's kernel cache key, and b12x refuses to
-    compile during CUDA graph capture.
-    """
-    from b12x.moe._shared.kernels.w4a16 import kernel as b12x_kernel
-
-    original = b12x_kernel._determine_blocks_per_sm
-    # Latched on the patched function itself: the patch is process-global state
-    # inside the b12x module, which reset_context() cannot (and must not) undo.
-    if getattr(original, "_sglang_unpinned", False):
-        return
-
-    def _unpinned(*args, **kwargs):
-        # Route to the cta_m_blocks==1 branch, which caps at 4 rather than 1.
-        # This also picks the uses_m_block_8=False register count (143 vs 120),
-        # the more conservative of the two, so occupancy stays achievable.
-        kwargs["uses_m_block_8"] = False
-        return original(*args, **kwargs)
-
-    _unpinned._sglang_unpinned = True
-    b12x_kernel._determine_blocks_per_sm = _unpinned
-    log_info_on_rank0(
-        logger, "b12x: dropped the one-CTA-per-SM pin for moe_block_size==8."
-    )
-
-
-def _warmup(*, plan, scratch, experts, top_k, num_experts, hidden_size, device, counts):
-    """Compile one kernel per token count, outside CUDA graph capture.
-
-    b12x refuses to compile while a graph is being captured, and falls back to
-    the plan's pinned tile config -- which does not fit every block size, so the
-    launch fails outright rather than running slowly. ``core_token_counts``
-    only declares the counts; it does not compile them. So every count a
-    captured graph can present has to be run once here, eagerly, first.
-    """
-    from b12x.moe import fused_moe
-
-    for tokens in counts:
-        a = torch.zeros(tokens, hidden_size, dtype=torch.bfloat16, device=device)
-        topk_ids = torch.arange(tokens * top_k, dtype=torch.int32, device=device)
-        topk_ids = (topk_ids % num_experts).view(tokens, top_k)
-        topk_weights = torch.full(
-            (tokens, top_k), 1.0 / top_k, dtype=torch.float32, device=device
-        )
-        out = torch.empty(tokens, hidden_size, dtype=torch.bfloat16, device=device)
-        fused_moe.run(
-            binding=fused_moe.bind(
-                plan,
-                scratch=scratch,
-                a=a,
-                experts=experts,
-                topk_ids=topk_ids,
-                topk_weights=topk_weights,
-                output=out,
-            )
-        )
-    torch.cuda.synchronize()
-
-
 # Module-level on purpose: this latch mirrors b12x's own process-global
 # compiled-kernel cache, which reset_context() cannot reset -- re-warming after
 # a context reset would be wasted work, not a correctness need.
 _B12X_WARMED = False
 
 
-def _warmup_legacy(*, launch, top_k, num_experts, hidden_size, device, counts):
-    """Compile the 0.15.3 kernels before any CUDA graph capture."""
+def _warmup(*, launch, top_k, num_experts, hidden_size, device, counts):
+    """Compile the kernels for every count before any CUDA graph capture."""
     global _B12X_WARMED
     for tokens in counts:
         a = torch.zeros(tokens, hidden_size, dtype=torch.bfloat16, device=device)
@@ -244,8 +187,8 @@ def _warmup_legacy(*, launch, top_k, num_experts, hidden_size, device, counts):
     _B12X_WARMED = True
 
 
-def _legacy_prepare(*, w13, s13, w2, s2, ones):
-    """0.15.3 weight prep. Repacks in place, so the caller's tensors stay live."""
+def _prepare_weights(*, w13, s13, w2, s2, ones):
+    """Weight prep. Repacks in place, so the caller's tensors stay live."""
     from b12x.integration import prepare_b12x_fp4_moe_weights
 
     return prepare_b12x_fp4_moe_weights(
@@ -267,10 +210,10 @@ def _legacy_prepare(*, w13, s13, w2, s2, ones):
     )
 
 
-def _legacy_plan(
+def _plan_scratch(
     *, num_experts, hidden_size, intermediate, top_k, device, swiglu_limit, counts
 ):
-    """0.15.3 scratch plan. Returns (plan, scratch)."""
+    """Frozen scratch plan. Returns (plan, scratch)."""
     from b12x.integration.tp_moe import TPMoEScratchCaps, plan_tp_moe_scratch
 
     caps = TPMoEScratchCaps(
@@ -300,8 +243,8 @@ def _legacy_plan(
     return plan, scratch
 
 
-def _legacy_launcher(*, plan, scratch, prepared, w13, s13, w2, s2, ones, swiglu_limit):
-    """Bind-and-run closure for 0.15.3, matching vLLM's call sequence."""
+def _make_launcher(*, plan, scratch, prepared, w13, s13, w2, s2, ones, swiglu_limit):
+    """Bind-and-run closure, matching vLLM's call sequence."""
     from b12x.integration.tp_moe import b12x_moe_fp4
 
     packed = prepared.w4a16
@@ -340,119 +283,24 @@ def _legacy_launcher(*, plan, scratch, prepared, w13, s13, w2, s2, ones, swiglu_
     return launch
 
 
-def _get_weight_plan(*, num_experts: int, hidden_size: int, intermediate: int):
-    """One weight plan per shape, shared by every expert layer.
-
-    Not just a memory saving: b12x's compiled-kernel cache is keyed per plan,
-    so sharing means the warm-up compiles each token count once for the whole
-    model instead of once per layer. Stored on ``get_resources().buffers`` so
-    unit-test teardown (``reset_context``) drops it with everything else.
-    """
-    from b12x.moe import fused_moe
-
-    from sglang.srt.runtime_context import get_resources
-
-    buffers = get_resources().buffers
-    key = f"b12x:weight_plan:{num_experts}:{hidden_size}:{intermediate}"
-    plan = buffers.get(key)
-    if plan is None:
-        plan = fused_moe.plan_weights(
-            quant_modes="w4a16",
-            source_format="fp4_e8m0_k32",
-            activation="silu",
-            params_dtype=torch.bfloat16,
-            num_experts=num_experts,
-            hidden_size=hidden_size,
-            intermediate_size=intermediate,
-            w13_layout="up_gate",
-        )
-        buffers[key] = plan
-    return plan
-
-
-def _get_scratch(
-    *,
-    weight_plan,
-    top_k: int,
-    device,
-    swiglu_limit,
-    tokens_per_seq,
-    experts,
-    num_experts: int,
-    hidden_size: int,
-):
-    """Plan and allocate the shared scratch buffer, once per shape."""
-    from b12x.moe import fused_moe
-
-    from sglang.srt.runtime_context import get_resources
-
-    max_tokens = _b12x_max_tokens()
-    # One scratch arena per shape, shared by every layer: they run sequentially
-    # and it is pure scratch. Allocated at load time so it can never land in a
-    # CUDA graph's private memory pool -- a buffer first allocated during
-    # capture is only valid inside that graph, and reusing it from an
-    # un-captured forward faults.
-    buffers = get_resources().buffers
-    key = f"b12x:scratch:{id(weight_plan)}:{top_k}:{device}:{swiglu_limit}"
-    entry = buffers.get(key)
-    if entry is None:
-        if envs.SGLANG_B12X_RELAX_BLOCKS_PER_SM.get():
-            _relax_blocks_per_sm()
-        counts = _core_token_counts(max_tokens, tokens_per_seq)
-        caps = fused_moe.Caps(
-            max_tokens=max_tokens,
-            num_topk=top_k,
-            device=device,
-            weight_plan=weight_plan,
-            quant_mode="w4a16",
-            swiglu_limit=swiglu_limit,
-            core_token_counts=counts,
-            frozen=True,
-        )
-        plan = fused_moe.plan(caps)
-        scratch = torch.empty(
-            fused_moe.required_nbytes(caps), dtype=torch.uint8, device=device
-        )
-        log_info_on_rank0(
-            logger,
-            f"Compiling {len(counts)} b12x W4A16 kernels "
-            f"(token counts {counts[0]}..{counts[-1]})...",
-        )
-        _warmup(
-            plan=plan,
-            scratch=scratch,
-            experts=experts,
-            top_k=top_k,
-            num_experts=num_experts,
-            hidden_size=hidden_size,
-            device=device,
-            counts=counts,
-        )
-        entry = (plan, scratch)
-        buffers[key] = entry
-    return entry
-
-
 class Mxfp4B12xMoEMethod:
     """b12x MXFP4 MoE: one fused W4A16 kernel per expert layer."""
 
     def __init__(self, fp8_method, prefix: str):
         if not is_b12x_available():
             raise RuntimeError(
-                "The b12x MoE backend needs the b12x package: "
-                "pip install --no-deps b12x==1.2.2"
+                "The b12x MoE backend needs the 0.15.3-generation b12x "
+                f"package: {_B12X_INSTALL_HINT}"
             )
+        _require_015_generation()
         if not is_sm120_supported():
             raise RuntimeError("Mxfp4B12xMoEMethod requires SM120 or SM121.")
         self._fp8 = fp8_method
         self.prefix = prefix
-        self._experts: Any = None
-        self._plan: Any = None
-        self._scratch: torch.Tensor | None = None
         self._swiglu_limit: float | None = None
-        # Set on the 0.15.3 path, where the whole call is a prepared closure.
+        # The whole call is a prepared closure; see _make_launcher.
         self._launch: Any = None
-        self._legacy_keepalive: Any = None
+        self._keepalive: Any = None
         self._ep_guard = False
 
     @property
@@ -538,105 +386,54 @@ class Mxfp4B12xMoEMethod:
         except Exception:
             spec_tokens = 1
 
-        if _b12x_is_legacy():
-            # 0.15.3: one call prepares the weights in place, and the scratch
-            # plan is built straight from the shapes -- there is no separate
-            # weight plan to share between layers.
-            w13 = layer.w13_weight.data.view(torch.uint8)
-            s13 = layer.w13_weight_scale_inv.data.view(torch.uint8)
-            w2 = layer.w2_weight.data.view(torch.uint8)
-            s2 = layer.w2_weight_scale_inv.data.view(torch.uint8)
-            prepared = _legacy_prepare(w13=w13, s13=s13, w2=w2, s2=s2, ones=ones)
-            counts = _core_token_counts(_b12x_max_tokens(), spec_tokens)
-            plan, scratch = _legacy_plan(
-                num_experts=num_experts,
-                hidden_size=hidden_size,
-                intermediate=intermediate,
-                top_k=int(layer.top_k),
-                device=device,
-                swiglu_limit=self._swiglu_limit,
-                counts=counts,
-            )
-            self._launch = _legacy_launcher(
-                plan=plan,
-                scratch=scratch,
-                prepared=prepared,
-                w13=w13,
-                s13=s13,
-                w2=w2,
-                s2=s2,
-                ones=ones,
-                swiglu_limit=self._swiglu_limit,
-            )
-            # reuse_input_storage=True: the prepared package aliases these
-            # tensors, so they must stay reachable. Keep the Parameters as they
-            # are and hold our own references.
-            self._legacy_keepalive = (prepared, w13, s13, w2, s2, ones, plan, scratch)
-            # Same reason as the 1.2.2 path: b12x will not compile while a CUDA
-            # graph is being captured, so every shape a graph can present has to
-            # have run once already.
-            if not _B12X_WARMED:
-                log_info_on_rank0(
-                    logger,
-                    f"Compiling b12x 0.15.3 W4A16 kernels for {len(counts)} "
-                    f"token counts ({counts[0]}..{counts[-1]})...",
-                )
-                _warmup_legacy(
-                    launch=self._launch,
-                    top_k=int(layer.top_k),
-                    num_experts=num_experts,
-                    hidden_size=hidden_size,
-                    device=device,
-                    counts=counts,
-                )
-            layer._dsv4_mxfp4_backend = "b12x_sm12x_015"
-            return
-
-        from b12x.moe import fused_moe
-
-        weight_plan = _get_weight_plan(
+        # One call prepares the weights in place, and the scratch plan is
+        # built straight from the shapes.
+        w13 = layer.w13_weight.data.view(torch.uint8)
+        s13 = layer.w13_weight_scale_inv.data.view(torch.uint8)
+        w2 = layer.w2_weight.data.view(torch.uint8)
+        s2 = layer.w2_weight_scale_inv.data.view(torch.uint8)
+        prepared = _prepare_weights(w13=w13, s13=s13, w2=w2, s2=s2, ones=ones)
+        counts = _core_token_counts(_b12x_max_tokens(), spec_tokens)
+        plan, scratch = _plan_scratch(
             num_experts=num_experts,
             hidden_size=hidden_size,
             intermediate=intermediate,
-        )
-        self._experts = fused_moe.prepare_weights(
-            plan=weight_plan,
-            params_dtype=torch.bfloat16,
-            w1_fp4=layer.w13_weight.data.view(torch.uint8),
-            w1_blockscale=layer.w13_weight_scale_inv.data.view(torch.uint8),
-            w1_global_scale=ones,
-            w2_fp4=layer.w2_weight.data.view(torch.uint8),
-            w2_blockscale=layer.w2_weight_scale_inv.data.view(torch.uint8),
-            w2_global_scale=ones,
-            a1_gscale=ones,
-            a2_gscale=ones,
-        )
-        self._plan, self._scratch = _get_scratch(
-            weight_plan=weight_plan,
             top_k=int(layer.top_k),
             device=device,
             swiglu_limit=self._swiglu_limit,
-            tokens_per_seq=spec_tokens,
-            experts=self._experts,
-            num_experts=num_experts,
-            hidden_size=hidden_size,
+            counts=counts,
         )
-
-        # b12x owns the runtime weights from here on. Whether it aliased the
-        # checkpoint storage or copied it is its choice; either way nothing else
-        # reads these Parameters again.
-        def _release(param: torch.Tensor) -> Parameter:
-            return Parameter(
-                torch.empty(0, dtype=param.dtype, device=param.device),
-                requires_grad=False,
+        self._launch = _make_launcher(
+            plan=plan,
+            scratch=scratch,
+            prepared=prepared,
+            w13=w13,
+            s13=s13,
+            w2=w2,
+            s2=s2,
+            ones=ones,
+            swiglu_limit=self._swiglu_limit,
+        )
+        # reuse_input_storage=True: the prepared package aliases these
+        # tensors, so they must stay reachable. Keep the Parameters as they
+        # are and hold our own references.
+        self._keepalive = (prepared, w13, s13, w2, s2, ones, plan, scratch)
+        # b12x will not compile while a CUDA graph is being captured, so every
+        # shape a graph can present has to have run once already.
+        if not _B12X_WARMED:
+            log_info_on_rank0(
+                logger,
+                f"Compiling b12x W4A16 kernels for {len(counts)} "
+                f"token counts ({counts[0]}..{counts[-1]})...",
             )
-
-        layer.w13_weight = _release(layer.w13_weight)
-        layer.w2_weight = _release(layer.w2_weight)
-        layer.w13_weight_scale_inv = _release(layer.w13_weight_scale_inv)
-        layer.w2_weight_scale_inv = _release(layer.w2_weight_scale_inv)
-        torch.cuda.empty_cache()
-
+            _warmup(
+                launch=self._launch,
+                top_k=int(layer.top_k),
+                num_experts=num_experts,
+                hidden_size=hidden_size,
+                device=device,
+                counts=counts,
+            )
         layer._dsv4_mxfp4_backend = "b12x_sm12x"
 
     def apply(
@@ -647,9 +444,6 @@ class Mxfp4B12xMoEMethod:
         from sglang.srt.layers.moe.moe_runner.b12x import B12xMoeQuantInfo
 
         quant_info = B12xMoeQuantInfo(
-            experts=self._experts,
-            plan=self._plan,
-            scratch=self._scratch,
             launch=self._launch,
             ep_guard=self._ep_guard,
         )

--- a/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
@@ -26,14 +26,13 @@ MoE surface matches the released wheel::
 (``--no-deps``: b12x's metadata pulls a newer torch and breaks the rest of the
 image.) Later b12x generations changed the W4A16 kernels (0.20.0) and then the
 API (1.2.x); anything but 0.15.3 is rejected at startup rather than silently
-producing different numerics -- see :func:`_check_b12x_version`.
+producing different numerics -- see :func:`_require_015_generation`.
 """
 
 from __future__ import annotations
 
 import logging
 import os
-import sys
 from typing import TYPE_CHECKING, Any
 
 import torch
@@ -57,46 +56,8 @@ _B12X_INSTALL_HINT = (
 )
 
 
-def _select_b12x_distribution() -> None:
-    """Put a local b12x tree on sys.path ahead of whatever pip installed.
-
-    For deployments that carry the 0.15.3 tree as a directory (e.g. extracted
-    from the dspark reference image) instead of pip-installing the pinned
-    source commit. Unset (the default) is a no-op.
-    """
-    path = envs.SGLANG_B12X_PATH.get()
-    if not path:
-        return
-    if not os.path.isdir(os.path.join(path, "b12x")):
-        raise FileNotFoundError(f"SGLANG_B12X_PATH={path!r} has no b12x package.")
-    loaded = sys.modules.get("b12x")
-    if loaded is not None:
-        # Idempotent: this runs once per expert layer. Only a b12x already
-        # imported from somewhere else is a problem, and it is fatal -- the
-        # generations share a module name but not an API.
-        want = os.path.realpath(path)
-        got = os.path.realpath(os.path.dirname(os.path.dirname(loaded.__file__)))
-        if want != got:
-            raise RuntimeError(
-                f"SGLANG_B12X_PATH={path!r} came too late: b12x was already "
-                f"imported from {loaded.__file__}."
-            )
-        return
-    sys.path.insert(0, path)
-
-
-def is_b12x_available() -> bool:
-    try:
-        _select_b12x_distribution()
-        import b12x.integration.tp_moe  # noqa: F401
-
-        return True
-    except ImportError:
-        return False
-
-
-def _check_b12x_version() -> None:
-    """This backend is validated against b12x 0.15.3, and only 0.15.3.
+def _require_015_generation() -> None:
+    """This backend runs against b12x 0.15.3, and only 0.15.3.
 
     Later generations rewrote the W4A16 kernels behind the same
     ``b12x.integration`` API (0.20.0) and then replaced the API (1.2.x), so a
@@ -107,15 +68,16 @@ def _check_b12x_version() -> None:
     import importlib.metadata
 
     try:
+        import b12x  # noqa: F401
+    except ImportError as e:
+        raise RuntimeError(f"b12x is not installed. {_B12X_INSTALL_HINT}") from e
+    try:
         version = importlib.metadata.version("b12x")
     except importlib.metadata.PackageNotFoundError:
         return
     if version != "0.15.3":
-        import b12x
-
         raise RuntimeError(
-            f"b12x at {b12x.__file__} is version {version}; this backend is "
-            "validated against 0.15.3 only. Install the pinned source commit: "
+            f"b12x {version} is installed; this backend requires 0.15.3. "
             f"{_B12X_INSTALL_HINT}"
         )
 
@@ -280,12 +242,7 @@ class Mxfp4B12xMoEMethod:
     """b12x MXFP4 MoE: one fused W4A16 kernel per expert layer."""
 
     def __init__(self, fp8_method, prefix: str):
-        if not is_b12x_available():
-            raise RuntimeError(
-                "The b12x MoE backend needs the 0.15.3-generation b12x "
-                f"package: {_B12X_INSTALL_HINT}"
-            )
-        _check_b12x_version()
+        _require_015_generation()
         if not is_sm120_supported():
             raise RuntimeError("Mxfp4B12xMoEMethod requires SM120 or SM121.")
         self._fp8 = fp8_method

--- a/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
@@ -1,11 +1,17 @@
-"""DeepSeek-V4 MXFP4 expert backend backed by the b12x 0.15.3 W4A16 fused MoE.
+"""DeepSeek-V4 MXFP4 expert backend backed by the b12x W4A16 fused MoE.
 
 Same checkpoint as :mod:`mxfp4_flashinfer_cutlass_moe`, different runtime: one
 fused kernel per expert layer instead of seven, and bf16 activations instead of
 MXFP8.
 
 This targets exactly one generation of the standalone ``b12x`` package: the
-0.15.3 API (``b12x.integration.tp_moe``). Three things depend on that choice:
+op-registry API (``b12x.moe.fused_moe``, ``Caps -> plan() -> bind() -> run()``)
+that lives on ``local-inference-lab/b12x`` master. The pin is the tree the
+official vLLM DGX Spark image ships (nightly-20260815, ``b4d6c7593``) plus the
+two upstream fixes that path needs -- ``5c8318009`` (route-packed W4A16 top-k
+scaling) and ``85d3681b`` (W4A16 route histograms preallocated for CUDA graph
+capture); vLLM does not stage either path, so its image runs without them.
+Three things depend on that choice:
 
 * ``source_format="fp4_e8m0_k32"`` consumes the checkpoint's E8M0 K/32 block
   scales byte for byte, so there is no scale relayout to get wrong.
@@ -13,20 +19,21 @@ This targets exactly one generation of the standalone ``b12x`` package: the
   it binds on real data (gate magnitudes reach 10.1, and half the layers sit
   within 7% of the limit), so dropping it is a correctness change, not a
   rounding one.
-* Kernels are warmed before CUDA graph capture: b12x refuses to compile while
-  a graph is being captured and falls back to a pinned tile config that does
-  not fit every block size, so every token count a captured graph can present
-  is compiled eagerly first (see :func:`_core_token_counts`).
+* Kernels are warmed before CUDA graph capture: an unwarmed token count under
+  capture raises ``RuntimeError`` at launch (``_require_cached``), so every
+  token count a captured graph can present is compiled eagerly first (see
+  :func:`_core_token_counts`).
 
-0.15.3 was never published to PyPI. Install it from the source commit whose
-MoE surface matches the released wheel::
+Install the pinned tree::
 
-    pip install --no-deps "b12x @ https://github.com/local-inference-lab/b12x/archive/7dc6fb8fcc6446ea093537d1657df81985fa5f43.tar.gz"
+    pip install --no-deps "b12x @ https://github.com/local-inference-lab/b12x/archive/85d3681bb2c3749e4e94e121d5d829c7ec6f0b9f.tar.gz"
 
 (``--no-deps``: b12x's metadata pulls a newer torch and breaks the rest of the
-image.) Later b12x generations changed the W4A16 kernels (0.20.0) and then the
-API (1.2.x); anything but 0.15.3 is rejected at startup rather than silently
-producing different numerics -- see :func:`_require_015_generation`.
+image.) Earlier generations -- 0.15.x and the PyPI 1.2.x wheels -- keep the old
+``b12x.integration.tp_moe`` API and different W4A16 kernels; they are rejected
+at startup rather than silently producing different numerics -- see
+:func:`_require_aligned_generation`. The last 0.15.3-based revision of this
+file is the parent of the commit that introduced this docstring.
 """
 
 from __future__ import annotations
@@ -46,9 +53,11 @@ from sglang.srt.utils.common import is_sm120_supported
 os.environ.setdefault("TLLM_LOG_LEVEL", "INFO")
 
 # Route the b12x compile cache through sglang's cache tree (same pattern as
-# DG_JIT_CACHE_DIR in deep_gemm_wrapper). b12x resolves
-# B12X_CUTE_COMPILE_CACHE_DIR at first compile, so import time is early enough.
-os.environ["B12X_CUTE_COMPILE_CACHE_DIR"] = envs.SGLANG_B12X_CACHE_DIR.get()
+# DG_JIT_CACHE_DIR in deep_gemm_wrapper). b12x resolves B12X_COMPILE_CACHE_DIR
+# at first compile, so import time is early enough. (The pre-op-registry name
+# B12X_CUTE_COMPILE_CACHE_DIR must not be set: unrecognized B12X_* variables
+# are folded into the compile-cache key and would fragment the cache.)
+os.environ["B12X_COMPILE_CACHE_DIR"] = envs.SGLANG_B12X_CACHE_DIR.get()
 
 logger = logging.getLogger(__name__)
 
@@ -57,33 +66,30 @@ if TYPE_CHECKING:
 
 _B12X_INSTALL_HINT = (
     "pip install --no-deps 'b12x @ https://github.com/local-inference-lab/"
-    "b12x/archive/7dc6fb8fcc6446ea093537d1657df81985fa5f43.tar.gz'"
+    "b12x/archive/85d3681bb2c3749e4e94e121d5d829c7ec6f0b9f.tar.gz'"
 )
 
 
-def _require_015_generation() -> None:
-    """This backend runs against b12x 0.15.3, and only 0.15.3.
+def _require_aligned_generation() -> None:
+    """This backend runs against the b12x op-registry generation only.
 
-    Later generations rewrote the W4A16 kernels behind the same
-    ``b12x.integration`` API (0.20.0) and then replaced the API (1.2.x), so a
-    version mismatch must fail here rather than surface as different numerics.
-    A source tree without dist-info cannot be checked and is trusted to be the
-    pinned 0.15.3.
+    The API moved twice (0.15.x ``b12x.integration.tp_moe`` -> PyPI 1.2.x same
+    module, new kernels -> master op registry ``b12x.moe.fused_moe``), and the
+    kernels changed with it, so a generation mismatch must fail here rather
+    than surface as different numerics. The probe is structural: only the
+    op-registry generation has a ``b12x.moe.fused_moe`` module.
     """
-    import importlib.metadata
+    import importlib.util
 
     try:
         import b12x  # noqa: F401
     except ImportError as e:
         raise RuntimeError(f"b12x is not installed. {_B12X_INSTALL_HINT}") from e
-    try:
-        version = importlib.metadata.version("b12x")
-    except importlib.metadata.PackageNotFoundError:
-        return
-    if version != "0.15.3":
+    if importlib.util.find_spec("b12x.moe.fused_moe") is None:
         raise RuntimeError(
-            f"b12x {version} is installed; this backend requires 0.15.3. "
-            f"{_B12X_INSTALL_HINT}"
+            "The installed b12x predates the op-registry API "
+            "(b12x.moe.fused_moe); this backend requires the pinned master "
+            f"tree. {_B12X_INSTALL_HINT}"
         )
 
 
@@ -96,14 +102,13 @@ def _core_token_counts(max_tokens: int, tokens_per_seq: int) -> tuple[int, ...]:
     """Token counts to plan capacity for, and to warm kernels at.
 
     Under CUDA graph capture b12x refuses to compile (``_require_cached``) and
-    falls back to the plan's pinned tile config, which does not fit every block
-    size -- so the launch fails outright rather than running slowly. Every token
-    count a captured graph can present must therefore have been run once
-    already. Decode graphs are captured at the configured batch sizes times the
-    speculative window; prefill is chunked, so a power-of-two ladder covers it.
+    raises at launch for any token count that was not run once already. Decode
+    graphs are captured at the configured batch sizes times the speculative
+    window; prefill is chunked, so a power-of-two ladder covers it.
 
-    Each count compiles its own kernel (the startup log line counts them), and
-    the same ladder sizes the scratch arena.
+    b12x buckets W4A16 token capacities to powers of two internally, so warming
+    every count here resolves to far fewer distinct kernels; the same ladder
+    sizes the scratch arena.
     """
     counts = set()
     batch_sizes = list(range(1, 33))
@@ -147,13 +152,25 @@ def _warmup(*, launch, top_k, num_experts, hidden_size, device, counts):
     _B12X_WARMED = True
 
 
-def _prepare_weights(*, w13, s13, w2, s2, ones):
-    """Weight prep. Repacks in place, so the caller's tensors stay live."""
-    from b12x.integration import prepare_b12x_fp4_moe_weights
+def _prepare_weights(*, w13, s13, w2, s2, ones, num_experts, hidden_size, intermediate):
+    """Weight plan + prep. Repacks in place, so the caller's tensors stay live."""
+    from b12x.moe import fused_moe
 
-    return prepare_b12x_fp4_moe_weights(
+    weight_plan = fused_moe.plan_weights(
+        quant_modes="w4a16",
         source_format="fp4_e8m0_k32",
+        activation="silu",
+        params_dtype=torch.bfloat16,
+        num_experts=num_experts,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate,
+        # sglang stores fused W13 as [up; gate] (load_up_proj_weight_first);
+        # vLLM stores [gate; up] and declares "w31" -- do not copy that value.
         w13_layout="up_gate",
+    )
+    return fused_moe.prepare_weights(
+        plan=weight_plan,
+        params_dtype=torch.bfloat16,
         w1_fp4=w13,
         w1_blockscale=s13,
         w1_global_scale=ones,
@@ -162,40 +179,27 @@ def _prepare_weights(*, w13, s13, w2, s2, ones):
         w2_blockscale=s2,
         w2_global_scale=ones,
         a2_gscale=ones,
-        activation="silu",
-        params_dtype=torch.bfloat16,
-        prepare_runtime_alphas=False,
-        prepare_w4a16=True,
-        reuse_input_storage=True,
     )
 
 
-def _plan_scratch(
-    *, num_experts, hidden_size, intermediate, top_k, device, swiglu_limit, counts
-):
+def _plan_scratch(*, experts, top_k, device, swiglu_limit, counts):
     """Frozen scratch plan. Returns (plan, scratch)."""
-    from b12x.integration.tp_moe import TPMoEScratchCaps, plan_tp_moe_scratch
+    from b12x.moe import fused_moe
 
-    caps = TPMoEScratchCaps(
+    caps = fused_moe.Caps(
         max_tokens=max(counts),
-        weight_E=num_experts,
-        k=hidden_size,
-        n=intermediate,
         num_topk=top_k,
         device=device,
-        dtype=torch.bfloat16,
+        weight_plan=experts.plan,
         core_token_counts=tuple(counts),
         route_num_experts=0,
         route_logits_dtype=None,
         quant_mode="w4a16",
-        activation="silu",
         apply_router_weight_on_input=False,
         swiglu_limit=swiglu_limit,
-        source_format="fp4_e8m0_k32",
-        w13_layout="up_gate",
         frozen=True,
     )
-    plan = plan_tp_moe_scratch(caps)
+    plan = fused_moe.plan(caps)
     specs = plan.scratch_specs()
     if len(specs) != 1 or specs[0].dtype != torch.uint8:
         raise RuntimeError(f"unexpected b12x scratch specs: {specs}")
@@ -203,40 +207,23 @@ def _plan_scratch(
     return plan, scratch
 
 
-def _make_launcher(*, plan, scratch, prepared, w13, s13, w2, s2, ones, swiglu_limit):
+def _make_launcher(*, plan, scratch, experts):
     """Bind-and-run closure, matching vLLM's call sequence."""
-    from b12x.integration.tp_moe import b12x_moe_fp4
-
-    packed = prepared.w4a16
-    w1_alphas = prepared.w1_runtime_alphas
-    w2_alphas = prepared.w2_runtime_alphas
-    if w1_alphas is None:
-        w1_alphas = ones
-    if w2_alphas is None:
-        w2_alphas = ones
+    from b12x.moe import fused_moe
 
     def launch(a, topk_ids, topk_weights, out):
-        b12x_moe_fp4(
+        fused_moe.run(
             binding=plan.bind(
                 scratch=scratch,
                 a=a,
-                a1_gscale=ones,
-                w1_fp4=w13,
-                w1_blockscale=s13,
-                w1_alphas=w1_alphas,
-                a2_gscale=ones,
-                w2_fp4=w2,
-                w2_blockscale=s2,
-                w2_alphas=w2_alphas,
+                experts=experts,
                 topk_weights=topk_weights,
                 topk_ids=topk_ids,
                 output=out,
-                activation="silu",
-                quant_mode="w4a16",
-                source_format="fp4_e8m0_k32",
-                w13_layout="up_gate",
-                prepared_w4a16=packed,
-                swiglu_limit=swiglu_limit,
+                # W4A16 contract, same as vLLM: activations are bf16 and every
+                # global scale is the unit filler prepare_weights built.
+                input_scales_static=True,
+                unit_scale_contract=True,
             )
         )
 
@@ -247,7 +234,7 @@ class Mxfp4B12xMoEMethod:
     """b12x MXFP4 MoE: one fused W4A16 kernel per expert layer."""
 
     def __init__(self, fp8_method, prefix: str):
-        _require_015_generation()
+        _require_aligned_generation()
         if not is_sm120_supported():
             raise RuntimeError("Mxfp4B12xMoEMethod requires SM120 or SM121.")
         self._fp8 = fp8_method
@@ -341,38 +328,33 @@ class Mxfp4B12xMoEMethod:
         except Exception:
             spec_tokens = 1
 
-        # One call prepares the weights in place, and the scratch plan is
-        # built straight from the shapes.
         w13 = layer.w13_weight.data.view(torch.uint8)
         s13 = layer.w13_weight_scale_inv.data.view(torch.uint8)
         w2 = layer.w2_weight.data.view(torch.uint8)
         s2 = layer.w2_weight_scale_inv.data.view(torch.uint8)
-        prepared = _prepare_weights(w13=w13, s13=s13, w2=w2, s2=s2, ones=ones)
-        counts = _core_token_counts(_b12x_max_tokens(), spec_tokens)
-        plan, scratch = _plan_scratch(
-            num_experts=num_experts,
-            hidden_size=hidden_size,
-            intermediate=intermediate,
-            top_k=int(layer.top_k),
-            device=device,
-            swiglu_limit=self._swiglu_limit,
-            counts=counts,
-        )
-        self._launch = _make_launcher(
-            plan=plan,
-            scratch=scratch,
-            prepared=prepared,
+        experts = _prepare_weights(
             w13=w13,
             s13=s13,
             w2=w2,
             s2=s2,
             ones=ones,
-            swiglu_limit=self._swiglu_limit,
+            num_experts=num_experts,
+            hidden_size=hidden_size,
+            intermediate=intermediate,
         )
-        # reuse_input_storage=True: the prepared package aliases these
-        # tensors, so they must stay reachable. Keep the Parameters as they
-        # are and hold our own references.
-        self._keepalive = (prepared, w13, s13, w2, s2, ones, plan, scratch)
+        counts = _core_token_counts(_b12x_max_tokens(), spec_tokens)
+        plan, scratch = _plan_scratch(
+            experts=experts,
+            top_k=int(layer.top_k),
+            device=device,
+            swiglu_limit=self._swiglu_limit,
+            counts=counts,
+        )
+        self._launch = _make_launcher(plan=plan, scratch=scratch, experts=experts)
+        # The prepared weights alias the checkpoint storage (REUSE_SOURCE for
+        # 128-aligned fp4_e8m0_k32), so these tensors must stay reachable. Keep
+        # the Parameters as they are and hold our own references.
+        self._keepalive = (experts, w13, s13, w2, s2, ones, plan, scratch)
         # b12x will not compile while a CUDA graph is being captured, so every
         # shape a graph can present has to have run once already.
         if not _B12X_WARMED and envs.SGLANG_B12X_WARMUP.get():

--- a/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
@@ -25,8 +25,8 @@ MoE surface matches the released wheel::
 
 (``--no-deps``: b12x's metadata pulls a newer torch and breaks the rest of the
 image.) Later b12x generations changed the W4A16 kernels (0.20.0) and then the
-API (1.2.x); they are rejected at startup rather than silently producing
-different numerics -- see :func:`_require_015_generation`.
+API (1.2.x); anything but 0.15.3 is rejected at startup rather than silently
+producing different numerics -- see :func:`_check_b12x_version`.
 """
 
 from __future__ import annotations
@@ -95,35 +95,28 @@ def is_b12x_available() -> bool:
         return False
 
 
-def _require_015_generation() -> None:
-    """Reject b12x generations other than 0.15.x, loudly and at load time.
+def _check_b12x_version() -> None:
+    """This backend is validated against b12x 0.15.3, and only 0.15.3.
 
-    0.20.0 rewrote the W4A16 kernels behind the same ``b12x.integration``
-    API (different numerics), and the 1.2.x line replaced the API as well
-    (``b12x.moe.fused_moe``). This backend is validated against 0.15.3 only.
-    A raw source tree without dist-info cannot be version-checked; the
-    ``fused_moe`` probe still rejects the 1.2.x line there.
+    Later generations rewrote the W4A16 kernels behind the same
+    ``b12x.integration`` API (0.20.0) and then replaced the API (1.2.x), so a
+    version mismatch must fail here rather than surface as different numerics.
+    A source tree without dist-info cannot be checked and is trusted to be the
+    pinned 0.15.3.
     """
     import importlib.metadata
 
-    import b12x
-
-    try:
-        import b12x.moe.fused_moe  # noqa: F401  # the 1.2.x-generation API
-
-        has_fused_moe = True
-    except ImportError:
-        has_fused_moe = False
-    version = None
     try:
         version = importlib.metadata.version("b12x")
     except importlib.metadata.PackageNotFoundError:
-        pass
-    if has_fused_moe or (version is not None and not version.startswith("0.15.")):
+        return
+    if version != "0.15.3":
+        import b12x
+
         raise RuntimeError(
-            f"b12x at {b12x.__file__} (version {version or 'unknown'}) is not "
-            "the 0.15.x generation this backend is validated against. "
-            f"Install the pinned source commit: {_B12X_INSTALL_HINT}"
+            f"b12x at {b12x.__file__} is version {version}; this backend is "
+            "validated against 0.15.3 only. Install the pinned source commit: "
+            f"{_B12X_INSTALL_HINT}"
         )
 
 
@@ -292,7 +285,7 @@ class Mxfp4B12xMoEMethod:
                 "The b12x MoE backend needs the 0.15.3-generation b12x "
                 f"package: {_B12X_INSTALL_HINT}"
             )
-        _require_015_generation()
+        _check_b12x_version()
         if not is_sm120_supported():
             raise RuntimeError("Mxfp4B12xMoEMethod requires SM120 or SM121.")
         self._fp8 = fp8_method

--- a/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
@@ -36,8 +36,9 @@ Install the pinned tree::
 image.) Earlier generations -- 0.15.x and the PyPI 1.2.x wheels -- keep the old
 ``b12x.integration.tp_moe`` API and different W4A16 kernels; they are rejected
 at startup rather than silently producing different numerics -- see
-:func:`_require_aligned_generation`. The last 0.15.3-based revision of this
-file is the parent of the commit that introduced this docstring.
+:func:`sglang.srt.utils.b12x.require_aligned_generation`. The last 0.15.3-based
+revision of this file is the parent of the commit that introduced this
+docstring.
 """
 
 from __future__ import annotations
@@ -51,50 +52,18 @@ from torch.nn import Module
 
 from sglang.srt.environ import envs
 from sglang.srt.utils import log_info_on_rank0
+from sglang.srt.utils.b12x import install_compile_cache_dir, require_aligned_generation
 from sglang.srt.utils.common import is_sm120_supported
 
 # Suppress TRT-LLM CUTLASS trace logs without overriding user configuration.
 os.environ.setdefault("TLLM_LOG_LEVEL", "INFO")
 
-# Route the b12x compile cache through sglang's cache tree (same pattern as
-# DG_JIT_CACHE_DIR in deep_gemm_wrapper). b12x resolves B12X_COMPILE_CACHE_DIR
-# at first compile, so import time is early enough. (The pre-op-registry name
-# B12X_CUTE_COMPILE_CACHE_DIR must not be set: unrecognized B12X_* variables
-# are folded into the compile-cache key and would fragment the cache.)
-os.environ["B12X_COMPILE_CACHE_DIR"] = envs.SGLANG_B12X_CACHE_DIR.get()
+install_compile_cache_dir()
 
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from sglang.srt.layers.moe.token_dispatcher import CombineInput, DispatchOutput
-
-_B12X_INSTALL_HINT = (
-    "pip install --no-deps 'b12x @ https://github.com/local-inference-lab/"
-    "b12x/archive/85d3681bb2c3749e4e94e121d5d829c7ec6f0b9f.tar.gz'"
-)
-
-
-def _require_aligned_generation() -> None:
-    """This backend runs against the b12x op-registry generation only.
-
-    The API moved twice (0.15.x ``b12x.integration.tp_moe`` -> PyPI 1.2.x same
-    module, new kernels -> master op registry ``b12x.moe.fused_moe``), and the
-    kernels changed with it, so a generation mismatch must fail here rather
-    than surface as different numerics. The probe is structural: only the
-    op-registry generation has a ``b12x.moe.fused_moe`` module.
-    """
-    import importlib.util
-
-    try:
-        import b12x  # noqa: F401
-    except ImportError as e:
-        raise RuntimeError(f"b12x is not installed. {_B12X_INSTALL_HINT}") from e
-    if importlib.util.find_spec("b12x.moe.fused_moe") is None:
-        raise RuntimeError(
-            "The installed b12x predates the op-registry API "
-            "(b12x.moe.fused_moe); this backend requires the pinned master "
-            f"tree. {_B12X_INSTALL_HINT}"
-        )
 
 
 def _b12x_max_tokens() -> int:
@@ -349,7 +318,7 @@ class Mxfp4B12xMoEMethod:
     """b12x MXFP4 MoE: one fused kernel per expert layer."""
 
     def __init__(self, fp8_method, prefix: str):
-        _require_aligned_generation()
+        require_aligned_generation()
         if not is_sm120_supported():
             raise RuntimeError("Mxfp4B12xMoEMethod requires SM120 or SM121.")
         self._fp8 = fp8_method
@@ -497,7 +466,7 @@ class Mxfp4B12xMoEMethod:
         self._keepalive = (experts, w13, s13, w2, s2, ones, plan_or_arena)
         # b12x will not compile while a CUDA graph is being captured, so every
         # shape a graph can present has to have run once already.
-        if not _B12X_WARMED and envs.SGLANG_B12X_WARMUP.get():
+        if not _B12X_WARMED and envs.SGLANG_B12X_ENABLE_WARMUP.get():
             log_info_on_rank0(
                 logger,
                 f"Compiling b12x {quant_mode} kernels for {len(counts)} "

--- a/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
@@ -183,8 +183,32 @@ def _prepare_weights(*, w13, s13, w2, s2, ones, num_experts, hidden_size, interm
 
 
 def _plan_scratch(*, experts, top_k, device, swiglu_limit, counts):
-    """Frozen scratch plan. Returns (plan, scratch)."""
+    """One frozen scratch plan + arena shared by every expert layer.
+
+    Every expert layer presents identical caps, so one plan and one arena
+    serve them all (per-layer arenas once wasted ~12 GB here; bind is a pure
+    view mapping over the arena, so sharing is allocation- and state-free).
+    The weight-plan identity check in bind passes across layers because
+    MoEWeightPreparationPlan is a tensor-free frozen dataclass with value
+    equality.
+    """
     from b12x.moe import fused_moe
+
+    from sglang.srt.runtime_context import get_resources
+
+    fingerprint = (
+        int(top_k),
+        tuple(counts),
+        None if swiglu_limit is None else float(swiglu_limit),
+        int(experts.num_experts),
+        int(experts.hidden_size),
+        int(experts.intermediate_size),
+    )
+    buffers = get_resources().buffers
+    key = f"b12x:moe_plan:{device}"
+    cached = buffers.get(key)
+    if cached is not None and cached[0] == fingerprint:
+        return cached[1], cached[2]
 
     caps = fused_moe.Caps(
         max_tokens=max(counts),
@@ -204,6 +228,7 @@ def _plan_scratch(*, experts, top_k, device, swiglu_limit, counts):
     if len(specs) != 1 or specs[0].dtype != torch.uint8:
         raise RuntimeError(f"unexpected b12x scratch specs: {specs}")
     scratch = torch.empty(int(specs[0].shape[0]), dtype=torch.uint8, device=device)
+    buffers[key] = (fingerprint, plan, scratch)
     return plan, scratch
 
 

--- a/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
@@ -19,8 +19,18 @@ FlashInfer. Three things depend on that choice:
   but it refuses to compile at all while a graph is being captured, which is
   what the warm-up exists for.
 
-Install with ``pip install --no-deps b12x==1.2.2``; without ``--no-deps`` pip
-pulls a newer torch and breaks the rest of the image.
+Two b12x API generations are supported, auto-detected by import shape
+(:func:`_b12x_is_legacy`); "legacy" throughout this file names the API
+generation, not a recommendation:
+
+* **1.2.2** (``b12x.moe.fused_moe``) is the current PyPI release and the
+  default. Install with ``pip install --no-deps b12x==1.2.2``; without
+  ``--no-deps`` pip pulls a newer torch and breaks the rest of the image.
+* **0.15.3** (``b12x.integration``, the legacy API) was never published to
+  PyPI and can only come from a checkout (``SGLANG_B12X_PATH``). On this
+  shape it is ~19% *faster* per call -- see
+  :func:`_select_b12x_distribution` for the numbers and the mechanism --
+  which is why a deployment would bother.
 """
 
 from __future__ import annotations

--- a/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
@@ -46,19 +46,6 @@ logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from sglang.srt.layers.moe.token_dispatcher import CombineInput, DispatchOutput
 
-# One scratch buffer per (num_experts, k, n, top_k, device), shared by every
-# layer: they run sequentially and it is pure scratch. Allocated at load time so
-# it can never land in a CUDA graph's private memory pool -- a buffer first
-# allocated during capture is only valid inside that graph, and reusing it from
-# an un-captured forward faults.
-_B12X_SCRATCH: dict = {}
-
-# Every expert layer in the model has the same shape, so they share one weight
-# plan. That is not just a memory saving: b12x's compiled-kernel cache is keyed
-# per plan, so sharing means the warm-up below compiles each token count once
-# for the whole model instead of once per layer.
-_B12X_WEIGHT_PLANS: dict = {}
-
 
 def _select_b12x_distribution() -> None:
     """Put the pinned b12x on sys.path ahead of whatever pip installed.
@@ -155,9 +142,6 @@ def _core_token_counts(max_tokens: int, tokens_per_seq: int) -> tuple[int, ...]:
     return tuple(sorted(c for c in counts if 0 < c <= max_tokens))
 
 
-_BLOCKS_PER_SM_RELAXED = False
-
-
 def _relax_blocks_per_sm() -> None:
     """Undo b12x's one-CTA-per-SM pin for moe_block_size==8.
 
@@ -172,12 +156,13 @@ def _relax_blocks_per_sm() -> None:
     launch bounds and therefore of b12x's kernel cache key, and b12x refuses to
     compile during CUDA graph capture.
     """
-    global _BLOCKS_PER_SM_RELAXED
-    if _BLOCKS_PER_SM_RELAXED:
-        return
     from b12x.moe._shared.kernels.w4a16 import kernel as b12x_kernel
 
     original = b12x_kernel._determine_blocks_per_sm
+    # Latched on the patched function itself: the patch is process-global state
+    # inside the b12x module, which reset_context() cannot (and must not) undo.
+    if getattr(original, "_sglang_unpinned", False):
+        return
 
     def _unpinned(*args, **kwargs):
         # Route to the cta_m_blocks==1 branch, which caps at 4 rather than 1.
@@ -186,8 +171,8 @@ def _relax_blocks_per_sm() -> None:
         kwargs["uses_m_block_8"] = False
         return original(*args, **kwargs)
 
+    _unpinned._sglang_unpinned = True
     b12x_kernel._determine_blocks_per_sm = _unpinned
-    _BLOCKS_PER_SM_RELAXED = True
     log_info_on_rank0(
         logger, "b12x: dropped the one-CTA-per-SM pin for moe_block_size==8."
     )
@@ -226,6 +211,9 @@ def _warmup(*, plan, scratch, experts, top_k, num_experts, hidden_size, device, 
     torch.cuda.synchronize()
 
 
+# Module-level on purpose: this latch mirrors b12x's own process-global
+# compiled-kernel cache, which reset_context() cannot reset -- re-warming after
+# a context reset would be wasted work, not a correctness need.
 _B12X_WARMED = False
 
 
@@ -340,11 +328,20 @@ def _legacy_launcher(*, plan, scratch, prepared, w13, s13, w2, s2, ones, swiglu_
 
 
 def _get_weight_plan(*, num_experts: int, hidden_size: int, intermediate: int):
-    """One weight plan per shape, shared by every expert layer."""
+    """One weight plan per shape, shared by every expert layer.
+
+    Not just a memory saving: b12x's compiled-kernel cache is keyed per plan,
+    so sharing means the warm-up compiles each token count once for the whole
+    model instead of once per layer. Stored on ``get_resources().buffers`` so
+    unit-test teardown (``reset_context``) drops it with everything else.
+    """
     from b12x.moe import fused_moe
 
-    key = (num_experts, hidden_size, intermediate)
-    plan = _B12X_WEIGHT_PLANS.get(key)
+    from sglang.srt.runtime_context import get_resources
+
+    buffers = get_resources().buffers
+    key = f"b12x:weight_plan:{num_experts}:{hidden_size}:{intermediate}"
+    plan = buffers.get(key)
     if plan is None:
         plan = fused_moe.plan_weights(
             quant_modes="w4a16",
@@ -356,7 +353,7 @@ def _get_weight_plan(*, num_experts: int, hidden_size: int, intermediate: int):
             intermediate_size=intermediate,
             w13_layout="up_gate",
         )
-        _B12X_WEIGHT_PLANS[key] = plan
+        buffers[key] = plan
     return plan
 
 
@@ -374,9 +371,17 @@ def _get_scratch(
     """Plan and allocate the shared scratch buffer, once per shape."""
     from b12x.moe import fused_moe
 
+    from sglang.srt.runtime_context import get_resources
+
     max_tokens = _b12x_max_tokens()
-    key = (id(weight_plan), top_k, str(device), swiglu_limit)
-    entry = _B12X_SCRATCH.get(key)
+    # One scratch arena per shape, shared by every layer: they run sequentially
+    # and it is pure scratch. Allocated at load time so it can never land in a
+    # CUDA graph's private memory pool -- a buffer first allocated during
+    # capture is only valid inside that graph, and reusing it from an
+    # un-captured forward faults.
+    buffers = get_resources().buffers
+    key = f"b12x:scratch:{id(weight_plan)}:{top_k}:{device}:{swiglu_limit}"
+    entry = buffers.get(key)
     if entry is None:
         if envs.SGLANG_B12X_RELAX_BLOCKS_PER_SM.get():
             _relax_blocks_per_sm()
@@ -411,7 +416,7 @@ def _get_scratch(
             counts=counts,
         )
         entry = (plan, scratch)
-        _B12X_SCRATCH[key] = entry
+        buffers[key] = entry
     return entry
 
 

--- a/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
@@ -45,6 +45,11 @@ from sglang.srt.utils.common import is_sm120_supported
 # Suppress TRT-LLM CUTLASS trace logs without overriding user configuration.
 os.environ.setdefault("TLLM_LOG_LEVEL", "INFO")
 
+# Route the b12x compile cache through sglang's cache tree (same pattern as
+# DG_JIT_CACHE_DIR in deep_gemm_wrapper). b12x resolves
+# B12X_CUTE_COMPILE_CACHE_DIR at first compile, so import time is early enough.
+os.environ["B12X_CUTE_COMPILE_CACHE_DIR"] = envs.SGLANG_B12X_CACHE_DIR.get()
+
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
@@ -370,7 +375,7 @@ class Mxfp4B12xMoEMethod:
         self._keepalive = (prepared, w13, s13, w2, s2, ones, plan, scratch)
         # b12x will not compile while a CUDA graph is being captured, so every
         # shape a graph can present has to have run once already.
-        if not _B12X_WARMED:
+        if not _B12X_WARMED and envs.SGLANG_B12X_WARMUP.get():
             log_info_on_rank0(
                 logger,
                 f"Compiling b12x W4A16 kernels for {len(counts)} "

--- a/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
@@ -27,10 +27,13 @@ generation, not a recommendation:
   default. Install with ``pip install --no-deps b12x==1.2.2``; without
   ``--no-deps`` pip pulls a newer torch and breaks the rest of the image.
 * **0.15.3** (``b12x.integration``, the legacy API) was never published to
-  PyPI and can only come from a checkout (``SGLANG_B12X_PATH``). On this
-  shape it is ~19% *faster* per call -- see
-  :func:`_select_b12x_distribution` for the numbers and the mechanism --
-  which is why a deployment would bother.
+  PyPI -- it ships only inside the dspark reference image, and 0.15.2 (the
+  last published 0.15.x) predates the ``fp4_e8m0_k32`` / ``w13_layout``
+  API this file needs -- so it can only come from a checkout
+  (``SGLANG_B12X_PATH``). At the decode working point (M=6) it is ~19%
+  *faster* per call -- see :func:`_select_b12x_distribution` -- while at
+  prefill-sized M the two generations are within noise; that decode delta
+  is why a deployment would bother.
 """
 
 from __future__ import annotations

--- a/python/sglang/srt/layers/quantization/mxfp4_flashinfer_trtllm_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_flashinfer_trtllm_moe.py
@@ -377,6 +377,7 @@ def maybe_fuse_routed_scale_and_shared_add(
     # alpha=scale)`. With no shared output, the missing scale is applied
     # in-place. Otherwise `routed` is already scale-final and we just add
     # `shared` (or pass through if there is none).
+    from sglang.srt.layers.quantization.mxfp4_b12x_moe import Mxfp4B12xMoEMethod
     from sglang.srt.layers.quantization.mxfp4_flashinfer_cutlass_moe import (
         Mxfp4FlashinferCutlassMoEMethod,
     )
@@ -390,6 +391,7 @@ def maybe_fuse_routed_scale_and_shared_add(
             Mxfp4FlashinferTrtllmMoEMethod,
             Mxfp4FlashinferCutlassMoEMethod,
             Mxfp4MarlinMoEMethod,
+            Mxfp4B12xMoEMethod,
         ),
     )
     if fused:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -260,6 +260,7 @@ MOE_RUNNER_BACKEND_CHOICES = [
     "flashinfer_cutlass",
     "flashinfer_mxfp4",
     "flashinfer_cutedsl",
+    "b12x",
     "cutlass",
     "aiter",
     "marlin",

--- a/python/sglang/srt/utils/b12x.py
+++ b/python/sglang/srt/utils/b12x.py
@@ -1,0 +1,88 @@
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Shared plumbing for the b12x backends (SM12x / GB10).
+
+sglang runs b12x from more than one place -- the MXFP4 MoE runner and the
+DSv4-Flash compressed-MLA attention branch -- and all of them need the same
+three things: the pinned install hint, the generation guard, and the compile
+cache pointed at sglang's cache tree. They live here so a pin move is one edit
+and the guard cannot drift between backends.
+
+The pin is the tree the official vLLM DGX Spark image ships (nightly-20260815,
+``b4d6c7593``) plus the two upstream fixes sglang's staging needs -- see the
+module docstring of :mod:`sglang.srt.layers.quantization.mxfp4_b12x_moe`.
+"""
+
+from __future__ import annotations
+
+import os
+
+from sglang.srt.environ import envs
+
+B12X_PIN = "85d3681bb2c3749e4e94e121d5d829c7ec6f0b9f"
+
+INSTALL_HINT = (
+    "pip install --no-deps 'b12x @ https://github.com/local-inference-lab/"
+    f"b12x/archive/{B12X_PIN}.tar.gz'"
+)
+
+# The op-registry entry points every b12x backend here is written against.
+# A tree that has the module but not these names is a different generation.
+_REQUIRED_FUSED_MOE_ATTRS = ("Caps", "plan", "plan_weights", "prepare_weights", "run")
+
+
+def install_compile_cache_dir() -> None:
+    """Route b12x's compile cache through sglang's cache tree.
+
+    Same pattern as ``DG_JIT_CACHE_DIR`` in ``deep_gemm_wrapper``. b12x
+    resolves ``B12X_COMPILE_CACHE_DIR`` at first compile, so any call before
+    the first kernel launch is early enough; ``setdefault`` so an explicitly
+    configured cache dir wins.
+
+    The pre-op-registry name ``B12X_CUTE_COMPILE_CACHE_DIR`` must not be set:
+    this generation ignores it, and unrecognized ``B12X_*`` variables are
+    folded into the compile-cache key, which would fragment the cache.
+    """
+    os.environ.setdefault("B12X_COMPILE_CACHE_DIR", envs.SGLANG_B12X_CACHE_DIR.get())
+
+
+def require_aligned_generation() -> None:
+    """Fail unless the installed b12x is the pinned op-registry generation.
+
+    The API moved twice (0.15.x ``b12x.integration.tp_moe`` -> PyPI 1.2.x same
+    module, new kernels -> master op registry ``b12x.moe.fused_moe``), and the
+    kernels changed with it, so a generation mismatch must fail here rather
+    than surface as different numerics. The wheel version string cannot be
+    used: it stayed 1.2.3 across the re-architecture. So the probe is
+    structural -- the ``b12x.moe.fused_moe`` module has to exist, and it has
+    to expose the op-registry entry points.
+    """
+    try:
+        import b12x  # noqa: F401
+    except ImportError as e:
+        raise RuntimeError(f"b12x is not installed. {INSTALL_HINT}") from e
+    try:
+        from b12x.moe import fused_moe
+    except ImportError as e:
+        raise RuntimeError(
+            "The installed b12x predates the op-registry API "
+            f"(b12x.moe.fused_moe); this backend requires the pinned master "
+            f"tree {B12X_PIN[:9]}. {INSTALL_HINT}"
+        ) from e
+    missing = [a for a in _REQUIRED_FUSED_MOE_ATTRS if not hasattr(fused_moe, a)]
+    if missing:
+        raise RuntimeError(
+            f"b12x.moe.fused_moe is missing {', '.join(missing)}: this is not "
+            f"the pinned op-registry generation {B12X_PIN[:9]}. {INSTALL_HINT}"
+        )


### PR DESCRIPTION

Updates the DSv4-Flash b12x MXFP4 expert backend so sglang runs the same MoE
kernels the official vLLM DGX Spark image runs. This supersedes the earlier
revision of this PR: same backend, but on the op-registry generation of b12x,
with one shared scratch arena, and with the activation-quantized recipe on by
default.

Branch: `b12x-moe-sm12x` (force-push of the reviewed content; four commits).

## Why

The official vLLM DGX Spark image (`eugr/spark-vllm-b12x`, nightly-20260815)
ships b12x built from `local-inference-lab/b12x` master at `b4d6c7593`, which is
the op-registry re-architecture (`Caps -> plan -> bind -> run`,
`b12x.moe.fused_moe`). The previous revision of this backend targeted the 0.15.3
`b12x.integration.tp_moe` API, so the two stacks were running different kernels
and any comparison between them was measuring two things at once.

## What changed

**1. Migrate the MoE backend to the op-registry generation.**
`prepare_b12x_fp4_moe_weights` splits into `plan_weights` + `prepare_weights`;
format / layout / activation move onto the weight plan; `Caps` takes
`weight_plan=experts.plan` instead of the per-tensor fields; `bind` takes
`experts=` instead of 12 tensor kwargs, plus the W4A16 contract flags vLLM sets
(`input_scales_static=True`, `unit_scale_contract=True`). `w13_layout` stays
`up_gate` — sglang stores fused W13 as `[up; gate]`, and vLLM's `"w31"` reflects
its own `[gate; up]` storage; copying that value would be a silent correctness
bug. The compile-cache variable is renamed with the generation
(`B12X_CUTE_COMPILE_CACHE_DIR` -> `B12X_COMPILE_CACHE_DIR`); the old name is not
merely ignored, it is folded into the compile-cache key and fragments it. The
generation guard becomes structural rather than a version string, because the
wheel version stayed `1.2.3` across the re-architecture and cannot distinguish
generations.

**2. The pin is two commits past the vLLM image tree.** Both hops fix b12x code
paths that sglang stages and vLLM's recipe never touches, which is why the image
runs without them:

- `5c8318009` — *Fix route-packed W4A16 top-k scaling* (b12x #219). At
  `b4d6c7593` the route-packed W4A16 epilogue references `metadata_row`, which is
  never defined when `mul_topk_weights` is compile-time enabled. Our FC2 applies
  top-k weights in-kernel, so it fails to compile. vLLM never stages that path
  (direct small-M kernels, router weight applied on the input).
- `85d3681b` — *preallocate W4A16 route histograms for CUDA graph capture*
  (b12x #150). At `5c8318009` the non-trellis W4A16 arena spec list omits the
  route-packing histogram, so `bind` maps no view for it and the eager
  `torch.empty` fallback is refused under capture (`expert_counts is not
  initialized for CUDA graph capture`). vLLM sidesteps this by making b12x MoE a
  piecewise-graph boundary; sglang captures the full model graph and needs the
  histogram in the arena.

Both landed upstream the same evening as the image tree. Every other commit in
the interval is comm / PCIe-DCP-only and inert here.

**3. One scratch plan and one arena, shared across expert layers.** Per-layer
`torch.empty` resurrected the arena-duplication bug the 0.15.3 line already
fixed once: 46 expert layers x ~250 MB left no room for the KV cache at
`--mem-fraction-static=0.75` — the server refused to boot, and the minimum
viable fraction was 0.829. Every expert layer presents identical caps, so one
plan and one arena serve them all, which is also what vLLM's shared workspace
manager does. Sharing is safe because `bind` is a pure view mapping over the
arena: it holds no per-layer state, and the weight-plan identity check it
performs passes across layers because `MoEWeightPreparationPlan` is a
tensor-free frozen dataclass with value equality. Both live in
`get_resources().buffers` behind a caps fingerprint, and layers are prepared at
load time, before any capture, so the allocation never moves an address a
captured graph baked.

**4. W4A8 by default — this flips the numerics of this backend.** The vLLM image
does not run the MoE as W4A16: its recipe sets `B12X_MOE_FORCE_A8=1`, selecting
`quant_mode=w4a8_mx`, where activations are quantized to MXFP8-E4M3 in-kernel and
served by the micro / dynamic kernel families that carry all of b12x's GB10
tuning. The W4A16 monolith is 945 us/launch at M=6 against their tuned dynamic
path, and their kernel is trace-confirmed as `MoEDynamicKernelSilu`, which is
structurally w4a8-only.

W4A8 picks implementation (micro vs dynamic) and tile regime from the live token
count, so the launcher plans per call, vLLM-style. That is affordable because
b12x planning on this recipe is host-only and allocation-free, and under
full-graph capture it runs once per bucket at capture time — replay is pure GPU.
The shared arena is sized once over the whole count ladder via
`required_nbytes`. `unit_scale_contract` stays W4A16-only per b12x's own gating;
`input_scales_static` holds for both.

**Accuracy evidence for the default flip.** DSv4-Flash on 2x DGX Spark, GSM8K
with no simulated accept length, three runs: **0.980 / 0.975 / 0.965**.
Speculative accept length holds at **4.02** — no degradation attributable to the
activation quantization.

To go back: `SGLANG_B12X_MOE_QUANT_MODE=w4a16` restores the frozen-plan
bf16-activation path unchanged.

**5. Shaping (no behavior change).**
- New `python/sglang/srt/utils/b12x.py` holds the pin, the install hint, the
  generation guard and the compile-cache plumbing. sglang runs b12x from more
  than one place, and each caller was about to grow its own copy; one home means
  a pin move is one edit and the guard cannot drift between backends.
- The compile-cache write becomes `setdefault`, so an explicitly configured
  `B12X_COMPILE_CACHE_DIR` is honoured instead of overwritten at import.
- The generation guard also checks the op-registry entry points
  (`Caps`, `plan`, `plan_weights`, `prepare_weights`, `run`), so a partial match
  fails at startup with the install hint instead of as an `AttributeError` deep
  in weight loading.

## Environment variables

| Name | Default | Meaning |
|---|---|---|
| `SGLANG_B12X_MOE_QUANT_MODE` | `w4a8_mx` | b12x quant mode, passed through verbatim. `w4a16` restores the previous path. Replaces the boolean sketch (`SGLANG_B12X_MOE_A8`) — the knob is the string b12x actually takes, and the set of modes is b12x's to grow. |
| `SGLANG_B12X_ENABLE_WARMUP` | `True` | Compile every planned token count at load time, before capture. Renamed from `SGLANG_B12X_WARMUP` for the `ENABLE_` verb; the old name never shipped, so there is no alias. |
| `SGLANG_B12X_MAX_TOKENS` | `4096` | Upper bound on tokens in one MoE call; sizes the arena. Track `--chunked-prefill-size` if that is raised. |
| `SGLANG_B12X_CACHE_DIR` | `<sglang cache>/b12x` | Forwarded to `B12X_COMPILE_CACHE_DIR`. |

## Install

```
pip install --no-deps "b12x @ https://github.com/local-inference-lab/b12x/archive/85d3681bb2c3749e4e94e121d5d829c7ec6f0b9f.tar.gz"
```

`--no-deps` is required: b12x's metadata pulls a newer torch and breaks the rest
of the image.

## Scope

SM120 / SM121 only, and only reachable when the b12x MoE method is selected — no
other target's code path is touched. Earlier b12x generations (0.15.x, the PyPI
1.2.x wheels) are rejected at startup rather than producing different numerics
silently.

## Test plan

- 2x DGX Spark (GB10, sm_121), DeepSeek-V4-Flash, TP=2: server boots at
  `--mem-fraction-static=0.75` (the arena fix), full-model CUDA graph capture
  completes (the `85d3681b` hop), GSM8K as above.
- `SGLANG_B12X_MOE_QUANT_MODE=w4a16` exercises the frozen-plan path.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32513702094](https://github.com/sgl-project/sglang/actions/runs/32513702094)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32513701772](https://github.com/sgl-project/sglang/actions/runs/32513701772)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32513702106](https://github.com/sgl-project/sglang/actions/runs/32513702106)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->