### PR TITLE
[AMD] Reuse DSV4 logits workspace for long contexts

### DIFF
--- a/python/sglang/srt/layers/attention/dsv4/indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/indexer.py
@@ -62,6 +62,29 @@ IndexerQuery: TypeAlias = Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
 
 
 _arange_cache = {}
+_aiter_logits_workspaces: Dict[Tuple[str, torch.cuda.Stream], torch.Tensor] = {}
+
+
+def _get_aiter_logits_workspace(
+    total_tokens: int,
+    max_seq_len: int,
+    device: torch.device,
+) -> torch.Tensor:
+    assert total_tokens > 0 and max_seq_len > 0
+    required_numel = total_tokens * max_seq_len
+    if torch.cuda.is_current_stream_capturing():
+        return torch.empty(required_numel, dtype=torch.float32, device=device).view(
+            total_tokens, max_seq_len
+        )
+
+    stream = torch.cuda.current_stream(device)
+    key = (str(device), stream)
+    workspace = _aiter_logits_workspaces.get(key)
+    if workspace is None or workspace.numel() < required_numel:
+        capacity = 1 << max(required_numel - 1, 0).bit_length()
+        workspace = torch.empty(capacity, dtype=torch.float32, device=device)
+        _aiter_logits_workspaces[key] = workspace
+    return workspace[:required_numel].view(total_tokens, max_seq_len)
 
 
 def fp8_paged_mqa_logits_torch(
@@ -150,11 +173,10 @@ def _aiter_fp8_paged_mqa_logits(
     total_tokens = batch_size * next_n
     _sl = seq_lens.squeeze(-1) if seq_lens.dim() == 2 else seq_lens
     kv_block_size = kvcache_fp8.shape[1]
-    logits = torch.empty(
+    logits = _get_aiter_logits_workspace(
         total_tokens,
         max_seq_len,
-        dtype=torch.float32,
-        device=q_fp8.device,
+        q_fp8.device,
     )
     deepgemm_fp8_paged_mqa_logits(
         q_fp8,

--- a/test/registered/unit/layers/test_dsv4_indexer_logits_workspace.py
+++ b/test/registered/unit/layers/test_dsv4_indexer_logits_workspace.py
@@ -1,0 +1,79 @@
+import unittest
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.layers.attention.dsv4.indexer import (
+    _aiter_logits_workspaces,
+    _get_aiter_logits_workspace,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestAiterLogitsWorkspace(unittest.TestCase):
+    def setUp(self):
+        _aiter_logits_workspaces.clear()
+
+    def tearDown(self):
+        _aiter_logits_workspaces.clear()
+
+    def test_reuses_geometric_capacity_per_stream(self):
+        device = torch.device("cpu")
+        stream = object()
+        with (
+            patch("torch.cuda.is_current_stream_capturing", return_value=False),
+            patch("torch.cuda.current_stream", return_value=stream),
+        ):
+            first = _get_aiter_logits_workspace(2, 3, device)
+            same_capacity = _get_aiter_logits_workspace(2, 4, device)
+            grown = _get_aiter_logits_workspace(2, 5, device)
+
+        self.assertEqual(first.shape, (2, 3))
+        self.assertEqual(same_capacity.shape, (2, 4))
+        self.assertEqual(
+            first.untyped_storage().data_ptr(),
+            same_capacity.untyped_storage().data_ptr(),
+        )
+        self.assertEqual(grown.shape, (2, 5))
+        self.assertNotEqual(
+            grown.untyped_storage().data_ptr(), first.untyped_storage().data_ptr()
+        )
+        self.assertEqual(_aiter_logits_workspaces[("cpu", stream)].numel(), 16)
+
+        other_stream = object()
+        with (
+            patch("torch.cuda.is_current_stream_capturing", return_value=False),
+            patch("torch.cuda.current_stream", return_value=other_stream),
+        ):
+            other = _get_aiter_logits_workspace(2, 3, device)
+
+        self.assertNotEqual(
+            other.untyped_storage().data_ptr(), grown.untyped_storage().data_ptr()
+        )
+        self.assertEqual(
+            set(_aiter_logits_workspaces),
+            {("cpu", stream), ("cpu", other_stream)},
+        )
+
+    def test_capture_uses_graph_owned_allocation(self):
+        with (
+            patch("torch.cuda.is_current_stream_capturing", return_value=True),
+            patch("torch.cuda.current_stream") as current_stream,
+        ):
+            result = _get_aiter_logits_workspace(2, 3, torch.device("cpu"))
+
+        self.assertEqual(result.shape, (2, 3))
+        self.assertFalse(_aiter_logits_workspaces)
+        current_stream.assert_not_called()
+
+    def test_rejects_empty_dimensions(self):
+        with self.assertRaises(AssertionError):
+            _get_aiter_logits_workspace(0, 3, torch.device("cpu"))
+        with self.assertRaises(AssertionError):
+            _get_aiter_logits_workspace(2, 0, torch.device("cpu"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

DeepSeek-V4 prefill calls the AITER C4 indexer with an FP32 logits tensor shaped `[total_tokens, max_seq_len]`. For long prompts, `max_seq_len` grows for every chunk, so allocating this tensor on every call leaves a sequence of differently sized blocks in the caching allocator. In DP8 testing, a 756K-token request exhausted device memory after about 376K processed tokens even though the persistent KV pools had enough capacity.

## Modifications

- reuse one eager AITER logits workspace per device and CUDA stream
- grow workspace capacity geometrically to the next power of two and return an exact shaped view
- allocate graph-owned storage during CUDA graph capture instead of retaining an eager workspace
- add CPU CI coverage for reuse, geometric growth, stream isolation, capture behavior, and invalid dimensions

## Accuracy Tests

This changes workspace ownership only. The existing AITER kernel receives the same FP32 dtype, logical shape, and arguments. Patched 756K c1 and c8 requests completed with zero cache hits and zero retractions.

- `test_dsv4_indexer_logits_workspace.py`: 3/3 pass
- `test_dsv4_nonpaged_indexer.py`: 7/7 pass
- MI355X eager workspace smoke: pass

## Speed Tests and Profiling

DeepSeek-V4-Pro, DP8/EP8/TP8, MI355X, original `mem_fraction_static=0.90`:

| Input | Result |
| --- | --- |
| 756K, c1 | 142.350 s TTFT |
| 756K, c8 | 221.501 s median TTFT, 222.085 s P99 |

The unpatched run OOMed after about 376K processed tokens. Lowering `mem_fraction_static` to 0.75 only moved the failure to about 663K. The reusable workspace completed both c1 and c8 at the original 0.90 setting, preserving persistent KV capacity. A patched 128K control showed no TTFT regression.

## Checklist

- [x] Format code with the repository pre-commit hooks.
- [x] Add focused unit tests and run neighboring DSV4 indexer tests.
- [x] Documentation is not required for this internal workspace ownership change.
- [x] Provide long-context validation and performance results.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31934229974](https://github.com/sgl-project/sglang/actions/runs/31934229974)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31934229857](https://github.com/sgl-project/sglang/actions/runs/31934229857)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->