### PR TITLE
Responses API Codex compatibility: custom tools, namespace tools, agent_message, array tool output

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -22,6 +22,7 @@ from openai.types.responses import (
     ResponseOutputText,
     ResponseReasoningItem,
 )
+from openai.types.responses.response_custom_tool_call import ResponseCustomToolCall
 from openai.types.responses.response_function_tool_call import ResponseFunctionToolCall
 from openai.types.responses.response_output_text import Logprob, LogprobTopLogprob
 from openai.types.responses.response_reasoning_item import (
@@ -80,6 +81,12 @@ if TYPE_CHECKING:
     from sglang.srt.parser.template_manager import TemplateManager
 
 logger = logging.getLogger(__name__)
+
+# Custom (freeform) tools carry a raw string instead of JSON arguments. They
+# are exposed to the chat layer as a function with this single string
+# property, and the wrapper is stripped again when emitting
+# ``custom_tool_call`` output items.
+_CUSTOM_TOOL_ARG_KEY = "input"
 
 
 class _MediaInputValidationError(ValueError):
@@ -857,7 +864,8 @@ class OpenAIServingResponses(OpenAIServingChat):
             output_items.append(reasoning_item)
 
         is_required = request.tool_choice == "required"
-        tool_call_items: list[ResponseFunctionToolCall] = []
+        custom_tool_names = self._custom_tool_names(request)
+        tool_call_items: list[ResponseFunctionToolCall | ResponseCustomToolCall] = []
         parsed_via_native = False
         if (
             content
@@ -878,13 +886,10 @@ class OpenAIServingResponses(OpenAIServingChat):
                     content, call_info_list = parser.parse_non_stream(content)
                     for call_info in call_info_list:
                         tool_call_items.append(
-                            ResponseFunctionToolCall(
-                                arguments=call_info.parameters or "",
-                                call_id=f"call_{random_uuid()[:24]}",
-                                type="function_call",
-                                name=call_info.name,
-                                id=f"fc_{random_uuid()[:8]}",
-                                status="completed",
+                            self._build_tool_call_item(
+                                call_info.name,
+                                call_info.parameters or "",
+                                custom_tool_names,
                             )
                         )
                     parsed_via_native = bool(call_info_list)
@@ -904,13 +909,8 @@ class OpenAIServingResponses(OpenAIServingChat):
                             tool.get("parameters", {}), ensure_ascii=False
                         )
                         tool_call_items.append(
-                            ResponseFunctionToolCall(
-                                arguments=arguments,
-                                call_id=f"call_{random_uuid()[:24]}",
-                                type="function_call",
-                                name=tool["name"],
-                                id=f"fc_{random_uuid()[:8]}",
-                                status="completed",
+                            self._build_tool_call_item(
+                                tool["name"], arguments, custom_tool_names
                             )
                         )
                     content = ""
@@ -960,9 +960,36 @@ class OpenAIServingResponses(OpenAIServingChat):
 
     @staticmethod
     def _response_tools_to_chat_tools(request: ResponsesRequest) -> list[Tool]:
-        # Only ``function`` tools flow to chat; built-ins go through harmony.
+        # ``function`` tools flow to chat as-is; built-ins go through harmony.
+        # ``custom`` (freeform) tools have no JSON schema, so expose each one
+        # as a function taking a single string argument: the model can then
+        # call it through the ordinary JSON tool-call path (parsers and
+        # constrained decoding keep working), and the raw string round-trips
+        # through the {"input": ...} wrapper (unwrapped again when emitting
+        # ``custom_tool_call`` output items).
         chat_tools = []
         for tool in request.tools:
+            if tool.type == "custom":
+                chat_tools.append(
+                    Tool(
+                        type="function",
+                        function=Function(
+                            name=tool.name,
+                            description=tool.description,
+                            parameters={
+                                "type": "object",
+                                "properties": {
+                                    _CUSTOM_TOOL_ARG_KEY: {
+                                        "type": "string",
+                                        "description": "Freeform tool input.",
+                                    }
+                                },
+                                "required": [_CUSTOM_TOOL_ARG_KEY],
+                            },
+                        ),
+                    )
+                )
+                continue
             if tool.type != "function":
                 continue
             chat_tools.append(
@@ -977,6 +1004,54 @@ class OpenAIServingResponses(OpenAIServingChat):
                 )
             )
         return chat_tools
+
+    @staticmethod
+    def _custom_tool_names(request: ResponsesRequest) -> set[str]:
+        return {
+            tool.name
+            for tool in (request.tools or [])
+            if tool.type == "custom" and tool.name
+        }
+
+    @staticmethod
+    def _custom_tool_input_from_arguments(arguments: str) -> str:
+        """Unwrap the {"input": ...} JSON produced by the synthetic custom-tool
+        schema back into the freeform string; fall back to the raw arguments
+        for malformed or unexpected shapes."""
+        try:
+            parsed = orjson.loads(arguments) if arguments else None
+        except orjson.JSONDecodeError:
+            return arguments or ""
+        if isinstance(parsed, dict):
+            value = parsed.get(_CUSTOM_TOOL_ARG_KEY)
+            if isinstance(value, str):
+                return value
+        return arguments or ""
+
+    @classmethod
+    def _build_tool_call_item(
+        cls, name: str, arguments: str, custom_tool_names: set[str]
+    ):
+        """Build the Responses output item for one parsed tool call: a
+        ``custom_tool_call`` when the tool was declared ``custom``, else a
+        ``function_call``."""
+        if name in custom_tool_names:
+            return ResponseCustomToolCall(
+                input=cls._custom_tool_input_from_arguments(arguments),
+                call_id=f"call_{random_uuid()[:24]}",
+                type="custom_tool_call",
+                name=name,
+                id=f"ctc_{random_uuid()[:8]}",
+                status="completed",
+            )
+        return ResponseFunctionToolCall(
+            arguments=arguments,
+            call_id=f"call_{random_uuid()[:24]}",
+            type="function_call",
+            name=name,
+            id=f"fc_{random_uuid()[:8]}",
+            status="completed",
+        )
 
     @staticmethod
     def _normalize_response_content_part_for_chat(content_part: Any) -> Any:
@@ -1036,6 +1111,25 @@ class OpenAIServingResponses(OpenAIServingChat):
             message = {**message, "role": "system"}
 
         msg_type = message.get("type")
+        if msg_type == "custom_tool_call":
+            # Freeform (``custom``) tool input is a raw string; wrap it in the
+            # same {"input": ...} object used when declaring the tool so chat
+            # templates that json-parse tool-call arguments survive.
+            return {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": message.get("call_id") or message.get("id"),
+                        "type": "function",
+                        "function": {
+                            "name": message.get("name"),
+                            "arguments": orjson.dumps(
+                                {_CUSTOM_TOOL_ARG_KEY: message.get("input") or ""}
+                            ).decode("utf-8"),
+                        },
+                    }
+                ],
+            }
         if msg_type == "function_call":
             # Coerce ``arguments`` to a valid JSON-object string so the chat
             # template's unconditional ``orjson.loads`` survives truncated or
