### PR TITLE
fix(sgl-kernel): preload CUDA runtime before loading common ops

### DIFF
--- a/python/sglang/kernels/aot/python/sgl_kernel/__init__.py
+++ b/python/sglang/kernels/aot/python/sgl_kernel/__init__.py
@@ -15,12 +15,12 @@ else:
         _preload_cuda_library,
     )
 
-    # Initialize the ops library based on current GPU
-    common_ops = _load_architecture_specific_ops()
-
     # Preload the CUDA library to avoid the issue of libcudart.so.12 not found
     if torch.version.cuda is not None:
         _preload_cuda_library()
+
+    # Initialize the ops library based on current GPU
+    common_ops = _load_architecture_specific_ops()
 
     from sgl_kernel.allreduce import *
     from sgl_kernel.attention import (


### PR DESCRIPTION
## Motivation

`common_ops.so` resolves its shared-library dependencies while it is dynamically loaded. Preloading `libcudart` afterward cannot prevent an earlier `libcudart.so.*` resolution failure.

## Modifications

Preload the CUDA runtime with `RTLD_GLOBAL` before loading the architecture-specific `common_ops` extension.

## Tests

- `python3 -m py_compile python/sglang/kernels/aot/python/sgl_kernel/__init__.py`
- `git diff --check origin/main...HEAD`
- `pre-commit run --files python/sglang/kernels/aot/python/sgl_kernel/__init__.py`
- Manual smoke test on an NVIDIA A100 CUDA host: applied the same loader-order change to the installed `sgl_kernel` package under `site-packages` and successfully started SGLang.

The original `libcudart.so.*` lookup failure was not reproducible on the test host. The change is based on the loader ordering: `common_ops.so` dependency resolution occurs before a subsequent CUDA runtime preload could run.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->pending<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->pending<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->