### PR TITLE
fix: remove needless borrows in cache-aware tests

### DIFF
--- a/sgl-model-gateway/src/policies/cache_aware.rs
+++ b/sgl-model-gateway/src/policies/cache_aware.rs
@@ -679,7 +679,7 @@ mod tests {
         let mut workers: Vec<Arc<dyn Worker>> = Vec::new();
         for j in 0..num_workers {
             workers.push(Arc::new(
-                BasicWorkerBuilder::new(&format!("http://w{}:8000", j))
+                BasicWorkerBuilder::new(format!("http://w{}:8000", j))
                     .worker_type(WorkerType::Regular)
                     .build(),
             ));
@@ -738,7 +738,7 @@ mod tests {
         let mut workers: Vec<Arc<dyn Worker>> = Vec::new();
         for j in 0..num_workers {
             workers.push(Arc::new(
-                BasicWorkerBuilder::new(&format!("http://w{}:8000", j))
+                BasicWorkerBuilder::new(format!("http://w{}:8000", j))
                     .worker_type(WorkerType::Regular)
                     .build(),
             ));


### PR DESCRIPTION

## Motivation

`cargo clippy --all-targets --all-features -- -D warnings` currently fails in `sgl-model-gateway` because two cache-aware policy tests borrow temporary `String` values passed to `BasicWorkerBuilder::new`.

Clippy reports `needless_borrows_for_generic_args` at both call sites. Since the gateway CI treats warnings as errors, these warnings make the lint job fail.

Fixes #35156

## Modifications

- Pass the `String` returned by `format!` directly to `BasicWorkerBuilder::new` at both affected call sites.
- Remove the unnecessary `&` borrows without changing test behavior.

## Accuracy Tests

Not applicable. This change only updates test setup code and does not affect model output.

## Speed Tests and Profiling

Not applicable. This change has no runtime or inference performance impact.

## Testing

```text
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --lib cache_aware
```

All checks passed. The focused test command ran 22 tests successfully.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Run relevant unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Documentation is not required because this is a test-only lint fix.
- [x] Accuracy and speed benchmarks are not applicable to this test-only change.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32029650568](https://github.com/sgl-project/sglang/actions/runs/32029650568)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32029650413](https://github.com/sgl-project/sglang/actions/runs/32029650413)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->