### PR TITLE
[Fix] MistralDetector: no dropped calls or leaked markup in streaming

### DIFF
--- a/python/sglang/srt/function_call/mistral_detector.py
+++ b/python/sglang/srt/function_call/mistral_detector.py
@@ -40,6 +40,9 @@ class MistralDetector(BaseFormatDetector):
         self._tool_calls_marker = "[TOOL_CALLS"
         self.eot_token = "]"
         self.tool_call_separator = ", "
+        # True once a canonical `[TOOL_CALLS] [` array has started: the rest of the
+        # array has no marker of its own, so parsing must stay on the base path.
+        self._json_array_mode = False
 
     def has_tool_call(self, text: str) -> bool:
         """Return True if the text contains either supported tool-call marker."""
@@ -93,6 +96,7 @@ class MistralDetector(BaseFormatDetector):
         # Loop to extract all consecutive compact tool calls.
         all_calls: list = []
         remaining = tool_part
+        parsed_any = False
         while remaining:
             parsed = self._try_parse_compact_args_format(remaining)
             if not parsed:
@@ -103,9 +107,15 @@ class MistralDetector(BaseFormatDetector):
             )
             all_calls.extend(new_calls)
             remaining = remaining[consumed:].strip()
+            parsed_any = True
 
-        if not all_calls:
+        if not parsed_any:
+            # Nothing was consumed, so `remaining` is still raw markup: drop it.
             return StreamingParseResult(normal_text=normal_text, calls=[])
