### PR TITLE
fix(rocm): allow the triton MoE runner for mxfp8 on all of ROCm, not only gfx95

### DIFF
--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -49,7 +49,6 @@ from sglang.srt.utils.common import (
     is_cpu,
     is_cuda,
     is_flashinfer_available,
-    is_gfx95_supported,
     is_hip,
     is_mnnvl_fabric_device,
     is_mps,
@@ -2489,11 +2488,17 @@ def _moe_runner_backend_quant_constraints(view: Any) -> dict:
     if view.quantization == "mxfp8" and not is_npu():
         from sglang.srt.server_args import MXFP8_MOE_RUNNER_BACKEND_CHOICES
 
-        is_gfx95_mxfp8 = is_hip() and is_gfx95_supported()
+        # Every entry in MXFP8_MOE_RUNNER_BACKEND_CHOICES is CUDA-only, so on ROCm
+        # the whitelist has no viable member and the default below selects a
+        # backend whose kernels and Python package are absent. gfx942 has a
+        # working path: mxfp8_block_convert_required() converts MXFP8 to
+        # block-fp8 [128, 128] at load and runs it through the native block-fp8
+        # triton kernels. Allow triton on all of ROCm, not only gfx95.
+        is_rocm_mxfp8 = is_hip()
         allowed = list(MXFP8_MOE_RUNNER_BACKEND_CHOICES)
-        if is_gfx95_mxfp8:
+        if is_rocm_mxfp8:
             allowed.append("triton")
-        mxfp8_default = "triton" if is_gfx95_mxfp8 else "flashinfer_trtllm"
+        mxfp8_default = "triton" if is_rocm_mxfp8 else "flashinfer_trtllm"
         if moe_runner_backend == "auto":
             moe_runner_backend = mxfp8_default
         elif moe_runner_backend not in allowed:


### PR DESCRIPTION
## Motivation

On gfx942 (MI300X/MI325X), SGLang cannot serve an mxfp8 checkpoint at all.

`_moe_runner_backend_quant_constraints` gates the "triton is allowed for mxfp8" escape hatch on `is_gfx95_supported()`. Every other member of `MXFP8_MOE_RUNNER_BACKEND_CHOICES` (cutlass, deep_gemm, flashinfer_trtllm, flashinfer_trtllm_routed) is CUDA-only, so on gfx942 the whitelist has no viable entry. An explicit `--moe-runner-backend triton` is rejected:

```
mxfp8 quantization supports only cutlass, deep_gemm, flashinfer_trtllm, flashinfer_trtllm_routed backends. Overriding 'triton'.
FlashInfer TRTLLM MoE is enabled.
```

and the server later dies during weight load:

```
File "sglang/srt/layers/quantization/fp8.py", line 2500, in apply
  activation_type = get_activation_type(
File "sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py", line 604, in get_activation_type
  from flashinfer.fused_moe.core import ActivationType
ModuleNotFoundError: No module named 'flashinfer'
```

It also silently defeats the model's own override: `_minimax_m3_overrides` sets `moe_runner_backend` to triton under `is_hip()`, and this post-process rewrites it back, so the user-visible symptom is a missing CUDA module on a ROCm image.

gfx942 already has a working path. `mxfp8_block_convert_required()` converts MXFP8 weights to block-fp8 [128, 128] at load and runs them through the native block-fp8 triton kernels, which is what triton selects here.

## Modifications

Widen the gate from `is_hip() and is_gfx95_supported()` to `is_hip()`, so triton is both permitted and the default for mxfp8 on all ROCm. No change on CUDA. `is_gfx95_supported` was this file's only use of that import, so it is dropped.

## Accuracy Tests

No numerical change on CUDA: the branch is guarded by `is_hip()`. On ROCm this replaces a hard startup failure with the block-fp8 triton path that `mxfp8_block_convert_required()` already documents for gfx942.

## Benchmarking and Profiling

8x MI325X (gfx942), `MiniMaxAI/MiniMax-M3-MXFP8`, TP=8, on `lmsysorg/sglang:v0.5.17-rocm720-mi30x`.

Before: the server cannot start (traceback above).
After: the server becomes ready and serves. RadixAttention on vs off over 753 requests at concurrency 32, two repetitions each:

| arm | mean tok/s | spread |
|---|---:|---:|
| `--disable-radix-cache` | 10,546.1 | 0.13% |
| default (RadixAttention) | 11,513.1 | 0.29% |

so +9.17% from the prefix cache, on a configuration that previously could not run.

Note that `--disable-flashinfer-autotune` is also required on this image: the CUDA-graph warmup calls `should_run_flashinfer_autotune()`, whose guard is `mr.device != "cuda"` and so does not fire under HIP. That is a separate issue and is not addressed here.

## Checklist

- [x] Format your code according to the Contributor Guide (`pre-commit run --files ...` passes: isort, ruff, black, codespell)
- [x] Provide a description of the motivation and modifications
- [x] Benchmark results included above

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32109534475](https://github.com/sgl-project/sglang/actions/runs/32109534475)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32109534301](https://github.com/sgl-project/sglang/actions/runs/32109534301)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->