### PR TITLE
Disagg: enqueue middle prefill KV transfer after launch

### DIFF
--- a/python/sglang/srt/disaggregation/base/conn.py
+++ b/python/sglang/srt/disaggregation/base/conn.py
@@ -137,9 +137,13 @@ class BaseKVSender(ABC):
         kv_indices: npt.NDArray[np.int32],
         state_indices: Optional[List] = None,
         num_kv_tokens: Optional[int] = None,
+        wait_event: Optional[object] = None,
     ):
         """
         Send the kv cache at the given kv indices and the extra cache/state at the given indices to the decoder server.
+
+        If wait_event is provided, an asynchronous sender must wait for it before
+        reading the source buffers.
         """
         ...
 

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -1203,6 +1203,7 @@ class CommonKVSender(BaseKVSender):
         kv_indices: npt.NDArray[np.int32],
         state_indices: Optional[List] = None,
         num_kv_tokens: Optional[int] = None,
+        wait_event: Optional[object] = None,
     ):
         pass
 

--- a/python/sglang/srt/disaggregation/common/utils.py
+++ b/python/sglang/srt/disaggregation/common/utils.py
@@ -26,6 +26,7 @@ class TransferKVChunk:
     state_indices: Optional[List]
     chunk_id: Optional[int] = None
     num_kv_tokens: Optional[int] = None
+    wait_event: Optional[object] = None
     trace_ctx: Union[TraceReqContext, TraceNullContext] = dataclasses.field(
         default_factory=TraceNullContext
     )

--- a/python/sglang/srt/disaggregation/fake/conn.py
+++ b/python/sglang/srt/disaggregation/fake/conn.py
@@ -79,6 +79,7 @@ class FakeKVSender(BaseKVSender):
         kv_indices: npt.NDArray[np.int32],
         state_indices: Optional[List] = None,
         num_kv_tokens: Optional[int] = None,
+        wait_event: Optional[object] = None,
     ):
         self.has_sent = True
         logger.debug(

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -1658,6 +1658,21 @@ class MooncakeKVManager(CommonKVManager):
                     self._staging_outstanding[kv_chunk.room] += 1
                     kv_chunk.staging_counted = True
 
+                if kv_chunk.wait_event is not None:
+                    kv_chunk.wait_event.synchronize()
+                    if (
+                        kv_chunk.room not in self.request_status
+                        or self.check_status(kv_chunk.room) == KVPoll.Failed
+                    ):
+                        self._staging_outstanding.pop(kv_chunk.room, None)
+                        if self.enable_trace:
+                            kv_chunk.trace_ctx.trace_slice_end(
+                                MooncakeRequestStage.MOONCAKE_WORKER_SEND.stage_name,
+                                MooncakeRequestStage.MOONCAKE_WORKER_SEND.level,
+                                thread_finish_flag=True,
+                            )
+                        continue
+
                 if (
                     self.enable_staging
                     and staging_strategy is None
@@ -2147,6 +2162,7 @@ class MooncakeKVManager(CommonKVManager):
         state_indices: Optional[List] = None,
         num_kv_tokens: Optional[int] = None,
         trace_ctx: Optional[Union[TraceReqContext, TraceNullContext]] = None,
+        wait_event: Optional[object] = None,
     ):
         assert self.disaggregation_mode == DisaggregationMode.PREFILL
         assert not is_last_chunk or (is_last_chunk and aux_index is not None)
@@ -2185,6 +2201,7 @@ class MooncakeKVManager(CommonKVManager):
                 prefill_aux_index=aux_index,
                 state_indices=state_indices,
                 num_kv_tokens=num_kv_tokens,
+                wait_event=wait_event,
                 trace_ctx=trace_ctx,
             )
         )
@@ -2266,6 +2283,7 @@ class MooncakeKVSender(CommonKVSender):
         kv_indices: npt.NDArray[np.int32],
         state_indices: Optional[List] = None,
         num_kv_tokens: Optional[int] = None,
+        wait_event: Optional[object] = None,
     ):
         kv_indices, index_slice, is_last_chunk, should_skip = (
             self._prepare_send_indices(kv_indices, state_indices)
@@ -2281,6 +2299,7 @@ class MooncakeKVSender(CommonKVSender):
                 False,
                 num_kv_tokens=num_kv_tokens,
                 trace_ctx=self.trace_ctx.copy_for_thread(),
+                wait_event=wait_event,
             )
         else:
             self.kv_mgr.add_transfer_request(
@@ -2292,6 +2311,7 @@ class MooncakeKVSender(CommonKVSender):
                 state_indices=state_indices,
                 num_kv_tokens=num_kv_tokens,
                 trace_ctx=self.trace_ctx.copy_for_thread(),
+                wait_event=wait_event,
             )
         self._record_transfer_indices(kv_indices, state_indices)
 

