### PR TITLE
Support runtime attach for UnifiedCache

### DIFF
--- a/python/sglang/srt/mem_cache/unified_cache/storage_attachment.py
+++ b/python/sglang/srt/mem_cache/unified_cache/storage_attachment.py
@@ -1,0 +1,274 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Runtime attach / detach of the HiCache (L3) storage backend.
+
+``UnifiedRadixCache`` owns the tree; this component owns the admin-API lifecycle
+of the storage backend behind it: validating the requested policies, starting and
+stopping the controller's storage threads, and cleaning up the bookkeeping that a
+half-finished prefetch / backup leaves behind.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Optional
+
+from sglang.srt.mem_cache.hybrid_cache.hybrid_cache_controller import (
+    HybridCacheController,
+)
+
+if TYPE_CHECKING:
+    from sglang.srt.mem_cache.unified_radix_cache import UnifiedRadixCache
+
+logger = logging.getLogger(__name__)
+
+# Kept in sync with the server-args choices; validated here so an admin request
+# with a bad policy is rejected before it can touch the controller.
+_PREFETCH_POLICIES = ("best_effort", "wait_complete", "timeout")
+_WRITE_POLICIES = ("write_back", "write_through", "write_through_selective")
+
+
+class StorageAttachment:
+    """Attach / detach the storage backend of one ``UnifiedRadixCache``."""
+
+    def __init__(self, cache: UnifiedRadixCache):
+        self._cache = cache
+
+    def attach(
+        self,
+        storage_backend: str,
+        storage_backend_extra_config_json: Optional[str] = None,
+        served_model_name: Optional[str] = None,
+        hicache_storage_prefetch_policy: Optional[str] = None,
+        hicache_write_policy: Optional[str] = None,
+    ) -> tuple[bool, str]:
+        """Enable the storage backend at runtime.
+
+        Starts the storage threads inside the cache controller and turns on the
+        prefetch / backup paths. The caller must ensure there are no running or
+        queued requests, so this does not race the scheduler thread.
+        """
+        cache = self._cache
+
+        # Validate first: no side effects on a bad request.
+        invalid = self._validate_policies(
+            hicache_storage_prefetch_policy, hicache_write_policy
+        )
+        if invalid is not None:
+            return False, invalid
+
+        controller = cache.cache_controller
+        if controller is None:
+            return (
+                False,
+                "HiCache is not initialized (no cache controller); "
+                "launch with --enable-hierarchical-cache to attach a backend.",
+            )
+
+        if cache.enable_storage:
+            current_backend = controller.storage_backend_type
+            if current_backend != storage_backend:
+                return (
+                    False,
+                    f"HiCache storage backend is already enabled with backend "
+                    f"'{current_backend}'. Cannot attach different backend "
+                    f"'{storage_backend}'. Detach first.",
+                )
+            # Same backend: the request degenerates to a policy update.
+            self._apply_policies(hicache_storage_prefetch_policy, hicache_write_policy)
+            return (
+                True,
+                "HiCache storage backend already enabled with same backend; "
+                "policies updated.",
+            )
+
+        # Apply policies before the controller attach, so the storage threads
+        # observe the new values as soon as they start.
+        self._apply_policies(hicache_storage_prefetch_policy, hicache_write_policy)
+
+        logger.info(f"Attaching HiCache storage backend: {storage_backend}")
+        try:
+            (
+                extra_config,
+                prefetch_threshold,
+                prefetch_timeout_base,
+                prefetch_timeout_per_ki_token,
+                hicache_storage_pass_prefix_keys,
+            ) = HybridCacheController.parse_storage_backend_extra_config(
+                storage_backend_extra_config_json
+            )
+        except Exception as e:
+            logger.exception(f"Failed to parse storage_backend_extra_config_json: {e}")
+            return (
+                False,
+                f"Failed to parse storage_backend_extra_config_json "
+                f"'{storage_backend_extra_config_json}': {e}",
+            )
+
+        try:
+            controller.attach_storage_backend(
+                storage_backend=storage_backend,
+                prefetch_threshold=prefetch_threshold,
+                model_name=served_model_name,
+                storage_backend_extra_config=extra_config,
+                host_pools=controller.mem_pool_host.entries,
+            )
+        except Exception as e:
+            logger.exception(
+                f"Failed to attach storage backend '{storage_backend}': {e}"
+            )
+            return False, f"Failed to attach storage backend '{storage_backend}': {e}"
+
+        cache._apply_storage_runtime_config(
+            storage_backend=storage_backend,
+            prefetch_threshold=prefetch_threshold,
+            prefetch_timeout_base=prefetch_timeout_base,
+            prefetch_timeout_per_ki_token=prefetch_timeout_per_ki_token,
+            hicache_storage_pass_prefix_keys=hicache_storage_pass_prefix_keys,
+            enable_storage=controller.enable_storage,
+            enable_storage_metrics=cache._enable_metrics_flag,
+            extra_metric_labels=cache.extra_metric_labels,
+        )
+        return True, "Attached HiCache storage backend successfully."
+
+    def detach(self) -> tuple[bool, str]:
+        """Disable the storage backend at runtime.
+
+        The caller must ensure there are no running or queued requests. Ordering
+        matters and is the reason this is not just ``controller.detach()``:
+
+        1. drain the control queues while the bookkeeping is still intact, so
+           in-flight acks / releases can still be matched to their nodes --
+           otherwise host pages and host locks leak;
+        2. stop the storage threads;
+        3. only then force-release whatever prefetch / backup is still tracked,
+           since nothing can race the bookkeeping once the threads are gone;
+        4. drain once more, because the release in step 3 only *queues* the host
+           pages -- this is what hands them back to the pool and its sidecars.
+        """
+        cache = self._cache
+        controller = cache.cache_controller
+        if controller is None:
+            return False, "HiCache storage backend is not initialized."
+
+        try:
+            cache.drain_storage_control_queues_local()
+            # Idempotent: ask the controller to clean up even when
+            # `enable_storage` is already False, since that may be leftover
+            # state from an earlier partial detach.
+            controller.detach_storage_backend()
+        except Exception as e:
+            logger.exception("Failed to detach storage backend.")
+            # Never crash the server for an admin operation. The controller
+            # raises while its threads are still alive, so leave `ongoing_*`
+            # untouched -- a retry must still be able to match their acks.
+            return False, f"Failed to detach HiCache storage backend: {e}"
+
+        try:
+            cache.drain_storage_control_queues_local()
+            self._release_pending_storage_ops()
+            cache.drain_storage_control_queues_local()
+        except Exception:
+            logger.exception("Failed post-detach cleanup of storage bookkeeping.")
+
+        cache.enable_storage = False
+        cache.enable_storage_metrics = False
+        return True, "Detached HiCache storage backend successfully."
+
+    def shutdown(self) -> None:
+        """Best-effort auto-detach on process shutdown.
+
+        Keeps startup and runtime behavior consistent: a backend attached either
+        via CLI args or via the admin API is detached on exit.
+        """
+        try:
+            if self._cache.enable_storage:
+                self.detach()
+        except Exception:
+            logger.exception("Failed to detach storage backend on process shutdown.")
+
+    @staticmethod
+    def _validate_policies(
+        hicache_storage_prefetch_policy: Optional[str],
+        hicache_write_policy: Optional[str],
+    ) -> Optional[str]:
+        """The rejection reason for an invalid policy, or None when both are ok."""
+        if (
+            hicache_storage_prefetch_policy is not None
+            and hicache_storage_prefetch_policy not in _PREFETCH_POLICIES
+        ):
+            return (
+                f"Invalid hicache_storage_prefetch_policy: "
+                f"{hicache_storage_prefetch_policy!r}. "
+                f"Expected one of {list(_PREFETCH_POLICIES)}."
+            )
+        if (
+            hicache_write_policy is not None
+            and hicache_write_policy not in _WRITE_POLICIES
+        ):
+            return (
+                f"Invalid hicache_write_policy: {hicache_write_policy!r}. "
+                f"Expected one of {list(_WRITE_POLICIES)}."
+            )
+        return None
+
+    def _apply_policies(
+        self,
+        hicache_storage_prefetch_policy: Optional[str],
+        hicache_write_policy: Optional[str],
+    ) -> None:
+        cache = self._cache
+        if hicache_storage_prefetch_policy is not None:
+            cache.prefetch_stop_policy = hicache_storage_prefetch_policy
+            logger.info(
+                f"Set hicache_storage_prefetch_policy to "
+                f"{hicache_storage_prefetch_policy}"
+            )
+        if hicache_write_policy is not None:
+            cache.cache_controller.write_policy = hicache_write_policy
+            cache.write_through_threshold = (
+                1 if hicache_write_policy == "write_through" else 2
+            )
+            cache.is_write_back = hicache_write_policy == "write_back"
+            logger.info(f"Set hicache_write_policy to {hicache_write_policy}")
+
+    def _release_pending_storage_ops(self) -> None:
+        """Release the host pages and host locks still held by tracked ops.
+
+        Prefetches go through ``release_aborted_request``, the same path the
+        scheduler uses for an aborted request, so the host-page free, the
+        ``dec_host_lock_ref`` and the ``prefetch_tokens_occupied`` accounting all
+        stay in one place. Backups only hold a host lock on their anchor node.
+        """
+        cache = self._cache
+
+        for req_id in list(cache.ongoing_prefetch):
+            try:
+                cache.release_aborted_request(req_id)
+            except Exception:
+                logger.exception(
+                    "Failed to release pending prefetch %s during detach", req_id
+                )
+                cache.ongoing_prefetch.pop(req_id, None)
+
+        for op_id, entry in list(cache.ongoing_backup.items()):
+            try:
+                node_id, lock_params = entry
+                cache.dec_host_lock_ref(node_id, lock_params)
+            except Exception:
+                logger.exception(
+                    "Failed to release host lock for backup op %s during detach", op_id
+                )
+            cache.ongoing_backup.pop(op_id, None)

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import atexit
 import logging
 import threading
 import time
