### PR TITLE
refactor(unified-memory): route the KV read path through one id translator

### DIFF
--- a/python/sglang/kernels/ops/kvcache/__init__.py
+++ b/python/sglang/kernels/ops/kvcache/__init__.py
@@ -62,6 +62,7 @@ _TRITON_KERNELS = [
     ("cache_ops", "concat_and_cast_mha_k_triton"),
     ("cache_ops", "launch_reshape_and_cache_flash"),
     ("pd_dcp_gather", "copy_mla_rows_into_pack"),
+    ("kv_read_table", "build_kv_read_table"),
     ("kv_indices", "create_flashinfer_kv_indices_triton"),
     ("kv_indices", "create_flashmla_kv_indices_triton"),
     ("kv_indices", "create_chunked_prefix_cache_kv_indices"),

--- a/python/sglang/kernels/ops/kvcache/kv_indices.py
+++ b/python/sglang/kernels/ops/kvcache/kv_indices.py
@@ -7,14 +7,25 @@ FLASHMLA_CREATE_KV_BLOCK_SIZE_TRITON = tl.constexpr(_FLASHMLA_CREATE_KV_BLOCK_SI
 
 @triton.jit
 def create_flashinfer_kv_indices_triton(
-    req_to_token_ptr,  # [max_batch, max_context_len]
+    req_to_token_ptr,  # [max_batch, max_context_len] token table; at
+    # ENTRY_PAGE_SIZE > 1 a PAGE-granular table (the unified pool's read table)
     req_pool_indices_ptr,
     page_kernel_lens_ptr,
     kv_indptr,
     kv_start_idx,
     kv_indices_ptr,
     req_to_token_ptr_stride: tl.constexpr,
+    ENTRY_PAGE_SIZE: tl.constexpr = 1,
 ):
+    """Gather per-request token ids into a flat CSR kv_indices stream.
+
+    ``ENTRY_PAGE_SIZE == 1`` (default): the source table is token-granular and
+    entries are emitted verbatim — byte-identical to the historical kernel.
+    ``ENTRY_PAGE_SIZE == ps``: the source is the translator's PAGE-granular
+    read table (entries already kernel-facing page ids); token ids are rebuilt
+    as ``token = entry * ps + pos % ps``, exact because converting an id keeps
+    its offset inside the page.
+    """
     BLOCK_SIZE: tl.constexpr = 512
     pid = tl.program_id(axis=0)
 
@@ -34,13 +45,23 @@ def create_flashinfer_kv_indices_triton(
         # index into req_to_token_ptr needs to be int64
         offset = tl.arange(0, BLOCK_SIZE).to(tl.int64) + i * BLOCK_SIZE
         mask = offset < kv_end - kv_start
-        data = tl.load(
-            req_to_token_ptr
-            + req_pool_index * req_to_token_ptr_stride
-            + kv_start
-            + offset,
-            mask=mask,
-        )
+        if ENTRY_PAGE_SIZE == 1:
+            data = tl.load(
+                req_to_token_ptr
+                + req_pool_index * req_to_token_ptr_stride
+                + kv_start
+                + offset,
+                mask=mask,
+            )
+        else:
+            pos = kv_start + offset
+            entry = tl.load(
+                req_to_token_ptr
+                + req_pool_index * req_to_token_ptr_stride
+                + pos // ENTRY_PAGE_SIZE,
+                mask=mask,
+            )
+            data = entry.to(tl.int64) * ENTRY_PAGE_SIZE + pos % ENTRY_PAGE_SIZE
         tl.store(kv_indices_ptr + kv_indices_offset + offset, data, mask=mask)
 
 

--- a/python/sglang/kernels/ops/kvcache/kv_indices.py
+++ b/python/sglang/kernels/ops/kvcache/kv_indices.py
@@ -14,7 +14,10 @@ def create_flashinfer_kv_indices_triton(
     kv_indptr,
     kv_start_idx,
     kv_indices_ptr,
-    req_to_token_ptr_stride: tl.constexpr,
+    # Runtime, not constexpr: the translator's eager table is allocated at the
+    # batch's live width, so a constexpr stride would JIT-specialize per width
+    # (a recompile every few decode steps at small page sizes).
+    req_to_token_ptr_stride,
     ENTRY_PAGE_SIZE: tl.constexpr = 1,
 ):
     """Gather per-request token ids into a flat CSR kv_indices stream.
@@ -30,7 +33,7 @@ def create_flashinfer_kv_indices_triton(
     pid = tl.program_id(axis=0)
 
     # find the req pool idx, this is for batch to token
-    req_pool_index = tl.load(req_pool_indices_ptr + pid)
+    req_pool_index = tl.load(req_pool_indices_ptr + pid).to(tl.int64)
     kv_indices_offset = tl.load(kv_indptr + pid)
 
     kv_start = 0

--- a/python/sglang/kernels/ops/kvcache/kv_indices.py
+++ b/python/sglang/kernels/ops/kvcache/kv_indices.py
@@ -23,7 +23,7 @@ def create_flashinfer_kv_indices_triton(
     """Gather per-request token ids into a flat CSR kv_indices stream.
 
     ``ENTRY_PAGE_SIZE == 1`` (default): the source table is token-granular and
-    entries are emitted verbatim — byte-identical to the historical kernel.
+    entries are emitted verbatim -- byte-identical to the historical kernel.
     ``ENTRY_PAGE_SIZE == ps``: the source is the translator's PAGE-granular
     read table (entries already kernel-facing page ids); token ids are rebuilt
     as ``token = entry * ps + pos % ps``, exact because converting an id keeps

--- a/python/sglang/kernels/ops/kvcache/kv_read_table.py
+++ b/python/sglang/kernels/ops/kvcache/kv_read_table.py
@@ -1,0 +1,138 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Builds the per-batch read table for the unified memory pool.
+
+One fused gather-and-translate. For each request row it reads the virtual ids
+out of `req_to_token`, converts each to the id the kernels can use, and writes
+the result into `out`:
+
+    out[b, c] = clamp(v2p[req_to_token[req[b], c * ps] // ps] * multiplier, 0)
+                for c < ceil(seq_lens[b] / ps)          -- the row's LIVE prefix
+
+`v2p` is the pool's virtual->physical page table and `multiplier` scales a
+physical page into the id space the per-layer views use (1 when they are not
+dense). Since only the page number is rewritten, a token-level consumer can
+rebuild flat ids as `entry * ps + offset`.
+
+PREFIX-ONLY per row: columns past the live prefix are never written. That
+matters twice over. A caller-owned buffer keeps whatever it had there, which
+is what lets a captured cuda-graph buffer be refreshed in place; and readers
+bound themselves by `cache_seqlens`, so they never look at those columns.
+
+Anything unwritten or freed reads as entry 0, the reserved padding slot: a
+`-1` in `req_to_token` and a freed (`-1`) v2p row both clamp there, so a
+kernel dereferences padding rather than a wild address.
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+_BLOCK_COLS = 256
+
+
+@triton.jit
+def build_kv_read_table_kernel(
+    req_to_token_ptr,  # in: [max_reqs, max_context] — VIRTUAL token ids
+    req_pool_indices_ptr,  # in: [bs] — row per batch lane
+    seq_lens_ptr,  # in: [bs]
+    v2p_ptr,  # in: [num_pages + 1] int64 — virtual->physical page table
+    out_ptr,  # out: [>=bs, >=max_pages] int32 — the read table
+    req_stride,  # runtime: req_to_token row stride (elements)
+    out_stride,  # runtime: out row stride (elements)
+    mult,  # runtime: kernel_page_multiplier of the target sub-pool
+    PAGE_SIZE: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    bid = tl.program_id(0)
+    blk = tl.program_id(1)
+    req = tl.load(req_pool_indices_ptr + bid).to(tl.int64)
+    seqlen = tl.load(seq_lens_ptr + bid)
+    n_pages = (seqlen + PAGE_SIZE - 1) // PAGE_SIZE
+
+    cols = blk * BLOCK + tl.arange(0, BLOCK)
+    mask = cols < n_pages
+    tok = tl.load(
+        req_to_token_ptr + req * req_stride + cols.to(tl.int64) * PAGE_SIZE,
+        mask=mask,
+        other=0,
+    ).to(tl.int64)
+    phys = tl.load(v2p_ptr + tok // PAGE_SIZE, mask=mask, other=0)
+    entry = tl.maximum(phys * mult, 0).to(tl.int32)
+    tl.store(out_ptr + bid.to(tl.int64) * out_stride + cols, entry, mask=mask)
+
+
+def build_kv_read_table(
+    *,
+    req_to_token: torch.Tensor,
+    req_pool_indices: torch.Tensor,
+    seq_lens: torch.Tensor,
+    v2p: torch.Tensor,
+    multiplier: int,
+    page_size: int,
+    max_pages: int,
+    out: torch.Tensor,
+) -> torch.Tensor:
+    """Fill ``out``'s live prefix with read-table entries.
+
+    ``out`` is caller-owned (fresh zeros for the eager path, the module's
+    capture-stable buffer for replay) and only its ``[:bs, :max_pages]``
+    region's live prefix is written — never rebound, never tail-cleared.
+    """
+    bs = int(req_pool_indices.numel())
+    assert (
+        out.dtype == torch.int32
+    ), f"build_kv_read_table: out must be int32, got {out.dtype}"
+    assert out.dim() == 2 and out.shape[0] >= bs and out.shape[1] >= max_pages, (
+        f"build_kv_read_table: out {tuple(out.shape)} cannot hold "
+        f"(bs={bs}, max_pages={max_pages})"
+    )
+    assert out.stride(1) == 1, "build_kv_read_table: out rows must be packed"
+    assert (max_pages - 1) * page_size < req_to_token.shape[1], (
+        f"build_kv_read_table: max_pages={max_pages} x ps={page_size} "
+        f"exceeds req_to_token width {req_to_token.shape[1]}"
+    )
+    if bs == 0 or max_pages == 0:
+        return out
+
+    if not req_to_token.is_cuda:
+        cols = torch.arange(max_pages, device=req_to_token.device)
+        live = cols[None, :] < (
+            (seq_lens[:bs, None].to(torch.int64) + page_size - 1) // page_size
+        )
+        tok = req_to_token[
+            req_pool_indices[:bs, None].to(torch.int64), (cols * page_size)[None, :]
+        ].to(torch.int64)
+        pages = torch.where(tok < 0, 0, tok // page_size)
+        entry = (v2p[pages] * multiplier).clamp(min=0).to(torch.int32)
+        dst = out[:bs, :max_pages]
+        dst.copy_(torch.where(live, entry, dst))
+        return out
+
+    grid = (bs, triton.cdiv(max_pages, _BLOCK_COLS))
+    build_kv_read_table_kernel[grid](
+        req_to_token,
+        req_pool_indices,
+        seq_lens,
+        v2p,
+        out,
+        req_to_token.stride(0),
+        out.stride(0),
+        multiplier,
+        PAGE_SIZE=page_size,
+        BLOCK=_BLOCK_COLS,
+    )
+    return out

--- a/python/sglang/kernels/ops/kvcache/kv_read_table.py
+++ b/python/sglang/kernels/ops/kvcache/kv_read_table.py
@@ -25,14 +25,13 @@ physical page into the id space the per-layer views use (1 when they are not
 dense). Since only the page number is rewritten, a token-level consumer can
 rebuild flat ids as `entry * ps + offset`.
 
-PREFIX-ONLY per row: columns past the live prefix are never written. That
-matters twice over. A caller-owned buffer keeps whatever it had there, which
-is what lets a captured cuda-graph buffer be refreshed in place; and readers
-bound themselves by `cache_seqlens`, so they never look at those columns.
+PREFIX-ONLY per row: columns past the live prefix are never written, so a
+caller-owned buffer keeps what it had there -- which is what lets a captured
+cuda-graph buffer be refreshed in place. Readers bound themselves by
+`cache_seqlens` and never look past the prefix.
 
-Anything unwritten or freed reads as entry 0, the reserved padding slot: a
-`-1` in `req_to_token` and a freed (`-1`) v2p row both clamp there, so a
-kernel dereferences padding rather than a wild address.
+A `-1` in `req_to_token` and a freed (`-1`) v2p row both clamp to entry 0, the
+reserved padding slot, so a kernel dereferences padding, not a wild address.
 """
 
 from __future__ import annotations
@@ -70,11 +69,8 @@ def build_kv_read_table_kernel(
         mask=mask,
         other=0,
     ).to(tl.int64)
-    # A `-1` slot must index page 0 (the sink), not `v2p[-1]`. Triton's `//`
-    # truncates toward zero, so `-1 // ps` is 0 for ps > 1 but -1 at ps == 1,
-    # which reads one element BEFORE the table and feeds the garbage straight
-    # through the clamp below as a live id. Fold the guard in explicitly so
-    # both page sizes -- and this kernel and its CPU reference -- agree.
+    # Triton's `//` truncates toward zero, so `-1 // ps` is 0 for ps > 1 but
+    # -1 at ps == 1, which would read one element BEFORE `v2p`.
     page = tl.where(tok < 0, 0, tok // PAGE_SIZE)
     phys = tl.load(v2p_ptr + page, mask=mask, other=0)
     entry = tl.maximum(phys * mult, 0).to(tl.int32)

--- a/python/sglang/kernels/ops/kvcache/kv_read_table.py
+++ b/python/sglang/kernels/ops/kvcache/kv_read_table.py
@@ -70,7 +70,13 @@ def build_kv_read_table_kernel(
         mask=mask,
         other=0,
     ).to(tl.int64)
-    phys = tl.load(v2p_ptr + tok // PAGE_SIZE, mask=mask, other=0)
+    # A `-1` slot must index page 0 (the sink), not `v2p[-1]`. Triton's `//`
+    # truncates toward zero, so `-1 // ps` is 0 for ps > 1 but -1 at ps == 1,
+    # which reads one element BEFORE the table and feeds the garbage straight
+    # through the clamp below as a live id. Fold the guard in explicitly so
+    # both page sizes -- and this kernel and its CPU reference -- agree.
+    page = tl.where(tok < 0, 0, tok // PAGE_SIZE)
+    phys = tl.load(v2p_ptr + page, mask=mask, other=0)
     entry = tl.maximum(phys * mult, 0).to(tl.int32)
     tl.store(out_ptr + bid.to(tl.int64) * out_stride + cols, entry, mask=mask)
 

--- a/python/sglang/kernels/ops/kvcache/kv_read_table.py
+++ b/python/sglang/kernels/ops/kvcache/kv_read_table.py
@@ -45,11 +45,11 @@ _BLOCK_COLS = 256
 
 @triton.jit
 def build_kv_read_table_kernel(
-    req_to_token_ptr,  # in: [max_reqs, max_context] — VIRTUAL token ids
-    req_pool_indices_ptr,  # in: [bs] — row per batch lane
+    req_to_token_ptr,  # in: [max_reqs, max_context] -- VIRTUAL token ids
+    req_pool_indices_ptr,  # in: [bs] -- row per batch lane
     seq_lens_ptr,  # in: [bs]
-    v2p_ptr,  # in: [num_pages + 1] int64 — virtual->physical page table
-    out_ptr,  # out: [>=bs, >=max_pages] int32 — the read table
+    v2p_ptr,  # in: [num_pages + 1] int64 -- virtual->physical page table
+    out_ptr,  # out: [>=bs, >=max_pages] int32 -- the read table
     req_stride,  # runtime: req_to_token row stride (elements)
     out_stride,  # runtime: out row stride (elements)
     mult,  # runtime: kernel_page_multiplier of the target sub-pool
@@ -92,7 +92,7 @@ def build_kv_read_table(
 
     ``out`` is caller-owned (fresh zeros for the eager path, the module's
     capture-stable buffer for replay) and only its ``[:bs, :max_pages]``
-    region's live prefix is written — never rebound, never tail-cleared.
+    region's live prefix is written -- never rebound, never tail-cleared.
     """
     bs = int(req_pool_indices.numel())
     assert (

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -29,6 +29,7 @@ from sglang.srt.layers.dcp import (
     get_dcp_lens,
 )
 from sglang.srt.layers.radix_attention import AttentionType
+from sglang.srt.mem_cache.base_swa_memory_pool import BaseSWAKVPool
 from sglang.srt.mem_cache.memory_pool import KVWriteLoc
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.model_executor.cuda_graph_config import (
@@ -208,14 +209,17 @@ class TritonAttnBackend(AttentionBackend):
         # Lets the Triton wrappers specialize on PAGE_SIZE; page_size=1 is
         # byte-identical to the slot-based envelope.
         self.page_size = getattr(model_runner, "page_size", 1) or 1
-        # Unified pool v2p hook (None = no-op): req_to_token holds VIRTUAL ids but
-        # kernels need the kernel-facing id space — PHYSICAL for MHA, DENSE for the
-        # per-layer-view MLA pool (translate_kv_loc_for_kernel falls back to the physical
-        # translate when kernel_page_multiplier == 1, so preferring it is exact for
-        # both). Applied eagerly so the captured graph has no translate.
+        # Unified pool v2p WRITE hook (None = no-op): the write loc arrives
+        # VIRTUAL and the store kernels need the kernel-facing id space
+        # (translate_kv_loc_for_kernel falls back to the physical translate when
+        # kernel_page_multiplier == 1, so preferring it is exact for both).
+        # Applied eagerly so the captured graph has no translate.
         self._translate_kv_loc = getattr(
             self.token_to_kv_pool_allocator, "translate_kv_loc_for_kernel", None
         ) or getattr(self.token_to_kv_pool_allocator, "translate_kv_loc", None)
+        # The runner's id translator: every read index this backend builds
+        # gathers from the table it hands out.
+        self.kv_index_translator = model_runner.kv_index_translator
         self.num_draft_tokens = get_spec().speculative_num_draft_tokens
         self.speculative_num_steps = get_spec().speculative_num_steps
         self.topk = get_spec().speculative_eagle_topk or 0
@@ -466,19 +470,20 @@ class TritonAttnBackend(AttentionBackend):
         self,
         bs: int,
         seq_lens: torch.Tensor,
-        req_pool_indices: torch.Tensor,
+        index_table,
         kv_indices: torch.Tensor,
     ) -> torch.Tensor:
         kv_indptr = self.kv_indptr[: bs + 1]
         kv_indptr[1:] = torch.cumsum(seq_lens, dim=0)
         create_flashinfer_kv_indices_triton[(bs,)](
-            self.req_to_token,
-            req_pool_indices,
+            index_table.ids,
+            index_table.row_ids,
             seq_lens,
             kv_indptr,
             None,
             kv_indices,
-            self.req_to_token.stride(0),
+            index_table.row_stride,
+            ENTRY_PAGE_SIZE=index_table.entry_page_size,
         )
         return kv_indptr
 
@@ -487,6 +492,7 @@ class TritonAttnBackend(AttentionBackend):
         bs: int,
         seq_lens: torch.Tensor,
         req_pool_indices: torch.Tensor,
+        index_table,
     ):
         """Fill KV (and SWA) cuda-graph buffers for decode/idle mode.
 
@@ -495,6 +501,9 @@ class TritonAttnBackend(AttentionBackend):
         ``num_kv_splits_lens`` is the per-request length used to size kv splits
         (per-DCP-rank length clamped to >=1 when DCP is enabled, full seq_lens
         otherwise).
+
+        ``index_table`` is the captured read-index view: under the unified pool the
+        gathers below read the converted tables.
         """
         seq_lens = seq_lens[:bs]
         req_pool_indices = req_pool_indices[:bs]
@@ -512,27 +521,20 @@ class TritonAttnBackend(AttentionBackend):
             num_kv_splits_lens = dcp_seq_lens.clamp_min(1)
         else:
             kv_indptr = self._fill_kv_indptr_and_indices(
-                bs, seq_lens, req_pool_indices, self.cuda_graph_kv_indices
+                bs, seq_lens, index_table, self.cuda_graph_kv_indices
             )
-            # Unified pool: VIRTUAL ids written here are translated to PHYSICAL in
-            # init_forward_metadata_out_graph (replay-prep) so the captured graph
-            # carries zero translate nodes.
             num_kv_splits_lens = seq_lens
         window_kv_indptr = self.window_kv_indptr
         window_kv_lens = None
         if self.sliding_window_size is not None and self.sliding_window_size > 0:
-            # Unified pool: leave the window VIRTUAL too (translated alongside the
-            # full kv_indices later); baseline SWA keeps the eager window translate.
             window_kv_indptr, _, window_kv_lens, _ = update_sliding_window_buffer(
                 self.window_kv_indptr,
-                self.req_to_token,
+                index_table,
                 self.sliding_window_size,
                 seq_lens,
-                req_pool_indices,
                 bs,
                 token_to_kv_pool=self.token_to_kv_pool,
                 window_kv_indices=self.cuda_graph_window_kv_indices,
-                skip_full_to_swa_translation=(self._translate_kv_loc is not None),
             )
         return kv_indptr, window_kv_indptr, window_kv_lens, num_kv_splits_lens
 
@@ -540,8 +542,8 @@ class TritonAttnBackend(AttentionBackend):
         self,
         bs: int,
         seq_lens: torch.Tensor,
-        req_pool_indices: torch.Tensor,
         spec_info,
+        index_table,
     ):
         """Fill all cuda-graph buffers for target_verify mode."""
         # Prefer the spec_info's per-request query length (DSpark draft propose
@@ -561,7 +563,7 @@ class TritonAttnBackend(AttentionBackend):
             device=self.device,
         )
         kv_indptr = self._fill_kv_indptr_and_indices(
-            bs, seq_lens, req_pool_indices, self.cuda_graph_kv_indices
+            bs, seq_lens, index_table, self.cuda_graph_kv_indices
         )
         window_kv_indptr = self.window_kv_indptr
         window_kv_indices = None
@@ -574,10 +576,9 @@ class TritonAttnBackend(AttentionBackend):
             window_kv_indptr, window_kv_indices, _, window_kv_offsets[:bs] = (
                 update_sliding_window_buffer(
                     self.window_kv_indptr,
-                    self.req_to_token,
+                    index_table,
                     self.sliding_window_size,
                     seq_lens[:bs],
-                    req_pool_indices,
                     bs,
                     token_to_kv_pool=self.token_to_kv_pool,
                     window_kv_indices=window_kv_indices,
@@ -611,9 +612,9 @@ class TritonAttnBackend(AttentionBackend):
         self,
         bs: int,
         seq_lens: torch.Tensor,
-        req_pool_indices: torch.Tensor,
         forward_mode: ForwardMode,
         spec_info: Optional[SpecInput],
+        index_table,
     ):
         """Fill QO + KV cuda-graph buffers for draft_extend mode."""
         seq_lens = seq_lens[:bs]
@@ -644,7 +645,7 @@ class TritonAttnBackend(AttentionBackend):
             extend_seq_lens = torch.zeros(bs, dtype=torch.int32, device=seq_lens.device)
         kv_lens = torch.clamp(seq_lens - extend_seq_lens, min=0).to(torch.int32)
         kv_indptr = self._fill_kv_indptr_and_indices(
-            bs, kv_lens, req_pool_indices, self.cuda_graph_kv_indices
+            bs, kv_lens, index_table, self.cuda_graph_kv_indices
         )
         return qo_indptr, kv_indptr, num_tokens_per_req
 
@@ -689,7 +690,7 @@ class TritonAttnBackend(AttentionBackend):
                 forward_mode=forward_mode,
                 spec_info=spec_info,
             )
-            out_cache_loc_full_physical = self._translate_cuda_graph_shared_pool_locs(
+            out_cache_loc_full_physical = self._fill_cuda_graph_write_locs(
                 forward_batch, bs
             )
             swa_out_cache_loc = self._fill_cuda_graph_swa_out_cache_loc(forward_batch)
@@ -709,7 +710,7 @@ class TritonAttnBackend(AttentionBackend):
                 spec_info=spec_info,
             )
             # Metadata view is reused from capture; just refill the buffers.
-            self._translate_cuda_graph_shared_pool_locs(forward_batch, bs)
+            self._fill_cuda_graph_write_locs(forward_batch, bs)
             self._fill_cuda_graph_swa_out_cache_loc(forward_batch)
 
     def _fill_cuda_graph_swa_out_cache_loc(
@@ -733,53 +734,18 @@ class TritonAttnBackend(AttentionBackend):
         )
         return self.cuda_graph_swa_out_cache_loc[:n]
 
-    def _translate_cuda_graph_shared_pool_locs(
+    def _fill_cuda_graph_write_locs(
         self, forward_batch: ForwardBatch, bs: int
     ) -> Optional[torch.Tensor]:
-        """Unified pool: eager v2p translate of the cuda-graph read+write LOC buffers,
-        run BEFORE graph.replay() reading the live post-compaction v2p, so the
-        captured graph carries zero translate nodes. No-op for non-unified pools.
+        """Unified pool: eager v2p translate of the cuda-graph WRITE loc into
+        the backend-owned capture-stable buffer, returned as the ``[:n]``
+        view; no-op for non-unified pools.
 
-        Read buffers (full kv_indices, SWA window) are translated IN PLACE; the
-        full-attn WRITE loc is RETURNED as the [:n] view of the backend-owned
-        out_cache_loc_full_physical buffer. Eager .item() bounds are fine here
-        (out-of-graph), so no in-graph translate variant is needed.
+        Runs BEFORE graph.replay() so it reads the live post-compaction v2p.
+        The length comes from the loc's shape, never an ``.item()`` sync.
         """
         if self._translate_kv_loc is None:
             return None
-        # seq_lens_sum is the reliable "mirror present" signal: it is
-        # None-preserving into the replay view, unlike seq_lens_cpu (always a
-        # non-None but stale slice for gpu_only batches). None -> fall back to a
-        # per-step D2H `.item()` on the indptr.
-        have_cpu_mirror = forward_batch.seq_lens_sum is not None
-        # Full-attention read path. kv_indptr[bs] == seq_lens_sum.
-        n_kv = (
-            forward_batch.seq_lens_sum
-            if have_cpu_mirror
-            else int(self.kv_indptr[bs].item())
-        )
-        if n_kv > 0:
-            self.cuda_graph_kv_indices[:n_kv] = self._translate_kv_loc(
-                self.cuda_graph_kv_indices[:n_kv]
-            )
-        # SWA window read path. window_kv_indptr[bs] == sum(min(seq_len, window)).
-        if self.sliding_window_size is not None and self.sliding_window_size > 0:
-            if have_cpu_mirror:
-                n_win = int(
-                    forward_batch.seq_lens_cpu[:bs]
-                    .clamp(max=self.sliding_window_size)
-                    .sum()
-                )
-            else:
-                n_win = int(self.window_kv_indptr[bs].item())
-            if n_win > 0:
-                self.cuda_graph_window_kv_indices[:n_win] = (
-                    self.token_to_kv_pool.translate_loc_from_full_to_swa(
-                        self.cuda_graph_window_kv_indices[:n_win]
-                    )
-                )
-        # Full-attention write path: translate out_cache_loc -> physical into the
-        # capture-stable buffer and RETURN the [:n] view.
         out_cache_loc = forward_batch.out_cache_loc
         n = out_cache_loc.shape[0]
         # Zero the padded tail first: a smaller replay batch leaves [n:] holding
@@ -806,6 +772,9 @@ class TritonAttnBackend(AttentionBackend):
 
         if forward_batch.forward_mode.is_decode_or_idle():
             if spec_info is None or spec_info.kv_indptr is None:
+                index_table = self.kv_index_translator.index_table_for_batch(
+                    forward_batch
+                )
                 # kv_indptr is None for draft-extend's idle batch; build from seq_lens.
                 if self.dcp_size > 1:
                     # DCP: per-rank sharded KV indices, else each rank reads the
@@ -826,11 +795,9 @@ class TritonAttnBackend(AttentionBackend):
                     kv_indptr = self._fill_kv_indptr_and_indices(
                         bs,
                         forward_batch.seq_lens,
-                        forward_batch.req_pool_indices,
+                        index_table,
                         kv_indices,
                     )
-                    if self._translate_kv_loc is not None:
-                        kv_indices = self._translate_kv_loc(kv_indices)
                 if (
                     self.sliding_window_size is not None
                     and self.sliding_window_size > 0
@@ -838,10 +805,9 @@ class TritonAttnBackend(AttentionBackend):
                     window_kv_indptr, window_kv_indices, window_kv_lens, _ = (
                         update_sliding_window_buffer(
                             self.window_kv_indptr,
-                            self.req_to_token,
+                            index_table,
                             self.sliding_window_size,
                             forward_batch.seq_lens,
-                            forward_batch.req_pool_indices,
                             bs,
                             self.device,
                             self.token_to_kv_pool,
@@ -931,10 +897,11 @@ class TritonAttnBackend(AttentionBackend):
             kv_indices = torch.empty(
                 seq_lens_sum, dtype=torch.int64, device=self.device
             )
+            index_table = self.kv_index_translator.index_table_for_batch(forward_batch)
             kv_indptr = self._fill_kv_indptr_and_indices(
                 bs,
                 forward_batch.seq_lens,
-                forward_batch.req_pool_indices,
+                index_table,
                 kv_indices,
             )
 
@@ -947,10 +914,9 @@ class TritonAttnBackend(AttentionBackend):
                     window_kv_offsets,
                 ) = update_sliding_window_buffer(
                     self.window_kv_indptr,
-                    self.req_to_token,
+                    index_table,
                     self.sliding_window_size,
                     forward_batch.seq_lens,
-                    forward_batch.req_pool_indices,
                     bs,
                     self.device,
                     self.token_to_kv_pool,
@@ -969,6 +935,7 @@ class TritonAttnBackend(AttentionBackend):
             attn_lse = None
 
         else:
+            index_table = self.kv_index_translator.index_table_for_batch(forward_batch)
             if self.dcp_size > 1:
                 kv_indptr, kv_indices, _ = self._dcp_kv_indices(
                     forward_batch.req_pool_indices,
@@ -989,11 +956,9 @@ class TritonAttnBackend(AttentionBackend):
                 kv_indptr = self._fill_kv_indptr_and_indices(
                     bs,
                     forward_batch.extend_prefix_lens,
-                    forward_batch.req_pool_indices,
+                    index_table,
                     kv_indices,
                 )
-                if self._translate_kv_loc is not None:
-                    kv_indices = self._translate_kv_loc(kv_indices)
             if self.sliding_window_size is not None and self.sliding_window_size > 0:
                 (
                     window_kv_indptr,
@@ -1002,10 +967,9 @@ class TritonAttnBackend(AttentionBackend):
                     window_kv_offsets,
                 ) = update_sliding_window_buffer(
                     self.window_kv_indptr,
-                    self.req_to_token,
+                    index_table,
                     self.sliding_window_size,
                     forward_batch.extend_prefix_lens,
-                    forward_batch.req_pool_indices,
                     bs,
                     self.device,
                     self.token_to_kv_pool,
@@ -1187,6 +1151,10 @@ class TritonAttnBackend(AttentionBackend):
                 dtype=torch.int64,
                 device=self.device,
             )
+        if self.kv_index_translator.is_translating:
+            self.kv_index_translator.ensure_capture_buffers(
+                max_bs=max_bs, max_context_len=self.max_context_len
+            )
 
     def _build_cuda_graph_forward_metadata(
         self,
@@ -1306,10 +1274,15 @@ class TritonAttnBackend(AttentionBackend):
         Public entry: :py:meth:`init_forward_metadata_out_graph`.
         """
         # NOTE: encoder_lens expected to be zeros or None
+        index_table = self.kv_index_translator.build_index_table(
+            req_pool_indices=req_pool_indices,
+            seq_lens=seq_lens,
+            captured=True,
+        )
         if forward_mode.is_decode_or_idle():
             assert spec_info is None, "Multi-step cuda graph init is not done here."
             _, _, window_kv_lens, num_kv_splits_lens = self._update_decode_kv_buffers(
-                bs, seq_lens, req_pool_indices
+                bs, seq_lens, req_pool_indices, index_table
             )
             self.get_num_kv_splits(
                 self.cuda_graph_num_kv_splits[:bs], num_kv_splits_lens[:bs]
@@ -1320,12 +1293,10 @@ class TritonAttnBackend(AttentionBackend):
                 )
         elif forward_mode.is_target_verify():
             bs = len(req_pool_indices)
-            self._update_target_verify_buffers(
-                bs, seq_lens, req_pool_indices, spec_info
-            )
+            self._update_target_verify_buffers(bs, seq_lens, spec_info, index_table)
         elif forward_mode.is_draft_extend_v2():
             self._update_draft_extend_buffers(
-                bs, seq_lens, req_pool_indices, forward_mode, spec_info
+                bs, seq_lens, forward_mode, spec_info, index_table
             )
         else:
             raise ValueError(
@@ -2246,15 +2217,13 @@ class TritonMultiStepDraftBackend:
 
 def update_sliding_window_buffer(
     window_kv_indptr,
-    req_to_token,
+    index_table,
     sliding_window_size,
     seq_lens,
-    req_pool_indices,
     bs,
     device=None,
     token_to_kv_pool=None,
     window_kv_indices=None,
-    skip_full_to_swa_translation=False,
 ):
     """Fill window KV buffers for sliding-window attention.
 
@@ -2262,13 +2231,12 @@ def update_sliding_window_buffer(
     path); omit it (or pass ``None``) to allocate a fresh tensor (eager path,
     requires ``device``).
 
-    ``skip_full_to_swa_translation=True`` leaves ``window_kv_indices`` as VIRTUAL
-    full-token ids (no eager full->swa translate). The unified-memory-pool cuda-graph
-    builder passes this so the window translate is deferred to
-    ``TritonAttnBackend._translate_cuda_graph_shared_pool_locs`` (run in
-    ``init_forward_metadata_out_graph``, BEFORE ``graph.replay()``), which reads
-    the live v2p and rewrites the static window buffer to swa-physical in place;
-    baseline SWA leaves it False (eager).
+    ``index_table`` is the batch's read-index source view. Unified pool: the
+    gather reads the parallel SWA array (built directly from virtual ids
+    through the swa side's own v2p), so the window indices come out
+    already swa-side ids — no translate here, eager or captured. Static SWA
+    pools gather full-token ids from req_to_token and keep the legacy
+    full->swa translate below.
     """
     window_kv_lens = torch.minimum(
         seq_lens,
@@ -2281,18 +2249,18 @@ def update_sliding_window_buffer(
             window_kv_indptr[-1], dtype=torch.int64, device=device
         )
     window_kv_start_idx = seq_lens - window_kv_lens
+    source_ids = index_table.sliding_window_read_ids()
     create_flashinfer_kv_indices_triton[(bs,)](
-        req_to_token,
-        req_pool_indices,
+        source_ids,
+        index_table.row_ids,
         window_kv_lens,
         window_kv_indptr,
         window_kv_start_idx,
         window_kv_indices,
-        req_to_token.stride(0),
+        source_ids.stride(0),
+        ENTRY_PAGE_SIZE=index_table.entry_page_size,
     )
-    if not skip_full_to_swa_translation and hasattr(
-        token_to_kv_pool, "translate_loc_from_full_to_swa"
-    ):
+    if not index_table.is_translated and isinstance(token_to_kv_pool, BaseSWAKVPool):
         kv_last_index = window_kv_indptr[-1]
         window_kv_indices[:kv_last_index] = (
             token_to_kv_pool.translate_loc_from_full_to_swa(

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -209,11 +209,9 @@ class TritonAttnBackend(AttentionBackend):
         # Lets the Triton wrappers specialize on PAGE_SIZE; page_size=1 is
         # byte-identical to the slot-based envelope.
         self.page_size = getattr(model_runner, "page_size", 1) or 1
-        # Unified pool v2p WRITE hook (None = no-op): the write loc arrives
-        # VIRTUAL and the store kernels need the kernel-facing id space
-        # (translate_kv_loc_for_kernel falls back to the physical translate when
-        # kernel_page_multiplier == 1, so preferring it is exact for both).
-        # Applied eagerly so the captured graph has no translate.
+        # Unified pool WRITE hook (None = no-op): the write loc arrives VIRTUAL
+        # and the store kernels need the kernel-facing space. Applied eagerly so
+        # the captured graph holds no translate.
         self._translate_kv_loc = getattr(
             self.token_to_kv_pool_allocator, "translate_kv_loc_for_kernel", None
         ) or getattr(self.token_to_kv_pool_allocator, "translate_kv_loc", None)

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -218,6 +218,9 @@ class TritonAttnBackend(AttentionBackend):
         # The runner's id translator: every read index this backend builds
         # gathers from the table it hands out.
         self.kv_index_translator = model_runner.kv_index_translator
+        # Set unconditionally: the read site evaluates it before the call,
+        # and a non-translating pool never looks at its value.
+        self.kv_read_tables = None
         self.num_draft_tokens = get_spec().speculative_num_draft_tokens
         self.speculative_num_steps = get_spec().speculative_num_steps
         self.topk = get_spec().speculative_eagle_topk or 0
@@ -1149,10 +1152,9 @@ class TritonAttnBackend(AttentionBackend):
                 dtype=torch.int64,
                 device=self.device,
             )
-        if self.kv_index_translator.is_translating:
-            self.kv_index_translator.ensure_capture_buffers(
-                max_bs=max_bs, max_context_len=self.max_context_len
-            )
+        self.kv_read_tables = self.kv_index_translator.make_capture_tables(
+            max_bs=max_bs, max_context_len=self.max_context_len
+        )
 
     def _build_cuda_graph_forward_metadata(
         self,
@@ -1275,7 +1277,7 @@ class TritonAttnBackend(AttentionBackend):
         index_table = self.kv_index_translator.build_index_table(
             req_pool_indices=req_pool_indices,
             seq_lens=seq_lens,
-            captured=True,
+            into=self.kv_read_tables,
         )
         if forward_mode.is_decode_or_idle():
             assert spec_info is None, "Multi-step cuda graph init is not done here."

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -2234,7 +2234,7 @@ def update_sliding_window_buffer(
     ``index_table`` is the batch's read-index source view. Unified pool: the
     gather reads the parallel SWA array (built directly from virtual ids
     through the swa side's own v2p), so the window indices come out
-    already swa-side ids — no translate here, eager or captured. Static SWA
+    already swa-side ids -- no translate here, eager or captured. Static SWA
     pools gather full-token ids from req_to_token and keep the legacy
     full->swa translate below.
     """

--- a/python/sglang/srt/mem_cache/kv_index_translator.py
+++ b/python/sglang/srt/mem_cache/kv_index_translator.py
@@ -59,6 +59,17 @@ from sglang.srt.mem_cache.multi_ended_allocator import (
 )
 
 
+class KVReadTables(msgspec.Struct, frozen=True):
+    """One capture-stable destination, however many id spaces the pool has.
+
+    A backend holds this and hands it back to `build_index_table(into=...)`;
+    it never has to know whether there is a sliding-window space behind it.
+    """
+
+    full: torch.Tensor
+    sliding_window: Optional[torch.Tensor]
+
+
 class KVIndexTable(msgspec.Struct, frozen=True):
     """Collection of what one batch gathers from."""
 
@@ -122,26 +133,31 @@ class KVIndexTranslator:
             if self.is_translating
             else None
         )
-        self._capture_full_ids: Optional[torch.Tensor] = None
-        self._capture_swa_ids: Optional[torch.Tensor] = None
         self._index_table_memo: Optional[Tuple[weakref.ref, KVIndexTable]] = None
 
-    # -- capture-stable buffers ------------------------------------------------
+    def make_capture_tables(
+        self, *, max_bs: int, max_context_len: int
+    ) -> Optional[KVReadTables]:
+        """Capture-stable destinations for a backend to own, or None when this
+        pool needs no translation and the backend will never fill any.
 
-    def ensure_capture_buffers(self, *, max_bs: int, max_context_len: int) -> None:
-        """Idempotent. Zero-filled ``(max_bs, ceil(ctx/ps))`` int32 per kind:
-        entry 0 is the reserved padding slot in every id space, so a captured
-        graph replaying before any refresh reads padding, not garbage."""
-        if not self.is_translating or self._capture_full_ids is not None:
-            return
+        Zero-filled: entry 0 is the reserved padding slot in every id space, so
+        a captured graph replaying before its first refresh reads padding, not
+        garbage.
+        """
+        if not self.is_translating:
+            return None
         max_pages = -(-max_context_len // self.page_size)
-        self._capture_full_ids = torch.zeros(
-            (max_bs, max_pages), dtype=torch.int32, device=self.device
-        )
-        if self._swa_v2p_table is not None:
-            self._capture_swa_ids = torch.zeros(
+
+        def _zeros():
+            return torch.zeros(
                 (max_bs, max_pages), dtype=torch.int32, device=self.device
             )
+
+        return KVReadTables(
+            full=_zeros(),
+            sliding_window=_zeros() if self._swa_v2p_table is not None else None,
+        )
 
     # -- per-batch view --------------------------------------------------------
 
@@ -151,14 +167,15 @@ class KVIndexTranslator:
         req_pool_indices: torch.Tensor,
         seq_lens: torch.Tensor,
         max_pages: Optional[int] = None,
-        captured: bool = False,
+        into: Optional[KVReadTables] = None,
     ) -> KVIndexTable:
         """The one per-batch entry point.
 
         Non-unified: the raw ``(req_to_token, req_pool_indices)`` passthrough,
-        no tensor ops and no copies. Unified: a fresh table of width
-        ``max_pages`` (eager), or a live-prefix refresh of the capture buffers
-        (``captured=True``), returned WHOLE so its pointer is capture-bakeable.
+        no tensor ops and no copies. Unified: fills each row's live prefix and
+        returns the table WHOLE, so a caller needing a stable pointer (a
+        captured graph bakes it) passes its own tables in ``into``;
+        ``into=None`` allocates of width ``max_pages`` instead.
         """
         if not self.is_translating:
             return KVIndexTable(
@@ -171,17 +188,19 @@ class KVIndexTranslator:
             )
 
         bs = int(req_pool_indices.numel())
-        if captured:
-            assert self._capture_full_ids is not None, (
-                "KVIndexTranslator.build_index_table(captured=True) before "
-                "ensure_capture_buffers()"
+        if into is not None:
+            out_full = into.full
+            out_swa = into.sliding_window
+            # A caller-owned table may be padded wider than req_to_token's span
+            # (trtllm_mla / flashmla pad to a page-count bound); the columns
+            # past it have no source to read, so stop there.
+            width = min(
+                out_full.shape[1] if max_pages is None else max_pages,
+                -(-self.req_to_token.shape[1] // self.page_size),
             )
-            out_full = self._capture_full_ids
-            out_swa = self._capture_swa_ids
-            width = out_full.shape[1] if max_pages is None else max_pages
         else:
             assert max_pages is not None, (
-                "KVIndexTranslator.build_index_table: eager path needs max_pages "
+                "KVIndexTranslator.build_index_table: allocating needs max_pages "
                 "(from the batch's seq_lens_cpu max)"
             )
             width = max_pages
@@ -229,33 +248,18 @@ class KVIndexTranslator:
         req_pool_indices: torch.Tensor,
         seq_lens: torch.Tensor,
     ) -> torch.Tensor:
-        """Fill a backend-owned padded 2-D block table's live prefix with
-        full-attention entries (trtllm_mla / flashmla consume such tables
-        directly — their rows ARE the index table's rows).
-
-        Prefix-only: columns past each row's live pages keep the backend's own
-        fill (-1 sentinel or stale-but-unread values).
-
-        Unified-only: callers dispatch on ``self.is_translating`` and keep
-        their static builder otherwise.
+        """`build_index_table(out=...)` for a caller that wants the tensor back
+        rather than the table: trtllm_mla / flashmla consume a block table
+        directly, its rows already being the index table's rows.
         """
         assert (
             self.is_translating
         ), "KVIndexTranslator.fill_read_table on a pool that needs no translation"
-        max_pages = min(
-            out.shape[1],
-            -(-self.req_to_token.shape[1] // self.page_size),
-        )
-        return build_kv_read_table(
-            req_to_token=self.req_to_token,
+        return self.build_index_table(
             req_pool_indices=req_pool_indices,
             seq_lens=seq_lens,
-            v2p=self._full_v2p_table,
-            multiplier=self._full_page_multiplier,
-            page_size=self.page_size,
-            max_pages=max_pages,
-            out=out,
-        )
+            into=KVReadTables(full=out, sliding_window=None),
+        ).ids
 
     def index_table_for_batch(self, forward_batch) -> KVIndexTable:
         """Eager per-batch view, memoized in one slot keyed by batch identity

--- a/python/sglang/srt/mem_cache/kv_index_translator.py
+++ b/python/sglang/srt/mem_cache/kv_index_translator.py
@@ -13,37 +13,33 @@
 # ==============================================================================
 """Turns the KV ids stored in `req_to_token` into ids attention kernels can use.
 
-WHY THIS EXISTS. A KV slot can be named in more than one **id space**:
+A KV slot can be named in three id spaces:
 
-  * **virtual** - what `req_to_token` stores. Stable: it keeps naming the same
-    logical slot even after the pool moves data around.
+  * **virtual** - what `req_to_token` stores. Keeps naming the same logical
+    slot even after the pool moves data around.
   * **physical** - where that slot sits in the pool right now.
-  * **kernel-facing** - what a kernel can index the per-layer K/V tensors with.
-    Same as physical for a plain pool; under the unified pool's per-layer views it
-    is the physical page scaled by the per-page block count.
+  * **kernel-facing** - what a kernel can index the per-layer K/V tensors
+    with. Same as physical on a plain pool; under the unified pool it is the
+    physical page scaled by the per-page block count.
 
-On a plain pool all three coincide and nothing here does any work. Under the
-unified memory pool they differ, so somebody must convert - and if every
-backend converts for itself, each one has to know the pool's internals and
-each is a place to get it wrong. This module is the one place that converts.
+All three coincide on a plain pool, so nothing here does any work there.
 
-WHAT BACKENDS GET. A `KVIndexTable`, which answers one question: *what do I
-gather from, and which row is mine?*
+Backends get a `KVIndexTable`, which answers "what do I gather from, and
+which row is mine?":
 
-    ids[row_ids[b], pos]        <- the gather every backend already does
+    ids[row_ids[b], pos]
 
-    plain pool : ids = req_to_token, row_ids = req_pool_indices
-                 (literally those objects - no copy, no kernel, no change)
-    unified    : ids = a freshly built array of kernel-facing ids,
+    plain pool : ids = req_to_token, row_ids = req_pool_indices (those very
+                 objects - no copy, no kernel)
+    unified    : ids = a built array of kernel-facing ids,
                  row_ids = arange(batch_size)
 
 Backends call their own copy a *page table* (fa3) or a *block table*
-(trtllm); this module calls what it hands them the **index table**.
+(trtllm); here it is the **index table**.
 
-WHY ONE TABLE IS ENOUGH FOR EVERYONE. Converting only ever rewrites the page
-number and keeps the offset inside the page. So a page-granular table serves
-both kinds of consumer: a block-table backend uses its rows as-is, and a
-backend that wants a flat per-token list rebuilds one with
+Converting only ever rewrites the page number and keeps the in-page offset, so
+one page-granular table serves both kinds of consumer: a block-table backend
+uses its rows as-is, and one that wants flat per-token ids rebuilds them as
 
     token_id = entry * entry_page_size + pos % entry_page_size
 """
@@ -272,11 +268,9 @@ class KVIndexTranslator:
             return memo[1]
         max_pages = None
         if self.is_translating:
-            # `seq_lens_sum` is the reliable "CPU mirror present" signal, not
-            # `seq_lens_cpu`: the latter is a non-None but STALE slice on a
-            # gpu_only batch, and a stale max under-sizes the table, leaving
-            # the columns past it reading as the sink for tokens the kernel
-            # wants. Fall back to the table's own width, which is always safe.
+            # `seq_lens_cpu` is a non-None but STALE slice on a gpu_only
+            # batch; `seq_lens_sum` is the signal that it is live. A stale max
+            # under-sizes the table and the tail then reads as the sink.
             slc = forward_batch.seq_lens_cpu
             if (
                 forward_batch.seq_lens_sum is not None

--- a/python/sglang/srt/mem_cache/kv_index_translator.py
+++ b/python/sglang/srt/mem_cache/kv_index_translator.py
@@ -272,11 +272,19 @@ class KVIndexTranslator:
             return memo[1]
         max_pages = None
         if self.is_translating:
+            # `seq_lens_sum` is the reliable "CPU mirror present" signal, not
+            # `seq_lens_cpu`: the latter is a non-None but STALE slice on a
+            # gpu_only batch, and a stale max under-sizes the table, leaving
+            # the columns past it reading as the sink for tokens the kernel
+            # wants. Fall back to the table's own width, which is always safe.
             slc = forward_batch.seq_lens_cpu
-            if slc is not None and slc.numel() > 0:
+            if (
+                forward_batch.seq_lens_sum is not None
+                and slc is not None
+                and slc.numel() > 0
+            ):
                 max_seq = int(slc.max())
             else:
-                # gpu_only batches carry no CPU mirror; bound by the table.
                 max_seq = self.req_to_token.shape[1]
             max_pages = max(-(-max_seq // self.page_size), 1)
         view = self.build_index_table(

--- a/python/sglang/srt/mem_cache/kv_index_translator.py
+++ b/python/sglang/srt/mem_cache/kv_index_translator.py
@@ -1,0 +1,300 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Turns the KV ids stored in `req_to_token` into ids attention kernels can use.
+
+WHY THIS EXISTS. A KV slot can be named in more than one **id space**:
+
+  * **virtual** - what `req_to_token` stores. Stable: it keeps naming the same
+    logical slot even after the pool moves data around.
+  * **physical** - where that slot sits in the pool right now.
+  * **kernel-facing** - what a kernel can index the per-layer K/V tensors with.
+    Same as physical for a plain pool; under the unified pool's per-layer views it
+    is the physical page scaled by the per-page block count.
+
+On a plain pool all three coincide and nothing here does any work. Under the
+unified memory pool they differ, so somebody must convert - and if every
+backend converts for itself, each one has to know the pool's internals and
+each is a place to get it wrong. This module is the one place that converts.
+
+WHAT BACKENDS GET. A `KVIndexTable`, which answers one question: *what do I
+gather from, and which row is mine?*
+
+    ids[row_ids[b], pos]        <- the gather every backend already does
+
+    plain pool : ids = req_to_token, row_ids = req_pool_indices
+                 (literally those objects - no copy, no kernel, no change)
+    unified    : ids = a freshly built array of kernel-facing ids,
+                 row_ids = arange(batch_size)
+
+Backends call their own copy a *page table* (fa3) or a *block table*
+(trtllm); this module calls what it hands them the **index table**.
+
+WHY ONE TABLE IS ENOUGH FOR EVERYONE. Converting only ever rewrites the page
+number and keeps the offset inside the page. So a page-granular table serves
+both kinds of consumer: a block-table backend uses its rows as-is, and a
+backend that wants a flat per-token list rebuilds one with
+
+    token_id = entry * entry_page_size + pos % entry_page_size
+"""
+
+from __future__ import annotations
+
+import weakref
+from typing import Optional, Tuple
+
+import msgspec
+import torch
+
+from sglang.kernels.ops.kvcache.kv_read_table import build_kv_read_table
+from sglang.srt.mem_cache.multi_ended_allocator import (
+    UnifiedMambaTokenToKVPoolAllocator,
+    UnifiedSWATokenToKVPoolAllocator,
+)
+
+
+class KVIndexTable(msgspec.Struct, frozen=True):
+    """Collection of what one batch gathers from."""
+
+    ids: torch.Tensor  # 2-D array of KV ids to gather from
+    row_ids: torch.Tensor  # which row belongs to batch lane b
+    row_stride: int  # stride between rows of `ids`, in elements
+    entry_page_size: int  # what one entry covers: 1 = a token, N = a page of N
+    is_translated: bool  # entries are already kernel-facing ids
+    sliding_window_ids: Optional[torch.Tensor]  # SWA models: the parallel swa array
+
+    def sliding_window_read_ids(self) -> torch.Tensor:
+        """Which array a sliding-window gather reads: the parallel swa array
+        when translated, else the full-attention array, which the caller maps
+        through the pool's own full->swa map."""
+        return self.sliding_window_ids if self.is_translated else self.ids
+
+
+class KVIndexTranslator:
+    """Built once per ModelRunner."""
+
+    def __init__(
+        self,
+        *,
+        req_to_token: torch.Tensor,
+        token_to_kv_pool_allocator,
+        token_to_kv_pool,
+        page_size: int,
+        device: str,
+    ):
+        self.req_to_token = req_to_token
+        self.page_size = page_size
+        self.device = device
+
+        self.is_translating = (
+            isinstance(
+                token_to_kv_pool_allocator,
+                (UnifiedMambaTokenToKVPoolAllocator, UnifiedSWATokenToKVPoolAllocator),
+            )
+            and token_to_kv_pool_allocator.get_kvcache() is token_to_kv_pool
+        )
+        if self.is_translating:
+            alloc = token_to_kv_pool_allocator
+            self._full_v2p_table = alloc.full_v2p_page_table
+            self._full_page_multiplier = alloc.kernel_page_multiplier
+            self._translate_full = alloc.translate_kv_loc_for_kernel
+            if isinstance(alloc, UnifiedSWATokenToKVPoolAllocator):
+                self._swa_v2p_table = alloc.swa_v2p_page_table
+                self._swa_page_multiplier = alloc.swa_kernel_page_multiplier
+            else:
+                self._swa_v2p_table = None
+                self._swa_page_multiplier = 1
+        else:
+            self._full_v2p_table = None
+            self._full_page_multiplier = 1
+            self._translate_full = None
+            self._swa_v2p_table = None
+            self._swa_page_multiplier = 1
+
+        self._rows: Optional[torch.Tensor] = (
+            torch.arange(req_to_token.shape[0], dtype=torch.int64, device=device)
+            if self.is_translating
+            else None
+        )
+        self._capture_full_ids: Optional[torch.Tensor] = None
+        self._capture_swa_ids: Optional[torch.Tensor] = None
+        self._index_table_memo: Optional[Tuple[weakref.ref, KVIndexTable]] = None
+
+    # -- capture-stable buffers ------------------------------------------------
+
+    def ensure_capture_buffers(self, *, max_bs: int, max_context_len: int) -> None:
+        """Idempotent. Zero-filled ``(max_bs, ceil(ctx/ps))`` int32 per kind:
+        entry 0 is the reserved padding slot in every id space, so a captured
+        graph replaying before any refresh reads padding, not garbage."""
+        if not self.is_translating or self._capture_full_ids is not None:
+            return
+        max_pages = -(-max_context_len // self.page_size)
+        self._capture_full_ids = torch.zeros(
+            (max_bs, max_pages), dtype=torch.int32, device=self.device
+        )
+        if self._swa_v2p_table is not None:
+            self._capture_swa_ids = torch.zeros(
+                (max_bs, max_pages), dtype=torch.int32, device=self.device
+            )
+
+    # -- per-batch view --------------------------------------------------------
+
+    def build_index_table(
+        self,
+        *,
+        req_pool_indices: torch.Tensor,
+        seq_lens: torch.Tensor,
+        max_pages: Optional[int] = None,
+        captured: bool = False,
+    ) -> KVIndexTable:
+        """The one per-batch entry point.
+
+        Non-unified: the raw ``(req_to_token, req_pool_indices)`` passthrough,
+        no tensor ops and no copies. Unified: a fresh table of width
+        ``max_pages`` (eager), or a live-prefix refresh of the capture buffers
+        (``captured=True``), returned WHOLE so its pointer is capture-bakeable.
+        """
+        if not self.is_translating:
+            return KVIndexTable(
+                ids=self.req_to_token,
+                row_ids=req_pool_indices,
+                row_stride=self.req_to_token.stride(0),
+                entry_page_size=1,
+                is_translated=False,
+                sliding_window_ids=None,
+            )
+
+        bs = int(req_pool_indices.numel())
+        if captured:
+            assert self._capture_full_ids is not None, (
+                "KVIndexTranslator.build_index_table(captured=True) before "
+                "ensure_capture_buffers()"
+            )
+            out_full = self._capture_full_ids
+            out_swa = self._capture_swa_ids
+            width = out_full.shape[1] if max_pages is None else max_pages
+        else:
+            assert max_pages is not None, (
+                "KVIndexTranslator.build_index_table: eager path needs max_pages "
+                "(from the batch's seq_lens_cpu max)"
+            )
+            width = max_pages
+            out_full = torch.zeros((bs, width), dtype=torch.int32, device=self.device)
+            out_swa = (
+                torch.zeros((bs, width), dtype=torch.int32, device=self.device)
+                if self._swa_v2p_table is not None
+                else None
+            )
+
+        build_kv_read_table(
+            req_to_token=self.req_to_token,
+            req_pool_indices=req_pool_indices,
+            seq_lens=seq_lens,
+            v2p=self._full_v2p_table,
+            multiplier=self._full_page_multiplier,
+            page_size=self.page_size,
+            max_pages=width,
+            out=out_full,
+        )
+        if out_swa is not None:
+            build_kv_read_table(
+                req_to_token=self.req_to_token,
+                req_pool_indices=req_pool_indices,
+                seq_lens=seq_lens,
+                v2p=self._swa_v2p_table,
+                multiplier=self._swa_page_multiplier,
+                page_size=self.page_size,
+                max_pages=width,
+                out=out_swa,
+            )
+        return KVIndexTable(
+            ids=out_full,
+            row_ids=self._rows[:bs],
+            row_stride=out_full.stride(0),
+            entry_page_size=self.page_size,
+            is_translated=True,
+            sliding_window_ids=out_swa,
+        )
+
+    def fill_read_table(
+        self,
+        *,
+        out: torch.Tensor,
+        req_pool_indices: torch.Tensor,
+        seq_lens: torch.Tensor,
+    ) -> torch.Tensor:
+        """Fill a backend-owned padded 2-D block table's live prefix with
+        full-attention entries (trtllm_mla / flashmla consume such tables
+        directly — their rows ARE the index table's rows).
+
+        Prefix-only: columns past each row's live pages keep the backend's own
+        fill (-1 sentinel or stale-but-unread values).
+
+        Unified-only: callers dispatch on ``self.is_translating`` and keep
+        their static builder otherwise.
+        """
+        assert (
+            self.is_translating
+        ), "KVIndexTranslator.fill_read_table on a pool that needs no translation"
+        max_pages = min(
+            out.shape[1],
+            -(-self.req_to_token.shape[1] // self.page_size),
+        )
+        return build_kv_read_table(
+            req_to_token=self.req_to_token,
+            req_pool_indices=req_pool_indices,
+            seq_lens=seq_lens,
+            v2p=self._full_v2p_table,
+            multiplier=self._full_page_multiplier,
+            page_size=self.page_size,
+            max_pages=max_pages,
+            out=out,
+        )
+
+    def index_table_for_batch(self, forward_batch) -> KVIndexTable:
+        """Eager per-batch view, memoized in one slot keyed by batch identity
+        so multi-consumer metadata builds share a build. The next batch
+        replaces the slot; consumers only read during their own build. The
+        captured path does not memoize — it refreshes its buffers per
+        replay."""
+        memo = self._index_table_memo
+        if memo is not None and memo[0]() is forward_batch:
+            return memo[1]
+        max_pages = None
+        if self.is_translating:
+            slc = forward_batch.seq_lens_cpu
+            if slc is not None and slc.numel() > 0:
+                max_seq = int(slc.max())
+            else:
+                # gpu_only batches carry no CPU mirror; bound by the table.
+                max_seq = self.req_to_token.shape[1]
+            max_pages = max(-(-max_seq // self.page_size), 1)
+        view = self.build_index_table(
+            req_pool_indices=forward_batch.req_pool_indices,
+            seq_lens=forward_batch.seq_lens,
+            max_pages=max_pages,
+        )
+        self._index_table_memo = (weakref.ref(forward_batch), view)
+        return view
+
+    # -- token-level translate surface (the mixin / local-attn consumers) ------
+
+    def translate_full_attn_ids(
+        self, kv_indices: torch.Tensor, *, out: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
+        """Virtual token ids -> kernel-facing full-attention ids (the identity
+        when no translation is needed, so callers never branch)."""
+        if not self.is_translating:
+            assert out is None, "passthrough translate takes no out="
+            return kv_indices
+        return self._translate_full(kv_indices, out=out)

--- a/python/sglang/srt/mem_cache/kv_index_translator.py
+++ b/python/sglang/srt/mem_cache/kv_index_translator.py
@@ -265,7 +265,7 @@ class KVIndexTranslator:
         """Eager per-batch view, memoized in one slot keyed by batch identity
         so multi-consumer metadata builds share a build. The next batch
         replaces the slot; consumers only read during their own build. The
-        captured path does not memoize — it refreshes its buffers per
+        captured path does not memoize -- it refreshes its buffers per
         replay."""
         memo = self._index_table_memo
         if memo is not None and memo[0]() is forward_batch:

--- a/python/sglang/srt/mem_cache/kv_index_translator.py
+++ b/python/sglang/srt/mem_cache/kv_index_translator.py
@@ -247,19 +247,19 @@ class KVIndexTranslator:
         out: torch.Tensor,
         req_pool_indices: torch.Tensor,
         seq_lens: torch.Tensor,
-    ) -> torch.Tensor:
-        """`build_index_table(out=...)` for a caller that wants the tensor back
-        rather than the table: trtllm_mla / flashmla consume a block table
-        directly, its rows already being the index table's rows.
+    ) -> None:
+        """`build_index_table(into=...)` for a caller that owns a bare block
+        table rather than a KVReadTables: trtllm_mla / flashmla consume that
+        table directly, its rows already being the index table's rows.
         """
         assert (
             self.is_translating
         ), "KVIndexTranslator.fill_read_table on a pool that needs no translation"
-        return self.build_index_table(
+        self.build_index_table(
             req_pool_indices=req_pool_indices,
             seq_lens=seq_lens,
             into=KVReadTables(full=out, sliding_window=None),
-        ).ids
+        )
 
     def index_table_for_batch(self, forward_batch) -> KVIndexTable:
         """Eager per-batch view, memoized in one slot keyed by batch identity

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -89,6 +89,7 @@ from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
 from sglang.srt.mem_cache.kv_cache_configurator import (
     KVCacheConfigurator,
 )
+from sglang.srt.mem_cache.kv_index_translator import KVIndexTranslator
 from sglang.srt.mem_cache.memory_pool import HybridReqToTokenPool, ReqToTokenPool
 from sglang.srt.model_executor.cuda_graph_config import (
     cuda_graph_fully_disabled,
@@ -856,6 +857,18 @@ class ModelRunner:
             return
         self.pre_model_load_memory += preloaded_weights_bytes / (1 << 30)
 
+    def init_kv_index_translator(self):
+        """The one object that converts KV ids for this runner: attention
+        backends build their read indices from the table it hands them instead
+        of probing the pool's id spaces themselves."""
+        self.kv_index_translator = KVIndexTranslator(
+            req_to_token=self.req_to_token_pool.req_to_token,
+            token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
+            token_to_kv_pool=self.token_to_kv_pool,
+            page_size=self.page_size or 1,
+            device=self.device,
+        )
+
     def alloc_memory_pool(self, memory_pool_config: Optional[MemoryPoolConfig] = None):
         """Allocate KV cache memory pools only (no backends or cuda graphs)."""
         if memory_pool_config is not None:
@@ -882,6 +895,8 @@ class ModelRunner:
     def _init_post_memory_pool_components(self):
         """Post-pool component wiring, split out of alloc_memory_pool so forks
         that build bespoke memory pools can reuse it after allocating them."""
+        self.init_kv_index_translator()
+
         # Must be called AFTER init_memory_pool so the pool object exists for
         # canary to monkey-patch, and BEFORE init_decode_cuda_graph so warmup
         # forwards captured into the graph see the patched pool methods.

--- a/python/sglang/test/kits/attention_unittest/attention_methods/dense_attention.py
+++ b/python/sglang/test/kits/attention_unittest/attention_methods/dense_attention.py
@@ -411,6 +411,9 @@ class MockModelRunner(ModelRunner):
             page_size=case.page_size,
             get_kvcache=lambda: self.token_to_kv_pool,
         )
+        # The attention backends read their KV ids through the runner's
+        # translator; build the real one (passthrough on a static pool).
+        self.init_kv_index_translator()
         self.attn_cp_size = 1
         self.attention_chunk_size = None
         self.hisparse_coordinator = None

--- a/python/sglang/test/kits/attention_unittest/attention_methods/dense_attention.py
+++ b/python/sglang/test/kits/attention_unittest/attention_methods/dense_attention.py
@@ -411,8 +411,6 @@ class MockModelRunner(ModelRunner):
             page_size=case.page_size,
             get_kvcache=lambda: self.token_to_kv_pool,
         )
-        # The attention backends read their KV ids through the runner's
-        # translator; build the real one (passthrough on a static pool).
         self.init_kv_index_translator()
         self.attn_cp_size = 1
         self.attention_chunk_size = None

--- a/python/sglang/test/kits/attention_unittest/attention_methods/dsa_attention.py
+++ b/python/sglang/test/kits/attention_unittest/attention_methods/dsa_attention.py
@@ -404,6 +404,9 @@ class DSAMockModelRunner(ModelRunner):
             kv_cache_dim=pool_kv_cache_dim,
         )
         self.token_to_kv_pool_allocator = SimpleNamespace(page_size=case.page_size)
+        # The attention backends read their KV ids through the runner's
+        # translator; build the real one (passthrough on a static pool).
+        self.init_kv_index_translator()
         self.attn_cp_size = 1
         self.attention_chunk_size = None
         self.hisparse_coordinator = None

--- a/python/sglang/test/kits/attention_unittest/attention_methods/dsa_attention.py
+++ b/python/sglang/test/kits/attention_unittest/attention_methods/dsa_attention.py
@@ -404,8 +404,6 @@ class DSAMockModelRunner(ModelRunner):
             kv_cache_dim=pool_kv_cache_dim,
         )
         self.token_to_kv_pool_allocator = SimpleNamespace(page_size=case.page_size)
-        # The attention backends read their KV ids through the runner's
-        # translator; build the real one (passthrough on a static pool).
         self.init_kv_index_translator()
         self.attn_cp_size = 1
         self.attention_chunk_size = None

--- a/python/sglang/test/kits/attention_unittest/attention_methods/dual_chunk_attention.py
+++ b/python/sglang/test/kits/attention_unittest/attention_methods/dual_chunk_attention.py
@@ -384,6 +384,9 @@ class DualChunkMockModelRunner(ModelRunner):
             enable_alt_stream=False,
         )
         self.token_to_kv_pool_allocator = SimpleNamespace(page_size=case.page_size)
+        # The attention backends read their KV ids through the runner's
+        # translator; build the real one (passthrough on a static pool).
+        self.init_kv_index_translator()
         self.attn_cp_size = 1
         self.attention_chunk_size = None
         self.hisparse_coordinator = None

--- a/python/sglang/test/kits/attention_unittest/attention_methods/dual_chunk_attention.py
+++ b/python/sglang/test/kits/attention_unittest/attention_methods/dual_chunk_attention.py
@@ -384,8 +384,6 @@ class DualChunkMockModelRunner(ModelRunner):
             enable_alt_stream=False,
         )
         self.token_to_kv_pool_allocator = SimpleNamespace(page_size=case.page_size)
-        # The attention backends read their KV ids through the runner's
-        # translator; build the real one (passthrough on a static pool).
         self.init_kv_index_translator()
         self.attn_cp_size = 1
         self.attention_chunk_size = None

--- a/python/sglang/test/kits/attention_unittest/attention_methods/gdn_attention.py
+++ b/python/sglang/test/kits/attention_unittest/attention_methods/gdn_attention.py
@@ -318,6 +318,9 @@ class MockGDNModelRunner(ModelRunner):
             page_size=case.page_size,
             get_kvcache=lambda: self.token_to_kv_pool,
         )
+        # The attention backends read their KV ids through the runner's
+        # translator; build the real one (passthrough on a static pool).
+        self.init_kv_index_translator()
         self.attn_cp_size = 1
         self.attention_chunk_size = None
         self.hisparse_coordinator = None

--- a/python/sglang/test/kits/attention_unittest/attention_methods/gdn_attention.py
+++ b/python/sglang/test/kits/attention_unittest/attention_methods/gdn_attention.py
@@ -318,8 +318,6 @@ class MockGDNModelRunner(ModelRunner):
             page_size=case.page_size,
             get_kvcache=lambda: self.token_to_kv_pool,
         )
-        # The attention backends read their KV ids through the runner's
-        # translator; build the real one (passthrough on a static pool).
         self.init_kv_index_translator()
         self.attn_cp_size = 1
         self.attention_chunk_size = None

--- a/python/sglang/test/kits/attention_unittest/attention_methods/kda_attention.py
+++ b/python/sglang/test/kits/attention_unittest/attention_methods/kda_attention.py
@@ -317,6 +317,9 @@ class MockKDAModelRunner(ModelRunner):
             enable_alt_stream=False,
         )
         self.token_to_kv_pool_allocator = SimpleNamespace(page_size=case.page_size)
+        # The attention backends read their KV ids through the runner's
+        # translator; build the real one (passthrough on a static pool).
+        self.init_kv_index_translator()
         self.attn_cp_size = 1
         self.attention_chunk_size = None
         self.hisparse_coordinator = None

--- a/python/sglang/test/kits/attention_unittest/attention_methods/kda_attention.py
+++ b/python/sglang/test/kits/attention_unittest/attention_methods/kda_attention.py
@@ -317,8 +317,6 @@ class MockKDAModelRunner(ModelRunner):
             enable_alt_stream=False,
         )
         self.token_to_kv_pool_allocator = SimpleNamespace(page_size=case.page_size)
-        # The attention backends read their KV ids through the runner's
-        # translator; build the real one (passthrough on a static pool).
         self.init_kv_index_translator()
         self.attn_cp_size = 1
         self.attention_chunk_size = None

--- a/python/sglang/test/kits/attention_unittest/attention_methods/lightning_attention.py
+++ b/python/sglang/test/kits/attention_unittest/attention_methods/lightning_attention.py
@@ -326,6 +326,9 @@ class MockLightningModelRunner(ModelRunner):
             enable_alt_stream=False,
         )
         self.token_to_kv_pool_allocator = SimpleNamespace(page_size=case.page_size)
+        # The attention backends read their KV ids through the runner's
+        # translator; build the real one (passthrough on a static pool).
+        self.init_kv_index_translator()
         self.attn_cp_size = 1
         self.attention_chunk_size = None
         self.hisparse_coordinator = None

--- a/python/sglang/test/kits/attention_unittest/attention_methods/lightning_attention.py
+++ b/python/sglang/test/kits/attention_unittest/attention_methods/lightning_attention.py
@@ -326,8 +326,6 @@ class MockLightningModelRunner(ModelRunner):
             enable_alt_stream=False,
         )
         self.token_to_kv_pool_allocator = SimpleNamespace(page_size=case.page_size)
-        # The attention backends read their KV ids through the runner's
-        # translator; build the real one (passthrough on a static pool).
         self.init_kv_index_translator()
         self.attn_cp_size = 1
         self.attention_chunk_size = None

--- a/python/sglang/test/kits/attention_unittest/attention_methods/mamba2_attention.py
+++ b/python/sglang/test/kits/attention_unittest/attention_methods/mamba2_attention.py
@@ -453,6 +453,9 @@ class MockMamba2ModelRunner(ModelRunner):
             enable_alt_stream=False,
         )
         self.token_to_kv_pool_allocator = SimpleNamespace(page_size=case.page_size)
+        # The attention backends read their KV ids through the runner's
+        # translator; build the real one (passthrough on a static pool).
+        self.init_kv_index_translator()
         self.attn_cp_size = 1
         self.attention_chunk_size = None
         self.hisparse_coordinator = None

--- a/python/sglang/test/kits/attention_unittest/attention_methods/mamba2_attention.py
+++ b/python/sglang/test/kits/attention_unittest/attention_methods/mamba2_attention.py
@@ -453,8 +453,6 @@ class MockMamba2ModelRunner(ModelRunner):
             enable_alt_stream=False,
         )
         self.token_to_kv_pool_allocator = SimpleNamespace(page_size=case.page_size)
-        # The attention backends read their KV ids through the runner's
-        # translator; build the real one (passthrough on a static pool).
         self.init_kv_index_translator()
         self.attn_cp_size = 1
         self.attention_chunk_size = None

--- a/python/sglang/test/kits/attention_unittest/attention_methods/mla_attention.py
+++ b/python/sglang/test/kits/attention_unittest/attention_methods/mla_attention.py
@@ -310,6 +310,9 @@ class MockMLAModelRunner(ModelRunner):
             enable_memory_saver=False,
         )
         self.token_to_kv_pool_allocator = SimpleNamespace(page_size=case.page_size)
+        # The attention backends read their KV ids through the runner's
+        # translator; build the real one (passthrough on a static pool).
+        self.init_kv_index_translator()
         self.attn_cp_size = 1
         self.attention_chunk_size = None
         self.hisparse_coordinator = None

--- a/python/sglang/test/kits/attention_unittest/attention_methods/mla_attention.py
+++ b/python/sglang/test/kits/attention_unittest/attention_methods/mla_attention.py
@@ -310,8 +310,6 @@ class MockMLAModelRunner(ModelRunner):
             enable_memory_saver=False,
         )
         self.token_to_kv_pool_allocator = SimpleNamespace(page_size=case.page_size)
-        # The attention backends read their KV ids through the runner's
-        # translator; build the real one (passthrough on a static pool).
         self.init_kv_index_translator()
         self.attn_cp_size = 1
         self.attention_chunk_size = None

--- a/test/registered/attention/test_create_kvindices.py
+++ b/test/registered/attention/test_create_kvindices.py
@@ -77,7 +77,7 @@ class TestCreateKvIndices(CustomTestCase):
 
     def _run_page_table_test(self, batch, ps, with_window_start):
         """ENTRY_PAGE_SIZE > 1: the source is a PAGE-granular table (the unified
-        pool's canonical); the kernel must reconstruct token ids by the affine
+        pool's read table); the kernel must reconstruct token ids by the affine
         rule token = entry * ps + pos % ps — including the kv_start_idx
         (sliding-window) offset path, whose pos is an absolute token position."""
         max_batch, max_pages = 64, 128

--- a/test/registered/attention/test_create_kvindices.py
+++ b/test/registered/attention/test_create_kvindices.py
@@ -75,6 +75,60 @@ class TestCreateKvIndices(CustomTestCase):
         for batch in BATCH:
             self._run_test(batch, MAX_BATCH, MAX_CONTEXT_LEN)
 
+    def _run_page_table_test(self, batch, ps, with_window_start):
+        """ENTRY_PAGE_SIZE > 1: the source is a PAGE-granular table (the unified
+        pool's canonical); the kernel must reconstruct token ids by the affine
+        rule token = entry * ps + pos % ps — including the kv_start_idx
+        (sliding-window) offset path, whose pos is an absolute token position."""
+        max_batch, max_pages = 64, 128
+        page_table = torch.randint(
+            0, 1 << 20, (max_batch, max_pages), dtype=torch.int32
+        )
+        req_pool_indices = torch.tensor(
+            np.random.choice(range(max_batch), size=batch, replace=False),
+            dtype=torch.int32,
+        )
+        lens = torch.tensor(
+            np.random.randint(1, max_pages * ps, size=batch), dtype=torch.int32
+        )
+        if with_window_start:
+            start = torch.clamp(
+                lens - torch.randint(1, ps * 3, (batch,), dtype=torch.int32), min=0
+            )
+            gather_lens = lens - start
+        else:
+            start, gather_lens = None, lens
+        kv_indptr = torch.zeros((batch + 1,), dtype=torch.int32)
+        kv_indptr[1:] = torch.cumsum(gather_lens, dim=0)
+
+        # ref: absolute positions [start, start+len) through the affine rule
+        refs = []
+        for i in range(batch):
+            s = int(start[i]) if start is not None else 0
+            pos = torch.arange(s, s + int(gather_lens[i]), dtype=torch.int64)
+            entry = page_table[int(req_pool_indices[i])][pos // ps].to(torch.int64)
+            refs.append(entry * ps + pos % ps)
+        ref = torch.cat(refs).contiguous()
+
+        out = torch.empty(int(kv_indptr[-1]), dtype=torch.int64)
+        create_flashinfer_kv_indices_triton[(batch,)](
+            page_table,
+            req_pool_indices,
+            gather_lens,
+            kv_indptr,
+            start,
+            out,
+            page_table.size(1),
+            ENTRY_PAGE_SIZE=ps,
+        )
+        self.assertTrue(torch.equal(ref, out))
+
+    def test_page_table_source_reconstruction(self):
+        for batch in (1, 37):
+            for ps in (4, 64, 256):
+                self._run_page_table_test(batch, ps, with_window_start=False)
+                self._run_page_table_test(batch, ps, with_window_start=True)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/attention/test_create_kvindices.py
+++ b/test/registered/attention/test_create_kvindices.py
@@ -78,7 +78,7 @@ class TestCreateKvIndices(CustomTestCase):
     def _run_page_table_test(self, batch, ps, with_window_start):
         """ENTRY_PAGE_SIZE > 1: the source is a PAGE-granular table (the unified
         pool's read table); the kernel must reconstruct token ids by the affine
-        rule token = entry * ps + pos % ps — including the kv_start_idx
+        rule token = entry * ps + pos % ps -- including the kv_start_idx
         (sliding-window) offset path, whose pos is an absolute token position."""
         max_batch, max_pages = 64, 128
         page_table = torch.randint(

--- a/test/registered/unit/mem_cache/test_kv_index_translator.py
+++ b/test/registered/unit/mem_cache/test_kv_index_translator.py
@@ -1,0 +1,547 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""KVIndexTranslator — the read-path id-space choke point.
+
+Covers, CPU-only (the builder's pure-torch reference path; GPU parity of the
+Triton kernel is a later CUDA CI pin):
+  - strict passthrough: a non-unified source returns the SAME req_to_token /
+    req_pool_indices objects — zero tensor ops, no copies (the property that
+    makes backend re-pointing byte-identical for every non-unified server);
+  - static SWA pools keep their legacy full->swa mapping on the view;
+  - the canonical table matches the hand formula
+        entry[b, c] = clamp(v2p[req_to_token[req[b], c*ps] // ps] * mult, 0)
+    over the REAL SWA composite's tables (full AND swa, ps in {1, 4},
+    multiplier in {1, 2L}), with the swa table built from VIRTUAL ids;
+  - sink routing: dead lanes (seq_len 0), -1 req_to_token entries, and
+    tombstoned v2p pages all read entry 0;
+  - the capture contract: buffers are zero-filled and idempotent; a refresh
+    updates ONLY the live prefix (stale tails and rows beyond bs keep prior
+    contents); the returned table is the WHOLE buffer (pointer-stable);
+  - the eager-view memo: a single source-resident slot keyed by batch
+    identity (same batch shares one build; the next batch replaces it; a
+    dead batch never matches).
+
+    python -m pytest test/registered/unit/mem_cache/test_kv_index_translator.py -v
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=8, suite="base-a-test-cpu")
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+from test_multi_ended_allocator import _FakeUnifiedSWAKVPool
+
+from sglang.srt.mem_cache.kv_index_translator import KVIndexTranslator
+from sglang.srt.mem_cache.multi_ended_allocator import (
+    UnifiedSWATokenToKVPoolAllocator,
+)
+from sglang.srt.mem_cache.unified_memory_pool import MHASubPoolSpec, UnifiedKVPool
+
+_DEV = "cpu"
+_FULL_L = 2
+_SWA_L = 3
+
+
+def _build_composite(ps, collapse=False, n_full_pages=16, n_swa_pages=8):
+    full_spec = MHASubPoolSpec(
+        name="full",
+        layer_num=_FULL_L,
+        head_num=2,
+        head_dim=4,
+        store_dtype=torch.float16,
+        grow_direction="up",
+    )
+    swa_spec = MHASubPoolSpec(
+        name="swa",
+        layer_num=_SWA_L,
+        head_num=2,
+        head_dim=4,
+        store_dtype=torch.float16,
+        grow_direction="down",
+    )
+    n_full, n_swa = n_full_pages * ps, n_swa_pages * ps
+    total = n_full * full_spec.entry_bytes() + n_swa * swa_spec.entry_bytes()
+    pool = UnifiedKVPool(
+        total_bytes=total,
+        sub_pool_specs=[full_spec, swa_spec],
+        device=_DEV,
+        enable_memory_saver=False,
+        page_size=ps,
+    )
+    kvcache = _FakeUnifiedSWAKVPool(pool)
+    allocator = UnifiedSWATokenToKVPoolAllocator(
+        unified_buffer=pool,
+        kvcache=kvcache,
+        device=_DEV,
+        full_max_total_num_tokens=n_full,
+        swa_max_total_num_tokens=n_swa,
+        page_size=ps,
+        need_sort=False,
+        forward_stream=None,
+    )
+    if collapse:
+        # The multiplier-1 arm: a sub-pool whose views are NOT dense, so its
+        # kernel-facing ids are the physical ones. No unified sub-pool is built
+        # that way today (the specs all report >1), so pin it here rather than
+        # lose the regime -- the table formula has to hold for both.
+        allocator.full_attn_allocator.kernel_page_multiplier = 1
+        allocator.swa_attn_allocator.kernel_page_multiplier = 1
+    # The real UnifiedSWAKVPool carries the pool-level full->swa translate, so
+    # the fake must too: it IS the runner's token_to_kv_pool (see _make_source),
+    # and a stand-in that lacked the method would force a wrapper object,
+    # modelling a pool/allocator split that never occurs for a target runner.
+    kvcache.translate_loc_from_full_to_swa = allocator.translate_loc_from_full_to_swa
+    return allocator
+
+
+def _make_source(allocator, req_to_token, ps):
+    """The owning runner's source: its token_to_kv_pool IS the allocator's own
+    kvcache. (A runner can share the allocator while owning a different pool —
+    see TestPoolOwnership.)"""
+    return KVIndexTranslator(
+        req_to_token=req_to_token,
+        token_to_kv_pool_allocator=allocator,
+        token_to_kv_pool=allocator.get_kvcache(),
+        page_size=ps,
+        device=_DEV,
+    )
+
+
+def _reference_table(req_to_token, req_pool_indices, seq_lens, v2p, mult, ps, width):
+    """Independent python derivation of the canonical formula."""
+    bs = req_pool_indices.numel()
+    out = torch.zeros((bs, width), dtype=torch.int32)
+    for b in range(bs):
+        req = int(req_pool_indices[b])
+        n_pages = -(-int(seq_lens[b]) // ps)
+        for c in range(min(n_pages, width)):
+            tok = int(req_to_token[req, c * ps])
+            page = 0 if tok < 0 else tok // ps
+            out[b, c] = max(int(v2p[page]) * mult, 0)
+    return out
+
+
+class TestPassthrough(unittest.TestCase):
+    def test_non_unified_returns_same_objects(self):
+        """The strict-passthrough property: no copy, no branch, the exact
+        tensors backends read today. A regression here (any tensor op on the
+        non-unified path) breaks byte-identity for every static-pool server."""
+        req_to_token = torch.arange(64, dtype=torch.int64).reshape(4, 16)
+        src = KVIndexTranslator(
+            req_to_token=req_to_token,
+            token_to_kv_pool_allocator=SimpleNamespace(),  # not a composite
+            token_to_kv_pool=SimpleNamespace(),  # not an SWAKVPool
+            page_size=1,
+            device=_DEV,
+        )
+        self.assertFalse(src.is_translating)
+        rows = torch.tensor([2, 0])
+        view = src.build_index_table(
+            req_pool_indices=rows, seq_lens=torch.tensor([5, 3])
+        )
+        self.assertIs(view.ids, req_to_token)
+        self.assertIs(view.row_ids, rows)
+        self.assertEqual(view.row_stride, req_to_token.stride(0))
+        self.assertEqual(view.entry_page_size, 1)
+        self.assertFalse(view.is_translated)
+        self.assertIsNone(view.sliding_window_ids)
+        # And the translate surface is the identity, not a wrapped copy.
+        t = torch.tensor([1, 2, 3])
+        self.assertIs(src.translate_full_attn_ids(t), t)
+
+
+def _alloc_and_fill(allocator, ps, lens):
+    """Allocate per-request virtual runs and write them into a fake
+    req_to_token; returns (req_to_token, req_pool_indices, seq_lens)."""
+    width = 16 * ps
+    req_to_token = torch.full((len(lens), width), -1, dtype=torch.int64)
+    for r, n in enumerate(lens):
+        n_alloc = -(-n // ps) * ps  # page-aligned virtual run
+        v = allocator.alloc(n_alloc)
+        assert v is not None
+        req_to_token[r, :n] = v[:n]
+    return (
+        req_to_token,
+        torch.arange(len(lens), dtype=torch.int64),
+        torch.tensor(lens, dtype=torch.int64),
+    )
+
+
+class TestCanonicalBuild(unittest.TestCase):
+
+    def test_canonical_matches_reference_dense_and_strided(self):
+        """The load-bearing formula pin: full AND swa canonical tables equal
+        the independent per-element derivation, across page sizes and both
+        multiplier regimes (strided=1, dense=2L). The swa table agreeing with
+        a formula over VIRTUAL ids is also the never-chained-through-
+        full-physical proof."""
+        for ps in (1, 4):
+            for collapse in (True, False):
+                allocator = _build_composite(ps, collapse=collapse)
+                full_mult = allocator.kernel_page_multiplier
+                swa_mult = allocator.swa_kernel_page_multiplier
+                req_to_token, rows, seq_lens = _alloc_and_fill(
+                    allocator, ps, lens=[5 * ps, 2 * ps, 3 * ps - 1]
+                )
+                src = _make_source(allocator, req_to_token, ps)
+                self.assertTrue(src.is_translating)
+                width = 6
+                view = src.build_index_table(
+                    req_pool_indices=rows, seq_lens=seq_lens, max_pages=width
+                )
+                self.assertTrue(view.is_translated)
+                self.assertEqual(view.entry_page_size, ps)
+                self.assertTrue(
+                    torch.equal(view.row_ids, torch.arange(3, dtype=torch.int64))
+                )
+                want_full = _reference_table(
+                    req_to_token,
+                    rows,
+                    seq_lens,
+                    allocator.full_v2p_page_table,
+                    full_mult,
+                    ps,
+                    width,
+                )
+                want_swa = _reference_table(
+                    req_to_token,
+                    rows,
+                    seq_lens,
+                    allocator.swa_v2p_page_table,
+                    swa_mult,
+                    ps,
+                    width,
+                )
+                self.assertTrue(
+                    torch.equal(view.ids, want_full),
+                    f"full canonical off-formula (ps={ps}, mult={full_mult})",
+                )
+                self.assertTrue(
+                    torch.equal(view.sliding_window_ids, want_swa),
+                    f"swa canonical off-formula (ps={ps}, mult={swa_mult})",
+                )
+
+    def test_sink_routing(self):
+        """Dead lanes (seq_len 0), -1 slots inside the live prefix, and
+        tombstoned v2p pages must ALL read entry 0 — one wild entry is a
+        captured-graph OOB read at replay."""
+        ps = 4
+        allocator = _build_composite(ps)
+        req_to_token, rows, seq_lens = _alloc_and_fill(
+            allocator, ps, lens=[3 * ps, 2 * ps, ps]
+        )
+        seq_lens[1] = 0  # dead lane
+        req_to_token[0, ps] = -1  # unwritten slot inside the live prefix
+        # Tombstone row 2's first page on BOTH sides.
+        tomb_page = int(req_to_token[2, 0]) // ps
+        allocator.full_v2p_page_table[tomb_page] = -1
+        allocator.swa_v2p_page_table[tomb_page] = -1
+        src = _make_source(allocator, req_to_token, ps)
+        view = src.build_index_table(
+            req_pool_indices=rows, seq_lens=seq_lens, max_pages=4
+        )
+        for table in (view.ids, view.sliding_window_ids):
+            self.assertTrue(bool((table >= 0).all()))
+            self.assertTrue(bool((table[1] == 0).all()), "dead lane not sunk")
+            self.assertEqual(int(table[0, 1]), 0, "-1 slot not sunk")
+            self.assertEqual(int(table[2, 0]), 0, "tombstone not sunk")
+
+
+class TestBuildInto(unittest.TestCase):
+    """fill_read_table fills a backend-owned padded block table's live prefix with
+    FULL-side canonical entries — the trtllm_mla / flashmla consumption route
+    (their rows ARE the canonical rows)."""
+
+    def test_prefix_filled_tail_sentinel_preserved_width_capped(self):
+        """Three contracts in one batch: entries equal the canonical formula,
+        lanes past each row's live pages keep the backend's -1 sentinel
+        (prefix-only — a tail write scatters the trtllm sentinel contract),
+        and a table padded WIDER than the req_to_token page span (trtllm's
+        LCM alignment) is capped instead of tripping the builder's width
+        assert."""
+        ps = 4
+        allocator = _build_composite(ps)
+        full_mult = allocator.kernel_page_multiplier
+        lens = [5, 2 * ps + 1, 1]
+        req_to_token, rows, seq_lens = _alloc_and_fill(allocator, ps, lens=lens)
+        src = _make_source(allocator, req_to_token, ps)
+        self.assertTrue(src.is_translating)
+
+        width_pages = req_to_token.shape[1] // ps + 3  # wider than the span
+        out = torch.full((len(lens), width_pages), -1, dtype=torch.int32)
+        got = src.fill_read_table(out=out, req_pool_indices=rows, seq_lens=seq_lens)
+        self.assertIs(got, out)
+
+        want = _reference_table(
+            req_to_token,
+            rows,
+            seq_lens,
+            allocator.full_v2p_page_table,
+            full_mult,
+            ps,
+            width_pages,
+        )
+        for b, n in enumerate(lens):
+            n_pages = -(-n // ps)
+            self.assertTrue(
+                torch.equal(out[b, :n_pages], want[b, :n_pages]),
+                f"row {b} live prefix off-formula",
+            )
+            self.assertTrue(
+                bool((out[b, n_pages:] == -1).all()),
+                f"row {b} tail sentinel clobbered",
+            )
+
+    def test_passthrough_source_refuses(self):
+        """Callers dispatch on `enabled`; a passthrough source has no v2p to
+        build from and must fail loud, not fill garbage."""
+        src = KVIndexTranslator(
+            req_to_token=torch.zeros((2, 4), dtype=torch.int64),
+            token_to_kv_pool_allocator=SimpleNamespace(),
+            token_to_kv_pool=SimpleNamespace(),
+            page_size=1,
+            device=_DEV,
+        )
+        with self.assertRaises(AssertionError):
+            src.fill_read_table(
+                out=torch.zeros((1, 4), dtype=torch.int32),
+                req_pool_indices=torch.tensor([0]),
+                seq_lens=torch.tensor([1]),
+            )
+
+
+class TestPoolOwnership(unittest.TestCase):
+    """A runner only gets the kernel-facing id space when the pool IT reads and
+    writes is the one the allocator's ids address.
+
+    Guarded shape: a runner handed a SHARED allocator (one slot index space,
+    one req_to_token) while owning a SEPARATE KV buffer sized to the
+    allocator's SLOT count. Probing the allocator alone reports "unified" for
+    that runner, so its indices would be mapped into the composite's
+    kernel-facing space (kernel-facing ids up to num_pages * multiplier) and then used
+    to address a buffer with only num_slots rows — out of bounds on both the
+    read gather and the KV store.
+    """
+
+    def test_real_factory_bundle_satisfies_the_ownership_identity(self):
+        """The guard rests on `allocator.get_kvcache() is token_to_kv_pool`
+        holding for a REAL target bundle. If a factory ever returned a pool
+        the allocator does not hold, the guard would silently disable the
+        unified path for EVERY model — so pin it against the real factory
+        rather than against this file's own construction."""
+        from sglang.srt.mem_cache.unified_memory_pool import init_unified_swa_pools
+
+        bundle = init_unified_swa_pools(
+            device="cpu",
+            kv_cache_dtype=torch.float16,
+            head_num=2,
+            head_dim=8,
+            v_head_dim=8,
+            swa_head_num=2,
+            swa_head_dim=8,
+            swa_v_head_dim=8,
+            page_size=1,
+            start_layer=0,
+            end_layer=4,
+            swa_attention_layer_ids=[1, 3],
+            full_attention_layer_ids=[0, 2],
+            full_max_total_num_tokens=64,
+            swa_max_total_num_tokens=32,
+            enable_memory_saver=False,
+            need_sort=False,
+        )
+        self.assertIs(
+            bundle.token_to_kv_pool_allocator.get_kvcache(),
+            bundle.token_to_kv_pool,
+        )
+        src = KVIndexTranslator(
+            req_to_token=torch.zeros((2, 8), dtype=torch.int32, device=_DEV),
+            token_to_kv_pool_allocator=bundle.token_to_kv_pool_allocator,
+            token_to_kv_pool=bundle.token_to_kv_pool,
+            page_size=1,
+            device=_DEV,
+        )
+        self.assertTrue(src.is_translating)
+
+    def test_runner_with_its_own_pool_is_disabled(self):
+        """Same allocator, different pool: must stay disabled."""
+        alloc = _build_composite(ps=1)
+        req_to_token = torch.zeros((2, 8), dtype=torch.int32, device=_DEV)
+        own_pool = SimpleNamespace()  # a separate buffer, not the composite's
+        src = KVIndexTranslator(
+            req_to_token=req_to_token,
+            token_to_kv_pool_allocator=alloc,
+            token_to_kv_pool=own_pool,
+            page_size=1,
+            device=_DEV,
+        )
+        self.assertFalse(src.is_translating)
+
+    def test_disabled_source_is_strict_passthrough(self):
+        """Consequence of the guard: such a runner must see RAW virtual ids on
+        the read rail — they index its own pool directly. A translate here is
+        the out-of-bounds bug the ownership identity exists to prevent."""
+        alloc = _build_composite(ps=1)
+        req_to_token = torch.arange(16, dtype=torch.int32, device=_DEV).view(2, 8)
+        src = KVIndexTranslator(
+            req_to_token=req_to_token,
+            token_to_kv_pool_allocator=alloc,
+            token_to_kv_pool=SimpleNamespace(),
+            page_size=1,
+            device=_DEV,
+        )
+        rows = torch.tensor([1, 0], dtype=torch.int32, device=_DEV)
+        view = src.build_index_table(
+            req_pool_indices=rows,
+            seq_lens=torch.tensor([3, 2], dtype=torch.int32, device=_DEV),
+        )
+        # Read rail: the EXACT objects a static-pool backend reads today.
+        self.assertIs(view.ids, req_to_token)
+        self.assertIs(view.row_ids, rows)
+        self.assertFalse(view.is_translated)
+        # And the token-level surface is the identity, same guard.
+        t = torch.tensor([5, 6], dtype=torch.int64, device=_DEV)
+        self.assertIs(src.translate_full_attn_ids(t), t)
+
+
+class TestCaptureContract(unittest.TestCase):
+    def test_capture_buffers_zero_filled_idempotent_and_prefix_only(self):
+        ps = 4
+        allocator = _build_composite(ps)
+        req_to_token = torch.full((4, 16 * ps), -1, dtype=torch.int64)
+        v = allocator.alloc(2 * ps)
+        req_to_token[1, : 2 * ps] = v
+        src = _make_source(allocator, req_to_token, ps)
+
+        src.ensure_capture_buffers(max_bs=4, max_context_len=8 * ps)
+        cap = src._capture_full_ids
+        self.assertTrue(bool((cap == 0).all()), "capture buffers must start zeroed")
+        src.ensure_capture_buffers(max_bs=4, max_context_len=8 * ps)
+        self.assertIs(
+            src._capture_full_ids, cap, "ensure_capture_buffers must be idempotent"
+        )
+
+        # Poison everything, then refresh a 1-row batch: ONLY its live prefix
+        # may change — stale tails and other rows are the fa3 contract.
+        cap.fill_(7)
+        src._capture_swa_ids.fill_(7)
+        view = src.build_index_table(
+            req_pool_indices=torch.tensor([1]),
+            seq_lens=torch.tensor([2 * ps]),
+            captured=True,
+        )
+        self.assertIs(view.ids, cap, "captured view must return the WHOLE buffer")
+        want = allocator.full_v2p_page_table[req_to_token[1, ::ps][:2] // ps] * (
+            2 * _FULL_L
+        )
+        self.assertTrue(torch.equal(cap[0, :2], want.to(torch.int32)))
+        self.assertTrue(bool((cap[0, 2:] == 7).all()), "stale tail was cleared")
+        self.assertTrue(bool((cap[1:] == 7).all()), "rows beyond bs were touched")
+
+    def test_row_ids_not_reallocated_across_builds(self):
+        """`row_ids` is a constant arange sized once from the request pool, so
+        builds at different batch sizes hand back slices of ONE buffer. A
+        per-build `torch.arange` would be correct but would spend an allocation
+        and a launch on every replay prep."""
+        allocator = _build_composite(1)
+        req_to_token, rows, seq_lens = _alloc_and_fill(allocator, 1, lens=[4, 2, 3])
+        src = _make_source(allocator, req_to_token, 1)
+        self.assertTrue(src.is_translating)
+        first = src.build_index_table(
+            req_pool_indices=rows[:2], seq_lens=seq_lens[:2], max_pages=4
+        )
+        second = src.build_index_table(
+            req_pool_indices=rows, seq_lens=seq_lens, max_pages=4
+        )
+        self.assertEqual(first.row_ids.data_ptr(), second.row_ids.data_ptr())
+        self.assertTrue(torch.equal(first.row_ids, torch.arange(2, device=_DEV)))
+        self.assertTrue(torch.equal(second.row_ids, torch.arange(3, device=_DEV)))
+        # Sized to bound any batch the request pool can hold.
+        self.assertGreaterEqual(src._rows.numel(), req_to_token.shape[0])
+
+
+class _FakeForwardBatch:
+    """Weakref-able stand-in (SimpleNamespace is not) carrying the three
+    fields `index_table_for_batch` reads."""
+
+    def __init__(self, *, req_pool_indices, seq_lens, seq_lens_cpu):
+        self.req_pool_indices = req_pool_indices
+        self.seq_lens = seq_lens
+        self.seq_lens_cpu = seq_lens_cpu
+
+
+class TestViewMemo(unittest.TestCase):
+    """The eager view is memoized ON THE SOURCE in a single slot keyed by
+    batch identity — per-batch state stays out of the ForwardBatch (it does
+    not scale with the number of id spaces), and one metadata build's many
+    consumers still share one table build."""
+
+    def _fb(self, allocator, ps, lens):
+        req_to_token, rows, seq_lens = _alloc_and_fill(allocator, ps, lens=lens)
+        fb = _FakeForwardBatch(
+            req_pool_indices=rows,
+            seq_lens=seq_lens,
+            seq_lens_cpu=seq_lens,
+        )
+        return fb, req_to_token
+
+    def test_same_batch_returns_the_memoized_view(self):
+        ps = 1
+        allocator = _build_composite(ps)
+        fb, req_to_token = self._fb(allocator, ps, lens=[3, 2])
+        src = _make_source(allocator, req_to_token, ps)
+        v1 = src.index_table_for_batch(fb)
+        v2 = src.index_table_for_batch(fb)
+        self.assertIs(v1, v2)
+
+    def test_next_batch_replaces_the_single_slot(self):
+        ps = 1
+        allocator = _build_composite(ps)
+        fb1, req_to_token = self._fb(allocator, ps, lens=[3, 2])
+        src = _make_source(allocator, req_to_token, ps)
+        v1 = src.index_table_for_batch(fb1)
+        fb2 = _FakeForwardBatch(
+            req_pool_indices=fb1.req_pool_indices,
+            seq_lens=fb1.seq_lens,
+            seq_lens_cpu=fb1.seq_lens_cpu,
+        )
+        v2 = src.index_table_for_batch(fb2)
+        self.assertIsNot(v1, v2)
+        # Single slot: fb1 no longer matches and rebuilds.
+        v1_again = src.index_table_for_batch(fb1)
+        self.assertIsNot(v1_again, v1)
+
+    def test_dead_batch_never_matches(self):
+        """A garbage-collected batch's slot must not serve a later batch: the
+        weakref key goes dead and the build runs fresh."""
+        import gc
+
+        ps = 1
+        allocator = _build_composite(ps)
+        fb1, req_to_token = self._fb(allocator, ps, lens=[3, 2])
+        src = _make_source(allocator, req_to_token, ps)
+        v1 = src.index_table_for_batch(fb1)
+        del fb1
+        gc.collect()
+        fb2, _ = self._fb(allocator, ps, lens=[2])
+        v2 = src.index_table_for_batch(fb2)
+        self.assertIsNot(v2, v1)
+        self.assertEqual(v2.ids.shape[0], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_kv_index_translator.py
+++ b/test/registered/unit/mem_cache/test_kv_index_translator.py
@@ -415,7 +415,7 @@ class TestPoolOwnership(unittest.TestCase):
 
 
 class TestCaptureContract(unittest.TestCase):
-    def test_capture_buffers_zero_filled_idempotent_and_prefix_only(self):
+    def test_caller_owned_table_is_returned_whole_and_filled_prefix_only(self):
         ps = 4
         allocator = _build_composite(ps)
         req_to_token = torch.full((4, 16 * ps), -1, dtype=torch.int64)
@@ -423,24 +423,21 @@ class TestCaptureContract(unittest.TestCase):
         req_to_token[1, : 2 * ps] = v
         src = _make_source(allocator, req_to_token, ps)
 
-        src.ensure_capture_buffers(max_bs=4, max_context_len=8 * ps)
-        cap = src._capture_full_ids
-        self.assertTrue(bool((cap == 0).all()), "capture buffers must start zeroed")
-        src.ensure_capture_buffers(max_bs=4, max_context_len=8 * ps)
-        self.assertIs(
-            src._capture_full_ids, cap, "ensure_capture_buffers must be idempotent"
-        )
+        tables = src.make_capture_tables(max_bs=4, max_context_len=8 * ps)
+        cap, cap_swa = tables.full, tables.sliding_window
+        self.assertTrue(bool((cap == 0).all()), "read tables must start zeroed")
+        self.assertIsNotNone(cap_swa, "the SWA composite has a second id space")
 
         # Poison everything, then refresh a 1-row batch: ONLY its live prefix
         # may change — stale tails and other rows are the fa3 contract.
         cap.fill_(7)
-        src._capture_swa_ids.fill_(7)
+        cap_swa.fill_(7)
         view = src.build_index_table(
             req_pool_indices=torch.tensor([1]),
             seq_lens=torch.tensor([2 * ps]),
-            captured=True,
+            into=tables,
         )
-        self.assertIs(view.ids, cap, "captured view must return the WHOLE buffer")
+        self.assertIs(view.ids, cap, "the caller's table comes back WHOLE")
         want = allocator.full_v2p_page_table[req_to_token[1, ::ps][:2] // ps] * (
             2 * _FULL_L
         )

--- a/test/registered/unit/mem_cache/test_kv_index_translator.py
+++ b/test/registered/unit/mem_cache/test_kv_index_translator.py
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""KVIndexTranslator — the read-path id-space choke point.
+"""KVIndexTranslator — the read-path id translator.
 
 Covers, CPU-only (the builder's pure-torch reference path; GPU parity of the
 Triton kernel is a later CUDA CI pin):
@@ -19,7 +19,7 @@ Triton kernel is a later CUDA CI pin):
     req_pool_indices objects — zero tensor ops, no copies (the property that
     makes backend re-pointing byte-identical for every non-unified server);
   - static SWA pools keep their legacy full->swa mapping on the view;
-  - the canonical table matches the hand formula
+  - the read table matches the hand formula
         entry[b, c] = clamp(v2p[req_to_token[req[b], c*ps] // ps] * mult, 0)
     over the REAL SWA composite's tables (full AND swa, ps in {1, 4},
     multiplier in {1, 2L}), with the swa table built from VIRTUAL ids;
@@ -118,7 +118,7 @@ def _make_source(allocator, req_to_token, ps):
 
 
 def _reference_table(req_to_token, req_pool_indices, seq_lens, v2p, mult, ps, width):
-    """Independent python derivation of the canonical formula."""
+    """Independent python derivation of the read-table formula."""
     bs = req_pool_indices.numel()
     out = torch.zeros((bs, width), dtype=torch.int32)
     for b in range(bs):
@@ -177,10 +177,10 @@ def _alloc_and_fill(allocator, ps, lens):
     )
 
 
-class TestCanonicalBuild(unittest.TestCase):
+class TestReadTableBuild(unittest.TestCase):
 
-    def test_canonical_matches_reference_dense_and_strided(self):
-        """The load-bearing formula pin: full AND swa canonical tables equal
+    def test_read_table_matches_reference_dense_and_strided(self):
+        """The load-bearing formula pin: full AND swa read tables equal
         the independent per-element derivation, across page sizes and both
         multiplier regimes (strided=1, dense=2L). The swa table agreeing with
         a formula over VIRTUAL ids is also the never-chained-through-
@@ -224,11 +224,11 @@ class TestCanonicalBuild(unittest.TestCase):
                 )
                 self.assertTrue(
                     torch.equal(view.ids, want_full),
-                    f"full canonical off-formula (ps={ps}, mult={full_mult})",
+                    f"full read table off-formula (ps={ps}, mult={full_mult})",
                 )
                 self.assertTrue(
                     torch.equal(view.sliding_window_ids, want_swa),
-                    f"swa canonical off-formula (ps={ps}, mult={swa_mult})",
+                    f"swa read table off-formula (ps={ps}, mult={swa_mult})",
                 )
 
     def test_sink_routing(self):
@@ -259,11 +259,11 @@ class TestCanonicalBuild(unittest.TestCase):
 
 class TestBuildInto(unittest.TestCase):
     """fill_read_table fills a backend-owned padded block table's live prefix with
-    FULL-side canonical entries — the trtllm_mla / flashmla consumption route
-    (their rows ARE the canonical rows)."""
+    FULL-side read-table entries — the trtllm_mla / flashmla consumption route
+    (their rows ARE the read table's rows)."""
 
     def test_prefix_filled_tail_sentinel_preserved_width_capped(self):
-        """Three contracts in one batch: entries equal the canonical formula,
+        """Three contracts in one batch: entries equal the read-table formula,
         lanes past each row's live pages keep the backend's -1 sentinel
         (prefix-only — a tail write scatters the trtllm sentinel contract),
         and a table padded WIDER than the req_to_token page span (trtllm's
@@ -389,7 +389,7 @@ class TestPoolOwnership(unittest.TestCase):
 
     def test_disabled_source_is_strict_passthrough(self):
         """Consequence of the guard: such a runner must see RAW virtual ids on
-        the read rail — they index its own pool directly. A translate here is
+        the read table — they index its own pool directly. A translate here is
         the out-of-bounds bug the ownership identity exists to prevent."""
         alloc = _build_composite(ps=1)
         req_to_token = torch.arange(16, dtype=torch.int32, device=_DEV).view(2, 8)
@@ -405,7 +405,7 @@ class TestPoolOwnership(unittest.TestCase):
             req_pool_indices=rows,
             seq_lens=torch.tensor([3, 2], dtype=torch.int32, device=_DEV),
         )
-        # Read rail: the EXACT objects a static-pool backend reads today.
+        # Read table: the EXACT objects a static-pool backend reads today.
         self.assertIs(view.ids, req_to_token)
         self.assertIs(view.row_ids, rows)
         self.assertFalse(view.is_translated)

--- a/test/registered/unit/mem_cache/test_kv_index_translator.py
+++ b/test/registered/unit/mem_cache/test_kv_index_translator.py
@@ -475,13 +475,16 @@ class TestCaptureContract(unittest.TestCase):
 
 
 class _FakeForwardBatch:
-    """Weakref-able stand-in (SimpleNamespace is not) carrying the three
-    fields `index_table_for_batch` reads."""
+    """Weakref-able stand-in (SimpleNamespace is not) carrying the four
+    fields `index_table_for_batch` reads. `seq_lens_sum` defaults to the real
+    sum: it is the signal that the CPU mirror is live, and a real ForwardBatch
+    always carries it (None only when the batch is gpu_only)."""
 
-    def __init__(self, *, req_pool_indices, seq_lens, seq_lens_cpu):
+    def __init__(self, *, req_pool_indices, seq_lens, seq_lens_cpu, seq_lens_sum=-1):
         self.req_pool_indices = req_pool_indices
         self.seq_lens = seq_lens
         self.seq_lens_cpu = seq_lens_cpu
+        self.seq_lens_sum = int(seq_lens.sum()) if seq_lens_sum == -1 else seq_lens_sum
 
 
 class TestViewMemo(unittest.TestCase):

--- a/test/registered/unit/mem_cache/test_kv_index_translator.py
+++ b/test/registered/unit/mem_cache/test_kv_index_translator.py
@@ -94,16 +94,12 @@ def _build_composite(ps, collapse=False, n_full_pages=16, n_swa_pages=8):
         forward_stream=None,
     )
     if collapse:
-        # The multiplier-1 arm: a sub-pool whose views are NOT dense, so its
-        # kernel-facing ids are the physical ones. No unified sub-pool is built
-        # that way today (the specs all report >1), so pin it here rather than
-        # lose the regime -- the table formula has to hold for both.
+        # The multiplier-1 arm, where kernel-facing ids ARE the physical ones.
+        # No unified sub-pool reports 1 today, so pin the regime here.
         allocator.full_attn_allocator.kernel_page_multiplier = 1
         allocator.swa_attn_allocator.kernel_page_multiplier = 1
-    # The real UnifiedSWAKVPool carries the pool-level full->swa translate, so
-    # the fake must too: it IS the runner's token_to_kv_pool (see _make_source),
-    # and a stand-in that lacked the method would force a wrapper object,
-    # modelling a pool/allocator split that never occurs for a target runner.
+    # The fake IS the runner's token_to_kv_pool, and the real UnifiedSWAKVPool
+    # carries the pool-level full->swa translate, so the fake must too.
     kvcache.translate_loc_from_full_to_swa = allocator.translate_loc_from_full_to_swa
     return allocator
 

--- a/test/registered/unit/mem_cache/test_kv_index_translator.py
+++ b/test/registered/unit/mem_cache/test_kv_index_translator.py
@@ -279,8 +279,7 @@ class TestBuildInto(unittest.TestCase):
 
         width_pages = req_to_token.shape[1] // ps + 3  # wider than the span
         out = torch.full((len(lens), width_pages), -1, dtype=torch.int32)
-        got = src.fill_read_table(out=out, req_pool_indices=rows, seq_lens=seq_lens)
-        self.assertIs(got, out)
+        src.fill_read_table(out=out, req_pool_indices=rows, seq_lens=seq_lens)
 
         want = _reference_table(
             req_to_token,

--- a/test/registered/unit/mem_cache/test_kv_index_translator.py
+++ b/test/registered/unit/mem_cache/test_kv_index_translator.py
@@ -11,12 +11,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""KVIndexTranslator — the read-path id translator.
+"""KVIndexTranslator -- the read-path id translator.
 
 Covers, CPU-only (the builder's pure-torch reference path; GPU parity of the
 Triton kernel is a later CUDA CI pin):
   - strict passthrough: a non-unified source returns the SAME req_to_token /
-    req_pool_indices objects — zero tensor ops, no copies (the property that
+    req_pool_indices objects -- zero tensor ops, no copies (the property that
     makes backend re-pointing byte-identical for every non-unified server);
   - static SWA pools keep their legacy full->swa mapping on the view;
   - the read table matches the hand formula
@@ -106,7 +106,7 @@ def _build_composite(ps, collapse=False, n_full_pages=16, n_swa_pages=8):
 
 def _make_source(allocator, req_to_token, ps):
     """The owning runner's source: its token_to_kv_pool IS the allocator's own
-    kvcache. (A runner can share the allocator while owning a different pool —
+    kvcache. (A runner can share the allocator while owning a different pool --
     see TestPoolOwnership.)"""
     return KVIndexTranslator(
         req_to_token=req_to_token,
@@ -233,7 +233,7 @@ class TestReadTableBuild(unittest.TestCase):
 
     def test_sink_routing(self):
         """Dead lanes (seq_len 0), -1 slots inside the live prefix, and
-        tombstoned v2p pages must ALL read entry 0 — one wild entry is a
+        tombstoned v2p pages must ALL read entry 0 -- one wild entry is a
         captured-graph OOB read at replay."""
         ps = 4
         allocator = _build_composite(ps)
@@ -259,13 +259,13 @@ class TestReadTableBuild(unittest.TestCase):
 
 class TestBuildInto(unittest.TestCase):
     """fill_read_table fills a backend-owned padded block table's live prefix with
-    FULL-side read-table entries — the trtllm_mla / flashmla consumption route
+    FULL-side read-table entries -- the trtllm_mla / flashmla consumption route
     (their rows ARE the read table's rows)."""
 
     def test_prefix_filled_tail_sentinel_preserved_width_capped(self):
         """Three contracts in one batch: entries equal the read-table formula,
         lanes past each row's live pages keep the backend's -1 sentinel
-        (prefix-only — a tail write scatters the trtllm sentinel contract),
+        (prefix-only -- a tail write scatters the trtllm sentinel contract),
         and a table padded WIDER than the req_to_token page span (trtllm's
         LCM alignment) is capped instead of tripping the builder's width
         assert."""
@@ -328,7 +328,7 @@ class TestPoolOwnership(unittest.TestCase):
     allocator's SLOT count. Probing the allocator alone reports "unified" for
     that runner, so its indices would be mapped into the composite's
     kernel-facing space (kernel-facing ids up to num_pages * multiplier) and then used
-    to address a buffer with only num_slots rows — out of bounds on both the
+    to address a buffer with only num_slots rows -- out of bounds on both the
     read gather and the KV store.
     """
 
@@ -336,7 +336,7 @@ class TestPoolOwnership(unittest.TestCase):
         """The guard rests on `allocator.get_kvcache() is token_to_kv_pool`
         holding for a REAL target bundle. If a factory ever returned a pool
         the allocator does not hold, the guard would silently disable the
-        unified path for EVERY model — so pin it against the real factory
+        unified path for EVERY model -- so pin it against the real factory
         rather than against this file's own construction."""
         from sglang.srt.mem_cache.unified_memory_pool import init_unified_swa_pools
 
@@ -388,7 +388,7 @@ class TestPoolOwnership(unittest.TestCase):
 
     def test_disabled_source_is_strict_passthrough(self):
         """Consequence of the guard: such a runner must see RAW virtual ids on
-        the read table — they index its own pool directly. A translate here is
+        the read table -- they index its own pool directly. A translate here is
         the out-of-bounds bug the ownership identity exists to prevent."""
         alloc = _build_composite(ps=1)
         req_to_token = torch.arange(16, dtype=torch.int32, device=_DEV).view(2, 8)
@@ -428,7 +428,7 @@ class TestCaptureContract(unittest.TestCase):
         self.assertIsNotNone(cap_swa, "the SWA composite has a second id space")
 
         # Poison everything, then refresh a 1-row batch: ONLY its live prefix
-        # may change — stale tails and other rows are the fa3 contract.
+        # may change -- stale tails and other rows are the fa3 contract.
         cap.fill_(7)
         cap_swa.fill_(7)
         view = src.build_index_table(
@@ -481,7 +481,7 @@ class _FakeForwardBatch:
 
 class TestViewMemo(unittest.TestCase):
     """The eager view is memoized ON THE SOURCE in a single slot keyed by
-    batch identity — per-batch state stays out of the ForwardBatch (it does
+    batch identity -- per-batch state stays out of the ForwardBatch (it does
     not scale with the number of id spaces), and one metadata build's many
     consumers still share one table build."""
 


### PR DESCRIPTION
> **Note on scope — this PR was split out.** It was previously part of #34613 alongside the 
> migration of the remaining attention backends. Separating the mechanism from the migration 
> keeps this PR reviewable as a pure refactor, and leaves #34613 as the backend-enablement 
> change. The stack was also reordered per review: the read path now lands FIRST, so the 
> write-loc refactor (#35245) can be built directly on the translator instead of being 
> relocated onto it afterwards. Stack order: **#34602 → this PR → #35245 → #34613**.
>
> Only the last 2 commits are for this PR. The other commits are from #34602.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

Each attention backend gathers `req_to_token` itself and then translates the result, so id-space 
knowledge is duplicated across every backend and every forward mode. That duplication is what
made the read path the harder half to extend:  a new backend must re-derive which table to read,
which translation applies, and where in the sequence to apply it.

## Modifications

<!-- Detail the changes made in this pull request. -->

Introduces a single object that owns every id-space decision on the read path, and points the 
Triton backend at it. Index construction becomes a fused gather-and-translate that emits 
kernel-facing ids directly into each row's live prefix, so there is no longer a fill-then-translate 
sequence that a caller could forget, duplicate, or apply to the wrong extent. Per-batch results 
live on the translator, not on the ForwardBatch: the eager view is memoized in a single 
translator-resident slot keyed by batch identity, so one metadata build's many consumers share 
one table build without adding any ForwardBatch field (more hybrid attention kinds mean more 
id spaces per forward — one batch field per id space does not scale). The write path is 
untouched here; it moves onto the same object in #35245.

Byte-identical for non-unified pools, where the translator resolves to the raw `req_to_token` 
and request indices the backends used before.

> **Note:** revalidated on the restructured series, rebased onto current main. Accuracy is GSM8K at n=200 per cell over the full cache x sched x cg x page-size grid (60 unified-vs-baseline pairs, 68/68 cells clean); speed is the product-config serving matrix (12 pairs, 5/5 cells clean). Measured against the parent PR, this PR's own drift is a median +0.08% ITL (range -0.42 … +0.89%), i.e. the read-path refactor is free.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

GSM8K, unified vs. baseline.

| Model family | Median Δ | Range |
|---|---:|---|
| Qwen3.5-9B |+0.75 pt | -3.5 … +2.0 |
| Kimi-Linear-48B |+0.00 pt | -1.5 … +1.5 |
| Falcon-H1-7B |+0.25 pt | -4.0 … +2.0 |
| gpt-oss-20b |+0.25 pt | -5.5 … +4.5 |

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

Serving benchmark (heavy-decode, radix-retract), unified vs. baseline at matched attention backend.

| Model family | Median Δ ITL |
|---|---:|
| Qwen3.5-9B | +0.58% |
| Kimi-Linear-48B | +1.14% |
| Falcon-H1-7B | +0.24% |
| gpt-oss-20b | -0.94% |

## Checklist

- [ ✅ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ✅ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ✅ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ✅ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33365729787](https://github.com/sgl-project/sglang/actions/runs/33365729787)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33365729495](https://github.com/sgl-project/sglang/actions/runs/33365729495)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33365729635](https://github.com/sgl-project/sglang/actions/runs/33365729635)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->