### PR TITLE
[AMD] Add moe_ep_size/moe_tp_size to the allreduce-fusion gate test mock

### DIFF
--- a/test/registered/ops/test_aiter_allreduce_fusion_amd.py
+++ b/test/registered/ops/test_aiter_allreduce_fusion_amd.py
@@ -413,7 +413,12 @@ class TestAiterAllreduceFusionGate(CustomTestCase):
                 mock.patch.object(
                     comm,
                     "get_parallel",
-                    lambda: types.SimpleNamespace(tp_size=tp_world_size),
+                    # The gate also reads moe_ep_size/moe_tp_size to detect
+                    # hybrid EP+TP, so the mock has to carry them. 1 means "not
+                    # hybrid", which is the dense-TP case these tests cover.
+                    lambda: types.SimpleNamespace(
+                        tp_size=tp_world_size, moe_ep_size=1, moe_tp_size=1
+                    ),
                 )
             )
             # the gate reads get_exec().comm.enable_aiter_allreduce_fusion


### PR DESCRIPTION
`test_aiter_allreduce_fusion_amd.py::TestAiterAllreduceFusionGate` has been red on both `pr-test-amd` and `pr-test-amd-rocm720` since Aug-12 ([log](https://github.com/sgl-project/sglang/actions/runs/32083881457/job/95552260314)):

```
File "python/sglang/srt/layers/communicator.py", line 828, in should_fuse_mlp_allreduce_with_next_layer
    if parallel.moe_ep_size > 1 and parallel.moe_tp_size > 1:
AttributeError: 'types.SimpleNamespace' object has no attribute 'moe_ep_size'
```

#30700 added a hybrid EP+TP check to `should_fuse_mlp_allreduce_with_next_layer`, so the gate now reads `moe_ep_size` and `moe_tp_size` off `get_parallel()`. The mock in this test only provides `tp_size`, so every case in the class raises before reaching its assertion.

This adds both attributes to the mock, set to 1. That is the dense-TP configuration these tests are written for: the new guard only short-circuits when both are greater than 1, so 1/1 leaves `test_dense_tp_fuses` asserting the fusion path as before, and the other cases still exercise the DP-attention and EP-backend branches they were added for.

Test-only change; no source behaviour is affected.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

This repairs an existing test rather than adding one, and there is no documentation or performance impact.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32101495165](https://github.com/sgl-project/sglang/actions/runs/32101495165)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32101494926](https://github.com/sgl-project/sglang/actions/runs/32101494926)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->