### PR TITLE
fix: Step3Detector streaming drops tool calls and grafts parameters

### DIFF
--- a/python/sglang/srt/function_call/step3_detector.py
+++ b/python/sglang/srt/function_call/step3_detector.py
@@ -66,9 +66,12 @@ class Step3Detector(BaseFormatDetector):
         self.tool_call_end = "<｜tool_call_end｜>"
         self.tool_sep = "<｜tool_sep｜>"
 
-        # Regex for parsing steptml invocations
+        # Regex for parsing steptml invocations. The body is allowed to be empty
+        # so that a parameter-less call (`<steptml:invoke name="x"></steptml:invoke>`)
+        # is still recognised instead of being silently dropped.
+        self.invoke_end = "</steptml:invoke>"
         self.invoke_regex = re.compile(
-            r'<steptml:invoke name="([^"]+)">(.+?)</steptml:invoke>', re.DOTALL
+            r'<steptml:invoke name="([^"]+)">(.*?)</steptml:invoke>', re.DOTALL
         )
         self.param_regex = re.compile(
             r'<steptml:parameter name="([^"]+)">([^<]*)</steptml:parameter>', re.DOTALL
@@ -127,11 +130,15 @@ class Step3Detector(BaseFormatDetector):
         try:
             pre_text, rest = text.split(self.bot_token, 1)
 
-            # If no end token, return everything as normal text
-            if self.eot_token not in rest:
-                return StreamingParseResult(normal_text=text, calls=[])
-
-            tool_section, post_text = rest.split(self.eot_token, 1)
+            # A block without its end token was cut short by the token limit.
+            # The unfinished markup is not content, so only the text that
+            # precedes the block is returned; the calls that did complete
+            # before the cut are still parsed below, as in streaming.
+            if self.eot_token in rest:
+                tool_section, post_text = rest.split(self.eot_token, 1)
+            else:
+                logger.warning("Tool call block is not terminated, treating as markup")
+                tool_section, post_text = rest, ""
 
             # Find all individual tool calls using regex
             calls = []
@@ -171,6 +178,11 @@ class Step3Detector(BaseFormatDetector):
     ) -> StreamingParseResult:
         """
         Streaming incremental parsing for Step3 format.
+
+        The buffer is drained in a loop: a single increment may carry the
+        preamble, several complete tool calls and the trailing text all at once
+        (``stream_interval > 1``, speculative decoding, or simply the last
+        increment of the stream, which has no successor to defer work to).
         """
         self._buffer += new_text
 
@@ -178,94 +190,144 @@ class Step3Detector(BaseFormatDetector):
         if not hasattr(self, "_tool_indices"):
             self._tool_indices = self._get_tool_indices(tools)
 
-        # If we've finished the tool block, everything is normal text
-        if self._tool_block_finished:
-            normal_text = self._buffer
-            self._buffer = ""
-            return StreamingParseResult(normal_text=normal_text)
-
-        # Check if tool block hasn't started yet
-        if not self._in_tool_block:
-            if self.bot_token in self._buffer:
-                idx = self._buffer.find(self.bot_token)
-                normal_text = self._buffer[:idx]
-                self._buffer = self._buffer[idx + len(self.bot_token) :]
-                self._in_tool_block = True
-                return StreamingParseResult(normal_text=normal_text)
-            else:
-                # Check if we might have a partial bot_token
-                partial_len = self._ends_with_partial_token(
-                    self._buffer, self.bot_token
-                )
-                if partial_len:
-                    return StreamingParseResult()  # Wait for more text
-                else:
-                    normal_text = self._buffer
-                    self._buffer = ""
-                    return StreamingParseResult(normal_text=normal_text)
-
-        # We're inside the tool block
+        normal_parts: List[str] = []
         calls: List[ToolCallItem] = []
 
-        # Check if tool block is ending
-        if self.eot_token in self._buffer:
-            idx = self._buffer.find(self.eot_token)
+        while self._buffer:
+            # Everything after the tool block is ordinary text
+            if self._tool_block_finished:
+                normal_parts.append(self._buffer)
+                self._buffer = ""
+                break
 
