### PR TITLE
[Observability] Trace DP controller delivery stalls

### DIFF
--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -74,6 +74,7 @@ from sglang.utils import TypeBasedDispatcher, get_exception_traceback
 logger = logging.getLogger(__name__)
 
 SCHEDULER_PIDS_ARG = "scheduler_pids"
+_SLOW_WORKER_SEND_SECONDS = 0.1
 
 
 class LoadBalanceMethod(Enum):
@@ -321,6 +322,9 @@ class DataParallelController:
 
         time_stats = DPControllerReqTimeStats.new_from_obj(
             unwrap_from_pickle(req.time_stats)
+        )
+        time_stats.has_timing_data = (
+            self.server_args.enable_request_time_stats_logging
         )
 
         time_stats.set_dp_dispatch_time()
@@ -747,9 +751,25 @@ class DataParallelController:
             ):
                 raise ValueError(f"DP rank {rank} is not active.")
             logger.debug(f"Direct routing to DP rank {rank}")
-            sock_send(self.workers[rank], req)
+            self._send_to_worker(rank, req)
             return True
         return False
+
+    def _send_to_worker(self, rank: int, req: Req) -> None:
+        if not self.server_args.enable_request_time_stats_logging:
+            sock_send(self.workers[rank], req)
+            return
+
+        start = time.perf_counter()
+        sock_send(self.workers[rank], req)
+        elapsed = time.perf_counter() - start
+        if elapsed >= _SLOW_WORKER_SEND_SECONDS:
+            logger.warning(
+                "Slow DP controller worker send: rank=%d rid=%s duration_ms=%.2f",
+                rank,
+                getattr(req, "rid", None),
+                elapsed * 1000,
+            )
 
     def round_robin_scheduler(self, req: Req):
         if self.maybe_external_dp_rank_routing(req):
@@ -764,7 +784,7 @@ class DataParallelController:
             self.round_robin_counter = (self.round_robin_counter + 1) % len(active)
             if self.status[slot]:
                 logger.debug(f"Choose worker {slot}")
-                sock_send(self.workers[slot], req)
+                self._send_to_worker(slot, req)
                 return
             attempts += 1
         raise RuntimeError(
@@ -781,13 +801,13 @@ class DataParallelController:
             "prefill or decode instances; send to the router instead."
         )
         target_rank = req.bootstrap_room % len(self.workers)
-        sock_send(self.workers[target_rank], req)
+        self._send_to_worker(target_rank, req)
 
     def total_requests_scheduler(self, req: Req):
         if self.maybe_external_dp_rank_routing(req):
             return
         target_worker = self.dp_budget.dispatch(LoadBalanceMethod.TOTAL_REQUESTS)
-        sock_send(self.workers[target_worker], req)
+        self._send_to_worker(target_worker, req)
 
     def total_tokens_scheduler(self, req: Req):
         if self.maybe_external_dp_rank_routing(req):
@@ -796,7 +816,7 @@ class DataParallelController:
         target_worker = self.dp_budget.dispatch(
             LoadBalanceMethod.TOTAL_TOKENS, estimated_tokens=estimated_tokens
         )
-        sock_send(self.workers[target_worker], req)
+        self._send_to_worker(target_worker, req)
 
     def event_loop(self):
         while True:

--- a/python/sglang/srt/managers/scheduler_components/output_streamer.py
+++ b/python/sglang/srt/managers/scheduler_components/output_streamer.py
@@ -187,6 +187,7 @@ class SchedulerOutputStreamer:
             and self.ps.attn_tp_rank == 0
             and get_observability().enable_request_time_stats_logging
         ):
+            req.time_stats.has_timing_data = True
             req.log_time_stats()
 
     def _stream_output_embedding(self, reqs: List[Req]):

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -2250,9 +2250,9 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 "num_retractions": recv_obj.retraction_counts[i],
             }
 
-            if self.enable_metrics:
-                if recv_obj.time_stats is not None:
-                    scheduler_time_stats = recv_obj.time_stats[i]
+            if recv_obj.time_stats is not None:
+                scheduler_time_stats = recv_obj.time_stats[i]
+                if self.enable_metrics or scheduler_time_stats.has_timing_data:
                     meta_info.update(scheduler_time_stats.convert_to_output_meta_info())
 
             if getattr(state.obj, "return_logprob", False):
@@ -2464,12 +2464,15 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
 
                 if self.server_args.speculative_algorithm:
                     self._calculate_spec_decoding_metrics(meta_info, recv_obj, i)
