### PR TITLE
[diffusion] test: tighten NVIDIA perf baselines

### DIFF
--- a/python/sglang/multimodal_gen/test/server/perf_baselines/5090.json
+++ b/python/sglang/multimodal_gen/test/server/perf_baselines/5090.json
@@ -2,6 +2,7 @@
     "metadata": {
         "model": "Diffusion Server",
         "hardware": "CI RTX 5090 pool",
+        "source_revision": "e9fe58139f48ec2a22fe4000ef604fc6862b1bfe",
         "description": "Reference numbers captured from real 5090 CI runner history (PR 29791 run 28492141274, job 84450974283).",
         "last_updated": "2026-07-01"
     },

--- a/python/sglang/multimodal_gen/test/server/perf_baselines/b200.json
+++ b/python/sglang/multimodal_gen/test/server/perf_baselines/b200.json
@@ -2,6 +2,7 @@
     "metadata": {
         "model": "Diffusion Server",
         "hardware": "CI B200 pool",
+        "source_revision": "e9fe58139f48ec2a22fe4000ef604fc6862b1bfe",
         "description": "Reference estimates for B200-only diffusion cases, split out from the shared diffusion baseline file.",
         "last_updated": "2026-07-01"
     },

--- a/python/sglang/multimodal_gen/test/server/perf_baselines/h100.json
+++ b/python/sglang/multimodal_gen/test/server/perf_baselines/h100.json
@@ -2,6 +2,7 @@
     "metadata": {
         "model": "Diffusion Server",
         "hardware": "CI H100 80GB pool",
+        "source_revision": "e9fe58139f48ec2a22fe4000ef604fc6862b1bfe",
         "description": "Reference numbers captured from CI diffusion runs (latest source: PR 28127 run 27487958425, tightened only from prior baselines).",
         "last_updated": "2026-06-14"
     },


### PR DESCRIPTION
## Summary

- Trigger the NVIDIA multimodal generation CI from exact `origin/main` revision `e9fe58139f48ec2a22fe4000ef604fc6862b1bfe`.
- Collect H100, B200, and RTX 5090 performance logs.
- Tighten existing performance baselines from those measurements without increasing any existing value.

## Method

The first CI run changes metadata only and therefore preserves all performance thresholds. After it completes, this PR will apply the same guardrail as #28123:

- update only fields observed in CI
- use `min(existing, measured)`
- do not increase any existing numeric baseline
- keep scenario and field sets stable
- leave unsupported or zero placeholders unchanged

## Validation

- pre-commit passed for all three NVIDIA baseline files
- no local tests were run; GPU validation will come from the PR CI

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31924624572](https://github.com/sgl-project/sglang/actions/runs/31924624572)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31924635960](https://github.com/sgl-project/sglang/actions/runs/31924635960)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->