### PR TITLE
docs: add website link to README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 --------------------------------------------------------------------------------
 
 <p align="center">
+<a href="https://www.sglang.io/"><b>🌐 Website</b></a> |
 <a href="https://lmsys.org/blog/"><b>Blog</b></a> |
 <a href="https://docs.sglang.io/"><b>Documentation</b></a> |
 <a href="https://roadmap.sglang.io/"><b>Roadmap</b></a> |


### PR DESCRIPTION
Adds www.sglang.io to the README's header nav. The README currently links the slack/roadmap/meet/docs subdomains but never the main website, which also hurts its search ranking — people googling SGLang can't find the official site.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32075518706](https://github.com/sgl-project/sglang/actions/runs/32075518706)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32075518551](https://github.com/sgl-project/sglang/actions/runs/32075518551)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->