### PR TITLE
[XPU] Add diffusion server test config for Intel XPU B60

### DIFF
--- a/python/sglang/multimodal_gen/test/server/consistency_thresholds/intel_xpu_b60.json
+++ b/python/sglang/multimodal_gen/test/server/consistency_thresholds/intel_xpu_b60.json
@@ -1,0 +1,17 @@
+{
+  "_comment": "Consistency thresholds for Intel Arc Pro B60 (XPU). The GT images are CUDA-generated, and XPU seeds its initial latent noise from a different RNG stream, so pixels cannot match: the image is semantically identical (CLIP stays high) while ssim/psnr/mean_abs_diff degrade. Per-case entries below are only tuned where an XPU run has actually been measured; the rest are inherited from h100.json and will need the same treatment as they are triaged.",
+  "cases": {
+    "qwen_image_t2i_2_gpus": {
+      "clip_threshold": 0.98,
+      "ssim_threshold": 0.79,
+      "psnr_threshold": 15.7,
+      "mean_abs_diff_threshold": 17.2
+    },
+    "fsdp-inference": {
+      "clip_threshold": 0.97,
+      "ssim_threshold": 0.6,
+      "psnr_threshold": 11.0,
+      "mean_abs_diff_threshold": 37.0
+    }
+  }
+}

--- a/python/sglang/multimodal_gen/test/server/testcase_configs.py
+++ b/python/sglang/multimodal_gen/test/server/testcase_configs.py
@@ -951,4 +951,5 @@ BASELINE_CONFIG = (
     BaselineConfig.load(get_perf_baseline_path())
     .update(Path(__file__).parent / "ascend" / "perf_baselines_npu.json")
     .update(Path(__file__).parent / "musa" / "perf_baselines_musa.json")
+    .update(Path(__file__).parent / "xpu" / "perf_baselines_xpu.json")
 )

--- a/python/sglang/multimodal_gen/test/server/xpu/perf_baselines_xpu.json
+++ b/python/sglang/multimodal_gen/test/server/xpu/perf_baselines_xpu.json
@@ -1,0 +1,34 @@
+{
+  "metadata": {
+    "model": "Diffusion Server",
+    "hardware": "Intel Arc Pro B60 (22.71 GiB per card)",
+    "description": "Reference numbers captured on XPU; these override the CUDA baselines only when running on XPU, since XPU reuses the shared case ids"
+  },
+  "scenarios": {
+    "fsdp-inference": {
+      "stages_ms": {
+        "InputValidationStage": 0.04,
+        "TextEncodingStage": 822.67,
+        "LatentPreparationStage": 0.21,
+        "TimestepPreparationStage": 34933.02,
+        "DenoisingStage": 9091.12,
+        "DecodingStage": 17.8
+      },
+      "denoise_step_ms": {
+        "0": 285.12,
+        "1": 1096.41,
+        "2": 1091.69,
+        "3": 1098.41,
+        "4": 1124.7,
+        "5": 1099.74,
+        "6": 1100.13,
+        "7": 1095.65,
+        "8": 1094.18
+      },
+      "expected_e2e_ms": 44870.65,
+      "expected_avg_denoise_ms": 1009.56,
+      "expected_median_denoise_ms": 1096.41,
+      "estimated_full_test_time_s": 157.0
+    }
+  }
+}

