### PR TITLE
[Fix] Assert the page-aligned SWA evict floor at PD decode prealloc

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -1694,7 +1694,13 @@ def alloc_for_decode_prealloc_hisparse(
             extend_num_tokens=fill_len,
             swa_tail_len=swa_tail_len,
         )
-        req.kv.swa_evicted_seqlen = fill_len - swa_tail_len
+        # swa_evicted_seqlen is the page-aligned eviction floor: _swa_tail_len
+        # floors its window_start to page_size, so fill_len - swa_tail_len is
+        # a page multiple. Assert it here to pin the invariant; a future caller
+        # bypassing _swa_tail_len must floor the value explicitly.
+        swa_evicted_seqlen = fill_len - swa_tail_len
+        assert swa_evicted_seqlen >= 0 and swa_evicted_seqlen % allocator.page_size == 0
+        req.kv.swa_evicted_seqlen = swa_evicted_seqlen
     else:
         kv_loc = allocator.alloc_logical_only(
             prefix_lens=prefix_lens,

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -1694,10 +1694,6 @@ def alloc_for_decode_prealloc_hisparse(
             extend_num_tokens=fill_len,
             swa_tail_len=swa_tail_len,
         )
-        # swa_evicted_seqlen is the page-aligned eviction floor: _swa_tail_len
-        # floors its window_start to page_size, so fill_len - swa_tail_len is
-        # a page multiple. Assert it here to pin the invariant; a future caller
-        # bypassing _swa_tail_len must floor the value explicitly.
         swa_evicted_seqlen = fill_len - swa_tail_len
         assert swa_evicted_seqlen >= 0 and swa_evicted_seqlen % allocator.page_size == 0
         req.kv.swa_evicted_seqlen = swa_evicted_seqlen


### PR DESCRIPTION
Pin the page-alignment invariant of swa_evicted_seqlen at the PD decode prealloc entry: `_swa_tail_len` already floors its window start to a page, so `fill_len - swa_tail_len` is a page multiple. Assert it here so any future caller bypassing `_swa_tail_len` fails loudly rather than silently poisoning the page-aligned liveness invariant (`free_swa_segment`'s contract).

Part of #35223.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32112220612](https://github.com/sgl-project/sglang/actions/runs/32112220612)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #32182772235](https://github.com/sgl-project/sglang/actions/runs/32182772235)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->