### PR TITLE
model: support encoder embedding models on Intel XPU (bge / NomicBERT / ModernBERT)

### DIFF
--- a/python/sglang/srt/layers/attention/xpu_backend.py
+++ b/python/sglang/srt/layers/attention/xpu_backend.py
@@ -12,6 +12,7 @@ from sglang.srt.layers.attention.flashattention_backend import (
     merge_state_v2_wrapper,
     prepare_swa_spec_page_table_triton,
 )
+from sglang.srt.layers.radix_attention import AttentionType
 from sglang.srt.mem_cache.memory_pool import KVWriteLoc
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
@@ -501,7 +502,11 @@ class XPUAttentionBackend(AttentionBackend):
         #     q = q.to(self.kv_cache_dtype)
         #     q_rope = q_rope.to(self.kv_cache_dtype) if q_rope is not None else None
         #     k_rope = k_rope.to(self.kv_cache_dtype) if k_rope is not None else None
-        causal = not layer.is_cross_attention
+        causal = not (
+            layer.is_cross_attention
+            or layer.attn_type
+            in (AttentionType.ENCODER_ONLY, AttentionType.DECODER_BIDIRECTIONAL)
+        )
 
         # Check if we should use local attention
         use_local_attn = (
@@ -824,7 +829,11 @@ class XPUAttentionBackend(AttentionBackend):
             if layer.sliding_window_size is not None and layer.sliding_window_size > -1
             else (-1, -1)
         )
-        causal = not layer.is_cross_attention
+        causal = not (
+            layer.is_cross_attention
+            or layer.attn_type
+            in (AttentionType.ENCODER_ONLY, AttentionType.DECODER_BIDIRECTIONAL)
+        )
 
         # For fa3 interface version compatibility, we put new fields into conditional keyword args
         kwargs = {}

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -874,6 +874,14 @@ class Scheduler(
                     reasoning_parser.detector.think_end_token,
                 )
 
+        # Encoder embeddings depend on the trailing separator token; preserve it
+        # when auto-truncating instead of head-slicing it off (embedding-only).
+        self._embedding_preserve_last_token_id = None
+        if not self.is_generation and self.tokenizer is not None:
+            self._embedding_preserve_last_token_id = getattr(
+                self.tokenizer, "sep_token_id", None
+            )
+
     def init_mamba_backend(self) -> None:
         if initialize_mamba_selective_state_update_backend is not None:
             initialize_mamba_selective_state_update_backend(self.server_args)
@@ -2609,6 +2617,7 @@ class Scheduler(
             req,
             self.max_req_input_len,
             get_serving().allow_auto_truncate,
+            self._embedding_preserve_last_token_id,
         )
         if error_msg:
             req.set_finish_with_abort(error_msg)
@@ -2905,6 +2914,7 @@ class Scheduler(
             req,
             self.max_req_input_len,
             get_serving().allow_auto_truncate,
+            self._embedding_preserve_last_token_id,
         )
         if error_msg:
             self._add_request_to_queue(req)

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1203,6 +1203,12 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                     "Truncating the input."
                 )
                 del input_ids[_max_req_len:]
