### PR TITLE
Increase post-capture decode memory reserve

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -4911,7 +4911,7 @@ class ServerArgs:
             if self.post_capture_kv_sizing_planned():
                 # Post-capture sizing measures free memory after graph capture, so
                 # skip the graph/activation reserve; keep only the floor + parallel slack.
-                reserved_mem = 512
+                reserved_mem = 1536
                 reserved_mem += self.tp_size * self.pp_size / 8 * 1024
             else:
                 # Tokens the activation working set scales with (per serving mode).


### PR DESCRIPTION
## Motivation

Post-capture KV sizing can otherwise leave too little fixed headroom for runtime decode buffers after CUDA graph capture.

## Modifications

Increase the fixed post-capture reserve floor from 512 MiB to 1536 MiB while retaining the existing parallelism-dependent slack.

## Accuracy Tests

- `uv run python3 -m py_compile python/sglang/srt/server_args.py`
- GPU end-to-end coverage was not run locally.

## Speed Tests and Profiling

Not run; this changes the memory-sizing safety margin rather than execution kernels.

## Checklist

- [x] `with-proxy uv run pre-commit run --files python/sglang/srt/server_args.py`
- [x] No documentation update is required for this sizing adjustment.

## Original commits

- `c96e2b686`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #31927523336](https://github.com/sgl-project/sglang/actions/runs/31927523336)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31927523226](https://github.com/sgl-project/sglang/actions/runs/31927523226)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->