-            # If we're in the middle of a tool call, we need to handle it
-            if self._in_tool_call:
-                # The buffer before eot_token might contain the end of the current tool call
-                before_eot = self._buffer[:idx]
-                if self.tool_call_end in before_eot:
-                    # Parse this final tool call
-                    result = self._parse_partial_tool_call(tools)
-                    calls.extend(result.calls)
-                else:
-                    # Incomplete tool call - log warning
-                    logger.warning("Tool block ended with incomplete tool call")
+            # Before the tool block: emit text, hold back a partial bot_token
+            if not self._in_tool_block:
+                idx = self._buffer.find(self.bot_token)
+                if idx == -1:
+                    partial_len = self._ends_with_partial_token(
+                        self._buffer, self.bot_token
+                    )
+                    if partial_len:
+                        if len(self._buffer) > partial_len:
+                            normal_parts.append(self._buffer[:-partial_len])
+                            self._buffer = self._buffer[-partial_len:]
+                        break  # wait for more text
+                    normal_parts.append(self._buffer)
+                    self._buffer = ""
+                    break
+                normal_parts.append(self._buffer[:idx])
+                self._buffer = self._buffer[idx + len(self.bot_token) :]
+                self._in_tool_block = True
+                continue
 
-            remaining = self._buffer[idx + len(self.eot_token) :]
-            self._buffer = ""
-            self._tool_block_finished = True
-
-            # Reset any partial tool call state
-            self._reset_streaming_state()
-
-            return StreamingParseResult(normal_text=remaining, calls=calls)
-
-        # Check if we're in a tool call or need to start one
-        if not self._in_tool_call:
-            if self.tool_call_begin in self._buffer:
-                idx = self._buffer.find(self.tool_call_begin)
-                # Remove any content before tool call begin (shouldn't happen but be safe)
-                self._buffer = self._buffer[idx + len(self.tool_call_begin) :]
+            # Inside the tool block, between calls
+            if not self._in_tool_call:
+                begin_idx = self._buffer.find(self.tool_call_begin)
+                eot_idx = self._buffer.find(self.eot_token)
+                if eot_idx != -1 and (begin_idx == -1 or eot_idx < begin_idx):
+                    self._buffer = self._buffer[eot_idx + len(self.eot_token) :]
+                    self._tool_block_finished = True
+                    self._reset_streaming_state()
+                    continue
+                if begin_idx == -1:
+                    break  # wait for the next call or the end of the block
+                # Anything between two calls is protocol filler, not content
+                self._buffer = self._buffer[begin_idx + len(self.tool_call_begin) :]
                 self._in_tool_call = True
                 self._function_name_sent = False
                 self._current_function_name = ""
                 self._current_parameters = {}
-                # Fall through to parse the partial tool call
-            else:
-                # Wait for tool call to begin
-                return StreamingParseResult()
+                continue
 
-        # Parse partial tool call
-        if self._in_tool_call:
-            return self._parse_partial_tool_call(tools)
+            # Inside a tool call
+            result, consumed = self._parse_partial_tool_call(tools)
+            calls.extend(result.calls)
+            if consumed:
+                continue
+            if self.eot_token in self._buffer:
+                # The block ends while this call is still unfinished: it was
+                # truncated (token limit), so it is markup, not content.
+                logger.warning("Tool block ended with incomplete tool call")
+                eot_idx = self._buffer.find(self.eot_token)
+                self._buffer = self._buffer[eot_idx + len(self.eot_token) :]
+                self._tool_block_finished = True
+                self._reset_streaming_state()
+                continue
+            break  # wait for more text
 
-        return StreamingParseResult()
+        return StreamingParseResult(normal_text="".join(normal_parts), calls=calls)
 
