### PR TITLE
Add deepseek_v4_flash_w8a8_8p_in32k_out1k_50ms

### DIFF
--- a/.github/workflows/nightly-test-npu.yml
+++ b/.github/workflows/nightly-test-npu.yml
@@ -294,11 +294,6 @@ jobs:
             runner: linux-aarch64-a3-16
             test_case: test/registered/npu/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_8p_in8k_out1k_50ms.py
             test_type: 'perf'
-          # deepseek_v4_flash performance tests
-          - name: deepseek_v4_flash_w8a8_8p_in32k_out1k_50ms
-            runner: linux-aarch64-a3-16
-            test_case: test/registered/npu/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_8p_in32k_out1k_50ms.py
-            test_type: 'perf'
     uses: ./.github/workflows/nightly-test-npu-e2e-single-node.yml
     with:
       runner: ${{ matrix.test_config.runner }}

--- a/.github/workflows/nightly-test-npu.yml
+++ b/.github/workflows/nightly-test-npu.yml
@@ -294,6 +294,11 @@ jobs:
             runner: linux-aarch64-a3-16
             test_case: test/registered/npu/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_8p_in8k_out1k_50ms.py
             test_type: 'perf'
+          # deepseek_v4_flash performance tests
+          - name: deepseek_v4_flash_w8a8_8p_in32k_out1k_50ms
+            runner: linux-aarch64-a3-16
+            test_case: test/registered/npu/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_8p_in32k_out1k_50ms.py
+            test_type: 'perf'
     uses: ./.github/workflows/nightly-test-npu-e2e-single-node.yml
     with:
       runner: ${{ matrix.test_config.runner }}

--- a/test/registered/npu/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_8p_in32k_out1k_50ms.py
+++ b/test/registered/npu/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_8p_in32k_out1k_50ms.py
@@ -1,0 +1,147 @@
+import unittest
+
+from sglang.test.ascend.e2e.test_npu_performance_utils import (
+    AISBENCHMARK_DATASET_DEFAULT,
+    BENCHMARK_TOOL_DEFAULT,
+    DEEPSEEK_V4_FLASH_W8A8_MTP_MODEL_PATH,
+    TestNpuPerformanceTestCaseBase,
+)
+from sglang.test.ci.ci_register import register_npu_ci
+
+register_npu_ci(
+    est_time=3600,
+    suite="",
+    nightly=True,
+    disabled="performance testcase",
+)
+
+# Environment variables for DSV4-Flash single-node PD-mix deployment.
+DEEPSEEK_V4_FLASH_W8A8_8P_ENVS = {
+    "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
+    "STREAMS_PER_DEVICE": "32",
+    "INF_NAN_MODE_FORCE_DISABLE": "1",
+    "HCCL_SOCKET_IFNAME": "lo",
+    "GLOO_SOCKET_IFNAME": "lo",
+    "USE_NPU_MOE_GATING_TOP_K": "1",
+    "SGLANG_NPU_USE_MULTI_STREAM": "1",
+    # deepep
+    "DEEP_NORMAL_MODE_USE_INT8_QUANT": "1",
+    "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK": "64",
+    # zbal
+    "HCCL_BUFFSIZE": "8",
+    "SGLANG_ZBAL_LOCAL_MEM_SIZE": "61000",
+    "SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK": "0",
+    "ZBAL_NPU_ALLOC_CONF": "use_vmm_for_static_memory:True",
+    "SGLANG_ZBAL_BOOTSTRAP_URL": "tcp://127.0.0.1:24669",
+    "ZBAL_ENABLE_GRAPH": "1",
+    # dsv4
+    "IS_DEEPSEEK_V4": "1",
+    "SGLANG_DEBUG_LAYER_NORM": "1",
+    "SGLANG_DEBUG_FWD_INPUT": "1",
+    "USE_FUSED_HC_PRE_ASCENDC": "1",
+    "SGLANG_DSV4_NPU_FUSED_COMPRESSOR": "1",
+    "SGLANG_DSV4_NPU_FUSED_COMPRESSOR_PREFILL": "0",
+    # skip gpu branch
+    "SGLANG_OPT_FP8_WO_A_GEMM": "0",
+    "SGLANG_OPT_USE_OVERLAP_STORE_CACHE": "False",
+    "FORCE_DRAFT_MODEL_NON_QUANT": "1",
+    "SGLANG_DSV4_FP4_EXPERTS": "False",
+    "SGLANG_OPT_FUSE_WQA_WKV": "0",
+    "SGLANG_OPT_BF16_FP32_GEMM_ALGO": "torch",
+    "SGLANG_OPT_USE_FUSED_HASH_TOPK": "False",
+    "SGLANG_OPT_USE_TILELANG_MHC_PRE": "False",
+    "SGLANG_OPT_DEEPGEMM_HC_PRENORM": "False",
+    "SGLANG_OPT_USE_TILELANG_MHC_POST": "False",
+    # mtp
+    "SGLANG_ENABLE_SPEC_V2": "1",
+    "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "1",
+    "SGLANG_NPU_PROFILING": "0",
+    "SGLANG_DEBUG_MTP_VERIFY": "0",
+    "SGLANG_DEBUG_MTP_VERIFY_LIMIT": "8",
+    "SGLANG_DEBUG_MTP_VERIFY_ROWS": "4",
+    "SGLANG_DISABLE_DRAFT_EXTEND_GRAPH": "1",
+}
+
+# Server launch arguments for DSV4-Flash W8A8 single-node 8p PD-mix.
+DEEPSEEK_V4_FLASH_W8A8_8P_OTHER_ARGS = [
+    "--page-size",
+    128,
+    "--tp-size",
+    16,
+    "--trust-remote-code",
+    "--device",
+    "npu",
+    "--prefill-max-requests",
+    32,
+    "--attention-backend",
+    "dsv4",
+    "--watchdog-timeout",
+    9000,
+    "--mem-fraction-static",
+    0.7,
+    "--chunked-prefill-size",
+    131072,
+    "--max-running-requests",
+    64,
+    "--dp-size",
+    16,
+    "--enable-dp-attention",
+    "--moe-a2a-backend",
+    "deepep",
+    "--deepep-mode",
+    "auto",
+    "--quantization",
+    "modelslim",
+    "--enable-dp-lm-head",
+    "--kv-cache-dtype",
+    "auto",
+    "--skip-server-warmup",
+    "--cuda-graph-bs",
+    1,
+    2,
+    4,
+    8,
+    # MTP (EAGLE) configuration.
+    "--speculative-algorithm",
+    "EAGLE",
+    "--speculative-num-steps",
+    2,
+    "--speculative-eagle-topk",
+    1,
+    "--speculative-num-draft-tokens",
+    3,
+    "--ep-size",
+    16,
+    "--disable-radix-cache",
+]
+
+
+class TestNPUDeepSeekV4FlashW8A88PIn32kOut1k50ms(TestNpuPerformanceTestCaseBase):
+    """Test NPU performance for DeepSeek-V4-Flash W8A8 8p in32k out1k."""
+
+    benchmark_tool = BENCHMARK_TOOL_DEFAULT
+    dataset_type = AISBENCHMARK_DATASET_DEFAULT
+    model = DEEPSEEK_V4_FLASH_W8A8_MTP_MODEL_PATH
+    other_args = DEEPSEEK_V4_FLASH_W8A8_8P_OTHER_ARGS
+    envs = DEEPSEEK_V4_FLASH_W8A8_8P_ENVS
+    dataset_name = "random"
+    dataset_path = "/root/.cache/modelscope/hub/datasets/gsm8k_deepseekv4/cache0_32000/formal_run1_64_32000_cache0.json"
+    input_len = 32000
+    output_len = 1000
+    num_prompts = 64
+    max_concurrency = 64
+    random_range_ratio = 1
+    warmup_requests = 0
+    request_rate = float("inf")
+    seed = 1
+    tpot = 50
+    max_attempts = 3
+    output_token_throughput = 927
+
+    def test_npu_deepseek_v4_flash_w8a8_8p_in32k_out1k_50ms(self):
+        """Run NPU performance test for DeepSeek-V4-Flash W8A8 8p in32k out1k."""
+        self.run_throughput()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/npu/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_8p_in32k_out1k_50ms.py
+++ b/test/registered/npu/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_8p_in32k_out1k_50ms.py
@@ -8,12 +8,7 @@ from sglang.test.ascend.e2e.test_npu_performance_utils import (
 )
 from sglang.test.ci.ci_register import register_npu_ci
 
