### PR TITLE
Add SM100 NVFP4 KV cache support for GLM-5.2 DSA

### DIFF
--- a/docs/docs/advanced_features/quantized_kv_cache.mdx
+++ b/docs/docs/advanced_features/quantized_kv_cache.mdx
@@ -62,6 +62,48 @@ python3 -m sglang.launch_server \
     --kv-cache-dtype fp4_mx_block16 \
 ```
 
+### GLM-5.2 DSA NVFP4 on SM100
+
+SGLang has a fused NVFP4 KV-cache decode path for the GLM-5.2 DSA layout on
+NVIDIA SM100 GPUs. The implementation stores each main-cache token in 416
+bytes: 256 bytes of packed E2M1 latent values, 32 bytes of block-16 E4M3
+scales, and 128 bytes of BF16 RoPE values. Together with the 132-byte DSA
+indexer row, this uses 548 bytes per token per layer.
+
+The specialization requires the GLM-5.2 DSA shape (512 NoPE dimensions, 64
+RoPE dimensions, and 512 value dimensions), 64 local query heads through
+attention DP, and a page size of 64. A representative TP8 launch is:
+
+```bash Command
+export MODEL_PATH="${MODEL_PATH:?set MODEL_PATH to the GLM-5.2 checkpoint}"
+
+python3 -m sglang.launch_server \
+    --model-path "$MODEL_PATH" \
+    --tp-size 8 \
+    --dp-size 8 \
+    --enable-dp-attention \
+    --attention-backend dsa \
+    --dsa-prefill-backend flashmla_sparse \
+    --dsa-decode-backend flashmla_kv \
+    --kv-cache-dtype nvfp4 \
+    --page-size 64
+```
+
+The weight dtype and weight-quantization method are independent of the KV
+cache format and should be selected for the checkpoint being served. Decode
+reads the packed cache directly and performs E2M1 dequantization inside the
+FlashMLA producer before the existing BF16 attention consumer. It does not
+materialize a full BF16 cache. Prefill gathers and dequantizes the paged prefix
+into a BF16 compatibility workspace for FlashMLA sparse-prefill; only decode is
+fused, and ordinary decode supports CUDA Graph replay.
+
+This path currently rejects non-SM100 devices, other DSA model layouts, local
+query-head counts other than 64, page sizes other than 64, and prefill CP or
+DCP configurations. HiSparse is not supported on this path. The native
+FlashMLA operator must be rebuilt from a source revision that includes the
+SM100 NVFP4 specialization; a missing operator is reported at backend
+initialization instead of silently falling back to an unfused decode path.
+
 ### Scaling Factors
 
 FP8 quantization requires scaling factors to properly quantize and dequantize the KV cache.
@@ -98,7 +140,11 @@ If scaling factors are not provided and not found in the checkpoint, it will def
 </Warning>
 
 <Tip>
-**FP4 (MXFP4)**: Unlike FP8, FP4 quantization handles scaling factors automatically on-the-fly during quantization and dequantization. No pre-quantized models or external scaling factor files are required—the block-based scaling factors are computed dynamically as needed.
+**FP4 block scales** are computed dynamically during cache writes. The
+GLM-5.2 DSA NVFP4 path additionally applies a persistent per-layer global K
+scale. SGLang loads that scale from the model's attention layer when present
+and otherwise uses `1.0`; calibrated checkpoint scales are recommended for
+accuracy.
 </Tip>
 
 ## Performance Considerations

--- a/docs/docs/advanced_features/quantized_kv_cache.mdx
+++ b/docs/docs/advanced_features/quantized_kv_cache.mdx
@@ -97,12 +97,37 @@ materialize a full BF16 cache. Prefill gathers and dequantizes the paged prefix
 into a BF16 compatibility workspace for FlashMLA sparse-prefill; only decode is
 fused, and ordinary decode supports CUDA Graph replay.
 
+Prefill context parallelism is supported with the CP-v2 interleave strategy.
+Each CP rank first all-gathers the BF16 latent K/RoPE rows into logical token
+order, then writes a replicated NVFP4 cache. This favors a simple correctness
+path; it does not shard KV-cache capacity or reduce the BF16 CP communication
+volume. For TP8, use:
+
+```bash Command
+python3 -m sglang.launch_server \
+    --model-path "$MODEL_PATH" \
+    --tp-size 8 \
+    --dp-size 1 \
+    --enable-prefill-cp \
+    --cp-strategy interleave \
+    --attn-cp-size 8 \
+    --attention-backend dsa \
+    --dsa-prefill-backend flashmla_sparse \
+    --dsa-decode-backend flashmla_kv \
+    --kv-cache-dtype nvfp4 \
+    --page-size 64
+```
+
+Prefill CUDA Graph is disabled while Prefill CP is active; ordinary decode
+CUDA Graph remains available.
+
 This path currently rejects non-SM100 devices, other DSA model layouts, local
-query-head counts other than 64, page sizes other than 64, and prefill CP or
-DCP configurations. HiSparse is not supported on this path. The native
-FlashMLA operator must be rebuilt from a source revision that includes the
-SM100 NVFP4 specialization; a missing operator is reported at backend
-initialization instead of silently falling back to an unfused decode path.
+query-head counts other than 64, page sizes other than 64, DCP, non-interleave
+Prefill CP, Prefill CP decode attention-TP, and DSA cache layer splitting.
+HiSparse is not supported on this path. The native FlashMLA operator must be
+rebuilt from a source revision that includes the SM100 NVFP4 specialization; a
+missing operator is reported at backend initialization instead of silently
+falling back to an unfused decode path.
 
 ### Scaling Factors
 

--- a/python/sglang/kernels/aot/cmake/flashmla.cmake
+++ b/python/sglang/kernels/aot/cmake/flashmla.cmake
@@ -126,7 +126,55 @@ set(FlashMLA_SOURCES
 )
 
 if(FLASHMLA_ENABLE_SM100)
+    # Extend the pinned open-source FlashMLA V32 producer with the GLM-5.2
+    # 416-byte NVFP4/BF16 cache. The packed E2M1 producer materializes the
+    # same BF16 tiles consumed by the stock FlashMLA QK/PV pipeline.
+    set(FLASHMLA_NVFP4_PATCH
+        "${CMAKE_CURRENT_LIST_DIR}/../patches/flashmla_sm100_nvfp4.patch")
+    set(FLASHMLA_SM100_HEAD64_KERNEL_FILE
+        "${repo-flashmla_SOURCE_DIR}/csrc/sm100/decode/head64/kernel.cuh")
+    set(FLASHMLA_NVFP4_MARKER
+        "SGLANG_SM100_GLM52_NVFP4_BF16_V1")
+
+    file(READ "${FLASHMLA_SM100_HEAD64_KERNEL_FILE}"
+        FLASHMLA_SM100_HEAD64_KERNEL_CONTENT)
+    string(FIND "${FLASHMLA_SM100_HEAD64_KERNEL_CONTENT}"
+        "${FLASHMLA_NVFP4_MARKER}" FLASHMLA_NVFP4_PATCHED)
+    if(FLASHMLA_NVFP4_PATCHED EQUAL -1)
+        find_program(FLASHMLA_PATCH_EXECUTABLE patch REQUIRED)
+        execute_process(
+            COMMAND "${FLASHMLA_PATCH_EXECUTABLE}" --batch --forward
+                    --ignore-whitespace -p1
+                    -i "${FLASHMLA_NVFP4_PATCH}"
+            WORKING_DIRECTORY "${repo-flashmla_SOURCE_DIR}"
+            RESULT_VARIABLE FLASHMLA_NVFP4_PATCH_RESULT
+            OUTPUT_VARIABLE FLASHMLA_NVFP4_PATCH_STDOUT
+            ERROR_VARIABLE FLASHMLA_NVFP4_PATCH_STDERR)
+        if(NOT FLASHMLA_NVFP4_PATCH_RESULT EQUAL 0)
+            message(FATAL_ERROR
+                "Failed to apply ${FLASHMLA_NVFP4_PATCH}:\n"
+                "${FLASHMLA_NVFP4_PATCH_STDOUT}\n"
+                "${FLASHMLA_NVFP4_PATCH_STDERR}")
+        endif()
+
+        file(READ "${FLASHMLA_SM100_HEAD64_KERNEL_FILE}"
+            FLASHMLA_SM100_HEAD64_KERNEL_CONTENT)
+        string(FIND "${FLASHMLA_SM100_HEAD64_KERNEL_CONTENT}"
+            "${FLASHMLA_NVFP4_MARKER}" FLASHMLA_NVFP4_PATCHED)
+        if(FLASHMLA_NVFP4_PATCHED EQUAL -1)
+            message(FATAL_ERROR
+                "FlashMLA NVFP4 patch completed without expected marker "
+                "${FLASHMLA_NVFP4_MARKER}")
+        endif()
+        message(STATUS "Applied SM100 GLM-5.2 NVFP4/BF16 FlashMLA patch")
+    else()
+        message(STATUS "SM100 GLM-5.2 NVFP4/BF16 FlashMLA patch already applied")
+    endif()
+
     list(APPEND FlashMLA_SOURCES
+        # GLM-5.2 416-byte NVFP4/BF16 DSA producer.
+        csrc/flashmla_nvfp4_sm100.cu
+
         # sm100 dense prefill/bwd.
         ${repo-flashmla_SOURCE_DIR}/csrc/sm100/prefill/dense/fmha_cutlass_fwd_sm100.cu
         ${repo-flashmla_SOURCE_DIR}/csrc/sm100/prefill/dense/fmha_cutlass_bwd_sm100.cu

--- a/python/sglang/kernels/aot/csrc/flashmla_extension.cc
+++ b/python/sglang/kernels/aot/csrc/flashmla_extension.cc
@@ -21,6 +21,18 @@ limitations under the License.
 #include "api/sparse_fwd.h"
 #include "sgl_kernel_ops.h"
 
+std::tuple<at::Tensor, at::Tensor, std::optional<at::Tensor>, std::optional<at::Tensor>> sparse_decode_fwd_nvfp4(
+    const at::Tensor& q,
+    const at::Tensor& packed_kv,
+    const at::Tensor& kv_global_scale,
+    const at::Tensor& indices,
+    const std::optional<at::Tensor>& topk_length,
+    const std::optional<at::Tensor>& attn_sink,
+    std::optional<at::Tensor> tile_scheduler_metadata,
+    std::optional<at::Tensor> num_splits,
+    int64_t d_v,
+    double sm_scale);
+
 static std::tuple<at::Tensor, at::Tensor, std::optional<at::Tensor>, std::optional<at::Tensor>> sgl_sparse_decode_fwd(
     const at::Tensor& q,
     const at::Tensor& kv,
@@ -97,6 +109,13 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "cumulative_seqlen_kv, Tensor o, Tensor lse, int mask_mode_code, float softmax_scale, int max_seqlen_q, int "
       "max_seqlen_kv, bool is_varlen) -> ()");
   m.impl("dense_prefill_fwd", torch::kCUDA, &FMHACutlassSM100FwdRun);
+
+  m.def(
+      "sparse_decode_fwd_nvfp4(Tensor q, Tensor packed_kv, Tensor kv_global_scale, Tensor indices, Tensor? "
+      "topk_length, Tensor? attn_sink, Tensor? tile_scheduler_metadata, Tensor? num_splits, int d_v, float "
+      "sm_scale) -> (Tensor, Tensor, Tensor?, Tensor?)");
+  m.impl("sparse_decode_fwd_nvfp4", torch::kCUDA, &sparse_decode_fwd_nvfp4);
+
 #endif
 
   m.def(

--- a/python/sglang/kernels/aot/csrc/flashmla_nvfp4_sm100.cu
+++ b/python/sglang/kernels/aot/csrc/flashmla_nvfp4_sm100.cu
@@ -1,0 +1,91 @@
+/* Copyright 2026 SGLang Team. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <c10/cuda/CUDAGuard.h>
+#include <torch/all.h>
+
+#include "api/sparse_decode.h"
+
+namespace {
+
+constexpr int kNvfp4RowBytes = 416;
+constexpr int kTopK = 2048;
+constexpr int kPageSize = 64;
+
+}  // namespace
+
+std::tuple<at::Tensor, at::Tensor, std::optional<at::Tensor>, std::optional<at::Tensor>>
+sparse_decode_fwd_nvfp4(
+    const at::Tensor& q,
+    const at::Tensor& packed_kv,
+    const at::Tensor& kv_global_scale,
+    const at::Tensor& indices,
+    const std::optional<at::Tensor>& topk_length,
+    const std::optional<at::Tensor>& attn_sink,
+    std::optional<at::Tensor> tile_scheduler_metadata,
+    std::optional<at::Tensor> num_splits,
+    int64_t d_v,
+    double sm_scale) {
+  TORCH_CHECK(q.is_cuda() && packed_kv.is_cuda() && indices.is_cuda());
+  TORCH_CHECK(
+      q.device() == packed_kv.device() && q.device() == indices.device() &&
+          q.device() == kv_global_scale.device(),
+      "q, packed_kv, indices, and kv_global_scale must be on one CUDA device");
+  TORCH_CHECK(q.scalar_type() == at::kBFloat16, "q must be BF16");
+  TORCH_CHECK(packed_kv.scalar_type() == at::kByte, "packed_kv must be uint8");
+  TORCH_CHECK(
+      kv_global_scale.is_cuda() && kv_global_scale.scalar_type() == at::kFloat &&
+      kv_global_scale.numel() == 1 && kv_global_scale.is_contiguous());
+  TORCH_CHECK(indices.scalar_type() == at::kInt);
+  TORCH_CHECK(q.dim() == 4 && q.size(2) == 64 && q.size(3) == 576);
+  TORCH_CHECK(
+      packed_kv.dim() == 4 && packed_kv.size(1) == kPageSize && packed_kv.size(2) == 1 &&
+      packed_kv.size(3) == kNvfp4RowBytes);
+  TORCH_CHECK(
+      indices.sizes() == at::IntArrayRef({q.size(0), q.size(1), kTopK}),
+      "indices must be [B, Sq, 2048]");
+  TORCH_CHECK(d_v == 512);
+  TORCH_CHECK(q.is_contiguous() && packed_kv.is_contiguous() && indices.is_contiguous());
+  if (topk_length.has_value()) {
+    TORCH_CHECK(topk_length->is_cuda() && topk_length->scalar_type() == at::kInt);
+    TORCH_CHECK(topk_length->device() == q.device());
+    TORCH_CHECK(topk_length->numel() == q.size(0));
+    TORCH_CHECK(topk_length->is_contiguous());
+  }
+  c10::cuda::CUDAGuard device_guard(q.device());
+  if (attn_sink.has_value()) {
+    TORCH_CHECK(
+        attn_sink->is_cuda() && attn_sink->device() == q.device() &&
+        attn_sink->scalar_type() == at::kFloat && attn_sink->numel() == 64 &&
+        attn_sink->is_contiguous());
+  }
+
+  auto [out, lse, new_metadata, new_splits] = sparse_attn_decode_interface(
+      q,
+      packed_kv,
+      indices,
+      topk_length,
+      attn_sink,
+      tile_scheduler_metadata,
+      num_splits,
+      std::nullopt,
+      std::nullopt,
+      std::nullopt,
+      static_cast<int>(d_v),
+      static_cast<float>(sm_scale),
+      kv_global_scale);
+
+  return {out, lse, new_metadata, new_splits};
+}

--- a/python/sglang/kernels/aot/patches/flashmla_sm100_nvfp4.patch
+++ b/python/sglang/kernels/aot/patches/flashmla_sm100_nvfp4.patch
@@ -1,0 +1,573 @@
+--- a/csrc/params.h
++++ b/csrc/params.h
+@@ -67,6 +67,8 @@
+     float sm_scale, sm_scale_div_log2;
+     int num_blocks, page_block_size, topk;
+     ModelType model_type;
++    bool is_nvfp4_kvcache = false;
++    float* __restrict__ kv_global_scale = nullptr;
+
+     cutlass::bfloat16_t* __restrict__ q;   // [b, s_q, h_q, d_qk]
+     cutlass::bfloat16_t* __restrict__ kv;  // [num_blocks, page_block_size, d_qk]
+--- a/csrc/api/sparse_decode.h
++++ b/csrc/api/sparse_decode.h
+@@ -193,7 +193,8 @@
+     const std::optional<at::Tensor> &extra_indices,
+     const std::optional<at::Tensor> &extra_topk_length,
+     int d_v,
+-    float sm_scale
++    float sm_scale,
++    const std::optional<at::Tensor> &kv_global_scale = std::nullopt
+ ) {
+     using bf16 = cutlass::bfloat16_t;
+
+@@ -217,6 +218,7 @@
+     bool have_extra_kcache = extra_kv.has_value();
+     bool have_extra_topk_length = extra_topk_length.has_value();
+     bool have_attn_sink = attn_sink.has_value();
++    bool is_nvfp4_kvcache = kv_global_scale.has_value();
+
+     int extra_num_blocks = 0, extra_page_block_size = 0, extra_topk = 0;
+     if (have_extra_kcache) {
+@@ -254,6 +256,7 @@
+     KU_CHECK_DEVICE(extra_kv);
+     KU_CHECK_DEVICE(extra_indices);
+     KU_CHECK_DEVICE(extra_topk_length);
++    KU_CHECK_DEVICE(kv_global_scale);
+
+     // Check data type
+     KU_CHECK_DTYPE(q, torch::kBFloat16);
+@@ -268,6 +271,13 @@
+     KU_CHECK_DTYPE(num_splits, torch::kInt32);
+     KU_CHECK_DTYPE(extra_indices, torch::kInt32);
+     KU_CHECK_DTYPE(extra_topk_length, torch::kInt32);
++    KU_CHECK_DTYPE(kv_global_scale, torch::kFloat32);
++    if (is_nvfp4_kvcache) {
++        TORCH_CHECK(kv_global_scale->numel() == 1);
++        TORCH_CHECK(h_q == 64, "NVFP4 is only implemented for H64");
++        TORCH_CHECK(d_qk == 576 && d_v == 512, "NVFP4 is only implemented for V32");
++        TORCH_CHECK(!have_extra_kcache, "NVFP4 extra cache is not implemented");
++    }
+
+     // Check layout
+     KU_CHECK_LAST_DIM_CONTIGUOUS(q);
+@@ -287,7 +297,9 @@
+     KU_CHECK_SHAPE(q, b, s_q, h_q, d_qk);
+     {
+         int bytes_per_token;
+-        if (d_qk == 576 && d_v == 512) {
++        if (is_nvfp4_kvcache) {
++            bytes_per_token = 416;
++        } else if (d_qk == 576 && d_v == 512) {
+             // V3.2 style
+             bytes_per_token = 512 + 64*2 + (512/128)*4;
+         } else if (d_qk == 512 && d_v == 512) {
+@@ -310,7 +322,7 @@
+     KU_CHECK_SHAPE(extra_topk_length, b);
+
+     at::cuda::CUDAGuard device_guard{(char)q.get_device()};
+-    auto opts = q.options();
++    auto opts = q.options().dtype(at::kBFloat16);
+
+     at::Tensor out = torch::empty({b, s_q, h_q, d_v}, opts);
+     at::Tensor lse = torch::empty({b, s_q, h_q}, opts.dtype(at::kFloat));
+@@ -381,12 +393,44 @@
+     }
+
+     DecodeImplMeta impl_meta = impl->get_meta(h_q, s_q);
++    if (is_nvfp4_kvcache && tile_scheduler_metadata.has_value()) {
++        // CUDA graph callers preallocate scheduler metadata using the stock
++        // FlashMLA policy and retain its address across replays.  Honor that
++        // externally supplied partition count so split-K scratch allocation
++        // and combine agree with the captured schedule.  The compact NVFP4
++        // policy below remains active when metadata is generated internally.
++        const int supplied_num_sm_parts = tile_scheduler_metadata->size(0);
++        TORCH_CHECK(
++            supplied_num_sm_parts > 0 &&
++                supplied_num_sm_parts <= impl_meta.num_sm_parts,
++            "Invalid externally supplied scheduler partition count: ",
++            supplied_num_sm_parts,
++            " (kernel maximum ",
++            impl_meta.num_sm_parts,
++            ")");
++        impl_meta.num_sm_parts = supplied_num_sm_parts;
++    } else if (is_nvfp4_kvcache) {
++        // Preserve the scheduler's one-KV-block payload while avoiding idle
++        // partitions.  The stock H64 policy launches one partition per SM for
++        // B1/Sq1 (148 on B200), although topk=2048 has 32 blocks plus five
++        // fixed scheduling-cost units.  Capping at 37 therefore retains all
++        // 32 useful splits without launching 111 empty partitions.
++        const int max_blocks_per_request =
++            (topk + extra_topk + impl_meta.block_size_topk - 1) /
++            impl_meta.block_size_topk;
++        const int max_useful_parts = std::max(
++            b * (max_blocks_per_request + impl_meta.fixed_overhead_num_blocks),
++            1);
++        impl_meta.num_sm_parts = std::min(impl_meta.num_sm_parts, max_useful_parts);
++    }
+
+     SparseAttnDecodeParams params = {
+         b, s_q, h_q, h_kv, d_qk, d_v,
+         sm_scale, sm_scale * LOG_2_E,
+         num_blocks, page_block_size, topk,
+         model_type,
++        is_nvfp4_kvcache,
++        ku::get_optional_tensor_ptr<float>(kv_global_scale),
+
+         (bf16*)q.data_ptr(),
+         (bf16*)kv.data_ptr(),
+--- a/csrc/sm100/decode/head64/config.h
++++ b/csrc/sm100/decode/head64/config.h
+@@ -58,9 +58,11 @@
+
+ template<
+     typename Shape_Q_SW128, typename TMA_Q_SW128,
+-    typename Shape_O, typename TMA_O
++    typename Shape_O, typename TMA_O,
++    bool IS_NVFP4_STORAGE
+ >
+ struct TmaParams {
++    static constexpr bool kIsNvfp4Storage = IS_NVFP4_STORAGE;
+     Shape_Q_SW128 shape_Q_SW128; TMA_Q_SW128 tma_Q_SW128;
+     Shape_O shape_O; TMA_O tma_O;
+     CUtensorMap tensor_map_q_sw64;  // Invalid if D_Q_SW64 == 0
+@@ -211,4 +213,4 @@
+
+ };
+
+-}
+\ No newline at end of file
++}
+--- a/csrc/sm100/decode/head64/kernel.cuh
++++ b/csrc/sm100/decode/head64/kernel.cuh
+@@ -16,6 +16,52 @@
+
+ namespace sm100::decode::head64 {
+
++// SGLANG_SM100_GLM52_NVFP4_BF16_V1
++// Decode one packed E2M1 block directly into the BF16 tile consumed by the
++// existing FlashMLA QK/PV pipeline.  Storage format and consumer compute type
++// intentionally remain independent: NVFP4 changes only the producer.
++struct Nvfp4Bf16x8 {
++    bf16 values[8];
++};
++
++__device__ __forceinline__ Nvfp4Bf16x8
++nvfp4_dequant_e2m1x8_prepared_half2(uint32_t packed, __half2 scale_half2) {
++    uint32_t fp16x2[4];
++    asm volatile(
++        "{\n"
++        ".reg .b8 byte0, byte1, byte2, byte3;\n"
++        "mov.b32 {byte0, byte1, byte2, byte3}, %4;\n"
++        "cvt.rn.f16x2.e2m1x2 %0, byte0;\n"
++        "cvt.rn.f16x2.e2m1x2 %1, byte1;\n"
++        "cvt.rn.f16x2.e2m1x2 %2, byte2;\n"
++        "cvt.rn.f16x2.e2m1x2 %3, byte3;\n"
++        "}\n"
++        : "=r"(fp16x2[0]), "=r"(fp16x2[1]),
++          "=r"(fp16x2[2]), "=r"(fp16x2[3])
++        : "r"(packed));
++    Nvfp4Bf16x8 result;
++    uint32_t* pairs = reinterpret_cast<uint32_t*>(&result);
++    CUTE_UNROLL
++    for (int i = 0; i < 4; ++i) {
++        const __half2 scaled = __hmul2(
++            *reinterpret_cast<const __half2*>(&fp16x2[i]), scale_half2);
++        const __nv_bfloat162 value = __float22bfloat162_rn(
++            __half22float2(scaled));
++        pairs[i] = *reinterpret_cast<const uint32_t*>(&value);
++    }
++    return result;
++}
++
++__device__ __forceinline__ half nvfp4_e4m3_scale_to_half(uint8_t code) {
++    const uint16_t packed = uint16_t(code) | (uint16_t(code) << 8);
++    uint32_t fp16x2;
++    asm volatile(
++        "cvt.rn.f16x2.e4m3x2 %0, %1;\n"
++        : "=r"(fp16x2)
++        : "h"(packed));
++    return *reinterpret_cast<const half*>(&fp16x2);
++}
++
+ template<ModelType MODEL_TYPE>
+ template<typename TmaParam>
+ __device__ void
+@@ -598,17 +644,23 @@
+                     for (int row = 0; row < B_TOPK; row += 4) {
+                         if (row+4 < B_TOPK)
+                             nxt_cur_indices = *(int4*)(plan.tma_coord[rs.index_buf_idx] + row + 4);
++                        uint8_t* raw_dst = reinterpret_cast<uint8_t*>(
++                            plan.u.kv.raw_nope[rs.buf_idx].data());
++                        constexpr int raw_row_bytes =
++                            TmaParam::kIsNvfp4Storage ? 288 : D_NOPE;
+                         ku::tma_gather4(
+                             block_idx >= args.num_orig_kv_blocks ? &tma_params.tensor_map_extra_kv_nope : &tma_params.tensor_map_kv_nope,
+                             plan.bar_raw_ready[rs.buf_idx],
+-                            plan.u.kv.raw_nope[rs.buf_idx].data() + D_NOPE*row,
++                            raw_dst + raw_row_bytes * row,
+                             0,
+                             cur_indices,
+                             (int64_t)TMA::CacheHintSm90::EVICT_LAST
+                         );
+                         cur_indices = nxt_cur_indices;
+                     }
+-                    plan.bar_raw_ready[rs.buf_idx].arrive_and_expect_tx(B_TOPK*D_NOPE*sizeof(e4m3));
++                    constexpr int raw_bytes = B_TOPK *
++                        (TmaParam::kIsNvfp4Storage ? 288 : D_NOPE);
++                    plan.bar_raw_ready[rs.buf_idx].arrive_and_expect_tx(raw_bytes);
+                     plan.bar_valid_coord_scale_free[rs.index_buf_idx].arrive();
+                     rs.update();
+                 }
+@@ -654,12 +706,18 @@
+             // Indices transformation warp
+             // Responsible for generating: TMA coordinates, scale factors, and valid masks
+             static_assert(B_TOPK == 64);
+-            static constexpr int tma_coords_step_per_token = MODEL_TYPE == ModelType::V32 ? 656/TMA_K_STRIDE : 576/TMA_K_STRIDE;
+-            int tma_coords_step_per_block = params.stride_kv_block / TMA_K_STRIDE; // must < 2G since k_batch_stride < 1T and TMA_K_STRIDE > 512
++            constexpr int tma_stride =
++                TmaParam::kIsNvfp4Storage ? 416 : TMA_K_STRIDE;
++            constexpr int tma_coords_step_per_token =
++                TmaParam::kIsNvfp4Storage
++                ? 1
++                : (MODEL_TYPE == ModelType::V32 ? 656/TMA_K_STRIDE : 576/TMA_K_STRIDE);
++            int tma_coords_step_per_block = params.stride_kv_block / tma_stride;
+             int tma_coords_step_per_extra_block = params.stride_extra_kv_block / TMA_K_STRIDE;
+             uint8_t* k_scales_ptr =
+                 MODEL_TYPE == ModelType::V32 ?
+-                (uint8_t*)params.kv + D_NOPE :
++                (uint8_t*)params.kv +
++                    (TmaParam::kIsNvfp4Storage ? 256 : D_NOPE) :
+                 (uint8_t*)params.kv + params.page_block_size*(D_NOPE+2*D_ROPE);
+             uint8_t* extra_k_scales_ptr =
+                 MODEL_TYPE == ModelType::V32 ?
+@@ -695,22 +753,28 @@
+                     char valid_mask = 0;
+                     CUTE_UNROLL
+                     for (int i = 0; i < 2; ++i) {
+-                        int block_idx, idx_in_block;
+-                        block_idx = (unsigned int)my_indices[i] / cur_block_size;
+-                        idx_in_block = (unsigned int)my_indices[i] % cur_block_size;
+-                        bool is_token_valid = my_indices[i] != -1 && (abs_pos+i < (IS_EXTRA_BLOCK?args.extra_topk_length:args.topk_length));
++                        int physical_limit = cur_block_size *
++                            (IS_EXTRA_BLOCK ? params.extra_num_blocks : params.num_blocks);
++                        bool is_token_valid =
++                            my_indices[i] >= 0 && my_indices[i] < physical_limit &&
++                            (abs_pos+i < (IS_EXTRA_BLOCK?args.extra_topk_length:args.topk_length));
++                        int safe_index = is_token_valid ? my_indices[i] : 0;
++                        int block_idx = (unsigned int)safe_index / cur_block_size;
++                        int idx_in_block = (unsigned int)safe_index % cur_block_size;
+                         valid_mask |= is_token_valid << i;
+                         tma_coords[i] = is_token_valid ? block_idx*cur_tma_coords_step_per_block + idx_in_block*tma_coords_step_per_token : -1; // If the token is invalid because it topk position exceeds topk_length, we must manually fill tma_coords with -1 to avoid copying-in NaN.
+                         if constexpr (MODEL_TYPE == ModelType::V32) {
+-                            int64_t offset = is_token_valid ? block_idx*cur_k_block_stride + idx_in_block*cur_k_row_stride : 0;
+-                            float4 cur_scale_fp32 = __ldg((float4*)(cur_k_scales_ptr + offset));
+-                            __nv_bfloat16 res[4];
+-                            res[0] = __float2bfloat16(cur_scale_fp32.x);
+-                            res[1] = __float2bfloat16(cur_scale_fp32.y);
+-                            res[2] = __float2bfloat16(cur_scale_fp32.z);
+-                            res[3] = __float2bfloat16(cur_scale_fp32.w);
+-                            if (!is_token_valid) *(uint64_t*)res = (uint64_t)0;
+-                            *(uint64_t*)(scales+i*NUM_SCALES_EACH_TOKEN) = *(uint64_t*)(res);
++                            if constexpr (!TmaParam::kIsNvfp4Storage) {
++                                int64_t offset = is_token_valid ? block_idx*cur_k_block_stride + idx_in_block*cur_k_row_stride : 0;
++                                float4 cur_scale_fp32 = __ldg((float4*)(cur_k_scales_ptr + offset));
++                                __nv_bfloat16 res[4];
++                                res[0] = __float2bfloat16(cur_scale_fp32.x);
++                                res[1] = __float2bfloat16(cur_scale_fp32.y);
++                                res[2] = __float2bfloat16(cur_scale_fp32.z);
++                                res[3] = __float2bfloat16(cur_scale_fp32.w);
++                                if (!is_token_valid) *(uint64_t*)res = (uint64_t)0;
++                                *(uint64_t*)(scales+i*NUM_SCALES_EACH_TOKEN) = *(uint64_t*)(res);
++                            }
+                         } else {
+                             int64_t offset = block_idx*cur_k_block_stride + idx_in_block*8; // Each token has 7 scale factors with an extra 1B padding
+                             uint64_t scalesx8 = is_token_valid ? __ldg((uint64_t*)(cur_k_scales_ptr + offset)) : 0;
+@@ -721,7 +785,9 @@
+                     valid_mask |= __shfl_xor_sync(0xFFFFFFFF, valid_mask, 0x1);
+                     valid_mask |= __shfl_xor_sync(0xFFFFFFFF, valid_mask, 0x2);
+                     if constexpr (MODEL_TYPE == ModelType::V32) {
+-                        *(__int128_t*)(plan.scales[rs.index_buf_idx] + lane_idx*2) = *(__int128_t*)scales;
++                        if constexpr (!TmaParam::kIsNvfp4Storage) {
++                            *(__int128_t*)(plan.scales[rs.index_buf_idx] + lane_idx*2) = *(__int128_t*)scales;
++                        }
+                     } else {
+                         *(__int128_t*)(plan.scales[rs.index_buf_idx] + lane_idx*2) = *(__int128_t*)scales;
+                     }
+@@ -754,10 +820,16 @@
+         constexpr int GROUP_SIZE = 8, NUM_GROUPS = 128/8, ROWS_PER_GROUP = B_TOPK / NUM_GROUPS, COLS_PER_GROUP = D_NOPE/(GROUP_SIZE*8);
+         int group_idx = idx_in_warpgroup/GROUP_SIZE, idx_in_group = idx_in_warpgroup%GROUP_SIZE;
+         Tensor nope0 = make_tensor(make_smem_ptr(plan.u.kv.dequant[0].nope.data()), SmemLayoutKTiles_SW128<D_NOPE/64>{});
++        Tensor nope1 = make_tensor(make_smem_ptr(plan.u.kv.dequant[1].nope.data()), SmemLayoutKTiles_SW128<D_NOPE/64>{});
+         bf16* nope0_base = &nope0(group_idx, idx_in_group*8);
+         bf16* nope1_base = nope0_base + (plan.u.kv.dequant[1].nope.data() - plan.u.kv.dequant[0].nope.data());
+         e4m3* raw_nope0_base = plan.u.kv.raw_nope[rs.buf_idx].data() + group_idx*D_NOPE + idx_in_group*8;
+         e4m3* raw_nope1_base = raw_nope0_base + B_H*D_NOPE;
++        half nvfp4_global_scale_half{};
++        if constexpr (TmaParam::kIsNvfp4Storage) {
++            nvfp4_global_scale_half =
++                __float2half_rn(__ldg(params.kv_global_scale));
++        }
+
+         run_main_loop([&](const MainLoopArgs &args) {
+             // plan.bar_last_store_done.wait(args.bar_phase_batch_rel); // No need to wait since the raw nope producer must wait
+@@ -776,31 +848,131 @@
+                         : "r"(cur_nope_base_uint_addr + 2*(local_row_idx*NUM_GROUPS*64 + local_col_idx*B_TOPK*64)), "q"(data)   // 2 for sizeof(bf16)
+                     );  // We have this `asm volatile` here, otherwise the compiler generates ST.E instead of STS
+                 };
++                auto st_bf16x8 = [&](bf16* destination,
++                                     const Nvfp4Bf16x8 &data) {
++                    const uint32_t smem_address =
++                        cute::cast_smem_ptr_to_uint(destination);
++                    asm volatile ("st.weak.shared::cta.b128 [%0], %1;\n"
++                        :
++                        : "r"(smem_address),
++                          "q"(*reinterpret_cast<const __int128_t*>(&data)));
++                };
+                 auto get_raw_fp8 = [&](int local_row_idx, int local_col_idx) -> uint64_t {
+                     return *(uint64_t*)(raw_nope_base + local_row_idx*NUM_GROUPS*D_NOPE + local_col_idx*(GROUP_SIZE*8));
+                 };
+                 // The following code suffers from a 2-way bank conflict when reading from SMEM.
+                 if constexpr (MODEL_TYPE == ModelType::V32) {
+-                    CUTE_UNROLL
+-                    for (int local_row_idx = 0; local_row_idx < ROWS_PER_GROUP; ++local_row_idx) {
+-                        int row_idx = local_row_idx*NUM_GROUPS + group_idx;
+-                        bf16 scales[4];
+-                        *(uint64_t*)scales = *(uint64_t*)plan.scales[rs.index_buf_idx][row_idx];
+-
+-                        uint64_t cur_data_fp8x8 = get_raw_fp8(local_row_idx, 0);
++                    if constexpr (TmaParam::kIsNvfp4Storage) {
++                        // Four lanes own one 64-value stripe. Each lane
++                        // decodes a full block-16, keeping its scale local.
++                        constexpr int NV_GROUP_SIZE = 4;
++                        constexpr int NV_NUM_GROUPS = 128 / NV_GROUP_SIZE;
++                        constexpr int NV_ROWS_PER_GROUP =
++                            B_TOPK / NV_NUM_GROUPS;
++                        constexpr int NV_COLS_PER_GROUP =
++                            D_NOPE / (NV_GROUP_SIZE * 16);
++                        const int nv_group_idx =
++                            idx_in_warpgroup / NV_GROUP_SIZE;
++                        const int nv_idx_in_group =
++                            idx_in_warpgroup % NV_GROUP_SIZE;
++                        const uint8_t* raw_buffer =
++                            reinterpret_cast<const uint8_t*>(
++                                plan.u.kv.raw_nope[rs.buf_idx].data());
++                        auto &nope = rs.buf_idx == 0 ? nope0 : nope1;
++
++                        CUTE_NO_UNROLL
++                        for (int local_row_idx = 0;
++                             local_row_idx < NV_ROWS_PER_GROUP;
++                             ++local_row_idx) {
++                            const int row_idx =
++                                local_row_idx * NV_NUM_GROUPS + nv_group_idx;
++                            const uint8_t* row_buffer =
++                                raw_buffer + row_idx * 288;
++                            const int first_logical_dim =
++                                nv_idx_in_group * 16;
++                            uint64_t cur_packed =
++                                *reinterpret_cast<const uint64_t*>(
++                                    row_buffer + first_logical_dim / 2);
++                            uint8_t cur_scale_code =
++                                row_buffer[256 + first_logical_dim / 16];
++
++                            CUTE_NO_UNROLL
++                            for (int local_col_idx = 0;
++                                 local_col_idx < NV_COLS_PER_GROUP;
++                                 ++local_col_idx) {
++                                const int logical_dim =
++                                    nv_idx_in_group * 16 +
++                                    local_col_idx * (NV_GROUP_SIZE * 16);
++                                const uint64_t packed = cur_packed;
++                                const uint8_t scale_code = cur_scale_code;
++                                if (local_col_idx + 1 < NV_COLS_PER_GROUP) {
++                                    const int next_logical_dim =
++                                        logical_dim + NV_GROUP_SIZE * 16;
++                                    cur_packed =
++                                        *reinterpret_cast<const uint64_t*>(
++                                            row_buffer + next_logical_dim / 2);
++                                    cur_scale_code = row_buffer[
++                                        256 + next_logical_dim / 16];
++                                }
++                                const half block_scale =
++                                    nvfp4_e4m3_scale_to_half(scale_code);
++                                const half effective_scale = __hmul(
++                                    block_scale, nvfp4_global_scale_half);
++                                const __half2 effective_scale_half2 =
++                                    __halves2half2(
++                                        effective_scale, effective_scale);
++                                const Nvfp4Bf16x8 low =
++                                    nvfp4_dequant_e2m1x8_prepared_half2(
++                                        static_cast<uint32_t>(packed),
++                                        effective_scale_half2);
++                                st_bf16x8(
++                                    &nope(row_idx, logical_dim), low);
++                                const Nvfp4Bf16x8 high =
++                                    nvfp4_dequant_e2m1x8_prepared_half2(
++                                        static_cast<uint32_t>(packed >> 32),
++                                        effective_scale_half2);
++                                st_bf16x8(
++                                    &nope(row_idx, logical_dim + 8), high);
++                            }
++                        }
++                    } else {
+                         CUTE_UNROLL
+-                        for (int local_col_idx = 0; local_col_idx < COLS_PER_GROUP; ++local_col_idx) {
+-                            ku::nve4m3x2 data_fp8[4];
+-                            ku::nvbf16x2 data_bf16[4];
+-                            *(uint64_t*)data_fp8 = cur_data_fp8x8;
+-                            if (local_col_idx+1 < COLS_PER_GROUP)
+-                                cur_data_fp8x8 = get_raw_fp8(local_row_idx, local_col_idx+1);
+-                            bf16 scale = scales[local_col_idx / (D_NOPE/(GROUP_SIZE*8)/4)];
++                        for (int local_row_idx = 0;
++                             local_row_idx < ROWS_PER_GROUP;
++                             ++local_row_idx) {
++                            int row_idx =
++                                local_row_idx * NUM_GROUPS + group_idx;
++                            bf16 scales[4];
++                            *(uint64_t*)scales = *(uint64_t*)
++                                plan.scales[rs.index_buf_idx][row_idx];
++
++                            uint64_t cur_data_fp8x8 =
++                                get_raw_fp8(local_row_idx, 0);
+                             CUTE_UNROLL
+-                            for (int i = 0; i < 4; ++i) {
+-                                data_bf16[i] = fp8x2_to_bf16x2_with_scale(data_fp8[i], *(ku::nvbf16*)(&scale));
++                            for (int local_col_idx = 0;
++                                 local_col_idx < COLS_PER_GROUP;
++                                 ++local_col_idx) {
++                                ku::nve4m3x2 data_fp8[4];
++                                ku::nvbf16x2 data_bf16[4];
++                                *(uint64_t*)data_fp8 = cur_data_fp8x8;
++                                if (local_col_idx + 1 < COLS_PER_GROUP) {
++                                    cur_data_fp8x8 = get_raw_fp8(
++                                        local_row_idx, local_col_idx + 1);
++                                }
++                                bf16 scale = scales[
++                                    local_col_idx /
++                                    (D_NOPE / (GROUP_SIZE * 8) / 4)];
++                                CUTE_UNROLL
++                                for (int i = 0; i < 4; ++i) {
++                                    data_bf16[i] =
++                                        fp8x2_to_bf16x2_with_scale(
++                                            data_fp8[i],
++                                            *(ku::nvbf16*)(&scale));
++                                }
++                                st_128b(
++                                    local_row_idx, local_col_idx,
++                                    *(__int128_t*)data_bf16);
+                             }
+-                            st_128b(local_row_idx, local_col_idx, *(__int128_t*)data_bf16);
+                         }
+                     }
+                 } else {
+@@ -865,6 +1037,10 @@
+         constexpr int BYTES_PER_TOKEN = D_NOPE + 2*D_ROPE + 8;
+         KU_ASSERT(params.stride_kv_row == BYTES_PER_TOKEN, "Each page block in KV cache must be contiguous for head64 sparse fp8 decoding attention in MODEL1");  // Each block must be contiguous
+     }
++    if (params.is_nvfp4_kvcache && MODEL_TYPE != ModelType::V32) {
++        CUTE_INVALID_CONTROL_PATH("NVFP4 KV cache is only supported by V32");
++        return;
++    }
+
+     auto shape_Q_SW128 = make_shape(B_H, D_Q, params.s_q, params.b);
+     auto tma_Q_SW128 = cute::make_tma_copy(
+@@ -908,6 +1084,38 @@
+     auto get_nope_rope_tensormap = [&](bool is_extra, void* k_ptr, int num_blocks, int64_t k_batch_stride) -> std::pair<CUtensorMap, CUtensorMap> {
+         static_assert(D_NOPE%8 == 0);
+         KU_ASSERT((int64_t)k_ptr % 16 == 0, "The base address of %sk_ptr (%p) must be 16B aligned for sparse fp8 attention on sm100f", is_extra?"extra_":"", k_ptr);
++        if (params.is_nvfp4_kvcache) {
++            constexpr int NVFP4_ROW_BYTES = 416;
++            constexpr int PACKED_AND_SCALE_BYTES = 288;
++            constexpr int ROPE_OFFSET = 288;
++            KU_ASSERT(!is_extra, "NVFP4 extra cache is not implemented");
++            KU_ASSERT(k_batch_stride % NVFP4_ROW_BYTES == 0,
++                "NVFP4 k_cache.stride(0) (%ld) must be a multiple of %d",
++                k_batch_stride, NVFP4_ROW_BYTES);
++            CUtensorMap tensor_map_kv_nope = ku::make_tensor_map(
++                {PACKED_AND_SCALE_BYTES/8,
++                 (uint64_t)num_blocks *
++                     (k_batch_stride/NVFP4_ROW_BYTES)},
++                {NVFP4_ROW_BYTES},
++                {PACKED_AND_SCALE_BYTES/8, 1},
++                k_ptr,
++                CUtensorMapDataType::CU_TENSOR_MAP_DATA_TYPE_INT64,
++                CUtensorMapSwizzle::CU_TENSOR_MAP_SWIZZLE_NONE,
++                CUtensorMapL2promotion::CU_TENSOR_MAP_L2_PROMOTION_L2_128B
++            );
++            CUtensorMap tensor_map_kv_rope = ku::make_tensor_map(
++                {D_ROPE,
++                 (uint64_t)num_blocks *
++                     (k_batch_stride/NVFP4_ROW_BYTES)},
++                {NVFP4_ROW_BYTES},
++                {K_ROPE_SW/2, 1},
++                (uint8_t*)k_ptr + ROPE_OFFSET,
++                CUtensorMapDataType::CU_TENSOR_MAP_DATA_TYPE_BFLOAT16,
++                CUtensorMapSwizzle::CU_TENSOR_MAP_SWIZZLE_64B,
++                CUtensorMapL2promotion::CU_TENSOR_MAP_L2_PROMOTION_L2_128B
++            );
++            return {tensor_map_kv_nope, tensor_map_kv_rope};
++        }
+         KU_ASSERT(k_batch_stride % TMA_K_STRIDE == 0, "%sk_cache.stride(0) (%ld) must be a multiple of %d. Padding might be necessary", is_extra?"extra_":"", k_batch_stride, TMA_K_STRIDE);
+         CUtensorMap tensor_map_kv_nope = ku::make_tensor_map(
+             {D_NOPE/8, (uint64_t)num_blocks * (k_batch_stride/TMA_K_STRIDE)},
+@@ -936,27 +1144,41 @@
+         std::tie(tensor_map_extra_kv_nope, tensor_map_extra_kv_rope) = get_nope_rope_tensormap(true, params.extra_kv, params.extra_num_blocks, params.stride_extra_kv_block);
+     }
+
+-    TmaParams<
+-        decltype(shape_Q_SW128), decltype(tma_Q_SW128),
+-        decltype(shape_O), decltype(tma_O)
+-    > tma_params = {
+-        shape_Q_SW128, tma_Q_SW128,
+-        shape_O, tma_O,
+-        tensor_map_q_sw64,
+-        tensor_map_kv_nope,
+-        tensor_map_kv_rope,
+-        tensor_map_extra_kv_nope,
+-        tensor_map_extra_kv_rope
+-    };
+-    auto mla_kernel = &flash_fwd_splitkv_mla_fp8_sparse_kernel<KernelTemplate<MODEL_TYPE>, decltype(tma_params)>;
+-
+     constexpr size_t smem_size = sizeof(SharedMemoryPlan);
+     static_assert(smem_size < 227*1024);
+-    KU_CUDA_CHECK(cudaFuncSetAttribute(mla_kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+-
+-    // NOTE Don't use PDL because of potential compiler bugs!
+-    mla_kernel<<<dim3(params.s_q, params.num_sm_parts, 1), dim3(NUM_THREADS, 1, 1), smem_size, params.stream>>>(params, tma_params);
+-    KU_CHECK_KERNEL_LAUNCH();
++    auto launch = [&]<bool IS_NVFP4_STORAGE>() {
++        TmaParams<
++            decltype(shape_Q_SW128), decltype(tma_Q_SW128),
++            decltype(shape_O), decltype(tma_O),
++            IS_NVFP4_STORAGE
++        > tma_params = {
++            shape_Q_SW128, tma_Q_SW128,
++            shape_O, tma_O,
++            tensor_map_q_sw64,
++            tensor_map_kv_nope,
++            tensor_map_kv_rope,
++            tensor_map_extra_kv_nope,
++            tensor_map_extra_kv_rope
++        };
++        auto mla_kernel =
++            &flash_fwd_splitkv_mla_fp8_sparse_kernel<
++                KernelTemplate<MODEL_TYPE>, decltype(tma_params)>;
++        KU_CUDA_CHECK(cudaFuncSetAttribute(
++            mla_kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
++            smem_size));
++
++        // NOTE Don't use PDL because of potential compiler bugs!
++        mla_kernel<<<dim3(params.s_q, params.num_sm_parts, 1),
++                     dim3(NUM_THREADS, 1, 1), smem_size, params.stream>>>(
++            params, tma_params);
++        KU_CHECK_KERNEL_LAUNCH();
++    };
++
++    if (params.is_nvfp4_kvcache) {
++        launch.template operator()<true>();
++    } else {
++        launch.template operator()<false>();
++    }
+ }
+
+ template<ModelType MODEL_TYPE>

--- a/python/sglang/kernels/aot/python/sgl_kernel/flash_mla.py
+++ b/python/sglang/kernels/aot/python/sgl_kernel/flash_mla.py
@@ -4,7 +4,7 @@ from typing import Optional, Tuple
 import torch
 
 try:
-    from sgl_kernel import flashmla_ops  # triggers TORCH extension registration
+    from sgl_kernel import flashmla_ops  # noqa: F401  # registers extension
 except Exception as _e:
     _flashmla_import_error = _e
 else:
@@ -197,6 +197,68 @@ def flash_mla_with_kvcache(
             extra_topk_length,
         )
     return out, softmax_lse
+
+
+def flash_mla_with_kvcache_nvfp4(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    kv_global_scale: torch.Tensor,
+    indices: torch.Tensor,
+    head_dim_v: int,
+    tile_scheduler_metadata: Optional[torch.Tensor],
+    num_splits: Optional[torch.Tensor],
+    softmax_scale: float,
+    topk_length: Optional[torch.Tensor] = None,
+    attn_sink: Optional[torch.Tensor] = None,
+) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]:
+    """SM100 GLM-5.2 sparse decode over the 416-byte mixed NVFP4 row.
+
+    Unlike :func:`flash_mla_with_kvcache`, this is a distinct ABI: the cache is
+    byte-addressed, RoPE is BF16, the global FP32 scale is explicit, and Q is
+    BF16.  The producer dequantizes E2M1 latent values into the same BF16
+    shared-memory layout consumed by the open FlashMLA FP8-cache kernel.
+    Keeping the op separate prevents a packed cache from being accidentally
+    interpreted as FlashMLA's 656-byte FP8 layout.
+    """
+
+    if _flashmla_import_error is not None:
+        raise _IMPORT_ERROR from _flashmla_import_error
+    if q.dtype != torch.bfloat16:
+        raise TypeError(f"NVFP4 sparse decode requires BF16 Q, got {q.dtype}")
+    if q.ndim != 4 or q.shape[2:] != (64, 576):
+        raise ValueError(f"expected Q [B, Sq, 64, 576], got {tuple(q.shape)}")
+    if k_cache.dtype != torch.uint8 or k_cache.ndim != 4:
+        raise TypeError("packed NVFP4 cache must be a four-dimensional uint8 tensor")
+    if tuple(k_cache.shape[1:]) != (64, 1, 416):
+        raise ValueError(
+            f"expected packed cache [pages, 64, 1, 416], got {tuple(k_cache.shape)}"
+        )
+    if kv_global_scale.dtype != torch.float32 or kv_global_scale.numel() != 1:
+        raise TypeError("kv_global_scale must be a one-element FP32 tensor")
+    if indices.dtype != torch.int32 or indices.shape != (
+        q.shape[0],
+        q.shape[1],
+        2048,
+    ):
+        raise ValueError(
+            "indices must be int32 [B, Sq, 2048], got "
+            f"dtype={indices.dtype}, shape={tuple(indices.shape)}"
+        )
+    if head_dim_v != 512:
+        raise ValueError(f"GLM-5.2 NVFP4 requires d_v=512, got {head_dim_v}")
+
+    return torch.ops.sgl_kernel.sparse_decode_fwd_nvfp4.default(
+        q,
+        k_cache,
+        kv_global_scale,
+        indices,
+        topk_length,
+        attn_sink,
+        tile_scheduler_metadata,
+        num_splits,
+        head_dim_v,
+        softmax_scale,
+    )
 
 
 def _flash_mla_with_kvcache_sched_meta(

--- a/python/sglang/kernels/aot/tests/test_flashmla_nvfp4_sm100.py
+++ b/python/sglang/kernels/aot/tests/test_flashmla_nvfp4_sm100.py
@@ -1,0 +1,476 @@
+import importlib.util
+import math
+import os
+from pathlib import Path
+
+import pytest
+import torch
+
+
+def _load_codec_module():
+    codec_path = (
+        Path(__file__).resolve().parents[3]
+        / "srt/layers/attention/dsa/nvfp4_k_cache.py"
+    )
+    spec = importlib.util.spec_from_file_location("dsa_nvfp4_k_cache_test", codec_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_CODEC = _load_codec_module()
+NVFP4_BYTES_PER_TOKEN = _CODEC.NVFP4_BYTES_PER_TOKEN
+dequantize_nvfp4_k_cache_paged_reference = (
+    _CODEC.dequantize_nvfp4_k_cache_paged_reference
+)
+quantize_nvfp4_k_cache_into = _CODEC.quantize_nvfp4_k_cache_into
+
+
+LOCAL_Q_HEADS = 64
+QK_DIM = 576
+V_DIM = 512
+PAGE_SIZE = 64
+TOPK = 2048
+CONTEXT_LENGTH = 200_000
+
+
+def _is_sm100() -> bool:
+    return torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 10
+
+
+def _load_flashmla_extension() -> None:
+    explicit_library = os.environ.get("SGLANG_FLASHMLA_LIBRARY")
+    if explicit_library:
+        torch.ops.load_library(explicit_library)
+        return
+    from sgl_kernel import flashmla_ops  # noqa: F401
+
+
+def _reference(
+    q: torch.Tensor,
+    cache: torch.Tensor,
+    global_scale: torch.Tensor,
+    indices: torch.Tensor,
+    topk_length: torch.Tensor,
+    sink: torch.Tensor | None,
+    sm_scale: float,
+    scheduler_metadata: torch.Tensor,
+):
+    b, sq, h, _ = q.shape
+    rows = b * sq
+    flat_indices = indices.reshape(rows, TOPK)
+    row_lengths = topk_length.reshape(b, 1).expand(b, sq).reshape(rows)
+    physical_tokens = cache.numel() // NVFP4_BYTES_PER_TOKEN
+    position = torch.arange(TOPK, device=q.device).view(1, TOPK)
+    valid = (
+        (position < row_lengths.reshape(rows, 1))
+        & (flat_indices >= 0)
+        & (flat_indices < physical_tokens)
+    )
+    safe_indices = flat_indices.masked_fill(~valid, 0)
+    decoded = (
+        dequantize_nvfp4_k_cache_paged_reference(
+            cache, safe_indices, global_scale, torch.bfloat16
+        )
+        .reshape(rows, TOPK, QK_DIM)
+        .float()
+    )
+
+    # Match the open FlashMLA FP8-cache contract: the producer materializes
+    # BF16 latent/RoPE tiles, QK and PV consume BF16 operands, and their
+    # accumulators plus online-softmax state remain FP32.
+    q_mma = q.reshape(rows, h, QK_DIM).float()
+    latent_mma = decoded[..., :V_DIM]
+    kv_mma = decoded
+    logits = torch.einsum("rhd,rkd->rhk", q_mma, kv_mma) * sm_scale
+    logits.masked_fill_(~valid[:, None, :], float("-inf"))
+    # FlashMLA's scheduler can split one request across many CTAs.  Each split
+    # runs its own online softmax and quantizes the *unnormalized* probability
+    # tile to BF16 before PV; the combine kernel then merges the normalized
+    # partial outputs using their LSEs.  Reconstruct the exact block ranges from
+    # DecodingSchedMeta instead of treating all 2048 candidates as one stream.
+    metadata_cpu = scheduler_metadata.detach().cpu()
+    request_split_ranges: list[list[tuple[int, int]]] = [[] for _ in range(b)]
+    num_blocks_per_request = [
+        max(1, math.ceil(int(length) / 64)) for length in topk_length.tolist()
+    ]
+    for meta in metadata_cpu:
+        begin_req, end_req, begin_block, end_block = map(int, meta[:4])
+        if begin_req >= b:
+            continue
+        for request in range(begin_req, min(end_req, b - 1) + 1):
+            start = begin_block if request == begin_req else 0
+            end = end_block if request == end_req else num_blocks_per_request[request]
+            if end > start:
+                request_split_ranges[request].append((start, end))
+    split_ranges = [
+        request_split_ranges[request] for request in range(b) for _ in range(sq)
+    ]
+
+    out = torch.empty(rows, h, V_DIM, dtype=torch.float32, device=q.device)
+    combined_lse = torch.empty(rows, h, dtype=torch.float32, device=q.device)
+    for request, ranges in enumerate(split_ranges):
+        assert ranges, f"scheduler produced no split for request {request}"
+        partial_outputs = []
+        partial_lses = []
+        for begin_block, end_block in ranges:
+            running_max = torch.full(
+                (h,), -1.0e30, dtype=torch.float32, device=q.device
+            )
+            running_sum = torch.zeros_like(running_max)
+            numerator = torch.zeros(h, V_DIM, dtype=torch.float32, device=q.device)
+            for block in range(begin_block, end_block):
+                start = block * 64
+                end = start + 64
+                block_logits = logits[request, :, start:end]
+                block_max = block_logits.max(dim=-1).values
+                # The H64 kernel uses ``__any_sync`` per warp: a trigger from
+                # any of 32 heads rescales that half of the head tile, while
+                # the other half remains independent.
+                should_rescale = (
+                    ((block_max - running_max) > 6.0)
+                    .view(-1, 32)
+                    .any(dim=-1, keepdim=True)
+                    .expand(-1, 32)
+                    .reshape(h)
+                )
+                new_max = torch.where(
+                    should_rescale,
+                    torch.maximum(running_max, block_max),
+                    running_max,
+                )
+                old_scale = torch.exp(running_max - new_max)
+                block_probability = torch.exp(block_logits - new_max.unsqueeze(-1))
+                block_probability = torch.nan_to_num(block_probability, nan=0.0)
+                numerator.mul_(old_scale.unsqueeze(-1))
+                numerator.add_(
+                    torch.einsum(
+                        "hk,kd->hd",
+                        block_probability.to(torch.bfloat16).float(),
+                        latent_mma[request, start:end],
+                    )
+                )
+                running_sum.mul_(old_scale).add_(block_probability.sum(dim=-1))
+                running_max = new_max
+            partial_outputs.append(numerator / running_sum.unsqueeze(-1))
+            partial_lses.append(torch.log(running_sum) + running_max)
+
+        split_lse = torch.stack(partial_lses, dim=0)
+        split_out = torch.stack(partial_outputs, dim=0)
+        if sink is not None:
+            combine_lse = torch.cat((split_lse, sink.view(1, h)), dim=0)
+            weights = torch.softmax(combine_lse, dim=0)[:-1]
+            combined_lse[request] = torch.logsumexp(combine_lse, dim=0)
+        else:
+            weights = torch.softmax(split_lse, dim=0)
+            combined_lse[request] = torch.logsumexp(split_lse, dim=0)
+        out[request] = torch.einsum("sh,shd->hd", weights, split_out)
+    return (
+        out.reshape(b, sq, h, V_DIM).to(torch.bfloat16),
+        combined_lse.reshape(b, sq, h).transpose(1, 2).contiguous(),
+    )
+
+
+def _make_case(b: int, sq: int, global_scale_value: float = 1.375):
+    device = torch.device("cuda")
+    generator = torch.Generator(device=device).manual_seed(20260810 + b * 10 + sq)
+    physical_tokens = b * CONTEXT_LENGTH
+    cache = torch.zeros(
+        math.ceil(physical_tokens / PAGE_SIZE),
+        PAGE_SIZE,
+        1,
+        NVFP4_BYTES_PER_TOKEN,
+        dtype=torch.uint8,
+        device=device,
+    )
+    q = (
+        torch.randn(
+            b,
+            sq,
+            LOCAL_Q_HEADS,
+            QK_DIM,
+            generator=generator,
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        * 0.125
+    )
+    indices = torch.empty(b, sq, TOPK, dtype=torch.int32, device=device)
+    for request in range(b):
+        request_start = request * CONTEXT_LENGTH
+        for query in range(sq):
+            row = torch.randperm(
+                CONTEXT_LENGTH, generator=generator, device=device, dtype=torch.int64
+            )[:TOPK].to(torch.int32)
+            indices[request, query] = row + request_start
+
+    # Exercise page boundaries, last valid row, negative/positive OOB values,
+    # and duplicates.  The last element is also masked by topk_length.
+    boundary_values = torch.tensor(
+        [
+            1,
+            63,
+            64,
+            65,
+            2047,
+            2048,
+            199_999,
+            200_000,
+            200_001,
+            201_999,
+            202_000,
+        ],
+        dtype=torch.int32,
+        device=device,
+    )
+    indices[0, 0, : boundary_values.numel()] = boundary_values
+    indices[0, 0, 20] = -1
+    indices[0, 0, 21] = indices[0, 0, 22]
+    topk_length = torch.full((b,), TOPK, dtype=torch.int32, device=device)
+    topk_length[-1] = TOPK - 1
+
+    valid_locations = torch.unique(
+        indices[(indices >= 0) & (indices < physical_tokens)].to(torch.int64)
+    )
+    latent = (
+        torch.randn(
+            valid_locations.numel(),
+            1,
+            V_DIM,
+            generator=generator,
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        * 0.125
+    )
+    rope = (
+        torch.randn(
+            valid_locations.numel(),
+            1,
+            QK_DIM - V_DIM,
+            generator=generator,
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        * 0.125
+    )
+    global_scale = torch.tensor(
+        [global_scale_value], dtype=torch.float32, device=device
+    )
+    quantize_nvfp4_k_cache_into(latent, rope, cache, valid_locations, global_scale)
+    sink = torch.linspace(-2.0, -0.25, LOCAL_Q_HEADS, device=device)
+    return q, cache, global_scale, indices, topk_length, sink
+
+
+@pytest.mark.skipif(not _is_sm100(), reason="SM100 is required")
+@torch.inference_mode()
+def test_glm52_nvfp4_repeated_single_kv_row():
+    _load_flashmla_extension()
+    device = torch.device("cuda")
+    cache = torch.zeros(
+        1,
+        PAGE_SIZE,
+        1,
+        NVFP4_BYTES_PER_TOKEN,
+        dtype=torch.uint8,
+        device=device,
+    )
+    # Every dimension has a deterministic sign/magnitude pattern, while each
+    # block remains exactly representable by the NVFP4->E4M3 contract.
+    values = torch.tensor(
+        [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0],
+        device=device,
+        dtype=torch.float32,
+    )
+    latent = values.repeat(V_DIM // values.numel())
+    latent[1::2].neg_()
+    latent = latent.mul(0.125).to(torch.bfloat16).view(1, 1, V_DIM)
+    rope = torch.zeros(1, 1, QK_DIM - V_DIM, dtype=torch.bfloat16, device=device)
+    global_scale = torch.tensor([0.125], dtype=torch.float32, device=device)
+    quantize_nvfp4_k_cache_into(
+        latent,
+        rope,
+        cache,
+        torch.zeros(1, dtype=torch.int64, device=device),
+        global_scale,
+    )
+    decoded = dequantize_nvfp4_k_cache_paged_reference(
+        cache,
+        torch.zeros(1, dtype=torch.int64, device=device),
+        global_scale,
+        torch.bfloat16,
+    )[0, 0, :V_DIM].float()
+    q = torch.zeros(1, 1, LOCAL_Q_HEADS, QK_DIM, dtype=torch.bfloat16, device=device)
+    indices = torch.zeros(1, 1, TOPK, dtype=torch.int32, device=device)
+    lengths = torch.full((1,), TOPK, dtype=torch.int32, device=device)
+    out, _, _, _ = torch.ops.sgl_kernel.sparse_decode_fwd_nvfp4.default(
+        q, cache, global_scale, indices, lengths, None, None, None, V_DIM, 1.0
+    )
+    actual = out.float()[0, 0, 0]
+    torch.testing.assert_close(actual, decoded, atol=8e-4, rtol=2.01 / 128)
+
+
+@pytest.mark.skipif(not _is_sm100(), reason="SM100 is required")
+@torch.inference_mode()
+def test_glm52_nvfp4_all_invalid_indices_return_zero_output():
+    _load_flashmla_extension()
+    device = torch.device("cuda")
+    q = torch.zeros(
+        1, 1, LOCAL_Q_HEADS, QK_DIM, dtype=torch.bfloat16, device=device
+    )
+    cache = torch.zeros(
+        1,
+        PAGE_SIZE,
+        1,
+        NVFP4_BYTES_PER_TOKEN,
+        dtype=torch.uint8,
+        device=device,
+    )
+    global_scale = torch.ones(1, dtype=torch.float32, device=device)
+    indices = torch.full((1, 1, TOPK), -1, dtype=torch.int32, device=device)
+    lengths = torch.full((1,), TOPK, dtype=torch.int32, device=device)
+    sink = torch.zeros(LOCAL_Q_HEADS, dtype=torch.float32, device=device)
+
+    out, lse, _, _ = torch.ops.sgl_kernel.sparse_decode_fwd_nvfp4.default(
+        q, cache, global_scale, indices, lengths, sink, None, None, V_DIM, 1.0
+    )
+
+    torch.testing.assert_close(out, torch.zeros_like(out), rtol=0, atol=0)
+    # Match FlashMLA's existing lonely-query convention: a query with no
+    # attendable key has a zero output and uses +inf as its LSE sentinel.
+    assert torch.isposinf(lse).all()
+
+
+@pytest.mark.skipif(not _is_sm100(), reason="SM100 is required")
+@pytest.mark.parametrize("b,sq", [(1, 1), (2, 1), (1, 6), (4, 6)])
+@torch.inference_mode()
+def test_glm52_nvfp4_sparse_decode(b: int, sq: int):
+    _load_flashmla_extension()
+    q, cache, global_scale, indices, topk_length, sink = _make_case(b, sq)
+    sm_scale = 1.0 / math.sqrt(QK_DIM)
+    out, lse, metadata, _num_splits = (
+        torch.ops.sgl_kernel.sparse_decode_fwd_nvfp4.default(
+            q,
+            cache,
+            global_scale,
+            indices,
+            topk_length,
+            sink,
+            None,
+            None,
+            V_DIM,
+            sm_scale,
+        )
+    )
+    ref_out, ref_lse = _reference(
+        q,
+        cache,
+        global_scale,
+        indices,
+        topk_length,
+        sink,
+        sm_scale,
+        metadata,
+    )
+    torch.testing.assert_close(out, ref_out, atol=8e-4, rtol=2.01 / 128)
+    torch.testing.assert_close(lse, ref_lse, atol=2e-4, rtol=8.01 / 65536)
+
+
+@pytest.mark.skipif(not _is_sm100(), reason="SM100 is required")
+@pytest.mark.parametrize("b,sq", [(1, 1), (2, 1), (4, 1), (1, 6), (2, 6), (4, 6)])
+@torch.inference_mode()
+def test_glm52_nvfp4_sparse_decode_cuda_graph_replay(b: int, sq: int):
+    _load_flashmla_extension()
+    q, cache, global_scale, indices, topk_length, _ = _make_case(b, sq)
+    out_address = None
+    graph = torch.cuda.CUDAGraph()
+    for _ in range(3):
+        torch.ops.sgl_kernel.sparse_decode_fwd_nvfp4.default(
+            q, cache, global_scale, indices, topk_length, None, None, None, V_DIM, 1.0
+        )
+    torch.cuda.synchronize()
+    with torch.cuda.graph(graph):
+        out, lse, _, _ = torch.ops.sgl_kernel.sparse_decode_fwd_nvfp4.default(
+            q, cache, global_scale, indices, topk_length, None, None, None, V_DIM, 1.0
+        )
+    out_address = out.data_ptr()
+    first = out.clone()
+    q.copy_(torch.zeros_like(q))
+    indices[..., 0].fill_(-1)
+    topk_length.fill_(TOPK - 1)
+    global_scale.fill_(0.5)
+    graph.replay()
+    torch.cuda.synchronize()
+    assert out.data_ptr() == out_address
+    assert torch.isfinite(lse).all()
+    assert not torch.equal(first, out)
+
+
+@pytest.mark.skipif(not _is_sm100(), reason="SM100 is required")
+@pytest.mark.parametrize("b,sq", [(1, 1), (2, 1), (4, 1), (1, 6), (4, 6)])
+@torch.inference_mode()
+def test_glm52_nvfp4_sparse_decode_cuda_graph_external_metadata(b: int, sq: int):
+    """Match SGLang graph capture, which supplies stock FlashMLA metadata."""
+    _load_flashmla_extension()
+
+    q, cache, global_scale, indices, topk_length, _ = _make_case(b, sq)
+    rows = b * sq
+    # The DSA backend flattens EAGLE's logical [B, Sq] into an effective
+    # [B * Sq, 1] sparse-decode batch before calling FlashMLA.
+    q_kernel = q.view(rows, 1, LOCAL_Q_HEADS, QK_DIM)
+    indices_kernel = indices.view(rows, 1, TOPK)
+    # Graph capture uses dummy short sequence lengths (1..Sq) even though the
+    # fixed sparse page table and scheduler retain the production top-k width.
+    row_lengths = torch.arange(
+        1, sq + 1, dtype=torch.int32, device=q.device
+    ).repeat(b)
+    scheduler_metadata, num_splits = (
+        torch.ops.sgl_kernel.get_mla_decoding_metadata.default(
+            row_lengths,
+            LOCAL_Q_HEADS,
+            1,
+            LOCAL_Q_HEADS,
+            True,
+            TOPK,
+        )
+    )
+    assert scheduler_metadata.shape[0] == 148
+    for _ in range(3):
+        torch.ops.sgl_kernel.sparse_decode_fwd_nvfp4.default(
+            q_kernel,
+            cache,
+            global_scale,
+            indices_kernel,
+            None,
+            None,
+            scheduler_metadata,
+            num_splits,
+            V_DIM,
+            1.0,
+        )
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        out, lse, _, _ = torch.ops.sgl_kernel.sparse_decode_fwd_nvfp4.default(
+            q_kernel,
+            cache,
+            global_scale,
+            indices_kernel,
+            None,
+            None,
+            scheduler_metadata,
+            num_splits,
+            V_DIM,
+            1.0,
+        )
+    out_address = out.data_ptr()
+    first = out.clone()
+    q_kernel.zero_()
+    indices_kernel[..., 0].fill_(-1)
+    graph.replay()
+    torch.cuda.synchronize()
+    assert out.data_ptr() == out_address
+    assert torch.isfinite(lse).all()
+    assert not torch.equal(first, out)

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1630,10 +1630,33 @@ def _dsa_kv_cache_dtype_default(view: Any) -> dict:
         )
     if kv_cache_dtype == "bf16":
         kv_cache_dtype = "bfloat16"
+    if kv_cache_dtype == "nvfp4":
+        model_arch = hf_config.architectures[0]
+        if major != 10 or is_hip():
+            raise ValueError(
+                f"DSA --kv-cache-dtype={kv_cache_dtype} currently requires an SM100 GPU"
+            )
+        if model_arch != "GlmMoeDsaForCausalLM":
+            raise ValueError(
+                f"DSA --kv-cache-dtype={kv_cache_dtype} is currently specialized for "
+                f"GLM-5.2, got architecture {model_arch}"
+            )
+        if view.enable_prefill_cp or view.dcp_size > 1:
+            raise ValueError(
+                "GLM-5.2 SM100 DSA --kv-cache-dtype=nvfp4 does not yet support "
+                "prefill context parallelism or decode context parallelism; "
+                "disable --enable-prefill-cp and set --dcp-size=1"
+            )
+        if view.enable_hisparse:
+            raise ValueError(
+                "GLM-5.2 SM100 DSA --kv-cache-dtype=nvfp4 does not yet support "
+                "HiSparse; disable --enable-hisparse"
+            )
     assert kv_cache_dtype in [
         "bfloat16",
         "fp8_e4m3",
-    ], "DeepSeek DSA only supports bf16/bfloat16 or fp8_e4m3 kv_cache_dtype"
+        "nvfp4",
+    ], "DeepSeek DSA only supports bf16/bfloat16, fp8_e4m3, or nvfp4 kv_cache_dtype"
     if kv_cache_dtype != view.kv_cache_dtype:
         return {"kv_cache_dtype": kv_cache_dtype}
     return {}
@@ -1701,6 +1724,35 @@ def _dsa_split_backend_resolution(view: Any) -> dict:
         logger.warning(
             "Set DSA backends for GLM FP8 KV Cache on SM120/SM121: "
             f"prefill={backend}, decode={backend}."
+        )
+        return declared
+
+    if kv_cache_dtype == "nvfp4":
+        if major != 10 or model_arch != "GlmMoeDsaForCausalLM" or is_hip():
+            raise ValueError(
+                f"DSA {kv_cache_dtype} FlashMLA is supported only for GLM-5.2 on SM100"
+            )
+        if view.page_size not in (None, 64):
+            raise ValueError(
+                f"GLM-5.2 SM100 {kv_cache_dtype} DSA requires --page-size=64, got {view.page_size}"
+            )
+        if user_set_prefill and view.dsa_prefill_backend != "flashmla_sparse":
+            raise ValueError(
+                "GLM-5.2 SM100 DSA NVFP4 requires "
+                "--dsa-prefill-backend=flashmla_sparse"
+            )
+        if user_set_decode and view.dsa_decode_backend != "flashmla_kv":
+            raise ValueError(
+                "GLM-5.2 SM100 DSA NVFP4 requires "
+                "--dsa-decode-backend=flashmla_kv"
+            )
+        if not user_set_prefill:
+            declared["dsa_prefill_backend"] = "flashmla_sparse"
+        if not user_set_decode:
+            declared["dsa_decode_backend"] = "flashmla_kv"
+        logger.warning(
+            f"Set GLM-5.2 SM100 {kv_cache_dtype} DSA backends: "
+            "prefill=flashmla_sparse, decode=flashmla_kv"
         )
         return declared
 

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1641,11 +1641,25 @@ def _dsa_kv_cache_dtype_default(view: Any) -> dict:
                 f"DSA --kv-cache-dtype={kv_cache_dtype} is currently specialized for "
                 f"GLM-5.2, got architecture {model_arch}"
             )
-        if view.enable_prefill_cp or view.dcp_size > 1:
+        if view.dcp_size > 1:
             raise ValueError(
                 "GLM-5.2 SM100 DSA --kv-cache-dtype=nvfp4 does not yet support "
-                "prefill context parallelism or decode context parallelism; "
-                "disable --enable-prefill-cp and set --dcp-size=1"
+                "decode context parallelism; set --dcp-size=1"
+            )
+        if view.enable_prefill_cp and view.cp_strategy != "interleave":
+            raise ValueError(
+                "GLM-5.2 SM100 DSA --kv-cache-dtype=nvfp4 supports prefill "
+                "context parallelism only with --cp-strategy=interleave"
+            )
+        if view.enable_dsa_cache_layer_split:
+            raise ValueError(
+                "GLM-5.2 SM100 DSA --kv-cache-dtype=nvfp4 does not yet support "
+                "--enable-dsa-cache-layer-split; use the replicated KV cache"
+            )
+        if view.enable_cp_decode_attn_tp:
+            raise ValueError(
+                "GLM-5.2 SM100 DSA --kv-cache-dtype=nvfp4 requires H64 "
+                "attention-DP decode; disable --enable-cp-decode-attn-tp"
             )
         if view.enable_hisparse:
             raise ValueError(

--- a/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
+++ b/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
@@ -62,6 +62,15 @@ class DecodeKVCacheOffloadManager:
             page_size=self.page_size,
             server_args=server_args,
             use_mla=isinstance(kv_cache, MLATokenToKVPool),
+            # Packed DSA caches express their physical row width directly
+            # (416 bytes for GLM-5.2 NVFP4) instead of
+            # kv_lora_rank + qk_rope_head_dim. Keep host/device item sizes
+            # identical for decode offload and HiCache transfers.
+            override_kv_cache_dim=(
+                kv_cache.kv_cache_dim
+                if isinstance(kv_cache, MLATokenToKVPool)
+                else None
+            ),
         )
 
         self.tp_group = tp_group

--- a/python/sglang/srt/layers/attention/dsa/nvfp4_k_cache.py
+++ b/python/sglang/srt/layers/attention/dsa/nvfp4_k_cache.py
@@ -1,0 +1,556 @@
+"""GLM-5.2 DSA mixed NVFP4/BF16 key-cache codec.
+
+The SM100 cache row is intentionally byte-addressed and has one canonical
+layout per physical token::
+
+    [ E2M1 latent (256 B) | E4M3 block-16 scales (32 B) | BF16 RoPE (128 B) ]
+
+Only the 512-dimensional latent vector uses NVFP4 block scaling.  The
+64-dimensional RoPE vector is stored directly as BF16.  The fused attention
+producer dequantizes the latent vector to BF16 and feeds the unchanged
+FlashMLA FP8-cache BF16 QK/PV consumer.  A persistent FP32 global scale is
+stored once per layer by the KV pool, outside this row.
+
+The PyTorch functions are executable, bit-exact references.  The Triton path
+scatters directly into the cache and is used for production cache writes; it
+does not materialize a full-cache dequantization workspace.
+"""
+
+from __future__ import annotations
+
+import math
+from numbers import Real
+
+import torch
+import triton
+import triton.language as tl
+
+NVFP4_BLOCK_SIZE = 16
+NVFP4_LATENT_DIM = 512
+NVFP4_ROPE_DIM = 64
+NVFP4_PACKED_LATENT_BYTES = 256
+NVFP4_SCALE_BYTES = 32
+NVFP4_ROPE_BYTES = 128
+NVFP4_BYTES_PER_TOKEN = 416
+
+_E2M1_MAX = 6.0
+_E4M3_MAX = 448.0
+_NUM_LATENT_BLOCKS = NVFP4_LATENT_DIM // NVFP4_BLOCK_SIZE
+_QUANTIZE_SMALL_BATCH_THRESHOLD = 64
+
+
+def _as_feature_matrix(x: torch.Tensor, dim: int, name: str) -> torch.Tensor:
+    if x.ndim == 3 and x.shape[1] == 1:
+        x = x[:, 0, :]
+    if x.ndim != 2 or x.shape[1] != dim:
+        raise ValueError(
+            f"{name} must have shape [num_tokens, {dim}] or "
+            f"[num_tokens, 1, {dim}], got {tuple(x.shape)}"
+        )
+    if x.dtype not in (torch.bfloat16, torch.float16, torch.float32):
+        raise TypeError(f"{name} must be BF16, FP16, or FP32, got {x.dtype}")
+    return x if x.stride(1) == 1 else x.contiguous()
+
+
+def _as_cache_rows(kv_buffer: torch.Tensor) -> torch.Tensor:
+    if kv_buffer.dtype != torch.uint8:
+        raise TypeError(f"kv_buffer must be uint8, got {kv_buffer.dtype}")
+    if kv_buffer.ndim < 2 or kv_buffer.shape[-1] != NVFP4_BYTES_PER_TOKEN:
+        raise ValueError(
+            f"kv_buffer must have shape [..., {NVFP4_BYTES_PER_TOKEN}], "
+            f"got {tuple(kv_buffer.shape)}"
+        )
+    if not kv_buffer.is_contiguous():
+        raise ValueError("kv_buffer must be contiguous")
+    return kv_buffer.view(-1, NVFP4_BYTES_PER_TOKEN)
+
+
+def _as_global_scale(
+    global_scale: torch.Tensor | Real, device: torch.device
+) -> torch.Tensor:
+    if isinstance(global_scale, torch.Tensor):
+        if global_scale.numel() != 1:
+            raise ValueError("global_scale must contain exactly one value")
+        scale = global_scale.to(device=device, dtype=torch.float32).reshape(1)
+        if not scale.is_cuda and not bool(
+            torch.isfinite(scale).all() & (scale > 0).all()
+        ):
+            raise ValueError("global_scale must be finite and positive")
+        return scale.contiguous()
+    if not isinstance(global_scale, Real):
+        raise TypeError("global_scale must be a number or one-element tensor")
+    value = float(global_scale)
+    if not math.isfinite(value) or value <= 0:
+        raise ValueError(f"global_scale must be finite and positive, got {value}")
+    return torch.tensor([value], dtype=torch.float32, device=device)
+
+
+def _validate_quant_inputs(
+    k_nope: torch.Tensor,
+    k_rope: torch.Tensor,
+    kv_buffer: torch.Tensor,
+    loc: torch.Tensor,
+):
+    k_nope = _as_feature_matrix(k_nope, NVFP4_LATENT_DIM, "k_nope")
+    k_rope = _as_feature_matrix(k_rope, NVFP4_ROPE_DIM, "k_rope")
+    rows = _as_cache_rows(kv_buffer)
+    loc = loc.reshape(-1)
+    if k_nope.shape[0] != k_rope.shape[0] or k_nope.shape[0] != loc.numel():
+        raise ValueError("k_nope, k_rope, and loc must have the same token count")
+    if loc.dtype not in (torch.int32, torch.int64):
+        raise TypeError(f"loc must be int32 or int64, got {loc.dtype}")
+    if not (k_nope.device == k_rope.device == rows.device == loc.device):
+        raise ValueError("all codec tensors must be on one device")
+    return k_nope, k_rope, rows, loc.contiguous()
+
+
+def _sanitize_nonfinite_torch(x: torch.Tensor, global_scale: torch.Tensor):
+    """Canonical finite-only policy for E2M1FN/E4M3FN storage.
+
+    NaN becomes positive zero.  Positive/negative infinity saturates to the
+    largest value representable by the recipe at the current global scale.
+    This policy is deterministic in both the CPU reference and CUDA writer.
+    """
+
+    bound = _E2M1_MAX * _E4M3_MAX * global_scale
+    return torch.nan_to_num(
+        x, nan=0.0, posinf=float("inf"), neginf=float("-inf")
+    ).clamp(min=-bound, max=bound)
+
+
+def _e2m1_rne_scaled_torch(x: torch.Tensor, denominator: torch.Tensor):
+    """Encode x/denominator using midpoint comparisons, without reciprocal.
+
+    Strict/non-strict comparisons alternate at the seven E2M1 midpoints to
+    implement round-to-nearest-even exactly.  Reciprocal multiplication is not
+    equivalent at exact ties because it can move the value by one FP32 ULP.
+    """
+
+    magnitude = x.abs()
+    code = (
+        (magnitude > denominator * 0.25).to(torch.uint8)
+        + (magnitude >= denominator * 0.75).to(torch.uint8)
+        + (magnitude > denominator * 1.25).to(torch.uint8)
+        + (magnitude >= denominator * 1.75).to(torch.uint8)
+        + (magnitude > denominator * 2.5).to(torch.uint8)
+        + (magnitude >= denominator * 3.5).to(torch.uint8)
+        + (magnitude > denominator * 5.0).to(torch.uint8)
+    )
+    code |= torch.signbit(x).to(torch.uint8) << 3
+    return torch.where(denominator > 0, code, torch.zeros_like(code))
+
+
+def _decode_e2m1_torch(code: torch.Tensor):
+    lut = torch.tensor(
+        [
+            0.0,
+            0.5,
+            1.0,
+            1.5,
+            2.0,
+            3.0,
+            4.0,
+            6.0,
+            -0.0,
+            -0.5,
+            -1.0,
+            -1.5,
+            -2.0,
+            -3.0,
+            -4.0,
+            -6.0,
+        ],
+        dtype=torch.float32,
+        device=code.device,
+    )
+    return lut[code.long()]
+
+
+def quantize_nvfp4_k_cache_into_reference(
+    k_nope: torch.Tensor,
+    k_rope: torch.Tensor,
+    kv_buffer: torch.Tensor,
+    loc: torch.Tensor,
+    global_scale: torch.Tensor | Real,
+) -> None:
+    """Bit-exact PyTorch reference for the mixed DSA row writer."""
+
+    k_nope, k_rope, rows, loc = _validate_quant_inputs(k_nope, k_rope, kv_buffer, loc)
+    if loc.numel() == 0:
+        return
+    g = _as_global_scale(global_scale, rows.device)
+    blocks = _sanitize_nonfinite_torch(k_nope.float(), g).reshape(
+        -1, _NUM_LATENT_BLOCKS, NVFP4_BLOCK_SIZE
+    )
+    scale = (blocks.abs().amax(-1) / (_E2M1_MAX * g)).clamp(0, _E4M3_MAX)
+    scale_fp8 = scale.to(torch.float8_e4m3fn)
+    denominator = scale_fp8.float().unsqueeze(-1) * g
+    codes = _e2m1_rne_scaled_torch(blocks, denominator).reshape(-1, NVFP4_LATENT_DIM)
+    packed = codes[:, 0::2] | (codes[:, 1::2] << 4)
+    rope = torch.nan_to_num(
+        k_rope.float(),
+        nan=0.0,
+        posinf=torch.finfo(torch.bfloat16).max,
+        neginf=torch.finfo(torch.bfloat16).min,
+    )
+    rope_bytes = rope.to(torch.bfloat16).contiguous().view(torch.uint8)
+
+    valid = (loc >= 0) & (loc < rows.shape[0])
+    if not bool(valid.any()):
+        return
+    dst = loc[valid].long()
+    rows[dst, :NVFP4_PACKED_LATENT_BYTES] = packed[valid]
+    rows[
+        dst,
+        NVFP4_PACKED_LATENT_BYTES : NVFP4_PACKED_LATENT_BYTES + NVFP4_SCALE_BYTES,
+    ] = scale_fp8[valid].contiguous().view(torch.uint8)
+    rows[dst, -NVFP4_ROPE_BYTES:] = rope_bytes[valid]
+
+
+def dequantize_nvfp4_k_cache_paged_reference(
+    kv_buffer: torch.Tensor,
+    indices: torch.Tensor,
+    global_scale: torch.Tensor | Real,
+    dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    """Gather and decode rows using the exact stored bytes as the reference."""
+
+    allowed = (torch.bfloat16, torch.float16, torch.float32, torch.float8_e4m3fn)
+    if dtype not in allowed:
+        raise ValueError(f"unsupported output dtype: {dtype}")
+    rows = _as_cache_rows(kv_buffer)
+    indices = indices.reshape(-1)
+    if indices.dtype not in (torch.int32, torch.int64):
+        raise TypeError("indices must be int32 or int64")
+    if indices.device != rows.device:
+        raise ValueError("indices and cache must be on one device")
+    output = torch.zeros(
+        (indices.numel(), 1, NVFP4_LATENT_DIM + NVFP4_ROPE_DIM),
+        dtype=dtype,
+        device=rows.device,
+    )
+    if indices.numel() == 0:
+        return output
+    valid = (indices >= 0) & (indices < rows.shape[0])
+    if not bool(valid.any()):
+        return output
+    selected = rows[indices[valid].long()]
+    packed = selected[:, :NVFP4_PACKED_LATENT_BYTES]
+    codes = torch.empty(
+        (selected.shape[0], NVFP4_LATENT_DIM), dtype=torch.uint8, device=rows.device
+    )
+    codes[:, 0::2] = packed & 0x0F
+    codes[:, 1::2] = packed >> 4
+    scales = (
+        selected[
+            :,
+            NVFP4_PACKED_LATENT_BYTES : NVFP4_PACKED_LATENT_BYTES + NVFP4_SCALE_BYTES,
+        ]
+        .contiguous()
+        .view(torch.float8_e4m3fn)
+        .float()
+    )
+    g = _as_global_scale(global_scale, rows.device)
+    latent = (
+        _decode_e2m1_torch(codes).reshape(-1, _NUM_LATENT_BLOCKS, NVFP4_BLOCK_SIZE)
+        * scales.unsqueeze(-1)
+        * g
+    ).reshape(-1, NVFP4_LATENT_DIM)
+    rope = selected[:, -NVFP4_ROPE_BYTES:].contiguous().view(torch.bfloat16)
+    output[valid, 0, :NVFP4_LATENT_DIM] = latent.to(dtype)
+    output[valid, 0, NVFP4_LATENT_DIM:] = rope.to(dtype)
+    return output
+
+
+@triton.jit
+def _e2m1_rne_scaled_triton(x, denominator):
+    magnitude = tl.abs(x)
+    code = (
+        (magnitude > denominator * 0.25).to(tl.uint8)
+        + (magnitude >= denominator * 0.75).to(tl.uint8)
+        + (magnitude > denominator * 1.25).to(tl.uint8)
+        + (magnitude >= denominator * 1.75).to(tl.uint8)
+        + (magnitude > denominator * 2.5).to(tl.uint8)
+        + (magnitude >= denominator * 3.5).to(tl.uint8)
+        + (magnitude > denominator * 5.0).to(tl.uint8)
+    )
+    sign = ((x.to(tl.uint32, bitcast=True) >> 31).to(tl.uint8)) << 3
+    return tl.where(denominator > 0, code | sign, 0).to(tl.uint8)
+
+
+@triton.jit
+def _decode_e2m1_triton(code):
+    magnitude_code = code & 0x07
+    magnitude = tl.where(
+        magnitude_code == 0,
+        0.0,
+        tl.where(
+            magnitude_code == 1,
+            0.5,
+            tl.where(
+                magnitude_code == 2,
+                1.0,
+                tl.where(
+                    magnitude_code == 3,
+                    1.5,
+                    tl.where(
+                        magnitude_code == 4,
+                        2.0,
+                        tl.where(
+                            magnitude_code == 5,
+                            3.0,
+                            tl.where(magnitude_code == 6, 4.0, 6.0),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+    return tl.where((code & 0x08) != 0, -magnitude, magnitude)
+
+
+@triton.jit
+def _quantize_nvfp4_k_cache_into_kernel(
+    k_nope_ptr,
+    k_rope_ptr,
+    rows_ptr,
+    loc_ptr,
+    global_scale_ptr,
+    num_rows,
+    k_nope_stride: tl.constexpr,
+    k_rope_stride: tl.constexpr,
+    row_stride: tl.constexpr,
+    NUM_LATENT_BLOCKS: tl.constexpr,
+    PACKED_BYTES: tl.constexpr,
+    SCALE_BYTES: tl.constexpr,
+    ROPE_DIM: tl.constexpr,
+    BLOCKS_PER_PROGRAM: tl.constexpr,
+):
+    token = tl.program_id(0)
+    part = tl.program_id(1)
+    dst = tl.load(loc_ptr + token).to(tl.int64)
+    valid_dst = (dst >= 0) & (dst < num_rows)
+    safe_dst = tl.where(valid_dst, dst, 0)
+    g = tl.load(global_scale_ptr).to(tl.float32)
+
+    block = part * BLOCKS_PER_PROGRAM + tl.arange(0, BLOCKS_PER_PROGRAM)
+    lane = tl.arange(0, 16)
+    valid_block = block < NUM_LATENT_BLOCKS
+    offsets = block[:, None] * 16 + lane[None, :]
+    x = tl.load(
+        k_nope_ptr + token * k_nope_stride + offsets,
+        mask=valid_dst & valid_block[:, None],
+        other=0.0,
+    ).to(tl.float32)
+    # E2M1FN has no non-finite encoding: NaN -> +0, Inf -> recipe maximum.
+    bound = 6.0 * 448.0 * g
+    x = tl.where(
+        x != x,  # noqa: PLR0124  # Triton NaN test
+        0.0,
+        tl.maximum(tl.minimum(x, bound), -bound),
+    )
+    scale = tl.clamp(tl.max(tl.abs(x), axis=1) / (6.0 * g), 0.0, 448.0)
+    scale_fp8 = scale.to(tl.float8e4nv)
+    denominator = tl.expand_dims(scale_fp8.to(tl.float32) * g, 1)
+    codes = _e2m1_rne_scaled_triton(x, denominator)
+    pairs = tl.reshape(codes, (BLOCKS_PER_PROGRAM, 8, 2))
+    low, high = tl.split(pairs)
+    byte = tl.arange(0, 8)
+    tl.store(
+        rows_ptr + safe_dst * row_stride + block[:, None] * 8 + byte[None, :],
+        low | (high << 4),
+        mask=valid_dst & valid_block[:, None],
+    )
+    tl.store(
+        rows_ptr + safe_dst * row_stride + PACKED_BYTES + block,
+        scale_fp8.to(tl.uint8, bitcast=True),
+        mask=valid_dst & valid_block,
+    )
+
+    if part == tl.cdiv(NUM_LATENT_BLOCKS, BLOCKS_PER_PROGRAM) - 1:
+        rope_offset = tl.arange(0, ROPE_DIM)
+        rope = tl.load(
+            k_rope_ptr + token * k_rope_stride + rope_offset,
+            mask=valid_dst,
+            other=0.0,
+        ).to(tl.float32)
+        rope = tl.where(
+            rope != rope,  # noqa: PLR0124  # Triton NaN test
+            0.0,
+            tl.maximum(tl.minimum(rope, 3.3895313892515355e38), -3.3895313892515355e38),
+        ).to(tl.bfloat16)
+        rope_bits = rope.to(tl.uint16, bitcast=True)
+        tl.store(
+            rows_ptr
+            + safe_dst * row_stride
+            + PACKED_BYTES
+            + SCALE_BYTES
+            + 2 * rope_offset,
+            rope_bits & 0xFF,
+            mask=valid_dst,
+        )
+        tl.store(
+            rows_ptr
+            + safe_dst * row_stride
+            + PACKED_BYTES
+            + SCALE_BYTES
+            + 2 * rope_offset
+            + 1,
+            rope_bits >> 8,
+            mask=valid_dst,
+        )
+
+
+def quantize_nvfp4_k_cache_into(
+    k_nope: torch.Tensor,
+    k_rope: torch.Tensor,
+    kv_buffer: torch.Tensor,
+    loc: torch.Tensor,
+    global_scale: torch.Tensor | Real,
+) -> None:
+    """Quantize and scatter DSA keys into the 416-byte mixed cache rows."""
+
+    k_nope, k_rope, rows, loc = _validate_quant_inputs(k_nope, k_rope, kv_buffer, loc)
+    if loc.numel() == 0:
+        return
+    scale = _as_global_scale(global_scale, rows.device)
+    if not rows.is_cuda:
+        quantize_nvfp4_k_cache_into_reference(k_nope, k_rope, rows, loc, scale)
+        return
+    blocks_per_program = 8 if loc.numel() <= _QUANTIZE_SMALL_BATCH_THRESHOLD else 32
+    num_warps = 1 if blocks_per_program == 8 else 4
+    parts = triton.cdiv(_NUM_LATENT_BLOCKS, blocks_per_program)
+    _quantize_nvfp4_k_cache_into_kernel[(loc.numel(), parts)](
+        k_nope,
+        k_rope,
+        rows,
+        loc,
+        scale,
+        rows.shape[0],
+        k_nope.stride(0),
+        k_rope.stride(0),
+        rows.stride(0),
+        NUM_LATENT_BLOCKS=_NUM_LATENT_BLOCKS,
+        PACKED_BYTES=NVFP4_PACKED_LATENT_BYTES,
+        SCALE_BYTES=NVFP4_SCALE_BYTES,
+        ROPE_DIM=NVFP4_ROPE_DIM,
+        BLOCKS_PER_PROGRAM=blocks_per_program,
+        num_warps=num_warps,
+    )
+
+
+def dequantize_nvfp4_k_cache_paged(
+    kv_buffer: torch.Tensor,
+    indices: torch.Tensor,
+    global_scale: torch.Tensor | Real,
+    dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    """Gather NVFP4 rows and decode them with one allocation and one kernel.
+
+    Production decode consumes the packed cache directly.  The current
+    FlashMLA sparse-prefill compatibility path calls this helper only for the
+    selected prefix rows; cache inspection, copy/offload validation, and
+    backend-attribution benchmarks also use it.  Keeping gather and decode
+    fused avoids the large chain of temporary tensors created by the bit-exact
+    PyTorch reference.
+    """
+
+    if dtype not in (torch.bfloat16, torch.float16, torch.float32):
+        raise ValueError(f"unsupported production dequant dtype: {dtype}")
+    rows = _as_cache_rows(kv_buffer)
+    flat_indices = indices.reshape(-1)
+    if flat_indices.dtype not in (torch.int32, torch.int64):
+        raise TypeError("indices must be int32 or int64")
+    if flat_indices.device != rows.device:
+        raise ValueError("indices and cache must be on one device")
+    output = torch.empty(
+        (flat_indices.numel(), 1, NVFP4_LATENT_DIM + NVFP4_ROPE_DIM),
+        dtype=dtype,
+        device=rows.device,
+    )
+    if flat_indices.numel() == 0:
+        return output
+    scale = _as_global_scale(global_scale, rows.device)
+    _dequantize_nvfp4_k_cache_paged_kernel[(flat_indices.numel(),)](
+        rows,
+        flat_indices,
+        scale,
+        output,
+        rows.shape[0],
+        rows.stride(0),
+        output.stride(0),
+        BLOCK=1024,
+        num_warps=4,
+    )
+    return output
+
+
+@triton.jit
+def _dequantize_nvfp4_k_cache_paged_kernel(
+    rows_ptr,
+    indices_ptr,
+    global_scale_ptr,
+    output_ptr,
+    num_rows,
+    row_stride: tl.constexpr,
+    output_stride: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    token = tl.program_id(0)
+    dimension = tl.arange(0, BLOCK)
+    physical = tl.load(indices_ptr + token).to(tl.int64)
+    valid_row = (physical >= 0) & (physical < num_rows)
+    safe_physical = tl.where(valid_row, physical, 0)
+    row = rows_ptr + safe_physical * row_stride
+
+    latent_mask = (dimension < 512) & valid_row
+    packed = tl.load(
+        row + dimension // 2,
+        mask=latent_mask,
+        other=0,
+    ).to(tl.uint8)
+    code = tl.where((dimension & 1) == 0, packed & 0x0F, packed >> 4)
+    scale_bits = tl.load(
+        row + 256 + dimension // 16,
+        mask=latent_mask,
+        other=0,
+    ).to(tl.uint8)
+    block_scale = scale_bits.to(tl.float8e4nv, bitcast=True).to(tl.float32)
+    global_scale = tl.load(global_scale_ptr).to(tl.float32)
+    latent = _decode_e2m1_triton(code) * block_scale * global_scale
+
+    rope_dimension = dimension - 512
+    rope_mask = (dimension >= 512) & (dimension < 576) & valid_row
+    rope_low = tl.load(
+        row + 288 + 2 * rope_dimension,
+        mask=rope_mask,
+        other=0,
+    ).to(tl.uint8)
+    rope_high = tl.load(
+        row + 288 + 2 * rope_dimension + 1,
+        mask=rope_mask,
+        other=0,
+    ).to(tl.uint8)
+    rope_bits = rope_low.to(tl.uint16) | (rope_high.to(tl.uint16) << 8)
+    rope = rope_bits.to(tl.bfloat16, bitcast=True).to(tl.float32)
+    value = tl.where(dimension < 512, latent, rope)
+    tl.store(
+        output_ptr + token * output_stride + dimension,
+        value,
+        mask=dimension < 576,
+    )
+
+
+__all__ = [
+    "NVFP4_BLOCK_SIZE",
+    "NVFP4_BYTES_PER_TOKEN",
+    "NVFP4_LATENT_DIM",
+    "NVFP4_PACKED_LATENT_BYTES",
+    "NVFP4_ROPE_BYTES",
+    "NVFP4_ROPE_DIM",
+    "NVFP4_SCALE_BYTES",
+    "dequantize_nvfp4_k_cache_paged",
+    "dequantize_nvfp4_k_cache_paged_reference",
+    "quantize_nvfp4_k_cache_into",
+    "quantize_nvfp4_k_cache_into_reference",
+]

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -316,6 +316,10 @@ class DeepseekSparseAttnBackend(
         self.dsa_kv_cache_store_fp8 = (
             model_runner.token_to_kv_pool.dsa_kv_cache_store_fp8
         )
+        self.dsa_kv_cache_store_nvfp4 = getattr(
+            model_runner.token_to_kv_pool, "dsa_kv_cache_store_nvfp4", False
+        )
+        self.dsa_kv_cache_store_packed_fp4 = self.dsa_kv_cache_store_nvfp4
         self.dsa_index_topk = get_dsa_index_topk(model_runner.model_config.hf_config)
         self.max_context_len = model_runner.model_config.context_len
         self.num_q_heads = (
@@ -340,7 +344,9 @@ class DeepseekSparseAttnBackend(
         self.dsa_topk_backend: DSATopKBackend = DSATopKBackend(
             model_runner.server_args.dsa_topk_backend
         )
-        if self.num_q_heads <= 64:
+        if self.dsa_kv_cache_store_packed_fp4:
+            self.flashmla_kv_num_q_heads = self.num_q_heads
+        elif self.num_q_heads <= 64:
             self.flashmla_kv_num_q_heads = 64
         elif self.num_q_heads <= 128:
             self.flashmla_kv_num_q_heads = 128
@@ -402,6 +408,49 @@ class DeepseekSparseAttnBackend(
         self.device_capability = torch.cuda.get_device_capability()
         self.device_sm_major = self.device_capability[0]
         self.kv_cache_dtype = model_runner.kv_cache_dtype
+
+        if self.dsa_kv_cache_store_packed_fp4:
+            expected = {
+                "device_sm_major": (self.device_sm_major, 10),
+                "local_q_heads": (self.num_q_heads, 64),
+                "kv_lora_rank": (self.kv_lora_rank, 512),
+                "qk_rope_head_dim": (self.qk_rope_head_dim, 64),
+                "index_topk": (self.dsa_index_topk, 2048),
+                "page_size": (self.real_page_size, 64),
+            }
+            mismatches = [
+                f"{name}={actual} (expected {wanted})"
+                for name, (actual, wanted) in expected.items()
+                if actual != wanted
+            ]
+            if mismatches:
+                raise ValueError(
+                    "GLM-5.2 SM100 NVFP4 DSA native kernel shape mismatch: "
+                    + ", ".join(mismatches)
+                )
+            if self.dsa_decode_impl != "flashmla_kv":
+                raise ValueError(
+                    "GLM-5.2 SM100 NVFP4 DSA requires "
+                    "--dsa-decode-backend=flashmla_kv"
+                )
+            if self.dsa_prefill_impl != "flashmla_sparse":
+                raise ValueError(
+                    "GLM-5.2 SM100 NVFP4 DSA requires "
+                    "--dsa-prefill-backend=flashmla_sparse"
+                )
+            # Importing the wrapper also loads flashmla_ops.  Fail at backend
+            # construction, rather than during graph capture, when a wheel was
+            # built without the native SM100 specialization.
+            from sgl_kernel.flash_mla import flash_mla_with_kvcache_nvfp4
+
+            del flash_mla_with_kvcache_nvfp4
+            required_op = "sparse_decode_fwd_nvfp4"
+            if not hasattr(torch.ops.sgl_kernel, required_op):
+                raise RuntimeError(
+                    f"sglang-kernel is missing {required_op}; rebuild "
+                    "the SM100 flashmla_ops extension from this source tree"
+                )
+            logger.info("Enabled GLM-5.2 SM100 NVFP4-to-BF16 fused FlashMLA decode")
 
         # `flashmla_sparse_q8` = the native FP8 SM90 sparse-prefill kernel. It always
         # runs FP8 (requires fp8_e4m3 KV) and is SM90-only, so validate both at
@@ -2109,9 +2158,23 @@ class DeepseekSparseAttnBackend(
                         self.forward_metadata.page_table_1_flattened
                     )
                     assert page_table_1_flattened is not None
-                    kv_cache = dequantize_k_cache_paged(
-                        kv_cache, page_table_1_flattened
-                    )
+                    if self.dsa_kv_cache_store_nvfp4:
+                        from sglang.srt.layers.attention.dsa.nvfp4_k_cache import (
+                            dequantize_nvfp4_k_cache_paged,
+                        )
+
+                        kv_cache = dequantize_nvfp4_k_cache_paged(
+                            kv_cache,
+                            page_table_1_flattened,
+                            self.token_to_kv_pool.get_mla_kv_global_scale(
+                                layer.layer_id
+                            ),
+                            dtype=torch.bfloat16,
+                        )
+                    else:
+                        kv_cache = dequantize_k_cache_paged(
+                            kv_cache, page_table_1_flattened
+                        )
                 else:
                     kv_cache = _cat([k, k_rope], dim=-1)
 
@@ -2399,12 +2462,17 @@ class DeepseekSparseAttnBackend(
     ) -> torch.Tensor:
         from sgl_kernel.flash_mla import flash_mla_sparse_fwd
 
-        # FlashMLA sparse kernel requires num_heads to be a multiple of 64 (Hopper) or 128 (Blackwell)
-        # When using TP, num_heads might be smaller (e.g., 256//8=32)
+        # With attention DP, every GLM-5.2 decode rank owns all 64 Q heads.
+        # Select the matching H64 sparse-prefill specialization rather than
+        # padding to the generic Blackwell H128 path.
         num_tokens, num_heads, head_dim = q_all.shape
 
         # Determine required padding based on GPU architecture (use cached value)
-        required_padding = 128 if self.device_sm_major >= 10 else 64
+        required_padding = (
+            64
+            if self.dsa_kv_cache_store_packed_fp4
+            else (128 if self.device_sm_major >= 10 else 64)
+        )
 
         need_padding = num_heads % required_padding != 0
 
@@ -2808,7 +2876,40 @@ class DeepseekSparseAttnBackend(
 
         # TODO the 2nd dim is seq_len_q, need to be >1 when MTP
         q_all = q_all.view(-1, 1, layer.tp_q_head_num, layer.head_dim)
+        q_input = q_all
         num_q_heads = q_all.shape[2]
+
+        if self.dsa_kv_cache_store_nvfp4:
+            from sgl_kernel.flash_mla import flash_mla_with_kvcache_nvfp4
+
+            if num_q_heads != 64:
+                raise ValueError(
+                    f"native GLM-5.2 NVFP4 decode requires Hq=64, got {num_q_heads}"
+                )
+            packed_kv = kv_cache.view(-1, self.real_page_size, 1, self.kv_cache_dim)
+            indices = page_table_1.unsqueeze(1).contiguous()
+            # `_compute_flashmla_metadata` builds the persistent graph schedule
+            # for the full 2048 slots, matching the existing FP8 path.  Passing
+            # a shorter topk_length with that schedule can leave a partition's
+            # scheduled start block beyond its runtime end block.  The kernel
+            # masks padded `-1` indices before any cache load, so retaining the
+            # fixed-width schedule is both safe and graph-stable.
+            topk_length = None
+            global_scale = self.token_to_kv_pool.get_mla_kv_global_scale(layer.layer_id)
+            o, _, _, _ = flash_mla_with_kvcache_nvfp4(
+                q=q_input,
+                k_cache=packed_kv,
+                kv_global_scale=global_scale,
+                indices=indices,
+                topk_length=topk_length,
+                attn_sink=None,
+                head_dim_v=v_head_dim,
+                tile_scheduler_metadata=metadata.flashmla_metadata.flashmla_metadata,
+                num_splits=metadata.flashmla_metadata.num_splits,
+                softmax_scale=sm_scale,
+            )
+            return o
+
         target_q_heads = self.flashmla_kv_num_q_heads
         if target_q_heads != num_q_heads:
             # Pad q heads to match FlashMLA decode supported head-count variants.
@@ -3369,7 +3470,7 @@ class DeepseekSparseAttnBackend(
         """
         if (
             # disable for MTP
-            self.dsa_kv_cache_store_fp8
+            (self.dsa_kv_cache_store_fp8 or self.dsa_kv_cache_store_packed_fp4)
             # flashmla_sparse_q8 shares flashmla_sparse's RAGGED prefill routing — the q8
             # dispatch lives inside the RAGGED branch of forward_extend; without this the
             # transform is PAGED, the q8 path is skipped, and the bf16 kernel crashes on

--- a/python/sglang/srt/mem_cache/dsa_cache_layer_split.py
+++ b/python/sglang/srt/mem_cache/dsa_cache_layer_split.py
@@ -433,11 +433,16 @@ class LayerSplitDSATokenToKVPool(DSATokenToKVPool):
         remote_kv_updatable = self.remote_kv_layer_id == layer_id
         if remote_kv_updatable:
             self._write_mla_kv_buffer(
-                self.remote_kv_buffer, loc, cache_k_nope, cache_k_rope
+                layer_id,
+                self.remote_kv_buffer,
+                loc,
+                cache_k_nope,
+                cache_k_rope,
             )
         if not self._is_layer_owned(layer_id):
             return
         self._write_mla_kv_buffer(
+            layer_id,
             self.kv_buffer[layer_id - self.start_layer],
             loc,
             cache_k_nope,

--- a/python/sglang/srt/mem_cache/index_key_cache.py
+++ b/python/sglang/srt/mem_cache/index_key_cache.py
@@ -53,7 +53,13 @@ class IndexKeyCache:
         for index_k in self.buffer:
             if index_k.shape[0] == 0:
                 continue
-            index_k[tgt_loc_flat] = index_k[src_loc_flat]
+            # The indexer cache is page-packed as [pages, page_size * row_bytes],
+            # while move_kv_cache receives physical token locations.  Flatten
+            # pages back to token rows before indexing; treating token locations
+            # as page indices fails as soon as a location exceeds num_pages.
+            row_bytes = index_k.shape[1] // self.pool.page_size
+            token_rows = index_k.view(-1, row_bytes)
+            token_rows[tgt_loc_flat] = token_rows[src_loc_flat]
 
     def get_local_buffer(self, layer_id: int) -> torch.Tensor:
         if self.pool.layer_transfer_counter is not None:

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -27,6 +27,9 @@ from sglang.srt.configs.model_config import (
 from sglang.srt.distributed.parallel_state import get_world_group
 from sglang.srt.distributed.utils import get_pp_indices
 from sglang.srt.environ import envs
+from sglang.srt.layers.attention.dsa.nvfp4_k_cache import (
+    NVFP4_BYTES_PER_TOKEN as DSA_NVFP4_BYTES_PER_TOKEN,
+)
 from sglang.srt.layers.quantization.fp4_kv_cache_quant_method import (
     get_kv_cache_quant_method,
     resolve_kv_cache_quant,
@@ -1356,7 +1359,48 @@ class KVCacheConfigurator:
             index_head_dim=get_dsa_index_head_dim(self.model_config.hf_config),
             **pool_kwargs,
         )
+        if getattr(token_to_kv_pool, "dsa_kv_cache_store_nvfp4", False):
+            self._load_dsa_nvfp4_global_scales(token_to_kv_pool)
         return token_to_kv_pool
+
+    def _load_dsa_nvfp4_global_scales(self, pool: DSATokenToKVPool) -> None:
+        """Copy calibrated per-layer K scales into the persistent NVFP4 pool."""
+
+        from sglang.srt.model_loader.utils import resolve_language_model
+
+        language_model = resolve_language_model(self.model)
+        layers = getattr(language_model, "layers", None)
+        if layers is None:
+            decoder = getattr(language_model, "decoder", None)
+            layers = [] if decoder is None else [decoder]
+
+        initialized = 0
+        for model_layer in layers:
+            attention = None
+            if hasattr(model_layer, "self_attn"):
+                self_attn = model_layer.self_attn
+                attention = getattr(
+                    self_attn, "attn", getattr(self_attn, "attn_mqa", None)
+                )
+            elif hasattr(model_layer, "attn"):
+                attention = model_layer.attn
+            elif hasattr(model_layer, "attention"):
+                attention = getattr(model_layer.attention, "attn", None)
+            if attention is None or not hasattr(attention, "layer_id"):
+                continue
+            layer_id = attention.layer_id
+            if not pool.start_layer <= layer_id < pool.start_layer + pool.layer_num:
+                continue
+            scale = getattr(attention, "k_scale_float", None)
+            if scale is None:
+                scale = getattr(attention, "k_scale", None)
+            pool.set_mla_kv_global_scale(layer_id, 1.0 if scale is None else scale)
+            initialized += 1
+        logger.info(
+            "Initialized DSA NVFP4 global scales for %d/%d local layers",
+            initialized,
+            pool.layer_num,
+        )
 
     def _build_mla_fp4_kv_pool(self, *, max_total_num_tokens: int) -> KVCache:
         token_to_kv_pool = MLATokenToKVPoolFP4(
@@ -2151,6 +2195,19 @@ def calculate_mla_kv_cache_dim(
     # For non-DSA models, MLA kv cache dim is simply kv_lora_rank + qk_rope_head_dim
     if not is_dsa_model:
         return kv_cache_dim
+
+    if is_float4_e2m1fn_x2(kv_cache_dtype):
+        if server_args.kv_cache_dtype != "nvfp4":
+            raise ValueError(
+                "DSA FP4 KV cache requires --kv-cache-dtype=nvfp4; "
+                f"got {server_args.kv_cache_dtype}"
+            )
+        if kv_lora_rank != 512 or qk_rope_head_dim != 64:
+            raise ValueError(
+                "DSA packed FP4 is specialized for GLM-5.2 QK=512+64, got "
+                f"{kv_lora_rank=} and {qk_rope_head_dim=}"
+            )
+        return DSA_NVFP4_BYTES_PER_TOKEN
 
     # TRTLLM backend does not override kv_cache_dim for MLA kv cache
     # Assuming dsa prefill and decode backends are the same when using trtllm MLA backend,

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -52,6 +52,11 @@ from sglang.kernels.ops.quantization.fp8_kernel import fp8_dtype, is_fp8_fnuz
 from sglang.srt.configs.mamba_utils import BaseLinearStateParams
 from sglang.srt.constants import GPU_MEMORY_TYPE_KV_CACHE
 from sglang.srt.environ import envs
+from sglang.srt.layers.attention.dsa.nvfp4_k_cache import (
+    NVFP4_BYTES_PER_TOKEN as DSA_NVFP4_BYTES_PER_TOKEN,
+    dequantize_nvfp4_k_cache_paged,
+    quantize_nvfp4_k_cache_into,
+)
 from sglang.srt.layers.attention.dsa.utils import aiter_can_use_preshuffle_paged_mqa
 from sglang.srt.layers.quantization.fp4_kv_cache_quant_method import (
     UnquantizedKVCacheMethod,
@@ -3964,11 +3969,35 @@ class MLATokenToKVPool(KVCache):
             and dtype == torch.float8_e4m3fn
             and override_kv_cache_dim is not None
         )
+        self.dsa_kv_cache_store_nvfp4 = (
+            use_dsa
+            and is_float4_e2m1fn_x2(dtype)
+            and override_kv_cache_dim == DSA_NVFP4_BYTES_PER_TOKEN
+        )
+        self.dsa_kv_cache_store_packed_fp4 = self.dsa_kv_cache_store_nvfp4
+        if (
+            use_dsa
+            and is_float4_e2m1fn_x2(dtype)
+            and override_kv_cache_dim is not None
+            and not self.dsa_kv_cache_store_packed_fp4
+        ):
+            raise ValueError(
+                "Unsupported DSA packed FP4 cache row: "
+                f"override_kv_cache_dim={override_kv_cache_dim}"
+            )
+        if self.dsa_kv_cache_store_packed_fp4:
+            if kv_lora_rank != 512 or qk_rope_head_dim != 64:
+                raise ValueError(
+                    "DSA packed FP4 requires kv_lora_rank=512 and "
+                    f"qk_rope_head_dim=64, got {kv_lora_rank=} and "
+                    f"{qk_rope_head_dim=}"
+                )
+            self.store_dtype = torch.uint8
         # When override_kv_cache_dim is provided with dsa model, we assume the
         # override kv cache dim is correct and use it directly.
         self.kv_cache_dim = (
             override_kv_cache_dim
-            if self.dsa_kv_cache_store_fp8
+            if self.dsa_kv_cache_store_fp8 or self.dsa_kv_cache_store_packed_fp4
             else (kv_lora_rank + qk_rope_head_dim)
         )
 
@@ -3999,6 +4028,13 @@ class MLATokenToKVPool(KVCache):
                     )
                     for _ in range(self.layer_num)
                 ]
+        if self.dsa_kv_cache_store_nvfp4 and not hasattr(self, "mla_kv_global_scale"):
+            # CUDA graphs capture this address and every encoded row depends on
+            # its value, so keep the per-layer scales outside discardable KV
+            # allocation regions.
+            self.mla_kv_global_scale = torch.ones(
+                self.layer_num, dtype=torch.float32, device=self.device
+            )
 
     def _clear_buffers(self):
         del self.kv_buffer
@@ -4008,6 +4044,8 @@ class MLATokenToKVPool(KVCache):
         kv_size_bytes = 0
         for kv_cache in self.kv_buffer:
             kv_size_bytes += get_tensor_size_bytes(kv_cache)
+        if hasattr(self, "mla_kv_global_scale"):
+            kv_size_bytes += get_tensor_size_bytes(self.mla_kv_global_scale)
         return kv_size_bytes
 
     # for disagg
@@ -4024,6 +4062,8 @@ class MLATokenToKVPool(KVCache):
         if self.layer_transfer_counter is not None:
             self.layer_transfer_counter.wait_until(layer_id - self.start_layer)
 
+        if self.dsa_kv_cache_store_packed_fp4:
+            return self.kv_buffer[layer_id - self.start_layer]
         if self.store_dtype != self.dtype:
             return self.kv_buffer[layer_id - self.start_layer].view(self.dtype)
 
@@ -4033,6 +4073,10 @@ class MLATokenToKVPool(KVCache):
         if self.layer_transfer_counter is not None:
             self.layer_transfer_counter.wait_until(layer_id - self.start_layer)
 
+        if self.dsa_kv_cache_store_packed_fp4:
+            # MLA aliases K and V in one latent row.  The fused consumer reads
+            # the same packed row for QK and PV.
+            return self.kv_buffer[layer_id - self.start_layer]
         if self.store_dtype != self.dtype:
             return self.kv_buffer[layer_id - self.start_layer][
                 ..., : self.kv_lora_rank
@@ -4041,6 +4085,40 @@ class MLATokenToKVPool(KVCache):
 
     def get_kv_buffer(self, layer_id: int):
         return self.get_key_buffer(layer_id), self.get_value_buffer(layer_id)
+
+    def get_mla_kv_global_scale(self, layer_id: int) -> torch.Tensor:
+        if not self.dsa_kv_cache_store_nvfp4:
+            raise RuntimeError("NVFP4 global scale requested from a non-NVFP4 pool")
+        index = layer_id - self.start_layer
+        if not 0 <= index < self.layer_num:
+            raise IndexError(
+                f"layer_id={layer_id} is outside [{self.start_layer}, "
+                f"{self.start_layer + self.layer_num})"
+            )
+        return self.mla_kv_global_scale[index : index + 1]
+
+    def set_mla_kv_global_scale(
+        self, layer_id: int, scale: Union[float, torch.Tensor]
+    ) -> None:
+        dst = self.get_mla_kv_global_scale(layer_id)
+        value = (
+            float(scale.detach().float().item())
+            if isinstance(scale, torch.Tensor)
+            else float(scale)
+        )
+        if not math.isfinite(value) or value <= 0:
+            raise ValueError(
+                f"DSA NVFP4 global scale must be finite and positive, got {value}"
+            )
+        dst.fill_(value)
+
+    def get_raw_mla_kv_buffer(self, layer_id: int) -> dict[str, torch.Tensor]:
+        if self.dsa_kv_cache_store_nvfp4:
+            return {
+                "kv": self.get_key_buffer(layer_id),
+                "global_scale": self.get_mla_kv_global_scale(layer_id),
+            }
+        raise RuntimeError("raw packed FP4 row requested from an unpacked pool")
 
     def set_kv_buffer(
         self,
@@ -4053,6 +4131,7 @@ class MLATokenToKVPool(KVCache):
         maybe_detect_oob(loc, 0, self.size + self.page_size, "set_kv_buffer (MLA)")
         layer_id = layer.layer_id
         assert not self.dsa_kv_cache_store_fp8
+        assert not self.dsa_kv_cache_store_packed_fp4
         parallel = get_parallel()
         if parallel.dcp_enabled:
             valid_mask = loc % parallel.attn_dcp_size == parallel.attn_dcp_rank
@@ -4071,12 +4150,21 @@ class MLATokenToKVPool(KVCache):
 
     def _write_mla_kv_buffer(
         self,
+        layer_id: int,
         dst_buffer: torch.Tensor,
         loc: torch.Tensor,
         cache_k_nope: torch.Tensor,
         cache_k_rope: torch.Tensor,
     ) -> None:
-        if _is_hip and self.use_dsa and self.dtype == fp8_dtype:
+        if self.dsa_kv_cache_store_nvfp4:
+            quantize_nvfp4_k_cache_into(
+                cache_k_nope,
+                cache_k_rope,
+                dst_buffer,
+                loc,
+                self.get_mla_kv_global_scale(layer_id),
+            )
+        elif _is_hip and self.use_dsa and self.dtype == fp8_dtype:
             # HIP FP8 path uses raw MLA KV layout (nope + rope) without per-block scales.
             # Fuse BF16/FP16 -> FP8 cast with paged KV write.
             set_mla_kv_buffer_triton_fp8_quant(
@@ -4134,6 +4222,7 @@ class MLATokenToKVPool(KVCache):
         )
         layer_id = layer.layer_id
         self._write_mla_kv_buffer(
+            layer_id,
             self.kv_buffer[layer_id - self.start_layer],
             loc,
             cache_k_nope,
@@ -4148,6 +4237,17 @@ class MLATokenToKVPool(KVCache):
     ):
         # get k nope and k rope from the kv buffer, and optionally cast them to dst_dtype.
         layer_id = layer.layer_id
+        if self.dsa_kv_cache_store_nvfp4:
+            decoded = dequantize_nvfp4_k_cache_paged(
+                self.get_key_buffer(layer_id),
+                loc,
+                self.get_mla_kv_global_scale(layer_id),
+                dtype=dst_dtype or torch.bfloat16,
+            )
+            return (
+                decoded[..., : self.kv_lora_rank],
+                decoded[..., self.kv_lora_rank :],
+            )
         kv_buffer = self.get_key_buffer(layer_id)
         dst_dtype = dst_dtype or self.dtype
         cache_k_nope = torch.empty(

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -31,6 +31,9 @@ from sglang.srt.configs.model_config import (
     is_minimax_sparse,
 )
 from sglang.srt.environ import envs
+from sglang.srt.layers.attention.dsa.nvfp4_k_cache import (
+    NVFP4_BYTES_PER_TOKEN as DSA_NVFP4_BYTES_PER_TOKEN,
+)
 from sglang.srt.mem_cache.allocation_sizing import get_alloc_len_per_decode
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import (
     get_compress_state_ring_size,
@@ -254,16 +257,27 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
                 calculate_mla_kv_cache_dim,
             )
 
-            cell_size = (
-                calculate_mla_kv_cache_dim(
-                    model_config=model_config,
-                    kv_cache_dtype=kv_cache_dtype,
-                    server_args=kvc.server_args,
-                )
-                * effective_num_layers
-                * kv_size
+            is_dsa_model = is_deepseek_dsa(model_config.hf_config)
+            is_dsa_packed_fp4 = (
+                is_dsa_model
+                and is_float4_e2m1fn_x2(kv_cache_dtype)
+                and kvc.server_args.kv_cache_dtype == "nvfp4"
             )
-            if is_float4_e2m1fn_x2(kv_cache_dtype):
+            if is_dsa_packed_fp4:
+                # The DSA row is already expressed in raw bytes.  Do not
+                # apply the generic FP4 half-byte adjustment a second time.
+                cell_size = DSA_NVFP4_BYTES_PER_TOKEN * effective_num_layers
+            else:
+                cell_size = (
+                    calculate_mla_kv_cache_dim(
+                        model_config=model_config,
+                        kv_cache_dtype=kv_cache_dtype,
+                        server_args=kvc.server_args,
+                    )
+                    * effective_num_layers
+                    * kv_size
+                )
+            if is_float4_e2m1fn_x2(kv_cache_dtype) and not is_dsa_model:
                 # kv_scale_buffer
                 scale_block_size = 16
                 cell_size = (cell_size // 2) + (
@@ -276,7 +290,7 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
                 )
 
             # Add indexer KV cache overhead for DSA models (DeepSeek V3.2)
-            if is_deepseek_dsa(model_config.hf_config):
+            if is_dsa_model:
                 cell_size += self._compute_dsa_indexer_cell_size(
                     kvc=kvc,
                     num_layers=num_layers,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -6099,6 +6099,7 @@ class ServerArgs:
                     if use_mla_backend:  # !FA4 + MLA
                         KV4_ATTENTION_MLA_BACKEND_CHOICES = [
                             "cutlass_mla",
+                            "dsa",
                             "flashinfer",
                             "trtllm_mla",
                         ]

--- a/test/registered/cp/test_cp_strategy_unit.py
+++ b/test/registered/cp/test_cp_strategy_unit.py
@@ -1149,6 +1149,78 @@ class TestCPInterleaveStrategy(CustomTestCase):
         self.assertTrue(torch.equal(full_k_nope, full_latent[:, :3].unsqueeze(1)))
         self.assertTrue(torch.equal(full_k_rope, full_latent[:, 3:].unsqueeze(1)))
 
+    def test_interleave_materialized_glm_kv_writes_identical_nvfp4_rows(self):
+        from sglang.srt.layers.attention.dsa.nvfp4_k_cache import (
+            NVFP4_BYTES_PER_TOKEN,
+            quantize_nvfp4_k_cache_into_reference,
+        )
+
+        cp_size = 4
+        total_tokens = 65
+        generator = torch.Generator().manual_seed(20260827)
+        k_nope = torch.randn(
+            total_tokens, 1, 512, generator=generator, dtype=torch.bfloat16
+        )
+        k_rope = torch.randn(
+            total_tokens, 1, 64, generator=generator, dtype=torch.bfloat16
+        )
+        full_latent = torch.cat([k_nope, k_rope], dim=-1).squeeze(1)
+        metas, rank_tensors = self._rank_tensors(
+            full_latent,
+            cp_size=cp_size,
+            seq_lens=[total_tokens],
+            extend_seq_lens=[total_tokens],
+        )
+        physical_rank_len = max(tensor.shape[0] for tensor in rank_tensors)
+        padded_rank_tensors = []
+        for tensor in rank_tensors:
+            padded = tensor.new_zeros((physical_rank_len, tensor.shape[1]))
+            padded[: tensor.shape[0]] = tensor
+            padded_rank_tensors.append(padded)
+
+        # Use a non-contiguous physical-location order to verify that the
+        # gathered logical token order remains aligned with out_cache_loc.
+        loc = torch.arange(total_tokens, dtype=torch.int64).roll(17)
+        reference_rows = torch.zeros(
+            total_tokens, 1, NVFP4_BYTES_PER_TOKEN, dtype=torch.uint8
+        )
+        quantize_nvfp4_k_cache_into_reference(
+            k_nope, k_rope, reference_rows, loc, global_scale=1.375
+        )
+
+        for rank in range(cp_size):
+            fb = self._forward_batch(metas[rank], [total_tokens])
+            local = rank_tensors[rank]
+            with (
+                get_parallel().override(
+                    attn_cp_rank=rank,
+                    attn_cp_size=cp_size,
+                ),
+                self._patch_interleave_all_gather(padded_rank_tensors),
+                patch(
+                    "sglang.srt.layers.cp.interleave.torch.cuda.current_stream",
+                    return_value=None,
+                ),
+            ):
+                full_k_nope, full_k_rope = InterleaveCPStrategy(
+                    cp_size=cp_size
+                ).materialize_full_mla_kv(
+                    fb,
+                    object(),
+                    local[:, :512].unsqueeze(1),
+                    local[:, 512:].unsqueeze(1),
+                )
+
+            actual_rows = torch.zeros_like(reference_rows)
+            quantize_nvfp4_k_cache_into_reference(
+                full_k_nope,
+                full_k_rope,
+                actual_rows,
+                loc,
+                global_scale=1.375,
+            )
+            self.assertTrue(torch.equal(actual_rows, reference_rows))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/kernels/ops/attention/test_dsa_indexer.py
+++ b/test/registered/kernels/ops/attention/test_dsa_indexer.py
@@ -1,4 +1,5 @@
 import unittest
+from types import SimpleNamespace
 from typing import List, Optional, Tuple
 from unittest.mock import MagicMock, patch
 
@@ -1124,6 +1125,128 @@ class TestDSAIndexer(CustomTestCase):
                     backend.decode_cuda_graph_metadata["page_table"] is None,
                     should_use_topk_v2,
                 )
+
+    def test_nvfp4_prefill_uses_ragged_indices_for_materialized_prefix(self):
+        backend = object.__new__(DeepseekSparseAttnBackend)
+        backend.dsa_kv_cache_store_fp8 = False
+        backend.dsa_kv_cache_store_nvfp4 = True
+        backend.dsa_kv_cache_store_packed_fp4 = True
+        backend.dsa_prefill_impl = "flashmla_sparse"
+        self.assertEqual(
+            backend.get_topk_transform_method(ForwardMode.EXTEND),
+            TopkTransformMethod.RAGGED,
+        )
+
+        # The legacy FP8 sparse-prefill fallback materializes a logical
+        # contiguous cache and therefore still requires RAGGED offsets.
+        backend.dsa_kv_cache_store_fp8 = True
+        backend.dsa_kv_cache_store_nvfp4 = False
+        backend.dsa_kv_cache_store_packed_fp4 = False
+        self.assertEqual(
+            backend.get_topk_transform_method(ForwardMode.EXTEND),
+            TopkTransformMethod.RAGGED,
+        )
+
+    def test_nvfp4_flashmla_dispatch_keeps_packed_cache(self):
+        backend = object.__new__(DeepseekSparseAttnBackend)
+        backend.dsa_kv_cache_store_nvfp4 = True
+        backend.real_page_size = 64
+        backend.kv_cache_dim = 416
+        global_scale = torch.tensor([1.375], device=self.device)
+        backend.token_to_kv_pool = MagicMock()
+        backend.token_to_kv_pool.get_mla_kv_global_scale.return_value = global_scale
+
+        q = torch.randn(2, 64, 576, dtype=torch.bfloat16, device=self.device)
+        packed_kv = torch.zeros(64, 1, 416, dtype=torch.uint8, device=self.device)
+        indices = torch.zeros(2, 2048, dtype=torch.int32, device=self.device)
+        lengths = torch.full((2,), 2048, dtype=torch.int32, device=self.device)
+        scheduler_metadata = torch.zeros(1, 8, dtype=torch.int32, device=self.device)
+        num_splits = torch.ones(3, dtype=torch.int32, device=self.device)
+        metadata = SimpleNamespace(
+            dsa_cache_seqlens_int32=lengths,
+            flashmla_metadata=SimpleNamespace(
+                flashmla_metadata=scheduler_metadata,
+                num_splits=num_splits,
+            ),
+        )
+        layer = SimpleNamespace(
+            tp_q_head_num=64,
+            head_dim=576,
+            layer_id=0,
+        )
+        output = torch.zeros(2, 1, 64, 512, dtype=torch.bfloat16, device=self.device)
+
+        with patch(
+            "sgl_kernel.flash_mla.flash_mla_with_kvcache_nvfp4",
+            return_value=(output, None, None, None),
+            create=True,
+        ) as fused:
+            actual = backend._forward_flashmla_kv(
+                q_all=q,
+                kv_cache=packed_kv,
+                v_head_dim=512,
+                sm_scale=1.0,
+                layer=layer,
+                metadata=metadata,
+                page_table_1=indices,
+            )
+
+        self.assertIs(actual, output)
+        kwargs = fused.call_args.kwargs
+        self.assertEqual(kwargs["q"].dtype, torch.bfloat16)
+        self.assertEqual(kwargs["q"].shape, (2, 1, 64, 576))
+        self.assertEqual(kwargs["k_cache"].shape, (1, 64, 1, 416))
+        self.assertEqual(kwargs["k_cache"].data_ptr(), packed_kv.data_ptr())
+        self.assertEqual(kwargs["indices"].shape, (2, 1, 2048))
+        self.assertIsNone(kwargs["topk_length"])
+        self.assertIs(kwargs["kv_global_scale"], global_scale)
+
+    def test_nvfp4_dsa_pool_moves_main_and_index_cache_together(self):
+        fp4_dtype = getattr(torch, "float4_e2m1fn_x2", None)
+        if fp4_dtype is None:
+            self.skipTest("torch build does not expose float4_e2m1fn_x2")
+        pool = DSATokenToKVPool(
+            size=128,
+            page_size=64,
+            kv_lora_rank=512,
+            dtype=fp4_dtype,
+            qk_rope_head_dim=64,
+            layer_num=2,
+            device=self.device,
+            index_head_dim=128,
+            enable_memory_saver=False,
+            kv_cache_dim=416,
+        )
+        source = torch.tensor([3, 7], dtype=torch.int64, device=self.device)
+        target = torch.tensor([9, 11], dtype=torch.int64, device=self.device)
+        for layer in range(pool.layer_num):
+            pool.kv_buffer[layer][source] = layer + 17
+            index_buffer = pool.index_k_with_scale_buffer[layer]
+            row_bytes = index_buffer.shape[1] // pool.page_size
+            index_rows = index_buffer.view(-1, row_bytes)
+            index_rows[source] = layer + 29
+        expected_main = [buffer[source].clone() for buffer in pool.kv_buffer]
+        expected_index = [
+            buffer.view(-1, buffer.shape[1] // pool.page_size)[source].clone()
+            for buffer in pool.index_k_with_scale_buffer
+        ]
+
+        pool.move_kv_cache(target, source)
+
+        for layer in range(pool.layer_num):
+            self.assertTrue(
+                torch.equal(pool.kv_buffer[layer][target], expected_main[layer])
+            )
+            self.assertTrue(
+                torch.equal(
+                    pool.index_k_with_scale_buffer[layer].view(
+                        -1,
+                        pool.index_k_with_scale_buffer[layer].shape[1]
+                        // pool.page_size,
+                    )[target],
+                    expected_index[layer],
+                )
+            )
 
     # TODO: enable this test after indexer accuracy aligned
     # @patch("sglang.srt.layers.attention.dsa.dsa_indexer.deep_gemm")

--- a/test/registered/unit/disaggregation/test_specv2_kvcache_offloading.py
+++ b/test/registered/unit/disaggregation/test_specv2_kvcache_offloading.py
@@ -9,7 +9,7 @@ Requires: torch, sglang (run in an environment with sglang installed)
 
 import unittest
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import torch
 
@@ -18,6 +18,7 @@ from sglang.srt.disaggregation.decode_kvcache_offload_manager import (
 )
 from sglang.srt.disaggregation.kv_events import OffloadedState
 from sglang.srt.managers.cache_controller import HiCacheAck
+from sglang.srt.mem_cache.memory_pool import MLATokenToKVPool
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=8, suite="base-a-test-cpu")
@@ -76,6 +77,52 @@ def _make_manager(pool_size: int, page_size: int = 1):
 class _FinishedEvent:
     def synchronize(self):
         pass
+
+
+class TestDecodeOffloadHostPool(unittest.TestCase):
+    def test_mla_host_pool_preserves_device_row_width(self):
+        kv_cache = object.__new__(MLATokenToKVPool)
+        kv_cache.kv_cache_dim = 416
+        allocator = MagicMock()
+        allocator.get_kvcache.return_value = kv_cache
+        server_args = SimpleNamespace(
+            page_size=64,
+            hicache_ratio=2.0,
+            hicache_size=0,
+            hicache_mem_layout="layer_first",
+            hicache_storage_backend_extra_config=None,
+            hicache_io_backend="kernel",
+            hicache_storage_backend=None,
+            served_model_name="test",
+        )
+
+        with (
+            patch(
+                "sglang.srt.disaggregation.decode_kvcache_offload_manager."
+                "build_kv_host_pool"
+            ) as build_host_pool,
+            patch(
+                "sglang.srt.disaggregation.decode_kvcache_offload_manager."
+                "HiCacheController"
+            ),
+            patch(
+                "sglang.srt.disaggregation.decode_kvcache_offload_manager."
+                "get_schedule",
+                return_value=SimpleNamespace(page_size=64),
+            ),
+            patch("torch.distributed.get_world_size", return_value=1),
+        ):
+            DecodeKVCacheOffloadManager(
+                req_to_token_pool=MagicMock(),
+                token_to_kv_pool_allocator=allocator,
+                tp_group=MagicMock(),
+                tree_cache=MagicMock(),
+                server_args=server_args,
+            )
+
+        self.assertEqual(
+            build_host_pool.call_args.kwargs["override_kv_cache_dim"], 416
+        )
 
 
 class TestReleaseFinishedReq(unittest.TestCase):

--- a/test/registered/unit/layers/attention/test_dsa_nvfp4_k_cache.py
+++ b/test/registered/unit/layers/attention/test_dsa_nvfp4_k_cache.py
@@ -1,0 +1,280 @@
+import importlib.util
+import math
+from pathlib import Path
+
+import pytest
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci, register_cuda_ci
+
+# CPU CI exercises the bit-exact codec/reference contract. The CUDA
+# registration targets Blackwell because the writer, 200K chunk chain, and
+# native FP4 dtype are part of the SM100 production path.
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+register_cuda_ci(
+    est_time=60,
+    stage="base-b-kernel-unit",
+    runner_config="4-gpu-b200",
+)
+
+
+def _load_codec_module():
+    codec_path = (
+        Path(__file__).resolve().parents[5]
+        / "python/sglang/srt/layers/attention/dsa/nvfp4_k_cache.py"
+    )
+    spec = importlib.util.spec_from_file_location("dsa_nvfp4_k_cache_test", codec_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_CODEC = _load_codec_module()
+NVFP4_BYTES_PER_TOKEN = _CODEC.NVFP4_BYTES_PER_TOKEN
+NVFP4_LATENT_DIM = _CODEC.NVFP4_LATENT_DIM
+NVFP4_PACKED_LATENT_BYTES = _CODEC.NVFP4_PACKED_LATENT_BYTES
+NVFP4_ROPE_BYTES = _CODEC.NVFP4_ROPE_BYTES
+NVFP4_ROPE_DIM = _CODEC.NVFP4_ROPE_DIM
+NVFP4_SCALE_BYTES = _CODEC.NVFP4_SCALE_BYTES
+dequantize_nvfp4_k_cache_paged_reference = (
+    _CODEC.dequantize_nvfp4_k_cache_paged_reference
+)
+dequantize_nvfp4_k_cache_paged = _CODEC.dequantize_nvfp4_k_cache_paged
+quantize_nvfp4_k_cache_into = _CODEC.quantize_nvfp4_k_cache_into
+quantize_nvfp4_k_cache_into_reference = _CODEC.quantize_nvfp4_k_cache_into_reference
+
+
+def _make_inputs(num_tokens: int, dtype=torch.float32, device="cpu"):
+    generator = torch.Generator(device=device).manual_seed(42)
+    latent = torch.randn(
+        num_tokens,
+        1,
+        NVFP4_LATENT_DIM,
+        generator=generator,
+        dtype=torch.float32,
+        device=device,
+    ).to(dtype)
+    rope = torch.randn(
+        num_tokens,
+        1,
+        NVFP4_ROPE_DIM,
+        generator=generator,
+        dtype=torch.float32,
+        device=device,
+    ).to(dtype)
+    return latent, rope
+
+
+def _unpack_codes(row: torch.Tensor):
+    packed = row[:NVFP4_PACKED_LATENT_BYTES]
+    codes = torch.empty(NVFP4_LATENT_DIM, dtype=torch.uint8)
+    codes[0::2] = packed & 0x0F
+    codes[1::2] = packed >> 4
+    return codes
+
+
+def test_layout_and_dsa_byte_accounting():
+    assert NVFP4_BYTES_PER_TOKEN == 256 + 32 + 128 == 416
+    assert NVFP4_PACKED_LATENT_BYTES == 256
+    assert NVFP4_SCALE_BYTES == 32
+    assert NVFP4_ROPE_BYTES == 128
+
+    # Existing DSA indexer storage is 128 E4M3 values + one FP32 scale.
+    indexer_bytes = 128 + 4
+    assert NVFP4_BYTES_PER_TOKEN + indexer_bytes == 548
+    # TRTLLM-GEN stores the full 576-dimensional key as raw E4M3.
+    assert 576 + indexer_bytes == 708
+    assert math.isclose(708 / 548, 1.291970802919708, rel_tol=0, abs_tol=1e-15)
+    # Open FlashMLA stores 512 E4M3 latent bytes, four FP32 scales, and
+    # 64 BF16 RoPE values, for a 656-byte main row.
+    assert 656 + indexer_bytes == 788
+    assert math.isclose(788 / 548, 1.437956204379562, rel_tol=0, abs_tol=1e-15)
+
+
+@pytest.mark.parametrize("global_scale", [0.03125, 0.5, 1.0, 1.375])
+@pytest.mark.parametrize("input_dtype", [torch.bfloat16, torch.float16, torch.float32])
+def test_reference_roundtrip_uses_stored_bytes(global_scale, input_dtype):
+    latent, rope = _make_inputs(5, input_dtype)
+    rows = torch.zeros(8, 1, NVFP4_BYTES_PER_TOKEN, dtype=torch.uint8)
+    loc = torch.tensor([6, 1, 4, 0, 3], dtype=torch.int64)
+    quantize_nvfp4_k_cache_into_reference(latent, rope, rows, loc, global_scale)
+
+    decoded = dequantize_nvfp4_k_cache_paged_reference(
+        rows, loc.to(torch.int32), global_scale, torch.float32
+    )
+    stored_rope = rows[loc, 0, -NVFP4_ROPE_BYTES:].contiguous().view(torch.bfloat16)
+    torch.testing.assert_close(
+        decoded[..., NVFP4_LATENT_DIM:].squeeze(1),
+        stored_rope.float(),
+        rtol=0,
+        atol=0,
+    )
+    assert torch.isfinite(decoded).all()
+
+
+def test_midpoint_rne_signed_zero_and_scale_before_code():
+    latent = torch.zeros(1, 1, NVFP4_LATENT_DIM, dtype=torch.float32)
+    # amax=6 makes the rounded block scale exactly 1 when global_scale=1.
+    latent[0, 0, :9] = torch.tensor([-0.0, 0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5.0, 6.0])
+    rope = torch.zeros(1, 1, NVFP4_ROPE_DIM)
+    rows = torch.zeros(1, 1, NVFP4_BYTES_PER_TOKEN, dtype=torch.uint8)
+    quantize_nvfp4_k_cache_into_reference(
+        latent, rope, rows, torch.tensor([0], dtype=torch.int32), 1.0
+    )
+    codes = _unpack_codes(rows[0, 0])
+    assert codes[:9].tolist() == [8, 0, 2, 2, 4, 4, 6, 6, 7]
+    scale = rows[0, 0, 256:288].contiguous().view(torch.float8_e4m3fn)
+    assert scale[0].float().item() == 1.0
+
+
+def test_zero_block_nonfinite_policy_and_invalid_locations():
+    latent = torch.zeros(4, 1, NVFP4_LATENT_DIM, dtype=torch.float32)
+    rope = torch.zeros(4, 1, NVFP4_ROPE_DIM, dtype=torch.float32)
+    latent[1, 0, :4] = torch.tensor([float("nan"), float("inf"), -float("inf"), 1.0])
+    rope[1, 0, :3] = torch.tensor([float("nan"), float("inf"), -float("inf")])
+    rows = torch.full((4, 1, NVFP4_BYTES_PER_TOKEN), 0xA5, dtype=torch.uint8)
+    before = rows.clone()
+    loc = torch.tensor([0, 2, -1, 4], dtype=torch.int64)
+    quantize_nvfp4_k_cache_into_reference(latent, rope, rows, loc, 0.5)
+
+    # Invalid destinations are screened before access and do not mutate rows.
+    assert torch.equal(rows[1], before[1])
+    assert torch.equal(rows[3], before[3])
+    assert _unpack_codes(rows[0, 0]).eq(0).all()
+    decoded = dequantize_nvfp4_k_cache_paged_reference(
+        rows, torch.tensor([2, -1, 4]), 0.5, torch.float32
+    )
+    assert torch.isfinite(decoded).all()
+    assert decoded[1:].eq(0).all()
+    assert decoded[0, 0, NVFP4_LATENT_DIM : NVFP4_LATENT_DIM + 3].tolist() == [
+        0.0,
+        torch.finfo(torch.bfloat16).max,
+        torch.finfo(torch.bfloat16).min,
+    ]
+
+
+@pytest.mark.parametrize("num_tokens", [0, 1, 31, 32, 33, 63, 64, 65, 1024])
+def test_cpu_reference_token_boundaries(num_tokens):
+    latent, rope = _make_inputs(num_tokens)
+    rows = torch.zeros(max(1, num_tokens), 1, NVFP4_BYTES_PER_TOKEN, dtype=torch.uint8)
+    loc = torch.arange(num_tokens, dtype=torch.int32)
+    quantize_nvfp4_k_cache_into_reference(latent, rope, rows, loc, 1.375)
+    decoded = dequantize_nvfp4_k_cache_paged_reference(rows, loc, 1.375)
+    assert decoded.shape == (num_tokens, 1, 576)
+
+
+def test_duplicate_location_with_identical_value_is_deterministic():
+    latent, rope = _make_inputs(1)
+    latent = latent.expand(2, -1, -1).contiguous()
+    rope = rope.expand(2, -1, -1).contiguous()
+    rows = torch.zeros(2, 1, NVFP4_BYTES_PER_TOKEN, dtype=torch.uint8)
+    quantize_nvfp4_k_cache_into_reference(latent, rope, rows, torch.tensor([1, 1]), 1.0)
+    expected = torch.zeros_like(rows)
+    quantize_nvfp4_k_cache_into_reference(
+        latent[:1], rope[:1], expected, torch.tensor([1]), 1.0
+    )
+    assert torch.equal(rows, expected)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.parametrize("num_tokens", [1, 31, 32, 33, 64, 65, 1024])
+def test_cuda_writer_is_bit_exact_to_cpu_reference(num_tokens):
+    latent, rope = _make_inputs(num_tokens, torch.bfloat16, "cuda")
+    loc = torch.randperm(num_tokens, device="cuda", dtype=torch.int64)
+    cuda_rows = torch.zeros(
+        num_tokens, 1, NVFP4_BYTES_PER_TOKEN, dtype=torch.uint8, device="cuda"
+    )
+    quantize_nvfp4_k_cache_into(latent, rope, cuda_rows, loc, 1.375)
+    torch.cuda.synchronize()
+
+    reference = torch.zeros_like(cuda_rows, device="cpu")
+    quantize_nvfp4_k_cache_into_reference(
+        latent.cpu(), rope.cpu(), reference, loc.cpu(), 1.375
+    )
+    assert torch.equal(cuda_rows.cpu(), reference)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.parametrize("output_dtype", [torch.bfloat16, torch.float16, torch.float32])
+def test_cuda_paged_dequant_matches_stored_byte_reference(output_dtype):
+    latent, rope = _make_inputs(65, torch.bfloat16, "cuda")
+    rows = torch.zeros(65, 1, NVFP4_BYTES_PER_TOKEN, dtype=torch.uint8, device="cuda")
+    locations = torch.arange(65, dtype=torch.int64, device="cuda")
+    quantize_nvfp4_k_cache_into(latent, rope, rows, locations, 1.375)
+    indices = torch.tensor([64, 1, 63, 1, -1, 65, 0], dtype=torch.int32, device="cuda")
+    actual = dequantize_nvfp4_k_cache_paged(rows, indices, 1.375, dtype=output_dtype)
+    expected = dequantize_nvfp4_k_cache_paged_reference(
+        rows, indices, 1.375, dtype=output_dtype
+    )
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.parametrize(
+    "chunk_size,expected_full_chunks",
+    [(8192, 24), (16384, 12), (32768, 6)],
+)
+def test_cuda_chunked_200k_chain_matches_one_shot(chunk_size, expected_full_chunks):
+    """Chunk boundaries must not change the final 200K physical cache bytes."""
+
+    num_tokens = 200_000
+    tail = num_tokens % chunk_size
+    assert tail == 3392
+    assert num_tokens // chunk_size == expected_full_chunks
+
+    generator = torch.Generator(device="cuda").manual_seed(20260810 + chunk_size)
+    latent = torch.randn(
+        num_tokens,
+        1,
+        NVFP4_LATENT_DIM,
+        generator=generator,
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+    rope = torch.randn(
+        num_tokens,
+        1,
+        NVFP4_ROPE_DIM,
+        generator=generator,
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+    locations = torch.arange(num_tokens, dtype=torch.int64, device="cuda")
+    one_shot = torch.zeros(
+        num_tokens,
+        1,
+        NVFP4_BYTES_PER_TOKEN,
+        dtype=torch.uint8,
+        device="cuda",
+    )
+    chunked = torch.zeros_like(one_shot)
+
+    quantize_nvfp4_k_cache_into(latent, rope, one_shot, locations, global_scale=1.375)
+    starts = list(range(0, num_tokens, chunk_size))
+    assert len(starts) == expected_full_chunks + 1
+    for start in starts:
+        end = min(start + chunk_size, num_tokens)
+        quantize_nvfp4_k_cache_into(
+            latent[start:end],
+            rope[start:end],
+            chunked,
+            locations[start:end],
+            global_scale=1.375,
+        )
+    torch.cuda.synchronize()
+    assert torch.equal(chunked, one_shot)
+
+
+@pytest.mark.parametrize("scale", [0.0, -1.0, float("nan"), float("inf")])
+def test_invalid_global_scale_rejected(scale):
+    latent, rope = _make_inputs(1)
+    rows = torch.zeros(1, 1, NVFP4_BYTES_PER_TOKEN, dtype=torch.uint8)
+    with pytest.raises(ValueError):
+        quantize_nvfp4_k_cache_into_reference(
+            latent, rope, rows, torch.tensor([0]), scale
+        )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/mem_cache/test_dsa_layer_shard_utils.py
+++ b/test/registered/unit/mem_cache/test_dsa_layer_shard_utils.py
@@ -118,6 +118,38 @@ class TestDSALayerShardUtils(CustomTestCase):
             self.assertTrue(torch.equal(buf, owner_kv[layer_id]))
             self.assertEqual(pool.remote_kv_layer_id, layer_id)
 
+    def test_mla_write_forwards_layer_id_to_base_writer(self):
+        writes = []
+        layer_id = 7
+        loc = torch.tensor([1], dtype=torch.int64)
+        nope = torch.zeros(1, 1, 8)
+        rope = torch.zeros(1, 1, 2)
+        local_buffer = torch.empty(2, 1, 10)
+
+        def write(actual_layer_id, dst, actual_loc, actual_nope, actual_rope):
+            writes.append((actual_layer_id, dst, actual_loc, actual_nope, actual_rope))
+
+        pool = SimpleNamespace(
+            size=1,
+            page_size=1,
+            start_layer=layer_id,
+            pending_remote_kv_layer_id=None,
+            remote_kv_layer_id=None,
+            kv_buffer=[local_buffer],
+            _is_layer_owned=lambda _: True,
+            _write_mla_kv_buffer=write,
+        )
+        layer = SimpleNamespace(layer_id=layer_id)
+
+        LayerSplitDSATokenToKVPool.set_mla_kv_buffer(pool, layer, loc, nope, rope)
+
+        self.assertEqual(len(writes), 1)
+        self.assertEqual(writes[0][0], layer_id)
+        self.assertIs(writes[0][1], local_buffer)
+        self.assertIs(writes[0][2], loc)
+        self.assertIs(writes[0][3], nope)
+        self.assertIs(writes[0][4], rope)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/mem_cache/test_dsa_pool_host_unit.py
+++ b/test/registered/unit/mem_cache/test_dsa_pool_host_unit.py
@@ -3,6 +3,7 @@ import unittest
 
 import torch
 
+from sglang.srt.layers.attention.dsa.nvfp4_k_cache import NVFP4_BYTES_PER_TOKEN
 from sglang.srt.mem_cache.memory_pool import DSATokenToKVPool
 from sglang.srt.mem_cache.memory_pool_host import DSAIndexerPoolHost
 from sglang.srt.mem_cache.pool_host.common import (
@@ -47,21 +48,43 @@ class TestDSAHiCacheTransfer(unittest.TestCase):
         ]
         return torch.cat(parts, dim=0)
 
-    def _run_device_to_host_indexer_copy(self, io_backend: str):
+    def _run_device_to_host_indexer_copy(
+        self,
+        io_backend: str,
+        *,
+        packed_fp4_format: str | None = None,
+    ):
         page_size = 1 if is_hip() else 64
         layer_num = 2
         size = page_size * 4
+        if packed_fp4_format is not None:
+            if is_hip():
+                self.skipTest("DSA packed FP4 host transfer is only supported on CUDA.")
+            fp4_dtype = getattr(torch, "float4_e2m1fn_x2", None)
+            if fp4_dtype is None:
+                self.skipTest("PyTorch does not expose torch.float4_e2m1fn_x2.")
+            kv_lora_rank = 512
+            qk_rope_head_dim = 64
+            if packed_fp4_format != "nvfp4":
+                raise ValueError(f"unsupported packed FP4 format: {packed_fp4_format}")
+            kv_cache_dim = NVFP4_BYTES_PER_TOKEN
+            dtype = fp4_dtype
+        else:
+            kv_lora_rank = 128
+            qk_rope_head_dim = 32
+            kv_cache_dim = 576
+            dtype = torch.bfloat16
 
         device_pool = DSATokenToKVPool(
             size=size,
             page_size=page_size,
-            kv_lora_rank=128,
-            dtype=torch.bfloat16,
-            qk_rope_head_dim=32,
+            kv_lora_rank=kv_lora_rank,
+            dtype=dtype,
+            qk_rope_head_dim=qk_rope_head_dim,
             layer_num=layer_num,
             device="cuda",
             enable_memory_saver=False,
-            kv_cache_dim=576,
+            kv_cache_dim=kv_cache_dim,
             index_head_dim=128,
         )
         pin_memory = io_backend == "kernel"
@@ -91,17 +114,25 @@ class TestDSAHiCacheTransfer(unittest.TestCase):
         finally:
             ALLOC_MEMORY_FUNCS["cuda"] = original_alloc
 
+        if packed_fp4_format is not None:
+            self.assertEqual(mla_host.kv_cache_dim, kv_cache_dim)
+        self.assertEqual(mla_host.dtype, device_pool.store_dtype)
+
         for layer_id in range(layer_num):
             buf = device_pool.index_k_with_scale_buffer[layer_id]
             data = torch.arange(
-                buf.numel(), device=buf.device, dtype=torch.uint8
+                buf.numel(), device=buf.device, dtype=torch.int64
             ).view_as(buf)
-            buf.copy_((data + layer_id) % 256)
+            buf.copy_(((data + layer_id) % 251).to(buf.dtype))
             kv_buf = device_pool.kv_buffer[layer_id]
             kv_data = torch.arange(
-                kv_buf.numel(), device=kv_buf.device, dtype=kv_buf.dtype
+                kv_buf.numel(), device=kv_buf.device, dtype=torch.int64
             ).view_as(kv_buf)
-            kv_buf.copy_(kv_data + layer_id)
+            if kv_buf.dtype == torch.uint8:
+                kv_data = ((kv_data + layer_id) % 251).to(kv_buf.dtype)
+            else:
+                kv_data = kv_data.to(kv_buf.dtype) + layer_id
+            kv_buf.copy_(kv_data)
 
         device_pages = torch.tensor([1, 2, 3], device="cuda", dtype=torch.int64)
         host_pages = torch.tensor(
@@ -144,6 +175,49 @@ class TestDSAHiCacheTransfer(unittest.TestCase):
                 ].cpu()
                 self.assertTrue(torch.equal(got_kv, expected_kv))
 
+        # Exercise the reverse transfer too.  The latent KV and the indexer
+        # sidecar must both survive a HiCache round trip; testing only D2H can
+        # hide a host layout that the H2D path interprets with another stride.
+        for layer_id in range(layer_num):
+            device_pool.kv_buffer[layer_id][device_indices].zero_()
+            page_indices = device_indices.reshape(-1, page_size)[:, 0] // page_size
+            device_pool.index_k_with_scale_buffer[layer_id][page_indices].zero_()
+            mla_host.load_to_device_per_layer(
+                device_pool,
+                host_indices,
+                device_indices,
+                layer_id,
+                io_backend,
+            )
+            indexer_host.load_to_device_per_layer(
+                device_pool,
+                host_indices,
+                device_indices,
+                layer_id,
+                io_backend,
+            )
+
+        for layer_id in range(layer_num):
+            for host_page, device_page in zip(
+                host_pages.tolist(), device_pages.tolist()
+            ):
+                host_start = host_page * page_size
+                device_start = device_page * page_size
+                got_kv = device_pool.kv_buffer[layer_id][
+                    device_start : device_start + page_size
+                ].cpu()
+                expected_kv = mla_host.kv_buffer[layer_id][
+                    host_start : host_start + page_size
+                ].cpu()
+                self.assertTrue(torch.equal(got_kv, expected_kv))
+                got_indexer = device_pool.index_k_with_scale_buffer[layer_id][
+                    device_page
+                ].cpu()
+                expected_indexer = indexer_host.index_k_with_scale_buffer[layer_id][
+                    host_page
+                ].cpu()
+                self.assertTrue(torch.equal(got_indexer, expected_indexer))
+
     @unittest.skipIf(
         is_hip(),
         '`io_backend="kernel"` path in MLATokenToKVPoolHost.backup_from_device_all_layer '
@@ -161,6 +235,16 @@ class TestDSAHiCacheTransfer(unittest.TestCase):
     )
     def test_device_to_host_indexer_direct(self):
         self._run_device_to_host_indexer_copy(io_backend="direct")
+
+    def test_nvfp4_device_to_host_indexer_kernel(self):
+        self._run_device_to_host_indexer_copy(
+            io_backend="kernel", packed_fp4_format="nvfp4"
+        )
+
+    def test_nvfp4_device_to_host_indexer_direct(self):
+        self._run_device_to_host_indexer_copy(
+            io_backend="direct", packed_fp4_format="nvfp4"
+        )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1586,6 +1586,28 @@ class TestPrefillOnlyDisableKvCache(unittest.TestCase):
                     self._validate_prefill_only_args(kv_cache_dtype=kv_cache_dtype)
 
 
+class TestKv4Compatibility(unittest.TestCase):
+    def test_dsa_nvfp4_is_allowed_by_generic_mla_gate(self):
+        args = ServerArgs(
+            model_path="dummy",
+            attention_backend="dsa",
+            kv_cache_dtype="nvfp4",
+        )
+        with (
+            patch.object(args, "use_mla_backend", return_value=True),
+            patch.object(
+                args,
+                "_resolved_attention_backends",
+                return_value=("dsa", "dsa"),
+            ),
+            patch.object(server_args_module, "is_cuda", return_value=True),
+            patch.object(
+                server_args_module, "is_sm100_supported", return_value=True
+            ),
+        ):
+            args._handle_kv4_compatibility()
+
+
 class TestCudaGraphConfigDataclassAccess(CustomTestCase):
     @patch(
         "sglang.srt.model_executor.runner_backend."

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -1157,6 +1157,7 @@ class TestGoldenModelOverrides(_IsolatedPublish):
                 dsa_prefill_backend=None,
                 dsa_decode_backend=None,
                 enable_hisparse=False,
+                page_size=64,
             )
             defaults.update(kw)
             return ResolvedView(
@@ -1205,6 +1206,60 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             self.assertEqual(
                 _dsa_split_backend_resolution(_view(arch="LlamaForCausalLM")), {}
             )
+        with (
+            patch("sglang.srt.configs.model_config.is_deepseek_dsa", return_value=True),
+            patch.object(overrides_module, "is_npu", return_value=False),
+            patch.object(overrides_module, "is_xpu", return_value=False),
+            patch.object(overrides_module, "is_hip", return_value=False),
+            patch("torch.cuda.get_device_capability", return_value=(10, 0)),
+        ):
+            self.assertEqual(
+                _dsa_split_backend_resolution(
+                    _view(
+                        arch="GlmMoeDsaForCausalLM",
+                        kv_cache_dtype="nvfp4",
+                    )
+                ),
+                {
+                    "dsa_prefill_backend": "flashmla_sparse",
+                    "dsa_decode_backend": "flashmla_kv",
+                },
+            )
+            self.assertEqual(
+                _dsa_split_backend_resolution(
+                    _view(
+                        arch="GlmMoeDsaForCausalLM",
+                        kv_cache_dtype="nvfp4",
+                        dsa_prefill_backend="flashmla_sparse",
+                        dsa_decode_backend="flashmla_kv",
+                    )
+                ),
+                {},
+            )
+            with self.assertRaisesRegex(ValueError, "page-size=64"):
+                _dsa_split_backend_resolution(
+                    _view(
+                        arch="GlmMoeDsaForCausalLM",
+                        kv_cache_dtype="nvfp4",
+                        page_size=32,
+                    )
+                )
+            with self.assertRaisesRegex(ValueError, "prefill-backend=flashmla_sparse"):
+                _dsa_split_backend_resolution(
+                    _view(
+                        arch="GlmMoeDsaForCausalLM",
+                        kv_cache_dtype="nvfp4",
+                        dsa_prefill_backend="fa3",
+                    )
+                )
+            with self.assertRaisesRegex(ValueError, "decode-backend=flashmla_kv"):
+                _dsa_split_backend_resolution(
+                    _view(
+                        arch="GlmMoeDsaForCausalLM",
+                        kv_cache_dtype="nvfp4",
+                        dsa_decode_backend="trtllm",
+                    )
+                )
         with (
             patch("sglang.srt.configs.model_config.is_deepseek_dsa", return_value=True),
             patch.object(overrides_module, "is_npu", return_value=False),
@@ -1417,12 +1472,15 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             _dsa_kv_cache_dtype_default,
         )
 
-        def _view(**kw):
-            hf = SimpleNamespace(architectures=["DeepseekV32ForCausalLM"])
+        def _view(arch="DeepseekV32ForCausalLM", **kw):
+            hf = SimpleNamespace(architectures=[arch])
             defaults = dict(
                 kv_cache_dtype="auto",
                 dsa_prefill_backend=None,
                 dsa_decode_backend=None,
+                enable_prefill_cp=False,
+                dcp_size=1,
+                enable_hisparse=False,
             )
             defaults.update(kw)
             return ResolvedView(
@@ -1459,6 +1517,56 @@ class TestGoldenModelOverrides(_IsolatedPublish):
                 self.assertEqual(
                     _dsa_kv_cache_dtype_default(_view()),
                     {"kv_cache_dtype": "fp8_e4m3"},
+                )
+                with patch.object(overrides_module, "is_hip", return_value=False):
+                    self.assertEqual(
+                        _dsa_kv_cache_dtype_default(
+                            _view(
+                                arch="GlmMoeDsaForCausalLM",
+                                kv_cache_dtype="nvfp4",
+                            )
+                        ),
+                        {},
+                    )
+                    with self.assertRaisesRegex(ValueError, "specialized for GLM-5.2"):
+                        _dsa_kv_cache_dtype_default(_view(kv_cache_dtype="nvfp4"))
+                    for topology in (
+                        {"enable_prefill_cp": True},
+                        {"dcp_size": 2},
+                    ):
+                        with (
+                            self.subTest(topology=topology),
+                            self.assertRaisesRegex(
+                                ValueError, "does not yet support.*context parallelism"
+                            ),
+                        ):
+                            _dsa_kv_cache_dtype_default(
+                                _view(
+                                    arch="GlmMoeDsaForCausalLM",
+                                    kv_cache_dtype="nvfp4",
+                                    **topology,
+                                )
+                            )
+                    with self.assertRaisesRegex(
+                        ValueError, "does not yet support HiSparse"
+                    ):
+                        _dsa_kv_cache_dtype_default(
+                            _view(
+                                arch="GlmMoeDsaForCausalLM",
+                                kv_cache_dtype="nvfp4",
+                                enable_hisparse=True,
+                            )
+                        )
+            with (
+                patch("torch.cuda.get_device_capability", return_value=(9, 0)),
+                patch.object(overrides_module, "is_hip", return_value=False),
+                self.assertRaisesRegex(ValueError, "requires an SM100 GPU"),
+            ):
+                _dsa_kv_cache_dtype_default(
+                    _view(
+                        arch="GlmMoeDsaForCausalLM",
+                        kv_cache_dtype="nvfp4",
+                    )
                 )
 
     def test_deepseek_v4_kv_cache_dtype_pass(self):

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -1479,7 +1479,10 @@ class TestGoldenModelOverrides(_IsolatedPublish):
                 dsa_prefill_backend=None,
                 dsa_decode_backend=None,
                 enable_prefill_cp=False,
+                cp_strategy=None,
                 dcp_size=1,
+                enable_dsa_cache_layer_split=False,
+                enable_cp_decode_attn_tp=False,
                 enable_hisparse=False,
             )
             defaults.update(kw)
@@ -1530,23 +1533,62 @@ class TestGoldenModelOverrides(_IsolatedPublish):
                     )
                     with self.assertRaisesRegex(ValueError, "specialized for GLM-5.2"):
                         _dsa_kv_cache_dtype_default(_view(kv_cache_dtype="nvfp4"))
-                    for topology in (
-                        {"enable_prefill_cp": True},
-                        {"dcp_size": 2},
-                    ):
-                        with (
-                            self.subTest(topology=topology),
-                            self.assertRaisesRegex(
-                                ValueError, "does not yet support.*context parallelism"
-                            ),
-                        ):
-                            _dsa_kv_cache_dtype_default(
-                                _view(
-                                    arch="GlmMoeDsaForCausalLM",
-                                    kv_cache_dtype="nvfp4",
-                                    **topology,
-                                )
+                    self.assertEqual(
+                        _dsa_kv_cache_dtype_default(
+                            _view(
+                                arch="GlmMoeDsaForCausalLM",
+                                kv_cache_dtype="nvfp4",
+                                enable_prefill_cp=True,
+                                cp_strategy="interleave",
                             )
+                        ),
+                        {},
+                    )
+                    with self.assertRaisesRegex(
+                        ValueError, "does not yet support decode context parallelism"
+                    ):
+                        _dsa_kv_cache_dtype_default(
+                            _view(
+                                arch="GlmMoeDsaForCausalLM",
+                                kv_cache_dtype="nvfp4",
+                                dcp_size=2,
+                            )
+                        )
+                    with self.assertRaisesRegex(
+                        ValueError, "only with --cp-strategy=interleave"
+                    ):
+                        _dsa_kv_cache_dtype_default(
+                            _view(
+                                arch="GlmMoeDsaForCausalLM",
+                                kv_cache_dtype="nvfp4",
+                                enable_prefill_cp=True,
+                                cp_strategy="zigzag",
+                            )
+                        )
+                    with self.assertRaisesRegex(
+                        ValueError, "does not yet support.*cache-layer-split"
+                    ):
+                        _dsa_kv_cache_dtype_default(
+                            _view(
+                                arch="GlmMoeDsaForCausalLM",
+                                kv_cache_dtype="nvfp4",
+                                enable_prefill_cp=True,
+                                cp_strategy="interleave",
+                                enable_dsa_cache_layer_split=True,
+                            )
+                        )
+                    with self.assertRaisesRegex(
+                        ValueError, "requires H64 attention-DP decode"
+                    ):
+                        _dsa_kv_cache_dtype_default(
+                            _view(
+                                arch="GlmMoeDsaForCausalLM",
+                                kv_cache_dtype="nvfp4",
+                                enable_prefill_cp=True,
+                                cp_strategy="interleave",
+                                enable_cp_decode_attn_tp=True,
+                            )
+                        )
                     with self.assertRaisesRegex(
                         ValueError, "does not yet support HiSparse"
                     ):


### PR DESCRIPTION
## Summary

- add a 416-byte/token SM100 NVFP4 cache layout for the GLM-5.2 DSA main KV cache:
  - 256 B packed E2M1 latent values
  - 32 B block-16 E4M3 scales
  - 128 B BF16 RoPE values
- add a per-layer persistent FP32 global K scale and exact host/device codec support
- add a fused FlashMLA sparse-decode path that loads and dequantizes NVFP4 in the producer and reuses the existing BF16 QK/PV consumer
- integrate pool allocation/accounting, DSA index-cache moves, CUDA Graph/EAGLE decode, PD decode offload, backend dispatch, and documentation

Together with the existing 132-byte DSA indexer row, the cache footprint is 548 B/token/layer.

## Scope and guards

This first implementation targets the production GLM-5.2 attention-DP shape on NVIDIA SM100:

- Hq=64, QK=576 (512 NoPE + 64 RoPE), V=512
- top-k=2048, page size=64
- `flashmla_sparse` prefill and `flashmla_kv` decode

Decode reads the packed cache directly without a full BF16 workspace. Prefix/chunked prefill currently materializes the paged prefix into a BF16 compatibility workspace before FlashMLA sparse prefill.

Unsupported devices, shapes, page sizes, explicit incompatible backends, prefill CP/DCP, and HiSparse fail at initialization instead of silently falling back. The change also preserves the actual 416-byte row width in PD decode offload host pools.

The FlashMLA delta is intentionally a single NVFP4-only patch against the existing pin. MXFP4/Humming, direct-FP4 MMA, H8, and FP8-consumer experiments are excluded.

## Validation

Clean build and tests were run on one B200 with CUDA 13.0:

- clean `flashmla_ops` rebuild from the pinned FlashMLA source: passed
- native SM100 decode correctness, invalid/OOB indices, attention sink, and CUDA Graph/EAGLE cases: 17 passed
- codec/layout, bit-exact writer, paged dequant, and full 200K chunk chains at 8K/16K/32K: 42 passed
- NVFP4 backend dispatch: passed
- PD decode offload row-width test: passed
- backend/topology override gates: passed
- registered-test validation, Python compile, and diff checks: passed

## Performance

B200 microbenchmarks for the GLM-5.2 attention-DP H64 shape show that the NVFP4 dequantization overhead is hidden relative to the open FlashMLA FP8/BF16-consumer path:

- kernel-only geometric mean: +0.02% (parity)
- production path: 2.66% lower latency
- CUDA Graph replay: 2.39% lower latency
- full 200K prefill at 8K/16K/32K chunks: 2.05% / 1.11% / 1.73% lower latency

TRTLLM-GEN FP8 remains a separate stretch target because it uses an FP8 TCGEN05 consumer. In the exact EAGLE-flat comparison, NVFP4 was 2.41% slower on the production path and 10.44% slower in CUDA Graph replay. This PR therefore claims parity with the open FlashMLA FP8 baseline, not parity with TRTLLM-GEN.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->