### PR TITLE
Remove 3 labeler globs that match no files

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -37,9 +37,6 @@ dependencies:
       - '**/Cargo.lock'
       - '**/pyproject*.toml'
       - '**/setup.py'
-      - '**/poetry.lock'
-      - '**/package.json'
-      - '**/package-lock.json'
 
 # Multi-modal
 Multi-modal:


### PR DESCRIPTION
## Motivation
Resolves 3 stale globs in `.github/labeler.yml`: `**/poetry.lock`, `**/package.json`, `**/package-lock.json` (lines 40-42). No file matching them exists in the tree, so these entries never worked.

## Modifications
Remove 3 dead labeler globs.

    # tracked files under the referenced globs
    git ls-files -- '**/poetry.lock' '**/package.json' '**/package-lock.json' | wc -l

I found this mismatch in your repo while analyzing public data with my tool: https://github.com/DanielSwift1992/gate. If you need more details, happy to share.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32070263411](https://github.com/sgl-project/sglang/actions/runs/32070263411)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32070263205](https://github.com/sgl-project/sglang/actions/runs/32070263205)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->