### PR TITLE
[Bugfix] Fix routing key propagation for embedding requests

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1258,6 +1258,7 @@ class EmbeddingReqInput:
                 lora_id=self.lora_id[i] if self.lora_id is not None else None,
                 positional_embed_overrides=self._get_positional_embed_overrides_item(i),
                 http_worker_ipc=self.http_worker_ipc,
+                routing_key=self.routing_key,
                 priority=self.priority,
                 return_pooled_hidden_states=self.return_pooled_hidden_states,
                 return_prompt_token_ids=self.return_prompt_token_ids,
@@ -1286,6 +1287,7 @@ class EmbeddingReqInput:
                 lora_id=self.lora_id[i] if self.lora_id is not None else None,
                 positional_embed_overrides=self._get_positional_embed_overrides_item(i),
                 http_worker_ipc=self.http_worker_ipc,
+                routing_key=self.routing_key,
                 priority=self.priority,
                 dimensions=self.dimensions,
                 return_pooled_hidden_states=self.return_pooled_hidden_states,
@@ -1318,6 +1320,8 @@ class TokenizedEmbeddingReqInput(BaseReq, kw_only=True):
     positional_embed_overrides: Optional[PositionalEmbeds] = None
     # For DP routing
     routed_dp_rank: Optional[int] = None
+    # Routing key for routing-key schedule policy
+    routing_key: Optional[str] = None
     # Priority for the request
     priority: Optional[int] = None
     # The number of dimensions the resulting output embeddings should have. It is applicable for Matryoshka Embeddings.

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2862,6 +2862,7 @@ class Scheduler(
             dimensions=recv_req.dimensions,
             lora_id=recv_req.lora_id,
             http_worker_ipc=recv_req.http_worker_ipc,
+            routing_key=recv_req.routing_key,
             time_stats=recv_req.time_stats,
             return_pooled_hidden_states=recv_req.return_pooled_hidden_states,
             multi_item_delimiter_indices=recv_req.multi_item_delimiter_indices,

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1464,6 +1464,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 dimensions=obj.dimensions,
                 lora_id=obj.lora_id,
                 http_worker_ipc=obj.http_worker_ipc,
+                routing_key=obj.routing_key,
                 return_pooled_hidden_states=obj.return_pooled_hidden_states,
                 multi_item_delimiter_indices=obj.multi_item_delimiter_indices,
             )

--- a/test/registered/unit/managers/test_embedding_routing_key.py
+++ b/test/registered/unit/managers/test_embedding_routing_key.py
@@ -1,0 +1,112 @@
+"""Regression tests for embedding routing-key propagation."""
+
+import unittest
+from array import array
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.io_struct import (  # noqa: E402
+    EmbeddingReqInput,
+    TokenizedEmbeddingReqInput,
+    msgpack_decode,
+    msgpack_encode,
+)
+from sglang.srt.managers.scheduler import Scheduler  # noqa: E402
+from sglang.srt.managers.tokenizer_manager import TokenizerManager  # noqa: E402
+from sglang.srt.sampling.sampling_params import SamplingParams  # noqa: E402
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestEmbeddingRoutingKey(CustomTestCase):
+    def test_batch_split_preserves_routing_key(self):
+        cases = (
+            (["first", "second"], False),
+            ([["query 1", "document 1"], ["query 2", "document 2"]], True),
+        )
+
+        for text, is_cross_encoder_request in cases:
+            with self.subTest(cross_encoder=is_cross_encoder_request):
+                req = EmbeddingReqInput(
+                    text=text,
+                    is_cross_encoder_request=is_cross_encoder_request,
+                    routing_key="session-a",
+                )
+                req.normalize_batch_and_arguments()
+
+                self.assertEqual(
+                    [req[i].routing_key for i in range(2)],
+                    ["session-a", "session-a"],
+                )
+
+    def test_tokenization_preserves_routing_key(self):
+        manager = TokenizerManager.__new__(TokenizerManager)
+        manager.preferred_sampling_params = None
+        manager.sampling_params_class = SamplingParams
+        manager.tokenizer = None
+        manager.model_config = SimpleNamespace(vocab_size=128)
+        manager.rid_to_state = {"embed-req": SimpleNamespace(time_stats=MagicMock())}
+        req = EmbeddingReqInput(
+            rid="embed-req",
+            text="hello",
+            sampling_params={},
+            routing_key="session-a",
+        )
+
+        tokenized_req = manager._create_tokenized_object(req, "hello", [1, 2])
+
+        self.assertEqual(tokenized_req.routing_key, "session-a")
+
+    def test_msgpack_round_trip_preserves_routing_key(self):
+        req = TokenizedEmbeddingReqInput(
+            rid="embed-req",
+            input_text="hello",
+            input_ids=array("q", [1, 2]),
+            mm_inputs=None,
+            token_type_ids=None,
+            sampling_params=SamplingParams(),
+            routing_key="session-a",
+        )
+
+        decoded = msgpack_decode(msgpack_encode(req))
+
+        self.assertEqual(decoded.routing_key, "session-a")
+
+    @patch("sglang.srt.managers.scheduler.validate_input_length", return_value=None)
+    @patch("sglang.srt.managers.scheduler.get_serving")
+    @patch("sglang.srt.managers.scheduler.Req")
+    def test_scheduler_receives_routing_key(
+        self, req_cls, get_serving, _validate_input_length
+    ):
+        get_serving.return_value = SimpleNamespace(allow_auto_truncate=False)
+        scheduler_req = MagicMock()
+        scheduler_req.origin_input_ids = array("q", [1, 2])
+        req_cls.return_value = scheduler_req
+
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.tokenizer = None
+        scheduler.max_req_input_len = 128
+        scheduler._maybe_namespace_elastic_radix_cache = MagicMock()
+        scheduler._add_request_to_queue = MagicMock()
+        tokenized_req = TokenizedEmbeddingReqInput(
+            rid="embed-req",
+            input_text="hello",
+            input_ids=array("q", [1, 2]),
+            sampling_params=SamplingParams(),
+            mm_inputs=None,
+            token_type_ids=None,
+            routing_key="session-a",
+        )
+
+        scheduler.handle_embedding_request(tokenized_req)
+
+        self.assertEqual(req_cls.call_args.kwargs["routing_key"], "session-a")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Preserve `routing_key` through the embedding request path, from batch splitting to scheduler admission.
- Restore the existing `--schedule-policy routing-key` behavior for `/v1/embeddings` requests carrying `x-smg-routing-key`.
- Keep requests without a routing key unchanged.
- Add focused CPU regression coverage for batch splitting, tokenization, msgpack IPC, and scheduler construction.

