### PR TITLE
[AMD] Define gfx1250 QuickReduce stubs

### DIFF
--- a/python/sglang/kernels/aot/csrc/allreduce/quick_all_reduce_base.h
+++ b/python/sglang/kernels/aot/csrc/allreduce/quick_all_reduce_base.h
@@ -88,11 +88,11 @@ __quickreduce_device_inline__ static void
 buffer_store_dwordx4(int32x4_t data, int32x4_t srsrc, int32_t voffset, int32_t soffset, int32_t aux) __asm(
     "llvm.amdgcn.raw.buffer.store.v4i32");
 #else
-__quickreduce_device_inline__ static int32x4_t
-buffer_load_dwordx4(int32x4_t srsrc, int32_t voffset, int32_t soffset, int32_t aux) {}
+__quickreduce_device_inline__ static int32x4_t buffer_load_dwordx4(int32x4_t, int32_t, int32_t, int32_t) {
+  return {};
+}
 
-__quickreduce_device_inline__ static void
-buffer_store_dwordx4(int32x4_t data, int32x4_t srsrc, int32_t voffset, int32_t soffset, int32_t aux) {}
+__quickreduce_device_inline__ static void buffer_store_dwordx4(int32x4_t, int32x4_t, int32_t, int32_t, int32_t) {}
 #endif
 
 __quickreduce_device_inline__ static void set_fp16_ovfl(bool const value) {


### PR DESCRIPTION
## Motivation

The gfx1250 AOT path added in #32466 compiles the QuickReduce source even though QuickReduce is runtime-disabled on that architecture. Its fallback `buffer_load_dwordx4` stub is a non-void function with no return, and both fallback stubs name parameters they intentionally do not use. This makes the disabled source path malformed under strict warning settings.

## Modifications

Return a zero-initialized vector from the gfx1250 load stub and omit parameter names from both fallback definitions. This keeps the unsupported operation well-defined and warning-clean without enabling QuickReduce on gfx1250.

## Accuracy Tests

Not applicable. The gfx1250 QuickReduce path remains runtime-disabled and this change does not affect model outputs.

Compile-only A/B check with Clang:

- Existing stub: `clang++ -std=c++17 -Wall -Wextra -Werror -fsyntax-only` fails on the missing return and unused parameters.
- Patched stub: the same command passes.

## Speed Tests and Profiling

Not applicable. This does not enable or execute QuickReduce on gfx1250.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (Not applicable: compile-only fallback definitions.)
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (Not applicable.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Not applicable; explained above.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32108961444](https://github.com/sgl-project/sglang/actions/runs/32108961444)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32108961427](https://github.com/sgl-project/sglang/actions/runs/32108961427)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->