### PR TITLE
[AMD] Use HIP batched copies for HiCache write-back

### DIFF
--- a/python/sglang/kernels/jit/csrc/kvcacheio/staged_write_back.cuh
+++ b/python/sglang/kernels/jit/csrc/kvcacheio/staged_write_back.cuh
@@ -8,30 +8,27 @@
 
 namespace sglang {
 
-#if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 12080
+#if defined(USE_ROCM) && defined(HIP_VERSION) && HIP_VERSION >= 70100000
+using MemcpyBatchPtr = void*;
+using HipMemcpyBatchAsyncFn =
+    hipError_t (*)(void**, void**, size_t*, size_t, hipMemcpyAttributes*, size_t*, size_t, size_t*, hipStream_t);
+
+inline auto get_hip_memcpy_batch_async() -> HipMemcpyBatchAsyncFn {
+  static HipMemcpyBatchAsyncFn hip_memcpy_batch_async = []() {
+    void* symbol = dlsym(RTLD_DEFAULT, "hipMemcpyBatchAsync");
+    return reinterpret_cast<HipMemcpyBatchAsyncFn>(symbol);
+  }();
+  return hip_memcpy_batch_async;
+}
+#elif defined(CUDA_VERSION) && CUDA_VERSION >= 12080
 #if CUDA_VERSION >= 13000
-using CudaMemcpyBatchPtr = const void*;
+using MemcpyBatchPtr = const void*;
 using CudaMemcpyBatchAsyncFn = cudaError_t (*)(
-    CudaMemcpyBatchPtr*,
-    CudaMemcpyBatchPtr*,
-    const size_t*,
-    size_t,
-    cudaMemcpyAttributes*,
-    size_t*,
-    size_t,
-    cudaStream_t);
+    MemcpyBatchPtr*, MemcpyBatchPtr*, const size_t*, size_t, cudaMemcpyAttributes*, size_t*, size_t, cudaStream_t);
 #else
