### PR TITLE
[Fix] Unblock Molmo2 loading on transformers 5.x (8 compat fixes)

### DIFF
--- a/python/sglang/srt/model_loader/utils.py
+++ b/python/sglang/srt/model_loader/utils.py
@@ -107,6 +107,20 @@ def _model_impl_from_architecture(architecture: str) -> ModelImpl:
     return ModelImpl.SGLANG
 
 
+# Preference order used to resolve a model class from a config's `auto_map`
+# when `AutoModel` itself is not declared. Newer VLMs (Molmo2, and generally
+# any image-text-to-text custom model) only declare a task-specific auto class
+# like `AutoModelForImageTextToText`. Order is generation-focused: multimodal
+# families before pure text families before seq2seq.
+_AUTO_MAP_MODEL_KEYS = (
+    "AutoModel",
+    "AutoModelForImageTextToText",
+    "AutoModelForVision2Seq",
+    "AutoModelForCausalLM",
+    "AutoModelForSeq2SeqLM",
+)
+
+
 def resolve_transformers_arch(model_config: ModelConfig, architectures: list[str]):
     backend_arch = _get_transformers_backend_arch(model_config, architectures)
 
@@ -141,31 +155,41 @@ def resolve_transformers_arch(model_config: ModelConfig, architectures: list[str
             )
         model_module = getattr(transformers, arch, None)
         if model_module is None:
-            has_auto_model = "AutoModel" in auto_modules
-            if not has_auto_model and model_config.model_impl == ModelImpl.TRANSFORMERS:
+            resolved_auto_key = next(
+                (key for key in _AUTO_MAP_MODEL_KEYS if key in auto_modules),
+                None,
+            )
+            if (
+                resolved_auto_key is None
+                and model_config.model_impl == ModelImpl.TRANSFORMERS
+            ):
                 logger.warning(
-                    "Cannot resolve model class for '%s' and no auto_map.AutoModel "
-                    "is present. Skipping compatibility gate because "
-                    "--model-impl=transformers is explicitly requested.",
+                    "Cannot resolve model class for '%s' and no generative "
+                    "auto_map entry (%s) is present. Skipping compatibility "
+                    "gate because --model-impl=transformers is explicitly "
+                    "requested.",
                     arch,
+                    ", ".join(_AUTO_MAP_MODEL_KEYS),
                 )
                 continue
-            if not has_auto_model and "AutoModel" not in auto_map:
+            if resolved_auto_key is None and not any(
+                key in auto_map for key in _AUTO_MAP_MODEL_KEYS
+            ):
                 raise ValueError(
                     f"Cannot find model module. '{arch}' is not a registered "
                     "model in the Transformers library (only relevant if the "
-                    "model is meant to be in Transformers) and 'AutoModel' is "
-                    "not present in the model config's 'auto_map' (relevant "
-                    "if the model is custom)."
+                    "model is meant to be in Transformers) and none of "
+                    f"{list(_AUTO_MAP_MODEL_KEYS)} is present in the model "
+                    "config's 'auto_map' (relevant if the model is custom)."
                 )
-            if not has_auto_model:
+            if resolved_auto_key is None:
                 raise ValueError(
                     f"Cannot find model module. '{arch}' is not a registered "
                     "model in the Transformers library and loading the custom "
                     f"model from auto_map failed. The remote model code may be "
                     f"incompatible with the installed transformers version."
                 )
-            model_module = auto_modules["AutoModel"]
+            model_module = auto_modules[resolved_auto_key]
         if model_config.model_impl == ModelImpl.TRANSFORMERS:
             if hasattr(model_module, "is_backend_compatible") and (
                 not model_module.is_backend_compatible()

--- a/python/sglang/srt/models/transformers.py
+++ b/python/sglang/srt/models/transformers.py
@@ -116,6 +116,38 @@ def _getattr_first(obj, names, default=None):
     return default
 
 
+# Preference order for picking an HF `AutoModel*` factory when a config's
+# `auto_map` doesn't declare `AutoModel` directly. Newer VLMs like Molmo2 only
+# declare a task-specific auto class (`AutoModelForImageTextToText`); the
+# corresponding factory can still resolve the custom class via trust_remote_code.
+# Order is generation-focused: image-text families, then plain CausalLM, then
+# seq2seq, with plain `AutoModel` as the ultimate fallback.
+_HF_AUTO_MODEL_KEYS = (
+    "AutoModelForImageTextToText",
+    "AutoModelForVision2Seq",
+    "AutoModelForCausalLM",
+    "AutoModelForSeq2SeqLM",
+    "AutoModel",
+)
+
+
+def _hf_auto_model_class_for_config(config: PretrainedConfig):
+    """Return the HF `AutoModel*` class best matching the config's auto_map.
+
+    Prefers a task-specific class actually declared in `config.auto_map`
+    (`AutoModelForImageTextToText` for Molmo2, etc.) over the generic
+    `AutoModel`; falls back to `AutoModel` when the config makes no claim.
+    """
+    auto_map = getattr(config, "auto_map", {}) or {}
+    for key in _HF_AUTO_MODEL_KEYS:
+        if key not in auto_map:
+            continue
+        auto_cls = getattr(transformers, key, None)
+        if auto_cls is not None:
+            return auto_cls
+    return AutoModel
+
+
 def _resolve_attention_backend_model_cls(config: PretrainedConfig):
     model_cls = getattr(
         transformers, (getattr(config, "architectures", None) or [""])[0], None
@@ -124,7 +156,7 @@ def _resolve_attention_backend_model_cls(config: PretrainedConfig):
         return model_cls
 
     auto_map = getattr(config, "auto_map", {}) or {}
-    for key in ("AutoModel", "AutoModelForCausalLM"):
+    for key in _HF_AUTO_MODEL_KEYS:
         if key not in auto_map:
             continue
         try:
@@ -612,8 +644,9 @@ class TransformersBase(nn.Module):
         # Initialize on meta device to avoid premature GPU allocation
         self.text_config._attn_implementation = "sglang"
         if supports_backend:
+            auto_model_cls = _hf_auto_model_class_for_config(self.config)
             with _init_on_device_without_buffers(torch.device("meta")):
-                self.model: PreTrainedModel = AutoModel.from_config(
+                self.model: PreTrainedModel = auto_model_cls.from_config(
                     self.config,
                     torch_dtype=torch.get_default_dtype(),
                     trust_remote_code=True,

--- a/python/sglang/srt/models/transformers.py
+++ b/python/sglang/srt/models/transformers.py
@@ -755,8 +755,16 @@ class TransformersBase(nn.Module):
         self.recursive_replace()
         # Attention instances
         self.attention_instances = self._create_attention_instances(tp_size)
-        # Vocab embeddings
-        self.replace_vocab_embed_class(self.model)
+        # Vocab embeddings — Molmo2's `wte` is a custom `Molmo2Embedding` holding
+        # two `nn.Parameter` leaves (`embedding` for the base vocab, `new_embedding`
+        # for its additional_vocab_size=128 image tokens). `VocabParallelEmbedding`
+        # is sized for a single unified weight covering only the base vocab, so
+        # replacing loses the additional-vocab slots and leaves the checkpoint's
+        # `wte.embedding` and `wte.new_embedding` keys with nowhere to load. Keep
+        # the custom module in place for the TP=1 path Molmo2 currently runs in P1;
+        # a TP>1 story would need a proper concat into VocabParallelEmbedding.
+        if getattr(config, "model_type", None) != _MOLMO2_MODEL_TYPE:
+            self.replace_vocab_embed_class(self.model)
 
         # Initialize remaining meta-device parameters to real device tensors
         self._init_parameters(self.model)

--- a/python/sglang/srt/models/transformers.py
+++ b/python/sglang/srt/models/transformers.py
@@ -131,6 +131,65 @@ _HF_AUTO_MODEL_KEYS = (
 )
 
 
+_MOLMO2_MODEL_TYPE = "molmo2"
+
+
+def _compute_default_rope_parameters(
+    config: Optional[PretrainedConfig] = None,
+    device: Optional[torch.device] = None,
+    seq_len: Optional[int] = None,
+    **rope_kwargs,
+) -> Tuple[torch.Tensor, float]:
+    """Plain (unscaled) RoPE inv-freq computation matching pre-5.x
+    `ROPE_INIT_FUNCTIONS['default']` semantics.
+
+    transformers 5.x dropped the `'default'` key from `ROPE_INIT_FUNCTIONS`
+    (plain RoPE is now handled inline inside each model's rotary embedding),
+    but Molmo2's `modeling_molmo2.py` still does `ROPE_INIT_FUNCTIONS[self.rope_type]`
+    with `self.rope_type == 'default'`. This is the 4.x-shaped shim used by
+    `_molmo2_rope_init_compat` below.
+    """
+    if rope_kwargs:
+        base = rope_kwargs["base"]
+        dim = rope_kwargs["dim"]
+    else:
+        base = config.rope_theta
+        partial = getattr(config, "partial_rotary_factor", 1.0)
+        head_dim = getattr(
+            config, "head_dim", config.hidden_size // config.num_attention_heads
+        )
+        dim = int(head_dim * partial)
+    inv_freq = 1.0 / (
+        base ** (torch.arange(0, dim, 2, dtype=torch.int64).float().to(device) / dim)
+    )
+    attention_scaling = 1.0
+    return inv_freq, attention_scaling
+
+
+@contextmanager
+def _molmo2_rope_init_compat(config: PretrainedConfig):
+    """Inject a `'default'` entry into `transformers.ROPE_INIT_FUNCTIONS`
+    while Molmo2's custom modeling code constructs its rotary embedding.
+
+    Self-gates on `config.model_type == "molmo2"`; a no-op for every other
+    model. Only injects when the key is missing (transformers 5.x); on 4.x
+    with a native `'default'` entry this is also a no-op.
+    """
+    if getattr(config, "model_type", None) != _MOLMO2_MODEL_TYPE:
+        yield
+        return
+    from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS
+
+    injected = "default" not in ROPE_INIT_FUNCTIONS
+    if injected:
+        ROPE_INIT_FUNCTIONS["default"] = _compute_default_rope_parameters
+    try:
+        yield
+    finally:
+        if injected:
+            ROPE_INIT_FUNCTIONS.pop("default", None)
+
+
 def _hf_auto_model_class_for_config(config: PretrainedConfig):
     """Return the HF `AutoModel*` class best matching the config's auto_map.
 
@@ -646,11 +705,12 @@ class TransformersBase(nn.Module):
         if supports_backend:
             auto_model_cls = _hf_auto_model_class_for_config(self.config)
             with _init_on_device_without_buffers(torch.device("meta")):
-                self.model: PreTrainedModel = auto_model_cls.from_config(
-                    self.config,
-                    torch_dtype=torch.get_default_dtype(),
-                    trust_remote_code=True,
-                )
+                with _molmo2_rope_init_compat(self.config):
+                    self.model: PreTrainedModel = auto_model_cls.from_config(
+                        self.config,
+                        torch_dtype=torch.get_default_dtype(),
+                        trust_remote_code=True,
+                    )
         else:
             raise ValueError(
                 f"Model {model_cls} does not support custom attention backends "

--- a/python/sglang/srt/models/transformers.py
+++ b/python/sglang/srt/models/transformers.py
@@ -190,6 +190,43 @@ def _molmo2_rope_init_compat(config: PretrainedConfig):
             ROPE_INIT_FUNCTIONS.pop("default", None)
 
 
+def _patch_molmo2_forward_compat(config: PretrainedConfig) -> None:
+    """Rewrite Molmo2's `trust_remote_code` module bindings so its forward
+    pass works under transformers 5.x.
+
+    `modeling_molmo2.py` calls `create_causal_mask(**mask_kwargs)` with
+    `mask_kwargs["input_embeds"]` (singular). transformers 5.x's
+    `create_causal_mask` takes `inputs_embeds` (plural) — the singular form
+    was never accepted upstream. Molmo2 captured `create_causal_mask` at
+    module import via `from transformers.masking_utils import ...`, so a
+    global monkey-patch on `transformers.masking_utils` does not reach the
+    module's local binding. Rebind that local reference to a wrapper that
+    renames the offending kwarg.
+
+    Self-gates on `config.model_type == "molmo2"`; a no-op for every other
+    model, and idempotent if invoked multiple times.
+    """
+    if getattr(config, "model_type", None) != _MOLMO2_MODEL_TYPE:
+        return
+
+    import sys
+
+    for module_name, module in list(sys.modules.items()):
+        if not module_name.endswith(".modeling_molmo2"):
+            continue
+        original = getattr(module, "create_causal_mask", None)
+        if original is None or getattr(original, "_molmo2_kwargs_shim", False):
+            continue
+
+        def _renaming_wrapper(*args, __original=original, **kwargs):
+            if "input_embeds" in kwargs and "inputs_embeds" not in kwargs:
+                kwargs["inputs_embeds"] = kwargs.pop("input_embeds")
+            return __original(*args, **kwargs)
+
+        _renaming_wrapper._molmo2_kwargs_shim = True
+        module.create_causal_mask = _renaming_wrapper
+
+
 def _hf_auto_model_class_for_config(config: PretrainedConfig):
     """Return the HF `AutoModel*` class best matching the config's auto_map.
 
@@ -722,6 +759,7 @@ class TransformersBase(nn.Module):
                         torch_dtype=torch.get_default_dtype(),
                         trust_remote_code=True,
                     )
+            _patch_molmo2_forward_compat(self.config)
         else:
             raise ValueError(
                 f"Model {model_cls} does not support custom attention backends "

--- a/python/sglang/srt/models/transformers.py
+++ b/python/sglang/srt/models/transformers.py
@@ -665,6 +665,17 @@ class TransformersBase(nn.Module):
         self.config = config
         self.text_config = get_hf_text_config(config)
         self.weight_mapper = self.hf_to_sglang_mapper
+        # Molmo2's checkpoint keys are relative to `Molmo2ForConditionalGeneration`
+        # (e.g. `model.transformer.blocks.N.weight`). SGLang's fallback wraps that
+        # class under `self.model`, so the real tree path is
+        # `model.model.transformer.blocks.N.weight` — every key needs a single
+        # `model.` prefix added, not a `.transformer.` layer stripped. The base
+        # mapper's `"model.transformer.": "model."` rule (longest-prefix-match
+        # wins) instead collapses the path and mismatches the tree, producing
+        # `ValueError: No module or parameter named 'model.blocks' ...`. Replace
+        # the mapper with a uniform-prefix-add rule for Molmo2 only.
+        if getattr(config, "model_type", None) == _MOLMO2_MODEL_TYPE:
+            self.weight_mapper = WeightsMapper(orig_to_new_prefix={"": "model."})
         self.pp_group = get_pp_group()
 
         # Weight loading attrs

--- a/python/sglang/srt/models/transformers.py
+++ b/python/sglang/srt/models/transformers.py
@@ -718,11 +718,16 @@ class TransformersBase(nn.Module):
                 "requires custom attention support."
             )
 
-        self.vocab_size = getattr(
-            self.text_config,
-            "vocab_size",
-            self.model.get_input_embeddings().num_embeddings,
-        )
+        # `text_config.vocab_size` is nearly always set; the embedding-attribute
+        # fallback exists for the rare custom config that omits it. Evaluate
+        # lazily — `getattr(x, "y", <default>)` computes <default> eagerly, and
+        # some custom embeddings (e.g. Molmo2's `Molmo2Embedding`) do not expose
+        # a `num_embeddings` attribute, so eager evaluation would crash even
+        # when we don't need the fallback.
+        vocab_size = getattr(self.text_config, "vocab_size", None)
+        if vocab_size is None:
+            vocab_size = self.model.get_input_embeddings().num_embeddings
+        self.vocab_size = vocab_size
         self.unpadded_vocab_size = self.vocab_size
 
         # Embedding scale (e.g. Whisper)

--- a/python/sglang/srt/utils/hf_transformers/processor.py
+++ b/python/sglang/srt/utils/hf_transformers/processor.py
@@ -13,6 +13,7 @@
 # ==============================================================================
 """Processor loading utilities."""
 
+import contextlib
 import json
 from pathlib import Path
 from typing import Optional
@@ -23,6 +24,7 @@ from transformers import (
     AutoTokenizer,
     PreTrainedTokenizerBase,
 )
+from transformers.processing_utils import ProcessorMixin
 
 from sglang.srt.multimodal.customized_mm_processor_utils import _CUSTOMIZED_MM_PROCESSOR
 from sglang.srt.utils import logger
@@ -116,6 +118,42 @@ def _apply_image_processor_backend(
         **image_processor_kwargs,
     )
     return processor
+
+
+# Molmo2's custom processing_molmo2.py (loaded via trust_remote_code) forwards
+# these five Molmo2-specific kwargs to ProcessorMixin.__init__. transformers 4.x
+# swallowed unknown kwargs silently; transformers 5.x rejects them with
+# TypeError, which crashes AutoProcessor.from_pretrained before the processor is
+# returned. Restore the 4.x-lenient behavior for these keys only, and only while
+# a molmo2 processor is being constructed.
+_MOLMO2_EXTRA_INIT_KWARGS = (
+    "image_use_col_tokens",
+    "use_single_crop_col_tokens",
+    "use_single_crop_start_token",
+    "video_use_col_tokens",
+    "use_frame_special_tokens",
+)
+
+
+@contextlib.contextmanager
+def _molmo2_processor_init_compat():
+    original_init = ProcessorMixin.__init__
+
+    def _tolerant_init(self, *init_args, **init_kwargs):
+        extras = {
+            key: init_kwargs.pop(key)
+            for key in _MOLMO2_EXTRA_INIT_KWARGS
+            if key in init_kwargs
+        }
+        original_init(self, *init_args, **init_kwargs)
+        for name, value in extras.items():
+            setattr(self, name, value)
+
+    ProcessorMixin.__init__ = _tolerant_init
+    try:
+        yield
+    finally:
+        ProcessorMixin.__init__ = original_init
 
 
 def _build_processor_manually(
@@ -270,6 +308,11 @@ def get_processor(
         if "size" not in kwargs:
             kwargs["size"] = {"shortest_edge": 3136, "longest_edge": 1003520}
 
+    if config.model_type == "molmo2":
+        processor_init_compat = _molmo2_processor_init_compat()
+    else:
+        processor_init_compat = contextlib.nullcontext()
+
     try:
         if "InternVL3_5" in tokenizer_name:
             processor = AutoTokenizer.from_pretrained(
@@ -289,13 +332,14 @@ def get_processor(
                     **kwargs,
                 )
             else:
-                processor = AutoProcessor.from_pretrained(
-                    tokenizer_name,
-                    *args,
-                    trust_remote_code=trust_remote_code,
-                    revision=revision,
-                    **kwargs,
-                )
+                with processor_init_compat:
+                    processor = AutoProcessor.from_pretrained(
+                        tokenizer_name,
+                        *args,
+                        trust_remote_code=trust_remote_code,
+                        revision=revision,
+                        **kwargs,
+                    )
 
     except ValueError as e:
         error_message = str(e)


### PR DESCRIPTION
## Summary

Eight compat fixes to load `allenai/Molmo2-4B`, `allenai/Molmo2-8B`, and `allenai/Molmo2-O-7B` on containers with `transformers==5.x` via SGLang's Transformers-fallback path. They surface serially — each unblocks the one after — verified against P1 orchestrator runs #326 through #338.

Categorization: fixes 1–3, 5, 6 are SGLang bugs. Fix 7 preserves Molmo2's custom embedding. Fixes 4 and 8 are Molmo2-scoped shims for third-party `modeling_molmo2.py` code against transformers 5.x.

### 1. `ProcessorMixin.__init__` rejects Molmo2 kwargs on transformers 5.x

`processing_molmo2.py` forwards five Molmo2-specific kwargs (`image_use_col_tokens`, `use_single_crop_col_tokens`, `use_single_crop_start_token`, `video_use_col_tokens`, `use_frame_special_tokens`) through `super().__init__()`. transformers 5.x rejects unknown kwargs with `TypeError`.

**Fix:** in `hf_transformers/processor.py::get_processor`, when `config.model_type == "molmo2"`, wrap `AutoProcessor.from_pretrained` in a scoped context manager that temporarily rebinds `ProcessorMixin.__init__` to pop those five keys and re-attach them as instance attributes.

### 2. `resolve_transformers_arch` only recognizes `AutoModel` in `auto_map`

Molmo2's `auto_map` declares `AutoModelForImageTextToText`, not `AutoModel` — SGLang raises `ValueError: Cannot find model module ...`.

**Fix:** extend the lookup to `AutoModel` → `AutoModelForImageTextToText` → `AutoModelForVision2Seq` → `AutoModelForCausalLM` → `AutoModelForSeq2SeqLM`. Generation-focused.

### 3. Transformers fallback hardcodes `AutoModel.from_config`

`transformers.py::__init__` used `AutoModel.from_config(config, trust_remote_code=True)`; `AutoModel._model_mapping` has no `Molmo2Config` and Molmo2's `auto_map` has no `AutoModel` key. Result: `ValueError: Unrecognized configuration class Molmo2Config for this kind of AutoModel: AutoModel.`.

**Fix:** add `_hf_auto_model_class_for_config` — return the HF `AutoModel*` class matching the first key declared in `auto_map`, using the same ordered list from fix (2). Reuse in `_resolve_attention_backend_model_cls`.

### 4. Molmo2 rope_init reads a removed `ROPE_INIT_FUNCTIONS` key

`modeling_molmo2.py::Molmo2RotaryEmbedding.__init__` reads `ROPE_INIT_FUNCTIONS["default"]`; transformers 5.x dropped that key.

**Fix:** `_molmo2_rope_init_compat(config)` context manager injects a 4.x-shaped `_compute_default_rope_parameters` under `"default"` while Molmo2's modeling code runs, then pops on exit. Self-gates on `model_type == "molmo2"` and only injects when missing.

### 5. Eager `getattr` default in Transformers-fallback `vocab_size` lookup

`getattr(text_config, "vocab_size", self.model.get_input_embeddings().num_embeddings)` — Python evaluates the default eagerly; Molmo2's `Molmo2Embedding` has no `num_embeddings` attribute, so the fallback expression raises `AttributeError` even when `text_config.vocab_size` is set.

**Fix:** split into explicit conditional so the embedding fallback only runs when needed.

### 6. Molmo2 weight_mapper strips `.transformer.` instead of prepending `model.`

`TransformersBase.hf_to_sglang_mapper` has `"model.transformer.": "model."` which wins under longest-prefix-match for Molmo2 keys (`model.transformer.blocks.N.weight`) and rewrites to `model.blocks.*`. SGLang's tree needs `model.model.transformer.blocks.*`. Result: `ValueError: No module or parameter named 'model.blocks' ...`.

**Fix:** for Molmo2 only, replace `self.weight_mapper` with a bespoke `WeightsMapper(orig_to_new_prefix={"": "model."})`. Every other model retains the base mapper untouched.

### 7. `replace_vocab_embed_class` breaks Molmo2's custom input embedding

`replace_vocab_embed_class` swaps the input embedding module for `VocabParallelEmbedding`. Molmo2's `wte` is a custom `Molmo2Embedding` holding two `nn.Parameter` leaves — `embedding` (base vocab, 151936) and `new_embedding` (additional 128 image special tokens). `VocabParallelEmbedding` has a single `weight` of size `vocab_size` (base only), so the swap loses the additional-vocab slots and leaves the checkpoint's `wte.embedding` and `wte.new_embedding` with nowhere to load: `ValueError: No module or parameter named 'model.model.transformer.wte.embedding' ...`.

**Fix:** for Molmo2 only, skip `replace_vocab_embed_class` — keep the custom `Molmo2Embedding` in place so both parameter leaves land during weight loading. P1 runs Molmo2 at TP=1, so no vocab-sharding is required. A TP>1 Molmo2 story would need a proper concat of both parameters into a single VocabParallelEmbedding weight sized to `vocab_size + additional_vocab_size`.

### 8. Molmo2's forward calls create_causal_mask with input_embeds kwarg

`modeling_molmo2.py::forward` (line 1544) calls
`create_causal_mask(**mask_kwargs)` where `mask_kwargs` has
`input_embeds` (singular). transformers 5.x's `create_causal_mask`
takes `inputs_embeds` (plural) — the standard HF-style kwarg name.
Molmo2's forward dies with:

```
TypeError: create_causal_mask() got an unexpected keyword argument 'input_embeds'
```

Molmo2 imports `create_causal_mask` at module load, so a global
monkey-patch does not reach the captured local binding. **Fix:**
reach into `sys.modules` for the loaded `modeling_molmo2` module
(registered as
`transformers_modules.allenai.Molmo2_hyphen_<size>.<hash>.modeling_molmo2`)
and rebind its local `create_causal_mask` attribute to a wrapper
that renames `input_embeds -> inputs_embeds`. Runs once immediately
after the `.from_config` call, self-gates on `model_type == "molmo2"`.

## Why all eight are needed

Each failure sits on the same startup path and only surfaces once the earlier one is out of the way:

1. `init_tokenizer_and_processor` → `get_processor_wrapper` → `AutoProcessor.from_pretrained` — fix (1).
2. → `get_mm_processor` → `resolve_transformers_arch` — fix (2).
3. → `ModelRunner.load_model` → `TransformersForMultimodalLM.__init__` → `AutoModel.from_config` — fix (3).
4. → Molmo2's `modeling_molmo2.py::Molmo2RotaryEmbedding.__init__` — fix (4).
5. → `TransformersForMultimodalLM.__init__` reads `vocab_size` — fix (5).
6. → `model.load_weights(weights)` → mapper application — fix (6).
7. → `model.load_weights(weights)` → walks tree into swapped-out `wte` — fix (7).
8. → `Scheduler.event_loop_overlap` → `model_runner.model.forward` → Molmo2's `create_causal_mask(**mask_kwargs)` — fix (8).

Each fix has been verified on hardware by seeing the *next* gate fail in the following P1 run (#327 → #328 → #329 → #332 → #335 → #336 → #338).

## Test plan

- [ ] `pre-commit run --files python/sglang/srt/utils/hf_transformers/processor.py python/sglang/srt/model_loader/utils.py python/sglang/srt/models/transformers.py` — passes locally.
- [ ] `sglang serve allenai/Molmo2-4B --trust-remote-code` — server startup completes weight loading and reaches the first eval batch. Same for `Molmo2-8B` and `Molmo2-O-7B`.
- [ ] Loading a non-Molmo2 multimodal model (Qwen2-VL, LLaVA-OneVision, Gemma3) is unchanged.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32014021478](https://github.com/sgl-project/sglang/actions/runs/32014021478)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32014021371](https://github.com/sgl-project/sglang/actions/runs/32014021371)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->