### PR TITLE
feat: add layer-wise KV transfer for PD disaggregation

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,6 +20,9 @@ ARG UBUNTU_MIRROR
 ARG GITHUB_ARTIFACTORY=github.com
 ARG INSTALL_FLASHINFER_JIT_CACHE=0
 ARG FLASHINFER_VERSION=0.6.15.post1
+ARG TRTLLM_GEN_MOE_CUBIN_URL="https://github.com/sgl-project/whl/releases/download/trtllm_gen_moe_cubin_20260617/trtllm_gen_moe_cubin_pool_20260617_v0613rc1.zip"
+ARG TRTLLM_GEN_MOE_CUBIN_SHA256="4900501cbe782a76b08a5858f9f07152287b97cb68114466dac286366b66c192"
+ARG TRTLLM_GEN_MOE_CUBIN_ARCHIVE_ROOT="trtllm_gen_moe_cubin_pool_20260617_v0613rc1"
 ARG MOONCAKE_VERSION=0.3.12.post1
 ARG MSCCLPP_VERSION=sglang-v0.9.1
 #if need other arg please add in MOONCAKE_COMPILE_ARG
@@ -28,7 +31,8 @@ ARG MOONCAKE_COMPILE_ARG="-DUSE_HTTP=ON -DUSE_MNNVL=ON -DUSE_CUDA=ON -DWITH_EP=O
 ENV DEBIAN_FRONTEND=noninteractive \
     CUDA_HOME=/usr/local/cuda \
     GDRCOPY_HOME=/usr/src/gdrdrv-${GDRCOPY_VERSION}/ \
-    FLASHINFER_VERSION=${FLASHINFER_VERSION}
+    FLASHINFER_VERSION=${FLASHINFER_VERSION} \
+    SGLANG_TRTLLM_GEN_MOE_CUBIN_POOL=/opt/trtllm_gen_moe_cubin_pool
 
 # Add GKE default lib and bin locations
 ENV PATH="${PATH}:/usr/local/nvidia/bin" \
@@ -75,6 +79,7 @@ RUN --mount=type=cache,target=/var/cache/apt,id=base-apt \
     build-essential \
     cmake \
     perl \
+    patch \
     patchelf \
     ccache \
     git-lfs \
@@ -166,6 +171,7 @@ ENV LANG=en_US.UTF-8 \
 #     |
 #     +-- devtools_builder (independent)
 #     +-- gateway_builder  (independent, only needs gateway source)
+#     +-- trtllm_cubin_builder (independent)
 #     |
 #     v
 #   framework (combines all artifacts)
@@ -342,7 +348,7 @@ FROM torch_deps AS hpc_ops_builder
 # HPC-Ops (https://github.com/Tencent/hpc-ops, MIT): fused attention / MoE /
 # RoPE kernels from the Tencent Hunyuan AI Infra team, consumed by the opt-in
 # hpc_ops attention and MoE runner backends.
-ARG HPC_OPS_COMMIT=6e2ecede9d6d47b2e680e839cc7ad7422bc8d88b
+ARG HPC_OPS_COMMIT=ab1a402724635507037426068f6cddc3d30dc0a8
 
 WORKDIR /build
 
@@ -467,6 +473,27 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     && rm -rf /root/.cargo /root/.rustup /build/sgl-model-gateway/target /build/sgl-model-gateway/bindings/python/target
 
 ########################################################
+# PARALLEL STAGE 6: TRT-LLM Generated-MoE Cubin Pool
+########################################################
+FROM base AS trtllm_cubin_builder
+
+RUN cubin_archive="/tmp/trtllm_gen_moe_cubin_pool.zip" && \
+    cubin_extract_dir="/tmp/trtllm_gen_moe_cubin_extract" && \
+    wget --no-verbose --output-document="${cubin_archive}" \
+      "${TRTLLM_GEN_MOE_CUBIN_URL}" && \
+    echo "${TRTLLM_GEN_MOE_CUBIN_SHA256}  ${cubin_archive}" | \
+      sha256sum --check --strict - && \
+    mkdir -p "${cubin_extract_dir}" && \
+    unzip -q "${cubin_archive}" -d "${cubin_extract_dir}" && \
+    test ! -e "${SGLANG_TRTLLM_GEN_MOE_CUBIN_POOL}" && \
+    mv "${cubin_extract_dir}/${TRTLLM_GEN_MOE_CUBIN_ARCHIVE_ROOT}" \
+      "${SGLANG_TRTLLM_GEN_MOE_CUBIN_POOL}" && \
+    test "$(find "${SGLANG_TRTLLM_GEN_MOE_CUBIN_POOL}" \
+      -type f -name '*.cubin' | wc -l)" -eq 1696 && \
+    rm -f "${cubin_archive}" && \
+    rm -rf "${cubin_extract_dir}"
+
+########################################################
 ########## Final Framework Image ######################
 ########################################################
 #
@@ -506,6 +533,21 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 
 # Copy flashinfer cubin (always) and jit-cache (if installed) packages
 COPY --from=flashinfer_cache /flashinfer_jit_output/ /usr/local/lib/python3.12/dist-packages/
+
+# Apply the FlashInfer CuTeDSL MLA decode-context-parallel runtime patch.
+# Exclude tests because they are not included in the installed wheel.
+COPY docker/kimi_k3/flashinfer-perkz-dcp-0.6.15.txt /tmp/flashinfer-perkz-dcp-0.6.15.txt
+RUN FLASHINFER_DCP_PATCH=/tmp/flashinfer-perkz-dcp-0.6.15.txt && \
+    FLASHINFER_SITE_PACKAGES="$(python3 -c 'from pathlib import Path; import flashinfer; print(Path(flashinfer.__file__).resolve().parent.parent)')" && \
+    sed '/^diff --git a\/tests\//,$d' "${FLASHINFER_DCP_PATCH}" | \
+      patch --dry-run --batch --forward --strip=1 --directory="${FLASHINFER_SITE_PACKAGES}" && \
+    sed '/^diff --git a\/tests\//,$d' "${FLASHINFER_DCP_PATCH}" | \
+      patch --batch --forward --strip=1 --directory="${FLASHINFER_SITE_PACKAGES}" && \
+    rm -f "${FLASHINFER_DCP_PATCH}" && \
+    rm -rf /root/.cache/flashinfer /root/.cache/pip
+
+# Copy the pinned FlashInfer MXFP4 MoE runner cubin pool
+COPY --from=trtllm_cubin_builder /opt/trtllm_gen_moe_cubin_pool /opt/trtllm_gen_moe_cubin_pool
 
 # Copy dev tools
 COPY --from=devtools_builder /tools/diff-so-fancy /usr/local/bin/
@@ -771,7 +813,8 @@ ARG GDRCOPY_VERSION=2.5.1
 
 ENV DEBIAN_FRONTEND=noninteractive \
     CUDA_HOME=/usr/local/cuda \
-    GDRCOPY_HOME=/usr/src/gdrdrv-${GDRCOPY_VERSION}/
+    GDRCOPY_HOME=/usr/src/gdrdrv-${GDRCOPY_VERSION}/ \
+    SGLANG_TRTLLM_GEN_MOE_CUBIN_POOL=/opt/trtllm_gen_moe_cubin_pool
 
 # Add GKE default lib and bin locations + CUDA compiler paths for FlashInfer JIT
 ENV PATH="${PATH}:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/cuda/nvvm/bin" \
@@ -856,6 +899,9 @@ RUN --mount=type=cache,target=/var/cache/apt,id=runtime-apt \
 
 # Copy Python site-packages from framework (already cleaned of __pycache__/tests/pyc files)
 COPY --from=framework_final /usr/local/lib/python3.12/dist-packages /usr/local/lib/python3.12/dist-packages
+
+# Copy the pinned FlashInfer MXFP4 MoE runner cubin pool
+COPY --from=framework_final /opt/trtllm_gen_moe_cubin_pool /opt/trtllm_gen_moe_cubin_pool
 
 # Copy SGLang workspace
 COPY --from=framework_final /sgl-workspace /sgl-workspace

--- a/proto/sglang/runtime/v1/sglang.proto
+++ b/proto/sglang/runtime/v1/sglang.proto
@@ -63,8 +63,24 @@ message SamplingParams {
   repeated int32 stop_token_ids = 11;
   optional bool ignore_eos = 12;
   optional int32 n = 13;
-  optional string json_schema = 14;
-  optional string regex = 15;
+  optional string json_schema = 14 [deprecated = true];
+  optional string regex = 15 [deprecated = true];
+  optional int64 seed = 16;
+  optional GuidedDecoding guided_decoding = 17;
+}
+
+message GuidedDecoding {
+  oneof constraint {
+    string json_schema = 1;
+    string regex = 2;
+    string ebnf = 3;
+    ChoiceConstraint choice = 4;
+    string structural_tag = 5;
+  }
+}
+
+message ChoiceConstraint {
+  repeated string values = 1;
 }
 
 // ---- Text-based generate (text in, text out) ----
