### PR TITLE
[Docs] Update Kimi-K3 installation options

### DIFF
--- a/docs/cookbook/autoregressive/Moonshotai/Kimi-K3.mdx
+++ b/docs/cookbook/autoregressive/Moonshotai/Kimi-K3.mdx
@@ -10,27 +10,33 @@ tag: NEW
 
 <Accordion title="Install SGLang">
 
-For all methods and hardware platforms, see the [official SGLang installation guide](../../../docs/get-started/install).
+For all methods and hardware platforms, see the [official SGLang installation guide](../../../docs/get-started/install). The two paths below match the **Python / Docker** toggle in the command panel.
 
 <Tabs>
+
+<Tab title="Python (pip / uv)">
+
+```bash Command
+pip install --upgrade pip
+pip install uv
+uv pip install sglang
+```
+
+Then run the **Python** output of the command panel below in that environment.
+
+</Tab>
 
 <Tab title="Docker">
 
 ```bash Command
-docker pull lmsysorg/sglang:kimi-k3 # CUDA13
-docker pull lmsysorg/sglang:kimi-k3-cu12 # CUDA12
-docker pull lmsysorg/sglang-rocm:v0.5.16-rocm720-mi35x-20260805 # ROCM daily image
+docker pull lmsysorg/sglang:latest
 ```
-
-These tags publish with the public K3 launch; until then, build from the Dockerfiles linked below.
 
 For how to launch the image, see [Install → Method 3: Using Docker](../../../docs/get-started/install#method-3-using-docker). Substitute the inner `sglang serve ...` with what the command generator below produces.
 
 </Tab>
 
 </Tabs>
-
-If you do not want to use a Docker image, reproduce the dependency installation steps from the [CUDA 13 Dockerfile](https://github.com/sgl-project/sglang/blob/kimi-k3/docker/kimi_k3/kimi_k3_cu13.Dockerfile) or [CUDA 12 Dockerfile](https://github.com/sgl-project/sglang/blob/kimi-k3/docker/kimi_k3/kimi_k3_cu12.Dockerfile).
 
 </Accordion>
 


### PR DESCRIPTION
## Motivation

The Kimi-K3 cookbook still points readers to prerelease model-specific images and Dockerfiles. Now that Kimi-K3 is supported by the current SGLang release paths, the installation section should use the standard Python and Docker instructions.

## Modifications

- Add a Python (pip / uv) installation tab matching the deployment command panel.
- Replace the Kimi-K3 prerelease Docker tags with `lmsysorg/sglang:latest`.
- Remove the obsolete prerelease notice and Dockerfile fallback instructions.
- Preserve links to the full installation guide and Docker launch instructions.

## Accuracy Tests

Not applicable; this is a documentation-only change.

## Speed Tests and Profiling

Not applicable; this change does not affect runtime behavior.

## Validation

- `node docs/scripts/check_cookbook_configs.mjs`
- `mint validate`
- `mint broken-links`

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (Not applicable; documentation-only change.)
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Not applicable; no runtime impact.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31849433065](https://github.com/sgl-project/sglang/actions/runs/31849433065)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31849432967](https://github.com/sgl-project/sglang/actions/runs/31849432967)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->