### PR TITLE
Update sgl-deep-ep release workflow for DeepEP v2

### DIFF
--- a/.github/workflows/release-whl-deepep.yml
+++ b/.github/workflows/release-whl-deepep.yml
@@ -42,7 +42,7 @@ jobs:
         include:
           - arch: x86_64
             runner: x64-kernel-build-node
-            source-branch: sgl-deepep-x86
+            source-branch: sgl-deepep-cu12-x86
           - arch: aarch64
             runner: arm-kernel-build-node
             source-branch: sgl-deepep-cu12-arm
@@ -107,10 +107,10 @@ jobs:
         include:
           - arch: x86_64
             runner: x64-kernel-build-node
-            source-branch: sgl-deepep-x86
+            source-branch: sgl-deepep
           - arch: aarch64
             runner: arm-kernel-build-node
-            source-branch: sgl-deepep-arm
+            source-branch: sgl-deepep
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Clean workspace

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,6 @@ ARG SGL_VERSION
 ARG SGL_DEEP_GEMM_VERSION=0.1.5.post2
 ARG USE_LATEST_SGLANG=0
 ARG GDRCOPY_VERSION=2.5.1
-ARG NCCL_VERSION=2.30.7
 ARG PIP_DEFAULT_INDEX
 ARG UBUNTU_MIRROR
 ARG GITHUB_ARTIFACTORY=github.com
@@ -174,7 +173,6 @@ ARG CUDA_VERSION
 ARG BUILD_TYPE
 ARG SGL_KERNEL_VERSION
 ARG GITHUB_ARTIFACTORY
-ARG NCCL_VERSION
 
 WORKDIR /sgl-workspace
 
@@ -250,10 +248,6 @@ RUN --mount=type=cache,target=/root/.cache/pip \
            sed -i 's/nvidia-cutlass-dsl\[cu13\]/nvidia-cutlass-dsl/' pyproject.toml; \
        fi \
     && python3 -m pip install --extra-index-url https://download.pytorch.org/whl/cu${CUINDEX} ".[${BUILD_TYPE}]" \
-    && if [ "${CUDA_VERSION%%.*}" = "13" ]; then \
-           python3 -m pip install --force-reinstall --no-deps \
-               "nvidia-nccl-cu13==${NCCL_VERSION}"; \
-       fi \
     && if [ "${CUDA_VERSION%%.*}" = "12" ]; then \
            pip list --format=freeze | awk -F'==' '/-cu13(==|$)/ {print $1}' \
                | xargs -r python3 -m pip uninstall -y && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,6 +9,7 @@ ARG SGL_VERSION
 ARG SGL_DEEP_GEMM_VERSION=0.1.5.post2
 ARG USE_LATEST_SGLANG=0
 ARG GDRCOPY_VERSION=2.5.1
+ARG NCCL_VERSION=2.30.7
 ARG PIP_DEFAULT_INDEX
 ARG UBUNTU_MIRROR
 ARG GITHUB_ARTIFACTORY=github.com
@@ -173,6 +174,7 @@ ARG CUDA_VERSION
 ARG BUILD_TYPE
 ARG SGL_KERNEL_VERSION
 ARG GITHUB_ARTIFACTORY
+ARG NCCL_VERSION
 
 WORKDIR /sgl-workspace
 
@@ -248,6 +250,10 @@ RUN --mount=type=cache,target=/root/.cache/pip \
            sed -i 's/nvidia-cutlass-dsl\[cu13\]/nvidia-cutlass-dsl/' pyproject.toml; \
        fi \
     && python3 -m pip install --extra-index-url https://download.pytorch.org/whl/cu${CUINDEX} ".[${BUILD_TYPE}]" \
+    && if [ "${CUDA_VERSION%%.*}" = "13" ]; then \
+           python3 -m pip install --force-reinstall --no-deps \
+               "nvidia-nccl-cu13==${NCCL_VERSION}"; \
+       fi \
     && if [ "${CUDA_VERSION%%.*}" = "12" ]; then \
            pip list --format=freeze | awk -F'==' '/-cu13(==|$)/ {print $1}' \
                | xargs -r python3 -m pip uninstall -y && \

--- a/docker/sgl-deep-ep.Dockerfile
+++ b/docker/sgl-deep-ep.Dockerfile
@@ -7,18 +7,16 @@ ARG ARCHITECTURE=x86_64
 ARG CUDA_TAG=cu130
 ARG CUDA_VERSION=13.0
 ARG GDRCOPY_VERSION=2.5.1
+ARG NCCL_VERSION=2.30.7
 ARG PYTHON_TAG=cp312-cp312
 ARG TORCH_VERSION=2.13.0
 
 ENV CUDA_HOME=/usr/local/cuda
-ENV GDRCOPY_HOME=/usr/local
 ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64:/usr/local/cuda/lib64:${LD_LIBRARY_PATH}
 ENV PATH=/opt/python/${PYTHON_TAG}/bin:${PATH}
 ENV PYTHON_BIN=/opt/python/${PYTHON_TAG}/bin/python
 
 # These mirror the build and RDMA dependencies used by ci_install_deepep.sh.
