### PR TITLE
[KV Cache] Use exact page demand for paged prefill eviction

### DIFF
--- a/python/sglang/srt/mem_cache/allocation.py
+++ b/python/sglang/srt/mem_cache/allocation.py
@@ -35,7 +35,7 @@ from sglang.srt.utils import (
     next_power_of_2,
     support_triton,
 )
-from sglang.srt.utils.common import is_pin_memory_available
+from sglang.srt.utils.common import get_num_new_pages, is_pin_memory_available
 
 _is_hip = is_hip()
 _is_npu = is_npu()
@@ -181,9 +181,13 @@ def alloc_paged_token_slots_extend(
     req_pool_indices: Optional[torch.Tensor] = None,
     batch=None,
 ):
-    # Over estimate the number of tokens: assume each request needs a new page.
     allocator = tree_cache.token_to_kv_pool_allocator
-    num_tokens = extend_num_tokens + len(seq_lens_cpu) * allocator.page_size
+    num_new_pages = get_num_new_pages(
+        seq_lens=seq_lens_cpu,
+        page_size=allocator.page_size,
+        prefix_lens=prefix_lens_cpu,
+    )
+    num_tokens = num_new_pages * allocator.page_size
     evict_from_tree_cache(tree_cache, num_tokens)
 
     is_dsv4 = req_pool_indices is not None and hasattr(allocator, "c128_attn_allocator")

