### PR TITLE
[flashinfer] Pass window_left at plan time for DFlash verify

### DIFF
--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -1931,11 +1931,18 @@ class FlashInferIndicesUpdaterPrefill:
                 fixed_split_size=fixed_split_size,
                 multi_item_params=multi_item_params,
                 cross_attention_custom_mask=swa_paged_custom_mask,
-                # paged-only SWA path only; ragged keeps its custom prefix
-                # mask, spec-verify keeps its tree mask
+                # Paged-only SWA path. DFlash verify is a linear block without a
+                # tree mask, so its layer still needs the kernel's moving window.
                 window_left=(
                     sliding_window_size
-                    if (wrapper_id == 0 and not use_ragged and spec_info is None)
+                    if (
+                        wrapper_id == 0
+                        and not use_ragged
+                        and (
+                            spec_info is None
+                            or spec_info.spec_input_type == SpecInputType.DFLASH_VERIFY
+                        )
+                    )
                     else -1
                 ),
             )

--- a/python/sglang/test/kits/attention_unittest/runner_modes/speculative_target_verify_runner.py
+++ b/python/sglang/test/kits/attention_unittest/runner_modes/speculative_target_verify_runner.py
@@ -265,7 +265,8 @@ def _make_flashinfer_dflash_swa_builtin_masks(
     *,
     device: str,
 ) -> list[torch.Tensor]:
-    """Mirror FlashInfer DFLASH verify's production no-custom-mask path."""
+    """Each query sees the sliding window ending at its own position, so the
+    window is per query and not per request."""
     draft_token_num = _check_target_verify_case(case)
     window = int(case.sliding_window_size)
     masks_by_req = []
@@ -276,9 +277,10 @@ def _make_flashinfer_dflash_swa_builtin_masks(
     ).unsqueeze(1)
     for prefix_len in case.prefix_lens:
         seq_len = prefix_len + draft_token_num
-        prefix_start = max(0, int(prefix_len) - window)
         k_idx = torch.arange(seq_len, dtype=torch.int32, device=device).unsqueeze(0)
-        masks_by_req.append((k_idx >= prefix_start) & (k_idx <= prefix_len + q_idx))
+        q_pos = int(prefix_len) + q_idx
+        lower = torch.clamp(q_pos - window, min=0)
+        masks_by_req.append((k_idx >= lower) & (k_idx <= q_pos))
 
     return masks_by_req
 


### PR DESCRIPTION
## Motivation

#31501 added plan-time `window_left` for the SWA paged prefill wrapper and gated it on
`spec_info is None`. The same commit noted, on the index trim right above it, that the trim
is request-granular and "exactness comes from plan-time window_left".

DFlash verify therefore still runs with the window compiled out. The whole block shares one
left bound anchored at the block start, so the query at block offset `j` attends to `j` keys
that a window ending at its own position excludes. DFlash verify is a linear block with no
tree mask -- the worker passes `custom_mask=None` -- so nothing else supplies the window.

## Modifications

- `flashinfer_backend.py`: allow the plan-time window for `SpecInputType.DFLASH_VERIFY`.
  EAGLE tree verify keeps the previous behaviour.
- `speculative_target_verify_runner.py`: correct the DFlash reference mask from
  `prefix_len - window` to `q_pos - window`.

The reference mask was built from the same request-granular rule as the code under test,
which is why the pre-existing `runner_dflash_verify_swa_chain` case passed. With the
reference corrected, that case becomes a regression test for this fix: at
`prefix_lens=(3, 5)` and `sliding_window_size=4`, the last query of the second request sees
two keys too many without the backend change.

## Accuracy Tests

Verify output changes on SWA layers whenever the committed prefix exceeds the window. The
window it removes is at most `draft_token_num - 1` keys at the oldest end of the window, so
the effect is small in absolute terms; the point is that verify and decode now use the same
window definition.

Measured on H200 with a sliding-window DFlash draft (window 2047, block 16) on flashinfer,
24 gsm8k prompts at T=0, this branch against the same tree with the backend hunk reverted:

| prompt | this branch | reverted |
|---|---|---|
| ~3070 tokens, so the prefix passes the window | accept 6.050 | accept 6.041 |
| gsm8k as-is, ~400 tokens with the completion | accept 6.545 | accept 6.545 |

The short row is the control: below the window the two masks are elementwise equal, and the
arms agree to the digit, which is also what makes the long row readable -- at T=0 with fixed
prompts the pipeline is deterministic, so 0.009 is the effect and not noise. It is that small
because the keys at stake are at most 15 out of 2047, at the oldest end of the window.

`test/registered/attention/unittests/swa/test_flashinfer.py::runner_dflash_verify_swa_chain`
fails before the backend change and passes after it.

## Speed Tests and Profiling

None. Passing `window_left >= 0` selects the flashinfer module with the window predicate
compiled in; no additional work per step.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32075240918](https://github.com/sgl-project/sglang/actions/runs/32075240918)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32075240770](https://github.com/sgl-project/sglang/actions/runs/32075240770)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
