### PR TITLE
feat: enable breakable/piecewise DSA prefill CUDA graph on ROCm (HIP)

### DIFF
--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -21,7 +21,9 @@ from sglang.srt.layers.attention.dsa.dsa_prefill_cuda_graph import (
     GRAPH_WEIGHTS_PROJ_LORA_ERROR,
     _is_in_piecewise_or_breakable_cuda_graph,
     bcg_dsa_indexer_prefill_split,
+    logits_head_gate_graph,
     pcg_dsa_indexer_prefill_split,
+    scale_head_gate_graph,
 )
 from sglang.srt.layers.attention.dsa.paged_mqa_logits_backend import (
     DSAPagedMQALogitsBackend,
@@ -139,11 +141,6 @@ if _is_cuda:
         fused_k_indexer_norm_rope,
         fused_k_indexer_norm_rope_store,
     )
-    from sglang.srt.layers.attention.dsa.dsa_prefill_cuda_graph import (
-        logits_head_gate_graph,
-        scale_head_gate_graph,
-    )
-
     @register_custom_op(mutates_args=["topk_indices"])
     @register_split_op()
     def broadcast_indexer_topk_from_rank0_(topk_indices: torch.Tensor) -> None:

--- a/python/sglang/srt/layers/attention/dsa/dsa_prefill_cuda_graph.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_prefill_cuda_graph.py
@@ -14,10 +14,7 @@ from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph impo
     get_tc_piecewise_forward_context,
     is_in_tc_piecewise_cuda_graph,
 )
-from sglang.srt.utils import is_cuda
 from sglang.srt.utils.custom_op import register_custom_op
