### PR TITLE
[Perf] Memoize Req.tail_str to halve stop-string decode calls per step

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -863,6 +863,13 @@ class Req(ReqDllmMixin):
         # full_untruncated_fill_ids from lengths alone, so in-place rewrites
         # that preserve length would silently corrupt fill_ids.
         self.output_ids = array("q")
+        # Last tail window + its decoded text for tail_str(): with stop
+        # strings configured, the same window is decoded twice per decode step
+        # (finish check, then the streaming prefix check). Keyed on window
+        # content so every output_ids mutation (append, retract, in-place
+        # fixup) invalidates naturally.
+        self._tail_str_cache_ids = None
+        self._tail_str_cache_text = ""
         # Full untruncated sequence: origin + output (+ DLLM mask block).
         # Kept in sync by _refresh_fill_ids; admission only updates
         # extend_range, never mutates this array's length.
@@ -1456,7 +1463,21 @@ class Req(ReqDllmMixin):
             return ""
 
         tail_len = self._stop_match_tail_len(new_accepted_len)
-        return self.tokenizer.decode(self.output_ids[-tail_len:])
+        window = self.output_ids[-tail_len:]
+        if tail_len >= len(self.output_ids):
+            # The window is the whole output (an unquantified regex repeat such
+            # as stop_regex=".*END", or the output is still shorter than the
+            # stop tail). It grows on every step, so a memo hit is impossible
+            # and caching would pin a whole-output id copy plus its text on
+            # the Req. Decode directly instead.
+            return self.tokenizer.decode(window)
+        if self._tail_str_cache_ids is None or self._tail_str_cache_ids != window:
+            text = self.tokenizer.decode(window)
+            # Store only after a successful decode so a raising decode cannot
+            # leave a window/text mismatch behind in the memo.
+            self._tail_str_cache_ids = window
+            self._tail_str_cache_text = text
+        return self._tail_str_cache_text
 
     def check_match_stop_str_prefix(self) -> bool:
         """

--- a/test/registered/unit/managers/test_tail_str_memo.py
+++ b/test/registered/unit/managers/test_tail_str_memo.py
@@ -1,0 +1,222 @@
+"""Req.tail_str memoization: with stop strings configured the same output_ids
+tail is consumed twice per decode step (_check_str_based_finish via
+update_finish_state, then the streaming check_match_stop_str_prefix inside
+SchedulerOutputStreamer.accept), so the second decode must be served from the
+memo — and the memo must never serve a stale string across append,
+retract-style regrow (same length, different content), or window-size changes
+(speculative multi-token accepts). Whole-output windows (unquantified stop
+regexes) must bypass the memo entirely: they grow every step, so there is no
+reuse to gain and caching would pin the full output on the Req. Pure CPU:
+drives the real Req (and the real accept() streaming route) against a counting
+fake tokenizer, cross-checking every value against an uncached reference
+decode."""
+
+import unittest
+from array import array
+
+from sglang.srt.managers.schedule_batch import Req
+from sglang.srt.sampling.sampling_params import SamplingParams
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+ID_TO_TEXT = {i: chr(ord("a") + i % 26) for i in range(10, 40)}
+
+
+class CountingTokenizer:
+    eos_token_id = -1
+    additional_stop_token_ids = None
+
+    def __init__(self):
+        self.decode_calls = 0
+
+    def decode(self, ids):
+        self.decode_calls += 1
+        return "".join(ID_TO_TEXT[int(i)] for i in ids)
+
+
+class MockTokForNormalize:
+    def encode(self, s, add_special_tokens=False):
+        return list(range(len(s)))
+
+
+def _ref_decode(ids):
+    return "".join(ID_TO_TEXT[int(i)] for i in ids)
+
+
+def _ref_tail(req, new_accepted_len=1):
+    tail_len = req._stop_match_tail_len(new_accepted_len)
+    return _ref_decode(req.output_ids[len(req.output_ids) - tail_len :])
+
+
+def _make_req(output_ids, stop=None, stop_regex=None):
+    sp = SamplingParams(max_new_tokens=1000, stop=stop, stop_regex=stop_regex)
+    sp.normalize(tokenizer=MockTokForNormalize())  # char-based stop_str_max_len
+    req = Req(
+        rid="t",
+        origin_input_text="",
+        origin_input_ids=array("q", [0]),
+        sampling_params=sp,
+        eos_token_ids=frozenset(),
+        vocab_size=10_000,
+    )
+    req.tokenizer = CountingTokenizer()
+    req.output_ids = array("q", output_ids)
+    return req
+
+
+def _make_streamer():
+    """Minimal _GenerationStreamAccumulator (the class whose accept() is the
+    production streaming route) that runs the happy path: every return-*
+    switch off, no spec, rust payload block skipped. Fields are populated by
+    reflection over the dataclass so a field rename fails loudly instead of
+    silently skipping coverage."""
+    import dataclasses
+
+    from sglang.srt.managers.scheduler_components.output_streamer import (
+        _GenerationStreamAccumulator,
+    )
+    from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+
+    overrides = {
+        "spec_algorithm": SpeculativeAlgorithm.NONE,
+        "disaggregation_mode": None,
+        "default_stream_interval": 1,
+        "default_force_stream_interval": 1,
+        "get_cached_tokens_details": lambda req: None,
+        "rust_server_mode": True,
+        "return_logprob": False,
+        "return_hidden_states": False,
+        "return_routed_experts": False,
+        "return_indexer_topk": False,
+        "return_sampling_mask": False,
+        "has_input_top_logprobs_flat": False,
+    }
+    kwargs = {}
+    for f in dataclasses.fields(_GenerationStreamAccumulator):
+        if f.name in overrides:
+            kwargs[f.name] = overrides[f.name]
+        elif f.default is not dataclasses.MISSING:
+            kwargs[f.name] = f.default
+        elif f.default_factory is not dataclasses.MISSING:  # type: ignore[misc]
+            kwargs[f.name] = f.default_factory()  # type: ignore[misc]
+    return _GenerationStreamAccumulator(**kwargs)
+
+
+class TestTailStrMemo(unittest.TestCase):
+    def test_both_call_sites_share_one_decode_per_step(self):
+        # The exact sequence batch_result_processor runs per still-alive
+        # streaming request per step: update_finish_state (which decodes the
+        # new tail) then check_match_stop_str_prefix (same window, must hit
+        # the memo instead of decoding again).
+        req = _make_req([10, 11, 12, 13, 14], stop=["zzz"])
+        next_id = 20
+        for _ in range(3):
+            req.output_ids.append(next_id)  # step commits one token
+            next_id += 1
+            before = req.tokenizer.decode_calls
+            req.update_finish_state(1)
+            self.assertFalse(req.finished())
+            self.assertFalse(req.check_match_stop_str_prefix())
+            self.assertEqual(req.tokenizer.decode_calls - before, 1)
+            self.assertEqual(req.tail_str(), _ref_tail(req))
+
+    def test_accept_streaming_route_hits_memo(self):
+        # Same per-step sequence, but the second consumer is the real
+        # production streaming route: SchedulerOutputStreamer.accept() ->
+        # check_match_stop_str_prefix() (stream_interval=1, so every step
+        # streams). One decode per step across both entry points.
+        req = _make_req([10, 11, 12, 13, 14], stop=["zzz"])
+        req.stream = True
+        streamer = _make_streamer()
+        next_id = 20
+        for step in range(3):
+            req.output_ids.append(next_id)  # step commits one token
+            next_id += 1
+            before = req.tokenizer.decode_calls
+            req.update_finish_state(1)
+            self.assertFalse(req.finished())
+            streamer.accept(req=req)
+            self.assertEqual(req.tokenizer.decode_calls - before, 1)
+            self.assertEqual(len(streamer.output_ids), step + 1)
+
+    def test_append_invalidates(self):
+        req = _make_req([10, 11, 12, 13, 14], stop=["zzz"])
+        self.assertEqual(req.tail_str(), _ref_tail(req))
+        req.output_ids.append(30)
+        before = req.tokenizer.decode_calls
+        self.assertEqual(req.tail_str(), _ref_tail(req))
+        self.assertEqual(req.tokenizer.decode_calls - before, 1)
+
+    def test_retract_regrow_same_length_is_not_stale(self):
+        # Retraction discards generated tokens and later decode steps grow
+        # output_ids back to a previously seen length with DIFFERENT content
+        # (here: pop one id, append another). A length-only cache key would
+        # serve the old window; the content key must miss. The stop string is
+        # short so the window is a bounded sliding tail of a longer output.
+        req = _make_req([10, 11, 12, 13, 14, 15, 16], stop=["zzz"])
+        self.assertEqual(req.tail_str(), _ref_tail(req))
+        req.output_ids.pop()
+        req.output_ids.append(30)
+        before = req.tokenizer.decode_calls
+        self.assertEqual(req.tail_str(), _ref_tail(req))
+        self.assertEqual(req.tokenizer.decode_calls - before, 1)
+
+    def test_interleaved_window_sizes_stay_correct(self):
+        # Speculative accepts widen the finish-check window
+        # (new_accepted_len > 1) while the streaming prefix check keeps
+        # new_accepted_len=1: two different windows consulted per step. The
+        # memo must answer each with its own value; being single-entry it
+        # thrashes on interleaves (no savings under spec decoding — 5 decodes
+        # for 6 queries here, 3-per-3 in steady state — the count below
+        # documents that), but never returns a wrong string.
+        req = _make_req([10, 11, 12, 13, 14, 15, 16, 17], stop=["zzz"])
+        for _ in range(2):
+            self.assertEqual(req.tail_str(1), _ref_tail(req, 1))
+            self.assertEqual(req.tail_str(3), _ref_tail(req, 3))
+            self.assertEqual(req.tail_str(1), _ref_tail(req, 1))
+        self.assertEqual(req.tokenizer.decode_calls, 5)
+
+    def test_unbounded_regex_window_bypasses_memo(self):
+        # stop_regex=".*END" has an unquantified repeat, so
+        # stop_regex_max_len is 2**30 and _stop_match_tail_len clamps to the
+        # whole output: the window grows on every step and a memo hit is
+        # impossible. The memo must stay untouched (no whole-output id copy
+        # or text pinned on the Req) and every call must still decode the
+        # correct value.
+        req = _make_req([10, 11, 12, 13], stop_regex=[".*END"])
+        self.assertEqual(
+            req._stop_match_tail_len(1), len(req.output_ids)
+        )  # whole-output window, as constructed
+        self.assertEqual(req.tail_str(), _ref_tail(req))
+        self.assertIsNone(req._tail_str_cache_ids)
+        self.assertEqual(req.tail_str(), _ref_tail(req))  # decodes again
+        self.assertIsNone(req._tail_str_cache_ids)
+        req.output_ids.append(20)
+        self.assertEqual(req.tail_str(), _ref_tail(req))
+        self.assertIsNone(req._tail_str_cache_ids)
+
+    def test_no_stop_config_never_decodes(self):
+        req = _make_req([10, 11, 12, 13])
+        self.assertEqual(req.tail_str(), "")
+        self.assertFalse(req.check_match_stop_str_prefix())
+        self.assertEqual(req.tokenizer.decode_calls, 0)
+
+    def test_values_match_uncached_reference_over_trace(self):
+        # Append/retract/append/spec trace; every query equals the reference.
+        # The trace crosses both the whole-output regime (output shorter than
+        # the stop tail) and the bounded sliding-window regime.
+        req = _make_req([10, 11, 12], stop=["zzz"])
+        for action in ("append 20", "append 21", "retract", "append 22", "spec3"):
+            if action == "retract":
+                req.output_ids.pop()
+            elif action == "spec3":
+                self.assertEqual(req.tail_str(3), _ref_tail(req, 3))
+                continue
+            else:
+                req.output_ids.append(int(action.split()[1]))
+            self.assertEqual(req.tail_str(), _ref_tail(req))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`Req.tail_str()` decodes its token window with `self.tokenizer.decode(...)` on every call, uncached. On the streaming stop-string path two call sites fire per still-alive request per decode step on the scheduler thread:

1. `update_finish_state()` → `_check_str_based_finish()` → `tail_str(new_accept_len)` (`python/sglang/srt/managers/batch_result_processor.py`)
2. `SchedulerOutputStreamer.accept()` → `check_match_stop_str_prefix()` → `tail_str()` (`python/sglang/srt/managers/scheduler_components/output_streamer.py`)

For non-speculative decode with `stream_interval=1` the two sites run with the identical token window in the same step, so the same tail was tokenizer-decoded twice per request per step. With a 151k-vocab fast tokenizer a single `decode` costs ~4-11 µs depending on window length, which adds up on the scheduler thread: ~1.7-3.5 ms per step at batch 128-256.

Scope honesty: where the second call does not happen (`stream_interval > 1` off its boundary, non-streaming requests) or the windows differ (speculative decoding), the memo simply misses or is never consulted — no regression, no benefit. Regex-only stop configs are handled but intentionally not memoized (see Fix).

## Fix

A content-keyed single-entry memo on `Req` (`_tail_str_cache_ids` / `_tail_str_cache_text`): `tail_str()` decodes only when the cached window content differs from the current window (elementwise id compare, ~0.12 µs on a hit), otherwise returns the cached text. `tokenizer.decode` is a pure function of the ids, so identical windows yield byte-identical text.

Two guards:

- **Whole-output windows bypass the memo.** An unquantified regex repeat (`stop_regex=".*END"`) makes `stop_regex_max_len` 2^30, so the window clamps to the entire output and grows every step — a hit is impossible and caching would pin a whole-output id copy plus its text (~MiB per request at long outputs) on the `Req`. Such windows decode directly and leave the memo untouched. The same applies while the output is still shorter than the stop tail.
- **The memo is written only after a successful decode**, so a raising `decode` cannot leave a window/text mismatch behind.

Requests without stop-string/regex config still early-return `""` without touching the cache.

## Measurements

Microbench with a real 151k-vocab fast tokenizer: `decode` 4.35 / 6.80 / 10.73 µs at 10/20/40-token windows, memo hit 0.12 µs. End-to-end scheduler-thread projection per decode step (approximate): batch 128: 1.74 → 0.89 ms/step; batch 256: 3.48 → 1.77 ms/step. Independently reproduced by a second harness within 2-9%.

## Tests

New `test_tail_str_memo.py` (8 tests): one-decode-per-step across both real entry points — including through the production `SchedulerOutputStreamer.accept()` streaming route — append invalidation, retract-regrow with same-length-different-content, interleaved speculative window sizes, whole-output regex windows bypassing the memo (correct values, memo never populated), no-stop-config never decodes, and value equality vs the uncached reference across a trace that crosses both window regimes. Mutation-checked: forcing the memo to never hit fails 3/8.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32099245917](https://github.com/sgl-project/sglang/actions/runs/32099245917)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32099245795](https://github.com/sgl-project/sglang/actions/runs/32099245795)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->