### PR TITLE
[diffusion] Add hierarchical startup-time breakdown (SGLANG_DIFFUSION_STARTUP_PROFILE)

### DIFF
--- a/python/sglang/multimodal_gen/envs.py
+++ b/python/sglang/multimodal_gen/envs.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     VERBOSE: bool = False
     SGLANG_DIFFUSION_SERVER_DEV_MODE: bool = False
     SGLANG_DIFFUSION_STAGE_LOGGING: bool = False
+    SGLANG_DIFFUSION_STARTUP_PROFILE: bool = False
     SGLANG_DIFFUSION_CFG_GATE_STEP: float = 1.0
     # cache-dit env vars (primary transformer)
     # on by default; engages only on 2 ranks with peer-to-peer access and falls
@@ -221,6 +222,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # If set, sgl_diffusion will enable stage logging, which will print the time
     # taken for each stage
     "SGLANG_DIFFUSION_STAGE_LOGGING": _lazy_bool("SGLANG_DIFFUSION_STAGE_LOGGING"),
+    # If set, log a hierarchical breakdown of server launch / pipeline load time
+    # (distributed init, per-component weight loading, ...). See #19087.
+    "SGLANG_DIFFUSION_STARTUP_PROFILE": _lazy_bool("SGLANG_DIFFUSION_STARTUP_PROFILE"),
     # Fraction of denoising steps that run both CFG branches before reusing the
     # last conditional-minus-unconditional residual. Keep 1.0 to disable.
     "SGLANG_DIFFUSION_CFG_GATE_STEP": _lazy_float(

--- a/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
+++ b/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
@@ -82,6 +82,10 @@ from sglang.multimodal_gen.runtime.utils.realtime_video import (
     RAW_RGB_CONTENT_TYPE,
     build_raw_rgb_frame_batches,
 )
+from sglang.multimodal_gen.runtime.utils.startup_profiler import (
+    log_startup_summary,
+    startup_phase,
+)
 from sglang.multimodal_gen.runtime.utils.trace_wrapper import (
     DiffStage,
     init_diffusion_tracing,
@@ -228,7 +232,13 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
 
     def init_device_and_model(self) -> None:
         """Initialize the device and load the model."""
-        current_platform.set_device(current_platform.get_device(self.local_rank))
+        with startup_phase("init_device_and_model"):
+            self._init_device_and_model()
+        log_startup_summary()
+
+    def _init_device_and_model(self) -> None:
+        with startup_phase("set_device"):
+            current_platform.set_device(current_platform.get_device(self.local_rank))
         # num_gpus is the total world size across every node; the co-located,
         # CPU-contending worker count on THIS host is num_gpus // nnodes.
         local_num_gpus = self.server_args.num_gpus // self.server_args.nnodes
@@ -249,16 +259,17 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
         os.environ["WORLD_SIZE"] = str(self.server_args.num_gpus)
         self._configure_persistent_torch_compile_cache()
         # initialize the distributed environment
-        maybe_init_distributed_environment_and_model_parallel(
-            tp_size=self.server_args.tp_size,
-            cfg_degree=self.server_args.cfg_parallel_degree or 1,
-            ulysses_degree=self.server_args.ulysses_degree,
-            ring_degree=self.server_args.ring_degree,
-            sp_size=self.server_args.sp_degree,
-            dp_size=self.server_args.dp_size,
-            distributed_init_method=rendezvous_addr.to_tcp(),
-            dist_timeout=self.server_args.dist_timeout,
-        )
+        with startup_phase("init_distributed_environment"):
+            maybe_init_distributed_environment_and_model_parallel(
+                tp_size=self.server_args.tp_size,
+                cfg_degree=self.server_args.cfg_parallel_degree or 1,
+                ulysses_degree=self.server_args.ulysses_degree,
+                ring_degree=self.server_args.ring_degree,
+                sp_size=self.server_args.sp_degree,
+                dp_size=self.server_args.dp_size,
+                distributed_init_method=rendezvous_addr.to_tcp(),
+                dist_timeout=self.server_args.dist_timeout,
+            )
 
         from sglang.srt.runtime_context import get_context
         from sglang.srt.server_args import ServerArgs as SrtServerArgs
@@ -285,7 +296,8 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
         else:
             setproctitle(f"sgl_diffusion::scheduler_{self.local_rank}")
 
-        self.pipeline = build_pipeline(self.server_args)
+        with startup_phase("build_pipeline"):
+            self.pipeline = build_pipeline(self.server_args)
 
         # apply layerwise offload after lora is applied while building LoRAPipeline
         # otherwise empty offloaded weights could fail lora converting

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/__init__.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/__init__.py
@@ -23,6 +23,7 @@ from sglang.multimodal_gen.runtime.utils.hf_diffusers_utils import (
     verify_model_config_and_directory as verify_model_config_and_directory,
 )
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+from sglang.multimodal_gen.runtime.utils.startup_profiler import startup_phase
 
 logger = init_logger(__name__)
 
@@ -69,16 +70,18 @@ def build_pipeline(
     else:
         logger.info("No pipeline_class_name specified, using model_index.json")
 
-        model_info = get_model_info(
-            model_path,
-            backend=server_args.backend,
-            model_id=server_args.model_id,
-        )
+        with startup_phase("get_model_info"):
+            model_info = get_model_info(
+                model_path,
+                backend=server_args.backend,
+                model_id=server_args.model_id,
+            )
         pipeline_cls = model_info.pipeline_cls
         logger.info(f"Using pipeline from model_index.json: {pipeline_cls.__name__}")
 
     # instantiate the pipelines
-    pipeline = pipeline_cls(model_path, server_args)
+    with startup_phase("pipeline_instantiation"):
+        pipeline = pipeline_cls(model_path, server_args)
 
     logger.info("Pipeline instantiated")
 

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/composed_pipeline_base.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/composed_pipeline_base.py
@@ -558,10 +558,11 @@ class ComposedPipelineBase(ABC):
                     attn_backend.name.lower(),
                     matched_backend_key,
                 )
-            with startup_phase(f"load_component.{module_name}"), (
+            with (
+                startup_phase(f"load_component.{module_name}"),
                 component_attn_backend_context_manager(
                     attn_backend, component_name=matched_backend_key or module_name
-                )
+                ),
             ):
                 module, memory_usage = PipelineComponentLoader.load_component(
                     component_name=load_module_name,

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/composed_pipeline_base.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/composed_pipeline_base.py
@@ -59,6 +59,7 @@ from sglang.multimodal_gen.runtime.utils.hf_diffusers_utils import (
     verify_model_config_and_directory,
 )
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+from sglang.multimodal_gen.runtime.utils.startup_profiler import startup_phase
 
 logger = init_logger(__name__)
 
@@ -146,7 +147,8 @@ class ComposedPipelineBase(ABC):
         self.memory_usages: dict[str, float] = {}
         # Load modules directly in initialization
         logger.info("Loading pipeline modules...")
-        self.modules = self.load_modules(server_args, loaded_modules)
+        with startup_phase("load_modules"):
+            self.modules = self.load_modules(server_args, loaded_modules)
 
         self.__post_init__()
 
@@ -161,10 +163,12 @@ class ComposedPipelineBase(ABC):
 
     def __post_init__(self) -> None:
         assert self.server_args is not None, "server_args must be set"
-        self.initialize_pipeline(self.server_args)
+        with startup_phase("initialize_pipeline"):
+            self.initialize_pipeline(self.server_args)
 
         logger.info("Creating pipeline stages...")
-        self.create_pipeline_stages(self.server_args)
+        with startup_phase("create_pipeline_stages"):
+            self.create_pipeline_stages(self.server_args)
 
     def get_module(self, module_name: str, default_value: Any = None) -> Any:
         return self.modules.get(module_name, default_value)
@@ -554,8 +558,10 @@ class ComposedPipelineBase(ABC):
                     attn_backend.name.lower(),
                     matched_backend_key,
                 )
-            with component_attn_backend_context_manager(
-                attn_backend, component_name=matched_backend_key or module_name
+            with startup_phase(f"load_component.{module_name}"), (
+                component_attn_backend_context_manager(
+                    attn_backend, component_name=matched_backend_key or module_name
+                )
             ):
                 module, memory_usage = PipelineComponentLoader.load_component(
                     component_name=load_module_name,

--- a/python/sglang/multimodal_gen/runtime/utils/startup_profiler.py
+++ b/python/sglang/multimodal_gen/runtime/utils/startup_profiler.py
@@ -11,7 +11,10 @@ from contextlib import contextmanager
 from typing import Iterator
 
 import sglang.multimodal_gen.envs as envs
-from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+from sglang.multimodal_gen.runtime.utils.logging_utils import (
+    get_is_main_process,
+    init_logger,
+)
 
 logger = init_logger(__name__)
 
@@ -84,8 +87,10 @@ def startup_phase(name: str):
 
 
 def log_startup_summary() -> None:
+    """Log the breakdown once. Every rank runs the same startup path, so only
+    rank 0 reports -- otherwise an 8-GPU launch prints eight identical trees."""
     profiler = get_startup_profiler()
-    if not profiler.enabled:
+    if not profiler.enabled or not get_is_main_process():
         return
     summary = profiler.render()
     if summary:

--- a/python/sglang/multimodal_gen/runtime/utils/startup_profiler.py
+++ b/python/sglang/multimodal_gen/runtime/utils/startup_profiler.py
@@ -25,7 +25,7 @@ class _Phase:
     def __init__(self, name: str):
         self.name = name
         self.duration_ms: float = 0.0
-        self.children: list["_Phase"] = []
+        self.children: list[_Phase] = []
 
 
 class StartupProfiler:

--- a/python/sglang/multimodal_gen/runtime/utils/startup_profiler.py
+++ b/python/sglang/multimodal_gen/runtime/utils/startup_profiler.py
@@ -1,0 +1,92 @@
+"""Hierarchical wall-clock timer for diffusion server/pipeline startup.
+
+Answers "what is actually taking time when we launch our models?" (see
+sgl-project/sglang#19087) without needing an ad-hoc print-timing pass each
+time. Disabled by default (SGLANG_DIFFUSION_STARTUP_PROFILE=0): the context
+manager is then a plain pass-through with no timing or bookkeeping overhead.
+"""
+
+import time
+from contextlib import contextmanager
+from typing import Iterator
+
+import sglang.multimodal_gen.envs as envs
+from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+
+logger = init_logger(__name__)
+
+
+class _Phase:
+    __slots__ = ("name", "duration_ms", "children")
+
+    def __init__(self, name: str):
+        self.name = name
+        self.duration_ms: float = 0.0
+        self.children: list["_Phase"] = []
+
+
+class StartupProfiler:
+    """Nests `phase()` calls into a tree and renders a flat, dotted-path summary.
+
+    Percentages are relative to the immediate parent phase, matching the
+    breakdown format worked out in #19087 (e.g. `load_modules.text_encoder:
+    32960ms (52%)` is 52% of `load_modules`, not of the whole startup).
+    """
+
+    def __init__(self, enabled: bool):
+        self.enabled = enabled
+        self._root = _Phase("root")
+        self._stack: list[_Phase] = [self._root]
+
+    @contextmanager
+    def phase(self, name: str) -> Iterator[None]:
+        if not self.enabled:
+            yield
+            return
+        node = _Phase(name)
+        self._stack[-1].children.append(node)
+        self._stack.append(node)
+        start = time.perf_counter()
+        try:
+            yield
+        finally:
+            node.duration_ms = (time.perf_counter() - start) * 1000
+            self._stack.pop()
+
+    def render(self) -> str:
+        lines: list[str] = []
+
+        def walk(node: _Phase, prefix: str, parent_ms: float):
+            qualified = f"{prefix}.{node.name}" if prefix else node.name
+            pct = (node.duration_ms / parent_ms * 100) if parent_ms > 0 else 0.0
+            lines.append(f"{qualified}: {node.duration_ms:.2f}ms ({pct:.1f}%)")
+            for child in node.children:
+                walk(child, qualified, node.duration_ms)
+
+        for top in self._root.children:
+            walk(top, "", top.duration_ms)
+        return "\n".join(lines)
+
+
+_profiler: StartupProfiler | None = None
+
+
+def get_startup_profiler() -> StartupProfiler:
+    global _profiler
+    if _profiler is None:
+        _profiler = StartupProfiler(enabled=envs.SGLANG_DIFFUSION_STARTUP_PROFILE)
+    return _profiler
+
+
+def startup_phase(name: str):
+    """`with startup_phase("build_pipeline"): ...` — see `StartupProfiler.phase`."""
+    return get_startup_profiler().phase(name)
+
+
+def log_startup_summary() -> None:
+    profiler = get_startup_profiler()
+    if not profiler.enabled:
+        return
+    summary = profiler.render()
+    if summary:
+        logger.info("[Startup Profile]\n%s", summary)

--- a/python/sglang/multimodal_gen/test/unit/test_startup_profiler.py
+++ b/python/sglang/multimodal_gen/test/unit/test_startup_profiler.py
@@ -1,0 +1,54 @@
+import time
+
+from sglang.multimodal_gen.runtime.utils.startup_profiler import StartupProfiler
+
+
+def test_disabled_profiler_is_zero_overhead_noop():
+    """When disabled, phase() must not build a tree at all (see #19087 -- the
+    profiler must cost nothing when off, since it wraps hot startup code)."""
+    profiler = StartupProfiler(enabled=False)
+    with profiler.phase("a"):
+        with profiler.phase("b"):
+            pass
+    assert profiler._root.children == []
+    assert profiler.render() == ""
+
+
+def test_nested_phases_report_percent_of_immediate_parent():
+    """A child's percentage is relative to its parent's duration, not the
+    grand total -- this is what makes `load_component.text_encoder: 52%`
+    meaningful instead of misleading once there's more than one level."""
+    profiler = StartupProfiler(enabled=True)
+    with profiler.phase("outer"):
+        time.sleep(0.02)
+        with profiler.phase("inner_a"):
+            time.sleep(0.01)
+        with profiler.phase("inner_b"):
+            time.sleep(0.005)
+
+    lines = profiler.render().splitlines()
+    assert len(lines) == 3
+    assert lines[0].startswith("outer: ")
+    assert "(100.0%)" in lines[0]  # top-level phase is 100% of itself
+    assert lines[1].startswith("outer.inner_a: ")
+    assert lines[2].startswith("outer.inner_b: ")
+
+    # inner_a took ~2x inner_b (10ms vs 5ms), so its percentage should be
+    # roughly double -- a derived property of the timings, not a fixed value.
+    pct_a = float(lines[1].split("(")[1].rstrip("%)"))
+    pct_b = float(lines[2].split("(")[1].rstrip("%)"))
+    assert pct_a > pct_b
+
+
+def test_sibling_phases_at_top_level_are_independent():
+    """Two unrelated top-level phases (e.g. init_distributed_environment and
+    build_pipeline) must not be nested under each other."""
+    profiler = StartupProfiler(enabled=True)
+    with profiler.phase("first"):
+        pass
+    with profiler.phase("second"):
+        pass
+
+    lines = profiler.render().splitlines()
+    assert lines[0].startswith("first: ")
+    assert lines[1].startswith("second: ")


### PR DESCRIPTION
## Summary

- add an opt-in hierarchical startup timer behind `SGLANG_DIFFUSION_STARTUP_PROFILE`, a plain pass-through when disabled
- instrument the launch path: device set, distributed init, `build_pipeline`, pipeline instantiation, and per-component weight loading
- report each phase as a percentage of its immediate parent, and log the tree once from rank 0
- add unit coverage for nesting, parent-relative percentages, and the disabled no-op path

## Motivation

#19087 asked for a detailed breakdown of diffusion launch time. The investigation there was done with ad-hoc print timing that was never committed, so the next person to look at launch cost starts from scratch. This lands the breakdown as a permanent facility.

The instrumented boundaries follow that thread's own findings: component loading dominates (Qwen-Image ~63s of a ~77s launch, split text_encoder / transformer), so `load_component.{name}` is the highest-signal level and is broken out per component.

## Modifications

- new `runtime/utils/startup_profiler.py`: `StartupProfiler.phase()` nests timings into a tree; `render()` flattens to dotted paths (`load_modules.load_component.text_encoder: 32960.00ms (52.0%)`). When disabled, `phase()` yields immediately — no node, no timer.
- new env var `SGLANG_DIFFUSION_STARTUP_PROFILE` in `envs.py`, following the existing `SGLANG_DIFFUSION_STAGE_LOGGING` pattern.
- `gpu_worker.py`: wrap `set_device`, `init_distributed_environment`, `build_pipeline`; emit the summary after init.
- `pipelines_core/__init__.py`: wrap `get_model_info`, `pipeline_instantiation`.
- `composed_pipeline_base.py`: wrap `load_modules`, `initialize_pipeline`, `create_pipeline_stages`, and each `load_component.{module_name}`.

Percentages are parent-relative rather than total-relative so a nested phase reads as "share of its parent" — matching the format used in the issue thread.

## Accuracy Tests

Not applicable — instrumentation only. No model code, numerics, or execution order changes; the profiler wraps existing calls in a context manager and is inert unless the env var is set.

## Speed Tests and Profiling

Disabled (default): `phase()` is a bare `yield` — no tree allocation, no `perf_counter` call. Enabled: a handful of `perf_counter` calls around phases that already take seconds.

## Validation

- `python -m py_compile` clean on all changed files
- `black --check` and `isort --check-only` (repo config, `.isort.cfg`) clean on all 6 changed files
- profiler logic verified standalone (`3 passed`): disabled-is-noop, percentages relative to immediate parent, sibling top-level phases do not nest
- rank gating: summary emitted only when `get_is_main_process()`, so an 8-GPU launch logs one tree rather than eight

Not yet run: an end-to-end launch of a real diffusion server with the flag enabled. I do not have NVIDIA hardware for this, and the AMD box used for the sibling PR became unreachable. The example output in the issue thread is what the format is modelled on, not a capture from this branch — happy to attach a real capture if a reviewer can run it, or to hold the PR until I can.

## Checklist

- [x] Add unit tests according to the contribution guide — `test/unit/test_startup_profiler.py`
- [x] Format code with pre-commit — `black --check` / `isort --check-only` clean; did not run the full pre-commit hook set (codespell, clang-format, etc.)
- [x] Follow the SGLang code style guidance

Refs #19087 (breakdown/instrumentation only; the follow-up optimizations discussed in the thread — parallel component loading, pinned-memory transfer, skipping unnecessary `nn.Embedding` init — are separate changes, and #19090 tracks sleep/wake)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31975208837](https://github.com/sgl-project/sglang/actions/runs/31975208837)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31975208619](https://github.com/sgl-project/sglang/actions/runs/31975208619)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->