### PR TITLE
[Spec] Fix SWA eviction bookkeeping for DFLASH-family decode

### DIFF
--- a/python/sglang/srt/speculative/dflash_info_v2.py
+++ b/python/sglang/srt/speculative/dflash_info_v2.py
@@ -124,6 +124,7 @@ class DFlashDraftInputV2(SpecInput):
         bs = batch.batch_size()
         if bs == 0:
             return
+        batch.maybe_evict_swa()
         self._ensure_prepare_length_buffers(bs, batch.device)
         assert self._prepare_batch_seq_lens_cpu_buf is not None
         assert self._prepare_cur_kv_lens_cpu_buf is not None
@@ -161,6 +162,7 @@ class DFlashDraftInputV2(SpecInput):
             committed_seq_lens_sum += committed_len
             reserved_seq_lens_sum += reserved_len
             num_needed_tokens += reserved_len - cur_alloc_len
+            req.decode_batch_idx += 1
 
             if top_k > max_top_k:
                 max_top_k = top_k


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

DFLASH-family speculative decode, including DSPARK, reserves target KV headroom through `DFlashDraftInputV2.prepare_for_decode()`, but this path did not run SWA eviction bookkeeping or advance the per-request decode clock used by `ScheduleBatch.maybe_evict_swa()`.

For hybrid-SWA models such as DeepSeek V4 Flash, SWA KV usage can then grow roughly linearly with full KV usage during long DSPARK decode, instead of reclaiming out-of-window SWA slots. This can fill the SWA pool and trigger repeated KV cache retractions/OOM behavior even when the model sliding window is small.

Validated scenario:

- Model: DeepSeek V4 Flash 0731 (`sliding_window=128`)
- Speculative decoding: `--speculative-algorithm DSPARK --speculative-dspark-block-size 5`
- `--swa-full-tokens-ratio 0.1`
- Base commit: `8720a72`
- Environment: H100 80G x 4, CUDA 13.0, Python 3.12.13

## Modifications

This PR updates `DFlashDraftInputV2.prepare_for_decode()` to run the decode bookkeeping expected by the SWA eviction path:

- Call `batch.maybe_evict_swa()` before reserving new target KV headroom.
- Increment `req.decode_batch_idx` once per decode iteration for each active request.

`DSPARK` is routed through `SpeculativeAlgorithm.is_dflash_family()`, so it uses this DFLASH-family prepare path.

## Accuracy Tests

Not run. This change only updates decode-time KV/SWA bookkeeping. It does not change model forward computation, sampling logits, attention kernels, or accepted token selection.

## Speed Tests and Profiling

Functional validation and a lightweight serving benchmark were run on H100 x 4.

Server command highlights:

```bash
export SGLANG_RAGGED_VERIFY_MODE=compact
export SGLANG_DSV4_COMPRESS_STATE_DTYPE=bf16

python3 -m sglang.launch_server \
    --port 8000 \
    --model-path ./models/DeepSeek-V4-Flash-0731 \
    --trust-remote-code \
    --tp-size 4 \
    --mem-fraction-static 0.8 \
    --context-length 1048576 \
    --max-running-requests 16 \
    --reasoning-parser deepseek-v4 \
    --tool-call-parser deepseekv4 \
    --moe-runner-backend marlin \
    --speculative-algorithm DSPARK \
    --speculative-dspark-block-size 5 \
    --swa-full-tokens-ratio 0.1 \
```

Benchmark command:

```bash
python -m sglang.benchmark.serving \
  --backend sglang-oai-chat \
  --dataset-name random \
  --num-prompts 32 \
  --random-input-len 1024 \
  --random-output-len 32768 \
  --random-range-ratio 1 \
  --request-rate inf \
  --model DeepSeek-V4-Flash-0731 \
  --host 127.0.0.1 \
  --port 8000
```

Results:

| Metric | Before | After |
| --- | ---: | ---: |
| KV cache full / retractions | Yes, repeated `KV cache pool is full` | No |
| Successful requests | 32 | 32 |
| Benchmark duration | 468.00 s | 369.78 s |
| Output token throughput | 2240.55 tok/s | 2835.66 tok/s |
| Mean TPOT | 8.01 ms | 4.42 ms |
| Mean ITL | 8.06 ms | 4.45 ms |
| Max ITL | 129233.10 ms | 6761.81 ms |
| Accept length | 5.22 | 5.25 |

Log behavior:

- Before the fix, single-request decode showed `#swa token` growing together with `#full token`.
- After the fix, single-request decode kept SWA usage near the sliding-window footprint while full KV continued to grow.
- Under the benchmark workload, the pre-fix run repeatedly triggered `KV cache pool is full`; the fixed run did not.

Example pre-fix single-request log:

