### PR TITLE
[Fix] Honor HiCache timeout with pending pool transfers

### DIFF
--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -1587,11 +1587,16 @@ class HiRadixCache(RadixCache):
             return can_terminate
 
         if len(operation.hash_value) == 0:
-            completed = False
+            kv_completed = False
         else:
-            completed = (
+            kv_completed = (
                 operation.completed_tokens == len(operation.hash_value) * self.page_size
             )
+
+        pool_transfers_completed = not getattr(
+            operation, "pool_transfers", None
+        ) or getattr(operation, "pool_transfers_done", True)
+        completed = kv_completed and pool_transfers_completed
 
         if self.prefetch_stop_policy == "wait_complete":
             can_terminate = completed
@@ -1600,13 +1605,6 @@ class HiRadixCache(RadixCache):
         else:
             # unknown prefetch stop policy, just return True
             return True
-
-        if (
-            completed
-            and getattr(operation, "pool_transfers", None)
-            and not getattr(operation, "pool_transfers_done", True)
-        ):
-            can_terminate = False
 
         operation_terminated = operation.is_terminated()
         states = torch.tensor(

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -1305,11 +1305,16 @@ class UnifiedRadixCache(BasePrefixCache):
             return True
 
         if len(operation.hash_value) == 0:
-            completed = False
+            kv_completed = False
         else:
-            completed = (
+            kv_completed = (
                 operation.completed_tokens == len(operation.hash_value) * self.page_size
             )
+
+        pool_transfers_completed = not getattr(
+            operation, "pool_transfers", None
+        ) or getattr(operation, "pool_transfers_done", True)
+        completed = kv_completed and pool_transfers_completed
 
         if self.prefetch_stop_policy == "wait_complete":
             can_terminate = completed
@@ -1319,13 +1324,6 @@ class UnifiedRadixCache(BasePrefixCache):
             )
         else:
             return True
-        if (
-            completed
-            and getattr(operation, "pool_transfers", None)
-            and not getattr(operation, "pool_transfers_done", True)
-        ):
-            can_terminate = False
-
         operation_terminated = operation.is_terminated()
         states = torch.tensor(
             [1 - int(can_terminate), int(operation_terminated)],

--- a/test/registered/unit/mem_cache/test_hicache_prefetch_termination.py
+++ b/test/registered/unit/mem_cache/test_hicache_prefetch_termination.py
@@ -75,9 +75,7 @@ class TestHiCachePrefetchTermination(unittest.TestCase):
                         has_pool_transfers=has_pool_transfers,
                         pool_transfers_done=pool_transfers_done,
                     )
-                    self.assertEqual(
-                        cache.can_terminate_prefetch(operation), expected
-                    )
+                    self.assertEqual(cache.can_terminate_prefetch(operation), expected)
 
     def test_terminated_operation_can_terminate_on_all_cache_types(self):
         for cache_type in self.CACHE_TYPES:

--- a/test/registered/unit/mem_cache/test_hicache_prefetch_termination.py
+++ b/test/registered/unit/mem_cache/test_hicache_prefetch_termination.py
@@ -1,0 +1,96 @@
+"""Unit tests for HiCache prefetch termination policies."""
+
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.mem_cache.hiradix_cache import HiRadixCache
+from sglang.srt.mem_cache.unified_radix_cache import UnifiedRadixCache
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestHiCachePrefetchTermination(unittest.TestCase):
+    CACHE_TYPES = (HiRadixCache, UnifiedRadixCache)
+    PAGE_SIZE = 16
+
+    def _build_cache(self, cache_type, policy, timed_out):
+        cache = object.__new__(cache_type)
+        cache.page_size = self.PAGE_SIZE
+        cache.prefetch_stop_policy = policy
+        cache._all_reduce_attn_groups = lambda tensor, op: None
+        cache.is_prefetch_timeout = lambda operation: timed_out
+        cache._prefetch_timeout_check_linear_func = lambda operation: timed_out
+        return cache
+
+    def _build_operation(
+        self,
+        *,
+        kv_completed,
+        has_pool_transfers,
+        pool_transfers_done,
+        terminated=False,
+    ):
+        return SimpleNamespace(
+            hash_value=["page"],
+            completed_tokens=self.PAGE_SIZE if kv_completed else 0,
+            pool_transfers=[object()] if has_pool_transfers else None,
+            pool_transfers_done=pool_transfers_done,
+            is_terminated=lambda: terminated,
+        )
+
+    def test_prefetch_termination_policy_matrix(self):
+        cases = (
+            ("best_effort", False, True, False, False, True),
+            ("wait_complete", True, False, False, False, True),
+            ("wait_complete", True, True, False, False, False),
+            ("wait_complete", True, True, True, False, True),
+            ("timeout", True, True, False, False, False),
+            ("timeout", True, True, False, True, True),
+            ("timeout", False, True, False, True, True),
+            ("timeout", True, True, True, False, True),
+            ("wait_complete", False, True, False, False, False),
+        )
+
+        for cache_type in self.CACHE_TYPES:
+            for (
+                policy,
+                kv_completed,
+                has_pool_transfers,
+                pool_transfers_done,
+                timed_out,
+                expected,
+            ) in cases:
+                with self.subTest(
+                    cache_type=cache_type.__name__,
+                    policy=policy,
+                    kv_completed=kv_completed,
+                    has_pool_transfers=has_pool_transfers,
+                    pool_transfers_done=pool_transfers_done,
+                    timed_out=timed_out,
+                ):
+                    cache = self._build_cache(cache_type, policy, timed_out)
+                    operation = self._build_operation(
+                        kv_completed=kv_completed,
+                        has_pool_transfers=has_pool_transfers,
+                        pool_transfers_done=pool_transfers_done,
+                    )
+                    self.assertEqual(
+                        cache.can_terminate_prefetch(operation), expected
+                    )
+
+    def test_terminated_operation_can_terminate_on_all_cache_types(self):
+        for cache_type in self.CACHE_TYPES:
+            with self.subTest(cache_type=cache_type.__name__):
+                cache = self._build_cache(cache_type, "wait_complete", False)
+                operation = self._build_operation(
+                    kv_completed=False,
+                    has_pool_transfers=True,
+                    pool_transfers_done=False,
+                    terminated=True,
+                )
+                self.assertTrue(cache.can_terminate_prefetch(operation))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

With the `timeout` prefetch policy, HiCache should stop when all transfers complete or when the configured timeout expires.

When the main KV transfer was complete but an auxiliary pool transfer was still pending, `can_terminate_prefetch()` first recognized the timeout and then unconditionally reset the result to `False`. As a result, delayed Mooncake sidecar reads could make the configured timeout ineffective.

Fixes #35012.

## Modifications

- Treat a prefetch as complete only when both the main KV transfer and all auxiliary pool transfers are complete.
- Keep timeout expiration as an independent termination condition.
- Apply the same semantics to `HiRadixCache` and `UnifiedRadixCache`.
- Add CPU unit tests covering `best_effort`, `wait_complete`, `timeout`, pending auxiliary transfers, and terminated operations for both cache implementations.

## Accuracy Tests

This change only affects prefetch termination control flow and does not modify model computation or outputs.

Local validation:

- Both implementations passed all 9 prefetch-policy matrix cases.
- `py_compile` passed for both modified source files and the new test.

## Speed Tests and Profiling

Not applicable. This change does not add work to the hot path beyond combining the existing completion flags.

## Checklist

- [x] Format the code according to the [formatting guide](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [testing guide](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Documentation update is not required because there is no user-facing API or configuration change.
- [x] Accuracy and speed benchmarks are not required because model computation and performance-sensitive operations are unchanged.
- [x] Follow the SGLang [code style guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32044161477](https://github.com/sgl-project/sglang/actions/runs/32044161477)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32044161339](https://github.com/sgl-project/sglang/actions/runs/32044161339)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->