### PR TITLE
[PD] Deferred decode-side KV release for aborts mid-transfer

### DIFF
--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -160,6 +160,9 @@ class CommonKVManager(BaseKVManager):
         self.is_hybrid_mla_backend = getattr(args, "is_hybrid_mla_backend", False)
         self.disaggregation_mode = disaggregation_mode
         self.server_args = server_args
+        self.enable_deferred_decode_kv_release = (
+            envs.SGLANG_DISAGGREGATION_DEFERRED_DECODE_KV_RELEASE.get()
+        )
         # for p/d multi node infer
         self.bootstrap_host = server_args.host
         self.bootstrap_port = server_args.disaggregation_bootstrap_port
@@ -251,6 +254,11 @@ class CommonKVManager(BaseKVManager):
             self.session_pool_lock = threading.Lock()
             self.addr_to_rooms_tracker: Dict[str, Set[int]] = defaultdict(set)
             self.prefill_response_tracker: Dict[int, Set[int]] = defaultdict(set)
+            # Deferred KV release: prefill ranks that have confirmed (via
+            # ABORT_ACK) their in-flight transfer for an aborted room has
+            # drained. A room is safe to release once every required prefill
+            # rank has acked (mirrors prefill_response_tracker for Success).
+            self._deferred_abort_ack_tracker: Dict[int, Set[int]] = defaultdict(set)
             # Heartbeat interval should be at least 2 seconds
             self.heartbeat_interval = max(
                 envs.SGLANG_DISAGGREGATION_HEARTBEAT_INTERVAL.get(), 2.0
@@ -334,6 +342,26 @@ class CommonKVManager(BaseKVManager):
     def record_failure(self, bootstrap_room: int, failure_reason: str):
         with self.failure_lock:
             self.failure_records[bootstrap_room] = failure_reason
+
+    def note_abort_ack(self, bootstrap_room: int, prefill_rank: int) -> None:
+        """Record that ``prefill_rank`` has drained its in-flight transfer for an
+        aborted room (called from the decode receiver thread on ABORT_ACK).
+
+        Kept independent of ``required_prefill_response_num_table``: the failing
+        request's receiver clears that table before the scheduler defers, so the
+        required count is snapshotted at defer time (see is_abort_release_safe)."""
+        self._deferred_abort_ack_tracker[bootstrap_room].add(prefill_rank)
+
+    def is_abort_release_safe(self, bootstrap_room: int, required_acks: int) -> bool:
+        """True once every prefill rank that could still be writing to this
+        room's KV pages has acked the drain."""
+        return (
+            len(self._deferred_abort_ack_tracker.get(bootstrap_room, ()))
+            >= required_acks
+        )
+
+    def clear_deferred_abort_state(self, bootstrap_room: int) -> None:
+        self._deferred_abort_ack_tracker.pop(bootstrap_room, None)
 
     def get_kv_replica_factor(self) -> int:
         if self._kv_replica_factor is None:

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -254,13 +254,9 @@ class CommonKVManager(BaseKVManager):
             self.session_pool_lock = threading.Lock()
             self.addr_to_rooms_tracker: Dict[str, Set[int]] = defaultdict(set)
             self.prefill_response_tracker: Dict[int, Set[int]] = defaultdict(set)
-            # Deferred KV release: prefill ranks that have confirmed (via
-            # ABORT_ACK) their in-flight transfer for an aborted room has
-            # drained. A room is safe to release once every required prefill
-            # rank has acked (mirrors prefill_response_tracker for Success).
-            # A room's entry exists only while it is actively being held; acks
-            # for an unregistered room are dropped so a stale/late ack can never
-            # pollute a later request that reuses the same bootstrap_room.
+            # Deferred KV release: room -> prefill ranks that acked their transfer
+            # drained. Entry exists only while the room is held, so a stale/late
+            # ack for a reused bootstrap_room is dropped.
             self._deferred_abort_ack_tracker: Dict[int, Set[int]] = {}
             # Heartbeat interval should be at least 2 seconds
             self.heartbeat_interval = max(
@@ -347,24 +343,19 @@ class CommonKVManager(BaseKVManager):
             self.failure_records[bootstrap_room] = failure_reason
 
     def register_deferred_abort_room(self, bootstrap_room: int) -> None:
-        """Start (or reset) drain-ack accounting for a room the decode scheduler
-        is now holding. A fresh set wipes any stale acks from a prior request
-        that reused this bootstrap_room, and gates note_abort_ack so late acks
-        for an already-released room are ignored."""
+        """Arm drain-ack accounting for a held room; a fresh set wipes stale acks
+        from a prior request that reused this bootstrap_room."""
         self._deferred_abort_ack_tracker[bootstrap_room] = set()
 
     def note_abort_ack(self, bootstrap_room: int, prefill_rank: int) -> None:
-        """Record that ``prefill_rank`` has drained its in-flight transfer for an
-        aborted room (called from the decode receiver thread on ABORT_ACK). Only
-        counts while the room is actively held; grabs the set by reference so a
-        concurrent clear on the scheduler thread cannot raise."""
+        """Record a prefill rank's drain ack (decode receiver thread). Only counts
+        while the room is held; grabs the set by reference to avoid racing clear."""
         acks = self._deferred_abort_ack_tracker.get(bootstrap_room)
         if acks is not None:
             acks.add(prefill_rank)
 
     def is_abort_release_safe(self, bootstrap_room: int, required_acks: int) -> bool:
-        """True once every prefill rank that could still be writing to this
-        room's KV pages has acked the drain."""
+        """True once every prefill rank that could still write these pages has acked."""
         return (
             len(self._deferred_abort_ack_tracker.get(bootstrap_room, ()))
             >= required_acks
@@ -1276,9 +1267,8 @@ class CommonKVSender(BaseKVSender):
         if hasattr(self.kv_mgr, "transfer_infos"):
             self.kv_mgr.transfer_infos.pop(self.bootstrap_room, None)
         if hasattr(self.kv_mgr, "_deferred_ack_targets"):
-            # Drop a held drain-ack target if the room concluded without the
-            # transfer worker ever draining it (e.g. aborted before any chunk
-            # was enqueued); otherwise it would leak on the prefill.
+            # Drop a held ack target if the room concluded without draining
+            # (e.g. aborted before any chunk enqueued); else it leaks on prefill.
             self.kv_mgr._deferred_ack_targets.pop(self.bootstrap_room, None)
 
     def abort(self):

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -258,7 +258,10 @@ class CommonKVManager(BaseKVManager):
             # ABORT_ACK) their in-flight transfer for an aborted room has
             # drained. A room is safe to release once every required prefill
             # rank has acked (mirrors prefill_response_tracker for Success).
-            self._deferred_abort_ack_tracker: Dict[int, Set[int]] = defaultdict(set)
+            # A room's entry exists only while it is actively being held; acks
+            # for an unregistered room are dropped so a stale/late ack can never
+            # pollute a later request that reuses the same bootstrap_room.
+            self._deferred_abort_ack_tracker: Dict[int, Set[int]] = {}
             # Heartbeat interval should be at least 2 seconds
             self.heartbeat_interval = max(
                 envs.SGLANG_DISAGGREGATION_HEARTBEAT_INTERVAL.get(), 2.0
@@ -343,14 +346,21 @@ class CommonKVManager(BaseKVManager):
         with self.failure_lock:
             self.failure_records[bootstrap_room] = failure_reason
 
+    def register_deferred_abort_room(self, bootstrap_room: int) -> None:
+        """Start (or reset) drain-ack accounting for a room the decode scheduler
+        is now holding. A fresh set wipes any stale acks from a prior request
+        that reused this bootstrap_room, and gates note_abort_ack so late acks
+        for an already-released room are ignored."""
+        self._deferred_abort_ack_tracker[bootstrap_room] = set()
+
     def note_abort_ack(self, bootstrap_room: int, prefill_rank: int) -> None:
         """Record that ``prefill_rank`` has drained its in-flight transfer for an
-        aborted room (called from the decode receiver thread on ABORT_ACK).
-
-        Kept independent of ``required_prefill_response_num_table``: the failing
-        request's receiver clears that table before the scheduler defers, so the
-        required count is snapshotted at defer time (see is_abort_release_safe)."""
-        self._deferred_abort_ack_tracker[bootstrap_room].add(prefill_rank)
+        aborted room (called from the decode receiver thread on ABORT_ACK). Only
+        counts while the room is actively held; grabs the set by reference so a
+        concurrent clear on the scheduler thread cannot raise."""
+        acks = self._deferred_abort_ack_tracker.get(bootstrap_room)
+        if acks is not None:
+            acks.add(prefill_rank)
 
     def is_abort_release_safe(self, bootstrap_room: int, required_acks: int) -> bool:
         """True once every prefill rank that could still be writing to this
@@ -1265,6 +1275,11 @@ class CommonKVSender(BaseKVSender):
             self.kv_mgr.req_to_decode_prefix_len.pop(self.bootstrap_room, None)
         if hasattr(self.kv_mgr, "transfer_infos"):
             self.kv_mgr.transfer_infos.pop(self.bootstrap_room, None)
+        if hasattr(self.kv_mgr, "_deferred_ack_targets"):
+            # Drop a held drain-ack target if the room concluded without the
+            # transfer worker ever draining it (e.g. aborted before any chunk
+            # was enqueued); otherwise it would leak on the prefill.
+            self.kv_mgr._deferred_ack_targets.pop(self.bootstrap_room, None)
 
     def abort(self):
         self.kv_mgr.record_failure(

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -2192,6 +2192,9 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
         decode_req.kv_receiver.clear()
         decode_req.kv_receiver = None
 
+    def has_pending_deferred_releases(self) -> bool:
+        return bool(self._deferred_releases)
+
     def resolve_deferred_releases(self) -> None:
         """Release KV pages/req-slots held for aborted mid-transfer requests once
         every prefill rank confirms its transfer drained (is_abort_release_safe),

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -1816,6 +1816,16 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
         self.spec_algorithm = scheduler.spec_algorithm
         self.enable_staging = envs.SGLANG_DISAGG_STAGING_BUFFER.get()
         self.staging_handler = None
+        self.enable_deferred_kv_release = (
+            envs.SGLANG_DISAGGREGATION_DEFERRED_DECODE_KV_RELEASE.get()
+        )
+        self.deferred_kv_release_timeout = (
+            envs.SGLANG_DISAGGREGATION_DEFERRED_DECODE_KV_RELEASE_TIMEOUT.get()
+        )
+        # Requests aborted mid-transfer whose KV pages/req-slot are held until the
+        # prefill confirms the transfer drained (is_abort_release_safe) or the
+        # timeout fires. Entries: (decode_req, deadline, metadata_idx, required_acks).
+        self._deferred_releases: List[Tuple[DecodeRequest, float, int, int]] = []
 
     def add(self, decode_req: DecodeRequest) -> None:
         self.queue.append(decode_req)
@@ -2035,6 +2045,10 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
 
         transferred_reqs = []
         indices_to_remove = set()
+        # Removed from the queue but whose KV pages / metadata buffer are held
+        # for deferred release (see resolve_deferred_releases); excluded from the
+        # immediate metadata-buffer teardown below.
+        deferred_indices = set()
         for i, (decode_req, poll) in enumerate(zip(self.queue, polls)):
             if rids_to_check is not None and decode_req.req.rid not in rids_to_check:
                 continue
@@ -2072,11 +2086,20 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
                 )
                 if self.scheduler.enable_hisparse:
                     self.scheduler.hisparse_coordinator.request_finished(decode_req.req)
-                # release pre-allocated kv cache, but don't insert into the tree since it's failed
-                release_kv_cache(decode_req.req, self.tree_cache, is_insert=False)
-                decode_req.kv_receiver.clear()
-                decode_req.kv_receiver = None
-                indices_to_remove.add(i)
+                if self.enable_deferred_kv_release:
+                    # An in-flight prefill->decode write may still target this
+                    # request's KV pages. Hold the pages/req-slot + metadata
+                    # buffer until the prefill confirms the transfer drained
+                    # (ABORT_ACK) or the timeout fires (resolve_deferred_releases).
+                    self._defer_release(decode_req)
+                    deferred_indices.add(i)
+                    indices_to_remove.add(i)
+                else:
+                    # release pre-allocated kv cache, but don't insert into the tree since it's failed
+                    release_kv_cache(decode_req.req, self.tree_cache, is_insert=False)
+                    decode_req.kv_receiver.clear()
+                    decode_req.kv_receiver = None
+                    indices_to_remove.add(i)
                 if self.scheduler.metrics_reporter.enable_metrics:
                     self.scheduler.metrics_collector.increment_transfer_failed_reqs()
                 continue
@@ -2114,6 +2137,10 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
                 raise ValueError(f"Unexpected poll case: {poll}")
 
         for i in indices_to_remove:
+            if i in deferred_indices:
+                # Held for deferred release: its metadata buffer stays an RDMA
+                # target until the transfer drains; freed in resolve_deferred_releases.
+                continue
             if self.enable_staging and self.staging_handler.is_staging_room(
                 self.queue[i].req.bootstrap_room
             ):
@@ -2133,9 +2160,60 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
 
         return transferred_reqs
 
+    def _defer_release(self, decode_req: DecodeRequest) -> None:
+        deadline = time.monotonic() + self.deferred_kv_release_timeout
+        # Every prefill rank we notified of the abort acks exactly once (real
+        # ranks after their in-flight write drains, dummy/already-done ranks
+        # immediately). Requiring an ack from each is dummy-proof: reaching the
+        # count means no prefill can still be writing to these pages. Snapshot
+        # now -- the receiver may be cleared by the time we resolve.
+        required_acks = len(decode_req.kv_receiver.bootstrap_infos)
+        self._deferred_releases.append(
+            (decode_req, deadline, decode_req.metadata_buffer_index, required_acks)
+        )
+
+    def _do_release(self, decode_req: DecodeRequest, idx: int) -> None:
+        room = decode_req.req.bootstrap_room
+        if self.enable_staging and self.staging_handler.is_staging_room(room):
+            self.staging_handler.unregister_decode_req(room)
+        # release pre-allocated kv cache, but don't insert into the tree since it's failed
+        release_kv_cache(decode_req.req, self.tree_cache, is_insert=False)
+        self.metadata_buffers.bootstrap_room[idx] = 0
+        self.req_to_metadata_buffer_idx_allocator.free(idx)
+        decode_req.kv_receiver.kv_mgr.clear_deferred_abort_state(room)
+        decode_req.kv_receiver.clear()
+        decode_req.kv_receiver = None
+
+    def resolve_deferred_releases(self) -> None:
+        """Release KV pages/req-slots held for aborted mid-transfer requests once
+        every prefill rank confirms its transfer drained (is_abort_release_safe),
+        or the per-request hold times out."""
+        if not self._deferred_releases:
+            return
+        now = time.monotonic()
+        still_held = []
+        for decode_req, deadline, idx, required_acks in self._deferred_releases:
+            room = decode_req.req.bootstrap_room
+            kv_mgr = decode_req.kv_receiver.kv_mgr
+            drained = kv_mgr.is_abort_release_safe(room, required_acks)
+            if not drained and now < deadline:
+                still_held.append((decode_req, deadline, idx, required_acks))
+                continue
+            if not drained:
+                logger.warning(
+                    f"Deferred KV release for room {room} timed out after "
+                    f"{self.deferred_kv_release_timeout}s without a full drain "
+                    f"ack from prefill; releasing anyway."
+                )
+            self._do_release(decode_req, idx)
+        self._deferred_releases = still_held
+
     def release_memory_occupation(self):
         """Clean up in-flight transfers before releasing GPU memory."""
         self.queue.clear()
+        # The whole KV pool is being torn down; drop held entries without
+        # per-request release (they point into the pool being freed).
+        self._deferred_releases.clear()
 
     def resume_memory_occupation(self):
         """Queues are already cleared on release; new transfers can be accepted."""
@@ -2373,6 +2451,7 @@ class SchedulerDisaggregationDecodeMixin:
             transferred_reqs = (
                 self.disagg_decode_transfer_queue.pop_transferred()
             )  # the requests which kv has arrived
+            self.disagg_decode_transfer_queue.resolve_deferred_releases()
             if self.enable_hisparse:
                 for req in transferred_reqs:
                     # Direct-to-host: KV data already in host pool, skip staging

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -2086,11 +2086,19 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
                 )
                 if self.scheduler.enable_hisparse:
                     self.scheduler.hisparse_coordinator.request_finished(decode_req.req)
-                if self.enable_deferred_kv_release:
-                    # An in-flight prefill->decode write may still target this
+                if (
+                    self.enable_deferred_kv_release
+                    and decode_req.kv_receiver.abort_notified
+                ):
+                    # This decode initiated the abort (an ABORT was sent to
+                    # prefill and the drain-ack tracker was armed), so an
+                    # in-flight prefill->decode write may still target this
                     # request's KV pages. Hold the pages/req-slot + metadata
                     # buffer until the prefill confirms the transfer drained
                     # (ABORT_ACK) or the timeout fires (resolve_deferred_releases).
+                    # A prefill-initiated failure (abort_notified is False) has
+                    # already stopped writing, so it falls through to immediate
+                    # release below.
                     self._defer_release(decode_req)
                     deferred_indices.add(i)
                     indices_to_remove.add(i)
@@ -2192,21 +2200,32 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
             return
         now = time.monotonic()
         still_held = []
+        to_release = []
         for decode_req, deadline, idx, required_acks in self._deferred_releases:
             room = decode_req.req.bootstrap_room
             kv_mgr = decode_req.kv_receiver.kv_mgr
             drained = kv_mgr.is_abort_release_safe(room, required_acks)
             if not drained and now < deadline:
                 still_held.append((decode_req, deadline, idx, required_acks))
-                continue
+            else:
+                to_release.append((decode_req, idx, room, drained))
+        # Commit the surviving set before releasing anything: an exception in
+        # _do_release must not leave an already-released entry in the list
+        # (a retry would double-free its metadata idx / hit a None receiver).
+        self._deferred_releases = still_held
+        for decode_req, idx, room, drained in to_release:
             if not drained:
                 logger.warning(
                     f"Deferred KV release for room {room} timed out after "
                     f"{self.deferred_kv_release_timeout}s without a full drain "
                     f"ack from prefill; releasing anyway."
                 )
-            self._do_release(decode_req, idx)
-        self._deferred_releases = still_held
+            try:
+                self._do_release(decode_req, idx)
+            except Exception:
+                # Isolate a single failed release so the rest still run and the
+                # decode loop is not bricked; the entry is already dropped.
+                logger.exception(f"Deferred KV release failed for room {room}")
 
     def release_memory_occupation(self):
         """Clean up in-flight transfers before releasing GPU memory."""
@@ -2432,6 +2451,12 @@ class SchedulerDisaggregationDecodeMixin:
         if get_disagg().disaggregation_decode_enable_offload_kvcache:
             self.decode_offload_manager.check_offload_progress()
 
+        # Resolve held deferred releases first, every iteration and regardless of
+        # the polling gate / retraction early-return below: their timeouts must
+        # still fire under memory pressure, and freeing them here gives the
+        # retracted-request resumption more room to work with.
+        self.disagg_decode_transfer_queue.resolve_deferred_releases()
+
         # try to resume retracted requests if there are enough space for another `num_reserved_decode_tokens` decode steps
         resumed_reqs = self.disagg_decode_prealloc_queue.resume_retracted_reqs()
         self.waiting_queue.extend(resumed_reqs)
@@ -2451,7 +2476,6 @@ class SchedulerDisaggregationDecodeMixin:
             transferred_reqs = (
                 self.disagg_decode_transfer_queue.pop_transferred()
             )  # the requests which kv has arrived
-            self.disagg_decode_transfer_queue.resolve_deferred_releases()
             if self.enable_hisparse:
                 for req in transferred_reqs:
                     # Direct-to-host: KV data already in host pool, skip staging

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -1822,9 +1822,8 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
         self.deferred_kv_release_timeout = (
             envs.SGLANG_DISAGGREGATION_DEFERRED_DECODE_KV_RELEASE_TIMEOUT.get()
         )
-        # Requests aborted mid-transfer whose KV pages/req-slot are held until the
-        # prefill confirms the transfer drained (is_abort_release_safe) or the
-        # timeout fires. Entries: (decode_req, deadline, metadata_idx, required_acks).
+        # Aborted-mid-transfer requests whose KV pages/slot are held until drained
+        # or timed out. Entries: (decode_req, deadline, metadata_idx, required_acks).
         self._deferred_releases: List[Tuple[DecodeRequest, float, int, int]] = []
 
     def add(self, decode_req: DecodeRequest) -> None:
@@ -2045,9 +2044,8 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
 
         transferred_reqs = []
         indices_to_remove = set()
-        # Removed from the queue but whose KV pages / metadata buffer are held
-        # for deferred release (see resolve_deferred_releases); excluded from the
-        # immediate metadata-buffer teardown below.
+        # Queue-removed but held for deferred release; excluded from the metadata
+        # teardown below.
         deferred_indices = set()
         for i, (decode_req, poll) in enumerate(zip(self.queue, polls)):
             if rids_to_check is not None and decode_req.req.rid not in rids_to_check:
@@ -2090,15 +2088,10 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
                     self.enable_deferred_kv_release
                     and decode_req.kv_receiver.abort_notified
                 ):
-                    # This decode initiated the abort (an ABORT was sent to
-                    # prefill and the drain-ack tracker was armed), so an
-                    # in-flight prefill->decode write may still target this
-                    # request's KV pages. Hold the pages/req-slot + metadata
-                    # buffer until the prefill confirms the transfer drained
-                    # (ABORT_ACK) or the timeout fires (resolve_deferred_releases).
-                    # A prefill-initiated failure (abort_notified is False) has
-                    # already stopped writing, so it falls through to immediate
-                    # release below.
+                    # Decode-initiated abort: a prefill write may still target
+                    # these pages, so hold them until the drain ack or timeout.
+                    # (A prefill-initiated failure has already stopped writing ->
+                    # immediate release below.)
                     self._defer_release(decode_req)
                     deferred_indices.add(i)
                     indices_to_remove.add(i)
@@ -2146,8 +2139,7 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
 
         for i in indices_to_remove:
             if i in deferred_indices:
-                # Held for deferred release: its metadata buffer stays an RDMA
-                # target until the transfer drains; freed in resolve_deferred_releases.
+                # Held for deferred release; metadata buffer freed at resolve time.
                 continue
             if self.enable_staging and self.staging_handler.is_staging_room(
                 self.queue[i].req.bootstrap_room
@@ -2170,11 +2162,8 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
 
     def _defer_release(self, decode_req: DecodeRequest) -> None:
         deadline = time.monotonic() + self.deferred_kv_release_timeout
-        # Every prefill rank we notified of the abort acks exactly once (real
-        # ranks after their in-flight write drains, dummy/already-done ranks
-        # immediately). Requiring an ack from each is dummy-proof: reaching the
-        # count means no prefill can still be writing to these pages. Snapshot
-        # now -- the receiver may be cleared by the time we resolve.
+        # Require an ack from every notified prefill rank (dummy-proof). Snapshot
+        # now -- the receiver may be cleared by resolve time.
         required_acks = len(decode_req.kv_receiver.bootstrap_infos)
         self._deferred_releases.append(
             (decode_req, deadline, decode_req.metadata_buffer_index, required_acks)
@@ -2196,9 +2185,8 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
         return bool(self._deferred_releases)
 
     def resolve_deferred_releases(self) -> None:
-        """Release KV pages/req-slots held for aborted mid-transfer requests once
-        every prefill rank confirms its transfer drained (is_abort_release_safe),
-        or the per-request hold times out."""
+        """Release held requests once every prefill rank acks the drain, or the
+        hold times out."""
         if not self._deferred_releases:
             return
         now = time.monotonic()
@@ -2212,9 +2200,8 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
                 still_held.append((decode_req, deadline, idx, required_acks))
             else:
                 to_release.append((decode_req, idx, room, drained))
-        # Commit the surviving set before releasing anything: an exception in
-        # _do_release must not leave an already-released entry in the list
-        # (a retry would double-free its metadata idx / hit a None receiver).
+        # Commit the survivors before releasing so a _do_release exception can't
+        # leave a released entry in the list (double-free / None receiver on retry).
         self._deferred_releases = still_held
         for decode_req, idx, room, drained in to_release:
             if not drained:
@@ -2226,15 +2213,13 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
             try:
                 self._do_release(decode_req, idx)
             except Exception:
-                # Isolate a single failed release so the rest still run and the
-                # decode loop is not bricked; the entry is already dropped.
+                # Isolate a failed release so the rest still run; entry already dropped.
                 logger.exception(f"Deferred KV release failed for room {room}")
 
     def release_memory_occupation(self):
         """Clean up in-flight transfers before releasing GPU memory."""
         self.queue.clear()
-        # The whole KV pool is being torn down; drop held entries without
-        # per-request release (they point into the pool being freed).
+        # Pool is being torn down; drop held entries without per-request release.
         self._deferred_releases.clear()
 
     def resume_memory_occupation(self):
@@ -2454,10 +2439,8 @@ class SchedulerDisaggregationDecodeMixin:
         if get_disagg().disaggregation_decode_enable_offload_kvcache:
             self.decode_offload_manager.check_offload_progress()
 
-        # Resolve held deferred releases first, every iteration and regardless of
-        # the polling gate / retraction early-return below: their timeouts must
-        # still fire under memory pressure, and freeing them here gives the
-        # retracted-request resumption more room to work with.
+        # Resolve held releases every iteration (before the retraction/polling
+        # gates below) so their timeouts fire under memory pressure.
         self.disagg_decode_transfer_queue.resolve_deferred_releases()
 
         # try to resume retracted requests if there are enough space for another `num_reserved_decode_tokens` decode steps

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -2041,20 +2041,24 @@ class MooncakeKVManager(CommonKVManager):
                     )
                     if self.enable_deferred_decode_kv_release:
                         # Deferred release: hold the ACK until the in-flight
-                        # transfer drains. Register the target BEFORE marking the
-                        # room Failed so the transfer worker -- which acks on the
-                        # Failed transition it observes -- always sees it. We do
-                        # NOT ack from this thread for an active room: only the
-                        # worker that owns the room knows when its write finished,
-                        # and acking here could race an in-flight write. If nothing
-                        # is in flight the worker never revisits the room and decode
+                        # transfer drains. Mark the room Failed FIRST (this stops
+                        # add_transfer_request from enqueuing any new chunk), THEN
+                        # register the ack target. Doing it in this order is
+                        # essential: if we registered first, the worker could
+                        # finish the in-flight chunk and ack (releasing the decode
+                        # pages) while the room is not yet Failed, letting a newly
+                        # enqueued chunk still write to those freed pages. We do
+                        # NOT ack from this thread for an active room -- only the
+                        # worker that owns the room knows when its write finished;
+                        # acking here would race an in-flight write. If nothing is
+                        # in flight the worker never revisits the room and decode
                         # falls back to its release timeout.
                         if room_active:
+                            self.update_status(room_to_be_aborted, KVPoll.Failed)
                             self._deferred_ack_targets[room_to_be_aborted] = (
                                 decode_ip,
                                 decode_port,
                             )
-                            self.update_status(room_to_be_aborted, KVPoll.Failed)
                             logger.debug(
                                 f"Received abort notification for room {room_to_be_aborted}, "
                                 f"marked as Failed; ACK deferred until transfer drains"

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -8,7 +8,7 @@ import struct
 import threading
 import time
 from collections import defaultdict
-from typing import List, Optional, Set, Tuple, Union
+from typing import Dict, List, Optional, Set, Tuple, Union
 
 import numpy as np
 import numpy.typing as npt
@@ -214,6 +214,11 @@ class MooncakeKVManager(CommonKVManager):
             # Per-room count of chunks not yet transferred; teardown waits for
             # zero so a deferred chunk is not dropped by an early conclude.
             self._staging_outstanding = defaultdict(int)
+            # Deferred decode-side KV release: aborted rooms whose ABORT_ACK is
+            # held until the in-flight transfer drains. room -> (decode_ip,
+            # decode_port). Written by the bootstrap thread, read/popped by the
+            # single transfer worker that owns the room (see transfer_worker).
+            self._deferred_ack_targets: Dict[int, Tuple[str, int]] = {}
             self.session_lock = threading.Lock()
             # Determine the number of threads to use for kv sender
             cpu_count = os.cpu_count()
@@ -1612,6 +1617,43 @@ class MooncakeKVManager(CommonKVManager):
             is_ipv6=na.is_ipv6,
         )
 
+    def _prefill_unique_rank(self) -> int:
+        """Stable id for this prefill sender, matching the value the transfer
+        worker syncs on Success so decode can aggregate acks per rank."""
+        return (
+            self.attn_tp_rank * (self.pp_size * self.attn_cp_size)
+            + self.pp_rank * self.attn_cp_size
+            + self.attn_cp_rank
+        )
+
+    def _send_abort_ack(self, decode_ip: str, decode_port: int, room: int) -> None:
+        """Tell decode its aborted room's transfer has drained on this prefill
+        rank (deferred-release path); best-effort like the abort notification."""
+        try:
+            na = NetworkAddress(decode_ip, decode_port)
+            self._send_multipart_locked(
+                na.to_tcp(),
+                [
+                    b"ABORT_ACK",
+                    str(room).encode("ascii"),
+                    str(self._prefill_unique_rank()).encode("ascii"),
+                ],
+                is_ipv6=na.is_ipv6,
+            )
+        except Exception as e:
+            logger.debug(f"Failed to send drained ABORT_ACK for room {room}: {e}")
+
+    def _maybe_ack_drained_abort(self, room: int) -> None:
+        """If ``room`` was aborted and its in-flight transfer has now drained
+        (no outstanding chunk on this worker), send the deferred ABORT_ACK.
+        A room is owned by exactly one transfer worker, so ``pop`` makes this
+        fire at most once."""
+        if self._staging_outstanding.get(room, 0) > 0:
+            return
+        target = self._deferred_ack_targets.pop(room, None)
+        if target is not None:
+            self._send_abort_ack(target[0], target[1], room)
+
     def transfer_worker(
         self,
         queue: FastQueue,
@@ -1651,6 +1693,10 @@ class MooncakeKVManager(CommonKVManager):
                             thread_finish_flag=True,
                         )
                     self._staging_outstanding.pop(kv_chunk.room, None)
+                    if self.enable_deferred_decode_kv_release:
+                        # Chunk skipped => nothing was written for this aborted
+                        # room; safe to release the held ACK.
+                        self._maybe_ack_drained_abort(kv_chunk.room)
                     continue
 
                 # Count each chunk once; the flag survives re-enqueue on defer.
@@ -1925,6 +1971,11 @@ class MooncakeKVManager(CommonKVManager):
                     continue
 
                 self._staging_outstanding[kv_chunk.room] -= 1
+                if self.enable_deferred_decode_kv_release:
+                    # In-flight write for this room just finished; if the room was
+                    # aborted mid-transfer and nothing else is outstanding, its
+                    # pages are now idle -- release the held ACK to decode.
+                    self._maybe_ack_drained_abort(kv_chunk.room)
                 # Tear down only when no chunk is still outstanding and the room
                 # has concluded: already cleared, Success, or a Failed *last*
                 # chunk. A non-last Failed chunk keeps the room (more chunks may
@@ -1984,11 +2035,38 @@ class MooncakeKVManager(CommonKVManager):
                     room_to_be_aborted = int(waiting_req_bytes[1].decode("ascii"))
                     decode_ip = waiting_req_bytes[2].decode("ascii")
                     decode_port = int(waiting_req_bytes[3].decode("ascii"))
-                    # No need to abort the room if it has already succeeded
-                    if (
+                    room_active = (
                         room_to_be_aborted in self.request_status
                         and self.check_status(room_to_be_aborted) != KVPoll.Success
-                    ):
+                    )
+                    if self.enable_deferred_decode_kv_release:
+                        # Deferred release: hold the ACK until the in-flight
+                        # transfer drains. Register the target BEFORE marking the
+                        # room Failed so the transfer worker -- which acks on the
+                        # Failed transition it observes -- always sees it. We do
+                        # NOT ack from this thread for an active room: only the
+                        # worker that owns the room knows when its write finished,
+                        # and acking here could race an in-flight write. If nothing
+                        # is in flight the worker never revisits the room and decode
+                        # falls back to its release timeout.
+                        if room_active:
+                            self._deferred_ack_targets[room_to_be_aborted] = (
+                                decode_ip,
+                                decode_port,
+                            )
+                            self.update_status(room_to_be_aborted, KVPoll.Failed)
+                            logger.debug(
+                                f"Received abort notification for room {room_to_be_aborted}, "
+                                f"marked as Failed; ACK deferred until transfer drains"
+                            )
+                        else:
+                            # Already completed/unknown: no in-flight write, ack now.
+                            self._send_abort_ack(
+                                decode_ip, decode_port, room_to_be_aborted
+                            )
+                        continue
+                    # No need to abort the room if it has already succeeded
+                    if room_active:
                         self.update_status(room_to_be_aborted, KVPoll.Failed)
                         logger.debug(
                             f"Received abort notification for room {room_to_be_aborted}, "
@@ -2102,9 +2180,16 @@ class MooncakeKVManager(CommonKVManager):
 
                 # Prefill acknowledges abort notification
                 if msg[0] == b"ABORT_ACK":
-                    # TODO(shangming): use this info to implement the deferred release mechanism if needed
                     ack_aborted_room = int(msg[1].decode("ascii"))
                     logger.debug(f"Received ABORT_ACK for room {ack_aborted_room}")
+                    # Deferred release: the ack carries the prefill rank and now
+                    # means "my in-flight transfer has drained". Aggregate acks
+                    # so the decode scheduler can release the held slot once every
+                    # required prefill rank has confirmed (see is_abort_release_safe).
+                    if self.enable_deferred_decode_kv_release and len(msg) >= 3:
+                        self.note_abort_ack(
+                            ack_aborted_room, int(msg[2].decode("ascii"))
+                        )
                     continue
 
                 bootstrap_room, status, prefill_rank = msg

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -800,13 +800,7 @@ class MooncakeKVManager(CommonKVManager):
                 )
                 for (src_ptr, dst_ptr, item_len) in layers_params
             ]
-            for future in concurrent.futures.as_completed(futures):
-                status = future.result()
-                if status != 0:
-                    for f in futures:
-                        f.cancel()
-                    return status
-            return 0
+            return self._await_transfer_futures(futures)
         else:
             # Combining all layers' params in one batch transfer is more efficient
             # compared to using multiple threads
@@ -857,6 +851,29 @@ class MooncakeKVManager(CommonKVManager):
                 f"{dst_kv_item_len}. With --enable-unified-memory both sides "
                 "must enable it and use the same page size and model spec."
             )
+
+    def _await_transfer_futures(self, futures) -> int:
+        """Wait for a chunk's per-layer RDMA writes and return the first non-zero
+        status. ``future.cancel()`` is a no-op once a future is running, so on
+        failure we cancel the not-yet-started ones but, when deferred decode-side
+        KV release is enabled, still drain the already-running ones before
+        returning: the drain-ack relies on ``_staging_outstanding == 0`` meaning
+        no write is still touching the decode pages, so no sibling write may
+        outlive this call. With the feature off, keep the original
+        early-return-on-first-failure behavior (byte-identical)."""
+        ret = 0
+        for future in concurrent.futures.as_completed(futures):
+            try:
+                status = future.result()
+            except concurrent.futures.CancelledError:
+                continue
+            if status != 0 and ret == 0:
+                ret = status
+                for f in futures:
+                    f.cancel()
+                if not self.enable_deferred_decode_kv_release:
+                    return ret
+        return ret
 
     def send_kvcache(
         self,
@@ -983,13 +1000,7 @@ class MooncakeKVManager(CommonKVManager):
                 executor.submit(process_layer, src_ptr, dst_ptr, token_item_len)
                 for src_ptr, dst_ptr, token_item_len in layers_params
             ]
-            for future in concurrent.futures.as_completed(futures):
-                status = future.result()
-                if status != 0:
-                    for pending in futures:
-                        pending.cancel()
-                    return status
-            return 0
+            return self._await_transfer_futures(futures)
 
         transfer_blocks = []
         for src_ptr, dst_ptr, token_item_len in layers_params:
@@ -1117,14 +1128,7 @@ class MooncakeKVManager(CommonKVManager):
                 executor.submit(process_layer_tp_aware, src_v_ptrs[i], dst_v_ptrs[i])
             )
 
-        for future in concurrent.futures.as_completed(futures):
-            status = future.result()
-            if status != 0:
-                for f in futures:
-                    f.cancel()
-                return status
-
-        return 0
+        return self._await_transfer_futures(futures)
 
     def send_aux(
         self,

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -214,10 +214,9 @@ class MooncakeKVManager(CommonKVManager):
             # Per-room count of chunks not yet transferred; teardown waits for
             # zero so a deferred chunk is not dropped by an early conclude.
             self._staging_outstanding = defaultdict(int)
-            # Deferred decode-side KV release: aborted rooms whose ABORT_ACK is
-            # held until the in-flight transfer drains. room -> (decode_ip,
-            # decode_port). Written by the bootstrap thread, read/popped by the
-            # single transfer worker that owns the room (see transfer_worker).
+            # Deferred KV release: aborted room -> (decode_ip, decode_port), ack
+            # held until the transfer drains. Written by the bootstrap thread,
+            # popped by the single transfer worker that owns the room.
             self._deferred_ack_targets: Dict[int, Tuple[str, int]] = {}
             self.session_lock = threading.Lock()
             # Determine the number of threads to use for kv sender
@@ -853,14 +852,10 @@ class MooncakeKVManager(CommonKVManager):
             )
 
     def _await_transfer_futures(self, futures) -> int:
-        """Wait for a chunk's per-layer RDMA writes and return the first non-zero
-        status. ``future.cancel()`` is a no-op once a future is running, so on
-        failure we cancel the not-yet-started ones but, when deferred decode-side
-        KV release is enabled, still drain the already-running ones before
-        returning: the drain-ack relies on ``_staging_outstanding == 0`` meaning
-        no write is still touching the decode pages, so no sibling write may
-        outlive this call. With the feature off, keep the original
-        early-return-on-first-failure behavior (byte-identical)."""
+        """Await a chunk's per-layer RDMA writes; return the first non-zero status.
+        cancel() is a no-op for a running future, so with deferred release on we
+        still drain the running ones before returning (no write may outlive this
+        call, which the drain-ack relies on). Off: original early-return."""
         ret = 0
         for future in concurrent.futures.as_completed(futures):
             try:
@@ -1622,8 +1617,7 @@ class MooncakeKVManager(CommonKVManager):
         )
 
     def _prefill_unique_rank(self) -> int:
-        """Stable id for this prefill sender, matching the value the transfer
-        worker syncs on Success so decode can aggregate acks per rank."""
+        """Stable per-sender id, matching what the transfer worker syncs on Success."""
         return (
             self.attn_tp_rank * (self.pp_size * self.attn_cp_size)
             + self.pp_rank * self.attn_cp_size
@@ -1631,8 +1625,7 @@ class MooncakeKVManager(CommonKVManager):
         )
 
     def _send_abort_ack(self, decode_ip: str, decode_port: int, room: int) -> None:
-        """Tell decode its aborted room's transfer has drained on this prefill
-        rank (deferred-release path); best-effort like the abort notification."""
+        """Best-effort ack that this rank's transfer for an aborted room drained."""
         try:
             na = NetworkAddress(decode_ip, decode_port)
             self._send_multipart_locked(
@@ -1648,10 +1641,8 @@ class MooncakeKVManager(CommonKVManager):
             logger.debug(f"Failed to send drained ABORT_ACK for room {room}: {e}")
 
     def _maybe_ack_drained_abort(self, room: int) -> None:
-        """If ``room`` was aborted and its in-flight transfer has now drained
-        (no outstanding chunk on this worker), send the deferred ABORT_ACK.
-        A room is owned by exactly one transfer worker, so ``pop`` makes this
-        fire at most once."""
+        """Send the deferred ack once an aborted room's chunks have drained
+        (outstanding == 0). pop() makes it fire at most once."""
         if self._staging_outstanding.get(room, 0) > 0:
             return
         target = self._deferred_ack_targets.pop(room, None)
@@ -1698,8 +1689,7 @@ class MooncakeKVManager(CommonKVManager):
                         )
                     self._staging_outstanding.pop(kv_chunk.room, None)
                     if self.enable_deferred_decode_kv_release:
-                        # Chunk skipped => nothing was written for this aborted
-                        # room; safe to release the held ACK.
+                        # Skipped => nothing written for this aborted room; ack.
                         self._maybe_ack_drained_abort(kv_chunk.room)
                     continue
 
@@ -1976,9 +1966,8 @@ class MooncakeKVManager(CommonKVManager):
 
                 self._staging_outstanding[kv_chunk.room] -= 1
                 if self.enable_deferred_decode_kv_release:
-                    # In-flight write for this room just finished; if the room was
-                    # aborted mid-transfer and nothing else is outstanding, its
-                    # pages are now idle -- release the held ACK to decode.
+                    # In-flight write finished; if aborted and nothing outstanding,
+                    # the pages are idle -> release the held ack.
                     self._maybe_ack_drained_abort(kv_chunk.room)
                 # Tear down only when no chunk is still outstanding and the room
                 # has concluded: already cleared, Success, or a Failed *last*
@@ -2044,19 +2033,13 @@ class MooncakeKVManager(CommonKVManager):
                         and self.check_status(room_to_be_aborted) != KVPoll.Success
                     )
                     if self.enable_deferred_decode_kv_release:
-                        # Deferred release: hold the ACK until the in-flight
-                        # transfer drains. Mark the room Failed FIRST (this stops
-                        # add_transfer_request from enqueuing any new chunk), THEN
-                        # register the ack target. Doing it in this order is
-                        # essential: if we registered first, the worker could
-                        # finish the in-flight chunk and ack (releasing the decode
-                        # pages) while the room is not yet Failed, letting a newly
-                        # enqueued chunk still write to those freed pages. We do
-                        # NOT ack from this thread for an active room -- only the
-                        # worker that owns the room knows when its write finished;
-                        # acking here would race an in-flight write. If nothing is
-                        # in flight the worker never revisits the room and decode
-                        # falls back to its release timeout.
+                        # Mark Failed FIRST (stops add_transfer_request enqueuing
+                        # new chunks), THEN register the ack target: registering
+                        # first would let the worker drain+ack while the room is
+                        # not yet Failed, so a newly enqueued chunk could still
+                        # write to the freed pages. The worker (not this thread)
+                        # acks once its in-flight write drains; if nothing is in
+                        # flight, decode falls back to the release timeout.
                         if room_active:
                             self.update_status(room_to_be_aborted, KVPoll.Failed)
                             self._deferred_ack_targets[room_to_be_aborted] = (
@@ -2190,10 +2173,8 @@ class MooncakeKVManager(CommonKVManager):
                 if msg[0] == b"ABORT_ACK":
                     ack_aborted_room = int(msg[1].decode("ascii"))
                     logger.debug(f"Received ABORT_ACK for room {ack_aborted_room}")
-                    # Deferred release: the ack carries the prefill rank and now
-                    # means "my in-flight transfer has drained". Aggregate acks
-                    # so the decode scheduler can release the held slot once every
-                    # required prefill rank has confirmed (see is_abort_release_safe).
+                    # Deferred release: the 3-frame ack carries the prefill rank
+                    # and means its transfer drained; aggregate for is_abort_release_safe.
                     if self.enable_deferred_decode_kv_release and len(msg) >= 3:
                         self.note_abort_ack(
                             ack_aborted_room, int(msg[2].decode("ascii"))

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -617,6 +617,14 @@ class Envs:
     SGLANG_DISAGGREGATION_FORCE_QUERY_PREFILL_DP_RANK = EnvBool(False)
     SGLANG_DISAGGREGATION_SAMPLING_MASK_MAX_TOKENS = EnvInt(0)
     SGLANG_DISAGGREGATION_BOOTSTRAP_ENTRY_CLEANUP_INTERVAL = EnvInt(120)
+    # Deferred decode-side KV release: when a decode request is aborted while its
+    # prefill->decode KV transfer may still be in flight, hold its KV pages and
+    # req-pool slot instead of freeing them immediately. The prefill signals (via
+    # ABORT_ACK) once the transfer has drained, and only then does decode release.
+    # If no signal arrives, the slot is force-released after the timeout below.
+    # Off by default: zero behavior/perf impact when disabled.
+    SGLANG_DISAGGREGATION_DEFERRED_DECODE_KV_RELEASE = EnvBool(False)
+    SGLANG_DISAGGREGATION_DEFERRED_DECODE_KV_RELEASE_TIMEOUT = EnvFloat(30.0)
 
     # ===================================================================
     # Distributed and model-parallel runtime

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -617,12 +617,9 @@ class Envs:
     SGLANG_DISAGGREGATION_FORCE_QUERY_PREFILL_DP_RANK = EnvBool(False)
     SGLANG_DISAGGREGATION_SAMPLING_MASK_MAX_TOKENS = EnvInt(0)
     SGLANG_DISAGGREGATION_BOOTSTRAP_ENTRY_CLEANUP_INTERVAL = EnvInt(120)
-    # Deferred decode-side KV release: when a decode request is aborted while its
-    # prefill->decode KV transfer may still be in flight, hold its KV pages and
-    # req-pool slot instead of freeing them immediately. The prefill signals (via
-    # ABORT_ACK) once the transfer has drained, and only then does decode release.
-    # If no signal arrives, the slot is force-released after the timeout below.
-    # Off by default: zero behavior/perf impact when disabled.
+    # Deferred decode-side KV release: on abort, hold an in-flight request's KV
+    # pages/slot until the prefill acks the transfer drained, or the timeout
+    # below fires. Off by default (no behavior/perf impact when disabled).
     SGLANG_DISAGGREGATION_DEFERRED_DECODE_KV_RELEASE = EnvBool(False)
     SGLANG_DISAGGREGATION_DEFERRED_DECODE_KV_RELEASE_TIMEOUT = EnvFloat(30.0)
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -4061,11 +4061,11 @@ class Scheduler(
         # Also skipped while deferred KV releases are pending: they hold pages out
         # of the allocator by design, so the pool is transiently below `total` and
         # would trip the idle leak invariant. Resumes once the holds resolve.
-        _transfer_q = getattr(self, "disagg_decode_transfer_queue", None)
-        _deferred_pending = (
-            _transfer_q is not None and _transfer_q.has_pending_deferred_releases()
+        deferred_pending = (
+            self.disaggregation_mode == DisaggregationMode.DECODE
+            and self.disagg_decode_transfer_queue.has_pending_deferred_releases()
         )
-        if not self.enable_hisparse and not _deferred_pending:
+        if not self.enable_hisparse and not deferred_pending:
             has_leak, messages = self.invariant_checker._check_all_pools(
                 self.pool_stats_observer.get_pool_stats(),
             )
@@ -4553,19 +4553,22 @@ class Scheduler(
             for decode_req in self.disagg_decode_transfer_queue.queue:
                 if recv_req.abort_all or decode_req.req.rid.startswith(recv_req.rid):
                     logger.debug(f"Abort transfer queue request. {decode_req.req.rid=}")
-                    was_notified = decode_req.kv_receiver.abort_notified
-                    decode_req.kv_receiver.abort()
-                    # Arm drain-ack accounting when the ABORT is sent (only on the
-                    # notify transition, so a repeated abort can't wipe collected
-                    # acks) so acks arriving before this req is deferred -- e.g.
-                    # during the next forward step -- are captured, not dropped.
-                    kv_mgr = decode_req.kv_receiver.kv_mgr
+                    receiver = decode_req.kv_receiver
+                    # abort() sends the ABORT and flips abort_notified False->True
+                    # on its first call only; snapshot the value before so we can
+                    # tell whether *this* call is the one that sent it.
+                    already_notified = receiver.abort_notified
+                    receiver.abort()
+                    newly_notified = not already_notified and receiver.abort_notified
+                    # Arm drain-ack accounting on that first ABORT so acks arriving
+                    # before this req is deferred (e.g. during the next forward
+                    # step) are captured; only on the transition, so a repeated
+                    # abort of the same req cannot reset the set and drop acks.
                     if (
-                        kv_mgr.enable_deferred_decode_kv_release
-                        and not was_notified
-                        and decode_req.kv_receiver.abort_notified
+                        receiver.kv_mgr.enable_deferred_decode_kv_release
+                        and newly_notified
                     ):
-                        kv_mgr.register_deferred_abort_room(
+                        receiver.kv_mgr.register_deferred_abort_room(
                             decode_req.req.bootstrap_room
                         )
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -4058,7 +4058,16 @@ class Scheduler(
 
         # memory leak check (skipped for hisparse — pool counters intentionally
         # diverge during host-backup, see _get_swa_token_info clamp).
-        if not self.enable_hisparse:
+        # Also skipped while deferred KV releases are pending: those hold an
+        # aborted request's KV pages/req-slot out of the allocator until the
+        # prefill confirms the transfer drained (or a timeout fires), so the pool
+        # is transiently below `total` by design and would otherwise trip the
+        # idle-time leak invariant. Once the holds resolve the check resumes.
+        _transfer_q = getattr(self, "disagg_decode_transfer_queue", None)
+        _deferred_pending = (
+            _transfer_q is not None and _transfer_q.has_pending_deferred_releases()
+        )
+        if not self.enable_hisparse and not _deferred_pending:
             has_leak, messages = self.invariant_checker._check_all_pools(
                 self.pool_stats_observer.get_pool_stats(),
             )

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -4546,7 +4546,24 @@ class Scheduler(
             for decode_req in self.disagg_decode_transfer_queue.queue:
                 if recv_req.abort_all or decode_req.req.rid.startswith(recv_req.rid):
                     logger.debug(f"Abort transfer queue request. {decode_req.req.rid=}")
+                    was_notified = decode_req.kv_receiver.abort_notified
                     decode_req.kv_receiver.abort()
+                    # Arm drain-ack accounting the first time the ABORT is sent,
+                    # so ABORT_ACKs that arrive before the scheduler defers this
+                    # req -- e.g. during the next forward step -- are captured
+                    # rather than dropped. Only on the notify transition, so a
+                    # repeated abort of the same req cannot wipe acks already
+                    # collected. A fresh set also drops any stale acks from a
+                    # prior request that reused this bootstrap_room.
+                    kv_mgr = decode_req.kv_receiver.kv_mgr
+                    if (
+                        kv_mgr.enable_deferred_decode_kv_release
+                        and not was_notified
+                        and decode_req.kv_receiver.abort_notified
+                    ):
+                        kv_mgr.register_deferred_abort_room(
+                            decode_req.req.bootstrap_room
+                        )
 
             # Abort requests already retracted to CPU cache
             if self.disagg_decode_prealloc_queue.retracted_queue:

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -4554,19 +4554,16 @@ class Scheduler(
                 if recv_req.abort_all or decode_req.req.rid.startswith(recv_req.rid):
                     logger.debug(f"Abort transfer queue request. {decode_req.req.rid=}")
                     receiver = decode_req.kv_receiver
-                    # abort() sends the ABORT and flips abort_notified False->True
-                    # on its first call only; snapshot the value before so we can
-                    # tell whether *this* call is the one that sent it.
-                    already_notified = receiver.abort_notified
                     receiver.abort()
-                    newly_notified = not already_notified and receiver.abort_notified
-                    # Arm drain-ack accounting on that first ABORT so acks arriving
-                    # before this req is deferred (e.g. during the next forward
-                    # step) are captured; only on the transition, so a repeated
-                    # abort of the same req cannot reset the set and drop acks.
+                    # Arm drain-ack accounting once the ABORT is sent, so acks
+                    # arriving before this req is deferred (e.g. during the next
+                    # forward step) are captured. A fresh set also drops stale acks
+                    # from a prior request that reused this bootstrap_room. A
+                    # redundant abort only re-wipes -- holds longer, never releases
+                    # early -- so no transition guard is needed.
                     if (
                         receiver.kv_mgr.enable_deferred_decode_kv_release
-                        and newly_notified
+                        and receiver.abort_notified
                     ):
                         receiver.kv_mgr.register_deferred_abort_room(
                             decode_req.req.bootstrap_room

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -4058,11 +4058,9 @@ class Scheduler(
 
         # memory leak check (skipped for hisparse — pool counters intentionally
         # diverge during host-backup, see _get_swa_token_info clamp).
-        # Also skipped while deferred KV releases are pending: those hold an
-        # aborted request's KV pages/req-slot out of the allocator until the
-        # prefill confirms the transfer drained (or a timeout fires), so the pool
-        # is transiently below `total` by design and would otherwise trip the
-        # idle-time leak invariant. Once the holds resolve the check resumes.
+        # Also skipped while deferred KV releases are pending: they hold pages out
+        # of the allocator by design, so the pool is transiently below `total` and
+        # would trip the idle leak invariant. Resumes once the holds resolve.
         _transfer_q = getattr(self, "disagg_decode_transfer_queue", None)
         _deferred_pending = (
             _transfer_q is not None and _transfer_q.has_pending_deferred_releases()
@@ -4557,13 +4555,10 @@ class Scheduler(
                     logger.debug(f"Abort transfer queue request. {decode_req.req.rid=}")
                     was_notified = decode_req.kv_receiver.abort_notified
                     decode_req.kv_receiver.abort()
-                    # Arm drain-ack accounting the first time the ABORT is sent,
-                    # so ABORT_ACKs that arrive before the scheduler defers this
-                    # req -- e.g. during the next forward step -- are captured
-                    # rather than dropped. Only on the notify transition, so a
-                    # repeated abort of the same req cannot wipe acks already
-                    # collected. A fresh set also drops any stale acks from a
-                    # prior request that reused this bootstrap_room.
+                    # Arm drain-ack accounting when the ABORT is sent (only on the
+                    # notify transition, so a repeated abort can't wipe collected
+                    # acks) so acks arriving before this req is deferred -- e.g.
+                    # during the next forward step -- are captured, not dropped.
                     kv_mgr = decode_req.kv_receiver.kv_mgr
                     if (
                         kv_mgr.enable_deferred_decode_kv_release

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -1468,11 +1468,13 @@ class SchedulerPPMixin:
     def process_decode_transfer_queue(
         self: Scheduler, release_rids: Optional[List[str]]
     ):
+        # Resolve held deferred releases every call, independent of release_rids,
+        # so ack/timeout-driven releases still fire when no rids are being polled.
+        self.disagg_decode_transfer_queue.resolve_deferred_releases()
         if release_rids is not None:
             released_reqs = self.disagg_decode_transfer_queue.pop_transferred(
                 release_rids
             )
-            self.disagg_decode_transfer_queue.resolve_deferred_releases()
             if self.enable_hisparse:
                 for req in released_reqs:
                     self.hisparse_coordinator.admit_request_direct(req)

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -1472,6 +1472,7 @@ class SchedulerPPMixin:
             released_reqs = self.disagg_decode_transfer_queue.pop_transferred(
                 release_rids
             )
+            self.disagg_decode_transfer_queue.resolve_deferred_releases()
             if self.enable_hisparse:
                 for req in released_reqs:
                     self.hisparse_coordinator.admit_request_direct(req)

--- a/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
+++ b/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
@@ -200,6 +200,7 @@ class TestDecodeQueueCleanup(CustomTestCase):
         queue = DecodeTransferQueue.__new__(DecodeTransferQueue)
         queue.queue = [decode_req]
         queue.enable_staging = False
+        queue.enable_deferred_kv_release = False
         queue.gloo_group = MagicMock()
         queue.req_to_metadata_buffer_idx_allocator = MagicMock()
         queue.tp_rank = 0

--- a/test/registered/unit/disaggregation/test_deferred_decode_kv_release.py
+++ b/test/registered/unit/disaggregation/test_deferred_decode_kv_release.py
@@ -9,7 +9,6 @@ fires. See DecodeTransferQueue.resolve_deferred_releases.
 """
 
 import unittest
-from collections import defaultdict
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -26,7 +25,7 @@ def _make_manager():
     """A bare CommonKVManager carrying only the deferred-ack state the helpers
     touch (avoids the heavy real __init__)."""
     mgr = CommonKVManager.__new__(CommonKVManager)
-    mgr._deferred_abort_ack_tracker = defaultdict(set)
+    mgr._deferred_abort_ack_tracker = {}
     return mgr
 
 
@@ -34,6 +33,7 @@ class TestAbortAckAggregation(CustomTestCase):
     def test_release_safe_only_after_all_required_ranks_ack(self):
         mgr = _make_manager()
         room = 100
+        mgr.register_deferred_abort_room(room)
         self.assertFalse(mgr.is_abort_release_safe(room, required_acks=2))
 
         mgr.note_abort_ack(room, 0)
@@ -45,6 +45,7 @@ class TestAbortAckAggregation(CustomTestCase):
     def test_duplicate_rank_ack_does_not_over_count(self):
         mgr = _make_manager()
         room = 101
+        mgr.register_deferred_abort_room(room)
         mgr.note_abort_ack(room, 0)
         mgr.note_abort_ack(room, 0)  # same rank twice
         # Two acks arrived but from one rank: not safe for a 2-rank prefill.
@@ -53,16 +54,63 @@ class TestAbortAckAggregation(CustomTestCase):
     def test_single_rank_fast_path(self):
         mgr = _make_manager()
         room = 102
+        mgr.register_deferred_abort_room(room)
         mgr.note_abort_ack(room, 0)
         self.assertTrue(mgr.is_abort_release_safe(room, required_acks=1))
 
     def test_clear_deferred_abort_state(self):
         mgr = _make_manager()
         room = 103
+        mgr.register_deferred_abort_room(room)
         mgr.note_abort_ack(room, 0)
         mgr.clear_deferred_abort_state(room)
         self.assertNotIn(room, mgr._deferred_abort_ack_tracker)
         self.assertFalse(mgr.is_abort_release_safe(room, required_acks=1))
+
+    def test_ack_before_register_is_dropped(self):
+        # An ack for a room that isn't actively held must not be recorded (it
+        # would otherwise pollute a later request reusing the same room).
+        mgr = _make_manager()
+        room = 104
+        mgr.note_abort_ack(room, 0)  # no register yet
+        self.assertNotIn(room, mgr._deferred_abort_ack_tracker)
+        self.assertFalse(mgr.is_abort_release_safe(room, required_acks=1))
+
+    def test_late_ack_after_release_does_not_pollute_reused_room(self):
+        # Regression for bootstrap_room reuse: req A (room R) releases, then a
+        # late ack from A arrives, then req B reuses room R. B must start from a
+        # clean slate and not inherit A's ack (which would release B early while
+        # its transfer is still in flight -> KV corruption).
+        mgr = _make_manager()
+        room = 105
+
+        # Req A: held, one of two ranks acks, then released (e.g. timed out).
+        mgr.register_deferred_abort_room(room)
+        mgr.note_abort_ack(room, 0)
+        mgr.clear_deferred_abort_state(room)
+
+        # Late ack from A's other rank arrives after release -> dropped.
+        mgr.note_abort_ack(room, 1)
+        self.assertNotIn(room, mgr._deferred_abort_ack_tracker)
+
+        # Req B reuses room R.
+        mgr.register_deferred_abort_room(room)
+        # Only B's rank-0 has acked so far; a 2-rank prefill is NOT safe yet.
+        mgr.note_abort_ack(room, 0)
+        self.assertFalse(mgr.is_abort_release_safe(room, required_acks=2))
+        mgr.note_abort_ack(room, 1)
+        self.assertTrue(mgr.is_abort_release_safe(room, required_acks=2))
+
+    def test_register_resets_stale_acks(self):
+        mgr = _make_manager()
+        room = 106
+        mgr.register_deferred_abort_room(room)
+        mgr.note_abort_ack(room, 0)
+        mgr.note_abort_ack(room, 1)
+        self.assertTrue(mgr.is_abort_release_safe(room, required_acks=2))
+        # Re-registering (a later reuse) wipes the prior acks.
+        mgr.register_deferred_abort_room(room)
+        self.assertFalse(mgr.is_abort_release_safe(room, required_acks=2))
 
 
 class _FakeIdxAllocator:
@@ -112,6 +160,9 @@ class TestResolveDeferredReleases(CustomTestCase):
         room, idx = 200, 7
         q = _make_queue()
         dreq = _make_decode_req(room, idx, mgr, n_prefill_ranks=2)
+        # In production the room is armed in abort_request when the ABORT is
+        # sent, before the scheduler defers here.
+        mgr.register_deferred_abort_room(room)
         q._defer_release(dreq)
 
         with patch.object(decode_mod, "release_kv_cache") as rel:
@@ -153,6 +204,32 @@ class TestResolveDeferredReleases(CustomTestCase):
         self.assertEqual(q._deferred_releases, [])
         self.assertEqual(q.req_to_metadata_buffer_idx_allocator.freed, [idx])
         self.assertIsNone(dreq.kv_receiver)
+
+    def test_failed_release_is_isolated_and_not_retried(self):
+        # A raising _do_release must drop the entry (no double-free on retry) and
+        # not brick resolve for the remaining entries or subsequent calls.
+        mgr = _make_manager()
+        q = _make_queue()
+        good = _make_decode_req(700, 1, mgr)
+        bad = _make_decode_req(701, 2, mgr)
+        # Both already past deadline -> both selected for release.
+        q._deferred_releases.append((bad, float("-inf"), 2, 1))
+        q._deferred_releases.append((good, float("-inf"), 1, 1))
+
+        calls = []
+
+        def fake_release(req, tree_cache, is_insert):
+            calls.append(req)
+            if req is bad.req:
+                raise RuntimeError("boom")
+
+        with patch.object(decode_mod, "release_kv_cache", side_effect=fake_release):
+            q.resolve_deferred_releases()  # must not raise
+            # The good one still released despite the bad one throwing.
+            self.assertIn(good.req, calls)
+            # Nothing left held, and a second call is a clean no-op (no retry).
+            self.assertEqual(q._deferred_releases, [])
+            q.resolve_deferred_releases()
 
     def test_defer_release_records_deadline_and_idx(self):
         mgr = _make_manager()

--- a/test/registered/unit/disaggregation/test_deferred_decode_kv_release.py
+++ b/test/registered/unit/disaggregation/test_deferred_decode_kv_release.py
@@ -1,0 +1,170 @@
+"""Unit tests for the deferred decode-side KV release mechanism.
+
+When a decode request is aborted while its prefill->decode KV transfer may still
+be in flight, the decode side holds its KV pages / req-slot instead of freeing
+them immediately (which could let the still-in-flight write land on pages already
+reused by another request). The pages are released once every prefill rank acks
+that its transfer drained (CommonKVManager.is_abort_release_safe), or a timeout
+fires. See DecodeTransferQueue.resolve_deferred_releases.
+"""
+
+import unittest
+from collections import defaultdict
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.srt.disaggregation import decode as decode_mod
+from sglang.srt.disaggregation.common.conn import CommonKVManager
+from sglang.srt.disaggregation.decode import DecodeTransferQueue
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _make_manager():
+    """A bare CommonKVManager carrying only the deferred-ack state the helpers
+    touch (avoids the heavy real __init__)."""
+    mgr = CommonKVManager.__new__(CommonKVManager)
+    mgr._deferred_abort_ack_tracker = defaultdict(set)
+    return mgr
+
+
+class TestAbortAckAggregation(CustomTestCase):
+    def test_release_safe_only_after_all_required_ranks_ack(self):
+        mgr = _make_manager()
+        room = 100
+        self.assertFalse(mgr.is_abort_release_safe(room, required_acks=2))
+
+        mgr.note_abort_ack(room, 0)
+        self.assertFalse(mgr.is_abort_release_safe(room, required_acks=2))
+
+        mgr.note_abort_ack(room, 1)
+        self.assertTrue(mgr.is_abort_release_safe(room, required_acks=2))
+
+    def test_duplicate_rank_ack_does_not_over_count(self):
+        mgr = _make_manager()
+        room = 101
+        mgr.note_abort_ack(room, 0)
+        mgr.note_abort_ack(room, 0)  # same rank twice
+        # Two acks arrived but from one rank: not safe for a 2-rank prefill.
+        self.assertFalse(mgr.is_abort_release_safe(room, required_acks=2))
+
+    def test_single_rank_fast_path(self):
+        mgr = _make_manager()
+        room = 102
+        mgr.note_abort_ack(room, 0)
+        self.assertTrue(mgr.is_abort_release_safe(room, required_acks=1))
+
+    def test_clear_deferred_abort_state(self):
+        mgr = _make_manager()
+        room = 103
+        mgr.note_abort_ack(room, 0)
+        mgr.clear_deferred_abort_state(room)
+        self.assertNotIn(room, mgr._deferred_abort_ack_tracker)
+        self.assertFalse(mgr.is_abort_release_safe(room, required_acks=1))
+
+
+class _FakeIdxAllocator:
+    def __init__(self):
+        self.freed = []
+
+    def free(self, idx):
+        self.freed.append(idx)
+
+
+def _make_queue(timeout=30.0):
+    q = DecodeTransferQueue.__new__(DecodeTransferQueue)
+    q._deferred_releases = []
+    q.deferred_kv_release_timeout = timeout
+    q.enable_staging = False
+    q.staging_handler = None
+    q.tree_cache = object()
+    q.metadata_buffers = SimpleNamespace(bootstrap_room={})
+    q.req_to_metadata_buffer_idx_allocator = _FakeIdxAllocator()
+    return q
+
+
+def _make_decode_req(room, idx, mgr, n_prefill_ranks=1):
+    receiver = SimpleNamespace(
+        kv_mgr=mgr,
+        # One entry per prefill rank the decode notified of the abort; its length
+        # is the required drain-ack count (see DecodeTransferQueue._defer_release).
+        bootstrap_infos=[{"rank": r} for r in range(n_prefill_ranks)],
+        clear=lambda: None,
+    )
+    return SimpleNamespace(
+        req=SimpleNamespace(bootstrap_room=room),
+        kv_receiver=receiver,
+        metadata_buffer_index=idx,
+    )
+
+
+class TestResolveDeferredReleases(CustomTestCase):
+    def test_noop_when_nothing_deferred(self):
+        q = _make_queue()
+        with patch.object(decode_mod, "release_kv_cache") as rel:
+            q.resolve_deferred_releases()
+        rel.assert_not_called()
+
+    def test_holds_until_drained_then_releases(self):
+        mgr = _make_manager()
+        room, idx = 200, 7
+        q = _make_queue()
+        dreq = _make_decode_req(room, idx, mgr, n_prefill_ranks=2)
+        q._defer_release(dreq)
+
+        with patch.object(decode_mod, "release_kv_cache") as rel:
+            # Not yet acked -> held, not released.
+            q.resolve_deferred_releases()
+            rel.assert_not_called()
+            self.assertEqual(len(q._deferred_releases), 1)
+
+            # One of two ranks acked -> still held.
+            mgr.note_abort_ack(room, 0)
+            q.resolve_deferred_releases()
+            rel.assert_not_called()
+            self.assertEqual(len(q._deferred_releases), 1)
+
+            # Both ranks acked -> released exactly once.
+            mgr.note_abort_ack(room, 1)
+            q.resolve_deferred_releases()
+            rel.assert_called_once_with(dreq.req, q.tree_cache, is_insert=False)
+
+        # Held state fully cleaned up.
+        self.assertEqual(q._deferred_releases, [])
+        self.assertEqual(q.req_to_metadata_buffer_idx_allocator.freed, [idx])
+        self.assertEqual(q.metadata_buffers.bootstrap_room[idx], 0)
+        self.assertNotIn(room, mgr._deferred_abort_ack_tracker)
+        self.assertIsNone(dreq.kv_receiver)
+
+    def test_releases_on_timeout_without_ack(self):
+        mgr = _make_manager()
+        room, idx = 300, 3
+        q = _make_queue(timeout=30.0)
+        dreq = _make_decode_req(room, idx, mgr, n_prefill_ranks=1)
+        # Force an already-expired deadline (no ack will ever arrive).
+        q._deferred_releases.append((dreq, float("-inf"), idx, 1))
+
+        with patch.object(decode_mod, "release_kv_cache") as rel:
+            q.resolve_deferred_releases()
+            rel.assert_called_once_with(dreq.req, q.tree_cache, is_insert=False)
+
+        self.assertEqual(q._deferred_releases, [])
+        self.assertEqual(q.req_to_metadata_buffer_idx_allocator.freed, [idx])
+        self.assertIsNone(dreq.kv_receiver)
+
+    def test_defer_release_records_deadline_and_idx(self):
+        mgr = _make_manager()
+        q = _make_queue(timeout=12.5)
+        dreq = _make_decode_req(room=400, idx=9, mgr=mgr)
+        q._defer_release(dreq)
+        self.assertEqual(len(q._deferred_releases), 1)
+        held_req, deadline, held_idx, required = q._deferred_releases[0]
+        self.assertIs(held_req, dreq)
+        self.assertEqual(held_idx, 9)
+        self.assertIsInstance(deadline, float)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Aborting a decode request (long-ITL abort/timeout, `/abort_request`) while its prefill→decode KV transfer is still in flight frees the request's KV pages and req-pool slot **immediately**, but does **not** cancel the transfer. The next request can then be allocated those same pages and have them overwritten by the earlier, still-in-flight write — the next request silently holds the first request's KV, with no error raised anywhere. This is the race [@ShangmingCai anticipated in #27372](https://github.com/sgl-project/sglang/pull/27372) ("we could introduce deferred release of decode-side KVCache to fix this"), the open bug in #32564, and the reason the `ABORT_ACK` handler in `mooncake/conn.py` carries a `TODO(shangming)` for exactly this mechanism.

It is also why an O(1) tail-pop free-slot change like #34876 is unsafe on the decode side today: LIFO reuse maximally shrinks the free→reuse window and maximizes the probability of hitting this race. This PR is the prerequisite that makes immediate slot reuse safe.

## What this does

An **env-gated deferred-release path**. When off (default) there is **zero behavior/perf change** — every new branch is behind an `enable_deferred_*` guard, and the wire format / free path are byte-identical. When on, an aborted request's KV pages, req-slot and metadata buffer are **held** until the prefill proves its transfer drained, then released.

**Prefill (`mooncake/conn.py`).** On an `ABORT` for an active room, mark the room `Failed` **first** (stops `add_transfer_request` from enqueuing new chunks), then register the ack target, and do **not** ack from the bootstrap thread. The single transfer worker that owns the room sends the `ABORT_ACK` — carrying its prefill rank — once the room's in-flight chunk has drained (at both the skip and completion sites, via `_maybe_ack_drained_abort`). Rooms already done/unknown ack immediately.

**Decode (`decode.py` + `common/conn.py`).** On the `Failed` poll (for a decode-initiated abort), instead of releasing, move the request to a held list with a deadline. `resolve_deferred_releases()` (called early every scheduler step) releases a room once **every prefill rank the abort was sent to** has acked (`is_abort_release_safe`) or the timeout fires. The per-room ack tracker is armed in `abort_request` when the `ABORT` is sent, so acks that arrive during the next forward step are captured.

### Why it's correct

- **Single-writer per room.** A room's chunks shard to one transfer queue served by exactly one worker thread (`session_port_sum % len(transfer_queues)`, one thread per queue), so a room's writes and its `_staging_outstanding` counter are single-writer. The ack is driven **entirely from that worker**, never the bootstrap thread, so it can't race an in-flight write. No new locks.
- **Dummy-proof denominator.** The decode requires an ack from **each** prefill rank it notified (`len(bootstrap_infos)`), not `required_prefill_response_num`. Every notified rank acks exactly once — real ranks after their write drains, dummy/already-done ranks immediately — so reaching the count provably means no prefill can still be writing to those pages. Over/under-counting from dummy ranks (which would cause early release = corruption) is impossible.
- **Timeout backstop.** If an ack never arrives (dead prefill rank, stuck send), the pages are force-released after the timeout — matching the ~30s mooncake transfer ceiling noted in #27372.

### Coverage / fallback (honest scope)

The fast (ack-driven) release fires for the primary corruption scenario — an abort while the transfer is actively in flight on the notified ranks. Cases where a rank already concluded before the abort fall back to the timeout hold (safe, never an early release). This is a deliberately lighter alternative to the full lease/barrier rework in #32564; it reuses the existing `ABORT`/`ABORT_ACK` channel and changes only *when* the ack is sent and *when* decode releases.

## Env

- `SGLANG_DISAGGREGATION_DEFERRED_DECODE_KV_RELEASE` (bool, default `False`)
- `SGLANG_DISAGGREGATION_DEFERRED_DECODE_KV_RELEASE_TIMEOUT` (float seconds, default `30.0`)

## Tests

`test/registered/unit/disaggregation/test_deferred_decode_kv_release.py`:
- ack aggregation: release-safe only after all required ranks ack; duplicate-rank ack does not over-count; single-rank fast path; state cleared.
- `resolve_deferred_releases`: holds until drained then releases exactly once (frees metadata idx, resets `bootstrap_room`, clears deferred state, nulls receiver); releases on timeout without ack; no-op when nothing deferred.

## Validation status

**Validated on a 2×H200 devbox** (1 prefill + 1 decode, mooncake, SmolLM2-135M, feature ON). Unit tests (12) also pass on the real modules.

- ✅ **No happy-path regression** with the flag on: PD warmup (a real prefill→decode transfer) and normal completions work.
- ✅ **Found + fixed a real crash** the unit tests and code review both missed: the idle-time pool-leak invariant (`Scheduler.on_idle`) counts deferred-held KV pages as a leak and kills the decode scheduler when it goes idle mid-hold. Fixed by skipping the idle pool/req-pool check while holds are pending (last commit).
- ✅ **Robust under an abort storm:** 132 requests aborted mid-transfer through the deferred path, **zero crashes**; after the holds resolved, the (now un-suppressed) idle invariant reported **no leak** — every held page was released.

### ✅ Corruption reproduced and the fix verified (deterministic)

Instrumented the devbox build with an env-gated delay in the prefill KV write (widen the in-flight window) + logging of each request's decode KV page set, the prefill write window, and the abort free/hold event. Constrained the decode pool (`--max-total-tokens 96`) so a freed page is forced to be reused.

**OFF (bug reproduced):** request A `ALLOC pages=[14..44]` → prefill `WRITE [14..44]` in flight `t=878.80→~884.80` → abort → `FREE mode=immediate t=881.28` → request B `ALLOC pages=[1..32]` at `t=881.31`. B's pages **overlap A's at [14..32]**, handed out **while A's write to those pages is still in flight** → A's write lands on B's KV = the #32564 corruption.

**ON (fix verified, identical scenario):** A `ALLOC [15..45]` → `WRITE [15..45]` in flight `990.13→~996.13` → abort → **`FREE mode=deferred`** → **no overlapping allocation occurs during the write window**; A's pages are held and released only after the drain (here via the 30 s timeout). No corruption, no crash. Under this pathological tiny pool the waiting requests fail-safe (backpressure/500) rather than receive corrupted KV — the correct trade-off.

### ✅ End-to-end wrong-output proof (deterministic)

The reuse window above is *necessary* for corruption; to show it produces *wrong tokens*, I modelled the aborted donor's still-in-flight write landing on the victim by capturing the donor's freed KV page at abort and, at the victim's commit (before it decodes), overwriting the *overlap* pages with foreign values. Same prompt, greedy decode, single victim page reused:

| | victim output |
|---|---|
| baseline (no abort) | `...the sequence: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,` |
| **OFF** (page freed → reused → stale write lands) | `Iortiumortiumortium torchvision…unsqueeze…trademin…nargs` — **garbage** |
| **ON** (page held → victim gets fresh pages, `NO overlap`) | `...the sequence: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,` — **correct** |

Even a *single* reused-then-overwritten KV page garbles the victim's entire generation. Same code path, opposite outcome, gated only by the flag. (Also note: on a single-queue 1P1D-tp1 path the prefill worker is serial, so the donor's write can't naturally reorder after the victim's — the real bug relies on Mooncake's async sibling-future writes that keep running after the worker concludes; the injection above models that landing deterministically. All repro instrumentation is test-only and not part of this PR.)

### Drain-ack correctness (addressed)

The drain-ack fires when `_staging_outstanding[room] == 0`, which assumes `send_kvcache` leaves no write in flight when it returns. Verified: the default `batch_transfer_sync` path is synchronous, and the custom-mem-pool executor path awaits every layer future on success. The one gap was the executor **failure** branch — it returned on the first failing future and only `cancel()`ed the rest (a no-op for an already-running future), so sibling writes could outlive the chunk (the lingering-write hazard #32564 flags) and the ack could fire early. The three KV-write executor loops now route through `_await_transfer_futures()`, which — when the feature is on — drains the running futures before returning (byte-identical early-return when off). `send_aux` is synchronous; the mamba/state path (`maybe_send_extra`) is a documented follow-up.

Still pending (need GPU/CI — not correctness blockers now that the above is fixed):
- ⚠️ **Fast-ACK path efficacy:** on fast tiny-model transfers most holds released via the timeout, not the drain-ack (window too narrow to abort mid-transfer). Needs a larger model / long context to show the ack path firing well below the timeout. The feature is *safe* either way (timeout is the backstop); this validates the optimization actually triggers.
- ⚠️ **Multi-node / TP>1 / dummy-rank fan-out** — the `len(bootstrap_infos)` denominator is untested where the real async multi-queue concurrency lives.
- ⚠️ **CI** — gated on the `run-ci` label; the full suite (incl. disaggregation integration tests) hasn't run.
- **Design overlap with #32564** (the heavier lease/barrier approach) is a maintainer call.

## Checklist

- [x] Format with pre-commit (black/isort)
- [x] Add unit tests
- [ ] Provide accuracy/speed benchmark results (N/A — abort-path correctness change; no kernel/throughput impact when off)
- [x] Code style

Related: #27372, #32564, #34876

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Self-review hardening (2nd commit)

An adversarial multi-agent review of the first commit surfaced and fixed several real issues:

- **Corruption (prefill ordering):** mark the room `Failed` **before** registering the ack target — the reverse order let the worker drain + ACK while the room wasn't yet `Failed`, so a newly-enqueued chunk could still write to already-freed decode pages.
- **Corruption (room-reuse pollution):** `bootstrap_room` is not globally unique; a stale/late ACK could satisfy a later request reusing the room and release it early. The ack tracker is now armed/reset per abort episode (in `abort_request` when the ABORT is sent) and drops acks for unregistered rooms.
- **Functionality (ack timing):** arming the tracker at defer-time lost almost every ACK (a full forward step runs between `abort()` and deferral), degrading every fast release to a timeout. Now armed when the ABORT is sent.
- **Leak/functional (resolve reachability):** `resolve_deferred_releases` now runs early and unconditionally (was behind the retraction early-return and the polling gate; and independent of `release_rids` in the PP path), so held slots still time out under memory pressure.
- **Corruption/cascade (resolve):** commit the surviving set before releasing and isolate a failing `_do_release`, so one error can't double-free a metadata idx or brick the decode loop.
- Only decode-initiated aborts are deferred (`abort_notified`); prefill-initiated failures release immediately.

Added regression tests for reuse-pollution, ack-before-register drop, and release-exception isolation.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32100643263](https://github.com/sgl-project/sglang/actions/runs/32100643263)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32100643146](https://github.com/sgl-project/sglang/actions/runs/32100643146)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->