### PR TITLE
fix(quant): route compressed-tensors quantized lm_head through the linear scheme

### DIFF
--- a/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -200,6 +200,22 @@ class CompressedTensorsConfig(QuantizationConfig):
                     use_triton_kernels, use_flashinfer_trtllm_moe, use_deep_gemm
                 )
             return CompressedTensorsFusedMoEMethod(self)
+
+        # ParallelLMHead subclasses VocabParallelEmbedding but is a linear
+        # (logits = hidden @ weight.T); apply the matching linear scheme so a
+        # quantized lm_head (e.g. FP8 per-channel) is dequantized correctly
+        # instead of being consumed as a raw bf16 tensor.
+        from sglang.srt.layers.vocab_parallel_embedding import ParallelLMHead
+
+        if isinstance(layer, ParallelLMHead):
+            try:
+                scheme = self.get_linear_scheme(layer=layer, layer_name=prefix)
+            except ValueError:
+                scheme = None
+            if scheme is not None:
+                layer.scheme = scheme
+                return CompressedTensorsLinearMethod(self)
+
         return None
 
     def _add_fused_moe_to_target_scheme_map(self):

--- a/test/registered/unit/layers/quantization/test_ct_parallel_lm_head_dispatch.py
+++ b/test/registered/unit/layers/quantization/test_ct_parallel_lm_head_dispatch.py
@@ -1,0 +1,93 @@
+"""CPU regression tests for compressed-tensors quantized ParallelLMHead dispatch.
+
+A compressed-tensors checkpoint that targets ``lm_head`` (e.g. FP8 W8A8
+per-channel or WNA16 pack-quantized) used to fall through to
+``UnquantizedEmbeddingMethod`` because ``get_quant_method()`` only dispatched
+``LinearBase`` and ``FusedMoE``. The per-channel ``weight_scale`` was then never
+loaded and the raw quantized weight was consumed as bf16, corrupting logits and
+producing degenerate repetition loops. These tests cover the
+``ParallelLMHead`` branch added to ``CompressedTensorsConfig.get_quant_method()``.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+from unittest import mock
+
+from sglang.srt.layers.quantization.compressed_tensors.compressed_tensors import (
+    CompressedTensorsConfig,
+    CompressedTensorsLinearMethod,
+)
+from sglang.srt.layers.quantization.compressed_tensors.schemes import (
+    CompressedTensorsW8A8Fp8,
+    CompressedTensorsWNA16,
+)
+from sglang.srt.layers.vocab_parallel_embedding import ParallelLMHead
+from sglang.test.test_utils import CustomTestCase
+
+
+def _make_cfg() -> CompressedTensorsConfig:
+    return CompressedTensorsConfig(
+        target_scheme_map={"lm_head": {"weights": None, "input_activations": None}},
+        ignore=[],
+        quant_format="mixed-precision",
+        sparsity_scheme_map={},
+        sparsity_ignore_list=[],
+    )
+
+
+class TestParallelLMHeadDispatch(CustomTestCase):
+    def test_w8a8_fp8_lm_head_dispatches(self):
+        # FP8 W8A8 per-channel lm_head (e.g. unsloth/Qwen3.8-27B-NVFP4) must
+        # route through the linear scheme so weight_scale is applied.
+        cfg = _make_cfg()
+        sentinel = mock.MagicMock(spec=CompressedTensorsW8A8Fp8)
+        cfg.get_linear_scheme = mock.MagicMock(return_value=sentinel)
+        layer = ParallelLMHead.__new__(ParallelLMHead)
+
+        method = cfg.get_quant_method(layer, prefix="lm_head")
+
+        self.assertIsInstance(method, CompressedTensorsLinearMethod)
+        self.assertIs(layer.scheme, sentinel)
+        cfg.get_linear_scheme.assert_called_once_with(layer=layer, layer_name="lm_head")
+
+    def test_wna16_lm_head_dispatches(self):
+        # WNA16 pack-quantized lm_head (the case covered by #28130) must also
+        # dispatch, keeping behavior consistent with vLLM #37291.
+        cfg = _make_cfg()
+        sentinel = mock.MagicMock(spec=CompressedTensorsWNA16)
+        cfg.get_linear_scheme = mock.MagicMock(return_value=sentinel)
+        layer = ParallelLMHead.__new__(ParallelLMHead)
+
+        method = cfg.get_quant_method(layer, prefix="lm_head")
+
+        self.assertIsInstance(method, CompressedTensorsLinearMethod)
+        self.assertIs(layer.scheme, sentinel)
+
+    def test_untargeted_lm_head_stays_unquantized(self):
+        # A ValueError from target matching means the head is not covered by
+        # any config group; keep the previous unquantized behavior.
+        cfg = _make_cfg()
+        cfg.get_linear_scheme = mock.MagicMock(side_effect=ValueError("Not targeted"))
+        layer = ParallelLMHead.__new__(ParallelLMHead)
+
+        method = cfg.get_quant_method(layer, prefix="lm_head")
+
+        self.assertIsNone(method)
+        self.assertFalse(hasattr(layer, "scheme"))
+
+    def test_none_scheme_stays_unquantized(self):
+        cfg = _make_cfg()
+        cfg.get_linear_scheme = mock.MagicMock(return_value=None)
+        layer = ParallelLMHead.__new__(ParallelLMHead)
+
+        method = cfg.get_quant_method(layer, prefix="lm_head")
+
+        self.assertIsNone(method)
+        self.assertFalse(hasattr(layer, "scheme"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->
Closes #34895

## Motivation

`CompressedTensorsConfig.get_quant_method()` only dispatches `LinearBase` and `FusedMoE`. `ParallelLMHead` (a `VocabParallelEmbedding` subclass) falls through to `return None` → `UnquantizedEmbeddingMethod`, so for a compressed-tensors checkpoint that targets `lm_head`, the per-channel `weight_scale` is never loaded:

```
Parameter lm_head.weight_scale not found in params_dict
```

The raw FP8 `lm_head.weight` (values ~±448) is then consumed as bf16 without its per-channel scale, corrupting logits ranking and producing degenerate repetition loops from the very first token.

Serving [unsloth/Qwen3.8-27B-NVFP4](https://huggingface.co/unsloth/Qwen3.8-27B-NVFP4) (compressed-tensors mixed-precision: NVFP4 W4A4 MLP layers 0–55, FP8 W8A8 per-channel linear_attn / layers 56–63 MLP / lm_head) with sglang repeats a single phrase forever inside reasoning (e.g. ``"need analysis there need analysis there need analysis there ..."``) on a short 67-token prompt, while the same checkpoint serves correctly with vLLM.

This closes the same gap as vLLM [#37291](https://github.com/vllm-project/vllm/pull/37291), which routes all matching schemes (including W8A8-FP8) through `CompressedTensorsLinearMethod`.

## Modifications

- Add a `ParallelLMHead` branch in `CompressedTensorsConfig.get_quant_method()` that reuses `get_linear_scheme(prefix)` and returns `CompressedTensorsLinearMethod` when the prefix matches a compressed-tensors target.
- Treat `ValueError` from target matching as unquantized, so ignored or untargeted lm_head stays unchanged.
- Add registered CPU unit tests covering W8A8-FP8 / WNA16 dispatch and the unquantized fallbacks.

## Accuracy Tests

2× RTX 5090 (sm120), flashinfer 0.6.17, sglang commit `41cd5a7`.

<details>
<summary>server E2E: unsloth/Qwen3.8-27B-NVFP4 before and after</summary>

Request: `Which is larger, 9.11 or 9.9? Answer briefly.` (temperature 0, max_tokens 300). Real responses from the same server, sam

```text
before (unpatched, real response):
  finish_reason=length
  reasoning_content repeats from the first token:
  "We need answer user asks which larger between numbers answer briefly need
   ensure analysis there user asks which larger between numbers answer briefly
   need ensure analysis there need analysis there need analysis there need
   analysis there ..." (repeats until max_tokens)
  content: "" (empty)

after (patched, real response):
  finish_reason=stop
  reasoning_content: "We need answer user: \"Which is larger, 9.11 or 9.9?
    Answer briefly.\" Need final brief. Compare decimals: 9.9 > 9.11 because
    9.9 = 9.90. Final: 9.9."
  content: "\n\n9.9"
```

Also verified on recursion and fibonacci probes (temperature 0): coherent answers, no repetition.
</details>

<details>
<summary>root-cause numbers</summary>

- `lm_head.weight` fp8 raw absmean ≈ 74.2 (values ~±448); correct dequantized absmean ≈ 0.011 (per-channel scale mean 1.55e-4, row-to-row spread up to 12×).
- With the scale dropped, top-10 logits overlap only 2/10 with the dequantized head on the same hidden state.
- `Parameter lm_head.weight_scale not found in params_dict` present in startup log before the patch, absent after.
- Real-config dispatch (non-mock): building `CompressedTensorsConfig` from the checkpoint's `quantization_config` and calling `get_quant_method(ParallelLMHead, "lm_head")` returns `CompressedTensorsLinearMethod` with a `CompressedTensorsW8A8Fp8` scheme.
</details>

<details>
<summary>unit tests</summary>

```bash
PYTHONPATH=python python -m unittest \
  test.registered.unit.layers.quantization.test_ct_parallel_lm_head_dispatch -v
```

```text
test_none_scheme_stays_unquantized ... ok
test_untargeted_lm_head_stays_unquantized ... ok
test_w8a8_fp8_lm_head_dispatches ... ok
test_wna16_lm_head_dispatches ... ok

Ran 4 tests in 0.495s
OK
```

Existing compressed-tensors unit tests in the same directory: 8/8 pass (no regression).
</details>

## Speed Tests and Profiling

Correctness-only dispatch change — lm_head is already quantized in the checkpoint and now stays quantized instead of being silently consumed as bf16. Measured on the same server, same checkpoint, with and without the patch: weight load time ~10.9s → ~5.3s, weight memory 11.18 → 10.60 GB/rank (lm_head kept in FP8, no bf16 materialization).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (N/A — bug fix, no documentation change)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31862591427](https://github.com/sgl-project/sglang/actions/runs/31862591427)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31862591272](https://github.com/sgl-project/sglang/actions/runs/31862591272)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
