### PR TITLE
[diffusion] Fix TeaCache CFG state lifecycle

### DIFF
--- a/python/sglang/multimodal_gen/configs/sample/teacache.py
+++ b/python/sglang/multimodal_gen/configs/sample/teacache.py
@@ -63,7 +63,10 @@ class TeaCacheParams(CacheParams):
         return self.coefficients
 
     def get_skip_boundaries(
-        self, num_inference_steps: int, do_cfg: bool
+        self,
+        num_inference_steps: int,
+        do_cfg: bool,
+        cfg_parallel: bool = False,
     ) -> tuple[int, int]:
         def _resolve_boundary(value: int | float) -> int:
             if isinstance(value, float):
@@ -75,7 +78,9 @@ class TeaCacheParams(CacheParams):
         start_skipping = _resolve_boundary(self.start_skipping)
         end_skipping = _resolve_boundary(self.end_skipping)
 
-        if do_cfg:
+        # Serial CFG performs two local forwards per diffusion timestep. CFG
+        # parallel performs one branch per rank, so its boundaries stay unchanged.
+        if do_cfg and not cfg_parallel:
             start_skipping *= 2
             end_skipping *= 2
 

--- a/python/sglang/multimodal_gen/runtime/cache/teacache.py
+++ b/python/sglang/multimodal_gen/runtime/cache/teacache.py
@@ -39,6 +39,7 @@ class TeaCacheContext:
         current_timestep: Current denoising timestep index (0-indexed).
         num_inference_steps: Total number of inference steps.
         do_cfg: Whether classifier-free guidance is enabled.
+        is_cfg_parallel: Whether CFG branches execute on separate ranks.
         is_cfg_negative: True if currently processing negative CFG branch.
         teacache_thresh: Threshold for accumulated L1 distance.
         coefficients: Polynomial coefficients for L1 rescaling.
@@ -48,6 +49,7 @@ class TeaCacheContext:
     current_timestep: int
     num_inference_steps: int
     do_cfg: bool
+    is_cfg_parallel: bool
     is_cfg_negative: bool  # For CFG branch selection
     teacache_thresh: float
     coefficients: list[float]
@@ -263,6 +265,7 @@ class TeaCacheMixin:
         from sglang.multimodal_gen.runtime.managers.forward_context import (
             get_forward_context,
         )
+        from sglang.multimodal_gen.runtime.server_args import get_global_server_args
 
         forward_context = get_forward_context()
         forward_batch = forward_context.forward_batch
@@ -281,16 +284,19 @@ class TeaCacheMixin:
         current_timestep = forward_context.current_timestep
         num_inference_steps = forward_batch.num_inference_steps
         do_cfg = forward_batch.do_classifier_free_guidance
+        is_cfg_parallel = bool(get_global_server_args().enable_cfg_parallel)
         is_cfg_negative = forward_batch.is_cfg_negative
 
