### PR TITLE
[PD] Avoid unused PREBUILT prompt tensor transfer

### DIFF
--- a/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
+++ b/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from array import array
 from http import HTTPStatus
 from typing import TYPE_CHECKING, List
 
@@ -30,14 +29,16 @@ class ScheduleBatchDisaggregationDecodeMixin:
 
         self.forward_mode = ForwardMode.PREBUILT
         reqs = self.reqs
-        input_ids = [r.get_fill_ids()[len(r.prefix_indices) :] for r in reqs]
-        extend_num_tokens = sum(len(ids) for ids in input_ids)
+        # PREBUILT never enters a model forward. Keep the legacy scalar metadata,
+        # but do not flatten and copy every transferred prompt to the GPU only to
+        # discard it before the first decode step.
         seq_lens = []
         pre_lens = []
         req_pool_indices = []
 
         # Pre-calculate total size
         total_size = sum(req.extend_range.length for req in reqs)
+        extend_num_tokens = total_size
         out_cache_loc = torch.empty(total_size, dtype=torch.int64, device=self.device)
 
         # Fill the tensor in one pass
@@ -77,9 +78,10 @@ class ScheduleBatchDisaggregationDecodeMixin:
             pre_lens.append(pre_len)
 
         # Set fields
-        self.input_ids = torch.tensor(
-            sum(input_ids, array("q")), dtype=torch.int32, device=self.device
-        )
+        # The first decode input and speculative extras are seeded by
+        # process_prebuilt through FutureMap, so merge/forward-entry rebuilds
+        # input_ids from the relay.
+        self.input_ids = None
         self.req_pool_indices = torch.tensor(
             req_pool_indices, dtype=torch.int64, device=self.device
         )

--- a/test/registered/unit/disaggregation/test_disaggregation_wire.py
+++ b/test/registered/unit/disaggregation/test_disaggregation_wire.py
@@ -18,6 +18,9 @@ from sglang.srt.disaggregation.common.utils import (
     unpack_int_lists,
     unpack_list_of_buffers,
 )
+from sglang.srt.disaggregation.decode_schedule_batch_mixin import (
+    ScheduleBatchDisaggregationDecodeMixin,
+)
 from sglang.srt.disaggregation.mooncake.conn import (
     KVArgsRegisterInfo,
     MooncakeKVManager,
@@ -94,6 +97,40 @@ class TestDisaggregationWire(unittest.TestCase):
     def test_empty_inner_list(self):
         packed = pack_int_lists([[]], "I")
         self.assertEqual(unpack_int_lists(packed, "I"), [[]])
+
+    def test_prebuilt_skips_unused_prompt_tensor(self):
+        req = SimpleNamespace(
+            req_pool_idx=0,
+            prefix_indices=[0, 1],
+            extend_range=SimpleNamespace(length=3),
+            origin_input_ids=[0, 1, 2, 3, 4],
+            output_ids=[],
+            retracted_stain=True,
+            is_retracted=True,
+            multimodal_inputs=None,
+            get_fill_ids=Mock(side_effect=AssertionError("prompt should not be read")),
+        )
+        batch = SimpleNamespace(
+            reqs=[req],
+            device="cpu",
+            req_to_token_pool=SimpleNamespace(
+                req_to_token=torch.arange(5, dtype=torch.int64).reshape(1, 5)
+            ),
+            return_logprob=False,
+            model_config=SimpleNamespace(vocab_size=32),
+        )
+
+        with patch(
+            "sglang.srt.disaggregation.decode_schedule_batch_mixin."
+            "SamplingBatchInfo.from_schedule_batch",
+            return_value=Mock(),
+        ):
+            ScheduleBatchDisaggregationDecodeMixin.prepare_for_prebuilt(batch)
+
+        self.assertIsNone(batch.input_ids)
+        self.assertEqual(batch.extend_num_tokens, 3)
+        self.assertTrue(torch.equal(batch.out_cache_loc, torch.tensor([2, 3, 4])))
+        req.get_fill_ids.assert_not_called()
 
     def test_list_of_buffers_roundtrip(self):
         bufs = [b"abc", b"", b"de", b"x" * 17]


### PR DESCRIPTION
## Motivation

Decode-side PREBUILT batches never enter a model forward. However, `prepare_for_prebuilt` still flattened every transferred prompt and copied the result to a CUDA `input_ids` tensor. The first decode step later reconstructs its input from the relay metadata, so this prompt transfer is unused and can be expensive for long-context disaggregated requests.

## Modifications

- Derive `extend_num_tokens` from the existing extend ranges.
- Leave `input_ids` unset for PREBUILT batches instead of reading, flattening, and copying the complete prompt.
- Preserve cache locations, sequence lengths, request-pool indices, sampling metadata, and relay behavior.
- Add one regression case to the existing disaggregation wire test.

## Accuracy Tests

GSM8K, 200 requests, 5-shot chat evaluation:

| Metric | Result |
|---|---:|
| Accuracy | **0.990** |
| Mean speculative acceptance length | 4.528467 |
| Acceptance rate | 0.705827 |
| CUDA graph request fraction | 1.0 |
| Retractions | 0 |
| Error markers | 0 |

The evaluation used natural model output; no simulated-accuracy path was enabled.

## Speed Tests and Profiling

AgentX 393-trace workload, Qwen3.5-397B-A17B NVFP4, 24 GB300 GPUs, 4P+1D, concurrency 896. The production A/B uses each arm's independently aligned formal `180-900 s` window.

| Metric | Baseline | This PR | Change |
|---|---:|---:|---:|
| Exact-shape output TPS/User | 71.75528 | 84.65411 | **+17.97615%** |
| Strict decode TPS/GPU | 3890.433 | 4385.898 | **+12.73548%** |
| Matched mean context | — | — | -0.08271% |
| Matched acceptance length | — | — | -0.03042% |

A targeted replay of the 44 observed PREBUILT prompt shapes reduced the unused transfer from `1.690525` to `0.001745 ms/target-step` on the GPU-visible timeline (`1.688780 ms` saved); CPU wall saving was `1.688699 ms/target-step`.

Targeted production-container unit coverage passed before the production A/B.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). No public API or configuration changes.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31987731787](https://github.com/sgl-project/sglang/actions/runs/31987731787)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31987731772](https://github.com/sgl-project/sglang/actions/runs/31987731772)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