-using CudaMemcpyBatchPtr = void*;
+using MemcpyBatchPtr = void*;
 using CudaMemcpyBatchAsyncFn = cudaError_t (*)(
-    CudaMemcpyBatchPtr*,
-    CudaMemcpyBatchPtr*,
-    size_t*,
-    size_t,
-    cudaMemcpyAttributes*,
-    size_t*,
-    size_t,
-    size_t*,
-    cudaStream_t);
+    MemcpyBatchPtr*, MemcpyBatchPtr*, size_t*, size_t, cudaMemcpyAttributes*, size_t*, size_t, size_t*, cudaStream_t);
 #endif
 
 inline auto get_cuda_memcpy_batch_async() -> CudaMemcpyBatchAsyncFn {
@@ -44,8 +41,8 @@ inline auto get_cuda_memcpy_batch_async() -> CudaMemcpyBatchAsyncFn {
 
 inline auto call_cuda_memcpy_batch_async(
     CudaMemcpyBatchAsyncFn copy_fn,
-    CudaMemcpyBatchPtr* dsts,
-    CudaMemcpyBatchPtr* srcs,
+    MemcpyBatchPtr* dsts,
+    MemcpyBatchPtr* srcs,
     size_t* sizes,
     size_t count,
     cudaMemcpyAttributes* attrs,
@@ -99,15 +96,22 @@ inline bool try_copy_page_first_pages_batch(
     int64_t page_size,
     int device_id,
     cudaStream_t stream) {
-#if defined(USE_ROCM) || !defined(CUDA_VERSION) || (CUDA_VERSION < 12080)
+#if (defined(USE_ROCM) && (!defined(HIP_VERSION) || HIP_VERSION < 70100000)) || \
+    (!defined(USE_ROCM) && (!defined(CUDA_VERSION) || CUDA_VERSION < 12080))
   return false;
 #else
   host::RuntimeCheck(src_ptrs.size() == dst_ptrs.size(), "Source and destination tensors must have the same count");
   constexpr size_t kLargeCopyThresholdBytes = 128 * 1024;
-  thread_local std::vector<CudaMemcpyBatchPtr> batch_srcs;
-  thread_local std::vector<CudaMemcpyBatchPtr> batch_dsts;
+  thread_local std::vector<MemcpyBatchPtr> batch_srcs;
+  thread_local std::vector<MemcpyBatchPtr> batch_dsts;
   thread_local std::vector<size_t> batch_sizes;
 
+#if defined(USE_ROCM)
+  auto copy_fn = get_hip_memcpy_batch_async();
+  if (copy_fn == nullptr) {
+    return false;
+  }
+#else
   int driver_version = 0;
   cudaError_t driver_version_err = cudaDriverGetVersion(&driver_version);
   if (driver_version_err != cudaSuccess || driver_version < 12080) {
@@ -118,6 +122,7 @@ inline bool try_copy_page_first_pages_batch(
   if (copy_fn == nullptr) {
     return false;
   }
+#endif
 
   const size_t num_copies = static_cast<size_t>(src_ptrs.size()) * static_cast<size_t>(num_pages);
   batch_srcs.clear();
@@ -155,6 +160,16 @@ inline bool try_copy_page_first_pages_batch(
     return false;
   }
 
+#if defined(USE_ROCM)
+  size_t fail_idx = std::numeric_limits<size_t>::max();
+  hipError_t err = copy_fn(
+      batch_dsts.data(), batch_srcs.data(), batch_sizes.data(), num_copies, nullptr, nullptr, 0, &fail_idx, stream);
+  if (err == hipErrorNotSupported || err == hipErrorInvalidValue) {
+    (void)hipGetLastError();
+    return false;
+  }
+  host::RuntimeCheck(err == hipSuccess, "hipMemcpyBatchAsync failed. error=", hipGetErrorString(err));
+#else
   std::vector<size_t> attrs_idxs(1, 0);
   cudaMemcpyAttributes attrs{};
   attrs.srcAccessOrder = cudaMemcpySrcAccessOrderStream;
@@ -179,6 +194,7 @@ inline bool try_copy_page_first_pages_batch(
     return false;
   }
   host::RuntimeCheck(err == cudaSuccess, "cudaMemcpyBatchAsync failed. error=", cudaGetErrorString(err));
+#endif
   return true;
 #endif
 }

--- a/python/sglang/kernels/jit/csrc/kvcacheio/staged_write_back.cuh
+++ b/python/sglang/kernels/jit/csrc/kvcacheio/staged_write_back.cuh
@@ -2,6 +2,8 @@
 
 #include "hicache.cuh"
 #include "relayout.cuh"
+#include <atomic>
+#include <cstdio>
 #include <dlfcn.h>
 #include <limits>
 #include <vector>
@@ -10,17 +12,37 @@ namespace sglang {
 
 #if defined(USE_ROCM) && defined(HIP_VERSION) && HIP_VERSION >= 70100000
 using MemcpyBatchPtr = void*;
-using HipMemcpyBatchAsyncFn =
-    hipError_t (*)(void**, void**, size_t*, size_t, hipMemcpyAttributes*, size_t*, size_t, size_t*, hipStream_t);
+using HipMemcpyBatchAsyncFn = hipError_t (*)(
+    MemcpyBatchPtr*, MemcpyBatchPtr*, size_t*, size_t, hipMemcpyAttributes*, size_t*, size_t, size_t*, hipStream_t);
 
 inline auto get_hip_memcpy_batch_async() -> HipMemcpyBatchAsyncFn {
+  // HIP intentionally uses symbol availability as its runtime capability gate.
   static HipMemcpyBatchAsyncFn hip_memcpy_batch_async = []() {
     void* symbol = dlsym(RTLD_DEFAULT, "hipMemcpyBatchAsync");
     return reinterpret_cast<HipMemcpyBatchAsyncFn>(symbol);
   }();
   return hip_memcpy_batch_async;
 }
-#elif defined(CUDA_VERSION) && CUDA_VERSION >= 12080
+
+inline void warn_hip_batch_fallback_once(hipError_t err, size_t fail_idx) {
+  static std::atomic_flag warned = ATOMIC_FLAG_INIT;
+  if (warned.test_and_set(std::memory_order_relaxed)) {
+    return;
+  }
+  if (fail_idx == std::numeric_limits<size_t>::max()) {
+    std::fprintf(
+        stderr,
+        "SGLang HiCache warning: hipMemcpyBatchAsync failed (%s); falling back to per-page copies.\n",
+        hipGetErrorString(err));
+  } else {
+    std::fprintf(
+        stderr,
+        "SGLang HiCache warning: hipMemcpyBatchAsync failed at copy %zu (%s); falling back to per-page copies.\n",
+        fail_idx,
+        hipGetErrorString(err));
+  }
+}
+#elif !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 12080
 #if CUDA_VERSION >= 13000
 using MemcpyBatchPtr = const void*;
 using CudaMemcpyBatchAsyncFn = cudaError_t (*)(
@@ -101,6 +123,10 @@ inline bool try_copy_page_first_pages_batch(
   return false;
 #else
   host::RuntimeCheck(src_ptrs.size() == dst_ptrs.size(), "Source and destination tensors must have the same count");
+  const size_t num_copies = static_cast<size_t>(src_ptrs.size()) * static_cast<size_t>(num_pages);
+  if (num_copies == 0) {
+    return true;
+  }
   constexpr size_t kLargeCopyThresholdBytes = 128 * 1024;
   thread_local std::vector<MemcpyBatchPtr> batch_srcs;
   thread_local std::vector<MemcpyBatchPtr> batch_dsts;
@@ -124,7 +150,6 @@ inline bool try_copy_page_first_pages_batch(
   }
 #endif
 
-  const size_t num_copies = static_cast<size_t>(src_ptrs.size()) * static_cast<size_t>(num_pages);
   batch_srcs.clear();
   batch_dsts.clear();
   batch_sizes.clear();
@@ -165,6 +190,7 @@ inline bool try_copy_page_first_pages_batch(
   hipError_t err = copy_fn(
       batch_dsts.data(), batch_srcs.data(), batch_sizes.data(), num_copies, nullptr, nullptr, 0, &fail_idx, stream);
   if (err == hipErrorNotSupported || err == hipErrorInvalidValue) {
+    warn_hip_batch_fallback_once(err, fail_idx);
     (void)hipGetLastError();
     return false;
   }

--- a/python/sglang/kernels/jit/csrc/kvcacheio/staged_write_back.cuh
+++ b/python/sglang/kernels/jit/csrc/kvcacheio/staged_write_back.cuh
@@ -144,6 +144,14 @@ inline bool try_copy_page_first_pages_batch(
     return false;
   }
 
+  // CUDA 13 removed failIdx; the dlsym'd ABI follows the loaded libcudart,
+  // while the function pointer signature follows the compile-time headers.
+  static int runtime_version = 0;
+  static const cudaError_t runtime_version_err = cudaRuntimeGetVersion(&runtime_version);
+  if (runtime_version_err != cudaSuccess || runtime_version / 1000 != CUDA_VERSION / 1000) {
+    return false;
+  }
+
   auto copy_fn = get_cuda_memcpy_batch_async();
   if (copy_fn == nullptr) {
     return false;

--- a/test/registered/kernels/ops/kvcache/test_hicache_page_first_write_back.py
+++ b/test/registered/kernels/ops/kvcache/test_hicache_page_first_write_back.py
@@ -49,11 +49,12 @@ def _token_indices_for_pages(
     pages: torch.Tensor,
     device: str = DEVICE,
     dtype: torch.dtype = torch.int64,
+    page_size: int = PAGE_SIZE,
 ) -> torch.Tensor:
     parts = [
         torch.arange(
-            int(page) * PAGE_SIZE,
-            (int(page) + 1) * PAGE_SIZE,
+            int(page) * page_size,
+            (int(page) + 1) * page_size,
             device=device,
             dtype=dtype,
         )
@@ -62,14 +63,14 @@ def _token_indices_for_pages(
     return torch.cat(parts, dim=0)
 
 
-def _pinned_host_pool(host_pool_cls, **kwargs):
+def _pinned_host_pool(host_pool_cls, page_size: int = PAGE_SIZE, **kwargs):
     original_alloc = ALLOC_MEMORY_FUNCS[DEVICE]
     ALLOC_MEMORY_FUNCS[DEVICE] = alloc_with_pin_memory
     try:
         return host_pool_cls(
             host_to_device_ratio=2.0,
             host_size=0,
-            page_size=PAGE_SIZE,
+            page_size=page_size,
             pin_memory=True,
             device="cpu",
             **kwargs,
@@ -85,13 +86,15 @@ def _fill_with_offset(tensor: torch.Tensor, offset: int) -> None:
     tensor.copy_(data + offset)
 
 
-def _assert_pages_equal(host_ref, device_ref, host_pages, device_pages) -> None:
+def _assert_pages_equal(
+    host_ref, device_ref, host_pages, device_pages, page_size: int = PAGE_SIZE
+) -> None:
     for host_page, device_page in zip(host_pages.tolist(), device_pages.tolist()):
-        host_start = host_page * PAGE_SIZE
-        device_start = device_page * PAGE_SIZE
+        host_start = host_page * page_size
+        device_start = device_page * page_size
         assert torch.equal(
-            host_ref[host_start : host_start + PAGE_SIZE].cpu(),
-            device_ref[device_start : device_start + PAGE_SIZE].cpu(),
+            host_ref[host_start : host_start + page_size].cpu(),
+            device_ref[device_start : device_start + page_size].cpu(),
         )
 
 
@@ -178,11 +181,11 @@ def _run_mha(element_dim: int, page_count: int) -> None:
         )
 
 
-def _run_mla(element_dim: int, page_count: int) -> None:
-    pool_size = PAGE_SIZE * (page_count + 8)
+def _run_mla(element_dim: int, page_count: int, page_size: int = PAGE_SIZE) -> None:
+    pool_size = page_size * (page_count + 8)
     device_pool = MLATokenToKVPool(
         size=pool_size,
-        page_size=PAGE_SIZE,
+        page_size=page_size,
         kv_lora_rank=element_dim - 64,
         qk_rope_head_dim=64,
         dtype=torch.bfloat16,
@@ -191,7 +194,10 @@ def _run_mla(element_dim: int, page_count: int) -> None:
         enable_memory_saver=False,
     )
     host_pool = _pinned_host_pool(
-        MLATokenToKVPoolHost, device_pool=device_pool, layout="page_first"
+        MLATokenToKVPoolHost,
+        page_size=page_size,
+        device_pool=device_pool,
+        layout="page_first",
     )
     assert can_use_write_back_jit_kernel(
         element_size=element_dim * host_pool.dtype.itemsize,
@@ -203,8 +209,10 @@ def _run_mla(element_dim: int, page_count: int) -> None:
 
     device_pages = torch.arange(2, 2 + page_count, device=DEVICE, dtype=torch.int64)
     host_pages = torch.arange(page_count, 0, -1, dtype=torch.int64)
-    device_indices = _token_indices_for_pages(device_pages)
-    host_indices = _token_indices_for_pages(host_pages, device="cpu")
+    device_indices = _token_indices_for_pages(device_pages, page_size=page_size)
+    host_indices = _token_indices_for_pages(
+        host_pages, device="cpu", page_size=page_size
+    )
     assert not host_indices.is_cuda
 
     host_pool.backup_from_device_all_layer(
@@ -218,6 +226,7 @@ def _run_mla(element_dim: int, page_count: int) -> None:
             device_pool.kv_buffer[layer_id],
             host_pages,
             device_pages,
+            page_size,
         )
 
     if not host_pool.can_use_jit:
@@ -226,7 +235,7 @@ def _run_mla(element_dim: int, page_count: int) -> None:
         device_pool.kv_buffer[layer_id].zero_()
 
     load_pages = torch.arange(1, 1 + page_count, device=DEVICE, dtype=torch.int64)
-    load_indices = _token_indices_for_pages(load_pages)
+    load_indices = _token_indices_for_pages(load_pages, page_size=page_size)
     host_indices_device = host_indices.to(DEVICE)
     for layer_id in range(NUM_LAYERS):
         host_pool.load_to_device_per_layer(
@@ -240,6 +249,7 @@ def _run_mla(element_dim: int, page_count: int) -> None:
             device_pool.kv_buffer[layer_id],
             host_pages,
             load_pages,
+            page_size,
         )
 
 
@@ -253,6 +263,11 @@ def test_page_first_staged_write_back_mha(element_dim: int, page_count: int) -> 
 @pytest.mark.parametrize("page_count", PAGE_COUNTS)
 def test_page_first_staged_write_back_mla(element_dim: int, page_count: int) -> None:
     _run_mla(element_dim, page_count)
+
+
+@pytest.mark.skipif(not is_hip(), reason="ROCm batch-copy coverage.")
+def test_page_first_staged_write_back_mla_rocm_batch_copy() -> None:
+    _run_mla(element_dim=576, page_count=4, page_size=256)
 
 
 if __name__ == "__main__":

--- a/test/registered/kernels/ops/kvcache/test_hicache_page_first_write_back.py
+++ b/test/registered/kernels/ops/kvcache/test_hicache_page_first_write_back.py
@@ -98,11 +98,11 @@ def _assert_pages_equal(
         )
 
 
-def _run_mha(element_dim: int, page_count: int) -> None:
-    pool_size = PAGE_SIZE * (page_count + 8)
+def _run_mha(element_dim: int, page_count: int, page_size: int = PAGE_SIZE) -> None:
+    pool_size = page_size * (page_count + 8)
     device_pool = MHATokenToKVPool(
         size=pool_size,
-        page_size=PAGE_SIZE,
+        page_size=page_size,
         head_num=element_dim // 128,
         head_dim=128,
         dtype=torch.bfloat16,
@@ -111,7 +111,10 @@ def _run_mha(element_dim: int, page_count: int) -> None:
         enable_memory_saver=False,
     )
     host_pool = _pinned_host_pool(
-        MHATokenToKVPoolHost, device_pool=device_pool, layout="page_first"
+        MHATokenToKVPoolHost,
+        page_size=page_size,
+        device_pool=device_pool,
+        layout="page_first",
     )
     assert can_use_write_back_jit_kernel(
         element_size=element_dim * host_pool.dtype.itemsize,
@@ -125,10 +128,12 @@ def _run_mha(element_dim: int, page_count: int) -> None:
 
     device_pages = torch.arange(2, 2 + page_count, device=DEVICE, dtype=torch.int64)
     host_pages = torch.arange(page_count, 0, -1, dtype=torch.int64)
-    device_indices = _token_indices_for_pages(device_pages)
+    device_indices = _token_indices_for_pages(device_pages, page_size=page_size)
     # host_indices stay on the CPU: this is the case the staged JIT kernel must
     # accept (kDLCPU / kDLGPUHost destination indices).
-    host_indices = _token_indices_for_pages(host_pages, device="cpu")
+    host_indices = _token_indices_for_pages(
+        host_pages, device="cpu", page_size=page_size
+    )
     assert not host_indices.is_cuda
 
     host_pool.backup_from_device_all_layer(
@@ -142,12 +147,14 @@ def _run_mha(element_dim: int, page_count: int) -> None:
             device_pool.k_buffer[layer_id],
             host_pages,
             device_pages,
+            page_size,
         )
         _assert_pages_equal(
             host_pool.v_data_refs[layer_id],
             device_pool.v_buffer[layer_id],
             host_pages,
             device_pages,
+            page_size,
         )
 
     # Load path (prefix-cache hit): exercises the hicache.cuh load matchers.
@@ -158,7 +165,7 @@ def _run_mha(element_dim: int, page_count: int) -> None:
         device_pool.v_buffer[layer_id].zero_()
 
     load_pages = torch.arange(1, 1 + page_count, device=DEVICE, dtype=torch.int64)
-    load_indices = _token_indices_for_pages(load_pages)
+    load_indices = _token_indices_for_pages(load_pages, page_size=page_size)
     host_indices_device = host_indices.to(DEVICE)
     for layer_id in range(NUM_LAYERS):
         host_pool.load_to_device_per_layer(
@@ -172,12 +179,14 @@ def _run_mha(element_dim: int, page_count: int) -> None:
             device_pool.k_buffer[layer_id],
             host_pages,
             load_pages,
+            page_size,
         )
         _assert_pages_equal(
             host_pool.v_data_refs[layer_id],
             device_pool.v_buffer[layer_id],
             host_pages,
             load_pages,
+            page_size,
         )
 
 
@@ -265,9 +274,12 @@ def test_page_first_staged_write_back_mla(element_dim: int, page_count: int) -> 
     _run_mla(element_dim, page_count)
 
 
-@pytest.mark.skipif(not is_hip(), reason="ROCm batch-copy coverage.")
-def test_page_first_staged_write_back_mla_rocm_batch_copy() -> None:
+def test_page_first_staged_write_back_mla_large_page() -> None:
     _run_mla(element_dim=576, page_count=4, page_size=256)
+
+
+def test_page_first_staged_write_back_mha_large_page() -> None:
+    _run_mha(element_dim=512, page_count=4, page_size=256)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Reduce CPU-side submission overhead for ROCm HiCache write-back by batching per-page D2H copies with hipMemcpyBatchAsync.

## Motivation

ROCm staged HiCache write-back currently submits one `hipMemcpyAsync` per page even though HIP 7.1+ provides `hipMemcpyBatchAsync`. This reduces CPU-side submission overhead for page-first D2H write-back while preserving the existing fallback on older runtimes or unsupported calls.

## Modifications

- Dynamically resolve `hipMemcpyBatchAsync` on ROCm 7.1+.
- Submit large page copies as one batch with null attributes, as required by the HIP API.
- Retain per-page fallback for old runtimes, missing symbols, and unsupported calls.
- Add a ROCm large-page correctness case that exceeds the existing 128 KiB batch threshold.

## Accuracy Tests

MI355X, ROCm 7.2.26015:

- `pytest -q -s test/registered/kernels/ops/kvcache/test_hicache_page_first_write_back.py`: 13 passed.
- `rocprofv3` confirms the large-page case issues `hipMemcpyBatchAsync`.

## Speed Tests and Profiling

Base-A / Candidate / Base-B on one idle MI355X, 16 MHA/MLA shapes, 8/32 layers, 1/4/16/64 pages, page size 256, 40 repetitions per shape:

- Host submission latency: 3.27% lower geomean; all 16 shapes improved.
- End-to-end synchronized D2H latency: +0.01% geomean (neutral, as expected because transferred bytes are unchanged).
- Largest individual submission reduction: 7.01%.

Additional Base-A / Candidate / Base-B at 61 layers on the same MI355X, 8 MHA/MLA shapes, 1/4/16/64 pages, page size 256, 40 repetitions per shape:

- Host submission latency: 5.82% lower geomean across all 8 shapes.
- MHA submission latency: 10.54% lower geomean. The 1-page case was 6.79% higher, while the 4/16/64-page cases were 8.21% / 18.63% / 19.70% lower.
- MLA submission latency: 0.85% lower geomean (effectively neutral; per-shape changes ranged from 1.46% higher to 3.23% lower).
- End-to-end synchronized D2H latency: -0.009% geomean (neutral).

## Checklist

- [x] Format code with pre-commit.
- [x] Add and run unit tests.
- [x] Provide correctness and speed results.
- [ ] Run repository CI.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32011332671](https://github.com/sgl-project/sglang/actions/runs/32011332671)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32011332516](https://github.com/sgl-project/sglang/actions/runs/32011332516)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->