### PR TITLE
model: InternVL fixes for concurrent multimodal on Intel XPU

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1135,6 +1135,9 @@ class Envs:
     # Multimodal processing
     # ===================================================================
     SGLANG_VLM_CACHE_SIZE_MB = EnvInt(100)
+    # XPU: cap tiles per InternVL ViT forward; batching many at tp>1 crashes
+    # Level Zero. 0 = off.
+    SGLANG_VIT_MAX_TILES = EnvInt(12)
     SGLANG_IMAGE_MAX_PIXELS = EnvInt(16384 * 28 * 28)
     SGLANG_RESIZE_RESAMPLE = EnvStr("")
     SGLANG_MM_BUFFER_SIZE_MB = EnvInt(0)

--- a/python/sglang/srt/layers/attention/vision.py
+++ b/python/sglang/srt/layers/attention/vision.py
@@ -969,6 +969,7 @@ class VisionIntelXPUAttention(nn.Module):
         bsz: int,
         seq_len: int,
         softmax_scale: Optional[float] = None,
+        forward_metadata: Optional[VisionAttentionMetadata] = None,
         **kwargs,
     ) -> torch.Tensor:
         r"""
@@ -980,10 +981,15 @@ class VisionIntelXPUAttention(nn.Module):
         window_size = kwargs.get("window_size", (-1, -1))
         s_aux = kwargs.get("s_aux", None)
 
-        cu_seqlens_source = cu_seqlens
-        cu_seqlens = resolve_seqlens(cu_seqlens_source, bsz, seq_len, device=q.device)
-        cu_seqlens = cu_seqlens.to(dtype=torch.int32).to(q.device)
-        max_seqlen = resolve_max_seqlen(cu_seqlens_source, cu_seqlens)
+        if forward_metadata is not None:
+            cu_seqlens = forward_metadata.cu_seqlens
+            max_seqlen = forward_metadata.max_seqlen
+        else:
+            cu_seqlens = resolve_seqlens(cu_seqlens, bsz, seq_len, device=q.device)
+            cu_seqlens = cu_seqlens.to(dtype=torch.int32).to(q.device)
+            max_seqlen = resolve_precomputed_max_seqlen(
+                cu_seqlens, kwargs.get("max_seqlen")
+            )
 
         fa_kwargs = dict(
             cu_seqlens_q=cu_seqlens,

--- a/python/sglang/srt/models/internvl.py
+++ b/python/sglang/srt/models/internvl.py
@@ -47,10 +47,11 @@ from sglang.srt.multimodal.internvl_vit_cuda_graph_runner import (
 )
 from sglang.srt.multimodal.mm_utils import run_dp_sharded_vision_model
 from sglang.srt.runtime_context import get_mm, get_parallel
-from sglang.srt.utils import is_cuda
+from sglang.srt.utils import is_cuda, is_xpu
 from sglang.utils import logger
 
 _is_cuda = is_cuda()
+_is_xpu = is_xpu()
 
 
 class InternAttention(nn.Module):
@@ -372,15 +373,17 @@ class InternVisionEncoder(nn.Module):
         encoder_states = () if output_hidden_states else None
         hidden_states = inputs_embeds
 
+        vision_max_seqlen = None
         if cu_seqlens is None:
             bsz, seq_len, _ = inputs_embeds.shape
             cu_seqlens = _get_cu_seqlens_for_shape(
                 bsz, seq_len, device=inputs_embeds.device
             )
+            vision_max_seqlen = seq_len
         forward_metadata = None
         if isinstance(cu_seqlens, torch.Tensor):
             forward_metadata = prepare_vision_attention_metadata(
-                cu_seqlens, device=inputs_embeds.device
+                cu_seqlens, device=inputs_embeds.device, max_seqlen=vision_max_seqlen
             )
         elif cu_seqlens is None:
             cu_seqlens = SingletonCache()
@@ -642,7 +645,19 @@ class InternVLChatModel(nn.Module):
         # Normal pixel_values are 4D [N, C, H, W]; precomputed embeddings are 2D or 3D.
         if pixel_values.dim() != 4:
             return pixel_values
-        image_features = self.extract_feature(pixel_values)
+        # XPU: too many tiles in one ViT forward crashes Level Zero at tp>1;
+        # chunk (tiles are independent, so concat is bit-exact).
+        max_tiles = envs.SGLANG_VIT_MAX_TILES.get()
+        if _is_xpu and max_tiles > 0 and pixel_values.shape[0] > max_tiles:
+            image_features = torch.cat(
+                [
+                    self.extract_feature(pixel_values[i : i + max_tiles])
+                    for i in range(0, pixel_values.shape[0], max_tiles)
+                ],
+                dim=0,
+            )
+        else:
+            image_features = self.extract_feature(pixel_values)
         return image_features
 
     def get_video_feature(self, items: List[MultimodalDataItem]):
@@ -716,7 +731,7 @@ class InternVLChatModel(nn.Module):
                 ckpt_gate_proj_name="gate_proj",
                 ckpt_down_proj_name="down_proj",
                 ckpt_up_proj_name="up_proj",
-                num_experts=self.config.num_experts,
+                num_experts=self.config.llm_config.num_experts,
             )
         elif "Qwen3ForCausalLM" in self.config.llm_config.architectures:
             stacked_params_mapping = [


### PR DESCRIPTION
## Motivation

Serving InternVL3_5 MoE models (e.g. `OpenGVLab/InternVL3_5-30B-A3B`) on Intel
XPU fails in two ways:

1. **Weight loading crashes** with
   `AttributeError: 'InternVLChatConfig' object has no attribute 'num_experts'`.
   The MoE expert mapping reads `config.num_experts`, but InternVL nests the LLM
   config — `num_experts` lives on `config.llm_config` (the Qwen3-MoE backbone,
   `num_experts=128`).
2. **The vision encoder hangs/crashes under concurrent multimodal at tp>1.**
   The XPU vision attention derives `max_seqlen` from GPU `cu_seqlens` in every
   block, and that device->host `.item()` deadlocks the Level Zero USM memcpy;
   separately, batching more than one request's ViT tiles into a single forward
   crashes Level Zero (DEVICE_LOST / OUT_OF_RESOURCES).

(Baseline: P1 build #4722.)

## Modifications

- `models/internvl.py`: read `num_experts` from `config.llm_config`.
- `layers/attention/vision.py`: let `VisionIntelXPUAttention.forward` accept and
  use `VisionAttentionMetadata` — it already exists upstream and is threaded into
  the vision encoder, but the XPU attention path still re-derived `max_seqlen`
  from GPU `cu_seqlens` every block. Reusing the host-side value skips that sync.
- `models/internvl.py`: pass the host-side `max_seqlen` (uniform ViT tiles) into
  `prepare_vision_attention_metadata` so the value above is available.
- `models/internvl.py` + `environ.py`: chunk the ViT forward to
  `SGLANG_VIT_MAX_TILES` (default 12) tiles on XPU; tiles are independent, so
  chunk-and-concat is bit-exact. All XPU paths are guarded by `is_xpu()`.

## Accuracy Test

Verified on Intel XPU, tp-4 (4× Arc Pro B60, 61.7 GB bf16, ~14.43 GB/rank): loads
as `InternVLChatModel` with **0 skipped params**, MoE initialized
(`UnquantizedFusedMoEMethod`), KV cache allocated; multimodal smoke via
`/v1/chat/completions` (red image + "What color is this image?" -> "Red").

P1 accuracy (lmms-eval, tp-4, build #4838): **mathvision_testmini 38.2**,
**mmmu_val 27.4**.

(Numbers are from the pre-rebase branch. After rebasing onto current main, an
earlier `mm_schedule` mask-readback workaround was dropped as superseded —
upstream now counts mm tokens from host offsets — and the vision fix was
re-expressed on upstream's `VisionAttentionMetadata` path.)

## Speed Test and Profiling

Not separately profiled. On XPU this removes a per-block device->host sync in the
vision attention path and bounds the ViT forward size; non-XPU paths are unchanged
(guarded by `is_xpu()`), so no regression is expected there.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32077622528](https://github.com/sgl-project/sglang/actions/runs/32077622528)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32077622043](https://github.com/sgl-project/sglang/actions/runs/32077622043)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->