--- a/test/registered/unit/mem_cache/test_paged_alloc_extend_eviction.py
+++ b/test/registered/unit/mem_cache/test_paged_alloc_extend_eviction.py
@@ -1,0 +1,89 @@
+"""Regression tests for paged prefill eviction accounting."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.mem_cache.allocation import alloc_paged_token_slots_extend
+from sglang.srt.mem_cache.base_prefix_cache import EvictParams
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+def _call_alloc_extend(
+    *,
+    page_size: int,
+    available_size: int,
+    prefix_lens: list[int],
+    seq_lens: list[int],
+):
+    prefix_lens_cpu = torch.tensor(prefix_lens, dtype=torch.int64)
+    seq_lens_cpu = torch.tensor(seq_lens, dtype=torch.int64)
+    extend_num_tokens = sum(seq - prefix for prefix, seq in zip(prefix_lens, seq_lens))
+    out = torch.arange(extend_num_tokens, dtype=torch.int64)
+
+    allocator = SimpleNamespace(
+        page_size=page_size,
+        available_size=MagicMock(return_value=available_size),
+        alloc_extend=MagicMock(return_value=out),
+    )
+    tree_cache = SimpleNamespace(
+        token_to_kv_pool_allocator=allocator,
+        is_chunk_cache=MagicMock(return_value=False),
+        evict=MagicMock(),
+    )
+
+    result = alloc_paged_token_slots_extend(
+        tree_cache=tree_cache,
+        prefix_lens=prefix_lens_cpu,
+        prefix_lens_cpu=prefix_lens_cpu,
+        seq_lens=seq_lens_cpu,
+        seq_lens_cpu=seq_lens_cpu,
+        last_loc=torch.tensor(
+            [prefix_len - 1 for prefix_len in prefix_lens], dtype=torch.int64
+        ),
+        extend_num_tokens=extend_num_tokens,
+    )
+    return result, out, tree_cache, allocator
+
+
+class TestPagedAllocExtendEviction(CustomTestCase):
+    def test_extend_within_partial_page_does_not_evict(self):
+        # Previous target: 1 + 1 * 64 = 65 tokens. The extend reuses the
+        # existing tail page, so the exact new-page capacity is zero.
+        result, expected, tree_cache, allocator = _call_alloc_extend(
+            page_size=64,
+            available_size=0,
+            prefix_lens=[63],
+            seq_lens=[64],
+        )
+
+        torch.testing.assert_close(result, expected)
+        tree_cache.evict.assert_not_called()
+        allocator.alloc_extend.assert_called_once()
+        self.assertEqual(allocator.alloc_extend.call_args.kwargs, {})
+
+    def test_mixed_batch_evicts_only_exact_page_shortfall(self):
+        # Previous target: 129 + 4 * 64 = 385 tokens, or a 353-token
+        # shortfall. The batch consumes one new page, leaving only 32 tokens
+        # to evict after accounting for the 32 already available.
+        result, expected, tree_cache, _ = _call_alloc_extend(
+            page_size=64,
+            available_size=32,
+            prefix_lens=[1, 63, 64, 65],
+            seq_lens=[2, 64, 128, 128],
+        )
+
+        torch.testing.assert_close(result, expected)
+        tree_cache.evict.assert_called_once_with(EvictParams(num_tokens=32))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_paged_alloc_extend_eviction.py
+++ b/test/registered/unit/mem_cache/test_paged_alloc_extend_eviction.py
@@ -1,6 +1,7 @@
 """Regression tests for paged prefill eviction accounting."""
 
 import unittest
+from array import array
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -12,7 +13,12 @@ from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
 maybe_stub_sgl_kernel()
 
 from sglang.srt.mem_cache.allocation import alloc_paged_token_slots_extend
-from sglang.srt.mem_cache.base_prefix_cache import EvictParams
+from sglang.srt.mem_cache.base_prefix_cache import (
+    EvictParams,
+    InsertParams,
+    MatchPrefixParams,
+)
+from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey
 
 register_cpu_ci(est_time=2, suite="base-a-test-cpu")
 
@@ -55,20 +61,96 @@ def _call_alloc_extend(
 
 
 class TestPagedAllocExtendEviction(CustomTestCase):
-    def test_extend_within_partial_page_does_not_evict(self):
-        # Previous target: 1 + 1 * 64 = 65 tokens. The extend reuses the
-        # existing tail page, so the exact new-page capacity is zero.
-        result, expected, tree_cache, allocator = _call_alloc_extend(
-            page_size=64,
-            available_size=0,
-            prefix_lens=[63],
-            seq_lens=[64],
+    def test_page_boundary_matrix(self):
+        for page_size in (16, 64, 128):
+            cases = (
+                # The existing tail page absorbs the extend.
+                ("within_partial_page", [page_size - 1], [page_size], 0, 0),
+                # One new page is needed, but it is already available.
+                (
+                    "exact_capacity_available",
+                    [page_size],
+                    [page_size + 1],
+                    page_size,
+                    0,
+                ),
+                # Crossing a page boundary needs one page; evict only its shortfall.
+                (
+                    "cross_one_boundary",
+                    [page_size - 1],
+                    [page_size + 1],
+                    page_size - 1,
+                    1,
+                ),
+                # Growing from page one into page three needs exactly two pages.
+                (
+                    "cross_multiple_boundaries",
+                    [1],
+                    [2 * page_size + 1],
+                    page_size // 2,
+                    3 * page_size // 2,
+                ),
+                # A reused request contributes no new page demand.
+                (
+                    "zero_length_extend",
+                    [page_size + 1],
+                    [page_size + 1],
+                    0,
+                    0,
+                ),
+            )
+
+            for name, prefix_lens, seq_lens, available_size, expected_evict in cases:
+                with self.subTest(page_size=page_size, case=name):
+                    result, expected, tree_cache, allocator = _call_alloc_extend(
+                        page_size=page_size,
+                        available_size=available_size,
+                        prefix_lens=prefix_lens,
+                        seq_lens=seq_lens,
+                    )
+
+                    torch.testing.assert_close(result, expected)
+                    if expected_evict:
+                        tree_cache.evict.assert_called_once_with(
+                            EvictParams(num_tokens=expected_evict)
+                        )
+                    else:
+                        tree_cache.evict.assert_not_called()
+                    allocator.alloc_extend.assert_called_once()
+                    self.assertEqual(allocator.alloc_extend.call_args.kwargs, {})
+
+    def test_partial_page_extend_preserves_cached_prefix(self):
+        page_size = 64
+        allocator = SimpleNamespace(
+            page_size=page_size,
+            device=torch.device("cpu"),
+            available_size=MagicMock(return_value=0),
+            alloc_extend=MagicMock(return_value=torch.tensor([64])),
+            free_segment=MagicMock(),
+        )
+        tree_cache = RadixCache.create_simulated(
+            mock_allocator=allocator, page_size=page_size
+        )
+        cached_key = RadixKey(array("q", range(page_size)))
+        tree_cache.insert(InsertParams(key=cached_key, value=torch.arange(page_size)))
+
+        prefix_lens = torch.tensor([page_size - 1], dtype=torch.int64)
+        seq_lens = torch.tensor([page_size], dtype=torch.int64)
+        result = alloc_paged_token_slots_extend(
+            tree_cache=tree_cache,
+            prefix_lens=prefix_lens,
+            prefix_lens_cpu=prefix_lens,
+            seq_lens=seq_lens,
+            seq_lens_cpu=seq_lens,
+            last_loc=torch.tensor([page_size - 2], dtype=torch.int64),
+            extend_num_tokens=1,
         )
 
-        torch.testing.assert_close(result, expected)
-        tree_cache.evict.assert_not_called()
-        allocator.alloc_extend.assert_called_once()
-        self.assertEqual(allocator.alloc_extend.call_args.kwargs, {})
+        torch.testing.assert_close(result, torch.tensor([64]))
+        self.assertEqual(tree_cache.total_size(), page_size)
+        allocator.free_segment.assert_not_called()
+        match = tree_cache.match_prefix(MatchPrefixParams(key=cached_key))
+        self.assertEqual(len(match.device_indices), page_size)
 
     def test_mixed_batch_evicts_only_exact_page_shortfall(self):
         # Previous target: 129 + 4 * 64 = 385 tokens, or a 353-token


### PR DESCRIPTION
## Motivation

`alloc_paged_token_slots_extend()` overestimates the capacity needed before
paged prefill allocation as:

```python
extend_num_tokens + batch_size * page_size
```

This ignores free slots in each request's existing partial tail page and can
evict reusable prefixes even when the allocation already fits.

For example, with `page_size=64`, `prefix_len=63`, and `seq_len=64`, the
one-token extend fits in the existing tail page and requires zero new pages.
The current estimate still requests 65 token slots of eviction headroom.

## Modifications

- Set the paged-prefill eviction target to
  `get_num_new_pages() * page_size`.
- Add CPU regression tests for page boundaries, cached-prefix survival, and a
  mixed-batch capacity shortfall.

## Accuracy Tests

Target regression:

```bash
PYTHONPATH=python python -m pytest -q \
  test/registered/unit/mem_cache/test_paged_alloc_extend_eviction.py
```

```text
3 passed, 15 subtests passed
```

The tests cover page sizes 16, 64, and 128, verify that a zero-new-page extend
preserves an evictable `RadixCache` prefix, and check a mixed batch where the
eviction shortfall drops from 353 tokens to the exact 32 tokens.

Adjacent allocator regression:

```bash
PYTHONPATH=python python -m pytest -q \
  test/registered/unit/mem_cache/test_paged_alloc_extend_eviction.py \
  test/registered/unit/mem_cache/test_swa_alloc_extend_page_estimation.py \
  test/registered/unit/mem_cache/test_multi_ended_allocator.py \
  test/registered/unit/mem_cache/test_hisparse_allocator.py \
  -k 'not TestO3FusedAllocBind'
```

```text
70 passed, 11 deselected, 15 subtests passed
```

`TestO3FusedAllocBind` was excluded locally because its unrelated Triton JIT
tests require Python development headers that are not installed on the test
host.

## Speed Tests and Profiling

One additional CPU `get_num_new_pages()` call costs about 9-10 us per paged
extend batch in the local microbenchmark (batch sizes 1-128). Its inputs are CPU
tensors, so this does not introduce GPU synchronization.

No general throughput improvement is claimed; the change only avoids
unnecessary prefix eviction under page-level cache pressure.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (No user-facing API or configuration change.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32919873078](https://github.com/sgl-project/sglang/actions/runs/32919873078)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32919872939](https://github.com/sgl-project/sglang/actions/runs/32919872939)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32919873067](https://github.com/sgl-project/sglang/actions/runs/32919873067)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->