### PR TITLE
[Fix] Read the DSA prefill CP flag from the parallel config bag in bootstrap

### DIFF
--- a/python/sglang/srt/distributed/bootstrap.py
+++ b/python/sglang/srt/distributed/bootstrap.py
@@ -239,7 +239,7 @@ def _init_parallel_groups(
         duplicate_attn_cp_group=(
             is_hip()
             and server_args.enable_two_batch_overlap
-            and server_args.enable_dsa_prefill_context_parallel
+            and get_parallel().enable_dsa_prefill_context_parallel
         ),
         enable_symm_mem=server_args.enable_symm_mem,
         recovered_rank=is_ep_joiner,


### PR DESCRIPTION
`enable_dsa_prefill_context_parallel` is `no_cli=True` and only ever set by resolution, so it must be read from the published `parallel` bag rather than off the supplied `server_args` instance. Also restores `test_supplied_instance_exposure_ratchet.py` on main.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32004688735](https://github.com/sgl-project/sglang/actions/runs/32004688735)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32004688540](https://github.com/sgl-project/sglang/actions/runs/32004688540)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->