### PR TITLE
[Fix] Read aiter topk sizing from schedule config

### DIFF
--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -35,7 +35,7 @@ import torch.nn.functional as F
 if TYPE_CHECKING:
     from triton_kernels.tensor_details.ragged_tensor import RaggedTensorMetadata
 
-from sglang.srt.runtime_context import get_exec, get_lora, get_parallel
+from sglang.srt.runtime_context import get_exec, get_lora, get_parallel, get_schedule
 
 try:
     from triton_kernels.tensor import make_ragged_tensor_metadata
@@ -170,20 +170,18 @@ def _get_aiter_topk_fuse_shared_max_tokens() -> int:
     (server args are fixed after startup)."""
     global _aiter_topk_fuse_shared_max_tokens_cache
     if _aiter_topk_fuse_shared_max_tokens_cache is None:
-        from sglang.srt.runtime_context import get_server_args
-
         try:
-            sa = get_server_args()
+            schedule = get_schedule()
         except ValueError:
-            # Global server args not published yet (e.g. a unit test or offline
+            # Resolved config not published yet (e.g. a unit test or offline
             # init that reaches the aiter grouped-topk path before startup).
             # Degrade gracefully instead of crashing -- this value only bounds
             # the fast-path coverage, not correctness (see docstring). Return the
             # safety cap WITHOUT caching, so a later call (once args are set)
             # still computes and caches the real value.
             return _AITER_TOPK_FUSE_SHARED_MAX_TOKENS_CAP
-        cps = getattr(sa, "chunked_prefill_size", None) or 0
-        mpt = getattr(sa, "max_prefill_tokens", None) or 0
+        cps = schedule.chunked_prefill_size or 0
+        mpt = schedule.max_prefill_tokens or 0
         m = max(int(cps), int(mpt), 8192)  # 8192 floor for tiny configs
         if int(cps) <= 0 and int(mpt) <= 0:
             # chunked prefill disabled -> use the safety cap


### PR DESCRIPTION
## Summary

- read `chunked_prefill_size` and `max_prefill_tokens` from the resolved `schedule` config namespace
- preserve the existing unpublished-config fallback and buffer sizing behavior
- remove the process-global `ServerArgs` alias reads introduced by #31323

This fixes `test_global_config_read_ratchet.py`, which currently fails on `main` and blocks unrelated PR reruns such as #34992.

## Validation

- `pre-commit run --files python/sglang/srt/layers/moe/topk.py`
- remote H100 devbox: `108 passed, 148 subtests passed` across the global-config ratchet and runtime-context test files
- remote focused smoke: unpublished config returns the safety cap; published `chunked_prefill_size=4096` / `max_prefill_tokens=16384` returns `16384`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #31988393798](https://github.com/sgl-project/sglang/actions/runs/31988393798)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #31988467340](https://github.com/sgl-project/sglang/actions/runs/31988467340)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->