### PR TITLE
[AMD] Qwen3.5: read token count from the fused AR quant tuple

### DIFF
--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -803,7 +803,15 @@ class Qwen3_5LinearDecoderLayer(nn.Module):
             )
         )
 
-        if not forward_batch.forward_mode.is_idle() and hidden_states.shape[0] > 0:
+        # The fused AR+RMSNorm+per-group-quant path hands down a
+        # ``(bf16, fp8, scale)`` tuple, so read the token count off the bf16
+        # element. ``linear_attn`` consumes the tuple itself further down.
+        num_tokens = (
+            hidden_states[0].shape[0]
+            if isinstance(hidden_states, tuple)
+            else hidden_states.shape[0]
+        )
+        if not forward_batch.forward_mode.is_idle() and num_tokens > 0:
             hidden_states = self.linear_attn(
                 hidden_states,
                 forward_batch,


### PR DESCRIPTION
`test_qwen35_fp8_ar_fusion_mi35x.py` has been failing on both `pr-test-amd` and `pr-test-amd-rocm720` since Aug-16 ([log](https://github.com/sgl-project/sglang/actions/runs/32083881457/job/95552260420)):

```
File "python/sglang/srt/models/qwen3_5.py", line 806, in forward
    if not forward_batch.forward_mode.is_idle() and hidden_states.shape[0] > 0:
AttributeError: 'tuple' object has no attribute 'shape'
```

#34474 added an empty-batch guard to both attention layers:

```python
if not forward_batch.forward_mode.is_idle() and hidden_states.shape[0] > 0:
```

That holds for the plain attention layer at line 1210, but not for the GDN layer at line 806. When the AMD fused AR+RMSNorm+per-group-quant path is active, `LayerCommunicator` is built with `enable_fused_ar_quant=True` and `fused_ar_quant_keep_bf16=True`, so `prepare_attn_and_capture_last_layer_outputs` returns a `(bf16, fp8, scale)` tuple rather than a tensor.

`linear_attn` already handles that tuple — `_forward_input_proj` unpacks it via `_select_fused_ar_input_for_linear`. Only the new guard assumes a tensor.

This reads the token count from the bf16 element when the input is a tuple, and leaves the tensor path unchanged. The plain attention layer at line 1210 is built with `fused_ar_quant_keep_bf16=False` and never sees a tuple, so it is left as is.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Notes on the unchecked items: `test_qwen35_fp8_ar_fusion_mi35x.py` already covers this path and is the test that is currently red, so no new test is added. No user-facing behaviour changes, and this is a crash fix with no before number to benchmark.

I have not run this on hardware yet — the change is confined to how the token count is read, but the AMD CI job is the real check.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32101051455](https://github.com/sgl-project/sglang/actions/runs/32101051455)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32101051345](https://github.com/sgl-project/sglang/actions/runs/32101051345)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->