### PR TITLE
[Fix] DCP: advertise the logical KV-event block size

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -9589,6 +9589,13 @@ class ServerArgs:
         ``--speculative-draft-load-format`` needs its own transfer engine."""
         return remote_instance_transfer_engine_of(self, load_format)
 
+    @property
+    def kv_event_block_size(self) -> int:
+        """Width KV events are emitted at: under DCP the radix tree pages at
+        ``page_size * dcp_size`` (``mem_cache/kv_cache_builder.py``).
+        """
+        return self.page_size * self.dcp_size
+
     def describe_kv_events_publisher(self) -> Optional[dict]:
         """Return a structured description of this server's KV-event
         publisher, or `None` if publishing is disabled / misconfigured.
@@ -9614,10 +9621,13 @@ class ServerArgs:
                 "topic": "",                      # ZMQ topic prefix on the
                                                   # SUB filter (empty =
                                                   # subscribe-all)
-                "block_size": <page_size>,        # subscribers MUST hash
-                                                  # prompts at this size
-                "dp_size": <dp_size>,             # number of SUB sockets
-                                                  # to open
+                "block_size": <kv_event_block_size>,  # subscribers MUST
+                                                  # hash prompts at this size
+                "dp_size": <dp_size>,             # number of SUB sockets to
+                                                  # open; not DCP-scaled, as
+                                                  # DCP shards within a rank
+                                                  # rather than adding
+                                                  # publishers
             }
 
         Returns None (i.e. "no publisher to describe") when any of:
@@ -9672,7 +9682,7 @@ class ServerArgs:
             "endpoint_host": host,
             "endpoint_port_base": port,
             "topic": cfg.topic,
-            "block_size": page_size,
+            "block_size": self.kv_event_block_size,
             "dp_size": self.dp_size,
         }
 

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -2212,5 +2212,35 @@ class TestTwoBatchOverlapBackend(CustomTestCase):
         args._check_two_batch_overlap()
 
 
+class TestDcpKvEventContract(CustomTestCase):
+    """DCP widens the radix-tree page to page_size * dcp_size, which the
+    advertised KV-event block size must reflect."""
+
+    KV_EVENTS = '{"publisher":"zmq","topic":"kv","endpoint":"tcp://*:5557"}'
+
+    def test_kv_events_descriptor_reports_logical_block_size(self):
+        """Advertising the physical page_size made every KV-aware router hash
+        prompts at a width no emitted block can match, silently pinning its
+        hit rate to zero while stores kept applying cleanly."""
+        args = ServerArgs(
+            model_path="dummy",
+            tp_size=4,
+            dcp_size=4,
+            page_size=64,
+            kv_events_config=self.KV_EVENTS,
+        )
+        self.assertEqual(args.describe_kv_events_publisher()["block_size"], 256)
+        args = ServerArgs(
+            model_path="dummy", page_size=64, kv_events_config=self.KV_EVENTS
+        )
+        self.assertEqual(args.describe_kv_events_publisher()["block_size"], 64)
+
+    def test_kv_event_block_size_widens_a_single_token_page(self):
+        # page_size=1 + DCP is a real deployment shape: the allocator is still
+        # paged, at dcp_size.
+        args = ServerArgs(model_path="dummy", tp_size=8, dcp_size=8, page_size=1)
+        self.assertEqual(args.kv_event_block_size, 8)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

Under DCP, SGLang runs two page sizes: the configured **physical** `page_size`, and a **logical** page `page_size * dcp_size` that the allocator is built with (`mem_cache/kv_cache_configurator.py`) and that the radix tree inherits (`mem_cache/kv_cache_builder.py`). KV events are chunked by the tree's page size, so they go out at the logical width.

`/server_info`'s `kv_events` descriptor advertised the **physical** `page_size`. A KV-aware router honoring the documented contract — *"subscribers MUST hash prompts at this size"* — then hashes requests at a width no emitted block can ever match. Stores apply cleanly, every lookup misses, and the router's KV hit rate is silently **exactly 0** while all local metrics look healthy.

## Modifications

- Add `ServerArgs.kv_event_block_size` (property): `page_size * dcp_size`, the width events are actually emitted at.
- `describe_kv_events_publisher` advertises it instead of the physical `page_size`. The `page_size` field itself is unchanged — only the advertised value is corrected.
- Document that the descriptor's `dp_size` is deliberately *not* DCP-scaled: DCP shards within a rank rather than adding publishers.

No working configuration changes behavior — under DCP the advertised value was unusable (hit rate 0), and without DCP the value is identical.

## Verification

Measured on 4x H200 with Kimi-Linear-48B-A3B-Instruct (`tp=4 dcp=4 page_size=64`):

- **Engine only, no router:** plain `sglang.launch_server` — before, `/server_info` reported `kv_events.block_size=64` while the ZMQ wire carried `BlockStored.block_size=256`; after, it reports 256, matching the wire.
- **End to end through a KV-aware router:** the equivalent consumer-side mistake gave a hit rate of **exactly 0** over six identical 1,686-token prompts, against **4.814814814814815 / 6** (the 96.3% arithmetic maximum, `5 * 26/27`) on otherwise identical no-DCP arms — including a same-attention-backend control arm, which rules out the backend. Correcting the width restored it to `5 * 6/7 = 4.285714285714286 / 6`, the arithmetic maximum for the 256-token logical page, and again to `3 * 6/7` on fresh content.
- The same consumer-side bug in Dynamo's SGLang integration (reading `server_args.page_size` directly, bypassing this descriptor) was fixed independently in ai-dynamo/dynamo#12765. This PR fixes the engine's own advertised contract, so any subscriber that honors it — e.g. sgl-router, whose `BlockSizeOracle` takes its width from this field and whose hashes must reach bit-parity with SGLang's `hash_page` at that width — is correct without needing DCP awareness of its own.
- **Unit tests** (`TestDcpKvEventContract`): red on `main`, green with the fix; covers `page_size=1 + dcp` (paged at `dcp_size`) and the non-DCP default. `pre-commit` passes.

## Note on scope

An earlier revision of this PR also added an args-time `tp_size % dcp_size` guard. That was **dropped**: `parallel_state.py` already raises `RuntimeError("tensor_model_parallel_size (N) must be divisible by decode_context_parallel_size (M)")` during dist init, before weights load. Confirmed by launching `--tp-size 1 --dcp-size 2` on `main`. Thanks @alexnails for questioning whether that check was needed — it wasn't.

## Checklist

- [x] Format your code with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation as needed.
- [x] Provide verification results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #32211162197](https://github.com/sgl-project/sglang/actions/runs/32211162197)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32211161961](https://github.com/sgl-project/sglang/actions/runs/32211161961)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->