### PR TITLE
Normalize LoRA paths at request boundaries

### DIFF
--- a/python/sglang/lang/backend/runtime_endpoint.py
+++ b/python/sglang/lang/backend/runtime_endpoint.py
@@ -509,9 +509,18 @@ class Runtime:
         return_logprob: Optional[Union[List[bool], bool]] = False,
         logprob_start_len: Optional[Union[List[int], int]] = None,
         top_logprobs_num: Optional[Union[List[int], int]] = None,
-        lora_path: Optional[List[Optional[str]]] = None,
+        lora_path: Optional[Union[str, List[Optional[str]]]] = None,
         session_id: Optional[str] = None,
     ):
+        if isinstance(lora_path, list):
+            batch_size = 1 if isinstance(prompt, str) else len(prompt)
+            if len(lora_path) != batch_size:
+                raise ValueError(
+                    f"lora_path length ({len(lora_path)}) must match "
+                    f"the prompt batch size ({batch_size})."
+                )
+            if isinstance(prompt, str):
+                lora_path = lora_path[0]
         json_data = {
             "text": prompt,
             "sampling_params": sampling_params,
@@ -521,13 +530,6 @@ class Runtime:
             "lora_path": lora_path,
             "session_id": session_id,
         }
-        if isinstance(lora_path, list):
-            batch_size = 1 if isinstance(prompt, str) else len(prompt)
-            if len(lora_path) != batch_size:
-                raise ValueError(
-                    f"lora_path length ({len(lora_path)}) must match "
-                    f"the prompt batch size ({batch_size})."
-                )
         response = requests.post(
             self.url + "/generate",
             json=json_data,

--- a/python/sglang/lang/backend/runtime_endpoint.py
+++ b/python/sglang/lang/backend/runtime_endpoint.py
@@ -521,7 +521,13 @@ class Runtime:
             "lora_path": lora_path,
             "session_id": session_id,
         }
-        assert not isinstance(lora_path, list) or len(lora_path) == len(prompt)
+        if isinstance(lora_path, list):
+            batch_size = 1 if isinstance(prompt, str) else len(prompt)
+            if len(lora_path) != batch_size:
+                raise ValueError(
+                    f"lora_path length ({len(lora_path)}) must match "
+                    f"the prompt batch size ({batch_size})."
+                )
         response = requests.post(
             self.url + "/generate",
             json=json_data,

--- a/python/sglang/lang/backend/runtime_endpoint.py
+++ b/python/sglang/lang/backend/runtime_endpoint.py
@@ -512,15 +512,6 @@ class Runtime:
         lora_path: Optional[Union[str, List[Optional[str]]]] = None,
         session_id: Optional[str] = None,
     ):