+
+        if self._tool_calls_marker in remaining:
+            # A call that never finished (truncated generation) is markup, not text.
+            remaining = ""
 
         combined_normal = (
             (normal_text + " " + remaining).strip() if remaining else normal_text
@@ -121,79 +131,150 @@ class MistralDetector(BaseFormatDetector):
         For the compact format, this buffers until the JSON arguments payload is complete,
         then emits two items: tool name (with empty parameters) and a full arguments JSON
         chunk (OpenAI streaming semantics).
+
+        The buffer is drained in a loop because a single increment can carry leading
+        text, one or more complete compact calls and trailing text at once. Whatever
+        remains after a call has to be re-examined here rather than deferred to the
+        next increment -- for the last increment of a stream there is none.
         """
         self._buffer += new_text
-        current_text = self._buffer
+        normal_text_parts: List[str] = []
+        calls: List[ToolCallItem] = []
 
-        # No marker: either flush as normal text or keep buffering a partial marker.
-        if self._tool_calls_marker not in current_text:
-            if not self._ends_with_partial_token(self._buffer, self._tool_calls_marker):
-                normal_text = self._buffer
+        while self._buffer:
+            current_text = self._buffer
+
+            # Inside a canonical array: its continuation (`, {...}]`) carries no
+            # marker of its own, so it has to stay on the base parsing path.
+            if self._json_array_mode:
+                self._drain_json_array(tools, normal_text_parts, calls)
+                if self._json_array_mode:
+                    break
+                continue
+
+            # No marker: either flush as normal text or keep buffering a partial marker.
+            if self._tool_calls_marker not in current_text:
+                if self._ends_with_partial_token(current_text, self._tool_calls_marker):
+                    break
                 self._buffer = ""
-                if self.eot_token in normal_text:
-                    normal_text = normal_text.replace(self.eot_token, "")
-                return StreamingParseResult(normal_text=normal_text)
+                normal_text_parts.append(current_text.replace(self.eot_token, ""))
+                break
+
+            # If there's leading normal text before the marker, stream it out first.
+            marker_pos = current_text.find(self._tool_calls_marker)
+            if marker_pos > 0:
+                normal_text_parts.append(current_text[:marker_pos])
+                self._buffer = current_text[marker_pos:]
+                continue
+
+            # Build tool indices if not already built.
+            if not hasattr(self, "_tool_indices"):
+                self._tool_indices = self._get_tool_indices(tools)
+
+            # Compact format: `[TOOL_CALLS]name[ARGS]{...}`.
+            compact = self._try_parse_compact_args_format(current_text)
+            if compact:
+                func_name, args_obj, consumed = compact
+                self._buffer = current_text[consumed:]
+                if func_name not in self._tool_indices:
+                    # Drop just this call, the way parse_base_json does. Emitting
+                    # the buffer as normal text would hand the raw `[TOOL_CALLS]`
+                    # markup to the client as assistant content.
+                    logger.warning(
+                        f"Model attempted to call undefined function: {func_name}"
+                    )
+                    continue
+                calls.extend(self._emit_compact_call(func_name, args_obj))
+                continue
+
+            # Canonical format: hand the array over to the base JSON parser.
+            if self.bot_token in current_text:
+                self._json_array_mode = True
+                continue
+
+            # Otherwise, keep buffering.
+            break
+
+        return StreamingParseResult(normal_text="".join(normal_text_parts), calls=calls)
+
+    def _drain_json_array(
+        self,
+        tools: List[Tool],
+        normal_text_parts: List[str],
+        calls: List[ToolCallItem],
+    ) -> None:
+        """Run the BaseFormatDetector JSON streaming logic until it stalls.
+
+        The base implementation performs at most one action per call (send a tool
+        name, or send one arguments diff), relying on a later increment to carry
+        the rest. The last increment of a stream has no successor, so drive it here
+        until it stops making progress -- otherwise a name arriving in the final
+        chunk is emitted without its arguments.
+        """
+        while True:
+            # `]` closes the array: consume it here and leave array mode, so any
+            # trailing text or compact call goes back through the marker path.
+            if self.current_tool_id > 0 and self._buffer.startswith(self.eot_token):
+                self._buffer = self._buffer[len(self.eot_token) :]
+                self._json_array_mode = False
+                return
+
+            # A `, ` separator split across increments has to be held: the base
+            # parser only guards against a partial bot_token and would otherwise
+            # flush the separator, and then the whole next object, as normal text.
+            if (
+                self.current_tool_id > 0
+                and self.tool_call_separator.startswith(self._buffer)
+                and len(self._buffer) < len(self.tool_call_separator)
+            ):
+                return
+
+            before = self._buffer
+            result = super().parse_streaming_increment(new_text="", tools=tools)
+            if result.normal_text:
+                normal_text_parts.append(result.normal_text)
+            calls.extend(result.calls or [])
+            if self._buffer == before and not result.calls:
+                return
+
+    def _emit_compact_call(self, func_name: str, args_obj: Any) -> List[ToolCallItem]:
+        """Record one completed compact call and return its two streaming items."""
+        # Initialize state if this is the first tool call.
+        if self.current_tool_id == -1:
+            self.current_tool_id = 0
+            self.prev_tool_call_arr = []
+            self.streamed_args_for_tool = []
+
+        args_json = json.dumps(args_obj, ensure_ascii=False)
+        tool_id = self.current_tool_id
+
+        # Ensure arrays are large enough.
+        while len(self.prev_tool_call_arr) <= tool_id:
+            self.prev_tool_call_arr.append({})
+        while len(self.streamed_args_for_tool) <= tool_id:
+            self.streamed_args_for_tool.append("")
+
+        self.prev_tool_call_arr[tool_id] = {"name": func_name, "arguments": args_obj}
+        self.streamed_args_for_tool[tool_id] = args_json
+
+        self.current_tool_id += 1
+        self.current_tool_name_sent = False
+        return [
+            ToolCallItem(tool_index=tool_id, name=func_name, parameters=""),
+            ToolCallItem(tool_index=tool_id, name=None, parameters=args_json),
+        ]
+
+    def finish(self, tools: List[Tool]) -> StreamingParseResult:
+        """Release text that was held back waiting for a marker that never came.
+
+        Anything still buffered when the stream ends is either plain text kept
+        for the next increment, or an unfinished tool call. The latter is markup
+        and must not reach the client as content.
+        """
+        held, self._buffer = self._buffer, ""
+        if self._json_array_mode or self._tool_calls_marker in held:
             return StreamingParseResult()
-
-        # If there's leading normal text before the marker, stream it out first.
-        marker_pos = current_text.find(self._tool_calls_marker)
-        if marker_pos > 0:
-            normal_text = current_text[:marker_pos]
-            self._buffer = current_text[marker_pos:]
-            return StreamingParseResult(normal_text=normal_text)
-
-        # Build tool indices if not already built.
-        if not hasattr(self, "_tool_indices"):
-            self._tool_indices = self._get_tool_indices(tools)
-
-        # Try compact first; JSON-array requires `] [` and often arrives later in streaming.
-        compact = self._try_parse_compact_args_format(current_text)
-        if compact:
-            func_name, args_obj, consumed = compact
-            if func_name not in self._tool_indices:
-                # Unknown tool: treat as normal text and reset state.
-                normal_text = self._buffer
-                self._buffer = ""
-                return StreamingParseResult(normal_text=normal_text)
-
-            # Initialize state if this is the first tool call.
-            if self.current_tool_id == -1:
-                self.current_tool_id = 0
-                self.prev_tool_call_arr = []
-                self.streamed_args_for_tool = []
-
-            args_json = json.dumps(args_obj, ensure_ascii=False)
-            tool_id = self.current_tool_id
-
-            # Ensure arrays are large enough.
-            while len(self.prev_tool_call_arr) <= tool_id:
-                self.prev_tool_call_arr.append({})
-            while len(self.streamed_args_for_tool) <= tool_id:
-                self.streamed_args_for_tool.append("")
-
-            self.prev_tool_call_arr[tool_id] = {
-                "name": func_name,
-                "arguments": args_obj,
-            }
-            self.streamed_args_for_tool[tool_id] = args_json
-
-            calls: List[ToolCallItem] = [
-                ToolCallItem(tool_index=tool_id, name=func_name, parameters=""),
-                ToolCallItem(tool_index=tool_id, name=None, parameters=args_json),
-            ]
-
-            # Consume parsed content from buffer.
-            self._buffer = current_text[consumed:]
-            self.current_tool_id += 1
-            self.current_tool_name_sent = False
-            return StreamingParseResult(normal_text="", calls=calls)
-
-        # Canonical format delegates to the BaseFormatDetector JSON streaming logic.
-        if self.bot_token in current_text:
-            return super().parse_streaming_increment(new_text="", tools=tools)
-
-        # Otherwise, keep buffering.
-        return StreamingParseResult()
+        return StreamingParseResult(normal_text=held.replace(self.eot_token, ""))
 
     def _try_parse_compact_args_format(
         self, text: str

--- a/test/registered/unit/function_call/test_mistral_detector.py
+++ b/test/registered/unit/function_call/test_mistral_detector.py
@@ -217,6 +217,139 @@ class TestMistralDetector(CustomTestCase):
         params = json.loads(full_params)
         self.assertEqual(params["city"], "Tokyo")
 
+    # ==================== Streaming Regression Tests ====================
+
+    CHUNK_SIZES = (None, 16, 8, 4, 1)
+
+    def _stream(self, text, chunk_size=None):
+        """Feed text through a fresh detector in fixed-size chunks.
+
+        Returns (normal_text, [(name, arguments_json)]) with the streamed items
+        merged back per tool_index, so a stream can be compared with
+        detect_and_parse and across chunk sizes. chunk_size=None sends everything
+        in one increment, which is what a request with a large stream_interval
+        (or several accepted speculative tokens) produces.
+        """
+        detector = MistralDetector()
+        results = [
+            detector.parse_streaming_increment(
+                text[i : i + (chunk_size or len(text))], self.tools
+            )
+            for i in range(0, len(text), chunk_size or len(text))
+        ]
+        results.append(detector.finish(self.tools))
+
+        normal_text = ""
+        merged = {}
+        order = []
+        for result in results:
+            normal_text += result.normal_text or ""
+            for call in result.calls or []:
+                if call.tool_index not in merged:
+                    merged[call.tool_index] = {"name": None, "arguments": ""}
+                    order.append(call.tool_index)
+                if call.name:
+                    merged[call.tool_index]["name"] = call.name
+                if call.parameters:
+                    merged[call.tool_index]["arguments"] += call.parameters
+        return normal_text, [(merged[i]["name"], merged[i]["arguments"]) for i in order]
+
+    def test_streaming_text_and_compact_call_in_one_chunk(self):
+        """A chunk holding both preamble and a complete compact call keeps the call.
+
+        The detector used to take a single action per increment: it emitted the
+        preamble and left the rest of the buffer untouched, so the tool call was
+        silently dropped whenever one chunk carried both.
+        """
+        text = 'Sure.\n[TOOL_CALLS]get_weather[ARGS]{"city": "Beijing"}'
+        normal_text, calls = self._stream(text)
+        self.assertEqual(calls, [("get_weather", '{"city": "Beijing"}')])
+        self.assertEqual(normal_text, "Sure.\n")
+
+    def test_streaming_two_compact_calls_in_one_chunk(self):
+        """Two compact calls in one increment both reach the client."""
+        text = (
+            '[TOOL_CALLS]get_weather[ARGS]{"city": "Beijing"}'
+            '[TOOL_CALLS]search[ARGS]{"query": "restaurants"}'
+        )
+        normal_text, calls = self._stream(text)
+        self.assertEqual(
+            calls,
+            [
+                ("get_weather", '{"city": "Beijing"}'),
+                ("search", '{"query": "restaurants"}'),
+            ],
+        )
+        self.assertEqual(normal_text, "")
+
+    def test_streaming_compact_call_is_chunk_size_invariant(self):
+        """Text following a compact call survives every chunk boundary.
+
+        Trailing content used to be dropped or kept depending on where the chunk
+        boundary fell, so the same response yielded different assistant content
+        at different stream intervals.
+        """
+        text = 'Sure.\n[TOOL_CALLS]get_weather[ARGS]{"city": "Beijing"}\nIt is sunny.'
+        outputs = {size: self._stream(text, size) for size in self.CHUNK_SIZES}
+        for size, (normal_text, calls) in outputs.items():
+            with self.subTest(chunk_size=size):
+                self.assertEqual(calls, [("get_weather", '{"city": "Beijing"}')])
+                self.assertIn("It is sunny.", normal_text)
+        self.assertEqual(len({normal_text for normal_text, _ in outputs.values()}), 1)
+
+    def test_streaming_unknown_compact_tool_leaks_no_markup(self):
+        """An undefined tool name is dropped, never echoed as assistant content.
+
+        detect_and_parse skips unknown tools, but the streaming path used to flush
+        the buffer as normal text, handing raw `[TOOL_CALLS]...[ARGS]{...}` markup
+        to the client.
+        """
+        text = 'Let me check.\n[TOOL_CALLS]get_wether[ARGS]{"city": "Beijing"}\nDone.'
+        for size in self.CHUNK_SIZES:
+            with self.subTest(chunk_size=size):
+                normal_text, calls = self._stream(text, size)
+                self.assertEqual(calls, [])
+                self.assertNotIn("[TOOL_CALLS", normal_text)
+                self.assertNotIn("[ARGS", normal_text)
+                self.assertNotIn("get_wether", normal_text)
+                self.assertIn("Let me check.", normal_text)
+                self.assertIn("Done.", normal_text)
+
+    def test_detect_and_parse_drops_truncated_compact_call(self):
+        """A call cut off by the token limit is markup, not assistant content."""
+        text = '[TOOL_CALLS]get_weather[ARGS]{"city": "Beijing"}[TOOL_CALLS]get_wea'
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.normal_text, "")
+
+    def test_streaming_json_array_two_calls(self):
+        """Both array entries stream out, and no part of the array leaks as text.
+
+        The base JSON parser sends a tool name and its arguments in separate
+        increments and relies on a following increment to carry the rest, so an
+        array completing in the last chunk lost its arguments. The continuation of
+        an array (`, {...}]`) also carries no `[TOOL_CALLS` marker, and used to be
+        flushed to the client as plain text along with the dropped second call.
+        """
+        text = (
+            '[TOOL_CALLS] [{"name": "get_weather", "arguments": {"city": "Beijing"}}, '
+            '{"name": "search", "arguments": {"query": "restaurants"}}]'
+        )
+        for size in self.CHUNK_SIZES:
+            with self.subTest(chunk_size=size):
+                normal_text, calls = self._stream(text, size)
+                self.assertEqual(normal_text, "")
+                self.assertEqual([name for name, _ in calls], ["get_weather", "search"])
+                self.assertEqual(json.loads(calls[0][1])["city"], "Beijing")
+                self.assertEqual(json.loads(calls[1][1])["query"], "restaurants")
+
+    def test_streaming_json_array_after_preamble_in_one_chunk(self):
+        """Preamble before a JSON array is delivered, not swallowed by the parser."""
+        text = 'Sure.\n[TOOL_CALLS] [{"name": "search", "arguments": {"query": "sf"}}]'
+        normal_text, calls = self._stream(text)
+        self.assertEqual(normal_text, "Sure.\n")
+        self.assertEqual(calls, [("search", '{"query": "sf"}')])
+
 
 if __name__ == "__main__":
     import unittest


### PR DESCRIPTION
## Motivation

`MistralDetector.parse_streaming_increment()` performs at most one action per increment: it emits either some normal text, or one tool call, and leaves the rest of the buffer for the next increment. That assumption breaks whenever a single increment carries more than one thing — which happens with `stream_interval > 1`, with speculative decoding accepting several tokens at once, and always on the last increment of a stream, where there is no next call.

On `main`, the compact Mistral format (`[TOOL_CALLS]name[ARGS]{...}`, used by the newer templates) is affected as follows:

| Model output (single increment) | main | expected |
| --- | --- | --- |
| `Sure.\n[TOOL_CALLS]get_weather[ARGS]{"city":"SF"}` | only `Sure.\n` is sent, the tool call is **silently dropped** | text + call |
| two consecutive compact calls | only the first call is sent | both calls |
| a compact call followed by prose | the trailing prose is kept or dropped **depending on where the chunk boundary falls** | same as non-streaming |
| a compact call with an undefined tool name | raw `[TOOL_CALLS]name[ARGS]{...}` is delivered to the client **as assistant content** (`detect_and_parse` drops it) | dropped, no markup in content |

The JSON-array format has two related problems: an array that completes inside the final increment loses its `arguments` (the base parser sends the name and waits for an increment that never comes), and the continuation of a multi-call array (`, {...}]`) carries no `[TOOL_CALLS` marker, so it was flushed to the client as plain text while the second call was dropped.

## Modifications

`python/sglang/srt/function_call/mistral_detector.py` only:

1. `parse_streaming_increment()` now drains the buffer in a loop instead of returning after the first action, so leading text, several complete compact calls and trailing text in one increment are all handled.
2. A compact call whose name is not in `_tool_indices` is dropped with a warning, matching `parse_base_json()`, instead of being flushed as normal text.
3. A canonical `[TOOL_CALLS] [` array switches the detector into an explicit array mode (`_json_array_mode`) and drives the base JSON parser until it stops making progress, so a name and its arguments both go out even in the last increment; the closing `]` leaves array mode, and a `, ` separator split across increments is held back. `finish()` treats a buffer still inside an unfinished array as markup, not content.
4. `detect_and_parse()`: text following an unparsable compact call is no longer dropped, and a call truncated by the token limit is treated as markup rather than returned as content.

No new environment variables, no change to `base_format_detector.py`, and no change to `structure_info()`. This is complementary to (and was verified against) the in-review base-detector work on unknown tool names in #34678: streaming `SGLANG_FORWARD_UNKNOWN_TOOLS` semantics are intentionally left untouched here.

## Accuracy Tests

7 streaming regression cases added to `test/registered/unit/function_call/test_mistral_detector.py`, each feeding the same model output at chunk sizes `(whole, 16, 8, 4, 1)` and comparing the merged stream against `detect_and_parse`: all 7 fail before this change and pass after.

Measured on a CPU-only run with the `function_call` sources and tests at `8720a72`:

| | before | after |
| --- | --- | --- |
| `test/registered/unit/function_call/` | 464 passed | **471 passed** (= 464 + 7), 0 failed |
| `test_mistral_detector.py` alone | — | 25 passed |
| separate 13-shape probe (markup leakage / chunk-invariance / agreement with `detect_and_parse`) | 11 shapes bad | **1** shape bad |

The one remaining bad shape is a JSON-array call with an unknown tool name, which needs the base-class change in #34678; with that branch applied on top it goes to 0. `black --check` and `isort --check-only` are clean on both files.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/development_guide_using_docker.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/development_guide_using_docker.html#running-unit-tests-adding-to-ci).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31861389058](https://github.com/sgl-project/sglang/actions/runs/31861389058)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31861388941](https://github.com/sgl-project/sglang/actions/runs/31861388941)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->