-    def _parse_partial_tool_call(self, tools: List[Tool]) -> StreamingParseResult:
-        """Parse partial tool call for streaming scenarios."""
+    def finish(self, tools: List[Tool]) -> StreamingParseResult:
+        """Flush at end of stream.
+
+        Text held back because it looked like the start of ``bot_token`` is real
+        content once no more text can arrive. A buffer still inside the tool
+        block is an unfinished tool call, i.e. markup, and is dropped -- but a
+        call whose name has already been streamed cannot be taken back, so its
+        JSON is closed here to keep ``arguments`` parsable.
+        """
+        held, self._buffer = self._buffer, ""
+        if held and not self._in_tool_block:
+            return StreamingParseResult(normal_text=held)
+
+        calls: List[ToolCallItem] = []
+        if self._in_tool_call and self._function_name_sent:
+            logger.warning("Stream ended inside a tool call, closing its arguments")
+            closing = "}" if self.streamed_args_for_tool[self.current_tool_id] else "{}"
+            calls.append(
+                ToolCallItem(tool_index=self.current_tool_id, parameters=closing)
+            )
+            self.streamed_args_for_tool[self.current_tool_id] += closing
+            self._reset_streaming_state()
+            self.current_tool_id += 1
+        return StreamingParseResult(calls=calls)
+
+    def _current_call_segment(self) -> str:
+        """The slice of the buffer that belongs to the call being parsed.
+
+        Parameters must never be read past this call's own end: when a second
+        complete call arrives in the same increment, an unbounded search grafts
+        its parameters onto the current call and drops it.
+        """
+        end = self._buffer.find(self.tool_call_end)
+        segment = self._buffer if end == -1 else self._buffer[:end]
+        close = segment.find(self.invoke_end)
+        if close != -1:
+            segment = segment[: close + len(self.invoke_end)]
+        return segment
+
+    def _skip_current_call(self) -> bool:
+        """Drop the malformed call in the buffer. True if the buffer advanced."""
+        self._reset_streaming_state()
+        end = self._buffer.find(self.tool_call_end)
+        if end == -1:
+            return False
+        self._buffer = self._buffer[end + len(self.tool_call_end) :]
+        return True
+
+    def _parse_partial_tool_call(
+        self, tools: List[Tool]
+    ) -> tuple[StreamingParseResult, bool]:
+        """Parse the tool call at the head of the buffer.
+
+        Returns the deltas to stream plus whether the buffer was advanced past
+        this call (so the caller may look at what follows it).
+        """
         calls = []
+        segment = self._current_call_segment()
 
         # Check if we have tool_sep (means we're past the type declaration)
-        if self.tool_sep not in self._buffer:
-            return StreamingParseResult(calls=calls)  # Wait for more text
+        if self.tool_sep not in segment:
+            if self.tool_call_end in self._buffer:
+                logger.warning("Tool call without a type separator, skipping")
+                return StreamingParseResult(calls=calls), self._skip_current_call()
+            return StreamingParseResult(calls=calls), False  # Wait for more text
 
-        type_part, invoke_part = self._buffer.split(self.tool_sep, 1)
+        type_part, invoke_part = segment.split(self.tool_sep, 1)
         if type_part.strip() != "function":
             # Invalid tool type, skip this tool call
-            self._reset_streaming_state()
-            return StreamingParseResult(calls=calls)
+            logger.warning(f"Unsupported tool call type: {type_part.strip()!r}")
+            return StreamingParseResult(calls=calls), self._skip_current_call()
 
         # Try to extract function name if not sent yet
         if not self._function_name_sent:
@@ -305,11 +367,10 @@ class Step3Detector(BaseFormatDetector):
                 else:
                     # Invalid function name
                     logger.warning(f"Invalid function name: {func_name}")
-                    self._reset_streaming_state()
-                    return StreamingParseResult(calls=calls)
+                    return StreamingParseResult(calls=calls), self._skip_current_call()
             else:
                 # Function name not complete yet
-                return StreamingParseResult(calls=calls)
+                return StreamingParseResult(calls=calls), False
 
         # Parse parameters incrementally
         if self._function_name_sent:
@@ -371,15 +432,19 @@ class Step3Detector(BaseFormatDetector):
 
             # Check if tool call is complete
             if self.tool_call_end in self._buffer:
