### PR TITLE
[AMD] Fix Quark Shared Experts Fusion Gate after load-time-override Removal

### DIFF
--- a/python/sglang/srt/layers/quantization/quark/quark.py
+++ b/python/sglang/srt/layers/quantization/quark/quark.py
@@ -336,29 +336,6 @@ class QuarkConfig(QuantizationConfig):
         if isinstance(self.dequantization_config, Fp8Config):
             self.weight_block_size = self.dequantization_config.weight_block_size
 
-        self._maybe_disable_shared_experts_fusion()
-
-    def _maybe_disable_shared_experts_fusion(self) -> None:
-        """Turn off shared-expert fusion when the producer keeps shared experts
-        in a higher precision than the routed experts.
-        """
-        if self.can_fuse_shared_expert():
-            return
-
-        from sglang.srt.arg_groups.overrides import declare_load_time_override
-
-        declare_load_time_override(
-            "QuarkConfig._maybe_disable_shared_experts_fusion",
-            {"disable_shared_experts_fusion": True},
-        )
-        logger.info(
-            "Quark: shared experts are excluded from quantization (kept in "
-            "a higher precision) while routed experts are quantized; "
-            "disabling shared experts fusion to avoid loading "
-            "higher-precision shared experts through the quantized "
-            "routed-expert path."
-        )
-
     @property
     def quantized_layers(self) -> tuple[list[str], int]:
         # Consumed by `report_online_quantization` in model_runner. Returns the

--- a/python/sglang/srt/models/deepseek_common/utils.py
+++ b/python/sglang/srt/models/deepseek_common/utils.py
@@ -152,6 +152,16 @@ def is_wint4afp8_or_wint4a16_config(
     ) or quant_config._is_wint4abf16(weight_quant, input_quant)
 
 
+def quant_blocks_shared_experts_fusion(
+    quant_config: Optional[QuantizationConfig],
+) -> bool:
+    """Whether the quantization keeps shared experts at a higher precision than
+    the routed experts, which would require shared expert fusion to be disabled.
+    """
+    can_fuse_fn = getattr(quant_config, "can_fuse_shared_expert", None)
+    return can_fuse_fn is not None and not can_fuse_fn()
+
+
 def yarn_get_mscale(scale: float = 1, mscale: float = 1) -> float:
     if scale <= 1:
         return 1.0

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -3061,6 +3061,13 @@ class DeepseekV2ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
             )
         if is_wint4afp8_or_wint4a16_config(quant_config):
             return "Deepseek V3/R1 W4AFP8/W4A16 model uses different quant method for routed experts and shared experts."
+        can_fuse_fn = getattr(quant_config, "can_fuse_shared_expert", None)
+        if can_fuse_fn is not None and not can_fuse_fn():
+            return (
+                "Quantization keeps shared experts at a higher precision than the "
+                "routed experts, so they cannot be fused into the quantized "
+                "routed-expert path."
+            )
         return None
 
     def determine_num_fused_shared_experts(self):

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -192,6 +192,7 @@ from sglang.srt.models.deepseek_common.utils import (
     _use_aiter_bpreshuffle_gfx95,
     _use_aiter_gfx95,
     is_wint4afp8_or_wint4a16_config,
+    quant_blocks_shared_experts_fusion,
 )
 from sglang.srt.runtime_context import (
     attention_backends,
@@ -3018,6 +3019,14 @@ class DeepseekV2ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
         ``install_shared_experts_fusion_decision``), so it takes the config and
         quantization it is asked about rather than reading an instance.
         """
+        # Need to disable if quant precision mismatch, even if
+        # --enforce-shared-experts-fusion is specified
+        if quant_blocks_shared_experts_fusion(quant_config):
+            return (
+                "Quantization keeps shared experts at a higher precision than the "
+                "routed experts, so they cannot be fused into the quantized "
+                "routed-expert path."
+            )
         if get_exec().moe.enforce_shared_experts_fusion:
             return None
         if is_sbo_enabled() or is_tbo_enabled():
@@ -3061,13 +3070,6 @@ class DeepseekV2ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
             )
         if is_wint4afp8_or_wint4a16_config(quant_config):
             return "Deepseek V3/R1 W4AFP8/W4A16 model uses different quant method for routed experts and shared experts."
-        can_fuse_fn = getattr(quant_config, "can_fuse_shared_expert", None)
-        if can_fuse_fn is not None and not can_fuse_fn():
-            return (
-                "Quantization keeps shared experts at a higher precision than the "
-                "routed experts, so they cannot be fused into the quantized "
-                "routed-expert path."
-            )
         return None
 
     def determine_num_fused_shared_experts(self):

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -143,6 +143,7 @@ from sglang.srt.models.deepseek_common.amd.deepseek_v4_fused_mhc import (
 from sglang.srt.models.deepseek_common.utils import (
     _use_aiter_bpreshuffle_gfx95,
     is_wint4afp8_or_wint4a16_config,
+    quant_blocks_shared_experts_fusion,
 )
 from sglang.srt.models.deepseek_v2 import (
     ParallelLMHead,
@@ -3016,6 +3017,14 @@ class DeepseekV4ForCausalLM(nn.Module):
         """V4 only fuses when explicitly asked to, and then the checkpoint must
         carry exactly one shared expert. Asked by the loader before any layer is
         built."""
+        # Need to disable if quant precision mismatch, even if
+        # --enforce-shared-experts-fusion is specified
+        if quant_blocks_shared_experts_fusion(quant_config):
+            return (
+                "Quantization keeps shared experts at a higher precision than the "
+                "routed experts, so they cannot be fused into the quantized "
+                "routed-expert path."
+            )
         if not get_exec().moe.enforce_shared_experts_fusion:
             return "Config does not support fused shared expert(s)."
         if hf_config.n_shared_experts != 1:

--- a/test/registered/unit/models/test_deepseek_v4_shared_expert_fusion.py
+++ b/test/registered/unit/models/test_deepseek_v4_shared_expert_fusion.py
@@ -86,6 +86,29 @@ class TestDeepseekV4SharedExpertFusionPolicy(CustomTestCase):
                 SimpleNamespace(n_shared_experts=2), None
             )
 
+    def test_mixed_precision_quant_vetoes_even_when_enforced(self):
+        """A precision mismatch causes crash when shared expert fusion is enabled,
+        so --enforce-shared-experts-fusion must not override it. Guards the gap
+        where the enforce early-return skipped the quant check entirely."""
+        self._publish(enforce=True)
+        mixed = SimpleNamespace(
+            get_name=lambda: "quark", can_fuse_shared_expert=lambda: False
+        )
+        self.assertIn(
+            "higher precision",
+            DeepseekV4ForCausalLM.shared_experts_fusion_disable_reason(
+                SimpleNamespace(n_shared_experts=1), mixed
+            ),
+        )
+        matched = SimpleNamespace(
+            get_name=lambda: "quark", can_fuse_shared_expert=lambda: True
+        )
+        self.assertIsNone(
+            DeepseekV4ForCausalLM.shared_experts_fusion_disable_reason(
+                SimpleNamespace(n_shared_experts=1), matched
+            )
+        )
+
     def test_dspark_entry_class_uses_the_v4_gate(self):
         """A DSV4 DSpark draft must inherit the target's default fusion policy."""
         self._publish(enforce=False)

