### PR TITLE
[Model Gateway] Publish gRPC breaker outcomes at selected body terminal

### DIFF
--- a/sgl-model-gateway/src/routers/grpc/client.rs
+++ b/sgl-model-gateway/src/routers/grpc/client.rs
@@ -133,11 +133,11 @@ impl GrpcClient {
         match (self, req) {
             (Self::Sglang(client), ProtoGenerateRequest::Sglang(boxed_req)) => {
                 let stream = client.generate(*boxed_req).await?;
-                Ok(ProtoStream::Sglang(stream))
+                Ok(ProtoStream::sglang(stream))
             }
             (Self::Vllm(client), ProtoGenerateRequest::Vllm(boxed_req)) => {
                 let stream = client.generate(*boxed_req).await?;
-                Ok(ProtoStream::Vllm(stream))
+                Ok(ProtoStream::vllm(stream))
             }
             _ => panic!("Mismatched client and request types"),
         }

--- a/sgl-model-gateway/src/routers/grpc/common/response_collection.rs
+++ b/sgl-model-gateway/src/routers/grpc/common/response_collection.rs
@@ -28,6 +28,13 @@ pub(crate) async fn collect_responses(
     let all_responses = match execution_result {
         ExecutionResult::Single { mut stream } => {
             let responses = utils::collect_stream_responses(&mut stream, "Single").await?;
+            if responses.is_empty() {
+                stream.reject_completed_body();
+                return Err(error::internal_error(
+                    "no_responses_from_server",
+                    "No responses from server",
+                ));
+            }
             stream.mark_completed();
             responses
         }

--- a/sgl-model-gateway/src/routers/grpc/common/stages/request_execution.rs
+++ b/sgl-model-gateway/src/routers/grpc/common/stages/request_execution.rs
@@ -128,6 +128,17 @@ impl RequestExecutionStage {
         clients: &mut ClientSelection,
         workers: &WorkerSelection,
     ) -> Result<ExecutionResult, Response> {
+        let worker = workers.single().cloned().ok_or_else(|| {
+            error!(
+                function = "execute_single",
+                "Expected single worker but got dual"
+            );
+            error::internal_error(
+                "expected_single_worker_got_dual",
+                "Expected single worker but got dual",
+            )
+        })?;
+
         let client = clients.single_mut().ok_or_else(|| {
             error!(
                 function = "execute_single",
@@ -139,22 +150,29 @@ impl RequestExecutionStage {
             )
         })?;
 
-        let result = client.generate(proto_request).await;
-
-        // Record circuit breaker outcome
-        workers.record_outcome(result.is_ok());
-
-        let stream = result.map_err(|e| {
-            error!(
-                function = "execute_single",
-                error = %e,
-                "Failed to start generation"
-            );
-            error::internal_error(
-                "start_generation_failed",
-                format!("Failed to start generation: {}", e),
-            )
-        })?;
+        // A start failure is terminal at this stage. On start success, the
+        // publication right follows the selected attempt into its body stream.
+        let stream = match client.generate(proto_request).await {
+            Ok(mut stream) => {
+                stream.attach_breaker_receipt(worker).map_err(|message| {
+                    error!(function = "execute_single", %message);
+                    error::internal_error("breaker_receipt_attach_failed", message)
+                })?;
+                stream
+            }
+            Err(e) => {
+                worker.record_outcome(false);
+                error!(
+                    function = "execute_single",
+                    error = %e,
+                    "Failed to start generation"
+                );
+                return Err(error::internal_error(
+                    "start_generation_failed",
+                    format!("Failed to start generation: {}", e),
+                ));
+            }
+        };
 
         Ok(ExecutionResult::Single { stream })
     }
@@ -281,3 +299,6 @@ impl RequestExecutionStage {
         })
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/sgl-model-gateway/src/routers/grpc/common/stages/request_execution/tests.rs
+++ b/sgl-model-gateway/src/routers/grpc/common/stages/request_execution/tests.rs
@@ -1,0 +1,575 @@
+use std::{
+    convert::Infallible,
+    net::SocketAddr,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+
+use axum::{body::Body, http::Response, routing::post, Router};
+use bytes::Bytes;
+use futures_util::stream;
+use http_body::Frame;
+use http_body_util::StreamBody;
+use prost::Message;
+use smg_grpc_client::{sglang_proto as sglang, vllm_proto as vllm};
+use tokio::{net::TcpListener, task::JoinHandle, time};
+
+use super::{ExecutionMode, RequestExecutionStage};
+use crate::{
+    core::{BasicWorkerBuilder, Worker},
+    routers::grpc::{
+        client::GrpcClient,
+        context::{ClientSelection, ExecutionResult, WorkerSelection},
+        proto_wrapper::ProtoGenerateRequest,
+    },
+};
+
+const GENERATE_PATH: &str = "/sglang.grpc.scheduler.SglangScheduler/Generate";
+const ABORT_PATH: &str = "/sglang.grpc.scheduler.SglangScheduler/Abort";
+const VLLM_GENERATE_PATH: &str = "/vllm.grpc.engine.VllmEngine/Generate";
+const VLLM_ABORT_PATH: &str = "/vllm.grpc.engine.VllmEngine/Abort";
+
+#[derive(Clone)]
+enum Behavior {
+    HeadersStatus(u32),
+    Messages {
+        messages: Vec<Vec<u8>>,
+        status: u32,
+    },
+    MessagesWithStatusMessage {
+        messages: Vec<Vec<u8>>,
+        status: u32,
+        message: &'static str,
+    },
+    Malformed,
+}
+
+struct Fixture {
+    address: SocketAddr,
+    generate_calls: Arc<AtomicUsize>,
+    abort_calls: Arc<AtomicUsize>,
+    server: JoinHandle<()>,
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        self.server.abort();
+    }
+}
+
+fn grpc_frame(payload: Vec<u8>) -> Bytes {
+    let mut frame = Vec::with_capacity(payload.len() + 5);
+    frame.push(0);
+    frame.extend_from_slice(&(payload.len() as u32).to_be_bytes());
+    frame.extend_from_slice(&payload);
+    Bytes::from(frame)
+}
+
+fn response(behavior: Behavior) -> Response<Body> {
+    let builder = Response::builder()
+        .status(200)
+        .header("content-type", "application/grpc");
+    match behavior {
+        Behavior::HeadersStatus(status) => builder
+            .header("grpc-status", status.to_string())
+            .body(Body::empty())
+            .unwrap(),
+        Behavior::Malformed => builder.body(Body::from(vec![0, 0, 0, 0, 1, 0xff])).unwrap(),
+        Behavior::Messages { messages, status } => {
+            let mut trailers = http::HeaderMap::new();
+            trailers.insert("grpc-status", status.to_string().parse().unwrap());
+            let frames = messages
+                .into_iter()
+                .map(|message| Ok::<_, Infallible>(Frame::data(grpc_frame(message))))
+                .chain(std::iter::once(Ok(Frame::trailers(trailers))));
+            builder
+                .body(Body::new(StreamBody::new(stream::iter(frames))))
+                .unwrap()
+        }
+        Behavior::MessagesWithStatusMessage {
+            messages,
+            status,
+            message,
+        } => {
+            let mut trailers = http::HeaderMap::new();
+            trailers.insert("grpc-status", status.to_string().parse().unwrap());
+            trailers.insert("grpc-message", message.parse().unwrap());
+            let frames = messages
+                .into_iter()
+                .map(|message| Ok::<_, Infallible>(Frame::data(grpc_frame(message))))
+                .chain(std::iter::once(Ok(Frame::trailers(trailers))));
+            builder
+                .body(Body::new(StreamBody::new(stream::iter(frames))))
+                .unwrap()
+        }
+    }
+}
+
+async fn fixture(behavior: Behavior) -> Fixture {
+    let generate_calls = Arc::new(AtomicUsize::new(0));
+    let abort_calls = Arc::new(AtomicUsize::new(0));
+    let generate_counter = Arc::clone(&generate_calls);
+    let vllm_generate_counter = Arc::clone(&generate_calls);
+    let abort_counter = Arc::clone(&abort_calls);
+    let vllm_abort_counter = Arc::clone(&abort_calls);
+    let vllm_behavior = behavior.clone();
+    let app = Router::new()
+        .route(
+            GENERATE_PATH,
+            post(move || {
+                let behavior = behavior.clone();
+                let generate_counter = Arc::clone(&generate_counter);
+                async move {
+                    generate_counter.fetch_add(1, Ordering::SeqCst);
+                    response(behavior)
+                }
+            }),
+        )
+        .route(
+            ABORT_PATH,
+            post(move || {
+                let abort_counter = Arc::clone(&abort_counter);
+                async move {
+                    abort_counter.fetch_add(1, Ordering::SeqCst);
+                    Response::builder()
+                        .status(200)
+                        .header("content-type", "application/grpc")
+                        .header("grpc-status", "0")
+                        .body(Body::empty())
+                        .unwrap()
+                }
+            }),
+        )
+        .route(
+            VLLM_GENERATE_PATH,
+            post(move || {
+                let behavior = vllm_behavior.clone();
+                let generate_counter = Arc::clone(&vllm_generate_counter);
+                async move {
+                    generate_counter.fetch_add(1, Ordering::SeqCst);
+                    response(behavior)
+                }
+            }),
+        )
+        .route(
+            VLLM_ABORT_PATH,
+            post(move || {
+                let abort_counter = Arc::clone(&vllm_abort_counter);
+                async move {
+                    abort_counter.fetch_add(1, Ordering::SeqCst);
+                    Response::builder()
+                        .status(200)
+                        .header("content-type", "application/grpc")
+                        .header("grpc-status", "0")
+                        .body(Body::empty())
+                        .unwrap()
+                }
+            }),
+        );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    Fixture {
+        address,
+        generate_calls,
+        abort_calls,
+        server,
+    }
+}
+
+fn encoded(response: sglang::generate_response::Response) -> Vec<u8> {
+    sglang::GenerateResponse {
+        response: Some(response),
+        ..Default::default()
+    }
+    .encode_to_vec()
+}
+
+fn chunk() -> Vec<u8> {
+    encoded(sglang::generate_response::Response::Chunk(
+        sglang::GenerateStreamChunk::default(),
+    ))
+}
+
+fn complete(index: u32) -> Vec<u8> {
+    encoded(sglang::generate_response::Response::Complete(
+        sglang::GenerateComplete {
+            index,
+            finish_reason: "stop".to_string(),
+            ..Default::default()
+        },
+    ))
+}
+
+fn in_band_error(http_status_code: &str) -> Vec<u8> {
+    encoded(sglang::generate_response::Response::Error(
+        sglang::GenerateError {
+            http_status_code: http_status_code.to_string(),
+            ..Default::default()
+        },
+    ))
+}
+
+fn vllm_complete() -> Vec<u8> {
+    vllm::GenerateResponse {
+        response: Some(vllm::generate_response::Response::Complete(
+            vllm::GenerateComplete {
+                finish_reason: "stop".to_string(),
+                ..Default::default()
+            },
+        )),
+    }
+    .encode_to_vec()
+}
+
+fn worker(name: &str) -> Arc<dyn Worker> {
+    Arc::new(BasicWorkerBuilder::new(format!("grpc://{name}")).build())
+}
+
+fn request(id: &str) -> ProtoGenerateRequest {
+    ProtoGenerateRequest::Sglang(Box::new(sglang::GenerateRequest {
+        request_id: id.to_string(),
+        stream: true,
+        ..Default::default()
+    }))
+}
+
+async fn selections(
+    fixture: &Fixture,
+    selected: Arc<dyn Worker>,
+) -> (ClientSelection, WorkerSelection) {
+    let client = GrpcClient::connect(&format!("grpc://{}", fixture.address), "sglang")
+        .await
+        .unwrap();
+    (
+        ClientSelection::Single { client },
+        WorkerSelection::Single { worker: selected },
+    )
+}
+
+async fn execute(fixture: &Fixture, selected: Arc<dyn Worker>) -> ExecutionResult {
+    let (mut clients, workers) = selections(fixture, selected).await;
+    RequestExecutionStage::new(ExecutionMode::Single)
+        .execute_single(request("receipt-test"), &mut clients, &workers)
+        .await
+        .unwrap()
+}
+
+async fn execute_vllm(fixture: &Fixture, selected: Arc<dyn Worker>) -> ExecutionResult {
+    let client = GrpcClient::connect(&format!("grpc://{}", fixture.address), "vllm")
+        .await
+        .unwrap();
+    let mut clients = ClientSelection::Single { client };
+    let workers = WorkerSelection::Single { worker: selected };
+    let request = ProtoGenerateRequest::Vllm(Box::new(vllm::GenerateRequest {
+        request_id: "vllm-receipt-test".to_string(),
+        stream: true,
+        ..Default::default()
+    }));
+    RequestExecutionStage::new(ExecutionMode::Single)
+        .execute_single(request, &mut clients, &workers)
+        .await
+        .unwrap()
+}
+
+fn into_stream(result: ExecutionResult) -> crate::routers::grpc::proto_wrapper::ProtoStream {
+    match result {
+        ExecutionResult::Single { stream } => stream,
+        _ => panic!("expected a single stream"),
+    }
+}
+
+fn outcomes(worker: &Arc<dyn Worker>) -> (u64, u64) {
+    (
+        worker.circuit_breaker().total_successes(),
+        worker.circuit_breaker().total_failures(),
+    )
+}
+
+async fn assert_abort_stays(fixture: &Fixture, expected: usize) {
+    time::timeout(Duration::from_secs(2), async {
+        while fixture.abort_calls.load(Ordering::SeqCst) != expected {
+            time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("abort count did not reach the expected value");
+    time::sleep(Duration::from_secs(2)).await;
+    assert_eq!(fixture.abort_calls.load(Ordering::SeqCst), expected);
+}
+
+#[tokio::test]
+async fn start_failure_is_published_by_the_dispatch_stage() {
+    for code in [3, 14] {
+        let fixture = fixture(Behavior::HeadersStatus(code)).await;
+        let selected = worker(&format!("start-{code}"));
+        let (mut clients, workers) = selections(&fixture, Arc::clone(&selected)).await;
+        let result = RequestExecutionStage::new(ExecutionMode::Single)
+            .execute_single(request("start-status"), &mut clients, &workers)
+            .await;
+        assert!(result.is_err());
+        assert_eq!(outcomes(&selected), (0, 1));
+    }
+}
+
+#[tokio::test]
+async fn every_body_status_is_one_failed_attempt_without_origin_guessing() {
+    for code in 1..=16 {
+        let fixture = fixture(Behavior::Messages {
+            messages: vec![chunk()],
+            status: code,
+        })
+        .await;
+        let selected = worker(&format!("body-{code}"));
+        let mut stream = into_stream(execute(&fixture, Arc::clone(&selected)).await);
+        assert!(matches!(stream.next().await, Some(Ok(_))));
+        assert!(matches!(stream.next().await, Some(Err(_))));
+        assert_eq!(outcomes(&selected), (0, 1), "gRPC status code {code}");
+        stream.mark_completed();
+        drop(stream);
+        assert_eq!(outcomes(&selected), (0, 1), "gRPC status code {code}");
+    }
+}
+
+#[tokio::test]
+async fn terminal_status_message_is_not_used_as_origin() {
+    let fixture = fixture(Behavior::MessagesWithStatusMessage {
+        messages: vec![chunk()],
+        status: 13,
+        message: "cancelled by caller",
+    })
+    .await;
+    let selected = worker("message-origin");
+    let mut stream = into_stream(execute(&fixture, Arc::clone(&selected)).await);
+
+    assert!(matches!(stream.next().await, Some(Ok(_))));
+    let status = match stream.next().await {
+        Some(Err(status)) => status,
+        _ => panic!("expected a terminal status"),
+    };
+    assert_eq!(status.message(), "cancelled by caller");
+    assert_eq!(outcomes(&selected), (0, 1));
+}
+
+#[tokio::test]
+async fn start_success_transfers_ownership_without_eager_publication() {
+    let fixture = fixture(Behavior::Malformed).await;
+    let selected = worker("selected");
+    let replacement = worker("replacement");
+    let mut stream = into_stream(execute(&fixture, Arc::clone(&selected)).await);
+
+    assert_eq!(outcomes(&selected), (0, 0));
+    assert!(stream
+        .attach_breaker_receipt(Arc::clone(&replacement))
+        .is_err());
+    assert!(matches!(stream.next().await, Some(Err(_))));
+    assert_eq!(outcomes(&selected), (0, 1));
+    assert_eq!(outcomes(&replacement), (0, 0));
+}
+
+#[tokio::test]
+async fn clean_drain_requires_the_consumers_completion_acknowledgement() {
+    let fixture = fixture(Behavior::Messages {
+        messages: vec![complete(0)],
+        status: 0,
+    })
+    .await;
+    let selected = worker("clean");
+    let mut stream = into_stream(execute(&fixture, Arc::clone(&selected)).await);
+
+    assert!(matches!(stream.next().await, Some(Ok(_))));
+    assert!(stream.next().await.is_none());
+    assert_eq!(outcomes(&selected), (0, 0));
+
+    stream.mark_completed();
+    stream.mark_completed();
+    assert_eq!(outcomes(&selected), (1, 0));
+    drop(stream);
+    assert_eq!(outcomes(&selected), (1, 0));
+}
+
+#[tokio::test]
+async fn clean_drain_rejected_by_consumer_is_failure_without_abort() {
+    let fixture = fixture(Behavior::Messages {
+        messages: vec![chunk()],
+        status: 0,
+    })
+    .await;
+    let selected = worker("rejected-body");
+    let mut stream = into_stream(execute(&fixture, Arc::clone(&selected)).await);
+
+    assert!(matches!(stream.next().await, Some(Ok(_))));
+    assert!(stream.next().await.is_none());
+    assert_eq!(outcomes(&selected), (0, 0));
+
+    stream.reject_completed_body();
+    stream.reject_completed_body();
+    drop(stream);
+    assert_eq!(outcomes(&selected), (0, 1));
+    assert_abort_stays(&fixture, 0).await;
+}
+
+#[tokio::test]
+async fn normal_consumer_observes_a_late_transport_failure_before_acknowledging() {
+    let fixture = fixture(Behavior::Messages {
+        messages: vec![complete(0)],
+        status: 13,
+    })
+    .await;
+    let selected = worker("late-status");
+    let mut stream = into_stream(execute(&fixture, Arc::clone(&selected)).await);
+
+    assert!(matches!(stream.next().await, Some(Ok(_))));
+    assert_eq!(outcomes(&selected), (0, 0));
+    assert!(matches!(stream.next().await, Some(Err(ref e)) if e.code() == tonic::Code::Internal));
+    assert_eq!(outcomes(&selected), (0, 1));
+    stream.mark_completed();
+    assert_eq!(outcomes(&selected), (0, 1));
+}
+
+#[tokio::test]
+async fn explicit_completion_is_absorbing_even_if_a_late_error_is_polled() {
+    let fixture = fixture(Behavior::Messages {
+        messages: vec![complete(0)],
+        status: 13,
+    })
+    .await;
+    let selected = worker("explicit-completion");
+    let mut stream = into_stream(execute(&fixture, Arc::clone(&selected)).await);
+
+    assert!(matches!(stream.next().await, Some(Ok(_))));
+    stream.mark_completed();
+    assert_eq!(outcomes(&selected), (1, 0));
+    assert!(matches!(stream.next().await, Some(Err(_))));
+    assert_eq!(outcomes(&selected), (1, 0));
+}
+
+#[tokio::test]
+async fn legacy_in_band_error_is_one_failed_attempt_independent_of_http_hint() {
+    for http_status_code in ["499", "400", "500", "", "not-a-status"] {
+        let fixture = fixture(Behavior::Messages {
+            messages: vec![in_band_error(http_status_code)],
+            status: 0,
+        })
+        .await;
+        let selected = worker(&format!("in-band-{http_status_code}"));
+        let mut stream = into_stream(execute(&fixture, Arc::clone(&selected)).await);
+
+        assert!(matches!(stream.next().await, Some(Ok(_))));
+        assert_eq!(outcomes(&selected), (0, 1));
+        assert!(stream.next().await.is_none());
+        stream.mark_completed();
+        drop(stream);
+        assert_eq!(outcomes(&selected), (0, 1));
+    }
+}
+
+#[tokio::test]
+async fn vllm_stream_uses_the_same_terminal_contract() {
+    let status_fixture = fixture(Behavior::Messages {
+        messages: vec![vllm_complete()],
+        status: 3,
+    })
+    .await;
+    let status_worker = worker("vllm-status");
+    let mut status_stream =
+        into_stream(execute_vllm(&status_fixture, Arc::clone(&status_worker)).await);
+    assert!(matches!(status_stream.next().await, Some(Ok(_))));
+    assert!(matches!(status_stream.next().await, Some(Err(_))));
+    assert_eq!(outcomes(&status_worker), (0, 1));
+
+    let failing_fixture = fixture(Behavior::Malformed).await;
+    let failing_worker = worker("vllm-failure");
+    let mut failing_stream =
+        into_stream(execute_vllm(&failing_fixture, Arc::clone(&failing_worker)).await);
+    assert_eq!(outcomes(&failing_worker), (0, 0));
+    assert!(matches!(failing_stream.next().await, Some(Err(_))));
+    assert_eq!(outcomes(&failing_worker), (0, 1));
+
+    let success_fixture = fixture(Behavior::Messages {
+        messages: vec![vllm_complete()],
+        status: 0,
+    })
+    .await;
+    let success_worker = worker("vllm-success");
+    let mut success_stream =
+        into_stream(execute_vllm(&success_fixture, Arc::clone(&success_worker)).await);
+    assert!(matches!(success_stream.next().await, Some(Ok(_))));
+    assert_eq!(outcomes(&success_worker), (0, 0));
+    assert!(success_stream.next().await.is_none());
+    assert_eq!(outcomes(&success_worker), (0, 0));
+    success_stream.mark_completed();
+    assert_eq!(outcomes(&success_worker), (1, 0));
+}
+
+#[tokio::test]
+async fn single_shape_mismatch_fails_before_dispatch() {
+    let fixture = fixture(Behavior::Malformed).await;
+    let selected = worker("client-worker");
+    let other = worker("other-worker");
+    let (mut clients, _) = selections(&fixture, Arc::clone(&selected)).await;
+    let workers = WorkerSelection::Dual {
+        prefill: selected,
+        decode: other,
+    };
+
+    let result = RequestExecutionStage::new(ExecutionMode::Single)
+        .execute_single(request("shape-mismatch"), &mut clients, &workers)
+        .await;
+    assert!(result.is_err());
+    assert_eq!(fixture.generate_calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn dual_streams_remain_detached_from_body_terminal_accounting() {
+    let fixture = fixture(Behavior::Malformed).await;
+    let prefill_worker = worker("prefill");
+    let decode_worker = worker("decode");
+    let prefill = GrpcClient::connect(&format!("grpc://{}", fixture.address), "sglang")
+        .await
+        .unwrap();
+    let decode = GrpcClient::connect(&format!("grpc://{}", fixture.address), "sglang")
+        .await
+        .unwrap();
+    let mut clients = ClientSelection::Dual { prefill, decode };
+    let workers = WorkerSelection::Dual {
+        prefill: Arc::clone(&prefill_worker),
+        decode: Arc::clone(&decode_worker),
+    };
+
+    let result = RequestExecutionStage::new(ExecutionMode::DualDispatch)
+        .execute_dual_dispatch(request("detached-dual"), &mut clients, &workers)
+        .await;
+    let ExecutionResult::Dual {
+        mut prefill,
+        decode,
+    } = result.unwrap()
+    else {
+        panic!("expected dual streams");
+    };
+    let mut decode = *decode;
+    assert!(matches!(prefill.next().await, Some(Err(_))));
+    assert!(matches!(decode.next().await, Some(Err(_))));
+    drop(prefill);
+    drop(decode);
+    assert_eq!(outcomes(&prefill_worker), (1, 0));
+    assert_eq!(outcomes(&decode_worker), (1, 0));
+}
+
+#[tokio::test]
+async fn early_drop_is_abandoned_and_abort_is_exactly_once_after_settle() {
+    let fixture = fixture(Behavior::Messages {
+        messages: vec![complete(0)],
+        status: 0,
+    })
+    .await;
+    let selected = worker("drop");
+    let stream = into_stream(execute(&fixture, Arc::clone(&selected)).await);
+
+    drop(stream);
+    assert_eq!(outcomes(&selected), (0, 0));
+    assert_abort_stays(&fixture, 1).await;
+}

--- a/sgl-model-gateway/src/routers/grpc/context.rs
+++ b/sgl-model-gateway/src/routers/grpc/context.rs
@@ -362,17 +362,6 @@ impl WorkerSelection {
         }
     }
 
-    /// Record circuit breaker outcome for all workers
-    pub fn record_outcome(&self, success: bool) {
-        match self {
-            Self::Single { worker } => worker.record_outcome(success),
-            Self::Dual { prefill, decode } => {
-                prefill.record_outcome(success);
-                decode.record_outcome(success);
-            }
-        }
-    }
-
     /// Record circuit breaker outcomes for dual dispatch (individual tracking)
     pub fn record_dual_outcomes(&self, prefill_success: bool, decode_success: bool) {
         if let Self::Dual { prefill, decode } = self {

--- a/sgl-model-gateway/src/routers/grpc/proto_wrapper.rs
+++ b/sgl-model-gateway/src/routers/grpc/proto_wrapper.rs
@@ -3,6 +3,8 @@
 //! This module provides unified enums that wrap proto types from both SGLang and vLLM,
 //! allowing the router to work with either backend transparently.
 
+use std::sync::Arc;
+
 use futures_util::StreamExt;
 use smg_grpc_client::{
     sglang_proto::{self as sglang, generate_complete::MatchedStop},
@@ -10,6 +12,8 @@ use smg_grpc_client::{
     vllm_engine::AbortOnDropStream as VllmStream,
     vllm_proto as vllm,
 };
+
+use crate::core::Worker;
 
 /// Unified ProtoRequest
 #[derive(Clone)]
@@ -99,6 +103,23 @@ pub enum ProtoGenerateResponse {
 }
 
 impl ProtoGenerateResponse {
+    /// Whether a legacy/custom SGLang producer sent an in-band error.
+    ///
+    /// Official `smg-grpc-servicer` releases supported by SGLang report
+    /// errors with gRPC status instead. The pinned legacy client schema still
+    /// exposes this variant, so treat it as a failed attempt without inferring
+    /// provenance from its untyped string fields.
+    fn legacy_in_band_attempt_outcome(&self) -> Option<AttemptOutcome> {
+        match self {
+            Self::Sglang(response) => matches!(
+                response.response,
+                Some(sglang::generate_response::Response::Error(_))
+            )
+            .then_some(AttemptOutcome::AttemptFailure),
+            Self::Vllm(_) => None,
+        }
+    }
+
     /// Get the response variant (chunk, complete, or error)
     ///
     /// Consumes self to avoid cloning large proto messages in hot streaming path
@@ -363,33 +384,154 @@ impl ProtoGenerateError {
     }
 }
 
-/// Unified stream wrapper
-pub enum ProtoStream {
+/// Terminal outcome of a selected single-worker attempt, decided at body terminal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AttemptOutcome {
+    /// The consumer accepted the fully drained response body.
+    Success,
+    /// The selected upstream attempt ended with a transport/protocol error.
+    ///
+    /// This is an attempt result, not a claim about which component caused it.
+    AttemptFailure,
+    /// The downstream stopped before an upstream terminal verdict was known.
+    Abandoned,
+}
+
+impl AttemptOutcome {
+    fn publish_to(self, worker: &dyn Worker) {
+        match self {
+            Self::Success => worker.record_outcome(true),
+            Self::AttemptFailure => worker.record_outcome(false),
+            Self::Abandoned => {}
+        }
+    }
+}
+
+/// Single-owner right to publish the breaker outcome of one selected attempt.
+///
+/// The right starts Detached, is transferred to the finally selected worker at
+/// stream-start success, and is consumed exactly once by the first legal
+/// body-terminal observation. Duplicate and late observations are absorbed.
+enum BreakerReceipt {
+    /// No breaker publication will happen (e.g. dual PD legs stay detached).
+    Detached,
+    /// The stream holds the publication right for this selected worker.
+    Active(Arc<dyn Worker>),
+    /// The right has been consumed; later observations are no-ops.
+    Resolved,
+}
+
+impl BreakerReceipt {
+    /// Consume the receipt, publishing `outcome` at most once (absorbing).
+    fn resolve(&mut self, outcome: AttemptOutcome) {
+        if let BreakerReceipt::Active(worker) = std::mem::replace(self, BreakerReceipt::Resolved) {
+            outcome.publish_to(worker.as_ref());
+        }
+    }
+}
+
+/// Unified stream wrapper carrying the breaker publication receipt.
+pub struct ProtoStream {
+    inner: ProtoStreamInner,
+    receipt: BreakerReceipt,
+}
+
+enum ProtoStreamInner {
     Sglang(SglangStream),
     Vllm(VllmStream),
 }
 
 impl ProtoStream {
-    /// Get next item from stream
-    pub async fn next(&mut self) -> Option<Result<ProtoGenerateResponse, tonic::Status>> {
-        match self {
-            Self::Sglang(stream) => stream
-                .next()
-                .await
-                .map(|result| result.map(|r| ProtoGenerateResponse::Sglang(Box::new(r)))),
-            Self::Vllm(stream) => stream
-                .next()
-                .await
-                .map(|result| result.map(ProtoGenerateResponse::Vllm)),
+    pub(crate) fn sglang(stream: SglangStream) -> Self {
+        Self {
+            inner: ProtoStreamInner::Sglang(stream),
+            receipt: BreakerReceipt::Detached,
         }
     }
 
-    /// Mark stream as completed (no abort needed)
-    pub fn mark_completed(&mut self) {
-        match self {
-            Self::Sglang(stream) => stream.mark_completed(),
-            Self::Vllm(stream) => stream.mark_completed(),
+    pub(crate) fn vllm(stream: VllmStream) -> Self {
+        Self {
+            inner: ProtoStreamInner::Vllm(stream),
+            receipt: BreakerReceipt::Detached,
         }
+    }
+
+    /// Attach the selected worker breaker publication right (crate-private).
+    ///
+    /// Called exactly once by the dispatch stage after stream-start success
+    /// and final worker selection; attaching twice is a programming error.
+    pub(crate) fn attach_breaker_receipt(
+        &mut self,
+        worker: Arc<dyn Worker>,
+    ) -> Result<(), &'static str> {
+        if !matches!(self.receipt, BreakerReceipt::Detached) {
+            return Err("breaker receipt is already attached or resolved");
+        }
+        self.receipt = BreakerReceipt::Active(worker);
+        Ok(())
+    }
+
+    /// Get next item from stream.
+    ///
+    /// Transport and legacy in-band failures resolve the receipt before they
+    /// are returned. The consumer acknowledges a successfully drained body
+    /// through `mark_completed`.
+    pub async fn next(&mut self) -> Option<Result<ProtoGenerateResponse, tonic::Status>> {
+        let item = match &mut self.inner {
+            ProtoStreamInner::Sglang(stream) => stream
+                .next()
+                .await
+                .map(|result| result.map(|r| ProtoGenerateResponse::Sglang(Box::new(r)))),
+            ProtoStreamInner::Vllm(stream) => stream
+                .next()
+                .await
+                .map(|result| result.map(ProtoGenerateResponse::Vllm)),
+        };
+        match &item {
+            None => {}
+            Some(Err(_)) => {
+                self.receipt.resolve(AttemptOutcome::AttemptFailure);
+            }
+            Some(Ok(response)) => {
+                if let Some(outcome) = response.legacy_in_band_attempt_outcome() {
+                    self.receipt.resolve(outcome);
+                }
+            }
+        }
+        item
+    }
+
+    /// Mark stream as completed (no abort needed).
+    ///
+    /// This is the consumer's enforced terminal declaration: it publishes one
+    /// success and suppresses the dependency's abort-on-drop behavior.
+    pub fn mark_completed(&mut self) {
+        self.receipt.resolve(AttemptOutcome::Success);
+        self.mark_inner_completed();
+    }
+
+    /// Reject a fully drained body that violates the consumer contract.
+    ///
+    /// The selected attempt failed, but the transport stream is already at a
+    /// clean terminal, so suppress the dependency's now-unnecessary abort.
+    pub(crate) fn reject_completed_body(&mut self) {
+        self.receipt.resolve(AttemptOutcome::AttemptFailure);
+        self.mark_inner_completed();
+    }
+
+    fn mark_inner_completed(&mut self) {
+        match &mut self.inner {
+            ProtoStreamInner::Sglang(stream) => stream.mark_completed(),
+            ProtoStreamInner::Vllm(stream) => stream.mark_completed(),
+        }
+    }
+}
+
+impl Drop for ProtoStream {
+    fn drop(&mut self) {
+        // Downstream drop consumes the receipt without publishing an outcome;
+        // inner abort-on-drop remains an independent responsibility.
+        self.receipt.resolve(AttemptOutcome::Abandoned);
     }
 }
 
@@ -518,3 +660,6 @@ impl ProtoEmbedError {
         }
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/sgl-model-gateway/src/routers/grpc/proto_wrapper/tests.rs
+++ b/sgl-model-gateway/src/routers/grpc/proto_wrapper/tests.rs
@@ -1,0 +1,47 @@
+use super::*;
+use crate::core::BasicWorkerBuilder;
+
+fn worker(name: &str) -> Arc<dyn Worker> {
+    Arc::new(BasicWorkerBuilder::new(format!("grpc://{name}")).build())
+}
+
+#[test]
+fn detects_legacy_sglang_errors_without_interpreting_http_hints() {
+    for http_status_code in ["499", "400", "500", "", "not-a-status"] {
+        let response = ProtoGenerateResponse::Sglang(Box::new(sglang::GenerateResponse {
+            response: Some(sglang::generate_response::Response::Error(
+                sglang::GenerateError {
+                    http_status_code: http_status_code.to_string(),
+                    ..Default::default()
+                },
+            )),
+            ..Default::default()
+        }));
+        assert_eq!(
+            response.legacy_in_band_attempt_outcome(),
+            Some(AttemptOutcome::AttemptFailure)
+        );
+    }
+    assert_eq!(
+        ProtoGenerateResponse::Vllm(vllm::GenerateResponse::default())
+            .legacy_in_band_attempt_outcome(),
+        None
+    );
+}
+
+#[test]
+fn receipt_consumes_the_publication_right_exactly_once() {
+    let selected = worker("selected");
+    let mut failed = BreakerReceipt::Active(Arc::clone(&selected));
+    failed.resolve(AttemptOutcome::AttemptFailure);
+    failed.resolve(AttemptOutcome::Success);
+    assert_eq!(selected.circuit_breaker().total_failures(), 1);
+    assert_eq!(selected.circuit_breaker().total_successes(), 0);
+
+    let abandoned_worker = worker("abandoned");
+    let mut abandoned = BreakerReceipt::Active(Arc::clone(&abandoned_worker));
+    abandoned.resolve(AttemptOutcome::Abandoned);
+    abandoned.resolve(AttemptOutcome::AttemptFailure);
+    assert_eq!(abandoned_worker.circuit_breaker().total_failures(), 0);
+    assert_eq!(abandoned_worker.circuit_breaker().total_successes(), 0);
+}

--- a/sgl-model-gateway/tests/reliability/grpc_breaker_receipt_test.rs
+++ b/sgl-model-gateway/tests/reliability/grpc_breaker_receipt_test.rs
@@ -1,0 +1,465 @@
+use std::{
+    collections::VecDeque,
+    convert::Infallible,
+    net::SocketAddr,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc, Mutex,
+    },
+    time::Duration,
+};
+
+use anyhow::Result;
+use axum::{
+    body::{to_bytes, Body},
+    http::{header::CONTENT_TYPE, Request, Response, StatusCode},
+    routing::post,
+    Router,
+};
+use bytes::Bytes;
+use futures_util::stream;
+use http_body::Frame;
+use http_body_util::StreamBody;
+use prost::Message;
+use smg::{
+    config::{RetryConfig, RouterConfig},
+    core::{BasicWorkerBuilder, ConnectionMode, ModelCard, RuntimeType, Worker, WorkerType},
+    routers::{grpc::client::GrpcClient, RouterFactory, RouterTrait},
+    tokenizer::traits::{Decoder, Encoder, Encoding, SpecialTokens, TokenIdType, Tokenizer},
+};
+use smg_grpc_client::sglang_proto as sglang;
+use tokio::{net::TcpListener, task::JoinHandle, time};
+use tower::ServiceExt;
+
+use crate::common;
+
+const GENERATE_PATH: &str = "/sglang.grpc.scheduler.SglangScheduler/Generate";
+const ABORT_PATH: &str = "/sglang.grpc.scheduler.SglangScheduler/Abort";
+
+#[derive(Default)]
+struct PlainTokenizer {
+    special: SpecialTokens,
+}
+
+impl Encoder for PlainTokenizer {
+    fn encode(&self, input: &str, _add_special_tokens: bool) -> Result<Encoding> {
+        Ok(Encoding::Plain(input.bytes().map(u32::from).collect()))
+    }
+
+    fn encode_batch(&self, inputs: &[&str], add_special_tokens: bool) -> Result<Vec<Encoding>> {
+        inputs
+            .iter()
+            .map(|input| self.encode(input, add_special_tokens))
+            .collect()
+    }
+}
+
+impl Decoder for PlainTokenizer {
+    fn decode(&self, token_ids: &[TokenIdType], _skip_special_tokens: bool) -> Result<String> {
+        Ok(token_ids
+            .iter()
+            .map(|id| char::from_u32(*id).unwrap_or('\u{fffd}'))
+            .collect())
+    }
+}
+
+impl Tokenizer for PlainTokenizer {
+    fn vocab_size(&self) -> usize {
+        256
+    }
+
+    fn get_special_tokens(&self) -> &SpecialTokens {
+        &self.special
+    }
+
+    fn token_to_id(&self, token: &str) -> Option<TokenIdType> {
+        token.bytes().next().map(u32::from)
+    }
+
+    fn id_to_token(&self, id: TokenIdType) -> Option<String> {
+        char::from_u32(id).map(|character| character.to_string())
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+#[derive(Clone)]
+enum Behavior {
+    HeadersStatus(u32),
+    Messages { messages: Vec<Vec<u8>>, status: u32 },
+}
+
+struct Upstream {
+    address: SocketAddr,
+    generate_calls: Arc<AtomicUsize>,
+    abort_calls: Arc<AtomicUsize>,
+    server: JoinHandle<()>,
+}
+
+impl Drop for Upstream {
+    fn drop(&mut self) {
+        self.server.abort();
+    }
+}
+
+fn grpc_frame(payload: Vec<u8>) -> Bytes {
+    let mut frame = Vec::with_capacity(payload.len() + 5);
+    frame.push(0);
+    frame.extend_from_slice(&(payload.len() as u32).to_be_bytes());
+    frame.extend_from_slice(&payload);
+    Bytes::from(frame)
+}
+
+fn response(behavior: Behavior) -> Response<Body> {
+    let builder = Response::builder()
+        .status(200)
+        .header("content-type", "application/grpc");
+    match behavior {
+        Behavior::HeadersStatus(status) => builder
+            .header("grpc-status", status.to_string())
+            .body(Body::empty())
+            .unwrap(),
+        Behavior::Messages { messages, status } => {
+            let mut trailers = http::HeaderMap::new();
+            trailers.insert("grpc-status", status.to_string().parse().unwrap());
+            let frames = messages
+                .into_iter()
+                .map(|message| Ok::<_, Infallible>(Frame::data(grpc_frame(message))))
+                .chain(std::iter::once(Ok(Frame::trailers(trailers))));
+            builder
+                .body(Body::new(StreamBody::new(stream::iter(frames))))
+                .unwrap()
+        }
+    }
+}
+
+async fn start_upstream(script: Vec<Behavior>) -> Upstream {
+    let script = Arc::new(Mutex::new(VecDeque::from(script)));
+    let generate_calls = Arc::new(AtomicUsize::new(0));
+    let abort_calls = Arc::new(AtomicUsize::new(0));
+    let generate_counter = Arc::clone(&generate_calls);
+    let abort_counter = Arc::clone(&abort_calls);
+    let app = Router::new()
+        .route(
+            GENERATE_PATH,
+            post(move || {
+                let script = Arc::clone(&script);
+                let generate_counter = Arc::clone(&generate_counter);
+                async move {
+                    generate_counter.fetch_add(1, Ordering::SeqCst);
+                    let behavior = script
+                        .lock()
+                        .unwrap()
+                        .pop_front()
+                        .expect("unexpected generate attempt");
+                    response(behavior)
+                }
+            }),
+        )
+        .route(
+            ABORT_PATH,
+            post(move || {
+                let abort_counter = Arc::clone(&abort_counter);
+                async move {
+                    abort_counter.fetch_add(1, Ordering::SeqCst);
+                    Response::builder()
+                        .status(200)
+                        .header("content-type", "application/grpc")
+                        .header("grpc-status", "0")
+                        .body(Body::empty())
+                        .unwrap()
+                }
+            }),
+        );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    Upstream {
+        address,
+        generate_calls,
+        abort_calls,
+        server,
+    }
+}
+
+fn complete() -> Vec<u8> {
+    sglang::GenerateResponse {
+        response: Some(sglang::generate_response::Response::Complete(
+            sglang::GenerateComplete {
+                output_ids: vec![65],
+                finish_reason: "stop".to_string(),
+                index: 0,
+                ..Default::default()
+            },
+        )),
+        ..Default::default()
+    }
+    .encode_to_vec()
+}
+
+fn chunk() -> Vec<u8> {
+    sglang::GenerateResponse {
+        response: Some(sglang::generate_response::Response::Chunk(
+            sglang::GenerateStreamChunk {
+                token_ids: vec![65],
+                index: 0,
+                ..Default::default()
+            },
+        )),
+        ..Default::default()
+    }
+    .encode_to_vec()
+}
+
+struct Harness {
+    app: Router,
+    worker: Arc<dyn Worker>,
+    upstream: Upstream,
+}
+
+async fn harness(script: Vec<Behavior>, max_attempts: u32) -> Harness {
+    let upstream = start_upstream(script).await;
+    let config = RouterConfig::builder()
+        .regular_mode(vec![])
+        .round_robin_policy()
+        .grpc_connection_default()
+        .host("127.0.0.1")
+        .port(0)
+        .max_payload_size(1024 * 1024)
+        .request_timeout_secs(10)
+        .worker_startup_timeout_secs(1)
+        .worker_startup_check_interval_secs(1)
+        .max_concurrent_requests(8)
+        .queue_timeout_secs(2)
+        .retry_config(RetryConfig {
+            max_retries: max_attempts,
+            initial_backoff_ms: 1,
+            max_backoff_ms: 1,
+            backoff_multiplier: 1.0,
+            jitter_factor: 0.0,
+        })
+        .build_unchecked();
+    let context = common::create_test_context_with_parsers(config).await;
+    context
+        .tokenizer_registry
+        .load("receipt-test", "mock-model", "inline", || async {
+            Ok(Arc::new(PlainTokenizer::default()) as Arc<dyn Tokenizer>)
+        })
+        .await
+        .unwrap();
+
+    let client = GrpcClient::connect(&format!("grpc://{}", upstream.address), "sglang")
+        .await
+        .unwrap();
+    let worker: Arc<dyn Worker> = Arc::new(
+        BasicWorkerBuilder::new(format!("grpc://{}", upstream.address))
+            .worker_type(WorkerType::Regular)
+            .connection_mode(ConnectionMode::Grpc { port: None })
+            .runtime_type(RuntimeType::Sglang)
+            .models(vec![ModelCard::new("mock-model")])
+            .grpc_client(client)
+            .build(),
+    );
+    context.worker_registry.register(Arc::clone(&worker));
+    let router: Arc<dyn RouterTrait> =
+        Arc::from(RouterFactory::create_router(&context).await.unwrap());
+    let app = common::test_app::create_test_app_with_context(router, context);
+    Harness {
+        app,
+        worker,
+        upstream,
+    }
+}
+
+fn generate_request(stream: bool) -> Request<Body> {
+    Request::builder()
+        .method("POST")
+        .uri("/generate")
+        .header(CONTENT_TYPE, "application/json")
+        .body(Body::from(format!(
+            r#"{{"model":"mock-model","input_ids":[65],"stream":{stream},"rid":"receipt-public"}}"#
+        )))
+        .unwrap()
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Snapshot {
+    successes: u64,
+    failures: u64,
+    generates: usize,
+    aborts: usize,
+}
+
+fn snapshot(worker: &Arc<dyn Worker>, upstream: &Upstream) -> Snapshot {
+    Snapshot {
+        successes: worker.circuit_breaker().total_successes(),
+        failures: worker.circuit_breaker().total_failures(),
+        generates: upstream.generate_calls.load(Ordering::SeqCst),
+        aborts: upstream.abort_calls.load(Ordering::SeqCst),
+    }
+}
+
+async fn assert_snapshot_stays(worker: &Arc<dyn Worker>, upstream: &Upstream, expected: Snapshot) {
+    time::timeout(Duration::from_secs(2), async {
+        while snapshot(worker, upstream) != expected {
+            time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("attempt state did not reach the expected snapshot");
+    time::sleep(Duration::from_secs(2)).await;
+    assert_eq!(snapshot(worker, upstream), expected);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn public_streaming_cancelled_body_is_one_failed_attempt_without_retry() {
+    let Harness {
+        app,
+        worker,
+        upstream,
+    } = harness(
+        vec![Behavior::Messages {
+            messages: vec![chunk()],
+            status: 1,
+        }],
+        2,
+    )
+    .await;
+    let response = app.oneshot(generate_request(true)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+    assert!(String::from_utf8_lossy(&body).contains("Stream error"));
+    assert_snapshot_stays(
+        &worker,
+        &upstream,
+        Snapshot {
+            successes: 0,
+            failures: 1,
+            generates: 1,
+            aborts: 1,
+        },
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn public_non_streaming_invalid_argument_body_retries_then_succeeds() {
+    let Harness {
+        app,
+        worker,
+        upstream,
+    } = harness(
+        vec![
+            Behavior::Messages {
+                messages: vec![chunk()],
+                status: 3,
+            },
+            Behavior::Messages {
+                messages: vec![complete()],
+                status: 0,
+            },
+        ],
+        2,
+    )
+    .await;
+    let response = app.oneshot(generate_request(false)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+    let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(
+        body.pointer("/0/text").and_then(|value| value.as_str()),
+        Some("A")
+    );
+    assert_snapshot_stays(
+        &worker,
+        &upstream,
+        Snapshot {
+            successes: 1,
+            failures: 1,
+            generates: 2,
+            aborts: 1,
+        },
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn public_non_streaming_empty_completion_set_is_failed_attempt_without_abort() {
+    let Harness {
+        app,
+        worker,
+        upstream,
+    } = harness(
+        vec![
+            Behavior::Messages {
+                messages: vec![chunk()],
+                status: 0,
+            },
+            Behavior::Messages {
+                messages: vec![complete()],
+                status: 0,
+            },
+        ],
+        2,
+    )
+    .await;
+    let response = app.oneshot(generate_request(false)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+    let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(
+        body.pointer("/0/text").and_then(|value| value.as_str()),
+        Some("A")
+    );
+    assert_snapshot_stays(
+        &worker,
+        &upstream,
+        Snapshot {
+            successes: 1,
+            failures: 1,
+            generates: 2,
+            aborts: 0,
+        },
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn public_start_failure_retries_without_creating_a_body_receipt() {
+    let Harness {
+        app,
+        worker,
+        upstream,
+    } = harness(
+        vec![
+            Behavior::HeadersStatus(14),
+            Behavior::Messages {
+                messages: vec![complete()],
+                status: 0,
+            },
+        ],
+        2,
+    )
+    .await;
+    let response = app.oneshot(generate_request(false)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+    let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(
+        body.pointer("/0/text").and_then(|value| value.as_str()),
+        Some("A")
+    );
+    assert_snapshot_stays(
+        &worker,
+        &upstream,
+        Snapshot {
+            successes: 1,
+            failures: 1,
+            generates: 2,
+            aborts: 0,
+        },
+    )
+    .await;
+}

--- a/sgl-model-gateway/tests/reliability/mod.rs
+++ b/sgl-model-gateway/tests/reliability/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod circuit_breaker_test;
 pub mod fault_tolerance_test;
+pub mod grpc_breaker_receipt_test;
 pub mod rate_limiting_test;
 pub mod retries_test;
 pub mod upstream_cancel_test;


### PR DESCRIPTION
## Motivation

The model gateway currently records a successful gRPC circuit-breaker outcome as soon as a selected Single attempt returns a response stream. Stream creation does not establish that the response body will complete successfully, so a later transport status or in-band protocol error can leave an eager success recorded for a failed attempt.

This change moves the selected-attempt publication right from dispatch into the response body and resolves it exactly once at a terminal observation.

## Modifications

- Keep stream-start failures in the dispatch stage, but do not publish success when stream creation succeeds.
- Attach one breaker receipt to a selected Single response body. The first terminal disposition consumes the receipt through an absorbing state transition.
- Publish one failed selected-attempt outcome for any attached body `tonic::Status`, legacy in-band error, or cleanly drained body rejected by the consumer contract.
- Publish success only when a consumer clean-drains the body, performs its local pre-acknowledgement checks, and calls `mark_completed`.
- Treat an early downstream drop as abandonment without publishing an outcome; the existing inner abort-on-drop behavior remains independent.
- Keep Dual/PD streams detached with their existing start-only accounting.
- Add focused receipt/state-machine tests and public `/generate` reliability coverage for late body failures, retry, empty completion rejection, and start failure.

This is intentionally limited to a Single selected attempt. It does not add HalfOpen ticket/epoch fencing, change retry ownership, establish `n > 1` completion ordering, or unify HTTP/gRPC/PD terminal policy.

Two points would benefit from maintainer confirmation:

1. Is consumer `mark_completed` acceptable as an absorbing terminal declaration after clean drain and local pre-acknowledgement checks?
2. Should every terminal error on an attached Single body count as a failed selected attempt without guessing provenance from tonic code, message text, or a legacy HTTP-status hint?

The accounting describes the selected upstream attempt outcome; it does not attribute blame to a worker, caller, proxy, or other component. The legacy in-band error path is compatibility-only.

## Accuracy Tests

Not applicable. This change does not affect model forward code or model outputs.

Fresh `main` validation:

- `cargo test --locked --lib routers::grpc::`: 32 passed.
- `cargo test --locked --test reliability_tests grpc_breaker_receipt_test`: 4 passed.
- `cargo test --locked --lib`: 407 passed.
- `cargo test --locked --test spec_test`: 89 passed, 1 ignored.
- `cargo fmt --all --check`: passed; the repository's official nightly gateway rustfmt pre-commit hook also passed.
- `pre-commit run --all-files`: passed.
- Strict all-target/all-feature clippy reproduced two existing `needless_borrows_for_generic_args` findings in `cache_aware.rs`; allowing only that baseline lint passed, with no warning added by this change.

## Speed Tests and Profiling

No material performance impact was observed. The change introduces no request-scale-proportional new lock, allocation, or network work, and does not claim a performance improvement.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (No user-facing API or configuration change.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32036469177](https://github.com/sgl-project/sglang/actions/runs/32036469177)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32036469011](https://github.com/sgl-project/sglang/actions/runs/32036469011)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->