### PR TITLE
[AMD] Add ROCm 10 (gfx942 / gfx950) stages to the ROCm Dockerfile

### DIFF
--- a/.github/workflows/release-docker-amd-rocm10-nightly.yml
+++ b/.github/workflows/release-docker-amd-rocm10-nightly.yml
@@ -1,0 +1,124 @@
+name: Release Docker Images Nightly ROCm10 (AMD)
+on:
+  workflow_dispatch:
+    inputs:
+      job_select:
+        description: 'Select which release job to run'
+        required: false
+        type: choice
+        default: 'all'
+        options:
+          - 'all'
+          - publish
+  # No schedule yet: the ROCm 10 stages pin a nightly SDK build
+  # (rocm==10.0.0a20260730) rather than a GA release, because the 10.0.0
+  # release's only torch builds are named +devrocm10.0.0.dev0.<sha>. Publishing
+  # that on a cron is premature, so this stays dispatch-only until ROCm 10 GA
+  # lets the Dockerfile pin a plain version.
+  # schedule:
+  #   - cron: '0 12 * * *'
+
+concurrency:
+  # A PR number if a pull request and otherwise the commit hash. This cancels
+  # queued and in-progress runs for the same PR (presubmit) or commit
+  # (postsubmit). The workflow name is prepended to avoid conflicts between
+  # different workflows.
+  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: github.repository == 'sgl-project/sglang' && (github.event_name != 'workflow_dispatch' || inputs.job_select == 'all' || inputs.job_select == 'publish')
+    runs-on: amd-docker-scale
+    environment: 'prod'
+    strategy:
+      fail-fast: false
+      matrix:
+        gpu_arch: ['gfx942-rocm10', 'gfx950-rocm10']
+        build_type: ['all']
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Required for git describe to find tags
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: "Set Date"
+        run: |
+          echo "DATE=$(date +%Y%m%d)" >> $GITHUB_ENV
+
+      - name: Get version from latest tag
+        id: version
+        run: |
+          # Use the shared helper so stable/post releases sort above rc tags.
+          VERSION=$(python3 python/tools/get_version_tag.py --tag-only | sed 's/^v//')
+
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not determine version from git tags"
+            exit 1
+          fi
+
+          # Get short commit hash of current HEAD
+          COMMIT_HASH=$(git rev-parse --short HEAD)
+
+          # Compose pretend version for setuptools_scm: e.g., 0.5.8.post1.dev20260211+g1a2b3c4
+          PRETEND_VERSION="${VERSION}.dev${{ env.DATE }}+g${COMMIT_HASH}"
+
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "pretend_version=${PRETEND_VERSION}" >> $GITHUB_OUTPUT
+          echo "Detected version: ${VERSION}"
+          echo "Pretend version for pip: ${PRETEND_VERSION}"
+
+      # Pushing to rocm/sgl-dev is deliberately left off while the SDK pin is a
+      # nightly alpha; only lmsysorg/sglang-rocm is published. Re-enable this
+      # login together with the push step below once the pin moves to GA.
+      # - name: Login to Docker Hub (AMD)
+      #   uses: docker/login-action@v2
+      #   with:
+      #     username: ${{ secrets.DOCKERHUB_AMD_USERNAME }}
+      #     password: ${{ secrets.DOCKERHUB_AMD_TOKEN }}
+
+      - name: Build ROCm 10 image
+        run: |
+          version=${{ steps.version.outputs.version }}
+          pretend_version=${{ steps.version.outputs.pretend_version }}
+          echo "Version: ${version}"
+          echo "Pretend version: ${pretend_version}"
+
+          if [ "${{ matrix.gpu_arch }}" = "gfx942-rocm10" ]; then
+            rocm_tag="rocm10.0-mi30x"
+          elif [ "${{ matrix.gpu_arch }}" = "gfx950-rocm10" ]; then
+            rocm_tag="rocm10.0-mi35x"
+          else
+            echo "Unsupported gfx arch"
+            exit 1
+          fi
+
+          tag=v${version}-${rocm_tag}
+          echo "IMAGE_TAG=${tag}-${{ env.DATE }}" >> $GITHUB_ENV
+
+          # remove --build-arg NIC_BACKEND=ainic for auto detection nic support in mori
+          # UBUNTU_CODENAME=noble because the ROCm 10 stages build on ubuntu:24.04
+          # while the Dockerfile defaults to jammy for the 22.04 bases; MORI's apt
+          # step interpolates it into the amdainic repo URL.
+          # ENABLE_NIXL=0 because Ubuntu 24.04's Abseil is too old for absl_log,
+          # the same wall the ROCm 7.15 stage hit (#32079).
+          # UBUNTU_MIRROR forces apt over HTTPS to dodge port-80 reachability flakes
+          # to Canonical's archive.ubuntu.com mirror IPs from the amd-docker-scale runner.
+          docker build . -f docker/rocm.Dockerfile --build-arg SGL_BRANCH=${{ github.ref_name }} --build-arg BUILD_TYPE=${{ matrix.build_type }} --build-arg GPU_ARCH=${{ matrix.gpu_arch }} --build-arg ENABLE_MORI=1 --build-arg ENABLE_NIXL=0 --build-arg UBUNTU_CODENAME=noble --build-arg SETUPTOOLS_SCM_PRETEND_VERSION=${pretend_version} --build-arg UBUNTU_MIRROR=https://archive.ubuntu.com -t rocm/sgl-dev:${tag}-${{ env.DATE }} --no-cache
+          # docker push rocm/sgl-dev:${tag}-${{ env.DATE }}
+
+      - name: Login to Docker Hub (lmsys)
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Push to lmsysorg/sglang-rocm
+        run: |
+          docker tag rocm/sgl-dev:${{ env.IMAGE_TAG }} lmsysorg/sglang-rocm:${{ env.IMAGE_TAG }}
+          docker push lmsysorg/sglang-rocm:${{ env.IMAGE_TAG }}