-                # Send closing brace if we've sent any parameters
-                if self.streamed_args_for_tool[self.current_tool_id]:
-                    calls.append(
-                        ToolCallItem(
-                            tool_index=self.current_tool_id,
-                            parameters="}",
-                        )
+                # Close the JSON object. A call with no parameters has streamed
+                # nothing so far, so it needs a whole "{}" -- otherwise its
+                # arguments stay "", which is not valid JSON.
+                closing = (
+                    "}" if self.streamed_args_for_tool[self.current_tool_id] else "{}"
+                )
+                calls.append(
+                    ToolCallItem(
+                        tool_index=self.current_tool_id,
+                        parameters=closing,
                     )
-                    self.streamed_args_for_tool[self.current_tool_id] += "}"
+                )
+                self.streamed_args_for_tool[self.current_tool_id] += closing
 
                 # Find the end position
                 end_idx = self._buffer.find(self.tool_call_end)
@@ -389,8 +454,9 @@ class Step3Detector(BaseFormatDetector):
                 # Reset state for next tool call
                 self._reset_streaming_state()
                 self.current_tool_id += 1
+                return StreamingParseResult(calls=calls), True
 
-        return StreamingParseResult(calls=calls)
+        return StreamingParseResult(calls=calls), False
 
     def _reset_streaming_state(self):
         """Reset streaming state for the next tool call"""

--- a/test/registered/unit/function_call/test_step3_detector_streaming.py
+++ b/test/registered/unit/function_call/test_step3_detector_streaming.py
@@ -1,0 +1,315 @@
+"""Streaming regression tests for Step3Detector -- no server, no model loading.
+
+Every case here feeds the *same* model output at several chunk sizes and
+compares the merged stream against ``detect_and_parse``. The bugs guarded are
+described in each docstring in black-box terms; all of them fail before the
+accompanying detector change and pass after it.
+"""
+
+import json
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.step3_detector import Step3Detector
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(1.0, "base-a-test-cpu")
+
+BOT = "<｜tool_calls_begin｜>"
+EOT = "<｜tool_calls_end｜>"
+CALL_BEGIN = "<｜tool_call_begin｜>"
+CALL_END = "<｜tool_call_end｜>"
+SEP = "<｜tool_sep｜>"
+
+# Markup that must never reach the client as assistant content.
+MARKUP = ("<steptml", "<｜tool_call", "<｜tool_sep")
+
+# Chunk sizes every case is replayed at. ``None`` means "the whole output in a
+# single increment", which is what the last increment of a stream looks like and
+# what ``stream_interval > 1`` or speculative decoding can produce mid-stream.
+CHUNK_SIZES = (None, 16, 8, 4, 1)
+
+
+def _call(name: str, params: str) -> str:
+    return (
+        f'{CALL_BEGIN}function{SEP}<steptml:invoke name="{name}">\n'
+        f"{params}"
+        f"</steptml:invoke>{CALL_END}\n"
+    )
+
+
+def _param(name: str, value: str) -> str:
+    return f'<steptml:parameter name="{name}">{value}</steptml:parameter>\n'
+
+
+class TestStep3DetectorStreaming(CustomTestCase):
+    def setUp(self):
+        self.tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="get_weather",
+                    description="Get weather information",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "city": {"type": "string", "description": "City name"},
+                            "days": {"type": "integer"},
+                        },
+                        "required": ["city"],
+                    },
+                ),
+            ),
+            Tool(
+                type="function",
+                function=Function(
+                    name="get_time",
+                    description="Get the current time",
+                    parameters={
+                        "type": "object",
+                        "properties": {"tz": {"type": "string"}},
+                    },
+                ),
+            ),
+            Tool(
+                type="function",
+                function=Function(
+                    name="ping",
+                    description="Takes no argument",
+                    parameters={"type": "object", "properties": {}},
+                ),
+            ),
+        ]
+
+    def _stream(self, text, chunk_size=None):
+        """Replay ``text`` through the streaming API and merge the deltas.
+
+        Returns ``(normal_text, [(name, arguments), ...])`` in the same shape
+        ``detect_and_parse`` produces, so the two can be compared directly.
+        """
+        if chunk_size is None:
+            chunks = [text]
+        else:
+            chunks = [text[i : i + chunk_size] for i in range(0, len(text), chunk_size)]
+        return self._stream_parts(chunks)
+
+    def _stream_parts(self, parts):
+        """Same as ``_stream`` but with explicitly chosen increment boundaries."""
+        detector = Step3Detector()
+
+        normal_text = ""
+        names = {}
+        arguments = {}
+        order = []
+
+        def absorb(result):
+            nonlocal normal_text
+            normal_text += result.normal_text or ""
+            for item in result.calls:
+                if item.tool_index not in arguments:
+                    arguments[item.tool_index] = ""
+                    order.append(item.tool_index)
+                if item.name:
+                    names[item.tool_index] = item.name
+                if item.parameters:
+                    arguments[item.tool_index] += item.parameters
+
+        for chunk in parts:
+            absorb(detector.parse_streaming_increment(chunk, self.tools))
+        # The serving layer calls finish() once the stream is over.
+        absorb(detector.finish(self.tools))
+
+        return normal_text, [(names.get(i), arguments.get(i, "")) for i in order]
+
+    def _assert_no_markup(self, text, label):
+        for markup in MARKUP:
+            self.assertNotIn(markup, text, f"{markup!r} leaked into content ({label})")
+
+    def _assert_matches_non_streaming(self, text):
+        """Content and calls must be chunk-invariant and match one-shot parsing."""
+        expected = Step3Detector().detect_and_parse(text, self.tools)
+        expected_calls = [(c.name, c.parameters) for c in expected.calls]
+        self._assert_no_markup(expected.normal_text or "", "non-streaming")
+        for chunk_size in CHUNK_SIZES:
+            with self.subTest(chunk_size=chunk_size):
+                normal_text, calls = self._stream(text, chunk_size)
+                self._assert_no_markup(normal_text, f"chunk_size={chunk_size}")
+                self.assertEqual(normal_text, expected.normal_text or "")
+                self.assertEqual(calls, expected_calls)
+                for _, params in calls:
+                    json.loads(params)  # arguments must always be valid JSON
+        return expected_calls
+
+    # ==================== One increment, several things ====================
+
+    def test_streaming_text_call_and_text_in_one_increment(self):
+        """A single increment carrying preamble + a call + trailing prose.
+
+        The detector used to perform one action per increment and defer the rest
+        to the next one, so an increment that also contained the tool call
+        emitted only the preamble and dropped the call entirely -- and the last
+        increment of a stream has no next increment to defer to.
+        """
+        text = (
+            "Sure.\n"
+            + BOT
+            + "\n"
+            + _call("get_weather", _param("city", "SF") + _param("days", "3"))
+            + EOT
+            + "\nDone."
+        )
+        calls = self._assert_matches_non_streaming(text)
+        self.assertEqual(calls, [("get_weather", '{"city": "SF", "days": 3}')])
+        normal_text, _ = self._stream(text)
+        self.assertEqual(normal_text, "Sure.\n\nDone.")
+
+    def test_streaming_two_calls_in_one_increment_keep_their_own_parameters(self):
+        """Two complete calls inside one increment.
+
+        Parameters were collected by scanning the whole buffer, so the second
+        call donated its parameters to the first one and was then dropped:
+        ``get_weather{"city": "SF", "tz": "UTC"}`` instead of two calls. The
+        increment boundaries here are explicit because this is what speculative
+        decoding produces: preamble, then several accepted calls at once.
+        """
+        parts = [
+            "Checking.\n" + BOT + "\n",
+            _call("get_weather", _param("city", "SF"))
+            + _call("get_time", _param("tz", "UTC")),
+            EOT + "\nBoth done.",
+        ]
+        normal_text, calls = self._stream_parts(parts)
+        self._assert_no_markup(normal_text, "explicit increments")
+        self.assertEqual(normal_text, "Checking.\n\nBoth done.")
+        self.assertEqual(
+            calls,
+            [("get_weather", '{"city": "SF"}'), ("get_time", '{"tz": "UTC"}')],
+        )
+        self._assert_matches_non_streaming("".join(parts))
+
+    def test_streaming_trailing_text_is_chunk_invariant(self):
+        """Prose after the tool block must not depend on the chunk boundaries.
+
+        With the whole answer in one increment the trailing sentence was lost,
+        while smaller chunks kept it -- the same answer yielded different
+        content depending on ``stream_interval``.
+        """
+        text = (
+            BOT
+            + "\n"
+            + _call("get_weather", _param("city", "SF"))
+            + EOT
+            + "\nIt is sunny in SF."
+        )
+        self._assert_matches_non_streaming(text)
+        for chunk_size in CHUNK_SIZES:
+            with self.subTest(chunk_size=chunk_size):
+                normal_text, _ = self._stream(text, chunk_size)
+                self.assertEqual(normal_text, "\nIt is sunny in SF.")
+
+    # ==================== Parameter-less calls ====================
+
+    def test_streaming_zero_parameter_call_has_valid_arguments(self):
+        """A call with no parameters must still stream ``{}``.
+
+        Nothing was streamed for such a call and the closing brace was only sent
+        when something had been streamed before, so ``arguments`` stayed the
+        empty string -- which is not valid JSON for the client.
+        """
+        text = BOT + "\n" + _call("ping", "") + EOT + "\nok"
+        calls = self._assert_matches_non_streaming(text)
+        self.assertEqual(calls, [("ping", "{}")])
+
+    def test_detect_and_parse_keeps_call_with_empty_invoke_body(self):
+        """``<steptml:invoke name="ping"></steptml:invoke>`` is a real call.
+
+        The invoke pattern required a non-empty body, so a parameter-less call
+        written without even a newline was not matched and the whole call was
+        silently dropped by one-shot parsing.
+        """
+        text = (
+            BOT
+            + "\n"
+            + f'{CALL_BEGIN}function{SEP}<steptml:invoke name="ping">'
+            + f"</steptml:invoke>{CALL_END}\n"
+            + EOT
+        )
+        result = Step3Detector().detect_and_parse(text, self.tools)
+        self.assertEqual(
+            [(c.name, c.parameters) for c in result.calls], [("ping", "{}")]
+        )
+        self._assert_matches_non_streaming(text)
+
+    # ==================== Calls that must be dropped ====================
+
+    def test_streaming_rejected_calls_keep_trailing_text(self):
+        """An unknown tool name, or a non-``function`` call type, is dropped.
+
+        Both are dropped by one-shot parsing, so streaming must drop them too --
+        without leaking the raw markup as assistant content and without eating
+        the prose that follows the tool block.
+        """
+        unknown = BOT + "\n" + _call("get_wether", _param("city", "SF")) + EOT + "\nhmm"
+        self.assertEqual(self._assert_matches_non_streaming(unknown), [])
+        self.assertEqual(self._stream(unknown)[0], "\nhmm")
+
+        bad_type = (
+            BOT
+            + "\n"
+            + f'{CALL_BEGIN}custom{SEP}<steptml:invoke name="get_weather">'
+            + _param("city", "SF")
+            + f"</steptml:invoke>{CALL_END}\n"
+            + EOT
+            + "\ntail"
+        )
+        self.assertEqual(self._assert_matches_non_streaming(bad_type), [])
+        self.assertEqual(self._stream(bad_type)[0], "\ntail")
+
+    def test_truncated_tool_block_is_markup_not_content(self):
+        """A block cut short by the token limit must not be echoed as content.
+
+        One-shot parsing returned the whole raw text -- ``<｜tool_calls_begin｜>``,
+        ``<steptml:invoke ...>`` and all -- as assistant content whenever the end
+        token was missing, and dropped the calls that had completed before the
+        cut. Streaming keeps the completed call and closes its arguments, since a
+        name already sent to the client cannot be taken back.
+        """
+        text = (
+            "Let me check.\n"
+            + BOT
+            + "\n"
+            + _call("get_weather", _param("city", "SF"))
+            + f'{CALL_BEGIN}function{SEP}<steptml:invoke name="get_ti'
+        )
+        result = Step3Detector().detect_and_parse(text, self.tools)
+        self._assert_no_markup(result.normal_text or "", "non-streaming")
+        self.assertEqual(result.normal_text, "Let me check.\n")
+        self.assertEqual(
+            [(c.name, c.parameters) for c in result.calls],
+            [("get_weather", '{"city": "SF"}')],
+        )
+
+        for chunk_size in CHUNK_SIZES:
+            with self.subTest(chunk_size=chunk_size):
+                normal_text, calls = self._stream(text, chunk_size)
+                self._assert_no_markup(normal_text, f"chunk_size={chunk_size}")
+                self.assertEqual(normal_text, "Let me check.\n")
+                self.assertEqual(calls, [("get_weather", '{"city": "SF"}')])
+
+    def test_streaming_releases_text_that_looked_like_a_tool_marker(self):
+        """Text ending in the first characters of the begin token is content.
+
+        Such a tail is held back in case the marker completes; once the stream is
+        over it cannot, so ``finish()`` has to release it instead of swallowing
+        it.
+        """
+        text = "The price is 10<｜"
+        for chunk_size in CHUNK_SIZES:
+            with self.subTest(chunk_size=chunk_size):
+                self.assertEqual(self._stream(text, chunk_size), (text, []))
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
## Motivation

