### PR TITLE
[Diffusion] Native Hunyuan3D image encoders

### DIFF
--- a/python/sglang/multimodal_gen/runtime/models/encoders/clip.py
+++ b/python/sglang/multimodal_gen/runtime/models/encoders/clip.py
@@ -162,6 +162,7 @@ class CLIPAttention(nn.Module):
             )
         self.scale = self.head_dim**-0.5
         self.dropout = config.attention_dropout
+        self.causal = isinstance(config, CLIPTextConfig)
 
         self.qkv_proj = QKVParallelLinear(
             hidden_size=self.embed_dim,
@@ -186,7 +187,7 @@ class CLIPAttention(nn.Module):
             self.head_dim,
             self.num_heads_per_partition,
             softmax_scale=self.scale,
-            causal=True,
+            causal=self.causal,
             supported_attention_backends=config._supported_attention_backends,
         )
 
@@ -246,7 +247,7 @@ class CLIPAttention(nn.Module):
                     key_states,
                     value_states,
                     attn_mask=None,
-                    is_causal=True,
+                    is_causal=self.causal,
                     scale=self.scale,
                 )
             else:
@@ -269,7 +270,7 @@ class CLIPAttention(nn.Module):
                     key_states,
                     value_states,
                     attn_mask=attn_mask,
-                    is_causal=attention_mask is None,
+                    is_causal=self.causal and attention_mask is None,
                     scale=self.scale,
                 )
             attn_output = attn_output.transpose(1, 2)

