### PR TITLE
[GDN] Validate FlashInfer Cake CP prefill on Blackwell

### DIFF
--- a/python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py
@@ -344,6 +344,7 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
             state_checkpoints=state_checkpoints,
             checkpoint_cu_starts=state_checkpoint_cu_starts,
             checkpoint_every_n_tokens=state_checkpoint_every_n_tokens,
+            use_cp="auto",
         )
 
         # Write back state to pool

--- a/test/registered/attention/unittests/gdn/test_flashinfer.py
+++ b/test/registered/attention/unittests/gdn/test_flashinfer.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 
 import torch
 
@@ -8,6 +9,7 @@ from sglang.srt.utils import is_flashinfer_available
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.kits.attention_unittest.attention_methods.gdn_attention import (
     GDNAttentionCase,
+    _cache_indices,
     build_gdn_attention_fixture,
     make_gdn_cases,
     run_gdn_attention_case,
@@ -346,6 +348,100 @@ class TestFlashInferLinearGDNBackendCorrectness(CustomTestCase):
         prefix_lens=(0, 64, 128),
         extend_lens=(64, 65, 129),
     )
+    CAKE_CP_CASE = GDNAttentionCase(
+        name="flashinfer_cake_gdn_cp_prefill",
+        backend="triton",
+        linear_attn_prefill_backend="flashinfer",
+        forward_mode=ForwardMode.EXTEND,
+        num_k_heads=2,
+        num_v_heads=4,
+        page_size=16,
+        prefix_lens=(0,),
+        extend_lens=(65,),
+    )
+
+    def test_cake_cp_prefill_route_matches_non_cp(self):
+        if _sm_major != 10:
+            self.skipTest("FlashInfer Cake GDN CP prefill requires SM100/SM103")
+
+        import flashinfer.gdn_prefill as flashinfer_gdn_prefill
+
+        cake_prefill = getattr(
+            flashinfer_gdn_prefill, "_chunk_gated_delta_rule_cake_sm100", None
+        )
+        if cake_prefill is None:
+            self.skipTest("FlashInfer build does not contain PR #4539 Cake GDN CP")
+
+        fixture = build_gdn_attention_fixture(
+            self,
+            self.CAKE_CP_CASE,
+            head_k_dim=self.HEAD_DIM,
+            head_v_dim=self.HEAD_DIM,
+            max_context_len=128,
+        )
+        cache = fixture.runner.req_to_token_pool.mamba2_layer_cache(0)
+        initial_conv = cache.conv[0].clone()
+        initial_ssm = cache.temporal.clone()
+        mixed_qkv = fixture.mixed_qkv.clone()
+        a = fixture.a.clone()
+        b = fixture.b.clone()
+        cake_calls = 0
+
+        def observed_cake(*args, **kwargs):
+            nonlocal cake_calls
+            cake_calls += 1
+            return cake_prefill(*args, **kwargs)
+
+        def unexpected_non_cp(*_args, **_kwargs):
+            raise AssertionError("SGLang FlashInfer prefill left the Cake CP route")
+
+        with (
+            patch.object(
+                flashinfer_gdn_prefill,
+                "_chunk_gated_delta_rule_cake_sm100",
+                observed_cake,
+            ),
+            patch.object(
+                flashinfer_gdn_prefill,
+                "chunk_gated_delta_rule_sm100",
+                unexpected_non_cp,
+            ),
+        ):
+            cake_output = run_gdn_fixture_eager(fixture)
+        cake_state = cache.temporal.clone()
+
+        self.assertEqual(cake_calls, 1)
+        torch.testing.assert_close(fixture.mixed_qkv, mixed_qkv, atol=0, rtol=0)
+        torch.testing.assert_close(fixture.a, a, atol=0, rtol=0)
+        torch.testing.assert_close(fixture.b, b, atol=0, rtol=0)
+
+        cache.conv[0].copy_(initial_conv)
+        cache.temporal.copy_(initial_ssm)
+        flashinfer_kernel = (
+            fixture.backend.linear_attn_backend.kernel_dispatcher.extend_kernel
+        )
+        public_prefill = flashinfer_kernel._prefill_fn
+
+        def non_cp_prefill(*args, **kwargs):
+            kwargs["use_cp"] = False
+            return public_prefill(*args, **kwargs)
+
+        flashinfer_kernel._prefill_fn = non_cp_prefill
+        non_cp_output = run_gdn_fixture_eager(fixture)
+        non_cp_state = cache.temporal.clone()
+
+        torch.testing.assert_close(cake_output, non_cp_output, atol=1e-2, rtol=1e-2)
+        selected = _cache_indices(fixture).long()
+        torch.testing.assert_close(
+            cake_state[selected], non_cp_state[selected], atol=1e-2, rtol=1e-2
+        )
+        untouched = torch.ones(
+            initial_ssm.shape[0], dtype=torch.bool, device=initial_ssm.device
+        )
+        untouched[selected] = False
+        torch.testing.assert_close(
+            cake_state[untouched], initial_ssm[untouched], atol=0, rtol=0
+        )
 
     def test_prefill_tracked_state_checkpoints(self):
         fixture = build_gdn_attention_fixture(


### PR DESCRIPTION
## Motivation

FlashInfer [#4539](https://github.com/flashinfer-ai/flashinfer/pull/4539) replaces the SM100/SM103 CP-selected GDN prefill implementation with the Cake backend while preserving the public `chunk_gated_delta_rule` API and its `use_cp="auto"` policy. SGLang already calls that public API; this PR makes the auto policy explicit and adds an SGLang-level route/contract test for the new backend.

This PR depends on FlashInfer #4539 and a subsequent FlashInfer release. It intentionally does not pin SGLang production dependencies to an unreleased Git commit; the new test skips when the installed FlashInfer build does not yet expose the Cake route.

## Modifications

- Pass `use_cp="auto"` explicitly from `FlashInferGDNKernel.extend`.
- Add an SM100/SM103 BF16 GQA generic-tail test through the real SGLang fixture and `FlashInferGDNKernel.extend`.
- Require the test invocation to enter Cake exactly once and make the legacy SM100 non-CP route fatal.
- Compare output and selected final-state rows against the same FlashInfer revision with `use_cp=False` at `atol=rtol=1e-2`.
- Verify Q/K/V/gate/beta/cu-seqlens/cache indices and unselected state rows are unchanged.

## Accuracy Tests

GB300 (SM103), CUDA 13.3, driver 580.159.03:

- Targeted SGLang pytest: `1 passed, 7 deselected` (Slurm job `3117357`; the test executed rather than skipping).
- Candidate route: FlashInfer #4539 Cake path; external/non-CP fallback is fatal.
- The SGLang route test compares #4539 Cake against the same candidate revision with `use_cp=False`; output and selected final state match at `atol=rtol=1e-2`.
- The benchmark runner independently repeats the same-revision `use_cp=False` output/state check on the dedicated B=1, L=65 generic-tail case. The three performance rows enforce the intended CP routes plus exact input and unselected-state immutability; the #4539 base CP route (`a91f9fa30a7e4752d8febcf108f7f64984858751`) is used only as the timing arm, not as a numerical oracle.
- Maximum observed absolute output error: `2.44140625e-4`
- Maximum observed absolute selected-state error: `3.90625e-3`
- Both candidate and baseline preserve all input tensors and unselected state rows exactly.

### Model-level GSM8K

On the same GB300, `Qwen/Qwen3.5-4B` was evaluated on the same 200 GSM8K questions with 5-shot completion prompts, one request at a time, temperature 0, and `max_tokens=512`. Radix caching was disabled in both arms because FlashInfer CP prefill does not yet support the state-checkpoint outputs needed by SGLang's radix state tracking.

| Prefill arm | GSM8K exact match | Difference vs. Triton |
|---|---:|---:|
| FlashInfer #4539 Cake | 0.890 (178/200) | 0.000 |
| Triton control | 0.890 (178/200) | — |

For the Cake arm, the live dispatcher reported `extend=FlashInferGDNKernel`, a job-unique empty workspace produced seven SM103 Cake cubins, and the server log contained zero non-CP fallback warnings. The Triton arm reported `extend=TritonGDNKernel` and produced no Cake cubins. Both arms exceeded the predeclared 0.80 accuracy threshold. This is an accuracy comparison, not an end-to-end speed claim: decode used Triton in both arms and dominates the sequential evaluation latency.

GSM8K Slurm job: `3123124`; evidence SHA-256: `b3d99f0fa31896e52798af3eed4f4d8c35b3877328065b0daaf8152f0adbf5d8`; dataset SHA-256: `3730d312f6e3440559ace48831e51066acaca737f6eabec99bccb9e4b3c39d14`.

## Speed Tests and Profiling

GB300 (SM103), CUDA 13.3, driver 580.159.03. These are SGLang adapter-level prefill calls (`FlashInferGDNKernel.extend`) with BF16 Q/K/V/state, Hq=Hk=2, Hv=8, D=128. Each row below uses an exact shape cell present in the original PR4078 benchmark set. The BF16 SGLang input/state profile is stated separately and is not presented as PR4078's dtype profile; no extra generic rows are included.

| Batch | Sequence lengths | #4539 Cake (ms) | #4539 base CP (ms) | Speedup |
|---:|---|---:|---:|---:|
| 1 | `[2048]` | 0.433250 | 0.485474 | 1.121x |
| 1 | `[8192]` | 0.444626 | 0.511026 | 1.149x |
| 4 | `[2048, 2048, 2048, 2048]` | 0.420082 | 0.487810 | 1.161x |

Geometric-mean speedup: **1.144x**.

Method: same-process ABBA paired samples using Cake `bench_gpu_time_interleaved` (`bench_gpu_time`), required CUPTI GPU activity timing, cold-L2 flush before each sample, 20 ms warmup and 100 ms measurement budget per arm, and a steady-state SM clock gate. The three rows collected 310–384 samples per arm at 2070/2070 MHz in Slurm job `3119121`. During the timed rows, both the candidate non-CP path and base-revision non-CP path were fatal, so every measured call used the intended CP route; the dedicated correctness case intentionally invoked the candidate revision's non-CP path as its numerical reference.

Commits:

- SGLang: `7cd1dcadc8bdd9e7737d6a0dc4c773600119ac77`
- FlashInfer candidate: `d32513c6b5ef378f5ecd95511a9f35e7e2f58b19`
- FlashInfer #4539 base: `a91f9fa30a7e4752d8febcf108f7f64984858751`
- Cake timing implementation: `25536d8f0acd0eb4503d9fd6b46509b9ac76a115`
- Evidence SHA-256: `4c618d8bd8f184177e0be138e99ed0d2da7f2c42881bce9ec6089834ab304621`

## Checklist

- [x] Format your code according to the [formatting guide](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [testing guide](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Documentation is not required for this explicit routing/test-only change; this PR body documents the upstream dependency and validation.
- [x] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style guidance.

## Review and Merge Process

This is opened as a draft until FlashInfer #4539 is merged and available in an SGLang-supported FlashInfer release.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32105664238](https://github.com/sgl-project/sglang/actions/runs/32105664238)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32105664058](https://github.com/sgl-project/sglang/actions/runs/32105664058)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
