### PR TITLE
[sglang-miles] Extract Anthropic conversion into standalone utils

### DIFF
--- a/python/sglang/srt/entrypoints/anthropic/serving.py
+++ b/python/sglang/srt/entrypoints/anthropic/serving.py
@@ -10,7 +10,7 @@ import asyncio
 import json
 import logging
 import uuid
-from typing import TYPE_CHECKING, Any, AsyncGenerator, Optional, Union
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Callable, Optional, Union
 
 from fastapi import Request
 from fastapi.responses import JSONResponse, StreamingResponse
@@ -181,6 +181,582 @@ def _scrub_error_message(message: str, status_code: int) -> str:
     return cleaned or "Request failed"
 
 
+def convert_to_chat_completion_request(
+    anthropic_request: AnthropicMessagesRequest,
+    *,
+    merge_inline_system: bool,
+    wrap_reasoning_history: Optional[Callable[[str], str]] = None,
+    apply_reasoning_enabled: Optional[
+        Callable[[ChatCompletionRequest, bool], None]
+    ] = None,
+) -> ChatCompletionRequest:
+    """Convert an Anthropic Messages request to an OpenAI ChatCompletion request."""
+    openai_messages = []
+
+    def _convert_anthropic_image_source_to_openai_part(
+        source: Any,
+    ) -> Optional[dict]:
+        # Source may arrive as a Pydantic model (typed ImageBlock.source)
+        # or as a raw dict when parsed from a nested tool_result payload.
+        if isinstance(source, BaseModel):
+            source = source.model_dump(exclude_none=True)
+        if not isinstance(source, dict):
+            return None
+
+        source_type = source.get("type")
+        if source_type == "base64":
+            media_type = source.get("media_type", "image/png")
+            data = source.get("data", "")
+            if not data:
+                return None
+            return {
+                "type": "image_url",
+                "image_url": {
+                    "url": f"data:{media_type};base64,{data}",
+                },
+            }
+
+        url = source.get("url")
+        if url:
+            return {
+                "type": "image_url",
+                "image_url": {
+                    "url": url,
+                },
+            }
+
+        return None
+
+    def _text_from_search_result(item: dict[str, Any]) -> str:
+        search_parts = []
+        title = item.get("title")
+        if title:
+            search_parts.append(f"Title: {title}")
+
+        source = item.get("source")
+        if isinstance(source, dict):
+            source_text = source.get("url") or source.get("text")
+            if source_text:
+                search_parts.append(f"Source: {source_text}")
+        elif source:
+            search_parts.append(f"Source: {source}")
+
+        content = item.get("content")
+        content_parts = []
+        if isinstance(content, str):
+            content_parts.append(content)
+        elif isinstance(content, list):
+            for part in content:
+                if not isinstance(part, dict):
+                    continue
+                if part.get("type") == "text" and part.get("text"):
+                    content_parts.append(part["text"])
+        if content_parts:
+            search_parts.append("Content: " + "\n".join(content_parts))
+
+        return "\n".join(search_parts)
+
+    def _convert_tool_result_content(
+        content: Any,
+    ) -> tuple[list[Union[str, list[dict]]], str]:
+        if isinstance(content, list):
+            tool_content_parts = []
+            tool_text_parts = []
+
+            for raw_item in content:
+                # Items may be typed Pydantic blocks (after request
+                # validation) or raw dicts (from legacy callers). Coerce
+                # to dict so the existing key-based logic still works.
+                if isinstance(raw_item, BaseModel):
+                    item = raw_item.model_dump(exclude_none=True)
+                elif isinstance(raw_item, dict):
+                    item = raw_item
+                else:
+                    continue
+
+                item_type = item.get("type")
+                if item_type == "text":
+                    text = item.get("text", "")
+                    if text:
+                        tool_text_parts.append(text)
+                        tool_content_parts.append({"type": "text", "text": text})
+                elif item_type == "image":
+                    image_part = _convert_anthropic_image_source_to_openai_part(
+                        item.get("source")
+                    )
+                    if image_part is not None:
+                        tool_content_parts.append(image_part)
+                elif item_type == "tool_reference":
+                    # Anthropic uses `tool_name`; the SGLang chat template
+                    # matches on `name`. Translate at the boundary.
+                    ref_name = item.get("tool_name") or item.get("name")
+                    if ref_name:
+                        tool_content_parts.append(
+                            {"type": "tool_reference", "name": ref_name}
+                        )
+                elif item_type == "search_result":
+                    search_text = _text_from_search_result(item)
+                    if search_text:
+                        tool_text_parts.append(search_text)
+                        tool_content_parts.append({"type": "text", "text": search_text})
+
+            tool_text = "\n".join(tool_text_parts)
+            # GLM templates expand references only at the start of a tool
+            # message, so isolate reference runs without changing part order.
+            tool_content_groups: list[list[dict]] = []
+            for part in tool_content_parts:
+                is_reference = part["type"] == "tool_reference"
+                if (
+                    not tool_content_groups
+                    or (tool_content_groups[-1][0]["type"] == "tool_reference")
+                    != is_reference
+                ):
+                    tool_content_groups.append([])
+                tool_content_groups[-1].append(part)
+
+            tool_contents: list[Union[str, list[dict]]] = []
+            for group in tool_content_groups:
+                if len(group) == 1 and group[0]["type"] == "text":
+                    tool_contents.append(group[0]["text"])
+                else:
+                    tool_contents.append(group)
+            return tool_contents or [""], tool_text
+
+        tool_text = str(content) if content else ""
+        return [tool_text], tool_text
+
+    def _convert_assistant_thinking_blocks(
+        blocks: list[AnthropicContentBlock],
+    ) -> Optional[str]:
+        """Re-wrap prior-turn thinking blocks in the parser's own tokens.
+
+        ``redacted_thinking`` carries encrypted bytes that no local
+        parser can interpret, so we raise rather than silently drop it.
+        On non-reasoning models (no detector configured) the rewrap is
+        best-effort: we log a warning and drop the thinking text so a
+        history echo doesn't 400 the whole request — the prior thinking
+        is opaque context the model didn't need anyway.
+        """
+        if any(block.type == "redacted_thinking" for block in blocks):
+            raise ValueError("Anthropic redacted_thinking history is not supported")
+
+        thinking_parts = [
+            block.thinking
+            for block in blocks
+            if block.type == "thinking" and block.thinking
+        ]
+        if not thinking_parts:
+            return None
+
+        if wrap_reasoning_history is None:
+            raise ValueError(
+                "Cannot convert thinking history without a reasoning adapter"
+            )
+        try:
+            return wrap_reasoning_history("\n".join(thinking_parts))
+        except ValueError as e:
+            logger.warning(
+                "Dropping prior-turn thinking history (%d blocks): %s",
+                len(thinking_parts),
+                e,
+            )
+            return None
+
+    system_parts: list[str] = []
+    if anthropic_request.system:
+        if isinstance(anthropic_request.system, str):
+            if anthropic_request.system.strip():
+                system_parts.append(anthropic_request.system)
+        else:
+            for block in anthropic_request.system:
+                if block.type == "text" and block.text:
+                    system_parts.append(block.text)
+
+    if merge_inline_system:
+        for msg in anthropic_request.messages:
+            if msg.role != "system":
+                continue
+            text = _extract_system_text(msg.content)
+            if text:
+                system_parts.append(text)
+
+    if system_parts:
+        openai_messages.append({"role": "system", "content": "\n".join(system_parts)})
+
+    def _emit_user_message(parts: list[dict]) -> None:
+        """Append accumulated parts as a user message, then clear them.
+
+        Used to flush content collected BEFORE a tool_result so the
+        wire order stays user(pre) → tool → user(post). Without this
+        flush, text/image parts that appeared before a tool_result
+        block would be moved AFTER the tool message at end of loop.
+        """
+        if not parts:
+            return
+        if len(parts) == 1 and parts[0]["type"] == "text":
+            openai_messages.append({"role": "user", "content": parts[0]["text"]})
+        else:
+            openai_messages.append({"role": "user", "content": list(parts)})
+        parts.clear()
+
+    # Convert messages
+    for msg in anthropic_request.messages:
+        if msg.role == "system" and merge_inline_system:
+            continue
+        if isinstance(msg.content, str):
+            openai_messages.append({"role": msg.role, "content": msg.content})
+            continue
+
+        # Complex content with blocks
+        openai_msg = {"role": msg.role}
+        content_parts: list[dict] = []
+        tool_calls: list[dict] = []
+
+        if msg.role == "assistant":
+            reasoning_history = _convert_assistant_thinking_blocks(msg.content)
+            if reasoning_history is not None:
+                content_parts.append({"type": "text", "text": reasoning_history})
+
+        for block in msg.content:
+            # ``thinking``/``redacted_thinking`` blocks are surfaced via
+            # the reasoning-history reconstruction above; skip them here
+            # to avoid double-injecting their text into the prompt.
+            if block.type in ("thinking", "redacted_thinking"):
+                continue
+
+            # ``is not None`` (not truthy) so an empty-string text block
+            # still produces a placeholder text part — without it, an
+            # assistant turn whose only content is "" vanishes and
+            # subsequent user→user pairs trip strict chat templates.
+            if block.type == "text" and block.text is not None:
+                content_parts.append({"type": "text", "text": block.text})
+
+            elif block.type == "image" and block.source:
+                image_part = _convert_anthropic_image_source_to_openai_part(
+                    block.source
+                )
+                if image_part is not None:
+                    content_parts.append(image_part)
+
+            elif block.type == "search_result":
+                search_text = _text_from_search_result(block.model_dump())
+                if search_text:
+                    content_parts.append({"type": "text", "text": search_text})
+
+            elif block.type == "tool_use":
+                tool_call = {
+                    "id": block.id or f"call_{uuid.uuid4().hex}",
+                    "type": "function",
+                    "function": {
+                        "name": block.name or "",
+                        "arguments": json.dumps(block.input or {}),
+                    },
+                }
+                tool_calls.append(tool_call)
+
+            elif block.type == "tool_result":
+                tool_contents, tool_text = _convert_tool_result_content(block.content)
+
+                # Use tool_use_id (per spec) with fallback to id
+                tool_call_id = block.tool_use_id or block.id or ""
+
+                # Tool results from user become separate tool messages.
+                # Flush any pending text/image first so the wire order
+                # is preserved (a tool_result that arrived AFTER a text
+                # block must come AFTER that text in OpenAI form too).
+                if msg.role == "user":
+                    _emit_user_message(content_parts)
+                    for tool_content in tool_contents:
+                        openai_messages.append(
+                            {
+                                "role": "tool",
+                                "tool_call_id": tool_call_id,
+                                "content": tool_content,
+                            }
+                        )
+                else:
+                    content_parts.append(
+                        {
+                            "type": "text",
+                            "text": f"Tool result: {tool_text}",
+                        }
+                    )
+
+        # Attach tool calls to assistant messages
+        if tool_calls:
+            openai_msg["tool_calls"] = tool_calls
+
+        # Attach content
+        if content_parts:
+            if len(content_parts) == 1 and content_parts[0]["type"] == "text":
+                openai_msg["content"] = content_parts[0]["text"]
+            else:
+                openai_msg["content"] = content_parts
+            openai_messages.append(openai_msg)
+        elif tool_calls:
+            openai_messages.append(openai_msg)
+        elif msg.role == "user":
+            # User turn that was entirely tool_results — the tool
+            # messages were already emitted above, nothing left.
+            continue
+        else:
+            # Assistant turn with no content and no tool_calls: emit
+            # an empty-string placeholder so strict templates still
+            # see a valid role-alternation sequence.
+            openai_msg["content"] = ""
+            openai_messages.append(openai_msg)
+
+    # Build ChatCompletionRequest
+    request_data = {
+        "messages": openai_messages,
+        "model": anthropic_request.model,
+        "max_tokens": anthropic_request.max_tokens,
+        "stream": anthropic_request.stream or False,
+    }
+
+    if anthropic_request.temperature is not None:
+        request_data["temperature"] = anthropic_request.temperature
+    if anthropic_request.top_p is not None:
+        request_data["top_p"] = anthropic_request.top_p
+    if anthropic_request.top_k is not None:
+        request_data["top_k"] = anthropic_request.top_k
+    if anthropic_request.stop_sequences is not None:
+        request_data["stop"] = anthropic_request.stop_sequences
+
+    # Enable usage in stream so we can report it
+    if anthropic_request.stream:
+        request_data["stream_options"] = StreamOptions(
+            include_usage=True,
+            continuous_usage_stats=True,
+        )
+
+    chat_request = ChatCompletionRequest(**request_data)
+
+    if anthropic_request.thinking is not None:
+        # The protocol layer already enforces SDK shape:
+        #   enabled  -> budget_tokens required (>=1024), display optional
+        #   disabled -> neither budget_tokens nor display allowed
+        #   adaptive -> budget_tokens forbidden, display optional
+        # So by the time we get here ``budget_tokens`` can only be
+        # set on ``enabled``. The local backend has no equivalent
+        # hard-cap knob, so we log a WARNING instead of rejecting —
+        # the Anthropic SDK would have accepted the request and we
+        # mirror that. Operators see the unenforced budget in logs.
+        if anthropic_request.thinking.budget_tokens is not None:
+            logger.warning(
+                "Anthropic thinking.budget_tokens=%d is accepted for "
+                "SDK compatibility but the local backend has no "
+                "equivalent hard-cap knob — the budget is not enforced",
+                anthropic_request.thinking.budget_tokens,
+            )
+        # Claude 4.7's ``adaptive`` is treated identically to ``enabled``
+        # because the local backend has no auto-throttle equivalent.
+        # Anything other than ``disabled`` enables reasoning.
+        enabled = anthropic_request.thinking.type != "disabled"
+        if anthropic_request.thinking.display == "omitted":
+            # Anthropic 4.7 spec: keep reasoning ON but hide reasoning
+            # text from the client. The OpenAI streaming pipeline has
+            # no equivalent suppress knob — log so operators can see
+            # the request, then proceed with normal reasoning emission.
+            logger.warning(
+                "Anthropic thinking.display='omitted' is accepted for "
+                "SDK compatibility but reasoning text will still be "
+                "emitted to the client"
+            )
+        if apply_reasoning_enabled is None:
+            raise ValueError(
+                "Cannot convert Anthropic thinking without a reasoning adapter"
+            )
+        apply_reasoning_enabled(chat_request, enabled)
+
+    # Claude 4.7 ``output_config``: map ``effort`` onto the OpenAI
+    # ``reasoning_effort`` knob. ``xhigh`` collapses to ``max`` because
+    # the OpenAI Literal does not include the Anthropic-only ``xhigh``.
+    # ``task_budget`` is a soft hint forwarded as a custom param so the
+    # model can see it without it becoming a hard cap (``max_tokens``
+    # is still the hard cap).
+    if anthropic_request.output_config is not None:
+        oc = anthropic_request.output_config
+        if oc.effort is not None:
+            chat_request.reasoning_effort = "max" if oc.effort == "xhigh" else oc.effort
+        if oc.task_budget is not None:
+            # Custom params are silently ignored by backends that
+            # don't recognise them; logging it makes the propagation
+            # visible.
+            logger.info(
+                "Anthropic output_config.task_budget hint: %d %s",
+                oc.task_budget.total,
+                oc.task_budget.type,
+            )
+
+    # ``betas`` is the Anthropic SDK's opt-in feature list (e.g.
+    # ``["thinking-2025-08-04"]``). The local backend has no
+    # equivalent beta system; accept-and-log so requests don't 400.
+    if anthropic_request.betas:
+        logger.info(
+            "Anthropic request opted into betas %s — no-op locally",
+            anthropic_request.betas,
+        )
+
+    # Convert tools. Deferred tools stay in the list with defer_loading=True;
+    # the chat template hides them from the initial <tools> block and renders
+    # them on demand when a tool_reference block names them.
+    if anthropic_request.tools:
+        converted_tools = []
+        for tool in anthropic_request.tools:
+            if is_server_tool(tool):
+                # Anthropic server-side tools (web_search_*, computer_*,
+                # bash_*, text_editor_*) have no client-side input_schema
+                # because Anthropic provides the implementation. We can't
+                # forward them to the OpenAI tools array (which requires a
+                # schema), so skip with a visible log.
+                logger.info(
+                    "Skipping built-in Anthropic server tool %r (type=%r): "
+                    "no native support in the OpenAI-compatible backend",
+                    tool.name,
+                    tool.type,
+                )
+                continue
+
+            # Custom tools always have a validated input_schema
+            # (enforced at Pydantic parse time).
+            converted_tools.append(
+                Tool(
+                    type="function",
+                    defer_loading=tool.defer_loading,
+                    function={
+                        "name": tool.name,
+                        "description": tool.description or "",
+                        "parameters": tool.input_schema,
+                    },
+                )
+            )
+
+        if converted_tools:
+            chat_request.tools = converted_tools
+
+    # Convert tool choice. ``any``/``tool`` express a hard requirement
+    # ("the model MUST call a tool"); if every requested tool was a
+    # server-side Anthropic built-in that we just skipped, there is
+    # no tool the model could call. Silently downgrading to "no tool"
+    # would deceive the caller, so raise an explicit 400.
+    if anthropic_request.tool_choice is not None:
+        tc_type = anthropic_request.tool_choice.type
+        if tc_type == "none":
+            chat_request.tool_choice = "none"
+        elif chat_request.tools:
+            if tc_type == "auto":
+                chat_request.tool_choice = "auto"
+            elif tc_type == "any":
+                chat_request.tool_choice = "required"
+            elif tc_type == "tool":
+                tool_name = anthropic_request.tool_choice.name
+                # ``Tool.function`` is a ``Function`` Pydantic model, not
+                # a dict — access by attribute. A dict ``.get`` would
+                # AttributeError and surface as a 500 instead of the
+                # intended 400 / happy path.
+                if not any(t.function.name == tool_name for t in chat_request.tools):
+                    raise ValueError(
+                        f"tool_choice references tool {tool_name!r} but it "
+                        f"is not in the forwarded tools list "
+                        f"(server-side Anthropic tools cannot be selected)"
+                    )
+                chat_request.tool_choice = ToolChoice(
+                    type="function",
+                    function=ToolChoiceFuncName(name=tool_name),
+                )
+        elif tc_type in ("any", "tool"):
+            raise ValueError(
+                f"tool_choice={tc_type!r} requires at least one custom "
+                f"tool; all supplied tools were server-side Anthropic "
+                f"built-ins which the OpenAI-compatible backend cannot "
+                f"invoke"
+            )
+    elif chat_request.tools:
+        chat_request.tool_choice = "auto"
+
+    return chat_request
+
+
+def convert_response(
+    response: ChatCompletionResponse,
+) -> AnthropicMessagesResponse:
+    """Convert an OpenAI ChatCompletionResponse to an Anthropic Messages response."""
+    if not response.choices:
+        return AnthropicMessagesResponse(
+            content=[TextBlock(text="")],
+            model=response.model,
+            stop_reason="end_turn",
+            usage=AnthropicUsage(input_tokens=0, output_tokens=0),
+        )
+
+    choice = response.choices[0]
+    content: list[AnthropicContentBlock] = []
+
+    # Add reasoning content as a thinking block. signature is omitted
+    # entirely when the backend doesn't provide one — empty strings
+    # would fail downstream Anthropic signature verifiers.
+    if choice.message.reasoning_content:
+        content.append(ThinkingBlock(thinking=choice.message.reasoning_content))
+
+    # Add text content
+    if choice.message.content:
+        content.append(TextBlock(text=choice.message.content))
+
+    # Add tool calls
+    if choice.message.tool_calls:
+        for tool_call in choice.message.tool_calls:
+            raw_args = tool_call.function.arguments
+            try:
+                tool_input = json.loads(raw_args)
+            except (json.JSONDecodeError, TypeError):
+                # Surface invalid tool arguments so an empty-dict
+                # tool call is never indistinguishable from a real
+                # one when something downstream goes wrong.
+                logger.warning(
+                    "Tool %r emitted invalid JSON arguments: %r — "
+                    "defaulting to empty input",
+                    tool_call.function.name,
+                    (raw_args or "")[:200],
+                )
+                tool_input = {}
+
+            content.append(
+                ToolUseBlock(
+                    id=tool_call.id,
+                    name=tool_call.function.name,
+                    input=tool_input,
+                )
+            )
+
+    # Map stop reason
+    finish_reason = choice.finish_reason or "stop"
+    if finish_reason not in STOP_REASON_MAP:
+        logger.warning(
+            "Unmapped OpenAI finish_reason %r; defaulting to end_turn",
+            finish_reason,
+        )
+    stop_reason = STOP_REASON_MAP.get(finish_reason, "end_turn")
+
+    # Anthropic requires ``content`` to contain at least one block.
+    # Empty string completions (max_tokens=1 stop, content filter, etc.)
+    # would otherwise ship ``content=[]`` and break strict SDK parsers.
+    if not content:
+        content.append(TextBlock(text=""))
+
+    return AnthropicMessagesResponse(
+        id=f"msg_{uuid.uuid4().hex}",
+        content=content,
+        model=response.model,
+        stop_reason=stop_reason,
+        usage=_anthropic_usage_from_openai(
+            response.usage,
+            include_input=True,
+            include_output=True,
+        ),
+    )
+
+
 class AnthropicServing:
     """Handler for Anthropic Messages API requests.
 
@@ -229,496 +805,16 @@ class AnthropicServing:
     def _convert_to_chat_completion_request(
         self, anthropic_request: AnthropicMessagesRequest
     ) -> ChatCompletionRequest:
-        """Convert an Anthropic Messages request to an OpenAI ChatCompletion request."""
-        openai_messages = []
-
-        def _convert_anthropic_image_source_to_openai_part(
-            source: Any,
-        ) -> Optional[dict]:
-            # Source may arrive as a Pydantic model (typed ImageBlock.source)
-            # or as a raw dict when parsed from a nested tool_result payload.
-            if isinstance(source, BaseModel):
-                source = source.model_dump(exclude_none=True)
-            if not isinstance(source, dict):
-                return None
-
-            source_type = source.get("type")
-            if source_type == "base64":
-                media_type = source.get("media_type", "image/png")
-                data = source.get("data", "")
-                if not data:
-                    return None
-                return {
-                    "type": "image_url",
-                    "image_url": {
-                        "url": f"data:{media_type};base64,{data}",
-                    },
-                }
-
-            url = source.get("url")
-            if url:
-                return {
-                    "type": "image_url",
-                    "image_url": {
-                        "url": url,
-                    },
-                }
-
-            return None
-
-        def _text_from_search_result(item: dict[str, Any]) -> str:
-            search_parts = []
-            title = item.get("title")
-            if title:
-                search_parts.append(f"Title: {title}")
-
-            source = item.get("source")
-            if isinstance(source, dict):
-                source_text = source.get("url") or source.get("text")
-                if source_text:
-                    search_parts.append(f"Source: {source_text}")
-            elif source:
-                search_parts.append(f"Source: {source}")
-
-            content = item.get("content")
-            content_parts = []
-            if isinstance(content, str):
-                content_parts.append(content)
-            elif isinstance(content, list):
-                for part in content:
-                    if not isinstance(part, dict):
-                        continue
-                    if part.get("type") == "text" and part.get("text"):
-                        content_parts.append(part["text"])
-            if content_parts:
-                search_parts.append("Content: " + "\n".join(content_parts))
-
-            return "\n".join(search_parts)
-
-        def _convert_tool_result_content(
-            content: Any,
-        ) -> tuple[list[Union[str, list[dict]]], str]:
-            if isinstance(content, list):
-                tool_content_parts = []
-                tool_text_parts = []
-
-                for raw_item in content:
-                    # Items may be typed Pydantic blocks (after request
-                    # validation) or raw dicts (from legacy callers). Coerce
-                    # to dict so the existing key-based logic still works.
-                    if isinstance(raw_item, BaseModel):
-                        item = raw_item.model_dump(exclude_none=True)
-                    elif isinstance(raw_item, dict):
-                        item = raw_item
-                    else:
-                        continue
-
-                    item_type = item.get("type")
-                    if item_type == "text":
-                        text = item.get("text", "")
-                        if text:
-                            tool_text_parts.append(text)
-                            tool_content_parts.append({"type": "text", "text": text})
-                    elif item_type == "image":
-                        image_part = _convert_anthropic_image_source_to_openai_part(
-                            item.get("source")
-                        )
-                        if image_part is not None:
-                            tool_content_parts.append(image_part)
-                    elif item_type == "tool_reference":
-                        # Anthropic uses `tool_name`; the SGLang chat template
-                        # matches on `name`. Translate at the boundary.
-                        ref_name = item.get("tool_name") or item.get("name")
-                        if ref_name:
-                            tool_content_parts.append(
-                                {"type": "tool_reference", "name": ref_name}
-                            )
-                    elif item_type == "search_result":
-                        search_text = _text_from_search_result(item)
-                        if search_text:
-                            tool_text_parts.append(search_text)
-                            tool_content_parts.append(
-                                {"type": "text", "text": search_text}
-                            )
-
-                tool_text = "\n".join(tool_text_parts)
-                # GLM templates expand references only at the start of a tool
-                # message, so isolate reference runs without changing part order.
-                tool_content_groups: list[list[dict]] = []
-                for part in tool_content_parts:
-                    is_reference = part["type"] == "tool_reference"
-                    if (
-                        not tool_content_groups
-                        or (tool_content_groups[-1][0]["type"] == "tool_reference")
-                        != is_reference
-                    ):
-                        tool_content_groups.append([])
-                    tool_content_groups[-1].append(part)
-
-                tool_contents: list[Union[str, list[dict]]] = []
-                for group in tool_content_groups:
-                    if len(group) == 1 and group[0]["type"] == "text":
-                        tool_contents.append(group[0]["text"])
-                    else:
-                        tool_contents.append(group)
-                return tool_contents or [""], tool_text
-
-            tool_text = str(content) if content else ""
-            return [tool_text], tool_text
-
-        def _convert_assistant_thinking_blocks(
-            blocks: list[AnthropicContentBlock],
-        ) -> Optional[str]:
-            """Re-wrap prior-turn thinking blocks in the parser's own tokens.
-
-            ``redacted_thinking`` carries encrypted bytes that no local
-            parser can interpret, so we raise rather than silently drop it.
-            On non-reasoning models (no detector configured) the rewrap is
-            best-effort: we log a warning and drop the thinking text so a
-            history echo doesn't 400 the whole request — the prior thinking
-            is opaque context the model didn't need anyway.
-            """
-            if any(block.type == "redacted_thinking" for block in blocks):
-                raise ValueError("Anthropic redacted_thinking history is not supported")
-
-            thinking_parts = [
-                block.thinking
-                for block in blocks
-                if block.type == "thinking" and block.thinking
-            ]
-            if not thinking_parts:
-                return None
-
-            try:
-                return self.openai_serving_chat.wrap_reasoning_history(
-                    "\n".join(thinking_parts)
-                )
-            except ValueError as e:
-                logger.warning(
-                    "Dropping prior-turn thinking history (%d blocks): %s",
-                    len(thinking_parts),
-                    e,
-                )
-                return None
-
-        system_parts: list[str] = []
-        if anthropic_request.system:
-            if isinstance(anthropic_request.system, str):
-                if anthropic_request.system.strip():
-                    system_parts.append(anthropic_request.system)
-            else:
-                for block in anthropic_request.system:
-                    if block.type == "text" and block.text:
-                        system_parts.append(block.text)
-
-        if self._merge_inline_system:
-            for msg in anthropic_request.messages:
-                if msg.role != "system":
-                    continue
-                text = _extract_system_text(msg.content)
-                if text:
-                    system_parts.append(text)
-
-        if system_parts:
-            openai_messages.append(
-                {"role": "system", "content": "\n".join(system_parts)}
-            )
-
-        def _emit_user_message(parts: list[dict]) -> None:
-            """Append accumulated parts as a user message, then clear them.
-
-            Used to flush content collected BEFORE a tool_result so the
-            wire order stays user(pre) → tool → user(post). Without this
-            flush, text/image parts that appeared before a tool_result
-            block would be moved AFTER the tool message at end of loop.
-            """
-            if not parts:
-                return
-            if len(parts) == 1 and parts[0]["type"] == "text":
-                openai_messages.append({"role": "user", "content": parts[0]["text"]})
-            else:
-                openai_messages.append({"role": "user", "content": list(parts)})
-            parts.clear()
-
-        # Convert messages
-        for msg in anthropic_request.messages:
-            if msg.role == "system" and self._merge_inline_system:
-                continue
-            if isinstance(msg.content, str):
-                openai_messages.append({"role": msg.role, "content": msg.content})
-                continue
-
-            # Complex content with blocks
-            openai_msg = {"role": msg.role}
-            content_parts: list[dict] = []
-            tool_calls: list[dict] = []
-
-            if msg.role == "assistant":
-                reasoning_history = _convert_assistant_thinking_blocks(msg.content)
-                if reasoning_history is not None:
-                    content_parts.append({"type": "text", "text": reasoning_history})
-
-            for block in msg.content:
-                # ``thinking``/``redacted_thinking`` blocks are surfaced via
-                # the reasoning-history reconstruction above; skip them here
-                # to avoid double-injecting their text into the prompt.
-                if block.type in ("thinking", "redacted_thinking"):
-                    continue
-
-                # ``is not None`` (not truthy) so an empty-string text block
-                # still produces a placeholder text part — without it, an
-                # assistant turn whose only content is "" vanishes and
-                # subsequent user→user pairs trip strict chat templates.
-                if block.type == "text" and block.text is not None:
-                    content_parts.append({"type": "text", "text": block.text})
-
-                elif block.type == "image" and block.source:
-                    image_part = _convert_anthropic_image_source_to_openai_part(
-                        block.source
-                    )
-                    if image_part is not None:
-                        content_parts.append(image_part)
-
-                elif block.type == "search_result":
-                    search_text = _text_from_search_result(block.model_dump())
-                    if search_text:
-                        content_parts.append({"type": "text", "text": search_text})
-
-                elif block.type == "tool_use":
-                    tool_call = {
-                        "id": block.id or f"call_{uuid.uuid4().hex}",
-                        "type": "function",
-                        "function": {
-                            "name": block.name or "",
-                            "arguments": json.dumps(block.input or {}),
-                        },
-                    }
-                    tool_calls.append(tool_call)
-
-                elif block.type == "tool_result":
-                    tool_contents, tool_text = _convert_tool_result_content(
-                        block.content
-                    )
-
-                    # Use tool_use_id (per spec) with fallback to id
-                    tool_call_id = block.tool_use_id or block.id or ""
-
-                    # Tool results from user become separate tool messages.
-                    # Flush any pending text/image first so the wire order
-                    # is preserved (a tool_result that arrived AFTER a text
-                    # block must come AFTER that text in OpenAI form too).
-                    if msg.role == "user":
-                        _emit_user_message(content_parts)
-                        for tool_content in tool_contents:
-                            openai_messages.append(
-                                {
-                                    "role": "tool",
-                                    "tool_call_id": tool_call_id,
-                                    "content": tool_content,
-                                }
-                            )
-                    else:
-                        content_parts.append(
-                            {
-                                "type": "text",
-                                "text": f"Tool result: {tool_text}",
-                            }
-                        )
-
-            # Attach tool calls to assistant messages
-            if tool_calls:
-                openai_msg["tool_calls"] = tool_calls
-
-            # Attach content
-            if content_parts:
-                if len(content_parts) == 1 and content_parts[0]["type"] == "text":
-                    openai_msg["content"] = content_parts[0]["text"]
-                else:
-                    openai_msg["content"] = content_parts
-                openai_messages.append(openai_msg)
-            elif tool_calls:
-                openai_messages.append(openai_msg)
-            elif msg.role == "user":
-                # User turn that was entirely tool_results — the tool
-                # messages were already emitted above, nothing left.
-                continue
-            else:
-                # Assistant turn with no content and no tool_calls: emit
-                # an empty-string placeholder so strict templates still
-                # see a valid role-alternation sequence.
-                openai_msg["content"] = ""
-                openai_messages.append(openai_msg)
-
-        # Build ChatCompletionRequest
-        request_data = {
-            "messages": openai_messages,
-            "model": anthropic_request.model,
-            "max_tokens": anthropic_request.max_tokens,
-            "stream": anthropic_request.stream or False,
-        }
-
-        if anthropic_request.temperature is not None:
-            request_data["temperature"] = anthropic_request.temperature
-        if anthropic_request.top_p is not None:
-            request_data["top_p"] = anthropic_request.top_p
-        if anthropic_request.top_k is not None:
-            request_data["top_k"] = anthropic_request.top_k
-        if anthropic_request.stop_sequences is not None:
-            request_data["stop"] = anthropic_request.stop_sequences
-
-        # Enable usage in stream so we can report it
-        if anthropic_request.stream:
-            request_data["stream_options"] = StreamOptions(
-                include_usage=True,
-                continuous_usage_stats=True,
-            )
-
-        chat_request = ChatCompletionRequest(**request_data)
-
-        if anthropic_request.thinking is not None:
-            # The protocol layer already enforces SDK shape:
-            #   enabled  -> budget_tokens required (>=1024), display optional
-            #   disabled -> neither budget_tokens nor display allowed
-            #   adaptive -> budget_tokens forbidden, display optional
-            # So by the time we get here ``budget_tokens`` can only be
-            # set on ``enabled``. The local backend has no equivalent
-            # hard-cap knob, so we log a WARNING instead of rejecting —
-            # the Anthropic SDK would have accepted the request and we
-            # mirror that. Operators see the unenforced budget in logs.
-            if anthropic_request.thinking.budget_tokens is not None:
-                logger.warning(
-                    "Anthropic thinking.budget_tokens=%d is accepted for "
-                    "SDK compatibility but the local backend has no "
-                    "equivalent hard-cap knob — the budget is not enforced",
-                    anthropic_request.thinking.budget_tokens,
-                )
-            # Claude 4.7's ``adaptive`` is treated identically to ``enabled``
-            # because the local backend has no auto-throttle equivalent.
-            # Anything other than ``disabled`` enables reasoning.
-            enabled = anthropic_request.thinking.type != "disabled"
-            if anthropic_request.thinking.display == "omitted":
-                # Anthropic 4.7 spec: keep reasoning ON but hide reasoning
-                # text from the client. The OpenAI streaming pipeline has
-                # no equivalent suppress knob — log so operators can see
-                # the request, then proceed with normal reasoning emission.
-                logger.warning(
-                    "Anthropic thinking.display='omitted' is accepted for "
-                    "SDK compatibility but reasoning text will still be "
-                    "emitted to the client"
-                )
-            self.openai_serving_chat.apply_reasoning_enabled(chat_request, enabled)
-
-        # Claude 4.7 ``output_config``: map ``effort`` onto the OpenAI
-        # ``reasoning_effort`` knob. ``xhigh`` collapses to ``max`` because
-        # the OpenAI Literal does not include the Anthropic-only ``xhigh``.
-        # ``task_budget`` is a soft hint forwarded as a custom param so the
-        # model can see it without it becoming a hard cap (``max_tokens``
-        # is still the hard cap).
-        if anthropic_request.output_config is not None:
-            oc = anthropic_request.output_config
-            if oc.effort is not None:
-                chat_request.reasoning_effort = (
-                    "max" if oc.effort == "xhigh" else oc.effort
-                )
-            if oc.task_budget is not None:
-                # Custom params are silently ignored by backends that
-                # don't recognise them; logging it makes the propagation
-                # visible.
-                logger.info(
-                    "Anthropic output_config.task_budget hint: %d %s",
-                    oc.task_budget.total,
-                    oc.task_budget.type,
-                )
-
-        # ``betas`` is the Anthropic SDK's opt-in feature list (e.g.
-        # ``["thinking-2025-08-04"]``). The local backend has no
-        # equivalent beta system; accept-and-log so requests don't 400.
-        if anthropic_request.betas:
-            logger.info(
-                "Anthropic request opted into betas %s — no-op locally",
-                anthropic_request.betas,
-            )
-
-        # Convert tools. Deferred tools stay in the list with defer_loading=True;
-        # the chat template hides them from the initial <tools> block and renders
-        # them on demand when a tool_reference block names them.
-        if anthropic_request.tools:
-            converted_tools = []
-            for tool in anthropic_request.tools:
-                if is_server_tool(tool):
-                    # Anthropic server-side tools (web_search_*, computer_*,
-                    # bash_*, text_editor_*) have no client-side input_schema
-                    # because Anthropic provides the implementation. We can't
-                    # forward them to the OpenAI tools array (which requires a
-                    # schema), so skip with a visible log.
-                    logger.info(
-                        "Skipping built-in Anthropic server tool %r (type=%r): "
-                        "no native support in the OpenAI-compatible backend",
-                        tool.name,
-                        tool.type,
-                    )
-                    continue
-
-                # Custom tools always have a validated input_schema
-                # (enforced at Pydantic parse time).
-                converted_tools.append(
-                    Tool(
-                        type="function",
-                        defer_loading=tool.defer_loading,
-                        function={
-                            "name": tool.name,
-                            "description": tool.description or "",
-                            "parameters": tool.input_schema,
-                        },
-                    )
-                )
-
-            if converted_tools:
-                chat_request.tools = converted_tools
-
-        # Convert tool choice. ``any``/``tool`` express a hard requirement
-        # ("the model MUST call a tool"); if every requested tool was a
-        # server-side Anthropic built-in that we just skipped, there is
-        # no tool the model could call. Silently downgrading to "no tool"
-        # would deceive the caller, so raise an explicit 400.
-        if anthropic_request.tool_choice is not None:
-            tc_type = anthropic_request.tool_choice.type
-            if tc_type == "none":
-                chat_request.tool_choice = "none"
-            elif chat_request.tools:
-                if tc_type == "auto":
-                    chat_request.tool_choice = "auto"
-                elif tc_type == "any":
-                    chat_request.tool_choice = "required"
-                elif tc_type == "tool":
-                    tool_name = anthropic_request.tool_choice.name
-                    # ``Tool.function`` is a ``Function`` Pydantic model, not
-                    # a dict — access by attribute. A dict ``.get`` would
-                    # AttributeError and surface as a 500 instead of the
-                    # intended 400 / happy path.
-                    if not any(
-                        t.function.name == tool_name for t in chat_request.tools
-                    ):
-                        raise ValueError(
-                            f"tool_choice references tool {tool_name!r} but it "
-                            f"is not in the forwarded tools list "
-                            f"(server-side Anthropic tools cannot be selected)"
-                        )
-                    chat_request.tool_choice = ToolChoice(
-                        type="function",
-                        function=ToolChoiceFuncName(name=tool_name),
-                    )
-            elif tc_type in ("any", "tool"):
-                raise ValueError(
-                    f"tool_choice={tc_type!r} requires at least one custom "
-                    f"tool; all supplied tools were server-side Anthropic "
-                    f"built-ins which the OpenAI-compatible backend cannot "
-                    f"invoke"
-                )
-        elif chat_request.tools:
-            chat_request.tool_choice = "auto"
-
-        return chat_request
+        return convert_to_chat_completion_request(
+            anthropic_request,
+            merge_inline_system=self._merge_inline_system,
+            wrap_reasoning_history=lambda reasoning_text: self.openai_serving_chat.wrap_reasoning_history(
+                reasoning_text
+            ),
+            apply_reasoning_enabled=lambda request, enabled: self.openai_serving_chat.apply_reasoning_enabled(
+                request, enabled
+            ),
+        )
 
     async def _handle_non_streaming(
         self,
@@ -1247,80 +1343,7 @@ class AnthropicServing:
     def _convert_response(
         self, response: ChatCompletionResponse
     ) -> AnthropicMessagesResponse:
-        """Convert an OpenAI ChatCompletionResponse to an Anthropic Messages response."""
-        if not response.choices:
-            return AnthropicMessagesResponse(
-                content=[TextBlock(text="")],
-                model=response.model,
-                stop_reason="end_turn",
-                usage=AnthropicUsage(input_tokens=0, output_tokens=0),
-            )
-
-        choice = response.choices[0]
-        content: list[AnthropicContentBlock] = []
-
-        # Add reasoning content as a thinking block. signature is omitted
-        # entirely when the backend doesn't provide one — empty strings
-        # would fail downstream Anthropic signature verifiers.
-        if choice.message.reasoning_content:
-            content.append(ThinkingBlock(thinking=choice.message.reasoning_content))
-
-        # Add text content
-        if choice.message.content:
-            content.append(TextBlock(text=choice.message.content))
-
-        # Add tool calls
-        if choice.message.tool_calls:
-            for tool_call in choice.message.tool_calls:
-                raw_args = tool_call.function.arguments
-                try:
-                    tool_input = json.loads(raw_args)
-                except (json.JSONDecodeError, TypeError):
-                    # Surface invalid tool arguments so an empty-dict
-                    # tool call is never indistinguishable from a real
-                    # one when something downstream goes wrong.
-                    logger.warning(
-                        "Tool %r emitted invalid JSON arguments: %r — "
-                        "defaulting to empty input",
-                        tool_call.function.name,
-                        (raw_args or "")[:200],
-                    )
-                    tool_input = {}
-
-                content.append(
-                    ToolUseBlock(
-                        id=tool_call.id,
-                        name=tool_call.function.name,
-                        input=tool_input,
-                    )
-                )
-
-        # Map stop reason
-        finish_reason = choice.finish_reason or "stop"
-        if finish_reason not in STOP_REASON_MAP:
-            logger.warning(
-                "Unmapped OpenAI finish_reason %r; defaulting to end_turn",
-                finish_reason,
-            )
-        stop_reason = STOP_REASON_MAP.get(finish_reason, "end_turn")
-
-        # Anthropic requires ``content`` to contain at least one block.
-        # Empty string completions (max_tokens=1 stop, content filter, etc.)
-        # would otherwise ship ``content=[]`` and break strict SDK parsers.
-        if not content:
-            content.append(TextBlock(text=""))
-
-        return AnthropicMessagesResponse(
-            id=f"msg_{uuid.uuid4().hex}",
-            content=content,
-            model=response.model,
-            stop_reason=stop_reason,
-            usage=_anthropic_usage_from_openai(
-                response.usage,
-                include_input=True,
-                include_output=True,
-            ),
-        )
+        return convert_response(response)
 
     def _convert_openai_error_response(self, response) -> JSONResponse:
         """Forward an upstream OpenAI-handler error as an Anthropic error.

