### PR TITLE
[XPU] Skip the EAGLE verify-decision TP broadcast on XPU

### DIFF
--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -828,13 +828,18 @@ def eagle_sample(
     # tensors feeding this point can make one rank accept a different number of
     # drafts, which desynchronizes the committed seq_lens and deadlocks the next
     # TP collective. Broadcast from rank 0 to ensure consistency.
-    tp_group = (
-        get_parallel().attn_tp_group if is_dp_attention_enabled() else get_tp_group()
-    )
-    if tp_group.world_size > 1:
-        tp_group.broadcast(predict, src=0)
-        tp_group.broadcast(accept_index, src=0)
-        tp_group.broadcast(num_correct_drafts, src=0)
+    # XPU opts out: always on the greedy path, it never ran this sync before, and
+    # the raw broadcast here hangs TP>1 EAGLE at warmup (#35144).
+    if not _is_xpu:
+        tp_group = (
+            get_parallel().attn_tp_group
+            if is_dp_attention_enabled()
+            else get_tp_group()
+        )
+        if tp_group.world_size > 1:
+            tp_group.broadcast(predict, src=0)
+            tp_group.broadcast(accept_index, src=0)
+            tp_group.broadcast(num_correct_drafts, src=0)
 
     if SIMULATE_ACC_LEN > 0:
         # Do simulation. The helper builds (and returns) a replacement


### PR DESCRIPTION
## Motivation

Fixes #35144.

#34238 de-indented the `predict` / `accept_index` / `num_correct_drafts` broadcast in
`eagle_sample()` out of the `else:` (sampling / rejection-sampling) branch so it covers the
greedy verify path too. `_is_xpu` is a term in that branch condition:

```python
if sampling_info.is_all_greedy or _is_cpu or _is_npu or _is_hip or _is_xpu:
    ...  # greedy verify -- XPU ALWAYS lands here
else:
    ...  # tree_speculative_sampling_target_only / chain_speculative_sampling_triton
```

So XPU can never reach the `else` branch: these three broadcasts were unreachable on XPU
before #34238 and now execute on every verify step.

That regressed XPU. EAGLE/NEXTN at TP=2 intermittently hangs at warmup, on the first decode
step after the first verify. The scheduler watchdog fires at 300 s and the server never becomes
ready:

```
# TP1 -- active, stuck on a Level Zero device event in the draft extend that follows verify
    ur::level_zero::urEventWait (libur_adapter_level_zero_v2.so.0.12.0)
    compute_spec_mrope_positions (forward_batch_info.py:1131)
    prepare_for_draft_extend (eagle_worker_common.py:178)
    _draft_extend_for_decode (eagle_worker_v2.py:887)
    run_batch (scheduler.py:3696)

# TP0 -- idle, already past run_batch, waiting on the CPU-group request broadcast
    c10d::Work::wait (libtorch_cpu.so)
    broadcast_pyobj (utils/common.py:2406)
    _broadcast_reqs_across_ranks (scheduler_components/request_receiver.py:210)
    recv_requests (scheduler_components/request_receiver.py:93)
```

`GroupCoordinator.broadcast()` issues a raw `torch.distributed.broadcast` on the device group.
That is the call shape XPU deliberately avoids for all-reduce — `GroupCoordinator.all_reduce()`
routes XPU through the `inplace_all_reduce` custom op, per the comment in `parallel_state.py`:

> Route through inplace_all_reduce custom op so Dynamo treats this as an opaque call and does not
> decompose it into `_c10d_functional` primitives (which invoke `sycl_event.wait()` and break XPU
> graph capture).

`broadcast()` has no such wrapper, so #34238 added three raw eager device-group collectives per
verify step on a backend with an explicit carve-out against them. Full stacks, environment and
the reproduction are in #35144.

## Modifications

Guard the sync with `if not _is_xpu:`, restoring XPU's pre-#34238 behavior. ROCm (the target of
#34238), CUDA, NPU and CPU are unchanged — for them this is a pure re-indent.

If maintainers would rather XPU keep the rank-0 sync, the alternative is to route this broadcast
through a custom op the way XPU all-reduce already is. Happy to switch to that instead — this PR
takes the minimal regression fix.

## Accuracy Tests

No output change on CUDA/ROCm/NPU/CPU — the guard only excludes XPU, and the enclosing
`tp_group.world_size > 1` check is untouched.

On XPU, `pytest -sv test/registered/spec/eagle/test_eagle_reject_sampling.py::TestQwen35EagleRS::test_a_gsm8k`
(`Qwen/Qwen3.5-9B`, `--device xpu --tp 2`, NEXTN, 2x Intel Arc Pro B60): GSM8K score 0.920,
`avg_spec_accept_length=3.18`.

Note the hang is intermittent, so a hang-rate table across repeated runs on this branch versus
the parent of #34238 is still being collected; it will be posted on #35144.

## Speed Tests and Profiling

Not applicable — this removes three small per-verify-step collectives on XPU and changes nothing
on any other backend.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

No new unit test: there is no XPU multi-GPU spec-decode test in CI to extend. The only
XPU-registered EAGLE test, `test/registered/spec/eagle/test_spec_eagle_parity.py::TestEagle3ParityXPU`,
runs on `nightly-xpu-1-gpu`, where `world_size == 1` makes this code path a no-op. Adding
`nightly-xpu-2-gpu` spec coverage would have caught this and is worth a follow-up — glad to take
it if maintainers agree on the suite.

cc @JessicaJiang-123 @XinyuJiangCMU (authors of #34238)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32035935575](https://github.com/sgl-project/sglang/actions/runs/32035935575)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32035935436](https://github.com/sgl-project/sglang/actions/runs/32035935436)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->