### PR TITLE
feat(sgl-router): add key_id + ingest prompt_len to S3 token export

### DIFF
--- a/experimental/sgl-router/src/server/cache_sim_extend.rs
+++ b/experimental/sgl-router/src/server/cache_sim_extend.rs
@@ -168,6 +168,7 @@ fn request_has_extension_unsafe_shape(request: &Value) -> bool {
 /// `request_id` is the join key shared with this request's ingress tee, so the
 /// oracle can pair the two records and report the response's output tokens
 /// against the prompt they extend.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn spawn_extend_tee(
     ctx: Arc<AppContext>,
     model: String,
@@ -176,6 +177,7 @@ pub(crate) fn spawn_extend_tee(
     prompt: Option<IngressPrompt>,
     source: ReplySource,
     slug: Option<String>,
+    key_id: Option<String>,
 ) {
     if ctx.cache_sim_tee.is_none() && ctx.s3_export_sink.is_none() {
         return;
@@ -275,6 +277,7 @@ pub(crate) fn spawn_extend_tee(
                         choice.as_ref().map(|c| c.index),
                         choice.as_ref().map(|c| c.count),
                         slug.as_deref(),
+                        key_id.as_deref(),
                     );
                 }
             } else {
@@ -958,6 +961,7 @@ mod spawn_tests {
             }),
             ReplySource::Json(body_with(1, 9)),
             None,
+            None,
         );
 
         let got = wait_for(&cap, 1).await;
@@ -1000,6 +1004,7 @@ mod spawn_tests {
             None,
             ReplySource::Json(body_with(1, 5)),
             None,
+            None,
         );
         let got = wait_for(&cap, 1).await;
         let v = &got[0];
@@ -1028,6 +1033,7 @@ mod spawn_tests {
                 opts,
             }),
             ReplySource::Json(body_with(1, 5)),
+            None,
             None,
         );
         let got = wait_for(&cap, 1).await;
@@ -1063,6 +1069,7 @@ mod spawn_tests {
                 opts,
             }),
             ReplySource::Json(body_with(3, 30)),
+            None,
             None,
         );
 
@@ -1134,6 +1141,7 @@ mod spawn_tests {
             }),
             ReplySource::Json(resp),
             None,
+            None,
         );
         let got = wait_for(&cap, 1).await;
         let v = &got[0];
@@ -1194,6 +1202,7 @@ mod spawn_tests {
             }),
             ReplySource::Json(resp),
             None,
+            None,
         );
         let got = wait_for(&cap, 2).await;
         let mut idx: Vec<u64> = got
@@ -1234,6 +1243,7 @@ mod spawn_tests {
                 opts,
             }),
             ReplySource::Json(body_with(1, 12)),
+            None,
             None,
         );
         let got = wait_for(&cap, 1).await;