--- a/python/sglang/srt/entrypoints/anthropic/utils.py
+++ b/python/sglang/srt/entrypoints/anthropic/utils.py
@@ -1,0 +1,397 @@
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Standalone Anthropic ↔ OpenAI conversion utilities.
+
+External OpenAI-compatible frontends (e.g. token-in-token-out session
+routers) must interpret Anthropic Messages requests exactly as this server
+does, but without a live serving runtime (tokenizer manager, engine,
+streaming loop). This module exposes ``serving.py``'s conversion semantics
+as unbound functions while leaving ``serving.py`` and ``protocol.py``
+untouched: request and response conversion delegate to the original
+``AnthropicServing`` methods through a runtime-detached instance, so there
+is one conversion implementation for the server and external callers.
+
+What is new here rather than delegated:
+
+- ``AnthropicRequestContext`` feature gates. ``serving.py`` accepts every
+  typed feature and logs/skips what the backend cannot honor; a frontend
+  that has only verified a subset end-to-end can instead fail closed with
+  an ``AnthropicRequestError`` (HTTP 400) before conversion. Thinking
+  (the request param and history blocks) always fails closed: its
+  conversion needs the serving runtime's reasoning parser and cannot be
+  reproduced data-only.
+- ``to_anthropic_error`` returns the Anthropic error envelope as a DTO
+  instead of a ``JSONResponse``, and maps 413/422 the way the HTTP layer's
+  ``/v1/messages`` exception handler does (``serving.py``'s own
+  ``ERROR_TYPE_MAP`` never sees those statuses because FastAPI raises
+  them before the handler runs).
+- ``to_anthropic_fake_sse_events`` eagerly synthesizes the Anthropic SSE
+  event sequence from one complete ``ChatCompletionResponse``. The server
+  streams real deltas from the engine; a frontend that proxies a finished
+  non-streaming response can still honor a client's ``stream: true`` with
+  this one-delta-per-block materialization.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from dataclasses import dataclass
+from typing import Any, Callable, Iterator, Optional
+
+from pydantic import ValidationError
+
+from sglang.srt.entrypoints.anthropic.protocol import (
+    AnthropicError,
+    AnthropicErrorResponse,
+    AnthropicMessageEndDelta,
+    AnthropicMessagesRequest,
+    AnthropicMessagesResponse,
+    AnthropicStreamEvent,
+    ContentBlockDeltaEvent,
+    ContentBlockStartEvent,
+    ContentBlockStopEvent,
+    InputJsonDelta,
+    MessageDeltaEvent,
+    MessageStartEvent,
+    MessageStopEvent,
+    TextBlock,
+    TextDelta,
+    ThinkingBlock,
+    ThinkingDelta,
+    ToolUseBlock,
+    is_server_tool,
+)
+from sglang.srt.entrypoints.anthropic.serving import (
+    ERROR_TYPE_MAP as _SERVING_ERROR_TYPE_MAP,
+)
+from sglang.srt.entrypoints.anthropic.serving import (
+    STOP_REASON_MAP,
+    AnthropicServing,
+    _anthropic_usage_from_openai,
+    _scrub_error_message,
+)
+from sglang.srt.entrypoints.openai.protocol import (
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+# ``serving.py``'s map plus the two statuses the HTTP layer maps in its
+# ``/v1/messages`` exception handler (``http_server.py``): FastAPI raises
+# 413/422 before ``AnthropicServing`` runs, so ``serving.py`` never needed
+# them. Unlisted statuses fall through to ``api_error`` in both sources.
+ERROR_TYPE_MAP = {
+    **_SERVING_ERROR_TYPE_MAP,
+    413: "request_too_large",
+    422: "invalid_request_error",
+}
+
+
+class AnthropicRequestError(ValueError):
+    """Anthropic request cannot be parsed, validated, or converted (HTTP 400)."""
+
+
+@dataclass(frozen=True)
+class AnthropicRequestContext:
+    """Immutable conversion policy for one deployment.
+
+    ``merge_inline_system`` mirrors what ``AnthropicServing.__init__``
+    probes from the chat template (``not detect_inline_system_support(...)``).
+    The ``allow_*`` gates reject known-but-disabled typed features with
+    ``AnthropicRequestError`` before conversion; when a gate is enabled,
+    conversion follows ``serving.py`` unchanged. Validation walks only the
+    typed request/content/tool models; ``tool_use.input``, custom-tool
+    ``input_schema`` and ``metadata`` remain arbitrary-JSON boundaries.
+    Thinking has no gate and is always rejected.
+    """
+
+    merge_inline_system: bool
+    allow_images: bool = False
+    allow_output_config: bool = False
+    allow_beta_fields: bool = False
+    allow_tool_references: bool = False
+    allow_search_results: bool = False
+    allow_server_tools: bool = False
+
+
+class _ConversionOnlyAnthropicServing(AnthropicServing):
+    """``AnthropicServing`` detached from the serving runtime.
+
+    The conversion methods only read ``self._merge_inline_system``; the
+    thinking/reasoning paths additionally need ``self.openai_serving_chat``
+    but the feature gates reject those requests before delegation, so
+    ``AnthropicServing.__init__`` (which requires a live
+    ``OpenAIServingChat``) is deliberately not called.
+    """
+
+    def __init__(self, merge_inline_system: bool):
+        self.openai_serving_chat = None
+        self._merge_inline_system = merge_inline_system
+
+
+def anthropic_message_id() -> str:
+    """Message-ID factory with the same format the server generates."""
+    return f"msg_{uuid.uuid4().hex}"
+
+
+def parse_anthropic_request(body: bytes) -> AnthropicMessagesRequest:
+    """Parse the raw request body; failures map to HTTP 400."""
+    try:
+        payload = json.loads(body)
+    except (json.JSONDecodeError, UnicodeDecodeError, ValueError) as e:
+        raise AnthropicRequestError(f"invalid JSON body: {e}") from e
+    try:
+        return AnthropicMessagesRequest.model_validate(payload)
+    except ValidationError as e:
+        raise AnthropicRequestError(str(e)) from e
+
+
+def _iter_typed_content_blocks(request: AnthropicMessagesRequest) -> Iterator[Any]:
+    """Yield every typed content block reachable from the request: top-level
+    ``system`` blocks, message blocks, and one level of ``tool_result`` nested
+    content (the depth ``serving.py``'s conversion reads)."""
+    if request.system is not None and not isinstance(request.system, str):
+        yield from request.system
+    for msg in request.messages:
+        if isinstance(msg.content, str):
+            continue
+        for block in msg.content:
+            yield block
+            if getattr(block, "type", None) == "tool_result" and isinstance(
+                block.content, list
+            ):
+                yield from block.content
+
+
+def _validate_known_features(
+    request: AnthropicMessagesRequest, context: AnthropicRequestContext
+) -> None:
+    """Reject known-but-disabled typed features (fail closed, HTTP 400).
+
+    Only typed models are walked; arbitrary-JSON boundaries are not recursed.
+    Unknown extra keys inside known models keep the Pydantic ignore behavior
+    and are not checked here.
+    """
+    if request.thinking is not None:
+        raise AnthropicRequestError("thinking is not supported by this endpoint")
+    if request.output_config is not None and not context.allow_output_config:
+        raise AnthropicRequestError("output_config is not enabled for this deployment")
+    if request.betas and not context.allow_beta_fields:
+        raise AnthropicRequestError("betas is not enabled for this deployment")
+    if request.tools and not context.allow_server_tools:
+        for tool in request.tools:
+            if is_server_tool(tool):
+                raise AnthropicRequestError(
+                    f"server tool {tool.name!r} (type={tool.type!r}) is not "
+                    f"enabled for this deployment"
+                )
+    for block in _iter_typed_content_blocks(request):
+        block_type = getattr(block, "type", None)
+        if block_type in ("thinking", "redacted_thinking"):
+            raise AnthropicRequestError(
+                "thinking content blocks are not supported by this endpoint"
+            )
+        if block_type == "image" and not context.allow_images:
+            raise AnthropicRequestError(
+                "image content blocks are not enabled for this deployment"
+            )
+        if block_type == "tool_reference" and not context.allow_tool_references:
+            raise AnthropicRequestError(
+                "tool_reference content blocks are not enabled for this deployment"
+            )
+        if block_type == "search_result" and not context.allow_search_results:
+            raise AnthropicRequestError(
+                "search_result content blocks are not enabled for this deployment"
+            )
+
+
+def to_openai_request(
+    request: AnthropicMessagesRequest, *, context: AnthropicRequestContext
+) -> ChatCompletionRequest:
+    """Convert an Anthropic Messages request to an OpenAI ChatCompletion
+    request under ``context``. Any validation or conversion failure raises
+    ``AnthropicRequestError`` (the server's behavior: HTTP 400)."""
+    _validate_known_features(request, context)
+    converter = _ConversionOnlyAnthropicServing(context.merge_inline_system)
+    try:
+        return converter._convert_to_chat_completion_request(request)
+    except Exception as e:
+        # Same policy as ``handle_messages``: every conversion failure is a
+        # 400 invalid_request_error, logged with its traceback server-side.
+        logger.exception("Error converting Anthropic request: %s", e)
+        raise AnthropicRequestError(str(e)) from e
+
+
+def to_anthropic_response(
+    response: ChatCompletionResponse,
+    *,
+    id_factory: Callable[[], str] = anthropic_message_id,
+) -> AnthropicMessagesResponse:
+    """Convert an OpenAI ChatCompletionResponse to an Anthropic Messages
+    response. ``id_factory`` replaces the delegate's internally generated
+    message ID (same wire format by default; inject for determinism)."""
+    # ``_convert_response`` never reads the inline-system policy.
+    anthropic_response = _ConversionOnlyAnthropicServing(
+        merge_inline_system=False
+    )._convert_response(response)
+    return anthropic_response.model_copy(update={"id": id_factory()})
+
+
+def to_anthropic_error(status_code: int, body: bytes) -> AnthropicErrorResponse:
+    """Map an upstream error status and body to an Anthropic error envelope.
+
+    Same payload parsing and scrub policy as ``serving.py``'s
+    ``_convert_openai_error_response``, but against the composite
+    ``ERROR_TYPE_MAP`` above and returning the envelope DTO — HTTP response
+    construction stays with the caller. 4xx keeps a sanitized upstream
+    message and honors an upstream ``error.type``; 5xx is always the
+    generic scrubbed message.
+    """
+    body = body or b""
+    error_type = ERROR_TYPE_MAP.get(status_code, "api_error")
+
+    upstream_message: Optional[str] = None
+    try:
+        payload = json.loads(body.decode("utf-8")) if body else None
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        # Non-JSON body (HTML gateway error, plain text, ...). Use a bounded
+        # slice of the raw body so the client still has a useful hint.
+        upstream_message = body.decode("utf-8", errors="replace")[:500]
+    else:
+        if isinstance(payload, dict):
+            error_payload = payload.get("error", payload)
+            if isinstance(error_payload, dict):
+                upstream_message = error_payload.get("message") or payload.get(
+                    "message"
+                )
+                # Honor the upstream error.type only for 4xx; 5xx is
+                # normalized by the scrub below.
+                if status_code < 500:
+                    upstream_type = error_payload.get("type")
+                    if isinstance(upstream_type, str) and upstream_type:
+                        error_type = upstream_type
+            elif isinstance(error_payload, str):
+                upstream_message = error_payload
+            elif isinstance(payload.get("message"), str):
+                upstream_message = payload["message"]
+
+    message = _scrub_error_message(upstream_message or "", status_code)
+    return AnthropicErrorResponse(
+        error=AnthropicError(type=error_type, message=message)
+    )
+
+
+def to_anthropic_fake_sse_events(
+    response: ChatCompletionResponse,
+    *,
+    model: str,
+    id_factory: Callable[[], str] = anthropic_message_id,
+) -> tuple[AnthropicStreamEvent, ...]:
+    """Eagerly synthesize the Anthropic SSE event sequence from one complete
+    OpenAI response.
+
+    Event schema, block ordering (thinking → text → tool_use), index
+    accounting, usage split (input on ``message_start``, output on
+    ``message_delta``) and stop-reason mapping follow the server's live
+    stream; collapsing each block into a single delta is the documented
+    difference. ``model`` must be the original Anthropic request model, not
+    the backend's possibly-aliased response model.
+    """
+    events: list[AnthropicStreamEvent] = [
+        MessageStartEvent(
+            message=AnthropicMessagesResponse(
+                id=id_factory(),
+                content=[],
+                model=model,
+                usage=_anthropic_usage_from_openai(
+                    response.usage,
+                    include_input=True,
+                    include_output=True,
+                    force_zero_output=True,
+                ),
+            )
+        )
+    ]
+
+    message = response.choices[0].message if response.choices else None
+    index = 0
+
+    if message is not None and message.reasoning_content:
+        events.append(
+            ContentBlockStartEvent(
+                index=index, content_block=ThinkingBlock(thinking="")
+            )
+        )
+        events.append(
+            ContentBlockDeltaEvent(
+                index=index, delta=ThinkingDelta(thinking=message.reasoning_content)
+            )
+        )
+        events.append(ContentBlockStopEvent(index=index))
+        index += 1
+
+    if message is not None and message.content:
+        events.append(
+            ContentBlockStartEvent(index=index, content_block=TextBlock(text=""))
+        )
+        events.append(
+            ContentBlockDeltaEvent(index=index, delta=TextDelta(text=message.content))
+        )
+        events.append(ContentBlockStopEvent(index=index))
+        index += 1
+
+    if message is not None and message.tool_calls:
+        for tool_call in message.tool_calls:
+            events.append(
+                ContentBlockStartEvent(
+                    index=index,
+                    content_block=ToolUseBlock(
+                        id=tool_call.id or f"toolu_{uuid.uuid4().hex}",
+                        name=tool_call.function.name,
+                        input={},
+                    ),
+                )
+            )
+            if tool_call.function.arguments:
+                events.append(
+                    ContentBlockDeltaEvent(
+                        index=index,
+                        delta=InputJsonDelta(partial_json=tool_call.function.arguments),
+                    )
+                )
+            events.append(ContentBlockStopEvent(index=index))
+            index += 1
+
+    finish_reason = (
+        (response.choices[0].finish_reason or "stop") if response.choices else "stop"
+    )
+    if finish_reason not in STOP_REASON_MAP:
+        logger.warning(
+            "Unmapped OpenAI finish_reason %r; defaulting to end_turn", finish_reason
+        )
+    events.append(
+        MessageDeltaEvent(
+            delta=AnthropicMessageEndDelta(
+                stop_reason=STOP_REASON_MAP.get(finish_reason, "end_turn")
+            ),
+            usage=_anthropic_usage_from_openai(
+                response.usage, include_input=False, include_output=True
+            ),
+        )
+    )
+    events.append(MessageStopEvent())
+    return tuple(events)

--- a/python/sglang/srt/entrypoints/anthropic/utils.py
+++ b/python/sglang/srt/entrypoints/anthropic/utils.py
@@ -11,34 +11,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Standalone Anthropic ↔ OpenAI conversion utilities.
+"""Anthropic error conversion and fake-SSE response helpers.
 
-External OpenAI-compatible frontends (e.g. token-in-token-out session
-routers) must interpret Anthropic Messages requests exactly as this server
-does, but without a live serving runtime (tokenizer manager, engine,
-streaming loop). Request and response conversion call the same module-level
-functions as ``AnthropicServing``, so there is one implementation for the
-server and external callers.
-
-What is new here rather than delegated:
-
-- ``AnthropicRequestContext`` feature gates. ``serving.py`` accepts every
-  typed feature and logs/skips what the backend cannot honor; a frontend
-  that has only verified a subset end-to-end can instead fail closed with
-  an ``AnthropicRequestError`` (HTTP 400) before conversion. Thinking
-  (the request param and history blocks) always fails closed: its
-  conversion needs the serving runtime's reasoning parser and cannot be
-  reproduced data-only.
-- ``to_anthropic_error`` returns the Anthropic error envelope as a DTO
-  instead of a ``JSONResponse``, and maps 413/422 the way the HTTP layer's
-  ``/v1/messages`` exception handler does (``serving.py``'s own
-  ``ERROR_TYPE_MAP`` never sees those statuses because FastAPI raises
-  them before the handler runs).
-- ``to_anthropic_fake_sse_events`` eagerly synthesizes the Anthropic SSE
-  event sequence from one complete ``ChatCompletionResponse``. The server
-  streams real deltas from the engine; a frontend that proxies a finished
-  non-streaming response can still honor a client's ``stream: true`` with
-  this one-delta-per-block materialization.
+Request and response format conversion lives in serving.py as public,
+runtime-independent functions. This module contains the two adaptations used
+by external frontends: an Anthropic error DTO and an eager event sequence for
+an already-complete OpenAI response.
 """
 
 from __future__ import annotations
@@ -46,16 +24,12 @@ from __future__ import annotations
 import json
 import logging
 import uuid
-from dataclasses import dataclass
-from typing import Any, Callable, Iterator, Optional
-
-from pydantic import ValidationError
+from typing import Callable, Optional
 
 from sglang.srt.entrypoints.anthropic.protocol import (
     AnthropicError,
     AnthropicErrorResponse,
     AnthropicMessageEndDelta,
-    AnthropicMessagesRequest,
     AnthropicMessagesResponse,
     AnthropicStreamEvent,
     ContentBlockDeltaEvent,
@@ -70,7 +44,6 @@ from sglang.srt.entrypoints.anthropic.protocol import (
     ThinkingBlock,
     ThinkingDelta,
     ToolUseBlock,
-    is_server_tool,
 )
 from sglang.srt.entrypoints.anthropic.serving import (
     ERROR_TYPE_MAP as _SERVING_ERROR_TYPE_MAP,
@@ -79,13 +52,8 @@ from sglang.srt.entrypoints.anthropic.serving import (
     STOP_REASON_MAP,
     _anthropic_usage_from_openai,
     _scrub_error_message,
-    convert_response,
-    convert_to_chat_completion_request,
 )
-from sglang.srt.entrypoints.openai.protocol import (
-    ChatCompletionRequest,
-    ChatCompletionResponse,
-)
+from sglang.srt.entrypoints.openai.protocol import ChatCompletionResponse
 
 logger = logging.getLogger(__name__)
 
@@ -100,138 +68,9 @@ ERROR_TYPE_MAP = {
 }
 
 
-class AnthropicRequestError(ValueError):
-    """Anthropic request cannot be parsed, validated, or converted (HTTP 400)."""
-
-
-@dataclass(frozen=True)
-class AnthropicRequestContext:
-    """Immutable conversion policy for one deployment.
-
-    ``merge_inline_system`` mirrors what ``AnthropicServing.__init__``
-    probes from the chat template (``not detect_inline_system_support(...)``).
-    The ``allow_*`` gates reject known-but-disabled typed features with
-    ``AnthropicRequestError`` before conversion; when a gate is enabled,
-    conversion follows ``serving.py`` unchanged. Validation walks only the
-    typed request/content/tool models; ``tool_use.input``, custom-tool
-    ``input_schema`` and ``metadata`` remain arbitrary-JSON boundaries.
-    Thinking has no gate and is always rejected.
-    """
-
-    merge_inline_system: bool
-    allow_images: bool = False
-    allow_output_config: bool = False
-    allow_beta_fields: bool = False
-    allow_tool_references: bool = False
-    allow_search_results: bool = False
-    allow_server_tools: bool = False
-
-
-def anthropic_message_id() -> str:
+def _anthropic_message_id() -> str:
     """Message-ID factory with the same format the server generates."""
     return f"msg_{uuid.uuid4().hex}"
-
-
-def parse_anthropic_request(body: bytes) -> AnthropicMessagesRequest:
-    """Parse the raw request body; failures map to HTTP 400."""
-    try:
-        payload = json.loads(body)
-    except (json.JSONDecodeError, UnicodeDecodeError, ValueError) as e:
-        raise AnthropicRequestError(f"invalid JSON body: {e}") from e
-    try:
-        return AnthropicMessagesRequest.model_validate(payload)
-    except ValidationError as e:
-        raise AnthropicRequestError(str(e)) from e
-
-
-def _iter_typed_content_blocks(request: AnthropicMessagesRequest) -> Iterator[Any]:
-    """Yield every typed content block reachable from the request: top-level
-    ``system`` blocks, message blocks, and one level of ``tool_result`` nested
-    content (the depth ``serving.py``'s conversion reads)."""
-    if request.system is not None and not isinstance(request.system, str):
-        yield from request.system
-    for msg in request.messages:
-        if isinstance(msg.content, str):
-            continue
-        for block in msg.content:
-            yield block
-            if getattr(block, "type", None) == "tool_result" and isinstance(
-                block.content, list
-            ):
-                yield from block.content
-
-
-def _validate_known_features(
-    request: AnthropicMessagesRequest, context: AnthropicRequestContext
-) -> None:
-    """Reject known-but-disabled typed features (fail closed, HTTP 400).
-
-    Only typed models are walked; arbitrary-JSON boundaries are not recursed.
-    Unknown extra keys inside known models keep the Pydantic ignore behavior
-    and are not checked here.
-    """
-    if request.thinking is not None:
-        raise AnthropicRequestError("thinking is not supported by this endpoint")
-    if request.output_config is not None and not context.allow_output_config:
-        raise AnthropicRequestError("output_config is not enabled for this deployment")
-    if request.betas and not context.allow_beta_fields:
-        raise AnthropicRequestError("betas is not enabled for this deployment")
-    if request.tools and not context.allow_server_tools:
-        for tool in request.tools:
-            if is_server_tool(tool):
-                raise AnthropicRequestError(
-                    f"server tool {tool.name!r} (type={tool.type!r}) is not "
-                    f"enabled for this deployment"
-                )
-    for block in _iter_typed_content_blocks(request):
-        block_type = getattr(block, "type", None)
-        if block_type in ("thinking", "redacted_thinking"):
-            raise AnthropicRequestError(
-                "thinking content blocks are not supported by this endpoint"
-            )
-        if block_type == "image" and not context.allow_images:
-            raise AnthropicRequestError(
-                "image content blocks are not enabled for this deployment"
-            )
-        if block_type == "tool_reference" and not context.allow_tool_references:
-            raise AnthropicRequestError(
-                "tool_reference content blocks are not enabled for this deployment"
-            )
-        if block_type == "search_result" and not context.allow_search_results:
-            raise AnthropicRequestError(
-                "search_result content blocks are not enabled for this deployment"
-            )
-
-
-def to_openai_request(
-    request: AnthropicMessagesRequest, *, context: AnthropicRequestContext
-) -> ChatCompletionRequest:
-    """Convert an Anthropic Messages request to an OpenAI ChatCompletion
-    request under ``context``. Any validation or conversion failure raises
-    ``AnthropicRequestError`` (the server's behavior: HTTP 400)."""
-    _validate_known_features(request, context)
-    try:
-        return convert_to_chat_completion_request(
-            request,
-            merge_inline_system=context.merge_inline_system,
-        )
-    except Exception as e:
-        # Same policy as ``handle_messages``: every conversion failure is a
-        # 400 invalid_request_error, logged with its traceback server-side.
-        logger.exception("Error converting Anthropic request: %s", e)
-        raise AnthropicRequestError(str(e)) from e
-
-
-def to_anthropic_response(
-    response: ChatCompletionResponse,
-    *,
-    id_factory: Callable[[], str] = anthropic_message_id,
-) -> AnthropicMessagesResponse:
-    """Convert an OpenAI ChatCompletionResponse to an Anthropic Messages
-    response. ``id_factory`` replaces the converter's internally generated
-    message ID (same wire format by default; inject for determinism)."""
-    anthropic_response = convert_response(response)
-    return anthropic_response.model_copy(update={"id": id_factory()})
 
 
 def to_anthropic_error(status_code: int, body: bytes) -> AnthropicErrorResponse:
@@ -282,7 +121,7 @@ def to_anthropic_fake_sse_events(
     response: ChatCompletionResponse,
     *,
     model: str,
-    id_factory: Callable[[], str] = anthropic_message_id,
+    id_factory: Callable[[], str] = _anthropic_message_id,
 ) -> tuple[AnthropicStreamEvent, ...]:
     """Eagerly synthesize the Anthropic SSE event sequence from one complete
     OpenAI response.

--- a/python/sglang/srt/entrypoints/anthropic/utils.py
+++ b/python/sglang/srt/entrypoints/anthropic/utils.py
@@ -16,11 +16,9 @@
 External OpenAI-compatible frontends (e.g. token-in-token-out session
 routers) must interpret Anthropic Messages requests exactly as this server
 does, but without a live serving runtime (tokenizer manager, engine,
-streaming loop). This module exposes ``serving.py``'s conversion semantics
-as unbound functions while leaving ``serving.py`` and ``protocol.py``
-untouched: request and response conversion delegate to the original
-``AnthropicServing`` methods through a runtime-detached instance, so there
-is one conversion implementation for the server and external callers.
+streaming loop). Request and response conversion call the same module-level
+functions as ``AnthropicServing``, so there is one implementation for the
+server and external callers.
 
 What is new here rather than delegated:
 
@@ -79,9 +77,10 @@ from sglang.srt.entrypoints.anthropic.serving import (
 )
 from sglang.srt.entrypoints.anthropic.serving import (
     STOP_REASON_MAP,
-    AnthropicServing,
     _anthropic_usage_from_openai,
     _scrub_error_message,
+    convert_response,
+    convert_to_chat_completion_request,
 )
 from sglang.srt.entrypoints.openai.protocol import (
     ChatCompletionRequest,
@@ -126,21 +125,6 @@ class AnthropicRequestContext:
     allow_tool_references: bool = False
     allow_search_results: bool = False
     allow_server_tools: bool = False
-
-
-class _ConversionOnlyAnthropicServing(AnthropicServing):
-    """``AnthropicServing`` detached from the serving runtime.
-
-    The conversion methods only read ``self._merge_inline_system``; the
-    thinking/reasoning paths additionally need ``self.openai_serving_chat``
-    but the feature gates reject those requests before delegation, so
-    ``AnthropicServing.__init__`` (which requires a live
-    ``OpenAIServingChat``) is deliberately not called.
-    """
-
-    def __init__(self, merge_inline_system: bool):
-        self.openai_serving_chat = None
-        self._merge_inline_system = merge_inline_system
 
 
 def anthropic_message_id() -> str:
@@ -226,9 +210,11 @@ def to_openai_request(
     request under ``context``. Any validation or conversion failure raises
     ``AnthropicRequestError`` (the server's behavior: HTTP 400)."""
     _validate_known_features(request, context)
-    converter = _ConversionOnlyAnthropicServing(context.merge_inline_system)
     try:
-        return converter._convert_to_chat_completion_request(request)
+        return convert_to_chat_completion_request(
+            request,
+            merge_inline_system=context.merge_inline_system,
+        )
     except Exception as e:
         # Same policy as ``handle_messages``: every conversion failure is a
         # 400 invalid_request_error, logged with its traceback server-side.
@@ -242,12 +228,9 @@ def to_anthropic_response(
     id_factory: Callable[[], str] = anthropic_message_id,
 ) -> AnthropicMessagesResponse:
     """Convert an OpenAI ChatCompletionResponse to an Anthropic Messages
-    response. ``id_factory`` replaces the delegate's internally generated
+    response. ``id_factory`` replaces the converter's internally generated
     message ID (same wire format by default; inject for determinism)."""
-    # ``_convert_response`` never reads the inline-system policy.
-    anthropic_response = _ConversionOnlyAnthropicServing(
-        merge_inline_system=False
-    )._convert_response(response)
+    anthropic_response = convert_response(response)
     return anthropic_response.model_copy(update={"id": id_factory()})
 
 

--- a/test/registered/unit/entrypoints/anthropic/test_utils.py
+++ b/test/registered/unit/entrypoints/anthropic/test_utils.py
@@ -1,0 +1,1115 @@
+"""Tests for the standalone Anthropic conversion utilities.
+
+Request/response conversion in ``utils`` delegates to the original
+``AnthropicServing`` methods through a runtime-detached instance, so the
+delegation tests here compare against a normally constructed
+``AnthropicServing``: if the serving methods ever grow instance state that
+``__init__`` provides but the detached instance does not, these fail.
+Conversion semantics themselves are covered by ``test_serving.py``; the
+behavior tests below cover only what ``utils`` adds — feature gates, the
+composite error map, the envelope DTO seam, eager fake-SSE synthesis, and
+message-ID injection.
+"""
+
+import ast
+import importlib.util
+import json
+import subprocess
+import sys
+import unittest
+import uuid
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()  # must precede imports that may pull in sgl_kernel
+
+from sglang.srt.entrypoints.anthropic import utils  # noqa: E402
+from sglang.srt.entrypoints.anthropic.protocol import (  # noqa: E402
+    AnthropicMessagesRequest,
+)
+from sglang.srt.entrypoints.anthropic.serving import AnthropicServing  # noqa: E402
+from sglang.srt.entrypoints.openai.protocol import ChatCompletionResponse  # noqa: E402
+from sglang.test.ci.ci_register import register_cpu_ci  # noqa: E402
+
+register_cpu_ci(est_time=30, suite="base-a-test-cpu")
+
+_FIXED_UUID = uuid.UUID(int=0x1234)
+_FIXED_MSG_ID = f"msg_{_FIXED_UUID.hex}"
+
+# Permissive policy: the delegation matrix compares the conversion semantics
+# of every typed feature, so no gate may reject the fixtures.
+_ALL_FEATURES = dict(
+    allow_images=True,
+    allow_output_config=True,
+    allow_beta_fields=True,
+    allow_tool_references=True,
+    allow_search_results=True,
+    allow_server_tools=True,
+)
+
+_DEFAULT_CTX = utils.AnthropicRequestContext(merge_inline_system=True)
+
+
+class _FakeOpenAIServingChat:
+    """Just enough of OpenAIServingChat for ``AnthropicServing.__init__``."""
+
+    def __init__(self, chat_template=None):
+        self.tokenizer_manager = SimpleNamespace(
+            tokenizer=SimpleNamespace(chat_template=chat_template)
+        )
+
+
+def _real_serving(merge_inline_system: bool) -> AnthropicServing:
+    """A normally constructed AnthropicServing with a forced policy.
+
+    The matrix must cover both policy values regardless of what the fake's
+    (absent) chat template probes to; template detection itself is covered
+    by ``test_serving.py``.
+    """
+    serving = AnthropicServing(_FakeOpenAIServingChat())
+    serving._merge_inline_system = merge_inline_system
+    return serving
+
+
+def _payload(messages, **extra) -> dict:
+    return {"model": "claude-test", "max_tokens": 64, "messages": messages, **extra}
+
+
+def _convert(payload: dict, context=_DEFAULT_CTX) -> dict:
+    request = utils.parse_anthropic_request(json.dumps(payload).encode())
+    openai_request = utils.to_openai_request(request, context=context)
+    return openai_request.model_dump(mode="json", exclude_none=True, by_alias=True)
+
+
+_TOOLS = [
+    {
+        "name": "get_weather",
+        "description": "w",
+        "input_schema": {"type": "object", "properties": {}},
+    }
+]
+
+_REQUEST_CASES = {
+    "text_system_sampling": _payload(
+        [{"role": "user", "content": "hello"}],
+        system="be brief",
+        temperature=0.5,
+        top_k=20,
+        top_p=0.9,
+        stop_sequences=["END", "STOP"],
+    ),
+    "system_blocks_and_inline_system": _payload(
+        [
+            {"role": "user", "content": "q"},
+            {"role": "system", "content": [{"type": "text", "text": " inline "}]},
+        ],
+        system=[{"type": "text", "text": "s1"}, {"type": "text", "text": "s2"}],
+    ),
+    "stream_with_options": _payload([{"role": "user", "content": "hi"}], stream=True),
+    "tool_roundtrip": _payload(
+        [
+            {"role": "user", "content": "weather?"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "checking"},
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_1",
+                        "name": "get_weather",
+                        "input": {"city": "Paris"},
+                    },
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "pre"},
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_1",
+                        "content": "sunny",
+                        "is_error": True,
+                    },
+                    {"type": "text", "text": "post"},
+                ],
+            },
+        ],
+        tools=_TOOLS,
+        tool_choice={"type": "auto"},
+    ),
+    "tool_result_variants": _payload(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "id": "legacy_id", "content": None}
+                ],
+            },
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "t2", "content": "inner"}
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "t3",
+                        "content": [
+                            {"type": "text", "text": "a"},
+                            {
+                                "type": "image",
+                                "source": {
+                                    "type": "base64",
+                                    "media_type": "image/png",
+                                    "data": "eA==",
+                                },
+                            },
+                            {"type": "tool_reference", "tool_name": "deferred_fn"},
+                            {
+                                "type": "search_result",
+                                "title": "T",
+                                "source": "https://s",
+                            },
+                        ],
+                    }
+                ],
+            },
+        ]
+    ),
+    "tool_choice_required": _payload(
+        [{"role": "user", "content": "q"}], tools=_TOOLS, tool_choice={"type": "any"}
+    ),
+    "tool_choice_named": _payload(
+        [{"role": "user", "content": "q"}],
+        tools=_TOOLS,
+        tool_choice={"type": "tool", "name": "get_weather"},
+    ),
+    "tool_choice_none": _payload(
+        [{"role": "user", "content": "q"}], tools=_TOOLS, tool_choice={"type": "none"}
+    ),
+    "empty_placeholders": _payload(
+        [
+            {"role": "assistant", "content": [{"type": "text", "text": ""}]},
+            {"role": "assistant", "content": []},
+            {"role": "user", "content": "q"},
+        ]
+    ),
+    "images": _payload(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "look"},
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "media_type": "image/jpeg",
+                            "data": "eA==",
+                        },
+                    },
+                    {
+                        "type": "image",
+                        "source": {"type": "url", "url": "https://x/y.png"},
+                    },
+                ],
+            }
+        ]
+    ),
+    "search_result_block": _payload(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "search_result",
+                        "title": "T",
+                        "source": "https://s",
+                        "content": [{"type": "text", "text": "C"}],
+                    }
+                ],
+            }
+        ]
+    ),
+    "output_config_and_betas": _payload(
+        [{"role": "user", "content": "q"}],
+        output_config={
+            "effort": "xhigh",
+            "task_budget": {"type": "tokens", "total": 1000},
+        },
+        betas=["thinking-2025-08-04"],
+    ),
+    "server_tools_skipped": _payload(
+        [{"role": "user", "content": "q"}],
+        tools=[{"type": "web_search_20250305", "name": "web_search"}, *_TOOLS],
+    ),
+    "unknown_extra_keys": _payload(
+        [{"role": "user", "content": "hi", "unknown_msg_key": 1}], unknown_top_key="x"
+    ),
+}
+
+
+def _chat_response(
+    message: dict, finish_reason: str = "stop", usage: dict = None
+) -> ChatCompletionResponse:
+    return ChatCompletionResponse.model_validate(
+        {
+            "id": "chatcmpl-1",
+            "object": "chat.completion",
+            "created": 1,
+            "model": "served-alias",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", **message},
+                    "finish_reason": finish_reason,
+                }
+            ],
+            "usage": usage
+            or {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+        }
+    )
+
+
+_RESPONSE_CASES = {
+    "text": ({"content": "hi"}, "stop", None),
+    "reasoning_and_tools": (
+        {
+            "content": "text",
+            "reasoning_content": "thought",
+            "tool_calls": [
+                {
+                    "id": "c1",
+                    "type": "function",
+                    "function": {"name": "f", "arguments": '{"a": 1}'},
+                },
+                {
+                    "id": "c2",
+                    "type": "function",
+                    "function": {"name": "g", "arguments": "not json"},
+                },
+            ],
+        },
+        "tool_calls",
+        None,
+    ),
+    "empty_content": ({"content": ""}, "stop", None),
+    "length_stop": ({"content": "x"}, "length", None),
+    "unmapped_finish_reason": ({"content": "x"}, "content_filter", None),
+    "cached_usage": (
+        {"content": "hi"},
+        "stop",
+        {
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "total_tokens": 15,
+            "prompt_tokens_details": {"cached_tokens": 4},
+        },
+    ),
+}
+
+
+class TestRequestDelegation(unittest.TestCase):
+    def test_matches_normally_constructed_serving(self):
+        for case in sorted(_REQUEST_CASES):
+            for merge_inline_system in (True, False):
+                with self.subTest(case=case, merge_inline_system=merge_inline_system):
+                    payload = _REQUEST_CASES[case]
+                    serving_request = AnthropicMessagesRequest.model_validate(payload)
+                    utils_request = utils.parse_anthropic_request(
+                        json.dumps(payload).encode()
+                    )
+                    context = utils.AnthropicRequestContext(
+                        merge_inline_system=merge_inline_system, **_ALL_FEATURES
+                    )
+                    with patch("uuid.uuid4", return_value=_FIXED_UUID):
+                        expected = _real_serving(
+                            merge_inline_system
+                        )._convert_to_chat_completion_request(serving_request)
+                        actual = utils.to_openai_request(utils_request, context=context)
+                    self.assertEqual(actual.model_dump(), expected.model_dump())
+
+    def test_conversion_failures_match_serving(self):
+        failure_payloads = {
+            "named_tool_missing": _payload(
+                [{"role": "user", "content": "q"}],
+                tools=_TOOLS,
+                tool_choice={"type": "tool", "name": "nope"},
+            ),
+            "required_without_tools": _payload(
+                [{"role": "user", "content": "q"}], tool_choice={"type": "any"}
+            ),
+        }
+        context = utils.AnthropicRequestContext(
+            merge_inline_system=True, **_ALL_FEATURES
+        )
+        for case, payload in sorted(failure_payloads.items()):
+            with self.subTest(case=case):
+                serving_request = AnthropicMessagesRequest.model_validate(payload)
+                with self.assertRaises(ValueError) as serving_error:
+                    _real_serving(True)._convert_to_chat_completion_request(
+                        serving_request
+                    )
+                utils_request = utils.parse_anthropic_request(
+                    json.dumps(payload).encode()
+                )
+                with self.assertRaises(utils.AnthropicRequestError) as utils_error:
+                    utils.to_openai_request(utils_request, context=context)
+                self.assertEqual(
+                    str(utils_error.exception), str(serving_error.exception)
+                )
+
+
+class TestRequestGoldens(unittest.TestCase):
+    """Absolute value pins for the gated launch surface.
+
+    The delegation matrix proves utils == serving at the same commit; these
+    goldens pin WHAT that shared behavior is, so a deliberate serving.py
+    semantic change must update them explicitly instead of moving both sides
+    of the delegation comparison silently.
+    """
+
+    def test_sampling_params_and_system(self):
+        dump = _convert(_REQUEST_CASES["text_system_sampling"])
+        self.assertEqual(
+            (dump["temperature"], dump["top_k"], dump["top_p"], dump["stop"]),
+            (0.5, 20, 0.9, ["END", "STOP"]),
+        )
+        self.assertEqual(dump["max_tokens"], 64)
+        self.assertIs(dump["stream"], False)
+        self.assertNotIn("stream_options", dump)
+        self.assertEqual(
+            dump["messages"],
+            [
+                {"role": "system", "content": "be brief"},
+                {"role": "user", "content": "hello"},
+            ],
+        )
+
+    def test_stream_true_sets_stream_options(self):
+        dump = _convert(_REQUEST_CASES["stream_with_options"])
+        self.assertIs(dump["stream"], True)
+        self.assertEqual(
+            dump["stream_options"],
+            {"include_usage": True, "continuous_usage_stats": True},
+        )
+
+    def test_system_blocks_and_inline_system_merge(self):
+        payload = _REQUEST_CASES["system_blocks_and_inline_system"]
+        merged = _convert(
+            payload, utils.AnthropicRequestContext(merge_inline_system=True)
+        )
+        self.assertEqual(
+            merged["messages"][0], {"role": "system", "content": "s1\ns2\ninline"}
+        )
+        self.assertEqual([m["role"] for m in merged["messages"]], ["system", "user"])
+
+        unmerged = _convert(
+            payload, utils.AnthropicRequestContext(merge_inline_system=False)
+        )
+        self.assertEqual(
+            unmerged["messages"][0], {"role": "system", "content": "s1\ns2"}
+        )
+        self.assertEqual(
+            [m["role"] for m in unmerged["messages"]], ["system", "user", "system"]
+        )
+
+    def test_tool_use_roundtrip_and_wire_order(self):
+        dump = _convert(_REQUEST_CASES["tool_roundtrip"])
+        self.assertEqual(
+            dump["messages"][1],
+            {
+                "role": "assistant",
+                "content": "checking",
+                "tool_calls": [
+                    {
+                        "id": "toolu_1",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": '{"city": "Paris"}',
+                        },
+                    }
+                ],
+            },
+        )
+        # Wire order preserved: user(pre) -> tool -> user(post); is_error is
+        # dropped from the OpenAI tool message.
+        self.assertEqual(dump["messages"][2], {"role": "user", "content": "pre"})
+        self.assertEqual(
+            dump["messages"][3],
+            {"role": "tool", "tool_call_id": "toolu_1", "content": "sunny"},
+        )
+        self.assertEqual(dump["messages"][4], {"role": "user", "content": "post"})
+        self.assertEqual(dump["tools"][0]["function"]["name"], "get_weather")
+
+    def test_tool_result_variants(self):
+        dump = _convert(
+            _payload(
+                [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "tool_result", "id": "legacy_id", "content": None}
+                        ],
+                    },
+                    {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": "t2",
+                                "content": "inner",
+                            }
+                        ],
+                    },
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": "t3",
+                                "content": [
+                                    {"type": "text", "text": "a"},
+                                    {"type": "text", "text": "b"},
+                                ],
+                            }
+                        ],
+                    },
+                ]
+            )
+        )
+        # None content -> ""; legacy ``id`` used as tool_call_id fallback.
+        self.assertEqual(
+            dump["messages"][0],
+            {"role": "tool", "tool_call_id": "legacy_id", "content": ""},
+        )
+        # Assistant-role tool_result folds into text.
+        self.assertEqual(
+            dump["messages"][1], {"role": "assistant", "content": "Tool result: inner"}
+        )
+        # Multi-text list keeps the parts list.
+        self.assertEqual(
+            dump["messages"][2]["content"],
+            [{"type": "text", "text": "a"}, {"type": "text", "text": "b"}],
+        )
+
+    def test_tool_choice_mappings(self):
+        msgs = [{"role": "user", "content": "q"}]
+        self.assertEqual(
+            _convert(_payload(msgs, tools=_TOOLS, tool_choice={"type": "any"}))[
+                "tool_choice"
+            ],
+            "required",
+        )
+        self.assertEqual(
+            _convert(_payload(msgs, tools=_TOOLS, tool_choice={"type": "none"}))[
+                "tool_choice"
+            ],
+            "none",
+        )
+        self.assertEqual(
+            _convert(
+                _payload(
+                    msgs,
+                    tools=_TOOLS,
+                    tool_choice={"type": "tool", "name": "get_weather"},
+                )
+            )["tool_choice"],
+            {"type": "function", "function": {"name": "get_weather"}},
+        )
+        self.assertEqual(_convert(_payload(msgs, tools=_TOOLS))["tool_choice"], "auto")
+        with self.assertRaisesRegex(
+            utils.AnthropicRequestError, "not in the forwarded tools list"
+        ):
+            _convert(
+                _payload(
+                    msgs, tools=_TOOLS, tool_choice={"type": "tool", "name": "missing"}
+                )
+            )
+        with self.assertRaisesRegex(
+            utils.AnthropicRequestError, "requires at least one custom"
+        ):
+            _convert(_payload(msgs, tool_choice={"type": "any"}))
+
+    def test_empty_text_and_empty_assistant_placeholders(self):
+        dump = _convert(_REQUEST_CASES["empty_placeholders"])
+        self.assertEqual(dump["messages"][0], {"role": "assistant", "content": ""})
+        self.assertEqual(dump["messages"][1], {"role": "assistant", "content": ""})
+
+
+class TestResponseDelegation(unittest.TestCase):
+    def test_matches_normally_constructed_serving(self):
+        for case in sorted(_RESPONSE_CASES):
+            with self.subTest(case=case):
+                message, finish_reason, usage = _RESPONSE_CASES[case]
+                response = _chat_response(message, finish_reason, usage)
+                with patch("uuid.uuid4", return_value=_FIXED_UUID):
+                    expected = _real_serving(True)._convert_response(response)
+                actual = utils.to_anthropic_response(
+                    response, id_factory=lambda: _FIXED_MSG_ID
+                )
+                self.assertEqual(actual.model_dump(), expected.model_dump())
+
+    def test_default_id_factory_keeps_wire_format(self):
+        result = utils.to_anthropic_response(_chat_response({"content": "hi"}))
+        self.assertRegex(result.id, r"^msg_[0-9a-f]{32}$")
+
+
+class TestResponseGoldens(unittest.TestCase):
+    """Absolute value pins for response conversion (see TestRequestGoldens)."""
+
+    def test_empty_choices_response(self):
+        no_choices = ChatCompletionResponse.model_validate(
+            {
+                "id": "c",
+                "object": "chat.completion",
+                "created": 1,
+                "model": "m",
+                "choices": [],
+                "usage": {
+                    "prompt_tokens": 0,
+                    "completion_tokens": 0,
+                    "total_tokens": 0,
+                },
+            }
+        )
+        result = utils.to_anthropic_response(no_choices, id_factory=lambda: "m")
+        self.assertEqual(result.stop_reason, "end_turn")
+        self.assertEqual([b.type for b in result.content], ["text"])
+        self.assertEqual(result.content[0].text, "")
+        self.assertEqual(
+            (result.usage.input_tokens, result.usage.output_tokens), (0, 0)
+        )
+
+    def test_block_order_and_invalid_json_tool_arguments(self):
+        message, finish_reason, _ = _RESPONSE_CASES["reasoning_and_tools"]
+        result = utils.to_anthropic_response(
+            _chat_response(message, finish_reason), id_factory=lambda: "m"
+        )
+        types = [(b.type, getattr(b, "name", None)) for b in result.content]
+        self.assertEqual(
+            types,
+            [("thinking", None), ("text", None), ("tool_use", "f"), ("tool_use", "g")],
+        )
+        self.assertEqual(result.content[2].input, {"a": 1})
+        # Invalid JSON arguments -> empty input, never a crash.
+        self.assertEqual(result.content[3].input, {})
+        self.assertEqual(result.stop_reason, "tool_use")
+
+    def test_stop_reason_mapping(self):
+        length = utils.to_anthropic_response(
+            _chat_response({"content": "x"}, "length"), id_factory=lambda: "m"
+        )
+        self.assertEqual(length.stop_reason, "max_tokens")
+        unmapped = utils.to_anthropic_response(
+            _chat_response({"content": "x"}, "content_filter"), id_factory=lambda: "m"
+        )
+        self.assertEqual(unmapped.stop_reason, "end_turn")
+
+
+class TestParse(unittest.TestCase):
+    def test_parse_failures_are_request_errors(self):
+        with self.assertRaisesRegex(utils.AnthropicRequestError, "invalid JSON body"):
+            utils.parse_anthropic_request(b"{not json")
+        with self.assertRaises(utils.AnthropicRequestError):
+            # missing required max_tokens
+            utils.parse_anthropic_request(
+                json.dumps({"model": "m", "messages": []}).encode()
+            )
+
+    def test_unknown_extra_keys_keep_pydantic_ignore_behavior(self):
+        payload = _payload(
+            [{"role": "user", "content": "hi", "unknown_msg_key": 1}],
+            unknown_top_key="x",
+        )
+        request = utils.parse_anthropic_request(json.dumps(payload).encode())
+        self.assertEqual(request.model, "claude-test")
+        self.assertFalse(hasattr(request, "unknown_top_key"))
+
+
+class TestFeatureGates(unittest.TestCase):
+    def test_disabled_features_fail_closed(self):
+        msgs = [{"role": "user", "content": "q"}]
+        cases = {
+            "thinking_param": _payload(
+                msgs, thinking={"type": "enabled", "budget_tokens": 2048}
+            ),
+            "output_config": _payload(msgs, output_config={"effort": "high"}),
+            "betas": _payload(msgs, betas=["b-1"]),
+            "image_block": _payload(
+                [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "image",
+                                "source": {"type": "base64", "data": "eA=="},
+                            }
+                        ],
+                    }
+                ]
+            ),
+            "thinking_block": _payload(
+                [
+                    {
+                        "role": "assistant",
+                        "content": [{"type": "thinking", "thinking": "t"}],
+                    }
+                ]
+            ),
+            "redacted_thinking_block": _payload(
+                [
+                    {
+                        "role": "assistant",
+                        "content": [{"type": "redacted_thinking", "data": "x"}],
+                    }
+                ]
+            ),
+            "search_result_block": _payload(
+                [{"role": "user", "content": [{"type": "search_result", "title": "t"}]}]
+            ),
+            "nested_tool_reference": _payload(
+                [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": "t",
+                                "content": [
+                                    {"type": "tool_reference", "tool_name": "f"}
+                                ],
+                            }
+                        ],
+                    }
+                ]
+            ),
+            "server_tool": _payload(
+                msgs, tools=[{"type": "web_search_20250305", "name": "web_search"}]
+            ),
+        }
+        for case, payload in sorted(cases.items()):
+            with self.subTest(case=case):
+                with self.assertRaises(utils.AnthropicRequestError):
+                    _convert(payload)
+
+    def test_thinking_rejected_even_with_all_gates_open(self):
+        context = utils.AnthropicRequestContext(
+            merge_inline_system=True, **_ALL_FEATURES
+        )
+        payload = _payload(
+            [{"role": "user", "content": "q"}],
+            thinking={"type": "enabled", "budget_tokens": 2048},
+        )
+        with self.assertRaises(utils.AnthropicRequestError):
+            _convert(payload, context)
+
+    def test_enabled_image_conversion(self):
+        context = utils.AnthropicRequestContext(
+            merge_inline_system=True, allow_images=True
+        )
+        dump = _convert(_REQUEST_CASES["images"], context)
+        parts = dump["messages"][0]["content"]
+        self.assertEqual([p["type"] for p in parts], ["text", "image_url", "image_url"])
+        self.assertEqual(parts[1]["image_url"]["url"], "data:image/jpeg;base64,eA==")
+        self.assertEqual(parts[2]["image_url"]["url"], "https://x/y.png")
+
+    def test_enabled_output_config_effort_mapping(self):
+        context = utils.AnthropicRequestContext(
+            merge_inline_system=True, allow_output_config=True
+        )
+        msgs = [{"role": "user", "content": "q"}]
+        high = _convert(_payload(msgs, output_config={"effort": "high"}), context)
+        xhigh = _convert(_payload(msgs, output_config={"effort": "xhigh"}), context)
+        self.assertEqual(high["reasoning_effort"], "high")
+        self.assertEqual(xhigh["reasoning_effort"], "max")
+
+    def test_enabled_server_tools_are_skipped_not_forwarded(self):
+        context = utils.AnthropicRequestContext(
+            merge_inline_system=True, allow_server_tools=True
+        )
+        dump = _convert(_REQUEST_CASES["server_tools_skipped"], context)
+        self.assertEqual(
+            [t["function"]["name"] for t in dump["tools"]], ["get_weather"]
+        )
+
+    def test_enabled_search_result_flattening(self):
+        context = utils.AnthropicRequestContext(
+            merge_inline_system=True, allow_search_results=True
+        )
+        dump = _convert(_REQUEST_CASES["search_result_block"], context)
+        self.assertEqual(
+            dump["messages"][0],
+            {"role": "user", "content": "Title: T\nSource: https://s\nContent: C"},
+        )
+
+    def test_enabled_tool_reference_translation(self):
+        context = utils.AnthropicRequestContext(
+            merge_inline_system=True, allow_tool_references=True
+        )
+        dump = _convert(
+            _payload(
+                [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": "t",
+                                "content": [
+                                    {
+                                        "type": "tool_reference",
+                                        "tool_name": "deferred_fn",
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ]
+            ),
+            context,
+        )
+        self.assertEqual(
+            dump["messages"][0]["content"],
+            [{"type": "tool_reference", "name": "deferred_fn"}],
+        )
+
+    def test_gate_depth_matches_conversion_depth_canary(self):
+        """Gated blocks nested at depth >= 2 (tool_result inside tool_result)
+        pass the closed gates today ONLY because conversion reads exactly one
+        nesting level and drops them — wire-safe by convention. The moment
+        serving.py deepens ``_convert_tool_result_content`` this fails: deepen
+        ``_iter_typed_content_blocks`` together with it."""
+        payload = _payload(
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "outer",
+                            "content": [
+                                {"type": "text", "text": "depth1"},
+                                {
+                                    "type": "tool_result",
+                                    "tool_use_id": "inner",
+                                    "content": [
+                                        {
+                                            "type": "image",
+                                            "source": {
+                                                "type": "base64",
+                                                "media_type": "image/png",
+                                                "data": "eA==",
+                                            },
+                                        }
+                                    ],
+                                },
+                            ],
+                        }
+                    ],
+                }
+            ]
+        )
+        dump = _convert(payload)  # closed gates: must not raise
+        self.assertEqual(
+            dump["messages"][0],
+            {"role": "tool", "tool_call_id": "outer", "content": "depth1"},
+        )
+        self.assertNotIn("image_url", json.dumps(dump))
+
+
+_ERROR_BODIES = [
+    b'{"error": "boom"}',
+    b'{"error": {"message": "m", "type": "custom_type"}}',
+    b'{"message": "top-level"}',
+    b"<html>gateway</html>",
+    b"",
+]
+
+
+class TestErrorConversion(unittest.TestCase):
+    def test_matches_serving_for_shared_statuses(self):
+        # Statuses present in serving.py's own ERROR_TYPE_MAP; 413/422 are
+        # composite additions with no serving.py equivalent (below).
+        for status in (400, 401, 403, 404, 408, 429, 500, 502, 503, 504):
+            for body in _ERROR_BODIES:
+                with self.subTest(status=status, body=body):
+                    serving_response = _real_serving(
+                        True
+                    )._convert_openai_error_response(
+                        SimpleNamespace(status_code=status, body=body)
+                    )
+                    self.assertEqual(serving_response.status_code, status)
+                    envelope = utils.to_anthropic_error(status, body)
+                    self.assertEqual(
+                        envelope.model_dump(), json.loads(bytes(serving_response.body))
+                    )
+
+    def test_composite_statuses_follow_http_layer_policy(self):
+        self.assertEqual(utils.ERROR_TYPE_MAP[413], "request_too_large")
+        self.assertEqual(utils.ERROR_TYPE_MAP[422], "invalid_request_error")
+        env_413 = utils.to_anthropic_error(413, b'{"error": "big"}')
+        self.assertEqual(
+            (env_413.error.type, env_413.error.message), ("request_too_large", "big")
+        )
+        env_422 = utils.to_anthropic_error(422, b'{"error": "bad"}')
+        self.assertEqual(
+            (env_422.error.type, env_422.error.message),
+            ("invalid_request_error", "bad"),
+        )
+        # The composite statuses share the full message policy: custom
+        # error.type honored for 4xx, empty body -> "Request failed".
+        custom = utils.to_anthropic_error(
+            413, b'{"error": {"message": "m", "type": "custom_type"}}'
+        )
+        self.assertEqual(
+            (custom.error.type, custom.error.message), ("custom_type", "m")
+        )
+        self.assertEqual(
+            utils.to_anthropic_error(422, b"").error.message, "Request failed"
+        )
+        # Unlisted statuses fall through to api_error in both sources.
+        self.assertEqual(
+            utils.to_anthropic_error(409, b'{"error": "conflict"}').error.type,
+            "api_error",
+        )
+
+    def test_message_policy_goldens(self):
+        """Absolute pins for the envelope message policy (see
+        TestRequestGoldens for why value pins accompany the delegation
+        matrix)."""
+        # 4xx keeps the parsed upstream message; custom error.type honored.
+        env = utils.to_anthropic_error(
+            400, b'{"error": {"message": "m", "type": "custom_type"}}'
+        )
+        self.assertEqual((env.error.type, env.error.message), ("custom_type", "m"))
+        # 5xx never echoes upstream detail or type.
+        env = utils.to_anthropic_error(
+            500, b'{"error": {"message": "secret", "type": "custom_type"}}'
+        )
+        self.assertEqual(
+            (env.error.type, env.error.message), ("api_error", "Internal server error")
+        )
+        # Empty-body fallbacks.
+        self.assertEqual(
+            utils.to_anthropic_error(400, b"").error.message, "Request failed"
+        )
+        self.assertEqual(
+            utils.to_anthropic_error(502, b"").error.message, "Internal server error"
+        )
+        # Non-JSON 4xx body passes through as a bounded hint.
+        self.assertEqual(
+            utils.to_anthropic_error(400, b"<html>gateway</html>").error.message,
+            "<html>gateway</html>",
+        )
+
+    def test_composite_map_matches_http_server_source(self):
+        """413/422 are a copy of the inline status->type dict in
+        ``http_server.py``'s ``/v1/messages`` exception handler, which is not
+        importable without loading the server app. Parse the source so a
+        policy change there fails loudly here instead of silently diverging
+        every external frontend."""
+        origin = importlib.util.find_spec("sglang.srt.entrypoints.http_server").origin
+        tree = ast.parse(Path(origin).read_text())
+        handler_maps = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Dict) or not node.keys:
+                continue
+            if not all(
+                key is not None
+                and isinstance(key, ast.Constant)
+                and isinstance(key.value, int)
+                for key in node.keys
+            ):
+                continue
+            mapping = {
+                key.value: value.value
+                for key, value in zip(node.keys, node.values)
+                if isinstance(value, ast.Constant)
+            }
+            if 413 in mapping and 422 in mapping:
+                handler_maps.append(mapping)
+        self.assertTrue(
+            handler_maps, "no status->type dict with 413/422 found in http_server.py"
+        )
+        for mapping in handler_maps:
+            for status, error_type in mapping.items():
+                self.assertEqual(
+                    utils.ERROR_TYPE_MAP.get(status, "api_error"),
+                    error_type,
+                    f"status {status} diverged from http_server.py policy",
+                )
+
+    def test_4xx_scrub_strips_traceback_lines_and_truncates(self):
+        upstream = "\n".join(
+            [
+                "Traceback (most recent call last):",
+                '  File "/app/handler.py", line 3, in run',
+                "real cause: " + "x" * 600,
+            ]
+        )
+        body = json.dumps({"error": {"message": upstream}}).encode()
+        message = utils.to_anthropic_error(400, body).error.message
+        self.assertNotIn("Traceback", message)
+        self.assertNotIn('File "/', message)
+        self.assertTrue(message.startswith("real cause: "))
+        self.assertEqual(len(message), 501)
+        self.assertTrue(message.endswith("…"))
+
+
+class TestFakeSse(unittest.TestCase):
+    def test_text_event_sequence_uses_request_model(self):
+        events = utils.to_anthropic_fake_sse_events(
+            _chat_response({"content": "hello"}),
+            model="claude-test",
+            id_factory=lambda: "msg_fixed",
+        )
+        self.assertEqual(
+            [e.type for e in events],
+            [
+                "message_start",
+                "content_block_start",
+                "content_block_delta",
+                "content_block_stop",
+                "message_delta",
+                "message_stop",
+            ],
+        )
+        start = events[0].message
+        # Model comes from the Anthropic request, not the backend alias.
+        self.assertEqual(start.model, "claude-test")
+        self.assertEqual(start.id, "msg_fixed")
+        self.assertEqual(start.content, [])
+        self.assertEqual(start.usage.input_tokens, 10)
+        self.assertEqual(start.usage.output_tokens, 0)
+        self.assertEqual(events[2].delta.text, "hello")
+        self.assertEqual(events[4].delta.stop_reason, "end_turn")
+        self.assertIsNone(events[4].usage.input_tokens)
+        self.assertEqual(events[4].usage.output_tokens, 5)
+
+    def test_multi_block_index_accounting(self):
+        events = utils.to_anthropic_fake_sse_events(
+            _chat_response(
+                {
+                    "content": "txt",
+                    "reasoning_content": "think",
+                    "tool_calls": [
+                        {
+                            "id": "c1",
+                            "type": "function",
+                            "function": {"name": "f", "arguments": '{"a": 1}'},
+                        },
+                        {
+                            "id": "c2",
+                            "type": "function",
+                            "function": {"name": "g", "arguments": ""},
+                        },
+                    ],
+                },
+                finish_reason="tool_calls",
+            ),
+            model="claude-test",
+            id_factory=lambda: "m",
+        )
+        starts = [e for e in events if e.type == "content_block_start"]
+        self.assertEqual(
+            [(e.index, e.content_block.type) for e in starts],
+            [(0, "thinking"), (1, "text"), (2, "tool_use"), (3, "tool_use")],
+        )
+        deltas = [e for e in events if e.type == "content_block_delta"]
+        # A zero-argument tool call emits no input_json_delta (live stream
+        # behavior).
+        self.assertEqual(
+            [(e.index, e.delta.type) for e in deltas],
+            [(0, "thinking_delta"), (1, "text_delta"), (2, "input_json_delta")],
+        )
+        self.assertEqual(deltas[2].delta.partial_json, '{"a": 1}')
+        stops = [e.index for e in events if e.type == "content_block_stop"]
+        self.assertEqual(stops, [0, 1, 2, 3])
+        self.assertEqual(events[-2].delta.stop_reason, "tool_use")
+        self.assertEqual(events[-1].type, "message_stop")
+
+    def test_unmapped_finish_reason_and_cached_usage(self):
+        events = utils.to_anthropic_fake_sse_events(
+            _chat_response(
+                {"content": "x"},
+                finish_reason="content_filter",
+                usage={
+                    "prompt_tokens": 10,
+                    "completion_tokens": 5,
+                    "total_tokens": 15,
+                    "prompt_tokens_details": {"cached_tokens": 4},
+                },
+            ),
+            model="claude-test",
+            id_factory=lambda: "m",
+        )
+        start_usage = events[0].message.usage
+        self.assertEqual(
+            (
+                start_usage.input_tokens,
+                start_usage.cache_read_input_tokens,
+                start_usage.output_tokens,
+            ),
+            (6, 4, 0),
+        )
+        message_delta = next(e for e in events if e.type == "message_delta")
+        # content_filter is unmapped and falls through to end_turn.
+        self.assertEqual(message_delta.delta.stop_reason, "end_turn")
+        self.assertIsNone(message_delta.usage.cache_read_input_tokens)
+        self.assertEqual(message_delta.usage.output_tokens, 5)
+
+
+class TestFakeSseEdgeCases(unittest.TestCase):
+    def test_empty_choices_emits_bare_envelope(self):
+        no_choices = ChatCompletionResponse.model_validate(
+            {
+                "id": "c",
+                "object": "chat.completion",
+                "created": 1,
+                "model": "m",
+                "choices": [],
+                "usage": {
+                    "prompt_tokens": 0,
+                    "completion_tokens": 0,
+                    "total_tokens": 0,
+                },
+            }
+        )
+        events = utils.to_anthropic_fake_sse_events(
+            no_choices, model="claude-test", id_factory=lambda: "m"
+        )
+        self.assertEqual(
+            [e.type for e in events], ["message_start", "message_delta", "message_stop"]
+        )
+        self.assertEqual(events[1].delta.stop_reason, "end_turn")
+
+
+class TestImportHygiene(unittest.TestCase):
+    def test_utils_import_loads_no_serving_runtime(self):
+        # External frontends import this module without a serving runtime;
+        # it must not pull the OpenAI serving chat, tokenizer manager, or
+        # engine (serving.py keeps OpenAIServingChat under TYPE_CHECKING).
+        code = (
+            "import sys\n"
+            "import sglang.srt.entrypoints.anthropic.utils\n"
+            "banned = ('sglang.srt.entrypoints.openai.serving_chat',\n"
+            "          'sglang.srt.managers.tokenizer_manager',\n"
+            "          'sglang.srt.entrypoints.engine')\n"
+            "loaded = [m for m in sys.modules for b in banned "
+            "if m == b or m.startswith(b + '.')]\n"
+            "assert not loaded, loaded\n"
+        )
+        subprocess.run([sys.executable, "-c", code], check=True, timeout=300)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test/registered/unit/entrypoints/anthropic/test_utils.py
+++ b/test/registered/unit/entrypoints/anthropic/test_utils.py
@@ -1,14 +1,12 @@
 """Tests for the standalone Anthropic conversion utilities.
 
-Request/response conversion in ``utils`` delegates to the original
-``AnthropicServing`` methods through a runtime-detached instance, so the
-delegation tests here compare against a normally constructed
-``AnthropicServing``: if the serving methods ever grow instance state that
-``__init__`` provides but the detached instance does not, these fail.
-Conversion semantics themselves are covered by ``test_serving.py``; the
-behavior tests below cover only what ``utils`` adds — feature gates, the
-composite error map, the envelope DTO seam, eager fake-SSE synthesis, and
-message-ID injection.
+Request/response conversion in ``utils`` and ``AnthropicServing`` shares
+module-level functions from ``serving.py``. The delegation tests verify the
+serving wrapper binds its runtime inputs consistently with the standalone
+path. Conversion semantics themselves are covered by ``test_serving.py``;
+the behavior tests below cover only what ``utils`` adds — feature gates,
+the composite error map, the envelope DTO seam, eager fake-SSE synthesis,
+and message-ID injection.
 """
 
 import ast

