### PR TITLE
[PD] Stage MLA DCP=8 relayout before Mooncake RDMA for KIMI K3

### DIFF
--- a/docs/docs/advanced_features/pd_disaggregation.mdx
+++ b/docs/docs/advanced_features/pd_disaggregation.mdx
@@ -304,6 +304,34 @@ python -m sglang_router.launch_router \
   --host 0.0.0.0 --port 8000
 ```
 
+## MLA DCP relayout with a GPU staging buffer
+
+When prefill uses DCP size 1 and decode uses DCP size greater than 1, each decode rank owns a strided subset of the prefill tokens. For MLA and hybrid-MLA models, the default Mooncake relayout path transfers these noncontiguous token rows directly. This can produce one small RDMA write per token and layer.
+
+Enable the DCP staging buffer on the **prefill server** to gather each decode rank's token rows into contiguous GPU memory before transfer. Mooncake then writes contiguous destination runs, normally one block per KV layer and destination cache page. The decode server receives data directly in its final KV cache and does not need a staging buffer or scatter step.
+
+```bash Command
+# Set these variables on the prefill server only.
+export SGLANG_DISAGG_DCP_STAGING_BUFFER=1
+export SGLANG_DISAGG_DCP_STAGING_BUFFER_SIZE_MB=64
+```
+
+This path currently requires:
+
+- The Mooncake transfer backend
+- An MLA or hybrid-MLA model
+- Prefill DCP size 1 and decode DCP size greater than 1
+
+The size is allocated per Mooncake transfer worker. Relayouts larger than the configured buffer are split into page-aligned batches.
+If the Triton gather cannot compile or execute, the prefill process disables this
+optimized path and falls back to direct DCP relayout. Mooncake transfer failures
+are still reported normally rather than being hidden by the fallback.
+
+Before production rollout, validate deterministic token and logprob parity against
+a monolithic baseline across page and chunk boundaries, long-context retrieval,
+and an accuracy sample such as GSM8K. The Kimi Linear PD+DCP nightly acceptance
+test exercises this staging path and includes these checks.
+
 ## NIXL
 ### Requirements
 

--- a/docs/docs/references/environment_variables.mdx
+++ b/docs/docs/references/environment_variables.mdx
@@ -897,7 +897,7 @@ SGLang supports various environment variables that can be used to configure its 
   </tbody>
 </table>
 
-## PD Disaggregation — Staging Buffer (Heterogeneous TP)
+## PD Disaggregation — Staging Buffers
 
 <table style={{width: "100%", borderCollapse: "collapse", tableLayout: "fixed"}}>
   <colgroup>
@@ -924,8 +924,18 @@ SGLang supports various environment variables that can be used to configure its 
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>4096</code></td>
     </tr>
     <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>SGLANG_DISAGG_DCP_STAGING_BUFFER</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Enable prefill-side GPU staging for Mooncake MLA or hybrid-MLA relayout from prefill DCP size 1 to decode DCP size greater than 1. Set this variable on prefill servers only.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>false</code></td>
+    </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>SGLANG_DISAGG_DCP_STAGING_BUFFER_SIZE_MB</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Prefill-side DCP relayout staging size in MB per Mooncake transfer worker. Larger relayouts are split into page-aligned batches.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>64</code></td>
+    </tr>
+    <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>SGLANG_STAGING_USE_TORCH</code></td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Force using PyTorch gather/scatter fallback instead of Triton fused kernels for staging operations. Useful for debugging.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Force the heterogeneous-TP staging path to use the PyTorch gather/scatter fallback instead of Triton fused kernels. This variable does not affect MLA DCP relayout staging.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>false</code></td>
     </tr>
   </tbody>

--- a/python/sglang/srt/disaggregation/common/staging_buffer.py
+++ b/python/sglang/srt/disaggregation/common/staging_buffer.py
@@ -7,7 +7,9 @@ buffer mechanism that gathers scattered head slices into contiguous GPU memory,
 enabling bulk RDMA transfers that reduce request count to O(layers) or O(1).
 
 Usage:
-    Activated by setting SGLANG_DISAGG_STAGING_BUFFER=1.
+    Heterogeneous TP staging is activated with SGLANG_DISAGG_STAGING_BUFFER=1.
+    MLA DCP relayout staging is activated with
+    SGLANG_DISAGG_DCP_STAGING_BUFFER=1.
 """
 
 from __future__ import annotations
@@ -27,6 +29,39 @@ logger = logging.getLogger(__name__)
 # TODO(yangminl): remove torch fallback implementations once the Triton kernels
 # have been validated in production across all configurations.
 _USE_TRITON_STAGING = not envs.SGLANG_STAGING_USE_TORCH.get()
+
+
+@triton.jit
+def _fused_gather_dcp_to_staging_kernel(
+    layer_ptrs,
+    token_indices,
+    token_item_lens,
+    layer_offsets,
+    staging,
+    num_tokens,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Pack strided MLA token rows into a layer-major byte buffer."""
+    layer_id = tl.program_id(0)
+    block_id = tl.program_id(1)
+
+    item_len = tl.load(token_item_lens + layer_id).to(tl.int64)
+    byte_offsets = block_id.to(tl.int64) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE).to(
+        tl.int64
+    )
+    mask = byte_offsets < num_tokens * item_len
+
+    packed_token = byte_offsets // item_len
+    byte_in_token = byte_offsets % item_len
+    src_token = tl.load(token_indices + packed_token, mask=mask, other=0).to(tl.int64)
+    src_layer = tl.load(layer_ptrs + layer_id).to(staging.dtype)
+    values = tl.load(
+        src_layer + src_token * item_len + byte_in_token,
+        mask=mask,
+    )
+
+    dst_layer_offset = tl.load(layer_offsets + layer_id).to(tl.int64)
+    tl.store(staging + dst_layer_offset + byte_offsets, values, mask=mask)
 
 
 @triton.jit
@@ -157,6 +192,87 @@ class StagingBuffer:
 
     def fits(self, required_bytes: int) -> bool:
         return required_bytes <= self.size_bytes
+
+
+def gather_dcp_tokens_to_staging(
+    src_data_ptrs: List[int],
+    src_token_indices,
+    token_item_lens: List[int],
+    staging_buffer: StagingBuffer,
+    gpu_id: int,
+) -> int:
+    """Gather MLA token rows into contiguous, layer-major staging memory.
+
+    The copy is byte-preserving so FP8 and other packed KV dtypes are not
+    converted. Returns the number of bytes written.
+    """
+    import numpy as np
+
+    if len(src_data_ptrs) != len(token_item_lens):
+        raise ValueError(
+            "src_data_ptrs and token_item_lens must have equal lengths, "
+            f"got {len(src_data_ptrs)} and {len(token_item_lens)}"
+        )
+    if any(item_len <= 0 for item_len in token_item_lens):
+        raise ValueError(
+            f"token_item_lens must contain only positive values, got {token_item_lens}"
+        )
+
+    indices_np = np.asarray(src_token_indices, dtype=np.int64)
+    if indices_np.ndim != 1:
+        raise ValueError(
+            f"src_token_indices must be one-dimensional, got shape {indices_np.shape}"
+        )
+    num_tokens = int(indices_np.size)
+    if num_tokens == 0 or not src_data_ptrs:
+        return 0
+
+    layer_offsets = []
+    total_bytes = 0
+    for item_len in token_item_lens:
+        layer_offsets.append(total_bytes)
+        total_bytes += num_tokens * item_len
+    if not staging_buffer.fits(total_bytes):
+        raise ValueError(
+            f"DCP staging buffer is too small: need {total_bytes} bytes, "
+            f"have {staging_buffer.get_size()}"
+        )
+
+    device = f"cuda:{gpu_id}"
+    torch.cuda.set_device(gpu_id)
+    layer_ptrs_tensor = torch.tensor(src_data_ptrs, dtype=torch.int64, device=device)
+    token_indices_tensor = torch.from_numpy(indices_np).to(device)
+    token_item_lens_tensor = torch.tensor(
+        token_item_lens, dtype=torch.int64, device=device
+    )
+    layer_offsets_tensor = torch.tensor(layer_offsets, dtype=torch.int64, device=device)
+
+    if not hasattr(staging_buffer, "_dcp_gather_stream"):
+        staging_buffer._dcp_gather_stream = torch.cuda.Stream(device=device)
+    gather_stream = staging_buffer._dcp_gather_stream
+    gather_stream.wait_stream(torch.cuda.default_stream(torch.device(device)))
+
+    block_size = 1024
+    max_item_len = max(token_item_lens)
+    grid = (
+        len(src_data_ptrs),
+        triton.cdiv(num_tokens * max_item_len, block_size),
+    )
+    with torch.cuda.stream(gather_stream):
+        _fused_gather_dcp_to_staging_kernel[grid](
+            layer_ptrs_tensor,
+            token_indices_tensor,
+            token_item_lens_tensor,
+            layer_offsets_tensor,
+            staging_buffer.buffer,
+            num_tokens,
+            block_size,
+        )
+
+    # Mooncake does not consume a CUDA stream/event, so host synchronization is
+    # required before the registered staging region is submitted to RDMA.
+    gather_stream.synchronize()
+    return total_bytes
 
 
 class StagingAllocator:

--- a/python/sglang/srt/disaggregation/common/staging_handler.py
+++ b/python/sglang/srt/disaggregation/common/staging_handler.py
@@ -676,6 +676,30 @@ def init_staging_buffers(
     return buffers
 
 
+def init_dcp_staging_buffers(register_fn, kv_args, count: int) -> list:
+    """Create fixed-size prefill buffers for GPU-assisted DCP relayout."""
+    from sglang.srt.disaggregation.common.staging_buffer import StagingBuffer
+    from sglang.srt.environ import envs
+
+    size_mb = envs.SGLANG_DISAGG_DCP_STAGING_BUFFER_SIZE_MB.get()
+    if size_mb <= 0:
+        raise ValueError(
+            "SGLANG_DISAGG_DCP_STAGING_BUFFER_SIZE_MB must be positive, "
+            f"got {size_mb}"
+        )
+    size_bytes = size_mb * 1024 * 1024
+    gpu_id = kv_args.gpu_id
+    device = f"cuda:{gpu_id}"
+    custom_mem_pool, _ = _get_custom_mem_pool(device)
+
+    buffers = []
+    for _ in range(count):
+        buf = StagingBuffer(size_bytes, device, gpu_id, custom_mem_pool=custom_mem_pool)
+        register_fn(buf.get_ptr(), buf.get_size())
+        buffers.append(buf)
+    return buffers
+
+
 def init_staging_allocator(register_fn, kv_args):
     """Create decode-side staging ring-buffer allocator and register with transport.
 

--- a/python/sglang/srt/disaggregation/common/utils.py
+++ b/python/sglang/srt/disaggregation/common/utils.py
@@ -133,6 +133,70 @@ def group_concurrent_contiguous(
     return src_groups, dst_groups
 
 
+def dcp_staging_required_bytes(num_tokens: int, token_item_lens: List[int]) -> int:
+    """Return bytes needed for the layer-major DCP staging layout."""
+    if num_tokens < 0:
+        raise ValueError(f"num_tokens must be non-negative, got {num_tokens}")
+    if any(item_len <= 0 for item_len in token_item_lens):
+        raise ValueError(
+            f"token_item_lens must contain only positive values, got {token_item_lens}"
+        )
+    return num_tokens * sum(token_item_lens)
+
+
+def build_dcp_staging_transfer_blocks(
+    staging_ptr: int,
+    dst_data_ptrs: List[int],
+    dst_token_indices: npt.NDArray[np.int64],
+    token_item_lens: List[int],
+) -> List[Tuple[int, int, int]]:
+    """Build page-sized transfers from packed DCP staging data.
+
+    The staging layout is layer-major: each layer contains all selected tokens
+    densely in transfer order. Therefore only destination discontinuities split
+    a transfer block; the strided source indices have already been eliminated by
+    the GPU gather.
+    """
+    if len(dst_data_ptrs) != len(token_item_lens):
+        raise ValueError(
+            "dst_data_ptrs and token_item_lens must have equal lengths, "
+            f"got {len(dst_data_ptrs)} and {len(token_item_lens)}"
+        )
+    dst_indices = np.asarray(dst_token_indices, dtype=np.int64)
+    if dst_indices.ndim != 1:
+        raise ValueError(
+            f"dst_token_indices must be one-dimensional, got shape {dst_indices.shape}"
+        )
+    if not dst_data_ptrs or dst_indices.size == 0:
+        return []
+    if any(item_len <= 0 for item_len in token_item_lens):
+        raise ValueError(
+            f"token_item_lens must contain only positive values, got {token_item_lens}"
+        )
+
+    breaks = np.where(np.diff(dst_indices) != 1)[0] + 1
+    group_starts = np.concatenate(([0], breaks))
+    group_ends = np.concatenate((breaks, [dst_indices.size]))
+
+    blocks: List[Tuple[int, int, int]] = []
+    layer_offset = 0
+    num_tokens = int(dst_indices.size)
+    for dst_ptr, item_len in zip(dst_data_ptrs, token_item_lens):
+        src_layer_ptr = staging_ptr + layer_offset
+        for start, end in zip(group_starts, group_ends):
+            start = int(start)
+            end = int(end)
+            blocks.append(
+                (
+                    src_layer_ptr + start * item_len,
+                    dst_ptr + int(dst_indices[start]) * item_len,
+                    (end - start) * item_len,
+                )
+            )
+        layer_offset += num_tokens * item_len
+    return blocks
+
+
 @dataclasses.dataclass(frozen=True)
 class DCPTokenTransferPlan:
     src_token_indices: npt.NDArray[np.int64]

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -33,7 +33,9 @@ from sglang.srt.disaggregation.common.utils import (
     AuxDataCodec,
     FastQueue,
     TransferKVChunk,
+    build_dcp_staging_transfer_blocks,
     build_dcp_token_transfer_plan,
+    dcp_staging_required_bytes,
     group_concurrent_contiguous,
     pack_int_lists,
     unpack_int_lists,
@@ -206,6 +208,8 @@ class MooncakeKVManager(CommonKVManager):
         self.init_engine()
         self.register_buffer_to_engine()
         self.enable_staging = envs.SGLANG_DISAGG_STAGING_BUFFER.get()
+        self.enable_dcp_staging = envs.SGLANG_DISAGG_DCP_STAGING_BUFFER.get()
+        self._dcp_staging_disabled = False
         self.enable_trace = server_args.enable_trace
         if self.disaggregation_mode == DisaggregationMode.PREFILL:
             self.start_prefill_thread()
@@ -242,6 +246,9 @@ class MooncakeKVManager(CommonKVManager):
             self._staging_ctx = PrefillStagingContext() if self.enable_staging else None
             if self.enable_staging:
                 self._init_staging_buffers(len(self.transfer_queues))
+            self._dcp_staging_buffers = []
+            if self.enable_dcp_staging:
+                self._init_dcp_staging_buffers(len(self.transfer_queues))
             for i, (queue, executor) in enumerate(
                 zip(self.transfer_queues, self.executors)
             ):
@@ -253,6 +260,11 @@ class MooncakeKVManager(CommonKVManager):
                         (
                             self._staging_ctx.buffers[i]
                             if self.enable_staging and self._staging_ctx.buffers
+                            else None
+                        ),
+                        (
+                            self._dcp_staging_buffers[i]
+                            if self.enable_dcp_staging and self._dcp_staging_buffers
                             else None
                         ),
                         i,
@@ -349,6 +361,17 @@ class MooncakeKVManager(CommonKVManager):
             get_schedule().chunked_prefill_size,
         )
         self.kv_buffer_tensors = None
+
+    def _init_dcp_staging_buffers(self, count: int):
+        from sglang.srt.disaggregation.common.staging_handler import (
+            init_dcp_staging_buffers,
+        )
+
+        self._dcp_staging_buffers = init_dcp_staging_buffers(
+            lambda ptr, size: self.engine.batch_register([ptr], [size]),
+            self.kv_args,
+            count,
+        )
 
     def _init_staging_allocator(self):
         from sglang.srt.disaggregation.common.staging_handler import (
@@ -893,6 +916,37 @@ class MooncakeKVManager(CommonKVManager):
             dst_device_data_ptrs=dst_device_kv_ptrs,
         )
 
+    def _resolve_dcp_transfer_layers(
+        self,
+        dst_kv_ptrs: List[int],
+        dcp_token_item_lens: List[int],
+        dst_layer_ids: List[int],
+    ) -> Tuple[List[int], List[int], List[int]]:
+        """Resolve PP-local source layers to their decode registrations."""
+        src_layer_ids = self.kv_args.kv_layer_ids
+        if src_layer_ids or dst_layer_ids:
+            dst_indices = resolve_dcp_dst_entry_indices(
+                src_layer_ids,
+                dst_layer_ids,
+                len(self.kv_args.kv_data_ptrs),
+                len(dst_kv_ptrs),
+            )
+            return (
+                self.kv_args.kv_data_ptrs,
+                [dst_kv_ptrs[j] for j in dst_indices],
+                dcp_token_item_lens[: len(self.kv_args.kv_data_ptrs)],
+            )
+
+        src_kv_ptrs, resolved_dst_ptrs, _ = self.get_mla_kv_ptrs_with_pp(
+            self.kv_args.kv_data_ptrs,
+            dst_kv_ptrs,
+        )
+        return (
+            src_kv_ptrs,
+            resolved_dst_ptrs,
+            dcp_token_item_lens[: len(src_kv_ptrs)],
+        )
+
     def send_kvcache_dcp(
         self,
         mooncake_session_id: str,
@@ -925,21 +979,11 @@ class MooncakeKVManager(CommonKVManager):
         if plan.src_token_indices.size == 0:
             return 0
 
-        src_layer_ids = self.kv_args.kv_layer_ids
-        if src_layer_ids or dst_layer_ids:
-            dst_indices = resolve_dcp_dst_entry_indices(
-                src_layer_ids,
-                dst_layer_ids,
-                len(self.kv_args.kv_data_ptrs),
-                len(dst_kv_ptrs),
-            )
-            src_kv_ptrs = self.kv_args.kv_data_ptrs
-            dst_kv_ptrs = [dst_kv_ptrs[j] for j in dst_indices]
-        else:
-            src_kv_ptrs, dst_kv_ptrs, _ = self.get_mla_kv_ptrs_with_pp(
-                self.kv_args.kv_data_ptrs,
-                dst_kv_ptrs,
-            )
+        src_kv_ptrs, dst_kv_ptrs, token_item_lens = self._resolve_dcp_transfer_layers(
+            dst_kv_ptrs,
+            dcp_token_item_lens,
+            dst_layer_ids,
+        )
         layers_current_pp_stage = len(src_kv_ptrs)
         src_groups, dst_groups = group_concurrent_contiguous(
             plan.src_token_indices,
@@ -950,7 +994,7 @@ class MooncakeKVManager(CommonKVManager):
             (
                 src_kv_ptrs[layer_id],
                 dst_kv_ptrs[layer_id],
-                dcp_token_item_lens[layer_id],
+                token_item_lens[layer_id],
             )
             for layer_id in range(layers_current_pp_stage)
         ]
@@ -992,6 +1036,136 @@ class MooncakeKVManager(CommonKVManager):
                 set_transfer_blocks(src_ptr, dst_ptr, token_item_len)
             )
         return self._transfer_data(mooncake_session_id, transfer_blocks)
+
+    def send_kvcache_dcp_staged(
+        self,
+        mooncake_session_id: str,
+        prefill_kv_indices: npt.NDArray[np.int32],
+        dst_kv_ptrs: List[int],
+        dst_kv_indices: npt.NDArray[np.int32],
+        *,
+        dcp_token_item_lens: List[int],
+        dst_dcp_size: int,
+        dst_dcp_rank: int,
+        src_page_offset: int,
+        decode_prefix_len: int,
+        num_kv_tokens: int,
+        executor: concurrent.futures.ThreadPoolExecutor,
+        dst_layer_ids: List[int],
+        staging_buffer,
+    ) -> int:
+        """Relayout DCP tokens with a GPU gather, then issue page-sized RDMA writes."""
+        if num_kv_tokens is None:
+            raise ValueError("PD DCP transfer requires num_kv_tokens")
+        if staging_buffer is None:
+            raise ValueError("PD DCP staging is enabled but no staging buffer is set")
+
+        def fallback_to_direct_transfer() -> int:
+            return self.send_kvcache_dcp(
+                mooncake_session_id,
+                prefill_kv_indices,
+                dst_kv_ptrs,
+                dst_kv_indices,
+                dcp_token_item_lens=dcp_token_item_lens,
+                dst_dcp_size=dst_dcp_size,
+                dst_dcp_rank=dst_dcp_rank,
+                src_page_offset=src_page_offset,
+                decode_prefix_len=decode_prefix_len,
+                num_kv_tokens=num_kv_tokens,
+                executor=executor,
+                dst_layer_ids=dst_layer_ids,
+            )
+
+        if getattr(self, "_dcp_staging_disabled", False):
+            return fallback_to_direct_transfer()
+
+        physical_page_size = self.kv_args.page_size
+        plan = build_dcp_token_transfer_plan(
+            prefill_kv_indices,
+            dst_kv_indices,
+            physical_page_size=physical_page_size,
+            dcp_size=dst_dcp_size,
+            dcp_rank=dst_dcp_rank,
+            src_page_offset=src_page_offset,
+            decode_prefix_len=decode_prefix_len,
+            num_kv_tokens=num_kv_tokens,
+        )
+        if plan.src_token_indices.size == 0:
+            return 0
+
+        src_kv_ptrs, resolved_dst_ptrs, token_item_lens = (
+            self._resolve_dcp_transfer_layers(
+                dst_kv_ptrs,
+                dcp_token_item_lens,
+                dst_layer_ids,
+            )
+        )
+        if not src_kv_ptrs:
+            return 0
+        bytes_per_packed_token = sum(token_item_lens)
+        max_tokens = staging_buffer.get_size() // bytes_per_packed_token
+        if max_tokens == 0:
+            logger.warning_once(
+                "DCP staging buffer cannot fit one token across all local layers; "
+                "falling back to direct strided transfer. Increase "
+                "SGLANG_DISAGG_DCP_STAGING_BUFFER_SIZE_MB."
+            )
+            return fallback_to_direct_transfer()
+
+        # Keep intermediate batches page-aligned so destination-contiguous
+        # tokens normally become one RDMA write per layer and physical page.
+        if max_tokens >= physical_page_size:
+            max_tokens = (max_tokens // physical_page_size) * physical_page_size
+
+        from sglang.srt.disaggregation.common.staging_buffer import (
+            gather_dcp_tokens_to_staging,
+        )
+
+        total_tokens = int(plan.src_token_indices.size)
+        for start in range(0, total_tokens, max_tokens):
+            if getattr(self, "_dcp_staging_disabled", False):
+                # Replaying the whole chunk is safe after an earlier staged batch:
+                # the direct path writes the same KV bytes to the same destinations.
+                return fallback_to_direct_transfer()
+
+            end = min(start + max_tokens, total_tokens)
+            src_token_indices = plan.src_token_indices[start:end]
+            dst_token_indices = plan.dst_token_indices[start:end]
+            required_bytes = dcp_staging_required_bytes(
+                len(src_token_indices), token_item_lens
+            )
+            if not staging_buffer.fits(required_bytes):
+                raise RuntimeError(
+                    "DCP staging batch sizing exceeded the registered buffer: "
+                    f"need={required_bytes}, have={staging_buffer.get_size()}"
+                )
+
+            try:
+                gather_dcp_tokens_to_staging(
+                    src_kv_ptrs,
+                    src_token_indices,
+                    token_item_lens,
+                    staging_buffer,
+                    self.kv_args.gpu_id,
+                )
+            except Exception:
+                self._dcp_staging_disabled = True
+                logger.exception(
+                    "DCP staging gather failed; disabling staged DCP relayout "
+                    "for this process and falling back to direct transfer"
+                )
+                return fallback_to_direct_transfer()
+            transfer_blocks = build_dcp_staging_transfer_blocks(
+                staging_buffer.get_ptr(),
+                resolved_dst_ptrs,
+                dst_token_indices,
+                token_item_lens,
+            )
+            ret = self._transfer_data(mooncake_session_id, transfer_blocks)
+            if ret != 0:
+                return ret
+
+        return 0
 
     def send_kvcache_slice(
         self,
@@ -1617,6 +1791,7 @@ class MooncakeKVManager(CommonKVManager):
         queue: FastQueue,
         executor: concurrent.futures.ThreadPoolExecutor,
         staging_buffer=None,
+        dcp_staging_buffer=None,
         worker_index=0,
     ):
         staging_strategy = None
@@ -1757,22 +1932,36 @@ class MooncakeKVManager(CommonKVManager):
                                 target_rank_registration_info.dcp_token_item_lens
                             )
                             assert dcp_token_item_lens is not None
-                            ret = self.send_kvcache_dcp(
-                                req.mooncake_session_id,
-                                kv_chunk.prefill_kv_indices,
-                                target_rank_registration_info.dst_kv_ptrs,
-                                chunked_dst_kv_indice,
+                            dcp_kwargs = dict(
                                 dcp_token_item_lens=dcp_token_item_lens,
                                 dst_dcp_size=target_rank_registration_info.dst_dcp_size,
                                 dst_dcp_rank=target_rank_registration_info.dst_dcp_rank,
                                 src_page_offset=kv_chunk.index_slice.start or 0,
                                 decode_prefix_len=req.decode_prefix_len or 0,
                                 num_kv_tokens=kv_chunk.num_kv_tokens,
-                                executor=executor,
                                 dst_layer_ids=(
                                     target_rank_registration_info.dst_kv_layer_ids
                                 ),
                             )
+                            if self.enable_dcp_staging:
+                                ret = self.send_kvcache_dcp_staged(
+                                    req.mooncake_session_id,
+                                    kv_chunk.prefill_kv_indices,
+                                    target_rank_registration_info.dst_kv_ptrs,
+                                    chunked_dst_kv_indice,
+                                    executor=executor,
+                                    staging_buffer=dcp_staging_buffer,
+                                    **dcp_kwargs,
+                                )
+                            else:
+                                ret = self.send_kvcache_dcp(
+                                    req.mooncake_session_id,
+                                    kv_chunk.prefill_kv_indices,
+                                    target_rank_registration_info.dst_kv_ptrs,
+                                    chunked_dst_kv_indice,
+                                    executor=executor,
+                                    **dcp_kwargs,
+                                )
                         elif (
                             self.is_mla_backend
                             or self.is_hybrid_mla_backend

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -48,6 +48,7 @@ from sglang.srt.disaggregation.utils import (
     is_aborted,
     is_dsv4_c128_online_enabled,
     is_mla_backend,
+    is_mla_or_hybrid_mla_backend,
     poll_and_all_reduce_attn_cp_tp_group,
     poll_and_all_reduce_pp,
     prepare_abort,
@@ -156,6 +157,23 @@ class PrefillBootstrapQueue:
             self.scheduler.tp_worker.model_runner.effective_max_total_num_tokens
         )
         self.transfer_backend = transfer_backend
+        if envs.SGLANG_DISAGG_DCP_STAGING_BUFFER.get():
+            if self.transfer_backend != TransferBackend.MOONCAKE:
+                raise RuntimeError(
+                    "SGLANG_DISAGG_DCP_STAGING_BUFFER currently requires the "
+                    "Mooncake transfer backend."
+                )
+            if not is_mla_or_hybrid_mla_backend(self.token_to_kv_pool):
+                raise RuntimeError(
+                    "SGLANG_DISAGG_DCP_STAGING_BUFFER is only supported for "
+                    "MLA or hybrid-MLA DCP relayout."
+                )
+            size_mb = envs.SGLANG_DISAGG_DCP_STAGING_BUFFER_SIZE_MB.get()
+            if size_mb <= 0:
+                raise RuntimeError(
+                    "SGLANG_DISAGG_DCP_STAGING_BUFFER_SIZE_MB must be positive, "
+                    f"got {size_mb}."
+                )
         if envs.SGLANG_DISAGG_STAGING_BUFFER.get():
             if self.is_mla_backend:
                 raise RuntimeError(

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -820,6 +820,18 @@ def is_mla_backend(target_kv_pool) -> bool:
     return isinstance(target_kv_pool, (MLATokenToKVPool, DeepSeekV4TokenToKVPool))
 
 
+def is_mla_or_hybrid_mla_backend(target_kv_pool) -> bool:
+    """Return whether a KV pool exposes an MLA full-attention cache."""
+    if is_mla_backend(target_kv_pool):
+        return True
+
+    from sglang.srt.mem_cache.memory_pool import HybridLinearKVPool
+
+    return isinstance(target_kv_pool, HybridLinearKVPool) and is_mla_backend(
+        target_kv_pool.full_kv_pool
+    )
+
+
 def compute_mamba_state_slice_blocks(
     src_dim: int,
     dst_dim: int,

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -678,6 +678,10 @@ class Envs:
     # Staging buffer for heterogeneous TP KV transfer
     SGLANG_DISAGG_STAGING_BUFFER = EnvBool(False)
     SGLANG_DISAGG_STAGING_POOL_SIZE_MB = EnvInt(4096)
+    # Prefill-side staging buffer for MLA and hybrid-MLA DCP token relayout. The
+    # buffer is registered with the transfer engine and reused by one worker.
+    SGLANG_DISAGG_DCP_STAGING_BUFFER = EnvBool(False)
+    SGLANG_DISAGG_DCP_STAGING_BUFFER_SIZE_MB = EnvInt(64)
     # TODO(yangminl): remove SGLANG_STAGING_USE_TORCH and the torch fallback in
     # staging_buffer.py once Triton kernels are fully validated in production.
     SGLANG_STAGING_USE_TORCH = EnvBool(False)

--- a/test/registered/disaggregation/test_kimi_linear_pd_dcp4.py
+++ b/test/registered/disaggregation/test_kimi_linear_pd_dcp4.py
@@ -317,6 +317,7 @@ class TestKimiLinearPDDCP4(GSM8KMixin, PDDisaggregationServerBase):
             cls.prefill_url,
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH * 5,
             other_args=args,
+            env={"SGLANG_DISAGG_DCP_STAGING_BUFFER": "1"},
         )
 
     @classmethod

--- a/test/registered/unit/disaggregation/test_dcp_staging_gather.py
+++ b/test/registered/unit/disaggregation/test_dcp_staging_gather.py
@@ -1,0 +1,43 @@
+import unittest
+
+import numpy as np
+import torch
+
+from sglang.srt.disaggregation.common.staging_buffer import (
+    StagingBuffer,
+    gather_dcp_tokens_to_staging,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=5, stage="base-b", runner_config="1-gpu-small")
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA is required")
+class TestDCPStagingGather(unittest.TestCase):
+    def test_gather_is_byte_preserving_and_layer_major(self):
+        device = "cuda:0"
+        layer0 = torch.arange(20 * 8, dtype=torch.uint8, device=device).reshape(20, 8)
+        layer1 = (
+            torch.arange(20 * 5, dtype=torch.uint8, device=device).reshape(20, 5) + 37
+        )
+        indices = np.array([3, 11, 19], dtype=np.int64)
+        indices_cuda = torch.tensor(indices, dtype=torch.int64, device=device)
+        staging = StagingBuffer(3 * (8 + 5), device, gpu_id=0)
+
+        written = gather_dcp_tokens_to_staging(
+            [layer0.data_ptr(), layer1.data_ptr()],
+            indices,
+            [8, 5],
+            staging,
+            gpu_id=0,
+        )
+
+        expected = torch.cat(
+            [layer0[indices_cuda].reshape(-1), layer1[indices_cuda].reshape(-1)]
+        )
+        self.assertEqual(written, expected.numel())
+        torch.testing.assert_close(staging.buffer[:written], expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/disaggregation/test_disaggregation_wire.py
+++ b/test/registered/unit/disaggregation/test_disaggregation_wire.py
@@ -12,6 +12,8 @@ from sglang.srt.disaggregation.common.staging_handler import (
     handle_staging_req,
 )
 from sglang.srt.disaggregation.common.utils import (
+    build_dcp_staging_transfer_blocks,
+    dcp_staging_required_bytes,
     group_concurrent_contiguous,
     pack_int_lists,
     pack_list_of_buffers,
@@ -28,6 +30,7 @@ from sglang.srt.disaggregation.mooncake.conn import (
 from sglang.srt.disaggregation.utils import (
     MetadataBuffers,
     get_dsv4_c128_state_indices,
+    is_mla_or_hybrid_mla_backend,
     setup_state_kv_args,
 )
 from sglang.srt.environ import envs
@@ -174,6 +177,237 @@ class TestGroupConcurrentContiguous(unittest.TestCase):
     def test_mismatched_nonempty_lengths_raise(self):
         with self.assertRaises(ValueError):
             group_concurrent_contiguous(self._arr([1, 2, 3]), self._arr([1, 2]))
+
+
+class TestDCPStagingLayout(unittest.TestCase):
+    def test_required_bytes_uses_layer_major_layout(self):
+        self.assertEqual(dcp_staging_required_bytes(64, [576, 320]), 64 * 896)
+
+    def test_contiguous_destination_page_becomes_one_block_per_layer(self):
+        blocks = build_dcp_staging_transfer_blocks(
+            staging_ptr=0x1000,
+            dst_data_ptrs=[0x100000, 0x200000],
+            dst_token_indices=np.arange(640, 704, dtype=np.int64),
+            token_item_lens=[576, 320],
+        )
+
+        self.assertEqual(
+            blocks,
+            [
+                (0x1000, 0x100000 + 640 * 576, 64 * 576),
+                (0x1000 + 64 * 576, 0x200000 + 640 * 320, 64 * 320),
+            ],
+        )
+
+    def test_destination_page_gap_splits_blocks_but_source_stays_packed(self):
+        blocks = build_dcp_staging_transfer_blocks(
+            staging_ptr=0x8000,
+            dst_data_ptrs=[0x300000],
+            dst_token_indices=np.array([10, 11, 12, 64, 65], dtype=np.int64),
+            token_item_lens=[576],
+        )
+
+        self.assertEqual(
+            blocks,
+            [
+                (0x8000, 0x300000 + 10 * 576, 3 * 576),
+                (0x8000 + 3 * 576, 0x300000 + 64 * 576, 2 * 576),
+            ],
+        )
+
+    def test_invalid_layer_geometry_raises(self):
+        with self.assertRaises(ValueError):
+            build_dcp_staging_transfer_blocks(
+                staging_ptr=0,
+                dst_data_ptrs=[1, 2],
+                dst_token_indices=np.array([0], dtype=np.int64),
+                token_item_lens=[576],
+            )
+
+
+class TestMLACacheDetection(unittest.TestCase):
+    def test_direct_mla_pool_is_supported(self):
+        from sglang.srt.mem_cache.memory_pool import MLATokenToKVPool
+
+        pool = object.__new__(MLATokenToKVPool)
+        self.assertTrue(is_mla_or_hybrid_mla_backend(pool))
+
+    def test_hybrid_pool_with_mla_full_cache_is_supported(self):
+        from sglang.srt.mem_cache.memory_pool import (
+            HybridLinearKVPool,
+            MLATokenToKVPool,
+        )
+
+        pool = object.__new__(HybridLinearKVPool)
+        pool.full_kv_pool = object.__new__(MLATokenToKVPool)
+        self.assertTrue(is_mla_or_hybrid_mla_backend(pool))
+
+    def test_hybrid_pool_without_mla_full_cache_is_rejected(self):
+        from sglang.srt.mem_cache.memory_pool import HybridLinearKVPool
+
+        pool = object.__new__(HybridLinearKVPool)
+        pool.full_kv_pool = object()
+        self.assertFalse(is_mla_or_hybrid_mla_backend(pool))
+
+
+class TestMooncakeDCPStaging(unittest.TestCase):
+    @staticmethod
+    def _manager():
+        manager = object.__new__(MooncakeKVManager)
+        manager.kv_args = SimpleNamespace(
+            page_size=64,
+            kv_layer_ids=[0, 1],
+            kv_data_ptrs=[0x100000, 0x200000],
+            gpu_id=0,
+        )
+        manager._transfer_data = Mock(return_value=0)
+        return manager
+
+    @staticmethod
+    def _staging(num_tokens):
+        staging_size = num_tokens * (576 + 320)
+        return SimpleNamespace(
+            get_size=lambda: staging_size,
+            get_ptr=lambda: 0x9000,
+            fits=lambda required: required <= staging_size,
+        )
+
+    @patch(
+        "sglang.srt.disaggregation.common.staging_buffer."
+        "gather_dcp_tokens_to_staging"
+    )
+    def test_strided_source_is_gathered_into_page_sized_transfers(self, gather):
+        manager = self._manager()
+        staging = self._staging(64)
+
+        ret = manager.send_kvcache_dcp_staged(
+            "peer",
+            np.arange(100, 108, dtype=np.int32),
+            [0x300000, 0x400000],
+            np.array([200], dtype=np.int32),
+            dcp_token_item_lens=[576, 320],
+            dst_dcp_size=8,
+            dst_dcp_rank=3,
+            src_page_offset=0,
+            decode_prefix_len=0,
+            num_kv_tokens=512,
+            executor=Mock(),
+            dst_layer_ids=[0, 1],
+            staging_buffer=staging,
+        )
+
+        self.assertEqual(ret, 0)
+        gather.assert_called_once()
+        gathered_indices = gather.call_args.args[1]
+        np.testing.assert_array_equal(
+            gathered_indices[:4], np.array([6403, 6411, 6419, 6427])
+        )
+        manager._transfer_data.assert_called_once_with(
+            "peer",
+            [
+                (0x9000, 0x300000 + 200 * 64 * 576, 64 * 576),
+                (
+                    0x9000 + 64 * 576,
+                    0x400000 + 200 * 64 * 320,
+                    64 * 320,
+                ),
+            ],
+        )
+
+    @patch(
+        "sglang.srt.disaggregation.common.staging_buffer."
+        "gather_dcp_tokens_to_staging"
+    )
+    def test_large_relayout_is_split_at_staging_capacity(self, gather):
+        manager = self._manager()
+
+        ret = manager.send_kvcache_dcp_staged(
+            "peer",
+            np.arange(100, 116, dtype=np.int32),
+            [0x300000, 0x400000],
+            np.array([200, 400], dtype=np.int32),
+            dcp_token_item_lens=[576, 320],
+            dst_dcp_size=8,
+            dst_dcp_rank=3,
+            src_page_offset=0,
+            decode_prefix_len=0,
+            num_kv_tokens=1024,
+            executor=Mock(),
+            dst_layer_ids=[0, 1],
+            staging_buffer=self._staging(64),
+        )
+
+        self.assertEqual(ret, 0)
+        self.assertEqual(gather.call_count, 2)
+        self.assertEqual(manager._transfer_data.call_count, 2)
+        self.assertEqual(
+            [len(call.args[1]) for call in manager._transfer_data.call_args_list],
+            [2, 2],
+        )
+
+    @patch(
+        "sglang.srt.disaggregation.common.staging_buffer."
+        "gather_dcp_tokens_to_staging",
+        side_effect=RuntimeError("Triton compilation failed"),
+    )
+    def test_gather_failure_disables_staging_and_falls_back(self, gather):
+        manager = self._manager()
+        manager.send_kvcache_dcp = Mock(return_value=0)
+        args = (
+            "peer",
+            np.arange(100, 108, dtype=np.int32),
+            [0x300000, 0x400000],
+            np.array([200], dtype=np.int32),
+        )
+        kwargs = dict(
+            dcp_token_item_lens=[576, 320],
+            dst_dcp_size=8,
+            dst_dcp_rank=3,
+            src_page_offset=0,
+            decode_prefix_len=0,
+            num_kv_tokens=512,
+            executor=Mock(),
+            dst_layer_ids=[0, 1],
+            staging_buffer=self._staging(64),
+        )
+
+        self.assertEqual(manager.send_kvcache_dcp_staged(*args, **kwargs), 0)
+        self.assertTrue(manager._dcp_staging_disabled)
+        self.assertEqual(manager.send_kvcache_dcp_staged(*args, **kwargs), 0)
+
+        gather.assert_called_once()
+        self.assertEqual(manager.send_kvcache_dcp.call_count, 2)
+        manager._transfer_data.assert_not_called()
+
+    @patch(
+        "sglang.srt.disaggregation.common.staging_buffer."
+        "gather_dcp_tokens_to_staging"
+    )
+    def test_transfer_failure_does_not_disable_staging(self, gather):
+        manager = self._manager()
+        manager.send_kvcache_dcp = Mock(return_value=0)
+        manager._transfer_data.side_effect = RuntimeError("RDMA transfer failed")
+
+        with self.assertRaisesRegex(RuntimeError, "RDMA transfer failed"):
+            manager.send_kvcache_dcp_staged(
+                "peer",
+                np.arange(100, 108, dtype=np.int32),
+                [0x300000, 0x400000],
+                np.array([200], dtype=np.int32),
+                dcp_token_item_lens=[576, 320],
+                dst_dcp_size=8,
+                dst_dcp_rank=3,
+                src_page_offset=0,
+                decode_prefix_len=0,
+                num_kv_tokens=512,
+                executor=Mock(),
+                dst_layer_ids=[0, 1],
+                staging_buffer=self._staging(64),
+            )
+
+        gather.assert_called_once()
+        self.assertFalse(getattr(manager, "_dcp_staging_disabled", False))
+        manager.send_kvcache_dcp.assert_not_called()
 
 
 class TestMooncakePPStaging(unittest.TestCase):


### PR DESCRIPTION
## Motivation

<img width="1920" height="1270" alt="Codex 图像 2026年8月17日 22_17_06" src="https://github.com/user-attachments/assets/ed860850-ce26-4b12-ba3d-3288cfcc791e" />


When Prefill uses DCP size 1 and Decode uses DCP size greater than 1, each Decode rank owns a strided subset of the Prefill KV tokens.

The existing Mooncake DCP relayout path builds transfer blocks only when both source and destination token addresses are contiguous. The destination offsets are packed, but the source offsets advance by `dcp_size`. As a result, the source is noncontiguous and the transfer is split into one RDMA block per token and KV layer.

For Kimi K3 MLA FP8 KV cache, one token row is approximately:

```text
(kv_lora_rank 512 + rope dimension 64) × 1 byte = 576 bytes
```

In a 56K-token, DCP=8, 24-MLA-layer deployment, this produces approximately 168K small transfer descriptors per Decode rank. The observed aggregate P-to-D bandwidth was about 1.23 GB/s across eight RDMA devices, despite the available link bandwidth being much higher.

This PR adds an opt-in GPU staging path that gathers each Decode rank's strided token rows into contiguous registered memory before issuing Mooncake transfers.

```text
Legacy:
strided source tokens
    -> one descriptor per token and layer
    -> approximately 576-byte RDMA writes