-                if self.enable_metrics:
-                    scheduler_time_stats = (
-                        recv_obj.time_stats[i]
-                        if recv_obj.time_stats is not None
-                        else None
-                    )
+                scheduler_time_stats = (
+                    recv_obj.time_stats[i]
+                    if recv_obj.time_stats is not None
+                    else None
+                )
+                if self.enable_metrics or (
+                    scheduler_time_stats is not None
+                    and scheduler_time_stats.has_timing_data
+                ):
                     completion_tokens = (
                         recv_obj.completion_tokens[i]
                         if not isinstance(recv_obj, BatchEmbeddingOutput)

--- a/python/sglang/srt/observability/req_time_stats.py
+++ b/python/sglang/srt/observability/req_time_stats.py
@@ -505,6 +505,8 @@ class APIServerReqTimeStats(ReqTimeStatsBase):
             meta_info["request_finished_ts"] = convert_time_to_realtime(
                 self.finished_time
             )
+        if scheduler_time_stats is not None and scheduler_time_stats.has_timing_data:
+            meta_info.update(scheduler_time_stats.convert_to_output_meta_info())
 
         decode_latency = self.get_decode_latency()
         if decode_latency > 0.0 and completion_tokens > 1:
@@ -550,16 +552,17 @@ class DPControllerReqTimeStats(ReqTimeStatsBase):
     # new timestamp, get by time.perf_counter()
     dpc_dispatch_time: float = 0.0
     dpc_dispatch_finish_time: float = 0.0
+    has_timing_data: bool = False
 
     def __getstate__(self) -> object:
-        state = {}
-        # send to Scheduler
-        # If necessary, can propagate the timestamp here, for example:
-        # state = {
-        #     "created_time": self.created_time,
-        #     "api_server_dispatch_time": self.api_server_dispatch_time,
-        #     "dpc_dispatch_time": self.dpc_dispatch_time,
-        # }
+        state = (
+            {
+                "dpc_dispatch_time": self.dpc_dispatch_time,
+                "has_timing_data": True,
+            }
+            if self.has_timing_data
+            else {}
+        )
         state.update(super().__getstate__())
         return state
 
@@ -649,6 +652,8 @@ class SchedulerReqTimeStats(ReqTimeStatsBase):
 
         state = {
             "has_timing_data": True,
+            "dpc_dispatch_time": self.dpc_dispatch_time,
+            "scheduler_recv_time": self.scheduler_recv_time,
             "wait_queue_entry_time": self.wait_queue_entry_time,
             "forward_entry_time": self.forward_entry_time,
             "prefill_finished_time": self.prefill_finished_time,
@@ -1166,6 +1171,18 @@ class SchedulerReqTimeStats(ReqTimeStatsBase):
 
     def convert_to_output_meta_info(self):
         meta_data = {}
+        if self.dpc_dispatch_time > 0.0:
+            meta_data["dpc_dispatch_time"] = convert_time_to_realtime(
+                self.dpc_dispatch_time
+            )
+        if self.scheduler_recv_time > 0.0:
+            meta_data["scheduler_recv_time"] = convert_time_to_realtime(
+                self.scheduler_recv_time
+            )
+        if self.wait_queue_entry_time > 0.0:
+            meta_data["wait_queue_entry_time"] = convert_time_to_realtime(
+                self.wait_queue_entry_time
+            )
         if self.forward_entry_time > 0.0:
             meta_data["forward_entry_time"] = convert_time_to_realtime(
                 self.forward_entry_time

--- a/test/registered/unit/managers/test_data_parallel_controller.py
+++ b/test/registered/unit/managers/test_data_parallel_controller.py
@@ -13,7 +13,7 @@ is exercised as the real method, no mock.
 
 import unittest
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import msgspec.structs
 
@@ -51,6 +51,7 @@ def _make_controller(dp_size: int) -> DataParallelController:
     ctl._active_workers = list(range(dp_size))
     ctl.round_robin_counter = 0
     ctl.dp_budget = DPBudget(dp_size=dp_size)
+    ctl.server_args = SimpleNamespace(enable_request_time_stats_logging=False)
     return ctl
 
 
@@ -60,6 +61,7 @@ def _req(routed_dp_rank=None, bootstrap_room=None, input_ids=None):
         routed_dp_rank=routed_dp_rank,
         bootstrap_room=bootstrap_room,
         input_ids=input_ids or [],
+        rid="test-rid",
     )
 
 
@@ -207,6 +209,24 @@ class TestRoundRobinScheduler(CustomTestCase):
         # Subsequent round-robin req still lands on worker 0
         ctl.round_robin_scheduler(_req())
         ctl.workers[0].send_pyobj.assert_called_once()
+
+    def test_logs_slow_worker_send_when_timing_is_enabled(self):
+        ctl = _make_controller(dp_size=2)
+        ctl.server_args.enable_request_time_stats_logging = True
+        with (
+            patch(
+                "sglang.srt.managers.data_parallel_controller.time.perf_counter",
+                side_effect=[10.0, 10.25],
+            ),
+            self.assertLogs(
+                "sglang.srt.managers.data_parallel_controller", level="WARNING"
+            ) as logs,
+        ):
+            ctl.round_robin_scheduler(_req())
+
+        self.assertIn("rank=0", logs.output[0])
+        self.assertIn("rid=test-rid", logs.output[0])
+        self.assertIn("duration_ms=250.00", logs.output[0])
 
 
 class TestFollowBootstrapRoomScheduler(CustomTestCase):

--- a/test/registered/unit/observability/test_req_time_stats.py
+++ b/test/registered/unit/observability/test_req_time_stats.py
@@ -39,6 +39,62 @@ class TestSetstatePreservesUnsetTimeSentinels(CustomTestCase):
         self.assertEqual(hop2.prefill_finished_time, 0.0)
         self.assertAlmostEqual(hop2.wait_queue_entry_time, 123.456 - 9.0)
 
+    def test_opt_in_scheduler_timestamps_survive_round_trip(self):
+        src = rts.SchedulerReqTimeStats(has_timing_data=True)
+        src.dpc_dispatch_time = 99.0
+        src.scheduler_recv_time = 100.0
+        src.wait_queue_entry_time = 101.0
+        src.forward_entry_time = 108.0
+
+        with mock.patch.object(rts, "global_diff_realtime_monotonic", 1_000_000.0):
+            blob = pickle.dumps(src)
+        with mock.patch.object(rts, "global_diff_realtime_monotonic", 1_000_005.0):
+            dst = pickle.loads(blob)
+
+        self.assertAlmostEqual(dst.dpc_dispatch_time, 94.0)
+        self.assertAlmostEqual(dst.scheduler_recv_time, 95.0)
+        self.assertAlmostEqual(dst.wait_queue_entry_time, 96.0)
+        self.assertAlmostEqual(dst.forward_entry_time, 103.0)
+        with mock.patch.object(rts, "global_diff_realtime_monotonic", 1_000_005.0):
+            meta_info = dst.convert_to_output_meta_info()
+            api = rts.APIServerReqTimeStats()
+            merged = api.convert_to_output_meta_info(dst)
+        self.assertAlmostEqual(meta_info["dpc_dispatch_time"], 1_000_099.0)
+        self.assertAlmostEqual(meta_info["scheduler_recv_time"], 1_000_100.0)
+        self.assertAlmostEqual(meta_info["wait_queue_entry_time"], 1_000_101.0)
+        self.assertAlmostEqual(meta_info["forward_entry_time"], 1_000_108.0)
+        self.assertAlmostEqual(merged["dpc_dispatch_time"], 1_000_099.0)
+        self.assertAlmostEqual(merged["scheduler_recv_time"], 1_000_100.0)
+        self.assertAlmostEqual(merged["wait_queue_entry_time"], 1_000_101.0)
+        self.assertAlmostEqual(merged["forward_entry_time"], 1_000_108.0)
+
+    def test_dpc_timestamp_survives_two_ipc_hops(self):
+        src = rts.DPControllerReqTimeStats(
+            dpc_dispatch_time=100.0, has_timing_data=True
+        )
+        with mock.patch.object(rts, "global_diff_realtime_monotonic", 1_000_000.0):
+            scheduler_blob = pickle.dumps(src)
+        with (
+            mock.patch.object(rts, "global_diff_realtime_monotonic", 1_000_005.0),
+            mock.patch.object(rts, "calibrate_time_diff"),
+        ):
+            dpc_hop = pickle.loads(scheduler_blob)
+            scheduler = rts.SchedulerReqTimeStats.new_from_obj(dpc_hop)
+            scheduler.has_timing_data = True
+            tokenizer_blob = pickle.dumps(scheduler)
+        with mock.patch.object(rts, "global_diff_realtime_monotonic", 1_000_009.0):
+            tokenizer_hop = pickle.loads(tokenizer_blob)
+            meta_info = tokenizer_hop.convert_to_output_meta_info()
+
+        self.assertAlmostEqual(tokenizer_hop.dpc_dispatch_time, 91.0)
+        self.assertAlmostEqual(meta_info["dpc_dispatch_time"], 1_000_100.0)
+
+    def test_dpc_timestamp_is_omitted_by_default(self):
+        src = rts.DPControllerReqTimeStats(dpc_dispatch_time=100.0)
+        state = src.__getstate__()
+        self.assertNotIn("dpc_dispatch_time", state)
+        self.assertNotIn("has_timing_data", state)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- make the existing `--enable-request-time-stats-logging` flag propagate API, DP-controller, scheduler-receive, queue, and prefill timestamps to response metadata
- keep timestamp IPC propagation disabled by default
- log synchronous DP-controller worker sends exceeding 100 ms with target rank, request ID, and duration
- add one-hop/two-hop clock-rebasing and controller logging tests

## Motivation

A hot DP8 c64 sequence reproduced round medians of 1.112 s, 7.972 s, and 1.116 s. The slow round spent about 6.230 s after API dispatch completed but before scheduler receive; scheduler processing itself was about 0.006 ms. The first two requests arrived immediately and the remaining 62 reached all eight ranks together, pointing at the single-threaded DP-controller delivery boundary.

This PR adds opt-in evidence for the next occurrence; it does not claim to fix the intermittent stall.

## Validation

- 18 DP-controller dispatch tests: pass
- 4 request-time serialization/rebasing tests: pass
- exact repository Ruff rules (`F401,F821,UP037`): pass
- isort 7.0.0: pass
- live DP8 responses contain the expected scheduler timestamp fields when enabled
- default DPC serialization omits the additional fields

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31890249739](https://github.com/sgl-project/sglang/actions/runs/31890249739)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31890249753](https://github.com/sgl-project/sglang/actions/runs/31890249753)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->