@@ -57,6 +58,7 @@ from sglang.srt.mem_cache.unified_cache.components import (
 from sglang.srt.mem_cache.unified_cache.session_ref_tracker import (
     UnifiedSessionRefTracker,
 )
+from sglang.srt.mem_cache.unified_cache.storage_attachment import StorageAttachment
 from sglang.srt.mem_cache.unified_cache.tree_core_registry import create_tree_core
 from sglang.srt.mem_cache.unified_cache.unified_tree_core import (  # noqa: F401
     NodeId,
@@ -216,6 +218,8 @@ class UnifiedRadixCache(BasePrefixCache):
         # HiCache D↔H defaults (overridden by init_hicache)
         self.cache_controller: Optional[HybridCacheController] = None
         self.host_pool_group = None  # set by attach_hybrid_pool_to_unified_cache
+        # Owns the runtime attach/detach of the L3 backend; built by init_hicache.
+        self._storage_attachment: Optional[StorageAttachment] = None
         self.prefetch_stop_policy = "best_effort"
         self.prefetch_threshold = 256
         self.prefetch_timeout_base = 1.0
@@ -380,6 +384,10 @@ class UnifiedRadixCache(BasePrefixCache):
                 )
         self.load_back_threshold = 10
         self.prefetch_stop_policy = server_args.hicache_storage_prefetch_policy
+
+        # Runtime attach/detach of the L3 backend (admin API + atexit shutdown).
+        self._storage_attachment = StorageAttachment(self)
+        atexit.register(self.shutdown)
 
         if storage_backend is not None:
             self._apply_storage_runtime_config(
@@ -1583,7 +1591,7 @@ class UnifiedRadixCache(BasePrefixCache):
         n_storage_hit: Optional[int],
         n_backup: Optional[int],
         n_release: Optional[int],
-        extra_release_counts: Optional[dict[PoolName, int]],
+        extra_release_counts: Optional[dict[PoolName, Optional[int]]],
         log_metrics: bool,
     ) -> None:
         cc = self.cache_controller
@@ -1725,6 +1733,54 @@ class UnifiedRadixCache(BasePrefixCache):
             log_metrics=True,
         )
 
