### PR TITLE
[Fix] Extend RoPE cos/sin cache with the subclass inv_freq and row scaling

### DIFF
--- a/python/sglang/srt/layers/rotary_embedding/base.py
+++ b/python/sglang/srt/layers/rotary_embedding/base.py
@@ -171,6 +171,11 @@ class RotaryEmbedding(BaseFusedOp):
     def _compute_cos_sin_cache(self) -> torch.Tensor:
         """Compute the cos and sin cache."""
         inv_freq = self._compute_inv_freq(self.base)
+        # Keep the inv_freq that built the native cache so that
+        # _ensure_cos_sin_cache_length() can extend it consistently.
+        # Registered as a non-persistent buffer (state_dict unchanged) so
+        # meta/IPC load paths materialize it alongside cos_sin_cache.
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
         t = torch.arange(self.max_position_embeddings, dtype=torch.float)
 
         freqs = torch.einsum("i,j -> ij", t, inv_freq)
@@ -191,8 +196,22 @@ class RotaryEmbedding(BaseFusedOp):
         device = self.cos_sin_cache.device
         dtype = self.cos_sin_cache.dtype
 
-        # Compute inv_freq on same device
-        inv_freq = self._compute_inv_freq(self.base).to(device=device)
+        # Reuse the inv_freq that built the native cache instead of re-deriving
+        # it from self.base. Subclasses (e.g. YaRN/DeepSeek scaling, DynamicNTK
+        # with its adjusted base) build the native cache with a different
+        # inv_freq, and the extension rows must continue the native ones.
+        stored_inv_freq = getattr(self, "inv_freq", None)
+        has_stored_inv_freq = (
+            stored_inv_freq is not None and stored_inv_freq.device.type != "meta"
+        )
+        if has_stored_inv_freq:
+            inv_freq = stored_inv_freq.to(device=device)
+        else:
+            # Historical fallback: subclasses that build their native cache
+            # without storing the inv_freq they used (e.g. Grok, Gemma3) or
+            # meta-device loads that never materialized the stored tensor get
+            # exactly the old behavior: base-class math, no row scaling.
+            inv_freq = self._compute_inv_freq(self.base).to(device=device)
 
         # Incremental computation for new positions only
         start = cur_len
@@ -200,9 +219,21 @@ class RotaryEmbedding(BaseFusedOp):
         if t_new.numel() == 0:
             return
 
+        if has_stored_inv_freq:
+            # Native rows of the scaling variants are scaled: the YaRN family
+            # multiplies cos/sin by mscale and LinearScaling divides time by the
+            # last block's scaling factor. Apply the same terms to extension rows.
+            time_scale = getattr(self, "_cache_time_scale", 1.0)
+            time_offset = getattr(self, "_cache_time_offset", 0.0)
+            if time_scale != 1.0 or time_offset != 0.0:
+                t_new = (t_new - time_offset) / time_scale
+            mscale = float(getattr(self, "mscale", 1.0))
+        else:
+            mscale = 1.0
+
         freqs_new = torch.einsum("i,j->ij", t_new, inv_freq)
-        cos_new = freqs_new.cos()
-        sin_new = freqs_new.sin()
+        cos_new = freqs_new.cos() * mscale
+        sin_new = freqs_new.sin() * mscale
         new_rows = torch.cat((cos_new, sin_new), dim=-1).to(dtype=dtype)
 
         # Update cache with new rows
@@ -533,6 +564,7 @@ class LinearScalingRotaryEmbedding(RotaryEmbedding):
 
     def _compute_cos_sin_cache(self) -> torch.Tensor:
         inv_freq = self._compute_inv_freq(self.base)
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
         cache_list: List[torch.Tensor] = []
         # offsets to the next cache in a tensor.
         # Each offset corresponds to the same index in scaling_factors.
@@ -563,6 +595,10 @@ class LinearScalingRotaryEmbedding(RotaryEmbedding):
             for i, scaling_factor in enumerate(self.scaling_factors)
         }
         assert len(self.scaling_factors) == len(offsets)
+        # Cache extension continues the last scaling block: time keeps being
+        # divided by its scaling factor, relative to its block offset.
+        self._cache_time_scale = float(self.scaling_factors[-1])
+        self._cache_time_offset = float(offsets[-1])
         return torch.cat(cache_list, dim=0)
 
     @property

