### PR TITLE
[Mac] Keep SGLang compile decorators eager with the Triton stub

### DIFF
--- a/python/sglang/_platform_stubs.py
+++ b/python/sglang/_platform_stubs.py
@@ -395,6 +395,7 @@ def install_platform_stubs() -> None:
         sys.meta_path.insert(0, _TritonFinder())
 
         triton = _make_mock("triton")
+        triton.__sglang_stub__ = True
         triton.__version__ = "3.0.0"
         triton.cdiv = _cdiv
         triton.next_power_of_2 = _next_power_of_2

--- a/python/sglang/_torch_compile.py
+++ b/python/sglang/_torch_compile.py
@@ -1,0 +1,26 @@
+"""SGLang-local wrapper for import-time ``torch.compile`` decorators."""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+import torch
+
+
+def _using_triton_stub() -> bool:
+    triton = sys.modules.get("triton")
+    return bool(getattr(triton, "__sglang_stub__", False))
+
+
+def sglang_compile(*args: Any, **kwargs: Any) -> Any:
+    """Compile an SGLang callable, or keep it eager with the Triton stub.
+
+    The macOS import stub is sufficient for defining Triton kernels, but it is
+    not a compiler implementation and cannot be inspected by TorchInductor.
+    Limit the eager fallback to SGLang call sites instead of replacing the
+    process-wide ``torch.compile`` function.
+    """
+    if _using_triton_stub():
+        kwargs["disable"] = True
+    return torch.compile(*args, **kwargs)

--- a/python/sglang/kernels/ops/speculative/cache_locs.py
+++ b/python/sglang/kernels/ops/speculative/cache_locs.py
@@ -4,6 +4,7 @@ import torch
 import triton
 import triton.language as tl
 
