### PR TITLE
[DCP] Build the MHA-extend reorg offsets on the host

### DIFF
--- a/python/sglang/srt/layers/dcp/comm.py
+++ b/python/sglang/srt/layers/dcp/comm.py
@@ -21,6 +21,7 @@ PR #25090 vs #14194):
 """
 
 import warnings
+from itertools import accumulate
 from typing import Optional
 
 import torch
@@ -196,21 +197,18 @@ def all_gather_kv_cache_for_mha_extend(
     token_to_kv_pool,
     attn_mqa,
     dcp_local_prefix_kv_indices,
-    seq_lens,
-    extend_prefix_lens,
     extend_prefix_lens_cpu: list[int],
-    extend_seq_lens,
+    extend_seq_lens_cpu: list[int],
     kv_a: torch.Tensor,
     k_pe: torch.Tensor,
 ):
     prefix_kv_a, prefix_k_pe = token_to_kv_pool.get_mla_kv_buffer(
         attn_mqa, dcp_local_prefix_kv_indices, dst_dtype=kv_a.dtype
     )
-    extend_prefix_lens_cpu = torch.tensor(extend_prefix_lens_cpu)
     gathered_kv_cache = all_gather_kv_cache_for_dcp(
         prefix_kv_a,
         prefix_k_pe,
-        extend_prefix_lens_cpu,
+        torch.tensor(extend_prefix_lens_cpu),
     )
     prefix_kv_a, prefix_k_pe = gathered_kv_cache.split(
         [kv_a.shape[-1], k_pe.shape[-1]], dim=-1
@@ -222,18 +220,14 @@ def all_gather_kv_cache_for_mha_extend(
         prefix_kv_a = prefix_kv_a.to(kv_a.dtype)
     if prefix_k_pe.dtype != k_pe.dtype:
         prefix_k_pe = prefix_k_pe.to(k_pe.dtype)
-    # re-organize kv with query orders
-    prefix_lens_cu = torch.zeros(
-        len(seq_lens) + 1,
-        dtype=torch.int32,
-        device=kv_a.device,
-    )
-    extend_lens_cu = torch.zeros_like(prefix_lens_cu)
-    prefix_lens_cu[1:] = torch.cumsum(extend_prefix_lens, dim=0)
-    extend_lens_cu[1:] = torch.cumsum(extend_seq_lens, dim=0)
+    # re-organize kv with query orders. The offsets index host-side slices, so
+    # accumulate them on the host: a device cumsum makes every slice bound a
+    # tensor->int conversion, i.e. a device sync per bound inside this loop.
+    prefix_lens_cu = list(accumulate(extend_prefix_lens_cpu, initial=0))
+    extend_lens_cu = list(accumulate(extend_seq_lens_cpu, initial=0))
     kv_a_tuple = ()
     k_pe_tuple = ()
-    for i in range(len(seq_lens)):
+    for i in range(len(extend_prefix_lens_cpu)):
         kv_a_tuple += (
             prefix_kv_a[prefix_lens_cu[i] : prefix_lens_cu[i + 1]],
             kv_a[extend_lens_cu[i] : extend_lens_cu[i + 1]],

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
@@ -231,10 +231,8 @@ class DeepseekMHAForwardMixin:
                         get_token_to_kv_pool(),
                         self.attn_mha,
                         forward_batch.attn_dcp_metadata.dcp_local_prefix_kv_indices,
-                        forward_batch.seq_lens,
-                        forward_batch.extend_prefix_lens,
                         forward_batch.extend_prefix_lens_cpu,
-                        forward_batch.extend_seq_lens,
+                        forward_batch.extend_seq_lens_cpu,
                         kv_a,
                         k_pe,
                     )

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha_rocm.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha_rocm.py
@@ -214,10 +214,8 @@ class DeepseekMHARocmForwardMixin:
                         get_token_to_kv_pool(),
                         self.attn_mha,
                         forward_batch.attn_dcp_metadata.dcp_local_prefix_kv_indices,
-                        forward_batch.seq_lens,
-                        forward_batch.extend_prefix_lens,
                         forward_batch.extend_prefix_lens_cpu,
-                        forward_batch.extend_seq_lens,
+                        forward_batch.extend_seq_lens_cpu,
                         kv_a,
                         k_pe,
                     )


### PR DESCRIPTION
## Motivation

`all_gather_kv_cache_for_mha_extend` builds its two cumulative-length tensors on the **device**, then uses them as Python slice bounds:

```python
prefix_lens_cu = torch.zeros(len(seq_lens) + 1, dtype=torch.int32, device=kv_a.device)
extend_lens_cu = torch.zeros_like(prefix_lens_cu)
prefix_lens_cu[1:] = torch.cumsum(extend_prefix_lens, dim=0)
extend_lens_cu[1:] = torch.cumsum(extend_seq_lens, dim=0)
for i in range(len(seq_lens)):
    kv_a_tuple += (prefix_kv_a[prefix_lens_cu[i] : prefix_lens_cu[i+1]],
                   kv_a[extend_lens_cu[i] : extend_lens_cu[i+1]])
    k_pe_tuple += (prefix_k_pe[prefix_lens_cu[i] : prefix_lens_cu[i+1]],
                   k_pe[extend_lens_cu[i] : extend_lens_cu[i+1]])
```

Each bound goes through `__index__` → `.item()` → a **device→host sync**: 8 per request, per call. This runs inside the forward on the scheduler thread, so the CPU cannot run ahead and batch prep stops overlapping GPU work.

Profiled on 8×B300 with DCP8, this was **27,982 `aten::item` calls costing 430 ms in a 6.7 s window**, plus 14,878 `cudaStreamSynchronize`. The same profile of a `--tp-size 8` run with no DCP shows 243 stream syncs total.

The sibling `all_gather_kv_cache_for_dcp` already builds its offsets on the host and does not have this problem.

## Modifications

The host-side lengths already exist — the function is handed `extend_prefix_lens_cpu`, and `ForwardBatch` carries `extend_seq_lens_cpu` right beside it (`forward_batch_info.py:535-536`, set together). Accumulate both on the host with `itertools.accumulate` and slice with plain ints.

`extend_prefix_lens` / `extend_seq_lens` are then unused, and `seq_lens` was only supplying a length, so all three drop out of the signature. Both call sites updated (`forward_mha.py`, `forward_mha_rocm.py`).

## Accuracy Tests

Greedy decode over a shared prefix reused by four queries of differing extend lengths — the exact path this function reorganizes. Output digest is **identical** before and after (`752a08531231e97a`), so the reorg is unchanged.

`test/registered/dcp/test_dsv31_dcp8_gsm8k.py` covers this path in CI.

## Benchmarking and Profiling

8×B300, DeepSeek-V2-Lite-Chat (MLA, 27 layers), `--tp-size 8 --dcp-size 8 --page-size 64`, shared-prefix workload (96 groups × 4096-token prefix, 768 requests, concurrency 16).

| | before | after |
|---|---|---|
| `aten::item` | 27,982 / 430.4 ms | 13,152 / **20.3 ms** |
| `cudaStreamSynchronize` | 14,878 / 307.7 ms | 832 / **16.5 ms** |
| `all_gather_kv_cache_for_mha_extend` | 4.35 ms/call | **2.05 ms/call** |
| `run_batch` | 22.4 ms/call | **17.9 ms/call** |

Stream syncs drop **94%**, landing near the 243 of a no-DCP run. The remaining `.item()` calls are on CPU tensors in `all_gather_kv_cache_for_dcp` and cost 20 ms rather than 430 ms.

End to end (fresh server per arm, 2 reps, no profiler): median TTFT **−15.0%** (451.8 → 384.1 ms), mean TTFT −7.6% (465.2 → 430.0 ms), throughput +1.0%. The workload is concurrency-bound, so latency moves more than throughput.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Provide accuracy results.
- [ ] Add unit tests — the sync is only observable on a live CUDA + DCP process group; suggestions for a cheap guard welcome.
- [ ] Update documentation / docstrings / example tutorials if this PR changes the behavior of the code.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [x] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31865166090](https://github.com/sgl-project/sglang/actions/runs/31865166090)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31865167030](https://github.com/sgl-project/sglang/actions/runs/31865167030)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->