### PR TITLE
[Test] Add unit tests for srt/utils/log_utils.py

### DIFF
--- a/test/registered/unit/utils/test_log_utils.py
+++ b/test/registered/unit/utils/test_log_utils.py
@@ -1,0 +1,139 @@
+"""CPU-only contract tests for shared logging targets and JSON events."""
+
+import io
+import json
+import logging
+import tempfile
+import unittest
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import patch
+
+from sglang.srt.utils import log_utils
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+def _close_logger(logger: logging.Logger) -> None:
+    for handler in logger.handlers[:]:
+        logger.removeHandler(handler)
+        handler.close()
+    logging.Logger.manager.loggerDict.pop(logger.name, None)
+
+
+class TestLogTargets(CustomTestCase):
+    def setUp(self):
+        self._temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._temp_dir.cleanup)
+
+    def _track_logger(self, logger: logging.Logger) -> logging.Logger:
+        self.addCleanup(_close_logger, logger)
+        return logger
+
+    def test_empty_targets_default_to_stdout(self):
+        for targets in (None, []):
+            with self.subTest(targets=targets):
+                stream = io.StringIO()
+                prefix = f"{__name__}.{self._testMethodName}.{targets!r}"
+                with patch.object(log_utils.sys, "stdout", stream):
+                    logger = self._track_logger(
+                        log_utils.create_log_targets(
+                            targets=targets, name_prefix=prefix
+                        )[0]
+                    )
+                    logger.info("stdout-record")
+
+                self.assertIs(logger.handlers[0].stream, stream)
+                self.assertIn("stdout-record", stream.getvalue())
+
+    def test_stdout_target_is_case_insensitive(self):
+        stream = io.StringIO()
+        with patch.object(log_utils.sys, "stdout", stream):
+            logger = self._track_logger(
+                log_utils.create_log_targets(
+                    targets=["StDoUt"], name_prefix=self._testMethodName
+                )[0]
+            )
+            logger.info("case-insensitive")
+
+        self.assertIn("case-insensitive", stream.getvalue())
+
+    def test_file_target_uses_distributed_rank_in_filename(self):
+        directory = Path(self._temp_dir.name)
+        with (
+            patch.object(log_utils.socket, "gethostname", return_value="worker-a"),
+            patch.object(log_utils.dist, "is_initialized", return_value=True),
+            patch.object(log_utils.dist, "get_rank", return_value=7),
+        ):
+            logger = self._track_logger(
+                log_utils.create_log_targets(
+                    targets=[str(directory)], name_prefix=self._testMethodName
+                )[0]
+            )
+            logger.info("file-record")
+            logger.handlers[0].flush()
+
+        log_path = directory / "worker-a_7.log"
+        self.assertTrue(log_path.is_file())
+        self.assertIn("file-record", log_path.read_text(encoding="utf-8"))
+
+    def test_repeated_target_creation_reuses_one_handler(self):
+        stream = io.StringIO()
+        prefix = f"{__name__}.{self._testMethodName}"
+        with patch.object(log_utils.sys, "stdout", stream):
+            first = self._track_logger(
+                log_utils.create_log_targets(targets=None, name_prefix=prefix)[0]
+            )
+            second = log_utils.create_log_targets(targets=None, name_prefix=prefix)[0]
+            first.info("one-record")
+
+        self.assertIs(first, second)
+        self.assertEqual(len(first.handlers), 1)
+        self.assertEqual(stream.getvalue().count("one-record"), 1)
+
+
+class TestLogJson(CustomTestCase):
+    def _capture_logger(self, name: str) -> tuple[logging.Logger, io.StringIO]:
+        stream = io.StringIO()
+        logger = logging.Logger(name)
+        logger.addHandler(logging.StreamHandler(stream))
+        self.addCleanup(_close_logger, logger)
+        return logger, stream
+
+    def test_log_json_accepts_one_logger(self):
+        logger, stream = self._capture_logger("single")
+
+        log_utils.log_json(logger, "scheduler.status", {"rank": 3})
+
+        record = json.loads(stream.getvalue())
+        self.assertEqual(record["event"], "scheduler.status")
+        self.assertEqual(record["rank"], 3)
+        datetime.fromisoformat(record["timestamp"])
+
+    def test_log_json_fans_out_unicode_with_one_timestamp(self):
+        first, first_stream = self._capture_logger("first")
+        second, second_stream = self._capture_logger("second")
+        now = datetime(2026, 8, 16, 12, 34, 56, 123456)
+
+        with patch.object(log_utils, "datetime") as mock_datetime:
+            mock_datetime.now.return_value = now
+            log_utils.log_json(
+                [first, second],
+                "request.finished",
+                {"message": "你好", "count": 2},
+            )
+
+        expected = {
+            "timestamp": now.isoformat(),
+            "event": "request.finished",
+            "message": "你好",
+            "count": 2,
+        }
+        self.assertEqual(json.loads(first_stream.getvalue()), expected)
+        self.assertEqual(json.loads(second_stream.getvalue()), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/utils/test_log_utils.py
+++ b/test/registered/unit/utils/test_log_utils.py
@@ -20,7 +20,9 @@ def _close_logger(logger: logging.Logger) -> None:
     for handler in logger.handlers[:]:
         logger.removeHandler(handler)
         handler.close()
-    logging.Logger.manager.loggerDict.pop(logger.name, None)
+    registered_logger = logging.Logger.manager.loggerDict.get(logger.name)
+    if registered_logger is logger:
+        logging.Logger.manager.loggerDict.pop(logger.name, None)
 
 
 class TestLogTargets(CustomTestCase):
@@ -36,11 +38,11 @@ class TestLogTargets(CustomTestCase):
         for targets in (None, []):
             with self.subTest(targets=targets):
                 stream = io.StringIO()
-                prefix = f"{__name__}.{self._testMethodName}.{targets!r}"
+                name_prefix = f"{__name__}.{self._testMethodName}.{targets!r}"
                 with patch.object(log_utils.sys, "stdout", stream):
                     logger = self._track_logger(
                         log_utils.create_log_targets(
-                            targets=targets, name_prefix=prefix
+                            targets=targets, name_prefix=name_prefix
                         )[0]
                     )
                     logger.info("stdout-record")
@@ -61,7 +63,7 @@ class TestLogTargets(CustomTestCase):
         self.assertIn("case-insensitive", stream.getvalue())
 
     def test_file_target_uses_distributed_rank_in_filename(self):
-        directory = Path(self._temp_dir.name)
+        log_directory = Path(self._temp_dir.name)
         with (
             patch.object(log_utils.socket, "gethostname", return_value="worker-a"),
             patch.object(log_utils.dist, "is_initialized", return_value=True),
@@ -69,28 +71,30 @@ class TestLogTargets(CustomTestCase):
         ):
             logger = self._track_logger(
                 log_utils.create_log_targets(
-                    targets=[str(directory)], name_prefix=self._testMethodName
+                    targets=[str(log_directory)], name_prefix=self._testMethodName
                 )[0]
             )
             logger.info("file-record")
             logger.handlers[0].flush()
 
-        log_path = directory / "worker-a_7.log"
+        log_path = log_directory / "worker-a_7.log"
         self.assertTrue(log_path.is_file())
         self.assertIn("file-record", log_path.read_text(encoding="utf-8"))
 
     def test_repeated_target_creation_reuses_one_handler(self):
         stream = io.StringIO()
-        prefix = f"{__name__}.{self._testMethodName}"
+        name_prefix = f"{__name__}.{self._testMethodName}"
         with patch.object(log_utils.sys, "stdout", stream):
-            first = self._track_logger(
-                log_utils.create_log_targets(targets=None, name_prefix=prefix)[0]
+            first_logger = self._track_logger(
+                log_utils.create_log_targets(targets=None, name_prefix=name_prefix)[0]
             )
-            second = log_utils.create_log_targets(targets=None, name_prefix=prefix)[0]
-            first.info("one-record")
+            second_logger = log_utils.create_log_targets(
+                targets=None, name_prefix=name_prefix
+            )[0]
+            first_logger.info("one-record")
 
-        self.assertIs(first, second)
-        self.assertEqual(len(first.handlers), 1)
+        self.assertIs(first_logger, second_logger)
+        self.assertEqual(len(first_logger.handlers), 1)
         self.assertEqual(stream.getvalue().count("one-record"), 1)
 
 
@@ -105,7 +109,7 @@ class TestLogJson(CustomTestCase):
     def test_log_json_accepts_one_logger(self):
         logger, stream = self._capture_logger("single")
 
-        log_utils.log_json(logger, "scheduler.status", {"rank": 3})
+        log_utils.log_json(loggers=logger, event="scheduler.status", data={"rank": 3})
 
         record = json.loads(stream.getvalue())
         self.assertEqual(record["event"], "scheduler.status")
@@ -113,20 +117,20 @@ class TestLogJson(CustomTestCase):
         datetime.fromisoformat(record["timestamp"])
 
     def test_log_json_fans_out_unicode_with_one_timestamp(self):
-        first, first_stream = self._capture_logger("first")
-        second, second_stream = self._capture_logger("second")
-        now = datetime(2026, 8, 16, 12, 34, 56, 123456)
+        first_logger, first_stream = self._capture_logger("first")
+        second_logger, second_stream = self._capture_logger("second")
+        fixed_timestamp = datetime(2026, 8, 16, 12, 34, 56, 123456)
 
         with patch.object(log_utils, "datetime") as mock_datetime:
-            mock_datetime.now.return_value = now
+            mock_datetime.now.return_value = fixed_timestamp
             log_utils.log_json(
-                [first, second],
-                "request.finished",
-                {"message": "你好", "count": 2},
+                loggers=[first_logger, second_logger],
+                event="request.finished",
+                data={"message": "你好", "count": 2},
             )
 
         expected = {
-            "timestamp": now.isoformat(),
+            "timestamp": fixed_timestamp.isoformat(),
             "event": "request.finished",
             "message": "你好",
             "count": 2,


### PR DESCRIPTION
## Motivation

Part of #20865. `srt/utils/log_utils.py` is shared by request logging and
scheduler-status logging, but its target selection, file naming, handler reuse,
and JSON output contracts did not have direct registered unit coverage.

## Modifications

- Add six CPU-only tests for default and explicit stdout targets, ranked file
  targets, and repeated logger construction without duplicate handlers.
- Exercise real temporary files and logging handlers rather than asserting on
  mocked return values.
- Cover both the single-logger and logger-list `log_json` APIs, including a
  stable timestamp and non-ASCII payload serialization.
- Register the test with `base-a-test-cpu`; it does not launch a server, load
  model weights, access the network, or require a GPU.

## Accuracy Tests

Not applicable. This PR adds tests only and does not change model output or
runtime behavior.

## Speed Tests and Profiling

Not applicable. The focused test completes in under 0.1 seconds in the local
CPU test process.

## Validation

All applicable pre-commit hooks passed, including isort, Ruff, Black,
codespell, and the registered-test validator:

```bash
uvx pre-commit run --files test/registered/unit/utils/test_log_utils.py
```

Focused CPU test command:

```bash
env PYTHONPATH=/tmp/sglang-log-utils-test-stubs \
  uvx --from pytest --with pytest-cov --with pytest-asyncio \
  --with pytest-subtests pytest -p sglang_test_stubs \
  test/registered/unit/utils/test_log_utils.py \
  --cov=sglang.srt.utils.log_utils --cov-report=term-missing -q
```

Full result:

```text
......                                                                 [100%]
================================ tests coverage ================================
______________ coverage: platform darwin, python 3.12.13-final-0 _______________

Name                                   Stmts   Miss  Cover   Missing
--------------------------------------------------------------------
python/sglang/srt/utils/log_utils.py      42      0   100%
--------------------------------------------------------------------
TOTAL                                     42      0   100%
6 passed, 2 subtests passed in 0.04s
```

The local macOS checkout does not contain SGLang's full GPU dependency stack,
so the focused pytest process used import-only stubs for unavailable package
entrypoint dependencies. The target `log_utils.py` module and all logging,
filesystem, distributed-rank mock, and JSON behavior exercised by the tests
were the repository implementations. PR CI provides the canonical full-
environment run.

## Checklist

- [x] Format your code according to the contribution guide.
- [x] Add unit tests according to the contribution guide.
- [x] Documentation updates are not needed for test-only coverage.
- [x] Accuracy and speed benchmarks are not applicable to a test-only PR.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31984554824](https://github.com/sgl-project/sglang/actions/runs/31984554824)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31984554651](https://github.com/sgl-project/sglang/actions/runs/31984554651)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->