@@ -1065,7 +1159,7 @@ class OpenAIServingResponses(OpenAIServingChat):
                     }
                 ],
             }
-        if msg_type == "function_call_output":
+        if msg_type in ("function_call_output", "custom_tool_call_output"):
             # ``output`` may be a string or an array of content parts (OpenAI
             # allows both); the chat tool message needs a string, so flatten.
             out = message.get("output", "")
@@ -1998,6 +2092,7 @@ class OpenAIServingResponses(OpenAIServingChat):
             "text": "",
         }
         tool_call_states: dict[int, dict[str, Any]] = {}
+        custom_tool_names = self._custom_tool_names(request)
         # Items closed during the stream, in wire order. Feeds the final
         # ``response.completed`` snapshot and the stored response.
         emitted_items: list = []
@@ -2158,6 +2253,57 @@ class OpenAIServingResponses(OpenAIServingChat):
             if state is None or state.get("done"):
                 return []
             arguments = state["arguments"]
+            if state.get("is_custom"):
+                # Custom (freeform) tool: unwrap the buffered {"input": ...}
+                # JSON into the raw string. Arguments cannot be unwrapped
+                # incrementally (JSON string escaping), so the input streams
+                # as a single delta followed by done.
+                tool_input = self._custom_tool_input_from_arguments(arguments)
+                completed_item = ResponseCustomToolCall(
+                    input=tool_input,
+                    call_id=state["call_id"],
+                    name=state["name"] or "",
+                    type="custom_tool_call",
+                    id=state["item_id"],
+                    status="completed",
+                )
+                events = []
+                if tool_input:
+                    events.append(
+                        _send_event(
+                            openai_responses_types.ResponseCustomToolCallInputDeltaEvent(
+                                type="response.custom_tool_call_input.delta",
+                                sequence_number=-1,
+                                item_id=state["item_id"],
+                                output_index=state["output_index"],
+                                delta=tool_input,
+                            )
+                        )
+                    )
+                events.extend(
+                    [
+                        _send_event(
+                            openai_responses_types.ResponseCustomToolCallInputDoneEvent(
+                                type="response.custom_tool_call_input.done",
+                                sequence_number=-1,
+                                item_id=state["item_id"],
+                                output_index=state["output_index"],
+                                input=tool_input,
+                            )
+                        ),
+                        _send_event(
+                            openai_responses_types.ResponseOutputItemDoneEvent(
+                                type="response.output_item.done",
+                                sequence_number=-1,
+                                output_index=state["output_index"],
+                                item=completed_item,
+                            )
+                        ),
+                    ]
+                )
+                emitted_items.append(completed_item)
+                state["done"] = True
+                return events
             completed_item = ResponseFunctionToolCall(
                 arguments=arguments,
                 call_id=state["call_id"],
@@ -2335,7 +2481,12 @@ class OpenAIServingResponses(OpenAIServingChat):
                                     for ev in _close_tool_call_state(other_index):
                                         yield ev
                             current_output_index += 1
-                            item_id = f"fc_{random_uuid()[:8]}"
+                            is_custom = (call.name or "") in custom_tool_names
+                            item_id = (
+                                f"ctc_{random_uuid()[:8]}"
+                                if is_custom
+                                else f"fc_{random_uuid()[:8]}"
+                            )
                             call_id = f"call_{random_uuid()[:24]}"
                             state = {
                                 "item_id": item_id,
@@ -2343,38 +2494,54 @@ class OpenAIServingResponses(OpenAIServingChat):
                                 "output_index": current_output_index,
                                 "name": call.name or "",
                                 "arguments": "",
+                                "is_custom": is_custom,
                                 "added": False,
                                 "done": False,
                             }
                             tool_call_states[tool_index] = state
                         if not state["added"]:
                             state["added"] = True
+                            if state.get("is_custom"):
+                                added_item = ResponseCustomToolCall(
+                                    input="",
+                                    call_id=state["call_id"],
+                                    name=state["name"],
+                                    type="custom_tool_call",
+                                    id=state["item_id"],
+                                    status="in_progress",
+                                )
+                            else:
+                                added_item = ResponseFunctionToolCall(
+                                    arguments="",
+                                    call_id=state["call_id"],
+                                    name=state["name"],
+                                    type="function_call",
+                                    id=state["item_id"],
+                                    status="in_progress",
+                                )
                             yield _send_event(
                                 openai_responses_types.ResponseOutputItemAddedEvent(
                                     type="response.output_item.added",
                                     sequence_number=-1,
                                     output_index=state["output_index"],
-                                    item=ResponseFunctionToolCall(
-                                        arguments="",
-                                        call_id=state["call_id"],
-                                        name=state["name"],
-                                        type="function_call",
-                                        id=state["item_id"],
-                                        status="in_progress",
-                                    ),
+                                    item=added_item,
                                 )
                             )
                         if call.parameters:
+                            # Custom tools buffer the wrapped JSON and stream
+                            # the unwrapped input at close; the raw string
+                            # cannot be unwrapped incrementally.
                             state["arguments"] += call.parameters
-                            yield _send_event(
-                                openai_responses_types.ResponseFunctionCallArgumentsDeltaEvent(
-                                    type="response.function_call_arguments.delta",
-                                    sequence_number=-1,
-                                    item_id=state["item_id"],
-                                    output_index=state["output_index"],
-                                    delta=call.parameters,
+                            if not state.get("is_custom"):
+                                yield _send_event(
+                                    openai_responses_types.ResponseFunctionCallArgumentsDeltaEvent(
+                                        type="response.function_call_arguments.delta",
+                                        sequence_number=-1,
+                                        item_id=state["item_id"],
+                                        output_index=state["output_index"],
+                                        delta=call.parameters,
+                                    )
                                 )
-                            )
 
                 def _emit_normal_text():
                     if normal_text and _should_emit_normal_text_as_message(

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import re
 import time
 from contextlib import AsyncExitStack
 from http import HTTPStatus
@@ -865,6 +866,7 @@ class OpenAIServingResponses(OpenAIServingChat):
 
         is_required = request.tool_choice == "required"
         custom_tool_names = self._custom_tool_names(request)
+        namespace_names = self._namespace_names(request)
         tool_call_items: list[ResponseFunctionToolCall | ResponseCustomToolCall] = []
         parsed_via_native = False
         if (
@@ -890,6 +892,7 @@ class OpenAIServingResponses(OpenAIServingChat):
                                 call_info.name,
                                 call_info.parameters or "",
                                 custom_tool_names,
+                                namespace_names,
                             )
                         )
                     parsed_via_native = bool(call_info_list)
@@ -910,7 +913,10 @@ class OpenAIServingResponses(OpenAIServingChat):
                         )
                         tool_call_items.append(
                             self._build_tool_call_item(
-                                tool["name"], arguments, custom_tool_names
+                                tool["name"],
+                                arguments,
+                                custom_tool_names,
+                                namespace_names,
                             )
                         )
                     content = ""
@@ -990,6 +996,36 @@ class OpenAIServingResponses(OpenAIServingChat):
                     )
                 )
                 continue
