### PR TITLE
feat(sgl-router): decompose the pre-first-token path into phase histograms

### DIFF
--- a/experimental/sgl-router/src/server/app.rs
+++ b/experimental/sgl-router/src/server/app.rs
@@ -149,6 +149,17 @@ impl RequestPhase {
 /// a future establishes a happens-before edge over everything the future did
 /// while it was still alive (including any `set()` call) — so the read is
 /// already ordered-after every write without needing `Acquire`/`Release`.
+/// The instant the edge middleware first saw the request, handed to handlers as
+/// a request extension.
+///
+/// A handler's own timer starts after axum has run the body extractor, so it
+/// cannot see the request-body read — which, with the chat body cap at 100 MiB,
+/// can dominate everything the handler goes on to measure. Anything comparing
+/// router metrics against an upstream observer's latency needs that span, or the
+/// difference shows up as an unexplained gap. `Copy`, so extracting is free.
+#[derive(Clone, Copy)]
+pub(crate) struct IngressAt(pub(crate) std::time::Instant);
+
 pub(crate) struct RequestPhaseCell(AtomicU8);
 
 impl Default for RequestPhaseCell {
@@ -287,6 +298,7 @@ async fn access_log_and_record(
     // `RequestPhaseCell`'s doc comment.
     let phase = Arc::new(RequestPhaseCell::default());
     req.extensions_mut().insert(Arc::clone(&phase));
+    req.extensions_mut().insert(IngressAt(start));
 
     let mut log_guard = AccessLogFallbackGuard {
         request_id: request_id.clone(),

--- a/experimental/sgl-router/src/server/metrics.rs
+++ b/experimental/sgl-router/src/server/metrics.rs
@@ -969,38 +969,35 @@ impl MetricsRegistry {
         hist.observe(seconds);
     }
 
-    /// Observe ingress tokenize cost (seconds) for `sgl_router_tokenize_seconds`.
+    /// Observe ingress tokenize cost (seconds) for `sgl_router_tokenize_seconds`
+    /// — body-fully-read to ids-ready, i.e. JSON parse + chat-template render +
+    /// encode.
     ///
-    /// BOUNDARY — the span starts once the request body is fully read into
-    /// memory and ends the instant token ids are ready. Concretely it covers the
-    /// body's JSON parse, the chat-template render, and the encode. It excludes
-    /// everything on both sides: body read and header handling before it,
-    /// admission wait, request build, worker connect, send, and dispatch after
-    /// it. That exclusion is the entire point. Widen this span to include
-    /// dispatch and the metric degenerates into a second, worse measurement of
-    /// `Server-Timing: router.ttfb`, answering nothing that header does not.
+    /// The exclusions are the point: admission wait, request build, connect,
+    /// send and dispatch are all outside. Widen the span to reach dispatch and
+    /// this degenerates into a worse copy of the `Server-Timing: router.ttfb`
+    /// header. The parse is deliberately INSIDE — unavoidable work between bytes
+    /// and ids, and on multimodal bodies (cap 100 MiB) it can outweigh the
+    /// encode, so read this as "bytes to ids", not pure BPE time.
     ///
-    /// The JSON parse is inside the span deliberately — it is unavoidable work
-    /// on the path from bytes to ids, and on large multimodal payloads (the body
-    /// cap is 100 MiB) it can outweigh the encode itself. Read this metric as
-    /// "bytes to ids", not as pure BPE time.
+    /// The first term of `sgl_router_ttft_overhead_seconds`, split out because
+    /// the terms have unrelated fixes — tokenize is CPU scaling with prompt
+    /// length and BPE-cache locality, admission wait is queueing under
+    /// saturation, and the latter dominates the aggregate exactly when someone
+    /// asks about the former. The two overlap by construction: do not sum them.
     ///
-    /// This is the FIRST TERM of `sgl_router_ttft_overhead_seconds`
-    /// (tokenize + admission wait + request build), broken out because the three
-    /// terms have unrelated causes and unrelated fixes: tokenize is CPU work
-    /// scaling with prompt length and BPE-cache locality, admission wait is
-    /// queueing under saturation. The aggregate cannot distinguish them, and
-    /// admission wait dominates it under load. The two metrics deliberately
-    /// overlap — do not sum them.
+    /// `/v1/chat/completions` ingress only, regardless of outcome, including
+    /// requests later shed at admission — a superset of `ttft_overhead_seconds`
+    /// (streaming-2xx only), so expect `tokenize_count ≥ overhead_count`.
+    /// `/v1/tokenize` encodes too but is not counted: its whole cost is already
+    /// `request_duration_seconds`, and blending it in would make the
+    /// distribution unattributable.
     ///
-    /// Recorded for EVERY request the ingress tokenizes, on every route and
-    /// regardless of outcome, including requests later shed at admission. Its
-    /// sample set is therefore a superset of `ttft_overhead_seconds`, which is
-    /// streaming-2xx only. Expect `tokenize_count ≥ overhead_count`; the gap is
-    /// non-streaming, non-2xx, and shed requests. Requests the ingress does not
-    /// tokenize (no chat encoder and a policy that needs no tokens) record
-    /// nothing at all rather than a zero, so the histogram stays a distribution
-    /// of real tokenize work. Uses [`TOKENIZE_BUCKETS`].
+    /// Gated on ATTEMPTED tokenization. Never-attempted records nothing rather
+    /// than a zero; an attempt yielding no ids (render failure, no tokenizable
+    /// field) IS recorded — a slow *failing* render is worth seeing — so a
+    /// sample can be parse-time only. Pair with
+    /// `sgl_router_ingress_tokenize_errors_total`. Uses [`TOKENIZE_BUCKETS`].
     pub fn observe_tokenize(&self, model_id: &str, seconds: f64) {
         // See `observe_request_duration` — drop non-finite before the map.
         if !seconds.is_finite() {
@@ -1468,7 +1465,7 @@ impl MetricsRegistry {
 
         // tokenize histogram
         out.push_str(
-            "# HELP sgl_router_tokenize_seconds Ingress cost from body-fully-read to token-ids-ready (JSON parse + chat-template render + encode), in seconds. Excludes admission wait, request build and engine dispatch. The tokenize term of sgl_router_ttft_overhead_seconds, recorded for every request the router tokenizes; overlaps that metric by construction - do not sum them.\n",
+            "# HELP sgl_router_tokenize_seconds Ingress cost from body-fully-read to token-ids-ready (JSON parse + chat-template render + encode), in seconds. Excludes admission wait, request build and engine dispatch. Recorded on the /v1/chat/completions ingress whenever it attempts tokenization, including requests later shed at admission; /v1/tokenize is not counted. The tokenize term of sgl_router_ttft_overhead_seconds - overlaps it by construction, do not sum them.\n",
         );
         out.push_str("# TYPE sgl_router_tokenize_seconds histogram\n");
         let guard = self.tokenize_seconds.lock();

--- a/experimental/sgl-router/src/server/metrics.rs
+++ b/experimental/sgl-router/src/server/metrics.rs
@@ -1114,6 +1114,20 @@ impl MetricsRegistry {
     /// read `admission_wait` as queue time and silently redefining it would
     /// misreport every one of them.
     ///
+    /// Two scope limits worth knowing before reading the number:
+    ///
+    /// ADMITTED REQUESTS ONLY. `acquire` returns `Err` for a request shed
+    /// because the wait queue is at its depth cap, so it never reaches this
+    /// marker. Under sustained saturation the histogram therefore samples the
+    /// survivors — the sheds are counted by
+    /// `sgl_router_backpressure_rejected_total`, not timed here.
+    ///
+    /// FIRST SELECTION ONLY. The plain-mode retry loop reselects a worker and
+    /// claims a fresh slot on a retryable dispatch failure, but that happens
+    /// after this marker, so re-selection cost lands in
+    /// `sgl_router_dispatch_seconds` instead. A fleet where retries are common
+    /// therefore shows selection cost split across the two.
+    ///
     /// Uses [`ADMISSION_WAIT_BUCKETS`] — it contains the parking wait, so it
     /// needs that grid's tall top, not the phase ladder's 5 s.
     pub fn observe_admit(&self, model_id: &str, seconds: f64) {
@@ -1170,10 +1184,13 @@ impl MetricsRegistry {
     /// `sgl_router_retries_exhausted_total` and the response counters.
     ///
     /// SPANS RETRIES. The marker sits after the retry loop, so one sample covers
-    /// every attempt plus backoff, not a single connect. That is the honest
-    /// number for TTFT attribution — the client waited for all of it — but it
-    /// means a retried request inflates this histogram's tail. Read it against
-    /// `sgl_router_retries_total` before concluding the engine got slower.
+    /// every attempt plus backoff, not a single connect — and, because the loop
+    /// reselects a worker per attempt, the re-selection cost that
+    /// `sgl_router_admit_seconds` stops measuring after the first claim. That is
+    /// the honest number for TTFT attribution — the client waited for all of it
+    /// — but it means a retried request inflates this histogram's tail. Read it
+    /// against `sgl_router_retries_total` before concluding the engine got
+    /// slower.
     ///
     /// Uses [`TTFT_OVERHEAD_BUCKETS`], not [`ROUTER_PHASE_BUCKETS`]: under engine
     /// saturation this parks for seconds and needs the tall grid.
@@ -1694,7 +1711,7 @@ impl MetricsRegistry {
 
         // admit histogram
         out.push_str(
-            "# HELP sgl_router_admit_seconds Worker selection (prompt hashing, radix-tree walk, oracle consult, candidate scoring) plus slot claim and any parking, in seconds; the admission term of sgl_router_ttft_overhead_seconds. Strict superset of sgl_router_admission_wait_seconds, which sees only requests that parked.\n",
+            "# HELP sgl_router_admit_seconds Worker selection (prompt hashing, radix-tree walk, oracle consult, candidate scoring) plus slot claim and any parking, in seconds; the admission term of sgl_router_ttft_overhead_seconds. Strict superset of sgl_router_admission_wait_seconds, which sees only requests that parked. Admitted requests only (sheds are counted by sgl_router_backpressure_rejected_total), and first selection only (retry re-selection lands in sgl_router_dispatch_seconds).\n",
         );
         out.push_str("# TYPE sgl_router_admit_seconds histogram\n");
         let guard = self.admit_seconds.lock();

--- a/experimental/sgl-router/src/server/metrics.rs
+++ b/experimental/sgl-router/src/server/metrics.rs
@@ -24,6 +24,7 @@
 //! | `sgl_router_request_duration_seconds` | Histogram | `model_id` |
 //! | `sgl_router_ttft_seconds` | Histogram | `model_id` |
 //! | `sgl_router_ttft_overhead_seconds` | Histogram | `model_id` |
+//! | `sgl_router_tokenize_seconds` | Histogram | `model_id` |
 //! | `sgl_router_itl_seconds` | Histogram | `model_id` |
 //! | `sgl_router_responses_total` | Counter | `route`, `method`, `status_code` |
 //! | `sgl_router_overlap_blocks` | Histogram | `model_id` |
@@ -175,6 +176,20 @@ const ADMISSION_WAIT_BUCKETS: &[f64] = &[
 /// check enforces the equality, so treat the shared range as incidental.
 const TTFT_OVERHEAD_BUCKETS: &[f64] = &[
     0.001, 0.005, 0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0,
+];
+
+/// Histogram bucket upper bounds (seconds) for `sgl_router_tokenize_seconds` —
+/// ingress chat-encode plus tokenize, in isolation.
+///
+/// Deliberately finer at the bottom than [`TTFT_OVERHEAD_BUCKETS`]: tokenize is
+/// a CPU-bound, sub-millisecond-to-low-millisecond operation on typical prompts,
+/// and the overhead ladder's 1 ms floor puts nearly every healthy sample in the
+/// first bucket, where `histogram_quantile` cannot resolve it. The ladder starts
+/// at 100 µs and still reaches 5 s so a pathological prompt (very long input, or
+/// a cold BPE merge cache under lock contention) lands in a real bucket rather
+/// than `+Inf`.
+const TOKENIZE_BUCKETS: &[f64] = &[
+    0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0,
 ];
 
 /// Recordable outcome for a request — narrowed to a handful of variants so
@@ -513,6 +528,12 @@ pub struct MetricsRegistry {
     /// time; see [`Self::observe_ttft_overhead`] for how its sample set relates
     /// to `ttft_seconds`.
     ttft_overhead_seconds: Mutex<HashMap<String, Histogram>>,
+    /// Ingress tokenize cost alone, per model — the first term of
+    /// `ttft_overhead_seconds`, broken out so a slow tokenizer is separable
+    /// from admission wait. Recorded on every request the ingress tokenizes,
+    /// which is a strictly wider sample set than `ttft_overhead_seconds`; see
+    /// [`Self::observe_tokenize`].
+    tokenize_seconds: Mutex<HashMap<String, Histogram>>,
     itl_seconds: Mutex<HashMap<String, Histogram>>,
     // Edge responses by route/method/status (incl. early-exit 400/413/503 and the
     // CatchPanicLayer-synthesized 500).
@@ -606,6 +627,7 @@ impl Default for MetricsRegistry {
             request_duration: Default::default(),
             ttft_seconds: Default::default(),
             ttft_overhead_seconds: Default::default(),
+            tokenize_seconds: Default::default(),
             itl_seconds: Default::default(),
             responses_total: Default::default(),
             overlap_blocks: Default::default(),
@@ -944,6 +966,50 @@ impl MetricsRegistry {
         let hist = guard
             .entry(model_id.to_owned())
             .or_insert_with(|| Histogram::new(TTFT_OVERHEAD_BUCKETS));
+        hist.observe(seconds);
+    }
+
+    /// Observe ingress tokenize cost (seconds) for `sgl_router_tokenize_seconds`.
+    ///
+    /// BOUNDARY — the span starts once the request body is fully read into
+    /// memory and ends the instant token ids are ready. Concretely it covers the
+    /// body's JSON parse, the chat-template render, and the encode. It excludes
+    /// everything on both sides: body read and header handling before it,
+    /// admission wait, request build, worker connect, send, and dispatch after
+    /// it. That exclusion is the entire point. Widen this span to include
+    /// dispatch and the metric degenerates into a second, worse measurement of
+    /// `Server-Timing: router.ttfb`, answering nothing that header does not.
+    ///
+    /// The JSON parse is inside the span deliberately — it is unavoidable work
+    /// on the path from bytes to ids, and on large multimodal payloads (the body
+    /// cap is 100 MiB) it can outweigh the encode itself. Read this metric as
+    /// "bytes to ids", not as pure BPE time.
+    ///
+    /// This is the FIRST TERM of `sgl_router_ttft_overhead_seconds`
+    /// (tokenize + admission wait + request build), broken out because the three
+    /// terms have unrelated causes and unrelated fixes: tokenize is CPU work
+    /// scaling with prompt length and BPE-cache locality, admission wait is
+    /// queueing under saturation. The aggregate cannot distinguish them, and
+    /// admission wait dominates it under load. The two metrics deliberately
+    /// overlap — do not sum them.
+    ///
+    /// Recorded for EVERY request the ingress tokenizes, on every route and
+    /// regardless of outcome, including requests later shed at admission. Its
+    /// sample set is therefore a superset of `ttft_overhead_seconds`, which is
+    /// streaming-2xx only. Expect `tokenize_count ≥ overhead_count`; the gap is
+    /// non-streaming, non-2xx, and shed requests. Requests the ingress does not
+    /// tokenize (no chat encoder and a policy that needs no tokens) record
+    /// nothing at all rather than a zero, so the histogram stays a distribution
+    /// of real tokenize work. Uses [`TOKENIZE_BUCKETS`].
+    pub fn observe_tokenize(&self, model_id: &str, seconds: f64) {
+        // See `observe_request_duration` — drop non-finite before the map.
+        if !seconds.is_finite() {
+            return;
+        }
+        let mut guard = self.tokenize_seconds.lock();
+        let hist = guard
+            .entry(model_id.to_owned())
+            .or_insert_with(|| Histogram::new(TOKENIZE_BUCKETS));
         hist.observe(seconds);
     }
 
@@ -1397,6 +1463,21 @@ impl MetricsRegistry {
                 &label_body,
                 hist,
             );
+        }
+        drop(guard);
+
+        // tokenize histogram
+        out.push_str(
+            "# HELP sgl_router_tokenize_seconds Ingress cost from body-fully-read to token-ids-ready (JSON parse + chat-template render + encode), in seconds. Excludes admission wait, request build and engine dispatch. The tokenize term of sgl_router_ttft_overhead_seconds, recorded for every request the router tokenizes; overlaps that metric by construction - do not sum them.\n",
+        );
+        out.push_str("# TYPE sgl_router_tokenize_seconds histogram\n");
+        let guard = self.tokenize_seconds.lock();
+        let mut models: Vec<&String> = guard.keys().collect();
+        models.sort();
+        for model_id in models {
+            let hist = guard.get(model_id).unwrap();
+            let label_body = format!("model_id=\"{}\"", escape_label(model_id));
+            render_histogram(&mut out, "sgl_router_tokenize_seconds", &label_body, hist);
         }
         drop(guard);
 
@@ -2258,6 +2339,69 @@ mod tests {
         // le=0.25 is cumulative over both observations.
         assert!(
             out.contains(r#"sgl_router_ttft_overhead_seconds_bucket{model_id="tiny",le="0.25"} 2"#)
+        );
+    }
+
+    #[test]
+    fn observe_tokenize_writes_buckets_sum_and_count() {
+        let reg = MetricsRegistry::new();
+        reg.observe_tokenize("tiny", 0.002);
+        reg.observe_tokenize("tiny", 0.03);
+        let out = reg.render();
+        assert!(
+            out.contains("# TYPE sgl_router_tokenize_seconds histogram"),
+            "expected tokenize TYPE header; got:\n{out}",
+        );
+        assert!(
+            out.contains(r#"sgl_router_tokenize_seconds_count{model_id="tiny"} 2"#),
+            "expected tokenize count=2; got:\n{out}",
+        );
+        // 0.002 <= 0.0025, so that bucket is 1 (cumulative); 0.03 exceeds it.
+        assert!(
+            out.contains(r#"sgl_router_tokenize_seconds_bucket{model_id="tiny",le="0.0025"} 1"#),
+            "expected le=0.0025 bucket = 1; got:\n{out}",
+        );
+        // le=0.05 is cumulative over both observations.
+        assert!(
+            out.contains(r#"sgl_router_tokenize_seconds_bucket{model_id="tiny",le="0.05"} 2"#),
+            "expected le=0.05 bucket = 2; got:\n{out}",
+        );
+    }
+
+    /// The whole point of a separate ladder: a typical tokenize (~1 ms) must not
+    /// collapse into the first bucket the way it does on the overhead grid,
+    /// where everything below 1 ms is unresolvable.
+    #[test]
+    fn tokenize_buckets_resolve_sub_millisecond() {
+        let reg = MetricsRegistry::new();
+        reg.observe_tokenize("tiny", 0.0002); // 200 us
+        reg.observe_tokenize("tiny", 0.0008); // 800 us
+        let out = reg.render();
+        // Two sub-millisecond samples land in DIFFERENT buckets.
+        assert!(
+            out.contains(r#"sgl_router_tokenize_seconds_bucket{model_id="tiny",le="0.00025"} 1"#),
+            "expected 200us alone in le=0.00025; got:\n{out}",
+        );
+        assert!(
+            out.contains(r#"sgl_router_tokenize_seconds_bucket{model_id="tiny",le="0.001"} 2"#),
+            "expected both by le=0.001; got:\n{out}",
+        );
+        // Both would be indistinguishable on the overhead ladder (floor 1 ms).
+        assert_eq!(TTFT_OVERHEAD_BUCKETS[0], 0.001);
+        assert!(TOKENIZE_BUCKETS[0] < TTFT_OVERHEAD_BUCKETS[0]);
+    }
+
+    /// Non-finite input must never reach the histogram — same contract as the
+    /// other `observe_*` entry points.
+    #[test]
+    fn observe_tokenize_drops_non_finite() {
+        let reg = MetricsRegistry::new();
+        reg.observe_tokenize("tiny", f64::NAN);
+        reg.observe_tokenize("tiny", f64::INFINITY);
+        let out = reg.render();
+        assert!(
+            !out.contains(r#"sgl_router_tokenize_seconds_count{model_id="tiny"}"#),
+            "non-finite observations must not create a series; got:\n{out}",
         );
     }
 

--- a/experimental/sgl-router/src/server/metrics.rs
+++ b/experimental/sgl-router/src/server/metrics.rs
@@ -27,6 +27,7 @@
 //! | `sgl_router_ingress_read_seconds` | Histogram | `model_id` |
 //! | `sgl_router_resolve_seconds` | Histogram | `model_id` |
 //! | `sgl_router_tokenize_seconds` | Histogram | `model_id` |
+//! | `sgl_router_admit_seconds` | Histogram | `model_id` |
 //! | `sgl_router_request_build_seconds` | Histogram | `model_id` |
 //! | `sgl_router_dispatch_seconds` | Histogram | `model_id` |
 //! | `sgl_router_itl_seconds` | Histogram | `model_id` |
@@ -551,6 +552,11 @@ pub struct MetricsRegistry {
     /// Ingress probe-parse plus model/policy/worker resolution, per model — the
     /// first term of `ttft_overhead_seconds`, before tokenize.
     resolve_seconds: Mutex<HashMap<String, Histogram>>,
+    /// Worker selection plus slot claim (and parking, if any), per model — the
+    /// admission term of `ttft_overhead_seconds`. A superset of
+    /// `admission_wait_seconds`, which sees only requests that parked. See
+    /// [`Self::observe_admit`].
+    admit_seconds: Mutex<HashMap<String, Histogram>>,
     /// Outgoing-body build (id/bootstrap injection, re-serialize), per model —
     /// the last term of `ttft_overhead_seconds`, after admission.
     request_build_seconds: Mutex<HashMap<String, Histogram>>,
@@ -654,6 +660,7 @@ impl Default for MetricsRegistry {
             tokenize_seconds: Default::default(),
             ingress_read_seconds: Default::default(),
             resolve_seconds: Default::default(),
+            admit_seconds: Default::default(),
             request_build_seconds: Default::default(),
             dispatch_seconds: Default::default(),
             itl_seconds: Default::default(),
@@ -1084,6 +1091,40 @@ impl MetricsRegistry {
         let hist = guard
             .entry(model_id.to_owned())
             .or_insert_with(|| Histogram::new(ROUTER_PHASE_BUCKETS));
+        hist.observe(seconds);
+    }
+
+    /// Observe admission cost (seconds) for `sgl_router_admit_seconds` — worker
+    /// SELECTION plus slot claim, plus parking when every candidate is at its
+    /// cap.
+    ///
+    /// Selection is the part with no other coverage and the part that can
+    /// actually grow: under the cache-aware policy it hashes the prompt into
+    /// blocks, walks the radix tree, consults the block-size oracle and scores
+    /// every candidate by overlap and load. That work scales with prompt length
+    /// and fleet size, and until this metric existed it was visible only in the
+    /// 1-in-N `admit_ms` debug line.
+    ///
+    /// Distinct from `sgl_router_admission_wait_seconds`, and a strict superset
+    /// of it: that metric is recorded after the parking `await` resolves, so it
+    /// sees ONLY requests that queued — a fast-path claim returns before it and
+    /// records nothing. Consequently `admission_wait_count / admit_count` is the
+    /// park rate, and `admit − admission_wait` is selection plus claim. Both are
+    /// kept, rather than widening the older metric, because dashboards already
+    /// read `admission_wait` as queue time and silently redefining it would
+    /// misreport every one of them.
+    ///
+    /// Uses [`ADMISSION_WAIT_BUCKETS`] — it contains the parking wait, so it
+    /// needs that grid's tall top, not the phase ladder's 5 s.
+    pub fn observe_admit(&self, model_id: &str, seconds: f64) {
+        // See `observe_request_duration` — drop non-finite before the map.
+        if !seconds.is_finite() {
+            return;
+        }
+        let mut guard = self.admit_seconds.lock();
+        let hist = guard
+            .entry(model_id.to_owned())
+            .or_insert_with(|| Histogram::new(ADMISSION_WAIT_BUCKETS));
         hist.observe(seconds);
     }
 
@@ -1648,6 +1689,21 @@ impl MetricsRegistry {
             let hist = guard.get(model_id).unwrap();
             let label_body = format!("model_id=\"{}\"", escape_label(model_id));
             render_histogram(&mut out, "sgl_router_resolve_seconds", &label_body, hist);
+        }
+        drop(guard);
+
+        // admit histogram
+        out.push_str(
+            "# HELP sgl_router_admit_seconds Worker selection (prompt hashing, radix-tree walk, oracle consult, candidate scoring) plus slot claim and any parking, in seconds; the admission term of sgl_router_ttft_overhead_seconds. Strict superset of sgl_router_admission_wait_seconds, which sees only requests that parked.\n",
+        );
+        out.push_str("# TYPE sgl_router_admit_seconds histogram\n");
+        let guard = self.admit_seconds.lock();
+        let mut models: Vec<&String> = guard.keys().collect();
+        models.sort();
+        for model_id in models {
+            let hist = guard.get(model_id).unwrap();
+            let label_body = format!("model_id=\"{}\"", escape_label(model_id));
+            render_histogram(&mut out, "sgl_router_admit_seconds", &label_body, hist);
         }
         drop(guard);
 
@@ -2607,6 +2663,7 @@ mod tests {
         reg.observe_resolve("tiny", 0.0003);
         reg.observe_tokenize("tiny", 0.002);
         reg.observe_admission_wait("tiny", 0.5);
+        reg.observe_admit("tiny", 0.6);
         reg.observe_request_build("tiny", 0.0008);
         reg.observe_dispatch("tiny", 0.4);
         let out = reg.render();
@@ -2615,6 +2672,7 @@ mod tests {
             "sgl_router_resolve_seconds",
             "sgl_router_tokenize_seconds",
             "sgl_router_admission_wait_seconds",
+            "sgl_router_admit_seconds",
             "sgl_router_request_build_seconds",
             "sgl_router_dispatch_seconds",
         ] {

--- a/experimental/sgl-router/src/server/metrics.rs
+++ b/experimental/sgl-router/src/server/metrics.rs
@@ -24,7 +24,11 @@
 //! | `sgl_router_request_duration_seconds` | Histogram | `model_id` |
 //! | `sgl_router_ttft_seconds` | Histogram | `model_id` |
 //! | `sgl_router_ttft_overhead_seconds` | Histogram | `model_id` |
+//! | `sgl_router_ingress_read_seconds` | Histogram | `model_id` |
+//! | `sgl_router_resolve_seconds` | Histogram | `model_id` |
 //! | `sgl_router_tokenize_seconds` | Histogram | `model_id` |
+//! | `sgl_router_request_build_seconds` | Histogram | `model_id` |
+//! | `sgl_router_dispatch_seconds` | Histogram | `model_id` |
 //! | `sgl_router_itl_seconds` | Histogram | `model_id` |
 //! | `sgl_router_responses_total` | Counter | `route`, `method`, `status_code` |
 //! | `sgl_router_overlap_blocks` | Histogram | `model_id` |
@@ -178,17 +182,22 @@ const TTFT_OVERHEAD_BUCKETS: &[f64] = &[
     0.001, 0.005, 0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0,
 ];
 
-/// Histogram bucket upper bounds (seconds) for `sgl_router_tokenize_seconds` —
-/// ingress chat-encode plus tokenize, in isolation.
+/// Histogram bucket upper bounds (seconds) for the router-internal phase
+/// histograms — `sgl_router_resolve_seconds`, `sgl_router_tokenize_seconds`,
+/// `sgl_router_request_build_seconds`.
 ///
-/// Deliberately finer at the bottom than [`TTFT_OVERHEAD_BUCKETS`]: tokenize is
-/// a CPU-bound, sub-millisecond-to-low-millisecond operation on typical prompts,
-/// and the overhead ladder's 1 ms floor puts nearly every healthy sample in the
-/// first bucket, where `histogram_quantile` cannot resolve it. The ladder starts
-/// at 100 µs and still reaches 5 s so a pathological prompt (very long input, or
-/// a cold BPE merge cache under lock contention) lands in a real bucket rather
-/// than `+Inf`.
-const TOKENIZE_BUCKETS: &[f64] = &[
+/// Deliberately finer at the bottom than [`TTFT_OVERHEAD_BUCKETS`]: all three
+/// are CPU-bound, sub-millisecond-to-low-millisecond operations on typical
+/// requests, and the overhead ladder's 1 ms floor puts nearly every healthy
+/// sample in the first bucket, where `histogram_quantile` cannot resolve it. The
+/// ladder starts at 100 µs and still reaches 5 s so a pathological request (a
+/// very long prompt, a cold BPE merge cache under lock contention, a 100 MiB
+/// multimodal body to parse) lands in a real bucket rather than `+Inf`.
+///
+/// `sgl_router_dispatch_seconds` deliberately does NOT use this ladder — it
+/// spans the network and the engine's own queueing, so it belongs on the
+/// coarse-topped [`TTFT_OVERHEAD_BUCKETS`] grid.
+const ROUTER_PHASE_BUCKETS: &[f64] = &[
     0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0,
 ];
 
@@ -534,6 +543,21 @@ pub struct MetricsRegistry {
     /// which is a strictly wider sample set than `ttft_overhead_seconds`; see
     /// [`Self::observe_tokenize`].
     tokenize_seconds: Mutex<HashMap<String, Histogram>>,
+    /// Edge-middleware entry to handler entry, per model — dominated by the
+    /// request-body read. Precedes every other span, and precedes the handler
+    /// clock that `ttft_overhead_seconds` and `request_duration_seconds` are
+    /// measured from. See [`Self::observe_ingress_read`].
+    ingress_read_seconds: Mutex<HashMap<String, Histogram>>,
+    /// Ingress probe-parse plus model/policy/worker resolution, per model — the
+    /// first term of `ttft_overhead_seconds`, before tokenize.
+    resolve_seconds: Mutex<HashMap<String, Histogram>>,
+    /// Outgoing-body build (id/bootstrap injection, re-serialize), per model —
+    /// the last term of `ttft_overhead_seconds`, after admission.
+    request_build_seconds: Mutex<HashMap<String, Histogram>>,
+    /// Dispatch to upstream response headers, per model — connect, send body,
+    /// wait. The first span that is NOT router-attributable: it contains the
+    /// network and the engine's own queueing. See [`Self::observe_dispatch`].
+    dispatch_seconds: Mutex<HashMap<String, Histogram>>,
     itl_seconds: Mutex<HashMap<String, Histogram>>,
     // Edge responses by route/method/status (incl. early-exit 400/413/503 and the
     // CatchPanicLayer-synthesized 500).
@@ -628,6 +652,10 @@ impl Default for MetricsRegistry {
             ttft_seconds: Default::default(),
             ttft_overhead_seconds: Default::default(),
             tokenize_seconds: Default::default(),
+            ingress_read_seconds: Default::default(),
+            resolve_seconds: Default::default(),
+            request_build_seconds: Default::default(),
+            dispatch_seconds: Default::default(),
             itl_seconds: Default::default(),
             responses_total: Default::default(),
             overlap_blocks: Default::default(),
@@ -997,7 +1025,7 @@ impl MetricsRegistry {
     /// than a zero; an attempt yielding no ids (render failure, no tokenizable
     /// field) IS recorded — a slow *failing* render is worth seeing — so a
     /// sample can be parse-time only. Pair with
-    /// `sgl_router_ingress_tokenize_errors_total`. Uses [`TOKENIZE_BUCKETS`].
+    /// `sgl_router_ingress_tokenize_errors_total`. Uses [`ROUTER_PHASE_BUCKETS`].
     pub fn observe_tokenize(&self, model_id: &str, seconds: f64) {
         // See `observe_request_duration` — drop non-finite before the map.
         if !seconds.is_finite() {
@@ -1006,7 +1034,104 @@ impl MetricsRegistry {
         let mut guard = self.tokenize_seconds.lock();
         let hist = guard
             .entry(model_id.to_owned())
-            .or_insert_with(|| Histogram::new(TOKENIZE_BUCKETS));
+            .or_insert_with(|| Histogram::new(ROUTER_PHASE_BUCKETS));
+        hist.observe(seconds);
+    }
+
+    /// Observe the pre-handler span (seconds) for
+    /// `sgl_router_ingress_read_seconds` — edge-middleware entry to chat-handler
+    /// entry, which is the request-body read plus axum routing and extractor
+    /// overhead.
+    ///
+    /// The only span the handler cannot time itself, because axum finishes the
+    /// `Bytes` extractor before the handler body runs and starts its clock. That
+    /// makes it invisible to `request_duration_seconds` and to every phase
+    /// histogram, so a client uploading a large multimodal body sees latency the
+    /// router reports nowhere. When an upstream observer's time-to-first-token
+    /// exceeds what the router and engine together account for, this is the
+    /// first place to look.
+    ///
+    /// Labelled by model, so it is recorded after model resolution even though
+    /// the span itself ended earlier; the value is captured at handler entry and
+    /// held. Uses [`TTFT_OVERHEAD_BUCKETS`] — a slow client on a large body puts
+    /// this in seconds, well past the phase ladder's 5 s top.
+    pub fn observe_ingress_read(&self, model_id: &str, seconds: f64) {
+        // See `observe_request_duration` — drop non-finite before the map.
+        if !seconds.is_finite() {
+            return;
+        }
+        let mut guard = self.ingress_read_seconds.lock();
+        let hist = guard
+            .entry(model_id.to_owned())
+            .or_insert_with(|| Histogram::new(TTFT_OVERHEAD_BUCKETS));
+        hist.observe(seconds);
+    }
+
+    /// Observe ingress resolve cost (seconds) for `sgl_router_resolve_seconds` —
+    /// request receipt to just before tokenize: the minimal `parse_probe` over
+    /// the body, model-id resolution, policy lookup and PD candidate selection.
+    ///
+    /// Recorded for every request that gets far enough to have a model, so a
+    /// request rejected as unknown-model records nothing. Normally microseconds;
+    /// it earns a histogram because `parse_probe` reads a body that may be
+    /// 100 MiB, so this is where an oversized payload shows up before tokenize.
+    pub fn observe_resolve(&self, model_id: &str, seconds: f64) {
+        // See `observe_request_duration` — drop non-finite before the map.
+        if !seconds.is_finite() {
+            return;
+        }
+        let mut guard = self.resolve_seconds.lock();
+        let hist = guard
+            .entry(model_id.to_owned())
+            .or_insert_with(|| Histogram::new(ROUTER_PHASE_BUCKETS));
+        hist.observe(seconds);
+    }
+
+    /// Observe outgoing-body build cost (seconds) for
+    /// `sgl_router_request_build_seconds` — admission slot acquired to
+    /// dispatch-ready: `input_ids` / PD `bootstrap_*` injection and the single
+    /// re-serialize of the request body.
+    ///
+    /// Recorded for every ADMITTED request; one shed at admission never reaches
+    /// this point. Scales with body size, not prompt length, so it is the term
+    /// that grows on multimodal traffic while tokenize stays flat.
+    pub fn observe_request_build(&self, model_id: &str, seconds: f64) {
+        // See `observe_request_duration` — drop non-finite before the map.
+        if !seconds.is_finite() {
+            return;
+        }
+        let mut guard = self.request_build_seconds.lock();
+        let hist = guard
+            .entry(model_id.to_owned())
+            .or_insert_with(|| Histogram::new(ROUTER_PHASE_BUCKETS));
+        hist.observe(seconds);
+    }
+
+    /// Observe dispatch cost (seconds) for `sgl_router_dispatch_seconds` —
+    /// dispatch-ready to upstream response headers: connect, send body, wait.
+    ///
+    /// The router/engine boundary, and the reason this metric exists. Every
+    /// other phase histogram is router-attributable CPU; this one is not — it
+    /// contains the network hop and whatever the engine does before flushing
+    /// headers, including its own admission queueing. Subtracting the engine's
+    /// self-reported time-to-first-token from this leaves network plus
+    /// engine-side queueing, which is what an unexplained TTFT gap between an
+    /// external observer and the engine usually turns out to be.
+    ///
+    /// Recorded for every request that receives upstream headers, streaming or
+    /// buffered, 2xx or not — deliberately wider than `ttft_overhead_seconds`,
+    /// which is streaming-2xx only, so an error-only regression is still
+    /// visible. Uses [`TTFT_OVERHEAD_BUCKETS`], not [`ROUTER_PHASE_BUCKETS`]:
+    /// under engine saturation this parks for seconds and needs the tall grid.
+    pub fn observe_dispatch(&self, model_id: &str, seconds: f64) {
+        // See `observe_request_duration` — drop non-finite before the map.
+        if !seconds.is_finite() {
+            return;
+        }
+        let mut guard = self.dispatch_seconds.lock();
+        let hist = guard
+            .entry(model_id.to_owned())
+            .or_insert_with(|| Histogram::new(TTFT_OVERHEAD_BUCKETS));
         hist.observe(seconds);
     }
 
@@ -1475,6 +1600,76 @@ impl MetricsRegistry {
             let hist = guard.get(model_id).unwrap();
             let label_body = format!("model_id=\"{}\"", escape_label(model_id));
             render_histogram(&mut out, "sgl_router_tokenize_seconds", &label_body, hist);
+        }
+        drop(guard);
+
+        // ingress_read histogram
+        out.push_str(
+            "# HELP sgl_router_ingress_read_seconds Edge-middleware entry to handler entry (request-body read plus routing/extractor overhead), in seconds. Precedes the handler clock, so this span is NOT included in sgl_router_request_duration_seconds or any phase histogram.\n",
+        );
+        out.push_str("# TYPE sgl_router_ingress_read_seconds histogram\n");
+        let guard = self.ingress_read_seconds.lock();
+        let mut models: Vec<&String> = guard.keys().collect();
+        models.sort();
+        for model_id in models {
+            let hist = guard.get(model_id).unwrap();
+            let label_body = format!("model_id=\"{}\"", escape_label(model_id));
+            render_histogram(
+                &mut out,
+                "sgl_router_ingress_read_seconds",
+                &label_body,
+                hist,
+            );
+        }
+        drop(guard);
+
+        // resolve histogram
+        out.push_str(
+            "# HELP sgl_router_resolve_seconds Ingress probe-parse plus model/policy/worker resolution, in seconds; the pre-tokenize term of sgl_router_ttft_overhead_seconds.\n",
+        );
+        out.push_str("# TYPE sgl_router_resolve_seconds histogram\n");
+        let guard = self.resolve_seconds.lock();
+        let mut models: Vec<&String> = guard.keys().collect();
+        models.sort();
+        for model_id in models {
+            let hist = guard.get(model_id).unwrap();
+            let label_body = format!("model_id=\"{}\"", escape_label(model_id));
+            render_histogram(&mut out, "sgl_router_resolve_seconds", &label_body, hist);
+        }
+        drop(guard);
+
+        // request_build histogram
+        out.push_str(
+            "# HELP sgl_router_request_build_seconds Outgoing-body build (input_ids / bootstrap injection and re-serialize) for admitted requests, in seconds; the post-admission term of sgl_router_ttft_overhead_seconds.\n",
+        );
+        out.push_str("# TYPE sgl_router_request_build_seconds histogram\n");
+        let guard = self.request_build_seconds.lock();
+        let mut models: Vec<&String> = guard.keys().collect();
+        models.sort();
+        for model_id in models {
+            let hist = guard.get(model_id).unwrap();
+            let label_body = format!("model_id=\"{}\"", escape_label(model_id));
+            render_histogram(
+                &mut out,
+                "sgl_router_request_build_seconds",
+                &label_body,
+                hist,
+            );
+        }
+        drop(guard);
+
+        // dispatch histogram
+        out.push_str(
+            "# HELP sgl_router_dispatch_seconds Dispatch to upstream response headers (connect, send body, wait), in seconds. NOT router-attributable - contains the network hop and the engine's own queueing before it flushes headers. Recorded for streaming and buffered responses alike.\n",
+        );
+        out.push_str("# TYPE sgl_router_dispatch_seconds histogram\n");
+        let guard = self.dispatch_seconds.lock();
+        let mut models: Vec<&String> = guard.keys().collect();
+        models.sort();
+        for model_id in models {
+            let hist = guard.get(model_id).unwrap();
+            let label_body = format!("model_id=\"{}\"", escape_label(model_id));
+            render_histogram(&mut out, "sgl_router_dispatch_seconds", &label_body, hist);
         }
         drop(guard);
 
@@ -2385,7 +2580,58 @@ mod tests {
         );
         // Both would be indistinguishable on the overhead ladder (floor 1 ms).
         assert_eq!(TTFT_OVERHEAD_BUCKETS[0], 0.001);
-        assert!(TOKENIZE_BUCKETS[0] < TTFT_OVERHEAD_BUCKETS[0]);
+        assert!(ROUTER_PHASE_BUCKETS[0] < TTFT_OVERHEAD_BUCKETS[0]);
+    }
+
+    /// The pre-dispatch path decomposes into resolve + tokenize + admit + build,
+    /// and dispatch carries the span beyond the router. Renders all of them so a
+    /// missing export block fails here rather than as a silently absent series
+    /// on a dashboard.
+    #[test]
+    fn phase_histograms_all_render() {
+        let reg = MetricsRegistry::new();
+        reg.observe_ingress_read("tiny", 0.01);
+        reg.observe_resolve("tiny", 0.0003);
+        reg.observe_tokenize("tiny", 0.002);
+        reg.observe_admission_wait("tiny", 0.5);
+        reg.observe_request_build("tiny", 0.0008);
+        reg.observe_dispatch("tiny", 0.4);
+        let out = reg.render();
+        for name in [
+            "sgl_router_ingress_read_seconds",
+            "sgl_router_resolve_seconds",
+            "sgl_router_tokenize_seconds",
+            "sgl_router_admission_wait_seconds",
+            "sgl_router_request_build_seconds",
+            "sgl_router_dispatch_seconds",
+        ] {
+            assert!(
+                out.contains(&format!("# TYPE {name} histogram")),
+                "{name} must render a TYPE header; got:\n{out}",
+            );
+            assert!(
+                out.contains(&format!(r#"{name}_count{{model_id="tiny"}} 1"#)),
+                "{name} must record one sample; got:\n{out}",
+            );
+        }
+    }
+
+    /// `dispatch` spans the network and the engine's queueing, so it must sit on
+    /// the tall grid — the fine phase ladder tops out at 5 s and would dump a
+    /// saturated engine into `+Inf`, hiding exactly the case worth seeing.
+    #[test]
+    fn dispatch_uses_the_tall_bucket_grid() {
+        let reg = MetricsRegistry::new();
+        reg.observe_dispatch("tiny", 30.0);
+        let out = reg.render();
+        assert!(
+            out.contains(r#"sgl_router_dispatch_seconds_bucket{model_id="tiny",le="30"} 1"#),
+            "a 30 s dispatch must land in a real bucket, not +Inf; got:\n{out}",
+        );
+        assert!(
+            *ROUTER_PHASE_BUCKETS.last().unwrap() < *TTFT_OVERHEAD_BUCKETS.last().unwrap(),
+            "the phase ladder must top out below the dispatch ladder",
+        );
     }
 
     /// Non-finite input must never reach the histogram — same contract as the

--- a/experimental/sgl-router/src/server/metrics.rs
+++ b/experimental/sgl-router/src/server/metrics.rs
@@ -1118,11 +1118,24 @@ impl MetricsRegistry {
     /// engine-side queueing, which is what an unexplained TTFT gap between an
     /// external observer and the engine usually turns out to be.
     ///
-    /// Recorded for every request that receives upstream headers, streaming or
-    /// buffered, 2xx or not — deliberately wider than `ttft_overhead_seconds`,
-    /// which is streaming-2xx only, so an error-only regression is still
-    /// visible. Uses [`TTFT_OVERHEAD_BUCKETS`], not [`ROUTER_PHASE_BUCKETS`]:
-    /// under engine saturation this parks for seconds and needs the tall grid.
+    /// Recorded only when headers actually came back, streaming or buffered, and
+    /// for an upstream 4xx/5xx as readily as a 2xx — a slow error is still a real
+    /// header-receipt time. Deliberately wider than `ttft_overhead_seconds`
+    /// (streaming-2xx only), so an error-only regression stays visible. A
+    /// dispatch that never yielded headers — connect refused, retries exhausted,
+    /// stale-request expiry — records nothing: its elapsed time is a give-up
+    /// latency, and mixing it in would make a fleet outage read as enormous
+    /// engine latency. Those failures are counted by
+    /// `sgl_router_retries_exhausted_total` and the response counters.
+    ///
+    /// SPANS RETRIES. The marker sits after the retry loop, so one sample covers
+    /// every attempt plus backoff, not a single connect. That is the honest
+    /// number for TTFT attribution — the client waited for all of it — but it
+    /// means a retried request inflates this histogram's tail. Read it against
+    /// `sgl_router_retries_total` before concluding the engine got slower.
+    ///
+    /// Uses [`TTFT_OVERHEAD_BUCKETS`], not [`ROUTER_PHASE_BUCKETS`]: under engine
+    /// saturation this parks for seconds and needs the tall grid.
     pub fn observe_dispatch(&self, model_id: &str, seconds: f64) {
         // See `observe_request_duration` — drop non-finite before the map.
         if !seconds.is_finite() {
@@ -1660,7 +1673,7 @@ impl MetricsRegistry {
 
         // dispatch histogram
         out.push_str(
-            "# HELP sgl_router_dispatch_seconds Dispatch to upstream response headers (connect, send body, wait), in seconds. NOT router-attributable - contains the network hop and the engine's own queueing before it flushes headers. Recorded for streaming and buffered responses alike.\n",
+            "# HELP sgl_router_dispatch_seconds Dispatch to upstream response headers (connect, send body, wait), in seconds. NOT router-attributable - contains the network hop and the engine's own queueing before it flushes headers. Spans all retry attempts, so read it against sgl_router_retries_total. Recorded only when headers came back (an upstream 4xx/5xx counts; a dispatch that never yielded headers does not).\n",
         );
         out.push_str("# TYPE sgl_router_dispatch_seconds histogram\n");
         let guard = self.dispatch_seconds.lock();

--- a/experimental/sgl-router/src/server/routes/chat.rs
+++ b/experimental/sgl-router/src/server/routes/chat.rs
@@ -7,7 +7,7 @@ use crate::policies::registry::{PdPoolResolver, PdResolveError};
 use crate::policies::{request_tokens_for, RequestTokens, SelectionContext};
 use crate::proxy::sse::{StreamCapture, StreamEnd};
 use crate::proxy::AbortReason;
-use crate::server::app::{RequestPhase, RequestPhaseCell};
+use crate::server::app::{IngressAt, RequestPhase, RequestPhaseCell};
 use crate::server::app_context::AppContext;
 use crate::server::cache_sim_extend::{self, ReplySource};
 use crate::server::error::ApiError;
@@ -184,6 +184,9 @@ pub(crate) async fn chat_completions(
     // extension) keep working — see `RequestPhaseCell`'s doc comment in
     // `crate::server::app`.
     phase: Option<Extension<Arc<RequestPhaseCell>>>,
+    // Same `Option<...>` rationale as `phase`. Carries the middleware's clock so
+    // the handler can attribute the body read that finished before it started.
+    ingress_at: Option<Extension<IngressAt>>,
     // Body-consuming extractor: MUST stay last. Every extractor before this
     // one must implement `FromRequestParts` (borrows the request head only);
     // `Bytes` is the one `FromRequest` extractor allowed per handler because
@@ -192,7 +195,14 @@ pub(crate) async fn chat_completions(
     // silently receive an empty body.
     body: Bytes,
 ) -> Result<Response<Body>, ApiError> {
-    chat_completions_inner(ctx, headers, phase.map(|Extension(p)| p), body).await
+    chat_completions_inner(
+        ctx,
+        headers,
+        phase.map(|Extension(p)| p),
+        ingress_at.map(|Extension(a)| a),
+        body,
+    )
+    .await
 }
 
 /// Parse model from body, select a healthy worker via the per-model policy, then
@@ -208,9 +218,15 @@ async fn chat_completions_inner(
     ctx: Arc<AppContext>,
     headers: HeaderMap,
     phase: Option<Arc<RequestPhaseCell>>,
+    ingress_at: Option<IngressAt>,
     body: Bytes,
 ) -> Result<Response<Body>, ApiError> {
     let start = std::time::Instant::now();
+    // Captured now, recorded once the model is known (it needs the label). The
+    // span already closed, so holding the value costs nothing and changes it not
+    // at all. `saturating_duration_since` because the two clocks are the same
+    // monotonic source but the ordering is not enforced by the type system.
+    let pre_handler = ingress_at.map(|IngressAt(at)| start.saturating_duration_since(at));
     let probe = parse_probe(&body)?;
     let streaming = probe.stream.unwrap_or(false);
     let model_str = probe
@@ -274,6 +290,15 @@ async fn chat_completions_inner(
     // tokenization and the outgoing-body injection below (and PD bootstrap
     // injection). `parse_probe` already validated the object shape.
     let at_pre_tokenize = start.elapsed();
+    // Everything before this point: probe-parse, model/policy/PD resolution.
+    // Cheap on a small body; the term that grows when `parse_probe` has to walk
+    // a multimodal payload.
+    ctx.metrics
+        .observe_resolve(&model_str, at_pre_tokenize.as_secs_f64());
+    if let Some(d) = pre_handler {
+        ctx.metrics
+            .observe_ingress_read(&model_str, d.as_secs_f64());
+    }
     let want_tokens = ctx.tokenizers.has_chat_encoder(&model_str) || policy.needs_request_tokens();
     let request_value: Option<serde_json::Value> = if want_tokens {
         Some(serde_json::from_slice(&body).map_err(|_| {
@@ -788,6 +813,10 @@ async fn chat_completions_inner(
         inject_max_tokens,
     )?;
     let at_post_build = start.elapsed();
+    ctx.metrics.observe_request_build(
+        &metrics_model,
+        at_post_build.saturating_sub(at_post_admit).as_secs_f64(),
+    );
 
     let result = if let Some(decode_worker) = decode_peer {
         // PD-disagg dispatch (Pattern B — spawn prefill, await decode).
@@ -1260,6 +1289,14 @@ async fn chat_completions_inner(
     // before the SSE pump takes over. The pump's own first-byte/drain/exit timing
     // is logged separately as `sse_pump_timing`.
     let at_post_dispatch = start.elapsed();
+    // The router/engine boundary: unlike every phase above it, this span is not
+    // router CPU — it carries the network hop and whatever the engine does
+    // before flushing headers. Recorded for streaming and buffered alike, and
+    // for non-2xx too, so an error-only regression stays visible.
+    ctx.metrics.observe_dispatch(
+        &metrics_model,
+        at_post_dispatch.saturating_sub(at_post_build).as_secs_f64(),
+    );
     if PHASE_LOG_COUNTER
         .fetch_add(1, Ordering::Relaxed)
         .is_multiple_of(PHASE_LOG_SAMPLE)

--- a/experimental/sgl-router/src/server/routes/chat.rs
+++ b/experimental/sgl-router/src/server/routes/chat.rs
@@ -338,6 +338,26 @@ async fn chat_completions_inner(
     } else {
         None
     };
+    // Ingress-tokenize cost as a metric, spanning `at_pre_tokenize` (body
+    // already fully read) to `at_post_tokenize` (ids ready) — parse + render +
+    // encode, and nothing downstream. Keep both markers adjacent to the tokenize
+    // work: extending this span past admission or dispatch would turn the metric
+    // into a duplicate of the `router.ttfb` Server-Timing header.
+    //
+    // Unsampled, unlike the diagnostic log below — a histogram is the aggregate
+    // the log's 1-in-N sample was only ever a proxy for. Recorded only when the
+    // ingress actually tokenized: a request
+    // on a model with no chat encoder, under a policy that needs no tokens,
+    // would otherwise contribute a meaningless ~0 sample and drag every
+    // quantile toward zero.
+    if want_tokens {
+        ctx.metrics.observe_tokenize(
+            &model_str,
+            at_post_tokenize
+                .saturating_sub(at_pre_tokenize)
+                .as_secs_f64(),
+        );
+    }
     // Diagnostic: ingress-tokenize cost, sampled. Fires for EVERY request that
     // reaches here — including those about to be shed at admission below — so a
     // shed request's pre-admission time (the latency the access log shows on a

--- a/experimental/sgl-router/src/server/routes/chat.rs
+++ b/experimental/sgl-router/src/server/routes/chat.rs
@@ -338,18 +338,12 @@ async fn chat_completions_inner(
     } else {
         None
     };
-    // Ingress-tokenize cost as a metric, spanning `at_pre_tokenize` (body
-    // already fully read) to `at_post_tokenize` (ids ready) — parse + render +
-    // encode, and nothing downstream. Keep both markers adjacent to the tokenize
-    // work: extending this span past admission or dispatch would turn the metric
-    // into a duplicate of the `router.ttfb` Server-Timing header.
-    //
-    // Unsampled, unlike the diagnostic log below — a histogram is the aggregate
-    // the log's 1-in-N sample was only ever a proxy for. Recorded only when the
-    // ingress actually tokenized: a request
-    // on a model with no chat encoder, under a policy that needs no tokens,
-    // would otherwise contribute a meaningless ~0 sample and drag every
-    // quantile toward zero.
+    // Keep both markers adjacent to the tokenize work: extending this span past
+    // admission or dispatch turns the metric into a duplicate of the
+    // `router.ttfb` Server-Timing header. Unsampled, unlike the log below.
+    // Gated on `want_tokens`: a request on a model with no chat encoder, under a
+    // policy needing no tokens, would otherwise contribute a meaningless ~0
+    // sample and drag every quantile toward zero.
     if want_tokens {
         ctx.metrics.observe_tokenize(
             &model_str,

--- a/experimental/sgl-router/src/server/routes/chat.rs
+++ b/experimental/sgl-router/src/server/routes/chat.rs
@@ -1291,12 +1291,20 @@ async fn chat_completions_inner(
     let at_post_dispatch = start.elapsed();
     // The router/engine boundary: unlike every phase above it, this span is not
     // router CPU — it carries the network hop and whatever the engine does
-    // before flushing headers. Recorded for streaming and buffered alike, and
-    // for non-2xx too, so an error-only regression stays visible.
-    ctx.metrics.observe_dispatch(
-        &metrics_model,
-        at_post_dispatch.saturating_sub(at_post_build).as_secs_f64(),
-    );
+    // before flushing headers.
+    //
+    // Only on `Ok`, which is precisely "headers came back". An upstream 4xx/5xx
+    // IS an Ok here and is recorded — a slow error is still a real
+    // header-receipt time. A dispatch that never produced headers (connect
+    // refused, retries exhausted, stale-request expiry) is NOT: its elapsed time
+    // is a give-up latency, and mixing that in would make a fleet outage read as
+    // enormous engine latency in the same histogram.
+    if result.is_ok() {
+        ctx.metrics.observe_dispatch(
+            &metrics_model,
+            at_post_dispatch.saturating_sub(at_post_build).as_secs_f64(),
+        );
+    }
     if PHASE_LOG_COUNTER
         .fetch_add(1, Ordering::Relaxed)
         .is_multiple_of(PHASE_LOG_SAMPLE)

--- a/experimental/sgl-router/src/server/routes/chat.rs
+++ b/experimental/sgl-router/src/server/routes/chat.rs
@@ -292,6 +292,20 @@ async fn chat_completions_inner(
         .as_ref()
         .and_then(|v| request_tokens_for(&ctx.tokenizers, &model_id, v));
     let at_post_tokenize = start.elapsed();
+    // Recorded here, adjacent to the two markers, so it is evident nothing
+    // downstream is inside the span — widening it past admission or dispatch
+    // would make the metric a duplicate of the `router.ttfb` Server-Timing
+    // header. Unsampled, unlike the diagnostic log below. Gated on
+    // `want_tokens`: a request the ingress never tries to tokenize would
+    // otherwise contribute a meaningless ~0 and drag every quantile down.
+    if want_tokens {
+        ctx.metrics.observe_tokenize(
+            &model_str,
+            at_post_tokenize
+                .saturating_sub(at_pre_tokenize)
+                .as_secs_f64(),
+        );
+    }
 
     // The request id, derived HERE rather than at dispatch because both tees
     // need it and the ingress one fires now. It is the join key that lets the
@@ -338,20 +352,6 @@ async fn chat_completions_inner(
     } else {
         None
     };
-    // Keep both markers adjacent to the tokenize work: extending this span past
-    // admission or dispatch turns the metric into a duplicate of the
-    // `router.ttfb` Server-Timing header. Unsampled, unlike the log below.
-    // Gated on `want_tokens`: a request on a model with no chat encoder, under a
-    // policy needing no tokens, would otherwise contribute a meaningless ~0
-    // sample and drag every quantile toward zero.
-    if want_tokens {
-        ctx.metrics.observe_tokenize(
-            &model_str,
-            at_post_tokenize
-                .saturating_sub(at_pre_tokenize)
-                .as_secs_f64(),
-        );
-    }
     // Diagnostic: ingress-tokenize cost, sampled. Fires for EVERY request that
     // reaches here — including those about to be shed at admission below — so a
     // shed request's pre-admission time (the latency the access log shows on a

--- a/experimental/sgl-router/src/server/routes/chat.rs
+++ b/experimental/sgl-router/src/server/routes/chat.rs
@@ -462,6 +462,14 @@ async fn chat_completions_inner(
         p.set(RequestPhase::Dispatch);
     }
     let at_post_admit = start.elapsed();
+    // Selection + claim + any parking. Recorded for EVERY admitted request,
+    // unlike `admission_wait_seconds`, which the fast path returns before ever
+    // reaching — leaving worker selection (prompt hashing, radix-tree walk,
+    // oracle consult, candidate scoring) unmeasured on the common path.
+    ctx.metrics.observe_admit(
+        &model_str,
+        at_post_admit.saturating_sub(at_post_tokenize).as_secs_f64(),
+    );
     // Diagnostic: count this request as holding a slot inside the synchronous
     // handler (post-acquire → response returned). Drops when the function
     // returns (headers time for streaming), so HANDLER_INFLIGHT reflects slots

--- a/experimental/sgl-router/tests/proxy/cache_aware_input_ids.rs
+++ b/experimental/sgl-router/tests/proxy/cache_aware_input_ids.rs
@@ -190,6 +190,43 @@ async fn request_records_every_phase_histogram() {
     }
 }
 
+/// A dispatch that never yields upstream headers records NO
+/// `sgl_router_dispatch_seconds` sample. Its elapsed time is a give-up latency,
+/// not a header-receipt time, and folding the two together would make a fleet
+/// outage read as enormous engine latency in the histogram operators use to
+/// judge the engine. The earlier phases still record — they really did happen.
+#[tokio::test]
+async fn failed_dispatch_records_no_dispatch_sample() {
+    // Port 1 on loopback: nothing listens, so the connect is refused.
+    let ctx = build_ctx("http://127.0.0.1:1".to_string());
+    let status = send(
+        Arc::clone(&ctx),
+        json!({
+            "model": MODEL,
+            "messages": [{"role": "user", "content": "hello there friend"}],
+        }),
+    )
+    .await;
+    assert!(
+        !status.is_success(),
+        "a refused upstream must not produce a success status; got {status}"
+    );
+
+    let m = ctx.metrics.render();
+    assert!(
+        !m.contains(&format!(
+            r#"sgl_router_dispatch_seconds_count{{model_id="{MODEL}"}}"#
+        )),
+        "a dispatch that never received headers must not be sampled; got:\n{m}"
+    );
+    assert!(
+        m.contains(&format!(
+            r#"sgl_router_tokenize_seconds_count{{model_id="{MODEL}"}} 1"#
+        )),
+        "phases that did complete must still record; got:\n{m}"
+    );
+}
+
 #[tokio::test]
 async fn tool_request_forwards_input_ids() {
     let mock = MockWorker::start(vec![]).await;

--- a/experimental/sgl-router/tests/proxy/cache_aware_input_ids.rs
+++ b/experimental/sgl-router/tests/proxy/cache_aware_input_ids.rs
@@ -152,6 +152,33 @@ async fn plain_chat_forwards_input_ids_and_keeps_messages() {
     );
 }
 
+/// The ingress records `sgl_router_tokenize_seconds` for a request it
+/// tokenizes. The registry unit tests cover the histogram in isolation; only
+/// this asserts the chat handler is wired to it, so deleting the call site or
+/// inverting its gate fails loudly here instead of passing silently.
+#[tokio::test]
+async fn tokenized_request_records_tokenize_seconds() {
+    let mock = MockWorker::start(vec![]).await;
+    let ctx = build_ctx(mock.url.clone());
+    let status = send(
+        Arc::clone(&ctx),
+        json!({
+            "model": MODEL,
+            "messages": [{"role": "user", "content": "hello there friend"}],
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let m = ctx.metrics.render();
+    assert!(
+        m.contains(&format!(
+            r#"sgl_router_tokenize_seconds_count{{model_id="{MODEL}"}} 1"#
+        )),
+        "ingress tokenize must be recorded once for a tokenized request; got:\n{m}"
+    );
+}
+
 #[tokio::test]
 async fn tool_request_forwards_input_ids() {
     let mock = MockWorker::start(vec![]).await;

--- a/experimental/sgl-router/tests/proxy/cache_aware_input_ids.rs
+++ b/experimental/sgl-router/tests/proxy/cache_aware_input_ids.rs
@@ -152,12 +152,17 @@ async fn plain_chat_forwards_input_ids_and_keeps_messages() {
     );
 }
 
-/// The ingress records `sgl_router_tokenize_seconds` for a request it
-/// tokenizes. The registry unit tests cover the histogram in isolation; only
-/// this asserts the chat handler is wired to it, so deleting the call site or
-/// inverting its gate fails loudly here instead of passing silently.
+/// One buffered request records the whole per-phase breakdown: resolve →
+/// tokenize → build → dispatch. The registry unit tests cover each histogram in
+/// isolation; only this asserts the chat handler is wired to all four, so
+/// deleting a call site or inverting a gate fails loudly here instead of passing
+/// silently.
+///
+/// Buffered, not streaming, on purpose: `ttft_overhead_seconds` and
+/// `ttft_seconds` are streaming-2xx only, so this also pins that the phase
+/// histograms cover the path those two do not.
 #[tokio::test]
-async fn tokenized_request_records_tokenize_seconds() {
+async fn request_records_every_phase_histogram() {
     let mock = MockWorker::start(vec![]).await;
     let ctx = build_ctx(mock.url.clone());
     let status = send(
@@ -171,12 +176,18 @@ async fn tokenized_request_records_tokenize_seconds() {
     assert_eq!(status, StatusCode::OK);
 
     let m = ctx.metrics.render();
-    assert!(
-        m.contains(&format!(
-            r#"sgl_router_tokenize_seconds_count{{model_id="{MODEL}"}} 1"#
-        )),
-        "ingress tokenize must be recorded once for a tokenized request; got:\n{m}"
-    );
+    for name in [
+        "sgl_router_ingress_read_seconds",
+        "sgl_router_resolve_seconds",
+        "sgl_router_tokenize_seconds",
+        "sgl_router_request_build_seconds",
+        "sgl_router_dispatch_seconds",
+    ] {
+        assert!(
+            m.contains(&format!(r#"{name}_count{{model_id="{MODEL}"}} 1"#)),
+            "{name} must be recorded once for one request; got:\n{m}"
+        );
+    }
 }
 
 #[tokio::test]

--- a/experimental/sgl-router/tests/proxy/cache_aware_input_ids.rs
+++ b/experimental/sgl-router/tests/proxy/cache_aware_input_ids.rs
@@ -180,6 +180,7 @@ async fn request_records_every_phase_histogram() {
         "sgl_router_ingress_read_seconds",
         "sgl_router_resolve_seconds",
         "sgl_router_tokenize_seconds",
+        "sgl_router_admit_seconds",
         "sgl_router_request_build_seconds",
         "sgl_router_dispatch_seconds",
     ] {


### PR DESCRIPTION
## Problem

Ingress tokenize cost is measured today but never exposed. `tokenize_ms` is computed at `chat.rs:276-294` and emitted only as a field on the **sampled** `phase_pre_admit` debug log — and it is rounded with `as_millis()`, so a typical sub-millisecond tokenize logs as `0` and is literally unrepresentable there.

The only metric containing it, `sgl_router_ttft_overhead_seconds`, folds it together with admission wait and request build. Admission wait dominates that aggregate under load — precisely when someone asks whether the router's own tokenizer is the bottleneck. The aggregate cannot answer that question.

## The boundary

Deliberately narrow — **body fully read → token ids ready**:

| Inside | Outside |
|---|---|
| body JSON parse | body read, header handling |
| chat-template render | admission wait |
| encode | request build, connect, send, dispatch |

Widening it to reach dispatch would degenerate this into a worse copy of the existing `Server-Timing: router.ttfb` header. Both markers sit adjacent to the tokenize call, and `observe_tokenize`'s doc states the rule so it cannot drift unnoticed.

The JSON parse is inside on purpose: unavoidable work between bytes and ids, and with the 100 MiB multimodal body cap it can outweigh the encode. Read it as *bytes to ids*, not pure BPE time.

## Buckets

Separate ladder from `TTFT_OVERHEAD_BUCKETS`, starting at 100 µs rather than 1 ms. On the overhead grid essentially every healthy tokenize collapses into the first bucket, where `histogram_quantile` cannot resolve it. Still reaches 5 s so a pathological prompt lands in a real bucket, not `+Inf`.

## Scope and semantics

- **`/v1/chat/completions` ingress only.** The handler is mounted only there (`app.rs:378`).
- **`/v1/tokenize` is not counted.** It encodes too (`routes/tokenize.rs:57`), but it is a standalone utility endpoint whose entire cost is already `sgl_router_request_duration_seconds`; blending it in would make the distribution unattributable.
- **Gated on *attempted* tokenization, not successful.** A never-attempted request records nothing rather than a zero. An attempt yielding no ids — render failure, or no tokenizable field — *is* recorded and may be parse-time only, because a slow *failing* render is exactly the latency worth seeing. Pair with `sgl_router_ingress_tokenize_errors_total` to separate them.
- **Unsampled**, unlike the debug log it supersedes.
- **Sample set is a superset** of `ttft_overhead_seconds` (streaming-2xx only): expect `tokenize_count >= overhead_count`; the gap is non-streaming, non-2xx and shed requests.
- **The two overlap by construction — do not sum them.** I chose a sibling histogram over decomposing `ttft_overhead_seconds` into three terms, since the latter breaks an existing metric. Happy to take the other call if maintainers prefer.
- `model_id` cardinality is bounded: `policies.get` rejects unknown models before the timing span opens.

## Testing

Three new tests in `server::metrics`:

- `observe_tokenize_writes_buckets_sum_and_count` — bucket/sum/count rendering
- `tokenize_buckets_resolve_sub_millisecond` — two sub-ms samples land in *distinct* buckets, and asserts `TOKENIZE_BUCKETS[0] < TTFT_OVERHEAD_BUCKETS[0]`, pinning why the separate ladder exists
- `observe_tokenize_drops_non_finite` — matches the non-finite contract of the other `observe_*` entry points

Verified locally: `cargo test --lib server::metrics` → **43 passed / 0 failed**. `cargo fmt --check` clean. `cargo clippy --all-targets -- -D warnings` reports the same single pre-existing `derivable_impls` finding in `config/types.rs` with and without this change (verified by stashing) — no new lint. `pre-commit` passes on both files apart from the rustfmt hook, which cannot launch in my environment for an unrelated local toolchain reason; its exact command was run directly and passes.

Second commit is a self-review pass correcting scope claims in the doc comment and HELP text and compressing the comment footprint — no behavior change.

Based on `combine/router-admission-http2-loadaware` because the ingress tokenization path and `metrics.rs` do not exist on `main`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34829052811](https://github.com/sgl-project/sglang/actions/runs/34829052811)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34829052725](https://github.com/sgl-project/sglang/actions/runs/34829052725)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->