### PR TITLE
[Docs] Feature MiniMax-H3 in the popular-models banner

### DIFF
--- a/docs/src/snippets/configs/popular-models.jsx
+++ b/docs/src/snippets/configs/popular-models.jsx
@@ -30,6 +30,23 @@ export const popularModels = [
     },
   },
   {
+    name: "MiniMax-H3",
+    vendor: "MiniMax",
+    href: "/cookbook/diffusion/MiniMax/MiniMax-H3",
+    logo: "/cards/logos/minimax.png",
+    badge: "New",
+    tags: ["7 platforms", "Video + audio", "BF16 / FP8"],
+    hero: {
+      eyebrow: "Featured model · New",
+      headline: "Meet MiniMax-H3 on SGLang",
+      blurb:
+        "MiniMax's video-and-audio diffusion model — one request returns an MP4 carrying 24 fps video and a synchronized stereo audio track. SGLang Diffusion serves all three task profiles — text, first/last frame, and image / video / audio reference conditioning — with Ulysses × Ring sequence parallelism and recipes across B200, B300, H200, H100, AMD MI300X / MI355X, and 2× RTX 5090.",
+      tags: ["Video + synced audio", "4–15 s at 24 fps", "8× B200 → 2× RTX 5090"],
+      cta: "Open the MiniMax-H3 cookbook",
+      caption: "MiniMax-H3 deployment guide",
+    },
+  },
+  {
     name: "Kimi-K3",
     vendor: "Moonshot AI",
     href: "/cookbook/autoregressive/Moonshotai/Kimi-K3",
@@ -61,23 +78,6 @@ export const popularModels = [
       tags: ["975B · 41B active", "1M context", "Text + image + audio"],
       cta: "Open the Inkling cookbook",
       caption: "Inkling deployment guide",
-    },
-  },
-  {
-    name: "GLM-5.2",
-    vendor: "Z.ai",
-    href: "/cookbook/autoregressive/GLM/GLM-5.2",
-    logo: "/cards/logos/glm.png",
-    badge: "New",
-    tags: ["7 platforms", "DSA attention", "FP8 / NVFP4"],
-    hero: {
-      eyebrow: "Featured model · New",
-      headline: "Meet GLM-5.2 on SGLang",
-      blurb:
-        "Z.ai's DeepSeek-Sparse-Attention Mixture-of-Experts model, with MTP speculative decoding and a 1M-token context window. Recipes cover FP8, BF16, and NVFP4 across H200, B200, B300, GB300, and AMD MI300X / MI325X / MI355X.",
-      tags: ["DSA attention", "1M context", "FP8 / BF16 / NVFP4"],
-      cta: "Open the GLM-5.2 cookbook",
-      caption: "GLM-5.2 deployment guide",
     },
   },
 ];


### PR DESCRIPTION
## Motivation

The featured-models carousel on the docs landing page (hero banner) and the Cookbook home (compact strip) currently lists only autoregressive LLMs. MiniMax-H3 has a complete cookbook page and vendor card, but no banner slot — this adds one so the diffusion side of the cookbook is represented in the rotation.

## Modifications

Single file: `docs/src/snippets/configs/popular-models.jsx` — the shared list that `<PopularModels>` walks for both surfaces.

- Add a `MiniMax-H3` entry (strip tags + `hero` block), placed second in the rotation.
- Drop the `GLM-5.2` entry so the list stays at four; its cookbook page and nav entry are untouched.

Per the file's own rule, the copy only makes claims that hold on the linked page:

- `7 platforms` and `BF16 / FP8` come from `configs/MiniMaxAI/minimax-h3.jsx` (`supportedHardware` = B200 / B300 / H200 / H100 / MI300X / MI355X / RTX 5090; the `quant` overlay = native BF16/FP32 with online FP8 on B200 / B300).
- The blurb paraphrases the page's own opening — video plus a synchronized stereo audio track in one request, the three task profiles (t2va / fl2va / ref2va), Ulysses × Ring sequence parallelism, and the recipe range from B200 down to 2× RTX 5090.
- `4–15 s at 24 fps` matches §4 and §8 of the page.
- Reuses the existing `/cards/logos/minimax.png`; no new asset.

## Accuracy Tests

N/A — docs only, no runtime code touched.

## Speed Tests and Profiling

N/A — docs only.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).

Validation: `node docs/scripts/check_cookbook_configs.mjs` → OK, and `mint validate` → build validation passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31986775209](https://github.com/sgl-project/sglang/actions/runs/31986775209)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31986775219](https://github.com/sgl-project/sglang/actions/runs/31986775219)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->