### PR TITLE
Support compressed-tensors NVFP4 Marlin with BF16 and DSpark

### DIFF
--- a/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -164,8 +164,9 @@ class CompressedTensorsConfig(QuantizationConfig):
         prefix: str,
     ) -> Optional[QuantizeMethodBase]:
         from sglang.srt.layers.linear import LinearBase
+        from sglang.srt.layers.vocab_parallel_embedding import ParallelLMHead
 
-        if isinstance(layer, LinearBase):
+        if isinstance(layer, (LinearBase, ParallelLMHead)):
             # If linear_fp8_config is set, use FP8 for linear layers
             # This allows mixed quantization: experts with int4, linear layers with fp8
             if self.linear_fp8_config is not None:

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
@@ -17,6 +17,10 @@ from sglang.srt.layers.quantization.compressed_tensors.schemes import (
     CompressedTensorsLinearScheme,
 )
 from sglang.srt.layers.quantization.fp4_utils import get_fp4_gemm_runner_backend
+from sglang.srt.layers.quantization.marlin_utils_fp4 import (
+    apply_fp4_marlin_linear,
+    prepare_nvfp4_layer_for_marlin,
+)
 from sglang.srt.layers.quantization.modelopt_quant import (
     enable_flashinfer_fp4_gemm,
     fp4_gemm,
@@ -35,7 +39,7 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsLinearScheme):
 
     @classmethod
     def get_min_capability(cls) -> int:
-        return 100
+        return 80 if get_fp4_gemm_runner_backend().is_marlin() else 100
 
     def create_weights(
         self,
@@ -50,6 +54,7 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsLinearScheme):
         layer.logical_widths = output_partition_sizes
         layer.input_size_per_partition = input_size_per_partition
         layer.output_size_per_partition = output_size_per_partition
+        layer.params_dtype = params_dtype
 
         # Weight
         weight = ModelWeightParameter(
@@ -99,6 +104,17 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsLinearScheme):
             layer.weight_global_scale.max().to(torch.float32), requires_grad=False
         )
 
+        if get_fp4_gemm_runner_backend().is_marlin():
+            layer.weight = Parameter(layer.weight_packed.data, requires_grad=False)
+            del layer.weight_packed
+            # Compressed Tensors stores global scales as divisors.
+            layer.weight_global_scale = Parameter(
+                1 / layer.weight_global_scale, requires_grad=False
+            )
+            layer.quant_config.group_size = self.group_size
+            prepare_nvfp4_layer_for_marlin(layer)
+            return
+
         if get_fp4_gemm_runner_backend().is_flashinfer_trtllm():
             # FlashInfer TRTLLM FP4 GEMM requires a different weight layout.
             # FlashInfer provides nvfp4_quantize to quantize + shuffle the
@@ -137,6 +153,18 @@ class CompressedTensorsW4A4Fp4(CompressedTensorsLinearScheme):
         x: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
+        if get_fp4_gemm_runner_backend().is_marlin():
+            return apply_fp4_marlin_linear(
+                input=x,
+                weight=layer.weight,
+                weight_scale=layer.weight_scale,
+                weight_global_scale=layer.weight_global_scale,
+                workspace=layer.workspace,
+                size_n=layer.output_size_per_partition,
+                size_k=layer.input_size_per_partition,
+                bias=bias,
+            )
+
         output_dtype = x.dtype
         w_n, _ = layer.weight_packed.shape
         output_shape = [x.shape[0], w_n]

--- a/python/sglang/srt/layers/quantization/marlin_utils_fp4.py
+++ b/python/sglang/srt/layers/quantization/marlin_utils_fp4.py
@@ -25,7 +25,26 @@ ScalarType, scalar_types = get_scalar_types()
 logger = logging.getLogger(__name__)
 
 
-def nvfp4_marlin_process_scales(marlin_scales: torch.Tensor) -> torch.Tensor:
+def _nvfp4_compute_scale_factor(
+    marlin_scales: torch.Tensor, a_dtype: torch.dtype | None = None
+) -> float:
+    if a_dtype == torch.half:
+        return 1.0
+
+    scaled = marlin_scales.float() * (2**7)
+    nonzero = scaled > 0
+    if nonzero.any():
+        max_val = scaled[nonzero].max()
+        if max_val < 448 * (2**7):
+            return ((448 * (2**7) / max_val).log2().floor().exp2()).item()
+    return 1.0
+
+
+def nvfp4_marlin_process_scales(
+    marlin_scales: torch.Tensor,
+    scale_factor: float | None = None,
+    a_dtype: torch.dtype | None = None,
+) -> tuple[torch.Tensor, float]:
     if not (marlin_scales >= 0).all():
         # NVFP4 ModelOpt scales are expected to be non-negative. Keep this as
         # a warning so unusual checkpoints can still load for diagnosis.
