### PR TITLE
[Fix] Support GLM ModelOpt NVFP4 with Humming on Hopper

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -1520,10 +1520,20 @@ class ModelConfig:
             # of an NVFP4/mixed checkpoint) must not be overridden back to the
             # source format
             if self.quantization not in REQUANTIZATION_METHODS:
-
                 # Detect which checkpoint is it
                 if not preserve_online_draft_quantization:
-                    for _, method in QUANTIZATION_METHODS.items():
+                    quantization_methods = list(QUANTIZATION_METHODS.items())
+                    # ModelOpt metadata is normalized to modelopt_fp4/modelopt_fp8
+                    # above, and those format handlers otherwise claim the
+                    # checkpoint before Humming gets a chance to consume it. An
+                    # explicit Humming request must take precedence over automatic
+                    # checkpoint-format detection.
+                    if self.quantization == "humming":
+                        quantization_methods.sort(
+                            key=lambda item: item[0] != "humming"
+                        )
+
+                    for _, method in quantization_methods:
                         quantization_override = method.override_quantization_method(
                             quant_cfg, self.quantization
                         )

--- a/python/sglang/srt/layers/quantization/humming.py
+++ b/python/sglang/srt/layers/quantization/humming.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import json
 import math
+import threading
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, List
 
@@ -220,6 +221,12 @@ class HummingConfig(QuantizationConfig):
 
     @classmethod
     def from_config(cls, config: dict[str, Any]) -> "HummingConfig":
+        # ModelConfig normalizes ModelOpt metadata to names such as
+        # ``modelopt_fp4`` for backend selection. Humming's schema library
+        # consumes the original ModelOpt format name plus ``quant_algo``.
+        if config.get("quant_method", "").startswith("modelopt_"):
+            config = config.copy()
+            config["quant_method"] = "modelopt"
         return cls(full_config=config)
 
     def get_scaled_act_names(self) -> List[str]:
@@ -338,6 +345,24 @@ class HummingConfig(QuantizationConfig):
             if force_weight_schema is not None and force_input_schema is None:
                 force_input_schema = HummingInputSchema()
 