--- a/python/sglang/srt/layers/rotary_embedding/mrope.py
+++ b/python/sglang/srt/layers/rotary_embedding/mrope.py
@@ -479,6 +479,7 @@ class YaRNScalingMRotaryEmbedding(MRotaryEmbedding):
 
     def _compute_cos_sin_cache(self) -> torch.Tensor:
         inv_freq = self._compute_inv_freq(self.scaling_factor)
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
         t = torch.arange(
             self.max_position_embeddings * self.scaling_factor, dtype=torch.float32
         )

--- a/python/sglang/srt/layers/rotary_embedding/rope_variant.py
+++ b/python/sglang/srt/layers/rotary_embedding/rope_variant.py
@@ -404,6 +404,7 @@ class DeepseekScalingRotaryEmbedding(RotaryEmbedding):
 
     def _compute_cos_sin_cache(self) -> torch.Tensor:
         inv_freq = self._compute_inv_freq(self.scaling_factor)
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
         t = torch.arange(
             self.max_position_embeddings * self.scaling_factor,
             device=self.device,
@@ -418,6 +419,37 @@ class DeepseekScalingRotaryEmbedding(RotaryEmbedding):
             self.cos_cached_total = torch.cos(emb) * self.mscale
             self.sin_cached_total = torch.sin(emb) * self.mscale
         return cache
+
+    def _ensure_cos_sin_cache_length(self, max_pos: int):
+        super()._ensure_cos_sin_cache_length(max_pos)
+        # On NPU the cache is consumed through cos/sin_cached_total (emb =
+        # cat(freqs, freqs), rows scaled by mscale), which the generic
+        # extension does not grow. Extend it with the same formula.
+        if not _is_npu:
+            return
+        total = getattr(self, "cos_cached_total", None)
+        if total is None:
+            return
+        # Align with the generic cache the super() call just grew (length >
+        # max_pos), not with max_pos itself, so the two stay in lockstep.
+        target_len = self.cos_sin_cache.size(0)
+        if target_len <= total.size(0):
+            return
+        inv_freq = getattr(self, "inv_freq", None)
+        if inv_freq is None or inv_freq.device.type == "meta":
+            return
+        inv_freq = inv_freq.to(device=total.device)
+        start = total.size(0)
+        t_new = torch.arange(
+            start, target_len, dtype=torch.float32, device=total.device
+        )
+        freqs_new = torch.einsum("i,j->ij", t_new, inv_freq)
+        emb = torch.cat((freqs_new, freqs_new), dim=-1)
+        mscale = float(getattr(self, "mscale", 1.0))
+        self.cos_cached_total = torch.cat((total, torch.cos(emb) * mscale), dim=0)
+        self.sin_cached_total = torch.cat(
+            (self.sin_cached_total, torch.sin(emb) * mscale), dim=0
+        )
 
     def get_cos_cached_total(self):
         return self.cos_cached_total
@@ -667,6 +699,7 @@ class DynamicNTKAlphaRotaryEmbedding(RotaryEmbedding):
             self.rotary_dim / (self.rotary_dim - 2)
         )
         inv_freq = self._compute_inv_freq(base)
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
         t = torch.arange(max_len, dtype=torch.float)
         freqs = torch.einsum("i,j -> ij", t, inv_freq)
         cos = freqs.cos()
@@ -866,6 +899,7 @@ class DynamicNTKScalingRotaryEmbedding(RotaryEmbedding):
             - (self.scaling_factor - 1)
         ) ** (self.rotary_dim / (self.rotary_dim - 2))
         inv_freq = self._compute_inv_freq(base)
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
         t = torch.arange(max_len, dtype=torch.float)
         freqs = torch.einsum("i,j -> ij", t, inv_freq)
         cos = freqs.cos()

--- a/python/sglang/srt/layers/rotary_embedding/yarn.py
+++ b/python/sglang/srt/layers/rotary_embedding/yarn.py
@@ -136,6 +136,7 @@ class YaRNScalingRotaryEmbedding(RotaryEmbedding):
 
     def _compute_cos_sin_cache(self) -> torch.Tensor:
         inv_freq = self._compute_inv_freq(self.scaling_factor)
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
         t = torch.arange(
             self.max_position_embeddings * self.scaling_factor, dtype=torch.float32
         )

