### PR TITLE
Fix sconv track refresh on graph capture

### DIFF
--- a/python/sglang/srt/layers/attention/linear/inkling_sconv_backend.py
+++ b/python/sglang/srt/layers/attention/linear/inkling_sconv_backend.py
@@ -445,16 +445,21 @@ class InklingShortConvAttnBackend(ShortConvAttnBackend):
             forward_batch.mamba_track_seqlens = self._graph_track_inert_seqlens[:rows]
         rows = forward_batch.batch_size
         query_start_loc = self.sconv_metadata.query_start_loc
+        # A capture batch is built directly rather than through
+        # ForwardBatch.init_new, so it carries no prefix lengths; its rows are
+        # masked off, so zeros keep the indices in bounds. A replayed or eager
+        # batch always has them, and must still fail rather than track against
+        # an invented prefix.
+        prefix_lens = forward_batch.extend_prefix_lens
+        if prefix_lens is None and on_graph_path:
+            prefix_lens = torch.zeros_like(forward_batch.mamba_track_seqlens)
         live = min(
             rows,
             forward_batch.mamba_track_seqlens.shape[0],
-            forward_batch.extend_prefix_lens.shape[0],
+            prefix_lens.shape[0],
         )
 
-        lens_to_track = (
-            forward_batch.mamba_track_seqlens[:live]
-            - forward_batch.extend_prefix_lens[:live]
-        )
+        lens_to_track = forward_batch.mamba_track_seqlens[:live] - prefix_lens[:live]
         chunk_aligned = (
             lens_to_track // self.mamba_cache_chunk_size
         ) * self.mamba_cache_chunk_size


### PR DESCRIPTION
## Motivation

Serving Inkling with MTP crashes at startup while capturing the draft-extend CUDA graph, with `forward_batch.extend_prefix_lens` being `None` in `_refresh_track_conv_indices`. Fixes https://github.com/sgl-project/sglang/issues/35039.

The read has been there since https://github.com/sgl-project/sglang/pull/33023, but it was unreachable: a batch without tracking metadata returned early. https://github.com/sgl-project/sglang/pull/34043 changed the graph path to fill inert track buffers and continue, so that this capture still launches the track scatter, and that made the read reachable for the first time. Only `prefill_cuda_graph_runner` populates `extend_prefix_lens`; a capture batch is constructed directly instead of through `ForwardBatch.init_new`, and none of the speculative capture runners fill it, so on the EAGLE draft-extend capture it is `None`.

The substitution is gated on `on_graph_path` rather than on `extend_prefix_lens is None` alone. A live batch always carries prefix lengths, so a `None` outside capture means something is genuinely wrong and should still raise rather than track against an invented prefix. Only DRAFT_EXTEND_V2 reaches this function; DSpark and DFlash run target-verify, which does not call it.

## Accuracy

Inkling with MTP and CUDA graphs enabled (`disable_cuda_graph=False`), one GPU, `--speculative-num-steps 2 --speculative-eagle-topk 1 --speculative-num-draft-tokens 3 --enable-multi-layer-eagle --speculative-use-rejection-sampling`:

```
                                              starts   crash   /generate   accept len
main                                            no      crash      -            -
https://github.com/sgl-project/sglang/pull/34043 sconv hunk reverted                     yes       0        200      1.73 / 2.08
guard on `extend_prefix_lens is None`          yes       0        200      1.82 / 1.98
guard on the inert-fill branch                  no      crash      -            -
this PR (`None` and `on_graph_path`)           yes       0        200      1.73 / 1.85
```

The revert row identifies the regression; it is not a candidate fix, since https://github.com/sgl-project/sglang/pull/34043 fixes a real state corruption. The third row works but relaxes the invariant: any future live path with a missing prefix would silently track against zeros. The fourth row is instructive and is why the guard is not keyed on "we just filled the inert buffers" — the inert fill writes `mamba_track_mask` back onto the batch, and a capture reuses one `ForwardBatch` across warmup and capture, so the second call takes the other branch.

A per-commit guard for MTP under the unified radix cache is tracked in https://github.com/sgl-project/sglang/issues/34899 and is blocked on this fix.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31959114997](https://github.com/sgl-project/sglang/actions/runs/31959114997)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #31959461399](https://github.com/sgl-project/sglang/actions/runs/31959461399)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->