### PR TITLE
fix(dsv4): avoid host synchronization when sizing SWA prefill buffers

### DIFF
--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -1791,7 +1791,12 @@ class DeepseekV4AttnBackend(
         cache = self.forward_metadata.sparse_prefill_cache
         if cache is None:
             seq_lens_cpu = forward_batch.seq_lens_cpu
+            extend_seq_lens_cpu = forward_batch.extend_seq_lens_cpu
             assert seq_lens_cpu is not None
+            assert extend_seq_lens_cpu is not None
+            seq_lens_cpu_list = [int(seq_len) for seq_len in seq_lens_cpu.tolist()]
+            assert len(seq_lens_cpu_list) == len(extend_seq_lens_cpu)
+
             # ``swa_window_size`` on the pool is its storage page size, not
             # the model's SWA window — pass both explicitly.
             cache = SparsePrefillChunkCache.build(
@@ -1803,7 +1808,9 @@ class DeepseekV4AttnBackend(
                 swa_window_size=SWA_WINDOW,
                 swa_page_size=token_to_kv_pool.swa_window_size,
                 num_qo_tokens=q_flat.shape[0],
-                max_seq_len=int(seq_lens_cpu.max().item()),
+                max_seq_len=max(seq_lens_cpu_list),
+                seq_lens_cpu=seq_lens_cpu_list,
+                extend_seq_lens_cpu=extend_seq_lens_cpu,
             )
             self.forward_metadata.sparse_prefill_cache = cache
 

--- a/python/sglang/srt/layers/attention/dsv4/sparse_prefill_utils.py
+++ b/python/sglang/srt/layers/attention/dsv4/sparse_prefill_utils.py
@@ -33,7 +33,7 @@ compressed branch becomes a no-op) and any ``compress_ratio >= 1``.
 """
 
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Optional, Sequence
 
 import torch
 import triton
@@ -188,6 +188,29 @@ def combine_topk_swa_indices(
     return combined_indices, combined_lens
 
 
+def compute_total_swa_tokens(
+    seq_lens_cpu: Sequence[int],
+    extend_seq_lens_cpu: Sequence[int],
+    swa_window: int,
+) -> int:
+    """Compute the exact SWA gather allocation size from host metadata.
+
+    Keeping this calculation on the host avoids reading the device-side cumsum
+    back with ``Tensor.item()``, which otherwise synchronizes the forward stream.
+    """
+    assert swa_window > 0
+    assert len(seq_lens_cpu) == len(extend_seq_lens_cpu)
+
+    total_swa = 0
+    for seq_len, extend_seq_len in zip(seq_lens_cpu, extend_seq_lens_cpu):
+        seq_len = int(seq_len)
+        extend_seq_len = int(extend_seq_len)
+        assert seq_len >= 0
+        assert extend_seq_len >= 0
+        total_swa += min(seq_len, extend_seq_len + swa_window - 1)
+    return total_swa
+
+
 def build_swa_token_ids(
     seq_lens: torch.Tensor,
     extend_seq_lens: torch.Tensor,
@@ -195,6 +218,7 @@ def build_swa_token_ids(
     req_to_token: torch.Tensor,
     full_to_swa: torch.Tensor,
     swa_window: int,
+    total_swa: int,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """Build a flat list of physical SWA-cache token IDs covering each
     request's positional union of every query's SWA window.
@@ -216,6 +240,8 @@ def build_swa_token_ids(
         full_to_swa: (full_pool_size + extra,) int64. Maps full kv id to
             SWA-cache id.
         swa_window: int. SWA window size.
+        total_swa: Exact output size, computed from the scheduler's host-side
+            sequence-length mirrors to avoid a device-to-host synchronization.
 
     Returns:
         swa_token_ids: (total_swa,) int32, flat physical SWA-cache token IDs.
@@ -228,6 +254,7 @@ def build_swa_token_ids(
     assert req_pool_indices.dtype == torch.int32
     assert req_to_token.dtype == torch.int32
     assert full_to_swa.dtype == torch.int64
+    assert total_swa >= 0
 
     num_reqs = seq_lens.shape[0]
     device = seq_lens.device
@@ -238,7 +265,6 @@ def build_swa_token_ids(
     swa_first_pos = (seq_lens - swa_gather_lens).to(torch.int32)
     swa_offsets = torch.zeros(num_reqs + 1, dtype=torch.int32, device=device)
     swa_offsets[1:] = torch.cumsum(swa_gather_lens, dim=0).to(torch.int32)
-    total_swa = int(swa_offsets[-1].item())  # one CPU sync per chunk
 
     swa_token_ids = torch.empty(total_swa, dtype=torch.int32, device=device)
     if total_swa == 0:
@@ -322,9 +348,17 @@ class SparsePrefillChunkCache:
         swa_page_size: int,
         num_qo_tokens: int,
         max_seq_len: int,
+        seq_lens_cpu: Sequence[int],
+        extend_seq_lens_cpu: Sequence[int],
     ) -> "SparsePrefillChunkCache":
         device = seq_lens.device
         num_reqs = seq_lens.shape[0]
+
+        assert len(seq_lens_cpu) == num_reqs
+        assert len(extend_seq_lens_cpu) == num_reqs
+        total_swa = compute_total_swa_tokens(
+            seq_lens_cpu, extend_seq_lens_cpu, swa_window_size
+        )
 
         query_start_loc = torch.zeros(num_reqs + 1, dtype=torch.int32, device=device)
         query_start_loc[1:] = torch.cumsum(extend_seq_lens, dim=0).to(torch.int32)
@@ -337,6 +371,7 @@ class SparsePrefillChunkCache:
                 req_to_token=req_to_token,
                 full_to_swa=full_to_swa,
                 swa_window=swa_window_size,
+                total_swa=total_swa,
             )
         )
 

--- a/test/registered/attention/unittests/dsv4/test_deepseek_v4.py
+++ b/test/registered/attention/unittests/dsv4/test_deepseek_v4.py
@@ -498,6 +498,27 @@ class TestDSV4BreakableCudaGraphMetadataContract(CustomTestCase):
             )
         )
 
