### PR TITLE
[NPU]fix(dspark): preserve parity in folded NPU paths

### DIFF
--- a/python/sglang/kernels/ops/speculative/dspark/dspark_draft_model.py
+++ b/python/sglang/kernels/ops/speculative/dspark/dspark_draft_model.py
@@ -23,19 +23,27 @@ class SampleStepTokens:
         temperatures: torch.Tensor,
         greedy_mask: torch.Tensor,
         exp_noise: torch.Tensor,
+        corrected_logits_out: Optional[torch.Tensor] = None,
+        write_corrected_logits: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        if step_logits.is_cuda:
+        # The Ascend Triton backend accepts PrivateUse1/NPU tensors even
+        # though PyTorch's ``Tensor.is_cuda`` is false for them.
+        if step_logits.is_cuda or step_logits.device.type == "npu":
             return cls.triton(
                 step_logits=step_logits,
                 temperatures=temperatures,
                 greedy_mask=greedy_mask,
                 exp_noise=exp_noise,
+                corrected_logits_out=corrected_logits_out,
+                write_corrected_logits=write_corrected_logits,
             )
         return cls.torch(
             step_logits=step_logits,
             temperatures=temperatures,
             greedy_mask=greedy_mask,
             exp_noise=exp_noise,
+            corrected_logits_out=corrected_logits_out,
+            write_corrected_logits=write_corrected_logits,
         )
 
     @classmethod
@@ -46,12 +54,16 @@ class SampleStepTokens:
         temperatures: torch.Tensor,
         greedy_mask: torch.Tensor,
         exp_noise: torch.Tensor,
+        corrected_logits_out: Optional[torch.Tensor] = None,
+        write_corrected_logits: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         return sample_step_tokens(
             step_logits=step_logits,
             temperatures=temperatures,
             greedy_mask=greedy_mask,
             exp_noise=exp_noise,
+            corrected_logits_out=corrected_logits_out,
+            write_corrected_logits=write_corrected_logits,
         )
 
     @classmethod
@@ -62,12 +74,16 @@ class SampleStepTokens:
         temperatures: torch.Tensor,
         greedy_mask: torch.Tensor,
         exp_noise: torch.Tensor,
+        corrected_logits_out: Optional[torch.Tensor] = None,
+        write_corrected_logits: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         return sample_step_tokens_triton(
             step_logits=step_logits,
             temperatures=temperatures,
             greedy_mask=greedy_mask,
             exp_noise=exp_noise,
+            corrected_logits_out=corrected_logits_out,
+            write_corrected_logits=write_corrected_logits,
         )
 
 
