### PR TITLE
Fix dsv4 kl test timeout

### DIFF
--- a/.github/workflows/pr-test-extra.yml
+++ b/.github/workflows/pr-test-extra.yml
@@ -205,6 +205,7 @@ jobs:
       caller_inputs: ${{ toJson(inputs) }}
       partitions: ${{ needs.check-changes.outputs.partitions }}
       run_timeout_minutes: '60'
+      timeout_per_file: '3600'
       rust_ext_artifact: ${{ needs.rust-ext-build.outputs.artifact_name }}
     secrets: inherit
 

--- a/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_dsv4.py
+++ b/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_dsv4.py
@@ -22,7 +22,7 @@ DSV4_FLASH_MODEL = "sgl-project/DeepSeek-V4-Flash-FP8"
 DSV4_DSPARK_MODEL = "deepseek-ai/DeepSeek-V4-Flash-DSpark"
 DSV4_FLASH_LAUNCH_TIMEOUT = 3600
 
-register_cuda_ci(est_time=1500, stage="extra-b", runner_config="4-gpu-h100")
+register_cuda_ci(est_time=2400, stage="extra-b", runner_config="4-gpu-h100")
 
 
 def _assert_dsv4_decode_cached_tokens(result, history_len, output_len, label):


### PR DESCRIPTION
## Motivation

`test_unified_radix_cache_kl_dsv4.py` is killed at 1200s on every scheduled run, most recently https://github.com/sgl-project/sglang/actions/runs/31849115802. The stage sets no `timeout_per_file`, so `run_suite.py` falls back to its flat 1200s default, which sits below the file's own registered `est_time` of 1500. It is the only registered CUDA test with an `est_time` above that default.

Measured with no harness timeout on 4 GPUs and a warm cache: 16 tests pass in 2055s. `est_time` moves to 2400 as well because `compute_partitions.py` packs shards by it, so raising only the per-file timeout would trade the file timeout for a job timeout.

Left alone: `--timeout-from-est-time` would have derived 3300s here, but it is gated on the `scheduled` input that `pr-test.yml` and `pr-test-extra.yml` never pass, and passing it would also flip `max-parallel` to 1 for every scheduled stage.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31895383698](https://github.com/sgl-project/sglang/actions/runs/31895383698)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #31895383613](https://github.com/sgl-project/sglang/actions/runs/31895383613)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->