--- a/test/registered/unit/layers/test_rotary_embedding_cache_extension.py
+++ b/test/registered/unit/layers/test_rotary_embedding_cache_extension.py
@@ -1,0 +1,356 @@
+"""Unit tests for RoPE cos_sin_cache extension across RotaryEmbedding variants.
+
+`_ensure_cos_sin_cache_length()` grows the cos/sin cache at load time to the
+reserved context length (see `reserve_rope_cache` in srt/utils/common.py).
+The extension rows must be a faithful continuation of the natively built
+cache: the same inv_freq and the same per-variant row scaling (YaRN-family
+mscale, LinearScaling time scaling).
+"""
+
+import unittest
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+import sglang.srt.layers.rotary_embedding.base as rotary_base
+import sglang.srt.layers.rotary_embedding.mrope as rotary_mrope
+from sglang.srt.layers.rotary_embedding.base import (
+    LinearScalingRotaryEmbedding,
+    RotaryEmbedding,
+)
+from sglang.srt.layers.rotary_embedding.mrope import YaRNScalingMRotaryEmbedding
+from sglang.srt.layers.rotary_embedding.rope_variant import (
+    DeepseekScalingRotaryEmbedding,
+    DynamicNTKAlphaRotaryEmbedding,
+    DynamicNTKScalingRotaryEmbedding,
+    Llama3RotaryEmbedding,
+)
+from sglang.srt.layers.rotary_embedding.yarn import YaRNScalingRotaryEmbedding
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+_FAKE_EXEC = SimpleNamespace(deterministic=SimpleNamespace(rl_on_policy_target=None))
+
+
+@contextmanager
+def _default_exec_context():
+    """Skip the published runtime-context requirement (CPU unit tests)."""
+    with (
+        patch.object(rotary_base, "get_exec", lambda: _FAKE_EXEC),
+        patch.object(rotary_mrope, "get_exec", lambda: _FAKE_EXEC),
+    ):
+        yield
+
+
+def _make_base():
+    return RotaryEmbedding(64, 64, 1024, 10000, True, torch.float32)
+
+
+def _make_yarn():
+    return YaRNScalingRotaryEmbedding(64, 64, 1024, 10000, True, 4.0, torch.float32)
+
+
+def _make_deepseek():
+    return DeepseekScalingRotaryEmbedding(
+        64, 64, 1024, 10000, True, 4.0, torch.float32, device="cpu"
+    )
+
+
+def _make_yarn_mrope():
+    return YaRNScalingMRotaryEmbedding(
+        64, 64, 1024, 10000, True, 4.0, torch.float32, mrope_section=[8, 12, 12]
+    )
+
+
+def _make_dynamic_ntk():
+    return DynamicNTKScalingRotaryEmbedding(
+        64, 64, 1024, 10000, True, 4.0, torch.float32
+    )
+
+
+def _make_dynamic_ntk_alpha():
+    return DynamicNTKAlphaRotaryEmbedding(
+        64, 64, 1024, 10000, True, 30.0, torch.float32
+    )
+
+
+def _make_linear():
+    return LinearScalingRotaryEmbedding(64, 64, 1024, 10000, True, [4.0], torch.float32)
+
+
+def _make_linear_multi():
+    # Blocks: [0, 2048) at scale 2.0, [2048, 3072) at scale 1.0. The last
+    # block has scale 1.0 but offset 2048, so extension rows must still be
+    # shifted by the block offset.
+    return LinearScalingRotaryEmbedding(
+        64, 64, 1024, 10000, True, [2.0, 1.0], torch.float32
+    )
+
+
+def _make_llama3():
+    return Llama3RotaryEmbedding(
+        64, 64, 1024, 10000, True, torch.float32, 8.0, 1.0, 4.0, 2048
+    )
+
+
+def _ntk_adjusted_base(rope):
+    max_len = rope.max_position_embeddings * rope.scaling_factor
+    return rope.base * (
+        (rope.scaling_factor * max_len / rope.max_position_embeddings)
+        - (rope.scaling_factor - 1)
+    ) ** (rope.rotary_dim / (rope.rotary_dim - 2))
+
+
+def _alpha_adjusted_base(rope):
+    return rope.base * rope.scaling_alpha ** (rope.rotary_dim / (rope.rotary_dim - 2))
+
+
+# name, factory, ground-truth inv_freq source, mscale getter, time scaling
+_CASES = [
+    ("base", _make_base, lambda r: r._compute_inv_freq(r.base), None, (1.0, 0.0)),
+    (
+        "yarn",
+        _make_yarn,
+        lambda r: r._compute_inv_freq(r.scaling_factor),
+        "mscale",
+        (1.0, 0.0),
+    ),
+    (
+        "deepseek_scaling",
+        _make_deepseek,
+        lambda r: r._compute_inv_freq(r.scaling_factor),
+        "mscale",
+        (1.0, 0.0),
+    ),
+    (
+        "yarn_mrope",
+        _make_yarn_mrope,
+        lambda r: r._compute_inv_freq(r.scaling_factor),
+        "mscale",
+        (1.0, 0.0),
+    ),
+    (
+        "dynamic_ntk",
+        _make_dynamic_ntk,
+        lambda r: r._compute_inv_freq(_ntk_adjusted_base(r)),
+        None,
+        (1.0, 0.0),
+    ),
+    (
+        "dynamic_ntk_alpha",
+        _make_dynamic_ntk_alpha,
+        lambda r: r._compute_inv_freq(_alpha_adjusted_base(r)),
+        None,
+        (1.0, 0.0),
+    ),
+    (
+        "linear_scaling",
+        _make_linear,
+        lambda r: r._compute_inv_freq(r.base),
+        None,
+        (4.0, 0.0),
+    ),
+    (
+        "llama3",
+        _make_llama3,
+        lambda r: r._compute_inv_freq(r.base),
+        None,
+        (1.0, 0.0),
+    ),
+    (
+        "linear_scaling_multi_factor",
+        _make_linear_multi,
+        lambda r: r._compute_inv_freq(r.base),
+        None,
+        (1.0, 2048.0),
+    ),
+]
+
+_NEEDED = 4096
+
+
+def _continuation_rows(
+    inv_freq, start, end, mscale=1.0, time_scale=1.0, time_offset=0.0
+):
+    t = torch.arange(start, end, dtype=torch.float32)
+    if time_scale != 1.0 or time_offset != 0.0:
+        t = (t - time_offset) / time_scale
+    freqs = torch.einsum("i,j->ij", t, inv_freq.float())
+    return torch.cat((freqs.cos() * mscale, freqs.sin() * mscale), dim=-1)
+
+
+class TestRotaryEmbeddingCacheExtension(CustomTestCase):
+    def test_extension_rows_continue_native_cache(self):
+        for name, make, inv_freq_fn, mscale_attr, (time_scale, time_offset) in _CASES:
+            with self.subTest(case=name):
+                with _default_exec_context():
+                    rope = make()
+                    native_len = rope.cos_sin_cache.shape[0]
+                    native_cache = rope.cos_sin_cache.clone()
+                    rope._ensure_cos_sin_cache_length(_NEEDED)
+                    # Ground truth: continue the native formula, i.e. the
+                    # subclass-scaled inv_freq and row scaling.
+                    mscale = getattr(rope, mscale_attr) if mscale_attr else 1.0
+                    gt = _continuation_rows(
+                        inv_freq_fn(rope),
+                        native_len,
+                        rope.cos_sin_cache.shape[0],
+                        mscale=mscale,
+                        time_scale=time_scale,
+                        time_offset=time_offset,
+                    )
+                new_len = rope.cos_sin_cache.shape[0]
+                self.assertGreaterEqual(new_len, _NEEDED)
+                # The natively computed rows must stay bit-identical.
+                self.assertTrue(
+                    torch.equal(rope.cos_sin_cache[:native_len], native_cache),
+                    f"{name}: extension modified native rows",
+                )
+                ext = rope.cos_sin_cache[native_len:]
+                self.assertTrue(
+                    torch.equal(ext, gt),
+                    f"{name}: max_abs_diff={(ext - gt).abs().max().item()}",
+                )
+
+    def test_extension_matches_fresh_longer_native_cache(self):
+        # For variants whose inv_freq does not depend on the cache length,
+        # extending a short-native cache must reproduce the rows of a freshly
+        # constructed longer-native cache bit-for-bit.
+        with _default_exec_context():
+            short = _make_base()
+            short._ensure_cos_sin_cache_length(4000)
+            long = RotaryEmbedding(64, 64, 4000, 10000, True, torch.float32)
+        self.assertTrue(
+            torch.equal(short.cos_sin_cache[1024:4000], long.cos_sin_cache[1024:4000])
+        )
+
+        with _default_exec_context():
+            short = _make_linear()
+            short._ensure_cos_sin_cache_length(8000)
+            long = LinearScalingRotaryEmbedding(
+                64, 64, 2000, 10000, True, [4.0], torch.float32
+            )
+        self.assertTrue(
+            torch.equal(short.cos_sin_cache[4096:8000], long.cos_sin_cache[4096:8000])
+        )
+
+    def test_grok_style_override_falls_back_to_historical_math(self):
+        # Grok's ScalingRotaryEmbedding overrides _compute_cos_sin_cache
+        # without storing the inv_freq it used, and its native rows are
+        # unscaled (its mscale multiply is commented out). Extension must
+        # not crash and must reproduce the historical base-class math with
+        # no row scaling -- in particular NOT the subclass mscale.
+        from sglang.srt.models.grok import ScalingRotaryEmbedding
+
+        with _default_exec_context():
+            rope = ScalingRotaryEmbedding(64, 64, 1024, 10000, True, 4.0, torch.float32)
+            self.assertFalse(hasattr(rope, "inv_freq"))
+            assert rope.mscale != 1.0
+            native_len = rope.cos_sin_cache.shape[0]
+            native_cache = rope.cos_sin_cache.clone()
+            rope._ensure_cos_sin_cache_length(_NEEDED)
+            new_len = rope.cos_sin_cache.shape[0]
+            gt = _continuation_rows(
+                rope._compute_inv_freq(rope.base), native_len, new_len
+            )
+        self.assertGreaterEqual(new_len, _NEEDED)
+        self.assertTrue(torch.equal(rope.cos_sin_cache[:native_len], native_cache))
+        self.assertTrue(
+            torch.equal(rope.cos_sin_cache[native_len:], gt),
+            f"max_abs_diff={(rope.cos_sin_cache[native_len:] - gt).abs().max().item()}",
+        )
+
+    def test_meta_inv_freq_falls_back_to_base_math(self):
+        # A meta/IPC load that never materialized the stored inv_freq buffer
+        # must fall back to the historical base-class math without crashing,
+        # and must not apply the subclass row scaling.
+        with _default_exec_context():
+            rope = _make_yarn()
+            native_len = rope.cos_sin_cache.shape[0]
+            native_cache = rope.cos_sin_cache.clone()
+            rope.inv_freq = torch.empty_like(rope.inv_freq, device="meta")
+            rope._ensure_cos_sin_cache_length(_NEEDED)
+            new_len = rope.cos_sin_cache.shape[0]
+            gt = _continuation_rows(
+                rope._compute_inv_freq(rope.base), native_len, new_len
+            )
+        self.assertGreaterEqual(new_len, _NEEDED)
+        self.assertTrue(torch.equal(rope.cos_sin_cache[:native_len], native_cache))
+        self.assertTrue(
+            torch.equal(rope.cos_sin_cache[native_len:], gt),
+            f"max_abs_diff={(rope.cos_sin_cache[native_len:] - gt).abs().max().item()}",
+        )
+
+    def test_deepseek_npu_totals_extension(self):
+        # On NPU, DeepseekScalingRotaryEmbedding also serves
+        # cos/sin_cached_total (emb = cat(freqs, freqs), rows * mscale).
+        # The extension must grow them with the same native formula.
+        import sglang.srt.layers.rotary_embedding.rope_variant as rotary_variant
+
+        with _default_exec_context(), patch.object(rotary_variant, "_is_npu", True):
+            rope = _make_deepseek()
+            native_len = rope.cos_cached_total.shape[0]
+            self.assertEqual(native_len, rope.cos_sin_cache.shape[0])
+            rope._ensure_cos_sin_cache_length(6000)
+            new_total_len = rope.cos_cached_total.shape[0]
+            inv_freq = rope.inv_freq
+            mscale = rope.mscale
+
+        # Totals track the generic cache length in lockstep (always covering
+        # the requested max_pos), not max_pos itself.
+        self.assertEqual(new_total_len, rope.cos_sin_cache.shape[0])
+        self.assertGreaterEqual(new_total_len, 6000)
+        t = torch.arange(native_len, new_total_len, dtype=torch.float32)
+        freqs = torch.einsum("i,j->ij", t, inv_freq.float())
+        emb = torch.cat((freqs, freqs), dim=-1)
+        gt_cos = torch.cos(emb) * mscale
+        gt_sin = torch.sin(emb) * mscale
+        self.assertTrue(
+            torch.equal(rope.cos_cached_total[native_len:], gt_cos),
+            "cos_cached_total extension rows != native formula",
+        )
+        self.assertTrue(
+            torch.equal(rope.sin_cached_total[native_len:], gt_sin),
+            "sin_cached_total extension rows != native formula",
+        )
+
+    def test_inv_freq_is_non_persistent_buffer(self):
+        # The stored tensor must be a registered non-persistent buffer:
+        # plain attributes never materialize on meta/IPC load paths, and a
+        # persistent buffer would change state_dict.
+        with _default_exec_context():
+            for name, make, _, _, _ in _CASES:
+                if name == "llama3":
+                    continue
+                rope = make()
+                self.assertIn(
+                    "inv_freq",
+                    dict(rope.named_buffers()),
+                    f"{name}: inv_freq must be a registered buffer",
+                )
+                self.assertNotIn(
+                    "inv_freq",
+                    rope.state_dict(),
+                    f"{name}: inv_freq must not be persistent",
+                )
+
+    def test_stored_inv_freq_matches_native_formula(self):
+        # The stored inv_freq must be the one the subclass actually used for
+        # the native cache, not the base-class derivation.
+        with _default_exec_context():
+            for name, make, inv_freq_fn, _, _ in _CASES:
+                if name == "llama3":
+                    continue
+                rope = make()
+                self.assertTrue(
+                    torch.equal(rope.inv_freq, inv_freq_fn(rope)),
+                    f"{name}: stored inv_freq != native inv_freq",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`_ensure_cos_sin_cache_length()` grows the RoPE cos/sin cache at load time (reserved context length + speculative margin). It re-derived the extension rows with `self._compute_inv_freq(self.base)`, which is only correct for the base class: YaRN/DeepSeek scaling define `_compute_inv_freq(scaling_factor)`, DynamicNTK and DynamicNTKAlpha build the native cache with an NTK-adjusted base, and LinearScaling divides time by the scaling factor. Extension rows therefore silently dropped the subclass scaling (max_abs_diff vs the native continuation up to ~2.14) — a silent miscalculation: the model runs fine but attends with wrong position embeddings on every extended row.

## Fix

Every `_compute_cos_sin_cache()` now stores the inv_freq it used, and `_ensure_cos_sin_cache_length()` reuses it and applies the same row scaling as the native rows (YaRN-family mscale, LinearScaling time scaling). Native caches are unchanged (bit-identical); extension rows now match the native-formula continuation bit-for-bit for all variants.

The stored inv_freq is a non-persistent registered buffer (state_dict unchanged) so meta/IPC load paths materialize it. If it is missing — Grok and other overrides build their native cache without storing it — or still sits on the meta device, the extension falls back to exactly the historical base-class math with no row scaling, so those paths keep the old behavior. LinearScaling now also applies the last block's offset when its factor is 1.0 (multi-factor caches), and the NPU-only cos/sin_cached_total of DeepseekScalingRotaryEmbedding is grown with the same native formula, tracking the generic cache length in lockstep. Llama4Vision's rank-3 complex cache is left untouched by this path.

## Tests

New `test/registered/unit/layers/test_rotary_embedding_cache_extension.py` covers, per variant (llama3, linear-scaling, yarn, deepseek-scaling, dynamic-NTK/alpha): native rows bit-identical to main, extension rows bit-identical to the native-formula continuation, repeated extension idempotence, missing/meta inv_freq fallback preserving historical behavior, NPU totals tracking the generic cache length, and the non-persistent buffer registration (`inv_freq` in `named_buffers()`, absent from `state_dict()`).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32038995540](https://github.com/sgl-project/sglang/actions/runs/32038995540)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32038995402](https://github.com/sgl-project/sglang/actions/runs/32038995402)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->