### PR TITLE
test: cover invalid DeepSeek OCR ngram config

### DIFF
--- a/test/registered/unit/sampling/test_custom_logit_processor.py
+++ b/test/registered/unit/sampling/test_custom_logit_processor.py
@@ -404,6 +404,33 @@ class TestDeepseekOCRNoRepeatNGramLogitProcessor(CustomTestCase):
         result = self.processor(logits, params)
         self.assertTrue(torch.equal(result, original))
 
+    def test_invalid_window_size_type_skips(self):
+        """Non-numeric window_size should be handled gracefully."""
+        req = _make_req(origin_input_ids=[1, 2, 1, 2])
+        params = [{"__req__": req, "ngram_size": 2, "window_size": "invalid"}]
+        logits = self._logits()
+        original = logits.clone()
+        result = self.processor(logits, params)
+        self.assertTrue(torch.equal(result, original))
+
+    def test_negative_ngram_size_skips(self):
+        """Negative ngram_size should disable ngram checking."""
+        req = _make_req(origin_input_ids=[1, 2, 1, 2])
+        params = [{"__req__": req, "ngram_size": -1, "window_size": 100}]
+        logits = self._logits()
+        original = logits.clone()
+        result = self.processor(logits, params)
+        self.assertTrue(torch.equal(result, original))
+
+    def test_negative_window_size_skips(self):
+        """Negative window_size should disable ngram checking."""
+        req = _make_req(origin_input_ids=[1, 2, 1, 2])
+        params = [{"__req__": req, "ngram_size": 2, "window_size": -1}]
+        logits = self._logits()
+        original = logits.clone()
+        result = self.processor(logits, params)
+        self.assertTrue(torch.equal(result, original))
+
     def test_falsy_params_in_list_skipped(self):
         """A falsy entry (None, {}, 0) in param list should be skipped."""
         req = _make_req(origin_input_ids=[1, 2, 1, 2])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Improve unit test coverage for invalid configuration handling in `DeepseekOCRNoRepeatNGramLogitProcessor`.

## Modifications

Add tests verifying that logits remain unchanged when:
- `window_size` is non-numeric
- `ngram_size` is negative
- `window_size` is negative

No production code is changed.

## Accuracy Tests

Not applicable. This PR only adds unit tests and does not modify model outputs.

## Speed Tests and Profiling

Not applicable. This PR only adds unit tests and does not affect inference performance.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32098031844](https://github.com/sgl-project/sglang/actions/runs/32098031844)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32098031651](https://github.com/sgl-project/sglang/actions/runs/32098031651)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->