### PR TITLE
[Fix] Llama4 NVFP4 checkpoint loading: fused expert scales and packed q/k permute

### DIFF
--- a/python/sglang/srt/models/mllama4.py
+++ b/python/sglang/srt/models/mllama4.py
@@ -623,7 +623,7 @@ class Llama4ForConditionalGeneration(nn.Module):
 
         def permute(w: torch.Tensor, n_heads: int):
             attn_in = self.language_model.config.head_dim * n_heads
-            attn_out = self.language_model.config.hidden_size
+            attn_out = w.shape[-1]
 
             return (
                 w.view(n_heads, attn_in // n_heads // 2, 2, attn_out)
@@ -632,15 +632,19 @@ class Llama4ForConditionalGeneration(nn.Module):
             )
 
         modules = name.split(".")
+        # 2D block scales share the weight's row layout. Per-tensor scales stay put.
+        is_permutable = modules[-1] == "weight" or (
+            modules[-1] == "weight_scale" and loaded_weight.dim() == 2
+        )
 
         # rotary embeds should be sliced
-        if ("wk" in modules or "k_proj" in modules) and modules[-1] == "weight":
+        if ("wk" in modules or "k_proj" in modules) and is_permutable:
             if _is_cpu:
                 dim = self.language_model.config.original_total_num_kv_heads
             else:
                 dim = self.language_model.config.num_key_value_heads
             loaded_weight = permute(loaded_weight, dim)
-        elif ("wq" in modules or "q_proj" in modules) and modules[-1] == "weight":
+        elif ("wq" in modules or "q_proj" in modules) and is_permutable:
             if _is_cpu:
                 dim = self.language_model.config.original_num_attention_heads
             else:
@@ -895,6 +899,24 @@ class Llama4ForConditionalGeneration(nn.Module):
             expert_id = int(expert_match.group(1))
             # For scale parameters, we can directly set the value
             param.data[expert_id] = loaded_weight
+        elif loaded_weight.dim() == 3:
+            # Fused scales are [E, in_groups, out], the param is [E, out, in_groups].
+            # Mirror _handle_expert_weight_params so gate/up split and sharding match.
+            _, _, shard_id_list = self._transform_expert_name(name)
+            if ".gate_up_proj" in name:
+                loaded_weight_list = loaded_weight.chunk(2, dim=-1)
+            else:  # down_proj
+                loaded_weight_list = [loaded_weight]
+            weight_loader = param.weight_loader
+            for weight_chunk, shard_id in zip(loaded_weight_list, shard_id_list):
+                for expert_id in range(num_experts):
+                    weight_loader(
+                        param,
+                        weight_chunk[expert_id].T,
+                        transformed_name,
+                        shard_id=shard_id,
+                        expert_id=expert_id,
+                    )
         else:
             # No expert ID found - this is a single scale for all experts
             # Load the same scale for all experts


### PR DESCRIPTION
## Motivation

Loading `nvidia/Llama-4-Scout-17B-16E-Instruct-NVFP4` crashes during weight loading on current main. Repro on a DGX Spark (GB10, SM121) at tp=1:

```bash
python3 -m sglang.launch_server \
  --model-path nvidia/Llama-4-Scout-17B-16E-Instruct-NVFP4 \
  --quantization modelopt_fp4 --tp-size 1 \
  --mem-fraction-static 0.70 --context-length 8192
```

It dies at the first expert scale with 0 of 14 shards loaded:

```
Multi-thread loading shards:   0% Completed | 0/14
  File ".../srt/models/mllama4.py", line 902, in _handle_expert_scale_params
    param.data[expert_id] = loaded_weight
RuntimeError: expand(CPUFloat8_e4m3fnType{[16, 512, 5120]}, size=[5120, 512]):
the number of sizes provided (2) must be greater or equal to the number of
dimensions in the tensor (3)
```

Fixing that alone gets you a second crash a bit later:

```
  File ".../srt/models/mllama4.py", line 629, in permute
    w.view(n_heads, attn_in // n_heads // 2, 2, attn_out)
RuntimeError: shape '[8, 64, 2, 5120]' is invalid for input of size 2621440
```

Both come from the loader assuming unquantized HF layouts.

### Fused expert block scales

This checkpoint stores the per-expert block scales fused into one 3D tensor under a name with no expert index. That matches how it stores the fused weights:

```
experts.down_proj_weight_scale:    [16, 512, 5120]   = [E, K/16, N]
experts.gate_up_proj_weight_scale: [16, 320, 16384]  = [E, K/16, 2N]
```

`_handle_expert_scale_params` only knows two cases. Either the name carries an expert index or the value is a per-tensor scalar to broadcast. A fused 3D tensor lands in the broadcast branch and gets assigned into a per-expert `[N, K/16]` slot. Hence the expand error. The param layout from `create_weights` in `modelopt_quant.py` is `[E, N, K/16]` so it is also transposed relative to the checkpoint.

### Packed q/k in the rotary permute

`permute()` takes the trailing dim from `config.hidden_size`. NVFP4 weights arrive packed two values per byte so `k_proj.weight` is `[1024, 2560] uint8` rather than `[1024, 5120]`. The matching 2D q/k `weight_scale` is `[1024, 320]` for k and has the same row layout as the weight. It needs the same permutation. Permuting the weight alone does not crash. It silently misaligns every row's scale.

## Modifications

All of it is in one file: `python/sglang/srt/models/mllama4.py`.

- `_handle_expert_scale_params` now sends 3D scales through the FusedMoE `weight_loader` per expert with a transpose. That mirrors `_handle_expert_weight_params` right below it and uses the same `chunk(2)` gate/up split and the same shard ids. The scales end up sharded exactly the way the weights are. Both existing branches are untouched.
- `permute()` in `permute_qk_weight_for_rotary` now takes the trailing dim from the tensor (`w.shape[-1]`) instead of `config.hidden_size`. The permutation only reorders rows so this is correct for packed and unpacked layouts alike. It now also covers 2D q/k `weight_scale`. 0-dim per-tensor scales are left alone.

There are no import changes and nothing here branches on GPU architecture. This is not SM12x specific. SM121 is the only place I have tested it. I could not test tp>1 on a single GPU box. The 3D scale path goes through the same TP-aware `weight_loader` the weights already use.

## Accuracy Tests

The scale permutation is the half of this that changes numbers instead of crashing, so it wants an accuracy check rather than a crash check. At the element level, skipping it pairs 88.8% of this checkpoint's `layers.0.self_attn.k_proj.weight_scale` with the wrong scale, with a mean relative error of 31.3% over the mismatched elements.

End to end on a DGX Spark (GB10, SM121) at tp=1 with `lmsysorg/sglang:latest` and the patch applied to the in-container source. Loading is not enough to serve on SM12x, so the fix proposed in #34192 is applied on top in every row that runs at all:

| build | gsm8k | invalid |
|---|---|---|
| main | does not load (dies at 0/14 shards) | |
| this PR | 0.925 | 0.000 |
| this PR with the `weight_scale` permutation left out | 0.485 | 0.000 |

That is `sglang.test.few_shot_gsm8k` at its defaults: 5-shot, 200 questions, greedy. The third row is why that half of the fix is there. Nothing crashes and no output is malformed. The answers are simply wrong.

Loading itself goes from dying at 0/14 shards to a clean 198 s load of 65.9 GB of weights.

## Speed Tests and Profiling

Not applicable. This only touches weight loading and the forward path is unchanged.

## Related

- #34192 is the SM12x runtime assert you hit after this fix. Separate bug. Its repro uses `--load-format dummy` so it never exercises checkpoint loading and does not overlap with this PR.
- #9526 and #12649 both previously identified these same two loading problems as part of larger changes (3 and 4 files that also reach into the fused MoE layer and modelopt quantization). Both were closed unmerged and #12649 explicitly as outdated. Neither fix ever landed. This PR is the loading-only subset and it was validated on hardware against the real checkpoint.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

`black` and `ruff` are clean on the changed file. There is no unit test yet because it needs a real NVFP4 checkpoint to be meaningful. I am happy to add a shape-level test for the 3D scale path if you want one. Docs are unchanged because this is not user facing.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31952815636](https://github.com/sgl-project/sglang/actions/runs/31952815636)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31952815513](https://github.com/sgl-project/sglang/actions/runs/31952815513)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->