-        # Reset at first timestep
-        if current_timestep == 0 and not self.is_cfg_negative:
+        # Serial CFG resets once on the positive branch. Under CFG parallel,
+        # each rank owns its own model state and must reset its local branch.
+        if current_timestep == 0 and (is_cfg_parallel or not is_cfg_negative):
             self.reset_teacache_state()
 
         return TeaCacheContext(
             current_timestep=current_timestep,
             num_inference_steps=num_inference_steps,
             do_cfg=do_cfg,
+            is_cfg_parallel=is_cfg_parallel,
             is_cfg_negative=is_cfg_negative,
             teacache_thresh=teacache_params.teacache_thresh,
             coefficients=teacache_params.get_coefficients(),

--- a/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
@@ -1305,7 +1305,9 @@ class WanTransformer3DModel(CachableDiT, LayerwiseOffloadableModuleMixin):
         teacache_params = ctx.teacache_params
         use_ret_steps = teacache_params.use_ret_steps
         start_skipping, end_skipping = teacache_params.get_skip_boundaries(
-            ctx.num_inference_steps, ctx.do_cfg
+            ctx.num_inference_steps,
+            ctx.do_cfg,
+            cfg_parallel=ctx.is_cfg_parallel,
         )
 
         # Determine boundary step

--- a/python/sglang/multimodal_gen/test/unit/test_teacache.py
+++ b/python/sglang/multimodal_gen/test/unit/test_teacache.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest.mock import patch
+
+
+def _load_runtime_module():
+    numpy_stub = ModuleType("numpy")
+    torch_stub = ModuleType("torch")
+    torch_stub.Tensor = type("Tensor", (), {})
+
+    server_args = SimpleNamespace(enable_cfg_parallel=False)
+    server_args_module = ModuleType("sglang.multimodal_gen.runtime.server_args")
+    server_args_module.get_global_server_args = lambda: server_args
+
+    forward_context = SimpleNamespace(current_timestep=0, forward_batch=None)
+    forward_context_module = ModuleType(
+        "sglang.multimodal_gen.runtime.managers.forward_context"
+    )
+    forward_context_module.get_forward_context = lambda: forward_context
+
+    stubs = {
+        "numpy": numpy_stub,
+        "torch": torch_stub,
+        server_args_module.__name__: server_args_module,
+        forward_context_module.__name__: forward_context_module,
+    }
+    module_path = (
+        Path(__file__).resolve().parents[2] / "runtime" / "cache" / "teacache.py"
+    )
+    return stubs, module_path, server_args, forward_context
+
+
+def _load_params_module():
+    sampling_params_module = ModuleType(
+        "sglang.multimodal_gen.configs.sample.sampling_params"
+    )
+    sampling_params_module.CacheParams = type("CacheParams", (), {})
+    module_path = (
+        Path(__file__).resolve().parents[2] / "configs" / "sample" / "teacache.py"
+    )
+    return {sampling_params_module.__name__: sampling_params_module}, module_path
+
+
+def _import_from_path(name, module_path):
+    spec = importlib.util.spec_from_file_location(name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_batch():
+    params = SimpleNamespace(
+        teacache_thresh=0.1,
+        get_coefficients=lambda: [1.0],
+    )
+    return SimpleNamespace(
+        enable_teacache=True,
+        teacache_params=params,
+        num_inference_steps=50,
+        do_classifier_free_guidance=True,
+        is_cfg_negative=False,
+    )
+
+
+class TestTeaCacheLifecycle(unittest.TestCase):
+    def test_serial_cfg_resets_only_before_positive_branch(self):
+        stubs, module_path, server_args, forward_context = _load_runtime_module()
+        with patch.dict(sys.modules, stubs):
+            module = _import_from_path("test_teacache_runtime_serial", module_path)
+
+            class DummyTeaCache(module.TeaCacheMixin):
+                prefix = "wan"
+
+            cache = DummyTeaCache()
+            cache._init_teacache_state()
+            batch = _make_batch()
+            forward_context.forward_batch = batch
+            server_args.enable_cfg_parallel = False
+
+            cache._get_teacache_context()
+            cache.cnt = 1
+            cache.previous_modulated_input = object()
+            batch.is_cfg_negative = True
+
+            ctx = cache._get_teacache_context()
+
+            self.assertEqual(cache.cnt, 1)
+            self.assertIsNotNone(cache.previous_modulated_input)
+            self.assertFalse(ctx.is_cfg_parallel)
+            self.assertTrue(ctx.is_cfg_negative)
+
+    def test_cfg_parallel_negative_branch_resets_at_request_start(self):
+        stubs, module_path, server_args, forward_context = _load_runtime_module()
+        with patch.dict(sys.modules, stubs):
+            module = _import_from_path("test_teacache_runtime_parallel", module_path)
+
+            class DummyTeaCache(module.TeaCacheMixin):
+                prefix = "wan"
+
+            cache = DummyTeaCache()
+            cache._init_teacache_state()
+            cache.cnt = 50
+            cache.is_cfg_negative = True
+            cache.previous_modulated_input_negative = object()
+            cache.previous_residual_negative = object()
+            cache.accumulated_rel_l1_distance_negative = 7.0
+
+            batch = _make_batch()
+            batch.is_cfg_negative = True
+            forward_context.forward_batch = batch
+            server_args.enable_cfg_parallel = True
+
+            ctx = cache._get_teacache_context()
+
+            self.assertEqual(cache.cnt, 0)
+            self.assertIsNone(cache.previous_modulated_input_negative)
+            self.assertIsNone(cache.previous_residual_negative)
+            self.assertEqual(cache.accumulated_rel_l1_distance_negative, 0.0)
+            self.assertTrue(ctx.is_cfg_parallel)
+            self.assertTrue(ctx.is_cfg_negative)
+
+
+class TestTeaCacheBoundaries(unittest.TestCase):
+    def test_cfg_parallel_uses_one_local_forward_per_timestep(self):
+        stubs, module_path = _load_params_module()
+        with patch.dict(sys.modules, stubs):
+            module = _import_from_path("test_teacache_params", module_path)
+            params = module.TeaCacheParams(start_skipping=5, end_skipping=-1)
+
+            self.assertEqual(params.get_skip_boundaries(50, True), (10, 98))
+            self.assertEqual(
+                params.get_skip_boundaries(50, True, cfg_parallel=True),
+                (5, 49),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #35054

## Motivation

TeaCache used the model's previous CFG branch flag when deciding whether to
reset request state. This reset the serial negative branch twice at timestep 0
and allowed state to survive across requests on a CFG-parallel negative rank.
CFG skip boundaries also assumed two local forwards whenever CFG was enabled,
which does not match CFG-parallel execution.

## Modifications

- Reset TeaCache from the current CFG branch and execution topology.
- Keep the existing doubled skip boundaries for serial CFG while using one
  local forward per timestep under CFG parallel.
- Add CPU-only regression tests for serial lifecycle, CFG-parallel request
  isolation, and topology-aware skip boundaries.

## Accuracy Tests

- `python3 -m unittest discover -s python/sglang/multimodal_gen/test/unit -p 'test_teacache.py' -v` — 3 tests passed.
- Model-level GPU accuracy tests were not available in the local environment.

## Speed Tests and Profiling

Not run locally. The change corrects the existing skip-window accounting and
does not add tensor operations, but end-to-end performance still requires the
repository's diffusion CI environment.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). (`pre-commit` is unavailable locally.)
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (No user-facing documentation change is needed.)
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Requires the diffusion CI environment.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32017195313](https://github.com/sgl-project/sglang/actions/runs/32017195313)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32017194672](https://github.com/sgl-project/sglang/actions/runs/32017194672)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->