### PR TITLE
fix(hicache): scope write-back load-back pins by component

### DIFF
--- a/python/sglang/srt/mem_cache/unified_cache/components/full_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/full_component.py
@@ -140,6 +140,9 @@ class FullComponent(TreeComponent):
     ):
         ct = self.component_type
         new_parent.component_data[ct].lock_ref = child.component_data[ct].lock_ref
+        new_parent.component_data[ct].load_back_pending_transfer_ids = (
+            child.component_data[ct].load_back_pending_transfer_ids.copy()
+        )
         new_parent.component_data[ct].session_ref = child.component_data[ct].session_ref
         child_cd = child.component_data[ct]
         assert new_parent.component_data[ct].session_ids is None

--- a/python/sglang/srt/mem_cache/unified_cache/components/swa_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/swa_component.py
@@ -427,6 +427,11 @@ class SWAComponent(TreeComponent):
         new_parent.component_data[self.component_type].lock_ref = child.component_data[
             self.component_type
         ].lock_ref
+        new_parent.component_data[
+            self.component_type
+        ].load_back_pending_transfer_ids = child.component_data[
+            self.component_type
+        ].load_back_pending_transfer_ids.copy()
         new_parent.component_data[self.component_type].session_ref = (
             child.component_data[self.component_type].session_ref
         )

--- a/python/sglang/srt/mem_cache/unified_cache/components/tree_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/tree_component.py
@@ -51,6 +51,7 @@ class ComponentData:
     metadata: dict[str, Any] = dataclasses.field(default_factory=dict)
     host_value: Optional[torch.Tensor] = None
     host_lock_ref: int = 0
+    load_back_pending_transfer_ids: set[int] = dataclasses.field(default_factory=set)
     session_ref: int = 0
     session_ids: Optional[set[str]] = None
 

--- a/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
+++ b/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
@@ -1160,6 +1160,13 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         else:
             self.full_host_duplicates.pop(node.id, None)
 
+    def _has_pending_full_load_back(self, node: UnifiedTreeNode) -> bool:
+        if self.is_write_back:
+            return bool(
+                node.component_data[BASE_COMPONENT_TYPE].load_back_pending_transfer_ids
+            )
+        return node.load_back_pending_id is not None
+
     def _is_settled_full_host_duplicate(self, node: UnifiedTreeNode) -> bool:
         """Full KV present on both tiers with no in-flight DMA on the node's
         host slots; mid-transfer nodes join the tracking at their ack."""
@@ -1169,7 +1176,7 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
             and cd.value is not None
             and cd.host_value is not None
             and node.write_through_pending_id is None
