### PR TITLE
feat(npu): support Kimi K3 PCP with FLA affine states

### DIFF
--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -344,6 +344,27 @@ def _target_checkpoint_bundles_dspark_draft(server_args: ServerArgs) -> bool:
     return checkpoint_bundles_dspark_draft(server_args.get_model_config().hf_config)
 
 
+def _supports_dspark_prefill_cp(server_args: ServerArgs) -> bool:
+    """Whether the target has the state bridge required by DSpark + CP.
+
+    Kimi-K3 on NPU runs context parallelism only for target-model prefill.  Its
+    DSpark draft/decode path remains CP-off, while the eager runner gathers the
+    target auxiliary hidden states back to global token order before handing
+    them to the draft worker.  Keep the exception deliberately narrow so other
+    DSpark models continue to fail closed until they provide the same bridge.
+    """
+    if not (
+        server_args.device.startswith("npu")
+        and getattr(server_args, "enable_prefill_cp", False)
+    ):
+        return False
+
+    hf_config = server_args.get_model_config().hf_config
+    model_type = getattr(hf_config, "model_type", None)
+    architectures = getattr(hf_config, "architectures", None) or []
+    return model_type == "kimi_k3" or "KimiK3ForConditionalGeneration" in architectures
+
+
 def _handle_dspark(server_args: ServerArgs) -> None:
     cfg = resolving_view(server_args)
     _is_npu = cfg.device.startswith("npu")
@@ -375,10 +396,11 @@ def _handle_dspark(server_args: ServerArgs) -> None:
                     "SGLANG_RAGGED_VERIFY_MODE=static."
                 )
         if cfg.attn_cp_size > 1:
-            raise ValueError(
-                "DSpark with dp attention does not support context parallel "
-                f"(attn_cp_size={cfg.attn_cp_size})."
-            )
+            if not _supports_dspark_prefill_cp(server_args):
+                raise ValueError(
+                    "DSpark with dp attention does not support context parallel "
+                    f"(attn_cp_size={cfg.attn_cp_size}) for this target."
+                )
         if (
             not _is_npu
             and cfg.speculative_moe_a2a_backend is not None

--- a/python/sglang/srt/disaggregation/ascend/conn.py
+++ b/python/sglang/srt/disaggregation/ascend/conn.py
@@ -91,6 +91,11 @@ class AscendKVManager(MooncakeKVManager):
 
             return super().get_mla_kv_ptrs_with_pp(src_kv_ptrs, dst_kv_ptrs, state_type)
 
+        if state_type is not None:
+            # State components, including dSparK draft KV, have their own flat
+            # layout and must not inherit the target NPU MLA buffer grouping.
+            return super().get_mla_kv_ptrs_with_pp(src_kv_ptrs, dst_kv_ptrs, state_type)
+
         # src_kv_ptrs: k_data, v_data, index_k_data(optional)
         # dst_kv_ptrs: k_data, v_data, index_k_data(optional)
         # state_type is accepted for parity with the common disaggregation path;

--- a/python/sglang/srt/disaggregation/base/conn.py
+++ b/python/sglang/srt/disaggregation/base/conn.py
@@ -24,6 +24,10 @@ class StateType(str, enum.Enum):
     SWA_RING = "swa_ring"
     # DeepSeek-V4 online C128 request-scoped state.
     C128_STATE = "c128_state"
+    # Speculative draft KV uses the target token-pool indices, but it is not
+    # part of the target model's KV/MLA buffer grouping. Keep it separate so
+    # target and draft models can have different layer and buffer counts.
+    DRAFT_KV = "draft_kv"
     # A block-scaled KV dtype keeps its per-block scales in buffers parallel to
     # K/V, one component per sub-pool so each carries the index payload of the
     # KV it describes (whole sequence for full attention, window for SWA).

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -85,6 +85,7 @@ from sglang.srt.mem_cache.common import (
 )
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
 from sglang.srt.mem_cache.memory_pool import (
+    HybridLinearKVPool,
     HybridReqToTokenPool,
     KVCache,
     ReqToTokenPool,
@@ -541,7 +542,15 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             kv_data_lens += device_kv_data_lens[c4_layer_num:]
             kv_item_lens += device_kv_item_lens[c4_layer_num:]
             kv_data_mem_kinds += ["VRAM"] * len(device_kv_data_ptrs[c4_layer_num:])
-        if self.draft_token_to_kv_pool is not None:
+        draft_kv_as_state = (
+            self.scheduler.spec_algorithm.is_dspark()
+            and _is_npu
+            and isinstance(self.token_to_kv_pool, HybridLinearKVPool)
+            and self.is_mla_backend
+        )
+        if draft_kv_as_state and self.draft_token_to_kv_pool is None:
+            raise RuntimeError("PD dSparK Decode requires an allocated draft KV pool.")
+        if self.draft_token_to_kv_pool is not None and not draft_kv_as_state:
             # We should also transfer draft model kv cache. The indices are
             # always shared with a target model.
             draft_kv_data_ptrs, draft_kv_data_lens, draft_kv_item_lens = (
@@ -557,7 +566,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         kv_args.kv_item_lens = kv_item_lens
         kv_args.kv_layer_ids = (
             self.token_to_kv_pool.get_kv_layer_ids()
-            if self.draft_token_to_kv_pool is None
+            if (self.draft_token_to_kv_pool is None or draft_kv_as_state)
             and hasattr(self.token_to_kv_pool, "get_kv_layer_ids")
             else []
         )
@@ -575,6 +584,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             self.draft_token_to_kv_pool,
             total_kv_layers=self.scheduler.model_config.num_hidden_layers,
             req_to_token_pool=getattr(self, "req_to_token_pool", None),
+            draft_kv_as_state=draft_kv_as_state,
         )
 
         kv_args.ib_device = get_disagg().disaggregation_ib_device
@@ -1441,6 +1451,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 StateType.MINIMAX_INDEX_K: _full_kv_pages_payload,
                 StateType.SWA_RING: _swa_ring_payload,
                 StateType.C128_STATE: _c128_state_payload,
+                StateType.DRAFT_KV: _full_kv_pages_payload,
                 StateType.BLOCK_SCALE: _full_kv_pages_payload,
                 StateType.BLOCK_SCALE_SWA: _swa_payload,
             }

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -1211,13 +1211,14 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
             StateType.DSA,
             StateType.SWA_RING,
             StateType.C128_STATE,
+            StateType.DRAFT_KV,
             StateType.BLOCK_SCALE,
             StateType.BLOCK_SCALE_SWA,
         )
 
     def _requires_exact_state_index_match(self, st: StateType) -> bool:
         """State types whose page lists are positional and must not be truncated."""
-        return st in (StateType.SWA_RING, StateType.C128_STATE)
+        return st in (StateType.SWA_RING, StateType.C128_STATE, StateType.DRAFT_KV)
 
     def maybe_send_extra(
         self,
@@ -1346,6 +1347,26 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                     )
                 src_indices = list(indices)
                 dst_indices_local = list(dst_indices)