+            is_modelopt_nvfp4 = (
+                getattr(weight_schema, "quant_method", None) == "modelopt"
+                and str(getattr(weight_schema, "quant_algo", "")).lower() == "nvfp4"
+            )
+            if (
+                force_input_schema is None
+                and is_modelopt_nvfp4
+                and torch.cuda.is_available()
+                and torch.cuda.get_device_capability()[0] < 12
+            ):
+                # ModelOpt NVFP4 uses K-groups of 16. On pre-SM120 devices,
+                # Humming lowers FP8 x FP4 through a kernel whose K quantum is
+                # 32, so its default FP8 activation fallback cannot consume
+                # those scales. Keep activations in the model dtype instead;
+                # this uses a K quantum of 16 and preserves checkpoint weights
+                # exactly. An explicit input-quant config still takes priority.
+                input_schema = HummingInputSchema()
+
             return HummingLayerQuantizationConfig(
                 weight_schema=weight_schema,
                 input_schema=input_schema,
@@ -423,6 +448,11 @@ class HummingLinearMethod(LinearMethodBase):
         self.is_online_quant = self.quant_config.is_online_quant
 
     def prepare_weight_loader(self, layer: torch.nn.Module, weight_loader: Callable):
+        # DeepSeek/GLM weights are loaded concurrently.  Multiple shards of an
+        # unexpectedly unquantized merged linear can therefore enter the
+        # fallback conversion at the same time.
+        fallback_lock = threading.Lock()
+
         def new_weight_loader(
             param: torch.nn.Parameter,
             loaded_weight: torch.Tensor,
@@ -459,32 +489,36 @@ class HummingLinearMethod(LinearMethodBase):
                 # fallback to unquantized linear
                 # some model skip some layer when quantizing model, but
                 # don't mark the layer as unquantized.
-                if not layer.is_fallback:
-                    layer.is_fallback = True
-                    for name, _ in list(layer.named_parameters()):
-                        if name != "bias":
-                            delattr(layer, name)
-                    delattr(layer, "locks")
-                    self.__class__ = UnquantizedLinearMethod  # type: ignore
-                    tensor = torch.empty(
-                        (
-                            layer.output_partition_sizes_sum,
-                            layer.input_size_per_partition,
-                        ),
-                        dtype=layer.param_dtype,
-                        device=param.device,
-                    )
-                    extra_weight_attrs = layer.extra_weight_attrs.copy()
-                    orig_weight_loader = extra_weight_attrs.pop("weight_loader")
-                    layer.weight = ModelWeightParameter(
-                        data=tensor,
-                        input_dim=1,
-                        output_dim=0,
-                        weight_loader=orig_weight_loader,
-                    )
-                    layer.weight.tp_size = layer.tp_size
-                    layer.weight.tp_rank = layer.tp_rank
-                    set_weight_attrs(layer.weight, extra_weight_attrs)
+                with fallback_lock:
+                    if not layer.is_fallback:
+                        for name, _ in list(layer.named_parameters()):
+                            if name != "bias":
+                                delattr(layer, name)
+                        delattr(layer, "locks")
+                        tensor = torch.empty(
+                            (
+                                layer.output_partition_sizes_sum,
+                                layer.input_size_per_partition,
+                            ),
+                            dtype=layer.param_dtype,
+                            device=param.device,
+                        )
+                        extra_weight_attrs = layer.extra_weight_attrs.copy()
+                        orig_weight_loader = extra_weight_attrs.pop("weight_loader")
+                        layer.weight = ModelWeightParameter(
+                            data=tensor,
+                            input_dim=1,
+                            output_dim=0,
+                            weight_loader=orig_weight_loader,
+                        )
+                        # ReplicatedLinear intentionally has no TP metadata.
+                        layer.weight.tp_size = getattr(layer, "tp_size", 1)
+                        layer.weight.tp_rank = getattr(layer, "tp_rank", 0)
+                        set_weight_attrs(layer.weight, extra_weight_attrs)
+                        self.__class__ = UnquantizedLinearMethod  # type: ignore
+                        # Publish the fallback state only after ``layer.weight``
+                        # is ready for other loader threads.
+                        layer.is_fallback = True
 
                 param = layer.weight
                 if shard_id is not None:
@@ -756,6 +790,11 @@ class HummingMoEMethod(FusedMoEMethodBase):
                     num_experts=num_experts,
                     param_dtype=params_dtype,
                     has_bias=with_bias,
+                    # w13 stacks the gate (w1) and up (w3) projections.  Some
+                    # checkpoint schemas, including ModelOpt NVFP4, keep one
+                    # tensor-wise scale for each projection and therefore need
+                    # two loader slots.
+                    stack_size=2,
                 ),
             },
             "w2": {
@@ -767,6 +806,7 @@ class HummingMoEMethod(FusedMoEMethodBase):
                     num_experts=num_experts,
                     param_dtype=params_dtype,
                     has_bias=with_bias,
+                    stack_size=1,
                 ),
             },
         }

