### PR TITLE
fix: exclude NaN-producing autotune config for DSA Triton prefill on ROCm

### DIFF
--- a/python/sglang/kernels/ops/attention/dsa/triton_sparse_mla.py
+++ b/python/sglang/kernels/ops/attention/dsa/triton_sparse_mla.py
@@ -27,11 +27,18 @@ def _prune_configs(configs, named_args, **kwargs):
 # The best (BLOCK_N, num_warps, num_stages) is shape- and arch-sensitive, so
 # autotune over a grid keyed on the attention shape. Benchmarked once per key
 # (a one-time stall on the first prefill of each new shape), then cached.
+#
+# On ROCm (gfx950) with Triton 3.7.0, the (BLOCK_N=128, num_warps=1,
+# num_stages=2) config compiles to a kernel that produces NaN/inf on this
+# sparse-MLA path (verified on 4x MI355X with GLM-5.2-MXFP4); exclude it there
+# so autotune can never pick the broken kernel.
+_is_hip = torch.version.hip is not None
 _AUTOTUNE_CONFIGS = [
     triton.Config({"BLOCK_N": bn}, num_warps=w, num_stages=ns)
     for bn in (32, 64, 128)
     for w in (1, 2, 4)
     for ns in (1, 2)
+    if not (_is_hip and bn == 128 and w == 1 and ns == 2)
 ]
 
 


### PR DESCRIPTION
## Motivation

On ROCm (gfx950) with Triton 3.7.0, the DSA sparse-MLA prefill kernel (`SGLANG_DSA_TRITON_PREFILL=1`) autotunes over `(BLOCK_N, num_warps, num_stages)` and can select `(BLOCK_N=128, num_warps=1, num_stages=2)`. That config compiles to a kernel that produces **NaN/inf** on this path, corrupting prefill output and subsequently decode (garbage tokens). Without the exclusion, autotune may pick the broken kernel on the first prefill of a shape and cache the bad choice.

This is a Triton 3.7.0 + gfx950 compilation issue; the fix here is a defensive exclusion so the broken config is never eligible.

## Modifications

`python/sglang/kernels/ops/attention/dsa/triton_sparse_mla.py`:
- Skip `(BLOCK_N=128, num_warps=1, num_stages=2)` in `_AUTOTUNE_CONFIGS` when running on HIP (`torch.version.hip is not None`). CUDA config space is unchanged.

## Tests / Verification

Environment: 4x MI355X (gfx950), ROCm 7.2.0, GLM-5.2-MXFP4, SGLang ROCm image + this patch, `SGLANG_DSA_TRITON_PREFILL=1`, ISL=8192/OSL=1024, TP4.

| C | s0 baseline (Total tok/s) | P01 Triton prefill (Total tok/s) | Gain |
|---|---|---|---|
| 1 | 1,979 | 2,036 | +2.9% |
| 8 | 6,850 | 8,317 | **+21.4%** |
| 32 | 11,287 | 13,096 | +16.0% |
| 128 | 13,980 | 17,356 | **+24.1%** |
| 512 | 14,883 | 18,136 | **+21.9%** |
| **peak** | 14,883 | **18,158** | **+22.0%** |

Before the exclusion, prefill output was corrupted (NaN/inf) and downstream decode produced garbage; after the exclusion all 10 benchmark points pass with rc=0 and the throughput above.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32109659456](https://github.com/sgl-project/sglang/actions/runs/32109659456)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32109659257](https://github.com/sgl-project/sglang/actions/runs/32109659257)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->