### PR TITLE
[Diffusion] Native Pi0.5 SigLIP vision tower

### DIFF
--- a/docs/cookbook/vla/OpenPI/Pi0.5.mdx
+++ b/docs/cookbook/vla/OpenPI/Pi0.5.mdx
@@ -18,6 +18,8 @@ Pi0.5 is an OpenPI / LeRobot diffusion Vision-Language-Action (dVLA) policy. It 
 
 SGLang serves Pi0.5 through the native `multimodal_gen` runtime. The implementation uses a SigLIP/PaliGemma prefix encoder and a Gemma action expert: the prefix is encoded once, then the action expert runs the flow-matching denoising loop. This is not a token decode workload, so the Pi0.5 path does not use the LLM sampler, logits processor, token streaming, paged decode KV cache, or a separate SRT serving engine.
 
+The SigLIP vision tower, PaliGemma language stack, and action expert are all SGLang-native modules. Transformers is used for checkpoint configuration and tokenization, not for the runtime neural network.
+
 The prefix encoder covers both stages of observation encoding: SigLIP turns resized camera pixels into continuous patch embeddings, then the PaliGemma transformer jointly encodes those patches with tokenized task/state inputs and produces per-layer prefix K/V. At flow timestep `t`, the action expert projects the noisy continuous action chunk `x_t` into action embeddings. Its queries attend to both the fixed prefix K/V and the current action K/V, while the timestep follows a separate sinusoidal-MLP path and conditions every action-expert layer through AdaRMSNorm gates.
 
 Supported public checkpoints:

--- a/python/sglang/multimodal_gen/runtime/models/encoders/gemma_3.py
+++ b/python/sglang/multimodal_gen/runtime/models/encoders/gemma_3.py
@@ -4,7 +4,6 @@
 # Adapted from sglang: python/sglang/srt/models/gemma3_causal.py
 
 import logging
-from functools import partial
 from typing import Any, Iterable, Optional, Set, Tuple
 
 import torch
@@ -14,9 +13,7 @@ from sglang.multimodal_gen.configs.models.encoders.base import BaseEncoderOutput
 from sglang.multimodal_gen.configs.models.encoders.gemma_3 import Gemma3Config
 from sglang.multimodal_gen.runtime.distributed import get_tp_world_size
 from sglang.multimodal_gen.runtime.layers.activation import GeluAndMul