@@ -77,10 +93,28 @@ def sample_step_tokens(
     temperatures: torch.Tensor,
     greedy_mask: torch.Tensor,
     exp_noise: torch.Tensor,
+    corrected_logits_out: Optional[torch.Tensor] = None,
+    write_corrected_logits: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
-    probs = torch.softmax(step_logits.float() / temperatures[:, None], dim=-1)
+    # Exponential-race sampling can be evaluated in log space:
+    #
+    #   argmax(softmax(logits / temperature) / Exp(1))
+    #     == argmax(logits - temperature * log(Exp(1))).
+    #
+    # Besides avoiding a full softmax, selecting unit noise for greedy rows
+    # leaves their keys equal to the original logits.  This is important for
+    # proposal parity: softmax can round two distinct, nearly tied logits to
+    # the same probability and change argmax's tie break.
+    if corrected_logits_out is not None:
+        if write_corrected_logits is None:
+            raise ValueError(
+                "write_corrected_logits is required with corrected_logits_out"
+            )
+        if bool(write_corrected_logits.item()):
+            corrected_logits_out.copy_(step_logits)
     noise = torch.where(greedy_mask[:, None], 1.0, exp_noise)
-    return probs.div_(noise).argmax(dim=-1)
+    keys = step_logits.float() - temperatures[:, None] * noise.log()
+    return keys.argmax(dim=-1)
 
 
 @triton.jit
@@ -89,13 +123,17 @@ def _online_partial_kernel(
     temperatures_ptr,
     greedy_mask_ptr,
     exp_noise_ptr,
-    tile_max_ptr,
     partial_key_ptr,
     partial_idx_ptr,
+    corrected_logits_out_ptr,
+    write_corrected_logits_ptr,
     V,
     stride_row,
+    corrected_stride_row,
     n_tiles,
     BLOCK_V: tl.constexpr,
+    STORE_CORRECTED: tl.constexpr,
+    ASCEND_RUNTIME_BRANCH: tl.constexpr,
 ):
     row = tl.program_id(0)
     tile = tl.program_id(1)
@@ -104,24 +142,45 @@ def _online_partial_kernel(
     logits = tl.load(
         logits_ptr + row * stride_row + offs, mask=mask, other=float("-inf")
     ).to(tl.float32)
-    temperature = tl.load(temperatures_ptr + row)
-    s = logits / temperature
-    tile_max = tl.max(s, axis=0)
+    if STORE_CORRECTED:
+        write_corrected = tl.load(write_corrected_logits_ptr) != 0
+        if ASCEND_RUNTIME_BRANCH:
+            if write_corrected:
+                tl.store(
+                    corrected_logits_out_ptr + row * corrected_stride_row + offs,
+                    logits,
+                    mask=mask,
+                )
+        else:
+            tl.store(
+                corrected_logits_out_ptr + row * corrected_stride_row + offs,
+                logits,
+                mask=mask & write_corrected,
+            )
     greedy = tl.load(greedy_mask_ptr + row) != 0
-    noise = tl.load(exp_noise_ptr + row * V + offs, mask=mask, other=1.0)
-    denom = tl.where(greedy, 1.0, noise)
-    key = tl.exp(s - tile_max) / denom
-    key = tl.where(mask, key, -1.0)
+    if ASCEND_RUNTIME_BRANCH:
+        if greedy:
+            # Avoid a full-vocabulary noise read and logarithm for the
+            # overwhelmingly common greedy request while keeping one graph.
+            key = logits
+        else:
+            temperature = tl.load(temperatures_ptr + row)
+            noise = tl.load(exp_noise_ptr + row * V + offs, mask=mask, other=1.0)
+            key = logits - temperature * tl.log(noise)
+    else:
+        temperature = tl.load(temperatures_ptr + row)
+        noise = tl.load(exp_noise_ptr + row * V + offs, mask=mask, other=1.0)
+        noise = tl.where(greedy, 1.0, noise)
+        key = logits - temperature * tl.log(noise)
+    key = tl.where(mask, key, float("-inf"))
     tile_best = tl.max(key, axis=0)
     idx = tl.where(key == tile_best, offs, _IDX_SENTINEL)
-    tl.store(tile_max_ptr + row * n_tiles + tile, tile_max)
     tl.store(partial_key_ptr + row * n_tiles + tile, tile_best)
     tl.store(partial_idx_ptr + row * n_tiles + tile, tl.min(idx, axis=0))
 
 
 @triton.jit
 def _online_combine_kernel(
-    tile_max_ptr,
     partial_key_ptr,
     partial_idx_ptr,
     next_tokens_ptr,
@@ -131,18 +190,16 @@ def _online_combine_kernel(
     row = tl.program_id(0)
     offs = tl.arange(0, BLOCK_TILES)
     mask = offs < n_tiles
-    tile_max = tl.load(
-        tile_max_ptr + row * n_tiles + offs, mask=mask, other=float("-inf")
+    keys = tl.load(
+        partial_key_ptr + row * n_tiles + offs,
+        mask=mask,
+        other=float("-inf"),
     )
-    keys = tl.load(partial_key_ptr + row * n_tiles + offs, mask=mask, other=-1.0)
     idxs = tl.load(
         partial_idx_ptr + row * n_tiles + offs, mask=mask, other=_IDX_SENTINEL
     )
-    global_max = tl.max(tile_max, axis=0)
-    rescaled = keys * tl.exp(tile_max - global_max)
-    rescaled = tl.where(mask, rescaled, -1.0)
-    best = tl.max(rescaled, axis=0)
-    cand = tl.where(rescaled == best, idxs, _IDX_SENTINEL)
+    best = tl.max(keys, axis=0)
+    cand = tl.where(keys == best, idxs, _IDX_SENTINEL)
     next_token = tl.min(cand, axis=0)
     # Degenerate rows (e.g. all -inf logits) leave cand all-sentinel; clamp to 0
     # so a valid token id is emitted instead of an out-of-range 2147483647.
@@ -156,6 +213,8 @@ def sample_step_tokens_triton(
     temperatures: torch.Tensor,
     greedy_mask: torch.Tensor,
     exp_noise: torch.Tensor,
+    corrected_logits_out: Optional[torch.Tensor] = None,
+    write_corrected_logits: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     bs, V = step_logits.shape
     device = step_logits.device
@@ -165,10 +224,24 @@ def sample_step_tokens_triton(
     greedy_mask = greedy_mask.to(torch.int32).contiguous()
     exp_noise = exp_noise.to(torch.float32).contiguous()
 
+    store_corrected = corrected_logits_out is not None
+    if store_corrected:
+        if write_corrected_logits is None:
+            raise ValueError(
+                "write_corrected_logits is required with corrected_logits_out"
+            )
+        assert corrected_logits_out.shape == step_logits.shape
+        assert corrected_logits_out.stride(1) == 1
+        corrected_stride_row = corrected_logits_out.stride(0)
+    else:
+        # Triton still requires pointer arguments for constexpr-disabled paths.
+        corrected_logits_out = step_logits
+        write_corrected_logits = greedy_mask
+        corrected_stride_row = stride_row
+
     n_tiles = triton.cdiv(V, _BLOCK_V)
     block_tiles = triton.next_power_of_2(n_tiles)
 
-    tile_max = torch.empty((bs, n_tiles), dtype=torch.float32, device=device)
     partial_key = torch.empty((bs, n_tiles), dtype=torch.float32, device=device)
     partial_idx = torch.empty((bs, n_tiles), dtype=torch.int32, device=device)
     next_tokens = torch.empty((bs,), dtype=torch.int64, device=device)
@@ -181,16 +254,19 @@ def sample_step_tokens_triton(
         temperatures,
         greedy_mask,
         exp_noise,
-        tile_max,
         partial_key,
         partial_idx,
+        corrected_logits_out,
+        write_corrected_logits,
         V,
         stride_row,
+        corrected_stride_row,
         n_tiles,
         BLOCK_V=_BLOCK_V,
+        STORE_CORRECTED=store_corrected,
+        ASCEND_RUNTIME_BRANCH=step_logits.device.type == "npu",
     )
     _online_combine_kernel[row_grid](
-        tile_max,
         partial_key,
         partial_idx,
         next_tokens,

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_kda_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_kda_backend.py
@@ -14,6 +14,7 @@ from sgl_kernel_npu.fla.kda_target_verify import kda_target_verify_npu
 from sgl_kernel_npu.fla.solve_tril import solve_tril_npu
 from sgl_kernel_npu.fla.utils import prepare_chunk_indices
 from sgl_kernel_npu.mamba.kda_state_commit import (
+    commit_kda_extended_conv_state,
     move_kda_temporal_snapshot,
     scatter_kda_conv_snapshot,
 )
@@ -630,31 +631,50 @@ class AscendKDAHybridLinearAttnBackend:
                                 src_indices_tensor,
                                 mamba_steps_to_track,
                             )
-                    else:
-                        track_mask = mamba_steps_to_track >= 0
-                        track_indices = mamba_track_indices[track_mask]
-                        if track_indices.numel() > 0:
-                            conv_states[:, track_indices] = conv_states[
-                                :, dst_indices_tensor[track_mask]
-                            ]
-
                 if not has_conv_snapshots:
-                    if dst_indices_tensor.numel() > 0:
-                        conv_state_rollback(
-                            conv_states,
-                            dst_indices_tensor,
-                            last_steps,
-                            draft_token_num,
-                        )
-
+                    # PR #35021 keeps all verify-token conv states in one
+                    # extended [window, channel] buffer. Commit tracking slots
+                    # first because they read the unmodified primary window;
+                    # then commit the primary slot in place. Both use #34944's
+                    # one-program-per-request/layer strategy and retain
+                    # conv_state_rollback only as a compatibility fallback.
                     if (
                         mamba_track_indices is not None
                         and mamba_track_indices.numel() > 0
                     ):
-                        conv_state_rollback(
+                        track_committed = commit_kda_extended_conv_state(
                             conv_states,
                             mamba_track_indices,
+                            dst_indices_tensor,
                             mamba_steps_to_track,
+                            draft_token_num,
+                        )
+                        if not track_committed:
+                            track_mask = mamba_steps_to_track >= 0
+                            track_indices = mamba_track_indices[track_mask]
+                            if track_indices.numel() > 0:
+                                conv_states[:, track_indices] = conv_states[
+                                    :, dst_indices_tensor[track_mask]
+                                ]
+                            conv_state_rollback(
+                                conv_states,
+                                mamba_track_indices,
+                                mamba_steps_to_track,
+                                draft_token_num,
+                            )
+
+                    primary_committed = commit_kda_extended_conv_state(
+                        conv_states,
+                        dst_indices_tensor,
+                        dst_indices_tensor,
+                        last_steps,
+                        draft_token_num,
+                    )
+                    if not primary_committed:
+                        conv_state_rollback(
+                            conv_states,
+                            dst_indices_tensor,
+                            last_steps,
                             draft_token_num,
                         )
 

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_kda_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_kda_backend.py
@@ -463,7 +463,6 @@ class AscendKDAAttnBackend(KDAAttnBackend):
             intermediate_states_buffer=intermediate_state,
             intermediate_state_indices=intermediate_indices,
             cache_steps=draft_token_num,
-            lower_bound=None,
             gates_are_preactivated=True,
         )
         if dense_token_indices is None:

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_kda_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_kda_backend.py
@@ -13,13 +13,6 @@ from sgl_kernel_npu.fla.kda_prefill import (
 from sgl_kernel_npu.fla.kda_target_verify import kda_target_verify_npu
 from sgl_kernel_npu.fla.solve_tril import solve_tril_npu
 from sgl_kernel_npu.fla.utils import prepare_chunk_indices
-from sgl_kernel_npu.mamba.causal_conv1d import (
-    causal_conv1d_fn_npu,
-    causal_conv1d_update_npu,
-)
-from sgl_kernel_npu.mamba.causal_conv1d_verify import (
-    causal_conv1d_linear_verify_npu,
-)
 from sgl_kernel_npu.mamba.kda_state_commit import (
     move_kda_temporal_snapshot,
     scatter_kda_conv_snapshot,
@@ -129,17 +122,51 @@ class AscendKDAAttnBackend(KDAAttnBackend):
     The model, scheduler, metadata, and non-operator control flow stay in the
     shared KDA backend. This class contains only the layout and operator
     differences required by Ascend.
+
+    Conv states use the GDN-style [layers, pool, window, channels] layout
+    (transposed from the shared KDA backend's [channels, window]). The
+    speculative window is extended by draft_tokens - 1 so that verify
+    writes all draft token conv states directly into conv_states; after
+    verify, conv_state_rollback reverts unaccepted tokens. This replaces
+    the previous intermediate_conv_window snapshot + scatter scheme.
     """
 
-    supports_speculative_conv_state_snapshots: bool = True
+    supports_speculative_conv_state_snapshots: bool = False
 
     def __init__(self, model_runner):
         super().__init__(model_runner)
-        # The NPU pool is allocated directly as [pool, channels, window].
-        self.conv_states_shape = (
-            model_runner.req_to_token_pool.mamba_pool.mamba_cache.conv[0].shape
+        # The NPU pool is allocated as [layers, pool, window, channels]
+        # (transposed from the shared KDA [channels, window]). Expose the
+        # transposed shape so _init_track_conv_indices reads
+        # conv_states_shape[-1] as the conv window length.
+        conv_pool_shape = model_runner.req_to_token_pool.mamba_pool.mamba_cache.conv[
+            0
+        ].shape
+        self.conv_states_shape = torch.Size(
+            (
+                *conv_pool_shape[:-2],
+                conv_pool_shape[-1],
+                conv_pool_shape[-2],
+            )
         )
         self.kernel_dispatcher.extend_kernel = _AscendKDAExtendKernel()
+
+    def _get_conv_weights_t(
+        self, layer: RadixLinearAttention, dtype: torch.dtype
+    ) -> torch.Tensor:
+        """Transposed conv weights [width, dim], cached on the layer.
+
+        The NPU causal_conv1d CANN op expects weight as [width, dim]
+        (transposed from layer.conv_weights [dim, width]) and requires
+        weight dtype to match the input. KDA keeps conv_weights in FP32
+        while inputs/conv_states are BF16, so the cached FP32 transpose is
+        cast to the caller's dtype here.
+        """
+        w = getattr(layer, "_conv_weights_t", None)
+        if w is None:
+            w = layer.conv_weights.transpose(0, 1).contiguous().to(dtype)
+            layer._conv_weights_t = w
+        return w
 
     def forward_decode(
         self,
@@ -158,13 +185,16 @@ class AscendKDAAttnBackend(KDAAttnBackend):
         query_start_loc = self.forward_metadata.query_start_loc
         cache_indices = self.forward_metadata.mamba_cache_indices
 
-        qkv = causal_conv1d_update_npu(
-            mixed_qkv,
-            conv_states,
-            layer.conv_weights,
-            layer.bias,
-            activation="silu",
-            conv_state_indices=cache_indices,
+        qkv = torch.ops.npu.causal_conv1d(
+            mixed_qkv.contiguous(),
+            self._get_conv_weights_t(layer, mixed_qkv.dtype),
+            conv_states=conv_states,
+            bias=layer.bias,
+            query_start_loc=query_start_loc,
+            cache_indices=cache_indices,
+            activation_mode=1,
+            pad_slot_id=-1,
+            run_mode=1,
         )
 
         if self.kernel_dispatcher.supports_packed_decode:
@@ -249,37 +279,27 @@ class AscendKDAAttnBackend(KDAAttnBackend):
         has_initial_state = forward_batch.extend_prefix_lens > 0
 
         if self.forward_metadata.has_mamba_track_mask:
-            conv_states[self.forward_metadata.conv_states_mask_indices] = mixed_qkv[
-                self.forward_metadata.track_conv_indices
-            ].transpose(-1, -2)
+            mixed_qkv_to_track = mixed_qkv[self.forward_metadata.track_conv_indices]
+            conv_states[self.forward_metadata.conv_states_mask_indices] = (
+                mixed_qkv_to_track
+            )
 
-        splits = [layer.q_dim, layer.k_dim, layer.v_dim]
-        q, k, v = mixed_qkv.transpose(0, 1).split(splits, dim=0)
-        q_conv_weight, k_conv_weight, v_conv_weight = layer.conv_weights.split(
-            splits, dim=0
-        )
-        q_conv_state, k_conv_state, v_conv_state = conv_states.split(splits, dim=-2)
-        if layer.bias is not None:
-            q_bias, k_bias, v_bias = layer.bias.split(splits, dim=0)
-        else:
-            q_bias, k_bias, v_bias = None, None, None
-
-        conv_kwargs = dict(
-            has_initial_state=has_initial_state,
-            cache_indices=cache_indices,
+        kernel_size = layer.conv_weights.shape[-1]
+        conv_states_for_prefill = conv_states[:, -(kernel_size - 1) :, :].contiguous()
+        mixed_qkv = torch.ops.npu.causal_conv1d(
+            mixed_qkv.contiguous(),
+            self._get_conv_weights_t(layer, mixed_qkv.dtype),
+            conv_states=conv_states_for_prefill,
+            bias=layer.bias,
             query_start_loc=query_start_loc,
-            seq_lens_cpu=forward_batch.extend_seq_lens_cpu,
+            cache_indices=cache_indices,
+            has_initial_state=has_initial_state,
+            activation_mode=1,
+            pad_slot_id=-1,
+            run_mode=0,
         )
-        q = self._causal_conv1d_extend(
-            q, q_conv_weight, q_bias, q_conv_state, **conv_kwargs
-        )
-        k = self._causal_conv1d_extend(
-            k, k_conv_weight, k_bias, k_conv_state, **conv_kwargs
-        )
-        v = self._causal_conv1d_extend(
-            v, v_conv_weight, v_bias, v_conv_state, **conv_kwargs
-        )
-
+        conv_states[:, -(kernel_size - 1) :, :] = conv_states_for_prefill
+        q, k, v = mixed_qkv.split([layer.q_dim, layer.k_dim, layer.v_dim], dim=-1)
         q = q.unflatten(-1, (-1, layer.head_q_dim)).unsqueeze(0)
         k = k.unflatten(-1, (-1, layer.head_k_dim)).unsqueeze(0)
         v = v.unflatten(-1, (-1, layer.head_v_dim)).unsqueeze(0)
@@ -312,42 +332,6 @@ class AscendKDAAttnBackend(KDAAttnBackend):
                 forward_batch, h, ssm_states, self.forward_metadata
             )
         return core_attn_out
-
-    def _causal_conv1d_extend(
-        self,
-        x: torch.Tensor,
-        weight: torch.Tensor,
-        bias: Optional[torch.Tensor],
-        state: torch.Tensor,
-        *,
-        has_initial_state: torch.Tensor,
-        cache_indices: torch.Tensor,
-        query_start_loc: torch.Tensor,
-        seq_lens_cpu: torch.Tensor,
-    ) -> torch.Tensor:
-        # The Ascend varlen kernel pads in the weight dtype. K3 keeps its
-        # weights in FP32 and its persistent convolution cache in BF16, so use
-        # a compact FP32 working set for the active rows and cast it back.
-        local_indices = torch.arange(
-            cache_indices.shape[0],
-            device=cache_indices.device,
-            dtype=cache_indices.dtype,
-        )
-        state_work = state.index_select(0, cache_indices.to(torch.int64))
-        state_work = state_work.to(weight.dtype).contiguous()
-        out = causal_conv1d_fn_npu(
-            x.to(weight.dtype),
-            weight,
-            bias,
-            activation="silu",
-            conv_states=state_work,
-            has_initial_state=has_initial_state,
-            cache_indices=local_indices,
-            query_start_loc=query_start_loc,
-            seq_lens_cpu=seq_lens_cpu,
-        )
-        state.index_copy_(0, cache_indices.to(torch.int64), state_work.to(state.dtype))
-        return out.to(x.dtype).transpose(0, 1)
 
     def _prepare_extend_gate_inputs(
         self,
@@ -422,18 +406,32 @@ class AscendKDAAttnBackend(KDAAttnBackend):
             )
 
         intermediate_indices = self.verify_intermediate_state_indices[:batch_size]
-        processed_qkv = causal_conv1d_linear_verify_npu(
-            dense_qkv.transpose(1, 2).contiguous(),
-            cache.conv[0],
-            layer.conv_weights,
-            layer.bias,
-            cache_indices[:batch_size],
-            cache.intermediate_conv_window[0],
-            intermediate_indices,
-            activation="silu",
-            update_persistent_state=False,
+        conv_states = cache.conv[0]
+        num_accepted_tokens = torch.full(
+            (batch_size,),
+            draft_token_num,
+            dtype=torch.int32,
+            device=mixed_qkv.device,
         )
-        processed_qkv = processed_qkv.transpose(1, 2).reshape(num_dense_tokens, -1)
+        dense_query_start_loc = torch.arange(
+            0,
+            num_dense_tokens + 1,
+            step=draft_token_num,
+            dtype=torch.int32,
+            device=mixed_qkv.device,
+        )
+        processed_qkv = torch.ops.npu.causal_conv1d(
+            dense_qkv.reshape(num_dense_tokens, -1).contiguous(),
+            self._get_conv_weights_t(layer, mixed_qkv.dtype),
+            conv_states=conv_states,
+            bias=layer.bias,
+            query_start_loc=dense_query_start_loc,
+            cache_indices=cache_indices[:batch_size],
+            num_accepted_tokens=num_accepted_tokens,
+            activation_mode=1,
+            pad_slot_id=-1,
+            run_mode=1,
+        )
         q, k, v = processed_qkv.split([layer.q_dim, layer.k_dim, layer.v_dim], dim=-1)
         q = q.unflatten(-1, (-1, layer.head_q_dim)).unsqueeze(0)
         k = k.unflatten(-1, (-1, layer.head_k_dim)).unsqueeze(0)

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_kda_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_kda_backend.py
@@ -20,6 +20,10 @@ from sgl_kernel_npu.mamba.causal_conv1d import (
 from sgl_kernel_npu.mamba.causal_conv1d_verify import (
     causal_conv1d_linear_verify_npu,
 )
+from sgl_kernel_npu.mamba.kda_state_commit import (
+    move_kda_temporal_snapshot,
+    scatter_kda_conv_snapshot,
+)
 
 from sglang.kernels.ops.attention.fla.cumsum import chunk_local_cumsum
 from sglang.kernels.ops.attention.fla.kda import chunk_kda_scaled_dot_kkt_fwd
@@ -554,14 +558,21 @@ class AscendKDAHybridLinearAttnBackend:
                 )
                 last_steps = last_correct_step_indices.to(torch.int32)
 
-                move_intermediate_cache_kda(
+                if not move_kda_temporal_snapshot(
                     ssm_states,
                     intermediate_state_cache,
                     dst_indices_tensor,
                     src_indices_tensor,
                     last_steps,
-                    h_block_size=1,
-                )
+                ):
+                    move_intermediate_cache_kda(
+                        ssm_states,
+                        intermediate_state_cache,
+                        dst_indices_tensor,
+                        src_indices_tensor,
+                        last_steps,
+                        h_block_size=1,
+                    )
                 draft_token_num = intermediate_state_cache.shape[2]
                 has_conv_snapshots = getattr(
                     self.linear_attn_backend,
@@ -572,35 +583,56 @@ class AscendKDAHybridLinearAttnBackend:
                     intermediate_conv_window_cache = (
                         mamba_caches.intermediate_conv_window[0]
                     )
-                    speculative_state_scatter_npu(
+                    if not scatter_kda_conv_snapshot(
                         conv_states,
                         intermediate_conv_window_cache,
                         dst_indices_tensor,
                         src_indices_tensor,
                         last_steps,
-                    )
+                    ):
+                        speculative_state_scatter_npu(
+                            conv_states,
+                            intermediate_conv_window_cache,
+                            dst_indices_tensor,
+                            src_indices_tensor,
+                            last_steps,
+                        )
                 if mamba_track_indices is not None:
                     assert mamba_steps_to_track is not None
                     mamba_track_indices = mamba_track_indices.to(torch.int32)
                     mamba_steps_to_track = mamba_steps_to_track.to(torch.int32)
 
-                    move_intermediate_cache_kda(
+                    if not move_kda_temporal_snapshot(
                         ssm_states,
                         intermediate_state_cache,
                         mamba_track_indices,
                         src_indices_tensor,
                         mamba_steps_to_track,
-                        h_block_size=1,
-                    )
+                    ):
+                        move_intermediate_cache_kda(
+                            ssm_states,
+                            intermediate_state_cache,
+                            mamba_track_indices,
+                            src_indices_tensor,
+                            mamba_steps_to_track,
+                            h_block_size=1,
+                        )
 
                     if has_conv_snapshots:
-                        speculative_state_scatter_npu(
+                        if not scatter_kda_conv_snapshot(
                             conv_states,
                             intermediate_conv_window_cache,
                             mamba_track_indices,
                             src_indices_tensor,
                             mamba_steps_to_track,
-                        )
+                        ):
+                            speculative_state_scatter_npu(
+                                conv_states,
+                                intermediate_conv_window_cache,
+                                mamba_track_indices,
+                                src_indices_tensor,
+                                mamba_steps_to_track,
+                            )
                     else:
                         track_mask = mamba_steps_to_track >= 0
                         track_indices = mamba_track_indices[track_mask]

--- a/python/sglang/srt/hardware_backend/npu/memory_pool_npu.py
+++ b/python/sglang/srt/hardware_backend/npu/memory_pool_npu.py
@@ -32,18 +32,19 @@ def _init_npu_conv_state(
     if speculative_num_draft_tokens is not None:
         extra_conv_len = speculative_num_draft_tokens - 1
 
-    # Mamba shapes are (channels, window), while KDA shapes are
-    # (window, channels). NPU kernels consume KDA state as
-    # [layers, pool, channels, window] and other Mamba state as
-    # [layers, pool, window, channels]. KDA keeps the base window fixed;
-    # speculative per-step windows live in the intermediate cache.
+    # Both KDA and Mamba/GDN NPU conv states use the unified
+    # [layers, pool, window, channels] layout. KDA shapes arrive as
+    # (window, channels) while Mamba/GDN shapes arrive as (channels, window);
+    # resolve the correct axis ordering and extend the window by
+    # speculative_num_draft_tokens - 1 so that verify can write all draft
+    # token conv states directly into conv_states (GDN rollback scheme).
     conv_state = [
         torch.zeros(
             size=(
                 conv_state_in.shape[0],
                 conv_state_in.shape[1],
-                conv_shape[1] if is_kda else conv_shape[1] + extra_conv_len,
-                conv_shape[0],
+                (conv_shape[0] if is_kda else conv_shape[1]) + extra_conv_len,
+                conv_shape[1] if is_kda else conv_shape[0],
             ),
             dtype=conv_state_in.dtype,
             device=conv_state_in.device,

--- a/python/sglang/srt/models/deepseek_v4_dspark.py
+++ b/python/sglang/srt/models/deepseek_v4_dspark.py
@@ -486,13 +486,15 @@ class DSparkV4MarkovHead(nn.Module):
         first_prev_tokens: torch.Tensor,
         hidden_states: Optional[torch.Tensor],
         sampler: StepSampler,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        return_corrected_logits: bool = True,
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
         return run_markov_block(
             self,
             base_logits,
             first_prev_tokens=first_prev_tokens,
             hidden_states=hidden_states,
             sampler=sampler,
+            return_corrected_logits=return_corrected_logits,
         )
 
 

--- a/python/sglang/srt/models/dflash.py
+++ b/python/sglang/srt/models/dflash.py
@@ -266,9 +266,15 @@ class DFlashAttention(nn.Module):
 
     def apply_k_rope(self, positions: torch.Tensor, k: torch.Tensor) -> torch.Tensor:
         # Match K shape so RoPE kernel head-count check passes on all backends.
+        original_shape = k.shape
+        if _is_npu and k.ndim == 2:
+            # Ascend's fused_rope_qk_mqa contract is [tokens, heads, dim],
+            # while the KV-only projection naturally produces a flattened 2D
+            # tensor. The regular attention path already uses the 3D contract.
+            k = k.view(k.shape[0], -1, self.head_dim)
         dummy_q = k.new_empty(k.shape)
         _, k = self.rotary_emb(positions, dummy_q, k)
-        return k
+        return k.reshape(original_shape)
 
 
 class DFlashMLP(nn.Module):

--- a/python/sglang/srt/models/dspark.py
+++ b/python/sglang/srt/models/dspark.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from typing import Callable, Iterable, Optional, Tuple
 
 import torch
@@ -8,9 +9,10 @@ import torch.nn.functional as F
 from torch import nn
 
 from sglang.srt.distributed.communication_op import tensor_model_parallel_all_gather
-from sglang.srt.environ import envs
+from sglang.srt.environ import DsparkFoldedSampling, envs
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.dflash import DFlashDraftModel
+from sglang.srt.runtime_context import get_parallel
 from sglang.srt.speculative.dflash_utils import can_dflash_slice_qkv_weight
 from sglang.srt.speculative.dspark_components.dspark_config import (
     parse_dspark_draft_config,
@@ -19,10 +21,24 @@ from sglang.srt.speculative.ragged_verify import (
     RaggedVerifyMode,
     read_ragged_verify_mode,
 )
+from sglang.srt.utils import is_npu
 
 logger = logging.getLogger(__name__)
+_is_npu = is_npu()
+
+if _is_npu:
+    from sgl_kernel_npu.dspark.top1 import select_global_top1_npu
 
 StepSampler = Callable[[torch.Tensor, int], torch.Tensor]
+
+
+@dataclass(frozen=True)
+class _DenseMarkovW2ShardGeometry:
+    tp_size: int
+    org_vocab_start: int
+    org_vocab_end: int
+    num_embeddings_per_partition: int
+    num_embeddings_padded: int
 
 
 def gather_and_crop_vocab(
@@ -39,11 +55,12 @@ def run_markov_block(
     first_prev_tokens: torch.Tensor,
     hidden_states: Optional[torch.Tensor],
     sampler: StepSampler,
-) -> Tuple[torch.Tensor, torch.Tensor]:
+    return_corrected_logits: bool = True,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
     batch_size, proposal_len = base_logits.shape[:2]
     if proposal_len == 0:
         empty = torch.empty(batch_size, 0, dtype=torch.long, device=base_logits.device)
-        return empty, base_logits
+        return empty, base_logits if return_corrected_logits else None
 
     sampled_tokens = []
     corrected_logits = []
@@ -57,11 +74,12 @@ def run_markov_block(
         )
         next_tokens = sampler(step_logits, step_idx)
         sampled_tokens.append(next_tokens)
-        corrected_logits.append(step_logits.unsqueeze(1))
+        if return_corrected_logits:
+            corrected_logits.append(step_logits.unsqueeze(1))
         prev_tokens = next_tokens
     return (
         torch.stack(sampled_tokens, dim=1),
-        torch.cat(corrected_logits, dim=1),
+        torch.cat(corrected_logits, dim=1) if return_corrected_logits else None,
     )
 
 
@@ -79,6 +97,95 @@ class VanillaMarkov(nn.Module):
             )
         self.markov_w1 = nn.Embedding(self.vocab_size, self.markov_rank)
         self.markov_w2 = nn.Linear(self.markov_rank, self.vocab_size, bias=False)
+        self._tp_shard: Optional[_DenseMarkovW2ShardGeometry] = None
+        self._shard_group = None
+
+    @property
+    def keeps_base_logits_tp_sharded(self) -> bool:
+        return self._tp_shard is not None
+
+    def configure_tp_shard(self, *, lm_head: nn.Module) -> None:
+        """Align vanilla Markov W2 with the vocab-parallel target lm_head.
+
+        A dense DSpark proposal applies the rank-256 W2 projection once per
+        proposal token. Keeping that projection replicated makes every TP rank
+        read and compute the full vocabulary seven times for Kimi-K3. The base
+        lm_head is already vocab-parallel, so compute the matching W2 slice
+        locally and all-gather only the corrected step logits.
+
+        Limit this optimization to the exact vanilla head on NPU and the folded
+        proposal path. Gated/RNN heads need a separate latent-state adaptation,
+        while the eager fallback remains the conservative parity path.
+        """
+        if (
+            type(self) is not VanillaMarkov
+            or not _is_npu
+            or not envs.SGLANG_DSPARK_FOLDED_PROPOSAL.get()
+            or (envs.SGLANG_DSPARK_FOLDED_SAMPLING.get() == DsparkFoldedSampling.FORCE)
+            or not envs.SGLANG_DSPARK_OPT_MARKOV_W2_TP_SHARD.get()
+        ):
+            return
+        required = (
+            "org_vocab_size",
+            "tp_size",
+            "num_embeddings_per_partition",
+            "num_embeddings_padded",
+            "shard_indices",
+        )
+        if any(not hasattr(lm_head, name) for name in required):
+            logger.warning(
+                "DSpark dense Markov W2 TP shard disabled: lm_head lacks vocab "
+                "partition metadata."
+            )
+            return
+        if int(lm_head.org_vocab_size) != self.vocab_size:
+            logger.warning(
+                "DSpark dense Markov W2 TP shard disabled: lm_head vocab %d != "
+                "markov vocab %d.",
+                int(lm_head.org_vocab_size),
+                self.vocab_size,
+            )
+            return
+        tp_size = int(lm_head.tp_size)
+        per_partition = int(lm_head.num_embeddings_per_partition)
+        num_padded = int(lm_head.num_embeddings_padded)
+        if (
+            tp_size <= 1
+            or per_partition * tp_size != num_padded
+            or num_padded != self.vocab_size
+            or self.vocab_size >= 1 << 24
+        ):
+            return
+        parallel = get_parallel()
+        shard_group = (
+            parallel.attn_tp_group
+            if getattr(lm_head, "use_attn_tp_group", False)
+            else parallel.tp_group
+        )
+        if int(shard_group.world_size) != tp_size:
+            logger.warning(
+                "DSpark dense Markov W2 TP shard disabled: group size %d != "
+                "lm_head tp_size %d.",
+                int(shard_group.world_size),
+                tp_size,
+            )
+            return
+        shard = lm_head.shard_indices
+        self._shard_group = shard_group
+        self._tp_shard = _DenseMarkovW2ShardGeometry(
+            tp_size=tp_size,
+            org_vocab_start=int(shard.org_vocab_start_index),
+            org_vocab_end=int(shard.org_vocab_end_index),
+            num_embeddings_per_partition=per_partition,
+            num_embeddings_padded=num_padded,
+        )
+        if getattr(parallel, "attn_tp_rank", 0) == 0:
+            logger.info(
+                "DSpark dense Markov W2 follows the lm_head TP%d vocab shard "
+                "(%d rows per rank).",
+                tp_size,
+                per_partition,
+            )
 
     def get_prev_embeddings(self, token_ids: torch.Tensor) -> torch.Tensor:
         return self.markov_w1(token_ids.long())
@@ -101,7 +208,100 @@ class VanillaMarkov(nn.Module):
         token_ids: torch.Tensor,
         hidden_states: Optional[torch.Tensor],
     ) -> torch.Tensor:
+        if self._tp_shard is not None:
+            return self._apply_step_logits_sharded(
+                base_local=logits, token_ids=token_ids
+            )
         return logits + self.compute_step_bias(token_ids, hidden_states)
+
+    def _apply_step_logits_sharded(
+        self, *, base_local: torch.Tensor, token_ids: torch.Tensor
+    ) -> torch.Tensor:
+        step_local = self._build_step_logits_local(
+            base_local=base_local, token_ids=token_ids
+        )
+        shard = self._tp_shard
+        assert shard is not None and self._shard_group is not None
+        full = self._shard_group.all_gather(step_local, dim=-1)
+        return full[..., : self.vocab_size]
+
+    def _build_step_logits_local(
+        self, *, base_local: torch.Tensor, token_ids: torch.Tensor
+    ) -> torch.Tensor:
+        shard = self._tp_shard
+        assert shard is not None
+        latent = self.get_prev_embeddings(token_ids)
+        weight_local = self.markov_w2.weight[
+            shard.org_vocab_start : shard.org_vocab_end
+        ]
+        bias_local = F.linear(latent.to(weight_local.dtype), weight_local)
+        pad = shard.num_embeddings_per_partition - bias_local.shape[-1]
+        if pad < 0:
+            raise RuntimeError(
+                "DSpark dense Markov W2 shard is wider than the lm_head partition."
+            )
+        if pad:
+            bias_local = F.pad(bias_local, (0, pad))
+        # Preserve the eager path's dtype promotion/rounding before the
+        # collective. This is important for exact greedy proposal parity.
+        return base_local + bias_local
+
+    def sample_greedy_block_sharded(
+        self,
+        base_logits: torch.Tensor,
+        *,
+        first_prev_tokens: torch.Tensor,
+    ) -> torch.Tensor:
+        """Greedily sample a TP-sharded Markov block without vocab gathers.
+
+        Each rank reduces its local vocab slice to one `(value, token_id)` pair
+        per row, then all-gathers only those pairs.  The tie break deliberately
+        selects the smallest global token id, matching `argmax` on a fully
+        gathered vocabulary.
+        """
+        shard = self._tp_shard
+        assert shard is not None and self._shard_group is not None
+        batch_size, proposal_len = base_logits.shape[:2]
+        if proposal_len == 0:
+            return torch.empty(
+                batch_size, 0, dtype=torch.long, device=base_logits.device
+            )
+
+        sampled_tokens = []
+        prev_tokens = first_prev_tokens.long()
+        for step_idx in range(proposal_len):
+            step_local = self._build_step_logits_local(
+                base_local=base_logits[:, step_idx, :], token_ids=prev_tokens
+            )
+            org_width = shard.org_vocab_end - shard.org_vocab_start
+            local_value, local_idx = step_local[:, :org_width].max(dim=-1)
+            global_idx = local_idx + shard.org_vocab_start
+            # Token ids below 2**24 are represented exactly in float32;
+            # DSpark vocabularies are also bounded by the int32 sampler
+            # contract.
+            candidates_local = torch.stack(
+                (local_value.float(), global_idx.float()), dim=-1
+            )
+            candidates = self._shard_group.all_gather(candidates_local, dim=1).view(
+                batch_size, shard.tp_size, 2
+            )
+            if _is_npu:
+                next_tokens = select_global_top1_npu(
+                    candidates, vocab_size=self.vocab_size
+                )
+            else:
+                values = candidates[:, :, 0]
+                indices = candidates[:, :, 1].to(torch.long)
+                best_value = values.max(dim=1).values
+                sentinel = torch.full_like(indices, self.vocab_size)
+                next_tokens = (
+                    torch.where(values == best_value[:, None], indices, sentinel)
+                    .min(dim=1)
+                    .values
+                )
+            sampled_tokens.append(next_tokens)
+            prev_tokens = next_tokens
+        return torch.stack(sampled_tokens, dim=1)
 
     def apply_block_logits(
         self,
@@ -121,13 +321,15 @@ class VanillaMarkov(nn.Module):
         first_prev_tokens: torch.Tensor,
         hidden_states: Optional[torch.Tensor],
         sampler: StepSampler,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        return_corrected_logits: bool = True,
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
         return run_markov_block(
             self,
             base_logits,
             first_prev_tokens=first_prev_tokens,
             hidden_states=hidden_states,
             sampler=sampler,
+            return_corrected_logits=return_corrected_logits,
         )
 
 
@@ -231,7 +433,8 @@ class RNNHead(VanillaMarkov):
         first_prev_tokens: torch.Tensor,
         hidden_states: Optional[torch.Tensor],
         sampler: StepSampler,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        return_corrected_logits: bool = True,
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
         if hidden_states is None:
             raise ValueError("RNNHead requires hidden_states.")
         batch_size, proposal_len = base_logits.shape[:2]
@@ -239,7 +442,7 @@ class RNNHead(VanillaMarkov):
             empty = torch.empty(
                 batch_size, 0, dtype=torch.long, device=base_logits.device
             )
-            return empty, base_logits
+            return empty, base_logits if return_corrected_logits else None
 
         state = torch.zeros(
             batch_size,
@@ -256,11 +459,12 @@ class RNNHead(VanillaMarkov):
             step_logits = base_logits[:, step_idx, :] + bias
             next_tokens = sampler(step_logits, step_idx)
             sampled_tokens.append(next_tokens)
-            corrected_logits.append(step_logits.unsqueeze(1))
+            if return_corrected_logits:
+                corrected_logits.append(step_logits.unsqueeze(1))
             prev_tokens = next_tokens
         return (
             torch.stack(sampled_tokens, dim=1),
-            torch.cat(corrected_logits, dim=1),
+            torch.cat(corrected_logits, dim=1) if return_corrected_logits else None,
         )
 
 
@@ -383,6 +587,7 @@ class DSparkDraftMixin:
     ) -> None:
         self.embed_tokens = embed_tokens
         self.lm_head = lm_head
+        self.markov_head.configure_tp_shard(lm_head=lm_head)
 
     def forward_embed(self, input_ids: torch.Tensor) -> torch.Tensor:
         # Embeds with the shared target embedding INSIDE the draft graph
@@ -413,7 +618,11 @@ class DSparkDraftMixin:
         if hidden.dtype != weight.dtype:
             hidden = hidden.to(weight.dtype)
         local_logits = torch.matmul(hidden, weight.T)
-        base_logits = gather_and_crop_vocab(local_logits, self.lm_head)
+        base_logits = (
+            local_logits
+            if self.markov_head.keeps_base_logits_tp_sharded
+            else gather_and_crop_vocab(local_logits, self.lm_head)
+        )
         return base_logits, None
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
@@ -695,8 +904,14 @@ class DSparkDraftMixin:
         k_all = k32.to(ctx_hidden.dtype)
         # One RoPE over all layers' heads (shared rotary params + positions).
         k_flat = k_all.reshape(tokens, num_layers * kv_size)
-        dummy_q = k_flat.new_empty(k_flat.shape)
-        _, k_flat = attn0.rotary_emb(positions, dummy_q, k_flat)
+        if _is_npu:
+            k_for_rope = k_flat.view(tokens, num_layers * num_kv_heads, head_dim)
+            dummy_q = k_for_rope.new_empty(k_for_rope.shape)
+            _, k_for_rope = attn0.rotary_emb(positions, dummy_q, k_for_rope)
+            k_flat = k_for_rope.reshape(tokens, num_layers * kv_size)
+        else:
+            dummy_q = k_flat.new_empty(k_flat.shape)
+            _, k_flat = attn0.rotary_emb(positions, dummy_q, k_flat)
         # [layers, tokens, heads, dim]: per-layer slices are contiguous views.
         k_all = (
             k_flat.view(tokens, num_layers, num_kv_heads, head_dim)

--- a/python/sglang/srt/models/kimi_k3.py
+++ b/python/sglang/srt/models/kimi_k3.py
@@ -567,12 +567,11 @@ class KimiK3MoE(nn.Module):
         # (TP8/EP8 MegaMoE + SP-MoE): +4~5% output tok/s and −5% ITL over
         # bs 1–32, GSM8K unchanged — so it is on whenever the shape allows,
         # no flag.
-        # EP a2a only: with plain-TP experts the fused front already lands both
-        # partial sums in one collective (_forward_fused), a strictly better
-        # overlap than two streams.
+        # In NPU attention-TP compatibility mode, the all-gather and
+        # reduce-scatter remain on the current stream while only the shared
+        # MLP runs on the side stream.
         self._sbo_shared_overlap = (
             self._ep_a2a
-            and not self._shared_experts_attn_tp_comm
             and self.shared_experts is not None
             and self.alt_stream is not None
         )
@@ -948,20 +947,43 @@ class KimiK3MoE(nn.Module):
             return self._latent_norm(latent)
         return self._latent_norm(tensor_model_parallel_all_reduce(latent))
 
-    def _forward_shared_experts(self, hidden_states: torch.Tensor) -> torch.Tensor:
-        """Run TP-sharded shared experts while DeepEP tokens stay scattered."""
+    def _prepare_shared_experts_input(
+        self, hidden_states: torch.Tensor
+    ) -> tuple[torch.Tensor, bool]:
+        """Gather shared-expert input on the current stream when required."""
         if not self._shared_experts_attn_tp_comm:
-            return self.shared_experts(hidden_states)
+            return hidden_states, False
 
         group = get_parallel().attn_tp_group
         # SP-MoE presents one contiguous token shard per attention-TP rank;
         # the DP local buffer is the full reassembled per-replica batch.
         gathered_hidden_states = get_local_dp_buffer(group)
         attn_tp_all_gather_into_tensor(gathered_hidden_states, hidden_states)
-        gathered_shared_output = self.shared_experts(gathered_hidden_states)
+        return gathered_hidden_states, True
+
+    @staticmethod
+    def _finalize_shared_experts_output(
+        gathered_shared_output: torch.Tensor,
+        hidden_states: torch.Tensor,
+        needs_reduce_scatter: bool,
+    ) -> torch.Tensor:
+        """Reduce-scatter shared-expert output on the current stream."""
+        if not needs_reduce_scatter:
+            return gathered_shared_output
+
         shared_output = torch.empty_like(hidden_states)
         attn_tp_reduce_scatter_tensor(shared_output, gathered_shared_output)
         return shared_output
+
+    def _forward_shared_experts(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Run TP-sharded shared experts while DeepEP tokens stay scattered."""
+        shared_input, needs_reduce_scatter = self._prepare_shared_experts_input(
+            hidden_states
+        )
+        gathered_shared_output = self.shared_experts(shared_input)
+        return self._finalize_shared_experts_output(
+            gathered_shared_output, hidden_states, needs_reduce_scatter
+        )
 
     def _forward_unfused(
         self,
@@ -982,18 +1004,40 @@ class KimiK3MoE(nn.Module):
         # bandwidth away from the critical path.
         shared_output = None
         shared_event = None
+        shared_output_needs_reduce_scatter = False
 
         def issue_shared():
             nonlocal shared_output, shared_event
+            nonlocal shared_output_needs_reduce_scatter
             if self.shared_experts is None or hidden_states.shape[0] == 0:
                 return
             if self._sbo_shared_overlap:
-                self.alt_stream.wait_stream(torch.cuda.current_stream())
+                shared_input, shared_output_needs_reduce_scatter = (
+                    self._prepare_shared_experts_input(hidden_states)
+                )
+                current_stream = torch.cuda.current_stream()
+                # Keep HCCL collectives on the current stream. The alternate
+                # stream only executes the shared-expert MLP.
+                shared_input.record_stream(self.alt_stream)
+                self.alt_stream.wait_stream(current_stream)
                 with torch.cuda.stream(self.alt_stream):
-                    shared_output = self._forward_shared_experts(hidden_states)
+                    shared_output = self.shared_experts(shared_input)
                     shared_event = self.alt_stream.record_event()
             else:
                 shared_output = self._forward_shared_experts(hidden_states)
+
+        def join_shared():
+            nonlocal shared_output
+            if shared_event is None:
+                return
+            # Join as late as possible, then keep the attention-TP collective
+            # on the current stream before the shared output is consumed.
+            torch.cuda.current_stream().wait_event(shared_event)
+            shared_output = self._finalize_shared_experts_output(
+                shared_output,
+                hidden_states,
+                shared_output_needs_reduce_scatter,
+            )
 
         # Front: gate + TopK (+ latent down-proj when the merged front covers it).
         # The gate and the latent down-proj read the same hidden_states, so the
@@ -1015,8 +1059,7 @@ class KimiK3MoE(nn.Module):
 
         if not self.use_latent_moe:
             expert_output = self.experts(hidden_states, topk_output)
-            if shared_event is not None:
-                torch.cuda.current_stream().wait_event(shared_event)
+            join_shared()
             if shared_output is not None:
                 expert_output = expert_output + shared_output
             if self.tp_size > 1:
@@ -1055,10 +1098,7 @@ class KimiK3MoE(nn.Module):
             latent = self._reduce_latent(expert_output)
             # up_proj is replicated, so the routed output is now fully reduced.
             out, _ = self.routed_expert_up_proj(latent)
-        if shared_event is not None:
-            # SBO join: as late as possible, so the side-stream shared experts
-            # get the whole routed a2a + latent tail to hide under.
-            torch.cuda.current_stream().wait_event(shared_event)
+        join_shared()
         if shared_output is not None:
             # tp1 shared experts (SP-MoE) are complete per-rank; TP-sharded
             # ones need the partial-sum reduction.

--- a/python/sglang/srt/speculative/dspark_components/dspark_draft_sampler.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_draft_sampler.py
@@ -57,14 +57,23 @@ class DsparkDraftSampler:
         self.folded_sampling = folded_sampling
         self.temperatures = None
         self.greedy_mask = None
+        self.kernel_greedy_mask = None
         self.exp_noise = None
         self.corrected_out = None
+        self.write_corrected_logits = None
+        self._staged_all_greedy = True
         if folded_sampling:
             vocab = int(model.lm_head.org_vocab_size)
             self.temperatures = torch.ones(
                 (max_bs,), dtype=torch.float32, device=device
             )
             self.greedy_mask = torch.ones((max_bs,), dtype=torch.bool, device=device)
+            # Keep the dtype consumed by the Triton kernel resident. Converting
+            # the bool request mask inside the captured Markov loop would add
+            # one graph op for every proposal step.
+            self.kernel_greedy_mask = torch.ones(
+                (max_bs,), dtype=torch.int32, device=device
+            )
             self.exp_noise = torch.empty(
                 (max_bs, vocab), dtype=torch.float32, device=device
             )
@@ -73,22 +82,47 @@ class DsparkDraftSampler:
                 dtype=model.lm_head.weight.dtype,
                 device=device,
             )
+            self.write_corrected_logits = torch.zeros(
+                (), dtype=torch.int32, device=device
+            )
 
     def stage_sampling_params(self, *, bs: int, sampling_info) -> None:
         """Host-side refresh of the static sampling params; must run before
         the draft graph replay that consumes them."""
         if not self.folded_sampling:
             return
-        if sampling_info is None:
-            self.temperatures[:bs].fill_(1.0)
-            self.greedy_mask[:bs].fill_(True)
+        all_greedy = sampling_info is None or sampling_info.is_all_greedy
+        if all_greedy:
+            # These buffers are initialized to the greedy state and remain
+            # valid across graph replays. Only restore them once after a
+            # stochastic batch instead of launching three tiny device ops on
+            # every greedy decode iteration.
+            if not self._staged_all_greedy:
+                self.greedy_mask.fill_(True)
+                self.kernel_greedy_mask.fill_(1)
+                self.write_corrected_logits.zero_()
+                self._staged_all_greedy = True
             return
+
         torch.clamp(
             sampling_info.temperatures.view(-1)[:bs].to(torch.float32),
             min=1e-5,
             out=self.temperatures[:bs],
         )
-        self.greedy_mask[:bs].copy_((sampling_info.top_ks <= 1).view(-1)[:bs])
+        live_greedy_mask = (sampling_info.top_ks <= 1).view(-1)[:bs]
+        self.greedy_mask[:bs].copy_(live_greedy_mask)
+        self.kernel_greedy_mask[:bs].copy_(live_greedy_mask)
+        # CUDA-graph buckets can be larger than the live batch. Reset their
+        # tail rows so a smaller request cannot inherit stochastic flags from
+        # a previous larger replay and pay full-vocabulary noise/log work.
+        self.greedy_mask[bs:].fill_(True)
+        self.kernel_greedy_mask[bs:].fill_(1)
+        if self._staged_all_greedy:
+            self.write_corrected_logits.fill_(1)
+        self._staged_all_greedy = False
+        # Refresh stochastic noise immediately before replay instead of baking
+        # RNG into every captured proposal.
+        self.exp_noise[:bs].exponential_(1)
 
     def __call__(self, hidden_states, input_ids):
         bs = hidden_states.shape[0] // self.gamma
@@ -99,31 +133,37 @@ class DsparkDraftSampler:
         if self.folded_sampling:
 
             def sampler(step_logits: torch.Tensor, step_idx: int) -> torch.Tensor:
-                del step_idx
-                # In-graph philox noise: each replay advances the generator
-                # and redraws.
-                noise = self.exp_noise[:bs].exponential_()
                 return SampleStepTokens.execute(
                     step_logits=step_logits,
                     temperatures=self.temperatures[:bs],
-                    greedy_mask=self.greedy_mask[:bs],
-                    exp_noise=noise,
+                    greedy_mask=self.kernel_greedy_mask[:bs],
+                    exp_noise=self.exp_noise[:bs],
+                    corrected_logits_out=self.corrected_out.view(
+                        -1, self.gamma, step_logits.shape[-1]
+                    )[:bs, step_idx, :],
+                    write_corrected_logits=self.write_corrected_logits,
                 )
 
         else:
             sampler = greedy_step_sampler
 
-        draft_tokens, corrected_logits = self.markov_head.sample_block(
-            base_logits,
-            first_prev_tokens=anchor,
-            hidden_states=hidden_states.view(bs, self.gamma, -1),
-            sampler=sampler,
-        )
-        self.out[: draft_tokens.numel()].copy_(draft_tokens.reshape(-1))
-        if self.folded_sampling:
-            self.corrected_out[: bs * self.gamma].copy_(
-                corrected_logits.reshape(bs * self.gamma, -1)
+        if not self.folded_sampling and getattr(
+            self.markov_head, "keeps_base_logits_tp_sharded", False
+        ):
+            draft_tokens = self.markov_head.sample_greedy_block_sharded(
+                base_logits, first_prev_tokens=anchor
             )
+            corrected_logits = None
+        else:
+            draft_tokens, corrected_logits = self.markov_head.sample_block(
+                base_logits,
+                first_prev_tokens=anchor,
+                hidden_states=hidden_states.view(bs, self.gamma, -1),
+                sampler=sampler,
+                return_corrected_logits=False,
+            )
+        self.out[: draft_tokens.numel()].copy_(draft_tokens.reshape(-1))
+        assert corrected_logits is None
         if self.confidence_out is not None:
             confidence = self.confidence_fn(
                 draft_hidden=hidden_states.view(bs, self.gamma, -1),
@@ -142,6 +182,16 @@ def _resolve_folded_sampling(*, model, gamma, max_bs, device, tp_rank) -> bool:
         return False
     if mode == DsparkFoldedSampling.FORCE:
         return True
+    if getattr(model.markov_head, "keeps_base_logits_tp_sharded", False):
+        # AUTO favors the greedy-only distributed top-1 graph when the dense
+        # Markov head follows lm_head's vocab shard. Sampling requests still
+        # use the exact eager fallback; FORCE retains the mixed in-graph path.
+        if tp_rank == 0:
+            logger.info(
+                "DSpark folded sampling AUTO selected greedy-only TP-sharded "
+                "proposal; stochastic requests use the eager proposal path."
+            )
+        return False
     vocab = int(model.lm_head.org_vocab_size)
     noise_bytes = max_bs * vocab * 4
     logits_bytes = max_bs * gamma * vocab * model.lm_head.weight.dtype.itemsize

--- a/test/registered/spec/dspark/test_dspark_kernel_parity.py
+++ b/test/registered/spec/dspark/test_dspark_kernel_parity.py
@@ -437,6 +437,18 @@ def _case_sample_step_tokens(tc):
         exp_noise=torch.ones(1, 2050, device=DEVICE),
     )
     tc.assertEqual(tokens.item(), 1000)
+    # Greedy rows must compare logits directly. A softmax can round these two
+    # distinct values to the same probability and incorrectly pick token 0.
+    near_tie = torch.tensor([[0.0, 1.0e-8, -1.0]], device=DEVICE)
+    near_tie_kw = dict(
+        step_logits=near_tie,
+        temperatures=torch.ones(1, device=DEVICE),
+        greedy_mask=torch.ones(1, dtype=torch.bool, device=DEVICE),
+        exp_noise=torch.ones_like(near_tie),
+    )
+    expected = near_tie.argmax(dim=-1)
+    tc._eq(cls.torch(**near_tie_kw), expected)
+    tc._eq(cls.triton(**near_tie_kw), expected)
     # Non-contiguous strided cropped view must match its contiguous copy.
     view = (torch.randn(2, 129536, device=DEVICE) * 4.0)[:, :VOCAB]
     tc.assertFalse(view.is_contiguous())
@@ -449,6 +461,29 @@ def _case_sample_step_tokens(tc):
         cls.triton(step_logits=view, **kw),
         cls.triton(step_logits=view.contiguous(), **kw),
     )
+    # Corrected logits are written directly into a gamma-strided graph buffer.
+    bs, gamma, vocab, step = 2, 3, 5003, 1
+    logits = torch.randn(bs, vocab, dtype=torch.bfloat16, device=DEVICE)
+    corrected = torch.full(
+        (bs, gamma, vocab), 17.0, dtype=torch.bfloat16, device=DEVICE
+    )
+    corrected_step = corrected[:, step, :]
+    write_flag = torch.zeros((), dtype=torch.int32, device=DEVICE)
+    direct_kw = dict(
+        step_logits=logits,
+        temperatures=torch.ones(bs, device=DEVICE),
+        greedy_mask=torch.ones(bs, dtype=torch.bool, device=DEVICE),
+        exp_noise=torch.ones(bs, vocab, device=DEVICE),
+        corrected_logits_out=corrected_step,
+        write_corrected_logits=write_flag,
+    )
+    cls.triton(**direct_kw)
+    tc.assertTrue(bool((corrected == 17.0).all()))
+    write_flag.fill_(1)
+    cls.triton(**direct_kw)
+    tc._eq(corrected_step, logits)
+    tc.assertTrue(bool((corrected[:, 0, :] == 17.0).all()))
+    tc.assertTrue(bool((corrected[:, 2, :] == 17.0).all()))
 
 
 def _case_scatter_compact_to_strided(tc):

--- a/test/registered/unit/npu/speculative/test_npu_dspark_sampling.py
+++ b/test/registered/unit/npu/speculative/test_npu_dspark_sampling.py
@@ -1,0 +1,451 @@
+import unittest
+from types import SimpleNamespace
+
+import torch
+import torch.nn.functional as F
+
+from sglang.kernels.ops.speculative.dspark.dspark_draft_model import (
+    SampleStepTokens,
+)
+from sglang.srt.layers.layernorm import RMSNorm
+from sglang.srt.layers.rotary_embedding import get_rope
+from sglang.srt.models.dflash import DFlashAttention
+from sglang.srt.models.dspark import DSparkDraftMixin, VanillaMarkov
+from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
+from sglang.srt.speculative.dspark_components.dspark_draft_sampler import (
+    DsparkDraftSampler,
+)
+from sglang.test.ci.ci_register import register_npu_ci
+
+register_npu_ci(est_time=25, suite="stage-a-unit-test-npu")
+
+
+class TestNpuDsparkSampling(unittest.TestCase):
+    def test_vanilla_markov_vocab_shards_match_replicated_logits(self):
+        device = torch.device("npu")
+        batch_size, vocab_size, markov_rank, tp_size = 2, 4096, 64, 4
+        head = VanillaMarkov(vocab_size=vocab_size, markov_rank=markov_rank).to(
+            device=device, dtype=torch.bfloat16
+        )
+        base_logits = torch.randn(
+            batch_size, vocab_size, device=device, dtype=torch.bfloat16
+        )
+        prev_tokens = torch.randint(vocab_size, (batch_size,), device=device)
+
+        expected = base_logits + head.compute_step_bias(prev_tokens, None)
+        latent = head.get_prev_embeddings(prev_tokens)
+        width = vocab_size // tp_size
+        local_steps = []
+        for rank in range(tp_size):
+            start, end = rank * width, (rank + 1) * width
+            local_bias = F.linear(
+                latent.to(head.markov_w2.weight.dtype),
+                head.markov_w2.weight[start:end],
+            )
+            local_steps.append(base_logits[:, start:end] + local_bias)
+        actual = torch.cat(local_steps, dim=-1)
+
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+        torch.testing.assert_close(
+            actual.argmax(dim=-1), expected.argmax(dim=-1), rtol=0, atol=0
+        )
+
+    def test_tp_sharded_greedy_block_matches_replicated_graph(self):
+        device = torch.device("npu")
+        batch_size, gamma, vocab_size = 2, 3, 4096
+        head = VanillaMarkov(vocab_size=vocab_size, markov_rank=64).to(
+            device=device, dtype=torch.bfloat16
+        )
+        base_logits = torch.randn(
+            batch_size,
+            gamma,
+            vocab_size,
+            device=device,
+            dtype=torch.bfloat16,
+        )
+        anchors = torch.randint(vocab_size, (batch_size,), device=device)
+        expected, _ = head.sample_block(
+            base_logits,
+            first_prev_tokens=anchors,
+            hidden_states=None,
+            sampler=lambda logits, _step_idx: logits.argmax(dim=-1),
+            return_corrected_logits=False,
+        )
+
+        class _IdentityGroup:
+            @staticmethod
+            def all_gather(value, dim=-1):
+                del dim
+                return value
+
+        head._tp_shard = SimpleNamespace(
+            tp_size=1,
+            org_vocab_start=0,
+            org_vocab_end=vocab_size,
+            num_embeddings_per_partition=vocab_size,
+            num_embeddings_padded=vocab_size,
+        )
+        head._shard_group = _IdentityGroup()
+        actual = head.sample_greedy_block_sharded(
+            base_logits, first_prev_tokens=anchors
+        )
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+        graph = torch.npu.NPUGraph()
+        with torch.npu.graph(graph):
+            graph_actual = head.sample_greedy_block_sharded(
+                base_logits, first_prev_tokens=anchors
+            )
+        graph.replay()
+        torch.npu.synchronize()
+        torch.testing.assert_close(graph_actual, expected, rtol=0, atol=0)
+
+    def test_greedy_near_tie_uses_logits_argmax(self):
+        device = torch.device("npu")
+        logits = torch.tensor([[0.0, 1.0e-8, -1.0]], device=device)
+        expected = logits.argmax(dim=-1)
+        actual = SampleStepTokens.execute(
+            step_logits=logits,
+            temperatures=torch.ones(1, device=device),
+            greedy_mask=torch.ones(1, dtype=torch.bool, device=device),
+            exp_noise=torch.ones_like(logits),
+        )
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+    def test_greedy_skips_corrected_logits_store(self):
+        device = torch.device("npu")
+        logits = torch.randn(2, 4097, device=device)
+        corrected = torch.full_like(logits, 17.0)
+        actual = SampleStepTokens.execute(
+            step_logits=logits,
+            temperatures=torch.ones(2, device=device),
+            greedy_mask=torch.ones(2, dtype=torch.bool, device=device),
+            exp_noise=torch.ones_like(logits),
+            corrected_logits_out=corrected,
+            write_corrected_logits=torch.zeros((), dtype=torch.int32, device=device),
+        )
+
+        torch.testing.assert_close(actual, logits.argmax(dim=-1), rtol=0, atol=0)
+        self.assertTrue(torch.all(corrected == 17.0).item())
+
+    def test_folded_proposal_graph_matches_eager(self):
+        device = torch.device("npu")
+        # Exercise a production-sized combine reduction and the gamma-strided
+        # corrected-logit destination, not only a one-tile toy vocabulary.
+        batch_size, gamma, hidden_size, vocab_size = 2, 3, 32, 163840
+
+        class _Model:
+            def __init__(self):
+                weight = torch.randn(
+                    vocab_size, hidden_size, dtype=torch.bfloat16, device=device
+                )
+                self.lm_head = SimpleNamespace(weight=weight, org_vocab_size=vocab_size)
+                self.markov_head = VanillaMarkov(
+                    vocab_size=vocab_size, markov_rank=8
+                ).to(device=device, dtype=torch.bfloat16)
+
+            def compute_base_logits(self, hidden_states):
+                return F.linear(hidden_states, self.lm_head.weight), None
+
+        model = _Model()
+        sampler = DsparkDraftSampler(
+            model=model,
+            gamma=gamma,
+            max_bs=batch_size,
+            device=device,
+            folded_sampling=True,
+        )
+        hidden = torch.randn(
+            batch_size * gamma,
+            hidden_size,
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        input_ids = torch.randint(
+            vocab_size, (batch_size * gamma,), dtype=torch.int64, device=device
+        )
+        base_logits, _ = model.compute_base_logits(hidden)
+        expected_greedy_tokens, _ = model.markov_head.sample_block(
+            base_logits.view(batch_size, gamma, vocab_size),
+            first_prev_tokens=input_ids.view(batch_size, gamma)[:, 0],
+            hidden_states=hidden.view(batch_size, gamma, hidden_size),
+            sampler=lambda step_logits, _step_idx: step_logits.argmax(dim=-1),
+        )
+
+        # Production capture also runs a warmup pass; compile the Ascend
+        # Triton kernel before entering NPUGraph capture.
+        sampler(hidden, input_ids)
+        torch.npu.synchronize()
+        graph = torch.npu.NPUGraph()
+        with torch.npu.graph(graph):
+            sampler(hidden, input_ids)
+
+        # Production captures with greedy defaults, then can stage a mixed
+        # replay into the same graph. Force row 1 toward token zero so a branch
+        # accidentally frozen to greedy cannot pass by chance.
+        mixed_greedy_mask = torch.tensor([True, False], device=device)
+        mixed_noise = torch.ones(batch_size, vocab_size, device=device)
+        mixed_noise[1, 0] = 1.0e-30
+        sampler.greedy_mask[:batch_size].copy_(mixed_greedy_mask)
+        sampler.kernel_greedy_mask[:batch_size].copy_(mixed_greedy_mask.to(torch.int32))
+        sampler.temperatures[:batch_size].fill_(1.0)
+        sampler.exp_noise[:batch_size].copy_(mixed_noise)
+        sampler.write_corrected_logits.fill_(1)
+        expected_tokens, expected_logits = model.markov_head.sample_block(
+            base_logits.view(batch_size, gamma, vocab_size),
+            first_prev_tokens=input_ids.view(batch_size, gamma)[:, 0],
+            hidden_states=hidden.view(batch_size, gamma, hidden_size),
+            sampler=lambda step_logits, _step_idx: SampleStepTokens.torch(
+                step_logits=step_logits,
+                temperatures=sampler.temperatures[:batch_size],
+                greedy_mask=mixed_greedy_mask,
+                exp_noise=mixed_noise,
+            ),
+        )
+        self.assertTrue(torch.all(expected_tokens[1] == 0).item())
+        graph.replay()
+        torch.npu.synchronize()
+
+        actual_tokens = sampler.out[: batch_size * gamma].view(batch_size, gamma)
+        actual_logits = sampler.corrected_out[: batch_size * gamma].view(
+            batch_size, gamma, vocab_size
+        )
+        torch.testing.assert_close(actual_tokens, expected_tokens, rtol=0, atol=0)
+        torch.testing.assert_close(actual_logits, expected_logits, rtol=0, atol=0)
+
+        # The same captured graph must suppress the full-vocabulary store when
+        # the next request is greedy; the device flag is staged before replay.
+        sampler.corrected_out.fill_(17.0)
+        sampler.greedy_mask.fill_(True)
+        sampler.kernel_greedy_mask.fill_(1)
+        sampler.write_corrected_logits.zero_()
+        graph.replay()
+        torch.npu.synchronize()
+        torch.testing.assert_close(
+            sampler.out[: batch_size * gamma].view(batch_size, gamma),
+            expected_greedy_tokens,
+            rtol=0,
+            atol=0,
+        )
+        self.assertTrue(torch.all(sampler.corrected_out == 17.0).item())
+
+    def test_markov_block_can_skip_corrected_logits_materialization(self):
+        device = torch.device("npu")
+        batch_size, gamma, vocab_size = 2, 3, 64
+        head = VanillaMarkov(vocab_size=vocab_size, markov_rank=8).to(
+            device=device, dtype=torch.bfloat16
+        )
+        base_logits = torch.randn(
+            batch_size, gamma, vocab_size, dtype=torch.bfloat16, device=device
+        )
+        anchors = torch.randint(vocab_size, (batch_size,), device=device)
+
+        expected_tokens, _ = head.sample_block(
+            base_logits,
+            first_prev_tokens=anchors,
+            hidden_states=None,
+            sampler=lambda logits, _step_idx: logits.argmax(dim=-1),
+        )
+        actual_tokens, corrected_logits = head.sample_block(
+            base_logits,
+            first_prev_tokens=anchors,
+            hidden_states=None,
+            sampler=lambda logits, _step_idx: logits.argmax(dim=-1),
+            return_corrected_logits=False,
+        )
+
+        self.assertIsNone(corrected_logits)
+        torch.testing.assert_close(actual_tokens, expected_tokens, rtol=0, atol=0)
+
+    def test_sampling_noise_is_staged_only_for_stochastic_batches(self):
+        device = torch.device("npu")
+        lm_head = SimpleNamespace(org_vocab_size=32, weight=torch.empty(0))
+        model = SimpleNamespace(lm_head=lm_head, markov_head=object())
+        sampler = DsparkDraftSampler(
+            model=model,
+            gamma=2,
+            max_bs=4,
+            device=device,
+            folded_sampling=True,
+        )
+        sampler.exp_noise.fill_(7.0)
+
+        all_greedy = SimpleNamespace(
+            temperatures=torch.ones(2, device=device),
+            top_ks=torch.ones(2, dtype=torch.int32, device=device),
+            is_all_greedy=True,
+        )
+        sampler.stage_sampling_params(bs=2, sampling_info=all_greedy)
+        self.assertTrue(torch.all(sampler.exp_noise == 7.0).item())
+        self.assertTrue(torch.all(sampler.greedy_mask).item())
+        self.assertTrue(torch.all(sampler.kernel_greedy_mask == 1).item())
+
+        mixed = SimpleNamespace(
+            temperatures=torch.ones(2, device=device),
+            top_ks=torch.tensor([1, 8], dtype=torch.int32, device=device),
+            is_all_greedy=False,
+        )
+        sampler.greedy_mask[2:].fill_(False)
+        sampler.stage_sampling_params(bs=2, sampling_info=mixed)
+        self.assertTrue(torch.all(sampler.exp_noise > 0).item())
+        self.assertFalse(torch.all(sampler.exp_noise == 7.0).item())
+        self.assertTrue(torch.equal(sampler.greedy_mask[:2], mixed.top_ks <= 1))
+        self.assertTrue(
+            torch.equal(
+                sampler.kernel_greedy_mask[:2],
+                (mixed.top_ks <= 1).to(torch.int32),
+            )
+        )
+        self.assertTrue(torch.all(sampler.greedy_mask[2:]).item())
+        self.assertTrue(torch.all(sampler.kernel_greedy_mask[2:] == 1).item())
+
+        # Returning to greedy restores both graph buffers once; subsequent
+        # greedy requests reuse the resident state and leave RNG untouched.
+        mixed_noise = sampler.exp_noise.clone()
+        sampler.stage_sampling_params(bs=2, sampling_info=all_greedy)
+        sampler.stage_sampling_params(bs=2, sampling_info=all_greedy)
+        self.assertTrue(torch.all(sampler.greedy_mask).item())
+        self.assertTrue(torch.all(sampler.kernel_greedy_mask == 1).item())
+        self.assertEqual(sampler.write_corrected_logits.item(), 0)
+        torch.testing.assert_close(sampler.exp_noise, mixed_noise, rtol=0, atol=0)
+
+    def test_mixed_rows_match_exponential_race_reference(self):
+        device = torch.device("npu")
+        generator = torch.Generator(device=device).manual_seed(19)
+        logits = torch.randn(4, 5003, device=device, generator=generator)
+        temperatures = torch.tensor([0.7, 1.0, 1.3, 0.5], device=device)
+        greedy_mask = torch.tensor([True, False, True, False], device=device)
+        exp_noise = torch.empty_like(logits).exponential_(1, generator=generator)
+
+        noise = torch.where(greedy_mask[:, None], 1.0, exp_noise)
+        expected = (logits.float() - temperatures[:, None] * noise.log()).argmax(dim=-1)
+        actual = SampleStepTokens.execute(
+            step_logits=logits,
+            temperatures=temperatures,
+            greedy_mask=greedy_mask,
+            exp_noise=exp_noise,
+        )
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+class TestNpuDsparkOptimizedPaths(unittest.TestCase):
+    def test_embedding_graph_matches_eager(self):
+        device = torch.device("npu")
+        owner = SimpleNamespace(
+            embed_tokens=torch.nn.Embedding(
+                128, 64, dtype=torch.bfloat16, device=device
+            )
+        )
+        input_ids = torch.arange(12, dtype=torch.int64, device=device)
+        expected = DSparkDraftMixin.forward_embed(owner, input_ids)
+
+        graph = torch.npu.NPUGraph()
+        with torch.npu.graph(graph):
+            actual = DSparkDraftMixin.forward_embed(owner, input_ids)
+        graph.replay()
+        torch.npu.synchronize()
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+    def test_flattened_kv_only_rope_uses_npu_3d_contract(self):
+        device = torch.device("npu")
+        set_global_server_args_for_scheduler(
+            ServerArgs(model_path="dummy", device="npu")
+        )
+        tokens, num_heads, head_dim = 5, 2, 64
+        rotary = get_rope(
+            head_dim,
+            rotary_dim=head_dim,
+            max_position=4096,
+            base=10000.0,
+            is_neox_style=True,
+        ).to(device)
+        positions = torch.arange(tokens, dtype=torch.int64, device=device)
+        flattened = torch.randn(
+            tokens,
+            num_heads * head_dim,
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        shaped = flattened.view(tokens, num_heads, head_dim)
+        _, expected = rotary(positions, torch.empty_like(shaped), shaped)
+
+        owner = SimpleNamespace(head_dim=head_dim, rotary_emb=rotary)
+        actual = DFlashAttention.apply_k_rope(owner, positions, flattened)
+        torch.testing.assert_close(
+            actual, expected.reshape_as(flattened), rtol=0, atol=0
+        )
+
+    def test_stacked_ctx_kv_matches_per_layer(self):
+        device = torch.device("npu")
+        set_global_server_args_for_scheduler(
+            ServerArgs(model_path="dummy", device="npu")
+        )
+        tokens, hidden_size = 5, 128
+        num_layers, num_kv_heads, head_dim = 3, 2, 64
+        kv_size = num_kv_heads * head_dim
+        eps = 1.0e-6
+        rotary = get_rope(
+            head_dim,
+            rotary_dim=head_dim,
+            max_position=4096,
+            base=10000.0,
+            is_neox_style=True,
+        ).to(device)
+
+        layers = []
+        weights = []
+        norm_weights = []
+        for _ in range(num_layers):
+            weight = torch.randn(
+                2 * kv_size,
+                hidden_size,
+                dtype=torch.bfloat16,
+                device=device,
+            )
+            k_norm = RMSNorm(head_dim, eps=eps).to(device=device, dtype=torch.bfloat16)
+            attn = SimpleNamespace(
+                kv_size=kv_size,
+                head_dim=head_dim,
+                num_kv_heads=num_kv_heads,
+                rotary_emb=rotary,
+                k_norm=k_norm,
+            )
+            layers.append(SimpleNamespace(self_attn=attn))
+            weights.append(weight)
+            norm_weights.append(k_norm.weight)
+
+        owner = SimpleNamespace(layers=layers)
+        stacked = {
+            "weight": torch.cat(weights, dim=0),
+            "bias": None,
+            "k_norm_weight": torch.stack(norm_weights).float(),
+            "eps": eps,
+        }
+        hidden = torch.randn(tokens, hidden_size, dtype=torch.bfloat16, device=device)
+        positions = torch.arange(tokens, dtype=torch.int64, device=device)
+
+        expected_k, expected_v = [], []
+        for layer, weight in zip(layers, weights):
+            kv = F.linear(hidden, weight)
+            k, v = kv.split((kv_size, kv_size), dim=-1)
+            k = layer.self_attn.k_norm(k.reshape(-1, head_dim)).view_as(k)
+            k = k.view(tokens, num_kv_heads, head_dim)
+            dummy_q = torch.empty_like(k)
+            _, k = rotary(positions, dummy_q, k)
+            expected_k.append(k)
+            expected_v.append(v.view(tokens, num_kv_heads, head_dim))
+
+        actual_k, actual_v = DSparkDraftMixin._project_ctx_kv_stacked(
+            owner, ctx_hidden=hidden, positions=positions, stacked=stacked
+        )
+        for layer in range(num_layers):
+            torch.testing.assert_close(
+                actual_k[layer], expected_k[layer], rtol=2.0e-2, atol=2.0e-2
+            )
+            torch.testing.assert_close(
+                actual_v[layer], expected_v[layer], rtol=2.0e-2, atol=2.0e-2
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. -->

This PR fixes numerical and graph-replay parity issues in DSpark's folded NPU paths, then optimizes the enabled paths so they preserve acceptance quality while outperforming the previous all-disabled fallback.

## Modifications

- Replace folded sampling based on `softmax(logits / temperature) / Exp(1)` with the equivalent log-space exponential race:
  - stochastic: `argmax(logits - temperature * log(Exp(1)))`
  - greedy: direct `argmax(logits)`
- Stage exponential noise immediately before graph replay only for stochastic requests. All-greedy requests avoid full-vocabulary RNG and corrected-logit stores.
- Keep the dense Vanilla Markov W2 projection aligned with the target LM-head TP vocabulary shard:
  - compute only the local vocabulary slice;
  - reduce each local slice to one `(value, token_id)` candidate;
  - all-gather only the small candidate tensor and select the global top-1 with an NPU Triton kernel;
  - preserve the eager full-logit path for stochastic sampling.
- Add contiguous KDA conv-snapshot and strided temporal-state commit kernels for Ascend, with the existing generic kernels retained as layout fallbacks.
- Reshape flattened K tensors to `[tokens, heads, head_dim]` before the Ascend RoPE kernel and apply the same 3-D contract to stacked context KV.
- Add NPU and NPUGraph regression tests for proposal parity, near ties, stochastic replay, TP-sharded top-1, production-size vocabulary reductions, and production KDA state layouts.

The proposal changes are gated by `is_npu()` and the new state kernels live in the Ascend backend, so GPU execution paths are unchanged.

## Correctness

| Check | Result |
|---|---:|
| Folded proposal vs. eager proposal with actual weights | Draft tokens exactly identical |
| Corrected logits maximum absolute error | `0` |
| Greedy near-tie case | Matches direct-logit `argmax` |
| Mixed sampling with identical exponential noise | Token-by-token identical |
| Stacked context K maximum absolute error | `<= 4.88e-4` |
| Stacked context V maximum absolute error | `<= 2.44e-4` |
| KDA conv/temporal state commits, ordinary + NPUGraph | Bitwise exact |

The near-tie regression came from converting logits to softmax probabilities before greedy selection: distinct logits can round to equal probabilities and change tie-breaking. Direct-logit argmax preserves their ordering.

## Performance

Tested on four Ascend nodes with Kimi K3 W4A8, TP64/DP4, exact 8,000 input / 1,000 output tokens, one request, four warm-up requests, and seeds 42-46.

### Group A reference: parent code, all four paths disabled

```text
SGLANG_DSPARK_FOLDED_PROPOSAL=0
SGLANG_DSPARK_FOLDED_SAMPLING=0
SGLANG_DSPARK_STACKED_CTX_KV=0
SGLANG_DSPARK_EMBED_IN_GRAPH=0
```

| Metric | Five-run mean |
|---|---:|
| TTFT | `7609.13 ms` |
| TPoT | `15.6189 ms` |
| ITL | `15.6189 ms` |
| Acceptance length | `~7.392` |

### Final code: optimized paths enabled (`1111`)

```text
SGLANG_DSPARK_FOLDED_PROPOSAL=1
SGLANG_DSPARK_FOLDED_SAMPLING=1  # AUTO selects greedy folded sampling; stochastic requests stay eager
SGLANG_DSPARK_STACKED_CTX_KV=1
SGLANG_DSPARK_EMBED_IN_GRAPH=1
```

| Seed | TTFT (ms) | TPoT (ms) | Acceptance length |
|---:|---:|---:|---:|
| 42 | 7731.116 | 15.806716 | 7.1667 |
| 43 | 7767.762 | 14.556558 | 7.4667 |
| 44 | 7758.790 | 15.001659 | 7.3667 |
| 45 | 7789.845 | 15.106276 | 7.3500 |
| 46 | 7533.141 | 14.453775 | 7.6633 |
| **Mean** | **7716.131** | **14.984997** | **7.4027** |

Compared with Group A, mean TPoT improves by `0.6339 ms/token` (`4.1%`) while mean acceptance length remains above 7.4 and mean TTFT remains below 7.8 seconds.

### State-commit microbenchmarks

| NPU Event mean | Generic | Optimized |
|---|---:|---:|
| Conv snapshot, ordinary | 3.0991 ms | 0.0903 ms |
| Conv snapshot, NPUGraph replay | 3.1370 ms | 0.0451 ms |
| Temporal snapshot, ordinary | 0.6749 ms | 0.1334 ms |
| Temporal snapshot, NPUGraph replay | 0.6800 ms | 0.0760 ms |

## Accuracy

| Benchmark | Result | Notes |
|---|---:|---|
| GSM8K-200 | `96.5%` | Initial parity implementation; invalid `0.5%` |
| GSM8K-1319 | `94.5%` | Final code; invalid `0.1%`; 1319/1319 complete; no request errors |
| GPQA-Diamond | `92.42%` (`183/198`) | Final code; 198 predictions and reviews; no request errors |

GPQA uses `temperature=1.0`, `top_p=0.95`, and `reasoning_effort=max`. The final score is within the existing same-model run range observed on this machine (`91.41%` to `94.44%`).

## Validation

- Full pre-commit suite: passed.
- Python compileall: passed.
- Final NPU/NPUGraph gate: `10 passed`.
- Five random 8k/1k runs: 5/5 completed, exactly 1,000 output tokens, no errors.
- GSM8K-1319 and GPQA-Diamond: complete, with no API, HTTP, or connection errors.

## Checklist

- [x] Format code with pre-commit.
- [x] Add NPU and NPUGraph unit tests.
- [ ] Update documentation (not required; no public API change).
- [x] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style guidance.

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from CODEOWNERS and other reviewers.
3. Trigger CI tests with comments or contact authorized users to do so.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32091023196](https://github.com/sgl-project/sglang/actions/runs/32091023196)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32091022802](https://github.com/sgl-project/sglang/actions/runs/32091022802)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