+    def test_sparse_prefill_total_swa_tokens_uses_host_lengths(self):
+        from sglang.srt.layers.attention.dsv4.sparse_prefill_utils import (
+            compute_total_swa_tokens,
+        )
+
+        cases = (
+            ((10, 256, 1000), (10, 1, 128), 128, 393),
+            ((1, 128, 129), (1, 1, 1), 128, 257),
+            ((0, 0), (0, 0), 128, 0),
+        )
+        for seq_lens, extend_seq_lens, window, expected in cases:
+            with self.subTest(
+                seq_lens=seq_lens,
+                extend_seq_lens=extend_seq_lens,
+                window=window,
+            ):
+                self.assertEqual(
+                    compute_total_swa_tokens(seq_lens, extend_seq_lens, window),
+                    expected,
+                )
+
     def test_sparse_prefill_workspace_reuses_and_grows(self):
         from sglang.srt.layers.attention.dsv4.sparse_prefill_utils import (
             SparsePrefillWorkspace,


### PR DESCRIPTION
## Summary

Remove the GPU-to-CPU synchronization in DSV4 sparse prefill SWA token-ID allocation.

Previously, `build_swa_token_ids()` read `swa_offsets[-1].item()` to obtain the exact allocation size. Since `swa_offsets` is produced on the forward stream, this forces the CPU to wait for the GPU once per prefill chunk.

This change derives the same exact SWA token count from scheduler-maintained host metadata (`seq_lens_cpu` and `extend_seq_lens_cpu`), using:

`sum(min(seq_len, extend_len + swa_window - 1))`

GPU-side `swa_gather_lens`, offsets, and token-ID construction remain unchanged.

## Changes

- Add a host-side helper to compute the exact SWA token-ID allocation size.
- Pass CPU sequence-length mirrors into `SparsePrefillChunkCache.build()`.
- Remove the device-side `.item()` call from `build_swa_token_ids()`.
- Add CPU unit coverage for normal, window-boundary, long-sequence, and empty-input cases.

## Expected impact

This removes one forward-stream synchronization per DSV4 sparse prefill chunk. The main benefit is improved CPU/GPU scheduling overlap and lower prefill latency tail under concurrent workloads; it does not change attention results or buffer layout.

## Validation

- `git diff --check`
- Python compilation for modified source and test files
- Added targeted CPU unit test for host-side SWA token-count calculation

## perf
From the test results, it can be seen that in some cases, both the p90 and p99 values of ttft and e2e time have decreased.
<ne-clipboard data="%7B%22type%22%3A%22fragment%22%2C%22name%22%3A%22%23fragment%22%2C%22children%22%3A%5B%7B%22id%22%3A%22%22%2C%22type%22%3A%22element%22%2C%22name%22%3A%22table%22%2C%22attrs%22%3A%7B%22rowCount%22%3A4%2C%22colCount%22%3A7%2C%22colWidths%22%3A%5B62%2C99%2C100%2C107%2C101%2C99%2C96%5D%7D%2C%22children%22%3A%5B%7B%22id%22%3A%22%22%2C%22type%22%3A%22element%22%2C%22name%22%3A%22tr%22%2C%22attrs%22%3A%7B%22height%22%3A70%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22element%22%2C%22id%22%3A%22u1edd1736%22%2C%22name%22%3A%22td%22%2C%22attrs%22%3A%7B%22cellBgColor%22%3A%22%23E7E9E8%22%2C%22verticalAlign%22%3A%22middle%22%2C%22col%22%3A0%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22element%22%2C%22id%22%3A%22uc05fdc3c%22%2C%22name%22%3A%22p%22%2C%22attrs%22%3A%7B%22alignment%22%3A%22center%22%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22text%22%2C%22id%22%3A%22u91103774%22%2C%22name%22%3A%22%23text%22%2C%22attrs%22%3A%7B%22bold%22%3Atrue%2C%22color%22%3A%22black%22%7D%2C%22data%22%3A%22%E5%B9%B6%E5%8F%91%22%7D%5D%7D%5D%7D%2C%7B%22type%22%3A%22element%22%2C%22id%22%3A%22u95316ae8%22%2C%22name%22%3A%22td%22%2C%22attrs%22%3A%7B%22cellBgColor%22%3A%22%23E7E9E8%22%2C%22verticalAlign%22%3A%22middle%22%2C%22col%22%3A1%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22element%22%2C%22id%22%3A%22u45f5b3aa%22%2C%22name%22%3A%22p%22%2C%22attrs%22%3A%7B%22alignment%22%3A%22center%22%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22text%22%2C%22id%22%3A%22u43d9e803%22%2C%22name%22%3A%22%23text%22%2C%22attrs%22%3A%7B%22bold%22%3Atrue%2C%22color%22%3A%22black%22%7D%2C%22data%22%3A%22E2E%20time(s)%22%7D%5D%7D%5D%7D%2C%7B%22type%22%3A%22element%22%2C%22id%22%3A%22u82d8d4e5%22%2C%22name%22%3A%22td%22%2C%22attrs%22%3A%7B%22cellBgColor%22%3A%22%23E7E9E8%22%2C%22verticalAlign%22%3A%22middle%22%2C%22col%22%3A2%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22element%22%2C%22id%22%3A%22ufa0208e5%22%2C%22name%22%3A%22p%22%2C%22attrs%22%3A%7B%22alignment%22%3A%22center%22%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22text%22%2C%22id%22%3A%22ueacbea2e%22%2C%22name%22%3A%22%23text%22%2C%22attrs%22%3A%7B%22bold%22%3Atrue%2C%22color%22%3A%22black%22%7D%2C%22data%22%3A%22old%20E2E%20time(s)%22%7D%5D%7D%5D%7D%2C%7B%22type%22%3A%22element%22%2C%22id%22%3A%22u6b328897%22%2C%22name%22%3A%22td%22%2C%22attrs%22%3A%7B%22cellBgColor%22%3A%22%23E7E9E8%22%2C%22verticalAlign%22%3A%22middle%22%2C%22col%22%3A3%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22element%22%2C%22id%22%3A%22u5ebf2094%22%2C%22name%22%3A%22p%22%2C%22attrs%22%3A%7B%22alignment%22%3A%22center%22%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22text%22%2C%22id%22%3A%22ua7488947%22%2C%22name%22%3A%22%23text%22%2C%22attrs%22%3A%7B%22bold%22%3Atrue%2C%22color%22%3A%22black%22%7D%2C%22data%22%3A%22Mean%20TTFT%20(s)%22%7D%5D%7D%5D%7D%2C%7B%22type%22%3A%22element%22%2C%22id%22%3A%22u04b859ac%22%2C%22name%22%3A%22td%22%2C%22attrs%22%3A%7B%22cellBgColor%22%3A%22%23E7E9E8%22%2C%22verticalAlign%22%3A%22middle%22%2C%22col%22%3A4%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22element%22%2C%22id%22%3A%22u6bd6616a%22%2C%22name%22%3A%22p%22%2C%22attrs%22%3A%7B%22alignment%22%3A%22center%22%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22text%22%2C%22id%22%3A%22u5f008068%22%2C%22name%22%3A%22%23text%22%2C%22attrs%22%3A%7B%22bold%22%3Atrue%2C%22color%22%3A%22black%22%7D%2C%22data%22%3A%22old%20Mean%20TTFT%20(s)%22%7D%5D%7D%5D%7D%2C%7B%22type%22%3A%22element%22%2C%22id%22%3A%22uf8734e64%22%2C%22name%22%3A%22td%22%2C%22attrs%22%3A%7B%22cellBgColor%22%3A%22%23E7E9E8%22%2C%22verticalAlign%22%3A%22middle%22%2C%22col%22%3A5%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22element%22%2C%22id%22%3A%22u9498d8ac%22%2C%22name%22%3A%22p%22%2C%22attrs%22%3A%7B%22alignment%22%3A%22center%22%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22text%22%2C%22id%22%3A%22ue160ccbd%22%2C%22name%22%3A%22%23text%22%2C%22attrs%22%3A%7B%22bold%22%3Atrue%2C%22color%22%3A%22black%22%7D%2C%22data%22%3A%22Mean%20TPOT%20(ms)%22%7D%5D%7D%5D%7D%2C%7B%22type%22%3A%22element%22%2C%22id%22%3A%22u910e8f94%22%2C%22name%22%3A%22td%22%2C%22attrs%22%3A%7B%22cellBgColor%22%3A%22%23E7E9E8%22%2C%22verticalAlign%22%3A%22middle%22%2C%22col%22%3A6%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22element%22%2C%22id%22%3A%22ud01afa86%22%2C%22name%22%3A%22p%22%2C%22attrs%22%3A%7B%22alignment%22%3A%22center%22%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22text%22%2C%22id%22%3A%22ua8458546%22%2C%22name%22%3A%22%23text%22%2C%22attrs%22%3A%7B%22bold%22%3Atrue%2C%22color%22%3A%22black%22%7D%2C%22data%22%3A%22old%20Mean%20TPOT%20(ms)%22%7D%5D%7D%5D%7D%5D%7D%2C%7B%22id%22%3A%22%22%2C%22type%22%3A%22element%22%2C%22name%22%3A%22tr%22%2C%22attrs%22%3A%7B%22height%22%3A43%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22element%22%2C%22id%22%3A%22uc2d32426%22%2C%22name%22%3A%22td%22%2C%22attrs%22%3A%7B%22verticalAlign%22%3A%22middle%22%2C%22col%22%3A0%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22element%22%2C%22id%22%3A%22u4079271b%22%2C%22name%22%3A%22p%22%2C%22attrs%22%3A%7B%22alignment%22%3A%22center%22%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22text%22%2C%22id%22%3A%22u4d474651%22%2C%22name%22%3A%22%23text%22%2C%22attrs%22%3A%7B%22color%22%3A%22black%22%2C%22fontsize%22%3A14%7D%2C%22data%22%3A%228%22%7D%5D%7D%5D%7D%2C%7B%22type%22%3A%22element%22%2C%22id%22%3A%22u2e46f7ba%22%2C%22name%22%3A%22td%22%2C%22attrs%22%3A%7B%22verticalAlign%22%3A%22middle%22%2C%22col%22%3A1%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22element%22%2C%22id%22%3A%22u0ead46c4%22%2C%22name%22%3A%22p%22%2C%22attrs%22%3A%7B%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22text%22%2C%22id%22%3A%22u7152e812%22%2C%22name%22%3A%22%23text%22%2C%22attrs%22%3A%7B%22fontsize%22%3A14%7D%2C%22data%22%3A%222775%5C%5C3837%5C%5C4626%22%7D%5D%7D%5D%7D%2C%7B%22type%22%3A%22element%22%2C%22id%22%3A%22u5d2bd85a%22%2C%22name%22%3A%22td%22%2C%22attrs%22%3A%7B%22verticalAlign%22%3A%22middle%22%2C%22col%22%3A2%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22element%22%2C%22id%22%3A%22u750f3ab0%22%2C%22name%22%3A%22p%22%2C%22attrs%22%3A%7B%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22text%22%2C%22id%22%3A%22u4bccaabc%22%2C%22name%22%3A%22%23text%22%2C%22attrs%22%3A%7B%22fontsize%22%3A14%7D%2C%22data%22%3A%222807%5C%5C3911%5C%5C5102%22%7D%5D%7D%5D%7D%2C%7B%22type%22%3A%22element%22%2C%22id%22%3A%22uf43e2c79%22%2C%22name%22%3A%22td%22%2C%22attrs%22%3A%7B%22verticalAlign%22%3A%22middle%22%2C%22col%22%3A3%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22element%22%2C%22id%22%3A%22u2aeaa65b%22%2C%22name%22%3A%22p%22%2C%22attrs%22%3A%7B%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22text%22%2C%22id%22%3A%22uf2611089%22%2C%22name%22%3A%22%23text%22%2C%22attrs%22%3A%7B%22fontsize%22%3A14%7D%2C%22data%22%3A%2246.77%5C%5C66.10%5C%5C120.92%22%7D%5D%7D%5D%7D%2C%7B%22type%22%3A%22element%22%2C%22id%22%3A%22u6efc28fc%22%2C%22name%22%3A%22td%22%2C%22attrs%22%3A%7B%22verticalAlign%22%3A%22middle%22%2C%22col%22%3A4%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22element%22%2C%22id%22%3A%22u2bc65744%22%2C%22name%22%3A%22p%22%2C%22attrs%22%3A%7B%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22text%22%2C%22id%22%3A%22u2d846f9b%22%2C%22name%22%3A%22%23text%22%2C%22attrs%22%3A%7B%22fontsize%22%3A14%7D%2C%22data%22%3A%2245.37%5C%5C61.59%5C%5C110.32%22%7D%5D%7D%5D%7D%2C%7B%22type%22%3A%22element%22%2C%22id%22%3A%22ub9be4825%22%2C%22name%22%3A%22td%22%2C%22attrs%22%3A%7B%22verticalAlign%22%3A%22middle%22%2C%22col%22%3A5%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22element%22%2C%22id%22%3A%22uc13834ca%22%2C%22name%22%3A%22p%22%2C%22attrs%22%3A%7B%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22text%22%2C%22id%22%3A%22u67f05f7f%22%2C%22name%22%3A%22%23text%22%2C%22attrs%22%3A%7B%22fontsize%22%3A14%7D%2C%22data%22%3A%222.67%5C%5C3.71%5C%5C4.48%22%7D%5D%7D%5D%7D%2C%7B%22type%22%3A%22element%22%2C%22id%22%3A%22u869cec39%22%2C%22name%22%3A%22td%22%2C%22attrs%22%3A%7B%22verticalAlign%22%3A%22middle%22%2C%22col%22%3A6%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22element%22%2C%22id%22%3A%22u71a3aaac%22%2C%22name%22%3A%22p%22%2C%22attrs%22%3A%7B%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22text%22%2C%22id%22%3A%22u220c2556%22%2C%22name%22%3A%22%23text%22%2C%22attrs%22%3A%7B%22fontsize%22%3A14%7D%2C%22data%22%3A%222.70%5C%5C3.75%5C%5C4.95%22%7D%5D%7D%5D%7D%5D%7D%2C%7B%22id%22%3A%22%22%2C%22type%22%3A%22element%22%2C%22name%22%3A%22tr%22%2C%22attrs%22%3A%7B%22height%22%3A43%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22element%22%2C%22id%22%3A%22u63e03d60%22%2C%22name%22%3A%22td%22%2C%22attrs%22%3A%7B%22verticalAlign%22%3A%22middle%22%2C%22col%22%3A0%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22element%22%2C%22id%22%3A%22u8f9bf1bb%22%2C%22name%22%3A%22p%22%2C%22attrs%22%3A%7B%22alignment%22%3A%22center%22%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22text%22%2C%22id%22%3A%22ufec320b2%22%2C%22name%22%3A%22%23text%22%2C%22attrs%22%3A%7B%22color%22%3A%22black%22%2C%22fontsize%22%3A14%7D%2C%22data%22%3A%2216%22%7D%5D%7D%5D%7D%2C%7B%22type%22%3A%22element%22%2C%22id%22%3A%22ub46ee638%22%2C%22name%22%3A%22td%22%2C%22attrs%22%3A%7B%22verticalAlign%22%3A%22middle%22%2C%22col%22%3A1%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22element%22%2C%22id%22%3A%22u5944724c%22%2C%22name%22%3A%22p%22%2C%22attrs%22%3A%7B%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22text%22%2C%22id%22%3A%22u7c7075a6%22%2C%22name%22%3A%22%23text%22%2C%22attrs%22%3A%7B%7D%2C%22data%22%3A%223438%5C%5C47465958%22%7D%5D%7D%5D%7D%2C%7B%22type%22%3A%22element%22%2C%22id%22%3A%22u23824296%22%2C%22name%22%3A%22td%22%2C%22attrs%22%3A%7B%22verticalAlign%22%3A%22middle%22%2C%22col%22%3A2%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22element%22%2C%22id%22%3A%22u65dcdd81%22%2C%22name%22%3A%22p%22%2C%22attrs%22%3A%7B%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22text%22%2C%22id%22%3A%22u7012c43c%22%2C%22name%22%3A%22%23text%22%2C%22attrs%22%3A%7B%22fontsize%22%3A14%7D%2C%22data%22%3A%223438%5C%5C4647%5C%5C6033%22%7D%5D%7D%5D%7D%2C%7B%22type%22%3A%22element%22%2C%22id%22%3A%22u0acd711d%22%2C%22name%22%3A%22td%22%2C%22attrs%22%3A%7B%22verticalAlign%22%3A%22middle%22%2C%22col%22%3A3%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22element%22%2C%22id%22%3A%22u6e44ed30%22%2C%22name%22%3A%22p%22%2C%22attrs%22%3A%7B%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22text%22%2C%22id%22%3A%22u584cfc55%22%2C%22name%22%3A%22%23text%22%2C%22attrs%22%3A%7B%22fontsize%22%3A14%7D%2C%22data%22%3A%2247.39%5C%5C63.18%5C%5C130.93%22%7D%5D%7D%5D%7D%2C%7B%22type%22%3A%22element%22%2C%22id%22%3A%22u5ac32ef9%22%2C%22name%22%3A%22td%22%2C%22attrs%22%3A%7B%22verticalAlign%22%3A%22middle%22%2C%22col%22%3A4%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22element%22%2C%22id%22%3A%22u95a9f8d6%22%2C%22name%22%3A%22p%22%2C%22attrs%22%3A%7B%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22text%22%2C%22id%22%3A%22ua25e4c68%22%2C%22name%22%3A%22%23text%22%2C%22attrs%22%3A%7B%22fontsize%22%3A14%7D%2C%22data%22%3A%2247.46%5C%5C63.40%5C%5C129.63%22%7D%5D%7D%5D%7D%2C%7B%22type%22%3A%22element%22%2C%22id%22%3A%22ubf3c1d72%22%2C%22name%22%3A%22td%22%2C%22attrs%22%3A%7B%22verticalAlign%22%3A%22middle%22%2C%22col%22%3A5%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22element%22%2C%22id%22%3A%22u3d20938e%22%2C%22name%22%3A%22p%22%2C%22attrs%22%3A%7B%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22text%22%2C%22id%22%3A%22udbad237f%22%2C%22name%22%3A%22%23text%22%2C%22attrs%22%3A%7B%7D%2C%22data%22%3A%223.32%5C%5C4.60%5C%5C5.77%22%7D%5D%7D%5D%7D%2C%7B%22type%22%3A%22element%22%2C%22id%22%3A%22u2bf68711%22%2C%22name%22%3A%22td%22%2C%22attrs%22%3A%7B%22verticalAlign%22%3A%22middle%22%2C%22col%22%3A6%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22element%22%2C%22id%22%3A%22uf128cf11%22%2C%22name%22%3A%22p%22%2C%22attrs%22%3A%7B%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22text%22%2C%22id%22%3A%22u533b159d%22%2C%22name%22%3A%22%23text%22%2C%22attrs%22%3A%7B%22fontsize%22%3A14%7D%2C%22data%22%3A%223.32%5C%5C4.60%5C%5C5.77%22%7D%5D%7D%5D%7D%5D%7D%2C%7B%22id%22%3A%22%22%2C%22type%22%3A%22element%22%2C%22name%22%3A%22tr%22%2C%22attrs%22%3A%7B%22height%22%3A42%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22element%22%2C%22id%22%3A%22uf905d4af%22%2C%22name%22%3A%22td%22%2C%22attrs%22%3A%7B%22verticalAlign%22%3A%22middle%22%2C%22col%22%3A0%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22element%22%2C%22id%22%3A%22u4925c1d6%22%2C%22name%22%3A%22p%22%2C%22attrs%22%3A%7B%22alignment%22%3A%22center%22%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22text%22%2C%22id%22%3A%22u19e9142b%22%2C%22name%22%3A%22%23text%22%2C%22attrs%22%3A%7B%22color%22%3A%22black%22%2C%22fontsize%22%3A14%7D%2C%22data%22%3A%2232%22%7D%5D%7D%5D%7D%2C%7B%22type%22%3A%22element%22%2C%22id%22%3A%22uc4102308%22%2C%22name%22%3A%22td%22%2C%22attrs%22%3A%7B%22verticalAlign%22%3A%22middle%22%2C%22col%22%3A1%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22element%22%2C%22id%22%3A%22u2bb8d734%22%2C%22name%22%3A%22p%22%2C%22attrs%22%3A%7B%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22text%22%2C%22id%22%3A%22u3659c509%22%2C%22name%22%3A%22%23text%22%2C%22attrs%22%3A%7B%22fontsize%22%3A14%7D%2C%22data%22%3A%224431%5C%5C6068%5C%5C7673%22%7D%5D%7D%5D%7D%2C%7B%22type%22%3A%22element%22%2C%22id%22%3A%22u1622d840%22%2C%22name%22%3A%22td%22%2C%22attrs%22%3A%7B%22verticalAlign%22%3A%22middle%22%2C%22col%22%3A2%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22element%22%2C%22id%22%3A%22ub6ed43b8%22%2C%22name%22%3A%22p%22%2C%22attrs%22%3A%7B%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22text%22%2C%22id%22%3A%22uddf85508%22%2C%22name%22%3A%22%23text%22%2C%22attrs%22%3A%7B%22fontsize%22%3A14%7D%2C%22data%22%3A%224484%5C%5C6108%5C%5C9183%22%7D%5D%7D%5D%7D%2C%7B%22type%22%3A%22element%22%2C%22id%22%3A%22u08d16d96%22%2C%22name%22%3A%22td%22%2C%22attrs%22%3A%7B%22verticalAlign%22%3A%22middle%22%2C%22col%22%3A3%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22element%22%2C%22id%22%3A%22u5e1572d4%22%2C%22name%22%3A%22p%22%2C%22attrs%22%3A%7B%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22text%22%2C%22id%22%3A%22u083cca4b%22%2C%22name%22%3A%22%23text%22%2C%22attrs%22%3A%7B%7D%2C%22data%22%3A%2260.16%5C%5C87.44%5C%5C247.79%22%7D%5D%7D%5D%7D%2C%7B%22type%22%3A%22element%22%2C%22id%22%3A%22uc6ba8e94%22%2C%22name%22%3A%22td%22%2C%22attrs%22%3A%7B%22verticalAlign%22%3A%22middle%22%2C%22col%22%3A4%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22element%22%2C%22id%22%3A%22u220c4668%22%2C%22name%22%3A%22p%22%2C%22attrs%22%3A%7B%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22text%22%2C%22id%22%3A%22u3284a556%22%2C%22name%22%3A%22%23text%22%2C%22attrs%22%3A%7B%7D%2C%22data%22%3A%2263.53%5C%5C84.93%5C%5C252.98%22%7D%5D%7D%5D%7D%2C%7B%22type%22%3A%22element%22%2C%22id%22%3A%22ufbd3961d%22%2C%22name%22%3A%22td%22%2C%22attrs%22%3A%7B%22verticalAlign%22%3A%22middle%22%2C%22col%22%3A5%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22element%22%2C%22id%22%3A%22u03fd5624%22%2C%22name%22%3A%22p%22%2C%22attrs%22%3A%7B%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22text%22%2C%22id%22%3A%22u5447d1da%22%2C%22name%22%3A%22%23text%22%2C%22attrs%22%3A%7B%22fontsize%22%3A14%7D%2C%22data%22%3A%224.27%5C%5C5.88%5C%5C7.45%22%7D%5D%7D%5D%7D%2C%7B%22type%22%3A%22element%22%2C%22id%22%3A%22u6b89c298%22%2C%22name%22%3A%22td%22%2C%22attrs%22%3A%7B%22verticalAlign%22%3A%22middle%22%2C%22col%22%3A6%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22element%22%2C%22id%22%3A%22ufcf8ed32%22%2C%22name%22%3A%22p%22%2C%22attrs%22%3A%7B%7D%2C%22children%22%3A%5B%7B%22type%22%3A%22text%22%2C%22id%22%3A%22u9ec52f84%22%2C%22name%22%3A%22%23text%22%2C%22attrs%22%3A%7B%22fontsize%22%3A14%7D%2C%22data%22%3A%224.32%5C%5C5.92%5C%5C8.94%22%7D%5D%7D%5D%7D%5D%7D%5D%7D%5D%2C%22attrs%22%3A%7B%7D%7D" source="https%3A%2F%2Fyuque.antfin.com%2Foversea%2Fndt4gu%2Fbyveusn0ay39a0fp%23rz8RZ"></ne-clipboard><div class="lake-content" typography="classic">
并发 | E2E time(s) | old E2E time(s) | Mean TTFT (s) | old Mean TTFT (s) | Mean TPOT (ms) | old Mean TPOT (ms)
-- | -- | -- | -- | -- | -- | --
8 | 2775\3837\4626 | 2807\3911\5102 | 46.77\66.10\120.92 | 45.37\61.59\110.32 | 2.67\3.71\4.48 | 2.70\3.75\4.95
16 | 3438\47465958 | 3438\4647\6033 | 47.39\63.18\130.93 | 47.46\63.40\129.63 | 3.32\4.60\5.77 | 3.32\4.60\5.77
32 | 4431\6068\7673 | 4484\6108\9183 | 60.16\87.44\247.79 | 63.53\84.93\252.98 | 4.27\5.88\7.45 | 4.32\5.92\8.94

</div>

before：
<img width="300" height="650" alt="image" src="https://github.com/user-attachments/assets/42854ca1-868d-467a-b6a0-a8767b06b042" />
<img width="300" height="650" alt="image" src="https://github.com/user-attachments/assets/98fe70cc-b0e9-45f2-9b24-7b82bc69e0a3" />
<img width="300" height="650" alt="image" src="https://github.com/user-attachments/assets/272b869a-7001-4599-89ab-ebc32d44308f" />
after：
<img width="300" height="650" alt="image" src="https://github.com/user-attachments/assets/39d03fb6-4b6e-4e9f-8f25-02c6ba6c2b32" />
<img width="300" height="650" alt="image" src="https://github.com/user-attachments/assets/20205165-af57-4119-90ec-834a2d8f9382" />
<img width="300" height="650" alt="image" src="https://github.com/user-attachments/assets/d8bf155b-b7b0-40fd-95a8-ad7cf20f6ffa" />


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->