### PR TITLE
Fix Qwen3 Coder stalls on large string tool arguments

### DIFF
--- a/python/sglang/srt/function_call/qwen3_coder_detector.py
+++ b/python/sglang/srt/function_call/qwen3_coder_detector.py
@@ -57,6 +57,14 @@ class Qwen3CoderDetector(BaseFormatDetector):
         # Initialize attributes that were missing in the original PR
         self.current_func_name: Optional[str] = None
 
+        # String-valued parameters may be arbitrarily large (for example, the
+        # full contents of a source file). Keep explicit state so their JSON
+        # string value can be emitted incrementally instead of buffering until
+        # the closing XML tag arrives.
+        self.current_streaming_param_name: Optional[str] = None
+        self.current_streaming_param_at_start: bool = False
+        self.current_streaming_param_quote_started: bool = False
+
     def has_tool_call(self, text: str) -> bool:
         return self.tool_call_start_token in text
 
@@ -95,6 +103,66 @@ class Qwen3CoderDetector(BaseFormatDetector):
         if inferred_type is None:
             return "string"
         return str(inferred_type).strip().lower()
+
+    def _parameter_streams_as_json_string(
+        self, param_name: str, param_config: dict
+    ) -> bool:
+        """Whether a parameter can be JSON-escaped and forwarded incrementally."""
+        if param_name not in param_config:
+            return True
+        return self._get_param_type(param_config[param_name]) in {
+            "string",
+            "str",
+            "text",
+            "varchar",
+            "char",
+            "enum",
+        }
+
+    def _find_parameter_end(self, text: str) -> Optional[tuple[int, int]]:
+        """Return the earliest parameter terminator and its consumed length."""
+        candidates = []
+        for token, consumed_length in (
+            (self.parameter_end_token, len(self.parameter_end_token)),
+            (self.parameter_prefix, 0),
+            (self.function_end_token, 0),
+        ):
+            position = text.find(token)
+            if position != -1:
+                candidates.append((position, consumed_length))
+        return min(candidates, key=lambda item: item[0]) if candidates else None
+
+    def _partial_parameter_end_suffix_length(self, text: str) -> int:
+        """Keep a possible split terminator suffix out of streamed arguments."""
+        longest = 0
+        for token in (
+            self.parameter_end_token,
+            self.parameter_prefix,
+            self.function_end_token,
+        ):
+            for size in range(1, min(len(text), len(token) - 1) + 1):
+                if text.endswith(token[:size]):
+                    longest = max(longest, size)
+        return longest
+
+    @staticmethod
+    def _json_string_fragment(text: str) -> str:
+        """Escape one string fragment without adding its surrounding quotes."""
+        return json.dumps(text, ensure_ascii=False)[1:-1]
+
+    def _start_streaming_json_string(self, calls: list[ToolCallItem]) -> None:
+        """Emit the key and opening quote for the current string parameter."""
+        prefix = f'{json.dumps(self.current_streaming_param_name)}: "'
+        if self.current_tool_param_count > 0:
+            prefix = f", {prefix}"
+        calls.append(ToolCallItem(tool_index=self.current_tool_id, parameters=prefix))
+        self.current_tool_param_count += 1
+        self.current_streaming_param_quote_started = True
+
+    def _reset_streaming_parameter(self) -> None:
+        self.current_streaming_param_name = None
+        self.current_streaming_param_at_start = False
+        self.current_streaming_param_quote_started = False
 
     def _convert_param_value(
         self, param_value: str, param_name: str, param_config: dict, func_name: str
@@ -264,6 +332,92 @@ class Qwen3CoderDetector(BaseFormatDetector):
             if not current_slice:
                 break
 
+            # A string parameter has already emitted its JSON key and opening
+            # quote. Forward safe value text on every parser invocation while
+            # retaining only a possible split XML terminator (and one trailing
+            # newline, which the legacy parser trims immediately before a
+            # closing tag).
+            if self.current_streaming_param_name is not None:
+                if self.current_streaming_param_at_start:
+                    self.current_streaming_param_at_start = False
+                    if current_slice.startswith("\n"):
+                        self.parsed_pos += 1
+                        continue
+
+                parameter_end = self._find_parameter_end(current_slice)
+                if parameter_end is not None:
+                    end_pos, end_token_len = parameter_end
+                    raw_value = current_slice[:end_pos]
+                    if raw_value.endswith("\n"):
+                        raw_value = raw_value[:-1]
+
+                    if self.current_streaming_param_quote_started:
+                        calls.append(
+                            ToolCallItem(
+                                tool_index=self.current_tool_id,
+                                parameters=f'{self._json_string_fragment(raw_value)}"',
+                            )
+                        )
+                    else:
+                        param_config = self._get_arguments_config(
+                            self.current_func_name, tools
+                        )
+                        converted_val = self._convert_param_value(
+                            raw_value,
+                            self.current_streaming_param_name,
+                            param_config,
+                            self.current_func_name,
+                        )
+                        json_key_val = (
+                            f"{json.dumps(self.current_streaming_param_name)}: "
+                            f"{json.dumps(converted_val, ensure_ascii=False)}"
+                        )
+                        if self.current_tool_param_count > 0:
+                            json_key_val = f", {json_key_val}"
+                        calls.append(
+                            ToolCallItem(
+                                tool_index=self.current_tool_id,
+                                parameters=json_key_val,
+                            )
+                        )
+                        self.current_tool_param_count += 1
+
+                    self._reset_streaming_parameter()
+                    self.parsed_pos += end_pos + end_token_len
+                    continue
+
+                held_suffix_len = self._partial_parameter_end_suffix_length(
+                    current_slice
+                )
+                emit_end = len(current_slice) - held_suffix_len
+
+                # Preserve one trailing newline until the next chunk tells us
+                # whether it belongs to the value or is formatting before the
+                # closing tag.
+                if emit_end > 0 and current_slice[emit_end - 1] == "\n":
+                    emit_end -= 1
+
+                if not self.current_streaming_param_quote_started:
+                    possible_null = current_slice[:emit_end]
+                    if len(possible_null) <= 4 and "null".startswith(
+                        possible_null.lower()
+                    ):
+                        break
+                    self._start_streaming_json_string(calls)
+                    continue
+
+                if emit_end <= 0:
+                    break
+
+                calls.append(
+                    ToolCallItem(
+                        tool_index=self.current_tool_id,
+                        parameters=self._json_string_fragment(current_slice[:emit_end]),
+                    )
+                )
+                self.parsed_pos += emit_end
+                continue
+
             # -------------------------------------------------------
             # 1. Priority detection: check if it's the start of Tool Call
             # -------------------------------------------------------
@@ -309,33 +463,35 @@ class Qwen3CoderDetector(BaseFormatDetector):
                     value_start_idx = name_end + 1
                     rest_of_slice = current_slice[value_start_idx:]
 
+                    param_name = current_slice[len(self.parameter_prefix) : name_end]
+                    param_config = self._get_arguments_config(
+                        self.current_func_name, tools
+                    )
+
+                    if self._parameter_streams_as_json_string(param_name, param_config):
+                        if not self.json_started:
+                            calls.append(
+                                ToolCallItem(
+                                    tool_index=self.current_tool_id, parameters="{"
+                                )
+                            )
+                            self.json_started = True
+
+                        self.current_streaming_param_name = param_name
+                        self.current_streaming_param_at_start = True
+                        self.current_streaming_param_quote_started = False
+                        self.parsed_pos += value_start_idx
+                        continue
+
                     # A parameter can end in multiple ways:
                     # 1. [Normal] Encounter </parameter>
                     # 2. [Abnormal] Encounter next <parameter=
                     # 3. [Abnormal] Encounter </function>
                     # So we need to find the smallest one as the parameter end position.
-                    cand_end_param = rest_of_slice.find(self.parameter_end_token)
-                    cand_next_param = rest_of_slice.find(self.parameter_prefix)
-                    cand_end_func = rest_of_slice.find(self.function_end_token)
+                    parameter_end = self._find_parameter_end(rest_of_slice)
 
-                    candidates = []
-                    if cand_end_param != -1:
-                        candidates.append(
-                            (cand_end_param, len(self.parameter_end_token))
-                        )
-                    if cand_next_param != -1:
-                        candidates.append((cand_next_param, 0))
-                    if cand_end_func != -1:
-                        candidates.append((cand_end_func, 0))
-
-                    if candidates:
-                        best_cand = min(candidates, key=lambda x: x[0])
-                        end_pos = best_cand[0]
-                        end_token_len = best_cand[1]
-
-                        param_name = current_slice[
-                            len(self.parameter_prefix) : name_end
-                        ]
+                    if parameter_end is not None:
+                        end_pos, end_token_len = parameter_end
                         raw_value = rest_of_slice[:end_pos]
 
                         # Cleanup value
@@ -353,9 +509,6 @@ class Qwen3CoderDetector(BaseFormatDetector):
                             )
                             self.json_started = True
 
