### PR TITLE
[Scheduler] Align `RadixCache` no-insert cleanup with `kv_len_to_handle`

### DIFF
--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -473,6 +473,19 @@ class RadixCache(KVCacheEventMixin, BasePrefixCache):
             )
             return
 
+        if not is_insert:
+            # The protected prefix is owned by the cache. Release every KV slot
+            # owned by the request, including slots without a committed token id.
+            kv_indices = self.req_to_token_pool.req_to_token[
+                req.req_pool_idx, req.cache_protected_len : kv_len_to_handle
+            ]
+            self.token_to_kv_pool_allocator.free_segment(
+                kv_indices, start_pos=req.cache_protected_len
+            )
+            if req.last_node is not None:
+                self.dec_lock_ref(req.last_node)
+            return
+
         token_ids = (req.origin_input_ids + req.output_ids)[:kv_len_to_handle]
         kv_indices = self.req_to_token_pool.req_to_token[
             req.req_pool_idx, : len(token_ids)
@@ -488,14 +501,11 @@ class RadixCache(KVCacheEventMixin, BasePrefixCache):
         values = kv_indices[:key_len].to(dtype=torch.int64, copy=True)
 
         # Radix Cache takes one ref in memory pool
-        if is_insert:
-            priority = getattr(req, "priority", 0) or 0
-            result = self.insert(
-                InsertParams(key=radix_key, value=values, priority=priority)
-            )
-            freed_end = result.prefix_len
-        else:
-            freed_end = key_len
+        priority = getattr(req, "priority", 0) or 0
+        result = self.insert(
+            InsertParams(key=radix_key, value=values, priority=priority)
+        )
+        freed_end = result.prefix_len
 
         # duplicates / uninserted range, then the unaligned tail
         self.token_to_kv_pool_allocator.free_segments(

--- a/test/registered/unit/mem_cache/test_decode_radix_lock_ref.py
+++ b/test/registered/unit/mem_cache/test_decode_radix_lock_ref.py
@@ -39,6 +39,7 @@ from sglang.srt.mem_cache.base_prefix_cache import (
 )
 from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey
 from sglang.srt.utils.common import Range
+from sglang.test.test_utils import CustomTestCase
 
 
 def _make_cache_with_pools(page_size=1):
@@ -92,7 +93,7 @@ def _make_req(fill_ids, req_pool_idx=0, cache_protected_len=0, last_node=None):
     return MockReq(fill_ids, req_pool_idx, cache_protected_len, last_node)
 
 
-class TestDecodeLockRefScenarios(unittest.TestCase):
+class TestDecodeLockRefScenarios(CustomTestCase):
     """Test lock_ref balance across decode transfer scenarios."""
 
     def _populate_prefix(self, cache, prefix_ids, prefix_values):
@@ -201,7 +202,10 @@ class TestDecodeLockRefScenarios(unittest.TestCase):
         self.assertEqual(cache.evictable_size(), len(full_ids))
 
     def test_incremental_transfer_failure(self):
-        """Scenario 3: prefix match > 0, transfer fails.
+        """Scenario 3: prefix match > 0, transfer fails after KV commit.
+
+        The final committed KV slot has no corresponding output token. Cleanup
+        must preserve the matched prefix and release the full request-owned suffix.
 
         Flow: inc_lock_ref(pop_preallocated)
               -> dec_lock_ref(cache_finished_req via release_kv_cache is_insert=False)
@@ -233,12 +237,20 @@ class TestDecodeLockRefScenarios(unittest.TestCase):
             cache_protected_len=prefix_len,
             last_node=matched_node,
         )
+        req.output_ids = array("q")
 
         # Transfer fails -> cache_finished_req with is_insert=False
         # This frees delta tokens and dec_lock_ref on last_node
+        cache.token_to_kv_pool_allocator.reset_mock()
         cache.cache_finished_req(
             req, is_insert=False, kv_len_to_handle=req.kv_committed_len
         )
+
+        free_call = cache.token_to_kv_pool_allocator.free_segment.call_args
+        torch.testing.assert_close(
+            free_call.args[0], torch.tensor(full_vals[prefix_len:])
+        )
+        self.assertEqual(free_call.kwargs["start_pos"], prefix_len)
 
         # The prefix node should be unlocked (back to evictable)
         self.assertEqual(cache.root_node.lock_ref, 1)


### PR DESCRIPTION
## Summary

- Size the no-insert release from `kv_len_to_handle` instead of the committed token IDs, matching what every other cache backend already does.
- Skip the radix-key construction and value copy on the no-insert path; only the insertion path needs them.
- Related: #35793 bounds the cacheable length on the insertion path.

## Background

- `cache_finished_req(..., is_insert=False)` discards a request without inserting its KV. The old code built `token_ids = (origin_input_ids + output_ids)[:kv_len_to_handle]` and released `[cache_protected_len, len(token_ids))`.
- `swa_radix_cache`, `pure_swa_radix_cache`, `mamba_radix_cache`, `unified_radix_cache` and `radix_cache_cpp` all slice the kv row by `kv_len_to_handle` directly. `RadixCache` was the only backend deriving the range from token IDs.
- That made the release range depend on `kv_committed_len <= len(origin_input_ids) + len(output_ids)`. Under overlap scheduling `kv_committed_len` is advanced in `prepare_for_decode` before the forward runs, so the two can differ transiently. No cleanup entry point is known to be reachable inside that window today, so this is defensive rather than a fix for an observed leak.

## Ownership contract

- `[0, cache_protected_len)` is cache-owned and must be preserved.
- `[cache_protected_len, kv_len_to_handle)` is request-owned committed KV and is released on no-insert cleanup.
- Anything past `kv_len_to_handle` is released by `release_kv_cache`.

## Change

- Return early for `is_insert=False`, releasing `[cache_protected_len, kv_len_to_handle)` with the existing `free_segment` primitive and dropping the radix-node lock, mirroring the `disable` branch directly above it.
- The insertion path is unchanged and no longer needs the `if is_insert:` guard.
- Extend the matched-prefix failure test to cover a committed KV slot with no corresponding output token.

## Validation

- `test_decode_radix_lock_ref.py`, `test_radix_cache_unit.py`, `test_paged_free_segment.py`, `test_free_kv_row_coalesce.py`, `test_unified_radix_lock_ref.py`: 69 tests, all passing.
- Page-set equivalence checked directly against `PagedTokenToKVPoolAllocator` with `page_size=4`: across every `(sequence length, cache_protected_len)` pair, the single-segment release frees exactly the same pages as the previous two-segment `free_segments` call, and the follow-up overallocated-tail release never double-frees a page.
- Repository pre-commit checks pass for both changed files.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #35288165906](https://github.com/sgl-project/sglang/actions/runs/35288165906)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35288165706](https://github.com/sgl-project/sglang/actions/runs/35288165706)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35288165863](https://github.com/sgl-project/sglang/actions/runs/35288165863)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->

