### PR TITLE
[GDN] Route promoted decode and verify rows through Cake

### DIFF
--- a/python/sglang/srt/layers/attention/linear/gdn_backend.py
+++ b/python/sglang/srt/layers/attention/linear/gdn_backend.py
@@ -477,6 +477,7 @@ class GDNAttnBackend(MambaAttnBackendBase):
             ssm_states=ssm_states,
             cache_indices=cache_indices,
             query_start_loc=query_start_loc,
+            layer_id=layer.layer_id,
         )
 
         self._track_mamba_state_decode(
@@ -683,6 +684,7 @@ class GDNAttnBackend(MambaAttnBackendBase):
                     intermediate_state_indices=intermediate_state_indices,
                     cache_steps=forward_batch.spec_info.draft_token_num,
                     retrieve_parent_token=retrieve_parent_token,
+                    layer_id=layer.layer_id,
                 )
         else:
             g, beta = fused_gdn_gating(layer.A_log, a, b, layer.dt_bias)

--- a/python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py
@@ -38,6 +38,8 @@ _flashinfer_chunk_gated_delta_rule = None
 _flashinfer_gated_delta_rule_mtp = None
 _flashinfer_gated_delta_rule_decode = None
 _flashinfer_gated_delta_rule_mtp_bf16 = None