`Step3Detector.parse_streaming_increment()` performed one action per increment and deferred whatever was left to the next one. The last increment of a stream has no successor, and `stream_interval > 1` or speculative decoding routinely delivers several protocol elements at once, so:

- an increment carrying the preamble, a complete call and the trailing prose emitted only the preamble and **dropped the tool call entirely**;
- parameters were collected by scanning the whole buffer, so a second complete call in the same increment donated its parameters to the first one and was then skipped: `get_weather{"city": "SF", "tz": "UTC"}` instead of two calls;
- prose after the tool block was lost when the whole answer arrived in one increment but kept at smaller chunk sizes, i.e. the same answer produced different content depending on `stream_interval`.

Three further problems in the same detector:

- a call with no parameters streamed nothing and therefore never received its closing brace, leaving `arguments` as `""`, which clients cannot parse (one-shot parsing returns `{}` for the same call);
- `invoke_regex` required a non-empty invoke body, so a parameter-less `<steptml:invoke name="ping"></steptml:invoke>` was silently dropped by `detect_and_parse`;
- `detect_and_parse` returned the raw text as assistant content whenever the end token was missing, so a block cut short by the token limit echoed `<｜tool_calls_begin｜> ... <steptml:invoke ...>` to the user and discarded the calls that had completed before the cut;
- text held back because it looked like the beginning of `<｜tool_calls_begin｜>` was never released, since `finish()` was not implemented for this detector.

