### PR TITLE
feat(rust-server): support custom_logit_processor in /generate

### DIFF
--- a/python/sglang/srt/managers/rust_server.py
+++ b/python/sglang/srt/managers/rust_server.py
@@ -801,6 +801,7 @@ class RustServer:
             ),
             allow_auto_truncate=sa.allow_auto_truncate,
             enable_return_hidden_states=sa.enable_return_hidden_states,
+            enable_custom_logit_processor=sa.enable_custom_logit_processor,
             # Not a `server_args` field: `TokenizerManager` derives it, and the
             # rust ingress needs the same number for its total-token check.
             num_reserved_tokens=compute_num_reserved_tokens(),

--- a/rust/sglang-server/src/message/config.rs
+++ b/rust/sglang-server/src/message/config.rs
@@ -137,6 +137,7 @@ pub struct ServerArgs {
     /// the scheduler simply won't produce them, so the request would 200 with the
     /// field silently missing.
     pub enable_return_hidden_states: bool,
+    pub enable_custom_logit_processor: bool,
     /// Output slots reserved per request on top of its input (eagle stores draft
     /// tokens there). Not a `server_args` field — `TokenizerManager` derives it and
     /// `RustServer._build_server_args` stamps it in, so both sides count alike.
@@ -174,6 +175,7 @@ impl ServerArgs {
         preferred_sampling_params,
         allow_auto_truncate,
         enable_return_hidden_states,
+        enable_custom_logit_processor,
         num_reserved_tokens,
         version,
         max_total_num_tokens,
@@ -204,6 +206,7 @@ impl ServerArgs {
         preferred_sampling_params: Option<PreferredSamplingParams>,
         allow_auto_truncate: bool,
         enable_return_hidden_states: bool,
+        enable_custom_logit_processor: bool,
         num_reserved_tokens: u64,
         version: String,
         max_total_num_tokens: u64,
@@ -232,6 +235,7 @@ impl ServerArgs {
             preferred_sampling_params,
             allow_auto_truncate,
             enable_return_hidden_states,
+            enable_custom_logit_processor,
             num_reserved_tokens,
             version,
             max_total_num_tokens,
@@ -268,6 +272,7 @@ impl Default for ServerArgs {
             preferred_sampling_params: None,
             allow_auto_truncate: false,
             enable_return_hidden_states: false,
+            enable_custom_logit_processor: false,
             num_reserved_tokens: 0,
             version: String::new(),
             max_total_num_tokens: 0,

--- a/rust/sglang-server/src/message/io_struct.rs
+++ b/rust/sglang-server/src/message/io_struct.rs
@@ -41,7 +41,7 @@ wire_struct! {
         session_id: (),
         session_params: (),
         lora_id: (),
-        custom_logit_processor: (),
+        custom_logit_processor: Option<&'a str>,
         positional_embed_overrides: (),
         /// PD-disaggregation block — the last fields emitted; everything after
         /// `disagg_prefill_dp_rank` in Python has a msgspec default and is
@@ -105,7 +105,7 @@ impl<'a> From<&'a GenerateRequest> for TokenizedGenerateReqInput<'a> {
             session_id: (),
             session_params: (),
             lora_id: (),
-            custom_logit_processor: (),
+            custom_logit_processor: req.custom_logit_processor.as_deref(),
             positional_embed_overrides: (),
             bootstrap_host: req.bootstrap_host.as_deref(),
             bootstrap_port: req.bootstrap_port,
@@ -174,6 +174,7 @@ mod tests {
             logprob_start_len: -1,
             top_logprobs_num: 3,
             return_hidden_states: true,
+            custom_logit_processor: Some("not parsed by Rust".into()),
             stream: true,
             ..Default::default()
         };
@@ -210,6 +211,12 @@ mod tests {
             Some(true),
             "return_hidden_states at idx 16"
         );
+        assert_eq!(
+            arr[23].as_str(),
+            Some("not parsed by Rust"),
+            "custom_logit_processor at idx 23"
+        );
+        assert!(arr[24].is_nil(), "positional_embed_overrides at idx 24");
     }
 
     /// The PD block must land on Python's wire indices 25–31, with the filler

--- a/rust/sglang-server/src/message/request.rs
+++ b/rust/sglang-server/src/message/request.rs
@@ -47,7 +47,7 @@ const JSON_TO_HEAP_FACTOR: usize = 8;
 /// as a pydantic dataclass, which drops extras. `deny_unknown_fields` here turned
 /// every `GenerateReqInput` field this server has not ported — `priority`,
 /// `extra_key`, `session_id`, `session_params`, `return_sampling_mask`,
-/// `custom_logit_processor`, and ~40 more — into a 400, so a client that worked
+/// and ~40 more — into a 400, so a client that worked
 /// against the Python server broke against this one. The cost of dropping it is
 /// that a typo (`temperature`) is silently ignored rather than reported; that is
 /// the same trade Python already makes.
@@ -85,6 +85,9 @@ pub struct GenerateBody {
     /// Scalar-only in Python too (`return_text_in_logprobs: bool`).
     #[serde(default)]
     pub return_text_in_logprobs: Option<bool>,
+    /// Scalars broadcast; nullable lists map per batch item.
+    #[serde(default)]
+    pub custom_logit_processor: Option<OneOrMany<Option<String>>>,
     // PD-disaggregation routing, injected per request by the PD router
     // (mini_lb / sgl-model-gateway): a scalar for a single prompt, one-per-item
     // lists for a batch. Elements are nullable (`List[Optional[...]]` in
@@ -145,6 +148,7 @@ impl GenerateBody {
             token_ids_logprob,
             return_hidden_states,
             return_text_in_logprobs,
+            custom_logit_processor,
             bootstrap_host,
             bootstrap_port,
             bootstrap_room,
@@ -319,6 +323,14 @@ impl GenerateBody {
         let logprob_start_lens = fan_out(logprob_start_len, n, "logprob_start_len")?;
         let top_logprobs_nums = fan_out(top_logprobs_num, n, "top_logprobs_num")?;
         let return_hidden = fan_out(return_hidden_states, n, "return_hidden_states")?;
+        let custom_logit_processors = match custom_logit_processor {
+            Some(OneOrMany::Many(_)) if !is_batch => {
+                return Err(Error::Validation(
+                    "custom_logit_processor list requires a batch request".into(),
+                ));
+            }
+            other => flatten_column(fan_out(other, n, "custom_logit_processor")?),
+        };
 
         // PD fields fan out like Python `_normalize_bootstrap_params`: scalars
         // broadcast — except a scalar `bootstrap_room`, which becomes `room + i`
@@ -370,6 +382,7 @@ impl GenerateBody {
             top_logprobs_nums,
             tid_logprobs,
             return_hidden,
+            custom_logit_processors,
             bootstrap_hosts,
             bootstrap_ports,
             bootstrap_rooms,
@@ -390,6 +403,7 @@ impl GenerateBody {
                 top_logprobs_num,
                 token_ids_logprob,
                 return_hidden_states,
+                custom_logit_processor,
                 bootstrap_host,
                 bootstrap_port,
                 bootstrap_room,
@@ -417,6 +431,7 @@ impl GenerateBody {
                 return_sampling_mask: false, // TODO: port Python's `return_sampling_mask`
                 return_hidden_states: return_hidden_states.unwrap_or(false),
                 return_text_in_logprobs,
+                custom_logit_processor,
                 bootstrap_host,
                 bootstrap_port,
                 bootstrap_room,
@@ -642,6 +657,8 @@ pub struct GenerateRequest {
     /// it is consumed on the way out, by `register_detok` → `DetokMsg::Register`
     /// → the shard's `decode_logprob_texts`.
     pub return_text_in_logprobs: Option<bool>,
+    /// Opaque serialized processor forwarded to the Python scheduler.
+    pub custom_logit_processor: Option<String>,
     /// PD-disaggregation routing, forwarded verbatim to the scheduler (which
     /// fills a `None` port from `--disaggregation-bootstrap-port` and 400-aborts
     /// a room-less request in PD mode).
@@ -889,6 +906,46 @@ mod tests {
         assert!(err.to_string().contains("length"), "{err}");
     }
 
+    #[test]
+    fn custom_logit_processor_normalizes_scalar_and_nullable_batch_values() {
+        let (ps, _) = requests(r#"{"text": "a"}"#).unwrap();
+        assert_eq!(ps[0].custom_logit_processor, None);
+
+        let (ps, _) = requests(r#"{"text": "a", "custom_logit_processor": null}"#).unwrap();
+        assert_eq!(ps[0].custom_logit_processor, None);
+
+        let (ps, _) =
+            requests(r#"{"text": "a", "custom_logit_processor": "not parsed by Rust"}"#).unwrap();
+        assert_eq!(
+            ps[0].custom_logit_processor.as_deref(),
+            Some("not parsed by Rust")
+        );
+
+        let (ps, _) =
+            requests(r#"{"text": ["a", "b"], "custom_logit_processor": "opaque"}"#).unwrap();
+        assert_eq!(
+            ps.iter()
+                .map(|p| p.custom_logit_processor.as_deref())
+                .collect::<Vec<_>>(),
+            vec![Some("opaque"), Some("opaque")]
+        );
+
+        let (ps, _) =
+            requests(r#"{"text": ["a", "b"], "custom_logit_processor": ["A", null]}"#).unwrap();
+        assert_eq!(
+            ps.iter()
+                .map(|p| p.custom_logit_processor.as_deref())
+                .collect::<Vec<_>>(),
+            vec![Some("A"), None]
+        );
+
+        let err = requests(r#"{"text": ["a", "b"], "custom_logit_processor": ["A"]}"#).unwrap_err();
+        assert!(err.to_string().contains("custom_logit_processor"), "{err}");
+
+        let err = requests(r#"{"text": "a", "custom_logit_processor": ["A"]}"#).unwrap_err();
+        assert!(err.to_string().contains("custom_logit_processor"), "{err}");
+    }
+
     /// `input_ids` batch (list of lists) fans out; scalar (list of ints) is single.
     #[test]
     fn input_ids_scalar_vs_batch() {
@@ -930,7 +987,6 @@ mod tests {
             r#""session_id": "s""#,
             r#""session_params": {"a": 1}"#,
             r#""return_sampling_mask": true"#,
-            r#""custom_logit_processor": "cls""#,
             r#""lora_path": "adapter""#,
             r#""image_data": "base64""#,
             r#""return_routed_experts": true"#,

--- a/rust/sglang-server/src/tokenizer_manager/to_scheduler.rs
+++ b/rust/sglang-server/src/tokenizer_manager/to_scheduler.rs
@@ -72,6 +72,7 @@ pub struct Limits {
     pub allow_auto_truncate: bool,
     /// Whether the server can produce hidden states at all.
     pub enable_return_hidden_states: bool,
+    pub enable_custom_logit_processor: bool,
 }
 
 impl From<&ServerArgs> for Limits {
@@ -83,6 +84,7 @@ impl From<&ServerArgs> for Limits {
             num_reserved_tokens: sa.num_reserved_tokens,
             allow_auto_truncate: sa.allow_auto_truncate,
             enable_return_hidden_states: sa.enable_return_hidden_states,
+            enable_custom_logit_processor: sa.enable_custom_logit_processor,
         }
     }
 }
@@ -622,6 +624,23 @@ fn validate(req: &mut Request, limits: &Limits) -> Result<(), Error> {
         ));
     }
 
+    // Match Python's feature gate; Rust does not deserialize the processor.
+    if !limits.enable_custom_logit_processor
+        && matches!(
+            &req.kind,
+            RequestKind::Generate(g)
+                if g.custom_logit_processor
+                    .as_deref()
+                    .is_some_and(|s| !s.is_empty())
+        )
+    {
+        return Err(Error::Validation(
+            "The server is not configured to enable custom logit processor. \
+             Please set `--enable-custom-logit-processor` to enable this feature."
+                .into(),
+        ));
+    }
+
     Ok(())
 }
 
@@ -692,6 +711,7 @@ fn check_total_tokens(g: &mut GenerateRequest, limits: &Limits) -> Result<(), Er
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::message::config::ServerArgs;
     use crate::message::request::GenerateRequest;
     use crate::message::response::ResponseSink;
     use crate::message::sampling::SamplingParams;
@@ -851,7 +871,18 @@ mod tests {
             num_reserved_tokens: 0,
             allow_auto_truncate: false,
             enable_return_hidden_states: false,
+            enable_custom_logit_processor: false,
         }
+    }
+
+    #[test]
+    fn custom_logit_processor_server_arg_reaches_limits() {
+        let server_args = ServerArgs {
+            enable_custom_logit_processor: true,
+            ..Default::default()
+        };
+        let limits = Limits::from(&server_args);
+        assert!(limits.enable_custom_logit_processor);
     }
 
     fn generate_req(id: u64, sampling_params: SamplingParams) -> Request {
@@ -1062,6 +1093,33 @@ mod tests {
             ..test_limits()
         };
         assert!(validate(&mut req(true), &enabled).is_ok());
+    }
+
+    #[test]
+    fn custom_logit_processor_gated_on_server_support() {
+        let req = |processor: Option<&str>| {
+            let mut r = generate_req(32, SamplingParams::default());
+            if let RequestKind::Generate(g) = &mut r.kind {
+                g.custom_logit_processor = processor.map(str::to_owned);
+            }
+            r
+        };
+        let disabled = test_limits();
+        assert!(validate(&mut req(None), &disabled).is_ok());
+        assert!(validate(&mut req(Some("")), &disabled).is_ok());
+        for processor in ["opaque", " "] {
+            let err = validate(&mut req(Some(processor)), &disabled).unwrap_err();
+            assert_eq!(err.http_status(), 400);
+            assert!(
+                err.to_string().contains("--enable-custom-logit-processor"),
+                "{err}"
+            );
+        }
+        let enabled = Limits {
+            enable_custom_logit_processor: true,
+            ..test_limits()
+        };
+        assert!(validate(&mut req(Some("not valid serialized")), &enabled).is_ok());
     }
 
     /// End-to-end through `drive`: an over-context request is rejected on the way


### PR DESCRIPTION
## Motivation

The Python frontend supports `custom_logit_processor` on generation requests,
while the Rust `/generate` frontend currently drops the field.

This implements item 21 of #23206 for the native `/generate` path.

## Changes

- Parse the existing scalar or nullable-list request shape.
- Reuse existing batch fanout semantics and broadcast memory budget.
- Populate the existing scheduler msgpack slot without changing wire order.
- Match the existing `--enable-custom-logit-processor` request gate.
- Keep the payload opaque in Rust.

## Scope

Native `/generate` only.

OpenAI Chat/Completions remain on Dynamo DTOs that do not directly expose this
SGLang extension, so adapter/schema work is separate.

Rust treats the processor payload as opaque and forwards it only when
`--enable-custom-logit-processor` is enabled. Python deserialization semantics
are unchanged by this PR.

## Accuracy Tests

N/A. No model forward/sampling kernels or custom processor execution changed.

## Tests

- `cargo fmt --all -- --check`
- `cargo test --locked -p sglang-server --lib` — 248 passed, 0 failed on Ubuntu.
- `cargo clippy -p sglang-server --all-targets -- -D warnings`
- Relevant `pre-commit` checks — passed.
- `SGLANG_BUILD_RUST_EXTS=server python setup.py build_rust --inplace` — passed.
- `git diff --check upstream/main...HEAD`
- [Temporary fork CPU validation run](https://github.com/charliechenye/sglang/actions/runs/32556564543) — all listed checks passed. The temporary workflow was removed before the final commit; the five production/test files are byte-identical between the tested tree and final `e8d1763933c6514bc5e1d7a503325460955ac066`.

Refs #23206, item 21.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32593560384](https://github.com/sgl-project/sglang/actions/runs/32593560384)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32593560240](https://github.com/sgl-project/sglang/actions/runs/32593560240)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32593560496](https://github.com/sgl-project/sglang/actions/runs/32593560496)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->