+from sglang._torch_compile import sglang_compile
 from sglang.srt.utils import (
     is_cpu,
     is_cuda,
@@ -158,7 +159,7 @@ def align_evict_mask_to_page_size(
         tl.store(evict_mask + bid * num_draft_tokens + i, False)
 
 
-@torch.compile(dynamic=True, disable=_is_npu)
+@sglang_compile(dynamic=True, disable=_is_npu)
 def get_src_tgt_cache_loc(
     seq_lens: torch.Tensor,
     out_cache_loc: torch.Tensor,

--- a/python/sglang/srt/layers/moe/kt_ep_wrapper.py
+++ b/python/sglang/srt/layers/moe/kt_ep_wrapper.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 
+from sglang._torch_compile import sglang_compile
 from sglang.srt.layers.quantization.base_config import FusedMoEMethodBase
 from sglang.srt.runtime_context import get_parallel
 from sglang.srt.utils import get_compiler_backend
@@ -95,7 +96,7 @@ def create_kt_config_from_server_args(
     )
 
 
-@torch.compile(dynamic=True, backend=get_compiler_backend())
+@sglang_compile(dynamic=True, backend=get_compiler_backend())
 def mask_cpu_expert_ids(topk_ids: torch.Tensor, num_gpu_experts: int) -> torch.Tensor:
     """Mask CPU expert IDs by setting them to -1.
 

--- a/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
@@ -8,6 +8,7 @@ import torch
 import triton
 import triton.language as tl
 
+from sglang._torch_compile import sglang_compile
 from sglang.kernels.ops.attention.dsv4 import silu_and_mul_masked_post_quant
 from sglang.kernels.ops.quantization import per_token_group_quant
 
@@ -77,7 +78,7 @@ _masked_standard_layout_memory_budget_bytes: Optional[int] = None
 
 # TODO(kaixih@nvidia): ideally we should merge this logic into
 # `fill_gateup_input_triton_kernel` to directly generate e8m0 scale.
-@torch.compile(disable=_is_hip or _is_npu)
+@sglang_compile(disable=_is_hip or _is_npu)
 def _cast_to_e8m0_with_rounding_up(x: torch.Tensor) -> torch.Tensor:
     temp = x.to(torch.float32).view(torch.int32)
     exp = torch.bitwise_right_shift(temp, 23)

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
@@ -14,6 +14,7 @@ import torch
 import torch.nn.functional as F
 import triton.language as tl
 
+from sglang._torch_compile import sglang_compile
 from sglang.kernels.ops.moe.fused_moe_triton_kernels import (
     act_and_mul_triton,
     invoke_fused_moe_kernel,
@@ -338,13 +339,13 @@ def fused_experts(
         )
 
 
-@torch.compile
+@sglang_compile
 def moe_sum_reduce_torch_compile(x, out, routed_scaling_factor):
     torch.sum(x, dim=1, out=out)
     out.mul_(routed_scaling_factor)
 
 
-@torch.compile
+@sglang_compile
 def _swiglu_silu_clamp_mul(x, gemm1_limit):
     gate, up = x.chunk(2, dim=-1)
     gate = F.silu(gate)
@@ -353,7 +354,7 @@ def _swiglu_silu_clamp_mul(x, gemm1_limit):
     return gate * up
 
 
-@torch.compile
+@sglang_compile
 def swiglu_gpt_oss_sigmoid_alpha(x, gemm1_alpha, gemm1_limit):
     # NOTE: This variant uses gemm1_alpha, unlike _swiglu_silu_clamp_mul.
     # At present, only GPT-OSS uses this variant.
@@ -363,7 +364,7 @@ def swiglu_gpt_oss_sigmoid_alpha(x, gemm1_alpha, gemm1_limit):
     return gate * torch.sigmoid(gate * gemm1_alpha) * (up + 1)
 
 
-@torch.compile
+@sglang_compile
 def swiglu_no_interleaved_with_alpha_and_limit(x, gemm1_alpha, gemm1_limit):
     gate, up = x.chunk(2, dim=-1)
     gate = gate.clamp(min=None, max=gemm1_limit)

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -32,6 +32,8 @@ from typing import (
 import torch
 import torch.nn.functional as F
 
+from sglang._torch_compile import sglang_compile
+
 if TYPE_CHECKING:
     from triton_kernels.tensor_details.ragged_tensor import RaggedTensorMetadata
 
@@ -968,7 +970,7 @@ def fused_topk(
 
 
 # This is used by the Deepseek V2/V3/R1 series models
-@torch.compile(dynamic=True, backend=get_compiler_backend(), disable=_is_npu)
+@sglang_compile(dynamic=True, backend=get_compiler_backend(), disable=_is_npu)
 def grouped_topk_gpu(
     hidden_states: torch.Tensor,
     gating_output: torch.Tensor,
@@ -1126,7 +1128,7 @@ def grouped_topk_xpu(
     )
 
 
-@torch.compile(dynamic=True, backend=get_compiler_backend(), disable=_is_npu)
+@sglang_compile(dynamic=True, backend=get_compiler_backend(), disable=_is_npu)
 def kimi_k2_biased_topk_impl(
     hidden_states: torch.Tensor,
     gating_output: torch.Tensor,
@@ -1167,7 +1169,7 @@ def kimi_k2_biased_topk_impl(
     return topk_weights, topk_ids
 
 
-@torch.compile(dynamic=True, backend=get_compiler_backend(), disable=_is_npu)
+@sglang_compile(dynamic=True, backend=get_compiler_backend(), disable=_is_npu)
 def biased_topk_impl(
     hidden_states: torch.Tensor,
     gating_output: torch.Tensor,
@@ -1287,7 +1289,7 @@ def biased_topk_jit_kernel_impl(
         return topk_weights, topk_ids
 
 
-@torch.compile(dynamic=True, backend=get_compiler_backend(), disable=_is_npu)
+@sglang_compile(dynamic=True, backend=get_compiler_backend(), disable=_is_npu)
 def biased_grouped_topk_impl(
     hidden_states: torch.Tensor,
     gating_output: torch.Tensor,
@@ -1426,7 +1428,7 @@ def _zero_topk_weights_padded_region(
     topk_weights[indices >= num_token_non_padded, :] = 0.0
 
 
-@torch.compile(dynamic=True, backend=get_compiler_backend())
+@sglang_compile(dynamic=True, backend=get_compiler_backend())
 def _biased_grouped_topk_postprocess(
     topk_ids, expert_location_dispatch_info, num_token_non_padded
 ):

--- a/python/sglang/srt/layers/quantization/kvfp4_tensor.py
+++ b/python/sglang/srt/layers/quantization/kvfp4_tensor.py
@@ -17,6 +17,8 @@ from enum import Enum
 
 import torch
 
+from sglang._torch_compile import sglang_compile
+
 
 class FP4KVCacheRecipe(Enum):
     MXFP4 = 1  # KVFP4: block-wise scaling
@@ -61,7 +63,7 @@ class FP4MXBlock16KVQuantizeUtil:
     """
 
     @staticmethod
-    @torch.compile
+    @sglang_compile
     def batched_quantize(tensor: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         """
 
@@ -104,7 +106,7 @@ class FP4MXBlock16KVQuantizeUtil:
         return packed, scale_factors
 
     @staticmethod
-    @torch.compile
+    @sglang_compile
     def batched_dequantize(
         quant_tensor: torch.Tensor,
         scale_factors: torch.Tensor,

--- a/python/sglang/srt/layers/rotary_embedding/utils.py
+++ b/python/sglang/srt/layers/rotary_embedding/utils.py
@@ -7,6 +7,7 @@ from typing import Tuple
 
 import torch
 
+from sglang._torch_compile import sglang_compile
 from sglang.srt.utils import cpu_has_amx_support, get_compiler_backend, is_cpu, is_npu
 
 _is_npu = is_npu()
@@ -93,7 +94,7 @@ def apply_rotary_pos_emb_native_eager(
     return q_embed, k_embed
 
 
-@torch.compile(dynamic=True, backend=get_compiler_backend())
+@sglang_compile(dynamic=True, backend=get_compiler_backend())
 def apply_rotary_pos_emb_native(
     q: torch.Tensor,
     k: torch.Tensor,

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -6,6 +6,7 @@ import torch
 import torch.distributed as dist
 from torch import nn
 
+from sglang._torch_compile import sglang_compile
 from sglang.kernels.ops.sampling.murmur_hash import murmur_hash32
 from sglang.srt.distributed import get_tp_group
 from sglang.srt.layers.dp_attention import (
@@ -684,7 +685,7 @@ def top_k_top_p_min_p_sampling_from_logits_ascend(
     return batch_next_token_ids.view(-1)
 
 
-@torch.compile(dynamic=True, disable=is_npu())
+@sglang_compile(dynamic=True, disable=is_npu())
 def multinomial_with_seed(
     logprobs: torch.Tensor, seed: torch.Tensor, positions: torch.Tensor
 ) -> torch.Tensor:

--- a/python/sglang/srt/layers/vocab_parallel_embedding.py
+++ b/python/sglang/srt/layers/vocab_parallel_embedding.py
@@ -9,6 +9,7 @@ from typing import List, Optional, Sequence, Tuple
 import torch
 from torch.nn.parameter import Parameter, UninitializedParameter
 
+from sglang._torch_compile import sglang_compile
 from sglang.kernels.ops.embeddings.vocab_parallel_embedding import (
     vocab_parallel_embedding as fused_vocab_parallel_embedding,
 )
@@ -135,7 +136,7 @@ class VocabParallelEmbeddingShardIndices:
         assert self.num_added_elements <= self.num_added_elements_padded
 
 
-@torch.compile(dynamic=True, backend=get_compiler_backend(), disable=_is_npu)
+@sglang_compile(dynamic=True, backend=get_compiler_backend(), disable=_is_npu)
 def get_masked_input_and_mask(
     input_: torch.Tensor,
     org_vocab_start_index: int,

--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Optional, Sequence
 import msgspec
 import torch
 
+from sglang._torch_compile import sglang_compile
 from sglang.kernels.ops.speculative.gather_spec_extras import gather_spec_extras
 from sglang.srt.environ import envs
 from sglang.srt.utils import is_cuda, is_hip, is_npu
@@ -72,7 +73,7 @@ _is_npu = is_npu()
 _DEBUG_ASSERT = envs.SGLANG_IS_IN_CI.get()
 
 
-@torch.compile(dynamic=True, disable=_is_npu)
+@sglang_compile(dynamic=True, disable=_is_npu)
 def _assert_nonneg_and_invalidate(
     values: torch.Tensor, buf: torch.Tensor, indices: torch.Tensor
 ) -> None:

--- a/python/sglang/srt/sampling/penaltylib/repetition_penalty.py
+++ b/python/sglang/srt/sampling/penaltylib/repetition_penalty.py
@@ -1,12 +1,13 @@
 import torch
 
+from sglang._torch_compile import sglang_compile
 from sglang.srt.sampling.penaltylib.orchestrator import _BatchedPenalizer
 from sglang.srt.utils import get_compiler_backend, is_npu
 
 _is_npu = is_npu()
 
 
-@torch.compile(dynamic=True, backend=get_compiler_backend(), disable=_is_npu)
+@sglang_compile(dynamic=True, backend=get_compiler_backend(), disable=_is_npu)
 def apply_scaling_penalties(logits, scaling_penalties):
     logits[:] = torch.where(
         logits < 0,

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, Callable, List, Literal, Optional, Tuple
 import torch
 from huggingface_hub import snapshot_download
 
+from sglang._torch_compile import sglang_compile
 from sglang.kernels.ops.speculative.cache_locs import (
     align_evict_mask_to_page_size as align_evict_mask_to_page_size,
 )
@@ -269,7 +270,7 @@ def spec_need_hidden_states() -> bool:
     return not spec.enable_multi_layer_eagle
 
 
-@torch.compile(dynamic=True, disable=_is_npu or _is_xpu)
+@sglang_compile(dynamic=True, disable=_is_npu or _is_xpu)
 def create_num_accept_tokens_filter(
     num_correct_drafts: torch.Tensor,
     unfinished_index_device: torch.Tensor,
@@ -303,7 +304,7 @@ def _select_top_k_tokens_first(
     return input_ids, hidden_states, topk_p, tree_info
 
 
-@torch.compile(dynamic=True, disable=_is_npu or _is_xpu)
+@sglang_compile(dynamic=True, disable=_is_npu or _is_xpu)
 def _select_top_k_tokens_later(
     i: int,
     topk_p: torch.Tensor,

--- a/test/registered/unit/compilation/test_torch_compile_stub.py
+++ b/test/registered/unit/compilation/test_torch_compile_stub.py
@@ -1,0 +1,66 @@
+# Copyright 2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for SGLang-local ``torch.compile`` handling with the Triton stub."""
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang import _torch_compile
+from sglang.test.ci.ci_register import register_cpu_ci, register_mlx_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+register_mlx_ci(est_time=1, suite="stage-a-unit-test-mlx")
+
+
+class TestTorchCompileStub(CustomTestCase):
+    def test_stub_disables_only_sglang_call_site(self):
+        original_compile = _torch_compile.torch.compile
+        sentinel = object()
+        triton_stub = SimpleNamespace(__sglang_stub__=True)
+
+        with (
+            patch.dict(sys.modules, {"triton": triton_stub}),
+            patch.object(
+                _torch_compile.torch, "compile", return_value=sentinel
+            ) as call,
+        ):
+            self.assertIs(
+                _torch_compile.sglang_compile("callable", dynamic=True), sentinel
+            )
+            call.assert_called_once_with("callable", dynamic=True, disable=True)
+
+        self.assertIs(_torch_compile.torch.compile, original_compile)
+
+    def test_real_triton_preserves_torch_compile_arguments(self):
+        sentinel = object()
+        real_triton = SimpleNamespace(__sglang_stub__=False)
+
+        with (
+            patch.dict(sys.modules, {"triton": real_triton}),
+            patch.object(
+                _torch_compile.torch, "compile", return_value=sentinel
+            ) as call,
+        ):
+            self.assertIs(
+                _torch_compile.sglang_compile("callable", dynamic=True), sentinel
+            )
+            call.assert_called_once_with("callable", dynamic=True)
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
## Problem

On Apple Silicon, SGLang installs its lightweight Triton import stub because a real Triton runtime is unavailable. The stub is sufficient to define/import Triton kernels, but import-time `torch.compile` decorators still initialize TorchInductor and inspect Triton runtime types before the decorated function is ever called.

As a result, importing common SRT modules fails during module initialization. This happens before model selection, so even a small dense CPU model is blocked by compile decorators in common MoE, sampling, embedding, and speculative modules.

## Reproduction before this PR

Run on Apple Silicon with the PyTorch CPU engine enabled and MLX disabled:

```bash
SGLANG_USE_CPU_ENGINE=1 SGLANG_USE_MLX=0 python - <<'PY'
from sglang.srt.layers.moe.moe_runner.deep_gemm import (
    _cast_to_e8m0_with_rounding_up,
)
print(_cast_to_e8m0_with_rounding_up)
PY
```

Before this change, the import enters `torch.compile`, initializes TorchInductor against the Triton stub, and fails with an error such as:

```text
TypeError: unsupported operand type(s) for |: 'module' and 'type'
```

Other common call sites fail similarly while inspecting missing members such as `triton.language.core.view`.

## Solution

- Mark the SGLang Triton stub explicitly.
- Add an SGLang-local compile wrapper that forwards the original arguments to `torch.compile`.
- When and only when the installed Triton module is the SGLang stub, force `disable=True` so the decorated callable stays eager.
- Migrate the 12 import-time compile call sites that are reached by the common HTTP/model-registry import chain.

The wrapper does not replace the process-wide `torch.compile` function. Real Triton platforms preserve the existing compile arguments and behavior.

The 12 call sites were checked individually: restoring any one of them to raw `torch.compile` reproduces the import-time failure.

## Behavior after this PR

The reproduction above imports successfully, and `torch.compile` remains the original process-global function:

```text
deep_gemm import: OK
global torch.compile unchanged: True
```

This PR intentionally addresses the compile/import boundary only. macOS CPU topology and optional `sgl_kernel` CPU AOT handling are separate follow-up changes.

## Validation

```bash
pytest -q test/registered/unit/compilation/test_torch_compile_stub.py
```

Result:

```text
2 passed
```

Also verified:

- real-Triton arguments are passed through unchanged;
- the stub overrides an explicit `disable=False` only for SGLang call sites;
- the global `torch.compile` function object is unchanged;
- each migrated call site fails the common import when individually restored to raw `torch.compile`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32094681555](https://github.com/sgl-project/sglang/actions/runs/32094681555)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32094681381](https://github.com/sgl-project/sglang/actions/runs/32094681381)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->