### PR TITLE
Avoid deadlock when shared-memory node probe fails

### DIFF
--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -2973,6 +2973,7 @@ def in_the_same_node_as(pg: ProcessGroup, source_rank: int = 0) -> List[bool]:
         recv = [None]
         if rank == source_rank:
             with contextlib.suppress(OSError):
+                # create a shared memory segment
                 shm = shared_memory.SharedMemory(
                     create=True, size=128, name=make_shm_name("nodecheck")
                 )
@@ -2989,6 +2990,7 @@ def in_the_same_node_as(pg: ProcessGroup, source_rank: int = 0) -> List[bool]:
                 is_in_the_same_node[rank] = 1
         elif name is not None:
             with contextlib.suppress(OSError):
+                # try to open the shared memory segment
                 # fix to https://stackoverflow.com/q/62748654/9191338
                 # Python incorrectly tracks shared memory even if it is not
                 # created by the process. The following patch is a workaround.

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -2970,24 +2970,25 @@ def in_the_same_node_as(pg: ProcessGroup, source_rank: int = 0) -> List[bool]:
     shm = None
 
     try:
-        with contextlib.suppress(OSError):
-            if rank == source_rank:
-                # create a shared memory segment
+        recv = [None]
+        if rank == source_rank:
+            with contextlib.suppress(OSError):
                 shm = shared_memory.SharedMemory(
                     create=True, size=128, name=make_shm_name("nodecheck")
                 )
                 shm.buf[: len(magic_message)] = magic_message
-                torch.distributed.broadcast_object_list(
-                    [shm.name], src=ranks[source_rank], group=pg
-                )
+                recv[0] = shm.name
+
+        torch.distributed.broadcast_object_list(
+            recv, src=ranks[source_rank], group=pg
+        )
+        name = recv[0]
+
+        if rank == source_rank:
+            if name is not None:
                 is_in_the_same_node[rank] = 1
-            else:
-                # try to open the shared memory segment
-                recv = [None]
-                torch.distributed.broadcast_object_list(
-                    recv, src=ranks[source_rank], group=pg
-                )
-                name = recv[0]
+        elif name is not None:
+            with contextlib.suppress(OSError):
                 # fix to https://stackoverflow.com/q/62748654/9191338
                 # Python incorrectly tracks shared memory even if it is not
                 # created by the process. The following patch is a workaround.

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -2980,9 +2980,7 @@ def in_the_same_node_as(pg: ProcessGroup, source_rank: int = 0) -> List[bool]:
                 shm.buf[: len(magic_message)] = magic_message
                 recv[0] = shm.name
 
-        torch.distributed.broadcast_object_list(
-            recv, src=ranks[source_rank], group=pg
-        )
+        torch.distributed.broadcast_object_list(recv, src=ranks[source_rank], group=pg)
         name = recv[0]
 
         if rank == source_rank:

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -2984,8 +2984,7 @@ def in_the_same_node_as(pg: ProcessGroup, source_rank: int = 0) -> List[bool]:
         name = recv[0]
 
         if rank == source_rank:
-            if name is not None:
-                is_in_the_same_node[rank] = 1
+            is_in_the_same_node[rank] = 1
         elif name is not None:
             with contextlib.suppress(OSError):
                 # try to open the shared memory segment

--- a/test/registered/unit/distributed/test_parallel_state.py
+++ b/test/registered/unit/distributed/test_parallel_state.py
@@ -44,6 +44,7 @@ from unittest.mock import Mock, patch
 import pytest
 import torch.distributed as dist
 import torch.multiprocessing as mp
+
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=15, suite="base-a-test-cpu")

--- a/test/registered/unit/distributed/test_parallel_state.py
+++ b/test/registered/unit/distributed/test_parallel_state.py
@@ -36,17 +36,49 @@ not the per-rank group membership logic.
 
 from __future__ import annotations
 
+import socket
 import sys
+from datetime import timedelta
 from unittest.mock import Mock, patch
 
 import pytest
-
+import torch.distributed as dist
+import torch.multiprocessing as mp
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=8, suite="base-a-test-cpu")
+register_cpu_ci(est_time=15, suite="base-a-test-cpu")
 
 # Import the actual parallel_state module
 parallel_state = pytest.importorskip("sglang.srt.distributed.parallel_state")
