### PR TITLE
fix: support optional input buffer widths in prefill graphs

### DIFF
--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -296,13 +296,15 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
         self.mamba_track_enabled = self._is_mamba_track_enabled()
 
         # --- buffers ---------------------------------------------------
+        # Resolve once so both graph buffer owners use the same width.
+        input_embeds_hidden_size = self._input_embeds_hidden_size()
         self.buffers: PrefillInputBuffers = PrefillInputBuffers.create(
             device=self.device,
             max_bs=self.max_bs,
             max_num_tokens=self.max_num_tokens,
             cache_loc_dtype=self._cache_loc_dtype(),
             is_multimodal=self.is_multimodal,
-            hidden_size=self.model_runner.model_config.hidden_size,
+            hidden_size=input_embeds_hidden_size,
             dtype=self.model_runner.dtype,
             enable_mamba_track=self.mamba_track_enabled,
         )
@@ -316,7 +318,7 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
             max_num_token=self.max_num_tokens,
             cache_loc_dtype=self._cache_loc_dtype(),
             is_multimodal=self.is_multimodal,
-            hidden_size=self.model_runner.model_config.hidden_size,
+            hidden_size=input_embeds_hidden_size,
             embed_dtype=self.model_runner.dtype,
             enable_mamba_track=self.mamba_track_enabled,
             enable_num_token_non_padded=enable_num_token_non_padded(),
@@ -530,6 +532,14 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
 
     def _cache_loc_dtype(self):
         return torch.int64 if not is_npu() else torch.int32
+
+    def _input_embeds_hidden_size(self) -> int:
+        """Return the configured prefill input-embedding buffer width."""
+        return getattr(
+            self.model_runner.model,
+            "input_embeds_hidden_size",
+            self.model_runner.model_config.hidden_size,
+        )
 
     def _next_token_logits_buffer(self, rows: int) -> Optional[torch.Tensor]:
         if not self.model_runner.pp_group.is_last_rank:

--- a/test/registered/unit/model_executor/test_prefill_cuda_graph_runner_helpers.py
+++ b/test/registered/unit/model_executor/test_prefill_cuda_graph_runner_helpers.py
@@ -4,6 +4,7 @@ import unittest
 from types import SimpleNamespace
 
 from sglang.srt.model_executor.runner.prefill_cuda_graph_runner import (
+    PrefillCudaGraphRunner,
     _resolve_transformer_layer_model,
 )
 from sglang.srt.model_loader.utils import resolve_language_model
@@ -22,6 +23,26 @@ class _LayerModel:
 
 
 class TestPrefillCudaGraphRunnerHelpers(CustomTestCase):
+    def test_input_embeds_hidden_size_uses_explicit_value(self):
+        """An explicit buffer width must take precedence over the default."""
+        runner = PrefillCudaGraphRunner.__new__(PrefillCudaGraphRunner)
+        runner.model_runner = SimpleNamespace(
+            model=SimpleNamespace(input_embeds_hidden_size=7),
+            model_config=SimpleNamespace(hidden_size=5),
+        )
+
+        self.assertEqual(runner._input_embeds_hidden_size(), 7)
+
+    def test_input_embeds_hidden_size_uses_default_value(self):
+        """The configured hidden size remains the default buffer width."""
+        runner = PrefillCudaGraphRunner.__new__(PrefillCudaGraphRunner)
+        runner.model_runner = SimpleNamespace(
+            model=SimpleNamespace(),
+            model_config=SimpleNamespace(hidden_size=5),
+        )
+
+        self.assertEqual(runner._input_embeds_hidden_size(), 5)
+
     def test_resolve_layer_model_from_language_model_wrapper(self):
         layer_model = _LayerModel()
         model = SimpleNamespace(language_model=SimpleNamespace(model=layer_model))


### PR DESCRIPTION
## Motivation

Prefill CUDA graphs allocate input buffers statically. Support an optional `input_embeds_hidden_size` value while preserving the current configured default.

## Modifications

- Use `input_embeds_hidden_size` when it is provided.
- Fall back to `model_config.hidden_size` when it is absent.
- Reuse the resolved value for both prefill buffer construction paths.
- Add unit coverage for the explicit and default paths.

## Accuracy Tests

- `pytest -q test/registered/unit/model_executor/test_prefill_cuda_graph_runner_helpers.py` — 8 passed.

## Speed Tests and Profiling

Not run. The default path is unchanged.

## Checklist

- [x] Format your code according to the [formatting guide](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [testing guide](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to the [documentation guide](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). No user-facing option is added.
- [x] Provide accuracy and speed results according to the [validation guide](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy). Focused tests are listed above; the default path is unchanged.
- [x] Follow the SGLang [code style guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31926254390](https://github.com/sgl-project/sglang/actions/runs/31926254390)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31926254308](https://github.com/sgl-project/sglang/actions/runs/31926254308)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->