### PR TITLE
[CPU] Support FP32 MoE Router Weights on AMX

### DIFF
--- a/python/sglang/kernels/aot/csrc/cpu/topk.cpp
+++ b/python/sglang/kernels/aot/csrc/cpu/topk.cpp
@@ -636,8 +636,8 @@ std::tuple<at::Tensor, at::Tensor> grouped_topk_cpu(
 
   CHECK_INPUT(gating_output);
 
-  const auto st = hidden_states.scalar_type();
-  CHECK_EQ(gating_output.scalar_type(), st);
+  const auto st = gating_output.scalar_type();
+  TORCH_CHECK(st == at::kFloat, "grouped_topk_cpu expects float32 gating_output, got: ", st);
 
   int64_t num_tokens = hidden_states.size(0);
   int64_t num_experts = gating_output.size(1);
@@ -645,42 +645,41 @@ std::tuple<at::Tensor, at::Tensor> grouped_topk_cpu(
   at::Tensor topk_weights = at::empty({num_tokens, topk}, hidden_states.options().dtype(at::kFloat));
   at::Tensor topk_ids = at::empty({num_tokens, topk}, hidden_states.options().dtype(at::kInt));
 
-  AT_DISPATCH_REDUCED_FLOATING_TYPES(st, "grouped_topk_kernel", [&] {
-    switch (num_experts) {
-      case 1:
-        LAUNCH_GROUPED_TOPK_KERNEL(1);
-        break;
-      case 2:
-        LAUNCH_GROUPED_TOPK_KERNEL(2);
-        break;
-      case 4:
-        LAUNCH_GROUPED_TOPK_KERNEL(4);
-        break;
-      case 8:
-        LAUNCH_GROUPED_TOPK_KERNEL(8);
-        break;
-      case 16:
-        LAUNCH_GROUPED_TOPK_KERNEL(16);
-        break;
-      case 32:
-        LAUNCH_GROUPED_TOPK_KERNEL(32);
-        break;
-      case 64:
-        LAUNCH_GROUPED_TOPK_KERNEL(64);
-        break;
-      case 128:
-        LAUNCH_GROUPED_TOPK_KERNEL(128);
-        break;
-      case 160:
-        LAUNCH_GROUPED_TOPK_KERNEL(160);
-        break;
-      case 256:
-        LAUNCH_GROUPED_TOPK_KERNEL(256);
-        break;
-      default:
-        TORCH_CHECK(false, "Unexpected num_experts: ", num_experts);
-    }
-  });
+  using scalar_t = float;
+  switch (num_experts) {
+    case 1:
+      LAUNCH_GROUPED_TOPK_KERNEL(1);
+      break;
+    case 2:
+      LAUNCH_GROUPED_TOPK_KERNEL(2);
+      break;
+    case 4:
+      LAUNCH_GROUPED_TOPK_KERNEL(4);
+      break;
+    case 8:
+      LAUNCH_GROUPED_TOPK_KERNEL(8);
+      break;
+    case 16:
+      LAUNCH_GROUPED_TOPK_KERNEL(16);
+      break;
+    case 32:
+      LAUNCH_GROUPED_TOPK_KERNEL(32);
+      break;
+    case 64:
+      LAUNCH_GROUPED_TOPK_KERNEL(64);
+      break;
+    case 128:
+      LAUNCH_GROUPED_TOPK_KERNEL(128);
+      break;
+    case 160:
+      LAUNCH_GROUPED_TOPK_KERNEL(160);
+      break;
+    case 256:
+      LAUNCH_GROUPED_TOPK_KERNEL(256);
+      break;
+    default:
+      TORCH_CHECK(false, "Unexpected num_experts: ", num_experts);
+  }
   return std::make_tuple(topk_weights, topk_ids);
 }
 
@@ -711,6 +710,7 @@ std::tuple<at::Tensor, at::Tensor> biased_grouped_topk_cpu(
   CHECK_INPUT(correction_bias);
 
   const auto st = gating_output.scalar_type();
+  TORCH_CHECK(st == at::kFloat, "biased_grouped_topk_cpu expects float32 gating_output, got: ", st);
   int64_t num_tokens = hidden_states.size(0);
   int64_t num_experts = gating_output.size(1);
   TORCH_CHECK(gating_output.size(0) == num_tokens, "Number of tokens mismatch");

--- a/python/sglang/kernels/aot/tests/test_moe_gate_router_fp32.py
+++ b/python/sglang/kernels/aot/tests/test_moe_gate_router_fp32.py
@@ -1,0 +1,49 @@
+import types
+import unittest
+from unittest.mock import patch
+
+import torch
+import torch.nn.functional as F
+
+from sglang.srt.models.deepseek_v2 import MoEGate
+
+
+class TestMoEGateCPUFP32Router(unittest.TestCase):
+    def _make_gate(self, weight_dtype: torch.dtype) -> MoEGate:
+        config = types.SimpleNamespace(
+            n_routed_experts=8,
+            hidden_size=32,
+            topk_method="greedy",
+        )
+        gate = MoEGate(config, quant_config=None)
+        gate.weight = torch.nn.Parameter(
+            torch.randn(
+                (config.n_routed_experts, config.hidden_size), dtype=weight_dtype
+            )
+        )
+        return gate
+
+    def test_cpu_amx_router_path_returns_fp32_logits_for_router_weights(self):
+        hidden_states = torch.randn((5, 32), dtype=torch.bfloat16)
+
+        for weight_dtype in (torch.bfloat16, torch.float32):
+            with self.subTest(weight_dtype=weight_dtype):
+                gate = self._make_gate(weight_dtype)
+                expected = F.linear(hidden_states.float(), gate.weight.float(), None)
+
+                with patch("sglang.srt.models.deepseek_v2._is_cpu", True), patch(
+                    "sglang.srt.models.deepseek_v2._is_cpu_amx_available", True
+                ), patch(
+                    "sglang.srt.models.deepseek_v2.use_intel_amx_backend",
+                    side_effect=AssertionError(
+                        "router correctness path should bypass packed AMX linear"
+                    ),
+                ):
+                    logits = gate(hidden_states)
+
+                self.assertEqual(logits.dtype, torch.float32)
+                torch.testing.assert_close(logits, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -1043,6 +1043,12 @@ def grouped_topk_gpu(
     return topk_weights, topk_ids
 
 
+def _ensure_cpu_router_logits_fp32(gating_output: torch.Tensor) -> torch.Tensor:
+    if gating_output.dtype != torch.float32:
+        return gating_output.to(torch.float32)
+    return gating_output
+
+
 def grouped_topk_cpu(
     hidden_states: torch.Tensor,
     gating_output: torch.Tensor,
@@ -1061,7 +1067,7 @@ def grouped_topk_cpu(
 
     return torch.ops.sgl_kernel.grouped_topk_cpu(
         hidden_states,
-        gating_output,
+        _ensure_cpu_router_logits_fp32(gating_output),
         topk,
         renormalize,
         num_expert_group,
@@ -1801,7 +1807,7 @@ def biased_grouped_topk_cpu(
 ):
     return torch.ops.sgl_kernel.biased_grouped_topk_cpu(
         hidden_states,
-        gating_output,
+        _ensure_cpu_router_logits_fp32(gating_output),
         correction_bias,
         topk,
         renormalize,

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -499,6 +499,9 @@ class MoEGate(nn.Module):
         gemm_output_zero_allocator: BumpAllocator = None,
         forward_batch: ForwardBatch = None,
     ):
+        if _is_cpu and _is_cpu_amx_available:
+            return F.linear(hidden_states.float(), self.weight.float(), None)
+
         if use_intel_amx_backend(self):
             return torch.ops.sgl_kernel.weight_packed_linear(
                 hidden_states,

--- a/test/registered/cpu/test_topk.py
+++ b/test/registered/cpu/test_topk.py
@@ -5,10 +5,14 @@ import torch
 
 from sglang.srt.eplb.expert_location_dispatch import ExpertLocationDispatchInfo
 from sglang.srt.layers.moe.topk import (
+    biased_grouped_topk_cpu as cpu_biased_grouped_topk,
+)
+from sglang.srt.layers.moe.topk import (
     biased_grouped_topk_impl as native_biased_grouped_topk,
 )
 from sglang.srt.layers.moe.topk import biased_topk_impl as native_biased_topk
 from sglang.srt.layers.moe.topk import fused_topk_torch_native as native_fused_topk
+from sglang.srt.layers.moe.topk import grouped_topk_cpu as cpu_grouped_topk
 from sglang.srt.layers.moe.topk import grouped_topk_gpu as native_grouped_topk
 from sglang.srt.models.llama4 import Llama4MoE
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -37,16 +41,13 @@ class TestGroupedTopK(CustomTestCase):
         )
 
         # fused version
-        topk_weights, topk_ids = torch.ops.sgl_kernel.grouped_topk_cpu(
+        topk_weights, topk_ids = cpu_grouped_topk(
             hidden_states,
             gating_output,
             topk,
             renormalize,
             G,
             topk_group,
-            0,
-            None,
-            None,
         )
 
         res = torch.zeros(M, E, dtype=torch.float)
@@ -64,6 +65,58 @@ class TestGroupedTopK(CustomTestCase):
             self._run_single_test(123, 64, 1, 6, 1, renormalize, torch.bfloat16)
             self._run_single_test(123, 256, 8, 4, 8, renormalize, torch.bfloat16)
             self._run_single_test(123, 160, 8, 6, 2, renormalize, torch.bfloat16)
+
+    def test_grouped_topk_cpu_direct_op_requires_fp32_logits(self):
+        hidden_states = torch.randn((17, 16), dtype=torch.bfloat16)
+        gating_output = torch.randn((17, 128), dtype=torch.bfloat16)
+
+        with self.assertRaisesRegex(
+            RuntimeError, "grouped_topk_cpu expects float32 gating_output"
+        ):
+            torch.ops.sgl_kernel.grouped_topk_cpu(
+                hidden_states,
+                gating_output,
+                8,
+                True,
+                8,
+                2,
+                0,
+                None,
+                None,
+            )
+
+    def test_grouped_topk_cpu_direct_op_accepts_mixed_hidden_and_logits_dtypes(self):
+        torch.manual_seed(0)
+        hidden_states = torch.randn((17, 16), dtype=torch.bfloat16)
+        gating_output = torch.randn((17, 128), dtype=torch.float32)
+
+        topk_weights, topk_ids = torch.ops.sgl_kernel.grouped_topk_cpu(
+            hidden_states,
+            gating_output,
+            8,
+            True,
+            8,
+            2,
+            0,
+            None,
+            None,
+        )
+
+        expected_weights, expected_ids = native_grouped_topk(
+            hidden_states.float(),
+            gating_output,
+            8,
+            True,
+            8,
+            2,
+        )
+        self.assertEqual(topk_weights.dtype, torch.float32)
+        self.assertEqual(topk_ids.dtype, torch.int32)
+        actual = torch.zeros_like(gating_output)
+        expected = torch.zeros_like(gating_output)
+        actual.scatter_(1, topk_ids.to(torch.int64), topk_weights)
+        expected.scatter_(1, expected_ids.to(torch.int64), expected_weights)
+        torch.testing.assert_close(actual, expected)
 
 
 # DeepSeek V2/V3/R1 uses biased_grouped_top
@@ -102,7 +155,7 @@ class TestBiasedGroupedTopK(CustomTestCase):
             else ref_topk_weights
         )
         # fused version
-        topk_weights, topk_ids = torch.ops.sgl_kernel.biased_grouped_topk_cpu(
+        topk_weights, topk_ids = cpu_biased_grouped_topk(
             hidden_states,
             gating_output,
             correction_bias,
@@ -110,9 +163,9 @@ class TestBiasedGroupedTopK(CustomTestCase):
             renormalize,
             G,
             topk_group,
-            0,
-            routed_scaling_factor,
-            None,
+            num_fused_shared_experts=0,
+            routed_scaling_factor=routed_scaling_factor,
+            apply_routed_scaling_factor_on_output=routed_scaling_factor is not None,
         )
 
         res = torch.zeros(M, E, dtype=torch.float)
@@ -138,6 +191,65 @@ class TestBiasedGroupedTopK(CustomTestCase):
                                 bias_dtype,
                                 routed_scaling_factor,
                             )
+
+    def test_biased_grouped_topk_cpu_direct_op_requires_fp32_logits(self):
+        hidden_states = torch.randn((17, 16), dtype=torch.bfloat16)
+        gating_output = torch.randn((17, 128), dtype=torch.bfloat16)
+        correction_bias = torch.randn(128, dtype=torch.float32)
+
+        with self.assertRaisesRegex(
+            RuntimeError, "biased_grouped_topk_cpu expects float32 gating_output"
+        ):
+            torch.ops.sgl_kernel.biased_grouped_topk_cpu(
+                hidden_states,
+                gating_output,
+                correction_bias,
+                8,
+                False,
+                8,
+                2,
+                0,
+                None,
+                None,
+            )
+
+    def test_biased_grouped_topk_cpu_direct_op_accepts_mixed_hidden_and_logits_dtypes(
+        self,
+    ):
+        torch.manual_seed(0)
+        hidden_states = torch.randn((17, 16), dtype=torch.bfloat16)
+        gating_output = torch.randn((17, 128), dtype=torch.float32)
+        correction_bias = torch.randn(128, dtype=torch.float32)
+
+        topk_weights, topk_ids = torch.ops.sgl_kernel.biased_grouped_topk_cpu(
+            hidden_states,
+            gating_output,
+            correction_bias,
+            8,
+            False,
+            8,
+            2,
+            0,
+            None,
+            None,
+        )
+
+        expected_weights, expected_ids = native_biased_grouped_topk(
+            hidden_states.float(),
+            gating_output,
+            correction_bias,
+            8,
+            False,
+            8,
+            2,
+        )
+        self.assertEqual(topk_weights.dtype, torch.float32)
+        self.assertEqual(topk_ids.dtype, torch.int32)
+        actual = torch.zeros_like(gating_output)
+        expected = torch.zeros_like(gating_output)
+        actual.scatter_(1, topk_ids.to(torch.int64), topk_weights)
+        expected.scatter_(1, expected_ids.to(torch.int64), expected_weights)
+        torch.testing.assert_close(actual, expected)
 
 
 class TestBiasedTopK(CustomTestCase):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Some MoE models use FP32 router weights while receiving BF16 hidden states. On CPU AMX, this combination exposed two issues:

The router logits could remain BF16, causing a dtype mismatch with the expected CUDA behavior of BF16 activations x FP32 router weights -> FP32 logits.
FP32 router weights are not supported by the packed AMX weight path, so PackWeightMethod disables the AMX backend and the router falls back to an incompatible or inefficient path.
This affects models and configurations using FP32 router weights, including LongCat, MiniMax-M2/M3, Hunyuan-V3, Grok, Ernie4.5-MoE-VL, Bailing/LLaDA2/Sarvam, and GLM4-MoE.

## Modifications

<!-- Detail the changes made in this pull request. -->
* Ensure the CPU AMX MoE router path computes logits using FP32 inputs and FP32 router weights, preserving the expected FP32 logits behavior.
* Keep FP32 router weights out of the unsupported packed AMX weight path and use the native FP32 linear implementation instead.
* Add CPU-side conversion of router logits to FP32 before invoking the grouped top-k and biased grouped top-k AOT kernels.
* Add explicit dtype validation in the CPU AOT top-k kernels so they require FP32 router logits and fail clearly for unsupported input dtypes.
  * Update the existing CPU top-k tests to cover:
  * Mixed BF16 hidden states and FP32 router logits.
* Correctness and output dtypes for grouped top-k and biased grouped top-k.
* Rejection of BF16 logits passed directly to the low-level CPU AOT operators.
* Add a regression test verifying that the CPU AMX router path returns FP32 logits for both BF16 and FP32 router weights and does not invoke the unsupported packed AMX linear backend.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32090915330](https://github.com/sgl-project/sglang/actions/runs/32090915330)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32090915133](https://github.com/sgl-project/sglang/actions/runs/32090915133)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->