@@ -84,6 +100,9 @@ message TextGenerateRequest {
   map<string, string> trace_headers = 12;
   optional string session_id = 13;
   optional DisaggregatedParams disaggregated_params = 14;
+  optional int32 priority = 15;
+  optional bool require_reasoning = 16;
+  optional uint32 max_thinking_tokens = 17;
 }
 
 message TextGenerateResponse {
@@ -108,6 +127,9 @@ message GenerateRequest {
   map<string, string> trace_headers = 11;
   optional string session_id = 12;
   optional DisaggregatedParams disaggregated_params = 13;
+  optional int32 priority = 14;
+  optional bool require_reasoning = 15;
+  optional uint32 max_thinking_tokens = 16;
 }
 
 message GenerateResponse {

--- a/python/sglang/kernels/ops/attention/fla/chunk_delta_h.py
+++ b/python/sglang/kernels/ops/attention/fla/chunk_delta_h.py
@@ -119,6 +119,9 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
     # per-slot pitch spans ALL layers' state, not H*V*K. int64: envelope pitches
     # overflow an int32 index product.
     index = tl.load(initial_state_indices + i_n).to(tl.int64)
+    # Padded rows carry the -1 sentinel; the decode kernel guards on it
+    # (fused_recurrent.py), the chunked extend path did not.
+    valid_state = index >= 0
     h0 = initial_state + index * stride_init_state
     ht = initial_state + index * stride_init_state
     if USE_INITIAL_STATE:
@@ -127,7 +130,7 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
         ht = ht + i_h * V * K
 
     # load initial state
-    if USE_INITIAL_STATE:
+    if USE_INITIAL_STATE and valid_state:
         p_h0_1 = tl.make_block_ptr(h0, (V, K), (K, 1), (i_v * BV, 0), (BV, 64), (1, 0))
         b_h1 += tl.load(p_h0_1, boundary_check=(0, 1)).to(tl.float32)
         if K > 64:
@@ -290,7 +293,7 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
             b_h4 += tl.trans(tl.dot(b_k, b_v))
 
     # epilogue
-    if INPLACE_UPDATE:
+    if INPLACE_UPDATE and valid_state:
         p_ht = tl.make_block_ptr(ht, (V, K), (K, 1), (i_v * BV, 0), (BV, 64), (1, 0))
         tl.store(p_ht, b_h1.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
         if K > 64:

--- a/python/sglang/kernels/ops/kimi_k3/attn_res_hip.py
+++ b/python/sglang/kernels/ops/kimi_k3/attn_res_hip.py
@@ -1,0 +1,212 @@
+"""Triton attention-residual aggregation for Kimi-K3 on ROCm.
+
+The HIP counterpart of attn_res.py: same aggregation point (score the bank rows
+against the current prefix, softmax, weighted sum, output RMSNorm), one launch,
+but built for a GPU with no TMA and no tcgen05. See _agg_kernel for why the
+shape differs so much from the SM100 kernel's.
+"""
+
+from __future__ import annotations
+
+from functools import cache
+from typing import Optional
+
+import torch
+import triton
+import triton.language as tl
+
+# _agg_kernel keeps a next_pow2(nvb) x next_pow2(H) fp32 tile in registers, and
+# that is the whole basis of its speed. Past this budget it spills and loses to
+# the 2-kernel Triton pipeline it replaces: measured at T=4 on MI355X,
+# next_pow2(nvb)=8 is 2.0x faster, 16 is 1.2x, 32 is 0.2x. K3 sits right at the
+# limit with H=7168 (one masked tile of 8192) and nvb <= 8.
+MAX_REGISTER_TILE: int = 8 * 8192
+
+
+@cache
+def supports_attn_res_hip(hidden_size: int, nvb: int) -> bool:
+    """Whether this shape fits the register budget. Callers must additionally
+    check that they are on ROCm; this is only the shape constraint."""
+    return _tile_size(hidden_size, nvb) <= MAX_REGISTER_TILE
+
+
+def _tile_size(hidden_size: int, nvb: int) -> int:
+    return triton.next_power_of_2(max(nvb, 1)) * triton.next_power_of_2(hidden_size)
+
+
+@triton.jit
+def _agg_kernel(
+    prefix_ptr,  # [T, H]
+    addend_ptr,  # [T, H]; the pending residual, or prefix_ptr when not HAS_ADD
+    prefix_out_ptr,  # [T, H]; materialized prefix, written when HAS_ADD
+    bank_ptr,  # [T, NB, H]
+    cw_ptr,  # [H] fp32; score_norm weight * score_proj weight
+    ow_ptr,  # [H]; out RMSNorm weight, unread when not APPLY_OUT_NORM
+    out_ptr,  # [T, H]
+    score_eps,
+    out_eps,
+    stride_pm,
+    stride_am,
+    stride_om,
+    stride_bm,
+    stride_bb,
+    stride_o,
+    H: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    NVB: tl.constexpr,
+    R_PAD: tl.constexpr,
+    HAS_ADD: tl.constexpr,
+    WRITE_BANK: tl.constexpr,
+    APPLY_OUT_NORM: tl.constexpr,
+):
+    """One CTA per token: score the NVB+1 rows, softmax, mix, apply the output
+    RMSNorm, all in one launch.
+
+    T is the decode batch size, so this runs a handful of CTAs on a 256-CU GPU
+    and what binds is the load latency and bandwidth of a *single* CU. That is
+    what dictates the shape, and why it is not a port of the SM100 kernel. That
+    one's online softmax reads each row once but chains one block-wide reduction
+    per row; here each link in that chain costs a full HBM round-trip —
+    measured 1.1us/row, dead linear in NVB, because there is no TMA pipeline to
+    hide it behind. Scoring the rows as one [R_PAD, BLOCK_H] tile instead puts
+    every row's load in flight at once, and keeping that tile in registers lets
+    the mix reuse it rather than re-reading the bank, which at one active CU is
+    the difference between ~9us and ~12.5us at NVB=8.
+
+    Holding the tile is why NVB is a constexpr and why MAX_REGISTER_TILE caps
+    the shape: the register budget is what this trades away.
+
+    The prefix row streams through anyway, so the pending residual add and the
+    bank snapshot ride along for free — no other program reads bank row NVB, so
+    those stores need no synchronization.
+
+    Taking the global max before exponentiating makes this bit-comparable to
+    the 2-kernel pipeline rather than to the SM100 kernel.
+    """
+    t = tl.program_id(0)
+    offs = tl.arange(0, BLOCK_H)
+    mask = offs < H
+
+    # The prefix row is score row NVB, and the only row that needs writing back.
+    row = tl.load(prefix_ptr + t * stride_pm + offs, mask=mask, other=0.0)
+    if HAS_ADD:
+        # Round to the storage dtype before scoring: downstream readers see
+        # these bits, so the score has to as well.
+        row = (
+            row.to(tl.float32)
+            + tl.load(addend_ptr + t * stride_am + offs, mask=mask, other=0.0).to(
+                tl.float32
+            )
+        ).to(prefix_out_ptr.dtype.element_ty)
+        tl.store(prefix_out_ptr + t * stride_om + offs, row, mask=mask)
+    if WRITE_BANK:
+        tl.store(bank_ptr + t * stride_bm + NVB * stride_bb + offs, row, mask=mask)
+    pv = row.to(tl.float32)
+
+    cw = tl.load(cw_ptr + offs, mask=mask, other=0.0)
+    p_score = tl.sum(pv * cw) / tl.sqrt(tl.sum(pv * pv) / H + score_eps)
+
+    # The whole bank, in registers: every row's load is in flight at once, and
+    # the mix below reuses it instead of going back to HBM.
+    offs_r = tl.arange(0, R_PAD)
+    mask_r = offs_r < NVB
+    tile = tl.load(
+        bank_ptr + t * stride_bm + offs_r[:, None] * stride_bb + offs[None, :],
+        mask=mask_r[:, None] & mask[None, :],
+        other=0.0,
+    ).to(tl.float32)
+    b_score = tl.sum(tile * cw[None, :], axis=1) / tl.sqrt(
+        tl.sum(tile * tile, axis=1) / H + score_eps
+    )
+
+    m = tl.maximum(tl.max(tl.where(mask_r, b_score, -float("inf"))), p_score)
+    b_w = tl.where(mask_r, tl.exp(b_score - m), 0.0)
+    p_w = tl.exp(p_score - m)
+    inv = 1.0 / (tl.sum(b_w) + p_w)
+
+    acc = pv * (p_w * inv) + tl.sum(b_w[:, None] * inv * tile, axis=0)
+
+    if APPLY_OUT_NORM:
+        scale = 1.0 / tl.sqrt(tl.sum(acc * acc) / H + out_eps)
+        ow = tl.load(ow_ptr + offs, mask=mask, other=0.0).to(tl.float32)
+        acc = acc * scale * ow
+    tl.store(out_ptr + t * stride_o + offs, acc.to(out_ptr.dtype.element_ty), mask=mask)
+
+
+def attn_res_hip(
+    prefix_sum: torch.Tensor,
+    bank: torch.Tensor,
+    cw: torch.Tensor,
+    ow: Optional[torch.Tensor],
+    out: torch.Tensor,
+    nvb: int,
+    score_eps: float,
+    out_eps: float,
+    *,
+    addend: Optional[torch.Tensor] = None,
+    prefix_out: Optional[torch.Tensor] = None,
+    write_prefix: bool = False,
+) -> None:
+    """Single-kernel attention-residual aggregation for ROCm.
+
+    Restrictions: nvb >= 1, and the shape must pass supports_attn_res_hip().
+
+    Parameters
+    ----------
+    prefix_sum : [T, H] bf16 — the running prefix, or its first term if addend
+                 is given
+    bank       : [T, NB, H] bf16 (rows 0..nvb-1 are aggregated)
+    cw         : [H] fp32 — precomputed score_norm weight * proj weight
+    ow         : [H] output RMSNorm weight, or None to return the pre-norm
+                 softmax mixture (the aggregate-stream value)
+    out        : [T, H] bf16 output buffer
+    nvb        : number of valid bank rows (>= 1)
+    score_eps, out_eps : RMSNorm epsilons; unlike the SM100 kernel these need
+                 not be equal
+    addend     : fold a pending residual add in, so the aggregated prefix is
+                 prefix_sum + addend; requires prefix_out
+    prefix_out : [T, H] bf16 buffer receiving that materialized prefix
+    write_prefix : also snapshot the prefix row into bank[:, nvb, :] (bit-exact
+                 copy, fused into the score pass which already has the row in
+                 registers); requires NB > nvb
+    """
+    T, H = prefix_sum.shape
+    assert nvb >= 1, "nvb == 0 has nothing to aggregate; the caller must handle it"
+    assert supports_attn_res_hip(H, nvb), (
+        f"attn_res_hip: register tile {_tile_size(H, nvb)} exceeds "
+        f"{MAX_REGISTER_TILE} (H={H}, nvb={nvb})"
+    )
+    has_add = addend is not None
+    assert not has_add or prefix_out is not None, "addend requires prefix_out"
+
+    # Triton needs a real pointer for every argument; the flags decide whether
+    # these are ever dereferenced.
+    addend_arg = addend if has_add else prefix_sum
+    prefix_out_arg = prefix_out if has_add else prefix_sum
+    ow_arg = ow if ow is not None else cw
+
+    _agg_kernel[(T,)](
+        prefix_sum,
+        addend_arg,
+        prefix_out_arg,
+        bank,
+        cw,
+        ow_arg,
+        out,
+        score_eps,
+        out_eps,
+        prefix_sum.stride(0),
+        addend_arg.stride(0),
+        prefix_out_arg.stride(0),
+        bank.stride(0),
+        bank.stride(1),
+        out.stride(0),
+        H=H,
+        BLOCK_H=triton.next_power_of_2(H),
+        NVB=nvb,
+        R_PAD=triton.next_power_of_2(nvb),
+        HAS_ADD=has_add,
+        WRITE_BANK=write_prefix,
+        APPLY_OUT_NORM=ow is not None,
+        num_warps=4,
+    )

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1725,6 +1725,9 @@ def _deepseek_moe_quant_resolution(view: Any) -> dict:
         if (
             view.moe_a2a_backend == "none"
             and view.moe_runner_backend == "auto"
+            # LongCat top-k spans the zero-expert logits, which trtllm-gen's
+            # fused routing cannot see.
+            and not model_arch.startswith("LongcatFlash")
             and (
                 quantization
                 in ["fp8", "modelopt_fp8", "modelopt_fp4", "modelopt_mixed"]

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -327,8 +327,10 @@ def _dspark_verify_on_decode_backend(
     if backend == "tokenspeed_mla":
         return kv_cache_dtype == "fp8_e4m3" and q_len <= 8
     if backend == "cutedsl_mla":
-        # The cute-dsl kernel rejects q_len >= 5 with no fallback.
-        return q_len <= 4
+        # cute-dsl monolithic MLA decode folds the verify tokens into the head
+        # dim (fold_sq), so it serves any DSPARK verify width. Needs flashinfer
+        # >= 0.6.15 (older builds reject q_len >= 5).
+        return True
     return False
 
 

--- a/python/sglang/srt/disaggregation/base/conn.py
+++ b/python/sglang/srt/disaggregation/base/conn.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import dataclasses
 import enum
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional
 
 import numpy as np
 import numpy.typing as npt
@@ -26,6 +26,33 @@ class StateType(str, enum.Enum):
     C128_STATE = "c128_state"
 
 
+class BufferType(str, enum.Enum):
+    KV = "kv"
+    STATE = "state"
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class LayerBufferHandles:
+    """Registered buffers owned by one layer."""
+
+    buffer_types: List[BufferType]
+    raw_data_ptrs_indices: List[int]
+    state_component_ids: List[Optional[int]]
+
+
+@dataclasses.dataclass
+class LayerPipelinedTransferContext:
+    """Request-specific context prepared before selecting transfer layers."""
+
+    kv_indices: npt.NDArray[np.int32]
+    state_indices: Optional[List]
+    final_state_indices: Optional[List]
+    index_slice: slice
+    is_last_chunk: bool
+    should_skip: bool
+    skip_dsa_state_layer_ids: Optional[set[int]]
+
+
 @dataclasses.dataclass
 class KVTransferMetric:
     # Backends that cannot isolate transfer latency can leave this as None.
@@ -37,6 +64,8 @@ class KVTransferMetric:
 
 class KVArgs:
     engine_rank: int
+    target_buffer_handles: Dict[int, LayerBufferHandles]
+    draft_buffer_handles: Dict[int, LayerBufferHandles]
     kv_data_ptrs: List[int]
     kv_data_lens: List[int]
     kv_item_lens: List[int]
@@ -142,6 +171,36 @@ class BaseKVSender(ABC):
         Send the kv cache at the given kv indices and the extra cache/state at the given indices to the decoder server.
         """
         ...
+
+    def prepare_layer_pipelined_transfer(
+        self,
+        kv_indices: npt.NDArray[np.int32],
+        state_indices: Optional[List] = None,
+        *,
+        final_state_indices: Optional[List] = None,
+        skip_dsa_state_layer_ids: Optional[set[int]] = None,
+    ) -> None:
+        """Prepare request indices before selecting target or draft layers."""
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support layer-pipelined KV transfer"
+        )
+
+    def send_layers(
+        self,
+        layer_ids: List[int],
+        is_draft: bool = False,
+        ready_event: Optional[object] = None,
+    ) -> None:
+        """Send buffers for the selected target or draft layers."""
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support layer-pipelined KV transfer"
+        )
+
+    def send_final_metadata(self, ready_event: Optional[object] = None) -> None:
+        """Send remaining state and final request metadata."""
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support layer-pipelined KV transfer"
+        )
 
     def pop_decode_prefix_len(self) -> int:
         return 0

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -24,6 +24,7 @@ from sglang.srt.disaggregation.base.conn import (
     KVArgs,
     KVPoll,
     KVTransferMetric,
+    LayerPipelinedTransferContext,
     StateType,
 )
 from sglang.srt.disaggregation.utils import (
@@ -1078,6 +1079,10 @@ class CommonKVSender(BaseKVSender):
         self._transfer_metric = KVTransferMetric()
         self._transfer_num_kv_indices = 0
         self._transfer_num_state_indices = 0
+        self._transfer_subset_bytes = 0
+        self.layer_pipelined_transfer_context: Optional[
+            LayerPipelinedTransferContext
+        ] = None
         # inner state
         self.curr_idx = 0
         self.init_time: Optional[float] = None
@@ -1143,6 +1148,7 @@ class CommonKVSender(BaseKVSender):
         total_bytes += (
             self._transfer_num_state_indices * self.kv_mgr.state_item_lens_sum
         )
+        total_bytes += getattr(self, "_transfer_subset_bytes", 0)
         # Pinned to 1 for MHA (disjoint slices); only MLA replication makes it > 1.
         total_bytes *= self.kv_mgr.get_kv_replica_factor()
         self._transfer_metric.transfer_total_bytes = total_bytes
@@ -1158,6 +1164,33 @@ class CommonKVSender(BaseKVSender):
             for component_indices in state_indices:
                 if component_indices is not None:
                     self._transfer_num_state_indices += len(component_indices)
+
+    def _record_transfer_subset(
+        self,
+        kv_indices: npt.NDArray[np.int32],
+        state_indices: Optional[List],
+        kv_data_ptrs_indices_subset: Optional[List[int]],
+        state_data_ptrs_indices_subset: Optional[Dict[int, List[int]]],
+    ) -> None:
+        """Record one layer-pipelined buffer subset by its actual item lengths."""
+        if kv_data_ptrs_indices_subset:
+            kv_item_lens = self.kv_mgr.kv_args.kv_item_lens
+            self._transfer_subset_bytes += len(kv_indices) * sum(
+                kv_item_lens[index] for index in kv_data_ptrs_indices_subset
+            )
+
+        if not state_data_ptrs_indices_subset or not state_indices:
+            return
+        state_item_lens = self.kv_mgr.kv_args.state_item_lens
+        for component_id, buffer_indices in state_data_ptrs_indices_subset.items():
+            if not buffer_indices or component_id >= len(state_indices):
+                continue
+            component_indices = state_indices[component_id]
+            if component_indices is None or component_id >= len(state_item_lens):
+                continue
+            self._transfer_subset_bytes += len(component_indices) * sum(
+                state_item_lens[component_id][index] for index in buffer_indices
+            )
 
     def _prepare_send_indices(
         self,
@@ -1192,6 +1225,28 @@ class CommonKVSender(BaseKVSender):
                 return kv_indices, index_slice, is_last_chunk, True
 
         return kv_indices, index_slice, is_last_chunk, False
+
+    def prepare_layer_pipelined_transfer(
+        self,
+        kv_indices: npt.NDArray[np.int32],
+        state_indices: Optional[List] = None,
+        *,
+        final_state_indices: Optional[List] = None,
+        skip_dsa_state_layer_ids: Optional[set[int]] = None,
+    ) -> None:
+        """Prepare one request chunk for subsequent layer selection."""
+        kv_indices, index_slice, is_last_chunk, should_skip = (
+            self._prepare_send_indices(kv_indices, state_indices)
+        )
+        self.layer_pipelined_transfer_context = LayerPipelinedTransferContext(
+            kv_indices=kv_indices,
+            state_indices=state_indices,
+            final_state_indices=final_state_indices,
+            index_slice=index_slice,
+            is_last_chunk=is_last_chunk,
+            should_skip=should_skip,
+            skip_dsa_state_layer_ids=skip_dsa_state_layer_ids,
+        )
 
     def send(
         self,

--- a/python/sglang/srt/disaggregation/common/utils.py
+++ b/python/sglang/srt/disaggregation/common/utils.py
@@ -3,7 +3,7 @@ import dataclasses
 import struct
 import threading
 from collections import deque
-from typing import List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import numpy.typing as npt
@@ -24,6 +24,9 @@ class TransferKVChunk:
     is_last_chunk: bool
     prefill_aux_index: Optional[int]
     state_indices: Optional[List]
+    kv_data_ptrs_indices_subset: Optional[List[int]] = None
+    state_data_ptrs_indices_subset: Optional[Dict[int, List[int]]] = None
+    ready_event: Optional[object] = None
     chunk_id: Optional[int] = None
     num_kv_tokens: Optional[int] = None
     trace_ctx: Union[TraceReqContext, TraceNullContext] = dataclasses.field(

--- a/python/sglang/srt/disaggregation/fake/conn.py
+++ b/python/sglang/srt/disaggregation/fake/conn.py
@@ -85,6 +85,42 @@ class FakeKVSender(BaseKVSender):
             f"FakeKVSender send with kv_indices: {kv_indices}, state_indices: {state_indices}"
         )
 
+    def prepare_layer_pipelined_transfer(
+        self,
+        kv_indices: npt.NDArray[np.int32],
+        state_indices: Optional[List] = None,
+        *,
+        final_state_indices: Optional[List] = None,
+        skip_dsa_state_layer_ids: Optional[set[int]] = None,
+    ) -> None:
+        self.layer_pipelined_transfer_context = (
+            kv_indices,
+            state_indices,
+            final_state_indices,
+            skip_dsa_state_layer_ids,
+        )
+
+    def send_layers(
+        self,
+        layer_ids: List[int],
+        is_draft: bool = False,
+        ready_event: Optional[object] = None,
+    ) -> None:
+        if getattr(self, "layer_pipelined_transfer_context", None) is None:
+            raise RuntimeError(
+                "prepare_layer_pipelined_transfer must be called before send_layers"
+            )
+        self.has_sent = True
+        logger.debug(
+            "FakeKVSender send_layers layer_ids=%s is_draft=%s",
+            layer_ids,
+            is_draft,
+        )
+
+    def send_final_metadata(self, ready_event: Optional[object] = None) -> None:
+        self.has_sent = True
+        self.layer_pipelined_transfer_context = None
+
     def failure_exception(self):
         raise Exception("Fake KVSender Exception")
 

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -8,14 +8,20 @@ import struct
 import threading
 import time
 from collections import defaultdict
-from typing import List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import numpy.typing as npt
 import zmq
 from prometheus_client import Counter
 
-from sglang.srt.disaggregation.base.conn import KVArgs, KVPoll, StateType
+from sglang.srt.disaggregation.base.conn import (
+    BufferType,
+    KVArgs,
+    KVPoll,
+    LayerPipelinedTransferContext,
+    StateType,
+)
 from sglang.srt.disaggregation.common.conn import (
     CommonKVBootstrapServer,
     CommonKVManager,
@@ -803,6 +809,52 @@ class MooncakeKVManager(CommonKVManager):
             dst_device_data_ptrs=dst_device_kv_ptrs,
         )
 
+    @staticmethod
+    def _select_buffer_subset(values: List, indices: List[int]) -> List:
+        return [values[index] for index in indices] if values else []
+
+    def _select_kv_buffer_subset(
+        self,
+        kv_data_ptrs_indices_subset: List[int],
+        dst_kv_ptrs: list[int],
+    ) -> Tuple[List[int], List[int], List[int]]:
+        """Select aligned KV pointers and item lengths by raw buffer index."""
+        indices = sorted(kv_data_ptrs_indices_subset)
+        return (
+            self._select_buffer_subset(self.kv_args.kv_data_ptrs, indices),
+            self._select_buffer_subset(dst_kv_ptrs, indices),
+            self._select_buffer_subset(self.kv_args.kv_item_lens, indices),
+        )
+
+    def send_kvcache_subset(
+        self,
+        mooncake_session_id: str,
+        kv_data_ptrs_indices_subset: List[int],
+        prefill_kv_indices: npt.NDArray[np.int32],
+        dst_kv_ptrs: list[int],
+        dst_kv_indices: npt.NDArray[np.int32],
+        executor: concurrent.futures.ThreadPoolExecutor,
+    ) -> int:
+        """Send a selected subset of registered KV buffers."""
+        if (
+            not self.is_mla_backend
+            and not self.is_hybrid_mla_backend
+            and len(kv_data_ptrs_indices_subset) % 2 != 0
+        ):
+            return -1
+        src_ptrs, dst_ptrs, item_lens = self._select_kv_buffer_subset(
+            kv_data_ptrs_indices_subset, dst_kv_ptrs
+        )
+        return self._send_kvcache_generic(
+            mooncake_session_id=mooncake_session_id,
+            src_data_ptrs=src_ptrs,
+            dst_data_ptrs=dst_ptrs,
+            item_lens=item_lens,
+            prefill_data_indices=prefill_kv_indices,
+            dst_data_indices=dst_kv_indices,
+            executor=executor,
+        )
+
     def send_kvcache_dcp(
         self,
         mooncake_session_id: str,
@@ -922,6 +974,71 @@ class MooncakeKVManager(CommonKVManager):
         each page to ensure correctness for any page_size and head-slicing configuration.
         This may introduce performance overhead (increased TTFT) for long sequences.
         """
+        src_k_ptrs, src_v_ptrs, dst_k_ptrs, dst_v_ptrs, _ = (
+            self.get_mha_kv_ptrs_with_pp(self.kv_args.kv_data_ptrs, dst_kv_ptrs)
+        )
+        return self._send_kvcache_slice_impl(
+            mooncake_session_id=mooncake_session_id,
+            prefill_kv_indices=prefill_kv_indices,
+            dst_kv_indices=dst_kv_indices,
+            dst_tp_rank=dst_tp_rank,
+            dst_attn_tp_size=dst_attn_tp_size,
+            dst_kv_item_len=dst_kv_item_len,
+            executor=executor,
+            src_k_ptrs=src_k_ptrs,
+            src_v_ptrs=src_v_ptrs,
+            dst_k_ptrs=dst_k_ptrs,
+            dst_v_ptrs=dst_v_ptrs,
+        )
+
+    def send_kvcache_slice_subset(
+        self,
+        mooncake_session_id: str,
+        kv_data_ptrs_indices_subset: List[int],
+        prefill_kv_indices: npt.NDArray[np.int32],
+        dst_kv_ptrs: list[int],
+        dst_kv_indices: npt.NDArray[np.int32],
+        dst_tp_rank: int,
+        dst_attn_tp_size: int,
+        dst_kv_item_len: int,
+        executor: concurrent.futures.ThreadPoolExecutor,
+    ) -> int:
+        """Send head slices for a selected subset of registered KV buffers."""
+        if len(kv_data_ptrs_indices_subset) % 2 != 0:
+            return -1
+        num_layers = len(kv_data_ptrs_indices_subset) // 2
+        selected_src_ptrs, selected_dst_ptrs, _ = self._select_kv_buffer_subset(
+            kv_data_ptrs_indices_subset, dst_kv_ptrs
+        )
+        return self._send_kvcache_slice_impl(
+            mooncake_session_id=mooncake_session_id,
+            prefill_kv_indices=prefill_kv_indices,
+            dst_kv_indices=dst_kv_indices,
+            dst_tp_rank=dst_tp_rank,
+            dst_attn_tp_size=dst_attn_tp_size,
+            dst_kv_item_len=dst_kv_item_len,
+            executor=executor,
+            src_k_ptrs=selected_src_ptrs[:num_layers],
+            src_v_ptrs=selected_src_ptrs[num_layers:],
+            dst_k_ptrs=selected_dst_ptrs[:num_layers],
+            dst_v_ptrs=selected_dst_ptrs[num_layers:],
+        )
+
+    def _send_kvcache_slice_impl(
+        self,
+        *,
+        mooncake_session_id: str,
+        prefill_kv_indices: npt.NDArray[np.int32],
+        dst_kv_indices: npt.NDArray[np.int32],
+        dst_tp_rank: int,
+        dst_attn_tp_size: int,
+        dst_kv_item_len: int,
+        executor: concurrent.futures.ThreadPoolExecutor,
+        src_k_ptrs: List[int],
+        src_v_ptrs: List[int],
+        dst_k_ptrs: List[int],
+        dst_v_ptrs: List[int],
+    ) -> int:
         # Extract configuration
         local_tp_rank_in_group = self.kv_args.engine_rank % self.attn_tp_size
         src_kv_item_len = self.kv_args.kv_item_lens[0]
@@ -964,10 +1081,6 @@ class MooncakeKVManager(CommonKVManager):
             ) % src_heads_per_rank
             num_heads_to_send = dst_heads_per_rank
             dst_head_start_offset = 0
-
-        src_k_ptrs, src_v_ptrs, dst_k_ptrs, dst_v_ptrs, layers_current_pp_stage = (
-            self.get_mha_kv_ptrs_with_pp(self.kv_args.kv_data_ptrs, dst_kv_ptrs)
-        )
 
         # Calculate precise byte offset and length for the sub-slice within the token
         src_head_slice_offset = src_head_start_offset * bytes_per_head_slice_to_send
@@ -1013,11 +1126,11 @@ class MooncakeKVManager(CommonKVManager):
             )
 
         futures = []
-        for i in range(layers_current_pp_stage):
+        for i in range(len(src_k_ptrs)):
             futures.append(
                 executor.submit(process_layer_tp_aware, src_k_ptrs[i], dst_k_ptrs[i])
             )
-        for i in range(layers_current_pp_stage):
+        for i in range(len(src_v_ptrs)):
             futures.append(
                 executor.submit(process_layer_tp_aware, src_v_ptrs[i], dst_v_ptrs[i])
             )
@@ -1180,185 +1293,263 @@ class MooncakeKVManager(CommonKVManager):
     ):
         rc = 0
         state_types = getattr(self.kv_args, "state_types", [])
-        for i, st in enumerate(state_types):
-            indices = (
-                prefill_state_indices[i] if i < len(prefill_state_indices) else None
+        for component_id, state_type in enumerate(state_types):
+            src_indices = (
+                prefill_state_indices[component_id]
+                if component_id < len(prefill_state_indices)
+                else None
             )
-            if indices is None:
+            if src_indices is None:
                 continue
-            src_data_ptrs = self.kv_args.state_data_ptrs[i]
-            src_item_lens = self.kv_args.state_item_lens[i]
-            src_dim_per_tensor = (
-                self.kv_args.state_dim_per_tensor[i]
-                if i < len(self.kv_args.state_dim_per_tensor)
+            component_rc = self._send_state_component(
+                req=req,
+                component_id=component_id,
+                state_type=state_type,
+                src_indices=src_indices,
+                executor=executor,
+                target_rank_registration_info=target_rank_registration_info,
+            )
+            rc = component_rc or rc
+        return rc
+
+    def maybe_send_extra_subset(
+        self,
+        req: TransferInfo,
+        prefill_state_indices: List,
+        state_data_ptrs_indices_subset: Dict[int, List[int]],
+        executor: concurrent.futures.ThreadPoolExecutor,
+        target_rank_registration_info: Optional[KVArgsRegisterInfo] = None,
+    ) -> int:
+        """Send selected registered state buffers grouped by component."""
+        rc = 0
+        state_types = getattr(self.kv_args, "state_types", [])
+        for component_id, buffer_indices in state_data_ptrs_indices_subset.items():
+            buffer_indices = sorted(buffer_indices)
+            if not buffer_indices:
+                continue
+            src_indices = (
+                prefill_state_indices[component_id]
+                if component_id < len(prefill_state_indices)
+                else None
+            )
+            if src_indices is None:
+                continue
+            component_rc = self._send_state_component(
+                req=req,
+                component_id=component_id,
+                state_type=state_types[component_id],
+                src_indices=src_indices,
+                executor=executor,
+                target_rank_registration_info=target_rank_registration_info,
+                state_data_ptrs_indices_subset=buffer_indices,
+            )
+            rc = component_rc or rc
+        return rc
+
+    def _send_state_component(
+        self,
+        *,
+        req: TransferInfo,
+        component_id: int,
+        state_type: StateType,
+        src_indices,
+        executor: concurrent.futures.ThreadPoolExecutor,
+        target_rank_registration_info: Optional[KVArgsRegisterInfo],
+        state_data_ptrs_indices_subset: Optional[List[int]] = None,
+    ) -> int:
+        src_data_ptrs = self.kv_args.state_data_ptrs[component_id]
+        src_item_lens = self.kv_args.state_item_lens[component_id]
+        src_dim_per_tensor = (
+            self.kv_args.state_dim_per_tensor[component_id]
+            if component_id < len(self.kv_args.state_dim_per_tensor)
+            else []
+        )
+        src_slice_outer_counts = getattr(self.kv_args, "state_slice_outer_counts", [])
+        src_slice_outer_counts = (
+            src_slice_outer_counts[component_id]
+            if component_id < len(src_slice_outer_counts)
+            else []
+        )
+        src_state_layer_ids = getattr(self.kv_args, "state_layer_ids", [])
+        src_state_layer_ids = (
+            src_state_layer_ids[component_id]
+            if component_id < len(src_state_layer_ids)
+            else []
+        )
+        conv_shard_groups = getattr(self.kv_args, "state_conv_shard_groups", [])
+        src_conv_shard_groups = (
+            conv_shard_groups[component_id]
+            if component_id < len(conv_shard_groups)
+            else []
+        )
+        if target_rank_registration_info is not None:
+            dst_data_ptrs = (
+                target_rank_registration_info.dst_state_data_ptrs[component_id]
+                if component_id < len(target_rank_registration_info.dst_state_data_ptrs)
                 else []
             )
-            src_conv_shard_groups = getattr(self.kv_args, "state_conv_shard_groups", [])
-            src_conv_shard_groups = (
-                src_conv_shard_groups[i] if i < len(src_conv_shard_groups) else []
+            dst_item_lens = (
+                target_rank_registration_info.dst_state_item_lens[component_id]
+                if component_id < len(target_rank_registration_info.dst_state_item_lens)
+                else []
             )
-            src_slice_outer_counts = getattr(
-                self.kv_args, "state_slice_outer_counts", []
+            dst_dim_per_tensor = (
+                target_rank_registration_info.dst_state_dim_per_tensor[component_id]
+                if component_id
+                < len(target_rank_registration_info.dst_state_dim_per_tensor)
+                else []
             )
-            src_slice_outer_counts = (
-                src_slice_outer_counts[i] if i < len(src_slice_outer_counts) else []
+            dst_state_layer_ids = (
+                target_rank_registration_info.dst_state_layer_ids[component_id]
+                if component_id < len(target_rank_registration_info.dst_state_layer_ids)
+                else []
             )
-            src_state_layer_ids = self.kv_args.state_layer_ids
-            src_state_layer_ids = (
-                src_state_layer_ids[i] if i < len(src_state_layer_ids) else []
+        else:
+            dst_data_ptrs, dst_item_lens, dst_dim_per_tensor = [], [], []
+            dst_state_layer_ids = []
+        dst_indices = (
+            req.dst_state_indices[component_id]
+            if component_id < len(req.dst_state_indices)
+            else []
+        )
+
+        if state_data_ptrs_indices_subset is not None:
+            select = self._select_buffer_subset
+            src_data_ptrs = select(src_data_ptrs, state_data_ptrs_indices_subset)
+            src_item_lens = select(src_item_lens, state_data_ptrs_indices_subset)
+            src_dim_per_tensor = select(
+                src_dim_per_tensor, state_data_ptrs_indices_subset
             )
-            if target_rank_registration_info is not None:
-                dst_data_ptrs = (
-                    target_rank_registration_info.dst_state_data_ptrs[i]
-                    if i < len(target_rank_registration_info.dst_state_data_ptrs)
-                    else []
+            src_conv_shard_groups = select(
+                src_conv_shard_groups, state_data_ptrs_indices_subset
+            )
+            src_slice_outer_counts = select(
+                src_slice_outer_counts, state_data_ptrs_indices_subset
+            )
+            src_state_layer_ids = select(
+                src_state_layer_ids, state_data_ptrs_indices_subset
+            )
+            if state_type != StateType.MAMBA:
+                dst_data_ptrs = select(dst_data_ptrs, state_data_ptrs_indices_subset)
+                dst_item_lens = select(dst_item_lens, state_data_ptrs_indices_subset)
+                dst_dim_per_tensor = select(
+                    dst_dim_per_tensor, state_data_ptrs_indices_subset
                 )
-                dst_item_lens = (
-                    target_rank_registration_info.dst_state_item_lens[i]
-                    if i < len(target_rank_registration_info.dst_state_item_lens)
-                    else []
+
+        if state_type == StateType.MAMBA:
+            if (
+                target_rank_registration_info is not None
+                and self.attn_tp_size != target_rank_registration_info.dst_attn_tp_size
+            ):
+                return self._send_mamba_state_slice(
+                    req,
+                    src_indices,
+                    src_data_ptrs,
+                    src_item_lens,
+                    src_dim_per_tensor,
+                    dst_data_ptrs,
+                    dst_indices,
+                    dst_item_lens,
+                    dst_dim_per_tensor,
+                    target_rank_registration_info.dst_tp_rank,
+                    target_rank_registration_info.dst_attn_tp_size,
+                    src_conv_shard_groups,
+                    src_slice_outer_counts,
+                    src_state_layer_ids,
+                    dst_state_layer_ids,
                 )
-                dst_dim_per_tensor = (
-                    target_rank_registration_info.dst_state_dim_per_tensor[i]
-                    if i < len(target_rank_registration_info.dst_state_dim_per_tensor)
-                    else []
-                )
-                dst_state_layer_ids = (
-                    target_rank_registration_info.dst_state_layer_ids[i]
-                    if i < len(target_rank_registration_info.dst_state_layer_ids)
-                    else []
-                )
-            else:
-                dst_data_ptrs, dst_item_lens, dst_dim_per_tensor = [], [], []
-                dst_state_layer_ids = []
-            dst_indices = (
-                req.dst_state_indices[i] if i < len(req.dst_state_indices) else []
+            return self._send_mamba_state(
+                req,
+                src_indices,
+                src_data_ptrs,
+                src_item_lens,
+                dst_data_ptrs,
+                dst_indices,
+                dst_item_lens,
+                src_state_layer_ids,
+                dst_state_layer_ids,
             )
 
-            if st == StateType.MAMBA:
-                if (
-                    target_rank_registration_info is not None
-                    and self.attn_tp_size
-                    != target_rank_registration_info.dst_attn_tp_size
-                ):
-                    rc = (
-                        self._send_mamba_state_slice(
-                            req,
-                            indices,
-                            src_data_ptrs,
-                            src_item_lens,
-                            src_dim_per_tensor,
-                            dst_data_ptrs,
-                            dst_indices,
-                            dst_item_lens,
-                            dst_dim_per_tensor,
-                            target_rank_registration_info.dst_tp_rank,
-                            target_rank_registration_info.dst_attn_tp_size,
-                            src_conv_shard_groups,
-                            src_slice_outer_counts,
-                            src_state_layer_ids,
-                            dst_state_layer_ids,
-                        )
-                        or rc
-                    )
-                else:
-                    rc = (
-                        self._send_mamba_state(
-                            req,
-                            indices,
-                            src_data_ptrs,
-                            src_item_lens,
-                            dst_data_ptrs,
-                            dst_indices,
-                            src_state_layer_ids,
-                            dst_state_layer_ids,
-                        )
-                        or rc
-                    )
-            elif self._is_generic_kvcache_state_type(st):
-                if (
-                    target_rank_registration_info is not None
-                    and not self.is_mla_backend
-                    and self.attn_tp_size
-                    != target_rank_registration_info.dst_attn_tp_size
-                ):
-                    raise RuntimeError(
-                        f"PD Disaggregation does NOT support PD different TP sizes for non-MLA {st.upper()} hybrid models yet."
-                    )
-                src_indices = list(indices)
-                dst_indices_local = list(dst_indices)
-                if (
-                    st == StateType.C128_STATE
-                    and len(src_indices) == 0
-                    and len(dst_indices_local) == 0
-                ):
-                    continue
-                if len(src_indices) != len(dst_indices_local):
-                    # These components are position- or request-indexed:
-                    # truncating silently misaligns rows and corrupts KV.
-                    # Paged SWA/DSA tolerate a 1-page drift -> keep the
-                    # lenient truncation below.
-                    if self._requires_exact_state_index_match(st):
-                        raise RuntimeError(
-                            f"{st.upper()} state index length mismatch: "
-                            f"prefill={len(src_indices)}, dst={len(dst_indices_local)}"
-                        )
-                    logger.warning(
-                        f"len(prefill_state_indices) = {len(src_indices)}, len(dst_state_indices) = {len(dst_indices_local)}"
-                    )
-                    if len(src_indices) > len(dst_indices_local):
-                        src_indices = src_indices[: len(dst_indices_local)]
-                    else:
-                        dst_indices_local = dst_indices_local[: len(src_indices)]
-                rc = (
-                    self._send_kvcache_generic(
-                        mooncake_session_id=req.mooncake_session_id,
-                        src_data_ptrs=src_data_ptrs,
-                        dst_data_ptrs=dst_data_ptrs,
-                        item_lens=src_item_lens,
-                        prefill_data_indices=np.array(src_indices, dtype=np.int32),
-                        dst_data_indices=np.array(dst_indices_local, dtype=np.int32),
-                        executor=executor,
-                        state_type=st,
-                    )
-                    or rc
+        if state_type in (
+            StateType.SWA,
+            StateType.DSA,
+            StateType.SWA_RING,
+            StateType.C128_STATE,
+        ):
+            if (
+                target_rank_registration_info is not None
+                and not self.is_mla_backend
+                and self.attn_tp_size != target_rank_registration_info.dst_attn_tp_size
+            ):
+                raise RuntimeError(
+                    "PD Disaggregation does NOT support PD different TP sizes "
+                    f"for non-MLA {state_type.upper()} hybrid models yet."
                 )
-            elif st == StateType.MINIMAX_INDEX_K:
-                # Equal-TP / PP=1 only. Sub-pools are compacted sparse-layer
-                # lists, so PP>1 mis-slices and heterogeneous TP is unsupported.
-                if self.pp_size is not None and self.pp_size > 1:
+            src_indices = list(src_indices)
+            dst_indices_local = list(dst_indices)
+            if (
+                state_type == StateType.C128_STATE
+                and len(src_indices) == 0
+                and len(dst_indices_local) == 0
+            ):
+                return 0
+            if len(src_indices) != len(dst_indices_local):
+                if state_type in (StateType.SWA_RING, StateType.C128_STATE):
                     raise RuntimeError(
-                        "PD disagg: PP>1 not supported for MiniMax sparse index yet."
+                        f"{state_type.upper()} state index length mismatch: "
+                        f"prefill={len(src_indices)}, dst={len(dst_indices_local)}"
                     )
-                if (
-                    target_rank_registration_info is not None
-                    and self.attn_tp_size
-                    != target_rank_registration_info.dst_attn_tp_size
-                ):
-                    raise RuntimeError(
-                        "PD disagg: heterogeneous TP not supported for MiniMax "
-                        "sparse index yet."
-                    )
-                src_indices = list(indices)
-                dst_indices_local = list(dst_indices)
+                logger.warning(
+                    "len(prefill_state_indices) = %s, len(dst_state_indices) = %s",
+                    len(src_indices),
+                    len(dst_indices_local),
+                )
                 if len(src_indices) > len(dst_indices_local):
                     src_indices = src_indices[: len(dst_indices_local)]
-                elif len(src_indices) < len(dst_indices_local):
+                else:
                     dst_indices_local = dst_indices_local[: len(src_indices)]
-                rc = (
-                    self._send_kvcache_generic(
-                        mooncake_session_id=req.mooncake_session_id,
-                        src_data_ptrs=src_data_ptrs,
-                        dst_data_ptrs=dst_data_ptrs,
-                        item_lens=src_item_lens,
-                        prefill_data_indices=np.array(src_indices, dtype=np.int32),
-                        dst_data_indices=np.array(dst_indices_local, dtype=np.int32),
-                        executor=executor,
-                        force_flat=True,
-                    )
-                    or rc
+            return self._send_kvcache_generic(
+                mooncake_session_id=req.mooncake_session_id,
+                src_data_ptrs=src_data_ptrs,
+                dst_data_ptrs=dst_data_ptrs,
+                item_lens=src_item_lens,
+                prefill_data_indices=np.array(src_indices, dtype=np.int32),
+                dst_data_indices=np.array(dst_indices_local, dtype=np.int32),
+                executor=executor,
+                state_type=state_type,
+            )
+
+        if state_type == StateType.MINIMAX_INDEX_K:
+            if self.pp_size is not None and self.pp_size > 1:
+                raise RuntimeError(
+                    "PD disagg: PP>1 not supported for MiniMax sparse index yet."
                 )
-        return rc
+            if (
+                target_rank_registration_info is not None
+                and self.attn_tp_size != target_rank_registration_info.dst_attn_tp_size
+            ):
+                raise RuntimeError(
+                    "PD disagg: heterogeneous TP not supported for MiniMax "
+                    "sparse index yet."
+                )
+            src_indices = list(src_indices)
+            dst_indices_local = list(dst_indices)
+            if len(src_indices) > len(dst_indices_local):
+                src_indices = src_indices[: len(dst_indices_local)]
+            elif len(src_indices) < len(dst_indices_local):
+                dst_indices_local = dst_indices_local[: len(src_indices)]
+            return self._send_kvcache_generic(
+                mooncake_session_id=req.mooncake_session_id,
+                src_data_ptrs=src_data_ptrs,
+                dst_data_ptrs=dst_data_ptrs,
+                item_lens=src_item_lens,
+                prefill_data_indices=np.array(src_indices, dtype=np.int32),
+                dst_data_indices=np.array(dst_indices_local, dtype=np.int32),
+                executor=executor,
+                force_flat=True,
+            )
+
+        return 0
 
     def _send_mamba_state(
         self,
@@ -1368,6 +1559,7 @@ class MooncakeKVManager(CommonKVManager):
         src_state_item_lens: list[int],
         dst_state_data_ptrs: list[int],
         dst_mamba_index: list,
+        dst_state_item_lens: list[int],
         src_layer_ids: Optional[List[int]] = None,
         dst_layer_ids: Optional[List[int]] = None,
     ):
@@ -1383,10 +1575,11 @@ class MooncakeKVManager(CommonKVManager):
         )
         for i, j in pairs:
             dst_state_ptr = dst_state_data_ptrs[j]
-            length = src_state_item_lens[i]
-            src_addr = src_state_data_ptrs[i] + length * int(prefill_mamba_index[0])
-            dst_addr = dst_state_ptr + length * int(dst_mamba_index[0])
-            transfer_blocks.append((src_addr, dst_addr, length))
+            src_length = src_state_item_lens[i]
+            dst_length = dst_state_item_lens[j]
+            src_addr = src_state_data_ptrs[i] + src_length * int(prefill_mamba_index[0])
+            dst_addr = dst_state_ptr + dst_length * int(dst_mamba_index[0])
+            transfer_blocks.append((src_addr, dst_addr, src_length))
 
         return self._transfer_data(req.mooncake_session_id, transfer_blocks)
 
@@ -1436,6 +1629,7 @@ class MooncakeKVManager(CommonKVManager):
                 src_state_item_lens,
                 dst_state_data_ptrs,
                 dst_mamba_index,
+                dst_state_item_lens,
                 src_layer_ids,
                 dst_layer_ids,
             )
@@ -1564,6 +1758,7 @@ class MooncakeKVManager(CommonKVManager):
                 )
                 polls = []
                 dst_ranks_infos = []
+                ready_event_synchronized = False
                 # Unique id per prefill sender so decode's response set size matches expected_response_num.
                 prefill_unique_rank = (
                     self.attn_tp_rank * (self.pp_size * self.attn_cp_size)
@@ -1592,6 +1787,13 @@ class MooncakeKVManager(CommonKVManager):
                                     prefill_unique_rank,
                                 )
                                 break
+
+                        if (
+                            kv_chunk.ready_event is not None
+                            and not ready_event_synchronized
+                        ):
+                            kv_chunk.ready_event.synchronize()
+                            ready_event_synchronized = True
 
                         target_rank_registration_info: KVArgsRegisterInfo = (
                             self.decode_kv_args_table[req.mooncake_session_id]
@@ -1639,7 +1841,56 @@ class MooncakeKVManager(CommonKVManager):
                         skip_kv, skip_state = self._get_dsa_cache_transfer_skip_flags(
                             target_rank_registration_info
                         )
-                        if (
+                        is_subset = (
+                            kv_chunk.kv_data_ptrs_indices_subset is not None
+                            or kv_chunk.state_data_ptrs_indices_subset is not None
+                        )
+                        if is_subset:
+                            ret = 0
+                            if (
+                                len(kv_chunk.prefill_kv_indices) > 0
+                                and kv_chunk.kv_data_ptrs_indices_subset
+                                and not skip_kv
+                            ):
+                                if (
+                                    self.is_mla_backend
+                                    or self.is_hybrid_mla_backend
+                                    or self.attn_tp_size
+                                    == target_rank_registration_info.dst_attn_tp_size
+                                ):
+                                    ret = self.send_kvcache_subset(
+                                        req.mooncake_session_id,
+                                        kv_chunk.kv_data_ptrs_indices_subset,
+                                        kv_chunk.prefill_kv_indices,
+                                        target_rank_registration_info.dst_kv_ptrs,
+                                        chunked_dst_kv_indice,
+                                        executor,
+                                    )
+                                else:
+                                    ret = self.send_kvcache_slice_subset(
+                                        req.mooncake_session_id,
+                                        kv_chunk.kv_data_ptrs_indices_subset,
+                                        kv_chunk.prefill_kv_indices,
+                                        target_rank_registration_info.dst_kv_ptrs,
+                                        chunked_dst_kv_indice,
+                                        target_rank_registration_info.dst_tp_rank,
+                                        target_rank_registration_info.dst_attn_tp_size,
+                                        target_rank_registration_info.dst_kv_item_len,
+                                        executor,
+                                    )
+                            if (
+                                ret == 0
+                                and kv_chunk.state_data_ptrs_indices_subset
+                                and not skip_state
+                            ):
+                                ret = self.maybe_send_extra_subset(
+                                    req,
+                                    kv_chunk.state_indices or [],
+                                    kv_chunk.state_data_ptrs_indices_subset,
+                                    executor,
+                                    target_rank_registration_info,
+                                )
+                        elif (
                             len(kv_chunk.prefill_kv_indices) == 0
                             or not self.kv_args.kv_data_ptrs
                             or skip_kv
@@ -2024,6 +2275,9 @@ class MooncakeKVManager(CommonKVManager):
         is_last_chunk: bool,
         aux_index: Optional[int] = None,
         state_indices: Optional[List] = None,
+        kv_data_ptrs_indices_subset: Optional[List[int]] = None,
+        state_data_ptrs_indices_subset: Optional[Dict[int, List[int]]] = None,
+        ready_event: Optional[object] = None,
         num_kv_tokens: Optional[int] = None,
         trace_ctx: Optional[Union[TraceReqContext, TraceNullContext]] = None,
     ):
@@ -2063,6 +2317,9 @@ class MooncakeKVManager(CommonKVManager):
                 is_last_chunk=is_last_chunk,
                 prefill_aux_index=aux_index,
                 state_indices=state_indices,
+                kv_data_ptrs_indices_subset=kv_data_ptrs_indices_subset,
+                state_data_ptrs_indices_subset=state_data_ptrs_indices_subset,
+                ready_event=ready_event,
                 num_kv_tokens=num_kv_tokens,
                 trace_ctx=trace_ctx,
             )
@@ -2173,6 +2430,105 @@ class MooncakeKVSender(CommonKVSender):
                 trace_ctx=self.trace_ctx.copy_for_thread(),
             )
         self._record_transfer_indices(kv_indices, state_indices)
+
+    def _get_layer_pipelined_transfer_context(
+        self,
+    ) -> LayerPipelinedTransferContext:
+        context = self.layer_pipelined_transfer_context
+        if context is None:
+            raise RuntimeError("prepare_layer_pipelined_transfer must be called first")
+        return context
+
+    def send_layers(
+        self,
+        layer_ids: List[int],
+        is_draft: bool = False,
+        ready_event: Optional[object] = None,
+    ) -> None:
+        context = self._get_layer_pipelined_transfer_context()
+        if context.should_skip:
+            return
+
+        handles_by_layer = (
+            self.kv_mgr.kv_args.draft_buffer_handles
+            if is_draft
+            else self.kv_mgr.kv_args.target_buffer_handles
+        )
+        kv_data_ptrs_indices_subset = []
+        state_data_ptrs_indices_subset = defaultdict(list)
+        for layer_id in layer_ids:
+            handles = handles_by_layer.get(layer_id)
+            if handles is None:
+                continue
+            for buffer_type, raw_index, component_id in zip(
+                handles.buffer_types,
+                handles.raw_data_ptrs_indices,
+                handles.state_component_ids,
+            ):
+                if buffer_type == BufferType.KV:
+                    kv_data_ptrs_indices_subset.append(raw_index)
+                else:
+                    if component_id is None:
+                        raise RuntimeError(
+                            "Layer-pipelined KV transfer found a state buffer "
+                            "without a registered component ID: "
+                            f"layer_id={layer_id}, is_draft={is_draft}, "
+                            f"buffer_type={buffer_type}, raw_index={raw_index}, "
+                            f"state_types={self.kv_mgr.kv_args.state_types}, "
+                            f"state_component_ids={handles.state_component_ids}."
+                        )
+                    if (
+                        not is_draft
+                        and context.skip_dsa_state_layer_ids
+                        and self.kv_mgr.kv_args.state_types[component_id]
+                        == StateType.DSA
+                        and layer_id in context.skip_dsa_state_layer_ids
+                    ):
+                        continue
+                    state_data_ptrs_indices_subset[component_id].append(raw_index)
+
+        if not kv_data_ptrs_indices_subset and not state_data_ptrs_indices_subset:
+            return
+
+        self.kv_mgr.add_transfer_request(
+            self.bootstrap_room,
+            context.kv_indices,
+            context.index_slice,
+            is_last_chunk=False,
+            state_indices=context.state_indices,
+            kv_data_ptrs_indices_subset=kv_data_ptrs_indices_subset,
+            state_data_ptrs_indices_subset=dict(state_data_ptrs_indices_subset),
+            ready_event=ready_event,
+            trace_ctx=self.trace_ctx.copy_for_thread(),
+        )
+        self._record_transfer_subset(
+            context.kv_indices,
+            context.state_indices,
+            kv_data_ptrs_indices_subset,
+            dict(state_data_ptrs_indices_subset),
+        )
+
+    def send_final_metadata(self, ready_event: Optional[object] = None) -> None:
+        context = self._get_layer_pipelined_transfer_context()
+        try:
+            if context.should_skip:
+                return
+
+            final_index = context.index_slice.stop
+            empty_kv_indices = np.array([], dtype=np.int32)
+            self.kv_mgr.add_transfer_request(
+                self.bootstrap_room,
+                empty_kv_indices,
+                slice(final_index, final_index),
+                is_last_chunk=True,
+                aux_index=self.aux_index,
+                state_indices=context.final_state_indices,
+                ready_event=ready_event,
+                trace_ctx=self.trace_ctx.copy_for_thread(),
+            )
+            self._record_transfer_indices(empty_kv_indices, context.final_state_indices)
+        finally:
+            self.layer_pipelined_transfer_context = None
 
     def poll(self) -> KVPoll:
         if self.conclude_state is None:

--- a/python/sglang/srt/disaggregation/pipelined_kv_transfer.py
+++ b/python/sglang/srt/disaggregation/pipelined_kv_transfer.py
@@ -1,0 +1,473 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, List, Optional, Tuple
+
+import numpy as np
+import torch
+
+from sglang.srt.configs.model_config import dsa_layer_skips_topk, is_deepseek_dsa
+from sglang.srt.disaggregation.base.conn import BaseKVManager, BufferType, StateType
+from sglang.srt.disaggregation.utils import (
+    MetadataBuffers,
+    TransferBackend,
+    get_dsv4_c128_state_indices,
+    is_dsv4_c128_online_enabled,
+)
+from sglang.srt.environ import envs
+from sglang.srt.managers.utils import GenerationBatchResult
+from sglang.srt.mem_cache.common import kv_to_page_indices
+from sglang.srt.model_executor.cuda_graph_config import Backend
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from sglang.srt.configs.model_config import ModelConfig
+    from sglang.srt.distributed.parallel_state_wrapper import ParallelState
+    from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
+    from sglang.srt.managers.tp_worker import BaseTpWorker
+    from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
+    from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
+    from sglang.srt.server_args import ServerArgs
+
+
+@dataclass(frozen=True, slots=True)
+class LayerPipelinedTransferPlan:
+    group_size: int
+    layer_ids_by_group: List[List[int]]
+    req_page_indices_list: List[np.ndarray]
+    req_state_indices_list: List[List]
+
+
+@dataclass(kw_only=True, frozen=True, slots=True)
+class LayerPipelinedKVTransferAdapter:
+    """Translate scheduler layer groups into layer-pipelined transfers."""
+
+    token_to_kv_pool_allocator: BaseTokenToKVPoolAllocator
+    kv_manager: BaseKVManager
+    server_args: ServerArgs
+    ps: ParallelState
+    model_config: ModelConfig
+    tp_worker: BaseTpWorker
+    model_worker: object
+    req_to_token_pool: ReqToTokenPool
+    metadata_buffers: MetadataBuffers
+    transfer_backend: TransferBackend
+    sliding_window_size: Optional[int] = None
+    enable_staging: bool = False
+    _config_incompatibility_reason: Optional[str] = field(
+        init=False, repr=False, compare=False
+    )
+    _draft_layer_ids: List[int] = field(init=False, repr=False, compare=False)
+    _skip_dsa_state_layer_ids: Optional[set[int]] = field(
+        init=False, repr=False, compare=False
+    )
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "_draft_layer_ids",
+            sorted(self.kv_manager.kv_args.draft_buffer_handles),
+        )
+        object.__setattr__(
+            self,
+            "_skip_dsa_state_layer_ids",
+            (
+                {
+                    layer_id
+                    for layer_id in range(self.model_config.num_hidden_layers)
+                    if dsa_layer_skips_topk(self.model_config.hf_text_config, layer_id)
+                }
+                if is_deepseek_dsa(self.model_config.hf_text_config)
+                else None
+            ),
+        )
+        reason = self._get_config_incompatibility_reason()
+        object.__setattr__(self, "_config_incompatibility_reason", reason)
+        if reason is not None:
+            logger.info("Layer-pipelined KV transfer is disabled: %s", reason)
+        else:
+            logger.info(
+                "Layer-pipelined KV transfer is enabled (individual batches may "
+                "still fall back to the regular path)"
+            )
+
+    def plan_batch(self, batch: ScheduleBatch) -> Optional[LayerPipelinedTransferPlan]:
+        """Return a layer-pipelined transfer plan, or None for the normal path."""
+        if self._config_incompatibility_reason is not None:
+            return None
+        if not self._is_batch_compatible(batch):
+            return None
+
+        group_size = (
+            envs.SGLANG_PIPELINE_GROUP_SIZE.get()
+            if envs.SGLANG_PIPELINE_GROUP_SIZE.is_set()
+            else self._get_adaptive_group_size(batch)
+        )
+        if group_size <= 0:
+            return None
+        return self._build_transfer_plan(
+            batch,
+            num_layers=self.model_config.num_hidden_layers,
+            group_size=group_size,
+        )
+
+    def run_batch(
+        self,
+        batch: ScheduleBatch,
+        plan: LayerPipelinedTransferPlan,
+        defer_sample: bool = False,
+        on_publish=None,
+    ) -> GenerationBatchResult:
+        """Run split prefill and enqueue each completed layer group."""
+        forward_batch = self.model_worker.forward_batch_generation_split_prefill_init(
+            batch
+        )
+        for req, kv_indices, state_indices in zip(
+            batch.reqs, plan.req_page_indices_list, plan.req_state_indices_list
+        ):
+            if req.inflight_middle_chunks > 0:
+                continue
+            req.disagg_kv_sender.prepare_layer_pipelined_transfer(
+                kv_indices,
+                state_indices,
+                final_state_indices=getattr(req, "non_pipelined_state_indices", None),
+                skip_dsa_state_layer_ids=self._skip_dsa_state_layer_ids,
+            )
+
+        logits_output = None
+        for group_id, layer_ids in enumerate(plan.layer_ids_by_group):
+            logits, ready_event = (
+                self.model_worker.forward_batch_generation_split_prefill(
+                    forward_batch, forward_count=len(layer_ids)
+                )
+            )
+            if logits is not None:
+                logits_output = logits
+
+            for req in batch.reqs:
+                if req.inflight_middle_chunks > 0:
+                    continue
+                req.disagg_kv_sender.send_layers(
+                    layer_ids,
+                    ready_event=ready_event,
+                )
+                if group_id == len(plan.layer_ids_by_group) - 1:
+                    req.ready_for_pipelined_transfer_finalize = True
+                    req.start_send_idx = min(
+                        req.extend_range.end, len(req.origin_input_ids)
+                    )
+
+        assert logits_output is not None, (
+            "forward_batch_generation_split_prefill should return logits after "
+            "the last layer"
+        )
+        result = self.model_worker.forward_batch_generation_split_prefill_finalize(
+            batch,
+            logits_output,
+            forward_batch,
+            defer_sample=defer_sample,
+            on_publish=on_publish,
+        )
+
+        if self._draft_layer_ids:
+            # Draft prefill is not split, so all draft buffers become ready together.
+            draft_ready_event = torch.cuda.Event()
+            draft_ready_event.record()
+            for req in batch.reqs:
+                if req.inflight_middle_chunks > 0:
+                    continue
+                req.disagg_kv_sender.send_layers(
+                    self._draft_layer_ids,
+                    is_draft=True,
+                    ready_event=draft_ready_event,
+                )
+
+        return result
+
+    def finalize_pipelined_transfer(self, req: Req) -> bool:
+        """Send final metadata for a request handled by the pipelined path."""
+        if not getattr(req, "ready_for_pipelined_transfer_finalize", False):
+            return False
+
+        self.metadata_buffers.set_buf(req)
+        metadata_ready_event = torch.cuda.Event()
+        metadata_ready_event.record()
+        req.disagg_kv_sender.send_final_metadata(metadata_ready_event)
+        return True
+
+    def _get_config_incompatibility_reason(self) -> Optional[str]:
+        if not envs.SGLANG_ENABLE_PIPELINED_KV_TRANSFER.get():
+            return "SGLANG_ENABLE_PIPELINED_KV_TRANSFER is not enabled"
+        if self.server_args.speculative_algorithm is not None:
+            return "speculative decoding is unsupported"
+        if (
+            self.ps.attn_dp_size > 1
+            and self.server_args.cuda_graph_config.prefill.backend != Backend.DISABLED
+        ):
+            return (
+                "prefill CUDA graph is incompatible with layer-pipelined KV transfer "
+                "when DP attention is enabled; set "
+                "--cuda-graph-backend-prefill disabled to use layer-pipelined KV "
+                "transfer with DP attention"
+            )
+        if self.transfer_backend not in (
+            TransferBackend.MOONCAKE,
+            TransferBackend.FAKE,
+        ):
+            return f"transfer backend {self.transfer_backend} is unsupported"
+        if getattr(self.server_args, "enable_hisparse", False):
+            return "prefill-side HiSparse is unsupported"
+        if self.ps.pp_size > 1:
+            return "pipeline parallelism is unsupported"
+        if self.ps.attn_cp_size > 1:
+            return "context parallelism is unsupported"
+        if getattr(self.ps, "dcp_size", 1) > 1:
+            return "decode context parallelism is unsupported"
+        if not callable(
+            getattr(self.tp_worker.model_runner.model, "forward_split_prefill", None)
+        ):
+            return "the model does not implement forward_split_prefill"
+        split_methods = (
+            "forward_batch_generation_split_prefill_init",
+            "forward_batch_generation_split_prefill",
+            "forward_batch_generation_split_prefill_finalize",
+        )
+        if any(
+            not callable(getattr(self.model_worker, method, None))
+            for method in split_methods
+        ):
+            return "the model worker does not support layer-pipelined split prefill"
+        if getattr(self.server_args, "expert_distribution_recorder_mode", None):
+            return "expert distribution recording is unsupported"
+        if getattr(self.server_args, "enable_return_routed_experts", False):
+            return "returning routed experts is unsupported"
+        if getattr(self.server_args, "enable_return_indexer_topk", False):
+            return "returning indexer top-k results is unsupported"
+        if getattr(self.server_args, "elastic_ep_backend", None):
+            return "elastic EP is unsupported"
+        return None
+
+    def _is_batch_compatible(self, batch: ScheduleBatch) -> bool:
+        if not batch.reqs:
+            return False
+        if all(req.inflight_middle_chunks > 0 for req in batch.reqs):
+            return False
+        if batch.forward_mode.is_split_prefill():
+            return False
+        if getattr(batch, "tbo_split_seq_index", None) is not None:
+            return False
+        if any(
+            req.pending_bootstrap
+            or req.multimodal_inputs is not None
+            or req.input_embeds is not None
+            or req.positional_embed_overrides is not None
+            for req in batch.reqs
+        ):
+            return False
+        return not self._batch_needs_staging_for_heterogeneous_tp(batch)
+
+    def _batch_needs_staging_for_heterogeneous_tp(self, batch: ScheduleBatch) -> bool:
+        if not self.enable_staging:
+            return False
+        transfer_infos = getattr(self.kv_manager, "transfer_infos", {})
+        decode_kv_args_table = getattr(self.kv_manager, "decode_kv_args_table", {})
+        attn_tp_size = getattr(self.kv_manager, "attn_tp_size", self.ps.attn_tp_size)
+        for req in batch.reqs:
+            room = getattr(req, "bootstrap_room", None)
+            for transfer_info in transfer_infos.get(room, {}).values():
+                if transfer_info.is_dummy:
+                    continue
+                register_info = decode_kv_args_table.get(
+                    transfer_info.mooncake_session_id
+                )
+                if (
+                    register_info is not None
+                    and register_info.dst_attn_tp_size != attn_tp_size
+                ):
+                    return True
+        return False
+
+    def _get_adaptive_group_size(self, batch: ScheduleBatch) -> int:
+        num_layers = self.model_config.num_hidden_layers
+        if num_layers <= 4:
+            return 0
+
+        min_tokens = max(1, envs.SGLANG_PIPELINE_MIN_TOKENS.get())
+        # Middle chunks stay on the regular path, so only count tokens that will
+        # actually participate in pipelined KV transfer for the threshold.
+        # Counting all tokens may enable pipelining when the actual transfer is
+        # too small, causing a performance regression.
+        pipelined_transfer_tokens = sum(
+            req.extend_range.length
+            for req in batch.reqs
+            if req.inflight_middle_chunks <= 0
+        )
+        if pipelined_transfer_tokens < min_tokens:
+            return 0
+
+        avg_tokens = sum(req.extend_range.length for req in batch.reqs) // len(
+            batch.reqs
+        )
+
+        # Adaptive group size via a continuous formula:
+        #   target_iters = clamp(MAX - progress * (MAX - MIN), MIN, MAX)
+        #   progress = (avg_tokens - min_tokens) / (sat_tokens - min_tokens)
+        #
+        # Pipeline total time:
+        #   Good bandwidth (T < C): total = C + T/N (last transfer is exposed)
+        #   Poor bandwidth (T > C): total = C/N + T (first compute is exposed)
+        #
+        # Short prompts have a high T/C ratio because attention is O(n^2) while
+        # transfer is O(n), so more groups reduce exposed T/N or C/N. For long
+        # prompts, compute dominates and fewer groups avoid unnecessary overhead.
+        max_iters = envs.SGLANG_PIPELINE_MAX_ITERS.get()
+        min_iters = envs.SGLANG_PIPELINE_MIN_ITERS.get()
+        if min_iters > max_iters:
+            min_iters, max_iters = max_iters, min_iters
+        sat_tokens = min_tokens * max(1.01, envs.SGLANG_PIPELINE_SAT_MULTIPLIER.get())
+        progress = min(
+            1.0,
+            max(0.0, (avg_tokens - min_tokens) / (sat_tokens - min_tokens)),
+        )
+        target_iters = max(
+            min_iters, round(max_iters - progress * (max_iters - min_iters))
+        )
+        return max(1, num_layers // target_iters)
+
+    def _build_transfer_plan(
+        self, batch: ScheduleBatch, num_layers: int, group_size: int
+    ) -> LayerPipelinedTransferPlan:
+        state_types = tuple(getattr(self.kv_manager.kv_args, "state_types", ()))
+        pipelined_component_ids = self._get_pipelined_component_ids(
+            num_layers, state_types
+        )
+        req_page_indices_list, req_state_indices_list = (
+            self._get_buffer_transfer_indices(
+                batch, state_types, pipelined_component_ids
+            )
+        )
+        layer_ids_by_group = [
+            list(range(group_start, min(group_start + group_size, num_layers)))
+            for group_start in range(0, num_layers, group_size)
+        ]
+        return LayerPipelinedTransferPlan(
+            group_size=group_size,
+            layer_ids_by_group=layer_ids_by_group,
+            req_page_indices_list=req_page_indices_list,
+            req_state_indices_list=req_state_indices_list,
+        )
+
+    def _get_pipelined_component_ids(
+        self, num_layers: int, state_types: Tuple[StateType, ...]
+    ) -> set[int]:
+        component_ids = set()
+        for layer_id in range(num_layers):
+            handles = self.kv_manager.kv_args.target_buffer_handles.get(layer_id)
+            if handles is None:
+                continue
+            for buffer_type, component_id in zip(
+                handles.buffer_types, handles.state_component_ids
+            ):
+                if buffer_type != BufferType.STATE or component_id is None:
+                    continue
+                if (
+                    state_types[component_id] == StateType.DSA
+                    and self._skip_dsa_state_layer_ids
+                    and layer_id in self._skip_dsa_state_layer_ids
+                ):
+                    continue
+                component_ids.add(component_id)
+
+        for handles in self.kv_manager.kv_args.draft_buffer_handles.values():
+            for buffer_type, component_id in zip(
+                handles.buffer_types, handles.state_component_ids
+            ):
+                if buffer_type == BufferType.STATE and component_id is not None:
+                    component_ids.add(component_id)
+        return component_ids
+
+    def _get_buffer_transfer_indices(
+        self,
+        batch: ScheduleBatch,
+        state_types: Tuple[StateType, ...],
+        pipelined_component_ids: set[int],
+    ) -> Tuple[List[np.ndarray], List[List]]:
+        page_size = self.token_to_kv_pool_allocator.page_size
+        token_to_kv_pool = self.token_to_kv_pool_allocator.get_kvcache()
+        req_page_indices_list = []
+        req_state_indices_list = []
+        for req in batch.reqs:
+            req.ready_for_pipelined_transfer_finalize = False
+            seq_len = min(req.extend_range.end, len(req.origin_input_ids))
+            kv_indices = self.req_to_token_pool.req_to_token[
+                req.req_pool_idx, req.start_send_idx : seq_len
+            ]
+            req_page_indices_list.append(kv_to_page_indices(kv_indices, page_size))
+
+            req_state_indices = []
+            for state_type in state_types:
+                if state_type == StateType.MAMBA:
+                    mamba_indices = (
+                        self.req_to_token_pool.req_index_to_mamba_index_mapping[
+                            req.req_pool_idx
+                        ]
+                    )
+                    mamba_indices = self.req_to_token_pool.translate_mamba_indices(
+                        mamba_indices
+                    )
+                    req_state_indices.append([mamba_indices.cpu().numpy()])
+                elif state_type == StateType.SWA:
+                    window_start = max(0, seq_len - self.sliding_window_size)
+                    window_start = (window_start // page_size) * page_size
+                    window_kv_indices = self.req_to_token_pool.req_to_token[
+                        req.req_pool_idx, window_start:seq_len
+                    ]
+                    window_kv_indices = (
+                        self.token_to_kv_pool_allocator.translate_loc_from_full_to_swa(
+                            window_kv_indices
+                        )
+                    )
+                    req_state_indices.append(
+                        kv_to_page_indices(window_kv_indices, page_size)
+                    )
+                elif state_type in (StateType.DSA, StateType.MINIMAX_INDEX_K):
+                    full_kv_indices = self.req_to_token_pool.req_to_token[
+                        req.req_pool_idx, :seq_len
+                    ]
+                    req_state_indices.append(
+                        kv_to_page_indices(full_kv_indices, page_size)
+                    )
+                elif state_type == StateType.SWA_RING:
+                    window_start = max(0, seq_len - token_to_kv_pool.unified_swa_window)
+                    positions = np.arange(window_start, seq_len, dtype=np.int64)
+                    ring_rows = (
+                        int(req.req_pool_idx) * token_to_kv_pool.unified_swa_ring_size
+                        + positions % token_to_kv_pool.unified_swa_ring_size
+                    )
+                    req_state_indices.append(ring_rows.astype(np.int32))
+                elif state_type == StateType.C128_STATE:
+                    online = is_dsv4_c128_online_enabled()
+                    ring_size = 1 if online else token_to_kv_pool.get_ring_size(128)
+                    req_state_indices.append(
+                        get_dsv4_c128_state_indices(
+                            int(req.req_pool_idx),
+                            len(req.origin_input_ids),
+                            online=online,
+                            ring_size=ring_size,
+                        )
+                    )
+                else:
+                    req_state_indices.append(None)
+            req_state_indices_list.append(req_state_indices)
+            non_pipelined = [
+                None if i in pipelined_component_ids else indices
+                for i, indices in enumerate(req_state_indices)
+            ]
+            req.non_pipelined_state_indices = (
+                non_pipelined
+                if any(indices is not None for indices in non_pipelined)
+                else None
+            )
+        return req_page_indices_list, req_state_indices_list

--- a/python/sglang/srt/disaggregation/pipelined_kv_transfer.py
+++ b/python/sglang/srt/disaggregation/pipelined_kv_transfer.py
@@ -19,6 +19,7 @@ from sglang.srt.environ import envs
 from sglang.srt.managers.utils import GenerationBatchResult
 from sglang.srt.mem_cache.common import kv_to_page_indices
 from sglang.srt.model_executor.cuda_graph_config import Backend
+from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 
 logger = logging.getLogger(__name__)
 
@@ -200,8 +201,14 @@ class LayerPipelinedKVTransferAdapter:
     def _get_config_incompatibility_reason(self) -> Optional[str]:
         if not envs.SGLANG_ENABLE_PIPELINED_KV_TRANSFER.get():
             return "SGLANG_ENABLE_PIPELINED_KV_TRANSFER is not enabled"
-        if self.server_args.speculative_algorithm is not None:
-            return "speculative decoding is unsupported"
+        spec_algo_str = self.server_args.speculative_algorithm
+        if spec_algo_str:
+            spec_algo = SpeculativeAlgorithm.from_string(spec_algo_str)
+            if not (spec_algo.is_eagle() or spec_algo.is_dspark()):
+                return (
+                    f"speculative algorithm {spec_algo_str!r} is unsupported "
+                    "(only EAGLE family and DSPARK support pipelined KV transfer)"
+                )
         if (
             self.ps.attn_dp_size > 1
             and self.server_args.cuda_graph_config.prefill.backend != Backend.DISABLED

--- a/python/sglang/srt/disaggregation/pipelined_kv_transfer.py
+++ b/python/sglang/srt/disaggregation/pipelined_kv_transfer.py
@@ -16,6 +16,7 @@ from sglang.srt.disaggregation.utils import (
     is_dsv4_c128_online_enabled,
 )
 from sglang.srt.environ import envs
+from sglang.srt.layers.cp.utils import CP_V2_DEFAULT_MODEL_CLASSES
 from sglang.srt.managers.utils import GenerationBatchResult
 from sglang.srt.mem_cache.common import kv_to_page_indices
 from sglang.srt.model_executor.cuda_graph_config import Backend
@@ -228,8 +229,9 @@ class LayerPipelinedKVTransferAdapter:
             return "prefill-side HiSparse is unsupported"
         if self.ps.pp_size > 1:
             return "pipeline parallelism is unsupported"
-        if self.ps.attn_cp_size > 1:
-            return "context parallelism is unsupported"
+        cp_reason = self._get_cp_incompatibility_reason()
+        if cp_reason is not None:
+            return cp_reason
         if getattr(self.ps, "dcp_size", 1) > 1:
             return "decode context parallelism is unsupported"
         if not callable(
@@ -254,6 +256,16 @@ class LayerPipelinedKVTransferAdapter:
             return "returning indexer top-k results is unsupported"
         if getattr(self.server_args, "elastic_ep_backend", None):
             return "elastic EP is unsupported"
+        return None
+
+    def _get_cp_incompatibility_reason(self) -> Optional[str]:
+        if self.ps.attn_cp_size <= 1:
+            return None
+        if not envs.SGLANG_ENABLE_CP_V2.get():
+            return "context parallelism v2 is disabled"
+        model_arch = self.model_config.hf_config.architectures[0]
+        if model_arch not in CP_V2_DEFAULT_MODEL_CLASSES:
+            return f"context parallelism is unsupported for model {model_arch}"
         return None
 
     def _is_batch_compatible(self, batch: ScheduleBatch) -> bool:

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -742,7 +742,12 @@ class SchedulerDisaggregationPrefillMixin:
                     self.batch_result_processor.add_sampling_mask_return_values(
                         i, req, logits_output
                     )
-                if not req.pending_bootstrap:
+                if not req.pending_bootstrap and not (
+                    self.layer_pipelined_kv_transfer
+                    and self.layer_pipelined_kv_transfer.finalize_pipelined_transfer(
+                        req
+                    )
+                ):
                     self.send_kv_chunk(req, last_chunk=True)
                 req.time_stats.set_prefill_transfer_queue_entry_time()
 

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -1003,6 +1003,10 @@ def setup_state_kv_args(
         MiniMaxSparseKVPool,
     )
 
+    kv_args.target_buffer_handles = {}
+    kv_args.draft_buffer_handles = {}
+    target_state_component_ids = {}
+    draft_state_component_ids = {}
     kv_args.state_types = []
     kv_args.state_data_ptrs = []
     kv_args.state_data_lens = []
@@ -1013,6 +1017,38 @@ def setup_state_kv_args(
     kv_args.is_hybrid_mla_backend = False
     kv_args.state_conv_shard_groups = []
 
+    def append_state_component_wrapper(
+        state_type,
+        data_ptrs,
+        data_lens,
+        item_lens,
+        dim_per_tensor=None,
+        conv_shard_groups=None,
+        slice_outer_counts=None,
+        layer_ids=None,
+        *,
+        is_draft=False,
+        shared_with_draft=False,
+    ):
+        component_id = len(kv_args.state_types)
+        append_state_component(
+            kv_args,
+            state_type,
+            data_ptrs,
+            data_lens,
+            item_lens,
+            dim_per_tensor,
+            conv_shard_groups,
+            slice_outer_counts,
+            layer_ids,
+        )
+        component_ids = (
+            draft_state_component_ids if is_draft else target_state_component_ids
+        )
+        component_ids[state_type] = component_id
+        if shared_with_draft:
+            draft_state_component_ids[state_type] = component_id
+
     if is_npu() and isinstance(token_to_kv_pool, DSV4NPUTokenToKVPool):
         # Pool ships each sub-pool as its own page-indexed component (fixed order
         # so prefill and decode register identically); skips get_state_buf_infos.
@@ -1022,7 +1058,7 @@ def setup_state_kv_args(
             comp_lens,
             comp_item_lens,
         ) in token_to_kv_pool.get_pd_state_components():
-            append_state_component(kv_args, st, comp_ptrs, comp_lens, comp_item_lens)
+            append_state_component_wrapper(st, comp_ptrs, comp_lens, comp_item_lens)
     elif isinstance(token_to_kv_pool, MiniMaxSparseKVPool):
         if token_to_kv_pool.index_kv_pool is not None:
             raise NotImplementedError(
@@ -1031,15 +1067,15 @@ def setup_state_kv_args(
             )
         if token_to_kv_pool.index_k_pool is not None:
             dp, dl, il = token_to_kv_pool.get_index_k_state_buf_infos()
-            append_state_component(kv_args, StateType.MINIMAX_INDEX_K, dp, dl, il)
+            append_state_component_wrapper(StateType.MINIMAX_INDEX_K, dp, dl, il)
     elif hasattr(token_to_kv_pool, "get_state_buf_infos"):
         data_ptrs, data_lens, item_lens = token_to_kv_pool.get_state_buf_infos()
 
         # DeepSeekV4TokenToKVPool inherits BaseSWAKVPool; its heterogeneous
         # state list is described per-entry via get_state_buf_infos.
         if isinstance(token_to_kv_pool, BaseSWAKVPool):
-            append_state_component(
-                kv_args, StateType.SWA, data_ptrs, data_lens, item_lens
+            append_state_component_wrapper(
+                StateType.SWA, data_ptrs, data_lens, item_lens
             )
             # unified_kv: the SWA ring lives in the unified buffers (no separate
             # swa_kv_pool) and is addressed per-row, so ship it as SWA_RING.
@@ -1050,8 +1086,7 @@ def setup_state_kv_args(
                     token_to_kv_pool.get_unified_swa_ring_buf_infos()
                 )
                 if ring_ptrs:
-                    append_state_component(
-                        kv_args,
+                    append_state_component_wrapper(
                         StateType.SWA_RING,
                         ring_ptrs,
                         ring_lens,
@@ -1062,8 +1097,7 @@ def setup_state_kv_args(
                     token_to_kv_pool.get_c128_state_buf_infos()
                 )
                 if c128_ptrs:
-                    append_state_component(
-                        kv_args,
+                    append_state_component_wrapper(
                         StateType.C128_STATE,
                         c128_ptrs,
                         c128_lens,
@@ -1091,8 +1125,7 @@ def setup_state_kv_args(
             # Global layer ids let the sender pair src/dst entries when the
             # prefill PP stage registers only its own subset of mamba layers.
             layer_ids = token_to_kv_pool.get_state_layer_ids()
-            append_state_component(
-                kv_args,
+            append_state_component_wrapper(
                 StateType.MAMBA,
                 data_ptrs,
                 data_lens,
@@ -1102,6 +1135,7 @@ def setup_state_kv_args(
                 slice_outer_counts,
                 layer_ids,
             )
+
         elif isinstance(token_to_kv_pool, (DSATokenToKVPool, NPUMLATokenToKVPool)):
             if draft_token_to_kv_pool is not None and isinstance(
                 draft_token_to_kv_pool, DSATokenToKVPool
@@ -1120,8 +1154,12 @@ def setup_state_kv_args(
                 )
                 kv_args.total_kv_layers = total_kv_layers
             else:
-                append_state_component(
-                    kv_args, StateType.DSA, data_ptrs, data_lens, item_lens
+                append_state_component_wrapper(
+                    StateType.DSA,
+                    data_ptrs,
+                    data_lens,
+                    item_lens,
+                    shared_with_draft=draft_token_to_kv_pool is not None,
                 )
 
     # DSV4 NextN shares the target allocator, so target and draft use the same
@@ -1192,12 +1230,12 @@ def setup_state_kv_args(
             draft_state_type = StateType.SWA
 
         if draft_ptrs:
-            append_state_component(
-                kv_args,
+            append_state_component_wrapper(
                 draft_state_type,
                 draft_ptrs,
                 draft_lens,
                 draft_item_lens,
+                is_draft=True,
             )
 
     if (
@@ -1222,8 +1260,7 @@ def setup_state_kv_args(
                 if hasattr(req_to_token_pool, "get_state_slice_outer_counts")
                 else None
             )
-            append_state_component(
-                kv_args,
+            append_state_component_wrapper(
                 StateType.MAMBA,
                 data_ptrs,
                 data_lens,
@@ -1232,6 +1269,60 @@ def setup_state_kv_args(
                 conv_shard_groups,
                 slice_outer_counts,
             )
+
+    def populate_buffer_handles(
+        pool,
+        output,
+        kv_buffer_offset,
+        state_component_ids,
+        state_buffer_offsets=None,
+    ):
+        get_handles = getattr(pool, "get_buffer_handles_by_layer", None)
+        if get_handles is None:
+            return
+        handles_by_layer = get_handles(
+            kv_buffer_offset=kv_buffer_offset,
+            state_component_ids=state_component_ids,
+            state_buffer_offsets=state_buffer_offsets,
+        )
+        overlap = set(output).intersection(handles_by_layer)
+        if overlap:
+            raise RuntimeError(f"Duplicate layer buffer handles: {sorted(overlap)}")
+        output.update(
+            {
+                layer_id: handles
+                for layer_id, handles in handles_by_layer.items()
+                if handles.buffer_types
+            }
+        )
+
+    populate_buffer_handles(
+        token_to_kv_pool,
+        kv_args.target_buffer_handles,
+        0,
+        target_state_component_ids,
+    )
+
+    if draft_token_to_kv_pool is not None:
+        draft_kv_buffer_count = len(
+            draft_token_to_kv_pool.get_contiguous_buf_infos()[0]
+        )
+        draft_state_buffer_offsets = {}
+        if (
+            StateType.DSA in target_state_component_ids
+            and target_state_component_ids.get(StateType.DSA)
+            == draft_state_component_ids.get(StateType.DSA)
+        ):
+            draft_state_buffer_offsets[StateType.DSA] = len(
+                token_to_kv_pool.get_state_buf_infos()[0]
+            )
+        populate_buffer_handles(
+            draft_token_to_kv_pool,
+            kv_args.draft_buffer_handles,
+            len(kv_args.kv_data_ptrs) - draft_kv_buffer_count,
+            draft_state_component_ids,
+            draft_state_buffer_offsets,
+        )
 
 
 def prepare_abort(req: Req, error_message: str, status_code=None):

--- a/python/sglang/srt/entrypoints/grpc_bridge.py
+++ b/python/sglang/srt/entrypoints/grpc_bridge.py
@@ -293,14 +293,23 @@ class RuntimeHandle:
 
     async def _run_generate(self, obj, chunk_callback, stream: bool, request):
         ready_event = None
+        gen = None
         try:
-            ready_event = self._install_on_ready(chunk_callback) if stream else None
+            ready_event = self._install_on_ready(chunk_callback)
             gen = self.tokenizer_manager.generate_request(obj, request=request)
             if stream:
+                completed_choices = set()
+                expected_choices = obj.batch_size * obj.parallel_sample_num
                 async for chunk in gen:
-                    finished = (
+                    choice_finished = (
                         chunk.get("meta_info", {}).get("finish_reason") is not None
                     )
+                    if choice_finished:
+                        choice_id = chunk.get(
+                            "index", chunk.get("meta_info", {}).get("id")
+                        )
+                        completed_choices.add(choice_id)
+                    finished = len(completed_choices) >= expected_choices
                     keep_going = await self._send_with_backpressure(
                         chunk_callback,
                         ready_event,
@@ -314,15 +323,26 @@ class RuntimeHandle:
                 self._safe_callback(chunk_callback, {}, finished=True)
             else:
                 result = await gen.__anext__()
-                self._safe_callback(chunk_callback, result, finished=True)
+                chunks = result if isinstance(result, list) else [result]
+                for index, chunk in enumerate(chunks):
+                    keep_going = await self._send_with_backpressure(
+                        chunk_callback,
+                        ready_event,
+                        chunk,
+                        finished=index == len(chunks) - 1,
+                        timeout_abort_rid=obj.rid,
+                    )
+                    if not keep_going:
+                        return
         except StopAsyncIteration:
             self._safe_callback(chunk_callback, {}, finished=True)
         except Exception as e:
             logger.error("gRPC generate error for rid=%s: %s", obj.rid, e)
             self._send_native_error(chunk_callback, str(e))
         finally:
-            if stream:
-                self._uninstall_on_ready(chunk_callback)
+            if gen is not None:
+                await gen.aclose()
+            self._uninstall_on_ready(chunk_callback)
 
     async def _run_embed(self, obj, chunk_callback, request):
         try:

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -895,7 +895,7 @@ async def generate_request(obj: GenerateReqInput, request: Request):
                     "error": {
                         "message": str(e),
                         "type": "invalid_request_error",
-                        "code": 400,
+                        "code": getattr(e, "status_code", 400),
                         "retryable": False,
                     }
                 }
@@ -2048,7 +2048,8 @@ async def vertex_generate(
 
 def _create_error_response(e):
     return ORJSONResponse(
-        {"error": {"message": str(e)}}, status_code=HTTPStatus.BAD_REQUEST
+        {"error": {"message": str(e)}},
+        status_code=getattr(e, "status_code", HTTPStatus.BAD_REQUEST),
     )
 
 

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -421,6 +421,13 @@ class Envs:
     SGLANG_DISAGGREGATION_ALL_CP_RANKS_TRANSFER = EnvBool(False)
     SGLANG_DISAGGREGATION_FORCE_QUERY_PREFILL_DP_RANK = EnvBool(False)
     SGLANG_DISAGGREGATION_SAMPLING_MASK_MAX_TOKENS = EnvInt(0)
+    # Layer-pipelined KV transfer: overlap transfer with prefill compute.
+    SGLANG_ENABLE_PIPELINED_KV_TRANSFER = EnvBool(False)
+    SGLANG_PIPELINE_GROUP_SIZE = EnvInt(0)
+    SGLANG_PIPELINE_MIN_TOKENS = EnvInt(3072)
+    SGLANG_PIPELINE_SAT_MULTIPLIER = EnvFloat(3.0)
+    SGLANG_PIPELINE_MAX_ITERS = EnvInt(10)
+    SGLANG_PIPELINE_MIN_ITERS = EnvInt(4)
 
     # Scheduler: others:
     # in seconds. Set if you observe high memory accumulation over a long serving period.

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -675,6 +675,9 @@ class Envs:
     SGLANG_FLASHINFER_USE_PAGED = EnvBool(False)
     # Default to the pick from flashinfer
     SGLANG_FLASHINFER_WORKSPACE_SIZE = EnvInt(384 * 1024 * 1024)
+    # Per-rank dispatch capacity of the FlashInfer MoE A2A dispatcher. Unset
+    # means each call site keeps its own default.
+    SGLANG_FLASHINFER_NUM_MAX_DISPATCH_TOKENS_PER_RANK = EnvInt(None)
     # Enable NVFP4 per-token activation scaling path for FlashInfer TRT-LLM MoE.
     SGLANG_FLASHINFER_NVFP4_PER_TOKEN_ACTIVATION = EnvBool(False)
     # Launch the TRT-LLM MoE grouped GEMMs with PDL only at or below this

--- a/python/sglang/srt/layers/attention/mamba/mamba2_metadata.py
+++ b/python/sglang/srt/layers/attention/mamba/mamba2_metadata.py
@@ -240,7 +240,7 @@ class Mamba2Metadata(ForwardMetadata):
         batch_size = getattr(forward_batch, "_original_batch_size", None)
         if batch_size is None:
             batch_size = len(forward_batch.seq_lens)
-        num_decodes = batch_size - num_prefills
+        num_decodes = max(0, batch_size - num_prefills)
         context_lens_tensor = forward_batch.extend_prefix_lens
         assert context_lens_tensor is not None
         has_initial_states = context_lens_tensor > 0

--- a/python/sglang/srt/layers/attn_residual.py
+++ b/python/sglang/srt/layers/attn_residual.py
@@ -9,6 +9,8 @@
 #           online-softmax consumers over a double-buffered chunk ring, out
 #           norm fused, per-nvb tuned launch config, one persistent CTA per
 #           SM. Taken on SM100+ with H=7168.
+#   hip   — single Triton kernel, everything in one launch; taken on ROCm
+#           within its register budget.
 #   fused — Triton 2-kernel pipeline with full H-parallelism; the fallback
 #           everywhere the fast kernel does not apply.
 # aggregate_stream_torch is the eager reference (tests and the
@@ -22,11 +24,13 @@ import triton.language as tl
 
 from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.linear import ReplicatedLinear
+from sglang.srt.utils import is_hip
 
 _BLOCK_H: int = 1024  # H = 7168 = 7 x 1024
 _MAX_ROWS: int = 16  # next_pow2(8 + 1), K3 has <= 8 snapshots
 
 _FAST_SUPPORTED = None
+_HIP_SHAPE_GATE = None
 
 
 def _use_fast(hidden_size: int) -> bool:
@@ -37,6 +41,19 @@ def _use_fast(hidden_size: int) -> bool:
         major, _ = torch.cuda.get_device_capability()
         _FAST_SUPPORTED = major >= 10
     return _FAST_SUPPORTED and hidden_size == 7168
+
+
+def _use_hip_fused(hidden_size: int, nvb: int) -> bool:
+    """This gate picks the single-kernel ROCm Triton kernel instead of the
+    2-kernel pipeline."""
+    if not is_hip():
+        return False
+    global _HIP_SHAPE_GATE
+    if _HIP_SHAPE_GATE is None:
+        from sglang.kernels.ops.kimi_k3.attn_res_hip import supports_attn_res_hip
+
+        _HIP_SHAPE_GATE = supports_attn_res_hip
+    return _HIP_SHAPE_GATE(hidden_size, nvb)
 
 
 def get_cw(
@@ -244,6 +261,41 @@ def _aggregate_fused(
     return out_norm(_mix_fused(prefix_sum, bank, nvb, score_proj, score_norm))
 
 
+def _aggregate_hip(
+    prefix_sum: torch.Tensor,
+    addend: Optional[torch.Tensor],
+    bank: torch.Tensor,
+    nvb: int,
+    score_proj: ReplicatedLinear,
+    score_norm: RMSNorm,
+    out_norm: Optional[RMSNorm],
+    write_bank_row: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Single ROCm Triton kernel: the bank stays in registers so scoring and
+    mixing share one read, and the pending residual add, the bank snapshot and
+    the output RMSNorm all fold into the same launch. out_norm None returns the
+    pre-norm mixture instead. Returns (result, prefix)."""
+    from sglang.kernels.ops.kimi_k3.attn_res_hip import attn_res_hip
+
+    cw = get_cw(score_proj, score_norm)
+    prefix = prefix_sum if addend is None else torch.empty_like(prefix_sum)
+    out = torch.empty_like(prefix_sum)
+    attn_res_hip(
+        prefix_sum,
+        bank,
+        cw,
+        out_norm.weight if out_norm is not None else None,
+        out,
+        nvb,
+        score_norm.variance_epsilon,
+        out_norm.variance_epsilon if out_norm is not None else 0.0,
+        addend=addend,
+        prefix_out=prefix,
+        write_prefix=write_bank_row,
+    )
+    return out, prefix
+
+
 def aggregate_stream_torch(
     prefix_sum: torch.Tensor,
     bank: torch.Tensor,
@@ -277,6 +329,10 @@ def aggregate_stream(
     raw wire only carries the current block's running prefix."""
     if nvb == 0:
         return prefix_sum
+    if _use_hip_fused(prefix_sum.shape[1], nvb):
+        return _aggregate_hip(
+            prefix_sum, None, bank, nvb, score_proj, score_norm, None
+        )[0]
     if prefix_sum.shape[1] % _BLOCK_H != 0:
         return aggregate_stream_torch(prefix_sum, bank, nvb, score_proj, score_norm)
     return _mix_fused(prefix_sum, bank, nvb, score_proj, score_norm)
@@ -295,6 +351,18 @@ def _aggregate_fused_add(
     """Aggregation point with a pending upstream residual add: materialize
     prefix = prefix_a + prefix_b, then aggregate. Returns (normed, prefix).
     write_bank_row rides _aggregate (fast path only)."""
+    if _use_hip_fused(prefix_a.shape[1], nvb):
+        # The hip kernel reads the prefix row anyway, so the add folds into it.
+        return _aggregate_hip(
+            prefix_a,
+            prefix_b,
+            bank,
+            nvb,
+            score_proj,
+            score_norm,
+            out_norm,
+            write_bank_row=write_bank_row,
+        )
     prefix = prefix_a + prefix_b
     return (
         _aggregate(
@@ -336,6 +404,17 @@ def _aggregate(
             out_norm,
             write_bank_row=write_bank_row,
         )
+    if _use_hip_fused(prefix_sum.shape[1], nvb):
+        return _aggregate_hip(
+            prefix_sum,
+            None,
+            bank,
+            nvb,
+            score_proj,
+            score_norm,
+            out_norm,
+            write_bank_row=write_bank_row,
+        )[0]
     assert not write_bank_row, "fused bank write is fast-path only"
     return _aggregate_fused(prefix_sum, bank, nvb, score_proj, score_norm, out_norm)
 
@@ -403,7 +482,10 @@ class AttnResidual:
             self.block_residual if rows is None else self.block_residual[rows]
         )
 
-        fused_write = write and _use_fast(hidden_states.shape[1])
+        fused_write = write and (
+            _use_fast(hidden_states.shape[1])
+            or _use_hip_fused(hidden_states.shape[1], nvb)
+        )
         if prefix_sum is None:
             # hidden_states already is the whole head (PP entry or a
             # block-boundary restart).

--- a/python/sglang/srt/layers/cp/interleave.py
+++ b/python/sglang/srt/layers/cp/interleave.py
@@ -62,7 +62,10 @@ class InterleaveCPStrategy(ContextParallelStrategy):
     kind = ContextParallelStrategyKind.INTERLEAVE
 
     def can_apply(self, num_tokens: int, forward_batch) -> bool:
-        if not forward_batch.forward_mode.is_context_parallel_extend():
+        if not (
+            forward_batch.forward_mode.is_context_parallel_extend()
+            or forward_batch.forward_mode.is_split_prefill()
+        ):
             return False
         cp_size = self.cp_size
         seq_len = sum(forward_batch.extend_seq_lens_cpu)

--- a/python/sglang/srt/layers/cp/utils.py
+++ b/python/sglang/srt/layers/cp/utils.py
@@ -140,7 +140,10 @@ def is_cp_v2_active(forward_batch) -> bool:
     if not enable_cp_v2():
         return False
     forward_mode = getattr(forward_batch, "forward_mode", None)
-    if forward_mode is None or not forward_mode.is_context_parallel_extend():
+    if forward_mode is None or not (
+        forward_mode.is_context_parallel_extend()
+        or forward_mode.is_split_prefill()
+    ):
         return False
 
     strategy = get_cp_strategy()

--- a/python/sglang/srt/layers/cp/zigzag.py
+++ b/python/sglang/srt/layers/cp/zigzag.py
@@ -110,7 +110,10 @@ class ZigzagCPStrategy(ContextParallelStrategy):
         if self.cp_size <= 1 or num_tokens < self.cp_size * 2:
             return False
         forward_mode = getattr(forward_batch, "forward_mode", None)
-        if forward_mode is not None and not forward_mode.is_context_parallel_extend():
+        if forward_mode is not None and not (
+            forward_mode.is_context_parallel_extend()
+            or forward_mode.is_split_prefill()
+        ):
             return False
 
         extend_lens = getattr(forward_batch, "extend_seq_lens_cpu", None)

--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -45,6 +45,7 @@ from sglang.srt.layers.logprob_processor import (
     get_token_ids_logprobs_raw,
     get_top_logprobs_raw,
 )
+from sglang.srt.layers.cp.utils import cp_gather_after_forward, is_cp_v2_active
 from sglang.srt.layers.vocab_parallel_embedding import VocabParallelEmbedding
 from sglang.srt.model_executor.forward_batch_info import (
     CaptureHiddenMode,
@@ -400,6 +401,20 @@ class LogitsProcessor(nn.Module):
         multi_item_delimiter_indices = None
         if isinstance(logits_metadata, ForwardBatch):
             multi_item_delimiter_indices = logits_metadata.multi_item_delimiter_indices
+            if logits_metadata.forward_mode.is_split_prefill() and is_cp_v2_active(
+                logits_metadata
+            ):
+                # Split-prefill may carry both the post-norm hidden states and an
+                # optional pre-norm copy; keep their token order aligned before
+                # pruning/logprob handling.
+                stream = torch.cuda.current_stream()
+                hidden_states = cp_gather_after_forward(
+                    hidden_states, logits_metadata, stream
+                )
+                if hidden_states_before_norm is not None:
+                    hidden_states_before_norm = cp_gather_after_forward(
+                        hidden_states_before_norm, logits_metadata, stream
+                    )
             logits_metadata = LogitsMetadata.from_forward_batch(logits_metadata)
 
         # Autotune dummy run discards this output; see _in_autotune_dummy_run.

--- a/python/sglang/srt/layers/moe/token_dispatcher/flashinfer.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/flashinfer.py
@@ -29,7 +29,6 @@ from sglang.srt.layers.moe.topk import (
 from sglang.srt.layers.moe.utils import get_moe_runner_backend
 from sglang.srt.runtime_context import get_schedule, get_spec
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
-from sglang.srt.utils import get_int_env_var
 
 try:
     from flashinfer import nvfp4_block_scale_interleave
@@ -125,9 +124,13 @@ class FlashinferDispatcher(BaseDispatcher):
         # (which warms up at batch_size = req_to_token_pool.size).
         cps = get_schedule().chunked_prefill_size
         default_max_tokens = max(cps if cps and cps > 0 else 4096, 4096)
-        self.max_num_tokens = get_int_env_var(
-            "SGLANG_FLASHINFER_NUM_MAX_DISPATCH_TOKENS_PER_RANK",
-            default_max_tokens,
+        configured_max_tokens = (
+            envs.SGLANG_FLASHINFER_NUM_MAX_DISPATCH_TOKENS_PER_RANK.get()
+        )
+        self.max_num_tokens = (
+            configured_max_tokens
+            if configured_max_tokens is not None
+            else default_max_tokens
         )
 
         # Calculate workspace size. For eagle mode, use the larger workspace size since nextn layer will be unquantized.

--- a/python/sglang/srt/layers/n_gram_embedding.py
+++ b/python/sglang/srt/layers/n_gram_embedding.py
@@ -49,7 +49,7 @@ class NgramEmbedding(torch.nn.Module):
                 + int(over_embedding_m + i * 2 + 1)
             )
         self.oe_embeder = VocabParallelEmbedding(
-            num_embeddings=self.exclusive_oe_embedder_size_sums[-1],
+            num_embeddings=int(self.exclusive_oe_embedder_size_sums[-1]),
             embedding_dim=oe_hidden_dim,
             use_attn_tp_group=use_attn_tp_group,
         )

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -70,6 +70,10 @@ from sglang.srt.utils.custom_op import register_custom_op
 
 has_triton_kernels = is_triton_kernels_available()
 
+# Serialized MXFP4 scales use raw UE8M0 bytes. Keep fresh parameters valid for
+# post-load transforms and dummy initialization; 127 is the neutral scale (1.0).
+_UE8M0_ONE = 127
+
 
 if is_flashinfer_available():
     from flashinfer import (
@@ -473,10 +477,13 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         set_weight_attrs(w13_weight, extra_weight_attrs)
 
         w13_weight_scale = torch.nn.Parameter(
-            torch.zeros(
-                layer.num_local_experts,
-                2 * intermediate_size_per_partition_after_pad,
-                hidden_size // mxfp4_block,
+            torch.full(
+                (
+                    layer.num_local_experts,
+                    2 * intermediate_size_per_partition_after_pad,
+                    hidden_size // mxfp4_block,
+                ),
+                fill_value=_UE8M0_ONE,
                 dtype=scale_dtype,
             ),
             requires_grad=False,
@@ -512,10 +519,13 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         set_weight_attrs(w2_weight, extra_weight_attrs)
 
         w2_weight_scale = torch.nn.Parameter(
-            torch.zeros(
-                layer.num_local_experts,
-                hidden_size,
-                intermediate_size_per_partition_after_pad // mxfp4_block,
+            torch.full(
+                (
+                    layer.num_local_experts,
+                    hidden_size,
+                    intermediate_size_per_partition_after_pad // mxfp4_block,
+                ),
+                fill_value=_UE8M0_ONE,
                 dtype=scale_dtype,
             ),
             requires_grad=False,

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -158,8 +158,9 @@ MultimodalDataInputFormat = Union[
 
 @dataclass
 class GenerateReqInput:
-    # Request ID(s). If omitted, generated during normalization. For batch
-    # requests, a string is expanded to per-item IDs using it as a prefix.
+    # Logical request ID(s). If omitted, generated during normalization. For
+    # batch requests, a string is expanded to one ID per original batch item.
+    # Parallel-sampling child IDs are internal to TokenizerManager.
     rid: Optional[Union[str, List[str]]] = field(default=None, kw_only=True)
     # Stable identity shared by requests in the same session. Unlike
     # session_params, this does not alter or reconstruct the prompt.
@@ -276,6 +277,9 @@ class GenerateReqInput:
     background: bool = False
     # Require reasoning for the request (hybrid reasoning model only)
     require_reasoning: bool = False
+    # Per-request thinking budget. Requires strict thinking so the runtime can
+    # enforce the limit rather than silently treating it as metadata.
+    max_thinking_tokens: Optional[int] = None
 
     # Priority for the request
     priority: Optional[int] = None
@@ -319,12 +323,17 @@ class GenerateReqInput:
     # Batch-level: List[List[int]] (one per request). After __getitem__: List[int].
     multi_item_delimiter_indices: Optional[Union[List[List[int]], List[int]]] = None
 
-    def regenerate_rid(self):
+    def regenerate_rid(self, prefix: Optional[str] = None):
         """Generate a new request ID and return it."""
+
+        def new_rid() -> str:
+            suffix = uuid.uuid4().hex
+            return f"{prefix}_{suffix}" if prefix is not None else suffix
+
         if isinstance(self.rid, list):
-            self.rid = [uuid.uuid4().hex for _ in range(len(self.rid))]
+            self.rid = [new_rid() for _ in range(len(self.rid))]
         else:
-            self.rid = uuid.uuid4().hex
+            self.rid = new_rid()
         return self.rid
 
     def _validate_rid_uniqueness(self):
@@ -480,7 +489,7 @@ class GenerateReqInput:
 
         # Expand input based on type
         self._expand_inputs(num)
-        self._normalize_rid(num)
+        self._normalize_rid()
         self._normalize_lora_paths(num)
         self._normalize_image_data(num)
         self._normalize_video_data(num)
@@ -590,16 +599,16 @@ class GenerateReqInput:
         else:  # Already a list
             self.sampling_params = self.sampling_params * self.parallel_sample_num
 
-    def _normalize_rid(self, num):
-        """Normalize request IDs for batch processing."""
+    def _normalize_rid(self):
+        """Normalize one logical request ID per original batch item."""
         if self.rid is None:
-            self.rid = [uuid.uuid4().hex for _ in range(num)]
+            self.rid = [uuid.uuid4().hex for _ in range(self.batch_size)]
         elif isinstance(self.rid, str):
-            new_rids = [f"{self.rid}_{i}" for i in range(num)]
-            self.rid = new_rids
+            if self.batch_size == 1:
+                self.rid = [self.rid]
+            else:
+                self.rid = [f"{self.rid}_{i}" for i in range(self.batch_size)]
         elif isinstance(self.rid, list):
-            # Note: the length of rid shall be the same as the batch_size,
-            # as the rid would be expanded for parallel sampling in tokenizer_manager
             if len(self.rid) != self.batch_size:
                 raise ValueError(
                     "The specified rids length mismatch with the batch_size for batch processing."
@@ -751,8 +760,9 @@ class GenerateReqInput:
         cache = self.__dict__.setdefault("_sub_obj_cache", {})
         if i in cache:
             return cache[i]
+        logical_index = i % self.batch_size
         sub = GenerateReqInput(
-            rid=self.rid[i],
+            rid=self.rid[logical_index],
             session_id=self.session_id,
             text=self.text[i] if self.text is not None else None,
             input_ids=self.input_ids[i] if self.input_ids is not None else None,
@@ -813,6 +823,8 @@ class GenerateReqInput:
             disagg_prefill_dp_rank=self.disagg_prefill_dp_rank,
             conversation_id=self.conversation_id,
             http_worker_ipc=self.http_worker_ipc,
+            require_reasoning=self.require_reasoning,
+            max_thinking_tokens=self.max_thinking_tokens,
             priority=self.priority,
             extra_key=self.extra_key[i] if self.extra_key is not None else None,
             no_logs=self.no_logs,

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1120,6 +1120,10 @@ class Req(ReqDllmMixin):
         self.skip_radix_cache_insert = bootstrap_host == FAKE_BOOTSTRAP_HOST
         self.disagg_kv_sender: Optional[BaseKVSender] = None
 
+        # State owned by the layer-pipelined prefill transfer adapter.
+        self.ready_for_pipelined_transfer_finalize = False
+        self.non_pipelined_state_indices: Optional[List] = None
+
         self.routed_dp_rank: Optional[int] = routed_dp_rank
         self.disagg_prefill_dp_rank: Optional[int] = disagg_prefill_dp_rank
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -73,6 +73,9 @@ from sglang.srt.disaggregation.decode_kvcache_offload_manager import (
     DecodeKVCacheOffloadManager,
 )
 from sglang.srt.disaggregation.encode_receiver import create_mm_receiver
+from sglang.srt.disaggregation.pipelined_kv_transfer import (
+    LayerPipelinedKVTransferAdapter,
+)
 from sglang.srt.disaggregation.prefill import (
     PrefillBootstrapQueue,
     SchedulerDisaggregationPrefillMixin,
@@ -598,6 +601,7 @@ class Scheduler(
 
         # Init prefill-decodedisaggregation
         self.init_disaggregation()
+        self.maybe_init_layer_pipelined_kv_transfer()
 
         # Init overlap schedule
         self.init_overlap()
@@ -1407,6 +1411,26 @@ class Scheduler(
                 tp_group=self.tp_group,
                 scheduler=self,
             )
+
+    def maybe_init_layer_pipelined_kv_transfer(self) -> None:
+        self.layer_pipelined_kv_transfer = None
+        if self.disaggregation_mode != DisaggregationMode.PREFILL:
+            return
+
+        self.layer_pipelined_kv_transfer = LayerPipelinedKVTransferAdapter(
+            server_args=self.server_args,
+            ps=self.ps,
+            model_config=self.model_config,
+            tp_worker=self.tp_worker,
+            model_worker=self.model_worker,
+            req_to_token_pool=self.req_to_token_pool,
+            token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
+            kv_manager=self.disagg_prefill_bootstrap_queue.kv_manager,
+            metadata_buffers=self.disagg_metadata_buffers,
+            transfer_backend=self.transfer_backend,
+            sliding_window_size=self.sliding_window_size,
+            enable_staging=self.enable_staging,
+        )
 
     def init_overlap(self):
         self.device_module = torch.get_device_module(self.device)
@@ -3553,6 +3577,12 @@ class Scheduler(
             for req in batch.reqs:
                 self.maybe_send_cached_prefix_chunk(req)
 
+        layer_pipelined_plan = (
+            self.layer_pipelined_kv_transfer.plan_batch(batch)
+            if self.is_generation and self.layer_pipelined_kv_transfer is not None
+            else None
+        )
+
         # Run forward
         if self.is_generation:
             if self.enable_overlap:
@@ -3591,9 +3621,17 @@ class Scheduler(
                                 )
 
                         # FIXME: pp is not compatible with overlap
-                        batch_result = self.model_worker.forward_batch_generation(
-                            batch, **fwd_kwargs
-                        )
+                        if layer_pipelined_plan is not None:
+                            batch_result = self.layer_pipelined_kv_transfer.run_batch(
+                                batch,
+                                layer_pipelined_plan,
+                                defer_sample=True,
+                                on_publish=fwd_kwargs.get("on_publish"),
+                            )
+                        else:
+                            batch_result = self.model_worker.forward_batch_generation(
+                                batch, **fwd_kwargs
+                            )
                         if batch.spec_algorithm.is_none():
                             self.future_map.publish(future_indices, batch.seq_lens + 1)
                         # Park any refs the worker wants kept alive 2 iters
@@ -3660,7 +3698,12 @@ class Scheduler(
                 # future_map relay / on_publish).
                 resolve_forward_inputs(batch, self.future_map)
                 with self._forward_isolation(batch, overlap=False):
-                    batch_result = self.model_worker.forward_batch_generation(batch)
+                    if layer_pipelined_plan is not None:
+                        batch_result = self.layer_pipelined_kv_transfer.run_batch(
+                            batch, layer_pipelined_plan
+                        )
+                    else:
+                        batch_result = self.model_worker.forward_batch_generation(batch)
                 # The isolation restore reverted the worker's in-forward SB edits;
                 # re-apply what must carry to the next iter.
                 batch.spec_info = batch_result.next_draft_input
@@ -3684,9 +3727,14 @@ class Scheduler(
                     else {}
                 )
                 resolve_forward_inputs(batch, self.future_map)
-                batch_result = self.model_worker.forward_batch_generation(
-                    batch, **kwargs
-                )
+                if layer_pipelined_plan is not None:
+                    batch_result = self.layer_pipelined_kv_transfer.run_batch(
+                        batch, layer_pipelined_plan
+                    )
+                else:
+                    batch_result = self.model_worker.forward_batch_generation(
+                        batch, **kwargs
+                    )
                 if batch_result.has_sampled_token_ids:
                     # Non-spec: relay via future_map, gathered next iter.
                     self._relay_forward_payload(batch.req_pool_indices, batch_result)

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -195,6 +195,10 @@ _INCREMENTAL_STREAMING_META_INFO_KEYS = (
 )
 
 
+class RequestAbortedError(ValueError):
+    status_code = 499
+
+
 @dataclasses.dataclass
 class ReqState:
     """Store the state a request."""
@@ -206,6 +210,9 @@ class ReqState:
 
     # For performance metrics
     time_stats: APIServerReqTimeStats
+    abort_requested: bool = False
+    lifecycle_id: object = dataclasses.field(default_factory=object)
+    dispatched: bool = False
     last_completion_tokens: int = 1
     ttft_observed: bool = False
 
@@ -545,6 +552,10 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
     def init_running_status(self):
         # Request states
         self.rid_to_state: Dict[str, ReqState] = {}
+        # Parallel sampling keeps one caller-visible logical RID per original
+        # prompt while the scheduler operates on separate prefix/sample RIDs.
+        self.logical_rid_to_child_rids: Dict[str, set[str]] = {}
+        self.child_rid_to_logical_rid: Dict[str, str] = {}
         self.event_loop = None
         self.asyncio_tasks = set()
 
@@ -740,6 +751,15 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         # Normalize the request
         obj.normalize_batch_and_arguments()
         self._set_default_priority(obj)
+        if (
+            isinstance(obj, GenerateReqInput)
+            and obj.max_thinking_tokens is not None
+            and not self.server_args.enable_strict_thinking
+        ):
+            raise ValueError(
+                "max_thinking_tokens requires the server to be launched with "
+                "--enable-strict-thinking"
+            )
 
         if isinstance(obj, GenerateReqInput) and obj.routed_dp_rank is not None:
             dp_size = self.elastic_worker_count
@@ -752,7 +772,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                     f"routed_dp_rank={obj.routed_dp_rank} out of range [0, {dp_size})"
                 )
 
-        self._init_req_state(obj, request)
+        request_lifecycles = self._init_req_state(obj, request)
         try:
             if self.server_args.language_only:
                 self._handle_epd_disaggregation_encode_request(obj)
@@ -762,13 +782,16 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
 
             async with self.is_pause_cond:
                 await self.is_pause_cond.wait_for(lambda: not self.is_pause)
+            self._raise_if_logical_request_aborted(obj)
 
             async with self.model_update_lock.reader_lock:
                 await self._validate_and_resolve_lora(obj)
+                self._raise_if_logical_request_aborted(obj)
 
                 # Tokenize the request and send it to the scheduler
                 if obj.is_single:
                     tokenized_obj = await self._tokenize_one_request(obj)
+                    self._raise_if_logical_rid_aborted(obj.rid)
                     state = self.rid_to_state[obj.rid]
                     if obj.return_prompt_token_ids:
                         state.prompt_token_ids = list(tokenized_obj.input_ids)
@@ -778,7 +801,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 else:
                     async for response in self._handle_batch_request(obj, request):
                         yield response
-        except Exception:
+        except BaseException:
             # _init_req_state created a rid_to_state entry per (sub-)request up
             # front. The normal remover is the scheduler-response path
             # (_handle_batch_output), so a failure *before* a request reaches the
@@ -786,7 +809,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             # request -- would otherwise leak those entries forever. Drop any that
             # are still pending; entries already removed on the normal completion
             # path are left untouched (pop is a no-op).
-            self._discard_pending_req_states(obj)
+            self._discard_pending_req_states(obj, request_lifecycles)
             raise
 
     def _detect_input_format(
@@ -1308,6 +1331,11 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             sampling_kwargs = {**self.preferred_sampling_params, **obj.sampling_params}
         else:
             sampling_kwargs = obj.sampling_params
+        if isinstance(obj, GenerateReqInput) and obj.max_thinking_tokens is not None:
+            sampling_kwargs = dict(sampling_kwargs)
+            custom_params = dict(sampling_kwargs.get("custom_params") or {})
+            custom_params["thinking_budget"] = obj.max_thinking_tokens
+            sampling_kwargs["custom_params"] = custom_params
         sampling_params = self.sampling_params_class(**sampling_kwargs)
         sampling_params.normalize(self.tokenizer)
         sampling_params.verify(self.model_config.vocab_size)
@@ -1518,6 +1546,9 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         time_stats = tokenized_obj.time_stats
         tokenized_obj.wrap_pickle_fields()
         self._dispatch_to_scheduler(tokenized_obj)
+        state = self.rid_to_state.get(tokenized_obj.rid)
+        if state is not None:
+            state.dispatched = True
         tokenized_obj.time_stats = time_stats
         tokenized_obj.time_stats.set_api_server_dispatch_finish_time()
 
@@ -1539,6 +1570,10 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             batch_req = BatchTokenizedEmbeddingReqInput(batch=tokenized_objs)
 
         self._dispatch_to_scheduler(batch_req)
+        for tokenized_obj in tokenized_objs:
+            state = self.rid_to_state.get(tokenized_obj.rid)
+            if state is not None:
+                state.dispatched = True
         for tokenized_obj, time_stat in zip(tokenized_objs, time_stats):
             tokenized_obj.time_stats = time_stat
         set_time_batch(tokenized_objs, "set_api_server_dispatch_finish_time")
@@ -1610,7 +1645,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             # Delete the key to prevent resending abort request to the scheduler and
             # to ensure aborted request state is cleaned up.
             if state.obj.rid in self.rid_to_state:
-                del self.rid_to_state[state.obj.rid]
+                self._remove_req_state(state.obj.rid)
 
             # Mark ongoing LoRA request as finished.
             if self.enable_lora and state.obj.lora_path:
@@ -1744,6 +1779,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         if getattr(obj, "parallel_sample_num", 1) == 1:
             if self._should_use_batch_tokenization(batch_size, obj):
                 tokenized_objs = await self._batch_tokenize_and_process(batch_size, obj)
+                self._raise_if_logical_request_aborted(obj)
                 self._send_batch_request(tokenized_objs)
 
                 # Set up generators for each request in the batch
@@ -1766,6 +1802,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                     for i in range(batch_size):
                         tmp_obj = obj[i]
                         tokenized_obj = await self._tokenize_one_request(tmp_obj)
+                        self._raise_if_logical_rid_aborted(tmp_obj.rid)
                         state = self.rid_to_state[tmp_obj.rid]
                         if tmp_obj.return_prompt_token_ids:
                             state.prompt_token_ids = list(tokenized_obj.input_ids)
@@ -1786,9 +1823,12 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             tokenized_objs = await asyncio.gather(
                 *(self._tokenize_one_request(obj) for obj in objs)
             )
+            self._raise_if_logical_request_aborted(obj)
 
             # Cache the common prefix for parallel sampling
             for i in range(batch_size):
+                logical_rid = objs[i].rid
+                self._raise_if_logical_rid_aborted(logical_rid)
                 tmp_obj = copy.copy(objs[i])
                 tokenized_obj = copy.copy(tokenized_objs[i])
                 # Ensure independent mm_items so wrap_shm_features won't mutate the original
@@ -1797,17 +1837,20 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                     tokenized_obj.mm_inputs.mm_items = [
                         copy.copy(item) for item in tokenized_obj.mm_inputs.mm_items
                     ]
-                tokenized_obj.rid = tmp_obj.regenerate_rid()
+                tokenized_obj.rid = tmp_obj.regenerate_rid(prefix=logical_rid)
                 tokenized_obj.sampling_params = copy.copy(tokenized_obj.sampling_params)
                 tokenized_obj.sampling_params.max_new_tokens = 0
                 tokenized_obj.stream = False
-                self._init_req_state(tmp_obj)
+                self._init_child_req_state(logical_rid, tmp_obj)
                 self._send_one_request(tokenized_obj)
                 await self._wait_one_response(tmp_obj, request).__anext__()
+                self._raise_if_logical_rid_aborted(logical_rid)
 
             # Expand requests, assign new rids for them, and send them
             for i in range(batch_size):
+                logical_rid = objs[i].rid
                 for _ in range(obj.parallel_sample_num):
+                    self._raise_if_logical_rid_aborted(logical_rid)
                     tmp_obj = copy.copy(objs[i])
                     tokenized_obj = copy.copy(tokenized_objs[i])
                     # Ensure independent mm_items so wrap_shm_features won't mutate the original
@@ -1816,8 +1859,8 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                         tokenized_obj.mm_inputs.mm_items = [
                             copy.copy(item) for item in tokenized_obj.mm_inputs.mm_items
                         ]
-                    tokenized_obj.rid = tmp_obj.regenerate_rid()
-                    self._init_req_state(tmp_obj)
+                    tokenized_obj.rid = tmp_obj.regenerate_rid(prefix=logical_rid)
+                    self._init_child_req_state(logical_rid, tmp_obj)
                     state = self.rid_to_state[tmp_obj.rid]
                     tokenized_obj.time_stats = state.time_stats
                     if tmp_obj.return_prompt_token_ids:
@@ -1826,17 +1869,38 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                     generators.append(self._wait_one_response(tmp_obj, request))
                     rids.append(tmp_obj.rid)
 
-                self.rid_to_state[objs[i].rid].time_stats.set_finished_time()
-                del self.rid_to_state[objs[i].rid]
+                parent_state = self.rid_to_state.get(logical_rid)
+                if parent_state is not None:
+                    parent_state.time_stats.set_finished_time()
+                self._remove_req_state(logical_rid)
 
         # Wait for all requests
         is_stream = hasattr(obj, "stream") and obj.stream
         if not is_stream:
-            outputs = await asyncio.gather(*(gen.__anext__() for gen in generators))
+            outputs = await self._collect_batch_responses(generators)
             yield outputs
         else:
-            rid_to_index = {rid: i for i, rid in enumerate(rids)}
-            task_map = {asyncio.create_task(gen.__anext__()): gen for gen in generators}
+            async for response in self._stream_batch_responses(generators, rids):
+                yield response
+
+    async def _collect_batch_responses(self, generators):
+        tasks = [asyncio.create_task(gen.__anext__()) for gen in generators]
+        try:
+            return await asyncio.gather(*tasks)
+        finally:
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+            await asyncio.gather(
+                *(gen.aclose() for gen in generators),
+                return_exceptions=True,
+            )
+
+    async def _stream_batch_responses(self, generators, rids):
+        rid_to_index = {rid: i for i, rid in enumerate(rids)}
+        task_map = {asyncio.create_task(gen.__anext__()): gen for gen in generators}
+        try:
             while task_map:
                 done, _ = await asyncio.wait(
                     task_map.keys(), return_when=asyncio.FIRST_COMPLETED
@@ -1852,20 +1916,55 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                         task_map[new_task] = gen
                     except StopAsyncIteration:
                         pass
+        finally:
+            pending_tasks = list(task_map)
+            for task in pending_tasks:
+                task.cancel()
+            if pending_tasks:
+                await asyncio.gather(*pending_tasks, return_exceptions=True)
+            await asyncio.gather(
+                *(gen.aclose() for gen in generators),
+                return_exceptions=True,
+            )
 
     def abort_request(self, rid: str = "", abort_all: bool = False):
         # Empty rid would startswith-match every request on the scheduler.
         if not abort_all and not rid:
             logger.warning("Ignore abort_request with empty rid and abort_all=False")
             return
-        if (
-            not abort_all
-            and self.server_args.tokenizer_worker_num == 1
-            and rid not in self.rid_to_state
-        ):
+        if abort_all:
+            for state_rid, state in self.rid_to_state.items():
+                if state_rid not in self.child_rid_to_logical_rid:
+                    state.abort_requested = True
+            target_rids = (rid,)
+        elif rid in self.child_rid_to_logical_rid:
+            # Preserve direct child aborts for internal callers.
+            target_rids = (rid,)
+        elif rid in self.rid_to_state:
+            state = self.rid_to_state[rid]
+            state.abort_requested = True
+            parallel_sample_num = getattr(state.obj, "parallel_sample_num", None)
+            if parallel_sample_num is None:
+                sampling_params = getattr(state.obj, "sampling_params", None)
+                parallel_sample_num = (
+                    sampling_params.get("n", 1)
+                    if isinstance(sampling_params, dict)
+                    else 1
+                )
+            if parallel_sample_num > 1:
+                # Snapshot because scheduler abort echoes remove child ownership.
+                target_rids = tuple(sorted(self.logical_rid_to_child_rids.get(rid, ())))
+            else:
+                target_rids = (rid,)
+        elif child_rids := self.logical_rid_to_child_rids.get(rid):
+            target_rids = tuple(sorted(child_rids))
+        elif self.server_args.tokenizer_worker_num == 1:
             return
-        req = AbortReq(rid=rid, abort_all=abort_all)
-        self._dispatch_to_scheduler(req)
+        else:
+            target_rids = (rid,)
+
+        for target_rid in target_rids:
+            self._dispatch_to_scheduler(AbortReq(rid=target_rid, abort_all=abort_all))
         if self.enable_metrics:
             # TODO: also use custom_labels from the request
             self.metrics_collector.observe_one_aborted_request(
@@ -2352,7 +2451,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                         )
                     )
 
-                del self.rid_to_state[rid]
+                self._remove_req_state(rid)
 
                 # Mark ongoing LoRA request as finished.
                 if self.enable_lora and state.obj.lora_path:
@@ -3088,7 +3187,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             "output_ids": output_ids,
             "meta_info": meta_info,
         }
-        del self.rid_to_state[recv_obj.rid]
+        self._remove_req_state(recv_obj.rid)
 
         state.out_list.append(out)
         state.event.set()
@@ -3244,11 +3343,80 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 obj.lora_id[i] if isinstance(obj.lora_id, list) else obj.lora_id
             )
 
+    @staticmethod
+    def _logical_rids(obj) -> List[str]:
+        if not hasattr(obj, "is_single") or obj.is_single:
+            return [obj.rid]
+        return list(obj.rid)
+
+    def _register_child_rid(self, logical_rid: str, child_rid: str) -> None:
+        if child_rid == logical_rid:
+            raise ValueError(
+                "Parallel-sampling child RID must differ from its logical RID"
+            )
+        owner = self.child_rid_to_logical_rid.get(child_rid)
+        if owner is not None and owner != logical_rid:
+            raise ValueError(
+                f"Request ID {child_rid} is already owned by logical request {owner}"
+            )
+        self.child_rid_to_logical_rid[child_rid] = logical_rid
+        self.logical_rid_to_child_rids.setdefault(logical_rid, set()).add(child_rid)
+
+    def _init_child_req_state(
+        self,
+        logical_rid: str,
+        obj: Union[GenerateReqInput, EmbeddingReqInput],
+        request: Optional[fastapi.Request] = None,
+    ) -> None:
+        self._raise_if_logical_rid_aborted(logical_rid)
+        logical_state = self.rid_to_state[logical_rid]
+        self._init_req_state(
+            obj,
+            request,
+            lifecycle_id=logical_state.lifecycle_id,
+        )
+        try:
+            self._register_child_rid(logical_rid, obj.rid)
+        except BaseException:
+            self._remove_req_state(obj.rid)
+            raise
+
+    def _remove_req_state(
+        self,
+        rid: str,
+        lifecycle_id: Optional[object] = None,
+    ) -> Optional[ReqState]:
+        """Remove a request state and its parallel-sampling ownership."""
+        state = self.rid_to_state.get(rid)
+        if state is None or (
+            lifecycle_id is not None and state.lifecycle_id is not lifecycle_id
+        ):
+            return None
+        self.rid_to_state.pop(rid)
+        logical_rid = self.child_rid_to_logical_rid.pop(rid, None)
+        if logical_rid is not None:
+            children = self.logical_rid_to_child_rids.get(logical_rid)
+            if children is not None:
+                children.discard(rid)
+                if not children:
+                    self.logical_rid_to_child_rids.pop(logical_rid, None)
+        return state
+
+    def _raise_if_logical_rid_aborted(self, logical_rid: str) -> None:
+        state = self.rid_to_state.get(logical_rid)
+        if state is None or state.abort_requested:
+            raise RequestAbortedError(f"Request {logical_rid} was aborted")
+
+    def _raise_if_logical_request_aborted(self, obj) -> None:
+        for logical_rid in self._logical_rids(obj):
+            self._raise_if_logical_rid_aborted(logical_rid)
+
     def _init_req_state(
         self,
         obj: Union[GenerateReqInput, EmbeddingReqInput],
         request: Optional[fastapi.Request] = None,
-    ):
+        lifecycle_id: Optional[object] = None,
+    ) -> Dict[str, object]:
         created_time = obj.received_time
 
         external_trace_header = None
@@ -3279,29 +3447,90 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 for i in range(len(obj.rid))
             ]
 
-        for rid, sub_obj, bootstrap_room in items:
-            if rid in self.rid_to_state:
+        rids = [rid for rid, _, _ in items]
+        seen_rids = set()
+        for rid in rids:
+            if rid in seen_rids:
                 raise ValueError(f"Duplicate request ID detected: {rid}")
+            seen_rids.add(rid)
+            if (
+                rid in self.rid_to_state
+                or rid in self.logical_rid_to_child_rids
+                or rid in self.child_rid_to_logical_rid
+            ):
+                raise ValueError(f"Duplicate request ID detected: {rid}")
+
+        # Mutate only after every RID passes duplicate validation so a rejected
+        # batch cannot leave a partial rid_to_state insertion behind.
+        lifecycle_ids = {}
+        for rid, sub_obj, bootstrap_room in items:
             time_stats = APIServerReqTimeStats(disagg_mode=self.disaggregation_mode)
-            state = ReqState([], False, asyncio.Event(), sub_obj, time_stats)
+            state = ReqState(
+                [],
+                False,
+                asyncio.Event(),
+                sub_obj,
+                time_stats,
+                lifecycle_id=lifecycle_id if lifecycle_id is not None else object(),
+            )
             self.rid_to_state[rid] = state
+            lifecycle_ids[rid] = state.lifecycle_id
             if self.enable_trace:
                 time_stats.init_trace_ctx(rid, bootstrap_room, external_trace_header)
             time_stats.set_created_time(created_time)
+        return lifecycle_ids
 
-    def _discard_pending_req_states(self, obj):
-        """Drop rid_to_state entries created by _init_req_state for *obj*.
+    def _discard_pending_req_states(
+        self,
+        obj,
+        lifecycle_ids: Optional[Dict[str, object]] = None,
+    ):
+        """Drop all logical and child state owned by *obj*.
 
-        Safe to call after a partial/failed dispatch: only entries still present
-        are removed, and the scheduler-response path looks up state with
-        ``.get(...)`` so a later output for a discarded rid is ignored, not fatal.
+        Safe to call after a partial/failed dispatch: only requests known to have
+        reached the scheduler are aborted, all owned state is removed, and a later
+        output for a discarded RID is ignored by the scheduler-response path.
         """
-        if not hasattr(obj, "is_single") or obj.is_single:
-            rids = [obj.rid]
-        else:
-            rids = obj.rid
-        for rid in rids:
-            self.rid_to_state.pop(rid, None)
+        if lifecycle_ids is None:
+            lifecycle_ids = {
+                logical_rid: state.lifecycle_id
+                for logical_rid in self._logical_rids(obj)
+                if (state := self.rid_to_state.get(logical_rid)) is not None
+            }
+        for logical_rid in self._logical_rids(obj):
+            lifecycle_id = lifecycle_ids.get(logical_rid)
+            if lifecycle_id is None:
+                continue
+            child_rids = tuple(
+                child_rid
+                for child_rid in self.logical_rid_to_child_rids.get(logical_rid, ())
+                if (
+                    (state := self.rid_to_state.get(child_rid)) is not None
+                    and state.lifecycle_id is lifecycle_id
+                )
+            )
+            logical_state = self.rid_to_state.get(logical_rid)
+            owns_logical_state = (
+                logical_state is not None and logical_state.lifecycle_id is lifecycle_id
+            )
+            target_rids = tuple(
+                rid for rid in child_rids if self.rid_to_state[rid].dispatched
+            )
+            if not child_rids and owns_logical_state and logical_state.dispatched:
+                target_rids = (logical_rid,)
+            for target_rid in target_rids:
+                try:
+                    self._dispatch_to_scheduler(
+                        AbortReq(rid=target_rid, abort_all=False)
+                    )
+                except Exception:
+                    logger.exception(
+                        "Failed to abort request rid=%s",
+                        target_rid,
+                    )
+            for child_rid in child_rids:
+                self._remove_req_state(child_rid, lifecycle_id)
+            self._remove_req_state(logical_rid, lifecycle_id)
 
     def _should_dispatch_to_encoder(
         self, obj: Union[GenerateReqInput, EmbeddingReqInput]

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -44,6 +44,7 @@ from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
 from sglang.srt.model_executor.forward_batch_info import (
     CaptureHiddenMode,
     ForwardBatch,
+    ForwardMode,
     PPProxyTensors,
 )
 from sglang.srt.model_executor.graph_memory_usage import (
@@ -656,6 +657,88 @@ class TpModelWorker(BaseTpWorker):
                 can_run_cuda_graph=can_run_cuda_graph,
                 expert_distribution_metrics=out.expert_distribution_metrics,
             )
+
+    def forward_batch_generation_split_prefill_init(
+        self,
+        batch: ScheduleBatch,
+        capture_hidden_mode: Optional[CaptureHiddenMode] = None,
+    ) -> ForwardBatch:
+        """Initialize a ForwardBatch for layer-pipelined split prefill."""
+        forward_batch = ForwardBatch.init_new(
+            batch,
+            self.model_runner,
+            capture_hidden_mode=capture_hidden_mode,
+            return_hidden_states_before_norm=False,
+        )
+        forward_batch.forward_mode = ForwardMode.SPLIT_PREFILL
+        forward_batch.split_index = 0
+        return forward_batch
+
+    def forward_batch_generation_split_prefill(
+        self,
+        forward_batch: ForwardBatch,
+        forward_count: int = 1,
+    ) -> tuple:
+        """Run one split-prefill layer group and return its ready event."""
+        out = self.model_runner.forward(
+            forward_batch,
+            reinit_attn_backend=(forward_batch.split_index == 0),
+            split_forward_count=forward_count,
+        )
+        event = torch.cuda.Event()
+        event.record()
+        return out.logits_output, event
+
+    def forward_batch_generation_split_prefill_finalize(
+        self,
+        batch: ScheduleBatch,
+        logits_output,
+        forward_batch: ForwardBatch,
+        defer_sample: bool = False,
+        on_publish=None,
+    ) -> GenerationBatchResult:
+        """Finalize layer-pipelined split prefill and sample next tokens."""
+        if batch.return_logprob:
+            extend_input_len_per_req = [
+                req.extend_range.length if req.extend_range is not None else 0
+                for req in batch.reqs
+            ]
+            extend_logprob_start_len_per_req = batch.extend_logprob_start_lens
+        else:
+            extend_input_len_per_req = None
+            extend_logprob_start_len_per_req = None
+
+        result = GenerationBatchResult(
+            logits_output=logits_output,
+            extend_input_len_per_req=extend_input_len_per_req,
+            extend_logprob_start_len_per_req=extend_logprob_start_len_per_req,
+            can_run_cuda_graph=False,
+        )
+        if not forward_batch.is_prefill_only:
+
+            def sample_batch():
+                result.next_token_ids = self.model_runner.sample(
+                    logits_output, forward_batch
+                )
+                return result
+
+            if defer_sample and forward_batch.sampling_info.grammars is not None:
+                result.delay_sample_func = sample_batch
+            else:
+                sample_batch()
+        else:
+            result.next_token_ids = torch.zeros(
+                len(forward_batch.seq_lens),
+                dtype=torch.long,
+                device=forward_batch.input_ids.device,
+            )
+            if (
+                forward_batch.return_logprob
+                and logits_output.next_token_logits is not None
+            ):
+                self.model_runner.compute_logprobs_only(logits_output, forward_batch)
+
+        return result
 
     def forward_batch_split_prefill(self, batch: ScheduleBatch):
         if batch.split_index == 0:

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -47,6 +47,7 @@ from sglang.srt.model_executor.forward_batch_info import (
     ForwardMode,
     PPProxyTensors,
 )
+from sglang.srt.layers.cp.utils import is_cp_v2_active, prepare_cp_forward
 from sglang.srt.model_executor.graph_memory_usage import (
     merge_graph_memory_usage,
     merge_graph_time_usage,
@@ -672,6 +673,8 @@ class TpModelWorker(BaseTpWorker):
         )
         forward_batch.forward_mode = ForwardMode.SPLIT_PREFILL
         forward_batch.split_index = 0
+        if is_cp_v2_active(forward_batch):
+            prepare_cp_forward(forward_batch)
         return forward_batch
 
     def forward_batch_generation_split_prefill(

--- a/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from contextlib import nullcontext
-from typing import List, Literal, NamedTuple, Optional, Tuple
+from typing import Dict, List, Literal, NamedTuple, Optional, Tuple
 
 import torch
 
@@ -17,6 +17,11 @@ from sglang.kernels.ops.attention.dsv4 import (
 )
 from sglang.kernels.ops.attention.dsv4.index_buf_accessor import NopeFp8RopeBf16Pack
 from sglang.srt.constants import GPU_MEMORY_TYPE_KV_CACHE
+from sglang.srt.disaggregation.base.conn import (
+    BufferType,
+    LayerBufferHandles,
+    StateType,
+)
 from sglang.srt.environ import envs
 from sglang.srt.mem_cache.base_swa_memory_pool import BaseSWAKVPool
 from sglang.srt.mem_cache.deepseek_v4_compress_state import CompressStatePool
@@ -720,6 +725,83 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
                 item_lens.append(buf[0].nbytes)
 
         return data_ptrs, data_lens, item_lens
+
+    def get_buffer_handles_by_layer(
+        self,
+        kv_buffer_offset: int = 0,
+        state_component_ids: Optional[Dict[StateType, int]] = None,
+        state_buffer_offsets: Optional[Dict[StateType, int]] = None,
+    ) -> Dict[int, LayerBufferHandles]:
+        state_component_ids = state_component_ids or {}
+        state_buffer_offsets = state_buffer_offsets or {}
+        swa_state_type = StateType.SWA_RING if self._unified_kv else StateType.SWA
+        swa_component_id = state_component_ids.get(swa_state_type)
+        c4_layer_count = len(self.c4_indexer_kv_pool.index_k_with_scale_buffer)
+        handles_by_layer = {}
+        for layer_id in range(self._stage_start, self._stage_end):
+            layer_item = self.layer_mapping[layer_id]
+            buffer_types = [BufferType.STATE]
+            raw_indices = [
+                state_buffer_offsets.get(swa_state_type, 0)
+                + layer_id
+                - self._stage_start
+            ]
+            component_ids = [swa_component_id]
+
+            if layer_item.compress_ratio == 4:
+                c4_index = layer_item.compress_layer_id
+                state_offset = (
+                    0 if self._unified_kv else self._stage_end - self._stage_start
+                )
+                c4_state_indices = [
+                    state_offset + c4_index,
+                    state_offset + c4_layer_count + c4_index,
+                ]
+                buffer_types = [
+                    BufferType.KV,
+                    BufferType.KV,
+                    BufferType.STATE,
+                    BufferType.STATE,
+                    BufferType.STATE,
+                ]
+                raw_indices = [
+                    kv_buffer_offset + c4_index,
+                    kv_buffer_offset + c4_layer_count + c4_index,
+                    *[
+                        state_buffer_offsets.get(StateType.SWA, 0) + index
+                        for index in c4_state_indices
+                    ],
+                    state_buffer_offsets.get(swa_state_type, 0)
+                    + layer_id
+                    - self._stage_start,
+                ]
+                component_ids = [
+                    None,
+                    None,
+                    state_component_ids.get(StateType.SWA),
+                    state_component_ids.get(StateType.SWA),
+                    swa_component_id,
+                ]
+            elif layer_item.compress_ratio == 128:
+                c128_index = layer_item.compress_layer_id
+                buffer_types = [BufferType.KV, BufferType.STATE, BufferType.STATE]
+                raw_indices = [
+                    kv_buffer_offset + 2 * c4_layer_count + c128_index,
+                    state_buffer_offsets.get(StateType.C128_STATE, 0) + c128_index,
+                    state_buffer_offsets.get(swa_state_type, 0)
+                    + layer_id
+                    - self._stage_start,
+                ]
+                component_ids = [
+                    None,
+                    state_component_ids.get(StateType.C128_STATE),
+                    swa_component_id,
+                ]
+
+            handles_by_layer[layer_id] = LayerBufferHandles(
+                buffer_types, raw_indices, component_ids
+            )
+        return handles_by_layer
 
     def get_unified_swa_ring_buf_infos(self) -> Tuple[List[int], List[int], List[int]]:
         """SWA-ring region [0, swa_pages) of every unified_kv layer, addressed

--- a/python/sglang/srt/mem_cache/dsa_cache_layer_split.py
+++ b/python/sglang/srt/mem_cache/dsa_cache_layer_split.py
@@ -31,11 +31,16 @@ from __future__ import annotations
 
 import logging
 from contextlib import nullcontext
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Dict, Optional
 
 import torch
 
 from sglang.kernels.ops.attention.dsa import index_buf_accessor
+from sglang.srt.disaggregation.base.conn import (
+    BufferType,
+    LayerBufferHandles,
+    StateType,
+)
 from sglang.srt.layers.cp.utils import get_layer_owner, get_layer_shard_range
 from sglang.srt.mem_cache.memory_pool import (
     GPU_MEMORY_TYPE_KV_CACHE,
@@ -257,6 +262,31 @@ class LayerSplitDSATokenToKVPool(DSATokenToKVPool):
             self.kv_buffer[i][0].nbytes * self.page_size for i in owned_layer_ids
         ]
         return kv_data_ptrs, kv_data_lens, kv_item_lens
+
+    def get_buffer_handles_by_layer(
+        self,
+        kv_buffer_offset: int = 0,
+        state_component_ids: Optional[Dict[StateType, int]] = None,
+        state_buffer_offsets: Optional[Dict[StateType, int]] = None,
+    ) -> Dict[int, LayerBufferHandles]:
+        owned_start, _ = self._owned_local_layer_range()
+        state_offset = (state_buffer_offsets or {}).get(StateType.DSA, 0)
+        component_id = (state_component_ids or {}).get(StateType.DSA)
+        handles_by_layer = {}
+        for local_layer_idx in range(self.layer_num):
+            layer_id = self.start_layer + local_layer_idx
+            if not self._is_layer_owned(layer_id):
+                continue
+            buffer_index = local_layer_idx - owned_start
+            handles_by_layer[layer_id] = LayerBufferHandles(
+                buffer_types=[BufferType.KV, BufferType.STATE],
+                raw_data_ptrs_indices=[
+                    kv_buffer_offset + buffer_index,
+                    state_offset + buffer_index,
+                ],
+                state_component_ids=[None, component_id],
+            )
+        return handles_by_layer
 
     def get_key_buffer(self, layer_id: int):
         if self.layer_transfer_counter is not None:

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -270,6 +270,19 @@ class KVCacheConfigurator:
             unified_memory_pool=pools.unified_memory_pool,
         )
 
+    # Note(kpham-sgl):
+    # 1. A replicated draft indexes the allocator's virtual locs raw, so its pools
+    #    span and page that space; the sharded target translates and stays per-rank.
+    # 2. A pool must page as its allocator does, or its last page falls short.
+    @property
+    def loc_space_scale(self) -> int:
+        dcp_size = self.server_args.dcp_size
+        return dcp_size if (self.is_draft_worker and dcp_size > 1) else 1
+
+    @property
+    def pool_page_size(self) -> int:
+        return get_schedule().page_size * self.loc_space_scale
+
     def _derive_pool_sizes(self, *, config: MemoryPoolConfig) -> _PoolSizes:
         max_total_num_tokens = config.max_total_num_tokens
         max_running_requests = config.max_running_requests
@@ -281,13 +294,12 @@ class KVCacheConfigurator:
 
         # Draft pools are replicated, not DCP-sharded, yet consume the shared
         # allocator's virtual locs in [0, max_total * dcp_size) untranslated.
-        dcp_size = self.server_args.dcp_size
-        if self.is_draft_worker and dcp_size > 1:
-            max_total_num_tokens *= dcp_size
-            if full_max_total_num_tokens is not None:
-                full_max_total_num_tokens *= dcp_size
-            if swa_max_total_num_tokens is not None:
-                swa_max_total_num_tokens *= dcp_size
+        loc_scale = self.loc_space_scale
+        max_total_num_tokens *= loc_scale
+        if full_max_total_num_tokens is not None:
+            full_max_total_num_tokens *= loc_scale
+        if swa_max_total_num_tokens is not None:
+            swa_max_total_num_tokens *= loc_scale
 
         # DSV4 compressed-attention pool sizes. Draft worker reuses target's
         # full/swa sizes but does NOT own c4/c128/state pools (those live on
@@ -1000,7 +1012,7 @@ class KVCacheConfigurator:
             c128_size=c128_max_total_num_tokens,
             c4_state_pool_size=c4_state_pool_size,
             c128_state_pool_size=c128_state_pool_size,
-            page_size=get_schedule().page_size,
+            page_size=self.pool_page_size,
             swa_page_size=swa_page_size,
             sliding_window=self.model_config.window_size,
             dtype=self.kv_cache_dtype,
@@ -1026,7 +1038,7 @@ class KVCacheConfigurator:
         PoolCls = current_platform.get_dsa_kv_pool_cls()
         token_to_kv_pool = PoolCls(
             max_total_num_tokens,
-            page_size=get_schedule().page_size,
+            page_size=self.pool_page_size,
             dtype=self.kv_cache_dtype,
             kv_lora_rank=self.model_config.kv_lora_rank,
             qk_rope_head_dim=self.model_config.qk_rope_head_dim,
@@ -1050,7 +1062,7 @@ class KVCacheConfigurator:
         PoolCls = current_platform.get_mla_kv_pool_cls()
         token_to_kv_pool = PoolCls(
             max_total_num_tokens,
-            page_size=get_schedule().page_size,
+            page_size=self.pool_page_size,
             dtype=self.kv_cache_dtype,
             kv_lora_rank=self.model_config.kv_lora_rank,
             qk_rope_head_dim=self.model_config.qk_rope_head_dim,
@@ -1067,7 +1079,7 @@ class KVCacheConfigurator:
         PoolCls = current_platform.get_mha_kv_pool_cls()
         token_to_kv_pool = PoolCls(
             max_total_num_tokens,
-            page_size=get_schedule().page_size,
+            page_size=self.pool_page_size,
             dtype=self.kv_cache_dtype,
             head_num=self.model_config.get_num_kv_heads(get_parallel().attn_tp_size),
             head_dim=self.model_config.head_dim,
@@ -1104,7 +1116,7 @@ class KVCacheConfigurator:
         token_to_kv_pool = SWAKVPool(
             size=full_max_total_num_tokens,
             size_swa=swa_max_total_num_tokens,
-            page_size=get_schedule().page_size,
+            page_size=self.pool_page_size,
             dtype=self.kv_cache_dtype,
             post_capture_active=self.post_capture_kv_active,
             head_num=self.model_config.get_num_kv_heads(get_parallel().attn_tp_size),
@@ -1126,7 +1138,7 @@ class KVCacheConfigurator:
 
         token_to_kv_pool = NPUMLATokenToKVPool(
             max_total_num_tokens,
-            page_size=get_schedule().page_size,
+            page_size=self.pool_page_size,
             dtype=self.kv_cache_dtype,
             kv_lora_rank=self.model_config.kv_lora_rank,
             qk_rope_head_dim=self.model_config.qk_rope_head_dim,
@@ -1146,7 +1158,7 @@ class KVCacheConfigurator:
 
         token_to_kv_pool = NPUMHATokenToKVPool(
             max_total_num_tokens,
-            page_size=get_schedule().page_size,
+            page_size=self.pool_page_size,
             dtype=self.kv_cache_dtype,
             head_num=self.model_config.get_num_kv_heads(get_parallel().attn_tp_size),
             head_dim=self.model_config.head_dim,
@@ -1186,7 +1198,7 @@ class KVCacheConfigurator:
             PoolCls = DSATokenToKVPool
         token_to_kv_pool = PoolCls(
             max_total_num_tokens,
-            page_size=get_schedule().page_size,
+            page_size=self.pool_page_size,
             dtype=self.kv_cache_dtype,
             kv_lora_rank=self.model_config.kv_lora_rank,
             qk_rope_head_dim=self.model_config.qk_rope_head_dim,
@@ -1208,7 +1220,7 @@ class KVCacheConfigurator:
     def _build_mla_fp4_kv_pool(self, *, max_total_num_tokens: int) -> KVCache:
         token_to_kv_pool = MLATokenToKVPoolFP4(
             max_total_num_tokens,
-            page_size=get_schedule().page_size,
+            page_size=self.pool_page_size,
             dtype=self.kv_cache_dtype,
             kv_lora_rank=self.model_config.kv_lora_rank,
             qk_rope_head_dim=self.model_config.qk_rope_head_dim,
@@ -1223,7 +1235,7 @@ class KVCacheConfigurator:
     def _build_mla_kv_pool(self, *, max_total_num_tokens: int) -> KVCache:
         token_to_kv_pool = MLATokenToKVPool(
             max_total_num_tokens,
-            page_size=get_schedule().page_size,
+            page_size=self.pool_page_size,
             dtype=self.kv_cache_dtype,
             kv_lora_rank=self.model_config.kv_lora_rank,
             qk_rope_head_dim=self.model_config.qk_rope_head_dim,
@@ -1286,7 +1298,7 @@ class KVCacheConfigurator:
         token_to_kv_pool = SWAKVPool(
             size=full_max_total_num_tokens,
             size_swa=size_swa,
-            page_size=get_schedule().page_size,
+            page_size=self.pool_page_size,
             dtype=self.kv_cache_dtype,
             post_capture_active=self.post_capture_kv_active,
             head_num=self.model_config.get_num_kv_heads(get_parallel().attn_tp_size),
@@ -1311,7 +1323,7 @@ class KVCacheConfigurator:
         )
         token_to_kv_pool = MiniMaxSparseKVPool(
             size=max_total_num_tokens,
-            page_size=get_schedule().page_size,
+            page_size=self.pool_page_size,
             dtype=self.kv_cache_dtype,
             # fp8 attn-GEMM mode opts the lightning-indexer cache into
             # fp8 too (fp8 indexer GEMMs); fp8 KV without the mode
@@ -1368,7 +1380,7 @@ class KVCacheConfigurator:
             else mha_pool_class
         )
         token_to_kv_pool = HybridLinearKVPool(
-            page_size=get_schedule().page_size,
+            page_size=self.pool_page_size,
             size=max_total_num_tokens,
             dtype=self.kv_cache_dtype,
             head_num=self.model_config.get_num_kv_heads(get_parallel().attn_tp_size),
@@ -1391,7 +1403,7 @@ class KVCacheConfigurator:
     def _build_mha_fp4_kv_pool(self, *, max_total_num_tokens: int) -> KVCache:
         token_to_kv_pool = MHATokenToKVPoolFP4(
             max_total_num_tokens,
-            page_size=get_schedule().page_size,
+            page_size=self.pool_page_size,
             dtype=self.kv_cache_dtype,
             head_num=self.model_config.get_num_kv_heads(get_parallel().attn_tp_size),
             head_dim=self.model_config.head_dim,
@@ -1424,7 +1436,7 @@ class KVCacheConfigurator:
             pool_kwargs["post_capture_active"] = self.post_capture_kv_active
         token_to_kv_pool = pool_cls(
             max_total_num_tokens,
-            page_size=get_schedule().page_size,
+            page_size=self.pool_page_size,
             dtype=self.kv_cache_dtype,
             head_num=self.model_config.get_num_kv_heads(get_parallel().attn_tp_size),
             head_dim=self.model_config.head_dim,

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -24,6 +24,7 @@ from sglang.srt.configs.model_config import (
     is_minimax_sparse,
 )
 from sglang.srt.distributed.parallel_state import get_world_group
+from sglang.srt.distributed.utils import get_pp_indices
 from sglang.srt.environ import envs
 from sglang.srt.layers.quantization.fp4_kv_cache_quant_method import (
     get_kv_cache_quant_method,
@@ -1817,6 +1818,27 @@ class KVCacheConfigurator:
         server_args = self.server_args
         assert config is not None
 
+        # mamba_cache_per_req covers every mamba layer, but under PP a rank only
+        # allocates its own [start_layer, end_layer) slice. Charge the largest
+        # per-stage share so every rank derives the same pool without a collective.
+        all_mamba_layers = config.mamba2_cache_params.layers
+        if self.ps.pp_size > 1 and all_mamba_layers:
+            max_stage_mamba_layers = max(
+                sum(1 for i in all_mamba_layers if start <= i < end)
+                for start, end in (
+                    get_pp_indices(
+                        self.model_config.num_hidden_layers, rank, self.ps.pp_size
+                    )
+                    for rank in range(self.ps.pp_size)
+                )
+            )
+        else:
+            max_stage_mamba_layers = len(all_mamba_layers)
+        pp_layer_scale = max_stage_mamba_layers / max(len(all_mamba_layers), 1)
+        stage_per_req = int(
+            config.mamba2_cache_params.mamba_cache_per_req * pp_layer_scale
+        )
+
         has_spec_dec = not self.spec_algorithm.is_none()
         # ReplaySSM drops the per-step intermediate_ssm scratch, so its mamba budget
         # no longer reserves the (1 + D/ratio) intermediate factor -- the whole
@@ -1844,6 +1866,7 @@ class KVCacheConfigurator:
             )
         else:
             replayssm_ring_per_req = 0
+        replayssm_ring_per_req = int(replayssm_ring_per_req * pp_layer_scale)
         if has_spec_dec:
             assert get_spec().speculative_num_draft_tokens is not None
             assert get_schedule().max_running_requests is not None
@@ -1865,7 +1888,7 @@ class KVCacheConfigurator:
                     get_schedule().max_mamba_cache_size // ratio,
                 )
                 intermediate_size = (
-                    config.mamba2_cache_params.mamba_cache_per_req
+                    stage_per_req
                     * (capped_reqs + 1)
                     * get_spec().speculative_num_draft_tokens
                 )
@@ -1884,15 +1907,15 @@ class KVCacheConfigurator:
             # pool's padding slot). Skipped under replayssm.
             if has_spec_dec and not replayssm_active:
                 intermediate_size = (
-                    config.mamba2_cache_params.mamba_cache_per_req
+                    stage_per_req
                     * (get_schedule().max_mamba_cache_size + 1)
                     * get_spec().speculative_num_draft_tokens
                 )
                 total_rest_memory = total_rest_memory - (intermediate_size / (1 << 30))
         else:
             # Use ratio-based calculation to auto-fit available memory
-            assert config.mamba2_cache_params.mamba_cache_per_req > 0
-            per_req = config.mamba2_cache_params.mamba_cache_per_req
+            assert stage_per_req > 0
+            per_req = stage_per_req
 
             # Solve jointly for max_mamba_cache_size (K), including the pool's
             # +1 padding slot on both buffers (see memory_pool.py):
@@ -1941,7 +1964,7 @@ class KVCacheConfigurator:
                 f"Not enough GPU memory for hybrid (mamba/linear-attention) state cache. "
                 f"Computed max_mamba_cache_size={get_schedule().max_mamba_cache_size} "
                 f"(total_rest_memory={total_rest_memory:.2f} GB, "
-                f"mamba_cache_per_req={config.mamba2_cache_params.mamba_cache_per_req / (1 << 20):.2f} MB). "
+                f"mamba_cache_per_req={stage_per_req / (1 << 20):.2f} MB). "
                 f"Try: (1) reduce --max-running-requests, "
                 f"(2) increase --mem-fraction-static, "
                 f"(3) reduce --speculative-num-draft-tokens, or "
@@ -1953,7 +1976,7 @@ class KVCacheConfigurator:
         # the ring is not allocated).
         mamba_state_memory = (
             (get_schedule().max_mamba_cache_size + 1)
-            * (config.mamba2_cache_params.mamba_cache_per_req + replayssm_ring_per_req)
+            * (stage_per_req + replayssm_ring_per_req)
             / (1 << 30)
         )
         return total_rest_memory - mamba_state_memory

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -31,7 +31,7 @@ import os
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass, fields
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
@@ -52,6 +52,11 @@ from sglang.kernels.ops.kvcache.kvcache import can_use_store_cache, store_cache
 from sglang.kernels.ops.quantization.fp8_kernel import fp8_dtype, is_fp8_fnuz
 from sglang.srt.configs.mamba_utils import BaseLinearStateParams
 from sglang.srt.constants import GPU_MEMORY_TYPE_KV_CACHE
+from sglang.srt.disaggregation.base.conn import (
+    BufferType,
+    LayerBufferHandles,
+    StateType,
+)
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.dsa.utils import aiter_can_use_preshuffle_paged_mqa
 from sglang.srt.layers.quantization.fp4_kv_cache_quant_method import (
@@ -482,6 +487,7 @@ class MambaPool:
 
         self.size = size
         self.device = device
+        self.mamba_layer_ids = mamba_layer_ids
         self.debug_memory_pool = envs.SGLANG_DEBUG_MEMORY_POOL.get()
         self.enable_linear_replayssm = enable_linear_replayssm
         self.linear_replayssm_cache_len = linear_replayssm_cache_len
@@ -1709,6 +1715,30 @@ class KVCache(abc.ABC):
     def register_layer_transfer_counter(self, layer_transfer_counter: LayerDoneCounter):
         self.layer_transfer_counter = layer_transfer_counter
 
+    def get_buffer_handles_by_layer(
+        self,
+        kv_buffer_offset: int = 0,
+        state_component_ids: Optional[Dict[StateType, int]] = None,
+        state_buffer_offsets: Optional[Dict[StateType, int]] = None,
+    ) -> Dict[int, LayerBufferHandles]:
+        """Return the registered KV buffers for every layer owned by this pool.
+
+        The dictionary uses global layer IDs as keys. ``kv_buffer_offset`` is
+        added to the pool-local buffer index so callers can address this pool
+        within a combined KV buffer list. The state arguments are accepted by
+        the common interface for stateful pool implementations, but are not
+        used by this KV-only pool.
+        """
+        return {
+            self.start_layer
+            + buffer_index: LayerBufferHandles(
+                buffer_types=[BufferType.KV],
+                raw_data_ptrs_indices=[kv_buffer_offset + buffer_index],
+                state_component_ids=[None],
+            )
+            for buffer_index in range(self.layer_num)
+        }
+
     def get_cpu_copy(self, indices, mamba_indices=None):
         raise NotImplementedError()
 
@@ -2210,6 +2240,25 @@ class MHATokenToKVPool(KVCache):
         ]
         item_lens = [d.item_len_bytes(self.page_size) for d in self._kv_buffer_descs]
         return ptrs, lens, item_lens
+
+    def get_buffer_handles_by_layer(
+        self,
+        kv_buffer_offset: int = 0,
+        state_component_ids: Optional[Dict[StateType, int]] = None,
+        state_buffer_offsets: Optional[Dict[StateType, int]] = None,
+    ) -> Dict[int, LayerBufferHandles]:
+        return {
+            self.start_layer
+            + buffer_index: LayerBufferHandles(
+                buffer_types=[BufferType.KV, BufferType.KV],
+                raw_data_ptrs_indices=[
+                    kv_buffer_offset + buffer_index,
+                    kv_buffer_offset + self.layer_num + buffer_index,
+                ],
+                state_component_ids=[None, None],
+            )
+            for buffer_index in range(self.layer_num)
+        }
 
     def get_cpu_copy(self, indices, mamba_indices=None):
         assert not self.use_hnd, (
@@ -3703,6 +3752,48 @@ class HybridLinearKVPool(KVCache):
         layer_ids = list(self.full_attention_layer_id_mapping)
         return layer_ids if self.use_mla else layer_ids * 2
 
+    def get_buffer_handles_by_layer(
+        self,
+        kv_buffer_offset: int = 0,
+        state_component_ids: Optional[Dict[StateType, int]] = None,
+        state_buffer_offsets: Optional[Dict[StateType, int]] = None,
+    ) -> Dict[int, LayerBufferHandles]:
+        handles_by_layer = {}
+        full_handles = self.full_kv_pool.get_buffer_handles_by_layer(
+            kv_buffer_offset=kv_buffer_offset,
+            state_component_ids=state_component_ids,
+            state_buffer_offsets=state_buffer_offsets,
+        )
+        for layer_id, kv_buffer_index in self.full_attention_layer_id_mapping.items():
+            handles_by_layer[layer_id] = full_handles[kv_buffer_index]
+
+        component_id = (state_component_ids or {}).get(StateType.MAMBA)
+        if component_id is None:
+            return handles_by_layer
+
+        mamba_layer_ids = getattr(self.mamba_pool, "mamba_layer_ids", [])
+        num_mamba_layers = len(mamba_layer_ids)
+        if num_mamba_layers:
+            overlap = set(handles_by_layer).intersection(mamba_layer_ids)
+            if overlap:
+                raise RuntimeError(
+                    f"Full-attention and Mamba layer handles overlap: {sorted(overlap)}"
+                )
+            num_state_tensors = (
+                len(self.mamba_pool.get_contiguous_buf_infos()[0]) // num_mamba_layers
+            )
+            state_offset = (state_buffer_offsets or {}).get(StateType.MAMBA, 0)
+            for layer_index, layer_id in enumerate(mamba_layer_ids):
+                handles_by_layer[layer_id] = LayerBufferHandles(
+                    buffer_types=[BufferType.STATE] * num_state_tensors,
+                    raw_data_ptrs_indices=[
+                        state_offset + tensor_id * num_mamba_layers + layer_index
+                        for tensor_id in range(num_state_tensors)
+                    ],
+                    state_component_ids=[component_id] * num_state_tensors,
+                )
+        return handles_by_layer
+
     def get_state_buf_infos(self):
         mamba_data_ptrs, mamba_data_lens, mamba_item_lens = (
             self.mamba_pool.get_contiguous_buf_infos()
@@ -4557,6 +4648,27 @@ class DSATokenToKVPool(MLATokenToKVPool):
             self.index_k_with_scale_buffer[i][0].nbytes for i in range(self.layer_num)
         ]
         return data_ptrs, data_lens, item_lens
+
+    def get_buffer_handles_by_layer(
+        self,
+        kv_buffer_offset: int = 0,
+        state_component_ids: Optional[Dict[StateType, int]] = None,
+        state_buffer_offsets: Optional[Dict[StateType, int]] = None,
+    ) -> Dict[int, LayerBufferHandles]:
+        state_offset = (state_buffer_offsets or {}).get(StateType.DSA, 0)
+        component_id = (state_component_ids or {}).get(StateType.DSA)
+        return {
+            self.start_layer
+            + buffer_index: LayerBufferHandles(
+                buffer_types=[BufferType.KV, BufferType.STATE],
+                raw_data_ptrs_indices=[
+                    kv_buffer_offset + buffer_index,
+                    state_offset + buffer_index,
+                ],
+                state_component_ids=[None, component_id],
+            )
+            for buffer_index in range(self.layer_num)
+        }
 
     def get_kv_size_bytes(self):
         kv_size_bytes = super().get_kv_size_bytes()

--- a/python/sglang/srt/mem_cache/swa_memory_pool.py
+++ b/python/sglang/srt/mem_cache/swa_memory_pool.py
@@ -3,6 +3,11 @@ from typing import Dict, List, Optional, Tuple
 
 import torch
 
+from sglang.srt.disaggregation.base.conn import (
+    BufferType,
+    LayerBufferHandles,
+    StateType,
+)
 from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.mem_cache.base_swa_memory_pool import BaseSWAKVPool
 from sglang.srt.mem_cache.memory_pool import (
@@ -136,6 +141,36 @@ class SWAKVPool(BaseSWAKVPool):
             full_kv_data_lens,
             full_kv_item_lens,
         )
+
+    def get_buffer_handles_by_layer(
+        self,
+        kv_buffer_offset: int = 0,
+        state_component_ids: Optional[Dict[StateType, int]] = None,
+        state_buffer_offsets: Optional[Dict[StateType, int]] = None,
+    ) -> Dict[int, LayerBufferHandles]:
+        full_handles = self.full_kv_pool.get_buffer_handles_by_layer(
+            kv_buffer_offset=kv_buffer_offset,
+            state_component_ids=state_component_ids,
+            state_buffer_offsets=state_buffer_offsets,
+        )
+        handles_by_layer = {}
+        for layer_id, (buffer_index, is_swa_layer) in self.layers_mapping.items():
+            if not is_swa_layer:
+                handles_by_layer[layer_id] = full_handles[buffer_index]
+                continue
+
+            value_buffer_index = self.swa_layer_nums + buffer_index
+            component_id = (state_component_ids or {}).get(StateType.SWA)
+            state_offset = (state_buffer_offsets or {}).get(StateType.SWA, 0)
+            handles_by_layer[layer_id] = LayerBufferHandles(
+                buffer_types=[BufferType.STATE, BufferType.STATE],
+                raw_data_ptrs_indices=[
+                    state_offset + buffer_index,
+                    state_offset + value_buffer_index,
+                ],
+                state_component_ids=[component_id, component_id],
+            )
+        return handles_by_layer
 
     def get_state_buf_infos(self):
         swa_kv_data_ptrs, swa_kv_data_lens, swa_kv_item_lens = (

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -568,6 +568,9 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
     model_specific_states: Dict[str, any] = None
     # current split index of layer
     split_index: int = 0
+    # CP-v2 shards split-prefill model inputs once and reuses them across layer groups.
+    split_prefill_cp_sharded_input_embeds: Optional[torch.Tensor] = None
+    split_prefill_cp_sharded_positions: Optional[torch.Tensor] = None
 
     # For multimodal
     mm_input_embeds: Optional[torch.Tensor] = None

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1298,11 +1298,19 @@ class ModelRunner:
         forward path needs — the cuda-graph path does the equivalent inside the
         runner's capture/replay, so this is skipped there.
         """
-        # For MLP sync
-        if forward_batch.global_num_tokens_cpu is not None:
-            forward_batch.prepare_mlp_sync_batch(self)
-        else:
-            forward_batch.prepare_attn_tp_scatter_input(self)
+        # Split prefill reuses one ForwardBatch across layer groups. DP padding and
+        # attn-TP token-count normalization mutate that batch and must run only once.
+        is_split_prefill_continuation = (
+            forward_batch.forward_mode.is_split_prefill()
+            and forward_batch.split_index > 0
+        )
+
+        if not is_split_prefill_continuation:
+            # For MLP sync
+            if forward_batch.global_num_tokens_cpu is not None:
+                forward_batch.prepare_mlp_sync_batch(self)
+            else:
+                forward_batch.prepare_attn_tp_scatter_input(self)
 
         # Normalize num_token_non_padded to be local to this attention TP rank if needed.
         # The skip is scoped to DSACPLayerCommunicator-style CP (DSA, MLA): those
@@ -1311,7 +1319,8 @@ class ModelRunner:
         # (Qwen3/Qwen2 MoE) keeps the attn_tp-replicated layout and wants the
         # adjustment to run — see docs/design/prefill-cp-mla.md §Phase 5.
         if (
-            forward_batch.num_token_non_padded is not None
+            not is_split_prefill_continuation
+            and forward_batch.num_token_non_padded is not None
             and forward_batch.global_num_tokens_gpu is not None
             and require_gathered_buffer(self.server_args)
             and not is_dsa_enable_prefill_cp()
@@ -1615,9 +1624,14 @@ class ModelRunner:
                     forward_batch, pp_proxy_tensors=pp_proxy_tensors
                 )
 
+            should_postprocess_mlp_sync = (
+                not forward_batch.forward_mode.is_split_prefill()
+                or forward_batch.split_index == self.model_config.num_hidden_layers
+            )
             if (
                 forward_batch.global_num_tokens_cpu is not None
                 and self.pp_group.is_last_rank
+                and should_postprocess_mlp_sync
             ):
                 forward_batch.post_forward_mlp_sync_batch(ret)
 

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -75,6 +75,7 @@ from sglang.srt.kv_canary.token_oracle.install import install_token_oracle_from_
 from sglang.srt.layers import deep_gemm_wrapper, model_parallel
 from sglang.srt.layers.attention.dsa.utils import is_dsa_enable_prefill_cp
 from sglang.srt.layers.cp.utils import (
+    cp_shard_model_inputs,
     get_cp_strategy,
     is_cp_v2_active,
 )
@@ -1379,13 +1380,48 @@ class ModelRunner:
             self.model_config.num_hidden_layers,
         )
         with device_timer_ctx(self.device_timer, "split_prefill"):
-            ret = self.model.forward_split_prefill(
-                forward_batch.input_ids,
-                forward_batch.positions,
-                forward_batch,
-                (forward_batch.split_index, next_split_index),
-            )
+            cp_v2_active = is_cp_v2_active(forward_batch)
+            forward_positions = forward_batch.positions
+            split_prefill_kwargs = {}
+            if cp_v2_active and forward_batch.split_index == 0:
+                # Shard once on the first layer group, then cache the CP-local view.
+                kwargs = self._extend_forward_kwargs(forward_batch, None)
+                input_embeds = kwargs.get("input_embeds")
+                if input_embeds is None:
+                    input_embeds = self.model.get_input_embeddings()(
+                        forward_batch.input_ids
+                    )
+                cp_shard_ctx = cp_shard_model_inputs(
+                    input_embeds, forward_batch.positions, forward_batch
+                )
+            else:
+                if cp_v2_active:
+                    # Later groups reuse the cached CP-local positions.
+                    forward_positions = (
+                        forward_batch.split_prefill_cp_sharded_positions
+                    )
+                cp_shard_ctx = contextlib.nullcontext((None, forward_positions))
+
+            with cp_shard_ctx as (forward_input_embeds, forward_positions):
+                if forward_input_embeds is not None:
+                    forward_batch.split_prefill_cp_sharded_input_embeds = (
+                        forward_input_embeds
+                    )
+                    forward_batch.split_prefill_cp_sharded_positions = (
+                        forward_positions
+                    )
+                    split_prefill_kwargs["input_embeds"] = forward_input_embeds
+                ret = self.model.forward_split_prefill(
+                    forward_batch.input_ids,
+                    forward_positions,
+                    forward_batch,
+                    (forward_batch.split_index, next_split_index),
+                    **split_prefill_kwargs,
+                )
         forward_batch.split_index = next_split_index
+        if cp_v2_active and next_split_index == self.model_config.num_hidden_layers:
+            forward_batch.split_prefill_cp_sharded_input_embeds = None
+            forward_batch.split_prefill_cp_sharded_positions = None
         return ret
 
     def forward(

--- a/python/sglang/srt/model_executor/model_runner_components/layer_setup.py
+++ b/python/sglang/srt/model_executor/model_runner_components/layer_setup.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, NamedTuple
 
 import msgspec
+from torch import nn
 
 if TYPE_CHECKING:
     from sglang.srt.configs.model_config import ModelConfig
@@ -23,7 +24,10 @@ def compute_attention_and_moe_layers(layer_model: Any) -> AttentionAndMoeLayers:
     moe_fusions: list[Any] = []
     dsa_indexers: list[Any] = []
     mha_companion_layers: list[Any] = []
-    for layer in layer_model.layers:
+    layers = layer_model.layers
+    if isinstance(layers, nn.ModuleDict):
+        layers = layers.values()
+    for layer in layers:
         attn_layer = None
         mha_companion_layer = None
         if hasattr(layer, "self_attn"):

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -2713,6 +2713,48 @@ class DeepseekV2Model(nn.Module):
         backend = getattr(backend, "primary", backend)
         return not getattr(backend, "use_mha", False)
 
+    def _forward_layer_range(
+        self,
+        start_layer: int,
+        end_layer: int,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        forward_batch: ForwardBatch,
+        residual: Optional[torch.Tensor],
+        zero_allocator: BumpAllocator,
+        gemm_output_zero_allocator: Optional[BumpAllocator],
+        llama_4_scaling: Optional[torch.Tensor],
+        topk_indices: Optional[torch.Tensor],
+        aux_hidden_states: List[torch.Tensor],
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]:
+        for i in range(start_layer, end_layer):
+            # NOTE: torch dynamo does not support graph break in context manager.
+            ctx = (
+                nullcontext()
+                if check_cuda_graph_backend(Phase.PREFILL, Backend.TC_PIECEWISE)
+                else get_global_expert_distribution_recorder().with_current_layer(i)
+            )
+            with ctx:
+                layer = self.layers[i]
+                hidden_states, residual, topk_indices = layer(
+                    positions,
+                    hidden_states,
+                    forward_batch,
+                    residual,
+                    zero_allocator,
+                    gemm_output_zero_allocator,
+                    llama_4_scaling,
+                    prev_topk_indices=topk_indices,
+                    captured_last_layer_outputs=(
+                        aux_hidden_states if i in self.layers_to_capture else None
+                    ),
+                    next_full_attention_layer_id=self.next_full_attention_layer_id.get(
+                        i
+                    ),
+                )
+
+        return hidden_states, residual, topk_indices
+
     def forward(
         self,
         input_ids: torch.Tensor,
@@ -2804,31 +2846,19 @@ class DeepseekV2Model(nn.Module):
         aux_hidden_states = AuxHiddenStatePacker(len(self.layers_to_capture))
         if self.pp_group.is_first_rank:
             topk_indices = None
-        for i in range(normal_start_layer, normal_end_layer):
-            # NOTE: torch dynamo does not support graph break in context manager
-            ctx = (
-                nullcontext()
-                if check_cuda_graph_backend(Phase.PREFILL, Backend.TC_PIECEWISE)
-                else get_global_expert_distribution_recorder().with_current_layer(i)
-            )
-            with ctx:
-                layer = self.layers[i]
-                hidden_states, residual, topk_indices = layer(
-                    positions,
-                    hidden_states,
-                    forward_batch,
-                    residual,
-                    zero_allocator,
-                    gemm_output_zero_allocator,
-                    llama_4_scaling,
-                    prev_topk_indices=topk_indices,
-                    captured_last_layer_outputs=(
-                        aux_hidden_states if i in self.layers_to_capture else None
-                    ),
-                    next_full_attention_layer_id=self.next_full_attention_layer_id.get(
-                        i
-                    ),
-                )
+        hidden_states, residual, topk_indices = self._forward_layer_range(
+            normal_start_layer,
+            normal_end_layer,
+            positions,
+            hidden_states,
+            forward_batch,
+            residual,
+            zero_allocator,
+            gemm_output_zero_allocator,
+            llama_4_scaling,
+            topk_indices,
+            aux_hidden_states,
+        )
 
         if normal_end_layer != self.end_layer:
             hidden_states, residual = model_forward_maybe_tbo(
@@ -2888,6 +2918,89 @@ class DeepseekV2Model(nn.Module):
         if len(aux_hidden_states) == 0:
             return hidden_states
         return hidden_states, aux_hidden_states.finalize()
+
+    def forward_split_prefill(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        split_interval: Tuple[int, int],
+        input_embeds: torch.Tensor = None,
+    ) -> Optional[Union[torch.Tensor, Tuple[torch.Tensor, List[torch.Tensor]]]]:
+        start, end = split_interval
+
+        if start == 0:
+            hidden_states = (
+                self.embed_tokens(input_ids) if input_embeds is None else input_embeds
+            )
+            total_num_layers = self.end_layer - self.start_layer
+            gemm_output_zero_allocator = (
+                BumpAllocator(
+                    buffer_size=self.gemm_output_zero_allocator_size,
+                    dtype=torch.float32,
+                    device=hidden_states.device,
+                )
+                if self.gemm_output_zero_allocator_size > 0
+                else None
+            )
+            llama_4_scaling = None
+            if self.llama_4_scaling_config is not None:
+                llama_4_scaling = _get_llama_4_scaling(
+                    original_max_position_embeddings=self.llama_4_scaling_config[
+                        "original_max_position_embeddings"
+                    ],
+                    scaling_beta=self.llama_4_scaling_config["beta"],
+                    positions=positions,
+                )
+
+            forward_batch.hidden_states = hidden_states
+            forward_batch.residual = None
+            forward_batch.model_specific_states = {
+                "deepseek_zero_allocator": BumpAllocator(
+                    buffer_size=total_num_layers * 2,
+                    dtype=torch.float32,
+                    device=hidden_states.device,
+                ),
+                "deepseek_gemm_output_zero_allocator": gemm_output_zero_allocator,
+                "deepseek_llama_4_scaling": llama_4_scaling,
+                "deepseek_topk_indices": None,
+                "deepseek_aux_hidden_states": [],
+            }
+
+        states = forward_batch.model_specific_states
+        assert states is not None, "Missing DeepSeek split-prefill state"
+        hidden_states, residual, topk_indices = self._forward_layer_range(
+            start,
+            end,
+            positions,
+            forward_batch.hidden_states,
+            forward_batch,
+            forward_batch.residual,
+            states["deepseek_zero_allocator"],
+            states["deepseek_gemm_output_zero_allocator"],
+            states["deepseek_llama_4_scaling"],
+            states["deepseek_topk_indices"],
+            states["deepseek_aux_hidden_states"],
+        )
+        forward_batch.hidden_states = hidden_states
+        forward_batch.residual = residual
+        states["deepseek_topk_indices"] = topk_indices
+
+        if end != self.end_layer:
+            return None
+
+        if residual is None:
+            hidden_states = self.norm(hidden_states)
+        else:
+            hidden_states, _ = self.norm(hidden_states, residual)
+        forward_batch.hidden_states = hidden_states
+
+        aux_hidden_states = states["deepseek_aux_hidden_states"]
+        forward_batch.residual = None
+        forward_batch.model_specific_states = None
+        if len(aux_hidden_states) == 0:
+            return hidden_states
+        return hidden_states, aux_hidden_states
 
 
 class DeepseekV2ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
@@ -3100,6 +3213,39 @@ class DeepseekV2ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
             )
         else:
             return hidden_states
+
+    @torch.no_grad()
+    def forward_split_prefill(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        split_interval: Tuple[int, int],
+        input_embeds: torch.Tensor = None,
+    ):
+        _, end = split_interval
+        with get_attn_tp_context().maybe_input_scattered(forward_batch):
+            hidden_states = self.model.forward_split_prefill(
+                input_ids,
+                positions,
+                forward_batch,
+                split_interval,
+                input_embeds,
+            )
+
+        if end != self.end_layer:
+            return None
+
+        aux_hidden_states = None
+        if self.capture_aux_hidden_states:
+            hidden_states, aux_hidden_states = hidden_states
+        return self.logits_processor(
+            input_ids,
+            hidden_states,
+            self.lm_head,
+            forward_batch,
+            aux_hidden_states,
+        )
 
     @property
     def start_layer(self):

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -2344,6 +2344,85 @@ class DeepseekV4Model(nn.Module):
         )
         return hidden_states
 
+    def _prepare_input_ids_global(
+        self, input_ids: torch.Tensor, forward_batch: ForwardBatch
+    ) -> torch.Tensor:
+        if get_parallel().attn_dp_size <= 1 or not get_moe_a2a_backend().is_none():
+            return input_ids
+
+        input_ids_global = torch.empty(
+            (get_global_dp_buffer_len(), 1),
+            dtype=input_ids.dtype,
+            device=input_ids.device,
+        )
+        # Token ids are replicated within an attention-TP group.
+        dp_gather_replicate(input_ids_global, input_ids[:, None], forward_batch)
+        return input_ids_global.squeeze(-1)
+
+    @staticmethod
+    def _reset_compressor_freqs_cache(forward_batch: ForwardBatch) -> None:
+        for attr in ("freqs_cis_c4", "freqs_cis_c128"):
+            if hasattr(forward_batch, attr):
+                delattr(forward_batch, attr)
+
+    def _forward_layer_range(
+        self,
+        start_layer: int,
+        end_layer: int,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_ids: torch.Tensor,
+        input_ids_global: torch.Tensor,
+        prev_residual: Optional[torch.Tensor] = None,
+        prev_post: Optional[torch.Tensor] = None,
+        prev_comb: Optional[torch.Tensor] = None,
+        dspark_aux_hidden_states: Optional[List[torch.Tensor]] = None,
+    ):
+        last_layer = None
+        for layer_id in range(start_layer, end_layer):
+            layer = self.layers[layer_id]
+            last_layer = layer
+            ctx = (
+                nullcontext()
+                if check_cuda_graph_backend(Phase.PREFILL, Backend.TC_PIECEWISE)
+                else get_global_expert_distribution_recorder().with_current_layer(
+                    layer_id
+                )
+            )
+            with ctx:
+                hidden_states, prev_residual, prev_post, prev_comb = layer(
+                    positions=positions,
+                    hidden_states=hidden_states,
+                    forward_batch=forward_batch,
+                    input_ids=input_ids,
+                    input_ids_global=input_ids_global,
+                    prev_residual=prev_residual,
+                    prev_post=prev_post,
+                    prev_comb=prev_comb,
+                )
+            if (
+                dspark_aux_hidden_states is not None
+                and layer_id in self.dspark_layers_to_capture
+            ):
+                completed = (
+                    layer.hc_post(hidden_states, prev_residual, prev_post, prev_comb)
+                    if self.use_fused_mhc_post_pre
+                    else hidden_states
+                )
+                dspark_aux_hidden_states.append(completed.mean(dim=1))
+
+        return hidden_states, prev_residual, prev_post, prev_comb, last_layer
+
+    def _finalize_hidden_states(
+        self, hidden_states: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        pre_hc_head = hidden_states.flatten(1)
+        hidden_states = self.hc_head(
+            hidden_states, self.hc_head_fn, self.hc_head_scale, self.hc_head_base
+        )
+        return self.norm(hidden_states), pre_hc_head
+
     def forward(
         self,
         input_ids: torch.Tensor,
@@ -2364,18 +2443,7 @@ class DeepseekV4Model(nn.Module):
                     hidden_states.shape[0], self.hc_mult, self.hidden_size
                 )
 
-        if get_parallel().attn_dp_size > 1 and get_moe_a2a_backend().is_none():
-            input_ids_global = torch.empty(
-                (get_global_dp_buffer_len(), 1),
-                dtype=input_ids.dtype,
-                device=input_ids.device,
-            )
-            # Token ids are replicated within an attention-TP group. Use replicate
-            # gather here to avoid summing duplicated ids when attention_tp_size > 1.
-            dp_gather_replicate(input_ids_global, input_ids[:, None], forward_batch)
-            input_ids_global = input_ids_global.squeeze(-1)
-        else:
-            input_ids_global = input_ids
+        input_ids_global = self._prepare_input_ids_global(input_ids, forward_batch)
 
         if dsa_use_prefill_cp(forward_batch):
             if self.pp_group.is_first_rank:
@@ -2385,9 +2453,8 @@ class DeepseekV4Model(nn.Module):
             input_ids_global = input_ids
 
         # Reset Compressor's per-step freqs_cis cache from any previous step.
-        for _attr in ("freqs_cis_c4", "freqs_cis_c128"):
-            if hasattr(forward_batch, _attr):
-                delattr(forward_batch, _attr)
+        self._reset_compressor_freqs_cache(forward_batch)
+
         capture_dspark = self.dspark_layers_to_capture is not None
         if capture_dspark and dsa_use_prefill_cp(forward_batch):
             raise NotImplementedError(
@@ -2408,37 +2475,25 @@ class DeepseekV4Model(nn.Module):
                 forward_batch=forward_batch,
             )
         else:
-            use_fused = self.use_fused_mhc_post_pre
-            prev_residual, prev_post, prev_comb = None, None, None
-            last_layer = None
-            for i in range(self.start_layer, self.end_layer):
-                layer = self.layers[i]
-                last_layer = layer
-                ctx = (
-                    nullcontext()
-                    if check_cuda_graph_backend(Phase.PREFILL, Backend.TC_PIECEWISE)
-                    else get_global_expert_distribution_recorder().with_current_layer(i)
-                )
-                with ctx:
-                    hidden_states, prev_residual, prev_post, prev_comb = layer(
-                        positions=positions,
-                        hidden_states=hidden_states,
-                        forward_batch=forward_batch,
-                        input_ids=input_ids,
-                        input_ids_global=input_ids_global,
-                        prev_residual=prev_residual,
-                        prev_post=prev_post,
-                        prev_comb=prev_comb,
-                    )
-                if capture_dspark and i in self.dspark_layers_to_capture:
-                    if use_fused:
-                        completed = layer.hc_post(
-                            hidden_states, prev_residual, prev_post, prev_comb
-                        )
-                    else:
-                        completed = hidden_states
-                    dspark_aux_hidden_states.append(completed.mean(dim=1))
-            if use_fused and last_layer is not None:
+            (
+                hidden_states,
+                prev_residual,
+                prev_post,
+                prev_comb,
+                last_layer,
+            ) = self._forward_layer_range(
+                self.start_layer,
+                self.end_layer,
+                positions,
+                hidden_states,
+                forward_batch,
+                input_ids,
+                input_ids_global,
+                dspark_aux_hidden_states=(
+                    dspark_aux_hidden_states if capture_dspark else None
+                ),
+            )
+            if self.use_fused_mhc_post_pre and last_layer is not None:
                 hidden_states = last_layer.hc_post(
                     hidden_states, prev_residual, prev_post, prev_comb
                 )
@@ -2456,16 +2511,85 @@ class DeepseekV4Model(nn.Module):
             # Flatten 3D mHC tensor for PP IPC.
             return PPProxyTensors({"hidden_states": hidden_states.flatten(1)})
 
-        pre_hc_head = hidden_states.flatten(1)
-
-        hidden_states = self.hc_head(
-            hidden_states, self.hc_head_fn, self.hc_head_scale, self.hc_head_base
-        )
-        hidden_states = self.norm(hidden_states)
+        hidden_states, pre_hc_head = self._finalize_hidden_states(hidden_states)
 
         if capture_dspark:
             return (hidden_states, pre_hc_head), dspark_aux_hidden_states
 
+        return hidden_states, pre_hc_head
+
+    def forward_split_prefill(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        split_interval: Tuple[int, int],
+        input_embeds: Optional[torch.Tensor] = None,
+    ):
+        start, end = split_interval
+
+        if start == self.start_layer:
+            hidden_states = (
+                self.embed_tokens(input_ids) if input_embeds is None else input_embeds
+            )
+            hidden_states = hidden_states.unsqueeze(1).repeat(1, self.hc_mult, 1)
+            forward_batch.hidden_states = hidden_states
+            forward_batch.model_specific_states = {
+                "deepseek_v4_input_ids": input_ids,
+                "deepseek_v4_input_ids_global": self._prepare_input_ids_global(
+                    input_ids, forward_batch
+                ),
+                "deepseek_v4_prev_residual": None,
+                "deepseek_v4_prev_post": None,
+                "deepseek_v4_prev_comb": None,
+                "deepseek_v4_dspark_aux_hidden_states": [],
+            }
+            self._reset_compressor_freqs_cache(forward_batch)
+
+        states = forward_batch.model_specific_states
+        assert states is not None, "Missing DeepSeek V4 split-prefill state"
+        (
+            hidden_states,
+            prev_residual,
+            prev_post,
+            prev_comb,
+            last_layer,
+        ) = self._forward_layer_range(
+            start,
+            end,
+            positions,
+            forward_batch.hidden_states,
+            forward_batch,
+            states["deepseek_v4_input_ids"],
+            states["deepseek_v4_input_ids_global"],
+            states["deepseek_v4_prev_residual"],
+            states["deepseek_v4_prev_post"],
+            states["deepseek_v4_prev_comb"],
+            dspark_aux_hidden_states=(
+                states["deepseek_v4_dspark_aux_hidden_states"]
+                if self.dspark_layers_to_capture is not None
+                else None
+            ),
+        )
+        forward_batch.hidden_states = hidden_states
+        states["deepseek_v4_prev_residual"] = prev_residual
+        states["deepseek_v4_prev_post"] = prev_post
+        states["deepseek_v4_prev_comb"] = prev_comb
+
+        if end != self.end_layer:
+            return None
+
+        if self.use_fused_mhc_post_pre and last_layer is not None:
+            hidden_states = last_layer.hc_post(
+                hidden_states, prev_residual, prev_post, prev_comb
+            )
+
+        hidden_states, pre_hc_head = self._finalize_hidden_states(hidden_states)
+        forward_batch.hidden_states = hidden_states
+        dspark_aux_hidden_states = states["deepseek_v4_dspark_aux_hidden_states"]
+        forward_batch.model_specific_states = None
+        if self.dspark_layers_to_capture is not None:
+            return (hidden_states, pre_hc_head), dspark_aux_hidden_states
         return hidden_states, pre_hc_head
 
 
@@ -2623,6 +2747,43 @@ class DeepseekV4ForCausalLM(nn.Module):
             hidden_states, aux_hidden_states = hidden_states
         hidden_states, pre_hc_head = hidden_states
 
+        return self.logits_processor(
+            input_ids,
+            hidden_states,
+            self.lm_head,
+            forward_batch,
+            aux_hidden_states,
+            hidden_states_before_norm=(
+                None if aux_hidden_states is not None else pre_hc_head
+            ),
+        )
+
+    @torch.no_grad()
+    def forward_split_prefill(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        split_interval: Tuple[int, int],
+        input_embeds: Optional[torch.Tensor] = None,
+    ):
+        _, end = split_interval
+        with get_attn_tp_context().maybe_input_scattered(forward_batch):
+            hidden_states = self.model.forward_split_prefill(
+                input_ids,
+                positions,
+                forward_batch,
+                split_interval,
+                input_embeds,
+            )
+
+        if end != self.end_layer:
+            return None
+
+        aux_hidden_states = None
+        if self.capture_aux_hidden_states:
+            hidden_states, aux_hidden_states = hidden_states
+        hidden_states, pre_hc_head = hidden_states
         return self.logits_processor(
             input_ids,
             hidden_states,

--- a/python/sglang/srt/models/mistral_large_3_eagle.py
+++ b/python/sglang/srt/models/mistral_large_3_eagle.py
@@ -4,19 +4,12 @@
 from typing import Optional
 
 import torch
-from torch import nn
 from transformers import PretrainedConfig
 
-from sglang.srt.configs.model_config import is_deepseek_dsa
-from sglang.srt.distributed import get_pp_group
-from sglang.srt.layers.attention.dsa.utils import is_dsa_enable_prefill_cp
-from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.linear import RowParallelLinear
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
-from sglang.srt.layers.utils.cp_utils import is_prefill_context_parallel_enabled
-from sglang.srt.layers.vocab_parallel_embedding import VocabParallelEmbedding
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
-from sglang.srt.models.deepseek_v2 import DeepseekV2DecoderLayer, DeepseekV2Model
+from sglang.srt.models.deepseek_v2 import DeepseekV2Model
 from sglang.srt.models.mistral_large_3 import MistralLarge3ForCausalLM
 from sglang.srt.utils import add_prefix
 
@@ -31,50 +24,17 @@ class MistralLarge3EagleModel(DeepseekV2Model):
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
     ):
-        nn.Module.__init__(self)
-
-        self.config = config
-        self.vocab_size = config.vocab_size
-        assert get_pp_group().world_size == 1
-        self.pp_group = get_pp_group()
-        self.dsa_enable_prefill_cp = is_dsa_enable_prefill_cp()
-        self.mla_enable_prefill_cp = (
-            is_prefill_context_parallel_enabled() and not is_deepseek_dsa(config)
-        )
-
-        self.embed_tokens = VocabParallelEmbedding(
-            config.vocab_size,
-            config.hidden_size,
-            prefix=add_prefix("embed_tokens", prefix),
-        )
-
-        self.layers = nn.ModuleList(
-            [
-                DeepseekV2DecoderLayer(
-                    config=config,
-                    prefix=add_prefix(prefix, f"layers.{i}"),
-                    quant_config=quant_config,
-                    layer_id=i,
-                    dsa_enable_prefill_cp=self.dsa_enable_prefill_cp,
-                    mla_enable_prefill_cp=self.mla_enable_prefill_cp,
-                )
-                for i in range(self.config.num_hidden_layers)
-            ]
-        )
-        self.start_layer = 0
-        self.end_layer = self.config.num_hidden_layers
+        super().__init__(config, quant_config, prefix=prefix)
+        assert self.pp_group.world_size == 1
 
         self.fc = RowParallelLinear(
-            self.config.hidden_size * 2,
-            self.config.hidden_size,
+            config.hidden_size * 2,
+            config.hidden_size,
             bias=False,
             quant_config=quant_config,
-            prefix=add_prefix(prefix, "fc"),
+            prefix=add_prefix("fc", prefix),
             input_is_parallel=False,
         )
-        self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self.layers_to_capture = []
-        self.llama_4_scaling_config = getattr(config, "llama_4_scaling", None)
 
     def forward(
         self,

--- a/python/sglang/srt/models/nemotron_h_mtp.py
+++ b/python/sglang/srt/models/nemotron_h_mtp.py
@@ -288,13 +288,14 @@ class NemotronHMultiTokenPredictor(nn.Module):
     def forward(
         self,
         input_ids: torch.Tensor,
-        hidden_states: torch.Tensor,
+        positions: torch.Tensor,
         forward_batch: ForwardBatch,
         inputs_embeds: torch.Tensor | None = None,
     ) -> torch.Tensor:
         if inputs_embeds is None:
             inputs_embeds = self.get_input_embeddings(input_ids)
 
+        hidden_states = forward_batch.spec_info.hidden_states
         residual = None
 
         for i in range(self.pattern_len):
@@ -352,11 +353,9 @@ class NemotronHForCausalLMMTP(NemotronHForCausalLM):
         input_embeds: torch.Tensor | None = None,
         **kwargs,
     ) -> torch.Tensor:
-        hidden_states = forward_batch.spec_info.hidden_states
-
         hidden_states = self.model(
             input_ids,
-            hidden_states,
+            positions,
             forward_batch,
             input_embeds,
         )

--- a/python/sglang/srt/models/qwen3.py
+++ b/python/sglang/srt/models/qwen3.py
@@ -560,8 +560,18 @@ class Qwen3ForCausalLM(nn.Module):
                 forward_batch.hidden_states = self.model.embed_tokens(input_ids)
             else:
                 forward_batch.hidden_states = input_embeds
+            forward_batch.model_specific_states = {"qwen3_aux_hidden_states": []}
+        aux_hidden_states = forward_batch.model_specific_states[
+            "qwen3_aux_hidden_states"
+        ]
         # decoder layer
         for i in range(start, end):
+            if i in self.model.layers_to_capture:
+                aux_hidden_states.append(
+                    forward_batch.hidden_states + forward_batch.residual
+                    if forward_batch.residual is not None
+                    else forward_batch.hidden_states
+                )
             layer = self.model.layers[i]
             forward_batch.hidden_states, forward_batch.residual = layer(
                 positions,
@@ -578,8 +588,13 @@ class Qwen3ForCausalLM(nn.Module):
             forward_batch.hidden_states = hidden_states
             # logits process
             result = self.logits_processor(
-                input_ids, forward_batch.hidden_states, self.lm_head, forward_batch
+                input_ids,
+                forward_batch.hidden_states,
+                self.lm_head,
+                forward_batch,
+                aux_hidden_states if self.capture_aux_hidden_states else None,
             )
+            forward_batch.model_specific_states = None
         else:
             result = None
 

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -1556,6 +1556,44 @@ class Qwen3_5ForCausalLM(nn.Module):
             num_groups=None,
         )
 
+    @torch.no_grad()
+    def forward_split_prefill(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        split_interval: Tuple[int, int],
+        input_embeds: torch.Tensor = None,
+    ):
+        start, end = split_interval
+        if start == 0:
+            if input_embeds is None:
+                forward_batch.hidden_states = self.embed_tokens(input_ids)
+            else:
+                forward_batch.hidden_states = input_embeds
+            forward_batch.residual = None
+
+        for i in range(start, end):
+            with get_global_expert_distribution_recorder().with_current_layer(i):
+                layer = self.layers[i]
+                forward_batch.hidden_states, forward_batch.residual = layer(
+                    positions=positions,
+                    hidden_states=forward_batch.hidden_states,
+                    residual=forward_batch.residual,
+                    forward_batch=forward_batch,
+                )
+
+        if end == self.config.num_hidden_layers:
+            if forward_batch.residual is None:
+                hidden_states = self.norm(forward_batch.hidden_states)
+            else:
+                hidden_states, _ = self.norm(
+                    forward_batch.hidden_states, forward_batch.residual
+                )
+            forward_batch.hidden_states = hidden_states
+
+        return None
+
 
 class Qwen3_5MoeForCausalLM(Qwen3_5ForCausalLM):
     def __init__(
@@ -1827,6 +1865,34 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration):
         else:
             torch.cuda.empty_cache()
             torch.cuda.synchronize()
+
+    @torch.no_grad()
+    def forward_split_prefill(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        split_interval: Tuple[int, int],
+        input_embeds: torch.Tensor = None,
+    ):
+        if forward_batch.contains_mm_inputs():
+            raise NotImplementedError(
+                "Qwen3.5 multimodal split-prefill is not supported"
+            )
+
+        _, end = split_interval
+        if self.is_mrope_enabled:
+            positions = forward_batch.mrope_positions
+
+        self.model.forward_split_prefill(
+            input_ids, positions, forward_batch, split_interval, input_embeds
+        )
+
+        if end == self.end_layer:
+            return self.logits_processor(
+                input_ids, forward_batch.hidden_states, self.lm_head, forward_batch
+            )
+        return None
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         weights = QWEN3_5_KV_SCALE_MAPPER.apply(weights)
@@ -2314,6 +2380,34 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3VLForConditionalGeneration):
             num_logical_experts=text_config.num_experts,
             num_groups=None,
         )
+
+    @torch.no_grad()
+    def forward_split_prefill(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        split_interval: Tuple[int, int],
+        input_embeds: torch.Tensor = None,
+    ):
+        if forward_batch.contains_mm_inputs():
+            raise NotImplementedError(
+                "Qwen3.5 multimodal split-prefill is not supported"
+            )
+
+        _, end = split_interval
+        if self.is_mrope_enabled:
+            positions = forward_batch.mrope_positions
+
+        self.model.forward_split_prefill(
+            input_ids, positions, forward_batch, split_interval, input_embeds
+        )
+
+        if end == self.end_layer:
+            return self.logits_processor(
+                input_ids, forward_batch.hidden_states, self.lm_head, forward_batch
+            )
+        return None
 
 
 EntryClass = [Qwen3_5MoeForConditionalGeneration, Qwen3_5ForConditionalGeneration]

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -68,7 +68,6 @@ from sglang.srt.utils.common import (
     get_device,
     get_device_memory_capacity,
     get_device_sm,
-    get_int_env_var,
     get_quantization_config,
     human_readable_int,
     is_blackwell_supported,
@@ -6632,8 +6631,8 @@ class ServerArgs:
         ):
             return
         required_tokens = self.cutedsl_moe_max_num_tokens()
-        max_dispatch_tokens_per_rank = get_int_env_var(
-            "SGLANG_FLASHINFER_NUM_MAX_DISPATCH_TOKENS_PER_RANK", 1024
+        max_dispatch_tokens_per_rank = (
+            envs.SGLANG_FLASHINFER_NUM_MAX_DISPATCH_TOKENS_PER_RANK.get() or 1024
         )
         max_cutedsl_tokens = max_dispatch_tokens_per_rank * view.ep_size
         if max_cutedsl_tokens < required_tokens:

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -13,6 +13,7 @@ from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
 from sglang.srt.model_executor.forward_batch_info import (
     CaptureHiddenMode,
+    ForwardBatch,
     compute_position,
 )
 from sglang.srt.runtime_context import get_exec, get_parallel, get_spec
@@ -399,6 +400,45 @@ class DSparkWorkerV2(BaseSpecWorker):
 
         return self._forward_decode(batch, on_publish, grammar_barrier)
 
+    def forward_batch_generation_split_prefill_init(
+        self, batch: ScheduleBatch
+    ) -> ForwardBatch:
+        if getattr(batch, "return_logprob", False):
+            raise ValueError(
+                "DSpark speculative decoding does not support return_logprob yet."
+            )
+        self._verify_planner.note_non_decode_step()
+        self._observers.note_prefill_step()
+        return self.target_worker.forward_batch_generation_split_prefill_init(
+            batch, capture_hidden_mode=CaptureHiddenMode.FULL
+        )
+
+    def forward_batch_generation_split_prefill(
+        self, forward_batch: ForwardBatch, forward_count: int = 1
+    ) -> tuple:
+        return self.target_worker.forward_batch_generation_split_prefill(
+            forward_batch, forward_count
+        )
+
+    def forward_batch_generation_split_prefill_finalize(
+        self,
+        batch: ScheduleBatch,
+        logits_output,
+        forward_batch: ForwardBatch,
+        defer_sample: bool = False,
+        on_publish=None,
+    ) -> GenerationBatchResult:
+        # DSpark KV injection consumes target tokens, so sampling cannot be deferred.
+        batch_output = (
+            self.target_worker.forward_batch_generation_split_prefill_finalize(
+                batch,
+                logits_output,
+                forward_batch,
+                defer_sample=False,
+            )
+        )
+        return self._finalize_prefill(batch, batch_output, on_publish)
+
     def _forward_prefill(
         self, batch: ScheduleBatch, on_publish
     ) -> GenerationBatchResult:
@@ -412,6 +452,14 @@ class DSparkWorkerV2(BaseSpecWorker):
         batch_output = self.target_worker.forward_batch_generation(
             batch, capture_hidden_mode=CaptureHiddenMode.FULL
         )
+        return self._finalize_prefill(batch, batch_output, on_publish)
+
+    def _finalize_prefill(
+        self,
+        batch: ScheduleBatch,
+        batch_output: GenerationBatchResult,
+        on_publish,
+    ) -> GenerationBatchResult:
         logits_output = batch_output.logits_output
         next_token_ids = batch_output.next_token_ids
         batch_output.new_seq_lens = batch.seq_lens

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -1100,6 +1100,73 @@ class EAGLEWorkerV2(BaseSpecWorker):
                     ),
                 )
 
+    def forward_batch_generation_split_prefill_init(
+        self, batch: ScheduleBatch
+    ) -> ForwardBatch:
+        capture_hidden_mode = (
+            CaptureHiddenMode.NULL
+            if self.speculative_algorithm.is_standalone()
+            else CaptureHiddenMode.FULL
+        )
+        return self.target_worker.forward_batch_generation_split_prefill_init(
+            batch, capture_hidden_mode=capture_hidden_mode
+        )
+
+    def forward_batch_generation_split_prefill(
+        self, forward_batch: ForwardBatch, forward_count: int = 1
+    ) -> tuple:
+        return self.target_worker.forward_batch_generation_split_prefill(
+            forward_batch, forward_count
+        )
+
+    def forward_batch_generation_split_prefill_finalize(
+        self,
+        batch: ScheduleBatch,
+        logits_output,
+        forward_batch: ForwardBatch,
+        defer_sample: bool = False,
+        on_publish=None,
+    ) -> GenerationBatchResult:
+        # Draft extend consumes target tokens, so target sampling cannot be deferred.
+        batch_output = (
+            self.target_worker.forward_batch_generation_split_prefill_finalize(
+                batch,
+                logits_output,
+                forward_batch,
+                defer_sample=False,
+            )
+        )
+        return self._forward_draft_extend_for_prefill(
+            batch, batch_output, on_publish=on_publish
+        )
+
+    def _forward_draft_extend_for_prefill(
+        self,
+        batch: ScheduleBatch,
+        batch_output: GenerationBatchResult,
+        on_publish=None,
+    ) -> GenerationBatchResult:
+        # Spec_v2 convention: batch.seq_lens = length BEFORE this iter's tokens.
+        # Extend processed L prompt tokens; next verify iter expects same L.
+        batch_output.new_seq_lens = batch.seq_lens
+        # Publish before draft_extend so the fence is at target-end.
+        if on_publish is not None:
+            on_publish(batch_output.new_seq_lens)
+
+        with (
+            self.draft_worker.draft_tp_context(self.draft_worker.draft_runner.tp_group),
+            speculative_moe_backend_context(),
+            speculative_moe_a2a_backend_context(),
+            spec_stage_span("draft_extend"),
+        ):
+            batch_output.next_draft_input = self.draft_worker._draft_extend_for_prefill(
+                batch,
+                batch_output.logits_output.hidden_states,
+                batch_output.next_token_ids,
+                batch_output.logits_output.mm_input_embeds,
+            )
+        return batch_output
+
     def forward_batch_generation(
         self, batch: ScheduleBatch, on_publish=None, grammar_barrier=None
     ):
@@ -1113,32 +1180,9 @@ class EAGLEWorkerV2(BaseSpecWorker):
             batch_output = self.target_worker.forward_batch_generation(
                 batch, capture_hidden_mode=target_capture_mode
             )
-
-            # Spec_v2 convention: batch.seq_lens = length BEFORE this iter's tokens.
-            # Extend processed L prompt tokens; next verify iter expects same L.
-            batch_output.new_seq_lens = batch.seq_lens
-            # Publish before draft_extend so the fence is at target-end.
-            if on_publish is not None:
-                on_publish(batch_output.new_seq_lens)
-
-            # Draft prefill
-            with (
-                self.draft_worker.draft_tp_context(
-                    self.draft_worker.draft_runner.tp_group
-                ),
-                speculative_moe_backend_context(),
-                speculative_moe_a2a_backend_context(),
-                spec_stage_span("draft_extend"),
-            ):
-                batch_output.next_draft_input = (
-                    self.draft_worker._draft_extend_for_prefill(
-                        batch,
-                        batch_output.logits_output.hidden_states,
-                        batch_output.next_token_ids,
-                        batch_output.logits_output.mm_input_embeds,
-                    )
-                )
-                return batch_output
+            return self._forward_draft_extend_for_prefill(
+                batch, batch_output, on_publish=on_publish
+            )
         else:
             self.activate_step_by_batch(batch.seq_lens.shape[0])
 

--- a/rust/sglang-grpc/src/server.rs
+++ b/rust/sglang-grpc/src/server.rs
@@ -229,7 +229,7 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
             .rid
             .clone()
             .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
-        let req_dict = build_text_generate_dict(&rid, &req);
+        let req_dict = build_text_generate_dict(&rid, &req).map_err(Status::invalid_argument)?;
 
         let mut receiver = self
             .bridge
@@ -298,7 +298,7 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
             .rid
             .clone()
             .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
-        let req_dict = build_generate_dict(&rid, &req);
+        let req_dict = build_generate_dict(&rid, &req).map_err(Status::invalid_argument)?;
 
         let mut receiver = self
             .bridge

--- a/rust/sglang-grpc/src/utils/request_utils.rs
+++ b/rust/sglang-grpc/src/utils/request_utils.rs
@@ -2,8 +2,25 @@ use std::collections::HashMap;
 
 use crate::proto;
 
+fn regex_escape_literal(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for character in value.chars() {
+        if matches!(
+            character,
+            '.' | '+' | '*' | '?' | '^' | '$' | '(' | ')' | '[' | ']' | '{' | '}' | '|' | '\\'
+        ) {
+            escaped.push('\\');
+        }
+        escaped.push(character);
+    }
+    escaped
+}
+
 /// Convert proto SamplingParams to a serde_json map (used as Python dict via PyO3).
-fn sampling_params_to_map(params: &Option<proto::SamplingParams>) -> serde_json::Value {
+#[allow(deprecated)]
+fn sampling_params_to_map(
+    params: &Option<proto::SamplingParams>,
+) -> Result<serde_json::Value, String> {
     match params {
         Some(p) => {
             let mut map = serde_json::Map::new();
@@ -46,15 +63,90 @@ fn sampling_params_to_map(params: &Option<proto::SamplingParams>) -> serde_json:
             if let Some(v) = p.n {
                 map.insert("n".into(), serde_json::json!(v));
             }
-            if let Some(ref v) = p.json_schema {
-                map.insert("json_schema".into(), serde_json::json!(v));
+            if let Some(v) = p.seed {
+                map.insert("sampling_seed".into(), serde_json::json!(v));
             }
-            if let Some(ref v) = p.regex {
-                map.insert("regex".into(), serde_json::json!(v));
+            if p.guided_decoding.is_some() && (p.json_schema.is_some() || p.regex.is_some()) {
+                return Err(
+                    "legacy json_schema/regex cannot be combined with guided_decoding".into(),
+                );
             }
-            serde_json::Value::Object(map)
+            if let Some(guided) = p.guided_decoding.as_ref() {
+                use proto::guided_decoding::Constraint;
+                match guided.constraint.as_ref() {
+                    Some(Constraint::JsonSchema(value)) if !value.is_empty() => {
+                        map.insert("json_schema".into(), serde_json::json!(value));
+                    }
+                    Some(Constraint::Regex(value)) if !value.is_empty() => {
+                        map.insert("regex".into(), serde_json::json!(value));
+                    }
+                    Some(Constraint::Ebnf(value)) if !value.is_empty() => {
+                        map.insert("ebnf".into(), serde_json::json!(value));
+                    }
+                    Some(Constraint::Choice(choice))
+                        if !choice.values.is_empty()
+                            && choice.values.iter().all(|value| !value.is_empty()) =>
+                    {
+                        let alternatives = choice
+                            .values
+                            .iter()
+                            .map(|value| regex_escape_literal(value))
+                            .collect::<Vec<_>>()
+                            .join("|");
+                        map.insert(
+                            "regex".into(),
+                            serde_json::json!(format!("(?:{alternatives})")),
+                        );
+                    }
+                    Some(Constraint::StructuralTag(value)) if !value.is_empty() => {
+                        map.insert("structural_tag".into(), serde_json::json!(value));
+                    }
+                    Some(Constraint::Choice(_)) => {
+                        return Err("guided choice must contain only non-empty values".into());
+                    }
+                    Some(_) => return Err("guided decoding constraint must not be empty".into()),
+                    None => return Err("guided decoding constraint must be specified".into()),
+                }
+            } else {
+                if let Some(value) = p.json_schema.as_ref() {
+                    if value.is_empty() {
+                        return Err("legacy json_schema must not be empty".into());
+                    }
+                    map.insert("json_schema".into(), serde_json::json!(value));
+                }
+                if let Some(value) = p.regex.as_ref() {
+                    if value.is_empty() {
+                        return Err("legacy regex must not be empty".into());
+                    }
+                    map.insert("regex".into(), serde_json::json!(value));
+                }
+            }
+            Ok(serde_json::Value::Object(map))
         }
-        None => serde_json::Value::Object(serde_json::Map::new()),
+        None => Ok(serde_json::Value::Object(serde_json::Map::new())),
+    }
+}
+
+fn insert_generation_controls(
+    d: &mut HashMap<String, serde_json::Value>,
+    priority: Option<i32>,
+    require_reasoning: Option<bool>,
+    max_thinking_tokens: Option<u32>,
+) {
+    if let Some(priority) = priority {
+        d.insert("priority".into(), serde_json::json!(priority));
+    }
+    if let Some(require_reasoning) = require_reasoning {
+        d.insert(
+            "require_reasoning".into(),
+            serde_json::json!(require_reasoning),
+        );
+    }
+    if let Some(max_thinking_tokens) = max_thinking_tokens {
+        d.insert(
+            "max_thinking_tokens".into(),
+            serde_json::json!(max_thinking_tokens),
+        );
     }
 }
 
@@ -111,13 +203,13 @@ pub(crate) fn extract_model_path(json_info: &str) -> String {
 pub(crate) fn build_text_generate_dict(
     rid: &str,
     req: &proto::TextGenerateRequest,
-) -> HashMap<String, serde_json::Value> {
+) -> Result<HashMap<String, serde_json::Value>, String> {
     let mut d = HashMap::new();
     d.insert("rid".into(), serde_json::json!(rid));
     d.insert("text".into(), serde_json::json!(req.text));
     d.insert(
         "sampling_params".into(),
-        sampling_params_to_map(&req.sampling_params),
+        sampling_params_to_map(&req.sampling_params)?,
     );
     d.insert(
         "stream".into(),
@@ -151,25 +243,31 @@ pub(crate) fn build_text_generate_dict(
     if let Some(ref session_id) = req.session_id {
         d.insert("session_id".into(), serde_json::json!(session_id));
     }
+    insert_generation_controls(
+        &mut d,
+        req.priority,
+        req.require_reasoning,
+        req.max_thinking_tokens,
+    );
     insert_disaggregated_params(&mut d, &req.disaggregated_params);
     if let Some(trace) = trace_headers_to_json(&req.trace_headers) {
         d.insert("external_trace_header".into(), trace);
     }
     d.insert("received_time".into(), serde_json::json!(now_timestamp()));
-    d
+    Ok(d)
 }
 
 /// Build a request dict for GenerateReqInput from proto GenerateRequest (tokenized).
 pub(crate) fn build_generate_dict(
     rid: &str,
     req: &proto::GenerateRequest,
-) -> HashMap<String, serde_json::Value> {
+) -> Result<HashMap<String, serde_json::Value>, String> {
     let mut d = HashMap::new();
     d.insert("rid".into(), serde_json::json!(rid));
     d.insert("input_ids".into(), serde_json::json!(req.input_ids));
     d.insert(
         "sampling_params".into(),
-        sampling_params_to_map(&req.sampling_params),
+        sampling_params_to_map(&req.sampling_params)?,
     );
     d.insert(
         "stream".into(),
@@ -199,12 +297,18 @@ pub(crate) fn build_generate_dict(
     if let Some(ref session_id) = req.session_id {
         d.insert("session_id".into(), serde_json::json!(session_id));
     }
+    insert_generation_controls(
+        &mut d,
+        req.priority,
+        req.require_reasoning,
+        req.max_thinking_tokens,
+    );
     insert_disaggregated_params(&mut d, &req.disaggregated_params);
     if let Some(trace) = trace_headers_to_json(&req.trace_headers) {
         d.insert("external_trace_header".into(), trace);
     }
     d.insert("received_time".into(), serde_json::json!(now_timestamp()));
-    d
+    Ok(d)
 }
 
 /// Build a request dict for EmbeddingReqInput from proto TextEmbedRequest.
@@ -267,6 +371,7 @@ pub(crate) fn build_classify_dict(
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use super::*;
 
@@ -283,11 +388,15 @@ mod tests {
         };
 
         assert_eq!(
-            build_text_generate_dict("request-1", &text_req).get("session_id"),
+            build_text_generate_dict("request-1", &text_req)
+                .unwrap()
+                .get("session_id"),
             Some(&serde_json::json!("session-1"))
         );
         assert_eq!(
-            build_generate_dict("request-2", &token_req).get("session_id"),
+            build_generate_dict("request-2", &token_req)
+                .unwrap()
+                .get("session_id"),
             Some(&serde_json::json!("session-1"))
         );
     }
@@ -312,6 +421,7 @@ mod tests {
             build_text_generate_dict("request-1", &text_req),
             build_generate_dict("request-2", &token_req),
         ] {
+            let request = request.unwrap();
             assert_eq!(
                 request.get("bootstrap_host"),
                 Some(&serde_json::json!("10.0.0.1"))
@@ -330,13 +440,121 @@ mod tests {
     #[test]
     fn generate_dicts_omit_disaggregated_params_when_absent() {
         let text_request =
-            build_text_generate_dict("request-1", &proto::TextGenerateRequest::default());
-        let token_request = build_generate_dict("request-2", &proto::GenerateRequest::default());
+            build_text_generate_dict("request-1", &proto::TextGenerateRequest::default()).unwrap();
+        let token_request =
+            build_generate_dict("request-2", &proto::GenerateRequest::default()).unwrap();
 
         for request in [text_request, token_request] {
             assert!(!request.contains_key("bootstrap_host"));
             assert!(!request.contains_key("bootstrap_port"));
             assert!(!request.contains_key("bootstrap_room"));
+        }
+    }
+
+    #[test]
+    fn generate_dicts_preserve_optional_generation_controls() {
+        let sampling_params = proto::SamplingParams {
+            seed: Some(42),
+            ..Default::default()
+        };
+        let text_request = proto::TextGenerateRequest {
+            sampling_params: Some(sampling_params.clone()),
+            priority: Some(3),
+            require_reasoning: Some(false),
+            max_thinking_tokens: Some(128),
+            ..Default::default()
+        };
+        let token_request = proto::GenerateRequest {
+            sampling_params: Some(proto::SamplingParams {
+                seed: Some(42),
+                ..Default::default()
+            }),
+            priority: Some(3),
+            require_reasoning: Some(false),
+            max_thinking_tokens: Some(128),
+            ..Default::default()
+        };
+
+        for mapped in [
+            build_text_generate_dict("text-request", &text_request).unwrap(),
+            build_generate_dict("token-request", &token_request).unwrap(),
+        ] {
+            assert_eq!(mapped["priority"], serde_json::json!(3));
+            assert_eq!(mapped["require_reasoning"], serde_json::json!(false));
+            assert_eq!(mapped["max_thinking_tokens"], serde_json::json!(128));
+            assert_eq!(
+                mapped["sampling_params"]["sampling_seed"],
+                serde_json::json!(42)
+            );
+        }
+
+        for mapped in [
+            build_text_generate_dict("text-request", &Default::default()).unwrap(),
+            build_generate_dict("token-request", &Default::default()).unwrap(),
+        ] {
+            assert!(!mapped.contains_key("priority"));
+            assert!(!mapped.contains_key("require_reasoning"));
+            assert!(!mapped.contains_key("max_thinking_tokens"));
+        }
+    }
+
+    #[test]
+    fn guided_choice_maps_to_escaped_regex() {
+        let request = proto::GenerateRequest {
+            sampling_params: Some(proto::SamplingParams {
+                guided_decoding: Some(proto::GuidedDecoding {
+                    constraint: Some(proto::guided_decoding::Constraint::Choice(
+                        proto::ChoiceConstraint {
+                            values: vec!["a+b".into(), "x.y".into()],
+                        },
+                    )),
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let mapped = build_generate_dict("request", &request).unwrap();
+        assert_eq!(
+            mapped["sampling_params"]["regex"],
+            serde_json::json!("(?:a\\+b|x\\.y)")
+        );
+    }
+
+    #[test]
+    fn invalid_guidance_combinations_are_rejected() {
+        let conflicting = proto::GenerateRequest {
+            sampling_params: Some(proto::SamplingParams {
+                regex: Some("[a-z]+".into()),
+                guided_decoding: Some(proto::GuidedDecoding {
+                    constraint: Some(proto::guided_decoding::Constraint::Regex("[0-9]+".into())),
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let empty_choice = proto::GenerateRequest {
+            sampling_params: Some(proto::SamplingParams {
+                guided_decoding: Some(proto::GuidedDecoding {
+                    constraint: Some(proto::guided_decoding::Constraint::Choice(
+                        proto::ChoiceConstraint { values: vec![] },
+                    )),
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let empty_legacy_regex = proto::GenerateRequest {
+            sampling_params: Some(proto::SamplingParams {
+                regex: Some(String::new()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        for request in [conflicting, empty_choice, empty_legacy_regex] {
+            assert!(build_generate_dict("request", &request).is_err());
         }
     }
 }

--- a/test/registered/4-gpu-models/test_nvidia_nemotron_3_super_nvfp4.py
+++ b/test/registered/4-gpu-models/test_nvidia_nemotron_3_super_nvfp4.py
@@ -12,7 +12,7 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
-register_cuda_ci(est_time=540, suite="nightly-4-gpu-b200", nightly=True)
+register_cuda_ci(est_time=810, suite="nightly-4-gpu-b200", nightly=True)
 
 NEMOTRON_3_SUPER_NVFP4_MODEL = "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4"
 
@@ -27,6 +27,31 @@ NEMOTRON_3_SUPER_NVFP4_ARGS = [
     "--disable-radix-cache",
     "--model-loader-extra-config",
     '{"enable_multithread_load": true, "num_threads": 17}',
+]
+
+DP_ATTENTION_EP_ARGS = [
+    "--dp-size",
+    "4",
+    "--enable-dp-attention",
+    "--enable-dp-lm-head",
+    "--ep-size",
+    "4",
+    "--moe-a2a-backend",
+    "flashinfer",
+    "--moe-runner-backend",
+    "flashinfer_cutedsl",
+    "--mamba-full-memory-ratio",
+    "5.0",
+    "--mamba-radix-cache-strategy",
+    "extra_buffer",
+    "--attention-backend",
+    "trtllm_mha",
+    "--max-running-requests",
+    "1024",
+    "--mem-fraction-static",
+    "0.93",
+    "--max-prefill-tokens",
+    "8192",
 ]
 
 MTP_ARGS = [
@@ -97,6 +122,33 @@ class TestNvidiaNemotron3SuperNVFP4MTP(CustomTestCase):
                 cls.base_url,
                 timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
                 other_args=NEMOTRON_3_SUPER_NVFP4_ARGS + MTP_ARGS,
+            )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_gsm8k(self):
+        _run_gsm8k(self)
+
+
+class TestNvidiaNemotron3SuperNVFP4DPAttentionEP(CustomTestCase):
+    """DP attention + EP with the FlashInfer one-sided A2A and CuteDSL MoE runner."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = NEMOTRON_3_SUPER_NVFP4_MODEL
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        with (
+            envs.SGLANG_ENABLE_ASYNC_ASSERT.override(0),
+            envs.SGLANG_FLASHINFER_NUM_MAX_DISPATCH_TOKENS_PER_RANK.override(4096),
+            envs.SGLANG_FLASHINFER_WORKSPACE_SIZE.override(1024 * 1024 * 1024),
+        ):
+            cls.process = popen_launch_server(
+                cls.model,
+                cls.base_url,
+                timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+                other_args=NEMOTRON_3_SUPER_NVFP4_ARGS + DP_ATTENTION_EP_ARGS,
             )
 
     @classmethod

--- a/test/registered/8-gpu-models/test_glm52_fp8.py
+++ b/test/registered/8-gpu-models/test_glm52_fp8.py
@@ -15,7 +15,7 @@ COMMON_ARGS = [
     "--trust-remote-code",
     "--reasoning-parser=glm45",
     "--tool-call-parser=glm47",
-    "--mem-fraction-static=0.85",
+    "--mem-fraction-static=0.8",
     "--enable-metrics",
 ]
 

--- a/test/registered/8-gpu-models/test_longcat_flash_lite_fp8.py
+++ b/test/registered/8-gpu-models/test_longcat_flash_lite_fp8.py
@@ -6,8 +6,7 @@ from sglang.test.performance_test_runner import PerformanceTestParams
 from sglang.test.run_combined_tests import run_combined_tests
 from sglang.test.test_utils import ModelLaunchSettings
 
-# Runs on both H200 and B200 via the nightly-8-gpu-common suite.
-register_cuda_ci(est_time=1200, suite="nightly-8-gpu-common", nightly=True)
+register_cuda_ci(est_time=1200, suite="nightly-8-gpu-h200", nightly=True)
 
 # LongCat-Flash-Lite-FP8 is the smallest member of the LongCat family
 # (~138 GB FP8 weights, hidden=3072, 14 layers, 256 routed + 128 zero
@@ -20,7 +19,6 @@ register_cuda_ci(est_time=1200, suite="nightly-8-gpu-common", nightly=True)
 # LongcatFlashNgramForCausalLM is remapped to model_type "longcat_flash")
 # with LongCat-Flash-Chat-FP8 and LongCat-2.0-FP8, so it guards the shared
 # code paths that recent LongCat EP fixes touched:
-#   - the scheduler moe-topk gate for --moe-a2a-backend (PR #30975)
 #   - ScMoE dense-branch gather (RoPE) + the MoE-vs-DeepEPMoE double
 #     all_reduce fix (PR #31311)
 #   - the zero-expert (identity) compute path (zero_expert_num=128) and
@@ -41,28 +39,14 @@ class TestLongCatFlashLiteFp8(unittest.TestCase):
 
     Two variants exercise the two MoE all-to-all backends that the LongCat
     EP fixes gate on:
-      - EP8 + deepep : real expert parallelism (the path #30975/#31311 fix)
       - EP8 + none   : EP-over-TP baseline (all_reduce / gather correctness)
+      - EP8 + deepep : real expert parallelism (the path #30975/#31311 fix),
+        skipped until DeepEP raises its low-latency top-k cap to 12
     """
 
-    def test_longcat_flash_lite_fp8(self):
-        variants = [
-            ModelLaunchSettings(
-                LONGCAT_FLASH_LITE_FP8_MODEL_PATH,
-                tp_size=8,
-                extra_args=COMMON_ARGS + ["--ep=8"],
-                variant="TP8+EP8+none",
-            ),
-            ModelLaunchSettings(
-                LONGCAT_FLASH_LITE_FP8_MODEL_PATH,
-                tp_size=8,
-                extra_args=COMMON_ARGS + ["--ep=8", "--moe-a2a-backend=deepep"],
-                variant="TP8+EP8+deepep",
-            ),
-        ]
-
+    def _run(self, variant: ModelLaunchSettings):
         run_combined_tests(
-            models=variants,
+            models=[variant],
             test_name="LongCat-Flash-Lite-FP8",
             # Measured 2026-07-22 on 8xH100-80GB, gsm8k 200q, 5-shot, greedy:
             #   TP8+EP8+none   -> 0.840
@@ -76,6 +60,30 @@ class TestLongCatFlashLiteFp8(unittest.TestCase):
             performance_params=PerformanceTestParams(
                 profile_dir="performance_profiles_longcat_flash_lite_fp8",
             ),
+        )
+
+    def test_longcat_flash_lite_fp8(self):
+        self._run(
+            ModelLaunchSettings(
+                LONGCAT_FLASH_LITE_FP8_MODEL_PATH,
+                tp_size=8,
+                extra_args=COMMON_ARGS + ["--ep=8"],
+                variant="TP8+EP8+none",
+            )
+        )
+
+    @unittest.skip(
+        "Blocked: DeepEP low-latency dispatch asserts num_topk <= kNumMaxTopK "
+        "(11 in internode_ll.cu), LongCat moe_topk is 12."
+    )
+    def test_longcat_flash_lite_fp8_deepep(self):
+        self._run(
+            ModelLaunchSettings(
+                LONGCAT_FLASH_LITE_FP8_MODEL_PATH,
+                tp_size=8,
+                extra_args=COMMON_ARGS + ["--ep=8", "--moe-a2a-backend=deepep"],
+                variant="TP8+EP8+deepep",
+            )
         )
 
 

--- a/test/registered/8-gpu-models/test_mistral_large3.py
+++ b/test/registered/8-gpu-models/test_mistral_large3.py
@@ -1,6 +1,7 @@
 import os
 import unittest
 
+from sglang.srt.environ import envs
 from sglang.test.accuracy_test_runner import AccuracyTestParams
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.performance_test_runner import PerformanceTestParams
@@ -84,14 +85,17 @@ class TestMistralLarge3(unittest.TestCase):
             ),
         ]
 
-        run_combined_tests(
-            models=variants,
-            test_name="Mistral-Large-3",
-            accuracy_params=AccuracyTestParams(dataset="gsm8k", baseline_accuracy=0.85),
-            performance_params=PerformanceTestParams(
-                profile_dir="performance_profiles_mistral_large3",
-            ),
-        )
+        with envs.SGLANG_ENABLE_ASYNC_ASSERT.override(0):
+            run_combined_tests(
+                models=variants,
+                test_name="Mistral-Large-3",
+                accuracy_params=AccuracyTestParams(
+                    dataset="gsm8k", baseline_accuracy=0.85
+                ),
+                performance_params=PerformanceTestParams(
+                    profile_dir="performance_profiles_mistral_large3",
+                ),
+            )
 
 
 if __name__ == "__main__":

--- a/test/registered/8-gpu-models/test_qwen35.py
+++ b/test/registered/8-gpu-models/test_qwen35.py
@@ -30,7 +30,7 @@ class TestQwen35(unittest.TestCase):
             "--tool-call-parser=qwen3_coder",
             "--mem-fraction-static=0.8",
         ]
-        dp_args = ["--dp=8", "--enable-dp-attention"]
+        dp_args = ["--dp=8", "--enable-dp-attention", "--disable-prefill-cuda-graph"]
         mtp_args = [
             "--speculative-algorithm=EAGLE",
             "--speculative-num-steps=3",

--- a/test/registered/8-gpu-models/test_qwen35.py
+++ b/test/registered/8-gpu-models/test_qwen35.py
@@ -30,7 +30,7 @@ class TestQwen35(unittest.TestCase):
             "--tool-call-parser=qwen3_coder",
             "--mem-fraction-static=0.8",
         ]
-        dp_args = ["--dp=8", "--enable-dp-attention", "--disable-prefill-cuda-graph"]
+        dp_args = ["--dp=8", "--enable-dp-attention"]
         mtp_args = [
             "--speculative-algorithm=EAGLE",
             "--speculative-num-steps=3",

--- a/test/registered/disaggregation/test_disaggregation_pipelined_kv_transfer.py
+++ b/test/registered/disaggregation/test_disaggregation_pipelined_kv_transfer.py
@@ -1,0 +1,65 @@
+import unittest
+from types import SimpleNamespace
+from typing import ClassVar
+
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.run_eval import run_eval
+from sglang.test.server_fixtures.disaggregation_fixture import (
+    PDDisaggregationServerBase,
+)
+from sglang.test.test_utils import DEFAULT_MODEL_NAME_FOR_TEST
+
+register_cuda_ci(est_time=900, stage="base-b", runner_config="2-gpu-large")
+
+# Matches the non-pipelined PD Llama baseline in test_disaggregation_basic.py.
+GSM8K_ACCURACY_FLOOR = 0.62
+# Force a fixed group size so pipelining actually engages: gsm8k prompts fall
+# below SGLANG_PIPELINE_MIN_TOKENS, so the adaptive sizer would otherwise skip
+# pipelining and the "enabled" run would silently reduce to the baseline path.
+PIPELINE_GROUP_SIZE = "8"
+
+
+class _GSM8KAccuracyMixin:
+    """Shared launch + gsm8k eval; concrete classes flip ``pipeline_enabled``."""
+
+    pipeline_enabled: ClassVar[bool] = False
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.model = DEFAULT_MODEL_NAME_FOR_TEST
+        if cls.pipeline_enabled:
+            cls.extra_prefill_env = {
+                "SGLANG_ENABLE_PIPELINED_KV_TRANSFER": "1",
+                "SGLANG_PIPELINE_GROUP_SIZE": PIPELINE_GROUP_SIZE,
+            }
+        cls.launch_all()
+
+    def test_gsm8k(self):
+        args = SimpleNamespace(
+            base_url=f"http://{self.base_host}:{self.lb_port}",
+            eval_name="gsm8k",
+            api="completion",
+            max_tokens=512,
+            num_examples=200,
+            num_threads=128,
+        )
+        metrics = run_eval(args)
+        print(f"pipeline_enabled={self.pipeline_enabled} metrics: {metrics}")
+        self.assertGreater(metrics["score"], GSM8K_ACCURACY_FLOOR)
+
+
+class TestPipelinedKVTransferDisabled(
+    _GSM8KAccuracyMixin, PDDisaggregationServerBase
+):
+    pipeline_enabled = False
+
+
+class TestPipelinedKVTransferEnabled(
+    _GSM8KAccuracyMixin, PDDisaggregationServerBase
+):
+    pipeline_enabled = True
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/entrypoints/test_grpc_bridge.py
+++ b/test/registered/unit/entrypoints/test_grpc_bridge.py
@@ -1,0 +1,115 @@
+import asyncio
+import enum
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.entrypoints.grpc_bridge import RuntimeHandle
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class _ChunkStatus(enum.Enum):
+    Ready = 1
+    Pending = 2
+    Closed = 3
+
+
+class _RecordingCallback:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, payload, *, finished=False, error=None):
+        self.calls.append((payload, finished, error))
+        return _ChunkStatus.Ready
+
+
+class _FakeTokenizerManager:
+    def __init__(self, responses):
+        self.responses = responses
+
+    def generate_request(self, obj, request=None):
+        async def generate():
+            for response in self.responses:
+                yield response
+
+        return generate()
+
+
+def _make_runtime_handle(responses):
+    handle = RuntimeHandle.__new__(RuntimeHandle)
+    handle.tokenizer_manager = _FakeTokenizerManager(responses)
+    return handle
+
+
+class TestNativeGrpcParallelResponses(CustomTestCase):
+    def test_non_streaming_returns_every_choice_before_finishing(self):
+        callback = _RecordingCallback()
+        responses = [
+            [
+                {"output_ids": [1], "meta_info": {"id": "choice-0"}},
+                {"output_ids": [2], "meta_info": {"id": "choice-1"}},
+            ]
+        ]
+        handle = _make_runtime_handle(responses)
+        obj = SimpleNamespace(rid="logical", batch_size=1, parallel_sample_num=2)
+
+        asyncio.run(
+            handle._run_generate(
+                obj,
+                callback,
+                stream=False,
+                request=None,
+            )
+        )
+
+        self.assertEqual([call[0]["output_ids"] for call in callback.calls], [[1], [2]])
+        self.assertEqual([call[1] for call in callback.calls], [False, True])
+
+    def test_streaming_first_finished_choice_is_not_batch_terminal(self):
+        callback = _RecordingCallback()
+        responses = [
+            {
+                "index": 0,
+                "output_ids": [1],
+                "meta_info": {"id": "choice-0", "finish_reason": None},
+            },
+            {
+                "index": 0,
+                "output_ids": [2],
+                "meta_info": {
+                    "id": "choice-0",
+                    "finish_reason": {"type": "stop"},
+                },
+            },
+            {
+                "index": 1,
+                "output_ids": [3],
+                "meta_info": {
+                    "id": "choice-1",
+                    "finish_reason": {"type": "stop"},
+                },
+            },
+        ]
+        handle = _make_runtime_handle(responses)
+        obj = SimpleNamespace(rid="logical", batch_size=1, parallel_sample_num=2)
+
+        asyncio.run(
+            handle._run_generate(
+                obj,
+                callback,
+                stream=True,
+                request=None,
+            )
+        )
+
+        self.assertEqual(
+            [call[0]["output_ids"] for call in callback.calls],
+            [[1], [2], [3]],
+        )
+        self.assertEqual([call[1] for call in callback.calls], [False, False, True])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -305,6 +305,38 @@ class TestGenerateReqInputNormalization(CustomTestCase):
         # Modalities should be set for all 3 examples
         self.assertEqual(req.modalities, ["image", "image", "image"])
 
+    def test_parallel_sampling_keeps_one_logical_rid_per_prompt(self):
+        """Test logical RID and reasoning control preservation across parallel samples."""
+        single = GenerateReqInput(
+            text="Hello",
+            rid="single",
+            sampling_params={"n": 3},
+            require_reasoning=True,
+            max_thinking_tokens=128,
+        )
+        single.normalize_batch_and_arguments()
+
+        self.assertEqual(single.rid, ["single"])
+        self.assertEqual([single[i].rid for i in range(3)], ["single"] * 3)
+        self.assertTrue(all(single[i].require_reasoning for i in range(3)))
+        self.assertEqual(
+            [single[i].max_thinking_tokens for i in range(3)],
+            [128] * 3,
+        )
+
+        batch = GenerateReqInput(
+            text=["Hello", "World"],
+            rid="batch",
+            sampling_params={"n": 2},
+        )
+        batch.normalize_batch_and_arguments()
+
+        self.assertEqual(batch.rid, ["batch_0", "batch_1"])
+        self.assertEqual(
+            [batch[i].rid for i in range(4)],
+            ["batch_0", "batch_1", "batch_0", "batch_1"],
+        )
+
     def test_audio_data_handling(self):
         """Test handling of audio_data."""
         req = copy.deepcopy(self.base_req)
@@ -647,6 +679,15 @@ class TestGenerateReqInputNormalization(CustomTestCase):
 
         self.assertNotEqual(original_rid, new_rid)
         self.assertEqual(req.rid, new_rid)
+
+    def test_regenerate_rid_with_parent_prefix(self):
+        """Test RID regeneration with a logical parent prefix."""
+        req = GenerateReqInput(text="Hello", rid="logical")
+        req.normalize_batch_and_arguments()
+
+        new_rid = req.regenerate_rid(prefix="logical")
+
+        self.assertTrue(new_rid.startswith("logical_"))
 
     def test_error_cases(self):
         """Test various error cases."""

--- a/test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
+++ b/test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
@@ -23,9 +23,19 @@ from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
 
 maybe_stub_sgl_kernel()
 
-from sglang.srt.managers.io_struct import AbortReq, BatchStrOutput, GenerateReqInput
-from sglang.srt.managers.tokenizer_manager import ReqState, TokenizerManager
-from sglang.srt.observability.req_time_stats import APIServerReqTimeStats
+from sglang.srt.managers.io_struct import (  # noqa: E402
+    AbortReq,
+    BatchStrOutput,
+    GenerateReqInput,
+)
+from sglang.srt.managers.tokenizer_manager import (  # noqa: E402
+    ReqState,
+    RequestAbortedError,
+    TokenizerManager,
+)
+from sglang.srt.observability.req_time_stats import (  # noqa: E402
+    APIServerReqTimeStats,
+)
 
 register_cpu_ci(est_time=15, suite="base-a-test-cpu")
 
@@ -111,6 +121,8 @@ def _make_tokenizer_manager() -> TokenizerManager:
     tm.server_args.dp_size = 1
     tm.disaggregation_mode = "none"
     tm.rid_to_state = {}
+    tm.logical_rid_to_child_rids = {}
+    tm.child_rid_to_logical_rid = {}
     tm.enable_metrics = False
     tm.enable_trace = False
     tm.enable_lora = False
@@ -120,10 +132,11 @@ def _make_tokenizer_manager() -> TokenizerManager:
     tm.dump_requests_folder = ""
     tm.crash_dump_folder = ""
     tm.send_to_scheduler = MagicMock()
+    tm._dispatch_to_scheduler = Mock()
     return tm
 
 
-def _make_req_state(rid: str = "test_rid") -> ReqState:
+def _make_req_state(rid: str = "test_rid", *, dispatched: bool = False) -> ReqState:
     """Create a minimal ReqState for testing."""
     obj = Mock(spec=GenerateReqInput)
     obj.rid = rid
@@ -137,6 +150,7 @@ def _make_req_state(rid: str = "test_rid") -> ReqState:
         event=asyncio.Event(),
         obj=obj,
         time_stats=APIServerReqTimeStats(),
+        dispatched=dispatched,
     )
 
 
@@ -338,6 +352,19 @@ class TestInitReqStateDuplicateDetection(CustomTestCase):
         tm._init_req_state(obj)
         self.assertIn(rid, tm.rid_to_state)
 
+    def test_batch_duplicate_preflight_does_not_insert_partial_state(self):
+        tm = _make_tokenizer_manager()
+        existing_rid = "existing"
+        existing_state = _make_req_state(existing_rid)
+        tm.rid_to_state[existing_rid] = existing_state
+        obj = _make_generate_obj(["new", existing_rid], is_single=False)
+
+        with self.assertRaisesRegex(ValueError, "Duplicate request ID"):
+            tm._init_req_state(obj)
+
+        self.assertNotIn("new", tm.rid_to_state)
+        self.assertIs(tm.rid_to_state[existing_rid], existing_state)
+
 
 class TestResubmitAfterCompletion(CustomTestCase):
     """End-to-end test: complete a request, then resubmit with the same rid."""
@@ -409,6 +436,7 @@ def _make_tm_for_generate() -> TokenizerManager:
     tm = _make_tokenizer_manager()
     tm.server_args.language_only = False
     tm.server_args.tokenizer_worker_num = 1
+    tm.server_args.enable_strict_thinking = False
     tm.auto_create_handle_loop = Mock()
     tm._set_default_priority = Mock()
     tm.request_logger = Mock()
@@ -429,6 +457,7 @@ def _make_generate_obj(rid, is_single):
     obj.received_time = 0.0
     obj.external_trace_header = None
     obj.bootstrap_room = None
+    obj.max_thinking_tokens = None
     obj.normalize_batch_and_arguments = Mock()
     if not is_single:
         obj.__getitem__.side_effect = lambda i: Mock()
@@ -438,17 +467,20 @@ def _make_generate_obj(rid, is_single):
 class TestDiscardPendingReqStates(CustomTestCase):
     """Direct tests for _discard_pending_req_states."""
 
-    def test_discard_single(self):
+    def test_discard_single_aborts_scheduler_before_cleanup(self):
         tm = _make_tokenizer_manager()
         rid = "d_single"
-        tm.rid_to_state[rid] = _make_req_state(rid)
+        tm.rid_to_state[rid] = _make_req_state(rid, dispatched=True)
         obj = Mock(spec=GenerateReqInput)
         obj.is_single = True
         obj.rid = rid
         tm._discard_pending_req_states(obj)
         self.assertNotIn(rid, tm.rid_to_state)
+        abort_req = tm._dispatch_to_scheduler.call_args.args[0]
+        self.assertEqual(abort_req.rid, rid)
+        self.assertFalse(abort_req.abort_all)
 
-    def test_discard_batch_removes_all(self):
+    def test_discard_unsent_batch_without_scheduler_abort(self):
         tm = _make_tokenizer_manager()
         rids = ["d0", "d1", "d2"]
         for r in rids:
@@ -459,6 +491,7 @@ class TestDiscardPendingReqStates(CustomTestCase):
         tm._discard_pending_req_states(obj)
         for r in rids:
             self.assertNotIn(r, tm.rid_to_state)
+        tm._dispatch_to_scheduler.assert_not_called()
 
     def test_discard_ignores_already_removed(self):
         """Popping a rid that is no longer present must not raise."""
@@ -469,6 +502,150 @@ class TestDiscardPendingReqStates(CustomTestCase):
         obj.rid = ["p1", "already_gone"]
         tm._discard_pending_req_states(obj)  # must not raise
         self.assertNotIn("p1", tm.rid_to_state)
+
+    def test_parallel_cleanup_aborts_children_and_allows_parent_reuse(self):
+        tm = _make_tokenizer_manager()
+        parent = _make_generate_obj("parent", is_single=True)
+        lifecycle_ids = tm._init_req_state(parent)
+
+        child_rids = {"prefix", "choice_0", "choice_1"}
+        for child_rid in child_rids:
+            child = _make_generate_obj(child_rid, is_single=True)
+            tm._init_child_req_state("parent", child)
+            tm.rid_to_state[child_rid].dispatched = True
+        tm._remove_req_state("parent")
+
+        tm._discard_pending_req_states(parent, lifecycle_ids)
+
+        aborted_rids = {
+            call.args[0].rid for call in tm._dispatch_to_scheduler.call_args_list
+        }
+        self.assertEqual(aborted_rids, child_rids)
+        self.assertFalse(tm.rid_to_state)
+        self.assertFalse(tm.logical_rid_to_child_rids)
+        self.assertFalse(tm.child_rid_to_logical_rid)
+
+        tm._init_req_state(_make_generate_obj("parent", is_single=True))
+        self.assertIn("parent", tm.rid_to_state)
+
+    def test_stale_cleanup_does_not_remove_reused_rid(self):
+        tm = _make_tokenizer_manager()
+        old_obj = _make_generate_obj("reused", is_single=True)
+        old_lifecycle_ids = tm._init_req_state(old_obj)
+        tm._remove_req_state("reused")
+
+        replacement = _make_generate_obj("reused", is_single=True)
+        tm._init_req_state(replacement)
+        replacement_state = tm.rid_to_state["reused"]
+
+        tm._discard_pending_req_states(old_obj, old_lifecycle_ids)
+
+        self.assertIs(tm.rid_to_state["reused"], replacement_state)
+        tm._dispatch_to_scheduler.assert_not_called()
+
+
+class TestParallelAbortRouting(CustomTestCase):
+    def test_parent_abort_fans_out_to_children(self):
+        tm = _make_tokenizer_manager()
+        tm.server_args.tokenizer_worker_num = 1
+        tm._register_child_rid("parent", "choice_0")
+        tm._register_child_rid("parent", "choice_1")
+
+        tm.abort_request("parent")
+
+        requests = [call.args[0] for call in tm._dispatch_to_scheduler.call_args_list]
+        self.assertEqual(
+            {request.rid for request in requests}, {"choice_0", "choice_1"}
+        )
+        self.assertTrue(all(not request.abort_all for request in requests))
+
+
+class TestParallelStreamTaskCleanup(CustomTestCase):
+    def test_failing_choice_cancels_and_closes_sibling_waiters(self):
+        tm = _make_tokenizer_manager()
+
+        async def drive():
+            sibling_closed = asyncio.Event()
+
+            async def failing_choice():
+                await asyncio.sleep(0)
+                raise RuntimeError("choice failed")
+                yield  # pragma: no cover
+
+            async def blocked_choice():
+                try:
+                    await asyncio.Event().wait()
+                    yield  # pragma: no cover
+                finally:
+                    sibling_closed.set()
+
+            stream = tm._stream_batch_responses(
+                [failing_choice(), blocked_choice()],
+                ["choice-0", "choice-1"],
+            )
+            with self.assertRaisesRegex(RuntimeError, "choice failed"):
+                await stream.__anext__()
+            self.assertTrue(sibling_closed.is_set())
+
+        asyncio.run(drive())
+
+    def test_failing_non_stream_choice_cancels_and_closes_sibling_waiters(self):
+        tm = _make_tokenizer_manager()
+
+        async def drive():
+            sibling_closed = asyncio.Event()
+
+            async def failing_choice():
+                await asyncio.sleep(0)
+                raise RuntimeError("choice failed")
+                yield  # pragma: no cover
+
+            async def blocked_choice():
+                try:
+                    await asyncio.Event().wait()
+                    yield  # pragma: no cover
+                finally:
+                    sibling_closed.set()
+
+            with self.assertRaisesRegex(RuntimeError, "choice failed"):
+                await tm._collect_batch_responses([failing_choice(), blocked_choice()])
+            self.assertTrue(sibling_closed.is_set())
+
+        asyncio.run(drive())
+
+
+class TestParallelRidReuse(CustomTestCase):
+    def test_completed_n2_request_can_repeat_the_same_logical_rid(self):
+        tm = _make_tokenizer_manager()
+
+        async def complete_child(rid):
+            await tm._handle_batch_output(_make_batch_str_output(rid))
+
+        for _ in range(2):
+            logical = GenerateReqInput(
+                text="hello",
+                rid="repeat-n2",
+                sampling_params={"n": 2},
+            )
+            logical.normalize_batch_and_arguments()
+            tm._init_req_state(logical)
+
+            prefix = GenerateReqInput(text="hello", rid="prefix")
+            prefix.normalize_batch_and_arguments()
+            tm._init_child_req_state("repeat-n2", prefix)
+            asyncio.run(complete_child("prefix"))
+
+            for child_rid in ("choice-0", "choice-1"):
+                child = GenerateReqInput(text="hello", rid=child_rid)
+                child.normalize_batch_and_arguments()
+                tm._init_child_req_state("repeat-n2", child)
+            tm._remove_req_state("repeat-n2")
+            asyncio.run(complete_child("choice-0"))
+            asyncio.run(complete_child("choice-1"))
+
+            self.assertFalse(tm.rid_to_state)
+            self.assertFalse(tm.logical_rid_to_child_rids)
+            self.assertFalse(tm.child_rid_to_logical_rid)
 
 
 class TestGenerateRequestCleanupOnDispatchFailure(CustomTestCase):
@@ -497,6 +674,7 @@ class TestGenerateRequestCleanupOnDispatchFailure(CustomTestCase):
         # Got past _init_req_state (which created the entry) ...
         tm._tokenize_one_request.assert_awaited_once()
         tm._send_one_request.assert_not_called()
+        tm._dispatch_to_scheduler.assert_not_called()
         # ... and the entry was cleaned up rather than leaked.
         self.assertNotIn(rid, tm.rid_to_state)
 
@@ -521,6 +699,66 @@ class TestGenerateRequestCleanupOnDispatchFailure(CustomTestCase):
         # All sub-request entries created by _init_req_state are cleaned up.
         for r in rids:
             self.assertNotIn(r, tm.rid_to_state)
+        tm._dispatch_to_scheduler.assert_not_called()
+
+    def test_interrupted_parallel_tokenization_prevents_child_dispatch(self):
+        for remove_state in (False, True):
+            with self.subTest(remove_state=remove_state):
+                tm = _make_tm_for_generate()
+                tm._send_one_request = Mock()
+                obj = GenerateReqInput(
+                    text="hello",
+                    rid="interrupted-during-tokenization",
+                    sampling_params={"n": 2},
+                )
+
+                async def drive():
+                    tokenization_started = asyncio.Event()
+                    allow_tokenization = asyncio.Event()
+
+                    async def blocked_tokenization(_obj):
+                        tokenization_started.set()
+                        await allow_tokenization.wait()
+                        return MagicMock()
+
+                    tm._tokenize_one_request = blocked_tokenization
+                    response = tm.generate_request(obj)
+                    task = asyncio.create_task(response.__anext__())
+                    await tokenization_started.wait()
+                    if remove_state:
+                        tm._remove_req_state("interrupted-during-tokenization")
+                    else:
+                        tm.abort_request("interrupted-during-tokenization")
+                    allow_tokenization.set()
+                    with self.assertRaisesRegex(
+                        RequestAbortedError, "interrupted-during-tokenization"
+                    ):
+                        await task
+
+                asyncio.run(drive())
+
+                tm._send_one_request.assert_not_called()
+                tm._dispatch_to_scheduler.assert_not_called()
+                self.assertFalse(tm.rid_to_state)
+                self.assertFalse(tm.logical_rid_to_child_rids)
+                self.assertFalse(tm.child_rid_to_logical_rid)
+
+    def test_thinking_budget_rejects_runtime_without_strict_thinking(self):
+        tm = _make_tm_for_generate()
+        obj = GenerateReqInput(
+            text="hello",
+            rid="thinking-budget",
+            sampling_params={},
+            max_thinking_tokens=32,
+        )
+
+        async def drive():
+            await tm.generate_request(obj).__anext__()
+
+        with self.assertRaisesRegex(ValueError, "--enable-strict-thinking"):
+            asyncio.run(drive())
+
+        self.assertFalse(tm.rid_to_state)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/mem_cache/test_mamba_donated_alloc_ratio.py
+++ b/test/registered/unit/mem_cache/test_mamba_donated_alloc_ratio.py
@@ -232,5 +232,84 @@ class TestMambaDonatedAllocRatio(unittest.TestCase):
         self.assertEqual(len(cache.prefix_nodes), N - 1)
 
 
+class TestPPMambaPoolSizing(unittest.TestCase):
+    """A PP rank only allocates mamba state for its own [start_layer, end_layer)
+    slice, so charging it for the whole model's layers starves the pool. Sizing
+    uses the largest per-stage share, which also keeps every rank on the same
+    pool size (and hence the same max_running_requests / pp_max_micro_batch_size)
+    without a collective."""
+
+    # Kimi-K3 shaped: 93 layers, linear attention everywhere except every 4th and
+    # the last, so the 69 mamba layers split unevenly over 8 stages (9 or 8 each).
+    TOTAL_LAYERS = 93
+    MAMBA_LAYERS = [i for i in range(93) if (i + 1) % 4 != 0 and i <= 90]
+    BUDGET_GB = 8.0
+
+    @classmethod
+    def _pool_size(cls, pp_rank, pp_size):
+        from sglang.srt import runtime_context as rc
+        from sglang.srt.configs.mamba_utils import (
+            Mamba2CacheParams,
+            Mamba2StateDType,
+            Mamba2StateShape,
+        )
+        from sglang.srt.distributed.utils import get_pp_indices
+        from sglang.srt.mem_cache.kv_cache_configurator import KVCacheConfigurator
+        from sglang.srt.runtime_context import get_schedule
+
+        shape = Mamba2StateShape(
+            conv=[(4096, 3)],
+            temporal=(64, 128, 128),
+            intermediate_size=0,
+            conv_dim=0,
+            ssm_state_size=0,
+            num_heads=0,
+            head_dim=0,
+            state_size=0,
+            conv_kernel=0,
+            num_k_heads_per_tp=8,
+        )
+        params = Mamba2CacheParams(
+            shape=shape,
+            dtype=Mamba2StateDType(conv=torch.bfloat16, temporal=torch.float32),
+            layers=list(cls.MAMBA_LAYERS),
+        )
+        start, end = get_pp_indices(cls.TOTAL_LAYERS, pp_rank, pp_size)
+        fake = SimpleNamespace(
+            mambaish_config=SimpleNamespace(mamba2_cache_params=params),
+            server_args=SimpleNamespace(),
+            spec_algorithm=SimpleNamespace(is_none=lambda: True),
+            layer_info=SimpleNamespace(start_layer=start, end_layer=end),
+            ps=SimpleNamespace(attn_dp_size=1, pp_size=pp_size),
+            hybrid_gdn_config=None,
+            model_config=SimpleNamespace(
+                hf_config=SimpleNamespace(), num_hidden_layers=cls.TOTAL_LAYERS
+            ),
+        )
+        with rc.get_context().override_server_args(
+            disable_radix_cache=False,
+            max_mamba_cache_size=None,
+            max_running_requests=None,
+            mamba_full_memory_ratio=0.5,
+            enable_linear_replayssm_spec=False,
+        ):
+            KVCacheConfigurator._handle_max_mamba_cache(fake, cls.BUDGET_GB)
+            return get_schedule().max_mamba_cache_size
+
+    def test_stage_is_not_charged_for_the_whole_model(self):
+        solo = self._pool_size(0, 1)
+        staged = self._pool_size(0, 8)
+        # The busiest stage holds 9 of the 69 mamba layers, so it should fit
+        # roughly 69/9 more slots than a rank holding all of them. pp_size=1 is
+        # unchanged: that rank does hold every layer.
+        self.assertGreater(staged, solo * 5)
+
+    def test_every_stage_agrees_on_the_pool_size(self):
+        sizes = {self._pool_size(r, 8) for r in range(8)}
+        self.assertEqual(
+            len(sizes), 1, f"per-rank pool sizes diverged: {sorted(sizes)}"
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Reduce time-to-first-token for prefill/decode disaggregation by overlapping prefill layer computation with KV/state transfer from the prefill instance to the decode instance. The regular transfer path remains available through compatibility checks and fallback.

## Modifications

- **KV manager-side:** Add per-layer subset transfer APIs for KV and state buffers, request-scoped layer-pipelining contexts, ready-event ordering, subset byte accounting, and final metadata requests. Mooncake implements the selected-buffer transfers.
- **Memory pool-side:** Register target and draft `layer_id -> buffer handles` mappings for MHA/MLA, DSA, SWA, Mamba, and DeepSeek-V4 stateful pools, including buffer type, raw pointer indices, state component IDs, and final non-pipelined state.
- **Worker / runner-side:** Add split-prefill init, layer-group execution, and finalize interfaces. `ModelRunner` preserves hidden states, residuals, and model-specific state across layer groups and records CUDA events for transfer overlap.
- **Scheduler-side:** Encapsulate most layer-pipelining orchestration in `LayerPipelinedKVTransferAdapter`, including batch compatibility planning, adaptive or configured layer-group sizing, sender orchestration, final metadata handling, and regular-path fallback.
- **Model-side:** Add `forward_split_prefill` support and cross-group state handling for DeepSeek V2-family/V4 and Qwen3.5, and forward the split-prefill lifecycle through EAGLE-family and DSpark speculative workers.
> Currently, only the Mooncake transfer backend is supported.


**Support Matrix**

| Model         | TP | DP | EP | EAGLE | DSpark |
| ------------- | -- | -- | -- | ----- | ------ |
| Qwen3.5       | ✓ | ✓ | ✓ | ✓ |       |
| GLM-5.2       | ✓ | ✓ | ✓ | ✓ |       |
| DeepSeek-V3.2 | ✓ | ✓ | ✓ | ✓ |       |
| DeepSeek-V4   | ✓ | ✓ | ✓ | ✓ | ✓     |

## Accuracy Tests

Switching to layer-pipelined PD disaggregation with the Mooncake transfer backend does not degrade model accuracy. `OFF` is the regular transfer path and `ON` is the layer-pipelined path.

| Benchmark | OFF | ON |
| --------- | --- | -- |
| GSM8K     | 0.897 | 0.892 |
| C-Eval    | 0.845 | 0.841 |
| MMLU      | 0.789 | 0.792 |

## Speed Tests

Enable layer-pipelined transfer with `SGLANG_ENABLE_PIPELINED_KV_TRANSFER=1`.
Scene format: `C<concurrency> <input>-<output>`; for example, `C10 4K-0.125K` means 10 concurrent requests with 4K input tokens and 0.125K output tokens.

**Qwen3.5-35B-A3B-FP8**

PD-disaggregated benchmark on 4 NVIDIA 5090 GPUs; `OFF/ON` denotes baseline/layer-wise transfer.

| Scenario      | Parallel Strategy | Input Throughput (tokens/s) OFF/ON | Output Throughput (tokens/s) OFF/ON | Mean TTFT (ms) OFF/ON | P90 TTFT (ms) OFF/ON | P95 TTFT (ms) OFF/ON | Mean TPOT (ms) OFF/ON | P95 TPOT (ms) OFF/ON |
| ------------- | ----------------- | ---------------------------------: | ----------------------------------: | --------------------: | -------------------: | -------------------: | --------------------: | -------------------: |
| C10 4K-0.125K | TP2               |              30,399.43 / 32,885.79 |                   949.98 / 1,027.68 |       461.87 / 348.94 |      645.99 / 498.60 |      723.83 / 589.86 |           6.93 / 7.02 |          7.22 / 7.19 |
| C10 6K-0.5K   | TP2               |              14,281.27 / 14,431.71 |                 1,190.11 / 1,202.64 |       334.33 / 216.17 |      465.28 / 206.35 |      550.66 / 217.24 |           7.73 / 7.87 |          7.87 / 7.95 |
| C10 7K-0.5K   | TP2               |              16,545.01 / 16,636.18 |                 1,181.79 / 1,188.30 |       325.27 / 273.50 |      438.77 / 335.03 |      511.41 / 394.05 |           7.81 / 7.87 |          7.93 / 7.96 |
| C10 8K-0.5K   | TP2               |              18,808.17 / 18,856.81 |                 1,175.51 / 1,178.55 |       379.37 / 298.68 |      479.05 / 358.13 |      539.87 / 451.22 |           7.76 / 7.89 |          7.89 / 7.98 |

Summary: TTFT decreased by 15.9%-35.3%, while prefill throughput increased by 0.26%-8.18%.


**DeepSeek-V4-Flash**

PD-disaggregated benchmark on 8 NVIDIA H100 GPUs; `OFF/ON` denotes regular/layer-wise transfer.

| Scenario                   | Parallel Strategy | Input Throughput (tokens/s) OFF/ON | Output Throughput (tokens/s) OFF/ON | Mean TTFT (ms) OFF/ON |  P90 TTFT (ms) OFF/ON |  P95 TTFT (ms) OFF/ON | Mean TPOT (ms) OFF/ON | P95 TPOT (ms) OFF/ON |
| -------------------------- | ----------------- | ---------------------------------: | ----------------------------------: | --------------------: | --------------------: | --------------------: | --------------------: | -------------------: |
| C8 8K-2K                   | TP4               |                9,411.39 / 9,446.64 |                 2,352.85 / 2,361.66 |       756.48 / 746.17 |   1,318.11 / 1,203.94 |   1,465.89 / 1,409.32 |           3.01 / 3.00 |          3.55 / 3.54 |
| C32 8K-1K                  | TP4               |              24,054.09 / 24,668.91 |                 3,006.76 / 3,083.61 |   6,817.05 / 6,519.27 |   7,212.77 / 6,870.03 |   7,301.08 / 6,935.93 |           3.86 / 3.89 |          4.56 / 4.59 |
| C32 8K-2K                  | TP4               |              20,198.84 / 20,309.84 |                 5,049.71 / 5,077.46 |   1,610.85 / 1,559.41 |   2,353.27 / 2,389.30 |   2,696.59 / 2,682.25 |           5.49 / 5.49 |          6.45 / 6.44 |
| C64 8K-2K                  | TP4               |              23,637.95 / 24,178.51 |                 5,909.49 / 6,044.63 |   8,660.40 / 7,200.89 |   9,257.15 / 7,961.35 | 10,746.83 / 10,912.76 |           6.38 / 6.86 |          7.51 / 8.21 |
| C96 8K-2K                  | TP4               |              23,576.49 / 24,155.84 |                 5,894.12 / 6,038.96 | 19,106.61 / 17,523.72 | 20,094.92 / 18,509.29 | 21,578.45 / 20,945.96 |           6.39 / 6.79 |          7.50 / 8.00 |
| C128 8K-2K                 | TP4               |              23,502.80 / 24,148.14 |                 5,875.70 / 6,037.04 | 29,271.04 / 27,516.91 | 31,089.55 / 29,177.74 | 33,298.55 / 31,167.56 |           6.40 / 6.73 |          7.52 / 7.92 |
| C12 60K-5K                 | TP4               |              22,233.28 / 22,285.13 |                 1,852.77 / 1,857.09 | 18,103.12 / 18,036.83 | 19,581.01 / 19,530.80 | 19,817.29 / 19,762.27 |           2.82 / 2.83 |          3.41 / 3.43 |
| C12 60K-5K (50% cache hit) | TP4+DP4           |              36,632.01 / 36,643.63 |                 2,986.76 / 2,987.71 |   4,514.32 / 4,436.57 |   6,429.70 / 6,130.98 |   7,205.62 / 6,802.35 |           3.11 / 3.11 |          3.23 / 3.26 |
| C12 60K-5K (80% cache hit) | TP4+DP4           |              41,773.06 / 41,769.38 |                 3,405.56 / 3,405.26 |   1,596.86 / 1,502.11 |   2,470.05 / 2,000.49 |   2,966.25 / 3,345.81 |           3.18 / 3.20 |          3.29 / 3.35 |

Summary:

- At medium-to-high concurrency on 8K prompts (`C32 8K-1K` through `C128 8K-2K`), TTFT decreased by 4.4%-16.9% and prefill throughput increased by 2.3%-2.7%.
- At lower concurrency (`C8/C32 8K-2K`), gains were limited: TTFT decreased by 1.4%-3.2% and prefill throughput increased by 0.37%-0.55%.
- For `C12 60K-5K`, prefill queueing dominates TTFT, leaving limited room for compute-transfer overlap; TTFT decreased by 0.37% and prefill throughput increased by 0.23%.
- With 50%/80% cache hit, reduced prefill computation shortens the overlap window, making KV transfer more exposed on the critical path; TTFT decreased by 1.7%/5.9% and prefill throughput changed by +0.03%/-0.01%.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->