--- a/test/registered/unit/entrypoints/anthropic/test_utils.py
+++ b/test/registered/unit/entrypoints/anthropic/test_utils.py
@@ -1,12 +1,8 @@
-"""Tests for the standalone Anthropic conversion utilities.
+"""Tests for the Anthropic conversion seams used by external frontends.
 
-Request/response conversion in ``utils`` and ``AnthropicServing`` shares
-module-level functions from ``serving.py``. The delegation tests verify the
-serving wrapper binds its runtime inputs consistently with the standalone
-path. Conversion semantics themselves are covered by ``test_serving.py``;
-the behavior tests below cover only what ``utils`` adds — feature gates,
-the composite error map, the envelope DTO seam, eager fake-SSE synthesis,
-and message-ID injection.
+Request and response goldens call the public runtime-independent functions in
+serving.py directly. The utils-specific tests cover the composite error DTO,
+eager fake-SSE synthesis, and message-ID generation.
 """
 
 import ast
@@ -15,10 +11,8 @@ import json
 import subprocess
 import sys
 import unittest
-import uuid
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import patch
 
 from sglang.test.test_utils import maybe_stub_sgl_kernel
 
@@ -28,27 +22,15 @@ from sglang.srt.entrypoints.anthropic import utils  # noqa: E402
 from sglang.srt.entrypoints.anthropic.protocol import (  # noqa: E402
     AnthropicMessagesRequest,
 )
-from sglang.srt.entrypoints.anthropic.serving import AnthropicServing  # noqa: E402
+from sglang.srt.entrypoints.anthropic.serving import (  # noqa: E402
+    AnthropicServing,
+    convert_response,
+    convert_to_chat_completion_request,
+)
 from sglang.srt.entrypoints.openai.protocol import ChatCompletionResponse  # noqa: E402
 from sglang.test.ci.ci_register import register_cpu_ci  # noqa: E402
 
 register_cpu_ci(est_time=30, suite="base-a-test-cpu")
-
-_FIXED_UUID = uuid.UUID(int=0x1234)
-_FIXED_MSG_ID = f"msg_{_FIXED_UUID.hex}"
-
-# Permissive policy: the delegation matrix compares the conversion semantics
-# of every typed feature, so no gate may reject the fixtures.
-_ALL_FEATURES = dict(
-    allow_images=True,
-    allow_output_config=True,
-    allow_beta_fields=True,
-    allow_tool_references=True,
-    allow_search_results=True,
-    allow_server_tools=True,
-)
-
-_DEFAULT_CTX = utils.AnthropicRequestContext(merge_inline_system=True)
 
 
 class _FakeOpenAIServingChat:
@@ -76,9 +58,11 @@ def _payload(messages, **extra) -> dict:
     return {"model": "claude-test", "max_tokens": 64, "messages": messages, **extra}
 
 
-def _convert(payload: dict, context=_DEFAULT_CTX) -> dict:
-    request = utils.parse_anthropic_request(json.dumps(payload).encode())
-    openai_request = utils.to_openai_request(request, context=context)
+def _convert(payload: dict, merge_inline_system: bool = True) -> dict:
+    request = AnthropicMessagesRequest.model_validate(payload)
+    openai_request = convert_to_chat_completion_request(
+        request, merge_inline_system=merge_inline_system
+    )
     return openai_request.model_dump(mode="json", exclude_none=True, by_alias=True)
 
 
@@ -139,59 +123,6 @@ _REQUEST_CASES = {
         tools=_TOOLS,
         tool_choice={"type": "auto"},
     ),
-    "tool_result_variants": _payload(
-        [
-            {
-                "role": "user",
-                "content": [
-                    {"type": "tool_result", "id": "legacy_id", "content": None}
-                ],
-            },
-            {
-                "role": "assistant",
-                "content": [
-                    {"type": "tool_result", "tool_use_id": "t2", "content": "inner"}
-                ],
-            },
-            {
-                "role": "user",
-                "content": [
-                    {
-                        "type": "tool_result",
-                        "tool_use_id": "t3",
-                        "content": [
-                            {"type": "text", "text": "a"},
-                            {
-                                "type": "image",
-                                "source": {
-                                    "type": "base64",
-                                    "media_type": "image/png",
-                                    "data": "eA==",
-                                },
-                            },
-                            {"type": "tool_reference", "tool_name": "deferred_fn"},
-                            {
-                                "type": "search_result",
-                                "title": "T",
-                                "source": "https://s",
-                            },
-                        ],
-                    }
-                ],
-            },
-        ]
-    ),
-    "tool_choice_required": _payload(
-        [{"role": "user", "content": "q"}], tools=_TOOLS, tool_choice={"type": "any"}
-    ),
-    "tool_choice_named": _payload(
-        [{"role": "user", "content": "q"}],
-        tools=_TOOLS,
-        tool_choice={"type": "tool", "name": "get_weather"},
-    ),
-    "tool_choice_none": _payload(
-        [{"role": "user", "content": "q"}], tools=_TOOLS, tool_choice={"type": "none"}
-    ),
     "empty_placeholders": _payload(
         [
             {"role": "assistant", "content": [{"type": "text", "text": ""}]},
@@ -236,20 +167,9 @@ _REQUEST_CASES = {
             }
         ]
     ),
-    "output_config_and_betas": _payload(
-        [{"role": "user", "content": "q"}],
-        output_config={
-            "effort": "xhigh",
-            "task_budget": {"type": "tokens", "total": 1000},
-        },
-        betas=["thinking-2025-08-04"],
-    ),
     "server_tools_skipped": _payload(
         [{"role": "user", "content": "q"}],
         tools=[{"type": "web_search_20250305", "name": "web_search"}, *_TOOLS],
-    ),
-    "unknown_extra_keys": _payload(
-        [{"role": "user", "content": "hi", "unknown_msg_key": 1}], unknown_top_key="x"
     ),
 }
 
@@ -277,7 +197,6 @@ def _chat_response(
 
 
 _RESPONSE_CASES = {
-    "text": ({"content": "hi"}, "stop", None),
     "reasoning_and_tools": (
         {
             "content": "text",
@@ -298,81 +217,11 @@ _RESPONSE_CASES = {
         "tool_calls",
         None,
     ),
-    "empty_content": ({"content": ""}, "stop", None),
-    "length_stop": ({"content": "x"}, "length", None),
-    "unmapped_finish_reason": ({"content": "x"}, "content_filter", None),
-    "cached_usage": (
-        {"content": "hi"},
-        "stop",
-        {
-            "prompt_tokens": 10,
-            "completion_tokens": 5,
-            "total_tokens": 15,
-            "prompt_tokens_details": {"cached_tokens": 4},
-        },
-    ),
 }
 
 
-class TestRequestDelegation(unittest.TestCase):
-    def test_matches_normally_constructed_serving(self):
-        for case in sorted(_REQUEST_CASES):
-            for merge_inline_system in (True, False):
-                with self.subTest(case=case, merge_inline_system=merge_inline_system):
-                    payload = _REQUEST_CASES[case]
-                    serving_request = AnthropicMessagesRequest.model_validate(payload)
-                    utils_request = utils.parse_anthropic_request(
-                        json.dumps(payload).encode()
-                    )
-                    context = utils.AnthropicRequestContext(
-                        merge_inline_system=merge_inline_system, **_ALL_FEATURES
-                    )
-                    with patch("uuid.uuid4", return_value=_FIXED_UUID):
-                        expected = _real_serving(
-                            merge_inline_system
-                        )._convert_to_chat_completion_request(serving_request)
-                        actual = utils.to_openai_request(utils_request, context=context)
-                    self.assertEqual(actual.model_dump(), expected.model_dump())
-
-    def test_conversion_failures_match_serving(self):
-        failure_payloads = {
-            "named_tool_missing": _payload(
-                [{"role": "user", "content": "q"}],
-                tools=_TOOLS,
-                tool_choice={"type": "tool", "name": "nope"},
-            ),
-            "required_without_tools": _payload(
-                [{"role": "user", "content": "q"}], tool_choice={"type": "any"}
-            ),
-        }
-        context = utils.AnthropicRequestContext(
-            merge_inline_system=True, **_ALL_FEATURES
-        )
-        for case, payload in sorted(failure_payloads.items()):
-            with self.subTest(case=case):
-                serving_request = AnthropicMessagesRequest.model_validate(payload)
-                with self.assertRaises(ValueError) as serving_error:
-                    _real_serving(True)._convert_to_chat_completion_request(
-                        serving_request
-                    )
-                utils_request = utils.parse_anthropic_request(
-                    json.dumps(payload).encode()
-                )
-                with self.assertRaises(utils.AnthropicRequestError) as utils_error:
-                    utils.to_openai_request(utils_request, context=context)
-                self.assertEqual(
-                    str(utils_error.exception), str(serving_error.exception)
-                )
-
-
 class TestRequestGoldens(unittest.TestCase):
-    """Absolute value pins for the gated launch surface.
-
-    The delegation matrix proves utils == serving at the same commit; these
-    goldens pin WHAT that shared behavior is, so a deliberate serving.py
-    semantic change must update them explicitly instead of moving both sides
-    of the delegation comparison silently.
-    """
+    """Absolute value pins for the public request converter."""
 
     def test_sampling_params_and_system(self):
         dump = _convert(_REQUEST_CASES["text_system_sampling"])
@@ -401,17 +250,13 @@ class TestRequestGoldens(unittest.TestCase):
 
     def test_system_blocks_and_inline_system_merge(self):
         payload = _REQUEST_CASES["system_blocks_and_inline_system"]
-        merged = _convert(
-            payload, utils.AnthropicRequestContext(merge_inline_system=True)
-        )
+        merged = _convert(payload, merge_inline_system=True)
         self.assertEqual(
             merged["messages"][0], {"role": "system", "content": "s1\ns2\ninline"}
         )
         self.assertEqual([m["role"] for m in merged["messages"]], ["system", "user"])
 
-        unmerged = _convert(
-            payload, utils.AnthropicRequestContext(merge_inline_system=False)
-        )
+        unmerged = _convert(payload, merge_inline_system=False)
         self.assertEqual(
             unmerged["messages"][0], {"role": "system", "content": "s1\ns2"}
         )
@@ -524,17 +369,13 @@ class TestRequestGoldens(unittest.TestCase):
             {"type": "function", "function": {"name": "get_weather"}},
         )
         self.assertEqual(_convert(_payload(msgs, tools=_TOOLS))["tool_choice"], "auto")
-        with self.assertRaisesRegex(
-            utils.AnthropicRequestError, "not in the forwarded tools list"
-        ):
+        with self.assertRaisesRegex(ValueError, "not in the forwarded tools list"):
             _convert(
                 _payload(
                     msgs, tools=_TOOLS, tool_choice={"type": "tool", "name": "missing"}
                 )
             )
-        with self.assertRaisesRegex(
-            utils.AnthropicRequestError, "requires at least one custom"
-        ):
+        with self.assertRaisesRegex(ValueError, "requires at least one custom"):
             _convert(_payload(msgs, tool_choice={"type": "any"}))
 
     def test_empty_text_and_empty_assistant_placeholders(self):
@@ -543,26 +384,12 @@ class TestRequestGoldens(unittest.TestCase):
         self.assertEqual(dump["messages"][1], {"role": "assistant", "content": ""})
 
 
-class TestResponseDelegation(unittest.TestCase):
-    def test_matches_normally_constructed_serving(self):
-        for case in sorted(_RESPONSE_CASES):
-            with self.subTest(case=case):
-                message, finish_reason, usage = _RESPONSE_CASES[case]
-                response = _chat_response(message, finish_reason, usage)
-                with patch("uuid.uuid4", return_value=_FIXED_UUID):
-                    expected = _real_serving(True)._convert_response(response)
-                actual = utils.to_anthropic_response(
-                    response, id_factory=lambda: _FIXED_MSG_ID
-                )
-                self.assertEqual(actual.model_dump(), expected.model_dump())
+class TestResponseGoldens(unittest.TestCase):
+    """Absolute value pins for the public response converter."""
 
     def test_default_id_factory_keeps_wire_format(self):
-        result = utils.to_anthropic_response(_chat_response({"content": "hi"}))
+        result = convert_response(_chat_response({"content": "hi"}))
         self.assertRegex(result.id, r"^msg_[0-9a-f]{32}$")
-
-
-class TestResponseGoldens(unittest.TestCase):
-    """Absolute value pins for response conversion (see TestRequestGoldens)."""
 
     def test_empty_choices_response(self):
         no_choices = ChatCompletionResponse.model_validate(
@@ -579,7 +406,7 @@ class TestResponseGoldens(unittest.TestCase):
                 },
             }
         )
-        result = utils.to_anthropic_response(no_choices, id_factory=lambda: "m")
+        result = convert_response(no_choices)
         self.assertEqual(result.stop_reason, "end_turn")
         self.assertEqual([b.type for b in result.content], ["text"])
         self.assertEqual(result.content[0].text, "")
@@ -589,170 +416,61 @@ class TestResponseGoldens(unittest.TestCase):
 
     def test_block_order_and_invalid_json_tool_arguments(self):
         message, finish_reason, _ = _RESPONSE_CASES["reasoning_and_tools"]
-        result = utils.to_anthropic_response(
-            _chat_response(message, finish_reason), id_factory=lambda: "m"
-        )
+        result = convert_response(_chat_response(message, finish_reason))
         types = [(b.type, getattr(b, "name", None)) for b in result.content]
         self.assertEqual(
             types,
             [("thinking", None), ("text", None), ("tool_use", "f"), ("tool_use", "g")],
         )
         self.assertEqual(result.content[2].input, {"a": 1})
-        # Invalid JSON arguments -> empty input, never a crash.
         self.assertEqual(result.content[3].input, {})
         self.assertEqual(result.stop_reason, "tool_use")
 
     def test_stop_reason_mapping(self):
-        length = utils.to_anthropic_response(
-            _chat_response({"content": "x"}, "length"), id_factory=lambda: "m"
-        )
+        length = convert_response(_chat_response({"content": "x"}, "length"))
         self.assertEqual(length.stop_reason, "max_tokens")
-        unmapped = utils.to_anthropic_response(
-            _chat_response({"content": "x"}, "content_filter"), id_factory=lambda: "m"
-        )
+        unmapped = convert_response(_chat_response({"content": "x"}, "content_filter"))
         self.assertEqual(unmapped.stop_reason, "end_turn")
 
 
-class TestParse(unittest.TestCase):
-    def test_parse_failures_are_request_errors(self):
-        with self.assertRaisesRegex(utils.AnthropicRequestError, "invalid JSON body"):
-            utils.parse_anthropic_request(b"{not json")
-        with self.assertRaises(utils.AnthropicRequestError):
-            # missing required max_tokens
-            utils.parse_anthropic_request(
-                json.dumps({"model": "m", "messages": []}).encode()
-            )
-
+class TestExtendedRequestGoldens(unittest.TestCase):
     def test_unknown_extra_keys_keep_pydantic_ignore_behavior(self):
         payload = _payload(
             [{"role": "user", "content": "hi", "unknown_msg_key": 1}],
             unknown_top_key="x",
         )
-        request = utils.parse_anthropic_request(json.dumps(payload).encode())
+        request = AnthropicMessagesRequest.model_validate(payload)
         self.assertEqual(request.model, "claude-test")
         self.assertFalse(hasattr(request, "unknown_top_key"))
 
-
-class TestFeatureGates(unittest.TestCase):
-    def test_disabled_features_fail_closed(self):
-        msgs = [{"role": "user", "content": "q"}]
-        cases = {
-            "thinking_param": _payload(
-                msgs, thinking={"type": "enabled", "budget_tokens": 2048}
-            ),
-            "output_config": _payload(msgs, output_config={"effort": "high"}),
-            "betas": _payload(msgs, betas=["b-1"]),
-            "image_block": _payload(
-                [
-                    {
-                        "role": "user",
-                        "content": [
-                            {
-                                "type": "image",
-                                "source": {"type": "base64", "data": "eA=="},
-                            }
-                        ],
-                    }
-                ]
-            ),
-            "thinking_block": _payload(
-                [
-                    {
-                        "role": "assistant",
-                        "content": [{"type": "thinking", "thinking": "t"}],
-                    }
-                ]
-            ),
-            "redacted_thinking_block": _payload(
-                [
-                    {
-                        "role": "assistant",
-                        "content": [{"type": "redacted_thinking", "data": "x"}],
-                    }
-                ]
-            ),
-            "search_result_block": _payload(
-                [{"role": "user", "content": [{"type": "search_result", "title": "t"}]}]
-            ),
-            "nested_tool_reference": _payload(
-                [
-                    {
-                        "role": "user",
-                        "content": [
-                            {
-                                "type": "tool_result",
-                                "tool_use_id": "t",
-                                "content": [
-                                    {"type": "tool_reference", "tool_name": "f"}
-                                ],
-                            }
-                        ],
-                    }
-                ]
-            ),
-            "server_tool": _payload(
-                msgs, tools=[{"type": "web_search_20250305", "name": "web_search"}]
-            ),
-        }
-        for case, payload in sorted(cases.items()):
-            with self.subTest(case=case):
-                with self.assertRaises(utils.AnthropicRequestError):
-                    _convert(payload)
-
-    def test_thinking_rejected_even_with_all_gates_open(self):
-        context = utils.AnthropicRequestContext(
-            merge_inline_system=True, **_ALL_FEATURES
-        )
-        payload = _payload(
-            [{"role": "user", "content": "q"}],
-            thinking={"type": "enabled", "budget_tokens": 2048},
-        )
-        with self.assertRaises(utils.AnthropicRequestError):
-            _convert(payload, context)
-
-    def test_enabled_image_conversion(self):
-        context = utils.AnthropicRequestContext(
-            merge_inline_system=True, allow_images=True
-        )
-        dump = _convert(_REQUEST_CASES["images"], context)
+    def test_image_conversion(self):
+        dump = _convert(_REQUEST_CASES["images"])
         parts = dump["messages"][0]["content"]
         self.assertEqual([p["type"] for p in parts], ["text", "image_url", "image_url"])
         self.assertEqual(parts[1]["image_url"]["url"], "data:image/jpeg;base64,eA==")
         self.assertEqual(parts[2]["image_url"]["url"], "https://x/y.png")
 
-    def test_enabled_output_config_effort_mapping(self):
-        context = utils.AnthropicRequestContext(
-            merge_inline_system=True, allow_output_config=True
-        )
+    def test_output_config_effort_mapping(self):
         msgs = [{"role": "user", "content": "q"}]
-        high = _convert(_payload(msgs, output_config={"effort": "high"}), context)
-        xhigh = _convert(_payload(msgs, output_config={"effort": "xhigh"}), context)
+        high = _convert(_payload(msgs, output_config={"effort": "high"}))
+        xhigh = _convert(_payload(msgs, output_config={"effort": "xhigh"}))
         self.assertEqual(high["reasoning_effort"], "high")
         self.assertEqual(xhigh["reasoning_effort"], "max")
 
-    def test_enabled_server_tools_are_skipped_not_forwarded(self):
-        context = utils.AnthropicRequestContext(
-            merge_inline_system=True, allow_server_tools=True
-        )
-        dump = _convert(_REQUEST_CASES["server_tools_skipped"], context)
+    def test_server_tools_are_skipped_not_forwarded(self):
+        dump = _convert(_REQUEST_CASES["server_tools_skipped"])
         self.assertEqual(
-            [t["function"]["name"] for t in dump["tools"]], ["get_weather"]
+            [tool["function"]["name"] for tool in dump["tools"]], ["get_weather"]
         )
 
-    def test_enabled_search_result_flattening(self):
-        context = utils.AnthropicRequestContext(
-            merge_inline_system=True, allow_search_results=True
-        )
-        dump = _convert(_REQUEST_CASES["search_result_block"], context)
+    def test_search_result_flattening(self):
+        dump = _convert(_REQUEST_CASES["search_result_block"])
         self.assertEqual(
             dump["messages"][0],
             {"role": "user", "content": "Title: T\nSource: https://s\nContent: C"},
         )
 
-    def test_enabled_tool_reference_translation(self):
-        context = utils.AnthropicRequestContext(
-            merge_inline_system=True, allow_tool_references=True
-        )
+    def test_nested_tool_reference_translation(self):
         dump = _convert(
             _payload(
                 [
@@ -772,56 +490,12 @@ class TestFeatureGates(unittest.TestCase):
                         ],
                     }
                 ]
-            ),
-            context,
+            )
         )
         self.assertEqual(
             dump["messages"][0]["content"],
             [{"type": "tool_reference", "name": "deferred_fn"}],
         )
-
-    def test_gate_depth_matches_conversion_depth_canary(self):
-        """Gated blocks nested at depth >= 2 (tool_result inside tool_result)
-        pass the closed gates today ONLY because conversion reads exactly one
-        nesting level and drops them — wire-safe by convention. The moment
-        serving.py deepens ``_convert_tool_result_content`` this fails: deepen
-        ``_iter_typed_content_blocks`` together with it."""
-        payload = _payload(
-            [
-                {
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "tool_result",
-                            "tool_use_id": "outer",
-                            "content": [
-                                {"type": "text", "text": "depth1"},
-                                {
-                                    "type": "tool_result",
-                                    "tool_use_id": "inner",
-                                    "content": [
-                                        {
-                                            "type": "image",
-                                            "source": {
-                                                "type": "base64",
-                                                "media_type": "image/png",
-                                                "data": "eA==",
-                                            },
-                                        }
-                                    ],
-                                },
-                            ],
-                        }
-                    ],
-                }
-            ]
-        )
-        dump = _convert(payload)  # closed gates: must not raise
-        self.assertEqual(
-            dump["messages"][0],
-            {"role": "tool", "tool_call_id": "outer", "content": "depth1"},
-        )
-        self.assertNotIn("image_url", json.dumps(dump))
 
 
 _ERROR_BODIES = [
@@ -964,6 +638,12 @@ class TestErrorConversion(unittest.TestCase):
 
 
 class TestFakeSse(unittest.TestCase):
+    def test_default_id_factory_keeps_wire_format(self):
+        events = utils.to_anthropic_fake_sse_events(
+            _chat_response({"content": "hello"}), model="claude-test"
+        )
+        self.assertRegex(events[0].message.id, r"^msg_[0-9a-f]{32}$")
+
     def test_text_event_sequence_uses_request_model(self):
         events = utils.to_anthropic_fake_sse_events(
             _chat_response({"content": "hello"}),


### PR DESCRIPTION
## Summary
Expose SGLang's Anthropic/OpenAI conversion for reuse by external frontends.

## Motivation
External OpenAI-compatible frontends that must interpret Anthropic Messages exactly as this server does (e.g. [Miles PR #2358](https://github.com/radixark/miles/pull/2358)) previously had to vendor `protocol.py`/`serving.py` and maintain a derived codec, plus a sync ledger to keep the copies honest. This gives the server and external callers one conversion implementation, maintained here.

## Usage
An external handler validates `AnthropicMessagesRequest`, then wraps its own OpenAI path with the shared converters:

```python
from sglang.srt.entrypoints.anthropic.serving import (
    convert_response,
    convert_to_chat_completion_request,
)

chat_request = convert_to_chat_completion_request(
    anthropic_request,
    merge_inline_system=merge_inline_system,
)
chat_response = await openai_backend(chat_request)
anthropic_response = convert_response(chat_response)
```

The result uses the same conversion as SGLang's `/v1/messages`; endpoint validation, routing, and transport remain caller-owned.

## Design Notes
- **Mental model:** An external `/v1/messages` handler parses `AnthropicMessagesRequest`; passes its deployment's `merge_inline_system` choice plus optional reasoning callbacks into `convert_to_chat_completion_request`; runs the resulting `ChatCompletionRequest` through its OpenAI-compatible backend; then converts the completed response with `convert_response` or `to_anthropic_fake_sse_events`. SGLang owns format conversion; the caller owns endpoint policy, session state, and transport.
- **Runtime boundary:** `convert_to_chat_completion_request` receives request data plus explicit inline-system policy and optional reasoning hooks; `convert_response` is data-only. `AnthropicServing` invokes both while supplying hooks from `OpenAIServingChat`, preserving server routing plus live streaming.
- **Utility boundary:** `utils.py` contains Anthropic error-envelope mapping plus eager fake-SSE construction from a completed OpenAI response. Raw-body parsing, feature policy, routing, and state remain caller-owned; no fake serving instance, `AnthropicRequestContext`, or `allow_*` matrix is exposed.
- **Streaming boundary:** Eager fake SSE materializes one delta per block after completion; SGLang's token-by-token streaming path is unchanged.

## Verification
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=python python -m pytest -p no:cacheprovider -q test/registered/unit/entrypoints/anthropic/test_utils.py test/registered/unit/entrypoints/anthropic/test_serving.py`: `84 passed, 55 subtests passed`; covers request/response goldens, existing serving behavior, error mapping, fake SSE, and import hygiene.
- Miles `tests/fast/router/test_session_anthropic.py` plus `tests/fast/utils/test_utils/test_mock_sglang_server.py`: `58 passed, 1 skipped`; verifies the paired session/TITO integration.
- `pre-commit run --files python/sglang/srt/entrypoints/anthropic/utils.py test/registered/unit/entrypoints/anthropic/test_utils.py`: passed.

## Review Focus
- `convert_to_chat_completion_request` / `AnthropicServing`: reasoning-callback injection and preservation of server conversion behavior.
- `utils.py`: error mapping, message scrubbing, and the eager fake-SSE boundary.
- Cross-repo ABI with Miles #2358: `merge_inline_system`, request/response types, and completed-response streaming.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33150255041](https://github.com/sgl-project/sglang/actions/runs/33150255041)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33150254812](https://github.com/sgl-project/sglang/actions/runs/33150254812)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33150255067](https://github.com/sgl-project/sglang/actions/runs/33150255067)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->