### PR TITLE
[Feat][GLM-5.2] Shared KV Cache for Prefill and Decode

### DIFF
--- a/python/sglang/kernels/aot/cmake/flashmla.cmake
+++ b/python/sglang/kernels/aot/cmake/flashmla.cmake
@@ -7,6 +7,44 @@ FetchContent_Declare(
 )
 FetchContent_Populate(repo-flashmla)
 
+# Keep the Shared-KV specialization as a patch over the exact pinned FlashMLA
+# source. It is exposed through a separate operator; the normal operator keeps
+# the original argument list and selects the compile-time disabled hooks.
+find_package(Git REQUIRED)
+set(SGLANG_FLASHMLA_SHARED_PATCH
+    "${CMAKE_CURRENT_LIST_DIR}/flashmla_shared_demand_cache.patch")
+execute_process(
+    COMMAND "${GIT_EXECUTABLE}" apply --unidiff-zero --check
+            "${SGLANG_FLASHMLA_SHARED_PATCH}"
+    WORKING_DIRECTORY "${repo-flashmla_SOURCE_DIR}"
+    RESULT_VARIABLE SGLANG_FLASHMLA_SHARED_PATCH_CHECK_RESULT
+    OUTPUT_QUIET
+    ERROR_QUIET
+)
+if(SGLANG_FLASHMLA_SHARED_PATCH_CHECK_RESULT EQUAL 0)
+    execute_process(
+        COMMAND "${GIT_EXECUTABLE}" apply --unidiff-zero
+                "${SGLANG_FLASHMLA_SHARED_PATCH}"
+        WORKING_DIRECTORY "${repo-flashmla_SOURCE_DIR}"
+        RESULT_VARIABLE SGLANG_FLASHMLA_SHARED_PATCH_RESULT
+    )
+    if(NOT SGLANG_FLASHMLA_SHARED_PATCH_RESULT EQUAL 0)
+        message(FATAL_ERROR "Failed to apply Shared-KV FlashMLA demand-cache patch")
+    endif()
+else()
+    execute_process(
+        COMMAND "${GIT_EXECUTABLE}" apply --unidiff-zero --reverse --check
+                "${SGLANG_FLASHMLA_SHARED_PATCH}"
+        WORKING_DIRECTORY "${repo-flashmla_SOURCE_DIR}"
+        RESULT_VARIABLE SGLANG_FLASHMLA_SHARED_PATCH_REVERSE_RESULT
+        OUTPUT_QUIET
+        ERROR_QUIET
+    )
+    if(NOT SGLANG_FLASHMLA_SHARED_PATCH_REVERSE_RESULT EQUAL 0)
+        message(FATAL_ERROR "Failed to apply Shared-KV FlashMLA demand-cache patch")
+    endif()
+endif()
+
 # flashmla submodule pin: NVIDIA/cutlass @ 147f5673d0c1c3dcf66f78d677fd647e4a020219
 FetchContent_Declare(
     repo-flashmla-cutlass

--- a/python/sglang/kernels/aot/cmake/flashmla_shared_demand_cache.patch
+++ b/python/sglang/kernels/aot/cmake/flashmla_shared_demand_cache.patch
@@ -1,0 +1,645 @@
+diff -ruN -U0 a/csrc/api/sparse_decode.h b/csrc/api/sparse_decode.h
+--- a/csrc/api/sparse_decode.h	2026-06-24 14:52:45
++++ b/csrc/api/sparse_decode.h	2026-08-13 19:50:27
+@@ -2,0 +3,2 @@
++#include <bit>
++
+@@ -72 +74,13 @@
+-                sm90::decode::sparse_fp8::run_flash_splitkv_mla_fp8_sparse_kernel<MODEL_TYPE, NUM_HEADS>(params);
++                if constexpr (MODEL_TYPE == ModelType::V32) {
++                    if (params.shared_kv_row_cache != nullptr) {
++                        if (params.shared_kv_current_rows != nullptr) {
++                            sm90::decode::sparse_fp8::run_flash_splitkv_mla_fp8_sparse_kernel<MODEL_TYPE, NUM_HEADS, true, true>(params);
++                        } else {
++                            sm90::decode::sparse_fp8::run_flash_splitkv_mla_fp8_sparse_kernel<MODEL_TYPE, NUM_HEADS, true, false>(params);
++                        }
++                    } else {
++                        sm90::decode::sparse_fp8::run_flash_splitkv_mla_fp8_sparse_kernel<MODEL_TYPE, NUM_HEADS, false, false>(params);
++                    }
++                } else {
++                    sm90::decode::sparse_fp8::run_flash_splitkv_mla_fp8_sparse_kernel<MODEL_TYPE, NUM_HEADS, false, false>(params);
++                }
+@@ -196 +210,13 @@
+-    float sm_scale
++    float sm_scale,
++    const std::optional<at::Tensor> &shared_kv_row_cache = std::nullopt,
++    const std::optional<at::Tensor> &shared_kv_cache_tags = std::nullopt,
++    const std::optional<at::Tensor> &shared_kv_request_slots = std::nullopt,
++    int64_t shared_kv_cache_rows_per_request = 0,
++    int64_t shared_kv_num_request_slots = 0,
++    int64_t shared_kv_cache_epoch = 0,
++    const std::optional<at::Tensor> &shared_kv_cache_generation_tensor = std::nullopt,
++    int64_t shared_kv_local_row_begin = 0,
++    int64_t shared_kv_local_row_end = 0,
++    const std::optional<at::Tensor> &shared_kv_current_rows = std::nullopt,
++    const std::optional<at::Tensor> &shared_kv_current_row_ids = std::nullopt,
++    const std::optional<at::Tensor> &shared_kv_current_row_counts = std::nullopt
+@@ -219,0 +246,12 @@
++    bool have_shared_kv_cache = shared_kv_row_cache.has_value();
++    TORCH_CHECK(
++        have_shared_kv_cache == shared_kv_cache_tags.has_value(),
++        "shared_kv_row_cache and shared_kv_cache_tags must be provided together");
++    bool have_shared_kv_current_rows = shared_kv_current_rows.has_value();
++    TORCH_CHECK(
++        have_shared_kv_current_rows == shared_kv_current_row_ids.has_value() &&
++            have_shared_kv_current_rows == shared_kv_current_row_counts.has_value(),
++        "Shared-KV current rows, row IDs, and row counts must be provided together");
++    TORCH_CHECK(
++        !have_shared_kv_current_rows || have_shared_kv_cache,
++        "Shared-KV current rows require the Shared FlashMLA path");
+@@ -256,0 +295,7 @@
++    KU_CHECK_DEVICE(shared_kv_row_cache);
++    KU_CHECK_DEVICE(shared_kv_cache_tags);
++    KU_CHECK_DEVICE(shared_kv_request_slots);
++    KU_CHECK_DEVICE(shared_kv_cache_generation_tensor);
++    KU_CHECK_DEVICE(shared_kv_current_rows);
++    KU_CHECK_DEVICE(shared_kv_current_row_ids);
++    KU_CHECK_DEVICE(shared_kv_current_row_counts);
+@@ -270,0 +316,7 @@
++    KU_CHECK_DTYPE(shared_kv_row_cache, torch::kUInt8);
++    KU_CHECK_DTYPE(shared_kv_cache_tags, torch::kInt64);
++    KU_CHECK_DTYPE(shared_kv_request_slots, torch::kInt64);
++    KU_CHECK_DTYPE(shared_kv_cache_generation_tensor, torch::kInt32);
++    KU_CHECK_DTYPE(shared_kv_current_rows, torch::kUInt8);
++    KU_CHECK_DTYPE(shared_kv_current_row_ids, torch::kInt32);
++    KU_CHECK_DTYPE(shared_kv_current_row_counts, torch::kInt32);
+@@ -284,0 +337,7 @@
++    KU_CHECK_CONTIGUOUS(shared_kv_row_cache);
++    KU_CHECK_CONTIGUOUS(shared_kv_cache_tags);
++    KU_CHECK_CONTIGUOUS(shared_kv_request_slots);
++    KU_CHECK_CONTIGUOUS(shared_kv_cache_generation_tensor);
++    KU_CHECK_CONTIGUOUS(shared_kv_current_rows);
++    KU_CHECK_CONTIGUOUS(shared_kv_current_row_ids);
++    KU_CHECK_CONTIGUOUS(shared_kv_current_row_counts);
+@@ -311,0 +371,53 @@
++    if (have_shared_kv_cache) {
++        TORCH_CHECK(arch.is_sm90a(), "Shared-KV demand cache is SM90-only");
++        TORCH_CHECK(d_qk == 576, "Shared-KV demand cache only supports V3.2 KV rows");
++        TORCH_CHECK(!have_extra_kcache, "Shared-KV demand cache does not support extra KV");
++        TORCH_CHECK(shared_kv_row_cache->dim() == 2);
++        TORCH_CHECK(shared_kv_row_cache->size(1) == 656);
++        TORCH_CHECK(shared_kv_cache_tags->dim() == 2);
++        TORCH_CHECK(shared_kv_cache_rows_per_request > 0);
++        TORCH_CHECK(std::has_single_bit(static_cast<uint64_t>(shared_kv_cache_rows_per_request)));
++        TORCH_CHECK(shared_kv_num_request_slots > 0);
++        TORCH_CHECK(shared_kv_cache_tags->size(0) == shared_kv_num_request_slots);
++        TORCH_CHECK(shared_kv_cache_tags->size(1) == shared_kv_cache_rows_per_request);
++        TORCH_CHECK(
++            shared_kv_row_cache->size(0) ==
++            shared_kv_num_request_slots * shared_kv_cache_rows_per_request);
++        if (shared_kv_num_request_slots > 1) {
++            TORCH_CHECK(
++                shared_kv_request_slots.has_value(),
++                "request slots are required for a multislice Shared-KV cache");
++        }
++        if (shared_kv_request_slots.has_value()) {
++            TORCH_CHECK(shared_kv_request_slots->dim() == 1);
++            TORCH_CHECK(shared_kv_request_slots->size(0) == b);
++        }
++        if (shared_kv_cache_generation_tensor.has_value()) {
++            TORCH_CHECK(shared_kv_cache_generation_tensor->numel() == 1);
++        }
++        if (have_shared_kv_current_rows) {
++            TORCH_CHECK(
++                shared_kv_current_rows->dim() == 3 &&
++                    shared_kv_current_rows->size(0) == b * s_q &&
++                    shared_kv_current_rows->size(1) >= 1 &&
++                    shared_kv_current_rows->size(1) <= 4 &&
++                    shared_kv_current_rows->size(2) == 656,
++                "Shared-KV current rows must have shape [b * s_q, width, 656] with 1 <= width <= 4");
++            TORCH_CHECK(
++                shared_kv_current_row_ids->dim() == 2 &&
++                    shared_kv_current_row_ids->size(0) == b * s_q &&
++                    shared_kv_current_row_ids->size(1) == shared_kv_current_rows->size(1),
++                "Shared-KV current row IDs must match the current-row width");
++            TORCH_CHECK(
++                shared_kv_current_row_counts->dim() == 1 &&
++                    shared_kv_current_row_counts->size(0) == b * s_q,
++                "Shared-KV current row counts must have shape [b * s_q]");
++        }
++        TORCH_CHECK(shared_kv_cache_epoch > 0 && shared_kv_cache_epoch < (1ll << 31));
++        const int64_t total_rows = static_cast<int64_t>(num_blocks) * page_block_size;
++        TORCH_CHECK(
++            shared_kv_local_row_begin >= 0 &&
++            shared_kv_local_row_begin < shared_kv_local_row_end &&
++            shared_kv_local_row_end <= total_rows);
++    }
++
+@@ -413,0 +526,15 @@
++
++        have_shared_kv_cache ? shared_kv_row_cache->data_ptr<uint8_t>() : nullptr,
++        have_shared_kv_cache ? reinterpret_cast<uint64_t*>(shared_kv_cache_tags->data_ptr<int64_t>()) : nullptr,
++        shared_kv_request_slots.has_value() ? shared_kv_request_slots->data_ptr<int64_t>() : nullptr,
++        static_cast<uint32_t>(shared_kv_cache_epoch),
++        shared_kv_cache_generation_tensor.has_value()
++            ? shared_kv_cache_generation_tensor->data_ptr<int32_t>()
++            : nullptr,
++        static_cast<int>(shared_kv_cache_rows_per_request),
++        static_cast<int>(shared_kv_num_request_slots),
++        static_cast<int>(shared_kv_local_row_begin),
++        static_cast<int>(shared_kv_local_row_end),
++        have_shared_kv_current_rows ? shared_kv_current_rows->data_ptr<uint8_t>() : nullptr,
++        have_shared_kv_current_rows ? int64_stride_to_int(shared_kv_current_rows->stride(0)) : 0,
++        have_shared_kv_current_rows ? int64_stride_to_int(shared_kv_current_rows->stride(1)) : 0,
+diff -ruN -U0 a/csrc/params.h b/csrc/params.h
+--- a/csrc/params.h	2026-06-24 14:52:45
++++ b/csrc/params.h	2026-08-13 19:50:27
+@@ -2,0 +3,2 @@
++#include <cstdint>
++
+@@ -91,0 +94,12 @@
++
++    // SM90 Shared-KV demand-row cache. Null disables the path.
++    uint8_t* __restrict__ shared_kv_row_cache;  // [request_slots * rows_per_request, 656]
++    uint64_t* __restrict__ shared_kv_cache_tags;  // [request_slots, rows_per_request]
++    const int64_t* __restrict__ shared_kv_request_slots;  // Optional [b]
++    uint32_t shared_kv_cache_epoch;
++    const int32_t* __restrict__ shared_kv_cache_generation;  // Optional scalar
++    int shared_kv_cache_rows_per_request;
++    int shared_kv_num_request_slots;
++    int shared_kv_local_row_begin, shared_kv_local_row_end;
++    uint8_t* __restrict__ shared_kv_current_rows;  // [b * s_q, width <= 4, 656]
++    int shared_kv_current_rows_stride_q, shared_kv_current_rows_stride_slot;
+diff -ruN -U0 a/csrc/sm90/decode/sparse_fp8/components/shared_demand_cache.h b/csrc/sm90/decode/sparse_fp8/components/shared_demand_cache.h
+--- a/csrc/sm90/decode/sparse_fp8/components/shared_demand_cache.h	1970-01-01 08:00:00
++++ b/csrc/sm90/decode/sparse_fp8/components/shared_demand_cache.h	2026-08-13 19:49:46
+@@ -0,0 +1,139 @@
++#pragma once
++
++#include <cstdint>
++
++namespace sm90::decode::sparse_fp8::shared_demand_cache {
++
++static constexpr int ROW_BYTES = 656;
++static constexpr uint64_t READY_BIT = 1ull << 63;
++
++enum class Access : int {
++    DIRECT = 0,
++    HIT = 1,
++    FILL = 2,
++    FILLING_FALLBACK = 3,
++    COLLISION_FALLBACK = 4,
++};
++
++struct ProbeResult {
++    int slot;
++    Access access;
++};
++
++static __forceinline__ __device__ uint64_t load_acquire(
++    const uint64_t* ptr
++) {
++    uint64_t value;
++    asm volatile(
++        "ld.global.acquire.gpu.u64 %0, [%1];"
++        : "=l"(value)
++        : "l"(ptr)
++        : "memory"
++    );
++    return value;
++}
++
++static __forceinline__ __device__ uint64_t compare_exchange_acq_rel(
++    uint64_t* ptr,
++    uint64_t expected,
++    uint64_t desired
++) {
++    uint64_t old;
++    asm volatile(
++        "atom.global.acq_rel.gpu.cas.b64 %0, [%1], %2, %3;"
++        : "=l"(old)
++        : "l"(ptr), "l"(expected), "l"(desired)
++        : "memory"
++    );
++    return old;
++}
++
++static __forceinline__ __device__ void store_release(
++    uint64_t* ptr,
++    uint64_t value
++) {
++    asm volatile(
++        "st.global.release.gpu.u64 [%0], %1;"
++        :
++        : "l"(ptr), "l"(value)
++        : "memory"
++    );
++}
++
++static __forceinline__ __device__ uint64_t filling_tag(
++    uint32_t epoch,
++    uint32_t physical_row
++) {
++    return (static_cast<uint64_t>(epoch) << 32) |
++           (static_cast<uint64_t>(physical_row) + 1);
++}
++
++static __forceinline__ __device__ uint32_t slot_for_row(
++    uint32_t physical_row,
++    int cache_rows
++) {
++    return ((physical_row ^ (physical_row >> 13)) * 2654435761u) &
++           static_cast<uint32_t>(cache_rows - 1);
++}
++
++static __forceinline__ __device__ ProbeResult probe(
++    uint64_t* tags,
++    int rows_per_request,
++    uint32_t epoch,
++    uint32_t physical_row,
++    bool allow_stale_ready_hit
++) {
++    const uint64_t filling = filling_tag(epoch, physical_row);
++    const uint64_t ready = filling | READY_BIT;
++    const uint32_t slot = slot_for_row(physical_row, rows_per_request);
++    uint64_t* tag_ptr = tags + slot;
++    for (int attempt = 0; attempt < 3; ++attempt) {
++        const uint64_t observed = load_acquire(tag_ptr);
++        if (observed == ready) {
++            return {static_cast<int>(slot), Access::HIT};
++        }
++        const uint32_t observed_epoch = static_cast<uint32_t>(
++            (observed & ~READY_BIT) >> 32
++        );
++        const bool same_row =
++            static_cast<uint32_t>(observed) == physical_row + 1;
++        if (observed_epoch == epoch) {
++            return {
++                -1,
++                same_row
++                    ? Access::FILLING_FALLBACK
++                    : Access::COLLISION_FALLBACK
++            };
++        }
++        if (
++            allow_stale_ready_hit && same_row &&
++            (observed & READY_BIT) != 0
++        ) {
++            const uint64_t old = compare_exchange_acq_rel(
++                tag_ptr, observed, ready
++            );
++            if (old == observed) {
++                return {static_cast<int>(slot), Access::HIT};
++            }
++            continue;
++        }
++        const uint64_t old = compare_exchange_acq_rel(
++            tag_ptr, observed, filling
++        );
++        if (old == observed) {
++            return {static_cast<int>(slot), Access::FILL};
++        }
++    }
++    return {-1, Access::COLLISION_FALLBACK};
++}
++
++static __forceinline__ __device__ void publish_ready(
++    uint64_t* tags,
++    int slot,
++    uint32_t epoch,
++    uint32_t physical_row
++) {
++    store_release(tags + slot, filling_tag(epoch, physical_row) | READY_BIT);
++}
++
++}  // namespace sm90::decode::sparse_fp8::shared_demand_cache
+diff -ruN -U0 a/csrc/sm90/decode/sparse_fp8/components/shared_kv_adapter.h b/csrc/sm90/decode/sparse_fp8/components/shared_kv_adapter.h
+--- a/csrc/sm90/decode/sparse_fp8/components/shared_kv_adapter.h	1970-01-01 08:00:00
++++ b/csrc/sm90/decode/sparse_fp8/components/shared_kv_adapter.h	2026-08-13 19:50:27
+@@ -0,0 +1,173 @@
++#pragma once
++
++#include <cstdint>
++
++#include "shared_demand_cache.h"
++
++namespace sm90::decode::sparse_fp8::shared_kv_adapter {
++
++using Access = shared_demand_cache::Access;
++
++struct ResolvedRow {
++    fp8* source;
++    uint8_t* cache_row;
++    uint64_t* cache_tags;
++    int cache_slot;
++    Access access;
++    uint32_t epoch;
++    uint32_t physical_row;
++    unsigned row_group_mask;
++    bool publisher;
++
++    template <bool ENABLED, typename Fragment>
++    __forceinline__ __device__ void store_fragment(
++        int byte_offset,
++        const Fragment& fragment
++    ) const {
++        if constexpr (ENABLED) {
++            if (access == Access::FILL) {
++                *reinterpret_cast<Fragment*>(cache_row + byte_offset) = fragment;
++            }
++        }
++    }
++
++    template <bool ENABLED>
++    __forceinline__ __device__ void publish() const {
++        if constexpr (ENABLED) {
++            if (access == Access::FILL) {
++                __syncwarp(row_group_mask);
++                if (publisher) {
++                    shared_demand_cache::publish_ready(
++                        cache_tags,
++                        cache_slot,
++                        epoch,
++                        physical_row
++                    );
++                }
++            }
++        }
++    }
++};
++
++static __forceinline__ __device__ ResolvedRow direct(fp8* authoritative) {
++    return {
++        authoritative,
++        nullptr,
++        nullptr,
++        -1,
++        Access::DIRECT,
++        0,
++        0,
++        0,
++        false,
++    };
++}
++
++template <bool ENABLED>
++static __forceinline__ __device__ uint32_t epoch(
++    const SparseAttnDecodeParams& params
++) {
++    if constexpr (!ENABLED) {
++        return 0;
++    }
++    return params.shared_kv_cache_generation != nullptr
++        ? static_cast<uint32_t>(*params.shared_kv_cache_generation)
++        : params.shared_kv_cache_epoch;
++}
++
++template <bool USE_CURRENT_ROWS>
++static __forceinline__ __device__ int current_row_match(int token_index) {
++    if constexpr (USE_CURRENT_ROWS) {
++        if (token_index <= -2 && token_index >= -5) {
++            return -token_index - 2;
++        }
++    }
++    return -1;
++}
++
++template <bool ENABLED, bool USE_CURRENT_ROWS>
++static __forceinline__ __device__ ResolvedRow resolve(
++    const SparseAttnDecodeParams& params,
++    fp8* authoritative,
++    int token_index,
++    int current_match,
++    int batch_idx,
++    int s_q_idx,
++    int lane_idx,
++    uint32_t cache_epoch
++) {
++    if constexpr (!ENABLED) {
++        return direct(authoritative);
++    }
++
++    if constexpr (USE_CURRENT_ROWS) {
++        if (current_match >= 0) {
++            const int query_row = batch_idx * params.s_q + s_q_idx;
++            return direct(reinterpret_cast<fp8*>(
++                params.shared_kv_current_rows +
++                query_row * params.shared_kv_current_rows_stride_q +
++                current_match * params.shared_kv_current_rows_stride_slot
++            ));
++        }
++    }
++
++    int64_t request_slot = 1;
++    if (params.shared_kv_request_slots != nullptr) {
++        request_slot = params.shared_kv_request_slots[batch_idx];
++    }
++    const bool valid_request_slot =
++        request_slot > 0 && request_slot <= params.shared_kv_num_request_slots;
++    const bool remote_row =
++        token_index >= 0 &&
++        (token_index < params.shared_kv_local_row_begin ||
++         token_index >= params.shared_kv_local_row_end);
++    if (!valid_request_slot || !remote_row) {
++        return direct(authoritative);
++    }
++
++    int64_t request_base =
++        (request_slot - 1) * params.shared_kv_cache_rows_per_request;
++    const int probe_rows = params.shared_kv_cache_rows_per_request;
++
++    const int source_lane = lane_idx % 8;
++    const unsigned row_group_mask = 0x01010101u << source_lane;
++    uint64_t* request_tags = params.shared_kv_cache_tags + request_base;
++    int probe_slot = -1;
++    int probe_access = static_cast<int>(Access::DIRECT);
++    if (lane_idx < 8) {
++        const auto result = shared_demand_cache::probe(
++            request_tags,
++            probe_rows,
++            cache_epoch,
++            static_cast<uint32_t>(token_index),
++            params.shared_kv_cache_generation != nullptr
++        );
++        probe_slot = result.slot;
++        probe_access = static_cast<int>(result.access);
++    }
++    probe_slot = __shfl_sync(row_group_mask, probe_slot, source_lane);
++    probe_access = __shfl_sync(row_group_mask, probe_access, source_lane);
++
++    const auto access = static_cast<Access>(probe_access);
++    uint8_t* cache_row = nullptr;
++    if (probe_slot >= 0) {
++        cache_row = params.shared_kv_row_cache +
++            (request_base + probe_slot) * shared_demand_cache::ROW_BYTES;
++    }
++    fp8* source = access == Access::HIT
++        ? reinterpret_cast<fp8*>(cache_row)
++        : authoritative;
++    return {
++        source,
++        cache_row,
++        request_tags,
++        probe_slot,
++        access,
++        cache_epoch,
++        static_cast<uint32_t>(token_index),
++        row_group_mask,
++        lane_idx < 8,
++    };
++}
++
++}  // namespace sm90::decode::sparse_fp8::shared_kv_adapter
+diff -ruN -U0 a/csrc/sm90/decode/sparse_fp8/config.h b/csrc/sm90/decode/sparse_fp8/config.h
+--- a/csrc/sm90/decode/sparse_fp8/config.h	2026-06-24 14:52:45
++++ b/csrc/sm90/decode/sparse_fp8/config.h	2026-08-13 19:49:46
+@@ -15 +15,6 @@
+-template<ModelType MODEL_TYPE, int NUM_HEADS>
++template<
++    ModelType MODEL_TYPE,
++    int NUM_HEADS,
++    bool USE_SHARED_CACHE,
++    bool USE_CURRENT_ROWS
++>
+diff -ruN -U0 a/csrc/sm90/decode/sparse_fp8/instantiations/model1_persistent_h128.cu b/csrc/sm90/decode/sparse_fp8/instantiations/model1_persistent_h128.cu
+--- a/csrc/sm90/decode/sparse_fp8/instantiations/model1_persistent_h128.cu	2026-06-24 14:52:45
++++ b/csrc/sm90/decode/sparse_fp8/instantiations/model1_persistent_h128.cu	2026-08-13 19:49:46
+@@ -5 +5 @@
+-template void run_flash_splitkv_mla_fp8_sparse_kernel<ModelType::MODEL1, 128>(const SparseAttnDecodeParams &params);
++template void run_flash_splitkv_mla_fp8_sparse_kernel<ModelType::MODEL1, 128, false, false>(const SparseAttnDecodeParams &params);
+diff -ruN -U0 a/csrc/sm90/decode/sparse_fp8/instantiations/model1_persistent_h64.cu b/csrc/sm90/decode/sparse_fp8/instantiations/model1_persistent_h64.cu
+--- a/csrc/sm90/decode/sparse_fp8/instantiations/model1_persistent_h64.cu	2026-06-24 14:52:45
++++ b/csrc/sm90/decode/sparse_fp8/instantiations/model1_persistent_h64.cu	2026-08-13 19:49:46
+@@ -5 +5 @@
+-template void run_flash_splitkv_mla_fp8_sparse_kernel<ModelType::MODEL1, 64>(const SparseAttnDecodeParams &params);
++template void run_flash_splitkv_mla_fp8_sparse_kernel<ModelType::MODEL1, 64, false, false>(const SparseAttnDecodeParams &params);
+@@ -8 +7,0 @@
+-
+diff -ruN -U0 a/csrc/sm90/decode/sparse_fp8/instantiations/v32_persistent_h128.cu b/csrc/sm90/decode/sparse_fp8/instantiations/v32_persistent_h128.cu
+--- a/csrc/sm90/decode/sparse_fp8/instantiations/v32_persistent_h128.cu	2026-06-24 14:52:45
++++ b/csrc/sm90/decode/sparse_fp8/instantiations/v32_persistent_h128.cu	2026-08-13 19:49:46
+@@ -5 +5,3 @@
+-template void run_flash_splitkv_mla_fp8_sparse_kernel<ModelType::V32, 128>(const SparseAttnDecodeParams &params);
++template void run_flash_splitkv_mla_fp8_sparse_kernel<ModelType::V32, 128, false, false>(const SparseAttnDecodeParams &params);
++template void run_flash_splitkv_mla_fp8_sparse_kernel<ModelType::V32, 128, true, false>(const SparseAttnDecodeParams &params);
++template void run_flash_splitkv_mla_fp8_sparse_kernel<ModelType::V32, 128, true, true>(const SparseAttnDecodeParams &params);
+diff -ruN -U0 a/csrc/sm90/decode/sparse_fp8/instantiations/v32_persistent_h64.cu b/csrc/sm90/decode/sparse_fp8/instantiations/v32_persistent_h64.cu
+--- a/csrc/sm90/decode/sparse_fp8/instantiations/v32_persistent_h64.cu	2026-06-24 14:52:45
++++ b/csrc/sm90/decode/sparse_fp8/instantiations/v32_persistent_h64.cu	2026-08-13 19:49:46
+@@ -5 +5,3 @@
+-template void run_flash_splitkv_mla_fp8_sparse_kernel<ModelType::V32, 64>(const SparseAttnDecodeParams &params);
++template void run_flash_splitkv_mla_fp8_sparse_kernel<ModelType::V32, 64, false, false>(const SparseAttnDecodeParams &params);
++template void run_flash_splitkv_mla_fp8_sparse_kernel<ModelType::V32, 64, true, false>(const SparseAttnDecodeParams &params);
++template void run_flash_splitkv_mla_fp8_sparse_kernel<ModelType::V32, 64, true, true>(const SparseAttnDecodeParams &params);
+diff -ruN -U0 a/csrc/sm90/decode/sparse_fp8/splitkv_mla.cuh b/csrc/sm90/decode/sparse_fp8/splitkv_mla.cuh
+--- a/csrc/sm90/decode/sparse_fp8/splitkv_mla.cuh	2026-06-24 14:52:45
++++ b/csrc/sm90/decode/sparse_fp8/splitkv_mla.cuh	2026-08-13 19:49:46
+@@ -16,0 +17 @@
++#include "components/shared_kv_adapter.h"
+@@ -86 +87,6 @@
+-template<ModelType MODEL_TYPE, int NUM_HEADS>
++template<
++    ModelType MODEL_TYPE,
++    int NUM_HEADS,
++    bool USE_SHARED_CACHE,
++    bool USE_CURRENT_ROWS
++>
+@@ -88 +94 @@
+-__device__ void KernelTemplate<MODEL_TYPE, NUM_HEADS>::devfunc(const SparseAttnDecodeParams &params, const TMAParams &tma_params) {
++__device__ void KernelTemplate<MODEL_TYPE, NUM_HEADS, USE_SHARED_CACHE, USE_CURRENT_ROWS>::devfunc(const SparseAttnDecodeParams &params, const TMAParams &tma_params) {
+@@ -463,0 +470,2 @@
++        const uint32_t shared_cache_epoch =
++            shared_kv_adapter::epoch<USE_SHARED_CACHE>(params);
+@@ -470 +478 @@
+-
++
+@@ -538,2 +546,8 @@
+-                    int block_index = token_index == -1 ? 0 : (int)((uint32_t)token_index/(uint32_t)page_block_size);   // Use uint32_t division and mod to improve performance
+-                    int rel_idx_in_block = (uint32_t)token_index % (uint32_t)page_block_size;   // NOTE When token_index is -1 (UINT_MAX), UINT_MAX%page_block_size < page_block_size, so there will be no illegal-memory-access error
++                    const int current_row_match =
++                        shared_kv_adapter::current_row_match<USE_CURRENT_ROWS>(
++                            token_index
++                        );
++                    const int kv_token_index =
++                        current_row_match >= 0 ? 0 : token_index;
++                    int block_index = kv_token_index == -1 ? 0 : (int)((uint32_t)kv_token_index/(uint32_t)page_block_size);   // Use uint32_t division and mod to improve performance
++                    int rel_idx_in_block = (uint32_t)kv_token_index % (uint32_t)page_block_size;   // NOTE When token_index is -1 (UINT_MAX), UINT_MAX%page_block_size < page_block_size, so there will be no illegal-memory-access error
+@@ -542,0 +557 @@
++                    auto shared_row = shared_kv_adapter::direct(nullptr);
+@@ -545,0 +561,14 @@
++                        shared_row = shared_kv_adapter::resolve<
++                            USE_SHARED_CACHE,
++                            USE_CURRENT_ROWS
++                        >(
++                            params,
++                            gK_base,
++                            token_index,
++                            current_row_match,
++                            batch_idx,
++                            s_q_idx,
++                            lane_idx,
++                            shared_cache_epoch
++                        );
++                        gK_base = shared_row.source;
+@@ -547,0 +577,6 @@
++                        if (lane_idx < 8) {
++                            shared_row.store_fragment<USE_SHARED_CACHE>(
++                                HEAD_DIM_NOPE,
++                                *reinterpret_cast<float4*>(scales_float)
++                            );
++                        }
+@@ -584,3 +619 @@
+-                        fp8x16 cur_fp8x16 = load_128b_from_gmem<fp8x16, L1CacheHint::EVICT_LAST, L2PrefetchHint::B256>(gK_nope + dim_idx*64);   // We use EVICT_LAST here since gK_base may not be aligned to 32B (for V3.2) and the performance is the best among all cache hints (for MODEL1)
+-                        bf16 scale = scales[MODEL_TYPE == ModelType::V32 ? dim_idx/2 : dim_idx];
+-                        auto dequant_and_save_bf16x8 = [&](const fp8x8 &data, int offset) {
++                        auto save_bf16x8 = [&](const bf16x8 &data, int offset) {
+@@ -588,2 +621 @@
+-                            bf16x8 cur_bf16x8 = cvt_fp8x8_bf16x8(data, __bfloat162bfloat162(*(__nv_bfloat16*)(&scale)));
+-                            *(__int128_t*)(sK_nope_base + smem_offset) = *(__int128_t*)&cur_bf16x8;
++                            *(__int128_t*)(sK_nope_base + smem_offset) = *(__int128_t*)&data;
+@@ -591 +623 @@
+-                                st_async_128b(sK_nope_peer_base + smem_offset, cur_bf16x8, peer_bar_k_remote_ready);
++                                st_async_128b(sK_nope_peer_base + smem_offset, data, peer_bar_k_remote_ready);
+@@ -593,0 +626,5 @@
++                        fp8x16 cur_fp8x16 = load_128b_from_gmem<fp8x16, L1CacheHint::EVICT_LAST, L2PrefetchHint::B256>(gK_nope + dim_idx*64);   // We use EVICT_LAST here since gK_base may not be aligned to 32B (for V3.2) and the performance is the best among all cache hints (for MODEL1)
++                        shared_row.store_fragment<USE_SHARED_CACHE>(
++                            (lane_idx / 8) * 16 + dim_idx * 64,
++                            *reinterpret_cast<uint128_t*>(&cur_fp8x16)
++                        );
+@@ -596,2 +633,4 @@
+-                        dequant_and_save_bf16x8(cur_fp8x16.lo, 0);
+-                        dequant_and_save_bf16x8(cur_fp8x16.hi, 8);
++                        bf16 scale = scales[MODEL_TYPE == ModelType::V32 ? dim_idx/2 : dim_idx];
++                        auto scale_bf16x2 = __bfloat162bfloat162(*(__nv_bfloat16*)(&scale));
++                        save_bf16x8(cvt_fp8x8_bf16x8(cur_fp8x16.lo, scale_bf16x2), 0);
++                        save_bf16x8(cvt_fp8x8_bf16x8(cur_fp8x16.hi, scale_bf16x2), 8);
+@@ -611,0 +651,7 @@
++                        shared_row.store_fragment<
++                            MODEL_TYPE == ModelType::V32 && USE_SHARED_CACHE
++                        >(
++                            HEAD_DIM_NOPE + NUM_SCALES * sizeof(float) +
++                                (lane_idx / 8) * 16 + dim_idx * 64,
++                            cur_bf16x8
++                        );
+@@ -623,0 +670,4 @@
++
++                    shared_row.publish<
++                        MODEL_TYPE == ModelType::V32 && USE_SHARED_CACHE
++                    >();
+@@ -686,2 +736,2 @@
+-template<ModelType MODEL_TYPE, int NUM_HEADS>
+-void KernelTemplate<MODEL_TYPE, NUM_HEADS>::run(const SparseAttnDecodeParams &params) {
++template<ModelType MODEL_TYPE, int NUM_HEADS, bool USE_SHARED_CACHE, bool USE_CURRENT_ROWS>
++void KernelTemplate<MODEL_TYPE, NUM_HEADS, USE_SHARED_CACHE, USE_CURRENT_ROWS>::run(const SparseAttnDecodeParams &params) {
+@@ -751 +801 @@
+-    auto mla_kernel = &flash_fwd_splitkv_mla_fp8_sparse_kernel<KernelTemplate<MODEL_TYPE, NUM_HEADS>, decltype(tma_params)>;
++    auto mla_kernel = &flash_fwd_splitkv_mla_fp8_sparse_kernel<KernelTemplate<MODEL_TYPE, NUM_HEADS, USE_SHARED_CACHE, USE_CURRENT_ROWS>, decltype(tma_params)>;
+@@ -782 +832 @@
+-template<ModelType MODEL_TYPE, int NUM_HEADS>
++template<ModelType MODEL_TYPE, int NUM_HEADS, bool USE_SHARED_CACHE, bool USE_CURRENT_ROWS>
+@@ -784 +834 @@
+-    KernelTemplate<MODEL_TYPE, NUM_HEADS>::run(params);
++    KernelTemplate<MODEL_TYPE, NUM_HEADS, USE_SHARED_CACHE, USE_CURRENT_ROWS>::run(params);
+diff -ruN -U0 a/csrc/sm90/decode/sparse_fp8/splitkv_mla.h b/csrc/sm90/decode/sparse_fp8/splitkv_mla.h
+--- a/csrc/sm90/decode/sparse_fp8/splitkv_mla.h	2026-06-24 14:52:45
++++ b/csrc/sm90/decode/sparse_fp8/splitkv_mla.h	2026-08-13 19:49:46
+@@ -7 +7,6 @@
+-template<ModelType MODEL_TYPE, int NUM_HEADS>
++template<
++    ModelType MODEL_TYPE,
++    int NUM_HEADS,
++    bool USE_SHARED_CACHE,
++    bool USE_CURRENT_ROWS
++>
+@@ -11 +15,0 @@
+-

--- a/python/sglang/kernels/aot/csrc/flashmla_extension.cc
+++ b/python/sglang/kernels/aot/csrc/flashmla_extension.cc
@@ -49,6 +49,59 @@ static std::tuple<at::Tensor, at::Tensor, std::optional<at::Tensor>, std::option
       static_cast<float>(sm_scale));
 }
 
+static std::tuple<at::Tensor, at::Tensor, std::optional<at::Tensor>, std::optional<at::Tensor>>
+sgl_sparse_decode_shared_fwd(
+    const at::Tensor& q,
+    const at::Tensor& kv,
+    const at::Tensor& indices,
+    const std::optional<at::Tensor>& topk_length,
+    const std::optional<at::Tensor>& attn_sink,
+    std::optional<at::Tensor> tile_scheduler_metadata,
+    std::optional<at::Tensor> num_splits,
+    const std::optional<at::Tensor>& extra_kv,
+    const std::optional<at::Tensor>& extra_indices,
+    const std::optional<at::Tensor>& extra_topk_length,
+    int64_t d_v,
+    double sm_scale,
+    const at::Tensor& shared_kv_row_cache,
+    const at::Tensor& shared_kv_cache_tags,
+    const std::optional<at::Tensor>& shared_kv_request_slots,
+    int64_t shared_kv_cache_rows_per_request,
+    int64_t shared_kv_num_request_slots,
+    int64_t shared_kv_cache_epoch,
+    const std::optional<at::Tensor>& shared_kv_cache_generation_tensor,
+    int64_t shared_kv_local_row_begin,
+    int64_t shared_kv_local_row_end,
+    const std::optional<at::Tensor>& shared_kv_current_rows,
+    const std::optional<at::Tensor>& shared_kv_current_row_ids,
+    const std::optional<at::Tensor>& shared_kv_current_row_counts) {
+  return sparse_attn_decode_interface(
+      q,
+      kv,
+      indices,
+      topk_length,
+      attn_sink,
+      tile_scheduler_metadata,
+      num_splits,
+      extra_kv,
+      extra_indices,
+      extra_topk_length,
+      static_cast<int>(d_v),
+      static_cast<float>(sm_scale),
+      shared_kv_row_cache,
+      shared_kv_cache_tags,
+      shared_kv_request_slots,
+      shared_kv_cache_rows_per_request,
+      shared_kv_num_request_slots,
+      shared_kv_cache_epoch,
+      shared_kv_cache_generation_tensor,
+      shared_kv_local_row_begin,
+      shared_kv_local_row_end,
+      shared_kv_current_rows,
+      shared_kv_current_row_ids,
+      shared_kv_current_row_counts);
+}
+
 static std::tuple<at::Tensor, at::Tensor, std::optional<at::Tensor>, std::optional<at::Tensor>> sgl_dense_decode_fwd(
     at::Tensor q,
     const at::Tensor& kcache,
@@ -104,6 +157,19 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "Tensor? tile_scheduler_metadata, Tensor? num_splits, Tensor? extra_kv, Tensor? extra_indices, "
       "Tensor? extra_topk_length, int d_v, float sm_scale) -> (Tensor, Tensor, Tensor?, Tensor?)");
   m.impl("sparse_decode_fwd", torch::kCUDA, &sgl_sparse_decode_fwd);
+
+  m.def(
+      "sparse_decode_shared_fwd(Tensor q, Tensor kv, Tensor indices, Tensor? topk_length, Tensor? attn_sink, "
+      "Tensor? tile_scheduler_metadata, Tensor? num_splits, Tensor? extra_kv, Tensor? extra_indices, "
+      "Tensor? extra_topk_length, int d_v, float sm_scale, Tensor shared_kv_row_cache, Tensor "
+      "shared_kv_cache_tags, Tensor? shared_kv_request_slots, "
+      "int shared_kv_cache_rows_per_request, int shared_kv_num_request_slots, "
+      "int shared_kv_cache_epoch, Tensor? shared_kv_cache_generation_tensor, "
+      "int shared_kv_local_row_begin, int "
+      "shared_kv_local_row_end, Tensor? shared_kv_current_rows=None, "
+      "Tensor? shared_kv_current_row_ids=None, Tensor? "
+      "shared_kv_current_row_counts=None) -> (Tensor, Tensor, Tensor?, Tensor?)");
+  m.impl("sparse_decode_shared_fwd", torch::kCUDA, &sgl_sparse_decode_shared_fwd);
 
   m.def(
       "dense_decode_fwd(Tensor q, Tensor kcache, int head_size_v, Tensor seqlens_k, Tensor block_table, float "

--- a/python/sglang/kernels/aot/python/sgl_kernel/flash_mla.py
+++ b/python/sglang/kernels/aot/python/sgl_kernel/flash_mla.py
@@ -4,7 +4,7 @@ from typing import Optional, Tuple
 import torch
 
 try:
-    from sgl_kernel import flashmla_ops  # triggers TORCH extension registration
+    from sgl_kernel import flashmla_ops  # noqa: F401  # register TORCH extension
 except Exception as _e:
     _flashmla_import_error = _e
 else:
@@ -36,6 +36,64 @@ class FlashMLASchedMeta:
     config: Optional[Config] = None
     tile_scheduler_metadata: Optional[torch.Tensor] = None
     num_splits: Optional[torch.Tensor] = None
+
+
+def _validate_shared_kv_current_rows(
+    q: torch.Tensor,
+    current_rows: Optional[torch.Tensor],
+    current_row_ids: Optional[torch.Tensor],
+    current_row_counts: Optional[torch.Tensor],
+) -> bool:
+    provided = (
+        current_rows is not None,
+        current_row_ids is not None,
+        current_row_counts is not None,
+    )
+    assert all(provided) or not any(
+        provided
+    ), "Shared-KV current rows, row IDs, and row counts must be provided together"
+    if not all(provided):
+        return False
+
+    assert current_rows is not None
+    assert current_row_ids is not None
+    assert current_row_counts is not None
+    query_rows = q.shape[0] * q.shape[1]
+    assert current_rows.dtype == torch.uint8, "current rows must have dtype uint8"
+    assert current_rows.is_contiguous(), "current rows must be contiguous"
+    assert (
+        current_rows.ndim == 3 and current_rows.shape[0] == query_rows
+    ), "current rows must match the flattened FlashMLA query rows"
+    current_row_width = current_rows.shape[1]
+    assert (
+        1 <= current_row_width <= 4 and current_rows.shape[2] == 656
+    ), "current rows must have shape [query rows, width, 656] with 1 <= width <= 4"
+    assert current_row_ids.dtype == torch.int32, "current row IDs must have dtype int32"
+    assert current_row_ids.is_contiguous(), "current row IDs must be contiguous"
+    assert current_row_ids.shape == (
+        query_rows,
+        current_row_width,
+    ), "current row IDs must match the current-row width"
+    assert (
+        current_row_counts.dtype == torch.int32
+    ), "current row counts must have dtype int32"
+    assert current_row_counts.is_contiguous(), "current row counts must be contiguous"
+    assert current_row_counts.shape == (
+        query_rows,
+    ), "current row counts must have shape [query rows]"
+    # Counts are produced by the graph-stable SGLang metadata path whose
+    # rows-per-request contract is already bounded by the allocated width.
+    # Capturing this dynamic check would replay five tiny validation kernels for every
+    # model
+    # layer, so keep it as an eager/debug boundary check only.
+    if not torch.cuda.is_available() or not torch.cuda.is_current_stream_capturing():
+        torch._assert_async(
+            (
+                (current_row_counts >= 0) & (current_row_counts <= current_row_width)
+            ).all(),
+            "current row counts are outside the valid range for the allocated current-row width",
+        )
+    return True
 
 
 def get_mla_metadata(
@@ -103,6 +161,18 @@ def flash_mla_with_kvcache(
     extra_indices_in_kvcache: Optional[torch.Tensor] = None,
     topk_length: Optional[torch.Tensor] = None,
     extra_topk_length: Optional[torch.Tensor] = None,
+    shared_kv_row_cache: Optional[torch.Tensor] = None,
+    shared_kv_cache_tags: Optional[torch.Tensor] = None,
+    shared_kv_request_slots: Optional[torch.Tensor] = None,
+    shared_kv_cache_rows_per_request: int = 0,
+    shared_kv_num_request_slots: int = 0,
+    shared_kv_cache_epoch: int = 0,
+    shared_kv_cache_generation_tensor: Optional[torch.Tensor] = None,
+    shared_kv_local_row_begin: int = 0,
+    shared_kv_local_row_end: int = 0,
+    shared_kv_current_rows: Optional[torch.Tensor] = None,
+    shared_kv_current_row_ids: Optional[torch.Tensor] = None,
+    shared_kv_current_row_counts: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """
     Arguments:
@@ -129,6 +199,12 @@ def flash_mla_with_kvcache(
 
     if softmax_scale is None:
         softmax_scale = q.shape[-1] ** (-0.5)
+    have_current_rows = _validate_shared_kv_current_rows(
+        q,
+        shared_kv_current_rows,
+        shared_kv_current_row_ids,
+        shared_kv_current_row_counts,
+    )
     if isinstance(tile_scheduler_metadata, FlashMLASchedMeta):
         return _flash_mla_with_kvcache_sched_meta(
             q=q,
@@ -147,7 +223,90 @@ def flash_mla_with_kvcache(
             extra_indices_in_kvcache=extra_indices_in_kvcache,
             topk_length=topk_length,
             extra_topk_length=extra_topk_length,
+            shared_kv_row_cache=shared_kv_row_cache,
+            shared_kv_cache_tags=shared_kv_cache_tags,
+            shared_kv_request_slots=shared_kv_request_slots,
+            shared_kv_cache_rows_per_request=shared_kv_cache_rows_per_request,
+            shared_kv_num_request_slots=shared_kv_num_request_slots,
+            shared_kv_cache_epoch=shared_kv_cache_epoch,
+            shared_kv_cache_generation_tensor=(shared_kv_cache_generation_tensor),
+            shared_kv_local_row_begin=shared_kv_local_row_begin,
+            shared_kv_local_row_end=shared_kv_local_row_end,
+            shared_kv_current_rows=shared_kv_current_rows,
+            shared_kv_current_row_ids=shared_kv_current_row_ids,
+            shared_kv_current_row_counts=shared_kv_current_row_counts,
         )
+
+    have_shared_cache = shared_kv_row_cache is not None
+    assert have_shared_cache == (shared_kv_cache_tags is not None)
+    assert (
+        have_shared_cache or not have_current_rows
+    ), "Shared-KV current rows require the Shared FlashMLA path"
+    if have_shared_cache:
+        assert indices is not None
+        assert not causal
+        assert is_fp8_kvcache
+        assert num_splits is not None
+        assert attn_sink is None
+        assert extra_k_cache is None
+        assert extra_indices_in_kvcache is None
+        assert extra_topk_length is None
+        assert shared_kv_cache_epoch > 0
+        if shared_kv_cache_generation_tensor is not None:
+            assert shared_kv_cache_generation_tensor.dtype == torch.int32
+            assert shared_kv_cache_generation_tensor.numel() == 1
+            assert shared_kv_cache_generation_tensor.is_contiguous()
+        assert shared_kv_local_row_end > shared_kv_local_row_begin
+        assert shared_kv_cache_rows_per_request > 0
+        assert (
+            shared_kv_cache_rows_per_request & (shared_kv_cache_rows_per_request - 1)
+            == 0
+        )
+        assert shared_kv_num_request_slots > 0
+        assert shared_kv_row_cache.ndim == 2
+        assert shared_kv_row_cache.shape == (
+            shared_kv_num_request_slots * shared_kv_cache_rows_per_request,
+            656,
+        )
+        assert shared_kv_cache_tags.shape == (
+            shared_kv_num_request_slots,
+            shared_kv_cache_rows_per_request,
+        )
+        if shared_kv_num_request_slots > 1:
+            assert (
+                shared_kv_request_slots is not None
+            ), "request slots are required for a multislice Shared-KV cache"
+        if shared_kv_request_slots is not None:
+            assert shared_kv_request_slots.dtype == torch.int64
+            assert shared_kv_request_slots.ndim == 1
+            assert shared_kv_request_slots.numel() == q.shape[0]
+        out, softmax_lse, _, _ = torch.ops.sgl_kernel.sparse_decode_shared_fwd.default(
+            q,
+            k_cache,
+            indices,
+            topk_length,
+            attn_sink,
+            tile_scheduler_metadata,
+            num_splits,
+            extra_k_cache,
+            extra_indices_in_kvcache,
+            extra_topk_length,
+            head_dim_v,
+            softmax_scale,
+            shared_kv_row_cache,
+            shared_kv_cache_tags,
+            shared_kv_request_slots,
+            shared_kv_cache_rows_per_request,
+            shared_kv_num_request_slots,
+            shared_kv_cache_epoch,
+            shared_kv_cache_generation_tensor,
+            shared_kv_local_row_begin,
+            shared_kv_local_row_end,
+            shared_kv_current_rows,
+            shared_kv_current_row_ids,
+            shared_kv_current_row_counts,
+        )
+        return out, softmax_lse
 
     assert num_splits is not None
     assert block_table is not None
@@ -157,6 +316,7 @@ def flash_mla_with_kvcache(
     assert extra_indices_in_kvcache is None
     assert topk_length is None
     assert extra_topk_length is None
+    assert not have_shared_cache
     if indices is not None:
         assert causal == False, "causal must be `false` if sparse attention is enabled."
     assert (descale_q is None) == (
@@ -216,6 +376,18 @@ def _flash_mla_with_kvcache_sched_meta(
     extra_indices_in_kvcache: Optional[torch.Tensor],
     topk_length: Optional[torch.Tensor],
     extra_topk_length: Optional[torch.Tensor],
+    shared_kv_row_cache: Optional[torch.Tensor],
+    shared_kv_cache_tags: Optional[torch.Tensor],
+    shared_kv_request_slots: Optional[torch.Tensor],
+    shared_kv_cache_rows_per_request: int,
+    shared_kv_num_request_slots: int,
+    shared_kv_cache_epoch: int,
+    shared_kv_cache_generation_tensor: Optional[torch.Tensor],
+    shared_kv_local_row_begin: int,
+    shared_kv_local_row_end: int,
+    shared_kv_current_rows: Optional[torch.Tensor],
+    shared_kv_current_row_ids: Optional[torch.Tensor],
+    shared_kv_current_row_counts: Optional[torch.Tensor],
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     assert num_splits is None, "num_splits must be None with FlashMLASchedMeta"
 
@@ -265,21 +437,56 @@ def _flash_mla_with_kvcache_sched_meta(
     if topk is not None:
         assert not causal, "causal must be False when sparse attention is enabled"
         assert is_fp8_kvcache, "is_fp8_kvcache must be True for sparse attention"
-        out, lse, new_tile_scheduler_metadata, new_num_splits = (
-            torch.ops.sgl_kernel.sparse_decode_fwd.default(
-                q,
-                k_cache,
-                indices,
-                topk_length,
-                attn_sink,
-                sched_meta.tile_scheduler_metadata,
-                sched_meta.num_splits,
-                extra_k_cache,
-                extra_indices_in_kvcache,
-                extra_topk_length,
-                head_dim_v,
-                softmax_scale,
+        have_shared_cache = shared_kv_row_cache is not None
+        assert have_shared_cache == (shared_kv_cache_tags is not None)
+        if have_shared_cache:
+            assert extra_k_cache is None
+            assert extra_indices_in_kvcache is None
+            assert extra_topk_length is None
+            assert shared_kv_cache_epoch > 0
+            if shared_kv_cache_generation_tensor is not None:
+                assert shared_kv_cache_generation_tensor.dtype == torch.int32
+                assert shared_kv_cache_generation_tensor.numel() == 1
+                assert shared_kv_cache_generation_tensor.is_contiguous()
+            assert shared_kv_local_row_end > shared_kv_local_row_begin
+            assert shared_kv_cache_rows_per_request > 0
+            assert shared_kv_num_request_slots > 0
+            if shared_kv_num_request_slots > 1:
+                assert (
+                    shared_kv_request_slots is not None
+                ), "request slots are required for a multislice Shared-KV cache"
+            sparse_op = torch.ops.sgl_kernel.sparse_decode_shared_fwd.default
+            shared_args = (
+                shared_kv_row_cache,
+                shared_kv_cache_tags,
+                shared_kv_request_slots,
+                shared_kv_cache_rows_per_request,
+                shared_kv_num_request_slots,
+                shared_kv_cache_epoch,
+                shared_kv_cache_generation_tensor,
+                shared_kv_local_row_begin,
+                shared_kv_local_row_end,
+                shared_kv_current_rows,
+                shared_kv_current_row_ids,
+                shared_kv_current_row_counts,
             )
+        else:
+            sparse_op = torch.ops.sgl_kernel.sparse_decode_fwd.default
+            shared_args = ()
+        out, lse, new_tile_scheduler_metadata, new_num_splits = sparse_op(
+            q,
+            k_cache,
+            indices,
+            topk_length,
+            attn_sink,
+            sched_meta.tile_scheduler_metadata,
+            sched_meta.num_splits,
+            extra_k_cache,
+            extra_indices_in_kvcache,
+            extra_topk_length,
+            head_dim_v,
+            softmax_scale,
+            *shared_args,
         )
     else:
         assert block_table is not None and cache_seqlens is not None

--- a/python/sglang/kernels/jit/csrc/deepseek_v32/indexer_k.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v32/indexer_k.cuh
@@ -234,6 +234,8 @@ struct FusedKIndexerNormRopeStoreParams {
   // Row stride for `k_input` (caller passes the non-contiguous wk slice directly).
   int64_t k_input_stride_batch;
   uint32_t batch_size;
+  uint32_t owner_rank;
+  uint32_t owner_size;
   float eps;
 };
 
@@ -260,6 +262,20 @@ K_INDEXER_KERNEL void fused_k_indexer_norm_rope_store(const __grid_constant__ Fu
   const bool is_rope_lane = lane_id < kRopeSize;
 
   if (work_id >= params.batch_size) return;
+
+  const auto index = static_cast<const int64_t*>(params.indices)[work_id];
+  if (index < 0) {
+    PDLWaitPrimary<kUsePDL>();
+    PDLTriggerSecondary<kUsePDL>();
+    return;
+  }
+  auto page = static_cast<int32_t>(index >> kPageBits);
+  if (page % params.owner_size != params.owner_rank) {
+    PDLWaitPrimary<kUsePDL>();
+    PDLTriggerSecondary<kUsePDL>();
+    return;
+  }
+  page /= params.owner_size;
 
   const auto input_ptr = static_cast<const DType*>(params.k_input) + work_id * params.k_input_stride_batch;
   const auto position = static_cast<int32_t>(static_cast<const PosT*>(params.positions)[work_id]);
@@ -330,8 +346,6 @@ K_INDEXER_KERNEL void fused_k_indexer_norm_rope_store(const __grid_constant__ Fu
   const auto scale = fmaxf(1e-4f, abs_max) / math::FP8_E4M3_MAX;
   const auto inv_scale = 1.0f / scale;
 
-  const auto index = static_cast<const int64_t*>(params.indices)[work_id];
-  const int32_t page = static_cast<int32_t>(index >> kPageBits);
   const int32_t offset = static_cast<int32_t>(index & ((1 << kPageBits) - 1));
   const auto page_ptr = static_cast<uint8_t*>(params.cache) + page * kPageBytes;
   const auto value_ptr = page_ptr + offset * kHeadDim;
@@ -361,7 +375,9 @@ struct FusedKIndexerNormRopeStoreKernel {
       const tvm::ffi::TensorView bias,
       const tvm::ffi::TensorView cos_sin_cache,
       const tvm::ffi::TensorView positions,
-      double eps) {
+      double eps,
+      int64_t owner_rank,
+      int64_t owner_size) {
     using namespace host;
     constexpr int64_t kHeadDim = 128;
     constexpr int64_t kRopeDim = 64;
@@ -415,6 +431,8 @@ struct FusedKIndexerNormRopeStoreKernel {
         .positions = positions.data_ptr(),
         .k_input_stride_batch = k_input.stride(0),
         .batch_size = batch_size,
+        .owner_rank = static_cast<uint32_t>(owner_rank),
+        .owner_size = static_cast<uint32_t>(owner_size),
         .eps = static_cast<float>(eps),
     };
     const auto num_blocks = div_ceil(batch_size, kFusedKIndexerNumWarps);

--- a/python/sglang/kernels/jit/csrc/dsa/fused_store_index_cache.cuh
+++ b/python/sglang/kernels/jit/csrc/dsa/fused_store_index_cache.cuh
@@ -21,6 +21,8 @@ struct FusedStoreCacheParam {
   void* __restrict__ cache;
   const void* __restrict__ indices;
   uint32_t num_tokens;
+  uint32_t owner_rank;
+  uint32_t owner_size;
 };
 
 [[maybe_unused]]
@@ -42,7 +44,7 @@ __global__ void fused_store_indexer_cache(const __grid_constant__ FusedStoreCach
   constexpr int64_t kPageBytes = 132 << kPageBits;
 
   // each warp handles 128 elements, each block handles multiple rows
-  const auto& [input, cache, indices, num_tokens] = param;
+  const auto& [input, cache, indices, num_tokens, owner_rank, owner_size] = param;
   const auto global_tid = blockIdx.x * blockDim.x + threadIdx.x;
   const auto global_wid = global_tid / 32;
   const auto lane_id = threadIdx.x % 32;
@@ -53,7 +55,16 @@ __global__ void fused_store_indexer_cache(const __grid_constant__ FusedStoreCach
 
   // prefetch the index
   const auto index = static_cast<const IndicesT*>(indices)[global_wid];
-  // always load the value from input (don't store if invalid)
+  if (index < 0) {
+    PDLTriggerSecondary<kUsePDL>();
+    return;
+  }
+  auto page = static_cast<int32_t>(index >> kPageBits);
+  if (page % owner_size != owner_rank) {
+    PDLTriggerSecondary<kUsePDL>();
+    return;
+  }
+  page /= owner_size;
   using KeyT2 = packed_t<KeyT>;
   using InStorage = AlignedVector<KeyT2, 2>;
   using OutStorage = AlignedVector<fp8x2_e4m3_t, 2>;
@@ -65,7 +76,6 @@ __global__ void fused_store_indexer_cache(const __grid_constant__ FusedStoreCach
   // use normal fp32 scale
   const auto scale = fmaxf(1e-4f, abs_max) / kFP8E4M3Max;
   const auto inv_scale = 1.0f / scale;
-  const int32_t page = index >> kPageBits;
   const int32_t offset = index & ((1 << kPageBits) - 1);
   const auto page_ptr = pointer::offset(cache, page * kPageBytes);
   const auto value_ptr = pointer::offset(page_ptr, offset * 128);
@@ -89,7 +99,12 @@ struct FusedStoreCacheIndexerKernel {
   static_assert(std::has_single_bit(kPageSize), "kPageSize must be a power of 2");
   static_assert(1 << kLogSize == kPageSize);
 
-  static void run(tvm::ffi::TensorView input, tvm::ffi::TensorView cache, tvm::ffi::TensorView indices) {
+  static void
+  run(tvm::ffi::TensorView input,
+      tvm::ffi::TensorView cache,
+      tvm::ffi::TensorView indices,
+      int64_t owner_rank,
+      int64_t owner_size) {
     using namespace host;
 
     auto N = SymbolicSize{"num_tokens"};
@@ -114,6 +129,8 @@ struct FusedStoreCacheIndexerKernel {
         .cache = cache.data_ptr(),
         .indices = indices.data_ptr(),
         .num_tokens = num_tokens,
+        .owner_rank = static_cast<uint32_t>(owner_rank),
+        .owner_size = static_cast<uint32_t>(owner_size),
     };
     const auto kBlockSize = 128;
     const auto num_blocks = div_ceil(num_tokens * 32, kBlockSize);

--- a/python/sglang/kernels/jit/csrc/shared_kv/publication.cuh
+++ b/python/sglang/kernels/jit/csrc/shared_kv/publication.cuh
@@ -1,0 +1,135 @@
+#pragma once
+
+#include <sgl_kernel/tensor.h>
+#include <sgl_kernel/utils.h>
+
+#include <sgl_kernel/utils.cuh>
+
+#include <dlpack/dlpack.h>
+#include <tvm/ffi/container/tensor.h>
+
+#include <cstdint>
+
+namespace sglang {
+namespace {
+
+template <uint32_t kWorldSize>
+__global__ void
+shared_kv_publish_kernel(uint32_t* const* __restrict__ peer_rows, uint32_t* __restrict__ epoch, uint32_t rank) {
+  static_assert(kWorldSize >= 2 && kWorldSize <= 8);
+  __shared__ uint32_t expected;
+  if (threadIdx.x == 0) {
+    expected = *epoch + 1u;
+    *epoch = expected;
+  }
+  __syncthreads();
+
+  if (threadIdx.x < kWorldSize) {
+    const uint32_t peer = threadIdx.x;
+    uint32_t* remote = peer_rows[peer] + rank;
+    asm volatile("st.release.sys.global.u32 [%0], %1;" : : "l"(remote), "r"(expected) : "memory");
+
+    uint32_t observed;
+    uint32_t* local = peer_rows[rank] + peer;
+    do {
+      asm volatile("ld.acquire.sys.global.u32 %0, [%1];" : "=r"(observed) : "l"(local) : "memory");
+    } while (static_cast<int32_t>(observed - expected) < 0);
+  }
+  __syncthreads();
+}
+
+template <uint32_t kWorldSize>
+__global__ void shared_kv_publish_status_kernel(
+    uint32_t* const* __restrict__ peer_rows,
+    uint32_t* __restrict__ epoch,
+    uint32_t* __restrict__ result,
+    uint32_t rank,
+    uint32_t local_success) {
+  static_assert(kWorldSize >= 2 && kWorldSize <= 8);
+  __shared__ uint32_t expected;
+  __shared__ uint32_t all_success;
+  if (threadIdx.x == 0) {
+    expected = *epoch + 1u;
+    *epoch = expected;
+    all_success = 1u;
+  }
+  __syncthreads();
+
+  if (threadIdx.x < kWorldSize) {
+    const uint32_t peer = threadIdx.x;
+    uint32_t* remote_row = peer_rows[peer];
+    asm volatile("st.release.sys.global.u32 [%0], %1;"
+                 :
+                 : "l"(remote_row + kWorldSize + rank), "r"(local_success)
+                 : "memory");
+    asm volatile("st.release.sys.global.u32 [%0], %1;" : : "l"(remote_row + rank), "r"(expected) : "memory");
+
+    uint32_t observed;
+    uint32_t* local_row = peer_rows[rank];
+    do {
+      asm volatile("ld.acquire.sys.global.u32 %0, [%1];" : "=r"(observed) : "l"(local_row + peer) : "memory");
+    } while (static_cast<int32_t>(observed - expected) < 0);
+
+    uint32_t peer_success;
+    asm volatile("ld.acquire.sys.global.u32 %0, [%1];"
+                 : "=r"(peer_success)
+                 : "l"(local_row + kWorldSize + peer)
+                 : "memory");
+    if (peer_success == 0u) {
+      atomicExch(&all_success, 0u);
+    }
+  }
+  __syncthreads();
+  if (threadIdx.x == 0) {
+    *result = all_success;
+  }
+}
+
+template <uint32_t kWorldSize>
+void shared_kv_publish(
+    tvm::ffi::TensorView flags, tvm::ffi::TensorView peer_ptrs, tvm::ffi::TensorView epoch, int64_t rank) {
+  using namespace host;
+  SymbolicDevice device;
+  device.set_options<kDLCUDA>();
+  TensorMatcher({-1}).with_dtype<int32_t>().with_device(device).verify(flags);
+  TensorMatcher({kWorldSize}).with_dtype<int64_t>().with_device(device).verify(peer_ptrs);
+  TensorMatcher({1}).with_dtype<int32_t>().with_device(device).verify(epoch);
+  RuntimeCheck(rank >= 0 && rank < kWorldSize, "rank out of range: ", rank);
+
+  auto** rows = reinterpret_cast<uint32_t**>(peer_ptrs.data_ptr());
+  auto* epoch_ptr = static_cast<uint32_t*>(epoch.data_ptr());
+  const DLDevice launch_device = device.unwrap();
+  LaunchKernel(1, 32, launch_device)(
+      shared_kv_publish_kernel<kWorldSize>, rows, epoch_ptr, static_cast<uint32_t>(rank));
+}
+
+template <uint32_t kWorldSize>
+void shared_kv_publish_status(
+    tvm::ffi::TensorView flags,
+    tvm::ffi::TensorView peer_ptrs,
+    tvm::ffi::TensorView epoch,
+    tvm::ffi::TensorView result,
+    int64_t rank,
+    bool local_success) {
+  using namespace host;
+  SymbolicDevice device;
+  device.set_options<kDLCUDA>();
+  TensorMatcher({-1}).with_dtype<int32_t>().with_device(device).verify(flags);
+  TensorMatcher({kWorldSize}).with_dtype<int64_t>().with_device(device).verify(peer_ptrs);
+  TensorMatcher({1}).with_dtype<int32_t>().with_device(device).verify(epoch);
+  TensorMatcher({1}).with_dtype<int32_t>().with_device(device).verify(result);
+  RuntimeCheck(rank >= 0 && rank < kWorldSize, "rank out of range: ", rank);
+
+  auto** rows = reinterpret_cast<uint32_t**>(peer_ptrs.data_ptr());
+  const DLDevice launch_device = device.unwrap();
+  LaunchKernel(1, 32, launch_device)(
+      shared_kv_publish_status_kernel<kWorldSize>,
+      rows,
+      static_cast<uint32_t*>(epoch.data_ptr()),
+      static_cast<uint32_t*>(result.data_ptr()),
+      static_cast<uint32_t>(rank),
+      static_cast<uint32_t>(local_success));
+}
+
+}  // namespace
+}  // namespace sglang

--- a/python/sglang/kernels/ops/attention/dsa/dequant_k_cache.py
+++ b/python/sglang/kernels/ops/attention/dsa/dequant_k_cache.py
@@ -250,7 +250,8 @@ def _dequantize_k_cache_paged_kernel(
     DIM_ROPE: tl.constexpr,
 ):
     token_id = tl.program_id(0)
-    token_id_paged = tl.load(page_table_1_ptr + token_id).to(tl.int32)
+    # Page IDs fit int32, but Shared-VMM byte offsets can exceed 2 GiB.
+    token_id_paged = tl.load(page_table_1_ptr + token_id).to(tl.int64)
     raw_block_id = tl.program_id(1)
 
     if raw_block_id < NUM_NOPE_BLOCKS:

--- a/python/sglang/kernels/ops/attention/dsa/index_buf_accessor.py
+++ b/python/sglang/kernels/ops/attention/dsa/index_buf_accessor.py
@@ -28,6 +28,9 @@ if TYPE_CHECKING:
 """
 k: data, 128 item per token, fp8
 s: scale, 1 item per token, fp32
+
+Page tables stay int32, but address arithmetic uses int64 because shared VMM
+slabs can span more than 2 GiB.
 """
 
 
@@ -262,7 +265,16 @@ class SetKAndS:
         cls.triton(*args, **kwargs, buf=buf)
 
     @classmethod
-    def triton(cls, pool, buf, loc, index_k, index_k_scale):
+    def triton(
+        cls,
+        pool,
+        buf,
+        loc,
+        index_k,
+        index_k_scale,
+        owner_rank: int = 0,
+        owner_size: int = 1,
+    ):
         loc = loc.to(torch.int64)
 
         _set_k_and_s_triton(
@@ -271,6 +283,8 @@ class SetKAndS:
             index_k=index_k,
             index_k_scale=index_k_scale,
             page_size=pool.page_size,
+            owner_rank=owner_rank,
+            owner_size=owner_size,
         )
 
 
@@ -280,6 +294,8 @@ def _set_k_and_s_triton(
     index_k: torch.Tensor,
     index_k_scale: torch.Tensor,
     page_size: int,
+    owner_rank: int = 0,
+    owner_size: int = 1,
 ):
     """
     :param buf: (num_pages, page_size 64 * (128B data + 4B scale)), uint8
@@ -326,6 +342,7 @@ def _set_k_and_s_triton(
     assert loc.is_contiguous()
     assert index_k.is_contiguous()
     assert index_k_scale.is_contiguous()
+    assert 0 <= owner_rank < owner_size
 
     if _is_fp8_fnuz:
         buf_fp8 = buf.view(torch.float8_e4m3fnuz)
@@ -345,6 +362,8 @@ def _set_k_and_s_triton(
         NUM_K_ELEMS_PER_TOKEN=index_head_dim,
         S_OFFSET_NBYTES_IN_PAGE=page_size * index_head_dim,
         PRESHUFFLE_TILE=INDEXER_K_CACHE_PRESHUFFLE_TILE if _use_aiter_preshuffle else 0,
+        OWNER_RANK=owner_rank,
+        OWNER_SIZE=owner_size,
     )
 
 
@@ -361,6 +380,8 @@ def _set_k_and_s_triton_kernel(
     NUM_K_ELEMS_PER_TOKEN: tl.constexpr,
     S_OFFSET_NBYTES_IN_PAGE: tl.constexpr,
     PRESHUFFLE_TILE: tl.constexpr,
+    OWNER_RANK: tl.constexpr,
+    OWNER_SIZE: tl.constexpr,
 ):
     token_id = tl.program_id(0)
 
@@ -368,12 +389,13 @@ def _set_k_and_s_triton_kernel(
 
     in_k_offsets = token_id * index_k_ptr_stride_0 + tl.arange(0, NUM_K_ELEMS_PER_TOKEN)
 
-    # no need for `mask`, since we read 128B for k and 4B for scale, both pow of 2
-    k = tl.load(index_k_ptr + in_k_offsets)
-    k_scale = tl.load(index_k_scale_ptr + token_id)
-
     loc_page_index = loc // PAGE_SIZE
     loc_token_offset_in_page = loc % PAGE_SIZE
+    owned = (loc >= 0) & ((loc_page_index % OWNER_SIZE) == OWNER_RANK)
+    loc_page_index = loc_page_index // OWNER_SIZE
+
+    k = tl.load(index_k_ptr + in_k_offsets, mask=owned)
+    k_scale = tl.load(index_k_scale_ptr + token_id, mask=owned)
 
     k_range = tl.arange(0, NUM_K_ELEMS_PER_TOKEN)
     if PRESHUFFLE_TILE:
@@ -403,8 +425,8 @@ def _set_k_and_s_triton_kernel(
         + loc_token_offset_in_page
     )
 
-    tl.store(buf_fp8_ptr + out_k_offsets, k)
-    tl.store(buf_fp32_ptr + out_s_offset, k_scale)
+    tl.store(buf_fp8_ptr + out_k_offsets, k, mask=owned)
+    tl.store(buf_fp32_ptr + out_s_offset, k_scale, mask=owned)
 
 
 def _get_k_triton(
@@ -467,7 +489,7 @@ def _get_k_triton_kernel(
     token_offset_in_page = token_id % page_size
 
     # Load the page index from page_indices
-    page_index = tl.load(page_indices_ptr + page_idx)
+    page_index = tl.load(page_indices_ptr + page_idx).to(tl.int64)
 
     # Calculate source offset in buf
     # buf[page_index, token_offset_in_page * index_head_dim : ...]
@@ -544,7 +566,7 @@ def _get_s_triton_kernel(
     token_offset_in_page = token_id % page_size
 
     # Load the page index from page_indices
-    page_index = tl.load(page_indices_ptr + page_idx)
+    page_index = tl.load(page_indices_ptr + page_idx).to(tl.int64)
 
     # Calculate source offset in buf
     # Scales are stored after K data: page_size * index_head_dim offset
@@ -677,7 +699,7 @@ def _get_k_and_s_triton_kernel(
     page_index = tl.load(
         page_indices_ptr + page_idx + page_indices_base,
         mask=token_valid_mask & page_idx_valid_mask,
-    )
+    ).to(tl.int64)
 
     # ===== Load K data =====
     # The address calculation logic for K: page_index * total number of elements in a single page + K offset of the token within the page.

--- a/python/sglang/kernels/ops/attention/dsa/transform_index.py
+++ b/python/sglang/kernels/ops/attention/dsa/transform_index.py
@@ -14,6 +14,147 @@ def transform_index_page_table_decode(**kwargs):
     return transform_index_page_table_decode_fast(**kwargs)
 
 
+@triton.jit
+def translate_owner_sharded_slots_kernel(
+    slots_ptr: torch.Tensor,
+    result_ptr: torch.Tensor,
+    num_slots,
+    OWNER_CP_SIZE: tl.constexpr,
+    OWNER_PAGE_SIZE: tl.constexpr,
+    OWNER_PAGES_PER_RANK: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < num_slots
+    logical_slots = tl.load(slots_ptr + offsets, mask=mask, other=-1)
+    valid = logical_slots >= 0
+    safe_slots = tl.where(valid, logical_slots, 0)
+    logical_pages = safe_slots // OWNER_PAGE_SIZE
+    page_offsets = safe_slots % OWNER_PAGE_SIZE
+    owners = logical_pages % OWNER_CP_SIZE
+    owner_pages = logical_pages // OWNER_CP_SIZE
+    physical_pages = owners * OWNER_PAGES_PER_RANK + owner_pages
+    physical_slots = physical_pages * OWNER_PAGE_SIZE + page_offsets
+    tl.store(
+        result_ptr + offsets,
+        tl.where(valid, physical_slots, logical_slots),
+        mask=mask,
+    )
+
+
+@triton.jit
+def translate_owner_sharded_slots_with_current_kernel(
+    slots_ptr: torch.Tensor,
+    result_ptr: torch.Tensor,
+    current_row_locs_ptr: torch.Tensor,
+    num_slots,
+    OWNER_CP_SIZE: tl.constexpr,
+    OWNER_PAGE_SIZE: tl.constexpr,
+    OWNER_PAGES_PER_RANK: tl.constexpr,
+    CURRENT_ROWS_PER_REQUEST: tl.constexpr,
+    TOPK: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < num_slots
+    logical_slots = tl.load(slots_ptr + offsets, mask=mask, other=-1)
+    valid = logical_slots >= 0
+    safe_slots = tl.where(valid, logical_slots, 0)
+    logical_pages = safe_slots // OWNER_PAGE_SIZE
+    page_offsets = safe_slots % OWNER_PAGE_SIZE
+    owners = logical_pages % OWNER_CP_SIZE
+    owner_pages = logical_pages // OWNER_CP_SIZE
+    physical_pages = owners * OWNER_PAGES_PER_RANK + owner_pages
+    physical_slots = physical_pages * OWNER_PAGE_SIZE + page_offsets
+
+    current_row_markers = tl.full(offsets.shape, -1, tl.int32)
+    query_row = offsets // TOPK
+    current_row_position = query_row % CURRENT_ROWS_PER_REQUEST
+    current_row_begin = query_row - current_row_position
+    for current_row_slot in tl.static_range(0, 4):
+        if current_row_slot < CURRENT_ROWS_PER_REQUEST:
+            current_row_loc = tl.load(
+                current_row_locs_ptr + current_row_begin + current_row_slot,
+                mask=mask & (current_row_slot <= current_row_position),
+                other=-1,
+            )
+            is_current_row = valid & (logical_slots == current_row_loc)
+            current_row_markers = tl.where(
+                is_current_row, -2 - current_row_slot, current_row_markers
+            )
+    translated_slots = tl.where(
+        current_row_markers <= -2, current_row_markers, physical_slots
+    )
+    tl.store(
+        result_ptr + offsets,
+        tl.where(valid, translated_slots, logical_slots),
+        mask=mask,
+    )
+
+
+def translate_owner_sharded_slots(
+    slot_indices: torch.Tensor,
+    *,
+    owner_cp_size: int,
+    owner_page_size: int,
+    owner_pages_per_rank: int,
+    result: Optional[torch.Tensor] = None,
+    current_row_locs: Optional[torch.Tensor] = None,
+    current_rows_per_request: int = 0,
+) -> torch.Tensor:
+    """Translate logical slots to the rank-major Shared-KV VMM layout."""
+    assert slot_indices.dtype == torch.int32
+    assert slot_indices.is_contiguous()
+    assert owner_cp_size > 1
+    assert owner_page_size > 0
+    assert owner_pages_per_rank > 0
+    if result is None:
+        result = torch.empty_like(slot_indices)
+    else:
+        assert result.dtype == torch.int32
+        assert result.shape == slot_indices.shape
+        assert result.is_contiguous()
+    has_current_rows = current_row_locs is not None
+    if has_current_rows:
+        assert slot_indices.dim() == 2
+        assert current_row_locs is not None
+        assert current_row_locs.dtype in (torch.int32, torch.int64)
+        assert current_row_locs.is_contiguous()
+        assert current_row_locs.numel() == slot_indices.shape[0]
+        assert 1 <= current_rows_per_request <= 4
+        assert slot_indices.shape[0] % current_rows_per_request == 0
+    else:
+        assert current_rows_per_request == 0
+    if slot_indices.numel() == 0:
+        return result
+    block_size = 256
+    grid = (triton.cdiv(slot_indices.numel(), block_size),)
+    if has_current_rows:
+        translate_owner_sharded_slots_with_current_kernel[grid](
+            slot_indices,
+            result,
+            current_row_locs,
+            slot_indices.numel(),
+            OWNER_CP_SIZE=owner_cp_size,
+            OWNER_PAGE_SIZE=owner_page_size,
+            OWNER_PAGES_PER_RANK=owner_pages_per_rank,
+            CURRENT_ROWS_PER_REQUEST=current_rows_per_request,
+            TOPK=slot_indices.shape[1],
+            BLOCK_SIZE=block_size,
+        )
+    else:
+        translate_owner_sharded_slots_kernel[grid](
+            slot_indices,
+            result,
+            slot_indices.numel(),
+            OWNER_CP_SIZE=owner_cp_size,
+            OWNER_PAGE_SIZE=owner_page_size,
+            OWNER_PAGES_PER_RANK=owner_pages_per_rank,
+            BLOCK_SIZE=block_size,
+        )
+    return result
+
+
 def _allocate_prefill_result(
     topk_indices: torch.Tensor,
     real_num_tokens: int,
@@ -49,6 +190,9 @@ def transform_index_page_table_decode_kernel(
     result_ptr: torch.Tensor,
     page_size: tl.constexpr,
     page_table_row_stride: tl.constexpr,
+    OWNER_CP_SIZE: tl.constexpr,
+    OWNER_PAGE_SIZE: tl.constexpr,
+    OWNER_PAGES_PER_RANK: tl.constexpr,
 ):
     TOPK: tl.constexpr = 2048
     req_id = tl.program_id(0)
@@ -60,6 +204,13 @@ def transform_index_page_table_decode_kernel(
     loaded_topk_indices = tl.load(topk_indices_ptr + offset)
     mask = loaded_topk_indices >= 0
     loaded_kv_indices = tl.load(page_table_ptr + loaded_topk_indices, mask=mask)
+    if OWNER_CP_SIZE > 1:
+        logical_page = loaded_kv_indices // OWNER_PAGE_SIZE
+        page_offset = loaded_kv_indices % OWNER_PAGE_SIZE
+        owner_rank = logical_page % OWNER_CP_SIZE
+        owner_page = logical_page // OWNER_CP_SIZE
+        physical_page = owner_rank * OWNER_PAGES_PER_RANK + owner_page
+        loaded_kv_indices = physical_page * OWNER_PAGE_SIZE + page_offset
     tl.store(result_ptr + offset, loaded_kv_indices, mask=mask)
     tl.store(result_ptr + offset, -1, mask=~mask)
 
@@ -127,6 +278,9 @@ def transform_index_page_table_decode_fast(
     topk_indices: torch.Tensor,
     result: Optional[torch.Tensor] = None,
     page_size: int = 1,
+    owner_cp_size: int = 1,
+    owner_page_size: int = 1,
+    owner_pages_per_rank: int = 0,
 ) -> torch.Tensor:
     """
     Transform the page table according to topk indices for sparse topk attention.
@@ -140,6 +294,10 @@ def transform_index_page_table_decode_fast(
     assert page_size == 1
     assert page_table.shape[0] == topk_indices.shape[0]
     assert topk_indices.shape[1] == 2048
+    assert owner_cp_size >= 1
+    if owner_cp_size > 1:
+        assert owner_page_size > 0
+        assert owner_pages_per_rank > 0
     qo_len = topk_indices.shape[0]
     if result is None:
         result = torch.empty_like(topk_indices, dtype=torch.int32)
@@ -151,6 +309,9 @@ def transform_index_page_table_decode_fast(
         result,
         page_size,
         page_table_row_stride=page_table.stride(0),
+        OWNER_CP_SIZE=owner_cp_size,
+        OWNER_PAGE_SIZE=owner_page_size,
+        OWNER_PAGES_PER_RANK=owner_pages_per_rank,
     )
     return result
 

--- a/python/sglang/kernels/ops/attention/fused_store_index_cache.py
+++ b/python/sglang/kernels/ops/attention/fused_store_index_cache.py
@@ -71,6 +71,9 @@ def fused_store_index_k_cache(
     index_k_with_scale: torch.Tensor,
     out_cache_loc: torch.Tensor,
     page_size: int = 64,
+    *,
+    owner_rank: int = 0,
+    owner_size: int = 1,
 ) -> None:
     """
     Fused: quantize bf16 key (N,128) -> fp8 + fp32 scale and write into DSATokenToKVPool.index_k_with_scale_buffer.
@@ -82,6 +85,7 @@ def fused_store_index_k_cache(
     assert key.is_cuda
     assert index_k_with_scale.is_cuda
     assert out_cache_loc.is_cuda
+    assert 0 <= owner_rank < owner_size
 
     # 1) normalize shapes
     if key.dim() != 2:
@@ -102,4 +106,6 @@ def fused_store_index_k_cache(
         index_k_with_scale = index_k_with_scale.contiguous()
 
     module = _jit_dsa_fused_store_module(key.dtype, out_cache_loc.dtype, page_size)
-    module.fused_store_index_k_cache(key, index_k_with_scale, out_cache_loc)
+    module.fused_store_index_k_cache(
+        key, index_k_with_scale, out_cache_loc, owner_rank, owner_size
+    )

--- a/python/sglang/kernels/ops/kvcache/dsa_shared.py
+++ b/python/sglang/kernels/ops/kvcache/dsa_shared.py
@@ -1,0 +1,460 @@
+import torch
+import triton
+import triton.language as tl
+
+from sglang.srt.utils.custom_op import register_custom_op
+
+_INDEXER_MATERIALIZE_DENSE_MAX_BATCH = 7
+_INDEXER_MATERIALIZE_WORKERS_PER_REQUEST = 128
+
+
+def _materialize_indexer_pages_grid(
+    batch_size: int, pages_per_request: int
+) -> tuple[int]:
+    """Bound graph replay work by batch size, not maximum context width."""
+    if min(batch_size, pages_per_request) <= 0:
+        raise ValueError("Indexer materialize dimensions must be positive")
+    if batch_size <= _INDEXER_MATERIALIZE_DENSE_MAX_BATCH:
+        return (batch_size * pages_per_request,)
+    return (batch_size * _INDEXER_MATERIALIZE_WORKERS_PER_REQUEST,)
+
+
+def _validate_materialize_indexer_pages_dynamic(
+    source_pages: torch.Tensor,
+    target_pages: torch.Tensor,
+    seq_len: torch.Tensor,
+    *,
+    page_size: int,
+    source_page_capacity: int,
+    target_page_capacity: int,
+) -> None:
+    # The page tables and sequence lengths are graph-stable buffers whose
+    # values change on replay. Capturing these reductions would replay three
+    # validation chains per layer, so keep dynamic bounds checks at the eager
+    # boundary while retaining the geometry checks on every invocation.
+    if torch.cuda.is_available() and torch.cuda.is_current_stream_capturing():
+        return
+    torch._assert_async(
+        torch.all(seq_len <= source_pages.shape[1] * page_size),
+        "Indexer request exceeds the supplied page table",
+    )
+    torch._assert_async(
+        torch.all((source_pages < 0) | (source_pages < source_page_capacity)),
+        "Indexer source page exceeds shared VMM capacity",
+    )
+    torch._assert_async(
+        torch.all((target_pages < 0) | (target_pages < target_page_capacity)),
+        "Indexer target page exceeds Pool Demand Cache capacity",
+    )
+
+
+@triton.jit
+def materialize_indexer_pages_kernel(
+    target_ptr,
+    source_ptr,
+    source_pages_ptr,
+    target_pages_ptr,
+    seq_len_ptr,
+    tags_ptr,
+    epoch_ptr,
+    source_row_stride: tl.constexpr,
+    target_row_stride: tl.constexpr,
+    source_page_batch_stride: tl.constexpr,
+    source_page_stride: tl.constexpr,
+    target_page_batch_stride: tl.constexpr,
+    target_page_stride: tl.constexpr,
+    seq_len_stride: tl.constexpr,
+    pages_per_request: tl.constexpr,
+    page_size: tl.constexpr,
+    page_bytes: tl.constexpr,
+    USE_TAGS: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    table_entry = tl.program_id(0)
+    batch = table_entry // pages_per_request
+    request_page = table_entry - batch * pages_per_request
+    seq_len = tl.load(seq_len_ptr + batch * seq_len_stride).to(tl.int64)
+    active_pages = (seq_len + page_size - 1) // page_size
+    if request_page >= active_pages:
+        return
+    source_offset = batch * source_page_batch_stride + request_page * source_page_stride
+    target_offset = batch * target_page_batch_stride + request_page * target_page_stride
+    source_page = tl.load(source_pages_ptr + source_offset).to(tl.int64)
+    target_page = tl.load(target_pages_ptr + target_offset).to(tl.int64)
+    if source_page < 0 or target_page < 0:
+        return
+    expected_tag = source_page + 1
+    if USE_TAGS:
+        epoch = tl.load(epoch_ptr).to(tl.int64)
+        expected_tag = (epoch << 32) | expected_tag
+        observed_tag = tl.load(tags_ptr + target_page)
+        if request_page != active_pages - 1 and observed_tag == expected_tag:
+            return
+    for byte_begin in tl.static_range(0, page_bytes, BLOCK):
+        offsets = byte_begin + tl.arange(0, BLOCK)
+        mask = offsets < page_bytes
+        values = tl.load(
+            source_ptr + source_page * source_row_stride + offsets,
+            mask=mask,
+        )
+        tl.store(
+            target_ptr + target_page * target_row_stride + offsets,
+            values,
+            mask=mask,
+        )
+    if USE_TAGS:
+        tl.store(tags_ptr + target_page, expected_tag)
+
+
+@triton.jit
+def materialize_indexer_pages_worker_kernel(
+    target_ptr,
+    source_ptr,
+    source_pages_ptr,
+    target_pages_ptr,
+    seq_len_ptr,
+    tags_ptr,
+    epoch_ptr,
+    source_row_stride: tl.constexpr,
+    target_row_stride: tl.constexpr,
+    source_page_batch_stride: tl.constexpr,
+    source_page_stride: tl.constexpr,
+    target_page_batch_stride: tl.constexpr,
+    target_page_stride: tl.constexpr,
+    seq_len_stride: tl.constexpr,
+    page_size: tl.constexpr,
+    page_bytes: tl.constexpr,
+    USE_TAGS: tl.constexpr,
+    WORKERS_PER_REQUEST: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    worker_entry = tl.program_id(0)
+    batch = worker_entry // WORKERS_PER_REQUEST
+    worker = worker_entry - batch * WORKERS_PER_REQUEST
+    seq_len = tl.load(seq_len_ptr + batch * seq_len_stride).to(tl.int64)
+    active_pages = (seq_len + page_size - 1) // page_size
+    if USE_TAGS:
+        epoch = tl.load(epoch_ptr).to(tl.int64)
+    request_page = worker
+    while request_page < active_pages:
+        source_offset = (
+            batch * source_page_batch_stride + request_page * source_page_stride
+        )
+        target_offset = (
+            batch * target_page_batch_stride + request_page * target_page_stride
+        )
+        source_page = tl.load(source_pages_ptr + source_offset).to(tl.int64)
+        target_page = tl.load(target_pages_ptr + target_offset).to(tl.int64)
+        valid = (source_page >= 0) & (target_page >= 0)
+        expected_tag = source_page + 1
+        if USE_TAGS:
+            expected_tag = (epoch << 32) | expected_tag
+            observed_tag = tl.load(tags_ptr + target_page, mask=valid, other=0)
+            needs_copy = valid & (
+                (request_page == active_pages - 1) | (observed_tag != expected_tag)
+            )
+        else:
+            needs_copy = valid
+        for byte_begin in tl.static_range(0, page_bytes, BLOCK):
+            offsets = byte_begin + tl.arange(0, BLOCK)
+            mask = needs_copy & (offsets < page_bytes)
+            values = tl.load(
+                source_ptr + source_page * source_row_stride + offsets,
+                mask=mask,
+                other=0,
+            )
+            tl.store(
+                target_ptr + target_page * target_row_stride + offsets,
+                values,
+                mask=mask,
+            )
+        # tl.debug_barrier lowers to a CTA-wide PTX bar.sync. One CTA handles
+        # multiple pages, so keep all warps on the same page until its payload
+        # is complete, then publish the tag before the next page.
+        tl.debug_barrier()
+        if USE_TAGS:
+            tl.store(tags_ptr + target_page, expected_tag, mask=needs_copy)
+        tl.debug_barrier()
+        request_page += WORKERS_PER_REQUEST
+
+
+@register_custom_op(mutates_args=["target", "tags"])
+def materialize_indexer_pages_triton(
+    target: torch.Tensor,
+    source: torch.Tensor,
+    source_pages: torch.Tensor,
+    target_pages: torch.Tensor,
+    seq_len: torch.Tensor,
+    *,
+    page_size: int,
+    tags: torch.Tensor | None = None,
+    epoch: torch.Tensor | None = None,
+) -> None:
+    if target.dim() != 2 or source.dim() != 2:
+        raise ValueError("Indexer page buffers must be two-dimensional")
+    if target.shape[1] != source.shape[1]:
+        raise ValueError("Indexer source and target page widths must match")
+    if (
+        source_pages.dim() != 2
+        or target_pages.shape != source_pages.shape
+        or seq_len.dim() != 1
+        or source_pages.shape[0] != seq_len.shape[0]
+    ):
+        raise ValueError("Indexer Pool Demand Cache metadata has invalid geometry")
+    _validate_materialize_indexer_pages_dynamic(
+        source_pages,
+        target_pages,
+        seq_len,
+        page_size=page_size,
+        source_page_capacity=source.shape[0],
+        target_page_capacity=target.shape[0],
+    )
+    if (tags is None) != (epoch is None):
+        raise ValueError("Indexer Pool Demand Cache tags and epoch must be paired")
+    use_tags = tags is not None
+    if use_tags and (
+        tags.dtype != torch.int64
+        or tags.dim() != 1
+        or tags.shape[0] < target.shape[0]
+        or epoch.dtype != torch.int32
+        or epoch.numel() != 1
+    ):
+        raise ValueError("Indexer Pool Demand Cache metadata has invalid geometry")
+    tag_storage = tags if tags is not None else target
+    epoch_storage = epoch if epoch is not None else seq_len
+    common_args = (
+        target,
+        source,
+        source_pages,
+        target_pages,
+        seq_len,
+        tag_storage,
+        epoch_storage,
+        source.stride(0),
+        target.stride(0),
+        source_pages.stride(0),
+        source_pages.stride(1),
+        target_pages.stride(0),
+        target_pages.stride(1),
+        seq_len.stride(0),
+    )
+    grid = _materialize_indexer_pages_grid(source_pages.shape[0], source_pages.shape[1])
+    if source_pages.shape[0] <= _INDEXER_MATERIALIZE_DENSE_MAX_BATCH:
+        materialize_indexer_pages_kernel[grid](
+            *common_args,
+            source_pages.shape[1],
+            page_size,
+            target.shape[1],
+            USE_TAGS=use_tags,
+            BLOCK=1024,
+            num_warps=8,
+        )
+    else:
+        materialize_indexer_pages_worker_kernel[grid](
+            *common_args,
+            page_size,
+            target.shape[1],
+            USE_TAGS=use_tags,
+            WORKERS_PER_REQUEST=_INDEXER_MATERIALIZE_WORKERS_PER_REQUEST,
+            BLOCK=1024,
+            num_warps=4,
+        )
+
+
+@triton.jit
+def set_mla_kv_buffer_owner_kernel(
+    kv_buffer_ptr,
+    cache_k_nope_ptr,
+    cache_k_rope_ptr,
+    loc_ptr,
+    buffer_stride: tl.constexpr,
+    nope_stride: tl.constexpr,
+    rope_stride: tl.constexpr,
+    nope_dim: tl.constexpr,
+    rope_dim: tl.constexpr,
+    owner_rank: tl.constexpr,
+    owner_size: tl.constexpr,
+    page_size: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    pid_loc = tl.program_id(0)
+    offs = tl.arange(0, BLOCK)
+    total_dim = nope_dim + rope_dim
+
+    loc = tl.load(loc_ptr + pid_loc).to(tl.int64)
+    page = loc // page_size
+    page_offset = loc - page * page_size
+    owned = (loc >= 0) & ((page % owner_size) == owner_rank)
+    local_loc = (page // owner_size) * page_size + page_offset
+    mask = (offs < total_dim) & owned
+    dst_ptr = kv_buffer_ptr + local_loc * buffer_stride + offs
+
+    is_nope = offs < nope_dim
+    src_nope = tl.load(
+        cache_k_nope_ptr + pid_loc * nope_stride + offs,
+        mask=mask & is_nope,
+        other=0,
+    )
+    src_rope = tl.load(
+        cache_k_rope_ptr + pid_loc * rope_stride + (offs - nope_dim),
+        mask=mask & ~is_nope,
+        other=0,
+    )
+    src = tl.where(is_nope, src_nope, src_rope)
+    tl.store(dst_ptr, src, mask=mask)
+
+
+def set_mla_kv_buffer_owner_triton(
+    kv_buffer: torch.Tensor,
+    loc: torch.Tensor,
+    cache_k_nope: torch.Tensor,
+    cache_k_rope: torch.Tensor,
+    *,
+    owner_rank: int,
+    owner_size: int,
+    page_size: int,
+) -> None:
+    if loc.numel() == 0:
+        return
+    total_dim = cache_k_nope.shape[-1] + cache_k_rope.shape[-1]
+    set_mla_kv_buffer_owner_kernel[(loc.numel(),)](
+        kv_buffer,
+        cache_k_nope,
+        cache_k_rope,
+        loc,
+        kv_buffer.stride(0),
+        cache_k_nope.stride(0),
+        cache_k_rope.stride(0),
+        cache_k_nope.shape[-1],
+        cache_k_rope.shape[-1],
+        owner_rank,
+        owner_size,
+        page_size,
+        BLOCK=triton.next_power_of_2(total_dim),
+    )
+
+
+@triton.jit
+def set_mla_kv_buffer_owner_and_current_kernel(
+    kv_buffer_ptr,
+    encoded_rows_ptr,
+    physical_rows_ptr,
+    counts_ptr,
+    cache_k_nope_ptr,
+    cache_k_rope_ptr,
+    loc_ptr,
+    buffer_stride: tl.constexpr,
+    encoded_query_stride: tl.constexpr,
+    encoded_current_stride: tl.constexpr,
+    physical_query_stride: tl.constexpr,
+    nope_stride: tl.constexpr,
+    rope_stride: tl.constexpr,
+    nope_dim: tl.constexpr,
+    rope_dim: tl.constexpr,
+    rows_per_request: tl.constexpr,
+    max_current_rows: tl.constexpr,
+    owner_rank: tl.constexpr,
+    owner_size: tl.constexpr,
+    page_size: tl.constexpr,
+    pages_per_rank: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    query_row = tl.program_id(0)
+    current_row = tl.program_id(1)
+    offs = tl.arange(0, BLOCK)
+    total_dim = nope_dim + rope_dim
+
+    position = query_row % rows_per_request
+    count = position + 1
+    request_begin = query_row - position
+    source_row = request_begin + current_row
+    query_loc = tl.load(loc_ptr + query_row).to(tl.int64)
+    loc = tl.load(loc_ptr + source_row).to(tl.int64)
+    valid = (query_loc >= 0) & (current_row < count) & (loc >= 0)
+    page = loc // page_size
+    page_offset = loc - page * page_size
+    owner = page % owner_size
+    owner_page = page // owner_size
+    physical_row = (owner * pages_per_rank + owner_page) * page_size + page_offset
+    owned = valid & ((page % owner_size) == owner_rank)
+    local_loc = owner_page * page_size + page_offset
+    byte_mask = (offs < total_dim) & valid
+
+    is_nope = offs < nope_dim
+    src_nope = tl.load(
+        cache_k_nope_ptr + source_row * nope_stride + offs,
+        mask=byte_mask & is_nope,
+        other=0,
+    )
+    src_rope = tl.load(
+        cache_k_rope_ptr + source_row * rope_stride + (offs - nope_dim),
+        mask=byte_mask & ~is_nope,
+        other=0,
+    )
+    src = tl.where(is_nope, src_nope, src_rope)
+    tl.store(
+        encoded_rows_ptr
+        + query_row * encoded_query_stride
+        + current_row * encoded_current_stride
+        + offs,
+        src,
+        mask=byte_mask,
+    )
+    tl.store(
+        kv_buffer_ptr + local_loc * buffer_stride + offs,
+        src,
+        mask=(offs < total_dim) & owned & (current_row == position),
+    )
+    tl.store(
+        physical_rows_ptr + query_row * physical_query_stride + current_row,
+        tl.where(valid, physical_row, -1),
+    )
+    tl.store(
+        counts_ptr + query_row,
+        tl.where(query_loc >= 0, count, 0),
+        mask=current_row == 0,
+    )
+
+
+def set_mla_kv_buffer_owner_and_current_triton(
+    kv_buffer: torch.Tensor,
+    encoded_rows: torch.Tensor,
+    physical_rows: torch.Tensor,
+    counts: torch.Tensor,
+    loc: torch.Tensor,
+    cache_k_nope: torch.Tensor,
+    cache_k_rope: torch.Tensor,
+    *,
+    rows_per_request: int,
+    owner_rank: int,
+    owner_size: int,
+    page_size: int,
+    pages_per_rank: int,
+) -> None:
+    if loc.numel() == 0:
+        return
+    total_dim = cache_k_nope.shape[-1] + cache_k_rope.shape[-1]
+    set_mla_kv_buffer_owner_and_current_kernel[(loc.numel(), encoded_rows.shape[1])](
+        kv_buffer,
+        encoded_rows,
+        physical_rows,
+        counts,
+        cache_k_nope,
+        cache_k_rope,
+        loc,
+        kv_buffer.stride(0),
+        encoded_rows.stride(0),
+        encoded_rows.stride(1),
+        physical_rows.stride(0),
+        cache_k_nope.stride(0),
+        cache_k_rope.stride(0),
+        cache_k_nope.shape[-1],
+        cache_k_rope.shape[-1],
+        rows_per_request,
+        encoded_rows.shape[1],
+        owner_rank,
+        owner_size,
+        page_size,
+        pages_per_rank,
+        BLOCK=triton.next_power_of_2(total_dim),
+    )

--- a/python/sglang/kernels/ops/kvcache/shared_kv_publication.py
+++ b/python/sglang/kernels/ops/kvcache/shared_kv_publication.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from sglang.kernels.jit.utils import cache_once, load_jit, make_cpp_args
+
+if TYPE_CHECKING:
+    from tvm_ffi.module import Module
+
+
+def _validate_world_size(world_size: int) -> None:
+    if not 2 <= world_size <= 8:
+        raise ValueError(
+            f"Shared KV publication world_size must be in [2, 8], got {world_size}"
+        )
+
+
+@cache_once
+def _jit_shared_kv_publication_module(world_size: int) -> Module:
+    _validate_world_size(world_size)
+    args = make_cpp_args(world_size)
+    return load_jit(
+        "shared_kv_publication",
+        *args,
+        cuda_files=["shared_kv/publication.cuh"],
+        cuda_wrappers=[
+            ("publish", f"shared_kv_publish<{args}>"),
+            ("publish_status", f"shared_kv_publish_status<{args}>"),
+        ],
+    )
+
+
+def compile_shared_kv_publication(world_size: int) -> None:
+    _jit_shared_kv_publication_module(world_size)
+
+
+def shared_kv_publish(
+    flags: torch.Tensor,
+    peer_ptrs: torch.Tensor,
+    epoch: torch.Tensor,
+    rank: int,
+    world_size: int,
+) -> None:
+    _validate_world_size(world_size)
+    if not flags.is_cuda or flags.dtype != torch.int32 or not flags.is_contiguous():
+        raise ValueError("flags must be a contiguous CUDA int32 tensor")
+    if (
+        not peer_ptrs.is_cuda
+        or peer_ptrs.dtype != torch.int64
+        or not peer_ptrs.is_contiguous()
+        or peer_ptrs.numel() != world_size
+    ):
+        raise ValueError(
+            f"peer_ptrs must be a contiguous CUDA int64[{world_size}] tensor"
+        )
+    if (
+        not epoch.is_cuda
+        or epoch.dtype != torch.int32
+        or not epoch.is_contiguous()
+        or epoch.numel() != 1
+    ):
+        raise ValueError("epoch must be a contiguous CUDA int32[1] tensor")
+    if flags.device != peer_ptrs.device or flags.device != epoch.device:
+        raise ValueError("flags, peer_ptrs, and epoch must share one CUDA device")
+    if not 0 <= rank < world_size:
+        raise ValueError(f"rank must be in [0, {world_size}), got {rank}")
+    _jit_shared_kv_publication_module(world_size).publish(flags, peer_ptrs, epoch, rank)
+
+
+def shared_kv_publish_status(
+    flags: torch.Tensor,
+    peer_ptrs: torch.Tensor,
+    epoch: torch.Tensor,
+    result: torch.Tensor,
+    rank: int,
+    world_size: int,
+    local_success: bool,
+) -> None:
+    _validate_world_size(world_size)
+    if not flags.is_cuda or flags.dtype != torch.int32 or not flags.is_contiguous():
+        raise ValueError("flags must be a contiguous CUDA int32 tensor")
+    if (
+        not peer_ptrs.is_cuda
+        or peer_ptrs.dtype != torch.int64
+        or not peer_ptrs.is_contiguous()
+        or peer_ptrs.numel() != world_size
+    ):
+        raise ValueError(
+            f"peer_ptrs must be a contiguous CUDA int64[{world_size}] tensor"
+        )
+    for name, tensor in (("epoch", epoch), ("result", result)):
+        if (
+            not tensor.is_cuda
+            or tensor.dtype != torch.int32
+            or not tensor.is_contiguous()
+            or tensor.numel() != 1
+        ):
+            raise ValueError(f"{name} must be a contiguous CUDA int32[1] tensor")
+    if not (flags.device == peer_ptrs.device == epoch.device == result.device):
+        raise ValueError(
+            "flags, peer_ptrs, epoch, and result must share one CUDA device"
+        )
+    if not 0 <= rank < world_size:
+        raise ValueError(f"rank must be in [0, {world_size}), got {rank}")
+    _jit_shared_kv_publication_module(world_size).publish_status(
+        flags,
+        peer_ptrs,
+        epoch,
+        result,
+        rank,
+        local_success,
+    )

--- a/python/sglang/kernels/ops/quantization/dsv32/elementwise.py
+++ b/python/sglang/kernels/ops/quantization/dsv32/elementwise.py
@@ -72,11 +72,15 @@ def fused_k_indexer_norm_rope_store(
     cos_sin_cache: torch.Tensor,
     positions: torch.Tensor,
     page_size: int,
+    *,
+    owner_rank: int = 0,
+    owner_size: int = 1,
 ) -> None:
     """V3.2 indexer K + fused store: LayerNorm + RoPE on leading dims + fp8
     act-quant + paged index-k cache write, in one launch. CUDA only."""
     if not out_cache_loc.is_contiguous():
         out_cache_loc = out_cache_loc.contiguous()
+    assert 0 <= owner_rank < owner_size
     module = _jit_k_indexer_norm_rope_store_module(k_input.dtype, page_size)
     module.forward(
         k_input,
@@ -87,4 +91,6 @@ def fused_k_indexer_norm_rope_store(
         cos_sin_cache,
         positions,
         float(eps),
+        owner_rank,
+        owner_size,
     )

--- a/python/sglang/srt/cuda_vmm_utils.py
+++ b/python/sglang/srt/cuda_vmm_utils.py
@@ -546,7 +546,14 @@ def _recv_fd(sock):
     return int(src_rank), int(base_idx), int(fds[0])
 
 
-def export_shareable_handles(retained_handles, group: ProcessGroup, rank: int):
+def export_shareable_handles(
+    retained_handles,
+    group: ProcessGroup,
+    rank: int,
+    *,
+    try_fabric: bool = True,
+    log_fallback: bool = True,
+):
     """Export retained VMM handles, preferring FABRIC and falling back to POSIX fds.
 
     FABRIC is used only if every rank can export it; otherwise all ranks use POSIX
@@ -559,27 +566,29 @@ def export_shareable_handles(retained_handles, group: ProcessGroup, rank: int):
 
     fabric_handles: List[bytes] = []
     fabric_error: Optional[Exception] = None
-    try:
-        for alloc_h in retained_handles:
-            fabric_h = check_drv(
-                drv.cuMemExportToShareableHandle(alloc_h, FABRIC, 0),
-                "cuMemExportToShareableHandle(FABRIC)",
-            )
-            fabric_handles.append(bytes(fabric_h.data))
-        fabric_ok = True
-    except Exception as e:
-        fabric_error = e
-        fabric_ok = False
-        fabric_handles = []
-        logger.info(
-            "FABRIC handle export failed on rank %s; falling back to "
-            "POSIX fd transport: %s",
-            rank,
-            e,
-        )
+    if try_fabric:
+        try:
+            for alloc_h in retained_handles:
+                fabric_h = check_drv(
+                    drv.cuMemExportToShareableHandle(alloc_h, FABRIC, 0),
+                    "cuMemExportToShareableHandle(FABRIC)",
+                )
+                fabric_handles.append(bytes(fabric_h.data))
+            fabric_ok = True
+        except Exception as e:
+            fabric_error = e
+            fabric_ok = False
+            fabric_handles = []
+            if log_fallback:
+                logger.info(
+                    "FABRIC handle export failed on rank %s; falling back to "
+                    "POSIX fd transport: %s",
+                    rank,
+                    e,
+                )
 
-    if all_ranks_ok(group, fabric_ok):
-        return fabric_handles, [], True
+        if all_ranks_ok(group, fabric_ok):
+            return fabric_handles, [], True
 
     posix_fds: List[int] = []
     posix_error: Optional[Exception] = None
@@ -625,11 +634,10 @@ def exchange_posix_fds(
     socket. Returns ``{(src_rank, base_idx): fd}`` for every peer. The caller
     owns the received fds and must close them.
     """
-    sock_kind = socket.SOCK_SEQPACKET
-    sock_dir = tempfile.mkdtemp(prefix="sgl_ar_fd_")
-    sock_path = os.path.join(sock_dir, f"rank_{rank}.sock")
-    server = socket.socket(socket.AF_UNIX, sock_kind)
-    server.settimeout(_FD_SEND_TIMEOUT_S)
+    sock_kind = getattr(socket, "SOCK_SEQPACKET", socket.SOCK_STREAM)
+    sock_dir = None
+    sock_path = None
+    server = None
     received_fds = {}
     errors = []
 
@@ -653,13 +661,38 @@ def exchange_posix_fds(
             errors.append(e)
 
     try:
-        server.bind(sock_path)
-        server.listen(world_size)
+        setup_error = None
+        try:
+            sock_dir = tempfile.mkdtemp(prefix="sgl_ar_fd_")
+            sock_path = os.path.join(sock_dir, f"rank_{rank}.sock")
+            server = socket.socket(socket.AF_UNIX, sock_kind)
+            server.settimeout(_FD_SEND_TIMEOUT_S)
+            server.bind(sock_path)
+            server.listen(world_size)
+        except BaseException as e:
+            setup_error = e
+
+        setup_errors = [None] * world_size
+        dist.all_gather_object(
+            setup_errors,
+            None if setup_error is None else str(setup_error),
+            group=group,
+        )
+        for failed_rank, error in enumerate(setup_errors):
+            if error is not None:
+                message = (
+                    f"POSIX fd exchange setup failed on rank {failed_rank}: {error}"
+                )
+                if failed_rank == rank:
+                    raise RuntimeError(message) from setup_error
+                raise RuntimeError(message)
+
         paths = [None] * world_size
         dist.all_gather_object(paths, sock_path, group=group)
 
         thread = threading.Thread(target=recv_loop, daemon=True)
         thread.start()
+        transfer_error = None
         try:
             for peer_rank, peer_path in enumerate(paths):
                 if peer_rank == rank:
@@ -669,13 +702,15 @@ def exchange_posix_fds(
                     sock.connect(peer_path)
                     for base_idx, fd in enumerate(local_fds):
                         _send_fd(sock, fd, rank, base_idx)
+        except BaseException as e:
+            transfer_error = e
         finally:
             thread.join(_FD_SEND_TIMEOUT_S)
 
-        if thread.is_alive():
-            raise RuntimeError("timed out waiting for POSIX fd exchange")
-        if errors:
-            raise RuntimeError("POSIX fd exchange receive failed") from errors[0]
+        if transfer_error is None and thread.is_alive():
+            transfer_error = RuntimeError("timed out waiting for POSIX fd exchange")
+        if transfer_error is None and errors:
+            transfer_error = RuntimeError("POSIX fd exchange receive failed")
 
         expected = {
             (src_rank, base_idx)
@@ -685,24 +720,47 @@ def exchange_posix_fds(
         }
         missing = expected.difference(received_fds)
         extra = set(received_fds).difference(expected)
-        if missing or extra:
-            for fd in received_fds.values():
-                os.close(fd)
-            raise RuntimeError(
+        if transfer_error is None and (missing or extra):
+            transfer_error = RuntimeError(
                 "POSIX fd exchange mismatch: "
                 f"missing={sorted(missing)[:8]}, extra={sorted(extra)[:8]}"
             )
+
+        transfer_errors = [None] * world_size
+        dist.all_gather_object(
+            transfer_errors,
+            None if transfer_error is None else str(transfer_error),
+            group=group,
+        )
+        for failed_rank, error in enumerate(transfer_errors):
+            if error is None:
+                continue
+            for fd in received_fds.values():
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+            received_fds.clear()
+            message = (
+                f"POSIX fd exchange transfer failed on rank {failed_rank}: {error}"
+            )
+            if failed_rank == rank:
+                raise RuntimeError(message) from transfer_error
+            raise RuntimeError(message)
         return received_fds
     finally:
-        server.close()
-        try:
-            os.unlink(sock_path)
-        except FileNotFoundError:
-            pass
-        try:
-            os.rmdir(sock_dir)
-        except OSError:
-            pass
+        if server is not None:
+            server.close()
+        if sock_path is not None:
+            try:
+                os.unlink(sock_path)
+            except FileNotFoundError:
+                pass
+        if sock_dir is not None:
+            try:
+                os.rmdir(sock_dir)
+            except OSError:
+                pass
 
 
 def import_peer_handle(fabric_handle, fd, *, use_fabric: bool, peer_rank: int):

--- a/python/sglang/srt/layers/attention/dsa/dsa_backend_mtp_precompute.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_backend_mtp_precompute.py
@@ -52,6 +52,8 @@ class PrecomputedMetadata:
 
     # FlashMLA (optional)
     flashmla_metadata: Optional[torch.Tensor] = None
+    # Stable req_pool_idx aligned with every flattened FlashMLA Q row.
+    shared_cache_request_slots: Optional[torch.Tensor] = None
 
 
 def compute_cu_seqlens(seqlens: torch.Tensor) -> torch.Tensor:
@@ -182,6 +184,7 @@ class DeepseekSparseAttnBackendMTPPrecomputeMixin:
                 max_len=max_len,
                 max_seqlen_k=max_len,
                 flashmla_metadata=flashmla_metadata,
+                shared_cache_request_slots=req_pool_indices[:bs],
             )
 
         # Convert to int32 and compute cumsum
@@ -227,6 +230,7 @@ class DeepseekSparseAttnBackendMTPPrecomputeMixin:
             max_len=max_len,
             max_seqlen_k=max_len,
             flashmla_metadata=flashmla_metadata,
+            shared_cache_request_slots=req_pool_indices[:bs],
         )
 
     def _precompute_target_verify_mode(
@@ -314,6 +318,9 @@ class DeepseekSparseAttnBackendMTPPrecomputeMixin:
                 max_len=-1,
                 max_seqlen_k=max_seqlen_k,
                 flashmla_metadata=flashmla_metadata,
+                shared_cache_request_slots=req_pool_indices[:bs].repeat_interleave(
+                    self.speculative_num_draft_tokens
+                ),
             )
 
         # Cache seqlens with draft tokens
@@ -374,6 +381,9 @@ class DeepseekSparseAttnBackendMTPPrecomputeMixin:
             max_len=-1,  # Not used in this mode
             max_seqlen_k=max_seqlen_k,
             flashmla_metadata=flashmla_metadata,
+            shared_cache_request_slots=req_pool_indices[:bs].repeat_interleave(
+                self.speculative_num_draft_tokens
+            ),
         )
 
 

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -133,6 +133,31 @@ if TYPE_CHECKING:
 DUAL_STREAM_TOKEN_THRESHOLD = 1024 if _is_cuda else 0
 
 
+def _full_batch_indexer_cache_inputs(
+    source_block_tables: torch.Tensor,
+    target_block_tables: torch.Tensor,
+    seqlens: torch.Tensor,
+    *,
+    batch_size: int,
+    next_n: int,
+) -> Optional[tuple[torch.Tensor, torch.Tensor, torch.Tensor]]:
+    """De-expand EAGLE metadata without partitioning Indexer computation."""
+    if (
+        batch_size <= 0
+        or next_n <= 0
+        or source_block_tables.dim() != 2
+        or target_block_tables.shape != source_block_tables.shape
+        or source_block_tables.shape[0] != batch_size * next_n
+        or seqlens.numel() != batch_size * next_n
+    ):
+        return None
+    return (
+        source_block_tables[::next_n],
+        target_block_tables[::next_n],
+        seqlens.view(batch_size, next_n)[:, -1],
+    )
+
+
 if _is_cuda:
     from sglang.kernels.ops.attention.dsv4 import fused_q_indexer_rope_first_quant
     from sglang.kernels.ops.quantization.dsv32 import (
@@ -179,6 +204,36 @@ def _broadcast_indexer_topk_from_rank0(
     else:
         _broadcast_indexer_topk_from_rank0_impl(topk_indices)
     return topk_indices
+
+
+def _prepare_paged_index_page_table(pool, page_table: torch.Tensor) -> torch.Tensor:
+    prepare = getattr(pool, "prepare_paged_index_page_table", None)
+    return prepare(page_table) if prepare is not None else page_table
+
+
+def _get_index_cache_write_targets(
+    pool, layer_id: int
+) -> tuple[tuple[torch.Tensor, int, int], ...]:
+    get_targets = getattr(pool, "get_index_k_write_targets", None)
+    if get_targets is not None:
+        return get_targets(layer_id)
+    return (
+        (
+            pool.get_index_k_with_scale_buffer(layer_id=layer_id),
+            0,
+            1,
+        ),
+    )
+
+
+def _synchronize_shared_cache_writes(pool) -> None:
+    from sglang.srt.layers.attention.dsa.shared_cache_access import (
+        get_dsa_shared_cache_access,
+    )
+
+    shared_access = get_dsa_shared_cache_access(pool)
+    if shared_access is not None and shared_access.uses_shared_indexer:
+        shared_access.publish_writes()
 
 
 def rotate_activation(x: torch.Tensor) -> torch.Tensor:
@@ -603,17 +658,22 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             and out_cache_loc is not None
             and can_use_dsa_fused_store(torch.bfloat16, out_cache_loc.dtype, page_size)
         ):
-            fused_k_indexer_norm_rope_store(
-                key_raw,
-                pool.get_index_k_with_scale_buffer(layer_id=layer_id),
-                out_cache_loc,
-                self.k_norm.weight,
-                self.k_norm.bias,
-                self.k_norm.variance_epsilon,
-                self._indexer_cos_sin_cache,
-                positions,
-                page_size,
-            )
+            for buffer, owner_rank, owner_size in _get_index_cache_write_targets(
+                pool, layer_id
+            ):
+                fused_k_indexer_norm_rope_store(
+                    key_raw,
+                    buffer,
+                    out_cache_loc,
+                    self.k_norm.weight,
+                    self.k_norm.bias,
+                    self.k_norm.variance_epsilon,
+                    self._indexer_cos_sin_cache,
+                    positions,
+                    page_size,
+                    owner_rank=owner_rank,
+                    owner_size=owner_size,
+                )
             return
 
         # Fallback: separate K kernel + store kernel.
@@ -728,6 +788,8 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
 
     @staticmethod
     def _get_index_k_read_buffer(pool, layer_id: int) -> torch.Tensor:
+        if hasattr(pool, "get_paged_index_k_with_scale_buffer"):
+            return pool.get_paged_index_k_with_scale_buffer(layer_id)
         # Read path: prefer the owner-broadcast scratch buffer under DSA cache
         # layer split; fall back to the owned buffer for plain pools. Stores go
         # through get_index_k_with_scale_buffer() (owned buffer) instead.
@@ -809,10 +871,11 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         if _is_hip and not _use_aiter_preshuffle:
             block_tables = metadata.get_page_table_1()
         else:
-            block_tables = metadata.get_page_table_64()
-
-        max_seq_len = block_tables.shape[1] * page_size
-        kv_cache_fp8 = self._get_index_k_read_buffer(get_token_to_kv_pool(), layer_id)
+            block_tables = metadata.get_prepared_paged_index_page_table()
+            if block_tables is None:
+                block_tables = _prepare_paged_index_page_table(
+                    get_token_to_kv_pool(), metadata.get_page_table_64()
+                )
 
         blocksize = page_size
         if (
@@ -832,6 +895,39 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
 
         B = metadata.get_seqlens_int32().shape[0]
         next_n = q_offset // B if B > 0 else 0
+        pool = get_token_to_kv_pool()
+        from sglang.srt.layers.attention.dsa.shared_cache_access import (
+            get_dsa_shared_cache_access,
+        )
+
+        shared_access = get_dsa_shared_cache_access(pool)
+        cache_inputs = None
+        if (
+            shared_access is not None
+            and shared_access.uses_shared_indexer
+            and self.paged_mqa_logits_backend.is_deepgemm()
+            and (
+                forward_batch.forward_mode.is_decode_or_idle()
+                or forward_batch.forward_mode.is_target_verify()
+            )
+        ):
+            cache_inputs = _full_batch_indexer_cache_inputs(
+                block_tables,
+                metadata.get_page_table_64(),
+                seqlens_32,
+                batch_size=B,
+                next_n=next_n,
+            )
+        if cache_inputs is None:
+            kv_cache_fp8 = self._get_index_k_read_buffer(pool, layer_id)
+        else:
+            source_pages, target_pages, cache_lengths = cache_inputs
+            kv_cache_fp8, dense_pages = shared_access.materialize_indexer_pages(
+                layer_id, source_pages, target_pages, cache_lengths
+            )
+            block_tables = dense_pages.repeat_interleave(next_n, dim=0)
+
+        max_seq_len = block_tables.shape[1] * page_size
         use_cute_dsl = (
             self.paged_mqa_logits_backend.is_cutedsl()
             and not forward_batch.forward_mode.is_draft_extend_v2()
@@ -1490,13 +1586,17 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
             )
         ):
             # NOTE: wrapper already normalizes shape/contiguity and asserts dtypes.
-            buf = pool.get_index_k_with_scale_buffer(layer_id=layer_id)
-            fused_store_index_k_cache(
-                key,
-                buf,
-                out_cache_loc,
-                pool.page_size,
-            )
+            for buffer, owner_rank, owner_size in _get_index_cache_write_targets(
+                pool, layer_id
+            ):
+                fused_store_index_k_cache(
+                    key,
+                    buffer,
+                    out_cache_loc,
+                    pool.page_size,
+                    owner_rank=owner_rank,
+                    owner_size=owner_size,
+                )
             return
 
         # Fast path: AITER fused quant + cache store
@@ -1615,6 +1715,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                 metadata,
                 return_indices,
             )
+            _synchronize_shared_cache_writes(get_token_to_kv_pool())
             topk_result = _broadcast_indexer_topk_from_rank0(topk_result)
             return maybe_capture_indexer_topk(layer_id, topk_result)
 
@@ -1799,6 +1900,8 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                 weights = self._apply_q_scale_and_softmax_scale(weights, q_scale)
             else:
                 weights = self._get_logits_head_gate(x_for_gate, q_scale)
+
+        _synchronize_shared_cache_writes(get_token_to_kv_pool())
 
         if _is_cuda or _is_hip:
             # In piecewise/breakable CUDA graph, any access to seq_lens_cpu

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer_metadata.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer_metadata.py
@@ -32,6 +32,9 @@ class BaseIndexerMetadata(ABC):
                 The page size of the table is 64.
         """
 
+    def get_prepared_paged_index_page_table(self) -> Optional[torch.Tensor]:
+        return None
+
     @abstractmethod
     def get_page_table_1(self) -> torch.Tensor:
         """
@@ -103,6 +106,9 @@ class DSAIndexerMetadata(BaseIndexerMetadata):
 
     def get_page_table_64(self) -> torch.Tensor:
         return self.attn_metadata.real_page_table
+
+    def get_prepared_paged_index_page_table(self) -> Optional[torch.Tensor]:
+        return self.attn_metadata.prepared_paged_index_page_table
 
     def get_page_table_1(self) -> torch.Tensor:
         return self.attn_metadata.page_table_1

--- a/python/sglang/srt/layers/attention/dsa/dsa_prefill_cuda_graph.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_prefill_cuda_graph.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import torch
 
 from sglang.srt.compilation.compilation_config import register_split_op
-from sglang.srt.model_executor.forward_context import get_attn_backend
+from sglang.srt.model_executor.forward_context import (
+    get_attn_backend,
+    get_token_to_kv_pool,
+)
 from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph import (
     eager_on_graph,
 )
@@ -130,6 +133,11 @@ def pcg_dsa_indexer_prefill_split(
             num_tokens=extend_num_tokens,
             topk_result=topk_result,
         )
+        from sglang.srt.layers.attention.dsa.dsa_indexer import (
+            _synchronize_shared_cache_writes,
+        )
+
+        _synchronize_shared_cache_writes(get_token_to_kv_pool())
         return
 
     # Fused path stores K (no-Hadamard) and computes q_fp8 + head gate in the
@@ -146,6 +154,11 @@ def pcg_dsa_indexer_prefill_split(
             num_tokens=extend_num_tokens,
             enable_dual_stream=False,
         )
+        from sglang.srt.layers.attention.dsa.dsa_indexer import (
+            _synchronize_shared_cache_writes,
+        )
+
+        _synchronize_shared_cache_writes(get_token_to_kv_pool())
         indexer._get_topk_ragged(
             False,
             forward_batch,
@@ -177,6 +190,11 @@ def pcg_dsa_indexer_prefill_split(
         act_quant=act_quant,
         out_cache_loc=forward_batch.out_cache_loc[:extend_num_tokens],
     )
+    from sglang.srt.layers.attention.dsa.dsa_indexer import (
+        _synchronize_shared_cache_writes,
+    )
+
+    _synchronize_shared_cache_writes(get_token_to_kv_pool())
     indexer._get_topk_ragged(
         False,
         forward_batch,

--- a/python/sglang/srt/layers/attention/dsa/shared_cache_access.py
+++ b/python/sglang/srt/layers/attention/dsa/shared_cache_access.py
@@ -1,0 +1,67 @@
+"""DSA adapter for model-neutral owner-sharded Shared-KV primitives."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import torch
+
+
+class DSASharedCacheAccess:
+    """The sole attention-side entry point for DSA Shared-KV behavior.
+
+    Main KV and Indexer both use the Shared-KV Demand Cache architecture. Main
+    KV uses a Slot Demand Cache in FlashMLA; Indexer Decode uses a Pool Demand
+    Cache before its paged MQA consumer. The pool owns storage, while this
+    adapter keeps model/backend code independent of its VMM implementation.
+    """
+
+    def __init__(self, pool: Any) -> None:
+        self._pool = pool
+
+    def publish_writes(self) -> None:
+        self._pool.synchronize_shared_writes()
+
+    @property
+    def uses_shared_indexer(self) -> bool:
+        return bool(self._pool.share_indexer)
+
+    def main_owner_translation_args(self) -> dict[str, int]:
+        layout = self._pool.main_layout
+        if layout is None:
+            raise RuntimeError("DSA Shared Main-KV layout is not initialized")
+        return {
+            "owner_cp_size": layout.cp_size,
+            "owner_page_size": layout.page_size,
+            "owner_pages_per_rank": layout.pages_per_rank,
+        }
+
+    def translate_main_slots(self, slots: torch.Tensor) -> torch.Tensor:
+        return self._pool.translate_main_slots(slots)
+
+    def prepare_indexer_pages(self, pages: torch.Tensor) -> torch.Tensor:
+        return self._pool.prepare_paged_index_page_table(pages)
+
+    def materialize_indexer_pages(
+        self,
+        layer_id: int,
+        source_pages: torch.Tensor,
+        target_pages: torch.Tensor,
+        seq_lens: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Materialize one layer's VMM pages into token-pool page slots."""
+        return self._pool.materialize_index_pages(
+            layer_id, source_pages, target_pages, seq_lens
+        )
+
+    def invalidate_indexer_cache(self) -> None:
+        self._pool.invalidate_indexer_cache()
+
+
+def get_dsa_shared_cache_access(pool: Any) -> Optional[DSASharedCacheAccess]:
+    access = getattr(pool, "shared_cache_access", None)
+    if access is None:
+        return None
+    if not isinstance(access, DSASharedCacheAccess):
+        raise TypeError("invalid DSA Shared cache-access adapter")
+    return access

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -27,6 +27,7 @@ from sglang.kernels.ops.attention.dsa.quant_k_cache import quantize_k_cache
 from sglang.kernels.ops.attention.dsa.transform_index import (
     transform_index_page_table_decode,
     transform_index_page_table_prefill,
+    translate_owner_sharded_slots,
 )
 from sglang.kernels.ops.attention.utils import (
     concat_mla_absorb_q_general,
@@ -46,6 +47,9 @@ from sglang.srt.layers.attention.dsa.dsa_indexer_metadata import DSAIndexerMetad
 from sglang.srt.layers.attention.dsa.dsa_topk_backend import (
     DSATopKBackend,
     TopkTransformMethod,
+)
+from sglang.srt.layers.attention.dsa.shared_cache_access import (
+    get_dsa_shared_cache_access,
 )
 from sglang.srt.layers.attention.dsa.utils import (
     can_dsa_prefill_cp_round_robin_split,
@@ -67,6 +71,12 @@ from sglang.srt.layers.cp.utils import is_cp_v2_active
 from sglang.srt.layers.utils.cp_utils import (
     cp_all_gather_rerange_output,
     cp_split_and_rebuild_position,
+)
+from sglang.srt.mem_cache.dsa_shared_demand import (
+    DSAFlashMLADemandCacheManager,
+    SlotDemandCache,
+    _expand_flashmla_shared_cache_request_slots,
+    resolve_flashmla_shared_max_current_rows,
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.runtime_context import get_buffer
@@ -93,6 +103,56 @@ if TYPE_CHECKING:
     from sglang.srt.layers.radix_attention import RadixAttention
     from sglang.srt.model_executor.model_runner import ModelRunner
     from sglang.srt.speculative.spec_info import SpecInput
+
+
+def _translate_pool_main_page_table(
+    pool,
+    page_table: torch.Tensor,
+    *,
+    current_row_locs: Optional[torch.Tensor] = None,
+    current_rows_per_request: int = 0,
+) -> torch.Tensor:
+    shared_access = get_dsa_shared_cache_access(pool)
+    owner_translation_args = (
+        shared_access.main_owner_translation_args()
+        if shared_access is not None
+        else None
+    )
+    if owner_translation_args is not None:
+        return translate_owner_sharded_slots(
+            page_table,
+            result=torch.empty_like(page_table),
+            current_row_locs=current_row_locs,
+            current_rows_per_request=current_rows_per_request,
+            **owner_translation_args,
+        )
+    if current_row_locs is not None:
+        raise RuntimeError("Current-row markers require owner-sharded Main KV")
+    if shared_access is None:
+        return page_table
+    return shared_access.translate_main_slots(page_table).to(torch.int32)
+
+
+def _get_pool_main_owner_translation_args(pool) -> Optional[dict[str, int]]:
+    shared_access = get_dsa_shared_cache_access(pool)
+    if shared_access is None:
+        return None
+    return shared_access.main_owner_translation_args()
+
+
+def _prepare_pool_index_page_table(pool, page_table: torch.Tensor) -> torch.Tensor:
+    shared_access = get_dsa_shared_cache_access(pool)
+    return (
+        shared_access.prepare_indexer_pages(page_table)
+        if shared_access is not None
+        else page_table
+    )
+
+
+def _synchronize_pool_main_cache(pool) -> None:
+    shared_access = get_dsa_shared_cache_access(pool)
+    if shared_access is not None:
+        shared_access.publish_writes()
 
 
 def _all_gather_dsa_trtllm_fp8_kv(
@@ -131,6 +191,7 @@ def materialize_full_kv_cp(
 
 
 _is_hip = is_hip()
+
 
 if _is_hip:
     from sglang.kernels.ops.attention.dsa.triton_kernel import get_valid_kv_indices
@@ -221,6 +282,15 @@ class DSAMetadata:
     dsa_max_seqlen_q: Literal[1] = 1  # always 1 for decode, variable for extend
 
     flashmla_metadata: Optional[DSAFlashMLAMetadata] = None
+    # Stable req_pool_idx for every flattened FlashMLA Q row. Decode and EAGLE
+    # target verify use it to select a request-private Demand-cache slice.
+    shared_cache_request_slots: Optional[torch.Tensor] = None
+    # Shared-object Demand-cache current rows. ``locs`` stays in the logical
+    # scheduler slot namespace so the mandatory owner-translation kernel can
+    # replace exact causal matches with FlashMLA's -2..-5 shadow markers.
+    shared_mla_current_rows: Optional[object] = None
+    shared_mla_current_row_locs: Optional[torch.Tensor] = None
+    shared_mla_current_rows_per_request: int = 0
     # DeepGEMM schedule metadata for paged MQA logits (decode/target_verify/draft_extend only).
     # Precomputed once per forward batch and reused across layers.
     paged_mqa_schedule_metadata: Optional[torch.Tensor] = None
@@ -231,6 +301,9 @@ class DSAMetadata:
     # DeepSeek-V4 top-k v2 plan (cluster-threshold metadata) for the folded
     # decode top-k transform. None unless the SGL top-k v2 path is enabled.
     topk_v2_plan: Optional[torch.Tensor] = None
+    # Backend-ready page-size-64 indexer table. Shared KV translates this once
+    # per forward/replay and all indexer layers reuse the stable buffer.
+    prepared_paged_index_page_table: Optional[torch.Tensor] = None
     # The sum of sequence lengths for key, prefill only
     seq_lens_sum: Optional[int] = None
     # The flattened 1D page table with shape (seq_lens_sum,), prefill only
@@ -432,6 +505,45 @@ class DeepseekSparseAttnBackend(
                 "--dsa-decode-backend flashmla_kv."
             )
 
+        max_current_rows = resolve_flashmla_shared_max_current_rows(
+            self.speculative_num_draft_tokens
+        )
+        self._shared_main_demand_cache = DSAFlashMLADemandCacheManager.create(
+            pool=self.token_to_kv_pool,
+            device=self.device,
+            enable_prefill=(
+                not skip_prefill
+                and self.dsa_prefill_impl in ("flashmla_kv", "flashmla_auto")
+                and self.dsa_kv_cache_store_fp8
+                and self.device_sm_major == 9
+                and self.kv_cache_dim == 656
+            ),
+            enable_decode=self.dsa_decode_impl == "flashmla_kv",
+            enable_current_rows=(
+                max_current_rows <= 4
+                and callable(
+                    getattr(
+                        self.token_to_kv_pool,
+                        "set_mla_kv_buffer_with_current_rows",
+                        None,
+                    )
+                )
+            ),
+            num_layers=model_runner.model_config.num_hidden_layers,
+            num_request_slots=self.req_to_token_pool.size,
+            max_current_rows=max_current_rows,
+        )
+        if get_dsa_shared_cache_access(self.token_to_kv_pool) is not None:
+            from sglang.srt.mem_cache.dsa_cache_shared import (
+                log_shared_dsa_capacity_accounting,
+            )
+
+            log_shared_dsa_capacity_accounting(
+                self.token_to_kv_pool,
+                main_demand_workspace_bytes=(
+                    self._shared_main_demand_cache.allocated_bytes
+                ),
+            )
         # Q8KV8 per-call device-tensor caches, populated lazily on the first
         # Q8KV8 dispatch (no-ops for other backends).
         self._q8kv8_identity_scale: Optional[torch.Tensor] = None
@@ -513,6 +625,27 @@ class DeepseekSparseAttnBackend(
         else:
             self.workspace_buffer = None
             self._multi_ctas_kv_counter_buffer = None
+
+    def _use_shared_decode_current_rows(self, forward_mode: ForwardMode) -> bool:
+        return bool(
+            self._shared_main_demand_cache.current_rows_by_layer
+            and self.dsa_decode_impl == "flashmla_kv"
+            and self.dsa_kv_cache_store_fp8
+            and self.use_fused_topk
+            and (forward_mode.is_decode_or_idle() or forward_mode.is_target_verify())
+        )
+
+    def _shared_decode_current_rows_per_request(self, forward_mode: ForwardMode) -> int:
+        if not self._use_shared_decode_current_rows(forward_mode):
+            return 0
+        return self._shared_main_demand_cache.current_rows_per_request(
+            target_verify=forward_mode.is_target_verify(),
+            decode=forward_mode.is_decode_or_idle(),
+        )
+
+    def _publish_shared_decode_step(self, layer: RadixAttention) -> None:
+        if layer.layer_id == self.token_to_kv_pool.start_layer:
+            _synchronize_pool_main_cache(self.token_to_kv_pool)
 
     def _make_aiter_dsa_decode_metadata_buffer(
         self,
@@ -744,6 +877,56 @@ class DeepseekSparseAttnBackend(
             return metadata.page_table_1.shape[1]
         return self.req_to_token.shape[1]
 
+    def _advance_flashmla_shared_decode_generation(
+        self, forward_mode: ForwardMode
+    ) -> None:
+        if (
+            forward_mode.is_decode_or_idle()
+            or forward_mode.is_target_verify()
+            or forward_mode.is_draft_extend_v2()
+        ):
+            self._shared_main_demand_cache.advance_decode_generation()
+
+    def _refresh_flashmla_shared_decode_request_lifecycle(
+        self, forward_batch: ForwardBatch
+    ) -> None:
+        if forward_batch.forward_mode.is_extend_without_speculative():
+            shared_access = get_dsa_shared_cache_access(self.token_to_kv_pool)
+            if shared_access is not None:
+                shared_access.invalidate_indexer_cache()
+        if (
+            not self._shared_main_demand_cache.has_decode_cache
+            or not forward_batch.forward_mode.is_extend_without_speculative()
+        ):
+            return
+        request_slots = forward_batch.req_pool_indices_cpu
+        if request_slots is None:
+            # Correctness fallback for synthetic/custom ForwardBatch producers.
+            # Normal scheduling supplies the CPU mirror and avoids this sync.
+            request_slots = forward_batch.req_pool_indices.detach().to("cpu")
+        request_slots = request_slots.to(dtype=torch.int64).view(-1)
+        free_slots = getattr(self.req_to_token_pool, "free_slots", None)
+        if free_slots is None:
+            active_request_slots = request_slots
+        else:
+            free_slot_set = set(free_slots)
+            active_request_slots = torch.tensor(
+                [
+                    slot
+                    for slot in range(1, self.req_to_token_pool.size + 1)
+                    if slot not in free_slot_set
+                ],
+                dtype=torch.int64,
+                device="cpu",
+            )
+        request_generations = self.req_to_token_pool.req_generation[
+            active_request_slots
+        ]
+        self._shared_main_demand_cache.refresh_decode_requests(
+            active_request_slots=active_request_slots,
+            request_generations=request_generations,
+        )
+
     def _transform_table_1_to_real(self, page_table: torch.Tensor) -> torch.Tensor:
         page_size = self.real_page_size
         if page_size == 1:
@@ -759,6 +942,7 @@ class DeepseekSparseAttnBackend(
         forward_batch: ForwardBatch,
         in_capture: bool = False,
     ):
+        self._advance_flashmla_shared_decode_generation(forward_batch.forward_mode)
         seq_lens_cpu = (
             forward_batch.seq_lens.cpu() if in_capture else forward_batch.seq_lens_cpu
         )
@@ -775,6 +959,8 @@ class DeepseekSparseAttnBackend(
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         """Init the metadata for a forward pass."""
+        self._refresh_flashmla_shared_decode_request_lifecycle(forward_batch)
+        self._advance_flashmla_shared_decode_generation(forward_batch.forward_mode)
         batch_size = forward_batch.batch_size
         device = forward_batch.seq_lens.device
 
@@ -995,6 +1181,10 @@ class DeepseekSparseAttnBackend(
                         f"kv_cache_capacity={kv_cache_capacity}"
                     )
 
+                page_table_1_flattened = _translate_pool_main_page_table(
+                    self.token_to_kv_pool, page_table_1_flattened
+                )
+
             if topk_transform_method == TopkTransformMethod.RAGGED:
                 topk_indices_offset = torch.repeat_interleave(
                     cu_seqlens_k[:-1],
@@ -1037,6 +1227,46 @@ class DeepseekSparseAttnBackend(
                 paged_mqa_ctx_lens_2d, 64, deep_gemm.get_num_sms()
             )
 
+        real_page_table = self._transform_table_1_to_real(page_table)
+        prepared_paged_index_page_table = (
+            _prepare_pool_index_page_table(self.token_to_kv_pool, real_page_table)
+            if topk_transform_method == TopkTransformMethod.PAGED
+            else None
+        )
+        flashmla_metadata = (
+            self._compute_flashmla_metadata(
+                cache_seqlens=dsa_cache_seqlens_int32,
+                seq_len_q=1,
+            )
+            if use_flashmla_kv
+            else None
+        )
+        shared_cache_request_slots = None
+        if self._shared_main_demand_cache.has_decode_cache and (
+            forward_batch.forward_mode.is_decode_or_idle()
+            or forward_batch.forward_mode.is_target_verify()
+        ):
+            shared_cache_request_slots = _expand_flashmla_shared_cache_request_slots(
+                forward_batch.req_pool_indices,
+                num_query_rows=seqlens_expanded.shape[0],
+            )
+        shared_mla_current_rows = None
+        shared_mla_current_row_locs = None
+        shared_mla_current_rows_per_request = (
+            self._shared_decode_current_rows_per_request(forward_batch.forward_mode)
+        )
+        if shared_mla_current_rows_per_request:
+            shared_mla_current_rows = (
+                self._shared_main_demand_cache.current_rows_by_layer
+            )
+            shared_mla_current_row_locs = forward_batch.out_cache_loc[
+                : seqlens_expanded.shape[0]
+            ]
+            if shared_mla_current_row_locs.numel() != seqlens_expanded.shape[0]:
+                raise RuntimeError(
+                    "Shared MLA current-row locations do not cover query rows"
+                )
+
         metadata = DSAMetadata(
             page_size=self.real_page_size,
             cache_seqlens_int32=cache_seqlens_int32,
@@ -1047,14 +1277,11 @@ class DeepseekSparseAttnBackend(
             seq_lens_sum=forward_batch.seq_lens_sum,
             page_table_1=page_table,
             page_table_1_flattened=page_table_1_flattened,
-            flashmla_metadata=(
-                self._compute_flashmla_metadata(
-                    cache_seqlens=dsa_cache_seqlens_int32,
-                    seq_len_q=1,
-                )
-                if use_flashmla_kv
-                else None
-            ),
+            flashmla_metadata=flashmla_metadata,
+            shared_cache_request_slots=shared_cache_request_slots,
+            shared_mla_current_rows=shared_mla_current_rows,
+            shared_mla_current_row_locs=shared_mla_current_row_locs,
+            shared_mla_current_rows_per_request=(shared_mla_current_rows_per_request),
             paged_mqa_schedule_metadata=paged_mqa_schedule_metadata,
             paged_mqa_ctx_lens_2d=paged_mqa_ctx_lens_2d,
             dsa_cache_seqlens_int32=dsa_cache_seqlens_int32,
@@ -1062,7 +1289,8 @@ class DeepseekSparseAttnBackend(
             dsa_cu_seqlens_k=dsa_cu_seqlens_k,
             dsa_seqlens_expanded=seqlens_expanded,
             dsa_extend_seq_lens_list=extend_seq_lens_cpu,
-            real_page_table=self._transform_table_1_to_real(page_table),
+            real_page_table=real_page_table,
+            prepared_paged_index_page_table=prepared_paged_index_page_table,
             dsa_max_seqlen_q=1,
             topk_indices_offset=topk_indices_offset,
             indexer_k_start_end=indexer_k_start_end,
@@ -1365,6 +1593,9 @@ class DeepseekSparseAttnBackend(
             ]
         else:
             real_page_table = self._transform_table_1_to_real(page_table_1)
+        prepared_paged_index_page_table = _prepare_pool_index_page_table(
+            self.token_to_kv_pool, real_page_table
+        )
 
         paged_mqa_schedule_metadata = None
         paged_mqa_ctx_lens_2d = None
@@ -1380,6 +1611,28 @@ class DeepseekSparseAttnBackend(
                 paged_mqa_ctx_lens_2d, 64, deep_gemm.get_num_sms()
             )
 
+        shared_cache_request_slots = None
+        if self._shared_main_demand_cache.has_decode_cache and (
+            forward_mode.is_decode_or_idle() or forward_mode.is_target_verify()
+        ):
+            shared_cache_request_slots = _expand_flashmla_shared_cache_request_slots(
+                req_pool_indices[:bs], num_query_rows=real_rows
+            )
+        shared_mla_current_rows = None
+        shared_mla_current_row_locs = None
+        shared_mla_current_rows_per_request = (
+            self._shared_decode_current_rows_per_request(forward_mode)
+        )
+        if shared_mla_current_rows_per_request:
+            if out_cache_loc is None:
+                raise RuntimeError(
+                    "Shared MLA current rows require CUDA-graph out_cache_loc"
+                )
+            shared_mla_current_rows = (
+                self._shared_main_demand_cache.current_rows_by_layer
+            )
+            shared_mla_current_row_locs = out_cache_loc[:real_rows]
+
         metadata = DSAMetadata(
             page_size=self.real_page_size,
             cache_seqlens_int32=cache_seqlens_int32,
@@ -1389,6 +1642,10 @@ class DeepseekSparseAttnBackend(
             cu_seqlens_k=cu_seqlens_k,
             page_table_1=page_table_1,
             flashmla_metadata=flashmla_metadata,
+            shared_cache_request_slots=shared_cache_request_slots,
+            shared_mla_current_rows=shared_mla_current_rows,
+            shared_mla_current_row_locs=shared_mla_current_row_locs,
+            shared_mla_current_rows_per_request=(shared_mla_current_rows_per_request),
             paged_mqa_schedule_metadata=paged_mqa_schedule_metadata,
             paged_mqa_ctx_lens_2d=paged_mqa_ctx_lens_2d,
             dsa_cache_seqlens_int32=dsa_cache_seqlens_int32,
@@ -1396,6 +1653,7 @@ class DeepseekSparseAttnBackend(
             dsa_cu_seqlens_k=dsa_cu_seqlens_k,
             dsa_seqlens_expanded=seqlens_expanded,
             real_page_table=real_page_table,
+            prepared_paged_index_page_table=prepared_paged_index_page_table,
             dsa_extend_seq_lens_list=dsa_extend_seq_lens_list,
             topk_v2_plan=self._build_topk_v2_plan(seqlens_expanded),
         )
@@ -1685,6 +1943,28 @@ class DeepseekSparseAttnBackend(
             )
         # NOTE(dark): (dsa-) cu_seqlens_q is always arange, no need to copy
 
+        shared_cache_request_slots = metadata.shared_cache_request_slots
+        if shared_cache_request_slots is not None:
+            expanded_request_slots = _expand_flashmla_shared_cache_request_slots(
+                req_pool_indices, num_query_rows=seqlens_expanded_size
+            )
+            shared_cache_request_slots.copy_(expanded_request_slots)
+
+        shared_current_row_locs = metadata.shared_mla_current_row_locs
+        if shared_current_row_locs is not None:
+            if out_cache_loc is None:
+                raise RuntimeError(
+                    "Shared MLA current rows require replay out_cache_loc"
+                )
+            replay_rows = out_cache_loc.numel()
+            if replay_rows > seqlens_expanded_size:
+                raise RuntimeError(
+                    "Shared MLA replay locations exceed captured query rows: "
+                    f"locations={replay_rows} rows={seqlens_expanded_size}"
+                )
+            shared_current_row_locs[:replay_rows].copy_(out_cache_loc)
+            shared_current_row_locs[replay_rows:seqlens_expanded_size].zero_()
+
         assert self.real_page_size == metadata.page_size
         if self.real_page_size > 1:
             if not used_fused_metadata_generation:
@@ -1694,6 +1974,17 @@ class DeepseekSparseAttnBackend(
                 metadata.real_page_table[:new_rows, :new_cols].copy_(real_table)
         else:
             assert metadata.real_page_table is metadata.page_table_1
+
+        prepared_page_table = metadata.prepared_paged_index_page_table
+        if (
+            prepared_page_table is not None
+            and prepared_page_table is not metadata.real_page_table
+        ):
+            prepared_page_table.copy_(
+                _prepare_pool_index_page_table(
+                    self.token_to_kv_pool, metadata.real_page_table
+                )
+            )
 
         if self.dsa_decode_impl == "flashmla_kv":
             flashmla_metadata = metadata.flashmla_metadata.slice(
@@ -1847,6 +2138,15 @@ class DeepseekSparseAttnBackend(
                 flashmla_metadata = metadata.flashmla_metadata.slice(slice(0, size + 1))
                 flashmla_metadata.copy_(precomputed.flashmla_metadata)
 
+        shared_cache_request_slots = metadata.shared_cache_request_slots
+        if shared_cache_request_slots is not None:
+            source_request_slots = precomputed.shared_cache_request_slots
+            if source_request_slots is None:
+                raise ValueError(
+                    "request-scoped FlashMLA cache requires precomputed request slots"
+                )
+            shared_cache_request_slots.copy_(source_request_slots)
+
         # Refresh DeepGEMM paged MQA schedule metadata for the actual seqlens of
         # this replay (the captured graph holds stale data otherwise, which can
         # deadlock the kernel when the runtime work decomposition diverges from
@@ -1867,6 +2167,17 @@ class DeepseekSparseAttnBackend(
                 object.__setattr__(metadata, "paged_mqa_ctx_lens_2d", seqlens_32_2d)
             else:
                 metadata.paged_mqa_ctx_lens_2d.copy_(seqlens_32_2d)
+
+        prepared_page_table = metadata.prepared_paged_index_page_table
+        if (
+            prepared_page_table is not None
+            and prepared_page_table is not metadata.real_page_table
+        ):
+            prepared_page_table.copy_(
+                _prepare_pool_index_page_table(
+                    self.token_to_kv_pool, metadata.real_page_table
+                )
+            )
 
         self.forward_metadata = metadata
 
@@ -1891,14 +2202,26 @@ class DeepseekSparseAttnBackend(
         metadata = self.forward_metadata
         assert causal, "DSA is causal only"
 
+        is_persistent_decode_extend = (
+            forward_batch.forward_mode.is_target_verify()
+            or forward_batch.forward_mode.is_draft_extend_v2()
+        )
         dsa_impl = (
             self.dsa_decode_impl
-            if (
-                forward_batch.forward_mode.is_target_verify()
-                or forward_batch.forward_mode.is_draft_extend_v2()
-            )
+            if is_persistent_decode_extend
             else self.dsa_prefill_impl
         )
+        shared_current_rows_layer_idx = (
+            layer.layer_id - self.token_to_kv_pool.start_layer
+        )
+        shared_current_rows = (
+            metadata.shared_mla_current_rows[shared_current_rows_layer_idx]
+            if metadata.shared_mla_current_rows is not None
+            and save_kv_cache
+            and k is not None
+            else None
+        )
+        shared_current_rows_per_request = metadata.shared_mla_current_rows_per_request
 
         if dsa_impl == "trtllm" and not self.use_mha:
             return self._forward_trtllm(
@@ -1926,12 +2249,24 @@ class DeepseekSparseAttnBackend(
                     if not layer.is_cross_attention
                     else forward_batch.encoder_out_cache_loc
                 )
-                self.token_to_kv_pool.set_mla_kv_buffer(  # type: ignore
-                    layer,
-                    cache_loc,
-                    k,
-                    k_rope,
-                )
+                if shared_current_rows is not None:
+                    self.token_to_kv_pool.set_mla_kv_buffer_with_current_rows(  # type: ignore
+                        layer,
+                        cache_loc,
+                        k,
+                        k_rope,
+                        shared_current_rows,
+                        query_rows=k.shape[0],
+                        rows_per_request=shared_current_rows_per_request,
+                    )
+                    self._publish_shared_decode_step(layer)
+                else:
+                    self.token_to_kv_pool.set_mla_kv_buffer(  # type: ignore
+                        layer,
+                        cache_loc,
+                        k,
+                        k_rope,
+                    )
 
         # Use MHA kernel if in MHA_ONE_SHOT mode
         if self.use_mha:
@@ -2009,6 +2344,29 @@ class DeepseekSparseAttnBackend(
             page_table_1 = self.token_to_kv_pool.translate_loc_to_hisparse_device(
                 page_table_1
             ).to(torch.int32)
+        elif topk_transform_method != TopkTransformMethod.RAGGED:
+            page_table_1 = _translate_pool_main_page_table(
+                self.token_to_kv_pool,
+                page_table_1,
+                current_row_locs=(
+                    metadata.shared_mla_current_row_locs
+                    if shared_current_rows is not None
+                    else None
+                ),
+                current_rows_per_request=(
+                    shared_current_rows_per_request
+                    if shared_current_rows is not None
+                    else 0
+                ),
+            )
+
+        reads_main_cache = not (
+            dsa_impl == "flashmla_sparse"
+            and topk_transform_method == TopkTransformMethod.RAGGED
+            and not any(forward_batch.extend_prefix_lens_cpu)
+        )
+        if reads_main_cache and shared_current_rows is None:
+            _synchronize_pool_main_cache(self.token_to_kv_pool)
 
         if dsa_impl == "tilelang":
             if q_rope is not None:
@@ -2141,6 +2499,13 @@ class DeepseekSparseAttnBackend(
         elif dsa_impl == "flashmla_kv":
             if q_rope is not None:
                 q_all = concat_mla_absorb_q_general(q_nope, q_rope)
+            local_layer_id = layer.layer_id - self.token_to_kv_pool.start_layer
+            shared_demand_cache, persistent_shared_cache = (
+                self._shared_main_demand_cache.cache_for_layer(
+                    local_layer_id=local_layer_id,
+                    persistent=forward_batch.forward_mode.is_target_verify(),
+                )
+            )
             return self._forward_flashmla_kv(
                 q_all=q_all,
                 kv_cache=kv_cache,
@@ -2150,6 +2515,14 @@ class DeepseekSparseAttnBackend(
                 layer=layer,
                 metadata=metadata,
                 page_table_1=page_table_1,
+                shared_demand_cache=shared_demand_cache,
+                persistent=persistent_shared_cache,
+                shared_cache_request_slots=(
+                    metadata.shared_cache_request_slots
+                    if persistent_shared_cache
+                    else None
+                ),
+                shared_current_rows=shared_current_rows,
             )
         elif dsa_impl == "fa3":
             return self._forward_fa3(
@@ -2218,6 +2591,18 @@ class DeepseekSparseAttnBackend(
                 llama_4_scaling,
             )
 
+        shared_current_rows_layer_idx = (
+            layer.layer_id - self.token_to_kv_pool.start_layer
+        )
+        shared_current_rows = (
+            metadata.shared_mla_current_rows[shared_current_rows_layer_idx]
+            if metadata.shared_mla_current_rows is not None
+            and save_kv_cache
+            and k is not None
+            else None
+        )
+        shared_current_rows_per_request = metadata.shared_mla_current_rows_per_request
+
         if k is not None:
             assert v is not None
             if save_kv_cache:
@@ -2226,14 +2611,28 @@ class DeepseekSparseAttnBackend(
                     if not layer.is_cross_attention
                     else forward_batch.encoder_out_cache_loc
                 )
-                self.token_to_kv_pool.set_mla_kv_buffer(  # type: ignore
-                    layer,
-                    cache_loc,
-                    k,
-                    k_rope,
-                )
+                if shared_current_rows is not None:
+                    self.token_to_kv_pool.set_mla_kv_buffer_with_current_rows(  # type: ignore
+                        layer,
+                        cache_loc,
+                        k,
+                        k_rope,
+                        shared_current_rows,
+                        query_rows=k.shape[0],
+                        rows_per_request=shared_current_rows_per_request,
+                    )
+                    self._publish_shared_decode_step(layer)
+                else:
+                    self.token_to_kv_pool.set_mla_kv_buffer(  # type: ignore
+                        layer,
+                        cache_loc,
+                        k,
+                        k_rope,
+                    )
 
         # Do absorbed multi-latent attention
+        if shared_current_rows is None:
+            _synchronize_pool_main_cache(self.token_to_kv_pool)
         kv_cache = self.token_to_kv_pool.get_key_buffer(layer.layer_id)
         if q_rope is not None:
             q_nope = q.view(-1, layer.tp_q_head_num, layer.v_head_dim)
@@ -2265,10 +2664,30 @@ class DeepseekSparseAttnBackend(
         elif self.use_fused_topk:
             page_table_1 = self._get_fused_topk_page_table(topk_indices)
         else:
+            owner_translation_args = _get_pool_main_owner_translation_args(
+                self.token_to_kv_pool
+            )
             page_table_1 = transform_index_page_table_decode(
                 page_table=metadata.page_table_1,
                 topk_indices=topk_indices,
                 page_size=1,
+                **(owner_translation_args or {}),
+            )
+
+        if self.hisparse_coordinator is None and self.use_fused_topk:
+            page_table_1 = _translate_pool_main_page_table(
+                self.token_to_kv_pool,
+                page_table_1,
+                current_row_locs=(
+                    metadata.shared_mla_current_row_locs
+                    if shared_current_rows is not None
+                    else None
+                ),
+                current_rows_per_request=(
+                    shared_current_rows_per_request
+                    if shared_current_rows is not None
+                    else 0
+                ),
             )
 
         if self.dsa_decode_impl == "flashmla_sparse":
@@ -2296,6 +2715,31 @@ class DeepseekSparseAttnBackend(
         elif self.dsa_decode_impl == "flashmla_kv":
             if q_rope is not None:
                 q_all = concat_mla_absorb_q_general(q_nope, q_rope)
+            if self._shared_main_demand_cache.has_decode_cache:
+                local_layer_id = layer.layer_id - self.token_to_kv_pool.start_layer
+                selected_cache, persistent_shared_cache = (
+                    self._shared_main_demand_cache.cache_for_layer(
+                        local_layer_id=local_layer_id,
+                        persistent=True,
+                    )
+                )
+                return self._forward_flashmla_kv(
+                    q_all=q_all,
+                    kv_cache=kv_cache,
+                    sm_scale=layer.scaling,
+                    v_head_dim=layer.v_head_dim,
+                    layer=layer,
+                    metadata=metadata,
+                    page_table_1=page_table_1,
+                    shared_demand_cache=selected_cache,
+                    persistent=persistent_shared_cache,
+                    shared_cache_request_slots=(
+                        metadata.shared_cache_request_slots
+                        if persistent_shared_cache
+                        else None
+                    ),
+                    shared_current_rows=shared_current_rows,
+                )
             return self._forward_flashmla_kv(
                 q_all=q_all,
                 kv_cache=kv_cache,
@@ -2305,6 +2749,8 @@ class DeepseekSparseAttnBackend(
                 layer=layer,
                 metadata=metadata,
                 page_table_1=page_table_1,
+                shared_demand_cache=self._shared_main_demand_cache.prefill_cache,
+                shared_current_rows=shared_current_rows,
             )
         elif self.dsa_decode_impl == "tilelang":
             # Cat-skip (HIP-only): when caller passes q_rope=None on HIP, q_all
@@ -2800,15 +3246,25 @@ class DeepseekSparseAttnBackend(
         layer,
         metadata: DSAMetadata,
         page_table_1,
+        shared_demand_cache: Optional[SlotDemandCache] = None,
+        persistent: bool = False,
+        shared_cache_request_slots: Optional[torch.Tensor] = None,
+        shared_current_rows: Optional[object] = None,
     ) -> torch.Tensor:
         from sgl_kernel.flash_mla import flash_mla_with_kvcache
 
         cache_seqlens = metadata.dsa_cache_seqlens_int32
-        assert metadata.flashmla_metadata is not None
+        flashmla_metadata = metadata.flashmla_metadata
+        assert flashmla_metadata is not None
+
+        query_rows = q_all.shape[0]
+        if cache_seqlens.shape[0] != query_rows:
+            cache_seqlens = cache_seqlens[:query_rows]
+            flashmla_metadata = flashmla_metadata.slice(slice(0, query_rows + 1))
 
         # TODO the 2nd dim is seq_len_q, need to be >1 when MTP
-        q_all = q_all.view(-1, 1, layer.tp_q_head_num, layer.head_dim)
-        num_q_heads = q_all.shape[2]
+        num_q_heads = q_all.shape[-2]
+        q_all = q_all.view(-1, 1, num_q_heads, layer.head_dim)
         target_q_heads = self.flashmla_kv_num_q_heads
         if target_q_heads != num_q_heads:
             # Pad q heads to match FlashMLA decode supported head-count variants.
@@ -2819,8 +3275,9 @@ class DeepseekSparseAttnBackend(
         else:
             q_input = q_all
 
-        kv_cache = kv_cache.view(-1, self.real_page_size, 1, self.kv_cache_dim)
         assert self.real_page_size == 64, "only page size 64 is supported"
+
+        kv_cache = kv_cache.view(-1, self.real_page_size, 1, self.kv_cache_dim)
 
         if not self.dsa_kv_cache_store_fp8:
             # inefficiently quantize the whole cache
@@ -2831,13 +3288,28 @@ class DeepseekSparseAttnBackend(
             indices.shape[-1] == self.dsa_index_topk
         )  # requirement of FlashMLA decode kernel
 
+        shared_cache_kwargs = {}
+        if shared_demand_cache is not None:
+            shared_cache_kwargs = shared_demand_cache.next_call_kwargs(
+                persistent=persistent,
+                request_slots=shared_cache_request_slots,
+            )
+        if shared_current_rows is not None:
+            query_rows = q_input.shape[0]
+            shared_cache_kwargs.update(
+                shared_kv_current_rows=(shared_current_rows.encoded_rows[:query_rows]),
+                shared_kv_current_row_ids=(
+                    shared_current_rows.physical_rows[:query_rows]
+                ),
+                shared_kv_current_row_counts=(shared_current_rows.counts[:query_rows]),
+            )
         o, _ = flash_mla_with_kvcache(
             q=q_input,
             k_cache=kv_cache,
             cache_seqlens=cache_seqlens,
             head_dim_v=v_head_dim,
-            tile_scheduler_metadata=metadata.flashmla_metadata.flashmla_metadata,
-            num_splits=metadata.flashmla_metadata.num_splits,
+            tile_scheduler_metadata=flashmla_metadata.flashmla_metadata,
+            num_splits=flashmla_metadata.num_splits,
             softmax_scale=sm_scale,
             indices=indices,
             # doc says it is not used, but if pass in None then error
@@ -2845,6 +3317,7 @@ class DeepseekSparseAttnBackend(
                 (q_all.shape[0], 0), dtype=torch.int32, device=q_all.device
             ),
             is_fp8_kvcache=True,
+            **shared_cache_kwargs,
         )
 
         if target_q_heads != num_q_heads:

--- a/python/sglang/srt/layers/cp/utils.py
+++ b/python/sglang/srt/layers/cp/utils.py
@@ -84,6 +84,34 @@ def get_glm_dsa_cp_layer_shard_info(
     return get_parallel().attn_cp_rank, shard_size
 
 
+def is_glm_dsa_cache_shared_enabled(model_runner: "ModelRunner") -> bool:
+    from sglang.srt.configs.model_config import is_deepseek_dsa
+
+    return (
+        not model_runner.is_draft_worker
+        and model_runner.server_args.enable_dsa_shared_kv_cache
+        and model_runner.use_mla_backend
+        and is_deepseek_dsa(model_runner.model_config.hf_config)
+    )
+
+
+def is_glm_dsa_shared_indexer_enabled(model_runner: "ModelRunner") -> bool:
+    return is_glm_dsa_cache_shared_enabled(model_runner) and not bool(
+        getattr(model_runner.server_args, "disable_dsa_shared_indexer_cache", False)
+    )
+
+
+def get_glm_dsa_shared_info(
+    model_runner: "ModelRunner",
+) -> Tuple[Optional[int], int]:
+    if not is_glm_dsa_cache_shared_enabled(model_runner):
+        return None, 1
+    shared_size = get_parallel().attn_cp_size
+    if shared_size <= 1:
+        return None, 1
+    return get_parallel().attn_cp_rank, shared_size
+
+
 def get_glm_dsa_layer_split_effective_num_layers(
     model_runner: "ModelRunner", num_layers: int
 ) -> int:
@@ -100,6 +128,17 @@ def get_glm_dsa_layer_split_effective_num_layers(
         return num_layers
     owned_layers_upper_bound = (num_layers + shard_size - 1) // shard_size
     return max(1, owned_layers_upper_bound + 1)
+
+
+def get_glm_dsa_shared_effective_num_layers(
+    model_runner: "ModelRunner", num_layers: int
+) -> int:
+    if not is_glm_dsa_cache_shared_enabled(model_runner):
+        return num_layers
+    shard_size = get_parallel().attn_cp_size
+    if shard_size <= 1:
+        return num_layers
+    return max(1, (num_layers + shard_size - 1) // shard_size)
 
 
 def get_layer_shard_range(
@@ -335,8 +374,11 @@ __all__ = [
     "cp_split_before_forward",
     "prepare_cp_forward",
     "is_glm_dsa_cache_layer_split_enabled",
+    "is_glm_dsa_cache_shared_enabled",
     "get_glm_dsa_cp_layer_shard_info",
     "get_glm_dsa_layer_split_effective_num_layers",
+    "get_glm_dsa_shared_info",
+    "get_glm_dsa_shared_effective_num_layers",
     "get_layer_shard_range",
     "get_layer_owner",
 ]

--- a/python/sglang/srt/mem_cache/dsa_cache_shared.py
+++ b/python/sglang/srt/mem_cache/dsa_cache_shared.py
@@ -1,0 +1,848 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional
+
+import torch
+
+from sglang.kernels.ops.attention.dsa import index_buf_accessor
+from sglang.kernels.ops.attention.dsa.quant_k_cache import (
+    quantize_k_cache_separate,
+)
+from sglang.kernels.ops.kvcache.dsa_shared import (
+    materialize_indexer_pages_triton,
+    set_mla_kv_buffer_owner_and_current_triton,
+    set_mla_kv_buffer_owner_triton,
+)
+from sglang.srt.layers.attention.dsa.utils import (
+    INDEXER_K_CACHE_PRESHUFFLE_TILE,
+    aiter_can_use_preshuffle_paged_mqa,
+)
+from sglang.srt.mem_cache.index_key_cache import IndexKeyCache
+from sglang.srt.mem_cache.memory_pool import (
+    GPU_MEMORY_TYPE_KV_CACHE,
+    DSATokenToKVPool,
+    RadixAttention,
+    maybe_detect_oob,
+)
+from sglang.srt.mem_cache.shared_kv.demand_cache import PoolDemandCache
+from sglang.srt.mem_cache.shared_kv.family import (
+    OwnerShardedFamily,
+    OwnerShardedFamilySpec,
+)
+from sglang.srt.mem_cache.shared_kv.layout import OwnerShardedLayout
+from sglang.srt.mem_cache.shared_kv.synchronization import SharedWritePublisher
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from sglang.srt.mem_cache.dsa_shared_demand import SharedMLACurrentRows
+
+
+@dataclass(frozen=True)
+class SharedDSACapacityAccounting:
+    logical_tokens: int
+    logical_pages: int
+    cp_size: int
+    main_physical_token_slots_per_layer_per_rank: int
+    indexer_mode: str
+    indexer_physical_token_slots_per_layer_per_rank: int
+    authoritative_bytes_per_rank: int
+    indexer_demand_bytes_per_rank: int
+    main_demand_bytes_per_rank: int
+    tracked_total_bytes_per_rank: int
+
+
+def log_shared_dsa_capacity_accounting(
+    pool: SharedDSATokenToKVPool, *, main_demand_workspace_bytes: int
+) -> SharedDSACapacityAccounting:
+    """Log logical capacity beside the physical HBM charged to each CP rank."""
+    main = pool.main_family.accounting()
+    publication_bytes = pool.shared_write_publisher.mapped_bytes_per_rank
+    if pool.share_indexer:
+        indexer = pool.index_key_cache.family.accounting()
+        indexer_mode = "shared"
+        indexer_physical_token_slots = indexer.minimum_blocks_per_rank * pool.page_size
+        indexer_authoritative_bytes = indexer.mapped_bytes_per_rank
+        indexer_demand_bytes = pool.index_key_cache.pool_cache.allocated_bytes
+    else:
+        indexer_mode = "replicated"
+        indexer_physical_token_slots = (
+            pool.index_key_cache.buffer[0].shape[0] * pool.page_size
+        )
+        indexer_authoritative_bytes = sum(
+            buffer.nbytes for buffer in pool.index_key_cache.buffer
+        )
+        indexer_demand_bytes = 0
+
+    authoritative_bytes = (
+        main.mapped_bytes_per_rank + indexer_authoritative_bytes + publication_bytes
+    )
+    tracked_total_bytes = (
+        authoritative_bytes + indexer_demand_bytes + main_demand_workspace_bytes
+    )
+    accounting = SharedDSACapacityAccounting(
+        logical_tokens=pool.size,
+        logical_pages=(pool.size + pool.page_size - 1) // pool.page_size,
+        cp_size=pool.shared_size,
+        main_physical_token_slots_per_layer_per_rank=(
+            main.minimum_blocks_per_rank * pool.page_size
+        ),
+        indexer_mode=indexer_mode,
+        indexer_physical_token_slots_per_layer_per_rank=(indexer_physical_token_slots),
+        authoritative_bytes_per_rank=authoritative_bytes,
+        indexer_demand_bytes_per_rank=indexer_demand_bytes,
+        main_demand_bytes_per_rank=main_demand_workspace_bytes,
+        tracked_total_bytes_per_rank=tracked_total_bytes,
+    )
+    logger.info(
+        "Shared DSA capacity ledger: logical_tokens=%s logical_pages=%s "
+        "cp_size=%s main_physical_token_slots_per_layer_per_rank=%s "
+        "indexer_mode=%s indexer_physical_token_slots_per_layer_per_rank=%s "
+        "authoritative_bytes_per_rank=%s "
+        "indexer_demand_bytes_per_rank=%s main_demand_bytes_per_rank=%s "
+        "tracked_total_bytes_per_rank=%s",
+        accounting.logical_tokens,
+        accounting.logical_pages,
+        accounting.cp_size,
+        accounting.main_physical_token_slots_per_layer_per_rank,
+        accounting.indexer_mode,
+        accounting.indexer_physical_token_slots_per_layer_per_rank,
+        accounting.authoritative_bytes_per_rank,
+        accounting.indexer_demand_bytes_per_rank,
+        accounting.main_demand_bytes_per_rank,
+        accounting.tracked_total_bytes_per_rank,
+    )
+    return accounting
+
+
+def gather_shared_index_rows(
+    pool: SharedDSATokenToKVPool,
+    buffer: torch.Tensor,
+    loc: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Gather packed Indexer rows from Shared-KV's page-major storage."""
+    loc = loc.view(-1).long()
+    page_size = pool.page_size
+    head_dim = pool.index_head_dim
+    scale_bytes = head_dim // pool.quant_block_size * 4
+    bytes_per_page = page_size * (head_dim + scale_bytes)
+    pages = torch.div(loc, page_size, rounding_mode="floor")
+    tokens = loc.remainder(page_size)
+    columns = torch.arange(head_dim, device=loc.device, dtype=torch.int64)
+    if aiter_can_use_preshuffle_paged_mqa():
+        tile = INDEXER_K_CACHE_PRESHUFFLE_TILE
+        k_offsets = (
+            pages[:, None] * bytes_per_page
+            + torch.div(tokens, tile, rounding_mode="floor")[:, None]
+            * (tile * head_dim)
+            + torch.div(columns, tile, rounding_mode="floor")[None, :] * (tile * tile)
+            + tokens.remainder(tile)[:, None] * tile
+            + columns.remainder(tile)[None, :]
+        )
+    else:
+        k_offsets = (
+            pages[:, None] * bytes_per_page
+            + tokens[:, None] * head_dim
+            + columns[None, :]
+        )
+    scale_columns = torch.arange(scale_bytes, device=loc.device, dtype=torch.int64)
+    scale_offsets = (
+        pages[:, None] * bytes_per_page
+        + page_size * head_dim
+        + tokens[:, None] * scale_bytes
+        + scale_columns[None, :]
+    )
+    flat = buffer.view(-1)
+    return flat[k_offsets], flat[scale_offsets]
+
+
+def indexer_pool_cache_shape(
+    index_buf_size: int,
+    page_size: int,
+    page_bytes: int,
+) -> tuple[int, int]:
+    if index_buf_size < 0 or min(page_size, page_bytes) <= 0:
+        raise ValueError("Indexer Pool Demand Cache dimensions must be positive")
+    logical_pages = (index_buf_size + page_size + 1) // page_size
+    return logical_pages, page_bytes
+
+
+@dataclass(frozen=True)
+class SharedDSAPageLayout:
+    owner_layout: OwnerShardedLayout
+    local_pages_per_layer: Optional[int] = None
+
+    @property
+    def cp_size(self) -> int:
+        return self.owner_layout.cp_size
+
+    @property
+    def page_size(self) -> int:
+        return self.owner_layout.ownership_granule
+
+    @property
+    def pages_per_rank(self) -> int:
+        return self.owner_layout.blocks_per_rank
+
+    def translate_slots(self, slot_indices: torch.Tensor) -> torch.Tensor:
+        return self.owner_layout.physical_rows(slot_indices)
+
+    def translate_local_slots(self, slot_indices: torch.Tensor) -> torch.Tensor:
+        return self.owner_layout.owner_local_rows(slot_indices)
+
+    def owned_slot_mask(
+        self, slot_indices: torch.Tensor, *, owner_rank: int
+    ) -> torch.Tensor:
+        return self.owner_layout.owned_row_mask(slot_indices, rank=owner_rank)
+
+
+class SharedIndexKeyCache:
+    """Page-owner-sharded Indexer K/scale storage exposed as one global VMM."""
+
+    def __init__(self, pool: SharedDSATokenToKVPool, index_buf_size: int):
+        self.pool = pool
+        logical_pages = (index_buf_size + pool.page_size + 1) // pool.page_size
+        requested_pages = (logical_pages + pool.shared_size - 1) // pool.shared_size
+        page_bytes = pool.page_size * (
+            pool.index_head_dim + pool.index_head_dim // pool.quant_block_size * 4
+        )
+        self.family = OwnerShardedFamily.create(
+            spec=OwnerShardedFamilySpec(
+                name="dsa_indexer_k",
+                num_layers=pool.layer_num,
+                logical_rows_per_layer=requested_pages * pool.shared_size,
+                ownership_granule=1,
+                storage_rows_per_granule=1,
+                row_shape=(page_bytes,),
+                dtype=pool.index_k_with_scale_buffer_dtype,
+                # DeepGEMM validates that the base pointer belongs to the
+                # process's current CUDA device. Put this rank's physical
+                # segment first and translate page IDs into rank-relative order.
+                map_rank_local=True,
+            ),
+            cp_size=pool.shared_size,
+            cpu_group=pool._get_cp_group().cpu_group,
+            zero_initialize=False,
+        )
+        self.layout = self.family.layout
+        self.buffer = self.family.slab.rank_local_views
+        self.local_buffer = self.family.slab.local_views
+        cache_shape = indexer_pool_cache_shape(
+            index_buf_size,
+            pool.page_size,
+            page_bytes,
+        )
+        with pool.memory_saver_adapter.region(GPU_MEMORY_TYPE_KV_CACHE):
+            self.pool_cache = PoolDemandCache.create(
+                keys=pool.indexer_cache_layer_ids,
+                entries_per_key=cache_shape[0],
+                entry_bytes=cache_shape[1],
+                dtype=pool.index_k_with_scale_buffer_dtype,
+                device=pool.device,
+            )
+
+    def clear(self) -> None:
+        self.buffer = []
+        self.local_buffer = []
+        self.pool_cache.clear()
+        self.family.close()
+
+    def get_global_buffer(self, layer_id: int) -> torch.Tensor:
+        return self.buffer[layer_id - self.pool.start_layer]
+
+    def get_local_buffer(self, layer_id: int) -> torch.Tensor:
+        return self.local_buffer[layer_id - self.pool.start_layer]
+
+    def materialize_pages(
+        self,
+        layer_id: int,
+        source_pages: torch.Tensor,
+        target_pages: torch.Tensor,
+        seq_len: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        source = self.get_global_buffer(layer_id)
+        cache_buffer, cache_tags = self.pool_cache.storage_for(layer_id)
+        materialize_indexer_pages_triton(
+            cache_buffer,
+            source,
+            source_pages,
+            target_pages,
+            seq_len,
+            page_size=self.pool.page_size,
+            tags=cache_tags,
+            epoch=self.pool_cache.epoch_tensor,
+        )
+        return cache_buffer, target_pages
+
+    def invalidate_cache(self) -> None:
+        self.pool_cache.invalidate()
+
+    def snapshot_move(
+        self, tgt_loc: torch.Tensor, src_loc: torch.Tensor
+    ) -> tuple[torch.Tensor, list[tuple[torch.Tensor, torch.Tensor]]]:
+        owned = self.pool.index_layout.owned_row_mask(
+            torch.div(tgt_loc, self.pool.page_size, rounding_mode="floor"),
+            rank=self.pool.shared_rank,
+        )
+        owned_targets = tgt_loc[owned]
+        global_sources = self.pool.translate_index_slots(src_loc[owned])
+        snapshots = [
+            gather_shared_index_rows(self.pool, buffer, global_sources)
+            for buffer in self.buffer
+        ]
+        return owned_targets, snapshots
+
+    def restore_move(
+        self,
+        owned_targets: torch.Tensor,
+        snapshots: list[tuple[torch.Tensor, torch.Tensor]],
+    ) -> None:
+        for buffer, (k_bytes, scale_bytes) in zip(self.local_buffer, snapshots):
+            index_buf_accessor.SetKAndS.execute(
+                pool=self.pool,
+                buf=buffer,
+                loc=owned_targets,
+                index_k=k_bytes.view(torch.float8_e4m3fn),
+                index_k_scale=scale_bytes.view(torch.float32),
+                owner_rank=self.pool.shared_rank,
+                owner_size=self.pool.shared_size,
+            )
+
+    def cpu_copy(self, indices: torch.Tensor):
+        """Copy logical Indexer pages through the rank-relative VMM view."""
+        page_indices = torch.unique(
+            torch.div(indices, self.pool.page_size, rounding_mode="floor"),
+            sorted=True,
+        )
+        translated_pages = self.pool.translate_index_pages(page_indices)
+        page_chunk_size = max(
+            1, self.pool.cpu_offloading_chunk_size // self.pool.page_size
+        )
+        torch.cuda.synchronize()
+        index_k_cpu = []
+        for buffer in self.buffer:
+            layer_copy = []
+            for i in range(0, len(translated_pages), page_chunk_size):
+                layer_copy.append(
+                    buffer[translated_pages[i : i + page_chunk_size]].to(
+                        "cpu", non_blocking=True
+                    )
+                )
+            index_k_cpu.append(layer_copy)
+        torch.cuda.synchronize()
+        return index_k_cpu
+
+    def load_cpu_copy(self, index_k_cpu, indices: torch.Tensor) -> None:
+        """Restore only the Indexer pages physically owned by this rank."""
+        page_indices = torch.unique(
+            torch.div(indices, self.pool.page_size, rounding_mode="floor"),
+            sorted=True,
+        )
+        page_chunk_size = max(
+            1, self.pool.cpu_offloading_chunk_size // self.pool.page_size
+        )
+        torch.cuda.synchronize()
+        for layer_id, local_buffer in enumerate(self.local_buffer):
+            for i in range(0, len(page_indices), page_chunk_size):
+                chunk_pages = page_indices[i : i + page_chunk_size]
+                owned = self.layout.owned_row_mask(
+                    chunk_pages, rank=self.pool.shared_rank
+                )
+                if not bool(owned.any().item()):
+                    continue
+                local_pages = self.layout.owner_local_rows(chunk_pages[owned])
+                cpu_chunk = index_k_cpu[layer_id][i // page_chunk_size]
+                local_buffer[local_pages] = cpu_chunk[owned.cpu()].to(
+                    local_buffer.device, non_blocking=True
+                )
+        torch.cuda.synchronize()
+
+    def state_buf_infos(self):
+        data_ptrs = [buf.data_ptr() for buf in self.local_buffer]
+        data_lens = [buf.nbytes for buf in self.local_buffer]
+        item_lens = [buf[0].nbytes for buf in self.local_buffer]
+        return data_ptrs, data_lens, item_lens
+
+
+class ReplicatedIndexKeyCache(IndexKeyCache):
+    """Full local Indexer storage used with owner-sharded Main KV."""
+
+    def snapshot_move(
+        self, tgt_loc: torch.Tensor, src_loc: torch.Tensor
+    ) -> tuple[torch.Tensor, list[tuple[torch.Tensor, torch.Tensor]]]:
+        snapshots = [
+            gather_shared_index_rows(self.pool, buffer, src_loc)
+            for buffer in self.buffer
+        ]
+        return tgt_loc, snapshots
+
+    def restore_move(
+        self,
+        targets: torch.Tensor,
+        snapshots: list[tuple[torch.Tensor, torch.Tensor]],
+    ) -> None:
+        for buffer, (k_bytes, scale_bytes) in zip(self.buffer, snapshots):
+            index_buf_accessor.SetKAndS.execute(
+                pool=self.pool,
+                buf=buffer,
+                loc=targets,
+                index_k=k_bytes.view(torch.float8_e4m3fn),
+                index_k_scale=scale_bytes.view(torch.float32),
+            )
+
+
+class SharedDSATokenToKVPool(DSATokenToKVPool):
+    def __init__(
+        self,
+        *args,
+        shared_rank: int,
+        shared_size: int,
+        indexer_cache_layer_ids: tuple[int, ...],
+        share_indexer: bool = True,
+        **kwargs,
+    ):
+        assert shared_size > 1
+        self.shared_rank = shared_rank
+        self.shared_size = shared_size
+        self.share_indexer = share_indexer
+        self.indexer_cache_layer_ids = indexer_cache_layer_ids
+        self.shared_cp_group = None
+        self.main_layout: Optional[SharedDSAPageLayout] = None
+        self.main_family: Optional[OwnerShardedFamily] = None
+        self.index_layout: Optional[OwnerShardedLayout] = None
+        self.local_kv_buffer: list[torch.Tensor] = []
+        self.shared_write_publisher: Optional[SharedWritePublisher] = None
+        self.shared_cache_access = None
+        super().__init__(*args, **kwargs)
+        from sglang.srt.layers.attention.dsa.shared_cache_access import (
+            DSASharedCacheAccess,
+        )
+
+        self.shared_cache_access = DSASharedCacheAccess(self)
+
+    def _get_cp_group(self):
+        if self.shared_cp_group is None:
+            from sglang.srt.runtime_context import get_parallel
+
+            self.shared_cp_group = get_parallel().attn_cp_group
+        return self.shared_cp_group
+
+    def _create_buffers(self) -> None:
+        logical_pages = (self.size + 2 * self.page_size - 1) // self.page_size
+        requested_pages = (logical_pages + self.shared_size - 1) // self.shared_size + 1
+        with self.memory_saver_adapter.region(GPU_MEMORY_TYPE_KV_CACHE):
+            self.main_family = OwnerShardedFamily.create(
+                spec=OwnerShardedFamilySpec(
+                    name="dsa_main_kv",
+                    num_layers=self.layer_num,
+                    logical_rows_per_layer=(
+                        requested_pages * self.shared_size * self.page_size
+                    ),
+                    ownership_granule=self.page_size,
+                    storage_rows_per_granule=self.page_size,
+                    row_shape=(1, self.kv_cache_dim),
+                    dtype=self.store_dtype,
+                    map_rank_local=False,
+                ),
+                cp_size=self.shared_size,
+                cpu_group=self._get_cp_group().cpu_group,
+                zero_initialize=False,
+            )
+        self.kv_buffer = self.main_family.slab.global_views
+        self.local_kv_buffer = self.main_family.slab.local_views
+        self.main_layout = SharedDSAPageLayout(
+            self.main_family.layout,
+            local_pages_per_layer=requested_pages,
+        )
+        self.shared_write_publisher = SharedWritePublisher(self._get_cp_group())
+        logger.info(
+            "DSA shared Main KV: rank=%s size=%s pages_per_layer=%s "
+            "rank_stride_pages=%s",
+            self.shared_rank,
+            self.shared_size,
+            requested_pages,
+            self.main_layout.pages_per_rank,
+        )
+
+    def _create_index_key_cache(self) -> SharedIndexKeyCache | ReplicatedIndexKeyCache:
+        if not getattr(self, "share_indexer", True):
+            logger.info("DSA shared Main KV with replicated Indexer")
+            return ReplicatedIndexKeyCache(self, self.index_buf_size)
+        cache = SharedIndexKeyCache(self, self.index_buf_size)
+        self.index_layout = cache.layout
+        logger.info(
+            "DSA shared Indexer: rank=%s size=%s pages_per_layer=%s "
+            "rank_stride_pages=%s",
+            self.shared_rank,
+            self.shared_size,
+            cache.layout.minimum_blocks_per_rank,
+            cache.layout.blocks_per_rank,
+        )
+        return cache
+
+    def _clear_buffers(self) -> None:
+        publisher = self.shared_write_publisher
+        main_family = self.main_family
+        index_key_cache = getattr(self, "index_key_cache", None)
+        self.kv_buffer = []
+        self.local_kv_buffer = []
+        self.shared_write_publisher = None
+        self.main_family = None
+        self.index_layout = None
+        self.index_key_cache = None
+        self.shared_cache_access = None
+        if publisher is not None:
+            publisher.close()
+        if main_family is not None:
+            main_family.close()
+        if index_key_cache is not None:
+            index_key_cache.clear()
+
+    def translate_index_pages(self, page_indices: torch.Tensor) -> torch.Tensor:
+        if not getattr(self, "share_indexer", True):
+            return page_indices
+        assert self.index_layout is not None
+        return self.index_layout.rank_relative_rows(page_indices, rank=self.shared_rank)
+
+    def translate_index_slots(self, slot_indices: torch.Tensor) -> torch.Tensor:
+        if not getattr(self, "share_indexer", True):
+            return slot_indices
+        assert self.index_layout is not None
+        pages = torch.div(slot_indices, self.page_size, rounding_mode="floor")
+        offsets = slot_indices.remainder(self.page_size)
+        return torch.where(
+            slot_indices >= 0,
+            self.index_layout.rank_relative_rows(pages, rank=self.shared_rank)
+            * self.page_size
+            + offsets,
+            slot_indices,
+        )
+
+    def prepare_paged_index_page_table(self, page_table: torch.Tensor) -> torch.Tensor:
+        if not getattr(self, "share_indexer", True):
+            return page_table
+        assert self.index_layout is not None
+        return self.index_layout.rank_relative_rows(
+            page_table, rank=self.shared_rank
+        ).to(torch.int32)
+
+    def translate_main_slots(self, slot_indices: torch.Tensor) -> torch.Tensor:
+        assert self.main_layout is not None
+        return self.main_layout.translate_slots(slot_indices)
+
+    def synchronize_shared_writes(self) -> None:
+        assert self.shared_write_publisher is not None
+        self.shared_write_publisher.publish()
+
+    def synchronize_shared_status(self, local_success: bool) -> bool:
+        assert self.shared_write_publisher is not None
+        return self.shared_write_publisher.publish_status(local_success)
+
+    def get_cpu_copy(self, indices, mamba_indices=None):
+        """Copy logical Main and Indexer rows through their shared views."""
+        del mamba_indices
+        self.synchronize_shared_writes()
+        translated = self.translate_main_slots(indices)
+        chunk_size = self.cpu_offloading_chunk_size
+        torch.cuda.synchronize()
+        kv_cache_cpu = []
+        for buffer in self.kv_buffer:
+            layer_copy = []
+            for i in range(0, len(translated), chunk_size):
+                layer_copy.append(
+                    buffer[translated[i : i + chunk_size]].to("cpu", non_blocking=True)
+                )
+            kv_cache_cpu.append(layer_copy)
+        torch.cuda.synchronize()
+        return {
+            "kv": kv_cache_cpu,
+            "index_k": self.index_key_cache.cpu_copy(indices),
+        }
+
+    def load_cpu_copy(self, kv_cache_cpu_dict, indices, mamba_indices=None):
+        """Restore owner-local rows, then publish them to peer VMM readers."""
+        del mamba_indices
+        assert self.main_layout is not None
+        chunk_size = self.cpu_offloading_chunk_size
+        torch.cuda.synchronize()
+        for layer_id, local_buffer in enumerate(self.local_kv_buffer):
+            for i in range(0, len(indices), chunk_size):
+                chunk_indices = indices[i : i + chunk_size]
+                owned = self.main_layout.owned_slot_mask(
+                    chunk_indices, owner_rank=self.shared_rank
+                )
+                if not bool(owned.any().item()):
+                    continue
+                local_rows = self.main_layout.translate_local_slots(
+                    chunk_indices[owned]
+                )
+                cpu_chunk = kv_cache_cpu_dict["kv"][layer_id][i // chunk_size]
+                local_buffer[local_rows] = cpu_chunk[owned.cpu()].to(
+                    local_buffer.device, non_blocking=True
+                )
+        self.index_key_cache.load_cpu_copy(kv_cache_cpu_dict["index_k"], indices)
+        self.synchronize_shared_writes()
+
+    def get_kv_size_bytes(self) -> int:
+        assert self.main_family is not None
+        assert self.shared_write_publisher is not None
+        if not getattr(self, "share_indexer", True):
+            return (
+                self.main_family.accounting().mapped_bytes_per_rank
+                + sum(buffer.nbytes for buffer in self.index_key_cache.buffer)
+                + self.shared_write_publisher.mapped_bytes_per_rank
+            )
+        return (
+            self.main_family.accounting().mapped_bytes_per_rank
+            + self.index_key_cache.family.accounting().mapped_bytes_per_rank
+            + self.index_key_cache.pool_cache.allocated_bytes
+            + self.shared_write_publisher.mapped_bytes_per_rank
+        )
+
+    def get_value_buffer(self, layer_id: int) -> torch.Tensor:
+        return self.get_key_buffer(layer_id)[..., : self.kv_lora_rank]
+
+    def _write_owned_mla_kv_buffer(
+        self,
+        kv_buffer: torch.Tensor,
+        loc: torch.Tensor,
+        cache_k_nope: torch.Tensor,
+        cache_k_rope: torch.Tensor,
+    ) -> None:
+        set_mla_kv_buffer_owner_triton(
+            kv_buffer,
+            loc,
+            cache_k_nope,
+            cache_k_rope,
+            owner_rank=self.shared_rank,
+            owner_size=self.shared_size,
+            page_size=self.page_size,
+        )
+
+    def set_mla_kv_buffer(
+        self,
+        layer: RadixAttention,
+        loc: torch.Tensor,
+        cache_k_nope: torch.Tensor,
+        cache_k_rope: torch.Tensor,
+    ) -> None:
+        maybe_detect_oob(
+            loc, 0, self.size + self.page_size, "set_mla_kv_buffer (DSA shared)"
+        )
+        self._write_mla_kv_buffer(
+            self.local_kv_buffer[layer.layer_id - self.start_layer],
+            loc,
+            cache_k_nope,
+            cache_k_rope,
+            write_fn=self._write_owned_mla_kv_buffer,
+        )
+
+    def set_mla_kv_buffer_with_current_rows(
+        self,
+        layer: RadixAttention,
+        loc: torch.Tensor,
+        cache_k_nope: torch.Tensor,
+        cache_k_rope: torch.Tensor,
+        current_rows: SharedMLACurrentRows,
+        *,
+        query_rows: int,
+        rows_per_request: int,
+    ) -> None:
+        if not self.dsa_kv_cache_store_fp8:
+            raise ValueError("Shared MLA current rows require scaled-FP8 Main KV")
+        if query_rows != loc.numel():
+            raise ValueError(
+                "Shared MLA current-row query count must match locations: "
+                f"query_rows={query_rows} locs={loc.numel()}"
+            )
+        expected_nope_shape = (query_rows, 1, 512)
+        expected_rope_shape = (query_rows, 1, 64)
+        if tuple(cache_k_nope.shape) != expected_nope_shape:
+            raise ValueError(
+                "Shared MLA current-row NoPE shape must be "
+                f"{expected_nope_shape}, got {tuple(cache_k_nope.shape)}"
+            )
+        if tuple(cache_k_rope.shape) != expected_rope_shape:
+            raise ValueError(
+                "Shared MLA current-row RoPE shape must be "
+                f"{expected_rope_shape}, got {tuple(cache_k_rope.shape)}"
+            )
+        if rows_per_request <= 0 or query_rows % rows_per_request:
+            raise ValueError(
+                "Shared MLA current rows require complete request groups: "
+                f"query_rows={query_rows} rows_per_request={rows_per_request}"
+            )
+        if query_rows > current_rows.encoded_rows.shape[0]:
+            raise ValueError("Shared MLA current-row query capacity exceeded")
+        if rows_per_request > current_rows.encoded_rows.shape[1]:
+            raise ValueError("Shared MLA per-request row capacity exceeded")
+        assert self.main_layout is not None
+
+        maybe_detect_oob(
+            loc,
+            0,
+            self.size + self.page_size,
+            "set_mla_kv_buffer_with_current_rows (DSA shared)",
+        )
+        cache_k_nope_fp8, cache_k_rope_fp8 = quantize_k_cache_separate(
+            cache_k_nope, cache_k_rope
+        )
+        set_mla_kv_buffer_owner_and_current_triton(
+            self.local_kv_buffer[layer.layer_id - self.start_layer],
+            current_rows.encoded_rows,
+            current_rows.physical_rows,
+            current_rows.counts,
+            loc,
+            cache_k_nope_fp8,
+            cache_k_rope_fp8,
+            rows_per_request=rows_per_request,
+            owner_rank=self.shared_rank,
+            owner_size=self.shared_size,
+            page_size=self.page_size,
+            pages_per_rank=self.main_layout.pages_per_rank,
+        )
+
+    def move_kv_cache(self, tgt_loc: torch.Tensor, src_loc: torch.Tensor) -> None:
+        size_limit = self.size + self.page_size
+        maybe_detect_oob(tgt_loc, 0, size_limit, "move_kv_cache tgt_loc")
+        maybe_detect_oob(src_loc, 0, size_limit, "move_kv_cache src_loc")
+        if tgt_loc.numel() == 0:
+            return
+        assert self.main_layout is not None
+        owned = self.main_layout.owned_slot_mask(tgt_loc, owner_rank=self.shared_rank)
+        local_targets = self.main_layout.translate_local_slots(tgt_loc[owned])
+        shared_sources = self.main_layout.translate_slots(src_loc[owned])
+        main_snapshots = [
+            shared_kv[shared_sources].clone() for shared_kv in self.kv_buffer
+        ]
+        index_targets, index_snapshots = self.index_key_cache.snapshot_move(
+            tgt_loc, src_loc
+        )
+
+        # EAGLE compaction can form a cross-owner swap or chain. Every rank must
+        # finish reading its remote sources before any owner overwrites a target
+        # that is another rank's source.
+        self.synchronize_shared_writes()
+
+        for local_kv, snapshot in zip(self.local_kv_buffer, main_snapshots):
+            local_kv[local_targets] = snapshot
+        self.index_key_cache.restore_move(index_targets, index_snapshots)
+
+        # Accepted-token relocation writes each destination only on its owner.
+        # Publish the completed Main-K and Indexer copies before a peer reads them.
+        self.synchronize_shared_writes()
+
+    def get_index_k_write_targets(
+        self, layer_id: int
+    ) -> tuple[tuple[torch.Tensor, int, int], ...]:
+        if not getattr(self, "share_indexer", True):
+            return ((self.index_key_cache.get_local_buffer(layer_id), 0, 1),)
+        return (
+            (
+                self.index_key_cache.get_local_buffer(layer_id),
+                self.shared_rank,
+                self.shared_size,
+            ),
+        )
+
+    def get_index_k_with_scale_buffer(self, layer_id: int) -> torch.Tensor:
+        return self.index_key_cache.get_local_buffer(layer_id)
+
+    def get_paged_index_k_with_scale_buffer(self, layer_id: int) -> torch.Tensor:
+        if not getattr(self, "share_indexer", True):
+            return self.index_key_cache.get_local_buffer(layer_id)
+        return self.index_key_cache.get_global_buffer(layer_id)
+
+    def materialize_index_pages(
+        self,
+        layer_id: int,
+        source_pages: torch.Tensor,
+        target_pages: torch.Tensor,
+        seq_len: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if not getattr(self, "share_indexer", True):
+            raise RuntimeError("Indexer Page Demand requires Shared Indexer storage")
+        return self.index_key_cache.materialize_pages(
+            layer_id, source_pages, target_pages, seq_len
+        )
+
+    def invalidate_indexer_cache(self) -> None:
+        if getattr(self, "share_indexer", True):
+            self.index_key_cache.invalidate_cache()
+
+    def get_index_k_continuous(
+        self, layer_id: int, seq_len: int, page_indices: torch.Tensor
+    ):
+        buffer = self.get_paged_index_k_with_scale_buffer(layer_id)
+        return index_buf_accessor.GetK.execute(
+            self,
+            buffer,
+            seq_len=seq_len,
+            page_indices=self.translate_index_pages(page_indices),
+        )
+
+    def get_index_k_scale_continuous(
+        self, layer_id: int, seq_len: int, page_indices: torch.Tensor
+    ):
+        buffer = self.get_paged_index_k_with_scale_buffer(layer_id)
+        return index_buf_accessor.GetS.execute(
+            self,
+            buffer,
+            seq_len=seq_len,
+            page_indices=self.translate_index_pages(page_indices),
+        )
+
+    def get_index_k_scale_buffer(
+        self,
+        layer_id: int,
+        seq_len_tensor: torch.Tensor,
+        page_indices: torch.Tensor,
+        seq_len_sum: int,
+        max_seq_len: int,
+    ):
+        buffer = self.get_paged_index_k_with_scale_buffer(layer_id)
+        return index_buf_accessor.GetKAndS.execute(
+            self,
+            buffer,
+            page_indices=self.translate_index_pages(page_indices),
+            seq_len_tensor=seq_len_tensor,
+            seq_len_sum=seq_len_sum,
+            max_seq_len=max_seq_len,
+        )
+
+    def set_index_k_scale_buffer(
+        self,
+        layer_id: int,
+        loc: torch.Tensor,
+        index_k: torch.Tensor,
+        index_k_scale: torch.Tensor,
+    ) -> None:
+        owner_rank = self.shared_rank if self.share_indexer else 0
+        owner_size = self.shared_size if self.share_indexer else 1
+        index_buf_accessor.SetKAndS.execute(
+            pool=self,
+            buf=self.index_key_cache.get_local_buffer(layer_id),
+            loc=loc,
+            index_k=index_k,
+            index_k_scale=index_k_scale,
+            owner_rank=owner_rank,
+            owner_size=owner_size,
+        )
+
+    def get_state_buf_infos(self):
+        return self.index_key_cache.state_buf_infos()

--- a/python/sglang/srt/mem_cache/dsa_shared_demand.py
+++ b/python/sglang/srt/mem_cache/dsa_shared_demand.py
@@ -1,0 +1,584 @@
+"""Framework policy and storage for FlashMLA Shared-KV demand caching."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+
+from sglang.srt.mem_cache.shared_kv.demand_cache import (
+    DEMAND_CACHE_EPOCH_BYTES,
+    DEMAND_CACHE_TAG_BYTES,
+)
+
+FLASHMLA_SHARED_ROW_BYTES = 656
+FLASHMLA_SHARED_PREFILL_ROWS = 1 << 18
+FLASHMLA_SHARED_DECODE_ROWS_PER_REQUEST = 1 << 12
+_FLASHMLA_SHARED_DECODE_CALLS_PER_GENERATION = 64
+_FLASHMLA_SHARED_DEMAND_CACHE_MAX_EPOCH = (1 << 31) - 1
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SharedMLACurrentRows:
+    """Graph-stable current-row shadow owned by the DSA cache adapter."""
+
+    encoded_rows: torch.Tensor
+    physical_rows: torch.Tensor
+    counts: torch.Tensor
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        max_query_rows: int,
+        max_current_rows: int,
+        device: torch.device | str,
+    ) -> SharedMLACurrentRows:
+        if max_query_rows <= 0 or max_current_rows <= 0:
+            raise ValueError("Shared MLA current-row capacities must be positive")
+        return cls(
+            encoded_rows=torch.empty(
+                (max_query_rows, max_current_rows, FLASHMLA_SHARED_ROW_BYTES),
+                dtype=torch.uint8,
+                device=device,
+            ),
+            physical_rows=torch.full(
+                (max_query_rows, max_current_rows),
+                -1,
+                dtype=torch.int32,
+                device=device,
+            ),
+            counts=torch.zeros((max_query_rows,), dtype=torch.int32, device=device),
+        )
+
+
+def get_indexer_pool_cache_layer_ids(
+    config: object, start_layer: int, end_layer: int
+) -> tuple[int, ...]:
+    """Return layers that produce fresh Indexer TopK and need local pages."""
+    if start_layer < 0 or end_layer < start_layer:
+        raise ValueError("Indexer Pool Demand Cache layer range is invalid")
+    cli_factor = getattr(config, "cli_factor", 1) or 1
+    if cli_factor > 1:
+        return tuple(
+            layer_id
+            for layer_id in range(start_layer, end_layer)
+            if layer_id % cli_factor == 0
+        )
+
+    from sglang.srt.configs.model_config import dsa_layer_skips_topk
+
+    return tuple(
+        layer_id
+        for layer_id in range(start_layer, end_layer)
+        if not dsa_layer_skips_topk(config, layer_id)
+    )
+
+
+def get_indexer_pool_cache_bytes(
+    *,
+    num_tokens: int,
+    page_size: int,
+    num_layers: int,
+    indexer_bytes_per_token: int,
+) -> int:
+    """Exact allocation for token-pool page data, tags, and epochs."""
+    if min(num_tokens, num_layers) < 0 or page_size <= 0:
+        raise ValueError("Indexer Pool Demand Cache dimensions must be non-negative")
+    if indexer_bytes_per_token <= 0:
+        raise ValueError("Indexer Pool Demand Cache row size must be positive")
+    if num_layers == 0:
+        return 0
+    logical_pages = (num_tokens + page_size + 1) // page_size
+    page_bytes = page_size * indexer_bytes_per_token
+    return (
+        num_layers * logical_pages * (page_bytes + DEMAND_CACHE_TAG_BYTES)
+        + num_layers * DEMAND_CACHE_EPOCH_BYTES
+    )
+
+
+@dataclass
+class FlashMLASharedDecodeGeneration:
+    """One graph-stable generation shared by all Decode layer caches."""
+
+    tensor: torch.Tensor
+    tags: torch.Tensor
+    max_generation: int = _FLASHMLA_SHARED_DEMAND_CACHE_MAX_EPOCH
+    calls_per_generation: int = 1
+    generation: int = 1
+    calls_in_generation: int = 0
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        device: torch.device | str,
+        tags: torch.Tensor,
+        max_generation: int = _FLASHMLA_SHARED_DEMAND_CACHE_MAX_EPOCH,
+        calls_per_generation: int = 1,
+    ) -> FlashMLASharedDecodeGeneration:
+        if max_generation < 2:
+            raise ValueError("Decode cache generation limit must be at least 2")
+        if calls_per_generation <= 0:
+            raise ValueError("Decode cache generation interval must be positive")
+        return cls(
+            tensor=torch.ones((), dtype=torch.int32, device=device),
+            tags=tags,
+            max_generation=max_generation,
+            calls_per_generation=calls_per_generation,
+        )
+
+    def advance(self) -> torch.Tensor:
+        self.calls_in_generation += 1
+        if self.calls_in_generation < self.calls_per_generation:
+            return self.tensor
+        self.calls_in_generation = 0
+        if self.generation >= self.max_generation:
+            self.tags.zero_()
+            self.generation = 1
+        else:
+            self.generation += 1
+        self.tensor.fill_(self.generation)
+        return self.tensor
+
+
+@dataclass
+class FlashMLASharedDecodeSlotLifecycle:
+    """Invalidate a fixed request-local cache slice when its request changes."""
+
+    tags: torch.Tensor
+    installed_generations: torch.Tensor
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        tags: torch.Tensor,
+        num_request_slots: int,
+    ) -> FlashMLASharedDecodeSlotLifecycle:
+        if tags.dim() != 3 or tags.shape[1] != num_request_slots:
+            raise ValueError("Decode cache tags must be [layers, request_slots, rows]")
+        if num_request_slots <= 0 or tags.shape[2] <= 0:
+            raise ValueError("Decode request-slot count must be positive")
+        return cls(
+            tags=tags,
+            installed_generations=torch.zeros(
+                num_request_slots + 1, dtype=torch.int64, device="cpu"
+            ),
+        )
+
+    def refresh(
+        self,
+        *,
+        active_request_slots: torch.Tensor,
+        request_generations: torch.Tensor,
+    ) -> list[int]:
+        slots = active_request_slots.to(device="cpu", dtype=torch.int64).view(-1)
+        generations = request_generations.to(device="cpu", dtype=torch.int64).view(-1)
+        if slots.shape != generations.shape:
+            raise ValueError("Request slots and generations must have equal shape")
+        if slots.numel() and (
+            int(slots.min()) <= 0
+            or int(slots.max()) >= self.installed_generations.numel()
+        ):
+            raise ValueError("Decode cache request slot is out of range")
+
+        active_generations: dict[int, int] = {}
+        for slot, generation in zip(slots.tolist(), generations.tolist()):
+            previous = active_generations.setdefault(slot, generation)
+            if previous != generation:
+                raise ValueError("One request slot has conflicting generations")
+
+        changed_slots = []
+        for slot in range(1, self.installed_generations.numel()):
+            if slot not in active_generations:
+                self.installed_generations[slot] = 0
+                continue
+            if self.installed_generations[slot] != active_generations[slot]:
+                changed_slots.append(slot)
+            self.installed_generations[slot] = active_generations[slot]
+
+        if changed_slots:
+            self.tags.index_fill_(
+                1,
+                torch.tensor(
+                    [slot - 1 for slot in changed_slots],
+                    dtype=torch.int64,
+                    device=self.tags.device,
+                ),
+                0,
+            )
+        return changed_slots
+
+
+@dataclass
+class SlotDemandCache:
+    """One-layer scratch that turns repeated peer-VMM rows into local hits."""
+
+    row_cache: torch.Tensor
+    tags: torch.Tensor
+    local_row_begin: int
+    local_row_end: int
+    rows_per_request: int
+    num_request_slots: int
+    generation_tensor: Optional[torch.Tensor] = None
+    epoch: int = 0
+
+    def next_call_kwargs(
+        self,
+        *,
+        persistent: bool = False,
+        request_slots: Optional[torch.Tensor] = None,
+    ) -> dict[str, object]:
+        if not persistent:
+            self.epoch += 1
+        elif self.epoch == 0:
+            # Persistent Decode tags retain their generation until the owning
+            # request slot is allocated to a new request generation.
+            self.epoch = 1
+        if self.epoch > _FLASHMLA_SHARED_DEMAND_CACHE_MAX_EPOCH:
+            # The clear and the following kernel are enqueued on the same stream.
+            # Epoch wrap is practically unreachable, but retaining an explicit
+            # reset makes stale READY tags impossible by construction.
+            self.tags.zero_()
+            self.epoch = 1
+        if self.num_request_slots == 1:
+            request_slots = None
+        kwargs = {
+            "shared_kv_row_cache": self.row_cache,
+            "shared_kv_cache_tags": self.tags,
+            "shared_kv_request_slots": request_slots,
+            "shared_kv_cache_rows_per_request": self.rows_per_request,
+            "shared_kv_num_request_slots": self.num_request_slots,
+            "shared_kv_cache_epoch": self.epoch,
+            "shared_kv_cache_generation_tensor": self.generation_tensor,
+            "shared_kv_local_row_begin": self.local_row_begin,
+            "shared_kv_local_row_end": self.local_row_end,
+        }
+        return kwargs
+
+
+def _build_slot_demand_cache(
+    pool,
+    *,
+    device: torch.device | str,
+    enabled: bool,
+    rows_per_request: int = FLASHMLA_SHARED_PREFILL_ROWS,
+    num_request_slots: int = 1,
+    tags: Optional[torch.Tensor] = None,
+    generation_tensor: Optional[torch.Tensor] = None,
+) -> Optional[SlotDemandCache]:
+    layout = getattr(pool, "main_layout", None)
+    if not enabled or layout is None or layout.cp_size <= 1:
+        return None
+    if layout.page_size != 64:
+        raise ValueError(
+            "FlashMLA Shared-KV demand cache requires page size 64, got "
+            f"{layout.page_size}"
+        )
+    if rows_per_request <= 0 or rows_per_request & (rows_per_request - 1):
+        raise ValueError(
+            "FlashMLA Shared-KV rows per request must be a power of two, got "
+            f"{rows_per_request}"
+        )
+    if num_request_slots <= 0:
+        raise ValueError(
+            "FlashMLA Shared-KV request-slot count must be positive, got "
+            f"{num_request_slots}"
+        )
+    shared_rank = getattr(pool, "shared_rank", None)
+    if shared_rank is None or not 0 <= shared_rank < layout.cp_size:
+        raise ValueError(f"invalid Shared-KV rank: {shared_rank}")
+
+    if layout.local_pages_per_layer is None:
+        raise ValueError("Shared-KV layout is missing local_pages_per_layer")
+    rank_stride_rows = layout.pages_per_rank * layout.page_size
+    local_rows_per_layer = layout.local_pages_per_layer * layout.page_size
+    local_row_begin = shared_rank * rank_stride_rows
+    if tags is None:
+        tags = torch.zeros(
+            (num_request_slots, rows_per_request),
+            dtype=torch.int64,
+            device=device,
+        )
+    elif tags.shape != (num_request_slots, rows_per_request):
+        raise ValueError(
+            "FlashMLA Shared-KV tag storage has shape "
+            f"{tuple(tags.shape)}, expected "
+            f"{(num_request_slots, rows_per_request)}"
+        )
+    return SlotDemandCache(
+        row_cache=torch.empty(
+            (num_request_slots * rows_per_request, FLASHMLA_SHARED_ROW_BYTES),
+            dtype=torch.uint8,
+            device=device,
+        ),
+        tags=tags,
+        local_row_begin=local_row_begin,
+        local_row_end=local_row_begin + local_rows_per_layer,
+        rows_per_request=rows_per_request,
+        num_request_slots=num_request_slots,
+        generation_tensor=generation_tensor,
+    )
+
+
+def _build_decode_slot_demand_caches(
+    pool,
+    *,
+    device: torch.device | str,
+    num_layers: int,
+    num_request_slots: int,
+    rows_per_request: int = FLASHMLA_SHARED_DECODE_ROWS_PER_REQUEST,
+) -> tuple[
+    list[SlotDemandCache],
+    FlashMLASharedDecodeGeneration,
+    FlashMLASharedDecodeSlotLifecycle,
+]:
+    tags = torch.zeros(
+        (num_layers, num_request_slots, rows_per_request),
+        dtype=torch.int64,
+        device=device,
+    )
+    generation = FlashMLASharedDecodeGeneration.create(
+        device=device,
+        tags=tags,
+        calls_per_generation=_FLASHMLA_SHARED_DECODE_CALLS_PER_GENERATION,
+    )
+    lifecycle = FlashMLASharedDecodeSlotLifecycle.create(
+        tags=tags,
+        num_request_slots=num_request_slots,
+    )
+    caches: list[SlotDemandCache] = []
+    for layer_id in range(num_layers):
+        cache = _build_slot_demand_cache(
+            pool,
+            device=device,
+            enabled=True,
+            rows_per_request=rows_per_request,
+            num_request_slots=num_request_slots,
+            tags=tags[layer_id],
+            generation_tensor=generation.tensor,
+        )
+        assert cache is not None
+        caches.append(cache)
+    return caches, generation, lifecycle
+
+
+def _expand_flashmla_shared_cache_request_slots(
+    req_pool_indices: torch.Tensor,
+    *,
+    num_query_rows: int,
+) -> torch.Tensor:
+    if req_pool_indices.dim() != 1 or req_pool_indices.numel() == 0:
+        raise ValueError("FlashMLA Shared-KV request slots must be non-empty 1D")
+    request_count = req_pool_indices.numel()
+    repeats, remainder = divmod(num_query_rows, request_count)
+    if repeats <= 0 or remainder:
+        raise ValueError(
+            "FlashMLA Shared-KV query rows must be a positive multiple of "
+            f"request count, got rows={num_query_rows} requests={request_count}"
+        )
+    if repeats == 1:
+        return req_pool_indices
+    return req_pool_indices.repeat_interleave(repeats)
+
+
+def resolve_flashmla_shared_max_current_rows(
+    speculative_num_draft_tokens: int | None,
+) -> int:
+    """Resolve the graph-stable current-row width for Decode/verify."""
+    return max(1, speculative_num_draft_tokens or 0)
+
+
+def get_flashmla_shared_demand_workspace_bytes(
+    *,
+    num_layers: int,
+    num_request_slots: int,
+    max_current_rows: int,
+) -> int:
+    """Return graph-stable HBM allocated outside the token KV pool."""
+    if num_layers <= 0 or num_request_slots <= 0 or max_current_rows <= 0:
+        raise ValueError("Shared demand-cache dimensions must be positive")
+    if max_current_rows > 4:
+        raise ValueError(
+            "FlashMLA Shared-KV supports at most four current rows per request"
+        )
+
+    row_and_tag_bytes = FLASHMLA_SHARED_ROW_BYTES + DEMAND_CACHE_TAG_BYTES
+    prefill_bytes = FLASHMLA_SHARED_PREFILL_ROWS * row_and_tag_bytes
+    decode_bytes = (
+        num_layers
+        * num_request_slots
+        * FLASHMLA_SHARED_DECODE_ROWS_PER_REQUEST
+        * row_and_tag_bytes
+    )
+
+    max_query_rows = num_request_slots * max_current_rows
+    current_rows_per_layer = (
+        max_query_rows * max_current_rows * FLASHMLA_SHARED_ROW_BYTES
+        + max_query_rows * max_current_rows * 4
+        + max_query_rows * 4
+    )
+    current_row_bytes = num_layers * current_rows_per_layer
+
+    generation_bytes = DEMAND_CACHE_EPOCH_BYTES
+    return prefill_bytes + decode_bytes + current_row_bytes + generation_bytes
+
+
+@dataclass
+class DSAFlashMLADemandCacheManager:
+    """Own all framework-side Main-KV Demand Cache policy state."""
+
+    prefill_cache: Optional[SlotDemandCache]
+    decode_caches: list[SlotDemandCache]
+    decode_generation: Optional[FlashMLASharedDecodeGeneration]
+    decode_lifecycle: Optional[FlashMLASharedDecodeSlotLifecycle]
+    current_rows_by_layer: list[SharedMLACurrentRows]
+    max_current_rows: int
+
+    @property
+    def allocated_bytes(self) -> int:
+        """HBM bytes owned by the graph-stable Main-KV Demand workspace."""
+        total = 0
+        if self.prefill_cache is not None:
+            total += self.prefill_cache.row_cache.nbytes
+            total += self.prefill_cache.tags.nbytes
+        for cache in self.decode_caches:
+            total += cache.row_cache.nbytes
+            total += cache.tags.nbytes
+        if self.decode_generation is not None:
+            total += self.decode_generation.tensor.nbytes
+        for current_rows in self.current_rows_by_layer:
+            total += current_rows.encoded_rows.nbytes
+            total += current_rows.physical_rows.nbytes
+            total += current_rows.counts.nbytes
+        return total
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        pool,
+        device: torch.device | str,
+        enable_prefill: bool,
+        enable_decode: bool,
+        enable_current_rows: bool,
+        num_layers: int,
+        num_request_slots: int,
+        max_current_rows: int,
+    ) -> DSAFlashMLADemandCacheManager:
+        prefill_cache = _build_slot_demand_cache(
+            pool,
+            device=device,
+            enabled=enable_prefill,
+        )
+        decode_caches: list[SlotDemandCache] = []
+        decode_generation = None
+        decode_lifecycle = None
+        if prefill_cache is not None and enable_decode:
+            (
+                decode_caches,
+                decode_generation,
+                decode_lifecycle,
+            ) = _build_decode_slot_demand_caches(
+                pool,
+                device=device,
+                num_layers=num_layers,
+                num_request_slots=num_request_slots,
+            )
+            logger.info(
+                "FlashMLA Shared-KV Slot Decode Demand Cache: "
+                "layers=%s request_slots=%s rows_per_request=%s bytes=%s",
+                len(decode_caches),
+                num_request_slots,
+                FLASHMLA_SHARED_DECODE_ROWS_PER_REQUEST,
+                sum(
+                    cache.row_cache.nbytes + cache.tags.nbytes
+                    for cache in decode_caches
+                ),
+            )
+
+        current_rows_by_layer: list[SharedMLACurrentRows] = []
+        if decode_caches and enable_current_rows:
+            max_query_rows = num_request_slots * max_current_rows
+            current_rows_by_layer = [
+                SharedMLACurrentRows.create(
+                    max_query_rows=max_query_rows,
+                    max_current_rows=max_current_rows,
+                    device=device,
+                )
+                for _ in range(num_layers)
+            ]
+
+        if prefill_cache is not None:
+            logger.info(
+                "FlashMLA Shared-KV Slot Prefill Demand Cache: "
+                "rows=%s bytes=%s local_rows=[%s,%s)",
+                prefill_cache.row_cache.shape[0],
+                prefill_cache.row_cache.nbytes + prefill_cache.tags.nbytes,
+                prefill_cache.local_row_begin,
+                prefill_cache.local_row_end,
+            )
+        if current_rows_by_layer:
+            shadow = current_rows_by_layer[0]
+            bytes_per_layer = (
+                shadow.encoded_rows.nbytes
+                + shadow.physical_rows.nbytes
+                + shadow.counts.nbytes
+            )
+            logger.info(
+                "FlashMLA Shared-KV current-row shadow: max_query_rows=%s "
+                "max_current_rows=%s layers=%s bytes_per_layer=%s total_bytes=%s",
+                num_request_slots * max_current_rows,
+                max_current_rows,
+                num_layers,
+                bytes_per_layer,
+                bytes_per_layer * num_layers,
+            )
+        return cls(
+            prefill_cache=prefill_cache,
+            decode_caches=decode_caches,
+            decode_generation=decode_generation,
+            decode_lifecycle=decode_lifecycle,
+            current_rows_by_layer=current_rows_by_layer,
+            max_current_rows=max_current_rows,
+        )
+
+    @property
+    def has_decode_cache(self) -> bool:
+        return bool(self.decode_caches)
+
+    def current_rows_per_request(self, *, target_verify: bool, decode: bool) -> int:
+        if not self.current_rows_by_layer or not (target_verify or decode):
+            return 0
+        return self.max_current_rows if target_verify else 1
+
+    def advance_decode_generation(self) -> None:
+        if self.decode_generation is not None:
+            self.decode_generation.advance()
+
+    def refresh_decode_requests(
+        self,
+        *,
+        active_request_slots: torch.Tensor,
+        request_generations: torch.Tensor,
+    ) -> None:
+        if self.decode_lifecycle is not None:
+            self.decode_lifecycle.refresh(
+                active_request_slots=active_request_slots,
+                request_generations=request_generations,
+            )
+
+    def cache_for_layer(
+        self,
+        *,
+        local_layer_id: int,
+        persistent: bool,
+    ) -> tuple[Optional[SlotDemandCache], bool]:
+        if persistent and self.decode_caches:
+            return self.decode_caches[local_layer_id], True
+        return self.prefill_cache, False

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -1305,12 +1305,16 @@ class KVCacheConfigurator:
         return token_to_kv_pool
 
     def _build_dsa_kv_pool(self, *, max_total_num_tokens: int) -> KVCache:
-        from sglang.srt.layers.cp.utils import get_glm_dsa_cp_layer_shard_info
+        from sglang.srt.layers.cp.utils import (
+            get_glm_dsa_cp_layer_shard_info,
+            get_glm_dsa_shared_info,
+        )
 
         (
             dsa_cp_layer_shard_rank,
             dsa_cp_layer_shard_size,
         ) = get_glm_dsa_cp_layer_shard_info(self)
+        dsa_shared_rank, dsa_shared_size = get_glm_dsa_shared_info(self)
         pool_kwargs = {}
         if get_memory().enable_hisparse:
             PoolCls = HiSparseDSATokenToKVPool
@@ -1319,6 +1323,28 @@ class KVCacheConfigurator:
             pool_kwargs["host_to_device_ratio"] = parse_hisparse_config(
                 self.server_args
             ).host_to_device_ratio
+        elif dsa_shared_rank is not None:
+            from sglang.srt.mem_cache.dsa_cache_shared import (
+                SharedDSATokenToKVPool,
+            )
+            from sglang.srt.mem_cache.dsa_shared_demand import (
+                get_indexer_pool_cache_layer_ids,
+            )
+
+            PoolCls = SharedDSATokenToKVPool
+            pool_kwargs["shared_rank"] = dsa_shared_rank
+            pool_kwargs["shared_size"] = dsa_shared_size
+            share_indexer = not self.server_args.disable_dsa_shared_indexer_cache
+            pool_kwargs["share_indexer"] = share_indexer
+            pool_kwargs["indexer_cache_layer_ids"] = (
+                get_indexer_pool_cache_layer_ids(
+                    self.model_config.hf_config,
+                    self.layer_info.start_layer,
+                    self.layer_info.end_layer,
+                )
+                if share_indexer
+                else ()
+            )
         elif dsa_cp_layer_shard_rank is not None:
             # DSA cache layer split: shard KV/indexer layers across CP ranks.
             from sglang.srt.mem_cache.dsa_cache_layer_split import (

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -4075,7 +4075,10 @@ class MLATokenToKVPool(KVCache):
         loc: torch.Tensor,
         cache_k_nope: torch.Tensor,
         cache_k_rope: torch.Tensor,
+        write_fn=None,
     ) -> None:
+        if write_fn is None:
+            write_fn = set_mla_kv_buffer_triton
         if _is_hip and self.use_dsa and self.dtype == fp8_dtype:
             # HIP FP8 path uses raw MLA KV layout (nope + rope) without per-block scales.
             # Fuse BF16/FP16 -> FP8 cast with paged KV write.
@@ -4097,7 +4100,7 @@ class MLATokenToKVPool(KVCache):
             # Reuse existing two-tensor write kernel (works with FP8 byte layout)
             # cache_k_nope_fp8: (num_tokens, 1, 528) uint8 [nope_fp8(512) | scales(16)]
             # cache_k_rope_fp8: (num_tokens, 1, 128) uint8 [rope_bf16_bytes(128)]
-            set_mla_kv_buffer_triton(
+            write_fn(
                 dst_buffer,
                 loc,
                 cache_k_nope_fp8,
@@ -4111,7 +4114,7 @@ class MLATokenToKVPool(KVCache):
                 cache_k_nope = cache_k_nope.view(self.store_dtype)
                 cache_k_rope = cache_k_rope.view(self.store_dtype)
 
-            set_mla_kv_buffer_triton(
+            write_fn(
                 dst_buffer,
                 loc,
                 cache_k_nope,

--- a/python/sglang/srt/mem_cache/shared_kv/__init__.py
+++ b/python/sglang/srt/mem_cache/shared_kv/__init__.py
@@ -1,0 +1,27 @@
+from sglang.srt.mem_cache.shared_kv.demand_cache import PoolDemandCache
+from sglang.srt.mem_cache.shared_kv.family import (
+    OwnerShardedFamily,
+    OwnerShardedFamilySpec,
+    SharedFamilyAccounting,
+)
+from sglang.srt.mem_cache.shared_kv.layout import OwnerShardedLayout
+from sglang.srt.mem_cache.shared_kv.synchronization import SharedWritePublisher
+from sglang.srt.mem_cache.shared_kv.vmm import (
+    RankMajorSharedSlab,
+    RankMajorSharedTensor,
+    create_rank_major_shared_slab,
+    create_rank_major_shared_tensor,
+)
+
+__all__ = [
+    "PoolDemandCache",
+    "OwnerShardedFamily",
+    "OwnerShardedFamilySpec",
+    "OwnerShardedLayout",
+    "RankMajorSharedSlab",
+    "RankMajorSharedTensor",
+    "SharedFamilyAccounting",
+    "SharedWritePublisher",
+    "create_rank_major_shared_slab",
+    "create_rank_major_shared_tensor",
+]

--- a/python/sglang/srt/mem_cache/shared_kv/demand_cache.py
+++ b/python/sglang/srt/mem_cache/shared_kv/demand_cache.py
@@ -1,0 +1,85 @@
+"""Model-neutral demand-cache policies for owner-sharded Shared KV."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+
+DEMAND_CACHE_TAG_BYTES = 8
+DEMAND_CACHE_EPOCH_BYTES = 4
+_MAX_EPOCH = (1 << 31) - 1
+
+
+@dataclass
+class PoolDemandCache:
+    """Demand cache backed by stable slots in a consumer-local pool.
+
+    The model adapter chooses the pool slot for each source object. Complete
+    historical objects remain resident, while mutable objects are refreshed.
+    This cache has no hashing, probing, eviction, collision state, or
+    first-writer arbitration.
+    """
+
+    data: torch.Tensor
+    tags: torch.Tensor
+    epoch_tensor: torch.Tensor
+    keys: tuple[int, ...]
+    epoch: int = 1
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        keys: tuple[int, ...],
+        entries_per_key: int,
+        entry_bytes: int,
+        dtype: torch.dtype,
+        device: torch.device | str,
+    ) -> PoolDemandCache:
+        if not keys or len(set(keys)) != len(keys):
+            raise ValueError("Pool demand-cache keys must be unique")
+        if entries_per_key <= 0 or entry_bytes <= 0:
+            raise ValueError("Pool demand-cache geometry must be positive")
+        return cls(
+            data=torch.empty(
+                (len(keys), entries_per_key, entry_bytes),
+                dtype=dtype,
+                device=device,
+            ),
+            tags=torch.zeros(
+                (len(keys), entries_per_key),
+                dtype=torch.int64,
+                device=device,
+            ),
+            epoch_tensor=torch.ones((), dtype=torch.int32, device=device),
+            keys=keys,
+        )
+
+    @property
+    def key_to_slot(self) -> dict[int, int]:
+        return {key: slot for slot, key in enumerate(self.keys)}
+
+    @property
+    def allocated_bytes(self) -> int:
+        return self.data.nbytes + self.tags.nbytes + self.epoch_tensor.nbytes
+
+    def storage_for(self, key: int) -> tuple[torch.Tensor, torch.Tensor]:
+        try:
+            slot = self.key_to_slot[key]
+        except KeyError as exc:
+            raise ValueError(f"Demand-cache key {key} is not configured") from exc
+        return self.data[slot], self.tags[slot]
+
+    def invalidate(self) -> None:
+        if self.epoch >= _MAX_EPOCH:
+            self.tags.zero_()
+            self.epoch = 1
+        else:
+            self.epoch += 1
+        self.epoch_tensor.fill_(self.epoch)
+
+    def clear(self) -> None:
+        self.data = None
+        self.tags = None
+        self.epoch_tensor = None

--- a/python/sglang/srt/mem_cache/shared_kv/family.py
+++ b/python/sglang/srt/mem_cache/shared_kv/family.py
@@ -1,0 +1,173 @@
+"""Model-neutral owner-sharded family construction and accounting."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+
+import torch
+import torch.distributed as dist
+from torch.distributed import ProcessGroup
+
+from sglang.srt.mem_cache.shared_kv.layout import OwnerShardedLayout
+from sglang.srt.mem_cache.shared_kv.vmm import (
+    RankMajorSharedSlab,
+    _synchronize_vmm_stage,
+    create_rank_major_shared_slab,
+)
+
+
+@dataclass(frozen=True)
+class OwnerShardedFamilySpec:
+    name: str
+    num_layers: int
+    logical_rows_per_layer: int
+    ownership_granule: int
+    storage_rows_per_granule: int
+    row_shape: tuple[int, ...]
+    dtype: torch.dtype
+    map_rank_local: bool = True
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("name must not be empty")
+        if self.num_layers <= 0:
+            raise ValueError(f"num_layers must be positive, got {self.num_layers}")
+        if self.logical_rows_per_layer < 0:
+            raise ValueError(
+                "logical_rows_per_layer must be non-negative, "
+                f"got {self.logical_rows_per_layer}"
+            )
+        if self.ownership_granule <= 0:
+            raise ValueError(
+                f"ownership_granule must be positive, got {self.ownership_granule}"
+            )
+        if self.storage_rows_per_granule <= 0:
+            raise ValueError(
+                "storage_rows_per_granule must be positive, "
+                f"got {self.storage_rows_per_granule}"
+            )
+        if not self.row_shape or any(dimension <= 0 for dimension in self.row_shape):
+            raise ValueError(
+                f"row_shape must contain positive dimensions: {self.row_shape}"
+            )
+
+
+@dataclass(frozen=True)
+class SharedFamilyAccounting:
+    name: str
+    logical_blocks_per_layer: int
+    minimum_blocks_per_rank: int
+    physical_blocks_per_rank: int
+    logical_storage_bytes: int
+    minimum_physical_bytes_per_rank: int
+    mapped_bytes_per_rank: int
+    alignment_overhead_bytes_per_rank: int
+
+
+@dataclass
+class OwnerShardedFamily:
+    spec: OwnerShardedFamilySpec
+    layout: OwnerShardedLayout
+    slab: RankMajorSharedSlab
+    _closed: bool = field(default=False, init=False)
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        spec: OwnerShardedFamilySpec,
+        cp_size: int,
+        cpu_group: ProcessGroup,
+        zero_initialize: bool = True,
+    ) -> OwnerShardedFamily:
+        group_size = dist.get_world_size(group=cpu_group)
+        if cp_size != group_size:
+            raise ValueError(
+                "Shared family cp_size must match the CPU process group size: "
+                f"cp_size={cp_size}, group_size={group_size}"
+            )
+        minimum_layout = OwnerShardedLayout(
+            cp_size=cp_size,
+            ownership_granule=spec.ownership_granule,
+            logical_rows=spec.logical_rows_per_layer,
+        )
+        storage_rows_per_layer = (
+            minimum_layout.minimum_blocks_per_rank * spec.storage_rows_per_granule
+        )
+        slab = create_rank_major_shared_slab(
+            (storage_rows_per_layer, *spec.row_shape),
+            layer_num=spec.num_layers,
+            dtype=spec.dtype,
+            cpu_group=cpu_group,
+            first_dim_multiple=spec.storage_rows_per_granule,
+            map_rank_local=spec.map_rank_local,
+        )
+        try:
+            if slab.rank_stride_rows % spec.storage_rows_per_granule != 0:
+                raise RuntimeError(
+                    f"Shared family {spec.name} rank stride {slab.rank_stride_rows} "
+                    "is not divisible by storage_rows_per_granule "
+                    f"{spec.storage_rows_per_granule}"
+                )
+
+            layout = OwnerShardedLayout(
+                cp_size=cp_size,
+                ownership_granule=spec.ownership_granule,
+                logical_rows=spec.logical_rows_per_layer,
+                physical_blocks_per_rank=(
+                    slab.rank_stride_rows // spec.storage_rows_per_granule
+                ),
+            )
+            if zero_initialize:
+                initialization_error = None
+                try:
+                    slab.allocation.local_view.zero_()
+                    torch.cuda.synchronize()
+                except BaseException as error:
+                    initialization_error = error
+                _synchronize_vmm_stage(
+                    cpu_group,
+                    dist.get_rank(group=cpu_group),
+                    "family zero initialization",
+                    initialization_error,
+                )
+            return cls(spec=spec, layout=layout, slab=slab)
+        except BaseException:
+            slab.close()
+            raise
+
+    def accounting(self) -> SharedFamilyAccounting:
+        row_bytes = (
+            math.prod(self.spec.row_shape)
+            * torch.empty((), dtype=self.spec.dtype).element_size()
+        )
+        logical_storage_bytes = (
+            self.spec.num_layers
+            * self.layout.logical_blocks
+            * self.spec.storage_rows_per_granule
+            * row_bytes
+        )
+        minimum_physical_bytes = (
+            self.spec.num_layers
+            * self.layout.minimum_blocks_per_rank
+            * self.spec.storage_rows_per_granule
+            * row_bytes
+        )
+        mapped_bytes = int(self.slab.allocation.aligned_bytes_per_rank)
+        return SharedFamilyAccounting(
+            name=self.spec.name,
+            logical_blocks_per_layer=self.layout.logical_blocks,
+            minimum_blocks_per_rank=self.layout.minimum_blocks_per_rank,
+            physical_blocks_per_rank=self.layout.blocks_per_rank,
+            logical_storage_bytes=logical_storage_bytes,
+            minimum_physical_bytes_per_rank=minimum_physical_bytes,
+            mapped_bytes_per_rank=mapped_bytes,
+            alignment_overhead_bytes_per_rank=(mapped_bytes - minimum_physical_bytes),
+        )
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self.slab.close()

--- a/python/sglang/srt/mem_cache/shared_kv/layout.py
+++ b/python/sglang/srt/mem_cache/shared_kv/layout.py
@@ -1,0 +1,103 @@
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+
+
+@dataclass(frozen=True)
+class OwnerShardedLayout:
+    """Map logical rows into rank-major owner-sharded storage."""
+
+    cp_size: int
+    ownership_granule: int
+    logical_rows: int
+    physical_blocks_per_rank: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        if self.cp_size <= 0:
+            raise ValueError(f"cp_size must be positive, got {self.cp_size}")
+        if self.ownership_granule <= 0:
+            raise ValueError(
+                f"ownership_granule must be positive, got {self.ownership_granule}"
+            )
+        if self.logical_rows < 0:
+            raise ValueError(
+                f"logical_rows must be non-negative, got {self.logical_rows}"
+            )
+        if (
+            self.physical_blocks_per_rank is not None
+            and self.physical_blocks_per_rank < self.minimum_blocks_per_rank
+        ):
+            raise ValueError(
+                "physical_blocks_per_rank must be at least "
+                f"{self.minimum_blocks_per_rank}, got "
+                f"{self.physical_blocks_per_rank}"
+            )
+
+    @property
+    def logical_blocks(self) -> int:
+        return (
+            self.logical_rows + self.ownership_granule - 1
+        ) // self.ownership_granule
+
+    @property
+    def minimum_blocks_per_rank(self) -> int:
+        return (self.logical_blocks + self.cp_size - 1) // self.cp_size
+
+    @property
+    def blocks_per_rank(self) -> int:
+        if self.physical_blocks_per_rank is not None:
+            return self.physical_blocks_per_rank
+        return self.minimum_blocks_per_rank
+
+    def _validate_rank(self, rank: int) -> None:
+        if rank < 0 or rank >= self.cp_size:
+            raise ValueError(f"rank must be in [0, {self.cp_size}), got {rank}")
+
+    @staticmethod
+    def _preserve_sentinels(
+        logical_rows: torch.Tensor, translated_rows: torch.Tensor
+    ) -> torch.Tensor:
+        return torch.where(logical_rows >= 0, translated_rows, logical_rows)
+
+    def _logical_parts(
+        self, logical_rows: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        safe_rows = torch.where(logical_rows >= 0, logical_rows, 0)
+        logical_blocks = torch.div(
+            safe_rows, self.ownership_granule, rounding_mode="floor"
+        )
+        block_offsets = safe_rows % self.ownership_granule
+        owners = logical_blocks % self.cp_size
+        owner_blocks = torch.div(logical_blocks, self.cp_size, rounding_mode="floor")
+        return logical_blocks, block_offsets, owners, owner_blocks
+
+    def owner_rank(self, logical_rows: torch.Tensor) -> torch.Tensor:
+        _, _, owners, _ = self._logical_parts(logical_rows)
+        return self._preserve_sentinels(logical_rows, owners)
+
+    def owner_local_rows(self, logical_rows: torch.Tensor) -> torch.Tensor:
+        _, block_offsets, _, owner_blocks = self._logical_parts(logical_rows)
+        translated = owner_blocks * self.ownership_granule + block_offsets
+        return self._preserve_sentinels(logical_rows, translated)
+
+    def physical_rows(self, logical_rows: torch.Tensor) -> torch.Tensor:
+        _, block_offsets, owners, owner_blocks = self._logical_parts(logical_rows)
+        physical_blocks = owners * self.blocks_per_rank + owner_blocks
+        translated = physical_blocks * self.ownership_granule + block_offsets
+        return self._preserve_sentinels(logical_rows, translated)
+
+    def rank_relative_rows(
+        self, logical_rows: torch.Tensor, *, rank: int
+    ) -> torch.Tensor:
+        self._validate_rank(rank)
+        _, block_offsets, owners, owner_blocks = self._logical_parts(logical_rows)
+        relative_owners = (owners - rank) % self.cp_size
+        relative_blocks = relative_owners * self.blocks_per_rank + owner_blocks
+        translated = relative_blocks * self.ownership_granule + block_offsets
+        return self._preserve_sentinels(logical_rows, translated)
+
+    def owned_row_mask(self, logical_rows: torch.Tensor, *, rank: int) -> torch.Tensor:
+        self._validate_rank(rank)
+        _, _, owners, _ = self._logical_parts(logical_rows)
+        return (logical_rows >= 0) & (owners == rank)

--- a/python/sglang/srt/mem_cache/shared_kv/synchronization.py
+++ b/python/sglang/srt/mem_cache/shared_kv/synchronization.py
@@ -1,0 +1,123 @@
+"""Mandatory device-side publication for owner-only shared writes."""
+
+import torch
+
+from sglang.kernels.ops.kvcache.shared_kv_publication import (
+    compile_shared_kv_publication,
+    shared_kv_publish,
+    shared_kv_publish_status,
+)
+from sglang.srt.mem_cache.shared_kv.vmm import (
+    RankMajorSharedTensor,
+    _synchronize_vmm_stage,
+    create_rank_major_shared_tensor,
+)
+
+
+class SharedWritePublisher:
+    def __init__(self, attention_cp_group: object) -> None:
+        self._rank = int(attention_cp_group.rank_in_group)
+        self._world_size = int(attention_cp_group.world_size)
+        if not 2 <= self._world_size <= 8:
+            raise ValueError(
+                "Shared KV publication attention CP size must be in [2, 8], "
+                f"got {self._world_size}"
+            )
+        if not 0 <= self._rank < self._world_size:
+            raise ValueError(
+                f"Shared KV publication rank must be in [0, {self._world_size}), "
+                f"got {self._rank}"
+            )
+
+        cpu_group = attention_cp_group.cpu_group
+        flags = create_rank_major_shared_tensor(
+            (2 * self._world_size,),
+            dtype=torch.int32,
+            cpu_group=cpu_group,
+        )
+        peer_ptrs = None
+        epoch = None
+        status_result = None
+        initialization_error = None
+        try:
+            flags.local_view.zero_()
+            peer_ptrs = torch.tensor(
+                [
+                    flags.global_view.data_ptr() + peer * flags.aligned_bytes_per_rank
+                    for peer in range(self._world_size)
+                ],
+                dtype=torch.int64,
+                device=flags.global_view.device,
+            )
+            epoch = torch.zeros(
+                (1,), dtype=torch.int32, device=flags.global_view.device
+            )
+            status_result = torch.ones(
+                (1,), dtype=torch.int32, device=flags.global_view.device
+            )
+            compile_shared_kv_publication(self._world_size)
+            torch.cuda.synchronize()
+        except BaseException as error:
+            initialization_error = error
+        try:
+            _synchronize_vmm_stage(
+                cpu_group,
+                self._rank,
+                "publisher initialization",
+                initialization_error,
+            )
+        except BaseException:
+            flags.close()
+            raise
+
+        assert peer_ptrs is not None and epoch is not None and status_result is not None
+        self._flags: RankMajorSharedTensor | None = flags
+        self._peer_ptrs: torch.Tensor | None = peer_ptrs
+        self._epoch: torch.Tensor | None = epoch
+        self._status_result: torch.Tensor | None = status_result
+
+    @property
+    def mapped_bytes_per_rank(self) -> int:
+        if self._flags is None:
+            return 0
+        return self._flags.aligned_bytes_per_rank
+
+    def publish(self) -> None:
+        if self._flags is None or self._peer_ptrs is None or self._epoch is None:
+            raise RuntimeError("Shared KV publisher is closed")
+        shared_kv_publish(
+            self._flags.global_view,
+            self._peer_ptrs,
+            self._epoch,
+            self._rank,
+            self._world_size,
+        )
+
+    def publish_status(self, local_success: bool) -> bool:
+        if (
+            self._flags is None
+            or self._peer_ptrs is None
+            or self._epoch is None
+            or self._status_result is None
+        ):
+            raise RuntimeError("Shared KV publisher is closed")
+        shared_kv_publish_status(
+            self._flags.global_view,
+            self._peer_ptrs,
+            self._epoch,
+            self._status_result,
+            self._rank,
+            self._world_size,
+            local_success,
+        )
+        return bool(self._status_result.item())
+
+    def close(self) -> None:
+        flags = self._flags
+        if flags is None:
+            return
+        self._flags = None
+        self._peer_ptrs = None
+        self._epoch = None
+        self._status_result = None
+        flags.close()

--- a/python/sglang/srt/mem_cache/shared_kv/vmm.py
+++ b/python/sglang/srt/mem_cache/shared_kv/vmm.py
@@ -1,0 +1,627 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Rank-major CUDA VMM storage shared by owner-sharded cache families."""
+
+from __future__ import annotations
+
+import ctypes
+import math
+import os
+from dataclasses import dataclass, field
+from typing import Optional
+
+import torch
+import torch.distributed as dist
+from torch.distributed import ProcessGroup
+
+from sglang.srt.cuda_vmm_utils import (
+    _get_cuda_driver,
+    all_ranks_ok,
+    check_drv,
+    exchange_posix_fds,
+    export_shareable_handles,
+    import_peer_handle,
+    make_rw_access_desc,
+)
+
+_shared_vmm_use_fabric: Optional[bool] = None
+
+
+def _validate_same_host_group(cpu_group: ProcessGroup) -> None:
+    rank = dist.get_rank(group=cpu_group)
+    hosts = [None] * dist.get_world_size(group=cpu_group)
+    hostname = None
+    host_error = None
+    try:
+        hostname = os.uname().nodename
+    except BaseException as error:
+        host_error = error
+    _synchronize_vmm_stage(cpu_group, rank, "host query", host_error)
+    dist.all_gather_object(hosts, hostname, group=cpu_group)
+    if len(set(hosts)) != 1:
+        raise ValueError(
+            "Shared KV VMM requires every attention CP rank on the same host."
+        )
+
+
+def _export_shareable_handles(retained_handles, group, rank):
+    global _shared_vmm_use_fabric
+    first_attempt = _shared_vmm_use_fabric is None
+    result = export_shareable_handles(
+        retained_handles,
+        group,
+        rank,
+        try_fabric=_shared_vmm_use_fabric is not False,
+        log_fallback=first_attempt and rank == 0,
+    )
+    _shared_vmm_use_fabric = result[2]
+    return result
+
+
+def _shareable_allocation_handle_types(drv):
+    handle_types = drv.CUmemAllocationHandleType
+    posix_fd = handle_types.CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR
+    if _shared_vmm_use_fabric is False:
+        return posix_fd
+    return posix_fd | handle_types.CU_MEM_HANDLE_TYPE_FABRIC
+
+
+def _synchronize_vmm_stage(
+    cpu_group: ProcessGroup,
+    rank: int,
+    stage: str,
+    local_error: Optional[BaseException],
+) -> None:
+    errors = [None] * dist.get_world_size(group=cpu_group)
+    dist.all_gather_object(
+        errors,
+        None if local_error is None else str(local_error),
+        group=cpu_group,
+    )
+    for failed_rank, error in enumerate(errors):
+        if error is not None:
+            message = f"shared KV VMM {stage} failed on rank {failed_rank}: {error}"
+            if failed_rank == rank:
+                raise RuntimeError(message) from local_error
+            raise RuntimeError(message)
+
+
+def _release_partial_vmm_mapping(
+    drv,
+    *,
+    base_va: Optional[int],
+    total_bytes: int,
+    mapped_addresses: list[int],
+    segment_bytes: int,
+) -> None:
+    while mapped_addresses:
+        drv.cuMemUnmap(mapped_addresses.pop(), segment_bytes)
+    if base_va is not None:
+        drv.cuMemAddressFree(base_va, total_bytes)
+
+
+def _release_vmm_handles_synchronized(
+    drv,
+    *,
+    retained_handles: list,
+    cpu_group: ProcessGroup,
+    rank: int,
+) -> None:
+    """Release setup handles and publish the result before the next family."""
+
+    release_error = None
+    try:
+        while retained_handles:
+            handle = retained_handles[-1]
+            check_drv(drv.cuMemRelease(handle), "cuMemRelease(shared setup handle)")
+            retained_handles.pop()
+    except BaseException as error:
+        release_error = error
+    _synchronize_vmm_stage(cpu_group, rank, "handle release", release_error)
+
+
+class _DLDevice(ctypes.Structure):
+    _fields_ = [("device_type", ctypes.c_int), ("device_id", ctypes.c_int)]
+
+
+class _DLDataType(ctypes.Structure):
+    _fields_ = [
+        ("code", ctypes.c_uint8),
+        ("bits", ctypes.c_uint8),
+        ("lanes", ctypes.c_uint16),
+    ]
+
+
+class _DLTensor(ctypes.Structure):
+    _fields_ = [
+        ("data", ctypes.c_void_p),
+        ("device", _DLDevice),
+        ("ndim", ctypes.c_int),
+        ("dtype", _DLDataType),
+        ("shape", ctypes.POINTER(ctypes.c_int64)),
+        ("strides", ctypes.POINTER(ctypes.c_int64)),
+        ("byte_offset", ctypes.c_uint64),
+    ]
+
+
+class _DLManagedTensor(ctypes.Structure):
+    pass
+
+
+_DELETER_FN = ctypes.CFUNCTYPE(None, ctypes.POINTER(_DLManagedTensor))
+_DLManagedTensor._fields_ = [
+    ("dl_tensor", _DLTensor),
+    ("manager_ctx", ctypes.c_void_p),
+    ("deleter", _DELETER_FN),
+]
+
+# Tensor storage may outlive its pool through a temporary view. Retain the tiny
+# callback objects after releasing the mapping so no stale DLPack callback is
+# collected while PyTorch still owns an alias.
+_CLOSED_DLPACK_REFS: list[list] = []
+
+
+def _dtype_to_dlpack(dtype: torch.dtype) -> tuple[int, int]:
+    mapping = {
+        torch.uint8: (1, 8),
+        torch.int8: (0, 8),
+        torch.int32: (0, 32),
+        torch.float16: (2, 16),
+        torch.bfloat16: (4, 16),
+        torch.float32: (2, 32),
+    }
+    if hasattr(torch, "float8_e4m3fn"):
+        mapping[torch.float8_e4m3fn] = (2, 8)
+    if dtype not in mapping:
+        raise TypeError(f"Unsupported shared KV VMM dtype: {dtype}")
+    return mapping[dtype]
+
+
+def _tensor_from_cuda_ptr(
+    ptr: int,
+    shape: tuple[int, ...],
+    dtype: torch.dtype,
+    device_id: int,
+    refs: list,
+) -> torch.Tensor:
+    dl_code, dl_bits = _dtype_to_dlpack(dtype)
+    shape_array = (ctypes.c_int64 * len(shape))(*shape)
+    managed = _DLManagedTensor()
+    managed.dl_tensor.data = ctypes.c_void_p(ptr)
+    managed.dl_tensor.device = _DLDevice(2, device_id)
+    managed.dl_tensor.ndim = len(shape)
+    managed.dl_tensor.dtype = _DLDataType(dl_code, dl_bits, 1)
+    managed.dl_tensor.shape = shape_array
+    managed.dl_tensor.strides = None
+    managed.dl_tensor.byte_offset = 0
+    managed.manager_ctx = None
+
+    @_DELETER_FN
+    def deleter(_):
+        return None
+
+    managed.deleter = deleter
+    refs.extend([managed, shape_array, deleter])
+    ctypes.pythonapi.PyCapsule_New.restype = ctypes.py_object
+    ctypes.pythonapi.PyCapsule_New.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_char_p,
+        ctypes.c_void_p,
+    ]
+    capsule = ctypes.pythonapi.PyCapsule_New(ctypes.byref(managed), b"dltensor", None)
+    return torch.from_dlpack(capsule)
+
+
+def _construct_rank_major_views(
+    *,
+    cpu_group: ProcessGroup,
+    rank: int,
+    base_va: int,
+    rank_local_base_va: Optional[int],
+    world_size: int,
+    local_rows: int,
+    row_shape: tuple[int, ...],
+    dtype: torch.dtype,
+    device_id: int,
+    refs: list,
+) -> tuple[torch.Tensor, Optional[torch.Tensor], torch.Tensor]:
+    """Construct all DLPack aliases, then publish one symmetric setup result."""
+
+    global_view = None
+    rank_local_view = None
+    local_view = None
+    view_error = None
+    try:
+        global_view = _tensor_from_cuda_ptr(
+            base_va,
+            (world_size * local_rows, *row_shape),
+            dtype,
+            device_id,
+            refs,
+        )
+        if rank_local_base_va is not None:
+            rank_local_view = _tensor_from_cuda_ptr(
+                rank_local_base_va,
+                (world_size * local_rows, *row_shape),
+                dtype,
+                device_id,
+                refs,
+            )
+        local_view = (
+            rank_local_view.narrow(0, 0, local_rows)
+            if rank_local_view is not None
+            else global_view.narrow(0, rank * local_rows, local_rows)
+        )
+    except BaseException as error:
+        view_error = error
+
+    _synchronize_vmm_stage(cpu_group, rank, "tensor view construction", view_error)
+    assert global_view is not None and local_view is not None
+    return global_view, rank_local_view, local_view
+
+
+def _align_first_dim(
+    shape: tuple[int, ...],
+    *,
+    dtype: torch.dtype,
+    granularity: int,
+    first_dim_multiple: int,
+) -> tuple[int, int]:
+    row_bytes = math.prod(shape[1:]) * torch.empty((), dtype=dtype).element_size()
+    rows_per_granularity = granularity // math.gcd(granularity, row_bytes)
+    row_alignment = math.lcm(rows_per_granularity, first_dim_multiple)
+    rows = ((shape[0] + row_alignment - 1) // row_alignment) * row_alignment
+    return rows, rows * row_bytes
+
+
+@dataclass
+class RankMajorSharedTensor:
+    global_view: torch.Tensor
+    rank_local_view: Optional[torch.Tensor]
+    local_view: torch.Tensor
+    local_rows: int
+    aligned_bytes_per_rank: int
+    _base_va: int
+    _rank_local_base_va: Optional[int]
+    _total_bytes: int
+    _world_size: int
+    _refs: list
+    _closed: bool = False
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        torch.cuda.synchronize()
+        del self.local_view
+        if self.rank_local_view is not None:
+            del self.rank_local_view
+        del self.global_view
+        drv = _get_cuda_driver()
+        base_vas = [self._base_va]
+        if self._rank_local_base_va is not None:
+            base_vas.append(self._rank_local_base_va)
+        for base_va in base_vas:
+            for segment in range(self._world_size):
+                address = base_va + segment * self.aligned_bytes_per_rank
+                check_drv(
+                    drv.cuMemUnmap(address, self.aligned_bytes_per_rank),
+                    f"cuMemUnmap(segment={segment})",
+                )
+            check_drv(
+                drv.cuMemAddressFree(base_va, self._total_bytes),
+                "cuMemAddressFree",
+            )
+        _CLOSED_DLPACK_REFS.append(self._refs)
+
+
+@dataclass
+class RankMajorSharedSlab:
+    allocation: RankMajorSharedTensor
+    layer_rows: int
+    global_views: list[torch.Tensor]
+    rank_local_views: list[torch.Tensor]
+    local_views: list[torch.Tensor]
+    _closed: bool = field(default=False, init=False)
+
+    @property
+    def rank_stride_rows(self) -> int:
+        return self.allocation.local_rows
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self.global_views.clear()
+        self.rank_local_views.clear()
+        self.local_views.clear()
+        self.allocation.close()
+
+
+def create_rank_major_shared_tensor(
+    local_shape: tuple[int, ...],
+    *,
+    dtype: torch.dtype,
+    cpu_group: ProcessGroup,
+    first_dim_multiple: int = 1,
+    map_rank_local: bool = True,
+) -> RankMajorSharedTensor:
+    global _shared_vmm_use_fabric
+
+    rank = dist.get_rank(group=cpu_group)
+    world_size = dist.get_world_size(group=cpu_group)
+    _validate_same_host_group(cpu_group)
+
+    drv = None
+    device_id = None
+    posix_fd = None
+    prop = None
+    granularity = None
+    local_rows = None
+    aligned_bytes = None
+    preflight_error = None
+    try:
+        drv = _get_cuda_driver()
+        device_id = torch.cuda.current_device()
+        posix_fd = (
+            drv.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR
+        )
+        prop = drv.CUmemAllocationProp()
+        prop.requestedHandleTypes = _shareable_allocation_handle_types(drv)
+        prop.type = drv.CUmemAllocationType.CU_MEM_ALLOCATION_TYPE_PINNED
+        prop.location = drv.CUmemLocation()
+        prop.location.type = drv.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE
+        prop.location.id = device_id
+        if hasattr(prop, "allocFlags") and hasattr(
+            prop.allocFlags, "gpuDirectRDMACapable"
+        ):
+            prop.allocFlags.gpuDirectRDMACapable = 1
+
+        granularity = int(
+            check_drv(
+                drv.cuMemGetAllocationGranularity(
+                    prop,
+                    drv.CUmemAllocationGranularity_flags.CU_MEM_ALLOC_GRANULARITY_RECOMMENDED,
+                ),
+                "cuMemGetAllocationGranularity",
+            )
+        )
+        local_rows, aligned_bytes = _align_first_dim(
+            local_shape,
+            dtype=dtype,
+            granularity=granularity,
+            first_dim_multiple=first_dim_multiple,
+        )
+    except BaseException as error:
+        preflight_error = error
+    _synchronize_vmm_stage(cpu_group, rank, "preflight", preflight_error)
+    assert drv is not None
+    assert device_id is not None
+    assert posix_fd is not None
+    assert prop is not None
+    assert granularity is not None
+    assert local_rows is not None
+    assert aligned_bytes is not None
+
+    err, local_handle = drv.cuMemCreate(aligned_bytes, prop, 0)
+    if not all_ranks_ok(cpu_group, err == drv.CUresult.CUDA_SUCCESS):
+        if err == drv.CUresult.CUDA_SUCCESS:
+            drv.cuMemRelease(local_handle)
+        _shared_vmm_use_fabric = False
+        prop.requestedHandleTypes = posix_fd
+        err, local_handle = drv.cuMemCreate(aligned_bytes, prop, 0)
+        create_error = (
+            None
+            if err == drv.CUresult.CUDA_SUCCESS
+            else RuntimeError(f"cuMemCreate(POSIX_FD): {err}")
+        )
+        try:
+            _synchronize_vmm_stage(cpu_group, rank, "allocation", create_error)
+        except BaseException:
+            if err == drv.CUresult.CUDA_SUCCESS:
+                drv.cuMemRelease(local_handle)
+            raise
+    elif err != drv.CUresult.CUDA_SUCCESS:
+        raise RuntimeError(f"cuMemCreate(FABRIC): {err}")
+
+    local_fds: list[int] = []
+    peer_fds: dict[tuple[int, int], int] = {}
+    imported_handles = []
+    base_va = None
+    rank_local_base_va = None
+    mapped_global_addresses: list[int] = []
+    mapped_local_addresses: list[int] = []
+    retained_handles: list = []
+    total_bytes = aligned_bytes * world_size
+    try:
+        fabric_handles, local_fds, use_fabric = _export_shareable_handles(
+            [local_handle], cpu_group, rank
+        )
+        gathered_handles = [None] * world_size
+        if use_fabric:
+            dist.all_gather_object(gathered_handles, fabric_handles[0], group=cpu_group)
+        else:
+            peer_fds = exchange_posix_fds(
+                cpu_group, rank, world_size, local_fds, [1] * world_size
+            )
+
+        mapping_error = None
+        try:
+            base_va = int(
+                check_drv(
+                    drv.cuMemAddressReserve(total_bytes, granularity, 0, 0),
+                    "cuMemAddressReserve",
+                )
+            )
+            if map_rank_local:
+                rank_local_base_va = int(
+                    check_drv(
+                        drv.cuMemAddressReserve(total_bytes, granularity, 0, 0),
+                        "cuMemAddressReserve(rank_local)",
+                    )
+                )
+            for peer_rank in range(world_size):
+                handle = local_handle
+                if peer_rank != rank:
+                    handle = import_peer_handle(
+                        gathered_handles[peer_rank],
+                        None if use_fabric else peer_fds[(peer_rank, 0)],
+                        use_fabric=use_fabric,
+                        peer_rank=peer_rank,
+                    )
+                    imported_handles.append(handle)
+                address = base_va + peer_rank * aligned_bytes
+                check_drv(
+                    drv.cuMemMap(address, aligned_bytes, 0, handle, 0),
+                    f"cuMemMap(rank={peer_rank})",
+                )
+                mapped_global_addresses.append(address)
+                check_drv(
+                    drv.cuMemSetAccess(
+                        address,
+                        aligned_bytes,
+                        [make_rw_access_desc(device_id)],
+                        1,
+                    ),
+                    f"cuMemSetAccess(rank={peer_rank})",
+                )
+
+                if map_rank_local:
+                    local_segment = (peer_rank - rank) % world_size
+                    local_address = rank_local_base_va + local_segment * aligned_bytes
+                    check_drv(
+                        drv.cuMemMap(local_address, aligned_bytes, 0, handle, 0),
+                        f"cuMemMap(rank_local={peer_rank})",
+                    )
+                    mapped_local_addresses.append(local_address)
+                    check_drv(
+                        drv.cuMemSetAccess(
+                            local_address,
+                            aligned_bytes,
+                            [make_rw_access_desc(device_id)],
+                            1,
+                        ),
+                        f"cuMemSetAccess(rank_local={peer_rank})",
+                    )
+        except BaseException as error:
+            mapping_error = error
+
+        _synchronize_vmm_stage(cpu_group, rank, "mapping", mapping_error)
+        refs = []
+        global_view, rank_local_view, local_view = _construct_rank_major_views(
+            cpu_group=cpu_group,
+            rank=rank,
+            base_va=base_va,
+            rank_local_base_va=rank_local_base_va,
+            world_size=world_size,
+            local_rows=local_rows,
+            row_shape=local_shape[1:],
+            dtype=dtype,
+            device_id=device_id,
+            refs=refs,
+        )
+        retained_handles.extend(imported_handles)
+        imported_handles.clear()
+        retained_handles.append(local_handle)
+        local_handle = None
+        _release_vmm_handles_synchronized(
+            drv,
+            retained_handles=retained_handles,
+            cpu_group=cpu_group,
+            rank=rank,
+        )
+        return RankMajorSharedTensor(
+            global_view=global_view,
+            rank_local_view=rank_local_view,
+            local_view=local_view,
+            local_rows=local_rows,
+            aligned_bytes_per_rank=aligned_bytes,
+            _base_va=base_va,
+            _rank_local_base_va=rank_local_base_va,
+            _total_bytes=total_bytes,
+            _world_size=world_size,
+            _refs=refs,
+        )
+    except BaseException:
+        _release_partial_vmm_mapping(
+            drv,
+            base_va=base_va,
+            total_bytes=total_bytes,
+            mapped_addresses=mapped_global_addresses,
+            segment_bytes=aligned_bytes,
+        )
+        _release_partial_vmm_mapping(
+            drv,
+            base_va=rank_local_base_va,
+            total_bytes=total_bytes,
+            mapped_addresses=mapped_local_addresses,
+            segment_bytes=aligned_bytes,
+        )
+        for handle in imported_handles:
+            drv.cuMemRelease(handle)
+        for handle in retained_handles:
+            drv.cuMemRelease(handle)
+        retained_handles.clear()
+        if local_handle is not None:
+            drv.cuMemRelease(local_handle)
+        raise
+    finally:
+        for fd in local_fds:
+            os.close(fd)
+        for fd in peer_fds.values():
+            os.close(fd)
+
+
+def create_rank_major_shared_slab(
+    layer_shape: tuple[int, ...],
+    *,
+    layer_num: int,
+    dtype: torch.dtype,
+    cpu_group: ProcessGroup,
+    first_dim_multiple: int = 1,
+    map_rank_local: bool = True,
+) -> RankMajorSharedSlab:
+    layer_rows = layer_shape[0]
+    allocation = create_rank_major_shared_tensor(
+        (layer_num * layer_rows, *layer_shape[1:]),
+        dtype=dtype,
+        cpu_group=cpu_group,
+        first_dim_multiple=first_dim_multiple,
+        map_rank_local=map_rank_local,
+    )
+    rank_stride_rows = allocation.local_rows
+    global_span = (allocation._world_size - 1) * rank_stride_rows + layer_rows
+
+    def layer_views(base: torch.Tensor) -> list[torch.Tensor]:
+        return [
+            base.narrow(0, layer_id * layer_rows, global_span)
+            for layer_id in range(layer_num)
+        ]
+
+    local_views = [
+        allocation.local_view.narrow(0, layer_id * layer_rows, layer_rows)
+        for layer_id in range(layer_num)
+    ]
+    return RankMajorSharedSlab(
+        allocation=allocation,
+        layer_rows=layer_rows,
+        global_views=layer_views(allocation.global_view),
+        rank_local_views=(
+            layer_views(allocation.rank_local_view)
+            if allocation.rank_local_view is not None
+            else []
+        ),
+        local_views=local_views,
+    )

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -450,6 +450,9 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
     # === Borrowed from ScheduleBatch: host metadata (CPU lists / mirrors) ===
     # Optional seq_lens on cpu (CPU mirror of seq_lens)
     seq_lens_cpu: Optional[torch.Tensor] = None
+    # CPU mirror of req_pool_indices. Shared Decode demand-cache lifecycle uses
+    # this to reset a request slice without synchronizing the device tensor.
+    req_pool_indices_cpu: Optional[torch.Tensor] = None
 
     # For logprob
     top_logprobs_nums: Optional[List[int]] = None
@@ -767,6 +770,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             seq_lens_sum=batch.seq_lens_sum,
             # Inputs aliased by reference from ScheduleBatch
             seq_lens_cpu=seq_lens_cpu,
+            req_pool_indices_cpu=batch.req_pool_indices_cpu,
             orig_seq_lens=batch.orig_seq_lens,
             out_cache_loc_dsv4=batch.out_cache_loc_dsv4,
             mamba_track_indices=batch.mamba_track_indices,

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -170,6 +170,49 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
             if has_kv_on_another_pp_stage
             else kvc.server_args.max_total_tokens or kvc.model_config.context_len
         )
+        self._fixed_bytes = 0
+        self._indexer_pool_cache_num_layers = 0
+        self._indexer_pool_cache_page_size = kvc.page_size
+        self._indexer_pool_cache_bytes_per_token = 0
+        server_args = kvc.server_args
+        from sglang.srt.layers.cp.utils import (
+            is_glm_dsa_cache_shared_enabled,
+            is_glm_dsa_shared_indexer_enabled,
+        )
+
+        if is_glm_dsa_shared_indexer_enabled(kvc):
+            from sglang.srt.mem_cache.dsa_shared_demand import (
+                get_indexer_pool_cache_layer_ids,
+            )
+
+            self._indexer_pool_cache_num_layers = len(
+                get_indexer_pool_cache_layer_ids(
+                    kvc.model_config.hf_config,
+                    kvc.layer_info.start_layer,
+                    kvc.layer_info.end_layer,
+                )
+            )
+            index_head_dim = get_dsa_index_head_dim(kvc.model_config.hf_config)
+            self._indexer_pool_cache_bytes_per_token = (
+                index_head_dim + index_head_dim // DSATokenToKVPool.quant_block_size * 4
+            ) * DSATokenToKVPool.index_k_with_scale_buffer_dtype.itemsize
+        if (
+            is_glm_dsa_cache_shared_enabled(kvc)
+            and server_args.dsa_prefill_backend in ("flashmla_kv", "flashmla_auto")
+            and server_args.dsa_decode_backend == "flashmla_kv"
+        ):
+            from sglang.srt.mem_cache.dsa_shared_demand import (
+                get_flashmla_shared_demand_workspace_bytes,
+                resolve_flashmla_shared_max_current_rows,
+            )
+
+            self._fixed_bytes = get_flashmla_shared_demand_workspace_bytes(
+                num_layers=num_layers,
+                num_request_slots=server_args.max_running_requests,
+                max_current_rows=resolve_flashmla_shared_max_current_rows(
+                    server_args.speculative_num_draft_tokens
+                ),
+            )
 
         # EAGLE/STANDALONE: scale cell_size to account for draft model KV cache.
         # Assumes draft and target share the same per-layer KV size (head_dim,
@@ -179,6 +222,8 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
             kvc.spec_algorithm.is_eagle() or kvc.spec_algorithm.is_standalone()
         ) and not kvc.is_draft_worker:
             eagle_draft_num_layers = kvc.spec_aux_config.eagle_draft_num_layers
+            if eagle_draft_num_layers is None and is_glm_dsa_cache_shared_enabled(kvc):
+                eagle_draft_num_layers = kvc.model_config.num_nextn_predict_layers
             if (
                 eagle_draft_num_layers is not None
                 and int(eagle_draft_num_layers) > 0
@@ -193,11 +238,17 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
                     target_kv_size = self._cell_size - target_indexer_size
                     from sglang.srt.layers.cp.utils import (
                         get_glm_dsa_layer_split_effective_num_layers,
+                        get_glm_dsa_shared_effective_num_layers,
+                        is_glm_dsa_cache_shared_enabled,
                     )
 
                     target_kv_num_layers = get_glm_dsa_layer_split_effective_num_layers(
                         kvc, num_layers
                     )
+                    if is_glm_dsa_cache_shared_enabled(kvc):
+                        target_kv_num_layers = get_glm_dsa_shared_effective_num_layers(
+                            kvc, num_layers
+                        )
                     draft_kv_size = int(
                         target_kv_size * draft_num_layers / target_kv_num_layers
                     )
@@ -211,6 +262,17 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
                     self._cell_size = int(
                         self._cell_size * (1 + draft_num_layers / int(num_layers))
                     )
+
+        if server_args.enable_dsa_shared_kv_cache:
+            logger.info(
+                "Shared DSA pool accounting: target_shared=%s "
+                "cell_bytes_per_token=%s fixed_workspace_bytes=%s "
+                "indexer_pool_cache_layers=%s",
+                is_glm_dsa_cache_shared_enabled(kvc),
+                self._cell_size,
+                self._fixed_bytes,
+                self._indexer_pool_cache_num_layers,
+            )
 
         # DFLASH/DSPARK: scale cell_size to account for draft model KV cache
         if kvc.spec_algorithm.is_dflash_family() and not kvc.is_draft_worker:
@@ -232,6 +294,18 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
                     draft_cell_size_per_token=_dflash_draft_cell_size(kvc) or None,
                 )
 
+    def _variable_bytes_for_tokens(self, num_tokens: int) -> int:
+        from sglang.srt.mem_cache.dsa_shared_demand import (
+            get_indexer_pool_cache_bytes,
+        )
+
+        return get_indexer_pool_cache_bytes(
+            num_tokens=num_tokens,
+            page_size=self._indexer_pool_cache_page_size,
+            num_layers=self._indexer_pool_cache_num_layers,
+            indexer_bytes_per_token=self._indexer_pool_cache_bytes_per_token or 1,
+        )
+
     def _compute_cell_size(self, kvc: KVCacheConfigurator, num_layers: int) -> int:
         """Compute per-token KV cache cost in bytes. Subclasses can override."""
         # args to config cell size
@@ -239,11 +313,18 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
         kv_cache_dtype = kvc.kv_cache_dtype
         from sglang.srt.layers.cp.utils import (
             get_glm_dsa_layer_split_effective_num_layers,
+            get_glm_dsa_shared_effective_num_layers,
+            is_glm_dsa_cache_shared_enabled,
         )
 
         effective_num_layers = get_glm_dsa_layer_split_effective_num_layers(
             kvc, num_layers
         )
+        dsa_shared_enabled = is_glm_dsa_cache_shared_enabled(kvc)
+        if dsa_shared_enabled:
+            effective_num_layers = get_glm_dsa_shared_effective_num_layers(
+                kvc, num_layers
+            )
 
         kv_size = torch._utils._element_size(kv_cache_dtype)
         tp_size = get_parallel().attn_tp_size
@@ -370,11 +451,22 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
 
             indexer_ratio = parse_hisparse_config(kvc.server_args).host_to_device_ratio
 
+        from sglang.srt.layers.cp.utils import (
+            get_glm_dsa_shared_effective_num_layers,
+            is_glm_dsa_shared_indexer_enabled,
+        )
         from sglang.srt.mem_cache.kv_cache_configurator import (
             _should_elide_dsa_index_k,
         )
 
-        if allocate_all_layers or not _should_elide_dsa_index_k(
+        if is_glm_dsa_shared_indexer_enabled(kvc) and not allocate_all_layers:
+            # Shared Indexer keeps every logical layer but page-owner-shards its
+            # authoritative storage across the CP group. Demand-cache workspace
+            # is accounted separately as a variable token cost.
+            num_indexer_layers = get_glm_dsa_shared_effective_num_layers(
+                kvc, num_layers
+            )
+        elif allocate_all_layers or not _should_elide_dsa_index_k(
             is_draft_worker=kvc.is_draft_worker
         ):
             num_indexer_layers = num_layers
@@ -415,11 +507,26 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
     def calculate_pool_sizes(
         self, available_bytes: int, page_size: int
     ) -> MemoryPoolConfig:
-        max_total_num_tokens = (
-            available_bytes // self._cell_size
-            if self._cell_size
-            else self._zero_kv_max_tokens
-        )
+        available_bytes = max(available_bytes - self._fixed_bytes, 0)
+        if not self._cell_size:
+            max_total_num_tokens = self._zero_kv_max_tokens
+        elif self._indexer_pool_cache_num_layers == 0:
+            max_total_num_tokens = available_bytes // self._cell_size
+        else:
+            upper_pages = available_bytes // self._cell_size // page_size
+            lower_pages = 0
+            while lower_pages < upper_pages:
+                candidate_pages = (lower_pages + upper_pages + 1) // 2
+                candidate_tokens = candidate_pages * page_size
+                used_bytes = (
+                    candidate_tokens * self._cell_size
+                    + self._variable_bytes_for_tokens(candidate_tokens)
+                )
+                if used_bytes <= available_bytes:
+                    lower_pages = candidate_pages
+                else:
+                    upper_pages = candidate_pages - 1
+            max_total_num_tokens = lower_pages * page_size
         max_total_num_tokens = max_total_num_tokens // page_size * page_size
         return MemoryPoolConfig(max_total_num_tokens=max_total_num_tokens)
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1133,6 +1133,18 @@ class ServerArgs:
         "Split DSA (DeepSeek Sparse Attention) GPU KV/indexer cache layers across context-parallel ranks to reduce per-rank KV memory. Currently only supported with the mooncake transfer backend (mooncake / mooncake_tcp); mori/nixl support will be added later by the community.",
         NS("parallel"),
     ] = False
+    enable_dsa_shared_kv_cache: A[
+        bool,
+        "Share DSA Main-KV and Indexer cache pages across context-parallel "
+        "ranks on mixed Prefill/Decode workers.",
+        NS("parallel"),
+    ] = False
+    disable_dsa_shared_indexer_cache: A[
+        bool,
+        "Keep a full local DSA Indexer cache on every rank while sharing only "
+        "Main KV. This trades KV capacity for lower Indexer read overhead.",
+        NS("parallel"),
+    ] = False
     enable_dsa_prefill_context_parallel: A[bool, Arg(no_cli=True), NS("parallel")] = (
         False
     )
@@ -5266,6 +5278,97 @@ class ServerArgs:
                 "--enable-dsa-cache-layer-split is only supported for DSA "
                 "(DeepSeek Sparse Attention) models."
             )
+        if (
+            self.disable_dsa_shared_indexer_cache
+            and not self.enable_dsa_shared_kv_cache
+        ):
+            raise ValueError(
+                "--disable-dsa-shared-indexer-cache requires "
+                "--enable-dsa-shared-kv-cache."
+            )
+        if self.enable_dsa_shared_kv_cache:
+            if not is_cuda():
+                raise ValueError("--enable-dsa-shared-kv-cache requires NVIDIA CUDA.")
+            if self.enable_dsa_cache_layer_split:
+                raise ValueError(
+                    "--enable-dsa-shared-kv-cache and "
+                    "--enable-dsa-cache-layer-split cannot be enabled together."
+                )
+            if not is_deepseek_dsa(hf_config):
+                raise ValueError(
+                    "--enable-dsa-shared-kv-cache is only supported for DSA "
+                    "(DeepSeek Sparse Attention) models."
+                )
+            if model_arch != "GlmMoeDsaForCausalLM":
+                raise ValueError(
+                    "--enable-dsa-shared-kv-cache release support is limited "
+                    "to GLM-5.2 (GlmMoeDsaForCausalLM)."
+                )
+            if self.attn_cp_size <= 1:
+                raise ValueError(
+                    "--enable-dsa-shared-kv-cache requires "
+                    "--attn-cp-size greater than 1."
+                )
+            if self.tp_size != 8 or self.attn_cp_size != 8:
+                raise ValueError(
+                    "--enable-dsa-shared-kv-cache release support requires " "TP8/CP8."
+                )
+            if self.nnodes != 1:
+                raise ValueError(
+                    "--enable-dsa-shared-kv-cache release support requires a "
+                    "single node (--nnodes 1)."
+                )
+            if self.dp_size != 1:
+                raise ValueError(
+                    "--enable-dsa-shared-kv-cache release support requires DP1."
+                )
+            import torch
+
+            if torch.cuda.get_device_capability()[0] != 9:
+                raise ValueError(
+                    "--enable-dsa-shared-kv-cache release support requires SM90."
+                )
+            requested_attention_backends = {
+                "--attention-backend": self.attention_backend,
+                "--prefill-attention-backend": self.prefill_attention_backend,
+                "--decode-attention-backend": self.decode_attention_backend,
+            }
+            invalid_attention_backends = [
+                f"{name}={backend!r}"
+                for name, backend in requested_attention_backends.items()
+                if backend not in (None, "dsa")
+            ]
+            if invalid_attention_backends:
+                raise ValueError(
+                    "--enable-dsa-shared-kv-cache release scope requires the "
+                    "attention backend to resolve to dsa; got "
+                    + ", ".join(invalid_attention_backends)
+                    + "."
+                )
+            release_settings = {
+                "--quantization": (self.quantization, "w4afp8"),
+                "--kv-cache-dtype": (self.kv_cache_dtype, "fp8_e4m3"),
+                "--page-size": (self.page_size, 64),
+                "--dsa-prefill-backend": (
+                    self.dsa_prefill_backend,
+                    "flashmla_kv",
+                ),
+                "--dsa-decode-backend": (
+                    self.dsa_decode_backend,
+                    "flashmla_kv",
+                ),
+            }
+            invalid_release_settings = [
+                f"{name}={actual!r} (expected {expected!r})"
+                for name, (actual, expected) in release_settings.items()
+                if actual != expected
+            ]
+            if invalid_release_settings:
+                raise ValueError(
+                    "--enable-dsa-shared-kv-cache release scope requires "
+                    + ", ".join(invalid_release_settings)
+                    + "."
+                )
 
         if self.enable_cp_decode_attn_tp:
             from sglang.srt.layers.cp.cp_decode_attn_tp import (
@@ -5387,6 +5490,45 @@ class ServerArgs:
                     )
                     self._set_default_dsa_backends(major)
 
+                if self.enable_dsa_shared_kv_cache:
+                    if (
+                        self.max_running_requests is None
+                        or not 1 <= self.max_running_requests <= 32
+                    ):
+                        raise ValueError(
+                            "--enable-dsa-shared-kv-cache requires an explicit "
+                            "--max-running-requests in [1, 32]."
+                        )
+                    if self.disaggregation_mode != "null":
+                        raise ValueError(
+                            "--enable-dsa-shared-kv-cache currently supports "
+                            "only mixed Prefill/Decode workers "
+                            "(--disaggregation-mode null)."
+                        )
+                    if int(resolved_view(self).attn_cp_size) <= 1:
+                        raise ValueError(
+                            "--enable-dsa-shared-kv-cache requires "
+                            "--attn-cp-size greater than 1."
+                        )
+                    if self.enable_hisparse:
+                        raise ValueError(
+                            "--enable-dsa-shared-kv-cache is incompatible "
+                            "with HiSparse."
+                        )
+                    if (
+                        self.speculative_algorithm is not None
+                        and self.speculative_num_draft_tokens is not None
+                        and self.speculative_num_draft_tokens > 4
+                    ):
+                        raise ValueError(
+                            "--enable-dsa-shared-kv-cache supports at most four "
+                            "speculative draft tokens."
+                        )
+                    if self.enable_hierarchical_cache:
+                        raise ValueError(
+                            "--enable-dsa-shared-kv-cache does not yet support "
+                            "hierarchical cache."
+                        )
                 if self.enable_prefill_cp:
                     assert (
                         self.disaggregation_mode != "decode"
@@ -5437,7 +5579,18 @@ class ServerArgs:
                         "prefill context parallelism, and CP + PP has not been "
                         "validated for this feature."
                     )
-
+                if self.enable_dsa_shared_kv_cache and (
+                    not self.enable_prefill_cp or self.cp_strategy != "interleave"
+                ):
+                    raise ValueError(
+                        "--enable-dsa-shared-kv-cache requires "
+                        "--enable-prefill-cp and --cp-strategy interleave."
+                    )
+                if self.enable_dsa_shared_kv_cache and self.pp_size > 1:
+                    raise ValueError(
+                        "--enable-dsa-shared-kv-cache is not supported with "
+                        "pipeline parallelism (pp_size > 1)."
+                    )
             else:
                 # DeepSeek V3/R1/V3.1
                 if self.cuda_graph_config.prefill.backend != Backend.DISABLED:

--- a/test/registered/kernels/ops/attention/test_dsa_transform_index.py
+++ b/test/registered/kernels/ops/attention/test_dsa_transform_index.py
@@ -7,6 +7,7 @@ import sglang.kernels.ops.attention.dsa.transform_index as transform_index_modul
 from sglang.kernels.ops.attention.dsa.transform_index import (
     transform_index_page_table_decode_fast,
     transform_index_page_table_prefill_fast,
+    translate_owner_sharded_slots,
 )
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
@@ -230,6 +231,96 @@ class TestDSATransformIndex(CustomTestCase):
     def test_decode_fast_correctness_and_strides(self):
         self._check_decode_case(17, 8192, provide_result=True)
         self._check_decode_case(17, 8192, zero_row_stride=True)
+
+    def test_decode_owner_sharded_translation(self):
+        page_table = torch.tensor(
+            [[0, 63, 64, 127, 128, 511, 512, 1023, 1024, -1]],
+            dtype=torch.int32,
+            device=self.device,
+        )
+        topk_indices = torch.full((1, TOPK), -1, dtype=torch.int64, device=self.device)
+        topk_indices[0, :10] = torch.arange(10, device=self.device)
+
+        actual = transform_index_page_table_decode_fast(
+            page_table=page_table,
+            topk_indices=topk_indices,
+            owner_cp_size=8,
+            owner_page_size=64,
+            owner_pages_per_rank=32,
+        )
+        torch.cuda.synchronize()
+
+        expected_prefix = torch.tensor(
+            [0, 63, 2048, 2111, 4096, 14399, 64, 14463, 128, -1],
+            dtype=torch.int32,
+            device=self.device,
+        )
+        torch.testing.assert_close(actual[0, :10], expected_prefix, rtol=0, atol=0)
+        self.assertTrue(torch.all(actual[0, 10:] == -1))
+
+    def test_owner_sharded_slots_translation(self):
+        logical_slots = torch.tensor(
+            [
+                [0, 63, 64, 127, 128, 511, 512, 1023, 1024, -1],
+                [1024, 0, 512, 64, 63, 128, 127, 511, 1023, -1],
+            ],
+            dtype=torch.int32,
+            device=self.device,
+        )
+        actual = translate_owner_sharded_slots(
+            logical_slots,
+            owner_cp_size=8,
+            owner_page_size=64,
+            owner_pages_per_rank=32,
+        )
+        torch.cuda.synchronize()
+
+        expected = torch.tensor(
+            [
+                [0, 63, 2048, 2111, 4096, 14399, 64, 14463, 128, -1],
+                [128, 0, 64, 2048, 63, 4096, 2111, 14399, 14463, -1],
+            ],
+            dtype=torch.int32,
+            device=self.device,
+        )
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+    def test_owner_sharded_slots_marks_causal_current_rows(self):
+        logical_slots = torch.tensor(
+            [
+                [10, 20, 30, 40, -1],
+                [10, 20, 30, 40, -1],
+                [10, 20, 30, 40, -1],
+                [10, 20, 30, 40, -1],
+            ],
+            dtype=torch.int32,
+            device=self.device,
+        )
+        current_row_locs = torch.tensor(
+            [10, 20, 30, 40], dtype=torch.int64, device=self.device
+        )
+
+        actual = translate_owner_sharded_slots(
+            logical_slots,
+            owner_cp_size=8,
+            owner_page_size=64,
+            owner_pages_per_rank=32,
+            current_row_locs=current_row_locs,
+            current_rows_per_request=4,
+        )
+        torch.cuda.synchronize()
+
+        expected = torch.tensor(
+            [
+                [-2, 20, 30, 40, -1],
+                [-2, -3, 30, 40, -1],
+                [-2, -3, -4, 40, -1],
+                [-2, -3, -4, -5, -1],
+            ],
+            dtype=torch.int32,
+            device=self.device,
+        )
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
 
     def test_decode_fast_extreme_shapes(self):
         self._check_decode_case(8192, 4096)

--- a/test/registered/kernels/ops/attention/test_dsv32_indexer_fusion.py
+++ b/test/registered/kernels/ops/attention/test_dsv32_indexer_fusion.py
@@ -138,6 +138,67 @@ def test_k_store_matches_unfused(strided):
     assert torch.equal(buf_ref, buf_fused)
 
 
+def test_k_store_owner_write_matches_full_buffer():
+    _skip_if_unavailable()
+    if not can_use_dsa_fused_store(torch.bfloat16, torch.int64, PAGE_SIZE):
+        pytest.skip("fused store JIT unavailable")
+
+    dev = "cuda"
+    cp_size = 4
+    pages_per_rank = 2
+    loc = torch.arange(cp_size * pages_per_rank, device=dev, dtype=torch.int64)
+    loc = loc * PAGE_SIZE + 3
+    B = loc.numel()
+    _, _, cos_sin_cache, positions = _make_inputs(B)
+    key = torch.randn(B, HEAD_DIM, dtype=torch.bfloat16, device=dev)
+    weight = torch.randn(HEAD_DIM, dtype=torch.float32, device=dev)
+    bias = torch.randn(HEAD_DIM, dtype=torch.float32, device=dev)
+
+    full = torch.zeros(
+        cp_size * pages_per_rank,
+        BYTES_PER_TOKEN * PAGE_SIZE,
+        dtype=torch.uint8,
+        device=dev,
+    )
+    fused_k_indexer_norm_rope_store(
+        key, full, loc, weight, bias, EPS, cos_sin_cache, positions, PAGE_SIZE
+    )
+
+    key_bf16 = fused_k_indexer_norm_rope(
+        key, weight, bias, EPS, cos_sin_cache, positions
+    )
+    for rank in range(cp_size):
+        expected = full[rank::cp_size]
+        fused_owner = torch.zeros_like(expected)
+        store_owner = torch.zeros_like(expected)
+
+        fused_k_indexer_norm_rope_store(
+            key,
+            fused_owner,
+            loc,
+            weight,
+            bias,
+            EPS,
+            cos_sin_cache,
+            positions,
+            PAGE_SIZE,
+            owner_rank=rank,
+            owner_size=cp_size,
+        )
+        fused_store_index_k_cache(
+            key_bf16,
+            store_owner,
+            loc,
+            PAGE_SIZE,
+            owner_rank=rank,
+            owner_size=cp_size,
+        )
+        torch.cuda.synchronize()
+
+        assert torch.equal(fused_owner, expected)
+        assert torch.equal(store_owner, expected)
+
+
 # ----------------------------------------------------------------------------
 # Q kernel: rope-first + fp8 quant + head-gate fold
 # ----------------------------------------------------------------------------

--- a/test/registered/kernels/ops/attention/test_flashmla_shared_demand_cache_correctness.py
+++ b/test/registered/kernels/ops/attention/test_flashmla_shared_demand_cache_correctness.py
@@ -1,0 +1,196 @@
+import unittest
+
+import torch
+
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(
+    est_time=60,
+    stage="base-b-kernel-unit",
+    runner_config="1-gpu-large",
+)
+
+
+class TestFlashMLASharedDemandCacheCorrectness(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("FlashMLA Shared-KV requires CUDA")
+        if torch.cuda.get_device_capability()[0] != 9:
+            raise unittest.SkipTest("FlashMLA Shared-KV requires SM90")
+
+        from sgl_kernel.flash_mla import (
+            flash_mla_with_kvcache,
+            get_mla_metadata,
+        )
+
+        cls.flash_mla_with_kvcache = staticmethod(flash_mla_with_kvcache)
+        cls.get_mla_metadata = staticmethod(get_mla_metadata)
+
+    def _fixture(self, *, seq_q: int):
+        device = torch.device("cuda")
+        torch.manual_seed(20260811)
+        num_rows = 2048
+        page_size = 64
+        num_heads = 64
+
+        rows = torch.empty((num_rows, 656), dtype=torch.uint8, device=device)
+        rows[:, :512].view(torch.float8_e4m3fn).copy_(
+            torch.randn((num_rows, 512), device=device).clamp_(-4, 4)
+        )
+        rows[:, 512:528].view(torch.float32).copy_(
+            torch.rand((num_rows, 4), dtype=torch.float32, device=device) + 0.25
+        )
+        rows[:, 528:].view(torch.bfloat16).copy_(
+            torch.randn((num_rows, 64), dtype=torch.bfloat16, device=device)
+        )
+        k_cache = rows.view(num_rows // page_size, page_size, 1, 656)
+        q = torch.randn((1, seq_q, num_heads, 576), dtype=torch.bfloat16, device=device)
+        indices = (
+            torch.arange(num_rows, dtype=torch.int32, device=device)
+            .view(1, 1, num_rows)
+            .expand(1, seq_q, num_rows)
+            .contiguous()
+        )
+        cache_seqlens = torch.full((1,), num_rows, dtype=torch.int32, device=device)
+        metadata, num_splits = self.get_mla_metadata(
+            cache_seqlens=cache_seqlens,
+            num_q_tokens_per_head_k=seq_q * num_heads,
+            num_heads_k=1,
+            num_heads_q=num_heads,
+            is_fp8_kvcache=True,
+            topk=num_rows,
+        )
+        return q, k_cache, rows, indices, cache_seqlens, metadata, num_splits
+
+    def _run_direct(self, q, k_cache, indices, cache_seqlens, metadata, num_splits):
+        return self.flash_mla_with_kvcache(
+            q=q,
+            k_cache=k_cache,
+            block_table=torch.empty((1, 0), dtype=torch.int32, device=q.device),
+            cache_seqlens=cache_seqlens,
+            head_dim_v=512,
+            tile_scheduler_metadata=metadata,
+            num_splits=num_splits,
+            is_fp8_kvcache=True,
+            indices=indices,
+        )
+
+    def _shared_kwargs(self, *, q, cache_rows, local_begin, local_end):
+        return dict(
+            shared_kv_row_cache=torch.empty(
+                (cache_rows, 656), dtype=torch.uint8, device=q.device
+            ),
+            shared_kv_cache_tags=torch.zeros(
+                (1, cache_rows), dtype=torch.int64, device=q.device
+            ),
+            shared_kv_cache_rows_per_request=cache_rows,
+            shared_kv_num_request_slots=1,
+            shared_kv_cache_epoch=1,
+            shared_kv_cache_generation_tensor=torch.ones(
+                (), dtype=torch.int32, device=q.device
+            ),
+            shared_kv_local_row_begin=local_begin,
+            shared_kv_local_row_end=local_end,
+        )
+
+    def test_request_slot_reuse_refills_after_lifecycle_invalidation(self):
+        q, k_cache, rows, indices, cache_seqlens, metadata, num_splits = self._fixture(
+            seq_q=1
+        )
+        kwargs = self._shared_kwargs(
+            q=q, cache_rows=4096, local_begin=2047, local_end=2048
+        )
+
+        self.flash_mla_with_kvcache(
+            q=q,
+            k_cache=k_cache,
+            block_table=torch.empty((1, 0), dtype=torch.int32, device=q.device),
+            cache_seqlens=cache_seqlens,
+            head_dim_v=512,
+            tile_scheduler_metadata=metadata,
+            num_splits=num_splits,
+            is_fp8_kvcache=True,
+            indices=indices,
+            **kwargs,
+        )
+
+        rows[17].copy_(rows[23])
+        # Production only rewrites a physical row after its old request slot is
+        # released.  The request-generation lifecycle clears that slot's tags
+        # before the replacement request can execute attention.
+        kwargs["shared_kv_cache_tags"].zero_()
+        kwargs["shared_kv_cache_generation_tensor"].fill_(2)
+        expected_out, expected_lse = self._run_direct(
+            q, k_cache, indices, cache_seqlens, metadata, num_splits
+        )
+        actual_out, actual_lse = self.flash_mla_with_kvcache(
+            q=q,
+            k_cache=k_cache,
+            block_table=torch.empty((1, 0), dtype=torch.int32, device=q.device),
+            cache_seqlens=cache_seqlens,
+            head_dim_v=512,
+            tile_scheduler_metadata=metadata,
+            num_splits=num_splits,
+            is_fp8_kvcache=True,
+            indices=indices,
+            **kwargs,
+        )
+
+        torch.testing.assert_close(actual_out, expected_out, rtol=0, atol=0)
+        torch.testing.assert_close(actual_lse, expected_lse, rtol=0, atol=0)
+
+    def test_current_row_widths_one_to_four_match_authoritative_rows(self):
+        for width in range(1, 5):
+            with self.subTest(width=width):
+                q, k_cache, rows, indices, cache_seqlens, metadata, num_splits = (
+                    self._fixture(seq_q=width)
+                )
+                expected_out, expected_lse = self._run_direct(
+                    q, k_cache, indices, cache_seqlens, metadata, num_splits
+                )
+                marked_indices = indices.clone()
+                current_rows = torch.empty(
+                    (width, width, 656), dtype=torch.uint8, device=q.device
+                )
+                current_row_ids = torch.full(
+                    (width, width), -1, dtype=torch.int32, device=q.device
+                )
+                current_row_counts = torch.arange(
+                    1, width + 1, dtype=torch.int32, device=q.device
+                )
+                for query_row in range(width):
+                    count = query_row + 1
+                    marked_indices[0, query_row, :count] = torch.arange(
+                        -2, -2 - count, -1, dtype=torch.int32, device=q.device
+                    )
+                    current_rows[query_row, :count].copy_(rows[:count])
+                    current_row_ids[query_row, :count] = torch.arange(
+                        count, dtype=torch.int32, device=q.device
+                    )
+
+                kwargs = self._shared_kwargs(
+                    q=q, cache_rows=4096, local_begin=0, local_end=2048
+                )
+                actual_out, actual_lse = self.flash_mla_with_kvcache(
+                    q=q,
+                    k_cache=k_cache,
+                    block_table=torch.empty((1, 0), dtype=torch.int32, device=q.device),
+                    cache_seqlens=cache_seqlens,
+                    head_dim_v=512,
+                    tile_scheduler_metadata=metadata,
+                    num_splits=num_splits,
+                    is_fp8_kvcache=True,
+                    indices=marked_indices,
+                    shared_kv_current_rows=current_rows,
+                    shared_kv_current_row_ids=current_row_ids,
+                    shared_kv_current_row_counts=current_row_counts,
+                    **kwargs,
+                )
+
+                torch.testing.assert_close(actual_out, expected_out, rtol=0, atol=0)
+                torch.testing.assert_close(actual_lse, expected_lse, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/kernels/ops/attention/test_flashmla_shared_demand_cache_source.py
+++ b/test/registered/kernels/ops/attention/test_flashmla_shared_demand_cache_source.py
@@ -1,0 +1,546 @@
+import importlib.util
+import re
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestFlashMLASharedDemandCacheSource(unittest.TestCase):
+    @staticmethod
+    def _patch_text() -> str:
+        repo_root = Path(__file__).resolve().parents[5]
+        return (
+            repo_root
+            / "python/sglang/kernels/aot/cmake/flashmla_shared_demand_cache.patch"
+        ).read_text()
+
+    @classmethod
+    def _file_patch(cls, path: str) -> str:
+        source = cls._patch_text()
+        begin = source.index(f"a/{path}")
+        next_file = source.find("\ndiff -ruN ", begin)
+        return source[begin:] if next_file < 0 else source[begin:next_file]
+
+    def test_row_subgroup_broadcasts_access_and_slot(self):
+        adapter = self._file_patch(
+            "csrc/sm90/decode/sparse_fp8/components/shared_kv_adapter.h"
+        )
+
+        self.assertNotIn("packed_probe_result", adapter)
+        self.assertEqual(adapter.count("__shfl_sync"), 2)
+
+    def test_probe_distinguishes_all_remote_read_reasons(self):
+        header = self._patch_text()
+
+        self.assertIn("FILLING_FALLBACK", header)
+        self.assertIn("COLLISION_FALLBACK", header)
+
+    def test_persistent_decode_can_promote_same_row_across_generations(self):
+        source = self._patch_text()
+
+        self.assertIn("bool allow_stale_ready_hit", source)
+        self.assertIn("allow_stale_ready_hit && same_row", source)
+        self.assertIn(
+            "params.shared_kv_cache_generation != nullptr",
+            source,
+        )
+
+    def test_cached_rows_use_32_byte_aligned_stride(self):
+        header = self._patch_text()
+
+        self.assertIn("ROW_BYTES = 656", header)
+
+    def test_shared_demand_cache_header_closes_its_namespace(self):
+        patch_text = self._patch_text()
+        header_begin = patch_text.index(
+            "a/csrc/sm90/decode/sparse_fp8/components/shared_demand_cache.h"
+        )
+        header_end = patch_text.index(
+            "a/csrc/sm90/decode/sparse_fp8/config.h", header_begin
+        )
+        header_patch = patch_text[header_begin:header_end]
+
+        self.assertIn(
+            "+}  // namespace sm90::decode::sparse_fp8::shared_demand_cache",
+            header_patch,
+        )
+
+    def test_shared_demand_cache_header_defines_ready_publication(self):
+        patch_text = self._patch_text()
+        header_begin = patch_text.index(
+            "a/csrc/sm90/decode/sparse_fp8/components/shared_demand_cache.h"
+        )
+        header_end = patch_text.index(
+            "a/csrc/sm90/decode/sparse_fp8/config.h", header_begin
+        )
+        header_patch = patch_text[header_begin:header_end]
+
+        self.assertIn("void publish_ready(", header_patch)
+        self.assertIn("store_release(tags + slot", header_patch)
+
+    def test_slot_mapping_matches_resident_shift13_hash(self):
+        header = self._patch_text()
+
+        self.assertIn("physical_row ^ (physical_row >> 13)", header)
+        self.assertIn("2654435761u", header)
+
+    def test_fixed_request_slot_uses_one_capacity_wide_probe(self):
+        adapter = self._file_patch(
+            "csrc/sm90/decode/sparse_fp8/components/shared_kv_adapter.h"
+        )
+
+        self.assertIn("params.shared_kv_cache_rows_per_request", adapter)
+        self.assertIn(
+            "(request_slot - 1) * params.shared_kv_cache_rows_per_request",
+            adapter,
+        )
+        self.assertEqual(adapter.count("shared_demand_cache::probe"), 1)
+
+    def test_split_kernel_delegates_shared_row_policy_to_adapter(self):
+        split_kernel = self._file_patch("csrc/sm90/decode/sparse_fp8/splitkv_mla.cuh")
+
+        self.assertIn("shared_kv_adapter::resolve<", split_kernel)
+        self.assertIn("shared_row.store_fragment<", split_kernel)
+        self.assertIn("shared_row.publish<", split_kernel)
+        self.assertNotIn("shared_demand_cache::probe", split_kernel)
+
+    def test_request_slot_metadata_matches_wrapper_and_extension_schema(self):
+        repo_root = Path(__file__).resolve().parents[5]
+        wrapper = (
+            repo_root / "python/sglang/kernels/aot/python/sgl_kernel/flash_mla.py"
+        ).read_text()
+        extension = (
+            repo_root / "python/sglang/kernels/aot/csrc/flashmla_extension.cc"
+        ).read_text()
+
+        for name in (
+            "shared_kv_request_slots",
+            "shared_kv_cache_rows_per_request",
+            "shared_kv_num_request_slots",
+            "shared_kv_cache_generation_tensor",
+        ):
+            self.assertIn(name, wrapper)
+            self.assertIn(name, extension)
+
+    def test_current_row_width_is_dynamic_in_flashmla_patch(self):
+        source = self._patch_text()
+
+        self.assertIn("shared_kv_current_rows->size(1) >= 1", source)
+        self.assertIn("shared_kv_current_rows->size(1) <= 4", source)
+        self.assertIn(
+            "shared_kv_current_row_ids->size(1) == shared_kv_current_rows->size(1)",
+            source,
+        )
+        self.assertNotIn("shared_kv_current_rows->size(1) == 4", source)
+
+    def test_probe_owns_stale_ready_policy_not_tag_encoding(self):
+        header = self._patch_text()
+        tag_begin = header.index("uint64_t filling_tag(")
+        tag_end = header.index(") {", tag_begin)
+        probe_begin = header.index("ProbeResult probe(")
+        probe_end = header.index(") {", probe_begin)
+
+        self.assertNotIn("allow_stale_ready_hit", header[tag_begin:tag_end])
+        self.assertIn("bool allow_stale_ready_hit", header[probe_begin:probe_end])
+
+    def test_unified_patch_hunk_lengths_match_headers(self):
+        lines = self._patch_text().splitlines()
+        header = re.compile(r"^@@ -\d+(?:,(\d+))? \+\d+(?:,(\d+))? @@")
+
+        for index, line in enumerate(lines):
+            match = header.match(line)
+            if match is None:
+                continue
+            expected_old = int(match.group(1) or 1)
+            expected_new = int(match.group(2) or 1)
+            actual_old = actual_new = 0
+            for hunk_line in lines[index + 1 :]:
+                if hunk_line.startswith(("@@ ", "diff ")):
+                    break
+                if hunk_line.startswith((" ", "-")):
+                    actual_old += 1
+                if hunk_line.startswith((" ", "+")):
+                    actual_new += 1
+            self.assertEqual(
+                (actual_old, actual_new),
+                (expected_old, expected_new),
+                f"malformed unified-diff hunk: {line}",
+            )
+
+    def test_current_row_marker_precedes_local_and_persistent_cache_paths(self):
+        adapter = self._file_patch(
+            "csrc/sm90/decode/sparse_fp8/components/shared_kv_adapter.h"
+        )
+        current = adapter.index("token_index <= -2 && token_index >= -5")
+        current_source = adapter.index("params.shared_kv_current_rows", current)
+        owner_local = adapter.index("const bool remote_row", current_source)
+        persistent_probe = adapter.index("shared_demand_cache::probe", owner_local)
+
+        self.assertLess(current, current_source)
+        self.assertLess(current_source, owner_local)
+        self.assertLess(owner_local, persistent_probe)
+        current_block = adapter[current:owner_local]
+        self.assertIn("return -token_index - 2", current_block)
+        self.assertNotIn("shared_demand_cache::probe", current_block)
+        self.assertNotIn("remote_probe_count", current_block)
+        self.assertNotIn("publish_ready", current_block)
+
+    def test_owner_translation_fuses_current_row_marker(self):
+        repo_root = Path(__file__).resolve().parents[5]
+        source = (
+            repo_root / "python/sglang/kernels/ops/attention/dsa/transform_index.py"
+        ).read_text()
+
+        physical = source.index("physical_slots =")
+        marker = source.index("current_row_markers", physical)
+        output = source.index("tl.store(", marker)
+        self.assertLess(physical, marker)
+        self.assertLess(marker, output)
+        self.assertIn("-2 - current_row_slot", source[marker:output])
+
+    def test_backend_forwards_graph_stable_current_rows_to_topk_and_flashmla(self):
+        repo_root = Path(__file__).resolve().parents[5]
+        backend = (
+            repo_root / "python/sglang/srt/layers/attention/dsa_backend.py"
+        ).read_text()
+        self.assertIn("shared_mla_current_rows", backend)
+        self.assertIn(
+            "metadata.shared_mla_current_rows[shared_current_rows_layer_idx]",
+            backend,
+        )
+        self.assertIn("current_row_locs=", backend)
+        self.assertIn("shared_kv_current_rows=", backend)
+
+    def test_current_row_writer_fuses_shadow_without_flat_staging(self):
+        repo_root = Path(__file__).resolve().parents[5]
+        cache = (
+            repo_root / "python/sglang/srt/mem_cache/dsa_cache_shared.py"
+        ).read_text()
+        setter = cache[
+            cache.index("    def set_mla_kv_buffer_with_current_rows(") : cache.index(
+                "    def move_kv_cache(",
+                cache.index("    def set_mla_kv_buffer_with_current_rows("),
+            )
+        ]
+        self.assertIn("current_rows.encoded_rows", setter)
+        self.assertNotIn("build_mla_current_row_shadow_triton(", setter)
+
+    def test_current_row_count_range_assert_is_not_captured_into_cuda_graph(self):
+        repo_root = Path(__file__).resolve().parents[5]
+        wrapper = (
+            repo_root / "python/sglang/kernels/aot/python/sgl_kernel/flash_mla.py"
+        ).read_text()
+        validator = wrapper[
+            wrapper.index("def _validate_shared_kv_current_rows(") : wrapper.index(
+                "def flash_mla_with_kvcache(",
+                wrapper.index("def _validate_shared_kv_current_rows("),
+            )
+        ]
+
+        guard = validator.index(
+            "if not torch.cuda.is_available() or not "
+            "torch.cuda.is_current_stream_capturing():"
+        )
+        dynamic_assert = validator.index("torch._assert_async(", guard)
+        self.assertLess(guard, dynamic_assert)
+
+
+class TestFlashMLASharedDemandCacheWrapper(unittest.TestCase):
+    @staticmethod
+    def _wrapper_module():
+        repo_root = Path(__file__).resolve().parents[5]
+        path = repo_root / "python/sglang/kernels/aot/python/sgl_kernel/flash_mla.py"
+        name = "sgl_kernel._request_scoped_flash_mla_test"
+        spec = importlib.util.spec_from_file_location(name, path)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[name] = module
+        spec.loader.exec_module(module)
+        return module
+
+    def test_wrapper_forwards_request_scoped_slot_contract(self):
+        flash_mla = self._wrapper_module()
+
+        q = torch.empty((2, 1, 64, 576), dtype=torch.bfloat16)
+        k_cache = torch.empty((128, 64, 1, 656), dtype=torch.uint8)
+        indices = torch.zeros((2, 1, 2048), dtype=torch.int32)
+        row_cache = torch.empty((16, 656), dtype=torch.uint8)
+        tags = torch.zeros((2, 8), dtype=torch.int64)
+        request_slots = torch.tensor([3, 7], dtype=torch.int64)
+        generation = torch.tensor(4, dtype=torch.int32)
+        current_rows = torch.empty((2, 4, 656), dtype=torch.uint8)
+        current_ids = torch.tensor(
+            [[0, -1, -1, -1], [64, -1, -1, -1]], dtype=torch.int32
+        )
+        current_counts = torch.ones((2,), dtype=torch.int32)
+        expected_out = torch.empty((2, 1, 64, 512), dtype=torch.bfloat16)
+        expected_lse = torch.empty((2, 64, 1), dtype=torch.float32)
+        op = MagicMock(return_value=(expected_out, expected_lse, None, None))
+
+        with (
+            patch.object(flash_mla, "_flashmla_import_error", None),
+            patch.object(
+                torch.ops.sgl_kernel,
+                "sparse_decode_shared_fwd",
+                SimpleNamespace(default=op),
+                create=True,
+            ),
+        ):
+            out, lse = flash_mla.flash_mla_with_kvcache(
+                q=q,
+                k_cache=k_cache,
+                block_table=torch.empty((2, 0), dtype=torch.int32),
+                cache_seqlens=torch.full((2,), 2048, dtype=torch.int32),
+                head_dim_v=512,
+                tile_scheduler_metadata=torch.empty((1,), dtype=torch.int32),
+                num_splits=torch.zeros((3,), dtype=torch.int32),
+                softmax_scale=576**-0.5,
+                is_fp8_kvcache=True,
+                indices=indices,
+                shared_kv_row_cache=row_cache,
+                shared_kv_cache_tags=tags,
+                shared_kv_request_slots=request_slots,
+                shared_kv_cache_rows_per_request=8,
+                shared_kv_num_request_slots=2,
+                shared_kv_cache_epoch=1,
+                shared_kv_cache_generation_tensor=generation,
+                shared_kv_local_row_begin=0,
+                shared_kv_local_row_end=1024,
+                shared_kv_current_rows=current_rows,
+                shared_kv_current_row_ids=current_ids,
+                shared_kv_current_row_counts=current_counts,
+            )
+
+        self.assertIs(out, expected_out)
+        self.assertIs(lse, expected_lse)
+        args = op.call_args.args
+        self.assertIs(args[12], row_cache)
+        self.assertIs(args[13], tags)
+        self.assertIs(args[14], request_slots)
+        self.assertEqual(args[15:17], (8, 2))
+        self.assertIs(args[18], generation)
+        self.assertIs(args[21], current_rows)
+        self.assertIs(args[22], current_ids)
+        self.assertIs(args[23], current_counts)
+
+    def test_wrapper_forwards_fixed_request_slot_contract(self):
+        flash_mla = self._wrapper_module()
+
+        q = torch.empty((2, 1, 64, 576), dtype=torch.bfloat16)
+        row_cache = torch.empty((16, 656), dtype=torch.uint8)
+        tags = torch.zeros((2, 8), dtype=torch.int64)
+        request_slots = torch.tensor([1, 2], dtype=torch.int64)
+        expected_out = torch.empty((2, 1, 64, 512), dtype=torch.bfloat16)
+        expected_lse = torch.empty((2, 64, 1), dtype=torch.float32)
+        op = MagicMock(return_value=(expected_out, expected_lse, None, None))
+
+        with (
+            patch.object(flash_mla, "_flashmla_import_error", None),
+            patch.object(
+                torch.ops.sgl_kernel,
+                "sparse_decode_shared_fwd",
+                SimpleNamespace(default=op),
+                create=True,
+            ),
+        ):
+            out, lse = flash_mla.flash_mla_with_kvcache(
+                q=q,
+                k_cache=torch.empty((128, 64, 1, 656), dtype=torch.uint8),
+                block_table=torch.empty((2, 0), dtype=torch.int32),
+                cache_seqlens=torch.full((2,), 2048, dtype=torch.int32),
+                head_dim_v=512,
+                tile_scheduler_metadata=torch.empty((1,), dtype=torch.int32),
+                num_splits=torch.zeros((3,), dtype=torch.int32),
+                is_fp8_kvcache=True,
+                indices=torch.zeros((2, 1, 2048), dtype=torch.int32),
+                shared_kv_row_cache=row_cache,
+                shared_kv_cache_tags=tags,
+                shared_kv_request_slots=request_slots,
+                shared_kv_cache_rows_per_request=8,
+                shared_kv_num_request_slots=2,
+                shared_kv_cache_epoch=1,
+                shared_kv_local_row_begin=0,
+                shared_kv_local_row_end=1024,
+            )
+
+        self.assertIs(out, expected_out)
+        self.assertIs(lse, expected_lse)
+        args = op.call_args.args
+        self.assertEqual(args[15], 8)
+        self.assertEqual(args[16], 2)
+
+    def test_wrapper_rejects_partial_or_malformed_current_rows_before_dispatch(self):
+        flash_mla = self._wrapper_module()
+        q = torch.empty((2, 1, 64, 576), dtype=torch.bfloat16)
+        base_kwargs = dict(
+            q=q,
+            k_cache=torch.empty((128, 64, 1, 656), dtype=torch.uint8),
+            block_table=torch.empty((2, 0), dtype=torch.int32),
+            cache_seqlens=torch.full((2,), 2048, dtype=torch.int32),
+            head_dim_v=512,
+            tile_scheduler_metadata=torch.empty((1,), dtype=torch.int32),
+            num_splits=torch.zeros((3,), dtype=torch.int32),
+            is_fp8_kvcache=True,
+            indices=torch.zeros((2, 1, 2048), dtype=torch.int32),
+            shared_kv_row_cache=torch.empty((16, 656), dtype=torch.uint8),
+            shared_kv_cache_tags=torch.zeros((2, 8), dtype=torch.int64),
+            shared_kv_request_slots=torch.tensor([1, 2], dtype=torch.int64),
+            shared_kv_cache_rows_per_request=8,
+            shared_kv_num_request_slots=2,
+            shared_kv_cache_epoch=1,
+            shared_kv_local_row_begin=0,
+            shared_kv_local_row_end=1024,
+        )
+        good_rows = torch.empty((2, 4, 656), dtype=torch.uint8)
+        good_ids = torch.full((2, 4), -1, dtype=torch.int32)
+        good_counts = torch.zeros((2,), dtype=torch.int32)
+
+        with (
+            patch.object(flash_mla, "_flashmla_import_error", None),
+            self.assertRaisesRegex(AssertionError, "provided together"),
+        ):
+            flash_mla.flash_mla_with_kvcache(
+                **base_kwargs, shared_kv_current_rows=good_rows
+            )
+
+        malformed = (
+            (good_rows.float(), good_ids, good_counts, "uint8"),
+            (
+                torch.empty((2, 4, 1312), dtype=torch.uint8)[:, :, ::2],
+                good_ids,
+                good_counts,
+                "contiguous",
+            ),
+            (good_rows[:1], good_ids, good_counts, "query rows"),
+            (
+                torch.empty((2, 0, 656), dtype=torch.uint8),
+                torch.empty((2, 0), dtype=torch.int32),
+                good_counts,
+                "1 <= width <= 4",
+            ),
+            (
+                torch.empty((2, 5, 656), dtype=torch.uint8),
+                torch.empty((2, 5), dtype=torch.int32),
+                good_counts,
+                "1 <= width <= 4",
+            ),
+            (
+                torch.empty((2, 2, 656), dtype=torch.uint8),
+                torch.empty((2, 3), dtype=torch.int32),
+                good_counts,
+                "match",
+            ),
+            (good_rows, good_ids.long(), good_counts, "int32"),
+            (good_rows, good_ids, good_counts.long(), "int32"),
+        )
+        with patch.object(flash_mla, "_flashmla_import_error", None):
+            for rows, ids, counts, message in malformed:
+                with self.subTest(message=message), self.assertRaisesRegex(
+                    AssertionError, message
+                ):
+                    flash_mla.flash_mla_with_kvcache(
+                        **base_kwargs,
+                        shared_kv_current_rows=rows,
+                        shared_kv_current_row_ids=ids,
+                        shared_kv_current_row_counts=counts,
+                    )
+
+            with self.assertRaisesRegex(RuntimeError, "range"):
+                flash_mla.flash_mla_with_kvcache(
+                    **base_kwargs,
+                    shared_kv_current_rows=good_rows,
+                    shared_kv_current_row_ids=good_ids,
+                    shared_kv_current_row_counts=torch.tensor(
+                        [0, 5], dtype=torch.int32
+                    ),
+                )
+
+    def test_wrapper_accepts_current_row_widths_one_to_four(self):
+        flash_mla = self._wrapper_module()
+        q = torch.empty((2, 1, 64, 576), dtype=torch.bfloat16)
+        expected_out = torch.empty((2, 1, 64, 512), dtype=torch.bfloat16)
+        expected_lse = torch.empty((2, 64, 1), dtype=torch.float32)
+        op = MagicMock(return_value=(expected_out, expected_lse, None, None))
+        base_kwargs = dict(
+            q=q,
+            k_cache=torch.empty((128, 64, 1, 656), dtype=torch.uint8),
+            block_table=torch.empty((2, 0), dtype=torch.int32),
+            cache_seqlens=torch.full((2,), 2048, dtype=torch.int32),
+            head_dim_v=512,
+            tile_scheduler_metadata=torch.empty((1,), dtype=torch.int32),
+            num_splits=torch.zeros((3,), dtype=torch.int32),
+            is_fp8_kvcache=True,
+            indices=torch.zeros((2, 1, 2048), dtype=torch.int32),
+            shared_kv_row_cache=torch.empty((16, 656), dtype=torch.uint8),
+            shared_kv_cache_tags=torch.zeros((2, 8), dtype=torch.int64),
+            shared_kv_request_slots=torch.tensor([1, 2], dtype=torch.int64),
+            shared_kv_cache_rows_per_request=8,
+            shared_kv_num_request_slots=2,
+            shared_kv_cache_epoch=1,
+            shared_kv_local_row_begin=0,
+            shared_kv_local_row_end=1024,
+        )
+
+        with (
+            patch.object(flash_mla, "_flashmla_import_error", None),
+            patch.object(
+                torch.ops.sgl_kernel,
+                "sparse_decode_shared_fwd",
+                SimpleNamespace(default=op),
+                create=True,
+            ),
+        ):
+            for width in range(1, 5):
+                with self.subTest(width=width):
+                    out, lse = flash_mla.flash_mla_with_kvcache(
+                        **base_kwargs,
+                        shared_kv_current_rows=torch.empty(
+                            (2, width, 656), dtype=torch.uint8
+                        ),
+                        shared_kv_current_row_ids=torch.full(
+                            (2, width), -1, dtype=torch.int32
+                        ),
+                        shared_kv_current_row_counts=torch.full(
+                            (2,), width, dtype=torch.int32
+                        ),
+                    )
+                    self.assertIs(out, expected_out)
+                    self.assertIs(lse, expected_lse)
+
+    def test_wrapper_rejects_multislice_cache_without_request_slots(self):
+        flash_mla = self._wrapper_module()
+
+        with (
+            patch.object(flash_mla, "_flashmla_import_error", None),
+            self.assertRaisesRegex(AssertionError, "request slots"),
+        ):
+            flash_mla.flash_mla_with_kvcache(
+                q=torch.empty((2, 1, 64, 576), dtype=torch.bfloat16),
+                k_cache=torch.empty((128, 64, 1, 656), dtype=torch.uint8),
+                block_table=torch.empty((2, 0), dtype=torch.int32),
+                cache_seqlens=torch.full((2,), 2048, dtype=torch.int32),
+                head_dim_v=512,
+                tile_scheduler_metadata=torch.empty((1,), dtype=torch.int32),
+                num_splits=torch.zeros((3,), dtype=torch.int32),
+                is_fp8_kvcache=True,
+                indices=torch.zeros((2, 1, 2048), dtype=torch.int32),
+                shared_kv_row_cache=torch.empty((16, 656), dtype=torch.uint8),
+                shared_kv_cache_tags=torch.zeros((2, 8), dtype=torch.int64),
+                shared_kv_cache_rows_per_request=8,
+                shared_kv_num_request_slots=2,
+                shared_kv_cache_epoch=1,
+                shared_kv_local_row_begin=0,
+                shared_kv_local_row_end=1024,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/models_e2e/test_dsa_glm52_shared_kv.py
+++ b/test/registered/models_e2e/test_dsa_glm52_shared_kv.py
@@ -1,0 +1,56 @@
+import unittest
+
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
+from sglang.test.server_fixtures.default_fixture import DefaultServerBase
+
+register_cuda_ci(est_time=720, stage="extra-b", runner_config="8-gpu-h200")
+
+
+class TestGLM52DSASharedKV(DefaultServerBase, GSM8KMixin):
+    model = "zai-org/GLM-5.2-FP8"
+    other_args = [
+        "--trust-remote-code",
+        "--tp",
+        "8",
+        "--attn-cp-size",
+        "8",
+        "--enable-prefill-cp",
+        "--cp-strategy",
+        "interleave",
+        "--enable-cp-decode-attn-tp",
+        "--enable-dsa-shared-kv-cache",
+        "--dsa-prefill-backend",
+        "flashmla_kv",
+        "--dsa-decode-backend",
+        "flashmla_kv",
+        "--max-running-requests",
+        "32",
+        "--kv-cache-dtype",
+        "fp8_e4m3",
+        "--quantization",
+        "w4afp8",
+        "--page-size",
+        "64",
+        "--mem-fraction-static",
+        "0.85",
+        "--speculative-algorithm",
+        "EAGLE",
+        "--speculative-num-steps",
+        "3",
+        "--speculative-eagle-topk",
+        "1",
+        "--speculative-num-draft-tokens",
+        "3",
+        "--model-loader-extra-config",
+        '{"enable_multithread_load": true, "num_threads": 64}',
+    ]
+
+    gsm8k_accuracy_thres = 0.94
+    gsm8k_num_questions = 500
+    gsm8k_num_threads = 100
+    gsm8k_num_shots = 24
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_dsa_shared_cache.py
+++ b/test/registered/unit/mem_cache/test_dsa_shared_cache.py
@@ -1,0 +1,1833 @@
+import unittest
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+
+import sglang.srt.layers.attention.dsa_backend as dsa_backend_module
+import sglang.srt.mem_cache.dsa_cache_shared as dsa_cache_shared_module
+import sglang.srt.mem_cache.dsa_shared_demand as dsa_shared_demand_module
+from sglang.srt.layers.attention.dsa.dsa_indexer import (
+    Indexer,
+    _full_batch_indexer_cache_inputs,
+    _get_index_cache_write_targets,
+    _prepare_paged_index_page_table,
+    _synchronize_shared_cache_writes,
+)
+from sglang.srt.layers.attention.dsa.dsa_topk_backend import TopkTransformMethod
+from sglang.srt.layers.attention.dsa.shared_cache_access import DSASharedCacheAccess
+from sglang.srt.layers.attention.dsa_backend import (
+    DeepseekSparseAttnBackend,
+    DSAFlashMLAMetadata,
+    DSAIndexerMetadata,
+    _get_pool_main_owner_translation_args,
+    _prepare_pool_index_page_table,
+    _synchronize_pool_main_cache,
+    _translate_pool_main_page_table,
+)
+from sglang.srt.layers.cp import utils as cp_utils
+from sglang.srt.layers.cp.utils import (
+    get_glm_dsa_shared_effective_num_layers,
+    get_glm_dsa_shared_info,
+    is_glm_dsa_cache_shared_enabled,
+)
+from sglang.srt.mem_cache.dsa_cache_shared import (
+    ReplicatedIndexKeyCache,
+    SharedDSAPageLayout,
+    SharedDSATokenToKVPool,
+    gather_shared_index_rows,
+    indexer_pool_cache_shape,
+)
+from sglang.srt.mem_cache.dsa_shared_demand import (
+    DSAFlashMLADemandCacheManager,
+    SharedMLACurrentRows,
+    SlotDemandCache,
+    _build_slot_demand_cache,
+    _expand_flashmla_shared_cache_request_slots,
+    get_indexer_pool_cache_layer_ids,
+)
+from sglang.srt.mem_cache.kv_cache_configurator import calculate_mla_kv_cache_dim
+from sglang.srt.mem_cache.memory_pool import MLATokenToKVPool
+from sglang.srt.mem_cache.shared_kv.demand_cache import PoolDemandCache
+from sglang.srt.mem_cache.shared_kv.layout import OwnerShardedLayout
+from sglang.srt.mem_cache.shared_kv.synchronization import SharedWritePublisher
+from sglang.srt.runtime_context import get_parallel
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestPoolDemandCache(CustomTestCase):
+    def test_pool_layer_storage_epoch_and_accounting(self):
+        cache = PoolDemandCache.create(
+            keys=(2, 6),
+            entries_per_key=3,
+            entry_bytes=4,
+            dtype=torch.uint8,
+            device="cpu",
+        )
+
+        layer2_data, layer2_tags = cache.storage_for(2)
+        layer6_data, layer6_tags = cache.storage_for(6)
+
+        self.assertEqual(layer2_data.shape, (3, 4))
+        self.assertEqual(layer2_tags.shape, (3,))
+        self.assertNotEqual(layer2_data.data_ptr(), layer6_data.data_ptr())
+        self.assertNotEqual(layer2_tags.data_ptr(), layer6_tags.data_ptr())
+        self.assertEqual(cache.allocated_bytes, 2 * 3 * 4 + 2 * 3 * 8 + 4)
+        self.assertFalse(hasattr(cache, "nbytes"))
+        self.assertEqual(cache.epoch, 1)
+        self.assertEqual(cache.epoch_tensor.item(), 1)
+
+        cache.invalidate()
+
+        self.assertEqual(cache.epoch, 2)
+        self.assertEqual(cache.epoch_tensor.item(), 2)
+        with self.assertRaisesRegex(ValueError, "key 10 is not configured"):
+            cache.storage_for(10)
+
+    def test_glm52_pool_keys_cover_only_target_topk_producers(self):
+        config = SimpleNamespace(
+            architectures=["GlmMoeDsaForCausalLM"],
+            index_topk=2048,
+            index_head_dim=128,
+            index_topk_freq=4,
+            index_skip_topk_offset=3,
+        )
+
+        self.assertEqual(
+            get_indexer_pool_cache_layer_ids(config, 0, 78),
+            (
+                0,
+                1,
+                2,
+                6,
+                10,
+                14,
+                18,
+                22,
+                26,
+                30,
+                34,
+                38,
+                42,
+                46,
+                50,
+                54,
+                58,
+                62,
+                66,
+                70,
+                74,
+            ),
+        )
+
+
+class TestFullBatchIndexerPoolCacheGeometry(CustomTestCase):
+    def test_cp8_keeps_all_requests_and_all_verify_rows_on_every_rank(self):
+        page_tables = torch.arange(32 * 5, dtype=torch.int32).view(32, 5)
+        lengths = torch.arange(100, 132, dtype=torch.int32)
+
+        pool_pages = page_tables + 1000
+        source_pages, target_pages, cache_lengths = _full_batch_indexer_cache_inputs(
+            page_tables,
+            pool_pages,
+            lengths,
+            batch_size=8,
+            next_n=4,
+        )
+
+        torch.testing.assert_close(source_pages, page_tables[::4])
+        torch.testing.assert_close(target_pages, pool_pages[::4])
+        torch.testing.assert_close(cache_lengths, lengths.view(8, 4)[:, -1])
+
+    def test_incomplete_request_geometry_falls_back(self):
+        page_tables = torch.arange(31 * 5, dtype=torch.int32).view(31, 5)
+        lengths = torch.arange(31, dtype=torch.int32)
+
+        self.assertIsNone(
+            _full_batch_indexer_cache_inputs(
+                page_tables,
+                page_tables,
+                lengths,
+                batch_size=8,
+                next_n=4,
+            )
+        )
+
+    def test_single_layer_cache_covers_logical_pool_page_domain(self):
+        self.assertEqual(
+            indexer_pool_cache_shape(
+                index_buf_size=1_070_336,
+                page_size=64,
+                page_bytes=8_448,
+            ),
+            (16_725, 8_448),
+        )
+
+    def test_mixed_lengths_and_batch_reorder_keep_pool_page_identity(self):
+        source = torch.tensor(
+            [[100, 107, 111, -1], [100, 103, 104, 108]], dtype=torch.int32
+        )
+        pool_pages = torch.tensor([[0, 7, 11, -1], [0, 3, 4, 8]], dtype=torch.int32)
+        reordered_source = source.flip(0)
+        reordered_pool_pages = pool_pages.flip(0)
+        cache = object.__new__(
+            __import__(
+                "sglang.srt.mem_cache.dsa_cache_shared",
+                fromlist=["SharedIndexKeyCache"],
+            ).SharedIndexKeyCache
+        )
+        cache.pool = SimpleNamespace(page_size=64)
+        cache.get_global_buffer = lambda _layer_id: torch.empty((16, 8))
+        cache.pool_cache = SimpleNamespace(
+            storage_for=lambda _layer_id: (
+                torch.empty((16, 8)),
+                torch.zeros(16, dtype=torch.int64),
+            ),
+            epoch_tensor=torch.ones((), dtype=torch.int32),
+        )
+
+        with patch(
+            "sglang.srt.mem_cache.dsa_cache_shared.materialize_indexer_pages_triton"
+        ) as materialize:
+            _, first_table = cache.materialize_pages(
+                0,
+                source,
+                pool_pages,
+                torch.tensor([129, 257], dtype=torch.int32),
+            )
+            _, reordered_table = cache.materialize_pages(
+                0,
+                reordered_source,
+                reordered_pool_pages,
+                torch.tensor([257, 129], dtype=torch.int32),
+            )
+
+        self.assertIs(first_table, pool_pages)
+        self.assertIs(reordered_table, reordered_pool_pages)
+        self.assertEqual(first_table[0, 0].item(), first_table[1, 0].item())
+        self.assertEqual(materialize.call_count, 2)
+        first_call = materialize.call_args_list[0]
+        self.assertIs(first_call.args[2], source)
+        self.assertIs(first_call.args[3], pool_pages)
+
+    def test_one_indexer_invalidation_advances_one_epoch(self):
+        cache = PoolDemandCache.create(
+            keys=(0,),
+            entries_per_key=4,
+            entry_bytes=8,
+            dtype=torch.uint8,
+            device="cpu",
+        )
+        pool = SimpleNamespace(
+            index_key_cache=SimpleNamespace(invalidate_cache=cache.invalidate)
+        )
+
+        SharedDSATokenToKVPool.invalidate_indexer_cache(pool)
+
+        self.assertEqual(cache.epoch, 2)
+
+
+def _build_mla_current_row_geometry(
+    logical_locs: torch.Tensor,
+    *,
+    rows_per_request: int,
+    max_current_rows: int,
+    owner_size: int,
+    page_size: int,
+    pages_per_rank: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Reference geometry used only to validate the fused production writer."""
+    if logical_locs.dim() != 1:
+        raise ValueError("Shared MLA current-row locations must be one-dimensional")
+    query_rows = logical_locs.numel()
+    if rows_per_request <= 0 or query_rows % rows_per_request:
+        raise ValueError(
+            "Shared MLA current rows require complete request groups: "
+            f"query_rows={query_rows} rows_per_request={rows_per_request}"
+        )
+    if max_current_rows < rows_per_request:
+        raise ValueError("Shared MLA per-request row capacity exceeded")
+    if owner_size <= 0 or page_size <= 0 or pages_per_rank <= 0:
+        raise ValueError("Shared MLA current-row layout dimensions must be positive")
+    if query_rows == 0:
+        return (
+            torch.empty(
+                (0, max_current_rows), dtype=torch.int32, device=logical_locs.device
+            ),
+            torch.empty((0,), dtype=torch.int32, device=logical_locs.device),
+        )
+
+    query_indices = torch.arange(query_rows, device=logical_locs.device)
+    positions = query_indices.remainder(rows_per_request)
+    counts = torch.where(
+        logical_locs >= 0, positions + 1, torch.zeros_like(positions)
+    ).to(torch.int32)
+    current_indices = torch.arange(max_current_rows, device=logical_locs.device)
+    source_indices = query_indices.sub(positions).unsqueeze(
+        1
+    ) + current_indices.unsqueeze(0)
+    valid = current_indices.unsqueeze(0) < counts.unsqueeze(1)
+    source_locs = logical_locs[source_indices.clamp(max=query_rows - 1)]
+    valid &= source_locs >= 0
+
+    pages = torch.div(source_locs, page_size, rounding_mode="floor")
+    page_offsets = source_locs.remainder(page_size)
+    owners = pages.remainder(owner_size)
+    owner_pages = torch.div(pages, owner_size, rounding_mode="floor")
+    physical_rows = (owners * pages_per_rank + owner_pages) * page_size + page_offsets
+    return (
+        torch.where(valid, physical_rows, -1).to(torch.int32),
+        counts,
+    )
+
+
+class TestSharedDSAKVCacheDimension(CustomTestCase):
+    @staticmethod
+    def _model_config():
+        return SimpleNamespace(
+            hf_config=object(),
+            kv_lora_rank=512,
+            qk_rope_head_dim=64,
+        )
+
+    @staticmethod
+    def _server_args(*, shared: bool, decode_backend: str):
+        return SimpleNamespace(
+            enable_dsa_shared_kv_cache=shared,
+            dsa_prefill_backend="flashmla_sparse_q8",
+            dsa_decode_backend=decode_backend,
+        )
+
+    @patch(
+        "sglang.srt.mem_cache.kv_cache_configurator.is_deepseek_dsa",
+        return_value=True,
+    )
+    def test_shared_flashmla_uses_scaled_fp8_layout(self, _):
+        dim = calculate_mla_kv_cache_dim(
+            model_config=self._model_config(),
+            kv_cache_dtype=torch.float8_e4m3fn,
+            server_args=self._server_args(shared=True, decode_backend="flashmla_kv"),
+        )
+
+        self.assertEqual(dim, 656)
+
+    @patch(
+        "sglang.srt.mem_cache.kv_cache_configurator.is_deepseek_dsa",
+        return_value=True,
+    )
+    def test_base_flashmla_retains_scaled_fp8_layout(self, _):
+        dim = calculate_mla_kv_cache_dim(
+            model_config=self._model_config(),
+            kv_cache_dtype=torch.float8_e4m3fn,
+            server_args=self._server_args(shared=False, decode_backend="flashmla_kv"),
+        )
+
+        self.assertEqual(dim, 656)
+
+
+def make_shared_dsa_layout(
+    cp_size: int,
+    page_size: int,
+    pages_per_rank: int,
+    *,
+    local_pages_per_layer: int | None = None,
+    rank_stride_pages: int | None = None,
+) -> SharedDSAPageLayout:
+    return SharedDSAPageLayout(
+        OwnerShardedLayout(
+            cp_size=cp_size,
+            ownership_granule=page_size,
+            logical_rows=cp_size * pages_per_rank * page_size,
+            physical_blocks_per_rank=rank_stride_pages or pages_per_rank,
+        ),
+        local_pages_per_layer=local_pages_per_layer,
+    )
+
+
+class TestSharedMLACurrentRows(CustomTestCase):
+    @staticmethod
+    def _make_write_pool(device: torch.device | str) -> SharedDSATokenToKVPool:
+        pool = object.__new__(SharedDSATokenToKVPool)
+        pool.start_layer = 0
+        pool.shared_rank = 0
+        pool.shared_size = 2
+        pool.page_size = 64
+        pool.size = 256
+        pool.dsa_kv_cache_store_fp8 = True
+        pool.main_layout = make_shared_dsa_layout(
+            2,
+            64,
+            2,
+            local_pages_per_layer=2,
+        )
+        pool.local_kv_buffer = [
+            torch.full((128, 1, 656), 0xCD, dtype=torch.uint8, device=device)
+        ]
+        return pool
+
+    def test_current_rows_normal_decode_geometry_is_one_rank_major_row_per_query(self):
+        physical_rows, counts = _build_mla_current_row_geometry(
+            torch.tensor([0, 64], dtype=torch.int64),
+            rows_per_request=1,
+            max_current_rows=1,
+            owner_size=2,
+            page_size=64,
+            pages_per_rank=2,
+        )
+
+        torch.testing.assert_close(
+            physical_rows, torch.tensor([[0], [128]], dtype=torch.int32)
+        )
+        torch.testing.assert_close(counts, torch.tensor([1, 1], dtype=torch.int32))
+
+    def test_current_rows_target_verify_geometry_is_request_major_and_causal(self):
+        physical_rows, counts = _build_mla_current_row_geometry(
+            torch.tensor([0, 1, 2, 3, 64, 65, 66, 67], dtype=torch.int64),
+            rows_per_request=4,
+            max_current_rows=4,
+            owner_size=2,
+            page_size=64,
+            pages_per_rank=2,
+        )
+
+        self.assertEqual(counts.tolist(), [1, 2, 3, 4, 1, 2, 3, 4])
+        self.assertEqual(physical_rows[3].tolist(), [0, 1, 2, 3])
+        self.assertEqual(physical_rows[7].tolist(), [128, 129, 130, 131])
+        self.assertEqual(physical_rows[0].tolist(), [0, -1, -1, -1])
+
+    def test_current_rows_three_token_target_verify_is_request_major_and_causal(self):
+        physical_rows, counts = _build_mla_current_row_geometry(
+            torch.tensor([0, 1, 2, 64, 65, 66], dtype=torch.int64),
+            rows_per_request=3,
+            max_current_rows=3,
+            owner_size=2,
+            page_size=64,
+            pages_per_rank=2,
+        )
+
+        self.assertEqual(counts.tolist(), [1, 2, 3, 1, 2, 3])
+        self.assertEqual(physical_rows[2].tolist(), [0, 1, 2])
+        self.assertEqual(physical_rows[5].tolist(), [128, 129, 130])
+        self.assertEqual(physical_rows[0].tolist(), [0, -1, -1])
+
+    def test_current_rows_graph_padding_has_zero_count_and_no_physical_rows(self):
+        physical_rows, counts = _build_mla_current_row_geometry(
+            torch.tensor([0, 1, -1, -1], dtype=torch.int64),
+            rows_per_request=4,
+            max_current_rows=4,
+            owner_size=2,
+            page_size=64,
+            pages_per_rank=2,
+        )
+
+        self.assertEqual(counts.tolist(), [1, 2, 0, 0])
+        self.assertEqual(physical_rows[2:].tolist(), [[-1] * 4, [-1] * 4])
+
+    def test_current_rows_geometry_rejects_partial_groups_and_insufficient_width(self):
+        kwargs = dict(owner_size=2, page_size=64, pages_per_rank=2)
+        with self.assertRaisesRegex(ValueError, "complete request groups"):
+            _build_mla_current_row_geometry(
+                torch.tensor([0, 1, 2]),
+                rows_per_request=2,
+                max_current_rows=2,
+                **kwargs,
+            )
+        with self.assertRaisesRegex(ValueError, "capacity"):
+            _build_mla_current_row_geometry(
+                torch.tensor([0, 1, 2, 3]),
+                rows_per_request=4,
+                max_current_rows=2,
+                **kwargs,
+            )
+
+    def test_current_rows_write_rejects_mismatched_kv_shapes_before_dispatch(self):
+        pool = self._make_write_pool("cpu")
+        current_rows = SharedMLACurrentRows.create(
+            max_query_rows=2, max_current_rows=1, device="cpu"
+        )
+        loc = torch.tensor([0, 1], dtype=torch.int64)
+        good_nope = torch.empty((2, 1, 512), dtype=torch.bfloat16)
+        good_rope = torch.empty((2, 1, 64), dtype=torch.bfloat16)
+
+        with self.assertRaisesRegex(ValueError, "NoPE shape"):
+            pool.set_mla_kv_buffer_with_current_rows(
+                SimpleNamespace(layer_id=0),
+                loc,
+                good_nope[:1],
+                good_rope,
+                current_rows,
+                query_rows=2,
+                rows_per_request=1,
+            )
+        with self.assertRaisesRegex(ValueError, "RoPE shape"):
+            pool.set_mla_kv_buffer_with_current_rows(
+                SimpleNamespace(layer_id=0),
+                loc,
+                good_nope,
+                good_rope[..., :32],
+                current_rows,
+                query_rows=2,
+                rows_per_request=1,
+            )
+
+    def test_current_rows_target_verify_shadow_has_exact_scaled_fp8_bytes(self):
+        if not torch.cuda.is_available():
+            self.skipTest("scaled-FP8 current-row test requires CUDA")
+
+        from sglang.kernels.ops.attention.dsa.quant_k_cache import (
+            quantize_k_cache_separate,
+        )
+
+        device = torch.device("cuda")
+        current_rows = SharedMLACurrentRows.create(
+            max_query_rows=4,
+            max_current_rows=4,
+            device=device,
+        )
+        pool = self._make_write_pool(device)
+
+        loc = torch.tensor([63, 64, 65, 66], dtype=torch.int64, device=device)
+        torch.manual_seed(20260809)
+        k_nope = torch.randn((4, 1, 512), dtype=torch.bfloat16, device=device)
+        k_rope = torch.randn((4, 1, 64), dtype=torch.bfloat16, device=device)
+        expected_nope, expected_rope = quantize_k_cache_separate(k_nope, k_rope)
+        expected = torch.cat(
+            [expected_nope.view(4, -1), expected_rope.view(4, -1)], dim=1
+        )
+
+        pool.set_mla_kv_buffer_with_current_rows(
+            SimpleNamespace(layer_id=0),
+            loc,
+            k_nope,
+            k_rope,
+            current_rows,
+            query_rows=4,
+            rows_per_request=4,
+        )
+        torch.cuda.synchronize()
+
+        self.assertEqual(current_rows.counts[:4].cpu().tolist(), [1, 2, 3, 4])
+        expected_physical_rows = [63, 128, 129, 130]
+        for query_row in range(4):
+            count = query_row + 1
+            self.assertEqual(
+                current_rows.physical_rows[query_row, :count].cpu().tolist(),
+                expected_physical_rows[:count],
+            )
+            torch.testing.assert_close(
+                current_rows.encoded_rows[query_row, :count],
+                expected[:count],
+                rtol=0,
+                atol=0,
+            )
+        expected_owner = torch.full_like(pool.local_kv_buffer[0][:, 0], 0xCD)
+        expected_owner[63] = expected[0]
+        torch.testing.assert_close(
+            pool.local_kv_buffer[0][:, 0], expected_owner, rtol=0, atol=0
+        )
+
+
+class TestSharedDSAPageLayout(CustomTestCase):
+    def setUp(self):
+        self.layout = make_shared_dsa_layout(4, 4, 3)
+
+    def test_owner_mask_and_local_slots_match(self):
+        slots = torch.tensor([0, 4, 8, 12, 16, 20], dtype=torch.int64)
+
+        self.assertEqual(
+            self.layout.owned_slot_mask(slots, owner_rank=1).tolist(),
+            [False, True, False, False, False, True],
+        )
+        self.assertEqual(
+            self.layout.translate_local_slots(slots).tolist(), [0, 0, 0, 0, 4, 4]
+        )
+
+    def test_different_segment_strides_keep_the_same_owner(self):
+        main_layout = make_shared_dsa_layout(4, 64, 128)
+        index_layout = make_shared_dsa_layout(4, 64, 256)
+        slots = torch.arange(0, 16 * 64, 64)
+
+        for owner_rank in range(4):
+            self.assertTrue(
+                torch.equal(
+                    main_layout.owned_slot_mask(slots, owner_rank=owner_rank),
+                    index_layout.owned_slot_mask(slots, owner_rank=owner_rank),
+                )
+            )
+
+    def test_layout_wraps_model_neutral_owner_sharding(self):
+        owner_layout = OwnerShardedLayout(
+            cp_size=4,
+            ownership_granule=64,
+            logical_rows=12 * 64,
+        )
+
+        layout = SharedDSAPageLayout(owner_layout)
+
+        self.assertIs(layout.owner_layout, owner_layout)
+        self.assertEqual(layout.pages_per_rank, 3)
+
+
+class TestSlotDemandCache(CustomTestCase):
+    def test_decode_slot_lifecycle_preserves_stable_request_cache(self):
+        tags = torch.zeros((2, 4, 8), dtype=torch.int64)
+        lifecycle = dsa_shared_demand_module.FlashMLASharedDecodeSlotLifecycle.create(
+            tags=tags, num_request_slots=4
+        )
+        slots = torch.tensor([1, 3], dtype=torch.int64)
+        generations = torch.tensor([7, 11], dtype=torch.int64)
+        lifecycle.refresh(
+            active_request_slots=slots,
+            request_generations=generations,
+        )
+        tags.fill_(29)
+
+        cleared = lifecycle.refresh(
+            active_request_slots=slots,
+            request_generations=generations,
+        )
+
+        self.assertEqual(cleared, [])
+        self.assertTrue(torch.all(tags == 29))
+
+    def test_decode_slot_lifecycle_invalidates_only_reused_request(self):
+        tags = torch.zeros((1, 4, 8), dtype=torch.int64)
+        lifecycle = dsa_shared_demand_module.FlashMLASharedDecodeSlotLifecycle.create(
+            tags=tags, num_request_slots=4
+        )
+        slots = torch.tensor([1, 2], dtype=torch.int64)
+        lifecycle.refresh(
+            active_request_slots=slots,
+            request_generations=torch.tensor([3, 5], dtype=torch.int64),
+        )
+        tags[:, 0, :] = 31
+        tags[:, 1, :] = 47
+
+        cleared = lifecycle.refresh(
+            active_request_slots=slots,
+            request_generations=torch.tensor([3, 6], dtype=torch.int64),
+        )
+
+        self.assertEqual(cleared, [2])
+        self.assertTrue(torch.all(tags[:, 0, :] == 31))
+        self.assertTrue(torch.all(tags[:, 1, :] == 0))
+
+    def test_decode_cache_uses_fixed_4k_request_slots(self):
+        self.assertEqual(
+            dsa_shared_demand_module.FLASHMLA_SHARED_DECODE_ROWS_PER_REQUEST,
+            1 << 12,
+        )
+        self.assertEqual(
+            dsa_shared_demand_module.FLASHMLA_SHARED_PREFILL_ROWS,
+            1 << 18,
+        )
+
+    def test_decode_epoch_advances_once_per_64_steps(self):
+        tags = torch.zeros((2, 4, 8), dtype=torch.int64)
+        state = dsa_shared_demand_module.FlashMLASharedDecodeGeneration.create(
+            device="cpu",
+            tags=tags,
+            calls_per_generation=(
+                dsa_shared_demand_module._FLASHMLA_SHARED_DECODE_CALLS_PER_GENERATION
+            ),
+        )
+
+        observed = [int(state.advance().item()) for _ in range(65)]
+
+        self.assertEqual(observed[:63], [1] * 63)
+        self.assertEqual(observed[63:], [2, 2])
+
+    def test_decode_epoch_wrap_clears_all_tags_before_reuse(self):
+        tags = torch.ones((2, 4, 8), dtype=torch.int64)
+        state = dsa_shared_demand_module.FlashMLASharedDecodeGeneration.create(
+            device="cpu",
+            tags=tags,
+            max_generation=2,
+            calls_per_generation=1,
+        )
+
+        self.assertEqual(int(state.advance().item()), 2)
+        self.assertEqual(int(state.advance().item()), 1)
+        torch.testing.assert_close(tags, torch.zeros_like(tags))
+
+    def test_decode_factory_uses_one_slice_per_request_and_layer(self):
+        self.assertEqual(
+            dsa_shared_demand_module.FLASHMLA_SHARED_DECODE_ROWS_PER_REQUEST,
+            1 << 12,
+        )
+        pool = SimpleNamespace(
+            main_layout=make_shared_dsa_layout(
+                8,
+                64,
+                100,
+                local_pages_per_layer=100,
+                rank_stride_pages=800,
+            ),
+            shared_rank=0,
+        )
+
+        caches, generation, lifecycle = (
+            dsa_shared_demand_module._build_decode_slot_demand_caches(
+                pool,
+                device="cpu",
+                num_layers=2,
+                rows_per_request=8,
+                num_request_slots=4,
+            )
+        )
+
+        self.assertEqual(lifecycle.tags.shape, (2, 4, 8))
+        self.assertEqual(len(caches), 2)
+        self.assertEqual(caches[0].row_cache.shape, (32, 656))
+        self.assertEqual(caches[1].row_cache.shape, (32, 656))
+        self.assertEqual(caches[0].num_request_slots, 4)
+        self.assertEqual(lifecycle.installed_generations.shape, (5,))
+        self.assertIs(caches[0].generation_tensor, generation.tensor)
+        self.assertIs(caches[1].generation_tensor, generation.tensor)
+
+    def test_decode_request_slots_keep_one_slot_per_query_row(self):
+        request_slots = torch.tensor([3, 7], dtype=torch.int64)
+
+        expanded = _expand_flashmla_shared_cache_request_slots(
+            request_slots, num_query_rows=2
+        )
+
+        torch.testing.assert_close(expanded, torch.tensor([3, 7]))
+
+    def test_target_verify_request_slots_repeat_in_request_major_order(self):
+        request_slots = torch.tensor([3, 7], dtype=torch.int64)
+
+        expanded = _expand_flashmla_shared_cache_request_slots(
+            request_slots, num_query_rows=6
+        )
+
+        torch.testing.assert_close(expanded, torch.tensor([3, 3, 3, 7, 7, 7]))
+
+    def test_request_slot_expansion_rejects_partial_request_rows(self):
+        with self.assertRaisesRegex(ValueError, "multiple of request count"):
+            _expand_flashmla_shared_cache_request_slots(
+                torch.tensor([3, 7], dtype=torch.int64), num_query_rows=5
+            )
+
+    def test_factory_uses_request_scoped_direct_map_and_rank_major_range(self):
+        pool = SimpleNamespace(
+            main_layout=make_shared_dsa_layout(
+                8,
+                64,
+                100,
+                local_pages_per_layer=100,
+                rank_stride_pages=800,
+            ),
+            shared_rank=3,
+        )
+
+        state = _build_slot_demand_cache(
+            pool,
+            device="cpu",
+            enabled=True,
+            rows_per_request=8,
+            num_request_slots=2,
+        )
+        request_slots = torch.tensor([3, 7], dtype=torch.int64)
+
+        self.assertIsNotNone(state)
+        self.assertEqual(state.row_cache.shape, (16, 656))
+        self.assertEqual(state.tags.shape, (2, 8))
+        self.assertEqual(state.rows_per_request, 8)
+        self.assertEqual(state.num_request_slots, 2)
+        self.assertEqual(state.local_row_begin, 3 * 800 * 64)
+        self.assertEqual(state.local_row_end, 3 * 800 * 64 + 100 * 64)
+        self.assertEqual(
+            state.next_call_kwargs(request_slots=request_slots),
+            {
+                "shared_kv_row_cache": state.row_cache,
+                "shared_kv_cache_tags": state.tags,
+                "shared_kv_request_slots": request_slots,
+                "shared_kv_cache_rows_per_request": 8,
+                "shared_kv_num_request_slots": 2,
+                "shared_kv_cache_epoch": 1,
+                "shared_kv_cache_generation_tensor": None,
+                "shared_kv_local_row_begin": 3 * 800 * 64,
+                "shared_kv_local_row_end": 3 * 800 * 64 + 100 * 64,
+            },
+        )
+
+    def test_persistent_cache_keeps_one_epoch_across_decode_steps(self):
+        pool = SimpleNamespace(
+            main_layout=make_shared_dsa_layout(
+                8,
+                64,
+                100,
+                local_pages_per_layer=100,
+                rank_stride_pages=800,
+            ),
+            shared_rank=0,
+        )
+        state = _build_slot_demand_cache(
+            pool,
+            device="cpu",
+            enabled=True,
+            rows_per_request=8,
+        )
+
+        epochs = [
+            state.next_call_kwargs(persistent=True)["shared_kv_cache_epoch"]
+            for _ in range(65)
+        ]
+
+        self.assertEqual(epochs, [1] * 65)
+
+    def test_factory_is_disabled_for_non_shared_pool(self):
+        state = _build_slot_demand_cache(
+            SimpleNamespace(main_layout=None),
+            device="cpu",
+            enabled=True,
+            rows_per_request=8,
+        )
+
+        self.assertIsNone(state)
+
+
+class TestSharedDSATokenToKVPoolHelpers(CustomTestCase):
+    def test_capacity_ledger_reports_logical_and_per_rank_physical_storage(self):
+        pool = SimpleNamespace(
+            size=1000,
+            page_size=64,
+            shared_size=8,
+            share_indexer=True,
+            main_family=SimpleNamespace(
+                accounting=lambda: SimpleNamespace(
+                    minimum_blocks_per_rank=3,
+                    physical_blocks_per_rank=30,
+                    mapped_bytes_per_rank=1100,
+                )
+            ),
+            index_key_cache=SimpleNamespace(
+                family=SimpleNamespace(
+                    accounting=lambda: SimpleNamespace(
+                        minimum_blocks_per_rank=4,
+                        physical_blocks_per_rank=40,
+                        mapped_bytes_per_rank=1300,
+                    )
+                ),
+                pool_cache=SimpleNamespace(allocated_bytes=310),
+            ),
+            shared_write_publisher=SimpleNamespace(mapped_bytes_per_rank=17),
+        )
+
+        with self.assertLogs(
+            "sglang.srt.mem_cache.dsa_cache_shared", level="INFO"
+        ) as captured:
+            accounting = dsa_cache_shared_module.log_shared_dsa_capacity_accounting(
+                pool, main_demand_workspace_bytes=700
+            )
+
+        self.assertEqual(
+            accounting,
+            dsa_cache_shared_module.SharedDSACapacityAccounting(
+                logical_tokens=1000,
+                logical_pages=16,
+                cp_size=8,
+                main_physical_token_slots_per_layer_per_rank=192,
+                indexer_mode="shared",
+                indexer_physical_token_slots_per_layer_per_rank=256,
+                authoritative_bytes_per_rank=2417,
+                indexer_demand_bytes_per_rank=310,
+                main_demand_bytes_per_rank=700,
+                tracked_total_bytes_per_rank=3427,
+            ),
+        )
+        self.assertEqual(len(captured.records), 1)
+        self.assertIn("logical_tokens=1000", captured.output[0])
+        self.assertIn(
+            "main_physical_token_slots_per_layer_per_rank=192", captured.output[0]
+        )
+        self.assertIn("tracked_total_bytes_per_rank=3427", captured.output[0])
+
+    def test_main_demand_workspace_accounting_counts_each_tensor_once(self):
+        prefill = SlotDemandCache(
+            row_cache=torch.empty((2, 5), dtype=torch.uint8),
+            tags=torch.empty((2,), dtype=torch.int64),
+            local_row_begin=0,
+            local_row_end=2,
+            rows_per_request=2,
+            num_request_slots=1,
+        )
+        decode_tags = torch.empty((1, 2), dtype=torch.int64)
+        decode = SlotDemandCache(
+            row_cache=torch.empty((2, 5), dtype=torch.uint8),
+            tags=decode_tags,
+            local_row_begin=0,
+            local_row_end=2,
+            rows_per_request=2,
+            num_request_slots=1,
+            generation_tensor=torch.empty((), dtype=torch.int32),
+        )
+        current = SharedMLACurrentRows(
+            encoded_rows=torch.empty((1, 1, 5), dtype=torch.uint8),
+            physical_rows=torch.empty((1, 1), dtype=torch.int32),
+            counts=torch.empty((1,), dtype=torch.int32),
+        )
+        manager = DSAFlashMLADemandCacheManager(
+            prefill_cache=prefill,
+            decode_caches=[decode],
+            decode_generation=SimpleNamespace(tensor=decode.generation_tensor),
+            decode_lifecycle=None,
+            current_rows_by_layer=[current],
+            max_current_rows=1,
+        )
+
+        self.assertEqual(manager.allocated_bytes, 69)
+
+    def test_capacity_ledger_reports_replicated_indexer_storage(self):
+        pool = SimpleNamespace(
+            size=1000,
+            page_size=64,
+            shared_size=8,
+            share_indexer=False,
+            main_family=SimpleNamespace(
+                accounting=lambda: SimpleNamespace(
+                    minimum_blocks_per_rank=3,
+                    physical_blocks_per_rank=30,
+                    mapped_bytes_per_rank=1100,
+                )
+            ),
+            index_key_cache=SimpleNamespace(
+                buffer=[
+                    torch.empty((17, 2), dtype=torch.uint8),
+                    torch.empty((17, 2), dtype=torch.uint8),
+                ]
+            ),
+            shared_write_publisher=SimpleNamespace(mapped_bytes_per_rank=17),
+        )
+
+        accounting = dsa_cache_shared_module.log_shared_dsa_capacity_accounting(
+            pool, main_demand_workspace_bytes=700
+        )
+
+        self.assertEqual(accounting.indexer_mode, "replicated")
+        self.assertEqual(
+            accounting.indexer_physical_token_slots_per_layer_per_rank, 1088
+        )
+        self.assertEqual(accounting.authoritative_bytes_per_rank, 1185)
+        self.assertEqual(accounting.indexer_demand_bytes_per_rank, 0)
+        self.assertEqual(accounting.tracked_total_bytes_per_rank, 1885)
+
+    def test_replicated_indexer_factory_skips_shared_vmm_and_demand_cache(self):
+        pool = object.__new__(SharedDSATokenToKVPool)
+        pool.share_indexer = False
+        pool.index_buf_size = 256
+
+        with patch(
+            "sglang.srt.mem_cache.dsa_cache_shared.ReplicatedIndexKeyCache"
+        ) as replicated:
+            cache = SharedDSATokenToKVPool._create_index_key_cache(pool)
+
+        replicated.assert_called_once_with(pool, 256)
+        self.assertIs(cache, replicated.return_value)
+
+    def test_replicated_indexer_snapshots_all_sources_before_overlap_restore(self):
+        pool = SimpleNamespace(page_size=2, index_head_dim=4, quant_block_size=4)
+        cache = object.__new__(ReplicatedIndexKeyCache)
+        cache.pool = pool
+        cache.buffer = [torch.arange(32, dtype=torch.uint8).view(2, 16)]
+        targets = torch.tensor([0, 2], dtype=torch.int64)
+        sources = torch.tensor([2, 0], dtype=torch.int64)
+
+        owned_targets, snapshots = cache.snapshot_move(targets, sources)
+
+        torch.testing.assert_close(owned_targets, targets)
+        expected_k, expected_scale = gather_shared_index_rows(
+            pool, cache.buffer[0], sources
+        )
+        torch.testing.assert_close(snapshots[0][0], expected_k)
+        torch.testing.assert_close(snapshots[0][1], expected_scale)
+
+        with patch(
+            "sglang.srt.mem_cache.dsa_cache_shared.index_buf_accessor.SetKAndS.execute"
+        ) as restore:
+            cache.restore_move(owned_targets, snapshots)
+
+        restore.assert_called_once()
+        self.assertIs(restore.call_args.kwargs["buf"], cache.buffer[0])
+        torch.testing.assert_close(restore.call_args.kwargs["loc"], targets)
+        torch.testing.assert_close(
+            restore.call_args.kwargs["index_k"], expected_k.view(torch.float8_e4m3fn)
+        )
+        torch.testing.assert_close(
+            restore.call_args.kwargs["index_k_scale"],
+            expected_scale.view(torch.float32),
+        )
+
+    def test_indexer_write_target_is_owner_local_shard(self):
+        local = torch.empty((8, 8), dtype=torch.uint8)
+        pool = SimpleNamespace(
+            start_layer=0,
+            shared_rank=2,
+            shared_size=4,
+            index_key_cache=SimpleNamespace(get_local_buffer=lambda _layer: local),
+        )
+
+        targets = SharedDSATokenToKVPool.get_index_k_write_targets(pool, 0)
+
+        self.assertEqual(targets, ((local, 2, 4),))
+
+    def test_replicated_indexer_write_target_uses_full_local_buffer(self):
+        local = torch.empty((8, 8), dtype=torch.uint8)
+        pool = SimpleNamespace(
+            start_layer=0,
+            shared_rank=2,
+            shared_size=4,
+            share_indexer=False,
+            index_key_cache=SimpleNamespace(get_local_buffer=lambda _layer: local),
+        )
+
+        targets = SharedDSATokenToKVPool.get_index_k_write_targets(pool, 0)
+
+        self.assertEqual(targets, ((local, 0, 1),))
+
+    def test_replicated_indexer_keeps_native_page_table_and_disables_demand(self):
+        pool = SimpleNamespace(share_indexer=False, index_layout=None)
+        pool.shared_cache_access = DSASharedCacheAccess(pool)
+        pages = torch.tensor([[0, 4, -1]], dtype=torch.int32)
+
+        prepared = SharedDSATokenToKVPool.prepare_paged_index_page_table(pool, pages)
+
+        self.assertIs(prepared, pages)
+        self.assertFalse(pool.shared_cache_access.uses_shared_indexer)
+
+    def test_kv_size_counts_main_indexer_and_publication_mappings(self):
+        pool = SimpleNamespace(
+            main_family=SimpleNamespace(
+                accounting=lambda: SimpleNamespace(mapped_bytes_per_rank=11)
+            ),
+            shared_write_publisher=SimpleNamespace(mapped_bytes_per_rank=17),
+            index_key_cache=SimpleNamespace(
+                family=SimpleNamespace(
+                    accounting=lambda: SimpleNamespace(mapped_bytes_per_rank=13)
+                ),
+                pool_cache=SimpleNamespace(allocated_bytes=31),
+            ),
+        )
+
+        self.assertEqual(SharedDSATokenToKVPool.get_kv_size_bytes(pool), 72)
+
+    def test_kv_size_counts_full_replicated_indexer_buffers(self):
+        index_buffers = [
+            torch.empty((3, 5), dtype=torch.uint8),
+            torch.empty((2, 7), dtype=torch.uint8),
+        ]
+        pool = SimpleNamespace(
+            share_indexer=False,
+            main_family=SimpleNamespace(
+                accounting=lambda: SimpleNamespace(mapped_bytes_per_rank=11)
+            ),
+            shared_write_publisher=SimpleNamespace(mapped_bytes_per_rank=17),
+            index_key_cache=SimpleNamespace(buffer=index_buffers),
+        )
+
+        self.assertEqual(SharedDSATokenToKVPool.get_kv_size_bytes(pool), 57)
+
+    def test_clear_buffers_closes_publisher_main_and_local_index_cache(self):
+        events = []
+        publisher = SimpleNamespace(close=lambda: events.append("publisher"))
+        main_family = SimpleNamespace(close=lambda: events.append("main"))
+        index_key_cache = SimpleNamespace(clear=lambda: events.append("index"))
+        pool = SimpleNamespace(
+            kv_buffer=["global-main"],
+            local_kv_buffer=["local-main"],
+            main_family=main_family,
+            index_key_cache=index_key_cache,
+            shared_write_publisher=publisher,
+        )
+
+        SharedDSATokenToKVPool._clear_buffers(pool)
+
+        self.assertEqual(events, ["publisher", "main", "index"])
+        self.assertEqual(pool.kv_buffer, [])
+        self.assertEqual(pool.local_kv_buffer, [])
+        self.assertIsNone(pool.shared_write_publisher)
+        self.assertIsNone(pool.main_family)
+
+        SharedDSATokenToKVPool._clear_buffers(pool)
+        self.assertEqual(events, ["publisher", "main", "index"])
+
+    def test_main_family_preserves_allocation_contract_and_publisher_order(self):
+        events = []
+        family = SimpleNamespace(
+            slab=SimpleNamespace(
+                global_views=[torch.empty((4 * 6 * 64, 1, 656), dtype=torch.uint8)],
+                local_views=[torch.empty((6 * 64, 1, 656), dtype=torch.uint8)],
+            ),
+            layout=OwnerShardedLayout(
+                cp_size=4,
+                ownership_granule=64,
+                logical_rows=4 * 6 * 64,
+                physical_blocks_per_rank=6,
+            ),
+        )
+        pool = SimpleNamespace(
+            size=1000,
+            page_size=64,
+            shared_size=4,
+            layer_num=2,
+            kv_cache_dim=656,
+            store_dtype=torch.uint8,
+            device="cpu",
+            shared_rank=0,
+            memory_saver_adapter=SimpleNamespace(
+                region=lambda _memory_type: nullcontext()
+            ),
+            _get_cp_group=lambda: SimpleNamespace(cpu_group="cpu"),
+        )
+
+        def create_family(**_kwargs):
+            events.append("family")
+            return family
+
+        def create_publisher(_group):
+            events.append("publisher")
+            return "publisher"
+
+        with (
+            patch(
+                "sglang.srt.mem_cache.dsa_cache_shared.OwnerShardedFamily.create",
+                side_effect=create_family,
+            ) as create,
+            patch(
+                "sglang.srt.mem_cache.dsa_cache_shared.SharedWritePublisher",
+                side_effect=create_publisher,
+            ),
+        ):
+            SharedDSATokenToKVPool._create_buffers(pool)
+
+        spec = create.call_args.kwargs["spec"]
+        self.assertEqual(events, ["family", "publisher"])
+        self.assertEqual(spec.num_layers, 2)
+        self.assertEqual(spec.logical_rows_per_layer, 4 * 6 * 64)
+        self.assertEqual(spec.ownership_granule, 64)
+        self.assertEqual(spec.storage_rows_per_granule, 64)
+        self.assertEqual(spec.row_shape, (1, 656))
+        self.assertEqual(spec.dtype, torch.uint8)
+        self.assertFalse(spec.map_rank_local)
+        self.assertFalse(create.call_args.kwargs["zero_initialize"])
+        self.assertEqual(pool.shared_write_publisher, "publisher")
+
+    def test_shared_main_k_writer_receives_quantized_fp8_bytes(self):
+        pool = SimpleNamespace(
+            use_dsa=True,
+            dtype=torch.float8_e4m3fn,
+            dsa_kv_cache_store_fp8=True,
+            store_dtype=torch.uint8,
+        )
+        dst = torch.empty((4, 8), dtype=torch.uint8)
+        loc = torch.tensor([0, 1], dtype=torch.int64)
+        nope = torch.ones((2, 4), dtype=torch.bfloat16)
+        rope = torch.ones((2, 2), dtype=torch.bfloat16)
+        nope_fp8 = torch.ones((2, 5), dtype=torch.uint8)
+        rope_fp8 = torch.ones((2, 3), dtype=torch.uint8)
+        writer = MagicMock()
+
+        with patch(
+            "sglang.srt.mem_cache.memory_pool.quantize_k_cache_separate",
+            return_value=(nope_fp8, rope_fp8),
+        ):
+            MLATokenToKVPool._write_mla_kv_buffer(
+                pool, dst, loc, nope, rope, write_fn=writer
+            )
+
+        writer.assert_called_once_with(dst, loc, nope_fp8, rope_fp8)
+
+    def test_shared_main_k_uses_owner_writer_without_row_selection(self):
+        pool = object.__new__(SharedDSATokenToKVPool)
+        pool.size = 64
+        pool.page_size = 4
+        pool.start_layer = 0
+        pool.local_kv_buffer = [torch.empty((4, 8), dtype=torch.uint8)]
+        pool._write_mla_kv_buffer = MagicMock()
+        loc = torch.tensor([0, 4, 8, 12], dtype=torch.int64)
+        nope = torch.ones((4, 5), dtype=torch.uint8)
+        rope = torch.ones((4, 3), dtype=torch.uint8)
+
+        SharedDSATokenToKVPool.set_mla_kv_buffer(
+            pool, SimpleNamespace(layer_id=0), loc, nope, rope
+        )
+
+        pool._write_mla_kv_buffer.assert_called_once_with(
+            pool.local_kv_buffer[0],
+            loc,
+            nope,
+            rope,
+            write_fn=pool._write_owned_mla_kv_buffer,
+        )
+
+    def test_shared_index_pages_translate_to_rank_major_vmm(self):
+        pool = SimpleNamespace(
+            shared_rank=2,
+            index_layout=make_shared_dsa_layout(4, 1, 256).owner_layout,
+        )
+        pages = torch.tensor([0, 1, 4, 5, -1], dtype=torch.int32)
+
+        translated = SharedDSATokenToKVPool.translate_index_pages(pool, pages)
+
+        self.assertEqual(translated.tolist(), [512, 768, 513, 769, -1])
+
+    def test_shared_index_slots_translate_page_owner_and_keep_token_offset(self):
+        pool = SimpleNamespace(
+            page_size=64,
+            shared_rank=2,
+            index_layout=make_shared_dsa_layout(4, 1, 256).owner_layout,
+        )
+        slots = torch.tensor([0, 64, 256, 320, -1], dtype=torch.int64)
+
+        translated = SharedDSATokenToKVPool.translate_index_slots(pool, slots)
+
+        self.assertEqual(translated.tolist(), [32768, 49152, 32832, 49216, -1])
+
+    def test_eagle_move_copies_main_and_indexer_only_on_destination_owner(self):
+        page_size = 4
+        main_layout = make_shared_dsa_layout(2, page_size, 4)
+        index_layout = make_shared_dsa_layout(2, 1, 4).owner_layout
+        local_main = torch.zeros((16, 1, 1), dtype=torch.uint8)
+        shared_main = torch.zeros((32, 1, 1), dtype=torch.uint8)
+        tgt_loc = torch.tensor([1], dtype=torch.int64)
+        src_loc = torch.tensor([5], dtype=torch.int64)
+        index_cache = MagicMock()
+        index_cache.snapshot_move.return_value = (tgt_loc, [(object(), object())])
+        publications = []
+
+        pool = SimpleNamespace(
+            size=32,
+            page_size=page_size,
+            index_head_dim=128,
+            quant_block_size=128,
+            shared_rank=0,
+            main_layout=main_layout,
+            index_layout=index_layout,
+            local_kv_buffer=[local_main],
+            kv_buffer=[shared_main],
+            index_key_cache=index_cache,
+            synchronize_shared_writes=lambda: publications.append("publish"),
+        )
+        shared_main[main_layout.translate_slots(src_loc)] = 11
+
+        SharedDSATokenToKVPool.move_kv_cache(pool, tgt_loc, src_loc)
+
+        self.assertEqual(local_main[1].item(), 11)
+        index_cache.snapshot_move.assert_called_once_with(tgt_loc, src_loc)
+        index_cache.restore_move.assert_called_once_with(
+            tgt_loc, index_cache.snapshot_move.return_value[1]
+        )
+        self.assertEqual(publications, ["publish", "publish"])
+
+    def test_write_fence_uses_model_neutral_publisher(self):
+        publisher = MagicMock(spec=SharedWritePublisher)
+        pool = SimpleNamespace(shared_write_publisher=publisher)
+
+        SharedDSATokenToKVPool.synchronize_shared_writes(pool)
+
+        publisher.publish.assert_called_once_with()
+
+    def test_indexer_runs_one_shared_write_fence_before_read(self):
+        calls = []
+        pool = SimpleNamespace(
+            share_indexer=True,
+            synchronize_shared_writes=lambda: calls.append("fence"),
+        )
+        pool.shared_cache_access = DSASharedCacheAccess(pool)
+
+        _synchronize_shared_cache_writes(pool)
+
+        self.assertEqual(calls, ["fence"])
+
+    def test_replicated_indexer_has_no_shared_write_fence(self):
+        calls = []
+        pool = SimpleNamespace(
+            share_indexer=False,
+            synchronize_shared_writes=lambda: calls.append("shared"),
+        )
+        pool.shared_cache_access = DSASharedCacheAccess(pool)
+
+        _synchronize_shared_cache_writes(pool)
+
+        self.assertEqual(calls, [])
+
+    def test_paged_indexer_uses_global_vmm_view_and_translated_page_table(self):
+        calls = []
+        expected = torch.zeros((2, 8), dtype=torch.uint8)
+        pool = SimpleNamespace(
+            shared_rank=2,
+            layer_transfer_counter=None,
+            start_layer=0,
+            index_layout=make_shared_dsa_layout(4, 1, 256).owner_layout,
+            index_key_cache=SimpleNamespace(
+                get_global_buffer=lambda _layer_id: expected
+            ),
+            synchronize_shared_writes=lambda: calls.append("fence"),
+        )
+        pool.shared_cache_access = DSASharedCacheAccess(pool)
+        pages = torch.tensor([0, 1, 2, 3, 4, -1], dtype=torch.int32)
+
+        translated = SharedDSATokenToKVPool.prepare_paged_index_page_table(pool, pages)
+        actual = SharedDSATokenToKVPool.get_paged_index_k_with_scale_buffer(pool, 0)
+
+        self.assertEqual(translated.tolist(), [512, 768, 0, 256, 513, -1])
+        self.assertIs(actual, expected)
+        self.assertEqual(calls, [])
+
+    def test_indexer_write_targets_use_only_owner_local_view(self):
+        owner_local = torch.empty((8, 8), dtype=torch.uint8)
+        pool = SimpleNamespace(
+            start_layer=0,
+            shared_rank=2,
+            shared_size=4,
+            index_key_cache=SimpleNamespace(
+                get_local_buffer=lambda _layer_id: owner_local
+            ),
+        )
+
+        targets = SharedDSATokenToKVPool.get_index_k_write_targets(pool, 0)
+
+        self.assertEqual(targets, ((owner_local, 2, 4),))
+
+    def test_attention_reads_canonical_main_view(self):
+        calls = []
+        global_view = torch.empty((24, 1, 8), dtype=torch.uint8)
+        rank_local_view = torch.empty((24, 1, 8), dtype=torch.uint8)
+        pool = SimpleNamespace(
+            layer_transfer_counter=None,
+            start_layer=0,
+            dtype=torch.uint8,
+            store_dtype=torch.uint8,
+            rank_local_kv_buffer=[rank_local_view],
+            kv_buffer=[global_view],
+            synchronize_shared_writes=lambda: calls.append("fence"),
+        )
+        pool.shared_cache_access = DSASharedCacheAccess(pool)
+
+        actual = SharedDSATokenToKVPool.get_key_buffer(pool, 0)
+
+        self.assertIs(actual, global_view)
+        self.assertEqual(calls, [])
+
+        _synchronize_pool_main_cache(pool)
+
+        self.assertEqual(calls, ["fence"])
+
+    def test_attention_translates_main_slots_to_canonical_layout(self):
+        pool = SimpleNamespace(
+            main_layout=make_shared_dsa_layout(4, 64, 3),
+        )
+        slots = torch.tensor([0, 64, 128, 192, 256, -1], dtype=torch.int64)
+
+        translated = SharedDSATokenToKVPool.translate_main_slots(pool, slots)
+
+        self.assertEqual(translated.tolist(), [0, 192, 384, 576, 64, -1])
+
+
+class TestSharedDSAIntegrationHooks(CustomTestCase):
+    @staticmethod
+    def _flashmla_backend(*, kv_cache_dim: int, stores_scaled_fp8: bool):
+        backend = object.__new__(DeepseekSparseAttnBackend)
+        backend.real_page_size = 64
+        backend.kv_cache_dim = kv_cache_dim
+        backend.dsa_kv_cache_store_fp8 = stores_scaled_fp8
+        backend.flashmla_kv_num_q_heads = 64
+        backend.dsa_index_topk = 2048
+        return backend
+
+    def test_decode_forwards_shared_demand_cache_to_flashmla(self):
+        backend = object.__new__(DeepseekSparseAttnBackend)
+        backend.dsa_decode_impl = "flashmla_kv"
+        request_slots = torch.tensor([3], dtype=torch.int64)
+        backend.forward_metadata = SimpleNamespace(
+            shared_cache_request_slots=request_slots,
+            shared_mla_current_rows=None,
+            shared_mla_current_rows_per_request=0,
+        )
+        kv_cache = torch.empty((64, 1, 656), dtype=torch.uint8)
+        backend.token_to_kv_pool = SimpleNamespace(
+            start_layer=0,
+            synchronize_shared_writes=lambda: None,
+            get_key_buffer=lambda _: kv_cache,
+        )
+        backend.hisparse_coordinator = None
+        backend.use_fused_topk = True
+        backend._get_fused_topk_page_table = lambda _: torch.zeros(
+            (1, 2048), dtype=torch.int32
+        )
+        backend._pad_topk_indices = lambda indices, _: indices
+        decode_cache = object()
+        backend._shared_main_demand_cache = SimpleNamespace(
+            has_decode_cache=True,
+            cache_for_layer=lambda **_: (decode_cache, True),
+        )
+        observed = {}
+
+        def run_flashmla(**kwargs):
+            observed.update(kwargs)
+            return torch.tensor([7])
+
+        backend._forward_flashmla_kv = run_flashmla
+        layer = SimpleNamespace(
+            is_cross_attention=False,
+            layer_id=0,
+            tp_q_head_num=16,
+            v_head_dim=512,
+            head_dim=576,
+            scaling=576**-0.5,
+        )
+        q = torch.empty((1, 16, 576), dtype=torch.bfloat16)
+        topk_indices = torch.zeros((1, 2048), dtype=torch.int32)
+
+        with patch(
+            "sglang.srt.layers.attention.dsa_backend.concat_mla_absorb_q_general",
+            side_effect=lambda q_nope, q_rope: torch.cat([q_nope, q_rope], dim=-1),
+        ):
+            result = backend.forward_decode(
+                q=q,
+                k=None,
+                v=None,
+                layer=layer,
+                forward_batch=SimpleNamespace(req_pool_indices=request_slots),
+                topk_indices=topk_indices,
+            )
+
+        torch.testing.assert_close(result, torch.tensor([7]))
+        self.assertIs(observed["shared_demand_cache"], decode_cache)
+        self.assertTrue(observed["persistent"])
+        self.assertIs(observed["shared_cache_request_slots"], request_slots)
+
+    def test_decode_graph_replay_refreshes_current_row_locations(self):
+        backend = object.__new__(DeepseekSparseAttnBackend)
+        backend.real_page_size = 1
+        backend.device = "cpu"
+        backend.dsa_index_topk = 2
+        backend.dsa_decode_impl = "test"
+        backend.speculative_num_draft_tokens = 4
+        backend.req_to_token = torch.tensor([[41, 42], [51, 52]], dtype=torch.int64)
+        backend.set_dsa_prefill_impl = lambda forward_batch: None
+
+        capture_locs = torch.full((8,), 7, dtype=torch.int64)
+        page_table = torch.zeros((8, 2), dtype=torch.int64)
+        metadata = SimpleNamespace(
+            cache_seqlens_int32=torch.zeros(2, dtype=torch.int32),
+            cu_seqlens_k=torch.zeros(3, dtype=torch.int32),
+            page_table_1=page_table,
+            dsa_cache_seqlens_int32=torch.zeros(8, dtype=torch.int32),
+            dsa_cu_seqlens_k=torch.zeros(9, dtype=torch.int32),
+            dsa_seqlens_expanded=torch.zeros(8, dtype=torch.int32),
+            shared_cache_request_slots=None,
+            shared_mla_current_row_locs=capture_locs,
+            page_size=1,
+            real_page_table=page_table,
+            prepared_paged_index_page_table=page_table,
+        )
+        backend.decode_cuda_graph_metadata = {2: metadata}
+        replay_locs = torch.tensor([99, 100, 101, 102], dtype=torch.int64)
+
+        expanded_lens = torch.tensor([3, 4, 5, 6, 2, 3, 4, 5], dtype=torch.int32)
+        with (
+            patch.object(dsa_backend_module, "is_cuda", return_value=False),
+            patch.object(
+                dsa_backend_module,
+                "seqlens_expand_triton",
+                return_value=expanded_lens,
+            ),
+        ):
+            backend._apply_cuda_graph_metadata(
+                bs=2,
+                req_pool_indices=torch.tensor([0, 1], dtype=torch.int64),
+                seq_lens=torch.tensor([2, 1], dtype=torch.int32),
+                seq_lens_cpu=torch.tensor([2, 1], dtype=torch.int32),
+                forward_mode=dsa_backend_module.ForwardMode.TARGET_VERIFY,
+                spec_info=None,
+                out_cache_loc=replay_locs,
+            )
+
+        torch.testing.assert_close(
+            metadata.shared_mla_current_row_locs,
+            torch.tensor([99, 100, 101, 102, 0, 0, 0, 0], dtype=torch.int64),
+        )
+
+    def test_base_flashmla_keeps_scaled_layout_and_legacy_scheduler(self):
+        calls = []
+
+        def flash_mla_with_kvcache(**kwargs):
+            calls.append(kwargs)
+            return torch.empty((1, 1, 64, 512), dtype=torch.bfloat16), None
+
+        cache_seqlens = torch.tensor([2048], dtype=torch.int32)
+        legacy_metadata = torch.tensor([1], dtype=torch.int32)
+        legacy_splits = torch.tensor([2], dtype=torch.int32)
+        metadata = SimpleNamespace(
+            dsa_cache_seqlens_int32=cache_seqlens,
+            flashmla_metadata=DSAFlashMLAMetadata(
+                flashmla_metadata=legacy_metadata,
+                num_splits=legacy_splits,
+            ),
+        )
+        backend = self._flashmla_backend(kv_cache_dim=656, stores_scaled_fp8=True)
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "sgl_kernel.flash_mla": SimpleNamespace(
+                    flash_mla_with_kvcache=flash_mla_with_kvcache
+                )
+            },
+        ):
+            backend._forward_flashmla_kv(
+                q_all=torch.empty((1, 64, 576), dtype=torch.bfloat16),
+                kv_cache=torch.empty((64, 1, 656), dtype=torch.uint8),
+                v_head_dim=512,
+                sm_scale=576**-0.5,
+                layer=SimpleNamespace(tp_q_head_num=64, head_dim=576),
+                metadata=metadata,
+                page_table_1=torch.zeros((1, 2048), dtype=torch.int32),
+            )
+
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0]["k_cache"].shape, (1, 64, 1, 656))
+        self.assertIs(calls[0]["cache_seqlens"], cache_seqlens)
+        self.assertIs(calls[0]["tile_scheduler_metadata"], legacy_metadata)
+        self.assertIs(calls[0]["num_splits"], legacy_splits)
+        self.assertEqual(calls[0]["block_table"].shape, (1, 0))
+
+    def test_base_flashmla_metadata_stays_legacy(self):
+        calls = []
+
+        def get_mla_metadata(**kwargs):
+            calls.append(kwargs)
+            return (
+                torch.tensor([1], dtype=torch.int32),
+                torch.tensor([2], dtype=torch.int32),
+            )
+
+        backend = object.__new__(DeepseekSparseAttnBackend)
+        backend.flashmla_kv_num_q_heads = 64
+        backend.dsa_index_topk = 2048
+        backend.token_to_kv_pool = SimpleNamespace()
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "sgl_kernel.flash_mla": SimpleNamespace(
+                    get_mla_metadata=get_mla_metadata
+                )
+            },
+        ):
+            metadata = backend._compute_flashmla_metadata(
+                cache_seqlens=torch.tensor([2048], dtype=torch.int32),
+                seq_len_q=1,
+            )
+
+        self.assertEqual(len(calls), 1)
+        self.assertNotEqual(calls[0], {})
+
+    def test_flashmla_trims_cp_padding_to_query_rows(self):
+        calls = []
+
+        def flash_mla_with_kvcache(**kwargs):
+            calls.append(kwargs)
+            return torch.empty((6, 1, 64, 512), dtype=torch.bfloat16), None
+
+        metadata = SimpleNamespace(
+            dsa_cache_seqlens_int32=torch.tensor(
+                [6, 6, 6, 6, 6, 6, 0, 0], dtype=torch.int32
+            ),
+            flashmla_metadata=DSAFlashMLAMetadata(
+                flashmla_metadata=torch.tensor([17], dtype=torch.int32),
+                num_splits=torch.arange(9, dtype=torch.int32),
+            ),
+        )
+        backend = self._flashmla_backend(kv_cache_dim=656, stores_scaled_fp8=True)
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "sgl_kernel.flash_mla": SimpleNamespace(
+                    flash_mla_with_kvcache=flash_mla_with_kvcache
+                )
+            },
+        ):
+            backend._forward_flashmla_kv(
+                q_all=torch.empty((6, 64, 576), dtype=torch.bfloat16),
+                kv_cache=torch.empty((64, 1, 656), dtype=torch.uint8),
+                v_head_dim=512,
+                sm_scale=576**-0.5,
+                layer=SimpleNamespace(tp_q_head_num=64, head_dim=576),
+                metadata=metadata,
+                page_table_1=torch.zeros((6, 2048), dtype=torch.int32),
+            )
+
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0]["cache_seqlens"].tolist(), [6] * 6)
+        self.assertEqual(calls[0]["num_splits"].tolist(), list(range(7)))
+
+    def test_indexer_keeps_existing_read_buffer_helper(self):
+        self.assertTrue(hasattr(Indexer, "_get_index_k_read_buffer"))
+
+    def test_index_write_targets_delegate_to_pool(self):
+        expected = ((object(), 3, 8), (object(), 0, 1))
+        pool = SimpleNamespace(get_index_k_write_targets=lambda _layer_id: expected)
+
+        self.assertEqual(_get_index_cache_write_targets(pool, 12), expected)
+
+    def test_page_tables_delegate_to_pool(self):
+        pool = SimpleNamespace(
+            prepare_paged_index_page_table=lambda table: table + 15,
+            main_layout=make_shared_dsa_layout(2, 1, 8),
+        )
+        pool.shared_cache_access = DSASharedCacheAccess(pool)
+        table = torch.tensor([[1, -1]], dtype=torch.int32)
+
+        self.assertEqual(
+            _prepare_paged_index_page_table(pool, table).tolist(), [[16, 14]]
+        )
+        with patch(
+            "sglang.srt.layers.attention.dsa_backend.translate_owner_sharded_slots",
+            return_value=torch.tensor([[8, -1]], dtype=torch.int32),
+        ) as translate:
+            translated = _translate_pool_main_page_table(pool, table)
+        self.assertEqual(translated.tolist(), [[8, -1]])
+        translate.assert_called_once()
+        self.assertEqual(
+            _prepare_pool_index_page_table(pool, table).tolist(), [[16, 14]]
+        )
+
+    def test_plain_pool_is_unchanged(self):
+        plain_buffer = object()
+        pool = SimpleNamespace(
+            get_index_k_with_scale_buffer=lambda layer_id: plain_buffer
+        )
+        table = torch.tensor([[3]], dtype=torch.int32)
+
+        self.assertEqual(
+            _get_index_cache_write_targets(pool, 7), ((plain_buffer, 0, 1),)
+        )
+        self.assertIs(_prepare_paged_index_page_table(pool, table), table)
+        self.assertIs(_prepare_pool_index_page_table(pool, table), table)
+        self.assertIs(_translate_pool_main_page_table(pool, table), table)
+
+    def test_main_owner_translation_args_follow_shared_layout(self):
+        pool = SimpleNamespace(main_layout=make_shared_dsa_layout(8, 64, 1024))
+        pool.shared_cache_access = DSASharedCacheAccess(pool)
+
+        self.assertEqual(
+            _get_pool_main_owner_translation_args(pool),
+            {
+                "owner_cp_size": 8,
+                "owner_page_size": 64,
+                "owner_pages_per_rank": 1024,
+            },
+        )
+
+    def test_main_owner_translation_does_not_mutate_reused_topk(self):
+        pool = SimpleNamespace(main_layout=make_shared_dsa_layout(8, 64, 1024))
+        pool.shared_cache_access = DSASharedCacheAccess(pool)
+        topk = torch.tensor([[0, 64, -1]], dtype=torch.int32)
+        original = topk.clone()
+
+        def translate(slots, *, result, **_kwargs):
+            self.assertIsNot(result, slots)
+            result.copy_(slots + 100)
+            return result
+
+        with patch(
+            "sglang.srt.layers.attention.dsa_backend.translate_owner_sharded_slots",
+            side_effect=translate,
+        ):
+            translated = _translate_pool_main_page_table(pool, topk)
+
+        self.assertIsNot(translated, topk)
+        torch.testing.assert_close(topk, original)
+        torch.testing.assert_close(translated, original + 100)
+
+    def test_plain_pool_has_no_fused_owner_translation(self):
+        self.assertIsNone(_get_pool_main_owner_translation_args(SimpleNamespace()))
+
+    def test_indexer_metadata_reuses_prepared_page_table(self):
+        logical = torch.tensor([[3]], dtype=torch.int32)
+        prepared = torch.tensor([[9]], dtype=torch.int32)
+        metadata = DSAIndexerMetadata(
+            attn_metadata=SimpleNamespace(
+                real_page_table=logical,
+                prepared_paged_index_page_table=prepared,
+            ),
+            topk_transform_method=TopkTransformMethod.PAGED,
+        )
+
+        self.assertIs(metadata.get_page_table_64(), logical)
+        self.assertIs(metadata.get_prepared_paged_index_page_table(), prepared)
+
+
+class TestSharedDSAPoolSelection(CustomTestCase):
+    def setUp(self):
+        self.runner = SimpleNamespace(
+            is_draft_worker=False,
+            use_mla_backend=True,
+            server_args=SimpleNamespace(
+                enable_dsa_shared_kv_cache=True,
+                enable_dsa_cache_layer_split=False,
+                enable_hisparse=False,
+            ),
+            model_config=SimpleNamespace(hf_config=SimpleNamespace()),
+        )
+
+    @patch("sglang.srt.configs.model_config.is_deepseek_dsa", return_value=True)
+    def test_shared_pool_info_uses_attention_cp_group(self, _):
+        with get_parallel().override(attn_cp_size=8, attn_cp_rank=3):
+            self.assertTrue(is_glm_dsa_cache_shared_enabled(self.runner))
+            self.assertEqual(get_glm_dsa_shared_info(self.runner), (3, 8))
+
+    @patch("sglang.srt.configs.model_config.is_deepseek_dsa", return_value=True)
+    def test_shared_capacity_counts_only_local_physical_pages(self, _):
+        with get_parallel().override(attn_cp_size=8, attn_cp_rank=3):
+            self.assertEqual(
+                get_glm_dsa_shared_effective_num_layers(self.runner, 61), 8
+            )
+
+    @patch("sglang.srt.configs.model_config.is_deepseek_dsa", return_value=True)
+    @patch(
+        "sglang.srt.model_executor.pool_configurator.get_memory",
+        return_value=SimpleNamespace(enable_hisparse=False),
+    )
+    @patch(
+        "sglang.srt.model_executor.pool_configurator.get_dsa_index_head_dim",
+        return_value=128,
+    )
+    @patch(
+        "sglang.srt.model_executor.pool_configurator.is_deepseek_dsa",
+        return_value=True,
+    )
+    def test_shared_capacity_owner_shards_indexer_cache(self, *_):
+        from sglang.srt.model_executor.pool_configurator import (
+            DefaultPoolConfigurator,
+        )
+
+        self.runner.kv_cache_dtype = torch.float8_e4m3fn
+        self.runner.model_config.kv_lora_rank = 512
+        self.runner.model_config.qk_rope_head_dim = 64
+        configurator = DefaultPoolConfigurator.__new__(DefaultPoolConfigurator)
+        configurator.kv_cache_dtype_str = "fp8_e4m3"
+
+        with get_parallel().override(attn_cp_size=8, attn_cp_rank=3, attn_tp_size=8):
+            cell_size = configurator._compute_cell_size(self.runner, num_layers=61)
+
+        main_owner_shard = (512 + 64) * 8
+        index_row = 128 + 128 // 128 * 4
+        owner_sharded_index = index_row * 8
+        self.assertEqual(cell_size, main_owner_shard + owner_sharded_index)
+
+    def test_default_pool_capacity_subtracts_fixed_workspace_before_rounding(self):
+        from sglang.srt.model_executor.pool_configurator import (
+            DefaultPoolConfigurator,
+        )
+
+        configurator = DefaultPoolConfigurator.__new__(DefaultPoolConfigurator)
+        configurator._cell_size = 128
+        configurator._fixed_bytes = 8192
+        configurator._indexer_pool_cache_num_layers = 0
+
+        config = configurator.calculate_pool_sizes(
+            available_bytes=8192 + 128 * 128,
+            page_size=64,
+        )
+
+        self.assertEqual(config.max_total_num_tokens, 128)
+
+    @patch(
+        "sglang.srt.model_executor.pool_configurator."
+        "DefaultPoolConfigurator._compute_cell_size",
+        return_value=128,
+    )
+    @patch(
+        "sglang.srt.model_executor.pool_configurator.mambaish_config",
+        return_value=None,
+    )
+    def test_shared_flashmla_demand_workspace_is_a_fixed_pool_bias(self, *_):
+        from sglang.srt.model_executor.pool_configurator import (
+            DefaultPoolConfigurator,
+        )
+
+        spec_algorithm = MagicMock()
+        spec_algorithm.is_eagle.return_value = False
+        spec_algorithm.is_standalone.return_value = False
+        spec_algorithm.is_dflash_family.return_value = False
+        kvc = SimpleNamespace(
+            model_config=SimpleNamespace(
+                context_len=4096,
+                hf_config=SimpleNamespace(
+                    architectures=["GlmMoeDsaForCausalLM"],
+                    index_topk=2048,
+                    index_head_dim=128,
+                    cli_factor=1,
+                ),
+            ),
+            layer_info=SimpleNamespace(
+                num_effective_layers=78,
+                start_layer=0,
+                end_layer=78,
+            ),
+            page_size=64,
+            kv_cache_dtype_str="fp8_e4m3",
+            spec_algorithm=spec_algorithm,
+            is_draft_worker=False,
+            use_mla_backend=True,
+            server_args=SimpleNamespace(
+                enable_dsa_shared_kv_cache=True,
+                dsa_prefill_backend="flashmla_kv",
+                dsa_decode_backend="flashmla_kv",
+                max_running_requests=32,
+                max_total_tokens=None,
+                speculative_num_draft_tokens=4,
+            ),
+        )
+
+        with get_parallel().override(attn_cp_size=8):
+            configurator = DefaultPoolConfigurator(kvc)
+
+        self.assertEqual(getattr(configurator, "_fixed_bytes", 0), 6_988_942_340)
+
+    def test_shared_flashmla_rejects_more_than_four_current_rows(self):
+        from sglang.srt.mem_cache.dsa_shared_demand import (
+            get_flashmla_shared_demand_workspace_bytes,
+        )
+
+        with self.assertRaisesRegex(ValueError, "at most four"):
+            get_flashmla_shared_demand_workspace_bytes(
+                num_layers=78,
+                num_request_slots=32,
+                max_current_rows=5,
+            )
+
+    def test_shared_flashmla_without_speculation_uses_one_current_row(self):
+        from sglang.srt.mem_cache.dsa_shared_demand import (
+            resolve_flashmla_shared_max_current_rows,
+        )
+
+        self.assertEqual(resolve_flashmla_shared_max_current_rows(None), 1)
+        self.assertEqual(resolve_flashmla_shared_max_current_rows(3), 3)
+        self.assertEqual(resolve_flashmla_shared_max_current_rows(4), 4)
+
+    @patch("sglang.srt.configs.model_config.is_deepseek_dsa", return_value=True)
+    def test_layer_split_capacity_api_remains_compatible(self, _):
+        self.runner.server_args.enable_dsa_shared_kv_cache = False
+        self.runner.server_args.enable_dsa_cache_layer_split = True
+        with get_parallel().override(attn_cp_size=8, attn_cp_rank=3):
+            self.assertTrue(
+                hasattr(cp_utils, "get_glm_dsa_layer_split_effective_num_layers")
+            )
+            self.assertEqual(
+                cp_utils.get_glm_dsa_layer_split_effective_num_layers(self.runner, 61),
+                9,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_dsa_shared_owner_write.py
+++ b/test/registered/unit/mem_cache/test_dsa_shared_owner_write.py
@@ -1,0 +1,493 @@
+import unittest
+from unittest.mock import patch
+
+import torch
+
+from sglang.test.ci.ci_register import register_cuda_ci
+
+_HAS_CUDA = torch.cuda.is_available()
+
+register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-small")
+
+
+@unittest.skipUnless(_HAS_CUDA, "Triton kernels require CUDA")
+class TestDSASharedOwnerWrite(unittest.TestCase):
+    def test_materialize_dynamic_validation_is_eager_only(self):
+        from sglang.kernels.ops.kvcache.dsa_shared import (
+            _validate_materialize_indexer_pages_dynamic,
+        )
+
+        seq_len = torch.tensor([64], dtype=torch.int32)
+        source_pages = torch.tensor([[0]], dtype=torch.int32)
+        target_pages = torch.tensor([[0]], dtype=torch.int32)
+
+        with (
+            patch("torch.cuda.is_current_stream_capturing", return_value=True),
+            patch("torch._assert_async") as assert_async,
+        ):
+            _validate_materialize_indexer_pages_dynamic(
+                source_pages,
+                target_pages,
+                seq_len,
+                page_size=64,
+                source_page_capacity=1,
+                target_page_capacity=1,
+            )
+            assert_async.assert_not_called()
+
+        with (
+            patch("torch.cuda.is_current_stream_capturing", return_value=False),
+            patch("torch._assert_async") as assert_async,
+        ):
+            _validate_materialize_indexer_pages_dynamic(
+                source_pages,
+                target_pages,
+                seq_len,
+                page_size=64,
+                source_page_capacity=1,
+                target_page_capacity=1,
+            )
+            self.assertEqual(assert_async.call_count, 3)
+
+    def test_materialize_indexer_pages_uses_bounded_graph_workers(self):
+        from sglang.kernels.ops.kvcache.dsa_shared import (
+            _materialize_indexer_pages_grid,
+        )
+
+        self.assertEqual(_materialize_indexer_pages_grid(1, 16_386), (16_386,))
+        self.assertEqual(_materialize_indexer_pages_grid(2, 16_386), (32_772,))
+        self.assertEqual(_materialize_indexer_pages_grid(4, 16_386), (65_544,))
+        self.assertEqual(_materialize_indexer_pages_grid(7, 16_386), (114_702,))
+        self.assertEqual(_materialize_indexer_pages_grid(8, 16_386), (1_024,))
+        self.assertEqual(_materialize_indexer_pages_grid(32, 16_386), (4_096,))
+
+    def test_materialize_indexer_pages_copies_vmm_sources_to_pool_pages(self):
+        from sglang.kernels.ops.kvcache.dsa_shared import (
+            materialize_indexer_pages_triton,
+        )
+
+        source = torch.arange(12 * 64, dtype=torch.uint8, device="cuda").view(12, 64)
+        source_pages = torch.tensor(
+            [[10, 7, 11, 8], [6, 9, 8, 7]], dtype=torch.int32, device="cuda"
+        )
+        pool_pages = torch.tensor(
+            [[4, 1, 5, 2], [0, 3, 2, 1]], dtype=torch.int32, device="cuda"
+        )
+        seq_len = torch.tensor([130, 65], dtype=torch.int32, device="cuda")
+        target = torch.full((8, 64), 0xFF, dtype=torch.uint8, device="cuda")
+
+        materialize_indexer_pages_triton(
+            target,
+            source,
+            source_pages,
+            pool_pages,
+            seq_len,
+            page_size=64,
+        )
+        torch.cuda.synchronize()
+
+        self.assertTrue(torch.equal(target[4], source[10]))
+        self.assertTrue(torch.equal(target[1], source[7]))
+        self.assertTrue(torch.equal(target[5], source[11]))
+        self.assertTrue(torch.equal(target[0], source[6]))
+        self.assertTrue(torch.equal(target[3], source[9]))
+        self.assertTrue(torch.all(target[2] == 0xFF))
+        self.assertTrue(torch.all(target[6:] == 0xFF))
+
+    def test_materialize_indexer_pages_supports_independent_table_strides(self):
+        from sglang.kernels.ops.kvcache.dsa_shared import (
+            materialize_indexer_pages_triton,
+        )
+
+        source = torch.arange(12 * 64, dtype=torch.uint8, device="cuda").view(12, 64)
+        source_pages = torch.tensor(
+            [[10, 7, 11, 8], [6, 9, 8, 7]], dtype=torch.int32, device="cuda"
+        )
+        pool_page_storage = torch.tensor(
+            [[4, 0], [1, 3], [5, 2], [2, 1]], dtype=torch.int32, device="cuda"
+        )
+        pool_pages = pool_page_storage.transpose(0, 1)
+        self.assertNotEqual(source_pages.stride(0), pool_pages.stride(0))
+        seq_len = torch.tensor([130, 65], dtype=torch.int32, device="cuda")
+        target = torch.full((8, 64), 0xFF, dtype=torch.uint8, device="cuda")
+
+        materialize_indexer_pages_triton(
+            target,
+            source,
+            source_pages,
+            pool_pages,
+            seq_len,
+            page_size=64,
+        )
+        torch.cuda.synchronize()
+
+        self.assertTrue(torch.equal(target[4], source[10]))
+        self.assertTrue(torch.equal(target[1], source[7]))
+        self.assertTrue(torch.equal(target[5], source[11]))
+        self.assertTrue(torch.equal(target[0], source[6]))
+        self.assertTrue(torch.equal(target[3], source[9]))
+
+    def test_materialize_indexer_pages_replays_with_updated_length_and_table(self):
+        from sglang.kernels.ops.kvcache.dsa_shared import (
+            materialize_indexer_pages_triton,
+        )
+
+        source = torch.arange(6 * 64, dtype=torch.uint8, device="cuda").view(6, 64)
+        page_table = torch.tensor(
+            [[4, 1, 5, 2], [0, 3, 2, 1]], dtype=torch.int32, device="cuda"
+        )
+        seq_len = torch.tensor([130, 65], dtype=torch.int32, device="cuda")
+        target = torch.zeros((8, 64), dtype=torch.uint8, device="cuda")
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            materialize_indexer_pages_triton(
+                target,
+                source,
+                page_table,
+                page_table,
+                seq_len,
+                page_size=64,
+            )
+
+        target.fill_(0xFF)
+        page_table.copy_(torch.tensor([[3, 0, 2, 1], [5, 4, 1, 0]], device="cuda"))
+        seq_len.copy_(torch.tensor([65, 1], device="cuda"))
+        graph.replay()
+        torch.cuda.synchronize()
+
+        active = torch.tensor([3, 0, 5], device="cuda")
+        self.assertTrue(torch.equal(target[active], source[active]))
+        self.assertTrue(torch.all(target[1:3] == 0xFF))
+        self.assertTrue(torch.all(target[4] == 0xFF))
+        self.assertTrue(torch.all(target[6:] == 0xFF))
+
+    def test_materialize_worker_replays_with_updated_length_and_table(self):
+        from sglang.kernels.ops.kvcache.dsa_shared import (
+            materialize_indexer_pages_triton,
+        )
+
+        batch_size = 8
+        pages_per_request = 4
+        total_pages = batch_size * pages_per_request
+        source = torch.arange(total_pages * 64, dtype=torch.int64, device="cuda").view(
+            total_pages, 64
+        )
+        target_pages = torch.arange(total_pages, dtype=torch.int32, device="cuda").view(
+            batch_size, pages_per_request
+        )
+        source_pages = target_pages.clone()
+        seq_len = torch.full((batch_size,), 130, dtype=torch.int32, device="cuda")
+        target = torch.zeros_like(source)
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            materialize_indexer_pages_triton(
+                target,
+                source,
+                source_pages,
+                target_pages,
+                seq_len,
+                page_size=64,
+            )
+
+        target.fill_(-1)
+        source_pages.copy_(torch.flip(target_pages, dims=[1]))
+        replay_lengths = torch.tensor(
+            [1, 65, 130, 193, 1, 65, 130, 193],
+            dtype=torch.int32,
+            device="cuda",
+        )
+        seq_len.copy_(replay_lengths)
+        graph.replay()
+        torch.cuda.synchronize()
+
+        for batch in range(batch_size):
+            active_pages = (int(replay_lengths[batch]) + 63) // 64
+            for page in range(pages_per_request):
+                target_page = int(target_pages[batch, page])
+                if page < active_pages:
+                    source_page = int(source_pages[batch, page])
+                    self.assertTrue(
+                        torch.equal(target[target_page], source[source_page])
+                    )
+                else:
+                    self.assertTrue(torch.all(target[target_page] == -1))
+
+    def test_persistent_pool_cache_reuses_history_and_refreshes_tail(self):
+        from sglang.kernels.ops.kvcache.dsa_shared import (
+            materialize_indexer_pages_triton,
+        )
+
+        source = torch.arange(4 * 64, dtype=torch.uint8, device="cuda").view(4, 64)
+        page_table = torch.tensor([[2, 0, 3, 1]], dtype=torch.int32, device="cuda")
+        seq_len = torch.tensor([130], dtype=torch.int32, device="cuda")
+        target = torch.full((4, 64), 0xFF, dtype=torch.uint8, device="cuda")
+        tags = torch.zeros(4, dtype=torch.int64, device="cuda")
+        epoch = torch.ones((), dtype=torch.int32, device="cuda")
+
+        materialize_indexer_pages_triton(
+            target,
+            source,
+            page_table,
+            page_table,
+            seq_len,
+            page_size=64,
+            tags=tags,
+            epoch=epoch,
+        )
+        first = target.clone()
+
+        source[2].add_(7)
+        source[0].add_(11)
+        source[3].add_(13)
+        materialize_indexer_pages_triton(
+            target,
+            source,
+            page_table,
+            page_table,
+            seq_len,
+            page_size=64,
+            tags=tags,
+            epoch=epoch,
+        )
+        torch.cuda.synchronize()
+
+        self.assertTrue(torch.equal(target[2], first[2]))
+        self.assertTrue(torch.equal(target[0], first[0]))
+        self.assertTrue(torch.equal(target[3], source[3]))
+
+        epoch.add_(1)
+        materialize_indexer_pages_triton(
+            target,
+            source,
+            page_table,
+            page_table,
+            seq_len,
+            page_size=64,
+            tags=tags,
+            epoch=epoch,
+        )
+        torch.cuda.synchronize()
+        active = page_table[0, :3].long()
+        self.assertTrue(torch.equal(target[active], source[active]))
+
+    def test_materialize_worker_crosses_page_rounds_before_publishing_tags(self):
+        from sglang.kernels.ops.kvcache.dsa_shared import (
+            materialize_indexer_pages_triton,
+        )
+
+        batch_size = 8
+        active_pages = 130
+        page_bytes = 8_448
+        source = torch.randint(
+            0,
+            256,
+            (batch_size * active_pages, page_bytes),
+            dtype=torch.uint8,
+            device="cuda",
+        )
+        page_table = torch.full((batch_size, 256), -1, dtype=torch.int32, device="cuda")
+        page_table[:, :active_pages] = torch.arange(
+            batch_size * active_pages, dtype=torch.int32, device="cuda"
+        ).view(batch_size, active_pages)
+        target = torch.zeros_like(source)
+        tags = torch.zeros(batch_size * active_pages, dtype=torch.int64, device="cuda")
+        epoch = torch.tensor(9, dtype=torch.int32, device="cuda")
+
+        materialize_indexer_pages_triton(
+            target,
+            source,
+            page_table,
+            page_table,
+            torch.full(
+                (batch_size,),
+                active_pages * 64,
+                dtype=torch.int32,
+                device="cuda",
+            ),
+            page_size=64,
+            tags=tags,
+            epoch=epoch,
+        )
+        torch.cuda.synchronize()
+
+        self.assertTrue(torch.equal(target, source))
+        expected_tags = (9 << 32) | (
+            torch.arange(batch_size * active_pages, dtype=torch.int64, device="cuda")
+            + 1
+        )
+        self.assertTrue(torch.equal(tags, expected_tags))
+
+    def test_materialize_allows_identical_shared_prefix_page_aliases(self):
+        from sglang.kernels.ops.kvcache.dsa_shared import (
+            materialize_indexer_pages_triton,
+        )
+
+        source = torch.arange(4 * 64, dtype=torch.uint8, device="cuda").view(4, 64)
+        source_pages = torch.tensor([[2], [2]], dtype=torch.int32, device="cuda")
+        target_pages = torch.tensor([[0], [0]], dtype=torch.int32, device="cuda")
+        target = torch.zeros((1, 64), dtype=torch.uint8, device="cuda")
+        tags = torch.zeros(1, dtype=torch.int64, device="cuda")
+        epoch = torch.tensor(3, dtype=torch.int32, device="cuda")
+
+        materialize_indexer_pages_triton(
+            target,
+            source,
+            source_pages,
+            target_pages,
+            torch.tensor([1, 1], dtype=torch.int32, device="cuda"),
+            page_size=64,
+            tags=tags,
+            epoch=epoch,
+        )
+        torch.cuda.synchronize()
+
+        self.assertTrue(torch.equal(target[0], source[2]))
+        self.assertEqual(tags.item(), (3 << 32) | 3)
+
+    def _run_case(self, rank: int, locations: torch.Tensor) -> None:
+        from sglang.kernels.ops.kvcache.dsa_shared import (
+            set_mla_kv_buffer_owner_triton,
+        )
+
+        cp_size = 4
+        page_size = 4
+        nope = torch.arange(
+            locations.numel() * 5, dtype=torch.uint8, device="cuda"
+        ).view(-1, 5)
+        rope = (
+            torch.arange(locations.numel() * 3, dtype=torch.uint8, device="cuda") + 91
+        ).view(-1, 3)
+        output = torch.zeros((16, 8), dtype=torch.uint8, device="cuda")
+        expected = torch.zeros_like(output)
+
+        set_mla_kv_buffer_owner_triton(
+            output,
+            locations,
+            nope,
+            rope,
+            owner_rank=rank,
+            owner_size=cp_size,
+            page_size=page_size,
+        )
+
+        valid = locations >= 0
+        pages = torch.div(locations.clamp_min(0), page_size, rounding_mode="floor")
+        owned = valid & ((pages % cp_size) == rank)
+        rows = torch.nonzero(owned, as_tuple=True)[0]
+        owned_locations = locations.index_select(0, rows)
+        local_locations = (
+            torch.div(
+                torch.div(owned_locations, page_size, rounding_mode="floor"),
+                cp_size,
+                rounding_mode="floor",
+            )
+            * page_size
+            + owned_locations % page_size
+        )
+        expected[local_locations] = torch.cat(
+            (nope.index_select(0, rows), rope.index_select(0, rows)), dim=-1
+        )
+        torch.cuda.synchronize()
+
+        self.assertTrue(torch.equal(output, expected))
+
+    def test_owner_write_matches_reference_for_every_rank(self):
+        locations = torch.tensor(
+            [0, 3, 4, 7, 8, 12, 16, 20, 31, -1],
+            dtype=torch.int64,
+            device="cuda",
+        )
+        for rank in range(4):
+            with self.subTest(rank=rank):
+                self._run_case(rank, locations)
+
+    def test_owner_write_replays_with_updated_static_inputs(self):
+        from sglang.kernels.ops.kvcache.dsa_shared import (
+            set_mla_kv_buffer_owner_triton,
+        )
+
+        locations = torch.tensor([0, 4, 8, 12], dtype=torch.int64, device="cuda")
+        nope = torch.ones((4, 5), dtype=torch.uint8, device="cuda")
+        rope = torch.full((4, 3), 2, dtype=torch.uint8, device="cuda")
+        output = torch.zeros((8, 8), dtype=torch.uint8, device="cuda")
+
+        set_mla_kv_buffer_owner_triton(
+            output, locations, nope, rope, owner_rank=1, owner_size=4, page_size=4
+        )
+        torch.cuda.synchronize()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            set_mla_kv_buffer_owner_triton(
+                output,
+                locations,
+                nope,
+                rope,
+                owner_rank=1,
+                owner_size=4,
+                page_size=4,
+            )
+
+        output.zero_()
+        locations.copy_(torch.tensor([4, 20, 0, -1], device="cuda"))
+        nope.fill_(7)
+        rope.fill_(9)
+        graph.replay()
+        torch.cuda.synchronize()
+
+        expected = torch.tensor([7] * 5 + [9] * 3, dtype=torch.uint8, device="cuda")
+        self.assertTrue(torch.equal(output[0], expected))
+        self.assertTrue(torch.equal(output[4], expected))
+        self.assertEqual(torch.count_nonzero(output[1:4]).item(), 0)
+        self.assertEqual(torch.count_nonzero(output[5:]).item(), 0)
+
+    def test_indexer_owner_write_matches_full_buffer(self):
+        from types import SimpleNamespace
+
+        from sglang.kernels.ops.attention.dsa.index_buf_accessor import SetKAndS
+
+        cp_size = 4
+        page_size = 64
+        pages_per_rank = 2
+        loc = torch.arange(cp_size * pages_per_rank, dtype=torch.int64, device="cuda")
+        loc = loc * page_size + 3
+        index_k = (
+            torch.arange(loc.numel() * 128, dtype=torch.float32, device="cuda")
+            .remainder_(31)
+            .view(loc.numel(), 128)
+            .to(torch.float8_e4m3fn)
+        )
+        index_k_scale = torch.arange(
+            1, loc.numel() + 1, dtype=torch.float32, device="cuda"
+        )
+        pool = SimpleNamespace(page_size=page_size)
+        full = torch.zeros(
+            cp_size * pages_per_rank,
+            page_size * 132,
+            dtype=torch.uint8,
+            device="cuda",
+        )
+
+        SetKAndS.execute(
+            pool=pool,
+            buf=full,
+            loc=loc,
+            index_k=index_k,
+            index_k_scale=index_k_scale,
+        )
+        for rank in range(cp_size):
+            owner = torch.zeros_like(full[rank::cp_size])
+            SetKAndS.execute(
+                pool=pool,
+                buf=owner,
+                loc=loc,
+                index_k=index_k,
+                index_k_scale=index_k_scale,
+                owner_rank=rank,
+                owner_size=cp_size,
+            )
+            torch.cuda.synchronize()
+            self.assertTrue(torch.equal(owner, full[rank::cp_size]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_dsa_shared_vmm.py
+++ b/test/registered/unit/mem_cache/test_dsa_shared_vmm.py
@@ -1,0 +1,404 @@
+import os
+import time
+import unittest
+
+import torch
+import torch.multiprocessing as mp
+
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=60, stage="base-c", runner_config="4-gpu-b200")
+
+POOL_PORT = 29722
+MAIN_ONLY_POOL_PORT = 29723
+STATUS_POOL_PORT = 29724
+
+
+def _destroy_distributed() -> None:
+    from sglang.srt.distributed.parallel_state import (
+        destroy_distributed_environment,
+        destroy_model_parallel,
+    )
+
+    destroy_model_parallel()
+    destroy_distributed_environment()
+
+
+def _run_shared_pool(rank: int, world_size: int, port: int):
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    torch.cuda.set_device(rank)
+
+    from sglang.kernels.ops.attention.dsa import index_buf_accessor
+    from sglang.kernels.ops.attention.fused_store_index_cache import (
+        fused_store_index_k_cache,
+    )
+    from sglang.srt.distributed.parallel_state import (
+        init_distributed_environment,
+        initialize_model_parallel,
+    )
+    from sglang.srt.mem_cache.dsa_cache_shared import SharedDSATokenToKVPool
+
+    init_distributed_environment(
+        world_size=world_size,
+        rank=rank,
+        local_rank=rank,
+        distributed_init_method=f"tcp://127.0.0.1:{port}",
+        backend="nccl",
+    )
+    initialize_model_parallel(
+        tensor_model_parallel_size=world_size,
+        attention_context_model_parallel_size=world_size,
+    )
+
+    pool = SharedDSATokenToKVPool(
+        128,
+        page_size=64,
+        kv_lora_rank=512,
+        dtype=torch.bfloat16,
+        qk_rope_head_dim=64,
+        layer_num=2,
+        device=f"cuda:{rank}",
+        index_head_dim=128,
+        enable_memory_saver=False,
+        kv_cache_dim=656,
+        shared_rank=rank,
+        shared_size=world_size,
+        indexer_cache_layer_ids=(0, 1),
+    )
+    assert len(pool.kv_buffer) == 2
+    assert len(pool.index_key_cache.buffer) == 2
+    assert pool.main_family.slab.rank_local_views == []
+    assert len(pool.index_key_cache.family.slab.rank_local_views) == 2
+    assert pool.main_layout.cp_size == world_size
+    assert pool.index_layout.cp_size == world_size
+    assert pool.kv_buffer[0].device.index == rank
+    assert pool.index_key_cache.buffer[0].device.index == rank
+
+    for layer_id in range(2):
+        pool.local_kv_buffer[layer_id].fill_(100 * layer_id + rank + 1)
+        pool.index_key_cache.local_buffer[layer_id].fill_(100 * layer_id + rank + 11)
+    torch.cuda.synchronize()
+    torch.distributed.barrier(group=pool.shared_cp_group.cpu_group)
+
+    for layer_id in range(2):
+        main_buffer = pool.get_key_buffer(layer_id)
+        index_buffer = pool.get_paged_index_k_with_scale_buffer(layer_id)
+        for owner_rank in range(world_size):
+            logical_page = torch.tensor(
+                [owner_rank], dtype=torch.int64, device=f"cuda:{rank}"
+            )
+            logical_slot = logical_page * pool.page_size
+            main_slot = pool.translate_main_slots(logical_slot)
+            index_page = pool.prepare_paged_index_page_table(logical_page)
+            assert torch.all(
+                main_buffer[main_slot] == 100 * layer_id + owner_rank + 1
+            ).item()
+            assert torch.all(
+                index_buffer[index_page] == 100 * layer_id + owner_rank + 11
+            ).item()
+
+    logical_slots = torch.arange(128, dtype=torch.int64, device=f"cuda:{rank}")
+    index_k_bytes = (
+        torch.arange(128 * 128, dtype=torch.int64, device=f"cuda:{rank}") % 120
+    ).to(torch.uint8)
+    index_k = index_k_bytes.view(128, 128).view(torch.float8_e4m3fn)
+    index_scale = torch.arange(1, 129, dtype=torch.float32, device=f"cuda:{rank}")
+    pool.set_index_k_scale_buffer(0, logical_slots, index_k, index_scale)
+    pool.synchronize_shared_writes()
+
+    actual_k, actual_scale = pool.get_index_k_scale_buffer(
+        0,
+        torch.tensor([128], dtype=torch.int64, device=f"cuda:{rank}"),
+        torch.tensor([[0, 1]], dtype=torch.int32, device=f"cuda:{rank}"),
+        128,
+        128,
+    )
+    assert torch.equal(actual_k, index_k_bytes.view(128, 128))
+    assert torch.equal(actual_scale, index_scale.view(torch.uint8).view(128, 4))
+
+    logical_slots = torch.arange(64, 192, dtype=torch.int64, device=f"cuda:{rank}")
+    key = (
+        torch.arange(128 * 128, dtype=torch.float32, device=f"cuda:{rank}")
+        .view(128, 128)
+        .remainder(97)
+        .sub_(48)
+        .to(torch.bfloat16)
+    )
+    full_index = torch.zeros_like(pool.index_key_cache.buffer[1])
+    fused_store_index_k_cache(key, full_index, logical_slots, pool.page_size)
+
+    for buffer, owner_rank, owner_size in pool.get_index_k_write_targets(1):
+        fused_store_index_k_cache(
+            key,
+            buffer,
+            logical_slots,
+            pool.page_size,
+            owner_rank=owner_rank,
+            owner_size=owner_size,
+        )
+    pool.synchronize_shared_writes()
+    logical_pages = torch.tensor([[1, 2]], dtype=torch.int32, device=f"cuda:{rank}")
+    seq_len = torch.tensor([128], dtype=torch.int64, device=f"cuda:{rank}")
+    expected_k, expected_scale = index_buf_accessor.GetKAndS.execute(
+        pool,
+        full_index,
+        page_indices=logical_pages,
+        seq_len_tensor=seq_len,
+        seq_len_sum=128,
+        max_seq_len=128,
+    )
+    actual_k, actual_scale = pool.get_index_k_scale_buffer(
+        1, seq_len, logical_pages, 128, 128
+    )
+    assert torch.equal(actual_k, expected_k)
+    assert torch.equal(actual_scale, expected_scale)
+
+    prepared_pages = pool.prepare_paged_index_page_table(logical_pages)
+    pool_cache, pool_page_table = pool.materialize_index_pages(
+        1,
+        prepared_pages,
+        logical_pages,
+        seq_len,
+    )
+    torch.cuda.synchronize()
+    assert torch.equal(pool_page_table, logical_pages)
+    assert torch.equal(
+        pool_cache[logical_pages.view(-1).long()],
+        full_index[logical_pages.view(-1).long()],
+    )
+
+    # Exercise a cross-owner swap. Delaying rank 1 makes the old one-phase
+    # implementation deterministically overwrite rank 1's source before it is
+    # read; a correct two-phase move snapshots every source before any write.
+    swap_targets = torch.tensor([1, 65], dtype=torch.int64, device=f"cuda:{rank}")
+    swap_sources = swap_targets.flip(0)
+    translated_swap = pool.translate_main_slots(swap_targets)
+    main_before = [buf[translated_swap].clone() for buf in pool.kv_buffer]
+    translated_index_swap = pool.translate_index_slots(swap_targets)
+    from sglang.srt.mem_cache.dsa_cache_shared import gather_shared_index_rows
+
+    index_before = [
+        gather_shared_index_rows(pool, buf, translated_index_swap)
+        for buf in pool.index_key_cache.buffer
+    ]
+    torch.distributed.barrier(group=pool.shared_cp_group.cpu_group)
+    if rank == 1:
+        time.sleep(0.5)
+    pool.move_kv_cache(swap_targets, swap_sources)
+
+    for layer_id, expected_rows in enumerate(main_before):
+        actual_rows = pool.kv_buffer[layer_id][translated_swap]
+        assert torch.equal(actual_rows, expected_rows.flip(0))
+    for layer_id, (expected_k, expected_scale) in enumerate(index_before):
+        actual_k, actual_scale = gather_shared_index_rows(
+            pool,
+            pool.index_key_cache.buffer[layer_id],
+            translated_index_swap,
+        )
+        assert torch.equal(actual_k, expected_k.flip(0))
+        assert torch.equal(actual_scale, expected_scale.flip(0))
+
+    offload_slots = swap_targets
+    expected_main = [
+        buf[pool.translate_main_slots(offload_slots)].clone() for buf in pool.kv_buffer
+    ]
+    expected_index = [
+        gather_shared_index_rows(pool, buf, pool.translate_index_slots(offload_slots))
+        for buf in pool.index_key_cache.buffer
+    ]
+    cpu_copy = pool.get_cpu_copy(offload_slots)
+    owned = pool.main_layout.owned_slot_mask(offload_slots, owner_rank=pool.shared_rank)
+    local_rows = pool.main_layout.translate_local_slots(offload_slots[owned])
+    for local_buffer in pool.local_kv_buffer:
+        local_buffer[local_rows].zero_()
+    pool.set_index_k_scale_buffer(
+        0,
+        offload_slots,
+        torch.zeros((2, 128), dtype=torch.float8_e4m3fn, device=f"cuda:{rank}"),
+        torch.zeros((2,), dtype=torch.float32, device=f"cuda:{rank}"),
+    )
+    pool.set_index_k_scale_buffer(
+        1,
+        offload_slots,
+        torch.zeros((2, 128), dtype=torch.float8_e4m3fn, device=f"cuda:{rank}"),
+        torch.zeros((2,), dtype=torch.float32, device=f"cuda:{rank}"),
+    )
+    pool.synchronize_shared_writes()
+    pool.load_cpu_copy(cpu_copy, offload_slots)
+
+    for layer_id, expected_rows in enumerate(expected_main):
+        actual_rows = pool.kv_buffer[layer_id][pool.translate_main_slots(offload_slots)]
+        assert torch.equal(actual_rows, expected_rows)
+    for layer_id, (expected_k, expected_scale) in enumerate(expected_index):
+        actual_k, actual_scale = gather_shared_index_rows(
+            pool,
+            pool.index_key_cache.buffer[layer_id],
+            pool.translate_index_slots(offload_slots),
+        )
+        assert torch.equal(actual_k, expected_k)
+        assert torch.equal(actual_scale, expected_scale)
+
+    pool._clear_buffers()
+    torch.distributed.barrier()
+    _destroy_distributed()
+
+
+def _run_shared_status(rank: int, world_size: int, port: int):
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    torch.cuda.set_device(rank)
+
+    from sglang.srt.distributed.parallel_state import (
+        get_attn_cp_group,
+        init_distributed_environment,
+        initialize_model_parallel,
+    )
+    from sglang.srt.mem_cache.shared_kv.synchronization import SharedWritePublisher
+
+    init_distributed_environment(
+        world_size=world_size,
+        rank=rank,
+        local_rank=rank,
+        distributed_init_method=f"tcp://127.0.0.1:{port}",
+        backend="nccl",
+    )
+    initialize_model_parallel(
+        tensor_model_parallel_size=world_size,
+        attention_context_model_parallel_size=world_size,
+    )
+    publisher = SharedWritePublisher(get_attn_cp_group())
+
+    # Rank 1 injects the local L2-copy failure. Every rank must observe the
+    # aggregate false result, and a later successful round must recover.
+    assert not publisher.publish_status(rank != 1)
+    assert publisher.publish_status(True)
+
+    publisher.close()
+    torch.distributed.barrier()
+    _destroy_distributed()
+
+
+def _run_main_only_shared_pool(rank: int, world_size: int, port: int):
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    torch.cuda.set_device(rank)
+
+    from sglang.kernels.ops.attention.fused_store_index_cache import (
+        fused_store_index_k_cache,
+    )
+    from sglang.srt.distributed.parallel_state import (
+        init_distributed_environment,
+        initialize_model_parallel,
+    )
+    from sglang.srt.mem_cache.dsa_cache_shared import (
+        ReplicatedIndexKeyCache,
+        SharedDSATokenToKVPool,
+        gather_shared_index_rows,
+    )
+
+    init_distributed_environment(
+        world_size=world_size,
+        rank=rank,
+        local_rank=rank,
+        distributed_init_method=f"tcp://127.0.0.1:{port}",
+        backend="nccl",
+    )
+    initialize_model_parallel(
+        tensor_model_parallel_size=world_size,
+        attention_context_model_parallel_size=world_size,
+    )
+
+    pool = SharedDSATokenToKVPool(
+        128,
+        page_size=64,
+        kv_lora_rank=512,
+        dtype=torch.bfloat16,
+        qk_rope_head_dim=64,
+        layer_num=2,
+        device=f"cuda:{rank}",
+        index_head_dim=128,
+        enable_memory_saver=False,
+        kv_cache_dim=656,
+        shared_rank=rank,
+        shared_size=world_size,
+        share_indexer=False,
+        indexer_cache_layer_ids=(),
+    )
+    assert isinstance(pool.index_key_cache, ReplicatedIndexKeyCache)
+    assert pool.index_layout is None
+    assert pool.prepare_paged_index_page_table(
+        torch.tensor([[0, 1]], dtype=torch.int32, device=f"cuda:{rank}")
+    ).tolist() == [[0, 1]]
+    assert pool.shared_cache_access.uses_shared_indexer is False
+
+    slots = torch.arange(128, dtype=torch.int64, device=f"cuda:{rank}")
+    key = (
+        torch.arange(128 * 128, dtype=torch.float32, device=f"cuda:{rank}")
+        .view(128, 128)
+        .remainder(97)
+        .sub_(48)
+        .to(torch.bfloat16)
+    )
+    for layer_id in range(2):
+        for buffer, owner_rank, owner_size in pool.get_index_k_write_targets(layer_id):
+            assert (owner_rank, owner_size) == (0, 1)
+            fused_store_index_k_cache(
+                key,
+                buffer,
+                slots,
+                pool.page_size,
+                owner_rank=owner_rank,
+                owner_size=owner_size,
+            )
+
+    swap_targets = torch.tensor([1, 65], dtype=torch.int64, device=f"cuda:{rank}")
+    swap_sources = swap_targets.flip(0)
+    before = [
+        gather_shared_index_rows(pool, buffer, swap_targets)
+        for buffer in pool.index_key_cache.buffer
+    ]
+    pool.move_kv_cache(swap_targets, swap_sources)
+    for layer_id, (expected_k, expected_scale) in enumerate(before):
+        actual_k, actual_scale = gather_shared_index_rows(
+            pool, pool.index_key_cache.buffer[layer_id], swap_targets
+        )
+        assert torch.equal(actual_k, expected_k.flip(0))
+        assert torch.equal(actual_scale, expected_scale.flip(0))
+
+    pool._clear_buffers()
+    torch.distributed.barrier()
+    _destroy_distributed()
+
+
+class TestSharedDSAPool(CustomTestCase):
+    def test_shared_status_propagates_an_injected_rank_failure(self):
+        if torch.cuda.device_count() < 2:
+            self.skipTest("shared DSA status test needs at least two GPUs")
+        mp.spawn(_run_shared_status, args=(2, STATUS_POOL_PORT), nprocs=2, join=True)
+
+    def test_shared_pool_shards_main_and_indexer(self):
+        if torch.cuda.device_count() < 2:
+            self.skipTest("shared DSA pool test needs at least two GPUs")
+        mp.spawn(_run_shared_pool, args=(2, POOL_PORT), nprocs=2, join=True)
+
+    def test_shared_pool_can_keep_replicated_indexer(self):
+        if torch.cuda.device_count() < 2:
+            self.skipTest("shared DSA pool test needs at least two GPUs")
+        mp.spawn(
+            _run_main_only_shared_pool,
+            args=(2, MAIN_ONLY_POOL_PORT),
+            nprocs=2,
+            join=True,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_shared_kv_family.py
+++ b/test/registered/unit/mem_cache/test_shared_kv_family.py
@@ -1,0 +1,297 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.srt.mem_cache.shared_kv import family as family_module
+from sglang.srt.mem_cache.shared_kv.family import (
+    OwnerShardedFamily,
+    OwnerShardedFamilySpec,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def _fake_slab(
+    *,
+    num_layers: int,
+    layer_rows: int,
+    rank_stride_rows: int,
+    aligned_bytes_per_rank: int,
+):
+    return SimpleNamespace(
+        allocation=SimpleNamespace(
+            aligned_bytes_per_rank=aligned_bytes_per_rank,
+        ),
+        layer_rows=layer_rows,
+        rank_stride_rows=rank_stride_rows,
+        global_views=[torch.empty((1,), dtype=torch.uint8) for _ in range(num_layers)],
+        rank_local_views=[
+            torch.empty((1,), dtype=torch.uint8) for _ in range(num_layers)
+        ],
+        local_views=[torch.empty((1,), dtype=torch.uint8) for _ in range(num_layers)],
+        close=MagicMock(),
+    )
+
+
+class TestOwnerShardedFamily(CustomTestCase):
+    def test_family_uses_aligned_slab_stride_for_physical_owner_mapping(self):
+        spec = OwnerShardedFamilySpec(
+            name="packed-c4",
+            num_layers=2,
+            logical_rows_per_layer=18,
+            ownership_granule=4,
+            storage_rows_per_granule=1,
+            row_shape=(16,),
+            dtype=torch.uint8,
+        )
+        slab = _fake_slab(
+            num_layers=2,
+            layer_rows=3,
+            rank_stride_rows=16,
+            aligned_bytes_per_rank=4096,
+        )
+
+        with (
+            patch(
+                "sglang.srt.mem_cache.shared_kv.family.create_rank_major_shared_slab",
+                return_value=slab,
+            ) as create_slab,
+            patch.object(family_module.dist, "get_world_size", return_value=2),
+        ):
+            family = OwnerShardedFamily.create(
+                spec=spec,
+                cp_size=2,
+                cpu_group="cp-cpu",
+                zero_initialize=False,
+            )
+
+        create_slab.assert_called_once_with(
+            (3, 16),
+            layer_num=2,
+            dtype=torch.uint8,
+            cpu_group="cp-cpu",
+            first_dim_multiple=1,
+            map_rank_local=True,
+        )
+        self.assertEqual(family.layout.minimum_blocks_per_rank, 3)
+        self.assertEqual(family.layout.blocks_per_rank, 16)
+        self.assertEqual(
+            family.layout.physical_rows(torch.tensor([0, 4])).tolist(),
+            [0, 64],
+        )
+
+    def test_family_exposes_checked_layer_views_and_idempotent_close(self):
+        spec = OwnerShardedFamilySpec(
+            name="c4-state",
+            num_layers=2,
+            logical_rows_per_layer=8,
+            ownership_granule=4,
+            storage_rows_per_granule=4,
+            row_shape=(32,),
+            dtype=torch.float32,
+        )
+        slab = _fake_slab(
+            num_layers=2,
+            layer_rows=4,
+            rank_stride_rows=16,
+            aligned_bytes_per_rank=4096,
+        )
+
+        with (
+            patch(
+                "sglang.srt.mem_cache.shared_kv.family.create_rank_major_shared_slab",
+                return_value=slab,
+            ),
+            patch.object(family_module.dist, "get_world_size", return_value=2),
+        ):
+            family = OwnerShardedFamily.create(
+                spec=spec,
+                cp_size=2,
+                cpu_group="cp-cpu",
+                zero_initialize=False,
+            )
+
+        family.close()
+        family.close()
+        slab.close.assert_called_once_with()
+
+    def test_accounting_separates_logical_tail_and_vmm_alignment(self):
+        spec = OwnerShardedFamilySpec(
+            name="packed-c4",
+            num_layers=2,
+            logical_rows_per_layer=18,
+            ownership_granule=4,
+            storage_rows_per_granule=1,
+            row_shape=(16,),
+            dtype=torch.uint8,
+        )
+        slab = _fake_slab(
+            num_layers=2,
+            layer_rows=3,
+            rank_stride_rows=16,
+            aligned_bytes_per_rank=4096,
+        )
+
+        with (
+            patch(
+                "sglang.srt.mem_cache.shared_kv.family.create_rank_major_shared_slab",
+                return_value=slab,
+            ),
+            patch.object(family_module.dist, "get_world_size", return_value=2),
+        ):
+            family = OwnerShardedFamily.create(
+                spec=spec,
+                cp_size=2,
+                cpu_group="cp-cpu",
+                zero_initialize=False,
+            )
+
+        accounting = family.accounting()
+        self.assertEqual(accounting.logical_blocks_per_layer, 5)
+        self.assertEqual(accounting.minimum_blocks_per_rank, 3)
+        self.assertEqual(accounting.logical_storage_bytes, 160)
+        self.assertEqual(accounting.minimum_physical_bytes_per_rank, 96)
+        self.assertEqual(accounting.mapped_bytes_per_rank, 4096)
+        self.assertEqual(accounting.alignment_overhead_bytes_per_rank, 4000)
+
+    def test_large_capacity_products_do_not_overflow_int32(self):
+        spec = OwnerShardedFamilySpec(
+            name="large-packed-kv",
+            num_layers=43,
+            logical_rows_per_layer=2**31,
+            ownership_granule=256,
+            storage_rows_per_granule=1,
+            row_shape=(584,),
+            dtype=torch.uint8,
+        )
+        minimum_blocks = (spec.logical_rows_per_layer // 256 + 7) // 8
+        local_rows = minimum_blocks
+        minimum_bytes = 43 * local_rows * 584
+        slab = _fake_slab(
+            num_layers=43,
+            layer_rows=local_rows,
+            rank_stride_rows=43 * local_rows,
+            aligned_bytes_per_rank=minimum_bytes + 65536,
+        )
+
+        with (
+            patch(
+                "sglang.srt.mem_cache.shared_kv.family.create_rank_major_shared_slab",
+                return_value=slab,
+            ),
+            patch.object(family_module.dist, "get_world_size", return_value=8),
+        ):
+            family = OwnerShardedFamily.create(
+                spec=spec,
+                cp_size=8,
+                cpu_group="cp-cpu",
+                zero_initialize=False,
+            )
+
+        self.assertGreater(family.accounting().logical_storage_bytes, 2**31)
+        self.assertGreater(family.accounting().mapped_bytes_per_rank, 2**31)
+
+    def test_family_rejects_cp_size_that_differs_from_process_group(self):
+        spec = OwnerShardedFamilySpec(
+            name="mismatched-group",
+            num_layers=1,
+            logical_rows_per_layer=8,
+            ownership_granule=4,
+            storage_rows_per_granule=1,
+            row_shape=(16,),
+            dtype=torch.uint8,
+        )
+
+        with (
+            patch.object(family_module.dist, "get_world_size", return_value=4),
+            patch.object(family_module, "create_rank_major_shared_slab") as create_slab,
+            self.assertRaisesRegex(ValueError, "cp_size=8, group_size=4"),
+        ):
+            OwnerShardedFamily.create(
+                spec=spec,
+                cp_size=8,
+                cpu_group="cp-cpu",
+                zero_initialize=False,
+            )
+
+        create_slab.assert_not_called()
+
+    def test_zero_initialization_failure_is_published_before_cleanup(self):
+        spec = OwnerShardedFamilySpec(
+            name="zero-init-failure",
+            num_layers=1,
+            logical_rows_per_layer=8,
+            ownership_granule=4,
+            storage_rows_per_granule=1,
+            row_shape=(16,),
+            dtype=torch.uint8,
+        )
+        slab = _fake_slab(
+            num_layers=1,
+            layer_rows=1,
+            rank_stride_rows=1,
+            aligned_bytes_per_rank=4096,
+        )
+        slab.allocation.local_view = MagicMock()
+        local_error = RuntimeError("CUDA zero initialization failed")
+
+        with (
+            patch.object(family_module.dist, "get_world_size", return_value=2),
+            patch.object(family_module.dist, "get_rank", return_value=1),
+            patch.object(
+                family_module, "create_rank_major_shared_slab", return_value=slab
+            ),
+            patch.object(
+                family_module.torch.cuda, "synchronize", side_effect=local_error
+            ),
+            patch.object(
+                family_module,
+                "_synchronize_vmm_stage",
+                side_effect=RuntimeError("symmetric zero-init failure"),
+                create=True,
+            ) as synchronize,
+            self.assertRaisesRegex(RuntimeError, "symmetric zero-init failure"),
+        ):
+            OwnerShardedFamily.create(
+                spec=spec,
+                cp_size=2,
+                cpu_group="cp-cpu",
+                zero_initialize=True,
+            )
+
+        synchronize.assert_called_once_with(
+            "cp-cpu", 1, "family zero initialization", local_error
+        )
+        slab.close.assert_called_once_with()
+
+    def test_invalid_family_specs_are_rejected(self):
+        valid = dict(
+            name="family",
+            num_layers=1,
+            logical_rows_per_layer=8,
+            ownership_granule=4,
+            storage_rows_per_granule=4,
+            row_shape=(16,),
+            dtype=torch.uint8,
+        )
+        for field, value in (
+            ("name", ""),
+            ("num_layers", 0),
+            ("logical_rows_per_layer", -1),
+            ("ownership_granule", 0),
+            ("storage_rows_per_granule", 0),
+            ("row_shape", ()),
+        ):
+            kwargs = dict(valid)
+            kwargs[field] = value
+            with self.subTest(field=field):
+                with self.assertRaisesRegex(ValueError, field):
+                    OwnerShardedFamilySpec(**kwargs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_shared_kv_layout.py
+++ b/test/registered/unit/mem_cache/test_shared_kv_layout.py
@@ -1,0 +1,162 @@
+import unittest
+
+import torch
+
+from sglang.srt.mem_cache.shared_kv.layout import OwnerShardedLayout
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestOwnerShardedLayout(CustomTestCase):
+    def test_kv_rows_map_to_rank_major_owner_segments(self):
+        layout = OwnerShardedLayout(
+            cp_size=4,
+            ownership_granule=256,
+            logical_rows=10 * 256,
+        )
+        logical_rows = torch.arange(10, dtype=torch.int64) * 256
+
+        self.assertEqual(layout.logical_blocks, 10)
+        self.assertEqual(layout.blocks_per_rank, 3)
+        self.assertEqual(
+            layout.physical_rows(logical_rows).tolist(),
+            [0, 768, 1536, 2304, 256, 1024, 1792, 2560, 512, 1280],
+        )
+
+    def test_c4_state_ring_uses_four_row_ownership_blocks(self):
+        layout = OwnerShardedLayout(
+            cp_size=2,
+            ownership_granule=4,
+            logical_rows=8,
+        )
+        logical_rows = torch.arange(8, dtype=torch.int64)
+
+        self.assertEqual(
+            layout.owner_rank(logical_rows).tolist(),
+            [0, 0, 0, 0, 1, 1, 1, 1],
+        )
+        self.assertEqual(
+            layout.owner_local_rows(logical_rows).tolist(),
+            [0, 1, 2, 3, 0, 1, 2, 3],
+        )
+
+    def test_offline_c128_state_uses_one_native_ownership_block(self):
+        layout = OwnerShardedLayout(
+            cp_size=8,
+            ownership_granule=128,
+            logical_rows=128,
+        )
+        logical_rows = torch.tensor([0, 63, 127], dtype=torch.int64)
+
+        self.assertEqual(layout.logical_blocks, 1)
+        self.assertEqual(layout.blocks_per_rank, 1)
+        self.assertEqual(layout.owner_rank(logical_rows).tolist(), [0, 0, 0])
+        self.assertEqual(layout.owner_local_rows(logical_rows).tolist(), [0, 63, 127])
+
+    def test_rank_relative_rows_rotate_the_current_rank_to_segment_zero(self):
+        layout = OwnerShardedLayout(
+            cp_size=4,
+            ownership_granule=4,
+            logical_rows=10 * 4,
+        )
+        logical_rows = torch.arange(10, dtype=torch.int64) * 4
+
+        self.assertEqual(
+            layout.rank_relative_rows(logical_rows, rank=2).tolist(),
+            [24, 36, 0, 12, 28, 40, 4, 16, 32, 44],
+        )
+
+    def test_physical_mapping_uses_the_aligned_owner_segment_stride(self):
+        layout = OwnerShardedLayout(
+            cp_size=4,
+            ownership_granule=4,
+            logical_rows=10 * 4,
+            physical_blocks_per_rank=8,
+        )
+        logical_rows = torch.tensor([0, 4, 8, 12, 16], dtype=torch.int64)
+
+        self.assertEqual(layout.minimum_blocks_per_rank, 3)
+        self.assertEqual(layout.blocks_per_rank, 8)
+        self.assertEqual(
+            layout.physical_rows(logical_rows).tolist(),
+            [0, 32, 64, 96, 4],
+        )
+
+        with self.assertRaisesRegex(ValueError, "physical_blocks_per_rank"):
+            OwnerShardedLayout(
+                cp_size=4,
+                ownership_granule=4,
+                logical_rows=10 * 4,
+                physical_blocks_per_rank=2,
+            )
+
+    def test_negative_sentinels_are_preserved_by_every_translation(self):
+        layout = OwnerShardedLayout(
+            cp_size=4,
+            ownership_granule=4,
+            logical_rows=32,
+        )
+        logical_rows = torch.tensor([-1, -7, 0, 5], dtype=torch.int32)
+
+        self.assertEqual(layout.owner_rank(logical_rows).tolist(), [-1, -7, 0, 1])
+        self.assertEqual(layout.owner_local_rows(logical_rows).tolist(), [-1, -7, 0, 1])
+        self.assertEqual(layout.physical_rows(logical_rows).tolist(), [-1, -7, 0, 9])
+        self.assertEqual(
+            layout.rank_relative_rows(logical_rows, rank=1).tolist(),
+            [-1, -7, 24, 1],
+        )
+
+    def test_owned_row_mask_rejects_sentinels(self):
+        layout = OwnerShardedLayout(
+            cp_size=2,
+            ownership_granule=4,
+            logical_rows=16,
+        )
+        logical_rows = torch.tensor([-1, 0, 4, 8, 12], dtype=torch.int64)
+
+        self.assertEqual(
+            layout.owned_row_mask(logical_rows, rank=1).tolist(),
+            [False, False, True, False, True],
+        )
+
+    def test_tensor_translations_preserve_shape_device_and_integer_dtype(self):
+        layout = OwnerShardedLayout(
+            cp_size=2,
+            ownership_granule=4,
+            logical_rows=16,
+        )
+        logical_rows = torch.tensor([[0, 4], [8, -1]], dtype=torch.int32)
+
+        for translated in (
+            layout.owner_rank(logical_rows),
+            layout.owner_local_rows(logical_rows),
+            layout.physical_rows(logical_rows),
+            layout.rank_relative_rows(logical_rows, rank=1),
+        ):
+            self.assertEqual(translated.shape, logical_rows.shape)
+            self.assertEqual(translated.dtype, logical_rows.dtype)
+            self.assertEqual(translated.device, logical_rows.device)
+
+    def test_invalid_layout_and_rank_are_rejected(self):
+        with self.assertRaisesRegex(ValueError, "cp_size"):
+            OwnerShardedLayout(cp_size=0, ownership_granule=4, logical_rows=8)
+        with self.assertRaisesRegex(ValueError, "ownership_granule"):
+            OwnerShardedLayout(cp_size=2, ownership_granule=0, logical_rows=8)
+        with self.assertRaisesRegex(ValueError, "logical_rows"):
+            OwnerShardedLayout(cp_size=2, ownership_granule=4, logical_rows=-1)
+
+        layout = OwnerShardedLayout(
+            cp_size=2,
+            ownership_granule=4,
+            logical_rows=8,
+        )
+        with self.assertRaisesRegex(ValueError, "rank"):
+            layout.rank_relative_rows(torch.tensor([0]), rank=2)
+        with self.assertRaisesRegex(ValueError, "rank"):
+            layout.owned_row_mask(torch.tensor([0]), rank=-1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_shared_kv_synchronization.py
+++ b/test/registered/unit/mem_cache/test_shared_kv_synchronization.py
@@ -1,0 +1,173 @@
+import inspect
+import os
+import unittest
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from sglang.kernels.ops.kvcache.shared_kv_publication import (
+    compile_shared_kv_publication,
+    shared_kv_publish,
+)
+from sglang.srt.mem_cache.shared_kv.synchronization import SharedWritePublisher
+from sglang.srt.mem_cache.shared_kv.vmm import create_rank_major_shared_tensor
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=15, stage="base-c", runner_config="4-gpu-b200")
+
+PORT = 29827
+DIRECT_PORT = 29828
+
+
+def _init_distributed(rank: int, world_size: int, port: int):
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    torch.cuda.set_device(rank)
+
+    from sglang.srt.distributed.parallel_state import (
+        init_distributed_environment,
+        initialize_model_parallel,
+    )
+    from sglang.srt.runtime_context import get_parallel
+
+    init_distributed_environment(
+        world_size=world_size,
+        rank=rank,
+        local_rank=rank,
+        distributed_init_method=f"tcp://127.0.0.1:{port}",
+        backend="nccl",
+    )
+    initialize_model_parallel(
+        tensor_model_parallel_size=world_size,
+        attention_context_model_parallel_size=world_size,
+    )
+    return get_parallel().attn_cp_group
+
+
+def _destroy_distributed() -> None:
+    from sglang.srt.distributed.parallel_state import (
+        destroy_distributed_environment,
+        destroy_model_parallel,
+    )
+
+    destroy_model_parallel()
+    destroy_distributed_environment()
+
+
+def _run_direct_ptx_publication(rank: int, world_size: int, port: int) -> None:
+    cp_group = _init_distributed(rank, world_size, port)
+    flags = create_rank_major_shared_tensor(
+        (world_size,), dtype=torch.int32, cpu_group=cp_group.cpu_group
+    )
+    flags.local_view.zero_()
+    torch.cuda.synchronize()
+    dist.barrier(group=cp_group.cpu_group)
+    peer_ptrs = torch.tensor(
+        [
+            flags.global_view.data_ptr() + peer * flags.aligned_bytes_per_rank
+            for peer in range(world_size)
+        ],
+        dtype=torch.int64,
+        device=f"cuda:{rank}",
+    )
+    epoch = torch.zeros((1,), dtype=torch.int32, device=f"cuda:{rank}")
+    if rank == 0:
+        torch.cuda._sleep(10_000_000)
+
+    shared_kv_publish(flags.global_view, peer_ptrs, epoch, rank, world_size)
+    torch.cuda.synchronize()
+
+    assert flags.local_view[:world_size].tolist() == [1] * world_size
+    dist.barrier(group=cp_group.cpu_group)
+    flags.close()
+    _destroy_distributed()
+
+
+def _run_delayed_device_publication(rank: int, world_size: int, port: int) -> None:
+    cp_group = _init_distributed(rank, world_size, port)
+    payload = create_rank_major_shared_tensor(
+        (1,), dtype=torch.int32, cpu_group=cp_group.cpu_group
+    )
+    payload.local_view.zero_()
+    torch.cuda.synchronize()
+    dist.barrier(group=cp_group.cpu_group)
+    publisher = SharedWritePublisher(cp_group)
+    if rank == 0:
+        torch.cuda._sleep(10_000_000)
+        payload.local_view[0] = 73
+    publisher.publish()
+    torch.cuda.synchronize()
+    assert payload.global_view[0].item() == 73
+    dist.barrier(group=cp_group.cpu_group)
+    actual_flags = publisher._flags.local_view[:world_size].tolist()
+    assert actual_flags == [1] * world_size, (rank, actual_flags)
+    dist.barrier(group=cp_group.cpu_group)
+
+    for _ in range(16):
+        publisher.publish()
+    torch.cuda.synchronize()
+    dist.barrier(group=cp_group.cpu_group)
+    assert publisher._flags.local_view[:world_size].tolist() == [17] * world_size
+    dist.barrier(group=cp_group.cpu_group)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        publisher.publish()
+    start_epoch = publisher._epoch.item()
+    for _ in range(17):
+        graph.replay()
+    torch.cuda.synchronize()
+    assert publisher._epoch.item() == start_epoch + 17
+    assert (
+        publisher._flags.local_view[:world_size].tolist()
+        == [start_epoch + 17] * world_size
+    )
+    dist.barrier(group=cp_group.cpu_group)
+
+    publisher.close()
+    publisher.close()
+    payload.close()
+    _destroy_distributed()
+
+
+class TestSharedWritePublisher(CustomTestCase):
+    def test_publication_jit_compiles(self):
+        if not torch.cuda.is_available():
+            self.skipTest("publication JIT compile test needs CUDA")
+        compile_shared_kv_publication(2)
+
+    def test_direct_ptx_publication_waits_for_every_rank(self):
+        if torch.cuda.device_count() < 2:
+            self.skipTest("device publication test needs at least two GPUs")
+        mp.spawn(
+            _run_direct_ptx_publication,
+            args=(2, DIRECT_PORT),
+            nprocs=2,
+            join=True,
+        )
+
+    def test_constructor_has_no_runtime_disable_or_strategy_switch(self):
+        parameters = inspect.signature(SharedWritePublisher).parameters
+
+        self.assertEqual(list(parameters), ["attention_cp_group"])
+        self.assertFalse(
+            {"enabled", "async_op", "strategy", "signal"}.intersection(parameters)
+        )
+
+    def test_delayed_writer_and_graph_replays_are_published(self):
+        if torch.cuda.device_count() < 2:
+            self.skipTest("device publication test needs at least two GPUs")
+        mp.spawn(
+            _run_delayed_device_publication,
+            args=(2, PORT),
+            nprocs=2,
+            join=True,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_shared_kv_vmm.py
+++ b/test/registered/unit/mem_cache/test_shared_kv_vmm.py
@@ -1,0 +1,384 @@
+import os
+import unittest
+from contextlib import nullcontext
+from unittest.mock import MagicMock, call, patch
+
+import torch
+import torch.multiprocessing as mp
+
+from sglang.srt.mem_cache.shared_kv import vmm
+from sglang.srt.mem_cache.shared_kv.vmm import (
+    RankMajorSharedSlab,
+    _align_first_dim,
+    _construct_rank_major_views,
+    _release_partial_vmm_mapping,
+    _release_vmm_handles_synchronized,
+    _synchronize_vmm_stage,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=30, stage="base-c", runner_config="4-gpu-b200")
+
+PORT = 29821
+
+
+def _destroy_distributed() -> None:
+    from sglang.srt.distributed.parallel_state import (
+        destroy_distributed_environment,
+        destroy_model_parallel,
+    )
+
+    destroy_model_parallel()
+    destroy_distributed_environment()
+
+
+def _run_neutral_rank_major_vmm(rank: int, world_size: int, port: int) -> None:
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    torch.cuda.set_device(rank)
+
+    from sglang.srt.distributed.parallel_state import (
+        init_distributed_environment,
+        initialize_model_parallel,
+    )
+    from sglang.srt.mem_cache.shared_kv.vmm import create_rank_major_shared_tensor
+    from sglang.srt.runtime_context import get_parallel
+
+    init_distributed_environment(
+        world_size=world_size,
+        rank=rank,
+        local_rank=rank,
+        distributed_init_method=f"tcp://127.0.0.1:{port}",
+        backend="nccl",
+    )
+    initialize_model_parallel(
+        tensor_model_parallel_size=world_size,
+        attention_context_model_parallel_size=world_size,
+    )
+    cpu_group = get_parallel().attn_cp_group.cpu_group
+
+    for iteration in range(2):
+        allocation = create_rank_major_shared_tensor(
+            (64, 1, 8),
+            dtype=torch.uint8,
+            cpu_group=cpu_group,
+            first_dim_multiple=64,
+        )
+        allocation.local_view.fill_(rank + iteration * world_size + 1)
+        torch.cuda.synchronize()
+        torch.distributed.barrier(group=cpu_group)
+
+        for owner_rank in range(world_size):
+            expected = owner_rank + iteration * world_size + 1
+            global_start = owner_rank * allocation.local_rows
+            relative_start = ((owner_rank - rank) % world_size) * allocation.local_rows
+            assert torch.all(
+                allocation.global_view.narrow(0, global_start, allocation.local_rows)
+                == expected
+            ).item()
+            assert torch.all(
+                allocation.rank_local_view.narrow(
+                    0, relative_start, allocation.local_rows
+                )
+                == expected
+            ).item()
+
+        allocation.close()
+        allocation.close()
+        torch.distributed.barrier(group=cpu_group)
+
+    _destroy_distributed()
+
+
+def _run_neutral_preflight_failure(rank: int, world_size: int, port: int) -> None:
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    torch.cuda.set_device(rank)
+
+    from sglang.srt.distributed.parallel_state import (
+        init_distributed_environment,
+        initialize_model_parallel,
+    )
+    from sglang.srt.mem_cache.shared_kv import vmm as child_vmm
+    from sglang.srt.runtime_context import get_parallel
+
+    init_distributed_environment(
+        world_size=world_size,
+        rank=rank,
+        local_rank=rank,
+        distributed_init_method=f"tcp://127.0.0.1:{port}",
+        backend="nccl",
+    )
+    initialize_model_parallel(
+        tensor_model_parallel_size=world_size,
+        attention_context_model_parallel_size=world_size,
+    )
+    cpu_group = get_parallel().attn_cp_group.cpu_group
+    driver_patch = (
+        patch.object(
+            child_vmm,
+            "_get_cuda_driver",
+            side_effect=RuntimeError("injected driver preflight failure"),
+        )
+        if rank == 1
+        else nullcontext()
+    )
+    with driver_patch:
+        try:
+            child_vmm.create_rank_major_shared_tensor(
+                (64, 8),
+                dtype=torch.uint8,
+                cpu_group=cpu_group,
+            )
+        except RuntimeError as error:
+            assert "shared KV VMM preflight failed on rank 1" in str(error)
+        else:
+            raise AssertionError("expected symmetric preflight failure")
+    _destroy_distributed()
+
+
+class TestRankMajorVMMContracts(CustomTestCase):
+    def test_posix_transport_is_reused_after_fabric_fallback(self):
+        vmm._shared_vmm_use_fabric = None
+        with patch.object(
+            vmm,
+            "export_shareable_handles",
+            return_value=([], [7], False),
+        ) as export:
+            vmm._export_shareable_handles([1], "group", 0)
+            vmm._export_shareable_handles([2], "group", 0)
+
+        self.assertEqual(
+            export.call_args_list,
+            [
+                call([1], "group", 0, try_fabric=True, log_fallback=True),
+                call([2], "group", 0, try_fabric=False, log_fallback=False),
+            ],
+        )
+
+    def test_allocation_handle_types_follow_selected_transport(self):
+        handle_types = MagicMock()
+        handle_types.CU_MEM_HANDLE_TYPE_FABRIC = 0x8
+        handle_types.CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR = 0x1
+        drv = MagicMock(CUmemAllocationHandleType=handle_types)
+
+        with patch.object(vmm, "_shared_vmm_use_fabric", None):
+            self.assertEqual(vmm._shareable_allocation_handle_types(drv), 0x9)
+        with patch.object(vmm, "_shared_vmm_use_fabric", False):
+            self.assertEqual(vmm._shareable_allocation_handle_types(drv), 0x1)
+
+    def test_preflight_failure_is_synchronized_before_first_allocation(self):
+        local_error = RuntimeError("cuMemGetAllocationGranularity failed")
+
+        with (
+            patch.object(vmm, "_validate_same_host_group"),
+            patch.object(vmm.dist, "get_rank", return_value=1),
+            patch.object(vmm.dist, "get_world_size", return_value=2),
+            patch.object(vmm, "_get_cuda_driver", side_effect=local_error),
+            patch.object(
+                vmm,
+                "_synchronize_vmm_stage",
+                side_effect=RuntimeError("symmetric preflight failure"),
+            ) as synchronize,
+            self.assertRaisesRegex(RuntimeError, "symmetric preflight failure"),
+        ):
+            vmm.create_rank_major_shared_tensor(
+                (64, 8),
+                dtype=torch.uint8,
+                cpu_group="group",
+            )
+
+        synchronize.assert_called_once_with("group", 1, "preflight", local_error)
+
+    def test_stage_failure_reports_local_rank_and_preserves_cause(self):
+        local_error = RuntimeError("cuMemCreate: CUDA_ERROR_OUT_OF_MEMORY")
+
+        with (
+            patch.object(vmm.dist, "get_world_size", return_value=2),
+            patch.object(
+                vmm.dist,
+                "all_gather_object",
+                side_effect=lambda output, value, group: output.__setitem__(0, value),
+            ),
+            self.assertRaisesRegex(
+                RuntimeError,
+                "shared KV VMM allocation failed on rank 0.*OUT_OF_MEMORY",
+            ) as raised,
+        ):
+            _synchronize_vmm_stage("group", 0, "allocation", local_error)
+
+        self.assertIs(raised.exception.__cause__, local_error)
+
+    def test_stage_failure_reports_remote_rank(self):
+        gathered_errors = [None, "cuMemMap(rank=0): CUDA_ERROR_INVALID_VALUE"]
+
+        with (
+            patch.object(vmm.dist, "get_world_size", return_value=2),
+            patch.object(
+                vmm.dist,
+                "all_gather_object",
+                side_effect=lambda output, _value, group: output.__setitem__(
+                    slice(None), gathered_errors
+                ),
+            ),
+            self.assertRaisesRegex(
+                RuntimeError,
+                "shared KV VMM mapping failed on rank 1.*cuMemMap",
+            ),
+        ):
+            _synchronize_vmm_stage("group", 0, "mapping", None)
+
+    def test_partial_mapping_cleanup_releases_reverse_map_order_then_va(self):
+        drv = MagicMock()
+        mapped_addresses = [0x1000, 0x3000]
+
+        _release_partial_vmm_mapping(
+            drv,
+            base_va=0x1000,
+            total_bytes=0x4000,
+            mapped_addresses=mapped_addresses,
+            segment_bytes=0x1000,
+        )
+
+        self.assertEqual(
+            drv.cuMemUnmap.call_args_list,
+            [call(0x3000, 0x1000), call(0x1000, 0x1000)],
+        )
+        drv.cuMemAddressFree.assert_called_once_with(0x1000, 0x4000)
+        self.assertEqual(mapped_addresses, [])
+
+    def test_local_handle_release_failure_is_synchronized_and_retained(self):
+        drv = MagicMock()
+        retained_handles = [11, 22]
+        release_error = RuntimeError("cuMemRelease: CUDA_ERROR_INVALID_HANDLE")
+
+        with (
+            patch.object(vmm, "check_drv", side_effect=release_error),
+            patch.object(
+                vmm,
+                "_synchronize_vmm_stage",
+                side_effect=RuntimeError("symmetric handle-release failure"),
+            ) as synchronize,
+            self.assertRaisesRegex(RuntimeError, "symmetric handle-release failure"),
+        ):
+            _release_vmm_handles_synchronized(
+                drv,
+                retained_handles=retained_handles,
+                cpu_group="group",
+                rank=1,
+            )
+
+        self.assertEqual(retained_handles, [11, 22])
+        synchronize.assert_called_once_with("group", 1, "handle release", release_error)
+
+    def test_remote_handle_release_failure_arrives_after_local_release(self):
+        drv = MagicMock()
+        retained_handles = [11, 22]
+
+        with (
+            patch.object(vmm, "check_drv"),
+            patch.object(
+                vmm,
+                "_synchronize_vmm_stage",
+                side_effect=RuntimeError("handle release failed on rank 0"),
+            ) as synchronize,
+            self.assertRaisesRegex(RuntimeError, "failed on rank 0"),
+        ):
+            _release_vmm_handles_synchronized(
+                drv,
+                retained_handles=retained_handles,
+                cpu_group="group",
+                rank=1,
+            )
+
+        self.assertEqual(retained_handles, [])
+        synchronize.assert_called_once_with("group", 1, "handle release", None)
+
+    def test_alignment_honors_driver_granularity_and_ownership_multiple(self):
+        rows, aligned_bytes = _align_first_dim(
+            (257, 3),
+            dtype=torch.uint8,
+            granularity=256,
+            first_dim_multiple=128,
+        )
+
+        self.assertEqual(rows, 512)
+        self.assertEqual(aligned_bytes, 1536)
+        self.assertEqual(aligned_bytes % 256, 0)
+        self.assertEqual(rows % 128, 0)
+
+    def test_slab_close_drops_layer_aliases_before_allocation(self):
+        allocation = MagicMock()
+        slab = RankMajorSharedSlab(
+            allocation=allocation,
+            layer_rows=4,
+            global_views=[torch.empty(0)],
+            rank_local_views=[torch.empty(0)],
+            local_views=[torch.empty(0)],
+        )
+
+        slab.close()
+        slab.close()
+
+        self.assertEqual(slab.global_views, [])
+        self.assertEqual(slab.rank_local_views, [])
+        self.assertEqual(slab.local_views, [])
+        allocation.close.assert_called_once_with()
+
+    def test_tensor_view_failure_is_synchronized_before_mapping_cleanup(self):
+        view_error = RuntimeError("torch.from_dlpack rejected CUDA pointer")
+
+        with (
+            patch.object(vmm, "_tensor_from_cuda_ptr", side_effect=view_error),
+            patch.object(
+                vmm,
+                "_synchronize_vmm_stage",
+                side_effect=RuntimeError("symmetric tensor-view failure"),
+            ) as synchronize,
+            self.assertRaisesRegex(RuntimeError, "symmetric tensor-view failure"),
+        ):
+            _construct_rank_major_views(
+                cpu_group="group",
+                rank=1,
+                base_va=0x1000,
+                rank_local_base_va=0x3000,
+                world_size=2,
+                local_rows=64,
+                row_shape=(1, 8),
+                dtype=torch.uint8,
+                device_id=1,
+                refs=[],
+            )
+
+        synchronize.assert_called_once_with(
+            "group", 1, "tensor view construction", view_error
+        )
+
+    def test_peer_reads_and_create_close_recreate(self):
+        if torch.cuda.device_count() < 2:
+            self.skipTest("neutral rank-major VMM test needs at least two GPUs")
+        mp.spawn(
+            _run_neutral_rank_major_vmm,
+            args=(2, PORT),
+            nprocs=2,
+            join=True,
+        )
+
+    def test_two_rank_preflight_failure_is_symmetric(self):
+        if torch.cuda.device_count() < 2:
+            self.skipTest("neutral rank-major VMM test needs at least two GPUs")
+        mp.spawn(
+            _run_neutral_preflight_failure,
+            args=(2, PORT + 1),
+            nprocs=2,
+            join=True,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/model_executor/test_pool_configurator.py
+++ b/test/registered/unit/model_executor/test_pool_configurator.py
@@ -79,6 +79,10 @@ def _make_model_runner(
     disaggregation_decode_extra_slots=0,
     kv_lora_rank=512,
     qk_rope_head_dim=64,
+    enable_dsa_shared_kv_cache=False,
+    disable_dsa_shared_indexer_cache=False,
+    dsa_prefill_backend="flashmla_kv",
+    dsa_decode_backend="flashmla_kv",
 ):
     """Create a mock ModelRunner with the fields configurators need."""
     mr = MagicMock()
@@ -140,6 +144,10 @@ def _make_model_runner(
         enable_hisparse=False,
         enable_hierarchical_cache=False,
         enable_dsa_cache_layer_split=False,
+        enable_dsa_shared_kv_cache=enable_dsa_shared_kv_cache,
+        disable_dsa_shared_indexer_cache=disable_dsa_shared_indexer_cache,
+        dsa_prefill_backend=dsa_prefill_backend,
+        dsa_decode_backend=dsa_decode_backend,
         kv_cache_dtype="auto",
     )
     mr.server_args = get_server_args()
@@ -615,6 +623,254 @@ class TestEagleConfigurator(CustomTestCase):
         total_layers = num_layers + eagle_draft_num_layers
         used = config.max_total_num_tokens * full_pt * total_layers
         self.assertLessEqual(used, available)
+
+    def test_shared_dsa_prices_replicated_eagle_draft_layers(self):
+        """Shared target layers are sharded, but EAGLE draft layers are not."""
+        num_layers = 32
+        draft_layers = 4
+        mr = _make_model_runner(
+            self,
+            num_layers=num_layers,
+            use_mla_backend=True,
+            kv_lora_rank=512,
+            qk_rope_head_dim=64,
+            max_running_requests=32,
+            speculative_num_draft_tokens=4,
+            enable_dsa_shared_kv_cache=True,
+            dsa_prefill_backend="flashmla_sparse",
+        )
+        hf_config = SimpleNamespace(
+            architectures=["GlmMoeDsaForCausalLM"],
+            index_topk=2048,
+            index_head_dim=128,
+        )
+        hf_config.get_text_config = lambda: hf_config
+        mr.model_config.hf_config = hf_config
+        mr.spec_algorithm.is_eagle.return_value = True
+        mr.spec_algorithm.is_standalone.return_value = False
+        mr.spec_algorithm.is_none.return_value = False
+        mr.spec_aux_config.eagle_draft_num_layers = draft_layers
+
+        with (
+            mock_cpu_env(),
+            get_parallel().override(attn_cp_size=8),
+        ):
+            from sglang.srt.model_executor.pool_configurator import (
+                create_memory_pool_configurator,
+            )
+
+            cfg = create_memory_pool_configurator(mr)
+
+        # mock_cpu_env prices every stored element at two bytes. The target owns
+        # ceil(32 / 8) layers; all four draft layers remain fully replicated.
+        full_layer_bytes = (512 + 64) * KV_SIZE + (128 + 4) * KV_SIZE
+        expected = full_layer_bytes * (4 + draft_layers)
+        self.assertEqual(cfg._cell_size, expected)
+
+    def test_shared_dsa_replicated_indexer_prices_full_indexer_layers(self):
+        num_layers = 32
+        mr = _make_model_runner(
+            self,
+            num_layers=num_layers,
+            use_mla_backend=True,
+            kv_lora_rank=512,
+            qk_rope_head_dim=64,
+            max_running_requests=32,
+            speculative_num_draft_tokens=4,
+            enable_dsa_shared_kv_cache=True,
+            disable_dsa_shared_indexer_cache=True,
+        )
+        hf_config = SimpleNamespace(
+            architectures=["GlmMoeDsaForCausalLM"],
+            index_topk=2048,
+            index_head_dim=128,
+        )
+        hf_config.get_text_config = lambda: hf_config
+        mr.model_config.hf_config = hf_config
+
+        with (
+            mock_cpu_env(),
+            get_parallel().override(attn_cp_size=8),
+        ):
+            from sglang.srt.model_executor.pool_configurator import (
+                create_memory_pool_configurator,
+            )
+
+            cfg = create_memory_pool_configurator(mr)
+
+        main_bytes_per_layer = (512 + 64) * KV_SIZE
+        indexer_bytes_per_layer = (128 + 4) * KV_SIZE
+        expected = main_bytes_per_layer * 4 + indexer_bytes_per_layer * num_layers
+        self.assertEqual(cfg._cell_size, expected)
+        self.assertEqual(cfg._indexer_pool_cache_num_layers, 0)
+
+    def test_shared_dsa_uses_model_mtp_layers_before_aux_config_is_ready(self):
+        num_layers = 78
+        mr = _make_model_runner(
+            self,
+            num_layers=num_layers,
+            use_mla_backend=True,
+            kv_lora_rank=512,
+            qk_rope_head_dim=64,
+            max_running_requests=32,
+            speculative_num_draft_tokens=4,
+            enable_dsa_shared_kv_cache=True,
+        )
+        hf_config = SimpleNamespace(
+            architectures=["GlmMoeDsaForCausalLM"],
+            index_topk=2048,
+            index_head_dim=128,
+        )
+        hf_config.get_text_config = lambda: hf_config
+        mr.model_config.hf_config = hf_config
+        mr.model_config.num_nextn_predict_layers = 1
+        mr.spec_algorithm.is_eagle.return_value = True
+        mr.spec_algorithm.is_standalone.return_value = False
+        mr.spec_algorithm.is_none.return_value = False
+        mr.spec_aux_config.eagle_draft_num_layers = None
+
+        with (
+            mock_cpu_env(),
+            get_parallel().override(attn_cp_size=8),
+        ):
+            from sglang.srt.model_executor.pool_configurator import (
+                create_memory_pool_configurator,
+            )
+
+            cfg = create_memory_pool_configurator(mr)
+
+        full_layer_bytes = (512 + 64) * KV_SIZE + (128 + 4) * KV_SIZE
+        self.assertEqual(cfg._cell_size, full_layer_bytes * (10 + 1))
+
+    def test_shared_dsa_prices_flashmla_demand_workspace(self):
+        num_layers = 78
+        max_running_requests = 32
+        max_current_rows = 4
+        mr = _make_model_runner(
+            self,
+            num_layers=num_layers,
+            use_mla_backend=True,
+            kv_lora_rank=512,
+            qk_rope_head_dim=64,
+            max_running_requests=max_running_requests,
+            speculative_num_draft_tokens=max_current_rows,
+            enable_dsa_shared_kv_cache=True,
+        )
+        hf_config = SimpleNamespace(
+            architectures=["GlmMoeDsaForCausalLM"],
+            index_topk=2048,
+            index_head_dim=128,
+        )
+        hf_config.get_text_config = lambda: hf_config
+        mr.model_config.hf_config = hf_config
+
+        with (
+            mock_cpu_env(),
+            get_parallel().override(attn_cp_size=8),
+        ):
+            from sglang.srt.mem_cache.dsa_shared_demand import (
+                get_flashmla_shared_demand_workspace_bytes,
+            )
+            from sglang.srt.model_executor.pool_configurator import (
+                create_memory_pool_configurator,
+            )
+
+            cfg = create_memory_pool_configurator(mr)
+
+        self.assertEqual(
+            cfg._fixed_bytes,
+            get_flashmla_shared_demand_workspace_bytes(
+                num_layers=num_layers,
+                num_request_slots=max_running_requests,
+                max_current_rows=max_current_rows,
+            ),
+        )
+
+    def test_shared_dsa_draft_worker_does_not_price_target_demand_workspace(self):
+        mr = _make_model_runner(
+            self,
+            num_layers=1,
+            use_mla_backend=True,
+            max_running_requests=32,
+            speculative_num_draft_tokens=4,
+            enable_dsa_shared_kv_cache=True,
+        )
+        hf_config = SimpleNamespace(
+            architectures=["GlmMoeDsaForCausalLM"],
+            index_topk=2048,
+            index_head_dim=128,
+        )
+        hf_config.get_text_config = lambda: hf_config
+        mr.model_config.hf_config = hf_config
+        mr.is_draft_worker = True
+
+        with (
+            mock_cpu_env(),
+            get_parallel().override(attn_cp_size=8),
+        ):
+            from sglang.srt.model_executor.pool_configurator import (
+                create_memory_pool_configurator,
+            )
+
+            cfg = create_memory_pool_configurator(mr)
+
+        self.assertEqual(cfg._fixed_bytes, 0)
+
+    def test_shared_dsa_prices_pool_cache_with_token_pool_pages(self):
+        num_layers = 32
+        producer_layers = 8
+        page_size = 64
+        max_tokens = 64 * 100
+        mr = _make_model_runner(
+            self,
+            num_layers=num_layers,
+            use_mla_backend=True,
+            kv_lora_rank=512,
+            qk_rope_head_dim=64,
+            page_size=page_size,
+            enable_dsa_shared_kv_cache=True,
+            dsa_prefill_backend="flashmla_sparse",
+        )
+        hf_config = SimpleNamespace(
+            architectures=["GlmMoeDsaForCausalLM"],
+            index_topk=2048,
+            index_head_dim=128,
+            index_topk_pattern=[
+                "C" if layer_id < producer_layers else "S"
+                for layer_id in range(num_layers)
+            ],
+        )
+        hf_config.get_text_config = lambda: hf_config
+        mr.model_config.hf_config = hf_config
+
+        with (
+            mock_cpu_env(),
+            get_parallel().override(attn_cp_size=8),
+        ):
+            from sglang.srt.model_executor.pool_configurator import (
+                create_memory_pool_configurator,
+            )
+
+            cfg = create_memory_pool_configurator(mr)
+
+        logical_pages = (max_tokens + page_size + 1) // page_size
+        page_bytes = page_size * (128 + 4)
+        expected_pool_bytes = (
+            producer_layers * logical_pages * (page_bytes + 8) + producer_layers * 4
+        )
+        self.assertEqual(
+            cfg._variable_bytes_for_tokens(max_tokens), expected_pool_bytes
+        )
+
+        exact_budget = cfg._cell_size * max_tokens + expected_pool_bytes
+        self.assertEqual(
+            cfg.calculate_pool_sizes(exact_budget, page_size).max_total_num_tokens,
+            max_tokens,
+        )
+        self.assertEqual(
+            cfg.calculate_pool_sizes(exact_budget - 1, page_size).max_total_num_tokens,
+            max_tokens - page_size,
+        )
 
     @patch(
         "sglang.srt.mem_cache.kv_cache_configurator.calculate_mla_kv_cache_dim",

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -758,6 +758,222 @@ class TestHiSparseDsaBackendPolicy(unittest.TestCase):
             server_args._validate_hisparse_kv_cache_dtype()
 
 
+class TestDSASharedCacheArgs(unittest.TestCase):
+    @staticmethod
+    def _make_args(**overrides):
+        values = dict(
+            model_path="dummy",
+            enable_dsa_shared_kv_cache=True,
+            disaggregation_mode="null",
+            tp_size=8,
+            attn_cp_size=8,
+            dp_size=1,
+            nnodes=1,
+            attention_backend="dsa",
+            enable_prefill_cp=True,
+            cp_strategy="interleave",
+            disaggregation_transfer_backend="mooncake",
+            pp_size=1,
+            max_running_requests=32,
+            quantization="w4afp8",
+            kv_cache_dtype="fp8_e4m3",
+            page_size=64,
+            dsa_prefill_backend="flashmla_kv",
+            dsa_decode_backend="flashmla_kv",
+        )
+        values.update(overrides)
+        args = ServerArgs(**values)
+        args.cuda_graph_config = CudaGraphConfig()
+        hf_config = SimpleNamespace(
+            architectures=["GlmMoeDsaForCausalLM"], index_topk=2048
+        )
+        args.get_model_config = lambda: SimpleNamespace(hf_config=hf_config)
+        return args
+
+    @staticmethod
+    def _adjust(args, *, cuda=True, capability=(9, 0)):
+        with (
+            patch(
+                "sglang.srt.configs.model_config.is_deepseek_dsa",
+                return_value=True,
+            ),
+            patch("sglang.srt.server_args.is_cuda", return_value=cuda),
+            patch("torch.cuda.get_device_capability", return_value=capability),
+        ):
+            args._handle_model_specific_adjustments()
+
+    def test_accepts_release_configuration(self):
+        args = self._make_args()
+
+        self._adjust(args)
+
+        self.assertTrue(args.enable_dsa_shared_kv_cache)
+
+    def test_requires_explicit_bounded_max_running_requests(self):
+        for value in (None, 0, 33):
+            with self.subTest(max_running_requests=value):
+                args = self._make_args(max_running_requests=value)
+                with self.assertRaisesRegex(
+                    ValueError, r"--max-running-requests.*\[1, 32\]"
+                ):
+                    self._adjust(args)
+
+    def test_accepts_max_running_requests_bounds(self):
+        for value in (1, 32):
+            with self.subTest(max_running_requests=value):
+                args = self._make_args(max_running_requests=value)
+                self._adjust(args)
+                self.assertEqual(args.max_running_requests, value)
+
+    def test_rejects_layer_split_at_the_same_time(self):
+        args = self._make_args(enable_dsa_cache_layer_split=True)
+
+        with self.assertRaisesRegex(ValueError, "cannot be enabled together"):
+            self._adjust(args)
+
+    def test_requires_nvidia_cuda(self):
+        args = self._make_args()
+
+        with self.assertRaisesRegex(ValueError, "requires NVIDIA CUDA"):
+            self._adjust(args, cuda=False)
+
+    def test_accepts_mixed_prefill_decode_worker(self):
+        args = self._make_args()
+
+        self._adjust(args)
+
+        self.assertTrue(args.enable_dsa_shared_kv_cache)
+
+    def test_shared_indexer_is_enabled_by_default(self):
+        args = self._make_args()
+
+        self._adjust(args)
+
+        self.assertFalse(args.disable_dsa_shared_indexer_cache)
+
+    def test_accepts_replicated_indexer_fallback(self):
+        args = self._make_args(disable_dsa_shared_indexer_cache=True)
+
+        self._adjust(args)
+
+        self.assertTrue(args.disable_dsa_shared_indexer_cache)
+
+    def test_rejects_replicated_indexer_flag_without_shared_main(self):
+        args = self._make_args(
+            enable_dsa_shared_kv_cache=False,
+            disable_dsa_shared_indexer_cache=True,
+        )
+
+        with self.assertRaisesRegex(
+            ValueError, "requires --enable-dsa-shared-kv-cache"
+        ):
+            self._adjust(args)
+
+    def test_rejects_pd_workers(self):
+        for mode in ("prefill", "decode"):
+            with self.subTest(mode=mode):
+                args = self._make_args(disaggregation_mode=mode)
+                with self.assertRaisesRegex(ValueError, "mixed Prefill/Decode"):
+                    self._adjust(args)
+
+    def test_requires_interleave_prefill_cp(self):
+        args = self._make_args(cp_strategy="zigzag")
+
+        with self.assertRaisesRegex(ValueError, "--cp-strategy interleave"):
+            self._adjust(args)
+
+    def test_requires_pp1(self):
+        args = self._make_args(pp_size=2)
+        with self.assertRaisesRegex(ValueError, "pipeline parallelism"):
+            self._adjust(args)
+
+    def test_requires_multiple_cp_ranks(self):
+        args = self._make_args(tp_size=1, attn_cp_size=1)
+
+        with self.assertRaisesRegex(ValueError, "attn-cp-size greater than 1"):
+            self._adjust(args)
+
+    def test_release_scope_requires_glm52_architecture(self):
+        args = self._make_args()
+        args.get_model_config = lambda: SimpleNamespace(
+            hf_config=SimpleNamespace(
+                architectures=["DeepseekV4ForCausalLM"], index_topk=2048
+            )
+        )
+
+        with self.assertRaisesRegex(ValueError, "GLM-5.2"):
+            self._adjust(args)
+
+    def test_release_scope_requires_tp8_cp8(self):
+        for field, value in (("tp_size", 4), ("attn_cp_size", 4)):
+            with self.subTest(field=field):
+                args = self._make_args(**{field: value})
+                with self.assertRaisesRegex(ValueError, "TP8/CP8"):
+                    self._adjust(args)
+
+    def test_release_scope_requires_single_node_dp1_sm90_dsa(self):
+        cases = (
+            ({"nnodes": 2}, "single node"),
+            ({"dp_size": 2}, "DP1"),
+            ({"attention_backend": "flashinfer"}, "attention backend.*dsa"),
+        )
+        for overrides, message in cases:
+            with self.subTest(overrides=overrides):
+                args = self._make_args(**overrides)
+                with self.assertRaisesRegex(ValueError, message):
+                    self._adjust(args)
+
+        args = self._make_args()
+        with self.assertRaisesRegex(ValueError, "SM90"):
+            self._adjust(args, capability=(10, 0))
+
+    def test_release_scope_requires_flashmla_fp8_page64_w4afp8(self):
+        cases = (
+            ("quantization", "fp8"),
+            ("kv_cache_dtype", "bfloat16"),
+            ("page_size", 32),
+            ("dsa_prefill_backend", "flashmla_sparse"),
+            ("dsa_decode_backend", "flashmla_sparse"),
+        )
+        for field, value in cases:
+            with self.subTest(field=field):
+                args = self._make_args(**{field: value})
+                with self.assertRaisesRegex(ValueError, "release scope"):
+                    self._adjust(args)
+
+    def test_rejects_hisparse(self):
+        args = self._make_args(enable_hisparse=True)
+
+        with self.assertRaisesRegex(ValueError, "HiSparse"):
+            self._adjust(args)
+
+    def test_accepts_speculative_decoding(self):
+        args = self._make_args(
+            speculative_algorithm="EAGLE",
+            speculative_num_draft_tokens=4,
+        )
+
+        self._adjust(args)
+
+        self.assertEqual(args.speculative_algorithm, "EAGLE")
+        self.assertTrue(args.enable_dsa_shared_kv_cache)
+
+    def test_rejects_more_than_four_speculative_draft_tokens(self):
+        args = self._make_args(
+            speculative_algorithm="EAGLE",
+            speculative_num_draft_tokens=5,
+        )
+
+        with self.assertRaisesRegex(ValueError, "at most four"):
+            self._adjust(args)
+
+    def test_rejects_hierarchical_cache(self):
+        args = self._make_args(enable_hierarchical_cache=True)
+
+        with self.assertRaisesRegex(ValueError, "does not yet support"):
+            self._adjust(args)
+
+
 class TestFa4PageSizeAutoForce(CustomTestCase):
     """FA4 requires page_size 128 for non-MLA models on SM100. The auto-force
     must trigger for `--attention-backend fa4` (combined) too, not only for the

--- a/test/registered/unit/test_cuda_vmm_utils.py
+++ b/test/registered/unit/test_cuda_vmm_utils.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import atexit
 import os
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
@@ -43,6 +44,133 @@ _FABRIC = drv.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_FABRIC
 _POSIX_FD = drv.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR
 _RECOMMENDED = drv.CUmemAllocationGranularity_flags.CU_MEM_ALLOC_GRANULARITY_RECOMMENDED
 _ALLOC_BYTES = 2 * 1024 * 1024
+
+
+def _gather_values(values):
+    def gather(output, _value, group):
+        assert group == "group"
+        output[:] = values
+
+    return gather
+
+
+def _assert_fd_exchange_setup_failure(setup_errors, bind_error=None) -> None:
+    server = MagicMock()
+    server.bind.side_effect = bind_error
+    failed_rank = next(i for i, error in enumerate(setup_errors) if error is not None)
+
+    with (
+        patch("socket.socket", return_value=server),
+        patch("tempfile.mkdtemp", return_value="/tmp/sgl_ar_fd_test"),
+        patch(
+            "sglang.srt.cuda_vmm_utils.dist.all_gather_object",
+            side_effect=_gather_values(setup_errors),
+        ) as gather,
+        patch("os.unlink"),
+        patch("os.rmdir"),
+        pytest.raises(
+            RuntimeError,
+            match=(
+                f"POSIX fd exchange setup failed on rank {failed_rank}: "
+                f"{setup_errors[failed_rank]}"
+            ),
+        ),
+    ):
+        exchange_posix_fds("group", 0, 2, [7], [1, 1])
+
+    gather.assert_called_once()
+    server.close.assert_called_once()
+
+
+def test_fd_exchange_reports_local_socket_setup_failure_before_path_gather() -> None:
+    _assert_fd_exchange_setup_failure(
+        ["address already in use", None], OSError("address already in use")
+    )
+
+
+def test_fd_exchange_stops_before_path_gather_on_remote_setup_failure() -> None:
+    _assert_fd_exchange_setup_failure([None, "permission denied"])
+
+
+class _ImmediateThread:
+    def __init__(self, *, target, daemon):
+        self.target = target
+
+    def start(self):
+        self.target()
+
+    def join(self, _timeout):
+        pass
+
+    def is_alive(self):
+        return False
+
+
+def _assert_fd_exchange_transfer_failure(
+    transfer_errors, *, connect_error=None, send_error=None
+) -> None:
+    server = MagicMock()
+    connections = [MagicMock(), MagicMock()]
+    server.accept.side_effect = [(conn, None) for conn in connections]
+    outbound = [MagicMock(), MagicMock()]
+    for sock in outbound:
+        sock.__enter__.return_value = sock
+    if connect_error is not None:
+        outbound[0].connect.side_effect = connect_error
+
+    gather_values = [
+        [None, None, None],
+        ["/tmp/rank_0.sock", "/tmp/rank_1.sock", "/tmp/rank_2.sock"],
+        transfer_errors,
+    ]
+
+    def gather(output, _value, group):
+        assert group == "group"
+        output[:] = gather_values.pop(0)
+
+    with (
+        patch("socket.socket", side_effect=[server, *outbound]),
+        patch("tempfile.mkdtemp", return_value="/tmp/sgl_ar_fd_test"),
+        patch("threading.Thread", _ImmediateThread),
+        patch(
+            "sglang.srt.cuda_vmm_utils._recv_fd",
+            side_effect=[(1, 0, 101), None, (2, 0, 102), None],
+        ),
+        patch(
+            "sglang.srt.cuda_vmm_utils._send_fd",
+            side_effect=send_error,
+        ),
+        patch(
+            "sglang.srt.cuda_vmm_utils.dist.all_gather_object",
+            side_effect=gather,
+        ) as all_gather,
+        patch("os.close") as close,
+        patch("os.unlink"),
+        patch("os.rmdir"),
+        pytest.raises(RuntimeError, match="POSIX fd exchange transfer failed"),
+    ):
+        exchange_posix_fds("group", 0, 3, [7], [1, 1, 1])
+
+    assert all_gather.call_count == 3
+    close.assert_any_call(101)
+    close.assert_any_call(102)
+
+
+def test_fd_exchange_agrees_on_connect_failure() -> None:
+    _assert_fd_exchange_transfer_failure(
+        ["connect failed", None, None],
+        connect_error=ConnectionRefusedError("connect failed"),
+    )
+
+
+def test_fd_exchange_agrees_on_send_failure() -> None:
+    _assert_fd_exchange_transfer_failure(
+        ["send failed", None, None], send_error=RuntimeError("send failed")
+    )
+
+
+def test_fd_exchange_reports_remote_transfer_failure_before_returning() -> None:
+    _assert_fd_exchange_transfer_failure([None, "send failed", None])
 
 
 @cache_once


### PR DESCRIPTION
## Summary

> **Supersedes [#31435](https://github.com/sgl-project/sglang/pull/31435).** This PR continues its GLM-5.2 Prefill CP Shared KV work and replaces it with a unified mixed Prefill/Decode implementation, adding Demand Cache, optional Shared Indexer, and EAGLE support.

Add an opt-in DSA Shared KV cache for GLM-5.2 TP8/Attention-CP8 serving(CP8TP8), with CP Prefill and TP Decode on the same workers. In the tested **H20-3e** configuration, token capacity is about **3.1x–4.8x** Base and **TPOT overhead is < 2 ms**. Persistent Main KV and, by default, Indexer pages keep one owner-sharded copy per CP group. Main KV uses a local Demand Cache for FlashMLA-KV, while Shared Indexer reuses the existing full-batch Indexer compute path. The Base path is unchanged when the feature is disabled, and **EAGLE** is supported.

## Motivation

Regular CP8 keeps eight physical Main KV and Indexer replicas for one logical cache. Shared KV stores one owner-sharded copy across the CP group and maps it into a common CUDA VMM address space.

- LayerSplit: layer owner → **per-layer NCCL broadcast** → local full-layer scratch → attention
- Shared KV: page owner → common VMM view → **local HBM read or demand peer-memory load** → attention

Demand loading is intentionally simple:

- **owner-local** rows are read directly
- a ready local cache row is consumed as a **hit**
- on a **miss**, FlashMLA-KV consumes the authoritative peer VMM row and opportunistically fills the local Demand Cache
- a **collision or in-progress fill** does not wait; it falls back to the authoritative row

Decode keeps current rows in a small local shadow. Shared Indexer materializes only the active shared pages into a reusable local buffer before running the existing full-batch Indexer compute. EAGLE Decode/verify uses the same Shared + Demand path; only draft-model KV remains local and replicated.

## Usage

Add `--enable-dsa-shared-kv-cache --max-running-requests N` to the existing GLM-5.2 Attention-CP FlashMLA-KV command. `N` is configurable in `[1, 32]` and determines the preallocated Decode Demand workspace. Add `--disable-dsa-shared-indexer-cache` to share Main KV while retaining the replicated Indexer.

<details><summary>Benchmark launch script</summary>

The two simulation variables below are benchmark-only. Production serving must leave both unset.

```bash
#!/usr/bin/env bash
set -euo pipefail

MODE=${1:?base|main-only|full}
MODEL_PATH=${MODEL_PATH:?set MODEL_PATH}
case "${MODE}" in
  base) SHARED_ARGS=() ;;
  main-only) SHARED_ARGS=(--enable-dsa-shared-kv-cache --disable-dsa-shared-indexer-cache) ;;
  full) SHARED_ARGS=(--enable-dsa-shared-kv-cache) ;;
  *) exit 2 ;;
esac

export SGLANG_JIT_DEEPGEMM_PRECOMPILE=0
export SGLANG_SIMULATE_ACC_LEN=3
export SGLANG_SIMULATE_ACC_TOKEN_MODE=real-draft-token

python3 -m sglang.launch_server \
  --model "${MODEL_PATH}" --tokenizer-path "${MODEL_PATH}" \
  --trust-remote-code --quantization w4afp8 \
  --host 127.0.0.1 --port 30080 \
  --tp-size 8 --attn-cp-size 8 --dp-size 1 \
  --attention-backend dsa \
  --dsa-prefill-backend flashmla_kv --dsa-decode-backend flashmla_kv \
  --enable-prefill-cp --cp-strategy interleave \
  --enable-dsa-prefill-context-parallel \
  --dsa-prefill-cp-mode round-robin-split \
  --enable-cp-decode-attn-tp "${SHARED_ARGS[@]}" \
  --kv-cache-dtype fp8_e4m3 --page-size 64 \
  --mem-fraction-static 0.85 \
  --chunked-prefill-size 16384 --max-prefill-tokens 32768 \
  --max-running-requests 32 --max-queued-requests 32 \
  --cuda-graph-max-bs-decode 32 --cuda-graph-bs-decode 8 32 \
  --moe-dense-tp-size 1 --disable-shared-experts-fusion \
  --watchdog-timeout 3600 --random-seed 20260820 \
  --skip-server-warmup --enable-cache-report --enable-metrics \
  --decode-log-interval 20 \
  --speculative-algorithm EAGLE --speculative-num-steps 3 \
  --speculative-eagle-topk 1 --speculative-num-draft-tokens 3
```

</details>

<details><summary>Benchmark script</summary>

```bash
#!/usr/bin/env bash
set -euo pipefail

SCENARIO=${1:?4k-cold-b32|100k-prefix90-b8|256k-prefix90-b16}
OUT=${OUT:-benchmark-${SCENARIO}}
case "${SCENARIO}" in
  4k-cold-b32)
    INPUT_LEN=4096; BATCH=32; EXPECTED_CACHED=0; POPULATE_LEN=0 ;;
  100k-prefix90-b8)
    INPUT_LEN=102400; BATCH=8; EXPECTED_CACHED=92160; POPULATE_LEN=92224 ;;
  256k-prefix90-b16)
    INPUT_LEN=262144; BATCH=16; EXPECTED_CACHED=235904; POPULATE_LEN=235968 ;;
  *) exit 2 ;;
esac
mkdir -p "${OUT}"

bench() {
  local name=$1 input_len=${2:-${INPUT_LEN}} output_len=${3:-1024}
  local num_prompts=${4:-${BATCH}}
  python3 -m sglang.benchmark.serving \
    --backend sglang --base-url http://127.0.0.1:30080 \
    --dataset-name random-ids --num-prompts "${num_prompts}" \
    --random-input-len "${input_len}" --random-output-len "${output_len}" \
    --random-range-ratio 1.0 --max-concurrency "${num_prompts}" \
    --warmup-requests 0 --seed 20260820 --tokenize-prompt \
    --disable-tqdm --output-details --cache-report \
    --extra-request-body '{"ignore_eos":true,"temperature":0}' \
    --output-file "${OUT}/${name}.jsonl" >"${OUT}/${name}.log" 2>&1
}

validate() {
  python3 - "$1" "${INPUT_LEN}" "${BATCH}" "${EXPECTED_CACHED}" <<'PY'
import json, sys
p, input_len, batch, cached = sys.argv[1], *map(int, sys.argv[2:])
d = json.loads(open(p).readline())
assert d["completed"] == batch and d["max_concurrency"] == batch
assert d["total_input_tokens"] == input_len * batch
assert d["total_output_tokens"] == 1024 * batch
assert all(x == cached for x in d["cached_tokens"])
assert not any(d["errors"])
assert abs(d["accept_length"] - 3.0) < 0.02
assert all(1020 <= len(x) <= 1023 for x in d["itls"])
PY
}

# Disjoint JIT warmup; its KV is flushed before measurement.
bench warmup 4096 1 1
curl -fsS -X POST http://127.0.0.1:30080/flush_cache >"${OUT}/flush-after-warmup.json"

for round in round1 round2; do
  curl -fsS -X POST http://127.0.0.1:30080/flush_cache >"${OUT}/${round}-flush.json"
  if (( POPULATE_LEN > 0 )); then bench "${round}-populate" "${POPULATE_LEN}" 1; fi
  bench "${round}"
  validate "${OUT}/${round}.jsonl"
done
```

The Prefix populate lengths include one extra 64-token page because the radix cache withholds its final page. Formal requests therefore report exactly 92,160 cached tokens for 100K and 235,904 for 256K.

</details>

## Capacity

Representative H20-3e startup capacity with `mem-fraction-static=0.85` and no explicit token cap:

| Storage mode | Token capacity | vs Base |
| --- | ---: | ---: |
| Base | 960,704 | 1.0x |
| Shared Main + replicated Indexer | 2,993,472 | 3.1x |
| Shared Main + Shared Indexer | 4,615,808 | 4.8x |

## Prefill/Decode performance

EAGLE accept length is fixed at 3. Values are R1/R2; all runs reached the target concurrency with Decode queue 0 and no errors.

| Workload | Mode | Cache hit | Mean TTFT | Mean TPOT | Output TPS | TPOT delta |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| 4K→1K, B32 Cold | Base | 0% | 8.51/8.45 s | 31.38/31.29 ms | 806.47/809.53 | baseline |
| 4K→1K, B32 Cold | Shared Main + replicated Indexer | 0% | 8.70/8.44 s | 32.03/31.87 ms | 789.88/798.14 | +0.62 ms |
| 4K→1K, B32 Cold | Shared Main + Shared Indexer | 0% | 8.41/8.36 s | 33.13/32.88 ms | 774.26/779.89 | +1.67 ms |
| 100K→1K, B8 Prefix-hit | Base | 90% | 7.05/6.84 s | 15.79/16.16 ms | 352.51/350.06 | baseline |
| 100K→1K, B8 Prefix-hit | Shared Main + replicated Indexer | 90% | 7.00/6.52 s | 16.74/17.59 ms | 339.09/333.70 | +1.19 ms |
| 100K→1K, B8 Prefix-hit | Shared Main + Shared Indexer | 90% | 6.54/7.00 s | 17.74/17.58 ms | 331.34/327.48 | +1.68 ms |
| 256K→1K, B16 Prefix-hit | Shared Main + Shared Indexer | 89.99% | 28.95/28.97 s | 56.01/55.95 ms | 189.58/189.64 | Base/Main-only unsupported |

<details><summary>Representative raw benchmark output</summary>

```text
# Base, 4K→1K/B32 Cold, R1
Successful requests:                     32
Benchmark duration (s):                  40.63
Input token throughput (tok/s):          3225.89
Output token throughput (tok/s):         806.47
Peak concurrent requests:                32
Accept length:                           3.00
Mean TTFT (ms):                          8506.64
Median TTFT (ms):                        9233.34
Mean TPOT (ms):                          31.38
Median TPOT (ms):                        30.67
Mean ITL (ms):                           31.40
Cache hit rate:                          0.0%

# Full Shared, 100K→1K/B8 Prefix-hit, R1
Successful requests:                     8
Benchmark duration (s):                  24.72
Input token throughput (tok/s):          33133.80
Output token throughput (tok/s):         331.34
Peak concurrent requests:                8
Accept length:                           3.00
Mean TTFT (ms):                          6544.17
Median TTFT (ms):                        7141.72
Mean TPOT (ms):                          17.74
Median TPOT (ms):                        17.16
Mean ITL (ms):                           17.75
Total cached tokens:                     737280
Cache hit rate:                          90.0%

# Full Shared, 256K→1K/B16 Prefix-hit, R1
Successful requests:                     16
Benchmark duration (s):                  86.42
Input token throughput (tok/s):          48532.75
Output token throughput (tok/s):         189.58
Peak concurrent requests:                16
Accept length:                           3.00
Mean TTFT (ms):                          28946.13
Median TTFT (ms):                        28632.25
Mean TPOT (ms):                          56.01
Median TPOT (ms):                        56.24
Mean ITL (ms):                           56.01
Total cached tokens:                     3774464
Cache hit rate:                          90.0%
```

</details>

## Correctness and release validation

- Periodic 32K and 100K EAGLE output IDs match exactly across Base, Main-only, and Full Shared; all correctness and benchmark requests completed without errors or retractions.
- The same 500-example, 24-shot GSM8K gate scored Base `0.948`, Main-only `0.950`, and Full Shared `0.944`; all pass the `0.94` threshold.
- Focused and multi-GPU tests cover remote VMM, Demand hit/fill/collision, current-row shadow, EAGLE relocation, and CUDA Graph replay. Python compilation and `git diff --check` pass.
- Fixed-accept performance runs are performance evidence only and are not reused as correctness evidence.

## Current limitations

- Shared CP ranks currently need to be in one peer-accessible NVLink domain; a future extension can use Multi-Node NVLink (MNNVL) fabric memory for multi-node NVLink supernodes such as GB200/GB300 NVL72.
- The current release guardrails require `--max-running-requests` in `[1, 32]` and EAGLE verify width up to four; both limits can be extended after larger workspace, CUDA Graph, and concurrency validation.
- The supported Shared Demand attention path currently uses FlashMLA-KV for Prefill and Decode; other DSA backends are not yet in the release scope.

Co-authored with [@foraxe](https://github.com/foraxe)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32128324083](https://github.com/sgl-project/sglang/actions/runs/32128324083)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32128323998](https://github.com/sgl-project/sglang/actions/runs/32128323998)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->