### PR TITLE
Expose selected worker ID in sglang model gateway responses

### DIFF
--- a/sgl-model-gateway/src/routers/header_utils.rs
+++ b/sgl-model-gateway/src/routers/header_utils.rs
@@ -7,6 +7,7 @@ use http::header::HeaderName;
 
 static HEADER_TARGET_WORKER: HeaderName = HeaderName::from_static("x-smg-target-worker");
 static HEADER_ROUTING_KEY: HeaderName = HeaderName::from_static("x-smg-routing-key");
+static HEADER_WORKER_ID: HeaderName = HeaderName::from_static("x-smg-worker-id");
 
 fn extract_header_value<'a>(headers: Option<&'a HeaderMap>, name: &HeaderName) -> Option<&'a str> {
     headers
@@ -53,6 +54,14 @@ pub fn preserve_response_headers(reqwest_headers: &HeaderMap) -> HeaderMap {
     }
 
     headers
+}
+
+pub(crate) fn insert_worker_id(headers: &mut HeaderMap, worker_url: &str) {
+    let worker_id = blake3::hash(worker_url.as_bytes()).to_hex();
+    headers.insert(
+        HEADER_WORKER_ID.clone(),
+        HeaderValue::from_str(worker_id.as_str()).expect("BLAKE3 hex is a valid header value"),
+    );
 }
 
 /// Determine if a header should be forwarded without allocating (case-insensitive)
@@ -295,5 +304,23 @@ mod tests {
         assert!(!should_forward_request_header("cookie"));
         assert!(!should_forward_request_header("x-custom-header"));
         assert!(!should_forward_request_header("x-api-key"));
+    }
+
+    #[test]
+    fn test_insert_worker_id_is_stable_and_opaque() {
+        let mut headers = HeaderMap::new();
+        insert_worker_id(&mut headers, "http://10.0.0.1:30000@2");
+
+        let worker_id = headers["x-smg-worker-id"].to_str().unwrap();
+        assert_eq!(worker_id.len(), 64);
+        assert!(worker_id.bytes().all(|byte| byte.is_ascii_hexdigit()));
+        assert!(!worker_id.contains("10.0.0.1"));
+
+        let mut repeated_headers = HeaderMap::new();
+        insert_worker_id(&mut repeated_headers, "http://10.0.0.1:30000@2");
+        assert_eq!(
+            repeated_headers["x-smg-worker-id"],
+            headers["x-smg-worker-id"]
+        );
     }
 }

--- a/sgl-model-gateway/src/routers/http/router.rs
+++ b/sgl-model-gateway/src/routers/http/router.rs
@@ -595,7 +595,7 @@ impl Router {
             // For non-streaming requests, preserve headers
             let response_headers = header_utils::preserve_response_headers(res.headers());
 
-            let response = match res.bytes().await {
+            let mut response = match res.bytes().await {
                 Ok(body) => {
                     let mut response = Response::new(Body::from(body));
                     *response.status_mut() = status;
@@ -607,6 +607,7 @@ impl Router {
                     error::internal_error("read_response_body_failed", error_msg)
                 }
             };
+            header_utils::insert_worker_id(response.headers_mut(), worker_url);
 
             // load_guard dropped here automatically after response body is read
             response
@@ -640,6 +641,7 @@ impl Router {
             let mut response = Response::new(body);
             *response.status_mut() = status;
             *response.headers_mut() = response_headers;
+            header_utils::insert_worker_id(response.headers_mut(), worker_url);
 
             // Attach load guard to response body for proper RAII lifecycle
             // Guard is dropped when response body is consumed or client disconnects

--- a/sgl-model-gateway/tests/routing/header_forwarding_test.rs
+++ b/sgl-model-gateway/tests/routing/header_forwarding_test.rs
@@ -3,7 +3,7 @@
 //! Tests for header propagation through the router to workers.
 
 use axum::{
-    body::Body,
+    body::{to_bytes, Body},
     extract::Request,
     http::{header::CONTENT_TYPE, StatusCode},
 };
@@ -303,6 +303,47 @@ mod header_forwarding_tests {
             "x-request-id should take priority"
         );
 
+        ctx.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_worker_id_is_stable_for_streaming_and_non_streaming_responses() {
+        let ctx = AppTestContext::new(vec![MockWorkerConfig {
+            port: 19406,
+            worker_type: WorkerType::Regular,
+            health_status: HealthStatus::Healthy,
+            response_delay_ms: 0,
+            fail_rate: 0.0,
+        }])
+        .await;
+        let app = ctx.create_app().await;
+        let mut worker_ids = Vec::new();
+
+        for stream in [false, true] {
+            let payload = json!({
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "stream": stream
+            });
+            let req = Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header(CONTENT_TYPE, "application/json")
+                .body(Body::from(serde_json::to_string(&payload).unwrap()))
+                .unwrap();
+
+            let resp = app.clone().oneshot(req).await.unwrap();
+            assert_eq!(resp.status(), StatusCode::OK);
+            worker_ids.push(
+                resp.headers()["x-smg-worker-id"]
+                    .to_str()
+                    .unwrap()
+                    .to_string(),
+            );
+            to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        }
+
+        assert_eq!(worker_ids[0], worker_ids[1]);
         ctx.shutdown().await;
     }
 }


### PR DESCRIPTION
## Why is this change needed?

Clients can provide a stable `x-smg-routing-key`, but today they cannot verify which backend worker served each response. This makes it difficult to diagnose whether multi-request agent sessions actually preserve worker affinity.

The HTTP regular router now returns an opaque, deterministic `x-smg-worker-id` derived from the selected worker URL (including its data-parallel rank, when present). The identifier is added to both streaming and non-streaming responses after worker selection, including the final response after gateway retries, without exposing the worker IP or URL.

For example, two requests routed to the same worker can now be correlated directly from their response headers:

```text
request 1 -> x-smg-worker-id: 0f3a...c912
request 2 -> x-smg-worker-id: 0f3a...c912
```

## Test Plan

- `cargo fmt --check`
- `cargo test --lib test_insert_worker_id_is_stable_and_opaque`
- `cargo test --test routing_tests test_worker_id_is_stable_for_streaming_and_non_streaming_responses`

The integration test verifies that both streaming and non-streaming chat-completion responses expose the same worker ID when routed to the same backend.

-Robot

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31902512993](https://github.com/sgl-project/sglang/actions/runs/31902512993)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31902512922](https://github.com/sgl-project/sglang/actions/runs/31902512922)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->