+                if st == StateType.DRAFT_KV:
+                    if not (
+                        len(src_data_ptrs)
+                        == len(src_item_lens)
+                        == len(dst_data_ptrs)
+                        == len(dst_item_lens)
+                    ):
+                        raise RuntimeError(
+                            "DRAFT_KV buffer metadata mismatch: "
+                            f"src_ptrs={len(src_data_ptrs)}, "
+                            f"src_item_lens={len(src_item_lens)}, "
+                            f"dst_ptrs={len(dst_data_ptrs)}, "
+                            f"dst_item_lens={len(dst_item_lens)}"
+                        )
+                    if list(src_item_lens) != list(dst_item_lens):
+                        raise RuntimeError(
+                            "DRAFT_KV cache layout mismatch between Prefill and "
+                            "Decode; use the same draft checkpoint, attention TP "
+                            "size, page size, dtype, and quantization on both sides."
+                        )
                 if (
                     st == StateType.C128_STATE
                     and len(src_indices) == 0

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -68,6 +68,7 @@ from sglang.srt.mem_cache.common import (
     release_kv_cache,
 )
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
+from sglang.srt.mem_cache.memory_pool import HybridLinearKVPool
 from sglang.srt.observability.req_time_stats import set_schedule_time_batch
 from sglang.srt.runtime_context import (
     get_disagg,
@@ -205,6 +206,13 @@ class PrefillBootstrapQueue:
         transfer_draft_cache = (
             not layer_shard_enabled or layer_shard_rank == layer_shard_size - 1
         )
+        draft_kv_as_state = (
+            self.scheduler.spec_algorithm.is_dspark()
+            and _is_npu
+            and isinstance(self.token_to_kv_pool, HybridLinearKVPool)
+            and self.is_mla_backend
+            and transfer_draft_cache
+        )
         kv_args.prefill_start_layer = (
             getattr(
                 self.token_to_kv_pool,
@@ -224,7 +232,13 @@ class PrefillBootstrapQueue:
             else getattr(self.token_to_kv_pool, "end_layer", None)
         )
 
-        if self.draft_token_to_kv_pool is not None and transfer_draft_cache:
+        if draft_kv_as_state and self.draft_token_to_kv_pool is None:
+            raise RuntimeError("PD dSparK Prefill requires an allocated draft KV pool.")
+        if (
+            self.draft_token_to_kv_pool is not None
+            and transfer_draft_cache
+            and not draft_kv_as_state
+        ):
             # We should also transfer draft model kv cache. The indices are
             # always shared with a target model.
             draft_kv_data_ptrs, draft_kv_data_lens, draft_kv_item_lens = (
@@ -239,7 +253,7 @@ class PrefillBootstrapQueue:
         kv_args.kv_item_lens = kv_item_lens
         kv_args.kv_layer_ids = (
             self.token_to_kv_pool.get_kv_layer_ids()
-            if self.draft_token_to_kv_pool is None
+            if (self.draft_token_to_kv_pool is None or draft_kv_as_state)
             and hasattr(self.token_to_kv_pool, "get_kv_layer_ids")
             else []
         )
@@ -263,6 +277,7 @@ class PrefillBootstrapQueue:
             self.draft_token_to_kv_pool if transfer_draft_cache else None,
             self.scheduler.model_config.num_hidden_layers,
             req_to_token_pool=req_to_token_pool,
+            draft_kv_as_state=draft_kv_as_state,
         )
 
         if isinstance(self.token_to_kv_pool, DeepSeekV4TokenToKVPool):
@@ -1249,6 +1264,7 @@ class SchedulerDisaggregationPrefillMixin:
                 StateType.MINIMAX_INDEX_K: _full_kv_pages_payload,
                 StateType.SWA_RING: _swa_ring_payload,
                 StateType.C128_STATE: _c128_state_payload,
+                StateType.DRAFT_KV: _full_kv_pages_payload,
                 StateType.BLOCK_SCALE: _full_kv_pages_payload,
                 StateType.BLOCK_SCALE_SWA: _swa_payload,
             }

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -745,9 +745,22 @@ def filter_kv_indices_for_cp_rank(
 
 def is_mla_backend(target_kv_pool) -> bool:
     from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
-    from sglang.srt.mem_cache.memory_pool import MLATokenToKVPool
+    from sglang.srt.mem_cache.memory_pool import (
+        HybridLinearKVPool,
+        MLATokenToKVPool,
+    )
 
-    return isinstance(target_kv_pool, (MLATokenToKVPool, DeepSeekV4TokenToKVPool))
+    if isinstance(target_kv_pool, (MLATokenToKVPool, DeepSeekV4TokenToKVPool)):
+        return True
+
+    # Kimi-K3 exposes its MLA cache through the hybrid KDA/MLA wrapper. The
+    # latent KV has one shared head and must use the flat MLA transfer path,
+    # rather than the MHA head-sliced path.
+    return (
+        isinstance(target_kv_pool, HybridLinearKVPool)
+        and bool(target_kv_pool.use_mla)
+        and isinstance(target_kv_pool.full_kv_pool, MLATokenToKVPool)
+    )
 
 
 def compute_mamba_state_slice_blocks(
@@ -969,6 +982,7 @@ def setup_state_kv_args(
     draft_token_to_kv_pool=None,
     total_kv_layers: int = None,
     req_to_token_pool=None,
+    draft_kv_as_state: bool = False,
 ) -> None:
     """Populate ``kv_args`` state-buffer fields from the given pool.
     Shared by prefill and decode bootstrap paths so the state_type dispatch
@@ -1099,9 +1113,31 @@ def setup_state_kv_args(
                 slice_outer_counts,
                 layer_ids,
             )
+            full_kv_pool = token_to_kv_pool.full_kv_pool
+            if isinstance(full_kv_pool, NPUMLATokenToKVPool):
+                if full_kv_pool.layer_num <= 0:
+                    raise ValueError(
+                        "NPU MLA KV pool must contain at least one full-attention "
+                        "layer for PD transfer."
+                    )
+                if len(kv_args.kv_data_ptrs) % full_kv_pool.layer_num != 0:
+                    raise ValueError(
+                        "NPU MLA KV buffer count must be divisible by its layer "
+                        f"count, got buffers={len(kv_args.kv_data_ptrs)}, "
+                        f"layers={full_kv_pool.layer_num}."
+                    )
+                # NPU MLA stores latent K and K-RoPE in separate unequal-width
+                # buffer groups. Keep that grouping independent of Mamba and
+                # speculative draft state components.
+                kv_args.kv_buf_groups = (
+                    len(kv_args.kv_data_ptrs) // full_kv_pool.layer_num
+                )
+                kv_args.total_kv_layers = total_kv_layers
         elif isinstance(token_to_kv_pool, (DSATokenToKVPool, NPUMLATokenToKVPool)):
-            if draft_token_to_kv_pool is not None and isinstance(
-                draft_token_to_kv_pool, DSATokenToKVPool
+            if (
+                not draft_kv_as_state
+                and draft_token_to_kv_pool is not None
+                and isinstance(draft_token_to_kv_pool, DSATokenToKVPool)
             ):
                 (
                     draft_data_ptrs,
@@ -1133,6 +1169,40 @@ def setup_state_kv_args(
                 c128_lens,
                 c128_item_lens,
             )
+
+    if draft_kv_as_state:
+        if draft_token_to_kv_pool is None:
+            raise ValueError(
+                "Draft KV state transfer requires a draft token-to-KV pool."
+            )
+        target_page_size = getattr(token_to_kv_pool, "page_size", None)
+        draft_page_size = getattr(draft_token_to_kv_pool, "page_size", None)
+        if (
+            target_page_size is not None
+            and draft_page_size is not None
+            and target_page_size != draft_page_size
+        ):
+            raise ValueError(
+                "Target and draft KV pools must use the same page size for "
+                "PD dSparK transfer, got target="
+                f"{target_page_size}, draft={draft_page_size}."
+            )
+        draft_ptrs, draft_lens, draft_item_lens = (
+            draft_token_to_kv_pool.get_contiguous_buf_infos()
+        )
+        draft_layer_ids = (
+            draft_token_to_kv_pool.get_kv_layer_ids()
+            if hasattr(draft_token_to_kv_pool, "get_kv_layer_ids")
+            else None
+        )
+        append_state_component(
+            kv_args,
+            StateType.DRAFT_KV,
+            draft_ptrs,
+            draft_lens,
+            draft_item_lens,
+            layer_ids=draft_layer_ids,
+        )
 
     # DSV4 NextN shares the target allocator, so target and draft use the same
     # local SWA indices. Keep draft buffers in a separate positional component

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
@@ -12,6 +12,7 @@ from sgl_kernel_npu.attention.sinks_attention import (
 
 from sglang.srt.configs.model_config import AttentionArch
 from sglang.srt.dllm.config import DllmConfig
+from sglang.srt.distributed import get_attn_cp_group
 from sglang.srt.hardware_backend.npu.attention.ascend_torch_native_backend import (
     AscendTorchNativeAttnBackend,
 )
@@ -22,7 +23,15 @@ from sglang.srt.hardware_backend.npu.attention.mla_preprocess import (
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
 from sglang.srt.layers.attention.dsa.utils import is_dsa_enable_prefill_cp
 from sglang.srt.layers.radix_attention import AttentionType
-from sglang.srt.layers.utils.cp_utils import cp_all_gather_rerange_kv_cache
+from sglang.srt.layers.utils.cp_utils import (
+    MLA_CP_RING_MAX_CAUSAL_BLOCK_SIZE,
+    cp_all_gather_rerange_kv_cache,
+    get_prefix_block_slices,
+    get_zigzag_cp_rank_block_lengths,
+    get_zigzag_cp_rank_chunk_indices,
+    get_zigzag_mla_cp_ring_visibility,
+    use_npu_mla_cp_ring,
+)
 from sglang.srt.mem_cache.memory_pool import KVWriteLoc
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
@@ -46,6 +55,8 @@ from sglang.srt.runtime_context import get_parallel
 
 logger = logging.getLogger(__name__)
 FULL_ATTENTION_WINDOW = 2147483647
+MLA_CP_RING_PREFIX_BLOCK_SIZE = 32768
+MLA_CP_RING_BATCH_PREFIX_MAX_TOKENS = 16384
 
 
 def _is_dflash_verify(spec_info: Optional[SpecInput]) -> bool:
@@ -69,9 +80,28 @@ def _reshape_kv_for_fia_nz(
     return tensor.view(-1, 1, num_heads * head_dim // 16, page_size, 16)
 
 
+def _split_cp_query_halves(q: torch.Tensor, cp_meta):
+    """Split live zigzag rows and report trailing CP-v2 padding rows."""
+    prev_rows = cp_meta.total_q_prev_tokens
+    logical_rows = prev_rows + cp_meta.total_q_next_tokens
+    if q.shape[0] < logical_rows:
+        raise ValueError(
+            "CP query has fewer rows than its metadata: "
+            f"tensor={q.shape[0]}, metadata={logical_rows}."
+        )
+    return q[:prev_rows], q[prev_rows:logical_rows], q.shape[0] - logical_rows
+
+
+def _restore_cp_query_padding(output: torch.Tensor, padding_rows: int) -> torch.Tensor:
+    if padding_rows == 0:
+        return output
+    return torch.cat(
+        [output, output.new_zeros((padding_rows, *output.shape[1:]))], dim=0
+    )
+
+
 @dataclass
 class ForwardMetadata:
-
     # calculated map for kv positions [bs * maxseqlen]
     block_tables: Optional[torch.Tensor] = None
 
@@ -100,6 +130,15 @@ class ForwardMetadata:
     # prefix cache
     prefix_lens: Optional[torch.Tensor] = None
     flatten_prefix_block_tables: Optional[torch.Tensor] = None
+
+
+@dataclass
+class MLACPRingSourceLayout:
+    token_count: int
+    early_token_count: int
+    early_to_prev_seq_lens: torch.Tensor
+    early_to_next_seq_lens: torch.Tensor
+    late_to_next_seq_lens: torch.Tensor
 
 
 class AscendAttnMaskBuilder:
@@ -298,8 +337,100 @@ def _cp_allgather_and_save_kv_npu(
     )
 
 
-class AscendAttnBackend(AttentionBackend):
+def _get_mla_cp_ring_cache_locs(forward_batch, layer, cp_size):
+    """Build natural paged-cache locations for every zigzag CP shard."""
+    cached_locs = getattr(forward_batch, "mla_cp_ring_cache_locs", None)
+    if cached_locs is not None:
+        return cached_locs
 
+    cache_loc = (
+        forward_batch.out_cache_loc
+        if not layer.is_cross_attention
+        else forward_batch.encoder_out_cache_loc
+    )
+    metadata = forward_batch.attn_cp_metadata
+    if cache_loc.shape[0] != sum(metadata.split_list):
+        raise ValueError(
+            "MLA CP ring cache locations do not match zigzag metadata: "
+            f"locations={cache_loc.shape[0]}, splits={sum(metadata.split_list)}."
+        )
+    natural_chunks = torch.split(cache_loc, metadata.split_list, dim=0)
+    cached_locs = tuple(
+        torch.cat(
+            [
+                natural_chunks[index]
+                for index in get_zigzag_cp_rank_chunk_indices(
+                    int(metadata.bs), cp_size, cp_rank
+                )
+            ],
+            dim=0,
+        )
+        for cp_rank in range(cp_size)
+    )
+    forward_batch.mla_cp_ring_cache_locs = cached_locs
+    return cached_locs
+
+
+def _get_mla_cp_ring_source_layouts(forward_batch, cp_size, cp_rank):
+    """Build source-specific block lengths and ATB sequence metadata."""
+    cached_layouts = getattr(forward_batch, "mla_cp_ring_source_layouts", None)
+    if cached_layouts is not None:
+        return cached_layouts
+
+    metadata = forward_batch.attn_cp_metadata
+    bs = int(metadata.bs)
+    local_prev_lens = [int(length) for length in metadata.actual_seq_q_prev_list]
+    local_next_lens = [int(length) for length in metadata.actual_seq_q_next_list]
+    expected_prev_lens, expected_next_lens = get_zigzag_cp_rank_block_lengths(
+        metadata.split_list, bs, cp_size, cp_rank
+    )
+    if local_prev_lens != expected_prev_lens or local_next_lens != expected_next_lens:
+        raise ValueError(
+            "MLA CP ring local Q lengths do not match zigzag metadata: "
+            f"prev={local_prev_lens}/{expected_prev_lens}, "
+            f"next={local_next_lens}/{expected_next_lens}."
+        )
+
+    layouts = []
+    for source_rank in range(cp_size):
+        early_lens, late_lens = get_zigzag_cp_rank_block_lengths(
+            metadata.split_list, bs, cp_size, source_rank
+        )
+        early_to_prev, _, late_to_next = get_zigzag_mla_cp_ring_visibility(
+            cp_rank, source_rank
+        )
+        if early_to_prev and any(
+            kv_len < q_len for q_len, kv_len in zip(local_prev_lens, early_lens)
+        ):
+            raise ValueError("MLA CP ring early KV length is shorter than early Q")
+        if any(kv_len < q_len for q_len, kv_len in zip(local_next_lens, early_lens)):
+            raise ValueError("MLA CP ring early KV length is shorter than late Q")
+        if late_to_next and any(
+            kv_len < q_len for q_len, kv_len in zip(local_next_lens, late_lens)
+        ):
+            raise ValueError("MLA CP ring late KV length is shorter than late Q")
+
+        layouts.append(
+            MLACPRingSourceLayout(
+                token_count=sum(early_lens) + sum(late_lens),
+                early_token_count=sum(early_lens),
+                early_to_prev_seq_lens=torch.tensor(
+                    [local_prev_lens, early_lens], dtype=torch.int32
+                ),
+                early_to_next_seq_lens=torch.tensor(
+                    [local_next_lens, early_lens], dtype=torch.int32
+                ),
+                late_to_next_seq_lens=torch.tensor(
+                    [local_next_lens, late_lens], dtype=torch.int32
+                ),
+            )
+        )
+    cached_layouts = tuple(layouts)
+    forward_batch.mla_cp_ring_source_layouts = cached_layouts
+    return cached_layouts
+
+
+class AscendAttnBackend(AttentionBackend):
     def __init__(self, model_runner: ModelRunner, speculative_step_id: int = 0):
         super().__init__()
         self.forward_metadata = None
@@ -396,6 +527,20 @@ class AscendAttnBackend(AttentionBackend):
             self.dllm_block_size = self.dllm_config.block_size
 
         self.attn_cp_size = model_runner.ps.attn_cp_size
+        self.mla_cp_ring_prefix_block_size = MLA_CP_RING_PREFIX_BLOCK_SIZE
+        if self.mla_cp_ring_prefix_block_size % self.page_size != 0:
+            raise ValueError(
+                "MLA CP ring prefix block size must be a multiple of "
+                f"page_size={self.page_size}, got "
+                f"{self.mla_cp_ring_prefix_block_size}."
+            )
+        # Shared by all MLA layers in this backend. Ring prefill is eager and
+        # layers execute serially, so two ping-pong receive buffers are enough
+        # for every layer and avoid allocator work in each ring step.
+        self._mla_cp_ring_exchange_buffers = None
+        self._mla_cp_ring_send_buffer = None
+        self._mla_cp_ring_seq_lens_cache = {}
+        self._mla_cp_ring_prefix_indices_cache = {}
 
     def _is_swa_layer(self, layer: RadixAttention) -> bool:
         return (
@@ -552,9 +697,7 @@ class AscendAttnBackend(AttentionBackend):
                 "cpu"
             )
             seq_prefix_lens = self.forward_metadata.prefix_lens.tolist()
-            self.forward_metadata.flatten_prefix_block_tables = torch.empty(
-                0, dtype=torch.int32
-            ).to(self.device)
+            prefix_block_table_chunks = []
             for req_idx, seq_len in zip(
                 forward_batch.req_pool_indices.tolist(), seq_prefix_lens
             ):
@@ -562,12 +705,12 @@ class AscendAttnBackend(AttentionBackend):
                 req_prefix_block_tables = (
                     req_indices[:seq_len][:: self.page_size] // self.page_size
                 )
-                self.forward_metadata.flatten_prefix_block_tables = torch.cat(
-                    (
-                        self.forward_metadata.flatten_prefix_block_tables,
-                        torch.flatten(req_prefix_block_tables),
-                    )
-                )
+                prefix_block_table_chunks.append(torch.flatten(req_prefix_block_tables))
+            self.forward_metadata.flatten_prefix_block_tables = (
+                prefix_block_table_chunks[0]
+                if len(prefix_block_table_chunks) == 1
+                else torch.cat(prefix_block_table_chunks)
+            )
 
         if self.use_sliding_window_kv_pool and forward_batch.out_cache_loc is not None:
             self.forward_metadata.swa_out_cache_loc = (
@@ -1008,13 +1151,9 @@ class AscendAttnBackend(AttentionBackend):
 
         # Local tokens are laid out [all_seqs_prev, all_seqs_next]; split at
         # total_q_prev_tokens rather than the midpoint to support bs > 1.
-        split = cp_meta.total_q_prev_tokens
-        q_prev = (
-            q[:split].contiguous().reshape(-1, layer.tp_q_head_num, layer.qk_head_dim)
-        )
-        q_next = (
-            q[split:].contiguous().reshape(-1, layer.tp_q_head_num, layer.qk_head_dim)
-        )
+        q_prev, q_next, padding_rows = _split_cp_query_halves(q, cp_meta)
+        q_prev = q_prev.contiguous().reshape(-1, layer.tp_q_head_num, layer.qk_head_dim)
+        q_next = q_next.contiguous().reshape(-1, layer.tp_q_head_num, layer.qk_head_dim)
 
         k_cache_paged = k_cache.view(
             -1, self.page_size, layer.tp_k_head_num * layer.qk_head_dim
@@ -1057,8 +1196,895 @@ class AscendAttnBackend(AttentionBackend):
             actual_seq_lengths_kv=cp_meta.kv_len_next_list,
         )
 
-        attn_out = torch.cat([attn_out_prev, attn_out_next], dim=0)
+        attn_out = _restore_cp_query_padding(
+            torch.cat([attn_out_prev, attn_out_next], dim=0), padding_rows
+        )
         return attn_out.view(-1, layer.tp_q_head_num * layer.v_head_dim)
+
+    def _get_mla_cp_ring_exchange_buffer(
+        self, packed_kv: torch.Tensor, slot: int
+    ) -> torch.Tensor:
+        buffers = getattr(self, "_mla_cp_ring_exchange_buffers", None)
+        spec = (packed_kv.shape, packed_kv.dtype, packed_kv.device)
+        if buffers is None or buffers[0] != spec:
+            buffers = (
+                spec,
+                torch.empty_like(packed_kv),
+                torch.empty_like(packed_kv),
+            )
+            self._mla_cp_ring_exchange_buffers = buffers
+        return buffers[1 + slot]
+
+    def _pack_mla_cp_ring_local_kv(
+        self,
+        local_latent_k: torch.Tensor,
+        local_k_rope: torch.Tensor,
+        max_rank_tokens: int,
+    ) -> torch.Tensor:
+        """Pack compact MLA KV directly into a reusable ring send buffer."""
+        local_token_count = local_latent_k.shape[0]
+        if local_k_rope.shape[0] != local_token_count:
+            raise ValueError("MLA CP ring latent and RoPE token counts differ")
+        if local_token_count > max_rank_tokens:
+            raise ValueError(
+                f"MLA CP ring local payload {local_token_count} exceeds "
+                f"max_rank_len {max_rank_tokens}."
+            )
+
+        latent = local_latent_k.flatten(1)
+        rope = local_k_rope.flatten(1)
+        shape = (max_rank_tokens, latent.shape[-1] + rope.shape[-1])
+        spec = (shape, local_latent_k.dtype, local_latent_k.device)
+        cached = self._mla_cp_ring_send_buffer
+        if cached is None or cached[0] != spec:
+            # The receiver slices by the source rank's exact token count, so
+            # padding is not consumed and only needs deterministic zeroing once.
+            cached = (spec, local_latent_k.new_zeros(shape))
+            self._mla_cp_ring_send_buffer = cached
+        packed = cached[1]
+        packed[:local_token_count, : latent.shape[-1]].copy_(latent)
+        packed[:local_token_count, latent.shape[-1] :].copy_(rope)
+        return packed
+
+    def _get_mla_cp_ring_seq_lens(
+        self, q_lens: List[int], kv_lens: List[int]
+    ) -> torch.Tensor:
+        """Reuse host length tensors across Kimi-K3's many MLA layers."""
+        key = (tuple(q_lens), tuple(kv_lens))
+        cache = getattr(self, "_mla_cp_ring_seq_lens_cache", None)
+        if cache is None:
+            cache = self._mla_cp_ring_seq_lens_cache = {}
+        seq_lens = cache.get(key)
+        if seq_lens is None:
+            # Bound the cache for serving workloads with highly variable
+            # batches. Clearing is safe because ATB consumes host metadata
+            # synchronously when the operator is launched.
+            if len(cache) >= 64:
+                cache.clear()
+            seq_lens = torch.tensor([q_lens, kv_lens], dtype=torch.int32)
+            cache[key] = seq_lens
+        return seq_lens
+
+    def _get_mla_cp_ring_causal_prefix_plan(
+        self, q_len: int, tile_size: int, device: torch.device
+    ) -> tuple[torch.Tensor, tuple[int, ...], tuple[int, ...]]:
+        """Return the packed strictly-lower causal rectangles for one request."""
+        key = (q_len, tile_size, str(device))
+        cache = getattr(self, "_mla_cp_ring_prefix_indices_cache", None)
+        if cache is None:
+            cache = self._mla_cp_ring_prefix_indices_cache = {}
+        plan = cache.get(key)
+        if plan is None:
+            tile_starts = tuple(range(tile_size, q_len, tile_size))
+            q_lens = tuple(
+                min(tile_size, q_len - tile_start) for tile_start in tile_starts
+            )
+            # ATB TND packs every sequence's keys contiguously. The strictly
+            # lower rectangles reuse progressively longer prefixes, so form
+            # one cached gather plan and apply it to K, K-RoPE and V.
+            prefix_indices = torch.tensor(
+                [index for tile_start in tile_starts for index in range(tile_start)],
+                dtype=torch.int64,
+                device=device,
+            )
+            if len(cache) >= 64:
+                cache.clear()
+            plan = (prefix_indices, q_lens, tile_starts)
+            cache[key] = plan
+        return plan
+
+    def _start_mla_cp_ring_kv_exchange(
+        self, packed_kv: torch.Tensor, recv_kv: Optional[torch.Tensor] = None
+    ):
+        """Start rotating one compact latent-KV shard to the next CP rank."""
+        cp_group = get_attn_cp_group()
+        cp_rank = cp_group.rank_in_group
+        next_global_rank = cp_group.ranks[(cp_rank + 1) % cp_group.world_size]
+        prev_global_rank = cp_group.ranks[(cp_rank - 1) % cp_group.world_size]
+        if recv_kv is None:
+            recv_kv = torch.empty_like(packed_kv)
+        elif (
+            recv_kv.shape != packed_kv.shape
+            or recv_kv.dtype != packed_kv.dtype
+            or recv_kv.device != packed_kv.device
+        ):
+            raise ValueError("MLA CP ring receive buffer does not match packed KV")
+        ops = [
+            torch.distributed.P2POp(
+                torch.distributed.irecv,
+                recv_kv,
+                prev_global_rank,
+                cp_group.device_group,
+            ),
+            torch.distributed.P2POp(
+                torch.distributed.isend,
+                packed_kv,
+                next_global_rank,
+                cp_group.device_group,
+            ),
+        ]
+        requests = torch.distributed.batch_isend_irecv(ops)
+        return recv_kv, requests
+
+    @staticmethod
+    def _finish_mla_cp_ring_kv_exchange(recv_kv, requests):
+        """Wait for a previously started compact-KV rotation."""
+        for request in requests:
+            request.wait()
+        return recv_kv
+
+    def _get_mla_cp_ring_prefix_token_plans(
+        self,
+        forward_batch: ForwardBatch,
+        prefix_lens: List[int],
+        minimum_block_lens: List[int],
+    ):
+        """Cache exact paged-prefix token indices for every bounded round.
+
+        Prefix page tables and block slicing are layer independent.  Building
+        an exact token plan once lets every MLA layer gather directly from the
+        flattened page pool, instead of selecting whole pages per request and
+        concatenating their trimmed data tensors again in every layer.
+        """
+        prefix_block_tables = self.forward_metadata.flatten_prefix_block_tables
+        if prefix_block_tables is None:
+            raise ValueError("MLA CP ring prefix block tables are missing")
+        prefix_block_tables = prefix_block_tables.reshape(-1)
+        key = (
+            tuple(int(length) for length in prefix_lens),
+            tuple(int(length) for length in minimum_block_lens),
+            self.mla_cp_ring_prefix_block_size,
+            self.page_size,
+        )
+        cache = getattr(forward_batch, "_mla_cp_ring_prefix_token_plans", None)
+        if cache is None:
+            cache = {}
+            forward_batch._mla_cp_ring_prefix_token_plans = cache
+        cached = cache.get(key)
+        if cached is not None:
+            return cached
+
+        request_page_offsets = []
+        page_offset = 0
+        for prefix_len in prefix_lens:
+            request_page_offsets.append(page_offset)
+            page_offset += (int(prefix_len) + self.page_size - 1) // self.page_size
+        if page_offset != prefix_block_tables.numel():
+            raise ValueError(
+                "Selected MLA CP ring prefix pages do not match prefix lengths: "
+                f"pages={prefix_block_tables.numel()}, expected={page_offset}."
+            )
+
+        page_token_offsets = torch.arange(
+            self.page_size,
+            dtype=torch.int64,
+            device=prefix_block_tables.device,
+        )
+        plans = []
+        for block_slices in get_prefix_block_slices(
+            prefix_lens,
+            self.mla_cp_ring_prefix_block_size,
+            minimum_block_lens,
+        ):
+            block_lens = tuple(int(length) for _, length in block_slices)
+            token_index_chunks = []
+            for request_index, (start, length) in enumerate(block_slices):
+                if length == 0:
+                    continue
+                first_page = start // self.page_size
+                page_start_offset = start % self.page_size
+                page_count = (
+                    page_start_offset + length + self.page_size - 1
+                ) // self.page_size
+                table_start = request_page_offsets[request_index] + first_page
+                page_indices = prefix_block_tables[
+                    table_start : table_start + page_count
+                ].to(torch.int64)
+                physical_token_indices = (
+                    page_indices.view(-1, 1) * self.page_size
+                    + page_token_offsets.view(1, -1)
+                ).reshape(-1)
+                token_index_chunks.append(
+                    physical_token_indices[
+                        page_start_offset : page_start_offset + length
+                    ]
+                )
+            if not token_index_chunks:
+                continue
+            token_indices = (
+                token_index_chunks[0]
+                if len(token_index_chunks) == 1
+                else torch.cat(token_index_chunks)
+            )
+            plans.append((block_lens, token_indices))
+
+        if len(cache) >= 8:
+            cache.clear()
+        cached = tuple(plans)
+        cache[key] = cached
+        return cached
+
+    def _iter_mla_cp_ring_compact_prefix_blocks(
+        self,
+        k_buffer: torch.Tensor,
+        v_buffer: torch.Tensor,
+        forward_batch: ForwardBatch,
+        prefix_lens: List[int],
+        minimum_block_lens: List[int],
+    ):
+        k_flat = k_buffer.flatten(0, 1)
+        v_flat = v_buffer.flatten(0, 1)
+        for block_lens, token_indices in self._get_mla_cp_ring_prefix_token_plans(
+            forward_batch, prefix_lens, minimum_block_lens
+        ):
+            yield (
+                list(block_lens),
+                torch.index_select(k_flat, 0, token_indices),
+                torch.index_select(v_flat, 0, token_indices),
+            )
+
+    def _iter_mla_cp_ring_prefix_kv_blocks(
+        self,
+        layer: RadixAttention,
+        forward_batch: ForwardBatch,
+        prefix_lens: List[int],
+        minimum_block_lens: List[int],
+    ):
+        """Load and expand the radix prefix in bounded blocks.
+
+        Expanding the complete accumulated prefix made the eager prefill peak
+        grow with every chunk and also presented a new, ever-larger shape to
+        AtbRingMLA.  Yielding one bounded block at a time caps both the
+        projection tensors and the operator workspace shapes.
+        """
+        if not any(prefix_lens):
+            return
+        if (
+            self.forward_metadata.prefix_lens is None
+            or self.forward_metadata.flatten_prefix_block_tables is None
+        ):
+            raise ValueError("MLA CP ring prefix metadata is missing")
+
+        k_buffer = self.token_to_kv_pool.get_key_buffer(layer.layer_id)
+        v_buffer = self.token_to_kv_pool.get_value_buffer(layer.layer_id)
+        for (
+            block_lens,
+            prefix_latent_k,
+            prefix_k_rope_compact,
+        ) in self._iter_mla_cp_ring_compact_prefix_blocks(
+            k_buffer,
+            v_buffer,
+            forward_batch,
+            prefix_lens,
+            minimum_block_lens,
+        ):
+            if prefix_latent_k.shape[0] != sum(block_lens):
+                raise ValueError(
+                    "MLA CP ring packed prefix block length is inconsistent"
+                )
+
+            projected_kv = layer.kv_b_proj(prefix_latent_k.squeeze(1))[0].view(
+                -1,
+                layer.tp_k_head_num,
+                layer.v_head_dim * 2,
+            )
+            prefix_k_nope, prefix_value = projected_kv.split(
+                [layer.v_head_dim, layer.v_head_dim], dim=-1
+            )
+            prefix_k_rope = prefix_k_rope_compact.expand(-1, layer.tp_k_head_num, -1)
+            # The projected K/V no longer depends on the compact latent
+            # tensor. Release page-selection intermediates before ATB runs.
+            del prefix_latent_k
+            yield block_lens, prefix_k_nope, prefix_k_rope, prefix_value
+            # A generator retains its frame across ``yield``. Explicitly drop
+            # the yielded block before constructing the next one, otherwise
+            # consecutive expanded blocks overlap in allocator lifetime.
+            del (
+                projected_kv,
+                prefix_k_nope,
+                prefix_k_rope,
+                prefix_k_rope_compact,
+                prefix_value,
+            )
+
+    def _run_mla_cp_ring_segment(
+        self,
+        q_nope: torch.Tensor,
+        q_rope: torch.Tensor,
+        k_nope: torch.Tensor,
+        k_rope: torch.Tensor,
+        value: torch.Tensor,
+        seq_lens: torch.Tensor,
+        layer: RadixAttention,
+        causal: bool,
+        previous_output: Optional[torch.Tensor],
+        previous_lse: Optional[torch.Tensor],
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Compute and online-merge one visible Q/KV block pair."""
+        if causal:
+            if seq_lens.ndim != 2 or seq_lens.shape[0] != 2:
+                raise ValueError(
+                    "causal MLA CP ring segments require [2, batch] lengths"
+                )
+            q_lens = [int(length) for length in seq_lens[0].tolist()]
+            if max(q_lens, default=0) > MLA_CP_RING_MAX_CAUSAL_BLOCK_SIZE:
+                return self._run_mla_cp_ring_causal_tiled(
+                    q_nope,
+                    q_rope,
+                    k_nope,
+                    k_rope,
+                    value,
+                    q_lens,
+                    [int(length) for length in seq_lens[1].tolist()],
+                    layer,
+                    previous_output,
+                    previous_lse,
+                )
+        q_len = q_nope.shape[0]
+        first_block = previous_output is None
+        if first_block != (previous_lse is None):
+            raise ValueError("MLA CP ring output and LSE must be initialized together")
+        if first_block:
+            output = q_nope.new_zeros(q_nope.shape)
+            softmax_lse = torch.zeros(
+                layer.tp_q_head_num,
+                q_len,
+                dtype=torch.float32,
+                device=q_nope.device,
+            )
+        else:
+            # ATB supports in-place online softmax merging. Reusing these two
+            # buffers avoids allocating output and LSE for every visible block.
+            output = previous_output
+            softmax_lse = previous_lse
+        torch_npu.atb.npu_ring_mla(
+            q_nope=q_nope,
+            q_rope=q_rope,
+            k_nope=k_nope,
+            k_rope=k_rope,
+            value=value,
+            mask=self.ringmla_mask,
+            seqlen=seq_lens,
+            head_num=layer.tp_q_head_num,
+            kv_head_num=layer.tp_k_head_num,
+            pre_out=previous_output,
+            prev_lse=previous_lse,
+            qk_scale=layer.scaling,
+            kernel_type="kernel_type_high_precision",
+            mask_type="mask_type_triu" if causal else "no_mask",
+            calc_type=("calc_type_first_ring" if first_block else "calc_type_default"),
+            output=output,
+            softmax_lse=softmax_lse,
+        )
+        return output, softmax_lse
+
+    def _run_mla_cp_ring_causal_tiled(
+        self,
+        q_nope: torch.Tensor,
+        q_rope: torch.Tensor,
+        k_nope: torch.Tensor,
+        k_rope: torch.Tensor,
+        value: torch.Tensor,
+        q_lens: List[int],
+        kv_lens: List[int],
+        layer: RadixAttention,
+        previous_output: Optional[torch.Tensor],
+        previous_lse: Optional[torch.Tensor],
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Tile a large causal diagonal while preserving online softmax.
+
+        ATB fixes the triangular mask at 512x512.  For query tile ``i``, keys
+        from earlier tiles are first merged without a mask and the matching
+        key tile is then merged with the triangular mask.  This is exactly the
+        original causal block, while allowing the real 8K/128K PCP workload
+        to remain on the MLA ring backend instead of silently falling back to
+        absorbed MLA all-gather.
+        """
+        if len(q_lens) != len(kv_lens):
+            raise ValueError("MLA CP ring tiled query/KV batch sizes differ")
+        if any(q_len <= 0 or q_len != kv_len for q_len, kv_len in zip(q_lens, kv_lens)):
+            raise ValueError(
+                "MLA CP ring causal tiling requires equal, non-empty Q/KV blocks"
+            )
+        if (previous_output is None) != (previous_lse is None):
+            raise ValueError("MLA CP ring output and LSE must be initialized together")
+        request_outputs = []
+        request_lses = []
+        q_offset = 0
+        kv_offset = 0
+        tile_size = MLA_CP_RING_MAX_CAUSAL_BLOCK_SIZE
+        for q_len, kv_len in zip(q_lens, kv_lens):
+            q_req = q_nope[q_offset : q_offset + q_len]
+            q_rope_req = q_rope[q_offset : q_offset + q_len]
+            k_req = k_nope[kv_offset : kv_offset + kv_len]
+            k_rope_req = k_rope[kv_offset : kv_offset + kv_len]
+            value_req = value[kv_offset : kv_offset + kv_len]
+            prev_req = (
+                previous_output[q_offset : q_offset + q_len]
+                if previous_output is not None
+                else None
+            )
+            prev_lse_req = (
+                previous_lse[:, q_offset : q_offset + q_len]
+                if previous_lse is not None
+                else None
+            )
+
+            # Treat the fixed-size diagonal tiles as independent TND
+            # sequences and execute all of them in one RingMLA launch.
+            # The strictly-lower rectangles are merged afterwards. Online
+            # softmax is order-independent, and the ring already merges
+            # prefix/source blocks out of natural order, so this preserves
+            # the same attention. With packed prefixes enabled below this
+            # reduces 2*T-1 launches to 2; the bounded fallback uses T.
+            tile_lens = [
+                min(tile_size, q_len - tile_start)
+                for tile_start in range(0, q_len, tile_size)
+            ]
+            request_output, request_lse = self._run_mla_cp_ring_segment(
+                q_req,
+                q_rope_req,
+                k_req,
+                k_rope_req,
+                value_req,
+                self._get_mla_cp_ring_seq_lens(tile_lens, tile_lens),
+                layer,
+                causal=True,
+                previous_output=prev_req,
+                previous_lse=prev_lse_req,
+            )
+
+            if (
+                len(tile_lens) > 1
+                and sum(range(tile_size, q_len, tile_size))
+                <= MLA_CP_RING_BATCH_PREFIX_MAX_TOKENS
+            ):
+                prefix_indices, prefix_q_lens, prefix_kv_lens = (
+                    self._get_mla_cp_ring_causal_prefix_plan(
+                        q_len, tile_size, q_req.device
+                    )
+                )
+                first_tile_len = tile_lens[0]
+                self._run_mla_cp_ring_segment(
+                    q_req[first_tile_len:],
+                    q_rope_req[first_tile_len:],
+                    torch.index_select(k_req, 0, prefix_indices),
+                    torch.index_select(k_rope_req, 0, prefix_indices),
+                    torch.index_select(value_req, 0, prefix_indices),
+                    self._get_mla_cp_ring_seq_lens(
+                        list(prefix_q_lens), list(prefix_kv_lens)
+                    ),
+                    layer,
+                    causal=False,
+                    previous_output=request_output[first_tile_len:],
+                    previous_lse=request_lse[:, first_tile_len:],
+                )
+            else:
+                tile_start = tile_lens[0]
+                for tile_len in tile_lens[1:]:
+                    tile_end = tile_start + tile_len
+                    # Earlier keys are fully visible to this query tile.
+                    # The supplied output/LSE slices are updated in place.
+                    self._run_mla_cp_ring_segment(
+                        q_req[tile_start:tile_end],
+                        q_rope_req[tile_start:tile_end],
+                        k_req[:tile_start],
+                        k_rope_req[:tile_start],
+                        value_req[:tile_start],
+                        self._get_mla_cp_ring_seq_lens([tile_len], [tile_start]),
+                        layer,
+                        causal=False,
+                        previous_output=request_output[tile_start:tile_end],
+                        previous_lse=request_lse[:, tile_start:tile_end],
+                    )
+                    tile_start = tile_end
+
+            request_outputs.append(request_output)
+            request_lses.append(request_lse)
+            q_offset += q_len
+            kv_offset += kv_len
+
+        if q_offset != q_nope.shape[0] or kv_offset != k_nope.shape[0]:
+            raise ValueError("MLA CP ring tiled sequence lengths do not match tensors")
+        if len(request_outputs) == 1:
+            return request_outputs[0], request_lses[0]
+        return torch.cat(request_outputs, dim=0), torch.cat(request_lses, dim=1)
+
+    def do_cp_mla_attn_ring(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        layer: RadixAttention,
+        forward_batch: ForwardBatch,
+    ) -> torch.Tensor:
+        """Run zigzag MLA attention by rotating latent KV.
+
+        Each compact shard received during the attention ring is scattered
+        directly to its natural paged-cache locations. No second CP all-gather
+        or full-sequence staging tensor is needed. Every rank still gets a
+        complete cache for radix-prefix correctness, while the existing
+        CP-rank-0 PD sender remains unchanged.
+        """
+        cp_meta = forward_batch.attn_cp_metadata
+        cp_group = get_attn_cp_group()
+        cp_rank = cp_group.rank_in_group
+        cp_size = cp_group.world_size
+        bs = int(cp_meta.bs)
+        block_lens_prev = [int(length) for length in cp_meta.actual_seq_q_prev_list]
+        block_lens_next = [int(length) for length in cp_meta.actual_seq_q_next_list]
+        if len(block_lens_prev) != bs or len(block_lens_next) != bs:
+            raise ValueError(
+                "MLA CP ring requires one early/late block length per request, "
+                f"got bs={bs}, prev={block_lens_prev}, next={block_lens_next}."
+            )
+        split = cp_meta.total_q_prev_tokens
+        next_tokens = cp_meta.total_q_next_tokens
+        if split != sum(block_lens_prev) or next_tokens != sum(block_lens_next):
+            raise ValueError("MLA CP ring token totals do not match CP metadata")
+        source_layouts = _get_mla_cp_ring_source_layouts(
+            forward_batch, cp_size, cp_rank
+        )
+        max_rank_tokens = int(cp_meta.max_rank_len[0])
+        if any(layout.token_count > max_rank_tokens for layout in source_layouts):
+            raise ValueError("MLA CP ring source payload exceeds max_rank_len")
+
+        if (
+            layer.v_head_dim != 128
+            or self.qk_rope_head_dim != 64
+            or layer.qk_head_dim != 192
+        ):
+            raise ValueError(
+                "npu_ring_mla requires q_nope/k_nope/value dim 128 and RoPE "
+                f"dim 64, got qk={layer.qk_head_dim}, v={layer.v_head_dim}, "
+                f"rope={self.qk_rope_head_dim}."
+            )
+        if layer.kv_b_proj is None:
+            raise ValueError("MLA CP ring requires kv_b_proj to expand latent KV")
+
+        local_latent_k = forward_batch.mla_cp_local_k
+        local_k_rope = forward_batch.mla_cp_local_k_rope
+        latent_head_num = local_latent_k.shape[1]
+        rope_head_num = local_k_rope.shape[1]
+        if latent_head_num != 1 or rope_head_num != 1:
+            raise ValueError(
+                "MLA CP ring expects one latent KV head, got "
+                f"K heads={latent_head_num}, K-RoPE heads={rope_head_num}."
+            )
+        local_token_count = split + next_tokens
+        if (
+            local_latent_k.shape[0] != local_token_count
+            or local_token_count != source_layouts[cp_rank].token_count
+        ):
+            raise ValueError(
+                "MLA CP ring local KV length does not match zigzag metadata: "
+                f"KV={local_latent_k.shape[0]}, Q={local_token_count}, "
+                f"layout={source_layouts[cp_rank].token_count}."
+            )
+        latent_feature_size = latent_head_num * self.kv_lora_rank
+
+        packed_kv = self._pack_mla_cp_ring_local_kv(
+            local_latent_k,
+            local_k_rope,
+            max_rank_tokens,
+        )
+
+        q = q.reshape(-1, layer.tp_q_head_num, layer.qk_head_dim)
+        q_nope, q_rope = q.split([layer.v_head_dim, self.qk_rope_head_dim], dim=-1)
+        # Materialize each last-dimension split once; the two token halves are
+        # then contiguous views and do not need four separate copy launches.
+        q_nope = q_nope.contiguous()
+        q_rope = q_rope.contiguous()
+        q_nope_prev, q_nope_next = q_nope[:split], q_nope[split:]
+        q_rope_prev, q_rope_next = q_rope[:split], q_rope[split:]
+        if q_nope_prev.shape[0] != split or q_nope_next.shape[0] != next_tokens:
+            raise ValueError(
+                "MLA CP ring local Q halves must match the zigzag metadata, "
+                f"got prev={q_nope_prev.shape[0]}, next={q_nope_next.shape[0]}, "
+                f"expected_prev={split}, expected_next={next_tokens}."
+            )
+
+        local_k_nope, local_expanded_k_rope = k.split(
+            [layer.v_head_dim, self.qk_rope_head_dim], dim=-1
+        )
+        cache_locs_by_rank = _get_mla_cp_ring_cache_locs(forward_batch, layer, cp_size)
+        prefix_lens = [int(length) for length in forward_batch.extend_prefix_lens_cpu]
+        if len(prefix_lens) != bs:
+            raise ValueError(
+                "MLA CP ring prefix lengths do not match batch size: "
+                f"prefixes={len(prefix_lens)}, bs={bs}."
+            )
+        output_prev = lse_prev = None
+        output_next = lse_next = None
+        output_all = lse_all = None
+
+        for ring_step in range(cp_size):
+            recv_kv = exchange_requests = None
+            if ring_step + 1 < cp_size:
+                # Launch the next rotation before projection and attention so
+                # HCCL can transfer compact KV while ATB consumes this shard.
+                recv_kv, exchange_requests = self._start_mla_cp_ring_kv_exchange(
+                    packed_kv,
+                    self._get_mla_cp_ring_exchange_buffer(packed_kv, ring_step % 2),
+                )
+
+            source_rank = (cp_rank - ring_step) % cp_size
+            source_layout = source_layouts[source_rank]
+            (
+                early_to_prev,
+                early_to_next,
+                late_to_next,
+            ) = get_zigzag_mla_cp_ring_visibility(cp_rank, source_rank)
+            source_packed_kv = packed_kv[: source_layout.token_count]
+            source_latent_k = source_packed_kv[:, :latent_feature_size].reshape(
+                -1, latent_head_num, self.kv_lora_rank
+            )
+            source_k_rope_compact = source_packed_kv[:, latent_feature_size:].reshape(
+                -1, rope_head_num, self.qk_rope_head_dim
+            )
+            if ring_step == 0:
+                source_k_nope = local_k_nope
+                source_k_rope = local_expanded_k_rope
+                source_value = v
+            else:
+                projected_kv = layer.kv_b_proj(source_latent_k.squeeze(1))[0].view(
+                    -1,
+                    layer.tp_k_head_num,
+                    layer.v_head_dim * 2,
+                )
+                source_k_nope, source_value = projected_kv.split(
+                    [layer.v_head_dim, layer.v_head_dim], dim=-1
+                )
+                source_k_rope = source_k_rope_compact.expand(
+                    -1, layer.tp_k_head_num, -1
+                )
+
+            # K/V projections are last-dimension views and expanded RoPE has
+            # a zero head stride. Materialize each full shard once, then pass
+            # contiguous first-dimension early/late views to RingMLA. Doing a
+            # separate contiguous() for both halves doubled copy launches.
+            source_k_nope = source_k_nope.contiguous()
+            source_k_rope = source_k_rope.contiguous()
+            source_value = source_value.contiguous()
+            source_early_tokens = source_layout.early_token_count
+            source_early_k = source_k_nope[:source_early_tokens]
+            source_early_rope = source_k_rope[:source_early_tokens]
+            source_early_v = source_value[:source_early_tokens]
+            source_late_k = source_k_nope[source_early_tokens:]
+            source_late_rope = source_k_rope[source_early_tokens:]
+            source_late_v = source_value[source_early_tokens:]
+
+            if source_rank == cp_rank:
+                # Both local early/late blocks are causal diagonals. Q and KV
+                # already use the same packed order
+                #   [all early requests, all late requests],
+                # so one TND launch can process the 2*BS independent causal
+                # sequences. This is the hot path in the captured 128K trace:
+                # it removes one RingMLA launch per MLA layer without copying.
+                diagonal_q_lens = block_lens_prev + block_lens_next
+                diagonal_kv_lens = (
+                    source_layout.early_to_prev_seq_lens[1].tolist()
+                    + source_layout.late_to_next_seq_lens[1].tolist()
+                )
+                output_all, lse_all = self._run_mla_cp_ring_segment(
+                    q_nope,
+                    q_rope,
+                    source_k_nope,
+                    source_k_rope,
+                    source_value,
+                    self._get_mla_cp_ring_seq_lens(diagonal_q_lens, diagonal_kv_lens),
+                    layer,
+                    causal=True,
+                    previous_output=None,
+                    previous_lse=None,
+                )
+                output_prev, output_next = output_all[:split], output_all[split:]
+                lse_prev, lse_next = lse_all[:, :split], lse_all[:, split:]
+
+                # The early local block is also fully visible to the late Q
+                # block. Merge that off-diagonal rectangle after the batched
+                # diagonals; online softmax makes the order irrelevant.
+                output_next, lse_next = self._run_mla_cp_ring_segment(
+                    q_nope_next,
+                    q_rope_next,
+                    source_early_k,
+                    source_early_rope,
+                    source_early_v,
+                    source_layout.early_to_next_seq_lens,
+                    layer,
+                    causal=False,
+                    previous_output=output_next,
+                    previous_lse=lse_next,
+                )
+            elif bs == 1 and source_rank > cp_rank:
+                # For one-request long-context prefill, Q-late sees both the
+                # early and late blocks of every higher source rank. Those KV
+                # blocks are contiguous and can be one unmasked sequence. Do
+                # not similarly merge Q-early and Q-late for lower ranks: ATB
+                # requires KV length >= Q length and their shared early KV may
+                # be shorter than the combined Q.
+                assert output_all is not None and lse_all is not None
+                output_next, lse_next = self._run_mla_cp_ring_segment(
+                    q_nope_next,
+                    q_rope_next,
+                    source_k_nope,
+                    source_k_rope,
+                    source_value,
+                    self._get_mla_cp_ring_seq_lens(
+                        [next_tokens], [source_layout.token_count]
+                    ),
+                    layer,
+                    causal=False,
+                    previous_output=output_next,
+                    previous_lse=lse_next,
+                )
+
+            # Local early Q block r sees early source blocks 0..r. Its own
+            # block is causal; strictly earlier blocks need no mask.
+            else:
+                if early_to_prev:
+                    output_prev, lse_prev = self._run_mla_cp_ring_segment(
+                        q_nope_prev,
+                        q_rope_prev,
+                        source_early_k,
+                        source_early_rope,
+                        source_early_v,
+                        source_layout.early_to_prev_seq_lens,
+                        layer,
+                        causal=source_rank == cp_rank,
+                        previous_output=output_prev,
+                        previous_lse=lse_prev,
+                    )
+
+                # Every early block precedes local late Q block (2*CP-1-r).
+                if early_to_next:
+                    output_next, lse_next = self._run_mla_cp_ring_segment(
+                        q_nope_next,
+                        q_rope_next,
+                        source_early_k,
+                        source_early_rope,
+                        source_early_v,
+                        source_layout.early_to_next_seq_lens,
+                        layer,
+                        causal=False,
+                        previous_output=output_next,
+                        previous_lse=lse_next,
+                    )
+
+                # A source late block (2*CP-1-s) is visible iff s >= r. Only
+                # the current rank's late block needs its causal mask.
+                if late_to_next:
+                    output_next, lse_next = self._run_mla_cp_ring_segment(
+                        q_nope_next,
+                        q_rope_next,
+                        source_late_k,
+                        source_late_rope,
+                        source_late_v,
+                        source_layout.late_to_next_seq_lens,
+                        layer,
+                        causal=source_rank == cp_rank,
+                        previous_output=output_next,
+                        previous_lse=lse_next,
+                    )
+
+            source_cache_locs = cache_locs_by_rank[source_rank]
+            if source_cache_locs.shape[0] != source_latent_k.shape[0]:
+                raise ValueError(
+                    f"MLA CP ring shard {source_rank} cache locations do not "
+                    f"match KV tokens: locations={source_cache_locs.shape[0]}, "
+                    f"KV={source_latent_k.shape[0]}."
+                )
+            self.token_to_kv_pool.set_kv_buffer(
+                layer,
+                KVWriteLoc(source_cache_locs, None),
+                source_latent_k,
+                source_k_rope_compact,
+            )
+
+            if exchange_requests is not None:
+                packed_kv = self._finish_mla_cp_ring_kv_exchange(
+                    recv_kv, exchange_requests
+                )
+
+        if any(prefix_lens):
+            # Prefix KV precedes both local zigzag blocks and is therefore an
+            # unmasked segment. Merge it after the ring so requests with an
+            # empty prefix already have initialized output/LSE buffers. The
+            # ring guard guarantees each non-empty prefix is at least as long
+            # as its Q block, as required by npu_ring_mla.
+            prefix_blocks = iter(
+                self._iter_mla_cp_ring_prefix_kv_blocks(
+                    layer,
+                    forward_batch,
+                    prefix_lens,
+                    [
+                        max(prev_len, next_len)
+                        for prev_len, next_len in zip(block_lens_prev, block_lens_next)
+                    ],
+                )
+            )
+            while True:
+                try:
+                    prefix_block = next(prefix_blocks)
+                except StopIteration:
+                    break
+                (
+                    prefix_block_lens,
+                    prefix_k_nope,
+                    prefix_k_rope,
+                    prefix_value,
+                ) = prefix_block
+                # Keep the two query halves separate. The ring operator
+                # requires KV length >= Q length; radix blocks are guaranteed
+                # to cover each half, but not their combined token count.
+                prefix_prev_seq_lens = self._get_mla_cp_ring_seq_lens(
+                    block_lens_prev, prefix_block_lens
+                )
+                prefix_next_seq_lens = self._get_mla_cp_ring_seq_lens(
+                    block_lens_next, prefix_block_lens
+                )
+                output_prev, lse_prev = self._run_mla_cp_ring_segment(
+                    q_nope_prev,
+                    q_rope_prev,
+                    prefix_k_nope,
+                    prefix_k_rope,
+                    prefix_value,
+                    prefix_prev_seq_lens,
+                    layer,
+                    causal=False,
+                    previous_output=output_prev,
+                    previous_lse=lse_prev,
+                )
+                output_next, lse_next = self._run_mla_cp_ring_segment(
+                    q_nope_next,
+                    q_rope_next,
+                    prefix_k_nope,
+                    prefix_k_rope,
+                    prefix_value,
+                    prefix_next_seq_lens,
+                    layer,
+                    causal=False,
+                    previous_output=output_next,
+                    previous_lse=lse_next,
+                )
+                # Drop the current block before requesting the next one so two
+                # expanded prefix blocks never overlap in allocator lifetime.
+                del (
+                    prefix_block,
+                    prefix_k_nope,
+                    prefix_k_rope,
+                    prefix_value,
+                    prefix_prev_seq_lens,
+                    prefix_next_seq_lens,
+                )
+
+        assert output_prev is not None and output_next is not None
+        del forward_batch.mla_cp_local_k
+        del forward_batch.mla_cp_local_k_rope
+
+        if output_all is None:
+            output_all = torch.cat((output_prev, output_next), dim=0)
+        return output_all.view(-1, layer.tp_q_head_num * layer.v_head_dim)
 
     def forward_sparse(
         self,
@@ -1225,14 +2251,15 @@ class AscendAttnBackend(AttentionBackend):
                 sinks=sinks,
             )
 
-        if not self.use_mla:
-            # Detect CP mode for prefill (context parallel)
-            is_cp_mode = (
-                forward_batch.forward_mode.is_context_parallel_extend()
-                and forward_batch.attn_cp_metadata is not None
-                and self.attn_cp_size > 1
-            )
+        # Detect CP mode for prefill (context parallel).  MLA and dense MHA use
+        # different kernels below, but both consume the same zigzag metadata.
+        is_cp_mode = (
+            forward_batch.forward_mode.is_context_parallel_extend()
+            and forward_batch.attn_cp_metadata is not None
+            and self.attn_cp_size > 1
+        )
 
+        if not self.use_mla:
             # In cross attention layer, when there is no vision input,the values of k and v is None
             if save_kv_cache and k is not None and v is not None:
                 if is_cp_mode:
@@ -1627,6 +2654,18 @@ class AscendAttnBackend(AttentionBackend):
                     attn_output = attn_output.view(
                         -1, layer.tp_q_head_num * layer.v_head_dim
                     )
+        elif is_cp_mode:
+            if not use_npu_mla_cp_ring(forward_batch):
+                raise NotImplementedError(
+                    "Ascend MLA prefill CP is implemented for Kimi-K3 ring only."
+                )
+            if save_kv_cache:
+                raise ValueError("Kimi-K3 MLA CP ring owns its KV cache writes.")
+            if not hasattr(forward_batch, "mla_cp_local_k") or not hasattr(
+                forward_batch, "mla_cp_local_k_rope"
+            ):
+                raise ValueError("Kimi-K3 MLA CP ring local KV is missing.")
+            return self.do_cp_mla_attn_ring(q, k, v, layer, forward_batch)
         elif sum(forward_batch.extend_prefix_lens_cpu) > 0:
             # This branch adds support for prefix cache for GLM-4.7-Flash.
             # When using the MLA architecture, if qk head dim equals v head dim and the head count is not a power of 2,
@@ -2856,9 +3895,7 @@ class AscendAttnBackend(AttentionBackend):
                 )
                 attn_output = attn_output[:, :, : layer.tp_q_head_num, :]
             else:
-                assert (
-                    self.graph_mode == False
-                )  # _npu_paged_attention_mla not support graph mode
+                assert not self.graph_mode  # _npu_paged_attention_mla no graph support
                 if q_rope is not None:
                     q = torch.cat([q, q_rope], dim=-1)
                 query = q.view(-1, layer.tp_q_head_num, layer.head_dim)

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_kda_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_kda_backend.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 import torch
 from sgl_kernel_npu.fla.kda_chunk_delta_h import (
+    chunk_gated_delta_rule_fwd_affine_npu,
     chunk_gated_delta_rule_fwd_h_npu,
 )
 from sgl_kernel_npu.fla.kda_gate import fused_kda_gate_npu
@@ -28,6 +29,12 @@ from sglang.srt.layers.attention.linear.kda_backend import (
     KDAAttnBackend,
     ragged_verify_dense_scatter_indices,
 )
+from sglang.srt.layers.attention.linear.kda_cp import (
+    build_kda_fla_cp_context,
+    compose_kda_cp_affine_states,
+    kda_use_fla_prefill_cp,
+    prepare_kda_cp_conv_states,
+)
 from sglang.srt.layers.radix_linear_attention import RadixLinearAttention
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 
@@ -52,6 +59,7 @@ class _AscendKDAExtendKernel:
         **kwargs,
     ):
         chunk_size = 64
+        cp_context = kwargs.get("cp_context")
         q = l2norm_fwd(q.contiguous())
         k = l2norm_fwd(k.contiguous())
         v = v.contiguous()
@@ -89,13 +97,39 @@ class _AscendKDAExtendKernel:
             chunk_indices=chunk_indices,
         )
         del triangular
+        kernel_state_source = ssm_states
+        kernel_state_indices = cache_indices
+        if cp_context is not None:
+            local_affine = chunk_gated_delta_rule_fwd_affine_npu(
+                k=gated_k,
+                w=w,
+                u=u,
+                gk=g,
+                cu_seqlens=query_start_loc,
+            )
+            local_initial_kv = compose_kda_cp_affine_states(
+                local_affine,
+                ssm_states,
+                cache_indices,
+                cp_context,
+                state_value_major=True,
+            )
+            kernel_state_source = local_initial_kv.transpose(-1, -2).contiguous()
+            kernel_state_indices = cp_context.local_segment_indices
+            if kernel_state_indices is None:
+                kernel_state_indices = torch.arange(
+                    cp_context.num_local_segments,
+                    dtype=cache_indices.dtype,
+                    device=cache_indices.device,
+                )
+
         chunk_states, new_values = chunk_gated_delta_rule_fwd_h_npu(
             k=gated_k,
             w=w,
             u=u,
             gk=g,
-            initial_state=ssm_states,
-            initial_state_indices=cache_indices,
+            initial_state=kernel_state_source,
+            initial_state_indices=kernel_state_indices,
             cu_seqlens=query_start_loc,
             chunk_indices=chunk_indices,
             use_exp2=True,
@@ -244,7 +278,33 @@ class AscendKDAAttnBackend(KDAAttnBackend):
             )
         has_initial_state = forward_batch.extend_prefix_lens > 0
 
-        if self.forward_metadata.has_mamba_track_mask:
+        use_fla_cp = kda_use_fla_prefill_cp(forward_batch)
+        fla_cp_context = None
+        fla_conv_initial_states = None
+        cp_physical_tokens = None
+        if use_fla_cp:
+            fla_cp_context = build_kda_fla_cp_context(
+                forward_batch, device=mixed_qkv.device
+            )
+            cp_logical_tokens = sum(fla_cp_context.local_segment_lens)
+            cp_physical_tokens = mixed_qkv.shape[0]
+            if cp_physical_tokens < cp_logical_tokens:
+                raise ValueError(
+                    "KDA FLA CP input is shorter than the logical zigzag shard: "
+                    f"physical={cp_physical_tokens}, logical={cp_logical_tokens}."
+                )
+            mixed_qkv = mixed_qkv[:cp_logical_tokens]
+            a = a[:, :cp_logical_tokens]
+            b = b[:, :cp_logical_tokens]
+            fla_conv_initial_states = prepare_kda_cp_conv_states(
+                mixed_qkv,
+                conv_states,
+                cache_indices,
+                fla_cp_context,
+                has_initial_state=has_initial_state,
+            )
+
+        if self.forward_metadata.has_mamba_track_mask and not use_fla_cp:
             conv_states[self.forward_metadata.conv_states_mask_indices] = mixed_qkv[
                 self.forward_metadata.track_conv_indices
             ].transpose(-1, -2)
@@ -260,12 +320,42 @@ class AscendKDAAttnBackend(KDAAttnBackend):
         else:
             q_bias, k_bias, v_bias = None, None, None
 
-        conv_kwargs = dict(
-            has_initial_state=has_initial_state,
-            cache_indices=cache_indices,
-            query_start_loc=query_start_loc,
-            seq_lens_cpu=forward_batch.extend_seq_lens_cpu,
-        )
+        if use_fla_cp:
+            assert fla_cp_context is not None
+            assert fla_conv_initial_states is not None
+            q_conv_state, k_conv_state, v_conv_state = fla_conv_initial_states.split(
+                splits, dim=1
+            )
+            local_indices = fla_cp_context.local_segment_indices
+            if local_indices is None or local_indices.dtype != cache_indices.dtype:
+                local_indices = torch.arange(
+                    fla_cp_context.num_local_segments,
+                    device=cache_indices.device,
+                    dtype=cache_indices.dtype,
+                )
+            local_has_initial_state = fla_cp_context.local_segment_has_initial_state
+            if local_has_initial_state is None:
+                local_has_initial_state = torch.ones(
+                    fla_cp_context.num_local_segments,
+                    dtype=torch.bool,
+                    device=mixed_qkv.device,
+                )
+            conv_kwargs = dict(
+                has_initial_state=local_has_initial_state,
+                cache_indices=local_indices,
+                query_start_loc=fla_cp_context.local_cu_seqlens,
+                seq_lens_cpu=(
+                    fla_cp_context.local_segment_lens_cpu
+                    or list(fla_cp_context.local_segment_lens)
+                ),
+            )
+        else:
+            conv_kwargs = dict(
+                has_initial_state=has_initial_state,
+                cache_indices=cache_indices,
+                query_start_loc=query_start_loc,
+                seq_lens_cpu=forward_batch.extend_seq_lens_cpu,
+            )
         q = self._causal_conv1d_extend(
             q, q_conv_weight, q_bias, q_conv_state, **conv_kwargs
         )
@@ -282,7 +372,10 @@ class AscendKDAAttnBackend(KDAAttnBackend):
         g, beta, extend_A_log, extend_dt_bias = self._prepare_extend_gate_inputs(
             layer, a, b
         )
-        track_ssm = self.forward_metadata.has_mamba_track_mask
+        track_ssm = self.forward_metadata.has_mamba_track_mask and not use_fla_cp
+        kernel_query_start_loc = (
+            fla_cp_context.local_cu_seqlens if use_fla_cp else query_start_loc
+        )
         core_attn_out = self.kernel_dispatcher.extend(
             q=q,
             k=k,
@@ -291,7 +384,7 @@ class AscendKDAAttnBackend(KDAAttnBackend):
             beta=beta,
             ssm_states=ssm_states,
             cache_indices=cache_indices,
-            query_start_loc=query_start_loc,
+            query_start_loc=kernel_query_start_loc,
             A_log=extend_A_log,
             dt_bias=extend_dt_bias,
             lower_bound=layer.lower_bound,
@@ -301,11 +394,29 @@ class AscendKDAAttnBackend(KDAAttnBackend):
             track_ssm_h_src=(
                 self.forward_metadata.track_ssm_h_src if track_ssm else None
             ),
+            cp_context=fla_cp_context,
         )
         if track_ssm:
             core_attn_out, h = core_attn_out
             self._track_mamba_state_extend(
                 forward_batch, h, ssm_states, self.forward_metadata
+            )
+        if (
+            use_fla_cp
+            and cp_physical_tokens is not None
+            and core_attn_out.shape[1] < cp_physical_tokens
+        ):
+            pad_tokens = cp_physical_tokens - core_attn_out.shape[1]
+            core_attn_out = torch.cat(
+                (
+                    core_attn_out,
+                    core_attn_out.new_zeros(
+                        core_attn_out.shape[0],
+                        pad_tokens,
+                        *core_attn_out.shape[2:],
+                    ),
+                ),
+                dim=1,
             )
         return core_attn_out
 
@@ -539,9 +650,7 @@ class AscendKDAHybridLinearAttnBackend:
                     ]
                 )
 
