### PR TITLE
fix: broadcast EAGLE draft-side sampling across TP ranks on ROCm

### DIFF
--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -44,6 +44,7 @@ from sglang.srt.model_executor.forward_context import ForwardContext, forward_co
 from sglang.srt.model_executor.runner import (
     DecodeCudaGraphRunner,
     get_batch_sizes_to_capture,
+    get_is_capture_mode,
 )
 from sglang.srt.runtime_context import (
     get_context,
@@ -121,6 +122,42 @@ _is_cuda = is_cuda()
 _is_musa = is_musa()
 _is_hip = is_hip()
 _is_xpu = is_xpu()
+
+
+def _sync_draft_sampling_across_tp(*tensors):
+    """Broadcast draft-side sampling results from TP rank 0 (AMD/HIP fix).
+
+    Floating-point non-determinism in the draft sampling path
+    (renorm_draft_probs + fast_topk on HIP) makes TP ranks pick different draft
+    tokens; with speculative_num_steps > 1 the divergence propagates into the
+    next step's input_ids / hidden_states and deadlocks the batch's collectives.
+
+    IMPORTANT: draft_forward runs *inside* a captured CUDA graph. Per
+    GroupCoordinator.graph_capture(), torch.distributed collectives are disabled
+    while capturing (they raise hipErrorCapturedEvent) and PyNccl is the enabled
+    path. Skipping the sync during capture (what patch v4 did) means the replayed
+    graph contains no sync at all. So use pynccl during capture, torch.distributed
+    otherwise.
+    """
+    from sglang.srt.distributed import get_tp_group
+    from sglang.srt.layers.dp_attention import is_dp_attention_enabled
+
+    grp = (
+        get_parallel().attn_tp_group if is_dp_attention_enabled() else get_tp_group()
+    )
+    if grp is None or grp.world_size <= 1:
+        return
+    if get_is_capture_mode():
+        pync = getattr(grp, "pynccl_comm", None)
+        if pync is None or pync.disabled:
+            return
+        for t in tensors:
+            if t is not None and t.is_contiguous():
+                pync.broadcast(t, src=0)
+    else:
+        for t in tensors:
+            if t is not None:
+                grp.broadcast(t, src=0)
 
 
 logger = logging.getLogger(__name__)
@@ -696,6 +733,7 @@ class EagleDraftWorker(EagleDraftWorkerBase):
                 if self.hot_token_id is not None:
                     topk_index = self.hot_token_id[topk_index]
                 hidden_states = logits_output.hidden_states
+                _sync_draft_sampling_across_tp(topk_index, topk_p, hidden_states)
 
         draft_probs = (
             torch.stack(draft_probs_list, dim=1)
@@ -829,6 +867,9 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             topk_p, topk_index = fast_sample(probs, num_samples=1)
         else:
             topk_p, topk_index = fast_topk(probs, self.topk, dim=-1)
+        _sync_draft_sampling_across_tp(
+            topk_index, topk_p, logits_output.hidden_states
+        )
         return EagleDraftInput(
             topk_p=topk_p,
             topk_index=topk_index,
@@ -987,6 +1028,9 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             ret_topk_p, ret_topk_index = fast_topk(probs, self.topk, dim=-1)
             ret_draft_probs = None
         ret_hidden_states = draft_logits_output.hidden_states
+        _sync_draft_sampling_across_tp(
+            ret_topk_index, ret_topk_p, ret_hidden_states
+        )
 
         # Construct the return values
         next_draft_input = batch_result.next_draft_input


### PR DESCRIPTION
## Motivation

On ROCm with TP > 1, EAGLE speculative decoding with `--speculative-num-steps > 1` can intermittently **silently deadlock** at high concurrency. Observed on 4x MI355X (gfx950) + GLM-5.2-MXFP4, TP4xDP2, EAGLE `--speculative-num-steps 5 --speculative-eagle-topk 1 --speculative-num-draft-tokens 6`: request count frozen, one DP replica at 100% GPU util (kernel busy-loop), the other idle, **no error / no watchdog** — the classic floating-point-divergence deadlock fingerprint.

Root cause: on HIP, the draft sampling path (`renorm_draft_probs` + `fast_topk`) is floating-point **non-deterministic**, so TP ranks can sample different draft tokens. With `speculative_num_steps > 1` the divergence propagates into the next step's `input_ids` / `hidden_states`, so ranks feed different inputs into the same TP collective → collective deadlock.

The verify side already syncs its decision across TP ranks (`eagle_sample` in `eagle_utils.py`, broadcast of `predict`/`accept_index`/`num_correct_drafts` — see #34238). The **draft side** has no such sync — that is the missing half.

## Modifications

Add `_sync_draft_sampling_across_tp()` in `python/sglang/srt/speculative/eagle_worker_v2.py` and call it after the sampling at all three draft-side sampling points:

1. `draft_forward` multi-step loop — sync `topk_index`, `topk_p`, `hidden_states`
2. `_draft_extend_for_prefill` — sync `topk_index`, `topk_p`, `hidden_states`
3. `_draft_extend_for_decode` — sync `ret_topk_index`, `ret_topk_p`, `ret_hidden_states`

The sync source is the attn-TP rank 0 (or global TP rank 0 when DP attention is off), matching the verify side.

**CUDA-graph capture caveat (why plain `tp_group.broadcast` is not enough):** `draft_forward` runs *inside* a captured CUDA graph. Per `GroupCoordinator.graph_capture()`, `torch.distributed` collectives are disabled during capture (raise `hipErrorCapturedEvent`) while **PyNccl is the enabled path**. The helper therefore uses:
- **capture mode** → `pynccl_comm.broadcast(t, src=0)` (recorded into the graph, survives replay)
- **eager mode** → `grp.broadcast(t, src=0)` (torch.distributed)

A sync that is skipped during capture is dead code on replay (the Python body of `draft_forward` never re-executes) — this was the failure mode of earlier iterations of this fix.

## Tests / Verification

Environment: 8x MI350X 288G (gfx950), ROCm 7.2.0, SGLang v0.5.16-based image + this patch, GLM-5.2-MXFP4, TP4xDP2 + DSA tilelang + KV fp8_e4m3 + INT4, EAGLE 5/1/6, ISL=8192/OSL=1024.

| Metric | Before | After |
|---|---|---|
| c=64 completion | hang, 420s timeout (95/192 frozen 11 min) | **97s, rc=0** |
| Full matrix (c1/2/4/8/16/64/256/512) | c64+ abort | **8/8 rc=0** |
| Accept length (c1) | ~5.85 | ~5.9 |
| Perf cost (c1 Total tok/s) | 2,002.42 | 2,004.25 (**+0.1%**, noise) |

The sync cost is absorbed into the graph and is not measurable; no compute path is changed.

Related: #34238 (verify-side sync, merged) — this PR closes the remaining draft-side gap on the same root cause.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31990206667](https://github.com/sgl-project/sglang/actions/runs/31990206667)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31990206452](https://github.com/sgl-project/sglang/actions/runs/31990206452)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->