### PR TITLE
[Bugfix] Fix Sarashina2 Vision multimodal imports

### DIFF
--- a/python/sglang/srt/models/sarashina2_vision.py
+++ b/python/sglang/srt/models/sarashina2_vision.py
@@ -24,11 +24,10 @@ from sglang.srt.layers.logits_processor import LogitsProcessor
 from sglang.srt.layers.pooler import Pooler, PoolingType
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.managers.mm_utils import (
-    MultimodalDataItem,
-    MultimodalInputs,
     MultiModalityDataPaddingPatternMultimodalTokens,
     general_mm_embed_routine,
 )
+from sglang.srt.managers.schedule_batch import MultimodalDataItem, MultimodalInputs
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.llama import LlamaForCausalLM

--- a/test/registered/unit/models/test_sarashina2_vision_import.py
+++ b/test/registered/unit/models/test_sarashina2_vision_import.py
@@ -1,0 +1,30 @@
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()  # must precede any import that pulls in sgl_kernel
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestSarashina2VisionImport(CustomTestCase):
+    def test_model_and_processor_registration(self):
+        from sglang.srt.models.sarashina2_vision import (
+            EntryClass,
+            Sarashina2VisionForCausalLM,
+        )
+        from sglang.srt.multimodal.processors.sarashina2_vision import (
+            Sarashina2VisionProcessor,
+        )
+
+        self.assertIs(EntryClass, Sarashina2VisionForCausalLM)
+        self.assertEqual(
+            Sarashina2VisionProcessor.models, [Sarashina2VisionForCausalLM]
+        )
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
## Motivation

SGLang silently skips Sarashina2 Vision model and processor registration because the model imports `MultimodalDataItem` and `MultimodalInputs` from `managers.mm_utils`, where those classes no longer exist.

The failure appears during model discovery as:

```text
ImportError: cannot import name 'MultimodalDataItem' from 'sglang.srt.managers.mm_utils'
```

## Modifications

- Import both multimodal data classes from `managers.schedule_batch`.
- Add a CPU regression test for the model entry class and processor registration.

## Accuracy Tests

```bash
PYTHONPATH=python python -m pytest -q   test/registered/unit/models/test_sarashina2_vision_import.py
```

```text
1 passed
```

Relevant isort, ruff, black, and codespell hooks pass.

## Speed Tests and Profiling

Not applicable. This only corrects import locations.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (Not applicable.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Not applicable.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32120898342](https://github.com/sgl-project/sglang/actions/runs/32120898342)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32120898343](https://github.com/sgl-project/sglang/actions/runs/32120898343)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->