### PR TITLE
[Fix] DeepSeek-V3.1 streaming tool-call detector loses calls at chunk boundaries

### DIFF
--- a/python/sglang/srt/function_call/deepseekv31_detector.py
+++ b/python/sglang/srt/function_call/deepseekv31_detector.py
@@ -113,12 +113,22 @@ class DeepSeekV31Detector(BaseFormatDetector):
 
         calls: list[ToolCallItem] = []
         try:
-            partial_match = re.search(
-                pattern=r"<｜tool▁call▁begin｜>(.*)<｜tool▁sep｜>(.*?)(<｜tool▁call▁end｜>|$)",
-                string=current_text,
-                flags=re.DOTALL,
-            )
-            if partial_match:
+            # Consume one complete
+            # `<｜tool▁call▁begin｜>name<｜tool▁sep｜>args<｜tool▁call▁end｜>` block
+            # per iteration (like detect_and_parse) so a single increment
+            # carrying several tool calls (batched detokenization,
+            # stream_interval > 1, speculative decode) emits all of them. The
+            # name group cannot contain `<`, so it cannot span a tool-token
+            # boundary the way the previous greedy `(.*)` did.
+            while True:
+                partial_match = re.search(
+                    pattern=r"<｜tool▁call▁begin｜>([^<]*?)<｜tool▁sep｜>(.*?)(<｜tool▁call▁end｜>|$)",
+                    string=current_text,
+                    flags=re.DOTALL,
+                )
+                if not partial_match:
+                    break
+
                 func_name = partial_match.group(1).strip()
                 func_args_raw = partial_match.group(2).strip()
                 is_tool_end = partial_match.group(3)
@@ -149,48 +159,51 @@ class DeepSeekV31Detector(BaseFormatDetector):
                         "name": func_name,
                         "arguments": {},
                     }
-                else:
-                    argument_diff = (
-                        func_args_raw[len(self._last_arguments) :]
-                        if func_args_raw.startswith(self._last_arguments)
-                        else func_args_raw
-                    )
 
