### PR TITLE
Account for reserved hugepages in the HiCache host memory check

### DIFF
--- a/python/sglang/srt/mem_cache/pool_host/base.py
+++ b/python/sglang/srt/mem_cache/pool_host/base.py
@@ -14,7 +14,6 @@ from sglang.srt.mem_cache.pool_host.common import (
     _cuda_host_unregister,
     get_allocator_from_storage,
 )
-from sglang.srt.mem_cache.storage.mmap import free_hugepage_bytes
 from sglang.srt.utils import is_cuda, is_hip
 
 logger = logging.getLogger(__name__)
@@ -147,11 +146,7 @@ class HostKVCache(abc.ABC):
         # the pool will be mapped from hugetlb the two budgets are alternatives
         # rather than additive: the allocation is a single mmap that either
         # fits in the hugetlb pool or falls back to plain pages.
-        hugetlb_bytes = (
-            free_hugepage_bytes()
-            if getattr(self.allocator, "uses_hugetlb", False)
-            else 0
-        )
+        hugetlb_bytes = self.allocator.free_hugetlb_bytes()
         if requested_bytes > max(available_bytes, hugetlb_bytes):
             hugetlb_note = (
                 f" ({hugetlb_bytes / 1e9:.2f} GB free in the hugetlb pool)"

--- a/python/sglang/srt/mem_cache/pool_host/base.py
+++ b/python/sglang/srt/mem_cache/pool_host/base.py
@@ -12,6 +12,7 @@ import torch
 from sglang.srt.mem_cache.memory_pool import KVCache
 from sglang.srt.mem_cache.pool_host.common import (
     _cuda_host_unregister,
+    device_uses_allocator,
     get_allocator_from_storage,
 )
 from sglang.srt.utils import is_cuda, is_hip
@@ -143,10 +144,12 @@ class HostKVCache(abc.ABC):
         requested_bytes = self.size * self.size_per_token
         available_bytes = host_mem.available - HICACHE_HOST_MEMORY_RESERVE_BYTES
         # Reserved hugepages are excluded from MemAvailable by design, so when
-        # the pool will be mapped from hugetlb the two budgets are alternatives
-        # rather than additive: the allocation is a single mmap that either
-        # fits in the hugetlb pool or falls back to plain pages.
-        hugetlb_bytes = self.allocator.free_hugetlb_bytes()
+        # the pool will really be mapped from hugetlb the two budgets are
+        # alternatives rather than additive: a single mmap either fits in the
+        # hugetlb pool or falls back to plain pages. That equivalence only holds
+        # for the narrow set of paths this credit is enabled for; see
+        # _hugetlb_admission_bytes().
+        hugetlb_bytes = self._hugetlb_admission_bytes()
         if requested_bytes > max(available_bytes, hugetlb_bytes):
             hugetlb_note = (
                 f" ({hugetlb_bytes / 1e9:.2f} GB free in the hugetlb pool)"
@@ -187,6 +190,32 @@ class HostKVCache(abc.ABC):
         # A lock for synchronized operations on memory allocation and state transitions.
         self.lock = threading.RLock()
         self.clear()
+
+    def _uses_single_host_mapping(self) -> bool:
+        """Whether init_kv_buffer() issues exactly one host allocation.
+
+        The hugetlb admission credit compares one logical byte total against the
+        free pool, but every mapping is rounded up to a whole hugepage
+        independently. With more than one mapping the sum of the logical sizes
+        can fit while the sum of the rounded sizes does not, so multi-mapping
+        pools get no credit rather than a wrong one.
+        """
+        return True
+
+    def _hugetlb_admission_bytes(self) -> int:
+        """Hugetlb-pool bytes that may be credited against this pool's request.
+
+        Deliberately conservative: credit is granted only when the hugetlb pool
+        is genuinely the memory this pool will be built from. It is zeroed when
+        the allocation dispatch bypasses the selected allocator (npu/musa go
+        through torch's pin_memory path) or when the pool needs more than one
+        mapping and per-mapping hugepage rounding could exceed the pool.
+        """
+        if not device_uses_allocator(self.device_pool.device):
+            return 0
+        if not self._uses_single_host_mapping():
+            return 0
+        return self.allocator.free_hugetlb_bytes()
 
     def destroy(self):
         """Unregister pinned host buffers in userspace before process exit.

--- a/python/sglang/srt/mem_cache/pool_host/base.py
+++ b/python/sglang/srt/mem_cache/pool_host/base.py
@@ -14,6 +14,7 @@ from sglang.srt.mem_cache.pool_host.common import (
     _cuda_host_unregister,
     get_allocator_from_storage,
 )
+from sglang.srt.mem_cache.storage.mmap import free_hugepage_bytes
 from sglang.srt.utils import is_cuda, is_hip
 
 logger = logging.getLogger(__name__)
@@ -142,11 +143,25 @@ class HostKVCache(abc.ABC):
         host_mem = psutil.virtual_memory()
         requested_bytes = self.size * self.size_per_token
         available_bytes = host_mem.available - HICACHE_HOST_MEMORY_RESERVE_BYTES
-        if requested_bytes > available_bytes:
+        # Reserved hugepages are excluded from MemAvailable by design, so when
+        # the pool will be mapped from hugetlb the two budgets are alternatives
+        # rather than additive: the allocation is a single mmap that either
+        # fits in the hugetlb pool or falls back to plain pages.
+        hugetlb_bytes = (
+            free_hugepage_bytes()
+            if getattr(self.allocator, "uses_hugetlb", False)
+            else 0
+        )
+        if requested_bytes > max(available_bytes, hugetlb_bytes):
+            hugetlb_note = (
+                f" ({hugetlb_bytes / 1e9:.2f} GB free in the hugetlb pool)"
+                if hugetlb_bytes
+                else ""
+            )
             raise ValueError(
                 f"Not enough host memory available. Requesting "
                 f"{requested_bytes / 1e9:.2f} GB but only have "
-                f"{available_bytes / 1e9:.2f} GB free. Please reduce the "
+                f"{available_bytes / 1e9:.2f} GB free{hugetlb_note}. Please reduce the "
                 f"size of the hierarchical cache."
             )
         else:

--- a/python/sglang/srt/mem_cache/pool_host/common.py
+++ b/python/sglang/srt/mem_cache/pool_host/common.py
@@ -13,6 +13,10 @@ logger = logging.getLogger(__name__)
 
 
 class HostTensorAllocator:
+    # alloc_mmap honors SGLANG_HUGEPAGE_SIZE and maps MAP_HUGETLB when set, so
+    # the hugetlb pool is spendable capacity for this allocator.
+    uses_hugetlb = True
+
     def __init__(self):
         """Initialize the HostTensorAllocator."""
         self.dtype = None
@@ -28,6 +32,10 @@ class HostTensorAllocator:
 
 
 class ShmHostTensorAllocator(HostTensorAllocator):
+    # alloc_shm maps a memfd/dev-shm object, which cannot come from hugetlb
+    # unless hugetlbfs is mounted there; it warns and uses plain pages instead.
+    uses_hugetlb = False
+
     def __init__(self):
         super().__init__()
         self.fds = []

--- a/python/sglang/srt/mem_cache/pool_host/common.py
+++ b/python/sglang/srt/mem_cache/pool_host/common.py
@@ -7,16 +7,12 @@ from collections import defaultdict
 
 import torch
 
-from sglang.srt.mem_cache.storage.mmap import alloc_mmap
+from sglang.srt.mem_cache.storage.mmap import alloc_mmap, free_hugepage_bytes
 
 logger = logging.getLogger(__name__)
 
 
 class HostTensorAllocator:
-    # alloc_mmap honors SGLANG_HUGEPAGE_SIZE and maps MAP_HUGETLB when set, so
-    # the hugetlb pool is spendable capacity for this allocator.
-    uses_hugetlb = True
-
     def __init__(self):
         """Initialize the HostTensorAllocator."""
         self.dtype = None
@@ -30,16 +26,29 @@ class HostTensorAllocator:
         self.dims = dims
         return alloc_mmap(dims, dtype)
 
+    def free_hugetlb_bytes(self) -> int:
+        """Free hugetlb-pool bytes this allocator could actually spend.
+
+        Reserved hugepages are excluded from MemAvailable, so a caller sizing an
+        allocation against available host memory has to add them back. Overriding
+        allocate() means overriding this too: the answer depends on where the
+        memory really comes from, and inheriting it would credit capacity to
+        backends that never map MAP_HUGETLB. alloc_mmap honors
+        SGLANG_HUGEPAGE_SIZE, so the pool is spendable here.
+        """
+        return free_hugepage_bytes()
+
 
 class ShmHostTensorAllocator(HostTensorAllocator):
-    # alloc_shm maps a memfd/dev-shm object, which cannot come from hugetlb
-    # unless hugetlbfs is mounted there; it warns and uses plain pages instead.
-    uses_hugetlb = False
-
     def __init__(self):
         super().__init__()
         self.fds = []
         self.mms = []
+
+    def free_hugetlb_bytes(self) -> int:
+        # alloc_shm maps a memfd/dev-shm object, which cannot come from hugetlb
+        # unless hugetlbfs is mounted there; it warns and uses plain pages.
+        return 0
 
     @property
     def fd(self):

--- a/python/sglang/srt/mem_cache/pool_host/common.py
+++ b/python/sglang/srt/mem_cache/pool_host/common.py
@@ -7,7 +7,11 @@ from collections import defaultdict
 
 import torch
 
-from sglang.srt.mem_cache.storage.mmap import alloc_mmap, free_hugepage_bytes
+from sglang.srt.mem_cache.storage.mmap import (
+    alloc_mmap,
+    free_hugepage_bytes,
+    hugepage_mmap_supported,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -34,8 +38,12 @@ class HostTensorAllocator:
         allocate() means overriding this too: the answer depends on where the
         memory really comes from, and inheriting it would credit capacity to
         backends that never map MAP_HUGETLB. alloc_mmap honors
-        SGLANG_HUGEPAGE_SIZE, so the pool is spendable here.
+        SGLANG_HUGEPAGE_SIZE, so the pool is spendable here -- but only when
+        libc is loadable, since without it alloc_mmap silently falls back to
+        ordinary pages and the hugetlb pool is never touched.
         """
+        if not hugepage_mmap_supported():
+            return 0
         return free_hugepage_bytes()
 
 
@@ -198,3 +206,22 @@ ALLOC_MEMORY_FUNCS = defaultdict(
         "musa": alloc_with_pin_memory,
     },
 )
+
+
+def alloc_func_uses_allocator(alloc_func) -> bool:
+    """Whether the dispatched allocation function honors the HostTensorAllocator.
+
+    An allowlist, not a denylist: only ``alloc_with_host_register`` is known to
+    route through the selected allocator. ``alloc_with_pin_memory`` (npu/musa)
+    calls ``torch.empty(..., pin_memory=True)`` and ignores it entirely, so
+    anything the allocator reports about where its memory comes from does not
+    describe the allocation that will actually happen. A future dispatch
+    function therefore gets no hugetlb credit until it is added here
+    deliberately.
+    """
+    return alloc_func is alloc_with_host_register
+
+
+def device_uses_allocator(device: str) -> bool:
+    """Whether allocations for ``device`` are dispatched to the selected allocator."""
+    return alloc_func_uses_allocator(ALLOC_MEMORY_FUNCS[device])

--- a/python/sglang/srt/mem_cache/pool_host/mha.py
+++ b/python/sglang/srt/mem_cache/pool_host/mha.py
@@ -1018,6 +1018,12 @@ class AsymmetricMHATokenToKVPoolHost(MHATokenToKVPoolHost):
     kernels derive copy sizes from each call's first tensor.
     """
 
+    def _uses_single_host_mapping(self) -> bool:
+        # K and V are two independent mmaps, each rounded up to a whole
+        # hugepage. Their logical sizes can sum to less than the free pool while
+        # the rounded sizes do not fit, so claim no hugetlb credit here.
+        return False
+
     def _init_write_back_staging_buffers(self):
         self.staging_page_capacity = 0
         self.staging_token_capacity = 0

--- a/python/sglang/srt/mem_cache/pool_host/mla.py
+++ b/python/sglang/srt/mem_cache/pool_host/mla.py
@@ -135,6 +135,11 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
     def get_ksize_per_token(self):
         return self.get_size_per_token()
 
+    def _uses_single_host_mapping(self) -> bool:
+        # page_first_kv_split issues 2-3 separate mappings (K, V, and optionally
+        # the index buffer), each independently rounded up to a whole hugepage.
+        return self.layout != "page_first_kv_split"
+
     def init_kv_buffer(self):
         if self.layout == "layer_first":
             dims = (

--- a/python/sglang/srt/mem_cache/storage/mmap/__init__.py
+++ b/python/sglang/srt/mem_cache/storage/mmap/__init__.py
@@ -3,9 +3,10 @@
 
 """Mmap allocator storage backend helpers for SGLang HiCache."""
 
-from .mmap_allocator import alloc_mmap, alloc_shm
+from .mmap_allocator import alloc_mmap, alloc_shm, free_hugepage_bytes
 
 __all__ = [
     "alloc_mmap",
     "alloc_shm",
+    "free_hugepage_bytes",
 ]

--- a/python/sglang/srt/mem_cache/storage/mmap/__init__.py
+++ b/python/sglang/srt/mem_cache/storage/mmap/__init__.py
@@ -3,10 +3,16 @@
 
 """Mmap allocator storage backend helpers for SGLang HiCache."""
 
-from .mmap_allocator import alloc_mmap, alloc_shm, free_hugepage_bytes
+from .mmap_allocator import (
+    alloc_mmap,
+    alloc_shm,
+    free_hugepage_bytes,
+    hugepage_mmap_supported,
+)
 
 __all__ = [
     "alloc_mmap",
     "alloc_shm",
     "free_hugepage_bytes",
+    "hugepage_mmap_supported",
 ]

--- a/python/sglang/srt/mem_cache/storage/mmap/mmap_allocator.py
+++ b/python/sglang/srt/mem_cache/storage/mmap/mmap_allocator.py
@@ -42,6 +42,53 @@ _MAP_HUGE_1GB = 30 << 26  # 0x78000000
 _MAP_FAILED = ctypes.c_void_p(-1).value
 _MADV_POPULATE_WRITE = getattr(mmap, "MADV_POPULATE_WRITE", 23)
 
+# Accepted SGLANG_HUGEPAGE_SIZE values -> (page size in bytes, mmap flags).
+_HUGEPAGE_SPECS = {
+    "2MB": (2 * 1024 * 1024, _MAP_HUGETLB | _MAP_HUGE_2MB),
+    "1GB": (1024 * 1024 * 1024, _MAP_HUGETLB | _MAP_HUGE_1GB),
+}
+
+# Per-size hugetlb pool counters, e.g. hugepages-2048kB/free_hugepages.
+_HUGEPAGE_SYSFS_DIR = "/sys/kernel/mm/hugepages"
+
+
+def _requested_hugepage_spec():
+    """(page size, mmap flags) alloc_mmap would use, or None for plain pages."""
+    hugepage_size = (envs.SGLANG_HUGEPAGE_SIZE.get() or "").strip().upper()
+    if hugepage_size == "":
+        return None
+    spec = _HUGEPAGE_SPECS.get(hugepage_size)
+    if spec is None:
+        logger.warning(
+            "Unrecognized SGLANG_HUGEPAGE_SIZE=%r; expected '2MB' or '1GB'. "
+            "Falling back to plain page-size mmap.",
+            envs.SGLANG_HUGEPAGE_SIZE.get(),
+        )
+    return spec
+
+
+def free_hugepage_bytes() -> int:
+    """Bytes currently free in the hugetlb pool alloc_mmap() would draw from.
+
+    Reserved hugepages are deliberately excluded from MemAvailable, so callers
+    sizing an allocation against available host memory undercount by the size
+    of the pool. Returns 0 whenever hugepages would not be used at all -- not
+    requested, an unknown size, or no hugetlb pool on this platform -- so the
+    result is always safe to treat as "no extra capacity".
+    """
+    spec = _requested_hugepage_spec()
+    if spec is None:
+        return 0
+    page_size = spec[0]
+    try:
+        with open(
+            f"{_HUGEPAGE_SYSFS_DIR}/hugepages-{page_size // 1024}kB/free_hugepages"
+        ) as f:
+            return int(f.read().strip()) * page_size
+    except (OSError, ValueError):
+        # No hugetlb support, pool not configured, or unreadable counter.
+        return 0
+
 
 def _alloc_hugepage(n_bytes: int, alloc_bytes: int, extra_flags: int) -> ctypes.Array:
     """Call mmap via libc with hugepage flags and return an owning ctypes array.
@@ -79,19 +126,11 @@ def alloc_mmap(dims: tuple, dtype: torch.dtype) -> torch.Tensor:
     hugepage_size = (envs.SGLANG_HUGEPAGE_SIZE.get() or "").strip().upper()
     n_bytes = math.prod(dims) * torch.empty([], dtype=dtype).element_size()
 
-    if hugepage_size == "":
+    spec = _requested_hugepage_spec()
+    if spec is None:
         page_size, extra_flags = mmap.PAGESIZE, 0
-    elif hugepage_size == "2MB":
-        page_size, extra_flags = 2 * 1024 * 1024, _MAP_HUGETLB | _MAP_HUGE_2MB
-    elif hugepage_size == "1GB":
-        page_size, extra_flags = 1024 * 1024 * 1024, _MAP_HUGETLB | _MAP_HUGE_1GB
     else:
-        logger.warning(
-            "Unrecognized SGLANG_HUGEPAGE_SIZE=%r; expected '2MB' or '1GB'. "
-            "Falling back to plain page-size mmap.",
-            envs.SGLANG_HUGEPAGE_SIZE.get(),
-        )
-        page_size, extra_flags = mmap.PAGESIZE, 0
+        page_size, extra_flags = spec
 
     alloc_bytes = math.ceil(n_bytes / page_size) * page_size
 

--- a/python/sglang/srt/mem_cache/storage/mmap/mmap_allocator.py
+++ b/python/sglang/srt/mem_cache/storage/mmap/mmap_allocator.py
@@ -68,9 +68,84 @@ def _requested_hugepage_spec():
     return spec
 
 
+def hugepage_mmap_supported() -> bool:
+    """Whether alloc_mmap() can actually issue a MAP_HUGETLB mapping.
+
+    The hugepage path goes through libc's mmap because Python's mmap module
+    cannot pass MAP_HUGETLB. Without libc, alloc_mmap() logs and silently falls
+    back to ordinary pages, so the hugetlb pool is not spendable here.
+    """
+    return _libc is not None
+
+
 def _read_pool_counter(pool_dir: str, name: str) -> int:
     with open(f"{pool_dir}/{name}") as f:
         return int(f.read().strip())
+
+
+def _mems_allowed_nodes() -> Optional[set]:
+    """NUMA nodes this process may allocate from, or None if unknown.
+
+    A ``--membind`` policy (SGLang applies one per scheduler when
+    SGLANG_NUMA_BIND_V2 is on) restricts allocation to a subset of nodes, but
+    the pool counters under /sys/kernel/mm/hugepages are global. Crediting the
+    global pool to a membound process would count pages it cannot allocate.
+    """
+    try:
+        with open("/proc/self/status") as f:
+            for line in f:
+                if line.startswith("Mems_allowed_list:"):
+                    value = line.split(":", 1)[1].strip()
+                    nodes = set()
+                    for part in value.split(","):
+                        if not part:
+                            continue
+                        if "-" in part:
+                            lo, hi = part.split("-", 1)
+                            nodes.update(range(int(lo), int(hi) + 1))
+                        else:
+                            nodes.add(int(part))
+                    return nodes
+    except (OSError, ValueError):
+        return None
+    return None
+
+
+def _hugepage_numa_nodes(page_size: int) -> Optional[set]:
+    """NUMA nodes that have a hugetlb pool of ``page_size``, or None if unknown."""
+    node_root = "/sys/devices/system/node"
+    try:
+        entries = os.listdir(node_root)
+    except OSError:
+        # No per-node view (e.g. non-NUMA kernel or a restricted container).
+        return None
+    nodes = set()
+    for entry in entries:
+        if not entry.startswith("node") or not entry[4:].isdigit():
+            continue
+        pool = f"{node_root}/{entry}/hugepages/hugepages-{page_size // 1024}kB"
+        try:
+            if _read_pool_counter(pool, "free_hugepages") > 0:
+                nodes.add(int(entry[4:]))
+        except (OSError, ValueError):
+            continue
+    return nodes
+
+
+def _numa_policy_allows_whole_pool(page_size: int) -> bool:
+    """Whether every hugepage this process could see is one it may allocate.
+
+    Conservative: returns False whenever the answer cannot be established.
+    """
+    allowed = _mems_allowed_nodes()
+    if allowed is None:
+        return False
+    with_pages = _hugepage_numa_nodes(page_size)
+    if with_pages is None:
+        # No per-node counters to compare against. Only safe if the process is
+        # unrestricted, which on a single-node system it effectively is.
+        return len(allowed) <= 1
+    return with_pages.issubset(allowed)
 
 
 def free_hugepage_bytes(page_size: Optional[int] = None) -> int:
@@ -91,6 +166,10 @@ def free_hugepage_bytes(page_size: Optional[int] = None) -> int:
             return 0
         page_size = spec[0]
     pool_dir = f"{_HUGEPAGE_SYSFS_DIR}/hugepages-{page_size // 1024}kB"
+    if not _numa_policy_allows_whole_pool(page_size):
+        # A membound process cannot spend pages sitting on other nodes, and the
+        # counters here are global. Rather than guess a share, credit nothing.
+        return 0
     try:
         free_pages = _read_pool_counter(pool_dir, "free_hugepages")
     except (OSError, ValueError):
@@ -102,7 +181,11 @@ def free_hugepage_bytes(page_size: Optional[int] = None) -> int:
         # the top rather than handing them out twice.
         reserved = _read_pool_counter(pool_dir, "resv_hugepages")
     except (OSError, ValueError):
-        reserved = 0
+        # free_hugepages was readable but resv_hugepages was not, so there is no
+        # way to tell committed pages apart from spendable ones. Fail closed:
+        # crediting the raw free count here would admit an allocation that the
+        # pool has already promised elsewhere.
+        return 0
     return max(free_pages - reserved, 0) * page_size
 
 

--- a/python/sglang/srt/mem_cache/storage/mmap/mmap_allocator.py
+++ b/python/sglang/srt/mem_cache/storage/mmap/mmap_allocator.py
@@ -6,6 +6,7 @@ import mmap
 import os
 import uuid
 import weakref
+from typing import Optional
 
 import torch
 
@@ -67,27 +68,42 @@ def _requested_hugepage_spec():
     return spec
 
 
-def free_hugepage_bytes() -> int:
-    """Bytes currently free in the hugetlb pool alloc_mmap() would draw from.
+def _read_pool_counter(pool_dir: str, name: str) -> int:
+    with open(f"{pool_dir}/{name}") as f:
+        return int(f.read().strip())
+
+
+def free_hugepage_bytes(page_size: Optional[int] = None) -> int:
+    """Bytes currently free in a hugetlb pool.
 
     Reserved hugepages are deliberately excluded from MemAvailable, so callers
     sizing an allocation against available host memory undercount by the size
-    of the pool. Returns 0 whenever hugepages would not be used at all -- not
-    requested, an unknown size, or no hugetlb pool on this platform -- so the
-    result is always safe to treat as "no extra capacity".
+    of the pool. ``page_size`` selects which per-size pool to read, for callers
+    that map hugepages themselves; the default reads the pool alloc_mmap()
+    would draw from for the current SGLANG_HUGEPAGE_SIZE. Returns 0 whenever
+    hugepages would not be used at all -- not requested, an unknown size, or no
+    hugetlb pool on this platform -- so the result is always safe to treat as
+    "no extra capacity".
     """
-    spec = _requested_hugepage_spec()
-    if spec is None:
-        return 0
-    page_size = spec[0]
+    if page_size is None:
+        spec = _requested_hugepage_spec()
+        if spec is None:
+            return 0
+        page_size = spec[0]
+    pool_dir = f"{_HUGEPAGE_SYSFS_DIR}/hugepages-{page_size // 1024}kB"
     try:
-        with open(
-            f"{_HUGEPAGE_SYSFS_DIR}/hugepages-{page_size // 1024}kB/free_hugepages"
-        ) as f:
-            return int(f.read().strip()) * page_size
+        free_pages = _read_pool_counter(pool_dir, "free_hugepages")
     except (OSError, ValueError):
         # No hugetlb support, pool not configured, or unreadable counter.
         return 0
+    try:
+        # free_hugepages still counts pages the kernel has promised to an
+        # existing mapping but not yet faulted, so take reservations back off
+        # the top rather than handing them out twice.
+        reserved = _read_pool_counter(pool_dir, "resv_hugepages")
+    except (OSError, ValueError):
+        reserved = 0
+    return max(free_pages - reserved, 0) * page_size
 
 
 def _alloc_hugepage(n_bytes: int, alloc_bytes: int, extra_flags: int) -> ctypes.Array:

--- a/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
+++ b/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
@@ -40,6 +40,11 @@ class MooncakeHostTensorAllocator(HostTensorAllocator):
         self.allocator = MooncakeHostMemAllocator()
         self.ptr = None
 
+    def free_hugetlb_bytes(self) -> int:
+        # MooncakeHostMemAllocator does its own host allocation and never maps
+        # MAP_HUGETLB from the kernel pool.
+        return 0
+
     def allocate(
         self, dims: tuple, dtype: torch.dtype, device: str = "cpu"
     ) -> torch.Tensor:

--- a/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
+++ b/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
@@ -41,8 +41,11 @@ class MooncakeHostTensorAllocator(HostTensorAllocator):
         self.ptr = None
 
     def free_hugetlb_bytes(self) -> int:
-        # MooncakeHostMemAllocator does its own host allocation and never maps
-        # MAP_HUGETLB from the kernel pool.
+        # Mooncake manages its own host allocation and applies its own hugepage
+        # policy, configured through its own environment variables
+        # (MC_STORE_USE_HUGEPAGE / MC_STORE_HUGEPAGE_SIZE) inside its own arena.
+        # This preflight neither sees nor governs that, so it claims no credit:
+        # 0 means "not this check's budget to spend", not "no hugepages".
         return 0
 
     def allocate(

--- a/python/sglang/srt/mem_cache/storage/umbp/umbp_host_allocator.py
+++ b/python/sglang/srt/mem_cache/storage/umbp/umbp_host_allocator.py
@@ -7,6 +7,7 @@ from typing import Any, Dict
 import torch
 
 from sglang.srt.mem_cache.pool_host.common import HostTensorAllocator
+from sglang.srt.mem_cache.storage.mmap import free_hugepage_bytes
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +47,13 @@ class UMBPHostTensorAllocator(HostTensorAllocator):
         self._numa_node = _int_env("SGLANG_HICACHE_HOST_NUMA_NODE", -1)
         self._prefault = _bool_env("SGLANG_HICACHE_HOST_PREFAULT", True)
         self._handles: Dict[int, Any] = {}
+
+    def free_hugetlb_bytes(self) -> int:
+        # mori maps AnonymousHugetlb from the same kernel pool, but selects the
+        # page size with its own knobs rather than SGLANG_HUGEPAGE_SIZE.
+        if not self._use_hugepage:
+            return 0
+        return free_hugepage_bytes(self._hugepage_size)
 
     def allocate(
         self, dims: tuple, dtype: torch.dtype, device: str = "cpu"

--- a/test/registered/unit/mem_cache/test_mmap_allocator.py
+++ b/test/registered/unit/mem_cache/test_mmap_allocator.py
@@ -7,12 +7,18 @@ import sys
 sys.modules["libtpu"] = None
 import mmap
 import os
+import tempfile
 import unittest
+from unittest.mock import patch
 
 import torch
 
-from sglang.srt.mem_cache.pool_host.common import ShmHostTensorAllocator
-from sglang.srt.mem_cache.storage.mmap import alloc_mmap, alloc_shm
+from sglang.srt.environ import envs
+from sglang.srt.mem_cache.pool_host.common import (
+    HostTensorAllocator,
+    ShmHostTensorAllocator,
+)
+from sglang.srt.mem_cache.storage.mmap import alloc_mmap, alloc_shm, mmap_allocator
 
 
 class TestMmapAllocator(unittest.TestCase):
@@ -113,6 +119,72 @@ class TestMmapAllocator(unittest.TestCase):
         with self.assertRaises(AssertionError) as ctx:
             allocator.allocate((2, 2), torch.float32, device="cuda")
         self.assertIn("only supports CPU allocations", str(ctx.exception))
+
+
+class TestFreeHugepageBytes(unittest.TestCase):
+    """free_hugepage_bytes() reports capacity MemAvailable deliberately hides."""
+
+    @staticmethod
+    def _fake_pool(root, page_kb, free_count):
+        pool_dir = os.path.join(root, f"hugepages-{page_kb}kB")
+        os.makedirs(pool_dir)
+        with open(os.path.join(pool_dir, "free_hugepages"), "w") as f:
+            f.write(f"{free_count}\n")
+
+    def _read(self, hugepage_size, root):
+        with envs.SGLANG_HUGEPAGE_SIZE.override(hugepage_size):
+            with patch.object(mmap_allocator, "_HUGEPAGE_SYSFS_DIR", root):
+                return mmap_allocator.free_hugepage_bytes()
+
+    def test_zero_when_hugepages_not_requested(self):
+        with tempfile.TemporaryDirectory() as root:
+            self._fake_pool(root, 2048, 1024)
+            # No credit unless the allocator was actually told to use hugetlb.
+            self.assertEqual(self._read(None, root), 0)
+
+    def test_zero_for_unrecognized_size(self):
+        with tempfile.TemporaryDirectory() as root:
+            self._fake_pool(root, 2048, 1024)
+            self.assertEqual(self._read("4MB", root), 0)
+
+    def test_reads_2mb_pool(self):
+        with tempfile.TemporaryDirectory() as root:
+            self._fake_pool(root, 2048, 1024)
+            self.assertEqual(self._read("2MB", root), 1024 * 2 * 1024 * 1024)
+
+    def test_reads_1gb_pool(self):
+        with tempfile.TemporaryDirectory() as root:
+            self._fake_pool(root, 1048576, 3)
+            self.assertEqual(self._read("1GB", root), 3 * 1024**3)
+
+    def test_does_not_cross_read_other_page_sizes(self):
+        with tempfile.TemporaryDirectory() as root:
+            # Only a 2MB pool exists; a 1GB request must not borrow from it.
+            self._fake_pool(root, 2048, 1024)
+            self.assertEqual(self._read("1GB", root), 0)
+
+    def test_zero_when_no_hugetlb_support(self):
+        # Non-Linux hosts (and kernels without hugetlb) have no sysfs pool.
+        with tempfile.TemporaryDirectory() as root:
+            self.assertEqual(self._read("2MB", os.path.join(root, "missing")), 0)
+
+    def test_zero_on_unreadable_counter(self):
+        with tempfile.TemporaryDirectory() as root:
+            pool_dir = os.path.join(root, "hugepages-2048kB")
+            os.makedirs(pool_dir)
+            with open(os.path.join(pool_dir, "free_hugepages"), "w") as f:
+                f.write("not-a-number\n")
+            self.assertEqual(self._read("2MB", root), 0)
+
+
+class TestAllocatorHugetlbCapability(unittest.TestCase):
+    def test_mmap_allocator_can_use_hugetlb(self):
+        self.assertTrue(HostTensorAllocator.uses_hugetlb)
+
+    def test_shm_allocator_cannot_use_hugetlb(self):
+        # alloc_shm warns and falls back to plain pages, so crediting the
+        # hugetlb pool to it would let an oversized pool past the pre-check.
+        self.assertFalse(ShmHostTensorAllocator.uses_hugetlb)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/mem_cache/test_mmap_allocator.py
+++ b/test/registered/unit/mem_cache/test_mmap_allocator.py
@@ -5,10 +5,12 @@ register_cpu_ci(est_time=10, suite="base-a-test-cpu")
 import sys
 
 sys.modules["libtpu"] = None
+import importlib
 import mmap
 import os
 import tempfile
 import unittest
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import torch
@@ -19,6 +21,26 @@ from sglang.srt.mem_cache.pool_host.common import (
     ShmHostTensorAllocator,
 )
 from sglang.srt.mem_cache.storage.mmap import alloc_mmap, alloc_shm, mmap_allocator
+
+# Optional storage backends: importable without their third-party packages
+# (those are imported inside __init__), but not worth failing this file over.
+_OPTIONAL_ALLOCATORS = (
+    (
+        "sglang.srt.mem_cache.storage.mooncake_store.mooncake_store",
+        "MooncakeHostTensorAllocator",
+    ),
+    (
+        "sglang.srt.mem_cache.storage.umbp.umbp_host_allocator",
+        "UMBPHostTensorAllocator",
+    ),
+)
+
+
+def _try_import(module_name, class_name):
+    try:
+        return getattr(importlib.import_module(module_name), class_name)
+    except Exception:
+        return None
 
 
 class TestMmapAllocator(unittest.TestCase):
@@ -125,11 +147,13 @@ class TestFreeHugepageBytes(unittest.TestCase):
     """free_hugepage_bytes() reports capacity MemAvailable deliberately hides."""
 
     @staticmethod
-    def _fake_pool(root, page_kb, free_count):
+    def _fake_pool(root, page_kb, free_count, reserved_count=0):
         pool_dir = os.path.join(root, f"hugepages-{page_kb}kB")
         os.makedirs(pool_dir)
         with open(os.path.join(pool_dir, "free_hugepages"), "w") as f:
             f.write(f"{free_count}\n")
+        with open(os.path.join(pool_dir, "resv_hugepages"), "w") as f:
+            f.write(f"{reserved_count}\n")
 
     def _read(self, hugepage_size, root):
         with envs.SGLANG_HUGEPAGE_SIZE.override(hugepage_size):
@@ -151,6 +175,25 @@ class TestFreeHugepageBytes(unittest.TestCase):
         with tempfile.TemporaryDirectory() as root:
             self._fake_pool(root, 2048, 1024)
             self.assertEqual(self._read("2MB", root), 1024 * 2 * 1024 * 1024)
+
+    def test_subtracts_reserved_pages(self):
+        # free_hugepages counts pages already promised to another mapping but
+        # not yet faulted; handing them out again would pass the check and then
+        # fail the mmap.
+        with tempfile.TemporaryDirectory() as root:
+            self._fake_pool(root, 2048, 1024, reserved_count=1000)
+            self.assertEqual(self._read("2MB", root), 24 * 2 * 1024 * 1024)
+
+    def test_never_reports_negative_capacity(self):
+        with tempfile.TemporaryDirectory() as root:
+            self._fake_pool(root, 2048, 4, reserved_count=9)
+            self.assertEqual(self._read("2MB", root), 0)
+
+    def test_missing_reservation_counter_is_treated_as_zero(self):
+        with tempfile.TemporaryDirectory() as root:
+            self._fake_pool(root, 2048, 8)
+            os.remove(os.path.join(root, "hugepages-2048kB", "resv_hugepages"))
+            self.assertEqual(self._read("2MB", root), 8 * 2 * 1024 * 1024)
 
     def test_reads_1gb_pool(self):
         with tempfile.TemporaryDirectory() as root:
@@ -176,15 +219,87 @@ class TestFreeHugepageBytes(unittest.TestCase):
                 f.write("not-a-number\n")
             self.assertEqual(self._read("2MB", root), 0)
 
+    def test_explicit_page_size_overrides_the_env(self):
+        # Callers that map hugepages themselves pick their own pool.
+        with tempfile.TemporaryDirectory() as root:
+            self._fake_pool(root, 1048576, 2)
+            with envs.SGLANG_HUGEPAGE_SIZE.override(None):
+                with patch.object(mmap_allocator, "_HUGEPAGE_SYSFS_DIR", root):
+                    self.assertEqual(
+                        mmap_allocator.free_hugepage_bytes(1024**3), 2 * 1024**3
+                    )
 
-class TestAllocatorHugetlbCapability(unittest.TestCase):
-    def test_mmap_allocator_can_use_hugetlb(self):
-        self.assertTrue(HostTensorAllocator.uses_hugetlb)
 
-    def test_shm_allocator_cannot_use_hugetlb(self):
+class TestAllocatorHugetlbCapacity(unittest.TestCase):
+    """Only allocators that really map MAP_HUGETLB may claim the pool."""
+
+    def _pool_of(self, root, page_kb, free_count):
+        TestFreeHugepageBytes._fake_pool(root, page_kb, free_count)
+        return patch.object(mmap_allocator, "_HUGEPAGE_SYSFS_DIR", root)
+
+    def test_mmap_allocator_reports_the_pool(self):
+        with tempfile.TemporaryDirectory() as root:
+            with self._pool_of(root, 2048, 8):
+                with envs.SGLANG_HUGEPAGE_SIZE.override("2MB"):
+                    self.assertEqual(
+                        HostTensorAllocator().free_hugetlb_bytes(), 8 * 2 * 1024 * 1024
+                    )
+
+    def test_shm_allocator_reports_zero(self):
         # alloc_shm warns and falls back to plain pages, so crediting the
         # hugetlb pool to it would let an oversized pool past the pre-check.
-        self.assertFalse(ShmHostTensorAllocator.uses_hugetlb)
+        with tempfile.TemporaryDirectory() as root:
+            with self._pool_of(root, 2048, 8):
+                with envs.SGLANG_HUGEPAGE_SIZE.override("2MB"):
+                    self.assertEqual(ShmHostTensorAllocator().free_hugetlb_bytes(), 0)
+
+    def test_mooncake_allocator_reports_zero(self):
+        # Mooncake allocates through its own host allocator, never alloc_mmap,
+        # so the kernel pool is not capacity it can spend.
+        cls = _try_import(*_OPTIONAL_ALLOCATORS[0])
+        if cls is None:
+            self.skipTest("mooncake backend is not importable")
+        with tempfile.TemporaryDirectory() as root:
+            with self._pool_of(root, 2048, 8):
+                with envs.SGLANG_HUGEPAGE_SIZE.override("2MB"):
+                    self.assertEqual(cls.free_hugetlb_bytes(None), 0)
+
+    def test_umbp_allocator_reads_its_own_page_size(self):
+        # mori maps hugepages, but selects the pool with its own knobs, so a
+        # 2MB pool must not be credited to a 1GB-backed allocator.
+        cls = _try_import(*_OPTIONAL_ALLOCATORS[1])
+        if cls is None:
+            self.skipTest("umbp backend is not importable")
+        read = cls.free_hugetlb_bytes
+        with tempfile.TemporaryDirectory() as root:
+            with self._pool_of(root, 2048, 8):
+                two_mb = SimpleNamespace(_use_hugepage=True, _hugepage_size=2 << 20)
+                one_gb = SimpleNamespace(_use_hugepage=True, _hugepage_size=1024**3)
+                disabled = SimpleNamespace(_use_hugepage=False, _hugepage_size=2 << 20)
+                self.assertEqual(read(two_mb), 8 * 2 * 1024 * 1024)
+                self.assertEqual(read(one_gb), 0)
+                self.assertEqual(read(disabled), 0)
+
+    def test_every_allocator_answers_for_its_own_backing(self):
+        # Inheriting the mmap-backed answer would credit the hugetlb pool to a
+        # backend that never maps MAP_HUGETLB, letting an oversized host pool
+        # past the pre-flight check and turning a clear error into an OOM.
+        for module_name, class_name in _OPTIONAL_ALLOCATORS:
+            _try_import(module_name, class_name)
+        pending, subclasses = list(HostTensorAllocator.__subclasses__()), []
+        while pending:
+            cls = pending.pop()
+            subclasses.append(cls)
+            pending.extend(cls.__subclasses__())
+        self.assertTrue(subclasses, "no allocator subclasses were imported")
+        for cls in subclasses:
+            if "allocate" in cls.__dict__:
+                self.assertIn(
+                    "free_hugetlb_bytes",
+                    cls.__dict__,
+                    f"{cls.__name__} overrides allocate() but inherits "
+                    "free_hugetlb_bytes()",
+                )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/mem_cache/test_mmap_allocator.py
+++ b/test/registered/unit/mem_cache/test_mmap_allocator.py
@@ -11,7 +11,7 @@ import os
 import tempfile
 import unittest
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import mock_open, patch
 
 import torch
 
@@ -189,11 +189,14 @@ class TestFreeHugepageBytes(unittest.TestCase):
             self._fake_pool(root, 2048, 4, reserved_count=9)
             self.assertEqual(self._read("2MB", root), 0)
 
-    def test_missing_reservation_counter_is_treated_as_zero(self):
+    def test_missing_reservation_counter_fails_closed(self):
+        # Without resv_hugepages there is no way to tell committed pages apart
+        # from spendable ones, and crediting the raw free count would admit an
+        # allocation the pool has already promised elsewhere.
         with tempfile.TemporaryDirectory() as root:
             self._fake_pool(root, 2048, 8)
             os.remove(os.path.join(root, "hugepages-2048kB", "resv_hugepages"))
-            self.assertEqual(self._read("2MB", root), 8 * 2 * 1024 * 1024)
+            self.assertEqual(self._read("2MB", root), 0)
 
     def test_reads_1gb_pool(self):
         with tempfile.TemporaryDirectory() as root:
@@ -300,6 +303,351 @@ class TestAllocatorHugetlbCapacity(unittest.TestCase):
                     f"{cls.__name__} overrides allocate() but inherits "
                     "free_hugetlb_bytes()",
                 )
+
+
+class TestHostKVCacheHugetlbAdmission(unittest.TestCase):
+    """The real HostKVCache.__init__ admission decision, not just its helpers.
+
+    Reverting the base.py gate must break something here; the helper tests alone
+    do not cover the site where the credit is actually spent.
+    """
+
+    GB = 1024**3
+    # 1 GiB per token keeps the pool a handful of tokens wide, so clear()
+    # allocates tiny bookkeeping tensors while the byte budgets stay realistic.
+    BYTES_PER_TOKEN = GB
+
+    def _pool_class(self, device="cuda", single_mapping=True):
+        from sglang.srt.mem_cache.pool_host.base import HostKVCache
+
+        outer = self
+
+        class _FakeHostKVCache(HostKVCache):
+            layer_num = 1
+            target_layer_num = 1
+
+            def get_size_per_token(self):
+                return outer.BYTES_PER_TOKEN
+
+            def init_kv_buffer(self):
+                outer.allocated = True
+                return torch.zeros(1)
+
+            def _uses_single_host_mapping(self):
+                return single_mapping
+
+            # Transfer-path abstract methods, unused by the admission check.
+            def get_data_page(self, *args, **kwargs):
+                raise NotImplementedError
+
+            def get_dummy_flat_data_page(self, *args, **kwargs):
+                raise NotImplementedError
+
+            def set_from_flat_data_page(self, *args, **kwargs):
+                raise NotImplementedError
+
+            def load_to_device_per_layer(self, *args, **kwargs):
+                raise NotImplementedError
+
+            def backup_from_device_all_layer(self, *args, **kwargs):
+                raise NotImplementedError
+
+        return _FakeHostKVCache
+
+    def _build(self, requested_bytes, available_bytes, hugetlb_bytes, **kwargs):
+        """Construct a pool with fully controlled memory budgets."""
+        from sglang.srt.mem_cache.pool_host import base as base_mod
+
+        device = kwargs.pop("device", "cuda")
+        cls = self._pool_class(device=device, **kwargs)
+        self.allocated = False
+
+        tokens = requested_bytes // self.BYTES_PER_TOKEN
+        assert tokens >= 1, "requested_bytes must be a whole number of tokens"
+        device_pool = SimpleNamespace(
+            store_dtype=torch.uint8,
+            # page_size 1 rounds the pool up by exactly one page/token.
+            size=tokens - 1,
+            start_layer=0,
+            end_layer=1,
+            layer_num=1,
+            layer_shard_enabled=False,
+            device=device,
+        )
+        allocator = SimpleNamespace(free_hugetlb_bytes=lambda: hugetlb_bytes, fd=None)
+
+        # available_bytes = MemAvailable - HICACHE_HOST_MEMORY_RESERVE_BYTES
+        vm = SimpleNamespace(
+            available=available_bytes + base_mod.HICACHE_HOST_MEMORY_RESERVE_BYTES
+        )
+        with patch.object(base_mod.psutil, "virtual_memory", return_value=vm), patch(
+            "sglang.srt.mem_cache.pool_host.base.get_allocator_from_storage",
+            return_value=allocator,
+        ):
+            return cls(
+                device_pool=device_pool,
+                host_to_device_ratio=1.0,
+                host_size=0,
+                page_size=1,
+                layout="page_first",
+                pin_memory=False,
+                device="cpu",
+            )
+
+    def test_hugetlb_pool_admits_when_plain_memory_is_short(self):
+        # Eligible single-mapping path on a device that dispatches to the
+        # allocator: the hugetlb pool is the memory the mmap will really use.
+        pool = self._build(
+            requested_bytes=8 * self.GB,
+            available_bytes=1 * self.GB,
+            hugetlb_bytes=64 * self.GB,
+        )
+        self.assertTrue(self.allocated)
+        self.assertGreater(pool.size, 0)
+
+    def test_rejects_and_reports_the_pool_when_both_budgets_are_short(self):
+        with self.assertRaises(ValueError) as ctx:
+            self._build(
+                requested_bytes=8 * self.GB,
+                available_bytes=1 * self.GB,
+                hugetlb_bytes=2 * self.GB,
+            )
+        message = str(ctx.exception)
+        self.assertIn("Not enough host memory available", message)
+        self.assertIn("hugetlb pool", message)
+
+    def test_no_hugetlb_note_when_the_pool_is_empty(self):
+        with self.assertRaises(ValueError) as ctx:
+            self._build(
+                requested_bytes=8 * self.GB,
+                available_bytes=1 * self.GB,
+                hugetlb_bytes=0,
+            )
+        self.assertNotIn("hugetlb pool", str(ctx.exception))
+
+    def test_budgets_are_alternatives_not_additive(self):
+        # The whole premise: the pool is ONE mapping that either fits the
+        # hugetlb pool or falls back to plain pages. Summing the two budgets
+        # would admit a request that neither path alone can satisfy.
+        with self.assertRaises(ValueError):
+            self._build(
+                requested_bytes=8 * self.GB,
+                available_bytes=5 * self.GB,
+                hugetlb_bytes=6 * self.GB,
+            )
+
+    def test_admission_is_exclusive_at_the_boundary(self):
+        # requested == budget must be admitted, not rejected.
+        pool = self._build(
+            requested_bytes=8 * self.GB,
+            available_bytes=1 * self.GB,
+            hugetlb_bytes=8 * self.GB,
+        )
+        self.assertTrue(self.allocated)
+        self.assertGreater(pool.size, 0)
+
+    def test_the_diagnostic_reports_the_hugetlb_figure_not_the_plain_one(self):
+        with self.assertRaises(ValueError) as ctx:
+            self._build(
+                requested_bytes=8 * self.GB,
+                available_bytes=1 * self.GB,
+                hugetlb_bytes=2 * self.GB,
+            )
+        message = str(ctx.exception)
+        # 2 GB free in the pool, 1 GB of plain memory: the note must not quote
+        # the plain figure back to the operator.
+        self.assertIn(f"{2 * self.GB / 1e9:.2f} GB free in the hugetlb pool", message)
+
+    def test_npu_rejects_because_it_never_reaches_the_allocator(self):
+        # ALLOC_MEMORY_FUNCS maps npu/musa to alloc_with_pin_memory, which calls
+        # torch.empty(pin_memory=True) and ignores the selected allocator, so
+        # whatever the allocator reports does not describe this allocation.
+        for device in ("npu", "musa"):
+            with self.subTest(device=device):
+                with self.assertRaises(ValueError):
+                    self._build(
+                        requested_bytes=8 * self.GB,
+                        available_bytes=1 * self.GB,
+                        hugetlb_bytes=64 * self.GB,
+                        device=device,
+                    )
+
+    def test_split_mapping_rejects_on_aggregate_logical_bytes(self):
+        # Two mappings are each rounded up to a whole hugepage, so the sum of
+        # the logical sizes fitting the pool does not mean both mappings fit.
+        with self.assertRaises(ValueError):
+            self._build(
+                requested_bytes=8 * self.GB,
+                available_bytes=1 * self.GB,
+                hugetlb_bytes=64 * self.GB,
+                single_mapping=False,
+            )
+
+
+class TestSplitMappingPoolsAreExcluded(unittest.TestCase):
+    """Pools that issue more than one host mapping must declare it."""
+
+    def test_ordinary_single_mapping_pools_keep_the_credit(self):
+        # The other half of the gate: the default must stay True, or the fix
+        # silently stops helping the very configurations it targets. Asserted
+        # on the real class, not on the base or on a test double.
+        from sglang.srt.mem_cache.pool_host.mha import MHATokenToKVPoolHost
+
+        for layout in ("layer_first", "page_first", "page_first_direct", "page_head"):
+            self.assertTrue(
+                MHATokenToKVPoolHost._uses_single_host_mapping(
+                    SimpleNamespace(layout=layout)
+                ),
+                f"layout={layout!r}",
+            )
+
+    def test_the_override_is_on_the_asymmetric_class_itself(self):
+        # Calling the method through the MRO would still pass if the override
+        # were moved up to the symmetric parent, which would wrongly zero the
+        # credit for every ordinary MHA pool.
+        from sglang.srt.mem_cache.pool_host.mha import (
+            AsymmetricMHATokenToKVPoolHost,
+            MHATokenToKVPoolHost,
+        )
+
+        self.assertIn(
+            "_uses_single_host_mapping", AsymmetricMHATokenToKVPoolHost.__dict__
+        )
+        self.assertNotIn("_uses_single_host_mapping", MHATokenToKVPoolHost.__dict__)
+
+    def test_multi_mapping_pools_do_not_silently_inherit_the_credit(self):
+        # Mirrors test_every_allocator_answers_for_its_own_backing: any pool
+        # that reaches the base preflight must answer for its own mapping
+        # count rather than inherit the single-mapping default.
+        import sglang.srt.mem_cache.memory_pool_host  # noqa: F401  (registers subclasses)
+        from sglang.srt.mem_cache.pool_host.base import HostKVCache
+
+        pending, subclasses = list(HostKVCache.__subclasses__()), []
+        while pending:
+            cls = pending.pop()
+            subclasses.append(cls)
+            pending.extend(cls.__subclasses__())
+        self.assertTrue(subclasses, "no HostKVCache subclasses were imported")
+        for cls in subclasses:
+            init = cls.__dict__.get("__init__")
+            if init is None:
+                continue
+            names = init.__code__.co_names
+            # Pools with their own preflight never reach the base gate.
+            if "virtual_memory" in names:
+                continue
+            self.assertIn(
+                "_uses_single_host_mapping",
+                {n for klass in cls.__mro__ for n in klass.__dict__},
+                f"{cls.__name__} reaches the base preflight",
+            )
+
+    def test_asymmetric_mha_is_not_single_mapping(self):
+        from sglang.srt.mem_cache.pool_host.mha import AsymmetricMHATokenToKVPoolHost
+
+        self.assertFalse(
+            AsymmetricMHATokenToKVPoolHost._uses_single_host_mapping(
+                SimpleNamespace(layout="page_first")
+            )
+        )
+
+    def test_mla_kv_split_layout_is_not_single_mapping(self):
+        from sglang.srt.mem_cache.pool_host.mla import MLATokenToKVPoolHost
+
+        read = MLATokenToKVPoolHost._uses_single_host_mapping
+        self.assertFalse(read(SimpleNamespace(layout="page_first_kv_split")))
+        self.assertTrue(read(SimpleNamespace(layout="page_first")))
+
+
+class TestDispatchCapability(unittest.TestCase):
+    def test_only_pin_memory_devices_bypass_the_allocator(self):
+        from sglang.srt.mem_cache.pool_host.common import device_uses_allocator
+
+        self.assertFalse(device_uses_allocator("npu"))
+        self.assertFalse(device_uses_allocator("musa"))
+        self.assertTrue(device_uses_allocator("cuda"))
+        self.assertTrue(device_uses_allocator("cpu"))
+
+    def test_an_unknown_dispatch_function_gets_no_credit(self):
+        # Allowlist, not denylist: a future bypassing dispatch function must
+        # not inherit the credit just by not being alloc_with_pin_memory.
+        from sglang.srt.mem_cache.pool_host.common import alloc_func_uses_allocator
+
+        def some_future_direct_allocator(*args, **kwargs):
+            raise NotImplementedError
+
+        self.assertFalse(alloc_func_uses_allocator(some_future_direct_allocator))
+
+
+class TestHugepageMmapRequiresLibc(unittest.TestCase):
+    def test_default_allocator_reports_zero_without_libc(self):
+        # Without libc, alloc_mmap() cannot pass MAP_HUGETLB and silently falls
+        # back to ordinary pages, so the pool is not capacity it can spend.
+        with tempfile.TemporaryDirectory() as root:
+            TestFreeHugepageBytes._fake_pool(root, 2048, 8)
+            with patch.object(mmap_allocator, "_HUGEPAGE_SYSFS_DIR", root):
+                with envs.SGLANG_HUGEPAGE_SIZE.override("2MB"):
+                    with patch.object(mmap_allocator, "_libc", None):
+                        self.assertEqual(HostTensorAllocator().free_hugetlb_bytes(), 0)
+                    self.assertEqual(
+                        HostTensorAllocator().free_hugetlb_bytes(), 8 * 2 * 1024 * 1024
+                    )
+
+
+class TestNumaPolicyGate(unittest.TestCase):
+    """A membound process must not be credited pages on nodes it cannot use."""
+
+    def _pool(self, root, free_count=8):
+        TestFreeHugepageBytes._fake_pool(root, 2048, free_count)
+        return patch.object(mmap_allocator, "_HUGEPAGE_SYSFS_DIR", root)
+
+    def _read(self, root, allowed, with_pages):
+        with self._pool(root):
+            with envs.SGLANG_HUGEPAGE_SIZE.override("2MB"):
+                with patch.object(
+                    mmap_allocator, "_mems_allowed_nodes", return_value=allowed
+                ), patch.object(
+                    mmap_allocator, "_hugepage_numa_nodes", return_value=with_pages
+                ):
+                    return mmap_allocator.free_hugepage_bytes()
+
+    def test_credits_when_every_hugepage_node_is_allowed(self):
+        with tempfile.TemporaryDirectory() as root:
+            self.assertEqual(
+                self._read(root, allowed={0, 1}, with_pages={0}), 8 * 2 * 1024 * 1024
+            )
+
+    def test_zero_when_pages_sit_on_a_forbidden_node(self):
+        # --membind=0 while the pool lives on node 1: the global counter says
+        # the pages are free, but this process can never allocate them.
+        with tempfile.TemporaryDirectory() as root:
+            self.assertEqual(self._read(root, allowed={0}, with_pages={0, 1}), 0)
+
+    def test_zero_when_the_policy_cannot_be_determined(self):
+        with tempfile.TemporaryDirectory() as root:
+            self.assertEqual(self._read(root, allowed=None, with_pages={0}), 0)
+
+    def test_multi_node_without_per_node_counters_is_not_credited(self):
+        with tempfile.TemporaryDirectory() as root:
+            self.assertEqual(self._read(root, allowed={0, 1}, with_pages=None), 0)
+        with tempfile.TemporaryDirectory() as root:
+            self.assertEqual(
+                self._read(root, allowed={0}, with_pages=None), 8 * 2 * 1024 * 1024
+            )
+
+    def test_mems_allowed_list_parsing(self):
+        read = mmap_allocator._mems_allowed_nodes
+        for value, expected in (
+            ("0", {0}),
+            ("0-3", {0, 1, 2, 3}),
+            ("0,2", {0, 2}),
+            ("0-1,4", {0, 1, 4}),
+        ):
+            with patch(
+                "builtins.open",
+                mock_open(read_data=f"Mems_allowed_list:\t{value}\n"),
+            ):
+                self.assertEqual(read(), expected, f"value={value!r}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Fixes #34972.

### Prior art: #27267

@jeynmann's #27267 ("MEM_CACHE: add hugepage preflight and allocation modes", open since 2026-06-04) already identified this same preflight bug and proposed a broader fix: a centralized `memory_available_bytes()` plus explicit hugepage allocation modes (off / prefer / required) wired through every host-pool path. I found it after opening this PR, and it deserves the credit for spotting the problem first.

This PR is deliberately narrower and does not supersede it. It stays scoped to #34972, subtracts `resv_hugepages` from the reported pool, keeps the existing hugepage-then-fallback semantics unchanged (no new modes, no new configuration surface), and grants the extra admission credit only on paths where the allocation demonstrably comes from that pool. If maintainers prefer the mode-based design in #27267, this can be closed or reduced to the `resv_hugepages` subtraction and the conservative gating below.

`HostKVCache.__init__` sizes the HiCache host pool against `psutil.virtual_memory().available`, which mirrors the kernel's `MemAvailable`. `MemAvailable` **deliberately excludes reserved hugepages**, since they are not reclaimable general-purpose memory — whether or not they are currently in use.

So reserving a hugetlb pool *for the host pool* shrinks the very budget this pre-flight check measures, and the check then rejects an allocation that the hugetlb pool can satisfy in full. The more hugepages you reserve to make the host pool fast, the more likely startup is to fail.

I reproduced the kernel-side premise directly (privileged Linux container, 5.15, aarch64), varying only `vm.nr_hugepages`:

| `nr_hugepages` | `Hugetlb` | `HugePages_Free` | `MemAvailable` |
|---|---|---|---|
| 0 | 0 kB | 0 | 6,970,912 kB |
| 233 | 477,184 kB | **233 (100% free)** | 6,520,848 kB |
| 0 | 0 kB | 0 | 6,998,664 kB |

Reserving ~477 MB of *entirely free* hugepages removed ~450 MB from `MemAvailable`. That accounting is correct for the kernel and wrong for this check, because the allocation it gates is the thing that will consume the pool.

Downstream confirms the intent: `alloc_mmap()` maps `MAP_HUGETLB` first and only falls back to plain pages when hugetlb allocation fails, so the code is already hugepage-aware everywhere except in the check.

## Modifications

**`storage/mmap/mmap_allocator.py`**
- Add `free_hugepage_bytes(page_size=None)`, reporting free capacity of a hugetlb pool, read per page size from `/sys/kernel/mm/hugepages/hugepages-<size>kB/`. It reports `free_hugepages - resv_hugepages`: `free_hugepages` still counts pages the kernel has already promised to an existing mapping but not yet faulted, and handing those out a second time would pass this check and then fail the `mmap`. It returns `0` whenever hugepages would not be used at all, or whenever the spendable amount cannot be established — not requested, unrecognized size, no hugetlb pool (e.g. macOS), an unreadable `resv_hugepages` (without it there is no way to separate committed pages from spendable ones), or a NUMA policy that does not cover the pool. So callers can always treat the result as "no extra capacity".
- Hoist the `SGLANG_HUGEPAGE_SIZE` → `(page size, mmap flags)` mapping into `_HUGEPAGE_SPECS` / `_requested_hugepage_spec()` so the check and the allocator cannot disagree about which pool is in play. `alloc_mmap()` behavior is unchanged.

**`pool_host/base.py`**
- Compare the request against `max(available_bytes, hugetlb_bytes)`. The budgets are **alternatives, not additive**: on the eligible paths the pool is a single mmap that either fits in the hugetlb pool or falls back to plain pages. Summing them would let through a request that neither path can satisfy.
- Route the credit through `HostKVCache._hugetlb_admission_bytes()`, which returns `0` unless this pool really will be built from that pool. See *Conservative exclusions* below — an over-credited budget admits an allocation that then dies at `mmap` time, which is worse than the startup error this PR removes.
- Mention free hugetlb capacity in the error when there is any, so a genuine failure is still diagnosable.

**Allocators — each answers for its own backing store**

`HostTensorAllocator.free_hugetlb_bytes()`, overridden wherever the memory does not come from `alloc_mmap()`:

| allocator | backing store | reports |
|---|---|---|
| `HostTensorAllocator` | `alloc_mmap` → `MAP_HUGETLB` per `SGLANG_HUGEPAGE_SIZE` | that pool |
| `ShmHostTensorAllocator` | `alloc_shm` (memfd / `/dev/shm`) | `0` |
| `MooncakeHostTensorAllocator` | `MooncakeHostMemAllocator` (own hugepage policy) | `0` |
| `UMBPHostTensorAllocator` | mori `AnonymousHugetlb`, sized by `SGLANG_HICACHE_HOST_HUGEPAGE_SIZE` | *its own* pool |

`alloc_shm()` cannot map hugetlb ("Hugepages are not supported with SHM allocator" — it warns and falls back to plain pages), so it reports nothing.

Mooncake reports `0`, but **not** because it never uses hugepages — it can. It applies its own hugepage policy, configured separately through its own environment variables (`MC_STORE_USE_HUGEPAGE` / `MC_STORE_HUGEPAGE_SIZE`) and allocated inside its own arena, which this preflight neither sees nor governs. So `0` is the correct conservative answer here: it means "not this check's budget to spend", not "no hugepages".

### Conservative exclusions

Each of these is a case where the hugetlb pool cannot be soundly credited against this check. In every one the credit is zeroed and the pre-existing `MemAvailable`-only behavior applies, so the worst case is the status quo:

- **No libc.** `alloc_mmap()` needs `libc` to pass `MAP_HUGETLB` (Python's `mmap` module cannot). When `ctypes` fails to load it, `alloc_mmap()` logs and quietly uses ordinary pages — so the default allocator now reports `0` in that state instead of crediting a pool it cannot reach. `hugepage_mmap_supported()` gates this. UMBP is unaffected: it maps through mori, not `libc`.
- **NPU / MUSA.** `ALLOC_MEMORY_FUNCS` dispatches these devices to `alloc_with_pin_memory()`, which calls `torch.empty(..., pin_memory=True)` and ignores the selected `HostTensorAllocator` entirely — yet the preflight was still asking that allocator for hugetlb capacity. Credit is now granted only when the dispatched allocation function actually consumes the selected allocator (`device_uses_allocator()`), so this is decided by the dispatch table rather than by string comparisons scattered across the pools.
- **Split / multi-mapping pools.** The check compares one aggregate logical byte count, but each mapping is rounded up to a whole hugepage independently, so the sum of the logical sizes can fit a pool that the sum of the rounded sizes cannot. Concretely, with 1 GiB pages `AsymmetricMHATokenToKVPoolHost` with K = 6,442,454,016 B and V = 4,294,969,344 B sums to exactly 10 GiB and passes an 11 GiB pool check, but each mapping rounds up independently to 7 GiB + 5 GiB = 12 GiB, which does not fit. `HostKVCache._uses_single_host_mapping()` returns `False` for that pool and for MLA's `page_first_kv_split` layout (2–3 mappings), which zeroes the credit. Doing this properly needs a mixed-allocation planner, which is out of scope here.
- **NUMA binding.** SGLang binds each scheduler to a node with `numactl --membind` when `SGLANG_NUMA_BIND_V2` is on (the default), but `/sys/kernel/mm/hugepages` counters are **global**. Crediting them to a membound process would count pages it can never allocate. The pool is credited only when every node holding free hugepages is in this process's `Mems_allowed_list`; when that cannot be established, the credit is zero.
- **Unknown reservations.** If `free_hugepages` is readable but `resv_hugepages` is not, committed and spendable pages cannot be told apart, so the result is `0` rather than the raw free count.
- **Mooncake.** Its own strict policy, as above.

Legacy `HostKVCache` subclasses in `memory_pool_host.py` run their own preflight and never call `HostKVCache.__init__`, so they are untouched by this change in either direction.

I first wrote this as a `uses_hugetlb` class flag and that was wrong: a flag on the base class is **inherited**, so `MooncakeHostTensorAllocator` and `UMBPHostTensorAllocator` would both have been credited a hugetlb pool they never map — turning this check into a no-op for precisely the hugepage deployments this PR is meant to fix. Asking each allocator keeps the answer tied to the implementation, and lets UMBP report the pool it actually maps rather than the one `SGLANG_HUGEPAGE_SIZE` names. A test asserts that any subclass overriding `allocate()` also overrides `free_hugetlb_bytes()`, so a future backend cannot silently inherit the wrong answer.

**Known limitation:** the credited figure is still the global pool total, not a per-node share. Rather than estimate a share, a process whose NUMA policy does not cover every hugepage-bearing node gets no credit at all (see *Conservative exclusions*), which keeps this sound at the cost of not helping membound workers that could partly benefit. Per-node accounting would be a natural follow-up if maintainers want it.

## Accuracy Tests

Not applicable — no change to model outputs or kernels.

## Speed Tests and Profiling

No steady-state performance change; this is startup-time admission control. It restores the intended hugetlb-backed host pool for configurations that currently fail to start.

## Tests

Added `TestFreeHugepageBytes` and `TestAllocatorHugetlbCapacity` to `test/registered/unit/mem_cache/test_mmap_allocator.py`, already registered in the CPU CI lane. They drive a synthetic sysfs tree, so they need no hugepages and no special privileges: pool read for 2MB and 1GB, reservations subtracted, capacity never negative, a missing `resv_hugepages` failing closed to zero capacity, no credit when unset/unrecognized, no cross-reading between page sizes, and `0` on a missing pool or a malformed counter. The allocator tests cover each backing store — including that UMBP reads its own page size and not `SGLANG_HUGEPAGE_SIZE`'s — plus the guard that no subclass inherits the mmap-backed answer.

Added for the conservative gating, all pure-mock and CPU-only:

- `TestHostKVCacheHugetlbAdmission` — drives the **real `HostKVCache.__init__` admission decision**, not just the helpers: an eligible single-mapping pool is admitted when the normal budget is below the request and the hugetlb pool is above it; both below raises `ValueError` and the message names the free pool; no hugetlb note when the pool is empty; NPU and MUSA are rejected on exactly the case that only the irrelevant allocator-reported budget would admit; and a split-mapping pool is rejected when only the aggregate logical bytes appear to fit.
- `TestSplitMappingPoolsAreExcluded`, `TestDispatchCapability`, `TestHugepageMmapRequiresLibc` — the individual gates, including that the default allocator reports `0` when `libc` is unavailable.
- `TestSplitMappingPoolsAreExcluded` also pins the other half of the gate: ordinary single-mapping MHA layouts must **keep** the credit, the split-mapping override must live on the asymmetric class itself, and any future pool reaching the base preflight must answer for its own mapping count rather than inherit the default.
- `TestNumaPolicyGate` — the pool is credited when every hugepage-bearing node is allowed, and zeroed when pages sit on a forbidden node, when the policy is unreadable, or when a multi-node process has no per-node counters to check against. Includes `Mems_allowed_list` range/list parsing.

This was a real gap in the previous revision of this PR: the helper tests all passed while the site where the credit is actually spent had no coverage at all, so reverting the `base.py` change left the whole suite green. Every new test above was checked individually by reverting the specific production line it guards and confirming that test fails, then restoring it. Full file on Linux / Python 3.10: `Ran 43 tests ... OK`. Twenty single-line reversions were checked this way — one per gate, plus the admission comparison itself (`max()` → sum, `>` → `>=`, the wrong figure in the diagnostic, the single-mapping default, and moving the split-mapping override onto the wrong class) — and each turned its guarding test red.

The `free_hugepage_bytes()` / `alloc_mmap()` behavior below was validated earlier against a **real hugetlb pool** in a privileged Linux container. That environment is no longer available to me and cannot be re-run. It covers only the `MAP_HUGETLB` allocation behavior of `alloc_mmap()`, which this PR does not change. It does **not** cover any of the gating described above, and `free_hugepage_bytes()` itself has changed since that run (the NUMA gate and the fail-closed `resv_hugepages` handling were both added afterwards), so treat the transcript as historical evidence for the premise, not as validation of the current code:

```
=== full test file on Linux ===
21 passed, 1 skipped        # skip = the mooncake case, needs the mooncake package

=== real hugetlb pool (100 x 2MB reserved) ===
sysfs: nr=100 free=100 resv=0
[PASS] resv_hugepages exists in real sysfs
[PASS] free_hugepage_bytes() == (free - resv) * page_size: 209715200 == 209715200
[PASS] alloc_mmap consumed real hugepages: 100 -> 68 = 32 pages consumed, expected 32
[PASS] reported capacity dropped by the allocation size: delta 67108864, expected 67108864
[PASS] mapping is readable/writable: round-trip ok
[PASS] reserved pages are subtracted: free=100 resv=40 -> 60 pages
```

The third and fourth lines are the ones that mattered for the refactor: a 64 MB `alloc_mmap` still consumed exactly 32 × 2 MB pages from the real hugetlb pool, and the number this check reads dropped by exactly the size of that allocation, so `MAP_HUGETLB` selection was intact and the two agreed. (That run predates the gating changes; its `21 passed, 1 skipped` is not the current test count.)

Thanks to @MarioR3k for the report and the detailed per-case breakdown in #34972. I do **not** have their environment (32 GB host, `--hicache-size 12`, `vm.nr_hugepages=6144`). @MarioR3k — if you are able to re-run your case 3 against this branch, that would confirm the end-to-end fix.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — no user-facing surface change
- [ ] Provide accuracy and speed benchmark results. — not applicable, see above
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31971780296](https://github.com/sgl-project/sglang/actions/runs/31971780296)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31971780225](https://github.com/sgl-project/sglang/actions/runs/31971780225)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
