### PR TITLE
[Docs] Fix SGLang-JAX Qwen quick start link

### DIFF
--- a/docs/docs/hardware-platforms/tpu.mdx
+++ b/docs/docs/hardware-platforms/tpu.mdx
@@ -618,7 +618,7 @@ For contributors who need TPU access for testing:
 
 - [SGLang-JAX Repository](https://github.com/sgl-project/sglang-jax)
 - [SGLang-JAX Installation Guide](https://github.com/sgl-project/sglang-jax/blob/main/docs/get_started/install.md)
-- [Qwen Models Quick Start](https://github.com/sgl-project/sglang-jax/blob/main/docs/basic_usage/qwen.md)
+- [Qwen Models Quick Start](https://github.com/sgl-project/sglang-jax/blob/main/docs/cookbook/autoregressive/Qwen/Qwen.md)
 - [Benchmark and Profiling Guide](https://github.com/sgl-project/sglang-jax/blob/main/docs/developer_guide/benchmark_and_profiling.md)
 - [Speculative Decoding](https://github.com/sgl-project/sglang-jax/blob/main/docs/features/speculative_decoding.md)
 


### PR DESCRIPTION
## Motivation

The TPU documentation links to the removed SGLang-JAX
`docs/basic_usage/qwen.md` page, which currently returns 404. SGLang-JAX
consolidated its model-specific usage documentation into the cookbook.

## Modifications

Update the Qwen quick-start reference to the current Qwen cookbook recipe.

## Accuracy Tests

Not applicable. This is a documentation-only change.

## Speed Tests and Profiling

Not applicable. This change does not affect runtime behavior.

## Validation

- `git diff --check`
- `codespell --config .codespellrc docs/docs/hardware-platforms/tpu.mdx`
- Verified that the replacement link returns HTTP 200.

## Checklist

- [x] Format the change according to the repository guidance.
- [x] Unit tests are not applicable to this documentation-only change.
- [x] Update documentation according to the documentation guidance.
- [x] Accuracy and speed benchmarks are not applicable.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32109861745](https://github.com/sgl-project/sglang/actions/runs/32109861745)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32109861610](https://github.com/sgl-project/sglang/actions/runs/32109861610)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->