+            if tool.type == "namespace":
+                # A namespace groups a family of function tools under one
+                # model-visible name. Flatten each inner tool to a function
+                # named ``f"{namespace}.{inner}"``; the emitted call item
+                # splits the pair back apart (see _split_namespaced_name).
+                # OpenAI defers inner schemas until tool search loads them;
+                # exposing them up front is a deliberate simplification that
+                # costs prompt tokens but keeps this a stateless translation.
+                if not tool.name:
+                    continue
+                for inner in tool.tools or []:
+                    if not isinstance(inner, dict):
+                        continue
+                    if inner.get("type", "function") != "function":
+                        continue
+                    inner_name = inner.get("name")
+                    if not inner_name:
+                        continue
+                    chat_tools.append(
+                        Tool(
+                            type="function",
+                            function=Function(
+                                name=f"{tool.name}.{inner_name}",
+                                description=inner.get("description")
+                                or tool.description,
+                                parameters=inner.get("parameters"),
+                            ),
+                        )
+                    )
+                continue
             if tool.type != "function":
                 continue
             chat_tools.append(
@@ -1014,6 +1050,33 @@ class OpenAIServingResponses(OpenAIServingChat):
         }
 
     @staticmethod
+    def _namespace_names(request: ResponsesRequest) -> set[str]:
+        return {
+            tool.name
+            for tool in (request.tools or [])
+            if tool.type == "namespace" and tool.name
+        }
+
+    @staticmethod
+    def _split_namespaced_name(
+        name: str, namespace_names: set[str]
+    ) -> tuple[str, Optional[str]]:
+        """Split a flattened ``namespace.tool`` chat name back into its parts.
+
+        Namespace tools are exposed to the model as functions named
+        ``f"{namespace}.{inner}"``; on emission the call item carries
+        ``name=inner`` plus a ``namespace`` field so clients (e.g. Codex)
+        can dispatch on the pair. Only prefixes that were actually declared
+        as namespaces split — an ordinary function whose name contains a dot
+        passes through untouched.
+        """
+        if "." in name:
+            prefix, _, suffix = name.partition(".")
+            if suffix and prefix in namespace_names:
+                return suffix, prefix
+        return name, None
+
+    @staticmethod
     def _custom_tool_input_from_arguments(arguments: str) -> str:
         """Unwrap the {"input": ...} JSON produced by the synthetic custom-tool
         schema back into the freeform string; fall back to the raw arguments
@@ -1030,11 +1093,16 @@ class OpenAIServingResponses(OpenAIServingChat):
 
     @classmethod
     def _build_tool_call_item(
-        cls, name: str, arguments: str, custom_tool_names: set[str]
+        cls,
+        name: str,
+        arguments: str,
+        custom_tool_names: set[str],
+        namespace_names: Optional[set[str]] = None,
     ):
         """Build the Responses output item for one parsed tool call: a
         ``custom_tool_call`` when the tool was declared ``custom``, else a
-        ``function_call``."""
+        ``function_call``. Calls to flattened namespace tools carry
+        ``name=inner`` plus a ``namespace`` field."""
         if name in custom_tool_names:
             return ResponseCustomToolCall(
                 input=cls._custom_tool_input_from_arguments(arguments),
@@ -1044,14 +1112,26 @@ class OpenAIServingResponses(OpenAIServingChat):
                 id=f"ctc_{random_uuid()[:8]}",
                 status="completed",
             )
+        local_name, namespace = cls._split_namespaced_name(
+            name, namespace_names or set()
+        )
+        extra = {"namespace": namespace} if namespace else {}
         return ResponseFunctionToolCall(
             arguments=arguments,
             call_id=f"call_{random_uuid()[:24]}",
             type="function_call",
-            name=name,
+            name=local_name,
             id=f"fc_{random_uuid()[:8]}",
             status="completed",
+            **extra,
         )
