### PR TITLE
[Diffusion] Native SANA-WM stage-2 refiner stack

### DIFF
--- a/docs/cookbook/diffusion/SANA-WM/SANA-WM.mdx
+++ b/docs/cookbook/diffusion/SANA-WM/SANA-WM.mdx
@@ -65,7 +65,7 @@ Both repo ids are registered in SGLang's **built-in model-overlay registry**, so
 
 The materialized checkpoint is a Diffusers directory whose `model_index.json` declares the loadable components:
 
-| Component (`model_index.json`) | Class |
+| Component (`model_index.json`) | Checkpoint class |
 |---|---|
 | `transformer` (Stage-1 DiT) | `diffusers.SanaWMTransformer3DModel` |
 | `vae` | `diffusers.AutoencoderKLCausalLTX2Video` |
@@ -78,7 +78,7 @@ How loading works:
 - The server resolves the checkpoint via `maybe_download_model(model_path, force_diffusers_model=True)` and verifies it contains a `model_index.json` plus the required component subdirectories (`transformer/`, `vae/`).
 - If `text_encoder` / `tokenizer` are not provided as component paths, the pipeline falls back to the default Stage-1 text encoder **`Efficient-Large-Model/gemma-2-2b-it`** (`DEFAULT_SANA_WM_TEXT_ENCODER`).
 - **Pick the path with `--pipeline-class-name`.** The checkpoint's `model_index.json` `_class_name` selects the default pipeline (`SanaWMTwoStagePipeline`). Pin it explicitly to choose: `--pipeline-class-name SanaWMTwoStagePipeline` for the `/v1/videos` paths (§4–5) or `--pipeline-class-name SanaWMRealtimePipeline` for live realtime (§6). Pinning is also required if you point `--model-path` at a bare safetensors file instead of a Diffusers directory.
-- **The Stage-2 LTX-2 refiner** lives under `refiner/` in the checkpoint: `refiner/transformer` (`transformer_2`), `refiner/connectors` (`connectors`), and `refiner/text_encoder` (the Gemma-3 encoder for `text_encoder_2`, whose tokenizer also serves as `tokenizer_2`). The refiner is **optional**: it is skipped (Stage-1-only output) when the env flag `SGLANG_SANA_WM_SKIP_REFINER` (or a `skip_refiner` request extra) is set, or when no `refiner/` is present (`transformer_2` unloaded). On the batch path it runs chunk-wise with `--refiner-chunked` (the official streaming path, default on) or whole-clip without it; on the realtime path the pipeline builds a `SanaWMChunkedRefinerChainStage` only when a refiner is available, and otherwise streams Stage-1 frames.
+- **The Stage-2 LTX-2 refiner** lives under `refiner/` in the checkpoint: `refiner/transformer` (`transformer_2`), `refiner/connectors` (`connectors`), and `refiner/text_encoder` (the Gemma-3 encoder for `text_encoder_2`, whose tokenizer also serves as `tokenizer_2`). These directories keep their Diffusers/Transformers checkpoint formats, but SGLang loads native refiner, connector, and text-only Gemma-3 modules; the unused Gemma-3 vision tower is not materialized. All three weighted refiner components support layerwise offload. The refiner is skipped (Stage-1-only output) when `SGLANG_SANA_WM_SKIP_REFINER` or a `skip_refiner` request extra is set. On the batch path it runs chunk-wise with `--refiner-chunked` (the official streaming path, default on) or whole-clip without it.
 
 <Note>
 Throughout this cookbook, `<checkpoint>` stands for the appropriate SANA-WM repo id from the table above (or a local materialized Diffusers directory).
@@ -180,11 +180,11 @@ sglang serve \
 Common launch variants:
 
 ```bash Command
-# recommended multi-GPU realtime profile
+# multi-GPU weight sharding
 sglang serve \
   --model-path Efficient-Large-Model/SANA-WM_streaming \
   --pipeline-class-name SanaWMRealtimePipeline \
-  --num-gpus 8 --sp-degree 8 \
+  --num-gpus 8 --use-fsdp-inference \
   --host 127.0.0.1 --port 30000
 
 # single GPU
@@ -193,20 +193,20 @@ sglang serve \
   --pipeline-class-name SanaWMRealtimePipeline \
   --num-gpus 1 --host 127.0.0.1 --port 30000
 
-# offload DiT + text encoder to CPU (tight VRAM)
+# layerwise offload the large Stage-2 refiner components (tight VRAM)
 sglang serve \
   --model-path Efficient-Large-Model/SANA-WM_streaming \
   --pipeline-class-name SanaWMRealtimePipeline \
   --host 127.0.0.1 --port 30000 \
-  --dit-cpu-offload --text-encoder-cpu-offload
+  --layerwise-offload-components transformer_2 text_encoder_2 connectors
 ```
 
 Notes on launch behavior:
 
 - **Default endpoint** is `127.0.0.1:30000` (`--host` / `--port` override).
-- **CPU offload flags are optional.** `--dit-cpu-offload`, `--text-encoder-cpu-offload`, and `--image-encoder-cpu-offload` are available; defaults are auto-adjusted from GPU memory (GPUs under 30 GB get more aggressive offloading).
-- **Multi-GPU realtime.** Prefer explicit sequence parallelism (`--sp-degree` equal to the number of GPUs for a single session). Do not enable CFG parallel for the realtime profile: the default realtime request uses `guidance_scale=1.0`, while CFG parallel requires active cond/uncond branches.
-- **FSDP.** Use `--use-fsdp-inference` only when you specifically need weight sharding for memory. For the low-latency realtime profile, prefer keeping components resident and using SP first.
+- **Residency controls are optional.** `--layerwise-offload-components` accepts every weighted refiner component shown above. The legacy `--dit-cpu-offload` and `--text-encoder-cpu-offload` flags remain supported; `--cpu-offload-components` is the explicit component-level alternative.
+- **Multi-GPU realtime.** SANA-WM currently rejects tensor and sequence parallelism. Use FSDP when weight sharding is required. Do not enable CFG parallel for the realtime profile: its default `guidance_scale=1.0` has no cond/uncond branches.
+- **FSDP.** Use `--use-fsdp-inference` only when weight sharding is required. For the low-latency realtime profile, keep components resident when memory allows.
 - **Warmup.** Server warmup is **automatically skipped** for the realtime pipeline — a synthetic warmup request has no WebSocket session, so the server detects the registered realtime adapter and skips it. No explicit `--warmup-mode` setting is needed.
 
 Once up, the realtime WebSocket endpoint lives at `ws://127.0.0.1:30000/v1/realtime_video/generate` (use the Python client in §7 to connect — plain `curl` does not speak the `ws://` upgrade).

--- a/docs/docs/sglang-diffusion/compatibility_matrix.mdx
+++ b/docs/docs/sglang-diffusion/compatibility_matrix.mdx
@@ -174,7 +174,7 @@ Rows are grouped when a family shares the same runtime path or optimization supp
           <tr>
             <td>SANA-WM</td>
             <td><div className="sgd-id-list"><code>Efficient-Large-Model/SANA-WM_bidirectional</code><code>Efficient-Large-Model/SANA-WM_streaming</code></div></td>
-            <td>World-model pipeline with bidirectional and streaming checkpoints.</td>
+            <td>Native world-model pipeline with bidirectional and streaming checkpoints; the LTX-2 refiner, connectors, and text-only Gemma-3 encoder support layerwise offload.</td>
           </tr>
         </tbody>
       </table>

