### PR TITLE
[BUG] Fix fallback tensor aliasing in DP MLP sync all_gather

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/dp_attn.py
+++ b/python/sglang/srt/managers/scheduler_components/dp_attn.py
@@ -138,9 +138,11 @@ class MLPSyncBatchInfo:
         fallback_tensor = self._get_fallback_tensor(device=device)
         info_width = local_info_tensor.numel()
         # Inactive max_world_size slots must decode as IDLE.
+        # `.contiguous()` can alias `fallback_tensor` when every expanded
+        # dimension is size 1; this tensor is written by distributed collectives.
         global_info_tensor = fallback_tensor.expand(
             self.dp_size, self.tp_size * self.cp_size, info_width
-        ).contiguous()
+        ).clone()
 
         if use_all_reduce:
             # Admission can expose different WORLD sizes; use fixed global slots.

--- a/test/registered/unit/managers/scheduler_components/test_mlp_sync_batch_info.py
+++ b/test/registered/unit/managers/scheduler_components/test_mlp_sync_batch_info.py
@@ -1,0 +1,69 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.scheduler_components import dp_attn
+from sglang.srt.managers.scheduler_components.dp_attn import MLPSyncBatchInfo
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestMLPSyncBatchInfo(CustomTestCase):
+    def test_all_gather_single_inactive_slot_uses_fallback_without_alias(self):
+        sync_info = MLPSyncBatchInfo(
+            dp_size=1,
+            tp_size=1,
+            cp_size=1,
+            num_tokens=8,
+            num_tokens_for_logprob=3,
+            can_run_decode_cuda_graph=False,
+            can_run_prefill_cuda_graph=True,
+            is_extend_in_batch=True,
+            local_can_run_tbo=True,
+            local_forward_mode=ForwardMode.DECODE.value,
+        )
+        tp_group = SimpleNamespace(active_ranks_cpu=torch.zeros(1, dtype=torch.int32))
+
+        def fake_all_gather_into_tensor(output_tensor, input_tensor, group):
+            output_tensor.copy_(input_tensor)
+
+        with (
+            patch.object(dp_attn, "get_tp_group", return_value=tp_group),
+            patch.object(dp_attn, "_ENABLE_METRICS_DP_ATTENTION", False),
+            patch.object(
+                torch.distributed,
+                "all_gather_into_tensor",
+                side_effect=fake_all_gather_into_tensor,
+            ),
+        ):
+            sync_info.all_gather(device="cpu", group=None)
+
+        self.assertEqual(
+            sync_info.tp0_info_cpu[0].tolist(),
+            [
+                0,
+                0,
+                1,
+                0,
+                1,
+                ForwardMode.IDLE.value,
+                0,
+            ],
+        )
+        self.assertEqual(sync_info.global_num_tokens, [0])
+        self.assertEqual(sync_info.global_num_tokens_for_logprob, [0])
+        self.assertTrue(sync_info.can_run_decode_cuda_graph)
+        self.assertFalse(sync_info.is_extend_in_batch)
+        self.assertFalse(sync_info.can_run_prefill_cuda_graph)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

This PR fixes a PyTorch overlapping-memory runtime error in
`MLPSyncBatchInfo.all_gather`.

`fallback_tensor.expand(...).contiguous()` can still alias `fallback_tensor`
when every expanded dimension is size 1. In that case, the gathered output tensor
and the fallback tensor share storage. Later, when inactive ranks are overwritten
with the fallback value, PyTorch rejects the in-place assignment:

`unsupported operation: some elements of the input tensor and the written-to tensor refer to a single memory location`

The fix changes the initialization to `expand(...).clone()` so the global gather
buffer always owns independent storage.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

- Replace `expand(...).contiguous()` with `expand(...).clone()` in DP MLP sync.
- Add a comment explaining why `clone()` is required.
- Add a CPU unit test for the single-slot inactive-rank fallback path.


<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

This issue would be encountered before this PR, causing the sglang service to fail to start: 
``` bash
[2026-08-17 03:44:24 PP0] Scheduler hit an exception: Traceback (most recent call last):
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 4947, in run_scheduler_process
    scheduler.run_event_loop()
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 1662, in run_event_loop
    dispatch_event_loop(self)
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py", line 4800, in dispatch_event_loop
    scheduler.event_loop_pp_disagg_prefill()
  File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 124, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler_pp_mixin.py", line 262, in event_loop_pp_disagg_prefill
    batch = self.dp_attn_adapter.maybe_prepare_mlp_sync_batch(batch)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler_components/dp_attn.py", line 431, in maybe_prepare_mlp_sync_batch
    batch = self.prepare_mlp_sync_batch(batch)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler_components/dp_attn.py", line 402, in prepare_mlp_sync_batch
    return prepare_mlp_sync_batch_raw(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler_components/dp_attn.py", line 339, in prepare_mlp_sync_batch_raw
    mlp_sync_info.all_gather(
  File "/sgl-workspace/sglang/python/sglang/srt/managers/scheduler_components/dp_attn.py", line 180, in all_gather
    tp_info[tp_active_ranks[:num_ranks_in_tp_info] == 0] = fallback_tensor
    ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: unsupported operation: some elements of the input tensor and the written-to tensor refer to a single memory location. Please clone() the tensor before performing the operation.
```

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31991859402](https://github.com/sgl-project/sglang/actions/runs/31991859402)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31991859377](https://github.com/sgl-project/sglang/actions/runs/31991859377)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->