--- a/test/registered/unit/model_loader/test_modelopt_loader.py
+++ b/test/registered/unit/model_loader/test_modelopt_loader.py
@@ -5,7 +5,10 @@ This test module verifies the functionality of ModelOptModelLoader, which
 applies NVIDIA Model Optimizer quantization to models during loading.
 """
 
+import time
 import unittest
+from concurrent.futures import ThreadPoolExecutor
+from threading import Event
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -19,6 +22,11 @@ from sglang.srt.layers.linear import ReplicatedLinear
 from sglang.srt.layers.logits_processor import should_apply_lm_head_quant_method
 from sglang.srt.layers.modelopt_utils import QUANT_CFG_CHOICES
 from sglang.srt.layers.quantization.fp8 import Fp8Config, Fp8LinearMethod
+from sglang.srt.layers.quantization.humming import (
+    HummingConfig,
+    HummingLinearMethod,
+    HummingMoEMethod,
+)
 from sglang.srt.layers.quantization.modelopt_quant import (
     ModelOptFp4Config,
     ModelOptFp4LinearMethod,
@@ -476,7 +484,7 @@ class TestParseQuantHfConfig(CustomTestCase):
     ]
 
     def setUp(self):
-        """Set up a real ModelConfig using TinyLlama (already used elsewhere)."""
+        """Set up the fields exercised here without a remote model lookup."""
         self.mock_tp_rank = patch(
             "sglang.srt.distributed.parallel_state.get_tensor_model_parallel_rank",
             return_value=0,
@@ -489,9 +497,16 @@ class TestParseQuantHfConfig(CustomTestCase):
         )
         self.mock_mp_is_initialized.start()
 
-        self.model_config = ModelConfig(
-            model_path="TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+        self.model_config = ModelConfig.__new__(ModelConfig)
+        self.model_config.model_path = "/nonexistent"
+        self.model_config.revision = None
+        self.model_config.hf_config = SimpleNamespace(
+            quantization_config=None,
+            compression_config=None,
         )
+        self.model_config.quantization = None
+        self.model_config.is_draft_model = False
+        self.model_config.is_draft_quantization_explicit = False
 
     def tearDown(self):
         self.mock_tp_rank.stop()
@@ -610,6 +625,186 @@ class TestParseQuantHfConfig(CustomTestCase):
         result = self.model_config._parse_quant_hf_config()
         self.assertEqual(result["quant_method"], "gptq")
         self.assertNotIn("quant_algo", result)
+
+    def test_explicit_humming_overrides_normalized_modelopt_fp4(self):
+        """A ModelOpt NVFP4 checkpoint must honor ``--quantization humming``."""
+        self.model_config.quantization = "humming"
+        self.model_config.hf_config.quantization_config = {
+            "quant_method": "modelopt",
+            "quant_algo": "NVFP4",
+            "config_groups": {
+                "group_0": {
+                    "targets": ["Linear"],
+                    "weights": {
+                        "dynamic": False,
+                        "num_bits": 4,
+                        "type": "float",
+                        "group_size": 16,
+                    },
+                    "input_activations": {
+                        "dynamic": False,
+                        "num_bits": 4,
+                        "type": "float",
+                        "group_size": 16,
+                    },
+                }
+            },
+        }
+
+        self.model_config._verify_quantization()
+
+        self.assertEqual(self.model_config.quantization, "humming")
+        # _parse_quant_hf_config normalizes the checkpoint metadata in place;
+        # Humming must translate that alias back to its ModelOpt schema name.
+        humming_config = HummingConfig.from_config(
+            self.model_config.hf_config.quantization_config
+        )
+        self.assertEqual(humming_config.full_config["quant_method"], "modelopt")
+
+    def test_humming_modelopt_nvfp4_moe_allocates_both_w13_scales(self):
+        """GLM-style gated MoE needs separate ModelOpt scales for w1 and w3."""
+        humming_config = HummingConfig.from_config(
+            {
+                "quant_method": "modelopt",
+                "quant_algo": "NVFP4",
+                "config_groups": {
+                    "group_0": {
+                        "targets": ["Linear"],
+                        "weights": {
+                            "dynamic": False,
+                            "num_bits": 4,
+                            "type": "float",
+                            "group_size": 16,
+                        },
+                        "input_activations": {
+                            "dynamic": False,
+                            "num_bits": 4,
+                            "type": "float",
+                            "group_size": 16,
+                        },
+                    }
+                },
+            }
+        )
+        with (
+            patch(
+                "sglang.srt.layers.quantization.humming.torch.cuda.is_available",
+                return_value=True,
+            ),
+            patch(
+                "sglang.srt.layers.quantization.humming.torch.cuda.get_device_capability",
+                return_value=(9, 0),
+            ),
+            patch(
+                "sglang.srt.layers.quantization.humming.envs."
+                "SGLANG_HUMMING_INPUT_QUANT_CONFIG.get",
+                return_value=None,
+            ),
+        ):
+            layer_config = humming_config.get_quant_config_for_layer(
+                prefix="model.layers.3.mlp.experts", layer_type="moe"
+            )
+        self.assertIsNotNone(layer_config)
+        # FP8 activations require K-groups >= 32 in Humming's SM90 kernels,
+        # while NVIDIA NVFP4 checkpoints use 16. Keep H20 activations in BF16.
+        self.assertEqual(layer_config.input_schema.get_activation_bits(), 16)
+
+        layer = nn.Module()
+        HummingMoEMethod(layer_config).create_weights(
+            layer=layer,
+            num_experts=3,
+            hidden_size=32,
+            intermediate_size_per_partition=16,
+            params_dtype=torch.bfloat16,
+        )
+
+        # w13 contains the gate/up pair; w2 is a single down projection.
+        self.assertEqual(tuple(layer.w13_weight_scale_2.shape), (3, 2))
+        self.assertEqual(tuple(layer.w2_weight_scale_2.shape), (3,))
+
+    def test_humming_unquantized_merged_linear_fallback_is_thread_safe(self):
+        """Concurrent GLM shard loads must publish a complete fallback layer."""
+        layer_config = HummingConfig.from_config(
+            {
+                "quant_method": "modelopt",
+                "quant_algo": "NVFP4",
+                "config_groups": {
+                    "group_0": {
+                        "targets": ["Linear"],
+                        "weights": {
+                            "dynamic": False,
+                            "num_bits": 4,
+                            "type": "float",
+                            "group_size": 16,
+                        },
+                        "input_activations": {
+                            "dynamic": False,
+                            "num_bits": 4,
+                            "type": "float",
+                            "group_size": 16,
+                        },
+                    }
+                },
+            }
+        ).get_quant_config_for_layer("model.layers.0.self_attn.qkv", "linear")
+        self.assertIsNotNone(layer_config)
+
+        loaded_shards = []
+
+        def original_loader(param, loaded_weight, shard_id):
+            loaded_shards.append(shard_id)
+
+        method = HummingLinearMethod(layer_config)
+        layer = nn.Module()
+        method.create_weights(
+            layer=layer,
+            input_size_per_partition=32,
+            output_partition_sizes=[16, 16],
+            input_size=32,
+            output_size=32,
+            params_dtype=torch.bfloat16,
+            weight_loader=original_loader,
+        )
+        quantized_param = layer.weight
+        loader = quantized_param.weight_loader
+        entered_allocation = Event()
+        release_allocation = Event()
+        second_started = Event()
+        real_empty = torch.empty
+
+        def blocking_empty(*args, **kwargs):
+            entered_allocation.set()
+            self.assertTrue(release_allocation.wait(timeout=5))
+            return real_empty(*args, **kwargs)
+
+        loaded_weight = torch.ones((16, 32), dtype=torch.bfloat16)
+
+        def load_second_shard():
+            second_started.set()
+            return loader(quantized_param, loaded_weight, 1)
+
+        with patch(
+            "sglang.srt.layers.quantization.humming.torch.empty",
+            side_effect=blocking_empty,
+        ):
+            with ThreadPoolExecutor(max_workers=2) as executor:
+                first = executor.submit(loader, quantized_param, loaded_weight, 0)
+                self.assertTrue(entered_allocation.wait(timeout=5))
+                second = executor.submit(load_second_shard)
+                self.assertTrue(second_started.wait(timeout=5))
+                try:
+                    time.sleep(0.05)
+                    self.assertFalse(second.done())
+                finally:
+                    release_allocation.set()
+                first.result(timeout=5)
+                second.result(timeout=5)
+
+        self.assertTrue(layer.is_fallback)
+        self.assertTrue(hasattr(layer, "weight"))
+        self.assertEqual(layer.weight.tp_size, 1)
+        self.assertEqual(layer.weight.tp_rank, 0)
+        self.assertCountEqual(loaded_shards, [0, 1])
 
     def test_inherited_draft_modelopt_fp4_accepts_fp8_checkpoint(self):
         # ServerArgs has already copied the target's modelopt_fp4 request to the


### PR DESCRIPTION
## Motivation

SGLang already has the Humming backend, but a GLM ModelOpt NVFP4 checkpoint cannot currently select it correctly on Hopper:

1. ModelOpt metadata is normalized to `modelopt_fp4`, whose format handler wins before an explicit `--quantization humming` request.
2. Humming's schema parser expects the original `quant_method=modelopt` plus `quant_algo=NVFP4` metadata.
3. On pre-SM120 GPUs, ModelOpt NVFP4's K-group size 16 is incompatible with Humming's default FP8-input FP4 fallback, whose K quantum is 32.
4. GLM's stacked gate/up MoE weights require two secondary/global-scale slots.
5. Concurrent loading of unquantized merged-linear shards can observe a partially initialized fallback layer.

This is distinct from #32033, which targets native `quant_method: w4afp8` checkpoints. This PR targets ModelOpt NVFP4 checkpoints and preserves their packed FP4 weights on H20/SM90.

Related: #22459.

## Modifications

- Honor an explicit Humming request before automatic checkpoint-format handlers.
- Translate SGLang's normalized `modelopt_*` alias back to the ModelOpt schema name for Humming.
- Select BF16-input W4A16 on pre-SM120 for ModelOpt NVFP4 group-16 checkpoints unless the user explicitly supplies an input-quant schema.
- Allocate two scale stacks for gated MoE `w13` and one for `w2`.
- Make merged-linear fallback initialization thread-safe and publish `is_fallback` only after the replacement weight is complete.
- Add regression coverage for backend selection, GLM MoE scale shapes, and concurrent fallback loading.

## Accuracy Tests

No kernel math or checkpoint values are changed; the patch routes the existing packed weights into Humming's existing W4A16 path. End-to-end generations completed without loader errors, NaNs, or crashes. A full model-quality benchmark has not been rerun yet.

## Speed Tests and Profiling

### Setup

- Hardware: 8 x NVIDIA H20 96 GB, driver 580.105.08.
- Model: GLM-5.2-NVFP4, ModelOpt NVFP4 checkpoint.
- Parallelism: TP8, DCP1, EP1.
- Common settings: `chunked-prefill-size=8192`, `mem-fraction-static=0.8`, FP8 E4M3 KV cache, decode CUDA Graph max batch 64, shared-experts fusion disabled.
- Marlin: `--quantization modelopt_fp4 --moe-runner-backend marlin --fp4-gemm-backend marlin`.
- Humming: `--quantization humming --moe-runner-backend humming`; on H20 this PR keeps the original group-16 NVFP4 weights and uses BF16 activations (W4A16).
- Fixed-length random token IDs, EOS disabled, and radix cache flushed before each cell. Concurrency 1/2/4 used 4/8/16 measured requests after 2/2/4 warmup requests.

### End-to-end results

The pairs below are **Marlin / Humming**. E2E delta is Humming relative to Marlin; a positive value means lower latency.

| Input -> output | Concurrency | TTFT (ms) | TPOT (ms) | Output throughput (tok/s) | Humming E2E delta |
|---|---:|---:|---:|---:|---:|
| 1K -> 256 | 1 | 434.65 / 370.80 | 10.25 / 10.92 | 83.87 / 81.01 | -3.53% |
| 1K -> 256 | 2 | 771.76 / 672.88 | 11.95 / 12.50 | 133.87 / 132.47 | -1.05% |
| 1K -> 256 | 4 | 830.87 / 669.19 | 14.13 / 15.48 | 230.59 / 221.56 | -4.08% |
| 8K -> 32 | 1 | 2801.47 / 2496.00 | 11.15 / 11.13 | 10.15 / 11.24 | +9.72% |
| 8K -> 32 | 2 | 5261.26 / 4701.58 | 22.73 / 22.02 | 10.72 / 11.88 | +9.75% |
| 8K -> 32 | 4 | 8485.94 / 7535.87 | 101.00 / 92.96 | 11.01 / 12.28 | +10.32% |

Humming improves TTFT in all six cells. For prefill-heavy 8K -> 32, it lowers E2E latency by 9.72%-10.32% and raises output throughput by 10.74%-11.51%. For decode-heavy 1K -> 256, Marlin still has 4.56%-9.51% lower TPOT and therefore 1.05%-4.08% lower final E2E latency. This PR enables the backend; it does not claim that Humming should replace Marlin for every workload.

### Memory capacity and 300K context

| Metric | Marlin | Humming | Humming change |
|---|---:|---:|---:|
| Per-GPU model/execution memory after loading | 61.36 GB | 56.80 GB | -4.56 GB |
| Per-GPU KV pool | 13.43 GB | 17.98 GB | +33.9% |
| `max_total_num_tokens` | 234,496 | 314,048 | +33.9% |
| 300K input | Rejected at 234,490-token limit | Completed | Enables the measured case |

For Humming at 300K -> 32, batch 1: TTFT 128.379 s, input throughput 2330.21 tok/s, TPOT 11.36 ms, and E2E latency 128.731 s. The request completed despite a recoverable temporary-workspace allocator warning, so production deployments should still keep additional memory headroom.

Targeted regression tests on the H20 image:

```text
3 passed, 24 deselected in 14.98s
TestParseQuantHfConfig: 10 passed, 12 subtests passed in 12.61s
```

After rebasing onto current `main`, `git diff --check` and `py_compile` pass. The only rebase conflict was in quantization-method selection; the newer `REQUANTIZATION_METHODS` guard is preserved.

## Checklist

- [ ] Run repository pre-commit in CI.
- [x] Add focused unit tests.
- [x] Documentation is not required for this bug fix; CLI behavior is unchanged.
- [x] Provide available end-to-end validation and disclose the remaining accuracy gate.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31988068687](https://github.com/sgl-project/sglang/actions/runs/31988068687)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31988068505](https://github.com/sgl-project/sglang/actions/runs/31988068505)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
