### PR TITLE
fix: fix: correct insert_sort logic in add_req_state for ignore_eos scheduling

### DIFF
--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -1096,10 +1096,11 @@ class PrefillAdder:
             if not insert_sort:
                 self.req_states.append((tokens_left, tokens_occupied))
             else:
-                i = 0
                 for i in range(len(self.req_states)):
                     if tokens_left <= self.req_states[i][0]:
                         break
+                else:
+                    i = len(self.req_states)
                 self.req_states.insert(i, (tokens_left, tokens_occupied))
 
         if self.req_states is None:


### PR DESCRIPTION
Clean rebase

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32042085845](https://github.com/sgl-project/sglang/actions/runs/32042085845)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32042085700](https://github.com/sgl-project/sglang/actions/runs/32042085700)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->