### PR TITLE
refactor: rename chat response token IDs

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -1117,7 +1117,7 @@ class ChatCompletionResponseChoice(BaseModel):
     matched_stop: Union[None, int, str] = None
     hidden_states: Optional[object] = None
     prompt_token_ids: Optional[List[int]] = None
-    token_ids: Optional[List[int]] = None
+    response_token_ids: Optional[List[int]] = None
     meta_info: Optional[Dict[str, Any]] = None
 
     @model_serializer(mode="wrap")
@@ -1127,8 +1127,8 @@ class ChatCompletionResponseChoice(BaseModel):
             data.pop("hidden_states", None)
         if self.prompt_token_ids is None:
             data.pop("prompt_token_ids", None)
-        if self.token_ids is None:
-            data.pop("token_ids", None)
+        if self.response_token_ids is None:
+            data.pop("response_token_ids", None)
         if self.meta_info is None:
             data.pop("meta_info", None)
         return data

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -1877,7 +1877,7 @@ class OpenAIServingChat(OpenAIServingBase):
                 ),
                 hidden_states=hidden_states,
                 prompt_token_ids=choice_prompt_token_ids,
-                token_ids=choice_token_ids,
+                response_token_ids=choice_token_ids,
                 meta_info=choice_meta_info,
             )
             choices.append(choice_data)

--- a/test/registered/sampling/test_sampling_mask.py
+++ b/test/registered/sampling/test_sampling_mask.py
@@ -213,7 +213,7 @@ class TestSamplingMask(SamplingMaskTestMixin, CustomTestCase):
         self.assertEqual(response.status_code, 200, response.text)
 
         choice = response.json()["choices"][0]
-        output_ids = choice["token_ids"]
+        output_ids = choice["response_token_ids"]
         meta_info = choice["meta_info"]
         sampling_masks = meta_info["output_token_sampling_mask"]
         sampling_logprobs = meta_info["output_token_sampling_logprobs"]

--- a/test/registered/unit/entrypoints/openai/test_protocol.py
+++ b/test/registered/unit/entrypoints/openai/test_protocol.py
@@ -603,7 +603,7 @@ class TestModelSerialization(unittest.TestCase):
         )
         default_data = default_choice.model_dump()
         self.assertNotIn("prompt_token_ids", default_data)
-        self.assertNotIn("token_ids", default_data)
+        self.assertNotIn("response_token_ids", default_data)
         self.assertNotIn("meta_info", default_data)
 
         choice = ChatCompletionResponseChoice(
@@ -611,12 +611,13 @@ class TestModelSerialization(unittest.TestCase):
             message=ChatMessage(role="assistant", content="Hello"),
             finish_reason="stop",
             prompt_token_ids=[1, 2, 3],
-            token_ids=[4, 5],
+            response_token_ids=[4, 5],
             meta_info={"prompt_tokens": 3},
         )
         data = choice.model_dump()
         self.assertEqual(data["prompt_token_ids"], [1, 2, 3])
-        self.assertEqual(data["token_ids"], [4, 5])
+        self.assertNotIn("token_ids", data)
+        self.assertEqual(data["response_token_ids"], [4, 5])
         self.assertEqual(data["meta_info"], {"prompt_tokens": 3})
 
 

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -2337,11 +2337,11 @@ class ServingChatTestCase(unittest.TestCase):
         choice = response.choices[0]
 
         self.assertEqual(choice.prompt_token_ids, [11, 12, 13])
-        self.assertEqual(choice.token_ids, [21, 22])
+        self.assertEqual(choice.response_token_ids, [21, 22])
         self.assertEqual(choice.meta_info, ret[0]["meta_info"])
         dumped_choice = response.model_dump()["choices"][0]
         self.assertEqual(dumped_choice["prompt_token_ids"], [11, 12, 13])
-        self.assertEqual(dumped_choice["token_ids"], [21, 22])
+        self.assertEqual(dumped_choice["response_token_ids"], [21, 22])
         self.assertEqual(dumped_choice["meta_info"], ret[0]["meta_info"])
 
     def test_streaming_cached_tokens_details_emits_sglext(self):


### PR DESCRIPTION
## Summary
Rename chat completion response token IDs to `response_token_ids`.

## Motivation
The chat completion payload produced by `return_token_ids` has a semantic mismatch: `choices[*].token_ids` contains only generated response token IDs, while prompt token IDs are returned separately in `prompt_token_ids`. The unqualified field name does not match the response-only data it carries and can be mistaken for all token IDs. This intentionally renames only that chat response key while keeping `return_token_ids`, internal `output_ids`, and ordinary completions response keys unchanged.

## Before / After
- **Before / After:** `ChatCompletionResponseChoice.token_ids` serialized as `choices[*].token_ids`; it now serializes as `choices[*].response_token_ids`.
- **What moved where:** The Python chat-completions response model, builder mapping, and direct test consumers use the new name. No compatibility alias or dual-key response is added.

## Behavior Preservation
- `test_protocol.py`: Model serialization omits unset token IDs and emits `response_token_ids` without the old `token_ids` key.
- `test_serving_chat.py`: Response construction retains prompt token IDs and metadata while mapping generated output IDs to the renamed field.
- Schema assertion: `ChatCompletionResponseChoice` contains `response_token_ids` and no longer contains the old `token_ids` field.

## Verification
- `python3 -m pytest -q test/registered/unit/entrypoints/openai/test_protocol.py test/registered/unit/entrypoints/openai/test_serving_chat.py`: 138 tests and 61 subtests passed on the final rebased commit.
- Pydantic schema assertion: printed `['prompt_token_ids', 'response_token_ids']`.

## Review Focus
- `ChatCompletionResponseChoice._serialize`: Check that omitted token IDs remove the new key and the old response key cannot be emitted.
- `OpenAIServingChat._build_chat_response`: Check that `return_token_ids` maps internal `output_ids` only to `response_token_ids`.
- Client contract: Existing chat clients reading `choices[*].token_ids` must migrate to `choices[*].response_token_ids`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32088996318](https://github.com/sgl-project/sglang/actions/runs/32088996318)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32088995850](https://github.com/sgl-project/sglang/actions/runs/32088995850)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->