### PR TITLE
[Fix] Normalize grayscale JPEGs in GPU image decoding

### DIFF
--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -92,7 +92,7 @@ from starlette.routing import Mount
 from torch import nn
 from torch.library import Library
 from torch.utils._contextlib import _DecoratorContextManager
-from torchvision.io import decode_jpeg
+from torchvision.io import ImageReadMode, decode_jpeg
 from typing_extensions import Literal
 
 from sglang.srt.environ import envs
@@ -1845,7 +1845,9 @@ def _load_image(
 
                 return decode_jpeg_with_fancy_upsampling(image_bytes)
             encoded_image = torch.frombuffer(image_bytes, dtype=torch.uint8)
-            image_tensor = decode_jpeg(encoded_image, device="cuda")
+            image_tensor = decode_jpeg(
+                encoded_image, mode=ImageReadMode.RGB, device="cuda"
+            )
             return image_tensor
         except Exception as e:
             if gpu_image_decode == "nvjpeg_fancy":

--- a/test/registered/unit/multimodal/test_base_processor_image_decode.py
+++ b/test/registered/unit/multimodal/test_base_processor_image_decode.py
@@ -1,12 +1,7 @@
-"""Unit tests for ``BaseMultimodalProcessor._load_single_item`` image decoding.
+"""Unit tests for the image decode paths used by ``BaseMultimodalProcessor``.
 
-Regression test for the change that forces the (otherwise lazy) PIL decode inside
-``_load_single_item`` — which runs in the ``io_executor`` worker thread — instead of
-letting it fire lazily on the main event-loop thread later (inside
-``pil_to_tensor``/``tobytes`` during processing). The behavior of the returned image
-(mode, pixels) must be unchanged; only *when/where* the decode happens differs.
-
-No server, no model loading — pure CPU.
+The tests cover eager PIL decoding in the I/O worker and JPEG channel normalization
+in the GPU fast paths. No server or model weights are required.
 """
 
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -52,10 +47,12 @@ def _png_bytes(mode: str = "RGB", size=(8, 8)) -> bytes:
     return buf.getvalue()
 
 
-def _jpeg_bytes(size=(8, 8)) -> bytes:
+def _jpeg_bytes(mode: str = "RGB", size=(8, 8)) -> bytes:
     arr = (np.random.RandomState(0).rand(size[1], size[0], 3) * 255).astype("uint8")
     buf = io.BytesIO()
-    Image.fromarray(arr, "RGB").save(buf, format="JPEG", quality=90, subsampling=2)
+    Image.fromarray(arr, "RGB").convert(mode).save(
+        buf, format="JPEG", quality=90, subsampling=2
+    )
     return buf.getvalue()
 
 
@@ -148,6 +145,29 @@ class TestLoadSingleItemImageDecode(CustomTestCase):
 
         self.assertIs(image, expected)
         decode.assert_called_once_with(data)
+
+    def test_standard_gpu_jpeg_decoder_normalizes_grayscale_to_rgb(self):
+        decode_jpeg = common.decode_jpeg
+
+        def decode_on_cpu(encoded_image, *, mode, device):
+            # Keep the test deterministic on CPU while checking the arguments used
+            # by the production CUDA path and exercising torchvision's conversion.
+            self.assertEqual(mode, common.ImageReadMode.RGB)
+            self.assertEqual(device, "cuda")
+            return decode_jpeg(encoded_image, mode=mode, device="cpu")
+
+        with (
+            patch.object(common, "is_cuda", return_value=True),
+            patch.object(common, "decode_jpeg", side_effect=decode_on_cpu),
+        ):
+            images = [
+                common._load_image(image_bytes=_jpeg_bytes(mode), gpu_image_decode=True)
+                for mode in ("L", "RGB")
+            ]
+
+        self.assertTrue(all(isinstance(image, torch.Tensor) for image in images))
+        self.assertEqual([tuple(image.shape) for image in images], [(3, 8, 8)] * 2)
+        self.assertEqual(tuple(torch.stack(images).shape), (2, 3, 8, 8))
 
     def test_high_fidelity_gpu_jpeg_decoder_falls_back_to_pil(self):
         data = _jpeg_bytes()


### PR DESCRIPTION
## Motivation

The torchvision CUDA JPEG decoder defaults to `ImageReadMode.UNCHANGED`, so grayscale JPEGs are decoded as `[1, H, W]` tensors while RGB JPEGs are decoded as `[3, H, W]`. The GPU-decoded tensors bypass the PIL `convert("RGB")` path in `BaseMultimodalProcessor`, causing mixed grayscale and RGB inputs to fail when an image processor stacks them.

This can return HTTP 500 for multimodal requests and can also fail later in a vision encoder that expects three input channels.

Related to #26751 and #28828. This change is based on the current `main` branch and keeps the high-fidelity `nvjpeg_fancy` path introduced by #34163 unchanged because that decoder already requests planar RGB output.

## Modifications

- Request `ImageReadMode.RGB` from the standard torchvision CUDA JPEG decoder.
- Add a deterministic CPU unit test that exercises torchvision's RGB conversion while verifying the arguments used by the CUDA path.
- Cover mixed grayscale/RGB JPEG shapes and confirm that the resulting tensors can be stacked.

## Accuracy Tests

- Environment: NVIDIA H20, PyTorch `2.11.0+cu130`, torchvision `0.26.0+cu130`.
- The unmodified GPU decode mode produced `[1, 640, 384]` for a grayscale JPEG and `[3, 640, 384]` for an RGB JPEG, reproducing the reported `torch.stack` error.
- The patched SGLang `_load_image` path produced two `[3, 640, 384]` CUDA tensors and stacked them into `[2, 3, 640, 384]` successfully.
- Random RGB JPEGs decoded with `UNCHANGED` and `RGB` were pixel-identical on GPU. For random grayscale JPEGs, all three RGB output channels were pixel-identical to the original luminance channel.
- `PYTHONPATH=python python3 test/registered/unit/multimodal/test_base_processor_image_decode.py -v` — 12 tests passed.
- `PYTHONPATH=python python3 test/registered/unit/utils/test_common.py -v` — 7 tests passed.

## Speed Tests and Profiling

H20 wall-clock benchmark using random `640x384` JPEGs, with 30 warmups and 8 rounds of 300 decodes per mode. Each round was synchronized before and after measurement.

| JPEG input | `UNCHANGED` median | `RGB` median | Delta |
| --- | ---: | ---: | ---: |
| RGB | 2.3672 ms | 2.3744 ms | +0.31% |
| Grayscale | 1.8561 ms | 1.8367 ms | -1.05% |

The differences are within run-to-run variation. A `640x384` grayscale decode uses 491,520 additional output bytes when expanded from one to three `uint8` channels; RGB JPEG output size is unchanged.

## Checklist

- [x] Formatted the changed files with pre-commit.
- [x] Added and ran a unit regression test.
- [x] Documentation is not required for this internal image-decoding fix.
- [x] Provided accuracy validation above; no model execution or kernel path is changed.
- [x] Followed the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32002487530](https://github.com/sgl-project/sglang/actions/runs/32002487530)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32002487027](https://github.com/sgl-project/sglang/actions/runs/32002487027)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
