### PR TITLE
Fix world-size-one aliasing in MLP batch sync

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/dp_attn.py
+++ b/python/sglang/srt/managers/scheduler_components/dp_attn.py
@@ -137,10 +137,14 @@ class MLPSyncBatchInfo:
         local_info_tensor = self._get_local_tensor(device=device)
         fallback_tensor = self._get_fallback_tensor(device=device)
         info_width = local_info_tensor.numel()
-        # Inactive max_world_size slots must decode as IDLE.
-        global_info_tensor = fallback_tensor.expand(
-            self.dp_size, self.tp_size * self.cp_size, info_width
-        ).contiguous()
+        # Inactive max_world_size slots must decode as IDLE. repeat() (not
+        # expand().contiguous()) so the buffer never aliases fallback_tensor:
+        # at world size 1 the expanded view is already contiguous, contiguous()
+        # is a no-op, and the masked fallback writes below would then read and
+        # write the same storage.
+        global_info_tensor = fallback_tensor.repeat(
+            self.dp_size, self.tp_size * self.cp_size, 1
+        )
 
         if use_all_reduce:
             # Admission can expose different WORLD sizes; use fixed global slots.


### PR DESCRIPTION
## Motivation

At world size one, `expand().contiguous()` can return storage that still aliases the fallback tensor, so later masked writes can corrupt the fallback values they read.

## Modifications

Allocate the gathered fallback buffer with `repeat()` so it always owns independent storage, including the world-size-one case.

## Accuracy Tests

- `uv run python3 -m py_compile python/sglang/srt/managers/scheduler_components/dp_attn.py`
- `uv run python3 -c "import torch; fallback = torch.arange(7); gathered = fallback.repeat(1, 1, 1); gathered.zero_(); assert fallback.tolist() == list(range(7))"`

## Speed Tests and Profiling

Not run; the change only affects construction of a small synchronization metadata buffer.

## Checklist

- [x] `with-proxy uv run pre-commit run --files python/sglang/srt/managers/scheduler_components/dp_attn.py`
- [x] No documentation update is required for this bug fix.

## Original commits

- `778b30ce0`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31976780289](https://github.com/sgl-project/sglang/actions/runs/31976780289)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31976780111](https://github.com/sgl-project/sglang/actions/runs/31976780111)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->