### PR TITLE
[Docs] Fix NVIDIA Model Optimizer PTQ links

### DIFF
--- a/docs/docs/advanced_features/quantization.mdx
+++ b/docs/docs/advanced_features/quantization.mdx
@@ -591,7 +591,7 @@ If a pre-quantized checkpoint is not available for your model, you can create on
 
 **Hardware requirements:** Hopper and higher are recommended. Insufficient GPU memory may cause weight offloading, resulting in extremely long quantization time.
 
-For detailed usage and supported model architectures, see [NVIDIA Model Optimizer LLM PTQ](https://github.com/NVIDIA/Model-Optimizer/tree/main/examples/llm_ptq).
+For detailed usage and supported model architectures, see [NVIDIA Model Optimizer Hugging Face PTQ](https://github.com/NVIDIA/Model-Optimizer/tree/main/examples/hf_ptq).
 
 SGLang includes a streamlined workflow for quantizing models with ModelOpt and automatically exporting them for deployment.
 
@@ -955,7 +955,7 @@ For the full quantization + format conversion workflow and a complete list of su
 - [GPTQModel](https://github.com/ModelCloud/GPTQModel)
 - [LLM Compressor](https://github.com/vllm-project/llm-compressor/)
 - [NVIDIA Model Optimizer (ModelOpt)](https://github.com/NVIDIA/Model-Optimizer)
-- [NVIDIA Model Optimizer LLM PTQ](https://github.com/NVIDIA/Model-Optimizer/tree/main/examples/llm_ptq)
+- [NVIDIA Model Optimizer Hugging Face PTQ](https://github.com/NVIDIA/Model-Optimizer/tree/main/examples/hf_ptq)
 - [Petit: NVFP4 on ROCm](https://github.com/causalflow-ai/petit-kernel) — [LMSYS blog](https://lmsys.org/blog/2025-09-21-petit-amdgpu/), [AMD ROCm blog](https://rocm.blogs.amd.com/artificial-intelligence/fp4-mixed-precision/README.html)
 - [vLLM Quantization](https://docs.vllm.ai/en/latest/quantization/)
 - [auto-round](https://github.com/intel/auto-round)


### PR DESCRIPTION
## Motivation

The quantization documentation contains two links to NVIDIA Model Optimizer's
removed `examples/llm_ptq` directory. Both links currently return 404. The
corresponding Hugging Face PTQ examples now live under `examples/hf_ptq`.

## Modifications

Update both Model Optimizer PTQ references and their labels to point to the
current Hugging Face PTQ examples.

## Accuracy Tests

Not applicable. This is a documentation-only change.

## Speed Tests and Profiling

Not applicable. This change does not affect runtime behavior.

## Validation

- `git diff --check`
- `codespell --config .codespellrc docs/docs/advanced_features/quantization.mdx`
- Verified that the replacement link returns HTTP 200.

## Checklist

- [x] Format the change according to the repository guidance.
- [x] Unit tests are not applicable to this documentation-only change.
- [x] Update documentation according to the documentation guidance.
- [x] Accuracy and speed benchmarks are not applicable.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32110033223](https://github.com/sgl-project/sglang/actions/runs/32110033223)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32110032713](https://github.com/sgl-project/sglang/actions/runs/32110032713)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->