### PR TITLE
fix: propagate rank-local tensor update failures

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/weight_updater.py
+++ b/python/sglang/srt/managers/scheduler_components/weight_updater.py
@@ -150,19 +150,48 @@ class SchedulerWeightUpdaterManager:
                 success=success, message=message
             )
 
-    def update_weights_from_tensor(self, recv_req: UpdateWeightsFromTensorReqInput):
+    def update_weights_from_tensor(
+        self, recv_req: UpdateWeightsFromTensorReqInput
+    ) -> UpdateWeightsFromTensorReqOutput:
         """Update the online model parameter from tensors."""
         with self._observe_weight_load("tensor"):
             if recv_req.disable_draft_model:
                 worker = self.tp_worker
             else:
                 worker = self.draft_worker or self.tp_worker
-            success, message = worker.update_weights_from_tensor(recv_req)
-            if success:
-                self.flush_cache_after_weight_update(recv_req)
-            else:
+
+            try:
+                success, message = worker.update_weights_from_tensor(recv_req)
+                if success:
+                    # Keep cleanup local: a rank may already have changed its weights even
+                    # when a peer fails, so it must not skip its requested cache flush.
+                    self.flush_cache_after_weight_update(recv_req)
+            except Exception:
+                success = False
+                message = traceback.format_exc()
+
+            # This must be the terminal synchronization point. Every rank participates
+            # even if its local update or cache flush raised, so peers do not wait in an
+            # unobservable barrier until the process-group timeout.
+            tp_size = torch.distributed.get_world_size(group=self.tp_cpu_group)
+            if tp_size > 1:
+                statuses: list[tuple[bool, str] | None] = [None] * tp_size
+                torch.distributed.all_gather_object(
+                    statuses, (success, message), group=self.tp_cpu_group
+                )
+                failures = [
+                    f"TP rank {rank}: {rank_message}"
+                    for rank, status in enumerate(statuses)
+                    if status is not None
+                    for rank_success, rank_message in [status]
+                    if not rank_success
+                ]
+                if failures:
+                    success = False
+                    message = "Weight update failed on " + "; ".join(failures)
+
+            if not success:
                 logger.error(message)
-            torch.distributed.barrier(group=self.tp_cpu_group)
             return UpdateWeightsFromTensorReqOutput(success=success, message=message)
 
     def update_weights_from_ipc(self, recv_req: UpdateWeightsFromIPCReqInput):

