### PR TITLE
fix: correct Optional[str] annotations in kimik2_detector

### DIFF
--- a/python/sglang/srt/function_call/kimik2_detector.py
+++ b/python/sglang/srt/function_call/kimik2_detector.py
@@ -88,8 +88,8 @@ class KimiK2Detector(BaseFormatDetector):
         self.tool_call_id_counter_regex = re.compile(r"^\d+$")
 
     def _parse_tool_call_id(
-        self, function_id: str, tools: List[Tool], function_args: str = None
-    ):
+        self, function_id: str, tools: List[Tool], function_args: Optional[str] = None
+    ) -> tuple[Optional[str], int]:
         """Parse a tool call ID into (function_name, call_index).
 
         Standard format: "functions.ReadFile:0" → ("ReadFile", 0)
@@ -113,7 +113,7 @@ class KimiK2Detector(BaseFormatDetector):
         logger.warning("Unexpected tool_call_id format: %s", function_id)
         return None, 0
 
-    def _infer_tool_name(self, tools: List[Tool], function_args: str = None):
+    def _infer_tool_name(self, tools: List[Tool], function_args: Optional[str] = None) -> Optional[str]:
         """Infer function name when the model omits it (bare counter ID).
 
         Matches argument keys against tool parameter schemas, preferring the


### PR DESCRIPTION
## Summary

Two methods in KimiK2Detector used `str = None` which is a mypy error (PEP 484 treats None as a distinct type from str).

## Changes

- `_parse_tool_call_id`: Changed `function_args: str = None` to `Optional[str]` and added return type `tuple[Optional[str], int]`
- `_infer_tool_name`: Changed `function_args: str = None` to `Optional[str]` and added return type `Optional[str]`

These are type-correctness fixes with no runtime behavior change.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31953721359](https://github.com/sgl-project/sglang/actions/runs/31953721359)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31953722122](https://github.com/sgl-project/sglang/actions/runs/31953722122)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->