### PR TITLE
[Perf] Avoid full-logits all-gather for TP greedy sampling

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -678,6 +678,10 @@ class Envs:
     SGLANG_DISTRIBUTED_INIT_METHOD_OVERRIDE = EnvStr(None)
     SGLANG_IS_FIRST_RANK_ON_NODE = EnvBool(True)
     SGLANG_SYNC_TOKEN_IDS_ACROSS_TP = EnvBool(False)
+    # Experimental: keep greedy LM-head logits vocab-sharded and exchange only
+    # each rank's argmax candidate. Unsupported sampling features fall back to
+    # the full-logits all-gather path.
+    SGLANG_ENABLE_TP_SHARDED_GREEDY = EnvBool(False)
     SGLANG_ENABLE_COLOCATED_BATCH_GEN = EnvBool(False)
     SGLANG_SHARED_EXPERT_TP1 = EnvBool(False)
     # Replicate the input embedding across TP ranks instead of sharding it

--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -179,6 +179,9 @@ class LogitsProcessorOutput:
     # The logits of the next tokens.       shape: [#seq, vocab_size]
     # Can be None for certain prefill-only requests (e.g., multi-item scoring) that don't need next token generation
     next_token_logits: Optional[torch.Tensor]
+    # Greedy-only TP fast path: globally selected token ids without gathering
+    # the vocab logits. Mutually exclusive with next_token_logits.
+    tp_sharded_greedy_token_ids: Optional[torch.Tensor] = None
     # Used by speculative decoding (EAGLE)
     # The last hidden layers
     hidden_states: Optional[torch.Tensor] = None
@@ -238,6 +241,7 @@ class LogitsMetadata:
     forward_mode: ForwardMode
     capture_hidden_mode: CaptureHiddenMode = CaptureHiddenMode.NULL
     next_token_logits_buffer: Optional[torch.Tensor] = None
+    use_tp_sharded_greedy: bool = False
 
     extend_return_logprob: bool = False
     extend_return_top_logprob: bool = False
@@ -278,6 +282,8 @@ class LogitsMetadata:
 
     @classmethod
     def from_forward_batch(cls, forward_batch: ForwardBatch):