+    def drain_storage_control_queues_local(self) -> None:
+        """Drain the storage control queues without cross-rank synchronization."""
+        cc = self.cache_controller
+        extra_queues = (
+            getattr(cc, "extra_host_mem_release_queues", {}) if cc is not None else {}
+        )
+        self._drain_storage_control_queues_impl(
+            n_storage_hit=0,
+            n_backup=None,
+            n_release=None,
+            extra_release_counts={pool_name: None for pool_name in extra_queues},
+            log_metrics=False,
+        )
+
+    def attach_storage_backend(
+        self,
+        storage_backend: str,
+        storage_backend_extra_config_json: Optional[str] = None,
+        served_model_name: Optional[str] = None,
+        hicache_storage_prefetch_policy: Optional[str] = None,
+        hicache_write_policy: Optional[str] = None,
+    ) -> tuple[bool, str]:
+        """Attach (enable) the HiCache storage backend at runtime."""
+        if self._storage_attachment is None:
+            return (
+                False,
+                "HiCache is not initialized; launch with "
+                "--enable-hierarchical-cache to attach a storage backend.",
+            )
+        return self._storage_attachment.attach(
+            storage_backend=storage_backend,
+            storage_backend_extra_config_json=storage_backend_extra_config_json,
+            served_model_name=served_model_name,
+            hicache_storage_prefetch_policy=hicache_storage_prefetch_policy,
+            hicache_write_policy=hicache_write_policy,
+        )
+
+    def detach_storage_backend(self) -> tuple[bool, str]:
+        """Detach (disable) the HiCache storage backend at runtime."""
+        if self._storage_attachment is None:
+            return False, "HiCache storage backend is not initialized."
+        return self._storage_attachment.detach()
+
+    def shutdown(self) -> None:
+        """Best-effort auto-detach of the storage backend on process shutdown."""
+        if self._storage_attachment is not None:
+            self._storage_attachment.shutdown()
+
     def _apply_storage_runtime_config(
         self,
         *,
@@ -1781,27 +1837,6 @@ class UnifiedRadixCache(BasePrefixCache):
                 )
         else:
             self.storage_metrics_collector = None
