### PR TITLE
[Sampling] Restore finite top-k requirement for sampling masks

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2572,13 +2572,11 @@ class Scheduler(
             self._add_request_to_queue(req)
             return
 
-        uses_top_k_or_top_p_truncation = (
-            req.sampling_params.top_k != TOP_K_ALL or req.sampling_params.top_p < 1.0
-        )
-        if req.return_sampling_mask and not uses_top_k_or_top_p_truncation:
+        if req.return_sampling_mask and req.sampling_params.top_k == TOP_K_ALL:
             error_msg = (
-                "return_sampling_mask cannot return the full vocabulary; set "
-                "top_p < 1 or a finite top_k."
+                "return_sampling_mask requires finite top_k; top_p-only sampling "
+                "is valid but can return huge masks in the tail, blowing up "
+                "metadata, so we need a safety cap."
             )
             req.set_finish_with_abort(error_msg)
             self.init_req_max_new_tokens(req)

--- a/test/registered/sampling/test_sampling_mask.py
+++ b/test/registered/sampling/test_sampling_mask.py
@@ -18,12 +18,14 @@ register_amd_ci(est_time=320, suite="stage-b-test-1-gpu-small-amd")
 
 _MAX_NEW_TOKENS = 4
 _TOP_P = 0.99
-_TOP_P_SMALL = 1e-5
 _TOP_K = 10
 _SAMPLING_SEED = 1234
 _SERVER_ARGS = (
     "--mem-fraction-static",
     "0.7",
+)
+_INVALID_SAMPLING_MASK_ERROR = (
+    "top_p-only sampling is valid but can return huge masks in the tail"
 )
 
 
@@ -78,6 +80,11 @@ class SamplingMaskTestMixin:
         for output_id, sampling_mask in zip(output_ids, sampling_masks):
             self.assertIn(output_id, sampling_mask)
         return sampling_masks
+
+    def _assert_rejects_unbounded_sampling_mask(self, sampling_params):
+        response = self._post_generate(sampling_params)
+        self.assertEqual(response.status_code, 400, response.text)
+        self.assertIn(_INVALID_SAMPLING_MASK_ERROR, response.text)
 
 
 class TestSamplingMask(SamplingMaskTestMixin, CustomTestCase):
@@ -184,24 +191,15 @@ class TestSamplingMask(SamplingMaskTestMixin, CustomTestCase):
             expected_logprob = math.log(probs[output_id] / support_mass)
             self.assertAlmostEqual(mask_logprob, expected_logprob, delta=1e-2)
 
-    def test_generate_returns_top_p_only_sampling_mask(self):
-        self._generate_sampling_masks(
-            {
-                "temperature": 1.0,
-                "top_p": _TOP_P_SMALL,
-                "max_new_tokens": _MAX_NEW_TOKENS,
-                "ignore_eos": True,
-            }
-        )
-
-    def test_chat_completions_returns_top_p_only_sampling_mask(self):
+    def test_chat_completions_returns_sampling_mask(self):
         response = requests.post(
             self.base_url + "/v1/chat/completions",
             json={
                 "model": self.model,
                 "messages": [{"role": "user", "content": "Name a capital city."}],
                 "temperature": 1.0,
-                "top_p": _TOP_P_SMALL,
+                "top_k": _TOP_K,
+                "top_p": _TOP_P,
                 "max_tokens": _MAX_NEW_TOKENS,
                 "ignore_eos": True,
                 "return_sampling_mask": True,
@@ -224,18 +222,22 @@ class TestSamplingMask(SamplingMaskTestMixin, CustomTestCase):
         for output_id, sampling_mask in zip(output_ids, sampling_masks):
             self.assertIn(output_id, sampling_mask)
 
-    def test_generate_rejects_full_vocabulary_sampling_mask(self):
-        response = self._post_generate(
+    def test_generate_rejects_unbounded_sampling_mask(self):
+        self._assert_rejects_unbounded_sampling_mask(
+            {
+                "temperature": 1.0,
+                "top_p": _TOP_P,
+                "max_new_tokens": _MAX_NEW_TOKENS,
+                "ignore_eos": True,
+            }
+        )
+        self._assert_rejects_unbounded_sampling_mask(
             {
                 "temperature": 1.0,
                 "top_p": 1.0,
                 "max_new_tokens": _MAX_NEW_TOKENS,
                 "ignore_eos": True,
             }
-        )
-        self.assertEqual(response.status_code, 400, response.text)
-        self.assertIn(
-            "return_sampling_mask cannot return the full vocabulary", response.text
         )
 
 


### PR DESCRIPTION
## Why

#33593 allowed `return_sampling_mask` with unlimited `top_k` when `top_p < 1`. Because `top_p` bounds probability mass rather than the number of retained tokens, it does not bound sampling-mask reconstruction or returned metadata.

This PR reverts that part of #33593 and requires finite `top_k` for sampling-mask requests. General support without finite `top_k` is tracked in #35765.

## Changes

- Restore the finite-`top_k` request validation.
- Keep the OpenAI chat path supported when finite `top_k` is provided.
- Restore registered coverage for rejecting sampling-mask requests without finite `top_k`.

## Validation

- `pre-commit run --files python/sglang/srt/managers/scheduler.py test/registered/sampling/test_sampling_mask.py`
- `python -m compileall -q python/sglang/srt/managers/scheduler.py test/registered/sampling/test_sampling_mask.py`
- `git diff --check`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32429576748](https://github.com/sgl-project/sglang/actions/runs/32429576748)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32429576565](https://github.com/sgl-project/sglang/actions/runs/32429576565)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32429576704](https://github.com/sgl-project/sglang/actions/runs/32429576704)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
