### PR TITLE
[Spec] Point multi-layer eagle's last shared-read runner at the draft runner

### DIFF
--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -956,6 +956,11 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
         self.plan_stream, self.plan_stream_ctx = get_plan_stream(self.device)
 
     @property
+    def last_shared_read_runner(self):
+        # Multi-layer eagle has no draft but draft-extend only
+        return self._draft_worker.draft_runner
+
+    @property
     def spec_v2_attn_backends(self) -> tuple:
         return (
             self._target_worker.model_runner.attn_backend,

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -957,7 +957,7 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
 
     @property
     def last_shared_read_runner(self):
-        # Multi-layer eagle has no draft but draft-extend only
+        # Multi-layer eagle has no draft forward, only draft extend.
         return self._draft_worker.draft_runner
 
     @property


### PR DESCRIPTION
`MultiLayerEagleWorkerV2` inherited `BaseSpecWorker.last_shared_read_runner`, which points at the target runner. Its step is draft-organize -> verify -> draft extend, and draft extend runs on the draft runner, so the target runner is not the one doing the step's last shared-buffer read.

No behavior change today: under this algorithm both runners' `shared_read_done_event` stay `None` (verify resolves to `UNKNOWN` because the algorithm's last reading phase is draft extend, and the draft-extend runners declare `UNKNOWN` for `DRAFT_EXTEND_V2`), so the scheduler takes the coarse WAR fence either way. This makes the ownership correct before anything starts relying on it.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31975628351](https://github.com/sgl-project/sglang/actions/runs/31975628351)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31975628395](https://github.com/sgl-project/sglang/actions/runs/31975628395)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->