@@ -38,9 +57,15 @@ def nvfp4_marlin_process_scales(marlin_scales: torch.Tensor) -> torch.Tensor:
     marlin_scales = marlin_scales.view(-1, 4)[:, [0, 2, 1, 3]].view(
         marlin_scales.size(0), -1
     )
-    marlin_scales = (marlin_scales * (2**7)).view(torch.int16) << 1
+    if scale_factor is None:
+        scale_factor = _nvfp4_compute_scale_factor(marlin_scales, a_dtype)
+    if scale_factor > 1.0:
+        marlin_scales = (marlin_scales.float() * scale_factor).to(torch.half)
+    marlin_scales = marlin_scales * (2**7)
+    marlin_scales[marlin_scales < 2] = 0
+    marlin_scales = marlin_scales.view(torch.int16) << 1
     marlin_scales = marlin_scales.view(torch.float8_e4m3fn)
-    return marlin_scales[:, 1::2].contiguous()
+    return marlin_scales[:, 1::2].contiguous(), scale_factor
 
 
 def nvfp4_marlin_process_global_scale(global_scale: torch.Tensor) -> torch.Tensor:
@@ -196,11 +221,14 @@ def prepare_nvfp4_layer_for_marlin(layer: torch.nn.Module) -> None:
         size_n=padded_size_n,
         group_size=16,
     )
-    weight_scale = nvfp4_marlin_process_scales(weight_scale)
+    weight_scale, scale_factor = nvfp4_marlin_process_scales(
+        weight_scale, a_dtype=param_dtype
+    )
     layer.weight_scale = torch.nn.Parameter(weight_scale, requires_grad=False)
 
     weight_global_scale = layer.weight_global_scale.to(param_dtype)
     weight_global_scale = nvfp4_marlin_process_global_scale(weight_global_scale)
+    weight_global_scale = weight_global_scale / scale_factor
     layer.weight_global_scale = torch.nn.Parameter(
         weight_global_scale, requires_grad=False
     )
@@ -500,8 +528,11 @@ def prepare_moe_nvfp4_layer_for_marlin(layer: torch.nn.Module) -> None:
             tensor_list.append(marlin_qweight)
         return torch.stack(tensor_list)
 
-    def _permute_scales(scales: torch.Tensor, is_w13: bool) -> torch.Tensor:
+    def _permute_scales(
+        scales: torch.Tensor, is_w13: bool
+    ) -> tuple[torch.Tensor, float]:
         scales = scales.to(param_dtype)
+        scale_factor = _nvfp4_compute_scale_factor(scales, param_dtype)
         if is_w13:
             size_n, size_k = intermediate_size * num_shards, hidden_size
         else:
@@ -516,8 +547,11 @@ def prepare_moe_nvfp4_layer_for_marlin(layer: torch.nn.Module) -> None:
                 size_n=size_n,
                 group_size=16,
             )
-            tensor_list.append(nvfp4_marlin_process_scales(marlin_scales))
-        return torch.stack(tensor_list)
+            marlin_scales, _ = nvfp4_marlin_process_scales(
+                marlin_scales, scale_factor=scale_factor, a_dtype=param_dtype
+            )
+            tensor_list.append(marlin_scales)
+        return torch.stack(tensor_list), scale_factor
 
     def _process_global_scale(global_scale: torch.Tensor) -> torch.Tensor:
         return nvfp4_marlin_process_global_scale(global_scale.to(param_dtype))
@@ -534,17 +568,17 @@ def prepare_moe_nvfp4_layer_for_marlin(layer: torch.nn.Module) -> None:
         _repack_weight(w13, True), requires_grad=False
     )
     layer.w2_weight = torch.nn.Parameter(_repack_weight(w2, False), requires_grad=False)
