### PR TITLE
[AMD] DSv4/#34624: fire compress+norm+rope fusion under MTP (target_verify)

### DIFF
--- a/python/sglang/kernels/jit/csrc/deepseek_v4/c128_v2.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/c128_v2.cuh
@@ -89,10 +89,46 @@ struct Compress128PrefillParams {
   uint32_t num_write;
 };
 
-template <typename Trait, bool kUsePDL, typename BufferFloat, typename InputFloat, typename OutFloat>
+/// \brief Load one lane's tile and widen it to the type the compressor computes
+/// in. The rows it reads come from two places with two layouts -- the ring
+/// buffer, and the tail of the wkv_gate gemm output that has not been staged yet
+/// -- so each pointer carries its own storage type and is reconciled here rather
+/// than forcing the producer to pre-convert.
+template <typename Dst, uint32_t kTileElements, typename Src>
+SGL_DEVICE device::AlignedVector<Dst, kTileElements> c128_load(
+    const Src* src,
+    const uint32_t lane_id) {
+  using namespace device;
+
+  using StorageSrc = AlignedVector<Src, kTileElements>;
+  const auto gmem = tile::Memory<StorageSrc>{lane_id, kWarpThreads};
+  const auto raw = gmem.load(src);
+
+  if constexpr (std::is_same_v<Dst, Src>) {
+    return raw;
+  } else {
+    AlignedVector<Dst, kTileElements> out;
+#pragma unroll
+    for (int32_t k = 0; k < kTileElements; ++k) {
+      out[k] = cast<Dst>(raw[k]);
+    }
+    return out;
+  }
+}
+
+// SrcFloat is only how kv_score arrives from the wkv_gate gemm; InputFloat stays
+// the compute dtype and the dtype of score_bias (ape). Splitting them lets that
+// gemm hand over bf16 and skip a widening pass, since this kernel widens on load.
+template <
+    typename Trait,
+    bool kUsePDL,
+    typename BufferFloat,
+    typename InputFloat,
+    typename SrcFloat,
+    typename OutFloat>
 SGL_DEVICE void c128_forward(
     const BufferFloat* kv_buf,  // [128n, 128n + 127]
-    const InputFloat* kv_src,   // ragged pointer at position = 128n + 127
+    const SrcFloat* kv_src,     // ragged pointer at position = 128n + 127
     OutFloat* kv_out,
     const InputFloat* score_bias,
     const int32_t buffer_len) {
@@ -107,7 +143,6 @@ SGL_DEVICE void c128_forward(
 
   /// NOTE: part 1: load kv + score
   using StorageIn = AlignedVector<InputFloat, kTileElements>;
-  const auto gmem_in = tile::Memory<StorageIn>{lane_id, kWarpThreads};
   StorageIn kv[kElementsPerWarp];
   StorageIn score[kElementsPerWarp];
   StorageIn bias[kElementsPerWarp];
@@ -116,42 +151,26 @@ SGL_DEVICE void c128_forward(
 #pragma unroll
   for (int32_t i = 0; i < kElementsPerWarp; ++i) {
     const int32_t j = i + warp_offset;
-    bias[i] = gmem_in.load(score_bias + j * Trait::kHeadDim);
+    bias[i] = c128_load<InputFloat, kTileElements>(score_bias + j * Trait::kHeadDim, lane_id);
   }
 
   const auto kv_start = kv_src - 127 * Trait::kElementSize;  // point to start
 
-  if constexpr (std::is_same_v<BufferFloat, InputFloat>) {
+  // The two sources differ in storage type as well as layout -- the ring buffer
+  // holds BufferFloat, the un-staged tail holds SrcFloat -- so each load widens
+  // to InputFloat at its own call site instead of branching on dtype up front.
 #pragma unroll
-    for (int32_t i = 0; i < kElementsPerWarp; ++i) {
-      const int32_t j = i + warp_offset;
-      __builtin_assume(j < 128);
-      const auto src = j < buffer_len ? kv_buf : kv_start;
-      kv[i] = gmem_in.load(src + j * Trait::kElementSize);
-      score[i] = gmem_in.load(src + j * Trait::kElementSize + Trait::kScoreOffset);
-    }
-  } else {  // mixed dtype
-    using StorageBuffer = AlignedVector<BufferFloat, Trait::kTileElements>;
-    const auto gmem_buffer = tile::Memory<StorageBuffer>{lane_id, kWarpThreads};
-
-#pragma unroll
-    for (int32_t i = 0; i < kElementsPerWarp; ++i) {
-      const int32_t j = i + warp_offset;
-      __builtin_assume(j < 128);
-      if (j < buffer_len) {
-        const auto src = kv_buf + j * Trait::kElementSize;
-        const auto kv_tmp = gmem_buffer.load(src);
-        const auto score_tmp = gmem_buffer.load(src + Trait::kScoreOffset);
-#pragma unroll
-        for (int32_t k = 0; k < kTileElements; ++k) {
-          kv[i][k] = cast<InputFloat>(kv_tmp[k]);
-          score[i][k] = cast<InputFloat>(score_tmp[k]);
-        }
-      } else {
-        const auto src = kv_start + j * Trait::kElementSize;
-        kv[i] = gmem_in.load(src);
-        score[i] = gmem_in.load(src + Trait::kScoreOffset);
-      }
+  for (int32_t i = 0; i < kElementsPerWarp; ++i) {
+    const int32_t j = i + warp_offset;
+    __builtin_assume(j < 128);
+    if (j < buffer_len) {
+      const auto src = kv_buf + j * Trait::kElementSize;
+      kv[i] = c128_load<InputFloat, kTileElements>(src, lane_id);
+      score[i] = c128_load<InputFloat, kTileElements>(src + Trait::kScoreOffset, lane_id);
+    } else {
+      const auto src = kv_start + j * Trait::kElementSize;
+      kv[i] = c128_load<InputFloat, kTileElements>(src, lane_id);
+      score[i] = c128_load<InputFloat, kTileElements>(src + Trait::kScoreOffset, lane_id);
     }
   }
 
@@ -281,7 +300,13 @@ SGL_DEVICE void c128_write_decode(BufferFloat* kv_buf, const InputFloat* kv_src)
 }
 
 /// \brief Need to reduce register usage to increase occupancy.
-template <int64_t kHeadDim, typename BufferFloat, typename InputFloat, typename OutFloat, bool kUsePDL>
+template <
+    int64_t kHeadDim,
+    typename BufferFloat,
+    typename InputFloat,
+    typename SrcFloat,
+    typename OutFloat,
+    bool kUsePDL>
 C128_KERNEL void flash_c128_decode(const __grid_constant__ Compress128DecodeParams params) {
   using namespace device;
   using Trait = C128Trait<kHeadDim>;
@@ -293,7 +318,7 @@ C128_KERNEL void flash_c128_decode(const __grid_constant__ Compress128DecodePara
   if (global_bid >= params.batch_size) return;
 
   const auto plan = params.plan_d[global_bid];
-  const auto kv_input = static_cast<const InputFloat*>(params.kv_input) + split_offset;
+  const auto kv_input = static_cast<const SrcFloat*>(params.kv_input) + split_offset;
   const auto kv_output = static_cast<OutFloat*>(params.kv_output) + split_offset;
   const auto kv_buffer = static_cast<BufferFloat*>(params.kv_buffer) + split_offset;
   const auto score_bias = static_cast<const InputFloat*>(params.score_bias) + split_offset;
@@ -306,15 +331,22 @@ C128_KERNEL void flash_c128_decode(const __grid_constant__ Compress128DecodePara
   PDLWaitPrimary<kUsePDL>();
   // the write warp must match the load warp in the following `c128_forward`
   if (warp_id == Trait::kNumWarps - 1) {
-    c128_write_decode<Trait, BufferFloat, InputFloat>(kv_dst, kv_src);
+    c128_write_decode<Trait, BufferFloat, SrcFloat>(kv_dst, kv_src);
   }
   if (plan.write_loc % 128 == 127) {
-    c128_forward<Trait, kUsePDL, BufferFloat, InputFloat, OutFloat>(kv_buf, kv_src, kv_out, score_bias, 128);
+    c128_forward<Trait, kUsePDL, BufferFloat, InputFloat, SrcFloat, OutFloat>(
+        kv_buf, kv_src, kv_out, score_bias, 128);
   }
 }
 
 // compress kernel
-template <int64_t kHeadDim, typename BufferFloat, typename InputFloat, typename OutFloat, bool kUsePDL>
+template <
+    int64_t kHeadDim,
+    typename BufferFloat,
+    typename InputFloat,
+    typename SrcFloat,
+    typename OutFloat,
+    bool kUsePDL>
 C128_KERNEL void flash_c128_prefill(const __grid_constant__ Compress128PrefillParams params) {
   using namespace device;
   using Trait = C128Trait<kHeadDim>;
@@ -325,7 +357,7 @@ C128_KERNEL void flash_c128_prefill(const __grid_constant__ Compress128PrefillPa
   if (global_pid >= params.num_compress) return;
 
   const auto plan = params.plan_c[global_pid];
-  const auto kv_input = static_cast<const InputFloat*>(params.kv_input) + split_offset;
+  const auto kv_input = static_cast<const SrcFloat*>(params.kv_input) + split_offset;
   const auto kv_output = static_cast<OutFloat*>(params.kv_output) + split_offset;
   const auto kv_buffer = static_cast<BufferFloat*>(params.kv_buffer) + split_offset;
   const auto score_bias = static_cast<const InputFloat*>(params.score_bias) + split_offset;
@@ -336,14 +368,21 @@ C128_KERNEL void flash_c128_prefill(const __grid_constant__ Compress128PrefillPa
   const auto kv_out = kv_output + global_pid * Trait::kHeadDim;
   const auto kv_buf = kv_buffer + plan.read_page_1 * Trait::kPageElementSize;
   PDLWaitPrimary<kUsePDL>();
-  c128_forward<Trait, kUsePDL, BufferFloat, InputFloat, OutFloat>(kv_buf, kv_src, kv_out, score_bias, plan.buffer_len);
+  c128_forward<Trait, kUsePDL, BufferFloat, InputFloat, SrcFloat, OutFloat>(
+      kv_buf, kv_src, kv_out, score_bias, plan.buffer_len);
 }
 
-template <int64_t kHeadDim, typename BufferFloat, typename InputFloat, typename OutFloat, bool kUsePDL>
+template <
+    int64_t kHeadDim,
+    typename BufferFloat,
+    typename InputFloat,
+    typename SrcFloat,
+    typename OutFloat,
+    bool kUsePDL>
 WRITE_KERNEL void write_c128_prefill(const __grid_constant__ Compress128PrefillParams params) {
   using namespace device;
   using Trait = C128Trait<kHeadDim>;
-  using StorageInput = AlignedVector<InputFloat, Trait::kTileElements>;
+  using StorageInput = AlignedVector<SrcFloat, Trait::kTileElements>;
 
   const uint32_t global_tid = blockIdx.x * blockDim.x + threadIdx.x;
   const uint32_t global_wid = global_tid / kWarpThreads;      // warp id
@@ -355,7 +394,7 @@ WRITE_KERNEL void write_c128_prefill(const __grid_constant__ Compress128PrefillP
   if (global_pid >= params.num_write) return;
 
   const auto plan = params.plan_w[global_pid];
-  const auto kv_input = static_cast<const InputFloat*>(params.kv_input) + split_offset;
+  const auto kv_input = static_cast<const SrcFloat*>(params.kv_input) + split_offset;
   const auto kv_buffer = static_cast<BufferFloat*>(params.kv_buffer) + split_offset;
   if (plan.is_invalid()) return;
 
@@ -371,7 +410,7 @@ WRITE_KERNEL void write_c128_prefill(const __grid_constant__ Compress128PrefillP
     data[i] = gmem_input.load(kv_src, i);
   }
 
-  if constexpr (std::is_same_v<BufferFloat, InputFloat>) {
+  if constexpr (std::is_same_v<BufferFloat, SrcFloat>) {
     PDLTriggerSecondary<kUsePDL>();
 #pragma unroll
     for (int32_t i = 0; i < 2; ++i) {
@@ -397,12 +436,21 @@ WRITE_KERNEL void write_c128_prefill(const __grid_constant__ Compress128PrefillP
   }
 }
 
-template <int64_t kHeadDim, typename BufferFloat, typename InputFloat, typename OutFloat, bool kUsePDL>
+template <
+    int64_t kHeadDim,
+    typename BufferFloat,
+    typename InputFloat,
+    typename SrcFloat,
+    typename OutFloat,
+    bool kUsePDL>
 struct FlashCompress128Kernel {
   using Trait = C128Trait<kHeadDim>;
-  static constexpr auto decode_kernel = flash_c128_decode<kHeadDim, BufferFloat, InputFloat, OutFloat, kUsePDL>;
-  static constexpr auto prefill_c_kernel = flash_c128_prefill<kHeadDim, BufferFloat, InputFloat, OutFloat, kUsePDL>;
-  static constexpr auto prefill_w_kernel = write_c128_prefill<kHeadDim, BufferFloat, InputFloat, OutFloat, kUsePDL>;
+  static constexpr auto decode_kernel =
+      flash_c128_decode<kHeadDim, BufferFloat, InputFloat, SrcFloat, OutFloat, kUsePDL>;
+  static constexpr auto prefill_c_kernel =
+      flash_c128_prefill<kHeadDim, BufferFloat, InputFloat, SrcFloat, OutFloat, kUsePDL>;
+  static constexpr auto prefill_w_kernel =
+      write_c128_prefill<kHeadDim, BufferFloat, InputFloat, SrcFloat, OutFloat, kUsePDL>;
 
   static void run_decode(
       const tvm::ffi::TensorView kv_buffer,
@@ -421,7 +469,7 @@ struct FlashCompress128Kernel {
         .with_device(device_)
         .verify(kv_buffer);
     TensorMatcher({N, Trait::kElementSize})  // kv score input
-        .with_dtype<InputFloat>()
+        .with_dtype<SrcFloat>()
         .with_device(device_)
         .verify(kv_input);
     TensorMatcher({N, kHeadDim})  // kv compressed output
@@ -468,7 +516,7 @@ struct FlashCompress128Kernel {
         .with_device(device_)
         .verify(kv_buffer);
     TensorMatcher({N, Trait::kElementSize})  // kv score input (ragged)
-        .with_dtype<InputFloat>()
+        .with_dtype<SrcFloat>()
         .with_device(device_)
         .verify(kv_input);
     TensorMatcher({C, kHeadDim})  // kv compressed output (compact)

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/c128_v2.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/c128_v2.cuh
@@ -95,9 +95,7 @@ struct Compress128PrefillParams {
 /// -- so each pointer carries its own storage type and is reconciled here rather
 /// than forcing the producer to pre-convert.
 template <typename Dst, uint32_t kTileElements, typename Src>
-SGL_DEVICE device::AlignedVector<Dst, kTileElements> c128_load(
-    const Src* src,
-    const uint32_t lane_id) {
+SGL_DEVICE device::AlignedVector<Dst, kTileElements> c128_load(const Src* src, const uint32_t lane_id) {
   using namespace device;
 
   using StorageSrc = AlignedVector<Src, kTileElements>;
@@ -334,8 +332,7 @@ C128_KERNEL void flash_c128_decode(const __grid_constant__ Compress128DecodePara
     c128_write_decode<Trait, BufferFloat, SrcFloat>(kv_dst, kv_src);
   }
   if (plan.write_loc % 128 == 127) {
-    c128_forward<Trait, kUsePDL, BufferFloat, InputFloat, SrcFloat, OutFloat>(
-        kv_buf, kv_src, kv_out, score_bias, 128);
+    c128_forward<Trait, kUsePDL, BufferFloat, InputFloat, SrcFloat, OutFloat>(kv_buf, kv_src, kv_out, score_bias, 128);
   }
 }
 

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/c4_v2.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/c4_v2.cuh
@@ -75,11 +75,20 @@ struct C4Trait {
   static_assert(kHeadDim % kTileDim == 0);
 };
 
-template <typename Trait, bool kUsePDL, typename BufferFloat, typename InputFloat, typename OutFloat>
+// SrcFloat is only how kv_score arrives from the wkv_gate gemm; InputFloat stays
+// the compute dtype and the dtype of score_bias (ape). Splitting them lets that
+// gemm hand over bf16 and skip a widening pass, since this kernel widens on load.
+template <
+    typename Trait,
+    bool kUsePDL,
+    typename BufferFloat,
+    typename InputFloat,
+    typename SrcFloat,
+    typename OutFloat>
 SGL_DEVICE void c4_forward(
     const BufferFloat* kv_buf_0,  // overlap [4n - 4, 4n - 1]
     const BufferFloat* kv_buf_1,  // normal [4n + 0, 4n + 3]
-    const InputFloat* kv_src,     // ragged pointer at position = 4n + 3
+    const SrcFloat* kv_src,       // ragged pointer at position = 4n + 3
     OutFloat* kv_out,
     const InputFloat* score_bias,
     const bool should_overlap,
@@ -97,7 +106,7 @@ SGL_DEVICE void c4_forward(
     bias[i] = gmem_in.load(score_bias + i * Trait::kHeadDim);
   }
 
-  if constexpr (std::is_same_v<BufferFloat, InputFloat>) {
+  if constexpr (std::is_same_v<BufferFloat, InputFloat> && std::is_same_v<SrcFloat, InputFloat>) {
     if (should_overlap) {
       const auto kv_start = kv_src - 7 * Trait::kElementSize;  // point to start
 #pragma unroll
@@ -127,7 +136,9 @@ SGL_DEVICE void c4_forward(
     }
   } else {  // mixed dtype
     using StorageBuffer = AlignedVector<BufferFloat, kTileElements>;
+    using StorageSrc = AlignedVector<SrcFloat, kTileElements>;
     const auto gmem_buffer = tile::Memory<StorageBuffer>::warp();
+    const auto gmem_src = tile::Memory<StorageSrc>::warp();
     const auto kv_start_0 = kv_src - 7 * Trait::kElementSize;  // point to start
 
 #pragma unroll
@@ -143,8 +154,13 @@ SGL_DEVICE void c4_forward(
         }
       } else if (should_overlap) {
         const auto base = kv_start_0 + i * Trait::kElementSize;
-        kv[i] = gmem_in.load(base);
-        score[i] = gmem_in.load(base + Trait::kScoreOffset);
+        const auto kv_tmp = gmem_src.load(base);
+        const auto score_tmp = gmem_src.load(base + Trait::kScoreOffset);
+#pragma unroll
+        for (int32_t j = 0; j < kTileElements; ++j) {
+          kv[i][j] = cast<InputFloat>(kv_tmp[j]);
+          score[i][j] = cast<InputFloat>(score_tmp[j]);
+        }
       } else {
         [[unlikely]];
         constexpr float kFloatNegInf = -FLT_MAX;
@@ -167,8 +183,13 @@ SGL_DEVICE void c4_forward(
         }
       } else {
         const auto base = kv_start + i * Trait::kElementSize + Trait::kOverlapOffset;
-        kv[i + 4] = gmem_in.load(base);
-        score[i + 4] = gmem_in.load(base + Trait::kScoreOffset);
+        const auto kv_tmp = gmem_src.load(base);
+        const auto score_tmp = gmem_src.load(base + Trait::kScoreOffset);
+#pragma unroll
+        for (int32_t j = 0; j < kTileElements; ++j) {
+          kv[i + 4][j] = cast<InputFloat>(kv_tmp[j]);
+          score[i + 4][j] = cast<InputFloat>(score_tmp[j]);
+        }
       }
     }
   }
@@ -253,7 +274,13 @@ SGL_DEVICE void c4_write_decode(BufferFloat* kv_buf, const InputFloat* kv_src) {
   }
 }
 
-template <int64_t kHeadDim, typename BufferFloat, typename InputFloat, typename OutFloat, bool kUsePDL>
+template <
+    int64_t kHeadDim,
+    typename BufferFloat,
+    typename InputFloat,
+    typename SrcFloat,
+    typename OutFloat,
+    bool kUsePDL>
 C4_KERNEL void flash_c4_decode(const __grid_constant__ Compress4DecodeParams params) {
   using namespace device;
   using Trait = C4Trait<kHeadDim>;
@@ -266,7 +293,7 @@ C4_KERNEL void flash_c4_decode(const __grid_constant__ Compress4DecodeParams par
   if (global_bid >= params.batch_size) return;
 
   const auto plan = params.plan_d[global_bid];
-  const auto kv_input = static_cast<const InputFloat*>(params.kv_input) + split_offset;
+  const auto kv_input = static_cast<const SrcFloat*>(params.kv_input) + split_offset;
   const auto kv_output = static_cast<OutFloat*>(params.kv_output) + split_offset;
   const auto kv_buffer = static_cast<BufferFloat*>(params.kv_buffer) + split_offset;
   const auto score_bias = static_cast<const InputFloat*>(params.score_bias) + split_offset;
@@ -278,15 +305,21 @@ C4_KERNEL void flash_c4_decode(const __grid_constant__ Compress4DecodeParams par
   const auto kv_dst = kv_buffer + plan.write_loc * Trait::kElementSize;
 
   PDLWaitPrimary<kUsePDL>();
-  c4_write_decode<Trait, BufferFloat, InputFloat>(kv_dst, kv_src);
+  c4_write_decode<Trait, BufferFloat, SrcFloat>(kv_dst, kv_src);
   if (plan.seq_len % 4 == 0) {
     const auto need_overlap = plan.seq_len > 4;
-    c4_forward<Trait, kUsePDL, BufferFloat, InputFloat, OutFloat>(
+    c4_forward<Trait, kUsePDL, BufferFloat, InputFloat, SrcFloat, OutFloat>(
         kv_buf_0, kv_buf_1, kv_src, kv_out, score_bias, need_overlap, 8);
   }
 }
 
-template <int64_t kHeadDim, typename BufferFloat, typename InputFloat, typename OutFloat, bool kUsePDL>
+template <
+    int64_t kHeadDim,
+    typename BufferFloat,
+    typename InputFloat,
+    typename SrcFloat,
+    typename OutFloat,
+    bool kUsePDL>
 C4_KERNEL void flash_c4_prefill(const __grid_constant__ Compress4PrefillParams params) {
   using namespace device;
   using Trait = C4Trait<kHeadDim>;
@@ -299,7 +332,7 @@ C4_KERNEL void flash_c4_prefill(const __grid_constant__ Compress4PrefillParams p
   if (global_pid >= params.num_compress) return;
 
   const auto plan = params.plan_c[global_pid];
-  const auto kv_input = static_cast<const InputFloat*>(params.kv_input) + split_offset;
+  const auto kv_input = static_cast<const SrcFloat*>(params.kv_input) + split_offset;
   const auto kv_output = static_cast<OutFloat*>(params.kv_output) + split_offset;
   const auto kv_buffer = static_cast<BufferFloat*>(params.kv_buffer) + split_offset;
   const auto score_bias = static_cast<const InputFloat*>(params.score_bias) + split_offset;
@@ -312,15 +345,21 @@ C4_KERNEL void flash_c4_prefill(const __grid_constant__ Compress4PrefillParams p
   const auto kv_buf_1 = kv_buffer + plan.read_page_1 * Trait::kPageElementSize;
   const bool need_overlap = plan.seq_len > 4;
   PDLWaitPrimary<kUsePDL>();
-  c4_forward<Trait, kUsePDL, BufferFloat, InputFloat, OutFloat>(
+  c4_forward<Trait, kUsePDL, BufferFloat, InputFloat, SrcFloat, OutFloat>(
       kv_buf_0, kv_buf_1, kv_src, kv_out, score_bias, need_overlap, plan.buffer_len);
 }
 
-template <int64_t kHeadDim, typename BufferFloat, typename InputFloat, typename OutFloat, bool kUsePDL>
+template <
+    int64_t kHeadDim,
+    typename BufferFloat,
+    typename InputFloat,
+    typename SrcFloat,
+    typename OutFloat,
+    bool kUsePDL>
 WRITE_KERNEL void write_c4_prefill(const __grid_constant__ Compress4PrefillParams params) {
   using namespace device;
   using Trait = C4Trait<kHeadDim>;
-  using StorageInput = AlignedVector<InputFloat, kTileElements>;
+  using StorageInput = AlignedVector<SrcFloat, kTileElements>;
 
   const uint32_t global_tid = blockIdx.x * blockDim.x + threadIdx.x;
   const uint32_t global_wid = global_tid / kWarpThreads;      // warp id
@@ -332,7 +371,7 @@ WRITE_KERNEL void write_c4_prefill(const __grid_constant__ Compress4PrefillParam
   if (global_pid >= params.num_write) return;
 
   const auto plan = params.plan_w[global_pid];
-  const auto kv_input = static_cast<const InputFloat*>(params.kv_input) + split_offset;
+  const auto kv_input = static_cast<const SrcFloat*>(params.kv_input) + split_offset;
   const auto kv_buffer = static_cast<BufferFloat*>(params.kv_buffer) + split_offset;
   if (plan.is_invalid()) return;
 
@@ -348,7 +387,7 @@ WRITE_KERNEL void write_c4_prefill(const __grid_constant__ Compress4PrefillParam
     data[i] = gmem_input.load(kv_src, i);
   }
 
-  if constexpr (std::is_same_v<BufferFloat, InputFloat>) {
+  if constexpr (std::is_same_v<BufferFloat, SrcFloat>) {
     PDLTriggerSecondary<kUsePDL>();
 #pragma unroll
     for (int32_t i = 0; i < 4; ++i) {
@@ -374,11 +413,20 @@ WRITE_KERNEL void write_c4_prefill(const __grid_constant__ Compress4PrefillParam
   }
 }
 
-template <int64_t kHeadDim, typename BufferFloat, typename InputFloat, typename OutFloat, bool kUsePDL>
+template <
+    int64_t kHeadDim,
+    typename BufferFloat,
+    typename InputFloat,
+    typename SrcFloat,
+    typename OutFloat,
+    bool kUsePDL>
 struct FlashCompress4Kernel {
-  static constexpr auto decode_kernel = flash_c4_decode<kHeadDim, BufferFloat, InputFloat, OutFloat, kUsePDL>;
-  static constexpr auto prefill_c_kernel = flash_c4_prefill<kHeadDim, BufferFloat, InputFloat, OutFloat, kUsePDL>;
-  static constexpr auto prefill_w_kernel = write_c4_prefill<kHeadDim, BufferFloat, InputFloat, OutFloat, kUsePDL>;
+  static constexpr auto decode_kernel =
+      flash_c4_decode<kHeadDim, BufferFloat, InputFloat, SrcFloat, OutFloat, kUsePDL>;
+  static constexpr auto prefill_c_kernel =
+      flash_c4_prefill<kHeadDim, BufferFloat, InputFloat, SrcFloat, OutFloat, kUsePDL>;
+  static constexpr auto prefill_w_kernel =
+      write_c4_prefill<kHeadDim, BufferFloat, InputFloat, SrcFloat, OutFloat, kUsePDL>;
   static constexpr uint32_t kBlockSize = 128;
   static constexpr uint32_t kTileDim = kTileElements * device::kWarpThreads;
   static constexpr uint32_t kNumSplit = kHeadDim / kTileDim;
@@ -402,7 +450,7 @@ struct FlashCompress4Kernel {
         .with_device(device_)
         .verify(kv_buffer);
     TensorMatcher({N, Trait::kElementSize})  // kv score input
-        .with_dtype<InputFloat>()
+        .with_dtype<SrcFloat>()
         .with_device(device_)
         .verify(kv_input);
     TensorMatcher({N, kHeadDim})  // kv compressed output
@@ -449,7 +497,7 @@ struct FlashCompress4Kernel {
         .with_device(device_)
         .verify(kv_buffer);
     TensorMatcher({N, Trait::kElementSize})  // kv score input (ragged)
-        .with_dtype<InputFloat>()
+        .with_dtype<SrcFloat>()
         .with_device(device_)
         .verify(kv_input);
     TensorMatcher({C, kHeadDim})  // kv compressed output (compact)

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/c4_v2.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/c4_v2.cuh
@@ -421,8 +421,7 @@ template <
     typename OutFloat,
     bool kUsePDL>
 struct FlashCompress4Kernel {
-  static constexpr auto decode_kernel =
-      flash_c4_decode<kHeadDim, BufferFloat, InputFloat, SrcFloat, OutFloat, kUsePDL>;
+  static constexpr auto decode_kernel = flash_c4_decode<kHeadDim, BufferFloat, InputFloat, SrcFloat, OutFloat, kUsePDL>;
   static constexpr auto prefill_c_kernel =
       flash_c4_prefill<kHeadDim, BufferFloat, InputFloat, SrcFloat, OutFloat, kUsePDL>;
   static constexpr auto prefill_w_kernel =

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/fused_compress4_norm_rope.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/fused_compress4_norm_rope.cuh
@@ -1,0 +1,969 @@
+/**
+ * \brief C4 decode compress fused with the norm + RoPE + fp8 store epilogue.
+ *
+ * The unfused chain runs flash_c4_decode, writes the compressed row to a
+ * temporary, and immediately reads it back in fused_norm_rope_flashmla. That
+ * temporary has no other consumer, so the round trip buys nothing but a second
+ * kernel launch -- which at these sizes is most of the cost, since the norm/rope
+ * kernel measures 4.3us against a launch floor of about 4us.
+ *
+ * Both halves already run one block per token, so fusing needs only a common
+ * thread->element mapping. This uses 2 elements per lane (256 threads for
+ * head_dim 512) rather than the compressor's 4, which puts thread tx on elements
+ * [2tx, 2tx+1] -- exactly where the epilogue expects them, and leaves the fp8
+ * groups at one warp / 64 elements / one UE8M0 scale so the bytes written to the
+ * cache are unchanged.
+ *
+ * Buffer layouts are inherited unchanged from c4_v2.cuh:
+ *   kv_buffer: [num_indices, 8, head_dim * 4]  (| kv overlap | kv | score overlap | score |)
+ *   kv_input:  [batch_size, head_dim * 4]
+ *   ape:       [8, head_dim]
+ */
+
+#include <sgl_kernel/tensor.h>
+#include <sgl_kernel/utils.h>
+
+#include <sgl_kernel/tile.cuh>
+#include <sgl_kernel/type.cuh>
+#include <sgl_kernel/utils.cuh>
+#include <sgl_kernel/vec.cuh>
+#include <sgl_kernel/warp.cuh>
+
+#include <sgl_kernel/deepseek_v4/compress_v2.cuh>
+#include <sgl_kernel/deepseek_v4/fp8_utils.cuh>
+
+#include <dlpack/dlpack.h>
+#include <tvm/ffi/container/tensor.h>
+#include <tvm/ffi/object.h>
+
+#include <bit>
+#include <cfloat>
+#include <cstdint>
+#include <type_traits>
+
+namespace sglang {
+
+using PlanD = device::compress::DecodePlan;
+using deepseek_v4::fp8::cast_to_ue8m0;
+using deepseek_v4::fp8::inv_scale_ue8m0;
+using deepseek_v4::fp8::pack_fp8;
+
+constexpr uint32_t kFusedBlockSize = 256;
+constexpr uint32_t kFusedNumWarps = kFusedBlockSize / device::kWarpThreads;
+
+#ifdef USE_ROCM
+/// A `warp` is 32 lanes everywhere in this tree, but the gfx9 wavefront is 64.
+/// The indexer fusion below cares about the difference: it decides both whether
+/// an early-out is uniform and whether a cross-lane step needs a barrier.
+constexpr uint32_t kWaveThreads = 64;
+
+/// `warp::reduce_*` asserts its width down to kWarpThreads, so the wavefront
+/// reductions the indexer fusion needs are spelled out here. The wavefront is a
+/// single lockstep unit, so these need no barrier even when the rest of the
+/// block has already exited.
+SGL_DEVICE float wave_reduce_sum(float value) {
+#pragma unroll
+  for (uint32_t mask = kWaveThreads / 2; mask >= 1; mask >>= 1) {
+    value += __shfl_xor(value, mask, kWaveThreads);
+  }
+  return value;
+}
+
+SGL_DEVICE float wave_reduce_max(float value) {
+#pragma unroll
+  for (uint32_t mask = kWaveThreads / 2; mask >= 1; mask >>= 1) {
+    value = fmaxf(value, __shfl_xor(value, mask, kWaveThreads));
+  }
+  return value;
+}
+#endif
+
+#define FUSED_C4_KERNEL __global__ __launch_bounds__(kFusedBlockSize, 4)
+
+
+struct FusedCompress4NormRopeParams {
+  void* __restrict__ kv_buffer;
+  const void* __restrict__ kv_input;
+  const void* __restrict__ score_bias;
+  const void* __restrict__ norm_weight;
+  const float* __restrict__ freqs_cis;
+  const int64_t* __restrict__ out_loc;
+  uint8_t* __restrict__ kvcache;
+  const PlanD* __restrict__ plan_d;
+  float eps;
+  uint32_t compress_ratio;
+  uint32_t batch_size;
+};
+
+/// \brief `kTileElements_` is elements per lane, and it is what reconciles the
+/// compressor's decomposition with the epilogue it is being fused into:
+///   - head_dim 512 (flashmla): 2, so a 256-thread block spans the whole row and
+///     thread tx lands on elements [2tx, 2tx+1]. The compressor alone uses 4.
+///   - head_dim 128 (indexer): 4, one warp per token, which is already what both
+///     halves do -- no remap at all.
+template <int64_t kHeadDim_, int32_t kTileElements_>
+struct FusedC4Trait {
+  static constexpr int32_t kTileElements = kTileElements_;
+  static constexpr int64_t kTileDim = kTileElements * device::kWarpThreads;
+  static constexpr int64_t kHeadDim = kHeadDim_;
+  static constexpr int64_t kOverlapOffset = kHeadDim;
+  static constexpr int64_t kScoreOffset = kHeadDim * 2;
+  static constexpr int64_t kElementSize = kHeadDim * 4;
+  static constexpr int64_t kPageElementSize = 4 * kElementSize;  // page size = 4
+  static constexpr uint32_t kNumSplit = kHeadDim / kTileDim;
+  static_assert(kHeadDim % kTileDim == 0);
+};
+
+/// \brief Load one lane's tile and widen it to the type the compressor computes
+/// in. The rows the compressor reads come from two places with two layouts --
+/// the ring buffer, and the tail of the wkv_gate gemm output that has not been
+/// staged yet -- so each pointer carries its own storage type and is reconciled
+/// here rather than forcing the producer to pre-convert.
+template <typename Trait, typename Dst, typename Src>
+SGL_DEVICE device::AlignedVector<Dst, Trait::kTileElements> fused_c4_load(const Src* src) {
+  using namespace device;
+
+  using StorageSrc = AlignedVector<Src, Trait::kTileElements>;
+  const auto gmem = tile::Memory<StorageSrc>::warp();
+  const auto raw = gmem.load(src);
+
+  if constexpr (std::is_same_v<Dst, Src>) {
+    return raw;
+  } else {
+    AlignedVector<Dst, Trait::kTileElements> out;
+#pragma unroll
+    for (int32_t j = 0; j < Trait::kTileElements; ++j) {
+      out[j] = cast<Dst>(raw[j]);
+    }
+    return out;
+  }
+}
+
+/// \brief Mirror of c4_write_decode: stage this step's kv/score into the ring
+/// buffer. Runs for every token, including the ones that do not compress.
+template <typename Trait, typename BufferFloat, typename InputFloat>
+SGL_DEVICE void fused_c4_write_decode(BufferFloat* kv_buf, const InputFloat* kv_src) {
+  using namespace device;
+
+  using StorageInput = AlignedVector<InputFloat, Trait::kTileElements>;
+  const auto gmem_input = tile::Memory<StorageInput>::warp();
+
+  StorageInput data[4];
+#pragma unroll
+  for (int32_t i = 0; i < 4; ++i) {
+    data[i] = gmem_input.load(kv_src + Trait::kHeadDim * i);
+  }
+
+  if constexpr (std::is_same_v<BufferFloat, InputFloat>) {
+#pragma unroll
+    for (int32_t i = 0; i < 4; ++i) {
+      gmem_input.store(kv_buf + Trait::kHeadDim * i, data[i]);
+    }
+  } else {
+    using StorageBuffer = AlignedVector<BufferFloat, Trait::kTileElements>;
+    const auto gmem_buffer = tile::Memory<StorageBuffer>::warp();
+
+    StorageBuffer data_cast[4];
+#pragma unroll
+    for (int32_t i = 0; i < 4; ++i) {
+#pragma unroll
+      for (int32_t j = 0; j < Trait::kTileElements; ++j) {
+        data_cast[i][j] = cast<BufferFloat>(data[i][j]);
+      }
+      gmem_buffer.store(kv_buf + Trait::kHeadDim * i, data_cast[i]);
+    }
+  }
+}
+
+/// \brief Mirror of c4_forward, but returns the compressed row in registers
+/// instead of storing it. Arithmetic and ordering are kept identical to the
+/// standalone kernel so the fused path stays bit-exact.
+template <typename Trait, typename BufferFloat, typename InputFloat, typename SrcFloat>
+SGL_DEVICE device::AlignedVector<float, Trait::kTileElements> fused_c4_forward(
+    const BufferFloat* kv_buf_0,  // overlap [4n - 4, 4n - 1]
+    const BufferFloat* kv_buf_1,  // normal [4n + 0, 4n + 3]
+    const SrcFloat* kv_src,       // ragged pointer at position = 4n + 3
+    const InputFloat* score_bias,
+    const bool should_overlap,
+    const int32_t buffer_len) {
+  using namespace device;
+
+  using StorageIn = AlignedVector<InputFloat, Trait::kTileElements>;
+  StorageIn kv[8];
+  StorageIn score[8];
+  StorageIn bias[8];
+
+#pragma unroll
+  for (int32_t i = 0; i < 8; ++i) {
+    bias[i] = fused_c4_load<Trait, InputFloat>(score_bias + i * Trait::kHeadDim);
+  }
+
+  const auto kv_start_0 = kv_src - 7 * Trait::kElementSize;  // point to start
+
+#pragma unroll
+  for (int32_t i = 0; i < 4; ++i) {
+    if (should_overlap && i < buffer_len) {
+      const auto base = kv_buf_0 + i * Trait::kElementSize;
+      kv[i] = fused_c4_load<Trait, InputFloat>(base);
+      score[i] = fused_c4_load<Trait, InputFloat>(base + Trait::kScoreOffset);
+    } else if (should_overlap) {
+      const auto base = kv_start_0 + i * Trait::kElementSize;
+      kv[i] = fused_c4_load<Trait, InputFloat>(base);
+      score[i] = fused_c4_load<Trait, InputFloat>(base + Trait::kScoreOffset);
+    } else {
+      [[unlikely]];
+      constexpr float kFloatNegInf = -FLT_MAX;
+      kv[i].fill(cast<InputFloat>(0.0f));
+      score[i].fill(cast<InputFloat>(kFloatNegInf));
+    }
+  }
+
+  const auto kv_start = kv_src - 3 * Trait::kElementSize;  // point to start
+#pragma unroll
+  for (int32_t i = 0; i < 4; ++i) {
+    if (i + 4 < buffer_len) {
+      const auto base = kv_buf_1 + i * Trait::kElementSize + Trait::kOverlapOffset;
+      kv[i + 4] = fused_c4_load<Trait, InputFloat>(base);
+      score[i + 4] = fused_c4_load<Trait, InputFloat>(base + Trait::kScoreOffset);
+    } else {
+      const auto base = kv_start + i * Trait::kElementSize + Trait::kOverlapOffset;
+      kv[i + 4] = fused_c4_load<Trait, InputFloat>(base);
+      score[i + 4] = fused_c4_load<Trait, InputFloat>(base + Trait::kScoreOffset);
+    }
+  }
+
+  /// NOTE: safe online softmax + weighted sum
+  AlignedVector<float, Trait::kTileElements> result;
+  float score_fp32[Trait::kTileElements][8];
+
+#pragma unroll
+  for (int32_t i = 0; i < Trait::kTileElements; ++i) {
+#pragma unroll
+    for (int32_t j = 0; j < 8; ++j) {
+      score_fp32[i][j] = cast<float>(score[j][i]) + cast<float>(bias[j][i]);
+    }
+  }
+
+#pragma unroll
+  for (int32_t i = 0; i < Trait::kTileElements; ++i) {
+    const auto& score = score_fp32[i];
+    float max_value = score[0];
+    float sum_exp_value = 0.0f;
+
+#pragma unroll
+    for (int32_t j = 1; j < 8; ++j) {
+      const auto fp32_score = score[j];
+      max_value = fmaxf(max_value, fp32_score);
+    }
+
+    float sum_product = 0.0f;
+#pragma unroll
+    for (int32_t j = 0; j < 8; ++j) {
+      const auto fp32_score = score[j];
+      const auto exp_score = expf(fp32_score - max_value);
+      sum_product += cast<float>(kv[j][i]) * exp_score;
+      sum_exp_value += exp_score;
+    }
+
+    result[i] = sum_product / sum_exp_value;
+  }
+  return result;
+}
+
+/// \brief compress -> RMSNorm -> RoPE / fp8 quant -> paged store, in one launch.
+template <
+    int64_t kHeadDim,
+    typename BufferFloat,
+    typename InputFloat,
+    typename SrcFloat,
+    typename DType,
+    int32_t kPageBits,
+    bool kUsePDL,
+    bool kBf16Store>
+FUSED_C4_KERNEL void flash_c4_decode_norm_rope(const __grid_constant__ FusedCompress4NormRopeParams params) {
+  using namespace device;
+  using Trait = FusedC4Trait<kHeadDim, 2>;
+
+  constexpr int64_t kRopeDim = 64;
+  constexpr int64_t kVecSize = Trait::kTileElements;
+  constexpr uint32_t kRopeWarp = kFusedNumWarps - 1;
+  constexpr int64_t kPageBytes =
+      kBf16Store ? (kHeadDim * 2ll << kPageBits) : host::div_ceil(584ll << kPageBits, 576) * 576;
+  static_assert(kHeadDim == kFusedBlockSize * kVecSize);
+  static_assert(kRopeDim == kWarpThreads * kVecSize);
+  static_assert(kHeadDim - kRopeDim == kRopeWarp * kWarpThreads * kVecSize);
+  using Float2 = AlignedVector<float, kVecSize>;
+  using Storage = AlignedVector<DType, kVecSize>;
+
+  const auto tx = threadIdx.x;
+  const auto warp_id = tx / kWarpThreads;
+  const auto lane_id = tx % kWarpThreads;
+  const auto token_id = blockIdx.x;
+  if (token_id >= params.batch_size) return;
+
+  // One warp per head_dim split, one block per token.
+  const int64_t split_offset = static_cast<int64_t>(warp_id) * Trait::kTileDim;
+
+  const auto plan = params.plan_d[token_id];
+  const auto kv_input = static_cast<const SrcFloat*>(params.kv_input) + split_offset;
+  const auto kv_buffer = static_cast<BufferFloat*>(params.kv_buffer) + split_offset;
+  const auto score_bias = static_cast<const InputFloat*>(params.score_bias) + split_offset;
+
+  const auto kv_src = kv_input + token_id * Trait::kElementSize;
+  const auto kv_buf_0 = kv_buffer + plan.read_page_0 * Trait::kPageElementSize;
+  const auto kv_buf_1 = kv_buffer + plan.read_page_1 * Trait::kPageElementSize;
+  const auto kv_dst = kv_buffer + plan.write_loc * Trait::kElementSize;
+
+  PDLWaitPrimary<kUsePDL>();
+  fused_c4_write_decode<Trait, BufferFloat, SrcFloat>(kv_dst, kv_src);
+
+  // Matches the standalone pair: compress only emits on ratio boundaries, and
+  // the norm/rope kernel returns early on exactly the same condition.
+  if (plan.seq_len % params.compress_ratio != 0) return;
+
+  const auto need_overlap = plan.seq_len > 4;
+  Float2 data = fused_c4_forward<Trait, BufferFloat, InputFloat, SrcFloat>(
+      kv_buf_0, kv_buf_1, kv_src, score_bias, need_overlap, 8);
+
+  const auto position = static_cast<int32_t>(plan.seq_len - params.compress_ratio);
+  const auto out_loc = params.out_loc[token_id];
+  const auto freqs_cis = params.freqs_cis + position * kRopeDim;
+
+  Float2 freq;
+  if (warp_id == kRopeWarp) freq.load(freqs_cis, lane_id);
+
+  // part 1: RMSNorm. Sum of squares reduced across the block, which holds the
+  // whole head_dim row.
+  {
+    __shared__ float partial_sums[kFusedNumWarps];
+
+    Storage weight_vec;
+    weight_vec.load(params.norm_weight, tx);
+
+    float sum_of_squares = 0.0f;
+#pragma unroll
+    for (int i = 0; i < kVecSize; ++i) {
+      sum_of_squares += data[i] * data[i];
+    }
+
+    const auto warp_sum = warp::reduce_sum(sum_of_squares);
+    if (lane_id == 0) partial_sums[warp_id] = warp_sum;
+    __syncthreads();
+    sum_of_squares = warp::reduce_sum<kFusedNumWarps>(partial_sums[lane_id % kFusedNumWarps]);
+    const auto norm_factor = math::rsqrt(sum_of_squares / kHeadDim + params.eps);
+
+#pragma unroll
+    for (int i = 0; i < kVecSize; ++i) {
+      const auto fp32_weight = cast<float>(weight_vec[i]);
+      data[i] = data[i] * norm_factor * fp32_weight;
+    }
+  }
+
+  const int64_t page = out_loc >> kPageBits;
+  const int64_t offset = out_loc & ((1 << kPageBits) - 1);
+  const auto page_ptr = params.kvcache + page * kPageBytes;
+  const auto value_ptr = page_ptr + offset * (kBf16Store ? (kHeadDim * 2) : 576);
+
+  PDLTriggerSecondary<kUsePDL>();
+
+  // part 2: rope on the last warp, then either a plain bf16 store or a
+  // per-warp fp8 group quant on the non-rope warps.
+  if constexpr (kBf16Store) {
+    Float2 d = data;
+    if (warp_id == kRopeWarp) {
+      const auto x_real = data[0];
+      const auto x_imag = data[1];
+      const auto freq_real = freq[0];
+      const auto freq_imag = freq[1];
+      d[0] = x_real * freq_real - x_imag * freq_imag;
+      d[1] = x_real * freq_imag + x_imag * freq_real;
+    }
+    reinterpret_cast<bf16x2_t*>(value_ptr)[tx] = cast<bf16x2_t>(fp32x2_t{d[0], d[1]});
+  } else if (warp_id == kRopeWarp) {
+    const auto x_real = data[0];
+    const auto x_imag = data[1];
+    const auto freq_real = freq[0];
+    const auto freq_imag = freq[1];
+    data[0] = x_real * freq_real - x_imag * freq_imag;
+    data[1] = x_real * freq_imag + x_imag * freq_real;
+    const auto result = cast<bf16x2_t>(fp32x2_t{data[0], data[1]});
+    const auto rope_ptr = value_ptr + 448;
+    reinterpret_cast<bf16x2_t*>(rope_ptr)[lane_id] = result;
+  } else {
+    // BF16 round-trip to match the precision of the non-fused path.
+    const auto x = cast<float>(cast<bf16_t>(data[0]));
+    const auto y = cast<float>(cast<bf16_t>(data[1]));
+    const auto abs_max = warp::reduce_max(fmaxf(fabs(x), fabs(y)));
+    const auto scale_raw = fmaxf(1e-4f, abs_max) / kFP8E4M3Max;
+    const auto scale_ue8m0 = cast_to_ue8m0(scale_raw);
+    const auto inv_scale = inv_scale_ue8m0(scale_ue8m0);
+    const auto result = pack_fp8(x * inv_scale, y * inv_scale);
+    const auto scale_ptr = page_ptr + (576 << kPageBits) + offset * 8;
+    reinterpret_cast<fp8x2_e4m3_t*>(value_ptr)[tx] = result;
+    if (lane_id == 0) static_cast<uint8_t*>(scale_ptr)[warp_id] = scale_ue8m0;
+  }
+}
+
+template <
+    int64_t kHeadDim,
+    typename BufferFloat,
+    typename InputFloat,
+    typename SrcFloat,
+    typename DType,
+    uint32_t kPageSize,
+    bool kUsePDL,
+    bool kBf16Store>
+struct FusedCompress4NormRopeKernel {
+  static constexpr int32_t kLogPageSize = std::countr_zero(kPageSize);
+  static constexpr int64_t kPageBytes =
+      kBf16Store ? (kHeadDim * 2 * kPageSize) : host::div_ceil(584 * kPageSize, 576) * 576;
+  static constexpr auto kernel = flash_c4_decode_norm_rope<
+      kHeadDim,
+      BufferFloat,
+      InputFloat,
+      SrcFloat,
+      DType,
+      kLogPageSize,
+      kUsePDL,
+      kBf16Store>;
+  using Trait = FusedC4Trait<kHeadDim, 2>;
+
+  static_assert(kHeadDim == 512, "fused c4 epilogue is defined for flashmla head_dim=512");
+  static_assert(std::has_single_bit(kPageSize), "kPageSize must be a power of 2");
+
+  static void run_decode(
+      const tvm::ffi::TensorView kv_buffer,
+      const tvm::ffi::TensorView kv_input,
+      const tvm::ffi::TensorView ape,
+      const tvm::ffi::TensorView plan_d_,
+      const tvm::ffi::TensorView norm_weight,
+      const double eps,
+      const tvm::ffi::TensorView freqs_cis,
+      const tvm::ffi::TensorView out_loc,
+      const tvm::ffi::TensorView kvcache,
+      const int64_t compress_ratio) {
+    using namespace host;
+
+    auto N = SymbolicSize{"batch_size"};
+    auto device_ = SymbolicDevice{};
+    device_.set_options<kDLGPU>();
+
+    TensorMatcher({-1, 4, Trait::kElementSize})  // kv score
+        .with_dtype<BufferFloat>()
+        .with_device(device_)
+        .verify(kv_buffer);
+    TensorMatcher({N, Trait::kElementSize})  // kv score input
+        .with_dtype<SrcFloat>()
+        .with_device(device_)
+        .verify(kv_input);
+    TensorMatcher({8, kHeadDim})  // ape
+        .with_dtype<InputFloat>()
+        .with_device(device_)
+        .verify(ape);
+    TensorMatcher({kHeadDim})  // norm weight
+        .with_dtype<DType>()
+        .with_device(device_)
+        .verify(norm_weight);
+    TensorMatcher({-1, 64})  // freqs_cis
+        .with_dtype<float>()
+        .with_device(device_)
+        .verify(freqs_cis);
+    TensorMatcher({-1})  // out_loc
+        .with_dtype<int64_t>()
+        .with_device(device_)
+        .verify(out_loc);
+    TensorMatcher({-1, -1})  // cache
+        .with_strides({kPageBytes, 1})
+        .with_dtype<uint8_t>()
+        .with_device(device_)
+        .verify(kvcache);
+
+    const auto plan_d = compress::verify_plan_d(plan_d_, N, device_);
+    const auto batch_size = static_cast<uint32_t>(N.unwrap());
+    if (batch_size == 0) return;
+    RuntimeCheck(out_loc.size(0) == N.unwrap());
+
+    const auto params = FusedCompress4NormRopeParams{
+        .kv_buffer = kv_buffer.data_ptr(),
+        .kv_input = kv_input.data_ptr(),
+        .score_bias = ape.data_ptr(),
+        .norm_weight = norm_weight.data_ptr(),
+        .freqs_cis = static_cast<const float*>(freqs_cis.data_ptr()),
+        .out_loc = static_cast<const int64_t*>(out_loc.data_ptr()),
+        .kvcache = static_cast<uint8_t*>(kvcache.data_ptr()),
+        .plan_d = plan_d,
+        .eps = static_cast<float>(eps),
+        .compress_ratio = static_cast<uint32_t>(compress_ratio),
+        .batch_size = batch_size,
+    };
+    // One block per token: the block owns the whole head_dim row.
+    LaunchKernel(batch_size, kFusedBlockSize, device_.unwrap())  //
+        .enable_pdl(kUsePDL)(kernel, params);
+  }
+};
+
+/// \brief compress -> RMSNorm -> RoPE -> hadamard -> fp8 quant -> paged store,
+/// for the indexer (head_dim 128). Unlike the flashmla variant this needs no
+/// remap: the compressor and the epilogue both already put one token on one
+/// warp with 4 elements per lane, and every reduction here is warp-local, so
+/// block size is free. 8 warps = 8 tokens per block, matching the epilogue.
+template <
+    typename BufferFloat,
+    typename InputFloat,
+    typename SrcFloat,
+    typename DType,
+    int32_t kPageBits,
+    bool kUsePDL,
+    int32_t kPreshuffleSize>
+FUSED_C4_KERNEL void flash_c4_decode_norm_rope_indexer(
+    const __grid_constant__ FusedCompress4NormRopeParams params) {
+  using namespace device;
+
+  constexpr int64_t kHeadDim = 128;
+  using Trait = FusedC4Trait<kHeadDim, 4>;
+  constexpr int64_t kRopeDim = 64;
+  constexpr int64_t kVecSize = Trait::kTileElements;
+  constexpr uint32_t kRopeSize = kRopeDim / kVecSize;
+  constexpr int64_t kPageBytes = 132ll << kPageBits;
+  static_assert(kHeadDim == kWarpThreads * kVecSize);
+  static_assert(kRopeDim == kWarpThreads * 2);
+  static_assert(Trait::kNumSplit == 1, "indexer fusion runs one warp per token");
+  using Float4 = AlignedVector<float, kVecSize>;
+  using Storage = AlignedVector<DType, kVecSize>;
+
+  const auto warp_id = threadIdx.x / kWarpThreads;
+  const auto lane_id = threadIdx.x % kWarpThreads;
+  const auto token_id = blockIdx.x * kFusedNumWarps + warp_id;
+  // Lanes whose 4-elem pack lies in the rope tail (= last `kRopeSize` packs).
+  const bool is_rope_lane = lane_id >= kWarpThreads - kRopeSize;
+
+  if (token_id >= params.batch_size) return;
+
+  const auto plan = params.plan_d[token_id];
+  const auto kv_input = static_cast<const SrcFloat*>(params.kv_input);
+  const auto kv_buffer = static_cast<BufferFloat*>(params.kv_buffer);
+  const auto score_bias = static_cast<const InputFloat*>(params.score_bias);
+
+  const auto kv_src = kv_input + token_id * Trait::kElementSize;
+  const auto kv_buf_0 = kv_buffer + plan.read_page_0 * Trait::kPageElementSize;
+  const auto kv_buf_1 = kv_buffer + plan.read_page_1 * Trait::kPageElementSize;
+  const auto kv_dst = kv_buffer + plan.write_loc * Trait::kElementSize;
+
+  PDLWaitPrimary<kUsePDL>();
+  fused_c4_write_decode<Trait, BufferFloat, SrcFloat>(kv_dst, kv_src);
+
+  // Warp-uniform, so the cross-lane butterflies below still see a full warp.
+  if (plan.seq_len % params.compress_ratio != 0) return;
+
+  Float4 data = fused_c4_forward<Trait, BufferFloat, InputFloat, SrcFloat>(
+      kv_buf_0, kv_buf_1, kv_src, score_bias, plan.seq_len > 4, 8);
+
+  const auto position = static_cast<int32_t>(plan.seq_len - params.compress_ratio);
+  const auto out_loc = params.out_loc[token_id];
+  const auto freqs_cis = params.freqs_cis + position * kRopeDim;
+
+  Float4 freq;
+
+  // part 1: norm
+  {
+    Storage weight_vec;
+    weight_vec.load(params.norm_weight, lane_id);
+    if (is_rope_lane) freq.load(freqs_cis, lane_id - (kWarpThreads - kRopeSize));
+
+    float sum_of_squares = 0.0f;
+#pragma unroll
+    for (int i = 0; i < kVecSize; ++i) {
+      sum_of_squares += data[i] * data[i];
+    }
+
+    sum_of_squares = warp::reduce_sum(sum_of_squares);
+    const auto norm_factor = math::rsqrt(sum_of_squares / kHeadDim + params.eps);
+
+#pragma unroll
+    for (int i = 0; i < kVecSize; ++i) {
+      const auto fp32_weight = cast<float>(weight_vec[i]);
+      data[i] = data[i] * norm_factor * fp32_weight;
+    }
+  }
+
+  // part 2: rope (rope-lane only, 4 elems per lane = 2 (real, imag) pairs)
+  if (is_rope_lane) {
+    const auto x_real = data[0];
+    const auto x_imag = data[1];
+    const auto y_real = data[2];
+    const auto y_imag = data[3];
+    const auto freq_x_real = freq[0];
+    const auto freq_x_imag = freq[1];
+    const auto freq_y_real = freq[2];
+    const auto freq_y_imag = freq[3];
+    data[0] = x_real * freq_x_real - x_imag * freq_x_imag;
+    data[1] = x_real * freq_x_imag + x_imag * freq_x_real;
+    data[2] = y_real * freq_y_real - y_imag * freq_y_imag;
+    data[3] = y_real * freq_y_imag + y_imag * freq_y_real;
+  }
+
+  // part 3: hadamard transform
+  {
+    {
+      const float a0 = data[0], a1 = data[1], a2 = data[2], a3 = data[3];
+      data[0] = a0 + a1;
+      data[1] = a0 - a1;
+      data[2] = a2 + a3;
+      data[3] = a2 - a3;
+    }
+    {
+      const float a0 = data[0], a1 = data[1], a2 = data[2], a3 = data[3];
+      data[0] = a0 + a2;
+      data[1] = a1 + a3;
+      data[2] = a0 - a2;
+      data[3] = a1 - a3;
+    }
+#pragma unroll
+    for (uint32_t mask = 1; mask < kWarpThreads; mask <<= 1) {
+#pragma unroll
+      for (int i = 0; i < kVecSize; ++i) {
+#ifndef USE_ROCM
+        const float other = __shfl_xor_sync(kFullMask, data[i], mask, kWarpThreads);
+#else
+        const float other = __shfl_xor(data[i], mask, kWarpThreads);
+#endif
+        data[i] = (lane_id & mask) ? (other - data[i]) : (data[i] + other);
+      }
+    }
+    const float kHadamardScale = math::rsqrt(static_cast<float>(kHeadDim));
+#pragma unroll
+    for (int i = 0; i < kVecSize; ++i)
+      data[i] *= kHadamardScale;
+  }
+
+  // part 4: per-warp UE8M0 quant + store (128 elements -> one fp8 group).
+  {
+    using OutStorage = AlignedVector<fp8x2_e4m3_t, 2>;
+    float local_max = math::abs(data[0]);
+#pragma unroll
+    for (int i = 1; i < kVecSize; ++i) {
+      local_max = math::max(local_max, math::abs(data[i]));
+    }
+    const auto abs_max = warp::reduce_max(local_max);
+    const auto scale = fmaxf(1e-4f, abs_max) / kFP8E4M3Max;
+    const auto inv_scale = 1.0f / scale;
+    const int64_t page = out_loc >> kPageBits;
+    const int64_t offset = out_loc & ((1 << kPageBits) - 1);
+    const auto page_ptr = params.kvcache + page * kPageBytes;
+    const auto value_ptr = page_ptr + offset * 128;
+    const auto scale_ptr = page_ptr + (128 << kPageBits) + offset * 4;
+    OutStorage result;
+    result[0] = pack_fp8(data[0] * inv_scale, data[1] * inv_scale);
+    result[1] = pack_fp8(data[2] * inv_scale, data[3] * inv_scale);
+    PDLTriggerSecondary<kUsePDL>();
+    if constexpr (kPreshuffleSize != 0) {
+      constexpr int32_t kTile = kPreshuffleSize;
+      const int32_t dim_base = lane_id * kVecSize;
+      const int32_t token_tile_id = offset / kTile;
+      const int32_t token_in_tile = offset % kTile;
+      const int32_t col_tile_id = dim_base / kTile;
+      const int32_t col_in_tile = dim_base % kTile;
+      const int32_t value_offset = token_tile_id * (kTile * static_cast<int32_t>(kHeadDim)) +
+                                   col_tile_id * (kTile * kTile) + token_in_tile * kTile + col_in_tile;
+      result.store(page_ptr + value_offset, 0);
+    } else {
+      result.store(value_ptr, lane_id);
+    }
+    if (lane_id == 0) reinterpret_cast<float*>(scale_ptr)[0] = scale;
+  }
+}
+
+#ifdef USE_ROCM
+/// \brief Same fusion as `flash_c4_decode_norm_rope_indexer`, but one token per
+/// *wavefront* instead of one token per 32-lane warp.
+///
+/// The warp-mapped version above loses to the two kernels it replaces, for two
+/// reasons that are both about the 32-vs-64 mismatch:
+///
+///   - Two tokens share a wavefront, so `seq_len % ratio` is not wave-uniform.
+///     Only one token in four compresses, so 1 - (3/4)^2 = 44% of wavefronts
+///     run the whole compress + norm + rope + quant tail for (usually) a single
+///     live token. The standalone norm/rope kernel launches over the compressed
+///     rows only and never pays this.
+///   - 4 elements per lane keeps `score_fp32[4][8]` live across the softmax,
+///     which put the kernel at 85 VGPRs / 5 waves per SIMD against 76 / 6 and
+///     26 / 8 for the pair it replaced.
+///
+/// Handing the token a whole wavefront at 2 elements per lane fixes both at
+/// once: the early-out becomes wave-uniform, and the live set halves. It also
+/// makes every cross-lane step here span exactly one wavefront, so the
+/// reductions and the Hadamard butterfly are plain shuffles. That matters more
+/// than it looks -- a block holds 4 independent tokens that exit at different
+/// times, so a __syncthreads() would be unusable here.
+template <
+    typename BufferFloat,
+    typename InputFloat,
+    typename SrcFloat,
+    typename DType,
+    int32_t kPageBits,
+    bool kUsePDL,
+    int32_t kPreshuffleSize>
+FUSED_C4_KERNEL void flash_c4_decode_norm_rope_indexer_w64(
+    const __grid_constant__ FusedCompress4NormRopeParams params) {
+  using namespace device;
+
+  constexpr int64_t kHeadDim = 128;
+  using Trait = FusedC4Trait<kHeadDim, 2>;
+  constexpr int64_t kRopeDim = 64;
+  constexpr int64_t kVecSize = Trait::kTileElements;
+  constexpr uint32_t kWarpsPerToken = Trait::kNumSplit;
+  constexpr uint32_t kThreadsPerToken = kWarpsPerToken * kWarpThreads;
+  constexpr uint32_t kTokensPerBlock = kFusedBlockSize / kThreadsPerToken;
+  constexpr int64_t kPageBytes = 132ll << kPageBits;
+  static_assert(kThreadsPerToken == kWaveThreads, "one token must own one wavefront");
+  static_assert(kHeadDim == kThreadsPerToken * kVecSize);
+  static_assert(kRopeDim == kWarpThreads * kVecSize, "rope tail is the token's last warp");
+  using Float2 = AlignedVector<float, kVecSize>;
+  using Storage = AlignedVector<DType, kVecSize>;
+
+  const auto tx = threadIdx.x;
+  const auto warp_id = tx / kWarpThreads;
+  const auto lane_id = tx % kWarpThreads;
+  const auto local_token = warp_id / kWarpsPerToken;
+  const auto split_id = warp_id % kWarpsPerToken;
+  // Element slot within the token's row, and equally the lane's index in the
+  // wavefront, which is what the butterflies below index by.
+  const auto wave_lane = split_id * kWarpThreads + lane_id;
+  const auto token_id = blockIdx.x * kTokensPerBlock + local_token;
+
+  if (token_id >= params.batch_size) return;
+
+  const int64_t split_offset = static_cast<int64_t>(split_id) * Trait::kTileDim;
+
+  const auto plan = params.plan_d[token_id];
+  const auto kv_input = static_cast<const SrcFloat*>(params.kv_input) + split_offset;
+  const auto kv_buffer = static_cast<BufferFloat*>(params.kv_buffer) + split_offset;
+  const auto score_bias = static_cast<const InputFloat*>(params.score_bias) + split_offset;
+
+  const auto kv_src = kv_input + token_id * Trait::kElementSize;
+  const auto kv_buf_0 = kv_buffer + plan.read_page_0 * Trait::kPageElementSize;
+  const auto kv_buf_1 = kv_buffer + plan.read_page_1 * Trait::kPageElementSize;
+  const auto kv_dst = kv_buffer + plan.write_loc * Trait::kElementSize;
+
+  PDLWaitPrimary<kUsePDL>();
+  fused_c4_write_decode<Trait, BufferFloat, SrcFloat>(kv_dst, kv_src);
+
+  // Wave-uniform: all 64 lanes of this token take the same branch.
+  if (plan.seq_len % params.compress_ratio != 0) return;
+
+  Float2 data = fused_c4_forward<Trait, BufferFloat, InputFloat, SrcFloat>(
+      kv_buf_0, kv_buf_1, kv_src, score_bias, plan.seq_len > 4, 8);
+
+  const auto position = static_cast<int32_t>(plan.seq_len - params.compress_ratio);
+  const auto out_loc = params.out_loc[token_id];
+  const auto freqs_cis = params.freqs_cis + position * kRopeDim;
+  const bool is_rope_warp = split_id == kWarpsPerToken - 1;
+
+  Float2 freq;
+
+  // part 1: norm
+  {
+    Storage weight_vec;
+    weight_vec.load(params.norm_weight, wave_lane);
+    if (is_rope_warp) freq.load(freqs_cis, lane_id);
+
+    float sum_of_squares = 0.0f;
+#pragma unroll
+    for (int i = 0; i < kVecSize; ++i) {
+      sum_of_squares += data[i] * data[i];
+    }
+
+    sum_of_squares = wave_reduce_sum(sum_of_squares);
+    const auto norm_factor = math::rsqrt(sum_of_squares / kHeadDim + params.eps);
+
+#pragma unroll
+    for (int i = 0; i < kVecSize; ++i) {
+      const auto fp32_weight = cast<float>(weight_vec[i]);
+      data[i] = data[i] * norm_factor * fp32_weight;
+    }
+  }
+
+  // part 2: rope on the token's last warp, 1 (real, imag) pair per lane
+  if (is_rope_warp) {
+    const auto x_real = data[0];
+    const auto x_imag = data[1];
+    const auto freq_real = freq[0];
+    const auto freq_imag = freq[1];
+    data[0] = x_real * freq_real - x_imag * freq_imag;
+    data[1] = x_real * freq_imag + x_imag * freq_real;
+  }
+
+  // part 3: hadamard. Same 128-point transform as the warp-mapped kernel: the
+  // element index is still `lane * kVecSize + i`, so moving a bit out of the
+  // register loop and into the lane loop leaves the result unchanged.
+  {
+    {
+      const float a0 = data[0], a1 = data[1];
+      data[0] = a0 + a1;
+      data[1] = a0 - a1;
+    }
+#pragma unroll
+    for (uint32_t mask = 1; mask < kWaveThreads; mask <<= 1) {
+#pragma unroll
+      for (int i = 0; i < kVecSize; ++i) {
+        const float other = __shfl_xor(data[i], mask, kWaveThreads);
+        data[i] = (wave_lane & mask) ? (other - data[i]) : (data[i] + other);
+      }
+    }
+    const float kHadamardScale = math::rsqrt(static_cast<float>(kHeadDim));
+#pragma unroll
+    for (int i = 0; i < kVecSize; ++i)
+      data[i] *= kHadamardScale;
+  }
+
+  // part 4: one fp8 group per 128-element row, so the scale reduces over the
+  // whole wavefront rather than over a warp.
+  {
+    float local_max = math::abs(data[0]);
+#pragma unroll
+    for (int i = 1; i < kVecSize; ++i) {
+      local_max = math::max(local_max, math::abs(data[i]));
+    }
+    const auto abs_max = wave_reduce_max(local_max);
+    const auto scale = fmaxf(1e-4f, abs_max) / kFP8E4M3Max;
+    const auto inv_scale = 1.0f / scale;
+    const int64_t page = out_loc >> kPageBits;
+    const int64_t offset = out_loc & ((1 << kPageBits) - 1);
+    const auto page_ptr = params.kvcache + page * kPageBytes;
+    const auto value_ptr = page_ptr + offset * 128;
+    const auto scale_ptr = page_ptr + (128 << kPageBits) + offset * 4;
+    const auto result = pack_fp8(data[0] * inv_scale, data[1] * inv_scale);
+    PDLTriggerSecondary<kUsePDL>();
+    if constexpr (kPreshuffleSize != 0) {
+      constexpr int32_t kTile = kPreshuffleSize;
+      const int32_t dim_base = wave_lane * kVecSize;
+      const int32_t token_tile_id = offset / kTile;
+      const int32_t token_in_tile = offset % kTile;
+      const int32_t col_tile_id = dim_base / kTile;
+      const int32_t col_in_tile = dim_base % kTile;
+      const int32_t value_offset = token_tile_id * (kTile * static_cast<int32_t>(kHeadDim)) +
+                                   col_tile_id * (kTile * kTile) + token_in_tile * kTile + col_in_tile;
+      *reinterpret_cast<fp8x2_e4m3_t*>(page_ptr + value_offset) = result;
+    } else {
+      reinterpret_cast<fp8x2_e4m3_t*>(value_ptr)[wave_lane] = result;
+    }
+    if (wave_lane == 0) reinterpret_cast<float*>(scale_ptr)[0] = scale;
+  }
+}
+#endif  // USE_ROCM
+
+template <
+    typename BufferFloat,
+    typename InputFloat,
+    typename SrcFloat,
+    typename DType,
+    uint32_t kPageSize,
+    bool kUsePDL,
+    int32_t kPreshuffleSize>
+struct FusedCompress4NormRopeIndexerKernel {
+  static constexpr int64_t kHeadDim = 128;
+  static constexpr int32_t kLogPageSize = std::countr_zero(kPageSize);
+  static constexpr int64_t kPageBytes = 132 * kPageSize;
+#ifdef USE_ROCM
+  static constexpr auto kernel = flash_c4_decode_norm_rope_indexer_w64<
+      BufferFloat,
+      InputFloat,
+      SrcFloat,
+      DType,
+      kLogPageSize,
+      kUsePDL,
+      kPreshuffleSize>;
+  static constexpr uint32_t kTokensPerBlock = kFusedBlockSize / kWaveThreads;
+  using Trait = FusedC4Trait<kHeadDim, 2>;
+#else
+  static constexpr auto kernel = flash_c4_decode_norm_rope_indexer<
+      BufferFloat,
+      InputFloat,
+      SrcFloat,
+      DType,
+      kLogPageSize,
+      kUsePDL,
+      kPreshuffleSize>;
+  static constexpr uint32_t kTokensPerBlock = kFusedNumWarps;
+  using Trait = FusedC4Trait<kHeadDim, 4>;
+#endif
+
+  static_assert(std::has_single_bit(kPageSize), "kPageSize must be a power of 2");
+
+  static void run_decode(
+      const tvm::ffi::TensorView kv_buffer,
+      const tvm::ffi::TensorView kv_input,
+      const tvm::ffi::TensorView ape,
+      const tvm::ffi::TensorView plan_d_,
+      const tvm::ffi::TensorView norm_weight,
+      const double eps,
+      const tvm::ffi::TensorView freqs_cis,
+      const tvm::ffi::TensorView out_loc,
+      const tvm::ffi::TensorView kvcache,
+      const int64_t compress_ratio) {
+    using namespace host;
+
+    auto N = SymbolicSize{"batch_size"};
+    auto device_ = SymbolicDevice{};
+    device_.set_options<kDLGPU>();
+
+    TensorMatcher({-1, 4, Trait::kElementSize})  // kv score
+        .with_dtype<BufferFloat>()
+        .with_device(device_)
+        .verify(kv_buffer);
+    TensorMatcher({N, Trait::kElementSize})  // kv score input
+        .with_dtype<SrcFloat>()
+        .with_device(device_)
+        .verify(kv_input);
+    TensorMatcher({8, kHeadDim})  // ape
+        .with_dtype<InputFloat>()
+        .with_device(device_)
+        .verify(ape);
+    TensorMatcher({kHeadDim})  // norm weight
+        .with_dtype<DType>()
+        .with_device(device_)
+        .verify(norm_weight);
+    TensorMatcher({-1, 64})  // freqs_cis
+        .with_dtype<float>()
+        .with_device(device_)
+        .verify(freqs_cis);
+    TensorMatcher({-1})  // out_loc
+        .with_dtype<int64_t>()
+        .with_device(device_)
+        .verify(out_loc);
+    TensorMatcher({-1, -1})  // cache
+        .with_strides({kPageBytes, 1})
+        .with_dtype<uint8_t>()
+        .with_device(device_)
+        .verify(kvcache);
+
+    const auto plan_d = compress::verify_plan_d(plan_d_, N, device_);
+    const auto batch_size = static_cast<uint32_t>(N.unwrap());
+    if (batch_size == 0) return;
+    RuntimeCheck(out_loc.size(0) == N.unwrap());
+
+    const auto params = FusedCompress4NormRopeParams{
+        .kv_buffer = kv_buffer.data_ptr(),
+        .kv_input = kv_input.data_ptr(),
+        .score_bias = ape.data_ptr(),
+        .norm_weight = norm_weight.data_ptr(),
+        .freqs_cis = static_cast<const float*>(freqs_cis.data_ptr()),
+        .out_loc = static_cast<const int64_t*>(out_loc.data_ptr()),
+        .kvcache = static_cast<uint8_t*>(kvcache.data_ptr()),
+        .plan_d = plan_d,
+        .eps = static_cast<float>(eps),
+        .compress_ratio = static_cast<uint32_t>(compress_ratio),
+        .batch_size = batch_size,
+    };
+    // A 256-thread block either way: 4 tokens of one wavefront each on HIP, or
+    // 8 tokens of one warp each elsewhere. Splitting into smaller blocks to
+    // spread across more CUs backfires: the tighter launch bound costs
+    // registers and the kernel spills (117 VGPRs clean at 256/occ4 vs 64 + 372B
+    // scratch at 128/occ8), which measured 2x slower in situ.
+    const uint32_t num_blocks = div_ceil(batch_size, kTokensPerBlock);
+    LaunchKernel(num_blocks, kFusedBlockSize, device_.unwrap())  //
+        .enable_pdl(kUsePDL)(kernel, params);
+  }
+};
+
+}  // namespace sglang

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/fused_compress4_norm_rope.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/fused_compress4_norm_rope.cuh
@@ -80,7 +80,6 @@ SGL_DEVICE float wave_reduce_max(float value) {
 
 #define FUSED_C4_KERNEL __global__ __launch_bounds__(kFusedBlockSize, 4)
 
-
 struct FusedCompress4NormRopeParams {
   void* __restrict__ kv_buffer;
   const void* __restrict__ kv_input;
@@ -417,15 +416,8 @@ struct FusedCompress4NormRopeKernel {
   static constexpr int32_t kLogPageSize = std::countr_zero(kPageSize);
   static constexpr int64_t kPageBytes =
       kBf16Store ? (kHeadDim * 2 * kPageSize) : host::div_ceil(584 * kPageSize, 576) * 576;
-  static constexpr auto kernel = flash_c4_decode_norm_rope<
-      kHeadDim,
-      BufferFloat,
-      InputFloat,
-      SrcFloat,
-      DType,
-      kLogPageSize,
-      kUsePDL,
-      kBf16Store>;
+  static constexpr auto kernel =
+      flash_c4_decode_norm_rope<kHeadDim, BufferFloat, InputFloat, SrcFloat, DType, kLogPageSize, kUsePDL, kBf16Store>;
   using Trait = FusedC4Trait<kHeadDim, 2>;
 
   static_assert(kHeadDim == 512, "fused c4 epilogue is defined for flashmla head_dim=512");
@@ -515,8 +507,7 @@ template <
     int32_t kPageBits,
     bool kUsePDL,
     int32_t kPreshuffleSize>
-FUSED_C4_KERNEL void flash_c4_decode_norm_rope_indexer(
-    const __grid_constant__ FusedCompress4NormRopeParams params) {
+FUSED_C4_KERNEL void flash_c4_decode_norm_rope_indexer(const __grid_constant__ FusedCompress4NormRopeParams params) {
   using namespace device;
 
   constexpr int64_t kHeadDim = 128;
@@ -703,8 +694,8 @@ template <
     int32_t kPageBits,
     bool kUsePDL,
     int32_t kPreshuffleSize>
-FUSED_C4_KERNEL void flash_c4_decode_norm_rope_indexer_w64(
-    const __grid_constant__ FusedCompress4NormRopeParams params) {
+FUSED_C4_KERNEL void
+flash_c4_decode_norm_rope_indexer_w64(const __grid_constant__ FusedCompress4NormRopeParams params) {
   using namespace device;
 
   constexpr int64_t kHeadDim = 128;

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/fused_compress4_norm_rope.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/fused_compress4_norm_rope.cuh
@@ -44,6 +44,8 @@
 namespace sglang {
 
 using PlanD = device::compress::DecodePlan;
+using PlanC = device::compress::CompressPlan;
+using PlanW = device::compress::WritePlan;
 using deepseek_v4::fp8::cast_to_ue8m0;
 using deepseek_v4::fp8::inv_scale_ue8m0;
 using deepseek_v4::fp8::pack_fp8;
@@ -79,6 +81,7 @@ SGL_DEVICE float wave_reduce_max(float value) {
 #endif
 
 #define FUSED_C4_KERNEL __global__ __launch_bounds__(kFusedBlockSize, 4)
+#define FUSED_C4_WRITE_KERNEL __global__ __launch_bounds__(128, 16)
 
 struct FusedCompress4NormRopeParams {
   void* __restrict__ kv_buffer;
@@ -92,6 +95,30 @@ struct FusedCompress4NormRopeParams {
   float eps;
   uint32_t compress_ratio;
   uint32_t batch_size;
+};
+
+/// \brief Extend/target-verify counterpart of FusedCompress4NormRopeParams.
+///
+/// Unlike decode, the current step carries multiple query tokens per sequence
+/// (mini-extend), so the compress domain (one entry per `plan_c`) and the
+/// ring-buffer write domain (one entry per `plan_w`) are separate and unequal.
+/// The fused compress+norm+rope kernel iterates over `plan_c`; the ring-buffer
+/// staging for future steps' overlap reads runs as a small companion launch
+/// over `plan_w` (mirrors c4_v2.cuh flash_c4_prefill + write_c4_prefill).
+struct FusedCompress4NormRopePrefillParams {
+  void* __restrict__ kv_buffer;
+  const void* __restrict__ kv_input;
+  const void* __restrict__ score_bias;
+  const void* __restrict__ norm_weight;
+  const float* __restrict__ freqs_cis;
+  const int64_t* __restrict__ out_loc;
+  uint8_t* __restrict__ kvcache;
+  const PlanC* __restrict__ plan_c;
+  const PlanW* __restrict__ plan_w;
+  float eps;
+  uint32_t compress_ratio;
+  uint32_t num_compress;
+  uint32_t num_write;
 };
 
 /// \brief `kTileElements_` is elements per lane, and it is what reconciles the
@@ -170,6 +197,70 @@ SGL_DEVICE void fused_c4_write_decode(BufferFloat* kv_buf, const InputFloat* kv_
         data_cast[i][j] = cast<BufferFloat>(data[i][j]);
       }
       gmem_buffer.store(kv_buf + Trait::kHeadDim * i, data_cast[i]);
+    }
+  }
+}
+
+/// \brief Extend-mode ring-buffer staging: copy each query token's raw
+/// kv/score row (kElementSize = head_dim * 4) into the ring buffer at its
+/// WritePlan slot, so a future step's compress can read it as overlap. This is
+/// a verbatim port of c4_v2.cuh::write_c4_prefill onto the fused prefill params;
+/// it is a separate launch because the write domain (one entry per `plan_w`)
+/// differs from the compress domain (one entry per `plan_c`). Uses the compress
+/// kernel's 4-elem/lane contiguous split (block=128), not the fused epilogue's
+/// 2-elem/256 mapping -- this only moves bytes, it does no math.
+template <int64_t kHeadDim, typename BufferFloat, typename SrcFloat, bool kUsePDL>
+FUSED_C4_WRITE_KERNEL void fused_c4_write_prefill(const __grid_constant__ FusedCompress4NormRopePrefillParams params) {
+  using namespace device;
+  using WTrait = FusedC4Trait<kHeadDim, 4>;
+  using StorageInput = AlignedVector<SrcFloat, 4>;
+
+  const uint32_t global_tid = blockIdx.x * blockDim.x + threadIdx.x;
+  const uint32_t global_wid = global_tid / kWarpThreads;      // warp id
+  const uint32_t global_pid = global_wid / WTrait::kNumSplit;  // write-plan id
+  const uint32_t global_sid = global_wid % WTrait::kNumSplit;  // split id
+  // Each warp handles one contiguous tile of the kElementSize row.
+  const int64_t split_offset = global_sid * (WTrait::kTileDim * 4);
+  if (global_pid >= params.num_write) return;
+
+  const auto plan = params.plan_w[global_pid];
+  const auto kv_input = static_cast<const SrcFloat*>(params.kv_input) + split_offset;
+  const auto kv_buffer = static_cast<BufferFloat*>(params.kv_buffer) + split_offset;
+  if (plan.is_invalid()) return;
+
+  const auto kv_src = kv_input + plan.ragged_id * WTrait::kElementSize;
+  const auto kv_buf = kv_buffer + plan.write_loc * WTrait::kElementSize;
+  const auto gmem_input = tile::Memory<StorageInput>::warp();
+
+  PDLWaitPrimary<kUsePDL>();
+  StorageInput data[4];
+#pragma unroll
+  for (int32_t i = 0; i < 4; ++i) {
+    data[i] = gmem_input.load(kv_src, i);
+  }
+
+  if constexpr (std::is_same_v<BufferFloat, SrcFloat>) {
+    PDLTriggerSecondary<kUsePDL>();
+#pragma unroll
+    for (int32_t i = 0; i < 4; ++i) {
+      gmem_input.store(kv_buf, data[i], i);
+    }
+  } else {
+    using StorageBuffer = AlignedVector<BufferFloat, 4>;
+    const auto gmem_buffer = tile::Memory<StorageBuffer>::warp();
+
+    StorageBuffer data_cast[4];
+#pragma unroll
+    for (int32_t i = 0; i < 4; ++i) {
+#pragma unroll
+      for (int32_t j = 0; j < 4; ++j) {
+        data_cast[i][j] = cast<BufferFloat>(data[i][j]);
+      }
+    }
+    PDLTriggerSecondary<kUsePDL>();
+#pragma unroll
+    for (int32_t i = 0; i < 4; ++i) {
+      gmem_buffer.store(kv_buf, data_cast[i], i);
     }
   }
 }
@@ -403,6 +494,144 @@ FUSED_C4_KERNEL void flash_c4_decode_norm_rope(const __grid_constant__ FusedComp
   }
 }
 
+/// \brief Extend/target-verify twin of flash_c4_decode_norm_rope. One block per
+/// compress plan (`plan_c`). The current query tokens are read from the ragged
+/// `kv_input` (staged into the ring buffer by fused_c4_write_prefill in a
+/// companion launch), so there is no in-kernel write here; everything else --
+/// the compress reduction, norm, rope and fp8/bf16 store -- is identical to the
+/// decode kernel.
+template <
+    int64_t kHeadDim,
+    typename BufferFloat,
+    typename InputFloat,
+    typename SrcFloat,
+    typename DType,
+    int32_t kPageBits,
+    bool kUsePDL,
+    bool kBf16Store>
+FUSED_C4_KERNEL void flash_c4_prefill_norm_rope(const __grid_constant__ FusedCompress4NormRopePrefillParams params) {
+  using namespace device;
+  using Trait = FusedC4Trait<kHeadDim, 2>;
+
+  constexpr int64_t kRopeDim = 64;
+  constexpr int64_t kVecSize = Trait::kTileElements;
+  constexpr uint32_t kRopeWarp = kFusedNumWarps - 1;
+  constexpr int64_t kPageBytes =
+      kBf16Store ? (kHeadDim * 2ll << kPageBits) : host::div_ceil(584ll << kPageBits, 576) * 576;
+  static_assert(kHeadDim == kFusedBlockSize * kVecSize);
+  static_assert(kRopeDim == kWarpThreads * kVecSize);
+  static_assert(kHeadDim - kRopeDim == kRopeWarp * kWarpThreads * kVecSize);
+  using Float2 = AlignedVector<float, kVecSize>;
+  using Storage = AlignedVector<DType, kVecSize>;
+
+  const auto tx = threadIdx.x;
+  const auto warp_id = tx / kWarpThreads;
+  const auto lane_id = tx % kWarpThreads;
+  const auto pid = blockIdx.x;
+  if (pid >= params.num_compress) return;
+
+  // Block-uniform early-out: one block owns one compress plan, so this cannot
+  // split a warp/block before the __syncthreads() in the norm below.
+  const auto plan = params.plan_c[pid];
+  if (plan.is_invalid()) return;
+
+  // One warp per head_dim split, one block per compress plan.
+  const int64_t split_offset = static_cast<int64_t>(warp_id) * Trait::kTileDim;
+
+  const auto kv_input = static_cast<const SrcFloat*>(params.kv_input) + split_offset;
+  const auto kv_buffer = static_cast<BufferFloat*>(params.kv_buffer) + split_offset;
+  const auto score_bias = static_cast<const InputFloat*>(params.score_bias) + split_offset;
+
+  const auto kv_src = kv_input + plan.ragged_id * Trait::kElementSize;
+  const auto kv_buf_0 = kv_buffer + plan.read_page_0 * Trait::kPageElementSize;
+  const auto kv_buf_1 = kv_buffer + plan.read_page_1 * Trait::kPageElementSize;
+
+  PDLWaitPrimary<kUsePDL>();
+  // Current tokens come from the ragged input; overlap from the ring buffer.
+  // `plan.buffer_len` says how many of the 8 window rows are already buffered.
+  const auto need_overlap = plan.seq_len > 4;
+  Float2 data = fused_c4_forward<Trait, BufferFloat, InputFloat, SrcFloat>(
+      kv_buf_0, kv_buf_1, kv_src, score_bias, need_overlap, plan.buffer_len);
+
+  const auto position = static_cast<int32_t>(plan.seq_len - params.compress_ratio);
+  const auto out_loc = params.out_loc[plan.ragged_id];
+  const auto freqs_cis = params.freqs_cis + position * kRopeDim;
+
+  Float2 freq;
+  if (warp_id == kRopeWarp) freq.load(freqs_cis, lane_id);
+
+  // part 1: RMSNorm. Sum of squares reduced across the block, which holds the
+  // whole head_dim row.
+  {
+    __shared__ float partial_sums[kFusedNumWarps];
+
+    Storage weight_vec;
+    weight_vec.load(params.norm_weight, tx);
+
+    float sum_of_squares = 0.0f;
+#pragma unroll
+    for (int i = 0; i < kVecSize; ++i) {
+      sum_of_squares += data[i] * data[i];
+    }
+
+    const auto warp_sum = warp::reduce_sum(sum_of_squares);
+    if (lane_id == 0) partial_sums[warp_id] = warp_sum;
+    __syncthreads();
+    sum_of_squares = warp::reduce_sum<kFusedNumWarps>(partial_sums[lane_id % kFusedNumWarps]);
+    const auto norm_factor = math::rsqrt(sum_of_squares / kHeadDim + params.eps);
+
+#pragma unroll
+    for (int i = 0; i < kVecSize; ++i) {
+      const auto fp32_weight = cast<float>(weight_vec[i]);
+      data[i] = data[i] * norm_factor * fp32_weight;
+    }
+  }
+
+  const int64_t page = out_loc >> kPageBits;
+  const int64_t offset = out_loc & ((1 << kPageBits) - 1);
+  const auto page_ptr = params.kvcache + page * kPageBytes;
+  const auto value_ptr = page_ptr + offset * (kBf16Store ? (kHeadDim * 2) : 576);
+
+  PDLTriggerSecondary<kUsePDL>();
+
+  // part 2: rope on the last warp, then either a plain bf16 store or a
+  // per-warp fp8 group quant on the non-rope warps.
+  if constexpr (kBf16Store) {
+    Float2 d = data;
+    if (warp_id == kRopeWarp) {
+      const auto x_real = data[0];
+      const auto x_imag = data[1];
+      const auto freq_real = freq[0];
+      const auto freq_imag = freq[1];
+      d[0] = x_real * freq_real - x_imag * freq_imag;
+      d[1] = x_real * freq_imag + x_imag * freq_real;
+    }
+    reinterpret_cast<bf16x2_t*>(value_ptr)[tx] = cast<bf16x2_t>(fp32x2_t{d[0], d[1]});
+  } else if (warp_id == kRopeWarp) {
+    const auto x_real = data[0];
+    const auto x_imag = data[1];
+    const auto freq_real = freq[0];
+    const auto freq_imag = freq[1];
+    data[0] = x_real * freq_real - x_imag * freq_imag;
+    data[1] = x_real * freq_imag + x_imag * freq_real;
+    const auto result = cast<bf16x2_t>(fp32x2_t{data[0], data[1]});
+    const auto rope_ptr = value_ptr + 448;
+    reinterpret_cast<bf16x2_t*>(rope_ptr)[lane_id] = result;
+  } else {
+    // BF16 round-trip to match the precision of the non-fused path.
+    const auto x = cast<float>(cast<bf16_t>(data[0]));
+    const auto y = cast<float>(cast<bf16_t>(data[1]));
+    const auto abs_max = warp::reduce_max(fmaxf(fabs(x), fabs(y)));
+    const auto scale_raw = fmaxf(1e-4f, abs_max) / kFP8E4M3Max;
+    const auto scale_ue8m0 = cast_to_ue8m0(scale_raw);
+    const auto inv_scale = inv_scale_ue8m0(scale_ue8m0);
+    const auto result = pack_fp8(x * inv_scale, y * inv_scale);
+    const auto scale_ptr = page_ptr + (576 << kPageBits) + offset * 8;
+    reinterpret_cast<fp8x2_e4m3_t*>(value_ptr)[tx] = result;
+    if (lane_id == 0) static_cast<uint8_t*>(scale_ptr)[warp_id] = scale_ue8m0;
+  }
+}
+
 template <
     int64_t kHeadDim,
     typename BufferFloat,
@@ -418,7 +647,14 @@ struct FusedCompress4NormRopeKernel {
       kBf16Store ? (kHeadDim * 2 * kPageSize) : host::div_ceil(584 * kPageSize, 576) * 576;
   static constexpr auto kernel =
       flash_c4_decode_norm_rope<kHeadDim, BufferFloat, InputFloat, SrcFloat, DType, kLogPageSize, kUsePDL, kBf16Store>;
+  static constexpr auto prefill_kernel =
+      flash_c4_prefill_norm_rope<kHeadDim, BufferFloat, InputFloat, SrcFloat, DType, kLogPageSize, kUsePDL, kBf16Store>;
+  static constexpr auto write_kernel = fused_c4_write_prefill<kHeadDim, BufferFloat, SrcFloat, kUsePDL>;
   using Trait = FusedC4Trait<kHeadDim, 2>;
+  // The ring-buffer write reuses the compressor's 4-elem/lane contiguous split
+  // (block=128), so its grid is sized from a 128-wide tile, not the epilogue's.
+  static constexpr uint32_t kWriteNumSplit = kHeadDim / (4 * device::kWarpThreads);
+  static constexpr uint32_t kWriteWarpsPerBlock = 128 / device::kWarpThreads;
 
   static_assert(kHeadDim == 512, "fused c4 epilogue is defined for flashmla head_dim=512");
   static_assert(std::has_single_bit(kPageSize), "kPageSize must be a power of 2");
@@ -492,6 +728,94 @@ struct FusedCompress4NormRopeKernel {
     LaunchKernel(batch_size, kFusedBlockSize, device_.unwrap())  //
         .enable_pdl(kUsePDL)(kernel, params);
   }
+
+  static void run_prefill(
+      const tvm::ffi::TensorView kv_buffer,
+      const tvm::ffi::TensorView kv_input,
+      const tvm::ffi::TensorView ape,
+      const tvm::ffi::TensorView plan_c_,
+      const tvm::ffi::TensorView plan_w_,
+      const tvm::ffi::TensorView norm_weight,
+      const double eps,
+      const tvm::ffi::TensorView freqs_cis,
+      const tvm::ffi::TensorView out_loc,
+      const tvm::ffi::TensorView kvcache,
+      const int64_t compress_ratio) {
+    using namespace host;
+
+    auto N = SymbolicSize{"num_q_tokens"};
+    auto C = SymbolicSize{"num_c_plans"};
+    auto W = SymbolicSize{"num_w_plans"};
+    auto device_ = SymbolicDevice{};
+    device_.set_options<kDLGPU>();
+
+    TensorMatcher({-1, 4, Trait::kElementSize})  // kv score ring buffer
+        .with_dtype<BufferFloat>()
+        .with_device(device_)
+        .verify(kv_buffer);
+    TensorMatcher({N, Trait::kElementSize})  // kv score input (ragged)
+        .with_dtype<SrcFloat>()
+        .with_device(device_)
+        .verify(kv_input);
+    TensorMatcher({8, kHeadDim})  // ape
+        .with_dtype<InputFloat>()
+        .with_device(device_)
+        .verify(ape);
+    TensorMatcher({kHeadDim})  // norm weight
+        .with_dtype<DType>()
+        .with_device(device_)
+        .verify(norm_weight);
+    TensorMatcher({-1, 64})  // freqs_cis
+        .with_dtype<float>()
+        .with_device(device_)
+        .verify(freqs_cis);
+    TensorMatcher({-1})  // out_loc (indexed by plan.ragged_id)
+        .with_dtype<int64_t>()
+        .with_device(device_)
+        .verify(out_loc);
+    TensorMatcher({-1, -1})  // cache
+        .with_strides({kPageBytes, 1})
+        .with_dtype<uint8_t>()
+        .with_device(device_)
+        .verify(kvcache);
+
+    const auto plan_c = compress::verify_plan_c(plan_c_, C, device_);
+    const auto plan_w = compress::verify_plan_w(plan_w_, W, device_);
+    const auto num_q_tokens = static_cast<uint32_t>(N.unwrap());
+    const auto num_c = static_cast<uint32_t>(C.unwrap());
+    const auto num_w = static_cast<uint32_t>(W.unwrap());
+    RuntimeCheck(out_loc.size(0) >= N.unwrap());
+    RuntimeCheck(num_q_tokens >= num_w, "invalid prefill plan: num_q < num_w");
+
+    const auto params = FusedCompress4NormRopePrefillParams{
+        .kv_buffer = kv_buffer.data_ptr(),
+        .kv_input = kv_input.data_ptr(),
+        .score_bias = ape.data_ptr(),
+        .norm_weight = norm_weight.data_ptr(),
+        .freqs_cis = static_cast<const float*>(freqs_cis.data_ptr()),
+        .out_loc = static_cast<const int64_t*>(out_loc.data_ptr()),
+        .kvcache = static_cast<uint8_t*>(kvcache.data_ptr()),
+        .plan_c = plan_c,
+        .plan_w = plan_w,
+        .eps = static_cast<float>(eps),
+        .compress_ratio = static_cast<uint32_t>(compress_ratio),
+        .num_compress = num_c,
+        .num_write = num_w,
+    };
+    const auto device = device_.unwrap();
+    // Compress + norm + rope + store, one block per compress plan. The current
+    // tokens are read from the ragged input, so this does not depend on the
+    // ring-buffer write below (mirrors c4_v2.cuh run_prefill's launch order).
+    if (num_c) {
+      LaunchKernel(num_c, kFusedBlockSize, device)  //
+          .enable_pdl(kUsePDL)(prefill_kernel, params);
+    }
+    // Stage this step's tokens into the ring buffer for future overlap reads.
+    if (const auto num_w_blocks = div_ceil(num_w * kWriteNumSplit, kWriteWarpsPerBlock)) {
+      LaunchKernel(num_w_blocks, 128, device)  //
+          .enable_pdl(kUsePDL)(write_kernel, params);
+    }
+  }
 };
 
 /// \brief compress -> RMSNorm -> RoPE -> hadamard -> fp8 quant -> paged store,
@@ -551,6 +875,171 @@ FUSED_C4_KERNEL void flash_c4_decode_norm_rope_indexer(const __grid_constant__ F
 
   const auto position = static_cast<int32_t>(plan.seq_len - params.compress_ratio);
   const auto out_loc = params.out_loc[token_id];
+  const auto freqs_cis = params.freqs_cis + position * kRopeDim;
+
+  Float4 freq;
+
+  // part 1: norm
+  {
+    Storage weight_vec;
+    weight_vec.load(params.norm_weight, lane_id);
+    if (is_rope_lane) freq.load(freqs_cis, lane_id - (kWarpThreads - kRopeSize));
+
+    float sum_of_squares = 0.0f;
+#pragma unroll
+    for (int i = 0; i < kVecSize; ++i) {
+      sum_of_squares += data[i] * data[i];
+    }
+
+    sum_of_squares = warp::reduce_sum(sum_of_squares);
+    const auto norm_factor = math::rsqrt(sum_of_squares / kHeadDim + params.eps);
+
+#pragma unroll
+    for (int i = 0; i < kVecSize; ++i) {
+      const auto fp32_weight = cast<float>(weight_vec[i]);
+      data[i] = data[i] * norm_factor * fp32_weight;
+    }
+  }
+
+  // part 2: rope (rope-lane only, 4 elems per lane = 2 (real, imag) pairs)
+  if (is_rope_lane) {
+    const auto x_real = data[0];
+    const auto x_imag = data[1];
+    const auto y_real = data[2];
+    const auto y_imag = data[3];
+    const auto freq_x_real = freq[0];
+    const auto freq_x_imag = freq[1];
+    const auto freq_y_real = freq[2];
+    const auto freq_y_imag = freq[3];
+    data[0] = x_real * freq_x_real - x_imag * freq_x_imag;
+    data[1] = x_real * freq_x_imag + x_imag * freq_x_real;
+    data[2] = y_real * freq_y_real - y_imag * freq_y_imag;
+    data[3] = y_real * freq_y_imag + y_imag * freq_y_real;
+  }
+
+  // part 3: hadamard transform
+  {
+    {
+      const float a0 = data[0], a1 = data[1], a2 = data[2], a3 = data[3];
+      data[0] = a0 + a1;
+      data[1] = a0 - a1;
+      data[2] = a2 + a3;
+      data[3] = a2 - a3;
+    }
+    {
+      const float a0 = data[0], a1 = data[1], a2 = data[2], a3 = data[3];
+      data[0] = a0 + a2;
+      data[1] = a1 + a3;
+      data[2] = a0 - a2;
+      data[3] = a1 - a3;
+    }
+#pragma unroll
+    for (uint32_t mask = 1; mask < kWarpThreads; mask <<= 1) {
+#pragma unroll
+      for (int i = 0; i < kVecSize; ++i) {
+#ifndef USE_ROCM
+        const float other = __shfl_xor_sync(kFullMask, data[i], mask, kWarpThreads);
+#else
+        const float other = __shfl_xor(data[i], mask, kWarpThreads);
+#endif
+        data[i] = (lane_id & mask) ? (other - data[i]) : (data[i] + other);
+      }
+    }
+    const float kHadamardScale = math::rsqrt(static_cast<float>(kHeadDim));
+#pragma unroll
+    for (int i = 0; i < kVecSize; ++i)
+      data[i] *= kHadamardScale;
+  }
+
+  // part 4: per-warp UE8M0 quant + store (128 elements -> one fp8 group).
+  {
+    using OutStorage = AlignedVector<fp8x2_e4m3_t, 2>;
+    float local_max = math::abs(data[0]);
+#pragma unroll
+    for (int i = 1; i < kVecSize; ++i) {
+      local_max = math::max(local_max, math::abs(data[i]));
+    }
+    const auto abs_max = warp::reduce_max(local_max);
+    const auto scale = fmaxf(1e-4f, abs_max) / kFP8E4M3Max;
+    const auto inv_scale = 1.0f / scale;
+    const int64_t page = out_loc >> kPageBits;
+    const int64_t offset = out_loc & ((1 << kPageBits) - 1);
+    const auto page_ptr = params.kvcache + page * kPageBytes;
+    const auto value_ptr = page_ptr + offset * 128;
+    const auto scale_ptr = page_ptr + (128 << kPageBits) + offset * 4;
+    OutStorage result;
+    result[0] = pack_fp8(data[0] * inv_scale, data[1] * inv_scale);
+    result[1] = pack_fp8(data[2] * inv_scale, data[3] * inv_scale);
+    PDLTriggerSecondary<kUsePDL>();
+    if constexpr (kPreshuffleSize != 0) {
+      constexpr int32_t kTile = kPreshuffleSize;
+      const int32_t dim_base = lane_id * kVecSize;
+      const int32_t token_tile_id = offset / kTile;
+      const int32_t token_in_tile = offset % kTile;
+      const int32_t col_tile_id = dim_base / kTile;
+      const int32_t col_in_tile = dim_base % kTile;
+      const int32_t value_offset = token_tile_id * (kTile * static_cast<int32_t>(kHeadDim)) +
+                                   col_tile_id * (kTile * kTile) + token_in_tile * kTile + col_in_tile;
+      result.store(page_ptr + value_offset, 0);
+    } else {
+      result.store(value_ptr, lane_id);
+    }
+    if (lane_id == 0) reinterpret_cast<float*>(scale_ptr)[0] = scale;
+  }
+}
+
+/// \brief Extend/target-verify twin of flash_c4_decode_norm_rope_indexer.
+/// One token per 32-lane warp, iterating over compress plans (`plan_c`) with no
+/// in-kernel write (staged separately by fused_c4_write_prefill). The is_invalid
+/// early-out is warp-uniform (work_id is warp-uniform), so the cross-lane
+/// hadamard butterflies below still see a full warp.
+template <
+    typename BufferFloat,
+    typename InputFloat,
+    typename SrcFloat,
+    typename DType,
+    int32_t kPageBits,
+    bool kUsePDL,
+    int32_t kPreshuffleSize>
+FUSED_C4_KERNEL void flash_c4_prefill_norm_rope_indexer(const __grid_constant__ FusedCompress4NormRopePrefillParams params) {
+  using namespace device;
+
+  constexpr int64_t kHeadDim = 128;
+  using Trait = FusedC4Trait<kHeadDim, 4>;
+  constexpr int64_t kRopeDim = 64;
+  constexpr int64_t kVecSize = Trait::kTileElements;
+  constexpr uint32_t kRopeSize = kRopeDim / kVecSize;
+  constexpr int64_t kPageBytes = 132ll << kPageBits;
+  static_assert(kHeadDim == kWarpThreads * kVecSize);
+  static_assert(kRopeDim == kWarpThreads * 2);
+  static_assert(Trait::kNumSplit == 1, "indexer fusion runs one warp per token");
+  using Float4 = AlignedVector<float, kVecSize>;
+  using Storage = AlignedVector<DType, kVecSize>;
+
+  const auto warp_id = threadIdx.x / kWarpThreads;
+  const auto lane_id = threadIdx.x % kWarpThreads;
+  const auto pid = blockIdx.x * kFusedNumWarps + warp_id;
+  const bool is_rope_lane = lane_id >= kWarpThreads - kRopeSize;
+
+  if (pid >= params.num_compress) return;
+
+  const auto plan = params.plan_c[pid];
+  if (plan.is_invalid()) return;
+
+  const auto kv_input = static_cast<const SrcFloat*>(params.kv_input);
+  const auto kv_buffer = static_cast<BufferFloat*>(params.kv_buffer);
+  const auto score_bias = static_cast<const InputFloat*>(params.score_bias);
+
+  const auto kv_src = kv_input + plan.ragged_id * Trait::kElementSize;
+  const auto kv_buf_0 = kv_buffer + plan.read_page_0 * Trait::kPageElementSize;
+  const auto kv_buf_1 = kv_buffer + plan.read_page_1 * Trait::kPageElementSize;
+
+  PDLWaitPrimary<kUsePDL>();
+  Float4 data = fused_c4_forward<Trait, BufferFloat, InputFloat, SrcFloat>(
+      kv_buf_0, kv_buf_1, kv_src, score_bias, plan.seq_len > 4, plan.buffer_len);
+
+  const auto position = static_cast<int32_t>(plan.seq_len - params.compress_ratio);
+  const auto out_loc = params.out_loc[plan.ragged_id];
   const auto freqs_cis = params.freqs_cis + position * kRopeDim;
 
   Float4 freq;
@@ -841,6 +1330,157 @@ flash_c4_decode_norm_rope_indexer_w64(const __grid_constant__ FusedCompress4Norm
     if (wave_lane == 0) reinterpret_cast<float*>(scale_ptr)[0] = scale;
   }
 }
+
+/// \brief Extend/target-verify twin of flash_c4_decode_norm_rope_indexer_w64.
+/// One token per wavefront, iterating over compress plans (`plan_c`) with no
+/// in-kernel write. The is_invalid early-out is wave-uniform (all 64 lanes of a
+/// token share token_id), so the wavefront butterflies stay intact.
+template <
+    typename BufferFloat,
+    typename InputFloat,
+    typename SrcFloat,
+    typename DType,
+    int32_t kPageBits,
+    bool kUsePDL,
+    int32_t kPreshuffleSize>
+FUSED_C4_KERNEL void
+flash_c4_prefill_norm_rope_indexer_w64(const __grid_constant__ FusedCompress4NormRopePrefillParams params) {
+  using namespace device;
+
+  constexpr int64_t kHeadDim = 128;
+  using Trait = FusedC4Trait<kHeadDim, 2>;
+  constexpr int64_t kRopeDim = 64;
+  constexpr int64_t kVecSize = Trait::kTileElements;
+  constexpr uint32_t kWarpsPerToken = Trait::kNumSplit;
+  constexpr uint32_t kThreadsPerToken = kWarpsPerToken * kWarpThreads;
+  constexpr uint32_t kTokensPerBlock = kFusedBlockSize / kThreadsPerToken;
+  constexpr int64_t kPageBytes = 132ll << kPageBits;
+  static_assert(kThreadsPerToken == kWaveThreads, "one token must own one wavefront");
+  static_assert(kHeadDim == kThreadsPerToken * kVecSize);
+  static_assert(kRopeDim == kWarpThreads * kVecSize, "rope tail is the token's last warp");
+  using Float2 = AlignedVector<float, kVecSize>;
+  using Storage = AlignedVector<DType, kVecSize>;
+
+  const auto tx = threadIdx.x;
+  const auto warp_id = tx / kWarpThreads;
+  const auto lane_id = tx % kWarpThreads;
+  const auto local_token = warp_id / kWarpsPerToken;
+  const auto split_id = warp_id % kWarpsPerToken;
+  const auto wave_lane = split_id * kWarpThreads + lane_id;
+  const auto pid = blockIdx.x * kTokensPerBlock + local_token;
+
+  if (pid >= params.num_compress) return;
+
+  const auto plan = params.plan_c[pid];
+  if (plan.is_invalid()) return;
+
+  const int64_t split_offset = static_cast<int64_t>(split_id) * Trait::kTileDim;
+
+  const auto kv_input = static_cast<const SrcFloat*>(params.kv_input) + split_offset;
+  const auto kv_buffer = static_cast<BufferFloat*>(params.kv_buffer) + split_offset;
+  const auto score_bias = static_cast<const InputFloat*>(params.score_bias) + split_offset;
+
+  const auto kv_src = kv_input + plan.ragged_id * Trait::kElementSize;
+  const auto kv_buf_0 = kv_buffer + plan.read_page_0 * Trait::kPageElementSize;
+  const auto kv_buf_1 = kv_buffer + plan.read_page_1 * Trait::kPageElementSize;
+
+  PDLWaitPrimary<kUsePDL>();
+  Float2 data = fused_c4_forward<Trait, BufferFloat, InputFloat, SrcFloat>(
+      kv_buf_0, kv_buf_1, kv_src, score_bias, plan.seq_len > 4, plan.buffer_len);
+
+  const auto position = static_cast<int32_t>(plan.seq_len - params.compress_ratio);
+  const auto out_loc = params.out_loc[plan.ragged_id];
+  const auto freqs_cis = params.freqs_cis + position * kRopeDim;
+  const bool is_rope_warp = split_id == kWarpsPerToken - 1;
+
+  Float2 freq;
+
+  // part 1: norm
+  {
+    Storage weight_vec;
+    weight_vec.load(params.norm_weight, wave_lane);
+    if (is_rope_warp) freq.load(freqs_cis, lane_id);
+
+    float sum_of_squares = 0.0f;
+#pragma unroll
+    for (int i = 0; i < kVecSize; ++i) {
+      sum_of_squares += data[i] * data[i];
+    }
+
+    sum_of_squares = wave_reduce_sum(sum_of_squares);
+    const auto norm_factor = math::rsqrt(sum_of_squares / kHeadDim + params.eps);
+
+#pragma unroll
+    for (int i = 0; i < kVecSize; ++i) {
+      const auto fp32_weight = cast<float>(weight_vec[i]);
+      data[i] = data[i] * norm_factor * fp32_weight;
+    }
+  }
+
+  // part 2: rope on the token's last warp, 1 (real, imag) pair per lane
+  if (is_rope_warp) {
+    const auto x_real = data[0];
+    const auto x_imag = data[1];
+    const auto freq_real = freq[0];
+    const auto freq_imag = freq[1];
+    data[0] = x_real * freq_real - x_imag * freq_imag;
+    data[1] = x_real * freq_imag + x_imag * freq_real;
+  }
+
+  // part 3: hadamard (128-point, indexed by wave_lane * kVecSize + i)
+  {
+    {
+      const float a0 = data[0], a1 = data[1];
+      data[0] = a0 + a1;
+      data[1] = a0 - a1;
+    }
+#pragma unroll
+    for (uint32_t mask = 1; mask < kWaveThreads; mask <<= 1) {
+#pragma unroll
+      for (int i = 0; i < kVecSize; ++i) {
+        const float other = __shfl_xor(data[i], mask, kWaveThreads);
+        data[i] = (wave_lane & mask) ? (other - data[i]) : (data[i] + other);
+      }
+    }
+    const float kHadamardScale = math::rsqrt(static_cast<float>(kHeadDim));
+#pragma unroll
+    for (int i = 0; i < kVecSize; ++i)
+      data[i] *= kHadamardScale;
+  }
+
+  // part 4: one fp8 group per 128-element row (scale reduces over the wavefront).
+  {
+    float local_max = math::abs(data[0]);
+#pragma unroll
+    for (int i = 1; i < kVecSize; ++i) {
+      local_max = math::max(local_max, math::abs(data[i]));
+    }
+    const auto abs_max = wave_reduce_max(local_max);
+    const auto scale = fmaxf(1e-4f, abs_max) / kFP8E4M3Max;
+    const auto inv_scale = 1.0f / scale;
+    const int64_t page = out_loc >> kPageBits;
+    const int64_t offset = out_loc & ((1 << kPageBits) - 1);
+    const auto page_ptr = params.kvcache + page * kPageBytes;
+    const auto value_ptr = page_ptr + offset * 128;
+    const auto scale_ptr = page_ptr + (128 << kPageBits) + offset * 4;
+    const auto result = pack_fp8(data[0] * inv_scale, data[1] * inv_scale);
+    PDLTriggerSecondary<kUsePDL>();
+    if constexpr (kPreshuffleSize != 0) {
+      constexpr int32_t kTile = kPreshuffleSize;
+      const int32_t dim_base = wave_lane * kVecSize;
+      const int32_t token_tile_id = offset / kTile;
+      const int32_t token_in_tile = offset % kTile;
+      const int32_t col_tile_id = dim_base / kTile;
+      const int32_t col_in_tile = dim_base % kTile;
+      const int32_t value_offset = token_tile_id * (kTile * static_cast<int32_t>(kHeadDim)) +
+                                   col_tile_id * (kTile * kTile) + token_in_tile * kTile + col_in_tile;
+      *reinterpret_cast<fp8x2_e4m3_t*>(page_ptr + value_offset) = result;
+    } else {
+      reinterpret_cast<fp8x2_e4m3_t*>(value_ptr)[wave_lane] = result;
+    }
+    if (wave_lane == 0) reinterpret_cast<float*>(scale_ptr)[0] = scale;
+  }
+}
 #endif  // USE_ROCM
 
 template <
@@ -864,6 +1504,14 @@ struct FusedCompress4NormRopeIndexerKernel {
       kLogPageSize,
       kUsePDL,
       kPreshuffleSize>;
+  static constexpr auto prefill_kernel = flash_c4_prefill_norm_rope_indexer_w64<
+      BufferFloat,
+      InputFloat,
+      SrcFloat,
+      DType,
+      kLogPageSize,
+      kUsePDL,
+      kPreshuffleSize>;
   static constexpr uint32_t kTokensPerBlock = kFusedBlockSize / kWaveThreads;
   using Trait = FusedC4Trait<kHeadDim, 2>;
 #else
@@ -875,9 +1523,21 @@ struct FusedCompress4NormRopeIndexerKernel {
       kLogPageSize,
       kUsePDL,
       kPreshuffleSize>;
+  static constexpr auto prefill_kernel = flash_c4_prefill_norm_rope_indexer<
+      BufferFloat,
+      InputFloat,
+      SrcFloat,
+      DType,
+      kLogPageSize,
+      kUsePDL,
+      kPreshuffleSize>;
   static constexpr uint32_t kTokensPerBlock = kFusedNumWarps;
   using Trait = FusedC4Trait<kHeadDim, 4>;
 #endif
+  static constexpr auto write_kernel = fused_c4_write_prefill<kHeadDim, BufferFloat, SrcFloat, kUsePDL>;
+  // head_dim 128 => one 128-wide tile, so the write is one warp per plan.
+  static constexpr uint32_t kWriteNumSplit = kHeadDim / (4 * device::kWarpThreads);
+  static constexpr uint32_t kWriteWarpsPerBlock = 128 / device::kWarpThreads;
 
   static_assert(std::has_single_bit(kPageSize), "kPageSize must be a power of 2");
 
@@ -954,6 +1614,90 @@ struct FusedCompress4NormRopeIndexerKernel {
     const uint32_t num_blocks = div_ceil(batch_size, kTokensPerBlock);
     LaunchKernel(num_blocks, kFusedBlockSize, device_.unwrap())  //
         .enable_pdl(kUsePDL)(kernel, params);
+  }
+
+  static void run_prefill(
+      const tvm::ffi::TensorView kv_buffer,
+      const tvm::ffi::TensorView kv_input,
+      const tvm::ffi::TensorView ape,
+      const tvm::ffi::TensorView plan_c_,
+      const tvm::ffi::TensorView plan_w_,
+      const tvm::ffi::TensorView norm_weight,
+      const double eps,
+      const tvm::ffi::TensorView freqs_cis,
+      const tvm::ffi::TensorView out_loc,
+      const tvm::ffi::TensorView kvcache,
+      const int64_t compress_ratio) {
+    using namespace host;
+
+    auto N = SymbolicSize{"num_q_tokens"};
+    auto C = SymbolicSize{"num_c_plans"};
+    auto W = SymbolicSize{"num_w_plans"};
+    auto device_ = SymbolicDevice{};
+    device_.set_options<kDLGPU>();
+
+    TensorMatcher({-1, 4, Trait::kElementSize})  // kv score ring buffer
+        .with_dtype<BufferFloat>()
+        .with_device(device_)
+        .verify(kv_buffer);
+    TensorMatcher({N, Trait::kElementSize})  // kv score input (ragged)
+        .with_dtype<SrcFloat>()
+        .with_device(device_)
+        .verify(kv_input);
+    TensorMatcher({8, kHeadDim})  // ape
+        .with_dtype<InputFloat>()
+        .with_device(device_)
+        .verify(ape);
+    TensorMatcher({kHeadDim})  // norm weight
+        .with_dtype<DType>()
+        .with_device(device_)
+        .verify(norm_weight);
+    TensorMatcher({-1, 64})  // freqs_cis
+        .with_dtype<float>()
+        .with_device(device_)
+        .verify(freqs_cis);
+    TensorMatcher({-1})  // out_loc (indexed by plan.ragged_id)
+        .with_dtype<int64_t>()
+        .with_device(device_)
+        .verify(out_loc);
+    TensorMatcher({-1, -1})  // cache
+        .with_strides({kPageBytes, 1})
+        .with_dtype<uint8_t>()
+        .with_device(device_)
+        .verify(kvcache);
+
+    const auto plan_c = compress::verify_plan_c(plan_c_, C, device_);
+    const auto plan_w = compress::verify_plan_w(plan_w_, W, device_);
+    const auto num_q_tokens = static_cast<uint32_t>(N.unwrap());
+    const auto num_c = static_cast<uint32_t>(C.unwrap());
+    const auto num_w = static_cast<uint32_t>(W.unwrap());
+    RuntimeCheck(out_loc.size(0) >= N.unwrap());
+    RuntimeCheck(num_q_tokens >= num_w, "invalid prefill plan: num_q < num_w");
+
+    const auto params = FusedCompress4NormRopePrefillParams{
+        .kv_buffer = kv_buffer.data_ptr(),
+        .kv_input = kv_input.data_ptr(),
+        .score_bias = ape.data_ptr(),
+        .norm_weight = norm_weight.data_ptr(),
+        .freqs_cis = static_cast<const float*>(freqs_cis.data_ptr()),
+        .out_loc = static_cast<const int64_t*>(out_loc.data_ptr()),
+        .kvcache = static_cast<uint8_t*>(kvcache.data_ptr()),
+        .plan_c = plan_c,
+        .plan_w = plan_w,
+        .eps = static_cast<float>(eps),
+        .compress_ratio = static_cast<uint32_t>(compress_ratio),
+        .num_compress = num_c,
+        .num_write = num_w,
+    };
+    const auto device = device_.unwrap();
+    if (const auto num_c_blocks = div_ceil(num_c, kTokensPerBlock)) {
+      LaunchKernel(num_c_blocks, kFusedBlockSize, device)  //
+          .enable_pdl(kUsePDL)(prefill_kernel, params);
+    }
+    if (const auto num_w_blocks = div_ceil(num_w * kWriteNumSplit, kWriteWarpsPerBlock)) {
+      LaunchKernel(num_w_blocks, 128, device)  //
+          .enable_pdl(kUsePDL)(write_kernel, params);
+    }
   }
 };
 

--- a/python/sglang/kernels/ops/attention/dsv4/__init__.py
+++ b/python/sglang/kernels/ops/attention/dsv4/__init__.py
@@ -11,6 +11,7 @@ from .compress import (
     CompressorDecodePlan,
     CompressorPrefillPlan,
     compress_forward,
+    compress_forward_norm_rope_store,
     compress_norm_rope_store,
 )
 from .compress_old import fused_norm_rope_inplace
@@ -23,7 +24,7 @@ from .elementwise import (
     fused_rope_inplace,
 )
 from .fp8_wo_a import sglang_per_token_group_quant_fp8_dsv4_wo_a
-from .gemm import linear_bf16_fp32
+from .gemm import linear_bf16_fp32, linear_kv_score
 from .moe import (
     hash_topk,
     mask_topk_ids,
@@ -39,6 +40,7 @@ __all__ = [
     "CompressorDecodePlan",
     "CompressorPrefillPlan",
     "compress_forward",
+    "compress_forward_norm_rope_store",
     "compress_norm_rope_store",
     "clear_unaccepted_c128_draft_states",
     "fused_norm_rope_inplace",
@@ -52,6 +54,7 @@ __all__ = [
     "sglang_per_token_group_quant_fp8_dsv4_wo_a",
     "make_name",
     "linear_bf16_fp32",
+    "linear_kv_score",
     "get_paged_mqa_logits_metadata",
     "triton_create_paged_compress_data",
     "topk_transform_512",

--- a/python/sglang/kernels/ops/attention/dsv4/compress.py
+++ b/python/sglang/kernels/ops/attention/dsv4/compress.py
@@ -73,15 +73,71 @@ def _jit_compress_norm_rope_module(
 
 
 @cache_once
+def _jit_fused_compress4_norm_rope_module(
+    head_dim: int,
+    dtype_buffer: torch.dtype,
+    dtype_in: torch.dtype,
+    dtype_src: torch.dtype,
+    dtype: torch.dtype,
+    page_size: int,
+    bf16_store: bool,
+) -> Module:
+    # dtype_in is what the compressor computes in and the dtype of `ape`;
+    # dtype_src is only how kv_score arrives from the wkv_gate gemm. Keeping them
+    # apart lets that gemm hand over bf16 and skip a widening pass, since the
+    # kernel widens on load anyway.
+    if head_dim == 128:
+        # Indexer variant: head_dim is fixed in the kernel, and the store is
+        # always fp8 (bf16_store is a flashmla-only option).
+        args = make_cpp_args(
+            dtype_buffer,
+            dtype_in,
+            dtype_src,
+            dtype,
+            page_size,
+            is_arch_support_pdl(),
+            (
+                INDEXER_K_CACHE_PRESHUFFLE_TILE
+                if aiter_can_use_preshuffle_paged_mqa()
+                else 0
+            ),
+        )
+        kernel_class = f"FusedCompress4NormRopeIndexerKernel<{args}>"
+    else:
+        args = make_cpp_args(
+            head_dim,
+            dtype_buffer,
+            dtype_in,
+            dtype_src,
+            dtype,
+            page_size,
+            is_arch_support_pdl(),
+            bf16_store,
+        )
+        kernel_class = f"FusedCompress4NormRopeKernel<{args}>"
+    return load_jit(
+        make_name(f"fused_compress4_norm_rope_{head_dim}"),
+        *args,
+        cuda_files=["deepseek_v4/fused_compress4_norm_rope.cuh"],
+        cuda_wrappers=[("decode", f"{kernel_class}::run_decode")],
+        extra_cuda_cflags=["-use_fast_math"],
+    )
+
+
+@cache_once
 def _jit_compress_module(
     head_dim: int,
     dtype_buffer: torch.dtype,
     dtype_in: torch.dtype,
+    dtype_src: torch.dtype,
     dtype_out: torch.dtype,
     ratio: Literal[4, 128],
 ) -> Module:
+    # dtype_in is the compute dtype and the dtype of `ape`; dtype_src is only how
+    # kv_score arrives from the wkv_gate gemm. Keeping them apart lets that gemm
+    # hand over bf16 and skip a widening pass, since the kernel widens on load.
     args = make_cpp_args(
-        head_dim, dtype_buffer, dtype_in, dtype_out, is_arch_support_pdl()
+        head_dim, dtype_buffer, dtype_in, dtype_src, dtype_out, is_arch_support_pdl()
     )
     kernel_class = f"FlashCompress{ratio}Kernel<{args}>"
     return load_jit(
@@ -390,18 +446,34 @@ def compress_forward(
 ) -> torch.Tensor:
     if out is None:
         num_q_tokens = plan[1].shape[0]  # NOTE: decode = bs, prefill = dynamic
-        out = kv_score_input.new_empty((num_q_tokens, head_dim))
+        # Follows `ape`, not `kv_score_input`: the latter is only a transport
+        # dtype and may arrive narrower than what the compressor computes in.
+        out = ape.new_empty((num_q_tokens, head_dim))
     assert plan.compress_ratio == compress_ratio
     if is_online:
         assert compress_ratio == 128 and head_dim == 512
+        # The online kernel is not templated on the input dtype.
+        kv_score_input = kv_score_input.to(ape.dtype)
         module = _jit_compress_128_online_module(512, kv_score_buffer.dtype)
     else:
         if _is_xpu:
+            # The XPU entry points are not templated on a source dtype, so a
+            # narrower transport still has to be widened before it is used as
+            # InputFloat.
+            kv_score_input = kv_score_input.to(ape.dtype)
             decode_fn, prefill_fn = _XPU_COMPRESS_FNS[compress_ratio]
         else:
-            dtype_in, dtype_out = kv_score_input.dtype, out.dtype
+            # These kernels take SrcFloat separately, so kv_score_input keeps
+            # its transport dtype and is widened on load inside the kernel.
+            # Materializing a wider copy first would only re-expand values the
+            # gemm already rounded, at the cost of a full-tensor pass.
             module = _jit_compress_module(
-                head_dim, kv_score_buffer.dtype, dtype_in, dtype_out, compress_ratio
+                head_dim,
+                kv_score_buffer.dtype,
+                ape.dtype,
+                kv_score_input.dtype,
+                out.dtype,
+                compress_ratio,
             )
 
     if _is_xpu:
@@ -411,6 +483,55 @@ def compress_forward(
 
     fn(kv_score_buffer, kv_score_input, out, ape, *plan[1:3])
     return out
+
+
+def compress_forward_norm_rope_store(
+    kv_score_buffer: torch.Tensor,
+    kv_score_input: torch.Tensor,
+    ape: torch.Tensor,
+    plan: Union[CompressorDecodePlan, CompressorPrefillPlan],
+    *,
+    head_dim: int,
+    norm_weight: torch.Tensor,
+    norm_eps: float,
+    freq_cis: torch.Tensor,
+    out_loc: torch.Tensor,
+    kvcache: torch.Tensor,
+    page_size: int,
+    bf16_store: bool = False,
+) -> None:
+    """compress_forward + compress_norm_rope_store in a single launch.
+
+    Covers both c4 decode pairings: head_dim 512 (flashmla epilogue) and 128
+    (indexer epilogue). The compressed row they would otherwise write is a
+    temporary with no other consumer, so the fused kernel keeps it in registers
+    and the epilogue reads it from there. That also means the result is not
+    bit-identical to the two-kernel chain, which rounds that row to bf16 on the
+    way out: measured at up to ~1e-4 of fp8 codes differing, by one code.
+    """
+    assert plan.is_decode and plan.compress_ratio == 4 and head_dim in (128, 512)
+    freq_cis = torch.view_as_real(freq_cis).flatten(-2)
+    module = _jit_fused_compress4_norm_rope_module(
+        head_dim,
+        kv_score_buffer.dtype,
+        ape.dtype,
+        kv_score_input.dtype,
+        norm_weight.dtype,
+        page_size,
+        bf16_store,
+    )
+    module.decode(
+        kv_score_buffer,
+        kv_score_input,
+        ape,
+        plan[1],
+        norm_weight,
+        norm_eps,
+        freq_cis,
+        out_loc,
+        kvcache,
+        plan.compress_ratio,
+    )
 
 
 def compress_norm_rope_store(

--- a/python/sglang/kernels/ops/attention/dsv4/compress.py
+++ b/python/sglang/kernels/ops/attention/dsv4/compress.py
@@ -119,7 +119,10 @@ def _jit_fused_compress4_norm_rope_module(
         make_name(f"fused_compress4_norm_rope_{head_dim}"),
         *args,
         cuda_files=["deepseek_v4/fused_compress4_norm_rope.cuh"],
-        cuda_wrappers=[("decode", f"{kernel_class}::run_decode")],
+        cuda_wrappers=[
+            ("decode", f"{kernel_class}::run_decode"),
+            ("prefill", f"{kernel_class}::run_prefill"),
+        ],
         extra_cuda_cflags=["-use_fast_math"],
     )
 
@@ -509,7 +512,7 @@ def compress_forward_norm_rope_store(
     bit-identical to the two-kernel chain, which rounds that row to bf16 on the
     way out: measured at up to ~1e-4 of fp8 codes differing, by one code.
     """
-    assert plan.is_decode and plan.compress_ratio == 4 and head_dim in (128, 512)
+    assert plan.compress_ratio == 4 and head_dim in (128, 512)
     freq_cis = torch.view_as_real(freq_cis).flatten(-2)
     module = _jit_fused_compress4_norm_rope_module(
         head_dim,
@@ -520,18 +523,35 @@ def compress_forward_norm_rope_store(
         page_size,
         bf16_store,
     )
-    module.decode(
-        kv_score_buffer,
-        kv_score_input,
-        ape,
-        plan[1],
-        norm_weight,
-        norm_eps,
-        freq_cis,
-        out_loc,
-        kvcache,
-        plan.compress_ratio,
-    )
+    if plan.is_decode:
+        module.decode(
+            kv_score_buffer,
+            kv_score_input,
+            ape,
+            plan[1],  # plan_d
+            norm_weight,
+            norm_eps,
+            freq_cis,
+            out_loc,
+            kvcache,
+            plan.compress_ratio,
+        )
+    else:
+        # Extend / target-verify: the compress kernel iterates plan_c and the
+        # ring-buffer staging iterates plan_w (both carried by CompressorPrefillPlan).
+        module.prefill(
+            kv_score_buffer,
+            kv_score_input,
+            ape,
+            plan[1],  # plan_c
+            plan[2],  # plan_w
+            norm_weight,
+            norm_eps,
+            freq_cis,
+            out_loc,
+            kvcache,
+            plan.compress_ratio,
+        )
 
 
 def compress_norm_rope_store(

--- a/python/sglang/kernels/ops/attention/dsv4/gemm.py
+++ b/python/sglang/kernels/ops/attention/dsv4/gemm.py
@@ -141,6 +141,23 @@ def _linear_bf16_fp32_hpc(
     )
 
 
+_KV_SCORE_BF16 = get_bool_env_var("SGLANG_OPT_KV_SCORE_BF16", "true")
+
+
+def linear_kv_score(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    """wkv_gate projection feeding the compressor.
+
+    The compressor kernels widen their input on load, so when they are built for
+    a bf16 source there is nothing to gain from materializing an fp32 copy of
+    the gemm output first -- that copy is a separate full-tensor pass whose only
+    effect is to re-expand values the gemm already rounded to bf16. Widening
+    inside the consumer instead is exact, not just close.
+    """
+    if _KV_SCORE_BF16 and _use_aiter and y.dtype == torch.bfloat16:
+        return tgemm.mm(x, y, otype=x.dtype)
+    return linear_bf16_fp32(x, y)
+
+
 def linear_bf16_fp32(
     x: torch.Tensor,
     y: torch.Tensor,
@@ -148,6 +165,10 @@ def linear_bf16_fp32(
     hpc_kernel_min_m: Optional[int] = None,
 ) -> torch.Tensor:
     if _use_aiter and y.dtype == torch.bfloat16:
+        # NOTE: do not "simplify" this to otype=torch.float32. aiter has no fp32
+        # epilogue for these shapes, so it runs the same widening pass internally
+        # and additionally drops off the single-kernel hgemm solution onto a
+        # split-k tensile one, i.e. three kernels instead of two.
         return tgemm.mm(x, y, otype=x.dtype).float()
     elif hpc_kernel_min_m is not None:
         output = _linear_bf16_fp32_hpc(x, y, min_m=hpc_kernel_min_m)

--- a/python/sglang/kernels/ops/attention/dsv4/gemm.py
+++ b/python/sglang/kernels/ops/attention/dsv4/gemm.py
@@ -141,7 +141,7 @@ def _linear_bf16_fp32_hpc(
     )
 
 
-_KV_SCORE_BF16 = get_bool_env_var("SGLANG_OPT_KV_SCORE_BF16", "true")
+_KV_SCORE_BF16 = get_bool_env_var("SGLANG_OPT_KV_SCORE_BF16", "false")
 
 
 def linear_kv_score(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1082,6 +1082,13 @@ class Envs:
     SGLANG_OPT_USE_AITER_SILU_MUL = EnvBool(False)
     SGLANG_OPT_USE_FUSED_COMPRESS = EnvBool(False)
     SGLANG_OPT_USE_FUSED_COMPRESS_TRITON = EnvBool(False)
+    # HIP only: run the c4 decode compress and its norm + RoPE + fp8 store
+    # as a single kernel. The compressed row they hand between them has no
+    # other consumer, so the fused kernel keeps it in registers. Output is
+    # not bit-identical: the two-kernel chain rounds the compressed row to
+    # bf16 before the norm reads it and the fused kernel keeps it in fp32, so
+    # a small number of fp8 codes land differently. Set to 0 to go back.
+    SGLANG_OPT_FUSE_COMPRESS_NORM_ROPE = EnvBool(True)
     SGLANG_OPT_USE_FUSED_QK_NORM_ROPE = EnvBool(True)
     SGLANG_OPT_USE_FUSED_CLAMP_ACT_MUL = EnvBool(True)
     SGLANG_ENABLE_NVFP4_GEMM_SWIGLU_FUSION = EnvBool(True)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1087,8 +1087,9 @@ class Envs:
     # other consumer, so the fused kernel keeps it in registers. Output is
     # not bit-identical: the two-kernel chain rounds the compressed row to
     # bf16 before the norm reads it and the fused kernel keeps it in fp32, so
-    # a small number of fp8 codes land differently. Set to 0 to go back.
-    SGLANG_OPT_FUSE_COMPRESS_NORM_ROPE = EnvBool(True)
+    # a small number of fp8 codes land differently. Default off pending
+    # isolated fused-path coverage and soak time; set to 1 to enable.
+    SGLANG_OPT_FUSE_COMPRESS_NORM_ROPE = EnvBool(False)
     SGLANG_OPT_USE_FUSED_QK_NORM_ROPE = EnvBool(True)
     SGLANG_OPT_USE_FUSED_CLAMP_ACT_MUL = EnvBool(True)
     SGLANG_ENABLE_NVFP4_GEMM_SWIGLU_FUSION = EnvBool(True)

--- a/python/sglang/srt/layers/attention/dsv4/compressor.py
+++ b/python/sglang/srt/layers/attention/dsv4/compressor.py
@@ -9,6 +9,7 @@ from sglang.kernels.fused_op import BaseFusedOp
 from sglang.kernels.ops.attention.dsa.triton_kernel import act_quant
 from sglang.kernels.ops.attention.dsv4 import (
     linear_bf16_fp32,
+    linear_kv_score,
     triton_create_paged_compress_data,
 )
 from sglang.kernels.ops.attention.dsv4.compress_old import (
@@ -421,7 +422,7 @@ class Compressor(BaseFusedOp):
         return ret
 
     def compute_kv_score(self, x: torch.Tensor, forward_batch: ForwardBatch):
-        kv_score = linear_bf16_fp32(x, self.wkv_gate.weight)
+        kv_score = linear_kv_score(x, self.wkv_gate.weight)
 
         # CUDA path: delegate to backend
         if dsa_use_prefill_cp(forward_batch):

--- a/python/sglang/srt/layers/attention/dsv4/compressor.py
+++ b/python/sglang/srt/layers/attention/dsv4/compressor.py
@@ -8,7 +8,6 @@ import torch.nn as nn
 from sglang.kernels.fused_op import BaseFusedOp
 from sglang.kernels.ops.attention.dsa.triton_kernel import act_quant
 from sglang.kernels.ops.attention.dsv4 import (
-    linear_bf16_fp32,
     linear_kv_score,
     triton_create_paged_compress_data,
 )

--- a/python/sglang/srt/layers/attention/dsv4/compressor_v2.py
+++ b/python/sglang/srt/layers/attention/dsv4/compressor_v2.py
@@ -9,6 +9,7 @@ from sglang.kernels.ops.attention.dsv4 import (
     CompressorDecodePlan,
     CompressorPrefillPlan,
     compress_forward,
+    compress_forward_norm_rope_store,
     compress_norm_rope_store,
 )
 from sglang.srt.environ import envs
@@ -174,6 +175,33 @@ class CompressorBackendMixin:
             assert kv_score_buffer.shape[-1] == last_dim
             kv_score_buffer = kv_score_buffer.view(-1, compress_ratio, last_dim)
 
+        # The compressed row is a temporary that only the norm/rope store reads,
+        # so for the one shape that has a fused kernel it never reaches memory.
+        if (
+            _is_hip
+            and envs.SGLANG_OPT_FUSE_COMPRESS_NORM_ROPE.get()
+            and compress_ratio == 4
+            and head_dim in (128, 512)
+            and plan.is_decode
+            and not is_online
+            and not use_fp4_indexer
+        ):
+            compress_forward_norm_rope_store(
+                kv_score_buffer=kv_score_buffer,
+                kv_score_input=kv_score_input,
+                ape=ape.view(-1, head_dim),
+                plan=plan,
+                head_dim=head_dim,
+                norm_weight=norm.weight,
+                norm_eps=norm.variance_epsilon,
+                freq_cis=freqs_cis_cache,
+                out_loc=out_loc,
+                kvcache=kv_cache,
+                page_size=page_size,
+                bf16_store=bf16_store,
+            )
+            return
+
         # Step 1: compress_forward
         kv_compressed = compress_forward(
             kv_score_buffer=kv_score_buffer,
@@ -221,7 +249,8 @@ class CompressorBackendMixin:
         if _is_hip and not envs.SGLANG_OPT_USE_JIT_NORM.get():
             self._forward_unified_hip(
                 token_to_kv_pool=token_to_kv_pool,
-                kv_score_input=kv_score_input,
+                # The triton compressor is not built per input dtype.
+                kv_score_input=kv_score_input.to(compressor.ape.dtype),
                 state_pool=state_pool,
                 compressor=compressor,
                 layer_id=layer_id,

--- a/python/sglang/srt/layers/attention/dsv4/compressor_v2.py
+++ b/python/sglang/srt/layers/attention/dsv4/compressor_v2.py
@@ -177,12 +177,16 @@ class CompressorBackendMixin:
 
         # The compressed row is a temporary that only the norm/rope store reads,
         # so for the one shape that has a fused kernel it never reaches memory.
+        # The fused compress+norm+rope kernel now has both a decode entry
+        # (plan.is_decode, one row per sequence) and an extend entry (the
+        # CompressorPrefillPlan, one row per compress plan) used by chunked
+        # prefill AND MTP target_verify. Both are numerically identical to the
+        # unfused chain; `plan.is_decode` is therefore no longer required.
         if (
             _is_hip
             and envs.SGLANG_OPT_FUSE_COMPRESS_NORM_ROPE.get()
             and compress_ratio == 4
             and head_dim in (128, 512)
-            and plan.is_decode
             and not is_online
             and not use_fp4_indexer
         ):

--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -288,8 +288,12 @@ def _forward_with_allreduce_fusion_quant_per_group(
         _use_aiter_bpreshuffle_gfx95 as use_bpreshuffle,
     )
     from sglang.srt.layers.quantization.fp8_utils import (
+        _NATIVE_BPRESHUFFLE_SCALE,
         materialize_bpreshuffle_fp8_scale,
+        view_aiter_fused_rms_transposed_fp8_scale,
     )
+
+    native_scale = use_bpreshuffle and _NATIVE_BPRESHUFFLE_SCALE
 
     if use_attn_tp_group:
         world_size = get_parallel().attn_tp_size
@@ -322,12 +326,16 @@ def _forward_with_allreduce_fusion_quant_per_group(
             return None
         bf16_out, residual_out = fused_result
         per_1x128_quant, fp8_dtype = _get_aiter_per_group_quant()
+        # Let the quant kernel write bpreshuffle's layout instead of transposing
+        # afterwards; the copy is a whole kernel launch for a few hundred elements.
         fp8_out, scale_out = per_1x128_quant(
             bf16_out,
             quant_dtype=fp8_dtype,
-            transpose_scale=False,
+            transpose_scale=native_scale,
         )
-        if use_bpreshuffle:
+        if native_scale:
+            scale_out = view_aiter_fused_rms_transposed_fp8_scale(scale_out)
+        elif use_bpreshuffle:
             scale_out = materialize_bpreshuffle_fp8_scale(scale_out)
         return (fp8_out, scale_out), residual_out
 
@@ -360,9 +368,11 @@ def _forward_with_allreduce_fusion_quant_per_group(
     fp8_out, scale_out = per_1x128_quant(
         bf16_out,
         quant_dtype=fp8_dtype,
-        transpose_scale=False,
+        transpose_scale=native_scale,
     )
-    if use_bpreshuffle:
+    if native_scale:
+        scale_out = view_aiter_fused_rms_transposed_fp8_scale(scale_out)
+    elif use_bpreshuffle:
         scale_out = materialize_bpreshuffle_fp8_scale(scale_out)
     return (bf16_out, fp8_out, scale_out), residual_out
 

--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -285,10 +285,12 @@ def _forward_with_allreduce_fusion_quant_per_group(
         tensor_model_parallel_fused_allreduce_rmsnorm_quant_per_group,
     )
     from sglang.srt.layers.quantization.fp8_utils import (
+        _NATIVE_BPRESHUFFLE_SCALE,
+    )
+    from sglang.srt.layers.quantization.fp8_utils import (
         _use_aiter_bpreshuffle_gfx95 as use_bpreshuffle,
     )
     from sglang.srt.layers.quantization.fp8_utils import (
-        _NATIVE_BPRESHUFFLE_SCALE,
         materialize_bpreshuffle_fp8_scale,
         view_aiter_fused_rms_transposed_fp8_scale,
     )

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from enum import Enum
 from functools import lru_cache, partial
 from typing import TYPE_CHECKING, Callable, List, Optional, Tuple, Union
@@ -104,6 +105,16 @@ _FORCE_CK_W8A8: bool = False
 def set_force_ck_w8a8(enabled: bool = True) -> None:
     global _FORCE_CK_W8A8
     _FORCE_CK_W8A8 = enabled
+
+
+# Ask the per-group quant kernel to write bpreshuffle's scale layout directly
+# instead of transposing its output afterwards. The post-kernel transpose moves
+# only a few hundred scale elements but costs a full kernel launch, and it fired
+# 213 times per decode step. Gated so both paths live in one binary and can be
+# A/B'd by env var alone; the two layouts were verified bit-identical.
+_NATIVE_BPRESHUFFLE_SCALE: bool = (
+    os.environ.get("SGLANG_OPT_NATIVE_BPRESHUFFLE_SCALE", "1") == "1"
+)
 
 
 def materialize_bpreshuffle_fp8_scale(scale: torch.Tensor) -> torch.Tensor:
@@ -1134,12 +1145,21 @@ def aiter_w8a8_block_fp8_linear(
             x_scale = torch.as_strided(x_scale, x_scale.shape, (1, x_scale.shape[0]))
     else:
         materialize_bpreshuffle_scale = _use_aiter_bpreshuffle_gfx95 and not use_triton
+        # Ask the quant kernel for bpreshuffle's layout directly rather than
+        # transposing its output afterwards: the post-kernel copy moves a few
+        # hundred scale elements but costs a full kernel launch, and it ran 213
+        # times per decode step. transpose_scale only changes the order the kernel
+        # writes into the same [M, G] buffer, so logical indexing is restored by
+        # strides alone.
+        native_scale = materialize_bpreshuffle_scale and _NATIVE_BPRESHUFFLE_SCALE
         q_input, x_scale = aiter_per1x128_quant(
             input_2d,
             quant_dtype=aiter.dtypes.fp8,
-            transpose_scale=False,
+            transpose_scale=native_scale,
         )
-        if materialize_bpreshuffle_scale:
+        if native_scale:
+            x_scale = view_aiter_fused_rms_transposed_fp8_scale(x_scale)
+        elif materialize_bpreshuffle_scale:
             x_scale = materialize_bpreshuffle_fp8_scale(x_scale)
 
     if use_triton:

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -111,9 +111,11 @@ def set_force_ck_w8a8(enabled: bool = True) -> None:
 # instead of transposing its output afterwards. The post-kernel transpose moves
 # only a few hundred scale elements but costs a full kernel launch, and it fired
 # 213 times per decode step. Gated so both paths live in one binary and can be
-# A/B'd by env var alone; the two layouts were verified bit-identical.
+# A/B'd by env var alone; the two layouts were verified bit-identical. Default
+# off pending isolated validation, including a non-DSV4 gfx95 smoke test since
+# this path also affects generic gfx95 AITER call sites; set to 1 to enable.
 _NATIVE_BPRESHUFFLE_SCALE: bool = (
-    os.environ.get("SGLANG_OPT_NATIVE_BPRESHUFFLE_SCALE", "1") == "1"
+    os.environ.get("SGLANG_OPT_NATIVE_BPRESHUFFLE_SCALE", "0") == "1"
 )
 
 

--- a/test/registered/kernels/ops/attention/test_c128_v2.py
+++ b/test/registered/kernels/ops/attention/test_c128_v2.py
@@ -30,6 +30,13 @@ RATIO = 128
 ATOL = 5e-3
 RTOL = 5e-3
 
+# kv_score arrives either as fp32 or, when the wkv_gate gemm hands its output
+# over directly, as bf16 that the kernel widens on load.
+SRC_DTYPES = [
+    pytest.param(torch.float32, id="src_fp32"),
+    pytest.param(torch.bfloat16, id="src_bf16"),
+]
+
 
 def _gt_compress(
     kv_score_input_cpu: torch.Tensor,  # [num_q, head_dim*2]
@@ -45,14 +52,22 @@ def _gt_compress(
 
 
 def _make_inputs(
-    num_q: int, head_dim: int, seed: int
+    num_q: int, head_dim: int, seed: int, src_dtype: torch.dtype = torch.float32
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     g = torch.Generator(device="cpu").manual_seed(seed)
     kv_score_input_cpu = torch.randn(
         num_q, head_dim * 2, generator=g, dtype=torch.float32
     )
+    # Round to the transport dtype up front so the fp64 reference and the kernel
+    # see the same values; what is under test is the compress math, not how far
+    # bf16 rounds the inputs.
+    kv_score_input_cpu = kv_score_input_cpu.to(src_dtype).float()
     ape_cpu = torch.randn(RATIO, head_dim, generator=g, dtype=torch.float32)
     return kv_score_input_cpu, ape_cpu
+
+
+def _to_src(t: torch.Tensor, src_dtype: torch.dtype) -> torch.Tensor:
+    return t.to(get_device()).to(src_dtype)
 
 
 def _run_prefill(
@@ -98,9 +113,10 @@ def _run_decode(
 # -----------------------------------------------------------------------------
 
 
+@pytest.mark.parametrize("src_dtype", SRC_DTYPES)
 @pytest.mark.parametrize("mode", ["legacy", "paged"])
 @pytest.mark.parametrize("seq_len", [128, 256, 512])
-def test_prefill_no_context(mode: str, seq_len: int) -> None:
+def test_prefill_no_context(mode: str, seq_len: int, src_dtype: torch.dtype) -> None:
     """Single-shot prefill, no prefix. Every compress event must match fp64 GT."""
     if mode == "legacy":
         ctx: Context = make_legacy_context(
@@ -110,13 +126,15 @@ def test_prefill_no_context(mode: str, seq_len: int) -> None:
         ctx = make_paged_context(bs=1, compress_ratio=RATIO, head_dim=HEAD_DIM)
 
     seq_lens_cpu, extend_lens_cpu, num_q = to_seq_extend([(seq_len, seq_len)])
-    kv_in_cpu, ape_cpu = _make_inputs(num_q, ctx.head_dim, seed=seq_len)
+    kv_in_cpu, ape_cpu = _make_inputs(
+        num_q, ctx.head_dim, seed=seq_len, src_dtype=src_dtype
+    )
 
     pool = make_state_pool(ctx.num_pages, RATIO, ctx.head_dim)
     out = _run_prefill(
         ctx,
         pool,
-        kv_in_cpu.to(get_device()),
+        _to_src(kv_in_cpu, src_dtype),
         ape_cpu.to(get_device()),
         seq_lens_cpu,
         extend_lens_cpu,
@@ -128,9 +146,12 @@ def test_prefill_no_context(mode: str, seq_len: int) -> None:
         triton.testing.assert_close(out[plan_id].cpu(), gt, atol=ATOL, rtol=RTOL)
 
 
+@pytest.mark.parametrize("src_dtype", SRC_DTYPES)
 @pytest.mark.parametrize("mode", ["legacy", "paged"])
 @pytest.mark.parametrize("prefix_len", [0, 128, 256])
-def test_prefill_then_decode(mode: str, prefix_len: int) -> None:
+def test_prefill_then_decode(
+    mode: str, prefix_len: int, src_dtype: torch.dtype
+) -> None:
     """Prefill ``prefix_len`` tokens, then decode through to the next 128 boundary."""
     seq_len = prefix_len + RATIO  # one full compress chunk after prefix
 
@@ -142,7 +163,7 @@ def test_prefill_then_decode(mode: str, prefix_len: int) -> None:
         ctx = make_paged_context(bs=1, compress_ratio=RATIO, head_dim=HEAD_DIM)
 
     kv_full_cpu, ape_cpu = _make_inputs(
-        seq_len, ctx.head_dim, seed=seq_len + prefix_len
+        seq_len, ctx.head_dim, seed=seq_len + prefix_len, src_dtype=src_dtype
     )
     pool = make_state_pool(ctx.num_pages, RATIO, ctx.head_dim)
 
@@ -151,7 +172,7 @@ def test_prefill_then_decode(mode: str, prefix_len: int) -> None:
         _run_prefill(
             ctx,
             pool,
-            kv_full_cpu[:prefix_len].to(get_device()),
+            _to_src(kv_full_cpu[:prefix_len], src_dtype),
             ape_cpu.to(get_device()),
             seq_lens_cpu,
             extend_lens_cpu,
@@ -163,7 +184,7 @@ def test_prefill_then_decode(mode: str, prefix_len: int) -> None:
         seq_lens_gpu = torch.tensor(
             [cur_seq_len], dtype=torch.int64, device=get_device()
         )
-        kv_step = kv_full_cpu[prefix_len + k : prefix_len + k + 1].to(get_device())
+        kv_step = _to_src(kv_full_cpu[prefix_len + k : prefix_len + k + 1], src_dtype)
         out = _run_decode(ctx, pool, kv_step, ape_cpu.to(get_device()), seq_lens_gpu)
         if cur_seq_len % RATIO == 0:
             final_out = out
@@ -174,10 +195,13 @@ def test_prefill_then_decode(mode: str, prefix_len: int) -> None:
     triton.testing.assert_close(final_out[0].cpu(), gt, atol=ATOL, rtol=RTOL)
 
 
+@pytest.mark.parametrize("src_dtype", SRC_DTYPES)
 @pytest.mark.parametrize("mode", ["legacy", "paged"])
 @pytest.mark.parametrize("prefix_len", [128, 120, 256])
 @pytest.mark.parametrize("extend_len", [128, 256])
-def test_prefill_then_extend(mode: str, prefix_len: int, extend_len: int) -> None:
+def test_prefill_then_extend(
+    mode: str, prefix_len: int, extend_len: int, src_dtype: torch.dtype
+) -> None:
     """Prefill once, then a second prefill that extends across compress event(s).
 
     A prefix that is not a multiple of the ratio (e.g. 120) makes the first
@@ -194,14 +218,16 @@ def test_prefill_then_extend(mode: str, prefix_len: int, extend_len: int) -> Non
     else:
         ctx = make_paged_context(bs=1, compress_ratio=RATIO, head_dim=HEAD_DIM)
 
-    kv_full_cpu, ape_cpu = _make_inputs(seq_len, ctx.head_dim, seed=prefix_len)
+    kv_full_cpu, ape_cpu = _make_inputs(
+        seq_len, ctx.head_dim, seed=prefix_len, src_dtype=src_dtype
+    )
     pool = make_state_pool(ctx.num_pages, RATIO, ctx.head_dim)
 
     seq_lens_cpu, extend_lens_cpu, _ = to_seq_extend([(prefix_len, prefix_len)])
     _run_prefill(
         ctx,
         pool,
-        kv_full_cpu[:prefix_len].to(get_device()),
+        _to_src(kv_full_cpu[:prefix_len], src_dtype),
         ape_cpu.to(get_device()),
         seq_lens_cpu,
         extend_lens_cpu,
@@ -211,7 +237,7 @@ def test_prefill_then_extend(mode: str, prefix_len: int, extend_len: int) -> Non
     out = _run_prefill(
         ctx,
         pool,
-        kv_full_cpu[prefix_len:].to(get_device()),
+        _to_src(kv_full_cpu[prefix_len:], src_dtype),
         ape_cpu.to(get_device()),
         seq_lens_cpu,
         extend_lens_cpu,
@@ -226,8 +252,9 @@ def test_prefill_then_extend(mode: str, prefix_len: int, extend_len: int) -> Non
         )
 
 
+@pytest.mark.parametrize("src_dtype", SRC_DTYPES)
 @pytest.mark.parametrize("mode", ["legacy", "paged"])
-def test_prefill_multibatch(mode: str) -> None:
+def test_prefill_multibatch(mode: str, src_dtype: torch.dtype) -> None:
     """Multi-batch prefill, each batch ending at a different chunk count."""
     seq_extend = [(128, 128), (256, 256), (384, 384)]
     bs = len(seq_extend)
@@ -239,12 +266,14 @@ def test_prefill_multibatch(mode: str) -> None:
         ctx = make_paged_context(bs=bs, compress_ratio=RATIO, head_dim=HEAD_DIM)
 
     seq_lens_cpu, extend_lens_cpu, num_q = to_seq_extend(seq_extend)
-    kv_in_cpu, ape_cpu = _make_inputs(num_q, ctx.head_dim, seed=99)
+    kv_in_cpu, ape_cpu = _make_inputs(
+        num_q, ctx.head_dim, seed=99, src_dtype=src_dtype
+    )
     pool = make_state_pool(ctx.num_pages, RATIO, ctx.head_dim)
     out = _run_prefill(
         ctx,
         pool,
-        kv_in_cpu.to(get_device()),
+        _to_src(kv_in_cpu, src_dtype),
         ape_cpu.to(get_device()),
         seq_lens_cpu,
         extend_lens_cpu,

--- a/test/registered/kernels/ops/attention/test_c128_v2.py
+++ b/test/registered/kernels/ops/attention/test_c128_v2.py
@@ -266,9 +266,7 @@ def test_prefill_multibatch(mode: str, src_dtype: torch.dtype) -> None:
         ctx = make_paged_context(bs=bs, compress_ratio=RATIO, head_dim=HEAD_DIM)
 
     seq_lens_cpu, extend_lens_cpu, num_q = to_seq_extend(seq_extend)
-    kv_in_cpu, ape_cpu = _make_inputs(
-        num_q, ctx.head_dim, seed=99, src_dtype=src_dtype
-    )
+    kv_in_cpu, ape_cpu = _make_inputs(num_q, ctx.head_dim, seed=99, src_dtype=src_dtype)
     pool = make_state_pool(ctx.num_pages, RATIO, ctx.head_dim)
     out = _run_prefill(
         ctx,

--- a/test/registered/kernels/ops/attention/test_c4_v2.py
+++ b/test/registered/kernels/ops/attention/test_c4_v2.py
@@ -31,6 +31,13 @@ WINDOW = 8  # = 2 * RATIO (overlap + current)
 ATOL = 5e-3
 RTOL = 5e-3
 
+# kv_score arrives either as fp32 or, when the wkv_gate gemm hands its output
+# over directly, as bf16 that the kernel widens on load.
+SRC_DTYPES = [
+    pytest.param(torch.float32, id="src_fp32"),
+    pytest.param(torch.bfloat16, id="src_bf16"),
+]
+
 
 # -----------------------------------------------------------------------------
 # fp64 ground truth (single compress event over a 8-token window).
@@ -107,14 +114,22 @@ def _run_decode(
 
 
 def _make_inputs(
-    num_q: int, head_dim: int, seed: int
+    num_q: int, head_dim: int, seed: int, src_dtype: torch.dtype = torch.float32
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     g = torch.Generator(device="cpu").manual_seed(seed)
     kv_score_input_cpu = torch.randn(
         num_q, head_dim * 4, generator=g, dtype=torch.float32
     )
+    # Round to the transport dtype up front so the fp64 reference and the kernel
+    # see the same values; what is under test is the compress math, not how far
+    # bf16 rounds the inputs.
+    kv_score_input_cpu = kv_score_input_cpu.to(src_dtype).float()
     ape_cpu = torch.randn(WINDOW, head_dim, generator=g, dtype=torch.float32)
     return kv_score_input_cpu, ape_cpu
+
+
+def _to_src(t: torch.Tensor, src_dtype: torch.dtype) -> torch.Tensor:
+    return t.to(get_device()).to(src_dtype)
 
 
 # -----------------------------------------------------------------------------
@@ -122,9 +137,10 @@ def _make_inputs(
 # -----------------------------------------------------------------------------
 
 
+@pytest.mark.parametrize("src_dtype", SRC_DTYPES)
 @pytest.mark.parametrize("mode", ["legacy", "paged"])
 @pytest.mark.parametrize("seq_len", [4, 8, 32, 256, 1024])
-def test_prefill_no_context(mode: str, seq_len: int) -> None:
+def test_prefill_no_context(mode: str, seq_len: int, src_dtype: torch.dtype) -> None:
     """Prefill once, no prefix. Every compress event must match fp64 GT."""
     if mode == "legacy":
         ctx: Context = make_legacy_context(
@@ -134,13 +150,15 @@ def test_prefill_no_context(mode: str, seq_len: int) -> None:
         ctx = make_paged_context(bs=1, compress_ratio=RATIO, head_dim=HEAD_DIM)
 
     seq_lens_cpu, extend_lens_cpu, num_q = to_seq_extend([(seq_len, seq_len)])
-    kv_in_cpu, ape_cpu = _make_inputs(num_q, ctx.head_dim, seed=seq_len)
+    kv_in_cpu, ape_cpu = _make_inputs(
+        num_q, ctx.head_dim, seed=seq_len, src_dtype=src_dtype
+    )
 
     pool = make_state_pool(ctx.num_pages, RATIO, ctx.head_dim)
     out = _run_prefill(
         ctx,
         pool,
-        kv_in_cpu.to(get_device()),
+        _to_src(kv_in_cpu, src_dtype),
         ape_cpu.to(get_device()),
         seq_lens_cpu,
         extend_lens_cpu,
@@ -159,9 +177,12 @@ def test_prefill_no_context(mode: str, seq_len: int) -> None:
         )
 
 
+@pytest.mark.parametrize("src_dtype", SRC_DTYPES)
 @pytest.mark.parametrize("mode", ["legacy", "paged"])
 @pytest.mark.parametrize("prefix_len", [4, 256])
-def test_prefill_then_decode(mode: str, prefix_len: int) -> None:
+def test_prefill_then_decode(
+    mode: str, prefix_len: int, src_dtype: torch.dtype
+) -> None:
     """Prefill once, then decode 4 more tokens through one compress boundary."""
     extend_decode = 4
     seq_len = prefix_len + extend_decode
@@ -174,7 +195,7 @@ def test_prefill_then_decode(mode: str, prefix_len: int) -> None:
         ctx = make_paged_context(bs=1, compress_ratio=RATIO, head_dim=HEAD_DIM)
 
     kv_full_cpu, ape_cpu = _make_inputs(
-        seq_len, ctx.head_dim, seed=seq_len + prefix_len
+        seq_len, ctx.head_dim, seed=seq_len + prefix_len, src_dtype=src_dtype
     )
     pool = make_state_pool(ctx.num_pages, RATIO, ctx.head_dim)
 
@@ -183,7 +204,7 @@ def test_prefill_then_decode(mode: str, prefix_len: int) -> None:
     _run_prefill(
         ctx,
         pool,
-        kv_full_cpu[:prefix_len].to(get_device()),
+        _to_src(kv_full_cpu[:prefix_len], src_dtype),
         ape_cpu.to(get_device()),
         seq_lens_cpu,
         extend_lens_cpu,
@@ -196,7 +217,7 @@ def test_prefill_then_decode(mode: str, prefix_len: int) -> None:
         seq_lens_gpu = torch.tensor(
             [cur_seq_len], dtype=torch.int64, device=get_device()
         )
-        kv_step = kv_full_cpu[prefix_len + k : prefix_len + k + 1].to(get_device())
+        kv_step = _to_src(kv_full_cpu[prefix_len + k : prefix_len + k + 1], src_dtype)
         out = _run_decode(ctx, pool, kv_step, ape_cpu.to(get_device()), seq_lens_gpu)
         if cur_seq_len % RATIO == 0:
             final_out = out
@@ -208,10 +229,13 @@ def test_prefill_then_decode(mode: str, prefix_len: int) -> None:
     triton.testing.assert_close(final_out[0].cpu(), gt, atol=ATOL, rtol=RTOL)
 
 
+@pytest.mark.parametrize("src_dtype", SRC_DTYPES)
 @pytest.mark.parametrize("mode", ["legacy", "paged"])
 @pytest.mark.parametrize("prefix_len", [256, 512, 768])
 @pytest.mark.parametrize("extend_len", [4, 32])
-def test_prefill_then_extend(mode: str, prefix_len: int, extend_len: int) -> None:
+def test_prefill_then_extend(
+    mode: str, prefix_len: int, extend_len: int, src_dtype: torch.dtype
+) -> None:
     """Prefill once, then prefill an extend that crosses one or more compress events.
 
     The first prefill ends at a swa_page boundary (only relevant for paged),
@@ -228,7 +252,9 @@ def test_prefill_then_extend(mode: str, prefix_len: int, extend_len: int) -> Non
         ctx = make_paged_context(bs=1, compress_ratio=RATIO, head_dim=HEAD_DIM)
 
     seq_len = prefix_len + extend_len
-    kv_full_cpu, ape_cpu = _make_inputs(seq_len, ctx.head_dim, seed=prefix_len)
+    kv_full_cpu, ape_cpu = _make_inputs(
+        seq_len, ctx.head_dim, seed=prefix_len, src_dtype=src_dtype
+    )
     pool = make_state_pool(ctx.num_pages, RATIO, ctx.head_dim)
 
     # First prefill: seq=prefix, ext=prefix.
@@ -236,7 +262,7 @@ def test_prefill_then_extend(mode: str, prefix_len: int, extend_len: int) -> Non
     _run_prefill(
         ctx,
         pool,
-        kv_full_cpu[:prefix_len].to(get_device()),
+        _to_src(kv_full_cpu[:prefix_len], src_dtype),
         ape_cpu.to(get_device()),
         seq_lens_cpu,
         extend_lens_cpu,
@@ -247,7 +273,7 @@ def test_prefill_then_extend(mode: str, prefix_len: int, extend_len: int) -> Non
     out = _run_prefill(
         ctx,
         pool,
-        kv_full_cpu[prefix_len:].to(get_device()),
+        _to_src(kv_full_cpu[prefix_len:], src_dtype),
         ape_cpu.to(get_device()),
         seq_lens_cpu,
         extend_lens_cpu,
@@ -262,7 +288,8 @@ def test_prefill_then_extend(mode: str, prefix_len: int, extend_len: int) -> Non
         )
 
 
-def test_paged_buffer_intermediate() -> None:
+@pytest.mark.parametrize("src_dtype", SRC_DTYPES)
+def test_paged_buffer_intermediate(src_dtype: torch.dtype) -> None:
     """Paged-only: after a multi-page prefill, verify the trailing 4 tokens of
     every swa_page sit in the correct state-pool slots.
 
@@ -279,13 +306,15 @@ def test_paged_buffer_intermediate() -> None:
     )
     seq_len = 1024  # 4 swa_pages
     seq_lens_cpu, extend_lens_cpu, num_q = to_seq_extend([(seq_len, seq_len)])
-    kv_in_cpu, ape_cpu = _make_inputs(num_q, ctx.head_dim, seed=42)
+    kv_in_cpu, ape_cpu = _make_inputs(
+        num_q, ctx.head_dim, seed=42, src_dtype=src_dtype
+    )
 
     pool = make_state_pool(ctx.num_pages, RATIO, ctx.head_dim)
     _run_prefill(
         ctx,
         pool,
-        kv_in_cpu.to(get_device()),
+        _to_src(kv_in_cpu, src_dtype),
         ape_cpu.to(get_device()),
         seq_lens_cpu,
         extend_lens_cpu,
@@ -313,8 +342,9 @@ def test_paged_buffer_intermediate() -> None:
             )
 
 
+@pytest.mark.parametrize("src_dtype", SRC_DTYPES)
 @pytest.mark.parametrize("mode", ["legacy", "paged"])
-def test_prefill_multibatch(mode: str) -> None:
+def test_prefill_multibatch(mode: str, src_dtype: torch.dtype) -> None:
     """Multi-batch prefill, both modes."""
     seq_extend = [(8, 8), (256, 256), (260, 260), (1023, 1023)]
     bs = len(seq_extend)
@@ -326,12 +356,14 @@ def test_prefill_multibatch(mode: str) -> None:
         ctx = make_paged_context(bs=bs, compress_ratio=RATIO, head_dim=HEAD_DIM)
 
     seq_lens_cpu, extend_lens_cpu, num_q = to_seq_extend(seq_extend)
-    kv_in_cpu, ape_cpu = _make_inputs(num_q, ctx.head_dim, seed=99)
+    kv_in_cpu, ape_cpu = _make_inputs(
+        num_q, ctx.head_dim, seed=99, src_dtype=src_dtype
+    )
     pool = make_state_pool(ctx.num_pages, RATIO, ctx.head_dim)
     out = _run_prefill(
         ctx,
         pool,
-        kv_in_cpu.to(get_device()),
+        _to_src(kv_in_cpu, src_dtype),
         ape_cpu.to(get_device()),
         seq_lens_cpu,
         extend_lens_cpu,

--- a/test/registered/kernels/ops/attention/test_c4_v2.py
+++ b/test/registered/kernels/ops/attention/test_c4_v2.py
@@ -306,9 +306,7 @@ def test_paged_buffer_intermediate(src_dtype: torch.dtype) -> None:
     )
     seq_len = 1024  # 4 swa_pages
     seq_lens_cpu, extend_lens_cpu, num_q = to_seq_extend([(seq_len, seq_len)])
-    kv_in_cpu, ape_cpu = _make_inputs(
-        num_q, ctx.head_dim, seed=42, src_dtype=src_dtype
-    )
+    kv_in_cpu, ape_cpu = _make_inputs(num_q, ctx.head_dim, seed=42, src_dtype=src_dtype)
 
     pool = make_state_pool(ctx.num_pages, RATIO, ctx.head_dim)
     _run_prefill(
@@ -356,9 +354,7 @@ def test_prefill_multibatch(mode: str, src_dtype: torch.dtype) -> None:
         ctx = make_paged_context(bs=bs, compress_ratio=RATIO, head_dim=HEAD_DIM)
 
     seq_lens_cpu, extend_lens_cpu, num_q = to_seq_extend(seq_extend)
-    kv_in_cpu, ape_cpu = _make_inputs(
-        num_q, ctx.head_dim, seed=99, src_dtype=src_dtype
-    )
+    kv_in_cpu, ape_cpu = _make_inputs(num_q, ctx.head_dim, seed=99, src_dtype=src_dtype)
     pool = make_state_pool(ctx.num_pages, RATIO, ctx.head_dim)
     out = _run_prefill(
         ctx,

--- a/test/registered/kernels/ops/attention/test_fused_compress4_norm_rope.py
+++ b/test/registered/kernels/ops/attention/test_fused_compress4_norm_rope.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import sys
+from typing import Tuple, Union
+
+import pytest
+import torch
+
+from sglang.kernels.ops.attention.deepseek_v4_rope import precompute_freqs_cis
+from sglang.kernels.ops.attention.dsv4 import (
+    compress_forward,
+    compress_forward_norm_rope_store,
+    compress_norm_rope_store,
+)
+from sglang.srt.utils import get_device, is_hip
+from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.kernels.deepseek_v4.common import (
+    LegacyContext,
+    PagedContext,
+    make_legacy_context,
+    make_paged_context,
+    make_state_pool,
+    to_seq_extend,
+)
+
+# HIP/gfx95 only: compress_forward_norm_rope_store is the fused c4 decode path.
+register_amd_ci(est_time=90, suite="nightly-amd-kernel-1-gpu", nightly=True)
+
+pytestmark = pytest.mark.skipif(
+    not is_hip(), reason="fused compress+norm+rope is HIP/gfx95 only"
+)
+
+Context = Union[LegacyContext, PagedContext]
+
+# c4 input row layout: | kv_overlap | kv | score_overlap | score |, each head_dim.
+RATIO = 4
+WINDOW = 8  # 2 * RATIO
+ROPE_DIM = 64
+NORM_EPS = 1.0e-6
+N_DECODE_STEPS = 8  # spans >=2 compress boundaries plus non-boundary steps
+
+# Per-head-dim store epilogue the fused kernel dispatches to. head_dim 512 is the
+# flashmla epilogue (bf16 store into a [slots, head_dim] bf16 buffer, page_size
+# 1); head_dim 128 is the indexer epilogue (fp8 store into the page-major
+# index-k-with-scale buffer, head_dim + 4 bytes per token, page_size 64). The
+# indexer store is always fp8; bf16_store is a flashmla-only option.
+CONFIGS = {
+    512: dict(page_size=1, bf16_store=True, store="bf16"),
+    128: dict(page_size=64, bf16_store=False, store="fp8"),
+}
+
+SRC_DTYPES = [
+    pytest.param(torch.float32, id="src_fp32"),
+    # bf16 source also exercises the kv_score bf16 transport the compressor
+    # kernels widen on load.
+    pytest.param(torch.bfloat16, id="src_bf16"),
+]
+
+
+def _make_ctx(mode: str, head_dim: int) -> Context:
+    if mode == "legacy":
+        return make_legacy_context(bs=1, compress_ratio=RATIO, head_dim=head_dim)
+    return make_paged_context(bs=1, compress_ratio=RATIO, head_dim=head_dim)
+
+
+def _make_inputs(
+    num_q: int, head_dim: int, seed: int, src_dtype: torch.dtype
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    g = torch.Generator(device="cpu").manual_seed(seed)
+    kv_score_input_cpu = torch.randn(
+        num_q, head_dim * 4, generator=g, dtype=torch.float32
+    )
+    # Round to the transport dtype up front so both paths see identical inputs;
+    # what is under test is fused-vs-chain, not how far bf16 rounds the inputs.
+    kv_score_input_cpu = kv_score_input_cpu.to(src_dtype).float()
+    ape_cpu = torch.randn(WINDOW, head_dim, generator=g, dtype=torch.float32)
+    return kv_score_input_cpu, ape_cpu
+
+
+def _to_src(t: torch.Tensor, src_dtype: torch.dtype) -> torch.Tensor:
+    return t.to(get_device()).to(src_dtype)
+
+
+def _make_cache(
+    head_dim: int, num_slots: int, page_size: int, store: str
+) -> torch.Tensor:
+    if store == "bf16":
+        return torch.zeros(
+            num_slots, head_dim, dtype=torch.bfloat16, device=get_device()
+        )
+    bytes_per_token = head_dim + 4  # fp8 codes + 4 scale bytes
+    num_pages = (num_slots + page_size) // page_size + 1
+    return torch.zeros(
+        num_pages, page_size * bytes_per_token, dtype=torch.uint8, device=get_device()
+    )
+
+
+def _assert_cache_close(store: str, a: torch.Tensor, b: torch.Tensor) -> None:
+    """The two paths must produce interchangeable caches.
+
+    The fused kernel keeps the compressed row in fp32 registers while the
+    two-kernel chain rounds it to bf16 between launches, so a handful of fp8
+    codes can land one code apart; scales are computed from the same amax and
+    stay identical. bf16 store carries the same intermediate difference forward.
+    """
+    if store == "bf16":
+        torch.testing.assert_close(a.float(), b.float(), atol=2e-2, rtol=2e-2)
+        return
+    diff = (a.to(torch.int16) - b.to(torch.int16)).abs()
+    assert diff.max().item() <= 1, f"fp8 store diverged by >1 code: max={diff.max()}"
+    assert diff.ne(0).float().mean().item() < 5e-3, "too many differing fp8 codes"
+
+
+@pytest.mark.parametrize("head_dim", list(CONFIGS))
+@pytest.mark.parametrize("mode", ["legacy", "paged"])
+@pytest.mark.parametrize("src_dtype", SRC_DTYPES)
+@pytest.mark.parametrize("prefix_len", [0, 6, 256])
+def test_fused_matches_chain_decode(
+    head_dim: int, mode: str, src_dtype: torch.dtype, prefix_len: int
+) -> None:
+    """Fused compress+norm+rope+store must match compress_forward + store.
+
+    A prefix that is not a multiple of the ratio (6) forces a partial first
+    block whose overlap is read from the state buffer; prefix 256 exercises a
+    multi-page paged layout. Stepping N_DECODE_STEPS past the prefix crosses
+    several compress boundaries and includes non-compress accumulate steps.
+    """
+    cfg = CONFIGS[head_dim]
+    device = get_device()
+    torch.manual_seed(head_dim + prefix_len + int(src_dtype == torch.bfloat16))
+
+    ctx = _make_ctx(mode, head_dim)
+    pool_chain = make_state_pool(ctx.num_pages, RATIO, head_dim)
+    pool_fused = make_state_pool(ctx.num_pages, RATIO, head_dim)
+
+    seq_len_total = prefix_len + N_DECODE_STEPS
+    kv_full_cpu, ape_cpu = _make_inputs(
+        seq_len_total, head_dim, seed=seq_len_total, src_dtype=src_dtype
+    )
+    ape = ape_cpu.to(device)
+    norm_weight = torch.randn(head_dim, dtype=torch.bfloat16, device=device)
+    freqs_cis = precompute_freqs_cis(
+        ROPE_DIM, seq_len_total + 4, 0, 10000, 1, 32, 1
+    ).to(device)
+
+    cache_chain = _make_cache(head_dim, N_DECODE_STEPS, cfg["page_size"], cfg["store"])
+    cache_fused = _make_cache(head_dim, N_DECODE_STEPS, cfg["page_size"], cfg["store"])
+
+    # Bring both pools to the same state with an identical prefix prefill
+    # (compress_forward only -- the fused path is decode-only).
+    if prefix_len > 0:
+        seq_lens_cpu, extend_lens_cpu, _ = to_seq_extend([(prefix_len, prefix_len)])
+        kv_pref = _to_src(kv_full_cpu[:prefix_len], src_dtype)
+        for pool in (pool_chain, pool_fused):
+            plan = ctx.make_prefill_plan(seq_lens_cpu, extend_lens_cpu, prefix_len)
+            compress_forward(
+                pool, kv_pref, ape, plan, head_dim=head_dim, compress_ratio=RATIO
+            )
+
+    next_slot = 0
+    for k in range(N_DECODE_STEPS):
+        pos = prefix_len + k
+        cur_seq_len = pos + 1
+        is_boundary = cur_seq_len % RATIO == 0
+        seq_lens_gpu = torch.tensor([cur_seq_len], dtype=torch.int64, device=device)
+        kv_step = _to_src(kv_full_cpu[pos : pos + 1], src_dtype)
+        out_loc = torch.tensor(
+            [next_slot if is_boundary else 0], dtype=torch.int64, device=device
+        )
+
+        before_chain = cache_chain.clone()
+        before_fused = cache_fused.clone()
+
+        plan = ctx.make_decode_plan(seq_lens_gpu)
+        row = compress_forward(
+            pool_chain, kv_step, ape, plan, head_dim=head_dim, compress_ratio=RATIO
+        )
+        compress_norm_rope_store(
+            row,
+            plan,
+            norm_weight=norm_weight,
+            norm_eps=NORM_EPS,
+            freq_cis=freqs_cis,
+            out_loc=out_loc,
+            kvcache=cache_chain,
+            page_size=cfg["page_size"],
+            bf16_store=cfg["bf16_store"],
+        )
+
+        plan_fused = ctx.make_decode_plan(seq_lens_gpu)
+        compress_forward_norm_rope_store(
+            kv_score_buffer=pool_fused,
+            kv_score_input=kv_step,
+            ape=ape,
+            plan=plan_fused,
+            head_dim=head_dim,
+            norm_weight=norm_weight,
+            norm_eps=NORM_EPS,
+            freq_cis=freqs_cis,
+            out_loc=out_loc,
+            kvcache=cache_fused,
+            page_size=cfg["page_size"],
+            bf16_store=cfg["bf16_store"],
+        )
+
+        if is_boundary:
+            next_slot += 1
+        else:
+            # A non-compress decode step must not touch either cache.
+            assert torch.equal(
+                cache_chain, before_chain
+            ), f"chain wrote cache on non-compress step (pos={pos})"
+            assert torch.equal(
+                cache_fused, before_fused
+            ), f"fused wrote cache on non-compress step (pos={pos})"
+
+        _assert_cache_close(cfg["store"], cache_chain, cache_fused)
+
+    assert next_slot >= 2, "test did not exercise at least two compress boundaries"
+    # The state buffers accumulate the same verbatim token rows in both paths.
+    torch.testing.assert_close(pool_fused, pool_chain, atol=1e-3, rtol=1e-3)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/test/registered/kernels/ops/attention/test_fused_compress4_norm_rope.py
+++ b/test/registered/kernels/ops/attention/test_fused_compress4_norm_rope.py
@@ -39,11 +39,13 @@ ROPE_DIM = 64
 NORM_EPS = 1.0e-6
 N_DECODE_STEPS = 8  # spans >=2 compress boundaries plus non-boundary steps
 
-# Per-head-dim store epilogue the fused kernel dispatches to. head_dim 512 is the
-# flashmla epilogue (bf16 store into a [slots, head_dim] bf16 buffer, page_size
-# 1); head_dim 128 is the indexer epilogue (fp8 store into the page-major
-# index-k-with-scale buffer, head_dim + 4 bytes per token, page_size 64). The
-# indexer store is always fp8; bf16_store is a flashmla-only option.
+# Per-head-dim store epilogue the fused kernel dispatches to. Both epilogues
+# write into a page-major uint8 cache whose row stride is page_size *
+# bytes_per_token. head_dim 512 is the flashmla epilogue (bf16 store, so
+# head_dim * 2 bytes per token, page_size 1); head_dim 128 is the indexer
+# epilogue (fp8 store into the index-k-with-scale layout, head_dim + 4 bytes per
+# token, page_size 64). The indexer store is always fp8; bf16_store is a
+# flashmla-only option.
 CONFIGS = {
     512: dict(page_size=1, bf16_store=True, store="bf16"),
     128: dict(page_size=64, bf16_store=False, store="fp8"),
@@ -84,31 +86,60 @@ def _to_src(t: torch.Tensor, src_dtype: torch.dtype) -> torch.Tensor:
 def _make_cache(
     head_dim: int, num_slots: int, page_size: int, store: str
 ) -> torch.Tensor:
-    if store == "bf16":
-        return torch.zeros(
-            num_slots, head_dim, dtype=torch.bfloat16, device=get_device()
-        )
-    bytes_per_token = head_dim + 4  # fp8 codes + 4 scale bytes
+    # bf16 store: head_dim * 2 bytes/token; fp8 indexer store: head_dim fp8
+    # codes + 4 scale bytes. Both are page-major uint8 buffers.
+    bytes_per_token = head_dim * 2 if store == "bf16" else head_dim + 4
     num_pages = (num_slots + page_size) // page_size + 1
     return torch.zeros(
         num_pages, page_size * bytes_per_token, dtype=torch.uint8, device=get_device()
     )
 
 
-def _assert_cache_close(store: str, a: torch.Tensor, b: torch.Tensor) -> None:
+def _dequant_indexer_fp8(
+    cache: torch.Tensor, head_dim: int, page_size: int
+) -> torch.Tensor:
+    """Decode the index-k store: head_dim e4m3 codes + one fp32 scale per token."""
+    n_code = page_size * head_dim
+    codes = (
+        cache[:, :n_code]
+        .view(torch.float8_e4m3fn)
+        .float()
+        .view(cache.shape[0], page_size, head_dim)
+    )
+    scale = (
+        cache[:, n_code:]
+        .reshape(cache.shape[0], page_size, 4)
+        .view(torch.float32)  # [pages, page_size, 1]
+    )
+    return codes * scale
+
+
+def _assert_cache_close(
+    store: str, a: torch.Tensor, b: torch.Tensor, head_dim: int, page_size: int
+) -> None:
     """The two paths must produce interchangeable caches.
 
     The fused kernel keeps the compressed row in fp32 registers while the
-    two-kernel chain rounds it to bf16 between launches, so a handful of fp8
-    codes can land one code apart; scales are computed from the same amax and
-    stay identical. bf16 store carries the same intermediate difference forward.
+    two-kernel chain rounds it to bf16 between launches. bf16 store carries that
+    intermediate difference straight into the cache; the fp8 indexer store keeps
+    codes essentially identical while a rare amax tie shifts one token's scale in
+    its lowest mantissa bits, so it is compared in dequantized value space where
+    at most a handful of elements may land one e4m3 code apart.
     """
     if store == "bf16":
-        torch.testing.assert_close(a.float(), b.float(), atol=2e-2, rtol=2e-2)
+        a_f = a.view(torch.bfloat16).float()
+        b_f = b.view(torch.bfloat16).float()
+        torch.testing.assert_close(a_f, b_f, atol=2e-2, rtol=2e-2)
         return
-    diff = (a.to(torch.int16) - b.to(torch.int16)).abs()
-    assert diff.max().item() <= 1, f"fp8 store diverged by >1 code: max={diff.max()}"
-    assert diff.ne(0).float().mean().item() < 5e-3, "too many differing fp8 codes"
+    va = _dequant_indexer_fp8(a, head_dim, page_size)
+    vb = _dequant_indexer_fp8(b, head_dim, page_size)
+    diff = (va - vb).abs()
+    # No element may diverge by more than a single e4m3 code step...
+    step_tol = 2e-1 + 2e-1 * vb.abs()
+    assert (diff > step_tol).sum().item() == 0, "value diverged beyond one fp8 code"
+    # ...and only a handful may shift at all.
+    small_tol = 2e-2 + 2e-2 * vb.abs()
+    assert (diff > small_tol).float().mean().item() < 5e-3, "too many fp8 codes shifted"
 
 
 @pytest.mark.parametrize("head_dim", list(CONFIGS))
@@ -138,7 +169,7 @@ def test_fused_matches_chain_decode(
         seq_len_total, head_dim, seed=seq_len_total, src_dtype=src_dtype
     )
     ape = ape_cpu.to(device)
-    norm_weight = torch.randn(head_dim, dtype=torch.bfloat16, device=device)
+    norm_weight = torch.randn(head_dim, dtype=torch.float32, device=device)
     freqs_cis = precompute_freqs_cis(
         ROPE_DIM, seq_len_total + 4, 0, 10000, 1, 32, 1
     ).to(device)
@@ -214,7 +245,9 @@ def test_fused_matches_chain_decode(
                 cache_fused, before_fused
             ), f"fused wrote cache on non-compress step (pos={pos})"
 
-        _assert_cache_close(cfg["store"], cache_chain, cache_fused)
+        _assert_cache_close(
+            cfg["store"], cache_chain, cache_fused, head_dim, cfg["page_size"]
+        )
 
     assert next_slot >= 2, "test did not exercise at least two compress boundaries"
     # The state buffers accumulate the same verbatim token rows in both paths.


### PR DESCRIPTION
> **Stacked on #34624 — draft, do not merge until #34624 lands.**
> This branch is based on the head of #34624, so the diff below includes #34624's
> commits. The only new change here is the last commit
> **`a2fcc273` — _feat(dsv4/#34624): fire compress+norm+rope fusion under MTP (target_verify)_**.
> Reviewers should look at that commit alone; it will rebase to an empty delta once #34624 merges.

## Summary

#34624 added the fused `compress + norm + rope` kernel with a **decode-only** entry.
Under **MTP** (speculative decoding via EAGLE, `target_verify`), the target model
runs `is_decode=False` (`CompressorPrefillPlan`), so it fell back to the **unfused**
`compress → fused_norm_rope → write` chain. Verified: **0 fused kernels across all 8
ranks** in a c32/8k1k MTP trace before this change.

This PR adds an **extend/prefill entry** so the fusion also fires under MTP `target_verify`
(and chunked prefill), folding the per-compress-region launch chain **3 → 2**.

## What changed (commit `a2fcc273`)

- `kernels/jit/csrc/deepseek_v4/fused_compress4_norm_rope.cuh`
  - New `FusedCompress4NormRopePrefillParams` (separate compress domain `plan_c` and
    ring-buffer write domain `plan_w`, which are unequal in extend).
  - New `run_prefill` + prefill kernels for both head-dims:
    - head_dim 512 (flashmla): `flash_c4_prefill_norm_rope`
    - head_dim 128 (indexer): `flash_c4_prefill_norm_rope_indexer` / `_w64`
  - Ring-buffer staging kept as a companion launch (`fused_c4_write_prefill`) because
    the write iterates `plan_w` (one per query token), not `plan_c` (one per compress plan).
- `kernels/ops/attention/dsv4/compress.py`
  - Binds `("prefill", run_prefill)` in the JIT module; dispatches decode vs prefill in
    `compress_forward_norm_rope_store`.
- `srt/layers/attention/dsv4/compressor_v2.py`
  - Drops the `plan.is_decode` requirement from the fusion gate (kept behind the existing
    `SGLANG_OPT_FUSE_COMPRESS_NORM_ROPE` env, default off).

Per compress region:

| | compress | norm+rope | write | launches |
|---|---|---|---|---|
| **before** | `flash_c4_prefill` | `fused_norm_rope_*` | `write_c4_prefill` | **3** |
| **after**  | `flash_c4_prefill_norm_rope` (compress+norm+rope, register-resident) | — | `fused_c4_write_prefill` | **2** |

The compressed row never reaches HBM between compress and norm; the two remaining
kernels do the same GPU work the three did.

## Kernel-launch evidence (CUDA-graph OFF, c32/8k1k MTP, per TARGET_VERIFY step, DP-0)

| kernel (compress region) | baseline | this PR |
|---|---:|---:|
| `flash_c4_prefill<512>` | 25 | **0** |
| `flash_c4_prefill<128>` | 25 | **0** |
| `fused_norm_rope_flashmla<512>` | 27.6 | 3.1¹ |
| `fused_norm_rope_indexer<128>` | 25 | **0** |
| `write_c4_prefill<512/128>` | 60 | **0** |
| `flash_c4_prefill_norm_rope<512>` (new) | 0 | 26 |
| `flash_c4_prefill_norm_rope_indexer_w64` (new) | 0 | 26 |
| `fused_c4_write_prefill<512/128>` (new) | 0 | 60 |

¹ residual is the non-verify (chunked-prefill) path.

Overall per step: **3105 → 3060 launches** (−45.8, −1.5%); the saving is host-launch
count (the fused kernels' GPU-busy ≈ the sum they replace). Confirmed `flash_c4_prefill_norm_rope`
fires on **all 8 ranks**.

## Benchmarks (DeepSeek-V4-Pro, MTP EAGLE steps=1/topk=1/draft=2, TP8 + DP-attention, FP8 KV, **CUDA graph ON**, ISL 8192 / OSL 1024, conc=32)

**4× max_conc (128 prompts, 32-prompt warmup):**

| metric | baseline | this PR | Δ |
|---|---:|---:|---:|
| output throughput (tok/s) | 864.2 | 862.2 | −0.2% |
| request throughput (req/s) | 0.844 | 0.842 | −0.2% |
| latency mean / p50 / p90 (s) | 37.10 / 38.48 / 45.38 | 37.44 / 38.25 / 47.98 | ~noise |

**10× max_conc (320 prompts, no warmup):**

| metric | baseline | this PR | Δ |
|---|---:|---:|---:|
| output throughput (tok/s) | 803.3 | **830.3** | **+3.4%** |
| request throughput (req/s) | 0.784 | 0.811 | +3.4% |
| latency mean (s) | 40.34 | 39.28 | −1.06 |
| latency **median p50** (s) | 40.81 | **39.91** | **−2.2%** |
| latency p90 (s) | 47.87 | 47.08 | −0.79 |
| wall (s) | 407.9 | 394.7 | −13.2 |

All runs 0 errors, 1024 output tokens/req.

**Reading:** with CUDA graphs **ON** the launch-count reduction is largely absorbed by
graph replay, so at 4×conc the delta is within noise; at 10×conc the deeper queue makes
the saved host work slightly more visible (**+3.4% throughput, −2.2% median latency**).
The larger win is in the **CUDA-graph-OFF / host-launch-bound** regime and at higher
concurrency (larger verify batches). Correctness-wise the fused path is numerically
identical to the unfused chain (bf16 round-trip on the store to match precision).

## Perfetto traces

CUDA-graph-OFF c32/8k1k MTP traces (8 ranks each), showing the compress region before/after:

- **baseline (unfused):** `sglang_profile_traces_baseline_cgoff2/1786722171.8240714-TP-*-DP-*.trace.json.gz`
- **this PR (fused):** `sglang_profile_traces_patched_cgoff/1786721637.5613604-TP-*-DP-*.trace.json.gz`

<!-- PERFETTO SCREENSHOTS: attach here.
     before: compress region shows flash_c4_prefill + fused_norm_rope_* + write_c4_prefill (3 kernels)
     after:  compress region shows flash_c4_prefill_norm_rope + fused_c4_write_prefill (2 kernels) -->

**[ TODO: attach Perfetto UI screenshots — before (3 kernels) vs after (2 kernels) ]**

## Validation

- Fused kernel not yet parity-tested on-device at merge time of #34624; the differential
  test added in #34624 covers decode. Extend/prefill parity should be validated before merge.
- Feature stays behind `SGLANG_OPT_FUSE_COMPRESS_NORM_ROPE` (default off).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->