### PR TITLE
[Fix][DSA] Fail loudly when trtllm-gen query rows exceed the CUDA gridDim.z limit instead of silently skipping attention

### DIFF
--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -3233,6 +3233,22 @@ class DeepseekSparseAttnBackend(
         batch_size = page_table_1.shape[0]
         _, num_heads, head_dim = q_all.shape
 
+        # The trtllm-gen MLA kernel maps its batch dimension onto gridDim.z, which CUDA
+        # caps at 65535. This path flattens every token into its own batch row, so a
+        # single long extend can exceed the cap. The launch then fails with
+        # CUDA_ERROR_INVALID_VALUE, which the trtllm-gen wrapper only prints instead of
+        # raising -- no attention kernel runs and the caller silently receives an
+        # uninitialized output buffer. Fail loudly rather than return wrong output.
+        if batch_size > 65535:
+            raise ValueError(
+                f"DSA trtllm backend got {batch_size} query rows in one forward, "
+                "exceeding the CUDA gridDim.z limit of 65535. This path launches one "
+                "row per token (tokens are flattened into the batch dimension); the "
+                "launch would otherwise fail silently and leave the attention output "
+                "uninitialized. Keep aggregate rows per forward at or below 65535, "
+                "e.g. via chunked prefill."
+            )
+
         self._multi_ctas_kv_counter_buffer = (
             grow_multi_ctas_kv_counter_buffer_if_needed(
                 self._multi_ctas_kv_counter_buffer,


### PR DESCRIPTION
## Motivation

Fixes the silent-corruption half of #34947.

The DSA `trtllm` path flattens every query token into its own batch row
(`q_all.view(batch_size, 1, ...)`), and flashinfer's trtllm-gen kernel maps that batch dimension
onto `gridDim.z`, whose CUDA limit is 65535. One unchunked extend of more than 65535 tokens makes
`cuLaunchKernelEx` fail with `CUDA_ERROR_INVALID_VALUE`, which the trtllm-gen wrapper only prints
to stderr — so **zero attention kernels run, the attention output stays uninitialized, and no
Python exception is raised**. The onset is exact: 65535 works, 65536 does not. Details, minimal
reproducer, and profiler evidence in #34947.

## Modifications

One guard (+17 lines) in `_forward_trtllm`, placed at the single choke point that all three
launch branches (prefill, target-verify, fused-topk) pass through, immediately after
`batch_size = page_table_1.shape[0]`: if `batch_size > 65535`, raise a `ValueError` explaining
the limit and the remedy (keep aggregate rows per forward ≤ 65535, e.g. chunked prefill).

**Semantics note for reviewers:** the exception escapes `run_batch`, so the scheduler treats it
as fatal (fail-fast at server level) rather than rejecting the single request. That matches how
other backend-layer asserts behave today and is strictly better than returning corrupted output.
If a per-request rejection at admission time is the preferred shape, that needs scheduler-level
validation — happy to follow up, but it is deliberately out of scope for this minimal guard.

Deliberately NOT in this PR: the capability fix (splitting the call, or adopting
`cum_seq_lens_q` from flashinfer#3238 so prefill stops flattening tokens into the batch
dimension) — left to the backend owners; this PR only removes the silent-wrong-output failure
mode.

## Verification (8×B200, DeepseekV32-arch fp8 47-layer checkpoint, TP2)

| case | before | after |
|---|---|---|
| `bench_one_batch --input-len 65535` | 2.19526 s prefill, 0 swallowed CUDA errors | 2.19524 s (identical), 0 errors |
| `--input-len 65536` | completes **silently**, prefill 1.8× "faster" (attention skipped), 47×2 swallowed launch errors | **ValueError on both TP ranks**, 0 swallowed errors, no bogus result row |
| HTTP server, chunked prefill 16384, 32K-token request | n/a | 200 OK, sane output, guard fired 0× |

Pinned lint clean (black 26.1.0 / isort 7.0.0 / ruff / codespell).

## Related

- Issue: #34947
- Companion FlashInfer-side pre-launch check (defense in depth for non-sglang callers): https://github.com/flashinfer-ai/flashinfer/pull/4536
- Prior art: flashinfer#3125 (root cause diagnosed, fix never landed), sglang#29453, sglang#29522, flashinfer#3238 (structural cure, unadopted)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32809368099](https://github.com/sgl-project/sglang/actions/runs/32809368099)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32809368060](https://github.com/sgl-project/sglang/actions/runs/32809368060)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32809368057](https://github.com/sgl-project/sglang/actions/runs/32809368057)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->