### PR TITLE
[Constrained] Support MistralCommon tokenizers in the XGrammar backend

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -21,6 +21,21 @@ class ThinkingMode(str, Enum):
 import jinja2
 import orjson
 from fastapi import Request
+
+try:
+    from mistral_common.exceptions import MistralCommonException
+
+    _MISTRAL_COMMON_ERRORS: tuple[type[BaseException], ...] = (MistralCommonException,)
+except ImportError:  # mistral_common is optional in slimmed-down installs
+    _MISTRAL_COMMON_ERRORS = ()
+
+# Chat-template failures that describe a bad request rather than a server fault:
+# Jinja raise_exception, tojson on an Undefined, and mistral_common's conversation
+# validation (which rejects e.g. an assistant turn with empty content).
+_CHAT_TEMPLATE_CLIENT_ERRORS: tuple[type[BaseException], ...] = (
+    jinja2.TemplateError,
+    TypeError,
+) + _MISTRAL_COMMON_ERRORS
 from fastapi.responses import ORJSONResponse, StreamingResponse
 from jsonschema import Draft202012Validator, SchemaError
 
@@ -546,14 +561,21 @@ class OpenAIServingChat(OpenAIServingBase):
                 if request.tools
                 else None
             )
-            prompt_ids = self.tokenizer_manager.tokenizer.apply_chat_template(
-                messages,
-                tokenize=True,
-                add_generation_prompt=True,
-                tools=request_tools,
-                return_dict=False,
-                **template_kwargs,
-            )
+            try:
+                prompt_ids = self.tokenizer_manager.tokenizer.apply_chat_template(
+                    messages,
+                    tokenize=True,
+                    add_generation_prompt=True,
+                    tools=request_tools,
+                    return_dict=False,
+                    **template_kwargs,
+                )
+            except _CHAT_TEMPLATE_CLIENT_ERRORS as template_error:
+                # mistral_common validates conversation structure — it rejects an
+                # assistant turn with empty content, for instance. That is a bad
+                # request, not a server fault, so mirror the Jinja path and surface
+                # it as 400 rather than letting it escape as a 500.
+                raise ValueError(str(template_error)) from template_error
             if assistant_prefix:
                 prompt_ids = self._append_assistant_prefix_to_prompt_ids(
                     prompt_ids, assistant_prefix
@@ -1365,7 +1387,7 @@ class OpenAIServingChat(OpenAIServingBase):
                     prompt_ids = self.tokenizer_manager.tokenizer.encode(
                         rendered_prompt, **encode_kwargs
                     )
-                except (jinja2.TemplateError, TypeError) as template_error:
+                except _CHAT_TEMPLATE_CLIENT_ERRORS as template_error:
                     # Template errors (e.g., from raise_exception in Jinja templates)
                     # and TypeError (e.g., tojson filter on Jinja2 Undefined variables)
                     # should be treated as client errors (400 BadRequest)

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -26,12 +26,9 @@ try:
     from mistral_common.exceptions import MistralCommonException
 
     _MISTRAL_COMMON_ERRORS: tuple[type[BaseException], ...] = (MistralCommonException,)
-except ImportError:  # mistral_common is optional in slimmed-down installs
+except ImportError:
     _MISTRAL_COMMON_ERRORS = ()
 
-# Chat-template failures that describe a bad request rather than a server fault:
-# Jinja raise_exception, tojson on an Undefined, and mistral_common's conversation
-# validation (which rejects e.g. an assistant turn with empty content).
 _CHAT_TEMPLATE_CLIENT_ERRORS: tuple[type[BaseException], ...] = (
     jinja2.TemplateError,
     TypeError,
@@ -561,21 +558,14 @@ class OpenAIServingChat(OpenAIServingBase):
                 if request.tools
                 else None
             )
-            try:
-                prompt_ids = self.tokenizer_manager.tokenizer.apply_chat_template(
-                    messages,
-                    tokenize=True,
-                    add_generation_prompt=True,
-                    tools=request_tools,
-                    return_dict=False,
-                    **template_kwargs,
-                )
-            except _CHAT_TEMPLATE_CLIENT_ERRORS as template_error:
-                # mistral_common validates conversation structure — it rejects an
-                # assistant turn with empty content, for instance. That is a bad
-                # request, not a server fault, so mirror the Jinja path and surface
-                # it as 400 rather than letting it escape as a 500.
-                raise ValueError(str(template_error)) from template_error
+            prompt_ids = self.tokenizer_manager.tokenizer.apply_chat_template(
+                messages,
+                tokenize=True,
+                add_generation_prompt=True,
+                tools=request_tools,
+                return_dict=False,
+                **template_kwargs,
+            )
             if assistant_prefix:
                 prompt_ids = self._append_assistant_prefix_to_prompt_ids(
                     prompt_ids, assistant_prefix

--- a/python/sglang/srt/utils/hf_transformers/mistral_utils.py
+++ b/python/sglang/srt/utils/hf_transformers/mistral_utils.py
@@ -634,4 +634,58 @@ def patch_mistral_common_tokenizer(tokenizer):
         return tokenizer._orig_apply_chat_template(messages, **kwargs)
 
     tokenizer.apply_chat_template = _safe_apply_chat_template
+
+    def init_xgrammar():
+        """Build XGrammar's TokenizerInfo from the underlying Tekken vocabulary.
+
+        XGrammar's ``from_huggingface`` path cannot read this tokenizer: its
+        ``get_vocab()`` is keyed by decoded text, so byte-level pieces collide and
+        most ids come back as 0. The raw byte pieces are only reachable through the
+        inner Tekkenizer, so build the ordered vocabulary directly.
+        """
+        from xgrammar import TokenizerInfo
+
+        tekken = getattr(
+            getattr(tokenizer.tokenizer, "instruct_tokenizer", None), "tokenizer", None
+        )
+        if tekken is None or not hasattr(tekken, "id_to_byte_piece"):
+            logger.warning(
+                "Cannot build XGrammar TokenizerInfo: no Tekkenizer found under %s",
+                type(tokenizer).__name__,
+            )
+            return None, None
+
+        vocab_size = tekken._vocab_size
+        num_special = tekken.num_special_tokens
+        special_names = {
+            entry["rank"]: entry["token_str"] for entry in tekken._all_special_tokens
+        }
+
+        # XGrammar reads a b"\x00"-prefixed token as its own special marker, so any
+        # real byte piece starting with NUL has to be renamed out of the way.
+        placeholder = "<|xg_special_token_{}|>"
+        encoded_vocab = []
+        for token_id in range(vocab_size):
+            if token_id < num_special:
+                encoded_vocab.append(
+                    special_names.get(token_id, placeholder.format(token_id))
+                )
+                continue
+            piece = tekken.id_to_byte_piece(token_id)
+            if piece.startswith(b"\x00"):
+                piece = placeholder.format(f"nul{token_id}")
+            encoded_vocab.append(piece)
+
+        eos_token_id = getattr(tokenizer, "eos_token_id", None)
+        override_stop_tokens = [eos_token_id] if eos_token_id is not None else None
+        try:
+            tokenizer_info = TokenizerInfo(
+                encoded_vocab, stop_token_ids=override_stop_tokens
+            )
+        except Exception as e:
+            logger.warning("Failed to build XGrammar TokenizerInfo: %s", e)
+            return None, None
+        return tokenizer_info, override_stop_tokens
+
+    tokenizer.init_xgrammar = init_xgrammar
     return tokenizer

--- a/python/sglang/srt/utils/hf_transformers/mistral_utils.py
+++ b/python/sglang/srt/utils/hf_transformers/mistral_utils.py
@@ -636,13 +636,6 @@ def patch_mistral_common_tokenizer(tokenizer):
     tokenizer.apply_chat_template = _safe_apply_chat_template
 
     def init_xgrammar():
-        """Build XGrammar's TokenizerInfo from the underlying Tekken vocabulary.
-
-        XGrammar's ``from_huggingface`` path cannot read this tokenizer: its
-        ``get_vocab()`` is keyed by decoded text, so byte-level pieces collide and
-        most ids come back as 0. The raw byte pieces are only reachable through the
-        inner Tekkenizer, so build the ordered vocabulary directly.
-        """
         from xgrammar import TokenizerInfo
 
         tekken = getattr(
@@ -655,35 +648,31 @@ def patch_mistral_common_tokenizer(tokenizer):
             )
             return None, None
 
-        vocab_size = tekken._vocab_size
-        num_special = tekken.num_special_tokens
-        special_names = {
-            entry["rank"]: entry["token_str"] for entry in tekken._all_special_tokens
-        }
-
-        # XGrammar reads a b"\x00"-prefixed token as its own special marker, so any
-        # real byte piece starting with NUL has to be renamed out of the way.
-        placeholder = "<|xg_special_token_{}|>"
-        encoded_vocab = []
-        for token_id in range(vocab_size):
-            if token_id < num_special:
-                encoded_vocab.append(
-                    special_names.get(token_id, placeholder.format(token_id))
-                )
-                continue
-            piece = tekken.id_to_byte_piece(token_id)
-            if piece.startswith(b"\x00"):
-                piece = placeholder.format(f"nul{token_id}")
-            encoded_vocab.append(piece)
-
-        eos_token_id = getattr(tokenizer, "eos_token_id", None)
-        override_stop_tokens = [eos_token_id] if eos_token_id is not None else None
         try:
+            placeholder = "<|xg_special_token_{}|>"
+            encoded_vocab = []
+            for token_id in range(tekken.n_words):
+                piece = (
+                    tekken.id_to_piece(token_id)
+                    if token_id < tekken.num_special_tokens
+                    else tekken.id_to_byte_piece(token_id)
+                )
+                # XGrammar reserves b"\x00"-prefixed tokens as special markers.
+                if isinstance(piece, bytes) and piece.startswith(b"\x00"):
+                    piece = placeholder.format(f"nul{token_id}")
+                encoded_vocab.append(piece)
+
+            eos_token_id = getattr(tokenizer, "eos_token_id", None)
+            override_stop_tokens = [eos_token_id] if eos_token_id is not None else None
             tokenizer_info = TokenizerInfo(
                 encoded_vocab, stop_token_ids=override_stop_tokens
             )
         except Exception as e:
-            logger.warning("Failed to build XGrammar TokenizerInfo: %s", e)
+            logger.warning(
+                "Failed to build XGrammar TokenizerInfo for %s: %s",
+                type(tokenizer).__name__,
+                e,
+            )
             return None, None
         return tokenizer_info, override_stop_tokens
 

--- a/test/registered/unit/constrained/test_mistral_common_xgrammar.py
+++ b/test/registered/unit/constrained/test_mistral_common_xgrammar.py
@@ -1,0 +1,121 @@
+"""
+Unit tests for the XGrammar bridge attached to MistralCommon tokenizers.
+
+XGrammar's from_huggingface path cannot read a MistralCommon tokenizer, so
+patch_mistral_common_tokenizer attaches an init_xgrammar hook that builds
+TokenizerInfo from the inner Tekkenizer's raw byte pieces. These tests drive that
+hook with a stub Tekkenizer so they need no model download.
+
+Usage:
+    python -m pytest test_mistral_common_xgrammar.py -v
+"""
+
+import unittest
+
+from sglang.srt.utils.hf_transformers.mistral_utils import (
+    patch_mistral_common_tokenizer,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+VOCAB_SIZE = 300
+NUM_SPECIAL = 8
+
+
+class _StubTekkenizer:
+    """Minimal stand-in for mistral_common's Tekkenizer."""
+
+    def __init__(self, vocab_size=VOCAB_SIZE, num_special=NUM_SPECIAL):
+        self._vocab_size = vocab_size
+        self.num_special_tokens = num_special
+        self._all_special_tokens = [
+            {"rank": 0, "token_str": "<unk>", "is_control": True},
+            {"rank": 1, "token_str": "<s>", "is_control": True},
+            {"rank": 2, "token_str": "</s>", "is_control": True},
+        ]
+
+    def id_to_byte_piece(self, token_id, special_token_policy=None):
+        if token_id < self.num_special_tokens:
+            return b""
+        # id == num_special is the NUL byte-fallback token, mirroring real Tekken.
+        if token_id == self.num_special_tokens:
+            return b"\x00"
+        return bytes([token_id % 256])
+
+
+class _StubMistralTokenizer:
+    """Stands in for MistralCommonBackend: name must contain 'MistralCommon'."""
+
+    def __init__(self, tekken=None):
+        inner = type("InstructTokenizer", (), {"tokenizer": tekken})()
+        self.tokenizer = type("MistralTokenizer", (), {"instruct_tokenizer": inner})()
+        self.eos_token_id = 2
+        self.chat_template = "x"
+
+    def add_special_tokens(self, *args, **kwargs):
+        return 0
+
+    def convert_tokens_to_ids(self, val):
+        return 0
+
+    def decode(self, *args, **kwargs):
+        return ""
+
+    def batch_decode(self, *args, **kwargs):
+        return []
+
+    def apply_chat_template(self, *args, **kwargs):
+        return []
+
+
+class _MistralCommonStub(_StubMistralTokenizer):
+    pass
+
+
+class TestMistralCommonXGrammar(unittest.TestCase):
+    def _patched(self, tekken=None):
+        tok = _MistralCommonStub(tekken if tekken is not None else _StubTekkenizer())
+        return patch_mistral_common_tokenizer(tok)
+
+    def test_hook_is_attached(self):
+        """The patch must expose init_xgrammar so XGrammar takes the special path."""
+        self.assertTrue(hasattr(self._patched(), "init_xgrammar"))
+
+    def test_builds_tokenizer_info_over_full_vocab(self):
+        """TokenizerInfo must cover every id, not just the decodable ones."""
+        info, stop_tokens = self._patched().init_xgrammar()
+
+        self.assertIsNotNone(info)
+        self.assertEqual(info.vocab_size, VOCAB_SIZE)
+        self.assertEqual(stop_tokens, [2])
+
+    def test_json_schema_compiles_and_constrains(self):
+        """A compiled JSON grammar must allow '{' first and reject a letter."""
+        from xgrammar import GrammarCompiler, GrammarMatcher, allocate_token_bitmask
+
+        info, _ = self._patched().init_xgrammar()
+        grammar = GrammarCompiler(tokenizer_info=info).compile_json_schema(
+            '{"type":"object","properties":{"a":{"type":"integer"}},"required":["a"]}'
+        )
+        mask = allocate_token_bitmask(1, info.vocab_size)
+        GrammarMatcher(grammar).fill_next_token_bitmask(mask)
+
+        def allowed(token_id):
+            # XGrammar sets a bit when the token is permitted.
+            return bool((int(mask[0][token_id // 32]) >> (token_id % 32)) & 1)
+
+        # The stub maps id -> bytes([id % 256]), so a byte's token id is its ordinal.
+        self.assertTrue(allowed(ord("{")))
+        self.assertFalse(allowed(ord("z")))
+
+    def test_returns_none_without_a_tekkenizer(self):
+        """Missing inner tokenizer must degrade to the documented (None, None)."""
+        info, stop_tokens = self._patched(tekken=object()).init_xgrammar()
+
+        self.assertIsNone(info)
+        self.assertIsNone(stop_tokens)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/constrained/test_mistral_common_xgrammar.py
+++ b/test/registered/unit/constrained/test_mistral_common_xgrammar.py
@@ -1,16 +1,6 @@
-"""
-Unit tests for the XGrammar bridge attached to MistralCommon tokenizers.
+import sys
 
-XGrammar's from_huggingface path cannot read a MistralCommon tokenizer, so
-patch_mistral_common_tokenizer attaches an init_xgrammar hook that builds
-TokenizerInfo from the inner Tekkenizer's raw byte pieces. These tests drive that
-hook with a stub Tekkenizer so they need no model download.
-
-Usage:
-    python -m pytest test_mistral_common_xgrammar.py -v
-"""
-
-import unittest
+import pytest
 
 from sglang.srt.utils.hf_transformers.mistral_utils import (
     patch_mistral_common_tokenizer,
@@ -24,29 +14,28 @@ NUM_SPECIAL = 8
 
 
 class _StubTekkenizer:
-    """Minimal stand-in for mistral_common's Tekkenizer."""
-
-    def __init__(self, vocab_size=VOCAB_SIZE, num_special=NUM_SPECIAL):
-        self._vocab_size = vocab_size
+    def __init__(
+        self,
+        vocab_size=VOCAB_SIZE,
+        num_special=NUM_SPECIAL,
+        fail_on_byte_piece=False,
+    ):
+        self.n_words = vocab_size
         self.num_special_tokens = num_special
-        self._all_special_tokens = [
-            {"rank": 0, "token_str": "<unk>", "is_control": True},
-            {"rank": 1, "token_str": "<s>", "is_control": True},
-            {"rank": 2, "token_str": "</s>", "is_control": True},
-        ]
+        self.fail_on_byte_piece = fail_on_byte_piece
 
-    def id_to_byte_piece(self, token_id, special_token_policy=None):
-        if token_id < self.num_special_tokens:
-            return b""
-        # id == num_special is the NUL byte-fallback token, mirroring real Tekken.
+    def id_to_piece(self, token_id):
+        return f"<special_{token_id}>"
+
+    def id_to_byte_piece(self, token_id):
+        if self.fail_on_byte_piece:
+            raise RuntimeError("byte-piece conversion failed")
         if token_id == self.num_special_tokens:
             return b"\x00"
         return bytes([token_id % 256])
 
 
 class _StubMistralTokenizer:
-    """Stands in for MistralCommonBackend: name must contain 'MistralCommon'."""
-
     def __init__(self, tekken=None):
         inner = type("InstructTokenizer", (), {"tokenizer": tekken})()
         self.tokenizer = type("MistralTokenizer", (), {"instruct_tokenizer": inner})()
@@ -73,49 +62,51 @@ class _MistralCommonStub(_StubMistralTokenizer):
     pass
 
 
-class TestMistralCommonXGrammar(unittest.TestCase):
-    def _patched(self, tekken=None):
-        tok = _MistralCommonStub(tekken if tekken is not None else _StubTekkenizer())
-        return patch_mistral_common_tokenizer(tok)
+def _patched(tekken):
+    return patch_mistral_common_tokenizer(_MistralCommonStub(tekken))
 
-    def test_hook_is_attached(self):
-        """The patch must expose init_xgrammar so XGrammar takes the special path."""
-        self.assertTrue(hasattr(self._patched(), "init_xgrammar"))
 
-    def test_builds_tokenizer_info_over_full_vocab(self):
-        """TokenizerInfo must cover every id, not just the decodable ones."""
-        info, stop_tokens = self._patched().init_xgrammar()
+def _is_allowed(mask, token_id):
+    return bool((int(mask[0][token_id // 32]) >> (token_id % 32)) & 1)
 
-        self.assertIsNotNone(info)
-        self.assertEqual(info.vocab_size, VOCAB_SIZE)
-        self.assertEqual(stop_tokens, [2])
 
-    def test_json_schema_compiles_and_constrains(self):
-        """A compiled JSON grammar must allow '{' first and reject a letter."""
-        from xgrammar import GrammarCompiler, GrammarMatcher, allocate_token_bitmask
+def test_builds_tokenizer_info_over_full_vocab():
+    info, stop_tokens = _patched(_StubTekkenizer()).init_xgrammar()
 
-        info, _ = self._patched().init_xgrammar()
-        grammar = GrammarCompiler(tokenizer_info=info).compile_json_schema(
-            '{"type":"object","properties":{"a":{"type":"integer"}},"required":["a"]}'
-        )
-        mask = allocate_token_bitmask(1, info.vocab_size)
-        GrammarMatcher(grammar).fill_next_token_bitmask(mask)
+    assert info is not None
+    assert info.vocab_size == VOCAB_SIZE
+    assert stop_tokens == [2]
 
-        def allowed(token_id):
-            # XGrammar sets a bit when the token is permitted.
-            return bool((int(mask[0][token_id // 32]) >> (token_id % 32)) & 1)
 
-        # The stub maps id -> bytes([id % 256]), so a byte's token id is its ordinal.
-        self.assertTrue(allowed(ord("{")))
-        self.assertFalse(allowed(ord("z")))
+def test_json_schema_compiles_and_constrains():
+    from xgrammar import GrammarCompiler, GrammarMatcher, allocate_token_bitmask
 
-    def test_returns_none_without_a_tekkenizer(self):
-        """Missing inner tokenizer must degrade to the documented (None, None)."""
-        info, stop_tokens = self._patched(tekken=object()).init_xgrammar()
+    info, _ = _patched(_StubTekkenizer()).init_xgrammar()
+    grammar = GrammarCompiler(tokenizer_info=info).compile_json_schema(
+        '{"type":"object","properties":{"a":{"type":"integer"}},"required":["a"]}'
+    )
+    mask = allocate_token_bitmask(1, info.vocab_size)
+    GrammarMatcher(grammar).fill_next_token_bitmask(mask)
 
-        self.assertIsNone(info)
-        self.assertIsNone(stop_tokens)
+    assert _is_allowed(mask, ord("{"))
+    assert not _is_allowed(mask, ord("z"))
+
+
+def test_returns_none_without_a_tekkenizer():
+    info, stop_tokens = _patched(object()).init_xgrammar()
+
+    assert info is None
+    assert stop_tokens is None
+
+
+def test_returns_none_when_vocab_extraction_fails():
+    info, stop_tokens = _patched(
+        _StubTekkenizer(fail_on_byte_piece=True)
+    ).init_xgrammar()
+
+    assert info is None
+    assert stop_tokens is None
 
 
 if __name__ == "__main__":
-    unittest.main()
+    sys.exit(pytest.main([__file__]))


### PR DESCRIPTION
Serving a Mistral model whose tokenizer resolves to `MistralCommonBackend` disables structured output entirely. XGrammar cannot build `TokenizerInfo` from it, so we log a warning, fall back to `grammar_backend="none"`, and every `json_schema` / `regex` / `ebnf` request is rejected with a 400. Neither alternate backend helps: outlines fails to compile any schema on this vocabulary, and llguidance refuses a non-fast tokenizer outright.

The cause is that `MistralCommonBackend.get_vocab()` is keyed by decoded text, so byte-level pieces collide and most ids come back as 0 — 130044 usable entries for a 131072 vocabulary. The raw byte pieces are only reachable through the inner Tekkenizer, so `patch_mistral_common_tokenizer` now attaches the `init_xgrammar` hook that `xgrammar_backend.py` already looks for (the same escape hatch `tiktoken_tokenizer.py` uses) and builds the ordered vocabulary directly. mistral_common stays responsible for encoding and chat templating; only what the grammar backend sees changes.

The second commit is related but separable: mistral_common validates conversation structure and rejects, for example, an assistant turn with empty content. That escaped as a 500 even though the Jinja path already mapped equivalent template errors to 400, so both paths now share one tuple of client-error types.

Verified end to end on `Mistral-Medium-3.5-128B` (tp 4, `--tool-call-parser mistral --reasoning-parser mistral`): no fallback warning, `json_schema` returns 200 and is actually enforced (a prose-style prompt with a strict schema still yields conformant JSON), the empty-assistant request returns 400 instead of 500, and plain chat is unchanged.

One caveat for reviewers: the hook reads `_vocab_size`, `_all_special_tokens` and `id_to_byte_piece` from mistral_common's Tekkenizer, two of which are private. If a future release changes them, `init_xgrammar` returns `(None, None)` and today's graceful fallback resumes rather than crashing. That path is covered by a unit test.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32144736824](https://github.com/sgl-project/sglang/actions/runs/32144736824)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #32144736445](https://github.com/sgl-project/sglang/actions/runs/32144736445)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->