### PR TITLE
Fix Qwen3-Reranker role mismatch in text reranker path

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_rerank.py
+++ b/python/sglang/srt/entrypoints/openai/serving_rerank.py
@@ -152,10 +152,12 @@ def _render_jinja_chat_template(
         document if isinstance(document, str) else _extract_text_from_content(document)
     )
 
+    # Note: This function is only called for Qwen3-Reranker text path,
+    # detected by the presence of yes/no judgment phrases in the chat template.
     render_kwargs = {
         "messages": [
-            {"role": "user", "content": query_text},
-            {"role": "user", "content": doc_text},
+            {"role": "query", "content": query_text},
+            {"role": "document", "content": doc_text},
         ]
     }
     # Only pass instruct when explicitly provided; template uses `default(...)`

--- a/test/registered/prefill_only/test_serving_rerank.py
+++ b/test/registered/prefill_only/test_serving_rerank.py
@@ -145,6 +145,24 @@ class TestOpenAIServingRerankUnit(unittest.TestCase):
             "I|Q|D",
         )
 
+    def test_helper_render_jinja_chat_template_roles(self):
+        """Verify that messages use 'query' and 'document' roles (not 'user')."""
+        try:
+            import jinja2  # noqa: F401
+        except ModuleNotFoundError:
+            self.skipTest("jinja2 is not installed")
+
+        # Template that selects by role (like the official Qwen3-Reranker template)
+        tpl = (
+            "{{ messages | selectattr('role', 'eq', 'query') | map(attribute='content') | first }}"
+            "|"
+            "{{ messages | selectattr('role', 'eq', 'document') | map(attribute='content') | first }}"
+        )
+        self.assertEqual(
+            _render_jinja_chat_template(tpl, query="my_query", document="my_doc", instruct=None),
+            "my_query|my_doc",
+        )
+
     def test_handle_non_streaming_request_qwen3_path_uses_score_prompts(self):
         class _TM(_DummyTokenizerManager):
             def __init__(self):


### PR DESCRIPTION
Change message roles from 'user' to 'query'/'document' in `_render_jinja_chat_template` to align with the official Qwen3-Reranker chat template which uses selectattr('role', 'eq', 'query'/'document').

The index-based sglang bundled template (messages[0]/messages[1]) remains compatible since the order is unchanged.

## Motivation

`_render_jinja_chat_template` in `serving_rerank.py` sets both query and document messages with `"role": "user"`. However, the official Qwen3-Reranker chat template (shipped with the model's tokenizer) uses `selectattr("role", "eq", "query"/"document")` to extract content:

```jinja
<Query>: {{ messages | selectattr("role", "eq", "query") | map(attribute="content") | first }}
<Document>: {{ messages | selectattr("role", "eq", "document") | map(attribute="content") | first }}
```

## Modifications

- Change message roles from `"user"` to `"query"` and `"document"` in `_render_jinja_chat_template` (`serving_rerank.py`)
- Add `test_helper_render_jinja_chat_template_roles` unit test to verify selectattr-based templates work correctly with the new roles

## Accuracy Tests

N/A — this change only affects prompt rendering for the reranker text path, not model outputs.

## Speed Tests and Profiling

N/A — no inference speed impact.

## Checklist

- [x] Format your code according to the pre-commit guidelines.
- [x] Add unit tests according to the Run and add unit tests guide.
- [ ] Update documentation — N/A
- [ ] Provide accuracy and speed benchmark results — N/A
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32111846189](https://github.com/sgl-project/sglang/actions/runs/32111846189)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32111845883](https://github.com/sgl-project/sglang/actions/runs/32111845883)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->