### PR TITLE
fix(logprobs): guard tolist on mixed token-ids/top logprobs batches (#34719)

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -408,14 +408,17 @@ class SchedulerBatchResultProcessor:
                 )
             if logits_output.next_token_top_logprobs_val:
                 logits_output.next_token_top_logprobs_val = [
-                    v.tolist() for v in logits_output.next_token_top_logprobs_val
+                    (v.tolist() if torch.is_tensor(v) else v)
+                    for v in logits_output.next_token_top_logprobs_val
                 ]
                 logits_output.next_token_top_logprobs_idx = [
-                    x.tolist() for x in logits_output.next_token_top_logprobs_idx
+                    (x.tolist() if torch.is_tensor(x) else x)
+                    for x in logits_output.next_token_top_logprobs_idx
                 ]
             if logits_output.next_token_token_ids_logprobs_val:
                 logits_output.next_token_token_ids_logprobs_val = [
-                    v.tolist() for v in logits_output.next_token_token_ids_logprobs_val
+                    (v.tolist() if torch.is_tensor(v) else v)
+                    for v in logits_output.next_token_token_ids_logprobs_val
                 ]
 
     def _apply_prefill_logprobs(
@@ -938,15 +941,18 @@ class SchedulerBatchResultProcessor:
             next_token_logprobs = logits_output.next_token_logprobs.tolist()
             if logits_output.next_token_top_logprobs_val:
                 logits_output.next_token_top_logprobs_val = [
-                    v.tolist() for v in logits_output.next_token_top_logprobs_val
+                    (v.tolist() if torch.is_tensor(v) else v)
+                    for v in logits_output.next_token_top_logprobs_val
                 ]
                 logits_output.next_token_top_logprobs_idx = [
-                    x.tolist() for x in logits_output.next_token_top_logprobs_idx
+                    (x.tolist() if torch.is_tensor(x) else x)
+                    for x in logits_output.next_token_top_logprobs_idx
                 ]
 
             if logits_output.next_token_token_ids_logprobs_val:
                 logits_output.next_token_token_ids_logprobs_val = [
-                    v.tolist() for v in logits_output.next_token_token_ids_logprobs_val
+                    (v.tolist() if torch.is_tensor(v) else v)
+                    for v in logits_output.next_token_token_ids_logprobs_val
                 ]
         return next_token_ids, next_token_logprobs
 


### PR DESCRIPTION
## Summary

Fixes #34719. When a request that asks for token-ids logprobs (`token_ids_logprob`) shares a batch with a request that does not, the scheduler process dies with:

```
AttributeError: 'list' object has no attribute 'tolist'
```

One scoring client can take the whole server down.

## Root cause

`get_token_ids_logprobs_raw` / `get_top_logprobs_raw` (`python/sglang/srt/layers/logprob_processor.py`) build per-request lists whose entries are **heterogeneous**:

- a request that asked for the logprobs contributes a device **tensor** (`vals.append(row ...)`, e.g. L151/L172);
- a co-batched request that did **not** contributes a bare **`[]`** (L144-145, L159-165).

Both consumers in `batch_result_processor.py` — `move_logprobs_to_cpu` (prefill) and `_normalize_decode_outputs` (decode) — then call `.tolist()` unconditionally on every entry:

```python
logits_output.next_token_token_ids_logprobs_val = [
    v.tolist() for v in logits_output.next_token_token_ids_logprobs_val
]
```

The plain-`[]` entries have no `.tolist()`, so the whole batch crashes. When every request in the batch asks for the logprobs the entries are all tensors and the bug is hidden — it only surfaces on mixed batches. `next_token_top_logprobs_val` / `next_token_top_logprobs_idx` carry the identical latent pattern at both sites.

## Fix

Guard each entry with `torch.is_tensor` before converting, matching the style already used for `embeddings` a few lines above (`[tensor.tolist() for tensor in embeddings]`). Tensor entries convert exactly as before; plain-list entries pass through unchanged — no behavior change for the all-requesting case.

## Verification

Standalone reproduction of the comprehension confirms the old code raises `AttributeError: 'list' object has no attribute 'tolist'` on a mixed `[tensor, []]` list, while the guarded version returns `[[...], []]` and leaves the all-tensor case byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31966715761](https://github.com/sgl-project/sglang/actions/runs/31966715761)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31966715537](https://github.com/sgl-project/sglang/actions/runs/31966715537)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->