+
+
+def _find_available_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _run_probe_with_unavailable_shm(rank: int, port: int) -> None:
+    """Run the real Gloo collective while only rank 0 cannot create shm."""
+    dist.init_process_group(
+        "gloo",
+        init_method=f"tcp://127.0.0.1:{port}",
+        rank=rank,
+        world_size=2,
+        timeout=timedelta(seconds=10),
+    )
+    try:
+        if rank == 0:
+            with patch(
+                "sglang.srt.distributed.parallel_state.shared_memory.SharedMemory",
+                side_effect=OSError("shared memory unavailable"),
+            ):
+                result = parallel_state.in_the_same_node_as(dist.group.WORLD)
+        else:
+            result = parallel_state.in_the_same_node_as(dist.group.WORLD)
+        assert result == [False, False]
+    finally:
+        dist.destroy_process_group()
 
 
 def test_parallel_group_construction_tp8_attn_cp2():
@@ -335,6 +367,15 @@ def test_group_desc_none_normalized_to_anonymous():
     assert _read_group_descs(None) == ("anonymous:device", "anonymous:cpu")
 
 
+def test_shm_creation_failure_keeps_all_ranks_in_the_collective():
+    mp.spawn(
+        _run_probe_with_unavailable_shm,
+        args=(_find_available_port(),),
+        nprocs=2,
+        join=True,
+    )
+
+
 if __name__ == "__main__":
     # Run tests without requiring GPUs
     import sys
@@ -345,6 +386,7 @@ if __name__ == "__main__":
         test_group_desc_propagated_via_real_new_group("tp")
         test_group_desc_propagated_via_real_new_group("pp")
         test_group_desc_none_normalized_to_anonymous()
+        test_shm_creation_failure_keeps_all_ranks_in_the_collective()
 
         sys.exit(0)
     except AssertionError as e:

--- a/test/registered/unit/distributed/test_parallel_state.py
+++ b/test/registered/unit/distributed/test_parallel_state.py
@@ -77,7 +77,7 @@ def _run_probe_with_unavailable_shm(rank: int, port: int) -> None:
                 result = parallel_state.in_the_same_node_as(dist.group.WORLD)
         else:
             result = parallel_state.in_the_same_node_as(dist.group.WORLD)
-        assert result == [False, False]
+        assert result == [True, False]
     finally:
         dist.destroy_process_group()
 


### PR DESCRIPTION
Fixes #34800

## Summary

- Keep every rank in `in_the_same_node_as()` on the same broadcast when the source shared-memory probe fails.
- Add a two-rank Gloo regression that forces source shared-memory creation to raise `OSError`.

## Root cause

`contextlib.suppress(OSError)` previously covered both local shared-memory operations and `broadcast_object_list()`. If source-rank creation failed, it skipped the broadcast while peers waited forever.

## Fix

Limit the `OSError` suppression to local shared-memory creation/opening. The source broadcasts `None` on creation failure, reports itself as colocated, and peers report that they are not on the source node. Downstream readers therefore fall back to the remote path without a negative local-reader count.

The macOS shared-memory name-length error is one trigger. The regression injects the same `OSError` and is registered in the Linux CPU CI lane to validate the platform-independent collective-safety invariant. Shared-memory name generation is intentionally unchanged.

## Validation

- `PYTHONPATH=python python/.venv/bin/python -m pytest test/registered/unit/distributed/test_parallel_state.py::test_shm_creation_failure_keeps_all_ranks_in_the_collective -q`
- `SKIP=no-commit-to-branch uvx pre-commit run --files python/sglang/srt/distributed/parallel_state.py test/registered/unit/distributed/test_parallel_state.py --show-diff-on-failure`
- GitHub Lint: [Run #31923509772](https://github.com/sgl-project/sglang/actions/runs/31923509772)
- `git diff --check`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31893507153](https://github.com/sgl-project/sglang/actions/runs/31893507153)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31893507005](https://github.com/sgl-project/sglang/actions/runs/31893507005)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