-    layer.w13_weight_scale = torch.nn.Parameter(
-        _permute_scales(w13_scale, True), requires_grad=False
-    )
-    layer.w2_weight_scale = torch.nn.Parameter(
-        _permute_scales(w2_scale, False), requires_grad=False
-    )
+    w13_scale, w13_scale_factor = _permute_scales(w13_scale, True)
+    w2_scale, w2_scale_factor = _permute_scales(w2_scale, False)
+    layer.w13_weight_scale = torch.nn.Parameter(w13_scale, requires_grad=False)
+    layer.w2_weight_scale = torch.nn.Parameter(w2_scale, requires_grad=False)
     layer.w13_weight_scale_2 = torch.nn.Parameter(
-        _process_global_scale(w13_global_scale), requires_grad=False
+        _process_global_scale(w13_global_scale) / w13_scale_factor,
+        requires_grad=False,
     )
     layer.w2_weight_scale_2 = torch.nn.Parameter(
-        _process_global_scale(w2_global_scale), requires_grad=False
+        _process_global_scale(w2_global_scale) / w2_scale_factor,
+        requires_grad=False,
     )
 
     if w13_bias is not None:

--- a/python/sglang/srt/models/dspark.py
+++ b/python/sglang/srt/models/dspark.py
@@ -9,6 +9,7 @@ from torch import nn
 
 from sglang.srt.distributed.communication_op import tensor_model_parallel_all_gather
 from sglang.srt.environ import envs
+from sglang.srt.layers.logits_processor import should_apply_lm_head_quant_method
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.dflash import DFlashDraftModel
 from sglang.srt.speculative.dflash_utils import can_dflash_slice_qkv_weight
@@ -409,6 +410,11 @@ class DSparkDraftMixin:
             )
         if self.logits_mup_width_multiplier:
             hidden = hidden / self.logits_mup_width_multiplier
+        quant_method = getattr(self.lm_head, "quant_method", None)
+        if should_apply_lm_head_quant_method(self.lm_head, quant_method):
+            local_logits = quant_method.apply(self.lm_head, hidden)
+            return gather_and_crop_vocab(local_logits, self.lm_head), None
+
         weight = self.lm_head.weight
         if hidden.dtype != weight.dtype:
             hidden = hidden.to(weight.dtype)

--- a/python/sglang/srt/speculative/dspark_components/dspark_draft_sampler.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_draft_sampler.py
@@ -70,7 +70,7 @@ class DsparkDraftSampler:
             )
             self.corrected_out = torch.empty(
                 (max_bs * self.gamma, vocab),
-                dtype=model.lm_head.weight.dtype,
+                dtype=getattr(model.lm_head, "orig_dtype", model.lm_head.weight.dtype),
                 device=device,
             )
 
@@ -144,7 +144,8 @@ def _resolve_folded_sampling(*, model, gamma, max_bs, device, tp_rank) -> bool:
         return True
     vocab = int(model.lm_head.org_vocab_size)
     noise_bytes = max_bs * vocab * 4
-    logits_bytes = max_bs * gamma * vocab * model.lm_head.weight.dtype.itemsize
+    logits_dtype = getattr(model.lm_head, "orig_dtype", model.lm_head.weight.dtype)
+    logits_bytes = max_bs * gamma * vocab * logits_dtype.itemsize
     need_gb = (noise_bytes + logits_bytes) / (1 << 30)
     available_gb = get_available_gpu_memory(device, torch.cuda.current_device())
     if available_gb - need_gb >= _CAPTURE_HEADROOM_GB:

--- a/test/registered/kernels/ops/quantization/test_gptq_marlin.py
+++ b/test/registered/kernels/ops/quantization/test_gptq_marlin.py
@@ -157,6 +157,10 @@ def test_nvfp4_marlin_dense_matches_dequant_reference(dtype):
     fp4_weight, scales, global_scale, weight_ref = make_nvfp4_weight_and_ref(
         size_n, size_k, dtype, group_size=group_size
     )
+    if dtype == torch.bfloat16:
+        # Exercise checkpoints that store small, unnormalized E4M3 scales.
+        scales = (scales.float() / 4096).to(torch.float8_e4m3fn)
+        global_scale = global_scale * 4096
 
     layer = torch.nn.Module()
     layer.quant_config = SimpleNamespace(group_size=group_size)


### PR DESCRIPTION
## Motivation

