### PR TITLE
[Kernel] DSv4 top-k v2: raw_indices output + adaptive cluster split

### DIFF
--- a/python/sglang/kernels/jit/csrc/deepseek_v4/topk_v2.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/topk_v2.cuh
@@ -12,6 +12,7 @@
 #include <sgl_kernel/tensor.h>
 #include <sgl_kernel/utils.h>
 
+#include <sgl_kernel/runtime.cuh>
 #include <sgl_kernel/utils.cuh>
 
 #include <sgl_kernel/deepseek_v4/topk_impl.cuh>
@@ -37,11 +38,15 @@ using Register2 = impl::TopKRegister<2>;  // <= 8192, register-resident, 1 read
 using Register4 = impl::TopKRegister<4>;  // <= 16384, register-resident, 1 read
 using Streaming = impl::TopKStreaming;
 using Cluster = impl::TopKCluster<8>;
+using Cluster4 = impl::TopKCluster<4>;  // 4-way split for mid-batch long rows
+using Cluster2 = impl::TopKCluster<2>;  // 2-way split for larger-batch long rows
 
 constexpr uint32_t kBlockSize = impl::TopKConfig::kBlockSize;
 constexpr uint32_t kOccupancy = impl::TopKConfig::kOccupancy;
 constexpr uint32_t kMaxTopK = impl::TopKConfig::kMaxTopK;
-constexpr uint32_t kClusterSize = Cluster::kClusterSize;
+constexpr uint32_t kClusterSize = Cluster::kClusterSize;    // 8
+constexpr uint32_t kClusterSize4 = Cluster4::kClusterSize;  // 4
+constexpr uint32_t kClusterSize2 = Cluster2::kClusterSize;  // 2
 constexpr uint32_t kReg2MaxSeqLen = Register2::kMaxSeqLen;  // 8192
 constexpr uint32_t kReg4MaxSeqLen = Register4::kMaxSeqLen;  // 16384
 
@@ -51,6 +56,40 @@ constexpr uint32_t kReg4MaxSeqLen = Register4::kMaxSeqLen;  // 16384
 constexpr uint32_t kClusterFloor = 65536;
 constexpr uint32_t kClusterMaxBatch = 512;
 constexpr uint32_t kNumPersistentClusters = 15 * kOccupancy;
+
+// --- Small-batch split routing thresholds (sm_100 anchors, rescaled per device) ---
+// An N-way split processes one row with N co-resident blocks. It is profitable
+// within a batch cap (~ SM count / N, since the cluster must be co-resident) and
+// above a seq floor (the two-pass scan stays an L2 re-read up to a length set by
+// L2 size, beyond which a single block turns DRAM-bound). Caps scale with SM
+// count and floors with L2 size at launch (see transform()).
+constexpr uint32_t kCalibSMCount = 152;
+constexpr uint32_t kCalibL2Bytes = 135528448;  // sm_100 reported L2 (129.25 MB)
+
+constexpr uint32_t kSmallBatchClusterCap = 64;       // 8-way batch ceiling
+constexpr uint32_t kSmallBatchSplitMinSeq = 196608;  // 8-way seq floor
+static_assert(kSmallBatchClusterCap >= kNumPersistentClusters);
+static_assert(kSmallBatchSplitMinSeq > kClusterFloor);
+
+// 8-way stays a single co-resident wave only up to (SM count * occupancy / 8)
+// clusters (kBlockSize occupancy is kOccupancy); above that it spills into a 2nd,
+// underutilised wave and a 4-way split -- which fills one wave up to ~2x the batch
+// -- measures faster at seq >= min_seq8. Anchored at kCalibSMCount, rescaled by
+// scale_sm() at launch so it tracks the real single-wave capacity per device.
+constexpr uint32_t kSmallBatch8WaveCap = kCalibSMCount * kOccupancy / kClusterSize;  // 38 @ 152 SM
+static_assert(kSmallBatch8WaveCap >= kNumPersistentClusters);
+static_assert(kSmallBatch8WaveCap <= kSmallBatchClusterCap);
+
+constexpr uint32_t kSmallBatch4Cap = 74;         // 4-way batch ceiling
+constexpr uint32_t kSmallBatch4MinSeq = 131072;  // 4-way seq floor
+static_assert(kSmallBatch4Cap >= kSmallBatchClusterCap);
+static_assert(kSmallBatch4MinSeq > kClusterFloor);
+
+constexpr uint32_t kSmallBatch2Cap = 76;         // 2-way batch ceiling
+constexpr uint32_t kSmallBatch2MinSeq = 114688;  // 2-way seq floor
+static_assert(kSmallBatch2Cap >= kSmallBatch4Cap);
+static_assert(kSmallBatch2MinSeq > kClusterFloor);
+
 
 /// Metadata tensor rows (each 8 B / 2 int32). Row 0 is the global plan result;
 /// rows 1..N are the (batch_id, seq_len) of items routed to the cluster pool.