--- a/python/sglang/multimodal_gen/runtime/models/encoders/dinov2.py
+++ b/python/sglang/multimodal_gen/runtime/models/encoders/dinov2.py
@@ -1,0 +1,500 @@
+# SPDX-License-Identifier: Apache-2.0
+# Adapted from Hugging Face Transformers DINOv2.
+
+from __future__ import annotations
+
+import collections.abc
+import math
+from collections.abc import Iterable
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+from transformers.models.dinov2.configuration_dinov2 import Dinov2Config
+
+from sglang.multimodal_gen.configs.models.encoders.base import BaseEncoderOutput
+from sglang.multimodal_gen.runtime.distributed import (
+    get_tp_world_size,
+    model_parallel_is_initialized,
+)
+from sglang.multimodal_gen.runtime.layers.activation import get_act_fn
+from sglang.multimodal_gen.runtime.layers.attention import LocalAttention
+from sglang.multimodal_gen.runtime.layers.linear import (
+    ColumnParallelLinear,
+    MergedColumnParallelLinear,
+    QKVParallelLinear,
+    RowParallelLinear,
+)
+from sglang.multimodal_gen.runtime.loader.weight_utils import default_weight_loader
+from sglang.multimodal_gen.runtime.managers.memory_managers.layerwise_offload import (
+    LayerwiseOffloadableModuleMixin,
+)
+from sglang.multimodal_gen.runtime.platforms import AttentionBackendEnum
+
+
+class Dinov2PatchEmbeddings(nn.Module):
+    def __init__(self, config: Dinov2Config):
+        super().__init__()
+        image_size = config.image_size
+        patch_size = config.patch_size
+        self.image_size = (
+            tuple(image_size)
+            if isinstance(image_size, collections.abc.Iterable)
+            else (image_size, image_size)
+        )
+        self.patch_size = (
+            tuple(patch_size)
+            if isinstance(patch_size, collections.abc.Iterable)
+            else (patch_size, patch_size)
+        )
+        self.num_channels = config.num_channels
+        self.num_patches = (self.image_size[0] // self.patch_size[0]) * (
+            self.image_size[1] // self.patch_size[1]
+        )
+        self.projection = nn.Conv2d(
+            config.num_channels,
+            config.hidden_size,
+            kernel_size=self.patch_size,
+            stride=self.patch_size,
+        )
+
+    def forward(self, pixel_values: torch.Tensor) -> torch.Tensor:
+        if pixel_values.shape[1] != self.num_channels:
+            raise ValueError(
+                f"DINOv2 expects {self.num_channels} image channels, "
+                f"got {pixel_values.shape[1]}"
+            )
+        return self.projection(pixel_values).flatten(2).transpose(1, 2)
+
+
+class Dinov2Embeddings(nn.Module):
+    def __init__(self, config: Dinov2Config):
+        super().__init__()
+        self.config = config
+        self.cls_token = nn.Parameter(torch.empty(1, 1, config.hidden_size))
+        self.use_mask_token = config.use_mask_token
+        if self.use_mask_token:
+            self.mask_token = nn.Parameter(torch.empty(1, config.hidden_size))
+        self.patch_embeddings = Dinov2PatchEmbeddings(config)
+        self.position_embeddings = nn.Parameter(
+            torch.empty(
+                1,
+                self.patch_embeddings.num_patches + 1,
+                config.hidden_size,
+            )
+        )
+        self.dropout = nn.Dropout(config.hidden_dropout_prob)
+        self.patch_size = config.patch_size
+
+    def interpolate_pos_encoding(
+        self,
+        embeddings: torch.Tensor,
+        height: int,
+        width: int,
+    ) -> torch.Tensor:
+        num_patches = embeddings.shape[1] - 1
+        num_positions = self.position_embeddings.shape[1] - 1
+        if num_patches == num_positions and height == width:
+            return self.position_embeddings
+
+        class_pos_embed = self.position_embeddings[:, :1]
+        patch_pos_embed = self.position_embeddings[:, 1:]
+        source_size = math.isqrt(num_positions)
+        if source_size * source_size != num_positions:
+            raise ValueError(
+                f"DINOv2 position embedding has {num_positions} non-square patches"
+            )
+
+        if isinstance(self.patch_size, collections.abc.Iterable):
+            patch_height, patch_width = self.patch_size
+        else:
+            patch_height = patch_width = self.patch_size
+        target_height = height // patch_height
+        target_width = width // patch_width
+        dim = embeddings.shape[-1]
+        patch_pos_embed = patch_pos_embed.reshape(
+            1, source_size, source_size, dim
+        ).permute(0, 3, 1, 2)
+        target_dtype = patch_pos_embed.dtype
+        patch_pos_embed = F.interpolate(
+            patch_pos_embed.float(),
+            size=(target_height, target_width),
+            mode="bicubic",
+            align_corners=False,
+        ).to(target_dtype)
+        patch_pos_embed = patch_pos_embed.permute(0, 2, 3, 1).reshape(1, -1, dim)
+        return torch.cat((class_pos_embed, patch_pos_embed), dim=1)
+
+    def forward(
+        self,
+        pixel_values: torch.Tensor,
+        bool_masked_pos: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        batch_size, _, height, width = pixel_values.shape
+        target_dtype = self.patch_embeddings.projection.weight.dtype
+        embeddings = self.patch_embeddings(pixel_values.to(dtype=target_dtype))
+        if bool_masked_pos is not None and self.use_mask_token:
+            embeddings = torch.where(
+                bool_masked_pos.unsqueeze(-1),
+                self.mask_token.to(embeddings.dtype).unsqueeze(0),
+                embeddings,
+            )
+
+        cls_tokens = self.cls_token.expand(batch_size, -1, -1)
+        embeddings = torch.cat((cls_tokens, embeddings), dim=1)
+        embeddings = embeddings + self.interpolate_pos_encoding(
+            embeddings, height, width
+        )
+        return self.dropout(embeddings)
+
+
+def _linear_output(linear: nn.Module, hidden_states: torch.Tensor) -> torch.Tensor:
+    output = linear(hidden_states)
+    return output[0] if isinstance(output, tuple) else output
+
+
+class Dinov2SelfAttention(nn.Module):
+    def __init__(self, config: Dinov2Config, *, use_tensor_parallel: bool):
+        super().__init__()
+        if config.hidden_size % config.num_attention_heads != 0:
+            raise ValueError(
+                f"DINOv2 hidden size {config.hidden_size} is not divisible by "
+                f"{config.num_attention_heads} attention heads"
+            )
+        self.num_attention_heads = config.num_attention_heads
+        self.attention_head_size = config.hidden_size // config.num_attention_heads
+        self.all_head_size = config.hidden_size
+        self.scaling = self.attention_head_size**-0.5
+        tp_size = get_tp_world_size() if use_tensor_parallel else 1
+        if self.num_attention_heads % tp_size != 0:
+            raise ValueError(
+                f"DINOv2 heads {self.num_attention_heads} are not divisible by "
+                f"TP size {tp_size}"
+            )
+        self.use_tensor_parallel = use_tensor_parallel
+        self.num_heads = self.num_attention_heads // tp_size
+        self.hidden_size = self.num_heads * self.attention_head_size
+        if use_tensor_parallel:
+            self.qkv_proj = QKVParallelLinear(
+                hidden_size=config.hidden_size,
+                head_size=self.attention_head_size,
+                total_num_heads=self.num_attention_heads,
+                total_num_kv_heads=self.num_attention_heads,
+                bias=config.qkv_bias,
+            )
+        else:
+            self.query = nn.Linear(
+                config.hidden_size, self.all_head_size, bias=config.qkv_bias
+            )
+            self.key = nn.Linear(
+                config.hidden_size, self.all_head_size, bias=config.qkv_bias
+            )
+            self.value = nn.Linear(
+                config.hidden_size, self.all_head_size, bias=config.qkv_bias
+            )
+        self.attn = LocalAttention(
+            num_heads=self.num_heads,
+            head_size=self.attention_head_size,
+            num_kv_heads=self.num_heads,
+            softmax_scale=self.scaling,
+            causal=False,
+            supported_attention_backends={
+                AttentionBackendEnum.FA,
+                AttentionBackendEnum.FA2,
+                AttentionBackendEnum.TORCH_SDPA,
+            },
+            allow_cudnn_sdp=True,
+        )
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        batch_size, seq_len = hidden_states.shape[:2]
+        if self.use_tensor_parallel:
+            qkv = _linear_output(self.qkv_proj, hidden_states)
+            query, key, value = qkv.split([self.hidden_size] * 3, dim=-1)
+        else:
+            query = self.query(hidden_states)
+            key = self.key(hidden_states)
+            value = self.value(hidden_states)
+        shape = (
+            batch_size,
+            seq_len,
+            self.num_heads,
+            self.attention_head_size,
+        )
+        query = query.view(shape)
+        key = key.view(shape)
+        value = value.view(shape)
+        context = self.attn(query, key, value)
+        return context.reshape(batch_size, seq_len, self.hidden_size)
+
+
+class Dinov2SelfOutput(nn.Module):
+    def __init__(self, config: Dinov2Config, *, use_tensor_parallel: bool):
+        super().__init__()
+        self.dense = (
+            RowParallelLinear(config.hidden_size, config.hidden_size)
+            if use_tensor_parallel
+            else nn.Linear(config.hidden_size, config.hidden_size)
+        )
+        self.dropout = nn.Dropout(config.hidden_dropout_prob)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.dropout(_linear_output(self.dense, hidden_states))
+
+
+class Dinov2Attention(nn.Module):
+    def __init__(self, config: Dinov2Config, *, use_tensor_parallel: bool):
+        super().__init__()
+        self.attention = Dinov2SelfAttention(
+            config, use_tensor_parallel=use_tensor_parallel
+        )
+        self.output = Dinov2SelfOutput(config, use_tensor_parallel=use_tensor_parallel)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.output(self.attention(hidden_states))
+
+
+class Dinov2LayerScale(nn.Module):
+    def __init__(self, config: Dinov2Config):
+        super().__init__()
+        self.lambda1 = nn.Parameter(torch.empty(config.hidden_size))
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return hidden_states * self.lambda1
+
+
+class Dinov2MLP(nn.Module):
+    def __init__(self, config: Dinov2Config, *, use_tensor_parallel: bool):
+        super().__init__()
+        hidden_features = int(config.hidden_size * config.mlp_ratio)
+        self.fc1 = (
+            ColumnParallelLinear(config.hidden_size, hidden_features)
+            if use_tensor_parallel
+            else nn.Linear(config.hidden_size, hidden_features)
+        )
+        self.activation = get_act_fn(config.hidden_act)
+        self.fc2 = (
+            RowParallelLinear(hidden_features, config.hidden_size)
+            if use_tensor_parallel
+            else nn.Linear(hidden_features, config.hidden_size)
+        )
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        hidden_states = _linear_output(self.fc1, hidden_states)
+        hidden_states = self.activation(hidden_states)
+        return _linear_output(self.fc2, hidden_states)
+
+
+class Dinov2SwiGLUFFN(nn.Module):
+    def __init__(self, config: Dinov2Config, *, use_tensor_parallel: bool):
+        super().__init__()
+        hidden_features = int(config.hidden_size * config.mlp_ratio)
+        hidden_features = (int(hidden_features * 2 / 3) + 7) // 8 * 8
+        self.weights_in = (
+            MergedColumnParallelLinear(
+                config.hidden_size,
+                [hidden_features, hidden_features],
+            )
+            if use_tensor_parallel
+            else nn.Linear(config.hidden_size, 2 * hidden_features)
+        )
+        self.weights_out = (
+            RowParallelLinear(hidden_features, config.hidden_size)
+            if use_tensor_parallel
+            else nn.Linear(hidden_features, config.hidden_size)
+        )
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        hidden_states = _linear_output(self.weights_in, hidden_states)
+        gate, value = hidden_states.chunk(2, dim=-1)
+        return _linear_output(self.weights_out, F.silu(gate) * value)
+
+
+class Dinov2DropPath(nn.Module):
+    def __init__(self, drop_prob: float):
+        super().__init__()
+        self.drop_prob = drop_prob
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        if self.drop_prob == 0.0 or not self.training:
+            return hidden_states
+        keep_prob = 1.0 - self.drop_prob
+        shape = (hidden_states.shape[0],) + (1,) * (hidden_states.ndim - 1)
+        random_tensor = torch.rand(
+            shape, dtype=hidden_states.dtype, device=hidden_states.device
+        )
+        random_tensor = torch.floor(random_tensor + keep_prob)
+        return hidden_states.div(keep_prob) * random_tensor
+
+
+class Dinov2Layer(nn.Module):
+    def __init__(self, config: Dinov2Config, *, use_tensor_parallel: bool):
+        super().__init__()
+        self.norm1 = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+        self.attention = Dinov2Attention(
+            config, use_tensor_parallel=use_tensor_parallel
+        )
+        self.layer_scale1 = Dinov2LayerScale(config)
+        self.drop_path = (
+            Dinov2DropPath(config.drop_path_rate)
+            if config.drop_path_rate > 0.0
+            else nn.Identity()
+        )
+        self.norm2 = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+        self.mlp = (
+            Dinov2SwiGLUFFN(config, use_tensor_parallel=use_tensor_parallel)
+            if config.use_swiglu_ffn
+            else Dinov2MLP(config, use_tensor_parallel=use_tensor_parallel)
+        )
+        self.layer_scale2 = Dinov2LayerScale(config)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        attention_output = self.attention(self.norm1(hidden_states))
+        hidden_states = (
+            self.drop_path(self.layer_scale1(attention_output)) + hidden_states
+        )
+        mlp_output = self.mlp(self.norm2(hidden_states))
+        return self.drop_path(self.layer_scale2(mlp_output)) + hidden_states
+
+
+class Dinov2Encoder(nn.Module):
+    def __init__(self, config: Dinov2Config, *, use_tensor_parallel: bool):
+        super().__init__()
+        self.layer = nn.ModuleList(
+            [
+                Dinov2Layer(config, use_tensor_parallel=use_tensor_parallel)
+                for _ in range(config.num_hidden_layers)
+            ]
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        *,
+        output_hidden_states: bool = False,
+    ) -> tuple[torch.Tensor, tuple[torch.Tensor, ...] | None]:
+        all_hidden_states = [] if output_hidden_states else None
+        for layer in self.layer:
+            if all_hidden_states is not None:
+                all_hidden_states.append(hidden_states)
+            hidden_states = layer(hidden_states)
+        if all_hidden_states is not None:
+            all_hidden_states.append(hidden_states)
+        return hidden_states, (
+            tuple(all_hidden_states) if all_hidden_states is not None else None
+        )
+
+
+class Dinov2Model(nn.Module, LayerwiseOffloadableModuleMixin):
+    layerwise_offload_dit_group_enabled = False
+    layer_names = ["encoder.layer"]
+
+    def __init__(
+        self,
+        config: Dinov2Config | dict[str, Any],
+        *,
+        use_tensor_parallel: bool | None = None,
+    ):
+        super().__init__()
+        if isinstance(config, dict):
+            config = Dinov2Config.from_dict(config)
+        if use_tensor_parallel is None:
+            use_tensor_parallel = model_parallel_is_initialized()
+        self.config = config
+        self.use_tensor_parallel = use_tensor_parallel
+        self.embeddings = Dinov2Embeddings(config)
+        self.encoder = Dinov2Encoder(config, use_tensor_parallel=use_tensor_parallel)
+        self.layernorm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+
+    @property
+    def device(self) -> torch.device:
+        return self.embeddings.patch_embeddings.projection.weight.device
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return self.embeddings.patch_embeddings.projection.weight.dtype
+
+    def forward(
+        self,
+        pixel_values: torch.Tensor,
+        bool_masked_pos: torch.Tensor | None = None,
+        output_hidden_states: bool | None = None,
+    ) -> BaseEncoderOutput:
+        if pixel_values is None:
+            raise ValueError("DINOv2 requires pixel_values")
+        output_hidden_states = bool(
+            self.config.output_hidden_states
+            if output_hidden_states is None
+            else output_hidden_states
+        )
+        hidden_states = self.embeddings(pixel_values, bool_masked_pos)
+        hidden_states, all_hidden_states = self.encoder(
+            hidden_states,
+            output_hidden_states=output_hidden_states,
+        )
+        hidden_states = self.layernorm(hidden_states)
+        return BaseEncoderOutput(
+            last_hidden_state=hidden_states,
+            pooler_output=hidden_states[:, 0],
+            hidden_states=all_hidden_states,
+        )
+
+    def load_weights(
+        self,
+        weights: Iterable[tuple[str, torch.Tensor]],
+    ) -> set[str]:
+        stacked_params_mapping = (
+            (
+                ".attention.attention.qkv_proj.",
+                ".attention.attention.query.",
+                "q",
+            ),
+            (
+                ".attention.attention.qkv_proj.",
+                ".attention.attention.key.",
+                "k",
+            ),
+            (
+                ".attention.attention.qkv_proj.",
+                ".attention.attention.value.",
+                "v",
+            ),
+        )
+        params = dict(self.named_parameters())
+        parallel_weight_loaders = {
+            f"{module_name}.{param_name}": module.weight_loader
+            for module_name, module in self.named_modules()
+            if isinstance(module, (ColumnParallelLinear, RowParallelLinear))
+            for param_name, _ in module.named_parameters(recurse=False)
+        }
+        loaded = set()
+        for name, tensor in weights:
+            for target_name, source_name, shard_id in (
+                stacked_params_mapping if self.use_tensor_parallel else ()
+            ):
+                if source_name not in name:
+                    continue
+                name = name.replace(source_name, target_name)
+                param = params[name]
+                parallel_weight_loaders[name](param, tensor, shard_id)
+                break
+            else:
+                try:
+                    param = params[name]
+                except KeyError as exc:
+                    raise ValueError(f"Unexpected DINOv2 weight: {name}") from exc
+                weight_loader = parallel_weight_loaders.get(name, default_weight_loader)
+                weight_loader(param, tensor)
+            loaded.add(name)
+
+        missing = set(params) - loaded
+        if missing:
+            examples = sorted(missing)[:8]
+            raise RuntimeError(
+                f"DINOv2 checkpoint is missing {len(missing)} parameters: {examples}"
+            )
+        return loaded
+
+
+EntryClass = Dinov2Model

--- a/python/sglang/multimodal_gen/runtime/models/encoders/hunyuan3d.py
+++ b/python/sglang/multimodal_gen/runtime/models/encoders/hunyuan3d.py
@@ -1,23 +1,40 @@
 # Copied and adapted from: https://github.com/Tencent-Hunyuan/Hunyuan3D-2
 
+import glob
+import os
+from collections.abc import Iterable
+from typing import Any
+
 import numpy as np
 import torch
 import torch.nn as nn
+from huggingface_hub import snapshot_download
 from torchvision import transforms
-from transformers import (
-    CLIPVisionConfig,
-    CLIPVisionModelWithProjection,
-    Dinov2Config,
-    Dinov2Model,
+from transformers.models.clip.configuration_clip import (
+    CLIPVisionConfig as TransformersCLIPVisionConfig,
 )
+from transformers.models.dinov2.configuration_dinov2 import Dinov2Config
 
+from sglang.multimodal_gen.configs.models.encoders.clip import (
+    CLIPVisionArchConfig,
+    CLIPVisionConfig,
+)
+from sglang.multimodal_gen.runtime.loader.weight_utils import (
+    pt_weights_iterator,
+    safetensors_weights_iterator,
+)
 from sglang.multimodal_gen.runtime.managers.memory_managers.layerwise_offload import (
     LayerwiseOffloadableModuleMixin,
+)
+from sglang.multimodal_gen.runtime.models.encoders.clip import (
+    CLIPVisionModel as NativeCLIPVisionModel,
+)
+from sglang.multimodal_gen.runtime.models.encoders.dinov2 import (
+    Dinov2Model as NativeDinov2Model,
 )
 
 
 def get_1d_sincos_pos_embed_from_grid(embed_dim, pos):
-
     assert embed_dim % 2 == 0
     omega = np.arange(embed_dim // 2, dtype=np.float64)
     omega /= embed_dim / 2.0
@@ -38,8 +55,8 @@ class ImageEncoder(nn.Module, LayerwiseOffloadableModuleMixin):
         "model.encoder.layer",
         "model.vision_model.encoder.layers",
     ]
-    MODEL_CLASS = None
-    MODEL_CONFIG_CLASS = None
+    MODEL_CLASS: type[nn.Module]
+    MODEL_CONFIG_CLASS: type
     mean = []
     std = []
 
@@ -54,14 +71,22 @@ class ImageEncoder(nn.Module, LayerwiseOffloadableModuleMixin):
         super().__init__()
 
         if config is None:
-            self.model = self.MODEL_CLASS.from_pretrained(version)
+            if not version:
+                raise ValueError("Image encoder requires either version or config")
+            source_config = self.MODEL_CONFIG_CLASS.from_pretrained(version)
         else:
-            self.model = self.MODEL_CLASS(self.MODEL_CONFIG_CLASS.from_dict(config))
+            source_config = self.MODEL_CONFIG_CLASS.from_dict(config)
+        self.model = self._build_model(source_config)
+        if config is None:
+            self._load_pretrained_weights(version)
         self.model.eval()
         self.model.requires_grad_(False)
         self.use_cls_token = use_cls_token
-        self.size = image_size // 14
-        self.num_patches = (image_size // 14) ** 2
+        patch_size = self.model.config.patch_size
+        if not isinstance(patch_size, int):
+            patch_size = patch_size[0]
+        self.size = image_size // patch_size
+        self.num_patches = self.size**2
         if self.use_cls_token:
             self.num_patches += 1
 
@@ -78,12 +103,62 @@ class ImageEncoder(nn.Module, LayerwiseOffloadableModuleMixin):
             ]
         )
 
+    @classmethod
+    def _build_model(cls, config: Any) -> nn.Module:
+        return cls.MODEL_CLASS(config)
+
+    def _load_pretrained_weights(self, version: str) -> None:
+        local_path = snapshot_download(
+            repo_id=version,
+            allow_patterns=["*.json", "*.safetensors", "*.bin"],
+        )
+        safetensors_files = sorted(glob.glob(os.path.join(local_path, "*.safetensors")))
+        if safetensors_files:
+            weights = safetensors_weights_iterator(safetensors_files)
+        else:
+            pt_files = sorted(glob.glob(os.path.join(local_path, "*.bin")))
+            if not pt_files:
+                raise FileNotFoundError(
+                    f"No safetensors or PyTorch weights found for {version}"
+                )
+            weights = pt_weights_iterator(pt_files)
+        self.load_weights((f"model.{name}", tensor) for name, tensor in weights)
+
+    def load_weights(
+        self,
+        weights: Iterable[tuple[str, torch.Tensor]],
+    ) -> set[str]:
+        def model_weights():
+            for name, tensor in weights:
+                if not name.startswith("model."):
+                    raise ValueError(f"Unexpected image encoder weight: {name}")
+                yield name.removeprefix("model."), tensor
+
+        loaded = self.model.load_weights(model_weights())
+        expected = set(dict(self.model.named_parameters()))
+        missing = expected - loaded
+        if missing:
+            examples = sorted(missing)[:8]
+            raise RuntimeError(
+                f"Image encoder checkpoint is missing {len(missing)} parameters: "
+                f"{examples}"
+            )
+        return {f"model.{name}" for name in loaded}
+
+    @property
+    def device(self) -> torch.device:
+        return next(self.model.parameters()).device
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return next(self.model.parameters()).dtype
+
     def forward(self, image, mask=None, value_range=(-1, 1), **kwargs):
         if value_range is not None:
             low, high = value_range
             image = (image - low) / (high - low)
 
-        image = image.to(self.model.device, dtype=self.model.dtype)
+        image = image.to(self.device, dtype=self.dtype)
         inputs = self.transform(image)
         outputs = self.model(inputs)
 
@@ -94,28 +169,38 @@ class ImageEncoder(nn.Module, LayerwiseOffloadableModuleMixin):
         return last_hidden_state
 
     def unconditional_embedding(self, batch_size, **kwargs):
-        device = next(self.model.parameters()).device
-        dtype = next(self.model.parameters()).dtype
         zero = torch.zeros(
             batch_size,
             self.num_patches,
             self.model.config.hidden_size,
-            device=device,
-            dtype=dtype,
+            device=self.device,
+            dtype=self.dtype,
         )
 
         return zero
 
 
 class CLIPImageEncoder(ImageEncoder):
-    MODEL_CLASS = CLIPVisionModelWithProjection
-    MODEL_CONFIG_CLASS = CLIPVisionConfig
+    MODEL_CLASS = NativeCLIPVisionModel
+    MODEL_CONFIG_CLASS = TransformersCLIPVisionConfig
     mean = [0.48145466, 0.4578275, 0.40821073]
     std = [0.26862954, 0.26130258, 0.27577711]
 
+    @classmethod
+    def _build_model(cls, config: TransformersCLIPVisionConfig) -> nn.Module:
+        arch_config = CLIPVisionArchConfig()
+        for name, value in config.to_dict().items():
+            setattr(arch_config, name, value)
+        native_config = CLIPVisionConfig(
+            arch_config=arch_config,
+            require_post_norm=False,
+            prefix="clip",
+        )
+        return cls.MODEL_CLASS(native_config)
+
 
 class DinoImageEncoder(ImageEncoder):
-    MODEL_CLASS = Dinov2Model
+    MODEL_CLASS = NativeDinov2Model
     MODEL_CONFIG_CLASS = Dinov2Config
     mean = [0.485, 0.456, 0.406]
     std = [0.229, 0.224, 0.225]
@@ -137,21 +222,24 @@ class DinoImageEncoderMV(DinoImageEncoder):
     ):
         super().__init__(version, config, use_cls_token, image_size, **kwargs)
         self.view_num = view_num
