### PR TITLE
[Fix] Mask the padded columns in apply_rotary_emb_flat_kernel

### DIFF
--- a/python/sglang/kernels/ops/attention/deepseek_v4_rope.py
+++ b/python/sglang/kernels/ops/attention/deepseek_v4_rope.py
@@ -204,6 +204,7 @@ def apply_rotary_emb_flat_kernel(
     sfr_d,
     USE_POS: tl.constexpr,
     IS_INVERSE: tl.constexpr,
+    ROPE_DIM: tl.constexpr,
     RD: tl.constexpr,
     RDH: tl.constexpr,
     BLOCK_ROWS: tl.constexpr,
@@ -219,16 +220,26 @@ def apply_rotary_emb_flat_kernel(
     rmask = row < n_rows
     tok = row // n_heads
     head = row % n_heads
+    # RD is ROPE_DIM rounded up to a power of two, so the columns from ROPE_DIM
+    # on are padding: clamp their addresses to stay inside x and freqs, and mask
+    # them out of the store below so they are neither rotated nor overwritten.
+    # Both are constexpr no-ops when ROPE_DIM is already a power of two.
     d = tl.arange(0, RD)
     base = tok[:, None] * sx_tok + head[:, None] * sx_head
-    xo = base + d[None, :] * sx_d
+    if ROPE_DIM == RD:
+        xo = base + d[None, :] * sx_d
+    else:
+        xo = base + tl.minimum(d, ROPE_DIM - 1)[None, :] * sx_d
     x = tl.load(x_ptr + xo, mask=rmask[:, None], other=0.0).to(tl.float32)
 
     if USE_POS:
         pos = tl.load(pos_ptr + tok, mask=rmask, other=0)
     else:
         pos = tok
-    cos_idx = (d // 2) * 2
+    if ROPE_DIM == RD:
+        cos_idx = (d // 2) * 2
+    else:
+        cos_idx = tl.minimum((d // 2) * 2, ROPE_DIM - 2)
     cos = tl.load(
         fr_ptr + pos[:, None] * sfr_pos + cos_idx[None, :] * sfr_d,
         mask=rmask[:, None],
@@ -251,7 +262,14 @@ def apply_rotary_emb_flat_kernel(
     x_rot = tl.reshape(x_neg, (BLOCK_ROWS, RD))
 
     out = x * cos + x_rot
-    tl.store(x_ptr + xo, out.to(x_ptr.dtype.element_ty), mask=rmask[:, None])
+    if ROPE_DIM == RD:
+        tl.store(x_ptr + xo, out.to(x_ptr.dtype.element_ty), mask=rmask[:, None])
+    else:
+        tl.store(
+            x_ptr + xo,
+            out.to(x_ptr.dtype.element_ty),
+            mask=rmask[:, None] & (d < ROPE_DIM)[None, :],
+        )
 
 
 # Use the batched / contiguous-load rope kernels (faster, coalesced) instead of the
@@ -311,6 +329,7 @@ def apply_rotary_emb_triton(
                 freqs_real.stride(1),
                 USE_POS=(positions is not None),
                 IS_INVERSE=inverse,
+                ROPE_DIM=rope_dim,
                 RD=RD,
                 RDH=RD // 2,
                 BLOCK_ROWS=FLAT_BLOCK_ROWS,

--- a/test/registered/kernels/ops/attention/test_deepseek_v4_rope_flat.py
+++ b/test/registered/kernels/ops/attention/test_deepseek_v4_rope_flat.py
@@ -1,0 +1,73 @@
+import sys
+
+import pytest
+import torch
+
+from sglang.kernels.ops.attention.deepseek_v4_rope import (
+    apply_rotary_emb_triton,
+    precompute_freqs_cis,
+    set_batched_rope,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=20, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+
+def _build(batch: int, n_heads: int, rope_dim: int):
+    torch.manual_seed(0)
+    x = torch.randn(batch, n_heads, rope_dim, device="cuda", dtype=torch.float32)
+    freqs = precompute_freqs_cis(rope_dim, batch, 0, 10000.0, 1.0, 32, 1).to("cuda")
+    return x, freqs
+
+
+def _apply(x, freqs, batched: bool):
+    previous = getattr(
+        sys.modules[apply_rotary_emb_triton.__module__], "_USE_BATCHED_ROPE"
+    )
+    set_batched_rope(batched)
+    try:
+        return apply_rotary_emb_triton(x.clone(), freqs)
+    finally:
+        set_batched_rope(previous)
+
+
+# rope_dim 6 / 96 / 192 are not powers of two, so the flat kernel pads its column
+# block to RD = next_power_of_2(rope_dim); those extra columns must not be read,
+# rotated or written back. 64 and 128 are the power-of-two controls.
+@pytest.mark.parametrize("rope_dim", [6, 64, 96, 128, 192])
+@pytest.mark.parametrize("batch,n_heads", [(4, 8), (2, 4)])
+class TestApplyRotaryEmbFlat:
+    def test_matches_per_token_kernel(self, rope_dim: int, batch: int, n_heads: int):
+        """The flat kernel must agree with the per-token kernel it replaces."""
+        x, freqs = _build(batch, n_heads, rope_dim)
+        reference = _apply(x, freqs, batched=False)
+        result = _apply(x, freqs, batched=True)
+        torch.testing.assert_close(result, reference, rtol=1e-5, atol=1e-5)
+
+    def test_leaves_padding_columns_alone(
+        self, rope_dim: int, batch: int, n_heads: int
+    ):
+        """The rotation must not reach past rope_dim into the next head's data."""
+        x, freqs = _build(batch, n_heads, rope_dim)
+        # A wider buffer whose tail columns are a known sentinel: anything the
+        # kernel writes past rope_dim lands on them.
+        padded = torch.full(
+            (batch, n_heads, 2 * rope_dim), -12345.0, device="cuda", dtype=torch.float32
+        )
+        padded[:, :, :rope_dim] = x
+        view = padded[:, :, :rope_dim]
+
+        set_batched_rope(True)
+        try:
+            apply_rotary_emb_triton(view, freqs)
+        finally:
+            set_batched_rope(False)
+
+        untouched = padded[:, :, rope_dim:]
+        assert torch.equal(
+            untouched, torch.full_like(untouched, -12345.0)
+        ), f"{int((untouched != -12345.0).sum())} sentinel elements past rope_dim were overwritten"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Motivation

Fixes #35096.

`apply_rotary_emb_flat_kernel` is launched with `RD = max(triton.next_power_of_2(rope_dim), 2)` and walks all `RD` columns under the row mask alone, so for a `rope_dim` that is not a power of two it reads, rotates and writes back the columns from `rope_dim` to `RD - 1`. The kernel works in place, so those stores land on the next head's data and, on the final row, past the end of the tensor. Both sibling kernels in this file mask the column axis against `rope_dim` (`:102`, `:154`), and `_fused_norm_rope_kernel` further down already takes the real width as a `ROPE_DIM: tl.constexpr` and masks with it (`:410`, `:438`).

This is latent on what ships today — DeepSeek-V4 uses a power-of-two `rope_dim` and the flat path is opt-in via `set_batched_rope(True)` / `SGLANG_ROPE_BATCHED=1` — so no current configuration is affected. The change makes the kernel consistent with the width it is already given.

## Modifications

- `apply_rotary_emb_flat_kernel` takes `ROPE_DIM: tl.constexpr`, matching the spelling `_fused_norm_rope_kernel` already uses in this file.
- The padded columns' addresses are clamped (`tl.minimum(d, ROPE_DIM - 1)`, and `tl.minimum((d // 2) * 2, ROPE_DIM - 2)` for the `cos`/`sin` index) so the loads stay inside `x` and `freqs`, and the store masks them out so nothing past `rope_dim` is written.
- Both guards sit behind `if ROPE_DIM == RD:`, which is a compile-time constant. For every power-of-two `rope_dim` — i.e. everything in the tree today — the emitted kernel is unchanged.

Clamping rather than masking the loads is deliberate: a first attempt that took the width as a *runtime* argument and masked the loads cost **3.4x** on the production shape (71.3 us → 242.9 us at `8192x128x64`), because the compiler could no longer prove the column addressing contiguous. The constexpr-plus-clamp form is free (numbers below).

## Accuracy Tests

New `test/registered/kernels/ops/attention/test_deepseek_v4_rope_flat.py`, 20 cases (`rope_dim` ∈ {6, 64, 96, 128, 192} × two shapes × two tests):

- `test_matches_per_token_kernel` — the flat kernel against the per-token kernel the same public call selects.
- `test_leaves_padding_columns_alone` — `x` is a view into a wider buffer whose tail columns hold a sentinel, so any write past `rope_dim` is visible.

All 20 pass with this change. Reverting the kernel and keeping the tests fails 9 — every non-power-of-two case — and passes the 11 power-of-two ones:

| | `rope_dim` 6 / 96 / 192 | `rope_dim` 64 / 128 |
|---|---|---|
| before | 9 failed | pass |
| after | pass | pass |

Measured against the per-token kernel at `batch=4, n_heads=8`: `rope_dim=6` was `max|flat - per_token| = 3.81` (48 of 192 elements) and is now `0.0000`. Under `compute-sanitizer --tool memcheck`, `rope_dim=6` reported invalid reads 5 bytes past the `freqs` allocation at `:238` and `rope_dim=96` 1 byte past `x` at `:225`, each followed by `unspecified launch failure`; both are `ERROR SUMMARY: 0 errors` after.

No model-level eval was run: with `rope_dim` a power of two the kernel compiles to the same code, so no shipped path changes output.

## Speed Tests and Profiling

`triton.testing.do_bench` on an NVIDIA B200, bf16, three interleaved before/after rounds (min–max across rounds):

| shape | before | after |
|---|---|---|
| 8192 × 128 × 64 (pow2, the production rope) | 71.32 – 71.34 us | 71.28 – 71.37 us |
| 8192 × 128 × 128 (pow2) | 151.30 – 151.32 us | 151.32 – 151.39 us |
| 4096 × 128 × 64 (pow2) | 39.21 – 39.25 us | 39.22 – 39.24 us |
| 2048 × 32 × 96 (not pow2) | 16.75 – 16.78 us | 16.33 – 16.34 us |

Neutral where it must be, and slightly faster on the non-power-of-two shape: clamping makes the padded lanes re-read one in-bounds element instead of walking off the row.

## Checklist

- [x] Format your code according to [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

`isort`, `black` and the repo's `ruff` selection are clean on both files. Documentation is unticked because the change is internal to a kernel.

## Environment

- `sgl-project/sglang` at `92b1d382c`
- NVIDIA B200 (sm_100), driver 595.71.05
- torch 2.13.0+cu130, triton 3.7.1, Python 3.12

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31998217502](https://github.com/sgl-project/sglang/actions/runs/31998217502)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31998217335](https://github.com/sgl-project/sglang/actions/runs/31998217335)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->