### PR TITLE
[Bugfix] Preserve word boundaries in streaming ASR rollback

### DIFF
--- a/python/sglang/srt/entrypoints/openai/streaming_asr.py
+++ b/python/sglang/srt/entrypoints/openai/streaming_asr.py
@@ -53,9 +53,8 @@ class StreamingASRState:
 
     def _record_emit(self, delta: str) -> str:
         if delta:
-            self.emitted_text = (
-                f"{self.emitted_text} {delta}".strip() if self.emitted_text else delta
-            )
+            separator = " " if needs_space(self.emitted_text, delta) else ""
+            self.emitted_text = f"{self.emitted_text}{separator}{delta}".strip()
         return delta
 
     def update(self, new_transcript: str) -> str:
@@ -67,8 +66,14 @@ class StreamingASRState:
             self.confirmed_text = ""
         self.full_transcript = new_transcript
         self.chunk_index += 1
-        if self.confirmed_text.startswith(old_confirmed):
-            return self._record_emit(self.confirmed_text[len(old_confirmed) :].strip())
+        prefix_len = len(old_confirmed)
+        suffix = self.confirmed_text[prefix_len:]
+        suffix_starts_at_boundary = not needs_space(old_confirmed, suffix)
+        is_append_only = self.confirmed_text.startswith(old_confirmed) and (
+            suffix_starts_at_boundary
+        )
+        if is_append_only:
+            return self._record_emit(suffix.strip())
         # Model revised earlier text, use word level common prefix to avoid
         # re-emitting already-sent content and cutting mid-word.
         old_words = old_confirmed.split()

--- a/python/sglang/srt/entrypoints/openai/streaming_asr.py
+++ b/python/sglang/srt/entrypoints/openai/streaming_asr.py
@@ -61,11 +61,18 @@ class StreamingASRState:
         old_confirmed = self.confirmed_text
         words = new_transcript.split()
         if len(words) > self.unfixed_token_num:
-            self.confirmed_text = " ".join(words[: -self.unfixed_token_num])
+            new_confirmed = " ".join(words[: -self.unfixed_token_num])
         else:
-            self.confirmed_text = ""
+            new_confirmed = ""
         self.full_transcript = new_transcript
         self.chunk_index += 1
+        rollback_suffix = old_confirmed[len(new_confirmed) :]
+        is_prefix_rollback = old_confirmed.startswith(new_confirmed) and (
+            not needs_space(new_confirmed, rollback_suffix)
+        )
+        if is_prefix_rollback:
+            return ""
+        self.confirmed_text = new_confirmed
         prefix_len = len(old_confirmed)
         suffix = self.confirmed_text[prefix_len:]
         suffix_starts_at_boundary = not needs_space(old_confirmed, suffix)

