### PR TITLE
[Speculative] Enable target-only mixed chunked prefill for DSpark

### DIFF
--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -515,13 +515,10 @@ def _handle_dspark(server_args: ServerArgs) -> None:
         )
 
     if server_args.enable_mixed_chunk:
-        declare_resolution(
-            server_args,
-            "_handle_dspark",
-            enable_mixed_chunk=False,
-        )
-        logger.warning(
-            "Mixed chunked prefill is disabled because of using dspark speculative decoding."
+        logger.info(
+            "Mixed chunked prefill is enabled for DSpark. Running decode "
+            "requests advance by one target token in each mixed batch and "
+            "resume speculative verification on the following decode batch."
         )
 
     from sglang.srt.speculative.ragged_verify import (

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -2761,7 +2761,52 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         # For split prefill, we need to set the forward mode to SPLIT_PREFILL
         self.forward_mode = ForwardMode.SPLIT_PREFILL
 
-    def mix_with_running(self, running_batch: ScheduleBatch):
+    def prepare_dspark_for_mixed(self) -> List[int]:
+        """Prepare a DSpark running batch for one target-only mixed step.
+
+        DSpark decode preparation reserves a verify window but intentionally
+        leaves ``seq_lens`` at the committed prefix.  A mixed target forward
+        consumes exactly the relayed bonus token, so point ``out_cache_loc`` at
+        the first reserved slot and advance the forward-facing sequence length
+        by one.  The returned prefix lengths must be captured before that
+        advance and appended to the prefill half by ``mix_with_running``.
+        """
+        if not self.spec_algorithm.is_dspark():
+            raise ValueError("prepare_dspark_for_mixed requires DSPARK")
+
+        from sglang.kernels.ops.speculative.cache_locs import (
+            assign_extend_cache_locs_func,
+        )
+
+        running_bs = self.batch_size()
+        # Some attention backends (including DSV4) opt out of FutureMap's
+        # regular seq-lens D2H and intentionally leave seq_lens_cpu unset.
+        # Mixed extend metadata still needs the committed prefix as a Python
+        # list, so materialize the small per-request mirror only on this path.
+        seq_lens_cpu = self.seq_lens_cpu
+        if seq_lens_cpu is None:
+            seq_lens_cpu = self.seq_lens.to(device="cpu")
+        prefix_lens = seq_lens_cpu.tolist()
+        self.out_cache_loc = assign_extend_cache_locs_func(
+            req_pool_indices=self.req_pool_indices,
+            req_to_token=self.req_to_token_pool.req_to_token,
+            start_offset=self.seq_lens,
+            end_offset=self.seq_lens + 1,
+            batch_size=running_bs,
+            draft_token_num=1,
+            device=self.device,
+        )
+        self.seq_lens = self.seq_lens + 1
+        self.seq_lens_cpu = seq_lens_cpu + 1
+        self.seq_lens_sum = int(self.seq_lens_cpu.sum())
+        return prefix_lens
+
+    def mix_with_running(
+        self,
+        running_batch: ScheduleBatch,
+        *,
+        running_prefix_lens: Optional[List[int]] = None,
+    ):
         self.forward_mode = ForwardMode.MIXED
         running_bs = running_batch.batch_size()
 
@@ -2782,10 +2827,17 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         delta = 0 if self.enable_overlap else -1
 
         # NOTE: prefix_indices is what has been cached, but we don't cache each decode step
-        self.prefix_lens = self.prefix_lens + [
-            len(r.origin_input_ids) + len(r.output_ids) + delta
-            for r in running_batch.reqs
-        ]
+        if running_prefix_lens is None:
+            running_prefix_lens = [
+                len(r.origin_input_ids) + len(r.output_ids) + delta
+                for r in running_batch.reqs
+            ]
+        elif len(running_prefix_lens) != running_bs:
+            raise ValueError(
+                "running_prefix_lens must have one entry per running request, "
+                f"got {len(running_prefix_lens)} for batch size {running_bs}"
+            )
+        self.prefix_lens = self.prefix_lens + running_prefix_lens
         self.extend_lens = self.extend_lens + [1] * running_bs
         self.extend_num_tokens = self.extend_num_tokens + running_bs
         # TODO (lianmin): Revisit this. It should be seq_len - 1

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3530,7 +3530,18 @@ class Scheduler(
             running_batch.filter_batch()
             if not running_batch.is_empty():
                 running_batch.prepare_for_decode()
-                new_batch.mix_with_running(running_batch)
+                running_prefix_lens = None
+                if running_batch.spec_algorithm.is_dspark():
+                    # Spec-v2 overlap keeps the authoritative accepted length
+                    # in FutureMap. Resolve it before turning this running
+                    # batch into a one-token target extend; req.output_ids and
+                    # req.kv_committed_len may still lag by one scheduler turn.
+                    if self.enable_overlap:
+                        self.future_map.resolve_seq_lens_cpu(running_batch)
+                    running_prefix_lens = running_batch.prepare_dspark_for_mixed()
+                new_batch.mix_with_running(
+                    running_batch, running_prefix_lens=running_prefix_lens
+                )
                 new_batch.decoding_reqs = running_batch.reqs
             running_batch = ScheduleBatch(
                 reqs=[], batch_is_full=running_batch.batch_is_full

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -96,6 +96,14 @@ class SchedulerBatchResultProcessor:
     output_streamer: SchedulerOutputStreamer
     abort_request: Callable
 
+    @staticmethod
+    def _commit_dspark_mixed_target_token(
+        *, batch: ScheduleBatch, req: Req, decoding_req_ids: set[int]
+    ) -> None:
+        """Settle the target-only token consumed by a DSpark mixed batch."""
+        if batch.spec_algorithm.is_dspark() and id(req) in decoding_req_ids:
+            req.kv_committed_len += 1
+
     def process_batch_result_prebuilt(self, batch: ScheduleBatch):
         assert self.disaggregation_mode == DisaggregationMode.DECODE
         use_free_group = get_disagg().disaggregation_decode_enable_radix_cache
@@ -285,6 +293,7 @@ class SchedulerBatchResultProcessor:
 
             # Check finish conditions
             logprob_pt = 0
+            decoding_req_ids = {id(req) for req in batch.decoding_reqs or []}
 
             for i, (req, next_token_id) in enumerate(zip(batch.reqs, next_token_ids)):
                 if (
@@ -316,6 +325,18 @@ class SchedulerBatchResultProcessor:
                 if req.inflight_middle_chunks <= 0:
                     req.time_stats.set_prefill_finished_time()
 
+                    # Spec-v2 normally commits accepted tokens in
+                    # _resolve_spec_v2_tokens.  A DSpark mixed batch takes the
+                    # target-only prefill path instead, so settle the one bonus
+                    # token consumed for each running request here.  New
+                    # prefill requests were already settled by
+                    # ScheduleBatch.prepare_for_extend and must not be touched.
+                    self._commit_dspark_mixed_target_token(
+                        batch=batch,
+                        req=req,
+                        decoding_req_ids=decoding_req_ids,
+                    )
+
                     # req output_ids are set here
                     req.output_ids.append(next_token_id)
 
@@ -327,7 +348,7 @@ class SchedulerBatchResultProcessor:
                         self._maybe_collect_indexer_topk(req)
                         release_kv_cache(req, self.tree_cache)
                         req.time_stats.set_completion_time()
-                    elif not batch.decoding_reqs or req not in batch.decoding_reqs:
+                    elif id(req) not in decoding_req_ids:
                         maybe_cache_unfinished_req(req, self.tree_cache)
                         if get_memory().enable_hisparse:
                             self.hisparse_coordinator.admit_request_into_staging(req)

--- a/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
+++ b/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
@@ -606,6 +606,12 @@ class SchedulerMetricsReporter:
             else self.scheduler.forward_ct
         )
         iter_msg = f" [{batch_iter}]" if LOG_FORWARD_ITERS else ""
+        forward_mode = batch.forward_mode.name if batch is not None else "UNKNOWN"
+        num_mixed_decode_reqs = (
+            len(batch.decoding_reqs or [])
+            if batch is not None and batch.forward_mode.is_mixed()
+            else 0
+        )
 
         msg = (
             f"Prefill batch{iter_msg}, "
@@ -616,6 +622,8 @@ class SchedulerMetricsReporter:
             f"#running-req: {prefill_stats.num_running_reqs.total}, "
             f"#queue-req: {len(self.scheduler.waiting_queue)}, "
             f"#pending-token: {prefill_stats.num_pending_tokens}, "
+            f"forward mode: {forward_mode}, "
+            f"#mixed-decode-req: {num_mixed_decode_reqs}, "
         )
 
         if self.scheduler.disaggregation_mode == DisaggregationMode.PREFILL:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -9848,7 +9848,8 @@ class ServerArgs:
         if self.speculative_algorithm is not None:
             assert (
                 not self.enable_mixed_chunk
-            ), "enable_mixed_chunk is required for speculative decoding"
+                or self.speculative_algorithm.upper() == "DSPARK"
+            ), "enable_mixed_chunk is only supported with DSPARK speculative decoding"
 
         # Check chunked prefill
         # Skip validation if chunked prefill is disabled (i.e., size <= 0).

--- a/test/registered/spec/dspark/test_dspark_draft_path_default.py
+++ b/test/registered/spec/dspark/test_dspark_draft_path_default.py
@@ -58,6 +58,16 @@ class TestTargetCheckpointBundlesDsparkDraft(CustomTestCase):
 
 
 class TestDsparkDraftPathDefaulting(CustomTestCase):
+    def test_mixed_chunk_remains_enabled(self):
+        server_args = _make_dspark_server_args(
+            model_path=_BUNDLED_MODEL_PATH, hf_config=_bundled_hf_config()
+        )
+        server_args.enable_mixed_chunk = True
+
+        _handle_dspark(server_args)
+
+        self.assertTrue(server_args.enable_mixed_chunk)
+
     def test_bundled_checkpoint_defaults_draft_path_to_model_path(self):
         server_args = _make_dspark_server_args(
             model_path=_BUNDLED_MODEL_PATH, hf_config=_bundled_hf_config()

--- a/test/registered/unit/managers/test_dspark_mixed_chunk_bookkeeping.py
+++ b/test/registered/unit/managers/test_dspark_mixed_chunk_bookkeeping.py
@@ -1,0 +1,46 @@
+import types
+import unittest
+
+from sglang.srt.managers.scheduler_components.batch_result_processor import (
+    SchedulerBatchResultProcessor,
+)
+from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestDsparkMixedChunkBookkeeping(unittest.TestCase):
+    def test_running_row_commits_one_target_token(self):
+        req = types.SimpleNamespace(kv_committed_len=17)
+        batch = types.SimpleNamespace(spec_algorithm=SpeculativeAlgorithm.DSPARK)
+
+        SchedulerBatchResultProcessor._commit_dspark_mixed_target_token(
+            batch=batch, req=req, decoding_req_ids={id(req)}
+        )
+
+        self.assertEqual(req.kv_committed_len, 18)
+
+    def test_new_prefill_row_is_not_double_committed(self):
+        req = types.SimpleNamespace(kv_committed_len=17)
+        batch = types.SimpleNamespace(spec_algorithm=SpeculativeAlgorithm.DSPARK)
+
+        SchedulerBatchResultProcessor._commit_dspark_mixed_target_token(
+            batch=batch, req=req, decoding_req_ids=set()
+        )
+
+        self.assertEqual(req.kv_committed_len, 17)
+
+    def test_non_dspark_mixed_row_keeps_existing_owner(self):
+        req = types.SimpleNamespace(kv_committed_len=17)
+        batch = types.SimpleNamespace(spec_algorithm=SpeculativeAlgorithm.NONE)
+
+        SchedulerBatchResultProcessor._commit_dspark_mixed_target_token(
+            batch=batch, req=req, decoding_req_ids={id(req)}
+        )
+
+        self.assertEqual(req.kv_committed_len, 17)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_schedule_batch_out_of_place.py
+++ b/test/registered/unit/managers/test_schedule_batch_out_of_place.py
@@ -2,7 +2,7 @@ import dataclasses
 import types
 import unittest
 from array import array
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import torch
 
@@ -13,6 +13,7 @@ maybe_stub_sgl_kernel()
 
 from sglang.srt.managers.schedule_batch import ScheduleBatch  # noqa: E402
 from sglang.srt.model_executor.forward_batch_info import ForwardMode  # noqa: E402
+from sglang.srt.speculative.spec_info import SpeculativeAlgorithm  # noqa: E402
 from sglang.srt.utils.common import Range  # noqa: E402
 
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
@@ -113,6 +114,84 @@ class TestMergeBatchOutOfPlace(unittest.TestCase):
 
 
 class TestMixWithRunningOutOfPlace(unittest.TestCase):
+    @patch("sglang.kernels.ops.speculative.cache_locs.assign_extend_cache_locs_func")
+    def test_prepare_dspark_for_mixed_uses_first_reserved_slot(self, assign_locs):
+        assign_locs.return_value = torch.tensor([101, 202], dtype=torch.int64)
+        req_to_token = torch.arange(128, dtype=torch.int32).view(2, 64)
+        batch = ScheduleBatch(
+            reqs=[types.SimpleNamespace(rid="r0"), types.SimpleNamespace(rid="r1")],
+            req_to_token_pool=types.SimpleNamespace(req_to_token=req_to_token),
+            req_pool_indices=torch.tensor([0, 1], dtype=torch.int64),
+            seq_lens=torch.tensor([10, 20], dtype=torch.int64),
+            seq_lens_cpu=torch.tensor([10, 20], dtype=torch.int64),
+            spec_algorithm=SpeculativeAlgorithm.DSPARK,
+            device="cpu",
+        )
+
+        prefix_lens = batch.prepare_dspark_for_mixed()
+
+        self.assertEqual(prefix_lens, [10, 20])
+        self.assertTrue(torch.equal(batch.seq_lens, torch.tensor([11, 21])))
+        self.assertTrue(torch.equal(batch.seq_lens_cpu, torch.tensor([11, 21])))
+        self.assertEqual(batch.seq_lens_sum, 32)
+        self.assertTrue(torch.equal(batch.out_cache_loc, torch.tensor([101, 202])))
+        kwargs = assign_locs.call_args.kwargs
+        self.assertTrue(torch.equal(kwargs["start_offset"], torch.tensor([10, 20])))
+        self.assertTrue(torch.equal(kwargs["end_offset"], torch.tensor([11, 21])))
+        self.assertEqual(kwargs["draft_token_num"], 1)
+
+    @patch("sglang.kernels.ops.speculative.cache_locs.assign_extend_cache_locs_func")
+    def test_prepare_dspark_for_mixed_materializes_missing_cpu_lens(self, assign_locs):
+        assign_locs.return_value = torch.tensor([101, 202], dtype=torch.int64)
+        batch = ScheduleBatch(
+            reqs=[types.SimpleNamespace(rid="r0"), types.SimpleNamespace(rid="r1")],
+            req_to_token_pool=types.SimpleNamespace(
+                req_to_token=torch.arange(128, dtype=torch.int32).view(2, 64)
+            ),
+            req_pool_indices=torch.tensor([0, 1], dtype=torch.int64),
+            seq_lens=torch.tensor([10, 20], dtype=torch.int64),
+            seq_lens_cpu=None,
+            spec_algorithm=SpeculativeAlgorithm.DSPARK,
+            device="cpu",
+        )
+
+        prefix_lens = batch.prepare_dspark_for_mixed()
+
+        self.assertEqual(prefix_lens, [10, 20])
+        self.assertTrue(torch.equal(batch.seq_lens_cpu, torch.tensor([11, 21])))
+        self.assertEqual(batch.seq_lens_sum, 32)
+
+    def test_mix_with_running_uses_resolved_dspark_prefix_lens(self):
+        extend_batch = make_schedule_batch(
+            1,
+            reqs=[types.SimpleNamespace(rid="prefill")],
+            model_config=types.SimpleNamespace(is_encoder_decoder=False),
+            sampling_info=MagicMock(),
+            return_logprob=False,
+            forward_mode=ForwardMode.EXTEND,
+            enable_overlap=True,
+            is_prefill_only=True,
+            out_cache_loc=torch.tensor([0, 1], dtype=torch.int64),
+            prefix_lens=[0],
+            extend_lens=[2],
+            extend_num_tokens=2,
+            extend_logprob_start_lens=[0],
+        )
+        running_batch = make_schedule_batch(
+            1,
+            reqs=[_FakeReq("decode", origin_len=4, output_len=1)],
+            model_config=types.SimpleNamespace(is_encoder_decoder=False),
+            sampling_info=MagicMock(),
+            return_logprob=False,
+            forward_mode=ForwardMode.DECODE,
+            out_cache_loc=torch.tensor([9], dtype=torch.int64),
+        )
+
+        extend_batch.mix_with_running(running_batch, running_prefix_lens=[37])
+
+        self.assertEqual(extend_batch.prefix_lens, [0, 37])
+        self.assertEqual(extend_batch.extend_lens, [2, 1])
+
     def test_mix_with_running_rebinds_extend_fields_without_mutating_either_side(self):
         """mix_with_running must append via rebound lists; no field of either side may be mutated in place."""
         extend_batch = make_schedule_batch(

--- a/test/registered/unit/observability/test_forward_pass_metrics.py
+++ b/test/registered/unit/observability/test_forward_pass_metrics.py
@@ -16,6 +16,7 @@ from sglang.srt.managers.scheduler_components.metrics_reporter import (
     _CacheHitRateWindow,
 )
 from sglang.test.test_utils import CustomTestCase
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
 
 
 def _make_ps(**overrides) -> ParallelState:
@@ -98,6 +99,8 @@ def _make_reporter(test, scheduler) -> SchedulerMetricsReporter:
     if not hasattr(scheduler, "kv_events_publisher"):
         scheduler.kv_events_publisher = types.SimpleNamespace(
             init_kv_events=lambda *a, **kw: None,
+            emit_kv_metrics=lambda *a, **kw: None,
+            publish_kv_events=lambda *a, **kw: None,
         )
     if not hasattr(scheduler, "tp_workers"):
         scheduler.tp_workers = []
@@ -151,9 +154,41 @@ class TestForwardPassMetrics(unittest.TestCase):
             prefill_stats=None,
             seq_lens_cpu=[],
             fpm_start_time=100.0,
+            forward_iter=0,
         )
         defaults.update(overrides)
         return types.SimpleNamespace(**defaults)
+
+    def test_prefill_log_identifies_mixed_batch(self):
+        self.scheduler.pool_stats_observer = types.SimpleNamespace(
+            get_pool_stats=lambda: types.SimpleNamespace(
+                get_prefill_usage_msg_parts=lambda: []
+            )
+        )
+        batch = self._make_batch(
+            forward_mode=ForwardMode.MIXED,
+            decoding_reqs=[object(), object(), object()],
+        )
+        stats = PrefillStats(
+            log_input_tokens=128,
+            log_hit_tokens=256,
+            new_token_ratio=1.0,
+            num_running_reqs=types.SimpleNamespace(total=3),
+            num_new_seqs=1,
+        )
+
+        with patch(
+            "sglang.srt.managers.scheduler_components.metrics_reporter.logger.info"
+        ) as log_info:
+            self.reporter.report_prefill_stats(
+                batch=batch,
+                prefill_stats=stats,
+                can_run_cuda_graph=False,
+            )
+
+        message = log_info.call_args.args[0]
+        self.assertIn("forward mode: MIXED", message)
+        self.assertIn("#mixed-decode-req: 3", message)
 
     def test_emit_mixed_batch_separates_prefill_and_decode(self):
         self.scheduler._fpm_dp_rank = 3

--- a/test/registered/unit/spec/test_decode_bookkeeping_ownership.py
+++ b/test/registered/unit/spec/test_decode_bookkeeping_ownership.py
@@ -49,6 +49,10 @@ _RESOLVE = (
     "managers/scheduler_components/batch_result_processor.py",
     "SchedulerBatchResultProcessor._resolve_spec_v2_tokens",
 )
+_MIXED_PREFILL_RESULT = (
+    "managers/scheduler_components/batch_result_processor.py",
+    "SchedulerBatchResultProcessor._commit_dspark_mixed_target_token",
+)
 _SS = "session/streaming_session.py"
 _OWNER_SITES = {
     # non-spec scheduler
@@ -78,6 +82,9 @@ _OWNER_SITES = {
     ): 1,
     (*_RESOLVE, "kv_committed_len"): 1,
     (*_RESOLVE, "spec_verify_ct"): 1,
+    # DSpark mixed chunk: target-only fallback commits one running token in the
+    # prefill result path; new prefill rows were already committed above.
+    (*_MIXED_PREFILL_RESULT, "kv_committed_len"): 1,
     # disaggregation decode prealloc: kv_allocated_len is settled inside the
     # owned-kv alloc_for_decode_prealloc(_hisparse) functions (op42).
     (


### PR DESCRIPTION
## Motivation

Mixed chunked prefill was previously force-disabled when DSpark speculative decoding was enabled, and server argument validation rejected this combination.

As a result, when long prefill requests arrive while DSpark decode requests are running, the decode batch may make no progress during consecutive prefill chunks. This can cause large inter-token latency spikes for active streaming requests.It is expected that the maximum value or P90 of ITL in the reasoning process can be improved.

This PR adds an initial correctness-first implementation of mixed chunked prefill for DSpark.

## Behavior

When a prefill batch is scheduled while DSpark decode requests are running:

- The prefill requests execute their normal extend forward.
- Each running decode request advances by one target-only token in the same mixed batch.
- The running requests resume normal DSpark speculative verification in the following decode batch.

This PR does not execute a full DSpark draft/verify block inside a mixed batch. Its primary goal is to reduce decode starvation and tail ITL during prefill interference, rather than improve pure decode throughput.

## Implementation

### Enable the configuration

- Stop force-disabling `enable_mixed_chunk` in the DSpark argument hook.
- Allow mixed chunked prefill only for DSpark speculative decoding.
- Continue rejecting the combination for other speculative algorithms that have not been validated.

### Prepare DSpark decode requests for a mixed forward

DSpark decode preparation reserves a speculative verify window but keeps the sequence length at the committed prefix until verification completes.

For a target-only mixed step, this PR:

- Resolves the authoritative sequence lengths from `FutureMap` under overlap scheduling.
- Maps the mixed token to the first reserved KV slot.
- Captures the prefix lengths before advancing the sequence.
- Advances the forward-facing sequence lengths by exactly one token.
- Passes the resolved prefix lengths explicitly into `mix_with_running()`.

For attention backends such as DSV4 that intentionally skip the regular CPU sequence-length relay, the small CPU mirror is materialized only when an actual mixed batch is constructed.

## perf
not use midxed-chunk
<img width="2944" height="304" alt="image" src="https://github.com/user-attachments/assets/d3d0c1e3-143b-4917-9de8-cdb98ff80e96" />
use midxed-chunk
<img width="2806" height="866" alt="image" src="https://github.com/user-attachments/assets/f02bf414-0757-4c7c-8b9d-ab0e9f5b525f" />

we use this benchmark to test:
```python
python3 -m sglang.bench_serving \
  --model "${MODEL_PATH}" \
  --flush-cache \
  --backend "sglang" \
  --dataset-name "random" \
  --dataset-path "${DATASET_PATH}" \
  --num-prompts 512 \
  --random-input-len 32768 \
  --random-output-len 512 \
  --random-range-ratio 0.5 \
  --max-concurrency 16 \
  --warmup-requests 100 \
```
<img width="634" height="248" alt="image" src="https://github.com/user-attachments/assets/ffb99a83-8698-4725-9e12-42744e4b47eb" />

We can observe that the maximum value of ITL has decreased significantly.

not use midxed-chunk
<img width="550" height="600" alt="image" src="https://github.com/user-attachments/assets/62861f68-bf0b-46db-9b9d-c7f53cd21fc5" />
use midxed-chunk
<img width="550" height="600" alt="image" src="https://github.com/user-attachments/assets/ad2c833d-b0b2-469f-b3b5-fd57537228fd" />

## accuracy test
<img width="2746" height="234" alt="image" src="https://github.com/user-attachments/assets/b8c8a1c9-b135-49ad-8ccd-81550b5cfd04" />


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32692993219](https://github.com/sgl-project/sglang/actions/runs/32692993219)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32692993136](https://github.com/sgl-project/sglang/actions/runs/32692993136)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32692993272](https://github.com/sgl-project/sglang/actions/runs/32692993272)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->