Staged:
strided source tokens
    -> Triton byte-preserving gather
    -> contiguous layer-major staging buffer
    -> normally one descriptor per layer and destination page
    -> 64 × 576 bytes = 36 KiB writes for Kimi K3
```

For the example above, the descriptor count is expected to decrease from approximately 168K to approximately 2.6K per rank. End-to-end post-change bandwidth and latency measurements are still pending on the target RDMA deployment.

## Modifications

- Add an opt-in Prefill-side MLA DCP staging path for the Mooncake transfer backend:
  - `SGLANG_DISAGG_DCP_STAGING_BUFFER=1`
  - `SGLANG_DISAGG_DCP_STAGING_BUFFER_SIZE_MB=64`
- Gather strided DCP-owned token rows into registered GPU memory using a fused Triton kernel.
- Preserve KV bytes exactly by operating on `uint8` data, avoiding FP8 conversion or reinterpretation.
- Store gathered data in a layer-major layout and build RDMA descriptors from destination-contiguous runs.
- Split transfers into page-aligned batches when a relayout is larger than the configured staging buffer.
- Support both direct MLA KV pools and hybrid-MLA pools such as Kimi K3's `HybridLinearKVPool`.
- Use 64-bit Triton byte offsets so staging buffers larger than 2 GiB do not overflow.
- Add a process-level circuit breaker:
  - If Triton gather compilation or execution fails, disable the staged path and replay the request through the legacy direct relayout path.
  - Mooncake/RDMA transfer failures are not caught or hidden by this fallback.
- Keep the feature disabled by default. The existing direct DCP relayout path remains unchanged unless the environment variable is enabled.
- Add environment validation and PD disaggregation documentation.

## Accuracy Tests

The staging kernel performs a byte-preserving gather and does not change KV dtype or numerical representation.

Added coverage includes:

- CUDA byte-parity testing for gathered FP8-compatible KV rows.
- CPU tests for:
  - DCP token ownership and layout.
  - Destination-contiguous block construction.
  - Page-aligned batching.
  - Direct MLA and hybrid-MLA pool detection.
  - Triton gather failure fallback and process-level disabling.
  - Verification that Mooncake transfer failures are not swallowed.
- The Kimi Linear PD+DCP nightly suite now explicitly enables the staged path and covers:
  - Deterministic token ID and logprob parity against a monolithic baseline.
  - Physical-page and chunk-boundary prompts.
  - 32K long-context needle retrieval.
  - GSM8K accuracy with 200 examples and a score threshold of 0.88.

Local validation completed:

- `pre-commit` passed for all modified files.
- Python syntax compilation passed.

The registered CUDA and 8×B200 Kimi Linear acceptance tests were not run locally and are expected to run in the corresponding CI environments.

## Speed Tests and Profiling

### Legacy-path observation

Kimi K3 deployment configuration:

- Prefill DCP: 1
- Decode DCP: 8
- Physical page size: 64
- MLA KV dtype: FP8
- MLA KV token size: approximately 576 bytes per layer
- MLA layers transferred: 24
- Input length: approximately 56K tokens

Observed legacy behavior:

- Approximately 168K transfer descriptors per Decode rank.
- Most descriptors represented one token and one layer.
- Approximately 576-byte RDMA payloads.
- Aggregate P-to-D bandwidth: approximately 1.23 GB/s across eight RDMA devices.

### Expected staged-path behavior

- Normally one transfer descriptor per destination page and KV layer.
- Approximately 2.6K descriptors per rank for the same 56K-token request.
- Approximately 36 KiB per full-page Kimi K3 transfer block.
- Approximately 64× fewer descriptors.

These figures describe the expected descriptor reduction. End-to-end post-change throughput, TTFT, and CPU profiling results are pending on the target Mooncake/RDMA environment.

## Checklist

- [x] Format the code with SGLang pre-commit hooks.
- [x] Add unit and registered CUDA tests.
- [x] Update PD disaggregation and environment-variable documentation.
- [ ] Run the registered CUDA byte-parity test in a GPU CI environment.
- [x] Run the Kimi Linear PD+DCP accuracy suite on 8×B200.
- [ ] Collect post-change Mooncake/RDMA bandwidth, TTFT, and descriptor-count measurements.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32048239255](https://github.com/sgl-project/sglang/actions/runs/32048239255)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32048239217](https://github.com/sgl-project/sglang/actions/runs/32048239217)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->