The streaming part of this was reported in #31915 (`step3_detector.py:264,318`); the issue author listed the three items they intend to fix themselves, and this one is not among them.

## Modifications

`python/sglang/srt/function_call/step3_detector.py` only:

- `parse_streaming_increment()` now drains the buffer in a loop over four states (after the block / before the block / between calls / inside a call), so a single increment can yield preamble, several calls and trailing prose at once. `_parse_partial_tool_call()` returns whether the buffer advanced, which is what lets the loop terminate and keeps it from silently degrading back to one action per increment.
- Parameters are scanned within `_current_call_segment()` — bounded by this call's `<｜tool_call_end｜>` or `</steptml:invoke>` — instead of the whole buffer, so a following call cannot donate its parameters.
- The closing brace is `"}"` if something was streamed for this call and `"{}"` if nothing was, so `arguments` is always valid JSON.
- `invoke_regex` accepts an empty invoke body.
- An unterminated block is treated as markup: `detect_and_parse()` returns only the text before the block, still parses the calls that completed, and logs a warning.
- `finish()` releases text that was held back as a possible marker, drops an unfinished call as markup, and closes the JSON of a call whose name has already been streamed.
- Malformed calls (no type separator, unsupported type, unknown function name) are skipped with a warning instead of stalling the loop.

