### PR TITLE
[Fix] Route text before the opening think token by position, not by index 0

### DIFF
--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -122,6 +122,28 @@ class BaseReasoningFormatDetector:
             self._detect_and_parse_impl(text)
         )
 
+    def _split_at_think_start(self, text: str) -> Tuple[str, str]:
+        """Remove the opening think token wherever it first appears, and return
+        ``(text_from_the_block, leading_normal_text)``.
+
+        The block opens at the marker, not at index 0: everything the model wrote
+        before it is content, and matching only at index 0 leaves the literal
+        marker sitting inside ``reasoning_content`` after a single leading space
+        or newline. Under ``force_reasoning`` the block was already opened by the
+        chat template, so the leading text is reasoning and only an echoed marker
+        is dropped -- which is what the streaming path does in both cases.
+        """
+        think_start_text = self.think_start_token + self.think_start_self_label
+        start_idx = text.find(think_start_text)
+        if start_idx <= 0:
+            return text, ""
+
+        preceding = text[:start_idx]
+        rest = text[start_idx + len(think_start_text) :]
+        if self._in_reasoning:
+            return preceding + rest, ""
+        return rest, preceding
+
     def _detect_and_parse_impl(self, text: str) -> StreamingParseResult:
         in_reasoning = self._in_reasoning or self.think_start_token in text
 
@@ -130,7 +152,7 @@ class BaseReasoningFormatDetector:
 
         # The text is considered to be in a reasoning block.
         think_start_text = self.think_start_token + self.think_start_self_label
-        processed_text = text
+        processed_text, leading_normal_text = self._split_at_think_start(text)
         while processed_text.startswith(think_start_text):
             processed_text = processed_text[len(think_start_text) :]
 
@@ -148,25 +170,29 @@ class BaseReasoningFormatDetector:
                 tool_idx = processed_text.find(self.tool_start_token)
                 reasoning_text = processed_text[:tool_idx]
                 # Preserve tool_start_token in normal text
-                normal_text = processed_text[tool_idx:]
+                normal_text = leading_normal_text + processed_text[tool_idx:]
                 return StreamingParseResult(
                     normal_text=normal_text, reasoning_text=reasoning_text
                 )
             # Assume reasoning was truncated before end token
-            return StreamingParseResult(reasoning_text=processed_text)
+            return StreamingParseResult(
+                normal_text=leading_normal_text, reasoning_text=processed_text
+            )
 
         # Extract reasoning content
         if self.think_end_token in processed_text:
             splits = processed_text.split(self.think_end_token, maxsplit=1)
             reasoning_text = splits[0]
-            normal_text = splits[1]
+            normal_text = leading_normal_text + splits[1]
 
             return StreamingParseResult(
                 normal_text=normal_text, reasoning_text=reasoning_text
             )
         else:
             # think_end_token is in self.previous_content for continue_final_message=True case
