### PR TITLE
[AMD][Fix] Route MoRI through the Qwen MoE all-to-all path

### DIFF
--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -151,6 +151,7 @@ def can_fuse_shared_expert(
         or getattr(config, "shared_expert_intermediate_size", 0) <= 0
         or config.shared_expert_intermediate_size != config.moe_intermediate_size
         or get_moe_a2a_backend().is_deepep()
+        or get_moe_a2a_backend().is_mori()
     ):
         return False
 
@@ -326,6 +327,7 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
                     dict(tp_rank=0, tp_size=1)
                     if (
                         get_moe_a2a_backend().is_deepep()
+                        or get_moe_a2a_backend().is_mori()
                         or get_moe_a2a_backend().is_flashinfer()
                     )
                     else {}
@@ -344,7 +346,7 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
         else:
             self.shared_expert_gate = torch.nn.Linear(config.hidden_size, 1, bias=False)
 
-        if get_moe_a2a_backend().is_deepep():
+        if get_moe_a2a_backend().is_deepep() or get_moe_a2a_backend().is_mori():
             # TODO: we will support tp < ep in the future
             self.ep_size = get_parallel().moe_ep_size
             self.num_experts = (
@@ -560,7 +562,7 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
         num_tokens, hidden_dim = hidden_states.shape
         hidden_states = hidden_states.view(-1, hidden_dim)
 
-        if get_moe_a2a_backend().is_deepep():
+        if get_moe_a2a_backend().is_deepep() or get_moe_a2a_backend().is_mori():
             return self._forward_deepep(hidden_states, forward_batch)
 
         use_fused_gate = (

--- a/test/registered/unit/models/test_shared_experts_fusion_gates.py
+++ b/test/registered/unit/models/test_shared_experts_fusion_gates.py
@@ -22,7 +22,7 @@ from sglang.srt.runtime_context import get_context, get_parallel
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
-register_cpu_ci(est_time=6, suite="base-a-test-cpu")
+register_cpu_ci(est_time=7, suite="base-a-test-cpu")
 
 
 def _quant(name: str):
@@ -497,6 +497,45 @@ class TestWrapperEntryClassGates(_FusionGateCase):
         self.assertIsNone(
             seen["quant"], "the MTP module ships unquantized in that checkpoint"
         )
+
+
+class TestA2ABackendGate(_FusionGateCase):
+    """`can_fuse_shared_expert` must refuse for every DeepEP-class backend it
+    is wired for. MoRI runs the same per-rank EP expert layout as DeepEP, so a
+    fused shared expert would occupy a global slot the layers never allocate —
+    the routed experts then read the wrong rows and accuracy collapses."""
+
+    def _config(self):
+        return SimpleNamespace(
+            model_type="qwen3_5_moe_text",
+            shared_expert_intermediate_size=1024,
+            moe_intermediate_size=1024,
+        )
+
+    def _use_backend(self, name: str):
+        from sglang.srt.layers.moe.utils import MoeA2ABackend
+        from sglang.srt.runtime_context import get_flags
+
+        moe = get_flags().moe
+        previous = moe.a2a_backend
+        moe.a2a_backend = MoeA2ABackend(name)
+        self.addCleanup(setattr, moe, "a2a_backend", previous)
+
+    def test_the_a2a_backends_refuse_fusion(self):
+        from sglang.srt.models.qwen2_moe import can_fuse_shared_expert
+
+        self._seed()
+        for backend in ("deepep", "mori"):
+            with self.subTest(backend=backend):
+                self._use_backend(backend)
+                self.assertFalse(can_fuse_shared_expert(self._config(), None))
+
+    def test_a_plain_tp_deployment_still_fuses(self):
+        from sglang.srt.models.qwen2_moe import can_fuse_shared_expert
+
+        self._seed()
+        self._use_backend("none")
+        self.assertTrue(can_fuse_shared_expert(self._config(), None))
 
 
 class TestFamiliesWithoutAGate(_FusionGateCase):


### PR DESCRIPTION
## Motivation

Serving **Qwen3.5-397B-A17B-MXFP4** with `--moe-a2a-backend mori` on MI355X (TP2 / EP2) produces near-zero GSM8K accuracy.

The Qwen2/Qwen3 MoE gates key on `get_moe_a2a_backend().is_deepep()`, which recognises **only** pure DeepEP. MoRI is a DeepEP-class backend and needs the same per-rank EP expert layout, so under MoRI the block silently fell through to the plain-TP path:

- the shared expert stayed sharded by TP, so each token computed only one shard and lost the rest of the shared-expert contribution;
- `can_fuse_shared_expert` still allowed the fusion, placing the shared expert in a **global** slot that the per-rank EP layers never allocate;
- the block never entered `_forward_deepep()`, so the routed experts never went through the MoRI dispatch/combine at all.

The corrupted first token poisons everything generated after it.

## Modifications

Add `get_moe_a2a_backend().is_mori()` alongside the existing `is_deepep()` at the four gates in `python/sglang/srt/models/qwen2_moe.py`: `can_fuse_shared_expert`, the shared-expert TP override, the EP layout branch, and the forward dispatch.

The remaining DeepEP-class backends (Mooncake, PPLX) are deliberately **not** included — they have no Qwen MoE coverage to validate the change against, so `is_mori()` keeps the blast radius to the backend that was actually tested.

Unit test added to `test/registered/unit/models/test_shared_experts_fusion_gates.py` pinning that `can_fuse_shared_expert` refuses for both `deepep` and `mori`, and still fuses on plain TP.

## Note on decode CUDA graph

This PR intentionally does **not** disable the decode CUDA graph for MoRI normal mode. MoRI normal is CUDA-graph safe: `mori_cpp.build_args` returns an args struct whose values (input/indices pointers, `curRankNumToken`, and the preallocated shmem buffer pointers) are snapshotted per graph node by `hipModuleLaunchKernel`, and every comm buffer has fixed capacity and a stable address.

I verified this on hardware. With the routing gates reverted, GSM8K is **0.000 in both eager and graph** — the earlier "eager works, graph breaks" reading was a misattribution of this routing bug:

| routing gates | decode CUDA graph | GSM8K |
|---|---|---|
| broken (`is_deepep()` only) | on | 0.000 (invalid 0.625) |
| broken (`is_deepep()` only) | **off (eager)** | **0.000** (invalid 0.600) |
| fixed (this PR) | on | 0.967 |

Disabling the decode graph also costs spec-decode acceptance, which is what breaks `test/registered/amd/test_moriep_small.py::TestMTP::test_gsm8k` (bar 2.8; passes on `main` at 3.0077). Reproduced independently on Qwen3.5 with EAGLE MTP — same server, only the graph flag differs:

| decode CUDA graph | accept length |
|---|---|
| on | **3.47 – 3.59** |
| off | 2.59 – 2.91 |

## Accuracy Tests

Qwen3.5-397B-A17B-MXFP4, 2x MI355X, TP2 / EP2, `--moe-a2a-backend mori` (deepep_mode normal), aiter attention, fp8 KV cache, decode CUDA graph **on**:

| Questions | Parallel | Accuracy |
|---|---|---|
| 60 | 30 | 0.967 |
| 400 | 64 | 0.925 |
| 1000 | 200 | **0.932** |

With EAGLE MTP (3 steps, topk 1, 4 draft tokens), 200 questions / parallel 30: accuracy **0.935**, accept length **~3.5**.

Before this change, the same configuration scores 0.000.

## Speed Tests and Profiling

GSM8K 1000 questions / parallel 200, same config: **1552.6 tok/s** output throughput.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32038594132](https://github.com/sgl-project/sglang/actions/runs/32038594132)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32038660480](https://github.com/sgl-project/sglang/actions/runs/32038660480)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->