### PR TITLE
[VLM] Add video input support for Kimi-K3

### DIFF
--- a/docs/cookbook/autoregressive/Moonshotai/Kimi-K3.mdx
+++ b/docs/cookbook/autoregressive/Moonshotai/Kimi-K3.mdx
@@ -98,7 +98,7 @@ import { Playground } from "/src/snippets/_playground.jsx";
 
 ## 1. Model Introduction
 
-**Kimi-K3** is Moonshot AI's flagship hybrid MoE vision-language model: **2.8 trillion parameters**, **16 of 896 experts** active per token, roughly **2.5× the scaling efficiency of Kimi-K2**. The backbone interleaves **Kimi Delta Attention (KDA)** with MLA across 93 layers (plus Attention Residuals and Stable LatentMoE); serving supports image input and a **1M-token** window with prefix caching. Weights ship in **MXFP4**: the FlashInfer MXFP4 (trtllm-gen SiTU) runner serves them on Blackwell, Marlin (W4A16) elsewhere, MegaMoE for short-context batch throughput.
+**Kimi-K3** is Moonshot AI's flagship hybrid MoE vision-language model: **2.8 trillion parameters**, **16 of 896 experts** active per token, roughly **2.5× the scaling efficiency of Kimi-K2**. The backbone interleaves **Kimi Delta Attention (KDA)** with MLA across 93 layers (plus Attention Residuals and Stable LatentMoE); serving supports image and video input (without audio track) and a **1M-token** window with prefix caching. Weights ship in **MXFP4**: the FlashInfer MXFP4 (trtllm-gen SiTU) runner serves them on Blackwell, Marlin (W4A16) elsewhere, MegaMoE for short-context batch throughput.
 
 K3 **always runs with thinking enabled**, with reasoning depth controlled by `reasoning_effort` (`low` / `high` / `max`; default `max`).
 
@@ -117,6 +117,38 @@ throughput and accuracy before you rely on any of them.
 **Recommended generation:** `temperature=1.0`, `top_p=0.95`, `presence_penalty=0`, `frequency_penalty=0` (fixed by the model; informational — do not hardcode in sample code).
 
 **Resources:** [HuggingFace](https://huggingface.co/moonshotai/Kimi-K3) · [Kimi-K3 Quickstart](https://platform.kimi.ai/docs/guide/kimi-k3-quickstart).
+
+### Video input
+
+Pass a public URL, server-accessible local file path, or Base64 data URL in a `video_url` content part. SGLang samples visual frames using the checkpoint's media processor configuration and sends timestamped temporal chunks to MoonViT3d. The video's audio track is not processed; separate `audio_url` input is not supported.
+
+```python Video input
+import base64
+
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:30000/v1", api_key="EMPTY")
+
+# Use an HTTPS URL directly, or encode a local video as a data URL.
+with open("video.mp4", "rb") as video_file:
+    video = "data:video/mp4;base64," + base64.b64encode(video_file.read()).decode()
+
+response = client.chat.completions.create(
+    model="moonshotai/Kimi-K3",
+    messages=[
+        {
+            "role": "user",
+            "content": [
+                {"type": "video_url", "video_url": {"url": video}},
+                {"type": "text", "text": "Describe what happens in this video."},
+            ],
+        }
+    ],
+    max_tokens=512,
+)
+
+print(response.choices[0].message.content)
+```
 
 ## 2. Configuration Tips
 

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -562,6 +562,7 @@ class ChatCompletionMessageContentImagePart(BaseModel):
 class ChatCompletionMessageContentVideoPart(BaseModel):
     type: Literal["video_url"]
     video_url: ChatCompletionMessageContentVideoURL
+    modalities: Optional[Literal["video"]] = "video"
 
 
 class ChatCompletionMessageContentAudioPart(BaseModel):

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -376,7 +376,7 @@ class OpenAIServingChat(OpenAIServingBase):
         messages: List[Dict[str, Any]],
         request: ChatCompletionRequest,
     ) -> tuple[List[Dict[str, Any]], int, Optional[str]]:
-        image_count = 0
+        media_count = 0
         for index, message in enumerate(messages):
             content = message.get("content")
             if isinstance(content, list):
@@ -399,7 +399,16 @@ class OpenAIServingChat(OpenAIServingBase):
                         if isinstance(image, str):
                             image = {"url": image, "detail": part.get("detail")}
                         parts.append({"type": "image_url", "image_url": image})
-                        image_count += 1
+                        media_count += 1
+                    elif part_type == "video_url":
+                        video = part.get("video_url") or {}
+                        if isinstance(video, str):
+                            video = {"url": video}
+                        # K3's chat encoder only recognizes image parts. Emit one
+                        # structural media placeholder here; the multimodal
+                        # processor expands it into timestamped video chunks.
+                        parts.append({"type": "image_url", "image_url": video})
+                        media_count += 1
                 message["content"] = parts
             elif isinstance(content, str):
                 message["content"] = neutralize_kimi_k3_image_placeholder(content)
@@ -443,7 +452,7 @@ class OpenAIServingChat(OpenAIServingBase):
             messages, assistant_prefix = self._handle_last_assistant_message(
                 messages, request
             )
-        return messages, image_count, assistant_prefix
+        return messages, media_count, assistant_prefix
 
     def _encode_messages(
         self,
@@ -495,15 +504,15 @@ class OpenAIServingChat(OpenAIServingBase):
                 ]
             return prompt_ids
         if self.chat_encoding_spec == "kimi_k3":
