### PR TITLE
[Fix] shared expert under-weighted when rsf is pre-folded in topk weights

### DIFF
--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -1902,7 +1902,9 @@ def remap_topk_for_per_rank_shared_slots(
 
     Routed IDs:  e -> e + (e // num_local_routed) * num_fused_shared_experts
     Shared IDs:  ep_rank * num_local_experts + num_local_routed
-    Shared weight: 1.0 on the aiter path, else 1/routed_scaling_factor (see below).
+    Shared weight: 1.0 when routed_scaling_factor is pre-folded into the
+    topk weights (aiter / apply_routed_scaling_factor_on_output families),
+    else 1/routed_scaling_factor (see below).
     """
     if topk_ids.shape[0] == 0:
         return topk_ids, topk_weights
@@ -1948,15 +1950,17 @@ def remap_topk_for_per_rank_shared_slots(
     #     under-weight the always-on shared expert by routed_scaling_factor and
     #     corrupt every MoE layer.
     #
-    # NOTE: forward_deepep also skips the post-MoE multiply for the non-aiter
-    # families where routed_scaling_factor is pre-folded in topk
-    # (should_fuse_routed_scaling_factor_in_topk / apply_routed_scaling_factor_on_output:
-    # ModelOpt NVFP4, cutlass/trtllm-routed fp8), so those would likewise need a
-    # 1.0 shared weight. This fix is deliberately scoped to the aiter path (the
-    # one validated on AMD MI355X); those other backends are left at their
-    # existing behavior and can be addressed by their maintainers.
+    # The same 1.0 is required for the non-aiter pre-folding families selected
+    # by topk_config.apply_routed_scaling_factor_on_output (which mirrors
+    # should_fuse_routed_scaling_factor_in_topk, the flag forward_deepep
+    # checks, at TopK construction time: ModelOpt NVFP4 non-marlin,
+    # cutlass/trtllm-routed fp8, unquantized trtllm-routed): their routed
+    # topk weights already carry
+    # routed_scaling_factor and forward_deepep skips the post-MoE multiply,
+    # so applying 1/rsf here would under-weight the shared expert the same
+    # way as on the aiter path.
     routed_scaling_factor = topk_config.routed_scaling_factor
-    if _use_aiter:
+    if _use_aiter or topk_config.apply_routed_scaling_factor_on_output:
         topk_weights[:, -num_fused_shared_experts:] = 1.0
     elif routed_scaling_factor is not None and routed_scaling_factor != 0:
         topk_weights[:, -num_fused_shared_experts:] = 1.0 / routed_scaling_factor

--- a/python/sglang/srt/layers/moe/waterfill.py
+++ b/python/sglang/srt/layers/moe/waterfill.py
@@ -78,14 +78,22 @@ class WaterfillBalancer:
         rank: int,
         layer_id: int,
         routed_scaling_factor: float = 1.0,
+        rsf_prefolded_in_topk: bool = False,
     ):
         self.num_routed_experts = num_routed_experts
         self.world_size = world_size
         self.rank = rank
         self.layer_id = layer_id
         self.old_experts_per_rank = num_routed_experts // world_size
+        # 1/rsf compensates the post-MoE routed_scaling_factor multiply so
+        # the always-on shared expert nets out to 1.0x. When rsf is
+        # pre-folded into the routed topk weights (aiter /
+        # apply_routed_scaling_factor_on_output families) that multiply is
+        # skipped and the shared expert needs its full 1.0 weight.
         self.shared_weight = (
-            1.0 / routed_scaling_factor if routed_scaling_factor != 0 else 1.0
+            1.0
+            if rsf_prefolded_in_topk
+            else (1.0 / routed_scaling_factor if routed_scaling_factor != 0 else 1.0)
         )
         self._counts_buf: Optional[Tensor] = None
         self.use_static_waterfill = not envs.SGLANG_DISABLE_STATIC_WATERFILL.get()

--- a/python/sglang/srt/model_executor/model_runner_components/moe_ep_setup.py
+++ b/python/sglang/srt/model_executor/model_runner_components/moe_ep_setup.py
@@ -58,8 +58,12 @@ def prepare_moe_topk(
         )
         if isinstance(module, TopK):
             routed_scaling_factor = module.topk_config.routed_scaling_factor
+            rsf_prefolded_in_topk = (
+                module.topk_config.apply_routed_scaling_factor_on_output
+            )
         else:
             routed_scaling_factor = module.routed_scaling_factor
+            rsf_prefolded_in_topk = module.apply_routed_scaling_factor_on_output
         module.waterfill_balancer = balancer_cls(
             num_routed_experts=num_physical_routed_experts,
             world_size=moe_ep_size,
@@ -68,6 +72,11 @@ def prepare_moe_topk(
             routed_scaling_factor=(
                 routed_scaling_factor if routed_scaling_factor is not None else 1.0
             ),
+            # Mirrors remap_topk_for_per_rank_shared_slots: forward_deepep
+            # skips the post-MoE rsf multiply whenever _use_aiter (aiter
+            # folds rsf into the TopK weights), so the shared-slot weight is
+            # 1.0 exactly when either signal holds.
+            rsf_prefolded_in_topk=rsf_prefolded_in_topk or _use_aiter,
         )
         num_prepared += 1
     if num_prepared:

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1698,13 +1698,13 @@ class DeepseekV2MoE(nn.Module):
 
         if (shared_output := state.pop("shared_output")) is not None:
             x = shared_output
-            if _use_aiter:
+            if self.experts.should_fuse_routed_scaling_factor_in_topk or _use_aiter:
                 x.add_(final_hidden_states)
             else:
                 x.add_(final_hidden_states, alpha=self.routed_scaling_factor)
             final_hidden_states = x
-        elif _use_aiter:
-            # fused in aiter_biased_grouped_topk so we can skip here
+        elif self.experts.should_fuse_routed_scaling_factor_in_topk or _use_aiter:
+            # fused in topk weights or aiter_biased_grouped_topk so we can skip here
             pass
         else:
             final_hidden_states *= self.routed_scaling_factor

--- a/test/registered/unit/batch_overlap/test_tbo_moe_op_output_routed_scaling.py
+++ b/test/registered/unit/batch_overlap/test_tbo_moe_op_output_routed_scaling.py
@@ -1,0 +1,165 @@
+"""Regression: TBO op_output must not re-apply an already-fused routed_scaling_factor.
+
+DeepseekV2MoE.op_output is the epilogue of the two-batch-overlap (TBO)
+DeepEP MoE pipeline. It multiplied the routed output by
+self.routed_scaling_factor in every non-aiter case (even when the factor was
+already folded into topk_weights), while the equivalent non-TBO
+path forward_deepep guards that multiply with
+experts.should_fuse_routed_scaling_factor_in_topk or _use_aiter.
+
+When the guard flag is true the factor is already applied upstream: topk.py
+folds it into topk_weights for quant methods that set
+should_fuse_routed_scaling_factor_in_topk (e.g. ModelOpt NVFP4), and
+aiter folds it into aiter_biased_grouped_topk. The TBO epilogue therefore
+applied it a second time and every TBO MoE layer silently returned output
+scaled by routed_scaling_factor**2 (2.5**2 for DeepSeek-V3).
+
+The verbatim op_output source is AST-extracted from the model file and
+executed against a stub state, so this test needs no GPU, weights, or server
+and runs on CPU in milliseconds.
+
+Usage:
+    python -m pytest test/registered/unit/batch_overlap/test_tbo_moe_op_output_routed_scaling.py -v
+"""
+
+import ast
+import importlib.util
+import textwrap
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+# CPU-only unit test; no CUDA/distributed dependencies.
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+ROUTED_SCALING_FACTOR = 2.5  # DeepSeek-V3-family value
+
+
+def _model_file() -> Path:
+    """Locate deepseek_v2.py in this checkout (fall back to installed sglang)."""
+    repo_file = (
+        Path(__file__).resolve().parents[4]
+        / "python"
+        / "sglang"
+        / "srt"
+        / "models"
+        / "deepseek_v2.py"
+    )
+    if repo_file.exists():
+        return repo_file
+    spec = importlib.util.find_spec("sglang")
+    assert spec is not None and spec.origin is not None, "sglang not importable"
+    return Path(spec.origin).resolve().parent / "srt" / "models" / "deepseek_v2.py"
+
+
+def _extract_op_output_source() -> str:
+    path = _model_file()
+    source = path.read_text()
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == "DeepseekV2MoE":
+            for item in node.body:
+                if isinstance(item, ast.FunctionDef) and item.name == "op_output":
+                    return textwrap.dedent(ast.get_source_segment(source, item))
+    raise AssertionError(f"DeepseekV2MoE.op_output not found in {path}")
+
+
+class _StubA2ABackend:
+    """op_output's mori fast path is a slice-only op; keep it disabled."""
+
+    def is_mori(self):
+        return False
+
+
+def _load_op_output(use_aiter: bool):
+    """Bind the verbatim op_output source to a stub module namespace."""
+    namespace = {
+        "torch": torch,
+        "_use_aiter": use_aiter,
+        "get_moe_a2a_backend": lambda: _StubA2ABackend(),
+    }
+    exec(compile(_extract_op_output_source(), str(_model_file()), "exec"), namespace)
+    return namespace["op_output"]
+
+
+class _StubState:
+    """The _StateDict surface op_output touches: attribute get/set + pop."""
+
+    def __init__(self, **fields):
+        object.__setattr__(self, "_fields", fields)
+
+    def pop(self, name):
+        return self._fields.pop(name)
+
+    def __getattr__(self, name):
+        try:
+            return object.__getattribute__(self, "_fields")[name]
+        except KeyError:
+            raise AttributeError(name)
+
+    def __setattr__(self, name, value):
+        self._fields[name] = value
+
+
+class TestTboOpOutputRoutedScalingFactor(unittest.TestCase):
+    def _run_op_output(self, should_fuse, use_aiter, has_shared):
+        """Return (op_output result, routed combine output, shared output)."""
+        torch.manual_seed(0)
+        combine = torch.randn(4, 6)
+        shared = torch.randn(4, 6) if has_shared else None
+        state = _StubState(
+            hidden_states_after_combine=combine.clone(),
+            shared_output=shared.clone() if shared is not None else None,
+        )
+        moe = SimpleNamespace(
+            routed_scaling_factor=ROUTED_SCALING_FACTOR,
+            experts=SimpleNamespace(
+                should_fuse_routed_scaling_factor_in_topk=should_fuse
+            ),
+        )
+        _load_op_output(use_aiter)(moe, state)
+        return state.hidden_states_mlp_output, combine, shared
+
+    def test_routed_scaling_factor_applied_exactly_once(self):
+        # All 2**3 combos of (folded-in-topk, aiter, shared experts): the
+        # routed output must carry exactly one factor of
+        # routed_scaling_factor, whether it was folded upstream or applied
+        # here.
+        for should_fuse in (False, True):
+            for use_aiter in (False, True):
+                for has_shared in (False, True):
+                    with self.subTest(
+                        should_fuse=should_fuse,
+                        use_aiter=use_aiter,
+                        has_shared=has_shared,
+                    ):
+                        out, combine, shared = self._run_op_output(
+                            should_fuse, use_aiter, has_shared
+                        )
+                        folded_upstream = should_fuse or use_aiter
+                        scale = 1.0 if folded_upstream else ROUTED_SCALING_FACTOR
+                        expected = combine * scale
+                        if shared is not None:
+                            expected = expected + shared
+                        torch.testing.assert_close(out, expected)
+
+    def test_fold_flag_changes_the_result(self):
+        # Guard against the parametrized test passing vacuously: with the
+        # fold flag on, the pre-fix epilogue returned
+        # combine * routed_scaling_factor (the factor squared in total),
+        # which must differ from the correct output.
+        out, combine, _ = self._run_op_output(
+            should_fuse=True, use_aiter=False, has_shared=False
+        )
+        self.assertFalse(
+            torch.allclose(out, combine * ROUTED_SCALING_FACTOR),
+            "op_output re-applied the already-fused routed_scaling_factor",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/moe/test_fused_shared_expert_scaling.py
+++ b/test/registered/unit/layers/moe/test_fused_shared_expert_scaling.py
@@ -1,18 +1,25 @@
 """Unit tests for fused shared-expert weight scaling on per-rank shared slots.
 
 These tests pin the contract of ``remap_topk_for_per_rank_shared_slots`` for
-the fused shared expert's topk weight on the two paths this fix covers:
+the fused shared expert's topk weight on the paths this fix covers:
 
   * aiter (HIP) path: routed_scaling_factor is folded into the routed weights and
     the post-MoE multiply is skipped, so the shared weight must be 1.0
     for a net 1.0x contribution.
+  * pre-folded non-aiter families (apply_routed_scaling_factor_on_output=True,
+    i.e. should_fuse_routed_scaling_factor_in_topk: ModelOpt NVFP4 non-marlin,
+    cutlass/trtllm-routed fp8): same as aiter -- the post-MoE multiply is
+    skipped, so the shared weight must be 1.0.
   * post-MoE scaling path (default): the whole MoE output is multiplied by
     routed_scaling_factor afterward, so the shared weight must be 1/rsf.
+
+The same three-way contract is pinned for ``WaterfillBalancer.shared_weight``,
+which fills the appended shared-expert column on the Waterfill (topk 8->9) path.
 """
 
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=7, suite="base-a-test-cpu")
+register_cpu_ci(est_time=8, suite="base-a-test-cpu")
 
 import unittest
 from types import SimpleNamespace
@@ -22,6 +29,7 @@ import torch
 
 from sglang.srt.layers.moe import topk as topk_module
 from sglang.srt.layers.moe.topk import TopKConfig
+from sglang.srt.layers.moe.waterfill import WaterfillBalancer
 from sglang.test.test_utils import CustomTestCase
 
 
@@ -32,7 +40,7 @@ class TestFusedSharedExpertScaling(CustomTestCase):
     EP_RANK = 0
     ROUTED_SCALING_FACTOR = 2.5
 
-    def _run_remap(self, *, use_aiter):
+    def _run_remap(self, *, use_aiter, apply_routed_scaling_factor_on_output=False):
         # Layout: [routed, routed, routed, shared]; the trailing column is the
         # fused shared expert. The shared weight starts at a sentinel to prove
         # the function overwrites it.
@@ -44,6 +52,7 @@ class TestFusedSharedExpertScaling(CustomTestCase):
             top_k=4,
             num_fused_shared_experts=1,
             routed_scaling_factor=self.ROUTED_SCALING_FACTOR,
+            apply_routed_scaling_factor_on_output=apply_routed_scaling_factor_on_output,
         )
 
         with (
@@ -72,6 +81,16 @@ class TestFusedSharedExpertScaling(CustomTestCase):
         # routed_scaling_factor is folded into the routed weights and the
         # post-MoE multiply is skipped -> shared weight must be 1.0, NOT 1/rsf.
         shared_weight = self._run_remap(use_aiter=True)
+        self.assertAlmostEqual(shared_weight, 1.0)
+
+    def test_prefolded_rsf_families_use_unit_shared_weight(self):
+        # Non-aiter pre-folding families (apply_routed_scaling_factor_on_output,
+        # i.e. ModelOpt NVFP4 non-marlin / cutlass/trtllm-routed fp8) fold rsf
+        # into the routed topk weights and forward_deepep skips the post-MoE
+        # multiply -> shared weight must be 1.0, NOT 1/rsf.
+        shared_weight = self._run_remap(
+            use_aiter=False, apply_routed_scaling_factor_on_output=True
+        )
         self.assertAlmostEqual(shared_weight, 1.0)
 
     def test_post_moe_scaling_path_compensates_with_inverse_rsf(self):
@@ -111,6 +130,78 @@ class TestFusedSharedExpertScaling(CustomTestCase):
         num_local_experts = num_local_routed + 1  # 33
         expected_shared_id = self.EP_RANK * num_local_experts + num_local_routed
         self.assertEqual(out_ids[0, -1].item(), expected_shared_id)
+
+    def test_waterfill_shared_weight_matches_remap_contract(self):
+        # WaterfillBalancer fills the appended shared-expert column with the
+        # same weight the per-rank-slot remap would: 1/rsf when the post-MoE
+        # multiply runs, 1.0 when rsf is pre-folded into the topk weights.
+        cases = (
+            (False, 1.0 / self.ROUTED_SCALING_FACTOR),
+            (True, 1.0),
+        )
+        for prefolded, expected in cases:
+            with self.subTest(rsf_prefolded_in_topk=prefolded):
+                balancer = WaterfillBalancer(
+                    num_routed_experts=self.NUM_PHYSICAL_ROUTED,
+                    world_size=self.EP_SIZE,
+                    rank=self.EP_RANK,
+                    layer_id=0,
+                    routed_scaling_factor=self.ROUTED_SCALING_FACTOR,
+                    rsf_prefolded_in_topk=prefolded,
+                )
+                self.assertAlmostEqual(balancer.shared_weight, expected)
+
+    def test_prepare_moe_topk_plumbs_prefolded_flag(self):
+        # prepare_moe_topk must pass the folded-RSF state (module flag OR
+        # aiter, which also skips the post-MoE multiply) into the
+        # WaterfillBalancer, keeping the shared-slot weight consistent with
+        # the remap contract. Removing the plumbing reverts every arm to
+        # 1/rsf and fails the aiter/flag-True cases below.
+        from types import SimpleNamespace
+
+        from sglang.srt.model_executor.model_runner_components import (
+            moe_ep_setup,
+        )
+
+        cases = (
+            # (apply flag, _use_aiter) -> expected shared-slot weight
+            (False, False, 1.0 / self.ROUTED_SCALING_FACTOR),
+            (False, True, 1.0),
+            (True, False, 1.0),
+        )
+        for apply_flag, aiter, expected in cases:
+            with self.subTest(apply_flag=apply_flag, aiter=aiter):
+
+                class _FakeTopK:
+                    pass
+
+                module = _FakeTopK()
+                module.enable_waterfill = True
+                module.waterfill_balancer = None
+                module.layer_id = 0
+                module.topk_config = SimpleNamespace(
+                    routed_scaling_factor=self.ROUTED_SCALING_FACTOR,
+                    apply_routed_scaling_factor_on_output=apply_flag,
+                )
+                model = SimpleNamespace(modules=lambda: [module])
+                with (
+                    patch.object(moe_ep_setup, "TopK", _FakeTopK),
+                    patch.object(moe_ep_setup, "HashTopK", _FakeTopK),
+                    patch.object(moe_ep_setup, "_use_aiter", aiter),
+                ):
+                    moe_ep_setup.prepare_moe_topk(
+                        model=model,
+                        model_config=SimpleNamespace(
+                            hf_config=SimpleNamespace(n_routed_experts=256)
+                        ),
+                        server_args=SimpleNamespace(ep_num_redundant_experts=8),
+                        moe_ep_size=self.EP_SIZE,
+                        moe_ep_rank=self.EP_RANK,
+                    )
+                self.assertIsNotNone(module.waterfill_balancer)
+                self.assertAlmostEqual(
+                    module.waterfill_balancer.shared_weight, expected
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
[Fix] shared expert under-weighted when rsf is pre-folded in topk weights

**Depends on #35152** (stacked on it; merge that first — the TBO `op_output` guard is what keeps the routed side at exactly one rsf application for the pre-folded families under two-batch overlap).

When routed_scaling_factor is pre-folded into the topk weights
(`should_fuse_routed_scaling_factor_in_topk` families: ModelOpt NVFP4
non-marlin, fp8 cutlass / trtllm-routed, unquantized trtllm-routed),
forward_deepep skips the post-MoE rsf multiply, but both shared-expert-fusion
paths still hard-coded the fused shared expert column weight to 1/rsf as if
the multiply still happened, so with `--enforce-shared-experts-fusion` or
`--enable-waterfill` the always-on shared expert contributes 1/rsf (0.4x for
DeepSeek rsf=2.5) instead of 1.0x in every MoE layer — a silent, layer-wide
output corruption.

`remap_topk_for_per_rank_shared_slots` now sets the shared weight to 1.0
whenever the rsf is pre-folded: the aiter arm is extended to also cover the
`apply_routed_scaling_factor_on_output` families (the same signal
forward_deepep checks, relayed through TopKConfig). `WaterfillBalancer`
mirrors the condition via a new `rsf_prefolded_in_topk` flag plumbed from
`prepare_moe_topk`. Non-fused families (deep_gemm fp8 etc.) and the existing
aiter behavior are bit-identical to before.

Follow-up to #28237, which fixed the aiter arm only and left the non-aiter
pre-folding families at 1/rsf (see the former in-code NOTE).

Tests: `test_fused_shared_expert_scaling.py` pins the weight at both sites
(remap arms; `WaterfillBalancer` direct; and `prepare_moe_topk`'s plumbing
for flag-only / aiter-only / both — the plumbing test fails if the new
passthrough is removed). GPU: 8 passed with the stacked TBO suite.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32809371145](https://github.com/sgl-project/sglang/actions/runs/32809371145)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32809370961](https://github.com/sgl-project/sglang/actions/runs/32809370961)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32809371076](https://github.com/sgl-project/sglang/actions/runs/32809371076)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->