--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -3,6 +3,8 @@
 #   docker build --build-arg SGL_BRANCH=v0.5.10.post1 --build-arg GPU_ARCH=gfx942-rocm720 -t v0.5.10.post1-rocm720-mi30x -f rocm.Dockerfile .
 #   docker build --build-arg SGL_BRANCH=v0.5.10.post1 --build-arg GPU_ARCH=gfx950 -t v0.5.10.post1-rocm700-mi35x -f rocm.Dockerfile .
 #   docker build --build-arg SGL_BRANCH=v0.5.10.post1 --build-arg GPU_ARCH=gfx950-rocm720 -t v0.5.10.post1-rocm720-mi35x -f rocm.Dockerfile .
+#   docker build --build-arg SGL_BRANCH=v0.5.10.post1 --build-arg GPU_ARCH=gfx942-rocm10 -t v0.5.10.post1-rocm10-mi30x -f rocm.Dockerfile .
+#   docker build --build-arg SGL_BRANCH=v0.5.10.post1 --build-arg GPU_ARCH=gfx950-rocm10 -t v0.5.10.post1-rocm10-mi35x -f rocm.Dockerfile .
 
 # Usage (to build SGLang ROCm + Mori docker image):
 # remove --build-arg NIC_BACKEND=ainic since new MoRI JIT will do NIC auto detection on target
@@ -25,6 +27,12 @@ ARG BASE_IMAGE_942="rocm/sgl-dev:rocm7-vllm-20250904"
 ARG BASE_IMAGE_942_ROCM720="rocm/pytorch:rocm7.2_ubuntu22.04_py3.10_pytorch_release_2.9.1"
 ARG BASE_IMAGE_950="rocm/sgl-dev:rocm7-vllm-20250904"
 ARG BASE_IMAGE_950_ROCM720="rocm/pytorch:rocm7.2_ubuntu22.04_py3.10_pytorch_release_2.9.1"
+# ROCm 10 ships no rocm/pytorch image, so the stack is assembled from the ROCm
+# pip channels on a plain Ubuntu base. AMD publishes a prebuilt ROCm 10 image
+# (rocm/sgl-dev:...-py3.14-rocm10rc2) but it is Python 3.14, where four srt_hip
+# deps (st_attn, vsa, petit_kernel, wave-lang) have neither a cp314 wheel nor an
+# sdist, so `pip install -e python[dev_hip]` cannot resolve at all.
+ARG BASE_IMAGE_ROCM10="ubuntu:24.04"
 
 # This is necessary for scope purpose
 ARG GPU_ARCH=gfx950
@@ -64,6 +72,100 @@ ENV AITER_COMMIT_DEFAULT="d9e5ef7ce08ee7045d583aed768cff41aa9210fe"
 FROM $BASE_IMAGE_950_ROCM720 AS gfx950-rocm720
 ENV BUILD_VLLM="0"
 ENV BUILD_TRITON="1"