```text
[2026-08-15 07:04:18 TP0] Prefill batch, #new-seq: 1, #new-token: 256, #cached-token: 0, full token usage: 0.00, swa token usage: 0.00, #running-req: 0, #queue-req: 0, #pending-token: 0, cuda graph: False, input throughput (token/s): 0.05
[2026-08-15 07:04:18 TP0] Decode batch, #running-req: 1, #full token: 512, full token usage: 0.00, #swa token: 512, swa token usage: 0.00, accept len: 4.12, accept rate: 0.62, cap len: 6.00, cuda graph: True, gen throughput (token/s): 0.03, #queue-req: 0
[2026-08-15 07:04:19 TP0] Decode batch, #running-req: 1, #full token: 512, full token usage: 0.00, #swa token: 512, swa token usage: 0.00, accept len: 3.85, accept rate: 0.57, cap len: 6.00, cuda graph: True, gen throughput (token/s): 411.23, #queue-req: 0
[2026-08-15 07:04:19 TP0] Decode batch, #running-req: 1, #full token: 768, full token usage: 0.00, #swa token: 768, swa token usage: 0.00, accept len: 4.60, accept rate: 0.72, cap len: 6.00, cuda graph: True, gen throughput (token/s): 491.59, #queue-req: 0
[2026-08-15 07:04:19 TP0] Decode batch, #running-req: 1, #full token: 1024, full token usage: 0.00, #swa token: 1024, swa token usage: 0.00, accept len: 4.17, accept rate: 0.64, cap len: 6.00, cuda graph: True, gen throughput (token/s): 446.68, #queue-req: 0
......
[2026-08-15 07:05:28 TP0] Decode batch, #running-req: 1, #full token: 32512, full token usage: 0.01, #swa token: 32512, swa token usage: 0.12, accept len: 5.35, accept rate: 0.87, cap len: 6.00, cuda graph: True, gen throughput (token/s): 539.91, #queue-req: 0
[2026-08-15 07:05:28 TP0] Decode batch, #running-req: 1, #full token: 32768, full token usage: 0.01, #swa token: 32768, swa token usage: 0.12, accept len: 5.58, accept rate: 0.92, cap len: 6.00, cuda graph: True, gen throughput (token/s): 561.68, #queue-req: 0
[2026-08-15 07:05:28 TP0] Decode batch, #running-req: 1, #full token: 33024, full token usage: 0.01, #swa token: 33024, swa token usage: 0.12, accept len: 5.53, accept rate: 0.91, cap len: 6.00, cuda graph: True, gen throughput (token/s): 559.27, #queue-req: 0
[2026-08-15 07:05:29] INFO:     127.0.0.1:55390 - "POST /v1/chat/completions HTTP/1.1" 200 OK
```

Example fixed single-request log:

```text
[2026-08-15 05:37:24 TP0] Prefill batch, #new-seq: 1, #new-token: 256, #cached-token: 0, full token usage: 0.00, swa token usage: 0.00, #running-req: 0, #queue-req: 0, #pending-token: 0, cuda graph: False, input throughput (token/s): 3.12
[2026-08-15 05:37:25 TP0] Decode batch, #running-req: 1, #full token: 512, full token usage: 0.00, #swa token: 512, swa token usage: 0.00, accept len: 4.22, accept rate: 0.65, cap len: 6.00, cuda graph: True, gen throughput (token/s): 3.08, #queue-req: 0
[2026-08-15 05:37:25 TP0] Decode batch, #running-req: 1, #full token: 768, full token usage: 0.00, #swa token: 512, swa token usage: 0.00, accept len: 4.25, accept rate: 0.65, cap len: 6.00, cuda graph: True, gen throughput (token/s): 453.13, #queue-req: 0
[2026-08-15 05:37:25 TP0] Decode batch, #running-req: 1, #full token: 768, full token usage: 0.00, #swa token: 512, swa token usage: 0.00, accept len: 3.50, accept rate: 0.50, cap len: 6.00, cuda graph: True, gen throughput (token/s): 373.22, #queue-req: 0
[2026-08-15 05:37:26 TP0] Decode batch, #running-req: 1, #full token: 1024, full token usage: 0.00, #swa token: 512, swa token usage: 0.00, accept len: 3.70, accept rate: 0.54, cap len: 6.00, cuda graph: True, gen throughput (token/s): 392.30, #queue-req: 0
......
[2026-08-15 05:38:24 TP0] Decode batch, #running-req: 1, #full token: 32512, full token usage: 0.01, #swa token: 512, swa token usage: 0.00, accept len: 5.88, accept rate: 0.97, cap len: 6.00, cuda graph: True, gen throughput (token/s): 589.29, #queue-req: 0
[2026-08-15 05:38:24 TP0] Decode batch, #running-req: 1, #full token: 32768, full token usage: 0.01, #swa token: 512, swa token usage: 0.00, accept len: 5.60, accept rate: 0.92, cap len: 6.00, cuda graph: True, gen throughput (token/s): 561.77, #queue-req: 0
[2026-08-15 05:38:24 TP0] Decode batch, #running-req: 1, #full token: 33024, full token usage: 0.01, #swa token: 512, swa token usage: 0.00, accept len: 5.47, accept rate: 0.90, cap len: 6.00, cuda graph: True, gen throughput (token/s): 549.11, #queue-req: 0
[2026-08-15 05:38:25] INFO:     127.0.0.1:56080 - "POST /v1/chat/completions HTTP/1.1" 200 OK
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Notes:
- Unit test is not included because the regression depends on the runtime SWA KV pool and long DSPARK decode behavior. The PR includes an H100 x 4 serving benchmark that reproduces the issue before the fix and validates it after the fix.
- Documentation update is not needed because this only fixes internal scheduler/spec decode bookkeeping.

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31875576398](https://github.com/sgl-project/sglang/actions/runs/31875576398)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31875576242](https://github.com/sgl-project/sglang/actions/runs/31875576242)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->