### PR TITLE
fix(model-gateway): accept token ID prompts in /v1/completions

### DIFF
--- a/sgl-model-gateway/src/completion.rs
+++ b/sgl-model-gateway/src/completion.rs
@@ -101,8 +101,9 @@ fn format_token_ids(token_ids: &[i32]) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use serde_json::json;
+
+    use super::*;
 
     #[test]
     fn accepts_and_round_trips_all_completion_prompt_shapes() {

--- a/sgl-model-gateway/src/completion.rs
+++ b/sgl-model-gateway/src/completion.rs
@@ -1,0 +1,146 @@
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+use crate::protocols::{
+    common::{GenerationRequest, InputIds, StringOrArray},
+    completion::CompletionRequest as TextCompletionRequest,
+};
+
+/// `/v1/completions` request accepted by the gateway.
+///
+/// `openai-protocol` currently models `prompt` as string-or-string-array,
+/// while SGLang's Python endpoint also accepts token IDs. Keep the existing
+/// typed request for text prompts and use a transparent envelope for token-ID
+/// prompts so extension fields are forwarded unchanged.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum CompletionRequest {
+    Text(Box<TextCompletionRequest>),
+    TokenIds(TokenIdCompletionRequest),
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct TokenIdCompletionRequest {
+    pub model: String,
+    pub prompt: InputIds,
+    #[serde(default)]
+    pub stream: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub logprobs: Option<u32>,
+    #[serde(flatten)]
+    pub other: Map<String, Value>,
+}
+
+impl CompletionRequest {
+    pub fn model(&self) -> &str {
+        match self {
+            Self::Text(request) => &request.model,
+            Self::TokenIds(request) => &request.model,
+        }
+    }
+
+    pub fn logprobs(&self) -> Option<u32> {
+        match self {
+            Self::Text(request) => request.logprobs,
+            Self::TokenIds(request) => request.logprobs,
+        }
+    }
+
+    pub fn batch_size(&self) -> Option<usize> {
+        match self {
+            Self::Text(request) => match &request.prompt {
+                StringOrArray::Array(prompts) if !prompts.is_empty() => Some(prompts.len()),
+                _ => None,
+            },
+            Self::TokenIds(request) => match &request.prompt {
+                InputIds::Batch(prompts) if !prompts.is_empty() => Some(prompts.len()),
+                _ => None,
+            },
+        }
+    }
+
+    pub fn first_prompt_for_routing(&self) -> Option<String> {
+        match self {
+            Self::Text(request) => match &request.prompt {
+                StringOrArray::String(prompt) => Some(prompt.clone()),
+                StringOrArray::Array(prompts) => prompts.first().cloned(),
+            },
+            Self::TokenIds(request) => match &request.prompt {
+                InputIds::Single(token_ids) => Some(format_token_ids(token_ids)),
+                InputIds::Batch(prompts) => prompts.first().map(|ids| format_token_ids(ids)),
+            },
+        }
+    }
+}
+
+impl GenerationRequest for CompletionRequest {
+    fn is_stream(&self) -> bool {
+        match self {
+            Self::Text(request) => request.stream,
+            Self::TokenIds(request) => request.stream,
+        }
+    }
+
+    fn get_model(&self) -> Option<&str> {
+        Some(self.model())
+    }
+
+    fn extract_text_for_routing(&self) -> String {
+        self.first_prompt_for_routing().unwrap_or_default()
+    }
+}
+
+fn format_token_ids(token_ids: &[i32]) -> String {
+    let mut rendered = String::from("token_ids:");
+    for token_id in token_ids {
+        rendered.push(' ');
+        rendered.push_str(&token_id.to_string());
+    }
+    rendered
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn accepts_and_round_trips_all_completion_prompt_shapes() {
+        let cases = [
+            json!("hello"),
+            json!(["hello", "world"]),
+            json!([1, 2, 3]),
+            json!([[1, 2], [3, 4]]),
+        ];
+
+        for prompt in cases {
+            let payload = json!({
+                "model": "test-model",
+                "prompt": prompt,
+                "max_tokens": 4,
+                "custom_extension": true,
+            });
+            let request: CompletionRequest = serde_json::from_value(payload.clone()).unwrap();
+            let serialized = serde_json::to_value(request).unwrap();
+            assert_eq!(serialized["prompt"], payload["prompt"]);
+            assert_eq!(serialized["custom_extension"], true);
+        }
+    }
+
+    #[test]
+    fn distinguishes_token_sequence_from_token_batch() {
+        let single: CompletionRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "prompt": [1, 2, 3]
+        }))
+        .unwrap();
+        let batch: CompletionRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "prompt": [[1, 2], [3, 4]]
+        }))
+        .unwrap();
+
+        assert_eq!(single.batch_size(), None);
+        assert_eq!(batch.batch_size(), Some(2));
+    }
+}

