### PR TITLE
[AMD][DSV4][SWA-BITEXACT 2/5] Host pools and L3 namespacing for strict SWA offload on unified_kv + HiCache

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -620,6 +620,11 @@ class Envs:
     SGLANG_OPT_SWA_RADIX_CACHE_COMPACT = EnvBool(False)
     SGLANG_OPT_SWA_SPLIT_LEAF_ON_INSERT = EnvBool(False)
     SGLANG_OPT_SWA_RELEASE_LEAF_LOCK_AFTER_WINDOW = EnvBool(False)
+    # Strict bit-exact SWA HiCache for unified_kv (DeepSeek-V4): offload the SWA
+    # ring to host and restore it on reuse instead of reprefilling a 128-token
+    # tail. Sizing: --hicache-swa-offload-page-stride. OFF == #29417 best-effort (tail
+    # reprefill, no SWA host pool) -- cheaper for short-prefix workloads.
+    SGLANG_UNIFIED_KV_BIT_EXACT_HICACHE = EnvBool(False)
 
     # ===================================================================
     # PD disaggregation runtime

--- a/python/sglang/srt/layers/attention/base_attn_backend.py
+++ b/python/sglang/srt/layers/attention/base_attn_backend.py
@@ -196,6 +196,35 @@ class AttentionBackend(ABC):
         """
         pass
 
+    def capture_swa_windows(
+        self, layer_id: int, kv: torch.Tensor, forward_batch: ForwardBatch
+    ) -> None:
+        """Prefill hook to snapshot the sliding window at page boundaries.
+
+        Called from the attention layer with the flat post-norm+rope KV, before
+        the device ring overwrites it. Only a backend whose ring is per-request
+        and recycled on completion has to copy the window somewhere durable; a
+        backend whose window stays addressable in the KV pool keeps nothing.
+        """
+        pass
+
+    def capture_swa_windows_decode(self, forward_batch: ForwardBatch) -> None:
+        """Decode counterpart of capture_swa_windows.
+
+        Called from ModelRunner outside the cuda graph, after the decode forward
+        wrote the ring and before the next step overwrites it.
+        """
+        pass
+
+    def capture_compress_state_windows_decode(
+        self, forward_batch: ForwardBatch
+    ) -> None:
+        """Decode hook for compressor state coupled to the sliding window.
+
+        Same call site and ordering contract as capture_swa_windows_decode.
+        """
+        pass
+
     @property
     def verify_mask(self) -> Optional[VerifyMask]:
         """The mask the draft stage fills in place, if this backend has one."""

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1375,6 +1375,7 @@ class Req(ReqDllmMixin):
                     ),
                     req=self,
                     cow_mamba=cow_mamba,
+                    for_reuse=True,
                 )
             )
             if envs.SGLANG_RADIX_FORCE_MISS.get():
@@ -2452,6 +2453,13 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         out_cache_loc, req_pool_indices_tensor, req_pool_indices_cpu = alloc_for_extend(
             self
         )
+
+        # unified_kv SWA HiCache: restore reused sliding-window KV into each
+        # request positional ring now that req_pool_idx is known, before the
+        # first forward reads it. No-op unless a req stashed a window at
+        # load_back (see SWAComponent.restore_pending_swa_windows).
+        if self.tree_cache is not None:
+            self.tree_cache.restore_swa_windows(reqs, req_pool_indices_cpu)
 
         # Set fields
         input_embeds = []

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -163,6 +163,7 @@ def match_prefix_for_req(
             ),
             cow_mamba=cow_mamba,
             req=req if include_req else None,
+            for_reuse=True,
         )
     )
     if envs.SGLANG_RADIX_FORCE_MISS.get():
@@ -350,7 +351,8 @@ class SchedulePolicy:
                             token_ids=prefix_ids,
                             extra_key=extra_key,
                             cache_salt=cache_salt,
-                        )
+                        ),
+                        for_reuse=True,
                     )
                 )
                 if envs.SGLANG_RADIX_FORCE_MISS.get():

--- a/python/sglang/srt/mem_cache/base_prefix_cache.py
+++ b/python/sglang/srt/mem_cache/base_prefix_cache.py
@@ -57,6 +57,12 @@ class MatchPrefixParams:
     cow_mamba: bool = False
     req: Optional[Req] = None
 
+    # True for cross-request reuse matches (scheduler-side lookups against the
+    # shared radix tree). False (default) for self-match lookups such as the
+    # one in `cache_unfinished_req`, which must keep trusting the device-only
+    # validators for the request's own freshly-computed nodes.
+    for_reuse: bool = False
+
 
 @dataclasses.dataclass
 class InsertParams:
@@ -407,6 +413,15 @@ class BasePrefixCache(ABC, PrefixCacheTrait):
         # trailing sliding window for re-prefill; every other cache keeps SWA
         # content-stable and overrides this where relevant.
         return 0
+
+    def restore_swa_windows(
+        self, reqs: Sequence[Req], req_pool_indices_cpu: torch.Tensor
+    ) -> None:
+        # Driven from prepare_for_extend once req_pool_idx is assigned, before the
+        # first forward reads the ring. Only a cache that hands a durable sliding
+        # window back on a prefix hit has anything to put there; a cache that
+        # re-prefills that window instead has nothing to restore.
+        pass
 
     def supports_mamba(self) -> bool:
         return False

--- a/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
@@ -782,6 +782,38 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         )
         return views, item_bytes
 
+    def swa_region_buffers(self) -> Tuple[List[torch.Tensor], int]:
+        """
+        Page-granular views of the SWA ring region [0, swa_pages) of every
+        unified_kv layer, one indexed row per sliding-window page
+        (``unified_swa_ring_size`` consecutive ring rows). Mirrors
+        ``unified_region_buffers`` so the SWA host pool transfers a whole window
+        per page and device rows match the host ``item_bytes`` in transfer_kv.
+        """
+        assert self._unified_kv, "swa_region_buffers requires unified_kv layout"
+
+        swa_pages = self.unified_kv_pool.swa_pages
+        head_dim = self.unified_kv_pool.head_dim
+        rows_per_page = self.unified_swa_ring_size
+        assert (
+            swa_pages % rows_per_page == 0
+        ), f"swa_pages {swa_pages} not a multiple of ring size {rows_per_page}"
+        num_pages = swa_pages // rows_per_page
+
+        views: List[torch.Tensor] = []
+        for buf in self.unified_kv_pool.kv_buffer:
+            page_view = (
+                buf.narrow(0, 0, swa_pages)
+                .reshape(num_pages, rows_per_page * head_dim)
+                .view(torch.uint8)
+            )
+            views.append(page_view)
+
+        item_bytes = (
+            rows_per_page * head_dim * self.unified_kv_pool.kv_buffer[0].element_size()
+        )
+        return views, item_bytes
+
     def get_state_buf_infos(self) -> Tuple[List[int], List[int], List[int]]:
         data_ptrs: List[int] = []
         data_lens: List[int] = []
@@ -810,6 +842,31 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
                 item_lens.append(t[0].nbytes * pool.ring_size)
 
         return data_ptrs, data_lens, item_lens
+
+    def get_swa_state_coupling_infos(self) -> List[Tuple[int, int]]:
+        """FlexKV integration contract: the SWA-slot -> state-row mapping.
+
+        FlexKV registers the c4 / indexer state device buffers itself (handles
+        come from ``get_state_buf_infos``); it only needs the mapping to
+        co-place / co-fetch each state row with the SWA window it rides. Returns
+        one ``(swa_page_size, ring_size)`` per sidecar state pool, in the SAME
+        order/filtering as the state-pool entries of ``get_state_buf_infos``. For
+        a SWA device location ``swa_loc`` the coupled state row is
+        ``(swa_loc // swa_page_size) * ring_size + (swa_loc % ring_size)`` when
+        ``swa_loc >= 0`` else ``-1`` (== translate_from_swa_loc_to_state_loc).
+
+        Co-lifetime invariant the connector MUST honor: for a given (rid, B) the
+        SWA window and its coupled state rows are allocated/freed together and
+        must be co-present on fetch -- if any coupled row is missing, drop the
+        whole SWA window (recompute), never fetch with a desynced state.
+        """
+        infos: List[Tuple[int, int]] = []
+        for pools in [self.compress_state_pools, self.indexer_compress_state_pools]:
+            for pool in pools:
+                if pool is None or pool.ratio == 128:
+                    continue
+                infos.append((pool.swa_page_size, pool.ring_size))
+        return infos
 
     def get_c128_state_buf_infos(
         self,

--- a/python/sglang/srt/mem_cache/hicache_storage.py
+++ b/python/sglang/srt/mem_cache/hicache_storage.py
@@ -389,6 +389,16 @@ class HiCacheFile(HiCacheStorage):
         if attn_cp_size > 1:
             self.config_suffix += f"_cp{attn_cp_rank}_{attn_cp_size}"
 
+        # Strict unified-kv SWA HiCache: the SWA window and its coupled c4/indexer
+        # overlap state persist as INDEPENDENT L3 pools coupled by key (sidecar
+        # C4_STATE->SWA + TRAILING_PAGES). The SWA blob is a pure window again (no
+        # A-gather tail packing), so its byte layout differs from the older
+        # ``_swapk1`` packed blobs -- namespace the whole cache by layout version so
+        # a stale packed blob cannot be read under the new independent layout. Bump
+        # the tag on any future SWA/state L3 layout change.
+        if envs.SGLANG_UNIFIED_KV_BIT_EXACT_HICACHE.get():
+            self.config_suffix += "_swaind1"
+
         if not os.path.exists(self.file_path) and tp_rank == 0 and attn_cp_rank == 0:
             os.makedirs(self.file_path)
             logger.info(f"Created HiCacheFile storage directory at {self.file_path}")

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
@@ -4,6 +4,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
+from sglang.srt.environ import envs
 from sglang.srt.mem_cache.hicache_storage import (
     PoolHitPolicy,
     PoolName,
@@ -32,6 +33,7 @@ from sglang.srt.runtime_context import (
     get_parallel,
     get_serving,
 )
+from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 
 if TYPE_CHECKING:
     import torch
@@ -443,6 +445,196 @@ def _dsv4_compressed_region_buffers(kvcache: Any, ratio: int) -> tuple[list, int
     return pool.kv_buffer, pool.bytes_per_page_padded
 
 
+def _dsv4_swa_ring_region_buffers(kvcache: Any) -> tuple[list, int]:
+    """Resolve (device_buffers, item_bytes) for the unified_kv SWA ring.
+
+    The SWA ring occupies rows [0, swa_pages) of every unified layer buffer
+    (addressed by req_pool_idx * swa_ring_size + pos % swa_ring_size). The host
+    pool pages the ring by sliding window: one host page mirrors one window
+    (unified_swa_ring_size consecutive rows), so device rows match the host
+    item_bytes in transfer_kv.
+    """
+    assert getattr(kvcache, "_unified_kv", False)
+    return kvcache.swa_region_buffers()
+
+
+def _dsv4_unified_state_paged_pool(
+    *,
+    pool_name: str,
+    state_pools,
+    global_layers,
+    ring_size: int,
+    num_host_pages: int,
+    allocator_type: str,
+    staging_slack_pages: int = 0,
+) -> DeepSeekV4PagedHostPool:
+    """Build a host pool for the c4 / c4-indexer overlap compress state. One host
+    page mirrors one per-request state ring block (ring_size slots). Uses
+    layer_first layout so data_refs[li][page_row] is the contiguous tile the
+    riding capture/restore helpers index directly. Not registered with the
+    HiCache controller; the tiles ride the SWA window's lifetime and are managed
+    by swa_component.
+
+    The pool splits into num_host_pages durable rows (addressed by the coupled
+    SWA window's host page row) plus staging_slack_pages staging rows (the only
+    region the allocator hands out, for transient capture keyed by (rid, B)
+    before the durable row is known). promote copies a staged tile into its
+    durable row, so the state persists in its own L3 pool at the same row as the
+    SWA window and is fetched by the coupled key family. staging_slack_pages == 0
+    keeps the legacy single-region behavior.
+    """
+    device_buffers = []
+    item_bytes = None
+    for gl in global_layers:
+        sp = state_pools[gl]
+        buf = sp.kv_score_buffer.kv_score  # [total_state_slots, last_dim]
+        device_buffers.append(buf)
+        ib = ring_size * buf.shape[-1] * buf.element_size()
+        if item_bytes is None:
+            item_bytes = ib
+        elif item_bytes != ib:
+            raise AssertionError(
+                f"{pool_name}: inconsistent state item_bytes {ib} vs {item_bytes} "
+                f"at global layer {gl}"
+            )
+    durable_pages = num_host_pages
+    total_pages = durable_pages + max(0, int(staging_slack_pages))
+    hp = DeepSeekV4PagedHostPool(
+        pool_name=pool_name,
+        device_buffers=device_buffers,
+        item_bytes=item_bytes,
+        num_host_pages=total_pages,
+        slot_page_size=ring_size,
+        layout="layer_first",
+        allocator_type=allocator_type,
+    )
+    if staging_slack_pages:
+        # Reserve [0, durable_pages) rows for window-coupled durable storage;
+        # allocator serves only the slack tail. Re-clear to apply the reserve.
+        hp._durable_reserve_slots = durable_pages * ring_size
+        hp.clear()
+    hp._capture_staging = {}
+    hp._capture_state_crc = {}
+    return hp
+
+
+# Default assumed average sequence length (tokens) of prefixes cached to host;
+# each such prefix needs one SWA window across many full-KV pages.
+_SWA_HICACHE_DEFAULT_AVG_SEQ_LEN = 50_000
+# Slow-launch WARN tier: above this per-rank size, page-locking the pool is slow
+# enough that a healthy launch can look like a hang -- warn, never fail. This is
+# the tier that owns the "fake hang" concern.
+_SWA_HICACHE_SLOW_LAUNCH_GB = 16.0
+# Hard FAIL-FAST tier: a fraction of *available* host DRAM the SWA offload pool
+# may claim on this node. Every GPU rank sharing the node pins its own copy, so
+# the per-rank ceiling is available_dram * fraction / ranks_per_node. This tier
+# owns only the "would physically exhaust host DRAM (real OOM)" concern -- NOT
+# slow pinning, which is the warn tier above.
+_SWA_HICACHE_HARD_LIMIT_DRAM_FRACTION = 0.9
+
+
+def _swa_host_hard_limit_gb(server_args) -> tuple[float, float | None, int | None]:
+    """Per-rank hard ceiling (GB) for the SWA offload host pool, derived from real
+    host DRAM instead of a fixed constant.
+
+    Every GPU rank on the node page-locks its own SWA host pool, so what fits per
+    rank is available_dram * fraction / ranks_per_node (ranks_per_node = tp_size
+    // nnodes). Returns (hard_gb, available_gb, ranks_per_node); if DRAM cannot be
+    probed, returns (inf, None, None) so the guard degrades to warn-only rather
+    than blocking launch.
+    """
+    try:
+        import psutil
+
+        avail_gb = psutil.virtual_memory().available / 1e9
+    except Exception:
+        return float("inf"), None, None
+    nnodes = max(1, int(getattr(server_args, "nnodes", 1) or 1))
+    tp_size = int(getattr(server_args, "tp_size", 1) or 1)
+    ranks_per_node = max(1, tp_size // nnodes)
+    hard_gb = avail_gb * _SWA_HICACHE_HARD_LIMIT_DRAM_FRACTION / ranks_per_node
+    return hard_gb, avail_gb, ranks_per_node
+
+
+def _check_swa_host_pool_upper_bound(
+    *,
+    swa_gb: float,
+    slow_gb: float,
+    hard_gb: float,
+    full_host_pages: int,
+    stride: int,
+    page_bytes: int,
+    avail_gb: float | None = None,
+    ranks_per_node: int | None = None,
+) -> None:
+    """Startup budget guard for the strict SWA offload host pool. The pool is pinned
+    host memory. Two tiers, never clamps:
+      * swa_gb in [slow_gb, hard_gb): warn and proceed. A large but feasible pin,
+        surfaced so slow page-locking is not mistaken for a hang.
+      * swa_gb >= hard_gb: raise ValueError. hard_gb is DRAM-derived, so crossing
+        it means the pool (summed across ranks on the node) would exhaust host
+        DRAM. Fail fast with a breakdown and the one knob that shrinks it: a
+        larger --hicache-swa-offload-page-stride.
+
+    Scope is the SWA host pool only; the FP4 c4/c128 host pools are out of scope.
+    """
+    if not page_bytes or swa_gb <= 0:
+        return
+    if swa_gb >= hard_gb:
+        dram_detail = ""
+        if avail_gb is not None and ranks_per_node is not None:
+            dram_detail = (
+                f" With {ranks_per_node} rank(s)/node each pinning this pool, "
+                f"that is ~{swa_gb * ranks_per_node:.0f} GB of host DRAM against "
+                f"{avail_gb:.0f} GB available "
+                f"(hard limit = {_SWA_HICACHE_HARD_LIMIT_DRAM_FRACTION:.0%} of "
+                f"available / rank = {hard_gb:.1f} GB/rank)."
+            )
+        raise ValueError(
+            f"[SWA-HiCache] SWA offload host pool would need {swa_gb:.1f} GB/rank "
+            f"(>= hard limit {hard_gb:.1f} GB/rank): full_host_pages={full_host_pages}, "
+            f"stride={stride}, page_bytes={page_bytes}.{dram_detail} Pinning this "
+            f"much host memory would exhaust host DRAM (OOM), not merely slow "
+            f"launch. Raise --hicache-swa-offload-page-stride to shrink this pool "
+            f"~linearly (the only knob that shrinks it); or disable strict reuse "
+            f"entirely (SGLANG_UNIFIED_KV_BIT_EXACT_HICACHE=0)."
+        )
+    if swa_gb >= slow_gb:
+        logger.warning(
+            "[SWA-HiCache] SWA host pool is %.1f GB/rank (>%.0f GB); host "
+            "pinning (cudaHostRegister) may slow server launch. Raise "
+            "--hicache-swa-offload-page-stride to shrink it, or use best-effort "
+            "(SGLANG_UNIFIED_KV_BIT_EXACT_HICACHE=0).",
+            swa_gb,
+            slow_gb,
+        )
+
+
+def _swa_host_num_pages(*, server_args, full_host_pages, device_ring_pages, page_bytes):
+    """SWA-ring host pool size in pages: one SWA window every ``stride`` full
+    pages, plus one tail window per in-flight request (bounded by the device
+    ring), floored at the device ring. _check_swa_host_pool_upper_bound warns
+    above _SWA_HICACHE_SLOW_LAUNCH_GB and fails fast above the DRAM-derived hard
+    ceiling; it never clamps."""
+    stride = max(1, int(getattr(server_args, "hicache_swa_offload_page_stride", 1)))
+    strided = -(-full_host_pages // stride)  # ceil(full_host_pages / stride)
+    tail_pages = device_ring_pages  # <= max in-flight tail windows
+    pages = max(1, device_ring_pages, strided + tail_pages)
+    gb = pages * page_bytes / 1e9
+    hard_gb, avail_gb, ranks_per_node = _swa_host_hard_limit_gb(server_args)
+    _check_swa_host_pool_upper_bound(
+        swa_gb=gb,
+        slow_gb=_SWA_HICACHE_SLOW_LAUNCH_GB,
+        hard_gb=hard_gb,
+        full_host_pages=full_host_pages,
+        stride=stride,
+        page_bytes=page_bytes,
+        avail_gb=avail_gb,
+        ranks_per_node=ranks_per_node,
+    )
+    return pages
+
+
 def build_deepseek_v4_hicache_stack(
     *,
     params: CacheInitParams,
@@ -462,11 +654,21 @@ def build_deepseek_v4_hicache_stack(
     full_layer_mapping = {layer_id: layer_id for layer_id in range(transfer_layer_num)}
 
     is_unified_kv = getattr(kvcache, "_unified_kv", False)
+    # Strict bit-exact SWA HiCache: offload the unified SWA ring to a host pool
+    # and restore it on reuse instead of reprefilling the trailing 128-token tail.
+    unified_swa_hicache = (
+        is_unified_kv and envs.SGLANG_UNIFIED_KV_BIT_EXACT_HICACHE.get()
+    )
     mtp_swa_device_buffers = []
     if is_unified_kv:
-        # unified_kv keeps the SWA ring inside the unified pool and never offloads it,
-        # so there is no separate SWA host pool to map.
-        swa_layer_mapping = {}
+        # Flag OFF: unified_kv keeps the SWA ring device-only (no host pool).
+        # Flag ON: mirror every layer like the non-unified SWA path so the ring
+        # can be offloaded/restored.
+        swa_layer_mapping = (
+            {layer_id: layer_id for layer_id in range(transfer_layer_num)}
+            if unified_swa_hicache
+            else {}
+        )
     else:
         if len(kvcache.swa_kv_pool.kv_buffer) != transfer_layer_num:
             raise ValueError(
@@ -559,6 +761,181 @@ def build_deepseek_v4_hicache_stack(
                 packed_draft_device_pools=tuple(mtp_swa_device_buffers),
             )
         )
+    elif unified_swa_hicache:
+        swa_ring_buffers, swa_item_bytes = _dsv4_swa_ring_region_buffers(kvcache)
+        num_swa_layers = len(swa_ring_buffers)
+        page_bytes = swa_item_bytes * num_swa_layers
+        # Page unit = one sliding window; the ring holds exactly num_slots windows.
+        swa_ring_size = kvcache.unified_swa_ring_size
+        device_ring_pages = kvcache.unified_kv_pool.swa_pages // swa_ring_size
+        unified_swa_host_pages = _swa_host_num_pages(
+            server_args=server_args,
+            full_host_pages=num_host_pages,
+            device_ring_pages=device_ring_pages,
+            page_bytes=page_bytes,
+        )
+        logger.info(
+            "[SWA-HiCache] SWA host pool: %d pages (%.2f GB), full_host_pages=%d, "
+            "layers=%d.",
+            unified_swa_host_pages,
+            unified_swa_host_pages * page_bytes / 1e9,
+            num_host_pages,
+            num_swa_layers,
+        )
+        swa_host_pool = DeepSeekV4PagedHostPool(
+            pool_name=str(PoolName.SWA),
+            device_buffers=swa_ring_buffers,
+            item_bytes=swa_item_bytes,
+            num_host_pages=unified_swa_host_pages,
+            slot_page_size=swa_ring_size,
+            layout=server_args.hicache_mem_layout,
+            allocator_type=server_args.hicache_storage_backend,
+        )
+        # Expose the host SWA pool + capture staging on the device kvcache so
+        # both the model forward (window capture) and swa_component insert
+        # (binding) can reach them.
+        kvcache._swa_host_pool = swa_host_pool
+        # Stride knob for sparse SWA offload, read by capture_swa_windows. Default
+        # 1 == one window per page; N>1 keeps one window every N pages plus the
+        # sequence tail window.
+        kvcache._swa_offload_page_stride = max(
+            1, int(getattr(server_args, "hicache_swa_offload_page_stride", 1))
+        )
+        # EAGLE makes the radix key a bigram view (len == tokens - 1): a node
+        # inserted with n tokens ends at ((n-1)//page)*page, one page below n
+        # whenever n is page-aligned -- which every chunked-prefill insert is.
+        # Windows keyed at the token boundary would sit one page past every node
+        # that could claim them and be freed unused, collapsing reuse to 0.
+        # Both capture sites read this flag and must agree boundary for boundary.
+        kvcache._swa_capture_bigram_key = SpeculativeAlgorithm.from_string(
+            server_args.speculative_algorithm
+        ).is_eagle()
+        if not hasattr(swa_host_pool, "_capture_staging"):
+            swa_host_pool._capture_staging = {}
+        if not hasattr(swa_host_pool, "_capture_crc"):
+            swa_host_pool._capture_crc = {}
+            swa_host_pool._dbg_restore_verified = 0
+
+        # c4 / c4-indexer overlap compress-state riding pools. Required whenever c4
+        # state layers exist -- there is no "SWA only" mode, because a captured SWA
+        # window is bit-exact on reuse only if the boundary overlap state
+        # [B-ratio, B) shares its bind/promote/offload/restore/free lifetime.
+        # State lives in its own L3 pool, coupled to the SWA window by key family
+        # plus positional durable row.
+        _state_ride = bool(c4_state_global_layers)
+        if _state_ride:
+            _ring_size = kvcache.compress_state_pools[
+                c4_state_global_layers[0]
+            ].ring_size
+            # Staging slack holds the transient landing rows for in-flight (rid, B)
+            # tiles not yet promoted to their window's durable row. State capture
+            # stages a tile at exactly the strided SWA window boundaries (see
+            # capture_c4_state_windows_unified), so in-flight tiles track the
+            # already-strided durable window budget; 1.5x gives concurrency headroom
+            # and each page is tiny (ring_size * slot_bytes * layers). Running out
+            # only excludes that boundary from reuse, never causes a dirty read.
+            _staging_slack = (unified_swa_host_pages * 3 + 1) // 2
+            kvcache._c4_state_host_pool = _dsv4_unified_state_paged_pool(
+                pool_name=str(PoolName.DEEPSEEK_V4_C4_STATE),
+                state_pools=kvcache.compress_state_pools,
+                global_layers=c4_state_global_layers,
+                ring_size=_ring_size,
+                num_host_pages=unified_swa_host_pages,
+                allocator_type=server_args.hicache_storage_backend,
+                staging_slack_pages=_staging_slack,
+            )
+            kvcache._c4_indexer_state_host_pool = _dsv4_unified_state_paged_pool(
+                pool_name=str(PoolName.DEEPSEEK_V4_C4_INDEXER_STATE),
+                state_pools=kvcache.indexer_compress_state_pools,
+                global_layers=c4_state_global_layers,
+                ring_size=_ring_size,
+                num_host_pages=unified_swa_host_pages,
+                allocator_type=server_args.hicache_storage_backend,
+                staging_slack_pages=_staging_slack,
+            )
+            kvcache._c4_state_layer_index = {
+                gl: i for i, gl in enumerate(c4_state_global_layers)
+            }
+            # Each state pool is registered below as a first-class HiCache pool and
+            # persisted/prefetched through its own page (get_data_page /
+            # set_from_flat / get_page_buffer_meta), coupled to the SWA window by
+            # key alone (sidecar C4_STATE->SWA + TRAILING_PAGES + batch_exists_v2
+            # min-across-pools). Nothing is blob-packed, so every L3 backend moves
+            # the state unchanged.
+            #   * _l3_page_size: L3 addresses the durable row by the coupled SWA
+            #     window page (index // swa_ring_size), not the state pool's own
+            #     ring_size slot -- the sidecar hands over SWA host indices.
+            #   * _manual_device_ride: device<->host stays owned by the manual
+            #     capture/restore ride, because the unified path overwrites the state
+            #     ring mid-prefill and a controller-driven device read would pick up
+            #     a dirty row. The controller device transfer becomes a no-op.
+            for _hp in (
+                kvcache._c4_state_host_pool,
+                kvcache._c4_indexer_state_host_pool,
+            ):
+                _hp._l3_page_size = swa_ring_size
+                _hp._manual_device_ride = True
+                # L3 backend page granularity == the coupled SWA window page
+                # (the sidecar hands SWA host indices). Must override the pool's
+                # own slot_page_size (== state ring_size, kept for the capture
+                # allocator/promote) so ``_batch_io_v2`` splits keys/indices per
+                # SWA page, matching the non-unified DeepSeekV4StateHostPool
+                # (page_size == swa_page_size). Leaving it at ring_size makes the
+                # storage backend reject every state page as a length mismatch.
+                _hp.page_size = swa_ring_size
+            logger.info(
+                "[SWA-HiCache] c4 state riding wired: %d c4 layers, ring_size=%d, "
+                "%d durable + %d staging host pages/pool (independent L3 pool, "
+                "key-coupled to SWA).",
+                len(c4_state_global_layers),
+                _ring_size,
+                unified_swa_host_pages,
+                _staging_slack,
+            )
+        else:
+            kvcache._c4_state_host_pool = None
+            kvcache._c4_indexer_state_host_pool = None
+            kvcache._c4_state_layer_index = None
+        swa_attn_allocator = params.token_to_kv_pool_allocator.swa_attn_allocator
+        entries.append(
+            build_pool_entry(
+                name=PoolName.SWA,
+                host_pool=swa_host_pool,
+                device_pool=None,
+                layer_mapping=swa_layer_mapping,
+                transfer_layer_num=transfer_layer_num,
+                host_evict_fn=host_swa_evict_fn,
+                device_evict_fn=device_swa_evict_fn,
+                device_alloc_fn=swa_attn_allocator.alloc,
+                device_free_fn=swa_attn_allocator.free,
+            )
+        )
+        # Register the unified c4 / c4-indexer overlap-state pools as first-class
+        # HiCache pools (device_pool=None, controller device transfer no-op'd via
+        # _manual_device_ride). This lands them in host_pool_group.entry_map, which
+        # activates the pre-existing SWA-coupled sidecar specs
+        # ((C4_STATE, SWA) / (C4_INDEXER_STATE, SWA), TRAILING_PAGES) so their L3
+        # pages ride the SWA window's key family. Mirrors the non-unified
+        # DEEPSEEK_V4_C4_STATE registration; replaces the A-gather blob packing.
+        if kvcache._c4_state_host_pool is not None:
+            entries.append(
+                build_pool_entry(
+                    name=PoolName.DEEPSEEK_V4_C4_STATE,
+                    host_pool=kvcache._c4_state_host_pool,
+                    device_pool=None,
+                    layer_mapping=c4_state_mapping,
+                    transfer_layer_num=transfer_layer_num,
+                )
+            )
+            entries.append(
+                build_pool_entry(
+                    name=PoolName.DEEPSEEK_V4_C4_INDEXER_STATE,
+                    host_pool=kvcache._c4_indexer_state_host_pool,
+                    device_pool=None,
+                    layer_mapping=c4_state_mapping,
+                    transfer_layer_num=transfer_layer_num,
+                )
+            )
 
     if c4_layer_mapping:
         c4_device_buffers, c4_item_bytes = _dsv4_compressed_region_buffers(kvcache, 4)
@@ -1176,6 +1553,9 @@ class StackBuildResult:
     host_pool_group: HostPoolGroup
     cache_controller: HybridCacheController
     component_host_pools: dict[ComponentType, Any]
+    # Strict bit-exact SWA HiCache (unified_kv only): couple SWA-host lifetime
+    # to Full-host via leaf-atomic eviction (no orphan tail). See SWAComponent.
+    swa_bit_exact: bool = False
     sidecars: list[SidecarPoolSpec] = field(default_factory=list)
     # Mamba state lives in req_to_token_pool, not in kvcache, so its
     # layer_transfer_counter has to be wired separately.
@@ -1230,6 +1610,35 @@ class _DeepSeekV4Strategy(StackStrategy):
         model_name=None,
         enable_storage_metrics=False,
     ):
+        # Fail fast before allocating/pinning the SWA host pool: strict
+        # bit-exact needs write_through so the owning request offloads its
+        # true SWA window at insert time (while its ring slot is still valid).
+        # write_back defers the ring->host copy to eviction, by when the slot
+        # may have been recycled -> silent non-bit-exact reuse.
+        swa_bit_exact = (
+            getattr(kvcache, "_unified_kv", False)
+            and envs.SGLANG_UNIFIED_KV_BIT_EXACT_HICACHE.get()
+        )
+        if swa_bit_exact and server_args.hicache_write_policy != "write_through":
+            raise ValueError(
+                "SGLANG_UNIFIED_KV_BIT_EXACT_HICACHE requires "
+                "--hicache-write-policy write_through (got "
+                f"{server_args.hicache_write_policy!r}); write_back cannot "
+                "guarantee the SWA ring is offloaded before its slot is reused."
+            )
+
+        if swa_bit_exact:
+            # The capture and restore halves of strict bit-exact SWA reuse land
+            # in later parts of this stack. A window restored without the
+            # c4/indexer state it was captured with is worse than a recomputed
+            # one -- the compressor would run against an antecedent the original
+            # prefill never used -- so until the last part is in, refuse to
+            # start rather than serve reuse that is silently not bit-exact.
+            raise ValueError(
+                "SGLANG_UNIFIED_KV_BIT_EXACT_HICACHE is not usable yet: the SWA "
+                "capture/restore path is not fully wired."
+            )
+
         host_pool_group, cache_controller = build_deepseek_v4_hicache_stack(
             params=params,
             server_args=server_args,
@@ -1275,6 +1684,7 @@ class _DeepSeekV4Strategy(StackStrategy):
             host_pool_group=host_pool_group,
             cache_controller=cache_controller,
             component_host_pools=component_host_pools,
+            swa_bit_exact=swa_bit_exact,
             sidecars=sidecars,
             transfer_layer_num=kvcache.end_layer - kvcache.start_layer,
             pools_desc="KV + SWA + DeepSeekV4 sidecars",
@@ -1703,6 +2113,25 @@ def _apply_stack_result(
         cache_attr, component_attr = _COMPONENT_HOST_ATTR[ct]
         setattr(cache, cache_attr, host_pool)
         setattr(cache.components[ct], component_attr, host_pool)
+
+    if result.swa_bit_exact and ComponentType.SWA in cache.components:
+        swa_comp = cache.components[ComponentType.SWA]
+        swa_comp._strict_bit_exact = True
+        # unified_kv: SWA device ring is positional; enable deferred
+        # positional restore (H->D at prepare_for_extend, after req_pool_idx).
+        swa_comp._unified_positional_swa = getattr(kvcache, "_unified_kv", False)
+        # Phase C: expose the c4/c4-indexer state riding pools + device state
+        # pool lists so the riding helpers (bind/promote/restore/free) can move
+        # state tiles alongside SWA windows. All None unless state riding wired.
+        swa_comp._c4_state_host_pool = getattr(kvcache, "_c4_state_host_pool", None)
+        swa_comp._c4_indexer_state_host_pool = getattr(
+            kvcache, "_c4_indexer_state_host_pool", None
+        )
+        swa_comp._c4_state_layer_index = getattr(kvcache, "_c4_state_layer_index", None)
+        swa_comp._compress_state_pools = getattr(kvcache, "compress_state_pools", None)
+        swa_comp._indexer_compress_state_pools = getattr(
+            kvcache, "indexer_compress_state_pools", None
+        )
 
     for sidecar in result.sidecars:
         cache.register_sidecar_pool(sidecar)

--- a/python/sglang/srt/mem_cache/memory_pool_host.py
+++ b/python/sglang/srt/mem_cache/memory_pool_host.py
@@ -20,6 +20,7 @@ _is_hip = is_hip()
 _is_npu = is_npu()
 _is_xpu = is_xpu()
 _is_mps = is_mps()
+
 if _is_cuda or _is_hip:
     from sgl_kernel.kvcacheio import (
         transfer_kv_all_layer_direct_lf_pf,
@@ -275,8 +276,70 @@ class DeepSeekV4PagedHostPool(HiSparseHostPoolMixin, HostKVCache):
         )
         self.can_use_jit = False
         self.can_use_write_back_jit = False
+        # SWA-capture completion event (lazily created on first capture, GPU
+        # only). Gates cross-stream consumers of a captured host page; see
+        # record_capture_done / wait_capture_done.
+        self._capture_done_event = None
         self._init_write_back_staging_buffers()
         self.clear()
+
+    def _ensure_capture_done_event(self):
+        """Lazily create the SWA-capture completion event (GPU only).
+
+        SWA-window capture (prefill and decode-source) enqueues its D2H on the compute
+        stream. That is same-stream-ordered against the ring write, but a cross-stream
+        consumer (restore H2D, L3 write-through, the device-landing check) must still
+        wait until the host page is fully written. record_capture_done records this
+        event on the compute stream and wait_capture_done awaits it. Returns None only
+        on cpu / no-GPU, where there is no stream to order.
+        """
+        if self._capture_done_event is None:
+            dev = self.gpu_device
+            if dev is None or str(dev) == "cpu":
+                return None
+            self._capture_done_event = torch.cuda.Event()
+        return self._capture_done_event
+
+    def record_capture_done(self, stream=None) -> None:
+        """Record the capture-completion event on ``stream`` (default: current)
+        AFTER the capture D2H copies were enqueued there, so any consumer that
+        calls ``wait_capture_done`` is ordered strictly after the host page is
+        fully written -- regardless of which stream produced or consumes it.
+        No-op on cpu / no-GPU."""
+        ev = self._ensure_capture_done_event()
+        if ev is None:
+            return
+        s = (
+            stream
+            if stream is not None
+            else torch.cuda.current_stream(device=self.gpu_device)
+        )
+        ev.record(s)
+
+    def wait_capture_done(self, stream=None) -> None:
+        """Make ``stream`` (default: current) wait until all enqueued SWA-capture
+        D2H copies have completed, so a cross-batch host-page read sees finished
+        bytes. No-op when no capture has run on this pool yet."""
+        ev = getattr(self, "_capture_done_event", None)
+        if ev is None:
+            return
+        s = (
+            stream
+            if stream is not None
+            else torch.cuda.current_stream(device=self.gpu_device)
+        )
+        s.wait_event(ev)
+
+    def sync_capture_done(self) -> None:
+        """Block the CPU until all enqueued capture D2H copies have landed.
+
+        wait_capture_done only orders a GPU stream, which does nothing for a
+        host-side read: the capture writes pinned pages with non_blocking=True, so
+        any CPU touch of those bytes (host->host promote, L3 page read) must wait
+        on the event itself. No-op when no capture has run on this pool yet."""
+        ev = getattr(self, "_capture_done_event", None)
+        if ev is not None:
+            ev.synchronize()
 
     def _init_write_back_staging_buffers(self):
         self.staging_buffer = None
@@ -301,7 +364,12 @@ class DeepSeekV4PagedHostPool(HiSparseHostPoolMixin, HostKVCache):
         return data_ptrs, data_lens, item_lens
 
     def _to_page_indices(self, indices: torch.Tensor) -> torch.Tensor:
-        return indices.reshape(-1, self.slot_page_size)[:, 0] // self.slot_page_size
+        # `_l3_page_size` (set on the unified c4/indexer STATE pools): the L3
+        # sidecar hands SWA host indices (one page == swa_ring_size slots), so the
+        # coupled DURABLE row is `index // swa_ring_size`, NOT the state pool's own
+        # ring_size slot. None (every other pool) => plain slot_page_size paging.
+        ps = getattr(self, "_l3_page_size", None) or self.slot_page_size
+        return indices.reshape(-1, ps)[:, 0] // ps
 
     def _has_transfer_indices(
         self, host_indices: torch.Tensor | None, device_indices: torch.Tensor | None
@@ -328,7 +396,14 @@ class DeepSeekV4PagedHostPool(HiSparseHostPoolMixin, HostKVCache):
         return self.kv_buffer if isinstance(self.kv_buffer, list) else [self.kv_buffer]
 
     def clear(self):
-        self.free_slots = torch.arange(self.size, dtype=torch.int64)
+        # Reserve the leading ``_durable_reserve_slots`` token slots (== N SWA
+        # page rows) so the allocator never hands them out. Those durable rows
+        # are addressed directly by the coupled SWA window page row
+        # (promote_captured_page writes them), while transient capture staging
+        # allocs only from the slack tail. Default 0 => arange(0, size), the
+        # plain behavior for every non-state pool.
+        reserve = int(getattr(self, "_durable_reserve_slots", 0) or 0)
+        self.free_slots = torch.arange(reserve, self.size, dtype=torch.int64)
         self.release_slots = []
         self.num_release_slots = 0
 
@@ -352,7 +427,14 @@ class DeepSeekV4PagedHostPool(HiSparseHostPoolMixin, HostKVCache):
 
     @synchronized
     def free(self, indices: torch.Tensor) -> int:
-        indices_cpu = indices.cpu()
+        # Never return durable-reserve rows to the free list: a durable row is
+        # owned by its coupled SWA window and recycled implicitly when that
+        # window's row is reused, not via this allocator. Filtered rows feed the
+        # upstream deferred-release queue (release_slots) like any other free.
+        indices_cpu = indices.to(dtype=torch.int64, device="cpu").flatten()
+        reserve = int(getattr(self, "_durable_reserve_slots", 0) or 0)
+        if reserve:
+            indices_cpu = indices_cpu[indices_cpu >= reserve]
         if indices_cpu.numel() == 0:
             return 0
 
@@ -360,9 +442,30 @@ class DeepSeekV4PagedHostPool(HiSparseHostPoolMixin, HostKVCache):
         self.num_release_slots += len(indices_cpu)
         return len(indices)
 
+    def promote_captured_page(self, staged_indices, durable_row: int) -> None:
+        """Co-lifetime: copy the c4/indexer state tile captured at
+        ``staged_indices`` (a slack-region page) into the durable ``durable_row``
+        (== the coupled SWA window host page row) for every layer, then release
+        the staging page. After this, ``get_data_page``/restore address the tile
+        by the SWA window row, so the state and its window share one L3 slot."""
+        # host->host copy runs on the CPU, so it must wait on the capture D2H that
+        # filled the staging page rather than just ordering a GPU stream.
+        self.sync_capture_done()
+        staged_row = int(staged_indices[0].item()) // self.slot_page_size
+        for li in range(self.layer_num):
+            self.data_refs[li][durable_row].copy_(self.data_refs[li][staged_row])
+        self.free(staged_indices)
+
     def backup_from_device_all_layer(
         self, device_pool, host_indices, device_indices, io_backend
     ):
+        # Unified c4/indexer STATE pool: L1<->L2 (device<->host) is owned by the
+        # manual bit-exact capture ride (swa_component), NOT the controller -- the
+        # unified path overwrites the state ring mid-prefill, so a controller device
+        # read here would be a dirty read. Durable host rows are already filled by
+        # the capture/promote path; this transfer is a no-op (L2<->L3 only).
+        if getattr(self, "_manual_device_ride", False):
+            return
         if not self._has_transfer_indices(host_indices, device_indices):
             return
         if (
@@ -433,6 +536,61 @@ class DeepSeekV4PagedHostPool(HiSparseHostPoolMixin, HostKVCache):
                 f"Unsupported V4 paged host layout/backend: {self.layout}/{io_backend}"
             )
 
+    def load_to_device_all_layer(
+        self, device_pool, host_indices, device_indices, io_backend
+    ):
+        """H->D restore for all layers in one fused op (reverse of
+        backup_from_device_all_layer).
+
+        The per-layer path issues one transfer op per layer, so a single reused window
+        costs layer_num kernel launches plus redundant index recomputation. The
+        direct/kernel layer_first primitives already accept the full per-layer
+        buffer/pointer lists, so we move every layer in one call. Byte-for-byte
+        identical to the per-layer loop (same primitive, same page indices); only the
+        launch overhead is removed.
+        """
+        if not self._has_transfer_indices(host_indices, device_indices):
+            return
+        if (
+            host_indices.numel() % self.slot_page_size != 0
+            or device_indices.numel() % self.slot_page_size != 0
+        ):
+            # Token-granular DSV4 C4 preload (not one contiguous byte range per
+            # token); mirror backup's all-layer token-granular helper.
+            transfer_cache_dsv4_mla(
+                src_ptrs=self.data_ptrs,
+                dst_ptrs=self.device_ptrs,
+                src_indices=host_indices.to(dtype=torch.int64),
+                dst_indices=device_indices.to(dtype=torch.int64),
+            )
+            return
+        host_rows = self._to_page_indices(host_indices)
+        device_rows = self._to_page_indices(device_indices)
+        if io_backend == "kernel" and self.layout == "layer_first":
+            transfer_kv_all_layer_mla(
+                src_layers=self.data_ptrs,
+                dst_layers=self.device_ptrs,
+                src_indices=host_rows,
+                dst_indices=device_rows,
+                item_size=self.item_bytes,
+                num_layers=self.layer_num,
+            )
+        elif io_backend == "direct" and self.layout == "layer_first":
+            transfer_kv_direct(
+                src_layers=self.data_refs,
+                dst_layers=self.device_buffers,
+                src_indices=host_rows,
+                dst_indices=device_rows,
+                page_size=1,
+            )
+        else:
+            # Layouts without a fused all-layer H2D path: fall back to the
+            # proven per-layer loop (correctness over speed).
+            for layer_id in range(self.layer_num):
+                self.load_to_device_per_layer(
+                    device_pool, host_indices, device_indices, layer_id, io_backend
+                )
+
     def load_to_device_per_layer(
         self,
         device_pool,
@@ -443,6 +601,10 @@ class DeepSeekV4PagedHostPool(HiSparseHostPoolMixin, HostKVCache):
         *,
         is_draft: bool = False,
     ):
+        # Unified c4/indexer STATE pool: L1<->L2 restore is owned by the manual
+        # bit-exact ride (_restore_state_windows), not the controller; no-op here.
+        if getattr(self, "_manual_device_ride", False):
+            return
         if not self._has_transfer_indices(host_indices, device_indices):
             return
         if (
@@ -502,38 +664,51 @@ class DeepSeekV4PagedHostPool(HiSparseHostPoolMixin, HostKVCache):
             )
 
     def get_data_page(self, index, flat=True):
-        index = int(index) // self.slot_page_size
+        # `_l3_page_size` (unified state pools): address the durable row by the
+        # coupled SWA window page; None => plain slot paging (SWA / C4 / C128).
+        # Reading the page on the CPU must wait on the capture D2H that filled it,
+        # else a half-written window/tile gets persisted to L3.
+        self.sync_capture_done()
+        _ps = getattr(self, "_l3_page_size", None) or self.slot_page_size
+        page_row = int(index) // _ps
         if self.layout == "layer_first":
             data_page = torch.stack(
-                [self.kv_buffer[i][index] for i in range(self.layer_num)]
+                [self.kv_buffer[i][page_row] for i in range(self.layer_num)]
             )
         elif self.layout in ["page_first", "page_first_direct"]:
-            data_page = self.kv_buffer[index]
+            data_page = self.kv_buffer[page_row]
         else:
             raise ValueError(f"Unsupported layout: {self.layout}")
-        return data_page.flatten() if flat else data_page
+        if not flat:
+            return data_page
+        return data_page.flatten()
 
     def get_dummy_flat_data_page(self):
-        return torch.zeros(
+        base = torch.zeros(
             (self.layer_num, self.item_bytes),
             dtype=self.dtype,
             device=self.device,
             pin_memory=self.pin_memory,
         ).flatten()
+        return base
 
     def set_from_flat_data_page(self, index, data_page):
-        index = int(index) // self.slot_page_size
+        # `_l3_page_size` (unified state pools): write the durable row addressed by
+        # the coupled SWA window page; None => plain slot paging.
+        _ps = getattr(self, "_l3_page_size", None) or self.slot_page_size
+        page_row = int(index) // _ps
+        data_page = data_page.view(self.dtype).reshape(-1)
         if self.layout == "layer_first":
-            data = data_page.view(self.dtype).reshape(self.layer_num, self.item_bytes)
+            data = data_page.reshape(self.layer_num, self.item_bytes)
             for i in range(self.layer_num):
-                self.kv_buffer[i][index].copy_(data[i])
+                self.kv_buffer[i][page_row].copy_(data[i])
         elif self.layout == "page_first":
-            self.kv_buffer[index].copy_(
-                data_page.view(self.dtype).reshape(self.layer_num, self.item_bytes)
+            self.kv_buffer[page_row].copy_(
+                data_page.reshape(self.layer_num, self.item_bytes)
             )
         elif self.layout == "page_first_direct":
-            self.kv_buffer[index].copy_(
-                data_page.view(self.dtype).reshape(self.layer_num, 1, self.item_bytes)
+            self.kv_buffer[page_row].copy_(
+                data_page.reshape(self.layer_num, 1, self.item_bytes)
             )
         else:
             raise ValueError(f"Unsupported layout: {self.layout}")

--- a/python/sglang/srt/mem_cache/storage/nixl/hicache_nixl.py
+++ b/python/sglang/srt/mem_cache/storage/nixl/hicache_nixl.py
@@ -112,6 +112,14 @@ class HiCacheNixl(HiCacheStorage):
         else:
             self.config_suffix = f"_{model_name}_{tp_rank}_{tp_size}"
 
+        # See HiCacheFile: strict unified-kv SWA HiCache persists the SWA window
+        # and its coupled c4/indexer overlap state as INDEPENDENT L3 pools coupled
+        # by key (no A-gather blob packing), so the SWA blob layout differs from the
+        # older ``_swapk1`` packed blobs. Namespace the key family by layout version
+        # so a stale packed blob can never be read under the new independent layout.
+        if envs.SGLANG_UNIFIED_KV_BIT_EXACT_HICACHE.get():
+            self.config_suffix += "_swaind1"
+
         sync_mode = getattr(
             nixlBind, "NIXL_THREAD_SYNC_RW", nixlBind.NIXL_THREAD_SYNC_STRICT
         )

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1634,6 +1634,26 @@ class ModelRunner:
         if get_exec().moe.elastic_ep_backend is not None:
             self.maybe_join_ep_ranks()
 
+        # Strict SWA HiCache: decode has no flat past-KV and runs under the cuda
+        # graph, so windows at page boundaries crossed during decode are captured
+        # here -- outside the graph, after the decode forward wrote the ring and
+        # before the next step overwrites ring slot 0. No-op unless the strict SWA
+        # host pool is wired; the backend guards the rest.
+        if not self.is_draft_worker and forward_batch.forward_mode.is_decode():
+            # The capture is enqueued on the current stream, which under the
+            # overlap scheduler is the worker's forward_stream -- the same stream
+            # that ran this decode forward and that will run the next one. So the
+            # ring read is same-stream-ordered between the two ring writes whether
+            # overlap is on or off. Cross-stream consumers of the captured host
+            # page (restore H2D, L3 write-through, device-landing check) are
+            # instead ordered by the capture-completion event that
+            # capture_swa_windows_decode records and wait_capture_done awaits.
+            self.attn_backend.capture_swa_windows_decode(forward_batch)
+
+            # Decode-source c4/c4-indexer overlap-state capture. Same timing,
+            # stream and event contract as the SWA decode capture above.
+            self.attn_backend.capture_compress_state_windows_decode(forward_batch)
+
         return output
 
     def _maybe_execute_deferred_mamba_cow_and_clear(

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -1623,6 +1623,10 @@ class MQALayer(MqaAttentionBase):
                 x_quant=x_quant,
             )
 
+        # Snapshot the sliding-window KV at each page boundary from the flat
+        # post-norm+rope KV before the device ring overwrites it (host offload).
+        if kv is not None:
+            attn_backend.capture_swa_windows(self.attn_mqa.layer_id, kv, forward_batch)
         # save_kv_cache = kv is not None selects who writes the ring. When kv is
         # None the store was already fused into _forward_prepare* (decode) or
         # done inline, so the backend skips its own store_cache; pass `q` as a

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2781,6 +2781,15 @@ class ServerArgs:
         "The size of host KV cache memory pool in gigabytes. Overrides --hicache-ratio in either host memory mode.",
         NS("memory"),
     ] = 0
+    hicache_swa_offload_page_stride: A[
+        int,
+        "Strict bit-exact SWA HiCache: offload one SWA sliding window every N "
+        "pages (plus the sequence tail window, always captured). 1 = per-page "
+        "(finest reuse granularity, most host memory). Larger N trades reuse "
+        "granularity for host memory; the SWA host pool is sized as "
+        "ceil(full_host_pages / N) + tail.",
+        NS("memory"),
+    ] = 1
     hicache_write_policy: A[
         str,
         Arg(

--- a/test/registered/mem_cache/test_swa_bitexact_extension_points.py
+++ b/test/registered/mem_cache/test_swa_bitexact_extension_points.py
@@ -1,0 +1,74 @@
+"""Interface tests for the extension points the strict SWA HiCache hangs on.
+
+These lock the shape of the hooks rather than any behaviour: the base-class
+implementations must exist, accept the arguments their callers pass, and do
+nothing. A shared call site that reaches the base class is what makes the
+feature inert when it is not wired, so losing one of these silently would turn
+an unwired deployment into an AttributeError on the hot path.
+"""
+
+import types
+import unittest
+
+import torch
+
+from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
+from sglang.srt.mem_cache.base_prefix_cache import BasePrefixCache, MatchPrefixParams
+from sglang.test.ci.ci_register import register_amd_ci
+
+register_amd_ci(est_time=15, suite="stage-b-test-1-gpu-small-amd")
+
+
+class TestForReuseParam(unittest.TestCase):
+    def test_defaults_to_false(self):
+        # Every existing caller omits it and must keep the self-match behaviour.
+        self.assertIs(MatchPrefixParams(None).for_reuse, False)
+
+    def test_accepts_true_without_touching_other_fields(self):
+        a = MatchPrefixParams(None)
+        b = MatchPrefixParams(None, for_reuse=True)
+        differing = [
+            f
+            for f in a.__dataclass_fields__
+            if getattr(a, f) != getattr(b, f) and f != "for_reuse"
+        ]
+        self.assertEqual(differing, [])
+
+
+class TestCaptureHookDefaults(unittest.TestCase):
+    """AttentionBackend's capture hooks default to doing nothing."""
+
+    def test_prefill_hook_is_noop(self):
+        kv = torch.zeros(4, 2)
+        fb = types.SimpleNamespace()
+        self.assertIsNone(AttentionBackend.capture_swa_windows(None, 0, kv, fb))
+
+    def test_decode_hooks_are_noop(self):
+        fb = types.SimpleNamespace()
+        self.assertIsNone(AttentionBackend.capture_swa_windows_decode(None, fb))
+        self.assertIsNone(
+            AttentionBackend.capture_compress_state_windows_decode(None, fb)
+        )
+
+    def test_a_backend_without_capture_still_answers_the_hooks(self):
+        class Bare(AttentionBackend):
+            pass
+
+        b = Bare()
+        for name in (
+            "capture_swa_windows",
+            "capture_swa_windows_decode",
+            "capture_compress_state_windows_decode",
+        ):
+            self.assertTrue(callable(getattr(b, name)), name)
+
+
+class TestRestoreHookDefault(unittest.TestCase):
+    def test_restore_is_noop(self):
+        reqs = [types.SimpleNamespace(req_pool_idx=0)]
+        idx = torch.zeros(1, dtype=torch.int64)
+        self.assertIsNone(BasePrefixCache.restore_swa_windows(None, reqs, idx))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/mem_cache/test_swa_bitexact_hicache.py
+++ b/test/registered/mem_cache/test_swa_bitexact_hicache.py
@@ -1,0 +1,332 @@
+"""Pure-logic unit tests for the strict bit-exact SWA HiCache feature.
+
+Covers the strict bit-exact SWA HiCache logic:
+  * sizing: hybrid_pool_assembler._swa_host_num_pages and its host-DRAM budget
+  * startup guards: the write-through requirement and the temporary gate that
+    refuses to boot while the capture/restore halves are unwired
+  * offload geometry: DeepSeekV4TokenToKVPool.swa_region_buffers page unit
+
+No GPU / model is required; heavy collaborators are faked so we exercise only
+the new logic.
+"""
+
+import math
+import types
+import unittest
+
+from sglang.srt.mem_cache import unified_radix_cache as R
+from sglang.srt.mem_cache.hybrid_cache import hybrid_pool_assembler as A
+from sglang.srt.mem_cache.unified_cache.components import ComponentType
+from sglang.test.ci.ci_register import register_amd_ci
+
+register_amd_ci(est_time=30, suite="stage-b-test-1-gpu-small-amd")
+
+FULL = R.BASE_COMPONENT_TYPE
+SWA = ComponentType.SWA
+
+
+def _sargs(stride=1):
+    return types.SimpleNamespace(hicache_swa_offload_page_stride=stride)
+
+
+class TestSwaHostSizing(unittest.TestCase):
+    """Stride model: SWA host pool == ceil(full_host_pages / stride)
+    + a device-ring-bounded tail allowance."""
+
+    def _pages(
+        self,
+        *,
+        stride=1,
+        full_host_pages=100_000,
+        device_ring_pages=65,
+        page_bytes=1,
+    ):
+        return A._swa_host_num_pages(
+            server_args=_sargs(stride),
+            full_host_pages=full_host_pages,
+            device_ring_pages=device_ring_pages,
+            page_bytes=page_bytes,
+        )
+
+    def test_stride1_covers_all_pages(self):
+        # stride 1 == per-page: one window per full page + tail allowance.
+        self.assertEqual(self._pages(stride=1), 100_000 + 65)
+
+    def test_larger_stride_shrinks_pool(self):
+        # coarser stride -> fewer windows -> smaller SWA pool.
+        self.assertLess(self._pages(stride=8), self._pages(stride=1))
+        self.assertEqual(self._pages(stride=8), math.ceil(100_000 / 8) + 65)
+
+    def test_tail_allowance_bounded_by_device_ring(self):
+        # a huge stride collapses the strided part to a single window; the pool
+        # is then just that window plus the device-ring tail allowance.
+        self.assertEqual(self._pages(stride=10_000_000, device_ring_pages=65), 1 + 65)
+
+    def test_floor_one_page(self):
+        self.assertEqual(
+            self._pages(stride=10_000_000, device_ring_pages=0, full_host_pages=1),
+            1,
+        )
+
+    def test_no_84gb_regression(self):
+        # A coarse stride keeps the pool a small fraction of the full host pool
+        # -- NOT device_ring * ratio which over-allocated to ~84GB.
+        pages = self._pages(stride=64, full_host_pages=100_000)
+        self.assertLess(pages, 100_000 * 0.02)
+        self.assertEqual(pages, math.ceil(100_000 / 64) + 65)
+
+    def test_warn_above_16gb_but_no_clamp(self):
+        # page_bytes chosen so the result exceeds the 16GB slow-launch threshold.
+        expected = 100_000 + 65  # stride 1
+        page_bytes = int(16e9 / expected) + 1_000_000  # push over 16GB
+        with self.assertLogs(A.logger, level="WARNING") as cm:
+            pages = self._pages(
+                stride=1, full_host_pages=100_000, page_bytes=page_bytes
+            )
+        self.assertEqual(pages, expected)  # warned, not clamped
+        self.assertTrue(any("may slow server launch" in m for m in cm.output))
+
+    def test_no_warn_below_16gb(self):
+        # Small page_bytes -> comfortably under threshold -> no warning emitted.
+        with self.assertRaises(AssertionError):
+            with self.assertLogs(A.logger, level="WARNING"):
+                self._pages(stride=1, full_host_pages=100_000, page_bytes=1)
+
+    def test_hard_ceiling_raises_and_names_the_stride(self):
+        # The DRAM-derived tier owns real OOM rather than slow pinning, so it
+        # fails instead of warning, and the message has to carry both the
+        # cross-rank arithmetic and the one knob that shrinks the pool.
+        with self.assertRaises(ValueError) as ctx:
+            A._check_swa_host_pool_upper_bound(
+                swa_gb=100.0,
+                slow_gb=A._SWA_HICACHE_SLOW_LAUNCH_GB,
+                hard_gb=10.0,
+                full_host_pages=100_000,
+                stride=1,
+                page_bytes=1 << 20,
+                avail_gb=64.0,
+                ranks_per_node=8,
+            )
+        msg = str(ctx.exception)
+        self.assertIn("hard limit", msg)
+        self.assertIn("--hicache-swa-offload-page-stride", msg)
+        self.assertIn("rank(s)/node", msg)
+
+    def test_hard_limit_is_per_rank_on_the_node(self):
+        # Every rank page-locks its own pool, so the ceiling is per rank: tp 8
+        # over 2 nodes puts 4 ranks on one node's DRAM.
+        hard_gb, avail_gb, ranks_per_node = A._swa_host_hard_limit_gb(
+            types.SimpleNamespace(tp_size=8, nnodes=2)
+        )
+        self.assertEqual(ranks_per_node, 4)
+        self.assertAlmostEqual(
+            hard_gb,
+            avail_gb * A._SWA_HICACHE_HARD_LIMIT_DRAM_FRACTION / 4,
+            places=6,
+        )
+
+
+class TestWriteBackGuard(unittest.TestCase):
+    """Strict bit-exact must fail fast at build() entry if write policy is not
+    write_through (write_back can leave the SWA ring un-offloaded -> silent
+    non-bit-exact reuse)."""
+
+    import unittest.mock as _mock
+
+    def _build(self, *, unified, write_policy, flag):
+        strategy = A._DeepSeekV4Strategy()
+        kv = types.SimpleNamespace(_unified_kv=unified)
+        sa = types.SimpleNamespace(hicache_write_policy=write_policy)
+        flag_obj = types.SimpleNamespace(get=lambda: flag)
+        with self._mock.patch.object(
+            A.envs, "SGLANG_UNIFIED_KV_BIT_EXACT_HICACHE", flag_obj
+        ):
+            strategy.build(
+                cache=None,
+                kvcache=kv,
+                params=None,
+                server_args=sa,
+                load_cache_event=None,
+            )
+
+    def test_write_back_trips_guard(self):
+        with self.assertRaises(ValueError) as ctx:
+            self._build(unified=True, write_policy="write_back", flag=True)
+        self.assertIn("write_through", str(ctx.exception))
+
+    def test_write_through_passes_guard(self):
+        # Passes the guard, then fails later on the None collaborators -- we only
+        # assert it is NOT the guard ValueError.
+        with self.assertRaises(Exception) as ctx:
+            self._build(unified=True, write_policy="write_through", flag=True)
+        self.assertNotIn("requires --hicache-write-policy", str(ctx.exception))
+
+    def test_flag_off_no_guard(self):
+        with self.assertRaises(Exception) as ctx:
+            self._build(unified=True, write_policy="write_back", flag=False)
+        self.assertNotIn("requires --hicache-write-policy", str(ctx.exception))
+
+    def test_non_unified_no_guard(self):
+        with self.assertRaises(Exception) as ctx:
+            self._build(unified=False, write_policy="write_back", flag=True)
+        self.assertNotIn("requires --hicache-write-policy", str(ctx.exception))
+
+    def test_flag_on_refuses_to_start_while_unwired(self):
+        # Past the write-policy guard nothing else stands between the flag and a
+        # half-wired reuse path, so enabling it must refuse to boot until the
+        # capture and restore halves are in.
+        with self.assertRaises(ValueError) as ctx:
+            self._build(unified=True, write_policy="write_through", flag=True)
+        self.assertIn("not usable yet", str(ctx.exception))
+
+
+class TestSwaRegionBuffers(unittest.TestCase):
+    """The SWA-ring host pool must be page-granular with the sliding window as
+    the page unit, so each indexed device row is exactly one host item_bytes.
+    Row-granular device buffers (head_dim rows) declared with a page-granular
+    item_bytes mismatch in transfer_kv_direct and crash."""
+
+    def _fake_pool(self, *, num_slots, ring_size, head_dim, compress_rows, layers):
+        import torch
+
+        swa_pages = num_slots * ring_size
+        rows = swa_pages + compress_rows
+        kv_buffer = [
+            torch.arange(rows * head_dim, dtype=torch.bfloat16).reshape(rows, head_dim)
+            for _ in range(layers)
+        ]
+        unified_kv_pool = types.SimpleNamespace(
+            swa_pages=swa_pages, head_dim=head_dim, kv_buffer=kv_buffer
+        )
+        return types.SimpleNamespace(
+            _unified_kv=True,
+            unified_swa_ring_size=ring_size,
+            unified_kv_pool=unified_kv_pool,
+        )
+
+    def test_page_granular_geometry(self):
+        import torch
+
+        from sglang.srt.mem_cache.deepseek_v4_memory_pool import (
+            DeepSeekV4TokenToKVPool as P,
+        )
+
+        ring_size, head_dim, num_slots, layers = 2, 4, 3, 2
+        pool = self._fake_pool(
+            num_slots=num_slots,
+            ring_size=ring_size,
+            head_dim=head_dim,
+            compress_rows=8,
+            layers=layers,
+        )
+        views, item_bytes = P.swa_region_buffers(pool)
+        # one page == one sliding window == ring_size rows (bf16 = 2 bytes).
+        self.assertEqual(item_bytes, ring_size * head_dim * 2)
+        self.assertEqual(len(views), layers)
+        for v in views:
+            self.assertEqual(v.dtype, torch.uint8)
+            # num_pages == swa_pages // ring_size == num_slots; row width == item_bytes.
+            self.assertEqual(v.shape, (num_slots, item_bytes))
+            self.assertEqual(v[0].nbytes, item_bytes)
+
+    def test_view_preserves_ring_data(self):
+        import torch
+
+        from sglang.srt.mem_cache.deepseek_v4_memory_pool import (
+            DeepSeekV4TokenToKVPool as P,
+        )
+
+        ring_size, head_dim = 2, 4
+        pool = self._fake_pool(
+            num_slots=3,
+            ring_size=ring_size,
+            head_dim=head_dim,
+            compress_rows=8,
+            layers=1,
+        )
+        views, _ = P.swa_region_buffers(pool)
+        buf = pool.unified_kv_pool.kv_buffer[0]
+        # host page 1 must be ring rows [ring_size, 2*ring_size) byte-identical.
+        expected = buf.narrow(0, ring_size, ring_size).reshape(-1).view(torch.uint8)
+        self.assertTrue(torch.equal(views[0][1], expected))
+
+    def test_rejects_non_unified(self):
+        from sglang.srt.mem_cache.deepseek_v4_memory_pool import (
+            DeepSeekV4TokenToKVPool as P,
+        )
+
+        pool = types.SimpleNamespace(_unified_kv=False)
+        with self.assertRaises(AssertionError):
+            P.swa_region_buffers(pool)
+
+    def test_rejects_non_divisible_ring(self):
+        from sglang.srt.mem_cache.deepseek_v4_memory_pool import (
+            DeepSeekV4TokenToKVPool as P,
+        )
+
+        # swa_pages must be a whole number of windows; a corrupt pool trips the guard.
+        pool = self._fake_pool(
+            num_slots=3, ring_size=2, head_dim=4, compress_rows=8, layers=1
+        )
+        pool.unified_kv_pool.swa_pages += 1  # 7, not a multiple of ring_size=2
+        with self.assertRaises(AssertionError):
+            P.swa_region_buffers(pool)
+
+    def test_all_pages_map_to_their_window(self):
+        import torch
+
+        from sglang.srt.mem_cache.deepseek_v4_memory_pool import (
+            DeepSeekV4TokenToKVPool as P,
+        )
+
+        ring_size, head_dim, num_slots = 2, 4, 5
+        pool = self._fake_pool(
+            num_slots=num_slots,
+            ring_size=ring_size,
+            head_dim=head_dim,
+            compress_rows=6,
+            layers=2,
+        )
+        views, _ = P.swa_region_buffers(pool)
+        for layer, view in enumerate(views):
+            buf = pool.unified_kv_pool.kv_buffer[layer]
+            self.assertEqual(view.shape[0], num_slots)  # one page per window
+            for page in range(num_slots):
+                # page p must be exactly ring rows [p*ring, (p+1)*ring), byte-identical.
+                expected = (
+                    buf.narrow(0, page * ring_size, ring_size)
+                    .reshape(-1)
+                    .view(torch.uint8)
+                )
+                self.assertTrue(torch.equal(view[page], expected))
+
+
+class TestSwaRingRegionDelegation(unittest.TestCase):
+    """The assembler seam must delegate SWA-ring buffer resolution to the pool
+    (which owns the unified_kv layout) and never re-derive geometry itself."""
+
+    def test_delegates_to_pool(self):
+        sentinel = (["buf0", "buf1"], 131072)
+        kvcache = types.SimpleNamespace(
+            _unified_kv=True, swa_region_buffers=lambda: sentinel
+        )
+        self.assertIs(A._dsv4_swa_ring_region_buffers(kvcache), sentinel)
+
+    def test_rejects_non_unified(self):
+        kvcache = types.SimpleNamespace(_unified_kv=False)
+        with self.assertRaises(AssertionError):
+            A._dsv4_swa_ring_region_buffers(kvcache)
+
+
+# ---------------------------------------------------------------------------
+# Commit-time c4/indexer STATE coupling guard, merged from
+# test_swa_commit_coupling_guard.py. Defense-in-depth for non-file backends /
+# partial per-pool get: the sidecar state pools ride the SWA window key family,
+# so a loaded SWA window has one coupled state page per state pool. If a
+# registered state pool loaded fewer pages than SWA, attaching would restore a
+# desynced (dirty) state, so the whole window must be dropped (recompute).
+# ---------------------------------------------------------------------------
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Part **2/5** of the strict bit-exact SWA prefix reuse for DeepSeek-V4 on the `unified_kv` attention backend with prefix cache enabled, described in [RFC #34562](https://github.com/sgl-project/sglang/issues/34562) and split out of [#32214](https://github.com/sgl-project/sglang/pull/32214). Builds on [1/5](https://github.com/sgl-project/sglang/pull/35303).

This part builds the storage substrate the later parts write into: a host pool that can hold SWA pages, a state pool for the coupled c4 / c4-indexer overlap state, an L3 key namespace that isolates the new blob layout, and the startup guards that keep an unusable configuration from booting.

**This part still cannot serve a reuse hit, and refuses to pretend otherwise.** Nothing captures or restores yet, so rather than leave a flag that quietly allocates host memory and returns nothing, `SGLANG_UNIFIED_KV_BIT_EXACT_HICACHE=1` makes the server **refuse to start** ("the SWA capture/restore path is not fully wired"). That temporary guard is removed in 5/5, when the last half lands. With the flag off — the default — no behavior changes.

## Modifications

<!-- Detail the changes made in this pull request. -->
- `memory_pool_host.py`: SWA host-pool support. Per-page capture-completion events (`record_capture_done` / `wait_capture_done` / `sync_capture_done`) so that cross-stream consumers of a captured page — the restore H2D, the L3 write-through, the device-landing check — are ordered against the capture that produced it; `promote_captured_page` and `load_to_device_all_layer` for the transfer paths.
- `hybrid_pool_assembler.py`: the feature gate, the pool sizing, and the startup guards. Also registers the coupled state pool.
  - **sizing.** One SWA window every `--hicache-swa-offload-page-stride` full host pages, plus one tail window per in-flight request (bounded by the device ring), floored at the device ring. The default stride of 1 is therefore the largest this pool ever gets, and raising the stride is the one knob that shrinks it — roughly linearly.
  - **DRAM budget.** The pool is pinned host memory, so it is checked at startup and never clamped: above 16 GB/rank it warns, because page-locking that much is slow enough to be mistaken for a hung launch; above 90% of available DRAM per rank (real available DRAM / ranks-per-node) it fails with the breakdown and the stride hint, since that pool summed across the node's ranks would exhaust host DRAM outright rather than merely delay the boot.
  - **write-through is required.** `write_back` cannot guarantee the SWA ring is offloaded before its slot is recycled, so the window a later request would reuse may never have reached the host. Fail at startup rather than serve a silently non-exact hit.
  - **the temporary "not usable yet" guard** described above, removed in 5/5.
- `deepseek_v4_memory_pool.py`: `swa_region_buffers()` and `get_swa_state_coupling_infos()` expose the ring regions and which state rides with which window, so the capture side in 3/5 does not need to know the pool's internals.
- `hicache_storage.py`, `storage/nixl/hicache_nixl.py`: L3 key namespace version (`_swaind1`). The strict path persists the window and its state as independent pools coupled by key, with no A-gather tail packing, so its byte layout differs from the older packed `_swapk1` blobs. Namespacing by layout version makes it impossible to read a stale packed blob under the new layout, in either direction.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
Not reachable in this part. With the flag off nothing in the changed paths executes differently; with the flag on the server refuses to start. Accuracy for the completed feature is reported in #32214 and the RFC.

`test/registered/mem_cache/test_swa_bitexact_hicache.py` adds 21 unit tests: the sizing arithmetic across strides and page counts (including that a coarse stride shrinks the pool and that the tail allowance stays bounded by the device ring), both DRAM tiers — the warning that does not clamp and the ceiling that fails with the stride hint — plus its per-rank derivation, both startup guards, and the ring-region geometry and its delegation.

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
No runtime path changes while the flag is off. The host memory this reserves once enabled is the sizing above; at the default stride of 1 that is one host page per full-KV host page plus the device-ring tail, which is why the stride knob exists.

## Stack

| part | contents |
|---|---|
| [1/5](https://github.com/sgl-project/sglang/pull/35303) | extension points, flag, server arg |
| **2/5 (this PR)** | HiCache substrate: SWA host pool, L3 key namespace, startup guards |
| 3/5 | capture of SWA windows and c4/indexer overlap state |
| 4/5 | window riding on radix nodes and the strict reuse gate |
| 5/5 | c4/indexer state riding; completes the feature |

[#32214](https://github.com/sgl-project/sglang/pull/32214) stays open as the
full-context reference until the stack is in.

A fork PR can only target `main`, so this PR's "Files changed" also contains [1/5](https://github.com/sgl-project/sglang/pull/35303) (15 files) until that lands. Reviewing the last commit gives just this part's change (6 files).

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32969107295](https://github.com/sgl-project/sglang/actions/runs/32969107295)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32969107064](https://github.com/sgl-project/sglang/actions/runs/32969107064)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32969107292](https://github.com/sgl-project/sglang/actions/runs/32969107292)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->