Compressed-tensors NVFP4 checkpoints currently require the native SM100+ FP4 runner. On SM80-SM90 GPUs, the existing Marlin NVFP4 path is available for ModelOpt checkpoints but is not wired into the compressed-tensors scheme.

BF16 models expose a second issue: small E4M3 block scales can underflow when Marlin encodes them through FP16 bit manipulation. In addition, compressed-tensors quantization is not attached to `ParallelLMHead`, and DSpark computes logits through the raw weight tensor, so a quantized `lm_head` is loaded or executed incorrectly.

Together these issues prevent checkpoints such as `unsloth/Qwen3.8-27B-NVFP4` from running correctly with `RadixArk/Qwen3.8-27B-DSpark` on RTX 4090/SM89.

## Modifications

- Add a Marlin fallback for compressed-tensors W4A4 NVFP4 on SM80-SM90.
- Convert compressed-tensors global scale divisors to Marlin multipliers.
- Rescale tiny BF16 NVFP4 block scales by an exact power of two and compensate the global scale, following the approach in vLLM PR https://github.com/vllm-project/vllm/pull/34577.
- Apply compressed-tensors quantization to `ParallelLMHead`.
- Route DSpark logits through the quantized `lm_head` method and size folded-sampling buffers from the original output dtype.

## Accuracy Tests

- `pytest -q test/registered/kernels/ops/quantization/test_gptq_marlin.py -k nvfp4_marlin_dense_matches_dequant_reference`: **2 passed** (FP16 and BF16).
- Synthetic tiny-scale BF16 Marlin comparison: relative MAE `0.001704`, cosine similarity `0.999996`.
- Real checkpoint NVFP4 MLP comparison: relative MAE `0.001906`, cosine similarity `0.999995`.
- Real checkpoint FP8 linear-attention comparison: relative MAE `0.02650`, cosine similarity `0.999638`.
- End-to-end smoke test with the checkpoints above: `6 * 7 -> 42`; two concurrent requests returned `42` and `81` correctly.

## Speed Tests and Profiling

RTX 4090, BF16 activations, Marlin FP4 GEMM, FP8 target/draft KV cache, DSpark block size 7, CUDA graphs enabled:

- 512 input / 256 output, concurrency 1: `82.30` output tok/s, mean TPOT `11.47 ms`.
- 8192 input / 64 output, concurrency 1: `3229.87` input tok/s, mean TPOT `7.88 ms`.
- 8192 input / 256 output live request: approximately `3330` prefill tok/s and `72` decode tok/s.

The server starts with a 262144-token context and two running request slots on one 48 GB RTX 4090.

Validation launch command:

```bash
CUDA_VISIBLE_DEVICES=1 sglang serve \
  --trust-remote-code \
  --model-path unsloth/Qwen3.8-27B-NVFP4 \
  --served-model-name unsloth/Qwen3.8-27B-NVFP4 \
  --host 127.0.0.1 --port 8081 \
  --tp-size 1 \
  --dtype bfloat16 \
  --context-length 262144 \
  --mem-fraction-static 0.88 \
  --max-running-requests 2 \
  --kv-cache-dtype fp8_e4m3 \
  --fp4-gemm-backend marlin \
  --attention-backend flashinfer \
  --image-processor-backend pil \
  --reasoning-parser qwen3 \
  --tool-call-parser qwen3_coder \
  --enable-cache-report \
  --speculative-algorithm DSPARK \
  --speculative-draft-model-path RadixArk/Qwen3.8-27B-DSpark \
  --speculative-dspark-block-size 7 \
  --speculative-draft-model-quantization unquant \
  --speculative-draft-attention-backend flashinfer \
  --speculative-draft-kv-cache-dtype fp8_e4m3 \
  --mamba-ssm-dtype bfloat16 \
  --mamba-radix-cache-strategy extra_buffer
```

## Checklist

- [x] Formatted with pre-commit; all hooks for the touched files pass.
- [x] Added and ran the relevant NVFP4 Marlin unit test.
- [x] Documentation update is not required; this extends an existing backend selection.
- [x] Included accuracy and speed results above.
- [x] Followed the existing compressed-tensors and Marlin code paths without adding a new backend abstraction.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31896134248](https://github.com/sgl-project/sglang/actions/runs/31896134248)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31896134111](https://github.com/sgl-project/sglang/actions/runs/31896134111)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->