### PR TITLE
[Fix] Restore fused_shared_experts_scaling_factor on biased_grouped_topk_cpu

### DIFF
--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -1901,7 +1901,14 @@ def biased_grouped_topk_cpu(
     num_fused_shared_experts: int = 0,
     routed_scaling_factor: Optional[float] = None,
     apply_routed_scaling_factor_on_output: Optional[bool] = False,
+    fused_shared_experts_scaling_factor: Optional[float] = None,
 ):
+    if fused_shared_experts_scaling_factor is not None:
+        raise ValueError(
+            "fused_shared_experts_scaling_factor is not supported for CPU biased "
+            f"grouped topk, got: {fused_shared_experts_scaling_factor}"
+        )
+
     return torch.ops.sgl_kernel.biased_grouped_topk_cpu(
         hidden_states,
         gating_output,


### PR DESCRIPTION
## Motivation

`select_experts()` passes `fused_shared_experts_scaling_factor` to `biased_grouped_topk()` unconditionally, but `biased_grouped_topk` is rebound to `biased_grouped_topk_cpu` at import time when the CPU engine runs on an AMX-capable host, and the CPU variant does not accept that keyword:

```
TypeError: biased_grouped_topk_cpu() got an unexpected keyword argument
'fused_shared_experts_scaling_factor'
```

This is raised while binding arguments, so it fires before the function body runs and even when the value is `None`. Any model on the `use_grouped_topk` + `correction_bias` path crashes at its first MoE forward, during warmup.

## Modifications

Accept `fused_shared_experts_scaling_factor` in `biased_grouped_topk_cpu` and reject a requested scale, so the argument is validated rather than silently ignored.

The CPU kernel enforces `num_fused_shared_experts == 0`, so no shared expert is appended on this path and there is no weight a scale could apply to:

```cpp
  TORCH_CHECK(
      num_fused_shared_experts == 0,
      "num_fused_shared_experts must be 0 default value, got: ",
      num_fused_shared_experts);
```

Whether a scale is needed is the caller's decision, so the CPU path only states that it cannot apply one and leaves the value itself alone. A call site that has no scale to request should leave the field unset; one that passes an explicit value now gets an error naming the parameter, instead of the unrelated `num_fused_shared_experts` message or the `TypeError` above.

The guard follows the shape already used for `routed_scaling_factor` in the same kernel:

```cpp
  TORCH_CHECK(
      !routed_scaling_factor.has_value() || routed_scaling_factor.value() == 1.0f,
      "routed_scaling_factor must be None or 1.0f default value, got: ",
      routed_scaling_factor.value());
```

`raise ValueError` rather than `assert`, matching `fused_topk_cpu`, which rejects its four unsupported arguments the same way: asserts are stripped under `python -O`.

## Accuracy Tests

No numerical change on any platform. The GPU path is untouched, and on CPU the accepted value is the existing default, under which no shared expert is appended.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32003680107](https://github.com/sgl-project/sglang/actions/runs/32003680107)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32003679991](https://github.com/sgl-project/sglang/actions/runs/32003679991)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->