--- a/python/sglang/srt/disaggregation/mori/conn.py
+++ b/python/sglang/srt/disaggregation/mori/conn.py
@@ -1418,6 +1418,7 @@ class MoriKVSender(CommonKVSender):
         kv_indices: npt.NDArray[np.int32],
         state_indices: Optional[List] = None,
         num_kv_tokens: Optional[int] = None,
+        wait_event: Optional[object] = None,
     ):
         kv_indices, index_slice, is_last_chunk, should_skip = (
             self._prepare_send_indices(kv_indices, state_indices)
@@ -1431,8 +1432,6 @@ class MoriKVSender(CommonKVSender):
             else None
         )
         self._record_transfer_indices(kv_indices, state_indices)
-        wait_event = getattr(self, "_early_send_wait_event", None)
-        self._early_send_wait_event = None
         self.kv_mgr.enqueue_transfer(
             _TransferChunk(
                 sender=self,
@@ -1463,6 +1462,11 @@ class MoriKVSender(CommonKVSender):
         # issuing the RDMA read (early-send overlaps that forward).
         if task.wait_event is not None:
             task.wait_event.synchronize()
+            if self.conclude_state is not None:
+                return
+            if self.kv_mgr.request_status.get(self.bootstrap_room) == KVPoll.Failed:
+                self._finalize_failure()
+                return
 
         statuses, infos = self.kv_mgr.add_transfer_request(
             self.bootstrap_room,

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -1123,12 +1123,18 @@ class NixlKVManager(CommonKVManager):
                     self._staging_outstanding.pop(room, None)
                     continue
 
-                assert room in self.transfer_infos
-
                 # Count each chunk once; the flag survives re-enqueue on defer.
                 if not kv_chunk.staging_counted:
                     self._staging_outstanding[room] += 1
                     kv_chunk.staging_counted = True
+
+                if kv_chunk.wait_event is not None:
+                    kv_chunk.wait_event.synchronize()
+                    if self.check_status(room) == KVPoll.Failed:
+                        self._staging_outstanding.pop(room, None)
+                        continue
+
+                assert room in self.transfer_infos
 
                 # Lazily build a per-worker staging strategy bound to this
                 # worker's private staging buffer (matches mooncake).
@@ -2399,6 +2405,7 @@ class NixlKVManager(CommonKVManager):
         aux_index: Optional[int] = None,
         state_indices: Optional[List] = None,
         num_kv_tokens: Optional[int] = None,
+        wait_event: Optional[object] = None,
     ):
         assert self.disaggregation_mode == DisaggregationMode.PREFILL
         assert not is_last_chunk or (is_last_chunk and aux_index is not None)
@@ -2430,6 +2437,7 @@ class NixlKVManager(CommonKVManager):
                 prefill_aux_index=aux_index,
                 state_indices=state_indices,
                 num_kv_tokens=num_kv_tokens,
+                wait_event=wait_event,
             )
         )
         return None
@@ -2757,6 +2765,7 @@ class NixlKVSender(CommonKVSender):
         kv_indices: npt.NDArray[np.int32],
         state_indices: Optional[List] = None,
         num_kv_tokens: Optional[int] = None,
+        wait_event: Optional[object] = None,
     ):
         if self._send_failed:
             return
@@ -2781,6 +2790,7 @@ class NixlKVSender(CommonKVSender):
             self.aux_index,
             state_indices,
             num_kv_tokens,
+            wait_event,
         )
         self._record_transfer_indices(kv_indices, state_indices)
         self.chunk_id += 1

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -634,9 +634,15 @@ class SchedulerDisaggregationPrefillMixin:
                     self.maybe_prefetch_staging_for_batch(batch)
                 batch_result = self.run_batch(batch)
                 self._apply_war_barrier()
+                defer_middle_chunk_transfer = (
+                    batch_result.delay_sample_func is not None
+                )
+                if not defer_middle_chunk_transfer:
+                    self._enqueue_middle_chunk_transfer(batch, batch_result)
                 self.result_queue.append((batch.copy(), batch_result))
             else:
                 batch_result = None
+                defer_middle_chunk_transfer = False
 
             # Process the last batch
             if self.last_batch:
@@ -651,9 +657,42 @@ class SchedulerDisaggregationPrefillMixin:
             # Run sample of the current batch
             # It depends on the result of the last batch (e.g., grammar), so we run it after the last batch is processed.
             self.launch_batch_sample_if_needed(batch_result, batch)
+            if defer_middle_chunk_transfer:
+                # Delayed sampling records copy_done here, not in run_batch.
+                self._enqueue_middle_chunk_transfer(batch, batch_result)
 
             # Update last_batch
             self.last_batch = batch