+        from sglang.srt.layers.tp_sharded_greedy import can_use_tp_sharded_greedy
+
         if (
             forward_batch.forward_mode.is_extend()
             and forward_batch.return_logprob
@@ -312,6 +318,7 @@ class LogitsMetadata:
             forward_mode=forward_batch.forward_mode,
             capture_hidden_mode=forward_batch.capture_hidden_mode,
             next_token_logits_buffer=forward_batch.next_token_logits_buffer,
+            use_tp_sharded_greedy=can_use_tp_sharded_greedy(forward_batch),
             extend_return_logprob=extend_return_logprob,
             extend_return_top_logprob=extend_return_top_logprob,
             extend_token_ids_logprob=extend_token_ids_logprob,
@@ -481,6 +488,20 @@ class LogitsProcessor(nn.Module):
         del hidden_states
 
         if not logits_metadata.extend_return_logprob:
+            if logits_metadata.use_tp_sharded_greedy:
+                greedy_token_ids = self._get_tp_sharded_greedy_token_ids(
+                    pruned_states, lm_head
+                )
+                if greedy_token_ids is not None:
+                    if sample_indices is not None:
+                        greedy_token_ids = greedy_token_ids[sample_indices]
+                    return LogitsProcessorOutput(
+                        next_token_logits=None,
+                        tp_sharded_greedy_token_ids=greedy_token_ids,
+                        hidden_states=hidden_states_to_store,
+                        mm_input_embeds=logits_metadata.mm_input_embeds,
+                    )
+
             # Compute logits for both input and sampled tokens.
             logits = self._get_logits(pruned_states, lm_head, logits_metadata)
             sampled_logits = (
@@ -512,6 +533,54 @@ class LogitsProcessor(nn.Module):
         )
         logprobs_result.write_input_to(logits_output)
         return logits_output
+
+    def _get_tp_sharded_greedy_token_ids(
+        self,
+        hidden_states: torch.Tensor,
+        lm_head: VocabParallelEmbedding,
+    ) -> Optional[torch.Tensor]:
+        """Try the no-full-logits greedy path; return ``None`` to fall back."""
+
+        if (
+            not self.do_tensor_parallel_all_gather
+            or self.do_tensor_parallel_all_gather_dp_attn
+            or not isinstance(lm_head, VocabParallelEmbedding)
+            or lm_head.tp_size <= 1
+            or lm_head.num_added_embeddings != 0
+            or lm_head.num_embeddings != self.vocab_size
+        ):
+            return None
+
+        logits = self._compute_lm_head(hidden_states, lm_head)
+        if logits.ndim != 2:
+            return None
+        if self.logit_scale is not None:
+            logits.mul_(self.logit_scale)
+        logits = logits.float()
+        if self.final_logit_softcapping:
+            if not (_is_npu or _is_cpu):
+                fused_softcap(logits, self.final_logit_softcapping)
+            else:
+                logits = self.final_logit_softcapping * torch.tanh(
+                    logits / self.final_logit_softcapping
+                )
+
+        from sglang.srt.distributed import get_tp_group
+        from sglang.srt.layers.tp_sharded_greedy import tp_sharded_greedy_argmax
+        from sglang.srt.utils.async_probe import sanitize_nan_logits
+
+        sanitize_nan_logits(logits, "tp-sharded greedy: local logits")
+        tp_group = (
+            get_parallel().attn_tp_group if self.use_attn_tp_group else get_tp_group()
+        )
+        shard = lm_head.shard_indices
+        return tp_sharded_greedy_argmax(
+            logits,
+            vocab_start=shard.org_vocab_start_index,
+            vocab_end=shard.org_vocab_end_index,
+            process_group=tp_group.device_group,
+            world_size=tp_group.world_size,
+        )
 
     def _get_pruned_states(
         self,

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -141,6 +141,15 @@ class Sampler(nn.Module):
             all_greedy=sampling_info.is_all_greedy,
         )
 
+        if logits_output.tp_sharded_greedy_token_ids is not None:
+            assert logits is None
+            assert sampling_info.is_all_greedy
+            assert not return_logprob
+            assert not any(sampling_info.return_sampling_masks or [])
+            batch_next_token_ids = logits_output.tp_sharded_greedy_token_ids
+            self._sync_token_ids_across_tp(batch_next_token_ids, sampling_info)
+            return batch_next_token_ids
+
         if _is_hip and logits.shape[0] == 0:
             return torch.empty((0,), dtype=torch.int64, device=logits.device)
 

--- a/python/sglang/srt/layers/tp_sharded_greedy.py
+++ b/python/sglang/srt/layers/tp_sharded_greedy.py
@@ -1,0 +1,140 @@
+"""Strictly-gated TP-sharded greedy argmax helpers.
+
+The fast path intentionally handles only the case where sampling is exactly
+``argmax(logits)``. Any operation which can inspect or mutate the full vocab
+logits must keep using the regular all-gather path.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+import torch.distributed as dist
+
+from sglang.srt.environ import envs
+
+
+def can_use_tp_sharded_greedy(forward_batch) -> bool:
+    """Return a rank-consistent, batch-only eligibility decision.
+
+    LM-head layout and TP topology checks are applied later by
+    :class:`LogitsProcessor`, where the sharded weight is available.
+    """
+
+    if not envs.SGLANG_ENABLE_TP_SHARDED_GREEDY.get():
+        return False
+
+    sampling_info = getattr(forward_batch, "sampling_info", None)
+    if sampling_info is None or not sampling_info.is_all_greedy:
+        return False
+    if getattr(forward_batch, "return_logprob", False):
+        return False
+    if any(getattr(forward_batch, "top_logprobs_nums", None) or []):
+        return False
+    if any(x for x in (getattr(forward_batch, "token_ids_logprobs", None) or [])):
+        return False
+    if getattr(forward_batch, "is_prefill_only", False):
+        return False
+    if getattr(forward_batch, "spec_info", None) is not None:
+        return False
+
+    forward_mode = forward_batch.forward_mode
+    if forward_mode.is_target_verify() or forward_mode.is_draft_extend_v2():
+        return False
+
+    if sampling_info.has_custom_logit_processor:
+        return False
+    if sampling_info.grammars or sampling_info.grammar_mask is not None:
+        return False
+    if sampling_info.logit_bias is not None:
+        return False
+    if sampling_info.acc_additive_penalties is not None:
+        return False
+    if sampling_info.acc_scaling_penalties is not None:
+        return False
+    if (
+        sampling_info.penalizer_orchestrator is not None
+        and sampling_info.penalizer_orchestrator.is_required
+    ):
+        return False
+    if any(sampling_info.return_sampling_masks or []):
+        return False
+
+    # The current draft deliberately leaves CUDA-graph buffers on the proven
+    # full-logits path. A follow-up can capture the tiny candidate collectives.
+    if getattr(forward_batch, "next_token_logits_buffer", None) is not None:
+        return False
+    return True
+
+
+def select_global_argmax_candidates(
+    candidate_values: torch.Tensor, candidate_token_ids: torch.Tensor
+) -> torch.Tensor:
+    """Select a global argmax, breaking exact ties by the lowest token id.
+
+    Both inputs have shape ``[tp_size, batch]``. NaNs must already have been
+    sanitized using the same policy as the regular sampler.
+    """
+
+    if (
+        candidate_values.ndim != 2
+        or candidate_token_ids.shape != candidate_values.shape
+    ):
+        raise ValueError("candidate values and token ids must have shape [tp, batch]")
+    max_id = torch.iinfo(candidate_token_ids.dtype).max
+    is_nan = torch.isnan(candidate_values)
+    nan_ids = torch.where(is_nan, candidate_token_ids, max_id).min(dim=0).values
+
+    # torch.argmax treats NaN as the winning value and returns its first index.
+    # Reproduce that behavior across shards when sanitization is disabled.
+    max_values = candidate_values.max(dim=0).values
+    tied_ids = torch.where(
+        candidate_values == max_values.unsqueeze(0),
+        candidate_token_ids,
+        max_id,
+    )
+    finite_ids = tied_ids.min(dim=0).values
+    return torch.where(is_nan.any(dim=0), nan_ids, finite_ids)
+
+
+def tp_sharded_greedy_argmax(
+    local_logits: torch.Tensor,
+    *,
+    vocab_start: int,
+    vocab_end: int,
+    process_group,
+    world_size: int,
+) -> Optional[torch.Tensor]:
+    """All-gather one ``(value, global_token_id)`` candidate per row/rank."""
+
+    valid_width = vocab_end - vocab_start
+    if (
+        local_logits.ndim != 2
+        or valid_width <= 0
+        or valid_width > local_logits.shape[1]
+        or world_size <= 1
+    ):
+        return None
+
+    local_values, local_indices = local_logits[:, :valid_width].max(dim=-1)
+    local_token_ids = local_indices.to(torch.int32).add_(vocab_start)
+
+    # One collective for the pair. The token id occupies the second float32
+    # lane as raw int32 bits, avoiding precision loss and a second NCCL launch.
+    packed = torch.empty(
+        (local_values.numel(), 2), dtype=torch.float32, device=local_values.device
+    )
+    packed[:, 0] = local_values
+    packed.view(torch.int32)[:, 1] = local_token_ids
+    gathered = torch.empty(
+        (world_size * local_values.numel(), 2),
+        dtype=packed.dtype,
+        device=packed.device,
+    )
+    dist.all_gather_into_tensor(gathered, packed, group=process_group)
+    batch = local_values.numel()
+    return select_global_argmax_candidates(
+        gathered[:, 0].view(world_size, batch),
+        gathered.view(torch.int32)[:, 1].view(world_size, batch),
+    ).to(torch.int64)

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1853,17 +1853,19 @@ class ModelRunner:
         # a previous replay into a request with no observer state.
         logits_output.auxiliary_device_output = None
         observer = self.sampling_observer
-        # Preserve two-argument overrides when observation is inactive.
-        if observer is not None and observer.is_active(forward_batch.sampling_info):
-            observer_state = self._preprocess_logits(
-                logits_output,
-                forward_batch.sampling_info,
-                observer=observer,
-            )
-        else:
-            observer_state = self._preprocess_logits(
-                logits_output, forward_batch.sampling_info
-            )
+        observer_state = None
+        if logits_output.tp_sharded_greedy_token_ids is None:
+            # Preserve two-argument overrides when observation is inactive.
+            if observer is not None and observer.is_active(forward_batch.sampling_info):
+                observer_state = self._preprocess_logits(
+                    logits_output,
+                    forward_batch.sampling_info,
+                    observer=observer,
+                )
+            else:
+                observer_state = self._preprocess_logits(
+                    logits_output, forward_batch.sampling_info
+                )
 
         # Sample the next tokens
         next_token_ids = self.sampler(

--- a/test/manual/bench_tp_sharded_greedy.py
+++ b/test/manual/bench_tp_sharded_greedy.py
@@ -1,0 +1,97 @@
+"""Compare full-vocab all-gather+argmax with TP candidate all-gather.
+
+Example:
+  torchrun --standalone --nproc-per-node=2 test/manual/bench_tp_sharded_greedy.py
+"""
+
+import argparse
+import os
+
+import torch
+import torch.distributed as dist
+
+from sglang.srt.layers.tp_sharded_greedy import tp_sharded_greedy_argmax
+
+
+def _time_ms(fn, warmup: int, iterations: int) -> float:
+    for _ in range(warmup):
+        fn()
+    dist.barrier()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(iterations):
+        fn()
+    end.record()
+    end.synchronize()
+    return start.elapsed_time(end) / iterations
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--vocab-size", type=int, default=128256)
+    parser.add_argument("--batches", type=int, nargs="+", default=[1, 4, 16, 64])
+    parser.add_argument("--warmup", type=int, default=20)
+    parser.add_argument("--iterations", type=int, default=200)
+    args = parser.parse_args()
+
+    dist.init_process_group("nccl")
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
+    device = torch.device("cuda", int(os.environ["LOCAL_RANK"]))
+    local_width = (args.vocab_size + world_size - 1) // world_size
+    padded_vocab = local_width * world_size
+    vocab_start = rank * local_width
+    vocab_end = min(vocab_start + local_width, args.vocab_size)
+
+    if rank == 0:
+        print("batch,full_allgather_argmax_us,candidate_allgather_us,speedup")
+    for batch in args.batches:
+        gen = torch.Generator(device=device).manual_seed(1234 + rank)
+        local_logits = torch.randn(
+            batch,
+            local_width,
+            dtype=torch.bfloat16,
+            device=device,
+            generator=gen,
+        ).float()
+        if vocab_end < vocab_start + local_width:
+            local_logits[:, vocab_end - vocab_start :] = -torch.inf
+
+        full_buffer = torch.empty(
+            padded_vocab * batch, dtype=local_logits.dtype, device=device
+        )
+
+        def full_path():
+            dist.all_gather_into_tensor(full_buffer, local_logits.contiguous().view(-1))
+            return (
+                full_buffer.view(world_size, batch, local_width)
+                .permute(1, 0, 2)
+                .reshape(batch, padded_vocab)[:, : args.vocab_size]
+                .argmax(dim=-1)
+            )
+
+        def candidate_path():
+            return tp_sharded_greedy_argmax(
+                local_logits,
+                vocab_start=vocab_start,
+                vocab_end=vocab_end,
+                process_group=dist.group.WORLD,
+                world_size=world_size,
+            )
+
+        torch.testing.assert_close(candidate_path(), full_path(), rtol=0, atol=0)
+        full_ms = _time_ms(full_path, args.warmup, args.iterations)
+        candidate_ms = _time_ms(candidate_path, args.warmup, args.iterations)
+        if rank == 0:
+            print(
+                f"{batch},{full_ms * 1000:.2f},{candidate_ms * 1000:.2f},"
+                f"{full_ms / candidate_ms:.3f}"
+            )
+
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/registered/unit/sampling/test_tp_sharded_greedy.py
+++ b/test/registered/unit/sampling/test_tp_sharded_greedy.py
@@ -1,0 +1,109 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang.srt.environ import envs
+from sglang.srt.layers.tp_sharded_greedy import (
+    can_use_tp_sharded_greedy,
+    select_global_argmax_candidates,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+register_cpu_ci(est_time=5, suite="base-c-test-cpu")
+
+
+class _ForwardMode:
+    def is_target_verify(self):
+        return False
+
+    def is_draft_extend_v2(self):
+        return False
+
+
+def _batch(**overrides):
+    sampling_info = SimpleNamespace(
+        is_all_greedy=True,
+        has_custom_logit_processor=False,
+        grammars=None,
+        grammar_mask=None,
+        logit_bias=None,
+        acc_additive_penalties=None,
+        acc_scaling_penalties=None,
+        penalizer_orchestrator=SimpleNamespace(is_required=False),
+        return_sampling_masks=[False, False],
+    )
+    defaults = dict(
+        sampling_info=sampling_info,
+        return_logprob=False,
+        top_logprobs_nums=[0, 0],
+        token_ids_logprobs=[None, None],
+        is_prefill_only=False,
+        spec_info=None,
+        forward_mode=_ForwardMode(),
+        next_token_logits_buffer=None,
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def test_select_global_candidates_tie_uses_lowest_token_id():
+    values = torch.tensor([[4.0, -torch.inf], [4.0, -torch.inf]])
+    token_ids = torch.tensor([[17, 9], [3, 2]], dtype=torch.int32)
+    assert torch.equal(
+        select_global_argmax_candidates(values, token_ids),
+        torch.tensor([3, 2], dtype=torch.int32),
+    )
+
+
+def test_select_global_candidates_per_row_winners():
+    values = torch.tensor([[1.0, 8.0, -2.0], [2.0, 7.0, 5.0]])
+    token_ids = torch.tensor([[1, 2, 3], [10, 11, 12]], dtype=torch.int32)
+    assert torch.equal(
+        select_global_argmax_candidates(values, token_ids),
+        torch.tensor([10, 2, 12], dtype=torch.int32),
+    )
+
+
+def test_select_global_candidates_nan_matches_first_global_argmax():
+    values = torch.tensor([[1.0, torch.nan], [torch.nan, torch.nan]])
+    token_ids = torch.tensor([[2, 3], [11, 7]], dtype=torch.int32)
+    assert torch.equal(
+        select_global_argmax_candidates(values, token_ids),
+        torch.tensor([11, 3], dtype=torch.int32),
+    )
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda b: setattr(b, "return_logprob", True),
+        lambda b: setattr(b, "top_logprobs_nums", [1, 0]),
+        lambda b: setattr(b, "token_ids_logprobs", [[7], None]),
+        lambda b: setattr(b, "spec_info", object()),
+        lambda b: setattr(b, "next_token_logits_buffer", torch.empty(1)),
+        lambda b: setattr(b.sampling_info, "is_all_greedy", False),
+        lambda b: setattr(b.sampling_info, "has_custom_logit_processor", True),
+        lambda b: setattr(b.sampling_info, "grammars", [object(), None]),
+        lambda b: setattr(b.sampling_info, "grammar_mask", object()),
+        lambda b: setattr(b.sampling_info, "logit_bias", torch.empty(1)),
+        lambda b: setattr(b.sampling_info, "acc_additive_penalties", torch.empty(1)),
+        lambda b: setattr(b.sampling_info, "acc_scaling_penalties", torch.empty(1)),
+        lambda b: setattr(b.sampling_info.penalizer_orchestrator, "is_required", True),
+        lambda b: setattr(b.sampling_info, "return_sampling_masks", [False, True]),
+    ],
+)
+def test_gate_falls_back_for_full_logits_features(mutation):
+    batch = _batch()
+    mutation(batch)
+    with envs.SGLANG_ENABLE_TP_SHARDED_GREEDY.override(True):
+        assert not can_use_tp_sharded_greedy(batch)
+
+
+def test_gate_requires_explicit_opt_in():
+    batch = _batch()
+    with envs.SGLANG_ENABLE_TP_SHARDED_GREEDY.override(False):
+        assert not can_use_tp_sharded_greedy(batch)
+    with envs.SGLANG_ENABLE_TP_SHARDED_GREEDY.override(True):
+        assert can_use_tp_sharded_greedy(batch)


### PR DESCRIPTION
**Incremental review:** [Files changed](https://github.com/sgl-project/sglang/pull/35268/files) against `main`.

## Motivation

Tensor-parallel generation currently materializes and all-gathers full-vocabulary logits on every rank before a strict greedy `argmax`. For greedy-only requests, each rank only needs to contribute its local maximum value and global token ID.

This PR adds an experimental opt-in path that changes the logits communication from `O(batch * vocab)` to `O(batch * TP)` candidates. It is related to, but does not duplicate, #31079: that PR gathers full logits to rank 0, while this path reduces each vocab shard locally and never communicates full logits.

## Modifications

- Add `SGLANG_ENABLE_TP_SHARDED_GREEDY=1` (off by default).
- Compute local FP32 LM-head logits and the local `(max value, global token ID)` on each TP rank.
- Pack each candidate into two 32-bit lanes, all-gather the candidates, and select the global winner with the same lowest-token-ID tie behavior as full-vocabulary `torch.argmax`.
- Pass the selected token IDs through `LogitsProcessorOutput` without constructing full-vocabulary logits.
- Strictly fall back to the existing path for logprobs, top-logprobs, token-ID logprobs, grammars, custom logit processors, logit bias, penalties, sampling masks, speculative modes, prefill-only requests, added embeddings, unsupported LM-head layouts, and CUDA-graph logits buffers.
- Add unit tests and a TP communication microbenchmark.

## Accuracy Tests

```text
pytest -q test/registered/unit/sampling/test_tp_sharded_greedy.py
18 passed
```

The tests cover per-row winners, exact ties, NaNs, explicit opt-in, and all full-logits fallback gates.

A fixed greedy E2E probe produced identical results with the feature disabled and enabled:

```text
prompt: "Hello"
output_ids: [13, 358]
text: ". I"
```

The communication benchmark also checks candidate-path token IDs against full all-gather + argmax with `rtol=0, atol=0` before timing each shape.

## Speed Tests and Profiling

Hardware/software:

- 2x NVIDIA A100-PCIE-40GB (SM80), TP=2
- PyTorch 2.11.0+cu130, NCCL 2.28.9
- BF16 model weights, FP32 logits
- CUDA graphs disabled (the experimental path currently falls back when graph logits buffers are present)
- `NCCL_P2P_DISABLE=1` for both paths because P2P/IPC communicator initialization hangs on this PHB-connected hosted instance; both paths use the same NCCL transport

Microbenchmark (`vocab_size=128256`, 100 iterations):

| Batch | Full all-gather + argmax (us) | Candidate all-gather (us) | Speedup |
|---:|---:|---:|---:|
| 1 | 213.91 | 403.08 | 0.531x |
| 4 | 420.88 | 400.34 | 1.051x |
| 16 | 1185.63 | 378.73 | 3.131x |
| 64 | 5100.59 | 384.84 | 13.254x |

E2E serving benchmark:

- Model: `Qwen/Qwen2.5-1.5B-Instruct`
- 128 requests, random input length 256, output length 128
- concurrency 64, temperature 0, TP=2
- CUDA graphs/custom all-reduce/overlap scheduling disabled for both paths
- cache flushed before every run
- A/B/A ordering after kernel caches were warm

| Metric | Baseline runs | Feature runs | Mean change |
|---|---:|---:|---:|
| Output throughput (tok/s) | 1603.47, 1583.17 | 1698.81, 1717.17 | **+7.20%** |
| Median E2E latency (ms) | 4892.71, 4913.26 | 4628.27, 4534.11 | **-6.56%** |
| Mean E2E latency (ms) | 4962.94, 5030.94 | 4737.79, 4737.67 | **-5.19%** |
| Mean TPOT (ms) | 33.55, 33.93 | 31.71, 31.80 | **-5.88%** |

The microbenchmark shows why the path remains experimental and opt-in: it targets medium/high-batch greedy decode, not batch 1.

## Checklist

- [x] Formatted with the repository's pinned Ruff, isort, and Black versions.
- [x] Added unit tests for correctness and fallback behavior.
- [x] Documented the experimental environment variable inline; no public default behavior changes.
- [x] Included accuracy, microbenchmark, and E2E benchmark results.
- [x] Followed the existing SGLang code style.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33374516014](https://github.com/sgl-project/sglang/actions/runs/33374516014)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33374515481](https://github.com/sgl-project/sglang/actions/runs/33374515481)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33374515809](https://github.com/sgl-project/sglang/actions/runs/33374515809)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->