--- a/sgl-model-gateway/src/completion.rs
+++ b/sgl-model-gateway/src/completion.rs
@@ -65,10 +65,10 @@ impl CompletionRequest {
                 StringOrArray::String(prompt) => Some(prompt.clone()),
                 StringOrArray::Array(prompts) => prompts.first().cloned(),
             },
-            Self::TokenIds(request) => match &request.prompt {
-                InputIds::Single(token_ids) => Some(format_token_ids(token_ids)),
-                InputIds::Batch(prompts) => prompts.first().map(|ids| format_token_ids(ids)),
-            },
+            // The current cache-aware policy matches character prefixes. Rendering
+            // token IDs as text would create false matches between unrelated token
+            // sequences, so token-ID requests use the no-request-text fallback.
+            Self::TokenIds(_) => None,
         }
     }
 }
@@ -88,15 +88,6 @@ impl GenerationRequest for CompletionRequest {
     fn extract_text_for_routing(&self) -> String {
         self.first_prompt_for_routing().unwrap_or_default()
     }
-}
-
-fn format_token_ids(token_ids: &[i32]) -> String {
-    let mut rendered = String::from("token_ids:");
-    for token_id in token_ids {
-        rendered.push(' ');
-        rendered.push_str(&token_id.to_string());
-    }
-    rendered
 }
 
 #[cfg(test)]
@@ -143,5 +134,42 @@ mod tests {
 
         assert_eq!(single.batch_size(), None);
         assert_eq!(batch.batch_size(), Some(2));
+    }
+
+    #[test]
+    fn preserves_text_prompt_routing_behavior() {
+        let single: CompletionRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "prompt": "shared text prefix"
+        }))
+        .unwrap();
+        let batch: CompletionRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "prompt": ["first prompt", "second prompt"]
+        }))
+        .unwrap();
+
+        assert_eq!(
+            single.first_prompt_for_routing().as_deref(),
+            Some("shared text prefix")
+        );
+        assert_eq!(
+            batch.first_prompt_for_routing().as_deref(),
+            Some("first prompt")
+        );
+    }
+
+    #[test]
+    fn token_id_prompts_do_not_create_text_routing_keys() {
+        for prompt in [json!([1]), json!([2]), json!([[1, 2], [3, 4]])] {
+            let request: CompletionRequest = serde_json::from_value(json!({
+                "model": "test-model",
+                "prompt": prompt
+            }))
+            .unwrap();
+
+            assert_eq!(request.first_prompt_for_routing(), None);
+            assert_eq!(request.extract_text_for_routing(), "");
+        }
     }
 }

--- a/sgl-model-gateway/src/lib.rs
+++ b/sgl-model-gateway/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod app_context;
 pub use smg_auth as auth;
+pub mod completion;
 pub mod config;
 pub mod core;
 pub mod middleware;

