### PR TITLE
[Fix][Profiler] Stop freezing the scheduler thread while the chrome trace is written

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1939,20 +1939,25 @@ class Scheduler(
 
             output = self._request_dispatcher(recv_req)
             if output is not None:
-                if self.rust_server is not None:
-                    # Embedded Rust server: every control-request response goes
-                    # back through the egress ring (the zmq tokenizer socket is
-                    # not consumed); the Rust api_server shapes it per-endpoint.
-                    self.rust_server.push_control_output(recv_req, output)
-                elif isinstance(output, RpcReqOutput):
-                    if self.ipc_channels.recv_from_rpc is not None:
-                        sock_send(self.ipc_channels.recv_from_rpc, output)
-                else:
-                    self.ipc_channels.send_to_tokenizer.send_output(output, recv_req)
+                self.send_control_output(recv_req, output)
 
         self.flush_wrapper.check_pending()
+        self.profiler_manager.check_pending_flush()
         if self.external_corpus_manager is not None:
             self.external_corpus_manager.check_pending_load()
+
+    def send_control_output(self, recv_req, output) -> None:
+        """Answer a control request, now or once a deferred handler completes."""
+        if self.rust_server is not None:
+            # Embedded Rust server: every control-request response goes
+            # back through the egress ring (the zmq tokenizer socket is
+            # not consumed); the Rust api_server shapes it per-endpoint.
+            self.rust_server.push_control_output(recv_req, output)
+        elif isinstance(output, RpcReqOutput):
+            if self.ipc_channels.recv_from_rpc is not None:
+                sock_send(self.ipc_channels.recv_from_rpc, output)
+        else:
+            self.ipc_channels.send_to_tokenizer.send_output(output, recv_req)
 
     def _materialize_cuda_vmm_inputs(self, recv_req):
         """Release VMM slices before request handling can reject the request."""
@@ -1981,6 +1986,7 @@ class Scheduler(
             ps=self.ps,
             dp_tp_cpu_group=self.dp_tp_cpu_group,
             get_forward_ct=lambda: self.forward_ct,
+            send_response=self.send_control_output,
         )
 
     def init_weight_updater(self) -> None:
@@ -5274,6 +5280,9 @@ def run_scheduler_process(
             # Graceful path only: on the exception path the GPU may be wedged
             # and the synchronize() in destroy() could itself hang.
             if scheduler.gracefully_exit:
+                # The loop above has stopped polling, so a trace still being
+                # written has to be waited for here to answer its /stop_profile.
+                scheduler.profiler_manager.drain_pending_flushes()
                 scheduler.release_host_resources()
 
 

--- a/python/sglang/srt/managers/scheduler_components/profiler_manager.py
+++ b/python/sglang/srt/managers/scheduler_components/profiler_manager.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
 import gc
+import gzip
 import logging
 import os
+import shutil
+import tempfile
 import time
+from collections import deque
+from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
 from typing import (
@@ -49,13 +54,67 @@ elif _is_mps:
 logger = logging.getLogger(__name__)
 
 
+# Compress the trace a few MB at a time: see _export_trace.
+_TRACE_GZIP_CHUNK = 4 << 20
+
+# Traces are hundreds of MB each while they wait to be written, so a profile that
+# is restarted faster than they can be written out has to wait for one.
+_MAX_PENDING_FLUSHES = 2
+
+
+def _export_trace(profiler: Any, path: str) -> None:
+    """Write out a chrome trace, compressing it in large chunks.
+
+    torch's own gzip export copies the json into the archive line by line, so it
+    needs the GIL once per line. A thread competing with the scheduler loop for
+    the GIL gets it rarely enough to stretch a 20 s write into 130 s; handing
+    zlib megabytes per call keeps this thread inside long C calls instead.
+    Everything else is torch's own staging block: the json goes to the system temp
+    directory and the archive is written in place.
+    """
+    if not path.endswith(".gz") or _is_mps:
+        # On MPS a Metal trace is saved alongside this one under a name derived
+        # from the path below, so it has to be the one the profile advertises.
+        profiler.export_chrome_trace(path)
+        return
+
+    # Not in the directory the traces are collected in: the json is an order of
+    # magnitude larger than the archive, so that volume does not have to hold both.
+    # The name is torch's rather than the trace's, because a profile id is free to
+    # be long enough, or multi-byte enough, to push a derived name past the limit a
+    # filesystem puts on one.
+    with tempfile.NamedTemporaryFile("w+b", suffix=".json") as handle:
+        profiler.export_chrome_trace(handle.name)
+        with open(handle.name, "rb") as fin, gzip.open(path, "wb") as fout:
+            shutil.copyfileobj(fin, fout, _TRACE_GZIP_CHUNK)
+
+
+@dataclass
+class _PendingTraceFlush:
+    """A trace being written out by the flush thread, drained by check_pending_flush.
+
+    output_dir is captured instead of read back from the manager, because a new
+    profiling session may already be configured by the time the write finishes.
+    """
+
+    export: Future
+    output_dir: Path
+    # Set for an explicit /stop_profile, which is answered once the trace is on disk.
+    reply_to: Optional[ProfileReq]
+
+
 @dataclass(kw_only=True)
 class SchedulerProfilerManager:
     ps: Any
     dp_tp_cpu_group: Any
     get_forward_ct: Callable[[], int]
+    # called as send_response(output=..., recv_req=...) to answer a deferred request
+    send_response: Callable[[Any, Any], None]
 
     def __post_init__(self) -> None:
+        self._flush_executor: Optional[ThreadPoolExecutor] = None
+        self._pending_flushes: deque[_PendingTraceFlush] = deque()
+
         if envs.SGLANG_PROFILE_V2.get():
             self._profile_manager = ProfileManager(
                 ps=self.ps,
@@ -311,7 +370,7 @@ class SchedulerProfilerManager:
             return merge_message
 
     def _stop_profile(
-        self, stage: Optional[ForwardMode] = None
+        self, stage: Optional[ForwardMode] = None, reply_to: Optional[ProfileReq] = None
     ) -> ProfileReqOutput | None:
         if envs.SGLANG_PROFILE_V2.get():
             self._apply_detailed_annotations(False)
@@ -332,6 +391,7 @@ class SchedulerProfilerManager:
 
         stage_suffix = f"-{stage.name}" if stage else ""
         logger.info("Stop profiling" + stage_suffix + "...")
+        pending = None
         if self.torch_profiler is not None:
             self.torch_profiler.stop()
             if not _is_npu:
@@ -352,10 +412,18 @@ class SchedulerProfilerManager:
                     + stage_suffix
                     + ".trace.json.gz"
                 )
+                path = os.path.join(self.torch_profiler_output_dir, filename)
 
-                self.torch_profiler.export_chrome_trace(
-                    os.path.join(self.torch_profiler_output_dir, filename)
-                )
+                if self.merge_profiles:
+                    # The merge below reads every trace whose name starts with this
+                    # profile id, so a trace this rank recorded earlier under the
+                    # same id has to be written first -- it publishes to the very
+                    # name the export below does. Then stay synchronous, because the
+                    # merge also reads the traces of the other ranks.
+                    self._drain_flushes(block=True)
+                    _export_trace(self.torch_profiler, path)
+                else:
+                    pending = self._flush_trace_async(path, reply_to)
             torch.distributed.barrier(self.dp_tp_cpu_group)
 
         if self.rpd_profiler is not None:
@@ -387,6 +455,15 @@ class SchedulerProfilerManager:
             if self.ps.gpu_id == get_device().base_gpu_id:
                 torch.cuda.cudart().cudaProfilerStop()
 
+        # The session itself ended when stop() returned, so profiling can be started
+        # again even while the trace of this one is still being written out.
+        self.profile_in_progress = False
+        self.profiler_start_forward_ct = None
+        self._apply_detailed_annotations(False)
+
+        if pending is not None:
+            return None  # answered by check_pending_flush() once the trace is written
+
         merge_message = self._merge_profile_traces()
 
         logger.info(
@@ -399,11 +476,110 @@ class SchedulerProfilerManager:
             self.torch_profiler = None
             gc.collect()
 
-        self.profile_in_progress = False
-        self.profiler_start_forward_ct = None
-
-        self._apply_detailed_annotations(False)
         return ProfileReqOutput(success=True, message=f"Succeeded.{merge_message}")
+
+    def _flush_trace_async(
+        self, path: str, reply_to: Optional[ProfileReq]
+    ) -> Optional[_PendingTraceFlush]:
+        """Hand the recorded trace to the flush thread and stop tracking it here.
+
+        Writing it out takes seconds per profiled second, which the scheduler thread
+        cannot afford to spend: requests in flight stall for the whole write, and a
+        health check that lands in the window fails, so the router drops the rank.
+
+        Returns None if the trace had to be written here after all, in which case
+        the caller answers its request itself.
+        """
+        if self._flush_executor is None:
+            # A single worker, so traces are written in the order they were recorded.
+            # Its thread is non-daemon, so interpreter exit joins it rather than
+            # truncating a trace that is still being written.
+            self._flush_executor = ThreadPoolExecutor(
+                max_workers=1, thread_name_prefix="sglang-trace-flush"
+            )
+
+        while len(self._pending_flushes) >= _MAX_PENDING_FLUSHES:
+            # Wait for the oldest rather than let recorded traces pile up: a stop
+            # that has to wait is what this code used to do for every stop.
+            self._drain_flushes(block=True, limit=1)
+
+        # The profiler object goes with it: this session is over, and the next one
+        # may well start before the write finishes.
+        holder = [self.torch_profiler]
+
+        def _export() -> None:
+            try:
+                _export_trace(holder[0], path)
+            finally:
+                # Free the trace here as well - it is hundreds of MB for a
+                # multi-second window, and reclaiming it is not cheap either. Also
+                # on the way out of a failed export, which would otherwise leave it
+                # for whenever a collection happens to come around.
+                holder[0] = None
+                gc.collect()
+
+        try:
+            export = self._flush_executor.submit(_export)
+        except RuntimeError:
+            # The flush thread is gone, which happens once shutdown has drained it.
+            # Write the trace here instead of dropping it, and leave torch_profiler
+            # in place for the caller to clean up as it did before.
+            _export()
+            return None
+
+        self.torch_profiler = None
+        pending = _PendingTraceFlush(
+            export=export,
+            output_dir=self.torch_profiler_output_dir,
+            reply_to=reply_to,
+        )
+        self._pending_flushes.append(pending)
+        return pending
+
+    def check_pending_flush(self) -> None:
+        """Drain trace writes that have finished. Called from the scheduler loop."""
+        self._drain_flushes()
+
+    def drain_pending_flushes(self) -> None:
+        """Finish traces that are still being written. Called on graceful shutdown.
+
+        The flush thread is not a daemon, so the process waits for the write during
+        interpreter teardown either way; waiting for it here means the /stop_profile
+        that asked for the trace still gets its answer.
+        """
+        self._drain_flushes(block=True)
+        if self._flush_executor is not None:
+            # Kept in place rather than cleared, so a stop that somehow arrives
+            # after this writes its trace inline instead of starting a thread that
+            # nothing would drain.
+            self._flush_executor.shutdown(wait=True)
+
+    def _drain_flushes(self, block: bool = False, limit: Optional[int] = None) -> None:
+        drained = 0
+        while self._pending_flushes and (limit is None or drained < limit):
+            if not block and not self._pending_flushes[0].export.done():
+                return
+            pending = self._pending_flushes.popleft()
+            error = pending.export.exception()
+            drained += 1
+            if error is None:
+                logger.info(
+                    "Profiling done. Traces are saved to: %s", pending.output_dir
+                )
+            else:
+                logger.error("Failed to export trace: %s", error, exc_info=error)
+            if pending.reply_to is not None:
+                self.send_response(
+                    output=ProfileReqOutput(
+                        success=error is None,
+                        message=(
+                            "Succeeded."
+                            if error is None
+                            else f"Failed to export trace: {error}"
+                        ),
+                    ),
+                    recv_req=pending.reply_to,
+                )
 
     def _profile_batch_predicate(self, batch: ScheduleBatch):
         if envs.SGLANG_PROFILE_V2.get():
@@ -478,4 +654,4 @@ class SchedulerProfilerManager:
                 )
                 return self._start_profile()
         else:
-            return self._stop_profile()
+            return self._stop_profile(reply_to=recv_req)

--- a/test/registered/unit/hardware_backend/mlx/test_metal_profiler.py
+++ b/test/registered/unit/hardware_backend/mlx/test_metal_profiler.py
@@ -212,7 +212,10 @@ class TestSchedulerProfilerManagerMPS(unittest.TestCase):
             gpu_id = 0
 
         mgr = SchedulerProfilerManager(
-            ps=FakePS(), dp_tp_cpu_group=None, get_forward_ct=lambda: 0
+            ps=FakePS(),
+            dp_tp_cpu_group=None,
+            get_forward_ct=lambda: 0,
+            send_response=lambda output, recv_req: None,
         )
         mgr._init_profile(output_dir, None, None, None, None, None, False, "test")
         return mgr
@@ -271,6 +274,9 @@ class TestSchedulerProfilerManagerMPS(unittest.TestCase):
                 mgr._stop_profile()
                 self.assertFalse(mgr.profile_in_progress)
                 capture_ctx.__exit__.assert_called_once()
+                # The trace is written by the flush thread, which needs the output
+                # directory to outlive it.
+                mgr.drain_pending_flushes()
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/managers/scheduler_components/test_profiler_manager_async_export.py
+++ b/test/registered/unit/managers/scheduler_components/test_profiler_manager_async_export.py
@@ -1,0 +1,556 @@
+"""The scheduler thread must not write profiler traces itself.
+
+Exporting a chrome trace costs seconds per profiled second, so doing it inline in
+_stop_profile() stalls the whole rank: requests in flight wait for it and health
+checks in the window fail. These tests pin the trace write to the flush thread,
+and pin what has to stay on the scheduler thread with it -- the barrier, so all
+ranks keep issuing group collectives in the same order.
+"""
+
+import gzip
+import json
+import os
+import tempfile
+import threading
+import time
+import unittest
+from concurrent.futures import wait
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.srt.managers.io_struct import ProfileReq, ProfileReqType
+from sglang.srt.managers.scheduler_components import profiler_manager
+from sglang.srt.managers.scheduler_components.profiler_manager import (
+    SchedulerProfilerManager,
+)
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+
+class FakeTorchProfiler:
+    """Stands in for torch.profiler.profile, with an export we control."""
+
+    def __init__(self, index=0):
+        self.index = index
+        self.stopped = False
+        self.exported = []
+        self.raise_on_export = None
+        self.entered_export = threading.Event()
+        self.release = threading.Event()
+        self.release.set()  # a test that wants a slow export clears this
+
+    def start(self):
+        pass
+
+    def stop(self):
+        self.stopped = True
+
+    def export_chrome_trace(self, path):
+        self.entered_export.set()
+        self.release.wait(timeout=60)
+        if self.raise_on_export is not None:
+            raise self.raise_on_export
+        self.exported.append(path)
+        with open(path, "w") as f:
+            json.dump({"traceEvents": [], "sglang_test_profiler": self.index}, f)
+
+
+class FakeProfilerFactory:
+    def __init__(self):
+        self.instances = []
+
+    def __call__(self, **kwargs):
+        self.instances.append(FakeTorchProfiler(len(self.instances)))
+        return self.instances[-1]
+
+
+class FakePS:
+    tp_rank = dp_rank = pp_rank = moe_ep_rank = 0
+    dp_size = pp_size = moe_ep_size = 1
+    gpu_id = 0
+
+
+class TestProfilerManagerAsyncExport(CustomTestCase):
+    def setUp(self):
+        self.factory = FakeProfilerFactory()
+        self.managers = []
+
+        profile_patcher = patch("torch.profiler.profile", self.factory)
+        profile_patcher.start()
+        self.addCleanup(profile_patcher.stop)
+
+        barrier_patcher = patch("torch.distributed.barrier")
+        self.barrier = barrier_patcher.start()
+        self.addCleanup(barrier_patcher.stop)
+
+        # Never leave a blocked export behind: the flush thread is not a daemon,
+        # so one would keep the test process alive after a failed assertion.
+        self.addCleanup(self._release_everything)
+
+    def _release_everything(self):
+        for profiler in self.factory.instances:
+            profiler.release.set()
+        for mgr in self.managers:
+            if mgr._flush_executor is not None:
+                mgr._flush_executor.shutdown(wait=True)
+
+    def _make_manager(self, output_dir, **init_kwargs):
+        responses = []
+        mgr = SchedulerProfilerManager(
+            ps=FakePS(),
+            dp_tp_cpu_group=None,
+            get_forward_ct=lambda: 0,
+            send_response=lambda *, output, recv_req: responses.append(
+                (output, recv_req)
+            ),
+        )
+        self.managers.append(mgr)
+        init = dict(
+            output_dir=output_dir,
+            start_step=None,
+            num_steps=None,
+            activities=["CPU"],
+            with_stack=False,
+            record_shapes=False,
+            profile_by_stage=False,
+            profile_id="test-id",
+        )
+        init.update(init_kwargs)
+        self.assertTrue(mgr._init_profile(**init).success)
+        return mgr, responses
+
+    def _assert_trace_written(self, directory, name):
+        """The trace on disk reads back as gzip, and no intermediate file is left."""
+        path = os.path.join(directory, name)
+        with gzip.open(path, "rt") as f:
+            json.load(f)
+        self.assertFalse(os.path.exists(path[: -len(".gz")]))
+
+    def _published_by(self, directory, name):
+        """The profiler whose export is the trace now under this name."""
+        with gzip.open(os.path.join(directory, name), "rt") as f:
+            return json.load(f)["sglang_test_profiler"]
+
+    def _gzip_stored_name(self, path):
+        """The name stored in the gzip header, which readers offer as a filename."""
+        with open(path, "rb") as f:
+            header = f.read(10)
+            self.assertEqual(header[:2], b"\x1f\x8b")
+            self.assertTrue(header[3] & 0x08, "the archive stores no name")
+            name = b""
+            while (char := f.read(1)) not in (b"\x00", b""):
+                name += char
+        return name.decode()
+
+    def _drain(self, mgr):
+        """Let every in-flight write finish, then run one scheduler-loop poll."""
+        wait([pending.export for pending in mgr._pending_flushes], timeout=60)
+        mgr.check_pending_flush()
+
+    def test_stop_profile_returns_before_the_trace_is_written(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            mgr, responses = self._make_manager(tmp)
+            self.assertTrue(mgr._start_profile().success)
+            profiler = self.factory.instances[-1]
+            profiler.release.clear()
+
+            recv_req = ProfileReq(req_type=ProfileReqType.STOP_PROFILE)
+            started = time.perf_counter()
+            output = mgr._stop_profile(reply_to=recv_req)
+            elapsed = time.perf_counter() - started
+
+            self.assertTrue(profiler.stopped)
+            self.assertTrue(profiler.entered_export.wait(timeout=10))
+            self.assertLess(elapsed, 5.0)  # i.e. it did not wait for the export
+            self.assertFalse(mgr.profile_in_progress)
+            # The barrier stays on the scheduler thread, where every rank reaches
+            # it at the same point in the group's sequence of collectives.
+            self.assertEqual(self.barrier.call_count, 1)
+
+            # Nobody is answered until the trace is actually on disk.
+            self.assertIsNone(output)
+            mgr.check_pending_flush()
+            self.assertEqual(responses, [])
+
+            profiler.release.set()
+            self._drain(mgr)
+            self.assertEqual(len(responses), 1)
+            output, answered_req = responses[0]
+            self.assertTrue(output.success, output.message)
+            self.assertIs(answered_req, recv_req)
+            self.assertEqual(len(mgr._pending_flushes), 0)
+            self.assertEqual(len(profiler.exported), 1)
+            self._assert_trace_written(tmp, "test-id-TP-0.trace.json.gz")
+
+    def test_detailed_annotations_are_off_before_the_deferred_return(self):
+        """The step-span flag is process-wide, so the deferred reply cannot own it.
+
+        `_stop_profile` now answers later than it used to. If the reset rode along
+        with that reply, every forward after a profile would keep emitting the
+        detailed spans until some later profile turned them off.
+        """
+        from sglang.srt.model_executor.step_span_utils import (
+            detailed_annotations_enabled,
+            set_detailed_annotations_enabled,
+        )
+
+        self.addCleanup(set_detailed_annotations_enabled, False)
+        with tempfile.TemporaryDirectory() as tmp:
+            mgr, _ = self._make_manager(tmp, detailed_annotations=True)
+            self.assertTrue(mgr._start_profile().success)
+            self.assertTrue(detailed_annotations_enabled())
+            profiler = self.factory.instances[-1]
+            profiler.release.clear()
+
+            recv_req = ProfileReq(req_type=ProfileReqType.STOP_PROFILE)
+            self.assertIsNone(mgr._stop_profile(reply_to=recv_req))
+            self.assertFalse(detailed_annotations_enabled())
+
+            profiler.release.set()
+            self._drain(mgr)
+
+    def test_stop_without_a_request_answers_nobody(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            mgr, responses = self._make_manager(tmp)
+            self.assertTrue(mgr._start_profile().success)
+            self.assertIsNone(mgr._stop_profile())
+            self._drain(mgr)
+            self.assertEqual(responses, [])
+
+    def test_profiling_restarts_while_the_previous_trace_is_written(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            mgr, responses = self._make_manager(tmp)
+            self.assertTrue(mgr._start_profile().success)
+            first = self.factory.instances[-1]
+            first.release.clear()
+            self.assertIsNone(mgr._stop_profile())
+
+            self.assertTrue(
+                mgr._init_profile(
+                    output_dir=tmp,
+                    start_step=None,
+                    num_steps=None,
+                    activities=["CPU"],
+                    with_stack=False,
+                    record_shapes=False,
+                    profile_by_stage=False,
+                    profile_id="second-id",
+                ).success
+            )
+            self.assertTrue(mgr._start_profile().success)
+            second = self.factory.instances[-1]
+            self.assertIsNot(second, first)
+            self.assertTrue(mgr.profile_in_progress)
+            self.assertIsNone(mgr._stop_profile())
+
+            # One writer, so the second trace waits its turn behind the first.
+            self.assertEqual(len(mgr._pending_flushes), 2)
+            self.assertFalse(second.entered_export.is_set())
+            first.release.set()
+            self._drain(mgr)
+            self.assertEqual(len(mgr._pending_flushes), 0)
+            self.assertEqual(len(first.exported), 1)
+            self._assert_trace_written(tmp, "test-id-TP-0.trace.json.gz")
+            self._assert_trace_written(tmp, "second-id-TP-0.trace.json.gz")
+
+    def test_by_stage_flush_at_the_decode_boundary_does_not_block(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            mgr, responses = self._make_manager(tmp, profile_by_stage=True, num_steps=4)
+            mgr._profile_batch_predicate(
+                SimpleNamespace(forward_mode=ForwardMode.EXTEND)
+            )
+            prefill = self.factory.instances[-1]
+            prefill.release.clear()
+
+            # The prefill trace is flushed here, between two batches, which is
+            # where a synchronous export freezes a live serving loop.
+            started = time.perf_counter()
+            mgr._profile_batch_predicate(
+                SimpleNamespace(forward_mode=ForwardMode.DECODE)
+            )
+            elapsed = time.perf_counter() - started
+
+            self.assertTrue(prefill.stopped)
+            self.assertTrue(prefill.entered_export.wait(timeout=10))
+            self.assertLess(elapsed, 5.0)
+            self.assertEqual(len(mgr._pending_flushes), 1)
+            # The decode stage is already recording while that write goes on.
+            self.assertTrue(mgr.profile_in_progress)
+            self.assertIsNot(self.factory.instances[-1], prefill)
+
+            prefill.release.set()
+            self._drain(mgr)
+            self.assertEqual(responses, [])
+            self._assert_trace_written(tmp, "test-id-TP-0-EXTEND.trace.json.gz")
+
+    def test_export_failure_is_reported_not_raised(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            mgr, responses = self._make_manager(tmp)
+            self.assertTrue(mgr._start_profile().success)
+            self.factory.instances[-1].raise_on_export = RuntimeError("no space left")
+
+            recv_req = ProfileReq(req_type=ProfileReqType.STOP_PROFILE)
+            self.assertIsNone(mgr._stop_profile(reply_to=recv_req))
+            self._drain(mgr)
+
+            self.assertEqual(len(responses), 1)
+            output, answered_req = responses[0]
+            self.assertFalse(output.success)
+            self.assertIn("no space left", output.message)
+            self.assertIs(answered_req, recv_req)
+
+    def test_merge_profiles_keeps_the_flush_synchronous(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            mgr, responses = self._make_manager(tmp, merge_profiles=True)
+            self.assertTrue(mgr._start_profile().success)
+            profiler = self.factory.instances[-1]
+
+            recv_req = ProfileReq(req_type=ProfileReqType.STOP_PROFILE)
+            output = mgr._stop_profile(reply_to=recv_req)
+
+            # The merge reads every rank's trace, so this path answers inline and
+            # only after its own export is done.
+            self.assertIsNotNone(output)
+            self.assertTrue(output.success, output.message)
+            self.assertEqual(len(profiler.exported), 1)
+            self._assert_trace_written(tmp, "test-id-TP-0.trace.json.gz")
+            self.assertEqual(len(mgr._pending_flushes), 0)
+            self.assertEqual(responses, [])
+
+    def test_shutdown_answers_a_stop_whose_trace_is_still_being_written(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            mgr, responses = self._make_manager(tmp)
+            self.assertTrue(mgr._start_profile().success)
+            recv_req = ProfileReq(req_type=ProfileReqType.STOP_PROFILE)
+            self.assertIsNone(mgr._stop_profile(reply_to=recv_req))
+
+            # The scheduler loop breaks on shutdown without polling again, so the
+            # teardown path has to deliver this one itself.
+            mgr.drain_pending_flushes()
+
+            self.assertEqual(len(responses), 1)
+            output, answered_req = responses[0]
+            self.assertTrue(output.success, output.message)
+            self.assertIs(answered_req, recv_req)
+            self.assertEqual(len(mgr._pending_flushes), 0)
+            self._assert_trace_written(tmp, "test-id-TP-0.trace.json.gz")
+
+    def test_a_stop_after_shutdown_still_writes_its_trace(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            mgr, responses = self._make_manager(tmp)
+            self.assertTrue(mgr._start_profile().success)
+            self.assertIsNone(mgr._stop_profile())  # starts the flush thread
+            mgr.drain_pending_flushes()  # and takes it away again
+
+            self.assertTrue(
+                mgr._init_profile(
+                    output_dir=tmp,
+                    start_step=None,
+                    num_steps=None,
+                    activities=["CPU"],
+                    with_stack=False,
+                    record_shapes=False,
+                    profile_by_stage=False,
+                    profile_id="second-id",
+                ).success
+            )
+            self.assertTrue(mgr._start_profile().success)
+
+            # Nothing left to drain a deferred flush, so this answers inline as
+            # every stop used to.
+            output = mgr._stop_profile(
+                reply_to=ProfileReq(req_type=ProfileReqType.STOP_PROFILE)
+            )
+            self.assertIsNotNone(output)
+            self.assertTrue(output.success, output.message)
+            self.assertEqual(responses, [])
+            self.assertEqual(len(mgr._pending_flushes), 0)
+            self._assert_trace_written(tmp, "test-id-TP-0.trace.json.gz")
+            self._assert_trace_written(tmp, "second-id-TP-0.trace.json.gz")
+
+    def test_an_uncompressed_trace_in_the_output_dir_is_left_alone(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            # Somebody's earlier uncompressed export of this same profile: the
+            # compression step must not write through it, let alone delete it.
+            bystander = os.path.join(tmp, "test-id-TP-0.trace.json")
+            with open(bystander, "w") as f:
+                f.write('{"traceEvents": ["keep me"]}')
+
+            mgr, _ = self._make_manager(tmp)
+            self.assertTrue(mgr._start_profile().success)
+            self.assertIsNone(mgr._stop_profile())
+            self._drain(mgr)
+
+            with open(bystander) as f:
+                self.assertEqual(f.read(), '{"traceEvents": ["keep me"]}')
+
+    def test_an_export_that_fails_before_writing_leaves_nothing_behind(self):
+        with tempfile.TemporaryDirectory() as tmp, tempfile.TemporaryDirectory() as td:
+            with patch.object(tempfile, "tempdir", td):
+                mgr, responses = self._make_manager(tmp)
+                self.assertTrue(mgr._start_profile().success)
+                self.factory.instances[-1].raise_on_export = RuntimeError(
+                    "no space left"
+                )
+                self.assertIsNone(mgr._stop_profile())
+                self._drain(mgr)
+
+            # No trace at the path the profile advertises, and the json that was
+            # staged for it is gone as well. A failure part-way through the copy is
+            # not covered, and needs no cover: it leaves a partial archive, which is
+            # what torch leaves too, gzipping straight to the destination.
+            self.assertEqual(os.listdir(tmp), [])
+            self.assertEqual(os.listdir(td), [])
+
+    def test_the_archive_names_the_trace_and_not_the_staged_json(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            mgr, _ = self._make_manager(tmp)
+            self.assertTrue(mgr._start_profile().success)
+            self.assertIsNone(mgr._stop_profile())
+            self._drain(mgr)
+
+            name = "test-id-TP-0.trace.json.gz"
+            path = os.path.join(tmp, name)
+            # The archive names the trace, not the temporary file that carried it.
+            self.assertEqual(self._gzip_stored_name(path), name[: -len(".gz")])
+
+    def test_on_mps_the_profiler_is_handed_the_advertised_path(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "test-id-TP-0.trace.json.gz")
+            profiler = FakeTorchProfiler()
+            # A Metal trace is saved alongside this one under a name built from
+            # the path the profiler is given, so a temporary path renames it too.
+            with patch.object(profiler_manager, "_is_mps", True):
+                profiler_manager._export_trace(profiler, path)
+
+            self.assertEqual(profiler.exported, [path])
+
+    def test_a_long_profile_id_still_writes_its_trace(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            # A profile id can bring the name of the trace to within a few bytes of
+            # the limit a filesystem puts on one -- and the limit counts bytes, not
+            # characters -- so nothing may derive a longer name from it.
+            profile_id = "😀" * 56
+            mgr, _ = self._make_manager(tmp, profile_id=profile_id)
+            self.assertTrue(mgr._start_profile().success)
+            self.assertIsNone(mgr._stop_profile())
+            self._drain(mgr)
+
+            self._assert_trace_written(tmp, f"{profile_id}-TP-0.trace.json.gz")
+
+    def test_the_uncompressed_trace_stays_out_of_the_output_dir(self):
+        with tempfile.TemporaryDirectory() as tmp, tempfile.TemporaryDirectory() as td:
+            # The json is an order of magnitude larger than the archive, so it
+            # goes where torch puts it and not onto the volume the traces are
+            # collected on.
+            with patch.object(tempfile, "tempdir", td):
+                mgr, _ = self._make_manager(tmp)
+                self.assertTrue(mgr._start_profile().success)
+                profiler = self.factory.instances[-1]
+                self.assertIsNone(mgr._stop_profile())
+                self._drain(mgr)
+
+            self.assertEqual(os.listdir(tmp), ["test-id-TP-0.trace.json.gz"])
+            self.assertTrue(profiler.exported[0].startswith(td), profiler.exported[0])
+            self.assertEqual(os.listdir(td), [])
+
+    def test_a_merge_waits_for_a_trace_that_is_still_being_written(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            mgr, _ = self._make_manager(tmp)
+            self.assertTrue(mgr._start_profile().success)
+            recorded = self.factory.instances[-1]
+            recorded.release.clear()
+            self.assertIsNone(mgr._stop_profile())
+
+            # A merge reads every trace whose name starts with the profile id, so
+            # one this rank recorded earlier under that id has to be written
+            # first: both publish to the same name, and the merge would otherwise
+            # read whichever landed last.
+            self.assertTrue(
+                mgr._init_profile(
+                    output_dir=tmp,
+                    start_step=None,
+                    num_steps=None,
+                    activities=["CPU"],
+                    with_stack=False,
+                    record_shapes=False,
+                    profile_by_stage=False,
+                    profile_id="test-id",
+                    merge_profiles=True,
+                ).success
+            )
+            self.assertTrue(mgr._start_profile().success)
+            merged = self.factory.instances[-1]
+            threading.Timer(0.2, recorded.release.set).start()
+            output = mgr._stop_profile()
+
+            self.assertIsNotNone(output)
+            self.assertEqual(len(mgr._pending_flushes), 0)
+            self._drain(mgr)
+            name = "test-id-TP-0.trace.json.gz"
+            self._assert_trace_written(tmp, name)
+            self.assertEqual(self._published_by(tmp, name), merged.index)
+
+    def test_a_stop_request_is_answered_once_its_trace_is_written(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            mgr, responses = self._make_manager(tmp)
+            start = ProfileReq(
+                req_type=ProfileReqType.START_PROFILE,
+                output_dir=tmp,
+                activities=["CPU"],
+                profile_id="test-id",
+            )
+            self.assertTrue(mgr._profile(start).success)
+
+            # The request path, which is what a /stop_profile actually reaches.
+            stop = ProfileReq(req_type=ProfileReqType.STOP_PROFILE)
+            self.assertIsNone(mgr._profile(stop))
+            self.assertEqual(responses, [])
+            self._drain(mgr)
+
+            self.assertEqual(len(responses), 1)
+            output, answered_req = responses[0]
+            self.assertTrue(output.success, output.message)
+            self.assertIs(answered_req, stop)
+
+    def test_recorded_traces_do_not_pile_up_while_the_writer_is_behind(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            mgr, _ = self._make_manager(tmp)
+            blocked = []
+            for i in range(3):
+                if i:
+                    self.assertTrue(
+                        mgr._init_profile(
+                            output_dir=tmp,
+                            start_step=None,
+                            num_steps=None,
+                            activities=["CPU"],
+                            with_stack=False,
+                            record_shapes=False,
+                            profile_by_stage=False,
+                            profile_id=f"id-{i}",
+                        ).success
+                    )
+                self.assertTrue(mgr._start_profile().success)
+                profiler = self.factory.instances[-1]
+                if i == 0:
+                    # Hold up the writer, then let it go while the third stop is
+                    # waiting for it, which is what bounds the queue.
+                    profiler.release.clear()
+                    threading.Timer(0.2, profiler.release.set).start()
+                blocked.append(profiler)
+                mgr._stop_profile()
+                self.assertLessEqual(len(mgr._pending_flushes), 2)
+
+            self._drain(mgr)
+            self.assertTrue(blocked[0].release.is_set())
+            for i in range(3):
+                name = "test-id" if i == 0 else f"id-{i}"
+                self._assert_trace_written(tmp, f"{name}-TP-0.trace.json.gz")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`SchedulerProfilerManager._stop_profile()` writes the chrome trace out inline on the scheduler
thread. The rank is frozen for the entire write: no batch is scheduled, in-flight requests stall,
and `/health_generate` calls that land in the window fail, so a router in front of the rank can
take it out of rotation for a profile the operator asked for deliberately.

This addresses the second of the two defects reported in #34943. The first one in that report — the
by-stage predicate counting `TARGET_VERIFY` batches as prefill, so a stage window terminates on a
later request — is a separate change and is **not** touched here, so this PR intentionally does not
close the issue.

Measured on one rank, `Qwen2.5-0.5B` at tp1, a 20 s profile window under steady load from the same
driver in every arm:

| | before | after |
|---|---|---|
| longest gap between request completions | 108.5 s | **32–36 s** (3 runs) |
| `/health_generate` failures in the window | 5 consecutive 503s | 1 |

The residual is worth stating plainly, because this PR does not remove it. Splitting the stall by
phase gives `torch_profiler.stop()` = 21.0 s and kineto's `export_chrome_trace()` = 13.9 s. The
latter holds the GIL inside C++ for its whole duration, so moving it to another thread cannot hide
it, and the former is torch's own teardown. What actually comes off the critical path is the gzip
write of the staged json, which for this window is ~3 GB in and ~118 MB out.

## Modifications

Two changes, and nothing else.

**1. The export runs on a flush thread, and an explicit `/stop_profile` is answered when the trace
is on disk.** `_stop_profile()` submits the write to a single-worker executor and hands the deferred
reply along with it; `Scheduler.send_control_output()` is extracted so the flush thread can send
that one reply. The scheduler loop reaps finished writes via `check_pending_flush()`, and
`run_scheduler_process`'s `finally` calls `drain_pending_flushes()` so a shutdown mid-write still
answers and still finishes the file. At most two flushes may be pending: a third stop waits for the
oldest to finish, which is no worse than what every stop does today. And if the executor is already
gone — shutdown has drained it — the export runs inline, exactly as it does now, rather than
dropping the trace.

Deliberately unchanged: `torch.distributed.barrier(dp_tp_cpu_group)` stays synchronous in its
original position, because that group also carries grammar `all_gather_object` and multimodal
`broadcast_object_list` at rank-symmetric points; and `merge_profiles=True` stays fully synchronous,
draining pending flushes first, because `ProfileMerger._discover_trace_files()` globs
`f"{profile_id}*.trace.json.gz"` and would otherwise race a trace this rank is still writing.

**2. The gzip write is chunked.** `_export_trace()` is torch's own staging block with one line
changed: `shutil.copyfileobj(fin, fout, 4 MiB)` instead of torch's `fout.writelines(fin)`. torch's
version needs the GIL once per line, which is precisely what makes the write unhideable from a
worker thread — in a contention experiment, writing a 1.6 MB trace that way from a background thread
while the scheduler spun took 142.9 s. Chunked, it is 6.8× faster under that contention, 1.2× faster
uncontended, and the resulting archive is byte-identical. On MPS the export stays inline, because a
Metal trace is written alongside it under a name derived from the same path.

### Behaviour change

An explicit `/stop_profile` reply now means "this rank's trace is on disk", not "every rank's".
Deferring the reply per rank is what buys the unblocking; restoring the old meaning would require
the reply to cross the barrier above, which has to stay where it is. Relatedly, a follower rank
whose export fails is now reported with `logger.error` rather than raising — before this change that
raise would have taken the rank down. Predicate-driven stops (`--profile-by-stage`, step-count
stops) reply to nobody and are unaffected.

## Accuracy Tests

Not applicable: no model, kernel or forward-path code is touched.

## Speed Tests and Profiling

The table above; the driver applies identical load in every arm and times the `/stop_profile`
round-trip. The produced trace was checked rather than assumed: it parses, carries 7,205,111 events
in 117,824,756 bytes, its gzip header stores the trace's own name (not the staged json's), it is
mode `0644`, and no staged json is left behind in the temp directory.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). — 17 tests in `test/registered/unit/managers/scheduler_components/test_profiler_manager_async_export.py`, covering the deferred reply, the shutdown drain, back-pressure, the inline fallback, the merge path, the MPS bypass, and the staged-json location and cleanup.
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — no user-facing documentation change; the one behaviour change is described above.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32809374381](https://github.com/sgl-project/sglang/actions/runs/32809374381)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32809374161](https://github.com/sgl-project/sglang/actions/runs/32809374161)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32809374343](https://github.com/sgl-project/sglang/actions/runs/32809374343)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->