### PR TITLE
refactor: decouple TRTLLMHAAttnBackend from FlashInferAttnBackend

### DIFF
--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -21,7 +21,10 @@ from sglang.kernels.ops.kvcache.trtllm_mha_page_table import (
     build_trtllm_mha_page_table,
 )
 from sglang.srt.environ import envs
-from sglang.srt.layers.attention.base_attn_backend import AttentionBackend, SharedReadEnds
+from sglang.srt.layers.attention.base_attn_backend import (
+    AttentionBackend,
+    SharedReadEnds,
+)
 from sglang.srt.layers.attention.flashinfer_backend import (
     FlashInferMultiStepDraftBackend,
 )

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -21,9 +21,8 @@ from sglang.kernels.ops.kvcache.trtllm_mha_page_table import (
     build_trtllm_mha_page_table,
 )
 from sglang.srt.environ import envs
-from sglang.srt.layers.attention.base_attn_backend import SharedReadEnds
+from sglang.srt.layers.attention.base_attn_backend import AttentionBackend, SharedReadEnds
 from sglang.srt.layers.attention.flashinfer_backend import (
-    FlashInferAttnBackend,
     FlashInferMultiStepDraftBackend,
 )
 from sglang.srt.layers.attention.trtllm_mla_backend import (
@@ -93,7 +92,7 @@ class TRTLLMMHAMetadata:
     encoder_row_map: torch.Tensor = None
 
 
-class TRTLLMHAAttnBackend(FlashInferAttnBackend):
+class TRTLLMHAAttnBackend(AttentionBackend):
     """TRTLLM MHA attention kernel from flashinfer."""
 
     # Build the page table on-device from seq_lens (incl. the SWA-translated table
@@ -113,12 +112,13 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         self,
         model_runner: ModelRunner,
         skip_prefill: bool = False,
-        kv_indptr_buf: Optional[torch.Tensor] = None,
-        kv_last_page_len_buf: Optional[torch.Tensor] = None,
         speculative_step_id: int = 0,
     ):
-        # Capture workspace size before super().__init__() to preserve user's
-        # SGLANG_FLASHINFER_WORKSPACE_SIZE setting (may be overridden by parent)
+        super().__init__()
+
+        self.token_to_kv_pool = model_runner.token_to_kv_pool
+        self.kv_cache_quant_method = self.token_to_kv_pool.get_kv_cache_quant_method()
+
         env_var = envs.SGLANG_FLASHINFER_WORKSPACE_SIZE
         workspace_size_bytes = (
             env_var.get()
@@ -126,9 +126,6 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             else DEFAULT_WORKSPACE_SIZE_MB * 1024 * 1024
         )
 
-        super().__init__(
-            model_runner, skip_prefill, kv_indptr_buf, kv_last_page_len_buf
-        )
         self.decode_kv_access = self.kv_cache_quant_method.resolve_attention_access(
             "decode", "trtllm_mha"
         )
@@ -186,6 +183,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         # SWA hybrid models split the KV cache into full and SWA pools with
         # separate index spaces; SWA layers need a translated page_table.
         self._swa_kv_pool: Optional[SWAKVPool] = self._resolve_swa_kv_pool(model_runner)
+        self.use_sliding_window_kv_pool = self._swa_kv_pool is not None
         # Raw full->swa index mapping tensor for the fused cuda-graph
         # metadata kernel (gather + // page_size happen on device).
         if self._swa_kv_pool is not None:
@@ -261,6 +259,11 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             "trtllm_mha_default_kv_scale",
             lambda: torch.ones(1, dtype=torch.float32, device=self.device),
         )
+
+    def _kv_write_scales(self, layer: RadixAttention):
+        if self.kv_cache_quant_method.needs_global_scale():
+            return None, None
+        return layer.k_scale, layer.v_scale
 
     def _check_decode_kv_access(self) -> None:
         supported_kinds = {
@@ -1423,8 +1426,6 @@ class TRTLLMHAAttnMultiStepDraftBackend(FlashInferMultiStepDraftBackend):
             self.attn_backends[i] = TRTLLMHAAttnBackend(
                 model_runner,
                 skip_prefill=True,
-                kv_indptr_buf=self.kv_indptr[i],
-                kv_last_page_len_buf=self.kv_last_page_len,
                 speculative_step_id=i,
             )
 


### PR DESCRIPTION
## Motivation

Addresses #28808. `TRTLLMHAAttnBackend` inherits from `FlashInferAttnBackend` but overrides nearly all attention logic and uses very little from the parent. The parent's `__init__` allocates prefill/decode wrappers, ragged wrappers, `IndicesUpdater` objects, and a workspace buffer that the TRTLLM backend never touches, wasting memory and adding confusion.

## Modifications

- Changed `TRTLLMHAAttnBackend` to inherit from `AttentionBackend` directly
- Set the small number of actually-used attributes (`token_to_kv_pool`, `kv_cache_quant_method`, `use_sliding_window_kv_pool`) directly in `__init__` instead of via the FlashInfer parent
- Moved `_kv_write_scales` into `TRTLLMHAAttnBackend` (only method inherited from FlashInfer that was actually called)
- Removed unused `kv_indptr_buf` and `kv_last_page_len_buf` constructor params (passed to FlashInfer super but never read by any TRTLLM code path)
- Updated `TRTLLMHAAttnMultiStepDraftBackend` to match the simplified constructor

No behavior changes: `forward()` dispatch comes from `AttentionBackend`, `shared_read_ends` fallback goes to `AttentionBackend` (FlashInfer never overrode it), and no code uses `isinstance(..., FlashInferAttnBackend)` to match TRTLLM backends.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32084864219](https://github.com/sgl-project/sglang/actions/runs/32084864219)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32084863391](https://github.com/sgl-project/sglang/actions/runs/32084863391)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->