### PR TITLE
[Diffusion] Fix H3 swap PEFT SwiGLU lora_B halves when loading FFN Lora

### DIFF
--- a/python/sglang/multimodal_gen/runtime/pipelines_core/lora_pipeline.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/lora_pipeline.py
@@ -39,6 +39,22 @@ os.environ["TOKENIZERS_PARALLELISM"] = "false"
 logger = init_logger(__name__)
 
 
+def _swap_peft_swiglu_fc1_lora_b(
+    source_name: str, target_name: str, weight: torch.Tensor
+) -> torch.Tensor:
+    # Only the PEFT -> native H3 FFN rewrite: ff.net.0.proj [value; gate]
+    # onto mlp.fc1 [gate; value]. Native fused mlp.fc1 and other models'
+    # ff.net.0.proj (e.g. Flux) must not match.
+    if (
+        weight.dim() != 2
+        or ".ff.net.0.proj.lora_B" not in source_name
+        or not target_name.endswith(".mlp.fc1.lora_B")
+    ):
+        return weight
+    value, gate = weight.chunk(2, dim=0)
+    return torch.cat([gate, value], dim=0)
+
+
 class LoRAPipeline(ComposedPipelineBase):
     """
     Pipeline that supports injecting LoRA adapters into the diffusion transformer.
@@ -775,6 +791,7 @@ class LoRAPipeline(ComposedPipelineBase):
                 else:
                     continue
 
+            weight = _swap_peft_swiglu_fc1_lora_b(name, target_name, weight)
             if target_name in self.lora_adapters[lora_nickname]:
                 raise ValueError(
                     f"Dit target weight name {target_name} already exists in lora_adapters[{lora_nickname}]"


### PR DESCRIPTION
## Motivation

MiniMax-H3 fuses SwiGLU `gate` / `up` into one `(28672, 5376)` matrix. The two official layouts store that fused tensor with opposite row order:
- diffusers / LightX2V: `ff.net.0.proj` = `[up; gate]`
- sglang native: `mlp.fc1` = `[gate; up]`

Loading a LightX2V LoRA already renames `ff.net.0.proj` → `mlp.fc1`, but does not swap `lora_B` rows. Shapes match and nothing errors, so the FFN adapter is applied with the two halves reversed. Attention LoRA is unaffected.

The two layouts are defined by the `forward` implementations:

diffusers [`SwiGLU`](https://github.com/huggingface/diffusers/blob/v0.37.0/src/diffusers/models/activations.py#L143-L146) (`ff.net.0.proj`):

```python
hidden_states, gate = hidden_states.chunk(2, dim=-1)
return hidden_states * self.activation(gate)   # [up; gate]
```

sglang [`_silu_mul`](https://github.com/sgl-project/sglang/blob/main/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py#L271-L272) (`mlp.fc1`):

```python
gate, up = hidden.chunk(2, dim=-1)
return F.silu(gate) * up                       # [gate; up]
```

The MiniMax-H3 repo ships the same DiT twice, which confirms the row-order mismatch is in the official weights, not a sglang-only convention:
- `FL2VA/transformer/` → `blocks.N.mlp.fc1.weight` (what sglang loads)
- `transformer/` → `transformer_blocks.N.ff.net.0.proj.weight` (what LightX2V trains against)

| tensor | as-is | after swapping the two 14336-row halves |
|---|---|---|
| fused FFN `fc1` / `ff.net.0.proj` (52 / 52 blocks) | 0 exact | **52 / 52 exact** |
| `fc2` / `ff.net.2` | exact | n/a |

They are the same model: native fused `qkv_proj` is bit-identical to diffusers `to_q/to_k/to_v` after the documented per-head `[q,k,v]` pack.

LightX2V's own two exports of the same adapter repeat the same signature:

| | as-is | swapped |
|---|---|---|
| `fc1` `lora_A` (50 / 50) | exact | n/a |
| `fc1` `lora_B` (50 / 50) | 0 exact | **50 / 50 exact** |
| `fc2` `lora_B` (50 / 50) | exact | n/a |

`lora_A` lives on the input side, so it does not need a row swap.

## Modifications

Swap the two 14336-row halves of `lora_B` only on the `ff.net.0.proj.lora_B` → `mlp.fc1.lora_B` path in `load_lora_adapter`.
Leave `lora_A` and `fc2` unchanged. Native fused `mlp.fc1` keys and other models' `ff.net.0.proj` (e.g. Flux) do not match both sides of the guard, so they are not rewritten.

## Accuracy Tests

Prompt: `A cat walking on a sunny beach, gentle waves.` Config: MiniMax-H3 FL2VA + `lightx2v/Minimax-h3-Turbo`
(`minimax_h3_fl2v_turbo_4step_v0.1.safetensors`), 1344×768 / 5 s, `seed=1101`, `lora_scale=0.0625`, `flow_shift=12`, `audio_flow_shift=3`, one H200. Same LoRA, 4-step and 8-step, before vs after this change.

https://github.com/user-attachments/assets/37ee7943-0d37-462a-96c3-fc2be88fca26



Before the fix the fur is smeared; after the fix hair, face, and eyes resolve. Audio RMS also rises (4-step 0.0063 → 0.0097, 8-step 0.0067 → 0.0129). Latency and peak memory are unchanged.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31880164198](https://github.com/sgl-project/sglang/actions/runs/31880164198)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31880164099](https://github.com/sgl-project/sglang/actions/runs/31880164099)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->