-
-    def attach_storage_backend(
-        self,
-        storage_backend: str,
-        storage_backend_extra_config_json: Optional[str] = None,
-        served_model_name: Optional[str] = None,
-        hicache_storage_prefetch_policy: Optional[str] = None,
-        hicache_write_policy: Optional[str] = None,
-    ) -> tuple[bool, str]:
-        return (
-            False,
-            "UnifiedRadixCache does not support runtime HiCache storage attach yet. "
-            "Configure hicache_storage_backend at startup instead.",
-        )
-
-    def detach_storage_backend(self) -> tuple[bool, str]:
-        return (
-            False,
-            "UnifiedRadixCache does not support runtime HiCache storage detach yet. "
-            "Restart without hicache_storage_backend to disable it.",
-        )
 
     def clear_storage_backend(self) -> bool:
         try:

--- a/test/registered/hicache/test_hicache_storage_runtime_attach_detach.py
+++ b/test/registered/hicache/test_hicache_storage_runtime_attach_detach.py
@@ -60,6 +60,7 @@ class TestHiCacheStorageRuntimeAttachDetach(CustomTestCase):
             "SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR": cls.temp_dir,
             # Make runs less flaky for CI/dev.
             "SGLANG_ENABLE_DETERMINISTIC_INFERENCE": "1",
+            "SGLANG_ENABLE_UNIFIED_RADIX_TREE": "1"
         }
 
     @classmethod


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Preceding Fix For https://github.com/sgl-project/sglang/pull/35081
Support Runtime attach/detach api for unified radix cache

- New component mem_cache/unified_cache/storage_attachment.py (StorageAttachment), which owns the runtime lifecycle of the storage backend: policy validation, same-/different-backend handling, extra-config parsing, controller attach, and the post-detach cleanup. Keeping it beside the tree instead of inside it leaves UnifiedRadixCache focused on cache logic, and gives the two entry points — the admin API and the atexit hook — one implementation.
- UnifiedRadixCache: replaced the two stubs with real attach_storage_backend / detach_storage_backend that delegate to the component, added shutdown() (registered with atexit in init_hicache, mirroring HiRadixCache) and a drain_storage_control_queues_local() helper for the teardown path.

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32097237057](https://github.com/sgl-project/sglang/actions/runs/32097237057)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #32097236894](https://github.com/sgl-project/sglang/actions/runs/32097236894)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->