+ENV BUILD_LLVM="0"
+ENV BUILD_AITER_ALL="1"
+ENV BUILD_MOONCAKE="1"
+ENV AITER_COMMIT_DEFAULT="d9e5ef7ce08ee7045d583aed768cff41aa9210fe"
+
+# ===============================
+# Shared ROCm 10 base: Ubuntu 24.04 + Python 3.12 + the ROCm 10 pip stack.
+#
+# Python 3.12 rather than the 3.14 of AMD's own ROCm 10 image: st_attn==0.0.7,
+# vsa==0.0.4, petit_kernel==0.0.2 and wave-lang==3.8.2 publish wheels only up to
+# cp313 (petit_kernel only cp310/cp312) and no sdist, so on 3.14 pip has no
+# candidate at all and gives up with resolution-too-deep.
+#
+# The version is a 10.0 nightly rather than plain `10.0.0`: the release version
+# exists in the devreleases channel, but its only torch builds are named
+# +devrocm10.0.0.dev0.<sha>, which is not a pin worth carrying. 10.0.0a20260730
+# is the last build of the 10.0 line and pairs with a clean torch version.
+FROM $BASE_IMAGE_ROCM10 AS rocm10-base
+
+ARG ROCM_VERSION="10.0.0a20260730"
+ARG TORCH_VERSION="2.12.0"
+ARG TORCHVISION_VERSION="0.27.0"
+ARG ROCM_INDEX_URL="https://rocm.nightlies.amd.com/whl-multi-arch/"
+ARG ROCM_EXTRA_INDEX_URL="https://rocm.devreleases.amd.com/whl-multi-arch/"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        curl \
+        git \
+        gnupg \
+        libstdc++-12-dev \
+        python-is-python3 \
+        python3 \
+        python3-dev \
+        python3-pip \
+        python3.12-venv \
+        wget \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv "$VIRTUAL_ENV"
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+RUN python3 -m pip install --no-cache-dir -U pip setuptools setuptools_scm wheel
+
+# Both arches' device wheels land in the shared base, matching AMD's own ROCm 10
+# image. They must be named explicitly: passing several device extras in one spec
+# (torch[device-gfx942,device-gfx950]) silently installs only the first, and the
+# missing arch then fails at runtime with hipErrorInvalidImage.
+RUN python3 -m pip install --no-cache-dir --pre \
+        --index-url ${ROCM_INDEX_URL} \
+        --extra-index-url ${ROCM_EXTRA_INDEX_URL} \
+        "rocm[libraries,devel,device-gfx942,device-gfx950]==${ROCM_VERSION}" \
+        "torch==${TORCH_VERSION}+rocm${ROCM_VERSION}" \
+        "torchvision==${TORCHVISION_VERSION}+rocm${ROCM_VERSION}" \
+        "amd-torch-device-gfx942==${TORCH_VERSION}+rocm${ROCM_VERSION}" \
+        "amd-torch-device-gfx950==${TORCH_VERSION}+rocm${ROCM_VERSION}" \
+        "amd-torchvision-device-gfx942==${TORCHVISION_VERSION}+rocm${ROCM_VERSION}" \
+        "amd-torchvision-device-gfx950==${TORCHVISION_VERSION}+rocm${ROCM_VERSION}"
+
+RUN rocm-sdk init && rocm-sdk targets
+
+ENV ROCM_HOME=$VIRTUAL_ENV/lib/python3.12/site-packages/_rocm_sdk_devel
+ENV ROCM_PATH=$ROCM_HOME
+ENV CPATH=$ROCM_HOME/include
+ENV LIBRARY_PATH=$ROCM_HOME/lib
+ENV LD_LIBRARY_PATH=$ROCM_HOME/lib
+RUN echo 'export PATH=$ROCM_HOME/llvm/bin:$ROCM_HOME/bin:$PATH' >> /etc/bash.bashrc
+
+# The SDK's hsakmtTargets.cmake hardcodes /usr/lib64/libc.so from its own build
+# host; Ubuntu keeps libc in /lib/x86_64-linux-gnu, so cmake would fail with
+# "ninja: error: /usr/lib64/libc.so missing and no known rule to make it".
+RUN mkdir -p /usr/lib64 && ln -sf /lib/x86_64-linux-gnu/libc.so /usr/lib64/libc.so
+
+# ROCm lives in site-packages here, but AITER shells out to
+# /opt/rocm/llvm/bin/amdgpu-arch at runtime to pick DEFAULT_GPU_ARCH, and the
+# rest of this Dockerfile refers to /opt/rocm throughout.
+RUN ln -s ${ROCM_HOME} /opt/rocm
+
+# ===============================
+# Base image 942 with rocm10 and args
+FROM rocm10-base AS gfx942-rocm10
+ENV BUILD_VLLM="0"
+ENV BUILD_TRITON="0"
+ENV BUILD_LLVM="0"
+ENV BUILD_AITER_ALL="1"
+ENV BUILD_MOONCAKE="1"
+ENV AITER_COMMIT_DEFAULT="d9e5ef7ce08ee7045d583aed768cff41aa9210fe"
+
+# ===============================
+# Base image 950 with rocm10 and args
+FROM rocm10-base AS gfx950-rocm10
+ENV BUILD_VLLM="0"
+ENV BUILD_TRITON="0"
 ENV BUILD_LLVM="0"
 ENV BUILD_AITER_ALL="1"
 ENV BUILD_MOONCAKE="1"
@@ -162,6 +264,9 @@ RUN set -eux; \
       *rocm720*) \
         echo "ROCm 7.2 (GPU_ARCH=${GPU_ARCH}): libdrm-amdgpu packages already present, skipping"; \
         ;; \