-            return StreamingParseResult(normal_text=processed_text)
+            return StreamingParseResult(
+                normal_text=leading_normal_text + processed_text
+            )
 
     def parse_streaming_increment(self, new_text: str) -> StreamingParseResult:
         """
@@ -203,8 +229,17 @@ class BaseReasoningFormatDetector:
             return StreamingParseResult()
 
         # Strip `<think>` token if present
+        leading_normal_text = ""
         if not self.stripped_think_start and think_start_text in current_text:
-            current_text = current_text.replace(think_start_text, "", 1)
+            if self._in_reasoning:
+                # force_reasoning: the block was open before the marker, so the
+                # text in front of an echoed marker is reasoning, not content.
+                current_text = current_text.replace(think_start_text, "", 1)
+            else:
+                # The block opens at the marker; what came before it is content.
+                start_idx = current_text.find(think_start_text)
+                leading_normal_text = current_text[:start_idx]
+                current_text = current_text[start_idx + len(think_start_text) :]
             # Write back, or stream_reasoning=False carries the token into finish().
             self._buffer = current_text
             self.stripped_think_start = True
@@ -218,7 +253,10 @@ class BaseReasoningFormatDetector:
 
             self._buffer = ""
             self._in_reasoning = False
-            normal_text = current_text[end_idx + len(self.think_end_token) :]
+            normal_text = (
+                leading_normal_text
+                + current_text[end_idx + len(self.think_end_token) :]
+            )
 
             return StreamingParseResult(
                 normal_text=normal_text, reasoning_text=reasoning_text
@@ -232,7 +270,7 @@ class BaseReasoningFormatDetector:
                 tool_idx = current_text.find(self.tool_start_token)
                 reasoning_text = current_text[:tool_idx]
                 # Preserve tool_start_token in normal text
-                normal_text = current_text[tool_idx:]
+                normal_text = leading_normal_text + current_text[tool_idx:]
                 self._buffer = ""
                 self._in_reasoning = False
                 return StreamingParseResult(
@@ -252,15 +290,28 @@ class BaseReasoningFormatDetector:
                 )
                 self._buffer = current_text[len(current_text) - holdback :]
                 return StreamingParseResult(
-                    reasoning_text=current_text[: len(current_text) - holdback]
+                    normal_text=leading_normal_text,
+                    reasoning_text=current_text[: len(current_text) - holdback],
                 )
             else:
-                return StreamingParseResult()
+                return StreamingParseResult(normal_text=leading_normal_text)
 
         # If we're not in a reasoning block return as normal text
         if not self._in_reasoning:
-            self._buffer = ""
-            return StreamingParseResult(normal_text=current_text)
+            # The prefix check above only fires when the *whole* buffer is a
+            # prefix of the opening token. A chunk that carries content first
+            # ("Sure." + "<") clears the buffer, so the rest of the marker
+            # arrives with nothing to attach to and the whole reasoning block
+            # reaches the client as raw text. Hold the partial marker back the
+            # same way the reasoning branch holds back the closing one.
+            holdback = (
+                self._ends_with_partial_token(current_text, think_start_text)
+                if not self.stripped_think_start
+                else 0
+            )
+            cut = len(current_text) - holdback
+            self._buffer = current_text[cut:]
+            return StreamingParseResult(normal_text=current_text[:cut])
 
         return StreamingParseResult()
 

--- a/test/registered/unit/parser/test_reasoning_parser.py
+++ b/test/registered/unit/parser/test_reasoning_parser.py
@@ -1055,24 +1055,47 @@ class TestStreamingChunkSizeInvariance(CustomTestCase):
                         self._feed(DeepSeekR1Detector(), text, chunk_size), expected
                     )
 
-    def test_text_before_think_token_is_chunk_dependent(self):
-        """Accepted divergence, inherited from main: text before `<think>` lands
-        in reasoning or content depending on where the chunk boundary falls."""
-        text = "lead<think>r</think>tail"
-        variants = {
-            self._feed(Qwen3Detector(), text, chunk_size)
-            for chunk_size in self.CHUNK_SIZES
-        }
+    def test_text_before_think_token_is_content(self):
+        """Text the model writes before `<think>` is content, whatever the
+        chunking. Previously this produced three different streaming splits --
+        including one where the whole block, markers and all, reached the client
+        as content -- plus a fourth from one-shot that kept the literal `<think>`
+        inside reasoning_content."""
+        self._assert_invariant(
+            Qwen3Detector,
+            "lead<think>r</think>tail",
+            ("r", "leadtail"),
+        )
 
-        self.assertEqual(
-            variants,
-            {("r", "leadtail"), ("", text), ("leadr", "tail")},
+    def test_single_leading_newline_before_think_token(self):
+        """The common shape: one character in front of the opening marker. The
+        one-shot path only stripped `<think>` at index 0, so the marker itself
+        used to be handed to the client inside reasoning_content."""
+        self._assert_invariant(
+            Qwen3Detector,
+            "\n<think>r</think>tail",
+            ("r", "\ntail"),
         )
-        # And the non-streaming path produces yet a fourth split.
-        one_shot = Qwen3Detector().detect_and_parse(text)
-        self.assertEqual(
-            (one_shot.reasoning_text, one_shot.normal_text), ("lead<think>r", "tail")
+
+    def test_forced_reasoning_keeps_lead_text_as_reasoning(self):
+        """When the chat template already opened the block, text before an echoed
+        marker is reasoning -- the opposite routing from the non-forced case, and
+        the streaming path's behaviour all along. Only the marker is dropped."""
+        self._assert_invariant(
+            DeepSeekR1Detector,
+            "lead<think>r</think>tail",
+            ("leadr", "tail"),
         )