--- a/test/registered/unit/managers/test_weight_updater_rank_failures.py
+++ b/test/registered/unit/managers/test_weight_updater_rank_failures.py
@@ -1,0 +1,149 @@
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+from sglang.srt.managers.scheduler_components.weight_updater import (
+    SchedulerWeightUpdaterManager,
+)
+
+
+def _manager(worker):
+    return SchedulerWeightUpdaterManager(
+        tp_worker=worker,
+        draft_worker=None,
+        tp_cpu_group=object(),
+        memory_saver_adapter=Mock(),
+        flush_cache=Mock(return_value=True),
+        is_fully_idle=Mock(return_value=True),
+    )
+
+
+def _request(flush_cache=False):
+    return SimpleNamespace(
+        disable_draft_model=True,
+        flush_cache=flush_cache,
+        torch_empty_cache=False,
+    )
+
+
+@patch(
+    "sglang.srt.managers.scheduler_components.weight_updater.torch.distributed.all_gather_object"
+)
+@patch(
+    "sglang.srt.managers.scheduler_components.weight_updater.torch.distributed.get_world_size",
+    return_value=2,
+)
+def test_update_weights_from_tensor_propagates_rank_failure(
+    _world_size, all_gather_object
+):
+    worker = Mock()
+    worker.update_weights_from_tensor.return_value = (True, "rank 0 ok")
+    manager = _manager(worker)
+
+    def gather(statuses, _local_status, group):
+        statuses[:] = [(True, "rank 0 ok"), (False, "rank 1 failed")]
+
+    all_gather_object.side_effect = gather
+
+    result = manager.update_weights_from_tensor(_request())
+
+    assert result.success is False
+    assert result.message == "Weight update failed on TP rank 1: rank 1 failed"
+
+
+@patch(
+    "sglang.srt.managers.scheduler_components.weight_updater.torch.distributed.all_gather_object"
+)
+@patch(
+    "sglang.srt.managers.scheduler_components.weight_updater.torch.distributed.get_world_size",
+    return_value=2,
+)
+def test_update_weights_from_tensor_collects_local_exception(
+    _world_size, all_gather_object
+):
+    worker = Mock()
+    worker.update_weights_from_tensor.side_effect = RuntimeError("local boom")
+    manager = _manager(worker)
+
+    def gather(statuses, local_status, group):
+        statuses[:] = [local_status, (True, "rank 1 ok")]
+
+    all_gather_object.side_effect = gather
+
+    result = manager.update_weights_from_tensor(_request())
+
+    assert result.success is False
+    assert "TP rank 0:" in result.message
+    assert "RuntimeError: local boom" in result.message
+
+
+@patch(
+    "sglang.srt.managers.scheduler_components.weight_updater.torch.distributed.all_gather_object"
+)
+@patch(
+    "sglang.srt.managers.scheduler_components.weight_updater.torch.distributed.get_world_size",
+    return_value=2,
+)
+def test_update_weights_from_tensor_flushes_locally_before_aggregating_peer_failure(
+    _world_size, all_gather_object
+):
+    worker = Mock()
+    worker.update_weights_from_tensor.return_value = (True, "rank 0 ok")
+    manager = _manager(worker)
+
+    def gather(statuses, _local_status, group):
+        manager.flush_cache.assert_called_once_with(empty_cache=False)
+        statuses[:] = [(True, "rank 0 ok"), (False, "rank 1 failed")]
+
+    all_gather_object.side_effect = gather
+
+    result = manager.update_weights_from_tensor(_request(flush_cache=True))
+
+    assert result.success is False
+    assert "TP rank 1: rank 1 failed" in result.message
+
+
+@patch(
+    "sglang.srt.managers.scheduler_components.weight_updater.torch.distributed.all_gather_object"
+)
+@patch(
+    "sglang.srt.managers.scheduler_components.weight_updater.torch.distributed.get_world_size",
+    return_value=2,
+)
+def test_update_weights_from_tensor_propagates_flush_exception(
+    _world_size, all_gather_object
+):
+    worker = Mock()
+    worker.update_weights_from_tensor.return_value = (True, "rank 0 ok")
+    manager = _manager(worker)
+    manager.flush_cache.return_value = False
+
+    def gather(statuses, local_status, group):
+        statuses[:] = [local_status, (True, "rank 1 ok")]
+
+    all_gather_object.side_effect = gather
+
+    result = manager.update_weights_from_tensor(_request(flush_cache=True))
+
+    assert result.success is False
+    assert "TP rank 0:" in result.message
+    assert "Cache flush failed after updating weights" in result.message
+
+
+@patch(
+    "sglang.srt.managers.scheduler_components.weight_updater.torch.distributed.get_world_size",
+    return_value=1,
+)
+def test_update_weights_from_tensor_tp1_success(_world_size):
+    worker = Mock()
+    worker.update_weights_from_tensor.return_value = (True, "ok")
+    manager = _manager(worker)
+
+    result = manager.update_weights_from_tensor(_request(flush_cache=True))
+
+    assert result.success is True
+    assert result.message == "ok"
+    manager.flush_cache.assert_called_once_with(empty_cache=False)


### PR DESCRIPTION
## Motivation

`update_weights_from_tensor` currently runs a rank-local update and then enters a plain TP CPU/Gloo barrier. If one rank raises during the local update (or during its requested cache flush), that rank exits the handler while its peers wait in the barrier until the process-group timeout. The original rank-local exception is also lost from the peer-visible response.

We observed this failure mode on TP=8 with EAGLE v2: TP0 remained in the CUDA-IPC tensor unwrap/update path, while TP1-7 timed out after 7200000 ms in the final Gloo barrier.

This is separate from, but can amplify, the EAGLE CUDA-IPC handle issue tracked in #17870.

## Changes

- Convert rank-local tensor update and cache-flush exceptions into a failure status.
- Use `all_gather_object` as the terminal TP synchronization point.
- Aggregate failures with their TP rank so the initiating caller sees the first useful error instead of a later barrier timeout.
- Preserve local cache cleanup before aggregating peer failures, because a locally successful rank may already have changed weights even if another rank failed.
- Remove the redundant plain barrier after the status gather.
- Add CPU unit coverage for peer failures, local exceptions, cache-flush failures, and TP=1 success.

## Scope

This does not recover a process that is already dead or a rank stuck forever inside a model-loader/CUDA operation. It prevents ordinary rank-local Python failures from stranding peers and makes the failure diagnosable.

## Test plan

- `git diff --check`
- `python -m py_compile` on the modified implementation and test
- Lightweight mocked-module execution verified that a peer failure is returned on all ranks and the terminal status gather is reached.
- Full upstream unit CI requested for `test_weight_updater_rank_failures.py`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31996872749](https://github.com/sgl-project/sglang/actions/runs/31996872749)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31996872588](https://github.com/sgl-project/sglang/actions/runs/31996872588)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->