-        if isinstance(lora_path, list):
-            batch_size = 1 if isinstance(prompt, str) else len(prompt)
-            if len(lora_path) != batch_size:
-                raise ValueError(
-                    f"lora_path length ({len(lora_path)}) must match "
-                    f"the prompt batch size ({batch_size})."
-                )
-            if isinstance(prompt, str):
-                lora_path = lora_path[0]
         json_data = {
             "text": prompt,
             "sampling_params": sampling_params,

--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -378,7 +378,7 @@ class Engine(EngineScoreMixin, EngineBase):
         logprob_start_len: Optional[Union[List[int], int]] = None,
         top_logprobs_num: Optional[Union[List[int], int]] = None,
         token_ids_logprob: Optional[Union[List[List[int]], List[int]]] = None,
-        lora_path: Optional[List[Optional[str]]] = None,
+        lora_path: Optional[Union[str, List[Optional[str]]]] = None,
         custom_logit_processor: Optional[Union[List[str], str]] = None,
         require_reasoning: bool = False,
         return_hidden_states: Union[
@@ -491,7 +491,7 @@ class Engine(EngineScoreMixin, EngineBase):
         logprob_start_len: Optional[Union[List[int], int]] = None,
         top_logprobs_num: Optional[Union[List[int], int]] = None,
         token_ids_logprob: Optional[Union[List[List[int]], List[int]]] = None,
-        lora_path: Optional[List[Optional[str]]] = None,
+        lora_path: Optional[Union[str, List[Optional[str]]]] = None,
         custom_logit_processor: Optional[Union[List[str], str]] = None,
         require_reasoning: bool = False,
         return_hidden_states: Union[

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -61,7 +61,10 @@ from sglang.srt.managers.schedule_batch import (
 from sglang.srt.multimodal.mm_utils import has_valid_data
 from sglang.srt.sampling.sampling_params import SamplingParams
 from sglang.srt.utils import ImageData, VideoData
-from sglang.srt.utils.field_validators import validate_optional_list_i64_1d_2d
+from sglang.srt.utils.field_validators import (
+    normalize_lora_paths,
+    validate_optional_list_i64_1d_2d,
+)
 from sglang.srt.utils.msgspec_utils import (
     Base64Bytes,
     msgspec_struct_pydantic_core_schema,
@@ -390,6 +393,12 @@ class GenerateReqInput:
         if self.session_id is not None and self.session_params is not None:
             raise ValueError("session_id and session_params cannot both be set.")
         self._handle_parallel_sampling()
+        self.lora_path = normalize_lora_paths(
+            self.lora_path,
+            self.batch_size,
+            is_single=self.is_single,
+            expansion_factor=self.parallel_sample_num,
+        )
 
         if self.is_single:
             self._normalize_single_inputs()
@@ -518,7 +527,6 @@ class GenerateReqInput:
         # Expand input based on type
         self._expand_inputs(num)
         self._normalize_rid(num)
-        self._normalize_lora_paths(num)
         self._normalize_image_data(num)
         self._normalize_mm_hashes(num)
         self._normalize_video_data(num)
@@ -549,16 +557,6 @@ class GenerateReqInput:
             if not isinstance(self.input_embeds, list):
                 raise ValueError("input_embeds should be a list for batch processing.")
             self.input_embeds = self.input_embeds * self.parallel_sample_num
-
-    def _normalize_lora_paths(self, num):
-        """Normalize LoRA paths for batch processing."""
-        if self.lora_path is not None:
-            if isinstance(self.lora_path, str):
-                self.lora_path = [self.lora_path] * num
-            elif isinstance(self.lora_path, list):
-                self.lora_path = self.lora_path * self.parallel_sample_num
-            else:
-                raise ValueError("lora_path should be a list or a string.")
 
     def _normalize_image_data(self, num):
         """Normalize image data for batch processing."""
@@ -1188,6 +1186,10 @@ class EmbeddingReqInput:
             else:
                 self.batch_size += 1
 
+        self.lora_path = normalize_lora_paths(
+            self.lora_path, self.batch_size, is_single=self.is_single
+        )
+
         # Fill in default arguments
         if self.is_single:
             if self.rid is None:
@@ -1208,22 +1210,7 @@ class EmbeddingReqInput:
             for i in range(self.batch_size):
                 self.sampling_params[i]["max_new_tokens"] = 0
 
-            self._normalize_lora_paths(self.batch_size)
-
         self._validate_rid_uniqueness()
-
-    def _normalize_lora_paths(self, num):
-        """Normalize LoRA paths for batch processing."""
-        if self.lora_path is not None:
-            if isinstance(self.lora_path, str):
-                self.lora_path = [self.lora_path] * num
-            elif isinstance(self.lora_path, list):
-                if len(self.lora_path) != num:
-                    raise ValueError(
-                        f"lora_path list length ({len(self.lora_path)}) must match batch size ({num})"
-                    )
-            else:
-                raise ValueError("lora_path should be a list or a string.")
 
     def contains_mm_input(self) -> bool:
         return (

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -3320,7 +3320,9 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         if isinstance(obj.lora_path, str):
             unique_lora_paths = set([obj.lora_path])
         else:
-            unique_lora_paths = set(obj.lora_path)
+            unique_lora_paths = {
+                lora_path for lora_path in obj.lora_path if lora_path is not None
+            }
 
         if (
             self.server_args.max_loaded_loras is not None

--- a/python/sglang/srt/utils/field_validators.py
+++ b/python/sglang/srt/utils/field_validators.py
@@ -50,13 +50,19 @@ def normalize_lora_paths(
         return None
     if isinstance(value, str):
         return value if is_single else [value] * (batch_size * expansion_factor)
-    if not isinstance(value, list):
-        raise ValueError("lora_path should be a list or a string.")
+    if not isinstance(value, list) or not all(
+        path is None or isinstance(path, str) for path in value
+    ):
+        raise ValueError(
+            "lora_path should be a string or a list containing strings or None."
+        )
     expected_size = 1 if is_single else batch_size
     if len(value) != expected_size:
         raise ValueError(
             f"lora_path list length ({len(value)}) must match batch size ({expected_size})"
         )
+    if all(path is None for path in value):
+        return None
     return value[0] if is_single else value * expansion_factor
 
 

--- a/python/sglang/srt/utils/field_validators.py
+++ b/python/sglang/srt/utils/field_validators.py
@@ -38,6 +38,28 @@ from array import array
 from typing import Any
 
 
+def normalize_lora_paths(
+    value: Any,
+    batch_size: int,
+    *,
+    is_single: bool,
+    expansion_factor: int = 1,
+) -> str | list[str | None] | None:
+    """Normalize LoRA paths to the request's single or batch shape."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value if is_single else [value] * (batch_size * expansion_factor)
+    if not isinstance(value, list):
+        raise ValueError("lora_path should be a list or a string.")
+    expected_size = 1 if is_single else batch_size
+    if len(value) != expected_size:
+        raise ValueError(
+            f"lora_path list length ({len(value)}) must match batch size ({expected_size})"
+        )
+    return value[0] if is_single else value * expansion_factor
+
+
 def validate_list_i64_1d(v: Any) -> list[int]:
     """Validates type: list[int]"""
     if v is None:


### PR DESCRIPTION
## Summary

- remove `Runtime.generate()`'s character-count-based LoRA validation and keep the client as a transport layer
- normalize LoRA paths once at the shared request boundary used by HTTP, Engine, gRPC, and OpenAI-compatible entry points
- use the same scalar-or-list API contract for Runtime and synchronous/asynchronous Engine generation
- handle base-model (`None`) entries and invalid adapter element types before registry resolution

## Root cause

`Runtime.generate()` accepts either a single prompt or a batch:

```python
prompt: Union[str, List[str]]
```

but previously checked a list-valued `lora_path` with:

```python
assert not isinstance(lora_path, list) or len(lora_path) == len(prompt)
```

For `prompt="hello"`, `len(prompt)` is the number of characters, not the request batch size. A valid call such as:

```python
runtime.generate(prompt="hello", lora_path=["adapter-a"])
```

therefore compared one adapter with five characters and raised `AssertionError`. The assertion also disappeared under `python -O`, making behavior interpreter-flag-dependent.

Simply accepting the list in `Runtime` was not sufficient. `GenerateReqInput` previously normalized LoRA paths only in its batch branch. A single request could reach the registry with a list-valued path, produce a list-valued `lora_id`, and fail when downstream single-request code treated the ID as a string. `EmbeddingReqInput` had the same single-request gap and maintained a separate batch implementation.

## Design

LoRA path shape is now normalized at the canonical request boundary, after request cardinality is known and before registry resolution:

- a single request has a scalar `str` or `None`
- a batch has one element per final request
- a scalar path supplied for a batch is broadcast across the batch
- a per-request list is checked against the original batch size
- generation parallel sampling expands the validated list by `n`
- a list containing only `None` is collapsed to `None`, so a base-model batch does not look like a LoRA request
- mixed base/LoRA batches preserve their positional `None` entries, while unique-adapter accounting excludes `None`
- list elements must be strings or `None`; invalid values fail at the request boundary instead of reaching the registry

`GenerateReqInput` and `EmbeddingReqInput` share the same lightweight normalizer. This gives direct HTTP requests, Runtime, Engine calls, gRPC, and OpenAI-compatible routes the same behavior because they all normalize before adapter resolution.

Runtime forwards the scalar-or-list value without duplicating shape policy. `Engine.generate()` and `Engine.async_generate()` now expose the same scalar-or-list type already supported by `EngineBase` and the canonical request structs.

## Behavior

| Input shape | LoRA input | Canonical request shape |
| --- | --- | --- |
| one prompt | `"adapter-a"` | `"adapter-a"` |
| one prompt | `["adapter-a"]` | `"adapter-a"` |
| one prompt | `[None]` | `None` |
| two prompts | `"adapter-a"` | `["adapter-a", "adapter-a"]` |
| two prompts | `["adapter-a", "adapter-b"]` | unchanged list |
| two prompts | `[None, None]` | `None` |
| two prompts | `[None, "adapter-a"]` | aligned mixed list; only `adapter-a` counts as a loaded adapter |
| one prompt with `n=3` | `["adapter-a"]` | three-element list |
| list length different from batch size | any list | descriptive `ValueError` |
| list containing a non-string value | e.g. `[123]` | descriptive `ValueError` |

## Validation

No test files are included in this PR. The final production diff was checked with:

```text
python -m py_compile: passed for all five changed files
ruff check: passed for all five changed files
LoRA boundary matrix: passed for single, batch, parallel sampling, all-None, mixed-None, invalid element type, and invalid length cases
git diff --check: passed
```

The PR changes five production files only:

- `python/sglang/lang/backend/runtime_endpoint.py`
- `python/sglang/srt/entrypoints/engine.py`
- `python/sglang/srt/managers/io_struct.py`
- `python/sglang/srt/managers/tokenizer_manager.py`
- `python/sglang/srt/utils/field_validators.py`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31851121597](https://github.com/sgl-project/sglang/actions/runs/31851121597)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31851121529](https://github.com/sgl-project/sglang/actions/runs/31851121529)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