+      *rocm10*) \
+        echo "ROCm 10 (GPU_ARCH=${GPU_ARCH}): libdrm comes with the pip ROCm SDK, skipping"; \
+        ;; \
       *) \
         echo "ROCm 7.0 (GPU_ARCH=${GPU_ARCH}): installing libdrm-amdgpu packages"; \
         curl -fsSL https://repo.radeon.com/rocm/rocm.gpg.key \
@@ -184,16 +289,17 @@ RUN python -m pip install --upgrade pip && pip install setuptools_scm
 RUN apt-get purge -y sccache; python -m pip uninstall -y sccache; rm -f "$(which sccache)"
 
 # Install AMD SMI Python package from ROCm distribution.
-# The ROCm 7.2 base image (rocm/pytorch) does not pre-install this package.
+# Neither the ROCm 7.2 base image (rocm/pytorch) nor the pip-installed ROCm 10
+# SDK pre-installs this package.
 RUN set -eux; \
     case "${GPU_ARCH}" in \
-      *rocm720*) \
-        echo "ROCm 7.2 flavor detected from GPU_ARCH=${GPU_ARCH}"; \
+      *rocm720*|*rocm10*) \
+        echo "ROCm 7.2 / 10 flavor detected from GPU_ARCH=${GPU_ARCH}"; \
         cd /opt/rocm/share/amd_smi \
         && python3 -m pip install --no-cache-dir . \
         ;; \
       *) \
-        echo "Not rocm720 (GPU_ARCH=${GPU_ARCH}), skip amdsmi installation"; \
+        echo "Not rocm720/rocm10 (GPU_ARCH=${GPU_ARCH}), skip amdsmi installation"; \
         ;; \
     esac
 

--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -636,6 +636,23 @@ RUN /bin/bash -lc 'set -euo pipefail; \
   cd /sgl-workspace/mori; \
   git checkout "${MORI_COMMIT}"; \
   git submodule update --init --recursive; \
+  # ROCm 10 vendors NUMA and libdrm inside the pip SDK's rocm_sysdeps tree, which
+  # is on none of the three search paths the MORI build needs: hsakmt-config.cmake
+  # calls find_dependency(NUMA), rocm_smi.h reaches for <libdrm/drm.h>, and
+  # mori_application links -ldrm/-ldrm_amdgpu. The SDK's own libraries find these
+  # through an $ORIGIN/rocm_sysdeps/lib RPATH that MORI's do not inherit, hence
+  # the ldconfig entry; every soname in there is librocm_sysdeps_*-prefixed, so it
+  # shadows nothing system-wide. The apt ROCm 7.x images have no rocm_sysdeps
+  # tree, so the guard keeps them on their existing behaviour.
+  ROCM_SYSDEPS="${ROCM_HOME:-/opt/rocm}/lib/rocm_sysdeps"; \
+  if [ -d "${ROCM_SYSDEPS}" ]; then \
+    export CMAKE_PREFIX_PATH="${ROCM_SYSDEPS}${CMAKE_PREFIX_PATH:+:${CMAKE_PREFIX_PATH}}"; \
+    export CPATH="${ROCM_SYSDEPS}/include${CPATH:+:${CPATH}}"; \
+    export LIBRARY_PATH="${ROCM_SYSDEPS}/lib${LIBRARY_PATH:+:${LIBRARY_PATH}}"; \
+    echo "${ROCM_SYSDEPS}/lib" > /etc/ld.so.conf.d/rocm-sysdeps.conf; \
+    ldconfig; \
+    echo "[MORI] rocm_sysdeps prefix: ${ROCM_SYSDEPS}"; \
+  fi; \
   python3 setup.py develop; \
   python3 -c "import os, torch; print(os.path.join(os.path.dirname(torch.__file__), \"lib\"))" > /etc/ld.so.conf.d/torch.conf; \
   ldconfig; \

--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -151,6 +151,15 @@ RUN mkdir -p /usr/lib64 && ln -sf /lib/x86_64-linux-gnu/libc.so /usr/lib64/libc.
 # rest of this Dockerfile refers to /opt/rocm throughout.
 RUN ln -s ${ROCM_HOME} /opt/rocm
 
+# BUILD_TRITON=0 keeps the Triton that ships with the ROCm 10 torch stack (3.8).
+# The rocm720 stages set it to 1, which runs AITER's install_triton.sh; that
+# script resolves its index from `dpkg -l rocm-core`, which does not exist for a
+# pip-installed SDK, so it would fall back to the ROCm 7.2 index and drop a
+# 7.2-built Triton 3.7.0 into a ROCm 10 image. There is no 3.7 to fall back to
+# either: AMD's ROCm 10 channel publishes only 3.8 (the 7.15 channel has 3.5-3.8,
+# which is why the gfx1250 stage can pin 3.7.1). AITER does not require 3.7 --
+# its requirements.txt leaves torch and triton to the base image on purpose.
+#
 # ===============================
 # Base image 942 with rocm10 and args
 FROM rocm10-base AS gfx942-rocm10

