### PR TITLE
feat: support return_logprob under DSPARK speculative decoding

### DIFF
--- a/python/sglang/srt/layers/logprob_processor.py
+++ b/python/sglang/srt/layers/logprob_processor.py
@@ -413,6 +413,28 @@ def compute_spec_v2_logprobs(
         )
 
 
+def compute_spec_v2_chain_logprobs(batch, logits_output, out_tokens: torch.Tensor):
+    """Compute logprobs for a linear (chain) verify block.
+
+    Chain verify (DFLASH / DSPARK) emits one output token per verify row in
+    order, so row j of ``next_token_logits`` is the distribution
+    ``out_tokens[:, j]`` came from and the tree accept-index gather reduces to
+    identity. Rows past the request's commit length carry unemitted drafts;
+    downstream slices them off by accept_lens.
+    """
+    bs, chain_len = out_tokens.shape
+    output_indices = torch.arange(
+        bs * chain_len, dtype=torch.int64, device=out_tokens.device
+    ).view(bs, chain_len)
+    compute_spec_v2_logprobs(
+        batch,
+        logits_output,
+        out_tokens.reshape(-1),
+        output_indices,
+        chain_len - 1,
+    )
+
+
 def _deterministic_inference_enabled() -> bool:
     """True when serving with --enable-deterministic-inference.
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2503,11 +2503,7 @@ class Scheduler(
         self._maybe_namespace_elastic_radix_cache(req)
 
         if self.spec_algorithm.is_dflash_family():
-            error_msg = (
-                "DSpark speculative decoding does not support return_logprob yet."
-                if self.spec_algorithm.is_dspark() and req.return_logprob
-                else validate_dflash_request(req, self.enable_overlap)
-            )
+            error_msg = validate_dflash_request(req, self.enable_overlap)
             if error_msg is not None:
                 req.set_finish_with_abort(error_msg)
                 self.init_req_max_new_tokens(req)

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -17,7 +17,7 @@ from sglang.srt.configs.hybrid_arch import mambaish_config
 from sglang.srt.distributed import get_tp_group
 from sglang.srt.distributed.parallel_state_wrapper import ParallelState
 from sglang.srt.environ import envs
-from sglang.srt.layers.logprob_processor import compute_spec_v2_logprobs
+from sglang.srt.layers.logprob_processor import compute_spec_v2_chain_logprobs
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
@@ -1897,16 +1897,7 @@ class DFlashWorkerV2(BaseSpecWorker):
             new_seq_lens = None
 
         if batch.return_logprob:
-            output_indices = torch.arange(
-                bs * block_size, dtype=torch.int64, device=device
-            ).view(bs, block_size)
-            compute_spec_v2_logprobs(
-                batch,
-                logits_output,
-                out_tokens.reshape(-1),
-                output_indices,
-                block_size - 1,
-            )
+            compute_spec_v2_chain_logprobs(batch, logits_output, out_tokens)
 
         if self._need_mamba_verify_commit:
             assert seq_lens_pre_verify is not None

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -11,6 +11,7 @@ from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.env_gate import (
 from sglang.srt.configs.hybrid_arch import mambaish_config
 from sglang.srt.distributed.parallel_state_wrapper import ParallelState
 from sglang.srt.environ import envs
+from sglang.srt.layers.logprob_processor import compute_spec_v2_chain_logprobs
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
@@ -411,11 +412,6 @@ class DSparkWorkerV2(BaseSpecWorker):
         on_publish=None,
         grammar_barrier=None,
     ) -> GenerationBatchResult:
-        if getattr(batch, "return_logprob", False):
-            raise ValueError(
-                "DSpark speculative decoding does not support return_logprob yet."
-            )
-
         if batch.forward_mode.is_extend() or batch.is_extend_in_batch:
             self._verify_planner.note_non_decode_step()
             self._observers.note_prefill_step()
@@ -708,6 +704,9 @@ class DSparkWorkerV2(BaseSpecWorker):
             prefix_lens=prefix_lens,
             draft_tokens=draft_tokens,
         )
+        if batch.return_logprob:
+            compute_spec_v2_chain_logprobs(batch, logits_output, accept.out_tokens)
+
         if on_publish is not None:
             if confidence is not None:
                 on_publish(accept.new_seq_lens, confidence=confidence)

--- a/test/registered/core/test_basic_sanity_dspark.py
+++ b/test/registered/core/test_basic_sanity_dspark.py
@@ -8,7 +8,7 @@ from sglang.test.kits.basic_scheduler_stress_kit import BasicSchedulerStressMixi
 from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
 from sglang.test.kits.fwd_occupancy_kit import FwdOccupancyMixin
 from sglang.test.kits.json_constrained_kit import JSONConstrainedMixin
-from sglang.test.kits.spec_server_kits import SpecGrammarKit
+from sglang.test.kits.spec_server_kits import SpecGrammarKit, SpecLogprobKit
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
@@ -16,7 +16,7 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
-register_cuda_ci(est_time=180, stage="base-b", runner_config="1-gpu-large")
+register_cuda_ci(est_time=300, stage="base-b", runner_config="1-gpu-large")
 
 TARGET_MODEL = "Qwen/Qwen3-14B"
 DRAFT_MODEL = "deepseek-ai/dspark_qwen3_14b_block7"
@@ -38,6 +38,7 @@ class TestBasicSanityDSpark(
     GSM8KMixin,
     JSONConstrainedMixin,
     SpecGrammarKit,
+    SpecLogprobKit,
     CustomTestCase,
 ):
     served_model_name = TARGET_MODEL
@@ -87,10 +88,6 @@ class TestBasicSanityDSpark(
                 "SGLANG_RAGGED_VERIFY_MODE": "compact",
             },
         )
-
-    @unittest.skip("DSPARK rejects return_logprob at admission")
-    def test_grammar_logprob_count_matches_completion_tokens(self):
-        pass
 
     @classmethod
     def tearDownClass(cls):

--- a/test/registered/unit/layers/test_spec_chain_logprobs.py
+++ b/test/registered/unit/layers/test_spec_chain_logprobs.py
@@ -1,0 +1,81 @@
+"""Per-request logprob params must expand in step with the chain row layout.
+
+compute_spec_v2_logprobs expands top_logprobs_nums / token_ids_logprobs by
+repeating each request's entry ``max_accept`` times, and the result processor
+reads the resulting lists back at flat index ``i * chain_len + j``. Chain verify
+(DFLASH / DSPARK) sets ``max_accept = chain_len``, so any drift between that
+expansion and the row layout silently pairs one request's top-k / probe ids
+with another request's distribution.
+
+The server-level kits do not close this gap: SpecLogprobKit's decode-vs-prefill
+comparison sends one request at a time (uniform params), and its ragged
+token_ids_logprob case only asserts the server does not crash. Heterogeneous
+params in a single batch are checked here.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.layers.logprob_processor import compute_spec_v2_chain_logprobs
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+BS = 3
+CHAIN_LEN = 4
+VOCAB = 17
+# Heterogeneous per-request params; uniform ones hide the misalignment.
+TOP_LOGPROBS_NUMS = [2, 0, 3]
+TOKEN_IDS_LOGPROBS = [[1, 5], None, [0, 2, 9]]
+
+
+class TestSpecChainLogprobs(CustomTestCase):
+    def test_top_and_token_ids_lists_are_row_major(self):
+        torch.manual_seed(0)
+        logits = torch.randn(BS * CHAIN_LEN, VOCAB)
+        out_tokens = torch.randint(0, VOCAB, (BS, CHAIN_LEN), dtype=torch.int64)
+        batch = SimpleNamespace(
+            seq_lens=torch.arange(BS),
+            sampling_info=SimpleNamespace(is_all_greedy=True, temperatures=None),
+            top_logprobs_nums=TOP_LOGPROBS_NUMS,
+            token_ids_logprobs=TOKEN_IDS_LOGPROBS,
+        )
+        logits_output = SimpleNamespace(next_token_logits=logits)
+
+        compute_spec_v2_chain_logprobs(batch, logits_output, out_tokens)
+
+        reference = torch.nn.functional.log_softmax(logits, dim=-1)
+        self.assertEqual(len(logits_output.next_token_top_logprobs_val), BS * CHAIN_LEN)
+        self.assertEqual(
+            len(logits_output.next_token_token_ids_logprobs_val), BS * CHAIN_LEN
+        )
+        for i in range(BS):
+            for j in range(CHAIN_LEN):
+                flat = i * CHAIN_LEN + j
+                top_idx = logits_output.next_token_top_logprobs_idx[flat].tolist()
+                expected_top = (
+                    reference[flat].topk(TOP_LOGPROBS_NUMS[i]).indices.tolist()
+                )
+                self.assertEqual(top_idx, expected_top, msg=f"req={i} pos={j}")
+
+                probe_ids = TOKEN_IDS_LOGPROBS[i]
+                got_ids = logits_output.next_token_token_ids_logprobs_idx[flat]
+                got_vals = logits_output.next_token_token_ids_logprobs_val[flat]
+                if probe_ids is None:
+                    self.assertEqual(got_ids, [], msg=f"req={i} pos={j}")
+                    continue
+                self.assertEqual(got_ids, probe_ids, msg=f"req={i} pos={j}")
+                for k, tid in enumerate(probe_ids):
+                    self.assertAlmostEqual(
+                        got_vals[k].item(),
+                        reference[flat, tid].item(),
+                        places=5,
+                        msg=f"req={i} pos={j} tid={tid}",
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`return_logprob` is rejected under DSPARK, both at admission in the scheduler and again at the top of `DSparkWorkerV2.forward_batch_speculative_generation`.

That rejection is scope, not a technical blocker. #33459 added logprob support for DFLASH: it dropped the `return_logprob` check from `validate_dflash_request` (which covered the whole dflash family) and, because only the DFLASH path had been validated, added a DSPARK-only guard in the scheduler to keep DSPARK where it was. The `raise` inside the DSPARK worker predates that and dates back to the original DSPARK PR (#30261).

The work #33459 did carries over as-is. DFLASH and DSPARK both verify a linear chain, so row `j` of the verify block is the distribution `out_tokens[:, j]` came from, and the tree accept-index gather that `compute_spec_v2_logprobs` expects degenerates to `arange`. DSPARK's `AcceptOuts.out_tokens` has the same `(bs, chain_len)` shape and the same semantics as DFLASH's — rows past the commit length carry unemitted drafts and are sliced off downstream by the accept lengths.

## Modifications

- Extract the chain mapping DFLASH had inline into `compute_spec_v2_chain_logprobs(batch, logits_output, out_tokens)` in `logprob_processor.py`, and call it from both `DFlashWorkerV2` and `DSparkWorkerV2`. DFLASH behavior is unchanged.
- Drop the two DSPARK guards: the `raise ValueError` in the worker, and the scheduler's admission branch (which now falls through to the shared `validate_dflash_request`).
- Mix `SpecLogprobKit` into `TestBasicSanityDSpark` and remove the `@unittest.skip` that stood in for it. Bumped `est_time` 180 → 300.
- Add `test/registered/unit/layers/test_spec_chain_logprobs.py`. The server kits leave one gap: `test_logprob_decode_match_prefill` sends one request at a time, so every request in a batch has the same `top_logprobs_num`, and `test_token_ids_logprob_ragged` only asserts the server does not 500. Nothing checks that heterogeneous per-request logprob params expand in step with the chain row layout — a drift there would silently pair one request's top-k with another request's distribution. The unit test covers that on CPU in ~10s.

## Accuracy Tests

On 1x H200 (`fa3` target + draft backend, Qwen3-14B + `dspark_qwen3_14b_block7`, `block_size=7` / 8 draft tokens, overlap scheduling on, accept length 2.9–3.5):

**DSPARK vs. no-spec baseline.** Same prompt set through both servers, dumping output token ids, per-token logprobs, top-k lists and token-ids logprobs. Cases were 5 x 64-token completions with per-request `top_logprobs_num` of `[5, 0, 3, 5, 1]` and probe id lists of varying length, plus `max_new_tokens` of 1, 2, 3, 5, 6, 7, 8 and 13 so completions end mid-chain and the trailing unemitted draft rows have to be sliced off. The two dumps are byte-identical:

```
$ cmp probe_dspark.json probe_baseline.json
(no output)

DSPARK spec vs no-spec baseline
  worst max|d| = 0.0000; cases with token divergence = 0
```

The decode-vs-prefill self-consistency tables for the two servers also match cell for cell (worst `max|d|` 0.1213, 8 top-1 ties flipped), i.e. the residual is the usual bf16 gap between the decode and prefill paths and is present in the baseline too.

**Test suites.**

- `test_basic_sanity_dspark.py -k logprob` → 6 passed (`test_logprob_decode_match_prefill` reports `max_diff=0.0873 / 0.0792` against a 0.5 threshold).
- `test_basic_sanity_dspark.py` (full) → 28 passed, 1 failed. The failure is `test_basic_math`, which reproduces byte-for-byte on unmodified `main`: Qwen3-14B enters reasoning mode and gets truncated by `max_new_tokens` before emitting `391`. Pre-existing, unrelated to this change.
- `test_dflash.py::TestDFlashServerBase` and `::TestDFlashServerOverlap` `-k logprob` → 12 passed. Regression check for the helper extraction.
- `test_spec_chain_logprobs.py` → 1 passed. Also checked it fails when the row layout is transposed against the param expansion, so it does guard what it claims to.

## Speed Tests and Profiling

No change on the non-logprob path — `compute_spec_v2_chain_logprobs` only runs when `batch.return_logprob` is set, and the DFLASH call site is a straight move of existing code.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31879765400](https://github.com/sgl-project/sglang/actions/runs/31879765400)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31879765275](https://github.com/sgl-project/sglang/actions/runs/31879765275)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->