--- a/experimental/sgl-router/src/server/routes/chat.rs
+++ b/experimental/sgl-router/src/server/routes/chat.rs
@@ -417,6 +417,7 @@ async fn chat_completions_inner(
             &t.ids,
             &derived_request_id,
             tee_attr.slug.as_deref(),
+            tee_attr.key_id.as_deref(),
         );
     }
     if let Some(p) = &phase {
@@ -617,6 +618,7 @@ async fn chat_completions_inner(
         let prompt = extend_prompt.clone();
         let request_id = derived_request_id.clone();
         let slug = tee_attr.slug.clone();
+        let key_id = tee_attr.key_id.clone();
         move || -> Option<StreamCapture> {
             if !armed {
                 return None;
@@ -658,6 +660,7 @@ async fn chat_completions_inner(
             let prompt = prompt.clone();
             let request_id = request_id.clone();
             let slug = slug.clone();
+            let key_id = key_id.clone();
             Some(StreamCapture {
                 max_bytes: cache_sim_extend::MAX_EXTEND_CAPTURE_BYTES,
                 _permit: permit,
@@ -670,6 +673,7 @@ async fn chat_completions_inner(
                         prompt,
                         ReplySource::Sse(buf),
                         slug,
+                        key_id,
                     );
                 }),
             })
@@ -1349,6 +1353,7 @@ async fn chat_completions_inner(
                     extend_prompt,
                     ReplySource::Json(bytes.clone()),
                     tee_attr.slug.clone(),
+                    tee_attr.key_id.clone(),
                 );
             }
         }

--- a/experimental/sgl-router/src/server/s3_export.rs
+++ b/experimental/sgl-router/src/server/s3_export.rs
@@ -32,6 +32,13 @@ pub(crate) struct ExportRecord {
     pub choice_index: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub choice_count: Option<usize>,
+    /// The upstream gateway's key identifier, read from `x-radixark-key-id`
+    /// (the same attribution the cache-sim tee carries — see
+    /// `cache_sim_tee::Attribution::key_id`). Lets downstream partition export
+    /// records by client key without a separate lookup. Absent for requests
+    /// with no gateway-resolved key (shared-bearer or direct-to-router).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub key_id: Option<String>,
     pub ts: String,
 }
 
@@ -561,6 +568,7 @@ impl S3ExportSink {
         input_ids: &[u32],
         request_id: &str,
         slug: Option<&str>,
+        key_id: Option<&str>,
     ) {
         if input_ids.is_empty() {
             return;
@@ -571,10 +579,14 @@ impl S3ExportSink {
             slug: safe_slug(slug),
             model: model.to_string(),
             input_ids: input_ids.to_vec(),
-            prompt_len: None,
+            // An ingest record's `input_ids` is the whole prompt, so the
+            // boundary is its length. Emitted (rather than left for downstream
+            // to compute) so ingest and extend records share one schema.
+            prompt_len: Some(input_ids.len()),
             output_tokens: None,
             choice_index: None,
             choice_count: None,
+            key_id: key_id.map(str::to_owned),
             ts: chrono::Utc::now().to_rfc3339(),
         });
     }
@@ -590,6 +602,7 @@ impl S3ExportSink {
         choice_index: Option<usize>,
         choice_count: Option<usize>,
         slug: Option<&str>,
+        key_id: Option<&str>,
     ) {
         if input_ids.is_empty() {
             return;
@@ -604,6 +617,7 @@ impl S3ExportSink {
             output_tokens,
             choice_index,
             choice_count,
+            key_id: key_id.map(str::to_owned),
             ts: chrono::Utc::now().to_rfc3339(),
         });
     }
@@ -900,6 +914,7 @@ mod tests {
             output_tokens: None,
             choice_index: None,
             choice_count: None,
+            key_id: None,
             ts: "2026-08-10T00:00:00Z".into(),
         };
         let line = r.to_ndjson_line();
@@ -912,6 +927,7 @@ mod tests {
         assert!(v.get("output_tokens").is_none());
         assert!(v.get("choice_index").is_none());
         assert!(v.get("choice_count").is_none());
+        assert!(v.get("key_id").is_none());
     }
 
     #[test]
@@ -926,6 +942,7 @@ mod tests {
             output_tokens: None,
             choice_index: Some(0),
             choice_count: Some(3),
+            key_id: None,
             ts: "2026-08-10T00:00:00Z".into(),
         };
         let v: serde_json::Value = serde_json::from_str(r.to_ndjson_line().trim_end()).unwrap();
@@ -945,12 +962,14 @@ mod tests {
             output_tokens: Some(9),
             choice_index: None,
             choice_count: None,
+            key_id: Some("key-123".into()),
             ts: "2026-08-10T00:00:00Z".into(),
         };
         let v: serde_json::Value = serde_json::from_str(r.to_ndjson_line().trim_end()).unwrap();
         assert_eq!(v["kind"], "extend");
         assert_eq!(v["prompt_len"], 2);
         assert_eq!(v["output_tokens"], 9);
+        assert_eq!(v["key_id"], "key-123");
     }
 
     #[test]
