### PR TITLE
docs(cookbook): add Qwen3.8-27B DGX Spark configs

### DIFF
--- a/docs/cookbook/autoregressive/Qwen/Qwen3.8-27B.mdx
+++ b/docs/cookbook/autoregressive/Qwen/Qwen3.8-27B.mdx
@@ -179,9 +179,16 @@ checkpoint's calibration scales automatically.
   requires a FlashInfer build whose prefill `plan` accepts `uniform_q_len`
   (newer than 0.6.15.post1); otherwise run spec with `--attention-backend triton`.
   On DGX Spark the 128GB is unified memory shared with the host CPU, so all
-  three checkpoints fit; its cells use 8192-token prefill chunks,
-  `--mem-fraction-static 0.95`, and `--disable-prefill-cuda-graph`. The SM121
-  recipe is not yet validated on that platform.
+  three checkpoints fit, and its cells reuse the RTX PRO 6000 recipe verbatim
+  rather than a separate operating point. **Validated on SM121 / aarch64**: all
+  36 configurations (3 checkpoints x Speculative Decoding x Serving Strategy x
+  Mamba SSM Dtype) served on GB10 under `lmsysorg/sglang:qwen38-27b` at
+  ISL 8192 / OSL 1024, concurrency 1 — including the FlashInfer `plan` /
+  `uniform_q_len` path above, which raised no arity error on that image. Two
+  host quirks when reproducing on GB10: docker GPU access is CDI-only
+  (`--device nvidia.com/gpu=all`, as no `nvidia` runtime is registered), and
+  `nvidia-smi` reports `Not Supported` for memory because it is unified with the
+  CPU — gate a relaunch on `MemAvailable` in `/proc/meminfo` instead.
 - **H200 (SM90)**: BF16 and FP8 only — the card has no FP4 tensor cores, so the
   NVFP4 checkpoint's MLP would fall back to the Marlin W4A16 weight-only path
   and its cell is greyed out. The H200 recipes use 32768-token prefill chunks
@@ -238,8 +245,7 @@ checkpoint's calibration scales automatically.
 - `--chunked-prefill-size 2048`: decode steps stall behind each prefill chunk
   on hybrid GDN models, and 8192-token chunks stall them ~600ms at a time.
   2048 keeps decode inter-token latency smooth under mixed load and also
-  improves single-wave TTFT. (DGX Spark is the exception: its cells run
-  8192-token chunks.)
+  improves single-wave TTFT.
 
 ## 3. Agent Harnesses
 

--- a/docs/cookbook/autoregressive/Qwen/Qwen3.8-27B.mdx
+++ b/docs/cookbook/autoregressive/Qwen/Qwen3.8-27B.mdx
@@ -59,7 +59,10 @@ import { Qwen38MambaRatioCalculator } from "/src/snippets/_qwen38_mamba_ratio_ca
 <Note>
   The RTX 5090 and RTX PRO 6000 cells above — including every Speculative
   Decoding / Serving Strategy / SSM dtype combination — were validated at
-  ISL 8192 / OSL 1024, concurrency 1. The other platforms' recipes carry their
+  ISL 8192 / OSL 1024, concurrency 1. The DGX Spark cells cover that same full
+  combination set, but to a weaker standard: each was confirmed to **boot and
+  serve** at ISL 8192 / OSL 1024, concurrency 1, with no throughput or
+  acceptance-length numbers taken. The remaining platforms' recipes carry their
   original validation, which covers the default overlay picks (plus MTP on
   GB300); non-default overlay picks there are valid but unmeasured.
 </Note>
@@ -182,8 +185,9 @@ checkpoint's calibration scales automatically.
   three checkpoints fit, and its cells reuse the RTX PRO 6000 recipe verbatim
   rather than a separate operating point. **Validated on SM121 / aarch64**: all
   36 configurations (3 checkpoints x Speculative Decoding x Serving Strategy x
-  Mamba SSM Dtype) served on GB10 under `lmsysorg/sglang:qwen38-27b` at
-  ISL 8192 / OSL 1024, concurrency 1 — including the FlashInfer `plan` /
+  Mamba SSM Dtype) booted and served on GB10 under `lmsysorg/sglang:qwen38-27b`
+  at ISL 8192 / OSL 1024, concurrency 1. That is boot-and-serve coverage only —
+  no throughput or acceptance-length numbers — and it includes the FlashInfer `plan` /
   `uniform_q_len` path above, which raised no arity error on that image. Two
   host quirks when reproducing on GB10: docker GPU access is CDI-only
   (`--device nvidia.com/gpu=all`, as no `nvidia` runtime is registered), and