--- a/test/registered/unit/entrypoints/openai/test_streaming_asr_state.py
+++ b/test/registered/unit/entrypoints/openai/test_streaming_asr_state.py
@@ -1,0 +1,165 @@
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()  # must precede any import that pulls in sgl_kernel
+
+import json
+from typing import List
+from unittest.mock import AsyncMock, Mock, patch
+
+from sglang.srt.entrypoints.openai.protocol import TranscriptionRequest
+from sglang.srt.entrypoints.openai.serving_transcription import (
+    OpenAIServingTranscription,
+)
+from sglang.srt.entrypoints.openai.streaming_asr import StreamingASRState
+from sglang.srt.managers.io_struct import GenerateReqInput
+from sglang.srt.utils import get_or_create_event_loop
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class _ScriptedQwen3ASRTokenizerManager:
+    def __init__(self, transcripts: List[str]):
+        self.model_config = Mock()
+        self.model_config.hf_config = Mock()
+        self.model_config.hf_config.architectures = ["Qwen3ASRForConditionalGeneration"]
+        self.server_args = Mock(asr_max_concurrent_sessions=32)
+        self._transcripts = iter(transcripts)
+
+    def generate_request(self, adapted_request, raw_request):
+        transcript = next(self._transcripts)
+
+        async def gen():
+            yield {"text": f"language English<asr_text>{transcript}"}
+
+        return gen()
+
+
+def _deltas_from_sse(frames: List[str]) -> List[str]:
+    deltas = []
+    for frame in frames:
+        if not frame.startswith("data: "):
+            continue
+        payload = frame[len("data: ") :].strip()
+        if payload == "[DONE]":
+            continue
+        response = json.loads(payload)
+        for choice in response.get("choices", []):
+            content = (choice.get("delta") or {}).get("content")
+            if content:
+                deltas.append(content)
+    return deltas
+
+
+class TestStreamingASRState(CustomTestCase):
+    @staticmethod
+    def _state() -> StreamingASRState:
+        return StreamingASRState(
+            chunk_size_sec=2.0,
+            unfixed_chunk_num=2,
+            unfixed_token_num=5,
+        )
+
+    def test_word_extension_is_treated_as_revision(self):
+        state = self._state()
+        self.assertEqual(
+            state.update("the cat one two three four five"),
+            "the cat",
+        )
+
+        delta = state.update("the caterpillar one two three four five")
+
+        self.assertEqual(delta, "caterpillar")
+        self.assertEqual(state.emitted_text, "the cat caterpillar")
+
+    def test_punctuation_suffix_does_not_add_space_to_prompt(self):
+        state = self._state()
+        self.assertEqual(
+            state.update("hello world one two three four five"),
+            "hello world",
+        )
+
+        delta = state.update("hello world, one two three four five")
+
+        self.assertEqual(delta, ",")
+        self.assertEqual(state.emitted_text, "hello world,")
+
+    def test_normal_append_keeps_word_separator(self):
+        state = self._state()
+        self.assertEqual(
+            state.update("hello one two three four five"),
+            "hello",
+        )
+
+        delta = state.update("hello world one two three four five")
+
+        self.assertEqual(delta, "world")
+        self.assertEqual(state.emitted_text, "hello world")
+
+
+class TestChunkedStreamingASRSSE(CustomTestCase):
+    def _stream_deltas(self, transcripts: List[str]) -> List[str]:
+        tokenizer_manager = _ScriptedQwen3ASRTokenizerManager(transcripts)
+        serving = OpenAIServingTranscription(tokenizer_manager)
+        request = TranscriptionRequest(
+            model="Qwen/Qwen3-ASR-0.6B",
+            stream=True,
+            audio_data=b"mock audio",
+        )
+        adapted_request = GenerateReqInput(
+            text="",
+            sampling_params={},
+            modalities=["audio"],
+        )
+        raw_request = Mock(headers={})
+        raw_request.is_disconnected = AsyncMock(return_value=False)
+
+        async def drive_stream():
+            frames = []
+            async for frame in serving._generate_chunked_asr_stream(
+                adapted_request, request, raw_request
+            ):
+                frames.append(frame)
+            return frames
+
+        chunks = [f"chunk-{i}".encode() for i in range(len(transcripts))]
+        with patch(
+            "sglang.srt.entrypoints.openai.serving_transcription.split_audio_chunks",
+            return_value=chunks,
+        ):
+            frames = get_or_create_event_loop().run_until_complete(drive_stream())
+        return _deltas_from_sse(frames)
+
+    def test_punctuation_revision_reaches_client_without_extra_space(self):
+        deltas = self._stream_deltas(
+            [
+                "hello world one two three four five",
+                "hello world, one two three four five",
+                "hello world, one two three four five",
+            ]
+        )
+
+        self.assertEqual(
+            deltas,
+            ["hello", " world", ",", " one", " two", " three", " four", " five"],
+        )
+        self.assertEqual("".join(deltas), "hello world, one two three four five")
+
+    def test_word_extension_reaches_client_as_a_complete_word(self):
+        deltas = self._stream_deltas(
+            [
+                "the cat one two three four five",
+                "the caterpillar one two three four five",
+                "the caterpillar one two three four five",
+            ]
+        )
+
+        self.assertEqual(deltas[2], " caterpillar")
+        self.assertNotIn("erpillar", [delta.strip() for delta in deltas])
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()

--- a/test/registered/unit/entrypoints/openai/test_streaming_asr_state.py
+++ b/test/registered/unit/entrypoints/openai/test_streaming_asr_state.py
@@ -97,6 +97,22 @@ class TestStreamingASRState(CustomTestCase):
         self.assertEqual(delta, "world")
         self.assertEqual(state.emitted_text, "hello world")
 
+    def test_temporary_prefix_shrink_does_not_repeat_words(self):
+        state = self._state()
+        self.assertEqual(
+            state.update("alpha beta gamma one two three four five"),
+            "alpha beta gamma",
+        )
+        self.assertEqual(
+            state.update("alpha beta one two three four five"),
+            "",
+        )
+
+        delta = state.update("alpha beta gamma delta one two three four five")
+
+        self.assertEqual(delta, "delta")
+        self.assertEqual(state.emitted_text, "alpha beta gamma delta")
+
 
 class TestChunkedStreamingASRSSE(CustomTestCase):
     def _stream_deltas(self, transcripts: List[str]) -> List[str]:


### PR DESCRIPTION
## Motivation

Fixes #35295.

Chunked streaming ASR can emit a mid-word fragment when a cumulative hypothesis revises a confirmed word. It can also insert a space before punctuation in the prompt prefix.

## Modifications

- Treat character-prefix growth as append-only only at a text boundary.
- Preserve punctuation-aware spacing in the emitted prompt prefix.
- Add CPU regression tests for state transitions and client-visible HTTP SSE deltas using the Qwen3-ASR adapter.

## Accuracy Tests

```text
32 passed
```

Command:

```bash
python -m pytest -q   test/registered/unit/entrypoints/openai/test_streaming_asr_state.py   test/registered/unit/entrypoints/openai/test_serving_transcription.py   test/registered/unit/entrypoints/openai/test_audio_chunking.py
```

Relevant isort, ruff, black, and codespell hooks pass.

## Speed Tests and Profiling

Not applicable. The change adds one constant-time boundary check per ASR chunk.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (Not applicable.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Not applicable beyond the regression tests above.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32116214816](https://github.com/sgl-project/sglang/actions/runs/32116214816)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32116214332](https://github.com/sgl-project/sglang/actions/runs/32116214332)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->