### PR TITLE
fix(mamba): separate state and checkpoint chunk sizes

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_hybrid_linear_attn_backend.py
@@ -17,6 +17,7 @@ from sglang.srt.layers.attention.mamba.mamba2_metadata import (
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.srt.model_executor.model_runner import ModelRunner
+from sglang.srt.runtime_context import npu_mamba_state_chunk_size
 from sglang.srt.speculative.eagle_info import EagleDraftInput, EagleVerifyInput
 from sglang.srt.speculative.spec_info import SpecInput
 
@@ -27,6 +28,12 @@ class AscendMambaAttnBackendBase(MambaAttnBackendBase):
     def __init__(self, model_runner: ModelRunner):
         super().__init__(model_runner)
         self.state_indices_list_gdn = []
+
+    def _mamba_state_chunk_size(self) -> int:
+        # L1 checkpoints use the 128-token page grid, while the Ascend GDN
+        # kernel packs `h` every 64 tokens. Using the L1 grid selects h[23]
+        # instead of the checkpoint state h[46] at token 2944.
+        return npu_mamba_state_chunk_size()
 
     def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
         assert (

--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -317,13 +317,16 @@ class MambaAttnBackendBase(AttentionBackend):
 
         return indices.clamp(0, query_start_loc[-1] - 1)
 
+    def _mamba_state_chunk_size(self) -> int:
+        return mamba_cache_chunk_size()
+
     def _init_track_ssm_indices(
         self, mamba_cache_indices: torch.Tensor, forward_batch: ForwardBatch
     ):
         """src/dst indices to track SSM states for prefix caching: aligned seqs
         cache last_recurrent_state, unaligned cache intermediate `h` at the last
         chunk boundary."""
-        chunk_size = mamba_cache_chunk_size()
+        chunk_size = self._mamba_state_chunk_size()
         # CPU to avoid kernel launches for the masking ops
         mamba_track_mask = forward_batch.mamba_track_mask.cpu()
         extend_seq_lens = forward_batch.extend_seq_lens.cpu()

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -11,11 +11,13 @@ from sglang.srt.runtime_context import (
     mamba_checkpoint_grid,
     mamba_extra_buffer_enabled,
     mamba_extra_buffer_lazy_enabled,
+    npu_mamba_state_chunk_size,
 )
 from sglang.srt.utils.common import (
     Range,
     ceil_align,
     flatten_arrays_to_pinned_cpu,
+    is_npu,
     is_pin_memory_available,
 )
 
@@ -147,6 +149,7 @@ INIT_INCREMENTAL_DETOKENIZATION_OFFSET = 5
 MM_PAD_SHIFT_VALUE = 1_000_000
 
 logger = logging.getLogger(__name__)
+_is_npu = is_npu()
 
 
 ReturnHiddenStatesMode = Union[bool, Literal["last"]]
@@ -2623,18 +2626,21 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         req: Req,
     ) -> _MambaRadixCacheV2TrackEntry:
         chunk_size = mamba_cache_chunk_size()
+        # Preserve the existing CUDA grid; only Ascend packs `h` independently
+        # from the page-aligned L1 checkpoint grid.
+        state_chunk_size = npu_mamba_state_chunk_size() if _is_npu else chunk_size
         # The donated depth has to be a radix node boundary. Read the tree's own
         # page rather than re-deriving how DCP widens it; the kernel still
         # snapshots on the chunk_size grid.
         checkpoint_grid = mamba_checkpoint_grid(self.tree_cache.page_size)
 
         def _force_track_h(i: int) -> int:
-            assert i % chunk_size == 0
+            assert i % state_chunk_size == 0
             # There are 3 cases for mamba_track_seqlen passed to mamba_track_seqlens_cpu:
-            # 1) aligned with chunk_size-> retrieve from last_recurrent_state
+            # 1) aligned with state_chunk_size -> retrieve from last_recurrent_state
             #    a) is the last position -> retrieve from last_recurrent_state
             #    b) is NOT the last position -> retrieve from h
-            # 2) unaligned with chunk_size -> retrieve from h
+            # 2) unaligned with state_chunk_size -> retrieve from h
             # Currently, the math calculation only supports case 1a and 2. So for 1b, we need to add 1
             # to force the math calculation to retrieve the correct mamba state from h.
             return i + 1
@@ -2659,13 +2665,13 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                 + (req.extend_range.length // checkpoint_grid) * checkpoint_grid
             )
 
-            # mamba_track_fla_chunk_aligned is the aligned seqlen based on chunk_size
+            # mamba_track_fla_chunk_aligned is aligned on the kernel state chunk.
             # If mamba_track_fla_chunk_aligned != mamba_track_seqlen_aligned, which is true when
             # checkpoint_grid is coarser than chunk_size, we need to force the math calculation to
             # retrieve the correct mamba state from h by _force_track_h()
             mamba_track_fla_chunk_aligned = (
                 len(req.prefix_indices)
-                + (req.extend_range.length // chunk_size) * chunk_size
+                + (req.extend_range.length // state_chunk_size) * state_chunk_size
             )
             if mamba_track_fla_chunk_aligned != mamba_track_seqlen_aligned:
                 # We want to track mamba_track_seqlen_aligned, and it's not the last position,

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -1517,6 +1517,11 @@ def mamba_cache_chunk_size() -> int:
     return get_server_args().mamba_cache_chunk_size
 
 
+def npu_mamba_state_chunk_size() -> int:
+    """Physical chunk size of the Ascend kernel's packed intermediate states."""
+    return get_server_args().npu_mamba_state_chunk_size
+
+
 def mamba_checkpoint_grid(tree_page: int) -> int:
     """The granularity a donated mamba checkpoint's depth must land on so the
     radix tree can name it. Pass the page the tree actually allocates on: DCP

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -9044,6 +9044,17 @@ class ServerArgs:
             self._mamba_cache_chunk_size = max(chunk_size, page_size)
         return self._mamba_cache_chunk_size
 
+    @property
+    def npu_mamba_state_chunk_size(self) -> int:
+        """Physical chunk used by the Ascend kernel's packed intermediate states."""
+        if not hasattr(self, "_npu_mamba_state_chunk_size"):
+            hf_config = self.get_model_config().hf_config
+            # Matches chunk_gated_delta_rule_fwd_h_npu's default chunk_size.
+            self._npu_mamba_state_chunk_size = getattr(
+                hf_config, "mamba_chunk_size", 64
+            )
+        return self._npu_mamba_state_chunk_size
+
     def _check_two_batch_overlap(self):
         # With no EP a2a backend, two-batch-overlap is only valid on the non-EP
         # DP TP-MoE path (overlapping the DP all_gatherv / reduce_scatterv with

--- a/test/registered/unit/layers/attention/test_mamba_checkpoint_chunk_sizes.py
+++ b/test/registered/unit/layers/attention/test_mamba_checkpoint_chunk_sizes.py
@@ -1,0 +1,109 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.layers.attention.hybrid_linear_attn_backend import (
+    MambaAttnBackendBase,
+)
+from sglang.srt.managers.schedule_batch import ScheduleBatch
+from sglang.srt.server_args import ServerArgs
+from sglang.srt.utils.common import Range
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestMambaCheckpointChunkSizes(unittest.TestCase):
+    def test_npu_state_chunk_can_be_smaller_than_cache_chunk(self):
+        server_args = object.__new__(ServerArgs)
+
+        with (
+            patch.object(
+                ServerArgs,
+                "get_model_config",
+                return_value=SimpleNamespace(hf_config=SimpleNamespace()),
+            ),
+            patch(
+                "sglang.srt.server_args.resolved_view",
+                return_value=SimpleNamespace(page_size=128),
+            ),
+        ):
+            self.assertEqual(server_args.npu_mamba_state_chunk_size, 64)
+            self.assertEqual(server_args.mamba_cache_chunk_size, 128)
+
+    def test_default_backend_keeps_cache_chunk_semantics(self):
+        backend = object.__new__(MambaAttnBackendBase)
+        with patch(
+            "sglang.srt.layers.attention.hybrid_linear_attn_backend."
+            "mamba_cache_chunk_size",
+            return_value=128,
+        ):
+            self.assertEqual(backend._mamba_state_chunk_size(), 128)
+
+    def test_scheduler_marks_interior_cache_boundary_for_h(self):
+        batch = object.__new__(ScheduleBatch)
+        batch.tree_cache = SimpleNamespace(page_size=128)
+        batch.req_to_token_pool = SimpleNamespace(
+            get_mamba_ping_pong_other_idx=lambda index: 1 - index
+        )
+        req = SimpleNamespace(
+            extend_range=Range(0, 3008),
+            prefix_indices=[],
+            mamba_ping_pong_track_buffer=torch.tensor([10, 11]),
+            mamba_next_track_idx=0,
+            mamba_last_track_idx=None,
+            mamba_last_track_seqlen=None,
+            mamba_branching_seqlen=None,
+        )
+
+        with (
+            patch(
+                "sglang.srt.managers.schedule_batch.mamba_cache_chunk_size",
+                return_value=128,
+            ),
+            patch(
+                "sglang.srt.managers.schedule_batch.npu_mamba_state_chunk_size",
+                return_value=64,
+            ),
+            patch("sglang.srt.managers.schedule_batch._is_npu", True),
+            patch(
+                "sglang.srt.managers.schedule_batch.mamba_checkpoint_grid",
+                return_value=128,
+            ),
+            patch(
+                "sglang.srt.managers.schedule_batch.mamba_extra_buffer_lazy_enabled",
+                return_value=False,
+            ),
+        ):
+            entry = batch._mamba_radix_cache_v2_req_prepare_for_extend(req)
+
+        self.assertTrue(entry.track_mask)
+        self.assertEqual(entry.track_seqlen, 2945)
+        self.assertEqual(req.mamba_last_track_seqlen, 2944)
+
+    def test_gdn_h_indices_use_state_chunk_not_cache_chunk(self):
+        backend = object.__new__(MambaAttnBackendBase)
+        backend.device = torch.device("cpu")
+        forward_batch = SimpleNamespace(
+            mamba_track_mask=torch.tensor([True, True]),
+            extend_seq_lens=torch.tensor([3000, 3008]),
+            mamba_track_indices=torch.tensor([20, 21]),
+            mamba_track_seqlens=torch.tensor([3000, 2945]),
+            extend_prefix_lens=torch.tensor([0, 0]),
+        )
+
+        with patch.object(backend, "_mamba_state_chunk_size", return_value=64):
+            h_src, h_dst, final_src, final_dst = backend._init_track_ssm_indices(
+                torch.tensor([10, 11]), forward_batch
+            )
+
+        torch.testing.assert_close(h_src, torch.tensor([46, 93]))
+        torch.testing.assert_close(h_dst, torch.tensor([20, 21]))
+        self.assertEqual(final_src.numel(), 0)
+        self.assertEqual(final_dst.numel(), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_mamba_checkpoint_depth.py
+++ b/test/registered/unit/managers/test_mamba_checkpoint_depth.py
@@ -30,6 +30,7 @@ def _track_seqlen(*, tree_page: int, prefix_len: int, extend_len: int) -> int:
     """Run one extend through the tracker and report the donated depth."""
     server_args = ServerArgs(model_path="dummy", page_size=CHUNK)
     # The property would otherwise load the HF config for the dummy model.
+    server_args._npu_mamba_state_chunk_size = CHUNK
     server_args._mamba_cache_chunk_size = CHUNK
     set_global_server_args_for_scheduler(server_args)
 


### PR DESCRIPTION
> [!IMPORTANT]
> This PR contains only the Mamba checkpoint semantic fix. It does not include
> #32500 or #35013. Merge this after #32500; #34560 is already merged into
> `main`. The end-to-end validation stack also included #35013 for packed MTP
> HiCache transfers.

## Motivation

Mamba radix caching currently uses `mamba_cache_chunk_size` for two different
concepts:

- the page-aligned granularity at which checkpoints can be stored in the radix
  cache; and
- the physical chunk size used by the kernel to pack the intermediate state
  tensor `h`.

These values are not always equal on Ascend. Qwen3.6 GDN uses 64-token kernel
state chunks with `page_size=128`, so L1 checkpoints remain on a 128-token grid
while `h` is packed every 64 tokens. Indexing `h` with the L1 grid restores the
wrong recurrent state. The incorrect state is selected before tier transfer,
so L2 and L3 can both replay the same wrong checkpoint; this is not a Mooncake
transport issue.

CUDA does not use this new semantic. The shared backend and non-NPU scheduler
path continue to use the existing `mamba_cache_chunk_size`, preserving their
current behavior.

This is the minimal checkpoint-semantics part of #33515, adapted to the latest
`main`. It intentionally does not include that PR's cold-prefill boundary
change.

## Minimal reproduction

Use Qwen3.6 GDN on Ascend with:

```text
kernel state chunk = 64
L1 page/checkpoint grid = 128
extend length = 3008
checkpoint depth = 2944
```

The scheduler uses a synthetic tracked length of 2945 to select the interior
state at checkpoint 2944. The packed state index must therefore be:

```text
2944 / 64 = h[46]
```

The previous code instead used the L1 checkpoint grid and selected:

```text
2944 / 128 = h[23]
```

The NPU backend comment records this concrete L1 failure, and the regression
test covers the per-request packed offset with expected `h_src=[46, 93]` for a
two-request batch.

## Modifications

- Add `npu_mamba_state_chunk_size` for the Ascend kernel's packed intermediate
  states.
- Override the state chunk only in `AscendMambaAttnBackendBase`.
- Use the new state chunk in scheduler tracking only when running on NPU.
- Keep `mamba_cache_chunk_size` and the checkpoint grid unchanged for radix
  placement, branching, convolution tracking, and all non-NPU backends.
- Preserve the latest `mamba_checkpoint_grid`/DCP checkpoint-depth behavior.
- Add focused regression tests for the 64-token state / 128-token L1 case and
  for unchanged shared-backend behavior.

## L1 divergence comparison

The A/B test used commits that differ only by this PR's patch. The before commit
was the validation stack parent `c2f86df61`; the after commit `14f0e87f3` has
the same stable patch-id as this PR head. Both runs used Qwen3.6-27B BF16, TP2,
Ascend NPU, NEXTN, 4 prompts with 3000 input tokens and 512 output tokens, and
reused exactly 2944 L1 device tokens for every prompt.

```text
                         before PR              after PR
first mismatch           [65, 88, 101, 23]      [217, 322, 293, 58]
weighted accept rate     60.4396%                62.8169%
weighted accept length   2.8132                  2.8845
```

The cold baseline was identical in both runs: weighted accept rate `63.4988%`
and weighted accept length `2.9050`. The later first mismatches and improved
NEXTN statistics show that the wrong `h` index is fixed. Replay is still not
token-identical to cold generation; that remaining divergence is the separate
cold-prefill boundary issue intentionally left out of this PR.

## L2/L3 replay verification

The end-to-end validation stack was latest `main` with #34560,
`#32500@9acc6b733`, #35013, and this PR. Model and request settings matched the
L1 test above.

- PR-focused tests on the standalone PR head: `6 passed`.
- Focused scheduler, state-index, and stacked NPU host-pool tests: `8 passed`.
- Host L2: `host=2944, device=0, storage=0` for 4/4 prompts.
- Mooncake L3: `storage=2944, device=0, host=0` for 4/4 prompts.
- L2 and L3 replay output IDs were identical for all four prompts:
  `sha256=a0349ca2a8cdf023da0ef7b86370fbc25eac55ba5d8a656665a845c4a1d969d9`.
- L2 and L3 speculative statistics were identical: weighted accept rate
  `62.8169%`, weighted accept length `2.8845`, and correct/proposed drafts
  `1338/2130`.

L2 and L3 had the same first mismatch positions as the fixed L1 run:
`[217, 322, 293, 58]`. Mooncake therefore adds no additional divergence.

## Accuracy verification

Ran the repository's `benchmark/gsm8k/bench_sglang.py` against the same full
NEXTN + Mooncake validation stack using the first 200 examples from the
official GSM8K test set:

```text
num_questions=200
num_shots=5
parallel=4
temperature=0
max_new_tokens=512
chat_template_kwargs={"enable_thinking": false}
```

Result: `194/200` correct (`97.0%` accuracy), `0%` invalid responses, no request
failures, and `218.519 s` latency. The previous incomplete-stack result was
`195/200`; only prompt 182 changed correctness, from the correct answer `23` to
`24`.

## Speed tests and profiling

This change adds no kernel launch or state copy. It only gives the Ascend state
index calculation its own chunk semantic. The 200-example accuracy run took
`218.519 s`; this is not a controlled performance comparison.

## Checklist

- [x] Format code with pre-commit.
- [x] Add focused unit tests, including unchanged non-NPU semantics.
- [x] Compare L1 replay before and after the exact PR patch.
- [x] Complete Qwen3.6 L2/L3 replay validation on the stated stacked setup.
- [x] Complete the 200-example GSM8K accuracy rerun on the stated stacked setup.
- [x] Release NPU resources after validation.
- [x] Documentation is not required for this internal correctness fix.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #32013403511](https://github.com/sgl-project/sglang/actions/runs/32013403511)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #32013403405](https://github.com/sgl-project/sglang/actions/runs/32013403405)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
