### PR TITLE
[AMD] Add the Kimi-K3 MI35x perf benchmarks in nightly

### DIFF
--- a/.github/workflows/nightly-test-amd-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-rocm720.yml
@@ -1580,6 +1580,23 @@ jobs:
           echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
           exit ${TEST_EXIT_CODE:-0}
 
+      # Shares the job with the eval above so the checkpoint is already cached
+      # and only one 8-GPU MI35x slot is consumed. Step ordering is also the
+      # accuracy gate: a failed eval fails the job before this runs, so
+      # throughput is never measured on a build that got the tokens wrong.
+      # continue-on-error matches every other combined accuracy + perf job here,
+      # so a perf hiccup cannot turn the accuracy result red.
+      - name: Performance Test MI35x ROCm 7.2 (8-GPU Kimi-K3)
+        timeout-minutes: 300
+        continue-on-error: true
+        run: |
+          > github_summary.md  # Clear summary file
+          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
+            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
+            python3 run_suite.py --hw amd --suite nightly-perf-8-gpu-mi35x-kimi-k3 --nightly --timeout-per-file 14400 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
+          echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
+          exit ${TEST_EXIT_CODE:-0}
+
   # ==============================================================================
   # 8-GPU Qwen3-235B (MI30x + MI35x MXFP4)
   # ==============================================================================

--- a/.github/workflows/nightly-test-amd-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-rocm720.yml
@@ -1593,7 +1593,7 @@ jobs:
           > github_summary.md  # Clear summary file
           bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
             -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
-            python3 run_suite.py --hw amd --suite nightly-perf-8-gpu-mi35x-kimi-k3 --nightly --timeout-per-file 14400 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
+            python3 registered/amd/perf/mi35x/test_kimi_k3_perf_mi35x.py || TEST_EXIT_CODE=$?
           echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
           exit ${TEST_EXIT_CODE:-0}
 

