### PR TITLE
[OpenAI] Preserve images in Responses tool outputs

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -1066,11 +1066,14 @@ class OpenAIServingResponses(OpenAIServingChat):
                 ],
             }
         if msg_type == "function_call_output":
-            # ``output`` may be a string or an array of content parts (OpenAI
-            # allows both); the chat tool message needs a string, so flatten.
+            # ``output`` may be a string or an array of content parts. Preserve
+            # multimodal tool results by translating Responses parts to their
+            # Chat Completions equivalents, just as we do for message items.
             out = message.get("output", "")
             if isinstance(out, list):
-                out = "".join(p.get("text", "") for p in out if isinstance(p, dict))
+                out = [
+                    cls._normalize_response_content_part_for_chat(part) for part in out
+                ]
             return {
                 "role": "tool",
                 "tool_call_id": message.get("call_id"),

--- a/test/registered/unit/entrypoints/openai/test_serving_responses.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_responses.py
@@ -123,6 +123,80 @@ class InputMessageConstructionTestCase(CustomTestCase):
             ],
         )
 
+    def test_function_call_output_image_reaches_chat_processing(self):
+        serving = make_serving(is_multimodal=True)
+        captured = {}
+
+        def fake_process(chat_request, is_multimodal):
+            captured["chat_request"] = chat_request
+            captured["is_multimodal"] = is_multimodal
+            return MessageProcessingResult(
+                prompt="rendered tool image",
+                prompt_ids=[1, 2, 3],
+                image_data=["https://example.com/image.png"],
+                audio_data=None,
+                video_data=None,
+                modalities=["image"],
+                stop=[],
+            )
+
+        serving._process_messages = Mock(side_effect=fake_process)
+        request = ResponsesRequest(
+            model="x",
+            input=[
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_image",
+                    "output": [
+                        {"type": "input_text", "text": "tool result"},
+                        {
+                            "type": "input_image",
+                            "image_url": "https://example.com/image.png",
+                            "detail": "high",
+                        },
+                    ],
+                }
+            ],
+            store=False,
+        )
+
+        messages, request_prompts, engine_prompts, _ = asyncio.run(
+            serving._make_request(request, None, serving.tokenizer_manager.tokenizer)
+        )
+
+        self.assertEqual(
+            messages,
+            [
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_image",
+                    "content": [
+                        {"type": "text", "text": "tool result"},
+                        {
+                            "type": "image_url",
+                            "image_url": {
+                                "url": "https://example.com/image.png",
+                                "detail": "high",
+                            },
+                        },
+                    ],
+                }
+            ],
+        )
+        self.assertEqual(request_prompts, ["rendered tool image"])
+        self.assertEqual(engine_prompts, ["rendered tool image"])
+        self.assertTrue(captured["is_multimodal"])
+        chat_message = captured["chat_request"].messages[0]
+        self.assertEqual(chat_message.role, "tool")
+        self.assertEqual(chat_message.content[0].type, "text")
+        self.assertEqual(chat_message.content[0].text, "tool result")
+        self.assertEqual(chat_message.content[1].type, "image_url")
+        self.assertEqual(
+            chat_message.content[1].image_url.url,
+            "https://example.com/image.png",
+        )
+        self.assertEqual(chat_message.content[1].image_url.detail, "high")
+
     def test_previous_response_id_input_list_does_not_call_copy_module(self):
         serving = make_serving()
         serving.use_harmony = True


### PR DESCRIPTION
Fixes #34927

function_call_output.output can be a list of content parts. We were flattening that list to text, which quietly dropped input_image parts before multimodal processing.

This sends list items through the same Responses-to-chat content normalizer already used for message inputs. Plain string tool outputs are unchanged.

Added a regression test that goes through ResponsesRequest and _make_request, then checks that both the text and image reach chat processing.

Tested the Responses unit test file locally: 33 passed. Black, isort, ruff, and the registered-test check also pass.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31884571794](https://github.com/sgl-project/sglang/actions/runs/31884571794)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31884571729](https://github.com/sgl-project/sglang/actions/runs/31884571729)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->