-        self.num_patches = self.num_patches
         pos = np.arange(self.view_num, dtype=np.float32)
         view_embedding = torch.from_numpy(
             get_1d_sincos_pos_embed_from_grid(self.model.config.hidden_size, pos)
         ).float()
 
         view_embedding = view_embedding.unsqueeze(1).repeat(1, self.num_patches, 1)
-        self.view_embed = view_embedding.unsqueeze(0)
+        self.register_buffer(
+            "view_embed",
+            view_embedding.unsqueeze(0),
+            persistent=False,
+        )
 
     def forward(self, image, mask=None, value_range=(-1, 1), view_idxs=None, **kwargs):
         if value_range is not None:
             low, high = value_range
             image = (image - low) / (high - low)
 
-        image = image.to(self.model.device, dtype=self.model.dtype)
+        image = image.to(self.device, dtype=self.dtype)
 
         bs, num_views, c, h, w = image.shape
         image = image.view(bs * num_views, c, h, w)
@@ -189,27 +277,28 @@ class DinoImageEncoderMV(DinoImageEncoder):
         return last_hidden_state
 
     def unconditional_embedding(self, batch_size, view_idxs, **kwargs):
-        device = next(self.model.parameters()).device
-        dtype = next(self.model.parameters()).dtype
         zero = torch.zeros(
             batch_size,
             self.num_patches * len(view_idxs[0]),
             self.model.config.hidden_size,
-            device=device,
-            dtype=dtype,
+            device=self.device,
+            dtype=self.dtype,
         )
         return zero
 
 
 def build_image_encoder(config):
