### PR TITLE
[AMD] Enable staged HiCache write-back for DeepSeek V4

### DIFF
--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
@@ -33,11 +33,49 @@ from sglang.srt.mem_cache.hicache_storage import (
 from sglang.srt.mem_cache.l2_transfer import L2Transfer
 from sglang.srt.mem_cache.memory_pool_host import HostPoolGroup, PoolEntry
 from sglang.srt.mem_cache.pool_host.mha import MHATokenToKVPoolHost
+from sglang.srt.utils import is_hip
 
 if TYPE_CHECKING:
     from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
 
 logger = logging.getLogger(__name__)
+_is_hip = is_hip()
+
+
+def _validate_rocm_kernel_host_pools(
+    mem_pool_host: Any,
+    io_backend: str,
+    new_entry: Optional[PoolEntry] = None,
+) -> None:
+    if not _is_hip or io_backend != "kernel":
+        return
+
+    if isinstance(mem_pool_host, HostPoolGroup):
+        pools = [(entry.name.value, entry.host_pool) for entry in mem_pool_host.entries]
+    else:
+        pools = [(type(mem_pool_host).__name__, mem_pool_host)]
+    if new_entry is not None:
+        pools.append((new_entry.name.value, new_entry.host_pool))
+    layer_first = [name for name, pool in pools if pool.layout == "layer_first"]
+    if layer_first:
+        raise RuntimeError(
+            "ROCm HiCache with io_backend='kernel' does not support "
+            "layout='layer_first': the GPU transfer kernel dereferences host "
+            f"CPU virtual addresses for: {', '.join(layer_first)}. Use "
+            "page_first with staged JIT write-back or use the direct IO backend."
+        )
+    unsupported = [
+        name
+        for name, pool in pools
+        if pool.layout == "page_first" and not pool.can_use_write_back_jit
+    ]
+    if unsupported:
+        raise RuntimeError(
+            "ROCm HiCache with io_backend='kernel' and layout='page_first' "
+            "requires staged JIT write-back for every host pool; unavailable "
+            f"for: {', '.join(unsupported)}. The non-JIT fallback dereferences "
+            "host CPU virtual addresses from a GPU kernel."
+        )
 
 
 class StorageOperation(BaseStorageOperation):
@@ -115,6 +153,7 @@ class HybridCacheController(BaseHiCacheController):
     ):
         startup_storage_backend = storage_backend
         self.extra_host_mem_release_queues: dict[PoolName, Queue[torch.Tensor]] = {}