-                    if argument_diff:
-                        calls.append(
-                            ToolCallItem(
-                                tool_index=self.current_tool_id,
-                                name=None,
-                                parameters=argument_diff,
-                            )
+                # Stream the arguments already buffered instead of returning
+                # right after the name and leaving the call in the buffer.
+                argument_diff = (
+                    func_args_raw[len(self._last_arguments) :]
+                    if func_args_raw.startswith(self._last_arguments)
+                    else func_args_raw
+                )
+
+                if argument_diff:
+                    calls.append(
+                        ToolCallItem(
+                            tool_index=self.current_tool_id,
+                            name=None,
+                            parameters=argument_diff,
                         )
-                        self._last_arguments += argument_diff
-                        self.streamed_args_for_tool[
-                            self.current_tool_id
-                        ] += argument_diff
+                    )
+                    self._last_arguments += argument_diff
+                    self.streamed_args_for_tool[self.current_tool_id] += argument_diff
 
-                    if _is_complete_json(func_args_raw):
-                        # Update the stored arguments
-                        try:
-                            parsed_args = json.loads(func_args_raw)
-                            self.prev_tool_call_arr[self.current_tool_id][
-                                "arguments"
-                            ] = parsed_args
-                        except json.JSONDecodeError:
-                            pass
+                if _is_complete_json(func_args_raw):
+                    # Update the stored arguments
+                    try:
+                        parsed_args = json.loads(func_args_raw)
+                        self.prev_tool_call_arr[self.current_tool_id][
+                            "arguments"
+                        ] = parsed_args
+                    except json.JSONDecodeError:
+                        pass
 
-                        # Find the end of the current tool call and remove only that part from buffer
-                        if is_tool_end:
-                            # Remove the completed tool call from buffer, keep any remaining content
-                            self._buffer = current_text[partial_match.end(3) :]
-                        else:
-                            self._buffer = ""
+                    # Find the end of the current tool call and remove only that part from buffer
+                    if is_tool_end:
+                        # Remove the completed tool call from buffer, keep any remaining content
+                        self._buffer = current_text[partial_match.end(3) :]
+                    else:
+                        self._buffer = ""
 
-                        result = StreamingParseResult(normal_text="", calls=calls)
-                        self.current_tool_id += 1
-                        self._last_arguments = ""
-                        self.current_tool_name_sent = False
-                        return result
+                    self.current_tool_id += 1
+                    self._last_arguments = ""
+                    self.current_tool_name_sent = False
+                    current_text = self._buffer
+                    continue
+
+                # Incomplete call: keep it buffered and wait for more tokens
+                break
 
             return StreamingParseResult(normal_text="", calls=calls)
 

--- a/test/registered/unit/function_call/test_deepseekv31_detector.py
+++ b/test/registered/unit/function_call/test_deepseekv31_detector.py
@@ -1,0 +1,158 @@
+"""Unit tests for DeepSeekV31Detector streaming tool calls — no server, no model loading."""
+
+import json
+import unittest
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.deepseekv31_detector import DeepSeekV31Detector
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(1.0, "base-a-test-cpu")
+
+CALLS_BEGIN = "<｜tool▁calls▁begin｜>"
+CALLS_END = "<｜tool▁calls▁end｜>"
+CALL_BEGIN = "<｜tool▁call▁begin｜>"
+CALL_SEP = "<｜tool▁sep｜>"
+CALL_END = "<｜tool▁call▁end｜>"
+
+
+def _call(name: str, args: str) -> str:
+    return f"{CALL_BEGIN}{name}{CALL_SEP}{args}{CALL_END}"
+
+
+class TestDeepSeekV31Streaming(unittest.TestCase):
+    def setUp(self):
+        self.tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="f1",
+                    description="first tool",
+                    parameters={"type": "object", "properties": {}},
+                ),
+            ),
+            Tool(
+                type="function",
+                function=Function(
+                    name="f2",
+                    description="second tool",
+                    parameters={"type": "object", "properties": {}},
+                ),
+            ),
+        ]
+
+    def _feed(self, chunks):
+        """Feeds chunks to a fresh detector, returns calls reconstructed per tool_index."""
+        detector = DeepSeekV31Detector()
+        emitted = []
+        for chunk in chunks:
+            emitted.extend(detector.parse_streaming_increment(chunk, self.tools).calls)
+
+        reconstructed = {}
+        for item in emitted:
+            entry = reconstructed.setdefault(
+                item.tool_index, {"name": None, "arguments": ""}
+            )
+            if item.name:
+                entry["name"] = item.name
+            entry["arguments"] += item.parameters
+        return [reconstructed[i] for i in sorted(reconstructed)]
+
+    def test_both_calls_in_single_increment(self):
+        """One chunk carrying two complete calls (batched detokenization,
+        stream_interval > 1, speculative decode) must emit both calls, not one
+        call whose name swallowed the first tool call."""
+        text = (
+            CALLS_BEGIN + _call("f1", '{"a": 1}') + _call("f2", '{"b": 2}') + CALLS_END
+        )
+        calls = self._feed([text])
+
+        self.assertEqual([c["name"] for c in calls], ["f1", "f2"])
+        self.assertEqual(json.loads(calls[0]["arguments"]), {"a": 1})
+        self.assertEqual(json.loads(calls[1]["arguments"]), {"b": 2})
+
+        # Raw-event pin for the fused end-token -> next-separator boundary:
+        # _feed() aggregates by tool_index, which would mask duplicate or
+        # out-of-order emissions; the raw stream must carry each name exactly
+        # once, in order, with no swallowed markup.
+        detector = DeepSeekV31Detector()
+        raw = detector.parse_streaming_increment(text, self.tools).calls
+        self.assertEqual([c.name for c in raw if c.name], ["f1", "f2"])
+        self.assertEqual([c.tool_index for c in raw if c.name], [0, 1])
+
+    def test_one_call_per_increment(self):
+        """Chunks each carrying one complete call must keep the two calls
+        separate even though the first call is never trimmed mid-stream."""
+        calls = self._feed(
+            [CALLS_BEGIN + _call("f1", '{"a": 1}'), _call("f2", '{"b": 2}')]
+        )
+
+        self.assertEqual([c["name"] for c in calls], ["f1", "f2"])
+        self.assertEqual(json.loads(calls[0]["arguments"]), {"a": 1})
+        self.assertEqual(json.loads(calls[1]["arguments"]), {"b": 2})
+
+    def test_token_by_token(self):
+        """Fine-grained streaming (one lattice token per chunk) must keep working."""
+        lattice = [
+            CALLS_BEGIN,
+            CALL_BEGIN,
+            "f",
+            "1",
+            CALL_SEP,
+            '{"',
+            "a",
+            '":',
+            " ",
+            "1",
+            "}",
+            CALL_END,
+            CALL_BEGIN,
+            "f",
+            "2",
+            CALL_SEP,
+            '{"',
+            "b",
+            '":',
+            " ",
+            "2",
+            "}",
+            CALL_END,
+            CALLS_END,
+        ]
+        calls = self._feed(lattice)
+
+        self.assertEqual([c["name"] for c in calls], ["f1", "f2"])
+        self.assertEqual(json.loads(calls[0]["arguments"]), {"a": 1})
+        self.assertEqual(json.loads(calls[1]["arguments"]), {"b": 2})
+
+    def test_single_call_across_increments(self):
+        """A call whose name and arguments arrive in separate chunks must still
+        be streamed as one complete call."""
+        chunks = [
+            CALLS_BEGIN + CALL_BEGIN + "f",
+            "1" + CALL_SEP + "{",
+            '"a": 1}',
+            CALL_END + CALLS_END,
+        ]
+        calls = self._feed(chunks)
+
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0]["name"], "f1")
+        self.assertEqual(json.loads(calls[0]["arguments"]), {"a": 1})
+
+    def test_streaming_matches_detect_and_parse(self):
+        """Streaming and one-shot parsing must agree on the parsed calls."""
+        text = (
+            CALLS_BEGIN + _call("f1", '{"a": 1}') + _call("f2", '{"b": 2}') + CALLS_END
+        )
+        streaming_calls = self._feed([text])
+        one_shot_calls = DeepSeekV31Detector().detect_and_parse(text, self.tools).calls
+
+        self.assertEqual(
+            [(c["name"], json.loads(c["arguments"])) for c in streaming_calls],
+            [(c.name, json.loads(c.parameters)) for c in one_shot_calls],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
[Fix] DeepSeek-V3.1 streaming tool-call detector loses calls at chunk boundaries

DeepSeekV31Detector.parse_streaming_increment matched the buffer with a greedy
DOTALL name group (.*) before <｜tool▁sep｜>, and returned right after emitting
the tool name without consuming the buffer. When a single streaming increment
spans one call's <｜tool▁call▁end｜> and the next call's <｜tool▁sep｜> (batched
detokenization, stream_interval > 1, speculative decode), the name group
swallows the first call whole: the client gets one call whose name embeds
call 1's markup and whose arguments belong to call 2 — call 1 is silently lost,
and streaming disagrees with detect_and_parse on the same output.
Fix: consume one complete tool-call block per loop iteration (mirroring
detect_and_parse and DeepSeekV32Detector), bound the name group to [^<]*? so it
cannot cross a tool-token boundary, and stream buffered arguments in the same
pass. Regression tests cover both-calls-in-one-increment, one call per
increment, token-by-token, a call split across increments, and streaming vs
one-shot agreement. Related to #31915 (greedy streaming regex family).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32028464490](https://github.com/sgl-project/sglang/actions/runs/32028464490)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32028464271](https://github.com/sgl-project/sglang/actions/runs/32028464271)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->