### PR TITLE
[Engine] Freeze GC after server warmup

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -2354,6 +2354,23 @@ def _wait_and_warmup(
     else:
         _global_state.tokenizer_manager.server_status = ServerStatus.Up
 
+    # Freeze GC after server warmup so static objects skip future GC gen2 collection.
+    # Use /freeze_gc to freeze scheduler and detokenizer as well.
+    freeze_key = server_args.admin_api_key or server_args.api_key
+    freeze_headers = {}
+    if freeze_key:
+        freeze_headers["Authorization"] = f"Bearer {freeze_key}"
+    try:
+        res = requests.post(
+            server_args.url() + "/freeze_gc",
+            headers=freeze_headers,
+            timeout=10,
+            verify=server_args.ssl_verify(),
+        )
+        res.raise_for_status()
+    except requests.exceptions.RequestException:
+        logger.warning("post-warmup freeze_gc failed", exc_info=True)
+
     # The server is ready for requests
     logger.info("The server is fired up and ready to roll!")
 

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -2331,6 +2331,25 @@ def _execute_server_warmup(server_args: ServerArgs):
     return success
 
 
+def _freeze_gc_after_server_warmup(server_args: ServerArgs):
+    # Freeze GC after server warmup so static objects skip future GC gen2 collection.
+    # Use /freeze_gc to freeze scheduler and detokenizer as well.
+    freeze_key = server_args.admin_api_key or server_args.api_key
+    freeze_headers = {}
+    if freeze_key:
+        freeze_headers["Authorization"] = f"Bearer {freeze_key}"
+    try:
+        res = requests.post(
+            server_args.url() + "/freeze_gc",
+            headers=freeze_headers,
+            timeout=10,
+            verify=server_args.ssl_verify(),
+        )
+        res.raise_for_status()
+    except requests.exceptions.RequestException:
+        logger.warning("post-warmup freeze_gc failed", exc_info=True)
+
+
 def _wait_and_warmup(
     server_args: ServerArgs,
     launch_callback: Optional[Callable[[], None]] = None,
@@ -2354,22 +2373,7 @@ def _wait_and_warmup(
     else:
         _global_state.tokenizer_manager.server_status = ServerStatus.Up
 
-    # Freeze GC after server warmup so static objects skip future GC gen2 collection.
-    # Use /freeze_gc to freeze scheduler and detokenizer as well.
-    freeze_key = server_args.admin_api_key or server_args.api_key
-    freeze_headers = {}
-    if freeze_key:
-        freeze_headers["Authorization"] = f"Bearer {freeze_key}"
-    try:
-        res = requests.post(
-            server_args.url() + "/freeze_gc",
-            headers=freeze_headers,
-            timeout=10,
-            verify=server_args.ssl_verify(),
-        )
-        res.raise_for_status()
-    except requests.exceptions.RequestException:
-        logger.warning("post-warmup freeze_gc failed", exc_info=True)
+    _freeze_gc_after_server_warmup(server_args)
 
     # The server is ready for requests
     logger.info("The server is fired up and ready to roll!")


### PR DESCRIPTION
## Motivation

Long-lived static objects created during startup remain eligible for later generation-2 garbage collections, which can introduce request-time pauses.

## Modifications

After warmup completes, call the existing `/freeze_gc` endpoint so the tokenizer, scheduler, and detokenizer processes freeze their static object graphs. The request uses the configured API key and TLS verification settings, and logs a warning without blocking startup if the call fails.

## Accuracy Tests

- `uv run python3 -m py_compile python/sglang/srt/entrypoints/http_server.py`
- Server startup and runtime GPU tests were not run locally.

## Speed Tests and Profiling

Not run; validating pause reduction requires a long-running server workload.

## Checklist

- [x] `with-proxy uv run pre-commit run --files python/sglang/srt/entrypoints/http_server.py`
- [x] No documentation update is required for this startup behavior.

## Original commits

- `3909fba5f`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #31976769528](https://github.com/sgl-project/sglang/actions/runs/31976769528)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31976769344](https://github.com/sgl-project/sglang/actions/runs/31976769344)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->