-
-_is_cuda = is_cuda()
 
 GRAPH_WEIGHTS_PROJ_LORA_ERROR = (
     "DSA indexer weights_proj LoRA is incompatible with "
@@ -31,58 +28,57 @@ def _is_in_piecewise_or_breakable_cuda_graph() -> bool:
     return is_in_tc_piecewise_cuda_graph() or is_in_breakable_cuda_graph()
 
 
-if _is_cuda:
+def _scale_head_gate_graph_fake_impl(
+    weights_raw: torch.Tensor,
+    n_heads_inv_sqrt: float,
+    softmax_scale: float,
+    q_scale: torch.Tensor,
+) -> torch.Tensor:
+    return torch.empty(
+        (weights_raw.shape[0], weights_raw.shape[1], q_scale.shape[-1]),
+        dtype=torch.float32,
+        device=weights_raw.device,
+    )
 
-    def _scale_head_gate_graph_fake_impl(
-        weights_raw: torch.Tensor,
-        n_heads_inv_sqrt: float,
-        softmax_scale: float,
-        q_scale: torch.Tensor,
-    ) -> torch.Tensor:
-        return torch.empty(
-            (weights_raw.shape[0], weights_raw.shape[1], q_scale.shape[-1]),
-            dtype=torch.float32,
-            device=weights_raw.device,
-        )
+# In-graph (PCG/BCG) head gate for the fused path: weights_proj is folded
+# into wk_weights_proj, so weights_raw is precomputed and there is no GEMM.
+@register_custom_op(fake_impl=_scale_head_gate_graph_fake_impl)
+def scale_head_gate_graph(
+    weights_raw: torch.Tensor,
+    n_heads_inv_sqrt: float,
+    softmax_scale: float,
+    q_scale: torch.Tensor,
+) -> torch.Tensor:
+    weights = weights_raw * n_heads_inv_sqrt
+    return weights.unsqueeze(-1) * q_scale * softmax_scale
 
-    # In-graph (PCG/BCG) head gate for the fused path: weights_proj is folded
-    # into wk_weights_proj, so weights_raw is precomputed and there is no GEMM.
-    @register_custom_op(fake_impl=_scale_head_gate_graph_fake_impl)
-    def scale_head_gate_graph(
-        weights_raw: torch.Tensor,
-        n_heads_inv_sqrt: float,
-        softmax_scale: float,
-        q_scale: torch.Tensor,
-    ) -> torch.Tensor:
-        weights = weights_raw * n_heads_inv_sqrt
-        return weights.unsqueeze(-1) * q_scale * softmax_scale
 
-    def _logits_head_gate_graph_fake_impl(
-        x: torch.Tensor,
-        weight: torch.Tensor,
-        n_heads_inv_sqrt: float,
-        softmax_scale: float,
-        q_scale: torch.Tensor,
-    ) -> torch.Tensor:
-        return torch.empty(
-            (x.shape[0], weight.shape[0], q_scale.shape[-1]),
-            dtype=torch.float32,
-            device=x.device,
-        )
+def _logits_head_gate_graph_fake_impl(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    n_heads_inv_sqrt: float,
+    softmax_scale: float,
+    q_scale: torch.Tensor,
+) -> torch.Tensor:
+    return torch.empty(
+        (x.shape[0], weight.shape[0], q_scale.shape[-1]),
+        dtype=torch.float32,
+        device=x.device,
+    )
 
-    # In-graph (PCG/BCG) head gate for the NON-prefill path
-    @register_custom_op(fake_impl=_logits_head_gate_graph_fake_impl)
-    def logits_head_gate_graph(
-        x: torch.Tensor,
-        weight: torch.Tensor,
-        n_heads_inv_sqrt: float,
-        softmax_scale: float,
-        q_scale: torch.Tensor,
-    ) -> torch.Tensor:
-        out = torch.mm(x, weight.t(), out_dtype=torch.float32)
-        weights = out * n_heads_inv_sqrt
-        weights = weights.unsqueeze(-1) * q_scale * softmax_scale
-        return weights
+# In-graph (PCG/BCG) head gate for the NON-prefill path
+@register_custom_op(fake_impl=_logits_head_gate_graph_fake_impl)
+def logits_head_gate_graph(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    n_heads_inv_sqrt: float,
+    softmax_scale: float,
+    q_scale: torch.Tensor,
+) -> torch.Tensor:
+    out = torch.mm(x, weight.t(), out_dtype=torch.float32)
+    weights = out * n_heads_inv_sqrt
+    weights = weights.unsqueeze(-1) * q_scale * softmax_scale
+    return weights
 
 
 @register_custom_op(mutates_args=["topk_result"])
@@ -103,7 +99,7 @@ def pcg_dsa_indexer_prefill_split(
     # call site pre-allocates it at a static, padded shape and a downstream
     # captured graph reads it at a fixed address; eager code instead allocates
     # and returns a fresh, naturally-sized tensor each call.
-    assert _is_cuda, "Internal error: DSA graph dispatch is only supported on CUDA"
+    # HIP (ROCm): the breakable/piecewise prefill graph uses the same split-op dispatch.
     from sglang.kernels.ops.attention.dsa.triton_kernel import act_quant
 
     forward_context = get_tc_piecewise_forward_context()

--- a/python/sglang/srt/layers/attention/dsa/utils.py
+++ b/python/sglang/srt/layers/attention/dsa/utils.py
@@ -139,10 +139,11 @@ def is_dsa_prefill_cp_round_robin_split():
 # inside a piecewise/breakable CUDA graph. Both fusions are now on by default on
 # this surface (no feature flag); each adds its own extra carve-outs at its call
 # site (e.g. the indexer also excludes DSA prefill context parallelism).
+# HIP (ROCm) is supported: the breakable prefill graph path was enabled for
+# gfx950 (MI355X) via the same split-op dispatch.
 def is_graph_dsa_split_op_surface(forward_batch: "ForwardBatch") -> bool:
     return (
-        is_cuda()
-        and (is_in_tc_piecewise_cuda_graph() or is_in_breakable_cuda_graph())
+        (is_in_tc_piecewise_cuda_graph() or is_in_breakable_cuda_graph())
         and forward_batch.forward_mode.is_extend_without_speculative()
     )
 


### PR DESCRIPTION
## Motivation

On ROCm (HIP), the DSA prefill CUDA graph path (`--cuda-graph-backend-prefill breakable` or `tc_piecewise`) is structurally unusable: three CUDA-only gates block the same split-op dispatch that works on CUDA. Attempting to use it crashes at the first captured shape:

1. `NameError: name 'logits_head_gate_graph' is not defined` — the in-graph head-gate ops are only registered under `if _is_cuda:`.
2. `AssertionError: Internal error: in-graph DSA prefill must go through the graph DSA split-op dispatch` — `pcg_dsa_indexer_prefill_split` asserts CUDA.
3. The `is_graph_dsa_split_op_surface()` surface check excludes HIP, so the split-op path is never taken.

This PR removes those gates so the breakable prefill graph works on HIP via the same split-op dispatch as CUDA.

## Modifications

1. **`python/sglang/srt/layers/attention/dsa/dsa_prefill_cuda_graph.py`**:
   - Register `scale_head_gate_graph` / `logits_head_gate_graph` unconditionally (drop `if _is_cuda:` wrapper).
   - Drop the CUDA-only assert in `pcg_dsa_indexer_prefill_split`.
2. **`python/sglang/srt/layers/attention/dsa/utils.py`**:
   - Remove the `is_cuda()` condition from `is_graph_dsa_split_op_surface()`.
3. **`python/sglang/srt/layers/attention/dsa/dsa_indexer.py`**:
   - Import `logits_head_gate_graph` / `scale_head_gate_graph` at module top level so they resolve on HIP.

## Tests / Verification

Environment: 4x MI355X (gfx950), ROCm 7.2.0, GLM-5.2-MXFP4, SGLang ROCm image + this patch, `--cuda-graph-backend-prefill breakable`, TP4.

- **Before**: 3 startup attempts, 3 different crashes at the first shape (NameError → AssertionError → AttributeError).
- **After**: all 42 breakable prefill graph shapes capture successfully, `[aiter] Registering 6594 cuda graph addresses`, target-verify graph also registers (8058 addrs), then benchmarks run clean.

Throughput (Total tok/s, 4-GPU, ISL=8192/OSL=1024):

| C | s0 baseline | P02b (mf0.74) | Gain |
|---|---|---|---|
| 1 | 1,979 | 2,036 | +2.9% |
| 8 | 6,850 | 7,663 | **+11.9%** |
| 128 | 13,980 | 14,754 | +5.5% |
| 512 | 14,883 | 15,064 | +1.2% |

**Known cost**: the prefill graph needs extra memory — mf drops 0.80 → 0.74 on this workload (KV pool shrinks ~7.5%). Combining breakable prefill graph with the Triton DSA prefill (`SGLANG_DSA_TRITON_PREFILL=1`) is not yet validated.

This is a capability enablement (unblocks the HIP prefill-graph architecture gap); the headline perf win on this stack comes from `SGLANG_DSA_TRITON_PREFILL=1` (separate change).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32110388641](https://github.com/sgl-project/sglang/actions/runs/32110388641)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32110388448](https://github.com/sgl-project/sglang/actions/runs/32110388448)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->