### PR TITLE
Replace vLLM operators with custom operators from the sglang kernel

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
@@ -89,6 +89,9 @@ class ForwardMetadata:
     seq_lens: Optional[torch.Tensor] = None
     actual_seq_lengths_q: Optional[torch.Tensor] = None
     actual_seq_lengths_q_pa: Optional[torch.Tensor] = None
+    # CPU mirror of actual_seq_lengths_q_pa for the host metadata op
+    # (torch.ops.npu.sparse_attn_sharedkv_metadata_host reads CPU int32 inputs).
+    actual_seq_lengths_q_pa_cpu: Optional[torch.Tensor] = None
     actual_seq_lengths_kv: Optional[torch.Tensor] = None
 
     # swa attention mask for graph mode decode

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_dsv4_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_dsv4_backend.py
@@ -1537,19 +1537,19 @@ class DeepseekV4AscendAttnBackend(
         c1a_kwargs = base_kwargs | common
         if self._is_dspark_draft_worker:
             seq_lens_cpu = getattr(fm, "seq_lens_cpu_int", None)
-            max_seqlen_kv = (
-                int(seq_lens_cpu[:bs].max().item())
-                if seq_lens_cpu is not None and bs > 0
-                else int(actual_seq_lengths_kv[:bs].max().item())
+            # do sparse_attn_sharedkv_metadata on CPU, Simple but with better performance, data movement can be ignored
+            cu_q_cpu = actual_seq_lengths_q_pa[: bs + 1].to("cpu", torch.int32)
+            seq_kv_cpu = (
+                seq_lens_cpu[:bs].int()
+                if seq_lens_cpu is not None
+                else actual_seq_lengths_kv[:bs].to("cpu", torch.int32)
             )
-            c1a_kwargs.update(
-                cu_seqlens_ori_kv=actual_seq_lengths_q_pa,
-                max_seqlen_q=max_seqlen_q,
-                max_seqlen_kv=max_seqlen_kv,
-            )
-            c1a_metadata = torch.ops._C_ascend.npu_sparse_attn_sharedkv_metadata(
-                device=str(actual_seq_lengths_kv.device),
-                **c1a_kwargs,
+            c1a_metadata = torch.ops.npu.sparse_attn_sharedkv_metadata_host(
+                **c1a_kwargs
+                | {
+                    "cu_seqlens_q": cu_q_cpu,
+                    "seqused_kv": seq_kv_cpu,
+                }
             )
         else:
             c1a_metadata = torch.ops.custom.npu_sparse_attn_sharedkv_metadata(

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_dsv4_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_dsv4_backend.py
@@ -989,6 +989,15 @@ class DeepseekV4AscendAttnBackend(
             dtype=torch.int32,
             device=device,
         )
+        if self._use_host_sparse_metadata:
+            # q_pa is constant per graph shape (never rewritten at replay), so the
+            # CPU mirror for the host metadata op is built once here.
+            metadata.actual_seq_lengths_q_pa_cpu = torch.arange(
+                0,
+                bs * tokens_per_req + tokens_per_req,
+                tokens_per_req,
+                dtype=torch.int32,
+            )
 
         # init >=1 so the captured kernel records valid attention work; replay overwrites in-place
         metadata.actual_seq_lengths_kv = torch.ones(
@@ -1189,6 +1198,10 @@ class DeepseekV4AscendAttnBackend(
                 fm.seq_lens_cpu_int,
                 ctx.live_seq_lens_cpu.int(),
             )
+        elif self._use_host_sparse_metadata:
+            # CPU mirror of the kv buffer written below, from its CPU source — the
+            # host metadata op reads this instead of a D2H sync.
+            fm.seq_lens_cpu_int = ctx.final_seq_lens_cpu[: ctx.bs].int().clamp(min=1)
         fm.actual_seq_lengths_kv.copy_(attn_seq_lens.clamp(min=1))
 
     def _refresh_graph_compress_page_tables_direct(self, ctx) -> None:
@@ -1432,6 +1445,14 @@ class DeepseekV4AscendAttnBackend(
                 [torch.zeros(1, dtype=torch.int32, device=device), actual_q],
                 dim=0,
             )
+            if self._use_host_sparse_metadata:
+                fm.actual_seq_lengths_q_pa_cpu = torch.cat(
+                    [
+                        torch.zeros(1, dtype=torch.int32),
+                        torch.cumsum(seq_lens_cpu, dim=0).int(),
+                    ],
+                    dim=0,
+                )
         elif forward_batch.forward_mode.is_decode():
             B = forward_batch.batch_size
             fm.actual_seq_lengths_q = torch.arange(
@@ -1440,6 +1461,10 @@ class DeepseekV4AscendAttnBackend(
             fm.actual_seq_lengths_q_pa = torch.arange(
                 0, B + 1, dtype=torch.int32, device=device
             )
+            if self._use_host_sparse_metadata:
+                fm.actual_seq_lengths_q_pa_cpu = torch.arange(
+                    0, B + 1, dtype=torch.int32
+                )
         elif (
             forward_batch.forward_mode.is_target_verify()
             or forward_batch.forward_mode.is_draft_extend_v2()
@@ -1458,6 +1483,16 @@ class DeepseekV4AscendAttnBackend(
                 [torch.zeros(1, dtype=torch.int32, device=device), actual_q],
                 dim=0,
             )
+            if self._use_host_sparse_metadata:
+                fm.actual_seq_lengths_q_pa_cpu = torch.cat(
+                    [
+                        torch.zeros(1, dtype=torch.int32),
+                        torch.arange(
+                            n_draft, B * n_draft + 1, n_draft, dtype=torch.int32
+                        ),
+                    ],
+                    dim=0,
+                )
         else:
             fm.actual_seq_lengths_q = None
             fm.actual_seq_lengths_q_pa = None
@@ -1537,8 +1572,11 @@ class DeepseekV4AscendAttnBackend(
         c1a_kwargs = base_kwargs | common
         if self._is_dspark_draft_worker:
             seq_lens_cpu = getattr(fm, "seq_lens_cpu_int", None)
-            # do sparse_attn_sharedkv_metadata on CPU, Simple but with better performance, data movement can be ignored
-            cu_q_cpu = actual_seq_lengths_q_pa[: bs + 1].to("cpu", torch.int32)
+            cu_q_cpu = getattr(fm, "actual_seq_lengths_q_pa_cpu", None)
+            if cu_q_cpu is None or cu_q_cpu.numel() < bs + 1:
+                cu_q_cpu = actual_seq_lengths_q_pa[: bs + 1].to("cpu", torch.int32)
+            else:
+                cu_q_cpu = cu_q_cpu[: bs + 1]
             seq_kv_cpu = (
                 seq_lens_cpu[:bs].int()
                 if seq_lens_cpu is not None

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_dsv4_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_dsv4_backend.py
@@ -817,6 +817,10 @@ class DeepseekV4AscendAttnBackend(
             getattr(model_runner, "is_draft_worker", False)
             and self._is_dspark_algorithm
         )
+        # The host metadata op is selected in _kernel_metadata_from_parts exactly
+        # on the DSpark draft worker; the CPU mirrors that feed it are built under
+        # the same condition.
+        self._use_host_sparse_metadata = self._is_dspark_draft_worker
         self._dsv4_graph_tokens_per_req = int(model_runner.decode_num_tokens_per_req())
         self._dsv4_state_pools_by_ratio = {
             pool.ratio: pool

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_dsv4_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_dsv4_backend.py
@@ -817,10 +817,6 @@ class DeepseekV4AscendAttnBackend(
             getattr(model_runner, "is_draft_worker", False)
             and self._is_dspark_algorithm
         )
-        # The host metadata op is selected in _kernel_metadata_from_parts exactly
-        # on the DSpark draft worker; the CPU mirrors that feed it are built under
-        # the same condition.
-        self._use_host_sparse_metadata = self._is_dspark_draft_worker
         self._dsv4_graph_tokens_per_req = int(model_runner.decode_num_tokens_per_req())
         self._dsv4_state_pools_by_ratio = {
             pool.ratio: pool
@@ -993,15 +989,14 @@ class DeepseekV4AscendAttnBackend(
             dtype=torch.int32,
             device=device,
         )
-        if self._use_host_sparse_metadata:
-            # q_pa is constant per graph shape (never rewritten at replay), so the
-            # CPU mirror for the host metadata op is built once here.
-            metadata.actual_seq_lengths_q_pa_cpu = torch.arange(
-                0,
-                bs * tokens_per_req + tokens_per_req,
-                tokens_per_req,
-                dtype=torch.int32,
-            )
+        # q_pa is constant per graph shape (never rewritten at replay), so the
+        # CPU mirror for the host metadata op is built once here.
+        metadata.actual_seq_lengths_q_pa_cpu = torch.arange(
+            0,
+            bs * tokens_per_req + tokens_per_req,
+            tokens_per_req,
+            dtype=torch.int32,
+        )
 
         # init >=1 so the captured kernel records valid attention work; replay overwrites in-place
         metadata.actual_seq_lengths_kv = torch.ones(
@@ -1202,7 +1197,7 @@ class DeepseekV4AscendAttnBackend(
                 fm.seq_lens_cpu_int,
                 ctx.live_seq_lens_cpu.int(),
             )
-        elif self._use_host_sparse_metadata:
+        else:
             # CPU mirror of the kv buffer written below, from its CPU source — the
             # host metadata op reads this instead of a D2H sync.
             fm.seq_lens_cpu_int = ctx.final_seq_lens_cpu[: ctx.bs].int().clamp(min=1)
@@ -1449,14 +1444,10 @@ class DeepseekV4AscendAttnBackend(
                 [torch.zeros(1, dtype=torch.int32, device=device), actual_q],
                 dim=0,
             )
-            if self._use_host_sparse_metadata:
-                fm.actual_seq_lengths_q_pa_cpu = torch.cat(
-                    [
-                        torch.zeros(1, dtype=torch.int32),
-                        torch.cumsum(seq_lens_cpu, dim=0).int(),
-                    ],
-                    dim=0,
-                )
+            fm.actual_seq_lengths_q_pa_cpu = torch.cat(
+                [torch.zeros(1, dtype=torch.int32), torch.cumsum(seq_lens_cpu, dim=0).int()],
+                dim=0,
+            )
         elif forward_batch.forward_mode.is_decode():
             B = forward_batch.batch_size
             fm.actual_seq_lengths_q = torch.arange(
@@ -1465,10 +1456,7 @@ class DeepseekV4AscendAttnBackend(
             fm.actual_seq_lengths_q_pa = torch.arange(
                 0, B + 1, dtype=torch.int32, device=device
             )
-            if self._use_host_sparse_metadata:
-                fm.actual_seq_lengths_q_pa_cpu = torch.arange(
-                    0, B + 1, dtype=torch.int32
-                )
+            fm.actual_seq_lengths_q_pa_cpu = torch.arange(0, B + 1, dtype=torch.int32)
         elif (
             forward_batch.forward_mode.is_target_verify()
             or forward_batch.forward_mode.is_draft_extend_v2()
@@ -1487,19 +1475,17 @@ class DeepseekV4AscendAttnBackend(
                 [torch.zeros(1, dtype=torch.int32, device=device), actual_q],
                 dim=0,
             )
-            if self._use_host_sparse_metadata:
-                fm.actual_seq_lengths_q_pa_cpu = torch.cat(
-                    [
-                        torch.zeros(1, dtype=torch.int32),
-                        torch.arange(
-                            n_draft, B * n_draft + 1, n_draft, dtype=torch.int32
-                        ),
-                    ],
-                    dim=0,
-                )
+            fm.actual_seq_lengths_q_pa_cpu = torch.cat(
+                [
+                    torch.zeros(1, dtype=torch.int32),
+                    torch.arange(n_draft, B * n_draft + 1, n_draft, dtype=torch.int32),
+                ],
+                dim=0,
+            )
         else:
             fm.actual_seq_lengths_q = None
             fm.actual_seq_lengths_q_pa = None
+            fm.actual_seq_lengths_q_pa_cpu = None
 
         fm.swa_page_table = (
             fm.block_tables_swa if fm.block_tables_swa is not None else fm.block_tables
@@ -1553,8 +1539,6 @@ class DeepseekV4AscendAttnBackend(
     ) -> dict:
         fm = self.forward_metadata
         common = {
-            "cu_seqlens_q": actual_seq_lengths_q_pa,
-            "seqused_kv": actual_seq_lengths_kv,
             "cmp_ratio": 1,
             "ori_mask_mode": 4,
             "cmp_mask_mode": 3,
@@ -1573,31 +1557,21 @@ class DeepseekV4AscendAttnBackend(
             "has_ori_kv": True,
             "has_cmp_kv": False,
         }
-        c1a_kwargs = base_kwargs | common
-        if self._is_dspark_draft_worker:
-            seq_lens_cpu = getattr(fm, "seq_lens_cpu_int", None)
-            cu_q_cpu = getattr(fm, "actual_seq_lengths_q_pa_cpu", None)
-            if cu_q_cpu is None or cu_q_cpu.numel() < bs + 1:
-                cu_q_cpu = actual_seq_lengths_q_pa[: bs + 1].to("cpu", torch.int32)
-            else:
-                cu_q_cpu = cu_q_cpu[: bs + 1]
-            seq_kv_cpu = (
-                seq_lens_cpu[:bs].int()
-                if seq_lens_cpu is not None
-                else actual_seq_lengths_kv[:bs].to("cpu", torch.int32)
-            )
-            c1a_metadata = torch.ops.npu.sparse_attn_sharedkv_metadata_host(
+        # The host metadata op reads CPU int32 mirrors — never a D2H sync of the
+        # device tensors (that would drain the stream and stall overlapped prep).
+        # cu_q mirror is sized for its graph bucket; slice down to this batch.
+        cu_q_cpu = fm.actual_seq_lengths_q_pa_cpu
+        if cu_q_cpu is not None and cu_q_cpu.numel() > bs + 1:
+            cu_q_cpu = cu_q_cpu[: bs + 1]
+        host_inputs = {"seqused_kv": fm.seq_lens_cpu_int[:bs].int()}
+        if cu_q_cpu is not None:
+            host_inputs["cu_seqlens_q"] = cu_q_cpu
+        c1a_kwargs = base_kwargs | common | host_inputs
+        kernel_metadata = {
+            "c1a_metadata": torch.ops.npu.sparse_attn_sharedkv_metadata_host(
                 **c1a_kwargs
-                | {
-                    "cu_seqlens_q": cu_q_cpu,
-                    "seqused_kv": seq_kv_cpu,
-                }
             )
-        else:
-            c1a_metadata = torch.ops.custom.npu_sparse_attn_sharedkv_metadata(
-                **c1a_kwargs,
-            )
-        kernel_metadata = {"c1a_metadata": c1a_metadata}
+        }
 
         if self._dsv4_has_c4:
             c4a_overrides = {
@@ -1607,7 +1581,7 @@ class DeepseekV4AscendAttnBackend(
             }
             c4a_kwargs = c1a_kwargs | c4a_overrides
             kernel_metadata["c4a_metadata"] = (
-                torch.ops.custom.npu_sparse_attn_sharedkv_metadata(**c4a_kwargs)
+                torch.ops.npu.sparse_attn_sharedkv_metadata_host(**c4a_kwargs)
             )
 
             if actual_seq_lengths_q_pa is not None:
@@ -1637,7 +1611,7 @@ class DeepseekV4AscendAttnBackend(
             c128a_overrides = {"cmp_ratio": 128, "has_cmp_kv": True}
             c128a_kwargs = c1a_kwargs | c128a_overrides
             kernel_metadata["c128a_metadata"] = (
-                torch.ops.custom.npu_sparse_attn_sharedkv_metadata(**c128a_kwargs)
+                torch.ops.npu.sparse_attn_sharedkv_metadata_host(**c128a_kwargs)
             )
 
         return kernel_metadata

--- a/python/sglang/srt/hardware_backend/npu/extra_ops_loader.py
+++ b/python/sglang/srt/hardware_backend/npu/extra_ops_loader.py
@@ -113,10 +113,7 @@ def initialize_dspark_sparse_attn_ops() -> Optional[Path]:
         name="DSpark sparse-attention",
         so_env="SGLANG_DSPARK_EXTRA_OPS_SO",
         namespace="_C_ascend",
-        required_ops=(
-            "npu_sparse_attn_sharedkv_metadata",
-            "npu_sparse_attn_sharedkv",
-        ),
+        required_ops=("npu_sparse_attn_sharedkv",),
         pre_load_imports=("torch_npu",),
     )
     return TorchOpLoader(spec).initialize()


### PR DESCRIPTION
## Motivation
On the current NPU platform, we have already provided our own definitions of the dsv4 spark‑related operators in the sglang kernel repository, and we implement dspark based on our custom sglang operators

## Modifications
1、Replace the vLLM dynamic library calls in ascend_dsv4_backend.py with sglang kernel calls.

## Accuracy Tests
This operator does not affect accuracy.

## Speed Tests and Profiling
Use the replaced operator after：
```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 160       
Successful requests:                     160       
Benchmark duration (s):                  51.04     
Total input tokens:                      1310720   
Total input text tokens:                 1310720   
Total generated tokens:                  163840    
Total generated tokens (retokenized):    163832    
Request throughput (req/s):              3.13      
Input token throughput (tok/s):          25681.59  
Output token throughput (tok/s):         3210.20   
Peak output token throughput (tok/s):    9005.00   
Peak concurrent requests:                160       
Total token throughput (tok/s):          28891.79  
Concurrency:                             144.42    
Accept length:                           5.41      
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   46068.74  
Median E2E Latency (ms):                 45406.44  
P90 E2E Latency (ms):                    48402.04  
P95 E2E Latency (ms):                    48758.49  
P99 E2E Latency (ms):                    49494.62  
---------------Time to First Token----------------
Mean TTFT (ms):                          16861.65  
Median TTFT (ms):                        17061.21  
P90 TTFT (ms):                           27113.55  
P95 TTFT (ms):                           27407.58  
P99 TTFT (ms):                           27411.84  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          28.55     
Median TPOT (ms):                        28.91     
P90 TPOT (ms):                           37.69     
P95 TPOT (ms):                           38.65     
P99 TPOT (ms):                           41.16     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           28.55     
Median ITL (ms):                         17.06     
P90 ITL (ms):                            21.43     
P95 ITL (ms):                            25.83     
P99 ITL (ms):                            398.31    
Max ITL (ms):                            12023.96  
==================================================
```


before:
```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 160       
Successful requests:                     160       
Benchmark duration (s):                  50.85     
Total input tokens:                      1310720   
Total input text tokens:                 1310720   
Total generated tokens:                  163840    
Total generated tokens (retokenized):    163832    
Request throughput (req/s):              3.15      
Input token throughput (tok/s):          25777.97  
Output token throughput (tok/s):         3222.25   
Peak output token throughput (tok/s):    9127.00   
Peak concurrent requests:                160       
Total token throughput (tok/s):          29000.22  
Concurrency:                             144.54    
Accept length:                           5.65      
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   45934.77  
Median E2E Latency (ms):                 45278.62  
P90 E2E Latency (ms):                    48245.83  
P95 E2E Latency (ms):                    48588.53  
P99 E2E Latency (ms):                    49312.42  
---------------Time to First Token----------------
Mean TTFT (ms):                          16870.18  
Median TTFT (ms):                        17077.78  
P90 TTFT (ms):                           27131.82  
P95 TTFT (ms):                           27414.92  
P99 TTFT (ms):                           27418.62  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          28.41     
Median TPOT (ms):                        28.76     
P90 TPOT (ms):                           37.59     
P95 TPOT (ms):                           38.53     
P99 TPOT (ms):                           41.01     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           28.41     
Median ITL (ms):                         16.93     
P90 ITL (ms):                            21.24     
P95 ITL (ms):                            25.59     
P99 ITL (ms):                            397.80    
Max ITL (ms):                            12014.81  
==================================================
```
## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32344119884](https://github.com/sgl-project/sglang/actions/runs/32344119884)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32344119615](https://github.com/sgl-project/sglang/actions/runs/32344119615)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32344119780](https://github.com/sgl-project/sglang/actions/runs/32344119780)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->