### PR TITLE
[Kernel] Barrier-free 2shot_push custom all-reduce for the mid-size band

### DIFF
--- a/python/sglang/kernels/jit/csrc/distributed/custom_all_reduce.cuh
+++ b/python/sglang/kernels/jit/csrc/distributed/custom_all_reduce.cuh
@@ -8,9 +8,9 @@
 //   - 2shot_pull: reduce-scatter fused with all-gather; each rank reduces its
 //     shard in place so every workspace ends up holding the full result.
 //   - 2shot_lamport: the same reduce-scatter, but the all-gather pushes each
-//     reduced shard into a separate lamport plane instead of the peers' pull
-//     workspaces. Readiness then rides in the data, so the exit barrier goes
-//     away: a rank copies each peer's shard out the moment it lands.
+//     reduced shard into the shared Lamport push plane instead of the peers'
+//     pull workspaces. Readiness then rides in the data, so the exit barrier
+//     goes away: a rank copies each peer's shard out the moment it lands.
 //
 // Unlike the previous implementation, the kernels carry no storage or IPC
 // logic: all pointers arrive via the communication planes (owned by Python)
@@ -309,7 +309,14 @@ ALL_REDUCE_KERNEL void all_reduce_2shot_lamport_kernel(
   }
 
   const auto num_threads = blockDim.x * gridDim.x;
-  const auto global_tid = blockIdx.x * blockDim.x + threadIdx.x;
+  const auto num_remote_vecs = num_total_vecs - num_vecs;
+  const auto block_major_tid = blockIdx.x * blockDim.x + threadIdx.x;
+  const auto warp_in_block = threadIdx.x / kWarpThreads;
+  const auto lane_id = threadIdx.x % kWarpThreads;
+  const auto global_warp_id = blockIdx.x + gridDim.x * warp_in_block;
+  const auto warp_striped_tid = global_warp_id * kWarpThreads + lane_id;
+  const auto global_tid =
+      num_remote_vecs < num_threads ? warp_striped_tid : block_major_tid;
 
   // shot 1: reduce our own shard from every peer, write it straight to our
   // output, and push it into every peer's gather plane.