--- a/test/registered/unit/models/test_shared_experts_fusion_gates.py
+++ b/test/registered/unit/models/test_shared_experts_fusion_gates.py
@@ -117,6 +117,25 @@ class TestDeepseekV2Gate(_FusionGateCase):
             self._reason(DeepseekV2ForCausalLM, self._config(), moe_ep_size=2)
         )
 
+    def test_mixed_precision_quant_vetoes_even_when_enforced(self):
+        """A precision mismatch causes crash when shared expert fusion is enabled,
+        so --enforce-shared-experts-fusion must not override it. Guards the gap
+        where the enforce early-return skipped the quant check entirely."""
+        from sglang.srt.models.deepseek_v2 import DeepseekV2ForCausalLM
+
+        self._seed(enforce_shared_experts_fusion=True)
+        mixed = SimpleNamespace(
+            get_name=lambda: "quark", can_fuse_shared_expert=lambda: False
+        )
+        self.assertIn(
+            "higher precision",
+            self._reason(DeepseekV2ForCausalLM, self._config(), mixed),
+        )
+        matched = SimpleNamespace(
+            get_name=lambda: "quark", can_fuse_shared_expert=lambda: True
+        )
+        self.assertIsNone(self._reason(DeepseekV2ForCausalLM, self._config(), matched))
+
 
 class TestGlmMoeLiteGate(_FusionGateCase):
     def _config(self, **kw):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

PR #33889 replaced process-global load-time config overrides with per-runner model-class gates and deleted `declare_load_time_override`. PR #29328 landed afterward still calling that deleted function from `QuarkConfig.__init__`, so any Quark checkpoint or online quantized checkpoint that cannot fuse shared expert(s) due to precision mismatch now raises `ImportError` at load. This PR restores the mixed-precision shared-experts decision path through the new gate architecture instead of the deleted global-override path.

## Modifications

- `quark/quark.py`: remove `_maybe_disable_shared_experts_fusion` and its `__init__` call. Quark no longer imperatively pushes a decision; `its can_fuse_shared_expert()` reader stays as the source of truth.
- `models/deepseek_v2.py`: DeepseekV3ForCausalLM.shared_experts_fusion_disable_reason now checks `quant_config.can_fuse_shared_expert()`, matching `qwen2_moe.can_fuse_shared_expert`'s implementation. The decision flows through the per-runner gate the loader calls (`install_shared_experts_fusion_decision`) instead of the deleted global override. This covers the whole DeepSeek family (V2/V3, Kimi-K2.5, Kimi-VL, DeepSeek-VL2/OCR, dots_vlm).

## Tests

Verified on **AMD MI355X** with both native AMD Quark MXFP4 checkpoint and online NVFP4 to MXFP4 requantization
(`--quantization quark_mxfp4` introduced in PR #29328) with both quantized and excluded shared expert. 

| Checkpoint | Arch / gate | Fusion decision | Verified |
| --- | --- | --- | --- |
| `nvidia/Kimi-K2.6-NVFP4` | KimiK25 / DeepseekV3 gate | **disabled** (shared experts kept higher precision) | ✅ loads + serves |
| `nvidia/DeepSeek-R1-NVFP4` | DeepseekV3 gate | **enabled** (shared_expert quantized, precision matches routed precision) | ✅ loads + serves |
| `nvidia/Qwen3.5-397B-A17B-NVFP4` | Qwen3.5 gate | **disabled** | ✅ loads + serves |
| `amd/Qwen3.5-35B-A3B-MXFP4` | Qwen3.5 gate | **disabled** | ✅ loads + serves |



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32088497917](https://github.com/sgl-project/sglang/actions/runs/32088497917)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32088497735](https://github.com/sgl-project/sglang/actions/runs/32088497735)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->