-            and node.load_back_pending_id is None
+            and not self._has_pending_full_load_back(node)
         )
 
     def _for_each_component_lru(
@@ -1407,7 +1414,7 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
             return False
         if (
             node.write_through_pending_id is not None
-            or node.load_back_pending_id is not None
+            or self._has_pending_full_load_back(node)
         ):
             return False
         return cd.host_lock_ref == 0
@@ -1949,6 +1956,7 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
 
     def commit_load_back(
         self,
+        transfer_id: int,
         node_id: NodeId,
         device_indices: torch.Tensor,
         kv_xfer: PoolTransfer,
@@ -1958,19 +1966,26 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         rebuild is deferred to the orchestration layer."""
         node = self.node_by_id(node_id)
         cache_actions: list[CacheAction | ComponentAction] = []
-        # Pin every node whose host slots the in-flight DMA reads (including
-        # aux-only nodes) against reclaim until the ack.
-        for xfers in ([kv_xfer], *comp_xfers.values()):
-            for xfer in xfers:
-                for nid in xfer.nodes_to_load or ():
-                    pinned = self.node_by_id(nid)
-                    # One live load-back per node; only the same anchor may
-                    # re-pin (a node can sit in Full and aux transfer lists).
-                    assert pinned.load_back_pending_id in (None, node_id), (
-                        f"node {nid} pinned by load-back "
-                        f"{pinned.load_back_pending_id}, new anchor {node_id}"
-                    )
-                    pinned.load_back_pending_id = node_id
+        component_xfers = {BASE_COMPONENT_TYPE: [kv_xfer], **comp_xfers}
+        if self.is_write_back:
+            for component_type, xfers in component_xfers.items():
+                for xfer in xfers:
+                    for nid in xfer.nodes_to_load or ():
+                        self.node_by_id(nid).component_data[
+                            component_type
+                        ].load_back_pending_transfer_ids.add(transfer_id)
+        else:
+            # Preserve the existing write-through behavior. The dedicated
+            # write-through fix is intentionally handled in a separate change.
+            for xfers in component_xfers.values():
+                for xfer in xfers:
+                    for nid in xfer.nodes_to_load or ():
+                        pinned = self.node_by_id(nid)
+                        assert pinned.load_back_pending_id in (None, node_id), (
+                            f"node {nid} pinned by load-back "
+                            f"{pinned.load_back_pending_id}, new anchor {node_id}"
+                        )
+                        pinned.load_back_pending_id = node_id
         kv_xfer.device_indices = device_indices
         self.components_by_type[BASE_COMPONENT_TYPE].commit_hicache_transfer(
             node,
@@ -1990,12 +2005,23 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         self._update_evictable_leaf_sets(node)
         return cache_actions
 
-    def finish_load_back(self, anchor_node_id: NodeId) -> None:
+    def finish_load_back(self, transfer_id: int, anchor_node_id: NodeId) -> None:
         """Clear the in-flight H->D marks along the anchor's root path at ack
         time; split fragments stay on the path, so the walk covers them."""
         node = self.node_by_id(anchor_node_id)
         while node is not None and node is not self.root_node:
-            if node.load_back_pending_id == anchor_node_id:
+            if self.is_write_back:
+                full_pending_ids = node.component_data[
+                    BASE_COMPONENT_TYPE
+                ].load_back_pending_transfer_ids
+                full_cleared = transfer_id in full_pending_ids
+                for component_type in self.component_types:
+                    node.component_data[
+                        component_type
+                    ].load_back_pending_transfer_ids.discard(transfer_id)
+                if full_cleared:
+                    self._update_duplicate_tracking(node)
+            elif node.load_back_pending_id == anchor_node_id:
                 node.load_back_pending_id = None
                 # The loaded copies become tracked duplicates only now.
                 self._update_duplicate_tracking(node)
@@ -2281,16 +2307,30 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
                 )
         # Every in-flight H->D mark must belong to a live load-back; a leaked
         # mark would pin the node's host copy against reclaim forever.
-        ongoing_load_ids = {node_id for _, node_id in ongoing_load_back}
-        for node in all_nodes:
-            if (
-                node.load_back_pending_id is not None
-                and node.load_back_pending_id not in ongoing_load_ids
-            ):
-                E(
-                    f"[Ongoing] node {node.id} load_back_pending_id="
-                    f"{node.load_back_pending_id} has no live load-back"
-                )
+        if self.is_write_back:
+            ongoing_transfer_ids = {transfer_id for transfer_id, _ in ongoing_load_back}
+            for node in all_nodes:
+                for component_type in self.component_types:
+                    pending_ids = node.component_data[
+                        component_type
+                    ].load_back_pending_transfer_ids
+                    leaked_ids = pending_ids - ongoing_transfer_ids
+                    if leaked_ids:
+                        E(
+                            f"[Ongoing] node {node.id} component={component_type} "
+                            f"load-back transfers {sorted(leaked_ids)} are not live"
+                        )
+        else:
+            ongoing_anchor_ids = {node_id for _, node_id in ongoing_load_back}
+            for node in all_nodes:
+                if (
+                    node.load_back_pending_id is not None
+                    and node.load_back_pending_id not in ongoing_anchor_ids
+                ):
+                    E(
+                        f"[Ongoing] node {node.id} load_back_pending_id="
+                        f"{node.load_back_pending_id} has no live load-back"
+                    )
 
         if errors:
             msg = (

--- a/python/sglang/srt/mem_cache/unified_cache/unified_tree_core_interface.py
+++ b/python/sglang/srt/mem_cache/unified_cache/unified_tree_core_interface.py
@@ -454,6 +454,7 @@ class UnifiedTreeCoreInterface(KVCacheEventMixin, ABC):
     @abstractmethod
     def commit_load_back(
         self,
+        transfer_id: int,
         node_id: NodeId,
         device_indices: torch.Tensor,
         kv_xfer: PoolTransfer,
@@ -463,7 +464,7 @@ class UnifiedTreeCoreInterface(KVCacheEventMixin, ABC):
         ...
 
     @abstractmethod
-    def finish_load_back(self, anchor_node_id: NodeId) -> None:
+    def finish_load_back(self, transfer_id: int, anchor_node_id: NodeId) -> None:
         """Clear the in-flight H->D marks on the anchor's root path at ack time."""
         ...
 
@@ -514,6 +515,7 @@ class UnifiedTreeCoreInterface(KVCacheEventMixin, ABC):
         """Verify tree invariants and raise AssertionError on any violation.
 
         ongoing_write_through/ongoing_load_back are (id, node_id) pairs for in-flight ops.
+        A load-back id is its transfer id, while node_id is its anchor.
         """
         ...
 

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -306,6 +306,7 @@ class UnifiedRadixCache(BasePrefixCache):
         self.session.slots.clear()
         self.ongoing_write_through: dict[int, _OngoingWriteThrough] = {}
         self.ongoing_load_back: dict[int, _OngoingLoadBack] = {}
+        self._next_load_back_transfer_id = 0
         self.enable_storage = False
         self.prefetch_loaded_tokens_by_reqid: dict[str, int] = {}
         self.ongoing_prefetch: dict[str, _OngoingPrefetch] = {}
@@ -1094,11 +1095,13 @@ class UnifiedRadixCache(BasePrefixCache):
                 return False
 
         # Load H→D
+        transfer_id = self._next_load_back_transfer_id
+        self._next_load_back_transfer_id += 1
         aux_xfers = [x for xfers in comp_xfers.values() for x in xfers]
         aux_xfers.extend(sidecar_xfers)
         device_indices = self.cache_controller.load(
             host_indices=kv_xfer.host_indices,
-            node_id=node_id,
+            node_id=transfer_id,
             extra_pools=aux_xfers or None,
         )
 
@@ -1110,11 +1113,11 @@ class UnifiedRadixCache(BasePrefixCache):
         # Commit the loaded KV back onto the node + apply its emitted actions.
         self._apply_cache_actions(
             self.tree_core.commit_load_back(
-                node_id, device_indices, kv_xfer, comp_xfers
+                transfer_id, node_id, device_indices, kv_xfer, comp_xfers
             )
         )
 
-        self.ongoing_load_back[node_id] = _OngoingLoadBack(
+        self.ongoing_load_back[transfer_id] = _OngoingLoadBack(
             node_id,
             self.inc_lock_ref(node_id).to_dec_params(),
             host_anchor_params,
@@ -1960,12 +1963,14 @@ class UnifiedRadixCache(BasePrefixCache):
         while finish_count > 0:
             ack = cc.ack_load_queue.pop(0)
             ack.finish_event.synchronize()
-            for ack_id in ack.node_ids:
-                node, lock_params, host_lock_params = self.ongoing_load_back.pop(ack_id)
+            for transfer_id in ack.node_ids:
+                node, lock_params, host_lock_params = self.ongoing_load_back.pop(
+                    transfer_id
+                )
                 self.dec_lock_ref(node, lock_params)
                 self.dec_host_lock_ref(node, host_lock_params)
                 # Unpin the loaded nodes; host copies stay as reclaimable duplicates.
-                self.tree_core.finish_load_back(node)
+                self.tree_core.finish_load_back(transfer_id, node)
 
             if self.metrics_collector is not None:
                 for pool, num_tokens in (ack.num_tokens_by_pool or {}).items():
@@ -2224,7 +2229,8 @@ class UnifiedRadixCache(BasePrefixCache):
             (nid, wt.node_id) for nid, wt in self.ongoing_write_through.items()
         ]
         ongoing_load_back = [
-            (nid, lb.node_id) for nid, lb in self.ongoing_load_back.items()
+            (transfer_id, lb.node_id)
+            for transfer_id, lb in self.ongoing_load_back.items()
         ]
         self.tree_core.sanity_check(ongoing_write_through, ongoing_load_back)
 

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -59,12 +59,15 @@ from sglang.srt.mem_cache.unified_cache.cache_action import (
     ReplaceWriteThroughOnNodeSplit,
     SWARebuild,
 )
+from sglang.srt.mem_cache.unified_cache.components.full_component import FullComponent
+from sglang.srt.mem_cache.unified_cache.components.swa_component import SWAComponent
 from sglang.srt.mem_cache.unified_cache.components.tree_component import (
     CacheTransferPhase,
     ComponentType,
     EvictLayer,
     TreeComponent,
 )
+from sglang.srt.mem_cache.unified_cache.unified_tree_core import UnifiedTreeCore
 from sglang.srt.mem_cache.unified_cache.unified_tree_core_interface import (
     DecSwaLockOnlyResult,
     DemoteResult,
@@ -252,6 +255,179 @@ class TestUnifiedTreeNodeGetPrefixHashValues(CustomTestCase):
         n4.parent = n3
         n4.hash_value = ["h4"]
         self.assertEqual(n4.get_prefix_hash_values(n3), ["h1", "h2", "h3"])
+
+
+class TestWriteBackComponentScopedLoadBack(CustomTestCase):
+    def _build_core(self):
+        component_types = (ComponentType.FULL, ComponentType.SWA)
+        root = UnifiedTreeNode(component_types)
+        shared = UnifiedTreeNode(component_types)
+        anchor_a = UnifiedTreeNode(component_types)
+        anchor_b = UnifiedTreeNode(component_types)
+        shared.parent = root
+        anchor_a.parent = shared
+        anchor_b.parent = shared
+
+        nodes = {node.id: node for node in (root, shared, anchor_a, anchor_b)}
+        core = mock.Mock()
+        core.is_write_back = True
+        core.component_types = component_types
+        core.root_node = root
+        core.node_by_id.side_effect = nodes.__getitem__
+        core.components_by_type = {ct: mock.Mock() for ct in component_types}
+        core.full_host_duplicates = {}
+        core._has_pending_full_load_back.side_effect = (
+            lambda node: UnifiedTreeCore._has_pending_full_load_back(core, node)
+        )
+        core._is_settled_full_host_duplicate.side_effect = (
+            lambda node: UnifiedTreeCore._is_settled_full_host_duplicate(core, node)
+        )
+        core._update_duplicate_tracking.side_effect = (
+            lambda node: UnifiedTreeCore._update_duplicate_tracking(core, node)
+        )
+        return core, shared, anchor_a, anchor_b
+
+    def test_different_anchors_load_different_components_on_same_node(self):
+        core, shared, anchor_a, anchor_b = self._build_core()
+        full_transfer = PoolTransfer(
+            name=PoolName.KV,
+            host_indices=torch.tensor([1], dtype=torch.int64),
+            nodes_to_load=[shared.id],
+        )
+        UnifiedTreeCore.commit_load_back(
+            core,
+            101,
+            anchor_a.id,
+            torch.tensor([2], dtype=torch.int64),
+            full_transfer,
+            {},
+        )
+
+        empty_full_transfer = PoolTransfer(
+            name=PoolName.KV,
+            host_indices=torch.empty((0,), dtype=torch.int64),
+            nodes_to_load=[],
+        )
+        swa_transfer = PoolTransfer(
+            name=PoolName.SWA,
+            host_indices=torch.tensor([3], dtype=torch.int64),
+            device_indices=torch.tensor([4], dtype=torch.int64),
+            nodes_to_load=[shared.id],
+        )
+        UnifiedTreeCore.commit_load_back(
+            core,
+            102,
+            anchor_b.id,
+            torch.empty((0,), dtype=torch.int64),
+            empty_full_transfer,
+            {ComponentType.SWA: [swa_transfer]},
+        )
+
+        self.assertEqual(
+            shared.component_data[ComponentType.FULL].load_back_pending_transfer_ids,
+            {101},
+        )
+        self.assertEqual(
+            shared.component_data[ComponentType.SWA].load_back_pending_transfer_ids,
+            {102},
+        )
+
+        UnifiedTreeCore.finish_load_back(core, 101, anchor_a.id)
+        self.assertFalse(
+            shared.component_data[ComponentType.FULL].load_back_pending_transfer_ids
+        )
+        self.assertEqual(
+            shared.component_data[ComponentType.SWA].load_back_pending_transfer_ids,
+            {102},
+        )
+        UnifiedTreeCore.finish_load_back(core, 102, anchor_b.id)
+        self.assertFalse(
+            shared.component_data[ComponentType.SWA].load_back_pending_transfer_ids
+        )
+
+    def test_same_component_tracks_multiple_transfer_ids_until_each_ack(self):
+        core, shared, anchor_a, anchor_b = self._build_core()
+        full_transfer = PoolTransfer(
+            name=PoolName.KV,
+            host_indices=torch.tensor([1], dtype=torch.int64),
+            nodes_to_load=[shared.id],
+        )
+        for transfer_id, anchor in ((111, anchor_a), (112, anchor_b)):
+            UnifiedTreeCore.commit_load_back(
+                core,
+                transfer_id,
+                anchor.id,
+                torch.tensor([2], dtype=torch.int64),
+                full_transfer,
+                {},
+            )
+
+        pending_ids = shared.component_data[
+            ComponentType.FULL
+        ].load_back_pending_transfer_ids
+        self.assertEqual(pending_ids, {111, 112})
+
+        UnifiedTreeCore.finish_load_back(core, 111, anchor_a.id)
+        self.assertEqual(pending_ids, {112})
+        UnifiedTreeCore.finish_load_back(core, 112, anchor_b.id)
+        self.assertFalse(pending_ids)
+
+    def test_l3_refill_duplicate_is_tracked_after_full_load_back_ack(self):
+        core, shared, anchor_a, _ = self._build_core()
+        full = shared.component_data[ComponentType.FULL]
+        full.host_value = torch.tensor([1], dtype=torch.int64)
+        full_transfer = PoolTransfer(
+            name=PoolName.KV,
+            host_indices=full.host_value,
+            nodes_to_load=[shared.id],
+        )
+        UnifiedTreeCore.commit_load_back(
+            core,
+            201,
+            anchor_a.id,
+            torch.tensor([2], dtype=torch.int64),
+            full_transfer,
+            {},
+        )
+        full.value = torch.tensor([2], dtype=torch.int64)
+
+        self.assertNotIn(shared.id, core.full_host_duplicates)
+        UnifiedTreeCore.finish_load_back(core, 201, anchor_a.id)
+        self.assertIn(shared.id, core.full_host_duplicates)
+
+    def test_split_copies_pending_ids_for_split_components(self):
+        component_types = (ComponentType.FULL, ComponentType.SWA)
+        child = UnifiedTreeNode(component_types)
+        new_parent = UnifiedTreeNode(component_types)
+        child.key = RadixKey([1, 2, 3, 4], extra_key=None)
+        new_parent.key = RadixKey([1, 2], extra_key=None)
+
+        for component_type in component_types:
+            child_data = child.component_data[component_type]
+            child_data.value = torch.tensor([1, 2, 3, 4], dtype=torch.int64)
+            child_data.host_value = torch.tensor([5, 6, 7, 8], dtype=torch.int64)
+            child_data.load_back_pending_transfer_ids.add(301)
+
+        full_component = mock.Mock(component_type=ComponentType.FULL)
+        FullComponent.redistribute_on_node_split(full_component, new_parent, child)
+
+        swa_component = mock.Mock(component_type=ComponentType.SWA)
+        host_lru = mock.Mock()
+        host_lru.in_list.return_value = True
+        swa_component.tree_core.host_lru_lists = {ComponentType.SWA: host_lru}
+        SWAComponent.redistribute_on_node_split(swa_component, new_parent, child)
+
+        for component_type in component_types:
+            self.assertEqual(
+                new_parent.component_data[
+                    component_type
+                ].load_back_pending_transfer_ids,
+                {301},
+            )
+            self.assertEqual(
+                child.component_data[component_type].load_back_pending_transfer_ids,
+                {301},
+            )
 
 
 def _write_backup(cache, node, write_back: bool = False) -> int:
@@ -2456,11 +2632,15 @@ class UnifiedRadixCacheSuite:
         cache.sanity_check()
 
     def test_hicache_l3_prefetch(self):
-        """L3 round trip: write with one tree, prefetch into a fresh tree.
+        """L3 round trip under write-through."""
+        self._run_hicache_l3_prefetch_round_trip(write_policy="write_through")
 
-        Uses two independent trees that share the same file storage dir so the
-        prefetch path genuinely reloads from L3 (no host/device residue).
-        """
+    def test_hicache_l3_prefetch_write_back(self):
+        """L3→Host→Device round trip preserves write-back load-back state."""
+        self._run_hicache_l3_prefetch_round_trip(write_policy="write_back")
+
+    def _run_hicache_l3_prefetch_round_trip(self, *, write_policy: str):
+        """Reload a stored prefix into a fresh tree and explicitly sanity-check it."""
         if self._skip_unsupported_hicache_test():
             return
         if self.cfg.has_mamba:
@@ -2486,6 +2666,7 @@ class UnifiedRadixCacheSuite:
             storage_backend="file",
             storage_dir=storage_dir,
             prefetch_threshold=1,
+            write_policy=write_policy,
         )
         self._insert(prod, prod_alloc, prod_rtp, seq)
         mp = prod.match_prefix(MatchPrefixParams(key=RadixKey(array("q", seq))))
@@ -2503,8 +2684,9 @@ class UnifiedRadixCacheSuite:
             storage_backend="file",
             storage_dir=storage_dir,
             prefetch_threshold=1,
+            write_policy=write_policy,
         )
-        req_id = "l3-prefetch-req"
+        req_id = f"l3-prefetch-{write_policy}"
         cons.prefetch_from_storage(
             req_id, cons.root_node.id, array("q", seq), None, None
         )


### PR DESCRIPTION
## Problem

In write-back mode, `UnifiedTreeNode.load_back_pending_id` is a node-wide, single-anchor guard for in-flight H→D DMA.

However, residency and load-back decisions are component-scoped. A shared radix-tree node can independently hold Full, SWA, or Mamba data on Host or Device. Each request rebuilds transfers per component, so two requests with different anchors can legitimately load different components from the same node before the first DMA ACK arrives.

A concrete sequence is:

1. Request A has a deep anchor. The shared node is in its Full prefix but outside its SWA window, so it loads `Full(node)` and stores anchor A in the node-wide pending field.
2. Before A's ACK, request B has a nearer anchor. Full is already represented as device-resident by A's commit, but SWA is still Host-only and falls inside B's window, so B loads `SWA(node)`.
3. The second commit checks the same node-wide field and rejects anchor B:

```text
assert pending_anchor in (None, anchor_b)
```

The two operations read different component host pools and are safe to run independently, but the node-wide single-anchor state treats them as conflicting.

## Solution

Scope write-back load-back pins to `(node, component, transfer)`:

- add `ComponentData.load_back_pending_transfer_ids`;
- allocate a unique transfer ID for each H→D operation;
- use the transfer ID as the cache-controller ACK key;
- pin only the component entries actually listed in each `PoolTransfer.nodes_to_load`;
- clear only that transfer ID when its ACK completes;
- allow different components, and multiple transfers, to remain independently pending on one node;
- use only Full-component pending IDs to protect Full Host duplicate reclamation;
- validate pending transfer IDs against live operations in `sanity_check()`.

The existing node-wide field remains untouched for non-write-back behavior. This PR is intentionally separate from #34519, which limits node-wide pending behavior in write-through mode.

## L3 considerations

Storage prefetch can create Host-side nodes or split an existing node before a later H→D ACK. The fix therefore also:

- copies component pending transfer-ID sets when Full/SWA data is redistributed during node split;
- keeps Full duplicate tracking deferred until the corresponding load-back ACK;
- verifies the real file-storage path: L3 → Host insertion → H→D load-back → ACK cleanup → explicit sanity check.

## Tests

Focused regressions cover:

- different anchors loading Full and SWA from the same shared node;
- multiple transfer IDs pending on the same component and cleared independently;
- Full duplicate tracking after an L3-refilled Host copy is loaded back;
- node split inheritance of Full/SWA pending transfer IDs.

Validation:

```text
99 passed, 308 skipped
```

The selected suite includes all load-back tests, storage-prefetch corruption tests, L3 write/prefetch tests, and the new regressions.

The explicit write-back file-L3 round-trip ran across Full and Full+SWA configurations with multiple page/window sizes:

```text
13 passed, 6 skipped
```

Each successful case performs L3 prefetch into a fresh tree, Host→Device load-back, ACK processing, KV-byte verification, and `sanity_check()`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31933353632](https://github.com/sgl-project/sglang/actions/runs/31933353632)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31933353414](https://github.com/sgl-project/sglang/actions/runs/31933353414)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->