+        _validate_rocm_kernel_host_pools(mem_pool_host, io_backend)
         super().__init__(
             token_to_kv_pool_allocator=token_to_kv_pool_allocator,
             mem_pool_host=mem_pool_host,
@@ -172,6 +211,9 @@ class HybridCacheController(BaseHiCacheController):
     def register_host_pool_entry(self, entry: PoolEntry) -> None:
         if not isinstance(self.mem_pool_host, HostPoolGroup):
             raise TypeError("Dynamic HiCache sidecars require HostPoolGroup.")
+        _validate_rocm_kernel_host_pools(
+            self.mem_pool_host, self.io_backend, new_entry=entry
+        )
         self.mem_pool_host.add_entry(entry)
         if not entry.is_primary_index_anchor:
             self.extra_host_mem_release_queues.setdefault(entry.name, Queue())

--- a/python/sglang/srt/mem_cache/memory_pool_host.py
+++ b/python/sglang/srt/mem_cache/memory_pool_host.py
@@ -50,15 +50,19 @@ if _is_npu:
 logger = logging.getLogger(__name__)
 
 
-def _tensor_version(tensor: torch.Tensor) -> int:
-    return 0 if tensor.is_inference() else tensor._version
+def _tensor_version(tensor: torch.Tensor) -> Optional[int]:
+    return None if tensor.is_inference() else tensor._version
 
 
 def _cached_hip_load_indices(owner, host_indices, device_indices, convert):
     """Reuse CPU page rows across the per-layer calls of one L2 load."""
     host_version = _tensor_version(host_indices)
     device_version = _tensor_version(device_indices)
-    cache = getattr(owner, "_hip_load_indices_cache", None)
+    if host_version is None or device_version is None:
+        host_rows, device_rows = convert()
+        return host_rows.cpu(), device_rows.cpu()
+
+    cache = owner._hip_load_indices_cache
     if (
         cache is not None
         and cache[0]() is host_indices
@@ -71,6 +75,8 @@ def _cached_hip_load_indices(owner, host_indices, device_indices, convert):
     host_rows, device_rows = convert()
     host_rows = host_rows.cpu()
     device_rows = device_rows.cpu()
+    # Replace the immutable tuple atomically so concurrent readers cannot see
+    # a partially updated cache entry.
     owner._hip_load_indices_cache = (
         weakref.ref(host_indices),
         weakref.ref(device_indices),
@@ -823,6 +829,7 @@ class DeepSeekV4PagedHostPool(HiSparseHostPoolMixin, HostKVCache):
         self.start_layer = 0
         self.end_layer = self.layer_num
         self.lock = threading.RLock()
+        self._hip_load_indices_cache = None
 
         self.device_buffers = device_buffers
         self.gpu_device = device_buffers[0].device if device_buffers else device
@@ -1027,6 +1034,10 @@ class DeepSeekV4PagedHostPool(HiSparseHostPoolMixin, HostKVCache):
                     element_size=self.item_bytes,
                 )
             else:
+                if _is_hip:
+                    raise RuntimeError(
+                        f"{self.pool_name} requires staged JIT write-back on ROCm"
+                    )
                 transfer_kv_all_layer_mla_lf_pf(
                     src_layers=self.device_ptrs,
                     dst=self.kv_buffer,
@@ -1252,6 +1263,7 @@ class DeepSeekV4StateHostPool(HostKVCache):
         self.start_layer = 0
         self.end_layer = self.layer_num
         self.lock = threading.RLock()
+        self._hip_load_indices_cache = None
 
         self.ring_size = 0
         self.state_page_bytes = 0
@@ -1449,6 +1461,10 @@ class DeepSeekV4StateHostPool(HostKVCache):
                     element_size=self.state_page_bytes,
                 )
             else:
+                if _is_hip:
+                    raise RuntimeError(
+                        f"{self.pool_name} requires staged JIT write-back on ROCm"
+                    )
                 transfer_kv_all_layer_mla_lf_pf(
                     src_layers=self.device_ptrs,
                     dst=self.kv_buffer,
@@ -1831,6 +1847,7 @@ class DSAIndexerPoolHost(HostKVCache):
         self.can_use_write_back_jit = False
         self._init_write_back_staging_buffers()
         self.lock = threading.RLock()
+        self._hip_load_indices_cache = None
         self.clear()
 
     def get_size_per_token(self):
@@ -2111,6 +2128,10 @@ class DSAIndexerPoolHost(HostKVCache):
                         element_size=self.indexer_page_stride_size,
                     )
                 else:
+                    if _is_hip:
+                        raise RuntimeError(
+                            "DSA indexer requires staged JIT write-back on ROCm"
+                        )
                     transfer_kv_all_layer_mla_lf_pf(
                         src_layers=self.index_k_device_ptrs,
                         dst=self.index_k_with_scale_buffer,

--- a/python/sglang/srt/mem_cache/memory_pool_host.py
+++ b/python/sglang/srt/mem_cache/memory_pool_host.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import threading
+import weakref
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
@@ -47,6 +48,38 @@ if _is_npu:
     pass
 
 logger = logging.getLogger(__name__)
+
+
+def _tensor_version(tensor: torch.Tensor) -> int:
+    return 0 if tensor.is_inference() else tensor._version
+
+
+def _cached_hip_load_indices(owner, host_indices, device_indices, convert):
+    """Reuse CPU page rows across the per-layer calls of one L2 load."""
+    host_version = _tensor_version(host_indices)
+    device_version = _tensor_version(device_indices)
+    cache = getattr(owner, "_hip_load_indices_cache", None)
+    if (
+        cache is not None
+        and cache[0]() is host_indices
+        and cache[1]() is device_indices
+        and cache[2] == host_version
+        and cache[3] == device_version
+    ):
+        return cache[4], cache[5]
+
+    host_rows, device_rows = convert()
+    host_rows = host_rows.cpu()
+    device_rows = device_rows.cpu()
+    owner._hip_load_indices_cache = (
+        weakref.ref(host_indices),
+        weakref.ref(device_indices),
+        host_version,
+        device_version,
+        host_rows,
+        device_rows,
+    )
+    return host_rows, device_rows
 
 
 from sglang.srt.mem_cache.pool_host import HostKVCache
@@ -872,7 +905,9 @@ class DeepSeekV4PagedHostPool(HiSparseHostPoolMixin, HostKVCache):
         if self.layout != "page_first" or (_is_npu or _is_xpu or _is_mps):
             return
 
-        self.can_use_write_back_jit = _is_cuda and can_use_write_back_jit_kernel(
+        self.can_use_write_back_jit = (
+            _is_cuda or _is_hip
+        ) and can_use_write_back_jit_kernel(
             element_size=self.item_bytes * self.dtype.itemsize,
         )
         staging_page_capacity = min(self.num_host_pages, _WRITE_BACK_STAGING_PAGE_CHUNK)
@@ -1047,9 +1082,36 @@ class DeepSeekV4PagedHostPool(HiSparseHostPoolMixin, HostKVCache):
                 dst_indices=device_indices.to(dtype=torch.int64),
             )
             return
+        if (
+            io_backend == "kernel"
+            and self.layout == "page_first"
+            and _is_hip
+            and self.device_buffers[layer_id].is_cuda
+        ):
+            # HIP-registered mmap storage can have distinct CPU and GPU aliases.
+            # Runtime copies resolve that mapping; a GPU kernel using data_ptr()
+            # directly can fault on the CPU virtual address.
+            host_rows, device_rows = _cached_hip_load_indices(
+                self,
+                host_indices,
+                device_indices,
+                lambda: (
+                    self._to_page_indices(host_indices),
+                    self._to_page_indices(device_indices),
+                ),
+            )
+            transfer_kv_per_layer_direct_pf_lf(
+                src_ptrs=[self.kv_buffer.unsqueeze(2)],
+                dst_ptrs=[self.device_buffers[layer_id]],
+                src_indices=host_rows,
+                dst_indices=device_rows,
+                layer_id=layer_id,
+                page_size=1,
+            )
+            return
+
         host_rows = self._to_page_indices(host_indices)
         device_rows = self._to_page_indices(device_indices)
-
         if io_backend == "kernel" and self.layout == "layer_first":
             transfer_kv_per_layer_mla(
                 src=self.data_refs[layer_id],
@@ -1306,7 +1368,9 @@ class DeepSeekV4StateHostPool(HostKVCache):
         if self.layout != "page_first" or (_is_npu or _is_xpu or _is_mps):
             return
 
-        self.can_use_write_back_jit = _is_cuda and can_use_write_back_jit_kernel(
+        self.can_use_write_back_jit = (
+            _is_cuda or _is_hip
+        ) and can_use_write_back_jit_kernel(
             element_size=self.state_page_bytes * self.dtype.itemsize,
         )
         staging_page_capacity = min(self.num_host_pages, _WRITE_BACK_STAGING_PAGE_CHUNK)
@@ -1427,6 +1491,31 @@ class DeepSeekV4StateHostPool(HostKVCache):
     ):
         if host_indices is None or device_indices is None:
             return
+        if (
+            io_backend == "kernel"
+            and self.layout == "page_first"
+            and _is_hip
+            and self.device_page_views[layer_id].is_cuda
+        ):
+            host_rows, device_rows = _cached_hip_load_indices(
+                self,
+                host_indices,
+                device_indices,
+                lambda: (
+                    self._to_page_indices(host_indices),
+                    self._to_page_indices(device_indices),
+                ),
+            )
+            transfer_kv_per_layer_direct_pf_lf(
+                src_ptrs=[self.kv_buffer.unsqueeze(2)],
+                dst_ptrs=[self.device_page_views[layer_id]],
+                src_indices=host_rows,
+                dst_indices=device_rows,
+                layer_id=layer_id,
+                page_size=1,
+            )
+            return
+
         host_rows = self._to_page_indices(host_indices)
         device_rows = self._to_page_indices(device_indices)
         if io_backend == "kernel" and self.layout == "layer_first":
@@ -1800,7 +1889,9 @@ class DSAIndexerPoolHost(HostKVCache):
         if self.layout != "page_first" or (_is_npu or _is_xpu or _is_mps):
             return
 
-        self.can_use_write_back_jit = _is_cuda and can_use_write_back_jit_kernel(
+        self.can_use_write_back_jit = (
+            _is_cuda or _is_hip
+        ) and can_use_write_back_jit_kernel(
             element_size=self.indexer_page_stride_size * self.indexer_dtype.itemsize,
         )
         staging_page_capacity = min(
@@ -1851,10 +1942,33 @@ class DSAIndexerPoolHost(HostKVCache):
         host_layer_id = layer_id if is_draft else self._host_layer_index(layer_id)
         device_layer_id = 0 if is_draft else layer_id
 
+        target_buffer = device_pool.index_k_with_scale_buffer[device_layer_id]
+        use_kernel = io_backend == "kernel" and self.indexer_page_stride_size % 8 == 0
+        if (
+            use_kernel
+            and self.layout == "page_first"
+            and _is_hip
+            and target_buffer.is_cuda
+        ):
+            host_page_indices, device_page_indices = _cached_hip_load_indices(
+                self,
+                host_indices,
+                device_indices,
+                lambda: self._get_indexer_page_indices(host_indices, device_indices),
+            )
+            transfer_kv_per_layer_direct_pf_lf(
+                src_ptrs=[self.index_k_with_scale_buffer],
+                dst_ptrs=[target_buffer],
+                src_indices=host_page_indices,
+                dst_indices=device_page_indices,
+                layer_id=host_layer_id,
+                page_size=1,
+            )
+            return
+
         host_page_indices, device_page_indices = self._get_indexer_page_indices(
             host_indices, device_indices
         )
-        use_kernel = io_backend == "kernel" and self.indexer_page_stride_size % 8 == 0
         if use_kernel:
             if self.layout == "layer_first":
                 transfer_kv_per_layer_mla(
@@ -1867,7 +1981,7 @@ class DSAIndexerPoolHost(HostKVCache):
             elif self.layout == "page_first":
                 transfer_kv_per_layer_mla_pf_lf(
                     src=self.index_k_with_scale_buffer,
-                    dst=device_pool.index_k_with_scale_buffer[device_layer_id],
+                    dst=target_buffer,
                     src_indices=host_page_indices,
                     dst_indices=device_page_indices,
                     layer_id=host_layer_id,

--- a/test/registered/kernels/ops/kvcache/test_hicache_page_first_write_back.py
+++ b/test/registered/kernels/ops/kvcache/test_hicache_page_first_write_back.py
@@ -14,7 +14,17 @@ import pytest
 import torch
 
 from sglang.kernels.ops.kvcache.hicache import can_use_write_back_jit_kernel
-from sglang.srt.mem_cache.memory_pool import MHATokenToKVPool, MLATokenToKVPool
+from sglang.srt.mem_cache.deepseek_v4_compress_state import CompressStatePool
+from sglang.srt.mem_cache.memory_pool import (
+    DSATokenToKVPool,
+    MHATokenToKVPool,
+    MLATokenToKVPool,
+)
+from sglang.srt.mem_cache.memory_pool_host import (
+    DeepSeekV4PagedHostPool,
+    DeepSeekV4StateHostPool,
+    DSAIndexerPoolHost,
+)
 from sglang.srt.mem_cache.pool_host.common import (
     ALLOC_MEMORY_FUNCS,
     alloc_with_pin_memory,
@@ -25,7 +35,7 @@ from sglang.srt.utils import is_cuda, is_hip, is_npu, is_xpu
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=15, stage="base-b", runner_config="1-gpu-large")
-register_amd_ci(est_time=30, stage="jit-kernel-unit", runner_config="amd")
+register_amd_ci(est_time=90, stage="jit-kernel-unit", runner_config="amd")
 
 pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available()
@@ -49,11 +59,12 @@ def _token_indices_for_pages(
     pages: torch.Tensor,
     device: str = DEVICE,
     dtype: torch.dtype = torch.int64,
+    page_size: int = PAGE_SIZE,
 ) -> torch.Tensor:
     parts = [
         torch.arange(
-            int(page) * PAGE_SIZE,
-            (int(page) + 1) * PAGE_SIZE,
+            int(page) * page_size,
+            (int(page) + 1) * page_size,
             device=device,
             dtype=dtype,
         )
@@ -62,14 +73,14 @@ def _token_indices_for_pages(
     return torch.cat(parts, dim=0)
 
 
-def _pinned_host_pool(host_pool_cls, **kwargs):
+def _pinned_host_pool(host_pool_cls, page_size: int = PAGE_SIZE, **kwargs):
     original_alloc = ALLOC_MEMORY_FUNCS[DEVICE]
     ALLOC_MEMORY_FUNCS[DEVICE] = alloc_with_pin_memory
     try:
         return host_pool_cls(
             host_to_device_ratio=2.0,
             host_size=0,
-            page_size=PAGE_SIZE,
+            page_size=page_size,
             pin_memory=True,
             device="cpu",
             **kwargs,
@@ -83,6 +94,11 @@ def _fill_with_offset(tensor: torch.Tensor, offset: int) -> None:
         tensor.numel(), device=tensor.device, dtype=tensor.dtype
     ).view_as(tensor)
     tensor.copy_(data + offset)
+
+
+def _fill_byte_rows(tensor: torch.Tensor, offset: int) -> None:
+    data = torch.arange(tensor.numel(), device=tensor.device, dtype=torch.int64)
+    tensor.copy_(((data + offset) % 251).to(torch.uint8).view_as(tensor))
 
 
 def _assert_pages_equal(host_ref, device_ref, host_pages, device_pages) -> None:
@@ -253,6 +269,223 @@ def test_page_first_staged_write_back_mha(element_dim: int, page_count: int) -> 
 @pytest.mark.parametrize("page_count", PAGE_COUNTS)
 def test_page_first_staged_write_back_mla(element_dim: int, page_count: int) -> None:
     _run_mla(element_dim, page_count)
+
+
+def test_dsv4_paged_host_pool_staged_roundtrip() -> None:
+    page_size = 64
+    page_count = 8
+    layer_num = 2
+    item_bytes = 37440
+    device_buffers = [
+        torch.empty(page_count, item_bytes, dtype=torch.uint8, device=DEVICE)
+        for _ in range(layer_num)
+    ]
+    for layer_id, buffer in enumerate(device_buffers):
+        _fill_byte_rows(buffer, layer_id * 37)
+
+    host_pool = DeepSeekV4PagedHostPool(
+        pool_name="dsv4-c4-test",
+        device_buffers=device_buffers,
+        item_bytes=item_bytes,
+        num_host_pages=page_count,
+        slot_page_size=page_size,
+        layout="page_first",
+        pin_memory=True,
+    )
+    assert host_pool.can_use_write_back_jit
+
+    host_pages = torch.tensor([0, 1], dtype=torch.int64)
+    source_pages = torch.tensor([2, 3], dtype=torch.int64, device=DEVICE)
+    host_indices = _token_indices_for_pages(
+        host_pages, device="cpu", page_size=page_size
+    )
+    source_indices = _token_indices_for_pages(source_pages, page_size=page_size)
+    expected = [buffer[source_pages].cpu().clone() for buffer in device_buffers]
+
+    host_pool.backup_from_device_all_layer(None, host_indices, source_indices, "kernel")
+    torch.cuda.synchronize()
+    for layer_id in range(layer_num):
+        assert torch.equal(
+            host_pool.kv_buffer[host_pages, layer_id], expected[layer_id]
+        )
+
+    target_pages = torch.tensor([5, 6], dtype=torch.int64, device=DEVICE)
+    target_indices = _token_indices_for_pages(target_pages, page_size=page_size)
+    for buffer in device_buffers:
+        buffer[target_pages].zero_()
+    host_indices_device = host_indices.to(DEVICE)
+    for layer_id in range(layer_num):
+        host_pool.load_to_device_per_layer(
+            None,
+            host_indices_device,
+            target_indices,
+            layer_id,
+            "kernel",
+        )
+    torch.cuda.synchronize()
+    for layer_id, buffer in enumerate(device_buffers):
+        assert torch.equal(buffer[target_pages].cpu(), expected[layer_id])
+
+    mutated_target_pages = torch.tensor([6, 7], dtype=torch.int64, device=DEVICE)
+    target_indices.copy_(
+        _token_indices_for_pages(mutated_target_pages, page_size=page_size)
+    )
+    for buffer in device_buffers:
+        buffer[mutated_target_pages].zero_()
+    for layer_id in range(layer_num):
+        host_pool.load_to_device_per_layer(
+            None,
+            host_indices_device,
+            target_indices,
+            layer_id,
+            "kernel",
+        )
+    torch.cuda.synchronize()
+    for layer_id, buffer in enumerate(device_buffers):
+        assert torch.equal(buffer[mutated_target_pages].cpu(), expected[layer_id])
+
+
+def test_dsv4_state_host_pool_staged_roundtrip() -> None:
+    swa_page_size = 64
+    page_count = 8
+    ring_size = 8
+    layer_num = 2
+    state_pools = [
+        CompressStatePool(
+            size=page_count * ring_size,
+            ring_size=ring_size,
+            overlap=True,
+            head_dim=64,
+            dtype=torch.bfloat16,
+            device=DEVICE,
+            enable_memory_saver=False,
+            ratio=4,
+            swa_page_size=swa_page_size,
+        )
+        for _ in range(layer_num)
+    ]
+    for layer_id, state_pool in enumerate(state_pools):
+        _fill_byte_rows(
+            state_pool.kv_score_buffer.kv_score.view(torch.uint8), layer_id * 43
+        )
+
+    host_pool = DeepSeekV4StateHostPool(
+        pool_name="dsv4-state-test",
+        state_pools=state_pools,
+        num_host_pages=page_count,
+        swa_page_size=swa_page_size,
+        layout="page_first",
+        pin_memory=True,
+    )
+    assert host_pool.can_use_write_back_jit
+
+    host_pages = torch.tensor([0, 1], dtype=torch.int64)
+    source_pages = torch.tensor([2, 3], dtype=torch.int64, device=DEVICE)
+    host_indices = _token_indices_for_pages(
+        host_pages, device="cpu", page_size=swa_page_size
+    )
+    source_indices = _token_indices_for_pages(source_pages, page_size=swa_page_size)
+    expected = [
+        page_view[source_pages].cpu().clone()
+        for page_view in host_pool.device_page_views
+    ]
+
+    host_pool.backup_from_device_all_layer(None, host_indices, source_indices, "kernel")
+    torch.cuda.synchronize()
+    for layer_id in range(layer_num):
+        assert torch.equal(
+            host_pool.kv_buffer[host_pages, layer_id], expected[layer_id]
+        )
+
+    target_pages = torch.tensor([5, 6], dtype=torch.int64, device=DEVICE)
+    target_indices = _token_indices_for_pages(target_pages, page_size=swa_page_size)
+    for page_view in host_pool.device_page_views:
+        page_view[target_pages].zero_()
+    host_indices_device = host_indices.to(DEVICE)
+    for layer_id in range(layer_num):
+        host_pool.load_to_device_per_layer(
+            None,
+            host_indices_device,
+            target_indices,
+            layer_id,
+            "kernel",
+        )
+    torch.cuda.synchronize()
+    for layer_id, page_view in enumerate(host_pool.device_page_views):
+        assert torch.equal(page_view[target_pages].cpu(), expected[layer_id])
+
+
+def test_dsv4_dsa_indexer_host_pool_staged_roundtrip() -> None:
+    page_size = 64
+    page_count = 8
+    layer_num = 2
+    device_pool = DSATokenToKVPool(
+        size=page_count * page_size,
+        page_size=page_size,
+        kv_lora_rank=128,
+        dtype=torch.bfloat16,
+        qk_rope_head_dim=32,
+        layer_num=layer_num,
+        device=DEVICE,
+        index_head_dim=128,
+        enable_memory_saver=False,
+        kv_cache_dim=576,
+    )
+    anchor_host = _pinned_host_pool(
+        MLATokenToKVPoolHost,
+        page_size=page_size,
+        device_pool=device_pool,
+        layout="page_first",
+        override_kv_cache_dim=device_pool.kv_cache_dim,
+    )
+    host_pool = DSAIndexerPoolHost(
+        device_pool=device_pool,
+        anchor_host=anchor_host,
+        layout="page_first",
+        pin_memory=True,
+    )
+    assert host_pool.can_use_write_back_jit
+
+    for layer_id, buffer in enumerate(device_pool.index_k_with_scale_buffer):
+        _fill_byte_rows(buffer, layer_id * 47)
+
+    host_pages = torch.tensor([0, 1], dtype=torch.int64)
+    source_pages = torch.tensor([2, 3], dtype=torch.int64, device=DEVICE)
+    host_indices = _token_indices_for_pages(
+        host_pages, device="cpu", page_size=page_size
+    )
+    source_indices = _token_indices_for_pages(source_pages, page_size=page_size)
+    expected = [
+        buffer[source_pages].cpu().clone()
+        for buffer in device_pool.index_k_with_scale_buffer
+    ]
+
+    host_pool.backup_from_device_all_layer(
+        device_pool, host_indices, source_indices, "kernel"
+    )
+    torch.cuda.synchronize()
+    for layer_id in range(layer_num):
+        assert torch.equal(
+            host_pool.index_k_with_scale_buffer[host_pages, layer_id, 0],
+            expected[layer_id],
+        )
+
+    target_pages = torch.tensor([5, 6], dtype=torch.int64, device=DEVICE)
+    target_indices = _token_indices_for_pages(target_pages, page_size=page_size)
+    for buffer in device_pool.index_k_with_scale_buffer:
+        buffer[target_pages].zero_()
+    host_indices_device = host_indices.to(DEVICE)
+    for layer_id in range(layer_num):
+        host_pool.load_to_device_per_layer(
+            device_pool,
+            host_indices_device,
+            target_indices,
+            layer_id,
+            "kernel",
+        )
+    torch.cuda.synchronize()
+    for layer_id, buffer in enumerate(device_pool.index_k_with_scale_buffer):
+        assert torch.equal(buffer[target_pages].cpu(), expected[layer_id])
 
 
 if __name__ == "__main__":

--- a/test/registered/kernels/ops/kvcache/test_hicache_page_first_write_back.py
+++ b/test/registered/kernels/ops/kvcache/test_hicache_page_first_write_back.py
@@ -312,7 +312,7 @@ def test_dsv4_paged_host_pool_staged_roundtrip() -> None:
     target_pages = torch.tensor([5, 6], dtype=torch.int64, device=DEVICE)
     target_indices = _token_indices_for_pages(target_pages, page_size=page_size)
     for buffer in device_buffers:
-        buffer[target_pages].zero_()
+        buffer[target_pages] = 0
     host_indices_device = host_indices.to(DEVICE)
     for layer_id in range(layer_num):
         host_pool.load_to_device_per_layer(
@@ -331,7 +331,7 @@ def test_dsv4_paged_host_pool_staged_roundtrip() -> None:
         _token_indices_for_pages(mutated_target_pages, page_size=page_size)
     )
     for buffer in device_buffers:
-        buffer[mutated_target_pages].zero_()
+        buffer[mutated_target_pages] = 0
     for layer_id in range(layer_num):
         host_pool.load_to_device_per_layer(
             None,
@@ -400,7 +400,7 @@ def test_dsv4_state_host_pool_staged_roundtrip() -> None:
     target_pages = torch.tensor([5, 6], dtype=torch.int64, device=DEVICE)
     target_indices = _token_indices_for_pages(target_pages, page_size=swa_page_size)
     for page_view in host_pool.device_page_views:
-        page_view[target_pages].zero_()
+        page_view[target_pages] = 0
     host_indices_device = host_indices.to(DEVICE)
     for layer_id in range(layer_num):
         host_pool.load_to_device_per_layer(
@@ -473,7 +473,7 @@ def test_dsv4_dsa_indexer_host_pool_staged_roundtrip() -> None:
     target_pages = torch.tensor([5, 6], dtype=torch.int64, device=DEVICE)
     target_indices = _token_indices_for_pages(target_pages, page_size=page_size)
     for buffer in device_pool.index_k_with_scale_buffer:
-        buffer[target_pages].zero_()
+        buffer[target_pages] = 0
     host_indices_device = host_indices.to(DEVICE)
     for layer_id in range(layer_num):
         host_pool.load_to_device_per_layer(

--- a/test/registered/unit/mem_cache/test_hicache_staged_write_back_dispatch.py
+++ b/test/registered/unit/mem_cache/test_hicache_staged_write_back_dispatch.py
@@ -16,6 +16,7 @@ from sglang.srt.mem_cache.hicache_storage import (
 )
 from sglang.srt.mem_cache.hybrid_cache.hybrid_cache_controller import (
     HybridCacheController,
+    _validate_rocm_kernel_host_pools,
 )
 from sglang.srt.mem_cache.l2_transfer import L2Transfer, L2TransferEngine
 from sglang.srt.mem_cache.memory_pool_host import (
@@ -37,6 +38,9 @@ register_cpu_ci(est_time=3, suite="base-a-test-cpu")
 MEMORY_POOL_HOST_MODULE = "sglang.srt.mem_cache.memory_pool_host"
 MHA_POOL_HOST_MODULE = "sglang.srt.mem_cache.pool_host.mha"
 MLA_POOL_HOST_MODULE = "sglang.srt.mem_cache.pool_host.mla"
+HYBRID_CACHE_CONTROLLER_MODULE = (
+    "sglang.srt.mem_cache.hybrid_cache.hybrid_cache_controller"
+)
 
 
 def _indices(start: int, end: int) -> torch.Tensor:
@@ -85,6 +89,32 @@ def _host_group_stub(captured, *, can_use_write_back_jit: bool) -> SimpleNamespa
         anchor_entry=entries[0],
         entry_map={entry.name: entry for entry in entries},
     )
+
+
+def _validation_host_group(
+    *, layout: str, capabilities: tuple[bool, ...]
+) -> HostPoolGroup:
+    names = (PoolName.KV, PoolName.SWA, PoolName.DEEPSEEK_V4_C4)
+    entries = []
+    for index, can_use_write_back_jit in enumerate(capabilities):
+        host_pool = SimpleNamespace(
+            layout=layout,
+            page_size=64,
+            device="cpu",
+            size=64,
+            logical_size=64,
+            can_use_write_back_jit=can_use_write_back_jit,
+        )
+        entries.append(
+            PoolEntry(
+                name=names[index],
+                host_pool=host_pool,
+                device_pool=None,
+                layer_mapper=lambda layer_id: layer_id,
+                is_primary_index_anchor=index == 0,
+            )
+        )
+    return HostPoolGroup(entries)
 
 
 def _cpu_staged_lf_pf_copy(
@@ -194,6 +224,58 @@ class TestHiCacheStagedWriteBackDispatch(CustomTestCase):
     def setUp(self):
         transfer_module._timing_events_supported.cache_clear()
         self.addCleanup(transfer_module._timing_events_supported.cache_clear)
+
+    def test_rocm_kernel_page_first_requires_staged_jit_for_every_pool(self):
+        host_group = _validation_host_group(
+            layout="page_first", capabilities=(True, False, True)
+        )
+        with mock.patch(f"{HYBRID_CACHE_CONTROLLER_MODULE}._is_hip", True):
+            with self.assertRaisesRegex(RuntimeError, "staged JIT write-back.*swa"):
+                _validate_rocm_kernel_host_pools(host_group, "kernel")
+
+    def test_rocm_kernel_layer_first_fails_at_startup(self):
+        host_group = _validation_host_group(
+            layout="layer_first", capabilities=(True, True)
+        )
+        with mock.patch(f"{HYBRID_CACHE_CONTROLLER_MODULE}._is_hip", True):
+            with self.assertRaisesRegex(RuntimeError, "layout='layer_first'"):
+                _validate_rocm_kernel_host_pools(host_group, "kernel")
+
+    def test_rocm_safe_host_pool_configurations_pass_startup(self):
+        page_first = _validation_host_group(
+            layout="page_first", capabilities=(True, True, True)
+        )
+        layer_first = _validation_host_group(
+            layout="layer_first", capabilities=(False, False)
+        )
+        with mock.patch(f"{HYBRID_CACHE_CONTROLLER_MODULE}._is_hip", True):
+            _validate_rocm_kernel_host_pools(page_first, "kernel")
+            _validate_rocm_kernel_host_pools(layer_first, "direct")
+        with mock.patch(f"{HYBRID_CACHE_CONTROLLER_MODULE}._is_hip", False):
+            _validate_rocm_kernel_host_pools(layer_first, "kernel")
+
+    def test_rocm_dynamic_host_pool_is_validated_before_registration(self):
+        host_group = _validation_host_group(
+            layout="page_first", capabilities=(True, True)
+        )
+        entry = PoolEntry(
+            name=PoolName.DEEPSEEK_V4_C4,
+            host_pool=SimpleNamespace(
+                layout="page_first", can_use_write_back_jit=False
+            ),
+            device_pool=None,
+            layer_mapper=lambda layer_id: layer_id,
+        )
+        controller = HybridCacheController.__new__(HybridCacheController)
+        controller.mem_pool_host = host_group
+        controller.io_backend = "kernel"
+        controller.enable_storage = False
+
+        with mock.patch(f"{HYBRID_CACHE_CONTROLLER_MODULE}._is_hip", True):
+            with self.assertRaisesRegex(RuntimeError, "deepseek_v4_c4"):
+                controller.register_host_pool_entry(entry)
+
+        self.assertNotIn(PoolName.DEEPSEEK_V4_C4, host_group.entry_map)
 
     @staticmethod
     def _start_writing(controller):


### PR DESCRIPTION
## Motivation

DeepSeek-V4 hybrid HiCache uses specialized paged, compress-state, and DSA indexer host pools. Their staged page-first write-back remained gated to native CUDA even though the shared JIT kernel supports HIP. Simply opening that gate is not sufficient on ROCm: on MI355X with ROCm 7.2.26015, mmap-backed memory registered with HIP has a device alias different from its CPU `data_ptr()`, so the existing PF-to-LF GPU load kernel faults while dereferencing the CPU virtual address.

## Modifications

- Enable staged write-back on ROCm for `DeepSeekV4PagedHostPool`, `DeepSeekV4StateHostPool`, and `DSAIndexerPoolHost`.
- Use HIP runtime H2D copies for page-first loads from registered host storage, allowing the runtime to resolve the GPU-visible host alias. CUDA retains the existing AOT kernel path.
- Cache converted CPU page-row indices across the layers of one L2 load, with tensor identity/version invalidation.
- Validate ROCm HiCache host-pool capabilities during controller construction and dynamic sidecar registration. `kernel + page_first` now fails at startup if any pool lacks staged JIT write-back, and `kernel + layer_first` is rejected because its GPU kernel dereferences host CPU virtual addresses. The existing runtime checks remain as defense in depth.
- Add byte-exact D2H/H2D round-trip coverage for C4/C128-style paged rows, compress-state ring rows, and DSA indexer rows, including in-place index mutation.

### Scope and index routing

This PR supports the DeepSeek-V4 `kernel + page_first` host pools listed above; it is not an allocator-wide fix for every kernel that can dereference registered mmap storage. Generic MLA/MHA page-first loads and ROCm kernel layer-first transfers require separate safe paths; the latter is rejected at startup by this PR.

`HybridCacheController` already routes write-back indices per pool through `supports_per_pool_backup_indices`: pools with staged JIT keep CPU host indices as required by `staged_write_back.cuh`, while non-staged pools move their indices to the GPU. This PR marks the three DeepSeek-V4 pools as staged-capable and completes that existing contract; it does not replace the controller with a new group-wide routing rule.

## Accuracy Tests

MI355X, ROCm 7.2.26015:

- Registered mmap pointer probe: CPU range `0x71c149b50000..0x71c149b58000`; `hipHostGetDevicePointer()` returned `0x717fd0020000`; `hipPointerGetAttributes()` reported the CPU host pointer and the distinct device pointer.
- The parent PF-to-LF kernel faulted at `0x71c149b53000`, inside that CPU range, confirming that the GPU kernel dereferenced the CPU VA rather than the registered device alias.
- Staged GPU suite: 15 passed.
- HostPoolGroup dispatch suite: 19 passed, 1 skipped, including startup rejection and dynamic-sidecar validation cases.
- DSV4 HiSparse suite: 16 passed, 2 skipped.
- DSA host-pool suite: 1 passed, 2 skipped, 2 subtests passed.

Real DeepSeek-V4-Pro TP8 service smokes (`kernel/page_first`, 32K L1, HiCache ratio 2):

- `write_through` operator-path smoke: every completed insertion eagerly backed up the prefix, deliberately forcing staged D2H without depending on eviction victim selection. Five distinct 8K prefixes filled/evicted L1; replaying the first returned `cached_tokens_details={device: 0, host: 7936}`. The initial and host-tier replay output token were both 65.
- `write_back` policy smoke on PR head `1dea66d`: after three cold fills, a seed-0 replay returned `cached_tokens_details={device: 7936, host: 0}`, proving the prefix remained device-only before eviction. Two additional cold fills exceeded L1; replaying seed 1 returned `cached_tokens_details={device: 0, host: 7936}`, proving eviction-triggered backup and load-back. The initial and host-tier replay output token were both 65.
- Both services started successfully on 8x MI355X. Live JIT produced staged modules for 65,536-byte C4 rows, 8,448-byte indexer rows, and 2,048-byte C128 rows.
- Final log scans found no memory-access fault, traceback, runtime error, OOM, write-back drop, or host-pressure backup failure.

## Speed Tests and Profiling

Direct-A / staged candidate / Direct-B on one idle MI355X, C4-style rows, 8 layers, 1/4/16/64 pages, 40 repetitions per shape:

- D2H synchronized completion latency: 73.37% lower geomean.
- H2D synchronized completion latency: 8.98% lower geomean.
- D2H host submission latency: 84.02% lower geomean.
- H2D host submission latency: 23.23% lower geomean.

Additional 61-layer scale check on the same MI355X, C4-style rows, 1/4/16/64 pages, 10 repetitions per shape:

- D2H synchronized completion latency: 90.24% lower geomean; every shape improved by 87.27%-91.42%.
- D2H host submission latency: 97.57% lower geomean; every shape improved by 90.67%-99.02%.
- H2D synchronized completion latency: 8.64% lower geomean; per-shape reductions were 24.01% / 3.35% / 2.68% / 2.51%.
- H2D host submission latency: 14.94% lower geomean, but the 16/64-page shapes were 1.99% / 3.61% higher. The H2D submission benefit therefore does not hold uniformly at larger page counts.

## Checklist

- [x] Format code with pre-commit.
- [x] Add and run focused unit/kernel tests.
- [x] Validate a real TP8 host-tier hit.
- [x] Provide paired performance results.
- [ ] Run repository CI.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32138879425](https://github.com/sgl-project/sglang/actions/runs/32138879425)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32138879088](https://github.com/sgl-project/sglang/actions/runs/32138879088)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->