-                        param_config = self._get_arguments_config(
-                            self.current_func_name, tools
-                        )
                         converted_val = self._convert_param_value(
                             raw_value, param_name, param_config, self.current_func_name
                         )

--- a/test/registered/unit/function_call/test_function_call_parser.py
+++ b/test/registered/unit/function_call/test_function_call_parser.py
@@ -2339,6 +2339,27 @@ class TestQwen3CoderDetector(unittest.TestCase):
                     },
                 ),
             ),
+            Tool(
+                type="function",
+                function=Function(
+                    name="write_file",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "file_path": {"type": "string"},
+                            "content": {"type": "string"},
+                            "note": {
+                                "anyOf": [
+                                    {"type": "string"},
+                                    {"type": "null"},
+                                ]
+                            },
+                            "overwrite": {"type": "boolean"},
+                        },
+                        "required": ["file_path", "content"],
+                    },
+                ),
+            ),
         ]
         self.detector = Qwen3CoderDetector()
 
@@ -2447,6 +2468,107 @@ class TestQwen3CoderDetector(unittest.TestCase):
             params = json.loads(collected_params)
             self.assertEqual(params["location"], "Boston")
             self.assertEqual(params["unit"], "celsius")
+
+    def test_streaming_string_parameter_emits_before_closing_tag(self):
+        """String argument deltas should arrive while the XML value is open."""
+        content_chunks = [
+            'const quote = "hello";\n',
+            "const slash = \\\\server;\n",
+            "const unicode = '你好';\n",
+        ]
+        chunks = [
+            "<tool_call><function=write_file>",
+            "<parameter=file_path>/tmp/demo.js</parameter>",
+            "<parameter=content>\n",
+            *content_chunks,
+            "\n</para",
+            "meter><parameter=overwrite>false</parameter>",
+            "</function></tool_call>",
+        ]
+
+        detector = Qwen3CoderDetector()
+        results = [
+            detector.parse_streaming_increment(chunk, self.tools) for chunk in chunks
+        ]
+
+        content_results = results[3 : 3 + len(content_chunks)]
+        self.assertTrue(all(result.calls for result in content_results))
+
+        arguments = "".join(
+            call.parameters for result in results for call in result.calls
+        )
+        self.assertEqual(
+            json.loads(arguments),
+            {
+                "file_path": "/tmp/demo.js",
+                "content": "".join(content_chunks),
+                "overwrite": False,
+            },
+        )
+
+    def test_streaming_large_string_parameter_keeps_buffer_bounded(self):
+        """An open string argument should not accumulate in the parser buffer."""
+        detector = Qwen3CoderDetector()
+        results = [
+            detector.parse_streaming_increment(
+                "<tool_call><function=write_file><parameter=content>", self.tools
+            )
+        ]
+
+        content_chunks = [f"chunk-{index:03d}:" + "x" * 1013 for index in range(128)]
+        for content_chunk in content_chunks:
+            result = detector.parse_streaming_increment(content_chunk, self.tools)
+            self.assertTrue(result.calls)
+            self.assertLessEqual(
+                len(detector._buffer), len(detector.parameter_end_token)
+            )
+            results.append(result)
+
+        results.append(
+            detector.parse_streaming_increment(
+                "</parameter></function></tool_call>", self.tools
+            )
+        )
+        arguments = "".join(
+            call.parameters for result in results for call in result.calls
+        )
+        self.assertEqual(
+            json.loads(arguments),
+            {"content": "".join(content_chunks)},
+        )
+
+    def test_streaming_nullable_string_preserves_null_conversion(self):
+        """Disambiguating string streaming must preserve JSON null values."""
+        detector = Qwen3CoderDetector()
+        chunks = [
+            "<tool_call><function=write_file><parameter=note>\n",
+            "nu",
+            "ll\n",
+            "</parameter></function></tool_call>",
+        ]
+        results = [
+            detector.parse_streaming_increment(chunk, self.tools) for chunk in chunks
+        ]
+        arguments = "".join(
+            call.parameters for result in results for call in result.calls
+        )
+        self.assertEqual(json.loads(arguments), {"note": None})
+
+        detector = Qwen3CoderDetector()
+        chunks = [
+            "<tool_call><function=write_file><parameter=note>",
+            "null",
+            " value",
+            "</parameter></function></tool_call>",
+        ]
+        results = [
+            detector.parse_streaming_increment(chunk, self.tools) for chunk in chunks
+        ]
+        self.assertTrue(results[2].calls)
+        arguments = "".join(
+            call.parameters for result in results for call in result.calls
+        )
+        self.assertEqual(json.loads(arguments), {"note": "null value"})
 
     def test_streaming_with_text_and_tool(self):
         """


### PR DESCRIPTION
## Motivation

Qwen3 Coder emits tool calls in an XML-like format. The streaming parser currently buffers every parameter value until it sees `</parameter>`. For large string arguments such as generated source files, the model keeps producing tokens but OpenAI-compatible clients receive no argument deltas. Client-side inactivity watchdogs can therefore time out and retry a healthy generation.

Credit to @ccq1: #25246 first identified this root cause and proposed incremental string emission. This PR reworks the fix on current `main` and preserves behavior added since that PR, especially complex JSON Schema type inference and nullable-string `null` conversion. Related: #27005.

## Modifications

- Stream schema-inferred string parameters as JSON-escaped argument fragments while their XML parameter is still open.
- After at most four characters of `null` disambiguation, retain only a possible split terminator suffix and one trailing newline instead of the full argument, keeping the parser buffer bounded for large values.
- Keep non-string parameters on the existing complete-value conversion path, including `anyOf`/`oneOf` schemas.
- Delay string quoting for at most four characters to distinguish a JSON `null` value from a string beginning with `null`, preserving existing nullable-string semantics.
- Add regressions for pre-close deltas, JSON escaping, split closing tags, bounded 128 KiB streaming, typed parameters after a streamed string, and nullable strings.

## Accuracy Tests

- All 19 parser-only `TestQwen3CoderDetector` tests pass locally (the `xgrammar` construction-only test was excluded because the macOS test host does not have that optional runtime dependency).
- A focused parser suite passes 9/9 tests, including 40 randomized chunk-boundary reconstructions and 330 nullable-string boundary cases.
- The existing streaming nullable-`anyOf` array test remains green, confirming that complex non-string schemas are not accidentally streamed as strings.
- `black==26.1.0` and `ruff==0.15.1 --select=F401,F821,UP037` pass on both changed files.

The parser output is unchanged after fragments are concatenated; only the timing of string argument deltas changes.

## Speed Tests and Profiling

In a local end-to-end DSH run, a 250-line file-writing argument produced 256 argument deltas with a maximum 287 ms inter-delta gap. The task remained active for more than 300 seconds and completed without the inactivity retry seen with the buffering parser.

The unit test also streams 128 KiB through an open string parameter and asserts that the parser buffer never grows beyond the terminator length.

## Checklist

- [x] Format code with the repository-pinned Black version.
- [x] Add unit tests for the parser regression and compatibility cases.
- [x] Documentation is not needed; this changes internal streaming timing without changing the public format.
- [x] Provide end-to-end timing and bounded-buffer results above.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31932735293](https://github.com/sgl-project/sglang/actions/runs/31932735293)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31932735059](https://github.com/sgl-project/sglang/actions/runs/31932735059)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->