### PR TITLE
fix(attention): convert flashinfer base-2 LSE to natural log in chunked-prefix MLA merge

### DIFF
--- a/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
@@ -202,6 +202,13 @@ class FlashInferMhaChunkKVRunner:
                 sm_scale=layer.scaling,
                 logits_soft_cap=logits_soft_cap,
             )
+        if forward_batch.mha_return_lse or forward_batch.attn_attend_prefix_cache:
+            # flashinfer's forward_return_lse yields base-2 LSE, while
+            # sgl_kernel.merge_state_v2 (chunked-prefix merge) expects the
+            # natural-log LSE — convert at this boundary.
+            out, lse = o
+            lse = lse * 0.6931471805599453  # ln(2)
+            return out, lse
         return o
 
 


### PR DESCRIPTION
## Motivation

`FlashInferMhaChunkKVRunner.forward` feeds the per-layer LSE of MLA chunked-prefix attention into `sgl_kernel.merge_state_v2`. FlashInfer's `BatchPrefillWithRaggedKVCacheWrapper.forward_return_lse` returns the LSE in base 2 (`log2(sum(exp2(x)))`; this is flashinfer's documented internal convention, see flashinfer-ai/flashinfer#2113). `merge_state_v2` computes the merge weights with the natural-log convention (`exp(lse)`). Feeding base-2 LSE into a base-e merge weights the two attention states incorrectly.

Measured effect of the mismatch (unit-level, chunked-prefix merge of an extend state and a prefix-chunk state vs an fp32 torch-native single-pass reference): max |error| = 0.105 at prefix length 4096. After converting base-2 to natural log at the runner boundary: max |error| = 0.0005.

Affected configurations: MLA models with the flashinfer attention backend, on extend batches that take the chunked-prefix path (`sum(extend_prefix_lens) >= SGLANG_CHUNKED_PREFIX_CACHE_THRESHOLD`, default 8192, i.e. above one-shot chunk capacity). The models routed through this merge are the users of `DeepseekMHAForwardMixin` / `DeepseekV2AttentionMLA`: `deepseek_v2.py` (DeepSeek-V2/V3/R1/V3.1, and the DSA variant — `_chunked_prefix_attn_mha` merges with `merge_state_v2` on the DSA path too), `deepseek_nextn.py`, `bailing_moe_v3.py`, `glm4_moe_lite.py`, and `sarvam_moe.py`. `deepseek_v4.py` is not affected (own MQA/sparse attention stack; no LSE state merge). The FA3 backend path is not affected: FA3 returns natural-log LSE, and its `merge_state_v2` call sites in `flashattention_backend.py` are consistent. The fallback `merge_state_triton` is also natural-log (`tl.exp`/`tl.log`), so both merge implementations share the convention flashinfer violates. vLLM avoids this class of bug with explicit per-backend `lse_base_on_e` flags.

Related: flashinfer-ai/flashinfer#4547 adds an opt-in `return_lse_base_on_e` to the ragged wrapper. When that lands, this conversion can be replaced by passing `return_lse_base_on_e=True` at the two wrapper call sites.

## Modifications

`python/sglang/srt/layers/attention/flashinfer_mla_backend.py` (+7 lines): in `FlashInferMhaChunkKVRunner.forward`, when the call returns an LSE (`forward_batch.mha_return_lse` or `forward_batch.attn_attend_prefix_cache`), multiply the wrapper's LSE by `ln(2)` before returning, converting base-2 LSE to natural-log LSE for the downstream `merge_state_v2` merge. No other path is changed; non-chunked prefill and decode are untouched.

## Accuracy Tests

Unit-level (standalone repro driving the actual cutlass ragged wrappers and `sgl_kernel.merge_state_v2` on an NVIDIA B300):

- Full-sequence ragged call vs fp32 torch-native attention: 0.0003 max error.
- Chunked merge with the raw base-2 LSE: 0.105 max error vs fp32 reference (prefix=4096).
- Chunked merge with the natural-log conversion applied: 0.0005 max error vs fp32 reference.

Serving-level, validated on the BailingMoeV3 hybrid MLA model against a Ling-3.0-tiny deployment (this stack predates the model's upstream availability; the model is not loadable on current main, so the serving validation ran on the pull/33561-based image with the identical patch):

- Bit-exact temperature-0 outputs vs the unpatched reference server on short, 4k-token, and 6k-token prompts.
- Prefix-carrying multi-turn batches produce coherent outputs; the residual delta vs the reference server (0.036-0.087 |dlogprob|) matches the reference path's own instance-to-instance noise floor.

## Speed Tests and Profiling

The fix does not change which kernels run, only the merge arithmetic. On the hybrid model above, routing prefix-carrying prefill batches through this (now numerically correct) chunked path replaces the fa2 paged MLA kernel with the cutlass ragged FMHA: 231.7 ms to 34.9 ms of MLA kernel time per 16x8k-token prefill block (torch profiler). Default paths are unaffected.

Figures (all from real runs; generation script available on request):

![merge error vs prefix length](https://raw.githubusercontent.com/advpropsys/flashinfer/pr-assets/fig1_merge_error_vs_prefix.png)

![LSE and merge weights](https://raw.githubusercontent.com/advpropsys/flashinfer/pr-assets/fig2_lse_and_merge_weights.png)

![serving dlogprob](https://raw.githubusercontent.com/advpropsys/flashinfer/pr-assets/fig3_serving_dlogprob.png)

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). (black 26.1.0 clean; ruff F401/F821/UP037 clean on the changed file)
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (No new sglang-side test added; the change is a 3-line numeric conversion verified by the external repro above. Happy to add one if reviewers want it in-tree.)
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (Not applicable; no user-facing behavior change beyond the numerical fix.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (See above.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