+
+    def _enqueue_middle_chunk_transfer(
+        self: Scheduler,
+        batch: ScheduleBatch,
+        result: GenerationBatchResult,
+    ) -> bool:
+        """Enqueue a pure middle chunk immediately after its GPU launch.
+
+        The backend worker waits on the already-recorded ``result.copy_done``,
+        which is ordered after this batch's forward. This starts transfer as
+        soon as the KV is ready while preserving the scheduler's existing
+        one-step overlap window.
+        """
+        if batch.contains_last_prefill_chunk or result.copy_done is None:
+            return False
+
+        req = batch.chunked_req
+        assert req is not None and batch.reqs == [req]
+        if req.pending_bootstrap or is_aborted(req):
+            return False
+        assert (
+            req.metadata_buffer_index >= 0
+        ), f"Req {req.rid} does not have metadata buffer allocated"
+        self.send_kv_chunk(
+            req,
+            last_chunk=False,
+            end_idx=min(req.extend_range.end, len(req.origin_input_ids)),
+            wait_event=result.copy_done,
+        )
+        return True
 
     def process_batch_result_disagg_prefill(
         self: Scheduler,
@@ -810,9 +849,13 @@ class SchedulerDisaggregationPrefillMixin:
                         )
                         logprob_pt += num_input_logprobs
 
-                # In non-overlap-mode, KV is sent in process_prefill_chunk
-                # Only send when req's sender is initialized
-                if self.enable_overlap and not req.pending_bootstrap:
+                # Middle chunks are normally enqueued immediately after launch.
+                # Keep this as the fallback for paths that could not enqueue then.
+                if (
+                    self.enable_overlap
+                    and not req.pending_bootstrap
+                    and req.start_send_idx < req.tmp_end_idx
+                ):
                     assert (
                         req.metadata_buffer_index >= 0
                     ), f"Req {req.rid} does not have metadata buffer allocated"
@@ -1075,7 +1118,8 @@ class SchedulerDisaggregationPrefillMixin:
                         self.optimistic_release_and_requeue(req)
                 # else: still bootstrapping, keep computing without sending
             elif self.enable_overlap:
