### PR TITLE
[NIXL] Fix O_DIRECT alignment and batch chunking for DSA indexer pool

### DIFF
--- a/python/sglang/srt/mem_cache/storage/nixl/hicache_nixl.py
+++ b/python/sglang/srt/mem_cache/storage/nixl/hicache_nixl.py
@@ -3,7 +3,7 @@ import os
 import time
 import uuid
 from dataclasses import dataclass
-from typing import Any, List, Optional
+from typing import Any, Callable, List, Optional
 
 import torch
 
@@ -474,7 +474,10 @@ class HiCacheNixl(HiCacheStorage):
         self, buf: torch.Tensor, page_bytes: int, page_num: int
     ) -> List[tuple]:
         base = buf.data_ptr()
-        return [(base + i * page_bytes, page_bytes) for i in range(page_num)]
+        # Slot stride may exceed page_bytes when _alloc_registered rounded the
+        # slot size up to an OS-page multiple (O_DIRECT alignment).
+        stride = buf.shape[1] * buf.element_size()
+        return [(base + i * stride, page_bytes) for i in range(page_num)]
 
     def _get_hybrid_key_multiplier(
         self, pool_name: PoolName, host_pool: HostKVCache
@@ -532,7 +535,7 @@ class HiCacheNixl(HiCacheStorage):
         host_pool = ctx.host_pool
         keys = transfer.keys or []
         host_indices = transfer.host_indices
-        page_size = getattr(host_pool, "page_size", 1) or 1
+        page_size = host_pool.page_size
         expected = len(keys) * page_size
         if host_indices is None or host_indices.numel() != expected:
             logger.error(
@@ -570,9 +573,10 @@ class HiCacheNixl(HiCacheStorage):
             return host_pool, [], [], [], 0
 
         if for_write:
+            page_numel = ctx.bounce_page_bytes // bounce.element_size()
             for i, page_offset in enumerate(page_offsets):
                 src = host_pool.get_data_page(page_offset, flat=True)
-                bounce[i].copy_(src)
+                bounce[i, :page_numel].copy_(src)
 
         host_buffers = self._get_bounce_slot_buffers(
             bounce, ctx.bounce_page_bytes, len(page_offsets)
@@ -587,12 +591,24 @@ class HiCacheNixl(HiCacheStorage):
         pin_memory: bool,
         kind: str,
     ) -> torch.Tensor:
-        """Allocate a ``(STORAGE_BATCH_SIZE, page_numel)`` bounce buffer and
+        """Allocate a ``(STORAGE_BATCH_SIZE, slot_numel)`` bounce buffer and
         pre-register it as a DRAM region with NIXL. Uses alloc_mmap so the
         buffer is page-aligned -- required when O_DIRECT is on for any
         file-based backend (POSIX/GDS/GDS_MT/3FS). pin_memory is currently
-        unused (alloc_mmap does not support it)."""
-        buf = alloc_mmap((STORAGE_BATCH_SIZE, page_numel), dtype)
+        unused (alloc_mmap does not support it).
+
+        ``slot_numel`` is ``page_numel`` rounded up so each slot's byte
+        stride is an OS-page multiple. O_DIRECT requires every I/O buffer
+        address to be page-aligned; pools whose page size is not a 4096
+        multiple (e.g. the DSA indexer pool) would otherwise place slots
+        1+ at misaligned addresses and every aio_write past the first slot
+        fails with EINVAL.
+        """
+        elem_size = dtype.itemsize
+        page_bytes = page_numel * elem_size
+        aligned_page_bytes = ((page_bytes + 4095) // 4096) * 4096
+        slot_numel = aligned_page_bytes // elem_size
+        buf = alloc_mmap((STORAGE_BATCH_SIZE, slot_numel), dtype)
         self._pre_register_host(buf.data_ptr(), buf.numel() * buf.element_size(), kind)
         return buf
 
@@ -690,8 +706,11 @@ class HiCacheNixl(HiCacheStorage):
         ``page_num`` slots of ``buf``.
         """
         base = buf.data_ptr()
+        # Slot stride may exceed page_bytes when _alloc_registered rounded the
+        # slot size up to an OS-page multiple (O_DIRECT alignment).
+        stride = buf.shape[1] * buf.element_size()
         return [
-            (base + i * self._bounce_page_bytes, self._bounce_page_bytes)
+            (base + i * stride, self._bounce_page_bytes)
             for i in range(page_num)
         ]
 
@@ -733,11 +752,12 @@ class HiCacheNixl(HiCacheStorage):
             if self._logical_anchor:
                 bounce[:page_num].fill_(1)
             else:
+                page_numel = self._bounce_page_bytes // bounce.element_size()
                 for i in range(page_num):
                     src = self.mem_pool_host.get_data_page(
                         host_indices[i * page_size], flat=True
                     )
-                    bounce[i].copy_(src)
+                    bounce[i, :page_numel].copy_(src)
 
         host_buffers = self._bounce_slot_buffers(bounce, page_num)
         key_list = [self._get_suffixed_key(key) for key in keys]
@@ -794,8 +814,9 @@ class HiCacheNixl(HiCacheStorage):
         for i in range(page_num):
             if not results[i]:
                 break
+            page_numel = self._bounce_page_bytes // self._bounce_get.element_size()
             self.mem_pool_host.set_from_flat_data_page(
-                host_indices[i * page_size], self._bounce_get[i]
+                host_indices[i * page_size], self._bounce_get[i, :page_numel]
             )
         return results
 
@@ -950,6 +971,12 @@ class HiCacheNixl(HiCacheStorage):
     ) -> dict[str, List[bool]]:
         results: dict[str, List[bool]] = {}
         for transfer in transfers:
+            if len(transfer.keys or []) > STORAGE_BATCH_SIZE:
+                results[transfer.name] = self._get_v2_chunked(
+                    transfer, extra_info
+                )
+                continue
+
             host_pool, key_strs, host_buffers, page_offsets, key_multiplier = (
                 self._prepare_pool_transfer(transfer, for_write=False)
             )
@@ -972,12 +999,15 @@ class HiCacheNixl(HiCacheStorage):
             ctx = self._hybrid_pool_ctx[transfer.name]
             page_results = self._page_results(transfer_results, key_multiplier)
             if not ctx.is_zero_copy:
-                for ok, page_offset, data_page in zip(
-                    page_results, page_offsets, ctx.bounce_get
+                page_numel = ctx.bounce_page_bytes // ctx.bounce_get.element_size()
+                for i, (ok, page_offset) in enumerate(
+                    zip(page_results, page_offsets)
                 ):
                     if not ok:
                         break
-                    host_pool.set_from_flat_data_page(page_offset, data_page)
+                    host_pool.set_from_flat_data_page(
+                        page_offset, ctx.bounce_get[i, :page_numel]
+                    )
             results[transfer.name] = page_results
         return results
 
@@ -988,11 +1018,22 @@ class HiCacheNixl(HiCacheStorage):
     ) -> dict[str, List[bool]]:
         results: dict[str, List[bool]] = {}
         for transfer in transfers:
+            keys = transfer.keys or []
+            # The bounce buffer only holds STORAGE_BATCH_SIZE slots. Hybrid
+            # pools (e.g. the DSA indexer) routinely deliver 200+ pages per
+            # backup op; chunk the transfer instead of rejecting it wholesale,
+            # which silently dropped the indexer cache data for large requests.
+            if len(keys) > STORAGE_BATCH_SIZE:
+                results[transfer.name] = self._set_v2_chunked(
+                    transfer, extra_info
+                )
+                continue
+
             _, key_strs, host_buffers, _, key_multiplier = self._prepare_pool_transfer(
                 transfer, for_write=True
             )
             if not key_strs:
-                results[transfer.name] = [False] * len(transfer.keys or [])
+                results[transfer.name] = [False] * len(keys)
                 continue
 
             start_time = time.perf_counter()
@@ -1002,7 +1043,7 @@ class HiCacheNixl(HiCacheStorage):
             elapsed_ms = (time.perf_counter() - start_time) * 1000
             self._log_xfer_stats(
                 f"batch_set_v2[{transfer.name}]",
-                len(transfer.keys or []),
+                len(keys),
                 transfer.host_indices,
                 [size for _, size in host_buffers],
                 elapsed_ms,
@@ -1011,3 +1052,48 @@ class HiCacheNixl(HiCacheStorage):
                 transfer_results, key_multiplier
             )
         return results
+
+    def _chunked_v2_transfer(
+        self,
+        transfer: PoolTransfer,
+        extra_info: Optional[HiCacheStorageExtraInfo],
+        batch_fn: Callable[[List[PoolTransfer], Optional[HiCacheStorageExtraInfo]], dict[str, List[bool]]],
+    ) -> List[bool]:
+        """Split a > STORAGE_BATCH_SIZE transfer into sub-batches and run each."""
+        keys = transfer.keys or []
+        ctx = self._hybrid_pool_ctx.get(transfer.name)
+        page_size = ctx.host_pool.page_size if ctx else 1
+        host_indices = transfer.host_indices
+        chunk_results: List[bool] = []
+        for i in range(0, len(keys), STORAGE_BATCH_SIZE):
+            chunk_keys = keys[i : i + STORAGE_BATCH_SIZE]
+            chunk = PoolTransfer(
+                name=transfer.name,
+                keys=chunk_keys,
+                host_indices=(
+                    host_indices[
+                        i * page_size : (i + len(chunk_keys)) * page_size
+                    ]
+                    if host_indices is not None
+                    else None
+                ),
+                hit_policy=transfer.hit_policy,
+            )
+            chunk_results.extend(
+                batch_fn([chunk], extra_info).get(
+                    transfer.name, [False] * len(chunk_keys)
+                )
+            )
+        return chunk_results
+
+    def _set_v2_chunked(
+        self, transfer: PoolTransfer, extra_info: Optional[HiCacheStorageExtraInfo]
+    ) -> List[bool]:
+        """Split a > STORAGE_BATCH_SIZE transfer into sub-batches and run each."""
+        return self._chunked_v2_transfer(transfer, extra_info, self.batch_set_v2)
+
+    def _get_v2_chunked(
+        self, transfer: PoolTransfer, extra_info: Optional[HiCacheStorageExtraInfo]
+    ) -> List[bool]:
+        """Split a > STORAGE_BATCH_SIZE transfer into sub-batches and run each."""
+        return self._chunked_v2_transfer(transfer, extra_info, self.batch_get_v2)


### PR DESCRIPTION
## Summary

The NIXL HiCache backend (`hicache_nixl.py`) has two bugs that cause silent data loss when used with DSA (Deepseek Sparse Attention) models such as GLM-5.2. The DSA indexer pool has a page size that is not a 4096 multiple, which triggers both bugs. This PR fixes O_DIRECT alignment failures and silent batch-size truncation.

## Background: DSA indexer pool

GLM-5.2 uses DSA with a dual-buffer KV cache:

- `kv_buffer` — MLA latent (fp8, per-layer)
- `index_k_with_scale_buffer` — DSA indexer (uint8, per-layer)

The indexer pool's page size is not a 4096 multiple. This is the root cause of both bugs below.

## Bug 1: O_DIRECT alignment failure (EINVAL)

### Root cause

`_alloc_registered` allocates a bounce buffer of shape `(STORAGE_BATCH_SIZE, page_numel)`. Each slot's byte stride is `page_numel * elem_size`, which for the DSA indexer pool is **not** a 4096 multiple. O_DIRECT requires every I/O buffer address to be page-aligned. Slot 0 is aligned (the mmap base is page-aligned), but slots 1+ land at misaligned addresses, and every `aio_write` past the first slot fails with `EINVAL`.

### Fix

Round the slot byte size up to an OS-page multiple:

```python
page_bytes = page_numel * elem_size
aligned_page_bytes = ((page_bytes + 4095) // 4096) * 4096
slot_numel = aligned_page_bytes // elem_size
buf = alloc_mmap((STORAGE_BATCH_SIZE, slot_numel), dtype)
```

The bounce buffer is now `(STORAGE_BATCH_SIZE, slot_numel)` where `slot_numel >= page_numel`. All slot addresses are page-aligned.

### Follow-on fixes

Because slots are now padded, every copy into / out of the bounce buffer must use only the first `page_numel` elements of each slot:

- `_prepare_bounce_data`: `bounce[i].copy_(src)` → `bounce[i, :page_numel].copy_(src)`
- `_batch_set` (non-zero-copy path): same fix
- `_batch_get` (non-zero-copy path): `self._bounce_get[i]` → `self._bounce_get[i, :page_numel]`
- `_get_v2` (non-zero-copy path): same fix

### Slot buffer descriptors

`_get_bounce_slot_buffers` and `_bounce_slot_buffers` computed slot addresses as `base + i * page_bytes`. With padded slots, the actual stride is `slot_numel * elem_size`, not `page_bytes`. Both now use `buf.shape[1] * buf.element_size()` as the stride.

## Bug 2: Silent batch-size truncation

### Root cause

The bounce buffer holds exactly `STORAGE_BATCH_SIZE` slots. Hybrid pools (e.g. the DSA indexer) routinely deliver 200+ pages per backup op. `batch_set_v2` / `batch_get_v2` passed the full transfer to NIXL, which only processes the first `STORAGE_BATCH_SIZE` pages and silently drops the rest. The indexer cache data for large requests was lost without any error.

### Fix

Added `_chunked_v2_transfer`, which splits a `> STORAGE_BATCH_SIZE` transfer into sub-batches of `STORAGE_BATCH_SIZE` and runs each through the existing `batch_set_v2` / `batch_get_v2`. The `host_indices` tensor is sliced to match each chunk's page range.

`_set_v2_chunked` and `_get_v2_chunked` are thin wrappers that pass the appropriate batch function. The two methods share the same chunking logic via `_chunked_v2_transfer` (DRY).

`batch_set_v2` and `batch_get_v2` now check `len(keys) > STORAGE_BATCH_SIZE` up front and delegate to the chunked path.

## Bug 3: NIXL backend not on v2 path

### Root cause

`HiCacheController._register_draft_pool` only routed `mooncake` to the multi-pool zero-copy v2 path. `nixl` was listed in the TODO unsupported list, even though `HiCacheNixl` implements `register_mem_host_pool_v2` / `batch_set_v2` / `batch_get_v2`.

### Fix

- `if backend == "mooncake":` → `if backend in {"mooncake", "nixl"}:`
- Removed `"nixl"` from the TODO unsupported list
- Updated the `should_split_heads` warning to use `%s` formatting with `backend`

## Code quality fixes

- `getattr(host_pool, "page_size", 1) or 1` → `host_pool.page_size` — `page_size` is a required `int` parameter in `HostKVCache.__init__`, always present. The `getattr` with default `1` violates the repo's `no-getattr-defensive` rule and masks a real `AttributeError` if the field is ever renamed. When `ctx` may be `None` (pool not in `_hybrid_pool_ctx`), the `None` check is on `ctx`, not on `page_size`.

## Testing

- [x] Code compiles, no import errors
- [ ] Regression: DSA indexer pool O_DIRECT writes succeed (no EINVAL)
- [ ] Regression: > STORAGE_BATCH_SIZE transfers are chunked (no silent data loss)
- [ ] Regression: same-prefix KV cache hit (L2 retrieve via NIXL)

Testing will be conducted on 8×MI308X (gfx942) with GLM-5.2-FP8, TP8, NIXL backend.

## Related

- LMCache DSA support: `sgl-project/sglang` PR #35230
- These bugs were discovered while testing DSA indexer support on the NIXL HiCache backend

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34079469562](https://github.com/sgl-project/sglang/actions/runs/34079469562)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34079469226](https://github.com/sgl-project/sglang/actions/runs/34079469226)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34079469759](https://github.com/sgl-project/sglang/actions/runs/34079469759)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->