-# The image builds only GDRCopy's user-space library: the host owns gdrdrv and
-# passes /dev/gdrdrv through at runtime.
 RUN yum install -y --nogpgcheck --enablerepo=powertools \
         cmake \
         curl \
@@ -51,13 +49,18 @@ RUN set -eux; \
     ln -sf "${cuda_stub}" /usr/lib64/libcuda.so; \
     ln -sf "${cuda_stub}" "/usr/lib/${ARCHITECTURE}-linux-gnu/libcuda.so"
 
-RUN git clone --depth 1 --branch "v${GDRCOPY_VERSION}" \
-        https://github.com/NVIDIA/gdrcopy.git /opt/gdrcopy \
-    && make -C /opt/gdrcopy CUDA="${CUDA_HOME}" prefix=/usr/local lib_install \
-    && printf '%s\n' /usr/local/lib > /etc/ld.so.conf.d/gdrcopy.conf \
-    && ldconfig \
-    && test -f /usr/local/include/gdrapi.h \
-    && ldconfig -p | grep -q libgdrapi
+# DeepEP v2 uses NCCL Gin on CUDA 13. Keep GDRCopy only for the CUDA 12
+# legacy NVSHMEM/IBGDA build.
+RUN set -eux; \
+    if [ "${CUDA_TAG}" = cu129 ]; then \
+        git clone --depth 1 --branch "v${GDRCOPY_VERSION}" \
+            https://github.com/NVIDIA/gdrcopy.git /opt/gdrcopy; \
+        make -C /opt/gdrcopy CUDA="${CUDA_HOME}" prefix=/usr/local lib_install; \
+        printf '%s\n' /usr/local/lib > /etc/ld.so.conf.d/gdrcopy.conf; \
+        ldconfig; \
+        test -f /usr/local/include/gdrapi.h; \
+        ldconfig -p | grep -q libgdrapi; \
+    fi
 
 RUN --mount=type=cache,id=sgl-deep-ep-pip-${CUDA_TAG}-${PYTHON_TAG}-${ARCHITECTURE},target=/root/.cache/pip \
     set -eux; \
@@ -66,6 +69,10 @@ RUN --mount=type=cache,id=sgl-deep-ep-pip-${CUDA_TAG}-${PYTHON_TAG}-${ARCHITECTU
     "${PYTHON_BIN}" -m pip install --force-reinstall \
         "torch==${TORCH_VERSION}" \
         --index-url "https://download.pytorch.org/whl/${CUDA_TAG}"; \
+    if [ "${CUDA_TAG}" = cu130 ]; then \
+        "${PYTHON_BIN}" -m pip install --force-reinstall --no-deps \
+            "nvidia-nccl-cu13==${NCCL_VERSION}"; \
+    fi; \
     "${PYTHON_BIN}" -m pip install \
         "auditwheel>=6.0" \
         build \


### PR DESCRIPTION
## Motivation

DeepEP's release branches have changed. CUDA 13 now uses the rebased DeepEP v2 branch and requires NCCL Gin from NCCL 2.30.7. The old workflow branch mapping and CUDA 13 GDRCopy builder dependency are obsolete.

## Modifications

- update the release matrix to use:
  - CUDA 13 x86_64/aarch64: `sgl-deepep`
  - CUDA 12.9 x86_64: `sgl-deepep-cu12-x86`
  - CUDA 12.9 aarch64: `sgl-deepep-cu12-arm`
- force reinstall `nvidia-nccl-cu13==2.30.7 --no-deps` after dependency resolution in the CUDA 13 wheel builder
- skip GDRCopy installation in the CUDA 13 wheel builder while preserving it for CUDA 12 legacy NVSHMEM/IBGDA builds
- retain NVSHMEM because the current DeepEP v2 extension still compiles and links legacy methods
- leave the main image and CI runtime NCCL configuration to #34923

## Accuracy Tests

Not applicable; this PR changes release and image dependency setup.

Validation:
- SGLang pre-commit hooks passed
- workflow parsed with the expected 2x2 branch mapping
- actionlint passed with the repository's existing custom runner labels allowlisted
- shell syntax and diff checks passed
- on an aarch64 GB300 devbox, built and installed a CUDA 13 / CPython 3.12 wheel from `sgl-deepep` using PyTorch 2.13.0+cu130 and NCCL 2.30.7
- `import deep_ep` passed without `/dev/gdrdrv`
- the built extension depends on NCCL and NVSHMEM but not GDRCopy

## Speed Tests and Profiling

Not applicable.

## Checklist

- [x] Format checks passed.
- [x] Updated the DeepEP packaging documentation in the companion PR.
- [x] Verified the CUDA 13 ARM build and import path on GB300.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31875654051](https://github.com/sgl-project/sglang/actions/runs/31875654051)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31875653898](https://github.com/sgl-project/sglang/actions/runs/31875653898)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