+
+    def test_content_ending_in_start_token_prefix_survives(self):
+        """The holdback that recombines a split opening marker must not swallow
+        content that merely ends in one of its prefixes and is never completed."""
+        for chunk_size in self.CHUNK_SIZES:
+            with self.subTest(chunk_size=chunk_size):
+                self.assertEqual(
+                    self._feed(Qwen3Detector(), "answer <", chunk_size),
+                    ("", "answer <"),
+                )
 
     def test_dsv4_reasoning_quoting_dsml_is_chunk_dependent(self):
         """Accepted divergence: streaming ends the block at the DSML marker, while


### PR DESCRIPTION
## Motivation

Fixes #35083.

`BaseReasoningFormatDetector` enters a reasoning block on `think_start_token in
text` (anywhere) but strips the marker with `startswith` (index 0 only).
Anything in front of the opening marker — a single space or newline is enough —
falls into the gap, and the streaming path has the mirror-image gap: it only
recognises a partial opening marker when the whole buffer is a prefix of it.

Same string, four answers on `main` (`--reasoning-parser qwen3`,
`"Sure.<think>checking</think>Done."`):

| path | `reasoning_content` | `content` |
|---|---|---|
| non-streaming | `'Sure.<think>checking'` | `'Done.'` |
| streaming, marker whole in one chunk | `'checking'` | `'Sure.Done.'` |
| streaming, chunk ends inside `<think>` | `''` | `'Sure.<think>checking</think>Done.'` |
| streaming, whole turn in one chunk | `'Sure.checking'` | `'Done.'` |

Row 3 streams the whole reasoning block, markers included, to the client as
assistant content. It needs a chunk carrying content plus a strict prefix of the
marker, which a multi-token decode step produces: `--stream-interval > 1`,
`sampling_params.stream_interval`, speculative decoding, or the detokenizer
releasing several tokens after an incomplete UTF-8 sequence. Rows 1, 2 and 4 need
no such condition.

#34458 already named this case and pinned it:

```python
def test_text_before_think_token_is_chunk_dependent(self):
    """Accepted divergence, inherited from main: text before `<think>` lands
    in reasoning or content depending on where the chunk boundary falls."""
```

This PR closes that exception instead of pinning it.

## Modifications

`python/sglang/srt/parser/reasoning_parser.py`

- `_split_at_think_start()` (new): removes the opening marker wherever it first
  appears and returns the text left of it separately. Under `force_reasoning` the
  block was already opened by the chat template, so the lead stays reasoning and
  only the echoed marker is dropped; otherwise the lead is content. Both match
  what the streaming path already did when the marker landed whole at a chunk
  start.
- `_detect_and_parse_impl()`: uses it, and prepends the lead to `normal_text` on
  every return path (truncated reasoning, `tool_start_token` interruption, the
  `</think>` split, and the `continue_final_message` branch).
- `_parse_streaming_increment_impl()`: the strip splits the lead out instead of
  `replace(..., 1)` swallowing it; the not-in-reasoning branch now holds back a
  trailing partial opening marker with `_ends_with_partial_token`, the same way
  the in-reasoning branch holds back the closing one. The holdback is skipped
  once `stripped_think_start` is set, so content after the block is not delayed,
  and `finish()` already flushes a held-back slice that never became a marker.

Detectors that override both methods (`gpt-oss`, `kimi_k3`, `muse`, `inkling`,
`apertus2509`, `cohere_command4`) are untouched.

Note: #34600 also edits `_parse_streaming_increment_impl` (the same two regions).
Whichever lands first, I am happy to rebase this one on top of it.

## Accuracy Tests

A differential harness over all 26 `ReasoningParser.DetectorMap` entries
(12 samples x {chunk sizes 1,2,3,7,13, six random splits, whole} x
`stream_reasoning` on/off, comparing streamed + `finish()` against
`detect_and_parse`): **21 model types diverged on this shape before, 0 after.**
The two that still diverge (`gpt-oss`, `kimi_k3`) are separate defects in their
own overrides, reported separately and out of scope here.

Tests, in `test/registered/unit/parser/test_reasoning_parser.py`:

- `test_text_before_think_token_is_content` — replaces
  `test_text_before_think_token_is_chunk_dependent`; the four splits collapse to
  `("r", "leadtail")` across all chunk sizes and one-shot.
- `test_single_leading_newline_before_think_token` — the common shape; guards the
  one-shot marker leak.
- `test_forced_reasoning_keeps_lead_text_as_reasoning` — the opposite routing
  under `force_reasoning`, so a future "simplification" cannot collapse the two.
- `test_content_ending_in_start_token_prefix_survives` — the new holdback must not
  swallow content that merely ends in a marker prefix and never completes.

Verified fail-before / pass-after: on the pre-fix source the first three fail
(16 failed / 1 passed with the four selected); with the fix
`test/registered/unit/parser/` is `344 passed, 165 subtests`, and
`test/registered/unit/function_call/ + parser/` is `808 passed`.
`test/registered/unit/entrypoints/openai` has 8 pre-existing failures in
`test_serving_transcription.py` — identical with and without this change.

## Benchmarking and Profiling

Not applicable — string handling on the parse path only. The new holdback defers
at most `len(think_start_token) - 1` characters of content, and only before the
first reasoning block.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests).
- [ ] Update documentation as needed, including docstrings or example tutorials.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31992374032](https://github.com/sgl-project/sglang/actions/runs/31992374032)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31992373703](https://github.com/sgl-project/sglang/actions/runs/31992373703)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->