+
+    @staticmethod
+    def _looks_like_encrypted_blob(text: str) -> bool:
+        """Heuristic for ciphertext in an ``encrypted_content`` part: one long
+        unbroken base64-ish token. Plaintext prose (spaces, punctuation)
+        never matches."""
+        return len(text) > 256 and re.fullmatch(r"[A-Za-z0-9+/=_\-]+", text) is not None
 
     @staticmethod
     def _normalize_response_content_part_for_chat(content_part: Any) -> Any:
@@ -1146,6 +1226,13 @@ class OpenAIServingResponses(OpenAIServingChat):
                 raw = orjson.dumps(raw).decode("utf-8")
             else:
                 raw = "{}"
+            # Calls to flattened namespace tools were emitted with
+            # ``name=inner`` + ``namespace``; re-qualify to the dotted chat
+            # name the model saw declared before replaying.
+            name = message.get("name")
+            namespace = message.get("namespace")
+            if namespace and name and not name.startswith(f"{namespace}."):
+                name = f"{namespace}.{name}"
             return {
                 "role": "assistant",
                 "tool_calls": [
@@ -1153,7 +1240,7 @@ class OpenAIServingResponses(OpenAIServingChat):
                         "id": message.get("call_id") or message.get("id"),
                         "type": "function",
                         "function": {
-                            "name": message.get("name"),
+                            "name": name,
                             "arguments": raw,
                         },
                     }
@@ -1161,15 +1248,64 @@ class OpenAIServingResponses(OpenAIServingChat):
             }
         if msg_type in ("function_call_output", "custom_tool_call_output"):
             # ``output`` may be a string or an array of content parts (OpenAI
-            # allows both); the chat tool message needs a string, so flatten.
+            # allows both). Text-only arrays flatten to a plain string (the
+            # shape every chat template accepts); arrays carrying non-text
+            # parts (e.g. ``input_image`` from Codex's view_image) pass
+            # through as normalized chat content parts so images reach the
+            # model instead of being dropped (issues #33867 / #34927).
             out = message.get("output", "")
             if isinstance(out, list):
-                out = "".join(p.get("text", "") for p in out if isinstance(p, dict))
+                parts = [
+                    cls._normalize_response_content_part_for_chat(p) for p in out
+                ]
+                parts = [p for p in parts if isinstance(p, dict)]
+                if any(p.get("type") != "text" for p in parts):
+                    out = parts
+                else:
+                    out = "".join(p.get("text", "") for p in parts)
             return {
                 "role": "tool",
                 "tool_call_id": message.get("call_id"),
                 "content": out,
             }
+        if msg_type == "agent_message":
+            # Inter-agent message from a Codex multi-agent thread. Against a
+            # non-OpenAI provider both part shapes carry plaintext (the
+            # client's ``new_encrypted`` merely relocates the string; real
+            # ciphertext only travels via ``encrypted_function_args``, which
+            # Codex strips for non-OpenAI providers), so render the message
+            # as text with its routing as a header. Stateless translation —
+            # hosted ``multi_agent_call`` actions stay unsupported.
+            texts: list[str] = []
+            for part in message.get("content") or []:
+                if not isinstance(part, dict):
+                    continue
+                if part.get("type") == "input_text":
+                    text = part.get("text") or ""
+                elif part.get("type") == "encrypted_content":
+                    text = part.get("encrypted_content") or ""
+                    if cls._looks_like_encrypted_blob(text):
+                        # A thread that originated against OpenAI can carry
+                        # real ciphertext; a visible placeholder beats
+                        # feeding the model base64 noise.
+                        text = "[encrypted agent message content unavailable]"
+                else:
+                    continue
+                if text:
+                    texts.append(text)
+            if not texts:
+                return None
+            author = message.get("author") or (message.get("agent") or {}).get(
+                "agent_name"
+            )
+            recipient = message.get("recipient")
+            header = "[agent message"
+            if author:
+                header += f" from {author}"
+            if recipient:
+                header += f" to {recipient}"
+            header += "]"
+            return {"role": "user", "content": header + "\n" + "\n".join(texts)}
         # Reasoning items render as {role: assistant, reasoning_content};
         # empty ones drop instead of injecting an empty assistant block.
         if msg_type == "reasoning":
@@ -2093,6 +2229,7 @@ class OpenAIServingResponses(OpenAIServingChat):
         }
         tool_call_states: dict[int, dict[str, Any]] = {}
         custom_tool_names = self._custom_tool_names(request)
+        namespace_names = self._namespace_names(request)
         # Items closed during the stream, in wire order. Feeds the final
         # ``response.completed`` snapshot and the stored response.
         emitted_items: list = []
@@ -2311,6 +2448,11 @@ class OpenAIServingResponses(OpenAIServingChat):
                 type="function_call",
                 id=state["item_id"],
                 status="completed",
+                **(
+                    {"namespace": state["namespace"]}
+                    if state.get("namespace")
+                    else {}
+                ),
             )
             events = [
                 _send_event(
@@ -2488,11 +2630,19 @@ class OpenAIServingResponses(OpenAIServingChat):
                                 else f"fc_{random_uuid()[:8]}"
                             )
                             call_id = f"call_{random_uuid()[:24]}"
+                            local_name, call_namespace = (
+                                (call.name or "", None)
+                                if is_custom
+                                else self._split_namespaced_name(
+                                    call.name or "", namespace_names
+                                )
+                            )
                             state = {
                                 "item_id": item_id,
                                 "call_id": call_id,
                                 "output_index": current_output_index,
-                                "name": call.name or "",
+                                "name": local_name,
+                                "namespace": call_namespace,
                                 "arguments": "",
                                 "is_custom": is_custom,
                                 "added": False,
@@ -2518,6 +2668,11 @@ class OpenAIServingResponses(OpenAIServingChat):
                                     type="function_call",
                                     id=state["item_id"],
                                     status="in_progress",
+                                    **(
+                                        {"namespace": state["namespace"]}
+                                        if state.get("namespace")
+                                        else {}
+                                    ),
                                 )
                             yield _send_event(
                                 openai_responses_types.ResponseOutputItemAddedEvent(

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -1022,6 +1022,7 @@ class OpenAIServingResponses(OpenAIServingChat):
                                 description=inner.get("description")
                                 or tool.description,
                                 parameters=inner.get("parameters"),
+                                strict=bool(inner.get("strict", False)),
                             ),
                         )
                     )
