### PR TITLE
[Fix] NextN: derive the quant-config rename mapper from the checkpoint's MTP layer index

### DIFF
--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -307,7 +307,11 @@ def _get_quantization_config(
                 f"method {model_config.quantization}. Supported dtypes: "
                 f"{supported_dtypes}"
             )
-        hf_to_sglang_mapper = getattr(model_class, "hf_to_sglang_mapper", None)
+        get_mapper = getattr(model_class, "get_hf_to_sglang_mapper", None)
+        if get_mapper is not None:
+            hf_to_sglang_mapper = get_mapper(model_config.hf_config)
+        else:
+            hf_to_sglang_mapper = getattr(model_class, "hf_to_sglang_mapper", None)
         # pass mappings by reference to quant_config
         if hf_to_sglang_mapper is not None and quant_config is not None:
             quant_config.apply_weight_name_mapper(hf_to_sglang_mapper)

--- a/python/sglang/srt/models/deepseek_nextn.py
+++ b/python/sglang/srt/models/deepseek_nextn.py
@@ -312,14 +312,19 @@ class DeepseekV3ForCausalLMNextN(DeepseekV3ForCausalLM):
     # The draft checkpoint reports the NextN architecture name.
     fused_shared_experts_architecture = "DeepseekV3ForCausalLMNextN"
 
-    # Support amd/DeepSeek-R1-0528-MXFP4 renaming: model.layers.61*.
-    # Ref: HF config.json for amd/DeepSeek-R1-0528-MXFP4
-    # https://huggingface.co/amd/DeepSeek-R1-0528-MXFP4/blob/main/config.json
-    hf_to_sglang_mapper = WeightsMapper(
-        orig_to_new_substr={
-            "model.layers.61": "model.decoder",
-        },
-    )
+    # The NextN layer index is checkpoint-dependent (model.layers.{num_hidden_layers}).
+    @classmethod
+    def get_hf_to_sglang_mapper(cls, hf_config) -> WeightsMapper:
+        nextn_layer = f"model.layers.{hf_config.num_hidden_layers}"
+        return WeightsMapper(
+            orig_to_new_prefix={
+                f"{nextn_layer}.eh_proj": "model.eh_proj",
+                f"{nextn_layer}.enorm": "model.enorm",
+                f"{nextn_layer}.hnorm": "model.hnorm",
+                f"{nextn_layer}.shared_head": "model.shared_head",
+                nextn_layer: "model.decoder",
+            },
+        )
 
     def _resolve_nextn_quant_config(self, config, quant_config):
         if quant_config is None or quant_config.get_name() != "quark":
@@ -328,7 +333,7 @@ class DeepseekV3ForCausalLMNextN(DeepseekV3ForCausalLM):
         from sglang.srt.layers.quantization.quark.utils import should_ignore_layer
 
         ckpt_prefix = f"model.layers.{config.num_hidden_layers}"
-        mapped_prefix = self.hf_to_sglang_mapper._map_name(ckpt_prefix)
+        mapped_prefix = self.get_hf_to_sglang_mapper(config)._map_name(ckpt_prefix)
         if should_ignore_layer(mapped_prefix, quant_config.exclude_layers):
             return None
         return quant_config


### PR DESCRIPTION
## Motivation

Mixed-precision NextN/MTP draft checkpoints fail to load when their quantization ignore list uses the natural export spelling (`model.layers.{num_hidden_layers}.*`):

```
ValueError: Downcasting not allowed: target.dtype=torch.float8_e4m3fn, loaded_weight.dtype=torch.bfloat16
```

The NextN wrapper renames draft modules at load (`model.layers.{N}.*` -> `model.decoder.*`, with `eh_proj`/`enorm`/`hnorm`/`shared_head` hoisted to the model root), and the loader applies the model class's `hf_to_sglang_mapper` to the quant config so ignore/scheme entries follow the rename. But that mapper is a static class attribute hardcoded to `model.layers.61` (DeepSeek-R1's index), so for any other checkpoint (e.g. GLM-5.2, whose MTP layer is 78) the quant-config entries are never translated: the draft's bf16 modules lose their ignore exemptions, fp8 params get created for them, and weight loading crashes as above.

## Modifications

- `deepseek_nextn.py`: replace the static mapper with a config-aware classmethod `get_hf_to_sglang_mapper(hf_config)` that builds the rename map from `num_hidden_layers` (the existing NextN index convention in this file), including the hoisted root modules. The quark NextN resolver uses the same dynamic mapper (it was silently wrong for non-61-layer checkpoints).
- `loader.py`: prefer the classmethod over the static `hf_to_sglang_mapper` attribute when a model class defines it. All other models are unaffected (fallback path unchanged).

Behavior for the original `model.layers.61` case is preserved (the dynamic map at N=61 is a superset of the old static map). Regex-style ignore entries are not remapped, same as before.

## Reproduction / validation

On 8x B300 with the open GLM-5.2-FP8 checkpoint as target and its MTP layer (layer 78) extracted as a standalone compressed-tensors draft (per-channel FP8 experts, bf16 attention/eh_proj/gate with an exact-name ignore list — the shape llm-compressor exports produce):

- without this change: draft weight load crashes with the `Downcasting not allowed` error above;
- with this change: server boots and serves, EAGLE accept length 2.2–2.8 (`--speculative-algorithm EAGLE --speculative-num-steps 2 --speculative-eagle-topk 1 --speculative-num-draft-tokens 3`).

Also running in production for a GLM-5.2 fine-tune deployment whose separately-exported MTP draft previously required a hand-patched ignore list; with this change the as-exported draft loads unmodified (multi-turn workloads, accept length 2.5–3.8).

Happy to add a unit test for the mapper if desired.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31864045396](https://github.com/sgl-project/sglang/actions/runs/31864045396)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31864045183](https://github.com/sgl-project/sglang/actions/runs/31864045183)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->