-    if config["type"] == "CLIPImageEncoder":
-        return CLIPImageEncoder(**config["kwargs"])
-    elif config["type"] == "DinoImageEncoder":
-        return DinoImageEncoder(**config["kwargs"])
-    elif config["type"] == "DinoImageEncoderMV":
-        return DinoImageEncoderMV(**config["kwargs"])
-    else:
-        raise ValueError(f'Unknown image encoder type: {config["type"]}')
+    encoder_classes = {
+        "CLIPImageEncoder": CLIPImageEncoder,
+        "DinoImageEncoder": DinoImageEncoder,
+        "DinoImageEncoderMV": DinoImageEncoderMV,
+    }
+    encoder_type = config["type"]
+    try:
+        encoder_cls = encoder_classes[encoder_type]
+    except KeyError as exc:
+        raise ValueError(f"Unknown image encoder type: {encoder_type}") from exc
+    return encoder_cls(**config["kwargs"])
 
 
 class DualImageEncoder(nn.Module, LayerwiseOffloadableModuleMixin):
@@ -236,6 +325,33 @@ class DualImageEncoder(nn.Module, LayerwiseOffloadableModuleMixin):
             "additional": self.additional_image_encoder(image, mask=mask, **kwargs),
         }
         return outputs
+
+    def load_weights(
+        self,
+        weights: Iterable[tuple[str, torch.Tensor]],
+    ) -> set[str]:
+        grouped: dict[str, list[tuple[str, torch.Tensor]]] = {
+            "main_image_encoder": [],
+            "additional_image_encoder": [],
+        }
+        for name, tensor in weights:
+            component_name, separator, nested_name = name.partition(".")
+            if not separator or component_name not in grouped:
+                raise ValueError(f"Unexpected dual image encoder weight: {name}")
+            grouped[component_name].append((nested_name, tensor))
+
+        loaded = set()
+        components = (
+            ("main_image_encoder", self.main_image_encoder),
+            ("additional_image_encoder", self.additional_image_encoder),
+        )
+        for component_name, component in components:
+            component_weights = grouped[component_name]
+            loaded.update(
+                f"{component_name}.{name}"
+                for name in component.load_weights(component_weights)
+            )
+        return loaded
 
     def unconditional_embedding(self, batch_size, **kwargs):
         outputs = {
@@ -276,6 +392,21 @@ class SingleImageEncoder(nn.Module, LayerwiseOffloadableModuleMixin):
             ),
         }
         return outputs