@@ -1255,9 +1256,7 @@ class OpenAIServingResponses(OpenAIServingChat):
             # model instead of being dropped (issues #33867 / #34927).
             out = message.get("output", "")
             if isinstance(out, list):
-                parts = [
-                    cls._normalize_response_content_part_for_chat(p) for p in out
-                ]
+                parts = [cls._normalize_response_content_part_for_chat(p) for p in out]
                 parts = [p for p in parts if isinstance(p, dict)]
                 if any(p.get("type") != "text" for p in parts):
                     out = parts
@@ -1269,13 +1268,14 @@ class OpenAIServingResponses(OpenAIServingChat):
                 "content": out,
             }
         if msg_type == "agent_message":
-            # Inter-agent message from a Codex multi-agent thread. Against a
-            # non-OpenAI provider both part shapes carry plaintext (the
-            # client's ``new_encrypted`` merely relocates the string; real
-            # ciphertext only travels via ``encrypted_function_args``, which
-            # Codex strips for non-OpenAI providers), so render the message
-            # as text with its routing as a header. Stateless translation —
-            # hosted ``multi_agent_call`` actions stay unsupported.
+            # Inter-agent message from a Codex multi-agent thread. It may
+            # carry plaintext ``input_text`` and/or ``encrypted_content``
+            # that is sometimes plaintext-in-disguise and sometimes real
+            # ciphertext (cross-provider threads). Plaintext is forwarded
+            # with the routing as a header; ciphertext-looking content is
+            # replaced with a visible placeholder because the server cannot
+            # decrypt it. Stateless translation — hosted ``multi_agent_call``
+            # actions stay unsupported.
             texts: list[str] = []
             for part in message.get("content") or []:
                 if not isinstance(part, dict):
@@ -2448,11 +2448,7 @@ class OpenAIServingResponses(OpenAIServingChat):
                 type="function_call",
                 id=state["item_id"],
                 status="completed",