@@ -1144,7 +1163,7 @@ mod tests {
         let up = Uploader::Fake(Arc::clone(&store));
         let sink =
             S3ExportSink::spawn_with_uploader(up, "pfx".into(), "pod-1".into(), test_metrics());
-        sink.offer_ingest("m", &[1, 2, 3], "rid", Some("slugA"));
+        sink.offer_ingest("m", &[1, 2, 3], "rid", Some("slugA"), Some("key-abc"));
         sink.offer_extend(
             "m",
             &[1, 2, 3, 4],
@@ -1154,6 +1173,7 @@ mod tests {
             None,
             None,
             Some("slugA"),
+            Some("key-abc"),
         );
         sink.drain().await;
 
@@ -1165,6 +1185,10 @@ mod tests {
         assert_eq!(body.lines().count(), 2, "ingest + extend");
         assert!(body.contains("\"kind\":\"ingest\""));
         assert!(body.contains("\"kind\":\"extend\""));
+        // Both records carry the gateway key_id; the ingest record now emits
+        // its prompt_len (= input_ids.len()) so it shares the extend schema.
+        assert_eq!(body.matches("\"key_id\":\"key-abc\"").count(), 2);
+        assert!(body.contains("\"prompt_len\":3"));
     }
 
     #[tokio::test]
@@ -1176,7 +1200,7 @@ mod tests {
             "pod-1".into(),
             test_metrics(),
         );
-        sink.offer_ingest("m", &[7], "rid", None); // missing slug
+        sink.offer_ingest("m", &[7], "rid", None, None); // missing slug
         sink.drain().await;
         let puts = store.puts.lock().unwrap();
         assert_eq!(puts.len(), 1);
@@ -1201,7 +1225,7 @@ mod tests {
         // Offer several records for a single slug.
         const N: usize = 8;
         for i in 0..N {
-            sink.offer_ingest("m", &[i as u32, i as u32 + 1], "rid", Some("slugA"));
+            sink.offer_ingest("m", &[i as u32, i as u32 + 1], "rid", Some("slugA"), None);
         }
         sink.drain().await;
 


### PR DESCRIPTION
## What

Two additive fields on the sgl-router S3 token export records, for offline cache-hit / token-dataset analysis:

1. **`key_id`** on every record (ingest + extend). Carries the upstream gateway's key identifier (`x-radixark-key-id`) — the same attribution the cache-sim tee already reads — so downstream can partition the exported token dataset by client key without a separate lookup.
2. **`prompt_len`** on ingest records. An ingest record's `input_ids` is the whole prompt, so the boundary is its length. Emitting it (rather than leaving downstream to compute `len(input_ids)`) gives ingest and extend records **one shared schema**.

## Why

- Downstream schema unification: both ingest and extend rows now expose `prompt_len` and (optionally) `key_id`.
- Attribution by key: reuses the gateway-resolved `key_id` that already flows through the router, so **no plaintext credential is stored** — only the opaque `key_id`. It is absent (field omitted) for requests with no gateway-resolved key (shared-bearer or direct-to-router), consistent with the cache-sim tee's semantics.

## How

- `s3_export.rs`: add `key_id: Option<String>` to `ExportRecord` (omitted when absent); `offer_ingest` gains a `key_id` param and now sets `prompt_len = Some(input_ids.len())`; `offer_extend` gains a `key_id` param.
- `chat.rs`: pass `tee_attr.key_id` at the ingest offer site and thread it through both `spawn_extend_tee` call sites (streaming closure + non-streaming).
- `cache_sim_extend.rs`: `spawn_extend_tee` gains a `key_id` param, forwarded to `sink.offer_extend`.

## Tests

- Updated all `ExportRecord` constructors and `offer_*` / `spawn_extend_tee` call sites.
- `drain_flushes_offered_records_to_uploader` now asserts both records carry `key_id` and the ingest record emits `prompt_len`.
- `extend_line_*` asserts `key_id` serializes.
- `cargo test --lib` (950 passed), `cargo clippy --lib` (clean), `cargo fmt` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32104676452](https://github.com/sgl-project/sglang/actions/runs/32104676452)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32104676292](https://github.com/sgl-project/sglang/actions/runs/32104676292)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->