### PR TITLE
[AMD] diffusion: normalize ModelOpt-FP8 weights to e4m3fnuz on gfx942

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/quantization/modelopt_quant.py
+++ b/python/sglang/multimodal_gen/runtime/layers/quantization/modelopt_quant.py
@@ -7,7 +7,7 @@ from functools import lru_cache
 from typing import Any, Dict, List, Optional
 
 import torch
-
+from sglang.kernels.ops.quantization.fp8_kernel import is_fp8_fnuz
 from sglang.multimodal_gen.runtime.layers.linear import (
     LinearMethodBase,
     UnquantizedLinearMethod,
@@ -22,7 +22,6 @@ from sglang.multimodal_gen.runtime.models.parameter import (
 )
 from sglang.multimodal_gen.runtime.platforms import current_platform
 from sglang.multimodal_gen.runtime.utils.weight_attrs import set_weight_attrs
-from sglang.kernels.ops.quantization.fp8_kernel import is_fp8_fnuz
 from sglang.srt.layers.quantization.fp8_utils import (
     apply_fp8_linear,
     cutlass_fp8_supported,

--- a/python/sglang/multimodal_gen/runtime/layers/quantization/modelopt_quant.py
+++ b/python/sglang/multimodal_gen/runtime/layers/quantization/modelopt_quant.py
@@ -22,9 +22,11 @@ from sglang.multimodal_gen.runtime.models.parameter import (
 )
 from sglang.multimodal_gen.runtime.platforms import current_platform
 from sglang.multimodal_gen.runtime.utils.weight_attrs import set_weight_attrs
+from sglang.kernels.ops.quantization.fp8_kernel import is_fp8_fnuz
 from sglang.srt.layers.quantization.fp8_utils import (
     apply_fp8_linear,
     cutlass_fp8_supported,
+    normalize_e4m3fn_to_e4m3fnuz,
 )
 from sglang.srt.layers.quantization.modelopt_quant import (
     pad_nvfp4_activation_for_cutlass,
@@ -411,8 +413,25 @@ class ModelOptFp8LinearMethod(LinearMethodBase):
                 )
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        # ROCm gfx942 (MI300X/MI325X) uses e4m3fnuz as its native fp8 dtype, so
+        # scaled_fp8_quant() produces e4m3fnuz activations. ModelOpt checkpoints
+        # ship e4m3fn weights. hipBLASLt rejects the resulting e4m3fn x e4m3fnuz
+        # torch._scaled_mm with HIPBLAS_STATUS_NOT_SUPPORTED. Reinterpreting the
+        # weights as e4m3fnuz and doubling the static scales is numerically
+        # identical and keeps the GEMM on the native fp8 path.
+        weight = layer.weight
+        if is_fp8_fnuz():
+            weight, weight_scale, input_scale = normalize_e4m3fn_to_e4m3fnuz(
+                weight=layer.weight,
+                weight_scale=layer.weight_scale,
+                input_scale=layer.input_scale,
+            )
+            copy_or_rebind_param(layer, "weight_scale", weight_scale)
+            if input_scale is not None:
+                copy_or_rebind_param(layer, "input_scale", input_scale)
+
         max_w_scale, quantized_weight = requantize_with_max_scale(
-            layer.weight, layer.weight_scale, layer.logical_widths
+            weight, layer.weight_scale, layer.logical_widths
         )
         # Preserve the parameter subclass metadata while rebinding to the
         # transposed FP8 view expected by the runtime.

--- a/python/sglang/multimodal_gen/runtime/layers/quantization/modelopt_quant.py
+++ b/python/sglang/multimodal_gen/runtime/layers/quantization/modelopt_quant.py
@@ -7,6 +7,7 @@ from functools import lru_cache
 from typing import Any, Dict, List, Optional
 
 import torch
+
 from sglang.kernels.ops.quantization.fp8_kernel import is_fp8_fnuz
 from sglang.multimodal_gen.runtime.layers.linear import (
     LinearMethodBase,


### PR DESCRIPTION
On gfx942 (MI300X / MI325X) the native fp8 dtype is e4m3fnuz, so `scaled_fp8_quant()` produces e4m3fnuz activations. ModelOpt checkpoints such as FLUX.2 ship e4m3fn weights. The resulting mixed e4m3fn x e4m3fnuz `torch._scaled_mm` is rejected by hipBLASLt with `HIPBLAS_STATUS_NOT_SUPPORTED`, and the server fails during warmup.

This converts the weights to e4m3fnuz in `process_weights_after_loading` when running on fnuz hardware, doubling the static scales. The conversion is numerically identical, and it keeps the GEMM on the native fp8 path instead of falling back to a bf16 dequant.

Tested on MI300X (gfx942). Before the change, warmup aborts in `modelopt_quant.py` with `HIPBLAS_STATUS_NOT_SUPPORTED`. After it, warmup completes and the server serves requests.

Non-ROCm hardware is unaffected: `is_fp8_fnuz()` is false there, so the new branch is skipped and the existing path runs unchanged.

Supersedes #28889, which had accumulated a long merge history. This is the same fix rebased onto current main as a single commit, with one correction: `is_fp8_fnuz` now lives in `sglang.kernels.ops.quantization.fp8_kernel`, so the import was updated to match.

Fixes #29590.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Notes on the unchecked items:

- Unit tests: the existing `multimodal-gen` FLUX.2 ModelOpt-FP8 job covers this path. It fails on gfx942 without this change and passes with it, so no new test is added.
- Documentation: no user-facing behaviour or option changes.
- Benchmarks: this is a correctness fix for a path that does not currently run on gfx942, so there is no before number to compare against. The effect is that the GEMM stays in fp8 rather than dequantizing to bf16.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32007675769](https://github.com/sgl-project/sglang/actions/runs/32007675769)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32007675255](https://github.com/sgl-project/sglang/actions/runs/32007675255)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->