-register_npu_ci(
-    est_time=3600,
-    suite="",
-    nightly=True,
-    disabled="performance testcase",
-)
+register_npu_ci(est_time=3600, suite="nightly-perf-16-npu-a3",nightly=True)
 
 # Environment variables for DSV4-Flash single-node PD-mix deployment.
 DEEPSEEK_V4_FLASH_W8A8_8P_ENVS = {

--- a/test/registered/npu/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_8p_in32k_out1k_50ms.py
+++ b/test/registered/npu/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_8p_in32k_out1k_50ms.py
@@ -8,7 +8,7 @@ from sglang.test.ascend.e2e.test_npu_performance_utils import (
 )
 from sglang.test.ci.ci_register import register_npu_ci
 
-register_npu_ci(est_time=3600, suite="nightly-perf-16-npu-a3",nightly=True)
+register_npu_ci(est_time=3600, suite="nightly-perf-16-npu-a3", nightly=True)
 
 # Environment variables for DSV4-Flash single-node PD-mix deployment.
 DEEPSEEK_V4_FLASH_W8A8_8P_ENVS = {


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

This PR introduces a new performance benchmark test case for the DeepSeek-V4-Flash model on the A3 hardware platform. As SGLang provides day-0 support for DeepSeek-V4 and is widely adopted as a production-grade inference framework , it is critical to establish clear performance baselines for new model-hardware combinations to prevent performance regression and ensure our deployment configurations meet service-level objectives.

The specific deployment configuration under test is:

Deployment Type: Single-node, mixed deployment

Concurrency: 64

Context Length: 8K

Quantization: W8A8 

The test case is designed to measure whether the model on A3 hardware meets the required performance targets in terms of:

TTFT (Time to First Token)

TPOT (Time Per Output Token) with a target of 50ms

Throughput

Specifically, this test simulates a high-throughput scenario with an input of 32K and an output of 1K, while the KV cache hit rate is 0%. This scenario is crucial for evaluating the system's raw computational capability without the performance benefits of prefix caching (RadixAttention) . Establishing this baseline is the first step before we can validate the effectiveness of SGLang's optimizations like RadixAttention in more realistic, cache-heavy workloads.

## Modifications

Added a new benchmark test case: In the benchmark directory (or the appropriate test suite as per project structure), added a new test file/function specifically for DeepSeek-V4-Flash on A3 hardware.

Test Configuration:

Model: DeepSeek-V4-Flash

Hardware: A3

Deployment: Single-node, mixed

Concurrency: 64

Input/Output Length: 32K / 1K

KV Cache Hit Rate: 0%

Quantization: W8A8

Performance Metrics: The test collects and reports TTFT, TPOT (with an assertion to check against the 50ms target), and overall throughput.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32035500815](https://github.com/sgl-project/sglang/actions/runs/32035500815)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32035500526](https://github.com/sgl-project/sglang/actions/runs/32035500526)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->