### PR TITLE
[MiniMax-M3] Use MSA for prefill index score

### DIFF
--- a/python/sglang/kernels/jit/csrc/minimax/minimax_decode_topk.cuh
+++ b/python/sglang/kernels/jit/csrc/minimax/minimax_decode_topk.cuh
@@ -349,14 +349,15 @@ __global__ void minimax_decode_topk_block_kernel(
 // Page-table output: for each (batch b, kv-head h) pseudo-request emit the
 // trtllm/fa3 page table -- selected blocks sorted ascending (so the final partial
 // block's pages land last), each expanded to its ppb = block_size/page_size pages
-// via req_to_token -- plus the effective KV length seq_lens_out.
+// via a batch-local physical page table -- plus the effective KV length
+// seq_lens_out.
 //
 // DP attention (num_kv_heads > 1): each kv head selects its OWN blocks, so the
 // per-request page table can't be shared across heads. We flatten (b, h) into
 // num_heads*batch pseudo-requests laid out batch-major (row = b*num_heads + h,
-// matching q.view(bs, nkv, gqa, d).reshape(bs*nkv, gqa, d)). seq_lens / slot_ids /
-// req_to_token are per-batch (head-independent: a token's cache slot is the same
-// for every head). The page index is head-encoded (head-minor) as
+// matching q.view(bs, nkv, gqa, d).reshape(bs*nkv, gqa, d)). The mapping is
+// head-independent: a token's cache slot is the same for every head. The page
+// index is head-encoded (head-minor) as
 // base_page*num_heads + h, which is exactly the page index into an HND cache
 // [num_pages, nkv, page_size, D] reshaped to [num_pages*nkv, 1, page_size, D] (a
 // free view when the cache is contiguous HND). num_heads == 1 (h == 0) reproduces
@@ -365,8 +366,7 @@ template <typename SeqLenT, bool kUsePDL>
 __global__ void minimax_decode_topk_page_table_kernel(
     const float* __restrict__ score,
     const SeqLenT* __restrict__ seq_lens,
-    const int32_t* __restrict__ req_to_token,
-    const int64_t* __restrict__ slot_ids,
+    const int32_t* __restrict__ source_page_table,
     int32_t* __restrict__ page_table,
     int32_t* __restrict__ seq_lens_out,
     int batch,
@@ -375,22 +375,22 @@ __global__ void minimax_decode_topk_page_table_kernel(
     int block_size,
     int topk,
     int page_size,
-    int r2t_stride,
-    int max_kv_len,
+    int source_page_table_stride,
+    int source_page_table_width,
     int max_sparse_pages) {
   const int b = blockIdx.x;  // grid.x = batch
   const int h = blockIdx.y;  // grid.y = num_heads (kv head)
   const int tx = threadIdx.x;
 
-  // Prefetch seq_lens / slot_ids (from earlier kernels) and the cheap setup
-  // before waiting on the score producer, so the prologue overlaps its tail (PDL).
+  // Resolve the mapping row and cheap setup before waiting on the score
+  // producer, so the prologue overlaps its tail (PDL).
   const int64_t seq_len = static_cast<int64_t>(seq_lens[b]);
   const int num_blocks_raw = static_cast<int>((seq_len + block_size - 1) / block_size);
   const int num_blocks = num_blocks_raw < max_seqblock ? num_blocks_raw : max_seqblock;
   const int ppb = block_size / page_size;
   const int64_t out_row = static_cast<int64_t>(b) * num_heads + h;  // flattened pseudo-request
   int32_t* __restrict__ pt_row = page_table + out_row * max_sparse_pages;
-  const int64_t r2t_base = static_cast<int64_t>(slot_ids[b]) * r2t_stride;
+  const int64_t source_row = static_cast<int64_t>(b) * source_page_table_stride;
   device::PDLWaitPrimary<kUsePDL>();
 
   if (num_blocks <= topk) {  // trivial: every block selected, all tokens valid
@@ -401,8 +401,10 @@ __global__ void minimax_decode_topk_page_table_kernel(
       const int slot = e / ppb;
       const int pp = e % ppb;
       int tok = slot * block_size + pp * page_size;
-      if (tok >= max_kv_len) tok = max_kv_len - 1;
-      pt_row[e] = req_to_token[r2t_base + tok] / page_size * num_heads + h;
+      int mapping_idx = tok / page_size;
+      if (mapping_idx >= source_page_table_width) mapping_idx = source_page_table_width - 1;
+      const int32_t base_page = source_page_table[source_row + mapping_idx];
+      pt_row[e] = base_page * num_heads + h;
     }
     return;
   }
@@ -440,8 +442,10 @@ __global__ void minimax_decode_topk_page_table_kernel(
     const int slot = e / ppb;
     const int pp = e % ppb;
     int tok = s_sorted[slot] * block_size + pp * page_size;
-    if (tok >= max_kv_len) tok = max_kv_len - 1;
-    pt_row[e] = req_to_token[r2t_base + tok] / page_size * num_heads + h;
+    int mapping_idx = tok / page_size;
+    if (mapping_idx >= source_page_table_width) mapping_idx = source_page_table_width - 1;
+    const int32_t base_page = source_page_table[source_row + mapping_idx];
+    pt_row[e] = base_page * num_heads + h;
   }
 }
 
@@ -509,12 +513,11 @@ void minimax_decode_topk(
 // page_table and seq_lens_out are allocated by the caller.
 template <typename SeqLenT, bool kUsePDL>
 void minimax_decode_topk_page_table(
-    tvm::ffi::TensorView score,         // [H, B, S] fp32 (H = num_kv_heads)
-    tvm::ffi::TensorView seq_lens,      // [B] int32/int64
-    tvm::ffi::TensorView req_to_token,  // [max_reqs, max_kv_len] int32
-    tvm::ffi::TensorView slot_ids,      // [B] int64 (req_pool_indices)
-    tvm::ffi::TensorView page_table,    // [B*H, max_sparse_pages] int32 (out)
-    tvm::ffi::TensorView seq_lens_out,  // [B*H] int32 (effective KV length, out)
+    tvm::ffi::TensorView score,              // [H, B, S] fp32 (H = num_kv_heads)
+    tvm::ffi::TensorView seq_lens,           // [B] int32/int64
+    tvm::ffi::TensorView source_page_table,  // [B, max_pages] physical page ids
+    tvm::ffi::TensorView page_table,         // [B*H, max_sparse_pages] int32 (out)
+    tvm::ffi::TensorView seq_lens_out,       // [B*H] int32 (effective KV length, out)
     int64_t block_size,
     int64_t topk,
     int64_t page_size) {
@@ -523,8 +526,7 @@ void minimax_decode_topk_page_table(
   SymbolicSize H = {"num_heads"};
   SymbolicSize B = {"batch"};
   SymbolicSize S = {"max_seqblock"};
-  SymbolicSize R = {"max_reqs"};
-  SymbolicSize KV = {"max_kv_len"};
+  SymbolicSize KV = {"source_page_table_width"};
   SymbolicSize BH = {"batch_heads"};
   SymbolicSize P = {"max_sparse_pages"};
   SymbolicDevice device_;
@@ -532,17 +534,16 @@ void minimax_decode_topk_page_table(
 
   TensorMatcher({H, B, S}).with_dtype<fp32_t>().with_device(device_).verify(score);
   TensorMatcher({B}).with_dtype<SeqLenT>().with_device(device_).verify(seq_lens);
-  TensorMatcher({R, KV}).with_dtype<int32_t>().with_device(device_).verify(req_to_token);
-  TensorMatcher({B}).with_dtype<int64_t>().with_device(device_).verify(slot_ids);
+  TensorMatcher({B, KV}).with_dtype<int32_t>().with_device(device_).verify(source_page_table);
   TensorMatcher({BH, P}).with_dtype<int32_t>().with_device(device_).verify(page_table);
   TensorMatcher({BH}).with_dtype<int32_t>().with_device(device_).verify(seq_lens_out);
 
   const int num_heads = static_cast<int>(H.unwrap());
   const int batch = static_cast<int>(B.unwrap());
   const int max_seqblock = static_cast<int>(S.unwrap());
-  const int max_kv_len = static_cast<int>(KV.unwrap());
+  const int source_page_table_width = static_cast<int>(KV.unwrap());
   const int max_sparse_pages = static_cast<int>(P.unwrap());
-  const int r2t_stride = static_cast<int>(req_to_token.stride(0));
+  const int source_page_table_stride = static_cast<int>(source_page_table.stride(0));
   const DLDevice device = device_.unwrap();
 
   RuntimeCheck(
@@ -564,8 +565,7 @@ void minimax_decode_topk_page_table(
           minimax_decode_topk_page_table_kernel<SeqLenT, kUsePDL>,
           static_cast<const float*>(score.data_ptr()),
           static_cast<const SeqLenT*>(seq_lens.data_ptr()),
-          static_cast<const int32_t*>(req_to_token.data_ptr()),
-          static_cast<const int64_t*>(slot_ids.data_ptr()),
+          static_cast<const int32_t*>(source_page_table.data_ptr()),
           static_cast<int32_t*>(page_table.data_ptr()),
           static_cast<int32_t*>(seq_lens_out.data_ptr()),
           batch,
@@ -574,8 +574,8 @@ void minimax_decode_topk_page_table(
           static_cast<int>(block_size),
           static_cast<int>(topk),
           static_cast<int>(page_size),
-          r2t_stride,
-          max_kv_len,
+          source_page_table_stride,
+          source_page_table_width,
           max_sparse_pages);
 }
 

--- a/python/sglang/kernels/ops/attention/minimax_decode_topk.py
+++ b/python/sglang/kernels/ops/attention/minimax_decode_topk.py
@@ -82,8 +82,7 @@ def minimax_decode_topk(
 def minimax_decode_topk_page_table(
     score: torch.Tensor,  # [num_kv_heads, batch, max_seqblock] fp32
     seq_lens: torch.Tensor,  # [batch] int32/int64
-    req_to_token: torch.Tensor,  # [max_reqs, max_kv_len] int32
-    slot_ids: torch.Tensor,  # [batch] int64 (req_pool_indices)
+    source_page_table: torch.Tensor,  # [batch, max_pages] physical page ids
     block_size: int,
     topk: int,
     page_size: int,
@@ -105,13 +104,15 @@ def minimax_decode_topk_page_table(
     assert score.is_cuda and score.dtype == torch.float32 and score.dim() == 3
     num_heads, batch, max_seqblock = score.shape
     assert block_size % page_size == 0
-    assert req_to_token.dtype == torch.int32 and slot_ids.dtype == torch.int64
+    assert source_page_table.dtype == torch.int32
+    assert source_page_table.dim() == 2
+    assert source_page_table.shape[0] == batch
     if not score.is_contiguous():
         score = score.contiguous()
     if not seq_lens.is_contiguous():
         seq_lens = seq_lens.contiguous()
-    if not slot_ids.is_contiguous():
-        slot_ids = slot_ids.contiguous()
+    if not source_page_table.is_contiguous():
+        source_page_table = source_page_table.contiguous()
 
     max_sparse_pages = topk * (block_size // page_size)
     page_table = torch.empty(
@@ -125,8 +126,7 @@ def minimax_decode_topk_page_table(
     module.minimax_decode_topk_page_table(
         score,
         seq_lens,
-        req_to_token,
-        slot_ids,
+        source_page_table,
         page_table,
         real_seq_lens,
         int(block_size),

--- a/python/sglang/kernels/ops/attention/minimax_sparse/decode/flash_with_topk_idx.py
+++ b/python/sglang/kernels/ops/attention/minimax_sparse/decode/flash_with_topk_idx.py
@@ -19,6 +19,10 @@ from ..common.utils import (
 from ..page_table import load_token_slots
 
 
+def _decode_score_one_page_kernel_config() -> tuple[int, int]:
+    return 2, 2
+
+
 @triton.heuristics(
     {
         "BLOCK_SIZE_H": lambda args: max(
@@ -993,6 +997,7 @@ def flash_decode_with_topk_idx(
 
     grid = (batch_size * NUM_KV_CHUNKS, num_kv_heads)
     if disable_index_value and page_size == block_size:
+        num_warps, num_stages = _decode_score_one_page_kernel_config()
         _decode_score_one_page_per_block_kernel[grid](
             q,
             k_cache,
@@ -1022,8 +1027,8 @@ def flash_decode_with_topk_idx(
             SCORE_TYPE=score_type,
             SKIP_TRIVIAL_TOPK_SCORE=skip_trivial_topk_score,
             IS_FP8=is_fp8,
-            num_warps=4,
-            num_stages=3,
+            num_warps=num_warps,
+            num_stages=num_stages,
         )
     elif disable_index_value:
         _decode_score_kernel[grid](

--- a/python/sglang/kernels/ops/attention/minimax_sparse/decode/flash_with_topk_idx.py
+++ b/python/sglang/kernels/ops/attention/minimax_sparse/decode/flash_with_topk_idx.py
@@ -214,6 +214,126 @@ def _decode_score_kernel(
             16, triton.next_power_of_2(args["gqa_group_size"])
         ),
         "BLOCK_SIZE_D": lambda args: triton.next_power_of_2(args["head_dim"]),
+    }
+)
+@triton.jit
+def _decode_score_one_page_per_block_kernel(
+    q_ptr,
+    k_cache_ptr,
+    page_table_ptr,
+    score_ptr,
+    seq_lens,
+    batch_size,
+    gqa_group_size,
+    head_dim,
+    block_size: tl.constexpr,
+    topk: tl.constexpr,
+    sm_scale,
+    k_scale,
+    init_blocks,
+    local_blocks,
+    stride_q_b,
+    stride_q_h,
+    stride_q_d,
+    stride_k_s,
+    stride_k_h,
+    stride_k_d,
+    stride_pt_b,
+    stride_s_h,
+    stride_s_b,
+    stride_s_n,
+    BLOCK_SIZE_H: tl.constexpr,
+    BLOCK_SIZE_D: tl.constexpr,
+    NUM_KV_CHUNKS: tl.constexpr,
+    SCORE_TYPE: tl.constexpr,
+    SKIP_TRIVIAL_TOPK_SCORE: tl.constexpr,
+    IS_FP8: tl.constexpr,
+):
+    """Decode index scores when one sparse block is one physical KV page."""
+    tl.static_assert(SCORE_TYPE == "max" or SCORE_TYPE == "lse")
+
+    pid_bc, pid_kh = tl.program_id(0), tl.program_id(1)
+    pid_b = pid_bc % batch_size
+    pid_c = pid_bc // batch_size
+    pid_h = pid_kh * gqa_group_size
+
+    seq_len = tl.load(seq_lens + pid_b).to(tl.int32)
+    num_blocks = tl.cdiv(seq_len, block_size)
+    if SKIP_TRIVIAL_TOPK_SCORE:
+        if num_blocks <= topk:
+            return
+
+    chunk_size_blocks = tl.cdiv(num_blocks, NUM_KV_CHUNKS)
+    chunk_start_block = pid_c * chunk_size_blocks
+    chunk_end_block = tl.minimum(chunk_start_block + chunk_size_blocks, num_blocks)
+    if chunk_start_block >= chunk_end_block:
+        return
+
+    q_ptrs = tl.make_block_ptr(
+        base=q_ptr + pid_b * stride_q_b + pid_h * stride_q_h,
+        shape=(gqa_group_size, head_dim),
+        strides=(stride_q_h, stride_q_d),
+        offsets=(0, 0),
+        block_shape=(BLOCK_SIZE_H, BLOCK_SIZE_D),
+        order=(1, 0),
+    )
+    q = tl.load(q_ptrs, boundary_check=(0, 1), padding_option="zero")
+
+    off_h = tl.arange(0, BLOCK_SIZE_H)
+    off_n = tl.arange(0, block_size)
+    off_d = tl.arange(0, BLOCK_SIZE_D)
+    head_mask = off_h < gqa_group_size
+    dim_mask = off_d < head_dim
+    local_start = tl.maximum(0, num_blocks - local_blocks)
+    page_table_row = page_table_ptr + pid_b * stride_pt_b
+    sm_scale_log2e = sm_scale * 1.4426950409
+
+    for logical_block in range(chunk_start_block, chunk_end_block):
+        physical_page = tl.load(page_table_row + logical_block).to(tl.int64)
+        slots = physical_page * block_size + off_n
+        k = tl.load(
+            k_cache_ptr
+            + slots[None, :] * stride_k_s
+            + pid_kh * stride_k_h
+            + off_d[:, None] * stride_k_d,
+            mask=dim_mask[:, None],
+            other=0.0,
+        )
+        if IS_FP8:
+            k = k.to(q.dtype)
+        qk = tl.dot(q, k) * (sm_scale_log2e * k_scale)
+        pos_mask = logical_block * block_size + off_n < seq_len
+        qk = tl.where(pos_mask[None, :], qk, float("-inf"))
+        sub_max = tl.max(qk, axis=1)
+        if SCORE_TYPE == "max":
+            block_score = sub_max
+        else:
+            block_score = sub_max + tl.log2(
+                tl.sum(tl.exp2(qk - sub_max[:, None]), axis=1)
+            )
+            block_score = tl.where(
+                block_score != block_score, float("-inf"), block_score
+            )
+
+        is_init = logical_block < init_blocks
+        is_local = (logical_block >= local_start) & (logical_block < num_blocks)
+        block_score = tl.where(is_local, 1e29, tl.where(is_init, 1e30, block_score))
+        tl.store(
+            score_ptr
+            + (pid_h + off_h) * stride_s_h
+            + pid_b * stride_s_b
+            + logical_block * stride_s_n,
+            block_score.to(score_ptr.dtype.element_ty),
+            mask=head_mask,
+        )
+
+
+@triton.heuristics(
+    {
+        "BLOCK_SIZE_H": lambda args: max(
+            16, triton.next_power_of_2(args["gqa_group_size"])
+        ),
+        "BLOCK_SIZE_D": lambda args: triton.next_power_of_2(args["head_dim"]),
         "HAS_SINK": lambda args: args["sink_ptr"] is not None,
     }
 )
@@ -872,7 +992,40 @@ def flash_decode_with_topk_idx(
     skip_trivial_topk_score = use_dense_main_attn or use_jit_topk
 
     grid = (batch_size * NUM_KV_CHUNKS, num_kv_heads)
-    if disable_index_value:
+    if disable_index_value and page_size == block_size:
+        _decode_score_one_page_per_block_kernel[grid](
+            q,
+            k_cache,
+            page_table,
+            score,
+            seq_lens,
+            batch_size,
+            gqa_group_size,
+            head_dim,
+            block_size,
+            topk,
+            sm_scale,
+            k_scale,
+            init_blocks,
+            local_blocks,
+            q.stride(0),
+            q.stride(1),
+            q.stride(2),
+            k_cache.stride(0),
+            k_cache.stride(1),
+            k_cache.stride(2),
+            page_table.stride(0),
+            score.stride(0),
+            score.stride(1),
+            score.stride(2),
+            NUM_KV_CHUNKS=NUM_KV_CHUNKS,
+            SCORE_TYPE=score_type,
+            SKIP_TRIVIAL_TOPK_SCORE=skip_trivial_topk_score,
+            IS_FP8=is_fp8,
+            num_warps=4,
+            num_stages=3,
+        )
+    elif disable_index_value:
         _decode_score_kernel[grid](
             q,
             k_cache,

--- a/python/sglang/kernels/ops/attention/minimax_sparse/decode/flash_with_topk_idx.py
+++ b/python/sglang/kernels/ops/attention/minimax_sparse/decode/flash_with_topk_idx.py
@@ -16,6 +16,7 @@ from ..common.utils import (
     sparse_out_dtype,
     unit_scale,
 )
+from ..page_table import load_token_slots
 
 
 @triton.heuristics(
@@ -46,12 +47,10 @@ from ..common.utils import (
 def _decode_score_kernel(
     q_ptr,  # Q: b x qh x d
     k_cache_ptr,  # K paged: max_slots x kh x d
-    req_to_token_ptr,  # req_to_token: max_reqs x max_kv_len
+    page_table_ptr,  # batch-local physical page ids
     score_ptr,  # Score: qh x b x max_seqblock
     seq_lens,
-    slot_ids,
     # shape
-    max_slots,
     batch_size,
     gqa_group_size,
     head_dim,
@@ -72,7 +71,7 @@ def _decode_score_kernel(
     stride_k_s,
     stride_k_h,
     stride_k_d,
-    stride_r2t_b,
+    stride_pt_b,
     stride_s_h,
     stride_s_b,
     stride_s_n,
@@ -85,6 +84,7 @@ def _decode_score_kernel(
     SCORE_TYPE: tl.constexpr,
     SKIP_TRIVIAL_TOPK_SCORE: tl.constexpr,
     IS_FP8: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
 ):
     tl.static_assert(SCORE_TYPE == "max" or SCORE_TYPE == "lse")
     sm_scale_log2e = sm_scale * 1.4426950409
@@ -108,7 +108,6 @@ def _decode_score_kernel(
     chunk_end = tl.minimum(chunk_end_block * block_size, seq_len)
     if chunk_start_block >= chunk_end_block:
         return
-    sid = (tl.load(slot_ids + pid_b).to(tl.int64) + max_slots) % max_slots
     # init qkv pointer
     q_ptrs = tl.make_block_ptr(
         base=q_ptr + pid_b * stride_q_b + pid_h * stride_q_h,
@@ -136,14 +135,16 @@ def _decode_score_kernel(
     # pre-compute local_start outside the loop (constant for entire batch)
     local_start = tl.maximum(0, num_blocks - local_blocks)
     # prefetch first iteration's slots
-    r2t_base = req_to_token_ptr + sid * stride_r2t_b
     prefetch_pos = chunk_start + off_n
     prefetch_mask = prefetch_pos < seq_len
-    prefetched_slots = tl.load(
-        r2t_base + prefetch_pos,
-        mask=prefetch_mask,
-        other=0,
-    ).to(tl.int64)
+    prefetched_slots = load_token_slots(
+        page_table_ptr,
+        pid_b,
+        prefetch_pos,
+        stride_pt_b,
+        prefetch_mask,
+        PAGE_SIZE,
+    )
     # score-only: compute block scores without loading V
     for i in range(chunk_start, chunk_end, BLOCK_SIZE_N):
         pos_mask = prefetch_mask
@@ -153,12 +154,14 @@ def _decode_score_kernel(
         if next_i < chunk_end:
             next_pos = next_i + off_n
             prefetch_mask = next_pos < seq_len
-            prefetched_slots = tl.load(
-                r2t_base + next_pos,
-                mask=prefetch_mask,
-                other=0,
-            ).to(tl.int64)
-        slots = (slots + max_slots) % max_slots
+            prefetched_slots = load_token_slots(
+                page_table_ptr,
+                pid_b,
+                next_pos,
+                stride_pt_b,
+                prefetch_mask,
+                PAGE_SIZE,
+            )
         # load K as (head_dim, BLOCK_SIZE_N) via indirect addressing
         k_off = (
             slots[None, :] * stride_k_s
@@ -235,14 +238,12 @@ def _decode_score_attn_kernel(
     sink_ptr,  # Sink: qh x d
     k_cache_ptr,  # K paged: max_slots x kh x d
     v_cache_ptr,  # V paged: max_slots x kh x d
-    req_to_token_ptr,  # req_to_token: max_reqs x max_kv_len
+    page_table_ptr,  # batch-local physical page ids
     o_ptr,  # O: c x b x qh x d
     lse_ptr,  # lse: c x b x qh
     score_ptr,  # Score: qh x b x max_seqblock
     seq_lens,
-    slot_ids,
     # shape
-    max_slots,
     batch_size,
     gqa_group_size,
     head_dim,
@@ -269,7 +270,7 @@ def _decode_score_attn_kernel(
     stride_v_s,
     stride_v_h,
     stride_v_d,
-    stride_r2t_b,
+    stride_pt_b,
     stride_o_c,
     stride_o_b,
     stride_o_h,
@@ -289,6 +290,7 @@ def _decode_score_attn_kernel(
     SCORE_TYPE: tl.constexpr,
     SKIP_TRIVIAL_TOPK_SCORE: tl.constexpr,
     IS_FP8: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
 ):
     tl.static_assert(SCORE_TYPE == "max" or SCORE_TYPE == "lse")
     sm_scale_log2e = sm_scale * 1.4426950409
@@ -309,9 +311,6 @@ def _decode_score_attn_kernel(
     chunk_end = tl.minimum(chunk_end_block * block_size, seq_len)
     if chunk_start_block >= chunk_end_block:
         return
-    sid = (
-        tl.load(slot_ids + pid_b).to(tl.int64) + max_slots
-    ) % max_slots  # to avoid bugs when slot_ids is negative
     # init qkv pointer
     q_ptrs = tl.make_block_ptr(
         base=q_ptr + pid_b * stride_q_b + pid_h * stride_q_h,
@@ -367,13 +366,14 @@ def _decode_score_attn_kernel(
     for i in range(chunk_start, chunk_end, BLOCK_SIZE_N):
         pos = i + off_n
         pos_mask = pos < seq_len
-        # resolve slot per position via req_to_token
-        slots = tl.load(
-            req_to_token_ptr + sid * stride_r2t_b + pos,
-            mask=pos_mask,
-            other=0,
-        ).to(tl.int64)
-        slots = (slots + max_slots) % max_slots  # safety against negative
+        slots = load_token_slots(
+            page_table_ptr,
+            pid_b,
+            pos,
+            stride_pt_b,
+            pos_mask,
+            PAGE_SIZE,
+        )
         # load K as (head_dim, BLOCK_SIZE_N) via indirect addressing
         k_off = (
             slots[None, :] * stride_k_s
@@ -786,10 +786,9 @@ def flash_decode_with_topk_idx(
     sink: Optional[torch.Tensor],
     k_cache: torch.Tensor,  # [max_slots, num_kv_heads, head_dim] (paged)
     v_cache: Optional[torch.Tensor],  # paged; ignored when disable_index_value=True
-    req_to_token: torch.Tensor,  # [max_reqs, max_kv_len]
+    page_table: torch.Tensor,  # [batch_size, max_pages] physical page ids
     seq_lens: torch.Tensor,  # [batch_size, ]
     max_seqlen: int,
-    slot_ids: torch.Tensor,  # [batch_size, ]
     block_size: int,
     topk: int,
     init_blocks: int,
@@ -819,9 +818,10 @@ def flash_decode_with_topk_idx(
         assert v_cache is not None
     # shape
     batch_size, num_q_heads, head_dim = q.shape
-    max_slots, num_kv_heads, _ = k_cache.shape
-    max_kv_len = req_to_token.shape[1]
-    assert slot_ids.shape[0] == batch_size and seq_lens.shape[0] == batch_size
+    _, num_kv_heads, _ = k_cache.shape
+    assert page_table.dtype == torch.int32 and page_table.dim() == 2
+    max_kv_len = page_table.shape[1] * page_size
+    assert page_table.shape[0] == batch_size and seq_lens.shape[0] == batch_size
     # gqa
     assert num_q_heads % num_kv_heads == 0
     gqa_group_size = num_q_heads // num_kv_heads
@@ -876,11 +876,9 @@ def flash_decode_with_topk_idx(
         _decode_score_kernel[grid](
             q,
             k_cache,
-            req_to_token,
+            page_table,
             score,
             seq_lens,
-            slot_ids,
-            max_slots,
             batch_size,
             gqa_group_size,
             head_dim,
@@ -896,7 +894,7 @@ def flash_decode_with_topk_idx(
             k_cache.stride(0),
             k_cache.stride(1),
             k_cache.stride(2),
-            req_to_token.stride(0),
+            page_table.stride(0),
             score.stride(0),
             score.stride(1),
             score.stride(2),
@@ -904,6 +902,7 @@ def flash_decode_with_topk_idx(
             SCORE_TYPE=score_type,
             SKIP_TRIVIAL_TOPK_SCORE=skip_trivial_topk_score,
             IS_FP8=is_fp8,
+            PAGE_SIZE=page_size,
         )
     else:
         assert v_cache is not None
@@ -923,13 +922,11 @@ def flash_decode_with_topk_idx(
             sink,
             k_cache,
             v_cache,
-            req_to_token,
+            page_table,
             o,
             lse,
             score,
             seq_lens,
-            slot_ids,
-            max_slots,
             batch_size,
             gqa_group_size,
             head_dim,
@@ -951,7 +948,7 @@ def flash_decode_with_topk_idx(
             v_cache.stride(0),
             v_cache.stride(1),
             v_cache.stride(2),
-            req_to_token.stride(0),
+            page_table.stride(0),
             o.stride(0),
             o.stride(1),
             o.stride(2),
@@ -966,6 +963,7 @@ def flash_decode_with_topk_idx(
             SCORE_TYPE=score_type,
             SKIP_TRIVIAL_TOPK_SCORE=skip_trivial_topk_score,
             IS_FP8=is_fp8,
+            PAGE_SIZE=page_size,
         )
     # Fused top-k + page-table transform: emit the dense backend's page table
     # directly (page-size-aware) instead of block ids, skipping a separate gather.
@@ -980,7 +978,7 @@ def flash_decode_with_topk_idx(
         # kernel emits a flattened [batch*num_q_heads] page table + seq_lens with
         # the kv head head-encoded (head-minor) into the page index.
         topk_idx, real_seq_lens = minimax_decode_topk_page_table(
-            score, seq_lens, req_to_token, slot_ids, block_size, topk, page_size
+            score, seq_lens, page_table, block_size, topk, page_size
         )
         if disable_index_value:
             return None, topk_idx, real_seq_lens

--- a/python/sglang/kernels/ops/attention/minimax_sparse/decode/topk_sparse.py
+++ b/python/sglang/kernels/ops/attention/minimax_sparse/decode/topk_sparse.py
@@ -89,6 +89,7 @@ def _gqa_share_sparse_decode_kernel(
     HAS_SINK: tl.constexpr,
     IS_FP8: tl.constexpr,
     PAGE_SIZE: tl.constexpr,
+    ONE_PAGE_PER_BLOCK: tl.constexpr,
 ):
     # decode program ids: split-K over the topk dimension to give every SM
     # something to do at small batch. pid(0) folds (batch, chunk) together so
@@ -165,14 +166,20 @@ def _gqa_share_sparse_decode_kernel(
         # Resolve slots from graph-owned page ids during replay.
         pos = c + off_n
         pos_mask = pos < seq_len
-        slots = load_token_slots(
-            page_table_ptr,
-            pid_b,
-            pos,
-            stride_pt_b,
-            pos_mask,
-            PAGE_SIZE,
-        )
+        if ONE_PAGE_PER_BLOCK:
+            physical_page = tl.load(
+                page_table_ptr + pid_b * stride_pt_b + c // BLOCK_SIZE_N
+            ).to(tl.int64)
+            slots = physical_page * BLOCK_SIZE_N + off_n
+        else:
+            slots = load_token_slots(
+                page_table_ptr,
+                pid_b,
+                pos,
+                stride_pt_b,
+                pos_mask,
+                PAGE_SIZE,
+            )
         # load K as (head_dim, BLOCK_SIZE_N) via indirect addressing
         k_off = (
             slots[None, :] * stride_k_s
@@ -418,6 +425,7 @@ def flash_decode_with_gqa_share_sparse(
         NUM_TOPK_CHUNKS=NUM_TOPK_CHUNKS,
         IS_FP8=is_fp8,
         PAGE_SIZE=page_size,
+        ONE_PAGE_PER_BLOCK=page_size == block_size,
     )
     # merge partials into chunk 0
     merge_grid = (batch_size, num_q_heads)

--- a/python/sglang/kernels/ops/attention/minimax_sparse/decode/topk_sparse.py
+++ b/python/sglang/kernels/ops/attention/minimax_sparse/decode/topk_sparse.py
@@ -15,6 +15,12 @@ from ..common.utils import (
 from ..page_table import load_token_slots
 
 
+def _decode_main_attention_kernel_config(batch_size: int) -> tuple[int, int]:
+    if 4 <= batch_size < 16:
+        return 8, 2
+    return 4, 2
+
+
 @triton.heuristics(
     {
         "BLOCK_SIZE_H": lambda args: max(
@@ -25,14 +31,6 @@ from ..page_table import load_token_slots
         "HAS_SINK": lambda args: args["sink_ptr"] is not None,
         "BATCH_SIZE_BUCKET": lambda args: triton.next_power_of_2(args["batch_size"]),
     }
-)
-@triton.autotune(
-    configs=[
-        triton.Config({}, num_warps=nw, num_stages=ns)
-        for nw in [4, 8]
-        for ns in [2, 3, 4, 5]
-    ],
-    key=["BATCH_SIZE_BUCKET", "gqa_group_size", "head_dim", "block_size", "HAS_SINK"],
 )
 @triton.jit
 def _gqa_share_sparse_decode_kernel(
@@ -381,6 +379,7 @@ def flash_decode_with_gqa_share_sparse(
     )
     # launch attention kernel
     grid = (batch_size * NUM_TOPK_CHUNKS, num_kv_heads)
+    num_warps, num_stages = _decode_main_attention_kernel_config(batch_size)
     _gqa_share_sparse_decode_kernel[grid](
         q,
         sink,
@@ -426,6 +425,8 @@ def flash_decode_with_gqa_share_sparse(
         IS_FP8=is_fp8,
         PAGE_SIZE=page_size,
         ONE_PAGE_PER_BLOCK=page_size == block_size,
+        num_warps=num_warps,
+        num_stages=num_stages,
     )
     # merge partials into chunk 0
     merge_grid = (batch_size, num_q_heads)

--- a/python/sglang/kernels/ops/attention/minimax_sparse/decode/topk_sparse.py
+++ b/python/sglang/kernels/ops/attention/minimax_sparse/decode/topk_sparse.py
@@ -12,6 +12,7 @@ from ..common.utils import (
     sparse_out_dtype,
     unit_scale,
 )
+from ..page_table import load_token_slots
 
 
 @triton.heuristics(
@@ -39,14 +40,12 @@ def _gqa_share_sparse_decode_kernel(
     sink_ptr,  # Sink: qh x d
     k_cache_ptr,  # K paged: max_slots x kh x d
     v_cache_ptr,  # V paged: max_slots x kh x d
-    req_to_token_ptr,  # req_to_token: max_reqs x max_kv_len
+    page_table_ptr,  # batch-local physical page ids
     idx_ptr,  # topk index: qh x b x topk
     o_ptr,  # O partial: c x b x qh x d
     lse_ptr,  # lse partial: c x b x qh
     seq_lens,
-    slot_ids,
     # shape
-    max_slots,
     batch_size,
     gqa_group_size,
     head_dim,
@@ -69,7 +68,7 @@ def _gqa_share_sparse_decode_kernel(
     stride_v_s,
     stride_v_h,
     stride_v_d,
-    stride_r2t_b,
+    stride_pt_b,
     stride_ti_h,
     stride_ti_b,
     stride_ti_t,
@@ -89,6 +88,7 @@ def _gqa_share_sparse_decode_kernel(
     NUM_TOPK_CHUNKS: tl.constexpr,
     HAS_SINK: tl.constexpr,
     IS_FP8: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
 ):
     # decode program ids: split-K over the topk dimension to give every SM
     # something to do at small batch. pid(0) folds (batch, chunk) together so
@@ -105,9 +105,6 @@ def _gqa_share_sparse_decode_kernel(
     chunk_end_topk_compiletime = chunk_start_topk + chunk_size_topk
     # get q k start and len after rmpad
     seq_len = tl.minimum(tl.load(seq_lens + pid_b), max_kv_len)
-    sid = (
-        tl.load(slot_ids + pid_b).to(tl.int64) + max_slots
-    ) % max_slots  # to avoid bugs when slot_ids is negative
     # get real topk
     off_t = tl.arange(0, BLOCK_SIZE_T)
     idx_base = idx_ptr + pid_kh * stride_ti_h + pid_b * stride_ti_b
@@ -165,15 +162,17 @@ def _gqa_share_sparse_decode_kernel(
         # load index
         c = tl.load(cur_idx_ptr).to(tl.int32) * BLOCK_SIZE_N
         cur_idx_ptr = cur_idx_ptr + stride_ti_t
-        # resolve slots for this block via req_to_token
+        # Resolve slots from graph-owned page ids during replay.
         pos = c + off_n
         pos_mask = pos < seq_len
-        slots = tl.load(
-            req_to_token_ptr + sid * stride_r2t_b + pos,
-            mask=pos_mask,
-            other=0,
-        ).to(tl.int64)
-        slots = (slots + max_slots) % max_slots  # safety against negative
+        slots = load_token_slots(
+            page_table_ptr,
+            pid_b,
+            pos,
+            stride_pt_b,
+            pos_mask,
+            PAGE_SIZE,
+        )
         # load K as (head_dim, BLOCK_SIZE_N) via indirect addressing
         k_off = (
             slots[None, :] * stride_k_s
@@ -311,9 +310,8 @@ def flash_decode_with_gqa_share_sparse(
     sink: Optional[torch.Tensor],
     k_cache: torch.Tensor,  # [max_slots, num_kv_heads, head_dim] (paged)
     v_cache: torch.Tensor,  # [max_slots, num_kv_heads, head_dim] (paged)
-    req_to_token: torch.Tensor,  # [max_reqs, max_kv_len]
+    page_table: torch.Tensor,  # [batch_size, max_pages] physical page ids
     seq_lens: torch.Tensor,  # [batch_size, ]
-    slot_ids: torch.Tensor,  # [batch_size, ]
     block_size: int,
     topk_idx: torch.Tensor,  # [num_kv_heads, batch_size, topk]
     sm_scale: Optional[float] = None,
@@ -321,6 +319,7 @@ def flash_decode_with_gqa_share_sparse(
     q_scale: Optional[float] = None,
     k_scale: Optional[float] = None,
     v_scale: Optional[float] = None,
+    page_size: int = 1,
 ) -> torch.Tensor:
     triton.set_allocator(robust_allocator)
     is_fp8 = check_sparse_kv_fp8(q, k_cache, v_cache, label="decode")
@@ -328,14 +327,14 @@ def flash_decode_with_gqa_share_sparse(
     v_scale = unit_scale(v_scale)
     # shape
     batch_size, num_q_heads, head_dim = q.shape
-    max_slots, num_kv_heads, _ = k_cache.shape
-    assert slot_ids.shape[0] == batch_size and seq_lens.shape[0] == batch_size
+    _, num_kv_heads, _ = k_cache.shape
+    assert page_table.dtype == torch.int32 and page_table.dim() == 2
+    assert page_table.shape[0] == batch_size and seq_lens.shape[0] == batch_size
     assert topk_idx.shape[0] == num_kv_heads
     assert (
         triton.next_power_of_2(block_size) == block_size
     ), f"block_size must be a power of 2, but got {block_size}"
-    # assert slot_ids.max() < max_slots, f"get slot_ids {slot_ids}, but kv_cache shape is {kv_cache.shape}"
-    max_kv_len = req_to_token.shape[1]
+    max_kv_len = page_table.shape[1] * page_size
     # gqa
     assert num_q_heads % num_kv_heads == 0
     gqa_group_size = num_q_heads // num_kv_heads
@@ -380,13 +379,11 @@ def flash_decode_with_gqa_share_sparse(
         sink,
         k_cache,
         v_cache,
-        req_to_token,
+        page_table,
         topk_idx,
         o_partial,
         lse_partial,
         seq_lens,
-        slot_ids,
-        max_slots,
         batch_size,
         gqa_group_size,
         head_dim,
@@ -406,7 +403,7 @@ def flash_decode_with_gqa_share_sparse(
         v_cache.stride(0),
         v_cache.stride(1),
         v_cache.stride(2),
-        req_to_token.stride(0),
+        page_table.stride(0),
         topk_idx.stride(0),
         topk_idx.stride(1),
         topk_idx.stride(2),
@@ -420,6 +417,7 @@ def flash_decode_with_gqa_share_sparse(
         BLOCK_SIZE_N=block_size,
         NUM_TOPK_CHUNKS=NUM_TOPK_CHUNKS,
         IS_FP8=is_fp8,
+        PAGE_SIZE=page_size,
     )
     # merge partials into chunk 0
     merge_grid = (batch_size, num_q_heads)

--- a/python/sglang/kernels/ops/attention/minimax_sparse/page_table.py
+++ b/python/sglang/kernels/ops/attention/minimax_sparse/page_table.py
@@ -1,0 +1,102 @@
+"""MiniMax sparse-attention page-table snapshot and lookup helpers."""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def load_token_slots(
+    page_table_ptr,
+    batch_idx,
+    positions,
+    stride_page_table_b,
+    mask,
+    PAGE_SIZE: tl.constexpr,
+):
+    """Resolve logical token positions through a batch-local physical page table."""
+    physical_pages = tl.load(
+        page_table_ptr + batch_idx * stride_page_table_b + positions // PAGE_SIZE,
+        mask=mask,
+        other=0,
+    ).to(tl.int64)
+    return physical_pages * PAGE_SIZE + positions % PAGE_SIZE
+
+
+@triton.jit
+def _build_page_table_kernel(
+    req_to_token_ptr,
+    req_pool_indices_ptr,
+    seq_lens_ptr,
+    page_table_ptr,
+    stride_r2t_b,
+    stride_pt_b,
+    max_num_pages,
+    max_slots,
+    SEQ_LEN_DELTA: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid_b = tl.program_id(0)
+    pid_c = tl.program_id(1)
+    page_offsets = pid_c * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    seq_len = tl.load(seq_lens_ptr + pid_b).to(tl.int64) + SEQ_LEN_DELTA
+    num_pages = tl.cdiv(seq_len, PAGE_SIZE)
+    in_bounds = page_offsets < max_num_pages
+    active = in_bounds & (page_offsets < num_pages)
+
+    req_idx = tl.load(req_pool_indices_ptr + pid_b).to(tl.int64)
+    logical_first = page_offsets * PAGE_SIZE
+    physical_slots = tl.load(
+        req_to_token_ptr + req_idx * stride_r2t_b + logical_first,
+        mask=active,
+        other=0,
+    ).to(tl.int64)
+    physical_slots = (physical_slots + max_slots) % max_slots
+    tl.store(
+        page_table_ptr + pid_b * stride_pt_b + page_offsets,
+        physical_slots // PAGE_SIZE,
+        mask=in_bounds,
+    )
+
+
+@torch.no_grad()
+def build_page_table_snapshot(
+    page_table: torch.Tensor,
+    req_to_token: torch.Tensor,
+    req_pool_indices: torch.Tensor,
+    seq_lens: torch.Tensor,
+    page_size: int,
+    max_slots: int,
+    *,
+    seq_len_delta: int = 0,
+) -> None:
+    """Snapshot active request rows into graph-owned physical page ids."""
+    assert page_table.dtype == torch.int32 and page_table.dim() == 2
+    assert req_to_token.dtype == torch.int32 and req_to_token.dim() == 2
+    assert page_table.shape[0] == req_pool_indices.shape[0] == seq_lens.shape[0]
+    assert page_size > 0
+    assert max_slots > 0 and max_slots % page_size == 0
+    if page_table.shape[0] == 0:
+        return
+
+    block_size = 256
+    grid = (
+        page_table.shape[0],
+        triton.cdiv(page_table.shape[1], block_size),
+    )
+    _build_page_table_kernel[grid](
+        req_to_token,
+        req_pool_indices,
+        seq_lens,
+        page_table,
+        req_to_token.stride(0),
+        page_table.stride(0),
+        page_table.shape[1],
+        max_slots,
+        SEQ_LEN_DELTA=seq_len_delta,
+        PAGE_SIZE=page_size,
+        BLOCK_SIZE=block_size,
+    )

--- a/python/sglang/kernels/ops/attention/minimax_sparse/prefill/flash_with_topk_idx.py
+++ b/python/sglang/kernels/ops/attention/minimax_sparse/prefill/flash_with_topk_idx.py
@@ -408,6 +408,52 @@ def _topk_index_kernel(
 
 
 @torch.no_grad()
+def topk_index_from_block_score(
+    score: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    prefix_lens: torch.Tensor,
+    cu_seqblocks_q: torch.Tensor,
+    max_seqblock_q: int,
+    all_seqblock_q: int,
+    block_size_q: int,
+    block_size_k: int,
+    topk: int,
+    init_blocks: int,
+    local_blocks: int,
+):
+    num_heads = score.shape[0]
+    batch_size = cu_seqlens.shape[0] - 1
+    topk_idx = torch.full(
+        (num_heads, all_seqblock_q, topk),
+        fill_value=-1,
+        device=score.device,
+        dtype=torch.int32,
+    )
+    grid = (max_seqblock_q, batch_size, num_heads)
+    _topk_index_kernel[grid](
+        score,
+        topk_idx,
+        block_size_q,
+        block_size_k,
+        cu_seqlens,
+        cu_seqblocks_q,
+        prefix_lens,
+        topk,
+        init_blocks,
+        local_blocks,
+        score.stride(0),
+        score.stride(1),
+        score.stride(2),
+        topk_idx.stride(0),
+        topk_idx.stride(1),
+        topk_idx.stride(2),
+        MASK_INIT=False,
+        MASK_LOCAL=False,
+    )
+    return topk_idx
+
+
+@torch.no_grad()
 def flash_prefill_with_topk_index(
     q: torch.Tensor,
     k_cache: torch.Tensor,  # paged
@@ -557,33 +603,17 @@ def flash_prefill_with_topk_index(
         num_stages=num_stages,
     )
 
-    # topk extraction kernel
-    topk_idx = torch.full(
-        (num_heads, all_seqblock_q, topk),
-        fill_value=-1,
-        device=score.device,
-        dtype=torch.int32,
-    )
-    # launch kernel
-    grid = (max_seqblock_q, batch_size, num_heads)
-    _topk_index_kernel[grid](
+    topk_idx = topk_index_from_block_score(
         score,
-        topk_idx,
+        cu_seqlens,
+        prefix_lens,
+        cu_seqblocks_q,
+        max_seqblock_q,
+        all_seqblock_q,
         block_size_q,
         block_size_k,
-        cu_seqlens,
-        cu_seqblocks_q,
-        prefix_lens,
         topk,
         init_blocks,
         local_blocks,
-        score.stride(0),
-        score.stride(1),
-        score.stride(2),
-        topk_idx.stride(0),
-        topk_idx.stride(1),
-        topk_idx.stride(2),
-        MASK_INIT=False,
-        MASK_LOCAL=False,
     )
     return o, topk_idx

--- a/python/sglang/kernels/ops/attention/minimax_sparse/prefill/flash_with_topk_idx.py
+++ b/python/sglang/kernels/ops/attention/minimax_sparse/prefill/flash_with_topk_idx.py
@@ -15,6 +15,7 @@ from ..common.utils import (
     sparse_out_dtype,
     unit_scale,
 )
+from ..page_table import load_token_slots
 
 
 @triton.heuristics(
@@ -74,14 +75,12 @@ def _flash_attn_fwd_with_block_score_kernel(
     sink_ptr,  # Sink: h x d
     o_ptr,  # O: n x h x d
     score_ptr,  # Score: h x n x max_seqblock
-    req_to_token_ptr,  # req_to_token: max_reqs x max_kv_len
+    page_table_ptr,  # batch-local physical page ids
     # seqlens
     cu_seqlens,
     seq_lens,
     prefix_lens,
-    slot_ids,
     # shape
-    max_slots,
     num_heads,
     gqa_group_size,
     qk_head_dim,
@@ -113,7 +112,7 @@ def _flash_attn_fwd_with_block_score_kernel(
     stride_s_h,
     stride_s_q,
     stride_s_k,
-    stride_r2t_b,
+    stride_pt_b,
     # META parameters
     BLOCK_SIZE_Q: tl.constexpr,  # q block size
     BLOCK_SIZE_K: tl.constexpr,  # k block size
@@ -124,6 +123,7 @@ def _flash_attn_fwd_with_block_score_kernel(
     SCORE_TYPE: tl.constexpr,
     DISABLE_INDEX_VALUE: tl.constexpr,
     IS_FP8: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
 ):
     tl.static_assert(SCORE_TYPE == "max" or SCORE_TYPE == "lse")
     sm_scale_log2e = sm_scale * 1.4426950409
@@ -139,9 +139,6 @@ def _flash_attn_fwd_with_block_score_kernel(
     q_len = tl.load(cu_seqlens + pid_b + 1) - seq_start
     seq_len = tl.load(seq_lens + pid_b)
     prefix_len = tl.load(prefix_lens + pid_b)
-    sid = (
-        tl.load(slot_ids + pid_b).to(tl.int64) + max_slots
-    ) % max_slots  # safety against negative
     if BLOCK_SIZE_Q * pid_q >= q_len:
         return
     block_num = (seq_len + block_size - 1) // block_size
@@ -196,15 +193,17 @@ def _flash_attn_fwd_with_block_score_kernel(
     diag_start = (prefix_len + pid_q * BLOCK_SIZE_Q) // BLOCK_SIZE_K * BLOCK_SIZE_K
     hi = min(seq_len, prefix_len + (pid_q + 1) * BLOCK_SIZE_Q)
     for i in tl.range(0, hi, BLOCK_SIZE_K):
-        # paged load K via req_to_token: pos -> slot -> k_cache
+        # Resolve logical positions through the per-forward page-table snapshot.
         pos = i + off_k
         pos_mask = pos < seq_len
-        slots = tl.load(
-            req_to_token_ptr + sid * stride_r2t_b + pos,
-            mask=pos_mask,
-            other=0,
-        ).to(tl.int64)
-        slots = (slots + max_slots) % max_slots  # safety against negative
+        slots = load_token_slots(
+            page_table_ptr,
+            pid_b,
+            pos,
+            stride_pt_b,
+            pos_mask,
+            PAGE_SIZE,
+        )
         # k shape: [BLOCK_SIZE_KD, BLOCK_SIZE_K] (transposed for tl.dot)
         k = tl.load(
             k_cache_ptr
@@ -445,8 +444,7 @@ def flash_prefill_with_topk_index(
     k_cache: torch.Tensor,  # paged
     v_cache: Optional[torch.Tensor],  # paged; ignored when disable_index_value=True
     sink: Optional[torch.Tensor],
-    req_to_token: torch.Tensor,
-    slot_ids: torch.Tensor,
+    page_table: torch.Tensor,
     cu_seqlens: torch.Tensor,
     seq_lens: torch.Tensor,
     prefix_lens: torch.Tensor,
@@ -467,6 +465,7 @@ def flash_prefill_with_topk_index(
     q_scale: Optional[float] = None,
     k_scale: Optional[float] = None,
     v_scale: Optional[float] = None,
+    page_size: int = 1,
 ):
     assert score_type in (
         "max",
@@ -482,7 +481,7 @@ def flash_prefill_with_topk_index(
     assert cu_seqlens.dtype == torch.int32
     # shape
     total_q, num_heads, qk_head_dim = q.shape
-    max_slots, num_kv_heads, _ = k_cache.shape
+    _, num_kv_heads, _ = k_cache.shape
     if disable_index_value:
         # placeholder for BLOCK_SIZE_VD; V is never loaded
         v_head_dim = qk_head_dim
@@ -492,6 +491,8 @@ def flash_prefill_with_topk_index(
         v_head_dim = v_cache.shape[-1]
     gqa_group_size = num_heads // num_kv_heads
     batch_size = cu_seqlens.shape[0] - 1
+    assert page_table.dtype == torch.int32 and page_table.dim() == 2
+    assert page_table.shape[0] == batch_size
     assert qk_head_dim <= 256 and v_head_dim <= 256, "head_dim must be less than 256"
     if sink is not None:
         assert sink.shape[0] == num_heads and sink.shape[1] == qk_head_dim
@@ -507,7 +508,15 @@ def flash_prefill_with_topk_index(
         cu_seqblocks_q, max_seqblock_q, all_seqblock_q, _, _, _ = get_cu_seqblocks(
             cu_seqlens, max_seqlen_q, block_size_q, block_size_k
         )
-    max_seqblock_k = triton.cdiv(max_seqlen_k, block_size_k)
+    # Replay-time prefixes may be longer than the capture-time fill value.
+    max_seqblock_k = triton.cdiv(
+        (
+            page_table.shape[1] * page_size
+            if torch.cuda.is_current_stream_capturing()
+            else max_seqlen_k
+        ),
+        block_size_k,
+    )
     if disable_index_value:
         o = None
     else:
@@ -532,12 +541,10 @@ def flash_prefill_with_topk_index(
         sink,
         o,
         score,
-        req_to_token,
+        page_table,
         cu_seqlens,
         seq_lens,
         prefix_lens,
-        slot_ids,
-        max_slots,
         num_heads,
         gqa_group_size,
         qk_head_dim,
@@ -565,10 +572,11 @@ def flash_prefill_with_topk_index(
         score.stride(0),
         score.stride(1),
         score.stride(2),
-        req_to_token.stride(0),
+        page_table.stride(0),
         SCORE_TYPE=score_type,
         DISABLE_INDEX_VALUE=disable_index_value,
         IS_FP8=is_fp8,
+        PAGE_SIZE=page_size,
     )
 
     # topk extraction kernel

--- a/python/sglang/kernels/ops/attention/minimax_sparse/prefill/flash_with_topk_idx.py
+++ b/python/sglang/kernels/ops/attention/minimax_sparse/prefill/flash_with_topk_idx.py
@@ -18,54 +18,16 @@ from ..common.utils import (
 from ..page_table import load_token_slots
 
 
+def _prefill_index_score_kernel_config() -> tuple[int, int, int, int]:
+    return 64, 128, 4, 2
+
+
 @triton.heuristics(
     {
         "BLOCK_SIZE_KD": lambda args: triton.next_power_of_2(args["qk_head_dim"]),
         "BLOCK_SIZE_VD": lambda args: triton.next_power_of_2(args["v_head_dim"]),
         "HAS_SINK": lambda args: args["sink_ptr"] is not None,
     }
-)
-@triton.autotune(
-    configs=[
-        # Small block (64x64): low shared mem, can use higher num_stages
-        triton.Config(
-            {"BLOCK_SIZE_Q": 64, "BLOCK_SIZE_K": 64}, num_warps=4, num_stages=2
-        ),
-        triton.Config(
-            {"BLOCK_SIZE_Q": 64, "BLOCK_SIZE_K": 64}, num_warps=4, num_stages=3
-        ),
-        triton.Config(
-            {"BLOCK_SIZE_Q": 64, "BLOCK_SIZE_K": 64}, num_warps=4, num_stages=4
-        ),
-        # Medium block (64x128, 128x64): moderate shared mem, ns=2,3
-        triton.Config(
-            {"BLOCK_SIZE_Q": 64, "BLOCK_SIZE_K": 128}, num_warps=8, num_stages=2
-        ),
-        triton.Config(
-            {"BLOCK_SIZE_Q": 64, "BLOCK_SIZE_K": 128}, num_warps=8, num_stages=3
-        ),
-        triton.Config(
-            {"BLOCK_SIZE_Q": 128, "BLOCK_SIZE_K": 64}, num_warps=8, num_stages=2
-        ),
-        triton.Config(
-            {"BLOCK_SIZE_Q": 128, "BLOCK_SIZE_K": 64}, num_warps=8, num_stages=3
-        ),
-        # Large block (128x128): high shared mem, ns=2,3 only, nw=8
-        triton.Config(
-            {"BLOCK_SIZE_Q": 128, "BLOCK_SIZE_K": 128}, num_warps=8, num_stages=2
-        ),
-        triton.Config(
-            {"BLOCK_SIZE_Q": 128, "BLOCK_SIZE_K": 128}, num_warps=8, num_stages=3
-        ),
-    ],
-    key=[
-        "qk_head_dim",
-        "v_head_dim",
-        "block_size",
-        "use_gumbel_topk",
-        "SCORE_TYPE",
-        "DISABLE_INDEX_VALUE",
-    ],
 )
 @triton.jit
 def _flash_attn_fwd_with_block_score_kernel(
@@ -537,6 +499,10 @@ def flash_prefill_with_topk_index(
         device=q.device,
     )
 
+    BLOCK_SIZE_Q, BLOCK_SIZE_K, num_warps, num_stages = (
+        _prefill_index_score_kernel_config()
+    )
+
     # launch kernel
     def grid(META):
         return (triton.cdiv(max_seqlen_q, META["BLOCK_SIZE_Q"]), batch_size * num_heads)
@@ -585,6 +551,10 @@ def flash_prefill_with_topk_index(
         IS_FP8=is_fp8,
         PAGE_SIZE=page_size,
         ONE_PAGE_PER_BLOCK=page_size == block_size_k,
+        BLOCK_SIZE_Q=BLOCK_SIZE_Q,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        num_warps=num_warps,
+        num_stages=num_stages,
     )
 
     # topk extraction kernel

--- a/python/sglang/kernels/ops/attention/minimax_sparse/prefill/flash_with_topk_idx.py
+++ b/python/sglang/kernels/ops/attention/minimax_sparse/prefill/flash_with_topk_idx.py
@@ -124,6 +124,7 @@ def _flash_attn_fwd_with_block_score_kernel(
     DISABLE_INDEX_VALUE: tl.constexpr,
     IS_FP8: tl.constexpr,
     PAGE_SIZE: tl.constexpr,
+    ONE_PAGE_PER_BLOCK: tl.constexpr,
 ):
     tl.static_assert(SCORE_TYPE == "max" or SCORE_TYPE == "lse")
     sm_scale_log2e = sm_scale * 1.4426950409
@@ -196,14 +197,20 @@ def _flash_attn_fwd_with_block_score_kernel(
         # Resolve logical positions through the per-forward page-table snapshot.
         pos = i + off_k
         pos_mask = pos < seq_len
-        slots = load_token_slots(
-            page_table_ptr,
-            pid_b,
-            pos,
-            stride_pt_b,
-            pos_mask,
-            PAGE_SIZE,
-        )
+        if ONE_PAGE_PER_BLOCK:
+            physical_page = tl.load(
+                page_table_ptr + pid_b * stride_pt_b + i // block_size
+            ).to(tl.int64)
+            slots = physical_page * block_size + off_k
+        else:
+            slots = load_token_slots(
+                page_table_ptr,
+                pid_b,
+                pos,
+                stride_pt_b,
+                pos_mask,
+                PAGE_SIZE,
+            )
         # k shape: [BLOCK_SIZE_KD, BLOCK_SIZE_K] (transposed for tl.dot)
         k = tl.load(
             k_cache_ptr
@@ -577,6 +584,7 @@ def flash_prefill_with_topk_index(
         DISABLE_INDEX_VALUE=disable_index_value,
         IS_FP8=is_fp8,
         PAGE_SIZE=page_size,
+        ONE_PAGE_PER_BLOCK=page_size == block_size_k,
     )
 
     # topk extraction kernel

--- a/python/sglang/kernels/ops/attention/minimax_sparse/prefill/flash_with_topk_idx.py
+++ b/python/sglang/kernels/ops/attention/minimax_sparse/prefill/flash_with_topk_idx.py
@@ -550,7 +550,7 @@ def flash_prefill_with_topk_index(
         DISABLE_INDEX_VALUE=disable_index_value,
         IS_FP8=is_fp8,
         PAGE_SIZE=page_size,
-        ONE_PAGE_PER_BLOCK=page_size == block_size_k,
+        ONE_PAGE_PER_BLOCK=page_size == block_size_k == BLOCK_SIZE_K,
         BLOCK_SIZE_Q=BLOCK_SIZE_Q,
         BLOCK_SIZE_K=BLOCK_SIZE_K,
         num_warps=num_warps,

--- a/python/sglang/kernels/ops/attention/minimax_sparse/prefill/topk_sparse.py
+++ b/python/sglang/kernels/ops/attention/minimax_sparse/prefill/topk_sparse.py
@@ -106,6 +106,7 @@ def _gqa_share_sparse_fwd_kernel(
     USE_TMA: tl.constexpr,
     IS_FP8: tl.constexpr,
     PAGE_SIZE: tl.constexpr,
+    ONE_PAGE_PER_BLOCK: tl.constexpr,
 ):
     sm_scale_log2e = sm_scale * 1.4426950409
     # get batch id and head id
@@ -191,14 +192,20 @@ def _gqa_share_sparse_fwd_kernel(
             # Resolve from graph-owned page ids during replay.
             pos = c + off_n
             pos_mask = pos < seq_len
-            slots = load_token_slots(
-                page_table_ptr,
-                pid_b,
-                pos,
-                stride_pt_b,
-                pos_mask,
-                PAGE_SIZE,
-            )
+            if ONE_PAGE_PER_BLOCK:
+                physical_page = tl.load(
+                    page_table_ptr + pid_b * stride_pt_b + c // BLOCK_SIZE_K
+                ).to(tl.int64)
+                slots = physical_page * BLOCK_SIZE_K + off_n
+            else:
+                slots = load_token_slots(
+                    page_table_ptr,
+                    pid_b,
+                    pos,
+                    stride_pt_b,
+                    pos_mask,
+                    PAGE_SIZE,
+                )
             # k shape: [BLOCK_SIZE_KD, BLOCK_SIZE_K] (transposed for tl.dot)
             k = tl.load(
                 k_cache_ptr
@@ -377,5 +384,6 @@ def flash_prefill_with_gqa_share_sparse(
         USE_TMA=use_tma,
         IS_FP8=is_fp8,
         PAGE_SIZE=page_size,
+        ONE_PAGE_PER_BLOCK=page_size == block_size_k,
     )
     return o

--- a/python/sglang/kernels/ops/attention/minimax_sparse/prefill/topk_sparse.py
+++ b/python/sglang/kernels/ops/attention/minimax_sparse/prefill/topk_sparse.py
@@ -13,6 +13,7 @@ from ..common.utils import (
     sparse_out_dtype,
     unit_scale,
 )
+from ..page_table import load_token_slots
 
 
 @triton.heuristics(
@@ -54,15 +55,13 @@ def _gqa_share_sparse_fwd_kernel(
     sink_ptr,  # Sink: h x d
     t_ptr,  # topk_idx: kh x n x k
     o_ptr,  # O: n x h x d
-    req_to_token_ptr,  # req_to_token: max_reqs x max_kv_len
+    page_table_ptr,  # batch-local physical page ids
     # seqlens
     cu_seqlens_q,
     cu_seqblocks_q,
     seq_lens,
     prefix_lens,
-    slot_ids,
     # shape
-    max_slots,
     num_kv_heads,
     gqa_group_size,
     qk_head_dim,
@@ -93,7 +92,7 @@ def _gqa_share_sparse_fwd_kernel(
     stride_on,
     stride_oh,
     stride_od,
-    stride_r2t_b,
+    stride_pt_b,
     # META parameters
     BLOCK_SIZE_Q: tl.constexpr,  # q block size
     BLOCK_SIZE_K: tl.constexpr,  # k block size
@@ -106,6 +105,7 @@ def _gqa_share_sparse_fwd_kernel(
     HAS_SINK: tl.constexpr,
     USE_TMA: tl.constexpr,
     IS_FP8: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
 ):
     sm_scale_log2e = sm_scale * 1.4426950409
     # get batch id and head id
@@ -120,9 +120,6 @@ def _gqa_share_sparse_fwd_kernel(
     q_block_len = tl.load(cu_seqblocks_q + pid_b + 1) - q_block_start
     seq_len = tl.load(seq_lens + pid_b)
     prefix_len = tl.load(prefix_lens + pid_b)
-    sid = (
-        tl.load(slot_ids + pid_b).to(tl.int64) + max_slots
-    ) % max_slots  # safety against negative
     if pid_q * num_q_loop >= q_block_len:
         return
     real_q_loop = min(num_q_loop, q_block_len - pid_q * num_q_loop)
@@ -191,15 +188,17 @@ def _gqa_share_sparse_fwd_kernel(
             # get current block start index (absolute K position)
             c = tl.load(t_ptr_j).to(tl.int32) * BLOCK_SIZE_K
             t_ptr_j = t_ptr_j + stride_tk
-            # paged load K via req_to_token: pos -> slot -> k_cache
+            # Resolve from graph-owned page ids during replay.
             pos = c + off_n
             pos_mask = pos < seq_len
-            slots = tl.load(
-                req_to_token_ptr + sid * stride_r2t_b + pos,
-                mask=pos_mask,
-                other=0,
-            ).to(tl.int64)
-            slots = (slots + max_slots) % max_slots  # safety against negative
+            slots = load_token_slots(
+                page_table_ptr,
+                pid_b,
+                pos,
+                stride_pt_b,
+                pos_mask,
+                PAGE_SIZE,
+            )
             # k shape: [BLOCK_SIZE_KD, BLOCK_SIZE_K] (transposed for tl.dot)
             k = tl.load(
                 k_cache_ptr
@@ -273,8 +272,7 @@ def flash_prefill_with_gqa_share_sparse(
     k_cache: torch.Tensor,
     v_cache: torch.Tensor,
     sink: Optional[torch.Tensor],
-    req_to_token: torch.Tensor,
-    slot_ids: torch.Tensor,
+    page_table: torch.Tensor,
     topk_idx: torch.Tensor,
     block_size_q: int,
     block_size_k: int,
@@ -289,6 +287,7 @@ def flash_prefill_with_gqa_share_sparse(
     q_scale: Optional[float] = None,
     k_scale: Optional[float] = None,
     v_scale: Optional[float] = None,
+    page_size: int = 1,
 ) -> torch.Tensor:
     triton.set_allocator(robust_allocator)
     is_fp8 = check_sparse_kv_fp8(q, k_cache, v_cache, label="prefill")
@@ -298,10 +297,12 @@ def flash_prefill_with_gqa_share_sparse(
     assert block_size_k in {16, 32, 64, 128}
     # shape
     total_q, num_q_heads, qk_head_dim = q.shape
-    max_slots, num_k_heads, _ = k_cache.shape
+    _, num_k_heads, _ = k_cache.shape
     _, num_v_heads, v_head_dim = v_cache.shape
     batch_size = cu_seqlens.shape[0] - 1
     topk = topk_idx.shape[-1]
+    assert page_table.dtype == torch.int32 and page_table.dim() == 2
+    assert page_table.shape[0] == batch_size
     assert topk_idx.shape[0] == num_k_heads
     # gqa
     assert num_k_heads == num_v_heads
@@ -339,13 +340,11 @@ def flash_prefill_with_gqa_share_sparse(
         sink,
         topk_idx,
         o,
-        req_to_token,
+        page_table,
         cu_seqlens,
         cu_seqblocks_q,
         seq_lens,
         prefix_lens,
-        slot_ids,
-        max_slots,
         num_k_heads,
         gqa_group_size,
         qk_head_dim,
@@ -372,10 +371,11 @@ def flash_prefill_with_gqa_share_sparse(
         o.stride(0),
         o.stride(1),
         o.stride(2),
-        req_to_token.stride(0),
+        page_table.stride(0),
         BLOCK_SIZE_Q=BLOCK_SIZE_Q,
         BLOCK_SIZE_K=BLOCK_SIZE_K,
         USE_TMA=use_tma,
         IS_FP8=is_fp8,
+        PAGE_SIZE=page_size,
     )
     return o

--- a/python/sglang/kernels/ops/attention/minimax_sparse/prefill/topk_sparse.py
+++ b/python/sglang/kernels/ops/attention/minimax_sparse/prefill/topk_sparse.py
@@ -16,6 +16,10 @@ from ..common.utils import (
 from ..page_table import load_token_slots
 
 
+def _prefill_main_attention_kernel_config() -> tuple[int, int]:
+    return 4, 3
+
+
 @triton.heuristics(
     {
         "BLOCK_SIZE_KD": lambda args: triton.next_power_of_2(args["qk_head_dim"]),
@@ -30,22 +34,6 @@ from ..page_table import load_token_slots
         "BLOCK_SIZE_QH": lambda args: args["BLOCK_SIZE_Q"] * args["BLOCK_SIZE_H"],
         "HAS_SINK": lambda args: args["sink_ptr"] is not None,
     }
-)
-@triton.autotune(
-    # Configs that fail to compile on the target arch are skipped, so widening
-    # the num_warps x num_stages grid only adds candidates, never a bad kernel.
-    configs=[
-        triton.Config({}, num_warps=nw, num_stages=ns)
-        for nw in (2, 4, 8)
-        for ns in (2, 3, 4)
-    ],
-    key=[
-        "BLOCK_SIZE_Q",
-        "BLOCK_SIZE_K",
-        "qk_head_dim",
-        "v_head_dim",
-        "gqa_group_size",
-    ],
 )
 @triton.jit
 def _gqa_share_sparse_fwd_kernel(
@@ -340,6 +328,7 @@ def flash_prefill_with_gqa_share_sparse(
         num_k_heads,
         batch_size,
     )
+    num_warps, num_stages = _prefill_main_attention_kernel_config()
     _gqa_share_sparse_fwd_kernel[grid](
         q,
         k_cache,
@@ -385,5 +374,7 @@ def flash_prefill_with_gqa_share_sparse(
         IS_FP8=is_fp8,
         PAGE_SIZE=page_size,
         ONE_PAGE_PER_BLOCK=page_size == block_size_k,
+        num_warps=num_warps,
+        num_stages=num_stages,
     )
     return o

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1425,6 +1425,7 @@ class Envs:
     SGLANG_OPT_USE_BF16_ROUTER_GEMM = EnvBool(True)
     SGLANG_OPT_USE_MINIMAX_DENSE_SPARSE_DECODE = EnvBool(False)
     SGLANG_DISABLE_MSA = EnvBool(False)
+    SGLANG_OPT_USE_MSA_PREFILL_INDEX_SCORE = EnvBool(True)
     SGLANG_OPT_USE_MSA_DECODE_UNDER_GRAPH = EnvBool(False)
     # Kill switch for the derived fp8 attention-GEMM mode (m3_fp8_attn_gemm_enabled):
     # forces the pre-fp8 behavior (bf16 indexer + widening sparse path, bf16 q)

--- a/python/sglang/srt/layers/attention/minimax_sparse_backend.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_backend.py
@@ -228,6 +228,10 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
             self._msa_cg: dict[int, tuple] = {}
 
         self.page_size = self.kv_pool.page_size
+        # GPU sparse kernels consume a page-table snapshot instead of the live
+        # token table; CUDA Graph replay requires an address-stable backing.
+        self._cuda_graph_page_table: Optional[torch.Tensor] = None
+        self._active_page_table: Optional[torch.Tensor] = None
         self.use_dense_sparse_decode = (
             (not self.is_npu)
             and envs.SGLANG_OPT_USE_MINIMAX_DENSE_SPARSE_DECODE.get()
@@ -322,6 +326,7 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
     def init_forward_metadata_out_graph(
         self, forward_batch: ForwardBatch, in_capture: bool = False
     ):
+        self._active_page_table = None
         # getattr covers replay views lacking extend_seq_lens_cpu and TARGET_VERIFY.
         self._msa_dec_meta = None
         if self.is_npu:
@@ -329,9 +334,13 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
             self._prefill_meta = None
             self._extend_meta = None
             self._extend_meta_key = None
+
+        bs = forward_batch.batch_size
+        seq_lens = forward_batch.seq_lens[:bs]
+        seq_lens_cpu = forward_batch.seq_lens_cpu[:bs]
         extend_lens = getattr(forward_batch, "extend_seq_lens_cpu", None)
         if extend_lens is not None:
-            self._max_seqlen_q = int(max(extend_lens))
+            self._max_seqlen_q = int(max(extend_lens[:bs]))
         else:
             self._max_seqlen_q = 1
         if in_capture and (
@@ -342,12 +351,40 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
             # (longer sequences) does not miss KV blocks.
             self._max_seqlen_k = self.max_context_len
         else:
-            self._max_seqlen_k = int(forward_batch.seq_lens_cpu.max().item())
+            self._max_seqlen_k = int(seq_lens_cpu.max().item())
 
-        # Build plan + page table eager (outside capture) so captured forward_decode
-        # runs only device-side ops; host-side code can't be captured.
-        if self._msa_owns_decode and forward_batch.forward_mode.is_decode_or_idle():
-            self._prepare_msa_decode_meta(forward_batch)
+        if not self.is_npu:
+            if (
+                self._cuda_graph_page_table is not None
+                and bs <= self._cuda_graph_page_table.shape[0]
+            ):
+                self._active_page_table = self._cuda_graph_page_table[:bs]
+            else:
+                max_num_pages = max(
+                    1, (self._max_seqlen_k + self.page_size - 1) // self.page_size
+                )
+                self._active_page_table = torch.empty(
+                    (bs, max_num_pages),
+                    dtype=torch.int32,
+                    device=self.req_to_token.device,
+                )
+
+            from sglang.kernels.ops.attention.minimax_sparse.page_table import (
+                build_page_table_snapshot,
+            )
+
+            build_page_table_snapshot(
+                self._active_page_table,
+                self.req_to_token,
+                forward_batch.req_pool_indices[:bs],
+                seq_lens,
+                self.page_size,
+                self.kv_pool.size + self.page_size,
+            )
+
+            # Build MSA metadata eagerly so captured decode runs only device-side ops.
+            if self._msa_owns_decode and forward_batch.forward_mode.is_decode_or_idle():
+                self._prepare_msa_decode_meta(seq_lens)
 
         # ---- REPLAY-FRESH native verify block_table ----
         if (
@@ -389,19 +426,19 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
                     // self.page_size
                 ).to(torch.int32)
 
-    def _prepare_msa_decode_meta(self, forward_batch: ForwardBatch):
-        """Refresh the persistent per-batch-size MSA decode plan + page table in place."""
+    def _prepare_msa_decode_meta(self, seq_lens: torch.Tensor):
+        """Refresh the persistent per-batch-size MSA decode plan from the snapshot."""
         from sglang.srt.layers.attention.minimax_sparse_ops.msa import (
             build_msa_decode_cg_plan,
             update_msa_decode_cg_meta,
         )
 
-        bs = forward_batch.seq_lens.shape[0]
+        bs = seq_lens.shape[0]
         if bs == 0:
             return
         entry = self._msa_cg.get(bs)
         if entry is None:
-            device = forward_batch.seq_lens.device
+            device = seq_lens.device
             plan = build_msa_decode_cg_plan(
                 self.num_q_heads,
                 self.num_kv_heads,
@@ -420,9 +457,8 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
         update_msa_decode_cg_meta(
             plan,
             kv_indices_buf,
-            self.req_to_token,
-            forward_batch.req_pool_indices,
-            forward_batch.seq_lens,
+            self._active_page_table,
+            seq_lens,
             self.block_size_k,
             self.topk_blocks,
             self.num_q_heads,
@@ -475,7 +511,16 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
             )
 
     def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
-        pass
+        if self.is_npu:
+            return
+        max_num_pages = (
+            self.req_to_token.shape[1] + self.page_size - 1
+        ) // self.page_size
+        self._cuda_graph_page_table = torch.empty(
+            (max_bs, max_num_pages),
+            dtype=torch.int32,
+            device=self.req_to_token.device,
+        )
 
     def get_cuda_graph_seq_len_fill_value(self):
         return 1
@@ -1394,6 +1439,8 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
                 minimax_sparse_prefill,
             )
 
+            assert self._active_page_table is not None
+
             idx_o, o = minimax_sparse_prefill(
                 q,
                 k_cache,
@@ -1403,8 +1450,7 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
                 idx_k_cache,
                 idx_v_cache,
                 None,
-                self.req_to_token,
-                forward_batch.req_pool_indices,
+                self._active_page_table,
                 cu_seqlens,
                 seq_lens,
                 prefix_lens,
@@ -1425,6 +1471,7 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
                 idx_q_scale=layer.idx_q_scale_float,
                 idx_k_scale=layer.idx_k_scale_float,
                 idx_v_scale=layer.idx_v_scale_float,
+                page_size=self.page_size,
             )
         if actual_num_tokens < original_num_tokens:
             pad_len = original_num_tokens - actual_num_tokens
@@ -1561,6 +1608,8 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
                 minimax_sparse_decode,
             )
 
+            assert self._active_page_table is not None
+
             idx_o, o = minimax_sparse_decode(
                 q,
                 None,
@@ -1570,8 +1619,7 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
                 None,
                 idx_k_cache,
                 idx_v_cache,
-                self.req_to_token,
-                forward_batch.req_pool_indices,
+                self._active_page_table,
                 forward_batch.seq_lens,
                 self._max_seqlen_k,
                 1,

--- a/python/sglang/srt/layers/attention/minimax_sparse_backend.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_backend.py
@@ -215,6 +215,7 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
                 )
 
         self._msa_dec_meta = None
+        self._msa_prefill_meta_cache: dict = {}
         if self.use_msa:
             from sglang.srt.runtime_context import get_parallel
 
@@ -337,6 +338,7 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
         self._active_page_table = None
         # getattr covers replay views lacking extend_seq_lens_cpu and TARGET_VERIFY.
         self._msa_dec_meta = None
+        self._msa_prefill_meta_cache.clear()
         if self.is_npu:
             # Invalidate cached prefill/extend metadata; rebuilt on first sparse layer.
             self._prefill_meta = None
@@ -1483,6 +1485,7 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
                 idx_k_scale=layer.idx_k_scale_float,
                 idx_v_scale=layer.idx_v_scale_float,
                 page_size=self.page_size,
+                msa_meta_cache=self._msa_prefill_meta_cache,
             )
         if actual_num_tokens < original_num_tokens:
             pad_len = original_num_tokens - actual_num_tokens

--- a/python/sglang/srt/layers/attention/minimax_sparse_backend.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_backend.py
@@ -16,7 +16,7 @@ from sglang.srt.configs.model_config import (
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
 from sglang.srt.mem_cache.memory_pool import MiniMaxSparseKVPool
-from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.server_args import m3_fp8_attn_gemm_enabled
 from sglang.srt.utils import is_npu
 
@@ -326,6 +326,14 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
     def init_forward_metadata_out_graph(
         self, forward_batch: ForwardBatch, in_capture: bool = False
     ):
+        if (
+            not self.is_npu
+            and in_capture
+            and forward_batch.forward_mode == ForwardMode.EXTEND
+        ):
+            raise ValueError(
+                "MiniMax sparse attention does not support Full prefill CUDA Graph."
+            )
         self._active_page_table = None
         # getattr covers replay views lacking extend_seq_lens_cpu and TARGET_VERIFY.
         self._msa_dec_meta = None

--- a/python/sglang/srt/layers/attention/minimax_sparse_backend.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_backend.py
@@ -373,8 +373,11 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
                 build_page_table_snapshot,
             )
 
+            active_num_pages = max(
+                1, (self._max_seqlen_k + self.page_size - 1) // self.page_size
+            )
             build_page_table_snapshot(
-                self._active_page_table,
+                self._active_page_table[:, :active_num_pages],
                 self.req_to_token,
                 forward_batch.req_pool_indices[:bs],
                 seq_lens,

--- a/python/sglang/srt/layers/attention/minimax_sparse_ops/minimax_sparse.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_ops/minimax_sparse.py
@@ -15,6 +15,7 @@ from sglang.kernels.ops.attention.minimax_sparse.decode.topk_sparse import (
 )
 from sglang.kernels.ops.attention.minimax_sparse.prefill.flash_with_topk_idx import (
     flash_prefill_with_topk_index,
+    topk_index_from_block_score,
 )
 from sglang.kernels.ops.attention.minimax_sparse.prefill.topk_sparse import (
     flash_prefill_with_gqa_share_sparse,
@@ -88,46 +89,87 @@ def minimax_sparse_prefill(
             cu_seqlens, max_seqlen_q, block_size_q, block_size_k, seqlens_cpu
         )
 
-    # All seqlen is less than topk, use full attention
-    # Step 1: Flash attention with topk index (using index head)
-    idx_o, topk_idx = flash_prefill_with_topk_index(
-        q=idx_q,
-        k_cache=idx_k_cache,
-        v_cache=idx_v_cache,
-        sink=idx_sink,
-        page_table=page_table,
-        cu_seqlens=cu_seqlens,
-        seq_lens=seq_lens,
-        prefix_lens=prefix_lens,
-        max_seqlen_q=max_seqlen_q,
-        max_seqlen_k=max_seqlen_k,
-        block_size_q=block_size_q,
-        block_size_k=block_size_k,
-        topk=topk,
-        init_blocks=init_blocks,
-        local_blocks=local_blocks,
-        sm_scale=idx_sm_scale,
-        score_type=score_type,
-        disable_index_value=disable_index_value,
-        cu_seqblocks_q=cu_seqblocks_q,
-        max_seqblock_q=max_seqblock_q,
-        all_seqblock_q=all_seqblock_q,
-        q_scale=idx_q_scale,
-        k_scale=idx_k_scale,
-        v_scale=idx_v_scale,
-        page_size=page_size,
-    )
-    # Step 2: Reduce topk idx if num_idx_heads > num_kv_heads
     num_idx_heads = idx_q.shape[1]
     num_kv_heads = k_cache.shape[1]
+    score = None
+    if (
+        use_msa
+        and disable_index_value
+        and idx_sink is None
+        and score_type == "max"
+        and page_size == block_size_k == 128
+    ):
+        from .msa import MSAUnavailableError, msa_sparse_prefill_index_score
+
+        try:
+            score = msa_sparse_prefill_index_score(
+                idx_q,
+                idx_k_cache,
+                page_table,
+                cu_seqlens,
+                seq_lens,
+                prefix_lens,
+                block_size_k,
+                sm_scale=idx_sm_scale,
+                q_scale=idx_q_scale,
+                k_scale=idx_k_scale,
+                meta_cache=msa_meta_cache,
+            )
+        except MSAUnavailableError as err:
+            _warn_msa_fallback(err)
+
+    if score is not None:
+        idx_o = None
+        topk_idx = topk_index_from_block_score(
+            score,
+            cu_seqlens,
+            prefix_lens,
+            cu_seqblocks_q,
+            max_seqblock_q,
+            all_seqblock_q,
+            block_size_q,
+            block_size_k,
+            topk,
+            init_blocks,
+            local_blocks,
+        )
+    else:
+        idx_o, topk_idx = flash_prefill_with_topk_index(
+            q=idx_q,
+            k_cache=idx_k_cache,
+            v_cache=idx_v_cache,
+            sink=idx_sink,
+            page_table=page_table,
+            cu_seqlens=cu_seqlens,
+            seq_lens=seq_lens,
+            prefix_lens=prefix_lens,
+            max_seqlen_q=max_seqlen_q,
+            max_seqlen_k=max_seqlen_k,
+            block_size_q=block_size_q,
+            block_size_k=block_size_k,
+            topk=topk,
+            init_blocks=init_blocks,
+            local_blocks=local_blocks,
+            sm_scale=idx_sm_scale,
+            score_type=score_type,
+            disable_index_value=disable_index_value,
+            cu_seqblocks_q=cu_seqblocks_q,
+            max_seqblock_q=max_seqblock_q,
+            all_seqblock_q=all_seqblock_q,
+            q_scale=idx_q_scale,
+            k_scale=idx_k_scale,
+            v_scale=idx_v_scale,
+            page_size=page_size,
+        )
+
+    # Reduce topk idx if num_idx_heads > num_kv_heads.
     idx_group_size = num_idx_heads // num_kv_heads
     if idx_group_size > 1:
         topk_idx = topk_index_reduce(
             topk_idx.view(num_kv_heads, idx_group_size, -1, topk), dim=1
         )
-    # Step 3: Sparse attention using topk index (main head). The MSA path only
-    # replaces this step; the indexer above is unchanged. MSA has no attn-sink
-    # input, so keep the Triton path when sink is present.
+    # Step 3: Sparse attention using topk index (main head). MSA has no
+    # attn-sink input, so keep the Triton path when sink is present.
     if use_msa and sink is None:
         from .msa import MSAUnavailableError, msa_sparse_prefill_main
 

--- a/python/sglang/srt/layers/attention/minimax_sparse_ops/minimax_sparse.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_ops/minimax_sparse.py
@@ -73,6 +73,7 @@ def minimax_sparse_prefill(
     idx_k_scale: Optional[float] = None,
     idx_v_scale: Optional[float] = None,
     page_size: int = 1,
+    msa_meta_cache: Optional[dict] = None,
 ):
     """Run MiniMax-M3 sparse prefill.
 
@@ -145,6 +146,7 @@ def minimax_sparse_prefill(
                 q_scale=q_scale,
                 k_scale=k_scale,
                 v_scale=v_scale,
+                meta_cache=msa_meta_cache,
             )
         except MSAUnavailableError as err:
             _warn_msa_fallback(err)

--- a/python/sglang/srt/layers/attention/minimax_sparse_ops/minimax_sparse.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_ops/minimax_sparse.py
@@ -46,8 +46,7 @@ def minimax_sparse_prefill(
         torch.Tensor
     ],  # [max_slots, 1, idx_head_dim] (paged index); None when disable_index_value
     idx_sink: Optional[torch.Tensor],  # [num_idx_heads, idx_head_dim]
-    req_to_token: torch.Tensor,  # [max_reqs, max_kv_len]
-    slot_ids: torch.Tensor,  # [batch_size, ]
+    page_table: torch.Tensor,  # [batch_size, max_pages] physical page ids
     cu_seqlens: torch.Tensor,  # [batch_size + 1, ] (Q-side cumulative)
     seq_lens: torch.Tensor,  # [batch_size, ] total K length (prefix + chunk)
     prefix_lens: torch.Tensor,  # [batch_size, ]
@@ -73,6 +72,7 @@ def minimax_sparse_prefill(
     idx_q_scale: Optional[float] = None,
     idx_k_scale: Optional[float] = None,
     idx_v_scale: Optional[float] = None,
+    page_size: int = 1,
 ):
     """Run MiniMax-M3 sparse prefill.
 
@@ -94,8 +94,7 @@ def minimax_sparse_prefill(
         k_cache=idx_k_cache,
         v_cache=idx_v_cache,
         sink=idx_sink,
-        req_to_token=req_to_token,
-        slot_ids=slot_ids,
+        page_table=page_table,
         cu_seqlens=cu_seqlens,
         seq_lens=seq_lens,
         prefix_lens=prefix_lens,
@@ -115,6 +114,7 @@ def minimax_sparse_prefill(
         q_scale=idx_q_scale,
         k_scale=idx_k_scale,
         v_scale=idx_v_scale,
+        page_size=page_size,
     )
     # Step 2: Reduce topk idx if num_idx_heads > num_kv_heads
     num_idx_heads = idx_q.shape[1]
@@ -136,8 +136,7 @@ def minimax_sparse_prefill(
                 k_cache=k_cache,
                 v_cache=v_cache,
                 topk_idx=topk_idx,
-                req_to_token=req_to_token,
-                slot_ids=slot_ids,
+                page_table=page_table,
                 cu_seqlens=cu_seqlens,
                 seq_lens=seq_lens,
                 prefix_lens=prefix_lens,
@@ -154,8 +153,7 @@ def minimax_sparse_prefill(
                 k_cache=k_cache,
                 v_cache=v_cache,
                 sink=sink,
-                req_to_token=req_to_token,
-                slot_ids=slot_ids,
+                page_table=page_table,
                 topk_idx=topk_idx,
                 block_size_q=block_size_q,
                 block_size_k=block_size_k,
@@ -169,6 +167,7 @@ def minimax_sparse_prefill(
                 q_scale=q_scale,
                 k_scale=k_scale,
                 v_scale=v_scale,
+                page_size=page_size,
             )
     else:
         o = flash_prefill_with_gqa_share_sparse(
@@ -176,8 +175,7 @@ def minimax_sparse_prefill(
             k_cache=k_cache,
             v_cache=v_cache,
             sink=sink,
-            req_to_token=req_to_token,
-            slot_ids=slot_ids,
+            page_table=page_table,
             topk_idx=topk_idx,
             block_size_q=block_size_q,
             block_size_k=block_size_k,
@@ -191,6 +189,7 @@ def minimax_sparse_prefill(
             q_scale=q_scale,
             k_scale=k_scale,
             v_scale=v_scale,
+            page_size=page_size,
         )
     return idx_o, o
 
@@ -206,8 +205,7 @@ def minimax_sparse_decode(
     idx_v_cache: Optional[
         torch.Tensor
     ],  # [max_slots, 1, idx_head_dim] (paged); None when disable_index_value
-    req_to_token: torch.Tensor,  # [max_reqs, max_kv_len]
-    slot_ids: torch.Tensor,  # [batch_size, ]
+    page_table: torch.Tensor,  # [batch_size, max_pages] physical page ids
     seq_lens: torch.Tensor,  # [batch_size, ]
     max_seqlen: int,  # max of seq_lens, passed from caller to avoid sync during CUDA graph capture
     block_size_q: int,  # useless for now, will always be 1
@@ -241,10 +239,9 @@ def minimax_sparse_decode(
         sink=idx_sink,
         k_cache=idx_k_cache,
         v_cache=idx_v_cache,
-        req_to_token=req_to_token,
+        page_table=page_table,
         seq_lens=seq_lens,
         max_seqlen=max_seqlen,
-        slot_ids=slot_ids,
         block_size=block_size_k,
         topk=topk,
         init_blocks=init_blocks,
@@ -282,8 +279,7 @@ def minimax_sparse_decode(
                     k_cache=k_cache,
                     v_cache=v_cache,
                     topk_idx=topk_idx,
-                    req_to_token=req_to_token,
-                    slot_ids=slot_ids,
+                    page_table=page_table,
                     seq_lens=seq_lens,
                     block_size_k=block_size_k,
                     sm_scale=sm_scale,
@@ -300,15 +296,15 @@ def minimax_sparse_decode(
                     sink=sink,
                     k_cache=k_cache,
                     v_cache=v_cache,
-                    req_to_token=req_to_token,
+                    page_table=page_table,
                     seq_lens=seq_lens,
-                    slot_ids=slot_ids,
                     block_size=block_size_k,
                     topk_idx=topk_idx,
                     sm_scale=sm_scale,
                     q_scale=q_scale,
                     k_scale=k_scale,
                     v_scale=v_scale,
+                    page_size=page_size,
                 )
         else:
             o = flash_decode_with_gqa_share_sparse(
@@ -316,14 +312,14 @@ def minimax_sparse_decode(
                 sink=sink,
                 k_cache=k_cache,
                 v_cache=v_cache,
-                req_to_token=req_to_token,
+                page_table=page_table,
                 seq_lens=seq_lens,
-                slot_ids=slot_ids,
                 block_size=block_size_k,
                 topk_idx=topk_idx,
                 sm_scale=sm_scale,
                 q_scale=q_scale,
                 k_scale=k_scale,
                 v_scale=v_scale,
+                page_size=page_size,
             )
     return idx_o, o

--- a/python/sglang/srt/layers/attention/minimax_sparse_ops/minimax_sparse.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_ops/minimax_sparse.py
@@ -20,6 +20,7 @@ from sglang.kernels.ops.attention.minimax_sparse.prefill.flash_with_topk_idx imp
 from sglang.kernels.ops.attention.minimax_sparse.prefill.topk_sparse import (
     flash_prefill_with_gqa_share_sparse,
 )
+from sglang.srt.environ import envs
 
 logger = logging.getLogger(__name__)
 _msa_fallback_warned = False
@@ -94,6 +95,7 @@ def minimax_sparse_prefill(
     score = None
     if (
         use_msa
+        and envs.SGLANG_OPT_USE_MSA_PREFILL_INDEX_SCORE.get()
         and disable_index_value
         and idx_sink is None
         and score_type == "max"

--- a/python/sglang/srt/layers/attention/minimax_sparse_ops/msa.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_ops/msa.py
@@ -84,38 +84,19 @@ def msa_available() -> bool:
         return False
 
 
-def _build_page_table(
-    req_to_token: torch.Tensor,  # [max_reqs, max_kv_len], physical slot per logical pos
-    slot_ids: torch.Tensor,  # [batch]
+def _pack_page_table(
+    page_table: torch.Tensor,  # [batch, max_pages] physical page ids
     seq_lens: torch.Tensor,  # [batch] total K length (prefix + chunk)
     page_size: int,
 ) -> torch.Tensor:
-    """Flattened physical page ids per request (MSA `kv_indices`).
-
-    sglang's paged allocator stores page_size contiguous physical slots per page, so the
-    physical page of logical position p is ``req_to_token[req, p] // page_size`` and is the
-    same for every p within a page. We read one slot per logical page to recover the table.
-
-    Vectorized (no per-request Python loop): pages are packed contiguously by request in the
-    same order MSA's planner expects (``kv_page_indptr = cumsum(ceil(seq_lens/page_size))``).
-    ``searchsorted`` maps each packed page slot back to its request; one ``.item()`` recovers
-    the total page count (this runs eagerly, outside CUDA-graph capture).
-    """
-    P = page_size
-    n_pages = (seq_lens.to(torch.int64) + (P - 1)) // P  # [batch]
-    offsets = (
-        torch.cumsum(n_pages, 0) - n_pages
-    )  # [batch] exclusive page offset per request
+    """Pack the batch-local physical page table into MSA ``kv_indices``."""
+    n_pages = (seq_lens.to(torch.int64) + page_size - 1) // page_size
+    offsets = torch.cumsum(n_pages, 0) - n_pages
     total = int(n_pages.sum().item())
-    idx = torch.arange(
-        total, device=req_to_token.device
-    )  # packed page slot -> (req, page)
-    req = torch.searchsorted(
-        offsets + n_pages, idx, right=True
-    )  # request id per packed slot
-    logical_first = (idx - offsets[req]) * P  # first logical position of that page
-    rows = slot_ids[req].to(torch.int64)
-    return (req_to_token[rows, logical_first] // P).to(torch.int32)
+    idx = torch.arange(total, device=page_table.device)
+    req = torch.searchsorted(offsets + n_pages, idx, right=True)
+    logical_page = idx - offsets[req]
+    return page_table[req, logical_page].to(torch.int32)
 
 
 def msa_sparse_prefill_main(
@@ -123,8 +104,7 @@ def msa_sparse_prefill_main(
     k_cache: torch.Tensor,  # [max_slots, num_kv_heads, head_dim] (slot-major NHD)
     v_cache: torch.Tensor,  # [max_slots, num_kv_heads, head_dim]
     topk_idx: torch.Tensor,  # [num_kv_heads, total_q, topk] (0-based, -1 pad) -- step1/2 output
-    req_to_token: torch.Tensor,  # [max_reqs, max_kv_len]
-    slot_ids: torch.Tensor,  # [batch]
+    page_table: torch.Tensor,  # [batch, max_pages] physical page ids
     cu_seqlens: torch.Tensor,  # [batch+1] cumulative Q lengths
     seq_lens: torch.Tensor,  # [batch] total K length (prefix + chunk)
     prefix_lens: torch.Tensor,  # [batch]
@@ -165,7 +145,7 @@ def msa_sparse_prefill_main(
 
     # Per-request Q lengths (extend) and physical page table.
     qo_segment_lens = (cu_seqlens[1:] - cu_seqlens[:-1]).to(torch.int32)
-    kv_indices = _build_page_table(req_to_token, slot_ids, seq_lens, P)
+    kv_indices = _pack_page_table(page_table, seq_lens, P)
 
     # topk_idx [Hkv, total_q, topk] -> kv_block_indexes [total_q, Hkv, topk].
     kv_block_indexes = topk_idx.permute(1, 0, 2).contiguous().to(torch.int32)
@@ -199,8 +179,7 @@ def msa_sparse_prefill_main(
 
 def build_msa_decode_meta(
     k_cache: torch.Tensor,  # [max_slots, num_kv_heads, head_dim]
-    req_to_token: torch.Tensor,
-    slot_ids: torch.Tensor,  # [batch]
+    page_table: torch.Tensor,  # [batch, max_pages] physical page ids
     seq_lens: torch.Tensor,  # [batch] cached KV length per request
     num_q_heads: int,
     block_size_k: int,
@@ -222,8 +201,8 @@ def build_msa_decode_meta(
     P = block_size_k
     if max_slots % P != 0:
         raise ValueError(f"max_slots={max_slots} not divisible by page_size={P}")
-    B = slot_ids.shape[0]
-    kv_indices = _build_page_table(req_to_token, slot_ids, seq_lens, P)
+    B = page_table.shape[0]
+    kv_indices = _pack_page_table(page_table, seq_lens, P)
     seq_lens_i32 = seq_lens.to(torch.int32)
     plan = _run_fmha_sm100_plan(
         torch.ones(B, dtype=torch.int32),
@@ -324,8 +303,7 @@ def build_msa_decode_cg_plan(
 def update_msa_decode_cg_meta(
     plan,
     kv_indices_buf: torch.Tensor,  # persistent page-table buffer [batch * max_pages]
-    req_to_token: torch.Tensor,
-    slot_ids: torch.Tensor,  # [batch]
+    page_table: torch.Tensor,  # [batch, max_pages] physical page ids
     seq_lens: torch.Tensor,  # [batch] cached KV length per request
     block_size_k: int,
     topk: int,
@@ -376,9 +354,8 @@ def update_msa_decode_cg_meta(
     ends = torch.cumsum(n_pages.to(torch.int64), 0)
     req = torch.searchsorted(ends, idx, right=True).clamp_max_(B - 1)
     starts = ends - n_pages
-    logical_first = ((idx - starts[req]) * P).clamp_(0, req_to_token.shape[1] - 1)
-    rows = slot_ids[req].to(torch.int64)
-    kv_indices_buf.copy_((req_to_token[rows, logical_first] // P).to(torch.int32))
+    logical_page = (idx - starts[req]).clamp_(0, page_table.shape[1] - 1)
+    kv_indices_buf.copy_(page_table[req, logical_page].to(torch.int32))
 
 
 def msa_sparse_decode_main(
@@ -386,8 +363,7 @@ def msa_sparse_decode_main(
     k_cache: torch.Tensor,  # [max_slots, num_kv_heads, head_dim] (slot-major NHD)
     v_cache: torch.Tensor,  # [max_slots, num_kv_heads, head_dim]
     topk_idx: torch.Tensor,  # [num_kv_heads, batch, topk] (0-based, -1 pad)
-    req_to_token: torch.Tensor,  # [max_reqs, max_kv_len]
-    slot_ids: torch.Tensor,  # [batch]
+    page_table: torch.Tensor,  # [batch, max_pages] physical page ids
     seq_lens: torch.Tensor,  # [batch] cached KV length per request
     block_size_k: int,  # == page_size == 128
     sm_scale: Optional[float] = None,
@@ -433,8 +409,7 @@ def msa_sparse_decode_main(
     if kv_indices is None or plan is None:
         kv_indices, plan = build_msa_decode_meta(
             k_cache,
-            req_to_token,
-            slot_ids,
+            page_table,
             seq_lens,
             H,
             P,

--- a/python/sglang/srt/layers/attention/minimax_sparse_ops/msa.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_ops/msa.py
@@ -113,6 +113,7 @@ def msa_sparse_prefill_main(
     q_scale: Optional[float] = None,
     k_scale: Optional[float] = None,
     v_scale: Optional[float] = None,
+    meta_cache: Optional[dict] = None,
 ) -> torch.Tensor:
     """Drop-in for flash_prefill_with_gqa_share_sparse using MSA fmha_sm100.
 
@@ -143,24 +144,30 @@ def msa_sparse_prefill_main(
     k_paged = k_cache.view(n_phys_pages, P, num_kv_heads, head_dim).permute(0, 2, 1, 3)
     v_paged = v_cache.view(n_phys_pages, P, num_kv_heads, head_dim).permute(0, 2, 1, 3)
 
-    # Per-request Q lengths (extend) and physical page table.
-    qo_segment_lens = (cu_seqlens[1:] - cu_seqlens[:-1]).to(torch.int32)
-    kv_indices = _pack_page_table(page_table, seq_lens, P)
+    cached_meta = meta_cache.get("prefill") if meta_cache is not None else None
+    if cached_meta is not None:
+        kv_indices, plan = cached_meta
+    else:
+        # Per-request Q lengths and physical page table are layer-invariant.
+        # Build them on the first sparse layer and reuse them for this forward.
+        qo_segment_lens = (cu_seqlens[1:] - cu_seqlens[:-1]).to(torch.int32)
+        kv_indices = _pack_page_table(page_table, seq_lens, P)
+        plan = _run_fmha_sm100_plan(
+            qo_segment_lens,
+            seq_lens.to(torch.int32),
+            num_q_heads,
+            num_kv_heads=num_kv_heads,
+            page_size=P,
+            kv_block_num=topk,
+            causal=True,
+            qo_offset=prefix_lens.to(torch.int32),
+            use_fp8_kvcache=is_fp8,
+        )
+        if meta_cache is not None:
+            meta_cache["prefill"] = (kv_indices, plan)
 
     # topk_idx [Hkv, total_q, topk] -> kv_block_indexes [total_q, Hkv, topk].
     kv_block_indexes = topk_idx.permute(1, 0, 2).contiguous().to(torch.int32)
-
-    plan = _run_fmha_sm100_plan(
-        qo_segment_lens,
-        seq_lens.to(torch.int32),
-        num_q_heads,
-        num_kv_heads=num_kv_heads,
-        page_size=P,
-        kv_block_num=topk,
-        causal=True,
-        qo_offset=prefix_lens.to(torch.int32),
-        use_fp8_kvcache=is_fp8,
-    )
     o, _ = fmha_sm100(
         q,
         k_paged,

--- a/python/sglang/srt/layers/attention/minimax_sparse_ops/msa.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_ops/msa.py
@@ -99,6 +99,82 @@ def _pack_page_table(
     return page_table[req, logical_page].to(torch.int32)
 
 
+def _prefill_kv_indices(
+    page_table: torch.Tensor,
+    seq_lens: torch.Tensor,
+    page_size: int,
+    meta_cache: Optional[dict],
+) -> torch.Tensor:
+    if meta_cache is not None and "kv_indices" in meta_cache:
+        return meta_cache["kv_indices"]
+    kv_indices = _pack_page_table(page_table, seq_lens, page_size)
+    if meta_cache is not None:
+        meta_cache["kv_indices"] = kv_indices
+    return kv_indices
+
+
+def msa_sparse_prefill_index_score(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    page_table: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    seq_lens: torch.Tensor,
+    prefix_lens: torch.Tensor,
+    block_size_k: int,
+    sm_scale: Optional[float] = None,
+    q_scale: Optional[float] = None,
+    k_scale: Optional[float] = None,
+    meta_cache: Optional[dict] = None,
+) -> torch.Tensor:
+    """Return MSA block-max scores as a zero-copy ``[H, Q, blocks]`` view."""
+    fmha_sm100, _ = _load_fmha_sm100()
+    _check_msa_dtypes(q, k_cache, k_cache)
+    max_slots, num_kv_heads, head_dim = k_cache.shape
+    num_q_heads = q.shape[1]
+    if max_slots % block_size_k != 0:
+        raise ValueError(
+            f"max_slots={max_slots} not divisible by page_size={block_size_k}"
+        )
+
+    n_phys_pages = max_slots // block_size_k
+    k_paged = k_cache.view(n_phys_pages, block_size_k, num_kv_heads, head_dim).permute(
+        0, 2, 1, 3
+    )
+    kv_indices = _prefill_kv_indices(page_table, seq_lens, block_size_k, meta_cache)
+    plan = meta_cache.get("index_plan") if meta_cache is not None else None
+    if plan is None:
+        plan = _run_fmha_sm100_plan(
+            (cu_seqlens[1:] - cu_seqlens[:-1]).to(torch.int32),
+            seq_lens.to(torch.int32),
+            num_q_heads,
+            num_kv_heads=num_kv_heads,
+            page_size=block_size_k,
+            causal=True,
+            qo_offset=prefix_lens.to(torch.int32),
+            output_maxscore=True,
+            use_fp8_kvcache=q.dtype == torch.float8_e4m3fn,
+        )
+        if meta_cache is not None:
+            meta_cache["index_plan"] = plan
+    max_score = meta_cache.get("index_score") if meta_cache is not None else None
+    _, max_score = fmha_sm100(
+        q,
+        k_paged,
+        k_paged,
+        plan,
+        kv_indices=kv_indices,
+        max_score=max_score,
+        output_o=False,
+        output_maxscore=True,
+        sm_scale=head_dim**-0.5 if sm_scale is None else sm_scale,
+        q_scale=unit_scale(q_scale),
+        k_scale=unit_scale(k_scale),
+    )
+    if meta_cache is not None:
+        meta_cache["index_score"] = max_score
+    return max_score.permute(0, 2, 1)
+
+
 def msa_sparse_prefill_main(
     q: torch.Tensor,  # [total_q, num_q_heads, head_dim]
     k_cache: torch.Tensor,  # [max_slots, num_kv_heads, head_dim] (slot-major NHD)
@@ -151,7 +227,7 @@ def msa_sparse_prefill_main(
         # Per-request Q lengths and physical page table are layer-invariant.
         # Build them on the first sparse layer and reuse them for this forward.
         qo_segment_lens = (cu_seqlens[1:] - cu_seqlens[:-1]).to(torch.int32)
-        kv_indices = _pack_page_table(page_table, seq_lens, P)
+        kv_indices = _prefill_kv_indices(page_table, seq_lens, P, meta_cache)
         plan = _run_fmha_sm100_plan(
             qo_segment_lens,
             seq_lens.to(torch.int32),

--- a/python/sglang/srt/layers/attention/minimax_sparse_ops/tests/test_flash_with_topk_idx.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_ops/tests/test_flash_with_topk_idx.py
@@ -476,5 +476,67 @@ def test_flash_decode_dense_page_table_trivial_rows_skip_score_writes():
             assert torch.equal(page_table_cpu[row, :valid_pages], expected)
 
 
+@pytest.mark.parametrize("score_type", ["max", "lse"])
+def test_flash_decode_score_one_page_per_block(score_type):
+    """The block-table score path must match token-table addressing."""
+    torch.manual_seed(43)
+    bs, nqh, nkh, hd, blk, tk = 2, 1, 1, 128, 128, 4
+    seq_lens_list = [513, 768]
+    q, _, k_cache, v_cache, _, seq_lens, _, slot_ids = build_inputs(
+        bs,
+        nqh,
+        nkh,
+        hd,
+        seq_lens_list,
+        max_kv_len=max(seq_lens_list),
+    )
+
+    pages_per_req = max(seq_lens_list) // blk
+    page_table = torch.randperm(
+        bs * pages_per_req, device=DEVICE, dtype=torch.int32
+    ).view(bs, pages_per_req)
+    req_to_token = (
+        page_table[:, :, None] * blk
+        + torch.arange(blk, device=DEVICE, dtype=torch.int32)[None, None, :]
+    ).reshape(bs, -1)
+
+    _, topk_new, _ = flash_decode_with_topk_idx(
+        q,
+        None,
+        k_cache,
+        None,
+        page_table,
+        seq_lens,
+        max(seq_lens_list),
+        blk,
+        tk,
+        0,
+        1,
+        disable_index_value=True,
+        score_type=score_type,
+        page_size=blk,
+    )
+    _, topk_ref = pytorch_reference(
+        q,
+        None,
+        k_cache,
+        v_cache,
+        req_to_token,
+        seq_lens,
+        slot_ids,
+        blk,
+        tk,
+        0,
+        1,
+        score_type=score_type,
+    )
+
+    for b, seq_len in enumerate(seq_lens_list):
+        actual_topk = min(tk, (seq_len + blk - 1) // blk)
+        assert set(topk_new[0, b, :actual_topk].tolist()) == set(
+            topk_ref[0, b, :actual_topk].tolist()
+        )
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v", "-s"]))

--- a/python/sglang/srt/layers/attention/minimax_sparse_ops/tests/test_flash_with_topk_idx.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_ops/tests/test_flash_with_topk_idx.py
@@ -6,6 +6,9 @@ import torch
 from sglang.kernels.ops.attention.minimax_sparse.decode.flash_with_topk_idx import (
     flash_decode_with_topk_idx,
 )
+from sglang.kernels.ops.attention.minimax_sparse.page_table import (
+    build_page_table_snapshot,
+)
 from sglang.srt.environ import envs
 
 DEVICE = "cuda"
@@ -25,7 +28,6 @@ def pytorch_reference(
     v_cache,
     req_to_token,
     seq_lens,
-    slot_ids,
     block_size,
     topk,
     init_blocks,
@@ -136,12 +138,16 @@ def build_inputs(
         req_to_token[i, :max_kv_len] = torch.arange(
             base, base + max_kv_len, device=DEVICE
         )
+    page_table = torch.empty_like(req_to_token)
+    build_page_table_snapshot(
+        page_table, req_to_token, slot_ids, seq_lens, 1, max_slots
+    )
     sink = (
         torch.randn(num_q_heads, head_dim, dtype=dtype, device=DEVICE)
         if with_sink
         else None
     )
-    return q, sink, k_cache, v_cache, req_to_token, seq_lens, max_kv_len, slot_ids
+    return q, sink, k_cache, v_cache, req_to_token, seq_lens, max_kv_len, page_table
 
 
 def make_seq_lens(pattern, batch_size, block_size):
@@ -212,7 +218,7 @@ def test_flash_decode_with_topk_idx(
     torch.manual_seed(42)
     seq_lens, mkl = make_seq_lens(seq_pat, bs, blk)
 
-    q, sink, k_cache, v_cache, req_to_token, seq_lens_t, mkl, slot_ids = build_inputs(
+    q, sink, k_cache, v_cache, req_to_token, seq_lens_t, mkl, page_table = build_inputs(
         bs,
         nqh,
         nkh,
@@ -227,10 +233,9 @@ def test_flash_decode_with_topk_idx(
         sink,
         k_cache,
         v_cache,
-        req_to_token,
+        page_table,
         seq_lens_t,
         mkl,
-        slot_ids,
         blk,
         tk,
         ib,
@@ -244,7 +249,6 @@ def test_flash_decode_with_topk_idx(
         v_cache,
         req_to_token,
         seq_lens_t,
-        slot_ids,
         blk,
         tk,
         ib,
@@ -293,7 +297,7 @@ def test_flash_decode_score_only(
     torch.manual_seed(42)
     seq_lens, mkl = make_seq_lens(seq_pat, bs, blk)
 
-    q, sink, k_cache, v_cache, req_to_token, seq_lens_t, mkl, slot_ids = build_inputs(
+    q, sink, k_cache, v_cache, req_to_token, seq_lens_t, mkl, page_table = build_inputs(
         bs,
         nqh,
         nkh,
@@ -308,10 +312,9 @@ def test_flash_decode_score_only(
         sink,
         k_cache,
         v_cache,
-        req_to_token,
+        page_table,
         seq_lens_t,
         mkl,
-        slot_ids,
         blk,
         tk,
         ib,
@@ -326,7 +329,6 @@ def test_flash_decode_score_only(
         v_cache,
         req_to_token,
         seq_lens_t,
-        slot_ids,
         blk,
         tk,
         ib,
@@ -363,7 +365,7 @@ def test_flash_decode_jit_topk_trivial_rows_skip_score_writes():
     bs, nqh, nkh, hd, blk, tk = 4, 8, 1, 128, 64, 32
     seq_lens, mkl = make_seq_lens("few_blocks", bs, blk)
 
-    q, sink, k_cache, v_cache, req_to_token, seq_lens_t, mkl, slot_ids = build_inputs(
+    q, sink, k_cache, v_cache, req_to_token, seq_lens_t, mkl, page_table = build_inputs(
         bs,
         nqh,
         nkh,
@@ -378,10 +380,9 @@ def test_flash_decode_jit_topk_trivial_rows_skip_score_writes():
             sink,
             k_cache,
             v_cache,
-            req_to_token,
+            page_table,
             seq_lens_t,
             mkl,
-            slot_ids,
             blk,
             tk,
             0,
@@ -394,7 +395,6 @@ def test_flash_decode_jit_topk_trivial_rows_skip_score_writes():
         v_cache,
         req_to_token,
         seq_lens_t,
-        slot_ids,
         blk,
         tk,
         0,
@@ -421,7 +421,7 @@ def test_flash_decode_dense_page_table_trivial_rows_skip_score_writes():
     bs, nqh, nkh, hd, blk, tk, page_size = 3, 4, 1, 128, 64, 32, 1
     seq_lens, mkl = make_seq_lens("few_blocks", bs, blk)
 
-    q, sink, k_cache, v_cache, req_to_token, seq_lens_t, mkl, slot_ids = build_inputs(
+    q, sink, k_cache, v_cache, req_to_token, seq_lens_t, mkl, page_table = build_inputs(
         bs,
         nqh,
         nkh,
@@ -435,10 +435,9 @@ def test_flash_decode_dense_page_table_trivial_rows_skip_score_writes():
         sink,
         k_cache,
         v_cache,
-        req_to_token,
+        page_table,
         seq_lens_t,
         mkl,
-        slot_ids,
         blk,
         tk,
         0,
@@ -453,7 +452,6 @@ def test_flash_decode_dense_page_table_trivial_rows_skip_score_writes():
         v_cache,
         req_to_token,
         seq_lens_t,
-        slot_ids,
         blk,
         tk,
         0,
@@ -482,7 +480,7 @@ def test_flash_decode_score_one_page_per_block(score_type):
     torch.manual_seed(43)
     bs, nqh, nkh, hd, blk, tk = 2, 1, 1, 128, 128, 4
     seq_lens_list = [513, 768]
-    q, _, k_cache, v_cache, _, seq_lens, _, slot_ids = build_inputs(
+    q, _, k_cache, v_cache, _, seq_lens, _, _ = build_inputs(
         bs,
         nqh,
         nkh,
@@ -523,7 +521,6 @@ def test_flash_decode_score_one_page_per_block(score_type):
         v_cache,
         req_to_token,
         seq_lens,
-        slot_ids,
         blk,
         tk,
         0,

--- a/python/sglang/srt/layers/attention/minimax_sparse_ops/tests/test_fp8_attn_gemm.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_ops/tests/test_fp8_attn_gemm.py
@@ -14,16 +14,19 @@ indexer, non-unit k_scale/v_scale semantics, and bf16-path regression.
 import pytest
 import torch
 
-from sglang.srt.layers.attention.minimax_sparse_ops.decode.flash_with_topk_idx import (
+from sglang.kernels.ops.attention.minimax_sparse.decode.flash_with_topk_idx import (
     flash_decode_with_topk_idx,
 )
-from sglang.srt.layers.attention.minimax_sparse_ops.decode.topk_sparse import (
+from sglang.kernels.ops.attention.minimax_sparse.decode.topk_sparse import (
     flash_decode_with_gqa_share_sparse,
 )
-from sglang.srt.layers.attention.minimax_sparse_ops.prefill.flash_with_topk_idx import (
+from sglang.kernels.ops.attention.minimax_sparse.page_table import (
+    build_page_table_snapshot,
+)
+from sglang.kernels.ops.attention.minimax_sparse.prefill.flash_with_topk_idx import (
     flash_prefill_with_topk_index,
 )
-from sglang.srt.layers.attention.minimax_sparse_ops.prefill.topk_sparse import (
+from sglang.kernels.ops.attention.minimax_sparse.prefill.topk_sparse import (
     flash_prefill_with_gqa_share_sparse,
 )
 
@@ -40,6 +43,19 @@ FP8_RTOL = 6e-2
 # widening mode (bf16 Q, fp8 KV) computes on exactly the dequantized values.
 WIDEN_ATOL = 1e-3
 WIDEN_RTOL = 1e-3
+
+
+def _build_page_table(req_to_token, slot_ids, seq_lens, max_slots, page_size=1):
+    max_pages = (req_to_token.shape[1] + page_size - 1) // page_size
+    page_table = torch.empty(
+        (slot_ids.shape[0], max_pages),
+        dtype=torch.int32,
+        device=req_to_token.device,
+    )
+    build_page_table_snapshot(
+        page_table, req_to_token, slot_ids, seq_lens, page_size, max_slots
+    )
+    return page_table
 
 
 def qdq(x: torch.Tensor):
@@ -137,8 +153,9 @@ def build_prefill_inputs(
 
 
 def run_step3_decode(q, k, v, req_to_token, seq_lens, slot_ids, topk_idx, **kw):
+    page_table = _build_page_table(req_to_token, slot_ids, seq_lens, k.shape[0])
     return flash_decode_with_gqa_share_sparse(
-        q, None, k, v, req_to_token, seq_lens, slot_ids, 128, topk_idx, **kw
+        q, None, k, v, page_table, seq_lens, 128, topk_idx, **kw
     )
 
 
@@ -223,13 +240,13 @@ def test_step3_decode_bf16_regression():
 
 
 def run_step3_prefill(q, k, v, r2t, sids, tidx, cu, seq_lens, prefix, max_q, **kw):
+    page_table = _build_page_table(r2t, sids, seq_lens, k.shape[0])
     return flash_prefill_with_gqa_share_sparse(
         q=q,
         k_cache=k,
         v_cache=v,
         sink=None,
-        req_to_token=r2t,
-        slot_ids=sids,
+        page_table=page_table,
         topk_idx=tidx,
         block_size_q=1,
         block_size_k=128,
@@ -323,14 +340,14 @@ def test_step3_prefill_scales():
 
 
 def run_indexer_decode(q, k, v, r2t, seq_lens, sids, **kw):
+    page_table = _build_page_table(r2t, sids, seq_lens, k.shape[0])
     return flash_decode_with_topk_idx(
         q=q,
         sink=None,
         k_cache=k,
         v_cache=v,
-        req_to_token=r2t,
+        page_table=page_table,
         seq_lens=seq_lens,
-        slot_ids=sids,
         max_seqlen=int(seq_lens.max().item()),
         block_size=128,
         topk=4,
@@ -396,13 +413,13 @@ def test_indexer_decode_score_only_fp8():
 
 
 def run_indexer_prefill(q, k, v, r2t, sids, cu, seq_lens, prefix, max_q, max_k, **kw):
+    page_table = _build_page_table(r2t, sids, seq_lens, k.shape[0])
     return flash_prefill_with_topk_index(
         q=q,
         k_cache=k,
         v_cache=v,
         sink=None,
-        req_to_token=r2t,
-        slot_ids=sids,
+        page_table=page_table,
         cu_seqlens=cu,
         seq_lens=seq_lens,
         prefix_lens=prefix,

--- a/python/sglang/srt/layers/attention/minimax_sparse_ops/tests/test_msa_fp8_parity.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_ops/tests/test_msa_fp8_parity.py
@@ -16,8 +16,14 @@ Run: pytest python/sglang/srt/layers/attention/minimax_sparse_ops/tests/test_msa
 import pytest
 import torch
 
-from sglang.srt.layers.attention.minimax_sparse_ops.decode.topk_sparse import (
+from sglang.kernels.ops.attention.minimax_sparse.decode.topk_sparse import (
     flash_decode_with_gqa_share_sparse,
+)
+from sglang.kernels.ops.attention.minimax_sparse.page_table import (
+    build_page_table_snapshot,
+)
+from sglang.kernels.ops.attention.minimax_sparse.prefill.topk_sparse import (
+    flash_prefill_with_gqa_share_sparse,
 )
 from sglang.srt.layers.attention.minimax_sparse_ops.msa import (
     build_msa_decode_cg_plan,
@@ -26,9 +32,6 @@ from sglang.srt.layers.attention.minimax_sparse_ops.msa import (
     msa_sparse_prefill_main,
     update_msa_decode_cg_meta,
 )
-from sglang.srt.layers.attention.minimax_sparse_ops.prefill.topk_sparse import (
-    flash_prefill_with_gqa_share_sparse,
-)
 
 DEVICE = "cuda"
 FP8 = torch.float8_e4m3fn
@@ -36,6 +39,20 @@ P = 128  # sparse block == page size
 # two independent e4m3-P quantizations (MSA + Triton)
 X_ATOL = 1e-1
 X_RTOL = 1e-1
+
+
+def _build_page_table(req_to_token, slot_ids, seq_lens, max_slots, page_size=1):
+    max_pages = (req_to_token.shape[1] + page_size - 1) // page_size
+    page_table = torch.empty(
+        (slot_ids.shape[0], max_pages),
+        dtype=torch.int32,
+        device=req_to_token.device,
+    )
+    build_page_table_snapshot(
+        page_table, req_to_token, slot_ids, seq_lens, page_size, max_slots
+    )
+    return page_table
+
 
 pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available() or not msa_available(),
@@ -115,11 +132,12 @@ def test_msa_fp8_decode_vs_triton_fp8():
     q8, qr = qdq(q)
     k8, kr = qdq(k)
     v8, vr = qdq(v)
+    page_table = _build_page_table(r2t, sids, seq_lens, k.shape[0], P)
     o_msa = msa_sparse_decode_main(
-        q8, k8, v8, tidx, r2t, sids, seq_lens, block_size_k=P
+        q8, k8, v8, tidx, page_table, seq_lens, block_size_k=P
     )
     o_triton = flash_decode_with_gqa_share_sparse(
-        q8, None, k8, v8, r2t, seq_lens, sids, P, tidx
+        q8, None, k8, v8, page_table, seq_lens, P, tidx, page_size=P
     )
     assert o_msa.dtype == torch.bfloat16
     torch.testing.assert_close(
@@ -127,7 +145,7 @@ def test_msa_fp8_decode_vs_triton_fp8():
     )
     # bf16 MSA on the dequantized tensors bounds the pure fp8-kernel error
     o_bf16 = msa_sparse_decode_main(
-        qr, kr, vr, tidx, r2t, sids, seq_lens, block_size_k=P
+        qr, kr, vr, tidx, page_table, seq_lens, block_size_k=P
     )
     err = (o_msa.float() - o_bf16.float()).abs().mean()
     ref = o_bf16.float().abs().mean()
@@ -139,14 +157,14 @@ def test_msa_fp8_decode_scales():
     q8, qr = qdq(q)
     k8, kr = qdq(k)
     v8, vr = qdq(v)
+    page_table = _build_page_table(r2t, sids, seq_lens, k.shape[0], P)
     q_scale, k_scale, v_scale = 1.5, 0.5, 2.0
     o = msa_sparse_decode_main(
         q8,
         k8,
         v8,
         tidx,
-        r2t,
-        sids,
+        page_table,
         seq_lens,
         block_size_k=P,
         q_scale=q_scale,
@@ -159,8 +177,7 @@ def test_msa_fp8_decode_scales():
         (kr * k_scale).to(torch.bfloat16),
         (vr * v_scale).to(torch.bfloat16),
         tidx,
-        r2t,
-        sids,
+        page_table,
         seq_lens,
         block_size_k=P,
     )
@@ -174,6 +191,7 @@ def test_msa_fp8_decode_capture_replay_bitexact():
     q8, _ = qdq(q)
     k8, _ = qdq(k)
     v8, _ = qdq(v)
+    page_table = _build_page_table(r2t, sids, seq_lens, k.shape[0], P)
     bs = q8.shape[0]
     nb_max = r2t.shape[1] // P
     plan = build_msa_decode_cg_plan(
@@ -181,7 +199,7 @@ def test_msa_fp8_decode_capture_replay_bitexact():
     )
     kv_indices = torch.zeros(bs * nb_max, dtype=torch.int32, device=DEVICE)
     update_msa_decode_cg_meta(
-        plan, kv_indices, r2t, sids, seq_lens, P, tidx.shape[-1], 16, 1
+        plan, kv_indices, page_table, seq_lens, P, tidx.shape[-1], 16, 1
     )
 
     def run():
@@ -190,8 +208,7 @@ def test_msa_fp8_decode_capture_replay_bitexact():
             k8,
             v8,
             tidx,
-            r2t,
-            sids,
+            page_table,
             seq_lens,
             block_size_k=P,
             kv_indices=kv_indices,
@@ -256,16 +273,16 @@ def test_msa_fp8_prefill_vs_triton_fp8(seq_lens, prefix_lens, branch):
     q8, _ = qdq(q)
     k8, _ = qdq(k)
     v8, _ = qdq(v)
+    page_table = _build_page_table(r2t, sids, seq_lens_t, k.shape[0], P)
     o_msa = msa_sparse_prefill_main(
-        q8, k8, v8, tidx, r2t, sids, cu, seq_lens_t, prefix, block_size_k=P
+        q8, k8, v8, tidx, page_table, cu, seq_lens_t, prefix, block_size_k=P
     )
     o_triton = flash_prefill_with_gqa_share_sparse(
         q=q8,
         k_cache=k8,
         v_cache=v8,
         sink=None,
-        req_to_token=r2t,
-        slot_ids=sids,
+        page_table=page_table,
         topk_idx=tidx,
         block_size_q=1,
         block_size_k=P,
@@ -273,6 +290,7 @@ def test_msa_fp8_prefill_vs_triton_fp8(seq_lens, prefix_lens, branch):
         seq_lens=seq_lens_t,
         prefix_lens=prefix,
         max_seqlen_q=max_q,
+        page_size=P,
     )
     assert o_msa.dtype == torch.bfloat16
     torch.testing.assert_close(

--- a/python/sglang/srt/layers/attention/minimax_sparse_ops/tests/test_msa_fp8_parity.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_ops/tests/test_msa_fp8_parity.py
@@ -25,6 +25,9 @@ from sglang.kernels.ops.attention.minimax_sparse.page_table import (
 from sglang.kernels.ops.attention.minimax_sparse.prefill.topk_sparse import (
     flash_prefill_with_gqa_share_sparse,
 )
+from sglang.srt.layers.attention.minimax_sparse_ops.minimax_sparse import (
+    minimax_sparse_prefill,
+)
 from sglang.srt.layers.attention.minimax_sparse_ops.msa import (
     build_msa_decode_cg_plan,
     msa_available,
@@ -256,6 +259,54 @@ def _prefill_setup(seq_lens_list, prefix_lens_list, topk=4):
             tidx[0, row, :ak] = sel.to(torch.int32)
             row += 1
     return q, k, v, r2t, sids, cu, seq_lens, prefix, tidx, max(q_lens)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, FP8], ids=["bf16", "fp8"])
+def test_msa_prefill_index_pipeline_vs_triton(dtype):
+    q, k, v, r2t, _, cu, seq_lens, prefix, _, max_q = _prefill_setup([1024], [512])
+    q = q.to(dtype)
+    k = k.to(dtype)
+    v = v.to(dtype)
+    idx_q = q[:, :2].contiguous()
+    page_table = page_table_from_r2t(r2t)
+    kwargs = dict(
+        q=q,
+        k_cache=k,
+        v_cache=v,
+        sink=None,
+        idx_q=idx_q,
+        idx_k_cache=k,
+        idx_v_cache=None,
+        idx_sink=None,
+        page_table=page_table,
+        cu_seqlens=cu,
+        seq_lens=seq_lens,
+        prefix_lens=prefix,
+        max_seqlen_q=max_q,
+        max_seqlen_k=int(seq_lens.max().item()),
+        block_size_q=1,
+        block_size_k=P,
+        topk=4,
+        init_blocks=0,
+        local_blocks=1,
+        disable_index_value=True,
+        page_size=P,
+    )
+
+    cache = {}
+    _, actual = minimax_sparse_prefill(**kwargs, use_msa=True, msa_meta_cache=cache)
+    _, expected = minimax_sparse_prefill(**kwargs, use_msa=False)
+    assert "index_plan" in cache and "prefill" in cache
+    torch.testing.assert_close(
+        actual.float(), expected.float(), atol=X_ATOL, rtol=X_RTOL
+    )
+
+    kv_indices_ptr = cache["kv_indices"].data_ptr()
+    score_ptr = cache["index_score"].data_ptr()
+    _, replay = minimax_sparse_prefill(**kwargs, use_msa=True, msa_meta_cache=cache)
+    assert cache["kv_indices"].data_ptr() == kv_indices_ptr
+    assert cache["index_score"].data_ptr() == score_ptr
+    assert torch.equal(actual, replay)
 
 
 @pytest.mark.parametrize(

--- a/python/sglang/srt/layers/attention/minimax_sparse_ops/tests/test_page_table_snapshot.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_ops/tests/test_page_table_snapshot.py
@@ -1,0 +1,124 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang.kernels.ops.attention.minimax_sparse.page_table import (
+    build_page_table_snapshot,
+)
+from sglang.srt.layers.attention.minimax_sparse_backend import (
+    MiniMaxSparseAttnBackend,
+)
+
+
+def _row_from_pages(pages: list[int], page_size: int) -> torch.Tensor:
+    return torch.cat(
+        [
+            torch.arange(
+                page * page_size,
+                (page + 1) * page_size,
+                dtype=torch.int32,
+                device="cuda",
+            )
+            for page in pages
+        ]
+    )
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="page-table snapshot requires CUDA"
+)
+def test_page_table_snapshot_uses_active_rows_and_draft_delta():
+    page_size = 4
+    max_slots = 64
+    req_to_token = torch.empty((3, 16), dtype=torch.int32, device="cuda")
+    req_to_token[0] = _row_from_pages([2, 7, 4, 9], page_size)
+    req_to_token[1] = _row_from_pages([6, 8, 11, 0], page_size)
+    req_to_token[2] = _row_from_pages([5, 1, 10, 3], page_size)
+
+    req_pool_indices = torch.tensor([2, 0], dtype=torch.int64, device="cuda")
+    seq_lens = torch.tensor([5, 9], dtype=torch.int32, device="cuda")
+    snapshot = torch.full((2, 4), -1, dtype=torch.int32, device="cuda")
+    original_ptr = snapshot.data_ptr()
+
+    build_page_table_snapshot(
+        snapshot,
+        req_to_token,
+        req_pool_indices,
+        seq_lens,
+        page_size,
+        max_slots,
+        seq_len_delta=3,
+    )
+
+    assert snapshot.data_ptr() == original_ptr
+    torch.testing.assert_close(
+        snapshot.cpu(),
+        torch.tensor([[5, 1, 0, 0], [2, 7, 4, 0]], dtype=torch.int32),
+    )
+
+
+def test_backend_slices_max_batch_buffers_before_snapshot(monkeypatch):
+    captured = {}
+
+    def fake_snapshot(
+        page_table,
+        req_to_token,
+        req_pool_indices,
+        seq_lens,
+        page_size,
+        max_slots,
+        *,
+        seq_len_delta=0,
+    ):
+        captured.update(
+            page_table=page_table,
+            req_pool_indices=req_pool_indices.clone(),
+            seq_lens=seq_lens.clone(),
+            page_size=page_size,
+            max_slots=max_slots,
+            seq_len_delta=seq_len_delta,
+        )
+
+    monkeypatch.setattr(
+        "sglang.kernels.ops.attention.minimax_sparse.page_table."
+        "build_page_table_snapshot",
+        fake_snapshot,
+    )
+
+    backend = object.__new__(MiniMaxSparseAttnBackend)
+    backend._msa_dec_meta = None
+    backend._active_page_table = None
+    backend._cuda_graph_page_table = torch.empty((4, 4), dtype=torch.int32)
+    backend._msa_owns_decode = False
+    backend.req_to_token = torch.zeros((4, 16), dtype=torch.int32)
+    backend.kv_pool = SimpleNamespace(size=60)
+    backend.page_size = 4
+    backend.max_context_len = 16
+    backend.speculative_num_draft_tokens = 8
+    backend.speculative_num_steps = 7
+
+    mode = SimpleNamespace(
+        is_target_verify=lambda: False,
+        is_draft_extend_v2=lambda: False,
+        is_decode_or_idle=lambda: True,
+    )
+    forward_batch = SimpleNamespace(
+        forward_mode=mode,
+        batch_size=2,
+        req_pool_indices=torch.tensor([2, 1, 99, 99], dtype=torch.int64),
+        seq_lens=torch.tensor([8, 7, 999, 999], dtype=torch.int32),
+        seq_lens_cpu=torch.tensor([8, 7, 999, 999], dtype=torch.int32),
+        extend_seq_lens_cpu=None,
+    )
+
+    backend.init_forward_metadata_out_graph(forward_batch, in_capture=True)
+
+    assert captured["page_table"].shape == (2, 4)
+    torch.testing.assert_close(
+        captured["req_pool_indices"], torch.tensor([2, 1], dtype=torch.int64)
+    )
+    torch.testing.assert_close(
+        captured["seq_lens"], torch.tensor([8, 7], dtype=torch.int32)
+    )
+    assert backend._max_seqlen_k == 16

--- a/python/sglang/srt/layers/attention/minimax_sparse_ops/tests/test_page_table_snapshot.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_ops/tests/test_page_table_snapshot.py
@@ -89,6 +89,7 @@ def test_backend_slices_max_batch_buffers_before_snapshot(monkeypatch):
     backend = object.__new__(MiniMaxSparseAttnBackend)
     backend.is_npu = False
     backend._msa_dec_meta = None
+    backend._msa_prefill_meta_cache = {}
     backend._active_page_table = None
     backend._cuda_graph_page_table = torch.empty((4, 4), dtype=torch.int32)
     backend._msa_owns_decode = False
@@ -129,3 +130,55 @@ def test_backend_slices_max_batch_buffers_before_snapshot(monkeypatch):
     assert backend._active_page_table.shape == (2, 4)
     assert captured["page_table"].shape == (2, 4)
     assert backend._max_seqlen_k == 16
+
+
+def test_msa_prefill_metadata_is_reused_within_forward(monkeypatch):
+    from sglang.srt.layers.attention.minimax_sparse_ops import msa
+
+    calls = {"pack": 0, "plan": 0, "fmha": 0}
+
+    def fake_pack(page_table, seq_lens, page_size):
+        calls["pack"] += 1
+        return page_table.flatten().to(torch.int32)
+
+    def fake_plan(*args, **kwargs):
+        calls["plan"] += 1
+        return object()
+
+    def fake_fmha(q, k, v, plan, **kwargs):
+        calls["fmha"] += 1
+        return q, None
+
+    monkeypatch.setattr(msa, "_pack_page_table", fake_pack)
+    monkeypatch.setattr(msa, "_run_fmha_sm100_plan", fake_plan)
+    monkeypatch.setattr(msa, "_load_fmha_sm100", lambda: (fake_fmha, None))
+
+    q = torch.zeros(4, 2, 128, dtype=torch.bfloat16)
+    k = torch.zeros(256, 1, 128, dtype=torch.bfloat16)
+    v = torch.zeros_like(k)
+    topk_idx = torch.zeros(1, 4, 1, dtype=torch.int32)
+    page_table = torch.tensor([[0, 1]], dtype=torch.int32)
+    cu_seqlens = torch.tensor([0, 4], dtype=torch.int32)
+    seq_lens = torch.tensor([132], dtype=torch.int32)
+    prefix_lens = torch.tensor([128], dtype=torch.int32)
+    cache = {}
+
+    kwargs = dict(
+        q=q,
+        k_cache=k,
+        v_cache=v,
+        topk_idx=topk_idx,
+        page_table=page_table,
+        cu_seqlens=cu_seqlens,
+        seq_lens=seq_lens,
+        prefix_lens=prefix_lens,
+        block_size_k=128,
+        meta_cache=cache,
+    )
+    msa.msa_sparse_prefill_main(**kwargs)
+    msa.msa_sparse_prefill_main(**kwargs)
+    assert calls == {"pack": 1, "plan": 1, "fmha": 2}
+
+    cache.clear()
+    msa.msa_sparse_prefill_main(**kwargs)
+    assert calls == {"pack": 2, "plan": 2, "fmha": 3}

--- a/python/sglang/srt/layers/attention/minimax_sparse_ops/tests/test_page_table_snapshot.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_ops/tests/test_page_table_snapshot.py
@@ -87,6 +87,7 @@ def test_backend_slices_max_batch_buffers_before_snapshot(monkeypatch):
     )
 
     backend = object.__new__(MiniMaxSparseAttnBackend)
+    backend.is_npu = False
     backend._msa_dec_meta = None
     backend._active_page_table = None
     backend._cuda_graph_page_table = torch.empty((4, 4), dtype=torch.int32)
@@ -112,13 +113,19 @@ def test_backend_slices_max_batch_buffers_before_snapshot(monkeypatch):
         extend_seq_lens_cpu=None,
     )
 
-    backend.init_forward_metadata_out_graph(forward_batch, in_capture=True)
+    backend.init_forward_metadata_out_graph(forward_batch, in_capture=False)
 
-    assert captured["page_table"].shape == (2, 4)
+    assert backend._active_page_table.shape == (2, 4)
+    assert captured["page_table"].shape == (2, 2)
     torch.testing.assert_close(
         captured["req_pool_indices"], torch.tensor([2, 1], dtype=torch.int64)
     )
     torch.testing.assert_close(
         captured["seq_lens"], torch.tensor([8, 7], dtype=torch.int32)
     )
+    assert backend._max_seqlen_k == 8
+
+    backend.init_forward_metadata_out_graph(forward_batch, in_capture=True)
+    assert backend._active_page_table.shape == (2, 4)
+    assert captured["page_table"].shape == (2, 4)
     assert backend._max_seqlen_k == 16

--- a/python/sglang/srt/layers/attention/minimax_sparse_ops/tests/test_sparse_gqa.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_ops/tests/test_sparse_gqa.py
@@ -13,6 +13,9 @@ import torch
 from sglang.kernels.ops.attention.minimax_sparse.decode.topk_sparse import (
     flash_decode_with_gqa_share_sparse,
 )
+from sglang.kernels.ops.attention.minimax_sparse.page_table import (
+    build_page_table_snapshot,
+)
 
 DEVICE = "cuda"
 RTOL = 5e-3
@@ -119,6 +122,11 @@ def build_inputs(
                 base, base + max_kv_len, device=DEVICE
             ).to(torch.int32)
 
+    page_table = torch.empty_like(req_to_token)
+    build_page_table_snapshot(
+        page_table, req_to_token, slot_ids, seq_lens, 1, max_slots
+    )
+
     num_blocks_list = [(sl + block_size - 1) // block_size for sl in seq_lens_list]
     actual_topk = min(topk, min(num_blocks_list))
     topk_idx = torch.zeros(
@@ -139,7 +147,7 @@ def build_inputs(
         else None
     )
 
-    return q, sink, k_cache, v_cache, req_to_token, seq_lens, slot_ids, topk_idx
+    return q, sink, k_cache, v_cache, req_to_token, seq_lens, page_table, topk_idx
 
 
 def _case(bs, nqh, nkh, hd, blk, tk, sink, seq_pat, paged=True):
@@ -208,7 +216,7 @@ def test_sparse_gqa_vs_reference(bs, nqh, nkh, hd, blk, tk, with_sink, seq_pat, 
     torch.manual_seed(42)
     seq_lens_list = make_seq_lens(seq_pat, bs, blk)
 
-    q, sink, k_cache, v_cache, req_to_token, seq_lens, slot_ids, topk_idx = (
+    q, sink, k_cache, v_cache, req_to_token, seq_lens, page_table, topk_idx = (
         build_inputs(
             bs,
             nqh,
@@ -227,9 +235,8 @@ def test_sparse_gqa_vs_reference(bs, nqh, nkh, hd, blk, tk, with_sink, seq_pat, 
         sink,
         k_cache,
         v_cache,
-        req_to_token,
+        page_table,
         seq_lens,
-        slot_ids,
         blk,
         topk_idx,
     )
@@ -263,7 +270,7 @@ def test_sparse_gqa_topk_exceeds_blocks(
     torch.manual_seed(42)
     seq_lens_list = [blk] * bs
 
-    q, sink, k_cache, v_cache, req_to_token, seq_lens, slot_ids, topk_idx = (
+    q, sink, k_cache, v_cache, req_to_token, seq_lens, page_table, topk_idx = (
         build_inputs(
             bs,
             nqh,
@@ -282,9 +289,8 @@ def test_sparse_gqa_topk_exceeds_blocks(
         sink,
         k_cache,
         v_cache,
-        req_to_token,
+        page_table,
         seq_lens,
-        slot_ids,
         blk,
         topk_idx,
     )
@@ -316,7 +322,7 @@ def test_sparse_gqa_deterministic(bs, nqh, nkh, hd, blk, tk, with_sink, seq_pat,
     torch.manual_seed(42)
     seq_lens_list = make_seq_lens(seq_pat, bs, blk)
 
-    q, sink, k_cache, v_cache, req_to_token, seq_lens, slot_ids, topk_idx = (
+    q, sink, k_cache, v_cache, req_to_token, seq_lens, page_table, topk_idx = (
         build_inputs(
             bs,
             nqh,
@@ -335,9 +341,8 @@ def test_sparse_gqa_deterministic(bs, nqh, nkh, hd, blk, tk, with_sink, seq_pat,
         sink,
         k_cache,
         v_cache,
-        req_to_token,
+        page_table,
         seq_lens,
-        slot_ids,
         blk,
         topk_idx,
     )
@@ -346,9 +351,8 @@ def test_sparse_gqa_deterministic(bs, nqh, nkh, hd, blk, tk, with_sink, seq_pat,
         sink,
         k_cache,
         v_cache,
-        req_to_token,
+        page_table,
         seq_lens,
-        slot_ids,
         blk,
         topk_idx,
     )

--- a/python/sglang/srt/layers/attention/minimax_sparse_ops/tests/test_sparse_gqa.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_ops/tests/test_sparse_gqa.py
@@ -358,5 +358,55 @@ def test_sparse_gqa_deterministic(bs, nqh, nkh, hd, blk, tk, with_sink, seq_pat,
     ), f"non-deterministic: max diff {(o1.float() - o2.float()).abs().max().item():.4e}"
 
 
+def test_sparse_gqa_one_page_per_block():
+    """The block-table fast path must match token-table addressing."""
+    torch.manual_seed(43)
+    bs, nqh, nkh, hd, blk, tk = 2, 16, 1, 128, 128, 4
+    seq_lens_list = [513, 768]
+    q, sink, k_cache, v_cache, _, seq_lens, _, topk_idx = build_inputs(
+        bs,
+        nqh,
+        nkh,
+        hd,
+        seq_lens_list,
+        blk,
+        tk,
+        paged=False,
+    )
+
+    pages_per_req = max(seq_lens_list) // blk
+    page_table = torch.randperm(
+        bs * pages_per_req, device=DEVICE, dtype=torch.int32
+    ).view(bs, pages_per_req)
+    req_to_token = (
+        page_table[:, :, None] * blk
+        + torch.arange(blk, device=DEVICE, dtype=torch.int32)[None, None, :]
+    ).reshape(bs, -1)
+
+    o_kernel = flash_decode_with_gqa_share_sparse(
+        q,
+        sink,
+        k_cache,
+        v_cache,
+        page_table,
+        seq_lens,
+        blk,
+        topk_idx,
+        page_size=blk,
+    )
+    o_ref = pytorch_sparse_gqa_reference(
+        q,
+        sink,
+        k_cache,
+        v_cache,
+        req_to_token,
+        seq_lens,
+        blk,
+        topk_idx,
+    ).to(o_kernel.dtype)
+
+    assert torch.allclose(o_kernel.float(), o_ref.float(), rtol=RTOL, atol=ATOL)
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v", "-s"]))

--- a/python/sglang/srt/layers/radix_attention.py
+++ b/python/sglang/srt/layers/radix_attention.py
@@ -178,10 +178,6 @@ class RadixAttention(nn.Module):
             and (torch.compiler.is_compiling() or not _force_eager_attn.get())
         ):
             if kwargs.get("idx_q") is not None:
-                if is_in_breakable_cuda_graph():
-                    return get_attn_backend().forward(
-                        q, k, v, self, forward_batch, save_kv_cache, **kwargs
-                    )
                 idx_q = kwargs["idx_q"]
                 idx_k = kwargs["idx_k"]
                 idx_v = kwargs.get("idx_v")
@@ -189,7 +185,12 @@ class RadixAttention(nn.Module):
                     (q.shape[0], self.tp_q_head_num * self.v_head_dim)
                 )
                 idx_out = q.new_empty((q.shape[0], idx_q.shape[1] * idx_q.shape[2]))
-                unified_sparse_attention_with_output(
+                sparse_attention_fn = (
+                    breakable_unified_sparse_attention_with_output
+                    if is_in_breakable_cuda_graph()
+                    else unified_sparse_attention_with_output
+                )
+                sparse_attention_fn(
                     q,
                     k,
                     v,
@@ -546,6 +547,10 @@ def unified_sparse_attention_with_output(
         _zero_padded_pcg_tail(buf, context)
     return
 
+
+breakable_unified_sparse_attention_with_output = eager_on_graph(True)(
+    unified_sparse_attention_with_output
+)
 
 breakable_unified_attention_with_output = eager_on_graph(True)(
     unified_attention_with_output

--- a/test/registered/kernels/ops/attention/test_minimax_decode_topk_page_table.py
+++ b/test/registered/kernels/ops/attention/test_minimax_decode_topk_page_table.py
@@ -23,6 +23,9 @@ from sglang.kernels.ops.attention.minimax_decode_topk import (
 from sglang.kernels.ops.attention.minimax_sparse.decode.topk_sparse import (
     flash_decode_with_gqa_share_sparse,
 )
+from sglang.kernels.ops.attention.minimax_sparse.page_table import (
+    build_page_table_snapshot,
+)
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=25, stage="base-b-kernel-unit", runner_config="4-gpu-b200")
@@ -82,6 +85,9 @@ def test_fused_page_table_matches_custom(bs, seq_len, nqh):
     for b in range(bs):
         r2t[b] = ((b * ppr + idxs // ps) * ps + idxs % ps).int()
 
+    page_table = torch.empty((bs, ppr), dtype=torch.int32, device=dev)
+    build_page_table_snapshot(page_table, r2t, sid, sl, ps, kf.shape[0])
+
     nb = (seq_len + block - 1) // block
     score = torch.full((1, bs, nb), -float("inf"), device=dev, dtype=torch.float32)
     score[0, :, :nb] = torch.randn(bs, nb, device=dev)
@@ -90,11 +96,20 @@ def test_fused_page_table_matches_custom(bs, seq_len, nqh):
     # block-id selection -> custom kernel (reference)
     ti = minimax_decode_topk(score, sl, block, topk)
     ref = flash_decode_with_gqa_share_sparse(
-        q, None, kf, vf, r2t, sl, sid, block, ti, sm_scale=D**-0.5
+        q,
+        None,
+        kf,
+        vf,
+        page_table,
+        sl,
+        block,
+        ti,
+        sm_scale=D**-0.5,
+        page_size=ps,
     )
 
     # fused page-table + effective KV length -> trtllm (allocated + returned)
-    pt, cache = minimax_decode_topk_page_table(score, sl, r2t, sid, block, topk, ps)
+    pt, cache = minimax_decode_topk_page_table(score, sl, page_table, block, topk, ps)
     # the kernel's effective KV length must match the actual block selection
     expect_cache = _effective_kv_from_selection(ti, sl, block)
     assert torch.equal(cache, expect_cache), f"{cache} != {expect_cache}"
@@ -141,6 +156,9 @@ def test_dp_flattened_page_table(nkv, bs, seq_len):
     for b in range(bs):
         r2t[b] = ((b * ppr + idxs // ps) * ps + idxs % ps).int()
 
+    page_table = torch.empty((bs, ppr), dtype=torch.int32, device=dev)
+    build_page_table_snapshot(page_table, r2t, sid, sl, ps, bs * ppr * ps)
+
     nb = (seq_len + block - 1) // block
     score = torch.full((nkv, bs, nb), -float("inf"), device=dev, dtype=torch.float32)
     score[:, :, :nb] = torch.randn(nkv, bs, nb, device=dev)
@@ -148,7 +166,7 @@ def test_dp_flattened_page_table(nkv, bs, seq_len):
 
     # per-head block-id selection is the reference for the flattened page table
     ti = minimax_decode_topk(score, sl, block, topk)  # [nkv, bs, topk]
-    pt, cache = minimax_decode_topk_page_table(score, sl, r2t, sid, block, topk, ps)
+    pt, cache = minimax_decode_topk_page_table(score, sl, page_table, block, topk, ps)
     msp = topk * ppb
     assert pt.shape == (bs * nkv, msp) and cache.shape == (bs * nkv,)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

MiniMax-M3 still uses Triton for prefill index score when MSA is enabled.

This draft is stacked on #34547 and includes the breakable CUDA Graph support and per-forward MSA metadata reuse from #33942. Per-layer MSA prepare erases the kernel gain, so this optimization assumes per-forward reuse is already in place.

## Modifications

- Split block-score generation from the existing Triton top-k selection and use MSA `output_maxscore` for the supported score-only max path.
- Prepare the packed page metadata, MSA index plan, and max-score backing once per forward and reuse them across sparse layers.
- Keep the Triton fallback and a default-enabled kill switch for the MSA index path.

## Accuracy Tests

| Configuration | GSM8K |
|---|---:|
| Baseline (#34547) | 0.9695 |
| This PR | 0.9710 |

## Speed Tests and Profiling

E2E measurements use TP4, FlashInfer routed MoE, CuTeDSL MXFP8 GEMM, and fixed
8K input / 1K output requests.

Kernel measurements use random non-zero inputs with metadata prepared once per
forward. Query length is fixed at 8K.

```bash
sglang serve \
  --model-path "$MODEL_PATH" \
  --host 0.0.0.0 --port 8000 \
  --tp 4 --dtype bfloat16 --trust-remote-code \
  --moe-runner-backend flashinfer_trtllm_routed \
  --fp8-gemm-backend flashinfer_cutedsl \
  --cuda-graph-backend-prefill breakable \
  --disable-radix-cache
```

| Prefix | KV dtype | MSA prepare (us) | Triton index score (us) | MSA index score (us) | Reduction |
|---:|---|---:|---:|---:|---:|
| 8K | FP8 | 556.202 | 100.289 | 75.360 | 24.86% |
| 8K | BF16 | 541.038 | 127.232 | 88.074 | 30.78% |
| 32K | FP8 | 543.053 | 234.844 | 174.936 | 25.51% |
| 32K | BF16 | 543.501 | 303.232 | 206.382 | 31.94% |
| 128K | FP8 | 547.737 | 770.290 | 574.002 | 25.48% |
| 128K | BF16 | 539.556 | 1025.552 | 683.387 | 33.36% |

With per-forward metadata reuse, the complete index score and top-k pipeline is
19.64% to 26.66% faster.

TTFT and TPOT are P50 latency in milliseconds.

| Concurrency | TTFT baseline | TTFT PR | TPOT baseline | TPOT PR |
|---:|---:|---:|---:|---:|
| 1 | 326.96 | 316.56 | 5.07 | 5.04 |
| 2 | 485.75 | 482.13 | 5.69 | 5.64 |
| 4 | 778.96 | 759.36 | 6.80 | 6.79 |
| 8 | 1375.28 | 1350.80 | 8.24 | 8.20 |
| 16 | 2577.34 | 2545.61 | 10.65 | 10.67 |
| 32 | 4969.73 | 4927.96 | 14.18 | 14.10 |
| 64 | 9768.90 | 9252.00 | 18.53 | 18.54 |

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31874548594](https://github.com/sgl-project/sglang/actions/runs/31874548594)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31874548425](https://github.com/sgl-project/sglang/actions/runs/31874548425)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->