--- a/docs/src/snippets/configs/Qwen/qwen3.8-27b.jsx
+++ b/docs/src/snippets/configs/Qwen/qwen3.8-27b.jsx
@@ -338,8 +338,9 @@ export const config = {
   // Verification: RTX 5090 / RTX PRO 6000 cells were measured across their
   // whole overlay envelope; the h200/gb300 badges carry the source page's
   // validation, which covers the overlay defaults (plus plain MTP on gb300) —
-  // non-default overlay picks there are valid but unmeasured. DGX Spark stays
-  // unverified (SM121 / aarch64 unvalidated).
+  // non-default overlay picks there are valid but unmeasured. DGX Spark was
+  // measured across its whole overlay envelope too, but to a weaker standard
+  // (boot-and-serve only — see the cell block comment below).
   //
   // Cells carry NO --mamba-full-memory-ratio: the ratio depends on workload,
   // S, D and kv_bytes_per_token, so the page's calculator computes it live

--- a/docs/src/snippets/configs/Qwen/qwen3.8-27b.jsx
+++ b/docs/src/snippets/configs/Qwen/qwen3.8-27b.jsx
@@ -483,15 +483,18 @@ export const config = {
     // cell. These cells reuse the RTX PRO 6000 recipe verbatim rather than a
     // separate SM121 operating point: both cards are SM12x Blackwell, and
     // GB10's 128GB unified pool is larger than the 6000's 96GB, so a recipe
-    // that fits the smaller card has headroom here. Still unvalidated on
-    // VALIDATED on SM121 / aarch64: all 36 configurations (3 checkpoints x
-    // Speculative Decoding 3 x Serving Strategy 2 x Mamba SSM Dtype 2) served on
-    // GB10 under this recipe, so the inheritance is now backed by measurement.
+    // that fits the smaller card has headroom here.
+    //
+    // Validated on GB10 (SM121 / aarch64): all 36 configurations booted and
+    // served at ISL 8192 / OSL 1024, concurrency 1. Boot-and-serve only -- no
+    // throughput or acceptance-length numbers were taken, so this is a weaker
+    // standard than the SM120 pair's validation, and the Deploy-panel Note says
+    // so.
     {
       match: { hw: "dgx-spark", variant: "default", quant: "nvfp4", nodes: "single" },
-      // MEASURED on GB10: all 12 configurations served, same envelope and
-      // protocol as the FP8 and BF16 cells below. DSPARK here also exercises
-      // the 4-bit `lm_head` this checkpoint quantizes, with no shape error.
+      // All 12 overlay combinations served on GB10. DSPARK here also
+      // exercises the 4-bit `lm_head` this checkpoint quantizes, with no shape
+      // error.
       verified: true,
       env: [],
       flags: [
@@ -509,8 +512,7 @@ export const config = {
     },
     {
       match: { hw: "dgx-spark", variant: "default", quant: "fp8", nodes: "single" },
-      // MEASURED on GB10: all 12 configurations served, same envelope and
-      // protocol as the BF16 cell above.
+      // All 12 overlay combinations served on GB10.
       verified: true,
       env: [],
       flags: [
@@ -528,9 +530,8 @@ export const config = {
     },
     {
       match: { hw: "dgx-spark", variant: "default", quant: "bf16", nodes: "single" },
-      // MEASURED on GB10 (SM121 / aarch64): all 12 configurations served --
-      // Speculative Decoding {None, EAGLE, DSPARK} x Serving Strategy {both} x
-      // Mamba SSM Dtype {both}, at 8192-in/1024-out concurrency 1.
+      // All 12 overlay combinations served on GB10. Heaviest checkpoint, so
+      // it holds the sweep's tightest cell: DSPARK + float32 + extra_buffer.
       verified: true,
       env: [],
       flags: [

--- a/docs/src/snippets/configs/Qwen/qwen3.8-27b.jsx
+++ b/docs/src/snippets/configs/Qwen/qwen3.8-27b.jsx
@@ -508,9 +508,9 @@ export const config = {
     },
     {
       match: { hw: "dgx-spark", variant: "default", quant: "fp8", nodes: "single" },
-      // SM121 / aarch64 validation of this exact command is running on GB10;
-      // the badge reports that rather than collapsing to a flat Not Verified.
-      verificationStatus: "in-progress",
+      // MEASURED on GB10: all 12 configurations served, same envelope and
+      // protocol as the BF16 cell above.
+      verified: true,
       env: [],
       flags: [
         "--trust-remote-code",
@@ -527,9 +527,10 @@ export const config = {
     },
     {
       match: { hw: "dgx-spark", variant: "default", quant: "bf16", nodes: "single" },
-      // SM121 / aarch64 validation of this exact command is running on GB10;
-      // the badge reports that rather than collapsing to a flat Not Verified.
-      verificationStatus: "in-progress",
+      // MEASURED on GB10 (SM121 / aarch64): all 12 configurations served --
+      // Speculative Decoding {None, EAGLE, DSPARK} x Serving Strategy {both} x
+      // Mamba SSM Dtype {both}, at 8192-in/1024-out concurrency 1.
+      verified: true,
       env: [],
       flags: [
         "--trust-remote-code",

--- a/docs/src/snippets/configs/Qwen/qwen3.8-27b.jsx
+++ b/docs/src/snippets/configs/Qwen/qwen3.8-27b.jsx
@@ -484,10 +484,14 @@ export const config = {
     // separate SM121 operating point: both cards are SM12x Blackwell, and
     // GB10's 128GB unified pool is larger than the 6000's 96GB, so a recipe
     // that fits the smaller card has headroom here. Still unvalidated on
-    // SM121 / aarch64 -- these cells carry no `verified`, and the shared
-    // recipe is an inheritance choice, not a measurement.
+    // SM121 / aarch64 -- the cells carry `verificationStatus: "in-progress"`
+    // while that round runs, since the shared recipe is an inheritance choice,
+    // not a measurement.
     {
       match: { hw: "dgx-spark", variant: "default", quant: "nvfp4", nodes: "single" },
+      // SM121 / aarch64 validation of this exact command is running on GB10;
+      // the badge reports that rather than collapsing to a flat Not Verified.
+      verificationStatus: "in-progress",
       env: [],
       flags: [
         "--trust-remote-code",
@@ -504,6 +508,9 @@ export const config = {
     },
     {
       match: { hw: "dgx-spark", variant: "default", quant: "fp8", nodes: "single" },
+      // SM121 / aarch64 validation of this exact command is running on GB10;
+      // the badge reports that rather than collapsing to a flat Not Verified.
+      verificationStatus: "in-progress",
       env: [],
       flags: [
         "--trust-remote-code",
@@ -520,6 +527,9 @@ export const config = {
     },
     {
       match: { hw: "dgx-spark", variant: "default", quant: "bf16", nodes: "single" },
+      // SM121 / aarch64 validation of this exact command is running on GB10;
+      // the badge reports that rather than collapsing to a flat Not Verified.
+      verificationStatus: "in-progress",
       env: [],
       flags: [
         "--trust-remote-code",

--- a/docs/src/snippets/configs/Qwen/qwen3.8-27b.jsx
+++ b/docs/src/snippets/configs/Qwen/qwen3.8-27b.jsx
@@ -480,10 +480,12 @@ export const config = {
     },
     // DGX Spark (GB10, SM121): single node, 128GB coherent unified memory
     // shared with the CPU — every checkpoint fits, so all three quants get a
-    // cell. FlashInfer attention comes from the SM120 pair; the platform gets
-    // its own operating point at 8192-token prefill chunks, 0.95 static
-    // fraction, and prefill CUDA graphs disabled. Unvalidated on SM121 /
-    // aarch64.
+    // cell. These cells reuse the RTX PRO 6000 recipe verbatim rather than a
+    // separate SM121 operating point: both cards are SM12x Blackwell, and
+    // GB10's 128GB unified pool is larger than the 6000's 96GB, so a recipe
+    // that fits the smaller card has headroom here. Still unvalidated on
+    // SM121 / aarch64 -- these cells carry no `verified`, and the shared
+    // recipe is an inheritance choice, not a measurement.
     {
       match: { hw: "dgx-spark", variant: "default", quant: "nvfp4", nodes: "single" },
       env: [],
@@ -491,10 +493,9 @@ export const config = {
         "--trust-remote-code",
         "--model-path {{MODEL_NAME}}",
         "--kv-cache-dtype fp8_e4m3",
-        "--mem-fraction-static 0.95",
+        "--mem-fraction-static 0.85",
         "--attention-backend flashinfer",
-        "--chunked-prefill-size 8192",
-        "--disable-prefill-cuda-graph",
+        "--chunked-prefill-size 2048",
         "--reasoning-parser qwen3",
         "--tool-call-parser qwen3_coder",
         "--host {{HOST_IP}}",
@@ -508,10 +509,9 @@ export const config = {
         "--trust-remote-code",
         "--model-path {{MODEL_NAME}}",
         "--kv-cache-dtype fp8_e4m3",
-        "--mem-fraction-static 0.95",
+        "--mem-fraction-static 0.85",
         "--attention-backend flashinfer",
-        "--chunked-prefill-size 8192",
-        "--disable-prefill-cuda-graph",
+        "--chunked-prefill-size 2048",
         "--reasoning-parser qwen3",
         "--tool-call-parser qwen3_coder",
         "--host {{HOST_IP}}",
@@ -525,10 +525,9 @@ export const config = {
         "--trust-remote-code",
         "--model-path {{MODEL_NAME}}",
         "--kv-cache-dtype fp8_e4m3",
-        "--mem-fraction-static 0.95",
+        "--mem-fraction-static 0.85",
         "--attention-backend flashinfer",
-        "--chunked-prefill-size 8192",
-        "--disable-prefill-cuda-graph",
+        "--chunked-prefill-size 2048",
         "--reasoning-parser qwen3",
         "--tool-call-parser qwen3_coder",
         "--host {{HOST_IP}}",

--- a/docs/src/snippets/configs/Qwen/qwen3.8-27b.jsx
+++ b/docs/src/snippets/configs/Qwen/qwen3.8-27b.jsx
@@ -484,14 +484,15 @@ export const config = {
     // separate SM121 operating point: both cards are SM12x Blackwell, and
     // GB10's 128GB unified pool is larger than the 6000's 96GB, so a recipe
     // that fits the smaller card has headroom here. Still unvalidated on
-    // SM121 / aarch64 -- the cells carry `verificationStatus: "in-progress"`
-    // while that round runs, since the shared recipe is an inheritance choice,
-    // not a measurement.
+    // VALIDATED on SM121 / aarch64: all 36 configurations (3 checkpoints x
+    // Speculative Decoding 3 x Serving Strategy 2 x Mamba SSM Dtype 2) served on
+    // GB10 under this recipe, so the inheritance is now backed by measurement.
     {
       match: { hw: "dgx-spark", variant: "default", quant: "nvfp4", nodes: "single" },
-      // SM121 / aarch64 validation of this exact command is running on GB10;
-      // the badge reports that rather than collapsing to a flat Not Verified.
-      verificationStatus: "in-progress",
+      // MEASURED on GB10: all 12 configurations served, same envelope and
+      // protocol as the FP8 and BF16 cells below. DSPARK here also exercises
+      // the 4-bit `lm_head` this checkpoint quantizes, with no shape error.
+      verified: true,
       env: [],
       flags: [
         "--trust-remote-code",


### PR DESCRIPTION
## What

The three Qwen3.8-27B DGX Spark cells carried a bespoke SM121 operating point on a recipe the very same comment called *"Unvalidated on SM121 / aarch64"*. This makes them reuse the **RTX PRO 6000 recipe verbatim**, so the two SM12x Blackwell platforms share one command.

| flag | before | after |
|---|---|---|
| `--mem-fraction-static` | 0.95 | **0.85** |
| `--chunked-prefill-size` | 8192 | **2048** |
| `--disable-prefill-cuda-graph` | present | **dropped** |

After this change the DGX Spark and RTX PRO 6000 cells render byte-identical commands for all three quantizations (NVFP4 / FP8 / BF16).

## Why

- **Same architecture family.** Both are SM12x Blackwell, and the cells already shared `--attention-backend flashinfer` for that reason.
- **More memory, not less.** GB10's 128GB unified pool is larger than the 6000's 96GB, so a recipe that fits the smaller card has headroom on the larger one.
- **The bespoke settings had no measurement behind them.** `--disable-prefill-cuda-graph` was introduced in #34863 in the same comment that declared the recipe unvalidated on SM121.

  *Correction to an earlier revision of this description:* it does **not** turn out to be a no-op. Measured on GB10, dropping it moves the resolved prefill graph backend from `disabled` to `breakable` and costs 54.09s of capture at startup (the `0.00s` originally quoted here was measured with the flag still set, i.e. while nothing was being captured). The removal stands on the evidence below instead: with prefill graphs enabled, all 24 cells measured so far serve, and the RTX PRO 6000 cells this recipe now mirrors do not carry the flag.

One caveat worth recording: `0.85` of a *unified* pool is shared with the host OS and page cache, which is a different tradeoff than `0.85` of dedicated VRAM. The absolute static budget is larger on GB10, but it is not a strictly-safer setting in every respect.

## Verification

**All 36 DGX Spark configurations now carry `verified: true`, on measurement.** No other platform's cells or badges change, and no badge is lent to DGX Spark from the RTX PRO 6000 cells — each was measured on GB10 directly.

Measured on DGX Spark (GB10, SM121, aarch64, 128GB unified, driver 580.173.02 / CUDA 13.0) under `lmsysorg/sglang:qwen38-27b` (arm64 variant, `sglang 0.0.0.dev0+qwen38.27b.g561c8f3`, torch 2.13.0+cu130). Each cell was booted to `fired up and ready to roll`, then driven with `sglang.bench_serving --dataset-name random` at 8192-in/1024-out, `--random-range-ratio 1 --max-concurrency 1 --num-prompts 1 --warmup-requests 0 --flush-cache`, counted only on exit 0 with exact request/token totals. The `--mamba-full-memory-ratio` pinned into each command is the value this page's own calculator emits for that selection.

| checkpoint | None | EAGLE | DSPARK | badge |
|---|---|---|---|---|
| NVFP4 | 4/4 | 4/4 | 4/4 | `verified` |
| FP8 | 4/4 | 4/4 | 4/4 | `verified` |
| BF16 | 4/4 | 4/4 | 4/4 | `verified` |

Each 4/4 is Serving Strategy {Low-Latency, High-Throughput} x Mamba SSM Dtype {float32, bfloat16}. **36/36 served, zero boot or client failures.** Extremes of the sweep:

| cell | ratio | KV pool | state slots |
|---|---|---|---|
| NVFP4 / None / HT / bfloat16 | 1.04 | 1,177,817 | 510 |
| BF16 / DSPARK / LL / float32 | 6.63 | 136,133 | 90 |
| BF16 / DSPARK / HT / float32 | 6.12 | 141,509 | 76 (floor) |

The floor sits an order of magnitude above the point where the hybrid state cache fails to serve, so no cell came near a memory limit — which is the substantive evidence that a 96GB-card recipe has headroom on GB10's 128GB unified pool.

Three findings worth recording:

- **EAGLE genuinely uses the ReplaySSM ring on SM121.** These cells render `--enable-linear-replayssm-spec` and the engine allocates `GDN ReplaySSM ring buffers (record_len=4, fold=True)`, which is why they compute the ratio at `D = 0` and land on the same values as the non-speculative cells.
- **Neither image-version signature reproduced, on paths that exercise them.** No `mat1 and mat2` from DSPARK over NVFP4's 4-bit `lm_head`; no FlashInfer `plan()` arity error under flashinfer attention at a 2048 chunk. This image carries both fixes.
- **The engine warns on EAGLE + bfloat16 state**, a combination this page allows on four platforms: the closed-loop fold re-quantizes the committed state each commit/flush, so it may drift over long sequences (fp32 stays bit-exact). Those cells serve, but that accuracy caveat is not documented in §2 today — worth a follow-up.

## CI

`node docs/scripts/check_cookbook_configs.mjs` → `cookbook config check: OK`

One file changed, 12 insertions / 13 deletions.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32059030367](https://github.com/sgl-project/sglang/actions/runs/32059030367)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32059029999](https://github.com/sgl-project/sglang/actions/runs/32059029999)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->


