### PR TITLE
[Spec] Stage DRAFT_EXTEND_V2 and point per-step fence at verify record

### DIFF
--- a/python/sglang/srt/layers/attention/base_attn_backend.py
+++ b/python/sglang/srt/layers/attention/base_attn_backend.py
@@ -113,6 +113,11 @@ class AttentionBackend(ABC):
         :py:meth:`init_forward_metadata_out_graph` call."""
         return False
 
+    # Opt in when this backend's DRAFT_EXTEND_V2 out-graph metadata init is a
+    # pure function of pre-verify state (it may read verify products by shape
+    # only), so the init can be staged before the verify launch.
+    supports_draft_extend_metadata_staging: bool = False
+
     # Opt out only when this backend never reads seq_lens_cpu / seq_lens_sum.
     needs_cpu_seq_lens: bool = True
 

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -503,6 +503,8 @@ class DeepseekV4AttnBackend(
     use_captured_forward_metadata_for_breakable_cuda_graph: bool = True
     supports_ragged_verify_graph: bool = True
     needs_cpu_seq_lens: bool = False
+    # Draft-extend init builds page tables from seq_lens / req_to_token only.
+    supports_draft_extend_metadata_staging: bool = True
 
     def shared_read_ends(self, fm: ForwardMode) -> SharedReadEnds:
         # Breakable-graph verify rereads shared state across segments.

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -387,6 +387,13 @@ class FlashInferAttnBackend(AttentionBackend):
             self.num_wrappers = 1
             self.dispatch_reason = None
 
+        # SWA draft-extend init derives prefix_lens from num_accept_tokens
+        # (update_sliding_window), a verify product; the single-wrapper path
+        # reads verify products by shape only.
+        self.supports_draft_extend_metadata_staging = (
+            model_runner.sliding_window_size is None
+        )
+
         # Qwen2/Qwen3 models require higher flashinfer workspace size
         if (
             "Qwen2ForCausalLM" in model_runner.model_config.hf_config.architectures

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -6,6 +6,9 @@ from typing import List, Optional
 
 import torch
 
+from sglang.kernels.ops.speculative.cache_locs import (
+    assign_extend_cache_locs_uniform_func,
+)
 from sglang.kernels.ops.speculative.topk1 import draft_topk1_postprocess
 from sglang.srt.distributed.parallel_state_wrapper import ParallelState
 from sglang.srt.environ import envs
@@ -185,6 +188,9 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             draft_tp_context if server_args.enable_dp_attention else empty_context
         )
         self.tree_mask_mode = default_tree_mask_mode()
+        # Per-step fence: whether the last dispatched step's draft_extend
+        # consumed staged reads inside its graph. False until a step runs.
+        self.last_draft_extend_staged = False
 
         self.plan_stream, self.plan_stream_ctx = get_plan_stream(self.device)
 
@@ -859,15 +865,28 @@ class EagleDraftWorker(EagleDraftWorkerBase):
         runner = self.cuda_graph_runner_for_draft_extend
         if runner is None or batch.forward_mode.is_idle():
             return False
-        # SWA metadata derives its prefix from num_accept_tokens (flashinfer
-        # update_sliding_window), a verify product that does not exist yet.
-        if self.draft_runner.sliding_window_size is not None:
+        if not self.draft_extend_attn_backend.supports_draft_extend_metadata_staging:
             return False
         # The DP-padded width would duplicate init_new's token-unit transform;
         # oversized batches would overflow the bucket pad.
         if runner.require_mlp_tp_gather or len(batch.seq_lens) > runner.max_bs:
             return False
         num_draft_tokens = self.speculative_num_draft_tokens
+        out_cache_loc = None
+        if self.draft_runner.sliding_window_size is not None:
+            # The init's SWA fill snapshots out_cache_loc by value; verify's
+            # out_cache_loc is itself gathered from req_to_token[seq : seq+draft),
+            # stable since prepare_for_draft, so the same gather reads the same
+            # slots. Slot gather is done inside the stage so it precedes the
+            # fill in one stream order.
+            out_cache_loc = assign_extend_cache_locs_uniform_func(
+                req_pool_indices=batch.req_pool_indices,
+                req_to_token=self.req_to_token_pool.req_to_token,
+                start_offset=batch.seq_lens,
+                batch_size=len(batch.seq_lens),
+                draft_token_num=num_draft_tokens,
+                device=batch.device,
+            )
         runner.stage_shared_reads(
             # Forward sees post-write length, matching prepare_for_draft_extend.
             seq_lens=batch.seq_lens + num_draft_tokens,
@@ -877,6 +896,7 @@ class EagleDraftWorker(EagleDraftWorkerBase):
                 else None
             ),
             req_pool_indices=batch.req_pool_indices,
+            out_cache_loc=out_cache_loc,
             out_cache_loc_dsv4=getattr(batch, "out_cache_loc_dsv4", None),
         )
         return True
@@ -963,6 +983,10 @@ class EagleDraftWorker(EagleDraftWorkerBase):
                 draft_logits_output = self.draft_runner.forward(
                     forward_batch
                 ).logits_output
+
+        # Per-step fence truth: verify is the last shared reader iff
+        # draft_extend consumed staged reads inside its graph.
+        self.last_draft_extend_staged = bool(staged and can_run_decode_cuda_graph)
 
         maybe_detect_nan(
             draft_logits_output.next_token_logits,
@@ -1087,8 +1111,12 @@ class EAGLEWorkerV2(BaseSpecWorker):
 
     @property
     def last_shared_read_runner(self):
-        # Per the base contract: the step's last shared-buffer-reading phase is
-        # draft_extend, which runs on the draft runner.
+        # Staged steps: verify is the last shared reader (#35059's decode
+        # publish covers it on the target runner). Un-staged / eager steps:
+        # draft_extend stays the last reader, keeping the pre-staging fence.
+        staged = getattr(self._draft_worker, "last_draft_extend_staged", False)
+        if staged:
+            return self.target_worker.model_runner
         return self._draft_worker.draft_runner
 
     @property


### PR DESCRIPTION
Stacks on #35126. Stage DRAFT_EXTEND_V2 shared reads before verify on backends that opt in (DSV4; flashinfer when it has no SWA), and make last_shared_read_runner answer the target runner on staged steps so the scheduler's WAR barrier uses the verify-time record.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34829064137](https://github.com/sgl-project/sglang/actions/runs/34829064137)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34829063549](https://github.com/sgl-project/sglang/actions/runs/34829063549)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34829064010](https://github.com/sgl-project/sglang/actions/runs/34829064010)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->