--- a/sgl-model-gateway/src/routers/http/pd_router.rs
+++ b/sgl-model-gateway/src/routers/http/pd_router.rs
@@ -17,6 +17,7 @@ use tracing::{debug, error, warn};
 
 use super::pd_types::api_path;
 use crate::{
+    completion::CompletionRequest,
     config::types::RetryConfig,
     core::{
         is_retryable_status, HashRing, RetryExecutor, Worker, WorkerLoadGuard, WorkerRegistry,
@@ -31,8 +32,7 @@ use crate::{
     protocols::{
         chat::ChatCompletionRequest,
         classify::ClassifyRequest,
-        common::{GenerationRequest, InputIds, StringOrArray},
-        completion::CompletionRequest,
+        common::{GenerationRequest, InputIds},
         embedding::EmbeddingRequest,
         generate::GenerateRequest,
         rerank::RerankRequest,
@@ -221,12 +221,7 @@ impl PDRouter {
     }
 
     fn get_completion_batch_size(req: &CompletionRequest) -> Option<usize> {
-        if let StringOrArray::Array(arr) = &req.prompt {
-            if !arr.is_empty() {
-                return Some(arr.len());
-            }
-        }
-        None
+        req.batch_size()
     }
 
     // Static key strings to avoid per-request allocations
@@ -1626,14 +1621,11 @@ impl RouterTrait for PDRouter {
         body: &CompletionRequest,
         model_id: Option<&str>,
     ) -> Response {
-        let is_stream = body.stream;
-        let return_logprob = body.logprobs.is_some();
+        let is_stream = body.is_stream();
+        let return_logprob = body.logprobs().is_some();
 
         let request_text = if self.policies_need_request_text() {
-            match &body.prompt {
-                StringOrArray::String(s) => Some(s.clone()),
-                StringOrArray::Array(v) => v.first().map(|s| s.to_string()),
-            }
+            body.first_prompt_for_routing()
         } else {
             None
         };

--- a/sgl-model-gateway/src/routers/http/pd_router.rs
+++ b/sgl-model-gateway/src/routers/http/pd_router.rs
@@ -1782,6 +1782,25 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_completion_token_id_batch_semantics() {
+        let single: CompletionRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "prompt": [1, 2, 3]
+        }))
+        .expect("valid single token-ID prompt");
+        let batch: CompletionRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "prompt": [[1, 2], [3, 4]]
+        }))
+        .expect("valid batched token-ID prompt");
+
+        assert_eq!(PDRouter::get_completion_batch_size(&single), None);
+        assert_eq!(PDRouter::get_completion_batch_size(&batch), Some(2));
+        assert_eq!(single.first_prompt_for_routing(), None);
+        assert_eq!(batch.first_prompt_for_routing(), None);
+    }
+
     #[tokio::test]
     async fn test_select_healthy_prefill_worker() {
         let router = create_test_pd_router();

--- a/sgl-model-gateway/src/routers/http/router.rs
+++ b/sgl-model-gateway/src/routers/http/router.rs
@@ -13,6 +13,7 @@ use tracing::{debug, error};
 
 use crate::{
     app_context::AppContext,
+    completion::CompletionRequest,
     config::types::RetryConfig,
     core::{
         is_retryable_status, AttachedBody, ConnectionMode, RetryExecutor, Worker, WorkerLoadGuard,
@@ -28,7 +29,6 @@ use crate::{
         chat::ChatCompletionRequest,
         classify::ClassifyRequest,
         common::GenerationRequest,
-        completion::CompletionRequest,
         embedding::EmbeddingRequest,
         generate::GenerateRequest,
         rerank::{RerankRequest, RerankResponse, RerankResult},

--- a/sgl-model-gateway/src/routers/http/router.rs
+++ b/sgl-model-gateway/src/routers/http/router.rs
@@ -198,9 +198,29 @@ impl Router {
         route: &'static str,
         model_id: Option<&str>,
     ) -> Response {
+        let request_text = Some(typed_req.extract_text_for_routing());
+        self.route_typed_request_with_routing_text(
+            headers,
+            typed_req,
+            route,
+            model_id,
+            request_text,
+        )
+        .await
+    }
+
+    async fn route_typed_request_with_routing_text<
+        T: GenerationRequest + serde::Serialize + Clone,
+    >(
+        &self,
+        headers: Option<&HeaderMap>,
+        typed_req: &T,
+        route: &'static str,
+        model_id: Option<&str>,
+        request_text: Option<String>,
+    ) -> Response {
         let start = Instant::now();
         let is_stream = typed_req.is_stream();
-        let text = typed_req.extract_text_for_routing();
         let model = model_id.unwrap_or(UNKNOWN_MODEL_ID);
         let endpoint = route_to_endpoint(route);
 
@@ -219,7 +239,14 @@ impl Router {
             // operation per attempt
             |_: u32| async {
                 let res = self
-                    .route_typed_request_once(headers, typed_req, route, model_id, is_stream, &text)
+                    .route_typed_request_once(
+                        headers,
+                        typed_req,
+                        route,
+                        model_id,
+                        is_stream,
+                        request_text.as_deref(),
+                    )
                     .await;
 
                 // Need to be outside `route_typed_request_once` because that function has multiple return paths
@@ -277,10 +304,10 @@ impl Router {
         route: &'static str,
         model_id: Option<&str>,
         is_stream: bool,
-        text: &str,
+        request_text: Option<&str>,
     ) -> Response {
         let worker = match self
-            .select_worker_for_model(model_id, Some(text), headers)
+            .select_worker_for_model(model_id, request_text, headers)
             .await
         {
             Some(w) => w,
@@ -772,8 +799,14 @@ impl RouterTrait for Router {
         body: &CompletionRequest,
         model_id: Option<&str>,
     ) -> Response {
-        self.route_typed_request(headers, body, "/v1/completions", model_id)
-            .await
+        self.route_typed_request_with_routing_text(
+            headers,
+            body,
+            "/v1/completions",
+            model_id,
+            body.first_prompt_for_routing(),
+        )
+        .await
     }
 
     async fn route_responses(

--- a/sgl-model-gateway/src/routers/mod.rs
+++ b/sgl-model-gateway/src/routers/mod.rs
@@ -10,14 +10,16 @@ use axum::{
     response::{IntoResponse, Response},
 };
 
-use crate::protocols::{
-    chat::ChatCompletionRequest,
-    classify::ClassifyRequest,
+use crate::{
     completion::CompletionRequest,
-    embedding::EmbeddingRequest,
-    generate::GenerateRequest,
-    rerank::RerankRequest,
-    responses::{ResponsesGetParams, ResponsesRequest},
+    protocols::{
+        chat::ChatCompletionRequest,
+        classify::ClassifyRequest,
+        embedding::EmbeddingRequest,
+        generate::GenerateRequest,
+        rerank::RerankRequest,
+        responses::{ResponsesGetParams, ResponsesRequest},
+    },
 };
 
 pub mod conversations;

--- a/sgl-model-gateway/src/routers/router_manager.rs
+++ b/sgl-model-gateway/src/routers/router_manager.rs
@@ -20,12 +20,12 @@ use tracing::{debug, info, warn};
 
 use crate::{
     app_context::AppContext,
+    completion::CompletionRequest,
     config::RoutingMode,
     core::{ConnectionMode, RuntimeType, WorkerRegistry, WorkerType},
     protocols::{
         chat::ChatCompletionRequest,
         classify::ClassifyRequest,
-        completion::CompletionRequest,
         embedding::EmbeddingRequest,
         generate::GenerateRequest,
         rerank::RerankRequest,
@@ -569,7 +569,7 @@ impl RouterTrait for RouterManager {
         // In non-IGW mode, pass through to router (router handles validation)
         let effective_model_id = if self.enable_igw {
             // Use provided model_id or fall back to body.model
-            let model = model_id.or(Some(&body.model));
+            let model = model_id.or(Some(body.model()));
             match self.resolve_model_id(model) {
                 Ok(id) => Some(id),
                 Err(err_response) => return *err_response,
@@ -588,7 +588,7 @@ impl RouterTrait for RouterManager {
         } else {
             (
                 StatusCode::NOT_FOUND,
-                format!("Model '{}' not found or no router available", body.model),
+                format!("Model '{}' not found or no router available", body.model()),
             )
                 .into_response()
         }

--- a/sgl-model-gateway/src/server.rs
+++ b/sgl-model-gateway/src/server.rs
@@ -25,6 +25,7 @@ use wfaas::LoggingSubscriber;
 
 use crate::{
     app_context::AppContext,
+    completion::CompletionRequest,
     config::{RouterConfig, RoutingMode},
     core::{
         job_queue::{JobQueue, JobQueueConfig},
@@ -42,7 +43,6 @@ use crate::{
     protocols::{
         chat::ChatCompletionRequest,
         classify::ClassifyRequest,
-        completion::CompletionRequest,
         embedding::EmbeddingRequest,
         generate::GenerateRequest,
         parser::{ParseFunctionCallRequest, SeparateReasoningRequest},
@@ -199,7 +199,7 @@ async fn v1_completions(
 ) -> Response {
     state
         .router
-        .route_completion(Some(&headers), &body, Some(&body.model))
+        .route_completion(Some(&headers), &body, Some(body.model()))
         .await
 }
 

--- a/sgl-model-gateway/tests/api/request_formats_test.rs
+++ b/sgl-model-gateway/tests/api/request_formats_test.rs
@@ -1,8 +1,14 @@
+use axum::{
+    body::Body,
+    extract::Request,
+    http::{header::CONTENT_TYPE, StatusCode},
+};
 use serde_json::json;
+use tower::ServiceExt;
 
 use crate::common::{
     mock_worker::{HealthStatus, MockWorkerConfig, WorkerType},
-    WorkerTestContext,
+    AppTestContext, WorkerTestContext,
 };
 
 #[cfg(test)]
@@ -152,6 +158,41 @@ mod request_format_tests {
 
         let result = ctx.make_request("/v1/completions", payload).await;
         assert!(result.is_ok());
+
+        ctx.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_gateway_accepts_completion_token_id_prompts() {
+        let ctx = AppTestContext::new(vec![MockWorkerConfig {
+            port: 19006,
+            worker_type: WorkerType::Regular,
+            health_status: HealthStatus::Healthy,
+            response_delay_ms: 0,
+            fail_rate: 0.0,
+        }])
+        .await;
+        let app = ctx.create_app().await;
+
+        for prompt in [json!([1, 2, 3, 4]), json!([[1, 2], [3, 4]])] {
+            let request = Request::builder()
+                .method("POST")
+                .uri("/v1/completions")
+                .header(CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    json!({
+                        "model": "test-model",
+                        "prompt": prompt,
+                        "max_tokens": 10,
+                        "stream": false
+                    })
+                    .to_string(),
+                ))
+                .unwrap();
+
+            let response = app.clone().oneshot(request).await.unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+        }
 
         ctx.shutdown().await;
     }

--- a/sgl-model-gateway/tests/routing/test_openai_routing.rs
+++ b/sgl-model-gateway/tests/routing/test_openai_routing.rs
@@ -19,11 +19,10 @@ use axum::{
 use data_connector::{ResponseId, StoredResponse};
 use serde_json::json;
 use smg::{
+    completion::CompletionRequest,
     config::{ConfigError, HistoryBackend, OracleConfig, RouterConfig, RoutingMode},
     protocols::{
         chat::{ChatCompletionRequest, ChatMessage, MessageContent},
-        common::StringOrArray,
-        completion::CompletionRequest,
         generate::GenerateRequest,
         responses::{ResponseInput, ResponsesGetParams, ResponsesRequest},
     },
@@ -51,42 +50,12 @@ fn create_minimal_chat_request() -> ChatCompletionRequest {
 
 /// Helper function to create a minimal completion request for testing
 fn create_minimal_completion_request() -> CompletionRequest {
-    CompletionRequest {
-        model: "gpt-3.5-turbo".to_string(),
-        prompt: StringOrArray::String("Hello".to_string()),
-        suffix: None,
-        max_tokens: Some(100),
-        temperature: None,
-        top_p: None,
-        n: None,
-        stream: false,
-        stream_options: None,
-        logprobs: None,
-        echo: false,
-        stop: None,
-        presence_penalty: None,
-        frequency_penalty: None,
-        best_of: None,
-        logit_bias: None,
-        user: None,
-        seed: None,
-        top_k: None,
-        min_p: None,
-        min_tokens: None,
-        repetition_penalty: None,
-        regex: None,
-        ebnf: None,
-        json_schema: None,
-        stop_token_ids: None,
-        no_stop_trim: false,
-        ignore_eos: false,
-        skip_special_tokens: true,
-        lora_path: None,
-        session_params: None,
-        return_hidden_states: false,
-        sampling_seed: None,
-        other: serde_json::Map::new(),
-    }
+    serde_json::from_value(serde_json::json!({
+        "model": "gpt-3.5-turbo",
+        "prompt": "Hello",
+        "max_tokens": 100
+    }))
+    .unwrap()
 }
 
 /// Test basic OpenAI router creation and configuration


### PR DESCRIPTION
## Motivation

The Python OpenAI-compatible `/v1/completions` API accepts pre-tokenized prompts as `List[int]` and batched token prompts as `List[List[int]]`.

The Rust model gateway currently models `prompt` as a string or an array of strings only. As a result, valid token-ID completion requests are rejected by Axum during request deserialization with HTTP 422 before they can be forwarded to the backend.

This creates an API compatibility gap between the Python server and the Rust model gateway.

## Modifications

* Extend the Rust completion prompt representation to accept:

  * text prompt
  * batch of text prompts
  * single token-ID sequence
  * batch of token-ID sequences
* Preserve token-ID prompts when forwarding requests to workers.
* Update completion batch-size detection for token-ID batches.
* Add regression coverage for unified and PD routing paths.

This PR only adds request parsing/forwarding compatibility. Token-ID prompts bypass the current text-based cache-aware routing; token-ID-aware radix/cache routing is intentionally left to a separate follow-up.

## Accuracy Tests

This change does not modify model computation or model outputs.

Route-level regression tests cover:

* existing text completion
* single `List[int]` token prompt
* batched `List[List[int]]` token prompts
* PD batch request semantics

Before this change, a real Axum `/v1/completions` request with a token-ID prompt returns HTTP 422.

With this change, the same request is accepted and forwarded successfully.

Validation:

* focused Rust tests: passed
* `cargo clippy -- -D warnings`: passed
* `cargo fmt --check`: passed
* patch/apply check against upstream main: passed

No GPU is required for this protocol-level fix.

## Speed Tests and Profiling

N/A. This is a request-schema and routing compatibility fix and does not change the inference execution path.

## Checklist

* [ ] Format your code according to the [[Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit)](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
* [x] Add unit tests according to the [[Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests)](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
* [x] Update documentation according to [[Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations)](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (No user-facing behavior beyond restoring existing Python API compatibility.)
* [x] Provide accuracy and speed benchmark results according to [[Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy)](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [[Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed)](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (No performance benchmark needed for this protocol-only change.)
* [x] Follow the SGLang code style [[guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance)](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32171702497](https://github.com/sgl-project/sglang/actions/runs/32171702497)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32171702123](https://github.com/sgl-project/sglang/actions/runs/32171702123)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->