--- a/python/sglang/multimodal_gen/configs/models/encoders/gemma_3.py
+++ b/python/sglang/multimodal_gen/configs/models/encoders/gemma_3.py
@@ -17,11 +17,7 @@ from sglang.multimodal_gen.configs.models.fsdp import (
 
 @dataclass
 class Gemma3ArchConfig(TextEncoderArchConfig):
-    """Minimal Gemma text-encoder config for tokenizer kwargs.
-
-    Note: runtime will load the actual `text_encoder/` module from the model repo
-    (e.g. Gemma3Model) via transformers; this config mainly controls tokenization.
-    """
+    """Gemma-3 text and vision architecture metadata."""
 
     vocab_size: int = 32000
     hidden_size: int = 4096

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/base.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/base.py
@@ -267,6 +267,25 @@ class PipelineConfig:
         # return the model-specific config for optimal deployment setting
         return ModelDeploymentConfig()
 
+    def resolve_dit_component(
+        self,
+        component_name: str,
+        default_config: DiTConfig,
+        default_model_class_name: str,
+    ) -> tuple[DiTConfig, str]:
+        """Resolve the config and native implementation for a DiT component."""
+        del component_name
+        return default_config, default_model_class_name
+
+    def resolve_text_encoder_architectures(
+        self,
+        component_name: str,
+        default_architectures: list[str],
+    ) -> list[str]:
+        """Resolve the native implementation for a text-encoder component."""
+        del component_name
+        return default_architectures
+
     def validate_server_args(self, server_args: Any) -> None:
         """Validate model-owned constraints after server args are normalized."""
 

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/sana_wm.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/sana_wm.py
@@ -8,9 +8,13 @@ import torch
 
 from sglang.multimodal_gen.configs.models import DiTConfig, VAEConfig
 from sglang.multimodal_gen.configs.models.dits.sana_wm import SanaWMConfig
+from sglang.multimodal_gen.configs.models.dits.sana_wm_refiner import (
+    SanaWMRefinerConfig,
+)
 from sglang.multimodal_gen.configs.models.encoders import BaseEncoderOutput
 from sglang.multimodal_gen.configs.models.encoders.base import EncoderConfig
 from sglang.multimodal_gen.configs.models.encoders.gemma2 import Gemma2Config
+from sglang.multimodal_gen.configs.models.encoders.gemma_3 import Gemma3Config
 from sglang.multimodal_gen.configs.models.vaes.ltx_video import LTXVideoVAEConfig
 from sglang.multimodal_gen.configs.pipeline_configs.base import (
     ModelTaskType,
@@ -56,6 +60,7 @@ class SanaWMPipelineConfig(PipelineConfig):
     optional 6-DoF camera trajectory, optional Stage-2 LTX-2 refiner)."""
 
     task_type: ModelTaskType = ModelTaskType.TI2V
+    native_only_components = ("transformer_2", "connectors", "text_encoder_2")
 
     # SanaWMBeforeDenoisingStage._splice_first_frame handles condition-image
     # resize + VAE-encode itself, so bypass the framework's generic TI2V
@@ -94,6 +99,7 @@ class SanaWMPipelineConfig(PipelineConfig):
 
     # --- DiT ---
     dit_config: DiTConfig = field(default_factory=SanaWMConfig)
+    refiner_dit_config: DiTConfig = field(default_factory=SanaWMRefinerConfig)
 
     # --- VAE: LTX-2 (128ch, 8× temporal, 32× spatial) ---
     vae_config: VAEConfig = field(default_factory=LTXVideoVAEConfig)
@@ -121,11 +127,13 @@ class SanaWMPipelineConfig(PipelineConfig):
             self.vae_tile_sample_min_num_frames - self.vae_tile_sample_stride_num_frames
         )
 
-    # --- Text encoder: Gemma-2-2b-it (single encoder, same as SANA T2I) ---
+    # --- Text encoders: stage-1 Gemma-2 and stage-2 refiner Gemma-3 ---
     text_encoder_configs: tuple[EncoderConfig, ...] = field(
-        default_factory=lambda: (Gemma2Config(),)
+        default_factory=lambda: (Gemma2Config(), Gemma3Config())
     )
-    text_encoder_precisions: tuple[str, ...] = field(default_factory=lambda: ("bf16",))
+    text_encoder_precisions: tuple[str, ...] = field(
+        default_factory=lambda: ("bf16", "bf16")
+    )
     text_encoder_extra_args: list[dict] = field(
         default_factory=lambda: [
             {
@@ -133,16 +141,53 @@ class SanaWMPipelineConfig(PipelineConfig):
                 # branches must have the same token dimension for CFG concat.
                 "padding": "max_length",
                 "return_attention_mask": True,
-            }
+            },
+            {},
         ]
     )
     chi_prompt: tuple[str, ...] = SANA_WM_CHI_PROMPT
     preprocess_text_funcs: tuple[Callable | None, ...] = field(
-        default_factory=lambda: (None,)
+        default_factory=lambda: (None, None)
     )
     postprocess_text_funcs: tuple[Callable, ...] = field(
-        default_factory=lambda: (sana_wm_postprocess_text,)
+        default_factory=lambda: (sana_wm_postprocess_text, sana_wm_postprocess_text)
     )
+
+    def resolve_dit_component(
+        self,
+        component_name: str,
+        default_config: DiTConfig,
+        default_model_class_name: str,
+    ) -> tuple[DiTConfig, str]:
+        if component_name != "transformer_2":
+            return super().resolve_dit_component(
+                component_name,
+                default_config,
+                default_model_class_name,
+            )
+        if default_model_class_name != "LTX2VideoTransformer3DModel":
+            raise ValueError(
+                "SANA-WM transformer_2 must use LTX2VideoTransformer3DModel "
+                f"weights, got {default_model_class_name}."
+            )
+        return self.refiner_dit_config, "SanaWMLTX2VideoRefiner"
+
+    def resolve_text_encoder_architectures(
+        self,
+        component_name: str,
+        default_architectures: list[str],
+    ) -> list[str]:
+        if component_name != "text_encoder_2":
+            return super().resolve_text_encoder_architectures(
+                component_name,
+                default_architectures,
+            )
+        if "Gemma3ForConditionalGeneration" not in default_architectures:
+            raise ValueError(
+                "SANA-WM text_encoder_2 must use Gemma3ForConditionalGeneration "
+                f"weights, got {default_architectures}."
+            )
+        return ["Gemma3TextEncoder"]
 
     # --- Scheduler ---
     # linear_flow training schedule from the released config.yaml.

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/text_encoder_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/text_encoder_loader.py
@@ -10,6 +10,7 @@ import torch
 import torch.distributed as dist
 from torch import nn
 from torch.distributed import init_device_mesh
+from transformers import PretrainedConfig
 from transformers.utils import SAFE_WEIGHTS_INDEX_NAME
 
 from sglang.multimodal_gen.configs.models import EncoderConfig, ModelConfig
@@ -345,17 +346,20 @@ class TextEncoderLoader(ComponentLoader):
         encoder_config = server_args.pipeline_config.text_encoder_configs[encoder_index]
         encoder_config.update_model_arch(model_config)
 
-        if encoder_index == 0:
-            for key, value in diffusers_pretrained_config.__dict__.items():
+        for key, value in diffusers_pretrained_config.__dict__.items():
+            if encoder_index == 0 or isinstance(value, PretrainedConfig):
                 setattr(encoder_config.arch_config, key, value)
         post_diffusers_config_update = getattr(
             encoder_config, "post_diffusers_config_update", None
         )
         if post_diffusers_config_update is not None:
             post_diffusers_config_update()
-        model_cls, _ = ModelRegistry.resolve_model_cls(
-            getattr(encoder_config, "architectures", [])
+        architectures = server_args.pipeline_config.resolve_text_encoder_architectures(
+            component_name,
+            list(getattr(encoder_config, "architectures", [])),
         )
+        encoder_config.arch_config.architectures = architectures
+        model_cls, _ = ModelRegistry.resolve_model_cls(architectures)
         # real dims are populated now; resolve fold vs replicate
         finalize_encoder_folding(
             encoder_config,

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/transformer_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/transformer_loader.py
@@ -154,6 +154,7 @@ class TransformerLoader(ComponentLoader):
         self, component_model_path: str, server_args: ServerArgs, component_name: str
     ):
         """Load the transformer based on the model path, and inference args."""
+        requested_component_name = component_name
         component_server_args = _server_args_for_transformer_component(
             server_args, component_name
         )
@@ -172,18 +173,26 @@ class TransformerLoader(ComponentLoader):
 
         # 2. dit config
         # Config from Diffusers supersedes sgl_diffusion's model config
-        component_name = _normalize_component_type(component_name)
-        server_args.model_paths[component_name] = component_model_path
-        if component_name in ("transformer", "unconditional_transformer", "video_dit"):
+        normalized_component_name = _normalize_component_type(component_name)
+        server_args.model_paths[requested_component_name] = component_model_path
+        if normalized_component_name in (
+            "transformer",
+            "unconditional_transformer",
+            "video_dit",
+        ):
             pipeline_dit_config_attr = "dit_config"
-        elif component_name in ("audio_dit",):
+        elif normalized_component_name == "audio_dit":
             pipeline_dit_config_attr = "audio_dit_config"
         else:
-            raise ValueError(f"Invalid module name: {component_name}")
+            raise ValueError(f"Invalid module name: {requested_component_name}")
         dit_config = getattr(server_args.pipeline_config, pipeline_dit_config_attr)
+        source_cls_name = config.pop("_class_name")
+        dit_config, cls_name = server_args.pipeline_config.resolve_dit_component(
+            requested_component_name,
+            dit_config,
+            source_cls_name,
+        )
         dit_config.update_model_arch(config)
-
-        cls_name = config.pop("_class_name")
         model_cls, _ = ModelRegistry.resolve_model_cls(cls_name)
 
         quant_spec = resolve_transformer_quant_load_spec(
@@ -275,7 +284,7 @@ class TransformerLoader(ComponentLoader):
             logger.warning(
                 "Direct GPU weight loading is enabled for %s; the complete checkpoint "
                 "state dict and materialized model weights may coexist on GPU during startup",
-                component_name,
+                requested_component_name,
             )
 
         quantized_attn_backend = _default_quantized_attention_backend(
@@ -288,7 +297,7 @@ class TransformerLoader(ComponentLoader):
             )
         attn_backend_context = (
             component_attn_backend_context_manager(
-                quantized_attn_backend, component_name=component_name
+                quantized_attn_backend, component_name=requested_component_name
             )
             if quantized_attn_backend is not None
             else nullcontext()

--- a/python/sglang/multimodal_gen/runtime/loader/fsdp_load.py
+++ b/python/sglang/multimodal_gen/runtime/loader/fsdp_load.py
@@ -60,6 +60,15 @@ logger = init_logger(__name__)
 _DTYPE_MISMATCH_EXAMPLE_LIMIT = 3
 
 
+def _unexpected_checkpoint_keys(
+    model: nn.Module, skipped_checkpoint_keys: list[str]
+) -> list[str]:
+    is_expected = getattr(model, "is_expected_unloaded_checkpoint_key", None)
+    if not callable(is_expected):
+        return skipped_checkpoint_keys
+    return [key for key in skipped_checkpoint_keys if not is_expected(key)]
+
+
 def _is_bitsandbytes_quant_config(quant_config: Any | None) -> bool:
     if quant_config is None:
         return False
@@ -825,19 +834,31 @@ def load_model_from_full_model_state_dict(
             local_main_process_only=True,
         )
 
-    if skipped_checkpoint_keys:
+    unexpected_checkpoint_keys = _unexpected_checkpoint_keys(
+        model, skipped_checkpoint_keys
+    )
+    expected_skipped_count = len(skipped_checkpoint_keys) - len(
+        unexpected_checkpoint_keys
+    )
+    if expected_skipped_count:
+        logger.debug(
+            "Skipped %d checkpoint keys declared unused by %s.",
+            expected_skipped_count,
+            model.__class__.__name__,
+        )
+    if unexpected_checkpoint_keys:
         logger.warning(
             "Checkpoint keys not loaded (no matching model parameter) %s",
             (
-                skipped_checkpoint_keys[:20]
-                if len(skipped_checkpoint_keys) > 20
-                else skipped_checkpoint_keys
+                unexpected_checkpoint_keys[:20]
+                if len(unexpected_checkpoint_keys) > 20
+                else unexpected_checkpoint_keys
             ),
         )
-        if len(skipped_checkpoint_keys) > 20:
+        if len(unexpected_checkpoint_keys) > 20:
             logger.warning(
                 "... and %d more skipped keys.",
-                len(skipped_checkpoint_keys) - 20,
+                len(unexpected_checkpoint_keys) - 20,
             )
 
     # parameters in nn.Module that doesn't exist in safetensor files

--- a/python/sglang/multimodal_gen/runtime/models/adapter/ltx_2_connector.py
+++ b/python/sglang/multimodal_gen/runtime/models/adapter/ltx_2_connector.py
@@ -6,12 +6,14 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from diffusers.models.attention import FeedForward
 
 from sglang.multimodal_gen.configs.models.adapter.ltx_2_connector import (
     LTX2ConnectorConfig,
 )
 from sglang.multimodal_gen.runtime.layers.attention import USPAttention
+from sglang.multimodal_gen.runtime.managers.memory_managers.layerwise_offload import (
+    LayerwiseOffloadableModuleMixin,
+)
 from sglang.multimodal_gen.runtime.platforms import AttentionBackendEnum
 
 
@@ -341,6 +343,35 @@ class LTX2RotaryPosEmbed1d(nn.Module):
         return cos_freqs, sin_freqs
 
 
+class LTX2ConnectorGELU(nn.Module):
+    def __init__(self, dim_in: int, dim_out: int):
+        super().__init__()
+        self.proj = nn.Linear(dim_in, dim_out)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return F.gelu(self.proj(hidden_states), approximate="tanh")
+
+
+class LTX2ConnectorFeedForward(nn.Module):
+    def __init__(self, dim: int, activation_fn: str):
+        super().__init__()
+        if activation_fn != "gelu-approximate":
+            raise ValueError(f"Unsupported connector activation: {activation_fn}")
+        inner_dim = dim * 4
+        self.net = nn.ModuleList(
+            [
+                LTX2ConnectorGELU(dim, inner_dim),
+                nn.Dropout(0.0),
+                nn.Linear(inner_dim, dim),
+            ]
+        )
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        for layer in self.net:
+            hidden_states = layer(hidden_states)
+        return hidden_states
+
+
 class LTX2TransformerBlock1d(nn.Module):
     def __init__(
         self,
@@ -365,7 +396,7 @@ class LTX2TransformerBlock1d(nn.Module):
         )
 
         self.norm2 = torch.nn.RMSNorm(dim, eps=eps, elementwise_affine=False)
-        self.ff = FeedForward(dim, activation_fn=activation_fn)
+        self.ff = LTX2ConnectorFeedForward(dim, activation_fn=activation_fn)
 
     def forward(
         self,
@@ -509,7 +540,6 @@ class LTX2ConnectorTransformer1d(nn.Module):
             batch_size,
             seq_len,
             device=hidden_states.device,
-            dtype=hidden_states.dtype,
         )
 
         # 3. Run 1D transformer blocks
@@ -528,11 +558,17 @@ class LTX2ConnectorTransformer1d(nn.Module):
         return hidden_states, attention_mask
 
 
-class LTX2TextConnectors(nn.Module):
+class LTX2TextConnectors(nn.Module, LayerwiseOffloadableModuleMixin):
     """
     Text connector stack used by LTX 2.0 to process the packed text encoder hidden states for both the video and audio
     streams.
     """
+
+    layerwise_offload_dit_group_enabled = False
+    layer_names = [
+        "video_connector.transformer_blocks",
+        "audio_connector.transformer_blocks",
+    ]
 
     def __init__(
         self,

--- a/python/sglang/multimodal_gen/runtime/models/dits/sana_wm_refiner_transformer.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/sana_wm_refiner_transformer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Any, Optional
 
 import torch
@@ -26,6 +27,8 @@ from sglang.multimodal_gen.runtime.models.dits.ltx_2 import (
     LTX2AudioVideoRotaryPosEmbed,
     LTX2FeedForward,
     LTX2TextProjection,
+    apply_interleaved_rotary_emb,
+    apply_split_rotary_emb,
 )
 
 
@@ -66,56 +69,165 @@ def unpack_latents(
     )
 
 
-def _slice_rope(
-    rope: tuple[torch.Tensor, torch.Tensor], start: int, end: Optional[int] = None
-) -> tuple[torch.Tensor, torch.Tensor]:
-    """Slice along token axis for either interleaved (rank-3) or split (rank-4)."""
-    cos, sin = rope
-    end_ = end if end is not None else cos.shape[-2 if cos.ndim == 4 else 1]
-    if cos.ndim == 3:
-        return cos[:, start:end_], sin[:, start:end_]
-    if cos.ndim == 4:
-        return cos[:, :, start:end_, :], sin[:, :, start:end_, :]
-    raise ValueError(f"Unexpected RoPE rank: {cos.ndim}")
+def _apply_refiner_rope(
+    hidden_states: torch.Tensor,
+    rotary_emb: tuple[torch.Tensor, torch.Tensor],
+) -> torch.Tensor:
+    if rotary_emb[0].ndim == 3:
+        return apply_interleaved_rotary_emb(hidden_states, rotary_emb).to(
+            hidden_states.dtype
+        )
+    if rotary_emb[0].ndim == 4:
+        return apply_split_rotary_emb(hidden_states, rotary_emb)
+    raise ValueError(f"Unexpected refiner RoPE rank: {rotary_emb[0].ndim}")
 
 
-def _streaming_self_attention(
-    attn: LTX2Attention,
+class SanaWMRefinerSelfAttention(LTX2Attention):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.capture_kv_before_rope = False
+        self.capture_kv_after_rope = False
+        self.kv_prefix: dict[str, Any] | None = None
+        self.captured_kv_before_rope: tuple[torch.Tensor, torch.Tensor] | None = None
+        self.captured_kv_after_rope: tuple[torch.Tensor, torch.Tensor] | None = None
+
+    def set_kv_capture(self, mode: str, enabled: bool) -> None:
+        if mode == "pre_rope":
+            self.capture_kv_before_rope = enabled
+            if enabled:
+                self.captured_kv_before_rope = None
+            return
+        if mode == "post_rope":
+            self.capture_kv_after_rope = enabled
+            if enabled:
+                self.captured_kv_after_rope = None
+            return
+        raise ValueError(f"Unsupported KV capture mode: {mode}")
+
+    def take_captured_kv(self, mode: str) -> tuple[torch.Tensor, torch.Tensor]:
+        if mode == "pre_rope":
+            captured = self.captured_kv_before_rope
+            self.captured_kv_before_rope = None
+        elif mode == "post_rope":
+            captured = self.captured_kv_after_rope
+            self.captured_kv_after_rope = None
+        else:
+            raise ValueError(f"Unsupported KV capture mode: {mode}")
+        if captured is None:
+            raise RuntimeError(f"Missing captured KV for mode {mode}")
+        return captured
+
+
+def refiner_self_attention(
+    attn: SanaWMRefinerSelfAttention,
     hidden_states: torch.Tensor,
     video_rotary_emb: tuple[torch.Tensor, torch.Tensor],
     n_context_tokens: int,
 ) -> torch.Tensor:
-    """Streaming SLA: context attends to context only, current attends to context+current.
-
-    Mirrors NVlabs `inference_sana_wm.py::_streaming_self_attention`.
-    """
-    seq_len = hidden_states.shape[1]
-    if n_context_tokens <= 0 or n_context_tokens >= seq_len:
-        return attn(hidden_states, context=None, pe=video_rotary_emb)
-
-    ctx_rope = _slice_rope(video_rotary_emb, 0, n_context_tokens)
-    out_ctx = attn(
-        hidden_states[:, :n_context_tokens],
-        context=None,
-        pe=ctx_rope,
+    """Run sink/current attention and the optional streaming KV-cache hooks."""
+    has_streaming_hooks = (
+        attn.capture_kv_before_rope
+        or attn.capture_kv_after_rope
+        or attn.kv_prefix is not None
     )
+    sequence_length = hidden_states.shape[1]
+    if not has_streaming_hooks and (
+        n_context_tokens <= 0 or n_context_tokens >= sequence_length
+    ):
+        return attn(
+            hidden_states,
+            pe=video_rotary_emb,
+            skip_sequence_parallel_override=True,
+        )
 
-    cur_rope = _slice_rope(video_rotary_emb, n_context_tokens, seq_len)
-    out_cur = attn(
-        hidden_states[:, n_context_tokens:],
-        context=hidden_states,
-        pe=cur_rope,
-        k_pe=video_rotary_emb,
-    )
-    return torch.cat([out_ctx, out_cur], dim=1)
+    gate_logits = None
+    if attn.to_gate_logits is not None:
+        gate_logits, _ = attn.to_gate_logits(hidden_states)
+
+    query, _ = attn.to_q(hidden_states)
+    key, _ = attn.to_k(hidden_states)
+    value, _ = attn.to_v(hidden_states)
+    if attn.qk_norm:
+        assert attn.q_norm is not None and attn.k_norm is not None
+        query_dtype, key_dtype = query.dtype, key.dtype
+        with torch.autocast(device_type=query.device.type, enabled=False):
+            query = attn.q_norm(query).to(query_dtype)
+            key = attn.k_norm(key).to(key_dtype)
+
+    if attn.capture_kv_before_rope:
+        attn.captured_kv_before_rope = (
+            key.detach().clone(),
+            value.detach().clone(),
+        )
+
+    query = _apply_refiner_rope(query, video_rotary_emb)
+    key = _apply_refiner_rope(key, video_rotary_emb)
+    if attn.capture_kv_after_rope:
+        attn.captured_kv_after_rope = (
+            key.detach().clone(),
+            value.detach().clone(),
+        )
+
+    prefix_length = 0
+    prefix = attn.kv_prefix
+    if isinstance(prefix, dict) and prefix.get("mode") == "rf_shifted_sink":
+        prefix_keys = []
+        prefix_values = []
+        sink_key = prefix.get("sink_k_pre")
+        sink_value = prefix.get("sink_v")
+        if sink_key is not None and sink_value is not None and sink_key.shape[1] > 0:
+            sink_rope = prefix.get("sink_pe")
+            if sink_rope is None:
+                raise ValueError("rf_shifted_sink prefix requires sink_pe")
+            prefix_keys.append(_apply_refiner_rope(sink_key.to(key.dtype), sink_rope))
+            prefix_values.append(sink_value.to(value.dtype))
+        history_key = prefix.get("history_k")
+        history_value = prefix.get("history_v")
+        if (
+            history_key is not None
+            and history_value is not None
+            and history_key.shape[1] > 0
+        ):
+            prefix_keys.append(history_key.to(key.dtype))
+            prefix_values.append(history_value.to(value.dtype))
+        if prefix_keys:
+            prefix_length = sum(prefix_key.shape[1] for prefix_key in prefix_keys)
+            key = torch.cat((*prefix_keys, key), dim=1)
+            value = torch.cat((*prefix_values, value), dim=1)
+
+    query = query.view(*query.shape[:2], attn.local_heads, attn.dim_head)
+    key = key.view(*key.shape[:2], attn.local_heads, attn.dim_head)
+    value = value.view(*value.shape[:2], attn.local_heads, attn.dim_head)
+    if n_context_tokens <= 0 or n_context_tokens >= sequence_length:
+        output = attn.attn(
+            query,
+            key,
+            value,
+            skip_sequence_parallel_override=True,
+        )
+    else:
+        context = attn.attn(
+            query[:, :n_context_tokens],
+            key[:, prefix_length : prefix_length + n_context_tokens],
+            value[:, prefix_length : prefix_length + n_context_tokens],
+            skip_sequence_parallel_override=True,
+        )
+        current = attn.attn(
+            query[:, n_context_tokens:],
+            key,
+            value,
+            skip_sequence_parallel_override=True,
+        )
+        output = torch.cat((context, current), dim=1)
+
+    if gate_logits is not None:
+        output = output * (2.0 * torch.sigmoid(gate_logits).unsqueeze(-1))
+    output, _ = attn.to_out[0](output.flatten(2))
+    return attn.to_out[1](output)
 
 
 class SanaWMRefinerBlock(nn.Module):
-    """Video-only LTX-2 transformer block.
-
-    Diffusers-compatible layout: `norm1 -> attn1 (self) -> norm2 -> attn2 (cross) -> norm3 -> ff`,
-    each modulated via per-block `scale_shift_table` + token-wise `temb`.
-    """
+    """Video-only LTX-2 transformer block with released-checkpoint key layout."""
 
     def __init__(
         self,
@@ -133,7 +245,7 @@ class SanaWMRefinerBlock(nn.Module):
         self.dim = int(dim)
 
         self.norm1 = nn.RMSNorm(self.dim, eps=norm_eps, elementwise_affine=False)
-        self.attn1 = LTX2Attention(
+        self.attn1 = SanaWMRefinerSelfAttention(
             query_dim=self.dim,
             heads=num_attention_heads,
             dim_head=attention_head_dim,
@@ -183,7 +295,7 @@ class SanaWMRefinerBlock(nn.Module):
         )
 
         normed = self.norm1(hidden_states) * (1 + scale_msa) + shift_msa
-        attn_out = _streaming_self_attention(
+        attn_out = refiner_self_attention(
             self.attn1,
             normed,
             video_rotary_emb,
@@ -209,8 +321,7 @@ class SanaWMLTX2VideoRefiner(CachableDiT, LayerwiseOffloadableModuleMixin):
     """SANA-WM stage-2 LTX-2 video-only refiner.
 
     Loads Diffusers-format refiner weights from `<model_path>/refiner/transformer/`.
-    Audio params present in the checkpoint are silently dropped by the loader's
-    `strict=False` state_dict load.
+    Audio and cross-modal params in that checkpoint are intentionally unused.
     """
 
     _fsdp_shard_conditions = [is_blocks_or_transformer_blocks]
@@ -218,6 +329,20 @@ class SanaWMLTX2VideoRefiner(CachableDiT, LayerwiseOffloadableModuleMixin):
     param_names_mapping = SanaWMRefinerArchConfig().param_names_mapping
     reverse_param_names_mapping: dict = {}
     lora_param_names_mapping: dict = {}
+    layer_names = ["transformer_blocks"]
+
+    @staticmethod
+    def is_expected_unloaded_checkpoint_key(name: str) -> bool:
+        if name.startswith(("audio_", "av_cross_attn_")):
+            return True
+        parts = name.split(".", 3)
+        if len(parts) < 3 or parts[0] != "transformer_blocks":
+            return False
+        branch = parts[2]
+        return branch.startswith("audio_") or branch in {
+            "video_a2v_cross_attn_scale_shift_table",
+            "video_to_audio_attn",
+        }
 
     def __init__(
         self,
@@ -295,13 +420,6 @@ class SanaWMLTX2VideoRefiner(CachableDiT, LayerwiseOffloadableModuleMixin):
             quant_config=quant_config,
         )
 
-        # LTX2AudioVideoRotaryPosEmbed expects `dim` to be the *total* hidden
-        # size (num_heads * head_dim), not the per-head dim. It internally
-        # reshapes cos/sin to (B, T, num_heads, head_dim/2). Passing
-        # `attention_head_dim` here would size the RoPE to head_dim/num_heads
-        # and produce a (1, num_heads, L, 2) cos/sin that won't match
-        # LTX2Attention's q/k. See LTX2Transformer3DAVModel.__init__ in
-        # ltx_2.py for the canonical convention (`dim=self.hidden_size`).
         self.rope = LTX2AudioVideoRotaryPosEmbed(
             dim=self.hidden_size,
             patch_size=self.patch_size,
@@ -318,82 +436,66 @@ class SanaWMLTX2VideoRefiner(CachableDiT, LayerwiseOffloadableModuleMixin):
             num_attention_heads=self.num_attention_heads,
         )
 
-        self.layer_names = ["transformer_blocks"]
-
     def _scale_timestep_for_adaln(self, timestep: torch.Tensor) -> torch.Tensor:
         return timestep * self.timestep_scale_multiplier
 
-    def forward(
+    def set_streaming_kv_prefixes(
+        self, prefixes: Sequence[dict[str, Any] | None] | None
+    ) -> None:
+        if prefixes is None:
+            self.clear_streaming_kv_prefixes()
+            return
+        if len(prefixes) != len(self.transformer_blocks):
+            raise ValueError(
+                "Expected one KV prefix per refiner block, got "
+                f"{len(prefixes)} for {len(self.transformer_blocks)} blocks."
+            )
+        for block, prefix in zip(self.transformer_blocks, prefixes, strict=True):
+            block.attn1.kv_prefix = prefix
+
+    def clear_streaming_kv_prefixes(self) -> None:
+        for block in self.transformer_blocks:
+            block.attn1.kv_prefix = None
+
+    def set_streaming_kv_capture(self, mode: str, enabled: bool) -> None:
+        for block in self.transformer_blocks:
+            block.attn1.set_kv_capture(mode, enabled)
+
+    def take_streaming_kv(self, mode: str) -> list[tuple[torch.Tensor, torch.Tensor]]:
+        return [block.attn1.take_captured_kv(mode) for block in self.transformer_blocks]
+
+    def forward_tokens(
         self,
         hidden_states: torch.Tensor,
         encoder_hidden_states: torch.Tensor,
         timestep: torch.Tensor,
-        encoder_hidden_states_image=None,
+        video_rotary_emb: tuple[torch.Tensor, torch.Tensor],
         encoder_attention_mask: Optional[torch.Tensor] = None,
-        num_frames: Optional[int] = None,
-        height: Optional[int] = None,
-        width: Optional[int] = None,
-        fps: float = 24.0,
         n_context_tokens: int = 0,
-        guidance=None,
-        **kwargs,
     ) -> torch.Tensor:
-        # Accept either packed (B, L, in_dim) or raw 5D (B, C, T, H, W).
-        if hidden_states.dim() == 5:
-            B_, _, T_, H_, W_ = hidden_states.shape
-            if num_frames is None:
-                num_frames = T_
-            if height is None:
-                height = H_
-            if width is None:
-                width = W_
-            hidden_states = pack_latents(
-                hidden_states,
-                patch_size=self.patch_size,
-                patch_size_t=self.patch_size_t,
-            )
-            packed_input = True
-        else:
-            if num_frames is None or height is None or width is None:
-                raise ValueError(
-                    "num_frames/height/width are required when hidden_states is pre-packed."
-                )
-            packed_input = False
-
-        B = hidden_states.size(0)
-
-        video_coords = self.rope.prepare_video_coords(
-            batch_size=B,
-            num_frames=num_frames,
-            height=height,
-            width=width,
-            device=hidden_states.device,
-            fps=fps,
-        )
-        video_rotary_emb = self.rope(
-            video_coords,
-            device=hidden_states.device,
-            out_dtype=hidden_states.dtype,
-        )
-
+        """Forward packed latent tokens with caller-provided absolute-position RoPE."""
+        batch_size = hidden_states.size(0)
         hidden_states, _ = self.proj_in(hidden_states)
 
-        scaled_t = self._scale_timestep_for_adaln(timestep)
+        if timestep.ndim == 3:
+            if timestep.shape[-1] != 1:
+                raise ValueError(
+                    "A rank-3 refiner timestep must have a singleton last dimension."
+                )
+            timestep = timestep.squeeze(-1)
         temb, embedded_timestep = self.time_embed(
-            scaled_t.flatten(), hidden_dtype=hidden_states.dtype
+            self._scale_timestep_for_adaln(timestep).flatten(),
+            hidden_dtype=hidden_states.dtype,
         )
-        if timestep.dim() >= 2:
-            temb = temb.view(B, -1, temb.size(-1))
-            embedded_timestep = embedded_timestep.view(
-                B, -1, embedded_timestep.size(-1)
-            )
-        else:
-            temb = temb.view(B, 1, temb.size(-1))
-            embedded_timestep = embedded_timestep.view(B, 1, embedded_timestep.size(-1))
+        temb = temb.view(batch_size, -1, temb.size(-1))
+        embedded_timestep = embedded_timestep.view(
+            batch_size, -1, embedded_timestep.size(-1)
+        )
 
         encoder_hidden_states = self.caption_projection(encoder_hidden_states)
-        encoder_hidden_states = encoder_hidden_states.view(B, -1, self.hidden_size)
-
+        encoder_hidden_states = encoder_hidden_states.view(
+            batch_size, -1, self.hidden_size
+        )
         for block in self.transformer_blocks:
             hidden_states = block(
                 hidden_states=hidden_states,
@@ -410,8 +512,71 @@ class SanaWMLTX2VideoRefiner(CachableDiT, LayerwiseOffloadableModuleMixin):
         shift, scale = scale_shift_values[:, :, 0], scale_shift_values[:, :, 1]
         hidden_states = self.norm_out(hidden_states) * (1 + scale) + shift
         hidden_states, _ = self.proj_out(hidden_states)
+        return hidden_states
 
-        if packed_input:
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        timestep: torch.Tensor,
+        encoder_hidden_states_image=None,
+        encoder_attention_mask: Optional[torch.Tensor] = None,
+        num_frames: Optional[int] = None,
+        height: Optional[int] = None,
+        width: Optional[int] = None,
+        fps: float = 24.0,
+        n_context_tokens: int = 0,
+        guidance=None,
+        **kwargs,
+    ) -> torch.Tensor:
+        input_is_packed = hidden_states.dim() == 3
+        if not input_is_packed:
+            if hidden_states.dim() != 5:
+                raise ValueError(
+                    "Refiner hidden_states must be packed 3D tokens or a 5D latent."
+                )
+            B_, _, T_, H_, W_ = hidden_states.shape
+            if num_frames is None:
+                num_frames = T_
+            if height is None:
+                height = H_
+            if width is None:
+                width = W_
+            hidden_states = pack_latents(
+                hidden_states,
+                patch_size=self.patch_size,
+                patch_size_t=self.patch_size_t,
+            )
+        else:
+            if num_frames is None or height is None or width is None:
+                raise ValueError(
+                    "num_frames/height/width are required when hidden_states is pre-packed."
+                )
+        batch_size = hidden_states.size(0)
+
+        video_coords = self.rope.prepare_video_coords(
+            batch_size=batch_size,
+            num_frames=num_frames,
+            height=height,
+            width=width,
+            device=hidden_states.device,
+            fps=fps,
+        )
+        video_rotary_emb = self.rope(
+            video_coords,
+            device=hidden_states.device,
+            out_dtype=hidden_states.dtype,
+        )
+
+        hidden_states = self.forward_tokens(
+            hidden_states=hidden_states,
+            encoder_hidden_states=encoder_hidden_states,
+            timestep=timestep,
+            video_rotary_emb=video_rotary_emb,
+            encoder_attention_mask=encoder_attention_mask,
+            n_context_tokens=n_context_tokens,
+        )
+        if input_is_packed:
             return hidden_states
         return unpack_latents(
             hidden_states,

--- a/python/sglang/multimodal_gen/runtime/models/encoders/gemma_3.py
+++ b/python/sglang/multimodal_gen/runtime/models/encoders/gemma_3.py
@@ -31,6 +31,24 @@ from sglang.multimodal_gen.runtime.utils.common import add_prefix
 
 logger = logging.getLogger(__name__)
 
+_GEMMA3_TEXT_WEIGHT_PREFIXES = (
+    "model.language_model.model.",
+    "language_model.model.",
+    "model.language_model.",
+    "language_model.",
+)
+
+
+def gemma3_text_weights(
+    weights: Iterable[Tuple[str, torch.Tensor]],
+) -> Iterable[Tuple[str, torch.Tensor]]:
+    """Select the language backbone from a multimodal Gemma-3 checkpoint."""
+    for name, weight in weights:
+        for prefix in _GEMMA3_TEXT_WEIGHT_PREFIXES:
+            if name.startswith(prefix):
+                yield name.removeprefix(prefix), weight
+                break
+
 
 def get_attention_sliding_window_size(config):
     return config.sliding_window - 1
@@ -940,6 +958,16 @@ class Gemma3TextModel(nn.Module):
         return loaded_params
 
 
+class Gemma3TextEncoder(Gemma3TextModel, LayerwiseOffloadableModuleMixin):
+    """Text-only Gemma-3 encoder for checkpoints that include an unused vision tower."""
+
+    layerwise_offload_dit_group_enabled = False
+    layer_names = ["layers"]
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> Set[str]:
+        return super().load_weights(gemma3_text_weights(weights))
+
+
 class Gemma3ForConditionalGeneration(nn.Module, LayerwiseOffloadableModuleMixin):
     # transformers 5.6.0 flattened SiglipVisionModel, dropping the
     # `vision_model` intermediate wrapper. Our reimpl keeps it, so remap
@@ -1247,4 +1275,4 @@ class Gemma3ForConditionalGeneration(nn.Module, LayerwiseOffloadableModuleMixin)
         return int(sliding_window) - 1
 
 
-EntryClass = Gemma3ForConditionalGeneration
+EntryClass = [Gemma3TextEncoder, Gemma3ForConditionalGeneration]

--- a/python/sglang/multimodal_gen/runtime/pipelines/sana_wm_pipeline.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines/sana_wm_pipeline.py
@@ -4,7 +4,9 @@ import os
 
 from sglang.multimodal_gen.configs.pipeline_configs.sana_wm import SanaWMPipelineConfig
 from sglang.multimodal_gen.configs.sample.sana_wm import SanaWMSamplingParams
-from sglang.multimodal_gen.runtime.loader.utils import get_memory_usage_of_component
+from sglang.multimodal_gen.runtime.loader.component_loaders.component_loader import (
+    PipelineComponentLoader,
+)
 from sglang.multimodal_gen.runtime.pipelines_core import LoRAPipeline
 from sglang.multimodal_gen.runtime.pipelines_core.composed_pipeline_base import (
     ComposedPipelineBase,
@@ -19,8 +21,6 @@ from sglang.multimodal_gen.runtime.pipelines_core.stages.model_specific_stages.s
     SanaWMTextEncodingStage,
 )
 from sglang.multimodal_gen.runtime.pipelines_core.stages.model_specific_stages.sana_wm.refiner import (
-    OfficialDiffusersLTX2RefinerModule,
-    OfficialGemma3TextEncoderModule,
     SanaWMLTX2RefinerStage,
     SanaWMRefinerDecodingStage,
     default_sana_wm_refiner_dtype,
@@ -149,15 +149,12 @@ class SanaWMTwoStagePipeline(SanaWMPipeline):
 
     pipeline_name = "SanaWMTwoStagePipeline"
 
-    # Stage-2 refiner sub-modules and their on-disk layout. Loaded through the
-    # official Diffusers/Transformers classes because NVlabs' reference refiner
-    # is a narrow video-only wrapper around those modules.
-    _REFINER_SUB_MODULES: tuple[tuple[str, str], ...] = (
-        ("transformer_2", "refiner/transformer"),
-        ("connectors", "refiner/connectors"),
-        ("text_encoder_2", "refiner/text_encoder"),
+    _REFINER_SUB_MODULES: tuple[tuple[str, str, str], ...] = (
+        ("transformer_2", "refiner/transformer", "diffusers"),
+        ("connectors", "refiner/connectors", "diffusers"),
+        ("text_encoder_2", "refiner/text_encoder", "transformers"),
         # The refiner Gemma-3 ships its tokenizer files alongside the encoder.
-        ("tokenizer_2", "refiner/text_encoder"),
+        ("tokenizer_2", "refiner/text_encoder", "transformers"),
     )
 
     def initialize_pipeline(self, server_args: ServerArgs) -> None:
@@ -204,79 +201,18 @@ class SanaWMTwoStagePipeline(SanaWMPipeline):
         return os.path.join(refiner_root, rel_subpath)
 
     def _load_refiner_modules(self, server_args: ServerArgs) -> None:
-        for module_name, subpath in self._REFINER_SUB_MODULES:
+        for module_name, subpath, library in self._REFINER_SUB_MODULES:
             component_path = self._resolve_refiner_component_path(
                 server_args, module_name, subpath
             )
-            logger.info(
-                "SANA-WM loading refiner component %s from %s",
-                module_name,
-                component_path,
-            )
-            module, memory_usage = self._load_official_refiner_component(
-                module_name,
-                component_path,
-                server_args,
+            module, memory_usage = PipelineComponentLoader.load_component(
+                component_name=module_name,
+                component_model_path=component_path,
+                transformers_or_diffusers=library,
+                server_args=server_args,
             )
             self.modules[module_name] = module
             self.memory_usages[module_name] = memory_usage
-
-    @staticmethod
-    def _load_official_refiner_component(
-        module_name: str,
-        component_path: str,
-        server_args: ServerArgs,
-    ):
-        """Load SANA-WM refiner modules through the same libraries as NVlabs.
-
-        The upstream wrapper (``diffusion/refiner/diffusers_ltx2_refiner.py``)
-        keeps the LTX-2 transformer/connectors as Diffusers modules and only
-        customizes the video-only forward surface; use that path for the
-        quality-critical stage-2 refiner instead of the experimental native port.
-        """
-
-        dtype = default_sana_wm_refiner_dtype(server_args)
-        if module_name == "transformer_2":
-            from diffusers.models.transformers.transformer_ltx2 import (
-                LTX2VideoTransformer3DModel,
-            )
-
-            module = LTX2VideoTransformer3DModel.from_pretrained(
-                component_path,
-                torch_dtype=dtype,
-            ).eval()
-            module = OfficialDiffusersLTX2RefinerModule(module)
-        elif module_name == "connectors":
-            from diffusers.pipelines.ltx2 import LTX2TextConnectors
-
-            module = LTX2TextConnectors.from_pretrained(
-                component_path,
-                torch_dtype=dtype,
-            ).eval()
-        elif module_name == "text_encoder_2":
-            from transformers import Gemma3ForConditionalGeneration
-
-            module = Gemma3ForConditionalGeneration.from_pretrained(
-                component_path,
-                torch_dtype=dtype,
-                low_cpu_mem_usage=True,
-            ).eval()
-            module = OfficialGemma3TextEncoderModule(module)
-        elif module_name == "tokenizer_2":
-            from transformers import AutoTokenizer
-
-            module = AutoTokenizer.from_pretrained(component_path)
-        else:
-            raise ValueError(f"Unsupported SANA-WM refiner component: {module_name}")
-
-        memory_usage = get_memory_usage_of_component(module)
-        logger.info(
-            "Loaded %s: %s (official native version). model size: %s GB",
-            module_name,
-            module.__class__.__name__,
-            memory_usage if memory_usage is not None else "NA",
-        )
-        return module, memory_usage or 0.0
 
     def _maybe_add_refiner_stage(self, server_args: ServerArgs) -> None:
         if sana_wm_skip_refiner_enabled():

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/sana_wm/realtime_chain.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/sana_wm/realtime_chain.py
@@ -450,6 +450,13 @@ class SanaWMChunkedRefinerChainStage(SanaWMRealtimeStage):
     """Chunked LTX-2 refiner on the uniform ``sink + i*block`` grid — refines
     COMPLETE blocks only (option b) and hands the refined buffer downstream."""
 
+    def set_component_residency_manager(self, manager) -> None:
+        super().set_component_residency_manager(manager)
+        self.refiner_stage.set_component_residency_manager(manager)
+
+    def component_uses(self, server_args: ServerArgs, stage_name: str | None = None):
+        return self.refiner_stage.component_uses(server_args, stage_name)
+
     @torch.no_grad()
     def forward(self, batch: Req, server_args: ServerArgs) -> Req:
         device = get_local_torch_device()
@@ -479,30 +486,34 @@ class SanaWMChunkedRefinerChainStage(SanaWMRealtimeStage):
                     ),
                 )
 
-            frontier = st.refined_full.shape[2]
-            end_f = stage1.shape[2]
-            while True:
-                block_start = frontier
-                block_end = block_start + st.block_size  # complete blocks only
-                if block_end > end_f:
-                    break
-                sink_seed = (
-                    stage1[:, :, : st.sink_size]
-                    if block_start == st.sink_size
-                    else None
-                )
-                refined = st.runner.refine_block(
-                    block_idx=st.next_ref_idx,
-                    clean_block=stage1[:, :, block_start:block_end].contiguous(),
-                    block_start=block_start,
-                    block_end=block_end,
-                    sink_seed_frames=sink_seed,
-                )
-                st.refined_full = torch.cat(
-                    [st.refined_full, refined.to(st.refined_full.dtype)], dim=2
-                )
-                st.next_ref_idx += 1
-                frontier = block_end
+            with self.use_declared_component(
+                component_name="transformer_2",
+                module=self.refiner_stage.transformer,
+            ):
+                frontier = st.refined_full.shape[2]
+                end_f = stage1.shape[2]
+                while True:
+                    block_start = frontier
+                    block_end = block_start + st.block_size
+                    if block_end > end_f:
+                        break
+                    sink_seed = (
+                        stage1[:, :, : st.sink_size]
+                        if block_start == st.sink_size
+                        else None
+                    )
+                    refined = st.runner.refine_block(
+                        block_idx=st.next_ref_idx,
+                        clean_block=stage1[:, :, block_start:block_end].contiguous(),
+                        block_start=block_start,
+                        block_end=block_end,
+                        sink_seed_frames=sink_seed,
+                    )
+                    st.refined_full = torch.cat(
+                        [st.refined_full, refined.to(st.refined_full.dtype)], dim=2
+                    )
+                    st.next_ref_idx += 1
+                    frontier = block_end
 
         batch.latents = st.refined_full
         return batch

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/sana_wm/realtime_stage.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/sana_wm/realtime_stage.py
@@ -32,7 +32,6 @@ from .base import (
 from .refiner import (
     STAGE_2_DISTILLED_SIGMA_VALUES,
     SanaWMLTX2RefinerStage,
-    _unwrap_diffusers_ltx2_refiner,
 )
 from .streaming_refiner import (
     RefinerChunkRunner,
@@ -410,14 +409,8 @@ class SanaWMRealtimeStage(RealtimeDiffusionStage):
         rs = self.refiner_stage
         if rs is None:
             raise RuntimeError("SANA-WM realtime refiner stage is not initialized")
-        # Keep refiner sub-modules resident: the realtime stage runs the refiner
-        # directly, outside the offline stage's use_declared_component context.
-        for _mod in (rs.text_encoder, rs.connectors, rs.transformer):
-            if _mod is not None:
-                _mod.to(device)
         prompt_embeds, prompt_mask = rs._encode_prompt(state.prompt, device)
-        unwrapped = _unwrap_diffusers_ltx2_refiner(rs.transformer)
-        core = _RefinerCore(unwrapped, device, rs.dtype)
+        core = _RefinerCore(rs.transformer, device, rs.dtype)
         sigmas = torch.tensor(
             STAGE_2_DISTILLED_SIGMA_VALUES, dtype=torch.float32, device=device
         )

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/sana_wm/refiner.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/sana_wm/refiner.py
@@ -23,9 +23,6 @@ from sglang.multimodal_gen.runtime.managers.forward_context import set_forward_c
 from sglang.multimodal_gen.runtime.managers.memory_managers.component_manager import (
     ComponentUse,
 )
-from sglang.multimodal_gen.runtime.managers.memory_managers.layerwise_offload import (
-    LayerwiseOffloadableModuleMixin,
-)
 from sglang.multimodal_gen.runtime.models.dits.sana_wm_refiner_transformer import (
     pack_latents,
     unpack_latents,
@@ -53,44 +50,6 @@ STAGE_2_DISTILLED_SIGMA_VALUES: tuple[float, ...] = _STAGE_2_DISTILLED_SIGMA_VAL
 
 # Default Gemma-3 token budget for the refiner prompt encoder.
 _REFINER_TEXT_MAX_LENGTH = 1024
-
-
-class _OfficialLayerwiseModule(nn.Module, LayerwiseOffloadableModuleMixin):
-    def __init__(self, module: nn.Module) -> None:
-        super().__init__()
-        self.module = module
-        self.layerwise_offload_managers = []
-
-    def forward(self, *args, **kwargs):
-        return self.module(*args, **kwargs)
-
-    def __getattr__(self, name: str):
-        try:
-            return super().__getattr__(name)
-        except AttributeError as exc:
-            wrapped = self.__dict__.get("module")
-            if wrapped is not None:
-                return getattr(wrapped, name)
-            modules = self.__dict__.get("_modules", {})
-            wrapped = modules.get("module")
-            if wrapped is not None:
-                return getattr(wrapped, name)
-            raise exc
-
-
-class OfficialDiffusersLTX2RefinerModule(_OfficialLayerwiseModule):
-    """Thin offload wrapper around Diffusers' official LTX-2 refiner module."""
-
-    layer_names = ["module.transformer_blocks"]
-
-
-class OfficialGemma3TextEncoderModule(_OfficialLayerwiseModule):
-    """Thin offload wrapper around HF Gemma-3 used by the official refiner."""
-
-    layer_names = [
-        "module.language_model.layers",
-        "module.model.language_model.layers",
-    ]
 
 
 def _truthy_flag(value: Any) -> bool:
@@ -142,51 +101,6 @@ def _is_current_cfg_main_rank() -> bool:
         return True
 
 
-def _pack_text_embeds(
-    text_hidden_states: torch.Tensor,
-    sequence_lengths: torch.Tensor,
-    *,
-    padding_side: str = "left",
-    scale_factor: int = 8,
-    eps: float = 1e-6,
-) -> torch.Tensor:
-    """Gemma-3 masked min-max text-embed pooling for the LTX-2 refiner.
-
-    Delegates to framework-wide ``pack_text_embeds`` (verified BITWISE-identical,
-    incl. bf16 and both padding sides) — a private fork would drift, like the
-    realtime<->batch parity bugs.
-    """
-    return pack_text_embeds(
-        text_hidden_states,
-        sequence_lengths,
-        padding_side=padding_side,
-        scale_factor=scale_factor,
-        eps=eps,
-    )
-
-
-def _refiner_config_value(transformer: nn.Module, name: str) -> Any:
-    transformer = _unwrap_diffusers_ltx2_refiner(transformer)
-    config = getattr(transformer, "config", None)
-    if config is not None:
-        if isinstance(config, dict) and name in config:
-            return config[name]
-        if hasattr(config, name):
-            return getattr(config, name)
-    return getattr(transformer, name)
-
-
-def _unwrap_diffusers_ltx2_refiner(transformer: nn.Module) -> nn.Module:
-    if isinstance(transformer, OfficialDiffusersLTX2RefinerModule):
-        return transformer.module
-    return transformer
-
-
-def _uses_diffusers_ltx2_refiner(transformer: nn.Module) -> bool:
-    transformer = _unwrap_diffusers_ltx2_refiner(transformer)
-    return transformer.__class__.__name__ == "LTX2VideoTransformer3DModel"
-
-
 def _as_additive_attention_mask(
     attention_mask: torch.Tensor | None,
     dtype: torch.dtype,
@@ -198,205 +112,13 @@ def _as_additive_attention_mask(
     return attention_mask.to(dtype)
 
 
-def _forward_diffusers_video_only(
-    transformer: nn.Module,
-    *,
-    hidden_states: torch.Tensor,
-    encoder_hidden_states: torch.Tensor,
-    timestep: torch.Tensor,
-    encoder_attention_mask: torch.Tensor | None,
-    num_frames: int,
-    height: int,
-    width: int,
-    fps: float,
-    n_context_tokens: int,
-) -> torch.Tensor:
-    """Official SANA-WM LTX-2 video-only forward adapted to injected modules."""
-
-    batch_size = hidden_states.size(0)
-    encoder_attention_mask = _as_additive_attention_mask(
-        encoder_attention_mask, hidden_states.dtype
-    )
-
-    video_coords = transformer.rope.prepare_video_coords(
-        batch_size, num_frames, height, width, hidden_states.device, fps=fps
-    )
-    video_rotary_emb = transformer.rope(video_coords, device=hidden_states.device)
-
-    hidden_states = transformer.proj_in(hidden_states)
-    temb, embedded_timestep = transformer.time_embed(
-        timestep.flatten(),
-        batch_size=batch_size,
-        hidden_dtype=hidden_states.dtype,
-    )
-    temb = temb.view(batch_size, -1, temb.size(-1))
-    embedded_timestep = embedded_timestep.view(
-        batch_size, -1, embedded_timestep.size(-1)
-    )
-
-    encoder_hidden_states = transformer.caption_projection(encoder_hidden_states)
-    encoder_hidden_states = encoder_hidden_states.view(
-        batch_size, -1, hidden_states.size(-1)
-    )
-
-    for block in transformer.transformer_blocks:
-        hidden_states = _forward_diffusers_video_block(
-            block=block,
-            hidden_states=hidden_states,
-            encoder_hidden_states=encoder_hidden_states,
-            temb=temb,
-            video_rotary_emb=video_rotary_emb,
-            encoder_attention_mask=encoder_attention_mask,
-            n_context_tokens=n_context_tokens,
-        )
-
-    scale_shift_values = (
-        transformer.scale_shift_table[None, None] + embedded_timestep[:, :, None]
-    )
-    shift, scale = scale_shift_values[:, :, 0], scale_shift_values[:, :, 1]
-    hidden_states = transformer.norm_out(hidden_states)
-    hidden_states = hidden_states * (1 + scale) + shift
-    return transformer.proj_out(hidden_states)
-
-
-def _forward_diffusers_video_block(
-    *,
-    block: nn.Module,
-    hidden_states: torch.Tensor,
-    encoder_hidden_states: torch.Tensor,
-    temb: torch.Tensor,
-    video_rotary_emb: tuple[torch.Tensor, torch.Tensor],
-    encoder_attention_mask: torch.Tensor | None,
-    n_context_tokens: int,
-) -> torch.Tensor:
-    batch_size = hidden_states.size(0)
-
-    norm_hidden_states = block.norm1(hidden_states)
-    num_ada_params = block.scale_shift_table.shape[0]
-    ada_values = block.scale_shift_table[None, None].to(temb.device) + temb.reshape(
-        batch_size, temb.size(1), num_ada_params, -1
-    )
-    shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = ada_values.unbind(
-        dim=2
-    )
-    norm_hidden_states = norm_hidden_states * (1 + scale_msa) + shift_msa
-
-    attn_hidden_states = _streaming_diffusers_self_attention(
-        attn=block.attn1,
-        hidden_states=norm_hidden_states,
-        query_rotary_emb=video_rotary_emb,
-        n_context_tokens=n_context_tokens,
-    )
-    hidden_states = hidden_states + attn_hidden_states * gate_msa
-
-    norm_hidden_states = block.norm2(hidden_states)
-    attn_hidden_states = block.attn2(
-        norm_hidden_states,
-        encoder_hidden_states=encoder_hidden_states,
-        query_rotary_emb=None,
-        attention_mask=encoder_attention_mask,
-    )
-    hidden_states = hidden_states + attn_hidden_states
-
-    norm_hidden_states = block.norm3(hidden_states) * (1 + scale_mlp) + shift_mlp
-    hidden_states = hidden_states + block.ff(norm_hidden_states) * gate_mlp
-    return hidden_states
-
-
-def _streaming_diffusers_self_attention(
-    *,
-    attn: nn.Module,
-    hidden_states: torch.Tensor,
-    query_rotary_emb: tuple[torch.Tensor, torch.Tensor],
-    n_context_tokens: int,
-) -> torch.Tensor:
-    """SANA-WM sink/current streaming mask using Diffusers LTX-2 attention."""
-
-    sequence_length = hidden_states.shape[1]
-    if n_context_tokens <= 0 or n_context_tokens >= sequence_length:
-        return attn(
-            hidden_states=hidden_states,
-            encoder_hidden_states=None,
-            query_rotary_emb=query_rotary_emb,
-        )
-
-    from diffusers.models.attention_dispatch import dispatch_attention_fn
-    from diffusers.models.transformers.transformer_ltx2 import (
-        apply_interleaved_rotary_emb,
-        apply_split_rotary_emb,
-    )
-
-    # Diffusers 0.38+ always defines `to_gate_logits`, while 0.37 only has it
-    # on gated variants. The public SANA-WM refiner config is ungated, so a
-    # missing attribute means the same thing as `None`.
-    to_gate_logits = getattr(attn, "to_gate_logits", None)
-    gate_logits = to_gate_logits(hidden_states) if to_gate_logits is not None else None
-
-    query = attn.to_q(hidden_states)
-    key = attn.to_k(hidden_states)
-    value = attn.to_v(hidden_states)
-
-    query = attn.norm_q(query)
-    key = attn.norm_k(key)
-
-    if attn.rope_type == "interleaved":
-        query = apply_interleaved_rotary_emb(query, query_rotary_emb)
-        key = apply_interleaved_rotary_emb(key, query_rotary_emb)
-    elif attn.rope_type == "split":
-        query = apply_split_rotary_emb(query, query_rotary_emb)
-        key = apply_split_rotary_emb(key, query_rotary_emb)
-    else:
-        raise ValueError(f"Unsupported LTX-2 RoPE type: {attn.rope_type}")
-
-    query = query.unflatten(2, (attn.heads, -1))
-    key = key.unflatten(2, (attn.heads, -1))
-    value = value.unflatten(2, (attn.heads, -1))
-
-    processor = attn.processor
-    backend = getattr(processor, "_attention_backend", None)
-    parallel_config = getattr(processor, "_parallel_config", None)
-    context_hidden_states = dispatch_attention_fn(
-        query[:, :n_context_tokens],
-        key[:, :n_context_tokens],
-        value[:, :n_context_tokens],
-        attn_mask=None,
-        dropout_p=0.0,
-        is_causal=False,
-        backend=backend,
-        parallel_config=parallel_config,
-    )
-    current_hidden_states = dispatch_attention_fn(
-        query[:, n_context_tokens:],
-        key,
-        value,
-        attn_mask=None,
-        dropout_p=0.0,
-        is_causal=False,
-        backend=backend,
-        parallel_config=parallel_config,
-    )
-
-    hidden_states = torch.cat([context_hidden_states, current_hidden_states], dim=1)
-    hidden_states = hidden_states.flatten(2, 3).to(query.dtype)
-
-    if gate_logits is not None:
-        hidden_states = hidden_states.unflatten(2, (attn.heads, -1))
-        gates = 2.0 * torch.sigmoid(gate_logits)
-        hidden_states = hidden_states * gates.unsqueeze(-1)
-        hidden_states = hidden_states.flatten(2, 3)
-
-    hidden_states = attn.to_out[0](hidden_states)
-    hidden_states = attn.to_out[1](hidden_states)
-    return hidden_states
-
-
 class SanaWMLTX2RefinerStage(PipelineStage):
     """Run the SANA-WM stage-2 LTX-2 refiner before VAE decode.
 
     Modules are injected by `SanaWMTwoStagePipeline`:
       * `transformer` (`SanaWMLTX2VideoRefiner`) -- video-only LTX-2 forward
       * `connectors` (`LTX2TextConnectors`)
-      * `text_encoder` (`Gemma3ForConditionalGeneration`)
+      * `text_encoder` (`Gemma3TextEncoder`)
       * `tokenizer` (HF `AutoTokenizer` for the refiner Gemma-3)
     """
 
@@ -439,11 +161,7 @@ class SanaWMLTX2RefinerStage(PipelineStage):
         ):
             return []
 
-        # Declare every component this stage forwards through so
-        # ComponentResidencyManager moves them onto GPU before the stage runs.
-        # Without this, `dit_cpu_offload=True` keeps refiner sub-modules on CPU
-        # and the first matmul fails with "mat2 is on cpu" vs cuda inputs.
-        # The tokenizer stays on CPU (no nn.Module weights to ferry).
+        # The tokenizer is CPU-only; declare weighted components in execution order.
         stage_name = self._component_stage_name(stage_name)
         return [
             ComponentUse(
@@ -503,14 +221,10 @@ class SanaWMLTX2RefinerStage(PipelineStage):
         input_ids = text_inputs.input_ids.to(device)
         attention_mask = text_inputs.attention_mask.to(device)
 
-        # Diffusers-backed official path loads HF Gemma3ForConditionalGeneration.
-        # NVlabs encodes through `.model`; the fallback SGLang-native encoder is
-        # still callable directly, so keep both surfaces.
         with self.use_declared_component(
             component_name="text_encoder_2", module=self.text_encoder
         ):
-            text_backbone = getattr(self.text_encoder, "model", self.text_encoder)
-            outputs = text_backbone(
+            outputs = self.text_encoder(
                 input_ids=input_ids,
                 attention_mask=attention_mask,
                 output_hidden_states=True,
@@ -523,7 +237,7 @@ class SanaWMLTX2RefinerStage(PipelineStage):
         stacked = torch.stack(per_layer_hidden, dim=-1)  # (B, L, D, n_layers)
         seq_lengths = attention_mask.sum(dim=-1)
         log_sana_wm_tensor_stats("refiner.text_hidden_states_stacked", stacked)
-        prompt_embeds = _pack_text_embeds(
+        prompt_embeds = pack_text_embeds(
             stacked,
             seq_lengths,
             padding_side=tokenizer.padding_side,
@@ -557,8 +271,8 @@ class SanaWMLTX2RefinerStage(PipelineStage):
     ) -> torch.Tensor:
         full_latent = torch.cat([sink, noisy_current], dim=2)
         batch_size, _, num_frames, height, width = full_latent.shape
-        patch_size = int(_refiner_config_value(self.transformer, "patch_size"))
-        patch_size_t = int(_refiner_config_value(self.transformer, "patch_size_t"))
+        patch_size = self.transformer.patch_size
+        patch_size_t = self.transformer.patch_size_t
         latent_tokens = pack_latents(full_latent, patch_size, patch_size_t)
 
         raw_timestep = torch.zeros(
@@ -573,41 +287,24 @@ class SanaWMLTX2RefinerStage(PipelineStage):
         with self.use_declared_component(
             component_name="transformer_2", module=self.transformer
         ):
-            if _uses_diffusers_ltx2_refiner(self.transformer):
-                model_timestep = raw_timestep.squeeze(-1) * float(
-                    _refiner_config_value(self.transformer, "timestep_scale_multiplier")
-                )
-                velocity_tokens = _forward_diffusers_video_only(
-                    self.transformer,
+            additive_mask = _as_additive_attention_mask(
+                prompt_attention_mask, self.dtype
+            )
+            with set_forward_context(
+                current_timestep=step_idx,
+                attn_metadata=None,
+            ):
+                velocity_tokens = self.transformer(
                     hidden_states=latent_tokens.to(self.dtype),
                     encoder_hidden_states=prompt_embeds,
-                    timestep=model_timestep,
-                    encoder_attention_mask=prompt_attention_mask,
+                    timestep=raw_timestep.squeeze(-1),
+                    encoder_attention_mask=additive_mask,
                     num_frames=num_frames,
                     height=height,
                     width=width,
                     fps=fps,
                     n_context_tokens=n_context_tokens,
                 )
-            else:
-                additive_mask = _as_additive_attention_mask(
-                    prompt_attention_mask, self.dtype
-                )
-                with set_forward_context(
-                    current_timestep=step_idx,
-                    attn_metadata=None,
-                ):
-                    velocity_tokens = self.transformer(
-                        hidden_states=latent_tokens.to(self.dtype),
-                        encoder_hidden_states=prompt_embeds,
-                        timestep=raw_timestep.squeeze(-1),
-                        encoder_attention_mask=additive_mask,
-                        num_frames=num_frames,
-                        height=height,
-                        width=width,
-                        fps=fps,
-                        n_context_tokens=n_context_tokens,
-                    )
 
         denoised = latent_tokens.float() - velocity_tokens.float() * raw_timestep
         return denoised[:, n_context_tokens:, :].to(self.dtype)
@@ -655,8 +352,8 @@ class SanaWMLTX2RefinerStage(PipelineStage):
         noisy = (1.0 - start_sigma) * current + start_sigma * eps
         log_sana_wm_tensor_stats("refiner.current_latent_noisy_initial", noisy)
 
-        patch_size = int(_refiner_config_value(self.transformer, "patch_size"))
-        patch_size_t = int(_refiner_config_value(self.transformer, "patch_size_t"))
+        patch_size = self.transformer.patch_size
+        patch_size_t = self.transformer.patch_size_t
 
         sink_tokens = pack_latents(sink, patch_size, patch_size_t)
         n_context_tokens = sink_tokens.shape[1]

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/sana_wm/streaming_refiner.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/sana_wm/streaming_refiner.py
@@ -5,8 +5,7 @@ Runs the refiner block-by-block carrying a refiner KV cache: a ``sink`` prefix
 (captured pre-RoPE, re-RoPE'd per block at shifted positions) plus a sliding
 ``history`` of refined-block K/V (post-RoPE), injected into each ``attn1`` as a
 KV prefix. Ports the reference NVlabs ``RefinerChunkRunner``
-(minimal-sanawm/refiner.py), operating on mg's already-loaded diffusers LTX-2
-refiner transformer.
+(``minimal-sanawm/refiner.py``) onto the native refiner transformer.
 """
 
 from __future__ import annotations
@@ -16,10 +15,10 @@ import time
 from typing import Any
 
 import torch
-from torch import nn
 
 from sglang.multimodal_gen.runtime.distributed import get_local_torch_device
 from sglang.multimodal_gen.runtime.models.dits.sana_wm_refiner_transformer import (
+    SanaWMLTX2VideoRefiner,
     pack_latents,
     unpack_latents,
 )
@@ -31,60 +30,13 @@ from .refiner import (
     STAGE_2_DISTILLED_SIGMA_VALUES,
     SanaWMLTX2RefinerStage,
     _as_additive_attention_mask,
-    _unwrap_diffusers_ltx2_refiner,
     log_sana_wm_tensor_stats,
     sana_wm_skip_refiner_enabled,
 )
 
 
-# --------------------------------------------------------------------------- #
-# Per-attn1 KV-prefix / capture hooks (port of refiner.py:753-788)
-# --------------------------------------------------------------------------- #
-def set_kv_prefix_on_blocks(transformer: nn.Module, kv_prefix_per_layer) -> None:
-    if kv_prefix_per_layer is None:
-        clear_kv_prefix_on_blocks(transformer)
-        return
-    for block, prefix in zip(transformer.transformer_blocks, kv_prefix_per_layer):
-        block.attn1._tf_kv_prefix = prefix
-
-
-def clear_kv_prefix_on_blocks(transformer: nn.Module) -> None:
-    for block in transformer.transformer_blocks:
-        block.attn1._tf_kv_prefix = None
-
-
-def set_capture_flag_on_blocks(
-    transformer: nn.Module, mode: str, *, enable: bool
-) -> None:
-    if mode == "pre_rope":
-        attr, clear_attr = "_kv_cache_capture", "_cached_kv_pre"
-    elif mode == "post_rope":
-        attr, clear_attr = "_tf_capture_kv", "_cached_kv_post"
-    else:
-        raise ValueError(f"unsupported capture mode: {mode}")
-    for block in transformer.transformer_blocks:
-        setattr(block.attn1, attr, bool(enable))
-        if enable and hasattr(block.attn1, clear_attr):
-            setattr(block.attn1, clear_attr, None)
-
-
-def collect_captured_kv_from_blocks(transformer: nn.Module, mode: str):
-    attr = "_cached_kv_pre" if mode == "pre_rope" else "_cached_kv_post"
-    out = []
-    for block in transformer.transformer_blocks:
-        cached = getattr(block.attn1, attr, None)
-        if cached is None:
-            raise RuntimeError(f"missing captured KV on {attr}")
-        out.append(cached)
-        setattr(block.attn1, attr, None)
-    return out
-
-
-# --------------------------------------------------------------------------- #
-# Absolute-position RoPE (port of refiner.py:721-750)
-# --------------------------------------------------------------------------- #
 def build_rotary_emb_for_absolute_positions(
-    *, transformer, batch_size, frame_positions, height, width, device, fps
+    *, transformer, batch_size, frame_positions, height, width, device, dtype, fps
 ):
     rope = transformer.rope
     patch_size_t = int(rope.patch_size_t)
@@ -114,177 +66,17 @@ def build_rotary_emb_for_absolute_positions(
         pixel_coords[:, 0, ...] + rope.causal_offset - rope.scale_factors[0]
     ).clamp(min=0)
     pixel_coords[:, 0, ...] = pixel_coords[:, 0, ...] / float(fps)
-    return rope(pixel_coords, device=device)
-
-
-# --------------------------------------------------------------------------- #
-# Self-attention with KV-prefix injection + capture (port of refiner.py:464-576)
-# --------------------------------------------------------------------------- #
-def streaming_self_attention(
-    *, attn, hidden_states, query_rotary_emb, n_context_tokens
-):
-    sequence_length = hidden_states.shape[1]
-    has_streaming_hooks = (
-        getattr(attn, "_kv_cache_capture", False)
-        or getattr(attn, "_tf_capture_kv", False)
-        or getattr(attn, "_tf_kv_prefix", None) is not None
-    )
-    if n_context_tokens >= sequence_length and not has_streaming_hooks:
-        return attn(
-            hidden_states=hidden_states,
-            encoder_hidden_states=None,
-            query_rotary_emb=query_rotary_emb,
-        )
-
-    from diffusers.models.attention_dispatch import dispatch_attention_fn
-    from diffusers.models.transformers.transformer_ltx2 import (
-        apply_interleaved_rotary_emb,
-        apply_split_rotary_emb,
-    )
-
-    # diffusers 0.38+ always defines `to_gate_logits`; 0.37 only on gated variants
-    # (the SANA-WM refiner is ungated) -> getattr so 0.37 works too.
-    _to_gate_logits = getattr(attn, "to_gate_logits", None)
-    gate_logits = (
-        _to_gate_logits(hidden_states) if _to_gate_logits is not None else None
-    )
-    query = attn.to_q(hidden_states)
-    key = attn.to_k(hidden_states)
-    value = attn.to_v(hidden_states)
-    query = attn.norm_q(query)
-    key = attn.norm_k(key)
-    if getattr(attn, "_kv_cache_capture", False):
-        attn._cached_kv_pre = (key.detach().clone(), value.detach().clone())
-
-    if attn.rope_type == "interleaved":
-        query = apply_interleaved_rotary_emb(query, query_rotary_emb)
-        key = apply_interleaved_rotary_emb(key, query_rotary_emb)
-    elif attn.rope_type == "split":
-        query = apply_split_rotary_emb(query, query_rotary_emb)
-        key = apply_split_rotary_emb(key, query_rotary_emb)
-    else:
-        raise ValueError(f"Unsupported LTX-2 RoPE type: {attn.rope_type}")
-    if getattr(attn, "_tf_capture_kv", False):
-        attn._cached_kv_post = (key.detach().clone(), value.detach().clone())
-
-    tf_prefix = getattr(attn, "_tf_kv_prefix", None)
-    if isinstance(tf_prefix, dict) and tf_prefix.get("mode") == "rf_shifted_sink":
-        prefix_k_parts = []
-        prefix_v_parts = []
-        sink_k_pre = tf_prefix.get("sink_k_pre")
-        sink_v = tf_prefix.get("sink_v")
-        if sink_k_pre is not None and sink_v is not None and sink_k_pre.shape[1] > 0:
-            sink_pe = tf_prefix.get("sink_pe")
-            if sink_pe is None:
-                raise RuntimeError("rf_shifted_sink prefix requires sink_pe")
-            if attn.rope_type == "interleaved":
-                sink_k = apply_interleaved_rotary_emb(sink_k_pre.to(key.dtype), sink_pe)
-            else:
-                sink_k = apply_split_rotary_emb(sink_k_pre.to(key.dtype), sink_pe)
-            prefix_k_parts.append(sink_k)
-            prefix_v_parts.append(sink_v.to(value.dtype))
-        history_k = tf_prefix.get("history_k")
-        history_v = tf_prefix.get("history_v")
-        if history_k is not None and history_v is not None and history_k.shape[1] > 0:
-            prefix_k_parts.append(history_k.to(key.dtype))
-            prefix_v_parts.append(history_v.to(value.dtype))
-        if prefix_k_parts:
-            key = torch.cat([*prefix_k_parts, key], dim=1)
-            value = torch.cat([*prefix_v_parts, value], dim=1)
-
-    query = query.unflatten(2, (attn.heads, -1))
-    key = key.unflatten(2, (attn.heads, -1))
-    value = value.unflatten(2, (attn.heads, -1))
-    processor = attn.processor
-    backend = getattr(processor, "_attention_backend", None)
-    parallel_config = getattr(processor, "_parallel_config", None)
-    if n_context_tokens <= 0 or n_context_tokens >= query.shape[1]:
-        hidden_states = dispatch_attention_fn(
-            query,
-            key,
-            value,
-            attn_mask=None,
-            dropout_p=0.0,
-            is_causal=False,
-            backend=backend,
-            parallel_config=parallel_config,
-        )
-    else:
-        context = dispatch_attention_fn(
-            query[:, :n_context_tokens],
-            key[:, :n_context_tokens],
-            value[:, :n_context_tokens],
-            attn_mask=None,
-            dropout_p=0.0,
-            is_causal=False,
-            backend=backend,
-            parallel_config=parallel_config,
-        )
-        current = dispatch_attention_fn(
-            query[:, n_context_tokens:],
-            key,
-            value,
-            attn_mask=None,
-            dropout_p=0.0,
-            is_causal=False,
-            backend=backend,
-            parallel_config=parallel_config,
-        )
-        hidden_states = torch.cat([context, current], dim=1)
-    hidden_states = hidden_states.flatten(2, 3).to(query.dtype)
-    if gate_logits is not None:
-        hidden_states = hidden_states.unflatten(2, (attn.heads, -1))
-        hidden_states = hidden_states * (2.0 * torch.sigmoid(gate_logits)).unsqueeze(-1)
-        hidden_states = hidden_states.flatten(2, 3)
-    hidden_states = attn.to_out[0](hidden_states)
-    return attn.to_out[1](hidden_states)
-
-
-def forward_video_block(
-    *,
-    block,
-    hidden_states,
-    encoder_hidden_states,
-    temb,
-    video_rotary_emb,
-    encoder_attention_mask,
-    n_context_tokens,
-):
-    batch = hidden_states.size(0)
-    norm_hidden_states = block.norm1(hidden_states)
-    num_ada_params = block.scale_shift_table.shape[0]
-    ada_values = block.scale_shift_table[None, None].to(temb.device) + temb.reshape(
-        batch, temb.size(1), num_ada_params, -1
-    )
-    shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = ada_values.unbind(
-        dim=2
-    )
-    norm_hidden_states = norm_hidden_states * (1 + scale_msa) + shift_msa
-    attn_hidden_states = streaming_self_attention(
-        attn=block.attn1,
-        hidden_states=norm_hidden_states,
-        query_rotary_emb=video_rotary_emb,
-        n_context_tokens=n_context_tokens,
-    )
-    hidden_states = hidden_states + attn_hidden_states * gate_msa
-    norm_hidden_states = block.norm2(hidden_states)
-    attn_hidden_states = block.attn2(
-        norm_hidden_states,
-        encoder_hidden_states=encoder_hidden_states,
-        query_rotary_emb=None,
-        attention_mask=encoder_attention_mask,
-    )
-    hidden_states = hidden_states + attn_hidden_states
-    norm_hidden_states = block.norm3(hidden_states) * (1 + scale_mlp) + shift_mlp
-    return hidden_states + block.ff(norm_hidden_states) * gate_mlp
+    return rope(pixel_coords, device=device, out_dtype=dtype)
 
 
 class _RefinerCore:
-    """Adapts the unwrapped diffusers refiner transformer to the
-    DiffusersLTX2Refiner interface RefinerChunkRunner expects."""
+    """Adapter used by ``RefinerChunkRunner`` for packed-token inference."""
 
     def __init__(
-        self, transformer: nn.Module, device: torch.device, dtype: torch.dtype
+        self,
+        transformer: SanaWMLTX2VideoRefiner,
+        device: torch.device,
+        dtype: torch.dtype,
     ):
         self.transformer = transformer
         self.device = device
@@ -300,43 +92,18 @@ class _RefinerCore:
         video_rotary_emb,
         n_context_tokens,
     ):
-        transformer = self.transformer
-        batch = hidden_states.size(0)
         if encoder_attention_mask is not None:
             encoder_attention_mask = _as_additive_attention_mask(
                 encoder_attention_mask, hidden_states.dtype
             )
-        hidden_states = transformer.proj_in(hidden_states)
-        temb, embedded_timestep = transformer.time_embed(
-            timestep.flatten(),
-            batch_size=batch,
-            hidden_dtype=hidden_states.dtype,
+        return self.transformer.forward_tokens(
+            hidden_states=hidden_states,
+            encoder_hidden_states=encoder_hidden_states,
+            timestep=timestep,
+            video_rotary_emb=video_rotary_emb,
+            encoder_attention_mask=encoder_attention_mask,
+            n_context_tokens=n_context_tokens,
         )
-        temb = temb.view(batch, -1, temb.size(-1))
-        embedded_timestep = embedded_timestep.view(
-            batch, -1, embedded_timestep.size(-1)
-        )
-        encoder_hidden_states = transformer.caption_projection(encoder_hidden_states)
-        encoder_hidden_states = encoder_hidden_states.view(
-            batch, -1, hidden_states.size(-1)
-        )
-        for block in transformer.transformer_blocks:
-            hidden_states = forward_video_block(
-                block=block,
-                hidden_states=hidden_states,
-                encoder_hidden_states=encoder_hidden_states,
-                temb=temb,
-                video_rotary_emb=video_rotary_emb,
-                encoder_attention_mask=encoder_attention_mask,
-                n_context_tokens=n_context_tokens,
-            )
-        scale_shift = (
-            transformer.scale_shift_table[None, None] + embedded_timestep[:, :, None]
-        )
-        shift, scale = scale_shift[:, :, 0], scale_shift[:, :, 1]
-        hidden_states = transformer.norm_out(hidden_states)
-        hidden_states = hidden_states * (1 + scale) + shift
-        return transformer.proj_out(hidden_states)
 
     def _predict_x0_active_block(
         self,
@@ -349,13 +116,13 @@ class _RefinerCore:
         fps,
         kv_prefix_per_layer,
     ):
-        ps = int(self.transformer.config.patch_size)
-        pst = int(self.transformer.config.patch_size_t)
+        ps = self.transformer.patch_size
+        pst = self.transformer.patch_size_t
         latent_tokens = pack_latents(active, ps, pst)
         batch, seq_len, _ = latent_tokens.shape
         timestep = torch.full(
             (batch, seq_len),
-            float(sigma_cur) * float(self.transformer.config.timestep_scale_multiplier),
+            float(sigma_cur),
             dtype=torch.float32,
             device=self.device,
         )
@@ -366,9 +133,10 @@ class _RefinerCore:
             height=int(active.shape[3]),
             width=int(active.shape[4]),
             device=self.device,
+            dtype=latent_tokens.dtype,
             fps=float(fps),
         )
-        set_kv_prefix_on_blocks(self.transformer, kv_prefix_per_layer)
+        self.transformer.set_streaming_kv_prefixes(kv_prefix_per_layer)
         try:
             velocity = self._forward_video_only_with_rope(
                 hidden_states=latent_tokens,
@@ -379,7 +147,7 @@ class _RefinerCore:
                 n_context_tokens=0,
             )
         finally:
-            clear_kv_prefix_on_blocks(self.transformer)
+            self.transformer.clear_streaming_kv_prefixes()
         raw_sigma = torch.full(
             (batch, seq_len, 1),
             float(sigma_cur),
@@ -407,8 +175,8 @@ class _RefinerCore:
         capture_mode,
         kv_prefix_per_layer,
     ):
-        ps = int(self.transformer.config.patch_size)
-        pst = int(self.transformer.config.patch_size_t)
+        ps = self.transformer.patch_size
+        pst = self.transformer.patch_size_t
         latent_tokens = pack_latents(clean_block, ps, pst)
         batch, seq_len, _ = latent_tokens.shape
         timestep = torch.zeros(batch, seq_len, dtype=torch.float32, device=self.device)
@@ -419,10 +187,11 @@ class _RefinerCore:
             height=int(clean_block.shape[3]),
             width=int(clean_block.shape[4]),
             device=self.device,
+            dtype=latent_tokens.dtype,
             fps=float(fps),
         )
-        set_kv_prefix_on_blocks(self.transformer, kv_prefix_per_layer)
-        set_capture_flag_on_blocks(self.transformer, capture_mode, enable=True)
+        self.transformer.set_streaming_kv_prefixes(kv_prefix_per_layer)
+        self.transformer.set_streaming_kv_capture(capture_mode, True)
         try:
             _ = self._forward_video_only_with_rope(
                 hidden_states=latent_tokens,
@@ -433,9 +202,9 @@ class _RefinerCore:
                 n_context_tokens=0,
             )
         finally:
-            set_capture_flag_on_blocks(self.transformer, capture_mode, enable=False)
-            clear_kv_prefix_on_blocks(self.transformer)
-        return collect_captured_kv_from_blocks(self.transformer, capture_mode)
+            self.transformer.set_streaming_kv_capture(capture_mode, False)
+            self.transformer.clear_streaming_kv_prefixes()
+        return self.transformer.take_streaming_kv(capture_mode)
 
 
 class RefinerChunkRunner:
@@ -540,6 +309,7 @@ class RefinerChunkRunner:
                 height=self.height,
                 width=self.width,
                 device=self.device,
+                dtype=self.dtype,
                 fps=self.fps,
             )
         kv_prefix_per_layer = []
@@ -647,7 +417,10 @@ class SanaWMStreamingRefinerStage(SanaWMLTX2RefinerStage):
 
     @torch.inference_mode()
     def forward(self, batch: Req, server_args: ServerArgs) -> Req:
-        if sana_wm_skip_refiner_enabled():
+        if sana_wm_skip_refiner_enabled(batch):
+            if batch.extra is None:
+                batch.extra = {}
+            batch.extra["sana_wm_refiner_applied"] = False
             return batch
         if batch.latents is None or batch.latents.ndim != 5:
             raise ValueError("SANA-WM streaming refiner expects 5D stage-1 latents.")
@@ -685,9 +458,7 @@ class SanaWMStreamingRefinerStage(SanaWMLTX2RefinerStage):
         with self.use_declared_component(
             component_name="transformer_2", module=self.transformer
         ) as transformer_mod:
-            self.transformer = transformer_mod
-            unwrapped = _unwrap_diffusers_ltx2_refiner(self.transformer)
-            core = _RefinerCore(unwrapped, device, self.dtype)
+            core = _RefinerCore(transformer_mod, device, self.dtype)
             runner = RefinerChunkRunner(
                 core,
                 prompt_embeds=prompt_embeds,

--- a/python/sglang/multimodal_gen/test/unit/sana_wm/test_native_refiner.py
+++ b/python/sglang/multimodal_gen/test/unit/sana_wm/test_native_refiner.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.multimodal_gen.runtime.models.adapter.ltx_2_connector import (
+    LTX2ConnectorFeedForward,
+    LTX2ConnectorTransformer1d,
+    LTX2TextConnectors,
+)
+from sglang.multimodal_gen.runtime.models.dits.sana_wm_refiner_transformer import (
+    SanaWMLTX2VideoRefiner,
+)
+from sglang.multimodal_gen.runtime.models.encoders.gemma_3 import (
+    Gemma3TextEncoder,
+    gemma3_text_weights,
+)
+
+
+class _FakeRope:
+    def prepare_video_coords(self, **kwargs):
+        return torch.zeros(1, 3, 1, 2, device=kwargs["device"])
+
+    def __call__(self, coords, **kwargs):
+        return coords, coords
+
+
+class _FakeRefiner:
+    patch_size = 1
+    patch_size_t = 1
+    rope = _FakeRope()
+
+    def forward_tokens(self, **kwargs):
+        return kwargs["hidden_states"] + 1
+
+
+class _Float32Rope(torch.nn.Module):
+    def forward(self, batch_size, seq_len, device):
+        frequencies = torch.zeros(
+            batch_size, 1, seq_len, 1, device=device, dtype=torch.float32
+        )
+        return frequencies, frequencies
+
+
+class TestSanaWMNativeRefiner(unittest.TestCase):
+    def test_forward_preserves_packed_input_contract(self) -> None:
+        packed = torch.zeros(1, 6, 2)
+        output = SanaWMLTX2VideoRefiner.forward(
+            _FakeRefiner(),
+            hidden_states=packed,
+            encoder_hidden_states=torch.empty(1, 0, 1),
+            timestep=torch.zeros(1, 6),
+            num_frames=2,
+            height=1,
+            width=3,
+        )
+
+        self.assertEqual(output.shape, packed.shape)
+        self.assertTrue(torch.equal(output, packed + 1))
+
+    def test_forward_preserves_5d_input_contract(self) -> None:
+        latents = torch.zeros(1, 2, 2, 1, 3)
+        output = SanaWMLTX2VideoRefiner.forward(
+            _FakeRefiner(),
+            hidden_states=latents,
+            encoder_hidden_states=torch.empty(1, 0, 1),
+            timestep=torch.zeros(1, 6),
+        )
+
+        self.assertEqual(output.shape, latents.shape)
+        self.assertTrue(torch.equal(output, latents + 1))
+
+    def test_refiner_components_expose_layerwise_blocks(self) -> None:
+        self.assertEqual(SanaWMLTX2VideoRefiner.layer_names, ["transformer_blocks"])
+
+    def test_refiner_only_ignores_released_audio_checkpoint_branches(self) -> None:
+        expected_unused = (
+            "audio_proj_in.weight",
+            "av_cross_attn_video_scale_shift.linear.weight",
+            "transformer_blocks.0.audio_attn1.to_q.weight",
+            "transformer_blocks.0.audio_to_video_attn.to_q.weight",
+            "transformer_blocks.0.video_to_audio_attn.to_q.weight",
+            "transformer_blocks.0.video_a2v_cross_attn_scale_shift_table",
+        )
+        for name in expected_unused:
+            self.assertTrue(
+                SanaWMLTX2VideoRefiner.is_expected_unloaded_checkpoint_key(name)
+            )
+        self.assertFalse(
+            SanaWMLTX2VideoRefiner.is_expected_unloaded_checkpoint_key(
+                "transformer_blocks.0.attn1.to_q.weight"
+            )
+        )
+        self.assertFalse(
+            SanaWMLTX2VideoRefiner.is_expected_unloaded_checkpoint_key(
+                "unexpected.weight"
+            )
+        )
+
+    def test_streaming_prefixes_require_one_entry_per_block(self) -> None:
+        refiner = SimpleNamespace(
+            transformer_blocks=[
+                SimpleNamespace(attn1=SimpleNamespace(kv_prefix=None)),
+                SimpleNamespace(attn1=SimpleNamespace(kv_prefix=None)),
+            ]
+        )
+        prefixes = [{"mode": "rf_shifted_sink"}, None]
+
+        SanaWMLTX2VideoRefiner.set_streaming_kv_prefixes(refiner, prefixes)
+        self.assertIs(refiner.transformer_blocks[0].attn1.kv_prefix, prefixes[0])
+        self.assertIsNone(refiner.transformer_blocks[1].attn1.kv_prefix)
+
+        SanaWMLTX2VideoRefiner.clear_streaming_kv_prefixes(refiner)
+        self.assertTrue(
+            all(block.attn1.kv_prefix is None for block in refiner.transformer_blocks)
+        )
+        with self.assertRaisesRegex(ValueError, "one KV prefix per refiner block"):
+            SanaWMLTX2VideoRefiner.set_streaming_kv_prefixes(refiner, prefixes[:1])
+        self.assertEqual(Gemma3TextEncoder.layer_names, ["layers"])
+        self.assertEqual(
+            LTX2TextConnectors.layer_names,
+            [
+                "video_connector.transformer_blocks",
+                "audio_connector.transformer_blocks",
+            ],
+        )
+
+    def test_connector_feed_forward_keeps_checkpoint_key_layout(self) -> None:
+        state_keys = set(LTX2ConnectorFeedForward(4, "gelu-approximate").state_dict())
+        self.assertEqual(
+            state_keys,
+            {
+                "net.0.proj.weight",
+                "net.0.proj.bias",
+                "net.2.weight",
+                "net.2.bias",
+            },
+        )
+
+    def test_connector_keeps_rope_frequencies_in_float32(self) -> None:
+        connector = object.__new__(LTX2ConnectorTransformer1d)
+        torch.nn.Module.__init__(connector)
+        connector.learnable_registers = None
+        connector.rope = _Float32Rope()
+        connector.transformer_blocks = torch.nn.ModuleList()
+        connector.norm_out = torch.nn.Identity()
+        connector.gradient_checkpointing = False
+
+        hidden_states = torch.zeros(1, 4, 2, dtype=torch.bfloat16)
+        output, _ = connector(hidden_states)
+
+        self.assertIs(output, hidden_states)
+
+    def test_text_encoder_selects_only_language_backbone_weights(self) -> None:
+        weights = [
+            ("model.language_model.model.layers.0.weight", torch.ones(1)),
+            ("model.vision_tower.weight", torch.ones(1)),
+            ("language_model.model.norm.weight", torch.ones(1)),
+        ]
+
+        self.assertEqual(
+            [name for name, _ in gemma3_text_weights(weights)],
+            ["layers.0.weight", "norm.weight"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/sglang/multimodal_gen/test/unit/sana_wm/test_pipeline_config.py
+++ b/python/sglang/multimodal_gen/test/unit/sana_wm/test_pipeline_config.py
@@ -1,8 +1,6 @@
 import argparse
 import os
-import sys
 import tempfile
-import types
 import unittest
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -46,13 +44,8 @@ from sglang.multimodal_gen.runtime.pipelines_core.stages.model_specific_stages.s
     sana_wm_action_to_camera_to_world,
 )
 from sglang.multimodal_gen.runtime.pipelines_core.stages.model_specific_stages.sana_wm.refiner import (
-    OfficialDiffusersLTX2RefinerModule,
-    OfficialGemma3TextEncoderModule,
     SanaWMLTX2RefinerStage,
     SanaWMRefinerDecodingStage,
-    _refiner_config_value,
-    _streaming_diffusers_self_attention,
-    _uses_diffusers_ltx2_refiner,
     sana_wm_skip_refiner_enabled,
 )
 from sglang.multimodal_gen.runtime.server_args import set_global_server_args
@@ -148,6 +141,27 @@ class TestSanaWMPipelineConfig(unittest.TestCase):
         )
         self.assertTrue(self.config.text_encoder_extra_args[0]["return_attention_mask"])
         self.assertTrue(self.config.chi_prompt)
+
+    def test_refiner_checkpoint_architectures_resolve_to_native_models(self) -> None:
+        dit_config, architecture = self.config.resolve_dit_component(
+            "transformer_2",
+            self.config.dit_config,
+            "LTX2VideoTransformer3DModel",
+        )
+        self.assertIs(dit_config, self.config.refiner_dit_config)
+        self.assertEqual(architecture, "SanaWMLTX2VideoRefiner")
+        self.assertEqual(
+            self.config.resolve_text_encoder_architectures(
+                "text_encoder_2", ["Gemma3ForConditionalGeneration"]
+            ),
+            ["Gemma3TextEncoder"],
+        )
+
+    def test_refiner_components_disable_external_module_fallback(self) -> None:
+        self.assertEqual(
+            self.config.native_only_components,
+            ("transformer_2", "connectors", "text_encoder_2"),
+        )
 
     def test_inference_flow_shift_matches_official_reference(self) -> None:
         self.assertEqual(self.config.flow_shift, 9.95)
@@ -410,14 +424,14 @@ class TestSanaWMTwoStagePipeline(unittest.TestCase):
         self.assertEqual(refiner_root, "/custom/refiner")
         self.assertEqual(refiner_gemma_root, "/custom/refiner/text_encoder")
 
-    def test_refiner_modules_are_loaded_from_official_subtrees(self) -> None:
+    def test_refiner_modules_use_unified_component_loaders(self) -> None:
         self.assertEqual(
             SanaWMTwoStagePipeline._REFINER_SUB_MODULES,
             (
-                ("transformer_2", "refiner/transformer"),
-                ("connectors", "refiner/connectors"),
-                ("text_encoder_2", "refiner/text_encoder"),
-                ("tokenizer_2", "refiner/text_encoder"),
+                ("transformer_2", "refiner/transformer", "diffusers"),
+                ("connectors", "refiner/connectors", "diffusers"),
+                ("text_encoder_2", "refiner/text_encoder", "transformers"),
+                ("tokenizer_2", "refiner/text_encoder", "transformers"),
             ),
         )
 
@@ -1255,35 +1269,6 @@ class TestSanaWMNativeDiTChunking(unittest.TestCase):
 
 
 class TestSanaWMRefinerStage(_GlobalStageArgsMixin, unittest.TestCase):
-    def test_diffusers_refiner_detection_uses_official_class_name(self) -> None:
-        class LTX2VideoTransformer3DModel(torch.nn.Module):
-            pass
-
-        self.assertTrue(_uses_diffusers_ltx2_refiner(LTX2VideoTransformer3DModel()))
-        self.assertTrue(
-            _uses_diffusers_ltx2_refiner(
-                OfficialDiffusersLTX2RefinerModule(LTX2VideoTransformer3DModel())
-            )
-        )
-
-    def test_refiner_config_value_prefers_diffusers_config(self) -> None:
-        module = SimpleNamespace(
-            patch_size=999,
-            config=SimpleNamespace(patch_size=1),
-        )
-
-        self.assertEqual(_refiner_config_value(module, "patch_size"), 1)
-
-    def test_official_refiner_wrappers_expose_layerwise_blocks(self) -> None:
-        self.assertEqual(
-            OfficialDiffusersLTX2RefinerModule.layer_names,
-            ["module.transformer_blocks"],
-        )
-        self.assertIn(
-            "module.model.language_model.layers",
-            OfficialGemma3TextEncoderModule.layer_names,
-        )
-
     def test_refiner_component_uses_follow_execution_order(self) -> None:
         stage = SanaWMLTX2RefinerStage(
             transformer=torch.nn.Identity(),
@@ -1347,75 +1332,6 @@ class TestSanaWMRefinerStage(_GlobalStageArgsMixin, unittest.TestCase):
 
         self.assertEqual(uses, [])
 
-    def test_streaming_diffusers_attention_accepts_ungated_ltx2_attention(self) -> None:
-        """Diffusers 0.37 LTX2Attention omits `to_gate_logits` for ungated configs."""
-
-        class IdentityLinear(torch.nn.Module):
-            def forward(self, x):
-                return x
-
-        class FakeProcessor:
-            _attention_backend = None
-            _parallel_config = None
-
-        class UngatedAttention(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.to_q = IdentityLinear()
-                self.to_k = IdentityLinear()
-                self.to_v = IdentityLinear()
-                self.norm_q = IdentityLinear()
-                self.norm_k = IdentityLinear()
-                self.to_out = torch.nn.ModuleList(
-                    [IdentityLinear(), torch.nn.Identity()]
-                )
-                self.heads = 2
-                self.rope_type = "split"
-                self.processor = FakeProcessor()
-
-        def dispatch_attention_fn(
-            query,
-            key,
-            value,
-            attn_mask=None,
-            dropout_p=0.0,
-            is_causal=False,
-            backend=None,
-            parallel_config=None,
-        ):
-            return query
-
-        attention_dispatch = types.ModuleType("diffusers.models.attention_dispatch")
-        attention_dispatch.dispatch_attention_fn = dispatch_attention_fn
-        transformer_ltx2 = types.ModuleType(
-            "diffusers.models.transformers.transformer_ltx2"
-        )
-        transformer_ltx2.apply_interleaved_rotary_emb = lambda x, _rope: x
-        transformer_ltx2.apply_split_rotary_emb = lambda x, _rope: x
-
-        with patch.dict(
-            sys.modules,
-            {
-                "diffusers": types.ModuleType("diffusers"),
-                "diffusers.models": types.ModuleType("diffusers.models"),
-                "diffusers.models.attention_dispatch": attention_dispatch,
-                "diffusers.models.transformers": types.ModuleType(
-                    "diffusers.models.transformers"
-                ),
-                "diffusers.models.transformers.transformer_ltx2": transformer_ltx2,
-            },
-        ):
-            hidden_states = torch.randn(1, 3, 4)
-            rotary = (torch.empty(0), torch.empty(0))
-            out = _streaming_diffusers_self_attention(
-                attn=UngatedAttention(),
-                hidden_states=hidden_states,
-                query_rotary_emb=rotary,
-                n_context_tokens=1,
-            )
-
-        self.assertEqual(out.shape, hidden_states.shape)
-
     def test_skip_refiner_flag_accepts_request_extra(self) -> None:
         batch = SimpleNamespace(extra={"diffusers_kwargs": {"skip_refiner": True}})
         self.assertTrue(sana_wm_skip_refiner_enabled(batch))
@@ -1430,7 +1346,7 @@ class TestSanaWMRefinerStage(_GlobalStageArgsMixin, unittest.TestCase):
         prompts = SanaWMLTX2RefinerStage._prompts_for_batch(batch, batch_size=2)
         self.assertEqual(prompts, ["left", "right"])
 
-    def test_refiner_prompt_encoding_uses_hf_gemma_backbone(self) -> None:
+    def test_refiner_prompt_encoding_uses_native_text_encoder(self) -> None:
         class DummyTokenizer:
             padding_side = "right"
             pad_token = None
@@ -1442,7 +1358,7 @@ class TestSanaWMRefinerStage(_GlobalStageArgsMixin, unittest.TestCase):
                     attention_mask=torch.tensor([[1, 1, 0, 0]]),
                 )
 
-        class DummyBackbone:
+        class DummyTextEncoder:
             def __init__(self):
                 self.called = False
 
@@ -1451,17 +1367,6 @@ class TestSanaWMRefinerStage(_GlobalStageArgsMixin, unittest.TestCase):
                 hidden0 = torch.arange(8, dtype=torch.float32).reshape(1, 4, 2)
                 hidden1 = hidden0 + 10
                 return SimpleNamespace(hidden_states=(hidden0, hidden1))
-
-        class DummyTextEncoder:
-            def __init__(self):
-                self.called = False
-                self.model = DummyBackbone()
-
-            def __call__(self, **kwargs):
-                self.called = True
-                raise AssertionError(
-                    "Gemma3ForConditionalGeneration.model was not used"
-                )
 
         class DummyConnectors:
             def __call__(self, prompt_embeds, attention_mask):
@@ -1480,8 +1385,7 @@ class TestSanaWMRefinerStage(_GlobalStageArgsMixin, unittest.TestCase):
             "drive forward", torch.device("cpu")
         )
 
-        self.assertTrue(stage.text_encoder.model.called)
-        self.assertFalse(stage.text_encoder.called)
+        self.assertTrue(stage.text_encoder.called)
         self.assertEqual(prompt_embeds.shape, (1, 4, 4))
         self.assertTrue(torch.equal(attention_mask, torch.tensor([[1, 1, 0, 0]])))
 

--- a/python/sglang/multimodal_gen/test/unit/test_fsdp_load.py
+++ b/python/sglang/multimodal_gen/test/unit/test_fsdp_load.py
@@ -44,6 +44,33 @@ class _CustomEntrypointModel(_UniformDtypeModel):
         pass
 
 
+class _PartialCheckpointModel(_UniformDtypeModel):
+    @staticmethod
+    def is_expected_unloaded_checkpoint_key(name: str) -> bool:
+        return name.startswith("unused.")
+
+
+class TestExpectedCheckpointKeys(unittest.TestCase):
+    def test_model_declared_unused_keys_do_not_hide_unexpected_keys(self):
+        model = _PartialCheckpointModel()
+
+        self.assertEqual(
+            fsdp_load._unexpected_checkpoint_keys(
+                model,
+                ["unused.audio.weight", "unexpected.weight"],
+            ),
+            ["unexpected.weight"],
+        )
+
+    def test_models_without_declaration_keep_all_skipped_keys(self):
+        keys = ["unexpected.weight"]
+
+        self.assertIs(
+            fsdp_load._unexpected_checkpoint_keys(_UniformDtypeModel(), keys),
+            keys,
+        )
+
+
 class TestFSDPMixedPrecisionPolicy(unittest.TestCase):
     def _load_and_capture_policy(
         self,


### PR DESCRIPTION
## Summary

- replace the SANA-WM stage-2 Diffusers/HF runtime modules with native SGLang refiner, connector, and text-only Gemma-3 implementations
- route nested refiner components through the unified component loaders and support layerwise offload for `transformer_2`, `text_encoder_2`, and `connectors`
- remove duplicate batch/streaming Diffusers forward paths, preserve streaming KV behavior behind explicit model APIs, and document the native runtime/residency behavior

## Details

- loads the released audiovisual LTX-2 checkpoint into a video-only 48-layer refiner while treating only the known audio/AV branches as intentionally unused
- avoids materializing the unused 416M-parameter Gemma-3 vision tower
- keeps Diffusers/Transformers checkpoint compatibility and the existing tokenizer path
- fixes the packed/5D refiner output contract and keeps timestep scaling owned by the native model
- removes the low-signal warning listing 2295 expected unused audio/AV checkpoint keys while preserving warnings for unknown keys

## Validation

- `pre-commit run --files ...`
- remote H100: `103 passed` for SANA-WM native/config tests and FSDP loader tests
- released SANA-WM checkpoint, BF16 math SDPA:
  - Gemma-3: all 49 hidden states bitwise identical to HF on the runtime-valid 128-token path; zero vision parameters materialized
  - connectors: exact checkpoint coverage; video/audio conditioning relative L2 `0.00273` / `0.00321`, cosine `> 0.99995`
  - refiner: all 48 layers loaded; final output max abs error `0.0234375` against Diffusers
  - streaming pre/post-RoPE KV capture and history-prefix injection passed
  - resident vs layerwise outputs are bitwise identical for the refiner, text encoder, and both connector stacks

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31893100590](https://github.com/sgl-project/sglang/actions/runs/31893100590)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31893100482](https://github.com/sgl-project/sglang/actions/runs/31893100482)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->