### PR TITLE
[spec] Reject trtllm_mha for DFlash drafts with non-causal sliding layers

### DIFF
--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -480,21 +480,20 @@ def _resolve_dflash_draft_attention_backend(server_args: ServerArgs) -> None:
             getattr(draft_hf_config, "text_config", None) or draft_hf_config
         )
         layer_types = get_dflash_layer_types(draft_hf_config)
-        num_layers = getattr(draft_text_config, "num_hidden_layers", None)
-        all_sliding = (
-            layer_types
-            and len(layer_types) == num_layers
-            and set(layer_types) == {"sliding_attention"}
-        )
-        all_causal = getattr(draft_text_config, "is_causal", False) is True
-        if not (all_sliding or all_causal):
+        has_sliding = bool(layer_types and "sliding_attention" in layer_types)
+        # Three-valued, like the model's own resolution (models/dflash.py:46-52):
+        # an absent key leaves a sliding layer on its causal default, so only an
+        # explicit False builds the layer trtllm cannot represent.
+        is_causal = getattr(draft_text_config, "is_causal", None)
+        if has_sliding and is_causal is False:
             logger.warning(
-                "DFLASH only enables 'trtllm_mha' when all layers use sliding "
-                "attention or the draft is explicitly causal; got "
-                "layer_types=%r, is_causal=%r. "
-                "Falling back to '%s'.",
+                "DFLASH 'trtllm_mha' cannot represent a sliding layer that is "
+                "not causal: the verify kernel is causal in-window, so the "
+                "backend expands the block into single-query rows that share "
+                "one window, anchored at the block's last position. Got "
+                "layer_types=%r, is_causal=%r. Falling back to '%s'.",
                 layer_types,
-                getattr(draft_text_config, "is_causal", None),
+                is_causal,
                 fallback_backend,
             )
             draft_backend = fallback_backend