## Root cause

The `/v1/embeddings` entrypoint correctly extracts `x-smg-routing-key` into
`EmbeddingReqInput`, but the embedding-specific downstream path does not
preserve it.

```text
Before

HTTP request
x-smg-routing-key: tenant-a
              |
              v
EmbeddingReqInput
routing_key = tenant-a
              |
              +-- batched request
              |        |
              |        v
              |   EmbeddingReqInput.__getitem__
              |   routing_key = None
              |        |
              +--------+
                       |
                       v
TokenizedEmbeddingReqInput
routing_key field absent
                       |
                       v
Tokenizer-to-scheduler IPC
routing key unavailable
                       |
                       v
Scheduler Req
routing_key = None
                       |
                       v
routing-key policy cannot see tenant-a
```

For batched requests, the key is first lost during
`EmbeddingReqInput.__getitem__`. For both single and batched requests, the
tokenized embedding request does not carry the field, so the scheduler receives
`routing_key=None`.

The request still completes successfully, making the failure silent: routing-key
scheduling behaves as if no key was provided.

PR #16839 added routing-key handling to the OpenAI entrypoints and completed the
generation request path. The embedding entrypoint and outer request object were
updated, but the embedding-specific downstream propagation was left incomplete.

## Fix

Preserve the existing routing key through every embedding request boundary.

```text
After

HTTP request
x-smg-routing-key: tenant-a
              |
              v
EmbeddingReqInput
routing_key = tenant-a
              |
              +-- batched request
              |        |
              |        v
              |   EmbeddingReqInput.__getitem__
              |   routing_key = tenant-a
              |        |
              +--------+
                       |
                       v
TokenizedEmbeddingReqInput
routing_key = tenant-a
                       |
                       v
Msgpack IPC round trip
routing_key = tenant-a
                       |
                       v
Scheduler Req
routing_key = tenant-a
                       |
                       v
routing-key policy can prioritize tenant-a
```

The fix is intentionally limited to field propagation:

- Copy the key in both embedding batch-split branches.
- Add the field to `TokenizedEmbeddingReqInput`.
- Pass it through `TokenizerManager` and scheduler `Req` construction.

This does not change the routing-key scheduling algorithm, generation request
propagation, or SMG cross-instance routing.

## Validation

The focused regression fails on unmodified `main` because batch items contain
`routing_key=None`, `TokenizedEmbeddingReqInput` has no such field, and the
scheduler does not receive it.

With this change:

- `test_embedding_routing_key.py`: 4 tests passed
  - normal and cross-encoder batch splitting
  - tokenizer request construction
  - msgpack IPC round trip
  - scheduler `Req` construction
- Existing type-based dispatcher test: 1 test passed
- Black, isort, configured Ruff checks, codespell, `py_compile`, CI registration parsing, and `git diff --check` passed

The focused tests are registered in the CPU CI suite and do not require a model
server or GPU.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31861835961](https://github.com/sgl-project/sglang/actions/runs/31861835961)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31861835852](https://github.com/sgl-project/sglang/actions/runs/31861835852)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->