-                **(
-                    {"namespace": state["namespace"]}
-                    if state.get("namespace")
-                    else {}
-                ),
+                **({"namespace": state["namespace"]} if state.get("namespace") else {}),
             )
             events = [
                 _send_event(

--- a/test/registered/core/test_responses_codex_compat.py
+++ b/test/registered/core/test_responses_codex_compat.py
@@ -32,6 +32,7 @@ def _request_with_namespace_tool() -> ResponsesRequest:
                         "type": "function",
                         "name": "spawn_agent",
                         "description": "Spawn a sub-agent.",
+                        "strict": True,
                         "parameters": {
                             "type": "object",
                             "properties": {"task": {"type": "string"}},
@@ -64,6 +65,10 @@ class TestNamespaceTools(CustomTestCase):
         spawn = by_name["multi_agent_v1.spawn_agent"].function
         self.assertEqual(spawn.description, "Spawn a sub-agent.")
         self.assertEqual(spawn.parameters["required"], ["task"])
+        # ``strict`` is part of the inner function definition and must survive
+        # flattening.
+        self.assertTrue(spawn.strict)
+        self.assertFalse(by_name["multi_agent_v1.send_message"].function.strict)
         # Inner without a description inherits the namespace's.
         self.assertEqual(
             by_name["multi_agent_v1.send_message"].function.description,
@@ -135,7 +140,9 @@ class TestAgentMessage(CustomTestCase):
             }
         )
         self.assertNotIn(blob, message["content"])
-        self.assertIn("[encrypted agent message content unavailable]", message["content"])
+        self.assertIn(
+            "[encrypted agent message content unavailable]", message["content"]
+        )
 
     def test_empty_agent_message_drops(self):
         message = OpenAIServingResponses._normalize_response_message_for_chat(

--- a/test/registered/core/test_responses_codex_compat.py
+++ b/test/registered/core/test_responses_codex_compat.py
@@ -1,0 +1,183 @@
+"""Responses API Codex-compatibility items: namespace tools, agent_message,
+and array-shaped tool output.
+
+Namespace tools flatten to ``f"{namespace}.{inner}"`` chat functions and the
+emitted call item splits the pair back apart; ``agent_message`` items from
+multi-agent threads render as text instead of 400ing; tool-output content
+arrays preserve non-text parts (``input_image``) as chat content parts instead
+of silently dropping them (issues #33867 / #34927).
+"""
+
+import unittest
+
+from sglang.srt.entrypoints.openai.protocol import ResponsesRequest
+from sglang.srt.entrypoints.openai.serving_responses import OpenAIServingResponses
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=15, suite="base-a-test-cpu")
+
+
+def _request_with_namespace_tool() -> ResponsesRequest:
+    return ResponsesRequest(
+        model="test-model",
+        input="spawn an agent",
+        tools=[
+            {
+                "type": "namespace",
+                "name": "multi_agent_v1",
+                "description": "Multi-agent orchestration tools.",
+                "tools": [
+                    {
+                        "type": "function",
+                        "name": "spawn_agent",
+                        "description": "Spawn a sub-agent.",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"task": {"type": "string"}},
+                            "required": ["task"],
+                        },
+                    },
+                    {
+                        "type": "function",
+                        "name": "send_message",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                ],
+            },
+            {
+                "type": "function",
+                "name": "dotted.but.flat",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        ],
+    )
+
+
+class TestNamespaceTools(CustomTestCase):
+    def test_namespace_flattens_to_qualified_chat_functions(self):
+        request = _request_with_namespace_tool()
+        chat_tools = OpenAIServingResponses._response_tools_to_chat_tools(request)
+        by_name = {tool.function.name: tool for tool in chat_tools}
+        self.assertIn("multi_agent_v1.spawn_agent", by_name)
+        self.assertIn("multi_agent_v1.send_message", by_name)
+        spawn = by_name["multi_agent_v1.spawn_agent"].function
+        self.assertEqual(spawn.description, "Spawn a sub-agent.")
+        self.assertEqual(spawn.parameters["required"], ["task"])
+        # Inner without a description inherits the namespace's.
+        self.assertEqual(
+            by_name["multi_agent_v1.send_message"].function.description,
+            "Multi-agent orchestration tools.",
+        )
+
+    def test_emitted_call_item_splits_namespace(self):
+        request = _request_with_namespace_tool()
+        namespace_names = OpenAIServingResponses._namespace_names(request)
+        item = OpenAIServingResponses._build_tool_call_item(
+            "multi_agent_v1.spawn_agent", '{"task": "t"}', set(), namespace_names
+        )
+        self.assertEqual(item.type, "function_call")
+        self.assertEqual(item.name, "spawn_agent")
+        self.assertEqual(item.model_dump()["namespace"], "multi_agent_v1")
+
+    def test_undeclared_dotted_name_passes_through(self):
+        request = _request_with_namespace_tool()
+        namespace_names = OpenAIServingResponses._namespace_names(request)
+        item = OpenAIServingResponses._build_tool_call_item(
+            "dotted.but.flat", "{}", set(), namespace_names
+        )
+        self.assertEqual(item.name, "dotted.but.flat")
+        self.assertNotIn("namespace", item.model_dump())
+
+    def test_replayed_namespaced_call_requalifies_for_chat(self):
+        message = OpenAIServingResponses._normalize_response_message_for_chat(
+            {
+                "type": "function_call",
+                "call_id": "call_1",
+                "name": "spawn_agent",
+                "namespace": "multi_agent_v1",
+                "arguments": '{"task": "t"}',
+            }
+        )
+        self.assertEqual(
+            message["tool_calls"][0]["function"]["name"],
+            "multi_agent_v1.spawn_agent",
+        )
+
+
+class TestAgentMessage(CustomTestCase):
+    def test_agent_message_renders_text_with_routing_header(self):
+        message = OpenAIServingResponses._normalize_response_message_for_chat(
+            {
+                "type": "agent_message",
+                "id": "amsg_123",
+                "author": "/root/agent_a",
+                "recipient": "/root",
+                "agent": {"agent_name": "/root"},
+                "content": [
+                    {"type": "input_text", "text": "sub-agent result"},
+                    {"type": "encrypted_content", "encrypted_content": "plain reply"},
+                ],
+            }
+        )
+        self.assertEqual(message["role"], "user")
+        self.assertIn("[agent message from /root/agent_a to /root]", message["content"])
+        self.assertIn("sub-agent result", message["content"])
+        self.assertIn("plain reply", message["content"])
+
+    def test_agent_message_ciphertext_becomes_placeholder(self):
+        blob = "QWJj" * 100  # 400 chars of unbroken base64
+        message = OpenAIServingResponses._normalize_response_message_for_chat(
+            {
+                "type": "agent_message",
+                "author": "/root/agent_a",
+                "content": [{"type": "encrypted_content", "encrypted_content": blob}],
+            }
+        )
+        self.assertNotIn(blob, message["content"])
+        self.assertIn("[encrypted agent message content unavailable]", message["content"])
+
+    def test_empty_agent_message_drops(self):
+        message = OpenAIServingResponses._normalize_response_message_for_chat(
+            {"type": "agent_message", "author": "/root/agent_a", "content": []}
+        )
+        self.assertIsNone(message)
+
+
+class TestToolOutputContentParts(CustomTestCase):
+    def test_text_only_array_output_flattens_to_string(self):
+        message = OpenAIServingResponses._normalize_response_message_for_chat(
+            {
+                "type": "function_call_output",
+                "call_id": "call_1",
+                "output": [
+                    {"type": "input_text", "text": "a"},
+                    {"type": "text", "text": "b"},
+                ],
+            }
+        )
+        self.assertEqual(message["content"], "ab")
+
+    def test_image_part_survives_as_chat_content_part(self):
+        data_url = "data:image/png;base64,iVBORw0KGgo="
+        for item_type in ("function_call_output", "custom_tool_call_output"):
+            message = OpenAIServingResponses._normalize_response_message_for_chat(
+                {
+                    "type": item_type,
+                    "call_id": "call_1",
+                    "output": [
+                        {"type": "input_text", "text": "screenshot:"},
+                        {"type": "input_image", "image_url": data_url},
+                    ],
+                }
+            )
+            self.assertEqual(message["role"], "tool")
+            parts = message["content"]
+            self.assertIsInstance(parts, list)
+            self.assertEqual(parts[0], {"type": "text", "text": "screenshot:"})
+            self.assertEqual(parts[1]["type"], "image_url")
+            self.assertEqual(parts[1]["image_url"]["url"], data_url)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/core/test_responses_custom_tools.py
+++ b/test/registered/core/test_responses_custom_tools.py
@@ -1,0 +1,112 @@
+"""Responses API custom (freeform) tool support.
+
+A client that declares ``tools: [{"type": "custom"}]`` must be able to
+round-trip the conversation: the declaration reaches the chat template, the
+model's call comes back as a ``custom_tool_call`` output item carrying the raw
+string input, and replaying ``custom_tool_call`` / ``custom_tool_call_output``
+items on the next turn is accepted instead of 400ing (the OpenAI Codex CLI
+``apply_patch_tool_type = freeform`` flow).
+"""
+
+import unittest
+
+import orjson
+
+from sglang.srt.entrypoints.openai.protocol import ResponsesRequest
+from sglang.srt.entrypoints.openai.serving_responses import OpenAIServingResponses
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=15, suite="base-a-test-cpu")
+
+
+def _request_with_custom_tool() -> ResponsesRequest:
+    return ResponsesRequest(
+        model="test-model",
+        input="patch README.md",
+        tools=[
+            {
+                "type": "custom",
+                "name": "apply_patch",
+                "description": "freeform patch tool",
+            },
+            {
+                "type": "function",
+                "name": "get_weather",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        ],
+    )
+
+
+class TestResponsesCustomTools(CustomTestCase):
+    def test_custom_tool_declaration_reaches_chat_tools(self):
+        request = _request_with_custom_tool()
+        chat_tools = OpenAIServingResponses._response_tools_to_chat_tools(request)
+        by_name = {tool.function.name: tool for tool in chat_tools}
+        self.assertIn("apply_patch", by_name)
+        self.assertIn("get_weather", by_name)
+        params = by_name["apply_patch"].function.parameters
+        self.assertEqual(params["required"], ["input"])
+        self.assertEqual(params["properties"]["input"]["type"], "string")
+
+    def test_custom_tool_call_replay_normalizes_to_assistant_tool_call(self):
+        patch = "*** Begin Patch\n*** End Patch\n"
+        message = OpenAIServingResponses._normalize_response_message_for_chat(
+            {
+                "type": "custom_tool_call",
+                "call_id": "call_1",
+                "name": "apply_patch",
+                "input": patch,
+            }
+        )
+        self.assertEqual(message["role"], "assistant")
+        (tool_call,) = message["tool_calls"]
+        self.assertEqual(tool_call["function"]["name"], "apply_patch")
+        arguments = orjson.loads(tool_call["function"]["arguments"])
+        self.assertEqual(arguments, {"input": patch})
+
+    def test_custom_tool_call_output_replay_normalizes_to_tool_message(self):
+        message = OpenAIServingResponses._normalize_response_message_for_chat(
+            {
+                "type": "custom_tool_call_output",
+                "call_id": "call_1",
+                "output": "done",
+            }
+        )
+        self.assertEqual(
+            message, {"role": "tool", "tool_call_id": "call_1", "content": "done"}
+        )
+
+    def test_unknown_item_type_still_rejected(self):
+        with self.assertRaises(ValueError):
+            OpenAIServingResponses._normalize_response_message_for_chat(
+                {"type": "additional_tools"}
+            )
+
+    def test_build_tool_call_item_maps_declared_custom_tools(self):
+        patch = "*** Begin Patch\nline\n*** End Patch\n"
+        wrapped = orjson.dumps({"input": patch}).decode("utf-8")
+        item = OpenAIServingResponses._build_tool_call_item(
+            "apply_patch", wrapped, {"apply_patch"}
+        )
+        self.assertEqual(item.type, "custom_tool_call")
+        self.assertEqual(item.name, "apply_patch")
+        self.assertEqual(item.input, patch)
+        self.assertEqual(item.status, "completed")
+
+        function_item = OpenAIServingResponses._build_tool_call_item(
+            "get_weather", "{}", {"apply_patch"}
+        )
+        self.assertEqual(function_item.type, "function_call")
+
+    def test_custom_tool_input_unwrap_falls_back_to_raw(self):
+        unwrap = OpenAIServingResponses._custom_tool_input_from_arguments
+        self.assertEqual(unwrap('{"input": "abc"}'), "abc")
+        self.assertEqual(unwrap("not json"), "not json")
+        self.assertEqual(unwrap('{"other": 1}'), '{"other": 1}')
+        self.assertEqual(unwrap(""), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/entrypoints/openai/test_serving_responses_stream.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_responses_stream.py
@@ -315,3 +315,114 @@ class MultiToolCallStreamingOrderTestCase(CustomTestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class CustomToolStreamingTestCase(CustomTestCase):
+    """Wire-level regression for custom (freeform) tool streaming: the wrapped
+    {"input": ...} JSON buffers across deltas (it cannot be unwrapped
+    incrementally) and surfaces as one unwrapped input delta + done at close,
+    with the completed snapshot carrying the custom_tool_call item."""
+
+    def test_custom_tool_call_stream_event_sequence(self):
+        import json as _json
+
+        from sglang.srt.function_call.core_types import (
+            StreamingParseResult,
+            ToolCallItem,
+        )
+
+        serving = make_serving()
+        serving.reasoning_parser = None
+        serving.tool_call_parser = "qwen3_coder"
+
+        request = ResponsesRequest(
+            model="x",
+            input="patch it",
+            stream=True,
+            store=False,
+            tools=[
+                {
+                    "type": "custom",
+                    "name": "apply_patch",
+                    "description": "freeform patch tool",
+                }
+            ],
+        )
+
+        patch_text = "*** Begin Patch\n*** End Patch\n"
+        wrapped = _json.dumps({"input": patch_text})
+        scripted = [
+            StreamingParseResult(
+                normal_text="",
+                calls=[
+                    ToolCallItem(
+                        tool_index=0, name="apply_patch", parameters=wrapped[:12]
+                    )
+                ],
+            ),
+            StreamingParseResult(
+                normal_text="",
+                calls=[ToolCallItem(tool_index=0, parameters=wrapped[12:])],
+            ),
+        ]
+        script_iter = iter(scripted)
+
+        def fake_parse_stream_chunk(delta):
+            sp = next(script_iter)
+            return sp.normal_text, sp.calls
+
+        with patch(
+            "sglang.srt.entrypoints.openai.serving_responses.FunctionCallParser"
+        ) as parser_cls:
+            parser_cls.return_value.detector.supports_structural_tag.return_value = True
+            parser_cls.return_value.parse_stream_chunk.side_effect = (
+                fake_parse_stream_chunk
+            )
+            parser_cls.return_value.parse_stream_end.return_value = ("", [])
+            fixture = StreamFixture(serving, request)
+            events = fixture.run(
+                [
+                    engine_chunk(" " * 5, 5),
+                    engine_chunk(" " * 12, 12, finish=True),
+                ]
+            )
+
+        types = event_types(events)
+        payloads = event_payloads(events)
+
+        # Ordering: item added -> unwrapped input delta -> input done -> item done.
+        added_idx = types.index("response.output_item.added")
+        delta_idx = types.index("response.custom_tool_call_input.delta")
+        done_idx = types.index("response.custom_tool_call_input.done")
+        item_done_idx = types.index("response.output_item.done")
+        self.assertLess(added_idx, delta_idx)
+        self.assertLess(delta_idx, done_idx)
+        self.assertLess(done_idx, item_done_idx)
+        # Custom tools must not leak function-call argument deltas.
+        self.assertNotIn("response.function_call_arguments.delta", types)
+        self.assertNotIn("response.function_call_arguments.done", types)
+
+        added = payloads[added_idx]["item"]
+        self.assertEqual(added["type"], "custom_tool_call")
+        self.assertEqual(added["name"], "apply_patch")
+        self.assertTrue(added["id"].startswith("ctc_"))
+
+        # The delta/done carry the UNWRAPPED freeform string.
+        self.assertEqual(payloads[delta_idx]["delta"], patch_text)
+        self.assertEqual(payloads[done_idx]["input"], patch_text)
+        self.assertEqual(payloads[done_idx]["item_id"], added["id"])
+
+        item_done = payloads[item_done_idx]["item"]
+        self.assertEqual(item_done["type"], "custom_tool_call")
+        self.assertEqual(item_done["input"], patch_text)
+        self.assertEqual(item_done["status"], "completed")
+
+        completed = find_completed_event(events)
+        ctc_items = [
+            item
+            for item in completed["response"]["output"]
+            if item["type"] == "custom_tool_call"
+        ]
+        self.assertEqual(len(ctc_items), 1)
+        self.assertEqual(ctc_items[0]["name"], "apply_patch")
+        self.assertEqual(ctc_items[0]["input"], patch_text)

--- a/test/registered/unit/entrypoints/openai/test_serving_responses_stream.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_responses_stream.py
@@ -313,10 +313,6 @@ class MultiToolCallStreamingOrderTestCase(CustomTestCase):
         self.assertEqual(items[0]["arguments"], '{"city": "Beijing"}')
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class CustomToolStreamingTestCase(CustomTestCase):
     """Wire-level regression for custom (freeform) tool streaming: the wrapped
     {"input": ...} JSON buffers across deltas (it cannot be unwrapped
@@ -426,3 +422,7 @@ class CustomToolStreamingTestCase(CustomTestCase):
         self.assertEqual(len(ctc_items), 1)
         self.assertEqual(ctc_items[0]["name"], "apply_patch")
         self.assertEqual(ctc_items[0]["input"], patch_text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

The OpenAI Codex CLI now drives providers through `/v1/responses`, and several item and tool types it sends are either silently dropped or hard-rejected by the Responses serving layer. Each of these kills a Codex conversation in a different way:

1. **Custom (freeform) tools** (`apply_patch_tool_type = freeform`), two separate failures: the declaration returns 200 but is silently dropped (`tool.type != "function"` skip), so the model never calls the tool; and independently, replaying a `custom_tool_call` / `custom_tool_call_output` item from any prior turn 400s, killing the conversation.
2. **Namespace tools**: Codex groups its multi-agent tool family under a `namespace` declaration (`ProviderCapabilities::namespace_tools` defaults to `true`, so custom providers receive them un-flattened). The protocol type already carries `ResponseTool.tools` ("Inner schemas for `namespace` tools") but nothing handles it — the model never sees the inner tools, so it never calls them.
3. **`agent_message` items**: any multi-agent thread carrying a sub-agent reply 400s with `Unsupported Responses API input item type: 'agent_message'` (same failure reported against other providers in openai/codex#33551).
4. **Array-shaped tool output**: list outputs were flattened by string-joining `text` fields, silently dropping `input_image` parts — live for Codex because `view_image` returns image parts in tool output (#33867, #34927).

## Modifications

All changes are stateless HTTP-serving-layer translation in `serving_responses.py`; no tokenizer, template, or engine changes.

**Custom (freeform) tools** — declaration shim to a one-string-argument function (`{"input": ...}`), so parsers and constrained decoding keep working; `custom_tool_call` / `custom_tool_call_output` input items normalize to chat messages; parsed calls to a declared custom tool emit `custom_tool_call` output items carrying the raw string; streaming emits `response.custom_tool_call_input.delta/done`. Known limitation: `format` (lark/regex grammars) is ignored — grammar-constrained custom tools run unconstrained.

**Namespace tools** — each inner function tool flattens to a chat function named `f"{namespace}.{inner}"`; emitted call items split the pair back (`name=inner` plus a `namespace` field); replayed namespaced calls re-qualify to the dotted name for the chat template. Only declared namespace prefixes split — a plain function whose name contains a dot passes through. Verified live against a Kimi K3 deployment that the model faithfully echoes dotted tool names in its calls. Deliberate simplification vs. OpenAI: inner schemas are exposed up front rather than deferred behind tool search.

**`agent_message`** — renders as a user message: routing header (`[agent message from X to Y]`) plus the message text. Codex agent messages may contain plaintext `input_text` and/or opaque `encrypted_content`; plaintext is forwarded, and ciphertext-looking content (one long unbroken base64 token) is replaced with a visible placeholder because SGLang cannot decrypt it. Hosted `multi_agent_call` actions remain unsupported and keep 400ing — accepting them would claim orchestration work the server never performs.

**Array-shaped tool output** — text-only arrays still flatten to a plain string (the shape every chat template accepts); arrays containing non-text parts route through the existing content-part normalizer (`input_text` → `text`, `input_image` → `image_url`) and pass through as chat content parts, so images in tool output reach the model. Fixes #33867 / #34927.

## Tests

Registered in `base-a-test-cpu` (not yet run by a maintainer-triggered suite):
- `test/registered/core/test_responses_custom_tools.py` — declaration shim shape, call emission, input replay, unknown-type rejection preserved.
- `test/registered/core/test_responses_codex_compat.py` — namespace flattening (description inheritance, `strict` preservation, qualified names), call-item split, undeclared-dotted-name passthrough, replay re-qualification; `agent_message` rendering, ciphertext placeholder, empty-message drop; text-only output flattening and `input_image` part survival for both output item types.
- `test/registered/unit/entrypoints/openai/test_serving_responses_stream.py` — wire-level custom-tool streaming regression: `output_item.added` → unwrapped `custom_tool_call_input.delta` → `.done` → `output_item.done` → the `custom_tool_call` in `response.completed.output`; no `function_call_arguments` events leak for custom tools.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->