### PR TITLE
Reject invalid base64 image payloads

### DIFF
--- a/python/sglang/multimodal_gen/runtime/utils/image_io.py
+++ b/python/sglang/multimodal_gen/runtime/utils/image_io.py
@@ -31,9 +31,9 @@ def save_base64_image_to_path(base64_data: str, target_path: str) -> str:
     os.makedirs(os.path.dirname(target_path), exist_ok=True)
 
     try:
-        image_data = base64.b64decode(data)
+        image_data = base64.b64decode(data, validate=True)
     except Exception as exc:
-        raise Exception(f"Failed to decode base64 image: {str(exc)}") from exc
+        raise ValueError(f"Failed to decode base64 image: {exc!s}") from exc
 
     with open(target_path, "wb") as f:
         f.write(image_data)

--- a/test/registered/unit/test_image_io.py
+++ b/test/registered/unit/test_image_io.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+def _load_save_base64_image_to_path():
+    module_path = (
+        Path(__file__).resolve().parents[3]
+        / "python"
+        / "sglang"
+        / "multimodal_gen"
+        / "runtime"
+        / "utils"
+        / "image_io.py"
+    )
+    spec = importlib.util.spec_from_file_location("image_io", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.save_base64_image_to_path
+
+
+def test_save_base64_image_to_path_rejects_invalid_payload(tmp_path):
+    save_base64_image_to_path = _load_save_base64_image_to_path()
+
+    with pytest.raises(ValueError, match="Failed to decode base64 image"):
+        save_base64_image_to_path("data:image/png;base64,@@@@", str(tmp_path / "image"))
+
+    assert not (tmp_path / "image.png").exists()
+
+
+def test_save_base64_image_to_path_writes_valid_payload(tmp_path):
+    save_base64_image_to_path = _load_save_base64_image_to_path()
+
+    saved_path = save_base64_image_to_path(
+        "data:image/png;base64,aW1hZ2U=",
+        str(tmp_path / "image"),
+    )
+
+    assert saved_path == str(tmp_path / "image.png")
+    assert Path(saved_path).read_bytes() == b"image"

--- a/test/registered/unit/test_image_io.py
+++ b/test/registered/unit/test_image_io.py
@@ -3,6 +3,9 @@ import importlib.util
 from pathlib import Path
 
 import pytest
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
 
 
 def _load_save_base64_image_to_path():

--- a/test/registered/unit/test_image_io.py
+++ b/test/registered/unit/test_image_io.py
@@ -3,6 +3,7 @@ import importlib.util
 from pathlib import Path
 
 import pytest
+
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=2, suite="base-a-test-cpu")


### PR DESCRIPTION
Summary:
- Decode image data URIs with base64 validation enabled.
- Raise ValueError for malformed payloads instead of writing best-effort decoded bytes.
- Add focused image_io tests for invalid and valid base64 payloads.

Testing:
- pytest test/registered/unit/test_image_io.py

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33325316146](https://github.com/sgl-project/sglang/actions/runs/33325316146)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33325316047](https://github.com/sgl-project/sglang/actions/runs/33325316047)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33325316101](https://github.com/sgl-project/sglang/actions/runs/33325316101)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->