### PR TITLE
[Kernel] Fuse W4A8 DeepEP quantization with permutation

### DIFF
--- a/python/sglang/kernels/ops/moe/ep_moe_kernels.py
+++ b/python/sglang/kernels/ops/moe/ep_moe_kernels.py
@@ -89,6 +89,9 @@ def deepep_permute_triton_kernel(
 ):
     OutDtype = gateup_input_ptr.dtype.element_ty
 
+    if a1_scales_ptr is not None:
+        inv_a1_scale = 1.0 / tl.load(a1_scales_ptr)
+
     src_idx = tl.program_id(0)
     src2dst_ptr = src2dst_ptr + src_idx * topk
     topk_ids_ptr = topk_ids_ptr + src_idx * topk
@@ -98,7 +101,14 @@ def deepep_permute_triton_kernel(
     for start_offset in tl.range(0, hidden_size, BLOCK_SIZE):
         offset = start_offset + tl.arange(0, BLOCK_SIZE)
         mask = offset < hidden_size
-        in_data = tl.load(src_ptr + offset, mask=mask).to(OutDtype)
+        in_data = tl.load(src_ptr + offset, mask=mask)
+        if a1_scales_ptr is not None:
+            in_data = tl.clamp(
+                in_data.to(tl.float32) * inv_a1_scale,
+                -448.0,
+                448.0,
+            )
+        in_data = in_data.to(OutDtype)
 
         for idx in range(topk):
             dst_idx = tl.load(src2dst_ptr + idx).to(tl.int64)

--- a/python/sglang/srt/layers/moe/cutlass_w4a8_moe.py
+++ b/python/sglang/srt/layers/moe/cutlass_w4a8_moe.py
@@ -332,26 +332,21 @@ def cutlass_w4a8_moe_deepep_normal(
         topk_ids_, num_experts
     )
     num_total_tokens = reorder_topk_ids.numel()
-    gateup_input_pre_reorder = torch.empty(
+    gateup_input = torch.empty(
         (int(num_total_tokens), a.shape[1]),
         device=device,
-        dtype=a.dtype,
+        dtype=torch.float8_e4m3fn,
     )
     deepep_permute_triton_kernel[(a.shape[0],)](
         a,
-        gateup_input_pre_reorder,
+        gateup_input,
         src2dst,
         topk_ids_.to(torch.int64),
-        None,
+        a1_scale.float(),
         topk,
         a.shape[1],
         BLOCK_SIZE=512,
     )
-    gateup_input = torch.empty(
-        gateup_input_pre_reorder.shape, dtype=torch.float8_e4m3fn, device=device
-    )
-    per_tensor_quant_fp8(gateup_input_pre_reorder, gateup_input, a1_scale.float(), True)
-    del gateup_input_pre_reorder
     local_topk_ids = topk_ids_
     local_topk_ids = (
         torch.where(local_topk_ids == -1, num_experts, topk_ids_).to(torch.int32)

--- a/test/registered/kernels/ops/moe/test_deepep_quant_permute.py
+++ b/test/registered/kernels/ops/moe/test_deepep_quant_permute.py
@@ -1,0 +1,80 @@
+import sys
+
+import pytest
+import torch
+
+from sglang.kernels.ops.moe.ep_moe_kernels import deepep_permute_triton_kernel
+from sglang.kernels.ops.quantization.per_tensor_quant_fp8 import (
+    per_tensor_quant_fp8,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=12, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+
+def _routing(num_tokens: int, topk: int):
+    topk_ids = torch.zeros((num_tokens, topk), dtype=torch.int64)
+    invalid = (torch.arange(num_tokens * topk).reshape(num_tokens, topk) + 1) % 5 == 0
+    topk_ids[invalid] = -1
+
+    src2dst = torch.full((num_tokens, topk), -1, dtype=torch.int64)
+    num_valid = int((~invalid).sum().item())
+    src2dst[~invalid] = torch.randperm(num_valid, dtype=torch.int64)
+    return topk_ids.cuda(), src2dst.cuda(), num_valid
+
+
+@pytest.mark.parametrize("num_tokens", [1, 7, 33])
+@pytest.mark.parametrize("hidden_size", [128, 512, 7168])
+@pytest.mark.parametrize("topk", [1, 2, 8])
+def test_deepep_quant_permute_matches_permute_then_quant(
+    num_tokens: int,
+    hidden_size: int,
+    topk: int,
+):
+    torch.manual_seed(num_tokens * 1000 + hidden_size + topk)
+    input = torch.randn((num_tokens, hidden_size), device="cuda", dtype=torch.bfloat16)
+    input[0, 0] = 500.0
+    scale = torch.tensor([0.75], device="cuda", dtype=torch.float32)
+    topk_ids, src2dst, num_valid = _routing(num_tokens, topk)
+
+    permuted = torch.empty(
+        (num_valid, hidden_size), device="cuda", dtype=torch.bfloat16
+    )
+    deepep_permute_triton_kernel[(num_tokens,)](
+        input,
+        permuted,
+        src2dst,
+        topk_ids,
+        None,
+        topk,
+        hidden_size,
+        BLOCK_SIZE=512,
+    )
+    flat_src2dst = src2dst.view(-1)
+    valid = flat_src2dst >= 0
+    source_rows = torch.arange(num_tokens, device="cuda").repeat_interleave(topk)
+    expected_permuted = torch.empty_like(permuted)
+    expected_permuted[flat_src2dst[valid]] = input[source_rows[valid]]
+    assert torch.equal(permuted, expected_permuted)
+
+    reference = torch.empty_like(permuted, dtype=torch.float8_e4m3fn)
+    per_tensor_quant_fp8(permuted, reference, scale, is_static=True)
+
+    fused = torch.empty_like(reference)
+    deepep_permute_triton_kernel[(num_tokens,)](
+        input,
+        fused,
+        src2dst,
+        topk_ids,
+        scale,
+        topk,
+        hidden_size,
+        BLOCK_SIZE=512,
+    )
+    torch.cuda.synchronize()
+
+    assert torch.equal(fused.view(torch.uint8), reference.view(torch.uint8))
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v", "-s"]))

--- a/test/registered/unit/layers/moe/test_w4afp8_deepep_post_reorder.py
+++ b/test/registered/unit/layers/moe/test_w4afp8_deepep_post_reorder.py
@@ -57,7 +57,22 @@ class TestW4AFP8DeepEPNormalPostReorder(CustomTestCase):
             self.assertEqual(BLOCK_SIZE, 512)
             output.zero_()
 
-        noop_launcher = _KernelLauncher(lambda *args, **kwargs: None)
+        def fake_permute(
+            _input,
+            output,
+            _src2dst,
+            _topk_ids,
+            scale,
+            _topk,
+            _hidden_size,
+            *,
+            BLOCK_SIZE,
+        ):
+            self.assertEqual(output.dtype, torch.float8_e4m3fn)
+            self.assertIs(scale, layer.w13_input_scale)
+            self.assertEqual(BLOCK_SIZE, 512)
+
+        permute_launcher = _KernelLauncher(fake_permute)
         post_reorder_launcher = _KernelLauncher(fake_post_reorder)
         preprocess_result = (
             torch.arange(num_tokens * topk),
@@ -82,6 +97,7 @@ class TestW4AFP8DeepEPNormalPostReorder(CustomTestCase):
             w13_input_scale=torch.ones(1),
             w2_input_scale=torch.ones(1),
         )
+        per_tensor_quant = Mock()
 
         with (
             patch.object(
@@ -89,7 +105,7 @@ class TestW4AFP8DeepEPNormalPostReorder(CustomTestCase):
                 "deepep_run_moe_deep_preprocess",
                 return_value=preprocess_result,
             ),
-            patch.object(w4a8_moe, "deepep_permute_triton_kernel", noop_launcher),
+            patch.object(w4a8_moe, "deepep_permute_triton_kernel", permute_launcher),
             patch.object(
                 w4a8_moe,
                 "deepep_post_reorder_triton_kernel",
@@ -110,7 +126,7 @@ class TestW4AFP8DeepEPNormalPostReorder(CustomTestCase):
             patch.object(
                 w4a8_moe,
                 "per_tensor_quant_fp8",
-                new=lambda *args, **kwargs: None,
+                new=per_tensor_quant,
             ),
             patch.object(w4a8_moe, "silu_and_mul", new=lambda *args, **kwargs: None),
         ):
@@ -139,6 +155,7 @@ class TestW4AFP8DeepEPNormalPostReorder(CustomTestCase):
 
         self.assertEqual(output.shape, (num_tokens, hidden_size))
         self.assertEqual(output.dtype, torch.bfloat16)
+        per_tensor_quant.assert_called_once()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Incremental review:** [Files changed](https://github.com/sgl-project/sglang/pull/35131/files) against `main`.

## Motivation

The W4A8 DeepEP-normal path currently permutes BF16 activations into an expert-ordered temporary, then launches a second kernel to quantize that entire temporary to FP8. This reads and writes the reordered activations twice, keeps a full BF16 buffer live, and adds one launch on the latency-sensitive MoE path.

## Modifications

- Make `deepep_permute_triton_kernel` optionally apply the static reciprocal input scale, clamp to the FP8 E4M3 range, and cast while scattering tokens into expert order.
- Allocate the final FP8 `gateup_input` directly in `cutlass_w4a8_moe_deepep_normal`, removing the BF16 reordered temporary and standalone input quantization launch.
- Preserve the existing unscaled behavior when the scale pointer is `None`, as used by the generic `moe_permute` path.
- Add a CUDA regression test covering random reorder mappings, invalid assignments, top-k variants, token counts, and hidden sizes, plus a CPU call-contract assertion for the DeepEP-normal path.

## Accuracy Tests

Tested on 1x NVIDIA H100 80GB (CUDA 13.0, PyTorch 2.11.0). The fused output is bitwise identical to the previous `permute -> static per-tensor FP8 quant` sequence for all 27 combinations of:

- `num_tokens`: 1, 7, 33
- `hidden_size`: 128, 512, 7168
- `topk`: 1, 2, 8
- random destination permutations and `-1` invalid assignments

```text
28 passed, 15 warnings in 8.46s
```

This includes 27 CUDA kernel cases and one CPU host-side call-contract test.

## Speed Tests and Profiling

H100 80GB microbenchmark, CUDA events, 50 warmups, median of 5 runs with 500 iterations per run. Output buffers were preallocated for both paths.

| Tokens | Hidden | Top-k | Old (us) | Fused (us) | Speedup | BF16 temporary removed |
|---:|---:|---:|---:|---:|---:|---:|
| 1 | 7168 | 1 | 19.835 | 10.374 | 1.912x | 0.014 MiB |
| 8 | 7168 | 2 | 19.566 | 10.206 | 1.917x | 0.219 MiB |
| 32 | 7168 | 8 | 19.436 | 10.337 | 1.880x | 3.500 MiB |
| 128 | 7168 | 8 | 19.237 | 10.307 | 1.866x | 14.000 MiB |

The input preparation changes from two kernel launches to one. The removed temporary is `num_routed_assignments * hidden_size * sizeof(bfloat16)` bytes.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (N/A: internal kernel optimization with no user-facing API change.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33374514706](https://github.com/sgl-project/sglang/actions/runs/33374514706)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33374514449](https://github.com/sgl-project/sglang/actions/runs/33374514449)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33374514741](https://github.com/sgl-project/sglang/actions/runs/33374514741)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->