--- a/python/sglang/multimodal_gen/test/test_utils.py
+++ b/python/sglang/multimodal_gen/test/test_utils.py
@@ -80,6 +80,7 @@ CONSISTENCY_THRESHOLD_FILE_BY_PLATFORM = {
     "h100": "h100.json",
     "b200": "b200.json",
     "5090": "5090.json",
+    "intel_xpu_b60": "intel_xpu_b60.json",
 }
 CONSISTENCY_PLATFORM_ALIASES = {
     "sm90": "h100",
@@ -91,6 +92,7 @@ CONSISTENCY_PLATFORM_ALIASES = {
     "sm120": "5090",
     "rtx5090": "5090",
     "5090": "5090",
+    "intelxpub60": "intel_xpu_b60",
 }
 CLIP_MODEL_NAME = "openai/clip-vit-large-patch14"
 DEFAULT_CLIP_THRESHOLD_IMAGE = 0.92
@@ -903,6 +905,8 @@ def get_consistency_platform() -> str:
         return "5090"
     if current_platform.is_blackwell():
         return "b200"
+    if current_platform.is_xpu():
+        return "intel_xpu_b60"
     return "h100"
 
 


### PR DESCRIPTION
## Motivation

**Let the `multimodal_gen` diffusion server tests run on Intel XPU with correct expectations.**

The diffusion server tests compare generated images against committed ground-truth images and check stage timings against committed perf baselines. Both sets of reference values are CUDA-derived, and neither is reachable from XPU today:

- `get_consistency_platform()` has no XPU branch, so an XPU run silently falls through to the `h100` thresholds.
- `BASELINE_CONFIG` composes per-platform perf overrides for Ascend and MUSA, but there is no XPU entry.

The image mismatch is not a correctness bug. XPU seeds its initial latent noise from a different RNG stream than CUDA, so the pixels cannot match bit-for-bit: the image stays semantically identical (CLIP remains high) while `ssim` / `psnr` / `mean_abs_diff` degrade. Comparing XPU output against CUDA thresholds therefore fails on a difference that carries no signal.

This PR adds XPU as a first-class platform in both registries, following the existing Ascend and MUSA pattern.

## Modifications

Purely additive: 4 files, 56 insertions, 0 deletions.

- **`test/test_utils.py`** — register `intel_xpu_b60` in `CONSISTENCY_THRESHOLD_FILE_BY_PLATFORM`, add the `intelxpub60` alias, and add the `current_platform.is_xpu()` branch to `get_consistency_platform()`.
- **`test/server/consistency_thresholds/intel_xpu_b60.json`** — XPU consistency thresholds for `qwen_image_t2i_2_gpus` and `fsdp-inference`.
- **`test/server/xpu/perf_baselines_xpu.json`** — XPU perf baselines for `fsdp-inference`, measured on Intel Arc Pro B60 (22.71 GiB per card).
- **`test/server/testcase_configs.py`** — chain the XPU baseline file into `BASELINE_CONFIG`, alongside the existing Ascend and MUSA `.update()` calls.

No CUDA path changes: both new files are read only when the resolved platform is XPU, and the two registry additions are new keys.

## Thresholds

| case | clip | ssim | psnr | mean_abs_diff |
| --- | --- | --- | --- | --- |
| `fsdp-inference` | 0.97 | 0.6 | 11.0 | 37.0 |
| `qwen_image_t2i_2_gpus` | 0.98 | 0.79 | 15.7 | 17.2 |

Only these two cases were measured on XPU hardware. Every other case still inherits from `h100.json`; that is called out in the `_comment` field of the threshold file so the remaining cases can be triaged the same way rather than being assumed correct.

## Accuracy Tests

Verified on 2x Intel Arc Pro B60 (22.7 GiB per card):

```
python/sglang/multimodal_gen/test/server/test_server_2_gpu.py::TestDiffusionServerTwoGpu::test_diffusion_generation[fsdp-inference]
```

Model `Tongyi-MAI/Z-Image-Turbo`. Passes end to end in ~157 s, including the consistency check against the thresholds above. Measured CLIP 0.9779 (passes); SSIM 0.6609 / PSNR 12.0434 / mean-abs-diff 33.3489, which fail the H100 thresholds and pass the XPU ones. XPU output is deterministic across 4 runs (identical md5).

The perf baselines are single-host measurements, not an averaged multi-run distribution, so they are starting reference values rather than tight regression bounds.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). — no new test case is introduced; this PR adds the platform configuration that existing diffusion server tests read on XPU.
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — N/A, no user-facing behaviour change.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

cc: @siju-samuel @rbabukv

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33606366411](https://github.com/sgl-project/sglang/actions/runs/33606366411)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33606364529](https://github.com/sgl-project/sglang/actions/runs/33606364529)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33606366341](https://github.com/sgl-project/sglang/actions/runs/33606366341)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->