### PR TITLE
dsv4: merge c4 prefill compress+write into a single launch

### DIFF
--- a/python/sglang/kernels/jit/csrc/deepseek_v4/c4_v2.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/c4_v2.cuh
@@ -286,12 +286,15 @@ C4_KERNEL void flash_c4_decode(const __grid_constant__ Compress4DecodeParams par
   }
 }
 
+// Compress body factored out so it can be driven by an explicit `block_idx`
+// (used both by the standalone `flash_c4_prefill` wrapper and by the merged
+// compress+write kernel). `blockDim.x` is kBlockSize (128) in both callers.
 template <int64_t kHeadDim, typename BufferFloat, typename InputFloat, typename OutFloat, bool kUsePDL>
-C4_KERNEL void flash_c4_prefill(const __grid_constant__ Compress4PrefillParams params) {
+SGL_DEVICE void c4_prefill_impl(const Compress4PrefillParams& params, const uint32_t block_idx) {
   using namespace device;
   using Trait = C4Trait<kHeadDim>;
 
-  const uint32_t global_tid = blockIdx.x * blockDim.x + threadIdx.x;
+  const uint32_t global_tid = block_idx * blockDim.x + threadIdx.x;
   const uint32_t global_wid = global_tid / kWarpThreads;      // warp id
   const uint32_t global_pid = global_wid / Trait::kNumSplit;  // plan id
   const uint32_t global_sid = global_wid % Trait::kNumSplit;  // split id
@@ -317,12 +320,20 @@ C4_KERNEL void flash_c4_prefill(const __grid_constant__ Compress4PrefillParams p
 }
 
 template <int64_t kHeadDim, typename BufferFloat, typename InputFloat, typename OutFloat, bool kUsePDL>
-WRITE_KERNEL void write_c4_prefill(const __grid_constant__ Compress4PrefillParams params) {
+C4_KERNEL void flash_c4_prefill(const __grid_constant__ Compress4PrefillParams params) {
+  c4_prefill_impl<kHeadDim, BufferFloat, InputFloat, OutFloat, kUsePDL>(params, blockIdx.x);
+}
+
+// Write body factored out so it can be driven by an explicit `block_idx`
+// (used both by the standalone `write_c4_prefill` wrapper and by the merged
+// compress+write kernel). `blockDim.x` is kBlockSize (128) in both callers.
+template <int64_t kHeadDim, typename BufferFloat, typename InputFloat, typename OutFloat, bool kUsePDL>
+SGL_DEVICE void c4_write_impl(const Compress4PrefillParams& params, const uint32_t block_idx) {
   using namespace device;
   using Trait = C4Trait<kHeadDim>;
   using StorageInput = AlignedVector<InputFloat, kTileElements>;
 
-  const uint32_t global_tid = blockIdx.x * blockDim.x + threadIdx.x;
+  const uint32_t global_tid = block_idx * blockDim.x + threadIdx.x;
   const uint32_t global_wid = global_tid / kWarpThreads;      // warp id
   const uint32_t global_pid = global_wid / Trait::kNumSplit;  // plan id
   const uint32_t global_sid = global_wid % Trait::kNumSplit;  // split id
@@ -375,10 +386,33 @@ WRITE_KERNEL void write_c4_prefill(const __grid_constant__ Compress4PrefillParam
 }
 
 template <int64_t kHeadDim, typename BufferFloat, typename InputFloat, typename OutFloat, bool kUsePDL>
+WRITE_KERNEL void write_c4_prefill(const __grid_constant__ Compress4PrefillParams params) {
+  c4_write_impl<kHeadDim, BufferFloat, InputFloat, OutFloat, kUsePDL>(params, blockIdx.x);
+}
+
+// Merged compress+write: grid-concatenation of the two independent prefill
+// domains into a single launch. Blocks [0, num_c_blocks) run the compress
+// epilogue; the trailing blocks run the ring-buffer write. Both sub-kernels use
+// the same 128-thread block, so a single blockDim works for both. There is no
+// cross-block dependency (compress reads prior-step overlap; write stages the
+// current tokens for future steps), so no grid-wide sync is required.
+template <int64_t kHeadDim, typename BufferFloat, typename InputFloat, typename OutFloat, bool kUsePDL>
+C4_KERNEL void flash_c4_prefill_merged(
+    const __grid_constant__ Compress4PrefillParams params, const uint32_t num_c_blocks) {
+  if (blockIdx.x < num_c_blocks) {
+    c4_prefill_impl<kHeadDim, BufferFloat, InputFloat, OutFloat, kUsePDL>(params, blockIdx.x);
+  } else {
+    c4_write_impl<kHeadDim, BufferFloat, InputFloat, OutFloat, kUsePDL>(params, blockIdx.x - num_c_blocks);
+  }
+}
+
+template <int64_t kHeadDim, typename BufferFloat, typename InputFloat, typename OutFloat, bool kUsePDL>
 struct FlashCompress4Kernel {
   static constexpr auto decode_kernel = flash_c4_decode<kHeadDim, BufferFloat, InputFloat, OutFloat, kUsePDL>;
   static constexpr auto prefill_c_kernel = flash_c4_prefill<kHeadDim, BufferFloat, InputFloat, OutFloat, kUsePDL>;
   static constexpr auto prefill_w_kernel = write_c4_prefill<kHeadDim, BufferFloat, InputFloat, OutFloat, kUsePDL>;
+  static constexpr auto prefill_merged_kernel =
+      flash_c4_prefill_merged<kHeadDim, BufferFloat, InputFloat, OutFloat, kUsePDL>;
   static constexpr uint32_t kBlockSize = 128;
   static constexpr uint32_t kTileDim = kTileElements * device::kWarpThreads;
   static constexpr uint32_t kNumSplit = kHeadDim / kTileDim;
@@ -484,6 +518,65 @@ struct FlashCompress4Kernel {
     if (const auto num_w_blocks = div_ceil(num_w * kNumSplit, kWarpsPerBlock)) {
       LaunchKernel(num_w_blocks, kBlockSize, device)  //
           .enable_pdl(kUsePDL)(prefill_w_kernel, params);
+    }
+  }
+
+  // Single-launch variant: grid-concatenate the compress and write domains so
+  // the whole prefill compress region fires as one kernel (compress blocks
+  // followed by write blocks). Same 128-thread block for both.
+  static void run_prefill_merged(
+      const tvm::ffi::TensorView kv_buffer,
+      const tvm::ffi::TensorView kv_input,
+      const tvm::ffi::TensorView kv_output,
+      const tvm::ffi::TensorView ape,
+      const tvm::ffi::TensorView plan_c_,
+      const tvm::ffi::TensorView plan_w_) {
+    using namespace host;
+
+    auto N = SymbolicSize{"num_q_tokens"};
+    auto C = SymbolicSize{"num_c_plans"};
+    auto W = SymbolicSize{"num_w_plans"};
+    auto device_ = SymbolicDevice{};
+    device_.set_options<kDLGPU>();
+
+    TensorMatcher({-1, 4, Trait::kElementSize})  // kv score
+        .with_dtype<BufferFloat>()
+        .with_device(device_)
+        .verify(kv_buffer);
+    TensorMatcher({N, Trait::kElementSize})  // kv score input (ragged)
+        .with_dtype<InputFloat>()
+        .with_device(device_)
+        .verify(kv_input);
+    TensorMatcher({C, kHeadDim})  // kv compressed output (compact)
+        .with_dtype<OutFloat>()
+        .with_device(device_)
+        .verify(kv_output);
+    TensorMatcher({8, kHeadDim})  // ape
+        .with_dtype<InputFloat>()
+        .with_device(device_)
+        .verify(ape);
+    const auto plan_c = compress::verify_plan_c(plan_c_, C, device_);
+    const auto plan_w = compress::verify_plan_w(plan_w_, W, device_);
+    const auto device = device_.unwrap();
+    const auto num_q_tokens = static_cast<uint32_t>(N.unwrap());
+    const auto num_c = static_cast<uint32_t>(C.unwrap());
+    const auto num_w = static_cast<uint32_t>(W.unwrap());
+    const auto params = Compress4PrefillParams{
+        .kv_buffer = kv_buffer.data_ptr(),
+        .kv_input = kv_input.data_ptr(),
+        .kv_output = kv_output.data_ptr(),
+        .score_bias = ape.data_ptr(),
+        .plan_c = plan_c,
+        .plan_w = plan_w,
+        .num_compress = num_c,
+        .num_write = num_w,
+    };
+    RuntimeCheck(num_q_tokens >= num_w, "invalid prefill plan: num_q < num_w");
+    const uint32_t num_c_blocks = div_ceil(num_c * kNumSplit, kWarpsPerBlock);
+    const uint32_t num_w_blocks = div_ceil(num_w * kNumSplit, kWarpsPerBlock);
+    if (const auto total_blocks = num_c_blocks + num_w_blocks) {
+      LaunchKernel(total_blocks, kBlockSize, device)  //
+          .enable_pdl(kUsePDL)(prefill_merged_kernel, params, num_c_blocks);
     }
   }
 };

--- a/python/sglang/kernels/ops/attention/dsv4/compress.py
+++ b/python/sglang/kernels/ops/attention/dsv4/compress.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING, Literal, NamedTuple, Optional, Union
 
 import torch
+
+# Opt-in: fold the prefill compress and ring-buffer write kernels into a single
+# grid-concatenated launch (currently ratio=4 / indexer path only). Off by
+# default so behavior matches upstream unless explicitly enabled.
+_MERGE_COMPRESS_WRITE = os.environ.get("SGLANG_OPT_MERGE_COMPRESS_WRITE", "0") == "1"
 
 from sglang.kernels.jit.utils import (
     cache_once,
@@ -84,14 +90,18 @@ def _jit_compress_module(
         head_dim, dtype_buffer, dtype_in, dtype_out, is_arch_support_pdl()
     )
     kernel_class = f"FlashCompress{ratio}Kernel<{args}>"
+    cuda_wrappers = [
+        ("decode", f"{kernel_class}::run_decode"),
+        ("prefill", f"{kernel_class}::run_prefill"),
+    ]
+    # Merged compress+write single launch is implemented for the ratio=4 path.
+    if ratio == 4:
+        cuda_wrappers.append(("prefill_merged", f"{kernel_class}::run_prefill_merged"))
     return load_jit(
         make_name(f"compress_{ratio}_v2"),
         *args,
         cuda_files=[f"deepseek_v4/c{ratio}_v2.cuh"],
-        cuda_wrappers=[
-            ("decode", f"{kernel_class}::run_decode"),
-            ("prefill", f"{kernel_class}::run_prefill"),
-        ],
+        cuda_wrappers=cuda_wrappers,
         extra_cuda_cflags=["-use_fast_math"],
     )
 
@@ -407,7 +417,13 @@ def compress_forward(
     if _is_xpu:
         fn = decode_fn if plan.is_decode else prefill_fn
     else:
-        fn = module.decode if plan.is_decode else module.prefill
+        if plan.is_decode:
+            fn = module.decode
+        elif _MERGE_COMPRESS_WRITE and compress_ratio == 4 and not is_online:
+            # Single grid-concatenated compress+write launch (ratio=4 path).
+            fn = module.prefill_merged
+        else:
+            fn = module.prefill
 
     fn(kv_score_buffer, kv_score_input, out, ape, *plan[1:3])
     return out


### PR DESCRIPTION
## Summary

Under prefill / `target_verify`, the ratio=4 (indexer) compress path launches
two independent kernels back-to-back:

- `flash_c4_prefill` — compress epilogue (compact output, one row per plan)
- `write_c4_prefill` — ring-buffer staging write

The **decode** path already fuses these inline (`flash_c4_decode`). This PR does
the same for **prefill** by grid-concatenating the two domains into a single
launch: blocks `[0, num_c_blocks)` run the compress epilogue, the trailing
blocks run the write, dispatched on `blockIdx.x`. Both sub-kernels use the same
128-thread block and have **no cross-block data dependency** (compress reads
prior-step overlap; write stages the current tokens for future steps), so no
grid-wide sync is required.

Implementation notes:
- The compress and write bodies are factored into `__device__` impls addressed
  by an explicit `block_idx`. The standalone `__global__` wrappers
  (`flash_c4_prefill`, `write_c4_prefill`) are preserved for backward
  compatibility.
- New `flash_c4_prefill_merged` kernel + `run_prefill_merged` launcher, exposed
  as `module.prefill_merged`.
- **Opt-in** via `SGLANG_OPT_MERGE_COMPRESS_WRITE` (default **off**). Decode and
  the c128 path are unchanged.

## Validation

- CG-OFF trace (DeepSeek-V4, MTP/EAGLE, TP8+DP-attn, MI355X) confirms the merged
  kernel fires and `write_c4_prefill` no longer appears (compress region 2 -> 1
  launch for the ratio=4 path); c128 path untouched.
- Output correctness verified end-to-end; 0 errors.

## Benchmark (conc=32, CG ON, 320 prompts, no warmup, ISL 8192 / OSL 1024, EAGLE 1/1/2)

| metric | baseline (split) | merged (this PR) | Δ |
|---|---:|---:|---:|
| output throughput (tok/s) | 843.8 | 857.0 | +1.6% |
| input throughput (tok/s) | 6617.4 | 6721.2 | +1.6% |
| latency p50 (s) | 39.23 | 38.46 | -2.0% |
| latency p90 (s) | 47.04 | 45.15 | -4.0% |
| wall (s) | 388.4 | 382.4 | -1.5% |

Since it is gated off by default, there is no behavior change unless
`SGLANG_OPT_MERGE_COMPRESS_WRITE=1` is set.

## Test plan

- [ ] Enable `SGLANG_OPT_MERGE_COMPRESS_WRITE=1` and confirm decode + prefill
      correctness on the ratio=4 indexer path.
- [ ] Confirm compress-region launch count drops by one on the prefill path via
      profiler trace.

Made with [Cursor](https://cursor.com)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #32050079152](https://github.com/sgl-project/sglang/actions/runs/32050079152)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #32050078881](https://github.com/sgl-project/sglang/actions/runs/32050078881)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->