--- a/test/registered/unit/spec/test_dflash_backend_resolution.py
+++ b/test/registered/unit/spec/test_dflash_backend_resolution.py
@@ -1,0 +1,67 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.srt.arg_groups.speculative_hook import (
+    _resolve_dflash_draft_attention_backend,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+_UNSET = object()
+
+
+def _resolve(*, layer_types: list[str], is_causal=_UNSET) -> str:
+    fields = {"layer_types": layer_types, "num_hidden_layers": len(layer_types)}
+    if is_causal is not _UNSET:
+        fields["is_causal"] = is_causal
+    draft_config = SimpleNamespace(text_config=SimpleNamespace(**fields))
+    server_args = SimpleNamespace(
+        speculative_draft_attention_backend="trtllm_mha",
+        speculative_draft_model_path="draft",
+        speculative_draft_model_revision="main",
+        trust_remote_code=False,
+        json_model_override_args="{}",
+    )
+    with (
+        patch("sglang.srt.utils.is_hip", return_value=False),
+        patch(
+            "sglang.srt.utils.hf_transformers_utils.get_config",
+            return_value=draft_config,
+        ),
+    ):
+        _resolve_dflash_draft_attention_backend(server_args)
+    return server_args.speculative_draft_attention_backend
+
+
+def test_trtllm_rejected_for_a_non_causal_sliding_layer():
+    """trtllm's verify kernel is causal in-window, so a non-causal block is served
+    by expanding it into single-query rows that share one `cache_seqlens` -- one
+    window for the whole block, anchored at its last position. It is the pairing
+    that breaks, so a mixed draft is rejected on the strength of its sliding
+    layers alone."""
+    for layer_types in (
+        ["sliding_attention"] * 5,
+        ["full_attention", "sliding_attention", "full_attention"],
+    ):
+        assert _resolve(layer_types=layer_types, is_causal=False) != "trtllm_mha"
+
+
+def test_trtllm_kept_when_no_layer_is_both_sliding_and_non_causal():
+    """A window is only mis-anchored if the layer carrying it is non-causal. A
+    draft that leaves `is_causal` unset keeps its sliding layers on the causal
+    layer default (models/dflash.py:72-77), and a non-causal draft with no
+    sliding layer has no window for the expansion to get wrong."""
+    for layer_types, is_causal in (
+        (["sliding_attention"] * 5, True),
+        (["sliding_attention"] * 5, _UNSET),
+        (["full_attention", "sliding_attention", "full_attention"], _UNSET),
+        (["full_attention"] * 5, False),
+    ):
+        assert _resolve(layer_types=layer_types, is_causal=is_causal) == "trtllm_mha"
+
+
+if __name__ == "__main__":
+    import pytest
+
+    raise SystemExit(pytest.main([__file__]))


### PR DESCRIPTION
## Motivation

trtllm's spec-decode kernel is causal in-window. `TRTLLMHAAttnBackend` therefore
serves an `ENCODER_ONLY` layer by expanding the verify block into `bs*L`
single-query decode rows, and those rows share one `cache_seqlens`. A decode row
is understood to sit at the end of its sequence, so every query in the block is
placed at the block's last position and they all get the same window, too narrow
by up to `block_size - 1` keys for the earlier ones. Nothing errors.

Measured on B200 against masks computed in fp32 over the same q/k/v, the
multi-query verify call (`q_len_per_req = block`) matches a per-query window to
0.0012 in bf16, while the expanded path matches the anchored mask instead, which
sits 0.365 away. The probe needs `block < window < prefix` to separate them at
all -- at a shipped window of 2047 against a 16-token block the two masks differ
by at most 15 keys out of 2047, at the oldest end of the window, which is why
this went unnoticed.

The gate meant to prevent this admitted exactly that shape. It kept `trtllm_mha`
when the layers were *all* sliding **or** the draft was *all* causal, treating
all-sliding as a reason to permit; a published DFlash draft is all-sliding with
`is_causal: false`, so it took the one path the backend cannot represent.

## Modifications

Gate on the pairing that actually breaks -- a layer that both slides and is not
causal -- instead of on two whole-draft shapes.

`is_causal` is three-valued to the model, so the check reads it that way. An
absent key leaves a sliding layer on `AttentionType.DECODER` and a full-attention
layer on `ENCODER_ONLY` (`models/dflash.py:72-77`); only an explicit `false`
builds a windowed layer the backend cannot represent. A draft that never declares
`is_causal` is unaffected.

The `all_sliding` clause is dropped rather than kept alongside. It was never
load-bearing even for the draft it was written for, which declares no `is_causal`
and so passes on causality alone. What the clause added was permission for
all-sliding drafts that *are* non-causal, which is the one shape that breaks.

## Accuracy Tests

Dropping `all_sliding` widens the gate: drafts with mixed `layer_types`, and
drafts with no sliding layer at all, were turned away before and are admitted
now. That covers most published DFlash drafts, so the check is that they are
served correctly rather than merely allowed.

`z-lab/gemma4-12B-it-DFlash` on `google/gemma-4-12b-it` is one of them: its
sliding layers come out causal and its full-attention layer non-causal, so a
window is in play on the path this PR admits. On B200 over 24 gsm8k prompts at
T=0 it reaches **accept 6.520 on `trtllm_mha` against 6.570 on triton**, both
arms in one container, with the served backend class read off the draft runner
so the trtllm arm cannot quietly be something else. It is run unmodified -- no
forced window and no forced causality, since a draft served under a mask it was
not trained for measures the code paths rather than the deployment.

A draft with no sliding layer is the other newly admitted shape. It has no
window for the expansion to anchor wrongly, which is the whole of the argument
there.

Outputs change only for a draft that declares `is_causal: false` and slides; it
now runs on the fallback backend instead of a mask trtllm cannot express.

`test_dflash_backend_resolution.py` fails on both tests with the previous gate
restored, once in each direction: it admitted a non-causal sliding draft, and it
turned away drafts that measure correct here.

## A caveat this PR does not address

`trtllm_mha` dispatches to two kernels: trtllm-gen on sm100, and the xqa impl on
sm90/sm120 (`trtllm_mha_backend.py:218`). Everything above is sm100. On sm90
DFlash does not work on this backend at all and nothing rejects it: a causal
draft dies in `flashinfer/xqa.py:417` (`Mask is required for speculative
decoding`, and DFlash's verify carries no custom mask), while a non-causal one
starts, serves fluent text, and drops from accept 8.04 to 1.42.

Widening the gate increases the exposure, since the drafts it newly admits are
the ones the old whitelist happened to keep away. An sm100 condition belongs
next to this one; I am happy to fold it in here if you would rather not land the
widening without it.

## Speed Tests and Profiling

None. The gate runs once during argument resolution.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
