### PR TITLE
fix: boot Inkling on Hopper without an explicit attention backend

### DIFF
--- a/python/sglang/srt/arg_groups/cuda_graph_hook.py
+++ b/python/sglang/srt/arg_groups/cuda_graph_hook.py
@@ -430,15 +430,24 @@ def apply_inkling_prefill_cuda_graph_default(server_args: Any):
     ):
         return
     arch = model_config_of(server_args).hf_config.architectures[0]
-    if arch in (
+    if arch not in (
         "InklingForConditionalGeneration",
         "InklingForConditionalGenerationMTP",
     ):
-        declare_resolution(
-            server_args,
-            "_apply_inkling_prefill_cuda_graph_default",
-            cuda_graph_backend_prefill=Backend.FULL,
-        )
+        return
+    # Only fa4 can capture a prefill graph; TritonAttnBackend rejects the EXTEND
+    # forward mode, so opting in off SM100 dies in capture.
+    from sglang.srt.arg_groups.model_overrides.inkling import (
+        resolve_inkling_attention_backend,
+    )
+
+    if resolve_inkling_attention_backend(server_args) != "fa4":
+        return
+    declare_resolution(
+        server_args,
+        "_apply_inkling_prefill_cuda_graph_default",
+        cuda_graph_backend_prefill=Backend.FULL,
+    )
 
 
 def apply_muse_glimmer_prefill_cuda_graph_max_bs_default(server_args: Any):

--- a/python/sglang/srt/arg_groups/model_overrides/inkling.py
+++ b/python/sglang/srt/arg_groups/model_overrides/inkling.py
@@ -17,6 +17,23 @@ from sglang.srt.runtime_context import get_platform
 logger = logging.getLogger(__name__)
 
 
+def resolve_inkling_attention_backend(server_args: Any) -> str:
+    """The attention backend Inkling will actually run on.
+
+    Shared with apply_inkling_prefill_cuda_graph_default, which runs before
+    declarative overrides are materialized and so cannot read the resolved
+    value off server_args.
+    """
+    cfg = resolving_view(server_args)
+    if not is_attention_backend_not_set(cfg):
+        return (
+            cfg.attention_backend
+            or cfg.prefill_attention_backend
+            or cfg.decode_attention_backend
+        )
+    return "fa4" if get_platform().is_sm100 else "triton"
+
+
 @_register_for(
     "InklingForConditionalGeneration",
     "InklingForConditionalGenerationMTP",
@@ -66,7 +83,7 @@ def _inkling_overrides(server_args: Any, hf_config: Any) -> dict:
     # (mirrors the MiniMax-M3 SM100 fa4-default above); an explicit
     # --attention-backend / --prefill/decode-attention-backend still wins.
     if is_attention_backend_not_set(cfg):
-        inkling_attn_backend = "fa4" if get_platform().is_sm100 else "triton"
+        inkling_attn_backend = resolve_inkling_attention_backend(server_args)
         overrides["attention_backend"] = inkling_attn_backend
         logger.info(
             f"Use {inkling_attn_backend} as the attention backend for Inkling "

--- a/test/registered/unit/server_args/test_inkling_prefill_graph_backend.py
+++ b/test/registered/unit/server_args/test_inkling_prefill_graph_backend.py
@@ -1,0 +1,102 @@
+"""Inkling's attention-backend and prefill-graph defaults must agree.
+
+Regression: the backend default is fa4 on SM100 and triton otherwise, while the
+full-graph prefill opt-in fired unconditionally. Only fa4 can capture a prefill
+graph, so off SM100 a bare launch died in capture_prefill_graph with
+`ValueError: Invalid forward mode: forward_mode=<ForwardMode.EXTEND: 1>`.
+
+The two decisions live in different files and run at different times, which is
+how they drifted apart. Every Inkling test pins --attention-backend fa4, so
+nothing covered the default path.
+
+    python -m pytest test/registered/unit/server_args/test_inkling_prefill_graph_backend.py -v
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.srt.arg_groups.cuda_graph_hook import (
+    apply_inkling_prefill_cuda_graph_default,
+)
+from sglang.srt.arg_groups.model_overrides.inkling import (
+    resolve_inkling_attention_backend,
+)
+from sglang.srt.arg_groups.overrides import resolution_result
+from sglang.srt.server_args import ServerArgs
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+_INKLING_ARCH = "InklingForConditionalGeneration"
+
+
+def _inkling_args(**overrides) -> ServerArgs:
+    args = ServerArgs(model_path="dummy")
+    args.cuda_graph_backend_prefill = None
+    args.disable_prefill_cuda_graph = False
+    args.attention_backend = None
+    args.prefill_attention_backend = None
+    args.decode_attention_backend = None
+    for key, value in overrides.items():
+        setattr(args, key, value)
+    return args
+
+
+def _resolved_prefill_backend(args: ServerArgs, *, sm100: bool, arch=_INKLING_ARCH):
+    """Run just the prefill-graph default and report what it declared."""
+    platform = SimpleNamespace(is_sm100=sm100)
+    with (
+        patch(
+            "sglang.srt.arg_groups.cuda_graph_hook.model_config_of",
+            return_value=SimpleNamespace(
+                hf_config=SimpleNamespace(architectures=[arch])
+            ),
+        ),
+        patch(
+            "sglang.srt.arg_groups.model_overrides.inkling.get_platform",
+            return_value=platform,
+        ),
+    ):
+        apply_inkling_prefill_cuda_graph_default(args)
+    return resolution_result(args, "cuda_graph_backend_prefill")
+
+
+def _backend(args: ServerArgs, *, sm100: bool) -> str:
+    with patch(
+        "sglang.srt.arg_groups.model_overrides.inkling.get_platform",
+        return_value=SimpleNamespace(is_sm100=sm100),
+    ):
+        return resolve_inkling_attention_backend(args)
+
+
+class TestInklingPrefillGraphBackend(CustomTestCase):
+    def test_hopper_default_does_not_opt_into_prefill_graph(self):
+        args = _inkling_args()
+        self.assertEqual(_backend(args, sm100=False), "triton")
+        self.assertIsNone(_resolved_prefill_backend(args, sm100=False))
+
+    def test_sm100_default_still_opts_into_prefill_graph(self):
+        args = _inkling_args()
+        self.assertEqual(_backend(args, sm100=True), "fa4")
+        self.assertIsNotNone(_resolved_prefill_backend(args, sm100=True))
+
+    def test_explicit_fa4_opts_in_on_hopper_too(self):
+        args = _inkling_args(attention_backend="fa4")
+        self.assertEqual(_backend(args, sm100=False), "fa4")
+        self.assertIsNotNone(_resolved_prefill_backend(args, sm100=False))
+
+    def test_explicit_triton_does_not_opt_in_on_sm100(self):
+        args = _inkling_args(attention_backend="triton")
+        self.assertIsNone(_resolved_prefill_backend(args, sm100=True))
+
+    def test_non_inkling_arch_untouched(self):
+        args = _inkling_args()
+        self.assertIsNone(
+            _resolved_prefill_backend(args, sm100=True, arch="Qwen3ForCausalLM")
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`python -m sglang.launch_server --model-path thinkingmachines/Inkling-Small --trust-remote-code` fails at startup on any non-SM100 GPU. Two independent gaps sit on the same default path.

**1.** The Inkling override picks the triton backend off SM100 (`arg_groups/overrides.py`, fa4 is gated on Blackwell there), and `TritonAttnBackend.__init__` asks `token_to_kv_pool.get_v_head_dim()` on its mambaish branch. `SWAKVPool` never implemented it — neither do its bases `BaseSWAKVPool` / `KVCache` — so every hybrid SWA + linear-attention model that resolves to triton dies with:

```
AttributeError: 'SWAKVPool' object has no attribute 'get_v_head_dim'
```

**2.** Past that, Inkling separately opts into FULL prefill CUDA-graph capture in `ServerArgs._apply_inkling_prefill_cuda_graph_default`. Only fa4 can capture a prefill graph; `TritonAttnBackend._apply_cuda_graph_metadata` rejects the EXTEND forward mode, so capture dies with:

```
ValueError: Invalid forward mode: forward_mode=<ForwardMode.EXTEND: 1> for CUDA Graph replay.
```

The two Inkling defaults are decided in different files at different times — the prefill opt-in runs in `__post_init__`, before declarative model overrides are materialized and so cannot read the resolved backend — which is how they drifted apart.

Nothing covers this today: all three Inkling tests (`test_inkling.py`, `test_unified_radix_cache_kl_hybrid_bitexact.py`, `test_inkling_small_nvfp4.py`) pin `--attention-backend fa4` explicitly, and the nvfp4 one runs on B200 where the default is fa4 anyway.

## Modifications

- Add `SWAKVPool.get_v_head_dim()`. It answers for the full-attention sub-pool, mirroring `HybridLinearKVPool`: the backend only reaches that branch when SWA and full share a value head dim (a differing pair is handled earlier off `model_config`), and layer 0 on a hybrid model is not necessarily a full-attention layer, which is exactly why the backend asks the pool instead of indexing layer 0.
- Extract `resolve_inkling_attention_backend()` in `arg_groups/overrides.py` and route both decisions through it. The prefill-graph opt-in now only fires when the resolved backend is fa4; off SM100 the generic breakable default takes over, which triton captures fine.
- Two regression tests, one per gap.

Note this does **not** change the fa4/triton choice itself. fa4 does run on SM90 — the bit-exact Inkling test runs it on `1-gpu-large` CI — so the `is_sm100_supported()` default may be worth revisiting, but that is a behavior change for maintainers to decide, not part of a startup-crash fix.

## Accuracy Tests

Not an accuracy change — the fix is confined to startup resolution. Verified functionally on 1x H200 with the shrunken `thinkingmachines/Inkling` @ `test` revision, launched bare (no `--attention-backend`, no cuda-graph flags — the exact trigger):

```
BOOT OK
{"text":" the French capital of France. The capital", ...}
backend chosen: Use triton as the attention backend for Inkling
prefill graph: backend=breakable      # no longer 'full'
```

Revert-then-red at both levels:

| reverted piece | unit test | bare launch |
|---|---|---|
| `SWAKVPool.get_v_head_dim` | red | `AttributeError: 'SWAKVPool' object has no attribute 'get_v_head_dim'` |
| prefill-graph gate | (covered by the CPU cases) | `ValueError: Invalid forward mode: ... EXTEND` |

Boundary probes on the same box, all with the pool fix in place:

| config | result |
|---|---|
| bare (triton + FULL prefill graph) | fails — EXTEND |
| `--disable-prefill-cuda-graph` | boots |
| `--attention-backend fa4` | boots |
| `--attention-backend triton --disable-prefill-cuda-graph` | boots |

Related existing suites (`test_model_overrides.py`, `unit/server_args/`, `unit/mem_cache/test_swa_unittest.py`, `unit/spec/test_resolve_swa_kv_pool.py`) show the same pass/fail set as pristine main — 248 passed / 1 failed on main, 254 passed / 1 failed here, the extra 6 being the new cases. The one failure (`test_server_args.py::TestMultimodalFeatureTransport::test_default_transport_is_cpu_for_unsupported_multinode_model`) is a pre-existing order-dependent failure: it reproduces on unmodified main in the same group and passes when run alone on this branch.

## Speed Tests and Profiling

No runtime path changes. `get_v_head_dim` is read once in `TritonAttnBackend.__init__`; the other change only affects argument resolution at startup.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33620768312](https://github.com/sgl-project/sglang/actions/runs/33620768312)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33620767559](https://github.com/sgl-project/sglang/actions/runs/33620767559)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33620768142](https://github.com/sgl-project/sglang/actions/runs/33620768142)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->