@@ -216,11 +255,14 @@ TOPK_KERNEL void topk_main_kernel(const __grid_constant__ TopKLaunchParams param
   }
 }
 
-template <bool kPDL, TopKMode kMode>
-CLUSTER_TOPK_KERNEL void topk_small_batch_kernel(const __grid_constant__ TopKLaunchParams params) {
+template <bool kPDL, TopKMode kMode, uint32_t kNumRanks = kClusterSize>
+TOPK_KERNEL __cluster_dims__(1, kNumRanks, 1) void topk_small_batch_kernel(
+    const __grid_constant__ TopKLaunchParams params) {
+  static_assert(kNumRanks == 2 || kNumRanks == 4 || kNumRanks == 8, "small-batch split factor must be 2, 4 or 8");
+  using ClusterT = impl::TopKCluster<kNumRanks>;
   device::enable_smem_spilling();
   auto problem = params.problem(blockIdx.x);
-  __shared__ impl::MaxSmem<Streaming::Smem, Cluster::Smem> smem;
+  __shared__ impl::MaxSmem<Streaming::Smem, typename ClusterT::Smem> smem;
   if (problem.seq_len <= problem.topk) return trivial_transform<kPDL, kMode>(problem);
 
   constexpr bool kNeedStaging = kMode != TopKMode::INDICES;
@@ -228,7 +270,7 @@ CLUSTER_TOPK_KERNEL void topk_small_batch_kernel(const __grid_constant__ TopKLau
   if constexpr (kNeedStaging) problem.out = s_topk_indices;
 
   // randomly elect one worker rank to avoid workload imbalance
-  const auto worker_rank = blockIdx.x % kClusterSize;
+  const auto worker_rank = blockIdx.x % kNumRanks;
 
   // for small batch, we will fuse in the cluster case
   if (problem.seq_len <= kReg4MaxSeqLen) {
@@ -244,7 +286,7 @@ CLUSTER_TOPK_KERNEL void topk_small_batch_kernel(const __grid_constant__ TopKLau
     if constexpr (kNeedStaging) {
       problem.out = cluster.map_shared_rank(s_topk_indices, worker_rank);
     }
-    Cluster::forward<kPDL>(problem, &smem);
+    ClusterT::forward<kPDL>(problem, &smem);
     if constexpr (kNeedStaging) {
       cluster.sync();
       if (blockIdx.y != worker_rank) return;
@@ -470,10 +512,59 @@ struct TopKKernel {
     };
     dispatch([&]<TopKMode kMode>() {
       if (use_cluster) {
-        if (batch_size <= kNumPersistentClusters) {
+        // Rescale the sm_100 anchors to this device: caps by SM count, floors by
+        // L2 size. Queries are cached (static) so they run once, not per launch.
+        static const uint32_t sm_count = std::max(host::runtime::get_sm_count(device.device_id), 1u);
+        static const uint32_t l2_bytes = std::max(host::runtime::get_l2_cache_size(device.device_id), 1u);
+        const auto scale_sm = [&](uint32_t v) {
+          return static_cast<uint32_t>((static_cast<uint64_t>(sm_count) * v) / kCalibSMCount);
+        };
+        const auto scale_l2 = [&](uint32_t v) {
+          return static_cast<uint32_t>((static_cast<uint64_t>(l2_bytes) * v) / kCalibL2Bytes);
+        };
+        const uint32_t cap8 = scale_sm(kSmallBatchClusterCap);
+        const uint32_t cap8_wave = scale_sm(kSmallBatch8WaveCap);
+        const uint32_t cap4 = scale_sm(kSmallBatch4Cap);
+        const uint32_t cap2 = scale_sm(kSmallBatch2Cap);
+        // Clamp so a smaller device cannot scale a cap below its neighbouring band or
+        // a floor at/under kClusterFloor (below which there is no cluster path).
+        const uint32_t cap4_eff = std::max(cap4, kSmallBatchClusterCap);
+        const uint32_t cap2_eff = std::max(cap2, kSmallBatch4Cap);
+        const uint32_t min_seq8 = std::max(scale_l2(kSmallBatchSplitMinSeq), kClusterFloor + 1);
+        const uint32_t min_seq4 = std::max(scale_l2(kSmallBatch4MinSeq), kClusterFloor + 1);
+        const uint32_t min_seq2 = std::max(scale_l2(kSmallBatch2MinSeq), kClusterFloor + 1);
+
+        // 8-way split: the original small-batch path (batch <= kNumPersistentClusters)
+        // plus long rows within a single 8-way wave (batch <= cap8_wave). Batches
+        // above the single-wave cap at high seq are handed to 4-way below, not 8-way,
+        // to avoid the underutilised 2nd-wave regression. Anything unmatched falls
+        // through to the persistent pool + main<3>.
+        const bool route_split8 =
+            (batch_size <= kNumPersistentClusters) || (batch_size <= cap8_wave && max_seq_len >= min_seq8);
+        // 4-way split: the mid-batch band above the 8-way cap, plus the high-seq
+        // (>= min_seq8) slice between the 8-way single-wave cap and cap8 that used to
+        // over-subscribe 8-way -- 4-way keeps that batch in one co-resident wave.
+        const bool route_split4 =
+            !route_split8 &&
+            ((batch_size > cap8 && batch_size <= cap4_eff && max_seq_len >= min_seq4) ||
+             (batch_size > cap8_wave && batch_size <= cap8 && max_seq_len >= min_seq8));
+        // 2-way split: band above the 4-way cap and the mid-long band below the 8-way
+        // seq floor. Lower priority than 8/4-way via the !route_split guards.
+        const bool route_split2 =
+            !route_split8 && !route_split4 &&
+            (batch_size > kNumPersistentClusters && batch_size <= cap2_eff && max_seq_len >= min_seq2);
+        if (route_split8) {
           LaunchKernel({batch_size, kClusterSize}, kBlockSize, device)
               .config({.use_pdl = kUsePDL, .cluster_dim = dim3{1, kClusterSize}})
-              .launch(topk_small_batch_kernel<kUsePDL, kMode>, params);
+              .launch(topk_small_batch_kernel<kUsePDL, kMode, kClusterSize>, params);
+        } else if (route_split4) {
+          LaunchKernel({batch_size, kClusterSize4}, kBlockSize, device)
+              .config({.use_pdl = kUsePDL, .cluster_dim = dim3{1, kClusterSize4}})
+              .launch(topk_small_batch_kernel<kUsePDL, kMode, kClusterSize4>, params);
+        } else if (route_split2) {
+          LaunchKernel({batch_size, kClusterSize2}, kBlockSize, device)
+              .config({.use_pdl = kUsePDL, .cluster_dim = dim3{1, kClusterSize2}})
+              .launch(topk_small_batch_kernel<kUsePDL, kMode, kClusterSize2>, params);
         } else {
           const uint32_t num_clusters = std::min(batch_size, kNumPersistentClusters);
           LaunchKernel({num_clusters, kClusterSize}, kBlockSize, device)

--- a/python/sglang/kernels/jit/include/sgl_kernel/runtime.cuh
+++ b/python/sglang/kernels/jit/include/sgl_kernel/runtime.cuh
@@ -29,6 +29,9 @@
 #ifndef cudaDevAttrComputeCapabilityMinor
 #define cudaDevAttrComputeCapabilityMinor hipDeviceAttributeComputeCapabilityMinor
 #endif
+#ifndef cudaDevAttrL2CacheSize
+#define cudaDevAttrL2CacheSize hipDeviceAttributeL2CacheSize
+#endif
 #ifndef cudaRuntimeGetVersion
 #define cudaRuntimeGetVersion hipRuntimeGetVersion
 #endif
@@ -64,6 +67,13 @@ inline auto get_sm_count(int device_id) -> uint32_t {
   int sm_count;
   RuntimeDeviceCheck(cudaDeviceGetAttribute(&sm_count, cudaDevAttrMultiProcessorCount, device_id));
   return static_cast<uint32_t>(sm_count);
+}
+
+// Return the L2 cache size in bytes for the given device
+inline auto get_l2_cache_size(int device_id) -> uint32_t {
+  int l2_cache_size;
+  RuntimeDeviceCheck(cudaDeviceGetAttribute(&l2_cache_size, cudaDevAttrL2CacheSize, device_id));
+  return static_cast<uint32_t>(l2_cache_size);
 }
 
 // Return the Major compute capability for the given device

--- a/test/registered/kernels/ops/attention/test_topk_v2.py
+++ b/test/registered/kernels/ops/attention/test_topk_v2.py
@@ -265,5 +265,54 @@ def test_topk_v2_output_indices(batch: int, seq: int, k: int) -> None:
     _assert_topk_close(scores.cpu(), ref_raw, our_raw, batch, seq_lens.cpu(), k)
 
 
+SPLIT_CONFIGS = [
+    # --- 8-way split band (batch <= 64 & max_seq >= 196608) ---
+    (64, 196608),
+    (64, 262144),
+    # --- 4-way split band (64 < batch <= 74 & max_seq >= 131072) ---
+    (72, 131072),
+    (72, 262144),
+    (74, 262144),  # 4-way batch cap
+    # --- 2-way split band (74 < batch <= 76 & max_seq >= 114688) ---
+    (75, 131072),
+    (76, 262144),  # 2-way batch cap
+    # --- 2-way split, low band (30 < batch <= 64 & 114688 <= max_seq < 196608) ---
+    (48, 114688),  # 2-way seq floor
+    (48, 131072),
+    (64, 163840),
+    # --- fallback (persistent pool + main<3>): just outside every split band ---
+    (77, 262144),  # batch above the 2-way cap
+    (96, 262144),  # well above all caps
+    (72, 98304),  # in a split batch band but seq below its floor
+]
+
+
+@pytest.mark.parametrize("page_mode", ["identity", "perm"])
+@pytest.mark.parametrize("k", [512, 2048])
+@pytest.mark.parametrize("batch,seq", SPLIT_CONFIGS)
+@torch.inference_mode()
+def test_topk_v2_split(batch: int, seq: int, k: int, page_mode: str) -> None:
+    """Adaptive cluster-split bands: both the page-transformed output (PAGE_TABLE
+    mode) and the raw index output (INDICES mode) must match torch.topk (set
+    equality, ties aside), across the 8/4/2-way split factors and the
+    persistent-pool fallback."""
+    torch.manual_seed(batch * 100003 + seq * 7 + k + 17)
+    device = "cuda"
+    width = (seq + 3) & ~3
+    scores = torch.randn(batch, width, dtype=torch.float32, device=device)[:, :seq]
+    seq_lens = torch.full((batch,), seq, dtype=torch.int32, device=device)
+    num_pages = (seq + PAGE_SIZE - 1) // PAGE_SIZE
+    page_table, inv_cpu = _make_page_table(batch, num_pages, page_mode, device)
+
+    ref_raw = _reference(scores, seq_lens, k)
+    scores_cpu, seq_cpu = scores.cpu(), seq_lens.cpu()
+    # PAGE_TABLE mode: transformed output, inverted through the page table
+    inv_out = _run(scores, seq_lens, page_table, inv_cpu, k)
+    _assert_topk_close(scores_cpu, ref_raw, inv_out, batch, seq_cpu, k)
+    # INDICES mode (page_table=None): the raw (pre-transform) selected positions
+    raw_out = _run_raw(scores, seq_lens, k)
+    _assert_topk_close(scores_cpu, ref_raw, raw_out, batch, seq_cpu, k)
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Route raw_indices callers through v2 instead of the ~2x slower v1, and add an adaptive small-batch cluster split factor N in {8,4,2} chosen from (batch, max_seq_len) so mid-batch long-context launches stay a single cluster-wave. Split caps are B200/sm100 autotune values scaled by SM count at runtime; shapes outside the split bands fall back unchanged. topk_impl.cuh is untouched (TopKCluster<N> was already generalized to any power-of-two N).

Correctness validated against torch.topk at zero tolerance for both the page-transformed and raw outputs: test_topk_v2.py 296 passed (244 existing + 52 new split-band cases). Perf on B200: win region 0.62-0.92x (best ~1.6x), fallback/short-seq within noise, page-only neutral.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

`topk_transform_512_v2` is the DeepSeek-V4 DSA-indexer fused top-k: it selects the
per-row top-k of `scores` (ragged `seq_lens`) and writes the page-table transform
of the selected indices. Two limitations remain:

1. **The raw (pre-transform) index output is gated off in the indexer.** v2 is
   only used when `raw_indices is None`; any caller that also needs the raw
   selected positions falls back to v1 (`topk_transform_512`), which is markedly
   slower on long context. v2 already carries a `raw_out` pointer — it was simply
   not wired up on the raw-needing path.

2. **The small-batch cluster path leaves SMs idle on mid-batch long rows.** The
   fused small-batch kernel splits one row across a fixed 8-block cluster. An
   N-block cluster must be co-resident (DSMEM), so an 8-way split only stays a
   single cluster wave up to a batch proportional to `SM_count / 8`. Above that,
   mid-batch long-context launches either spill into a second wave or fall back
   to the persistent pool + streaming `main<3>`, both of which run the long rows
   over serial waves while most SMs sit idle (achieved occupancy ~50%).
<!-- Describe the purpose and goals of this pull request. -->

## Modifications

Two behavioral files plus one runtime helper; `topk_impl.cuh` is untouched.

### `indexer.py` — route `raw_indices` through v2

```diff
-elif envs.SGLANG_OPT_USE_TOPK_V2.get() and raw_indices is None:
+elif envs.SGLANG_OPT_USE_TOPK_V2.get():
     topk_transform_512_v2(
-        ..., indexer_metadata.topk_metadata,
+        ..., indexer_metadata.topk_metadata, raw_indices,
     )
```

`topk_transform_512_v2`'s signature already ends in `out_raw_indices: Optional`,
so raw-needing callers stay on v2 instead of dropping to v1. `raw_indices is None`
produces the identical page-only behavior as before.

### `topk_v2.cuh` — adaptive cluster-split factor N ∈ {8, 4, 2}

`topk_small_batch_kernel` is templated on the split factor:

```cpp
template <bool kPDL, uint32_t kNumRanks = kClusterSize>
TOPK_KERNEL __cluster_dims__(1, kNumRanks, 1) void topk_small_batch_kernel(...)
```

The body uses `ClusterT = impl::TopKCluster<kNumRanks>` and
`worker_rank = blockIdx.x % kNumRanks`; the epilogue and synchronization are
otherwise unchanged. `TopKCluster<N>` is already generalized to any power-of-two
N, so `topk_impl.cuh` needs no change and N ∈ {2, 4} reuse the existing
implementation.

The host selects N from `(batch_size, max_seq_len)` so the split stays a single
cluster wave, and falls back unchanged otherwise:

- **8-way** (large seq, small batch) — the original small-batch path.
- **4-way** — mid-batch band above the 8-way cap.
- **2-way** — lowest coordination cost (2-rank DSMEM all-reduce); the band above
  the 4-way cap and a lower seq floor.
- **else** — persistent pool + `main<3>`, identical to the current code, so no
  shape outside the split bands is perturbed.

Each split is bounded by a **batch cap** and a **seq floor**. Both are derived
from hardware and rescaled to the running device at launch:

- **Batch cap** scales with SM count (an N-block cluster must be co-resident, so
  the single-wave batch ceiling is proportional to the SM count).
- **Seq floor** scales with L2 cache size. The kernel scans each row twice (a
  radix pass to fix the threshold, then a gather pass); while a row fits in L2
  the second pass is an L2 re-read, but once it spills, the second pass re-reads
  from DRAM and a single streaming block becomes bandwidth-bound — which is where
  the split begins to pay off.

Thresholds are calibrated on sm_100 (152 SMs, 128 MB L2) and kept as kernel-side
`constexpr` anchors; the runtime scaling reproduces those values exactly on
sm_100 and routes by each device's own SM count and L2 size elsewhere, with
clamps so a smaller device cannot scale a cap below its neighbouring band or a
seq floor at/under the cluster floor. Routing only affects which path a shape
takes — every path computes the same top-k, so device scaling cannot change
results, only performance. This adds `host::runtime::get_l2_cache_size` in
`runtime.cuh` alongside the existing `get_sm_count`.

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

Validated against `torch.topk` (largest, per-row over `scores[i, :seq_len]`) with
**zero tolerance**: per-row top-k index-set equality plus matching `-1` padding,
for both the page-transformed output and the raw index output. The existing
`MAX_PERMIT_ERROR = 5` only forgives fp16-histogram equal-score tie swaps and is
unchanged.

`test/registered/kernels/ops/attention/test_topk_v2.py`: **296 passed** on B200
(244 existing + 52 new). The new `test_topk_v2_split` covers the 8/4/2-way bands,
each split's batch cap, the low-seq 2-way band, and the persistent-pool fallback
(batch/seq just outside every band), × k ∈ {512, 2048} × identity/perm page
tables, checking both the transformed and raw outputs against `torch.topk`.
Correctness is routing-independent, so these cases validate every split factor
regardless of which one a given device's scaled thresholds select.
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

CUDA-event median on B200 (sm_100); ratio = this PR / current v2, so **< 1 is
faster**. raw-index path (page-only tracks it):

| batch | seq    | ratio | note |
|------:|-------:|:-----:|:-----|
| 76 | 262144 | **0.62** | ~1.6× |
| 75 | 262144 | 0.73 | |
| 48 | 114688 | 0.74 | |
| 48 | 131072 | 0.76 | |
| 72 | 262144 | 0.77 | |
| 74 | 262144 | 0.78 | |
| 72 | 196608 | 0.81 | |
| 64 | 262144 | 0.92 | |
| 76 | 262144 | 0.62 | k=2048 |

Shapes outside the split bands (larger batch, short sequences) are dispatched
identically to the current code and stay within `0.95–1.02×` run-to-run noise.
NCU confirms the mechanism: a single split kernel in one cluster wave replaces
the baseline's persistent-pool multi-wave + `main<3>` chain. The page-only path
is neutral (~1.0×) — adding the raw output costs no measurable time.
<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->