### PR TITLE
[Scheduler] Release all request-owned KV on no-insert cleanup

### DIFF
--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -473,6 +473,19 @@ class RadixCache(KVCacheEventMixin, BasePrefixCache):
             )
             return
 
+        if not is_insert:
+            # The protected prefix is owned by the cache. Release every KV slot
+            # owned by the request, including slots without a committed token id.
+            kv_indices = self.req_to_token_pool.req_to_token[
+                req.req_pool_idx, req.cache_protected_len : kv_len_to_handle
+            ]
+            self.token_to_kv_pool_allocator.free_segment(
+                kv_indices, start_pos=req.cache_protected_len
+            )
+            if req.last_node is not None:
+                self.dec_lock_ref(req.last_node)
+            return
+
         token_ids = (req.origin_input_ids + req.output_ids)[:kv_len_to_handle]
         kv_indices = self.req_to_token_pool.req_to_token[
             req.req_pool_idx, : len(token_ids)
@@ -488,14 +501,11 @@ class RadixCache(KVCacheEventMixin, BasePrefixCache):
         values = kv_indices[:key_len].to(dtype=torch.int64, copy=True)
 
         # Radix Cache takes one ref in memory pool
-        if is_insert:
-            priority = getattr(req, "priority", 0) or 0
-            result = self.insert(
-                InsertParams(key=radix_key, value=values, priority=priority)
-            )
-            freed_end = result.prefix_len
-        else:
-            freed_end = key_len
+        priority = getattr(req, "priority", 0) or 0
+        result = self.insert(
+            InsertParams(key=radix_key, value=values, priority=priority)
+        )
+        freed_end = result.prefix_len
 
         # duplicates / uninserted range, then the unaligned tail
         self.token_to_kv_pool_allocator.free_segments(

--- a/test/registered/unit/mem_cache/test_decode_radix_lock_ref.py
+++ b/test/registered/unit/mem_cache/test_decode_radix_lock_ref.py
@@ -39,6 +39,7 @@ from sglang.srt.mem_cache.base_prefix_cache import (
 )
 from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey
 from sglang.srt.utils.common import Range
+from sglang.test.test_utils import CustomTestCase
 
 
 def _make_cache_with_pools(page_size=1):
@@ -92,7 +93,7 @@ def _make_req(fill_ids, req_pool_idx=0, cache_protected_len=0, last_node=None):
     return MockReq(fill_ids, req_pool_idx, cache_protected_len, last_node)
 
 
-class TestDecodeLockRefScenarios(unittest.TestCase):
+class TestDecodeLockRefScenarios(CustomTestCase):
     """Test lock_ref balance across decode transfer scenarios."""
 
     def _populate_prefix(self, cache, prefix_ids, prefix_values):
@@ -291,6 +292,29 @@ class TestDecodeLockRefScenarios(unittest.TestCase):
         self.assertEqual(cache.root_node.lock_ref, root_lock_before)
         self.assertEqual(cache.protected_size(), 0)
         self.assertEqual(cache.evictable_size(), 0)
+
+    def test_failure_frees_kv_without_committed_token_id(self):
+        """Rejecting an uncommitted token must release its allocated KV slot."""
+        cache, req_to_token = _make_cache_with_pools()
+        kv_indices = torch.tensor([100, 200, 300], dtype=torch.int64)
+        req_to_token[0, : len(kv_indices)] = kv_indices
+
+        req = _make_req(
+            fill_ids=[10, 20, 30],
+            req_pool_idx=0,
+            cache_protected_len=0,
+            last_node=cache.root_node,
+        )
+        req.output_ids = array("q")
+
+        cache.token_to_kv_pool_allocator.reset_mock()
+        cache.cache_finished_req(
+            req, is_insert=False, kv_len_to_handle=req.kv_committed_len
+        )
+
+        free_call = cache.token_to_kv_pool_allocator.free_segment.call_args
+        torch.testing.assert_close(free_call.args[0], kv_indices)
+        self.assertEqual(free_call.kwargs["start_pos"], 0)
 
     def test_pop_preallocated_rechecks_budget_after_lock(self):
         queue = DecodePreallocQueue.__new__(DecodePreallocQueue)


### PR DESCRIPTION
## Why

`RadixCache.cache_finished_req(..., is_insert=False)` means that a request is being discarded without inserting its KV into the radix cache. The implementation derived the release range from committed token IDs rather than from `kv_len_to_handle`. When a forward pass had committed a KV slot but its sampled output token was rejected before token commit, the token-ID list was shorter and the final request-owned KV slot could leak.

## Change

- Preserve the cache-owned protected prefix.
- For no-insert cleanup, release every request-owned committed slot in `[cache_protected_len, kv_len_to_handle)` directly from the request-to-token mapping.
- Release the request's radix-node lock as before.
- Leave the normal cache-insertion path unchanged.

This fixes the generic no-insert cleanup contract; it does not depend on sampling-mask code.

## PR chain

This is part 1 of the sampling-support correctness series. The core capture PR will depend on this fix, and #34037 will remain the final bounded-mode PR. Cross-links will be updated when part 2 is opened.

## Validation

- The focused test covers a committed KV slot with no corresponding committed output token.
- This test passed in the H200 validation run for #34037 before extraction.
- Repository pre-commit checks passed for both changed files, including the registered-test validator.
- `git diff --check` passed.

Local execution of the focused test was unavailable in this checkout because its Python environment does not contain PyTorch.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32074667969](https://github.com/sgl-project/sglang/actions/runs/32074667969)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32074667760](https://github.com/sgl-project/sglang/actions/runs/32074667760)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->