--- a/test/registered/amd/perf/mi35x/test_kimi_k3_perf_mi35x.py
+++ b/test/registered/amd/perf/mi35x/test_kimi_k3_perf_mi35x.py
@@ -1,0 +1,163 @@
+"""MI35x nightly performance benchmark for Kimi-K3 (8-GPU).
+
+Benchmarks moonshotai/Kimi-K3 at TP8 on MI35x using the same non-speculative
+Day-0 recipe as the accuracy test (sgl-project/sglang#32548), so the two are
+directly comparable and a perf regression cannot be confused with a config
+difference.
+
+This runs as the step after the eval inside nightly-8-gpu-mi35x-kimi-k3-rocm720
+rather than as a job of its own, which is how every other combined accuracy plus
+performance job in that workflow is arranged. Sharing the job means the 1.56 TB
+checkpoint is already in the container cache, and it takes one 8-GPU MI35x slot
+instead of two on a runner scarce enough that the difference is real wall time.
+Step ordering also supplies the gate for free: a failed eval fails the job, so
+this never measures throughput on a build that got the tokens wrong.
+
+#32548 reports the reference numbers to compare against: 102.5 tok/s/GPU at
+concurrency 2 rising to 612.3 at concurrency 32, non-speculative.
+
+Registry: nightly-perf-8-gpu-mi35x-kimi-k3 suite
+"""
+
+import os
+import unittest
+from typing import List
+
+from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.nightly_bench_utils import BenchmarkResult
+from sglang.test.nightly_utils import NightlyBenchmarkRunner
+from sglang.test.test_utils import DEFAULT_URL_FOR_TEST, _parse_int_list_env
+
+# Register for AMD CI - Kimi K3 perf benchmark on MI35x (~150 min: the 1.56 TB
+# MXFP4 checkpoint dominates startup before any batch is timed)
+register_amd_ci(est_time=9000, suite="nightly-perf-8-gpu-mi35x-kimi-k3", nightly=True)
+
+KIMI_K3_MODEL_PATH = os.environ.get("KIMI_K3_MODEL_PATH", "moonshotai/Kimi-K3")
+RESULT_DIR = "performance_results_kimi_k3_mi35x"
+# Matched to --cuda-graph-max-bs-decode; capturing decode graphs above the
+# largest batch we time would only burn capture time across K3's 93 attention
+# + 92 MoE layers.
+MAX_BATCH_SIZE = 64
+
+
+def generate_simple_markdown_report(results: List[BenchmarkResult]) -> str:
+    """Markdown table without trace or cost columns.
+
+    Skips the first result when it is a warmup run (duplicate batch_size).
+    """
+    model_header = results[0].model_path
+    if results[0].run_name and results[0].run_name != "default":
+        model_header += f" ({results[0].run_name})"
+
+    gpu_config = os.getenv("GPU_CONFIG", "MI35x")
+    if gpu_config:
+        model_header += f" [{gpu_config}]"
+
+    summary = f"### {model_header}\n"
+    summary += "| batch size | input len | latency (s) | input throughput (tok/s) | output throughput (tok/s) | ITL (ms) |\n"
+    summary += "| ---------- | --------- | ----------- | ------------------------ | ------------------------- | -------- |\n"
+
+    report_results = (
+        results[1:]
+        if len(results) > 1 and results[0].batch_size == results[1].batch_size
+        else results
+    )
+
+    for result in report_results:
+        itl = 1 / (result.output_throughput / result.batch_size) * 1000
+        summary += f"| {result.batch_size} | {result.input_len} | {result.latency:.2f} | {result.input_throughput:.2f} | {result.output_throughput:.2f} | {itl:.2f} |\n"
+
+    return summary
+
+
+class TestNightlyKimiK3PerformanceMI35x(unittest.TestCase):
+    """Kimi-K3 TP8 throughput on AMD MI35x."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.batch_sizes = [1, 8, 16, MAX_BATCH_SIZE]
+        cls.input_lens = tuple(_parse_int_list_env("NIGHTLY_INPUT_LENS", "4096"))
+        cls.output_lens = tuple(_parse_int_list_env("NIGHTLY_OUTPUT_LENS", "512"))
+
+        cls.model_config = {
+            "name": "default",
+            "model_path": KIMI_K3_MODEL_PATH,
+            "other_args": [
+                "--trust-remote-code",
+                "--tp",
+                "8",
+                "--attention-backend",
+                "triton",
+                "--dtype",
+                "bfloat16",
+                "--mem-fraction-static",
+                "0.85",
+                "--disable-radix-cache",
+                "--cuda-graph-max-bs-decode",
+                str(MAX_BATCH_SIZE),
+                "--max-running-requests",
+                str(MAX_BATCH_SIZE),
+                "--reasoning-parser",
+                "kimi_k3",
+                "--tool-call-parser",
+                "kimi_k3",
+                "--model-loader-extra-config",
+                '{"enable_multithread_load": true}',
+                "--watchdog-timeout",
+                "1200",
+            ],
+            # See the accuracy test for what each of these does; AITER_FLYDSL_FORCE
+            # is read by AITER itself rather than sglang.
+            "env_vars": {
+                "SGLANG_USE_AITER": "1",
+                "SGLANG_AITER_K3_OPT": "1",
+                "AITER_FLYDSL_FORCE": "1",
+                "AITER_SITUV2_A8W4": "1",
+            },
+        }
+
+        cls.runner = NightlyBenchmarkRunner(RESULT_DIR, cls.__name__, cls.base_url)
+        cls.runner.setup_result_directory()
+        cls.runner.full_report = f"## {cls.__name__}\n"
+
+    def test_bench_kimi_k3(self):
+        """Run the Kimi-K3 batch-size sweep."""
+        old_env = {}
+        for key, value in self.model_config.get("env_vars", {}).items():
+            old_env[key] = os.environ.get(key)
+            os.environ[key] = value
+
+        try:
+            result_tuple = self.runner.run_benchmark_for_model(
+                model_path=self.model_config["model_path"],
+                batch_sizes=self.batch_sizes,
+                input_lens=self.input_lens,
+                output_lens=self.output_lens,
+                other_args=self.model_config["other_args"],
+                variant=self.model_config["name"],
+                extra_bench_args=["--trust-remote-code"],
+                timeout=9000,
+            )
+            results = result_tuple[0]
+            success = result_tuple[1]
+
+            if results:
+                self.runner.full_report += (
+                    generate_simple_markdown_report(results) + "\n"
+                )
+
+            self.assertTrue(
+                success, f"Benchmark failed for {self.model_config['model_path']}"
+            )
+        finally:
+            for key, value in old_env.items():
+                if value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = value
+            self.runner.write_final_report()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/amd/perf/mi35x/test_kimi_k3_perf_mi35x.py
+++ b/test/registered/amd/perf/mi35x/test_kimi_k3_perf_mi35x.py
@@ -21,10 +21,9 @@ Registry: nightly-perf-8-gpu-mi35x-kimi-k3 suite
 
 import os
 import unittest
-from typing import List
 
 from sglang.test.ci.ci_register import register_amd_ci
-from sglang.test.nightly_bench_utils import BenchmarkResult
+from sglang.test.nightly_bench_utils import generate_simple_markdown_report
 from sglang.test.nightly_utils import NightlyBenchmarkRunner
 from sglang.test.test_utils import DEFAULT_URL_FOR_TEST, _parse_int_list_env
 
@@ -34,40 +33,12 @@ register_amd_ci(est_time=9000, suite="nightly-perf-8-gpu-mi35x-kimi-k3", nightly
 
 KIMI_K3_MODEL_PATH = os.environ.get("KIMI_K3_MODEL_PATH", "moonshotai/Kimi-K3")
 RESULT_DIR = "performance_results_kimi_k3_mi35x"
-# Matched to --cuda-graph-max-bs-decode; capturing decode graphs above the
-# largest batch we time would only burn capture time across K3's 93 attention
-# + 92 MoE layers.
+# 64 is what the ~53 GB per GPU left after the MXFP4 weights admits, which is
+# also why the accuracy test caps concurrency there. The largest batch timed,
+# --max-running-requests and --cuda-graph-max-bs-decode are then held equal to
+# it, so capture across K3's 93 attention + 92 MoE layers is not spent on
+# batches the server would never admit.
 MAX_BATCH_SIZE = 64
-
-
-def generate_simple_markdown_report(results: List[BenchmarkResult]) -> str:
-    """Markdown table without trace or cost columns.
-
-    Skips the first result when it is a warmup run (duplicate batch_size).
-    """
-    model_header = results[0].model_path
-    if results[0].run_name and results[0].run_name != "default":
-        model_header += f" ({results[0].run_name})"
-
-    gpu_config = os.getenv("GPU_CONFIG", "MI35x")
-    if gpu_config:
-        model_header += f" [{gpu_config}]"
-
-    summary = f"### {model_header}\n"
-    summary += "| batch size | input len | latency (s) | input throughput (tok/s) | output throughput (tok/s) | ITL (ms) |\n"
-    summary += "| ---------- | --------- | ----------- | ------------------------ | ------------------------- | -------- |\n"
-
-    report_results = (
-        results[1:]
-        if len(results) > 1 and results[0].batch_size == results[1].batch_size
-        else results
-    )
-
-    for result in report_results:
-        itl = 1 / (result.output_throughput / result.batch_size) * 1000
-        summary += f"| {result.batch_size} | {result.input_len} | {result.latency:.2f} | {result.input_throughput:.2f} | {result.output_throughput:.2f} | {itl:.2f} |\n"
-
-    return summary
 
 
 class TestNightlyKimiK3PerformanceMI35x(unittest.TestCase):
@@ -76,7 +47,10 @@ class TestNightlyKimiK3PerformanceMI35x(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.base_url = DEFAULT_URL_FOR_TEST
-        cls.batch_sizes = [1, 8, 16, MAX_BATCH_SIZE]
+        # The leading 1 is repeated so the report helper drops it as a warmup
+        # run. The perf step launches its own server, so the first request pays
+        # for warmup, and batch 1 is the row that distorts most.
+        cls.batch_sizes = [1, 1, 8, 16, MAX_BATCH_SIZE]
         cls.input_lens = tuple(_parse_int_list_env("NIGHTLY_INPUT_LENS", "4096"))
         cls.output_lens = tuple(_parse_int_list_env("NIGHTLY_OUTPUT_LENS", "512"))
 
@@ -144,7 +118,8 @@ class TestNightlyKimiK3PerformanceMI35x(unittest.TestCase):
 
             if results:
                 self.runner.full_report += (
-                    generate_simple_markdown_report(results) + "\n"
+                    generate_simple_markdown_report(results, default_gpu_config="MI35x")
+                    + "\n"
                 )
 
             self.assertTrue(

--- a/test/run_suite.py
+++ b/test/run_suite.py
@@ -141,6 +141,7 @@ NIGHTLY_SUITES = {
         "nightly-amd-2-gpu-mi35x-deepseek-r1-mxfp4-tp2",
         "nightly-amd-8-gpu-mi35x-deepseek-r1-mxfp4-tp4",
         "nightly-amd-accuracy-8-gpu-mi35x-kimi-k3",
+        "nightly-perf-8-gpu-mi35x-kimi-k3",
         "nightly-amd-4-gpu",
         "nightly-amd-8-gpu",
         "nightly-amd-vlm",

--- a/test/run_suite.py
+++ b/test/run_suite.py
@@ -141,7 +141,6 @@ NIGHTLY_SUITES = {
         "nightly-amd-2-gpu-mi35x-deepseek-r1-mxfp4-tp2",
         "nightly-amd-8-gpu-mi35x-deepseek-r1-mxfp4-tp4",
         "nightly-amd-accuracy-8-gpu-mi35x-kimi-k3",
-        "nightly-perf-8-gpu-mi35x-kimi-k3",
         "nightly-amd-4-gpu",
         "nightly-amd-8-gpu",
         "nightly-amd-vlm",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #32568. Adds the Kimi-K3 MI35x performance benchmarks to the nightly, running immediately after the existing accuracy step in the same job so throughput is only measured once the model is known to produce correct tokens.

## Hardware result

[Run 32074996819 summary](https://github.com/sgl-project/sglang/actions/runs/32074996819/attempts/1#summary-95526175371) — both accuracy and performance steps passed on 8×MI355X with ROCm 7.2, on head `33d2793ae0`.

**Accuracy**

| Metric | Result |
| --- | ---: |
| GSM8K accuracy | **0.953** (threshold 0.92) |
| Invalid responses | 0.1% |
| Eval latency | 270.60 s |
| Eval output throughput | 501.01 tok/s |

**Performance sweep**

| batch size | input len | latency (s) | input throughput (tok/s) | output throughput (tok/s) | ITL (ms) |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 4096 | 9.34 | 13,530.74 | 56.62 | 17.66 |
| 8 | 4096 | 13.85 | 18,097.61 | 340.10 | 23.52 |
| 16 | 4096 | 17.68 | 18,196.44 | 581.97 | 27.49 |
| 64 | 4096 | 37.73 | 18,217.66 | 1,403.86 | 45.59 |

**Runtime**

| Phase | Runtime |
| --- | ---: |
| Container setup | 4m 23s |
| Dependency install | 1m 59s |
| Accuracy step (server load + eval) | 45m 57s |
| └ GSM8K request phase | 4m 31s |
| Performance step | 5m 51s |
| **Full job** | **58m 17s** |

The accuracy step dominates because it includes loading the 1.56 TB checkpoint and server warmup. Perf runs immediately afterward in the same job, reusing the node's on-disk model cache and avoiding another container setup.

> The sweep above was measured with `batch_sizes = [1, 8, 16, 64]`, before the warmup change below. Its batch-1 row therefore includes first-request warmup; with the repeated leading `1` that row becomes a post-warmup measurement and should land above 56.62 tok/s. The other three rows are unaffected. The perf step should gain roughly one batch-1 iteration of wall time, about 9 s.

## Review follow-up

Three notes from @bingxche, all addressed:

- **Use the shared report helper.** `sglang.test.nightly_bench_utils` already exports `generate_simple_markdown_report`, and its `default_gpu_config` parameter covers the `"MI35x"` label that the local copy hardcoded. The shared version is otherwise line-for-line identical, and it guards the ITL division against a zero `output_throughput` where the copy did not, so this removes duplication and closes a latent `ZeroDivisionError`. `test_gpt_oss_perf_mi35x.py` already imports it this way. Dropping the copy left `typing.List` and `BenchmarkResult` unused, so both imports are gone.
- **Make the warmup skip actually fire.** The helper detects a warmup run by a repeated leading batch size, so with `[1, 8, 16, 64]` that branch was dead and the batch-1 row absorbed first-request warmup. Now `[1, 1, 8, 16, 64]`.
- **Fix the circular `MAX_BATCH_SIZE` comment.** It claimed the value was "matched to `--cuda-graph-max-bs-decode`" when `MAX_BATCH_SIZE` is what that flag is set from, so it explained nothing. It now states the constraint the accuracy test records — the ~53 GB per GPU left after the MXFP4 weights — and keeps only the non-circular half, that graphs are not captured for batches the server would never admit.

### Why a warmup batch, given perf runs right after accuracy

Running after the eval does not leave the perf sweep warm, because what it inherits is only on-disk state:

- `run_benchmark_for_model` calls `popen_launch_server(...)` and then `kill_process_tree(...)` in its `finally`. The accuracy test does the same, so its server is already gone when the perf step starts and the sweep measures a brand-new process. The step still finished in 5m51s against ~41 min of loading in the accuracy step, which is the on-disk checkpoint and page cache being reused — not process state.
- The server's own startup warmup is on by default but sends `input_ids=[10, 11, 12]` with `max_new_tokens=8`. The first measured run is a 4096-token prefill with 512 output tokens, so shape-keyed Triton/AITER autotuning and allocator first-touch for those buffers still land on it. HIP graph capture does happen during init, so that cost is already outside the measurement, and `--disable-radix-cache` means there is no prefix reuse between runs.
- `test_gpt_oss_perf_mi35x.py`, the one MI35x perf test that already repeats the leading batch size, runs in `nightly-accuracy-8-gpu-mi35x-rocm720` — an accuracy step followed by a perf step in the same job on the same runner class. So the precedent comes from exactly this arrangement.

Worth knowing for review: it is a precedent of one. The other fourteen MI35x perf tests use `[1, 8, 16, 64]` and so fold warmup into their batch-1 row, which means K3's batch-1 number will not be directly comparable to theirs. The tradeoff is a cleaner regression signal for K3 over time against cross-model comparability, at a cost of about 9 s per nightly. Happy to drop it if the reviewer would rather K3 match the majority.

## Test plan

Verified with a harness that loads the real `NightlyBenchmarkRunner` and the real `nightly_bench_utils` with only the torch-backed leaf imports stubbed, so the code under test is the tree's:

- [x] `setUpClass()` runs to completion and creates `performance_results_kimi_k3_mi35x`
- [x] Every `runner.*` attribute the test touches exists on `NightlyBenchmarkRunner`
- [x] The `run_benchmark_for_model(...)` call binds against the real signature
- [x] No local `generate_simple_markdown_report` remains; the call site resolves to the shared function by identity, and the only symbol imported from `nightly_bench_utils` is that function
- [x] No unused imports remain (checked by AST, so the dropped `List` / `BenchmarkResult` cannot silently linger)
- [x] Rendering a five-run sweep through the shared helper emits four rows, so the warmup row is genuinely dropped, and the `[MI35x]` label still appears via `default_gpu_config`
- [x] Workflow YAML parses; job count, `job_select` options and `check-all-jobs` entries are unchanged from the base
- [x] The K3 job runs `nightly-amd-accuracy-8-gpu-mi35x-kimi-k3` first, then directly invokes `registered/amd/perf/mi35x/test_kimi_k3_perf_mi35x.py` in the same job; `test/run_suite.py` is unchanged
- [x] `codespell --config .codespellrc` clean repo-wide; `black --check` and `isort --check-only` clean
- [x] Direct file invocation validated on hardware at head `33d2793ae0`; see **Hardware result** above
- [ ] Re-run on hardware to capture the post-warmup batch-1 number. The review changes touch only the batch list and the report helper, not the server args, so accuracy is unaffected and the other three sweep rows should reproduce.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0082a-b346-7d44-bae7-405b5a1a15eb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0082a-b346-7d44-bae7-405b5a1a15eb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #32086654794](https://github.com/sgl-project/sglang/actions/runs/32086654794)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32086654466](https://github.com/sgl-project/sglang/actions/runs/32086654466)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->









