### PR TITLE
[Fix] Keep normal text preceding the tool-call opener in streaming parsers

### DIFF
--- a/python/sglang/srt/function_call/base_format_detector.py
+++ b/python/sglang/srt/function_call/base_format_detector.py
@@ -164,6 +164,21 @@ class BaseFormatDetector(ABC):
                 # Might be partial bot_token, keep buffering
                 return StreamingParseResult()
 
+        # A coalesced increment (stream_interval > 1, speculative decoding, or
+        # the final flush) can carry normal text and the bot_token together,
+        # e.g. "Sure. <tool_call>\n{...". Emit the text preceding the first
+        # bot_token as normal_text instead of silently dropping it, then parse
+        # the tool call from the bot_token onwards.
+        if self.current_tool_id == -1 and not self.current_tool_name_sent:
+            bot_pos = current_text.find(self.bot_token)
+            if bot_pos > 0:
+                normal_text = current_text[:bot_pos]
+                self._buffer = current_text[bot_pos:]
+                result = self.parse_streaming_increment("", tools)
+                if result.normal_text:
+                    normal_text += result.normal_text
+                return StreamingParseResult(normal_text=normal_text, calls=result.calls)
+
         # Build tool indices if not already built
         if not hasattr(self, "_tool_indices"):
             self._tool_indices = self._get_tool_indices(tools)

--- a/python/sglang/srt/function_call/glm4_moe_detector.py
+++ b/python/sglang/srt/function_call/glm4_moe_detector.py
@@ -468,6 +468,15 @@ class Glm4MoeDetector(BaseFormatDetector):
                 # Could be start of tool call, keep buffering
                 return StreamingParseResult(normal_text="", calls=[])
 
+        # Extract any text before the first bot_token and return it as normal_text
+        normal_text = ""
+        first_bot_token_idx = current_text.find(self.bot_token)
+        if first_bot_token_idx > 0:
+            normal_text = current_text[:first_bot_token_idx]
+            current_text = current_text[first_bot_token_idx:]
+            # Update buffer to only include from the bot token onwards
+            self._buffer = current_text
+
         if not hasattr(self, "_tool_indices"):
             self._tool_indices = self._get_tool_indices(tools)
 
@@ -488,7 +497,7 @@ class Glm4MoeDetector(BaseFormatDetector):
                 if func_name_raw is None or not func_name_raw.strip():
                     # If we only have the start token without a function name,
                     # continue buffering until we get more content
-                    return StreamingParseResult(normal_text="", calls=[])
+                    return StreamingParseResult(normal_text=normal_text, calls=[])
 
                 func_name = func_name_raw.strip()
                 func_args_raw = func_args_raw.strip() if func_args_raw else ""
@@ -597,7 +606,9 @@ class Glm4MoeDetector(BaseFormatDetector):
                         # Remove the completed tool call from buffer
                         self._buffer = current_text[partial_match.end(3) :]
 
-                        result = StreamingParseResult(normal_text="", calls=calls)
+                        result = StreamingParseResult(
+                            normal_text=normal_text, calls=calls
+                        )
                         self.current_tool_id += 1
                         self._last_arguments = ""
                         self.current_tool_name_sent = False
@@ -605,11 +616,11 @@ class Glm4MoeDetector(BaseFormatDetector):
                         self._reset_streaming_state()
                         return result
 
-            return StreamingParseResult(normal_text="", calls=calls)
+            return StreamingParseResult(normal_text=normal_text, calls=calls)
 
         except Exception as e:
             logger.error(f"Error in parse_streaming_increment: {e}", exc_info=True)