+
+    def load_weights(
+        self,
+        weights: Iterable[tuple[str, torch.Tensor]],
+    ) -> set[str]:
+        prefix = "main_image_encoder."
+        nested_weights = []
+        for name, tensor in weights:
+            if not name.startswith(prefix):
+                raise ValueError(f"Unexpected single image encoder weight: {name}")
+            nested_weights.append((name.removeprefix(prefix), tensor))
+        return {
+            f"{prefix}{name}"
+            for name in self.main_image_encoder.load_weights(nested_weights)
+        }
 
 
 # Entry class for model registry

--- a/python/sglang/multimodal_gen/runtime/pipelines/hunyuan3d_pipeline.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines/hunyuan3d_pipeline.py
@@ -283,6 +283,28 @@ class Hunyuan3D2Pipeline(ComposedPipelineBase):
         return component.eval()
 
     @classmethod
+    def _load_conditioner(
+        cls,
+        cfg: dict[str, Any],
+        weights: dict[str, torch.Tensor] | None,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> nn.Module:
+        if "target" not in cfg:
+            raise KeyError("Expected key 'target' in conditioner config.")
+        target_cls = cls._resolve_class(cfg["target"])
+        params = cfg.get("params", {})
+
+        with set_default_torch_dtype(dtype):
+            conditioner = target_cls(**params)
+
+        if weights is not None:
+            conditioner.load_weights(weights.items())
+
+        conditioner.to(device=device, dtype=dtype)
+        return conditioner.eval()
+
+    @classmethod
     def _instantiate_component(cls, cfg: dict[str, Any]) -> Any:
         """Instantiate a lightweight component (scheduler / image_processor) without weights."""
         if "target" not in cfg:
@@ -337,7 +359,7 @@ class Hunyuan3D2Pipeline(ComposedPipelineBase):
             model_config["vae"], ckpt.get("vae"), device, dtype
         )
 
