### PR TITLE
[Spec][Ngram] feat: support dynamic external ngram corpora

### DIFF
--- a/proto/sglang/runtime/v1/sglang.proto
+++ b/proto/sglang/runtime/v1/sglang.proto
@@ -103,6 +103,7 @@ message TextGenerateRequest {
   optional int32 priority = 15;
   optional bool require_reasoning = 16;
   optional uint32 max_thinking_tokens = 17;
+  optional string ngram_corpus_id = 18;
 }
 
 message TextGenerateResponse {
@@ -130,6 +131,7 @@ message GenerateRequest {
   optional int32 priority = 14;
   optional bool require_reasoning = 15;
   optional uint32 max_thinking_tokens = 16;
+  optional string ngram_corpus_id = 17;
 }
 
 message GenerateResponse {

--- a/python/sglang/kernels/jit/csrc/ngram_corpus/ngram.cpp
+++ b/python/sglang/kernels/jit/csrc/ngram_corpus/ngram.cpp
@@ -9,6 +9,10 @@ namespace sglang {
 
 namespace ngram {
 
+namespace {
+constexpr int64_t kAllCorporaHandle = -1;
+}
+
 Ngram::Ngram(size_t capacity, const Param& param) : param_(param) {
   if (!(param_.max_trie_depth > 1)) {
     throw std::runtime_error(
@@ -65,14 +69,15 @@ void Ngram::asyncInsert(std::vector<std::vector<int32_t>>&& tokens) {
   }
 }
 
-// NOTE: staging operations (start/append/finish) are called from a background
-// thread during async corpus loading. They do NOT hold mutex_ because
-// staging_sam_ is disjoint from sams_ / trie_. Only finishExternalCorpusLoad
-// briefly acquires mutex_ when moving the completed SAM into sams_.
+// NOTE: staging operations (start/append/finish) are called from one background
+// thread during async corpus loading. The staged SAM is disjoint from every
+// query-visible index until commitExternalCorpusLoad.
 void Ngram::startExternalCorpusLoad() {
   if (staging_sam_) {
     throw std::runtime_error("startExternalCorpusLoad called while another load is in progress");
   }
+  staging_corpus_id_.clear();
+  staging_corpus_handle_ = 0;
   staging_sam_ = std::make_unique<SuffixAutomaton>();
 }
 
@@ -80,49 +85,91 @@ void Ngram::appendExternalCorpusTokens(const std::vector<int32_t>& tokens) {
   if (!staging_sam_) {
     throw std::runtime_error("appendExternalCorpusTokens called without startExternalCorpusLoad");
   }
+  if (!staging_corpus_id_.empty()) {
+    throw std::runtime_error("appendExternalCorpusTokens called after finishExternalCorpusLoad");
+  }
   staging_sam_->appendTokens(tokens);
 }
 
-void Ngram::finishExternalCorpusLoad(const std::string& corpus_id) {
+void Ngram::finishExternalCorpusLoad(const std::string& corpus_id, int64_t corpus_handle) {
   if (!staging_sam_) {
     throw std::runtime_error("finishExternalCorpusLoad called without startExternalCorpusLoad");
   }
+  if (corpus_id.empty()) {
+    throw std::runtime_error("External corpus id must be non-empty");
+  }
+  if (corpus_id.find_first_of("\t\n\r") != std::string::npos) {
+    throw std::runtime_error("External corpus id must not contain tabs or line breaks");
+  }
+  if (corpus_handle <= 0) {
+    throw std::runtime_error("External corpus handle must be a positive int64");
+  }
   staging_sam_->finalize();
   if (staging_sam_->empty()) {
-    staging_sam_.reset();
+    resetStagingSam();
     throw std::runtime_error("External corpus is empty — no tokens were loaded.");
   }
-  // Only lock briefly to install the completed SAM.
+  // Validate against the current published indexes, but deliberately keep the
+  // finalized SAM in staging. Distributed callers publish only after every
+  // participating rank reports a successful build.
   std::unique_lock<std::mutex> lock(mutex_);
-  if (sams_.find(corpus_id) != sams_.end()) {
+  if (sam_handle_by_id_.find(corpus_id) != sam_handle_by_id_.end()) {
     throw std::runtime_error(
         "External corpus '" + corpus_id + "' already exists. Remove it before adding a new corpus with the same id.");
   }
-  sams_.emplace(corpus_id, std::move(staging_sam_));
+  if (sams_.find(corpus_handle) != sams_.end()) {
+    throw std::runtime_error("External corpus handle " + std::to_string(corpus_handle) + " already exists");
+  }
+  staging_corpus_id_ = corpus_id;
+  staging_corpus_handle_ = corpus_handle;
+}
+
+void Ngram::commitExternalCorpusLoad(const std::string& corpus_id) {
+  if (!staging_sam_ || staging_corpus_id_.empty()) {
+    throw std::runtime_error("commitExternalCorpusLoad called without a finalized staged corpus");
+  }
+  if (corpus_id != staging_corpus_id_) {
+    throw std::runtime_error(
+        "commitExternalCorpusLoad corpus id mismatch: expected '" + staging_corpus_id_ + "', got '" + corpus_id +
+        "'");
+  }
+
+  std::unique_lock<std::mutex> lock(mutex_);
+  const int64_t corpus_handle = staging_corpus_handle_;
+  sams_.emplace(corpus_handle, ExternalCorpus{corpus_id, std::move(staging_sam_)});
+  sam_handle_by_id_.emplace(corpus_id, corpus_handle);
+  staging_corpus_id_.clear();
+  staging_corpus_handle_ = 0;
 }
 
 void Ngram::removeExternalCorpus(const std::string& corpus_id) {
   std::unique_lock<std::mutex> lock(mutex_);
-  sams_.erase(corpus_id);
+  auto handle_it = sam_handle_by_id_.find(corpus_id);
+  if (handle_it != sam_handle_by_id_.end()) {
+    sams_.erase(handle_it->second);
+    sam_handle_by_id_.erase(handle_it);
+  }
 }
 
 void Ngram::resetStagingSam() {
-  // staging_sam_ is only accessed from the loading thread — no lock needed.
   staging_sam_.reset();
+  staging_corpus_id_.clear();
+  staging_corpus_handle_ = 0;
 }
 
 void Ngram::clearExternalCorpus() {
   std::unique_lock<std::mutex> lock(mutex_);
+  sam_handle_by_id_.clear();
   sams_.clear();
-  staging_sam_.reset();
+  resetStagingSam();
 }
 
 std::vector<std::pair<std::string, int64_t>> Ngram::listExternalCorpora() const {
   std::unique_lock<std::mutex> lock(mutex_);
   std::vector<std::pair<std::string, int64_t>> entries;
   entries.reserve(sams_.size());
-  for (const auto& [id, sam] : sams_) {
-    entries.emplace_back(id, sam->tokenCount());
+  for (const auto& [_, corpus] : sams_) {
+    entries.emplace_back(corpus.id, corpus.sam->tokenCount());
   }
   return entries;
 }
@@ -144,9 +191,17 @@ void Ngram::insertWorker() {
 Result Ngram::batchMatch(
     const std::vector<int64_t>& state_ids,
     const std::vector<std::vector<int32_t>>& tokens,
-    const std::vector<size_t>& total_lens) {
+    const std::vector<size_t>& total_lens,
+    const std::vector<int64_t>& corpus_handles) {
   if (state_ids.size() != tokens.size() || state_ids.size() != total_lens.size()) {
     throw std::runtime_error("batchMatch expects state_ids, tokens, and total_lens to match in size");
+  }
+  // An empty vector preserves the legacy all-SAM behavior. In an aligned
+  // per-request vector, -1 selects all SAMs, 0 (or any unknown handle) selects
+  // no external SAM, and a known positive handle selects exactly one SAM.
+  const bool per_request = !corpus_handles.empty();
+  if (per_request && corpus_handles.size() != state_ids.size()) {
+    throw std::runtime_error("batchMatch expects corpus_handles to match state_ids in size");
   }
 
   std::unique_lock<std::mutex> lock(mutex_);
@@ -183,6 +238,31 @@ Result Ngram::batchMatch(
 
     auto& state = match_state_[state_ids[i]];
 
+    const bool use_all_sams = !per_request || corpus_handles[i] == kAllCorporaHandle;
+    if (!use_all_sams) {
+      const SuffixAutomaton* sam = nullptr;
+      const int64_t handle = corpus_handles[i];
+      if (handle > 0) {
+        auto it = sams_.find(handle);
+        if (it != sams_.end()) {
+          sam = it->second.sam.get();
+        }
+      }
+      const size_t sam_budget =
+          sam ? std::min(param_.external_sam_budget, total_draft_token_num) : size_t{0};
+      const size_t req_trie_budget = total_draft_token_num - sam_budget;
+      Result res = (trie_.get()->*trie_result_build_fn)(
+          suffix.data(), suffix.size(), suffix.back(), req_trie_budget, param_, state, total_lens[i]);
+      if (sam_budget > 0) {
+        auto sam_res =
+            (sam->*sam_result_build_fn)(suffix.data(), suffix.size(), suffix.back(), sam_budget, param_);
+        res = combineRootResults_(suffix.back(), static_cast<int>(total_draft_token_num + 1), res, sam_res);
+      }
+      merged.token.insert(merged.token.end(), res.token.begin(), res.token.end());
+      merged.mask.insert(merged.mask.end(), res.mask.begin(), res.mask.end());
+      continue;
+    }
+
     if (total_sam_budget == 0 || per_sam_budget == 0) {
       auto res = (trie_.get()->*trie_result_build_fn)(
           suffix.data(), suffix.size(), suffix.back(), total_draft_token_num, param_, state, total_lens[i]);
@@ -194,7 +274,8 @@ Result Ngram::batchMatch(
     auto combined = (trie_.get()->*trie_result_build_fn)(
         suffix.data(), suffix.size(), suffix.back(), trie_budget, param_, state, total_lens[i]);
 
-    for (const auto& [_, sam] : sams_) {
+    for (const auto& [_, corpus] : sams_) {
+      const auto& sam = corpus.sam;
       auto sam_res =
           (sam.get()->*sam_result_build_fn)(suffix.data(), suffix.size(), suffix.back(), per_sam_budget, param_);
       combined = combineRootResults_(suffix.back(), static_cast<int>(total_draft_token_num + 1), combined, sam_res);

--- a/python/sglang/kernels/jit/csrc/ngram_corpus/ngram.h
+++ b/python/sglang/kernels/jit/csrc/ngram_corpus/ngram.h
@@ -20,17 +20,26 @@ namespace sglang {
 namespace ngram {
 
 class Ngram {
+  struct ExternalCorpus {
+    std::string id;
+    std::unique_ptr<SuffixAutomaton> sam;
+  };
+
   std::unique_ptr<Trie> trie_;
-  std::unordered_map<std::string, std::unique_ptr<SuffixAutomaton>> sams_;
-  // FIXME: single staging slot — only one corpus can be loaded at a time.
-  // To support concurrent loads, move staging into a per-load local variable.
+  // SAM ownership is keyed by the request-facing handle. A single secondary
+  // id index supports duplicate checks and removal without raw-pointer indexes.
+  std::unordered_map<int64_t, ExternalCorpus> sams_;
+  std::unordered_map<std::string, int64_t> sam_handle_by_id_;
+  // A finalized staged SAM remains outside every query index until commit.
+  // ExternalCorpusManager serializes loads, so one staging slot is sufficient.
   std::unique_ptr<SuffixAutomaton> staging_sam_;
+  std::string staging_corpus_id_;
+  int64_t staging_corpus_handle_ = 0;
   Param param_;
 
-  // NOTE: protects trie_, sams_, and pending_count_. staging_sam_ is NOT
-  // protected by mutex_ — it is only accessed from the corpus loading thread.
-  // finishExternalCorpusLoad briefly acquires mutex_ to move the completed
-  // SAM into sams_.
+  // NOTE: protects trie_, published SAM indexes, and pending_count_. Staging
+  // is built by one loading thread and is only finalized/committed/cancelled
+  // after that thread has stopped.
   mutable std::mutex mutex_;
   mutable std::condition_variable sync_cv_;
   // NOTE: tracks inserts from enqueue through trie_->insert() completion,
@@ -52,8 +61,11 @@ class Ngram {
 
   void appendExternalCorpusTokens(const std::vector<int32_t>& tokens);
 
-  // Publishes the staged corpus. Duplicate corpus_id is rejected.
-  void finishExternalCorpusLoad(const std::string& corpus_id);
+  // Finalizes the staged corpus but does not make it queryable.
+  void finishExternalCorpusLoad(const std::string& corpus_id, int64_t corpus_handle);
+
+  // Atomically installs the finalized staged corpus into all query indexes.
+  void commitExternalCorpusLoad(const std::string& corpus_id);
 
   void removeExternalCorpus(const std::string& corpus_id);
 
@@ -66,7 +78,8 @@ class Ngram {
   Result batchMatch(
       const std::vector<int64_t>& state_ids,
       const std::vector<std::vector<int32_t>>& tokens,
-      const std::vector<size_t>& total_lens);
+      const std::vector<size_t>& total_lens,
+      const std::vector<int64_t>& corpus_handles = {});
 
   void eraseMatchState(const std::vector<int64_t>& state_ids);
 

--- a/python/sglang/kernels/jit/csrc/ngram_corpus/ngram_corpus_ffi.cpp
+++ b/python/sglang/kernels/jit/csrc/ngram_corpus/ngram_corpus_ffi.cpp
@@ -58,6 +58,7 @@ struct NgramCorpusObj : public tvm::ffi::Object {
       const tvm::ffi::TensorView tokens_flat,
       const tvm::ffi::TensorView offsets,
       const tvm::ffi::TensorView total_lens_tv,
+      const tvm::ffi::TensorView corpus_handles_tv,
       const tvm::ffi::TensorView out_tokens,
       const tvm::ffi::TensorView out_mask) {
     auto* sid = static_cast<const int64_t*>(state_ids_tv.data_ptr());
@@ -74,7 +75,15 @@ struct NgramCorpusObj : public tvm::ffi::Object {
       total_lens[i] = static_cast<size_t>(tlens[i]);
     }
 
-    auto result = ngram_->batchMatch(state_ids, tokens, total_lens);
+    // Optional per-request corpus handles. Empty tensor -> legacy
+    // all-SAM search; length must equal batch_size otherwise (checked in C++).
+    std::vector<int64_t> corpus_handles;
+    if (corpus_handles_tv.size(0) > 0) {
+      auto* handle = static_cast<const int64_t*>(corpus_handles_tv.data_ptr());
+      corpus_handles.assign(handle, handle + corpus_handles_tv.size(0));
+    }
+
+    auto result = ngram_->batchMatch(state_ids, tokens, total_lens, corpus_handles);
     write_result_(result, out_tokens, out_mask);
   }
 
@@ -96,8 +105,12 @@ struct NgramCorpusObj : public tvm::ffi::Object {
     ngram_->appendExternalCorpusTokens(tokens);
   }
 
-  void finish_external_corpus_load(const std::string& corpus_id) {
-    ngram_->finishExternalCorpusLoad(corpus_id);
+  void finish_external_corpus_load(const std::string& corpus_id, int64_t corpus_handle) {
+    ngram_->finishExternalCorpusLoad(corpus_id, corpus_handle);
+  }
+
+  void commit_external_corpus_load(const std::string& corpus_id) {
+    ngram_->commitExternalCorpusLoad(corpus_id);
   }
 
   void remove_external_corpus(const std::string& corpus_id) {
@@ -162,6 +175,7 @@ void register_ngram_corpus() {
       .def("start_external_corpus_load", &NgramCorpusObj::start_external_corpus_load)
       .def("append_external_corpus_tokens", &NgramCorpusObj::append_external_corpus_tokens)
       .def("finish_external_corpus_load", &NgramCorpusObj::finish_external_corpus_load)
+      .def("commit_external_corpus_load", &NgramCorpusObj::commit_external_corpus_load)
       .def("remove_external_corpus", &NgramCorpusObj::remove_external_corpus)
       .def("cancel_external_corpus_load", &NgramCorpusObj::cancel_external_corpus_load)
       .def("clear_external_corpus", &NgramCorpusObj::clear_external_corpus)

--- a/python/sglang/kernels/ops/speculative/ngram_corpus.py
+++ b/python/sglang/kernels/ops/speculative/ngram_corpus.py
@@ -58,6 +58,13 @@ def get_ngram_corpus_cls():
                 raise ValueError(
                     f"Unknown match_type: '{match_type}'. Must be 'BFS' or 'PROB'."
                 )
+            if not 0 <= external_sam_budget < draft_token_num:
+                raise ValueError(
+                    "external_sam_budget must be non-negative and smaller than "
+                    "draft_token_num"
+                )
+            if external_corpus_max_tokens <= 0:
+                raise ValueError("external_corpus_max_tokens must be positive")
             self.__ffi_init__(
                 capacity,
                 max_trie_depth,
@@ -79,18 +86,41 @@ def get_ngram_corpus_cls():
             state_ids: List[int],
             batch_tokens: List[List[int]],
             total_lens: List[int],
+            corpus_handles: List[int] | None = None,
         ) -> Tuple[np.ndarray, np.ndarray]:
             tokens_flat, offsets = _to_csr(batch_tokens)
             batch_size = len(batch_tokens)
+            if len(state_ids) != batch_size or len(total_lens) != batch_size:
+                raise ValueError(
+                    "state_ids, batch_tokens, and total_lens must have the same "
+                    "batch size"
+                )
+            if corpus_handles is not None and len(corpus_handles) != batch_size:
+                raise ValueError(
+                    "corpus_handles must be omitted or match the batch size "
+                    f"({len(corpus_handles)} != {batch_size})"
+                )
             d = self._draft_token_num
 
             state_ids_t = torch.tensor(state_ids, dtype=torch.int64)
             total_lens_t = torch.tensor(total_lens, dtype=torch.int64)
+            # Per-request corpus handles (int64). Empty tensor keeps
+            # the legacy all-SAM search path in C++.
+            corpus_handles_t = torch.tensor(
+                corpus_handles if corpus_handles is not None else [],
+                dtype=torch.int64,
+            )
             out_tokens = torch.zeros(batch_size * d, dtype=torch.int32)
             out_mask = torch.zeros(batch_size * d * d, dtype=torch.uint8)
 
             self.batch_match_stateful(  # type: ignore
-                state_ids_t, tokens_flat, offsets, total_lens_t, out_tokens, out_mask
+                state_ids_t,
+                tokens_flat,
+                offsets,
+                total_lens_t,
+                corpus_handles_t,
+                out_tokens,
+                out_mask,
             )
 
             return out_tokens.numpy().astype(np.int64), out_mask.numpy().astype(
@@ -102,8 +132,15 @@ def get_ngram_corpus_cls():
             self.erase_match_state(state_ids_t)  # type: ignore
 
         def load_external_corpus_named(
-            self, corpus_id: str, chunks: Iterable[Sequence[int]], max_tokens: int
+            self,
+            corpus_id: str,
+            corpus_handle: int,
+            chunks: Iterable[Sequence[int]],
+            max_tokens: int,
         ) -> Tuple[int, int]:
+            """Build and finalize a corpus in staging without publishing it."""
+            if not corpus_id:
+                raise ValueError("corpus_id must be non-empty")
             self.start_external_corpus_load()  # type: ignore
             chunk_count = 0
             loaded_token_count = 0
@@ -118,11 +155,19 @@ def get_ngram_corpus_cls():
                     loaded_token_count += len(tokens_t)
                     self.append_external_corpus_tokens(tokens_t)  # type: ignore
                     chunk_count += 1
-                self.finish_external_corpus_load(corpus_id)  # type: ignore
+                self.finish_external_corpus_load(  # type: ignore
+                    corpus_id, corpus_handle
+                )
             except Exception:
                 self.cancel_external_corpus_load()  # type: ignore
                 raise
             return chunk_count, loaded_token_count
+
+        def commit_corpus(self, corpus_id: str) -> None:
+            self.commit_external_corpus_load(corpus_id)  # type: ignore
+
+        def cancel_corpus_load(self) -> None:
+            self.cancel_external_corpus_load()  # type: ignore
 
         def remove_corpus(self, corpus_id: str) -> None:
             self.remove_external_corpus(corpus_id)  # type: ignore

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -713,24 +713,29 @@ def _handle_ngram(server_args: ServerArgs) -> None:
             server_args.speculative_num_draft_tokens
             // server_args.speculative_eagle_topk
         )
+    external_sam_budget = server_args.speculative_ngram_external_sam_budget
+    external_corpus_max_tokens = (
+        server_args.speculative_ngram_external_corpus_max_tokens
+    )
+    if external_sam_budget < 0:
+        raise ValueError(
+            "--speculative-ngram-external-sam-budget must be non-negative."
+        )
+    if external_corpus_max_tokens <= 0:
+        raise ValueError(
+            "--speculative-ngram-external-corpus-max-tokens must be positive."
+        )
+    if external_sam_budget > server_args.speculative_num_draft_tokens - 1:
+        raise ValueError(
+            "--speculative-ngram-external-sam-budget must be less than or equal "
+            "to --speculative-num-draft-tokens - 1 "
+            f"({server_args.speculative_num_draft_tokens - 1})."
+        )
     if server_args.speculative_ngram_external_corpus_path is not None:
-        if server_args.speculative_ngram_external_sam_budget <= 0:
+        if external_sam_budget == 0:
             raise ValueError(
                 "--speculative-ngram-external-sam-budget must be positive when "
                 "--speculative-ngram-external-corpus-path is set."
-            )
-        if server_args.speculative_ngram_external_corpus_max_tokens <= 0:
-            raise ValueError(
-                "--speculative-ngram-external-corpus-max-tokens must be positive when "
-                "--speculative-ngram-external-corpus-path is set."
-            )
-        if (
-            server_args.speculative_ngram_external_sam_budget
-            > server_args.speculative_num_draft_tokens - 1
-        ):
-            raise ValueError(
-                "speculative_ngram_external_sam_budget must be less than or equal to "
-                f"speculative_num_draft_tokens - 1 ({server_args.speculative_num_draft_tokens - 1})."
             )
     logger.warning(
         "The mixed chunked prefill are disabled because of "

--- a/python/sglang/srt/entrypoints/EngineBase.py
+++ b/python/sglang/srt/entrypoints/EngineBase.py
@@ -36,6 +36,8 @@ class EngineBase(ABC):
         rid: Optional[Union[List[str], str]] = None,
         priority: Optional[int] = None,
         session_id: Optional[str] = None,
+        *,
+        ngram_corpus_id: Optional[Union[List[Optional[str]], str]] = None,
     ) -> Union[Dict, Iterator[Dict]]:
         """Generate outputs based on given inputs."""
         pass

--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -401,6 +401,7 @@ class Engine(EngineScoreMixin, EngineBase):
         session_id: Optional[str] = None,
         *,
         cache_salt: Optional[Union[List[str], str]] = None,
+        ngram_corpus_id: Optional[Union[List[Optional[str]], str]] = None,
     ) -> Union[Dict, Iterator[Dict]]:
         """
         The arguments of this function is the same as `sglang/srt/managers/io_struct.py::GenerateReqInput`.
@@ -420,6 +421,7 @@ class Engine(EngineScoreMixin, EngineBase):
             mm_hashes=mm_hashes,
             mm_content_hashes=mm_content_hashes,
             cache_salt=cache_salt,
+            ngram_corpus_id=ngram_corpus_id,
             return_logprob=return_logprob,
             logprob_start_len=logprob_start_len,
             top_logprobs_num=top_logprobs_num,
@@ -514,6 +516,7 @@ class Engine(EngineScoreMixin, EngineBase):
         session_id: Optional[str] = None,
         *,
         cache_salt: Optional[Union[List[str], str]] = None,
+        ngram_corpus_id: Optional[Union[List[Optional[str]], str]] = None,
     ) -> Union[Dict, AsyncIterator[Dict]]:
         """
         The arguments of this function is the same as `sglang/srt/managers/io_struct.py::GenerateReqInput`.
@@ -533,6 +536,7 @@ class Engine(EngineScoreMixin, EngineBase):
             mm_hashes=mm_hashes,
             mm_content_hashes=mm_content_hashes,
             cache_salt=cache_salt,
+            ngram_corpus_id=ngram_corpus_id,
             return_logprob=return_logprob,
             logprob_start_len=logprob_start_len,
             top_logprobs_num=top_logprobs_num,

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -62,6 +62,7 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import ORJSONResponse, Response, StreamingResponse
 from fastapi.routing import APIRoute
+from pydantic import BaseModel, ConfigDict, StrictInt, StrictStr
 
 from sglang.srt.configs.embedding_model_spec import resolved_embedding_plan
 from sglang.srt.constants import HEALTH_CHECK_RID_PREFIX
@@ -114,6 +115,7 @@ from sglang.srt.entrypoints.warmup import execute_warmups
 from sglang.srt.environ import envs
 from sglang.srt.function_call.function_call_parser import FunctionCallParser
 from sglang.srt.managers.io_struct import (
+    AddExternalCorpusReqInput,
     AbortReq,
     AttachHiCacheStorageReqInput,
     CheckWeightsReqInput,
@@ -961,19 +963,45 @@ async def flush_cache(timeout: float = Query(0.0, ge=0.0)):
     )
 
 
+class AddExternalCorpusRequest(BaseModel):
+    """Strict transport schema for external corpus uploads.
+
+    Cross-field and token semantic validation is centralized in the tokenizer
+    manager so non-HTTP entry paths behave identically.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    corpus_id: Optional[StrictStr] = None
+    file_path: Optional[StrictStr] = None
+    documents: Optional[List[StrictStr]] = None
+    token_chunks: Optional[List[List[StrictInt]]] = None
+
+
+class RemoveExternalCorpusRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    corpus_id: StrictStr
+
+
 @app.post("/add_external_corpus")
 @auth_level(AuthLevel.ADMIN_OPTIONAL)
-async def add_external_corpus(request: Request):
-    """Add an external corpus for ngram speculative decoding."""
-    from sglang.srt.managers.io_struct import AddExternalCorpusReqInput
+async def add_external_corpus(
+    body: Annotated[AddExternalCorpusRequest, Body()],
+):
+    """Add an external corpus for NGRAM speculative decoding.
 
-    try:
-        obj = AddExternalCorpusReqInput(**(await request.json()))
-    except TypeError as e:
-        return ORJSONResponse(
-            {"success": False, "message": str(e)},
-            status_code=HTTPStatus.BAD_REQUEST,
-        )
+    Provide exactly one source. ``token_chunks`` preserves token IDs verbatim;
+    use ``-2147483648`` between documents when a boundary is required.
+    """
+    # Pass the validated containers through directly; model_dump() would build
+    # another nested token list before the tokenizer manager sees it.
+    obj = AddExternalCorpusReqInput(
+        corpus_id=body.corpus_id,
+        file_path=body.file_path,
+        documents=body.documents,
+        token_chunks=body.token_chunks,
+    )
     result = await _global_state.tokenizer_manager.add_external_corpus(obj)
     return ORJSONResponse(
         {
@@ -988,16 +1016,18 @@ async def add_external_corpus(request: Request):
 
 @app.post("/remove_external_corpus")
 @auth_level(AuthLevel.ADMIN_OPTIONAL)
-async def remove_external_corpus(request: Request):
+async def remove_external_corpus(
+    body: Annotated[RemoveExternalCorpusRequest, Body()],
+):
     """Remove an external corpus by ID."""
-    body = await request.json()
-    corpus_id = body.get("corpus_id")
-    if not corpus_id:
+    if not body.corpus_id:
         return ORJSONResponse(
             {"success": False, "message": "corpus_id is required."},
             status_code=HTTPStatus.BAD_REQUEST,
         )
-    result = await _global_state.tokenizer_manager.remove_external_corpus(corpus_id)
+    result = await _global_state.tokenizer_manager.remove_external_corpus(
+        body.corpus_id
+    )
     return ORJSONResponse(
         {"success": result.success, "message": result.message},
         status_code=200 if result.success else HTTPStatus.BAD_REQUEST,

--- a/python/sglang/srt/entrypoints/http_server_engine.py
+++ b/python/sglang/srt/entrypoints/http_server_engine.py
@@ -116,6 +116,8 @@ class HttpServerEngineAdapter(EngineBase):
         custom_logit_processor=None,
         priority=None,
         session_id=None,
+        *,
+        ngram_corpus_id=None,
     ):
         payload = {
             "text": prompt,
@@ -130,6 +132,7 @@ class HttpServerEngineAdapter(EngineBase):
             "custom_logit_processor": custom_logit_processor,
             "priority": priority,
             "session_id": session_id,
+            "ngram_corpus_id": ngram_corpus_id,
         }
         # Filter out None values
         payload = {k: v for k, v in payload.items() if v is not None}

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -390,6 +390,8 @@ class CompletionRequest(BaseModel):
     extra_key: Optional[Union[List[str], str]] = None
     # Cache salt for request caching
     cache_salt: Optional[Union[List[str], str]] = None
+    # External NGRAM corpus selector. A scalar broadcasts across a prompt batch.
+    ngram_corpus_id: Optional[Union[List[Optional[str]], str]] = None
     # Priority for the request
     priority: Optional[int] = None
 
@@ -860,6 +862,8 @@ class ChatCompletionRequest(BaseModel):
     extra_key: Optional[Union[List[str], str]] = None
     # Cache salt for request caching
     cache_salt: Optional[Union[List[str], str]] = None
+    # External NGRAM corpus selector for this chat request.
+    ngram_corpus_id: Optional[str] = None
     # Priority for the request
     priority: Optional[int] = None
 
@@ -1548,6 +1552,9 @@ class ResponsesRequest(BaseModel):
     )
     cache_salt: Optional[str] = Field(
         default=None, description="Cache salt for request caching"
+    )
+    ngram_corpus_id: Optional[str] = Field(
+        default=None, description="External NGRAM corpus selector"
     )
 
     # SGLang sampling extras. ``None`` defers to ``--preferred-sampling-params``.

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -1020,6 +1020,7 @@ class OpenAIServingChat(OpenAIServingBase):
             session_id=request.session_id,
             extra_key=request.extra_key,
             cache_salt=request.cache_salt,
+            ngram_corpus_id=request.ngram_corpus_id,
             require_reasoning=processed_messages.require_reasoning,
             priority=request.priority,
             routing_key=self.extract_routing_key(raw_request),

--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -97,6 +97,23 @@ class OpenAIServingCompletion(OpenAIServingBase):
         else:
             prompt_kwargs = {"input_ids": prompt}
 
+        # The OpenAI field may use a one-element list for a single prompt, while
+        # the native single-request schema expects a scalar selector.
+        ngram_corpus_id = request.ngram_corpus_id
+        if (
+            (
+                isinstance(prompt, str)
+                or (
+                    isinstance(prompt, list)
+                    and prompt
+                    and isinstance(prompt[0], int)
+                )
+            )
+            and isinstance(ngram_corpus_id, list)
+            and len(ngram_corpus_id) == 1
+        ):
+            ngram_corpus_id = ngram_corpus_id[0]
+
         # Extract custom labels from raw request headers
         custom_labels = self.extract_custom_labels(raw_request)
 
@@ -130,6 +147,7 @@ class OpenAIServingCompletion(OpenAIServingBase):
             session_id=request.session_id,
             extra_key=request.extra_key,
             cache_salt=request.cache_salt,
+            ngram_corpus_id=ngram_corpus_id,
             priority=request.priority,
             routing_key=self.extract_routing_key(raw_request),
             custom_labels=custom_labels,

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -456,6 +456,7 @@ class OpenAIServingResponses(OpenAIServingChat):
                         session_id=request.session_id,
                         extra_key=request.extra_key,
                         cache_salt=request.cache_salt,
+                        ngram_corpus_id=request.ngram_corpus_id,
                         # background+stream streams on this connection, so don't detach.
                         background=request.background and not request.stream,
                         require_reasoning=require_reasoning,
@@ -2565,6 +2566,7 @@ class OpenAIServingResponses(OpenAIServingChat):
                 session_id=adapted_request.session_id,
                 extra_key=adapted_request.extra_key,
                 cache_salt=adapted_request.cache_salt,
+                ngram_corpus_id=adapted_request.ngram_corpus_id,
                 return_logprob=adapted_request.return_logprob,
                 logprob_start_len=adapted_request.logprob_start_len,
                 top_logprobs_num=adapted_request.top_logprobs_num,

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -296,6 +296,10 @@ class GenerateReqInput:
     # Extra cache key for caller-defined request classification.
     extra_key: Optional[Union[List[str], str]] = None
 
+    # Per-request external NGRAM corpus selector. None preserves the legacy
+    # all-SAM search; an empty string explicitly selects online-trie-only.
+    ngram_corpus_id: Optional[Union[List[Optional[str]], str]] = None
+
     # Whether to disallow logging for this request (e.g. due to ZDR)
     no_logs: bool = False
     # For custom metric labels
@@ -505,6 +509,12 @@ class GenerateReqInput:
                 )
             if value == "":
                 setattr(self, field_name, None)
+        if self.ngram_corpus_id is not None and not isinstance(
+            self.ngram_corpus_id, str
+        ):
+            raise ValueError(
+                "ngram_corpus_id should be a string for a single request."
+            )
 
     def _normalize_batch_inputs(self):
         """Normalize inputs for a batch of examples, including parallel sampling expansion."""
@@ -529,6 +539,7 @@ class GenerateReqInput:
         self._normalize_custom_logit_processor(num)
         self._normalize_extra_key(num)
         self._normalize_cache_salt(num)
+        self._normalize_ngram_corpus_id(num)
         self._normalize_bootstrap_params(num)
 
     def _expand_inputs(self, num):
@@ -790,6 +801,28 @@ class GenerateReqInput:
         else:
             raise ValueError("cache_salt should be a list or a string.")
 
+    def _normalize_ngram_corpus_id(self, num):
+        """Normalize ngram_corpus_id for batch processing."""
+        if self.ngram_corpus_id is None:
+            return
+        if isinstance(self.ngram_corpus_id, str):
+            self.ngram_corpus_id = [self.ngram_corpus_id] * num
+        elif isinstance(self.ngram_corpus_id, list):
+            if len(self.ngram_corpus_id) != self.batch_size:
+                raise ValueError(
+                    "The length of ngram_corpus_id should be equal to the batch size."
+                )
+            if any(
+                value is not None and not isinstance(value, str)
+                for value in self.ngram_corpus_id
+            ):
+                raise ValueError(
+                    "Every ngram_corpus_id should be a string or None."
+                )
+            self.ngram_corpus_id = self.ngram_corpus_id * self.parallel_sample_num
+        else:
+            raise ValueError("ngram_corpus_id should be a list or a string.")
+
     def _normalize_bootstrap_params(self, num):
         """Normalize bootstrap parameters for batch processing."""
         # Normalize bootstrap_host
@@ -921,6 +954,9 @@ class GenerateReqInput:
             priority=self.priority,
             extra_key=self.extra_key[i] if self.extra_key is not None else None,
             cache_salt=(self.cache_salt[i] if self.cache_salt is not None else None),
+            ngram_corpus_id=(
+                self.ngram_corpus_id[i] if self.ngram_corpus_id is not None else None
+            ),
             no_logs=self.no_logs,
             custom_labels=self.custom_labels,
             return_bytes=self.return_bytes,
@@ -1040,6 +1076,12 @@ class TokenizedGenerateReqInput(BaseReq, kw_only=True):
 
     # Cache namespace used to isolate otherwise-identical prefixes.
     cache_salt: Optional[str] = None
+
+    # Per-request external NGRAM corpus selector (resolved). Keep new fields at
+    # the end of this array-like wire struct so older field indices stay stable.
+    # None preserves the legacy all-SAM search; an empty string selects
+    # online-trie-only.
+    ngram_corpus_id: Optional[str] = None
 
     def wrap_pickle_fields(self):
         self.mm_inputs = wrap_as_pickle(self.mm_inputs)

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -847,6 +847,7 @@ class Req(ReqDllmMixin):
         metrics_collector: Optional[SchedulerMetricsCollector] = None,
         extra_key: Optional[str] = None,
         routing_key: Optional[str] = None,
+        ngram_corpus_id: Optional[str] = None,
         dimensions: Optional[int] = None,
         http_worker_ipc: Optional[str] = None,
         time_stats: Optional[
@@ -935,6 +936,7 @@ class Req(ReqDllmMixin):
         self.cache_salt = cache_salt or None
         self.lora_id = lora_id
         self.routing_key = routing_key
+        self.ngram_corpus_id = ngram_corpus_id
 
         # Memory pool info
         self.req_pool_idx: Optional[int] = None

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -944,7 +944,9 @@ class Scheduler(
 
             self.external_corpus_manager = ExternalCorpusManager(
                 self.draft_worker,
-                self.ipc_channels.send_to_tokenizer.send_output,
+                self._send_control_output,
+                self._synchronize_external_corpus_load_result,
+                self.draft_worker.ngram_corpus.cancel_external_corpus_load,
             )
         else:
             self.external_corpus_manager = None
@@ -1889,19 +1891,119 @@ class Scheduler(
             output = self._request_dispatcher(recv_req)
             if output is not None:
                 if self.rust_server is not None:
-                    # Embedded Rust server: every control-request response goes
-                    # back through the egress ring (the zmq tokenizer socket is
-                    # not consumed); the Rust api_server shapes it per-endpoint.
-                    self.rust_server.push_control_output(recv_req, output)
+                    self._send_control_output(output, recv_req)
                 elif isinstance(output, RpcReqOutput):
                     if self.ipc_channels.recv_from_rpc is not None:
                         sock_send(self.ipc_channels.recv_from_rpc, output)
                 else:
-                    self.ipc_channels.send_to_tokenizer.send_output(output, recv_req)
+                    self._send_control_output(output, recv_req)
 
         self.flush_wrapper.check_pending()
         if self.external_corpus_manager is not None:
             self.external_corpus_manager.check_pending_load()
+
+    def _send_control_output(self, output, recv_req) -> None:
+        """Route synchronous and deferred control replies to the active frontend."""
+        rust_server = self.rust_server
+        if rust_server is not None:
+            # The embedded Rust frontend does not consume the tokenizer ZMQ
+            # socket, so every control reply must return through its egress ring.
+            rust_server.push_control_output(recv_req, output)
+        elif envs.SGLANG_RUST_SERVER.get():
+            # Non-entry TP ranks execute broadcast control requests too, but
+            # only the rank hosting the Rust frontend owns a waiting HTTP sink.
+            return
+        else:
+            self.ipc_channels.send_to_tokenizer.send_output(output, recv_req)
+
+    def _synchronize_external_corpus_load_result(
+        self, result: Optional[AddExternalCorpusReqOutput]
+    ) -> Optional[AddExternalCorpusReqOutput]:
+        """Return a result only after every local control rank reports one.
+
+        Pending polls exchange one byte. The more expensive Python-object
+        gather happens only once all ranks are ready (and at the commit/cleanup
+        fences, where every caller is already ready).
+        """
+        group = self._external_corpus_control_group()
+        if group is None:
+            return result
+
+        ready = torch.tensor(
+            0 if result is None else 1, dtype=torch.uint8, device="cpu"
+        )
+        torch.distributed.all_reduce(
+            ready,
+            op=torch.distributed.ReduceOp.MIN,
+            group=group.cpu_group,
+        )
+        if not ready.item():
+            return None
+        assert result is not None
+
+        local = (
+            result.success,
+            result.corpus_id,
+            result.message,
+            result.loaded_token_count,
+        )
+        gathered = group.all_gather_object(local)
+        successful = [entry for entry in gathered if entry[0]]
+        consistent = len(successful) == len(gathered) and len(
+            {(entry[1], entry[3]) for entry in successful}
+        ) == 1
+        if consistent:
+            return result
+
+        details = "; ".join(
+            f"rank {rank}: {message or 'inconsistent corpus load result'}"
+            for rank, (success, _corpus_id, message, _count) in enumerate(gathered)
+            if not success
+        )
+        if not details:
+            details = "worker ranks reported inconsistent corpus ids or token counts"
+        return AddExternalCorpusReqOutput(
+            success=False,
+            message=f"External corpus load failed across worker ranks: {details}",
+        )
+
+    def _external_corpus_control_group(self) -> Optional[Any]:
+        """Return the TP group that receives NGRAM control broadcasts.
+
+        NGRAM startup rejects DP attention, so its request receiver always
+        broadcasts control messages across the ordinary TP group.
+        """
+        return self.tp_group if self.ps.tp_size > 1 else None
+
+    def _merge_external_corpus_control_output(self, output):
+        """Merge a synchronous corpus-control result across broadcast ranks."""
+        group = self._external_corpus_control_group()
+        if group is None:
+            return output
+
+        payload = (
+            tuple(sorted(output.corpus_token_counts.items()))
+            if isinstance(output, ListExternalCorporaReqOutput)
+            else None
+        )
+        gathered = group.all_gather_object(
+            (output.success, output.message, payload)
+        )
+
+        failures = [
+            f"rank {rank}: {message or 'operation failed'}"
+            for rank, (success, message, _payload) in enumerate(gathered)
+            if not success
+        ]
+        payloads = {entry[2] for entry in gathered if entry[0]}
+        if not failures and len(payloads) <= 1:
+            return output
+        if not failures:
+            failures.append("worker ranks returned inconsistent corpus lists")
+        message = "; ".join(failures)
+        if isinstance(output, ListExternalCorporaReqOutput):
+            return ListExternalCorporaReqOutput(success=False, message=message)
+        return RemoveExternalCorpusReqOutput(success=False, message=message)
 
     def _materialize_cuda_vmm_inputs(self, recv_req):
         """Release VMM slices before request handling can reject the request."""
@@ -2423,6 +2525,7 @@ class Scheduler(
                 routing_key=recv_req.routing_key,
                 extra_key=recv_req.extra_key,
                 cache_salt=recv_req.cache_salt,
+                ngram_corpus_id=recv_req.ngram_corpus_id,
                 http_worker_ipc=recv_req.http_worker_ipc,
                 dllm_config=self.dllm_config,
                 time_stats=recv_req.time_stats,
@@ -3997,31 +4100,37 @@ class Scheduler(
         self, recv_req: AddExternalCorpusReqInput
     ) -> Optional[AddExternalCorpusReqOutput]:
         if self.external_corpus_manager is None:
-            return AddExternalCorpusReqOutput(
+            output = AddExternalCorpusReqOutput(
                 success=False,
                 message="Ngram speculative decoding is not enabled.",
             )
-        return self.external_corpus_manager.add(recv_req)
+        else:
+            output = self.external_corpus_manager.add(recv_req)
+        return output
 
     def remove_external_corpus(
         self, recv_req: RemoveExternalCorpusReqInput
     ) -> RemoveExternalCorpusReqOutput:
         if self.external_corpus_manager is None:
-            return RemoveExternalCorpusReqOutput(
+            output = RemoveExternalCorpusReqOutput(
                 success=False,
                 message="Ngram speculative decoding is not enabled.",
             )
-        return self.external_corpus_manager.remove(recv_req)
+        else:
+            output = self.external_corpus_manager.remove(recv_req)
+        return self._merge_external_corpus_control_output(output)
 
     def list_external_corpora(
         self, recv_req: ListExternalCorporaReqInput
     ) -> ListExternalCorporaReqOutput:
         if self.external_corpus_manager is None:
-            return ListExternalCorporaReqOutput(
+            output = ListExternalCorporaReqOutput(
                 success=False,
                 message="Ngram speculative decoding is not enabled.",
             )
-        return self.external_corpus_manager.list(recv_req)
+        else:
+            output = self.external_corpus_manager.list(recv_req)
+        return self._merge_external_corpus_control_output(output)
 
     def clear_hicache_storage_wrapped(self, recv_req: ClearHiCacheReqInput):
         if self.enable_hierarchical_cache:

--- a/python/sglang/srt/managers/tokenizer_control_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_control_mixin.py
@@ -87,6 +87,70 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
+def _validate_external_corpus_token_chunks(
+    token_chunks: object,
+    *,
+    max_tokens: int,
+    vocab_size: int,
+    separator_token: int,
+) -> List[List[int]]:
+    """Validate the public ``List[List[int]]`` contract in place."""
+    if not isinstance(token_chunks, list):
+        raise ValueError("token_chunks must be a list of token lists.")
+    if not token_chunks:
+        raise ValueError("token_chunks must be non-empty.")
+
+    total_tokens = 0
+    int32_min = -(2**31)
+    int32_max = 2**31 - 1
+
+    for chunk_idx, chunk in enumerate(token_chunks):
+        if not isinstance(chunk, list):
+            raise ValueError(
+                f"token_chunks[{chunk_idx}] must be a list of integer token IDs."
+            )
+        if not chunk:
+            raise ValueError(f"token_chunks[{chunk_idx}] must be non-empty.")
+
+        total_tokens += len(chunk)
+        if total_tokens > max_tokens:
+            raise ValueError(
+                f"token_chunks total {total_tokens} exceeds "
+                f"external corpus token limit {max_tokens}."
+            )
+
+        for token_idx, token in enumerate(chunk):
+            if type(token) is not int:
+                raise ValueError(
+                    f"token_chunks[{chunk_idx}][{token_idx}] must be an integer "
+                    f"token ID, got {type(token).__name__}."
+                )
+            if token < int32_min or token > int32_max:
+                raise ValueError(
+                    f"token_chunks[{chunk_idx}][{token_idx}]={token} is outside "
+                    "the signed int32 range."
+                )
+            if token != separator_token and not 0 <= token < vocab_size:
+                raise ValueError(
+                    f"token_chunks[{chunk_idx}][{token_idx}]={token} is invalid; "
+                    f"expected {separator_token} (document separator) or a token "
+                    f"ID in [0, {vocab_size})."
+                )
+
+    return token_chunks
+
+
+def _dynamic_external_corpus_topology_error(server_args: ServerArgs) -> Optional[str]:
+    if server_args.dp_size == 1 and server_args.pp_size == 1:
+        return None
+    return (
+        "Dynamic external corpus management requires dp_size=1 and pp_size=1 "
+        f"(got dp_size={server_args.dp_size}, pp_size={server_args.pp_size}). "
+        "Use the startup external-corpus option for DP/PP deployments."
+    )
+
+
 # Declarative spec: (attr_name_prefix, response_type[, mode])
 # Each entry creates self.{prefix}_communicator and registers
 # response_type -> communicator.handle_recv in the dispatch table.
@@ -190,13 +254,52 @@ class TokenizerControlMixin:
                 success=False,
                 message="Ngram speculative decoding is not enabled.",
             )
+        if error := _dynamic_external_corpus_topology_error(self.server_args):
+            return AddExternalCorpusReqOutput(success=False, message=error)
+        if self.server_args.speculative_ngram_external_sam_budget <= 0:
+            return AddExternalCorpusReqOutput(
+                success=False,
+                message=(
+                    "Dynamic external corpus loading is disabled; set "
+                    "--speculative-ngram-external-sam-budget to a positive value."
+                ),
+            )
         truncated = False
         try:
             if not obj.corpus_id:
                 import uuid
 
                 obj.corpus_id = uuid.uuid4().hex
-            if obj.file_path is not None:
+            source_count = sum(
+                source is not None
+                for source in (obj.token_chunks, obj.file_path, obj.documents)
+            )
+            if source_count != 1:
+                return AddExternalCorpusReqOutput(
+                    success=False,
+                    message=(
+                        "Exactly one of token_chunks, file_path, or documents must "
+                        "be provided."
+                    ),
+                )
+            if obj.token_chunks is not None:
+                from sglang.srt.speculative.cpp_ngram.external_corpus import (
+                    SEPARATOR_TOKEN,
+                )
+
+                max_tokens = (
+                    self.server_args.speculative_ngram_external_corpus_max_tokens
+                )
+                # Exact IDs are never re-tokenized. The semantic validation
+                # boundary lives here so every tokenizer-manager entry path has
+                # identical range, vocabulary, and token-budget behavior.
+                obj.token_chunks = _validate_external_corpus_token_chunks(
+                    obj.token_chunks,
+                    max_tokens=max_tokens,
+                    vocab_size=self.model_config.vocab_size,
+                    separator_token=SEPARATOR_TOKEN,
+                )
+            elif obj.file_path is not None:
                 from sglang.srt.speculative.cpp_ngram.external_corpus import (
                     iter_external_corpus_chunks,
                 )
@@ -237,11 +340,6 @@ class TokenizerControlMixin:
                     total_tokens += len(token_ids)
                     has_prev = True
                 obj.token_chunks = token_chunks
-            else:
-                return AddExternalCorpusReqOutput(
-                    success=False,
-                    message="Either file_path or documents must be provided.",
-                )
             obj.file_path = None
             obj.documents = None
             results = await self.add_external_corpus_communicator(obj)
@@ -266,6 +364,8 @@ class TokenizerControlMixin:
                 success=False,
                 message="Ngram speculative decoding is not enabled.",
             )
+        if error := _dynamic_external_corpus_topology_error(self.server_args):
+            return RemoveExternalCorpusReqOutput(success=False, message=error)
         results = await self.remove_external_corpus_communicator(
             RemoveExternalCorpusReqInput(corpus_id=corpus_id)
         )
@@ -284,9 +384,20 @@ class TokenizerControlMixin:
         results = await self.list_external_corpora_communicator(
             ListExternalCorporaReqInput()
         )
-        all_success, all_message = FanOutCommunicator.merge_results(results)
-        # Merge corpus token counts from all DP ranks (each rank loads the same set).
-        corpus_token_counts = results[0].corpus_token_counts if all_success else {}
+        all_success = all(result.success for result in results)
+        all_message = " | ".join(
+            dict.fromkeys(result.message for result in results if result.message)
+        )
+        corpus_token_counts = {}
+        if all_success:
+            corpus_token_counts = results[0].corpus_token_counts
+            if any(
+                result.corpus_token_counts != corpus_token_counts
+                for result in results[1:]
+            ):
+                all_success = False
+                all_message = "Worker replicas returned inconsistent corpus lists."
+                corpus_token_counts = {}
         return ListExternalCorporaReqOutput(
             success=all_success,
             corpus_token_counts=corpus_token_counts,

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1433,6 +1433,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 extra_key=obj.extra_key,
                 cache_salt=obj.cache_salt,
                 routing_key=obj.routing_key,
+                ngram_corpus_id=obj.ngram_corpus_id,
                 token_type_ids=token_type_ids,
                 need_wait_for_mm_inputs=obj.need_wait_for_mm_inputs,
                 num_items_assigned=obj.num_items_assigned,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2299,12 +2299,12 @@ class ServerArgs:
     ] = None
     speculative_ngram_external_sam_budget: A[
         int,
-        "Number of draft nodes reserved for the external SAM subtree in ngram speculative decoding.",
+        "Number of draft nodes reserved for external SAMs in ngram speculative decoding. Set a positive value to enable external corpora.",
         NS("spec"),
     ] = 0
     speculative_ngram_external_corpus_max_tokens: A[
         int,
-        "Fail startup if the tokenized external ngram corpus exceeds this many tokens. Tune this based on your CPU memory budget.",
+        "Maximum total tokens across loaded external ngram corpora. Tune this based on your CPU memory budget.",
         NS("spec"),
     ] = 10000000
 

--- a/python/sglang/srt/session/session_controller.py
+++ b/python/sglang/srt/session/session_controller.py
@@ -313,6 +313,7 @@ class Session:
             routing_key=req.routing_key,
             extra_key=req.extra_key,
             cache_salt=req.cache_salt,
+            ngram_corpus_id=req.ngram_corpus_id,
             http_worker_ipc=req.http_worker_ipc,
             time_stats=req.time_stats,
         )

--- a/python/sglang/srt/speculative/cpp_ngram/ngram_corpus.py
+++ b/python/sglang/srt/speculative/cpp_ngram/ngram_corpus.py
@@ -2,13 +2,16 @@
 
 import logging
 from collections.abc import Iterable, Sequence
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 
 from sglang.kernels.ops.speculative.ngram_corpus import get_ngram_corpus_cls
 
 logger = logging.getLogger(__name__)
+
+_ALL_CORPORA_HANDLE = -1
+_NO_CORPUS_HANDLE = 0
 
 
 class NgramCorpus:
@@ -38,8 +41,13 @@ class NgramCorpus:
         self.external_corpus_max_tokens = external_corpus_max_tokens
         self._req_id_to_state_id: Dict[str, int] = {}
         self._next_state_id: int = 0
-        self._corpus_token_counts: Dict[str, int] = {}
+        # Published id -> (request-facing handle, token count).
+        self._corpora: Dict[str, Tuple[int, int]] = {}
+        self._next_corpus_handle: int = 1
         self._total_loaded_tokens: int = 0
+        self._staging_corpus_id: Optional[str] = None
+        self._staging_corpus_handle: Optional[int] = None
+        self._staging_token_count: int = 0
 
     def _get_state_id(self, req_id: str) -> int:
         sid = self._req_id_to_state_id.get(req_id)
@@ -62,32 +70,89 @@ class NgramCorpus:
     def load_external_corpus_named(
         self, corpus_id: str, chunks: Iterable[Sequence[int]]
     ) -> int:
-        if corpus_id in self._corpus_token_counts:
+        if not corpus_id:
+            raise ValueError("External corpus id must be non-empty.")
+        if any(delimiter in corpus_id for delimiter in "\t\n\r"):
+            raise ValueError(
+                "External corpus id must not contain tabs or line breaks."
+            )
+        if corpus_id in self._corpora:
             raise ValueError(
                 f"External corpus '{corpus_id}' already exists. Remove it before "
                 f"adding a new corpus with the same id."
             )
-        # Note(kpham-sgl): remaining_token_budget is stale (e.g if there are removes
-        # during the load), which makes the budget more conservative than it should be.
-        # This is acceptable because otherwise load_external_corpus_named would need to check the budget after each chunk,
-        # which would be inefficient.
+        if self._staging_corpus_id is not None:
+            raise RuntimeError(
+                f"External corpus '{self._staging_corpus_id}' is still staged. "
+                "Commit or cancel it before starting another load."
+            )
+        corpus_handle = self._next_corpus_handle
+        self._next_corpus_handle += 1
+        # A concurrent removal can only make this snapshot conservative.
         _, loaded_token_count = self._obj.load_external_corpus_named(
-            corpus_id, chunks, self.remaining_token_budget
+            corpus_id, corpus_handle, chunks, self.remaining_token_budget
         )
+        self._staging_corpus_id = corpus_id
+        self._staging_corpus_handle = corpus_handle
+        self._staging_token_count = loaded_token_count
         return loaded_token_count
 
-    # Commit corpus bookkeeping after successful load. Call only at background thread join.
-    # (or after synchronous load_external_corpus_named returns)
     def commit_external_corpus_load(
         self, corpus_id: str, loaded_token_count: int
     ) -> None:
-        self._corpus_token_counts[corpus_id] = loaded_token_count
-        self._total_loaded_tokens += loaded_token_count
+        """Atomically publish the finalized staging corpus to local readers."""
+        if self._staging_corpus_id != corpus_id:
+            raise RuntimeError(
+                "No staged external corpus matches "
+                f"'{corpus_id}' (staged: {self._staging_corpus_id!r})."
+            )
+        if loaded_token_count != self._staging_token_count:
+            raise RuntimeError(
+                f"Staged corpus '{corpus_id}' has {self._staging_token_count} "
+                f"tokens, not {loaded_token_count}."
+            )
+        assert self._staging_corpus_handle is not None
+        # Install the single Python metadata entry first. It has no observers
+        # during this scheduler-thread call, and can be removed if the C++
+        # commit reports a normal validation error. After C++ publication only
+        # non-failing attribute assignments remain.
+        new_total = self._total_loaded_tokens + loaded_token_count
+        self._corpora[corpus_id] = (
+            self._staging_corpus_handle,
+            loaded_token_count,
+        )
+        try:
+            self._obj.commit_corpus(corpus_id)
+        except Exception:
+            self._corpora.pop(corpus_id, None)
+            raise
+        self._total_loaded_tokens = new_total
+        self._clear_staging_metadata()
+
+    def cancel_external_corpus_load(self, corpus_id: Optional[str] = None) -> None:
+        """Discard an unpublished staging corpus; published corpora are untouched."""
+        if (
+            corpus_id is not None
+            and self._staging_corpus_id is not None
+            and corpus_id != self._staging_corpus_id
+        ):
+            raise RuntimeError(
+                f"Cannot cancel staged corpus '{self._staging_corpus_id}' as "
+                f"'{corpus_id}'."
+            )
+        self._obj.cancel_corpus_load()
+        self._clear_staging_metadata()
+
+    def _clear_staging_metadata(self) -> None:
+        self._staging_corpus_id = None
+        self._staging_corpus_handle = None
+        self._staging_token_count = 0
 
     def remove_external_corpus(self, corpus_id: str) -> None:
         self._obj.remove_corpus(corpus_id)
-        old_count = self._corpus_token_counts.pop(corpus_id, 0)
-        self._total_loaded_tokens -= old_count
+        metadata = self._corpora.pop(corpus_id, None)
+        if metadata is not None:
+            self._total_loaded_tokens -= metadata[1]
 
     def list_external_corpora(self) -> Dict[str, int]:
         return self._obj.list_corpora()
@@ -102,9 +167,40 @@ class NgramCorpus:
         req_ids: List[str],
         batch_tokens: List[List[int]],
         total_lens: List[int],
+        corpus_ids: Optional[List[Optional[str]]] = None,
     ) -> Tuple[np.ndarray, np.ndarray]:
+        if len(req_ids) != len(batch_tokens) or len(req_ids) != len(total_lens):
+            raise ValueError(
+                "req_ids, batch_tokens, and total_lens must have the same batch size"
+            )
+        if corpus_ids is not None and len(corpus_ids) != len(req_ids):
+            raise ValueError(
+                "corpus_ids must be omitted or match the request batch size "
+                f"({len(corpus_ids)} != {len(req_ids)})"
+            )
+        if corpus_ids is not None and any(
+            corpus_id is not None and not isinstance(corpus_id, str)
+            for corpus_id in corpus_ids
+        ):
+            raise ValueError("Every corpus_id must be a string or None.")
         state_ids = [self._get_state_id(rid) for rid in req_ids]
-        return self._obj.match_stateful(state_ids, batch_tokens, total_lens)
+        corpus_handles = None
+        if corpus_ids is not None:
+            corpus_handles = []
+            for corpus_id in corpus_ids:
+                if corpus_id is None:
+                    corpus_handles.append(_ALL_CORPORA_HANDLE)
+                elif not corpus_id:
+                    corpus_handles.append(_NO_CORPUS_HANDLE)
+                else:
+                    corpus_handles.append(
+                        self._corpora.get(
+                            corpus_id, (_NO_CORPUS_HANDLE, 0)
+                        )[0]
+                    )
+        return self._obj.match_stateful(
+            state_ids, batch_tokens, total_lens, corpus_handles
+        )
 
     def erase_match_state(self, req_ids: List[str]):
         state_ids = []

--- a/python/sglang/srt/speculative/external_corpus_manager.py
+++ b/python/sglang/srt/speculative/external_corpus_manager.py
@@ -4,7 +4,6 @@ Handles add/remove/list operations and async background loading.
 Used by the Scheduler — not a mixin, a standalone manager object.
 """
 
-import logging
 import threading
 from typing import Callable, Optional, Tuple
 
@@ -17,8 +16,6 @@ from sglang.srt.managers.io_struct import (
     RemoveExternalCorpusReqOutput,
 )
 
-logger = logging.getLogger(__name__)
-
 
 class ExternalCorpusManager:
     """Manages external SAM corpus lifecycle for a single scheduler.
@@ -28,29 +25,138 @@ class ExternalCorpusManager:
             remove_external_corpus, list_external_corpora methods).
         send_response: callable(output, recv_req) to send deferred responses
             back to the tokenizer manager.
+        synchronize_load_result: callable that aggregates a completed
+            local load across worker ranks before it is committed and returned.
+        cancel_load: callable that discards the worker's unpublished staging
+            corpus after a distributed build or commit failure.
     """
 
-    def __init__(self, draft_worker, send_response: Callable):
+    def __init__(
+        self,
+        draft_worker,
+        send_response: Callable,
+        synchronize_load_result: Callable,
+        cancel_load: Callable,
+    ):
         self._worker = draft_worker
         self._send_response = send_response
+        self._synchronize_load_result = synchronize_load_result
+        self._cancel_load = cancel_load
         self._pending_load: Optional[
             Tuple[AddExternalCorpusReqInput, threading.Thread]
         ] = None
         self._load_result: Optional[AddExternalCorpusReqOutput] = None
 
     def check_pending_load(self):
-        """Poll from the scheduler event loop. Sends response when done."""
+        """Coordinate, publish, and reply after a background build finishes."""
         if self._pending_load is None:
             return
         recv_req, thread = self._pending_load
-        if thread.is_alive():
+        corpus_id = recv_req.corpus_id or ""
+        local_result = None
+        if not thread.is_alive():
+            thread.join()  # formal happens-before for _load_result visibility
+            local_result = self._load_result
+        # Every participating scheduler rank calls the synchronizer on every
+        # pending poll, including ranks whose thread is still alive. This keeps
+        # distributed collective order identical across ranks.
+        result = self._synchronize_load_result(local_result)
+        if result is None:
             return
+
+        if not result.success:
+            # A locally successful build is still staging-only. Discard staging
+            # on every rank so the next load starts from the same clean state.
+            cleanup = self._cancel_staged_load(corpus_id)
+            cleanup_result = self._coordinate(cleanup)
+            assert cleanup_result is not None
+            if not cleanup_result.success:
+                result.message += f" Cleanup also failed: {cleanup_result.message}"
+            self._complete(result, recv_req)
+            return
+
+        assert local_result is not None
+        try:
+            self._worker.commit_corpus_load(corpus_id, local_result.loaded_token_count)
+            local_commit = AddExternalCorpusReqOutput(
+                success=True,
+                corpus_id=corpus_id,
+                message="External corpus commit succeeded.",
+                loaded_token_count=local_result.loaded_token_count,
+            )
+        except Exception as e:
+            local_commit = AddExternalCorpusReqOutput(
+                success=False,
+                corpus_id=corpus_id,
+                message=f"External corpus commit failed: {e}",
+            )
+
+        commit_result = self._coordinate(local_commit)
+        assert commit_result is not None
+        if commit_result.success:
+            # The commit-result collective is also the publication fence: no
+            # rank returns to inference until every rank has published.
+            self._complete(result, recv_req)
+            return
+
+        # Roll back ranks that published and cancel staging on ranks whose
+        # commit failed. Synchronize cleanup before any scheduler can resume.
+        cleanup = self._rollback_local_commit(corpus_id, local_commit.success)
+        # This coordination is the cleanup fence, not a substitute for checking
+        # whether rollback succeeded on every rank.
+        cleanup_result = self._coordinate(cleanup)
+        assert cleanup_result is not None
+        if not cleanup_result.success:
+            commit_result.message += f" Cleanup also failed: {cleanup_result.message}"
+        self._complete(commit_result, recv_req)
+
+    def _coordinate(
+        self, result: Optional[AddExternalCorpusReqOutput]
+    ) -> Optional[AddExternalCorpusReqOutput]:
+        return self._synchronize_load_result(result)
+
+    def _cancel_staged_load(self, corpus_id: str) -> AddExternalCorpusReqOutput:
+        try:
+            self._cancel_load(corpus_id)
+            return AddExternalCorpusReqOutput(
+                success=True,
+                corpus_id=corpus_id,
+                message="External corpus staging was cancelled.",
+            )
+        except Exception as e:
+            return AddExternalCorpusReqOutput(
+                success=False,
+                corpus_id=corpus_id,
+                message=f"Failed to cancel external corpus staging: {e}",
+            )
+
+    def _rollback_local_commit(
+        self, corpus_id: str, was_published: bool
+    ) -> AddExternalCorpusReqOutput:
+        try:
+            if was_published:
+                self._worker.remove_external_corpus(corpus_id)
+            else:
+                self._cancel_load(corpus_id)
+            return AddExternalCorpusReqOutput(
+                success=True,
+                corpus_id=corpus_id,
+                message="External corpus rollback succeeded.",
+            )
+        except Exception as e:
+            return AddExternalCorpusReqOutput(
+                success=False,
+                corpus_id=corpus_id,
+                message=f"External corpus rollback failed: {e}",
+            )
+
+    def _complete(
+        self,
+        result: AddExternalCorpusReqOutput,
+        recv_req: AddExternalCorpusReqInput,
+    ) -> None:
         self._pending_load = None
-        thread.join()  # formal happens-before for _load_result visibility
-        result = self._load_result
         self._load_result = None
-        if result.success:
-            self._worker.commit_corpus_load(result.corpus_id, result.loaded_token_count)
         self._send_response(result, recv_req)
 
     def add(
@@ -83,11 +189,20 @@ class ExternalCorpusManager:
         thread.start()
         return None  # response sent later by check_pending_load
 
-    # FIXME(kpham-sgl): remove a corpus during a pending load is an undefined behaviour
-    # and should be explicitly prevented.
     def remove(
         self, recv_req: RemoveExternalCorpusReqInput
     ) -> RemoveExternalCorpusReqOutput:
+        if (
+            self._pending_load is not None
+            and self._pending_load[0].corpus_id == recv_req.corpus_id
+        ):
+            return RemoveExternalCorpusReqOutput(
+                success=False,
+                message=(
+                    f"Cannot remove corpus '{recv_req.corpus_id}' while its load "
+                    "is pending."
+                ),
+            )
         try:
             self._worker.remove_external_corpus(recv_req.corpus_id)
             return RemoveExternalCorpusReqOutput(

--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -256,6 +256,9 @@ class NGRAMWorker(BaseSpecWorker):
         req_ids = []
         batch_tokens = []
         total_lens = []
+        # Keep the legacy all-SAM fast path allocation-free. Build an aligned
+        # selector list lazily only when one request explicitly selects a corpus.
+        corpus_ids: Optional[List[Optional[str]]] = None
         assert len(batch.reqs) == len(self.prev_accept_lens)
         # Overlap mode processes results one iteration behind, so the last
         # round's accepted tokens are not yet in req.output_ids and must be
@@ -263,8 +266,7 @@ class NGRAMWorker(BaseSpecWorker):
         # results before the next draft prep, so output_ids is already
         # complete and splicing would duplicate the tail.
         use_prev_tokens = self.enable_overlap and not batch.grammar_needs_sync()
-        i = 0
-        for req in batch.reqs:
+        for i, req in enumerate(batch.reqs):
             prev_tokens = (
                 self.prev_token_ids[i * stride : i * stride + self.prev_accept_lens[i]]
                 if use_prev_tokens
@@ -277,12 +279,15 @@ class NGRAMWorker(BaseSpecWorker):
             )
             req_ids.append(req.rid)
             batch_tokens.append(check_token)
-            i += 1
+            if corpus_ids is not None:
+                corpus_ids.append(req.ngram_corpus_id)
+            elif req.ngram_corpus_id is not None:
+                corpus_ids = [None] * i + [req.ngram_corpus_id]
             total_lens.append(
                 len(req.origin_input_ids) + len(req.output_ids) + len(prev_tokens)
             )
         req_drafts, mask = self.ngram_corpus.batch_get(
-            req_ids, batch_tokens, total_lens
+            req_ids, batch_tokens, total_lens, corpus_ids
         )
         total_draft_token_num = len(req_drafts)
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3702,6 +3702,7 @@ dependencies = [
  "axum 0.8.9",
  "bytemuck",
  "bytes",
+ "constant_time_eq",
  "core_affinity",
  "dynamo-parsers",
  "dynamo-protocols",

--- a/rust/sglang-grpc/src/utils/request_utils.rs
+++ b/rust/sglang-grpc/src/utils/request_utils.rs
@@ -243,6 +243,12 @@ pub(crate) fn build_text_generate_dict(
     if let Some(ref session_id) = req.session_id {
         d.insert("session_id".into(), serde_json::json!(session_id));
     }
+    if let Some(ref ngram_corpus_id) = req.ngram_corpus_id {
+        d.insert(
+            "ngram_corpus_id".into(),
+            serde_json::json!(ngram_corpus_id),
+        );
+    }
     insert_generation_controls(
         &mut d,
         req.priority,
@@ -296,6 +302,12 @@ pub(crate) fn build_generate_dict(
     }
     if let Some(ref session_id) = req.session_id {
         d.insert("session_id".into(), serde_json::json!(session_id));
+    }
+    if let Some(ref ngram_corpus_id) = req.ngram_corpus_id {
+        d.insert(
+            "ngram_corpus_id".into(),
+            serde_json::json!(ngram_corpus_id),
+        );
     }
     insert_generation_controls(
         &mut d,
@@ -462,6 +474,7 @@ mod tests {
             priority: Some(3),
             require_reasoning: Some(false),
             max_thinking_tokens: Some(128),
+            ngram_corpus_id: Some("docs".into()),
             ..Default::default()
         };
         let token_request = proto::GenerateRequest {
@@ -472,6 +485,7 @@ mod tests {
             priority: Some(3),
             require_reasoning: Some(false),
             max_thinking_tokens: Some(128),
+            ngram_corpus_id: Some("docs".into()),
             ..Default::default()
         };
 
@@ -482,6 +496,7 @@ mod tests {
             assert_eq!(mapped["priority"], serde_json::json!(3));
             assert_eq!(mapped["require_reasoning"], serde_json::json!(false));
             assert_eq!(mapped["max_thinking_tokens"], serde_json::json!(128));
+            assert_eq!(mapped["ngram_corpus_id"], serde_json::json!("docs"));
             assert_eq!(
                 mapped["sampling_params"]["sampling_seed"],
                 serde_json::json!(42)
@@ -495,6 +510,7 @@ mod tests {
             assert!(!mapped.contains_key("priority"));
             assert!(!mapped.contains_key("require_reasoning"));
             assert!(!mapped.contains_key("max_thinking_tokens"));
+            assert!(!mapped.contains_key("ngram_corpus_id"));
         }
     }
 

--- a/rust/sglang-server/Cargo.toml
+++ b/rust/sglang-server/Cargo.toml
@@ -36,6 +36,7 @@ arc-swap = "1"
 axum = { version = "0.8.9", features = ["json", "tokio"] }
 # Safe POD slice casts (feature buffers viewed as bytes for the shm copy).
 bytemuck = "1"
+constant_time_eq = "0.4"
 core_affinity = "0.8"
 # the dynamo-tokenizers is deps on hf-hub, should bump version together.
 dynamo-tokenizers = "1.7.0"

--- a/rust/sglang-server/src/api_server.rs
+++ b/rust/sglang-server/src/api_server.rs
@@ -55,15 +55,17 @@ pub async fn serve(
     };
     // Each endpoint module registers its own routes and merges here.
     let router = Router::new()
-        .merge(common::routes())
+        .merge(common::routes(&server_args))
         .merge(native_api::routes())
         .merge(openai::routes());
 
-    // TODO(auth): no API-key boundary yet. Python gates every route (except
-    // /health*, /metrics*, OPTIONS) via `add_api_key_middleware`; until ported,
-    // a configured `api_key` does NOT protect these routes.
+    // TODO(auth): the general Python API-key boundary has not been ported yet.
+    // The external-corpus management routes enforce their ADMIN_OPTIONAL key
+    // policy locally because they mutate server state; other routes remain as
+    // documented by the existing Rust-server limitation.
     //
-    // No body limit, matching the Python server.
+    // No global body limit, matching the Python server. Routes that deserialize
+    // unusually large nested inputs install their own tighter limit.
     let mut app = router
         .layer(axum::extract::DefaultBodyLimit::disable())
         .with_state(state);

--- a/rust/sglang-server/src/api_server/common.rs
+++ b/rust/sglang-server/src/api_server/common.rs
@@ -6,21 +6,43 @@
 //! `api_server` module.
 
 use axum::{
+    Json,
     Router,
-    extract::State,
-    http::StatusCode,
+    extract::{DefaultBodyLimit, FromRequestParts, State, rejection::JsonRejection},
+    http::{StatusCode, header::AUTHORIZATION, request::Parts},
     response::{IntoResponse, Response},
-    routing::get,
+    routing::{get, post},
 };
+use serde::Deserialize;
 
 use super::AppState;
 use super::guard::AbortGuard;
 use super::submit::submit;
-use crate::message::{ControlRequest, EgressItem, GetInternalStateReq, RequestKind};
+use crate::message::{
+    AddExternalCorpusReqInput, ControlRequest, EgressItem, GetInternalStateReq,
+    ListExternalCorporaReqInput, RemoveExternalCorpusReqInput, RequestKind,
+};
 use crate::runtime::ServerArgs;
 
+// A signed-i32 token needs at most 11 decimal bytes. Even when every token is in
+// its own chunk, brackets and separators keep compact JSON below 16 bytes/token.
+// The fixed allowance covers field names and framing.
+const EXTERNAL_CORPUS_ADD_BODY_BYTES_PER_TOKEN: usize = 16;
+const EXTERNAL_CORPUS_ADD_BODY_FIXED_BYTES: usize = 1 << 20;
+
 /// The routes this module owns, mounted by `api_server::serve`.
-pub(super) fn routes() -> Router<AppState> {
+pub(super) fn routes(server_args: &ServerArgs) -> Router<AppState> {
+    routes_with_external_body_limit(external_corpus_add_body_limit(server_args))
+}
+
+fn external_corpus_add_body_limit(server_args: &ServerArgs) -> usize {
+    server_args
+        .speculative_ngram_external_corpus_max_tokens
+        .saturating_mul(EXTERNAL_CORPUS_ADD_BODY_BYTES_PER_TOKEN)
+        .saturating_add(EXTERNAL_CORPUS_ADD_BODY_FIXED_BYTES)
+}
+
+fn routes_with_external_body_limit(add_body_limit: usize) -> Router<AppState> {
     Router::new()
         // Control-plane: reuses the ingress FSM (no tokenization), returns one
         // non-streamed JSON result. Adding one = a route line + its struct tag.
@@ -29,6 +51,368 @@ pub(super) fn routes() -> Router<AppState> {
         // alias).
         .route("/get_model_info", get(model_info))
         .route("/model_info", get(model_info))
+        .route(
+            "/add_external_corpus",
+            post(add_external_corpus).layer(DefaultBodyLimit::max(add_body_limit)),
+        )
+        .route("/remove_external_corpus", post(remove_external_corpus))
+        .route("/list_external_corpora", get(list_external_corpora))
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct AddExternalCorpusBody {
+    #[serde(default)]
+    corpus_id: Option<String>,
+    #[serde(default)]
+    file_path: Option<String>,
+    #[serde(default)]
+    documents: Option<Vec<String>>,
+    #[serde(default)]
+    token_chunks: Option<Vec<Vec<i32>>>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RemoveExternalCorpusBody {
+    corpus_id: String,
+}
+
+/// Authentication guard for the Python endpoints' `ADMIN_OPTIONAL` level.
+///
+/// This is a parts extractor (and is the first handler argument), so an
+/// unauthorized upload is rejected before Axum/serde reads or allocates its
+/// request body.
+struct ExternalCorpusAuth;
+
+impl FromRequestParts<AppState> for ExternalCorpusAuth {
+    type Rejection = Response;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        if external_corpus_authorized(parts, &state.server_args) {
+            Ok(Self)
+        } else {
+            Err((
+                StatusCode::UNAUTHORIZED,
+                Json(serde_json::json!({"error": "Unauthorized"})),
+            )
+                .into_response())
+        }
+    }
+}
+
+fn external_corpus_authorized(parts: &Parts, server_args: &ServerArgs) -> bool {
+    // ADMIN_OPTIONAL precedence matches Python: an admin key, when configured,
+    // supersedes the ordinary API key for these management endpoints.
+    let expected = server_args
+        .admin_api_key
+        .as_deref()
+        .filter(|key| !key.is_empty())
+        .or_else(|| {
+            server_args
+                .api_key
+                .as_deref()
+                .filter(|key| !key.is_empty())
+        });
+    let Some(expected) = expected else {
+        return true;
+    };
+    let Some(value) = parts
+        .headers
+        .get(AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+    else {
+        return false;
+    };
+    let Some((scheme, token)) = value.split_once(' ') else {
+        return false;
+    };
+    scheme.eq_ignore_ascii_case("bearer")
+        && constant_time_eq::constant_time_eq(token.as_bytes(), expected.as_bytes())
+}
+
+#[derive(Default, Deserialize)]
+struct ExternalCorpusControlResult {
+    success: bool,
+    #[serde(default)]
+    corpus_id: String,
+    #[serde(default)]
+    message: String,
+    #[serde(default)]
+    loaded_token_count: u64,
+    #[serde(default)]
+    corpus_token_counts: std::collections::BTreeMap<String, u64>,
+}
+
+enum ExternalCorpusResponseKind {
+    Add,
+    Remove,
+    List,
+}
+
+fn external_corpus_response(
+    value: ExternalCorpusControlResult,
+    kind: ExternalCorpusResponseKind,
+    status: StatusCode,
+) -> Response {
+    let public = match kind {
+        ExternalCorpusResponseKind::Add => serde_json::json!({
+            "success": value.success,
+            "corpus_id": value.corpus_id,
+            "message": value.message,
+            "loaded_token_count": value.loaded_token_count,
+        }),
+        ExternalCorpusResponseKind::Remove => serde_json::json!({
+            "success": value.success,
+            "message": value.message,
+        }),
+        ExternalCorpusResponseKind::List => serde_json::json!({
+            "success": value.success,
+            "corpus_token_counts": value.corpus_token_counts,
+            "message": value.message,
+        }),
+    };
+    (status, Json(public)).into_response()
+}
+
+fn corpus_error(kind: ExternalCorpusResponseKind, message: impl Into<String>) -> Response {
+    external_corpus_response(
+        ExternalCorpusControlResult {
+            message: message.into(),
+            ..Default::default()
+        },
+        kind,
+        StatusCode::BAD_REQUEST,
+    )
+}
+
+fn corpus_json_rejection(kind: ExternalCorpusResponseKind, error: JsonRejection) -> Response {
+    let status = error.status();
+    external_corpus_response(
+        ExternalCorpusControlResult {
+            message: error.body_text(),
+            ..Default::default()
+        },
+        kind,
+        status,
+    )
+}
+
+fn supports_dynamic_external_corpus(server_args: &ServerArgs) -> bool {
+    server_args.pp_size == 1 && server_args.dp_size == 1
+}
+
+fn external_corpus_backend_error(
+    state: &AppState,
+    kind: ExternalCorpusResponseKind,
+) -> Option<Response> {
+    (state.server_args.speculative_algorithm.as_deref() != Some("NGRAM")).then(|| {
+        corpus_error(kind, "Ngram speculative decoding is not enabled.")
+    })
+}
+
+fn external_corpus_topology_error(
+    state: &AppState,
+    kind: ExternalCorpusResponseKind,
+) -> Option<Response> {
+    (!supports_dynamic_external_corpus(&state.server_args)).then(|| {
+        corpus_error(
+            kind,
+            "dynamic external corpus management requires pp_size=1 and dp_size=1; use the startup external-corpus option for DP/PP deployments",
+        )
+    })
+}
+
+fn corpus_control_response(bytes: bytes::Bytes, kind: ExternalCorpusResponseKind) -> Response {
+    match rmp_serde::from_slice::<ExternalCorpusControlResult>(&bytes) {
+        // Match the Python endpoints: operational failures are public 400s,
+        // while successful scheduler replies are 200s. Typed decoding also
+        // strips internal BaseReq fields such as rid/http_worker_ipc.
+        Ok(value) => {
+            let status = if value.success {
+                StatusCode::OK
+            } else {
+                StatusCode::BAD_REQUEST
+            };
+            external_corpus_response(value, kind, status)
+        }
+        Err(error) => {
+            tracing::error!(%error, "invalid external-corpus control response");
+            external_corpus_response(
+                ExternalCorpusControlResult {
+                    message: "bad external-corpus response".into(),
+                    ..Default::default()
+                },
+                kind,
+                StatusCode::INTERNAL_SERVER_ERROR,
+            )
+        }
+    }
+}
+
+fn validate_corpus_id(corpus_id: &str) -> Result<(), &'static str> {
+    if corpus_id
+        .chars()
+        .any(|ch| matches!(ch, '\t' | '\n' | '\r'))
+    {
+        return Err("corpus_id must not contain tabs or newlines");
+    }
+    Ok(())
+}
+
+fn validate_token_chunks(
+    chunks: &[Vec<i32>],
+    max_tokens: usize,
+    vocab_size: u64,
+) -> Result<(), String> {
+    if chunks.is_empty() || chunks.iter().any(Vec::is_empty) {
+        return Err("token_chunks must be non-empty and contain no empty chunks".into());
+    }
+    let total_tokens = chunks
+        .iter()
+        .try_fold(0usize, |total, chunk| total.checked_add(chunk.len()))
+        .ok_or_else(|| "token_chunks token count overflow".to_string())?;
+    if total_tokens > max_tokens {
+        return Err(format!(
+            "token_chunks total {total_tokens} exceeds external corpus token limit {max_tokens}"
+        ));
+    }
+    for (chunk_index, chunk) in chunks.iter().enumerate() {
+        for (token_index, &token) in chunk.iter().enumerate() {
+            if token != i32::MIN && !(token >= 0 && (token as u64) < vocab_size) {
+                return Err(format!(
+                    "token_chunks[{chunk_index}][{token_index}]={token} is outside the model vocabulary"
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn add_external_corpus(
+    _auth: ExternalCorpusAuth,
+    State(state): State<AppState>,
+    body: Result<Json<AddExternalCorpusBody>, JsonRejection>,
+) -> Response {
+    let body = match body {
+        Ok(Json(body)) => body,
+        Err(error) => {
+            return corpus_json_rejection(ExternalCorpusResponseKind::Add, error);
+        }
+    };
+    if let Some(response) =
+        external_corpus_backend_error(&state, ExternalCorpusResponseKind::Add)
+    {
+        return response;
+    }
+    if let Some(response) =
+        external_corpus_topology_error(&state, ExternalCorpusResponseKind::Add)
+    {
+        return response;
+    }
+    if state.server_args.speculative_ngram_external_sam_budget == 0 {
+        return corpus_error(
+            ExternalCorpusResponseKind::Add,
+            "dynamic external corpus loading is disabled; set --speculative-ngram-external-sam-budget to a positive value",
+        );
+    }
+    if body.file_path.is_some() || body.documents.is_some() {
+        return corpus_error(
+            ExternalCorpusResponseKind::Add,
+            "the Rust server accepts token_chunks only; tokenize file_path/documents client-side",
+        );
+    }
+    let Some(chunks) = body.token_chunks else {
+        return corpus_error(
+            ExternalCorpusResponseKind::Add,
+            "token_chunks must be provided",
+        );
+    };
+    let vocab_size = state.server_args.model_config.vocab_size.unwrap_or(0);
+    if let Err(message) = validate_token_chunks(
+        &chunks,
+        state.server_args.speculative_ngram_external_corpus_max_tokens,
+        vocab_size,
+    ) {
+        return corpus_error(ExternalCorpusResponseKind::Add, message);
+    }
+    let corpus_id = body
+        .corpus_id
+        .filter(|id| !id.is_empty())
+        .unwrap_or_else(|| uuid::Uuid::new_v4().simple().to_string());
+    if let Err(message) = validate_corpus_id(&corpus_id) {
+        return corpus_error(ExternalCorpusResponseKind::Add, message);
+    }
+    let control = ControlRequest::AddExternalCorpusReqInput(AddExternalCorpusReqInput::new(
+        crate::ids::Rid::new().to_string(),
+        corpus_id,
+        chunks,
+    ));
+    match await_control_result(&state, control).await {
+        Ok(bytes) => corpus_control_response(bytes, ExternalCorpusResponseKind::Add),
+        Err(response) => response,
+    }
+}
+
+async fn remove_external_corpus(
+    _auth: ExternalCorpusAuth,
+    State(state): State<AppState>,
+    body: Result<Json<RemoveExternalCorpusBody>, JsonRejection>,
+) -> Response {
+    let body = match body {
+        Ok(Json(body)) => body,
+        Err(error) => {
+            return corpus_json_rejection(ExternalCorpusResponseKind::Remove, error);
+        }
+    };
+    if let Some(response) =
+        external_corpus_backend_error(&state, ExternalCorpusResponseKind::Remove)
+    {
+        return response;
+    }
+    if let Some(response) =
+        external_corpus_topology_error(&state, ExternalCorpusResponseKind::Remove)
+    {
+        return response;
+    }
+    if body.corpus_id.is_empty() {
+        return corpus_error(
+            ExternalCorpusResponseKind::Remove,
+            "corpus_id is required",
+        );
+    }
+    if let Err(message) = validate_corpus_id(&body.corpus_id) {
+        return corpus_error(ExternalCorpusResponseKind::Remove, message);
+    }
+    let control = ControlRequest::RemoveExternalCorpusReqInput(RemoveExternalCorpusReqInput::new(
+        crate::ids::Rid::new().to_string(),
+        body.corpus_id,
+    ));
+    match await_control_result(&state, control).await {
+        Ok(bytes) => corpus_control_response(bytes, ExternalCorpusResponseKind::Remove),
+        Err(response) => response,
+    }
+}
+
+async fn list_external_corpora(
+    _auth: ExternalCorpusAuth,
+    State(state): State<AppState>,
+) -> Response {
+    if let Some(response) =
+        external_corpus_backend_error(&state, ExternalCorpusResponseKind::List)
+    {
+        return response;
+    }
+    let control = ControlRequest::ListExternalCorporaReqInput(ListExternalCorporaReqInput::new(
+        crate::ids::Rid::new().to_string(),
+    ));
+    match await_control_result(&state, control).await {
+        Ok(bytes) => corpus_control_response(bytes, ExternalCorpusResponseKind::List),
+        Err(response) => response,
+    }
 }
 
 /// Submit a control request through the ingress FSM (no tokenization) and await the
@@ -153,8 +537,9 @@ fn shape_server_info(msgpack: &[u8], server_args: &ServerArgs) -> Result<Vec<u8>
         }
     }
 
-    // Top-level non-secret config from typed accessors (structurally can't surface
-    // a key field, unlike the raw dump).
+    // Top-level config is an explicit non-secret allowlist. Never serialize the
+    // whole typed ServerArgs here: it also holds the API/admin keys used by the
+    // management-route auth guard.
     let response = serde_json::json!({
         "model_path": server_args.model_path,
         "served_model_name": server_args.served_model_name,
@@ -169,7 +554,213 @@ fn shape_server_info(msgpack: &[u8], server_args: &ServerArgs) -> Result<Vec<u8>
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use axum::{body::Body, http::Request};
+    use tower::ServiceExt;
+
     use super::*;
+    use crate::tokenizer_manager::Senders;
+
+    fn senders() -> Senders {
+        Senders {
+            tm: flume::unbounded().0,
+            abort: flume::unbounded().0,
+            tok: flume::unbounded().0,
+            detok: vec![],
+        }
+    }
+
+    fn app_state(senders: Senders) -> AppState {
+        AppState {
+            senders,
+            egress_buf: 8,
+            server_args: Arc::new(
+                ServerArgs::from_json(r#"{"speculative_algorithm":"NGRAM"}"#).unwrap(),
+            ),
+            chat_formatter: None,
+            egress_activity: Default::default(),
+        }
+    }
+
+    #[test]
+    fn external_corpus_topology_requires_single_pp_and_dp() {
+        let single = ServerArgs::from_json(r#"{"pp_size": 1, "dp_size": 1}"#).unwrap();
+        let pp = ServerArgs::from_json(r#"{"pp_size": 2, "dp_size": 1}"#).unwrap();
+        let dp = ServerArgs::from_json(r#"{"pp_size": 1, "dp_size": 2}"#).unwrap();
+        assert!(supports_dynamic_external_corpus(&single));
+        assert!(!supports_dynamic_external_corpus(&pp));
+        assert!(!supports_dynamic_external_corpus(&dp));
+    }
+
+    #[tokio::test]
+    async fn external_corpus_operational_failure_is_public_http_400() {
+        let payload = rmp_serde::to_vec(&serde_json::json!({
+            "success": false,
+            "corpus_id": "",
+            "message": "duplicate",
+            "loaded_token_count": 0,
+            "rid": "internal-rid",
+            "http_worker_ipc": "internal-ipc"
+        }))
+        .unwrap();
+        let payload = bytes::Bytes::from(payload);
+        let response = corpus_control_response(payload.clone(), ExternalCorpusResponseKind::Add);
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = axum::body::to_bytes(response.into_body(), 4096)
+            .await
+            .unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(value["success"], false);
+        assert_eq!(value["message"], "duplicate");
+        assert!(value.get("rid").is_none());
+        assert!(value.get("http_worker_ipc").is_none());
+        assert_eq!(value.as_object().unwrap().len(), 4);
+
+        let response = corpus_control_response(payload.clone(), ExternalCorpusResponseKind::Remove);
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = axum::body::to_bytes(response.into_body(), 4096)
+            .await
+            .unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(value.as_object().unwrap().len(), 2);
+        assert!(value.get("corpus_id").is_none());
+
+        let response = corpus_control_response(payload, ExternalCorpusResponseKind::List);
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = axum::body::to_bytes(response.into_body(), 4096)
+            .await
+            .unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(value.as_object().unwrap().len(), 3);
+        assert_eq!(value["corpus_token_counts"], serde_json::json!({}));
+    }
+
+    #[test]
+    fn external_corpus_auth_matches_admin_optional_precedence() {
+        fn authorized(server_args: &ServerArgs, value: Option<&str>) -> bool {
+            let mut request = Request::builder();
+            if let Some(value) = value {
+                request = request.header(AUTHORIZATION, value);
+            }
+            let (parts, ()) = request.body(()).unwrap().into_parts();
+            external_corpus_authorized(&parts, server_args)
+        }
+
+        let none = ServerArgs::from_json("{}").unwrap();
+        assert!(authorized(&none, None));
+
+        let api = ServerArgs::from_json(r#"{"api_key":"api-secret"}"#).unwrap();
+        assert!(!authorized(&api, None));
+        assert!(authorized(&api, Some("Bearer api-secret")));
+        assert!(authorized(&api, Some("bearer api-secret")));
+        assert!(!authorized(&api, Some("Bearer wrong")));
+
+        let both = ServerArgs::from_json(
+            r#"{"api_key":"api-secret","admin_api_key":"admin-secret"}"#,
+        )
+        .unwrap();
+        assert!(!authorized(&both, Some("Bearer api-secret")));
+        assert!(authorized(&both, Some("Bearer admin-secret")));
+    }
+
+    #[tokio::test]
+    async fn add_external_corpus_body_limit_overrides_global_disable() {
+        let app = routes_with_external_body_limit(16)
+            .layer(DefaultBodyLimit::disable())
+            .with_state(app_state(senders()));
+        let request = Request::builder()
+            .method("POST")
+            .uri("/add_external_corpus")
+            .header("content-type", "application/json")
+            .body(Body::from(r#"{"token_chunks":[[1]]}"#))
+            .unwrap();
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    #[tokio::test]
+    async fn external_corpus_auth_rejects_before_body_validation() {
+        let mut state = app_state(senders());
+        let server_args = ServerArgs::from_json(
+            r#"{"api_key":"api-secret","speculative_algorithm":"NGRAM"}"#,
+        )
+        .unwrap();
+        state.server_args = Arc::new(server_args);
+        let app = routes(&state.server_args).with_state(state);
+        let request = Request::builder()
+            .method("POST")
+            .uri("/add_external_corpus")
+            .header("content-type", "application/json")
+            .body(Body::from("not json"))
+            .unwrap();
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn add_external_corpus_requires_positive_sam_budget() {
+        let state = app_state(senders());
+        let app = routes(&state.server_args).with_state(state);
+        let request = Request::builder()
+            .method("POST")
+            .uri("/add_external_corpus")
+            .header("content-type", "application/json")
+            .body(Body::from(r#"{"token_chunks":[[1]]}"#))
+            .unwrap();
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn add_external_corpus_requires_ngram_backend() {
+        let mut state = app_state(senders());
+        state.server_args = Arc::new(ServerArgs::from_json("{}").unwrap());
+        let app = routes(&state.server_args).with_state(state);
+        let request = Request::builder()
+            .method("POST")
+            .uri("/add_external_corpus")
+            .header("content-type", "application/json")
+            .body(Body::from(r#"{"token_chunks":[[1]]}"#))
+            .unwrap();
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn external_corpus_body_limit_tracks_configured_token_limit() {
+        let args = ServerArgs::from_json(
+            r#"{"speculative_ngram_external_corpus_max_tokens":20000000}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            external_corpus_add_body_limit(&args),
+            20_000_000 * EXTERNAL_CORPUS_ADD_BODY_BYTES_PER_TOKEN
+                + EXTERNAL_CORPUS_ADD_BODY_FIXED_BYTES
+        );
+    }
+
+    #[test]
+    fn exact_token_chunks_are_strictly_validated() {
+        assert!(validate_token_chunks(&[vec![1, 2], vec![i32::MIN, 3]], 5, 4).is_ok());
+        assert!(validate_token_chunks(&[], 5, 4).is_err());
+        assert!(validate_token_chunks(&[Vec::new()], 5, 4).is_err());
+        assert!(validate_token_chunks(&[vec![1, 2, 3]], 2, 4).is_err());
+        assert!(validate_token_chunks(&[vec![-1]], 5, 4).is_err());
+        assert!(validate_token_chunks(&[vec![4]], 5, 4).is_err());
+        for body in [
+            r#"{"token_chunks": [[true]]}"#,
+            r#"{"token_chunks": [[1.0]]}"#,
+            r#"{"token_chunks": [["1"]]}"#,
+            r#"{"token_chunks": [[2147483648]]}"#,
+            r#"{"token_chunks": [[1]], "unknown": true}"#,
+        ] {
+            assert!(serde_json::from_str::<AddExternalCorpusBody>(body).is_err());
+        }
+        assert!(validate_corpus_id("docs").is_ok());
+        assert!(validate_corpus_id("bad\tname").is_err());
+        assert!(validate_corpus_id("bad\nname").is_err());
+    }
 
     /// The scheduler's `internal_state` embeds the full server-args dump (incl.
     /// `api_key`/`admin_api_key`). `/server_info` must surface only the allowlisted

--- a/rust/sglang-server/src/api_server/openai/chat.rs
+++ b/rust/sglang-server/src/api_server/openai/chat.rs
@@ -23,6 +23,7 @@ use dynamo_protocols::types::{
     TopLogprobs,
 };
 use futures::StreamExt;
+use serde::Deserialize;
 use tokio::sync::mpsc;
 
 use super::super::guard::AbortGuard;
@@ -43,12 +44,20 @@ pub(super) fn routes() -> Router<AppState> {
     Router::new().route("/v1/chat/completions", post(chat_completions))
 }
 
+#[derive(Deserialize)]
+struct ChatCompletionRequestWithExtensions {
+    #[serde(flatten)]
+    request: CreateChatCompletionRequest,
+    #[serde(default)]
+    ngram_corpus_id: Option<String>,
+}
+
 async fn chat_completions(
     State(state): State<AppState>,
-    body: Result<Json<CreateChatCompletionRequest>, JsonRejection>,
+    body: Result<Json<ChatCompletionRequestWithExtensions>, JsonRejection>,
 ) -> Response {
-    let request = match body {
-        Ok(Json(request)) => request,
+    let (request, ngram_corpus_id) = match body {
+        Ok(Json(body)) => (body.request, body.ngram_corpus_id),
         Err(rejection) => {
             return openai_error(StatusCode::BAD_REQUEST, rejection.body_text(), false);
         }
@@ -196,6 +205,7 @@ async fn chat_completions(
             logprob_start_len: -1,
             top_logprobs_num: request.top_logprobs.unwrap_or(0) as i64,
             return_text_in_logprobs: want_logprobs.then_some(true),
+            ngram_corpus_id: ngram_corpus_id.clone(),
             ..Default::default()
         };
         let rx = match submit_generation(&state, native, stream, &mut guard).await {
@@ -847,14 +857,15 @@ pub(super) fn chat_logprobs(extras: Option<&ChunkExtras>) -> ChatChoiceLogprobs 
 
 #[cfg(test)]
 mod tests {
-    use super::super::test_utils::{chat_submitted, chunk, senders};
+    use super::super::test_utils::{app_state, chat_submitted, chunk, post_json, senders};
     use super::{
-        SamplingDefaults, chat_event_stream, chat_logprobs, chat_sampling_params,
-        merge_template_stops, unary_chat,
+        ChatCompletionRequestWithExtensions, SamplingDefaults, chat_event_stream, chat_logprobs,
+        chat_sampling_params, merge_template_stops, unary_chat,
     };
     use crate::api_server::guard::AbortGuard;
-    use crate::message::ChunkExtras;
+    use crate::message::{ChunkExtras, RequestKind};
     use crate::runtime::DefaultSamplingParams;
+    use crate::tokenizer_manager::TmEvent;
     use axum::http::StatusCode;
     use dynamo_protocols::types::{CreateChatCompletionRequest, Stop};
     use futures::StreamExt;
@@ -865,6 +876,56 @@ mod tests {
             "messages": [{"role": "user", "content": "hi"}]
         }))
         .unwrap()
+    }
+
+    #[test]
+    fn ngram_corpus_extension_is_not_dropped() {
+        let body: ChatCompletionRequestWithExtensions =
+            serde_json::from_value(serde_json::json!({
+                "model": "test",
+                "messages": [{"role": "user", "content": "hi"}],
+                "ngram_corpus_id": "docs"
+            }))
+            .unwrap();
+        assert_eq!(body.ngram_corpus_id.as_deref(), Some("docs"));
+    }
+
+    #[tokio::test]
+    async fn ngram_corpus_extension_reaches_submitted_request() {
+        let (tm, tm_rx) = flume::unbounded();
+        let mut channels = senders();
+        channels.tm = tm;
+        let mut state = app_state(channels);
+        let chatml = super::super::template::builtin_template("chatml").unwrap();
+        state.chat_formatter = Some(super::super::ChatFormatter::Legacy(Box::new(
+            super::super::template::LegacyFormatter { spec: chatml },
+        )));
+        let app = super::routes().with_state(state);
+        let response_task = tokio::spawn(post_json(
+            app,
+            "/v1/chat/completions",
+            serde_json::json!({
+                "model": "model",
+                "messages": [{"role": "user", "content": "hello"}],
+                "ngram_corpus_id": "docs"
+            }),
+        ));
+
+        let event = tm_rx.recv_async().await.unwrap();
+        let TmEvent::Ingress(request) = event else {
+            panic!("expected ingress request");
+        };
+        let RequestKind::Generate(native) = &request.kind else {
+            panic!("expected generation request");
+        };
+        assert_eq!(native.ngram_corpus_id.as_deref(), Some("docs"));
+        request
+            .sink
+            .try_send(chunk(request.rid.as_str(), "ok", true))
+            .unwrap();
+
+        let response = response_task.await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
     }
 
     /// Python `to_sampling_params` priority: user value > model generation

--- a/rust/sglang-server/src/api_server/openai/completions.rs
+++ b/rust/sglang-server/src/api_server/openai/completions.rs
@@ -18,6 +18,7 @@ use dynamo_protocols::types::{
     CreateCompletionResponse, Logprobs, Prompt, Stop,
 };
 use futures::StreamExt;
+use serde::Deserialize;
 use tokio::sync::mpsc;
 
 use super::super::guard::AbortGuard;
@@ -34,6 +35,14 @@ use crate::message::{
 
 pub(super) fn routes() -> Router<AppState> {
     Router::new().route("/v1/completions", post(completions))
+}
+
+#[derive(Deserialize)]
+struct CompletionRequestWithExtensions {
+    #[serde(flatten)]
+    request: CreateCompletionRequest,
+    #[serde(default)]
+    ngram_corpus_id: Option<OneOrMany<Option<String>>>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -59,10 +68,10 @@ pub(super) struct ChoiceExtensions {
 
 async fn completions(
     State(state): State<AppState>,
-    body: Result<Json<CreateCompletionRequest>, JsonRejection>,
+    body: Result<Json<CompletionRequestWithExtensions>, JsonRejection>,
 ) -> Response {
-    let request = match body {
-        Ok(Json(request)) => request,
+    let (request, ngram_corpus_id) = match body {
+        Ok(Json(body)) => (body.request, body.ngram_corpus_id),
         Err(rejection) => {
             return openai_error(StatusCode::BAD_REQUEST, rejection.body_text(), false);
         }
@@ -115,6 +124,22 @@ async fn completions(
             return openai_error(StatusCode::BAD_REQUEST, &message, false);
         }
     };
+    let ngram_corpus_ids = match ngram_corpus_id {
+        None => vec![None; prompts.len()],
+        Some(OneOrMany::One(value)) => vec![value; prompts.len()],
+        Some(OneOrMany::Many(values)) if values.len() == prompts.len() => values,
+        Some(OneOrMany::Many(values)) => {
+            return openai_error(
+                StatusCode::BAD_REQUEST,
+                format!(
+                    "ngram_corpus_id list length {} does not match prompt count {}",
+                    values.len(),
+                    prompts.len()
+                ),
+                false,
+            );
+        }
+    };
     let mut sampling = match completion_sampling_params(&request) {
         Ok(sampling) => sampling,
         Err(message) => {
@@ -148,7 +173,11 @@ async fn completions(
     let mut guard = AbortGuard::new_empty(state.senders.clone());
     let mut submitted = Vec::with_capacity(choice_count);
 
-    for (prompt_index, prompt) in prompts.into_iter().enumerate() {
+    for (prompt_index, (prompt, ngram_corpus_id)) in prompts
+        .into_iter()
+        .zip(ngram_corpus_ids)
+        .enumerate()
+    {
         let (text, input_ids, mut prompt_echo) = match prompt {
             PromptSpec::Text(text) => {
                 let prompt_echo = if echo { text.clone() } else { String::new() };
@@ -182,6 +211,7 @@ async fn completions(
                 },
                 top_logprobs_num: request.logprobs.unwrap_or(0) as i64,
                 return_text_in_logprobs: request.logprobs.map(|_| true),
+                ngram_corpus_id: ngram_corpus_id.clone(),
                 ..Default::default()
             };
             let rx = match submit_generation(&state, native, stream, &mut guard).await {
@@ -733,13 +763,14 @@ fn append_top_logprobs(
 
 #[cfg(test)]
 mod tests {
-    use super::super::test_utils::{chunk, senders, submitted};
+    use super::super::test_utils::{app_state, chunk, post_json, senders, submitted};
     use super::{
-        ChoiceExtensions, PromptSpec, completion_event_stream, completion_logprobs,
-        completion_prompt_specs, completion_response_value, unary_completion,
+        ChoiceExtensions, CompletionRequestWithExtensions, PromptSpec, completion_event_stream,
+        completion_logprobs, completion_prompt_specs, completion_response_value, unary_completion,
     };
     use crate::api_server::guard::AbortGuard;
-    use crate::message::ChunkExtras;
+    use crate::message::{ChunkExtras, RequestKind};
+    use crate::tokenizer_manager::TmEvent;
     use axum::http::StatusCode;
     use dynamo_protocols::types::{
         Choice, CreateCompletionRequest, CreateCompletionResponse, Prompt,
@@ -762,6 +793,56 @@ mod tests {
         assert!(matches!(request.prompt, Prompt::StringArray(_)));
         assert_eq!(request.n, Some(2));
         assert!(request.stream_options.unwrap().continuous_usage_stats);
+    }
+
+    #[test]
+    fn ngram_corpus_extension_is_not_dropped() {
+        let body: CompletionRequestWithExtensions =
+            serde_json::from_value(serde_json::json!({
+                "model": "m",
+                "prompt": ["a", "b"],
+                "ngram_corpus_id": ["docs", null]
+            }))
+            .unwrap();
+        assert!(matches!(body.request.prompt, Prompt::StringArray(_)));
+        assert!(matches!(
+            body.ngram_corpus_id,
+            Some(crate::message::OneOrMany::Many(values))
+                if values == vec![Some("docs".into()), None]
+        ));
+    }
+
+    #[tokio::test]
+    async fn ngram_corpus_extension_reaches_submitted_request() {
+        let (tm, tm_rx) = flume::unbounded();
+        let mut channels = senders();
+        channels.tm = tm;
+        let app = super::routes().with_state(app_state(channels));
+        let response_task = tokio::spawn(post_json(
+            app,
+            "/v1/completions",
+            serde_json::json!({
+                "model": "model",
+                "prompt": "hello",
+                "ngram_corpus_id": "docs"
+            }),
+        ));
+
+        let event = tm_rx.recv_async().await.unwrap();
+        let TmEvent::Ingress(request) = event else {
+            panic!("expected ingress request");
+        };
+        let RequestKind::Generate(native) = &request.kind else {
+            panic!("expected generation request");
+        };
+        assert_eq!(native.ngram_corpus_id.as_deref(), Some("docs"));
+        request
+            .sink
+            .try_send(chunk(request.rid.as_str(), "ok", true))
+            .unwrap();
+
+        let response = response_task.await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
     }
 
     #[test]

--- a/rust/sglang-server/src/message.rs
+++ b/rust/sglang-server/src/message.rs
@@ -22,7 +22,10 @@ pub use egress::{
     frame_egress_result,
 };
 pub use finish_reason::Matched;
-pub(crate) use io_struct::{AbortReq, ControlRequest, GetInternalStateReq};
+pub(crate) use io_struct::{
+    AbortReq, AddExternalCorpusReqInput, ControlRequest, GetInternalStateReq,
+    ListExternalCorporaReqInput, RemoveExternalCorpusReqInput,
+};
 pub use request::{GenerateBody, GenerateRequest, MmRequest, MmWorkItem, RequestKind};
 // Constructed directly only by tests: `api_server::prefetch` fills its
 // `prefetched` field, everything else gets it packed inside a `GenerateRequest`.

--- a/rust/sglang-server/src/message/io_struct.rs
+++ b/rust/sglang-server/src/message/io_struct.rs
@@ -41,9 +41,8 @@ wire_struct! {
         lora_id: (),
         custom_logit_processor: (),
         positional_embed_overrides: (),
-        /// PD-disaggregation block — the last fields emitted; everything after
-        /// `disagg_prefill_dp_rank` in Python has a msgspec default and is
-        /// omitted (short arrays decode with defaulted tails).
+        /// PD-disaggregation block. The selector below requires emitting the
+        /// intervening defaulted fields as positional fillers.
         bootstrap_host: Option<&'a str>,
         bootstrap_port: Option<i64>,
         bootstrap_room: Option<i64>,
@@ -51,6 +50,23 @@ wire_struct! {
         decode_tp_size: Option<i64>,
         routed_dp_rank: Option<i64>,
         disagg_prefill_dp_rank: Option<i64>,
+        /// Tail fields through Python's `ngram_corpus_id`. These fillers are
+        /// required because msgspec's array-like wire format is positional.
+        routing_key: (),
+        require_reasoning: bool,
+        priority: (),
+        extra_key: (),
+        no_logs: bool,
+        return_bytes: bool,
+        return_entropy: bool,
+        need_wait_for_mm_inputs: (),
+        num_items_assigned: (),
+        mm_data_mooncake: (),
+        encoder_urls: (),
+        multi_item_delimiter_indices: (),
+        time_stats: (),
+        cache_salt: (),
+        ngram_corpus_id: Option<&'a str>,
     }
 }
 
@@ -69,6 +85,20 @@ control_messages! {
 
     /// `/server_info`'s control request: a bare `BaseReq` with no extra fields.
     GetInternalStateReq {}
+
+    /// Load already-tokenized external NGRAM corpus chunks.
+    AddExternalCorpusReqInput {
+        corpus_id: Option<String>,
+        file_path: (),
+        documents: (),
+        token_chunks: Vec<Vec<i32>>,
+    }
+
+    RemoveExternalCorpusReqInput {
+        corpus_id: String,
+    }
+
+    ListExternalCorporaReqInput {}
 }
 
 /// Borrow a request as its wire struct, resolving `Option` scalars to the wire
@@ -112,11 +142,50 @@ impl<'a> From<&'a GenerateRequest> for TokenizedGenerateReqInput<'a> {
             decode_tp_size: req.decode_tp_size,
             routed_dp_rank: req.routed_dp_rank,
             disagg_prefill_dp_rank: req.disagg_prefill_dp_rank,
+            routing_key: (),
+            require_reasoning: false,
+            priority: (),
+            extra_key: (),
+            no_logs: false,
+            return_bytes: false,
+            return_entropy: false,
+            need_wait_for_mm_inputs: (),
+            num_items_assigned: (),
+            mm_data_mooncake: (),
+            encoder_urls: (),
+            multi_item_delimiter_indices: (),
+            time_stats: (),
+            cache_salt: (),
+            ngram_corpus_id: req.ngram_corpus_id.as_deref(),
         }
     }
 }
 
 impl GetInternalStateReq {
+    pub fn new(rid: String) -> Self {
+        Self { rid }
+    }
+}
+
+impl AddExternalCorpusReqInput {
+    pub fn new(rid: String, corpus_id: String, token_chunks: Vec<Vec<i32>>) -> Self {
+        Self {
+            rid,
+            corpus_id: Some(corpus_id),
+            file_path: (),
+            documents: (),
+            token_chunks,
+        }
+    }
+}
+
+impl RemoveExternalCorpusReqInput {
+    pub fn new(rid: String, corpus_id: String) -> Self {
+        Self { rid, corpus_id }
+    }
+}
+
+impl ListExternalCorporaReqInput {
     pub fn new(rid: String) -> Self {
         Self { rid }
     }
@@ -155,6 +224,45 @@ mod tests {
         assert!(arr[5].is_nil());
     }
 
+    #[test]
+    fn external_corpus_control_messages_match_python_layout() {
+        let add = AddExternalCorpusReqInput::new(
+            "load-rid".into(),
+            "docs".into(),
+            vec![vec![1, 2], vec![i32::MIN, 3]],
+        )
+        .encode()
+        .unwrap();
+        let value = rmpv::decode::read_value(&mut &add[..]).unwrap();
+        let arr = value.as_array().expect("array");
+        assert_eq!(arr.len(), 7);
+        assert_eq!(arr[0].as_str(), Some("AddExternalCorpusReqInput"));
+        assert_eq!(arr[3].as_str(), Some("docs"));
+        assert!(arr[4].is_nil(), "file_path");
+        assert!(arr[5].is_nil(), "documents");
+        assert!(arr[6].is_array(), "token_chunks");
+
+        let remove = RemoveExternalCorpusReqInput::new(
+            "remove-rid".into(),
+            "docs".into(),
+        )
+        .encode()
+        .unwrap();
+        let value = rmpv::decode::read_value(&mut &remove[..]).unwrap();
+        let arr = value.as_array().expect("array");
+        assert_eq!(arr.len(), 4);
+        assert_eq!(arr[0].as_str(), Some("RemoveExternalCorpusReqInput"));
+        assert_eq!(arr[3].as_str(), Some("docs"));
+
+        let list = ListExternalCorporaReqInput::new("list-rid".into())
+            .encode()
+            .unwrap();
+        let value = rmpv::decode::read_value(&mut &list[..]).unwrap();
+        let arr = value.as_array().expect("array");
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr[0].as_str(), Some("ListExternalCorporaReqInput"));
+    }
+
     /// The header must be positionally aligned: `input_embeds` (idx 5) /
     /// `token_type_ids` (idx 7) present as nil so `sampling_params` lands at idx 8 and
     /// the array reaches msgspec's min length. Regression guard for that decode failure.
@@ -172,15 +280,16 @@ mod tests {
             logprob_start_len: -1,
             top_logprobs_num: 3,
             return_hidden_states: true,
+            ngram_corpus_id: Some("docs".into()),
             stream: true,
             ..Default::default()
         };
         let bytes = TokenizedGenerateReqInput::from(&req).encode().unwrap();
         let val = rmpv::decode::read_value(&mut &bytes[..]).unwrap();
         let arr = val.as_array().expect("array");
-        // msgspec requires >= 14 (through `stream`); we emit 32 (through
-        // `disagg_prefill_dp_rank`). Trailing defaulted fields are omitted.
-        assert_eq!(arr.len(), 32, "header ends at disagg_prefill_dp_rank");
+        // msgspec requires >= 14 (through `stream`); the selector is appended
+        // after every pre-existing field, at the true positional tail.
+        assert_eq!(arr.len(), 47, "header ends at ngram_corpus_id");
         assert_eq!(arr[0].as_str(), Some("TokenizedGenerateReqInput"));
         assert_eq!(arr[1].as_str(), Some("r1"));
         assert!(arr[5].is_nil(), "idx 5 must be input_embeds (nil)");
@@ -208,6 +317,13 @@ mod tests {
             Some(true),
             "return_hidden_states at idx 16"
         );
+        assert_eq!(arr[36].as_bool(), Some(false), "no_logs at idx 36");
+        assert_eq!(arr[37].as_bool(), Some(false), "return_bytes at idx 37");
+        assert_eq!(arr[38].as_bool(), Some(false), "return_entropy at idx 38");
+        for (i, slot) in arr.iter().enumerate().take(46).skip(39) {
+            assert!(slot.is_nil(), "idx {i} must be a nil default");
+        }
+        assert_eq!(arr[46].as_str(), Some("docs"), "ngram_corpus_id at idx 46");
     }
 
     /// The PD block must land on Python's wire indices 25–31, with the filler

--- a/rust/sglang-server/src/message/request.rs
+++ b/rust/sglang-server/src/message/request.rs
@@ -82,6 +82,10 @@ pub struct GenerateBody {
     pub token_ids_logprob: Option<OneOrMany<TokenIds>>,
     #[serde(default)]
     pub return_hidden_states: Option<OneOrMany<bool>>,
+    /// Per-request external NGRAM corpus selector. `null` preserves the legacy
+    /// all-corpus search while an empty string explicitly selects trie-only.
+    #[serde(default)]
+    pub ngram_corpus_id: Option<OneOrMany<Option<String>>>,
     /// Scalar-only in Python too (`return_text_in_logprobs: bool`).
     #[serde(default)]
     pub return_text_in_logprobs: Option<bool>,
@@ -144,6 +148,7 @@ impl GenerateBody {
             top_logprobs_num,
             token_ids_logprob,
             return_hidden_states,
+            ngram_corpus_id,
             return_text_in_logprobs,
             bootstrap_host,
             bootstrap_port,
@@ -319,6 +324,13 @@ impl GenerateBody {
         let logprob_start_lens = fan_out(logprob_start_len, n, "logprob_start_len")?;
         let top_logprobs_nums = fan_out(top_logprobs_num, n, "top_logprobs_num")?;
         let return_hidden = fan_out(return_hidden_states, n, "return_hidden_states")?;
+        if !is_batch && matches!(&ngram_corpus_id, Some(OneOrMany::Many(_))) {
+            return Err(Error::Validation(
+                "ngram_corpus_id must be a string for a single request".into(),
+            ));
+        }
+        let ngram_corpus_ids =
+            flatten_column(fan_out(ngram_corpus_id, n, "ngram_corpus_id")?);
 
         // PD fields fan out like Python `_normalize_bootstrap_params`: scalars
         // broadcast — except a scalar `bootstrap_room`, which becomes `room + i`
@@ -370,6 +382,7 @@ impl GenerateBody {
             top_logprobs_nums,
             tid_logprobs,
             return_hidden,
+            ngram_corpus_ids,
             bootstrap_hosts,
             bootstrap_ports,
             bootstrap_rooms,
@@ -390,6 +403,7 @@ impl GenerateBody {
                 top_logprobs_num,
                 token_ids_logprob,
                 return_hidden_states,
+                ngram_corpus_id,
                 bootstrap_host,
                 bootstrap_port,
                 bootstrap_room,
@@ -416,6 +430,7 @@ impl GenerateBody {
                 token_ids_logprob: token_ids_logprob.filter(|ids| !ids.is_empty()),
                 return_sampling_mask: false, // TODO: port Python's `return_sampling_mask`
                 return_hidden_states: return_hidden_states.unwrap_or(false),
+                ngram_corpus_id,
                 return_text_in_logprobs,
                 bootstrap_host,
                 bootstrap_port,
@@ -613,6 +628,8 @@ pub struct GenerateRequest {
     pub token_ids_logprob: Option<TokenIds>,
     pub return_sampling_mask: bool,
     pub return_hidden_states: bool,
+    /// `None` keeps the legacy all-SAM behavior; `Some("")` means trie-only.
+    pub ngram_corpus_id: Option<String>,
     /// Decode logprob token ids to text in each `[logprob, token_id, text]` tuple
     /// (default leaves the text slot null). Deliberately NOT in the scheduler
     /// header — Python's `TokenizedGenerateReqInput` has no such field either;
@@ -839,6 +856,35 @@ mod tests {
         let (ps, is_batch) = requests(r#"{"text": ["only"]}"#).unwrap();
         assert!(is_batch, "single-element list is still a batch");
         assert_eq!(ps.len(), 1);
+    }
+
+    #[test]
+    fn ngram_corpus_id_broadcasts_and_preserves_null_and_empty() {
+        let (ps, _) = requests(
+            r#"{"text": ["a", "b"], "ngram_corpus_id": ["docs", null]}"#,
+        )
+        .unwrap();
+        assert_eq!(ps[0].ngram_corpus_id.as_deref(), Some("docs"));
+        assert_eq!(ps[1].ngram_corpus_id, None);
+
+        let (ps, _) = requests(
+            r#"{"text": ["a", "b"], "ngram_corpus_id": ""}"#,
+        )
+        .unwrap();
+        assert_eq!(ps[0].ngram_corpus_id.as_deref(), Some(""));
+        assert_eq!(ps[1].ngram_corpus_id.as_deref(), Some(""));
+
+        let err = requests(
+            r#"{"text": ["a", "b"], "ngram_corpus_id": ["docs"]}"#,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("ngram_corpus_id"), "{err}");
+
+        let err = requests(
+            r#"{"text": "a", "ngram_corpus_id": ["docs"]}"#,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("single request"), "{err}");
     }
 
     /// Scalar `sampling_params` broadcasts to every item; a list maps per item.

--- a/rust/sglang-server/src/runtime/config.rs
+++ b/rust/sglang-server/src/runtime/config.rs
@@ -83,6 +83,14 @@ pub struct ServerArgs {
     pub log_level: String,
     #[serde(default)]
     pub log_level_http: Option<String>,
+    /// Bearer keys protecting the HTTP API. Most Rust endpoints do not yet
+    /// implement the Python server's auth middleware, but privileged routes
+    /// must still consume these values rather than becoming an unauthenticated
+    /// side door when either key is configured.
+    #[serde(default)]
+    pub api_key: Option<String>,
+    #[serde(default)]
+    pub admin_api_key: Option<String>,
     /// Optional built-in chat-template name or path to a Jinja/legacy JSON
     /// template file. Without an override, uses the tokenizer config template.
     #[serde(default)]
@@ -116,6 +124,19 @@ pub struct ServerArgs {
     /// see [`Self::enable_pd_bootstrap`].)
     #[serde(default = "default_disaggregation_mode")]
     pub disaggregation_mode: String,
+    /// Pipeline-parallel stages. Dynamic external-corpus controls cannot be
+    /// acknowledged safely across PP's point-to-point request forwarding yet.
+    #[serde(default = "default_worker_num")]
+    pub pp_size: usize,
+    /// Data-parallel replicas expose independent Rust HTTP ports. Until a
+    /// control-plane fan-out exists, one request cannot update every replica.
+    #[serde(default = "default_worker_num")]
+    pub dp_size: usize,
+    /// Speculative decoding backend selected by Python after argument
+    /// normalization (for example `"NGRAM"`). External-corpus controls are
+    /// meaningful only for the NGRAM backend.
+    #[serde(default)]
+    pub speculative_algorithm: Option<String>,
     /// The resolved Python `ModelConfig`, attached to the blob at dump time.
     #[serde(default)]
     pub model_config: ModelConfig,
@@ -144,6 +165,14 @@ pub struct ServerArgs {
     pub version: Option<String>,
     #[serde(default)]
     pub max_total_num_tokens: Option<u64>,
+    /// Zero disables dynamic external-corpus loading. Positive values reserve
+    /// this many speculative draft slots for the selected external SAM.
+    #[serde(default)]
+    pub speculative_ngram_external_sam_budget: usize,
+    /// Per-server upper bound applied before external corpus chunks enter the
+    /// scheduler. The scheduler enforces its remaining global budget as well.
+    #[serde(default = "default_external_corpus_max_tokens")]
+    pub speculative_ngram_external_corpus_max_tokens: usize,
 }
 
 /// The slice of the resolved Python `ModelConfig` the rust server reads.
@@ -218,6 +247,10 @@ fn default_disaggregation_mode() -> String {
 }
 fn default_worker_num() -> usize {
     1
+}
+
+fn default_external_corpus_max_tokens() -> usize {
+    10_000_000
 }
 
 impl ServerArgs {

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -318,6 +318,7 @@ class ServingChatTestCase(unittest.TestCase):
             return_prompt_token_ids=True,
             cache_salt="tenant-a",
             extra_key="classification",
+            ngram_corpus_id="docs",
         )
 
         with patch(
@@ -333,6 +334,7 @@ class ServingChatTestCase(unittest.TestCase):
         self.assertEqual(adapted.sampling_params["stop"], ["STOP"])
         self.assertEqual(adapted.cache_salt, "tenant-a")
         self.assertEqual(adapted.extra_key, "classification")
+        self.assertEqual(adapted.ngram_corpus_id, "docs")
         conv_mock.assert_not_called()
 
     def test_kimi_k3_usage_excludes_assistant_generation_stub(self):

--- a/test/registered/unit/entrypoints/openai/test_serving_completions.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_completions.py
@@ -72,10 +72,12 @@ class ServingCompletionTestCase(unittest.TestCase):
             max_tokens=1,
             cache_salt="tenant-a",
             extra_key="classification",
+            ngram_corpus_id="docs",
         )
         internal, _ = self.sc._convert_to_internal_request(req)
         self.assertEqual(internal.cache_salt, "tenant-a")
         self.assertEqual(internal.extra_key, "classification")
+        self.assertEqual(internal.ngram_corpus_id, "docs")
 
     def test_single_request_rejects_batched_cache_salt(self):
         req = CompletionRequest(
@@ -83,6 +85,30 @@ class ServingCompletionTestCase(unittest.TestCase):
             prompt=[1, 2, 3, 4],
             max_tokens=1,
             cache_salt=["tenant-a"],
+        )
+        internal, _ = self.sc._convert_to_internal_request(req)
+        with self.assertRaisesRegex(ValueError, "single request"):
+            internal.normalize_batch_and_arguments()
+
+    def test_single_prompt_accepts_one_corpus_id(self):
+        for prompt in ("hello", [1, 2, 3, 4]):
+            with self.subTest(prompt=prompt):
+                req = CompletionRequest(
+                    model="x",
+                    prompt=prompt,
+                    max_tokens=1,
+                    ngram_corpus_id=["docs"],
+                )
+                internal, _ = self.sc._convert_to_internal_request(req)
+                internal.normalize_batch_and_arguments()
+                self.assertEqual(internal.ngram_corpus_id, "docs")
+
+    def test_single_token_ids_prompt_rejects_multiple_corpus_ids(self):
+        req = CompletionRequest(
+            model="x",
+            prompt=[1, 2, 3, 4],
+            max_tokens=1,
+            ngram_corpus_id=["docs", "other"],
         )
         internal, _ = self.sc._convert_to_internal_request(req)
         with self.assertRaisesRegex(ValueError, "single request"):

--- a/test/registered/unit/entrypoints/openai/test_serving_responses.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_responses.py
@@ -1,6 +1,6 @@
 import asyncio
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 from openai.types.responses import (
     ResponseOutputMessage,
@@ -293,6 +293,7 @@ class ReasoningRequestForwardingTestCase(unittest.TestCase):
             input="answer",
             request_id="resp_reasoning",
             store=False,
+            ngram_corpus_id="docs",
         )
 
         with (
@@ -308,7 +309,47 @@ class ReasoningRequestForwardingTestCase(unittest.TestCase):
 
         self.assertEqual(response.status, "completed")
         self.assertFalse(captured["adapted_request"].require_reasoning)
+        self.assertEqual(captured["adapted_request"].ngram_corpus_id, "docs")
         self.assertFalse(parser_cls.call_args.kwargs["force_reasoning"])
+
+    def test_builtin_tool_followup_preserves_ngram_corpus_id(self):
+        from sglang.srt.managers.io_struct import GenerateReqInput
+
+        serving = make_serving()
+        submitted = []
+
+        async def generate_request(request, raw_request):
+            submitted.append(request)
+            yield {"text": f"turn-{len(submitted)}"}
+
+        serving.tokenizer_manager.generate_request = generate_request
+        context = Mock()
+        context.need_builtin_tool_call.side_effect = [True, False]
+        context.call_tool = AsyncMock(return_value={"tool": "result"})
+        context.render_for_completion.return_value = [7, 8, 9]
+        adapted = GenerateReqInput(
+            input_ids=[1, 2, 3],
+            sampling_params={"max_new_tokens": 8},
+            ngram_corpus_id="docs",
+        )
+
+        async def consume():
+            return [
+                item
+                async for item in serving._generate_with_builtin_tools(
+                    "resp_tools",
+                    None,
+                    adapted,
+                    adapted.sampling_params,
+                    context,
+                )
+            ]
+
+        asyncio.run(consume())
+
+        self.assertEqual(len(submitted), 2)
+        self.assertEqual(submitted[0].ngram_corpus_id, "docs")
+        self.assertEqual(submitted[1].ngram_corpus_id, "docs")
 
 
 class SkipSpecialTokensForwardingTestCase(CustomTestCase):

--- a/test/registered/unit/entrypoints/test_engine_ngram_api.py
+++ b/test/registered/unit/entrypoints/test_engine_ngram_api.py
@@ -1,0 +1,32 @@
+import inspect
+import unittest
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.entrypoints.EngineBase import EngineBase
+from sglang.srt.entrypoints.engine import Engine
+from sglang.srt.entrypoints.http_server_engine import HttpServerEngineAdapter
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestEngineNgramApi(unittest.TestCase):
+    def test_ngram_corpus_id_is_keyword_only(self):
+        methods = (
+            EngineBase.generate,
+            Engine.generate,
+            Engine.async_generate,
+            HttpServerEngineAdapter.generate,
+        )
+
+        for method in methods:
+            with self.subTest(method=method.__qualname__):
+                parameter = inspect.signature(method).parameters["ngram_corpus_id"]
+                self.assertIs(parameter.kind, inspect.Parameter.KEYWORD_ONLY)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_external_corpus_token_validation.py
+++ b/test/registered/unit/managers/test_external_corpus_token_validation.py
@@ -1,0 +1,174 @@
+import asyncio
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from sglang.srt.managers.io_struct import (
+    AddExternalCorpusReqInput,
+    AddExternalCorpusReqOutput,
+    ListExternalCorporaReqOutput,
+)
+from sglang.srt.managers.tokenizer_control_mixin import (
+    TokenizerControlMixin,
+    _validate_external_corpus_token_chunks,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class _ExplodingChunk(list):
+    def __iter__(self):
+        raise AssertionError("over-limit chunks must not be scanned")
+
+
+class TestExternalCorpusTokenValidation(unittest.TestCase):
+    def test_canonical_lists_are_not_copied(self):
+        chunks = [[1, 2], [3, 4]]
+
+        validated = _validate_external_corpus_token_chunks(
+            chunks,
+            max_tokens=4,
+            vocab_size=10,
+            separator_token=-(2**31),
+        )
+
+        self.assertIs(validated, chunks)
+        self.assertIs(validated[0], chunks[0])
+
+    def test_over_limit_fails_before_scanning_tokens(self):
+        chunks = [_ExplodingChunk([1, 2, 3])]
+
+        with self.assertRaisesRegex(ValueError, "exceeds"):
+            _validate_external_corpus_token_chunks(
+                chunks,
+                max_tokens=2,
+                vocab_size=10,
+                separator_token=-(2**31),
+            )
+
+    def test_dynamic_mutations_reject_dp_or_pp_topology_before_dispatch(self):
+        methods = (
+            ("add_external_corpus", (AddExternalCorpusReqInput(token_chunks=[[1]]),)),
+            ("remove_external_corpus", ("docs",)),
+        )
+        for dp_size, pp_size in ((2, 1), (1, 2)):
+            for method_name, args in methods:
+                with self.subTest(method=method_name, dp_size=dp_size, pp_size=pp_size):
+                    communicator = AsyncMock()
+                    fake = SimpleNamespace(
+                        server_args=SimpleNamespace(
+                            speculative_algorithm="NGRAM",
+                            dp_size=dp_size,
+                            pp_size=pp_size,
+                        ),
+                        auto_create_handle_loop=lambda: None,
+                        add_external_corpus_communicator=communicator,
+                        remove_external_corpus_communicator=communicator,
+                    )
+
+                    result = asyncio.run(
+                        getattr(TokenizerControlMixin, method_name)(fake, *args)
+                    )
+
+                    self.assertFalse(result.success)
+                    self.assertIn("dp_size=1 and pp_size=1", result.message)
+                    communicator.assert_not_called()
+
+    def test_distributed_list_is_read_only_and_detects_divergence(self):
+        communicator = AsyncMock(
+            return_value=[
+                ListExternalCorporaReqOutput(
+                    success=True, corpus_token_counts={"docs": 3}
+                ),
+                ListExternalCorporaReqOutput(
+                    success=True, corpus_token_counts={"docs": 3}
+                ),
+            ]
+        )
+        fake = SimpleNamespace(
+            server_args=SimpleNamespace(
+                speculative_algorithm="NGRAM", dp_size=2, pp_size=1
+            ),
+            auto_create_handle_loop=lambda: None,
+            list_external_corpora_communicator=communicator,
+        )
+
+        result = asyncio.run(TokenizerControlMixin.list_external_corpora(fake))
+        self.assertTrue(result.success)
+        self.assertEqual(result.corpus_token_counts, {"docs": 3})
+
+        communicator.return_value[1] = ListExternalCorporaReqOutput(
+            success=True, corpus_token_counts={"other": 4}
+        )
+        result = asyncio.run(TokenizerControlMixin.list_external_corpora(fake))
+        self.assertFalse(result.success)
+        self.assertEqual(result.corpus_token_counts, {})
+        self.assertIn("inconsistent", result.message)
+
+    def test_dynamic_add_requires_positive_sam_budget(self):
+        communicator = AsyncMock()
+        fake = SimpleNamespace(
+            server_args=SimpleNamespace(
+                speculative_algorithm="NGRAM",
+                speculative_ngram_external_sam_budget=0,
+                dp_size=1,
+                pp_size=1,
+            ),
+            auto_create_handle_loop=lambda: None,
+            add_external_corpus_communicator=communicator,
+        )
+
+        result = asyncio.run(
+            TokenizerControlMixin.add_external_corpus(
+                fake, AddExternalCorpusReqInput(token_chunks=[[1]])
+            )
+        )
+
+        self.assertFalse(result.success)
+        self.assertIn("external-sam-budget", result.message)
+        communicator.assert_not_called()
+
+    def test_documents_over_token_limit_are_truncated_with_message(self):
+        communicator = AsyncMock(
+            return_value=[
+                AddExternalCorpusReqOutput(
+                    success=True,
+                    corpus_id="docs",
+                    message="loaded",
+                    loaded_token_count=2,
+                )
+            ]
+        )
+        fake = SimpleNamespace(
+            server_args=SimpleNamespace(
+                speculative_algorithm="NGRAM",
+                speculative_ngram_external_sam_budget=1,
+                speculative_ngram_external_corpus_max_tokens=3,
+                dp_size=1,
+                pp_size=1,
+            ),
+            tokenizer=SimpleNamespace(
+                encode=lambda _doc, add_special_tokens=False: [1, 2]
+            ),
+            auto_create_handle_loop=lambda: None,
+            add_external_corpus_communicator=communicator,
+        )
+
+        result = asyncio.run(
+            TokenizerControlMixin.add_external_corpus(
+                fake,
+                AddExternalCorpusReqInput(
+                    corpus_id="docs", documents=["first", "second"]
+                ),
+            )
+        )
+
+        self.assertTrue(result.success)
+        self.assertIn("truncated", result.message)
+        dispatched = communicator.call_args.args[0]
+        self.assertEqual(dispatched.token_chunks, [[1, 2]])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -566,6 +566,38 @@ class TestGenerateReqInputNormalization(CustomTestCase):
                 with self.assertRaisesRegex(ValueError, "should be a string"):
                     req.normalize_batch_and_arguments()
 
+    def test_ngram_corpus_id_normalization(self):
+        req = GenerateReqInput(
+            text=["Hello", "World"],
+            ngram_corpus_id=["docs", None],
+            sampling_params={"n": 2},
+        )
+        req.normalize_batch_and_arguments()
+        self.assertEqual(req.ngram_corpus_id, ["docs", None] * 2)
+        self.assertEqual(req[0].ngram_corpus_id, "docs")
+        self.assertIsNone(req[1].ngram_corpus_id)
+
+        req = GenerateReqInput(
+            text=["Hello", "World"], ngram_corpus_id="", sampling_params=[{}, {}]
+        )
+        req.normalize_batch_and_arguments()
+        self.assertEqual(req.ngram_corpus_id, ["", ""])
+
+        with self.assertRaisesRegex(ValueError, "single request"):
+            GenerateReqInput(
+                text="Hello", ngram_corpus_id=["docs"]
+            ).normalize_batch_and_arguments()
+
+        with self.assertRaisesRegex(ValueError, "string or None"):
+            GenerateReqInput(
+                text=["Hello", "World"], ngram_corpus_id=["docs", 1]
+            ).normalize_batch_and_arguments()
+
+        with self.assertRaisesRegex(ValueError, "batch size"):
+            GenerateReqInput(
+                text=["Hello", "World"], ngram_corpus_id=["docs"]
+            ).normalize_batch_and_arguments()
+
     def test_logprob_parameters_normalization(self):
         """Test normalization of logprob-related parameters."""
         # Test single example

--- a/test/registered/unit/managers/test_scheduler_control_output.py
+++ b/test/registered/unit/managers/test_scheduler_control_output.py
@@ -1,0 +1,106 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from sglang.srt.environ import envs
+from sglang.srt.managers.io_struct import ListExternalCorporaReqOutput
+from sglang.srt.managers.scheduler import Scheduler
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestSchedulerControlOutput(CustomTestCase):
+    def _scheduler(self):
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.server_args = SimpleNamespace()
+        scheduler.tp_worker = object()
+        scheduler.ps = SimpleNamespace(gpu_id=0)
+        scheduler.nccl_port = 0
+
+        class _DraftWorker:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+                self.ngram_corpus = SimpleNamespace(cancel_external_corpus_load=Mock())
+
+        scheduler.spec_algorithm = SimpleNamespace(
+            is_none=lambda: False,
+            is_ngram=lambda: True,
+            create_worker=lambda server_args: _DraftWorker,
+        )
+        scheduler.ipc_channels = SimpleNamespace(
+            send_to_tokenizer=SimpleNamespace(send_output=Mock())
+        )
+        scheduler.rust_server = None
+        scheduler.maybe_init_draft_worker()
+        return scheduler
+
+    def test_deferred_corpus_reply_uses_scheduler_router(self):
+        scheduler = self._scheduler()
+        callback = scheduler.external_corpus_manager._send_response
+        self.assertIs(callback.__self__, scheduler)
+        self.assertIs(callback.__func__, Scheduler._send_control_output)
+        synchronizer = scheduler.external_corpus_manager._synchronize_load_result
+        self.assertIs(synchronizer.__self__, scheduler)
+        self.assertIs(
+            synchronizer.__func__,
+            Scheduler._synchronize_external_corpus_load_result,
+        )
+        self.assertIs(
+            scheduler.external_corpus_manager._cancel_load,
+            scheduler.draft_worker.ngram_corpus.cancel_external_corpus_load,
+        )
+
+    def test_router_uses_rust_egress_when_present(self):
+        scheduler = self._scheduler()
+        rust_server = Mock()
+        scheduler.rust_server = rust_server
+        request = object()
+        output = object()
+
+        scheduler._send_control_output(output, request)
+
+        rust_server.push_control_output.assert_called_once_with(request, output)
+        scheduler.ipc_channels.send_to_tokenizer.send_output.assert_not_called()
+
+    def test_router_uses_tokenizer_socket_without_rust_server(self):
+        scheduler = self._scheduler()
+        request = object()
+        output = object()
+
+        with envs.SGLANG_RUST_SERVER.override(False):
+            scheduler._send_control_output(output, request)
+
+        scheduler.ipc_channels.send_to_tokenizer.send_output.assert_called_once_with(
+            output, request
+        )
+
+    def test_non_entry_rust_rank_drops_control_reply(self):
+        scheduler = self._scheduler()
+
+        with envs.SGLANG_RUST_SERVER.override(True):
+            scheduler._send_control_output(object(), object())
+
+        scheduler.ipc_channels.send_to_tokenizer.send_output.assert_not_called()
+
+    def test_list_control_output_detects_cross_rank_divergence(self):
+        scheduler = self._scheduler()
+        group = Mock()
+        group.all_gather_object.return_value = [
+            (True, "", (("a", 3),)),
+            (True, "", (("a", 4),)),
+        ]
+        scheduler._external_corpus_control_group = Mock(return_value=group)
+
+        output = scheduler._merge_external_corpus_control_output(
+            ListExternalCorporaReqOutput(success=True, corpus_token_counts={"a": 3})
+        )
+
+        self.assertFalse(output.success)
+        self.assertIn("inconsistent", output.message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_session_token_share_unit.py
+++ b/test/registered/unit/mem_cache/test_session_token_share_unit.py
@@ -23,7 +23,7 @@ from sglang.test.test_utils import CustomTestCase
 VOCAB = 1 << 20
 
 
-def _recv(rid, input_ids, max_new_tokens=8):
+def _recv(rid, input_ids, max_new_tokens=8, ngram_corpus_id=None):
     return SimpleNamespace(
         rid=rid,
         input_ids=array("q", input_ids),
@@ -47,6 +47,7 @@ def _recv(rid, input_ids, max_new_tokens=8):
         routing_key=None,
         extra_key=None,
         cache_salt=None,
+        ngram_corpus_id=ngram_corpus_id,
         http_worker_ipc=None,
         time_stats=None,
     )
@@ -99,6 +100,14 @@ class TestSessionTokenShare(CustomTestCase):
         r3 = self._create("r3", [9])
         self.assertEqual(list(r3.origin_input_ids), in1 + out1 + in2 + out2 + [9])
         self.assertEqual(list(r3.full_untruncated_fill_ids), list(r3.origin_input_ids))
+
+    def test_ngram_corpus_id_is_preserved_when_session_rebuilds_req(self):
+        req = self.session.create_req(
+            _recv("r1", [1, 2, 3], ngram_corpus_id="docs"),
+            tokenizer=None,
+            vocab_size=VOCAB,
+        )
+        self.assertEqual(req.ngram_corpus_id, "docs")
 
     def test_mid_turn_abort_then_continue(self):
         in1, out1 = list(range(200, 210)), [1, 2, 3]

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1350,17 +1350,25 @@ class TestNgramExternalSamArgs(CustomTestCase):
         )
         with self.assertRaises(ValueError) as context:
             handle_speculative_decoding(args)
-        self.assertIn("speculative_num_draft_tokens - 1", str(context.exception))
+        self.assertIn("--speculative-num-draft-tokens - 1", str(context.exception))
 
     def test_external_corpus_max_tokens_must_be_positive(self):
         args = self._make_dummy_ngram_args(
-            speculative_ngram_external_corpus_path="/tmp/ngram-corpus.jsonl",
             speculative_ngram_external_sam_budget=2,
             speculative_ngram_external_corpus_max_tokens=0,
         )
         with self.assertRaises(ValueError) as context:
             handle_speculative_decoding(args)
         self.assertIn("external-corpus-max-tokens", str(context.exception))
+
+    def test_external_sam_budget_is_validated_without_startup_corpus(self):
+        for budget in (-1, 12):
+            with self.subTest(budget=budget):
+                args = self._make_dummy_ngram_args(
+                    speculative_ngram_external_sam_budget=budget,
+                )
+                with self.assertRaises(ValueError):
+                    handle_speculative_decoding(args)
 
 
 class TestDecoupledSpecArgs(CustomTestCase):

--- a/test/registered/unit/spec/test_ngram_corpus.py
+++ b/test/registered/unit/spec/test_ngram_corpus.py
@@ -757,6 +757,42 @@ class TestNgramCorpusMatchBenchmark(CustomTestCase):
 class TestNgramCorpusMultiSam(CustomTestCase):
     """Verify multi-SAM add/remove/list and budget splitting."""
 
+    def test_staged_corpus_is_invisible_until_commit(self):
+        corpus = _make_corpus("BFS", draft_token_num=6, external_sam_budget=4)
+        loaded_token_count = corpus.load_external_corpus_named(
+            "staged", [[1, 2, 3, 40, 41]]
+        )
+
+        self.assertEqual(corpus.list_external_corpora(), {})
+        ids, masks = _batch_get(corpus, [[1, 2, 3]])
+        self.assertNotIn(
+            40,
+            {
+                token
+                for path in corpus.leaf_paths_from_mask(
+                    ids.tolist(), masks.reshape(6, 6).tolist()
+                )
+                for token in path
+            },
+        )
+
+        corpus.commit_external_corpus_load("staged", loaded_token_count)
+        self.assertEqual(corpus.list_external_corpora(), {"staged": 5})
+        ids, masks = _batch_get(corpus, [[1, 2, 3]])
+        self.assertIn(
+            [3, 40, 41],
+            corpus.leaf_paths_from_mask(
+                ids.tolist(), masks.reshape(6, 6).tolist()
+            ),
+        )
+
+    def test_corpus_id_rejects_list_delimiters(self):
+        corpus = _make_corpus("BFS", external_sam_budget=1)
+        for corpus_id in ("bad\tid", "bad\nid", "bad\rid"):
+            with self.subTest(corpus_id=repr(corpus_id)):
+                with self.assertRaisesRegex(ValueError, "tabs or line breaks"):
+                    corpus.load_external_corpus_named(corpus_id, [[1, 2]])
+
     def test_add_and_list(self):
         corpus = _make_corpus("BFS", draft_token_num=4, external_sam_budget=3)
         loaded_token_count = corpus.load_external_corpus_named("a", [[1, 2, 3, 4, 5]])
@@ -896,7 +932,7 @@ class TestMultiSamHttpMock(CustomTestCase):
         try:
             from starlette.testclient import TestClient
 
-            from sglang.srt.entrypoints.http_server import app, set_global_state
+            from sglang.srt.entrypoints import http_server
         except (ImportError, OSError):
             raise unittest.SkipTest(
                 "http_server import requires CUDA libraries not available on CPU"
@@ -929,9 +965,16 @@ class TestMultiSamHttpMock(CustomTestCase):
                 success=True, corpus_token_counts={"a": 100, "b": 200}
             )
         )
-        set_global_state(mock_state)
-        cls.client = TestClient(app)
+        cls.http_server = http_server
+        cls.client = TestClient(http_server.app)
+        cls.prior_global_state = http_server.get_global_state()
+        http_server.set_global_state(mock_state)
         cls.mock_tm = tm
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.client.close()
+        cls.http_server._global_state = cls.prior_global_state
 
     def test_add_corpus(self):
         resp = self.client.post(
@@ -967,12 +1010,372 @@ class TestMultiSamHttpMock(CustomTestCase):
         )
         self.assertEqual(resp.status_code, 400)
 
+    def test_remove_corpus_rejects_invalid_json_shapes(self):
+        for payload in ([], {"corpus_id": 1}, {"corpus_id": "x", "extra": True}):
+            with self.subTest(payload=payload):
+                resp = self.client.post("/remove_external_corpus", json=payload)
+                self.assertEqual(resp.status_code, 400)
+
     def test_list_corpora(self):
         resp = self.client.get("/list_external_corpora")
         self.assertEqual(resp.status_code, 200)
         data = resp.json()
         self.assertTrue(data["success"])
         self.assertEqual(data["corpus_token_counts"], {"a": 100, "b": 200})
+
+
+class TestNgramCorpusRequestScoped(CustomTestCase):
+    """Phase 3: per-request external corpus selection.
+
+    ``corpus_ids`` is lossless -- it only changes which SAM proposes drafts (the
+    target still verifies every token). ``None`` preserves the legacy all-SAM
+    search in every batch position; an empty string explicitly selects trie-only.
+    """
+
+    @staticmethod
+    def _two_corpora(draft_token_num=6, external_sam_budget=4):
+        # Two corpora sharing prefix [1,2,3] with distinct continuations, so a
+        # match against [1,2,3] reveals which SAM(s) were consulted.
+        corpus = _make_corpus(
+            "BFS",
+            draft_token_num=draft_token_num,
+            external_sam_budget=external_sam_budget,
+        )
+        loaded = corpus.load_external_corpus_named("a", [[1, 2, 3, 10, 11]])
+        corpus.commit_external_corpus_load("a", loaded)
+        loaded = corpus.load_external_corpus_named("b", [[1, 2, 3, 20, 21]])
+        corpus.commit_external_corpus_load("b", loaded)
+        return corpus
+
+    @staticmethod
+    def _leaf_paths(corpus, ids, masks, req_idx, d):
+        row_ids = ids.reshape(-1, d)[req_idx].tolist()
+        row_masks = masks.reshape(-1, d, d)[req_idx].tolist()
+        return corpus.leaf_paths_from_mask(row_ids, row_masks)
+
+    def test_single_id_selects_only_that_corpus(self):
+        corpus = self._two_corpora()
+        ids, masks = corpus.batch_get(
+            req_ids=["r0"],
+            batch_tokens=[[1, 2, 3]],
+            total_lens=[3],
+            corpus_ids=["a"],
+        )
+        leaf = self._leaf_paths(corpus, ids, masks, 0, 6)
+        self.assertIn([3, 10, 11], leaf)
+        self.assertNotIn([3, 20, 21], leaf)
+
+    def test_multi_selector_isolated_within_batch(self):
+        corpus = self._two_corpora()
+        ids, masks = corpus.batch_get(
+            req_ids=["r0", "r1"],
+            batch_tokens=[[1, 2, 3], [1, 2, 3]],
+            total_lens=[3, 3],
+            corpus_ids=["a", "b"],
+        )
+        leaf0 = self._leaf_paths(corpus, ids, masks, 0, 6)
+        leaf1 = self._leaf_paths(corpus, ids, masks, 1, 6)
+        self.assertIn([3, 10, 11], leaf0)
+        self.assertNotIn([3, 20, 21], leaf0)
+        self.assertIn([3, 20, 21], leaf1)
+        self.assertNotIn([3, 10, 11], leaf1)
+
+    def test_unknown_id_uses_trie_only_no_cross_sam(self):
+        corpus = self._two_corpora()
+        ids, masks = corpus.batch_get(
+            req_ids=["r0"],
+            batch_tokens=[[1, 2, 3]],
+            total_lens=[3],
+            corpus_ids=["does-not-exist"],
+        )
+        leaf = self._leaf_paths(corpus, ids, masks, 0, 6)
+        flat = {tok for path in leaf for tok in path}
+        # Online trie is empty; an unknown id must NOT fall back to all-SAM.
+        self.assertNotIn(10, flat)
+        self.assertNotIn(20, flat)
+
+    def test_none_in_mixed_batch_uses_legacy_all_sam(self):
+        corpus = self._two_corpora()
+        ids, masks = corpus.batch_get(
+            req_ids=["r0", "r1"],
+            batch_tokens=[[1, 2, 3], [1, 2, 3]],
+            total_lens=[3, 3],
+            corpus_ids=["a", None],
+        )
+        leaf0 = self._leaf_paths(corpus, ids, masks, 0, 6)
+        leaf1 = self._leaf_paths(corpus, ids, masks, 1, 6)
+        self.assertIn([3, 10, 11], leaf0)
+        self.assertIn([3, 10, 11], leaf1)
+        self.assertIn([3, 20, 21], leaf1)
+
+    def test_remove_then_selection_misses(self):
+        corpus = self._two_corpora()
+        corpus.remove_external_corpus("a")
+        ids, masks = corpus.batch_get(
+            req_ids=["r0", "r1"],
+            batch_tokens=[[1, 2, 3], [1, 2, 3]],
+            total_lens=[3, 3],
+            corpus_ids=["a", "b"],
+        )
+        leaf0 = self._leaf_paths(corpus, ids, masks, 0, 6)
+        leaf1 = self._leaf_paths(corpus, ids, masks, 1, 6)
+        # "a" was removed -> its handle is now unknown -> trie-only.
+        flat0 = {tok for path in leaf0 for tok in path}
+        self.assertNotIn(10, flat0)
+        # "b" is still selectable.
+        self.assertIn([3, 20, 21], leaf1)
+
+    def test_legacy_all_search_when_corpus_ids_none(self):
+        corpus = self._two_corpora()
+        # No corpus_ids -> both SAMs contribute (backward compatible).
+        ids, masks = corpus.batch_get(
+            req_ids=["r0"],
+            batch_tokens=[[1, 2, 3]],
+            total_lens=[3],
+        )
+        leaf = self._leaf_paths(corpus, ids, masks, 0, 6)
+        self.assertIn([3, 10, 11], leaf)
+        self.assertIn([3, 20, 21], leaf)
+
+
+class TestExternalCorpusManagerLifecycle(CustomTestCase):
+    def test_pending_load_only_blocks_same_id_remove(self):
+        from types import SimpleNamespace
+        from unittest.mock import Mock
+
+        from sglang.srt.managers.io_struct import RemoveExternalCorpusReqInput
+        from sglang.srt.speculative.external_corpus_manager import (
+            ExternalCorpusManager,
+        )
+
+        worker = SimpleNamespace(remove_external_corpus=Mock())
+        manager = ExternalCorpusManager(worker, Mock(), lambda result: result, Mock())
+        manager._pending_load = (SimpleNamespace(corpus_id="loading"), Mock())
+
+        same_id = manager.remove(RemoveExternalCorpusReqInput(corpus_id="loading"))
+        other_id = manager.remove(RemoveExternalCorpusReqInput(corpus_id="existing"))
+
+        self.assertFalse(same_id.success)
+        self.assertIn("pending", same_id.message)
+        self.assertTrue(other_id.success)
+        worker.remove_external_corpus.assert_called_once_with("existing")
+
+    def test_distributed_build_failure_cancels_staging(self):
+        from types import SimpleNamespace
+        from unittest.mock import Mock
+
+        from sglang.srt.managers.io_struct import AddExternalCorpusReqOutput
+        from sglang.srt.speculative.external_corpus_manager import (
+            ExternalCorpusManager,
+        )
+
+        worker = SimpleNamespace(commit_corpus_load=Mock())
+        send_response = Mock()
+        cancel = Mock()
+        failure = AddExternalCorpusReqOutput(success=False, message="rank failed")
+        synchronize = Mock(
+            side_effect=[
+                failure,
+                AddExternalCorpusReqOutput(success=True, corpus_id="docs"),
+            ]
+        )
+        manager = ExternalCorpusManager(worker, send_response, synchronize, cancel)
+        thread = Mock()
+        thread.is_alive.return_value = False
+        request = SimpleNamespace(corpus_id="docs")
+        manager._pending_load = (request, thread)
+        manager._load_result = AddExternalCorpusReqOutput(
+            success=True, corpus_id="docs", loaded_token_count=7
+        )
+
+        manager.check_pending_load()
+
+        cancel.assert_called_once_with("docs")
+        worker.commit_corpus_load.assert_not_called()
+        send_response.assert_called_once_with(failure, request)
+
+    def test_peer_commit_failure_rolls_back_local_publication(self):
+        from types import SimpleNamespace
+        from unittest.mock import Mock
+
+        from sglang.srt.managers.io_struct import AddExternalCorpusReqOutput
+        from sglang.srt.speculative.external_corpus_manager import (
+            ExternalCorpusManager,
+        )
+
+        worker = SimpleNamespace(
+            commit_corpus_load=Mock(), remove_external_corpus=Mock()
+        )
+        send_response = Mock()
+        cancel = Mock()
+        build_result = AddExternalCorpusReqOutput(
+            success=True, corpus_id="docs", loaded_token_count=7
+        )
+        commit_failure = AddExternalCorpusReqOutput(
+            success=False, message="peer commit failed"
+        )
+        synchronize = Mock(
+            side_effect=[
+                build_result,
+                commit_failure,
+                AddExternalCorpusReqOutput(success=True, corpus_id="docs"),
+            ]
+        )
+        manager = ExternalCorpusManager(worker, send_response, synchronize, cancel)
+        thread = Mock()
+        thread.is_alive.return_value = False
+        request = SimpleNamespace(corpus_id="docs")
+        manager._pending_load = (request, thread)
+        manager._load_result = build_result
+
+        manager.check_pending_load()
+
+        worker.commit_corpus_load.assert_called_once_with("docs", 7)
+        worker.remove_external_corpus.assert_called_once_with("docs")
+        cancel.assert_not_called()
+        self.assertEqual(synchronize.call_count, 3)
+        send_response.assert_called_once_with(commit_failure, request)
+
+
+class TestExactTokenChunks(CustomTestCase):
+    """Phase 3: client-provided exact token_chunks are used verbatim
+    (no re-tokenization) and validated before scheduler dispatch."""
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            from sglang.srt.managers.io_struct import (
+                AddExternalCorpusReqInput,
+                AddExternalCorpusReqOutput,
+            )
+            from sglang.srt.managers.tokenizer_control_mixin import (
+                TokenizerControlMixin,
+            )
+            from sglang.srt.speculative.cpp_ngram.external_corpus import (
+                SEPARATOR_TOKEN,
+            )
+        except (ImportError, OSError) as e:  # pragma: no cover - env dependent
+            raise unittest.SkipTest(
+                f"tokenizer_control_mixin import unavailable: {e}"
+            )
+        cls.Mixin = TokenizerControlMixin
+        cls.ReqIn = AddExternalCorpusReqInput
+        cls.ReqOut = AddExternalCorpusReqOutput
+        cls.SEP = SEPARATOR_TOKEN
+
+    def _make_self(self, max_tokens=100, vocab_size=100, communicator=None):
+        from types import SimpleNamespace
+        from unittest.mock import AsyncMock
+
+        server_args = SimpleNamespace(
+            speculative_algorithm="NGRAM",
+            speculative_ngram_external_sam_budget=1,
+            speculative_ngram_external_corpus_max_tokens=max_tokens,
+            dp_size=1,
+            pp_size=1,
+        )
+        if communicator is None:
+            communicator = AsyncMock(
+                return_value=[
+                    self.ReqOut(
+                        success=True,
+                        corpus_id="cid",
+                        message="ok",
+                        loaded_token_count=0,
+                    )
+                ]
+            )
+        return SimpleNamespace(
+            server_args=server_args,
+            model_config=SimpleNamespace(vocab_size=vocab_size),
+            auto_create_handle_loop=lambda: None,
+            add_external_corpus_communicator=communicator,
+        )
+
+    def _call(self, fake_self, obj):
+        import asyncio
+
+        return asyncio.run(self.Mixin.add_external_corpus(fake_self, obj))
+
+    def test_exact_chunks_used_verbatim(self):
+        from unittest.mock import AsyncMock
+
+        comm = AsyncMock(
+            return_value=[
+                self.ReqOut(
+                    success=True,
+                    corpus_id="cid",
+                    message="ok",
+                    loaded_token_count=7,
+                )
+            ]
+        )
+        fake = self._make_self(communicator=comm)
+        chunks = [[1, 2, 3], [self.SEP, 4, 5, 6]]
+        obj = self.ReqIn(corpus_id="c", token_chunks=[list(c) for c in chunks])
+        out = self._call(fake, obj)
+        self.assertTrue(out.success)
+        self.assertEqual(out.corpus_id, "cid")
+        self.assertEqual(out.loaded_token_count, 7)
+        comm.assert_called_once()
+        passed = comm.call_args.args[0]
+        # Verbatim: no re-tokenization, and documents/file_path cleared.
+        self.assertEqual(passed.token_chunks, chunks)
+        self.assertIsNone(passed.file_path)
+        self.assertIsNone(passed.documents)
+
+    def test_empty_chunk_rejected(self):
+        from unittest.mock import AsyncMock
+
+        comm = AsyncMock()
+        fake = self._make_self(communicator=comm)
+        obj = self.ReqIn(corpus_id="c", token_chunks=[[1, 2], []])
+        out = self._call(fake, obj)
+        self.assertFalse(out.success)
+        self.assertIn("non-empty", out.message)
+        comm.assert_not_called()
+
+    def test_empty_chunk_list_rejected(self):
+        from unittest.mock import AsyncMock
+
+        comm = AsyncMock()
+        fake = self._make_self(communicator=comm)
+        obj = self.ReqIn(corpus_id="c", token_chunks=[])
+        out = self._call(fake, obj)
+        self.assertFalse(out.success)
+        self.assertIn("non-empty", out.message)
+        comm.assert_not_called()
+
+    def test_over_limit_rejected(self):
+        from unittest.mock import AsyncMock
+
+        comm = AsyncMock()
+        fake = self._make_self(max_tokens=5, communicator=comm)
+        obj = self.ReqIn(corpus_id="c", token_chunks=[[1, 2, 3], [4, 5, 6]])
+        out = self._call(fake, obj)
+        self.assertFalse(out.success)
+        self.assertIn("exceeds", out.message)
+        comm.assert_not_called()
+
+    def test_separator_token_allowed(self):
+        from unittest.mock import AsyncMock
+
+        comm = AsyncMock(
+            return_value=[
+                self.ReqOut(
+                    success=True,
+                    corpus_id="cid",
+                    message="ok",
+                    loaded_token_count=5,
+                )
+            ]
+        )
+        fake = self._make_self(communicator=comm)
+        obj = self.ReqIn(corpus_id="c", token_chunks=[[1, 2], [self.SEP, 3, 4]])
+        out = self._call(fake, obj)
+        self.assertTrue(out.success)
+        self.assertEqual(out.loaded_token_count, 5)
+        comm.assert_called_once()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Part of #21052.

SGLang already supports multiple external NGRAM Suffix Automata (SAMs) and Python HTTP endpoints for adding, removing, and listing them. However, generation requests cannot select a specific corpus: the legacy matcher searches every published SAM. This makes domain- or tenant-scoped corpora impossible and can spend the external-SAM draft budget on unrelated corpora.

This PR adds request-scoped corpus selection and hardens the dynamic corpus lifecycle so a corpus is published only after every participating TP rank has built and committed the same corpus. It also brings the request field and management path across the native Engine/HTTP APIs, OpenAI-compatible APIs, gRPC/protobuf, the embedded Rust server, Python scheduler, FFI, and C++ matcher.

### Roadmap alignment

- Directly implements the open roadmap item **“User request take in corpus_ids to match”** in #21052. The public field is named `ngram_corpus_id` because each request selects at most one external corpus.
- Hardens the completed **“Support multiple SAMs with dynamic add/remove via HTTP API”** item with exact token chunks, strict validation, Rust-server routes, and TP-wide staged commit/rollback.
- Partially advances the scheduler-transport work by coordinating TP ranks. It does **not** complete dynamic corpus transport for DP, PP, disaggregation, or multi-scheduler deployments, so this PR does not close the roadmap issue.
- Per-request Trie/SAM construction from the prompt, longer SAM matching, and dynamic Trie/SAM budget allocation remain out of scope.

## Modifications

### Per-request corpus selection

Add the optional `ngram_corpus_id` field throughout the generation stack:

- Native `/generate` and `GenerateReqInput`
- `Engine.generate`, `Engine.async_generate`, and HTTP Engine adapters (keyword-only)
- OpenAI Chat Completions, Completions, and Python Responses APIs
- Session request reconstruction and Responses tool follow-up requests
- gRPC `TextGenerateRequest` and `GenerateRequest`
- Embedded Rust request parsing and Python msgspec transport
- Scheduler request state, NGRAM worker, Python corpus wrapper, FFI, and C++ matching

| `ngram_corpus_id` value | Matching behavior |
| --- | --- |
| omitted / `null` / Python `None` | Preserve the legacy behavior and search all published external SAMs |
| a known non-empty ID | Search only that external SAM |
| `""` | Use the online Trie only |
| an unknown or removed ID | Safely use the online Trie only; never fall back to all SAMs |

For batched generation, a scalar ID broadcasts to every prompt, while a list must align with the prompt batch. Parallel sampling expands the selector together with the request.

The Python layer resolves corpus IDs to stable `int64` handles before entering the matching hot path. C++ stores published corpora in a handle-indexed table with an ID-to-handle side index; strings are not used during per-token matching.

### Dynamic corpus management

The existing management endpoints are retained and made consistent:

- `POST /add_external_corpus`
- `POST /remove_external_corpus`
- `GET /list_external_corpora`

Python `/add_external_corpus` accepts exactly one source:

- `token_chunks`: exact token IDs, used verbatim without re-tokenization
- `documents`: tokenized by the server
- `file_path`: streamed from the configured file

`token_chunks` is validated for non-empty chunks, signed-int32 values, model vocabulary range, the `-2147483648` document separator, and the configured global token limit. Corpus IDs reject tab/CR/LF delimiters; an omitted or empty ID is generated automatically.

The embedded Rust server exposes the same three routes, but intentionally accepts `token_chunks` only; callers must tokenize `documents` or `file_path` client-side. Rust also adds:

- strict request schemas and public response shaping
- `ADMIN_OPTIONAL` bearer authentication (`admin_api_key` takes precedence over `api_key`)
- constant-time key comparison and authentication before body allocation
- an upload body limit derived from `--speculative-ngram-external-corpus-max-tokens`

### Transactional publication across TP ranks

- Corpus construction happens in a background staging slot and remains invisible to inference until commit.
- Every TP rank builds locally. A CPU-group readiness reduction and result gather verify that all ranks produced the same corpus ID and token count.
- Publication occurs only after the all-rank build succeeds. A second synchronization point acts as the commit fence.
- Build failure cancels staging on every rank. Partial commit failure removes already-published copies and cancels unpublished staging before schedulers resume.
- Removing the same corpus ID while it is still loading is rejected; other published corpora remain available.
- `remove` and `list` results are gathered across TP ranks, and divergent corpus lists are surfaced as an error.
- Deferred control replies use one scheduler router for either the Python tokenizer socket or the embedded Rust egress path.

### Wire and compatibility details

- New Engine parameters are keyword-only.
- Protobuf fields use new optional tags (`TextGenerateRequest` field 18 and `GenerateRequest` field 17).
- `ngram_corpus_id` is appended at the end of the Python array-like msgspec wire struct; the Rust encoder emits the intervening default slots so existing field positions do not move.
- Requests that omit the new field keep the legacy all-SAM behavior without allocating a selector vector.
- Server-argument validation now consistently enforces `0 <= external_sam_budget <= draft_tokens - 1` and a positive corpus token limit.

### Example

```bash
# Load exact token IDs (supported by both Python and Rust frontends).
curl -X POST http://localhost:30000/add_external_corpus \
  -H 'Content-Type: application/json' \
  -d '{
    "corpus_id": "docs-v1",
    "token_chunks": [[101, 102, 103], [-2147483648, 201, 202]]
  }'

# Select that corpus for one OpenAI-compatible request.
curl -X POST http://localhost:30000/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{
    "model": "default",
    "messages": [{"role": "user", "content": "Summarize the docs"}],
    "ngram_corpus_id": "docs-v1"
  }'
```

## Compatibility and Current Limitations

- Existing clients are backward compatible when they omit `ngram_corpus_id`.
- Unknown or removed corpus IDs intentionally select Trie-only instead of returning an error. Callers that need strict existence checks should use `/list_external_corpora`.
- Dynamic `add` and `remove` currently require `dp_size=1` and `pp_size=1`; multi-TP is supported. DP/PP deployments should continue using the startup external-corpus option. `list` remains read-only and checks replica consistency.
- Rust and Python management capabilities differ intentionally: Rust accepts exact `token_chunks` only, while Python can also tokenize `documents` or read `file_path`.
- Management request validation is stricter than before: unknown fields, implicit type coercions, multiple simultaneous sources, and invalid server-argument combinations are rejected.
- This PR does not claim mixed-version rolling-upgrade compatibility between Rust and Python processes.

## Accuracy Tests

NGRAM speculative decoding remains lossless because the target model still verifies every proposed token. The selector changes the source of draft candidates, not target-model verification.

### Coverage added (execution pending)

- Staged-corpus invisibility, commit, cancellation, rollback, pending-load/remove conflicts, and cross-rank list consistency
- Single-corpus and mixed-batch isolation, legacy `None`, Trie-only `""`, and unknown/removed corpus behavior
- Exact token-chunk and corpus-ID validation, token limits, topology restrictions, authentication, and upload body limits
- Engine, OpenAI Chat/Completions/Responses, session, gRPC/protobuf, Rust request, and msgspec-wire propagation
- Scheduler control-output routing and distributed result merging

The added tests have not yet run in the PR test matrices for this head. No end-to-end model-generation accuracy comparison has been run yet.

## Speed Tests and Profiling

Not run yet.

The omitted-selector path preserves the existing allocation-free all-SAM fast path. Explicit selection resolves the string ID to an integer handle before matching and queries only the selected SAM, while corpus construction stays on the background control path. End-to-end decode throughput/latency, external-corpus load time, and peak CPU memory still need benchmarking.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32002497184](https://github.com/sgl-project/sglang/actions/runs/32002497184)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32002497007](https://github.com/sgl-project/sglang/actions/runs/32002497007)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->