--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -319,10 +319,14 @@ RUN if [ "$BRANCH_TYPE" = "local" ]; then \
     && AMDGPU_TARGET=$GPU_ARCH_LIST python setup_rocm.py install \
     && cd ../../../.. \
     && rm -rf python/pyproject.toml && mv python/pyproject_other.toml python/pyproject.toml \
+    && case "${GPU_ARCH}" in \
+         *rocm7_15*|*rocm10*) CT_EXTRA="rocm_rock" ;; \
+         *)                   CT_EXTRA="rocm_legacy" ;; \
+       esac \
     && if [ "$BUILD_TYPE" = "srt" ]; then \
-         export SETUPTOOLS_SCM_PRETEND_VERSION="${SETUPTOOLS_SCM_PRETEND_VERSION}" && python -m pip --no-cache-dir install -e "python[srt_hip,diffusion_hip]"; \
+         export SETUPTOOLS_SCM_PRETEND_VERSION="${SETUPTOOLS_SCM_PRETEND_VERSION}" && python -m pip --no-cache-dir install -e "python[srt_hip,diffusion_hip,${CT_EXTRA}]"; \
        else \
-         export SETUPTOOLS_SCM_PRETEND_VERSION="${SETUPTOOLS_SCM_PRETEND_VERSION}" && python -m pip --no-cache-dir install -e "python[all_hip]"; \
+         export SETUPTOOLS_SCM_PRETEND_VERSION="${SETUPTOOLS_SCM_PRETEND_VERSION}" && python -m pip --no-cache-dir install -e "python[all_hip,${CT_EXTRA}]"; \
        fi
 
 RUN python -m pip cache purge

