### PR TITLE
[Spec] Drop the unconditional stream sync from spec-prefill H2D copies

### DIFF
--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -1473,9 +1473,11 @@ class DFlashWorkerV2(BaseSpecWorker):
             # Materialize prompt tokens into the draft KV cache immediately. This is required
             # for radix cache safety (the scheduler may update radix after prefill returns).
             device = next_token_ids.device
-            ctx_lens = torch.tensor(batch.extend_lens, dtype=torch.int32, device=device)
-            draft_seq_lens = torch.tensor(
-                batch.prefix_lens, dtype=torch.int32, device=device
+            ctx_lens = torch.tensor(batch.extend_lens, dtype=torch.int32).to(
+                device, non_blocking=True
+            )
+            draft_seq_lens = torch.tensor(batch.prefix_lens, dtype=torch.int32).to(
+                device, non_blocking=True
             )
 
             if batch.out_cache_loc is None:

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -452,9 +452,11 @@ class DSparkWorkerV2(BaseSpecWorker):
         # Must inject before prefill returns: the scheduler may update radix
         # afterward, invalidating out_cache_loc.
         device = next_token_ids.device
-        ctx_lens = torch.tensor(batch.extend_lens, dtype=torch.int32, device=device)
-        draft_seq_lens = torch.tensor(
-            batch.prefix_lens, dtype=torch.int32, device=device
+        ctx_lens = torch.tensor(batch.extend_lens, dtype=torch.int32).to(
+            device, non_blocking=True
+        )
+        draft_seq_lens = torch.tensor(batch.prefix_lens, dtype=torch.int32).to(
+            device, non_blocking=True
         )
         positions, _ = compute_position(
             self.model_runner.prefill_attention_backend_str,


### PR DESCRIPTION
## What

`torch.tensor(python_list, device="cuda")` lowers to `memcpy_and_sync()` — a `cudaMemcpyAsync` followed by an **unconditional** `cudaStreamSynchronize`. In both spec workers, the `ctx_lens` / `draft_seq_lens` copies are issued a few statements after `target_worker.forward_batch_generation(...)`, which does not synchronize before returning — so the host blocks on the **entire target prefill forward** for an 8-byte copy. `torch.tensor(...).to(device, non_blocking=True)` performs the same copy without draining the stream.

Four sites — the same two lines in both spec workers:

| file | tensors |
|---|---|
| `speculative/dspark_components/dspark_worker_v2.py` | `ctx_lens`, `draft_seq_lens` |
| `speculative/dflash_worker_v2.py` | `ctx_lens`, `draft_seq_lens` (verbatim twin of the above) |

Within each file the two lines must change together: the sync drains the queue, so converting only the first would just make the second one the payer.

## Why this is safe

Both tensors have exactly one consumer on this path: `compute_position` → `compute_position_triton`, which reads them with `tl.load` on the current stream. Every CUDA/HIP attention backend takes that branch (`support_triton()`); nothing reads the values back on the host, and there is no stream switch or synchronization primitive anywhere between the copy and the kernel. The `torch_native` / `intel_amx` fallback (`compute_position_torch`) does host-read them — still correct, because the implicit `.item()` synchronizes the same stream the copy was enqueued on; those backends simply see no win.

This is the same idiom the non-spec prefill path already uses for the same two quantities (`forward_batch_info.py` builds `extend_seq_lens` / `extend_prefix_lens` with `torch.tensor(...).to(device, non_blocking=True)`), and the same fix #34782 (merged) applied to the DSpark decode path.

## Scope change from the first revision

The first push also converted two more `torch.tensor(list, device=...)` sites, in `mem_cache/allocation.py` and `speculative/frozen_kv_mtp_utils.py`. Both dropped: neither is reachable in the configuration where the drain was observed (the `allocation.py` sentinel is on the dLLM-only kv-reuse branch; the `frozen_kv_mtp_utils.py` site is Frozen-KV-MTP-only), and the right fix for the `allocation.py` sentinel is the on-device `torch.full((1,), -1, device=...)` that #32575 already applied to its sibling line — that belongs in its own follow-up, not riding along unmeasured here.

## Honest scoping — please read before treating this as a perf PR

On the setup where this was found (2× DGX Spark / GB10 sm_121 / DeepSeek-V4-Flash / TP=2 across two nodes), **prefill is ~99.4% GPU-bound**: 27.0 ms idle out of a 4409 ms window. That caps the host-side upside at **~0.6%**, and I could **not** demonstrate an end-to-end improvement above run-to-run noise.

One more caveat in the same spirit: for pageable sources the CUDA sync-behavior appendix leaves the driver latitude to stage an "async" copy through an internal stream sync ("might be synchronous with respect to host"). If this driver takes that path, the change removes PyTorch's explicit post-copy drain and inherits an implicit one in the same position.

So the case for this patch is **"remove a sync that serves no purpose on these call sites, and align them with the idiom the surrounding code already uses"**, not a measured speedup. A deployment whose prefill is less GPU-bound, or one where one of these syncs lands next to a long-running kernel, could see more — the cost of a sync has no intrinsic magnitude, only a position on the stream.

Filing as draft; happy to close it if the maintainers would rather not carry a change without a demonstrated win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32168567081](https://github.com/sgl-project/sglang/actions/runs/32168567081)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32168566642](https://github.com/sgl-project/sglang/actions/runs/32168566642)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->