### PR TITLE
[SM120] flash_mla: allocate the page-split buffer outside inference mode

### DIFF
--- a/python/sglang/kernels/ops/attention/flash_mla_sm120.py
+++ b/python/sglang/kernels/ops/attention/flash_mla_sm120.py
@@ -400,12 +400,16 @@ def _split_kv_pages_to_64(
     key = f"flash_mla_sm120_split:{dev}"
     buf = buffers.get(key)
     if buf is None or buf.shape[0] < num_dst_pages:
-        buf = torch.empty(
-            num_dst_pages,
-            _BYTES_PER_DST_PAGE_PADDED,
-            dtype=torch.uint8,
-            device=dev,
-        )
+        # The first allocation can happen under inference mode (autotune), but
+        # the buffer is written again during CUDA graph capture outside
+        # inference mode, where an inference tensor cannot be mutated.
+        with torch.inference_mode(False):
+            buf = torch.empty(
+                num_dst_pages,
+                _BYTES_PER_DST_PAGE_PADDED,
+                dtype=torch.uint8,
+                device=dev,
+            )
         buffers[key] = buf
     out = buf[:num_dst_pages]
 


### PR DESCRIPTION
## Purpose

`_split_kv_pages_to_64` keeps two lazily allocated persistent buffers in the same
`buffers` dict, with the same lifetime: allocated once on first use, reused across
autotune, CUDA graph capture and steady-state serving.

On current main only one of them is protected:

```python
    buf = buffers.get(key)                      # page-split destination
    if buf is None or buf.shape[0] < num_dst_pages:
        buf = torch.empty(...)                  # <- no guard
        buffers[key] = buf
...
        mbuf = buffers.get(mkey)                # dirty mask
        if mbuf is None or mbuf.shape[0] < N:
            # The first allocation can happen under inference mode (autotune),
            # but the buffer is zeroed again later during CUDA graph capture
            # outside inference mode -- an inference tensor cannot be mutated
            # there, so force a normal tensor.
            with torch.inference_mode(False):   # <- guarded
                mbuf = torch.empty(N, dtype=torch.int8, device=dev)
            buffers[mkey] = mbuf
```

The reasoning in that comment applies verbatim to `buf`: it is written during CUDA graph
capture too. This PR closes the asymmetry.

The `mbuf` guard was added after @moxcat reported the failure while running DSV4 on
SM120; the fix at the time covered *both* lazy buffers in this function, and the `buf`
half was lost somewhere between that backport and main. The same pattern, with the same
justification, also exists in
`sglang/srt/layers/moe/moe_runner/flashinfer_cutedsl.py`.

When it does fire, the symptom is:

```
RuntimeError: Inplace update to inference tensor outside InferenceMode is not allowed
```

## What I could and could not verify

I could not construct a configuration on 4x RTX 6000D (SM120) where the unguarded
allocation actually lands under inference mode. Instrumenting the allocation site:

| config | autotune ran | mode at allocation | result |
| --- | --- | --- | --- |
| `--moe-runner-backend deep_gemm` | no (0 invocations) | `inference_mode=False` | boots, no error |
| `--moe-runner-backend flashinfer_mxfp4`, DeepSeek-V4-Flash-0731 | yes (4 invocations) | `inference_mode=False` | boots, no error |

In both, `buf` is first allocated during `Capturing batches`, so the ordering never
arises. So I am not attaching a before/after reproducer — the case for this change is
the asymmetry with `mbuf`, not a failure I can demonstrate on demand.

@moxcat — if you still have the configuration that hit this originally, it would turn the
table above into a real before/after.

## Context

Split out of #29927 at @Fridge003's request, since it is not SM120 enablement work.
#29927 now depends on it.

## Scope

One allocation site. Buffer contents, shape, caching key and lifetime are unchanged;
only the mode it is allocated under. No-op wherever the allocation already happens
outside inference mode.
