### PR TITLE
model: fix Step3 (step3_vl) crash on configs without pad_token_id

### DIFF
--- a/python/sglang/srt/models/step3_vl.py
+++ b/python/sglang/srt/models/step3_vl.py
@@ -435,7 +435,9 @@ class Step3TextModel(nn.Module):
         prefix: str = "",
     ) -> None:
         super().__init__()
-        self.padding_idx = config.pad_token_id
+        # Step3TextConfig defines only bos/eos, not pad_token_id; padding_idx is
+        # unused here, so default to None.
+        self.padding_idx = getattr(config, "pad_token_id", None)
         self.vocab_size = config.vocab_size
 
         self.embed_tokens = VocabParallelEmbedding(


### PR DESCRIPTION
## Motivation

Serving `stepfun-ai/step3` (`Step3VLForConditionalGeneration`, a 321B MoE VLM)
crashes at model init:

```
AttributeError: 'Step3TextConfig' object has no attribute 'pad_token_id'
```

`Step3TextModel.__init__` reads `config.pad_token_id`, but `Step3TextConfig`
defines only `bos_token_id` / `eos_token_id`, so it fails before any weights
load. (Baseline: P1 build #4780.)

## Modifications

`models/step3_vl.py`: default the field to `None` —
`self.padding_idx = getattr(config, "pad_token_id", None)`. `padding_idx` is only
assigned in this class (never used, not passed to `embed_tokens`), so `None` is
safe. This clears the reported `AttributeError`.

## Accuracy Test

Not run. `stepfun-ai/step3` is 321B params (~642 GB in bf16) and does not fit the
available hardware (8 × 24 GB = 192 GB), so it cannot be loaded here at any TP —
load / generation / gsm8k were not executed. The change is a targeted fix for the
exact reported config-init crash (static analysis); further issues may surface on
a host large enough to hold the weights. The same code path (`models/step3_vl.py`)
already serves the smaller sibling `stepfun-ai/Step3-VL-10B`.

## Speed Test and Profiling

N/A — config-init crash fix; no change to the compute path.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32075838408](https://github.com/sgl-project/sglang/actions/runs/32075838408)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32075838503](https://github.com/sgl-project/sglang/actions/runs/32075838503)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->