-        components["hy3dshape_conditioner"] = self._load_simple_component(
+        components["hy3dshape_conditioner"] = self._load_conditioner(
             model_config["conditioner"], ckpt.get("conditioner"), device, dtype
         )
 

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/hunyuan3d/shape.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/hunyuan3d/shape.py
@@ -214,7 +214,12 @@ class Hunyuan3DShapeBeforeDenoisingStage(PipelineStage):
         # 3. Conditioning with CFG
         do_cfg = batch.guidance_scale >= 0 and not self.guidance_embed
 
-        cond = self.conditioner(image=image, **cond_inputs)
+        with set_forward_context(
+            current_timestep=0,
+            attn_metadata=None,
+            forward_batch=batch,
+        ):
+            cond = self.conditioner(image=image, **cond_inputs)
         if do_cfg:
             un_cond = self.conditioner.unconditional_embedding(
                 image.shape[0], **cond_inputs

--- a/python/sglang/multimodal_gen/test/unit/test_hunyuan3d_image_encoder.py
+++ b/python/sglang/multimodal_gen/test/unit/test_hunyuan3d_image_encoder.py
@@ -1,0 +1,184 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+from transformers.models.clip.configuration_clip import CLIPVisionConfig
+from transformers.models.dinov2.configuration_dinov2 import Dinov2Config
+
+import sglang.multimodal_gen.runtime.models.encoders.clip as clip_module
+import sglang.multimodal_gen.runtime.models.encoders.dinov2 as dinov2_module
+from sglang.multimodal_gen.configs.models.encoders.clip import (
+    CLIPTextArchConfig,
+    CLIPTextConfig,
+    CLIPVisionArchConfig,
+)
+from sglang.multimodal_gen.configs.models.encoders.clip import (
+    CLIPVisionConfig as NativeCLIPVisionConfig,
+)
+from sglang.multimodal_gen.runtime.models.encoders.dinov2 import Dinov2Model
+from sglang.multimodal_gen.runtime.models.encoders.hunyuan3d import (
+    CLIPImageEncoder,
+    DinoImageEncoder,
+    SingleImageEncoder,
+)
+
+
+class _TestAttention(nn.Module):
+    def __init__(self, *args, softmax_scale=None, causal=None, **kwargs):
+        super().__init__()
+        self.softmax_scale = softmax_scale
+        self.causal = causal
+
+    def forward(self, query, key, value):
+        output = F.scaled_dot_product_attention(
+            query.transpose(1, 2),
+            key.transpose(1, 2),
+            value.transpose(1, 2),
+            scale=self.softmax_scale,
+        )
+        return output.transpose(1, 2)
+
+
+def _dino_config() -> Dinov2Config:
+    return Dinov2Config(
+        hidden_size=16,
+        image_size=8,
+        patch_size=4,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        mlp_ratio=2,
+        use_swiglu_ffn=True,
+        hidden_dropout_prob=0.0,
+        attention_probs_dropout_prob=0.0,
+        drop_path_rate=0.0,
+    )
+
+
+def _initialize_finite(module: nn.Module) -> None:
+    with torch.no_grad():
+        for parameter in module.parameters():
+            parameter.uniform_(-0.05, 0.05)
+
+
+def test_native_dinov2_preserves_checkpoint_layout_and_layerwise_path(monkeypatch):
+    monkeypatch.setattr(dinov2_module, "LocalAttention", _TestAttention)
+    model = Dinov2Model(_dino_config()).eval()
+    _initialize_finite(model)
+
+    state_keys = set(model.state_dict())
+    layer_prefix = "encoder.layer.0"
+    assert f"{layer_prefix}.attention.attention.query.weight" in state_keys
+    assert f"{layer_prefix}.attention.attention.key.weight" in state_keys
+    assert f"{layer_prefix}.attention.attention.value.weight" in state_keys
+    assert f"{layer_prefix}.mlp.weights_in.weight" in state_keys
+    assert f"{layer_prefix}.layer_scale1.lambda1" in state_keys
+    assert model.layer_names == ["encoder.layer"]
+
+    output = model(torch.zeros(1, 3, 8, 8))
+    assert output.last_hidden_state.shape == (1, 5, 16)
+    assert output.pooler_output.shape == (1, 16)
+
+
+def test_hunyuan_dino_loader_requires_complete_checkpoint(monkeypatch):
+    monkeypatch.setattr(dinov2_module, "LocalAttention", _TestAttention)
+    config = _dino_config().to_dict()
+    source = DinoImageEncoder(config=config, image_size=8)
+    target = DinoImageEncoder(config=config, image_size=8)
+    _initialize_finite(source)
+    weights = [
+        (f"model.{name}", tensor.clone())
+        for name, tensor in source.model.state_dict().items()
+    ]
+
+    loaded = target.load_weights(weights)
+
+    assert loaded == {f"model.{name}" for name in source.model.state_dict()}
+    for name, tensor in source.model.state_dict().items():
+        torch.testing.assert_close(target.model.state_dict()[name], tensor)
+
+    incomplete = weights[:-1]
+    try:
+        target.load_weights(incomplete)
+    except RuntimeError as exc:
+        assert "checkpoint is missing" in str(exc)
+    else:
+        raise AssertionError("Incomplete DINOv2 checkpoint should be rejected")
+
+
+def test_single_image_encoder_dispatches_nested_weights(monkeypatch):
+    monkeypatch.setattr(dinov2_module, "LocalAttention", _TestAttention)
+    config = {
+        "type": "DinoImageEncoder",
+        "kwargs": {"config": _dino_config().to_dict(), "image_size": 8},
+    }
+    source = SingleImageEncoder(config)
+    target = SingleImageEncoder(config)
+    weights = [(name, tensor.clone()) for name, tensor in source.state_dict().items()]
+
+    loaded = target.load_weights(weights)
+
+    assert loaded == set(source.state_dict())
+
+
+def test_hunyuan_clip_reuses_native_clip_without_post_norm(monkeypatch):
+    class FakeNativeCLIPVisionModel(nn.Module):
+        def __init__(self, config):
+            super().__init__()
+            self.config = config
+
+    monkeypatch.setattr(
+        CLIPImageEncoder,
+        "MODEL_CLASS",
+        FakeNativeCLIPVisionModel,
+    )
+    config = CLIPVisionConfig(
+        hidden_size=16,
+        intermediate_size=32,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        image_size=8,
+        patch_size=4,
+    )
+
+    model = CLIPImageEncoder._build_model(config)
+
+    assert model.config.hidden_size == 16
+    assert model.config.patch_size == 4
+    assert model.config.require_post_norm is False
+
+
+def test_native_clip_attention_is_causal_only_for_text(monkeypatch):
+    class FakeParallelLinear(nn.Module):
+        def __init__(self, *args, **kwargs):
+            super().__init__()
+
+    monkeypatch.setattr(clip_module, "QKVParallelLinear", FakeParallelLinear)
+    monkeypatch.setattr(clip_module, "RowParallelLinear", FakeParallelLinear)
+    monkeypatch.setattr(clip_module, "LocalAttention", _TestAttention)
+    monkeypatch.setattr(clip_module, "get_tp_world_size", lambda: 1)
+
+    vision_config = NativeCLIPVisionConfig(
+        arch_config=CLIPVisionArchConfig(
+            hidden_size=16,
+            intermediate_size=32,
+            num_attention_heads=4,
+        )
+    )
+    text_config = CLIPTextConfig(
+        arch_config=CLIPTextArchConfig(
+            hidden_size=16,
+            intermediate_size=32,
+            num_attention_heads=4,
+        )
+    )
+
+    vision_attention = clip_module.CLIPAttention(vision_config)
+    text_attention = clip_module.CLIPAttention(text_config)
+
+    assert vision_attention.causal is False
+    assert vision_attention.attn.causal is False
+    assert text_attention.causal is True
+    assert text_attention.attn.causal is True


### PR DESCRIPTION
## Summary

- replace the Transformers CLIP and DINOv2 neural modules in the Hunyuan3D Shape conditioner with native SGLang implementations
- add a native DINOv2 encoder with packed QKV, tensor-parallel linear layers, explicit checkpoint loading, and layerwise offload support
- fix native CLIP vision attention to be non-causal while preserving causal CLIP text attention
- make the Hunyuan3D conditioner weight-loading contract explicit and validate complete checkpoints

## Why

Hunyuan3D Shape instantiated full Transformers vision models inside an otherwise native pipeline. This bypassed SGLang tensor parallelism and layerwise offload. It also exposed a latent correctness bug in the shared native CLIP implementation: vision attention was configured as causal.

## Validation

- `pre-commit run --files` for all changed files
- `pytest -q python/sglang/multimodal_gen/test/unit/test_hunyuan3d_image_encoder.py`
- `pytest -q python/sglang/multimodal_gen/test/unit/test_disagg_roles.py`
- DINOv2-Giant checkpoint parity for TP=1 and TP=2
- 40-layer DINOv2 layerwise-offload parity against resident execution

For DINOv2-Giant on H100 with Torch SDPA, the 20-run median encoder latency changed from 10.42 ms to 9.68 ms (-7.1%). TP=1 cosine similarity against Transformers was 0.9999989; TP=2 was 0.9999966, with identical outputs across ranks.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #31901159523](https://github.com/sgl-project/sglang/actions/runs/31901159523)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #31901159320](https://github.com/sgl-project/sglang/actions/runs/31901159320)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->