+_cake_gdn_decode_api = None
+_cake_gdn_decode_api_checked = False
 
 
 def maybe_build_flashinfer_checkpoint_plan(
@@ -128,6 +130,21 @@ def is_flashinfer_gdn_prefill_available() -> bool:
     return bool(available and prefill_fn is not None)
 
 
+def _get_cake_gdn_decode_api():
+    """Return the optional public Cake GDN loader without compiling a kernel."""
+
+    global _cake_gdn_decode_api, _cake_gdn_decode_api_checked
+    if not _cake_gdn_decode_api_checked:
+        _cake_gdn_decode_api_checked = True
+        try:
+            from flashinfer.jit import cake_gdn_noncp_decode
+
+            _cake_gdn_decode_api = cake_gdn_noncp_decode
+        except ImportError:
+            _cake_gdn_decode_api = None
+    return _cake_gdn_decode_api
+
+
 # ---------------------------------------------------------------------------
 # Kernel implementation
 # ---------------------------------------------------------------------------
@@ -164,6 +181,24 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
         sm_major = torch.cuda.get_device_capability()[0]
         self.use_state_pool = sm_major >= 10
         self.supports_target_verify = sm_major in (9, 10)
+        self._cake_gdn_api = None
+        self._cake_gdn_arch = None
+        self._cake_gdn_entries = {}
+        self._cake_gdn_outputs = {}
+        self._cake_gdn_logged_routes = set()
+
+        if self.use_state_pool:
+            cake_gdn_api = _get_cake_gdn_decode_api()
+            if cake_gdn_api is not None:
+                capability = torch.cuda.get_device_capability()
+                try:
+                    self._cake_gdn_arch = cake_gdn_api.arch_for_compute_capability(
+                        *capability
+                    )
+                except cake_gdn_api.CakeGDNUnsupportedError:
+                    pass
+                else:
+                    self._cake_gdn_api = cake_gdn_api
 
         if sm_major == 9 and self._prefill_fn is None:
             raise RuntimeError("FlashInfer GDN prefill kernel is unavailable.")
@@ -206,6 +241,218 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
 
         logger.info("Using FlashInfer GDN kernels")
 
+    @staticmethod
+    def _is_cake_strided_layout(
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        state: torch.Tensor,
+        *,
+        batch_size: int,
+        seq_len: int,
+        num_q_heads: int,
+        num_v_heads: int,
+    ) -> bool:
+        """Match the dense-inner, runtime-strided public Cake tensor ABI."""
+
+        return (
+            tuple(q.shape) == (batch_size, seq_len, num_q_heads, 128)
+            and tuple(k.shape) == (batch_size, seq_len, num_q_heads, 128)
+            and tuple(v.shape) == (batch_size, seq_len, num_v_heads, 128)
+            and tuple(a.shape) == (batch_size, seq_len, num_v_heads)
+            and tuple(b.shape) == (batch_size, seq_len, num_v_heads)
+            and state.ndim == 4
+            and tuple(state.shape[1:]) == (num_v_heads, 128, 128)
+            and tuple(q.stride()[2:]) == (128, 1)
+            and tuple(k.stride()[2:]) == (128, 1)
+            and tuple(v.stride()[2:]) == (128, 1)
+            and q.stride(1) >= num_q_heads * 128
+            and k.stride(1) >= num_q_heads * 128
+            and v.stride(1) >= num_v_heads * 128
+            and q.stride(0) >= seq_len * q.stride(1)
+            and k.stride(0) >= seq_len * k.stride(1)
+            and v.stride(0) >= seq_len * v.stride(1)
+            and a.stride(2) == 1
+            and b.stride(2) == 1
+            and a.stride(1) >= num_v_heads
+            and b.stride(1) >= num_v_heads
+            and a.stride(0) >= seq_len * a.stride(1)
+            and b.stride(0) >= seq_len * b.stride(1)
+            and tuple(state.stride()[1:]) == (128 * 128, 128, 1)
+            and state.stride(0) >= num_v_heads * 128 * 128
+        )
+
+    def _cake_output_buffer(
+        self,
+        q: torch.Tensor,
+        *,
+        layer_id: int,
+        batch_size: int,
+        seq_len: int,
+        num_v_heads: int,
+    ) -> torch.Tensor:
+        stream_handle = int(torch.cuda.current_stream(q.device).cuda_stream)
+        key = (
+            q.device.index,
+            stream_handle,
+            layer_id,
+            batch_size,
+            seq_len,
+            num_v_heads,
+        )
+        output = self._cake_gdn_outputs.get(key)
+        if output is None:
+            if torch.cuda.is_current_stream_capturing():
+                raise RuntimeError(
+                    "Cake GDN output buffer was not prepared before CUDA Graph capture"
+                )
+            output = torch.empty(
+                batch_size,
+                seq_len,
+                num_v_heads,
+                128,
+                dtype=torch.bfloat16,
+                device=q.device,
+            )
+            self._cake_gdn_outputs[key] = output
+        return output
+
+    def _try_cake_decode(
+        self,
+        *,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        state: torch.Tensor,
+        state_indices: torch.Tensor,
+        A_log: torch.Tensor,
+        a: torch.Tensor,
+        dt_bias: torch.Tensor,
+        b: torch.Tensor,
+        layer_id: Optional[int],
+        disable_state_update: bool,
+        intermediate_state: Optional[torch.Tensor],
+        cache_steps: int,
+    ) -> Optional[torch.Tensor]:
+        """Launch an exact promoted Cake row, or return None when unsupported."""
+
+        if self._cake_gdn_api is None or layer_id is None:
+            return None
+        batch_size, seq_len, num_q_heads, head_size = q.shape
+        num_v_heads = v.shape[2]
+        tensors = (q, k, v, state, state_indices, A_log, a, dt_bias, b)
+        if (
+            head_size != 128
+            or v.shape[-1] != 128
+            or any(tensor.device != q.device for tensor in tensors)
+            or any(tensor.dtype != torch.bfloat16 for tensor in (q, k, v, state, a, b))
+            or A_log.dtype != torch.float32
+            or dt_bias.dtype != torch.float32
+            or tuple(A_log.shape) != (num_v_heads,)
+            or tuple(dt_bias.shape) != (num_v_heads,)
+            or not A_log.is_contiguous()
+            or not dt_bias.is_contiguous()
+            or state_indices.dtype != torch.int32
+            or tuple(state_indices.shape) != (batch_size,)
+            or not state_indices.is_contiguous()
+            or not self._is_cake_strided_layout(
+                q,
+                k,
+                v,
+                a,
+                b,
+                state,
+                batch_size=batch_size,
+                seq_len=seq_len,
+                num_q_heads=num_q_heads,
+                num_v_heads=num_v_heads,
+            )
+        ):
+            return None
+
+        cache_intermediate_states = intermediate_state is not None
+        if cache_intermediate_states:
+            expected_cache_shape = (
+                batch_size,
+                cache_steps,
+                num_v_heads,
+                128,
+                128,
+            )
+            if (
+                tuple(intermediate_state.shape) != expected_cache_shape
+                or intermediate_state.dtype != torch.bfloat16
+                or intermediate_state.device != q.device
+                or not intermediate_state.is_contiguous()
+            ):
+                return None
+
+        try:
+            route = self._cake_gdn_api.select_cake_gdn_decode_variant(
+                arch=self._cake_gdn_arch,
+                batch_size=batch_size,
+                io_dtype="bfloat16",
+                state_dtype="bfloat16",
+                head_size=128,
+                layout="pretranspose",
+                num_k_heads=num_q_heads,
+                num_q_heads=num_q_heads,
+                num_v_heads=num_v_heads,
+                scale=128**-0.5,
+                seq_len=seq_len,
+                use_qk_l2norm=True,
+                strided_inputs=True,
+                disable_state_update=disable_state_update,
+                cache_intermediate_states=cache_intermediate_states,
+                cache_steps=cache_steps,
+            )
+        except self._cake_gdn_api.CakeGDNUnsupportedError:
+            return None
+
+        entry = self._cake_gdn_entries.get(route.variant_name)
+        if entry is None:
+            if torch.cuda.is_current_stream_capturing():
+                raise RuntimeError(
+                    "Cake GDN kernel was not loaded before CUDA Graph capture"
+                )
+            entry = self._cake_gdn_api.load_cake_gdn_kernel(
+                route.variant_name, self._cake_gdn_arch
+            )
+            self._cake_gdn_entries[route.variant_name] = entry
+
+        output = self._cake_output_buffer(
+            q,
+            layer_id=layer_id,
+            batch_size=batch_size,
+            seq_len=seq_len,
+            num_v_heads=num_v_heads,
+        )
+        state_heads = batch_size * num_v_heads
+        tile_v = 128 if state_heads >= 1024 else 64 if state_heads >= 512 else 32
+        entry(
+            q,
+            k,
+            v,
+            state,
+            A_log,
+            a,
+            dt_bias,
+            b,
+            output,
+            intermediate_state if intermediate_state is not None else output,
+            state_indices,
+            state_indices,
+            batch_size * num_v_heads * (128 // tile_v),
+            1,
+            1,
+        )
+        if route.route_id not in self._cake_gdn_logged_routes:
+            self._cake_gdn_logged_routes.add(route.route_id)
+            logger.info("Using %s", route.route_id)
+        return output.view(1, batch_size * seq_len, num_v_heads, 128)
+
     # ---- decode ----
 
     def decode(
@@ -236,6 +483,23 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
         b_fi = b.view(batch_size, 1, num_v_heads)
 
         if self.use_state_pool:
+            output_cake = self._try_cake_decode(
+                q=query_fi,
+                k=key_fi,
+                v=value_fi,
+                state=ssm_states,
+                state_indices=cache_indices,
+                A_log=A_log.detach(),
+                a=a_fi,
+                dt_bias=dt_bias.detach(),
+                b=b_fi,
+                layer_id=kwargs.get("layer_id"),
+                disable_state_update=False,
+                intermediate_state=None,
+                cache_steps=0,
+            )
+            if output_cake is not None:
+                return output_cake
             output_fi, _ = self._decode_fn(
                 q=query_fi,
                 k=key_fi,
@@ -415,6 +679,24 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
             # per-call batch id, while SGLang's speculative state cache is
             # pool-scoped and may include an extra dummy slot.
             intermediate_states_buffer_mtp = intermediate_states_buffer[:batch_size]
+
+        output_cake = self._try_cake_decode(
+            q=query_mtp,
+            k=key_mtp,
+            v=value_mtp,
+            state=ssm_states,
+            state_indices=cache_indices,
+            A_log=A_log.detach(),
+            a=a_mtp,
+            dt_bias=dt_bias.detach(),
+            b=b_mtp,
+            layer_id=kwargs.get("layer_id"),
+            disable_state_update=True,
+            intermediate_state=intermediate_states_buffer_mtp,
+            cache_steps=cache_steps,
+        )
+        if output_cake is not None:
+            return output_cake
 
         output_fi, _ = self._mtp_fn(
             q=query_mtp,

--- a/python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py
@@ -185,6 +185,7 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
         self._cake_gdn_arch = None
         self._cake_gdn_entries = {}
         self._cake_gdn_outputs = {}
+        self._cake_gdn_dt_bias_fp32 = {}
         self._cake_gdn_logged_routes = set()
 
         if self.use_state_pool:
@@ -319,6 +320,27 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
             self._cake_gdn_outputs[key] = output
         return output
 
+    def _cake_fp32_dt_bias(
+        self,
+        dt_bias: torch.Tensor,
+        *,
+        layer_id: int,
+    ) -> torch.Tensor:
+        """Return persistent FP32 model storage prepared before graph capture."""
+
+        if dt_bias.dtype == torch.float32:
+            return dt_bias
+        key = (dt_bias.device.index, layer_id, dt_bias.data_ptr())
+        converted = self._cake_gdn_dt_bias_fp32.get(key)
+        if converted is None:
+            if torch.cuda.is_current_stream_capturing():
+                raise RuntimeError(
+                    "Cake GDN FP32 dt_bias was not prepared before CUDA Graph capture"
+                )
+            converted = dt_bias.detach().float()
+            self._cake_gdn_dt_bias_fp32[key] = converted
+        return converted
+
     def _try_cake_decode(
         self,
         *,
@@ -349,7 +371,7 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
             or any(tensor.device != q.device for tensor in tensors)
             or any(tensor.dtype != torch.bfloat16 for tensor in (q, k, v, state, a, b))
             or A_log.dtype != torch.float32
-            or dt_bias.dtype != torch.float32
+            or dt_bias.dtype not in (torch.bfloat16, torch.float32)
             or tuple(A_log.shape) != (num_v_heads,)
             or tuple(dt_bias.shape) != (num_v_heads,)
             or not A_log.is_contiguous()
@@ -410,6 +432,8 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
             )
         except self._cake_gdn_api.CakeGDNUnsupportedError:
             return None
+
+        dt_bias = self._cake_fp32_dt_bias(dt_bias, layer_id=layer_id)
 
         entry = self._cake_gdn_entries.get(route.variant_name)
         if entry is None:

--- a/python/sglang/test/kits/attention_unittest/attention_methods/gdn_attention.py
+++ b/python/sglang/test/kits/attention_unittest/attention_methods/gdn_attention.py
@@ -55,6 +55,7 @@ class GDNAttentionCase:
     page_size: int
     prefix_lens: tuple[int, ...]
     extend_lens: tuple[int, ...] = ()
+    linear_attn_decode_backend: str | None = None
     linear_attn_prefill_backend: str | None = None
 
     @property
@@ -254,7 +255,7 @@ class MockGDNModelRunner(ModelRunner):
             enable_deterministic_inference=False,
             enable_mis=False,
             linear_attn_backend="triton",
-            linear_attn_decode_backend=None,
+            linear_attn_decode_backend=case.linear_attn_decode_backend,
             linear_attn_prefill_backend=case.linear_attn_prefill_backend,
             max_running_requests=None,
             revision=None,
@@ -863,6 +864,8 @@ def make_gdn_case_with_prefix_lens(
         page_size=case.page_size,
         prefix_lens=prefix_lens,
         extend_lens=extend_lens,
+        linear_attn_decode_backend=case.linear_attn_decode_backend,
+        linear_attn_prefill_backend=case.linear_attn_prefill_backend,
     )
 
 

--- a/test/registered/attention/unittests/gdn/test_flashinfer.py
+++ b/test/registered/attention/unittests/gdn/test_flashinfer.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest import mock
 
 import torch
 
@@ -346,6 +347,84 @@ class TestFlashInferLinearGDNBackendCorrectness(CustomTestCase):
         prefix_lens=(0, 64, 128),
         extend_lens=(64, 65, 129),
     )
+    CAKE_DECODE_CASE = GDNAttentionCase(
+        name="flashinfer_cake_gdn_decode_b4_t1",
+        backend="flashinfer",
+        forward_mode=ForwardMode.DECODE,
+        num_k_heads=16,
+        num_v_heads=32,
+        page_size=16,
+        prefix_lens=(4, 7, 10, 13),
+        linear_attn_decode_backend="flashinfer",
+        linear_attn_prefill_backend="flashinfer",
+    )
+    CAKE_VERIFY_CASE = GDNAttentionCase(
+        name="flashinfer_cake_gdn_verify_b8_t4",
+        backend="flashinfer",
+        forward_mode=ForwardMode.TARGET_VERIFY,
+        num_k_heads=16,
+        num_v_heads=32,
+        page_size=16,
+        prefix_lens=(4, 5, 6, 7, 8, 9, 10, 11),
+        extend_lens=(4,) * 8,
+        linear_attn_decode_backend="flashinfer",
+        linear_attn_prefill_backend="flashinfer",
+    )
+
+    def _cake_api_or_skip(self):
+        try:
+            from flashinfer.jit import cake_gdn_noncp_decode
+        except ImportError:
+            self.skipTest("public FlashInfer Cake GDN loader is unavailable")
+        return cake_gdn_noncp_decode
+
+    def test_cake_exact_decode_eager_and_cuda_graph(self):
+        cake_api = self._cake_api_or_skip()
+        with mock.patch.object(
+            cake_api,
+            "load_cake_gdn_kernel",
+            wraps=cake_api.load_cake_gdn_kernel,
+        ) as load_kernel:
+            run_gdn_attention_case(
+                self,
+                self.CAKE_DECODE_CASE,
+                head_k_dim=self.HEAD_DIM,
+                head_v_dim=self.HEAD_DIM,
+            )
+            run_gdn_cuda_graph_decode_case(
+                self,
+                self.CAKE_DECODE_CASE,
+                head_k_dim=self.HEAD_DIM,
+                head_v_dim=self.HEAD_DIM,
+                cuda_graph_capture_batch_size=4,
+            )
+        self.assertGreater(load_kernel.call_count, 0)
+
+    def test_cake_exact_verify_eager_and_cuda_graph(self):
+        cake_api = self._cake_api_or_skip()
+        with mock.patch.object(
+            cake_api,
+            "load_cake_gdn_kernel",
+            wraps=cake_api.load_cake_gdn_kernel,
+        ) as load_kernel:
+            run_gdn_eagle_verify_case(
+                self,
+                self.CAKE_VERIFY_CASE,
+                topk=1,
+                spec_kind="frozen_kv_mtp",
+                head_k_dim=self.HEAD_DIM,
+                head_v_dim=self.HEAD_DIM,
+            )
+            run_gdn_eagle_verify_cuda_graph_case(
+                self,
+                self.CAKE_VERIFY_CASE,
+                topk=1,
+                spec_kind="frozen_kv_mtp",
+                head_k_dim=self.HEAD_DIM,
+                head_v_dim=self.HEAD_DIM,
+                cuda_graph_capture_batch_size=8,
+            )
+        self.assertGreater(load_kernel.call_count, 0)
 
     def test_prefill_tracked_state_checkpoints(self):
         fixture = build_gdn_attention_fixture(

--- a/test/registered/attention/unittests/gdn/test_flashinfer.py
+++ b/test/registered/attention/unittests/gdn/test_flashinfer.py
@@ -391,6 +391,8 @@ class TestFlashInferLinearGDNBackendCorrectness(CustomTestCase):
                 head_k_dim=self.HEAD_DIM,
                 head_v_dim=self.HEAD_DIM,
             )
+            eager_load_count = load_kernel.call_count
+            self.assertGreater(eager_load_count, 0)
             run_gdn_cuda_graph_decode_case(
                 self,
                 self.CAKE_DECODE_CASE,
@@ -398,7 +400,7 @@ class TestFlashInferLinearGDNBackendCorrectness(CustomTestCase):
                 head_v_dim=self.HEAD_DIM,
                 cuda_graph_capture_batch_size=4,
             )
-        self.assertGreater(load_kernel.call_count, 0)
+        self.assertGreater(load_kernel.call_count, eager_load_count)
 
     def test_cake_exact_verify_eager_and_cuda_graph(self):
         cake_api = self._cake_api_or_skip()
@@ -415,6 +417,8 @@ class TestFlashInferLinearGDNBackendCorrectness(CustomTestCase):
                 head_k_dim=self.HEAD_DIM,
                 head_v_dim=self.HEAD_DIM,
             )
+            eager_load_count = load_kernel.call_count
+            self.assertGreater(eager_load_count, 0)
             run_gdn_eagle_verify_cuda_graph_case(
                 self,
                 self.CAKE_VERIFY_CASE,
@@ -424,7 +428,7 @@ class TestFlashInferLinearGDNBackendCorrectness(CustomTestCase):
                 head_v_dim=self.HEAD_DIM,
                 cuda_graph_capture_batch_size=8,
             )
-        self.assertGreater(load_kernel.call_count, 0)
+        self.assertGreater(load_kernel.call_count, eager_load_count)
 
     def test_prefill_tracked_state_checkpoints(self):
         fixture = build_gdn_attention_fixture(


### PR DESCRIPTION
## Summary

- lazily load the optional public FlashInfer Cake GDN decode package on SM100/SM103
- fail closed on unsupported dtype, layout, shape, stride, state-pool, or graph-capture combinations
- preserve caller-stream and CUDA graph semantics with preallocated workspace/state and cached FP32 dt bias
- route the promoted BF16 T=1 decode and T=4 verify rows used by Qwen3-Next

## Qualification

- B200/SM100: 9 focused SGLang tests passed, covering 26 subtests including eager and CUDA graph setup
- GB300/SM103: 9 focused SGLang tests passed, covering the same 26 subtests
- exact Qwen verify row B=8,T=4,H=16,HV=32: B200 0.011168 ms Cake vs 0.015664 ms live FlashInfer (1.403x); GB300 0.010480 ms vs 0.014592 ms (1.392x)
- correctness uses fixed BF16 atol=rtol=1e-2; dual-arch public ABI/stream/graph and sanitizer gates pass

Model accuracy and same-node serving E2E A/B are currently running and will be added before this PR is marked ready.

## Dependencies

- FlashInfer: https://github.com/flashinfer-ai/flashinfer/pull/4581

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32141884215](https://github.com/sgl-project/sglang/actions/runs/32141884215)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32141883775](https://github.com/sgl-project/sglang/actions/runs/32141883775)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->