### PR TITLE
Sampler: add missing TP=1 short-circuit in _sync_token_ids_across_tp

### DIFF
--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -72,8 +72,10 @@ class Sampler(nn.Module):
     def __init__(self):
         super().__init__()
         self.tp_sync_group = get_tp_group().device_group
+        self.tp_sync_group_size = get_tp_group().world_size
         if is_dp_attention_enabled():
             self.tp_sync_group = get_parallel().attn_tp_group.device_group
+            self.tp_sync_group_size = get_parallel().attn_tp_group.world_size
 
         self.rl_on_policy_target = get_exec().deterministic.rl_on_policy_target
         # In RL on-policy mode, deterministic inference is automatically enabled.
@@ -497,6 +499,10 @@ class Sampler(nn.Module):
     def _sync_token_ids_across_tp(
         self, batch_next_token_ids: torch.Tensor, sampling_info: SamplingBatchInfo
     ):
+        # With a single TP rank there is nothing to synchronize, and calling
+        # torch.distributed.all_reduce would still hit the NCCL backend
+        if self.tp_sync_group_size == 1:
+            return
         if SYNC_TOKEN_IDS_ACROSS_TP or sampling_info.grammars:
             # For performance reasons, SGLang does not sync the final token IDs across TP ranks by default.
             # This saves one all-reduce, but the correctness of this approach depends on the determinism of several operators:


### PR DESCRIPTION
  ## Motivation

  Sampler._sync_token_ids_across_tp directly calls torch.distributed.all_reduce and misses the world_size == 1 short-circuit that the wrapped tp_group.all_reduce provides at parallel_state.py:667. Sampler.__init__ cached self.tp_sync_group but not the corresponding world_size, so the sync function had no way to skip the no-op all_reduce on TP=1.

  This is the only direct torch.distributed.* call in the LLM forward/sampling hot path missing this guard. Every other site already handles the TP=1 case — see references in Modifications.

  As a result, on TP=1 the sync path still invokes the NCCL backend for a semantically no-op all_reduce, even though no cross-rank communication is needed.

  ## Modifications

  python/sglang/srt/layers/sampler.py (9 lines added, 0 removed):

  1. Sampler.__init__: cache self.tp_sync_group_size = <group>.world_size, covering both the default branch (get_tp_group()) and the is_dp_attention_enabled() branch (get_parallel().attn_tp_group).
  2. Sampler._sync_token_ids_across_tp: add if self.tp_sync_group_size == 1: return at the top, before if SYNC_TOKEN_IDS_ACROSS_TP or sampling_info.grammars:.

  Aligns with the existing convention already applied elsewhere:
  - parallel_state.py:667 — if self.world_size == 1: return (canonical pattern used by wrapped tp_group.all_reduce)
  - constrained/grammar_manager.py:242 — if self.grammar_sync_size == 1: ... (same semantic)
  - mem_cache/hiradix_cache.py, unified_radix_cache.py, managers/hisparse_coordinator.py, mem_cache/embedding_cache_controller.py, layers/flashinfer_comm_fusion.py, mem_cache/pool_host/base.py, mem_cache/kv_cache_configurator.py — all guard direct collectives with world_size > 1.

  TP>1 behavior is unchanged.

  ## Accuracy Tests

  Not applicable — no change to model forward / sampling logic. On TP>1 the new guard never fires (byte-for-byte identical path). On TP=1 the all_reduce is a no-op semantically, so skipping it changes no output.

  Verified a grammar-constrained request (POST /v1/chat/completions with response_format.type = "json_schema") on TP=1:
  - Before patch: need NCCL all_reduce.
  - After patch: 200 OK with output matching the schema; server stays up.
  - Plain chat request: unaffected on both before/after builds.

  ## Speed Tests and Profiling

  Not applicable. On TP=1 the patch removes a no-op torch.distributed.all_reduce call and its NCCL backend round-trip, which is a minor speedup, not a regression. On TP>1 the execution path is unchanged.

  ## Checklist

  - Format your code according to the https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit.
  - Add unit tests according to the https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests.
  - Update documentation according to https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations. (N/A — code comment in patch explains the rationale)
  - Provide accuracy and speed benchmark results according to https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy and
  https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed. (N/A — see above)
  - Follow the SGLang code style https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32011764631](https://github.com/sgl-project/sglang/actions/runs/32011764631)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32011764284](https://github.com/sgl-project/sglang/actions/runs/32011764284)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->