### PR TITLE
[diffusion] cli: restore gated Diffusers model detection

### DIFF
--- a/python/sglang/cli/utils.py
+++ b/python/sglang/cli/utils.py
@@ -5,6 +5,7 @@ import subprocess
 from functools import lru_cache
 
 from huggingface_hub import HfApi
+from huggingface_hub.errors import GatedRepoError
 
 from sglang.srt.environ import envs
 from sglang.utils import (
@@ -61,7 +62,7 @@ def get_is_diffusion_model(model_path: str) -> bool:
     For registered models, consults the diffusion registry first.
     For other local directories, checks the filesystem directly.
     For other HF/ModelScope model IDs, attempts to fetch only model_index.json.
-    For gated repos where file download fails, falls back to HF model card
+    For gated HF repos where file download fails, falls back to HF model card
     metadata (library_name == "diffusers").
     Returns False on any failure (network error, 404, offline mode, etc.)
     so that the caller falls through to the standard LLM server path.
@@ -78,8 +79,10 @@ def get_is_diffusion_model(model_path: str) -> bool:
     if os.path.isdir(model_path):
         return _is_diffusers_model_dir(model_path)
 
+    use_modelscope = envs.SGLANG_USE_MODELSCOPE.get()
+
     try:
-        if envs.SGLANG_USE_MODELSCOPE.get():
+        if use_modelscope:
             from modelscope import model_file_download
 
             file_path = model_file_download(
@@ -93,6 +96,8 @@ def get_is_diffusion_model(model_path: str) -> bool:
         return _is_diffusers_model_dir(os.path.dirname(file_path))
     except Exception as e:
         logger.debug("Failed to auto-detect diffusion model for %s: %s", model_path, e)
+        if not use_modelscope and isinstance(e, GatedRepoError):
+            return _is_gated_diffusion_repo(model_path)
         return False
 
 

--- a/test/registered/unit/cli/test_utils.py
+++ b/test/registered/unit/cli/test_utils.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import httpx
+from huggingface_hub.errors import (
+    GatedRepoError,
+    RemoteEntryNotFoundError,
+    RepositoryNotFoundError,
+)
+
+from sglang.cli.utils import get_is_diffusion_model
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _hub_error(error_type, status_code):
+    request = httpx.Request("GET", "https://huggingface.co/test/model")
+    response = httpx.Response(status_code, request=request)
+    return error_type("test error", response=response)
+
+
+class TestDiffusionModelDetection(CustomTestCase):
+    def setUp(self):
+        super().setUp()
+        for target in (
+            "sglang.cli.utils._is_diffusion_model_from_registry",
+            "sglang.cli.utils._is_overlay_diffusion_model",
+            "sglang.cli.utils.os.path.isdir",
+        ):
+            patcher = patch(target, return_value=False)
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+        modelscope_patcher = patch(
+            "sglang.cli.utils.envs.SGLANG_USE_MODELSCOPE.get", return_value=False
+        )
+        modelscope_patcher.start()
+        self.addCleanup(modelscope_patcher.stop)
+
+    @patch("sglang.cli.utils.HfApi")
+    @patch("huggingface_hub.hf_hub_download")
+    def test_gated_diffusion_repo_uses_metadata_fallback(
+        self, mock_download, mock_hf_api
+    ):
+        mock_download.side_effect = _hub_error(GatedRepoError, 401)
+        mock_hf_api.return_value.model_info.return_value = SimpleNamespace(
+            library_name="diffusers"
+        )
+
+        self.assertTrue(get_is_diffusion_model("test/gated-diffusion-model"))
+        mock_hf_api.return_value.model_info.assert_called_once_with(
+            "test/gated-diffusion-model"
+        )
+
+    @patch("sglang.cli.utils.HfApi")
+    @patch("huggingface_hub.hf_hub_download")
+    def test_gated_non_diffusion_repo_is_not_detected(self, mock_download, mock_hf_api):
+        mock_download.side_effect = _hub_error(GatedRepoError, 401)
+        mock_hf_api.return_value.model_info.return_value = SimpleNamespace(
+            library_name="transformers"
+        )
+
+        self.assertFalse(get_is_diffusion_model("test/gated-llm-model"))
+        mock_hf_api.return_value.model_info.assert_called_once_with(
+            "test/gated-llm-model"
+        )
+
+    @patch("sglang.cli.utils.HfApi")
+    @patch("huggingface_hub.hf_hub_download")
+    def test_non_gated_hub_errors_do_not_use_metadata_fallback(
+        self, mock_download, mock_hf_api
+    ):
+        for error_type in (RemoteEntryNotFoundError, RepositoryNotFoundError):
+            with self.subTest(error_type=error_type.__name__):
+                mock_download.side_effect = _hub_error(error_type, 404)
+                self.assertFalse(get_is_diffusion_model("test/llm-model"))
+        mock_hf_api.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`get_is_diffusion_model()` identifies remote Diffusers repositories by downloading `model_index.json`. For gated Hugging Face repositories, that download raises `GatedRepoError` before the file can be inspected. Although the existing helper and docstring describe a model-card metadata fallback, the exception path returned `False` without invoking it.

This misclassifies gated Diffusers repositories and can route `sglang serve` to the standard LLM backend or cause `sglang generate` to reject a supported diffusion model.

## Modifications

- Restore the model-card metadata fallback for Hugging Face `GatedRepoError` only.
- Keep ModelScope failures, missing files, missing repositories, offline mode, and other network errors on the existing `False` fallback path.
- Add CPU regression tests covering gated Diffusers repositories, gated non-Diffusers repositories, missing `model_index.json`, and missing repositories.

## Accuracy Tests

This change does not affect model outputs.

- `python test/registered/unit/cli/test_utils.py -v` — passed
- `python -m pytest test/registered/unit/cli/test_utils.py -q` — 3 passed, 2 subtests passed
- `python python/sglang/multimodal_gen/test/unit/test_server_args.py TestDiffusionModelDetection -v` — passed
- Live detection of `alvdansen/h3-keyframe-animation` now returns `True`

## Speed Tests and Profiling

Not applicable. The additional metadata request occurs only after a gated Hugging Face repository rejects the `model_index.json` download.

## Checklist

- [x] Format the code with pre-commit.
- [x] Add CPU unit tests for the changed behavior.
- [x] Keep the detection behavior documented in the function docstring.
- [x] Confirm that accuracy and performance benchmarks are not applicable.
- [x] Follow the SGLang code style guidance.