### PR TITLE
Fix BaseConnector signal handling semantics

### DIFF
--- a/python/sglang/srt/connector/base_connector.py
+++ b/python/sglang/srt/connector/base_connector.py
@@ -65,15 +65,30 @@ class BaseConnector(ABC):
     def _close_by_signal(self, existing_handler=None):
 
         def new_handler(signum, frame):
-            self.close()
-            if existing_handler:
-                existing_handler(signum, frame)
+            try:
+                self.close()
+            finally:
+                if existing_handler == signal.SIG_IGN:
+                    return
+
+                if callable(existing_handler):
+                    existing_handler(signum, frame)
+                    return
+
+                # A container's PID 1 ignores signals with a default
+                # disposition, so re-raising SIGTERM would not terminate it.
+                if os.getpid() == 1:
+                    os._exit(128 + signum)
+                    return
+
+                # Preserve the default signal disposition after cleanup.
+                signal.signal(signum, signal.SIG_DFL)
+                signal.raise_signal(signum)
 
         return new_handler
 
 
 class BaseKVConnector(BaseConnector):
-
     @abstractmethod
     def get(self, key: str) -> Optional[torch.Tensor]:
         raise NotImplementedError()


### PR DESCRIPTION
## Summary

- preserve the signal disposition that was installed before `BaseConnector`
- clean up the connector's temporary directory before delegating or exiting
- explicitly terminate container PID 1 when the previous disposition was `SIG_DFL`

## Root cause

`BaseConnector` wraps `SIGINT` and `SIGTERM` and previously delegated with:

```python
if existing_handler:
    existing_handler(signum, frame)
```

Python represents the two sentinel dispositions as integer-valued enums:

- `signal.SIG_DFL == 0`
- `signal.SIG_IGN == 1`

That truthiness check therefore introduced two deterministic failures:

1. A default `SIGTERM` disposition is falsy. The wrapper deleted the temporary directory and returned, swallowing the signal and leaving the service running.
2. An ignored disposition is truthy but not callable. The wrapper attempted to call it and raised `TypeError: 'Handlers' object is not callable`.

For a containerized server, the first case can turn a graceful Kubernetes or Docker shutdown into a wait until the grace period expires, followed by `SIGKILL`.

## Fix

The new wrapper distinguishes signal dispositions explicitly:

- `SIG_IGN`: clean up and return without calling the integer sentinel
- callable handler: clean up and delegate to it
- `SIG_DFL`: restore the default disposition and re-raise the signal after cleanup

The cleanup runs in `finally`, so failure during temporary-directory cleanup cannot prevent the previous signal behavior from running.

Linux treats PID 1 specially and ignores signals whose disposition is the default. SGLang's Kubernetes example starts `python3 -m sglang.launch_server` directly as the container process, so merely restoring `SIG_DFL` and re-raising `SIGTERM` is insufficient in that configuration. For PID 1, the handler exits explicitly with `128 + signum` after cleanup; other processes retain native signal termination semantics.

## Behavior after this change

| Previous disposition | Result after cleanup |
| --- | --- |
| `SIG_DFL`, regular process | restore and re-raise; process exits from the signal |
| `SIG_DFL`, PID 1 | explicitly exit with `128 + signum` |
| `SIG_IGN` | remain alive without attempting an integer call |
| callable | invoke the previous handler |