-                mamba_caches = (
-                    self.linear_attn_backend.req_to_token_pool.get_speculative_mamba2_params_all_layers()
-                )
+                mamba_caches = self.linear_attn_backend.req_to_token_pool.get_speculative_mamba2_params_all_layers()
 
                 conv_states = mamba_caches.conv[0]
                 ssm_states = mamba_caches.temporal

--- a/python/sglang/srt/hardware_backend/npu/modules/deepseek_v2_attention_mla_npu.py
+++ b/python/sglang/srt/hardware_backend/npu/modules/deepseek_v2_attention_mla_npu.py
@@ -16,6 +16,7 @@ from sglang.srt.layers.attention.dsa.utils import (
     dsa_use_prefill_cp,
 )
 from sglang.srt.layers.communicator import ScatterMode, get_attn_tp_context
+from sglang.srt.layers.utils.cp_utils import use_npu_mla_cp_ring
 from sglang.srt.model_executor.forward_context import get_token_to_kv_pool
 
 if TYPE_CHECKING:
@@ -113,10 +114,22 @@ def forward_mha_prepare_npu(
         k_pe = latent_cache[:, :, m.kv_lora_rank :]
         if m.rotary_emb is not None:
             q_pe, k_pe = m.rotary_emb(positions, q_pe, k_pe)
-        # this is for model kimi-vl-a3B-instruct
-        get_token_to_kv_pool().set_kv_buffer(
-            m, forward_batch.out_cache_loc, kv_a.unsqueeze(1), k_pe
-        )
+        # The CP ring backend rotates this local latent KV during attention
+        # and writes every received shard directly into its natural cache
+        # locations. Avoid a redundant rank-local cache write here.
+        if not use_npu_mla_cp_ring(forward_batch, m):
+            # this is for model kimi-vl-a3B-instruct
+            get_token_to_kv_pool().set_kv_buffer(
+                m, forward_batch.out_cache_loc, kv_a.unsqueeze(1), k_pe
+            )
+
+    if use_npu_mla_cp_ring(forward_batch, m):
+        # RadixAttention's MHA signature only carries expanded K/V. Preserve
+        # compact rank-local latent KV on the per-forward object so the Ascend
+        # backend can rotate it and materialize the full PD cache afterwards.
+        forward_batch.mla_cp_local_k = kv_a.unsqueeze(1).contiguous()
+        forward_batch.mla_cp_local_k_rope = k_pe.contiguous()
+        forward_batch._use_npu_mla_cp_ring = True
 
     q[..., m.qk_nope_head_dim :] = q_pe
 

--- a/python/sglang/srt/layers/attention/linear/kda_backend.py
+++ b/python/sglang/srt/layers/attention/linear/kda_backend.py
@@ -10,6 +10,11 @@ from sglang.kernels.ops.mamba.causal_conv1d_triton import (
 )
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.hybrid_linear_attn_backend import MambaAttnBackendBase
+from sglang.srt.layers.attention.linear.kda_cp import (
+    build_kda_fla_cp_context,
+    kda_use_fla_prefill_cp,
+    prepare_kda_cp_conv_states,
+)
 from sglang.srt.layers.attention.linear.kernels.kda_triton import TritonKDAKernel
 from sglang.srt.layers.attention.linear.utils import (
     LinearAttnKernelBackend,
@@ -32,9 +37,7 @@ elif is_cpu():
 
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_executor.model_runner import ModelRunner
-from sglang.srt.runtime_context import (
-    get_spec,
-)
+from sglang.srt.runtime_context import get_spec
 
 
 class KDAKernelDispatcher:
@@ -610,6 +613,42 @@ class KDAAttnBackend(MambaAttnBackendBase):
 
         return core_attn_out
 
+    @staticmethod
+    def _qkv_channels_to_heads(
+        tensor: torch.Tensor,
+        layer: RadixLinearAttention,
+        *,
+        num_heads: Optional[int] = None,
+    ) -> torch.Tensor:
+        """Convert ``[..., Q|K|V channels]`` to per-head Q/K/V blocks."""
+        if num_heads is None:
+            num_heads = layer.num_q_heads
+        if not (layer.num_q_heads == layer.num_k_heads == layer.num_v_heads):
+            raise NotImplementedError(
+                "KDA prefill CP currently requires equal Q/K/V head counts."
+            )
+        splits = [
+            num_heads * layer.head_q_dim,
+            num_heads * layer.head_k_dim,
+            num_heads * layer.head_v_dim,
+        ]
+        q, k, v = tensor.split(splits, dim=-1)
+        q = q.unflatten(-1, (num_heads, layer.head_q_dim))
+        k = k.unflatten(-1, (num_heads, layer.head_k_dim))
+        v = v.unflatten(-1, (num_heads, layer.head_v_dim))
+        return torch.cat((q, k, v), dim=-1)
+
+    @staticmethod
+    def _heads_to_qkv_channels(
+        tensor: torch.Tensor,
+        layer: RadixLinearAttention,
+    ) -> torch.Tensor:
+        """Inverse of :meth:`_qkv_channels_to_heads`."""
+        q, k, v = tensor.split(
+            [layer.head_q_dim, layer.head_k_dim, layer.head_v_dim], dim=-1
+        )
+        return torch.cat((q.flatten(-2), k.flatten(-2), v.flatten(-2)), dim=-1)
+
     def forward_extend(
         self,
         layer: RadixLinearAttention,
@@ -638,8 +677,35 @@ class KDAAttnBackend(MambaAttnBackendBase):
                 "extend_prefix_lens cannot be None in non-TARGET_VERIFY mode."
             )
         has_initial_state = forward_batch.extend_prefix_lens > 0
+        use_fla_cp = kda_use_fla_prefill_cp(forward_batch)
+        fla_cp_context = None
+        fla_conv_initial_states = None
+        cp_physical_tokens = None
 
-        if self.forward_metadata.has_mamba_track_mask:
+        if use_fla_cp:
+            if not isinstance(mixed_qkv, torch.Tensor):
+                raise TypeError("KDA FLA CP requires a dense projected QKV tensor")
+            fla_cp_context = build_kda_fla_cp_context(
+                forward_batch, device=mixed_qkv.device
+            )
+            cp_logical_tokens = sum(fla_cp_context.local_segment_lens)
+            cp_physical_tokens = mixed_qkv.shape[0]
+            if cp_physical_tokens < cp_logical_tokens:
+                raise ValueError(
+                    "KDA FLA CP input is shorter than the logical zigzag shard: "
+                    f"physical={cp_physical_tokens}, logical={cp_logical_tokens}."
+                )
+            mixed_qkv = mixed_qkv[:cp_logical_tokens]
+            a = a[:, :cp_logical_tokens]
+            b = b[:, :cp_logical_tokens]
+            fla_conv_initial_states = prepare_kda_cp_conv_states(
+                mixed_qkv,
+                conv_states,
+                cache_indices,
+                fla_cp_context,
+                has_initial_state=has_initial_state,
+            )
+        if self.forward_metadata.has_mamba_track_mask and not use_fla_cp:
             # Snapshot the conv sliding window at the last track-aligned chunk
             # boundary into the ping-pong track slots (the prefix-cache restore
             # source). The KDA pool stores conv states as [kernel-1, dim], so
@@ -651,54 +717,125 @@ class KDAAttnBackend(MambaAttnBackendBase):
 
         splits = [layer.q_dim, layer.k_dim, layer.v_dim]
         q, k, v = mixed_qkv.transpose(0, 1).split(splits, dim=0)
+        full_splits = [layer.q_dim, layer.k_dim, layer.v_dim]
         q_conv_weight, k_conv_weight, v_conv_weight = layer.conv_weights.split(
-            splits, dim=0
+            full_splits, dim=0
         )
-        q_conv_state, k_conv_state, v_conv_state = conv_states.split(splits, dim=-2)
+        q_conv_state, k_conv_state, v_conv_state = conv_states.split(
+            full_splits, dim=-2
+        )
         if layer.bias is not None:
-            q_bias, k_bias, v_bias = layer.bias.split(splits, dim=0)
+            q_bias, k_bias, v_bias = layer.bias.split(full_splits, dim=0)
         else:
             q_bias, k_bias, v_bias = None, None, None
 
-        q = causal_conv1d_fn(
-            q,
-            q_conv_weight,
-            q_bias,
-            activation="silu",
-            conv_states=q_conv_state,
-            has_initial_state=has_initial_state,
-            cache_indices=cache_indices,
-            query_start_loc=query_start_loc,
-            seq_lens_cpu=forward_batch.extend_seq_lens_cpu,
-        ).transpose(0, 1)
-        k = causal_conv1d_fn(
-            k,
-            k_conv_weight,
-            k_bias,
-            activation="silu",
-            conv_states=k_conv_state,
-            has_initial_state=has_initial_state,
-            cache_indices=cache_indices,
-            query_start_loc=query_start_loc,
-            seq_lens_cpu=forward_batch.extend_seq_lens_cpu,
-        ).transpose(0, 1)
-        v = causal_conv1d_fn(
-            v,
-            v_conv_weight,
-            v_bias,
-            activation="silu",
-            conv_states=v_conv_state,
-            has_initial_state=has_initial_state,
-            cache_indices=cache_indices,
-            query_start_loc=query_start_loc,
-            seq_lens_cpu=forward_batch.extend_seq_lens_cpu,
-        ).transpose(0, 1)
+        if use_fla_cp:
+            assert fla_conv_initial_states is not None
+            q_conv_run_state, k_conv_run_state, v_conv_run_state = (
+                fla_conv_initial_states.split(splits, dim=1)
+            )
+        else:
+            q_conv_run_state = q_conv_state
+            k_conv_run_state = k_conv_state
+            v_conv_run_state = v_conv_state
+
+        def run_conv(x, weight, bias, state):
+            if use_fla_cp:
+                assert fla_cp_context is not None
+                local_indices = fla_cp_context.local_segment_indices
+                if local_indices is None or local_indices.dtype != cache_indices.dtype:
+                    local_indices = torch.arange(
+                        fla_cp_context.num_local_segments,
+                        device=cache_indices.device,
+                        dtype=cache_indices.dtype,
+                    )
+                local_has_initial_state = fla_cp_context.local_segment_has_initial_state
+                if local_has_initial_state is None:
+                    local_has_initial_state = torch.ones(
+                        fla_cp_context.num_local_segments,
+                        dtype=torch.bool,
+                        device=x.device,
+                    )
+                state_work = state.to(weight.dtype).contiguous()
+                out = causal_conv1d_fn(
+                    x.to(weight.dtype),
+                    weight,
+                    bias,
+                    activation="silu",
+                    conv_states=state_work,
+                    has_initial_state=local_has_initial_state,
+                    cache_indices=local_indices,
+                    query_start_loc=fla_cp_context.local_cu_seqlens,
+                    seq_lens_cpu=(
+                        fla_cp_context.local_segment_lens_cpu
+                        or list(fla_cp_context.local_segment_lens)
+                    ),
+                )
+                return out.to(x.dtype).transpose(0, 1)
+
+            if is_npu():
+                # The Ascend varlen wrapper requires dense cache slots and uses
+                # the weight dtype for its workspace. Compact only active rows
+                # and explicitly copy the final BF16 cache state back.
+                valid_cache_indices = cache_indices >= 0
+                safe_cache_indices = cache_indices.clamp_min(0)
+                local_indices = torch.arange(
+                    cache_indices.shape[0],
+                    device=cache_indices.device,
+                    dtype=cache_indices.dtype,
+                )
+                state_work = (
+                    state.index_select(0, safe_cache_indices)
+                    .to(weight.dtype)
+                    .contiguous()
+                )
+                if not bool(valid_cache_indices.all()):
+                    state_work[~valid_cache_indices].zero_()
+                out = causal_conv1d_fn(
+                    x.to(weight.dtype),
+                    weight,
+                    bias,
+                    activation="silu",
+                    conv_states=state_work,
+                    has_initial_state=has_initial_state,
+                    cache_indices=local_indices,
+                    query_start_loc=query_start_loc,
+                    seq_lens_cpu=forward_batch.extend_seq_lens_cpu,
+                )
+                active_indices = cache_indices[valid_cache_indices]
+                if active_indices.numel() > 0:
+                    state.index_copy_(
+                        0,
+                        active_indices,
+                        state_work[valid_cache_indices].to(state.dtype),
+                    )
+                return out.to(x.dtype).transpose(0, 1)
+
+            return causal_conv1d_fn(
+                x,
+                weight,
+                bias,
+                activation="silu",
+                conv_states=state,
+                has_initial_state=has_initial_state,
+                cache_indices=cache_indices,
+                query_start_loc=query_start_loc,
+                seq_lens_cpu=forward_batch.extend_seq_lens_cpu,
+            ).transpose(0, 1)
+
+        q = run_conv(q, q_conv_weight, q_bias, q_conv_run_state)
+        k = run_conv(k, k_conv_weight, k_bias, k_conv_run_state)
+        v = run_conv(v, v_conv_weight, v_bias, v_conv_run_state)
 
         q = q.unflatten(-1, (-1, layer.head_q_dim)).unsqueeze(0)  # n (h d) -> 1 n h d
         k = k.unflatten(-1, (-1, layer.head_k_dim)).unsqueeze(0)  # n (h d) -> 1 n h d
         v = v.unflatten(-1, (-1, layer.head_v_dim)).unsqueeze(0)  # n (h d) -> 1 n h d
 
-        track_ssm = self.forward_metadata.has_mamba_track_mask
+        track_ssm = self.forward_metadata.has_mamba_track_mask and not use_fla_cp
+        kernel_query_start_loc = (
+            fla_cp_context.local_cu_seqlens if use_fla_cp else query_start_loc
+        )
+
         core_attn_out = self.kernel_dispatcher.extend(
             q=q,
             k=k,
@@ -707,7 +844,7 @@ class KDAAttnBackend(MambaAttnBackendBase):
             beta=b,
             ssm_states=ssm_states,
             cache_indices=cache_indices,
-            query_start_loc=query_start_loc,
+            query_start_loc=kernel_query_start_loc,
             A_log=layer.A_log,
             dt_bias=layer.dt_bias,
             lower_bound=layer.lower_bound,
@@ -722,16 +859,35 @@ class KDAAttnBackend(MambaAttnBackendBase):
             track_ssm_h_src=(
                 self.forward_metadata.track_ssm_h_src if track_ssm else None
             ),
+            cp_context=fla_cp_context,
         )
         if track_ssm:
             # Snapshot the SSM state at the last track-aligned chunk boundary
             # from the kernel's per-chunk states (h) / final states into the
             # ping-pong track slots (see _init_track_ssm_indices).
             core_attn_out, h = core_attn_out
+
+        if track_ssm:
             self._track_mamba_state_extend(
                 forward_batch, h, ssm_states, self.forward_metadata
             )
-
+        if (
+            use_fla_cp
+            and cp_physical_tokens is not None
+            and core_attn_out.shape[1] < cp_physical_tokens
+        ):
+            pad_tokens = cp_physical_tokens - core_attn_out.shape[1]
+            core_attn_out = torch.cat(
+                (
+                    core_attn_out,
+                    core_attn_out.new_zeros(
+                        core_attn_out.shape[0],
+                        pad_tokens,
+                        *core_attn_out.shape[2:],
+                    ),
+                ),
+                dim=1,
+            )
         return core_attn_out
 
     def _forward_target_verify(

--- a/python/sglang/srt/layers/attention/linear/kda_cp.py
+++ b/python/sglang/srt/layers/attention/linear/kda_cp.py
@@ -1,0 +1,938 @@
+"""FLA affine-state context parallel helpers for KDA prefill.
+
+This adapts flash-linear-attention PR 691's affine recurrent-state composition
+to SGLang's two-segment zigzag layout. QKV activations stay rank-local; only the
+much smaller per-segment state transforms are gathered across CP ranks.
+
+Decode never enters these helpers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from itertools import accumulate
+from typing import Any, Optional
+
+import torch
+from sglang.srt.runtime_context import get_parallel
+from sglang.srt.server_args import get_global_server_args
+from sglang.srt.utils import is_npu
+
+
+@dataclass(frozen=True)
+class KDAFLACPContext:
+    """Operator-level CP metadata for the PR-691-style KDA path."""
+
+    group: Any
+    cp_size: int
+    cp_rank: int
+    batch_size: int
+    split_list: tuple[int, ...]
+    local_segment_lens: tuple[int, ...]
+    local_cu_seqlens: torch.Tensor
+    local_segment_slots: tuple[int, ...]
+    rank_segment_slots: tuple[tuple[int, ...], ...]
+    fixed_segment_sources: tuple[int, ...]
+    max_rank_segments: int
+    fixed_segment_lens: tuple[int, ...]
+    track_after_slots: tuple[int, ...]
+    track_state_indices: torch.Tensor
+    track_request_indices: Optional[torch.Tensor] = None
+    track_request_ids: tuple[int, ...] = ()
+    local_segment_indices: Optional[torch.Tensor] = None
+    local_segment_has_initial_state: Optional[torch.Tensor] = None
+    local_segment_lens_cpu: Optional[list[int]] = None
+    local_segment_ends: tuple[int, ...] = ()
+    affine_steps: tuple[
+        tuple[int, tuple[int, ...], tuple[int, ...], tuple[int, ...]], ...
+    ] = ()
+    affine_owner_ranks: Optional[torch.Tensor] = None
+    affine_source_segments: Optional[torch.Tensor] = None
+    affine_local_indices: Optional[torch.Tensor] = None
+    affine_local_steps: tuple[int, ...] = ()
+    affine_local_steps_tensor: Optional[torch.Tensor] = None
+    affine_local_output_indices: Optional[torch.Tensor] = None
+    affine_source_flat_indices: Optional[torch.Tensor] = None
+    conv_local_tail_steps: Optional[torch.Tensor] = None
+    conv_local_tail_output_indices: Optional[torch.Tensor] = None
+    conv_prefix_output_index: int = -1
+    affine_track_step: int = -1
+    scratch_buffers: dict[str, torch.Tensor] = field(
+        default_factory=dict, repr=False, compare=False
+    )
+
+    @property
+    def num_local_segments(self) -> int:
+        return len(self.local_segment_lens)
+
+    @property
+    def num_fixed_segments(self) -> int:
+        # Reserve two subsegments for every natural zigzag block.  Normally only
+        # part 0 is populated; part 1 is used when a radix checkpoint splits a
+        # block. Collectives send only rank-owned segments, padded to the maximum
+        # rank segment count.
+        return self.batch_size * 2 * self.cp_size * 2
+
+
+def kda_use_prefill_cp(forward_batch: Any) -> bool:
+    """Whether this forward needs a context-parallel KDA implementation."""
+    parallel = get_parallel()
+    mode = forward_batch.forward_mode
+    return bool(
+        is_npu()
+        and parallel.enable_prefill_context_parallel
+        and parallel.attn_cp_size > 1
+        and forward_batch.attn_cp_metadata is not None
+        and mode.is_context_parallel_extend()
+        and not mode.is_mixed()
+        and not mode.is_target_verify()
+        and not mode.is_draft_extend_v2()
+    )
+
+
+def kda_use_fla_prefill_cp(forward_batch: Any) -> bool:
+    """Whether PR-691-style state composition can handle this KDA batch."""
+    metadata = getattr(forward_batch, "attn_cp_metadata", None)
+    has_nonempty_zigzag_blocks = bool(
+        metadata is not None
+        and getattr(metadata, "split_list", None)
+        and min(metadata.split_list) > 0
+    )
+    return bool(kda_use_prefill_cp(forward_batch) and has_nonempty_zigzag_blocks)
+
+
+def _validate_zigzag_metadata(metadata: Any, cp_size: int) -> None:
+    required = (
+        "bs",
+        "split_list",
+        "cp_reverse_index",
+        "reverse_split_len",
+        "per_rank_actual_token",
+        "max_rank_len",
+    )
+    missing = [name for name in required if getattr(metadata, name, None) is None]
+    if missing:
+        raise NotImplementedError(
+            "KDA prefill context parallel currently requires the zigzag CP "
+            f"strategy; metadata is missing {missing}."
+        )
+    if len(metadata.per_rank_actual_token) != cp_size:
+        raise ValueError(
+            "KDA CP metadata/group size mismatch: "
+            f"metadata={len(metadata.per_rank_actual_token)}, cp_size={cp_size}"
+        )
+
+
+def _natural_block_owner_rank(block_id: int, cp_size: int) -> int:
+    if block_id < cp_size:
+        return block_id
+    return 2 * cp_size - block_id - 1
+
+
+def _build_affine_steps(
+    *,
+    cp_size: int,
+    batch_size: int,
+    local_segment_slots: tuple[int, ...],
+    fixed_segment_sources: tuple[int, ...],
+) -> tuple[tuple[int, tuple[int, ...], tuple[int, ...], tuple[int, ...]], ...]:
+    """Precompute the natural-order affine/conv execution plan once per batch."""
+    blocks_per_request = 2 * cp_size
+    local_slot_to_index = {
+        fixed_slot: local_index
+        for local_index, fixed_slot in enumerate(local_segment_slots)
+    }
+    steps = []
+    for block_id in range(blocks_per_request):
+        owner_rank = _natural_block_owner_rank(block_id, cp_size)
+        for part_id in range(2):
+            fixed_slots = tuple(
+                ((request_id * blocks_per_request + block_id) * 2 + part_id)
+                for request_id in range(batch_size)
+            )
+            source_segments = tuple(
+                fixed_segment_sources[fixed_slot] for fixed_slot in fixed_slots
+            )
+            if all(source_segment < 0 for source_segment in source_segments):
+                continue
+            local_indices = tuple(
+                local_slot_to_index.get(fixed_slot, -1) for fixed_slot in fixed_slots
+            )
+            steps.append((owner_rank, fixed_slots, source_segments, local_indices))
+    return tuple(steps)
+
+
+def build_kda_fla_cp_context(
+    forward_batch: Any,
+    *,
+    device: torch.device,
+    group: Optional[Any] = None,
+) -> KDAFLACPContext:
+    """Build local segment offsets for a zigzag-sharded KDA invocation.
+
+    A tracked radix boundary may fall inside one natural zigzag block.  Split
+    only that block at the exact cache boundary, making the recurrent and
+    convolution state at the boundary directly observable without gathering
+    token activations.
+    """
+    if group is None:
+        cached = getattr(forward_batch, "kda_fla_cp_context", None)
+        if cached is not None:
+            return cached
+    parallel = get_parallel()
+    cp_size = parallel.attn_cp_size
+    cp_rank = parallel.attn_cp_rank
+    metadata = forward_batch.attn_cp_metadata
+    _validate_zigzag_metadata(metadata, cp_size)
+    bs = int(metadata.bs)
+    blocks_per_request = 2 * cp_size
+    split_list = tuple(int(length) for length in metadata.split_list)
+    if min(split_list) <= 0:
+        raise ValueError("KDA FLA CP requires every zigzag block to be non-empty")
+
+    track_mask_tensor = getattr(forward_batch, "mamba_track_mask", None)
+    if track_mask_tensor is None:
+        track_mask = [False] * bs
+    else:
+        track_mask = [
+            bool(value) for value in track_mask_tensor.detach().cpu().tolist()[:bs]
+        ]
+        if len(track_mask) != bs:
+            raise ValueError("KDA FLA CP track mask does not match batch size")
+
+    track_offsets = [-1] * bs
+    if any(track_mask):
+        track_seqlens = getattr(forward_batch, "mamba_track_seqlens", None)
+        track_indices = getattr(forward_batch, "mamba_track_indices", None)
+        if track_seqlens is None or track_indices is None:
+            raise ValueError("KDA FLA CP radix tracking metadata is incomplete")
+        track_seqlens_cpu = track_seqlens.detach().cpu().tolist()[:bs]
+        prefix_lens_cpu = getattr(forward_batch, "extend_prefix_lens_cpu", None)
+        if prefix_lens_cpu is None:
+            prefix_lens_cpu = (
+                forward_batch.extend_prefix_lens.detach().cpu().tolist()[:bs]
+            )
+        cache_chunk_size = get_global_server_args().mamba_cache_chunk_size
+        for request_id, should_track in enumerate(track_mask):
+            if not should_track:
+                continue
+            reported_extend_offset = int(track_seqlens_cpu[request_id]) - int(
+                prefix_lens_cpu[request_id]
+            )
+            # The scheduler may add one to force an intermediate-h lookup.  The
+            # actual radix state is always the preceding cache-chunk boundary,
+            # which is exactly the same alignment used for the conv checkpoint.
+            track_offsets[request_id] = (
+                reported_extend_offset // cache_chunk_size
+            ) * cache_chunk_size
+
+    fixed_segment_lens = [0] * (bs * blocks_per_request * 2)
+    track_after_slots = [-1] * bs
+    for request_id in range(bs):
+        cursor = 0
+        request_total = sum(
+            split_list[
+                request_id * blocks_per_request : (request_id + 1) * blocks_per_request
+            ]
+        )
+        track_offset = track_offsets[request_id]
+        if track_mask[request_id] and not 0 < track_offset <= request_total:
+            raise ValueError(
+                "KDA FLA CP radix checkpoint is outside the extend range: "
+                f"request={request_id}, offset={track_offset}, extend={request_total}."
+            )
+        for block_id in range(blocks_per_request):
+            block_len = split_list[request_id * blocks_per_request + block_id]
+            fixed_slot = (request_id * blocks_per_request + block_id) * 2
+            block_end = cursor + block_len
+            if cursor < track_offset < block_end:
+                fixed_segment_lens[fixed_slot] = track_offset - cursor
+                fixed_segment_lens[fixed_slot + 1] = block_end - track_offset
+                track_after_slots[request_id] = fixed_slot
+            else:
+                fixed_segment_lens[fixed_slot] = block_len
+                if track_offset == block_end:
+                    track_after_slots[request_id] = fixed_slot
+            cursor = block_end
+        if track_mask[request_id] and track_after_slots[request_id] < 0:
+            raise ValueError(
+                f"KDA FLA CP could not place request {request_id}'s radix checkpoint"
+            )
+
+    rank_segment_slots_list = []
+    fixed_segment_sources = [-1] * len(fixed_segment_lens)
+    for rank in range(cp_size):
+        rank_slots = []
+        for block_id in (rank, blocks_per_request - rank - 1):
+            for request_id in range(bs):
+                fixed_slot = (request_id * blocks_per_request + block_id) * 2
+                for part_id in range(2):
+                    if fixed_segment_lens[fixed_slot + part_id] > 0:
+                        fixed_segment_sources[fixed_slot + part_id] = len(rank_slots)
+                        rank_slots.append(fixed_slot + part_id)
+        rank_segment_slots_list.append(tuple(rank_slots))
+
+    rank_segment_slots = tuple(rank_segment_slots_list)
+    local_segment_slots = rank_segment_slots[cp_rank]
+    local_segment_lens = tuple(
+        fixed_segment_lens[fixed_slot] for fixed_slot in local_segment_slots
+    )
+    local_cu_seqlens = torch.tensor(
+        [0, *accumulate(local_segment_lens)],
+        dtype=torch.int32,
+        device=device,
+    )
+    track_state_indices = torch.full((bs,), -1, dtype=torch.int64, device=device)
+    track_request_ids = tuple(
+        request_id for request_id, should_track in enumerate(track_mask) if should_track
+    )
+    track_request_indices = torch.tensor(
+        track_request_ids,
+        dtype=torch.int64,
+        device=device,
+    )
+    if any(track_mask):
+        track_indices = forward_batch.mamba_track_indices.to(
+            device=device, dtype=torch.int64
+        )[:bs]
+        mask_device = torch.tensor(track_mask, dtype=torch.bool, device=device)
+        track_state_indices = torch.where(
+            mask_device, track_indices, track_state_indices
+        )
+
+    fixed_segment_sources_tuple = tuple(fixed_segment_sources)
+    affine_steps = _build_affine_steps(
+        cp_size=cp_size,
+        batch_size=bs,
+        local_segment_slots=local_segment_slots,
+        fixed_segment_sources=fixed_segment_sources_tuple,
+    )
+    # The fused batch-one merge consumes this compact execution plan directly
+    # on device.  Building it once with the CP context avoids reconstructing
+    # Python indexing tensors in every KDA layer.  Multi-request batches keep
+    # using the general composition path below.
+    affine_owner_ranks = None
+    affine_source_segments = None
+    affine_local_indices = None
+    affine_local_steps = ()
+    affine_local_steps_tensor = None
+    affine_local_output_indices = None
+    affine_source_flat_indices = None
+    conv_local_tail_steps = None
+    conv_local_tail_output_indices = None
+    conv_prefix_output_index = -1
+    affine_track_step = -1
+    if bs == 1:
+        affine_owner_ranks = torch.tensor(
+            [step[0] for step in affine_steps], dtype=torch.int32, device=device
+        )
+        affine_source_segments = torch.tensor(
+            [step[2][0] for step in affine_steps],
+            dtype=torch.int32,
+            device=device,
+        )
+        affine_local_indices = torch.tensor(
+            [step[3][0] for step in affine_steps],
+            dtype=torch.int32,
+            device=device,
+        )
+        affine_local_steps = tuple(
+            step_id for step_id, step in enumerate(affine_steps) if step[3][0] >= 0
+        )
+        affine_local_steps_tensor = torch.tensor(
+            affine_local_steps, dtype=torch.int64, device=device
+        )
+        affine_local_output_indices = torch.tensor(
+            [affine_steps[step_id][3][0] for step_id in affine_local_steps],
+            dtype=torch.int64,
+            device=device,
+        )
+        affine_source_flat_indices = affine_owner_ranks.to(torch.int64) * max(
+            len(rank_slots) for rank_slots in rank_segment_slots
+        ) + affine_source_segments.to(torch.int64)
+        conv_tail_steps = []
+        conv_tail_output_indices = []
+        for step_id in affine_local_steps:
+            output_index = affine_steps[step_id][3][0]
+            if step_id == 0:
+                conv_prefix_output_index = output_index
+            else:
+                conv_tail_steps.append(step_id - 1)
+                conv_tail_output_indices.append(output_index)
+        conv_local_tail_steps = torch.tensor(
+            conv_tail_steps, dtype=torch.int64, device=device
+        )
+        conv_local_tail_output_indices = torch.tensor(
+            conv_tail_output_indices, dtype=torch.int64, device=device
+        )
+        if track_request_ids:
+            affine_track_step = next(
+                (
+                    step_id
+                    for step_id, step in enumerate(affine_steps)
+                    if step[1][0] == track_after_slots[0]
+                ),
+                -1,
+            )
+            if affine_track_step < 0:
+                raise RuntimeError(
+                    "KDA FLA CP could not map the radix checkpoint into the "
+                    "affine execution plan"
+                )
+
+    context = KDAFLACPContext(
+        group=group or parallel.attn_cp_group,
+        cp_size=cp_size,
+        cp_rank=cp_rank,
+        batch_size=bs,
+        split_list=split_list,
+        local_segment_lens=local_segment_lens,
+        local_cu_seqlens=local_cu_seqlens,
+        local_segment_slots=local_segment_slots,
+        rank_segment_slots=rank_segment_slots,
+        fixed_segment_sources=fixed_segment_sources_tuple,
+        max_rank_segments=max(len(rank_slots) for rank_slots in rank_segment_slots),
+        fixed_segment_lens=tuple(fixed_segment_lens),
+        track_after_slots=tuple(track_after_slots),
+        track_state_indices=track_state_indices,
+        track_request_indices=track_request_indices,
+        track_request_ids=track_request_ids,
+        local_segment_indices=torch.arange(
+            len(local_segment_lens), dtype=torch.int32, device=device
+        ),
+        local_segment_has_initial_state=torch.ones(
+            len(local_segment_lens), dtype=torch.bool, device=device
+        ),
+        local_segment_lens_cpu=list(local_segment_lens),
+        local_segment_ends=tuple(accumulate(local_segment_lens)),
+        affine_steps=affine_steps,
+        affine_owner_ranks=affine_owner_ranks,
+        affine_source_segments=affine_source_segments,
+        affine_local_indices=affine_local_indices,
+        affine_local_steps=affine_local_steps,
+        affine_local_steps_tensor=affine_local_steps_tensor,
+        affine_local_output_indices=affine_local_output_indices,
+        affine_source_flat_indices=affine_source_flat_indices,
+        conv_local_tail_steps=conv_local_tail_steps,
+        conv_local_tail_output_indices=conv_local_tail_output_indices,
+        conv_prefix_output_index=conv_prefix_output_index,
+        affine_track_step=affine_track_step,
+    )
+    if group is None:
+        forward_batch.kda_fla_cp_context = context
+    return context
+
+
+def _get_scratch_buffer(
+    context: KDAFLACPContext,
+    key: str,
+    like: torch.Tensor,
+    shape: tuple[int, ...],
+) -> torch.Tensor:
+    buffer = context.scratch_buffers.get(key)
+    if (
+        buffer is None
+        or tuple(buffer.shape) != shape
+        or buffer.dtype != like.dtype
+        or buffer.device != like.device
+    ):
+        buffer = like.new_empty(shape)
+        context.scratch_buffers[key] = buffer
+    return buffer
+
+
+def _all_gather_fixed_shape(
+    local: torch.Tensor, context: KDAFLACPContext, *, scratch_key: str
+) -> torch.Tensor:
+    gathered_shape = (context.cp_size * local.shape[0], *local.shape[1:])
+    gathered = _get_scratch_buffer(
+        context, f"{scratch_key}_gathered", local, gathered_shape
+    )
+    context.group.all_gather_into_tensor(gathered, local.contiguous())
+    return gathered.view(context.cp_size, *local.shape)
+
+
+def _write_state_pool(
+    state_pool: torch.Tensor,
+    state_indices: torch.Tensor,
+    values: torch.Tensor,
+) -> None:
+    """Write valid recurrent states without boolean indexing for batch one.
+
+    Kimi-K3 PCP currently serves one request per CP batch.  In that hot path,
+    boolean indexing creates an ``aten::index`` synchronization point in every
+    KDA layer.  A masked single-row write is equivalent even for an invalid
+    index because it writes the original sentinel row back unchanged.  Keep
+    the general multi-request implementation as the correctness fallback.
+    """
+    valid = state_indices >= 0
+    safe_indices = state_indices.clamp_min(0).to(torch.int64)
+    if state_indices.numel() == 1:
+        old_values = state_pool.index_select(0, safe_indices)
+        masked_values = torch.where(
+            valid.view(1, *([1] * (values.ndim - 1))),
+            values.to(state_pool.dtype),
+            old_values,
+        )
+        state_pool.index_copy_(0, safe_indices, masked_values)
+        return
+
+    active_indices = state_indices[valid].to(torch.int64)
+    if active_indices.numel() > 0:
+        state_pool.index_copy_(
+            0,
+            active_indices,
+            values[valid].to(state_pool.dtype),
+        )
+
+
+def compose_kda_cp_affine_states(
+    local_affine: torch.Tensor,
+    initial_state_source: torch.Tensor,
+    initial_state_indices: torch.Tensor,
+    context: KDAFLACPContext,
+    *,
+    state_value_major: bool = False,
+) -> torch.Tensor:
+    """Compose all zigzag segment transforms and return local initial states.
+
+    ``local_affine`` stores ``[H | M]`` for every local segment such that
+    ``state_out = M @ state_in + H``. All ranks gather these compact transforms,
+    walk the natural block order, and independently derive identical final
+    request states. This is the inference counterpart of FLA PR 691's forward
+    pre-processing and merge kernels.
+    """
+    bs = context.batch_size
+    expected_segments = context.num_local_segments
+    if local_affine.ndim != 4 or local_affine.shape[0] != expected_segments:
+        raise ValueError(
+            "KDA FLA CP affine tensor must be [local_segments, heads, K, V+K], "
+            f"got {tuple(local_affine.shape)} for bs={bs}."
+        )
+    key_dim = local_affine.shape[-2]
+    value_dim = local_affine.shape[-1] - key_dim
+    if value_dim <= 0:
+        raise ValueError("KDA FLA CP affine tensor has an invalid value dimension")
+    if initial_state_indices.numel() != bs:
+        raise ValueError(
+            "KDA FLA CP state indices must match batch size: "
+            f"indices={initial_state_indices.numel()}, bs={bs}."
+        )
+    expected_state_shape = (
+        (value_dim, key_dim) if state_value_major else (key_dim, value_dim)
+    )
+    if tuple(initial_state_source.shape[-2:]) != expected_state_shape:
+        raise ValueError(
+            "KDA FLA CP state shape does not match affine transform: "
+            f"state={tuple(initial_state_source.shape[-2:])}, "
+            f"expected={expected_state_shape}."
+        )
+
+    identity_transform = None
+    if expected_segments == context.max_rank_segments:
+        # The common no-checkpoint path owns exactly two segments per rank and
+        # needs no collective padding or identity materialisation.
+        padded_affine = local_affine
+    else:
+        identity_transform = local_affine.new_zeros(*local_affine.shape[1:])
+        identity = torch.eye(
+            key_dim, dtype=local_affine.dtype, device=local_affine.device
+        ).view(1, key_dim, key_dim)
+        identity_transform[..., value_dim:].copy_(identity)
+        padded_affine = identity_transform.expand(
+            context.max_rank_segments, *identity_transform.shape
+        ).clone()
+        padded_affine[:expected_segments].copy_(local_affine)
+    gathered = _all_gather_fixed_shape(padded_affine, context, scratch_key="affine")
+    valid = initial_state_indices >= 0
+    safe_indices = initial_state_indices.clamp_min(0).to(torch.int64)
+    state = initial_state_source.index_select(0, safe_indices)
+    if state_value_major:
+        state = state.transpose(-1, -2).contiguous()
+    state = state.float()
+    state = state * valid.view(bs, 1, 1, 1)
+    local_initial = _get_scratch_buffer(
+        context,
+        "affine_initial",
+        state,
+        (expected_segments, *state.shape[1:]),
+    )
+    track_request_ids = context.track_request_ids or tuple(
+        request_id
+        for request_id, fixed_slot in enumerate(context.track_after_slots)
+        if fixed_slot >= 0
+    )
+    use_fused_merge = bool(
+        local_affine.device.type in ("npu", "cuda")
+        and bs == 1
+        and key_dim <= 128
+        and len(context.affine_steps) <= 2 * context.cp_size + 1
+        and (not track_request_ids or track_request_ids == (0,))
+        and context.affine_owner_ranks is not None
+        and context.affine_source_segments is not None
+        and context.affine_local_indices is not None
+        and (not track_request_ids or context.affine_track_step >= 0)
+    )
+    if use_fused_merge:
+        # Compose the precomputed natural-order plan in one device kernel.  A
+        # radix checkpoint may split one zigzag block, so the plan can contain
+        # one extra transform and a rank can own three local segments.  The
+        # same launch writes local initial states, the final cache state, and
+        # the tracked checkpoint state.
+        from sgl_kernel_npu.fla.kda_chunk_delta_h import (
+            merge_kda_cp_affine_states,
+        )
+
+        final_state = _get_scratch_buffer(
+            context,
+            "affine_final",
+            state,
+            tuple(state.shape),
+        )
+        tracked_state = (
+            _get_scratch_buffer(
+                context,
+                "affine_tracked",
+                state,
+                tuple(state.shape),
+            )
+            if track_request_ids
+            else None
+        )
+        merge_kda_cp_affine_states(
+            gathered,
+            state,
+            local_initial,
+            final_state,
+            cp_rank=context.cp_rank,
+            owner_ranks=context.affine_owner_ranks,
+            source_segments=context.affine_source_segments,
+            local_indices=context.affine_local_indices,
+            local_steps=context.affine_local_steps,
+            tracked_state=tracked_state,
+            track_step=context.affine_track_step,
+        )
+        _write_state_pool(
+            initial_state_source,
+            initial_state_indices,
+            (
+                final_state.transpose(-1, -2).contiguous()
+                if state_value_major
+                else final_state
+            ),
+        )
+        if track_request_ids:
+            assert tracked_state is not None
+            _write_state_pool(
+                initial_state_source,
+                context.track_state_indices,
+                (
+                    tracked_state.transpose(-1, -2).contiguous()
+                    if state_value_major
+                    else tracked_state
+                ),
+            )
+        return local_initial
+
+    tracked_state = torch.empty_like(state) if track_request_ids else None
+    tracked_state_is_set = [False] * bs if track_request_ids else None
+    affine_steps = context.affine_steps or _build_affine_steps(
+        cp_size=context.cp_size,
+        batch_size=bs,
+        local_segment_slots=context.local_segment_slots,
+        fixed_segment_sources=context.fixed_segment_sources,
+    )
+
+    for owner_rank, fixed_slots, source_segments, local_indices in affine_steps:
+        if owner_rank == context.cp_rank:
+            for request_id, local_index in enumerate(local_indices):
+                if local_index >= 0:
+                    local_initial[local_index].copy_(state[request_id])
+        if bs == 1 and source_segments[0] >= 0:
+            # Avoid stack/index materialisation for the serving hot path.
+            transforms = gathered[owner_rank, source_segments[0]].unsqueeze(0)
+        else:
+            if identity_transform is None:
+                identity_transform = local_affine.new_zeros(*local_affine.shape[1:])
+                identity = torch.eye(
+                    key_dim,
+                    dtype=local_affine.dtype,
+                    device=local_affine.device,
+                ).view(1, key_dim, key_dim)
+                identity_transform[..., value_dim:].copy_(identity)
+            transforms = torch.stack(
+                [
+                    (
+                        gathered[owner_rank, source_segment]
+                        if source_segment >= 0
+                        else identity_transform
+                    )
+                    for source_segment in source_segments
+                ]
+            )
+        transforms = transforms.float()
+        additive = transforms[..., :value_dim]
+        transition = transforms[..., value_dim:]
+        state = torch.matmul(transition, state) + additive
+        for request_id in track_request_ids:
+            fixed_slot = fixed_slots[request_id]
+            if context.track_after_slots[request_id] == fixed_slot:
+                assert tracked_state is not None
+                assert tracked_state_is_set is not None
+                tracked_state[request_id].copy_(state[request_id])
+                tracked_state_is_set[request_id] = True
+
+    _write_state_pool(
+        initial_state_source,
+        initial_state_indices,
+        state.transpose(-1, -2).contiguous() if state_value_major else state,
+    )
+
+    track_request_indices = context.track_request_indices
+    if track_request_indices is None:
+        track_request_indices = torch.tensor(
+            track_request_ids,
+            dtype=torch.int64,
+            device=initial_state_source.device,
+        )
+    if track_request_indices.numel() > 0:
+        assert tracked_state is not None
+        assert tracked_state_is_set is not None
+        for request_id in track_request_ids:
+            if not tracked_state_is_set[request_id]:
+                raise RuntimeError(
+                    "KDA FLA CP did not produce a requested radix checkpoint"
+                )
+        track_pool_indices = context.track_state_indices.index_select(
+            0, track_request_indices
+        )
+        tracked_values = tracked_state.index_select(0, track_request_indices)
+        if state_value_major:
+            tracked_values = tracked_values.transpose(-1, -2).contiguous()
+        initial_state_source.index_copy_(
+            0,
+            track_pool_indices,
+            tracked_values.to(initial_state_source.dtype),
+        )
+    return local_initial
+
+
+def prepare_kda_cp_conv_states(
+    local_x: torch.Tensor,
+    conv_state_source: torch.Tensor,
+    cache_indices: torch.Tensor,
+    context: KDAFLACPContext,
+    has_initial_state: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Build exact initial causal-conv windows for both local zigzag blocks.
+
+    Only ``kernel_size - 1`` raw QKV tokens per segment are gathered. Prefix
+    convolution state seeds block 0; gathered tails advance the rolling window
+    in natural order. The final full-head state is written on every CP rank.
+    """
+    if local_x.ndim != 2 or conv_state_source.ndim != 3:
+        raise ValueError(
+            "KDA FLA CP conv expects local [tokens, channels] and state "
+            f"[slots, channels, window], got {tuple(local_x.shape)} and "
+            f"{tuple(conv_state_source.shape)}."
+        )
+    bs = context.batch_size
+    window = conv_state_source.shape[-1]
+    channels = local_x.shape[-1]
+    if conv_state_source.shape[-2] != channels:
+        raise ValueError("KDA FLA CP conv channel count does not match cache")
+    if cache_indices.numel() != bs:
+        raise ValueError("KDA FLA CP conv cache indices do not match batch size")
+    if sum(context.local_segment_lens) != local_x.shape[0]:
+        raise ValueError(
+            "KDA FLA CP conv token count does not match local zigzag segments: "
+            f"tokens={local_x.shape[0]}, segments={sum(context.local_segment_lens)}."
+        )
+
+    padded_tails = _get_scratch_buffer(
+        context,
+        "conv_local_tails",
+        local_x,
+        (context.max_rank_segments, window, channels),
+    )
+    if len(context.local_segment_ends) == context.num_local_segments and all(
+        length >= window for length in context.local_segment_lens
+    ):
+        for segment_id, segment_end in enumerate(context.local_segment_ends):
+            padded_tails[segment_id].copy_(local_x[segment_end - window : segment_end])
+    else:
+        padded_tails.zero_()
+        segment_start = 0
+        for segment_id, segment_len in enumerate(context.local_segment_lens):
+            take = min(window, segment_len)
+            if take:
+                segment_end = segment_start + segment_len
+                padded_tails[segment_id, -take:].copy_(
+                    local_x[segment_end - take : segment_end]
+                )
+            segment_start += segment_len
+    gathered_tails = _all_gather_fixed_shape(padded_tails, context, scratch_key="conv")
+
+    valid = cache_indices >= 0
+    use_prefix = valid
+    if has_initial_state is not None:
+        if has_initial_state.numel() != bs:
+            raise ValueError(
+                "KDA FLA CP conv initial-state mask does not match batch size"
+            )
+        use_prefix = valid & has_initial_state.to(device=valid.device, dtype=torch.bool)
+    safe_indices = cache_indices.clamp_min(0).to(torch.int64)
+    prefix_state = conv_state_source.index_select(0, safe_indices)
+    prefix_state = prefix_state * use_prefix.view(bs, 1, 1)
+    local_initial = _get_scratch_buffer(
+        context,
+        "conv_initial",
+        prefix_state,
+        (context.num_local_segments, channels, window),
+    )
+    final_states = []
+    track_request_ids = context.track_request_ids or tuple(
+        request_id
+        for request_id, fixed_slot in enumerate(context.track_after_slots)
+        if fixed_slot >= 0
+    )
+    affine_steps = context.affine_steps or _build_affine_steps(
+        cp_size=context.cp_size,
+        batch_size=bs,
+        local_segment_slots=context.local_segment_slots,
+        fixed_segment_sources=context.fixed_segment_sources,
+    )
+    use_direct_conv_plan = bool(
+        bs == 1
+        and context.affine_owner_ranks is not None
+        and context.affine_source_segments is not None
+        and context.affine_local_steps_tensor is not None
+        and context.affine_local_output_indices is not None
+        and context.affine_source_flat_indices is not None
+        and context.conv_local_tail_steps is not None
+        and context.conv_local_tail_output_indices is not None
+        and context.affine_local_steps_tensor.numel() == context.num_local_segments
+        and (not track_request_ids or track_request_ids == (0,))
+        and (not track_request_ids or context.affine_track_step >= 0)
+        and all(
+            step[2][0] >= 0 and context.fixed_segment_lens[step[1][0]] >= window
+            for step in affine_steps
+        )
+    )
+    if use_direct_conv_plan:
+        # For long-prefill segments the complete conv window after a segment
+        # is exactly that segment's gathered tail. The state before step i is
+        # therefore either the radix-prefix state (i=0) or tail(i-1). Build
+        # every local initial state, final cache state, and optional radix
+        # checkpoint with one plan gather instead of a Python cat/copy loop.
+        ordered_tails = (
+            gathered_tails.flatten(0, 1)
+            .index_select(0, context.affine_source_flat_indices)
+            .transpose(1, 2)
+        )
+        if context.conv_prefix_output_index >= 0:
+            local_initial[context.conv_prefix_output_index].copy_(prefix_state[0])
+        if context.conv_local_tail_steps.numel() > 0:
+            local_initial.index_copy_(
+                0,
+                context.conv_local_tail_output_indices,
+                ordered_tails.index_select(0, context.conv_local_tail_steps),
+            )
+        _write_state_pool(
+            conv_state_source,
+            cache_indices,
+            ordered_tails[-1:],
+        )
+        if track_request_ids:
+            _write_state_pool(
+                conv_state_source,
+                context.track_state_indices,
+                ordered_tails[
+                    context.affine_track_step : context.affine_track_step + 1
+                ],
+            )
+        return local_initial
+
+    tracked_states = torch.empty_like(prefix_state) if track_request_ids else None
+    tracked_state_is_set = [False] * bs if track_request_ids else None
+    rolling_scratch = _get_scratch_buffer(
+        context,
+        "conv_rolling",
+        prefix_state,
+        (bs, 2, channels, window),
+    )
+
+    for request_id in range(bs):
+        rolling = prefix_state[request_id]
+        rolling_step = 0
+        for owner_rank, fixed_slots, source_segments, local_indices in affine_steps:
+            fixed_slot = fixed_slots[request_id]
+            local_index = local_indices[request_id]
+            if local_index >= 0:
+                local_initial[local_index].copy_(rolling)
+            take = min(window, context.fixed_segment_lens[fixed_slot])
+            if take:
+                source_segment = source_segments[request_id]
+                if source_segment < 0:
+                    raise RuntimeError(
+                        "KDA FLA CP conv segment has no owning rank source"
+                    )
+                tail = gathered_tails[owner_rank, source_segment, -take:].transpose(
+                    0, 1
+                )
+                next_rolling = rolling_scratch[request_id, rolling_step % 2]
+                if take >= window:
+                    next_rolling.copy_(tail[..., -window:])
+                else:
+                    next_rolling[..., :-take].copy_(rolling[..., take:])
+                    next_rolling[..., -take:].copy_(tail)
+                rolling = next_rolling
+                rolling_step += 1
+            if context.track_after_slots[request_id] == fixed_slot:
+                assert tracked_states is not None
+                assert tracked_state_is_set is not None
+                tracked_states[request_id].copy_(rolling)
+                tracked_state_is_set[request_id] = True
+        final_states.append(rolling)
+
+    final_states = (
+        final_states[0].unsqueeze(0) if bs == 1 else torch.stack(final_states)
+    )
+    _write_state_pool(conv_state_source, cache_indices, final_states)
+
+    track_request_indices = context.track_request_indices
+    if track_request_indices is None:
+        track_request_indices = torch.tensor(
+            track_request_ids,
+            dtype=torch.int64,
+            device=conv_state_source.device,
+        )
+    if track_request_indices.numel() > 0:
+        assert tracked_states is not None
+        assert tracked_state_is_set is not None
+        for request_id in track_request_ids:
+            if not tracked_state_is_set[request_id]:
+                raise RuntimeError(
+                    "KDA FLA CP did not produce a requested conv checkpoint"
+                )
+        track_pool_indices = context.track_state_indices.index_select(
+            0, track_request_indices
+        )
+        conv_state_source.index_copy_(
+            0,
+            track_pool_indices,
+            tracked_states.index_select(0, track_request_indices).to(
+                conv_state_source.dtype
+            ),
+        )
+    return local_initial
+
+
+__all__ = [
+    "KDAFLACPContext",
+    "build_kda_fla_cp_context",
+    "compose_kda_cp_affine_states",
+    "kda_use_fla_prefill_cp",
+    "kda_use_prefill_cp",
+    "prepare_kda_cp_conv_states",
+]

--- a/python/sglang/srt/layers/cp/utils.py
+++ b/python/sglang/srt/layers/cp/utils.py
@@ -45,6 +45,7 @@ CP_V2_DEFAULT_MODEL_CLASSES = frozenset(
         "DeepseekV32ForCausalLM",
         "GlmMoeDsaForCausalLM",
         "GptOssForCausalLM",
+        "KimiK3ForConditionalGeneration",
         "MiMoV2FlashForCausalLM",
         "MiMoV2ForCausalLM",
         "Qwen3MoeForCausalLM",
@@ -137,11 +138,15 @@ def enable_cp_v2() -> bool:
 
 
 def is_cp_v2_active(forward_batch) -> bool:
-    """Return whether the current forward batch is running through CP-v2."""
+    """Return whether the current local forward batch should use CP-v2."""
     if not enable_cp_v2():
         return False
     forward_mode = getattr(forward_batch, "forward_mode", None)
-    if forward_mode is None or not forward_mode.is_context_parallel_extend():
+    if (
+        forward_mode is None
+        or not forward_mode.is_context_parallel_extend()
+        or getattr(forward_mode, "is_mixed", lambda: False)()
+    ):
         return False
 
     strategy = get_cp_strategy()

--- a/python/sglang/srt/layers/cp/zigzag.py
+++ b/python/sglang/srt/layers/cp/zigzag.py
@@ -106,6 +106,126 @@ class ZigzagCPStrategy(ContextParallelStrategy):
     name = "zigzag"
     kind = ContextParallelStrategyKind.ZIGZAG
 
+    def __init__(self, cp_size: int):
+        super().__init__(cp_size)
+        self._ragged_shard_indices: dict[
+            tuple[torch.device, tuple[int, ...], tuple[int, ...]], torch.Tensor
+        ] = {}
+        self._ragged_restore_indices: dict[
+            tuple[
+                torch.device,
+                tuple[int, ...],
+                tuple[int, ...],
+                tuple[int, ...],
+                int,
+                int,
+            ],
+            torch.Tensor,
+        ] = {}
+
+    @staticmethod
+    def _bounded_cache_insert(cache: dict, key, value, limit: int = 64) -> None:
+        if len(cache) >= limit:
+            cache.clear()
+        cache[key] = value
+
+    def _get_ragged_shard_indices(
+        self, device: torch.device, metadata: ZigzagContextParallelMetadata
+    ) -> torch.Tensor:
+        """Map natural tokens directly to this rank's two zigzag halves."""
+        split_lens = tuple(int(length) for length in metadata.split_list)
+        zigzag_index = tuple(int(index) for index in metadata.zigzag_index)
+        key = (device, split_lens, zigzag_index)
+        indices = self._ragged_shard_indices.get(key)
+        if indices is not None:
+            return indices
+
+        natural_starts = [0] + list(accumulate(split_lens))
+        index_chunks = [
+            torch.arange(
+                natural_starts[segment_id],
+                natural_starts[segment_id] + split_lens[segment_id],
+                dtype=torch.int64,
+                device=device,
+            )
+            for segment_id in zigzag_index
+            if split_lens[segment_id] > 0
+        ]
+        if not index_chunks:
+            indices = torch.empty(0, dtype=torch.int64, device=device)
+        elif len(index_chunks) == 1:
+            indices = index_chunks[0]
+        else:
+            indices = torch.cat(index_chunks)
+
+        expected_tokens = sum(split_lens[index] for index in zigzag_index)
+        if indices.numel() != expected_tokens:
+            raise RuntimeError(
+                "Zigzag CP ragged shard plan has the wrong token count: "
+                f"indices={indices.numel()}, expected={expected_tokens}."
+            )
+        self._bounded_cache_insert(self._ragged_shard_indices, key, indices)
+        return indices
+
+    def _get_ragged_restore_indices(
+        self,
+        device: torch.device,
+        metadata: ZigzagContextParallelMetadata,
+        per_rank_tokens: List[int],
+        max_rank_len: int,
+    ) -> torch.Tensor:
+        """Map fixed-shape rank-major gather output to natural token order."""
+        reverse_split_lens = tuple(int(length) for length in metadata.reverse_split_len)
+        reverse_order = tuple(int(index) for index in metadata.cp_reverse_index)
+        rank_tokens = tuple(int(length) for length in per_rank_tokens)
+        key = (
+            device,
+            reverse_split_lens,
+            reverse_order,
+            rank_tokens,
+            int(max_rank_len),
+            int(metadata.bs),
+        )
+        indices = self._ragged_restore_indices.get(key)
+        if indices is not None:
+            return indices
+
+        segments_per_rank = int(metadata.bs) * 2
+        compact_segment_starts = [0] + list(accumulate(reverse_split_lens))
+        compact_rank_starts = [0] + list(accumulate(rank_tokens))
+        index_chunks = []
+        for segment_id in reverse_order:
+            length = reverse_split_lens[segment_id]
+            if length == 0:
+                continue
+            owner_rank = segment_id // segments_per_rank
+            within_rank_start = (
+                compact_segment_starts[segment_id] - compact_rank_starts[owner_rank]
+            )
+            fixed_start = owner_rank * max_rank_len + within_rank_start
+            index_chunks.append(
+                torch.arange(
+                    fixed_start,
+                    fixed_start + length,
+                    dtype=torch.int64,
+                    device=device,
+                )
+            )
+        if not index_chunks:
+            indices = torch.empty(0, dtype=torch.int64, device=device)
+        elif len(index_chunks) == 1:
+            indices = index_chunks[0]
+        else:
+            indices = torch.cat(index_chunks)
+
+        if indices.numel() != metadata.total_seq_lens:
+            raise RuntimeError(
+                "Zigzag CP ragged restore plan has the wrong token count: "
+                f"indices={indices.numel()}, expected={metadata.total_seq_lens}."
+            )
+        self._bounded_cache_insert(self._ragged_restore_indices, key, indices)
+        return indices
+
     def can_apply(self, num_tokens: int, forward_batch) -> bool:
         if self.cp_size <= 1 or num_tokens < self.cp_size * 2:
             return False
@@ -115,8 +235,16 @@ class ZigzagCPStrategy(ContextParallelStrategy):
 
         extend_lens = getattr(forward_batch, "extend_seq_lens_cpu", None)
         if extend_lens is None:
+            # ScheduleBatch exposes the same unpadded request lengths under
+            # ``extend_lens``.  Accept both so DP-attention can decide PCP
+            # before it fabricates idle work or materializes padding.
+            extend_lens = getattr(forward_batch, "extend_lens", None)
+        if extend_lens is None:
             return True
-        return all(int(length) >= self.cp_size * 2 for length in extend_lens)
+        extend_lens = [int(length) for length in extend_lens]
+        return int(num_tokens) >= sum(extend_lens) and all(
+            length >= self.cp_size * 2 for length in extend_lens
+        )
 
     def build_metadata(
         self,
@@ -301,37 +429,42 @@ class ZigzagCPStrategy(ContextParallelStrategy):
     def shard_hidden_states(self, x: Any, forward_batch) -> Any:
         metadata = forward_batch.attn_cp_metadata
         x = x[: metadata.total_seq_lens]
-        chunks = torch.split(x, metadata.split_list, dim=0)
-        local_x = torch.cat([chunks[i] for i in metadata.zigzag_index], dim=0)
+        local_x = torch.index_select(
+            x, 0, self._get_ragged_shard_indices(x.device, metadata)
+        )
         return pad_local_rows(local_x, metadata, dim=0)
 
     def shard_position_ids(self, positions: Any, forward_batch) -> Any:
         metadata = forward_batch.attn_cp_metadata
         positions = positions[..., : metadata.total_seq_lens]
-        chunks = torch.split(positions, metadata.split_list, dim=-1)
-        local_positions = torch.cat([chunks[i] for i in metadata.zigzag_index], dim=-1)
+        local_positions = torch.index_select(
+            positions,
+            -1,
+            self._get_ragged_shard_indices(positions.device, metadata),
+        )
         return pad_local_rows(local_positions, metadata, dim=-1)
 
     def gather_hidden_states(
         self, x: Any, forward_batch, stream: Optional[Any] = None
     ) -> Any:
-        gathered = self._all_gather_reorganized(x, forward_batch)
-        chunks = torch.split(
-            gathered, forward_batch.attn_cp_metadata.reverse_split_len, dim=0
-        )
-        return torch.cat(
-            [chunks[i] for i in forward_batch.attn_cp_metadata.cp_reverse_index], dim=0
-        )
+        return self._gather_and_restore(x, forward_batch)
 
     def gather_kv_cache(
         self, x: Any, forward_batch, stream: Optional[Any] = None
     ) -> Any:
-        gathered = self._all_gather_reorganized(x, forward_batch)
-        chunks = torch.split(
-            gathered, forward_batch.attn_cp_metadata.reverse_split_len, dim=0
+        return self._gather_and_restore(x, forward_batch)
+
+    def _gather_and_restore(self, x: torch.Tensor, forward_batch) -> torch.Tensor:
+        metadata = forward_batch.attn_cp_metadata
+        gathered, per_rank_tokens, max_rank_len = self._all_gather_fixed_shape(
+            x, forward_batch
         )
-        return torch.cat(
-            [chunks[i] for i in forward_batch.attn_cp_metadata.cp_reverse_index], dim=0
+        return torch.index_select(
+            gathered,
+            0,
+            self._get_ragged_restore_indices(
+                gathered.device, metadata, per_rank_tokens, max_rank_len
+            ),
         )
 
     def get_supported_attention_backend(self):
@@ -348,9 +481,9 @@ class ZigzagCPStrategy(ContextParallelStrategy):
         attn_fn,
         attention_backend: CPAttentionBackendKind = CPAttentionBackendKind.FLASH_ATTENTION,
     ) -> Any:
-        assert (
-            attention_backend in self.get_supported_attention_backend()
-        ), f"{self.name} CP does not support {attention_backend=}"
+        assert attention_backend in self.get_supported_attention_backend(), (
+            f"{self.name} CP does not support {attention_backend=}"
+        )
 
         meta = forward_batch.attn_cp_metadata
         q_prev = q[: meta.total_q_prev_tokens]
@@ -438,7 +571,7 @@ class ZigzagCPStrategy(ContextParallelStrategy):
             latent_full[..., kv_lora_rank:],
         )
 
-    def _all_gather_reorganized(self, x: torch.Tensor, forward_batch):
+    def _all_gather_fixed_shape(self, x: torch.Tensor, forward_batch):
         meta = forward_batch.attn_cp_metadata
         per_rank_token = meta.per_rank_logical_token or meta.per_rank_actual_token
         max_len = max(per_rank_token)
@@ -467,12 +600,4 @@ class ZigzagCPStrategy(ContextParallelStrategy):
                 dtype=x.dtype,
             )
         group.all_gather_into_tensor(gathered, x)
-
-        chunks = torch.split(gathered, [max_len] * self.cp_size, dim=0)
-        return torch.cat(
-            [
-                chunks[rank][:per_rank_len]
-                for rank, per_rank_len in enumerate(per_rank_token)
-            ],
-            dim=0,
-        )
+        return gathered, per_rank_token, max_len

--- a/python/sglang/srt/layers/utils/cp_utils.py
+++ b/python/sglang/srt/layers/utils/cp_utils.py
@@ -22,6 +22,10 @@ from sglang.srt.runtime_context import (
     uses_mla_backend,
 )
 
+# ``npu_ring_mla`` has a fixed 512x512 causal mask.  Larger zigzag blocks are
+# query-tiled by the Ascend backend; this is a tile size, not a request limit.
+MLA_CP_RING_MAX_CAUSAL_BLOCK_SIZE = 512
+
 
 @dataclass
 class ContextParallelMetadata:
@@ -87,6 +91,204 @@ def mla_use_prefill_cp(forward_batch, mla_enable_prefill_cp=None):
     )
 
 
+def get_npu_mla_cp_ring_validation_error(forward_batch, attention=None):
+    """Return why the Ascend MLA CP ring path cannot run.
+
+    The ring path accepts uneven zigzag blocks and radix prefixes that satisfy
+    the ATB ``kvSeqLen >= qSeqLen`` rule. Every block must also be non-empty.
+    Causal blocks larger than the 512-token ATB mask are tiled and
+    online-merged.
+    """
+    if attention is not None and (
+        getattr(attention, "qk_nope_head_dim", None) != 128
+        or getattr(attention, "qk_rope_head_dim", None) != 64
+        or getattr(attention, "v_head_dim", None) != 128
+    ):
+        return "npu_ring_mla requires 128-dim NoPE/value and 64-dim RoPE"
+
+    metadata = getattr(forward_batch, "attn_cp_metadata", None)
+    if metadata is None:
+        return "context-parallel metadata is missing"
+    bs = getattr(metadata, "bs", None)
+    if bs is None or int(bs) <= 0:
+        return "batch size must be positive"
+    bs = int(bs)
+    prefix_lens = getattr(forward_batch, "extend_prefix_lens_cpu", None)
+    if (
+        prefix_lens is None
+        or len(prefix_lens) != bs
+        or any(int(length) < 0 for length in prefix_lens)
+    ):
+        return "prefix-cache metadata is invalid"
+
+    cp_size = get_parallel().attn_cp_size
+    split_list = getattr(metadata, "split_list", None)
+    blocks_per_request = 2 * cp_size
+    if split_list is None or len(split_list) != bs * blocks_per_request:
+        return "only the zigzag CP layout is supported"
+    for request_id in range(bs):
+        begin = request_id * blocks_per_request
+        request_blocks = split_list[begin : begin + blocks_per_request]
+        if min(request_blocks) <= 0:
+            return "each request's zigzag blocks must have non-zero lengths"
+        prefix_len = int(prefix_lens[request_id])
+        if prefix_len != 0 and prefix_len < max(request_blocks):
+            return (
+                "non-zero prefix length must be at least the largest zigzag "
+                "block for npu_ring_mla"
+            )
+
+    per_rank_tokens = getattr(metadata, "per_rank_actual_token", None)
+    max_rank_len = getattr(metadata, "max_rank_len", None)
+    if (
+        per_rank_tokens is None
+        or len(per_rank_tokens) != cp_size
+        or max_rank_len is None
+        or len(max_rank_len) != cp_size
+        or len(set(max_rank_len)) != 1
+        or max_rank_len[0] < max(per_rank_tokens)
+    ):
+        return "context-parallel ring payload metadata is invalid"
+    return None
+
+
+def use_npu_mla_cp_ring(forward_batch, attention=None) -> bool:
+    selected = (
+        getattr(attention, "_use_npu_mla_cp_ring", False)
+        if attention is not None
+        else getattr(forward_batch, "_use_npu_mla_cp_ring", False)
+    )
+    return selected and (
+        get_npu_mla_cp_ring_validation_error(forward_batch, attention) is None
+    )
+
+
+def get_zigzag_mla_cp_ring_visibility(cp_rank: int, source_rank: int):
+    """Return visibility of a source rank's early/late KV zigzag blocks.
+
+    The tuple is ``(early_to_local_early, early_to_local_late,
+    late_to_local_late)``. Equality denotes the two causal diagonal blocks;
+    the caller applies a triangular mask only in that case.
+    """
+    return source_rank <= cp_rank, True, source_rank >= cp_rank
+
+
+def get_zigzag_cp_rank_chunk_indices(bs: int, cp_size: int, cp_rank: int):
+    """Return natural-layout chunk indices owned by one zigzag CP rank.
+
+    The returned order is ``[all request early blocks, all request late
+    blocks]``, matching the rank-local tensor layout used by CP-v2.
+    """
+    if bs <= 0 or cp_size <= 0 or not 0 <= cp_rank < cp_size:
+        raise ValueError(
+            f"Invalid zigzag CP topology: bs={bs}, cp_size={cp_size}, "
+            f"cp_rank={cp_rank}."
+        )
+    segments = 2 * cp_size
+    return list(range(cp_rank, bs * segments, segments)) + list(
+        range(segments - cp_rank - 1, bs * segments, segments)
+    )
+
+
+def get_zigzag_cp_rank_block_lengths(split_list, bs: int, cp_size: int, cp_rank: int):
+    """Return per-request ``(early, late)`` block lengths for a CP rank."""
+    segments = 2 * cp_size
+    if len(split_list) != bs * segments:
+        raise ValueError(
+            "Zigzag split metadata does not match batch/CP topology: "
+            f"splits={len(split_list)}, expected={bs * segments}."
+        )
+    chunk_indices = get_zigzag_cp_rank_chunk_indices(bs, cp_size, cp_rank)
+    return (
+        [int(split_list[index]) for index in chunk_indices[:bs]],
+        [int(split_list[index]) for index in chunk_indices[bs:]],
+    )
+
+
+def pack_paged_prefix_cache(paged_cache, prefix_lens, page_size: int):
+    """Remove per-request tail padding from selected prefix-cache pages."""
+    if page_size <= 0:
+        raise ValueError(f"page_size must be positive, got {page_size}")
+    page_offset = 0
+    packed_requests = []
+    for prefix_len in prefix_lens:
+        prefix_len = int(prefix_len)
+        if prefix_len < 0:
+            raise ValueError(f"prefix length must be non-negative, got {prefix_len}")
+        page_count = (prefix_len + page_size - 1) // page_size
+        request_pages = paged_cache[page_offset : page_offset + page_count]
+        page_offset += page_count
+        if prefix_len > 0:
+            packed_requests.append(request_pages.flatten(0, 1)[:prefix_len])
+    if page_offset != paged_cache.shape[0]:
+        raise ValueError(
+            "Selected prefix pages do not match prefix lengths: "
+            f"pages={paged_cache.shape[0]}, consumed={page_offset}."
+        )
+    if not packed_requests:
+        return paged_cache.flatten(0, 1)[:0]
+    return torch.cat(packed_requests, dim=0)
+
+
+def get_prefix_block_slices(
+    prefix_lens: List[int],
+    block_size: int,
+    minimum_block_lens: List[int] | None = None,
+):
+    """Plan bounded, round-major slices for packed per-request prefixes.
+
+    ``npu_ring_mla`` requires every non-empty KV segment to be at least as
+    long as its query segment.  A short tail is therefore folded into the
+    preceding block instead of being emitted as a separate undersized block.
+    The resulting block size is bounded by ``block_size + minimum - 1``.
+    """
+    if block_size <= 0:
+        raise ValueError(f"prefix block size must be positive, got {block_size}")
+    if minimum_block_lens is None:
+        minimum_block_lens = [0] * len(prefix_lens)
+    if len(prefix_lens) != len(minimum_block_lens):
+        raise ValueError(
+            "prefix and minimum block length lists must have the same size"
+        )
+
+    request_slices = []
+    for prefix_len, minimum_block_len in zip(prefix_lens, minimum_block_lens):
+        prefix_len = int(prefix_len)
+        minimum_block_len = int(minimum_block_len)
+        if prefix_len < 0 or minimum_block_len < 0:
+            raise ValueError(
+                "prefix and minimum block lengths must be non-negative, got "
+                f"prefix={prefix_len}, minimum={minimum_block_len}"
+            )
+
+        slices = []
+        start = 0
+        while start < prefix_len:
+            remaining = prefix_len - start
+            length = min(block_size, remaining)
+            tail = remaining - length
+            if tail and tail < minimum_block_len:
+                length = remaining
+            slices.append((start, length))
+            start += length
+        request_slices.append(slices)
+
+    rounds = []
+    max_rounds = max((len(slices) for slices in request_slices), default=0)
+    for round_index in range(max_rounds):
+        rounds.append(
+            [
+                (
+                    slices[round_index]
+                    if round_index < len(slices)
+                    else (int(prefix_len), 0)
+                )
+                for prefix_len, slices in zip(prefix_lens, request_slices)
+            ]
+        )
+    return rounds
+
+
 def can_cp_split(seq_len: int, cp_size: int, forward_batch):
     # Base conditions: CP must be enabled, size > 1, and this must be a
     # CP-extend (prefill) step. The seq_len // (cp_size * 2) check ensures
@@ -137,9 +339,9 @@ def cp_split_and_rebuild_data(forward_batch, input_: torch.Tensor):
 
     if is_dsa_prefill_cp_round_robin_split():
         cp_size = get_parallel().attn_cp_size
-        assert (
-            input_.shape[0] % cp_size == 0
-        ), f"Expect input shape 0 can divided by cp size, but got input shape {input_.shape}, cp size {cp_size}"
+        assert input_.shape[0] % cp_size == 0, (
+            f"Expect input shape 0 can divided by cp size, but got input shape {input_.shape}, cp size {cp_size}"
+        )
         return dsa_cp_round_robin_split_data(input_)
 
     input_list = list(

--- a/python/sglang/srt/managers/scheduler_components/request_receiver.py
+++ b/python/sglang/srt/managers/scheduler_components/request_receiver.py
@@ -158,21 +158,7 @@ class SchedulerRequestReceiver:
                 work_reqs = None
                 control_reqs = None
 
-            if self.ps.attn_tp_size != 1:
-                work_reqs = broadcast_pyobj(
-                    work_reqs,
-                    self.attn_tp_group.rank,
-                    self.attn_tp_cpu_group,
-                    src=self.attn_tp_group.ranks[0],
-                )
-
-            if self.ps.attn_cp_size != 1:
-                work_reqs = broadcast_pyobj(
-                    work_reqs,
-                    self.attn_cp_group.rank,
-                    self.attn_cp_cpu_group,
-                    src=self.attn_cp_group.ranks[0],
-                )
+            work_reqs = self._broadcast_within_attention_dp_group(work_reqs)
 
             # When dp_attention_local_control_broadcast is enabled, each DP
             # group leader already receives control messages from the DP
@@ -184,20 +170,9 @@ class SchedulerRequestReceiver:
                 or is_ep_scale_joiner()
             )
             if _local_ctrl:
-                if self.ps.attn_tp_size != 1:
-                    control_reqs = broadcast_pyobj(
-                        control_reqs,
-                        self.attn_tp_group.rank,
-                        self.attn_tp_cpu_group,
-                        src=self.attn_tp_group.ranks[0],
-                    )
-                if self.ps.attn_cp_size != 1:
-                    control_reqs = broadcast_pyobj(
-                        control_reqs,
-                        self.attn_cp_group.rank,
-                        self.attn_cp_cpu_group,
-                        src=self.attn_cp_group.ranks[0],
-                    )
+                control_reqs = self._broadcast_within_attention_dp_group(
+                    control_reqs
+                )
             elif self.ps.tp_size != 1:
                 control_reqs = broadcast_pyobj(
                     control_reqs,
@@ -214,6 +189,33 @@ class SchedulerRequestReceiver:
                 src=self.tp_group.ranks[0],
             )
         return recv_reqs
+
+    def _broadcast_within_attention_dp_group(
+        self, reqs: Optional[List]
+    ) -> List:
+        """Broadcast from the (attention-CP0, attention-TP0) DP leader.
+
+        Only that leader receives requests. First seed its CP0 attention-TP
+        row, then let the populated row seed every attention-CP column. Other
+        CP rows must not start an attention-TP broadcast with ``None``.
+        """
+        if self.ps.attn_tp_size != 1 and self.ps.attn_cp_rank == 0:
+            reqs = broadcast_pyobj(
+                reqs,
+                self.attn_tp_group.rank,
+                self.attn_tp_cpu_group,
+                src=self.attn_tp_group.ranks[0],
+            )
+
+        if self.ps.attn_cp_size != 1:
+            reqs = broadcast_pyobj(
+                reqs,
+                self.attn_cp_group.rank,
+                self.attn_cp_cpu_group,
+                src=self.attn_cp_group.ranks[0],
+            )
+
+        return reqs
 
     def unwrap_pickle_wrapper(self, recv_reqs: Optional[List]) -> None:
         if not recv_reqs:

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -3847,7 +3847,18 @@ class HybridLinearKVPool(KVCache):
     def get_kv_layer_ids(self):
         """Global layer ids aligned with the full-attention KV buffers."""
         layer_ids = list(self.full_attention_layer_id_mapping)
-        return layer_ids if self.use_mla else layer_ids * 2
+        if not layer_ids:
+            return []
+        num_entries = len(self.full_kv_pool.get_contiguous_buf_infos()[0])
+        if num_entries % len(layer_ids) != 0:
+            raise RuntimeError(
+                "Hybrid KV buffer count must be divisible by its full-attention "
+                f"layer count, got buffers={num_entries}, layers={len(layer_ids)}."
+            )
+        # Most MLA pools have one entry per layer and MHA pools have K/V
+        # entries. NPU MLA keeps latent K and K-RoPE as two separate groups,
+        # so derive the multiplicity from the concrete backing pool.
+        return layer_ids * (num_entries // len(layer_ids))
 
     def get_state_buf_infos(self):
         mamba_data_ptrs, mamba_data_lens, mamba_item_lens = (

--- a/python/sglang/srt/model_executor/runner/eager_runner.py
+++ b/python/sglang/srt/model_executor/runner/eager_runner.py
@@ -67,6 +67,7 @@ from sglang.srt.runtime_context import (
 from sglang.srt.utils import is_hip, is_npu
 from sglang.srt.utils.common import (
     ceil_align,
+    get_current_device_stream_fast,
     get_eager_max_batch_size,
     require_mlp_sync,
 )
@@ -393,7 +394,11 @@ class EagerRunner(BaseRunner):
             model_kwargs = {"input_embeds": sharded_input_embeds}
             if (pp_proxy_tensors := kwargs.get("pp_proxy_tensors")) is not None:
                 model_kwargs["pp_proxy_tensors"] = pp_proxy_tensors
-            hidden_states = model.model(
+            cp_model_getter = getattr(model, "get_context_parallel_model", None)
+            cp_model = (
+                cp_model_getter() if cp_model_getter is not None else model.model
+            )
+            hidden_states = cp_model(
                 forward_batch.input_ids,
                 sharded_positions,
                 forward_batch,
@@ -411,7 +416,7 @@ class EagerRunner(BaseRunner):
                 else hidden_states
             )
 
-        stream = torch.cuda.current_stream()
+        stream = get_current_device_stream_fast()
         hidden_states = cp_gather_after_forward(hidden_states, forward_batch, stream)
         # DSpark aux tensors ride the same CP token split; gather them the same way.
         if aux_hidden_states is not None:

--- a/python/sglang/srt/models/deepseek_common/attention_backend_handler.py
+++ b/python/sglang/srt/models/deepseek_common/attention_backend_handler.py
@@ -1,5 +1,8 @@
 from sglang.srt.layers.attention.tbo_backend import TboAttnBackend
-from sglang.srt.layers.utils.cp_utils import mla_use_prefill_cp
+from sglang.srt.layers.utils.cp_utils import (
+    get_npu_mla_cp_ring_validation_error,
+    mla_use_prefill_cp,
+)
 from sglang.srt.model_executor.forward_context import get_attn_backend
 from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph import (
     is_in_breakable_cuda_graph,
@@ -71,6 +74,16 @@ def handle_attention_ascend(attn, forward_batch):
     ):
         if hasattr(attn, "use_dsa") and attn.use_dsa:
             return AttnForwardMethod.DSA_NPU
+        elif getattr(attn, "_use_npu_mla_cp_ring", False) and mla_use_prefill_cp(
+            forward_batch, attn.mla_enable_prefill_cp
+        ):
+            reason = get_npu_mla_cp_ring_validation_error(forward_batch, attn)
+            if reason is not None:
+                raise ValueError(f"Kimi-K3 MLA CP ring is unavailable: {reason}")
+            # npu_ring_mla consumes expanded 128-dim K/V, so use the MHA
+            # preparation path while rotating compact latent KV between
+            # CP ranks inside the Ascend backend.
+            return AttnForwardMethod.MHA_NPU
         else:
             return AttnForwardMethod.MHA_NPU
     else:

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -210,6 +210,7 @@ from sglang.srt.utils import (
     BumpAllocator,
     LazyValue,
     add_prefix,
+    get_current_device_stream_fast,
     is_non_idle_and_non_empty,
     make_layers,
     use_intel_amx_backend,
@@ -2281,7 +2282,7 @@ class DeepseekV2AttentionMLA(
             latent_cache.contiguous(),
             self.cp_size,
             forward_batch,
-            torch.cuda.current_stream(),
+            get_current_device_stream_fast(),
         )
         k_nope = latent_cache_output[..., : self.kv_lora_rank].unsqueeze(1)
         k_pe = latent_cache_output[..., self.kv_lora_rank :].unsqueeze(1)

--- a/python/sglang/srt/models/kimi_k3.py
+++ b/python/sglang/srt/models/kimi_k3.py
@@ -76,6 +76,7 @@ from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.layers.quantization.fp8_utils import block_quant_dequant
 from sglang.srt.layers.radix_linear_attention import RadixLinearAttention
 from sglang.srt.layers.utils import PPMissingLayer, get_layer_id
+from sglang.srt.layers.utils.cp_utils import is_mla_prefill_cp_enabled
 from sglang.srt.layers.vocab_parallel_embedding import (
     ParallelLMHead,
     VocabParallelEmbedding,
@@ -1004,8 +1005,22 @@ class KimiK3MoE(nn.Module):
 
         group = get_parallel().attn_tp_group
         # SP-MoE presents one contiguous token shard per attention-TP rank;
-        # the DP local buffer is the full reassembled per-replica batch.
+        # the DP local buffer is the full reassembled per-replica batch. CP-v2
+        # shards the DP-local batch after that buffer length was published, so
+        # the pooled buffer can be larger than this CP rank's attention-TP
+        # gather. HCCL requires the output to contain exactly world_size input
+        # tensors; use only the active rows rather than the full DP capacity.
+        required_rows = hidden_states.shape[0] * group.world_size
         gathered_hidden_states = get_local_dp_buffer(group)
+        if (
+            gathered_hidden_states.shape[0] < required_rows
+            or gathered_hidden_states.shape[1:] != hidden_states.shape[1:]
+        ):
+            gathered_hidden_states = hidden_states.new_empty(
+                (required_rows, *hidden_states.shape[1:])
+            )
+        else:
+            gathered_hidden_states = gathered_hidden_states[:required_rows]
         attn_tp_all_gather_into_tensor(gathered_hidden_states, hidden_states)
         gathered_shared_output = self.shared_experts(gathered_hidden_states)
         shared_output = torch.empty_like(hidden_states)
@@ -1919,6 +1934,7 @@ class KimiK3MLAAttention(DeepseekV2AttentionMLA):
         # The fused Ascend split+RMSNorm path is not numerically equivalent for
         # Kimi-K3. Other MLA models retain the existing fused fast path.
         self._disable_npu_fused_split_qk_norm = True
+        self._use_npu_mla_cp_ring = True
         super().__init__(
             layer_id=layer_idx,
             hidden_size=config.hidden_size,
@@ -1931,6 +1947,7 @@ class KimiK3MLAAttention(DeepseekV2AttentionMLA):
             v_head_dim=config.v_head_dim,
             q_lora_rank=config.q_lora_rank,
             kv_lora_rank=config.kv_lora_rank,
+            mla_enable_prefill_cp=is_mla_prefill_cp_enabled(),
             skip_rope=True,
             reduce_results=not self.all_reduce_fusion,
             alt_stream=alt_stream,
@@ -2377,7 +2394,20 @@ class KimiK3DecoderLayer(nn.Module):
         # output back; padded rows are discarded downstream.
         num_padded = hidden_states.shape[0]
         num_real = num_padded
-        if self._trim_padded_attn and forward_batch.forward_mode.is_extend():
+        cp_metadata = forward_batch.attn_cp_metadata
+        if cp_metadata is not None:
+            # CP-v2 pads every rank to a common physical row count for its
+            # collectives. KDA/MLA attention metadata, including causal-conv
+            # query_start_loc, covers only this rank's logical zigzag rows.
+            # Never feed the rank-local alignment tail into attention or its
+            # KV/state updates.
+            per_rank_tokens = (
+                cp_metadata.per_rank_logical_token or cp_metadata.per_rank_actual_token
+            )
+            num_real = min(
+                int(per_rank_tokens[get_parallel().attn_cp_rank]), num_padded
+            )
+        elif self._trim_padded_attn and forward_batch.forward_mode.is_extend():
             extend_lens = forward_batch.extend_seq_lens_cpu
             if extend_lens is not None:
                 num_real = min(int(sum(extend_lens)), num_padded)
@@ -2695,7 +2725,14 @@ class KimiK3LinearModel(nn.Module):
         forward_batch: ForwardBatch,
         inputs_embeds: torch.Tensor | None = None,
         pp_proxy_tensors: Optional[PPProxyTensors] = None,
+        input_embeds: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        if input_embeds is not None:
+            if inputs_embeds is not None:
+                raise ValueError(
+                    "Only one of input_embeds and inputs_embeds may be provided."
+                )
+            inputs_embeds = input_embeds
         if get_pp_group().is_first_rank:
             if inputs_embeds is not None:
                 hidden_states = inputs_embeds
@@ -3320,6 +3357,22 @@ class KimiK3ForConditionalGeneration(nn.Module):
     @property
     def model(self):
         return self.language_model
+
+    @property
+    def logits_processor(self):
+        return self.language_model.logits_processor
+
+    @property
+    def capture_aux_hidden_states(self):
+        return self.language_model.capture_aux_hidden_states
+
+    @property
+    def pp_group(self):
+        return self.language_model.pp_group
+
+    def get_context_parallel_model(self):
+        """Return the text backbone used between CP shard and gather."""
+        return self.language_model.model
 
     def __setattr__(self, name, value):
         if name == "model":

--- a/test/registered/cp/test_cp_strategy_unit.py
+++ b/test/registered/cp/test_cp_strategy_unit.py
@@ -5,6 +5,9 @@ from unittest.mock import patch
 
 import torch
 
+from sglang.srt.hardware_backend.npu.attention.ascend_backend import (
+    AscendAttnBackend,
+)
 from sglang.srt.layers.cp.base import (
     ContextParallelStrategyKind,
     get_cp_strategy,
@@ -28,11 +31,26 @@ from sglang.srt.layers.cp.utils import (
     prepare_cp_forward,
 )
 from sglang.srt.layers.cp.zigzag import ZigzagCPStrategy
+from sglang.srt.layers.utils.cp_utils import (
+    get_npu_mla_cp_ring_validation_error,
+    get_prefix_block_slices,
+    get_zigzag_cp_rank_block_lengths,
+    get_zigzag_cp_rank_chunk_indices,
+    get_zigzag_mla_cp_ring_visibility,
+    pack_paged_prefix_cache,
+    use_npu_mla_cp_ring,
+)
 from sglang.srt.mem_cache.memory_pool import KVWriteLoc
 from sglang.srt.model_executor.cuda_graph_config import Backend
 from sglang.srt.model_executor.forward_batch_info import (
     CaptureHiddenMode,
     ForwardMode,
+)
+from sglang.srt.models.deepseek_common.attention_backend_handler import (
+    handle_attention_ascend,
+)
+from sglang.srt.models.deepseek_common.attention_forward_methods.forward_methods import (
+    AttnForwardMethod,
 )
 from sglang.srt.model_executor.runner.prefill_cuda_graph_runner import (
     PrefillCudaGraphRunner,
@@ -61,6 +79,260 @@ class _FakeCPGroup:
 class TestCPStrategyUnit(CustomTestCase):
     def tearDown(self):
         init_cp_strategy(enable_prefill_cp=False, cp_size=1, cp_strategy="zigzag")
+
+    def test_ascend_prefill_cp_for_other_models_keeps_mha(self):
+        forward_mode = SimpleNamespace(
+            is_extend=lambda: True,
+            is_target_verify=lambda: False,
+            is_draft_extend_v2=lambda: False,
+        )
+        forward_batch = SimpleNamespace(forward_mode=forward_mode)
+        attn = SimpleNamespace(use_dsa=False, mla_enable_prefill_cp=True)
+
+        with patch(
+            "sglang.srt.models.deepseek_common.attention_backend_handler."
+            "mla_use_prefill_cp",
+            return_value=True,
+        ) as use_prefill_cp:
+            method = handle_attention_ascend(attn, forward_batch)
+
+        self.assertEqual(method, AttnForwardMethod.MHA_NPU)
+        use_prefill_cp.assert_not_called()
+
+    def test_ascend_prefill_cp_ring_dispatches_to_mha(self):
+        forward_mode = SimpleNamespace(
+            is_extend=lambda: True,
+            is_target_verify=lambda: False,
+            is_draft_extend_v2=lambda: False,
+        )
+        forward_batch = SimpleNamespace(forward_mode=forward_mode)
+        attn = SimpleNamespace(
+            use_dsa=False,
+            mla_enable_prefill_cp=True,
+            qk_nope_head_dim=128,
+            qk_rope_head_dim=64,
+            v_head_dim=128,
+            _use_npu_mla_cp_ring=True,
+        )
+
+        with (
+            patch(
+                "sglang.srt.models.deepseek_common.attention_backend_handler."
+                "mla_use_prefill_cp",
+                return_value=True,
+            ),
+            patch(
+                "sglang.srt.models.deepseek_common.attention_backend_handler."
+                "get_npu_mla_cp_ring_validation_error",
+                return_value=None,
+            ),
+        ):
+            method = handle_attention_ascend(attn, forward_batch)
+
+        self.assertEqual(method, AttnForwardMethod.MHA_NPU)
+
+    def test_mla_cp_ring_batch_guard(self):
+        metadata = SimpleNamespace(bs=1, split_list=[64] * 8)
+        forward_batch = SimpleNamespace(
+            attn_cp_metadata=metadata,
+            extend_prefix_lens_cpu=[0],
+            _use_npu_mla_cp_ring=True,
+        )
+
+        def update_payload_metadata():
+            rank_tokens = []
+            for rank in range(4):
+                early_lens, late_lens = get_zigzag_cp_rank_block_lengths(
+                    metadata.split_list, metadata.bs, 4, rank
+                )
+                rank_tokens.append(sum(early_lens) + sum(late_lens))
+            metadata.per_rank_actual_token = rank_tokens
+            metadata.max_rank_len = [max(rank_tokens)] * 4
+
+        update_payload_metadata()
+        with patch(
+            "sglang.srt.layers.utils.cp_utils.get_parallel",
+            return_value=SimpleNamespace(attn_cp_size=4),
+        ):
+            self.assertIsNone(get_npu_mla_cp_ring_validation_error(forward_batch))
+            self.assertTrue(use_npu_mla_cp_ring(forward_batch))
+
+            metadata.bs = 2
+            metadata.split_list = [65] + [64] * 7 + [33] + [32] * 7
+            forward_batch.extend_prefix_lens_cpu = [0, 0]
+            update_payload_metadata()
+            self.assertIsNone(get_npu_mla_cp_ring_validation_error(forward_batch))
+            self.assertTrue(use_npu_mla_cp_ring(forward_batch))
+
+            forward_batch.extend_prefix_lens_cpu = [0, 65]
+            self.assertIsNone(get_npu_mla_cp_ring_validation_error(forward_batch))
+
+            forward_batch.extend_prefix_lens_cpu = [0, 1]
+            self.assertEqual(
+                get_npu_mla_cp_ring_validation_error(forward_batch),
+                "non-zero prefix length must be at least the largest zigzag "
+                "block for npu_ring_mla",
+            )
+
+            metadata.split_list[-1] = 0
+            self.assertEqual(
+                get_npu_mla_cp_ring_validation_error(forward_batch),
+                "each request's zigzag blocks must have non-zero lengths",
+            )
+            forward_batch.extend_prefix_lens_cpu = [0, 0]
+            metadata.split_list = [513] * 8 + [32] * 8
+            update_payload_metadata()
+            self.assertIsNone(get_npu_mla_cp_ring_validation_error(forward_batch))
+
+            metadata.split_list = [65] + [64] * 7 + [33] + [32] * 7
+            update_payload_metadata()
+            metadata.max_rank_len = [1] * 4
+            self.assertEqual(
+                get_npu_mla_cp_ring_validation_error(forward_batch),
+                "context-parallel ring payload metadata is invalid",
+            )
+
+    def test_mla_cp_ring_maps_rank_shards_to_natural_cache_locations(self):
+        cp_size = 4
+        blocks_per_request = 2 * cp_size
+        split_list = [2] * blocks_per_request + [1] * blocks_per_request
+        full_kv = torch.arange(sum(split_list)).unsqueeze(1)
+        natural_chunks = torch.split(full_kv, split_list, dim=0)
+        restored_cache = torch.full_like(full_kv, -1)
+
+        for rank in range(cp_size):
+            shard_indices = get_zigzag_cp_rank_chunk_indices(
+                bs=2, cp_size=cp_size, cp_rank=rank
+            )
+            shard = torch.cat([natural_chunks[index] for index in shard_indices], dim=0)
+            shard_cache_locs = torch.cat(
+                [natural_chunks[index].flatten() for index in shard_indices], dim=0
+            )
+            restored_cache[shard_cache_locs] = shard
+
+        self.assertEqual(
+            get_zigzag_cp_rank_chunk_indices(bs=2, cp_size=4, cp_rank=0),
+            [0, 8, 7, 15],
+        )
+        torch.testing.assert_close(restored_cache, full_kv)
+
+        with self.assertRaisesRegex(ValueError, "Invalid zigzag CP topology"):
+            get_zigzag_cp_rank_chunk_indices(bs=2, cp_size=4, cp_rank=4)
+
+    def test_mla_cp_ring_derives_uneven_source_block_lengths(self):
+        split_list = list(range(1, 17))
+        self.assertEqual(
+            get_zigzag_cp_rank_block_lengths(split_list, 2, 4, 0),
+            ([1, 9], [8, 16]),
+        )
+        self.assertEqual(
+            get_zigzag_cp_rank_block_lengths(split_list, 2, 4, 3),
+            ([4, 12], [5, 13]),
+        )
+
+        for total_tokens in range(8, 80):
+            base, remainder = divmod(total_tokens, 8)
+            blocks = [
+                base + (1 if block_id < remainder else 0) for block_id in range(8)
+            ]
+            for cp_rank in range(4):
+                local_early, local_late = get_zigzag_cp_rank_block_lengths(
+                    blocks, 1, 4, cp_rank
+                )
+                for source_rank in range(4):
+                    source_early, source_late = get_zigzag_cp_rank_block_lengths(
+                        blocks, 1, 4, source_rank
+                    )
+                    early_to_prev, _, late_to_next = get_zigzag_mla_cp_ring_visibility(
+                        cp_rank, source_rank
+                    )
+                    if early_to_prev:
+                        self.assertGreaterEqual(source_early[0], local_early[0])
+                    self.assertGreaterEqual(source_early[0], local_late[0])
+                    if late_to_next:
+                        self.assertGreaterEqual(source_late[0], local_late[0])
+
+    def test_mla_cp_ring_packs_prefix_pages_per_request(self):
+        selected_pages = torch.arange(12).view(3, 4, 1)
+        packed_prefix = pack_paged_prefix_cache(
+            selected_pages, prefix_lens=[3, 5], page_size=4
+        )
+        torch.testing.assert_close(
+            packed_prefix.flatten(), torch.tensor([0, 1, 2, 4, 5, 6, 7, 8])
+        )
+
+    def test_mla_cp_ring_prefix_blocks_fold_short_tails(self):
+        self.assertEqual(
+            get_prefix_block_slices(
+                prefix_lens=[0, 10, 25],
+                block_size=8,
+                minimum_block_lens=[0, 3, 6],
+            ),
+            [
+                [(0, 0), (0, 10), (0, 8)],
+                [(0, 0), (10, 0), (8, 8)],
+                [(0, 0), (10, 0), (16, 9)],
+            ],
+        )
+
+    def test_mla_cp_ring_direct_pack(self):
+        backend = AscendAttnBackend.__new__(AscendAttnBackend)
+        backend._mla_cp_ring_send_buffer = None
+        latent = torch.arange(12, dtype=torch.float32).reshape(3, 1, 4)
+        rope = torch.arange(6, dtype=torch.float32).reshape(3, 1, 2)
+
+        direct = backend._pack_mla_cp_ring_local_kv(latent, rope, 5).clone()
+        expected = torch.zeros(5, 6)
+        expected[:3] = torch.cat((latent.flatten(1), rope.flatten(1)), dim=-1)
+
+        torch.testing.assert_close(direct, expected)
+
+    def test_mla_cp_ring_direct_prefix_gather(self):
+        backend = AscendAttnBackend.__new__(AscendAttnBackend)
+        backend.page_size = 4
+        backend.mla_cp_ring_prefix_block_size = 4
+        backend.forward_metadata = SimpleNamespace(
+            flatten_prefix_block_tables=torch.tensor([1, 3, 0], dtype=torch.int32)
+        )
+        forward_batch = SimpleNamespace()
+        k_buffer = torch.arange(16, dtype=torch.float32).reshape(4, 4, 1)
+        v_buffer = k_buffer + 100
+        args = (k_buffer, v_buffer, forward_batch, [5, 3], [0, 0])
+
+        direct = list(backend._iter_mla_cp_ring_compact_prefix_blocks(*args))
+
+        self.assertEqual([item[0] for item in direct], [[4, 3], [1, 0]])
+        torch.testing.assert_close(
+            direct[0][1].flatten(),
+            torch.tensor([4, 5, 6, 7, 0, 1, 2], dtype=torch.float32),
+        )
+        torch.testing.assert_close(
+            direct[1][1].flatten(), torch.tensor([12], dtype=torch.float32)
+        )
+        torch.testing.assert_close(direct[0][2], direct[0][1] + 100)
+        torch.testing.assert_close(direct[1][2], direct[1][1] + 100)
+
+    def test_mla_cp_ring_zigzag_visibility_is_causal(self):
+        cp_size = 4
+        for cp_rank in range(cp_size):
+            prev_visible_blocks = []
+            next_visible_blocks = []
+            for source_rank in range(cp_size):
+                early_to_prev, early_to_next, late_to_next = (
+                    get_zigzag_mla_cp_ring_visibility(cp_rank, source_rank)
+                )
+                if early_to_prev:
+                    prev_visible_blocks.append(source_rank)
+                if early_to_next:
+                    next_visible_blocks.append(source_rank)
+                if late_to_next:
+                    next_visible_blocks.append(2 * cp_size - 1 - source_rank)
+
+            self.assertEqual(prev_visible_blocks, list(range(cp_rank + 1)))
+            self.assertEqual(
+                sorted(next_visible_blocks),
+                list(range(2 * cp_size - cp_rank)),
+            )
 
     def test_strategy_kind_maps_cli_values(self):
         self.assertEqual(ContextParallelStrategyKind.NONE.value, 0)
@@ -304,6 +576,30 @@ class TestCPZigzagStrategy(CustomTestCase):
             self.assertTrue(enable_cp_v2())
             self.assertTrue(is_cp_v2_active(active_batch))
             self.assertFalse(is_cp_v2_active(inactive_batch))
+
+    def test_prefill_and_decode_dp_replicas_decide_cp_independently(self):
+        prefill_batch = SimpleNamespace(
+            input_ids=torch.arange(8),
+            forward_mode=ForwardMode.EXTEND,
+            extend_seq_lens_cpu=[8],
+        )
+        decode_batch = SimpleNamespace(
+            input_ids=torch.arange(8),
+            forward_mode=ForwardMode.DECODE,
+            extend_seq_lens_cpu=[8],
+        )
+        mixed_batch = SimpleNamespace(
+            input_ids=torch.arange(8),
+            forward_mode=ForwardMode.MIXED,
+            extend_seq_lens_cpu=[8],
+        )
+
+        with patch(
+            "sglang.srt.environ.envs.SGLANG_ENABLE_CP_V2.get", return_value=True
+        ):
+            self.assertTrue(is_cp_v2_active(prefill_batch))
+            self.assertFalse(is_cp_v2_active(decode_batch))
+            self.assertFalse(is_cp_v2_active(mixed_batch))
 
     def _expected_metadata(self, *, rank, cp_size, seq_lens, extend_seq_lens):
         bs = len(extend_seq_lens)
@@ -573,6 +869,38 @@ class TestCPZigzagStrategy(CustomTestCase):
                 )
 
             self.assertTrue(torch.equal(gathered, kv))
+
+    def test_zigzag_direct_layout_paths_restore_natural_order(self):
+        cp_size = 4
+        seq_lens = [17, 12, 9]
+        extend_seq_lens = [13, 10, 9]
+        x = torch.arange(sum(extend_seq_lens) * 3).view(sum(extend_seq_lens), 3)
+        metas, padded_rank_tensors = self._padded_rank_tensors(
+            x,
+            cp_size=cp_size,
+            seq_lens=seq_lens,
+            extend_seq_lens=extend_seq_lens,
+        )
+
+        for rank in range(cp_size):
+            metadata = metas[rank]
+            fb = self._forward_batch(metadata, extend_seq_lens)
+            strategy = ZigzagCPStrategy(cp_size=cp_size)
+            local_x = padded_rank_tensors[rank][: metadata.per_rank_actual_token[rank]]
+            with (
+                get_parallel().override(
+                    attn_cp_group=_FakeCPGroup(padded_rank_tensors)
+                ),
+                patch(
+                    "sglang.srt.distributed.device_communicators.pynccl_allocator.use_symmetric_memory",
+                    return_value=torch.no_grad(),
+                ),
+            ):
+                direct_shard = strategy.shard_hidden_states(x, fb)
+                direct_gather = strategy.gather_hidden_states(local_x, fb)
+
+            self.assertTrue(torch.equal(direct_shard, local_x))
+            self.assertTrue(torch.equal(direct_gather, x))
 
     def test_zigzag_padding_aligns_local_tensors(self):
         cp_size = 2

--- a/test/registered/cp/test_kda_prefill_cp_unit.py
+++ b/test/registered/cp/test_kda_prefill_cp_unit.py
@@ -1,0 +1,256 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import torch
+
+try:
+    from sglang.srt.hardware_backend.npu.attention.ascend_kda_backend import (
+        AscendKDAAttnBackend,
+    )
+except ModuleNotFoundError as exc:
+    if not (exc.name or "").startswith("sgl_kernel_npu"):
+        raise
+    AscendKDAAttnBackend = None
+from sglang.srt.layers.attention.linear.kda_cp import (
+    KDAFLACPContext,
+    compose_kda_cp_affine_states,
+    kda_use_fla_prefill_cp,
+    prepare_kda_cp_conv_states,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class _ForwardMode:
+    def is_context_parallel_extend(self):
+        return True
+
+    def is_mixed(self):
+        return False
+
+    def is_target_verify(self):
+        return False
+
+    def is_draft_extend_v2(self):
+        return False
+
+
+class _FakeFixedShapeGatherGroup:
+    def __init__(self, all_rank_tensors, rank):
+        self.all_rank_tensors = all_rank_tensors
+        self.rank = rank
+
+    def all_gather_into_tensor(self, output, input_tensor):
+        torch.testing.assert_close(input_tensor, self.all_rank_tensors[self.rank])
+        torch.cat(self.all_rank_tensors, dim=0, out=output)
+
+
+def _context(group, rank, local_lens=(1, 1), split_list=(1, 1, 1, 1)):
+    return KDAFLACPContext(
+        group=group,
+        cp_size=2,
+        cp_rank=rank,
+        batch_size=1,
+        split_list=split_list,
+        local_segment_lens=local_lens,
+        local_cu_seqlens=torch.tensor(
+            [0, local_lens[0], sum(local_lens)], dtype=torch.int32
+        ),
+        local_segment_slots=((0, 6), (2, 4))[rank],
+        rank_segment_slots=((0, 6), (2, 4)),
+        fixed_segment_sources=(0, -1, 0, -1, 1, -1, 1, -1),
+        max_rank_segments=2,
+        fixed_segment_lens=tuple(
+            value for length in split_list for value in (length, 0)
+        ),
+        track_after_slots=(-1,),
+        track_state_indices=torch.tensor([-1]),
+    )
+
+
+class TestKDAPrefillCP(unittest.TestCase):
+    def test_fla_affine_composes_natural_zigzag_order(self):
+        # Natural transforms are 2x+1, 3x+2, 4x+3, 5x+4.
+        all_rank_affine = [
+            torch.tensor([[[[1.0, 2.0]]], [[[4.0, 5.0]]]]),
+            torch.tensor([[[[2.0, 3.0]]], [[[3.0, 4.0]]]]),
+        ]
+        expected_initial = [
+            torch.tensor([[[[7.0]]], [[[191.0]]]]),
+            torch.tensor([[[[15.0]]], [[[47.0]]]]),
+        ]
+        for rank in range(2):
+            state_pool = torch.tensor([[[[7.0]]]])
+            context = _context(_FakeFixedShapeGatherGroup(all_rank_affine, rank), rank)
+            local_initial = compose_kda_cp_affine_states(
+                all_rank_affine[rank],
+                state_pool,
+                torch.tensor([0], dtype=torch.int32),
+                context,
+            )
+            torch.testing.assert_close(local_initial, expected_initial[rank])
+            torch.testing.assert_close(state_pool, torch.tensor([[[[959.0]]]]))
+
+    def test_fla_affine_supports_value_major_npu_state_pool(self):
+        all_rank_affine = [
+            torch.tensor([[[[1.0, 2.0]]], [[[4.0, 5.0]]]]),
+            torch.tensor([[[[2.0, 3.0]]], [[[3.0, 4.0]]]]),
+        ]
+        state_pool = torch.tensor([[[[7.0]]]])
+        context = _context(_FakeFixedShapeGatherGroup(all_rank_affine, 0), 0)
+        compose_kda_cp_affine_states(
+            all_rank_affine[0],
+            state_pool,
+            torch.tensor([0], dtype=torch.int32),
+            context,
+            state_value_major=True,
+        )
+        torch.testing.assert_close(state_pool, torch.tensor([[[[959.0]]]]))
+
+    def test_fla_conv_uses_only_segment_tails(self):
+        local_inputs = [
+            torch.tensor([[1.0], [2.0], [7.0], [8.0]]),
+            torch.tensor([[3.0], [4.0], [5.0], [6.0]]),
+        ]
+        all_rank_tails = [
+            torch.tensor([[[0.0], [1.0], [2.0]], [[0.0], [7.0], [8.0]]]),
+            torch.tensor([[[0.0], [0.0], [3.0]], [[4.0], [5.0], [6.0]]]),
+        ]
+        local_lens = [(2, 2), (1, 3)]
+        expected = [
+            torch.tensor([[[-2.0, -1.0, 0.0]], [[4.0, 5.0, 6.0]]]),
+            torch.tensor([[[0.0, 1.0, 2.0]], [[1.0, 2.0, 3.0]]]),
+        ]
+        for rank in range(2):
+            state_pool_seed = torch.tensor([[[-2.0, -1.0, 0.0]]])
+            context = _context(
+                _FakeFixedShapeGatherGroup(all_rank_tails, rank),
+                rank,
+                local_lens[rank],
+                (2, 1, 3, 2),
+            )
+            state_pool = state_pool_seed.clone()
+            local_initial = prepare_kda_cp_conv_states(
+                local_inputs[rank],
+                state_pool,
+                torch.tensor([0], dtype=torch.int32),
+                context,
+            ).clone()
+            torch.testing.assert_close(local_initial, expected[rank])
+            torch.testing.assert_close(state_pool, torch.tensor([[[6.0, 7.0, 8.0]]]))
+
+    def test_fla_cp_is_npu_prefill_only(self):
+        forward_batch = SimpleNamespace(
+            attn_cp_metadata=SimpleNamespace(split_list=[1, 1, 1, 1]),
+            forward_mode=_ForwardMode(),
+        )
+        with (
+            patch(
+                "sglang.srt.layers.attention.linear.kda_cp.get_parallel",
+                return_value=SimpleNamespace(
+                    enable_prefill_context_parallel=True,
+                    attn_cp_size=2,
+                ),
+            ),
+            patch(
+                "sglang.srt.layers.attention.linear.kda_cp.is_npu",
+                return_value=True,
+            ),
+        ):
+            self.assertTrue(kda_use_fla_prefill_cp(forward_batch))
+
+    @unittest.skipIf(
+        AscendKDAAttnBackend is None,
+        "requires the matching sgl-kernel-npu KDA affine-state PR",
+    )
+    def test_ascend_extend_uses_local_cp_conv_boundaries(self):
+        context = _context(None, rank=0)
+        conv_states = torch.zeros(1, 3, 2)
+        cache = SimpleNamespace(conv=[conv_states], temporal=torch.zeros(1, 1, 1, 1))
+
+        backend = object.__new__(AscendKDAAttnBackend)
+        backend.forward_metadata = SimpleNamespace(
+            query_start_loc=torch.tensor([0, 4], dtype=torch.int32),
+            mamba_cache_indices=torch.tensor([0], dtype=torch.int32),
+            has_mamba_track_mask=False,
+        )
+        backend.req_to_token_pool = SimpleNamespace(
+            mamba2_layer_cache=lambda _layer_id: cache
+        )
+        backend.kernel_dispatcher = SimpleNamespace(
+            extend=Mock(return_value=torch.zeros(1, 2, 1, 1))
+        )
+        backend._causal_conv1d_extend = Mock(
+            side_effect=lambda x, *_args, **_kwargs: x.transpose(0, 1)
+        )
+        backend._prepare_extend_gate_inputs = Mock(
+            side_effect=lambda _layer, a, b: (a, b, None, None)
+        )
+
+        layer = SimpleNamespace(
+            layer_id=0,
+            q_dim=1,
+            k_dim=1,
+            v_dim=1,
+            head_q_dim=1,
+            head_k_dim=1,
+            head_v_dim=1,
+            conv_weights=torch.zeros(3, 2),
+            bias=None,
+            A_log=None,
+            dt_bias=None,
+            lower_bound=None,
+        )
+        forward_batch = SimpleNamespace(
+            forward_mode=SimpleNamespace(
+                is_target_verify=lambda: False,
+                is_draft_extend_v2=lambda: False,
+            ),
+            extend_prefix_lens=torch.tensor([0]),
+            extend_seq_lens_cpu=[4],
+        )
+        local_conv_states = torch.zeros(2, 3, 2)
+
+        with (
+            patch(
+                "sglang.srt.hardware_backend.npu.attention.ascend_kda_backend."
+                "kda_use_fla_prefill_cp",
+                return_value=True,
+            ),
+            patch(
+                "sglang.srt.hardware_backend.npu.attention.ascend_kda_backend."
+                "build_kda_fla_cp_context",
+                return_value=context,
+            ),
+            patch(
+                "sglang.srt.hardware_backend.npu.attention.ascend_kda_backend."
+                "prepare_kda_cp_conv_states",
+                return_value=local_conv_states,
+            ),
+        ):
+            backend.forward_extend(
+                layer,
+                forward_batch,
+                mixed_qkv=torch.zeros(2, 3),
+                a=torch.zeros(1, 2, 1),
+                b=torch.zeros(1, 2, 1),
+            )
+
+        self.assertEqual(backend._causal_conv1d_extend.call_count, 3)
+        for call in backend._causal_conv1d_extend.call_args_list:
+            torch.testing.assert_close(
+                call.kwargs["query_start_loc"], context.local_cu_seqlens
+            )
+            self.assertEqual(call.kwargs["seq_lens_cpu"], [1, 1])
+
+        kernel_call = backend.kernel_dispatcher.extend.call_args
+        torch.testing.assert_close(
+            kernel_call.kwargs["query_start_loc"], context.local_cu_seqlens
+        )
+        self.assertIs(kernel_call.kwargs["cp_context"], context)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/disaggregation/test_kimi_k3_dspark_pd.py
+++ b/test/registered/unit/disaggregation/test_kimi_k3_dspark_pd.py
@@ -1,0 +1,113 @@
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.disaggregation.ascend.conn import AscendKVManager
+from sglang.srt.disaggregation.base.conn import KVArgs, StateType
+from sglang.srt.disaggregation.utils import is_mla_backend, setup_state_kv_args
+from sglang.srt.hardware_backend.npu.memory_pool_npu import NPUMLATokenToKVPool
+from sglang.srt.mem_cache.memory_pool import HybridLinearKVPool
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _make_hybrid_pool(*, page_size: int = 128) -> HybridLinearKVPool:
+    full_kv_pool = object.__new__(NPUMLATokenToKVPool)
+    full_kv_pool.layer_num = 6
+    full_kv_pool.page_size = page_size
+
+    pool = object.__new__(HybridLinearKVPool)
+    pool.use_mla = True
+    pool.page_size = page_size
+    pool.full_kv_pool = full_kv_pool
+    pool.full_attention_layer_id_mapping = {
+        layer_id: index for index, layer_id in enumerate(range(1, 7))
+    }
+    pool.mamba_pool = SimpleNamespace(
+        get_contiguous_buf_infos=lambda: ([100], [200], [20]),
+        get_state_dim_per_tensor=lambda: [64],
+        get_state_layer_ids=lambda: [1],
+        get_state_conv_shard_groups=lambda: [[]],
+        get_state_slice_outer_counts=lambda: [1],
+    )
+    return pool
+
+
+def _make_draft_pool(*, page_size: int = 128):
+    return SimpleNamespace(
+        page_size=page_size,
+        get_contiguous_buf_infos=lambda: (
+            list(range(1000, 1010)),
+            [4096] * 10,
+            [512] * 10,
+        ),
+    )
+
+
+class TestKimiK3DSparkPD(unittest.TestCase):
+    def test_hybrid_npu_mla_uses_flat_transfer(self):
+        pool = _make_hybrid_pool()
+        pool.full_kv_pool.get_contiguous_buf_infos = lambda: (
+            list(range(12)),
+            [4096] * 12,
+            [512] * 12,
+        )
+        self.assertTrue(is_mla_backend(pool))
+        self.assertEqual(pool.get_kv_layer_ids(), list(range(1, 7)) * 2)
+
+    def test_draft_kv_does_not_change_target_mla_grouping(self):
+        kv_args = KVArgs()
+        # Six latent-K buffers followed by six K-RoPE buffers.
+        kv_args.kv_data_ptrs = list(range(12))
+
+        setup_state_kv_args(
+            kv_args,
+            _make_hybrid_pool(),
+            draft_token_to_kv_pool=_make_draft_pool(),
+            total_kv_layers=24,
+            draft_kv_as_state=True,
+        )
+
+        self.assertEqual(kv_args.kv_buf_groups, 2)
+        self.assertEqual(len(kv_args.kv_data_ptrs), 12)
+        self.assertEqual(
+            kv_args.state_types,
+            [StateType.MAMBA, StateType.DRAFT_KV],
+        )
+        self.assertEqual(kv_args.state_data_ptrs[1], list(range(1000, 1010)))
+
+    def test_draft_kv_requires_matching_page_size(self):
+        kv_args = KVArgs()
+        kv_args.kv_data_ptrs = list(range(12))
+
+        with self.assertRaisesRegex(ValueError, "same page size"):
+            setup_state_kv_args(
+                kv_args,
+                _make_hybrid_pool(),
+                draft_token_to_kv_pool=_make_draft_pool(page_size=64),
+                total_kv_layers=24,
+                draft_kv_as_state=True,
+            )
+
+    def test_ascend_draft_state_bypasses_target_mla_grouping(self):
+        manager = object.__new__(AscendKVManager)
+        manager.kv_args = SimpleNamespace(
+            prefill_start_layer=0,
+            kv_buf_groups=2,
+            total_kv_layers=24,
+            mla_compression_ratios=None,
+        )
+        src = list(range(10))
+        dst = list(range(100, 110))
+
+        sliced_src, sliced_dst, count = manager.get_mla_kv_ptrs_with_pp(
+            src, dst, StateType.DRAFT_KV
+        )
+
+        self.assertEqual(sliced_src, src)
+        self.assertEqual(sliced_dst, dst)
+        self.assertEqual(count, 10)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_pp_cp_rank_offsets.py
+++ b/test/registered/unit/managers/test_pp_cp_rank_offsets.py
@@ -36,8 +36,15 @@ def _fake_group() -> SimpleNamespace:
     return SimpleNamespace(rank=0, ranks=[0], cpu_group=object())
 
 
-def _make_receiver(ps: ParallelState) -> SchedulerRequestReceiver:
+def _make_receiver(
+    ps: ParallelState,
+    *,
+    attn_tp_group=None,
+    attn_cp_group=None,
+) -> SchedulerRequestReceiver:
     group = _fake_group()
+    attn_tp_group = attn_tp_group or group
+    attn_cp_group = attn_cp_group or group
     return SchedulerRequestReceiver(
         recv_from_tokenizer=None,
         recv_from_rpc=None,
@@ -47,10 +54,10 @@ def _make_receiver(ps: ParallelState) -> SchedulerRequestReceiver:
         ps=ps,
         tp_group=group,
         tp_cpu_group=group,
-        attn_tp_group=group,
-        attn_tp_cpu_group=group,
-        attn_cp_group=group,
-        attn_cp_cpu_group=group,
+        attn_tp_group=attn_tp_group,
+        attn_tp_cpu_group=attn_tp_group.cpu_group,
+        attn_cp_group=attn_cp_group,
+        attn_cp_cpu_group=attn_cp_group.cpu_group,
         world_group=group,
         server_args=SimpleNamespace(
             enable_dp_attention=True,
@@ -64,6 +71,88 @@ def _make_receiver(ps: ParallelState) -> SchedulerRequestReceiver:
 
 
 class TestPPCPRankOffsets(unittest.TestCase):
+    def test_request_broadcast_seeds_cp0_tp_row_before_cp_columns(self):
+        ps = _make_ps(
+            pp_rank=0,
+            pp_size=1,
+            attn_tp_rank=1,
+            attn_tp_size=4,
+            attn_cp_rank=0,
+            attn_cp_size=4,
+        )
+        attn_tp_group = SimpleNamespace(
+            rank=1, ranks=[0, 1, 2, 3], cpu_group="attn_tp"
+        )
+        attn_cp_group = SimpleNamespace(
+            rank=1, ranks=[1, 5, 9, 13], cpu_group="attn_cp"
+        )
+        receiver = _make_receiver(
+            ps,
+            attn_tp_group=attn_tp_group,
+            attn_cp_group=attn_cp_group,
+        )
+        calls = []
+
+        def fake_broadcast(data, rank, group, src):
+            calls.append((data, rank, group, src))
+            return ["request"]
+
+        with patch(
+            "sglang.srt.managers.scheduler_components.request_receiver."
+            "broadcast_pyobj",
+            side_effect=fake_broadcast,
+        ):
+            self.assertEqual(
+                receiver._broadcast_within_attention_dp_group(None),
+                ["request"],
+            )
+
+        self.assertEqual(
+            calls,
+            [
+                (None, 1, "attn_tp", 0),
+                (["request"], 1, "attn_cp", 1),
+            ],
+        )
+
+    def test_request_broadcast_skips_unseeded_nonzero_cp_tp_row(self):
+        ps = _make_ps(
+            pp_rank=0,
+            pp_size=1,
+            attn_tp_rank=0,
+            attn_tp_size=4,
+            attn_cp_rank=1,
+            attn_cp_size=4,
+        )
+        attn_tp_group = SimpleNamespace(
+            rank=4, ranks=[4, 5, 6, 7], cpu_group="attn_tp"
+        )
+        attn_cp_group = SimpleNamespace(
+            rank=4, ranks=[0, 4, 8, 12], cpu_group="attn_cp"
+        )
+        receiver = _make_receiver(
+            ps,
+            attn_tp_group=attn_tp_group,
+            attn_cp_group=attn_cp_group,
+        )
+        calls = []
+
+        def fake_broadcast(data, rank, group, src):
+            calls.append((data, rank, group, src))
+            return ["request"]
+
+        with patch(
+            "sglang.srt.managers.scheduler_components.request_receiver."
+            "broadcast_pyobj",
+            side_effect=fake_broadcast,
+        ):
+            self.assertEqual(
+                receiver._broadcast_within_attention_dp_group(None),
+                ["request"],
+            )
+
+        self.assertEqual(calls, [(None, 4, "attn_cp", 0)])
+
     def test_request_receiver_uses_cp_size_for_pp_recv_rank(self):
         ps = _make_ps()
         calls = []

--- a/test/registered/unit/models/test_kimi_k3_cp.py
+++ b/test/registered/unit/models/test_kimi_k3_cp.py
@@ -1,0 +1,84 @@
+import inspect
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import torch
+
+from sglang.srt.models.kimi_k3 import (
+    KimiK3ForConditionalGeneration,
+    KimiK3LinearForCausalLM,
+    KimiK3LinearModel,
+    KimiK3MoE,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def test_kimi_k3_cp_model_accepts_generic_input_embed_keyword():
+    parameters = inspect.signature(KimiK3LinearModel.forward).parameters
+
+    assert "input_embeds" in parameters
+    assert "inputs_embeds" in parameters
+
+
+def test_kimi_k3_wrappers_expose_cp_v2_protocol():
+    assert hasattr(KimiK3LinearForCausalLM, "get_input_embeddings")
+
+    wrapper_protocol = (
+        "capture_aux_hidden_states",
+        "get_context_parallel_model",
+        "get_input_embeddings",
+        "logits_processor",
+        "pp_group",
+    )
+    for name in wrapper_protocol:
+        assert hasattr(KimiK3ForConditionalGeneration, name), name
+
+
+def _run_shared_expert_gather(buffer_rows: int):
+    hidden_states = torch.arange(12, dtype=torch.float32).reshape(3, 4)
+    group = SimpleNamespace(world_size=2)
+    shared_experts = Mock(side_effect=lambda value: value + 1)
+    moe = SimpleNamespace(
+        _shared_experts_attn_tp_comm=True,
+        shared_experts=shared_experts,
+    )
+
+    def all_gather(output, local_input):
+        assert output.shape == (6, 4)
+        output.copy_(torch.cat((local_input, local_input), dim=0))
+
+    def reduce_scatter(output, gathered_input):
+        output.copy_(gathered_input[:3] + gathered_input[3:])
+
+    with (
+        patch(
+            "sglang.srt.models.kimi_k3.get_parallel",
+            return_value=SimpleNamespace(attn_tp_group=group),
+        ),
+        patch(
+            "sglang.srt.models.kimi_k3.get_local_dp_buffer",
+            return_value=torch.empty(buffer_rows, 4),
+        ),
+        patch(
+            "sglang.srt.models.kimi_k3.attn_tp_all_gather_into_tensor",
+            side_effect=all_gather,
+        ),
+        patch(
+            "sglang.srt.models.kimi_k3.attn_tp_reduce_scatter_tensor",
+            side_effect=reduce_scatter,
+        ),
+    ):
+        output = KimiK3MoE._forward_shared_experts(moe, hidden_states)
+
+    assert shared_experts.call_args.args[0].shape == (6, 4)
+    torch.testing.assert_close(output, 2 * (hidden_states + 1))
+
+
+def test_kimi_k3_cp_shared_expert_slices_full_dp_buffer():
+    _run_shared_expert_gather(buffer_rows=12)
+
+
+def test_kimi_k3_cp_shared_expert_grows_undersized_buffer():
+    _run_shared_expert_gather(buffer_rows=2)

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -53,7 +53,10 @@ from sglang.srt.arg_groups.serving_hook import (
     handle_ssl_validation,
     handle_tokenizer_batching,
 )
-from sglang.srt.arg_groups.speculative_hook import handle_speculative_decoding
+from sglang.srt.arg_groups.speculative_hook import (
+    _supports_dspark_prefill_cp,
+    handle_speculative_decoding,
+)
 from sglang.srt.arg_groups.validation_hook import check_two_batch_overlap
 from sglang.srt.entrypoints.sidecar import (
     SGLANG_GRPC_ENDPOINT_ENV,
@@ -1034,6 +1037,20 @@ class TestContextParallelServerArgs(CustomTestCase):
             setattr(server_args, key, value)
         return server_args
 
+    def test_canonical_prefill_cp_cli_sets_unified_fields(self):
+        args = self.parser.parse_args(
+            [
+                "--model",
+                "dummy",
+                "--enable-prefill-cp",
+                "--cp-strategy",
+                "interleave",
+            ]
+        )
+
+        self.assertTrue(args.enable_prefill_cp)
+        self.assertEqual(args.cp_strategy, "interleave")
+
     def test_canonical_prefill_cp_requires_strategy(self):
         args = self.parser.parse_args(["--model", "dummy", "--enable-prefill-cp"])
 
@@ -1659,6 +1676,40 @@ class TestDecoupledSpecArgs(CustomTestCase):
             prepare_server_args(
                 ["--model-path", "dummy", "--decoupled-spec-role", "bogus"]
             )
+
+
+class TestDSparkPrefillCPArgs(unittest.TestCase):
+    @staticmethod
+    def _make_args(**overrides):
+        args = SimpleNamespace(
+            device="npu",
+            enable_prefill_cp=True,
+            get_model_config=lambda: SimpleNamespace(
+                hf_config=SimpleNamespace(
+                    model_type="kimi_k3",
+                    architectures=["KimiK3ForConditionalGeneration"],
+                )
+            ),
+        )
+        for name, value in overrides.items():
+            setattr(args, name, value)
+        return args
+
+    def test_kimi_k3_npu_supports_prefill_only_cp(self):
+        self.assertTrue(_supports_dspark_prefill_cp(self._make_args()))
+
+    def test_cuda_target_remains_rejected(self):
+        self.assertFalse(_supports_dspark_prefill_cp(self._make_args(device="cuda")))
+
+    def test_other_npu_target_remains_rejected(self):
+        args = self._make_args(
+            get_model_config=lambda: SimpleNamespace(
+                hf_config=SimpleNamespace(
+                    model_type="qwen3", architectures=["Qwen3ForCausalLM"]
+                )
+            )
+        )
+        self.assertFalse(_supports_dspark_prefill_cp(args))
 
 
 class TestAdaptiveSpecArgs(CustomTestCase):


### PR DESCRIPTION
## Summary

- add NPU prefill context parallelism for Kimi K3 MLA and KDA
- implement KDA PCP with the FLA affine-state formulation: Q/K/V stay rank-local, each zigzag segment produces an affine `[H | M]` transform, and only those state transforms are gathered and composed in natural sequence order
- handle CP-aware causal-convolution state, recurrent-state updates, physical padding, uneven/ragged zigzag segments, and radix checkpoints
- preserve Kimi K3 PD disaggregation support when dSparK is enabled only on decode

This replaces the earlier sequence-to-head/head-to-sequence activation A2A draft. The final path does **not** use activation A2A.

## Kernel dependency

Depends on sgl-project/sgl-kernel-npu#745 for the NPU affine preprocess and fused affine merge kernels.

## Validation

- `test/registered/cp/test_kda_prefill_cp_unit.py`
- `test/registered/unit/disaggregation/test_kimi_k3_dspark_pd.py`
- 8 tests passed
- paired import validation against the kernel PR
- kernel affine preprocess/merge smoke tests passed on NPU

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->