### PR TITLE
Support model-defined prefill input embedding width

### DIFF
--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -296,13 +296,19 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
         self.mamba_track_enabled = self._is_mamba_track_enabled()
 
         # --- buffers ---------------------------------------------------
+        # `hidden_size` here sizes only the multimodal `input_embeds` buffer,
+        # which `general_mm_embed_routine` copies the merged text+media
+        # embeddings into. A model whose merge happens above the embedding width
+        # (e.g. a residual-stream merge) writes a wider tensor than
+        # `config.hidden_size`, so let it declare that width.
+        input_embeds_hidden_size = self._input_embeds_hidden_size()
         self.buffers: PrefillInputBuffers = PrefillInputBuffers.create(
             device=self.device,
             max_bs=self.max_bs,
             max_num_tokens=self.max_num_tokens,
             cache_loc_dtype=self._cache_loc_dtype(),
             is_multimodal=self.is_multimodal,
-            hidden_size=self.model_runner.model_config.hidden_size,
+            hidden_size=input_embeds_hidden_size,
             dtype=self.model_runner.dtype,
             enable_mamba_track=self.mamba_track_enabled,
         )
@@ -316,7 +322,7 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
             max_num_token=self.max_num_tokens,
             cache_loc_dtype=self._cache_loc_dtype(),
             is_multimodal=self.is_multimodal,
-            hidden_size=self.model_runner.model_config.hidden_size,
+            hidden_size=input_embeds_hidden_size,
             embed_dtype=self.model_runner.dtype,
             enable_mamba_track=self.mamba_track_enabled,
             enable_num_token_non_padded=enable_num_token_non_padded(),
@@ -530,6 +536,25 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
 
     def _cache_loc_dtype(self):
         return torch.int64 if not is_npu() else torch.int32
+
+    def _input_embeds_hidden_size(self) -> int:
+        """Width of the `input_embeds` the model writes inside the graph.
+
+        Defaults to `config.hidden_size`; a model that merges multimodal
+        embeddings at a wider width declares it via `input_embeds_hidden_size`.
+
+        `getattr` with a default rather than an always-present field: the
+        property exists only on the handful of model classes whose merge width
+        differs, and adding it to every model in the registry to satisfy a
+        `None` check is not worth it. Same shape as the `hc_hidden_size`
+        opt-in already threaded through `base_runner` and
+        `decode_cuda_graph_runner`.
+        """
+        return getattr(
+            self.model_runner.model,
+            "input_embeds_hidden_size",
+            self.model_runner.model_config.hidden_size,
+        )
 
     def _next_token_logits_buffer(self, rows: int) -> Optional[torch.Tensor]:
         if not self.model_runner.pp_group.is_last_rank:


### PR DESCRIPTION
## Motivation

Some multimodal models merge text and media embeddings at a width that differs from `config.hidden_size`, so prefill CUDA graph buffers sized only from the configuration can be too narrow.

## Modifications

- Let a model expose `input_embeds_hidden_size` for the prefill graph input buffer.
- Use that width consistently for both the input buffer and shared buffer registry.
- Preserve `config.hidden_size` as the default for all existing models.

## Accuracy Tests

- `FLASHINFER_DISABLE_VERSION_CHECK=1 LD_PRELOAD=/usr/lib64/libnuma.so.1 with-proxy uv run --with pytest python3 -m pytest -q test/registered/unit/model_executor/test_prefill_cuda_graph_runner.py test/registered/unit/model_executor/test_prefill_cuda_graph_runner_helpers.py` (11 passed, 2 subtests passed)
- Direct helper smoke check verified both the model-defined width and the configuration fallback.

## Speed Tests and Profiling

Not run; this changes buffer sizing only and requires a model with a wider multimodal merge path for end-to-end profiling.

## Checklist

- [x] `with-proxy uv run pre-commit run --files python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py`
- [x] `uv run python3 -m py_compile python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py`
- [x] No documentation update is required for this model implementation hook.

## Original commits

- `c6998c515`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31928029316](https://github.com/sgl-project/sglang/actions/runs/31928029316)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31928029209](https://github.com/sgl-project/sglang/actions/runs/31928029209)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->