-            return StreamingParseResult(normal_text=current_text)
+            return StreamingParseResult(normal_text=normal_text + current_text)
 
     def _parse_argument_pairs(
         self, pairs: List[Tuple[str, str]], func_name: str, tools: List[Tool]

--- a/test/registered/unit/function_call/test_function_call_parser.py
+++ b/test/registered/unit/function_call/test_function_call_parser.py
@@ -3203,6 +3203,79 @@ class TestGlm4MoeDetector(unittest.TestCase):
         self.assertIsInstance(value, dict)
         self.assertEqual(value, {"pattern": "\\d+"})
 
+    # -- Streaming: normal text coalesced with the tool-call opener --
+
+    def _stream_collect(self, chunks):
+        """Feed chunks to a fresh detector; return (normal_text, calls by index)."""
+        detector = type(self.detector)()
+        normal_text = ""
+        tool_calls_by_index = {}
+        for chunk in chunks:
+            result = detector.parse_streaming_increment(chunk, self.tools)
+            normal_text += result.normal_text
+            for call in result.calls:
+                if call.tool_index is not None:
+                    entry = tool_calls_by_index.setdefault(
+                        call.tool_index, {"name": "", "parameters": ""}
+                    )
+                    if call.name:
+                        entry["name"] = call.name
+                    if call.parameters:
+                        entry["parameters"] += call.parameters
+        return normal_text, tool_calls_by_index
+
+    def test_streaming_normal_text_in_same_chunk_as_tool_call_start(self):
+        """Normal text sharing an increment with the bot_token must survive.
+
+        Coalesced deltas (--stream-interval > 1, speculative decoding, or the
+        final flush) can carry "Sure, ...\n<tool_call>get_weather\n..." in one
+        chunk; the text before the bot_token used to be silently dropped.
+        """
+        chunks = [
+            "Sure, let me check the weather.\n<tool_call>get_weather\n<arg_key>city</arg_key>\n<arg_value>Beijing</arg_value>\n</tool_call>",
+            "",
+        ]
+        normal_text, tool_calls = self._stream_collect(chunks)
+        self.assertIn("Sure, let me check the weather.", normal_text)
+        self.assertNotIn("<tool_call>", normal_text)
+        self.assertNotIn("<arg_key>", normal_text)
+        self.assertEqual(normal_text.count("Sure"), 1)
+        self.assertEqual(len(tool_calls), 1)
+        self.assertEqual(tool_calls[0]["name"], "get_weather")
+        self.assertEqual(json.loads(tool_calls[0]["parameters"]), {"city": "Beijing"})
+
+    def test_streaming_normal_text_char_by_char(self):
+        """Control: the same prose+tool stream fed one character at a time."""
+        text = (
+            "Sure, let me check the weather.\n"
+            "<tool_call>get_weather\n<arg_key>city</arg_key>\n"
+            "<arg_value>Beijing</arg_value>\n</tool_call>"
+        )
+        normal_text, tool_calls = self._stream_collect(list(text) + ["", ""])
+        self.assertIn("Sure, let me check the weather.", normal_text)
+        self.assertNotIn("<tool_call>", normal_text)
+        self.assertEqual(len(tool_calls), 1)
+        self.assertEqual(tool_calls[0]["name"], "get_weather")
+        self.assertEqual(json.loads(tool_calls[0]["parameters"]), {"city": "Beijing"})
+
+    def test_streaming_partial_bot_token_is_held_back(self):
+        """A partial bot_token at a chunk boundary must not leak as normal text."""
+        text = (
+            "Sure, let me check the weather.\n"
+            "<tool_call>get_weather\n<arg_key>city</arg_key>\n"
+            "<arg_value>Beijing</arg_value>\n</tool_call>"
+        )
+        split = text.find("<tool_call>") + len("<tool_call")
+        normal_text, _ = self._stream_collect([text[:split], ""])
+        self.assertNotIn("<tool_call", normal_text)
+        normal_text, tool_calls = self._stream_collect(
+            [text[:split], text[split:], "", ""]
+        )
+        self.assertIn("Sure, let me check the weather.", normal_text)
+        self.assertNotIn("<tool_call>", normal_text)
+        self.assertEqual(len(tool_calls), 1)
+        self.assertEqual(tool_calls[0]["name"], "get_weather")
+
 
 class TestGlm47MoeDetector(unittest.TestCase):
     def setUp(self):
@@ -4863,6 +4936,83 @@ class TestQwen25Detector(unittest.TestCase):
         self.assertEqual(len(result), 2, f"Expected 2 tool calls, got {len(result)}")
         cities = [json.loads(result[i]["parameters"])["city"] for i in sorted(result)]
         self.assertEqual(cities, ["NYC", "LA"])
+
+    # -- Streaming: normal text coalesced with the tool-call opener --
+
+    def _stream_collect(self, chunks):
+        """Feed chunks to a fresh detector; return (normal_text, calls by index)."""
+        detector = type(self.detector)()
+        normal_text = ""
+        tool_calls_by_index = {}
+        for chunk in chunks:
+            result = detector.parse_streaming_increment(chunk, self.tools)
+            normal_text += result.normal_text
+            for call in result.calls:
+                if call.tool_index is not None:
+                    entry = tool_calls_by_index.setdefault(
+                        call.tool_index, {"name": "", "parameters": ""}
+                    )
+                    if call.name:
+                        entry["name"] = call.name
+                    if call.parameters:
+                        entry["parameters"] += call.parameters
+        return normal_text, tool_calls_by_index
+
+    def test_streaming_normal_text_in_same_chunk_as_tool_call_start(self):
+        """Normal text sharing an increment with the bot_token must survive.
+
+        Coalesced deltas (--stream-interval > 1, speculative decoding, or the
+        final flush) can carry "Sure, ...\n<tool_call>\n{...}" in one chunk;
+        the text before the bot_token used to be silently dropped.
+        """
+        chunks = [
+            'Sure, let me check the weather.\n<tool_call>\n{"name": "get_current_weather", "arguments": {"city": "NYC", "state": "NY", "unit": "fahrenheit"}}\n</tool_call>',
+            "",
+            "",
+        ]
+        normal_text, tool_calls = self._stream_collect(chunks)
+        self.assertIn("Sure, let me check the weather.", normal_text)
+        self.assertNotIn("<tool_call>", normal_text)
+        self.assertEqual(normal_text.count("Sure"), 1)
+        self.assertEqual(len(tool_calls), 1)
+        self.assertEqual(tool_calls[0]["name"], "get_current_weather")
+        self.assertEqual(
+            json.loads(tool_calls[0]["parameters"]),
+            {"city": "NYC", "state": "NY", "unit": "fahrenheit"},
+        )
+
+    def test_streaming_normal_text_char_by_char(self):
+        """Control: the same prose+tool stream fed one character at a time."""
+        text = (
+            "Sure, let me check the weather.\n"
+            '<tool_call>\n{"name": "get_current_weather", "arguments": {"city": "NYC", "state": "NY", "unit": "fahrenheit"}}\n</tool_call>'
+        )
+        normal_text, tool_calls = self._stream_collect(list(text) + ["", ""])
+        self.assertIn("Sure, let me check the weather.", normal_text)
+        self.assertNotIn("<tool_call>", normal_text)
+        self.assertEqual(len(tool_calls), 1)
+        self.assertEqual(tool_calls[0]["name"], "get_current_weather")
+        self.assertEqual(
+            json.loads(tool_calls[0]["parameters"]),
+            {"city": "NYC", "state": "NY", "unit": "fahrenheit"},
+        )
+
+    def test_streaming_partial_bot_token_is_held_back(self):
+        """A partial bot_token at a chunk boundary must not leak as normal text."""
+        text = (
+            "Sure, let me check the weather.\n"
+            '<tool_call>\n{"name": "get_current_weather", "arguments": {"city": "NYC", "state": "NY", "unit": "fahrenheit"}}\n</tool_call>'
+        )
+        split = text.find("<tool_call>") + len("<tool_call")
+        normal_text, _ = self._stream_collect([text[:split], ""])
+        self.assertNotIn("<tool_call", normal_text)
+        normal_text, tool_calls = self._stream_collect(
+            [text[:split], text[split:], "", ""]
+        )
+        self.assertIn("Sure, let me check the weather.", normal_text)
+        self.assertNotIn("<tool_call>", normal_text)
+        self.assertEqual(len(tool_calls), 1)
+        self.assertEqual(tool_calls[0]["name"], "get_current_weather")
 
 
 class TestGemma4Detector(unittest.TestCase):


### PR DESCRIPTION
## Problem

Streaming tool-call detectors built on `BaseFormatDetector` (qwen25 and other JSON-array formats) and `Glm4MoeDetector` silently dropped assistant prose that arrived in the same streaming increment as the `bot_token`, so `Sure, let me check. <tool_call>...` lost `Sure, let me check. `. This is reachable with `--stream-interval > 1`, multi-token speculative-decode deltas, or the final flush that emits all pending tokens in one event.

## Fix

Emit the text before the `bot_token` as `normal_text` when entering tool-call mode and trim the buffer at the `bot_token`, mirroring the in-tree `HermesDetector` / `Glm47MoeDetector` behavior and the earlier KimiK2 fix (#25071). Partial `bot_token` holdback, pure-prose increments, and parallel tool calls are unchanged.

## Tests

New streaming tests cover the coalesced, char-by-char, and partial-opener cases for `Qwen25Detector` and `Glm4MoeDetector`. Targeted runs of the touched and adjacent detector classes (`Qwen25`, `Glm4Moe`, `Glm47Moe`, `Hermes`, `BaseFormatDetector`, `JsonArrayParser`) all pass.

## Known pre-existing interactions (out of scope)

- A `JsonArrayParser` stream over a bare object with a nested array value already stalls on `main`; with this change it emits the JSON prefix as `normal_text` and still fails to produce a call. Both behaviors are broken; all working paths are unchanged.
- The new partial-opener tests use containment assertions on the call payload rather than exact-equality on the full streamed output, because on `main` the one-shot path swallows the preamble prose (the very bug this PR fixes), so exact equality against a straddled stream fails on `main` via `normal_text`. The tool-call payload itself is unaffected by chunking: aggregated `{name, parameters}` per call is byte-identical between one-shot and every possible two-chunk split (checked exhaustively over all split positions plus char-by-char streaming for both detectors). An earlier revision of this note claimed a straddle-related argument drop on `main`; that claim was retracted after re-testing — it was an artifact of an uneven trailing-flush count between the two compared streams.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32038248044](https://github.com/sgl-project/sglang/actions/runs/32038248044)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32038248022](https://github.com/sgl-project/sglang/actions/runs/32038248022)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->