### PR TITLE
[AMD] Fix ROCm FP8 DP gather quantization

### DIFF
--- a/python/sglang/kernels/ops/quantization/fp8_kernel.py
+++ b/python/sglang/kernels/ops/quantization/fp8_kernel.py
@@ -576,6 +576,32 @@ def _run_per_token_group_quant_8bit_kernel(
         )
         return
 
+    if _is_hip:
+        if (
+            scale_ue8m0
+            or fuse_silu_and_mul
+            or masked_m is not None
+            or not x_s.is_contiguous()
+        ):
+            raise NotImplementedError(
+                "The ROCm Triton fallback supports only row-major FP8 group quantization"
+            )
+        block = triton.next_power_of_2(group_size)
+        _per_token_group_quant_8bit[(x.numel() // group_size,)](
+            x,
+            x_q,
+            x_s,
+            group_size,
+            group_size,
+            eps,
+            bit8_min=fp8_min,
+            bit8_max=fp8_max,
+            BLOCK=block,
+            num_warps=min(max(block // 256, 1), 8),
+            num_stages=1,
+        )
+        return
+
     assert (
         eps == 1e-10
     ), f"per_token_group_quant bakes the absmax floor in at 1e-10, got {eps}"

--- a/test/registered/kernels/ops/quantization/test_rocm_per_token_group_quant_fp8.py
+++ b/test/registered/kernels/ops/quantization/test_rocm_per_token_group_quant_fp8.py
@@ -1,0 +1,40 @@
+import unittest
+
+import torch
+
+from sglang.kernels.ops.quantization.fp8_kernel import (
+    fp8_dtype,
+    fp8_max,
+    sglang_per_token_group_quant_fp8,
+)
+from sglang.srt.utils import is_hip
+from sglang.test.ci.ci_register import register_amd_ci
+
+register_amd_ci(est_time=5, stage="jit-kernel-unit", runner_config="amd")
+
+
+@unittest.skipUnless(is_hip(), "ROCm-only regression")
+class TestRocmPerTokenGroupQuantFp8(unittest.TestCase):
+    def test_row_major_group_128(self):
+        torch.manual_seed(34296)
+        value = torch.randn((4, 7168), device="cuda", dtype=torch.bfloat16)
+
+        actual, actual_scale = sglang_per_token_group_quant_fp8(value, 128)
+
+        grouped = value.float().reshape(4, 56, 128)
+        expected_scale = grouped.abs().amax(dim=-1).clamp_min(1e-10) / fp8_max
+        torch.cuda.synchronize()
+
+        self.assertEqual(actual.dtype, fp8_dtype)
+        self.assertTrue(actual_scale.is_contiguous())
+        torch.testing.assert_close(actual_scale, expected_scale, rtol=2e-7, atol=0)
+
+        dequantized = actual.float().reshape_as(grouped) * actual_scale[..., None]
+        relative_error = (
+            (grouped - dequantized).abs() / (grouped.abs() + 1e-6)
+        ).mean()
+        self.assertLess(relative_error.item(), 0.05)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- route ordinary ROCm row-major FP8 group quantization through the existing in-file Triton kernel
- write directly into caller-owned quantized/scales outputs with the requested gfx950 E4M3 range
- add an AMD JIT-kernel CI regression for group-128 `[4, 7168]` quantization

## Root cause

The ROCm DP FP8-gather path reached a CUDA-only JIT wrapper that is not imported on HIP. Importing it is not sufficient: it compiles `cuda_fp8.h`, while the pinned `sgl_kernel` wheel also lacks the AOT v2 op. The local Triton kernel is the supported dependency-free fallback for the plain row-major case. Unsupported UE8M0/fused/masked/column-major combinations fail explicitly.

## Validation

- focused gfx950 numerical regression: pass
- AMD CI registration: `jit-kernel-unit-test-amd`
- full DeepSeek-V4-Pro DP8/EP8/TP8 service reaches healthy state with `SGLANG_ENABLE_DP_GATHER_FP8=1`
- three stable c64 1K-to-1 rounds have balanced DP routing and zero retractions

## Performance note

This fixes the crash, but does not enable FP8 gather by default. In the tested DSV4 workload, FP8 wire gather regressed median/P99 TTFT by 8.33%/14.05% versus the same Gatherv bundle, so the environment gate should remain disabled pending a better communication decomposition.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31890246697](https://github.com/sgl-project/sglang/actions/runs/31890246697)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31890246560](https://github.com/sgl-project/sglang/actions/runs/31890246560)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->