### PR TITLE
[diffusion] Fix width/height silently dropped on multipart /v1/videos requests

### DIFF
--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/video_api.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/video_api.py
@@ -574,6 +574,8 @@ async def create_video(
     size: Optional[str] = Form(None),
     fps: Optional[int] = Form(None),
     num_frames: Optional[int] = Form(None),
+    width: Optional[int] = Form(None),
+    height: Optional[int] = Form(None),
     seed: Optional[int] = Form(None),
     generator_device: Optional[str] = Form("cuda"),
     negative_prompt: Optional[str] = Form(None),
@@ -700,6 +702,8 @@ async def create_video(
         }
         fps_val = form_value("fps", fps)
         num_frames_val = form_value("num_frames", num_frames)
+        width_val = form_value("width", width)
+        height_val = form_value("height", height)
 
         req = VideoGenerationsRequest(
             prompt=prompt,
@@ -715,6 +719,8 @@ async def create_video(
             size=form_value("size", size),
             fps=fps_val,
             num_frames=num_frames_val,
+            width=width_val,
+            height=height_val,
             seed=form_value("seed", seed),
             generator_device=form_value("generator_device", generator_device),
             negative_prompt=form_text_value("negative_prompt", negative_prompt),


### PR DESCRIPTION
## Summary
- `create_video()` declares explicit `Form(...)` parameters for `seconds`, `size`, `fps`, `num_frames`, `seed`, etc., but not for `width`/`height`. Because those two names are already declared fields on `VideoGenerationsRequest`, the generic "extra form field" fallback explicitly excludes already-declared fields, so a multipart request's `width`/`height` are never read — the pipeline's `SamplingParams` subclass default silently wins instead.
- Fix: add `width`/`height` as explicit `Form(None)` parameters, threaded through the same `form_value()` precedence already used for `fps`/`num_frames`.
- Not model-specific: any multipart `/v1/videos` request with explicit `width`/`height` hits this, for any model (surfaced here while building an image-to-video client against LTX-2.5, #35107). The JSON body path was already unaffected.

## Test plan
- [x] Before: multipart request for `width=704&height=512` produced a `960x544` video (LTX25SamplingParams' hardcoded default), confirmed via `ffprobe` on the actual output.
- [x] After: same request produces `704x512` output, confirmed via `ffprobe`.
- [x] JSON body path re-verified unaffected (worked before and after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32004190886](https://github.com/sgl-project/sglang/actions/runs/32004190886)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32004190724](https://github.com/sgl-project/sglang/actions/runs/32004190724)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->