### PR TITLE
Support configurable Mooncake memory and NoF replica counts via environment variables

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -708,6 +708,10 @@ class Envs:
     MOONCAKE_ENABLE_SSD_OFFLOAD = EnvBool(False)
     MOONCAKE_OFFLOAD_FILE_STORAGE_PATH = EnvStr(None)
     MOONCAKE_TENANT_ID = EnvStr("default")
+    # Number of memory replicas for each Mooncake put (default 1).
+    MOONCAKE_REPLICA_NUM = EnvInt(1)
+    # Number of NoF (NVMe-oF) replicas for each Mooncake put (default 0).
+    MOONCAKE_NOF_REPLICA_NUM = EnvInt(0)
 
     # ===================================================================
     # MoRI transport and expert dispatch

--- a/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
+++ b/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
@@ -264,6 +264,12 @@ class MooncakeBaseStore:
     def __init__(self):
         self.store = None
         self.config = None
+        # Replica counts for KV put operations, configurable via
+        # MOONCAKE_REPLICA_NUM / MOONCAKE_NOF_REPLICA_NUM. Defaults match
+        # Mooncake's default ReplicateConfig (1 memory replica, no NoF
+        # replica) so existing deployments are unchanged unless set.
+        self._replica_num = envs.MOONCAKE_REPLICA_NUM.get()
+        self._nof_replica_num = envs.MOONCAKE_NOF_REPLICA_NUM.get()
 
     def _import_mooncake_store(self):
         try:
@@ -1307,6 +1313,19 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
                 )
             config = self._replicate_config_cls()
             config.group_ids = group_ids
+
+        # Apply replica counts from MOONCAKE_REPLICA_NUM / MOONCAKE_NOF_REPLICA_NUM
+        # when either is non-default (default: 1 memory replica, no NoF replica).
+        # The default keeps the plain batch_put_from path (no custom config);
+        # any custom replica setting is forwarded via ReplicateConfig.
+        if self._replica_num != 1 or self._nof_replica_num != 0:
+            if self._replicate_config_cls is not None:
+                if config is None:
+                    config = self._replicate_config_cls()
+                if hasattr(config, "replica_num"):
+                    config.replica_num = self._replica_num
+                if hasattr(config, "nof_replica_num"):
+                    config.nof_replica_num = self._nof_replica_num
 
         if self._uses_multi_buffer(buffer_ptrs):
             config = config or self._replicate_config_cls()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
Mooncake already supports NVMe-oF (NoF) as a storage backend, allowing KV caches to be placed on high-speed SSD pools for low-cost, large-capacity tiered storage. However, in the current SGLang integration with MooncakeStore, there is no way to control replica placement—specifically, no way to request NoF replicas—on a per‑Put basis.

This prevents SGLang from leveraging Mooncake’s NoF capabilities even when an SSD pool is deployed. The goal is to enable SGLang to configure both the total number of replicas and the number of NoF replicas via environment variables (MOONCAKE_REPLICA_NUM and MOONCAKE_NOF_REPLICA_NUM), forwarding these settings through Mooncake's ReplicateConfig in the batch put path. Defaults (1 and 0) keep the existing no-config path unchanged, ensuring backward compatibility, while a hasattr guard protects against older Mooncake versions that lack nof_replica_num support.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32015697088](https://github.com/sgl-project/sglang/actions/runs/32015697088)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32015696866](https://github.com/sgl-project/sglang/actions/runs/32015696866)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->