### PR TITLE
docs(cookbook): selection-aware verification badge

### DIFF
--- a/.claude/skills/cookbook-add-model/references/authoring-reference.md
+++ b/.claude/skills/cookbook-add-model/references/authoring-reference.md
@@ -34,7 +34,7 @@ the full contract):
 | `quantizations` | `{id, label}[]` | 3rd-dim option list. |
 | `strategies` | `{id, label}[]` | 4th-dim option list. Canonical ids: `low-latency` / `balanced` / `high-throughput` (never model-specific ids like `mtp`). **The count follows the page's operating points**: one recipe → a single `balanced`; two → `low-latency` + `high-throughput`; three → the full trio (the ideal). Tiers apply per (hw × variant × quant) combination — a single-recipe combination parks under its semantically honest tier (clear slant → that tier, e.g. DSv4's RTX 6000 → `low-latency`; no slant → `balanced`, e.g. Qwen3.5's Xeon); the page's list is the union and the engine greys unused chips per selection. Never invent a recipe just to fill chips. When two recipes differ by MTP / speculative decoding, the assignment is deterministic: spec ON → `low-latency`, spec OFF → `high-throughput` (at saturation the draft+verify overhead outweighs the speedup — same reason DSv4's high-throughput recipes disable MTP). The recurring markers in the other direction: dp-attention ON (MLA-attention models) and EP / DP+EP ON (MoE models) → `high-throughput`. |
 | `nodesOptions` | `{id, label}[]` | 5th-dim option list. The `id` MUST be `single` or `multi-N` — the engine parses N from the id for `--nnodes`. |
-| `cells` | `{match, verified?, nnodes?, env, flags}[]` | One per supported (hw × match-dim) combination. See §2.2. `nnodes` supplies the node count when the config declares no `nodes` dim (default 1). |
+| `cells` | `{match, verified?, verificationStatus?, nnodes?, env, flags}[]` | One per supported (hw × match-dim) combination. See §2.2. `nnodes` supplies the node count when the config declares no `nodes` dim (default 1). `verified` is a boolean; `verificationStatus` overrides it with `"verified" \| "in-progress" \| "unverified"`. Either may instead be a **function of the full selection** (match + overlay dims) for recipes whose validation covers only part of their overlay envelope — see §2.2. |
 | `modelNames` | `{[key]: string}` | HF slug lookup. Keys are either `hw\|variant\|quant` (most specific) or `variant\|quant` (fallback). |
 | `placeholders` | `{[key]: {target, label, default?}}` | `{{KEY}}` interpolation map for command + curl. `target` is `'command'` or `'curl'`. Editable through the Env modal. |
 | `curl` | string | cURL template. Uses `{{MODEL_NAME}}` + placeholder keys. |
@@ -95,7 +95,17 @@ Each cell describes one verified (or auto-estimated) launch recipe.
 {
   match: { hw: "b200", variant: "flash", quant: "fp4",
            strategy: "low-latency", nodes: "single" },
-  verified: true,                  // green "Verified" badge; absence = yellow
+  verified: true,                  // green "Verified" badge; absence = yellow.
+                                   // May also be a FUNCTION of the selection
+                                   // when the cell's validation covers only
+                                   // part of its overlay envelope, e.g.
+                                   //   verified: (sel) =>
+                                   //     sel.tier === "low-latency" &&
+                                   //     sel.spec === "none",
+                                   // so an unmeasured overlay pick reads
+                                   // "Not Verified" instead of borrowing the
+                                   // cell's badge. Same for verificationStatus
+                                   // (return a status id string).
   env: [
     "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=1024",
   ],

--- a/.claude/skills/cookbook-add-model/templates/config.jsx.tmpl
+++ b/.claude/skills/cookbook-add-model/templates/config.jsx.tmpl
@@ -328,6 +328,11 @@ sgl-eval run gsm8k \\
   // EXAMPLE cells — one per hardware family to show the shape. REPLACE each with
   // your model's verified recipe, or DELETE families you don't support. `match`
   // MUST have exactly the 5 keys; env/flags are flat literals.
+  // `verified` (or `verificationStatus`) may be a function of the full
+  // selection when validation covers only part of a cell's overlay envelope:
+  //   verified: (sel) => sel.tier === "low-latency" && sel.spec === "none",
+  // Unmeasured overlay picks then read "Not Verified" instead of inheriting
+  // the cell's badge (authoring-reference §2.2).
   // Accuracy-degrading flags (W4A4-style runtime quant, lossy --kv-cache-dtype)
   // default to Playground/tips — putting one in a cell needs explicit user
   // confirmation (authoring-reference §2.2).

--- a/.claude/skills/cookbook-review-pr/SKILL.md
+++ b/.claude/skills/cookbook-review-pr/SKILL.md
@@ -106,6 +106,13 @@ than restating.
   should be exactly what the quant chip declares, so absent a recorded
   sign-off in the PR (e.g. carried verbatim from a measured legacy recipe's
   default command), request the flag move to Playground/tips.
+- Verification badge honesty on configs with `overlayDims`: a cell's
+  `verified: true` asserts the badge for EVERY overlay combination, since
+  overlays never re-match the cell. If the PR's stated validation covers only
+  part of the overlay envelope (e.g. defaults only), the cell should use the
+  function form — `verified: (sel) => ...` / `verificationStatus: (sel) => ...`
+  (authoring-reference §2.2) — so unmeasured picks read "Not Verified". Flag a
+  static `true` whose envelope exceeds the recorded measurements.
 - Flag order: `--model-path` first (an optional `--trust-remote-code` may precede it —
   the DSv4 cells do), then parallelism, then MoE, then tuning, `--host`/`--port`
   last (the playground's insert anchors assume this).

--- a/docs/src/snippets/_deployment.jsx
+++ b/docs/src/snippets/_deployment.jsx
@@ -443,8 +443,16 @@ export const Deployment = ({ config, benchmarks }) => {
     typeof v === "string"
       ? (VERIFY_LABEL[v] ? v : "unverified")
       : (v ? "verified" : "unverified");
-  const cellVerifyStatus = (c) =>
-    c ? verifyStatusOf(c.verificationStatus ?? c.verified) : "unverified";
+  // Either field may also be a function of the full selection, so overlay
+  // picks — which never re-match the cell — can still move the badge: a
+  // recipe verified only at its default serving tier reports "unverified"
+  // the moment a non-default overlay option is selected.
+  const cellVerifyStatus = (c, selection) => {
+    if (!c) return "unverified";
+    let v = c.verificationStatus ?? c.verified;
+    if (typeof v === "function") v = v(selection);
+    return verifyStatusOf(v);
+  };
 
   // Two kinds of selector row:
   //   match dims    participate in cell lookup (cell.match[dim] === sel[dim])
@@ -1240,7 +1248,7 @@ export const Deployment = ({ config, benchmarks }) => {
   // ==== 5. Derived values ====
   const s = makeStyles(isDark);
   const cell = findCell(config.cells, sel);
-  const verifyStatus = cellVerifyStatus(cell);
+  const verifyStatus = cellVerifyStatus(cell, sel);
   // Pin the calculator-computed ratio into the rendered command (before the
   // host/port tail); cells themselves stay ratio-free.
   const cellWithRatio = (() => {


### PR DESCRIPTION
Split out of #35065 per [review feedback](https://github.com/sgl-project/sglang/pull/35065#pullrequestreview-4948957181): the `_deployment.jsx` change ships separately from the model-data PR.

### What

`verified` / `verificationStatus` on a cell may now be a **function of the full selection** (match + overlay dims):

```js
verified: (sel) => sel.tier === "low-latency" && sel.spec === "none",
```

### Why

Overlay dims never re-match a cell, so a static `verified: true` asserts the green badge for **every** overlay combination — including ones the page's validation never covered. Checked kimi-k3 first: it uses static `verificationStatus` strings only, and no existing engine capability can express "verified at the defaults, unverified off them", so the engine change is required for this semantics. With the function form, unmeasured overlay picks read **Not Verified** instead of inheriting the cell's badge, while every option stays selectable.

### Compatibility

- Booleans and status strings behave exactly as before (single call site; `sel` simply passed through).
- No existing config changes behavior; the function form is opt-in per cell.

### Skills / references / templates

Per the cookbook engine-change process:
- `cookbook-add-model/references/authoring-reference.md` §2.2 + cells table: function form documented.
- `cookbook-add-model/templates/config.jsx.tmpl`: example in the cells comment.
- `cookbook-review-pr/SKILL.md` §3: badge-honesty checklist item (flag a static `true` whose envelope exceeds the recorded measurements).

### First consumer

#35065 (Qwen3.8-27B): h200/gb300 recipes are validated only at their overlay defaults (plus plain MTP on gb300). Until this merges, its function-valued fields degrade to the pre-existing always-Verified behavior (a function is truthy), so ordering is safe either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32005901115](https://github.com/sgl-project/sglang/actions/runs/32005901115)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32005900716](https://github.com/sgl-project/sglang/actions/runs/32005900716)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->