Streaming cannot retract a tool name it has already sent, so for a generation cut off mid-call the streamed calls still legitimately differ from one-shot parsing; `finish()` closes the JSON so that `arguments` stays parsable in that case.

## Accuracy Test

Not applicable: no changes to model outputs or sampling.

## Benchmarking and Profiling

Not applicable: the parsing work per increment is unchanged; the loop only replaces "return and wait for the next increment" with "continue on the same buffer".

## Checklist

- New CPU-only tests in `test/registered/unit/function_call/test_step3_detector_streaming.py` (8 cases). Each one replays the same model output at chunk sizes whole/16/8/4/1 and asserts that the content contains no markup, that content and calls are identical across chunk sizes, that they match `detect_and_parse`, and that every `arguments` value is valid JSON. All 8 fail before this change and pass after it.
- `test/registered/unit/function_call/` goes from 464 to 472 passed, no failures.
- `black` and `isort` clean.

## Note on overlapping PRs

#31547 and #30253 touch this file on an older base. This change does not modify `param_regex` (#31547) or the signature of `parse_arguments()` (#30253), so there is no semantic overlap, but there will be textual conflicts. Happy to rebase on top of either if they land first.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31875991430](https://github.com/sgl-project/sglang/actions/runs/31875991430)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31875991122](https://github.com/sgl-project/sglang/actions/runs/31875991122)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->