@@ -330,7 +337,6 @@ ALL_REDUCE_KERNEL void all_reduce_2shot_lamport_kernel(
   vec_t pos_zero_vec;
   Lamport::fill_pos_zero(pos_zero_vec.data());
   const auto local_gather = gather_ptrs[params.rank];
-  const auto num_remote_vecs = num_total_vecs - num_vecs;
   for (auto rid = global_tid; rid < num_remote_vecs; rid += num_threads) {
     // compact the two remote ranges around our own, already-written shard
     const auto vid = rid < vec_offset ? rid : rid + num_vecs;
@@ -427,8 +433,8 @@ struct AllReduceKernel {
     const auto& pull = comm.get_pull_obj();
     const auto graph_params = use_graph ? graph_params_opt.value().data_ptr() : nullptr;
     // only 2shot pull + graph mode forces inplace implementation
-    // (2shot_lamport gathers through its own plane, so it never writes over
-    // an input a peer may still be reducing)
+    // (2shot_lamport gathers through the shared push plane, so it never
+    // writes over an input a peer may still be reducing)
     const auto is_inplace = use_graph && algo == "2shot_pull";
     Tensor out = is_inplace ? in : ffi::empty_like(in);
     const auto params = PullParams{
@@ -467,7 +473,7 @@ struct AllReduceKernel {
     using LS_GRAPH = LoadStoreImpl<vec_t, kWorldSize, /*kUseGraph=*/true>;
     using MC = MultiCastImpl<vec_t, kWorldSize, /*kUseGraph=*/false>;
     if (algo == "2shot_lamport") {
-      CHECK_HOST(!use_multicast) << "2shot_lamport gathers through its own plane, not multimem";
+      CHECK_HOST(!use_multicast) << "2shot_lamport gathers through the shared push plane, not multimem";
       const auto& gather = comm.get_gather_obj();
       const uint32_t lamport_blocks = gather.num_blocks;
       CHECK_HOST(lamport_blocks <= pull.num_blocks)

--- a/python/sglang/kernels/jit/csrc/distributed/custom_all_reduce.cuh
+++ b/python/sglang/kernels/jit/csrc/distributed/custom_all_reduce.cuh
@@ -7,9 +7,10 @@
 //     workspaces, a CUDA-graph pointer table, or a multicast address).
 //   - 2shot_pull: reduce-scatter fused with all-gather; each rank reduces its
 //     shard in place so every workspace ends up holding the full result.
-//   - 2shot_lamport: the same reduce-scatter, but the all-gather pushes each
-//     reduced shard into the shared Lamport push plane instead of the peers'
-//     pull workspaces. Readiness then rides in the data, so the exit barrier
+//   - 2shot_push: the same reduce-scatter, but the all-gather pushes each
+//     reduced shard into the shared push plane instead of the peers' pull
+//     workspaces. Readiness then rides in the data — the same pos-zero marker
+//     1shot_push uses, which is what "push" names here — so the exit barrier
 //     goes away: a rank copies each peer's shard out the moment it lands.
 //
 // Unlike the previous implementation, the kernels carry no storage or IPC
@@ -66,7 +67,7 @@ struct AllReducePullParams {
 };
 
 template <uint32_t kWorldSize>
-struct AllReduceLamportParams {
+struct AllReduce2ShotPushParams {
   void* __restrict__ output;
   uint32_t num_vecs;
   uint32_t rank;
@@ -88,7 +89,7 @@ struct LoadStoreImpl {
   static constexpr uint32_t size() {
     return kWorldSize;
   }
-  /// Templated on the params struct so the lamport kernel, whose params carry
+  /// Templated on the params struct so the 2shot_push kernel, whose params carry
   /// a gather plane as well, reuses the same peer table.
   template <typename Params>
   SGL_DEVICE LoadStoreImpl(const Params& params, uint32_t vec_offset = 0) {
@@ -279,8 +280,8 @@ ALL_REDUCE_KERNEL void all_reduce_2shot_pull_kernel(const __grid_constant__ AllR
 }
 
 template <typename Impl, typename T, uint32_t kWorldSize, bool kUsePDL>
-ALL_REDUCE_KERNEL void all_reduce_2shot_lamport_kernel(
-    const __grid_constant__ AllReduceLamportParams<kWorldSize> params) {
+ALL_REDUCE_KERNEL void all_reduce_2shot_push_kernel(
+    const __grid_constant__ AllReduce2ShotPushParams<kWorldSize> params) {
   using namespace device;
   constexpr uint32_t kVecSize = 16 / (sizeof(T) * 2);
   using vec_t = AlignedVector<packed_t<T>, kVecSize>;
@@ -398,7 +399,7 @@ struct AllReduceKernel {
       const bool use_multicast) {
     using namespace host;
     const auto& comm = *comm_ref.get();
-    CHECK_HOST(algo == "1shot_pull" || algo == "2shot_pull" || algo == "1shot_push" || algo == "2shot_lamport")
+    CHECK_HOST(algo == "1shot_pull" || algo == "2shot_pull" || algo == "1shot_push" || algo == "2shot_push")
         << algo;
     CHECK_HOST(comm.get_world_size() == kWorldSize) << comm.get_world_size();
     CHECK_HOST(in.IsContiguous() && is_type<T>(in.dtype()) && in.device().device_type == kDLCUDA);
@@ -433,7 +434,7 @@ struct AllReduceKernel {
     const auto& pull = comm.get_pull_obj();
     const auto graph_params = use_graph ? graph_params_opt.value().data_ptr() : nullptr;
     // only 2shot pull + graph mode forces inplace implementation
-    // (2shot_lamport gathers through the shared push plane, so it never
+    // (2shot_push gathers through the shared push plane, so it never
     // writes over an input a peer may still be reducing)
     const auto is_inplace = use_graph && algo == "2shot_pull";
     Tensor out = is_inplace ? in : ffi::empty_like(in);
@@ -472,14 +473,14 @@ struct AllReduceKernel {
     using LS = LoadStoreImpl<vec_t, kWorldSize, /*kUseGraph=*/false>;
     using LS_GRAPH = LoadStoreImpl<vec_t, kWorldSize, /*kUseGraph=*/true>;
     using MC = MultiCastImpl<vec_t, kWorldSize, /*kUseGraph=*/false>;
-    if (algo == "2shot_lamport") {
-      CHECK_HOST(!use_multicast) << "2shot_lamport gathers through the shared push plane, not multimem";
+    if (algo == "2shot_push") {
+      CHECK_HOST(!use_multicast) << "2shot_push gathers through the shared push plane, not multimem";
       const auto& gather = comm.get_gather_obj();
-      const uint32_t lamport_blocks = gather.num_blocks;
-      CHECK_HOST(lamport_blocks <= pull.num_blocks)
-          << "gather plane is " << lamport_blocks << " blocks wide but only " << pull.num_blocks
+      const uint32_t gather_blocks = gather.num_blocks;
+      CHECK_HOST(gather_blocks <= pull.num_blocks)
+          << "gather plane is " << gather_blocks << " blocks wide but only " << pull.num_blocks
           << " pull semaphores back it";
-      const auto lamport_params = AllReduceLamportParams<kWorldSize>{
+      const auto gather_params = AllReduce2ShotPushParams<kWorldSize>{
           .output = out.data_ptr(),
           .num_vecs = num_vecs,
           .rank = pull.rank,
@@ -488,10 +489,10 @@ struct AllReduceKernel {
           .gather = gather.get_workspace<kWorldSize>(div_ceil(nbytes, int64_t{kWorldSize})),
       };
       if (!use_graph) cuda_memcpy(local_workspace, in.data_ptr());
-      const auto kernel = use_graph ? all_reduce_2shot_lamport_kernel<LS_GRAPH, T, kWorldSize, kUsePDL>
-                                    : all_reduce_2shot_lamport_kernel<LS, T, kWorldSize, kUsePDL>;
-      LaunchKernel(lamport_blocks, choose_block_size(num_vecs), stream)  //
-          .enable_pdl(kUsePDL)(kernel, lamport_params);
+      const auto kernel = use_graph ? all_reduce_2shot_push_kernel<LS_GRAPH, T, kWorldSize, kUsePDL>
+                                    : all_reduce_2shot_push_kernel<LS, T, kWorldSize, kUsePDL>;
+      LaunchKernel(gather_blocks, choose_block_size(num_vecs), stream)  //
+          .enable_pdl(kUsePDL)(kernel, gather_params);
       return out;
     }
     if (algo == "1shot_pull") {

--- a/python/sglang/kernels/jit/csrc/distributed/custom_all_reduce.cuh
+++ b/python/sglang/kernels/jit/csrc/distributed/custom_all_reduce.cuh
@@ -1,17 +1,16 @@
 // Custom all-reduce kernels over the decoupled Communicator storage plane.
 //
-// Three algorithms are provided behind one entry point:
+// Four algorithms are provided behind one entry point:
 //   - 1shot_push: lamport-style push of local data to every peer's push
 //     workspace, then a local polling reduce (best at small sizes).
 //   - 1shot_pull: every rank reduces all peers' data (from the symmetric pull
 //     workspaces, a CUDA-graph pointer table, or a multicast address).
 //   - 2shot_pull: reduce-scatter fused with all-gather; each rank reduces its
 //     shard in place so every workspace ends up holding the full result.
-//   - 2shot_push: the same reduce-scatter, but the all-gather pushes each
-//     reduced shard into the shared push plane instead of the peers' pull
-//     workspaces. Readiness then rides in the data — the same pos-zero marker
-//     1shot_push uses, which is what "push" names here — so the exit barrier
-//     goes away: a rank copies each peer's shard out the moment it lands.
+//   - 2shot_scatter: the same reduce-scatter / all-gather split, but both
+//     halves push. Readiness rides in the data — the same pos-zero marker
+//     1shot_push uses, which is what "push" names here — so neither half
+//     needs a barrier and no rank ever reads a peer's input.
 //
 // Unlike the previous implementation, the kernels carry no storage or IPC
 // logic: all pointers arrive via the communication planes (owned by Python)
@@ -67,13 +66,14 @@ struct AllReducePullParams {
 };
 
 template <uint32_t kWorldSize>
-struct AllReduce2ShotPushParams {
+struct AllReduce2ShotScatterParams {
+  const void* __restrict__ input;
   void* __restrict__ output;
   uint32_t num_vecs;
   uint32_t rank;
-  void* const* __restrict__ graph_params;
-  PullWorkSpace<kWorldSize> ws;
-  PushWorkSpace<kWorldSize> gather;
+  uint32_t slot_vecs;  // div_ceil(num_vecs, kWorldSize): shard slot stride
+  PushWorkSpace<kWorldSize> scatter;  // one shard slot per source
+  PushWorkSpace<kWorldSize> gather;   // the shared push plane, flat per half
 };
 
 /// `vec_offset` is a *vector index* and must stay folded into the base pointers
@@ -89,8 +89,8 @@ struct LoadStoreImpl {
   static constexpr uint32_t size() {
     return kWorldSize;
   }
-  /// Templated on the params struct so the 2shot_push kernel, whose params carry
-  /// a gather workspace as well, reuses the same peer table.
+  /// Templated on the params struct so kernels whose params carry extra
+  /// workspaces reuse the same peer table.
   template <typename Params>
   SGL_DEVICE LoadStoreImpl(const Params& params, uint32_t vec_offset = 0) {
     if constexpr (kUseGraph) {
@@ -279,68 +279,102 @@ ALL_REDUCE_KERNEL void all_reduce_2shot_pull_kernel(const __grid_constant__ AllR
   barrier.arrive_rel_acq(/*n=*/1);
 }
 
-template <typename Impl, typename T, uint32_t kWorldSize, bool kUsePDL>
-ALL_REDUCE_KERNEL void all_reduce_2shot_push_kernel(
-    const __grid_constant__ AllReduce2ShotPushParams<kWorldSize> params) {
+/// Barrier-free two-shot all-reduce with a *pushed* reduce-scatter.
+///
+///   A: push my input, shard-wise, into each owner's scatter slot;
+///   B: poll my own scatter slots, reduce my shard, push it into every peer's
+///      gather half of the shared push plane, restore the scatter markers;
+///   C: drain my gather half into the output, restoring its markers.
+template <typename T, uint32_t kWorldSize, bool kUsePDL, bool kUseMc = false>
+ALL_REDUCE_KERNEL void all_reduce_2shot_scatter_kernel(
+    const __grid_constant__ AllReduce2ShotScatterParams<kWorldSize> params) {
   using namespace device;
   constexpr uint32_t kVecSize = 16 / (sizeof(T) * 2);
   using vec_t = AlignedVector<packed_t<T>, kVecSize>;
   using Lamport = distributed::LamportTrait<T, kVecSize * 2, /*kAtom=*/4>;
-  const auto num_total_vecs = params.num_vecs;
-  const auto avg_vecs = num_total_vecs / kWorldSize;
-  const auto rem_vecs = num_total_vecs % kWorldSize;
-  const auto num_vecs = avg_vecs + (params.rank < rem_vecs ? 1 : 0);
-  const auto vec_offset = params.rank * avg_vecs + min(params.rank, rem_vecs);
-  const auto impl = Impl{params, vec_offset};
-  PDLWaitPrimary<kUsePDL>();
-  const auto epoch = distributed::PushEpoch<kWorldSize>{params.gather};
-  const auto barrier = distributed::Barrier<kWorldSize>{
-      params.ws.semaphores.data(),
-      params.rank,
-      /*num_arrives=*/1,
-  };
-  barrier.arrive_relaxed(/*n=*/0);
-  __syncthreads();
-
-  // One slot per peer, so the epoch's half of the plane holds a whole message.
-  void* gather_ptrs[kWorldSize];
-#pragma unroll
-  for (uint32_t i = 0; i < kWorldSize; ++i) {
-    gather_ptrs[i] = epoch.slot_ptr(/*dst=*/i);
-  }
-
+  const auto r = params.rank;
+  const auto num_vecs = params.num_vecs;
+  const auto slot_vecs = params.slot_vecs;
   const auto num_threads = blockDim.x * gridDim.x;
-  const auto num_remote_vecs = num_total_vecs - num_vecs;
-  const auto block_major_tid = blockIdx.x * blockDim.x + threadIdx.x;
-  const auto warp_in_block = threadIdx.x / kWarpThreads;
-  const auto lane_id = threadIdx.x % kWarpThreads;
-  const auto global_warp_id = blockIdx.x + gridDim.x * warp_in_block;
-  const auto warp_striped_tid = global_warp_id * kWarpThreads + lane_id;
-  const auto global_tid =
-      num_remote_vecs < num_threads ? warp_striped_tid : block_major_tid;
+  const auto global_tid = blockIdx.x * blockDim.x + threadIdx.x;
+  PDLWaitPrimary<kUsePDL>();
+  const auto scatter_epoch = distributed::PushEpoch<kWorldSize>{params.scatter};
+  const auto gather_epoch = distributed::PushEpoch<kWorldSize>{params.gather};
 
-  // shot 1: reduce our own shard from every peer, write it straight to our
-  // output, and push it into every peer's gather plane.
-  for (auto vid = global_tid; vid < num_vecs; vid += num_threads) {
-    vec_t vec;
-    impl.load_reduce(vec, vid);
-    Lamport::clear_pos_zero(vec.data());
-    const auto out_vid = vec_offset + vid;
-    vec.store(params.output, out_vid);
-#pragma unroll
-    for (uint32_t i = 0; i < kWorldSize; ++i) {
-      if (i != params.rank) ptx::st_relaxed_16B(vec, gather_ptrs[i], out_vid);
+  const auto my_lo = r * slot_vecs;
+  const auto my_hi = min((r + 1) * slot_vecs, num_vecs);
+  const auto my_len = my_hi > my_lo ? my_hi - my_lo : 0;
+
+  // A: scatter my input to the owners (my own shard is read locally in B).
+  // Each warp takes one destination -- rotated so every peer's ingress port
+  // is busy from the first wave -- instead of a vid loop deriving the
+  // destination by a runtime division per vector. The slot pointer is then
+  // warp-uniform, the lanes write coalesced runs, and every warp has work at
+  // every size.
+  {
+    constexpr uint32_t kFan = kWorldSize - 1;
+    const auto warp = global_tid / 32;
+    const auto lane = global_tid % 32;
+    const auto num_warps = num_threads / 32;
+    auto dst = r + 1 + warp % kFan;
+    if (dst >= kWorldSize) dst -= kWorldSize;
+    const auto group_warps = num_warps / kFan + (warp % kFan < num_warps % kFan ? 1 : 0);
+    const auto lo = min(dst * slot_vecs, num_vecs);
+    const auto len = min(lo + slot_vecs, num_vecs) - lo;
+    const auto slot = scatter_epoch.slot_ptr(dst, r);
+    for (auto lid = (warp / kFan) * 32 + lane; lid < len; lid += group_warps * 32) {
+      vec_t vec;
+      vec.load(params.input, lo + lid);
+      Lamport::clear_pos_zero(vec.data());
+      ptx::st_relaxed_16B(vec, slot, lid);
     }
   }
 
-  // shot 2: poll the peers' shards out of our own gather region, restoring the
-  // marker behind us so this epoch comes back around empty.
   vec_t pos_zero_vec;
   Lamport::fill_pos_zero(pos_zero_vec.data());
-  const auto local_gather = gather_ptrs[params.rank];
+
+  // B: reduce my shard out of my scatter slots, fan the result out
+  for (auto lid = global_tid; lid < my_len; lid += num_threads) {
+    const auto vid = my_lo + lid;
+    vec_t vecs[kWorldSize];
+    vecs[r].load(params.input, vid);
+    do {
+      bool has_zero = false;
+#pragma unroll
+      for (uint32_t src = 0; src < kWorldSize; ++src) {
+        if (src != r) {
+          ptx::ld_relaxed_16B(vecs[src], scatter_epoch.slot_ptr(r, src), lid);
+          has_zero |= Lamport::has_pos_zero(vecs[src].data());
+        }
+      }
+      if (!has_zero) break;
+    } while (true);
+    vec_t out = reduce_vec(vecs);
+    Lamport::clear_pos_zero(out.data());
+    if constexpr (kUseMc) {
+      // one multimem store instead of the unicast fan-out (total egress
+      // 1.5S -> 1.0S). It also lands in our own gather half, which nobody
+      // drains; phase C restores those markers so the shared slots come
+      // back clean for the plane's next user.
+      ptx::st_multimem_16B(out, params.gather.mc_workspace + gather_epoch.slot_offset(), vid);
+    } else {
+#pragma unroll
+      for (uint32_t dst = 0; dst < kWorldSize; ++dst) {
+        if (dst != r) ptx::st_relaxed_16B(out, gather_epoch.slot_ptr(dst), vid);
+      }
+    }
+    out.store(params.output, vid);
+#pragma unroll
+    for (uint32_t src = 0; src < kWorldSize; ++src) {
+      if (src != r) ptx::st_global_16B(pos_zero_vec, scatter_epoch.slot_ptr(r, src), lid);
+    }
+  }
+
+  // C: drain the gather half (everyone else's shards) into the output
+  const auto local_gather = gather_epoch.slot_ptr(r);
+  const auto num_remote_vecs = num_vecs - my_len;
   for (auto rid = global_tid; rid < num_remote_vecs; rid += num_threads) {
-    // compact the two remote ranges around our own, already-written shard
-    const auto vid = rid < vec_offset ? rid : rid + num_vecs;
+    const auto vid = rid < my_lo ? rid : rid + my_len;
     vec_t vec;
     do {
       ptx::ld_relaxed_16B(vec, local_gather, vid);
@@ -350,9 +384,21 @@ ALL_REDUCE_KERNEL void all_reduce_2shot_push_kernel(
     ptx::st_global_16B(pos_zero_vec, local_gather, vid);
   }
 
+  if constexpr (kUseMc) {
+    for (auto lid = global_tid; lid < my_len; lid += num_threads) {
+      const auto vid = my_lo + lid;
+      vec_t vec;
+      do {
+        ptx::ld_relaxed_16B(vec, local_gather, vid);
+        if (!Lamport::has_pos_zero(vec.data())) break;
+      } while (true);
+      ptx::st_global_16B(pos_zero_vec, local_gather, vid);
+    }
+  }
+
   PDLTriggerSecondary<kUsePDL>();
   __syncthreads();
-  epoch.flip();
+  gather_epoch.flip();  // one flip: the planes share the counter
 }
 
 template <uint32_t N>
@@ -399,7 +445,8 @@ struct AllReduceKernel {
       const bool use_multicast) {
     using namespace host;
     const auto& comm = *comm_ref.get();
-    CHECK_HOST(algo == "1shot_pull" || algo == "2shot_pull" || algo == "1shot_push" || algo == "2shot_push")
+    CHECK_HOST(
+        algo == "1shot_pull" || algo == "2shot_pull" || algo == "1shot_push" || algo == "2shot_scatter")
         << algo;
     CHECK_HOST(comm.get_world_size() == kWorldSize) << comm.get_world_size();
     CHECK_HOST(in.IsContiguous() && is_type<T>(in.dtype()) && in.device().device_type == kDLCUDA);
@@ -431,11 +478,34 @@ struct AllReduceKernel {
       return out;
     }
 
+    if (algo == "2shot_scatter") {
+      CHECK_HOST(!use_graph);  // reads only our own input: nothing to register
+      const auto& push = comm.get_push_obj();
+      const auto& scatter = comm.get_scatter_obj();
+      const auto slot_vecs = div_ceil(num_vecs, kWorldSize);
+      Tensor out = ffi::empty_like(in);
+      const auto params = AllReduce2ShotScatterParams<kWorldSize>{
+          .input = in.data_ptr(),
+          .output = out.data_ptr(),
+          .num_vecs = num_vecs,
+          .rank = push.rank,
+          .slot_vecs = slot_vecs,
+          .scatter = scatter.get_workspace<kWorldSize>(int64_t{slot_vecs} * 16),
+          .gather = push.get_workspace<kWorldSize>(div_ceil(nbytes, int64_t{kWorldSize})),
+      };
+      CHECK_HOST(!use_multicast || params.gather.mc_workspace != nullptr)
+          << "multicast needs a push plane with an mc workspace";
+      const auto kernel = use_multicast
+          ? all_reduce_2shot_scatter_kernel<T, kWorldSize, kUsePDL, /*kUseMc=*/true>
+          : all_reduce_2shot_scatter_kernel<T, kWorldSize, kUsePDL>;
+      LaunchKernel(push.num_blocks, choose_block_size(num_vecs), stream)  //
+          .enable_pdl(kUsePDL)(kernel, params);
+      return out;
+    }
+
     const auto& pull = comm.get_pull_obj();
     const auto graph_params = use_graph ? graph_params_opt.value().data_ptr() : nullptr;
     // only 2shot pull + graph mode forces inplace implementation
-    // (2shot_push gathers through the shared push plane, so it never
-    // writes over an input a peer may still be reducing)
     const auto is_inplace = use_graph && algo == "2shot_pull";
     Tensor out = is_inplace ? in : ffi::empty_like(in);
     const auto params = PullParams{
@@ -473,31 +543,6 @@ struct AllReduceKernel {
     using LS = LoadStoreImpl<vec_t, kWorldSize, /*kUseGraph=*/false>;
     using LS_GRAPH = LoadStoreImpl<vec_t, kWorldSize, /*kUseGraph=*/true>;
     using MC = MultiCastImpl<vec_t, kWorldSize, /*kUseGraph=*/false>;
-    if (algo == "2shot_push") {
-      CHECK_HOST(!use_multicast) << "2shot_push gathers through the shared push plane, not multimem";
-      // The all-gather half rides the 1shot_push plane, so it inherits that
-      // grid -- bound to the counter array -- and lands in slots that must
-      // have been sized to hold a shard (`get_workspace` checks that).
-      const auto& push = comm.get_push_obj();
-      const uint32_t gather_blocks = push.num_blocks;
-      CHECK_HOST(gather_blocks <= pull.num_blocks)
-          << "push plane is " << gather_blocks << " blocks wide but only " << pull.num_blocks
-          << " pull semaphores back it";
-      const auto gather_params = AllReduce2ShotPushParams<kWorldSize>{
-          .output = out.data_ptr(),
-          .num_vecs = num_vecs,
-          .rank = pull.rank,
-          .graph_params = static_cast<void* const*>(graph_params),
-          .ws = ws,
-          .gather = push.get_workspace<kWorldSize>(div_ceil(nbytes, int64_t{kWorldSize})),
-      };
-      if (!use_graph) cuda_memcpy(local_workspace, in.data_ptr());
-      const auto kernel = use_graph ? all_reduce_2shot_push_kernel<LS_GRAPH, T, kWorldSize, kUsePDL>
-                                    : all_reduce_2shot_push_kernel<LS, T, kWorldSize, kUsePDL>;
-      LaunchKernel(gather_blocks, choose_block_size(num_vecs), stream)  //
-          .enable_pdl(kUsePDL)(kernel, gather_params);
-      return out;
-    }
     if (algo == "1shot_pull") {
       // first copy to the workspace
       CHECK_HOST(!use_multicast);

--- a/python/sglang/kernels/jit/csrc/distributed/custom_all_reduce.cuh
+++ b/python/sglang/kernels/jit/csrc/distributed/custom_all_reduce.cuh
@@ -71,7 +71,7 @@ struct AllReduce2ShotPushParams {
   void* __restrict__ output;
   uint32_t num_vecs;
   uint32_t rank;
-  uint32_t slot_vecs;  // div_ceil(num_vecs, kWorldSize): shard slot stride
+  uint32_t slot_vecs;                 // div_ceil(num_vecs, kWorldSize): shard slot stride
   PushWorkSpace<kWorldSize> scatter;  // one shard slot per source
   PushWorkSpace<kWorldSize> gather;   // the shared push plane, flat per half
 };
@@ -286,8 +286,8 @@ ALL_REDUCE_KERNEL void all_reduce_2shot_pull_kernel(const __grid_constant__ AllR
 ///      gather half of the shared push plane, restore the scatter markers;
 ///   C: drain my gather half into the output, restoring its markers.
 template <typename T, uint32_t kWorldSize, bool kUsePDL, bool kUseMc = false>
-ALL_REDUCE_KERNEL void all_reduce_2shot_push_kernel(
-    const __grid_constant__ AllReduce2ShotPushParams<kWorldSize> params) {
+ALL_REDUCE_KERNEL void
+all_reduce_2shot_push_kernel(const __grid_constant__ AllReduce2ShotPushParams<kWorldSize> params) {
   using namespace device;
   constexpr uint32_t kVecSize = 16 / (sizeof(T) * 2);
   using vec_t = AlignedVector<packed_t<T>, kVecSize>;
@@ -448,9 +448,7 @@ struct AllReduceKernel {
       const bool use_multicast) {
     using namespace host;
     const auto& comm = *comm_ref.get();
-    CHECK_HOST(
-        algo == "1shot_pull" || algo == "2shot_pull" || algo == "1shot_push" || algo == "2shot_push")
-        << algo;
+    CHECK_HOST(algo == "1shot_pull" || algo == "2shot_pull" || algo == "1shot_push" || algo == "2shot_push") << algo;
     CHECK_HOST(comm.get_world_size() == kWorldSize) << comm.get_world_size();
     CHECK_HOST(in.IsContiguous() && is_type<T>(in.dtype()) && in.device().device_type == kDLCUDA);
     const auto num_elems_int64 = in.numel();
@@ -497,9 +495,8 @@ struct AllReduceKernel {
       };
       CHECK_HOST(!use_multicast || params.gather.mc_workspace != nullptr)
           << "multicast needs a push plane with an mc workspace";
-      const auto kernel = use_multicast
-          ? all_reduce_2shot_push_kernel<T, kWorldSize, kUsePDL, /*kUseMc=*/true>
-          : all_reduce_2shot_push_kernel<T, kWorldSize, kUsePDL>;
+      const auto kernel = use_multicast ? all_reduce_2shot_push_kernel<T, kWorldSize, kUsePDL, /*kUseMc=*/true>
+                                        : all_reduce_2shot_push_kernel<T, kWorldSize, kUsePDL>;
       LaunchKernel(push.num_blocks, choose_block_size(num_vecs), stream)  //
           .enable_pdl(kUsePDL)(kernel, params);
       return out;

--- a/python/sglang/kernels/jit/csrc/distributed/custom_all_reduce.cuh
+++ b/python/sglang/kernels/jit/csrc/distributed/custom_all_reduce.cuh
@@ -7,7 +7,7 @@
 //     workspaces, a CUDA-graph pointer table, or a multicast address).
 //   - 2shot_pull: reduce-scatter fused with all-gather; each rank reduces its
 //     shard in place so every workspace ends up holding the full result.
-//   - 2shot_scatter: the same reduce-scatter / all-gather split, but both
+//   - 2shot_push: the same reduce-scatter / all-gather split, but both
 //     halves push. Readiness rides in the data — the same pos-zero marker
 //     1shot_push uses, which is what "push" names here — so neither half
 //     needs a barrier and no rank ever reads a peer's input.
@@ -66,7 +66,7 @@ struct AllReducePullParams {
 };
 
 template <uint32_t kWorldSize>
-struct AllReduce2ShotScatterParams {
+struct AllReduce2ShotPushParams {
   const void* __restrict__ input;
   void* __restrict__ output;
   uint32_t num_vecs;
@@ -286,8 +286,8 @@ ALL_REDUCE_KERNEL void all_reduce_2shot_pull_kernel(const __grid_constant__ AllR
 ///      gather half of the shared push plane, restore the scatter markers;
 ///   C: drain my gather half into the output, restoring its markers.
 template <typename T, uint32_t kWorldSize, bool kUsePDL, bool kUseMc = false>
-ALL_REDUCE_KERNEL void all_reduce_2shot_scatter_kernel(
-    const __grid_constant__ AllReduce2ShotScatterParams<kWorldSize> params) {
+ALL_REDUCE_KERNEL void all_reduce_2shot_push_kernel(
+    const __grid_constant__ AllReduce2ShotPushParams<kWorldSize> params) {
   using namespace device;
   constexpr uint32_t kVecSize = 16 / (sizeof(T) * 2);
   using vec_t = AlignedVector<packed_t<T>, kVecSize>;
@@ -337,7 +337,10 @@ ALL_REDUCE_KERNEL void all_reduce_2shot_scatter_kernel(
   for (auto lid = global_tid; lid < my_len; lid += num_threads) {
     const auto vid = my_lo + lid;
     vec_t vecs[kWorldSize];
-    vecs[r].load(params.input, vid);
+#pragma unroll
+    for (uint32_t src = 0; src < kWorldSize; ++src) {
+      if (src == r) vecs[src].load(params.input, vid);
+    }
     do {
       bool has_zero = false;
 #pragma unroll
@@ -398,7 +401,7 @@ ALL_REDUCE_KERNEL void all_reduce_2shot_scatter_kernel(
 
   PDLTriggerSecondary<kUsePDL>();
   __syncthreads();
-  gather_epoch.flip();  // one flip: the planes share the counter
+  gather_epoch.flip();  // one flip: both regions share the plane's counter
 }
 
 template <uint32_t N>
@@ -446,7 +449,7 @@ struct AllReduceKernel {
     using namespace host;
     const auto& comm = *comm_ref.get();
     CHECK_HOST(
-        algo == "1shot_pull" || algo == "2shot_pull" || algo == "1shot_push" || algo == "2shot_scatter")
+        algo == "1shot_pull" || algo == "2shot_pull" || algo == "1shot_push" || algo == "2shot_push")
         << algo;
     CHECK_HOST(comm.get_world_size() == kWorldSize) << comm.get_world_size();
     CHECK_HOST(in.IsContiguous() && is_type<T>(in.dtype()) && in.device().device_type == kDLCUDA);
@@ -478,26 +481,25 @@ struct AllReduceKernel {
       return out;
     }
 
-    if (algo == "2shot_scatter") {
+    if (algo == "2shot_push") {
       CHECK_HOST(!use_graph);  // reads only our own input: nothing to register
       const auto& push = comm.get_push_obj();
-      const auto& scatter = comm.get_scatter_obj();
       const auto slot_vecs = div_ceil(num_vecs, kWorldSize);
       Tensor out = ffi::empty_like(in);
-      const auto params = AllReduce2ShotScatterParams<kWorldSize>{
+      const auto params = AllReduce2ShotPushParams<kWorldSize>{
           .input = in.data_ptr(),
           .output = out.data_ptr(),
           .num_vecs = num_vecs,
           .rank = push.rank,
           .slot_vecs = slot_vecs,
-          .scatter = scatter.get_workspace<kWorldSize>(int64_t{slot_vecs} * 16),
+          .scatter = push.get_scatter_workspace<kWorldSize>(int64_t{slot_vecs} * 16),
           .gather = push.get_workspace<kWorldSize>(div_ceil(nbytes, int64_t{kWorldSize})),
       };
       CHECK_HOST(!use_multicast || params.gather.mc_workspace != nullptr)
           << "multicast needs a push plane with an mc workspace";
       const auto kernel = use_multicast
-          ? all_reduce_2shot_scatter_kernel<T, kWorldSize, kUsePDL, /*kUseMc=*/true>
-          : all_reduce_2shot_scatter_kernel<T, kWorldSize, kUsePDL>;
+          ? all_reduce_2shot_push_kernel<T, kWorldSize, kUsePDL, /*kUseMc=*/true>
+          : all_reduce_2shot_push_kernel<T, kWorldSize, kUsePDL>;
       LaunchKernel(push.num_blocks, choose_block_size(num_vecs), stream)  //
           .enable_pdl(kUsePDL)(kernel, params);
       return out;

--- a/python/sglang/kernels/jit/csrc/distributed/custom_all_reduce.cuh
+++ b/python/sglang/kernels/jit/csrc/distributed/custom_all_reduce.cuh
@@ -333,8 +333,13 @@ all_reduce_2shot_push_kernel(const __grid_constant__ AllReduce2ShotPushParams<kW
   vec_t pos_zero_vec;
   Lamport::fill_pos_zero(pos_zero_vec.data());
 
+  const bool spread_shard = my_len * 4 <= num_threads;
+  const auto tid_bc = spread_shard
+      ? (blockIdx.x + gridDim.x * (threadIdx.x / 32)) * 32 + (threadIdx.x % 32)
+      : global_tid;
+
   // B: reduce my shard out of my scatter slots, fan the result out
-  for (auto lid = global_tid; lid < my_len; lid += num_threads) {
+  for (auto lid = tid_bc; lid < my_len; lid += num_threads) {
     const auto vid = my_lo + lid;
     vec_t vecs[kWorldSize];
 #pragma unroll
@@ -376,7 +381,7 @@ all_reduce_2shot_push_kernel(const __grid_constant__ AllReduce2ShotPushParams<kW
   // C: drain the gather half (everyone else's shards) into the output
   const auto local_gather = gather_epoch.slot_ptr(r);
   const auto num_remote_vecs = num_vecs - my_len;
-  for (auto rid = global_tid; rid < num_remote_vecs; rid += num_threads) {
+  for (auto rid = tid_bc; rid < num_remote_vecs; rid += num_threads) {
     const auto vid = rid < my_lo ? rid : rid + my_len;
     vec_t vec;
     do {
@@ -388,7 +393,7 @@ all_reduce_2shot_push_kernel(const __grid_constant__ AllReduce2ShotPushParams<kW
   }
 
   if constexpr (kUseMc) {
-    for (auto lid = global_tid; lid < my_len; lid += num_threads) {
+    for (auto lid = tid_bc; lid < my_len; lid += num_threads) {
       const auto vid = my_lo + lid;
       vec_t vec;
       do {

--- a/python/sglang/kernels/jit/csrc/distributed/custom_all_reduce.cuh
+++ b/python/sglang/kernels/jit/csrc/distributed/custom_all_reduce.cuh
@@ -7,6 +7,10 @@
 //     workspaces, a CUDA-graph pointer table, or a multicast address).
 //   - 2shot_pull: reduce-scatter fused with all-gather; each rank reduces its
 //     shard in place so every workspace ends up holding the full result.
+//   - 2shot_lamport: the same reduce-scatter, but the all-gather pushes each
+//     reduced shard into a separate lamport plane instead of the peers' pull
+//     workspaces. Readiness then rides in the data, so the exit barrier goes
+//     away: a rank copies each peer's shard out the moment it lands.
 //
 // Unlike the previous implementation, the kernels carry no storage or IPC
 // logic: all pointers arrive via the communication planes (owned by Python)
@@ -61,6 +65,16 @@ struct AllReducePullParams {
   PullWorkSpace<kWorldSize> ws;
 };
 
+template <uint32_t kWorldSize>
+struct AllReduceLamportParams {
+  void* __restrict__ output;
+  uint32_t num_vecs;
+  uint32_t rank;
+  void* const* __restrict__ graph_params;
+  PullWorkSpace<kWorldSize> ws;
+  PushWorkSpace<kWorldSize> gather;
+};
+
 /// `vec_offset` is a *vector index* and must stay folded into the base pointers
 /// here: a typed 32-bit bias becomes one widening multiply-add off a
 /// constant-bank base, which ptxas keeps on the uniform datapath, so the whole
@@ -74,7 +88,10 @@ struct LoadStoreImpl {
   static constexpr uint32_t size() {
     return kWorldSize;
   }
-  SGL_DEVICE LoadStoreImpl(const AllReducePullParams<kWorldSize>& params, uint32_t vec_offset = 0) {
+  /// Templated on the params struct so the lamport kernel, whose params carry
+  /// a gather plane as well, reuses the same peer table.
+  template <typename Params>
+  SGL_DEVICE LoadStoreImpl(const Params& params, uint32_t vec_offset = 0) {
     if constexpr (kUseGraph) {
 #pragma unroll
       for (uint32_t i = 0; i < kWorldSize; ++i) {
@@ -261,6 +278,76 @@ ALL_REDUCE_KERNEL void all_reduce_2shot_pull_kernel(const __grid_constant__ AllR
   barrier.arrive_rel_acq(/*n=*/1);
 }
 
+template <typename Impl, typename T, uint32_t kWorldSize, bool kUsePDL>
+ALL_REDUCE_KERNEL void all_reduce_2shot_lamport_kernel(
+    const __grid_constant__ AllReduceLamportParams<kWorldSize> params) {
+  using namespace device;
+  constexpr uint32_t kVecSize = 16 / (sizeof(T) * 2);
+  using vec_t = AlignedVector<packed_t<T>, kVecSize>;
+  using Lamport = distributed::LamportTrait<T, kVecSize * 2, /*kAtom=*/4>;
+  const auto num_total_vecs = params.num_vecs;
+  const auto avg_vecs = num_total_vecs / kWorldSize;
+  const auto rem_vecs = num_total_vecs % kWorldSize;
+  const auto num_vecs = avg_vecs + (params.rank < rem_vecs ? 1 : 0);
+  const auto vec_offset = params.rank * avg_vecs + min(params.rank, rem_vecs);
+  const auto impl = Impl{params, vec_offset};
+  PDLWaitPrimary<kUsePDL>();
+  const auto epoch = distributed::PushEpoch<kWorldSize>{params.gather};
+  const auto barrier = distributed::Barrier<kWorldSize>{
+      params.ws.semaphores.data(),
+      params.rank,
+      /*num_arrives=*/1,
+  };
+  barrier.arrive_relaxed(/*n=*/0);
+  __syncthreads();
+
+  // One slot per peer, so the epoch's half of the plane holds a whole message.
+  void* gather_ptrs[kWorldSize];
+#pragma unroll
+  for (uint32_t i = 0; i < kWorldSize; ++i) {
+    gather_ptrs[i] = epoch.slot_ptr(/*dst=*/i);
+  }
+
+  const auto num_threads = blockDim.x * gridDim.x;
+  const auto global_tid = blockIdx.x * blockDim.x + threadIdx.x;
+
+  // shot 1: reduce our own shard from every peer, write it straight to our
+  // output, and push it into every peer's gather plane.
+  for (auto vid = global_tid; vid < num_vecs; vid += num_threads) {
+    vec_t vec;
+    impl.load_reduce(vec, vid);
+    Lamport::clear_pos_zero(vec.data());
+    const auto out_vid = vec_offset + vid;
+    vec.store(params.output, out_vid);
+#pragma unroll
+    for (uint32_t i = 0; i < kWorldSize; ++i) {
+      if (i != params.rank) ptx::st_relaxed_16B(vec, gather_ptrs[i], out_vid);
+    }
+  }
+
+  // shot 2: poll the peers' shards out of our own gather region, restoring the
+  // marker behind us so this epoch comes back around empty.
+  vec_t pos_zero_vec;
+  Lamport::fill_pos_zero(pos_zero_vec.data());
+  const auto local_gather = gather_ptrs[params.rank];
+  const auto num_remote_vecs = num_total_vecs - num_vecs;
+  for (auto rid = global_tid; rid < num_remote_vecs; rid += num_threads) {
+    // compact the two remote ranges around our own, already-written shard
+    const auto vid = rid < vec_offset ? rid : rid + num_vecs;
+    vec_t vec;
+    do {
+      ptx::ld_relaxed_16B(vec, local_gather, vid);
+      if (!Lamport::has_pos_zero(vec.data())) break;
+    } while (true);
+    vec.store(params.output, vid);
+    ptx::st_global_16B(pos_zero_vec, local_gather, vid);
+  }
+
+  PDLTriggerSecondary<kUsePDL>();
+  __syncthreads();
+  epoch.flip();
+}
+
 template <uint32_t N>
 __global__ void memcpy_kernel(void* __restrict__ dst, const void* __restrict__ src, uint32_t num_vecs) {
   static_assert(N % 4 == 0, "at least 4-bytes aligned for uint32_t load/store");
@@ -305,7 +392,8 @@ struct AllReduceKernel {
       const bool use_multicast) {
     using namespace host;
     const auto& comm = *comm_ref.get();
-    CHECK_HOST(algo == "1shot_pull" || algo == "2shot_pull" || algo == "1shot_push") << algo;
+    CHECK_HOST(algo == "1shot_pull" || algo == "2shot_pull" || algo == "1shot_push" || algo == "2shot_lamport")
+        << algo;
     CHECK_HOST(comm.get_world_size() == kWorldSize) << comm.get_world_size();
     CHECK_HOST(in.IsContiguous() && is_type<T>(in.dtype()) && in.device().device_type == kDLCUDA);
     const auto num_elems_int64 = in.numel();
@@ -339,6 +427,8 @@ struct AllReduceKernel {
     const auto& pull = comm.get_pull_obj();
     const auto graph_params = use_graph ? graph_params_opt.value().data_ptr() : nullptr;
     // only 2shot pull + graph mode forces inplace implementation
+    // (2shot_lamport gathers through its own plane, so it never writes over
+    // an input a peer may still be reducing)
     const auto is_inplace = use_graph && algo == "2shot_pull";
     Tensor out = is_inplace ? in : ffi::empty_like(in);
     const auto params = PullParams{
@@ -376,6 +466,28 @@ struct AllReduceKernel {
     using LS = LoadStoreImpl<vec_t, kWorldSize, /*kUseGraph=*/false>;
     using LS_GRAPH = LoadStoreImpl<vec_t, kWorldSize, /*kUseGraph=*/true>;
     using MC = MultiCastImpl<vec_t, kWorldSize, /*kUseGraph=*/false>;
+    if (algo == "2shot_lamport") {
+      CHECK_HOST(!use_multicast) << "2shot_lamport gathers through its own plane, not multimem";
+      const auto& gather = comm.get_gather_obj();
+      const uint32_t lamport_blocks = gather.num_blocks;
+      CHECK_HOST(lamport_blocks <= pull.num_blocks)
+          << "gather plane is " << lamport_blocks << " blocks wide but only " << pull.num_blocks
+          << " pull semaphores back it";
+      const auto lamport_params = AllReduceLamportParams<kWorldSize>{
+          .output = out.data_ptr(),
+          .num_vecs = num_vecs,
+          .rank = pull.rank,
+          .graph_params = static_cast<void* const*>(graph_params),
+          .ws = ws,
+          .gather = gather.get_workspace<kWorldSize>(div_ceil(nbytes, int64_t{kWorldSize})),
+      };
+      if (!use_graph) cuda_memcpy(local_workspace, in.data_ptr());
+      const auto kernel = use_graph ? all_reduce_2shot_lamport_kernel<LS_GRAPH, T, kWorldSize, kUsePDL>
+                                    : all_reduce_2shot_lamport_kernel<LS, T, kWorldSize, kUsePDL>;
+      LaunchKernel(lamport_blocks, choose_block_size(num_vecs), stream)  //
+          .enable_pdl(kUsePDL)(kernel, lamport_params);
+      return out;
+    }
     if (algo == "1shot_pull") {
       // first copy to the workspace
       CHECK_HOST(!use_multicast);

--- a/python/sglang/kernels/jit/csrc/distributed/custom_all_reduce.cuh
+++ b/python/sglang/kernels/jit/csrc/distributed/custom_all_reduce.cuh
@@ -90,7 +90,7 @@ struct LoadStoreImpl {
     return kWorldSize;
   }
   /// Templated on the params struct so the 2shot_push kernel, whose params carry
-  /// a gather plane as well, reuses the same peer table.
+  /// a gather workspace as well, reuses the same peer table.
   template <typename Params>
   SGL_DEVICE LoadStoreImpl(const Params& params, uint32_t vec_offset = 0) {
     if constexpr (kUseGraph) {
@@ -475,10 +475,13 @@ struct AllReduceKernel {
     using MC = MultiCastImpl<vec_t, kWorldSize, /*kUseGraph=*/false>;
     if (algo == "2shot_push") {
       CHECK_HOST(!use_multicast) << "2shot_push gathers through the shared push plane, not multimem";
-      const auto& gather = comm.get_gather_obj();
-      const uint32_t gather_blocks = gather.num_blocks;
+      // The all-gather half rides the 1shot_push plane, so it inherits that
+      // grid -- bound to the counter array -- and lands in slots that must
+      // have been sized to hold a shard (`get_workspace` checks that).
+      const auto& push = comm.get_push_obj();
+      const uint32_t gather_blocks = push.num_blocks;
       CHECK_HOST(gather_blocks <= pull.num_blocks)
-          << "gather plane is " << gather_blocks << " blocks wide but only " << pull.num_blocks
+          << "push plane is " << gather_blocks << " blocks wide but only " << pull.num_blocks
           << " pull semaphores back it";
       const auto gather_params = AllReduce2ShotPushParams<kWorldSize>{
           .output = out.data_ptr(),
@@ -486,7 +489,7 @@ struct AllReduceKernel {
           .rank = pull.rank,
           .graph_params = static_cast<void* const*>(graph_params),
           .ws = ws,
-          .gather = gather.get_workspace<kWorldSize>(div_ceil(nbytes, int64_t{kWorldSize})),
+          .gather = push.get_workspace<kWorldSize>(div_ceil(nbytes, int64_t{kWorldSize})),
       };
       if (!use_graph) cuda_memcpy(local_workspace, in.data_ptr());
       const auto kernel = use_graph ? all_reduce_2shot_push_kernel<LS_GRAPH, T, kWorldSize, kUsePDL>

--- a/python/sglang/kernels/jit/csrc/distributed/registry.cuh
+++ b/python/sglang/kernels/jit/csrc/distributed/registry.cuh
@@ -142,9 +142,7 @@ inline void register_communicator() {
       .def_ro("num_bytes", &dist::PullPlaneObj::num_bytes);
 
   refl::ObjectDef<dist::CommunicatorObj>()
-      .def(
-          refl::init<dist::Optional<dist::PushPlaneRef>, dist::Optional<dist::PullPlaneRef>>(),
-          "__init__")
+      .def(refl::init<dist::Optional<dist::PushPlaneRef>, dist::Optional<dist::PullPlaneRef>>(), "__init__")
       .def("get_rank", &dist::CommunicatorObj::get_rank)
       .def("get_world_size", &dist::CommunicatorObj::get_world_size)
       .def("get_push", &dist::CommunicatorObj::get_push)

--- a/python/sglang/kernels/jit/csrc/distributed/registry.cuh
+++ b/python/sglang/kernels/jit/csrc/distributed/registry.cuh
@@ -17,24 +17,26 @@ BasePlane::BasePlane(uint32_t rank, uint32_t world_size) : rank(rank), world_siz
 PushPlaneObj::PushPlaneObj(
     uint32_t rank,
     uint32_t world_size,
-    std::vector<TensorView> workspaces,  // world_size * [2 * world_size][slot_bytes]
+    std::vector<TensorView> workspaces,  // world_size * [2 * world_size or 4 * world_size][slot_bytes]
     TensorView counter,                  // [num_blocks]
     intptr_t mc_workspace_ptr)
     : BasePlane(rank, world_size),  //
       num_blocks(),
       slot_bytes(),
+      has_scatter(),
       counter(),
       workspaces{},
       mc_workspace() {
   CHECK_HOST(workspaces.size() == world_size) << "Bad push workspace count";
   // Shared symbolic sizes and device enforce consistency across ranks; the
   // matchers also require contiguity (no strides given) and uint8 dtype.
+  auto R = SymbolicSize{"num_slots"};
   auto N = SymbolicSize{"slot_bytes"};
   auto M = SymbolicSize{"num_blocks"};
   auto device_sym = SymbolicDevice{};
   device_sym.set_options<kDLCUDA>();
   for (uint32_t i = 0; i < world_size; ++i) {
-    TensorMatcher({2 * world_size, N})  //
+    TensorMatcher({R, N})  //
         .with_dtype<uint8_t>()
         .with_device(device_sym)
         .verify(workspaces[i]);
@@ -44,10 +46,15 @@ PushPlaneObj::PushPlaneObj(
       .with_device(device_sym)
       .verify(counter);
   CHECK_HOST(N.unwrap() > 0 && M.unwrap() > 0) << "A push plane needs a non-empty workspace and counter";
+  // 2 phases x one slot per peer; doubled again when the plane's second half
+  // carries the 2shot_push scatter region.
+  CHECK_HOST(R.unwrap() == 2 * world_size || R.unwrap() == 4 * world_size)
+      << "A push plane holds 2 * world_size slots, or 4 * world_size with a scatter region; got " << R.unwrap();
 
   // only set the value safely after the symbolic size has been verified
   this->num_blocks = static_cast<uint32_t>(M.unwrap());
   this->slot_bytes = N.unwrap();
+  this->has_scatter = R.unwrap() == 4 * world_size;
   this->counter = static_cast<Counter*>(counter.data_ptr());
   for (uint32_t i = 0; i < world_size; ++i) {
     this->workspaces[i] = static_cast<uint8_t*>(workspaces[i].data_ptr());
@@ -100,25 +107,14 @@ PullPlaneObj::PullPlaneObj(
   this->mc_workspace = reinterpret_cast<uint8_t*>(mc_workspace_ptr);
 }
 
-CommunicatorObj::CommunicatorObj(
-    Optional<PushPlaneRef> push, Optional<PullPlaneRef> pull, Optional<PushPlaneRef> scatter)
-    : m_push(std::move(push)), m_pull(std::move(pull)), m_scatter(std::move(scatter)) {
+CommunicatorObj::CommunicatorObj(Optional<PushPlaneRef> push, Optional<PullPlaneRef> pull)
+    : m_push(std::move(push)), m_pull(std::move(pull)) {
   CHECK_HOST(m_push.has_value() || m_pull.has_value()) << "A communicator needs at least one plane";
   if (m_push.has_value() && m_pull.has_value()) {
     const auto& push_obj = *m_push.value().get();
     const auto& pull_obj = *m_pull.value().get();
     CHECK_HOST(push_obj.rank == pull_obj.rank && push_obj.world_size == pull_obj.world_size)
         << "Push and pull planes disagree on (rank, world_size)";
-  }
-  if (m_scatter.has_value()) {
-    CHECK_HOST(m_push.has_value()) << "A scatter plane is useless without a push plane to gather through";
-    const auto& scatter_obj = *m_scatter.value().get();
-    const auto& push_obj = *m_push.value().get();
-    CHECK_HOST(scatter_obj.rank == push_obj.rank && scatter_obj.world_size == push_obj.world_size)
-        << "Scatter and push planes disagree on (rank, world_size)";
-    CHECK_HOST(scatter_obj.counter == push_obj.counter)
-        << "The scatter plane must share the push plane's epoch counter";
-    CHECK_HOST(scatter_obj.num_blocks == push_obj.num_blocks) << "Scatter and push planes disagree on num_blocks";
   }
 }
 
@@ -135,7 +131,8 @@ inline void register_communicator() {
       .def_ro("rank", &dist::PushPlaneObj::rank)
       .def_ro("world_size", &dist::PushPlaneObj::world_size)
       .def_ro("num_blocks", &dist::PushPlaneObj::num_blocks)
-      .def_ro("slot_bytes", &dist::PushPlaneObj::slot_bytes);
+      .def_ro("slot_bytes", &dist::PushPlaneObj::slot_bytes)
+      .def_ro("has_scatter", &dist::PushPlaneObj::has_scatter);
 
   refl::ObjectDef<dist::PullPlaneObj>()
       .def(refl::init<uint32_t, uint32_t, Tensors, Tensors, intptr_t, intptr_t>(), "__init__")
@@ -146,16 +143,12 @@ inline void register_communicator() {
 
   refl::ObjectDef<dist::CommunicatorObj>()
       .def(
-          refl::init<
-              dist::Optional<dist::PushPlaneRef>,
-              dist::Optional<dist::PullPlaneRef>,
-              dist::Optional<dist::PushPlaneRef>>(),
+          refl::init<dist::Optional<dist::PushPlaneRef>, dist::Optional<dist::PullPlaneRef>>(),
           "__init__")
       .def("get_rank", &dist::CommunicatorObj::get_rank)
       .def("get_world_size", &dist::CommunicatorObj::get_world_size)
       .def("get_push", &dist::CommunicatorObj::get_push)
       .def("get_pull", &dist::CommunicatorObj::get_pull)
-      .def("get_scatter", &dist::CommunicatorObj::get_scatter)
       .def("set_pull_blocks", &dist::CommunicatorObj::set_pull_blocks)
       .def("set_pull_multicast_blocks", &dist::CommunicatorObj::set_pull_multicast_blocks);
 }

--- a/python/sglang/kernels/jit/csrc/distributed/registry.cuh
+++ b/python/sglang/kernels/jit/csrc/distributed/registry.cuh
@@ -100,14 +100,25 @@ PullPlaneObj::PullPlaneObj(
   this->mc_workspace = reinterpret_cast<uint8_t*>(mc_workspace_ptr);
 }
 
-CommunicatorObj::CommunicatorObj(Optional<PushPlaneRef> push, Optional<PullPlaneRef> pull)
-    : m_push(std::move(push)), m_pull(std::move(pull)) {
+CommunicatorObj::CommunicatorObj(
+    Optional<PushPlaneRef> push, Optional<PullPlaneRef> pull, Optional<PushPlaneRef> scatter)
+    : m_push(std::move(push)), m_pull(std::move(pull)), m_scatter(std::move(scatter)) {
   CHECK_HOST(m_push.has_value() || m_pull.has_value()) << "A communicator needs at least one plane";
   if (m_push.has_value() && m_pull.has_value()) {
     const auto& push_obj = *m_push.value().get();
     const auto& pull_obj = *m_pull.value().get();
     CHECK_HOST(push_obj.rank == pull_obj.rank && push_obj.world_size == pull_obj.world_size)
         << "Push and pull planes disagree on (rank, world_size)";
+  }
+  if (m_scatter.has_value()) {
+    CHECK_HOST(m_push.has_value()) << "A scatter plane is useless without a push plane to gather through";
+    const auto& scatter_obj = *m_scatter.value().get();
+    const auto& push_obj = *m_push.value().get();
+    CHECK_HOST(scatter_obj.rank == push_obj.rank && scatter_obj.world_size == push_obj.world_size)
+        << "Scatter and push planes disagree on (rank, world_size)";
+    CHECK_HOST(scatter_obj.counter == push_obj.counter)
+        << "The scatter plane must share the push plane's epoch counter";
+    CHECK_HOST(scatter_obj.num_blocks == push_obj.num_blocks) << "Scatter and push planes disagree on num_blocks";
   }
 }
 
@@ -135,12 +146,16 @@ inline void register_communicator() {
 
   refl::ObjectDef<dist::CommunicatorObj>()
       .def(
-          refl::init<dist::Optional<dist::PushPlaneRef>, dist::Optional<dist::PullPlaneRef>>(),
+          refl::init<
+              dist::Optional<dist::PushPlaneRef>,
+              dist::Optional<dist::PullPlaneRef>,
+              dist::Optional<dist::PushPlaneRef>>(),
           "__init__")
       .def("get_rank", &dist::CommunicatorObj::get_rank)
       .def("get_world_size", &dist::CommunicatorObj::get_world_size)
       .def("get_push", &dist::CommunicatorObj::get_push)
       .def("get_pull", &dist::CommunicatorObj::get_pull)
+      .def("get_scatter", &dist::CommunicatorObj::get_scatter)
       .def("set_pull_blocks", &dist::CommunicatorObj::set_pull_blocks)
       .def("set_pull_multicast_blocks", &dist::CommunicatorObj::set_pull_multicast_blocks);
 }

--- a/python/sglang/kernels/jit/csrc/distributed/registry.cuh
+++ b/python/sglang/kernels/jit/csrc/distributed/registry.cuh
@@ -100,14 +100,22 @@ PullPlaneObj::PullPlaneObj(
   this->mc_workspace = reinterpret_cast<uint8_t*>(mc_workspace_ptr);
 }
 
-CommunicatorObj::CommunicatorObj(Optional<PushPlaneRef> push, Optional<PullPlaneRef> pull)
-    : m_push(std::move(push)), m_pull(std::move(pull)) {
+CommunicatorObj::CommunicatorObj(
+    Optional<PushPlaneRef> push, Optional<PullPlaneRef> pull, Optional<PushPlaneRef> gather)
+    : m_push(std::move(push)), m_pull(std::move(pull)), m_gather(std::move(gather)) {
   CHECK_HOST(m_push.has_value() || m_pull.has_value()) << "A communicator needs at least one plane";
+  const auto identity = [](uint32_t rank, uint32_t world_size, const BasePlane& other, const char* what) {
+    CHECK_HOST(rank == other.rank && world_size == other.world_size) << what << " disagree on (rank, world_size)";
+  };
   if (m_push.has_value() && m_pull.has_value()) {
     const auto& push_obj = *m_push.value().get();
-    const auto& pull_obj = *m_pull.value().get();
-    CHECK_HOST(push_obj.rank == pull_obj.rank && push_obj.world_size == pull_obj.world_size)
-        << "Push and pull planes disagree on (rank, world_size)";
+    identity(push_obj.rank, push_obj.world_size, *m_pull.value().get(), "Push and pull planes");
+  }
+  if (m_gather.has_value()) {
+    // The gather plane rides on the pull plane's barrier, so it needs one.
+    CHECK_HOST(m_pull.has_value()) << "A gather plane is useless without a pull plane to barrier on";
+    const auto& gather_obj = *m_gather.value().get();
+    identity(gather_obj.rank, gather_obj.world_size, *m_pull.value().get(), "Gather and pull planes");
   }
 }
 
@@ -134,11 +142,17 @@ inline void register_communicator() {
       .def_ro("num_bytes", &dist::PullPlaneObj::num_bytes);
 
   refl::ObjectDef<dist::CommunicatorObj>()
-      .def(refl::init<dist::Optional<dist::PushPlaneRef>, dist::Optional<dist::PullPlaneRef>>(), "__init__")
+      .def(
+          refl::init<
+              dist::Optional<dist::PushPlaneRef>,
+              dist::Optional<dist::PullPlaneRef>,
+              dist::Optional<dist::PushPlaneRef>>(),
+          "__init__")
       .def("get_rank", &dist::CommunicatorObj::get_rank)
       .def("get_world_size", &dist::CommunicatorObj::get_world_size)
       .def("get_push", &dist::CommunicatorObj::get_push)
       .def("get_pull", &dist::CommunicatorObj::get_pull)
+      .def("get_gather", &dist::CommunicatorObj::get_gather)
       .def("set_pull_blocks", &dist::CommunicatorObj::set_pull_blocks)
       .def("set_pull_multicast_blocks", &dist::CommunicatorObj::set_pull_multicast_blocks);
 }

--- a/python/sglang/kernels/jit/csrc/distributed/registry.cuh
+++ b/python/sglang/kernels/jit/csrc/distributed/registry.cuh
@@ -100,22 +100,14 @@ PullPlaneObj::PullPlaneObj(
   this->mc_workspace = reinterpret_cast<uint8_t*>(mc_workspace_ptr);
 }
 
-CommunicatorObj::CommunicatorObj(
-    Optional<PushPlaneRef> push, Optional<PullPlaneRef> pull, Optional<PushPlaneRef> gather)
-    : m_push(std::move(push)), m_pull(std::move(pull)), m_gather(std::move(gather)) {
+CommunicatorObj::CommunicatorObj(Optional<PushPlaneRef> push, Optional<PullPlaneRef> pull)
+    : m_push(std::move(push)), m_pull(std::move(pull)) {
   CHECK_HOST(m_push.has_value() || m_pull.has_value()) << "A communicator needs at least one plane";
-  const auto identity = [](uint32_t rank, uint32_t world_size, const BasePlane& other, const char* what) {
-    CHECK_HOST(rank == other.rank && world_size == other.world_size) << what << " disagree on (rank, world_size)";
-  };
   if (m_push.has_value() && m_pull.has_value()) {
     const auto& push_obj = *m_push.value().get();
-    identity(push_obj.rank, push_obj.world_size, *m_pull.value().get(), "Push and pull planes");
-  }
-  if (m_gather.has_value()) {
-    // The gather plane rides on the pull plane's barrier, so it needs one.
-    CHECK_HOST(m_pull.has_value()) << "A gather plane is useless without a pull plane to barrier on";
-    const auto& gather_obj = *m_gather.value().get();
-    identity(gather_obj.rank, gather_obj.world_size, *m_pull.value().get(), "Gather and pull planes");
+    const auto& pull_obj = *m_pull.value().get();
+    CHECK_HOST(push_obj.rank == pull_obj.rank && push_obj.world_size == pull_obj.world_size)
+        << "Push and pull planes disagree on (rank, world_size)";
   }
 }
 
@@ -143,16 +135,12 @@ inline void register_communicator() {
 
   refl::ObjectDef<dist::CommunicatorObj>()
       .def(
-          refl::init<
-              dist::Optional<dist::PushPlaneRef>,
-              dist::Optional<dist::PullPlaneRef>,
-              dist::Optional<dist::PushPlaneRef>>(),
+          refl::init<dist::Optional<dist::PushPlaneRef>, dist::Optional<dist::PullPlaneRef>>(),
           "__init__")
       .def("get_rank", &dist::CommunicatorObj::get_rank)
       .def("get_world_size", &dist::CommunicatorObj::get_world_size)
       .def("get_push", &dist::CommunicatorObj::get_push)
       .def("get_pull", &dist::CommunicatorObj::get_pull)
-      .def("get_gather", &dist::CommunicatorObj::get_gather)
       .def("set_pull_blocks", &dist::CommunicatorObj::set_pull_blocks)
       .def("set_pull_multicast_blocks", &dist::CommunicatorObj::set_pull_multicast_blocks);
 }

--- a/python/sglang/kernels/jit/include/sgl_kernel/distributed/communicator.cuh
+++ b/python/sglang/kernels/jit/include/sgl_kernel/distributed/communicator.cuh
@@ -451,7 +451,7 @@ struct CommunicatorObj : public tvm::ffi::Object {
   // Only the constructors live in csrc/distributed/registry.cuh: kernel
   // modules are separate shared objects that see this header but never link
   // that translation unit, so everything they call has to be inline here.
-  CommunicatorObj(Optional<PushPlaneRef> push, Optional<PullPlaneRef> pull);
+  CommunicatorObj(Optional<PushPlaneRef> push, Optional<PullPlaneRef> pull, Optional<PushPlaneRef> scatter);
 
   uint32_t get_rank() const {
     return m_push.has_value() ? m_push.value()->rank : m_pull.value()->rank;
@@ -466,6 +466,9 @@ struct CommunicatorObj : public tvm::ffi::Object {
   bool has_pull() const {
     return m_pull.has_value();
   }
+  bool has_scatter() const {
+    return m_scatter.has_value();
+  }
   /// The planes as handles, for callers that hold on to one (Python). Kernels
   /// want `get_*_obj()` below, which skips the refcount traffic.
   Optional<PushPlaneRef> get_push() const {
@@ -474,6 +477,9 @@ struct CommunicatorObj : public tvm::ffi::Object {
   Optional<PullPlaneRef> get_pull() const {
     return m_pull;
   }
+  Optional<PushPlaneRef> get_scatter() const {
+    return m_scatter;
+  }
   const PushPlaneObj& get_push_obj() const {
     CHECK_HOST(m_push.has_value()) << "This communicator has no push plane";
     return *m_push.value().get();
@@ -481,6 +487,10 @@ struct CommunicatorObj : public tvm::ffi::Object {
   const PullPlaneObj& get_pull_obj() const {
     CHECK_HOST(m_pull.has_value()) << "This communicator has no pull plane";
     return *m_pull.value().get();
+  }
+  const PushPlaneObj& get_scatter_obj() const {
+    CHECK_HOST(m_scatter.has_value()) << "This communicator has no scatter plane";
+    return *m_scatter.value().get();
   }
 
   /// Both knobs only ever narrow the grid: unset means "the plane's capacity",
@@ -507,6 +517,7 @@ struct CommunicatorObj : public tvm::ffi::Object {
   std::optional<uint32_t> m_pull_multicast_blocks;
   Optional<PushPlaneRef> m_push;
   Optional<PullPlaneRef> m_pull;
+  Optional<PushPlaneRef> m_scatter;
 };
 
 SGLANG_REGISTER_FFI_REFERENCE_CLASS(CommunicatorRef, CommunicatorObj);

--- a/python/sglang/kernels/jit/include/sgl_kernel/distributed/communicator.cuh
+++ b/python/sglang/kernels/jit/include/sgl_kernel/distributed/communicator.cuh
@@ -451,7 +451,7 @@ struct CommunicatorObj : public tvm::ffi::Object {
   // Only the constructors live in csrc/distributed/registry.cuh: kernel
   // modules are separate shared objects that see this header but never link
   // that translation unit, so everything they call has to be inline here.
-  CommunicatorObj(Optional<PushPlaneRef> push, Optional<PullPlaneRef> pull);
+  CommunicatorObj(Optional<PushPlaneRef> push, Optional<PullPlaneRef> pull, Optional<PushPlaneRef> gather);
 
   uint32_t get_rank() const {
     return m_push.has_value() ? m_push.value()->rank : m_pull.value()->rank;
@@ -466,6 +466,9 @@ struct CommunicatorObj : public tvm::ffi::Object {
   bool has_pull() const {
     return m_pull.has_value();
   }
+  bool has_gather() const {
+    return m_gather.has_value();
+  }
   /// The planes as handles, for callers that hold on to one (Python). Kernels
   /// want `get_*_obj()` below, which skips the refcount traffic.
   Optional<PushPlaneRef> get_push() const {
@@ -474,6 +477,9 @@ struct CommunicatorObj : public tvm::ffi::Object {
   Optional<PullPlaneRef> get_pull() const {
     return m_pull;
   }
+  Optional<PushPlaneRef> get_gather() const {
+    return m_gather;
+  }
   const PushPlaneObj& get_push_obj() const {
     CHECK_HOST(m_push.has_value()) << "This communicator has no push plane";
     return *m_push.value().get();
@@ -481,6 +487,10 @@ struct CommunicatorObj : public tvm::ffi::Object {
   const PullPlaneObj& get_pull_obj() const {
     CHECK_HOST(m_pull.has_value()) << "This communicator has no pull plane";
     return *m_pull.value().get();
+  }
+  const PushPlaneObj& get_gather_obj() const {
+    CHECK_HOST(m_gather.has_value()) << "This communicator has no gather plane";
+    return *m_gather.value().get();
   }
 
   /// Both knobs only ever narrow the grid: unset means "the plane's capacity",
@@ -507,6 +517,7 @@ struct CommunicatorObj : public tvm::ffi::Object {
   std::optional<uint32_t> m_pull_multicast_blocks;
   Optional<PushPlaneRef> m_push;
   Optional<PullPlaneRef> m_pull;
+  Optional<PushPlaneRef> m_gather;
 };
 
 SGLANG_REGISTER_FFI_REFERENCE_CLASS(CommunicatorRef, CommunicatorObj);

--- a/python/sglang/kernels/jit/include/sgl_kernel/distributed/communicator.cuh
+++ b/python/sglang/kernels/jit/include/sgl_kernel/distributed/communicator.cuh
@@ -451,7 +451,7 @@ struct CommunicatorObj : public tvm::ffi::Object {
   // Only the constructors live in csrc/distributed/registry.cuh: kernel
   // modules are separate shared objects that see this header but never link
   // that translation unit, so everything they call has to be inline here.
-  CommunicatorObj(Optional<PushPlaneRef> push, Optional<PullPlaneRef> pull, Optional<PushPlaneRef> gather);
+  CommunicatorObj(Optional<PushPlaneRef> push, Optional<PullPlaneRef> pull);
 
   uint32_t get_rank() const {
     return m_push.has_value() ? m_push.value()->rank : m_pull.value()->rank;
@@ -466,9 +466,6 @@ struct CommunicatorObj : public tvm::ffi::Object {
   bool has_pull() const {
     return m_pull.has_value();
   }
-  bool has_gather() const {
-    return m_gather.has_value();
-  }
   /// The planes as handles, for callers that hold on to one (Python). Kernels
   /// want `get_*_obj()` below, which skips the refcount traffic.
   Optional<PushPlaneRef> get_push() const {
@@ -477,9 +474,6 @@ struct CommunicatorObj : public tvm::ffi::Object {
   Optional<PullPlaneRef> get_pull() const {
     return m_pull;
   }
-  Optional<PushPlaneRef> get_gather() const {
-    return m_gather;
-  }
   const PushPlaneObj& get_push_obj() const {
     CHECK_HOST(m_push.has_value()) << "This communicator has no push plane";
     return *m_push.value().get();
@@ -487,10 +481,6 @@ struct CommunicatorObj : public tvm::ffi::Object {
   const PullPlaneObj& get_pull_obj() const {
     CHECK_HOST(m_pull.has_value()) << "This communicator has no pull plane";
     return *m_pull.value().get();
-  }
-  const PushPlaneObj& get_gather_obj() const {
-    CHECK_HOST(m_gather.has_value()) << "This communicator has no gather plane";
-    return *m_gather.value().get();
   }
 
   /// Both knobs only ever narrow the grid: unset means "the plane's capacity",
@@ -517,7 +507,6 @@ struct CommunicatorObj : public tvm::ffi::Object {
   std::optional<uint32_t> m_pull_multicast_blocks;
   Optional<PushPlaneRef> m_push;
   Optional<PullPlaneRef> m_pull;
-  Optional<PushPlaneRef> m_gather;
 };
 
 SGLANG_REGISTER_FFI_REFERENCE_CLASS(CommunicatorRef, CommunicatorObj);

--- a/python/sglang/kernels/jit/include/sgl_kernel/distributed/communicator.cuh
+++ b/python/sglang/kernels/jit/include/sgl_kernel/distributed/communicator.cuh
@@ -366,10 +366,10 @@ struct PushPlaneObj : public tvm::ffi::Object, BasePlane {
       TensorView counter,                  // [num_blocks]
       intptr_t mc_workspace_ptr);
 
-  uint32_t num_blocks;  // bound to the counter array, hence not tunable
-  int64_t slot_bytes;   // per-slot bytes, one size for both regions
-  bool has_scatter;     // workspaces carry 4 * world_size rows, not 2 *
-  Counter* counter;     // rank-local memory
+  uint32_t num_blocks;                             // bound to the counter array, hence not tunable
+  int64_t slot_bytes;                              // per-slot bytes, one size for both regions
+  bool has_scatter;                                // workspaces carry 4 * world_size rows, not 2 *
+  Counter* counter;                                // rank-local memory
   std::array<uint8_t*, kMaxWorldSize> workspaces;  // symmetric memory
   uint8_t* mc_workspace;                           // multicast VA of the local workspace (may be null)
 
@@ -393,8 +393,7 @@ struct PushPlaneObj : public tvm::ffi::Object, BasePlane {
   PushWorkSpace<N> get_scatter_workspace(int64_t size) const {
     CHECK_HOST(N == world_size) << "Plane holds " << world_size << " ranks, asked for " << N;
     CHECK_HOST(has_scatter) << "This push plane has no scatter region";
-    CHECK_HOST(size >= 0 && size <= slot_bytes)
-        << size << " bytes escape the " << slot_bytes << "-byte scatter slot";
+    CHECK_HOST(size >= 0 && size <= slot_bytes) << size << " bytes escape the " << slot_bytes << "-byte scatter slot";
     CHECK_HOST(2 * N * slot_bytes <= std::numeric_limits<uint32_t>::max())
         << 2 * N * slot_bytes << " bytes of scatter region exceeds the 32-bit offset range";
     const int64_t region_offset = 2 * N * slot_bytes;  // past the shared rows

--- a/python/sglang/kernels/jit/include/sgl_kernel/distributed/communicator.cuh
+++ b/python/sglang/kernels/jit/include/sgl_kernel/distributed/communicator.cuh
@@ -346,6 +346,13 @@ struct BasePlane {
  * be zero-filled before first use and every kernel MUST restore the marker
  * on its way out. `counter` is rank-local (never read by a peer).
  *
+ * A plane may carry an optional *scatter region*: a workspace with
+ * `4 * world_size` slot rows instead of `2 * world_size` dedicates the
+ * second half to `2shot_push`'s per-source shard slices, under the same
+ * marker discipline and slot size. Both regions share the one counter, so
+ * every push-family kernel advances the double buffer together — by
+ * construction rather than by a cross-object check.
+ *
  * Holds no storage: the caller (Python) owns the tensors and their lifetime.
  */
 struct PushPlaneObj : public tvm::ffi::Object, BasePlane {
@@ -355,13 +362,14 @@ struct PushPlaneObj : public tvm::ffi::Object, BasePlane {
   PushPlaneObj(
       uint32_t rank,
       uint32_t world_size,
-      std::vector<TensorView> workspaces,  // world_size * [2 * world_size][slot_bytes]
+      std::vector<TensorView> workspaces,  // world_size * [2 * world_size or 4 * world_size][slot_bytes]
       TensorView counter,                  // [num_blocks]
       intptr_t mc_workspace_ptr);
 
-  uint32_t num_blocks;                             // bound to the counter array, hence not tunable
-  int64_t slot_bytes;                              // per-slot bytes; each rank holds 2 * world_size slots
-  Counter* counter;                                // rank-local memory
+  uint32_t num_blocks;  // bound to the counter array, hence not tunable
+  int64_t slot_bytes;   // per-slot bytes, one size for both regions
+  bool has_scatter;     // workspaces carry 4 * world_size rows, not 2 *
+  Counter* counter;     // rank-local memory
   std::array<uint8_t*, kMaxWorldSize> workspaces;  // symmetric memory
   uint8_t* mc_workspace;                           // multicast VA of the local workspace (may be null)
 
@@ -377,6 +385,22 @@ struct PushPlaneObj : public tvm::ffi::Object, BasePlane {
     PushWorkSpace<N> ws{{}, counter, offset_mc(mc_workspace, offset), static_cast<uint32_t>(slot_bytes)};
     for (uint32_t i = 0; i < N; ++i) {
       ws.workspaces[i] = workspaces[i] + offset;
+    }
+    return ws;
+  }
+
+  template <uint32_t N>
+  PushWorkSpace<N> get_scatter_workspace(int64_t size) const {
+    CHECK_HOST(N == world_size) << "Plane holds " << world_size << " ranks, asked for " << N;
+    CHECK_HOST(has_scatter) << "This push plane has no scatter region";
+    CHECK_HOST(size >= 0 && size <= slot_bytes)
+        << size << " bytes escape the " << slot_bytes << "-byte scatter slot";
+    CHECK_HOST(2 * N * slot_bytes <= std::numeric_limits<uint32_t>::max())
+        << 2 * N * slot_bytes << " bytes of scatter region exceeds the 32-bit offset range";
+    const int64_t region_offset = 2 * N * slot_bytes;  // past the shared rows
+    PushWorkSpace<N> ws{{}, counter, offset_mc(mc_workspace, region_offset), static_cast<uint32_t>(slot_bytes)};
+    for (uint32_t i = 0; i < N; ++i) {
+      ws.workspaces[i] = workspaces[i] + region_offset;
     }
     return ws;
   }
@@ -451,7 +475,7 @@ struct CommunicatorObj : public tvm::ffi::Object {
   // Only the constructors live in csrc/distributed/registry.cuh: kernel
   // modules are separate shared objects that see this header but never link
   // that translation unit, so everything they call has to be inline here.
-  CommunicatorObj(Optional<PushPlaneRef> push, Optional<PullPlaneRef> pull, Optional<PushPlaneRef> scatter);
+  CommunicatorObj(Optional<PushPlaneRef> push, Optional<PullPlaneRef> pull);
 
   uint32_t get_rank() const {
     return m_push.has_value() ? m_push.value()->rank : m_pull.value()->rank;
@@ -466,9 +490,6 @@ struct CommunicatorObj : public tvm::ffi::Object {
   bool has_pull() const {
     return m_pull.has_value();
   }
-  bool has_scatter() const {
-    return m_scatter.has_value();
-  }
   /// The planes as handles, for callers that hold on to one (Python). Kernels
   /// want `get_*_obj()` below, which skips the refcount traffic.
   Optional<PushPlaneRef> get_push() const {
@@ -477,9 +498,6 @@ struct CommunicatorObj : public tvm::ffi::Object {
   Optional<PullPlaneRef> get_pull() const {
     return m_pull;
   }
-  Optional<PushPlaneRef> get_scatter() const {
-    return m_scatter;
-  }
   const PushPlaneObj& get_push_obj() const {
     CHECK_HOST(m_push.has_value()) << "This communicator has no push plane";
     return *m_push.value().get();
@@ -487,10 +505,6 @@ struct CommunicatorObj : public tvm::ffi::Object {
   const PullPlaneObj& get_pull_obj() const {
     CHECK_HOST(m_pull.has_value()) << "This communicator has no pull plane";
     return *m_pull.value().get();
-  }
-  const PushPlaneObj& get_scatter_obj() const {
-    CHECK_HOST(m_scatter.has_value()) << "This communicator has no scatter plane";
-    return *m_scatter.value().get();
   }
 
   /// Both knobs only ever narrow the grid: unset means "the plane's capacity",
@@ -517,7 +531,6 @@ struct CommunicatorObj : public tvm::ffi::Object {
   std::optional<uint32_t> m_pull_multicast_blocks;
   Optional<PushPlaneRef> m_push;
   Optional<PullPlaneRef> m_pull;
-  Optional<PushPlaneRef> m_scatter;
 };
 
 SGLANG_REGISTER_FFI_REFERENCE_CLASS(CommunicatorRef, CommunicatorObj);

--- a/python/sglang/kernels/ops/communication/all_reduce.py
+++ b/python/sglang/kernels/ops/communication/all_reduce.py
@@ -184,7 +184,7 @@ class Communicator(tvm_ffi.Object):
 
     @property
     def gather(self) -> PushPlane | None:
-        """The 2shot_lamport gather plane, or None when that algo is off."""
+        """The shared push-plane handle used by 2shot_lamport, or None."""
         return self.get_gather()
 
 

--- a/python/sglang/kernels/ops/communication/all_reduce.py
+++ b/python/sglang/kernels/ops/communication/all_reduce.py
@@ -22,16 +22,16 @@ class AllReduceAlgo(enum.Enum):
     ONE_SHOT_PUSH = enum.auto()
     ONE_SHOT_PULL = enum.auto()
     TWO_SHOT_PULL = enum.auto()
-    TWO_SHOT_SCATTER = enum.auto()
+    TWO_SHOT_PUSH = enum.auto()
 
     def supports_zero_copy(self) -> bool:
         """Whether peers can reduce straight out of the caller's own buffer.
 
-        The two push algorithms cannot: ``1shot_push`` and ``2shot_scatter``
+        The two push algorithms cannot: ``1shot_push`` and ``2shot_push``
         both publish their input to peers up front (whole, or shard-wise), so
         there is nothing for the graph pointer table to register.
         """
-        return self not in (AllReduceAlgo.ONE_SHOT_PUSH, AllReduceAlgo.TWO_SHOT_SCATTER)
+        return self not in (AllReduceAlgo.ONE_SHOT_PUSH, AllReduceAlgo.TWO_SHOT_PUSH)
 
     @property
     def algo_name(self) -> str:
@@ -42,7 +42,7 @@ _ALGO_NAMES = {
     AllReduceAlgo.ONE_SHOT_PUSH: "1shot_push",
     AllReduceAlgo.ONE_SHOT_PULL: "1shot_pull",
     AllReduceAlgo.TWO_SHOT_PULL: "2shot_pull",
-    AllReduceAlgo.TWO_SHOT_SCATTER: "2shot_scatter",
+    AllReduceAlgo.TWO_SHOT_PUSH: "2shot_push",
 }
 
 if TYPE_CHECKING:
@@ -64,6 +64,12 @@ def _init_communicator() -> None:
 class PushPlane(tvm_ffi.Object):
     """Lamport push plane: a zero-filled symmetric workspace + a local counter.
 
+    A plane whose workspaces carry ``4 * world_size`` slot rows instead of
+    ``2 * world_size`` dedicates the second half to ``2shot_push``'s
+    per-source shard slots (same slot size, same marker discipline); both
+    halves share the one counter, so every push-family kernel advances the
+    double buffer together.
+
     All buffers are owned by the caller; this object only validates and
     records them.
     """
@@ -72,6 +78,8 @@ class PushPlane(tvm_ffi.Object):
     if TYPE_CHECKING:
         rank: int
         world_size: int
+        slot_bytes: int
+        has_scatter: bool
 
     def __init__(
         self,
@@ -84,9 +92,11 @@ class PushPlane(tvm_ffi.Object):
     ) -> None:
         """
         :param workspaces: per-rank ``[2 * world_size, slot_bytes]`` uint8
-                           views of symmetric memory. The local rank's view
-                           MUST be zero-filled before first use -- the
-                           kernels poll for a pos-zero marker.
+                           views of symmetric memory (``4 * world_size``
+                           rows when the plane carries a scatter region).
+                           The local rank's view MUST be zero-filled before
+                           first use -- the kernels poll for a pos-zero
+                           marker.
         :param counter: local ``[num_blocks, 4]`` uint8 tensor, zero-filled.
         :param mc_workspace: multicast VA of the local workspace, or None.
         """
@@ -158,7 +168,6 @@ class Communicator(tvm_ffi.Object):
         def get_world_size(self) -> int: ...
         def get_push(self) -> PushPlane | None: ...
         def get_pull(self) -> PullPlane | None: ...
-        def get_scatter(self) -> PushPlane | None: ...
         def set_pull_blocks(self, num_blocks: int | None) -> None: ...
         def set_pull_multicast_blocks(self, num_blocks: int | None) -> None: ...
 
@@ -166,9 +175,8 @@ class Communicator(tvm_ffi.Object):
         self,
         push: PushPlane | None = None,
         pull: PullPlane | None = None,
-        scatter: PushPlane | None = None,
     ) -> None:
-        self.__ffi_init__(push, pull, scatter)
+        self.__ffi_init__(push, pull)
 
     @property
     def rank(self) -> int:
@@ -187,11 +195,6 @@ class Communicator(tvm_ffi.Object):
     def pull(self) -> PullPlane | None:
         """The pull plane, or None for a push-only communicator."""
         return self.get_pull()
-
-    @property
-    def scatter(self) -> PushPlane | None:
-        """2shot_scatter's shard-slot plane; shares the push plane's epoch."""
-        return self.get_scatter()
 
 
 def _init_ipc_manager() -> None:

--- a/python/sglang/kernels/ops/communication/all_reduce.py
+++ b/python/sglang/kernels/ops/communication/all_reduce.py
@@ -22,6 +22,7 @@ class AllReduceAlgo(enum.Enum):
     ONE_SHOT_PUSH = enum.auto()
     ONE_SHOT_PULL = enum.auto()
     TWO_SHOT_PULL = enum.auto()
+    TWO_SHOT_LAMPORT = enum.auto()
 
     def is_push(self) -> bool:
         return self == AllReduceAlgo.ONE_SHOT_PUSH
@@ -35,6 +36,7 @@ _ALGO_NAMES = {
     AllReduceAlgo.ONE_SHOT_PUSH: "1shot_push",
     AllReduceAlgo.ONE_SHOT_PULL: "1shot_pull",
     AllReduceAlgo.TWO_SHOT_PULL: "2shot_pull",
+    AllReduceAlgo.TWO_SHOT_LAMPORT: "2shot_lamport",
 }
 
 if TYPE_CHECKING:
@@ -150,6 +152,7 @@ class Communicator(tvm_ffi.Object):
         def get_world_size(self) -> int: ...
         def get_push(self) -> PushPlane | None: ...
         def get_pull(self) -> PullPlane | None: ...
+        def get_gather(self) -> PushPlane | None: ...
         def set_pull_blocks(self, num_blocks: int | None) -> None: ...
         def set_pull_multicast_blocks(self, num_blocks: int | None) -> None: ...
 
@@ -157,8 +160,9 @@ class Communicator(tvm_ffi.Object):
         self,
         push: PushPlane | None = None,
         pull: PullPlane | None = None,
+        gather: PushPlane | None = None,
     ) -> None:
-        self.__ffi_init__(push, pull)
+        self.__ffi_init__(push, pull, gather)
 
     @property
     def rank(self) -> int:
@@ -177,6 +181,11 @@ class Communicator(tvm_ffi.Object):
     def pull(self) -> PullPlane | None:
         """The pull plane, or None for a push-only communicator."""
         return self.get_pull()
+
+    @property
+    def gather(self) -> PushPlane | None:
+        """The 2shot_lamport gather plane, or None when that algo is off."""
+        return self.get_gather()
 
 
 def _init_ipc_manager() -> None:

--- a/python/sglang/kernels/ops/communication/all_reduce.py
+++ b/python/sglang/kernels/ops/communication/all_reduce.py
@@ -159,7 +159,6 @@ class Communicator(tvm_ffi.Object):
         def get_world_size(self) -> int: ...
         def get_push(self) -> PushPlane | None: ...
         def get_pull(self) -> PullPlane | None: ...
-        def get_gather(self) -> PushPlane | None: ...
         def set_pull_blocks(self, num_blocks: int | None) -> None: ...
         def set_pull_multicast_blocks(self, num_blocks: int | None) -> None: ...
 
@@ -167,9 +166,8 @@ class Communicator(tvm_ffi.Object):
         self,
         push: PushPlane | None = None,
         pull: PullPlane | None = None,
-        gather: PushPlane | None = None,
     ) -> None:
-        self.__ffi_init__(push, pull, gather)
+        self.__ffi_init__(push, pull)
 
     @property
     def rank(self) -> int:
@@ -188,11 +186,6 @@ class Communicator(tvm_ffi.Object):
     def pull(self) -> PullPlane | None:
         """The pull plane, or None for a push-only communicator."""
         return self.get_pull()
-
-    @property
-    def gather(self) -> PushPlane | None:
-        """The shared push-plane handle used by 2shot_push, or None."""
-        return self.get_gather()
 
 
 def _init_ipc_manager() -> None:

--- a/python/sglang/kernels/ops/communication/all_reduce.py
+++ b/python/sglang/kernels/ops/communication/all_reduce.py
@@ -22,17 +22,16 @@ class AllReduceAlgo(enum.Enum):
     ONE_SHOT_PUSH = enum.auto()
     ONE_SHOT_PULL = enum.auto()
     TWO_SHOT_PULL = enum.auto()
-    TWO_SHOT_PUSH = enum.auto()
+    TWO_SHOT_SCATTER = enum.auto()
 
     def supports_zero_copy(self) -> bool:
         """Whether peers can reduce straight out of the caller's own buffer.
 
-        Only ``1shot_push`` cannot: it publishes its input to every peer up
-        front, so there is nothing for the graph pointer table to register.
-        The two-shot push does read peers' inputs in place — it pushes only
-        the *reduced shard*, in its all-gather half.
+        The two push algorithms cannot: ``1shot_push`` and ``2shot_scatter``
+        both publish their input to peers up front (whole, or shard-wise), so
+        there is nothing for the graph pointer table to register.
         """
-        return self != AllReduceAlgo.ONE_SHOT_PUSH
+        return self not in (AllReduceAlgo.ONE_SHOT_PUSH, AllReduceAlgo.TWO_SHOT_SCATTER)
 
     @property
     def algo_name(self) -> str:
@@ -43,7 +42,7 @@ _ALGO_NAMES = {
     AllReduceAlgo.ONE_SHOT_PUSH: "1shot_push",
     AllReduceAlgo.ONE_SHOT_PULL: "1shot_pull",
     AllReduceAlgo.TWO_SHOT_PULL: "2shot_pull",
-    AllReduceAlgo.TWO_SHOT_PUSH: "2shot_push",
+    AllReduceAlgo.TWO_SHOT_SCATTER: "2shot_scatter",
 }
 
 if TYPE_CHECKING:
@@ -159,6 +158,7 @@ class Communicator(tvm_ffi.Object):
         def get_world_size(self) -> int: ...
         def get_push(self) -> PushPlane | None: ...
         def get_pull(self) -> PullPlane | None: ...
+        def get_scatter(self) -> PushPlane | None: ...
         def set_pull_blocks(self, num_blocks: int | None) -> None: ...
         def set_pull_multicast_blocks(self, num_blocks: int | None) -> None: ...
 
@@ -166,8 +166,9 @@ class Communicator(tvm_ffi.Object):
         self,
         push: PushPlane | None = None,
         pull: PullPlane | None = None,
+        scatter: PushPlane | None = None,
     ) -> None:
-        self.__ffi_init__(push, pull)
+        self.__ffi_init__(push, pull, scatter)
 
     @property
     def rank(self) -> int:
@@ -186,6 +187,11 @@ class Communicator(tvm_ffi.Object):
     def pull(self) -> PullPlane | None:
         """The pull plane, or None for a push-only communicator."""
         return self.get_pull()
+
+    @property
+    def scatter(self) -> PushPlane | None:
+        """2shot_scatter's shard-slot plane; shares the push plane's epoch."""
+        return self.get_scatter()
 
 
 def _init_ipc_manager() -> None:

--- a/python/sglang/kernels/ops/communication/all_reduce.py
+++ b/python/sglang/kernels/ops/communication/all_reduce.py
@@ -22,10 +22,17 @@ class AllReduceAlgo(enum.Enum):
     ONE_SHOT_PUSH = enum.auto()
     ONE_SHOT_PULL = enum.auto()
     TWO_SHOT_PULL = enum.auto()
-    TWO_SHOT_LAMPORT = enum.auto()
+    TWO_SHOT_PUSH = enum.auto()
 
-    def is_push(self) -> bool:
-        return self == AllReduceAlgo.ONE_SHOT_PUSH
+    def supports_zero_copy(self) -> bool:
+        """Whether peers can reduce straight out of the caller's own buffer.
+
+        Only ``1shot_push`` cannot: it publishes its input to every peer up
+        front, so there is nothing for the graph pointer table to register.
+        The two-shot push does read peers' inputs in place — it pushes only
+        the *reduced shard*, in its all-gather half.
+        """
+        return self != AllReduceAlgo.ONE_SHOT_PUSH
 
     @property
     def algo_name(self) -> str:
@@ -36,7 +43,7 @@ _ALGO_NAMES = {
     AllReduceAlgo.ONE_SHOT_PUSH: "1shot_push",
     AllReduceAlgo.ONE_SHOT_PULL: "1shot_pull",
     AllReduceAlgo.TWO_SHOT_PULL: "2shot_pull",
-    AllReduceAlgo.TWO_SHOT_LAMPORT: "2shot_lamport",
+    AllReduceAlgo.TWO_SHOT_PUSH: "2shot_push",
 }
 
 if TYPE_CHECKING:
@@ -184,7 +191,7 @@ class Communicator(tvm_ffi.Object):
 
     @property
     def gather(self) -> PushPlane | None:
-        """The shared push-plane handle used by 2shot_lamport, or None."""
+        """The shared push-plane handle used by 2shot_push, or None."""
         return self.get_gather()
 
 

--- a/python/sglang/kernels/ops/communication/mp.py
+++ b/python/sglang/kernels/ops/communication/mp.py
@@ -135,16 +135,25 @@ def multigpu_launch(
     `timeout`, if given, bounds each per-world-size torchrun invocation (in
     seconds). On expiry the child's whole process group is killed and the
     launcher exits non-zero. `None` (the default) waits indefinitely.
+
+    An *external* torchrun is honoured as-is: the relaunch below only knows how
+    to fill one node, so a multi-node run has to be started by the caller, and
+    this detects that and runs the body in place rather than nesting a
+    single-node torchrun underneath it.
     """
     pid_key = env_key + "_PID"
     if env_key in os.environ:
         assert pid_key in os.environ
+    # either the relaunch below, or someone else's torchrun -- which is how a
+    # multi-node run gets started, since the relaunch only fills one node
+    if env_key in os.environ or "TORCHELASTIC_RUN_ID" in os.environ:
         if name != "__main__":
             return
-        rank = int(os.environ["LOCAL_RANK"])
-        if rank != 0:
+        local_rank = int(os.environ["LOCAL_RANK"])
+        # gate on the global rank: on a multi-node run every node has a rank 0
+        if int(os.environ.get("RANK", local_rank)) != 0:
             sys.stdout = open(os.devnull, "w")
-        torch.cuda.set_device(rank)
+        torch.cuda.set_device(local_rank)
         return sys.exit(inner())
     assert pid_key not in os.environ
     if name != "__main__":

--- a/python/sglang/srt/distributed/device_communicators/configs/custom_all_reduce_v2.py
+++ b/python/sglang/srt/distributed/device_communicators/configs/custom_all_reduce_v2.py
@@ -34,7 +34,7 @@ class Heuristic(NamedTuple):
     """Self-contained algo ranges for one dispatch context (graph or eager).
 
     Five algos are tried in order of preference (fastest first):
-      1. ``2shot_scatter``: nbytes in ``two_shot_scatter`` (a barrier-free band)
+      1. ``2shot_push``: nbytes in ``two_shot_push`` (a barrier-free band)
       2. ``1shot_push``:    nbytes <= ``one_shot_push_threshold``
       3. ``1shot_pull``:    nbytes <= ``one_shot_pull_threshold``
       4. ``2shot_pull`` mc: nbytes in ``mc.min_bytes..mc.max_bytes``
@@ -42,7 +42,7 @@ class Heuristic(NamedTuple):
       5. ``2shot_pull``:    nbytes <= ``two_shot_pull_threshold``
     Above all of these, the caller falls back to NCCL.
 
-    ``two_shot_scatter`` is tried first so its band may start below
+    ``two_shot_push`` is tried first so its band may start below
     ``one_shot_push_threshold``.
 
     Setting two adjacent thresholds equal effectively disables the middle
@@ -53,8 +53,8 @@ class Heuristic(NamedTuple):
     one_shot_pull_threshold: int
     two_shot_pull_threshold: int
     mc: Range = Range(0, 0)  # default: multicast disabled in this context
-    two_shot_scatter: Range = Range(0, 0)  # default: 2shot_scatter disabled here
-    two_shot_scatter_mc: Range = Range(0, 0)  # multimem fan-out sub-band of 2shot_scatter
+    two_shot_push: Range = Range(0, 0)  # default: 2shot_push disabled here
+    two_shot_push_mc: Range = Range(0, 0)  # multimem fan-out sub-band of 2shot_push
 
     @property
     def max_push_bytes(self) -> int:
@@ -71,23 +71,23 @@ class Heuristic(NamedTuple):
         )
 
     @property
-    def max_two_shot_scatter_bytes(self) -> int:
-        return self.two_shot_scatter.max_bytes
+    def max_two_shot_push_bytes(self) -> int:
+        return self.two_shot_push.max_bytes
 
     def clip(
         self,
         *,
         max_push_bytes: int,
         max_pull_bytes: int,
-        max_two_shot_scatter_bytes: int,
+        max_two_shot_push_bytes: int,
     ) -> "Heuristic":
         return Heuristic(
             min(self.one_shot_push_threshold, max_push_bytes),
             min(self.one_shot_pull_threshold, max_pull_bytes),
             min(self.two_shot_pull_threshold, max_pull_bytes),
             self.mc.clip(max_pull_bytes),
-            self.two_shot_scatter.clip(max_two_shot_scatter_bytes),
-            self.two_shot_scatter_mc.clip(max_two_shot_scatter_bytes),
+            self.two_shot_push.clip(max_two_shot_push_bytes),
+            self.two_shot_push_mc.clip(max_two_shot_push_bytes),
         )
 
 
@@ -97,7 +97,7 @@ class AllReduceConfig(NamedTuple):
     The two ``Heuristic`` entries describe the size crossover for each
     dispatch context (CUDA-graph capture vs eager). Block-count knobs apply
     to the kernel grid:
-      - ``num_push_blocks``: shared 1shot_push / 2shot_scatter grid (bound
+      - ``num_push_blocks``: shared 1shot_push / 2shot_push grid (bound
         to the counter array)
       - ``num_pull_blocks``: 1shot_pull (any mode) and non-mc 2shot_pull
       - ``num_mc_blocks``  : mc 2shot_pull; ``None`` disables multicast
@@ -118,10 +118,10 @@ class AllReduceConfig(NamedTuple):
         return max(self.graph.max_pull_bytes, self.eager.max_pull_bytes)
 
     @property
-    def max_two_shot_scatter_bytes(self) -> int:
+    def max_two_shot_push_bytes(self) -> int:
         return max(
-            self.graph.max_two_shot_scatter_bytes,
-            self.eager.max_two_shot_scatter_bytes,
+            self.graph.max_two_shot_push_bytes,
+            self.eager.max_two_shot_push_bytes,
         )
 
     def clip(
@@ -129,12 +129,12 @@ class AllReduceConfig(NamedTuple):
         *,
         max_push_bytes: int,
         max_pull_bytes: int,
-        max_two_shot_scatter_bytes: int,
+        max_two_shot_push_bytes: int,
     ) -> "AllReduceConfig":
         bounds = dict(
             max_push_bytes=max_push_bytes,
             max_pull_bytes=max_pull_bytes,
-            max_two_shot_scatter_bytes=max_two_shot_scatter_bytes,
+            max_two_shot_push_bytes=max_two_shot_push_bytes,
         )
         return self._replace(
             graph=self.graph.clip(**bounds),
@@ -354,21 +354,21 @@ def get_supported_world_sizes() -> tuple[int, ...]:
 
 # A world size does not pin down the interconnect: 8 ranks on one board and 8
 # ranks spanning two nodes have different crossovers, and the tables above are
-# tuned on the former. Being barrier-free and remote-read-free, 2shot_scatter
+# tuned on the former. Being barrier-free and remote-read-free, 2shot_push
 # gains most exactly where fabric round-trips cost most, so its multi-node
 # band runs both lower and wider than the single-node one.
 class _MultinodePushBands(NamedTuple):
-    """The eager 2shot_scatter retune a multi-node group swaps in."""
+    """The eager 2shot_push retune a multi-node group swaps in."""
 
-    two_shot_scatter: Range
-    two_shot_scatter_mc: Range = Range(0, 0)
+    two_shot_push: Range
+    two_shot_push_mc: Range = Range(0, 0)
 
 
 _MULTINODE_PUSH_BANDS: dict[tuple[int, int], _MultinodePushBands] = {
     # for 2 x GB200 (4 GPUs each).
     (10, 8): _MultinodePushBands(
-        two_shot_scatter=Range(288 * KB, 16 * MB),
-        two_shot_scatter_mc=Range(int(3.5 * MB), 16 * MB),
+        two_shot_push=Range(288 * KB, 16 * MB),
+        two_shot_push_mc=Range(int(3.5 * MB), 16 * MB),
     ),
 }
 
@@ -380,7 +380,7 @@ def get_all_reduce_config(world_size: int, multinode: bool = False) -> AllReduce
     Only SM90, SM100 and SM107 are benchmarked so far; other archs get a
     conservative default (1 MB one-shot crossovers, no multicast).
 
-    ``multinode`` swaps in a separately tuned ``2shot_scatter`` band where
+    ``multinode`` swaps in a separately tuned ``2shot_push`` band where
     one exists. Only the eager row can differ: a multi-node group forces eager anyway, because
     graph zero-copy input registration is node-local.
     """

--- a/python/sglang/srt/distributed/device_communicators/configs/custom_all_reduce_v2.py
+++ b/python/sglang/srt/distributed/device_communicators/configs/custom_all_reduce_v2.py
@@ -341,11 +341,29 @@ def get_supported_world_sizes() -> tuple[int, ...]:
     return tuple(_get_all_reduce_configs())
 
 
+_MULTINODE_LAMPORT: dict[tuple[int, int], Range] = {
+    # 2 x GB200 (4 GPUs each). lamport beats mc 2shot_pull by 3-30% here and
+    # loses to it from 4 MB up; below 512 KB 1shot_push is still ahead.
+    (10, 8): Range(512 * KB, int(3.5 * MB)),
+}
+
+
 @cache
-def get_all_reduce_config(world_size: int) -> AllReduceConfig:
+def get_all_reduce_config(world_size: int, multinode: bool = False) -> AllReduceConfig:
     """Tuned thresholds and block counts for the current arch / world size.
 
     Only SM90, SM100 and SM107 are benchmarked so far; other archs get a
     conservative default (1 MB one-shot crossovers, no multicast).
+
+    ``multinode`` swaps in a separately tuned ``2shot_lamport`` band where one
+    exists. Only the eager row can differ: a multi-node group forces eager
+    anyway, because graph zero-copy input registration is node-local.
     """
-    return _get_all_reduce_configs()[world_size]
+    config = _get_all_reduce_configs()[world_size]
+    if not multinode:
+        return config
+    cuda_major, _ = torch.cuda.get_device_capability()
+    band = _MULTINODE_LAMPORT.get((cuda_major, world_size))
+    if band is None:
+        return config
+    return config._replace(eager=config.eager._replace(lamport=band))

--- a/python/sglang/srt/distributed/device_communicators/configs/custom_all_reduce_v2.py
+++ b/python/sglang/srt/distributed/device_communicators/configs/custom_all_reduce_v2.py
@@ -34,7 +34,7 @@ class Heuristic(NamedTuple):
     """Self-contained algo ranges for one dispatch context (graph or eager).
 
     Five algos are tried in order of preference (fastest first):
-      1. ``2shot_push``: nbytes in ``two_shot_push.min_bytes..two_shot_push.max_bytes``
+      1. ``2shot_scatter``: nbytes in ``two_shot_scatter`` (a barrier-free band)
       2. ``1shot_push``:    nbytes <= ``one_shot_push_threshold``
       3. ``1shot_pull``:    nbytes <= ``one_shot_pull_threshold``
       4. ``2shot_pull`` mc: nbytes in ``mc.min_bytes..mc.max_bytes``
@@ -42,18 +42,19 @@ class Heuristic(NamedTuple):
       5. ``2shot_pull``:    nbytes <= ``two_shot_pull_threshold``
     Above all of these, the caller falls back to NCCL.
 
-    ``two_shot_push`` is tried first so its band may start below
-    ``one_shot_push_threshold``
+    ``two_shot_scatter`` is tried first so its band may start below
+    ``one_shot_push_threshold``.
 
     Setting two adjacent thresholds equal effectively disables the middle
-    algo; leaving ``mc`` / ``two_shot_push`` at the default disables that algo.
+    algo; leaving a ``Range`` at the default disables that algo.
     """
 
     one_shot_push_threshold: int
     one_shot_pull_threshold: int
     two_shot_pull_threshold: int
     mc: Range = Range(0, 0)  # default: multicast disabled in this context
-    two_shot_push: Range = Range(0, 0)  # default: 2shot_push disabled here
+    two_shot_scatter: Range = Range(0, 0)  # default: 2shot_scatter disabled here
+    two_shot_scatter_mc: Range = Range(0, 0)  # multimem fan-out sub-band of 2shot_scatter
 
     @property
     def max_push_bytes(self) -> int:
@@ -62,28 +63,31 @@ class Heuristic(NamedTuple):
     @property
     def max_pull_bytes(self) -> int:
         # The pull workspace hosts every pull-variant kernel, so it has to
-        # fit whichever variant runs at the largest size. 2shot_push
-        # stages its input through it too, and only gathers elsewhere.
+        # fit whichever variant runs at the largest size.
         return max(
             self.one_shot_pull_threshold,
             self.two_shot_pull_threshold,
             self.mc.max_bytes,
-            self.two_shot_push.max_bytes,
         )
 
     @property
-    def max_two_shot_push_bytes(self) -> int:
-        return self.two_shot_push.max_bytes
+    def max_two_shot_scatter_bytes(self) -> int:
+        return self.two_shot_scatter.max_bytes
 
     def clip(
-        self, *, max_push_bytes: int, max_pull_bytes: int, max_two_shot_push_bytes: int
+        self,
+        *,
+        max_push_bytes: int,
+        max_pull_bytes: int,
+        max_two_shot_scatter_bytes: int,
     ) -> "Heuristic":
         return Heuristic(
             min(self.one_shot_push_threshold, max_push_bytes),
             min(self.one_shot_pull_threshold, max_pull_bytes),
             min(self.two_shot_pull_threshold, max_pull_bytes),
             self.mc.clip(max_pull_bytes),
-            self.two_shot_push.clip(max_two_shot_push_bytes),
+            self.two_shot_scatter.clip(max_two_shot_scatter_bytes),
+            self.two_shot_scatter_mc.clip(max_two_shot_scatter_bytes),
         )
 
 
@@ -93,8 +97,8 @@ class AllReduceConfig(NamedTuple):
     The two ``Heuristic`` entries describe the size crossover for each
     dispatch context (CUDA-graph capture vs eager). Block-count knobs apply
     to the kernel grid:
-      - ``num_push_blocks``: shared 1shot_push / 2shot_push grid (bound to
-        the counter array)
+      - ``num_push_blocks``: shared 1shot_push / 2shot_scatter grid (bound
+        to the counter array)
       - ``num_pull_blocks``: 1shot_pull (any mode) and non-mc 2shot_pull
       - ``num_mc_blocks``  : mc 2shot_pull; ``None`` disables multicast
     """
@@ -114,18 +118,23 @@ class AllReduceConfig(NamedTuple):
         return max(self.graph.max_pull_bytes, self.eager.max_pull_bytes)
 
     @property
-    def max_two_shot_push_bytes(self) -> int:
+    def max_two_shot_scatter_bytes(self) -> int:
         return max(
-            self.graph.max_two_shot_push_bytes, self.eager.max_two_shot_push_bytes
+            self.graph.max_two_shot_scatter_bytes,
+            self.eager.max_two_shot_scatter_bytes,
         )
 
     def clip(
-        self, *, max_push_bytes: int, max_pull_bytes: int, max_two_shot_push_bytes: int
+        self,
+        *,
+        max_push_bytes: int,
+        max_pull_bytes: int,
+        max_two_shot_scatter_bytes: int,
     ) -> "AllReduceConfig":
         bounds = dict(
             max_push_bytes=max_push_bytes,
             max_pull_bytes=max_pull_bytes,
-            max_two_shot_push_bytes=max_two_shot_push_bytes,
+            max_two_shot_scatter_bytes=max_two_shot_scatter_bytes,
         )
         return self._replace(
             graph=self.graph.clip(**bounds),
@@ -166,18 +175,18 @@ def _sm100_configs(num_sm: int) -> dict[int, AllReduceConfig]:
         4: config(
             4,
             graph=(
-                2.250 * MB,
-                2.250 * MB,
+                0.625 * MB,
+                0.625 * MB,
                 128.0 * MB,
                 Range(0, 0),
-                Range(int(1.25 * MB), 16 * MB),
+                Range(int(0.625 * MB), 16 * MB),
             ),
             eager=(
-                3.000 * MB,
-                3.000 * MB,
+                0.625 * MB,
+                0.625 * MB,
                 32.00 * MB,
                 Range(0, 0),
-                Range(2 * MB, 16 * MB),
+                Range(int(0.625 * MB), 16 * MB),
             ),
         ),
         5: config(
@@ -343,10 +352,24 @@ def get_supported_world_sizes() -> tuple[int, ...]:
     return tuple(_get_all_reduce_configs())
 
 
-_MULTINODE_TWO_SHOT_PUSH: dict[tuple[int, int], Range] = {
-    # 2 x GB200 (4 GPUs each). 2shot_push beats mc 2shot_pull by 3-30% here
-    # and loses to it from 4 MB up; below 512 KB 1shot_push is still ahead.
-    (10, 8): Range(512 * KB, int(3.5 * MB)),
+# A world size does not pin down the interconnect: 8 ranks on one board and 8
+# ranks spanning two nodes have different crossovers, and the tables above are
+# tuned on the former. Being barrier-free and remote-read-free, 2shot_scatter
+# gains most exactly where fabric round-trips cost most, so its multi-node
+# band runs both lower and wider than the single-node one.
+class _MultinodePushBands(NamedTuple):
+    """The eager 2shot_scatter retune a multi-node group swaps in."""
+
+    two_shot_scatter: Range
+    two_shot_scatter_mc: Range = Range(0, 0)
+
+
+_MULTINODE_PUSH_BANDS: dict[tuple[int, int], _MultinodePushBands] = {
+    # for 2 x GB200 (4 GPUs each).
+    (10, 8): _MultinodePushBands(
+        two_shot_scatter=Range(288 * KB, 16 * MB),
+        two_shot_scatter_mc=Range(int(3.5 * MB), 16 * MB),
+    ),
 }
 
 
@@ -357,15 +380,15 @@ def get_all_reduce_config(world_size: int, multinode: bool = False) -> AllReduce
     Only SM90, SM100 and SM107 are benchmarked so far; other archs get a
     conservative default (1 MB one-shot crossovers, no multicast).
 
-    ``multinode`` swaps in a separately tuned ``2shot_push`` band where one
-    exists. Only the eager row can differ: a multi-node group forces eager
-    anyway, because graph zero-copy input registration is node-local.
+    ``multinode`` swaps in a separately tuned ``2shot_scatter`` band where
+    one exists. Only the eager row can differ: a multi-node group forces eager anyway, because
+    graph zero-copy input registration is node-local.
     """
     config = _get_all_reduce_configs()[world_size]
     if not multinode:
         return config
     cuda_major, _ = torch.cuda.get_device_capability()
-    band = _MULTINODE_TWO_SHOT_PUSH.get((cuda_major, world_size))
-    if band is None:
+    bands = _MULTINODE_PUSH_BANDS.get((cuda_major, world_size))
+    if bands is None:
         return config
-    return config._replace(eager=config.eager._replace(two_shot_push=band))
+    return config._replace(eager=config.eager._replace(**bands._asdict()))

--- a/python/sglang/srt/distributed/device_communicators/configs/custom_all_reduce_v2.py
+++ b/python/sglang/srt/distributed/device_communicators/configs/custom_all_reduce_v2.py
@@ -34,7 +34,7 @@ class Heuristic(NamedTuple):
     """Self-contained algo ranges for one dispatch context (graph or eager).
 
     Five algos are tried in order of preference (fastest first):
-      1. ``2shot_lamport``: nbytes in ``lamport.min_bytes..lamport.max_bytes``
+      1. ``2shot_push``: nbytes in ``two_shot_push.min_bytes..two_shot_push.max_bytes``
       2. ``1shot_push``:    nbytes <= ``one_shot_push_threshold``
       3. ``1shot_pull``:    nbytes <= ``one_shot_pull_threshold``
       4. ``2shot_pull`` mc: nbytes in ``mc.min_bytes..mc.max_bytes``
@@ -42,18 +42,18 @@ class Heuristic(NamedTuple):
       5. ``2shot_pull``:    nbytes <= ``two_shot_pull_threshold``
     Above all of these, the caller falls back to NCCL.
 
-    ``lamport`` is tried first so its band may start below
+    ``two_shot_push`` is tried first so its band may start below
     ``one_shot_push_threshold``
 
     Setting two adjacent thresholds equal effectively disables the middle
-    algo; leaving ``mc`` / ``lamport`` at the default disables that algo.
+    algo; leaving ``mc`` / ``two_shot_push`` at the default disables that algo.
     """
 
     one_shot_push_threshold: int
     one_shot_pull_threshold: int
     two_shot_pull_threshold: int
     mc: Range = Range(0, 0)  # default: multicast disabled in this context
-    lamport: Range = Range(0, 0)  # default: 2shot_lamport disabled here
+    two_shot_push: Range = Range(0, 0)  # default: 2shot_push disabled here
 
     @property
     def max_push_bytes(self) -> int:
@@ -62,28 +62,28 @@ class Heuristic(NamedTuple):
     @property
     def max_pull_bytes(self) -> int:
         # The pull workspace hosts every pull-variant kernel, so it has to
-        # fit whichever variant runs at the largest size. 2shot_lamport
+        # fit whichever variant runs at the largest size. 2shot_push
         # stages its input through it too, and only gathers elsewhere.
         return max(
             self.one_shot_pull_threshold,
             self.two_shot_pull_threshold,
             self.mc.max_bytes,
-            self.lamport.max_bytes,
+            self.two_shot_push.max_bytes,
         )
 
     @property
-    def max_lamport_bytes(self) -> int:
-        return self.lamport.max_bytes
+    def max_two_shot_push_bytes(self) -> int:
+        return self.two_shot_push.max_bytes
 
     def clip(
-        self, *, max_push_bytes: int, max_pull_bytes: int, max_lamport_bytes: int
+        self, *, max_push_bytes: int, max_pull_bytes: int, max_two_shot_push_bytes: int
     ) -> "Heuristic":
         return Heuristic(
             min(self.one_shot_push_threshold, max_push_bytes),
             min(self.one_shot_pull_threshold, max_pull_bytes),
             min(self.two_shot_pull_threshold, max_pull_bytes),
             self.mc.clip(max_pull_bytes),
-            self.lamport.clip(max_lamport_bytes),
+            self.two_shot_push.clip(max_two_shot_push_bytes),
         )
 
 
@@ -93,7 +93,7 @@ class AllReduceConfig(NamedTuple):
     The two ``Heuristic`` entries describe the size crossover for each
     dispatch context (CUDA-graph capture vs eager). Block-count knobs apply
     to the kernel grid:
-      - ``num_push_blocks``: shared 1shot_push / 2shot_lamport grid (bound to
+      - ``num_push_blocks``: shared 1shot_push / 2shot_push grid (bound to
         the counter array)
       - ``num_pull_blocks``: 1shot_pull (any mode) and non-mc 2shot_pull
       - ``num_mc_blocks``  : mc 2shot_pull; ``None`` disables multicast
@@ -114,16 +114,18 @@ class AllReduceConfig(NamedTuple):
         return max(self.graph.max_pull_bytes, self.eager.max_pull_bytes)
 
     @property
-    def max_lamport_bytes(self) -> int:
-        return max(self.graph.max_lamport_bytes, self.eager.max_lamport_bytes)
+    def max_two_shot_push_bytes(self) -> int:
+        return max(
+            self.graph.max_two_shot_push_bytes, self.eager.max_two_shot_push_bytes
+        )
 
     def clip(
-        self, *, max_push_bytes: int, max_pull_bytes: int, max_lamport_bytes: int
+        self, *, max_push_bytes: int, max_pull_bytes: int, max_two_shot_push_bytes: int
     ) -> "AllReduceConfig":
         bounds = dict(
             max_push_bytes=max_push_bytes,
             max_pull_bytes=max_pull_bytes,
-            max_lamport_bytes=max_lamport_bytes,
+            max_two_shot_push_bytes=max_two_shot_push_bytes,
         )
         return self._replace(
             graph=self.graph.clip(**bounds),
@@ -341,9 +343,9 @@ def get_supported_world_sizes() -> tuple[int, ...]:
     return tuple(_get_all_reduce_configs())
 
 
-_MULTINODE_LAMPORT: dict[tuple[int, int], Range] = {
-    # 2 x GB200 (4 GPUs each). lamport beats mc 2shot_pull by 3-30% here and
-    # loses to it from 4 MB up; below 512 KB 1shot_push is still ahead.
+_MULTINODE_TWO_SHOT_PUSH: dict[tuple[int, int], Range] = {
+    # 2 x GB200 (4 GPUs each). 2shot_push beats mc 2shot_pull by 3-30% here
+    # and loses to it from 4 MB up; below 512 KB 1shot_push is still ahead.
     (10, 8): Range(512 * KB, int(3.5 * MB)),
 }
 
@@ -355,7 +357,7 @@ def get_all_reduce_config(world_size: int, multinode: bool = False) -> AllReduce
     Only SM90, SM100 and SM107 are benchmarked so far; other archs get a
     conservative default (1 MB one-shot crossovers, no multicast).
 
-    ``multinode`` swaps in a separately tuned ``2shot_lamport`` band where one
+    ``multinode`` swaps in a separately tuned ``2shot_push`` band where one
     exists. Only the eager row can differ: a multi-node group forces eager
     anyway, because graph zero-copy input registration is node-local.
     """
@@ -363,7 +365,7 @@ def get_all_reduce_config(world_size: int, multinode: bool = False) -> AllReduce
     if not multinode:
         return config
     cuda_major, _ = torch.cuda.get_device_capability()
-    band = _MULTINODE_LAMPORT.get((cuda_major, world_size))
+    band = _MULTINODE_TWO_SHOT_PUSH.get((cuda_major, world_size))
     if band is None:
         return config
-    return config._replace(eager=config.eager._replace(lamport=band))
+    return config._replace(eager=config.eager._replace(two_shot_push=band))

--- a/python/sglang/srt/distributed/device_communicators/configs/custom_all_reduce_v2.py
+++ b/python/sglang/srt/distributed/device_communicators/configs/custom_all_reduce_v2.py
@@ -93,7 +93,8 @@ class AllReduceConfig(NamedTuple):
     The two ``Heuristic`` entries describe the size crossover for each
     dispatch context (CUDA-graph capture vs eager). Block-count knobs apply
     to the kernel grid:
-      - ``num_push_blocks``: 1shot_push grid (bound to the counter array)
+      - ``num_push_blocks``: shared 1shot_push / 2shot_lamport grid (bound to
+        the counter array)
       - ``num_pull_blocks``: 1shot_pull (any mode) and non-mc 2shot_pull
       - ``num_mc_blocks``  : mc 2shot_pull; ``None`` disables multicast
     """

--- a/python/sglang/srt/distributed/device_communicators/configs/custom_all_reduce_v2.py
+++ b/python/sglang/srt/distributed/device_communicators/configs/custom_all_reduce_v2.py
@@ -19,7 +19,9 @@ class Range(NamedTuple):
     max_bytes: int
 
     def contains(self, nbytes: int) -> bool:
-        return self.min_bytes <= nbytes <= self.max_bytes
+        # `Range(0, 0)` is the "algo disabled here" convention, so it must not
+        # match even a zero-byte message
+        return self.max_bytes > 0 and self.min_bytes <= nbytes <= self.max_bytes
 
     def clip(self, max_bytes: int) -> "Range":
         return Range(
@@ -31,22 +33,27 @@ class Range(NamedTuple):
 class Heuristic(NamedTuple):
     """Self-contained algo ranges for one dispatch context (graph or eager).
 
-    Four algos are tried in order of preference (fastest first):
-      1. ``1shot_push``:    nbytes <= ``one_shot_push_threshold``
-      2. ``1shot_pull``:    nbytes <= ``one_shot_pull_threshold``
-      3. ``2shot_pull`` mc: nbytes in ``mc.min_bytes..mc.max_bytes``
+    Five algos are tried in order of preference (fastest first):
+      1. ``2shot_lamport``: nbytes in ``lamport.min_bytes..lamport.max_bytes``
+      2. ``1shot_push``:    nbytes <= ``one_shot_push_threshold``
+      3. ``1shot_pull``:    nbytes <= ``one_shot_pull_threshold``
+      4. ``2shot_pull`` mc: nbytes in ``mc.min_bytes..mc.max_bytes``
                             (only when multicast is enabled at runtime)
-      4. ``2shot_pull``:    nbytes <= ``two_shot_pull_threshold``
+      5. ``2shot_pull``:    nbytes <= ``two_shot_pull_threshold``
     Above all of these, the caller falls back to NCCL.
 
+    ``lamport`` is tried first so its band may start below
+    ``one_shot_push_threshold``
+
     Setting two adjacent thresholds equal effectively disables the middle
-    algo; leaving ``mc`` at the default disables multicast.
+    algo; leaving ``mc`` / ``lamport`` at the default disables that algo.
     """
 
     one_shot_push_threshold: int
     one_shot_pull_threshold: int
     two_shot_pull_threshold: int
     mc: Range = Range(0, 0)  # default: multicast disabled in this context
+    lamport: Range = Range(0, 0)  # default: 2shot_lamport disabled here
 
     @property
     def max_push_bytes(self) -> int:
@@ -55,19 +62,28 @@ class Heuristic(NamedTuple):
     @property
     def max_pull_bytes(self) -> int:
         # The pull workspace hosts every pull-variant kernel, so it has to
-        # fit whichever variant runs at the largest size.
+        # fit whichever variant runs at the largest size. 2shot_lamport
+        # stages its input through it too, and only gathers elsewhere.
         return max(
             self.one_shot_pull_threshold,
             self.two_shot_pull_threshold,
             self.mc.max_bytes,
+            self.lamport.max_bytes,
         )
 
-    def clip(self, *, max_push_bytes: int, max_pull_bytes: int) -> "Heuristic":
+    @property
+    def max_lamport_bytes(self) -> int:
+        return self.lamport.max_bytes
+
+    def clip(
+        self, *, max_push_bytes: int, max_pull_bytes: int, max_lamport_bytes: int
+    ) -> "Heuristic":
         return Heuristic(
             min(self.one_shot_push_threshold, max_push_bytes),
             min(self.one_shot_pull_threshold, max_pull_bytes),
             min(self.two_shot_pull_threshold, max_pull_bytes),
             self.mc.clip(max_pull_bytes),
+            self.lamport.clip(max_lamport_bytes),
         )
 
 
@@ -96,14 +112,21 @@ class AllReduceConfig(NamedTuple):
     def max_pull_bytes(self) -> int:
         return max(self.graph.max_pull_bytes, self.eager.max_pull_bytes)
 
-    def clip(self, *, max_push_bytes: int, max_pull_bytes: int) -> "AllReduceConfig":
+    @property
+    def max_lamport_bytes(self) -> int:
+        return max(self.graph.max_lamport_bytes, self.eager.max_lamport_bytes)
+
+    def clip(
+        self, *, max_push_bytes: int, max_pull_bytes: int, max_lamport_bytes: int
+    ) -> "AllReduceConfig":
+        bounds = dict(
+            max_push_bytes=max_push_bytes,
+            max_pull_bytes=max_pull_bytes,
+            max_lamport_bytes=max_lamport_bytes,
+        )
         return self._replace(
-            graph=self.graph.clip(
-                max_push_bytes=max_push_bytes, max_pull_bytes=max_pull_bytes
-            ),
-            eager=self.eager.clip(
-                max_push_bytes=max_push_bytes, max_pull_bytes=max_pull_bytes
-            ),
+            graph=self.graph.clip(**bounds),
+            eager=self.eager.clip(**bounds),
         )
 
 
@@ -139,8 +162,20 @@ def _sm100_configs(num_sm: int) -> dict[int, AllReduceConfig]:
         ),
         4: config(
             4,
-            graph=(2.250 * MB, 2.250 * MB, 128.0 * MB),
-            eager=(3.000 * MB, 3.000 * MB, 32.00 * MB),
+            graph=(
+                2.250 * MB,
+                2.250 * MB,
+                128.0 * MB,
+                Range(0, 0),
+                Range(int(1.25 * MB), 16 * MB),
+            ),
+            eager=(
+                3.000 * MB,
+                3.000 * MB,
+                32.00 * MB,
+                Range(0, 0),
+                Range(2 * MB, 16 * MB),
+            ),
         ),
         5: config(
             5,

--- a/python/sglang/srt/distributed/device_communicators/custom_all_reduce_v2.py
+++ b/python/sglang/srt/distributed/device_communicators/custom_all_reduce_v2.py
@@ -156,7 +156,13 @@ class CustomAllReduceV2:
         self.device = device
         self.rank = dist.get_rank(group=self.group)
         self.world_size = dist.get_world_size(group=self.group)
-        base_config = get_all_reduce_config(self.world_size)
+        # A multi-node (MNNVL) group keeps the symm-mem workspace plane but
+        # loses graph zero-copy input registration (cudaIpc / node-local VMM
+        # remap), and its crossovers differ from a single node at the same
+        # world size — so it picks both a different config and eager-only
+        # dispatch below.
+        is_multinode = not all(in_the_same_node_as(group, source_rank=0))
+        base_config = get_all_reduce_config(self.world_size, multinode=is_multinode)
         if max_pull_size is None:
             max_pull_size = min(base_config.max_pull_bytes, max_size)
         if max_push_size is None:
@@ -220,10 +226,6 @@ class CustomAllReduceV2:
             max_lamport_bytes=self.max_lamport_size,
         )._replace(num_pull_blocks=num_pull_blocks, num_push_blocks=num_push_blocks)
         self.override_algo: Optional[AllReduceAlgo] = None
-        # On a multi-node (MNNVL) group the symm-mem workspace plane works
-        # across nodes, but graph zero-copy input registration (cudaIpc /
-        # node-local VMM remap) does not — force eager pull inside graphs.
-        is_multinode = not all(in_the_same_node_as(group, source_rank=0))
         tms_cudagraph = envs.SGLANG_MEMORY_SAVER_CUDA_GRAPH.get()
         self._is_graph_mode_supported = not tms_cudagraph and not is_multinode
         # device-side pointer table: one row of world_size pointers per
@@ -314,9 +316,7 @@ class CustomAllReduceV2:
                 self.rank,
                 self.world_size,
                 workspaces=slice_all([pull_bytes], pull_offset),
-                semaphores=slice_all(
-                    [num_sem_blocks, _SEMAPHORE_BYTES], sem_offset
-                ),
+                semaphores=slice_all([num_sem_blocks, _SEMAPHORE_BYTES], sem_offset),
                 mc_workspace=mc_at(pull_offset),
                 mc_semaphore=mc_at(sem_offset),
             )

--- a/python/sglang/srt/distributed/device_communicators/custom_all_reduce_v2.py
+++ b/python/sglang/srt/distributed/device_communicators/custom_all_reduce_v2.py
@@ -11,11 +11,10 @@ The CUDA side is split into independent pieces:
   all-reduce tensors that are not symmetric memory, so it stages them
   through; the K3 fused collectives bring their own symmetric input and
   borrow the semaphores alone.
-- the gather handle: an alias of ``PushPlane``, used by ``2shot_push`` for
-  the all-gather half of its reduce-scatter. Sharing the handle also shares
-  the epoch counter, so both algorithms advance the double buffer together.
-- ``Communicator``: the planes above (any may be absent), the handle every
-  kernel takes, plus the pull launch widths.
+- ``Communicator``: the two planes above (either may be absent), the handle
+  every kernel takes, plus the pull launch widths. ``2shot_push`` reaches its
+  all-gather region through the push plane, so it also shares that plane's
+  epoch counter: both push algorithms advance the double buffer together.
 - the all-reduce kernel: a pure function of ``(Communicator, input, algo,
   graph_params, use_multicast)`` with four algorithms (1shot_push /
   1shot_pull / 2shot_pull / 2shot_push) and three pull data sources (eager
@@ -289,8 +288,8 @@ class CustomAllReduceV2:
         :param max_two_shot_push_size: explicit ``2shot_push`` message ceiling,
                                  which may enlarge the shared push slots;
                                  overrides both the tuned size and
-                                 ``max_size``. ``0`` disables the algo and its
-                                 gather handle.
+                                 ``max_size``. ``0`` disables the algo and
+                                 leaves the slots at the 1shot_push size.
         :param max_pull_blocks: cap on the barrier plane's block count; ``0``
                                 builds a push-only instance.
         :param max_push_blocks: exact push grid width, overriding the tuned
@@ -422,7 +421,6 @@ class CustomAllReduceV2:
             counter=self._push_counter.view(-1, 1).view(torch.uint8),
             mc_workspace=mc_at(0),
         )
-        gather_plane = push_plane if self.two_shot_push_enabled else None
         pull_plane = None
         if self.pull_enabled:
             pull_plane = PullPlane(
@@ -436,7 +434,7 @@ class CustomAllReduceV2:
         if not self.has_multicast or not self.pull_enabled:
             self.config = self.config._replace(num_mc_blocks=None)
 
-        self.obj = Communicator(push=push_plane, pull=pull_plane, gather=gather_plane)
+        self.obj = Communicator(push=push_plane, pull=pull_plane)
         if self.pull_enabled:
             self.obj.set_pull_blocks(self.config.num_pull_blocks)
         if self.config.num_mc_blocks is not None:

--- a/python/sglang/srt/distributed/device_communicators/custom_all_reduce_v2.py
+++ b/python/sglang/srt/distributed/device_communicators/custom_all_reduce_v2.py
@@ -3,7 +3,7 @@
 The CUDA side is split into independent pieces:
 
 - ``PushPlane``: the zero-filled symmetric push buffers plus a rank-local
-  phase counter. ``1shot_push`` and ``2shot_lamport`` share this plane: the
+  phase counter. ``1shot_push`` and ``2shot_push`` share this plane: the
   former treats it as one full-input slot per source, while the latter lays
   the reduced shards contiguously across those same slots.
 - ``PullPlane``: the symmetric pull buffers plus the per-block semaphores
@@ -11,14 +11,14 @@ The CUDA side is split into independent pieces:
   all-reduce tensors that are not symmetric memory, so it stages them
   through; the K3 fused collectives bring their own symmetric input and
   borrow the semaphores alone.
-- the gather handle: an alias of ``PushPlane``, used by ``2shot_lamport`` for
+- the gather handle: an alias of ``PushPlane``, used by ``2shot_push`` for
   the all-gather half of its reduce-scatter. Sharing the handle also shares
   the epoch counter, so both algorithms advance the double buffer together.
 - ``Communicator``: the planes above (any may be absent), the handle every
   kernel takes, plus the pull launch widths.
 - the all-reduce kernel: a pure function of ``(Communicator, input, algo,
   graph_params, use_multicast)`` with four algorithms (1shot_push /
-  1shot_pull / 2shot_pull / 2shot_lamport) and three pull data sources (eager
+  1shot_pull / 2shot_pull / 2shot_push) and three pull data sources (eager
   pull buffer / CUDA-graph pointer table / multicast address).
 
 All storage is allocated and owned here, in Python.
@@ -122,7 +122,7 @@ class CustomAllReduceV2:
         *,
         max_pull_size: Optional[int] = None,
         max_push_size: Optional[int] = None,
-        max_lamport_size: Optional[int] = None,
+        max_two_shot_push_size: Optional[int] = None,
         max_pull_blocks: Optional[int] = None,
         max_push_blocks: Optional[int] = None,
     ) -> None:
@@ -136,7 +136,7 @@ class CustomAllReduceV2:
                               push-only instance.
         :param max_push_size: explicit per-slot push workspace size;
                               overrides both the tuned size and ``max_size``.
-        :param max_lamport_size: explicit ``2shot_lamport`` message ceiling,
+        :param max_two_shot_push_size: explicit ``2shot_push`` message ceiling,
                                  which may enlarge the shared push slots;
                                  overrides both the tuned size and
                                  ``max_size``. ``0`` disables the algo and its
@@ -167,8 +167,8 @@ class CustomAllReduceV2:
             max_pull_size = min(base_config.max_pull_bytes, max_size)
         if max_push_size is None:
             max_push_size = min(base_config.max_push_bytes, max_size)
-        if max_lamport_size is None:
-            max_lamport_size = min(base_config.max_lamport_bytes, max_size)
+        if max_two_shot_push_size is None:
+            max_two_shot_push_size = min(base_config.max_two_shot_push_bytes, max_size)
         if _FORCE_PULL_SIZE_KB is not None:
             max_pull_size = int(_FORCE_PULL_SIZE_KB) * 1024
         if _FORCE_PUSH_SIZE_KB is not None:
@@ -206,24 +206,24 @@ class CustomAllReduceV2:
             num_pull_blocks = max(min(num_pull_blocks, max_pull_blocks), 1)
         if max_push_blocks is not None:
             num_push_blocks = max(max_push_blocks, 1)
-        self.lamport_enabled = self.pull_enabled and max_lamport_size > 0
+        self.two_shot_push_enabled = self.pull_enabled and max_two_shot_push_size > 0
         self.gather_slot_size = (
             _ceil_align(
-                _div_ceil(max_lamport_size, self.world_size),
+                _div_ceil(max_two_shot_push_size, self.world_size),
                 _ALIGN_BYTES,
             )
-            if self.lamport_enabled
+            if self.two_shot_push_enabled
             else 0
         )
         self.shared_slot_size = max(self.max_push_size, self.gather_slot_size)
-        self.max_lamport_size = min(
+        self.max_two_shot_push_size = min(
             self.gather_slot_size * self.world_size, self.max_pull_size
         )
         self.max_size = max(self.max_pull_size, self.max_push_size)
         self.config = base_config.clip(
             max_push_bytes=self.max_push_size,
             max_pull_bytes=self.max_pull_size,
-            max_lamport_bytes=self.max_lamport_size,
+            max_two_shot_push_bytes=self.max_two_shot_push_size,
         )._replace(num_pull_blocks=num_pull_blocks, num_push_blocks=num_push_blocks)
         self.override_algo: Optional[AllReduceAlgo] = None
         tms_cudagraph = envs.SGLANG_MEMORY_SAVER_CUDA_GRAPH.get()
@@ -253,18 +253,18 @@ class CustomAllReduceV2:
 
         Layout per rank: ``[2 * world_size shared push slots | pull buffer |
         pull semaphores]``. The shared slots serve both ``1shot_push`` and
-        ``2shot_lamport``; their common counter is rank-local and therefore
+        ``2shot_push``; their common counter is rank-local and therefore
         lives in a plain CUDA tensor.
         """
         cfg = self.config
         push_num_slots = 2 * self.world_size  # 2 phases x world_size peers
         push_bytes = push_num_slots * self.shared_slot_size
         pull_bytes = self.max_pull_size  # 0 when the pull half is disabled
-        # Lamport now launches with the push grid (`num_sms`) but enters
+        # 2shot_push now launches with the push grid (`num_sms`) but enters
         # through the pull barrier. Allocate enough semaphore rows for that
         # grid while keeping the tuned pull launch width in Communicator.
         num_sem_blocks = cfg.num_pull_blocks if self.pull_enabled else 0
-        if self.lamport_enabled:
+        if self.two_shot_push_enabled:
             num_sem_blocks = max(num_sem_blocks, cfg.num_push_blocks)
         sem_bytes = _SEMAPHORE_BYTES * num_sem_blocks
         total_bytes = push_bytes + pull_bytes + sem_bytes
@@ -309,7 +309,7 @@ class CustomAllReduceV2:
             counter=self._push_counter.view(-1, 1).view(torch.uint8),
             mc_workspace=mc_at(0),
         )
-        gather_plane = push_plane if self.lamport_enabled else None
+        gather_plane = push_plane if self.two_shot_push_enabled else None
         pull_plane = None
         if self.pull_enabled:
             pull_plane = PullPlane(
@@ -331,12 +331,12 @@ class CustomAllReduceV2:
         if self.rank == 0:
             logger.info(
                 "All Reduce config: symmetric_memory = %.2f MB, "
-                "local_buffer = %.2f MB, multicast = %s, pull = %s, lamport = %s",
+                "local_buffer = %.2f MB, multicast = %s, pull = %s, 2shot_push = %s",
                 total_bytes / MB,
                 (self.graph_params.nbytes + self._push_counter.nbytes) / MB,
                 self.config.num_mc_blocks is not None,
                 self.pull_enabled,
-                self.lamport_enabled,
+                self.two_shot_push_enabled,
             )
         dist.barrier(group=self.group)
 
@@ -379,10 +379,8 @@ class CustomAllReduceV2:
         heuristic = self.config.graph if can_use_graph else self.config.eager
         can_use_multicast = self.config.num_mc_blocks is not None
         # tried first so its band may start below one_shot_push_threshold
-        if heuristic.lamport.contains(nbytes):
-            return AllReduceConfig(
-                AllReduceAlgo.TWO_SHOT_LAMPORT, use_graph=can_use_graph
-            )
+        if heuristic.two_shot_push.contains(nbytes):
+            return AllReduceConfig(AllReduceAlgo.TWO_SHOT_PUSH, use_graph=can_use_graph)
         if nbytes <= heuristic.one_shot_push_threshold:
             return AllReduceConfig(AllReduceAlgo.ONE_SHOT_PUSH)
         if nbytes <= heuristic.one_shot_pull_threshold:
@@ -416,7 +414,7 @@ class CustomAllReduceV2:
         if self.override_algo is not None:
             # TODO: enhance this override pattern
             algo = self.override_algo
-            use_graph = self._can_use_graph() and not algo.is_push()
+            use_graph = self._can_use_graph() and algo.supports_zero_copy()
             use_multicast = False
         else:
             config = self._pick_config(nbytes, self._can_use_graph())

--- a/python/sglang/srt/distributed/device_communicators/custom_all_reduce_v2.py
+++ b/python/sglang/srt/distributed/device_communicators/custom_all_reduce_v2.py
@@ -9,12 +9,15 @@ The CUDA side is split into independent pieces:
   all-reduce tensors that are not symmetric memory, so it stages them
   through; the K3 fused collectives bring their own symmetric input and
   borrow the semaphores alone.
-- ``Communicator``: the two planes above (either may be absent), the handle
-  every kernel takes, plus the pull launch widths.
+- the gather plane: a second ``PushPlane``, used by ``2shot_lamport`` for
+  the all-gather half of its reduce-scatter. It cannot share the push plane,
+  whose epoch ``1shot_push`` advances on its own schedule.
+- ``Communicator``: the planes above (any may be absent), the handle every
+  kernel takes, plus the pull launch widths.
 - the all-reduce kernel: a pure function of ``(Communicator, input, algo,
-  graph_params, use_multicast)`` with three algorithms (1shot_push /
-  1shot_pull / 2shot_pull) and three pull data sources (eager pull buffer /
-  CUDA-graph pointer table / multicast address).
+  graph_params, use_multicast)`` with four algorithms (1shot_push /
+  1shot_pull / 2shot_pull / 2shot_lamport) and three pull data sources (eager
+  pull buffer / CUDA-graph pointer table / multicast address).
 
 All storage is allocated and owned here, in Python.
 
@@ -80,6 +83,10 @@ def _ceil_align(nbytes: int, align: int) -> int:
     return (nbytes + align - 1) // align * align
 
 
+def _div_ceil(nbytes: int, div: int) -> int:
+    return (nbytes + div - 1) // div
+
+
 def _allocate_symmetric_memory(nbytes: int, device: torch.device, group: ProcessGroup):
     from torch._C._distributed_c10d import _SymmetricMemory
 
@@ -113,6 +120,7 @@ class CustomAllReduceV2:
         *,
         max_pull_size: Optional[int] = None,
         max_push_size: Optional[int] = None,
+        max_lamport_size: Optional[int] = None,
         max_pull_blocks: Optional[int] = None,
         max_push_blocks: Optional[int] = None,
     ) -> None:
@@ -126,6 +134,10 @@ class CustomAllReduceV2:
                               push-only instance.
         :param max_push_size: explicit per-slot push workspace size;
                               overrides both the tuned size and ``max_size``.
+        :param max_lamport_size: explicit ``2shot_lamport`` message ceiling,
+                                 which sizes the gather plane; overrides both
+                                 the tuned size and ``max_size``. ``0``
+                                 disables the algo and its plane.
         :param max_pull_blocks: cap on the barrier plane's block count; ``0``
                                 builds a push-only instance.
 
@@ -146,6 +158,8 @@ class CustomAllReduceV2:
             max_pull_size = min(base_config.max_pull_bytes, max_size)
         if max_push_size is None:
             max_push_size = min(base_config.max_push_bytes, max_size)
+        if max_lamport_size is None:
+            max_lamport_size = min(base_config.max_lamport_bytes, max_size)
         if _FORCE_PULL_SIZE_KB is not None:
             max_pull_size = int(_FORCE_PULL_SIZE_KB) * 1024
         if _FORCE_PUSH_SIZE_KB is not None:
@@ -177,15 +191,29 @@ class CustomAllReduceV2:
             else 0
         )
         self.max_push_size = _ceil_align(max(max_push_size, _ALIGN_BYTES), _ALIGN_BYTES)
-        self.max_size = max(self.max_pull_size, self.max_push_size)
         num_pull_blocks = base_config.num_pull_blocks
         num_push_blocks = base_config.num_push_blocks
         if max_pull_blocks:
             num_pull_blocks = max(min(num_pull_blocks, max_pull_blocks), 1)
         if max_push_blocks is not None:
             num_push_blocks = max(max_push_blocks, 1)
+        self.lamport_enabled = self.pull_enabled and max_lamport_size > 0
+        self.gather_slot_size = (
+            _ceil_align(
+                _div_ceil(max_lamport_size, self.world_size),
+                _ALIGN_BYTES,
+            )
+            if self.lamport_enabled
+            else 0
+        )
+        self.max_lamport_size = min(
+            self.gather_slot_size * self.world_size, self.max_pull_size
+        )
+        self.max_size = max(self.max_pull_size, self.max_push_size)
         self.config = base_config.clip(
-            max_push_bytes=self.max_push_size, max_pull_bytes=self.max_pull_size
+            max_push_bytes=self.max_push_size,
+            max_pull_bytes=self.max_pull_size,
+            max_lamport_bytes=self.max_lamport_size,
         )._replace(num_pull_blocks=num_pull_blocks, num_push_blocks=num_push_blocks)
         self.override_algo: Optional[AllReduceAlgo] = None
         # On a multi-node (MNNVL) group the symm-mem workspace plane works
@@ -218,18 +246,21 @@ class CustomAllReduceV2:
         """Slice one symmetric-memory allocation into every shared buffer.
 
         Layout per rank: ``[2 * world_size push slots | pull buffer | pull
-        semaphores]``. One allocation rather than three keeps it to a single
-        rendezvous and a single multicast base to offset from. The push
-        counter is rank-local, so it lives in a plain CUDA tensor.
+        semaphores | 2 * world_size gather slots]``. One allocation rather
+        than four keeps it to a single rendezvous and a single multicast base
+        to offset from. The push and gather counters are rank-local, so they
+        live in plain CUDA tensors.
         """
         cfg = self.config
         push_num_slots = 2 * self.world_size  # 2 phases x world_size peers
         push_bytes = push_num_slots * self.max_push_size
         pull_bytes = self.max_pull_size  # 0 when the pull half is disabled
         sem_bytes = _SEMAPHORE_BYTES * cfg.num_pull_blocks if self.pull_enabled else 0
-        total_bytes = push_bytes + pull_bytes + sem_bytes
+        gather_bytes = push_num_slots * self.gather_slot_size  # 0 when disabled
+        total_bytes = push_bytes + pull_bytes + sem_bytes + gather_bytes
         pull_offset = push_bytes
         sem_offset = push_bytes + pull_bytes
+        gather_offset = sem_offset + sem_bytes
 
         self._symm_tensor, symm_mem = _allocate_symmetric_memory(
             total_bytes, device=self.device, group=self.group
@@ -238,9 +269,9 @@ class CustomAllReduceV2:
             symm_mem.get_buffer(i, [total_bytes], torch.uint8)
             for i in range(self.world_size)
         ]
-        # The push slots (lamport pos-zero markers) and the semaphores must
-        # start zeroed; the pull buffer need not, but it rides along in the
-        # one-shot memset.
+        # The push and gather slots (lamport pos-zero markers) and the
+        # semaphores must start zeroed; the pull buffer need not, but it rides
+        # along in the one-shot memset.
         slabs[self.rank].zero_()
         torch.cuda.synchronize()
         dist.barrier(group=self.group)
@@ -269,6 +300,19 @@ class CustomAllReduceV2:
             counter=self._push_counter.view(-1, 1).view(torch.uint8),
             mc_workspace=mc_at(0),
         )
+        gather_plane = None
+        if self.lamport_enabled:
+            self._gather_counter = torch.zeros(
+                (cfg.num_pull_blocks,), dtype=torch.uint32, device=self.device
+            )
+            gather_plane = PushPlane(
+                self.rank,
+                self.world_size,
+                workspaces=slice_all(
+                    [push_num_slots, self.gather_slot_size], gather_offset
+                ),
+                counter=self._gather_counter.view(-1, 1).view(torch.uint8),
+            )
         pull_plane = None
         if self.pull_enabled:
             pull_plane = PullPlane(
@@ -284,17 +328,18 @@ class CustomAllReduceV2:
         if not self.has_multicast or not self.pull_enabled:
             self.config = self.config._replace(num_mc_blocks=None)
 
-        self.obj = Communicator(push=push_plane, pull=pull_plane)
+        self.obj = Communicator(push=push_plane, pull=pull_plane, gather=gather_plane)
         if self.config.num_mc_blocks is not None:
             self.obj.set_pull_multicast_blocks(self.config.num_mc_blocks)
         if self.rank == 0:
             logger.info(
                 "All Reduce config: symmetric_memory = %.2f MB, "
-                "local_buffer = %.2f MB, multicast = %s, pull = %s",
+                "local_buffer = %.2f MB, multicast = %s, pull = %s, lamport = %s",
                 total_bytes / MB,
                 (self.graph_params.nbytes + self._push_counter.nbytes) / MB,
                 self.config.num_mc_blocks is not None,
                 self.pull_enabled,
+                self.lamport_enabled,
             )
         dist.barrier(group=self.group)
 
@@ -336,6 +381,11 @@ class CustomAllReduceV2:
         # TODO: refactor this along with the config file
         heuristic = self.config.graph if can_use_graph else self.config.eager
         can_use_multicast = self.config.num_mc_blocks is not None
+        # tried first so its band may start below one_shot_push_threshold
+        if heuristic.lamport.contains(nbytes):
+            return AllReduceConfig(
+                AllReduceAlgo.TWO_SHOT_LAMPORT, use_graph=can_use_graph
+            )
         if nbytes <= heuristic.one_shot_push_threshold:
             return AllReduceConfig(AllReduceAlgo.ONE_SHOT_PUSH)
         if nbytes <= heuristic.one_shot_pull_threshold:

--- a/python/sglang/srt/distributed/device_communicators/custom_all_reduce_v2.py
+++ b/python/sglang/srt/distributed/device_communicators/custom_all_reduce_v2.py
@@ -56,7 +56,9 @@ from sglang.srt.utils.cuda_vmm_utils import (
     is_vmm_pointer,
 )
 
+from .configs.custom_all_reduce_v2 import AllReduceConfig as TunedConfig
 from .configs.custom_all_reduce_v2 import (
+    Heuristic,
     get_all_reduce_config,
     get_supported_world_sizes,
 )
@@ -75,18 +77,31 @@ _SEMAPHORE_BYTES = 128
 _MAX_GRAPH_INPUTS = 131072
 # resolved once at import time; explicit constructor sizes take precedence
 _DEFAULT_MAX_SIZE = envs.SGLANG_CUSTOM_ALL_REDUCE_V2_MAX_SIZE_KB.get() * 1024
-# forced per-direction workspace sizes; highest priority, override both the
-# tuned config and explicit constructor sizes (None = not forced)
-_FORCE_PULL_SIZE_KB = envs.SGLANG_FORCE_CUSTOM_ALL_REDUCE_V2_PULL_SIZE_KB.get()
-_FORCE_PUSH_SIZE_KB = envs.SGLANG_FORCE_CUSTOM_ALL_REDUCE_V2_PUSH_SIZE_KB.get()
 
 
-def _ceil_align(nbytes: int, align: int) -> int:
-    return (nbytes + align - 1) // align * align
+def _forced_size(env_kb: Optional[int]) -> Optional[int]:
+    """Bytes behind a ``SGLANG_FORCE_*_SIZE_KB`` env var; ``None`` when unset."""
+    return None if env_kb is None else int(env_kb) * 1024
+
+
+# forced per-direction workspace sizes; highest priority, they override both
+# the tuned config and explicit constructor sizes
+_FORCE_PULL_SIZE = _forced_size(
+    envs.SGLANG_FORCE_CUSTOM_ALL_REDUCE_V2_PULL_SIZE_KB.get()
+)
+_FORCE_PUSH_SIZE = _forced_size(
+    envs.SGLANG_FORCE_CUSTOM_ALL_REDUCE_V2_PUSH_SIZE_KB.get()
+)
 
 
 def _div_ceil(nbytes: int, div: int) -> int:
     return (nbytes + div - 1) // div
+
+
+def _align(nbytes: int) -> int:
+    """Round a workspace size up to ``_ALIGN_BYTES``, never down to zero."""
+    nbytes = max(nbytes, _ALIGN_BYTES)
+    return (nbytes + _ALIGN_BYTES - 1) // _ALIGN_BYTES * _ALIGN_BYTES
 
 
 def _allocate_symmetric_memory(nbytes: int, device: torch.device, group: ProcessGroup):
@@ -111,6 +126,141 @@ class AllReduceConfig(NamedTuple):
     algo: AllReduceAlgo
     use_graph: bool = False
     use_multicast: bool = False
+
+
+class _WorkspaceSizes(NamedTuple):
+    """Aligned byte capacities of one instance's symmetric-memory workspace.
+
+    ``pull`` and ``push`` are the per-direction message ceilings; either may
+    be ``0``. ``gather_slot`` is the shard slot ``2shot_push`` all-gathers
+    into, and ``two_shot_push`` the message ceiling that slot buys.
+    """
+
+    pull: int
+    push: int
+    gather_slot: int
+    two_shot_push: int
+
+    @property
+    def pull_enabled(self) -> bool:
+        return self.pull > 0
+
+    @property
+    def two_shot_push_enabled(self) -> bool:
+        return self.gather_slot > 0
+
+    @property
+    def shared_slot(self) -> int:
+        """Size of one of the ``2 * world_size`` shared push slots.
+
+        The two push algos share the plane, so a slot has to hold either
+        occupant: a whole ``1shot_push`` input, or a ``2shot_push`` shard.
+        """
+        return max(self.push, self.gather_slot)
+
+    @property
+    def max_message(self) -> int:
+        """Largest message any algorithm on this workspace can take."""
+        return max(self.pull, self.push)
+
+    @classmethod
+    def resolve(
+        cls,
+        tuned: TunedConfig,
+        world_size: int,
+        *,
+        max_size: int,
+        max_pull_size: Optional[int],
+        max_push_size: Optional[int],
+        max_two_shot_push_size: Optional[int],
+        pull_blocks_disabled: bool,
+    ) -> "_WorkspaceSizes":
+        """Resolve the constructor's optional caps into concrete capacities.
+
+        Precedence, highest first: the ``SGLANG_FORCE_*`` env vars, the
+        explicit constructor argument, then what the tuned config wants
+        clipped to ``max_size``.
+        """
+        if max_pull_size is None:
+            max_pull_size = min(tuned.max_pull_bytes, max_size)
+        if max_push_size is None:
+            max_push_size = min(tuned.max_push_bytes, max_size)
+        if max_two_shot_push_size is None:
+            max_two_shot_push_size = min(tuned.max_two_shot_push_bytes, max_size)
+        if _FORCE_PULL_SIZE is not None:
+            max_pull_size = _FORCE_PULL_SIZE
+        if _FORCE_PUSH_SIZE is not None:
+            max_push_size = _FORCE_PUSH_SIZE
+
+        # Zero on either pull knob opts out of the pull half entirely: no
+        # pull plane at all, and every pull algo disabled by clipping its
+        # threshold to 0. Push-only callers (the fused qk-norm instances)
+        # take this path rather than allocating a placeholder buffer just to
+        # satisfy a constructor.
+        pull_off = pull_blocks_disabled or max_pull_size <= 0
+        # 2shot_push stages its input through the pull buffer, so it goes
+        # down with the pull half; what it gathers is one reduced shard per
+        # rank, hence a slot of 1/world_size of the message.
+        gather_off = pull_off or max_two_shot_push_size <= 0
+        gather_slot = (
+            0 if gather_off else _align(_div_ceil(max_two_shot_push_size, world_size))
+        )
+        pull = 0 if pull_off else _align(max_pull_size)
+        return cls(
+            pull=pull,
+            push=_align(max_push_size),
+            gather_slot=gather_slot,
+            # rounding the shard up bought a bit of headroom; the pull
+            # buffer still has to hold the whole message
+            two_shot_push=min(gather_slot * world_size, pull),
+        )
+
+
+def _narrow_config(
+    tuned: TunedConfig,
+    sizes: _WorkspaceSizes,
+    *,
+    max_pull_blocks: Optional[int],
+    max_push_blocks: Optional[int],
+) -> TunedConfig:
+    """Narrow a tuned config to what this instance actually allocated.
+
+    Every algo's size threshold is clipped to its workspace capacity, and
+    the kernel grids to the caller's block limits.
+    """
+
+    def force_thresholds(heuristic: Heuristic) -> Heuristic:
+        # forced sizes bypass the tuned NCCL-crossover heuristics: lift
+        # each direction's ceiling to the forced workspace capacity (the
+        # clip() below only ever lowers thresholds)
+        if _FORCE_PULL_SIZE is not None:
+            heuristic = heuristic._replace(two_shot_pull_threshold=_FORCE_PULL_SIZE)
+        if _FORCE_PUSH_SIZE is not None:
+            heuristic = heuristic._replace(one_shot_push_threshold=_FORCE_PUSH_SIZE)
+        return heuristic
+
+    # a cap, and `0` is not one: it means "push-only instance", which leaves
+    # no pull plane to size in the first place
+    num_pull_blocks = tuned.num_pull_blocks
+    if max_pull_blocks:
+        num_pull_blocks = max(min(num_pull_blocks, max_pull_blocks), 1)
+    # not a cap but an override: callers size the push grid by occupancy,
+    # which may land either side of the tuned default
+    num_push_blocks = tuned.num_push_blocks
+    if max_push_blocks is not None:
+        num_push_blocks = max(max_push_blocks, 1)
+    return (
+        tuned._replace(
+            graph=force_thresholds(tuned.graph),
+            eager=force_thresholds(tuned.eager),
+        )
+        .clip(
+            max_push_bytes=sizes.push,
+            max_pull_bytes=sizes.pull,
+            max_two_shot_push_bytes=sizes.two_shot_push,
+        )
+        ._replace(num_pull_blocks=num_pull_blocks, num_push_blocks=num_push_blocks)
+    )
 
 
 class CustomAllReduceV2:
@@ -143,6 +293,8 @@ class CustomAllReduceV2:
                                  gather handle.
         :param max_pull_blocks: cap on the barrier plane's block count; ``0``
                                 builds a push-only instance.
+        :param max_push_blocks: exact push grid width, overriding the tuned
+                                one in either direction.
 
         ``SGLANG_FORCE_CUSTOM_ALL_REDUCE_V2_PULL_SIZE_KB`` /
         ``SGLANG_FORCE_CUSTOM_ALL_REDUCE_V2_PUSH_SIZE_KB`` take the highest
@@ -162,69 +314,30 @@ class CustomAllReduceV2:
         # world size — so it picks both a different config and eager-only
         # dispatch below.
         is_multinode = not all(in_the_same_node_as(group, source_rank=0))
-        base_config = get_all_reduce_config(self.world_size, multinode=is_multinode)
-        if max_pull_size is None:
-            max_pull_size = min(base_config.max_pull_bytes, max_size)
-        if max_push_size is None:
-            max_push_size = min(base_config.max_push_bytes, max_size)
-        if max_two_shot_push_size is None:
-            max_two_shot_push_size = min(base_config.max_two_shot_push_bytes, max_size)
-        if _FORCE_PULL_SIZE_KB is not None:
-            max_pull_size = int(_FORCE_PULL_SIZE_KB) * 1024
-        if _FORCE_PUSH_SIZE_KB is not None:
-            max_push_size = int(_FORCE_PUSH_SIZE_KB) * 1024
-
-        def force_thresholds(heuristic):
-            # forced sizes bypass the tuned NCCL-crossover heuristics: lift
-            # each direction's ceiling to the forced workspace capacity (the
-            # clip() below only ever lowers thresholds)
-            if _FORCE_PULL_SIZE_KB is not None:
-                heuristic = heuristic._replace(two_shot_pull_threshold=max_pull_size)
-            if _FORCE_PUSH_SIZE_KB is not None:
-                heuristic = heuristic._replace(one_shot_push_threshold=max_push_size)
-            return heuristic
-
-        base_config = base_config._replace(
-            graph=force_thresholds(base_config.graph),
-            eager=force_thresholds(base_config.eager),
+        tuned = get_all_reduce_config(self.world_size, multinode=is_multinode)
+        sizes = _WorkspaceSizes.resolve(
+            tuned,
+            self.world_size,
+            max_size=max_size,
+            max_pull_size=max_pull_size,
+            max_push_size=max_push_size,
+            max_two_shot_push_size=max_two_shot_push_size,
+            pull_blocks_disabled=max_pull_blocks == 0,
         )
-        # Zero on either pull knob opts out of the pull half entirely: no
-        # pull plane at all, and every pull algo disabled below by clipping
-        # its threshold to 0. Push-only callers (the fused qk-norm instances)
-        # take this path rather than allocating a placeholder buffer just to
-        # satisfy a constructor.
-        self.pull_enabled = max_pull_blocks != 0 and max_pull_size > 0
-        self.max_pull_size = (
-            _ceil_align(max(max_pull_size, _ALIGN_BYTES), _ALIGN_BYTES)
-            if self.pull_enabled
-            else 0
+        self.pull_enabled = sizes.pull_enabled
+        self.two_shot_push_enabled = sizes.two_shot_push_enabled
+        self.max_pull_size = sizes.pull
+        self.max_push_size = sizes.push
+        self.max_two_shot_push_size = sizes.two_shot_push
+        self.gather_slot_size = sizes.gather_slot
+        self.shared_slot_size = sizes.shared_slot
+        self.max_size = sizes.max_message
+        self.config = _narrow_config(
+            tuned,
+            sizes,
+            max_pull_blocks=max_pull_blocks,
+            max_push_blocks=max_push_blocks,
         )
-        self.max_push_size = _ceil_align(max(max_push_size, _ALIGN_BYTES), _ALIGN_BYTES)
-        num_pull_blocks = base_config.num_pull_blocks
-        num_push_blocks = base_config.num_push_blocks
-        if max_pull_blocks:
-            num_pull_blocks = max(min(num_pull_blocks, max_pull_blocks), 1)
-        if max_push_blocks is not None:
-            num_push_blocks = max(max_push_blocks, 1)
-        self.two_shot_push_enabled = self.pull_enabled and max_two_shot_push_size > 0
-        self.gather_slot_size = (
-            _ceil_align(
-                _div_ceil(max_two_shot_push_size, self.world_size),
-                _ALIGN_BYTES,
-            )
-            if self.two_shot_push_enabled
-            else 0
-        )
-        self.shared_slot_size = max(self.max_push_size, self.gather_slot_size)
-        self.max_two_shot_push_size = min(
-            self.gather_slot_size * self.world_size, self.max_pull_size
-        )
-        self.max_size = max(self.max_pull_size, self.max_push_size)
-        self.config = base_config.clip(
-            max_push_bytes=self.max_push_size,
-            max_pull_bytes=self.max_pull_size,
-            max_two_shot_push_bytes=self.max_two_shot_push_size,
-        )._replace(num_pull_blocks=num_pull_blocks, num_push_blocks=num_push_blocks)
         self.override_algo: Optional[AllReduceAlgo] = None
         tms_cudagraph = envs.SGLANG_MEMORY_SAVER_CUDA_GRAPH.get()
         self._is_graph_mode_supported = not tms_cudagraph and not is_multinode

--- a/python/sglang/srt/distributed/device_communicators/custom_all_reduce_v2.py
+++ b/python/sglang/srt/distributed/device_communicators/custom_all_reduce_v2.py
@@ -3,21 +3,23 @@
 The CUDA side is split into independent pieces:
 
 - ``PushPlane``: the zero-filled symmetric push buffers plus a rank-local
-  phase counter. ``1shot_push`` and ``2shot_push`` share this plane: the
+  phase counter. ``1shot_push`` and ``2shot_scatter`` share this plane: the
   former treats it as one full-input slot per source, while the latter lays
-  the reduced shards contiguously across those same slots.
+  the reduced shards contiguously across those same slots in its all-gather
+  half.
 - ``PullPlane``: the symmetric pull buffers plus the per-block semaphores
   guarding them. The buffers exist only because this class hands the
   all-reduce tensors that are not symmetric memory, so it stages them
   through; the K3 fused collectives bring their own symmetric input and
   borrow the semaphores alone.
-- ``Communicator``: the two planes above (either may be absent), the handle
-  every kernel takes, plus the pull launch widths. ``2shot_push`` reaches its
-  all-gather region through the push plane, so it also shares that plane's
-  epoch counter: both push algorithms advance the double buffer together.
+- the scatter plane: ``2shot_scatter``'s per-source shard slots, a third
+  ``PushPlane`` sharing the push plane's epoch counter so every push-family
+  algorithm advances the double buffer together.
+- ``Communicator``: the planes above (any may be absent), the handle every
+  kernel takes, plus the pull launch widths.
 - the all-reduce kernel: a pure function of ``(Communicator, input, algo,
   graph_params, use_multicast)`` with four algorithms (1shot_push /
-  1shot_pull / 2shot_pull / 2shot_push) and three pull data sources (eager
+  1shot_pull / 2shot_pull / 2shot_scatter) and three pull data sources (eager
   pull buffer / CUDA-graph pointer table / multicast address).
 
 All storage is allocated and owned here, in Python.
@@ -131,31 +133,35 @@ class _WorkspaceSizes(NamedTuple):
     """Aligned byte capacities of one instance's symmetric-memory workspace.
 
     ``pull`` and ``push`` are the per-direction message ceilings; either may
-    be ``0``. ``gather_slot`` is the shard slot ``2shot_push`` all-gathers
-    into, and ``two_shot_push`` the message ceiling that slot buys.
+    be ``0``. ``scatter_slot`` sizes ``2shot_scatter``'s per-peer shard slots
+    -- one size serves both its planes, since the scatter inbox holds a
+    contribution shard and the gather half one reduced shard per slot --
+    with ``two_shot_scatter`` the message ceiling that buys.
     """
 
     pull: int
     push: int
-    gather_slot: int
-    two_shot_push: int
+    scatter_slot: int
+    two_shot_scatter: int
 
     @property
     def pull_enabled(self) -> bool:
         return self.pull > 0
 
     @property
-    def two_shot_push_enabled(self) -> bool:
-        return self.gather_slot > 0
+    def two_shot_scatter_enabled(self) -> bool:
+        return self.scatter_slot > 0
 
     @property
     def shared_slot(self) -> int:
         """Size of one of the ``2 * world_size`` shared push slots.
 
-        The two push algos share the plane, so a slot has to hold either
-        occupant: a whole ``1shot_push`` input, or a ``2shot_push`` shard.
+        The push algos share the plane, so a slot has to hold either
+        occupant: a whole ``1shot_push`` input, or a reduced shard from
+        ``2shot_scatter``'s all-gather half (the same shard size that sizes
+        the scatter slots).
         """
-        return max(self.push, self.gather_slot)
+        return max(self.push, self.scatter_slot)
 
     @property
     def max_message(self) -> int:
@@ -171,7 +177,7 @@ class _WorkspaceSizes(NamedTuple):
         max_size: int,
         max_pull_size: Optional[int],
         max_push_size: Optional[int],
-        max_two_shot_push_size: Optional[int],
+        max_two_shot_scatter_size: Optional[int],
         pull_blocks_disabled: bool,
     ) -> "_WorkspaceSizes":
         """Resolve the constructor's optional caps into concrete capacities.
@@ -184,8 +190,8 @@ class _WorkspaceSizes(NamedTuple):
             max_pull_size = min(tuned.max_pull_bytes, max_size)
         if max_push_size is None:
             max_push_size = min(tuned.max_push_bytes, max_size)
-        if max_two_shot_push_size is None:
-            max_two_shot_push_size = min(tuned.max_two_shot_push_bytes, max_size)
+        if max_two_shot_scatter_size is None:
+            max_two_shot_scatter_size = min(tuned.max_two_shot_scatter_bytes, max_size)
         if _FORCE_PULL_SIZE is not None:
             max_pull_size = _FORCE_PULL_SIZE
         if _FORCE_PUSH_SIZE is not None:
@@ -197,21 +203,19 @@ class _WorkspaceSizes(NamedTuple):
         # take this path rather than allocating a placeholder buffer just to
         # satisfy a constructor.
         pull_off = pull_blocks_disabled or max_pull_size <= 0
-        # 2shot_push stages its input through the pull buffer, so it goes
-        # down with the pull half; what it gathers is one reduced shard per
-        # rank, hence a slot of 1/world_size of the message.
-        gather_off = pull_off or max_two_shot_push_size <= 0
-        gather_slot = (
-            0 if gather_off else _align(_div_ceil(max_two_shot_push_size, world_size))
+        # 2shot_scatter workspaces are the scatter slots and the shared push plane's
+        # gather half, and both hold one reduced shard per peer, so one size
+        # serves both.
+        scatter_slot = (
+            0
+            if max_two_shot_scatter_size <= 0
+            else _align(_div_ceil(max_two_shot_scatter_size, world_size))
         )
-        pull = 0 if pull_off else _align(max_pull_size)
         return cls(
-            pull=pull,
+            pull=0 if pull_off else _align(max_pull_size),
             push=_align(max_push_size),
-            gather_slot=gather_slot,
-            # rounding the shard up bought a bit of headroom; the pull
-            # buffer still has to hold the whole message
-            two_shot_push=min(gather_slot * world_size, pull),
+            scatter_slot=scatter_slot,
+            two_shot_scatter=scatter_slot * world_size,
         )
 
 
@@ -256,7 +260,7 @@ def _narrow_config(
         .clip(
             max_push_bytes=sizes.push,
             max_pull_bytes=sizes.pull,
-            max_two_shot_push_bytes=sizes.two_shot_push,
+            max_two_shot_scatter_bytes=sizes.two_shot_scatter,
         )
         ._replace(num_pull_blocks=num_pull_blocks, num_push_blocks=num_push_blocks)
     )
@@ -271,7 +275,7 @@ class CustomAllReduceV2:
         *,
         max_pull_size: Optional[int] = None,
         max_push_size: Optional[int] = None,
-        max_two_shot_push_size: Optional[int] = None,
+        max_two_shot_scatter_size: Optional[int] = None,
         max_pull_blocks: Optional[int] = None,
         max_push_blocks: Optional[int] = None,
     ) -> None:
@@ -285,11 +289,11 @@ class CustomAllReduceV2:
                               push-only instance.
         :param max_push_size: explicit per-slot push workspace size;
                               overrides both the tuned size and ``max_size``.
-        :param max_two_shot_push_size: explicit ``2shot_push`` message ceiling,
-                                 which may enlarge the shared push slots;
-                                 overrides both the tuned size and
-                                 ``max_size``. ``0`` disables the algo and
-                                 leaves the slots at the 1shot_push size.
+        :param max_two_shot_scatter_size: explicit ``2shot_scatter`` message
+                                 ceiling; sizes the scatter slots and may
+                                 enlarge the shared push slots. Overrides both
+                                 the tuned size and ``max_size``; ``0``
+                                 disables the algo and its plane.
         :param max_pull_blocks: cap on the barrier plane's block count; ``0``
                                 builds a push-only instance.
         :param max_push_blocks: exact push grid width, overriding the tuned
@@ -320,15 +324,15 @@ class CustomAllReduceV2:
             max_size=max_size,
             max_pull_size=max_pull_size,
             max_push_size=max_push_size,
-            max_two_shot_push_size=max_two_shot_push_size,
+            max_two_shot_scatter_size=max_two_shot_scatter_size,
             pull_blocks_disabled=max_pull_blocks == 0,
         )
         self.pull_enabled = sizes.pull_enabled
-        self.two_shot_push_enabled = sizes.two_shot_push_enabled
+        self.two_shot_scatter_enabled = sizes.two_shot_scatter_enabled
         self.max_pull_size = sizes.pull
         self.max_push_size = sizes.push
-        self.max_two_shot_push_size = sizes.two_shot_push
-        self.gather_slot_size = sizes.gather_slot
+        self.max_two_shot_scatter_size = sizes.two_shot_scatter
+        self.scatter_slot_size = sizes.scatter_slot
         self.shared_slot_size = sizes.shared_slot
         self.max_size = sizes.max_message
         self.config = _narrow_config(
@@ -363,25 +367,24 @@ class CustomAllReduceV2:
     def _init_workspace(self) -> None:
         """Slice one symmetric-memory allocation into every shared buffer.
 
-        Layout per rank: ``[2 * world_size shared push slots | pull buffer |
-        pull semaphores]``. The shared slots serve both ``1shot_push`` and
-        ``2shot_push``; their common counter is rank-local and therefore
-        lives in a plain CUDA tensor.
+        Layout per rank: ``[2 * world_size shared push slots | 2 * world_size
+        scatter slots | pull buffer | pull semaphores]``. The shared slots
+        serve ``1shot_push`` and both two-shot gather halves; the scatter
+        slots hold ``2shot_scatter``'s per-source shards. One rank-local
+        counter (a plain CUDA tensor) drives both planes' epochs, so every
+        push-family algorithm advances the double buffer together.
         """
         cfg = self.config
         push_num_slots = 2 * self.world_size  # 2 phases x world_size peers
         push_bytes = push_num_slots * self.shared_slot_size
+        scatter_bytes = push_num_slots * self.scatter_slot_size  # 0 if disabled
         pull_bytes = self.max_pull_size  # 0 when the pull half is disabled
-        # 2shot_push now launches with the push grid (`num_sms`) but enters
-        # through the pull barrier. Allocate enough semaphore rows for that
-        # grid while keeping the tuned pull launch width in Communicator.
         num_sem_blocks = cfg.num_pull_blocks if self.pull_enabled else 0
-        if self.two_shot_push_enabled:
-            num_sem_blocks = max(num_sem_blocks, cfg.num_push_blocks)
         sem_bytes = _SEMAPHORE_BYTES * num_sem_blocks
-        total_bytes = push_bytes + pull_bytes + sem_bytes
-        pull_offset = push_bytes
-        sem_offset = push_bytes + pull_bytes
+        total_bytes = push_bytes + scatter_bytes + pull_bytes + sem_bytes
+        scatter_offset = push_bytes
+        pull_offset = push_bytes + scatter_bytes
+        sem_offset = pull_offset + pull_bytes
 
         self._symm_tensor, symm_mem = _allocate_symmetric_memory(
             total_bytes, device=self.device, group=self.group
@@ -414,13 +417,26 @@ class CustomAllReduceV2:
         self._push_counter = torch.zeros(
             (cfg.num_push_blocks,), dtype=torch.uint32, device=self.device
         )
+        counter = self._push_counter.view(-1, 1).view(torch.uint8)
         push_plane = PushPlane(
             self.rank,
             self.world_size,
             workspaces=slice_all([push_num_slots, self.shared_slot_size], 0),
-            counter=self._push_counter.view(-1, 1).view(torch.uint8),
+            counter=counter,
             mc_workspace=mc_at(0),
         )
+        scatter_plane = None
+        if self.two_shot_scatter_enabled:
+            # same counter tensor as the push plane: one epoch for the family
+            scatter_plane = PushPlane(
+                self.rank,
+                self.world_size,
+                workspaces=slice_all(
+                    [push_num_slots, self.scatter_slot_size], scatter_offset
+                ),
+                counter=counter,
+                mc_workspace=mc_at(scatter_offset),
+            )
         pull_plane = None
         if self.pull_enabled:
             pull_plane = PullPlane(
@@ -434,7 +450,7 @@ class CustomAllReduceV2:
         if not self.has_multicast or not self.pull_enabled:
             self.config = self.config._replace(num_mc_blocks=None)
 
-        self.obj = Communicator(push=push_plane, pull=pull_plane)
+        self.obj = Communicator(push=push_plane, pull=pull_plane, scatter=scatter_plane)
         if self.pull_enabled:
             self.obj.set_pull_blocks(self.config.num_pull_blocks)
         if self.config.num_mc_blocks is not None:
@@ -442,12 +458,13 @@ class CustomAllReduceV2:
         if self.rank == 0:
             logger.info(
                 "All Reduce config: symmetric_memory = %.2f MB, "
-                "local_buffer = %.2f MB, multicast = %s, pull = %s, 2shot_push = %s",
+                "local_buffer = %.2f MB, multicast = %s, pull = %s, "
+                "2shot_scatter = %s",
                 total_bytes / MB,
                 (self.graph_params.nbytes + self._push_counter.nbytes) / MB,
                 self.config.num_mc_blocks is not None,
                 self.pull_enabled,
-                self.two_shot_push_enabled,
+                self.two_shot_scatter_enabled,
             )
         dist.barrier(group=self.group)
 
@@ -489,9 +506,13 @@ class CustomAllReduceV2:
         # TODO: refactor this along with the config file
         heuristic = self.config.graph if can_use_graph else self.config.eager
         can_use_multicast = self.config.num_mc_blocks is not None
-        # tried first so its band may start below one_shot_push_threshold
-        if heuristic.two_shot_push.contains(nbytes):
-            return AllReduceConfig(AllReduceAlgo.TWO_SHOT_PUSH, use_graph=can_use_graph)
+        # the bands are tried first so they may start below the thresholds
+        if heuristic.two_shot_scatter.contains(nbytes):
+            return AllReduceConfig(
+                AllReduceAlgo.TWO_SHOT_SCATTER,
+                use_multicast=self.has_multicast
+                and heuristic.two_shot_scatter_mc.contains(nbytes),
+            )
         if nbytes <= heuristic.one_shot_push_threshold:
             return AllReduceConfig(AllReduceAlgo.ONE_SHOT_PUSH)
         if nbytes <= heuristic.one_shot_pull_threshold:

--- a/python/sglang/srt/distributed/device_communicators/custom_all_reduce_v2.py
+++ b/python/sglang/srt/distributed/device_communicators/custom_all_reduce_v2.py
@@ -3,15 +3,17 @@
 The CUDA side is split into independent pieces:
 
 - ``PushPlane``: the zero-filled symmetric push buffers plus a rank-local
-  phase counter.
+  phase counter. ``1shot_push`` and ``2shot_lamport`` share this plane: the
+  former treats it as one full-input slot per source, while the latter lays
+  the reduced shards contiguously across those same slots.
 - ``PullPlane``: the symmetric pull buffers plus the per-block semaphores
   guarding them. The buffers exist only because this class hands the
   all-reduce tensors that are not symmetric memory, so it stages them
   through; the K3 fused collectives bring their own symmetric input and
   borrow the semaphores alone.
-- the gather plane: a second ``PushPlane``, used by ``2shot_lamport`` for
-  the all-gather half of its reduce-scatter. It cannot share the push plane,
-  whose epoch ``1shot_push`` advances on its own schedule.
+- the gather handle: an alias of ``PushPlane``, used by ``2shot_lamport`` for
+  the all-gather half of its reduce-scatter. Sharing the handle also shares
+  the epoch counter, so both algorithms advance the double buffer together.
 - ``Communicator``: the planes above (any may be absent), the handle every
   kernel takes, plus the pull launch widths.
 - the all-reduce kernel: a pure function of ``(Communicator, input, algo,
@@ -135,9 +137,10 @@ class CustomAllReduceV2:
         :param max_push_size: explicit per-slot push workspace size;
                               overrides both the tuned size and ``max_size``.
         :param max_lamport_size: explicit ``2shot_lamport`` message ceiling,
-                                 which sizes the gather plane; overrides both
-                                 the tuned size and ``max_size``. ``0``
-                                 disables the algo and its plane.
+                                 which may enlarge the shared push slots;
+                                 overrides both the tuned size and
+                                 ``max_size``. ``0`` disables the algo and its
+                                 gather handle.
         :param max_pull_blocks: cap on the barrier plane's block count; ``0``
                                 builds a push-only instance.
 
@@ -206,6 +209,7 @@ class CustomAllReduceV2:
             if self.lamport_enabled
             else 0
         )
+        self.shared_slot_size = max(self.max_push_size, self.gather_slot_size)
         self.max_lamport_size = min(
             self.gather_slot_size * self.world_size, self.max_pull_size
         )
@@ -245,22 +249,25 @@ class CustomAllReduceV2:
     def _init_workspace(self) -> None:
         """Slice one symmetric-memory allocation into every shared buffer.
 
-        Layout per rank: ``[2 * world_size push slots | pull buffer | pull
-        semaphores | 2 * world_size gather slots]``. One allocation rather
-        than four keeps it to a single rendezvous and a single multicast base
-        to offset from. The push and gather counters are rank-local, so they
-        live in plain CUDA tensors.
+        Layout per rank: ``[2 * world_size shared push slots | pull buffer |
+        pull semaphores]``. The shared slots serve both ``1shot_push`` and
+        ``2shot_lamport``; their common counter is rank-local and therefore
+        lives in a plain CUDA tensor.
         """
         cfg = self.config
         push_num_slots = 2 * self.world_size  # 2 phases x world_size peers
-        push_bytes = push_num_slots * self.max_push_size
+        push_bytes = push_num_slots * self.shared_slot_size
         pull_bytes = self.max_pull_size  # 0 when the pull half is disabled
-        sem_bytes = _SEMAPHORE_BYTES * cfg.num_pull_blocks if self.pull_enabled else 0
-        gather_bytes = push_num_slots * self.gather_slot_size  # 0 when disabled
-        total_bytes = push_bytes + pull_bytes + sem_bytes + gather_bytes
+        # Lamport now launches with the push grid (`num_sms`) but enters
+        # through the pull barrier. Allocate enough semaphore rows for that
+        # grid while keeping the tuned pull launch width in Communicator.
+        num_sem_blocks = cfg.num_pull_blocks if self.pull_enabled else 0
+        if self.lamport_enabled:
+            num_sem_blocks = max(num_sem_blocks, cfg.num_push_blocks)
+        sem_bytes = _SEMAPHORE_BYTES * num_sem_blocks
+        total_bytes = push_bytes + pull_bytes + sem_bytes
         pull_offset = push_bytes
         sem_offset = push_bytes + pull_bytes
-        gather_offset = sem_offset + sem_bytes
 
         self._symm_tensor, symm_mem = _allocate_symmetric_memory(
             total_bytes, device=self.device, group=self.group
@@ -269,9 +276,9 @@ class CustomAllReduceV2:
             symm_mem.get_buffer(i, [total_bytes], torch.uint8)
             for i in range(self.world_size)
         ]
-        # The push and gather slots (lamport pos-zero markers) and the
-        # semaphores must start zeroed; the pull buffer need not, but it rides
-        # along in the one-shot memset.
+        # The shared push slots (Lamport pos-zero markers) and semaphores must
+        # start zeroed; the pull buffer need not, but it rides along in the
+        # one-shot memset.
         slabs[self.rank].zero_()
         torch.cuda.synchronize()
         dist.barrier(group=self.group)
@@ -296,23 +303,11 @@ class CustomAllReduceV2:
         push_plane = PushPlane(
             self.rank,
             self.world_size,
-            workspaces=slice_all([push_num_slots, self.max_push_size], 0),
+            workspaces=slice_all([push_num_slots, self.shared_slot_size], 0),
             counter=self._push_counter.view(-1, 1).view(torch.uint8),
             mc_workspace=mc_at(0),
         )
-        gather_plane = None
-        if self.lamport_enabled:
-            self._gather_counter = torch.zeros(
-                (cfg.num_pull_blocks,), dtype=torch.uint32, device=self.device
-            )
-            gather_plane = PushPlane(
-                self.rank,
-                self.world_size,
-                workspaces=slice_all(
-                    [push_num_slots, self.gather_slot_size], gather_offset
-                ),
-                counter=self._gather_counter.view(-1, 1).view(torch.uint8),
-            )
+        gather_plane = push_plane if self.lamport_enabled else None
         pull_plane = None
         if self.pull_enabled:
             pull_plane = PullPlane(
@@ -320,7 +315,7 @@ class CustomAllReduceV2:
                 self.world_size,
                 workspaces=slice_all([pull_bytes], pull_offset),
                 semaphores=slice_all(
-                    [cfg.num_pull_blocks, _SEMAPHORE_BYTES], sem_offset
+                    [num_sem_blocks, _SEMAPHORE_BYTES], sem_offset
                 ),
                 mc_workspace=mc_at(pull_offset),
                 mc_semaphore=mc_at(sem_offset),
@@ -329,6 +324,8 @@ class CustomAllReduceV2:
             self.config = self.config._replace(num_mc_blocks=None)
 
         self.obj = Communicator(push=push_plane, pull=pull_plane, gather=gather_plane)
+        if self.pull_enabled:
+            self.obj.set_pull_blocks(self.config.num_pull_blocks)
         if self.config.num_mc_blocks is not None:
             self.obj.set_pull_multicast_blocks(self.config.num_mc_blocks)
         if self.rank == 0:

--- a/python/sglang/srt/distributed/device_communicators/custom_all_reduce_v2.py
+++ b/python/sglang/srt/distributed/device_communicators/custom_all_reduce_v2.py
@@ -3,23 +3,22 @@
 The CUDA side is split into independent pieces:
 
 - ``PushPlane``: the zero-filled symmetric push buffers plus a rank-local
-  phase counter. ``1shot_push`` and ``2shot_scatter`` share this plane: the
+  phase counter. ``1shot_push`` and ``2shot_push`` share this plane: the
   former treats it as one full-input slot per source, while the latter lays
   the reduced shards contiguously across those same slots in its all-gather
-  half.
+  half. When ``2shot_push`` is enabled the plane doubles its slot rows and
+  the second half holds the per-source shard inbox, so every push-family
+  algorithm advances one double buffer together.
 - ``PullPlane``: the symmetric pull buffers plus the per-block semaphores
   guarding them. The buffers exist only because this class hands the
   all-reduce tensors that are not symmetric memory, so it stages them
   through; the K3 fused collectives bring their own symmetric input and
   borrow the semaphores alone.
-- the scatter plane: ``2shot_scatter``'s per-source shard slots, a third
-  ``PushPlane`` sharing the push plane's epoch counter so every push-family
-  algorithm advances the double buffer together.
-- ``Communicator``: the planes above (any may be absent), the handle every
+- ``Communicator``: the planes above (either may be absent), the handle every
   kernel takes, plus the pull launch widths.
 - the all-reduce kernel: a pure function of ``(Communicator, input, algo,
   graph_params, use_multicast)`` with four algorithms (1shot_push /
-  1shot_pull / 2shot_pull / 2shot_scatter) and three pull data sources (eager
+  1shot_pull / 2shot_pull / 2shot_push) and three pull data sources (eager
   pull buffer / CUDA-graph pointer table / multicast address).
 
 All storage is allocated and owned here, in Python.
@@ -133,35 +132,24 @@ class _WorkspaceSizes(NamedTuple):
     """Aligned byte capacities of one instance's symmetric-memory workspace.
 
     ``pull`` and ``push`` are the per-direction message ceilings; either may
-    be ``0``. ``scatter_slot`` sizes ``2shot_scatter``'s per-peer shard slots
-    -- one size serves both its planes, since the scatter inbox holds a
-    contribution shard and the gather half one reduced shard per slot --
-    with ``two_shot_scatter`` the message ceiling that buys.
+    be ``0``. ``push_slot`` is the push plane's one slot size: big enough
+    for a whole ``1shot_push`` input, and for one ``2shot_push`` shard (the
+    scatter inbox and the gather half both hold one shard per slot), with
+    ``two_shot_push`` the message ceiling that buys.
     """
 
     pull: int
     push: int
-    scatter_slot: int
-    two_shot_scatter: int
+    push_slot: int
+    two_shot_push: int
 
     @property
     def pull_enabled(self) -> bool:
         return self.pull > 0
 
     @property
-    def two_shot_scatter_enabled(self) -> bool:
-        return self.scatter_slot > 0
-
-    @property
-    def shared_slot(self) -> int:
-        """Size of one of the ``2 * world_size`` shared push slots.
-
-        The push algos share the plane, so a slot has to hold either
-        occupant: a whole ``1shot_push`` input, or a reduced shard from
-        ``2shot_scatter``'s all-gather half (the same shard size that sizes
-        the scatter slots).
-        """
-        return max(self.push, self.scatter_slot)
+    def two_shot_push_enabled(self) -> bool:
+        return self.two_shot_push > 0
 
     @property
     def max_message(self) -> int:
@@ -177,7 +165,7 @@ class _WorkspaceSizes(NamedTuple):
         max_size: int,
         max_pull_size: Optional[int],
         max_push_size: Optional[int],
-        max_two_shot_scatter_size: Optional[int],
+        max_two_shot_push_size: Optional[int],
         pull_blocks_disabled: bool,
     ) -> "_WorkspaceSizes":
         """Resolve the constructor's optional caps into concrete capacities.
@@ -190,8 +178,8 @@ class _WorkspaceSizes(NamedTuple):
             max_pull_size = min(tuned.max_pull_bytes, max_size)
         if max_push_size is None:
             max_push_size = min(tuned.max_push_bytes, max_size)
-        if max_two_shot_scatter_size is None:
-            max_two_shot_scatter_size = min(tuned.max_two_shot_scatter_bytes, max_size)
+        if max_two_shot_push_size is None:
+            max_two_shot_push_size = min(tuned.max_two_shot_push_bytes, max_size)
         if _FORCE_PULL_SIZE is not None:
             max_pull_size = _FORCE_PULL_SIZE
         if _FORCE_PUSH_SIZE is not None:
@@ -203,19 +191,19 @@ class _WorkspaceSizes(NamedTuple):
         # take this path rather than allocating a placeholder buffer just to
         # satisfy a constructor.
         pull_off = pull_blocks_disabled or max_pull_size <= 0
-        # 2shot_scatter workspaces are the scatter slots and the shared push plane's
-        # gather half, and both hold one reduced shard per peer, so one size
-        # serves both.
-        scatter_slot = (
+        # Every 2shot_push slot -- scatter inbox or gather half -- holds one
+        # shard, so the shard size and the 1shot input ceiling together fix
+        # the plane's single slot size.
+        shard = (
             0
-            if max_two_shot_scatter_size <= 0
-            else _align(_div_ceil(max_two_shot_scatter_size, world_size))
+            if max_two_shot_push_size <= 0
+            else _align(_div_ceil(max_two_shot_push_size, world_size))
         )
         return cls(
             pull=0 if pull_off else _align(max_pull_size),
             push=_align(max_push_size),
-            scatter_slot=scatter_slot,
-            two_shot_scatter=scatter_slot * world_size,
+            push_slot=max(_align(max_push_size), shard),
+            two_shot_push=shard * world_size,
         )
 
 
@@ -260,7 +248,7 @@ def _narrow_config(
         .clip(
             max_push_bytes=sizes.push,
             max_pull_bytes=sizes.pull,
-            max_two_shot_scatter_bytes=sizes.two_shot_scatter,
+            max_two_shot_push_bytes=sizes.two_shot_push,
         )
         ._replace(num_pull_blocks=num_pull_blocks, num_push_blocks=num_push_blocks)
     )
@@ -275,7 +263,7 @@ class CustomAllReduceV2:
         *,
         max_pull_size: Optional[int] = None,
         max_push_size: Optional[int] = None,
-        max_two_shot_scatter_size: Optional[int] = None,
+        max_two_shot_push_size: Optional[int] = None,
         max_pull_blocks: Optional[int] = None,
         max_push_blocks: Optional[int] = None,
     ) -> None:
@@ -289,7 +277,7 @@ class CustomAllReduceV2:
                               push-only instance.
         :param max_push_size: explicit per-slot push workspace size;
                               overrides both the tuned size and ``max_size``.
-        :param max_two_shot_scatter_size: explicit ``2shot_scatter`` message
+        :param max_two_shot_push_size: explicit ``2shot_push`` message
                                  ceiling; sizes the scatter slots and may
                                  enlarge the shared push slots. Overrides both
                                  the tuned size and ``max_size``; ``0``
@@ -324,16 +312,15 @@ class CustomAllReduceV2:
             max_size=max_size,
             max_pull_size=max_pull_size,
             max_push_size=max_push_size,
-            max_two_shot_scatter_size=max_two_shot_scatter_size,
+            max_two_shot_push_size=max_two_shot_push_size,
             pull_blocks_disabled=max_pull_blocks == 0,
         )
         self.pull_enabled = sizes.pull_enabled
-        self.two_shot_scatter_enabled = sizes.two_shot_scatter_enabled
+        self.two_shot_push_enabled = sizes.two_shot_push_enabled
         self.max_pull_size = sizes.pull
         self.max_push_size = sizes.push
-        self.max_two_shot_scatter_size = sizes.two_shot_scatter
-        self.scatter_slot_size = sizes.scatter_slot
-        self.shared_slot_size = sizes.shared_slot
+        self.max_two_shot_push_size = sizes.two_shot_push
+        self.push_slot_size = sizes.push_slot
         self.max_size = sizes.max_message
         self.config = _narrow_config(
             tuned,
@@ -367,23 +354,23 @@ class CustomAllReduceV2:
     def _init_workspace(self) -> None:
         """Slice one symmetric-memory allocation into every shared buffer.
 
-        Layout per rank: ``[2 * world_size shared push slots | 2 * world_size
-        scatter slots | pull buffer | pull semaphores]``. The shared slots
-        serve ``1shot_push`` and both two-shot gather halves; the scatter
-        slots hold ``2shot_scatter``'s per-source shards. One rank-local
-        counter (a plain CUDA tensor) drives both planes' epochs, so every
-        push-family algorithm advances the double buffer together.
+        Layout per rank: ``[2 * world_size push slots (4 * world_size when
+        ``2shot_push`` is enabled) | pull buffer | pull semaphores]``. The
+        first ``2 * world_size`` slots serve ``1shot_push`` and the two-shot
+        gather half; the doubled tail is ``2shot_push``'s per-source shard
+        inbox, recognised by the plane from the row count, so one rank-local
+        counter (a plain CUDA tensor) drives the epoch of every push-family
+        algorithm.
         """
         cfg = self.config
-        push_num_slots = 2 * self.world_size  # 2 phases x world_size peers
-        push_bytes = push_num_slots * self.shared_slot_size
-        scatter_bytes = push_num_slots * self.scatter_slot_size  # 0 if disabled
+        # 2 phases x world_size peers, doubled again for the scatter region
+        push_num_slots = (4 if self.two_shot_push_enabled else 2) * self.world_size
+        push_bytes = push_num_slots * self.push_slot_size
         pull_bytes = self.max_pull_size  # 0 when the pull half is disabled
         num_sem_blocks = cfg.num_pull_blocks if self.pull_enabled else 0
         sem_bytes = _SEMAPHORE_BYTES * num_sem_blocks
-        total_bytes = push_bytes + scatter_bytes + pull_bytes + sem_bytes
-        scatter_offset = push_bytes
-        pull_offset = push_bytes + scatter_bytes
+        total_bytes = push_bytes + pull_bytes + sem_bytes
+        pull_offset = push_bytes
         sem_offset = pull_offset + pull_bytes
 
         self._symm_tensor, symm_mem = _allocate_symmetric_memory(
@@ -421,22 +408,10 @@ class CustomAllReduceV2:
         push_plane = PushPlane(
             self.rank,
             self.world_size,
-            workspaces=slice_all([push_num_slots, self.shared_slot_size], 0),
+            workspaces=slice_all([push_num_slots, self.push_slot_size], 0),
             counter=counter,
             mc_workspace=mc_at(0),
         )
-        scatter_plane = None
-        if self.two_shot_scatter_enabled:
-            # same counter tensor as the push plane: one epoch for the family
-            scatter_plane = PushPlane(
-                self.rank,
-                self.world_size,
-                workspaces=slice_all(
-                    [push_num_slots, self.scatter_slot_size], scatter_offset
-                ),
-                counter=counter,
-                mc_workspace=mc_at(scatter_offset),
-            )
         pull_plane = None
         if self.pull_enabled:
             pull_plane = PullPlane(
@@ -450,7 +425,7 @@ class CustomAllReduceV2:
         if not self.has_multicast or not self.pull_enabled:
             self.config = self.config._replace(num_mc_blocks=None)
 
-        self.obj = Communicator(push=push_plane, pull=pull_plane, scatter=scatter_plane)
+        self.obj = Communicator(push=push_plane, pull=pull_plane)
         if self.pull_enabled:
             self.obj.set_pull_blocks(self.config.num_pull_blocks)
         if self.config.num_mc_blocks is not None:
@@ -459,12 +434,12 @@ class CustomAllReduceV2:
             logger.info(
                 "All Reduce config: symmetric_memory = %.2f MB, "
                 "local_buffer = %.2f MB, multicast = %s, pull = %s, "
-                "2shot_scatter = %s",
+                "2shot_push = %s",
                 total_bytes / MB,
                 (self.graph_params.nbytes + self._push_counter.nbytes) / MB,
                 self.config.num_mc_blocks is not None,
                 self.pull_enabled,
-                self.two_shot_scatter_enabled,
+                self.two_shot_push_enabled,
             )
         dist.barrier(group=self.group)
 
@@ -507,11 +482,11 @@ class CustomAllReduceV2:
         heuristic = self.config.graph if can_use_graph else self.config.eager
         can_use_multicast = self.config.num_mc_blocks is not None
         # the bands are tried first so they may start below the thresholds
-        if heuristic.two_shot_scatter.contains(nbytes):
+        if heuristic.two_shot_push.contains(nbytes):
             return AllReduceConfig(
-                AllReduceAlgo.TWO_SHOT_SCATTER,
+                AllReduceAlgo.TWO_SHOT_PUSH,
                 use_multicast=self.has_multicast
-                and heuristic.two_shot_scatter_mc.contains(nbytes),
+                and heuristic.two_shot_push_mc.contains(nbytes),
             )
         if nbytes <= heuristic.one_shot_push_threshold:
             return AllReduceConfig(AllReduceAlgo.ONE_SHOT_PUSH)

--- a/test/registered/kernels/benchmark/communication/bench_custom_all_reduce.py
+++ b/test/registered/kernels/benchmark/communication/bench_custom_all_reduce.py
@@ -288,18 +288,6 @@ def benchmark(message_KB: int, provider: str):
 
 
 if __name__ == "__main__":
-    # `python bench_custom_all_reduce.py [--num-gpu N,...]` relaunches itself
-    # under a single-node torchrun, once per world size. For more GPUs than one
-    # node has, drive it with your own torchrun instead -- `multigpu_launch`
-    # detects that and runs the sweep in place:
-    #
-    #   torchrun --nnodes=2 --nproc_per_node=4 --node_rank=$R \
-    #     --master_addr=$MASTER --master_port=$PORT --rdzv_backend=static \
-    #     bench_custom_all_reduce.py
-    #
-    # A multi-node group needs a VMM-backed allocator for the v2 planes to
-    # rendezvous (`PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`), and
-    # reports `aot` / `jit-graph` as skipped for the reasons above.
     multigpu_bench_main(
         name=__name__,
         file=__file__,

--- a/test/registered/kernels/benchmark/communication/bench_custom_all_reduce.py
+++ b/test/registered/kernels/benchmark/communication/bench_custom_all_reduce.py
@@ -38,7 +38,10 @@ WORLD_SIZES = list(range(2, 9)) + [16]
 MAX_BYTES = max(MESSAGE_SIZES_KB) * 1024
 # trtllm allreduce_fusion only supports these world sizes.
 FI_SUPPORTED_WORLD_SIZES = (2, 4, 8)
-# AOT custom_all_reduce (v1) only supports these world sizes.
+# AOT custom_all_reduce (v1) only supports these world sizes -- and only within
+# one node: it publishes its workspace through cudaIpc, so
+# `can_use_custom_all_reduce_with_nvlink` disables it on a multi-node group.
+# The v2 planes rendezvous over fabric handles and do cross nodes.
 AOT_SUPPORTED_WORLD_SIZES = (2, 4, 6, 8)
 # jit-eager times the naive-loop dispatch (eager heuristics); jit-graph
 # captures the calls in a CUDA graph (graph heuristics + pointer table).
@@ -207,6 +210,13 @@ BACKEND_FACTORY = {
 
 
 @cache_once
+def _is_multinode() -> bool:
+    from sglang.srt.distributed.parallel_state import in_the_same_node_as
+
+    return not all(in_the_same_node_as(_init_cpu_group(), source_rank=0))
+
+
+@cache_once
 def _init_all_backends() -> None:
     """Pre-build every supported backend before any timed iteration so JIT
     compilation / IPC setup don't bleed into the first measured size.
@@ -219,6 +229,8 @@ def _init_all_backends() -> None:
     factories = dict(BACKEND_FACTORY)
     if world_size not in AOT_SUPPORTED_WORLD_SIZES:
         factories.pop("aot")
+    if _is_multinode():
+        factories.pop("aot", None)  # cudaIpc: cannot leave the node
     if world_size not in FI_SUPPORTED_WORLD_SIZES:
         factories.pop("fi")
     for fn in factories.values():
@@ -248,6 +260,10 @@ def benchmark(message_KB: int, provider: str):
         marker.skip(
             f"AOT custom_all_reduce needs world_size in " f"{AOT_SUPPORTED_WORLD_SIZES}"
         )
+    if provider == "aot" and _is_multinode():
+        marker.skip("AOT custom_all_reduce is cudaIpc-based: single node only")
+    if provider == "jit-graph" and _is_multinode():
+        marker.skip("no graph context across nodes: jit-graph == jit-eager")
     _init_all_backends()
     backend = BACKEND_FACTORY[provider]()
     message_bytes = message_KB * 1024
@@ -272,6 +288,18 @@ def benchmark(message_KB: int, provider: str):
 
 
 if __name__ == "__main__":
+    # `python bench_custom_all_reduce.py [--num-gpu N,...]` relaunches itself
+    # under a single-node torchrun, once per world size. For more GPUs than one
+    # node has, drive it with your own torchrun instead -- `multigpu_launch`
+    # detects that and runs the sweep in place:
+    #
+    #   torchrun --nnodes=2 --nproc_per_node=4 --node_rank=$R \
+    #     --master_addr=$MASTER --master_port=$PORT --rdzv_backend=static \
+    #     bench_custom_all_reduce.py
+    #
+    # A multi-node group needs a VMM-backed allocator for the v2 planes to
+    # rendezvous (`PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`), and
+    # reports `aot` / `jit-graph` as skipped for the reasons above.
     multigpu_bench_main(
         name=__name__,
         file=__file__,

--- a/test/registered/kernels/benchmark/communication/bench_custom_all_reduce.py
+++ b/test/registered/kernels/benchmark/communication/bench_custom_all_reduce.py
@@ -45,7 +45,7 @@ FI_SUPPORTED_WORLD_SIZES = (2, 4, 8)
 AOT_SUPPORTED_WORLD_SIZES = (2, 4, 6, 8)
 # jit-eager times the naive-loop dispatch (eager heuristics); jit-graph
 # captures the calls in a CUDA graph (graph heuristics + pointer table).
-PROVIDERS = ["nccl", "aot", "jit-eager", "jit-graph", "fi"]
+PROVIDERS = ["nccl", "aot", "jit-eager", "jit-graph", "fi", "fi-mnnvl"]
 WORLD_SIZES = get_benchmark_range(WORLD_SIZES, [2, 4, 8])
 
 # ---------------------------------------------------------------------------
@@ -146,6 +146,8 @@ class AOTAllReduceBackend:
 
 
 class FlashInferAllReduceBackend:
+    FI_BACKEND = "trtllm"
+
     def __init__(self) -> None:
         import flashinfer.comm as comm
 
@@ -158,14 +160,24 @@ class FlashInferAllReduceBackend:
         num_tokens = MAX_BYTES // (hidden_dim * DTYPE_ITEMSIZE)
         self._comm = comm
         self._hidden_dim = hidden_dim
-        self._workspace = comm.create_allreduce_fusion_workspace(
-            backend="trtllm",
+        create_kw = dict(
+            backend=self.FI_BACKEND,
             world_size=world_size,
             rank=rank,
             max_token_num=num_tokens,
             hidden_dim=hidden_dim,
             dtype=DTYPE,
         )
+        if self.FI_BACKEND == "mnnvl":
+            from sglang.srt.distributed.parallel_state import in_the_same_node_as
+            from sglang.srt.layers.flashinfer_comm_fusion import _TorchDistBackend
+
+            create_kw["comm_backend"] = _TorchDistBackend(
+                device_group=_init_nccl_group(), cpu_group=group
+            )
+            create_kw["group"] = _init_nccl_group()
+            create_kw["gpus_per_node"] = sum(in_the_same_node_as(group, source_rank=0))
+        self._workspace = comm.create_allreduce_fusion_workspace(**create_kw)
 
     def graph_context(self):
         return contextlib.nullcontext()
@@ -178,6 +190,10 @@ class FlashInferAllReduceBackend:
             launch_with_pdl=is_arch_support_pdl(),
             fp32_acc=True,
         )
+
+
+class FlashInferMnnvlBackend(FlashInferAllReduceBackend):
+    FI_BACKEND = "mnnvl"
 
 
 @cache_once
@@ -200,12 +216,18 @@ def _init_fi_backend() -> FlashInferAllReduceBackend:
     return FlashInferAllReduceBackend()
 
 
+@cache_once
+def _init_fi_mnnvl_backend() -> FlashInferMnnvlBackend:
+    return FlashInferMnnvlBackend()
+
+
 BACKEND_FACTORY = {
     "nccl": _init_nccl_backend,
     "jit-eager": _init_jit_backend,
     "jit-graph": _init_jit_backend,
     "aot": _init_aot_backend,
     "fi": _init_fi_backend,
+    "fi-mnnvl": _init_fi_mnnvl_backend,
 }
 
 
@@ -233,6 +255,9 @@ def _init_all_backends() -> None:
         factories.pop("aot", None)  # cudaIpc: cannot leave the node
     if world_size not in FI_SUPPORTED_WORLD_SIZES:
         factories.pop("fi")
+        factories.pop("fi-mnnvl")
+    if _is_multinode():
+        factories.pop("fi", None)  # the trtllm workspace is single-node only
     for fn in factories.values():
         fn()
 
@@ -251,11 +276,13 @@ def benchmark(message_KB: int, provider: str):
     cpu_group = _init_cpu_group()
     gpu_group = _init_nccl_group()
     world_size = dist.get_world_size(cpu_group)
-    if provider == "fi" and world_size not in FI_SUPPORTED_WORLD_SIZES:
+    if provider.startswith("fi") and world_size not in FI_SUPPORTED_WORLD_SIZES:
         marker.skip(
-            f"flashinfer trtllm allreduce_fusion needs world_size in "
+            f"flashinfer allreduce_fusion needs world_size in "
             f"{FI_SUPPORTED_WORLD_SIZES}"
         )
+    if provider == "fi" and _is_multinode():
+        marker.skip("flashinfer trtllm workspace is single-node only")
     if provider == "aot" and world_size not in AOT_SUPPORTED_WORLD_SIZES:
         marker.skip(
             f"AOT custom_all_reduce needs world_size in " f"{AOT_SUPPORTED_WORLD_SIZES}"

--- a/test/registered/kernels/ops/communication/test_custom_all_reduce.py
+++ b/test/registered/kernels/ops/communication/test_custom_all_reduce.py
@@ -35,6 +35,7 @@ from sglang.kernels.ops.communication.all_reduce import (
 )
 from sglang.kernels.ops.communication.mp import register_comm_cleanup
 from sglang.srt.distributed.device_communicators.custom_all_reduce_v2 import (
+    _ALIGN_BYTES,
     CustomAllReduceV2,
 )
 from sglang.test.ci.ci_register import register_cuda_ci
@@ -69,6 +70,7 @@ TEST_ALGOS = [
     AllReduceAlgo.ONE_SHOT_PULL,
     AllReduceAlgo.ONE_SHOT_PUSH,
     AllReduceAlgo.TWO_SHOT_PULL,
+    AllReduceAlgo.TWO_SHOT_LAMPORT,
 ]
 USE_GRAPH_OPTIONS = [False, True]
 TEST_LAYERS = 4
@@ -161,7 +163,11 @@ def _init_comm_once() -> CustomAllReduceV2:
         torch.tensor([], dtype=d).element_size() for d in TEST_DTYPES
     )
     comm = CustomAllReduceV2(
-        cpu_group, device, max_pull_size=max_size, max_push_size=max_size
+        cpu_group,
+        device,
+        max_pull_size=max_size,
+        max_push_size=max_size,
+        max_lamport_size=max_size,
     )
     if comm.disabled:
         raise RuntimeError("JIT CustomAllReduceV2 is disabled on this system")
@@ -228,6 +234,68 @@ def test_custom_all_reduce(
         # while triton's converts to numpy on the host (~0.6 s per 32 MB
         # tensor) and would dominate the test wall time.
         torch.testing.assert_close(out_ref, out_jit, atol=0, rtol=0)
+
+
+def test_empty_input_dispatches_like_the_smallest_one() -> None:
+    """A zero-byte all-reduce must not take a different code path.
+    """
+    comm = _init_comm_once()
+    for can_use_graph in (True, False):
+        empty, smallest = (
+            comm._pick_config(n, can_use_graph=can_use_graph) for n in (0, 16)
+        )
+        assert empty == smallest, (
+            f"{can_use_graph=}: empty input picked {empty}, 16 bytes picked "
+            f"{smallest}"
+        )
+
+
+@torch.inference_mode()
+def test_2shot_lamport_gather() -> None:
+    nccl_group = _init_nccl_group_once()
+    device = torch.device(f"cuda:{int(os.environ['LOCAL_RANK'])}")
+    dtype = torch.bfloat16
+    push_size = _ALIGN_BYTES // dtype.itemsize  # exactly fills a push slot
+    lamport_size = 16 * push_size  # far more than the push slots hold
+    lamport_bytes = lamport_size * dtype.itemsize
+    comm = CustomAllReduceV2(
+        _init_cpu_group_once(),
+        device,
+        max_pull_size=lamport_bytes,
+        max_push_size=_ALIGN_BYTES,
+        max_lamport_size=lamport_bytes,
+    )
+    if comm.disabled:
+        raise RuntimeError("JIT CustomAllReduceV2 is disabled on this system")
+    register_comm_cleanup(comm)
+    # a whole message spans one slot per peer, in either plane
+    assert comm.gather_slot_size * comm.world_size >= lamport_bytes
+    assert comm.max_push_size * comm.world_size < lamport_bytes
+
+    plan = [(AllReduceAlgo.TWO_SHOT_LAMPORT, lamport_size)] * TEST_LAYERS
+    plan += [(AllReduceAlgo.ONE_SHOT_PUSH, push_size)] * TEST_LAYERS
+    plan[::2], plan[1::2] = plan[:TEST_LAYERS], plan[TEST_LAYERS:]
+
+    graph = torch.cuda.CUDAGraph()
+    graph_inps = [torch.zeros((size,), dtype=dtype, device=device) for _, size in plan]
+    outs: list[torch.Tensor] = []
+    with comm.capture():
+        with torch.cuda.graph(graph):
+            for (algo, _), inp in zip(plan, graph_inps):
+                comm.override_algo = algo
+                outs.append(comm.custom_all_reduce(inp))
+    torch.cuda.synchronize()
+
+    for _ in range(TEST_LOOP):
+        refs = []
+        for (_, size), graph_inp in zip(plan, graph_inps):
+            inp = torch.randint(0, 16, (size,), dtype=dtype, device=device)
+            graph_inp.copy_(inp)
+            dist.all_reduce(inp, group=nccl_group)
+            refs.append(inp)
+        graph.replay()
+        for ref, out in zip(refs, outs):
+            torch.testing.assert_close(ref, out, atol=0, rtol=0)
 
 
 if __name__ == "__main__":

--- a/test/registered/kernels/ops/communication/test_custom_all_reduce.py
+++ b/test/registered/kernels/ops/communication/test_custom_all_reduce.py
@@ -35,7 +35,7 @@ from sglang.kernels.ops.communication.all_reduce import (
 )
 from sglang.kernels.ops.communication.mp import register_comm_cleanup
 from sglang.srt.distributed.device_communicators.configs.custom_all_reduce_v2 import (
-    _MULTINODE_TWO_SHOT_PUSH,
+    _MULTINODE_PUSH_BANDS,
     get_all_reduce_config,
     get_supported_world_sizes,
 )
@@ -75,7 +75,7 @@ TEST_ALGOS = [
     AllReduceAlgo.ONE_SHOT_PULL,
     AllReduceAlgo.ONE_SHOT_PUSH,
     AllReduceAlgo.TWO_SHOT_PULL,
-    AllReduceAlgo.TWO_SHOT_PUSH,
+    AllReduceAlgo.TWO_SHOT_SCATTER,
 ]
 USE_GRAPH_OPTIONS = [False, True]
 TEST_LAYERS = 4
@@ -172,7 +172,7 @@ def _init_comm_once() -> CustomAllReduceV2:
         device,
         max_pull_size=max_size,
         max_push_size=max_size,
-        max_two_shot_push_size=max_size,
+        max_two_shot_scatter_size=max_size,
     )
     if comm.disabled:
         raise RuntimeError("JIT CustomAllReduceV2 is disabled on this system")
@@ -254,30 +254,31 @@ def test_empty_input_dispatches_like_the_smallest_one() -> None:
         )
 
 
-def test_multinode_only_retunes_the_eager_2shot_push_band() -> None:
+def test_multinode_only_retunes_the_eager_scatter_band() -> None:
     cuda_major, _ = torch.cuda.get_device_capability()
     tuned = {
-        world_size: band
-        for (major, world_size), band in _MULTINODE_TWO_SHOT_PUSH.items()
+        world_size: bands
+        for (major, world_size), bands in _MULTINODE_PUSH_BANDS.items()
         if major == cuda_major
     }
     for world_size in get_supported_world_sizes():
         single = get_all_reduce_config(world_size)
         multi = get_all_reduce_config(world_size, multinode=True)
-        band = tuned.get(world_size)
-        if band is None:
+        bands = tuned.get(world_size)
+        if bands is None:
             assert multi == single, f"{world_size=} has no multi-node entry"
             continue
-        assert multi.eager.two_shot_push == band
+        assert multi.eager.two_shot_scatter == bands.two_shot_scatter
+        # the mc sub-band must stay inside the band whose fan-out it refines
+        assert bands.two_shot_scatter_mc.min_bytes >= bands.two_shot_scatter.min_bytes
+        assert bands.two_shot_scatter_mc.max_bytes <= bands.two_shot_scatter.max_bytes
         assert multi == single._replace(
-            eager=single.eager._replace(two_shot_push=band)
-        ), f"{world_size=} multi-node override reached past eager.two_shot_push"
-        # the band has to stay inside the pull workspace it stages through
-        assert band.max_bytes <= multi.eager.max_pull_bytes
+            eager=single.eager._replace(**bands._asdict())
+        ), f"{world_size=} multi-node override reached past the eager bands"
 
 
 @torch.inference_mode()
-def test_2shot_push_shares_the_1shot_plane() -> None:
+def test_2shot_scatter_shares_the_1shot_plane() -> None:
     nccl_group = _init_nccl_group_once()
     device = torch.device(f"cuda:{int(os.environ['LOCAL_RANK'])}")
     dtype = torch.bfloat16
@@ -289,25 +290,25 @@ def test_2shot_push_shares_the_1shot_plane() -> None:
         device,
         max_pull_size=two_shot_bytes,
         max_push_size=_ALIGN_BYTES,
-        max_two_shot_push_size=two_shot_bytes,
+        max_two_shot_scatter_size=two_shot_bytes,
     )
     if comm.disabled:
         raise RuntimeError("JIT CustomAllReduceV2 is disabled on this system")
     register_comm_cleanup(comm)
-    # A whole 2shot_push message spans one enlarged shared slot per peer. Keep
-    # the tuned 1shot limit smaller: physical capacity must not silently widen
-    # its dispatch range.
-    assert comm.gather_slot_size * comm.world_size >= two_shot_bytes
+    # A whole 2shot_scatter message spans one enlarged shared slot per peer.
+    # Keep the tuned 1shot limit smaller: physical capacity must not silently
+    # widen its dispatch range.
+    assert comm.scatter_slot_size * comm.world_size >= two_shot_bytes
     assert comm.max_push_size * comm.world_size < two_shot_bytes
-    assert comm.shared_slot_size == comm.gather_slot_size
+    assert comm.shared_slot_size == comm.scatter_slot_size
     assert comm.shared_slot_size > comm.max_push_size
 
-    plan = [(AllReduceAlgo.TWO_SHOT_PUSH, two_shot_size)] * TEST_LAYERS
+    plan = [(AllReduceAlgo.TWO_SHOT_SCATTER, two_shot_size)] * TEST_LAYERS
     plan += [(AllReduceAlgo.ONE_SHOT_PUSH, push_size)] * TEST_LAYERS
     plan[::2], plan[1::2] = plan[:TEST_LAYERS], plan[TEST_LAYERS:]
 
     # Exercise the shared epoch in eager mode before capturing the same
-    # alternating sequence. Separate push/gather counters would let the two
+    # alternating sequence. Separate push/scatter counters would let the two
     # protocols select the same half of the aliased storage here.
     for _ in range(TEST_LOOP):
         for algo, size in plan:

--- a/test/registered/kernels/ops/communication/test_custom_all_reduce.py
+++ b/test/registered/kernels/ops/communication/test_custom_all_reduce.py
@@ -35,7 +35,7 @@ from sglang.kernels.ops.communication.all_reduce import (
 )
 from sglang.kernels.ops.communication.mp import register_comm_cleanup
 from sglang.srt.distributed.device_communicators.configs.custom_all_reduce_v2 import (
-    _MULTINODE_LAMPORT,
+    _MULTINODE_TWO_SHOT_PUSH,
     get_all_reduce_config,
     get_supported_world_sizes,
 )
@@ -75,7 +75,7 @@ TEST_ALGOS = [
     AllReduceAlgo.ONE_SHOT_PULL,
     AllReduceAlgo.ONE_SHOT_PUSH,
     AllReduceAlgo.TWO_SHOT_PULL,
-    AllReduceAlgo.TWO_SHOT_LAMPORT,
+    AllReduceAlgo.TWO_SHOT_PUSH,
 ]
 USE_GRAPH_OPTIONS = [False, True]
 TEST_LAYERS = 4
@@ -172,7 +172,7 @@ def _init_comm_once() -> CustomAllReduceV2:
         device,
         max_pull_size=max_size,
         max_push_size=max_size,
-        max_lamport_size=max_size,
+        max_two_shot_push_size=max_size,
     )
     if comm.disabled:
         raise RuntimeError("JIT CustomAllReduceV2 is disabled on this system")
@@ -254,11 +254,11 @@ def test_empty_input_dispatches_like_the_smallest_one() -> None:
         )
 
 
-def test_multinode_only_retunes_the_eager_lamport_band() -> None:
+def test_multinode_only_retunes_the_eager_2shot_push_band() -> None:
     cuda_major, _ = torch.cuda.get_device_capability()
     tuned = {
         world_size: band
-        for (major, world_size), band in _MULTINODE_LAMPORT.items()
+        for (major, world_size), band in _MULTINODE_TWO_SHOT_PUSH.items()
         if major == cuda_major
     }
     for world_size in get_supported_world_sizes():
@@ -268,41 +268,41 @@ def test_multinode_only_retunes_the_eager_lamport_band() -> None:
         if band is None:
             assert multi == single, f"{world_size=} has no multi-node entry"
             continue
-        assert multi.eager.lamport == band
+        assert multi.eager.two_shot_push == band
         assert multi == single._replace(
-            eager=single.eager._replace(lamport=band)
-        ), f"{world_size=} multi-node override reached past eager.lamport"
+            eager=single.eager._replace(two_shot_push=band)
+        ), f"{world_size=} multi-node override reached past eager.two_shot_push"
         # the band has to stay inside the pull workspace it stages through
         assert band.max_bytes <= multi.eager.max_pull_bytes
 
 
 @torch.inference_mode()
-def test_2shot_lamport_shared_push_plane() -> None:
+def test_2shot_push_shares_the_1shot_plane() -> None:
     nccl_group = _init_nccl_group_once()
     device = torch.device(f"cuda:{int(os.environ['LOCAL_RANK'])}")
     dtype = torch.bfloat16
     push_size = _ALIGN_BYTES // dtype.itemsize  # exactly fills a push slot
-    lamport_size = 16 * push_size  # far more than the push slots hold
-    lamport_bytes = lamport_size * dtype.itemsize
+    two_shot_size = 16 * push_size  # far more than the push slots hold
+    two_shot_bytes = two_shot_size * dtype.itemsize
     comm = CustomAllReduceV2(
         _init_cpu_group_once(),
         device,
-        max_pull_size=lamport_bytes,
+        max_pull_size=two_shot_bytes,
         max_push_size=_ALIGN_BYTES,
-        max_lamport_size=lamport_bytes,
+        max_two_shot_push_size=two_shot_bytes,
     )
     if comm.disabled:
         raise RuntimeError("JIT CustomAllReduceV2 is disabled on this system")
     register_comm_cleanup(comm)
-    # A whole Lamport message spans one enlarged shared slot per peer. Keep
+    # A whole 2shot_push message spans one enlarged shared slot per peer. Keep
     # the tuned 1shot limit smaller: physical capacity must not silently widen
     # its dispatch range.
-    assert comm.gather_slot_size * comm.world_size >= lamport_bytes
-    assert comm.max_push_size * comm.world_size < lamport_bytes
+    assert comm.gather_slot_size * comm.world_size >= two_shot_bytes
+    assert comm.max_push_size * comm.world_size < two_shot_bytes
     assert comm.shared_slot_size == comm.gather_slot_size
     assert comm.shared_slot_size > comm.max_push_size
 
-    plan = [(AllReduceAlgo.TWO_SHOT_LAMPORT, lamport_size)] * TEST_LAYERS
+    plan = [(AllReduceAlgo.TWO_SHOT_PUSH, two_shot_size)] * TEST_LAYERS
     plan += [(AllReduceAlgo.ONE_SHOT_PUSH, push_size)] * TEST_LAYERS
     plan[::2], plan[1::2] = plan[:TEST_LAYERS], plan[TEST_LAYERS:]
 

--- a/test/registered/kernels/ops/communication/test_custom_all_reduce.py
+++ b/test/registered/kernels/ops/communication/test_custom_all_reduce.py
@@ -34,6 +34,11 @@ from sglang.kernels.ops.communication.all_reduce import (
     get_all_reduce_module,
 )
 from sglang.kernels.ops.communication.mp import register_comm_cleanup
+from sglang.srt.distributed.device_communicators.configs.custom_all_reduce_v2 import (
+    _MULTINODE_LAMPORT,
+    get_all_reduce_config,
+    get_supported_world_sizes,
+)
 from sglang.srt.distributed.device_communicators.custom_all_reduce_v2 import (
     _ALIGN_BYTES,
     CustomAllReduceV2,
@@ -237,8 +242,7 @@ def test_custom_all_reduce(
 
 
 def test_empty_input_dispatches_like_the_smallest_one() -> None:
-    """A zero-byte all-reduce must not take a different code path.
-    """
+    """A zero-byte all-reduce must not take a different code path."""
     comm = _init_comm_once()
     for can_use_graph in (True, False):
         empty, smallest = (
@@ -248,6 +252,28 @@ def test_empty_input_dispatches_like_the_smallest_one() -> None:
             f"{can_use_graph=}: empty input picked {empty}, 16 bytes picked "
             f"{smallest}"
         )
+
+
+def test_multinode_only_retunes_the_eager_lamport_band() -> None:
+    cuda_major, _ = torch.cuda.get_device_capability()
+    tuned = {
+        world_size: band
+        for (major, world_size), band in _MULTINODE_LAMPORT.items()
+        if major == cuda_major
+    }
+    for world_size in get_supported_world_sizes():
+        single = get_all_reduce_config(world_size)
+        multi = get_all_reduce_config(world_size, multinode=True)
+        band = tuned.get(world_size)
+        if band is None:
+            assert multi == single, f"{world_size=} has no multi-node entry"
+            continue
+        assert multi.eager.lamport == band
+        assert multi == single._replace(
+            eager=single.eager._replace(lamport=band)
+        ), f"{world_size=} multi-node override reached past eager.lamport"
+        # the band has to stay inside the pull workspace it stages through
+        assert band.max_bytes <= multi.eager.max_pull_bytes
 
 
 @torch.inference_mode()

--- a/test/registered/kernels/ops/communication/test_custom_all_reduce.py
+++ b/test/registered/kernels/ops/communication/test_custom_all_reduce.py
@@ -251,7 +251,7 @@ def test_empty_input_dispatches_like_the_smallest_one() -> None:
 
 
 @torch.inference_mode()
-def test_2shot_lamport_gather() -> None:
+def test_2shot_lamport_shared_push_plane() -> None:
     nccl_group = _init_nccl_group_once()
     device = torch.device(f"cuda:{int(os.environ['LOCAL_RANK'])}")
     dtype = torch.bfloat16
@@ -268,13 +268,29 @@ def test_2shot_lamport_gather() -> None:
     if comm.disabled:
         raise RuntimeError("JIT CustomAllReduceV2 is disabled on this system")
     register_comm_cleanup(comm)
-    # a whole message spans one slot per peer, in either plane
+    # A whole Lamport message spans one enlarged shared slot per peer. Keep
+    # the tuned 1shot limit smaller: physical capacity must not silently widen
+    # its dispatch range.
     assert comm.gather_slot_size * comm.world_size >= lamport_bytes
     assert comm.max_push_size * comm.world_size < lamport_bytes
+    assert comm.shared_slot_size == comm.gather_slot_size
+    assert comm.shared_slot_size > comm.max_push_size
 
     plan = [(AllReduceAlgo.TWO_SHOT_LAMPORT, lamport_size)] * TEST_LAYERS
     plan += [(AllReduceAlgo.ONE_SHOT_PUSH, push_size)] * TEST_LAYERS
     plan[::2], plan[1::2] = plan[:TEST_LAYERS], plan[TEST_LAYERS:]
+
+    # Exercise the shared epoch in eager mode before capturing the same
+    # alternating sequence. Separate push/gather counters would let the two
+    # protocols select the same half of the aliased storage here.
+    for _ in range(TEST_LOOP):
+        for algo, size in plan:
+            inp = torch.randint(0, 16, (size,), dtype=dtype, device=device)
+            ref = inp.clone()
+            dist.all_reduce(ref, group=nccl_group)
+            comm.override_algo = algo
+            out = comm.custom_all_reduce(inp)
+            torch.testing.assert_close(ref, out, atol=0, rtol=0)
 
     graph = torch.cuda.CUDAGraph()
     graph_inps = [torch.zeros((size,), dtype=dtype, device=device) for _, size in plan]

--- a/test/registered/kernels/ops/communication/test_custom_all_reduce.py
+++ b/test/registered/kernels/ops/communication/test_custom_all_reduce.py
@@ -75,7 +75,7 @@ TEST_ALGOS = [
     AllReduceAlgo.ONE_SHOT_PULL,
     AllReduceAlgo.ONE_SHOT_PUSH,
     AllReduceAlgo.TWO_SHOT_PULL,
-    AllReduceAlgo.TWO_SHOT_SCATTER,
+    AllReduceAlgo.TWO_SHOT_PUSH,
 ]
 USE_GRAPH_OPTIONS = [False, True]
 TEST_LAYERS = 4
@@ -172,7 +172,7 @@ def _init_comm_once() -> CustomAllReduceV2:
         device,
         max_pull_size=max_size,
         max_push_size=max_size,
-        max_two_shot_scatter_size=max_size,
+        max_two_shot_push_size=max_size,
     )
     if comm.disabled:
         raise RuntimeError("JIT CustomAllReduceV2 is disabled on this system")
@@ -268,17 +268,17 @@ def test_multinode_only_retunes_the_eager_scatter_band() -> None:
         if bands is None:
             assert multi == single, f"{world_size=} has no multi-node entry"
             continue
-        assert multi.eager.two_shot_scatter == bands.two_shot_scatter
+        assert multi.eager.two_shot_push == bands.two_shot_push
         # the mc sub-band must stay inside the band whose fan-out it refines
-        assert bands.two_shot_scatter_mc.min_bytes >= bands.two_shot_scatter.min_bytes
-        assert bands.two_shot_scatter_mc.max_bytes <= bands.two_shot_scatter.max_bytes
+        assert bands.two_shot_push_mc.min_bytes >= bands.two_shot_push.min_bytes
+        assert bands.two_shot_push_mc.max_bytes <= bands.two_shot_push.max_bytes
         assert multi == single._replace(
             eager=single.eager._replace(**bands._asdict())
         ), f"{world_size=} multi-node override reached past the eager bands"
 
 
 @torch.inference_mode()
-def test_2shot_scatter_shares_the_1shot_plane() -> None:
+def test_2shot_push_shares_the_1shot_plane() -> None:
     nccl_group = _init_nccl_group_once()
     device = torch.device(f"cuda:{int(os.environ['LOCAL_RANK'])}")
     dtype = torch.bfloat16
@@ -290,20 +290,21 @@ def test_2shot_scatter_shares_the_1shot_plane() -> None:
         device,
         max_pull_size=two_shot_bytes,
         max_push_size=_ALIGN_BYTES,
-        max_two_shot_scatter_size=two_shot_bytes,
+        max_two_shot_push_size=two_shot_bytes,
     )
     if comm.disabled:
         raise RuntimeError("JIT CustomAllReduceV2 is disabled on this system")
     register_comm_cleanup(comm)
-    # A whole 2shot_scatter message spans one enlarged shared slot per peer.
-    # Keep the tuned 1shot limit smaller: physical capacity must not silently
-    # widen its dispatch range.
-    assert comm.scatter_slot_size * comm.world_size >= two_shot_bytes
+    # A whole 2shot_push message spans one enlarged push slot per peer, and
+    # the plane doubles its rows for the shard inbox. Keep the tuned 1shot
+    # limit smaller: physical capacity must not silently widen its dispatch
+    # range.
+    assert comm.push_slot_size * comm.world_size >= two_shot_bytes
     assert comm.max_push_size * comm.world_size < two_shot_bytes
-    assert comm.shared_slot_size == comm.scatter_slot_size
-    assert comm.shared_slot_size > comm.max_push_size
+    assert comm.push_slot_size > comm.max_push_size
+    assert comm.obj.push.has_scatter
 
-    plan = [(AllReduceAlgo.TWO_SHOT_SCATTER, two_shot_size)] * TEST_LAYERS
+    plan = [(AllReduceAlgo.TWO_SHOT_PUSH, two_shot_size)] * TEST_LAYERS
     plan += [(AllReduceAlgo.ONE_SHOT_PUSH, push_size)] * TEST_LAYERS
     plan[::2], plan[1::2] = plan[:TEST_LAYERS], plan[TEST_LAYERS:]
 


### PR DESCRIPTION
## Motivation

Inspired by *Every Microsecond Matters: Achieving Near Speed-of-Light Latency in GPU 
Collectives* ([arXiv:2607.16100](https://arxiv.org/abs/2607.16100)) and TensorRT-LLM's [MNNVL all-reduce](https://github.com/NVIDIA/TensorRT-LLM/blob/6c1ce33e7fbb1730c3d85150e6ac73ebc1b76deb/cpp/tensorrt_llm/kernels/communicationKernels/mnnvlAllreduceKernels.cu#L877), this PR adds a 
Lamport-flagged, barrier-free two-shot all-reduce kernel to `CustomAllReduceV2`. 
Against upstream's dispatch it cuts the 640 KB – 16 MB band by up to 34% in graph
mode and 46% in eager on one GB200 node, and by 6–50% across [448 KB, 16 MB]
on a two-node ws=8 group

## Main Changes

- ***Kernel** (`csrc/distributed/custom_all_reduce.cuh`): new
  `all_reduce_2shot_push_kernel` behind the existing entry point — a
  destination-rotated scatter pass, a poll/reduce/fan-out shard pass, and a
  gather drain, plus a `kUseMc` template variant that swaps the gather
  fan-out for one `multimem.st` per vector. Purely additive; no existing
  kernel changes.
- **Planes** (`communicator.cuh`, `registry.cuh`): a push plane may carry
  an optional *scatter region*. The plane recognises the region from the row 
  count, so both constructors keep upstream's exact signatures, and one 
  epoch counter flips the whole push family's double buffer together by 
  construction.
- **Dispatch/config** (`configs/custom_all_reduce_v2.py`,
  `custom_all_reduce_v2.py`): `two_shot_push` band and
  `two_shot_push_mc` sub-band on `Heuristic`; a retuned SM100 world-4
  row; and a *multi-node override mechanism*
  (`get_all_reduce_config(multinode=True)` + `_MULTINODE_PUSH_BANDS`) —
  upstream has no multi-node-specific tuning at all, a multi-node group
  simply ran the single-node row. The workspace doubles the
  push plane's slot rows when the band is on
  (`[push slots | pull | semaphores]`), and the sizing/clipping code around
  it is refactored (`_WorkspaceSizes.resolve`, `_narrow_config`).
- **Benchmark** (`bench_custom_all_reduce.py`): `fi-mnnvl` provider (rides a
  torch-dist comm backend, no MPI, multi-node capable) and multi-node
  provider guards (aot is cudaIpc-bound, trtllm-fi's workspace is
  single-node, jit-graph has no cross-node graph context).

### Dispatch: who owned each band before

SM100 world 4, one node (both contexts):

| size | before | after (this PR) |
|---:|---|---|
| ≤ 0.625 MB | `1shot_push` | `1shot_push` (unchanged) |
| 0.625 – 2.25 MB | `1shot_push` | **`2shot_push`** |
| 2.25 – 3 MB | graph: `2shot_pull` · eager: `1shot_push` | **`2shot_push`** |
| 3 – 16 MB | `2shot_pull` | **`2shot_push`** |
| > 16 MB | `2shot_pull` | `2shot_pull` (unchanged) |


SM100 world 8, two nodes:

| size | before | after (this PR) |
|---:|---|---|
| < 288 KB | `1shot_push` | `1shot_push` (unchanged) |
| 288 – 768 KB | `1shot_push` | **`2shot_push`** |
| 768 KB – 3.5 MB | mc `2shot_pull` | **`2shot_push`** |
| 3.5 – 16 MB | mc `2shot_pull` | **`2shot_push` (multimem fan-out)** |
| > 16 MB | mc `2shot_pull` | mc `2shot_pull` (unchanged) |

Single-node world 8 and every other (arch, world size) row are untouched:
the new bands exist only where they were measured.

## Accuracy Tests

```
$ python test/registered/kernels/ops/communication/test_custom_all_reduce.py --num-gpu 2,4
243 passed   (world 2)
243 passed   (world 4)
```
## Benchmark

Run with `bench_custom_all_reduce.py` on GB200, both `jit-graph` and `jit-eager` are affected. 
```
python test/registered/kernels/benchmark/communication/bench_custom_all_reduce.py --num-gpu 4
```
| message | graph before | graph after | Δ | eager before | eager after | Δ |
|---:|---:|---:|---:|---:|---:|---:|
| 4 KB | 3.69 µs | 3.71 | +0.7% | 3.71 µs | 3.72 | +0.1% |
| 8 KB | 3.78 µs | 3.79 | +0.2% | 3.77 µs | 3.79 | +0.6% |
| 16 KB | 3.80 µs | 3.83 | +0.8% | 3.81 µs | 3.83 | +0.4% |
| 32 KB | 3.85 µs | 3.86 | +0.1% | 3.84 µs | 3.87 | +0.8% |
| 64 KB | 3.93 µs | 3.94 | +0.4% | 3.92 µs | 3.95 | +0.6% |
| 128 KB | 4.04 µs | 4.09 | +1.2% | 4.05 µs | 4.09 | +1.0% |
| 192 KB | 4.23 µs | 4.27 | +1.0% | 4.24 µs | 4.27 | +0.6% |
| 256 KB | 4.49 µs | 4.50 | +0.2% | 4.50 µs | 4.50 | -0.1% |
| 384 KB | 4.94 µs | 4.98 | +0.8% | 4.95 µs | 4.98 | +0.6% |
| 512 KB | 5.51 µs | 5.54 | +0.4% | 5.51 µs | 5.54 | +0.6% |
| 640 KB | 6.22 µs | 5.92 | **-4.7%** | 6.21 µs | 5.92 | **-4.8%** |
| 768 KB | 6.79 µs | 6.07 | **-10.6%** | 6.77 µs | 6.06 | **-10.5%** |
| 896 KB | 7.37 µs | 6.24 | **-15.3%** | 7.37 µs | 6.25 | **-15.2%** |
| 1 MB | 7.92 µs | 6.44 | **-18.7%** | 7.94 µs | 6.44 | **-18.9%** |
| 1.5 MB | 10.34 µs | 7.37 | **-28.7%** | 10.33 µs | 7.38 | **-28.6%** |
| 2 MB | 12.50 µs | 8.21 | **-34.3%** | 12.50 µs | 8.21 | **-34.3%** |
| 3 MB | 15.02 µs | 10.12 | **-32.7%** | 18.69 µs | 10.12 | **-45.9%** |
| 4 MB | 18.73 µs | 13.00 | **-30.6%** | 23.31 µs | 13.01 | **-44.2%** |
| 8 MB | 29.11 µs | 22.46 | **-22.8%** | 34.04 µs | 22.47 | **-34.0%** |
| 16 MB | 46.78 µs | 42.65 | **-8.8%** | 56.40 µs | 42.65 | **-24.4%** |
| 32 MB | 83.03 µs | 82.98 | -0.1% | 101.63 µs | 102.22 | +0.6% |
| 64 MB | 155.40 µs | 155.51 | +0.1% | 196.24 µs | 196.96 | +0.4% |


### World 8 across two GB200 nodes

The same algo tested on an 8-rank group spanning two GB200 nodes over MNNVL in eager mode, result as below.


| message | upstream picks | before | this PR picks | after | Δ |
|---:|---|---:|---|---:|---:|
| 256 KB | 1shot_push | 6.22 µs | 1shot_push | 6.22 | +0.0% |
| 448 KB | 1shot_push | 8.57 µs | 2shot_push | 6.32 | **-26.2%** |
| 512 KB | 1shot_push | 9.31 µs | 2shot_push | 6.41 | **-31.2%** |
| 640 KB | 1shot_push | 10.78 µs | 2shot_push | 6.63 | **-38.5%** |
| 768 KB | 1shot_push | 12.57 µs | 2shot_push | 6.85 | **-45.5%** |
| 1 MB | 2shot_pull_mc | 14.80 µs | 2shot_push | 7.42 | **-49.9%** |
| 1.5 MB | 2shot_pull_mc | 15.85 µs | 2shot_push | 8.56 | **-46.0%** |
| 2 MB | 2shot_pull_mc | 16.95 µs | 2shot_push | 9.65 | **-43.1%** |
| 3 MB | 2shot_pull_mc | 20.53 µs | 2shot_push | 11.97 | **-41.7%** |
| 4 MB | 2shot_pull_mc | 21.59 µs | 2shot_push mc | 14.90 | **-31.0%** |
| 6 MB | 2shot_pull_mc | 26.92 µs | 2shot_push mc | 20.62 | **-23.4%** |
| 8 MB | 2shot_pull_mc | 32.70 µs | 2shot_push mc | 26.31 | **-19.6%** |
| 12 MB | 2shot_pull_mc | 42.25 µs | 2shot_push mc | 38.03 | **-10.0%** |
| 16 MB | 2shot_pull_mc | 52.82 µs | 2shot_push mc | 49.87 | **-5.6%** |









<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33726918269](https://github.com/sgl-project/sglang/actions/runs/33726918269)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33726918205](https://github.com/sgl-project/sglang/actions/runs/33726918205)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33726918212](https://github.com/sgl-project/sglang/actions/runs/33726918212)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->