--- a/python/pyproject_other.toml
+++ b/python/pyproject_other.toml
@@ -108,14 +108,12 @@ tracing = [
 # HIP (Heterogeneous-computing Interface for Portability) for AMD
 # => base docker rocm/vllm-dev:20250114, not from public vllm whl
 srt_hip = [
-  # Pin to 0.15.0: 0.16.0 needs torch>=2.10 (incompatible with ROCm torch
-  # 2.9.1). An open-ended `<0.16.0` made pip backtrack into an unbuildable
-  # ancient setuptools sdist; an exact pin keeps the resolver converging.
-  "compressed-tensors==0.15.0",
   "petit_kernel==0.0.2",
   "sglang[runtime_common]",
   "torch",
   "wave-lang==3.8.2",
+  # compressed-tensors version is supplied by rocm_legacy or rocm_rock (see below),
+  # injected alongside this extra by the Dockerfile / CI install script.
 ]
 
 diffusion_hip = [
@@ -126,6 +124,23 @@ diffusion_hip = [
   "st_attn==0.0.7",
   "vsa==0.0.4",
 ]
+
+# Per-ROCm-SDK compressed-tensors version extras. The two versions are mutually
+# exclusive: 0.15.0 requires torch<2.11 and 0.16.0 requires torch>=2.10, so the
+# right one depends on which torch the ROCm SDK generation ships. Pinning the
+# wrong one leaves pip trying to replace the image's ROCm torch with a PyPI
+# build, which it cannot do, and the resolve then blows up.
+#
+#   rocm_legacy = ROCm 7.0 / 7.2 legacy SDK, torch 2.9.x   → 0.15.0
+#   rocm_rock   = ROCm 7.15 / 10.x rock SDK, torch 2.11+   → 0.16.0
+#
+# Neither is pulled automatically; the Dockerfile and the CI install script
+# append one of them based on the GPU_ARCH / ROCm version detected at build or
+# test time. Local developers should add the appropriate extra manually, e.g.:
+#   pip install -e "python[dev_hip,rocm_legacy]"
+#   pip install -e "python[dev_hip,rocm_rock]"
+rocm_legacy = ["compressed-tensors==0.15.0"]
+rocm_rock   = ["compressed-tensors==0.16.0"]
 
 # For Intel Gaudi(device : hpu) follow the installation guide
 # https://docs.vllm.ai/en/latest/getting_started/gaudi-installation.html

--- a/scripts/ci/amd/amd_ci_install_dependency.sh
+++ b/scripts/ci/amd/amd_ci_install_dependency.sh
@@ -236,6 +236,19 @@ if docker exec ci_sglang test -d /sgl-workspace/mori; then
     cd /sgl-workspace/mori
     git checkout '${MORI_COMMIT}'
     git submodule update --init --recursive
+    # Same rocm_sysdeps handling as docker/rocm.Dockerfile's MORI step: ROCm 10's
+    # pip SDK vendors NUMA and libdrm there, off every default search path. Kept
+    # scoped to the MORI build instead of exported image-wide because
+    # rocm_sysdeps/include also carries zlib.h/expat.h/elf.h, which would shadow
+    # the system headers for every other component.
+    ROCM_SYSDEPS=\"\${ROCM_HOME:-/opt/rocm}/lib/rocm_sysdeps\"
+    if [ -d \"\${ROCM_SYSDEPS}\" ]; then
+      export CMAKE_PREFIX_PATH=\"\${ROCM_SYSDEPS}\${CMAKE_PREFIX_PATH:+:\${CMAKE_PREFIX_PATH}}\"
+      export CPATH=\"\${ROCM_SYSDEPS}/include\${CPATH:+:\${CPATH}}\"
+      export LIBRARY_PATH=\"\${ROCM_SYSDEPS}/lib\${LIBRARY_PATH:+:\${LIBRARY_PATH}}\"
+      echo \"\${ROCM_SYSDEPS}/lib\" > /etc/ld.so.conf.d/rocm-sysdeps.conf
+      ldconfig
+    fi
     python3 setup.py develop
     python3 -c 'import os, torch; print(os.path.join(os.path.dirname(torch.__file__), \"lib\"))' > /etc/ld.so.conf.d/torch.conf
     ldconfig

--- a/scripts/ci/amd/amd_ci_install_dependency.sh
+++ b/scripts/ci/amd/amd_ci_install_dependency.sh
@@ -115,6 +115,21 @@ git_clone_with_retry() {
   return 1
 }
 
+# Detect ROCm version inside the CI container to select the correct
+# compressed-tensors extra (rocm_legacy=0.15.0 vs rocm_rock=0.16.0).
+# Same detection pattern used by the AITER and MORI blocks below.
+CI_ROCM_VERSION=$(docker exec ci_sglang bash -c 'cat $ROCM_HOME/.info/version 2>/dev/null || cat /opt/rocm/.info/version 2>/dev/null || echo unknown')
+echo "Detected ROCm version inside container: ${CI_ROCM_VERSION}"
+
+if [[ "${CI_ROCM_VERSION}" != "unknown" ]] && \
+   [[ "$(printf '%s\n' "7.15.0" "${CI_ROCM_VERSION}" | sort -V | head -n1)" == "7.15.0" ]]; then
+  CT_EXTRA="rocm_rock"
+else
+  CT_EXTRA="rocm_legacy"
+fi
+echo "Using compressed-tensors extra: ${CT_EXTRA}"
+EXTRAS="${EXTRAS},${CT_EXTRA}"
+
 # Install checkout sglang
 if [ -n "$SKIP_SGLANG_BUILD" ]; then
   echo "Didn't build checkout SGLang"


### PR DESCRIPTION
> Draft. Both ROCm 10 stages now build and the standard AMD CI install runs on them, with stage-a at 6/8 on gfx942 — the two failures are a missing gated-model token, not ROCm 10. Still unverified: stage-b and the kernel suites. See **Open items**.

## Motivation

ROCm 10 has no `rocm/pytorch` image, so the stack is assembled from AMD's ROCm pip channels on `ubuntu:24.04`, the same way the gfx1250 ROCm 7.15 stage in #32754 does.

AMD does publish a prebuilt ROCm 10 image, `rocm/sgl-dev:v0.5.15.post1-ubuntu24.04-py3.14-rocm10rc2`, and it covers exactly the arches we need (`GPU_ARCH_LIST=gfx942;gfx950;gfx1100;gfx1201`). We cannot use it: it is **Python 3.14**, and four `srt_hip` / `diffusion_hip` deps publish no cp314 wheel and no sdist —

| package | pinned | wheels on PyPI |
| --- | --- | --- |
| `st_attn` | 0.0.7 | cp310–cp313 |
| `vsa` | 0.0.4 | cp310–cp313 |
| `petit_kernel` | 0.0.2 | cp310, cp312 |
| `wave-lang` | 3.8.2 | cp310–cp313 |

so `pip install -e "python[dev_hip,tracing]"` has no candidate for any of them, backtracks over everything else and dies with `resolution-too-deep`. On Python 3.12 the same dependency set resolves in 19s. Hence a self-built py3.12 stage.

## Modifications

**1. `compressed-tensors` split by ROCm SDK generation** (cherry-picked from `00e5cfbef5` on the gfx1250/Helios branch, which is not on main)

0.15.0 requires `torch<2.11`; 0.16.0 requires `torch>=2.10`. ROCm 7.0/7.2 ship torch 2.9.x, ROCm 7.15/10.x ship torch 2.11+. With the wrong pin, pip cannot satisfy `compressed-tensors` without replacing the image's ROCm torch with a PyPI build, which it cannot do — the resolve then dies as `resolution-too-deep` on AMD's ROCm 10 image, or as an unbounded recursion in resolvelib's `_build_result` on a self-built one. The version moves out of `srt_hip` into two extras that the Dockerfile and the CI install script select between:

```
rocm_legacy = compressed-tensors==0.15.0   # ROCm 7.0 / 7.2
rocm_rock   = compressed-tensors==0.16.0   # ROCm 7.15 / 10.x
```

Three adaptations vs. the original commit: the pin lives in `srt_hip` on this baseline rather than `runtime_common`, so the non-HIP platform extras (HPU/MUSA/MPS) inherit the unpinned entry and need no edit; the Dockerfile's `GPU_ARCH` case also matches `*rocm10*`; and the install line keeps main's `SETUPTOOLS_SCM_PRETEND_VERSION` form.

**2. `gfx942-rocm10` / `gfx950-rocm10` stages**

Both share a `rocm10-base` stage and differ only in the `BUILD_*` flags. Pinned to `rocm==10.0.0a20260730` + torch 2.12.0. Two details worth a reviewer's attention:

- The per-arch torch device wheels are named explicitly. Passing several device extras in one spec (`torch[device-gfx942,device-gfx950]`) silently installs only the first, and the missing arch then fails at runtime with `hipErrorInvalidImage` on an otherwise healthy GPU.
- The pin is a 10.0 nightly rather than plain `10.0.0`. The release version exists in the devreleases channel, but its only torch builds are named `+devrocm10.0.0.dev0.<sha>`; `10.0.0a20260730` is the last build of the 10.0 line and pairs with a clean torch version.

The two `GPU_ARCH` case branches are extended: rocm10 skips the ROCm 7.0 `libdrm-amdgpu` install (the pip SDK carries it, and that apt repo is jammy-only) and joins rocm720 in installing amdsmi from `/opt/rocm/share/amd_smi`. The rocm720 torch-wheel triton patch stays skipped — it rewrites a wheel baked into that base image and has no ROCm 10 equivalent.

**3. A comment recording why `BUILD_TRITON=0`**

The neighbouring rocm720 stages set it to 1, so the 0 needs justifying. AITER's `install_triton.sh` picks its index from `dpkg -l rocm-core`, which a pip-installed SDK does not provide, so it would fall back to the ROCm 7.2 index and install a 7.2-built Triton 3.7.0 into a ROCm 10 image. No 3.7 exists for this line anyway — AMD's ROCm 10 channel publishes only 3.8, while the 7.15 channel has 3.5–3.8, which is why the gfx1250 stage can pin 3.7.1. AITER does not ask for 3.7: its `requirements.txt` deliberately leaves torch and triton to the base image.

**4. MORI needs the SDK's vendored `rocm_sysdeps` on three search paths**

Enabling MORI is what turned up the one genuine ROCm 10 incompatibility here. Because ROCm 10 has no apt packages, the pip SDK vendors NUMA and libdrm under `$ROCM_HOME/lib/rocm_sysdeps`, a tree that is on none of the paths the MORI build consults. Each failure only surfaced once the previous one was fixed:

- `hsakmt-config.cmake` calls `find_dependency(NUMA)`. On ROCm 7.2 that exact line is *commented out*, so this is new in ROCm 10. `apt install libnuma-dev` is not the fix: Ubuntu ships no CMake config for NUMA, while the SDK ships a `numa-config.cmake` that nothing looks for.
- `rocm_smi.h` pulls in `kfd_ioctl.h`, which includes `<libdrm/drm.h>`.
- `mori_application` links `-ldrm` and `-ldrm_amdgpu`.

Runtime needs one more step: the SDK's own libraries resolve these through an `$ORIGIN/rocm_sysdeps/lib` RPATH that MORI's libraries do not inherit, so the directory also needs an `ldconfig` entry before `import mori` works. That is safe system-wide because every soname in the tree is `librocm_sysdeps_*`-prefixed — there are no unprefixed ones to shadow a system library.

Two deliberate scoping choices:

- The exports stay inside the MORI build instead of being set on `rocm10-base`, because `rocm_sysdeps/include` also carries `zlib.h`, `expat.h` and `elf.h`, which would shadow the system headers for AITER, sgl-kernel, TileLang and Mooncake.
- `scripts/ci/amd/amd_ci_install_dependency.sh` needs the same block, because it rebuilds MORI in-container and that `docker exec` does not inherit the build step's environment. Without it the rebuild overwrites `libmori_pybinds.so` and `mori.umbp` stops importing on an image that was fine to begin with.

Both call sites are guarded on the directory existing, so the apt-based ROCm 7.x images keep their current behaviour.

**5. A dispatch-only nightly release workflow**

`release-docker-amd-rocm10-nightly.yml` builds both arches and publishes only to `lmsysorg/sglang-rocm`; there is no cron and no `rocm/sgl-dev` push while the SDK pin is an alpha.

It is modelled on `release-docker-amd-rocm720-nightly.yml` rather than the ROCm 7.15 one, which has two problems worth fixing separately: it passes `--build-arg SGLANG_VERSION` and `--build-arg GPU_ARCH_LIST_ARG`, neither of which is an `ARG` in `docker/rocm.Dockerfile`, so both are silently dropped and its version override never takes effect; and it passes no `ENABLE_NIXL`, inheriting the Dockerfile default of 1, which cannot work on 24.04. Neither has been noticed because that workflow's cron and pushes are all commented out.

Beyond `ENABLE_NIXL=0`, the ROCm 10 workflow must pass `UBUNTU_CODENAME=noble`: the stages build on `ubuntu:24.04` while the Dockerfile defaults to `jammy` for the 22.04 bases, and MORI's apt step interpolates the codename into the `amdainic` repo URL.

## Verification

**gfx950-rocm10** on an MI355X (`BRANCH_TYPE=local`, `ENABLE_NIXL=0`), 46.3 GB, all 29 steps: the AITER prebuild compiles gfx950 kernels at main's pin `d9e5ef7`, Mooncake, TileLang and the Rust extensions all build.

**gfx942-rocm10** on an MI300X (`BRANCH_TYPE=local`, `ENABLE_MORI=1`, `ENABLE_NIXL=0`, `UBUNTU_CODENAME=noble`), 46 GB, all 29 steps, with MORI compiling for gfx942 and UMBP enabled (gRPC + Protobuf found).

The unmodified `scripts/ci/amd/amd_ci_install_dependency.sh` then runs against the gfx942 image and picks the right extra:

```
Detected ROCm version inside container: 10.0.0
Using compressed-tensors extra: rocm_rock
```

`compressed_tensors` resolves to 0.16.0, confirming the extra took effect. The sglang install is a 9-package delta, the same shape as the 8-package delta on today's rocm720 image — the resolver blowup is gone. The AITER version check correctly identifies the dev build (`v0.1.20.dev12+gd9e5ef7ce`) and skips a rebuild, the MORI reinstall completes, and `sglang.srt.entrypoints.http_server` imports. Runtime: ROCm 10.0.0, Python 3.12.3, torch 2.12.0+rocm10, 8 GPUs at `gfx942:sramecc+:xnack-`.

`stage-a-test-1-gpu-small-amd`, **6 of 8 passing**. Both failures are the local environment rather than ROCm 10:

| test | result | cause |
| --- | --- | --- |
| `unit/models/test_vit_pos_embed_interpolate` | pass | |
| `quant/test_fused_rms_fp8_group_quant` | pass | |
| `amd/test_fp8_per_channel_detection` | pass | |
| `attention/test_wave_attention_kernels` | pass | |
| `unit/mem_cache/test_umbp_store` | pass | MORI + UMBP now present |
| `quant/test_awq_dequant` | pass | including `test_gemm`, which failed on the earlier gfx950 run |
| `core/test_basic_sanity` | fail | HF 401, neither host's token can reach gated `meta-llama/Llama-3.1-8B-Instruct` |
| `core/test_basic_sanity_eagle3` | fail | same |

## Open items

- [x] Rebuild with `ENABLE_MORI=1` and confirm MORI compiles on ROCm 10 / py3.12. It does not without modification — see **Modifications 4**. `UBUNTU_CODENAME=noble` is confirmed necessary and sufficient for the apt half.
- [x] Build `gfx942-rocm10`. Built on an MI300X; stage-a run above is from that image.
- [x] Confirm `test_awq_dequant::test_gemm` is pre-existing rather than the rough PYTHONPATH-shadowed environment used on the gfx950 run. It **passes** on a clean run, so it was the environment and not ROCm 10 or Triton.
- [ ] Run stage-a with a token that can reach the gated models, plus stage-b and the kernel suites.
- [ ] NIXL does not build: `Your Abseil version is too old ... missing support for absl_log` on Ubuntu 24.04. The ROCm 7.15 stage hit the same wall and #32079 handles it by passing `--build-arg ENABLE_NIXL=0`, which is what the workflow here does. PD disaggregation on ROCm 10 needs Abseil solved separately.
- [ ] Remaining workflow onboarding, following the shape of #17799: `pr-test-amd-rocm10.yml`, `nightly-test-amd-rocm10.yml`, a rocm10 tag branch in `release-docker-amd.yml`, and the `release-branch-cut.yml` wiring. The nightly cron and the `rocm/sgl-dev` push should wait until the pin moves off the 10.0 alpha.

## Related

- #32754 — gfx1250 / ROCm 7.15 enablement; the stage here follows its pip-installed-SDK pattern and it carries the `compressed-tensors` commit cherry-picked in this PR
- #32079 — `ENABLE_NIXL=0` and the nofile ulimit for the ROCm 7.15 build
- #34403 — pinning the Triton wheel explicitly instead of deferring to AITER

Made with [Cursor](https://cursor.com)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32014809630](https://github.com/sgl-project/sglang/actions/runs/32014809630)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32014809355](https://github.com/sgl-project/sglang/actions/runs/32014809355)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32014809684](https://github.com/sgl-project/sglang/actions/runs/32014809684)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
