### PR TITLE
[Bugfix] Fix int32 destination offset overflow in CUTLASS MoE pre-reorder

### DIFF
--- a/python/sglang/kernels/ops/moe/ep_moe_kernels.py
+++ b/python/sglang/kernels/ops/moe/ep_moe_kernels.py
@@ -241,7 +241,7 @@ def pre_reorder_triton_kernel_for_cutlass_moe(
         for idx in range(topk):
             expert_id = tl.load(token_topk_ids_ptr + idx)
             if expert_id != num_local_experts:
-                dst_idx = tl.load(token_src2dst_ptr + idx)
+                dst_idx = tl.load(token_src2dst_ptr + idx).to(tl.int64)
                 tl.store(dst_ptr_offs + dst_idx * hidden_size, out_data, mask=mask)
 
 


### PR DESCRIPTION
## Motivation

<img width="755" height="561" alt="image" src="https://github.com/user-attachments/assets/33953193-ec5e-458b-bcd3-971e9643db58" />

`pre_reorder_triton_kernel_for_cutlass_moe` loads `dst_idx` from the `src2dst` mapping as an `int32` and uses it to calculate the destination address:

```python
dst_ptr_offs + dst_idx * hidden_size
```

Because `dst_idx` is 32-bit, `dst_idx * hidden_size` can overflow signed 32-bit arithmetic when the destination activation buffer contains more than `2**31` elements.

For example, with `hidden_size = 6144`, the first overflowing destination row is:

```text
ceil(2**31 / 6144) = 349,526
```

This is reachable during large expert-parallel prefill workloads. The wrapped offset can cause a CUDA illegal memory access or write to an incorrect GPU address.

## Modifications

Promote `dst_idx` to `tl.int64` immediately after loading it:

```python
dst_idx = tl.load(token_src2dst_ptr + idx).to(tl.int64)
```

This ensures that the multiplication by `hidden_size` and the destination pointer offset are evaluated using 64-bit arithmetic.

The `src2dst` mapping remains `int32`; only the address calculation is widened.

## Accuracy Tests

The change only affects destination address arithmetic. Outputs below the signed 32-bit offset boundary remain unchanged.

The overflow boundary can be validated with an FP8 destination buffer using:

- `hidden_size = 6144`
- `dst_idx = 349,526`
- A destination element offset greater than `2**31`
- One BF16 input row converted and written to the selected FP8 row

Expected behavior:

- Before the fix: CUDA illegal memory access or an incorrect destination write.
- After the fix: the selected destination row matches the FP8-converted input row.

Large-offset validation requires a CUDA GPU with enough memory for a contiguous allocation larger than 2 GiB.

## Speed Tests and Profiling

Not benchmarked.

The change adds one scalar `int32`-to-`int64` conversion for each valid routed destination. It does not change the number of loads, stores, kernel launches, or transferred elements.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Documentation changes are not required for this internal kernel fix.
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32833006827](https://github.com/sgl-project/sglang/actions/runs/32833006827)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32833007031](https://github.com/sgl-project/sglang/actions/runs/32833007031)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32833006686](https://github.com/sgl-project/sglang/actions/runs/32833006686)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->