-            messages, image_count, assistant_prefix = self._prepare_kimi_k3_messages(
+            messages, media_count, assistant_prefix = self._prepare_kimi_k3_messages(
                 messages, request
             )
             template_kwargs = dict(request.chat_template_kwargs or {})
             template_kwargs.pop("tokenize", None)
             template_kwargs.pop("return_dict", None)
             template_kwargs.pop("image_prompts", None)
-            if image_count:
-                template_kwargs["image_prompts"] = ["<|media_pad|>"] * image_count
+            if media_count:
+                template_kwargs["image_prompts"] = ["<|media_pad|>"] * media_count
 
             if (
                 request.reasoning_effort in ("low", "high", "max")

--- a/python/sglang/srt/models/kimi_k3.py
+++ b/python/sglang/srt/models/kimi_k3.py
@@ -3281,6 +3281,7 @@ class KimiK3ForConditionalGeneration(nn.Module):
                     group_items = [selected_items[index] for index in indices]
                     group_configs = [deferred[index] for index in indices]
                     first_config = group_configs[0]
+                    global_indices = [image_indices[index] for index in indices]
                     if backend == "gpu":
                         from sglang.srt.multimodal.processors.kimi_k25 import (
                             _gpu_preprocess_images,
@@ -3302,7 +3303,7 @@ class KimiK3ForConditionalGeneration(nn.Module):
                                 x, first_config.transparent_bg_config
                             ),
                         )
-                        expected_grids = grid_thws_host[indices]
+                        expected_grids = grid_thws_host[global_indices]
                         if not torch.equal(produced_grids.cpu(), expected_grids):
                             raise ValueError(
                                 "Kimi-K3 deferred GPU preprocessing produced wrong grids"
@@ -3321,7 +3322,8 @@ class KimiK3ForConditionalGeneration(nn.Module):
                         )
 
                     patch_counts = [
-                        int(grid_thws_host[index].prod().item()) for index in indices
+                        int(grid_thws_host[index].prod().item())
+                        for index in global_indices
                     ]
                     if sum(patch_counts) != pixel_values.shape[0]:
                         raise ValueError(

--- a/python/sglang/srt/models/kimi_k3_vl.py
+++ b/python/sglang/srt/models/kimi_k3_vl.py
@@ -250,7 +250,7 @@ class Learnable2DInterpPosEmbDividedFixed(nn.Module):
             else:
                 pos_emb_3d = pos_emb_2d.unsqueeze(0).repeat(t, 1, 1) + self.time_weight[
                     0:t
-                ].to(pos_emb_2d.dtype)
+                ].to(device=pos_emb_2d.device, dtype=pos_emb_2d.dtype)
 
             pos_embs.append(pos_emb_3d.reshape(-1, pos_emb_3d.shape[-1]))
 

--- a/python/sglang/srt/multimodal/processors/kimi_k3.py
+++ b/python/sglang/srt/multimodal/processors/kimi_k3.py
@@ -11,7 +11,8 @@ at load time.
 import functools
 import math
 import re
-from typing import Dict, List, Optional, Union
+from dataclasses import dataclass
+from typing import Any, Dict, List, Literal, Optional, Union
 
 import numpy as np
 import torch
@@ -72,6 +73,113 @@ def _encode_k3_special_tokens(tokenizer, text: str) -> list[int]:
         return list(tokenizer.encode(text))
 
 
+@dataclass(frozen=True)
+class _KimiK3VisualItem:
+    """One MoonViT input grid derived from an image or a video chunk."""
+
+    media_type: Literal["image", "video"]
+    frames: tuple[Any, ...]
+    source_index: int
+    in_patch_limit: int
+    timestamp_text: str = ""
+
+    @property
+    def size(self) -> tuple[int, int]:
+        return _get_image_dimensions(self.frames[0])
+
+
+def _format_k3_timestamp(timestamp: float, mode: str) -> str:
+    total_seconds = max(0, int(timestamp))
+    milliseconds = int((max(0.0, timestamp) % 1) * 1000)
+    hours = (total_seconds // 3600) % 24
+    minutes = (total_seconds // 60) % 60
+    seconds = total_seconds % 60
+    if mode == "hh:mm:ss.fff":
+        return f"{hours:02d}:{minutes:02d}:{seconds:02d}.{milliseconds:03d}"
+    if mode == "mm:ss.fff":
+        return f"{(total_seconds // 60) % 60:02d}:{seconds:02d}.{milliseconds:03d}"
+    if mode == "mm:ss":
+        return f"{(total_seconds // 60) % 60:02d}:{seconds:02d}"
+    raise ValueError(f"Invalid Kimi-K3 timestamp mode: {mode}")
+
+
+def _video_frame_to_chw(frame):
+    if isinstance(frame, np.ndarray):
+        frame = torch.from_numpy(frame)
+    if isinstance(frame, torch.Tensor):
+        if frame.ndim != 3:
+            raise ValueError(f"Expected a 3D video frame, got shape {frame.shape}.")
+        if frame.shape[-1] in (1, 3, 4) and frame.shape[0] not in (1, 3, 4):
+            frame = frame.permute(2, 0, 1)
+        return frame.contiguous()
+    if isinstance(frame, Image.Image):
+        return frame
+    raise TypeError(f"Unsupported Kimi-K3 video frame type: {type(frame)}")
+
+
+def _split_k3_video(
+    video,
+    media_proc_cfg: dict,
+    source_index: int,
+) -> list[_KimiK3VisualItem]:
+    total_frames = len(video)
+    if total_frames <= 0:
+        raise ValueError("Kimi-K3 video input must contain at least one frame.")
+
+    avg_fps = float(getattr(video, "avg_fps", 0) or 0)
+    if avg_fps <= 0:
+        raise ValueError("Kimi-K3 video input must report a positive frame rate.")
+
+    sample_fps = min(float(media_proc_cfg.get("sample_fps", 8.0)), avg_fps)
+    sampled_nframes = max(round(total_frames * sample_fps / avg_fps), 1)
+    max_frames = media_proc_cfg.get("max_num_frames_each_video")
+    if max_frames is not None:
+        sampled_nframes = min(sampled_nframes, max(1, int(max_frames)))
+    sampled_nframes = min(sampled_nframes, total_frames)
+
+    frame_indices = (
+        np.linspace(0, total_frames - 1, sampled_nframes).round().astype(int).tolist()
+    )
+    if hasattr(video, "get_frames_as_tensor"):
+        decoded_frames = video.get_frames_as_tensor(frame_indices)
+    elif hasattr(video, "get_frames_at"):
+        decoded_frames = video.get_frames_at(frame_indices)
+    else:
+        decoded_frames = [video[index] for index in frame_indices]
+    frames = [_video_frame_to_chw(frame) for frame in decoded_frames]
+
+    temporal_merge = int(media_proc_cfg.get("temporal_merge_kernel_size", 4))
+    if temporal_merge < 1 or temporal_merge > 4:
+        raise ValueError("Kimi-K3 temporal_merge_kernel_size must be between 1 and 4.")
+
+    per_frame_limit = int(
+        media_proc_cfg.get("in_patch_limit_each_frame")
+        or media_proc_cfg["in_patch_limit"]
+    )
+    total_patch_limit = media_proc_cfg.get("in_patch_limit_video")
+    if total_patch_limit is not None:
+        per_frame_limit = min(
+            per_frame_limit,
+            max(1, round(int(total_patch_limit) / sampled_nframes)),
+        )
+
+    timestamp_mode = media_proc_cfg.get("timestamp_mode", "hh:mm:ss.fff")
+    chunks = []
+    for start in range(0, sampled_nframes, temporal_merge):
+        chunks.append(
+            _KimiK3VisualItem(
+                media_type="video",
+                frames=tuple(frames[start : start + temporal_merge]),
+                source_index=source_index,
+                in_patch_limit=per_frame_limit,
+                timestamp_text=_format_k3_timestamp(
+                    frame_indices[start] / avg_fps, timestamp_mode
+                ),
+            )
+        )
+    return chunks
+
+
 def _expand_k3_image_prompt_token_ids(
     input_ids: Union[List[int], torch.Tensor],
     image_token_id: int,
@@ -121,6 +229,62 @@ def _expand_k3_image_prompt_token_ids(
     return torch.tensor(output, dtype=torch.long).unsqueeze(0)
 
 
+def _expand_k3_visual_prompt_token_ids(
+    input_ids: Union[List[int], torch.Tensor],
+    image_token_id: int,
+    visual_items: list[_KimiK3VisualItem],
+    resize_configs: list[dict],
+    tokenizer,
+) -> torch.Tensor:
+    """Replace each source-media placeholder with its MoonViT grid(s)."""
+    if len(visual_items) != len(resize_configs):
+        raise ValueError("Expected one resize config for each Kimi-K3 visual item.")
+
+    if isinstance(input_ids, torch.Tensor):
+        input_ids = input_ids.detach().flatten().cpu().numpy()
+    input_ids = np.asarray(input_ids, dtype=np.int64)
+
+    groups: list[list[tuple[_KimiK3VisualItem, dict]]] = []
+    for item, config in zip(visual_items, resize_configs):
+        if item.source_index == len(groups):
+            groups.append([])
+        elif item.source_index != len(groups) - 1:
+            raise ValueError("Kimi-K3 visual items are not ordered by source media.")
+        groups[item.source_index].append((item, config))
+
+    placeholder_count = int(np.count_nonzero(input_ids == image_token_id))
+    if placeholder_count != len(groups):
+        raise ValueError(
+            f"Expected {len(groups)} visual placeholder token(s), "
+            f"found {placeholder_count}."
+        )
+
+    output = []
+    source_index = 0
+    for token_id in input_ids:
+        if token_id != image_token_id:
+            output.append(int(token_id))
+            continue
+
+        group = groups[source_index]
+        if group[0][0].media_type == "image" and len(group) != 1:
+            raise ValueError("A Kimi-K3 image source must produce exactly one grid.")
+        for item, config in group:
+            if item.media_type == "image":
+                width, height = item.size
+                media_prefix = f"<|media_begin|>image {width}x{height}<|media_content|>"
+            else:
+                media_prefix = (
+                    f"{item.timestamp_text}<|media_begin|>video<|media_content|>"
+                )
+            output.extend(_encode_k3_special_tokens(tokenizer, media_prefix))
+            output.extend([image_token_id] * int(config["num_tokens"]))
+            output.extend(_encode_k3_special_tokens(tokenizer, "<|media_end|>"))
+        source_index += 1
+
+    return torch.tensor(output, dtype=torch.long).unsqueeze(0)
+
+
 def _expand_k3_image_prompt_text(
     input_text: str,
     image_token: str,
@@ -162,6 +326,48 @@ def _k3_to_cuda_chw(image: Union[torch.Tensor, Image.Image]) -> torch.Tensor:
     return image
 
 
+def _gpu_preprocess_k3_visual_items(
+    visual_items: list[_KimiK3VisualItem],
+    resize_configs: list[dict],
+    image_scale: torch.Tensor,
+    image_bias: torch.Tensor,
+    patch_size: int,
+    transparent_bg_config: Optional[dict],
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Preprocess image/video frames and restore each item's temporal grid."""
+    if len(visual_items) != len(resize_configs):
+        raise ValueError("Expected one resize config for each Kimi-K3 visual item.")
+
+    frames = []
+    frame_configs = []
+    for item, config in zip(visual_items, resize_configs):
+        frames.extend(item.frames)
+        frame_configs.extend([config] * len(item.frames))
+
+    pixel_values, frame_grids = _gpu_preprocess_images(
+        frames,
+        frame_configs,
+        image_scale,
+        image_bias,
+        patch_size,
+        to_chw=_k3_to_cuda_chw,
+        post_resize=lambda x: _fill_transparent_bg(x, transparent_bg_config),
+    )
+
+    grids = []
+    frame_index = 0
+    for item in visual_items:
+        item_grids = frame_grids[frame_index : frame_index + len(item.frames)]
+        frame_index += len(item.frames)
+        if len(item_grids) == 0 or not torch.all(item_grids[:, 0] == 1):
+            raise ValueError("Expected one spatial MoonViT grid per video frame.")
+        if not torch.all(item_grids[:, 1:] == item_grids[0, 1:]):
+            raise ValueError("Kimi-K3 video frames must share one spatial grid.")
+        grids.append((len(item.frames), *item_grids[0, 1:].tolist()))
+
+    return pixel_values, torch.tensor(grids, dtype=torch.int64)
+
+
 class KimiK3GPUProcessorWrapper(KimiGPUProcessorWrapper):
     def __init__(self, hf_processor, image_token, image_token_id, config):
         self.preprocess_config = config
@@ -181,6 +387,21 @@ class KimiK3GPUProcessorWrapper(KimiGPUProcessorWrapper):
 
     def preprocess_fingerprint_payload(self):
         return self.preprocess_config
+
+    def _normalize_visual_items(self, images) -> list[_KimiK3VisualItem]:
+        return [
+            (
+                image
+                if isinstance(image, _KimiK3VisualItem)
+                else _KimiK3VisualItem(
+                    media_type="image",
+                    frames=(image,),
+                    source_index=index,
+                    in_patch_limit=self._in_patch_limit,
+                )
+            )
+            for index, image in enumerate(images or [])
+        ]
 
     def _prepare_input_ids(
         self, input_text, resize_configs, original_input_ids, image_sizes
@@ -203,10 +424,58 @@ class KimiK3GPUProcessorWrapper(KimiGPUProcessorWrapper):
         original_input_ids = kwargs.pop("sglang_original_input_ids", None)
         if images and torch.cuda.is_available():
             return self._gpu_call(text, images, original_input_ids)
+        if images and any(
+            isinstance(image, _KimiK3VisualItem) and image.media_type == "video"
+            for image in images
+        ):
+            raise RuntimeError("Kimi-K3 video preprocessing requires CUDA.")
         return self._cpu_call(text, images, original_input_ids, **kwargs)
 
     def _gpu_call(self, text, images, original_input_ids=None):
         input_text = text[0] if isinstance(text, list) else text
+
+        if any(isinstance(image, _KimiK3VisualItem) for image in images):
+            visual_items = self._normalize_visual_items(images)
+            resize_configs = []
+            for item in visual_items:
+                width, height = item.size
+                resize_configs.append(
+                    navit_resize_config(
+                        width,
+                        height,
+                        self._patch_size,
+                        self._merge_kernel_size,
+                        item.in_patch_limit,
+                        self._patch_limit_on_one_side,
+                        self._fixed_output_tokens,
+                    )
+                )
+
+            if original_input_ids is None:
+                original_input_ids = _encode_k3_special_tokens(
+                    self._hf_processor.tokenizer, input_text
+                )
+            input_ids = _expand_k3_visual_prompt_token_ids(
+                original_input_ids,
+                self._image_token_id,
+                visual_items,
+                resize_configs,
+                self._hf_processor.tokenizer,
+            )
+            image_scale, image_bias = self._get_gpu_norm_tensors()
+            pixel_values, grid_thws = _gpu_preprocess_k3_visual_items(
+                visual_items,
+                resize_configs,
+                image_scale,
+                image_bias,
+                self._patch_size,
+                self._transparent_bg_config,
+            )
+            return {
+                "input_ids": input_ids,
+                "pixel_values": pixel_values,
+                "image_grid_thw": grid_thws,
+            }
 
         resize_configs = []
         image_sizes = []
@@ -401,6 +670,28 @@ class KimiK3ImageProcessor(
         )
         super().__init__(hf_config, server_args, processor, *args, **kwargs)
         self.mm_tokens = mm_tokens
+        self.media_proc_cfg = dict(_processor.media_processor.media_proc_cfg)
+
+    @staticmethod
+    def _resolve_visual_modalities(request_obj, image_count, video_count):
+        modalities = []
+        for modality in getattr(request_obj, "modalities", None) or []:
+            if isinstance(modality, list):
+                modalities.extend(modality)
+            else:
+                modalities.append(modality)
+
+        if not modalities:
+            return ["image"] * image_count + ["video"] * video_count
+        if (
+            any(modality not in ("image", "video") for modality in modalities)
+            or modalities.count("image") != image_count
+            or modalities.count("video") != video_count
+        ):
+            raise ValueError(
+                "Kimi-K3 media order does not match the supplied image/video data."
+            )
+        return modalities
 
     def _should_defer_gpu_preprocessing(self, images) -> bool:
         """
@@ -663,11 +954,22 @@ class KimiK3ImageProcessor(
         self, image_data, input_text, request_obj, **kwargs
     ):
         """Compatibility path for precomputed inputs and lightweight test stubs."""
+        image_data = list(image_data or [])
+        video_data = list(getattr(request_obj, "video_data", None) or [])
         expected_image_count = len(image_data or [])
         placeholder_count = self.count_image_placeholders(
             input_text, self.mm_tokens.image_token_id
         )
-        if placeholder_count is not None:
+        if video_data:
+            base_output = await self.fast_load_mm_data(
+                prompt=input_text,
+                image_data=image_data,
+                video_data=video_data,
+                multimodal_tokens=self.mm_tokens,
+                discard_alpha_channel=False,
+                input_ids=input_text if placeholder_count is not None else None,
+            )
+        elif placeholder_count is not None:
             base_output = await self.fast_load_mm_data(
                 prompt=input_text,
                 image_data=image_data,
@@ -682,11 +984,52 @@ class KimiK3ImageProcessor(
                 multimodal_tokens=self.mm_tokens,
                 discard_alpha_channel=False,
             )
-        if len(base_output.images) != expected_image_count:
+        loaded_images = list(getattr(base_output, "images", None) or [])
+        loaded_videos = list(getattr(base_output, "videos", None) or [])
+        if len(loaded_images) != expected_image_count or len(loaded_videos) != len(
+            video_data
+        ):
             raise ValueError(
-                "Kimi image placeholders must map one-to-one to image data: "
-                f"expected {expected_image_count}, loaded {len(base_output.images)}"
+                "Kimi visual placeholders must map one-to-one to source media: "
+                f"expected {expected_image_count} image(s) and {len(video_data)} "
+                f"video(s), loaded {len(loaded_images)} image(s) and "
+                f"{len(loaded_videos)} video(s)"
             )
+
+        if video_data:
+            modalities = self._resolve_visual_modalities(
+                request_obj, expected_image_count, len(video_data)
+            )
+            image_iter = iter(loaded_images)
+            video_iter = iter(loaded_videos)
+            visual_items = []
+            for source_index, modality in enumerate(modalities):
+                if modality == "image":
+                    visual_items.append(
+                        _KimiK3VisualItem(
+                            media_type="image",
+                            frames=(next(image_iter),),
+                            source_index=source_index,
+                            in_patch_limit=int(self.media_proc_cfg["in_patch_limit"]),
+                        )
+                    )
+                    continue
+
+                video = next(video_iter)
+                try:
+                    visual_items.extend(
+                        _split_k3_video(video, self.media_proc_cfg, source_index)
+                    )
+                finally:
+                    close = getattr(video, "close", None)
+                    if close is not None:
+                        close()
+
+            # K3 uses the image placeholder id for every MoonViT grid. The T
+            # dimension distinguishes temporal video chunks from still images.
+            base_output.images = visual_items
+            base_output.videos = []
+
         if self._should_defer_gpu_preprocessing(base_output.images):
             return self._build_deferred_output(base_output)
         mm_items, input_ids, _ = await self.process_and_combine_mm_data_async(
@@ -713,24 +1056,47 @@ class KimiK3ImageProcessor(
         *args,
         **kwargs,
     ):
-        if request_obj.video_data or kwargs.get("audio_data"):
-            raise ValueError("Kimi-K3 supports image input only")
+        audio_data = kwargs.get("audio_data") or getattr(
+            request_obj, "audio_data", None
+        )
+        if audio_data:
+            raise ValueError(
+                "Kimi-K3 supports image and video input (without audio track) only"
+            )
 
+        image_data = list(image_data or [])
+        video_data = list(getattr(request_obj, "video_data", None) or [])
         expected_image_count = len(image_data or [])
+        expected_media_count = expected_image_count + len(video_data)
         placeholder_count = self.count_image_placeholders(
             input_text, self.mm_tokens.image_token_id
         )
         if placeholder_count is not None:
-            if placeholder_count != expected_image_count:
+            if placeholder_count != expected_media_count:
                 raise ValueError(
-                    "Kimi image placeholders must map one-to-one to image data: "
-                    f"expected {expected_image_count}, found {placeholder_count} token(s)"
+                    "Kimi visual placeholders must map one-to-one to source media: "
+                    f"expected {expected_media_count}, found {placeholder_count} "
+                    "token(s)"
                 )
+        elif video_data:
+            placeholder_count = input_text.count(self.mm_tokens.image_token)
+            if placeholder_count != expected_media_count:
+                raise ValueError(
+                    "Kimi visual placeholders must map one-to-one to source media: "
+                    f"expected {expected_media_count}, found {placeholder_count}."
+                )
+
+        if video_data:
+            self._resolve_visual_modalities(
+                request_obj, expected_image_count, len(video_data)
+            )
         if (
-            any(self._is_preprocessed_input(item) for item in image_data)
+            video_data
+            or any(self._is_preprocessed_input(item) for item in image_data)
             or not self.mm_preprocess_cache.enabled
         ):
-            # 1. keep preprocessed inputs and cache-off requests on the legacy path
+            # 1. keep video, preprocessed inputs, and cache-off requests on the
+            # uncached path. Image artifacts remain image-only.
             return await self._process_mm_data_uncached(
                 image_data, input_text, request_obj, **kwargs
             )

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -990,6 +990,36 @@ class ServingChatTestCase(unittest.TestCase):
         self.assertEqual(result.prompt_ids, [7, 8, 9])
         self.assertEqual(result.image_data[0].url, "image-1")
 
+    def test_kimi_k3_routes_video_through_one_structural_media_placeholder(self):
+        self.template_manager.chat_template_name = None
+        self.chat.chat_encoding_spec = "kimi_k3"
+        self.tm.model_config.is_multimodal = True
+        self.tm.tokenizer.apply_chat_template.return_value = [7, 99, 8]
+        request = ChatCompletionRequest(
+            model="x",
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "video_url",
+                            "video_url": {"url": "https://example.com/video.mp4"},
+                        },
+                        {"type": "text", "text": "Describe it."},
+                    ],
+                }
+            ],
+        )
+
+        result = self.chat._process_messages(request, is_multimodal=True)
+
+        call = self.tm.tokenizer.apply_chat_template.call_args
+        self.assertEqual(call.kwargs["image_prompts"], ["<|media_pad|>"])
+        self.assertEqual(call.args[0][0]["content"][0]["type"], "image_url")
+        self.assertIsNone(result.image_data)
+        self.assertEqual(result.video_data, ["https://example.com/video.mp4"])
+        self.assertEqual(result.modalities, ["video"])
+
     def test_kimi_k3_neutralizes_text_only_assistant_history(self):
         self.template_manager.chat_template_name = None
         self.chat.chat_encoding_spec = "kimi_k3"

--- a/test/registered/unit/models/test_kimi_k25.py
+++ b/test/registered/unit/models/test_kimi_k25.py
@@ -26,6 +26,7 @@ from sglang.srt.managers.schedule_batch import (
     MultimodalProcessorOutput,
 )
 from sglang.srt.models.kimi_k3 import KimiK3ForConditionalGeneration
+from sglang.srt.models.kimi_k3_vl import Learnable2DInterpPosEmbDividedFixed
 from sglang.srt.models.kimi_k25 import (
     KimiK25ForConditionalGeneration,
     mm_projection_auto,
@@ -53,6 +54,10 @@ from sglang.srt.multimodal.processors.kimi_k3 import (
     KimiK3ImageProcessor,
     _expand_k3_image_prompt_text,
     _expand_k3_image_prompt_token_ids,
+    _expand_k3_visual_prompt_token_ids,
+    _gpu_preprocess_k3_visual_items,
+    _KimiK3VisualItem,
+    _split_k3_video,
 )
 from sglang.srt.multimodal.processors.kimi_k25 import (
     KimiGPUProcessorWrapper,
@@ -581,14 +586,51 @@ def test_kimi_lazy_vmm_cache_hit_uses_proxy_consumer_count():
     proxy.acknowledge_consumption.assert_called_once_with(2)
 
 
+def test_kimi_k3_temporal_position_embedding_follows_weight_device():
+    position_embedding = Learnable2DInterpPosEmbDividedFixed(
+        height=2,
+        width=2,
+        num_frames=2,
+        dim=4,
+    )
+    position_embedding.weight = nn.Parameter(position_embedding.weight.to("meta"))
+
+    output = position_embedding.position_embeddings(torch.tensor([[2, 2, 2]]))
+
+    assert output.device.type == "meta"
+
+
 class _Tokenizer:
     def encode(self, text, allowed_special=None):
         tokens = {
             "<|media_begin|>image 1536x1024<|media_content|>": [10, 11],
             "<|media_begin|>image 1024x1536<|media_content|>": [12, 13],
+            "00:00:00.000<|media_begin|>video<|media_content|>": [20, 21],
+            "00:00:01.000<|media_begin|>video<|media_content|>": [22, 23],
             "<|media_end|>": [14],
         }
         return tokens.get(text, [])
+
+
+class _FakeVideo:
+    def __init__(self, frame_count=10, fps=5.0):
+        self.frames = (
+            torch.arange(frame_count * 6 * 8 * 3)
+            .remainder(256)
+            .to(torch.uint8)
+            .reshape(frame_count, 6, 8, 3)
+        )
+        self.avg_fps = fps
+        self.closed = False
+
+    def __len__(self):
+        return len(self.frames)
+
+    def get_frames_as_tensor(self, indices):
+        return self.frames[indices]
+
+    def close(self):
+        self.closed = True
 
 
 class _HFProcessor:
@@ -693,6 +735,104 @@ def test_kimi_k3_expands_image_placeholders_with_original_dimensions():
     )
 
     assert actual.tolist() == [[1, 10, 11, 99, 99, 99, 14, 2, 12, 13, 99, 99, 14, 3]]
+
+
+def test_kimi_k3_expands_one_video_placeholder_into_timestamped_chunks():
+    image = Image.new("RGB", (1536, 1024))
+    frame = torch.zeros(3, 6, 8, dtype=torch.uint8)
+    visual_items = [
+        _KimiK3VisualItem("image", (image,), 0, 16384),
+        _KimiK3VisualItem("video", (frame,) * 4, 1, 8192, "00:00:00.000"),
+        _KimiK3VisualItem("video", (frame,) * 4, 1, 8192, "00:00:01.000"),
+    ]
+
+    actual = _expand_k3_visual_prompt_token_ids(
+        [1, 99, 2, 99, 3],
+        99,
+        visual_items,
+        [{"num_tokens": 3}, {"num_tokens": 2}, {"num_tokens": 2}],
+        _Tokenizer(),
+    )
+
+    assert actual.tolist() == [
+        [
+            1,
+            10,
+            11,
+            99,
+            99,
+            99,
+            14,
+            2,
+            20,
+            21,
+            99,
+            99,
+            14,
+            22,
+            23,
+            99,
+            99,
+            14,
+            3,
+        ]
+    ]
+
+
+def test_kimi_k3_samples_and_splits_video_into_four_frame_grids():
+    video = _FakeVideo(frame_count=10, fps=5.0)
+    config = {
+        "sample_fps": 4,
+        "max_num_frames_each_video": None,
+        "temporal_merge_kernel_size": 4,
+        "in_patch_limit": 100,
+        "in_patch_limit_each_frame": 20,
+        "in_patch_limit_video": 80,
+        "timestamp_mode": "hh:mm:ss.fff",
+    }
+
+    chunks = _split_k3_video(video, config, source_index=0)
+
+    assert [len(chunk.frames) for chunk in chunks] == [4, 4]
+    assert [chunk.timestamp_text for chunk in chunks] == [
+        "00:00:00.000",
+        "00:00:01.000",
+    ]
+    assert all(chunk.in_patch_limit == 10 for chunk in chunks)
+    assert all(frame.shape == (3, 6, 8) for chunk in chunks for frame in chunk.frames)
+
+
+def test_kimi_k3_preprocess_preserves_temporal_grid_dimension():
+    frames = tuple(torch.full((3, 14, 14), i, dtype=torch.uint8) for i in range(4))
+    item = _KimiK3VisualItem(
+        "video",
+        frames,
+        source_index=0,
+        in_patch_limit=100,
+        timestamp_text="00:00:00.000",
+    )
+    resize_config = {
+        "new_height": 14,
+        "new_width": 14,
+        "pad_height": 14,
+        "pad_width": 14,
+    }
+
+    with patch(
+        "sglang.srt.multimodal.processors.kimi_k3._k3_to_cuda_chw",
+        side_effect=lambda frame: frame,
+    ):
+        pixel_values, grid_thw = _gpu_preprocess_k3_visual_items(
+            [item],
+            [resize_config],
+            torch.full((1, 3, 1, 1), 1 / 255),
+            torch.zeros(1, 3, 1, 1),
+            patch_size=14,
+            transparent_bg_config=None,
+        )
+
+    assert pixel_values.shape == (16, 3, 14, 14)
+    assert grid_thw.tolist() == [[4, 2, 2]]
 
 
 def test_kimi_k3_cpu_prompt_uses_the_same_media_contract():
@@ -1378,7 +1518,7 @@ def test_kimi_k3_rejects_silently_dropped_images():
     processor.mm_preprocess_cache = MultimodalPreprocessCache(0)
     processor.load_mm_data = AsyncMock(return_value=SimpleNamespace(images=[object()]))
 
-    with pytest.raises(ValueError, match="expected 2, loaded 1"):
+    with pytest.raises(ValueError, match=r"expected 2 image\(s\).*loaded 1 image\(s\)"):
         asyncio.run(
             processor.process_mm_data_async(
                 image_data=["image-1", "image-2"],
@@ -1417,6 +1557,52 @@ def test_kimi_k3_uses_token_ids_to_preserve_media_boundaries():
     processor.load_mm_data.assert_not_awaited()
 
 
+def test_kimi_k3_loads_mixed_media_and_preserves_source_order():
+    processor = object.__new__(KimiK3ImageProcessor)
+    processor.mm_feature_transport = "cpu"
+    processor.mm_tokens = SimpleNamespace(
+        image_token="<|media_pad|>", image_token_id=99
+    )
+    processor.media_proc_cfg = {
+        "sample_fps": 4,
+        "max_num_frames_each_video": None,
+        "temporal_merge_kernel_size": 4,
+        "in_patch_limit": 100,
+        "in_patch_limit_each_frame": 20,
+        "in_patch_limit_video": 80,
+        "timestamp_mode": "hh:mm:ss.fff",
+    }
+    video = _FakeVideo(frame_count=10, fps=5.0)
+    loaded = SimpleNamespace(
+        images=[object()],
+        videos=[video],
+        input_ids=[1, 99, 2, 99, 3],
+    )
+    processor.fast_load_mm_data = AsyncMock(return_value=loaded)
+    processor.load_mm_data = AsyncMock()
+    processor.process_and_combine_mm_data_async = AsyncMock(
+        return_value=([], torch.tensor([[1, 2]]), None)
+    )
+
+    asyncio.run(
+        processor.process_mm_data_async(
+            image_data=["image-1"],
+            input_text=[1, 99, 2, 99, 3],
+            request_obj=SimpleNamespace(
+                video_data=["video-1"], modalities=["video", "image"]
+            ),
+        )
+    )
+
+    processor.fast_load_mm_data.assert_awaited_once()
+    processor.load_mm_data.assert_not_awaited()
+    assert [item.media_type for item in loaded.images] == ["video", "video", "image"]
+    assert [item.source_index for item in loaded.images] == [0, 0, 1]
+    assert [len(item.frames) for item in loaded.images] == [4, 4, 1]
+    assert loaded.videos == []
+    assert video.closed
+
+
 def test_kimi_k3_rejects_tokenized_placeholder_mismatch():
     processor = object.__new__(KimiK3ImageProcessor)
     processor.mm_tokens = SimpleNamespace(image_token_id=99)
@@ -1436,25 +1622,18 @@ def test_kimi_k3_rejects_tokenized_placeholder_mismatch():
     processor.load_mm_data.assert_not_awaited()
 
 
-@pytest.mark.parametrize(
-    ("request_obj", "extra_kwargs"),
-    [
-        (SimpleNamespace(video_data=["video"]), {}),
-        (SimpleNamespace(video_data=None), {"audio_data": ["audio"]}),
-    ],
-)
-def test_kimi_k3_rejects_unsupported_modalities(request_obj, extra_kwargs):
+def test_kimi_k3_rejects_audio_input():
     processor = object.__new__(KimiK3ImageProcessor)
     processor.mm_tokens = Mock()
     processor.load_mm_data = AsyncMock()
 
-    with pytest.raises(ValueError, match="supports image input only"):
+    with pytest.raises(ValueError, match=r"video input \(without audio track\) only"):
         asyncio.run(
             processor.process_mm_data_async(
                 image_data=[],
                 input_text="prompt",
-                request_obj=request_obj,
-                **extra_kwargs,
+                request_obj=SimpleNamespace(video_data=None),
+                audio_data=["audio"],
             )
         )
     processor.load_mm_data.assert_not_awaited()

--- a/test/registered/unit/models/test_kimi_k3_vision.py
+++ b/test/registered/unit/models/test_kimi_k3_vision.py
@@ -537,7 +537,7 @@ def test_kimi_k3_preprocesses_only_dp_owner_images(monkeypatch):
             offsets=[(index, index)],
             feature=torch.full((3, 2, 2), index, dtype=torch.uint8),
             model_specific_data={
-                "image_grid_thw": torch.tensor([[1, 1, 1]]),
+                "image_grid_thw": torch.tensor([[1, 1, index + 1]]),
                 DEFERRED_PREPROCESSING_KEY: deferred_config,
             },
         )
@@ -547,7 +547,11 @@ def test_kimi_k3_preprocesses_only_dp_owner_images(monkeypatch):
 
     def fake_preprocess(images, resize_configs, *args, **kwargs):
         calls.append([int(image[0, 0, 0]) for image in images])
-        return torch.tensor([[float(calls[-1][0]), 0.0]]), torch.tensor([[1, 1, 1]])
+        image_index = calls[-1][0]
+        return (
+            torch.tensor([[float(image_index), 0.0]] * (image_index + 1)),
+            torch.tensor([[1, 1, image_index + 1]]),
+        )
 
     # Configured TP size (the IPC consumer count) comes from the published
     # bags; the live topology is forced through the context's own override.
@@ -566,7 +570,7 @@ def test_kimi_k3_preprocesses_only_dp_owner_images(monkeypatch):
 
     assert calls == [[1]]
     assert one.dtype == torch.float32
-    assert one.tolist() == [[1.0, 0.0]]
+    assert one.tolist() == [[1.0, 0.0], [1.0, 0.0]]
 
 
 def test_kimi_k3_scheduler_leaves_feature_placement_to_dp_owner():


### PR DESCRIPTION
## Motivation

Kimi-K3 has a temporal MoonViT3d vision stack, but its SGLang multimodal processor currently handles still images only. Although the OpenAI-compatible protocol can carry `video_url` content, Kimi-K3 requests cannot route decoded video frames through the checkpoint's media processor and vision tower.

This adds video input support for Kimi-K3 while preserving the existing image path. Video frames are processed; audio tracks are not.

The implementation targets the current Kimi multimodal pipeline. This is related to the earlier Kimi-K2.5 attempt in #21023, which was closed after that older processor pipeline was replaced.

## Modifications

- accept Kimi-K3 `video_url` inputs from server-accessible URLs, local paths, and Base64 data URLs
- sample frames with the checkpoint media configuration and split them into timestamped temporal chunks for MoonViT3d
- preserve mixed image/video ordering and enforce one-to-one visual placeholder mapping
- reuse the Kimi image placeholder token while carrying temporal `grid_thw` metadata through preprocessing and model execution
- map image grids globally for encoder-DP execution
- keep image artifact caching unchanged; video requests intentionally use the uncached path
- expose video token usage in non-streaming Chat Completions responses
- document video request examples and the no-audio limitation
- add focused OpenAI protocol, processor, model, and DP regression tests

## Accuracy Tests

Unit tests:

```text
pytest test/registered/unit/entrypoints/openai/test_serving_chat.py \
       test/registered/unit/models/test_kimi_k25.py \
       test/registered/unit/models/test_kimi_k3_vision.py

162 passed
```

Real-model smoke tests used Kimi-K3 with TP8 on one 8x NVIDIA B300 node:

- video URL, local path, and Base64 data URL inputs
- mixed image/video input ordering
- Chat Completions streaming
- Responses API
- image-only regression

A 5.16 MB MP4 produced HTTP 200 and correctly identified one restaurant scene with roughly six people dining and conversing. The request used 43,969 prompt tokens, including 43,200 visual tokens.

An extracted 49.4 KB frame produced HTTP 200 and correctly described the two foreground diners. The request used 1,282 prompt tokens, including 1,170 image tokens.

## Speed Tests and Profiling

There is no before/after video latency comparison because Kimi-K3 video requests were unsupported before this change. Cold end-to-end measurements on the TP8 B300 deployment, with `reasoning_effort=low`, `max_tokens=256`, and no cached prompt tokens:

| Input | End-to-end latency | Completion tokens |
|---|---:|---:|
| 5.16 MB MP4 | 6.361 s | 115 |
| 49.4 KB image | 1.343 s | 127 |

The text path is unchanged. The existing image artifact-cache path remains active for image-only requests; videos bypass it because the cache currently stores image artifacts only.

## Limitations

- video audio tracks are not processed
- separate audio input is not added by this PR
- video preprocessing intentionally bypasses the image artifact cache

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32139310022](https://github.com/sgl-project/sglang/actions/runs/32139310022)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32139309596](https://github.com/sgl-project/sglang/actions/runs/32139309596)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->