-                # Delay KV transfer to process_batch_result_disagg_prefill when overlap is enabled to ensure results are resolved
+                # Snapshot the completed boundary. The next iteration enqueues
+                # this range with the producer batch's completion event.
                 req.tmp_end_idx = min(
                     req.extend_range.end,
                     len(req.origin_input_ids),
@@ -1133,14 +1177,18 @@ class SchedulerDisaggregationPrefillMixin:
         if self.enable_overlap:
             ev = torch.cuda.Event()
             ev.record(self.forward_stream)
-            req.disagg_kv_sender._early_send_wait_event = ev
-        self.send_kv_chunk(req, last_chunk=False, end_idx=cached_end)
+        else:
+            ev = None
+        self.send_kv_chunk(
+            req, last_chunk=False, end_idx=cached_end, wait_event=ev
+        )
 
     def send_kv_chunk(
         self: Scheduler,
         req: Req,
         last_chunk: bool = False,
         end_idx: Optional[int] = None,
+        wait_event: Optional[object] = None,
     ) -> None:
         """
         Send a prefilled chunk to the decode server
@@ -1317,6 +1365,7 @@ class SchedulerDisaggregationPrefillMixin:
                 page_indices,
                 state_indices if segment_is_last else None,
                 num_kv_tokens=seg_end - seg_start,
+                wait_event=wait_event,
             )
         req.start_send_idx = end_idx
         # A last chunk needs no entry: every `last_chunk=True` call site has

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1165,9 +1165,8 @@ class Req(ReqDllmMixin):
         # start_send_idx = req.extend_range.end
         self.start_send_idx: int = 0
 
-        # For overlap schedule, we delay the kv transfer until `process_batch_result_disagg_prefill` rather than `process_prefill_chunk` in non-overlap
-        # This is because kv is not ready in `process_prefill_chunk`.
-        # We use `tmp_end_idx` to store the end index of the kv cache to send.
+        # Fallback boundary for overlap paths that cannot enqueue this middle
+        # chunk immediately after launch (for example, optimistic bootstrap).
         self.tmp_end_idx: int = -1
         # Decode-side cached-prefix length; base of the staging chunk grid
         # (start_send_idx starts here but advances with every send).

--- a/test/registered/unit/disaggregation/test_prefill_middle_chunk_transfer.py
+++ b/test/registered/unit/disaggregation/test_prefill_middle_chunk_transfer.py
@@ -1,0 +1,108 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import numpy as np
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.disaggregation.base.conn import KVPoll
+from sglang.srt.disaggregation.common.utils import TransferKVChunk
+from sglang.srt.disaggregation.mooncake.conn import MooncakeKVManager
+from sglang.srt.disaggregation.nixl.conn import NixlKVManager
+from sglang.srt.disaggregation.prefill import SchedulerDisaggregationPrefillMixin
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+def make_chunk(wait_event):
+    return TransferKVChunk(
+        room=7,
+        prefill_kv_indices=np.array([1], dtype=np.int32),
+        index_slice=slice(0, 1),
+        is_last_chunk=False,
+        prefill_aux_index=None,
+        state_indices=None,
+        wait_event=wait_event,
+    )
+
+
+class TestPrefillMiddleChunkTransfer(unittest.TestCase):
+    def test_middle_chunk_is_enqueued_with_producer_event(self):
+        wait_event = object()
+        req = SimpleNamespace(
+            rid="middle",
+            pending_bootstrap=False,
+            to_finish=None,
+            finished_reason=None,
+            metadata_buffer_index=3,
+            extend_range=SimpleNamespace(end=8192),
+            origin_input_ids=range(20_000),
+        )
+        scheduler = SimpleNamespace(send_kv_chunk=MagicMock())
+        batch = SimpleNamespace(
+            reqs=[req],
+            chunked_req=req,
+            contains_last_prefill_chunk=False,
+        )
+        result = SimpleNamespace(copy_done=wait_event)
+
+        sent = SchedulerDisaggregationPrefillMixin._enqueue_middle_chunk_transfer(
+            scheduler, batch, result
+        )
+
+        self.assertTrue(sent)
+        scheduler.send_kv_chunk.assert_called_once_with(
+            req,
+            last_chunk=False,
+            end_idx=8192,
+            wait_event=wait_event,
+        )
+
+    def test_final_chunk_stays_on_result_processing_path(self):
+        scheduler = SimpleNamespace(send_kv_chunk=MagicMock())
+        sent = SchedulerDisaggregationPrefillMixin._enqueue_middle_chunk_transfer(
+            scheduler,
+            SimpleNamespace(contains_last_prefill_chunk=True),
+            SimpleNamespace(copy_done=object()),
+        )
+
+        self.assertFalse(sent)
+        scheduler.send_kv_chunk.assert_not_called()
+
+    def test_mooncake_worker_waits_before_accessing_source(self):
+        wait_event = MagicMock()
+        wait_event.synchronize.side_effect = KeyboardInterrupt
+        manager = object.__new__(MooncakeKVManager)
+        manager.enable_trace = False
+        manager.request_status = {7: KVPoll.WaitingForInput}
+        manager._staging_outstanding = {7: 0}
+        manager.check_status = MagicMock(return_value=KVPoll.WaitingForInput)
+        queue = SimpleNamespace(get=MagicMock(return_value=make_chunk(wait_event)))
+
+        with self.assertRaises(KeyboardInterrupt):
+            manager.transfer_worker(queue, MagicMock())
+
+        wait_event.synchronize.assert_called_once_with()
+        self.assertEqual(manager._staging_outstanding[7], 1)
+
+    def test_nixl_worker_waits_before_accessing_source(self):
+        wait_event = MagicMock()
+        wait_event.synchronize.side_effect = KeyboardInterrupt
+        manager = object.__new__(NixlKVManager)
+        manager._staging_outstanding = {7: 0}
+        manager.check_status = MagicMock(return_value=KVPoll.WaitingForInput)
+        queue = SimpleNamespace(get=MagicMock(return_value=make_chunk(wait_event)))
+
+        with self.assertRaises(KeyboardInterrupt):
+            manager.transfer_worker(queue)
+
+        wait_event.synchronize.assert_called_once_with()
+        self.assertEqual(manager._staging_outstanding[7], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- enqueue PDD middle-chunk KV transfer immediately after the producer batch launch
- pass the producer `copy_done` event to Mooncake, NIXL, and Mori workers so they wait off the scheduler thread
- keep final-chunk handling and the existing one-step overlap window unchanged

## Why

The overlap scheduler currently waits until the previous prefill result is processed before submitting its KV chunk. That puts CPU result processing and KV submission back on the scheduler critical path and weakens zero-overhead scheduling.

## Validation

- unit tests: 4 passed in the official SGLang ROCm image
- GLM-5.2 dummy-weight PDD on one MI350X8: P TP4 + D TP4, 25,001-token cache-miss prompt split into 4 chunks
- TP0 profile: 390 matched Mooncake HIP copies, 2.506 GB, with 390 API-to-GPU arrows
- physical XGMI counters rose on matching P/D GPU pairs during the request

This PR intentionally does not add multi-inflight or multi-step-ahead scheduling.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32013667094](https://github.com/sgl-project/sglang/actions/runs/32013667094)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32013666617](https://github.com/sgl-project/sglang/actions/runs/32013666617)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->