+                # Encoder embeddings depend on the trailing separator; re-append
+                # it after head-truncation (embedding-only).
+                if not self.is_generation and self.tokenizer is not None:
+                    sep_id = getattr(self.tokenizer, "sep_token_id", None)
+                    if sep_id is not None and input_ids and input_ids[-1] != sep_id:
+                        input_ids[-1] = sep_id
                 input_token_num = len(input_ids)
             else:
                 raise ValueError(

--- a/python/sglang/srt/managers/utils.py
+++ b/python/sglang/srt/managers/utils.py
@@ -191,7 +191,10 @@ class GenerationBatchResult:
 
 
 def validate_input_length(
-    req: Req, max_req_input_len: int, allow_auto_truncate: bool
+    req: Req,
+    max_req_input_len: int,
+    allow_auto_truncate: bool,
+    preserve_last_token_id: Optional[int] = None,
 ) -> Optional[str]:
     """Validate and potentially truncate input length.
 
@@ -199,6 +202,12 @@ def validate_input_length(
         req: The request containing input_ids to validate
         max_req_input_len: Maximum allowed input length
         allow_auto_truncate: Whether to truncate long inputs
+        preserve_last_token_id: If set and the input ends with this token id
+            (e.g. a BERT ``[SEP]``), keep it as the final token after
+            truncation. Encoder embedding models that pool over / rely on the
+            trailing special token need it preserved; a plain head-slice would
+            drop it and change the pooled embedding. Left as ``None`` for
+            generation models, whose trailing tokens carry no such role.
 
     Returns:
         Error message if validation fails, None if successful
@@ -210,7 +219,15 @@ def validate_input_length(
                 "the max context length. Truncated. "
                 f"{len(req.origin_input_ids)=}, {max_req_input_len=}."
             )
-            req.origin_input_ids = req.origin_input_ids[:max_req_input_len]
+            truncated = req.origin_input_ids[:max_req_input_len]
+            if (
+                preserve_last_token_id is not None
+                and req.origin_input_ids[-1] == preserve_last_token_id
+                and truncated
+                and truncated[-1] != preserve_last_token_id
+            ):
+                truncated[-1] = preserve_last_token_id
+            req.origin_input_ids = truncated
             return None
         else:
             error_msg = (

--- a/python/sglang/srt/models/modernbert.py
+++ b/python/sglang/srt/models/modernbert.py
@@ -1,0 +1,289 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Inference-only ModernBERT model (encoder-only, embedding).
+
+ModernBERT (https://arxiv.org/abs/2412.13663) is a modern encoder with rotary
+position embeddings, alternating local (sliding-window) / global attention,
+pre-norm blocks and a GeGLU MLP. This implementation targets the embedding use
+case (e.g. ``ibm-granite/granite-embedding-english-r2``).
+
+Attention is computed in-model with ``F.scaled_dot_product_attention`` rather
+than through ``RadixAttention``: ModernBERT is bidirectional with a *symmetric*
+sliding window and keeps no autoregressive KV cache, neither of which the paged
+decoder attention backends express (the intel_xpu backend in particular forces
+``causal`` and ignores ``AttentionType.ENCODER_ONLY``). Several other encoders in
+SGLang (whisper, pixtral, ...) take the same in-model SDPA approach. RoPE reuses
+the shared ``get_rope`` factory (two instances, one per attention theta).
+"""
+
+from typing import Iterable, Optional, Set, Tuple
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+from transformers import PretrainedConfig
+
+from sglang.srt.layers.pooler import EmbeddingPoolerOutput, Pooler, PoolingType
+from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.layers.rotary_embedding import get_rope
+from sglang.srt.layers.vocab_parallel_embedding import VocabParallelEmbedding
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_loader.weight_utils import default_weight_loader
+
+
+def _rope_thetas(config: PretrainedConfig) -> Tuple[float, float]:
+    """Return (global_theta, local_theta), robust to transformers versions.
+
+    Newer transformers normalizes to ``rope_parameters`` keyed by
+    ``full_attention`` / ``sliding_attention``; older configs expose flat
+    ``global_rope_theta`` / ``local_rope_theta``.
+    """
+    rope_parameters = getattr(config, "rope_parameters", None)
+    if rope_parameters is not None:
+        return (
+            float(rope_parameters["full_attention"]["rope_theta"]),
+            float(rope_parameters["sliding_attention"]["rope_theta"]),
+        )
+    return float(config.global_rope_theta), float(config.local_rope_theta)
+
+
+class ModernBertEmbeddings(nn.Module):
+    def __init__(self, config: PretrainedConfig):
+        super().__init__()
+        self.tok_embeddings = VocabParallelEmbedding(
+            config.vocab_size, config.hidden_size, enable_tp=False
+        )
+        self.norm = nn.LayerNorm(
+            config.hidden_size, eps=config.norm_eps, bias=config.norm_bias
+        )
+
+    def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.norm(self.tok_embeddings(input_ids))
+
+
+class ModernBertMLP(nn.Module):
+    """GeGLU MLP: Wi projects to 2*intermediate, split into (input, gate)."""
+
+    def __init__(self, config: PretrainedConfig):
+        super().__init__()
+        self.Wi = nn.Linear(
+            config.hidden_size, int(config.intermediate_size) * 2, bias=config.mlp_bias
+        )
+        self.act = nn.GELU()
+        self.Wo = nn.Linear(
+            config.intermediate_size, config.hidden_size, bias=config.mlp_bias
+        )
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        inp, gate = self.Wi(hidden_states).chunk(2, dim=-1)
+        return self.Wo(self.act(inp) * gate)
+
+
+class ModernBertAttention(nn.Module):
+    def __init__(self, config: PretrainedConfig, layer_idx: int):
+        super().__init__()
+        self.num_heads = config.num_attention_heads
+        self.head_dim = config.hidden_size // config.num_attention_heads
+        self.Wqkv = nn.Linear(
+            config.hidden_size,
+            3 * self.head_dim * self.num_heads,
+            bias=config.attention_bias,
+        )
+        self.Wo = nn.Linear(
+            config.hidden_size, config.hidden_size, bias=config.attention_bias
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        positions: torch.Tensor,
+        rotary_emb: nn.Module,
+        attn_mask: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        # hidden_states: (seq, hidden) for a single sequence; rotary_emb is the
+        # shared global/local get_rope instance.
+        seq_len = hidden_states.shape[0]
+        qkv = self.Wqkv(hidden_states)
+        qkv = qkv.view(seq_len, 3, self.num_heads * self.head_dim)
+        q, k, v = qkv.unbind(dim=1)  # each (seq, heads * head_dim)
+
+        # get_rope applies RoPE in-place on the (seq, heads*head_dim) layout.
+        q, k = rotary_emb(positions, q, k)
+
+        # SDPA expects (batch, heads, seq, head_dim); reshape from (seq, heads*hd).
+        q = q.view(seq_len, self.num_heads, self.head_dim).transpose(0, 1)
+        k = k.view(seq_len, self.num_heads, self.head_dim).transpose(0, 1)
+        v = v.view(seq_len, self.num_heads, self.head_dim).transpose(0, 1)
+
+        # mask is a bool keep-mask (1,1,seq,seq) or None.
+        out = F.scaled_dot_product_attention(
+            q.unsqueeze(0),
+            k.unsqueeze(0),
+            v.unsqueeze(0),
+            attn_mask=attn_mask,
+            scale=self.head_dim**-0.5,
+        )
+        out = out.squeeze(0).transpose(0, 1).reshape(seq_len, -1)
+        return self.Wo(out)
+
+
+class ModernBertLayer(nn.Module):
+    def __init__(self, config: PretrainedConfig, layer_idx: int):
+        super().__init__()
+        # Layer 0 has no attn_norm (embeddings.norm already pre-normalizes).
+        if layer_idx == 0:
+            self.attn_norm = nn.Identity()
+        else:
+            self.attn_norm = nn.LayerNorm(
+                config.hidden_size, eps=config.norm_eps, bias=config.norm_bias
+            )
+        self.attn = ModernBertAttention(config, layer_idx)
+        self.mlp_norm = nn.LayerNorm(
+            config.hidden_size, eps=config.norm_eps, bias=config.norm_bias
+        )
+        self.mlp = ModernBertMLP(config)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        positions: torch.Tensor,
+        rotary_emb: nn.Module,
+        attn_mask: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        hidden_states = hidden_states + self.attn(
+            self.attn_norm(hidden_states), positions, rotary_emb, attn_mask
+        )
+        hidden_states = hidden_states + self.mlp(self.mlp_norm(hidden_states))
+        return hidden_states
+
+
+class ModernBertModel(nn.Module):
+    def __init__(
+        self,
+        *,
+        config: PretrainedConfig,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ):
+        super().__init__()
+        self.config = config
+        self.num_heads = config.num_attention_heads
+        self.head_dim = config.hidden_size // config.num_attention_heads
+
+        # Alternating attention: every ``global_attn_every_n_layers``-th layer is
+        # global (full bidirectional), the rest are local (symmetric window).
+        # ``layer_types`` (newer transformers) is authoritative when present.
+        layer_types = getattr(config, "layer_types", None)
+        if layer_types is not None:
+            self.is_global = [t == "full_attention" for t in layer_types]
+        else:
+            n = config.global_attn_every_n_layers
+            self.is_global = [i % n == 0 for i in range(config.num_hidden_layers)]
+
+        # Half-window each side. Newer configs expose ``sliding_window`` (already
+        # halved); older ones expose ``local_attention`` (the full window).
+        sliding_window = getattr(config, "sliding_window", None)
+        if sliding_window is not None:
+            self.local_window = sliding_window
+        else:
+            self.local_window = config.local_attention // 2
+
+        self.embeddings = ModernBertEmbeddings(config)
+        self.layers = nn.ModuleList(
+            [ModernBertLayer(config, i) for i in range(config.num_hidden_layers)]
+        )
+        self.final_norm = nn.LayerNorm(
+            config.hidden_size, eps=config.norm_eps, bias=config.norm_bias
+        )
+
+        # Two shared rotary embeddings (NeoX-style), one per attention theta.
+        global_theta, local_theta = _rope_thetas(config)
+        self.global_rotary = get_rope(
+            head_size=self.head_dim,
+            rotary_dim=self.head_dim,
+            max_position=config.max_position_embeddings,
+            base=global_theta,
+            is_neox_style=True,
+        )
+        self.local_rotary = get_rope(
+            head_size=self.head_dim,
+            rotary_dim=self.head_dim,
+            max_position=config.max_position_embeddings,
+            base=local_theta,
+            is_neox_style=True,
+        )
+
+        self.pooler = Pooler(pooling_type=PoolingType.MEAN, normalize=True)
+
+    def _local_mask(self, seq_len: int, device: torch.device) -> torch.Tensor:
+        # Symmetric sliding window: |i - j| <= local_window is allowed.
+        # Use a BOOLEAN mask (True = keep). The Intel XPU SDPA kernel silently
+        # ignores an additive float(-inf) attn_mask, but honors a bool mask.
+        idx = torch.arange(seq_len, device=device)
+        dist = (idx.unsqueeze(0) - idx.unsqueeze(1)).abs()
+        allowed = dist <= self.local_window
+        return allowed.view(1, 1, seq_len, seq_len)
+
+    def _encode_one(
+        self, hidden_states: torch.Tensor, positions: torch.Tensor
+    ) -> torch.Tensor:
+        seq_len = hidden_states.shape[0]
+        device = hidden_states.device
+
+        local_mask = self._local_mask(seq_len, device)
+
+        for i, layer in enumerate(self.layers):
+            if self.is_global[i]:
+                # Global layers are full bidirectional attention (no mask).
+                hidden_states = layer(
+                    hidden_states, positions, self.global_rotary, None
+                )
+            else:
+                hidden_states = layer(
+                    hidden_states, positions, self.local_rotary, local_mask
+                )
+        return hidden_states
+
+    @torch.no_grad()
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_embeds: torch.Tensor = None,
+        get_embedding: bool = False,
+    ) -> EmbeddingPoolerOutput:
+        assert get_embedding, "ModernBertModel only supports embedding"
+
+        hidden_states = self.embeddings(input_ids)
+
+        # Tokens for all requests are flattened into one stream; slice per
+        # request (each is an independent encoder pass with its own mask).
+        seq_lens = forward_batch.extend_seq_lens_cpu
+        outputs = []
+        start = 0
+        for seq_len in seq_lens:
+            end = start + seq_len
+            outputs.append(
+                self._encode_one(hidden_states[start:end], positions[start:end])
+            )
+            start = end
+        hidden_states = torch.cat(outputs, dim=0)
+
+        hidden_states = self.final_norm(hidden_states)
+        return self.pooler(hidden_states, forward_batch)
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> Set[str]:
+        params_dict = dict(self.named_parameters())
+        loaded: Set[str] = set()
+        for name, loaded_weight in weights:
+            if name not in params_dict:
+                # Encoder-only embedding model: skip any MLM head / unused tensors.
+                continue
+            param = params_dict[name]
+            weight_loader = getattr(param, "weight_loader", default_weight_loader)
+            weight_loader(param, loaded_weight)
+            loaded.add(name)
+        return loaded
+
+
+EntryClass = [ModernBertModel]

--- a/python/sglang/srt/models/nomic_bert.py
+++ b/python/sglang/srt/models/nomic_bert.py
@@ -1,0 +1,209 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Inference-only NomicBERT model (encoder-only, embedding).
+
+`nomic-ai/nomic-embed-text-v1.5` (arch ``NomicBertModel``, ``model_type:
+nomic_bert``) is a BERT-style bidirectional encoder with rotary position
+embeddings, a SwiGLU gated MLP and post-norm blocks, mean-pooled for embeddings.
+
+Attention is computed in-model with ``F.scaled_dot_product_attention`` (no KV
+cache, bidirectional), matching the approach used by ``modernbert.py`` and other
+SGLang encoders; RoPE reuses the shared ``get_rope`` factory. The stock server
+otherwise falls back to the generic Transformers wrapper, which raises
+``NotImplementedError: get_input_embeddings not auto-handled for NomicBertModel``.
+"""
+
+from typing import Iterable, Optional, Set, Tuple
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+from transformers import PretrainedConfig
+
+from sglang.srt.layers.pooler import EmbeddingPoolerOutput, Pooler, PoolingType
+from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.layers.rotary_embedding import get_rope
+from sglang.srt.layers.vocab_parallel_embedding import VocabParallelEmbedding
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_loader.weight_utils import default_weight_loader
+
+
+class NomicBertEmbeddings(nn.Module):
+    def __init__(self, config: PretrainedConfig):
+        super().__init__()
+        self.word_embeddings = VocabParallelEmbedding(
+            config.vocab_size, config.n_embd, enable_tp=False
+        )
+        self.token_type_embeddings = VocabParallelEmbedding(
+            config.type_vocab_size, config.n_embd, enable_tp=False
+        )
+        self.emb_ln = nn.LayerNorm(config.n_embd, eps=config.layer_norm_epsilon)
+
+    def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
+        # token_type_ids are all 0 for single-sequence embedding inputs.
+        embeds = self.word_embeddings(input_ids)
+        token_type = self.token_type_embeddings(
+            torch.zeros_like(input_ids, dtype=torch.long)
+        )
+        return self.emb_ln(embeds + token_type)
+
+
+class NomicBertGatedMLP(nn.Module):
+    """SwiGLU: fc2(fc11(x) * silu(fc12(x)))."""
+
+    def __init__(self, config: PretrainedConfig):
+        super().__init__()
+        self.fc11 = nn.Linear(config.n_embd, config.n_inner, bias=config.mlp_fc1_bias)
+        self.fc12 = nn.Linear(config.n_embd, config.n_inner, bias=config.mlp_fc1_bias)
+        self.fc2 = nn.Linear(config.n_inner, config.n_embd, bias=config.mlp_fc2_bias)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.fc2(self.fc11(x) * F.silu(self.fc12(x)))
+
+
+class NomicBertAttention(nn.Module):
+    def __init__(self, config: PretrainedConfig):
+        super().__init__()
+        self.num_heads = config.n_head
+        self.head_dim = config.n_embd // config.n_head
+        self.Wqkv = nn.Linear(
+            config.n_embd, 3 * config.n_embd, bias=config.qkv_proj_bias
+        )
+        self.out_proj = nn.Linear(
+            config.n_embd, config.n_embd, bias=config.qkv_proj_bias
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        positions: torch.Tensor,
+        rotary_emb: nn.Module,
+    ) -> torch.Tensor:
+        # hidden_states: (seq, hidden) for a single sequence (bidirectional, no mask).
+        seq_len = hidden_states.shape[0]
+        qkv = self.Wqkv(hidden_states)
+        q, k, v = qkv.chunk(3, dim=-1)  # each (seq, heads * head_dim)
+
+        # get_rope applies RoPE in-place on the (seq, heads*head_dim) layout.
+        q, k = rotary_emb(positions, q, k)
+
+        q = q.view(seq_len, self.num_heads, self.head_dim).transpose(0, 1)
+        k = k.view(seq_len, self.num_heads, self.head_dim).transpose(0, 1)
+        v = v.view(seq_len, self.num_heads, self.head_dim).transpose(0, 1)
+
+        out = F.scaled_dot_product_attention(
+            q.unsqueeze(0),
+            k.unsqueeze(0),
+            v.unsqueeze(0),
+            scale=self.head_dim**-0.5,
+        )
+        out = out.squeeze(0).transpose(0, 1).reshape(seq_len, -1)
+        return self.out_proj(out)
+
+
+class NomicBertLayer(nn.Module):
+    """Post-norm block: h = norm1(attn(h) + h); h = norm2(mlp(h) + h)."""
+
+    def __init__(self, config: PretrainedConfig):
+        super().__init__()
+        self.attn = NomicBertAttention(config)
+        self.mlp = NomicBertGatedMLP(config)
+        self.norm1 = nn.LayerNorm(config.n_embd, eps=config.layer_norm_epsilon)
+        self.norm2 = nn.LayerNorm(config.n_embd, eps=config.layer_norm_epsilon)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        positions: torch.Tensor,
+        rotary_emb: nn.Module,
+    ) -> torch.Tensor:
+        hidden_states = self.norm1(
+            self.attn(hidden_states, positions, rotary_emb) + hidden_states
+        )
+        hidden_states = self.norm2(self.mlp(hidden_states) + hidden_states)
+        return hidden_states
+
+
+class NomicBertModel(nn.Module):
+    def __init__(
+        self,
+        *,
+        config: PretrainedConfig,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ):
+        super().__init__()
+        self.config = config
+        self.head_dim = config.n_embd // config.n_head
+
+        self.embeddings = NomicBertEmbeddings(config)
+        self.layers = nn.ModuleList(
+            [NomicBertLayer(config) for _ in range(config.n_layer)]
+        )
+        self.rotary_emb = get_rope(
+            head_size=self.head_dim,
+            rotary_dim=self.head_dim,
+            max_position=config.max_position_embeddings,
+            base=int(config.rotary_emb_base),
+            is_neox_style=True,
+        )
+        self.pooler = Pooler(pooling_type=PoolingType.MEAN, normalize=True)
+
+    def _encode_one(
+        self, hidden_states: torch.Tensor, positions: torch.Tensor
+    ) -> torch.Tensor:
+        for layer in self.layers:
+            hidden_states = layer(hidden_states, positions, self.rotary_emb)
+        return hidden_states
+
+    @torch.no_grad()
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_embeds: torch.Tensor = None,
+        get_embedding: bool = False,
+    ) -> EmbeddingPoolerOutput:
+        assert get_embedding, "NomicBertModel only supports embedding"
+
+        hidden_states = self.embeddings(input_ids)
+
+        # Tokens for all requests are flattened into one stream; encode each
+        # request independently (bidirectional, per-request positions).
+        seq_lens = forward_batch.extend_seq_lens_cpu
+        outputs = []
+        start = 0
+        for seq_len in seq_lens:
+            end = start + seq_len
+            outputs.append(
+                self._encode_one(hidden_states[start:end], positions[start:end])
+            )
+            start = end
+        hidden_states = torch.cat(outputs, dim=0)
+
+        return self.pooler(hidden_states, forward_batch)
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> Set[str]:
+        # Checkpoint names -> module tree:
+        #   embeddings.word_embeddings / embeddings.token_type_embeddings -> as-is
+        #   emb_ln.* -> embeddings.emb_ln.*
+        #   encoder.layers.N.{attn.Wqkv, attn.out_proj, mlp.fc11/fc12/fc2,
+        #                     norm1, norm2} -> layers.N.*
+        params_dict = dict(self.named_parameters())
+        loaded: Set[str] = set()
+        for name, loaded_weight in weights:
+            if name.startswith("emb_ln."):
+                name = "embeddings." + name
+            elif name.startswith("encoder.layers."):
+                name = name[len("encoder.") :]
+            if name not in params_dict:
+                # Skip unused tensors (e.g. any MLM head).
+                continue
+            param = params_dict[name]
+            weight_loader = getattr(param, "weight_loader", default_weight_loader)
+            weight_loader(param, loaded_weight)
+            loaded.add(name)
+        return loaded
+
+
+EntryClass = [NomicBertModel]


### PR DESCRIPTION
Enables three encoder embedding models on the Intel XPU backend: `BAAI/bge-base-en-v1.5`,
`nomic-ai/nomic-embed-text-v1.5`, and `ibm-granite/granite-embedding-english-r2`.

## Motivation

- **bge-base-en-v1.5** (`BertModel`, already supported by `bert.py`) loads on XPU
  but returns wrong embeddings — SciFact scored 0, output cosine vs HuggingFace
  0.26-0.47. Two XPU-specific bugs in shared code affect every BERT/RoBERTa
  encoder on `intel_xpu`.
- **nomic-embed-text-v1.5** (`NomicBertModel`) had no SGLang implementation, so
  the Transformers fallback raised
  `NotImplementedError: get_input_embeddings not auto-handled for NomicBertModel`.
- **granite-embedding-english-r2** (`ModernBertModel`) also fell back and crashed
  in the forward pass (`RuntimeError` in `set_kv_buffer`) — the wrapper routed a
  bidirectional encoder through the paged decoder KV cache.

## Modifications

- `layers/attention/xpu_backend.py`: honor `AttentionType.ENCODER_ONLY` /
  `DECODER_BIDIRECTIONAL` — the prefill path used `causal = not is_cross_attention`
  and ran encoder layers with a causal mask. Now matches every other backend.
- `managers/{scheduler,tokenizer_manager,utils}.py`: preserve the trailing
  separator token when auto-truncating over-length embedding inputs (CLS/mean
  pooling depends on it). Gated on `not is_generation`, so generation is
  unaffected.
- `models/nomic_bert.py` (new): `NomicBertModel` — RoPE, SwiGLU MLP, post-norm
  blocks; mean pooling; in-model SDPA (no KV cache).
- `models/modernbert.py` (new): `ModernBertModel` — RoPE, alternating
  local/global attention, GeGLU MLP; mean pooling; in-model SDPA.

`bert.py` couldn't be reused for the two new models (it requires absolute,
non-RoPE positions). The two model files are additive; the shared bge fixes are
gated and leave decoder generation byte-for-byte unchanged.

## Accuracy Test

Intel XPU (Arc Pro B60, tp-size 1), vs the HuggingFace reference; MTEB SciFact
NDCG@10 (300 queries / 5183 corpus):

| Model | per-embedding cosine vs HF | SciFact NDCG@10 | HF ref |
|---|---|---|---|
| bge-base-en-v1.5 | 0.99997 (short); long docs 0.997-0.9999 after SEP fix | 0.6981 | 0.7387 |
| nomic-embed-text-v1.5 | 1.00000 | 0.6803 | (prefix-sensitive) |
| granite-embedding-r2 (ModernBERT) | 1.000000 fp32 / >=0.9999 bf16 | 0.6720 | 0.6815 |

All load with 0 skipped params. Residual gaps: bge — the scheduler's small
reserved-token margin on the 8% of docs >512 tokens; nomic — the harness omits
nomic's `search_query:`/`search_document:` retrieval prefixes; ModernBERT — bf16
execution-order noise.

## Speed Test and Profiling

No change to existing code paths. The bge causal fix flips a boolean for encoder
layers only and the truncation guard runs once per over-length embedding request;
the two new models are small encoders running attention in-model via SDPA (no
paged attention / KV cache). Decoder generation is unaffected.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32078514647](https://github.com/sgl-project/sglang/actions/runs/32078514647)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32078514463](https://github.com/sgl-project/sglang/actions/runs/32078514463)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->