-from sglang.multimodal_gen.runtime.layers.attention import LocalAttention
 from sglang.multimodal_gen.runtime.layers.linear import (
-    ColumnParallelLinear,
     MergedColumnParallelLinear,
     QKVParallelLinear,
     RowParallelLinear,
@@ -27,6 +24,7 @@ from sglang.multimodal_gen.runtime.loader.weight_utils import default_weight_loa
 from sglang.multimodal_gen.runtime.managers.memory_managers.layerwise_offload import (
     LayerwiseOffloadableModuleMixin,
 )
+from sglang.multimodal_gen.runtime.models.encoders.siglip import SiglipVisionModel
 from sglang.multimodal_gen.runtime.utils.common import add_prefix
 
 logger = logging.getLogger(__name__)
@@ -438,270 +436,6 @@ class Gemma3TextScaledWordEmbedding(nn.Embedding):
 
     def forward(self, input_ids: torch.Tensor):
         return super().forward(input_ids) * self.embed_scale
-
-
-# --- Siglip Vision Model Implementation ---
-
-
-class QuickGELU(nn.Module):
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return x * torch.sigmoid(1.702 * x)
-
-
-class SiglipVisionEmbeddings(nn.Module):
-    def __init__(self, config):
-        super().__init__()
-        self.config = config
-        self.embed_dim = config.hidden_size
-        self.image_size = config.image_size
-        self.patch_size = config.patch_size
-
-        self.patch_embedding = nn.Conv2d(
-            in_channels=config.num_channels,
-            out_channels=self.embed_dim,
-            kernel_size=self.patch_size,
-            stride=self.patch_size,
-            padding="valid",
-        )
-
-        self.num_patches = (self.image_size // self.patch_size) ** 2
-        self.num_positions = self.num_patches
-        # Use simple Embedding for position embeddings (usually small enough)
-        self.position_embedding = nn.Embedding(self.num_positions, self.embed_dim)
-        self.register_buffer(
-            "position_ids",
-            torch.arange(self.num_positions).expand((1, -1)),
-            persistent=False,
-        )
-
-    def forward(self, pixel_values: torch.Tensor) -> torch.Tensor:
-        target_dtype = self.patch_embedding.weight.dtype
-        patch_embeds = self.patch_embedding(
-            pixel_values.to(dtype=target_dtype)
-        )  # shape = [*, width, grid, grid]
-        embeddings = patch_embeds.flatten(2).transpose(1, 2)
-        embeddings = embeddings + self.position_embedding(self.position_ids)
-
-        return embeddings
-
-
-class SiglipMLP(nn.Module):
-    def __init__(
-        self,
-        config,
-        act_layer: type[nn.Module] = QuickGELU,
-        quant_config: Optional[QuantizationConfig] = None,
-        prefix: str = "",
-    ):
-        super().__init__()
-        self.fc1 = ColumnParallelLinear(
-            config.hidden_size,
-            config.intermediate_size,
-            quant_config=quant_config,
-            prefix=add_prefix("fc1", prefix),
-        )
-        self.act = act_layer()
-        self.fc2 = RowParallelLinear(
-            config.intermediate_size,
-            config.hidden_size,
-            quant_config=quant_config,
-            prefix=add_prefix("fc2", prefix),
-        )
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        x_parallel, _ = self.fc1(x)
-        x_parallel = self.act(x_parallel)
-        x, _ = self.fc2(x_parallel)
-        return x
-
-
-class SiglipAttention(nn.Module):
-    def __init__(
-        self,
-        hidden_size: int,
-        num_heads: int,
-        quant_config: Optional[QuantizationConfig] = None,
-        prefix: str = "",
-    ):
-        super().__init__()
-        self.hidden_size = hidden_size
-        self.num_heads = num_heads
-        tp_size = get_tp_world_size()
-        self.head_dim = hidden_size // num_heads
-        self.num_heads_per_partition = num_heads // tp_size
-        # Cache the per-rank projection width so forward() does not re-read the
-        # global TP size (which is not patched to the folding group at run time).
-        self.embed_dim_per_partition = self.num_heads_per_partition * self.head_dim
-        self.scaling = self.head_dim**-0.5
-
-        self.qkv_proj = QKVParallelLinear(
-            hidden_size=hidden_size,
-            head_size=self.head_dim,
-            total_num_heads=num_heads,
-            total_num_kv_heads=num_heads,
-            bias=True,
-            quant_config=quant_config,
-            prefix=add_prefix("qkv_proj", prefix),
-        )
-
-        self.out_proj = RowParallelLinear(
-            input_size=hidden_size,
-            output_size=hidden_size,
-            bias=True,
-            quant_config=quant_config,
-            prefix=add_prefix("out_proj", prefix),
-        )
-
-        self.attn = LocalAttention(
-            num_heads=self.num_heads_per_partition,
-            head_size=self.head_dim,
-            num_kv_heads=self.num_heads_per_partition,
-            softmax_scale=self.scaling,
-            causal=False,  # Bidirectional for Vision
-        )
-
-    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
-        qkv, _ = self.qkv_proj(hidden_states)
-        q, k, v = qkv.split([self.embed_dim_per_partition] * 3, dim=-1)
-
-        batch_size, seq_len, _ = q.shape
-        q = q.view(batch_size, seq_len, self.num_heads_per_partition, self.head_dim)
-        k = k.view(batch_size, seq_len, self.num_heads_per_partition, self.head_dim)
-        v = v.view(batch_size, seq_len, self.num_heads_per_partition, self.head_dim)
-
-        attn_output = self.attn(q, k, v)
-
-        attn_output = attn_output.reshape(
-            batch_size, seq_len, self.embed_dim_per_partition
-        )
-
-        output, _ = self.out_proj(attn_output)
-        return output
-
-
-class SiglipEncoderLayer(nn.Module):
-    def __init__(
-        self,
-        config,
-        act_layer: type[nn.Module] = QuickGELU,
-        norm_layer: type[nn.Module] = None,
-        quant_config: Optional[QuantizationConfig] = None,
-        prefix: str = "",
-    ) -> None:
-        super().__init__()
-        if norm_layer is None:
-            norm_layer = partial(nn.LayerNorm, eps=config.layer_norm_eps)
-        self.layer_norm1 = norm_layer(config.hidden_size)
-        self.layer_norm2 = norm_layer(config.hidden_size)
-        self.self_attn = SiglipAttention(
-            hidden_size=config.hidden_size,
-            num_heads=config.num_attention_heads,
-            quant_config=quant_config,
-            prefix=add_prefix("self_attn", prefix),
-        )
-        self.mlp = SiglipMLP(
-            config,
-            act_layer=act_layer,
-            quant_config=quant_config,
-            prefix=add_prefix("mlp", prefix),
-        )
-
-    def forward(
-        self,
-        hidden_states: torch.Tensor,
-    ) -> torch.Tensor:
-        residual = hidden_states
-        hidden_states = self.layer_norm1(hidden_states)
-        hidden_states = self.self_attn(hidden_states)
-        hidden_states = residual + hidden_states
-
-        residual = hidden_states
-        hidden_states = self.layer_norm2(hidden_states)
-        hidden_states = self.mlp(hidden_states)
-        hidden_states = residual + hidden_states
-        return hidden_states
-
-
-class SiglipEncoder(nn.Module):
-    def __init__(
-        self,
-        config,
-        quant_config: Optional[QuantizationConfig] = None,
-        prefix: str = "",
-    ) -> None:
-        super().__init__()
-        self.config = config
-        num_hidden_layers = config.num_hidden_layers
-        norm_layer = partial(nn.LayerNorm, eps=config.layer_norm_eps)
-        self.layers = nn.ModuleList(
-            [
-                SiglipEncoderLayer(
-                    config=config,
-                    norm_layer=norm_layer,
-                    quant_config=quant_config,
-                    prefix=add_prefix(f"layers.{layer_idx}", prefix),
-                )
-                for layer_idx in range(num_hidden_layers)
-            ]
-        )
-
-    def forward(
-        self,
-        inputs_embeds: torch.Tensor,
-    ) -> torch.Tensor:
-        hidden_states = inputs_embeds
-        for encoder_layer in self.layers:
-            hidden_states = encoder_layer(hidden_states)
-        return hidden_states
-
-
-class SiglipVisionTransformer(nn.Module):
-    def __init__(
-        self,
-        config,
-        quant_config: Optional[QuantizationConfig] = None,
-        prefix: str = "",
-    ) -> None:
-        super().__init__()
-        self.config = config
-        embed_dim = config.hidden_size
-        self.embeddings = SiglipVisionEmbeddings(config)
-        self.encoder = SiglipEncoder(
-            config=config,
-            quant_config=quant_config,
-            prefix=add_prefix("encoder", prefix),
-        )
-        self.post_layernorm = nn.LayerNorm(embed_dim, eps=config.layer_norm_eps)
-
-    @property
-    def device(self) -> torch.device:
-        return self.encoder.layers[0].layer_norm1.weight.device
-
-    def forward(self, pixel_values: torch.Tensor) -> torch.Tensor:
-        hidden_states = self.embeddings(pixel_values.to(self.device))
-        last_hidden_state = self.encoder(inputs_embeds=hidden_states)
-        last_hidden_state = self.post_layernorm(last_hidden_state)
-        return last_hidden_state
-
-
-class SiglipVisionModel(nn.Module):
-    def __init__(
-        self,
-        config,
-        quant_config: Optional[QuantizationConfig] = None,
-        prefix: str = "",
-    ):
-        super().__init__()
-        self.vision_model = SiglipVisionTransformer(
-            config, quant_config, prefix=add_prefix("vision_model", prefix)
-        )
-
-    @property
-    def device(self) -> torch.device:
-        return self.vision_model.device
-
-    def forward(self, pixel_values: torch.Tensor):
-        return self.vision_model(pixel_values)
 
 
 class Gemma3MultiModalProjector(nn.Module):

--- a/python/sglang/multimodal_gen/runtime/models/encoders/siglip.py
+++ b/python/sglang/multimodal_gen/runtime/models/encoders/siglip.py
@@ -1,0 +1,347 @@
+# SPDX-License-Identifier: Apache-2.0
+# Adapted from vLLM and Hugging Face Transformers SigLIP implementations.
+
+from collections.abc import Callable
+from functools import partial
+from typing import Any
+
+import torch
+from torch import nn
+
+from sglang.multimodal_gen.runtime.distributed import get_tp_world_size
+from sglang.multimodal_gen.runtime.layers.activation import QuickGELU
+from sglang.multimodal_gen.runtime.layers.attention import LocalAttention
+from sglang.multimodal_gen.runtime.layers.linear import (
+    ColumnParallelLinear,
+    QKVParallelLinear,
+    RowParallelLinear,
+)
+from sglang.multimodal_gen.runtime.layers.quantization import QuantizationConfig
+from sglang.multimodal_gen.runtime.managers.memory_managers.layerwise_offload import (
+    LayerwiseOffloadableModuleMixin,
+)
+from sglang.multimodal_gen.runtime.platforms import AttentionBackendEnum
+from sglang.multimodal_gen.runtime.utils.common import add_prefix
+
+ActivationFactory = Callable[[], nn.Module]
+
+
+class SiglipVisionEmbeddings(nn.Module):
+    def __init__(self, config: Any):
+        super().__init__()
+        self.config = config
+        self.embed_dim = config.hidden_size
+        self.image_size = config.image_size
+        self.patch_size = config.patch_size
+        self.patch_embedding = nn.Conv2d(
+            in_channels=config.num_channels,
+            out_channels=self.embed_dim,
+            kernel_size=self.patch_size,
+            stride=self.patch_size,
+            padding="valid",
+        )
+
+        self.num_patches = (self.image_size // self.patch_size) ** 2
+        self.num_positions = self.num_patches
+        self.position_embedding = nn.Embedding(self.num_positions, self.embed_dim)
+        self.register_buffer(
+            "position_ids",
+            torch.arange(self.num_positions).expand((1, -1)),
+            persistent=False,
+        )
+
+    def forward(self, pixel_values: torch.Tensor) -> torch.Tensor:
+        patch_embeds = self.patch_embedding(
+            pixel_values.to(dtype=self.patch_embedding.weight.dtype)
+        )
+        embeddings = patch_embeds.flatten(2).transpose(1, 2)
+        return embeddings + self.position_embedding(self.position_ids)
+
+
+class SiglipMLP(nn.Module):
+    def __init__(
+        self,
+        config: Any,
+        *,
+        activation_factory: ActivationFactory = QuickGELU,
+        tensor_parallel: bool = True,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ):
+        super().__init__()
+        self.tensor_parallel = tensor_parallel
+        if tensor_parallel:
+            self.fc1 = ColumnParallelLinear(
+                config.hidden_size,
+                config.intermediate_size,
+                quant_config=quant_config,
+                prefix=add_prefix("fc1", prefix),
+            )
+            self.fc2 = RowParallelLinear(
+                config.intermediate_size,
+                config.hidden_size,
+                quant_config=quant_config,
+                prefix=add_prefix("fc2", prefix),
+            )
+        else:
+            if quant_config is not None:
+                raise ValueError("SigLIP quantization requires tensor parallel layers")
+            self.fc1 = nn.Linear(config.hidden_size, config.intermediate_size)
+            self.fc2 = nn.Linear(config.intermediate_size, config.hidden_size)
+        self.act = activation_factory()
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        hidden_states = self.fc1(hidden_states)
+        if self.tensor_parallel:
+            hidden_states = hidden_states[0]
+        hidden_states = self.act(hidden_states)
+        hidden_states = self.fc2(hidden_states)
+        if self.tensor_parallel:
+            hidden_states = hidden_states[0]
+        return hidden_states
+
+
+class SiglipAttention(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        num_heads: int,
+        *,
+        tensor_parallel: bool = True,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ):
+        super().__init__()
+        if hidden_size % num_heads != 0:
+            raise ValueError(
+                f"SigLIP hidden size {hidden_size} is not divisible by {num_heads} heads"
+            )
+
+        self.tensor_parallel = tensor_parallel
+        self.hidden_size = hidden_size
+        self.embed_dim = hidden_size
+        self.num_heads = num_heads
+        self.head_dim = hidden_size // num_heads
+        self.scaling = self.head_dim**-0.5
+
+        if tensor_parallel:
+            tp_size = get_tp_world_size()
+            if num_heads % tp_size != 0:
+                raise ValueError(
+                    f"SigLIP heads {num_heads} are not divisible by TP size {tp_size}"
+                )
+            self.num_heads_per_partition = num_heads // tp_size
+            self.embed_dim_per_partition = self.num_heads_per_partition * self.head_dim
+            self.qkv_proj = QKVParallelLinear(
+                hidden_size=hidden_size,
+                head_size=self.head_dim,
+                total_num_heads=num_heads,
+                total_num_kv_heads=num_heads,
+                bias=True,
+                quant_config=quant_config,
+                prefix=add_prefix("qkv_proj", prefix),
+            )
+            self.out_proj = RowParallelLinear(
+                input_size=hidden_size,
+                output_size=hidden_size,
+                bias=True,
+                quant_config=quant_config,
+                prefix=add_prefix("out_proj", prefix),
+            )
+        else:
+            if quant_config is not None:
+                raise ValueError("SigLIP quantization requires tensor parallel layers")
+            self.num_heads_per_partition = num_heads
+            self.embed_dim_per_partition = hidden_size
+            self.q_proj = nn.Linear(hidden_size, hidden_size)
+            self.k_proj = nn.Linear(hidden_size, hidden_size)
+            self.v_proj = nn.Linear(hidden_size, hidden_size)
+            self.out_proj = nn.Linear(hidden_size, hidden_size)
+
+        attention_kwargs = {}
+        if not tensor_parallel:
+            attention_kwargs = {
+                "supported_attention_backends": {
+                    AttentionBackendEnum.FA,
+                    AttentionBackendEnum.FA2,
+                    AttentionBackendEnum.TORCH_SDPA,
+                },
+                "compute_dtype": self.projection_dtype,
+                "allow_cudnn_sdp": True,
+            }
+        self.attn = LocalAttention(
+            num_heads=self.num_heads_per_partition,
+            head_size=self.head_dim,
+            num_kv_heads=self.num_heads_per_partition,
+            softmax_scale=self.scaling,
+            causal=False,
+            **attention_kwargs,
+        )
+
+    @property
+    def projection_dtype(self) -> torch.dtype:
+        if self.tensor_parallel:
+            return self.qkv_proj.weight.dtype
+        return self.q_proj.weight.dtype
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        if self.tensor_parallel:
+            qkv, _ = self.qkv_proj(hidden_states)
+            query, key, value = qkv.split([self.embed_dim_per_partition] * 3, dim=-1)
+        else:
+            query = self.q_proj(hidden_states)
+            key = self.k_proj(hidden_states)
+            value = self.v_proj(hidden_states)
+
+        batch_size, seq_len = hidden_states.shape[:2]
+        shape = (batch_size, seq_len, self.num_heads_per_partition, self.head_dim)
+        query = query.view(shape)
+        key = key.view(shape)
+        value = value.view(shape)
+        hidden_states = self.attn(query, key, value)
+        hidden_states = hidden_states.reshape(
+            batch_size, seq_len, self.embed_dim_per_partition
+        )
+        hidden_states = self.out_proj(hidden_states)
+        if self.tensor_parallel:
+            hidden_states = hidden_states[0]
+        return hidden_states
+
+
+class SiglipEncoderLayer(nn.Module):
+    def __init__(
+        self,
+        config: Any,
+        *,
+        activation_factory: ActivationFactory = QuickGELU,
+        tensor_parallel: bool = True,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ):
+        super().__init__()
+        norm_factory = partial(nn.LayerNorm, eps=config.layer_norm_eps)
+        self.layer_norm1 = norm_factory(config.hidden_size)
+        self.layer_norm2 = norm_factory(config.hidden_size)
+        self.self_attn = SiglipAttention(
+            config.hidden_size,
+            config.num_attention_heads,
+            tensor_parallel=tensor_parallel,
+            quant_config=quant_config,
+            prefix=add_prefix("self_attn", prefix),
+        )
+        self.mlp = SiglipMLP(
+            config,
+            activation_factory=activation_factory,
+            tensor_parallel=tensor_parallel,
+            quant_config=quant_config,
+            prefix=add_prefix("mlp", prefix),
+        )
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.self_attn(self.layer_norm1(hidden_states))
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.mlp(self.layer_norm2(hidden_states))
+        return residual + hidden_states
+
+
+class SiglipEncoder(nn.Module):
+    def __init__(
+        self,
+        config: Any,
+        *,
+        activation_factory: ActivationFactory = QuickGELU,
+        tensor_parallel: bool = True,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ):
+        super().__init__()
+        self.config = config
+        self.layers = nn.ModuleList(
+            [
+                SiglipEncoderLayer(
+                    config,
+                    activation_factory=activation_factory,
+                    tensor_parallel=tensor_parallel,
+                    quant_config=quant_config,
+                    prefix=add_prefix(f"layers.{layer_idx}", prefix),
+                )
+                for layer_idx in range(config.num_hidden_layers)
+            ]
+        )
+
+    def forward(self, inputs_embeds: torch.Tensor) -> torch.Tensor:
+        hidden_states = inputs_embeds
+        for layer in self.layers:
+            hidden_states = layer(hidden_states)
+        return hidden_states
+
+
+class SiglipVisionTransformer(nn.Module):
+    def __init__(
+        self,
+        config: Any,
+        *,
+        activation_factory: ActivationFactory = QuickGELU,
+        tensor_parallel: bool = True,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ):
+        super().__init__()
+        self.config = config
+        self.embeddings = SiglipVisionEmbeddings(config)
+        self.encoder = SiglipEncoder(
+            config,
+            activation_factory=activation_factory,
+            tensor_parallel=tensor_parallel,
+            quant_config=quant_config,
+            prefix=add_prefix("encoder", prefix),
+        )
+        self.post_layernorm = nn.LayerNorm(
+            config.hidden_size, eps=config.layer_norm_eps
+        )
+
+    @property
+    def device(self) -> torch.device:
+        return self.embeddings.patch_embedding.weight.device
+
+    def forward(self, pixel_values: torch.Tensor) -> torch.Tensor:
+        hidden_states = self.embeddings(pixel_values.to(self.device))
+        if self.encoder.layers:
+            encoder_dtype = self.encoder.layers[0].self_attn.projection_dtype
+            if hidden_states.dtype != encoder_dtype:
+                hidden_states = hidden_states.to(encoder_dtype)
+        hidden_states = self.encoder(hidden_states)
+        return self.post_layernorm(hidden_states)
+
+
+class SiglipVisionModel(nn.Module, LayerwiseOffloadableModuleMixin):
+    layerwise_offload_dit_group_enabled = False
+    layer_names = ["vision_model.encoder.layers"]
+
+    def __init__(
+        self,
+        config: Any,
+        *,
+        activation_factory: ActivationFactory = QuickGELU,
+        tensor_parallel: bool = True,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ):
+        super().__init__()
+        self.vision_model = SiglipVisionTransformer(
+            config,
+            activation_factory=activation_factory,
+            tensor_parallel=tensor_parallel,
+            quant_config=quant_config,
+            prefix=add_prefix("vision_model", prefix),
+        )
+
+    @property
+    def device(self) -> torch.device:
+        return self.vision_model.device
+
+    def forward(self, pixel_values: torch.Tensor) -> torch.Tensor:
+        return self.vision_model(pixel_values)

--- a/python/sglang/multimodal_gen/runtime/models/vlas/pi05_core.py
+++ b/python/sglang/multimodal_gen/runtime/models/vlas/pi05_core.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
+from functools import partial
 from typing import Any, Literal
 
 import torch
@@ -12,8 +13,7 @@ import torch.nn.functional as F
 from torch import Tensor, nn
 from transformers.modeling_outputs import BaseModelOutputWithPooling
 from transformers.models.auto import CONFIG_MAPPING
-from transformers.models.gemma.modeling_gemma import GemmaConfig
-from transformers.models.paligemma.modeling_paligemma import PaliGemmaModel
+from transformers.models.gemma.configuration_gemma import GemmaConfig
 
 from sglang.multimodal_gen.configs.pipeline_configs.pi05 import Pi05PipelineConfig
 from sglang.multimodal_gen.runtime.distributed.parallel_state import (
@@ -22,6 +22,7 @@ from sglang.multimodal_gen.runtime.distributed.parallel_state import (
     get_ulysses_parallel_world_size,
     model_parallel_is_initialized,
 )
+from sglang.multimodal_gen.runtime.layers.activation import get_act_fn
 from sglang.multimodal_gen.runtime.layers.attention import LocalAttention, USPAttention
 from sglang.multimodal_gen.runtime.layers.linear import (
     MergedColumnParallelLinear,
@@ -30,6 +31,7 @@ from sglang.multimodal_gen.runtime.layers.linear import (
 )
 from sglang.multimodal_gen.runtime.layers.rotary_embedding import RotaryEmbedding
 from sglang.multimodal_gen.runtime.managers.forward_context import set_forward_context
+from sglang.multimodal_gen.runtime.models.encoders.siglip import SiglipVisionModel
 from sglang.multimodal_gen.runtime.platforms import AttentionBackendEnum
 from sglang.multimodal_gen.runtime.vla.prefix_cache import VLADensePrefixCache
 from sglang.srt.layers.activation import GeluAndMul
@@ -104,73 +106,6 @@ def _use_ulysses_action_attention(num_heads: int) -> bool:
         and ring_world_size == 1
         and num_heads % sp_world_size == 0
     )
-
-
-class Pi05SiglipAttention(nn.Module):
-    def __init__(self, attention: nn.Module):
-        super().__init__()
-        self.embed_dim = attention.embed_dim
-        self.num_heads = attention.num_heads
-        self.head_dim = attention.head_dim
-        self.scale = getattr(attention, "scale", self.head_dim**-0.5)
-        self.dropout = getattr(attention, "dropout", 0.0)
-        self.q_proj = attention.q_proj
-        self.k_proj = attention.k_proj
-        self.v_proj = attention.v_proj
-        self.out_proj = attention.out_proj
-        self.attn = LocalAttention(
-            num_heads=self.num_heads,
-            head_size=self.head_dim,
-            num_kv_heads=self.num_heads,
-            softmax_scale=self.scale,
-            causal=False,
-            supported_attention_backends={
-                AttentionBackendEnum.FA,
-                AttentionBackendEnum.FA2,
-                AttentionBackendEnum.TORCH_SDPA,
-            },
-            compute_dtype=self.q_proj.weight.dtype,
-            allow_cudnn_sdp=True,
-        )
-
-    def forward(
-        self,
-        hidden_states: torch.Tensor,
-        attention_mask: torch.Tensor | None = None,
-        output_attentions: bool = False,
-        **kwargs,
-    ) -> tuple[torch.Tensor, None]:
-        input_shape = hidden_states.shape[:-1]
-        query_states = self.q_proj(hidden_states).view(
-            *input_shape,
-            self.num_heads,
-            self.head_dim,
-        )
-        key_states = self.k_proj(hidden_states).view(
-            *input_shape,
-            self.num_heads,
-            self.head_dim,
-        )
-        value_states = self.v_proj(hidden_states).view(
-            *input_shape,
-            self.num_heads,
-            self.head_dim,
-        )
-        attn_output = self.attn(
-            query_states,
-            key_states,
-            value_states,
-            attn_mask=attention_mask,
-        )
-        attn_output = attn_output.reshape(*input_shape, self.embed_dim).contiguous()
-        return self.out_proj(attn_output), None
-
-
-def patch_siglip_vision_attention_to_native(vision_model: nn.Module) -> None:
-    for layer in vision_model.encoder.layers:
-        if isinstance(layer.self_attn, Pi05SiglipAttention):
-            continue
-        layer.self_attn = Pi05SiglipAttention(layer.self_attn)
 
 
 class PiGemmaRMSNorm(nn.Module):
@@ -788,13 +723,42 @@ class PiGemmaForCausalLM(nn.Module):
         self.lm_head = None
 
 
-class PaliGemmaModelWithPiGemma(PaliGemmaModel):
+class PaliGemmaMultiModalProjector(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.linear = nn.Linear(
+            config.vision_config.hidden_size,
+            config.vision_config.projection_dim,
+            bias=True,
+        )
+
+    def forward(self, image_features: torch.Tensor) -> torch.Tensor:
+        return self.linear(image_features)
+
+
+class PaliGemmaModelWithPiGemma(nn.Module):
     def __init__(self, config, *, tensor_parallel: bool = False):
-        super().__init__(config)
-        del self.language_model
+        super().__init__()
+        self.config = config
+        self.vision_tower = SiglipVisionModel(
+            config.vision_config,
+            activation_factory=partial(get_act_fn, config.vision_config.hidden_act),
+            tensor_parallel=False,
+        )
+        self.multi_modal_projector = PaliGemmaMultiModalProjector(config)
         self.language_model = PiGemmaModel(
             config.text_config,
             tensor_parallel=tensor_parallel,
+        )
+
+    def get_image_features(
+        self, pixel_values: torch.Tensor
+    ) -> BaseModelOutputWithPooling:
+        vision_features = self.vision_tower(pixel_values)
+        image_features = self.multi_modal_projector(vision_features)
+        return BaseModelOutputWithPooling(
+            last_hidden_state=vision_features,
+            pooler_output=image_features,
         )
 
 
@@ -905,34 +869,6 @@ def prepare_optional_full_attention_mask(
         return None
     masks_4d = att_2d_masks[:, None, :, :]
     return torch.where(masks_4d, 0.0, OPENPI_ATTENTION_MASK_VALUE)
-
-
-def siglip_vision_forward_with_openpi_dtype(
-    self,
-    pixel_values,
-    interpolate_pos_encoding: bool | None = False,
-    **kwargs,
-) -> BaseModelOutputWithPooling:
-    hidden_states = self.embeddings(
-        pixel_values,
-        interpolate_pos_encoding=interpolate_pos_encoding,
-    )
-    if (
-        len(self.encoder.layers) > 0
-        and self.encoder.layers[0].self_attn.q_proj.weight.dtype == torch.bfloat16
-    ):
-        hidden_states = hidden_states.to(torch.bfloat16)
-
-    encoder_outputs = self.encoder(inputs_embeds=hidden_states, **kwargs)
-    last_hidden_state = encoder_outputs.last_hidden_state
-    last_hidden_state = self.post_layernorm(last_hidden_state)
-    pooler_output = self.head(last_hidden_state) if self.use_head else None
-    return BaseModelOutputWithPooling(
-        last_hidden_state=last_hidden_state,
-        pooler_output=pooler_output,
-        hidden_states=encoder_outputs.hidden_states,
-        attentions=encoder_outputs.attentions,
-    )
 
 
 def compute_layer_complete(
@@ -1059,12 +995,6 @@ class PaliGemmaWithExpertModel(nn.Module):
                 config=vlm_config_hf,
                 tensor_parallel=prefix_tensor_parallel,
             )
-            vision_tower = self.paligemma.model.vision_tower
-            vision_model = getattr(vision_tower, "vision_model", vision_tower)
-            vision_model.forward = siglip_vision_forward_with_openpi_dtype.__get__(
-                vision_model,
-                type(vision_model),
-            )
             self.paligemma.lm_head = None
 
         if runtime_role in ("all", "action"):
@@ -1090,14 +1020,6 @@ class PaliGemmaWithExpertModel(nn.Module):
             self.gemma_expert.lm_head = None
             self.gemma_expert.model.embed_tokens = None
         self.to_selected_dtype(precision)
-        self.patch_native_attention_after_dtype_finalize()
-
-    def patch_native_attention_after_dtype_finalize(self) -> None:
-        if self.paligemma is None:
-            return
-        vision_tower = self.paligemma.model.vision_tower
-        vision_model = getattr(vision_tower, "vision_model", vision_tower)
-        patch_siglip_vision_attention_to_native(vision_model)
 
     def to_selected_dtype(
         self, precision: Literal["bfloat16", "float32"] = "bfloat16"

--- a/python/sglang/multimodal_gen/test/unit/test_pi05_runtime_helpers.py
+++ b/python/sglang/multimodal_gen/test/unit/test_pi05_runtime_helpers.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+from functools import partial
 from types import SimpleNamespace
 
 import numpy as np
@@ -8,11 +9,8 @@ from torch import nn
 
 import sglang.multimodal_gen.runtime.models.vlas.pi05_policy as pi05_policy_module
 from sglang.multimodal_gen.configs.pipeline_configs.pi05 import Pi05PipelineConfig
-from sglang.multimodal_gen.runtime.models.vlas.pi05_core import (
-    Pi05CoreModel,
-    Pi05SiglipAttention,
-    patch_siglip_vision_attention_to_native,
-)
+from sglang.multimodal_gen.runtime.models.encoders.siglip import SiglipVisionModel
+from sglang.multimodal_gen.runtime.models.vlas.pi05_core import Pi05CoreModel
 from sglang.multimodal_gen.runtime.models.vlas.pi05_policy import (
     Pi05CheckpointManifest,
     Pi05PolicyModel,
@@ -183,30 +181,30 @@ def test_action_parallel_info_reports_single_rank_without_process_group():
     }
 
 
-class _FakeSiglipAttention(nn.Module):
-    def __init__(self):
-        super().__init__()
-        self.embed_dim = 8
-        self.num_heads = 2
-        self.head_dim = 4
-        self.scale = self.head_dim**-0.5
-        self.dropout = 0.0
-        self.q_proj = nn.Linear(self.embed_dim, self.embed_dim)
-        self.k_proj = nn.Linear(self.embed_dim, self.embed_dim)
-        self.v_proj = nn.Linear(self.embed_dim, self.embed_dim)
-        self.out_proj = nn.Linear(self.embed_dim, self.embed_dim)
+def test_siglip_non_tp_model_keeps_transformers_checkpoint_names():
+    config = SimpleNamespace(
+        hidden_size=8,
+        intermediate_size=16,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        layer_norm_eps=1e-6,
+        image_size=4,
+        patch_size=2,
+        num_channels=3,
+    )
+    model = SiglipVisionModel(
+        config,
+        activation_factory=partial(nn.GELU, approximate="tanh"),
+        tensor_parallel=False,
+    )
 
-
-def test_siglip_attention_patch_uses_native_wrapper_once():
-    layer = SimpleNamespace(self_attn=_FakeSiglipAttention())
-    vision_model = SimpleNamespace(encoder=SimpleNamespace(layers=[layer]))
-
-    patch_siglip_vision_attention_to_native(vision_model)
-    first = layer.self_attn
-    patch_siglip_vision_attention_to_native(vision_model)
-
-    assert isinstance(first, Pi05SiglipAttention)
-    assert layer.self_attn is first
+    state_keys = set(model.state_dict())
+    prefix = "vision_model.encoder.layers.0.self_attn"
+    assert f"{prefix}.q_proj.weight" in state_keys
+    assert f"{prefix}.k_proj.weight" in state_keys
+    assert f"{prefix}.v_proj.weight" in state_keys
+    assert not any("qkv_proj" in key for key in state_keys)
+    assert model.layer_names == ["vision_model.encoder.layers"]
 
 
 def test_prefix_language_embedding_matches_openpi_scale():


### PR DESCRIPTION
## Summary

- extract the existing native SigLIP implementation from Gemma3 into a shared encoder
- replace Pi0.5's Hugging Face `PaliGemmaModel` vision tower and runtime attention monkey patch with the native SigLIP/PiGemma composition
- preserve both Gemma3 TP packed-QKV weights and Pi0.5 non-TP Transformers checkpoint names
- document that the Pi0.5 runtime neural network is fully native

## Why

Pi0.5 constructed a Transformers PaliGemma model, deleted its language model, and monkey-patched every SigLIP attention layer after dtype materialization. This left a third-party `nn.Module` in the native runtime and made checkpoint layout, dtype handling, attention selection, and layerwise ownership harder to reason about.

The shared native encoder now owns those semantics directly. Transformers remains only for configuration, output dataclasses, and tokenization.

## Validation

- remote pre-commit: passed
- remote Pi0.5 unit tests: `24 passed`
- `lerobot/pi05_base` real checkpoint: strict load passed
- old/new real-checkpoint vision features, first-layer prefix K/V, masks, and 2-step actions: bitwise equal, max absolute error `0`
- old/new Gemma3 TP SigLIP state-dict and output parity: bitwise equal, max absolute error `0`
- H100 single-image SigLIP forward, 50 repeats: median `5.075 ms -> 4.858 ms` (`-4.3%`)

The public Python E2E preprocessor could not be run because `google/paligemma-3b-pt-224` requires gated access in the validation environment. The direct policy validation uses the same real checkpoint and covers vision encoding, prefix K/V generation, and action denoising without tokenizer access.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31895887526](https://github.com/sgl-project/sglang/actions/runs/31895887526)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #31895901766](https://github.com/sgl-project/sglang/actions/runs/31895901766)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->