### PR TITLE
[Distributed] Enable custom all-reduce for attention TP groups

### DIFF
--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -2576,7 +2576,10 @@ def initialize_model_parallel(
             get_world_group().local_rank,
             backend,
             use_pynccl=SYNC_TOKEN_IDS_ACROSS_TP or enable_symm_mem,
-            use_custom_allreduce=False,
+            # Attention TP can be a derived subgroup of the full TP group.
+            # Inherit the global policy and let per-group capability detection
+            # select a custom communicator or fall back.
+            use_custom_allreduce=None,
             use_torch_symm_mem_allreduce=False,
             use_message_queue_broadcaster=envs.SGLANG_USE_MESSAGE_QUEUE_BROADCASTER.get(),
             group_name="attention_tp",

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -8039,10 +8039,6 @@ class ServerArgs:
         if (
             not envs.SGLANG_ENABLE_CUSTOM_ALL_REDUCE_V2_MULTINODE.is_set()
             and is_mnnvl_fabric_device()
-            # CustomAllReduceV2 supports world sizes 2..8 only
-            # (can_use_custom_all_reduce_v2 rejects larger groups); don't
-            # auto-opt-in a TP16+ launch just to fall back downstream.
-            and self.tp_size <= 8
         ):
             logger.info(
                 "MNNVL fabric device detected with nnodes=%d: enabling "

--- a/test/registered/unit/distributed/test_parallel_state.py
+++ b/test/registered/unit/distributed/test_parallel_state.py
@@ -86,10 +86,12 @@ def test_parallel_group_construction_tp8_attn_cp2():
 
         # Mock init_model_parallel_group to capture the groups being created
         created_groups = {}
+        created_group_options = {}
 
         def mock_init_model_parallel_group(group_ranks, local_rank, backend, **kwargs):
             group_name = kwargs.get("group_name", "unknown")
             created_groups[group_name] = group_ranks
+            created_group_options[group_name] = kwargs
 
             # Create a mock group object
             mock_group = Mock()
@@ -146,6 +148,13 @@ def test_parallel_group_construction_tp8_attn_cp2():
             assert (
                 attn_cp_groups == expected_attn_cp
             ), f"Wrong ATTN_CP groups: {attn_cp_groups}"
+
+            # Derived attention-TP groups inherit the global custom-AR policy;
+            # the communicator performs the final per-group capability check.
+            assert (
+                created_group_options["attention_tp"]["use_custom_allreduce"]
+                is None
+            )
 
             print("TP=8, Attn CP=2 group construction verified")
 

--- a/test/registered/unit/server_args/test_mnnvl_auto_inference.py
+++ b/test/registered/unit/server_args/test_mnnvl_auto_inference.py
@@ -73,16 +73,20 @@ class TestCaV2MultinodeAuto(CustomTestCase):
             self.assertFalse(envs.SGLANG_ENABLE_CUSTOM_ALL_REDUCE_V2_MULTINODE.get())
             self.assertFalse(envs.SGLANG_OPT_USE_CUSTOM_ALL_REDUCE_V2.get())
 
-    def test_tp16_not_auto_opted_in(self):
-        """CustomAllReduceV2 supports world sizes 2..8 only; a TP16 fabric
-        launch must not auto-set the multinode opt-in (it would log
-        'enabling' and then silently fall back downstream)."""
+    def test_tp16_auto_opt_in_defers_to_group_capability(self):
+        """The server-level TP size must not suppress eligible derived groups.
+
+        A TP16 launch can contain attention-TP4/8 subgroups. Auto-enable the
+        MNNVL mode here and let each process group's capability check select
+        V2 or fall back independently.
+        """
         with _cleared(
             envs.SGLANG_ENABLE_CUSTOM_ALL_REDUCE_V2_MULTINODE,
             envs.SGLANG_OPT_USE_CUSTOM_ALL_REDUCE_V2,
         ), patch("sglang.srt.server_args.is_mnnvl_fabric_device", return_value=True):
             _HANDLE(SimpleNamespace(nnodes=2, tp_size=16))
-            self.assertFalse(envs.SGLANG_ENABLE_CUSTOM_ALL_REDUCE_V2_MULTINODE.is_set())
+            self.assertTrue(envs.SGLANG_ENABLE_CUSTOM_ALL_REDUCE_V2_MULTINODE.get())
+            self.assertTrue(envs.SGLANG_OPT_USE_CUSTOM_ALL_REDUCE_V2.get())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Enable custom-all-reduce capability detection for derived attention tensor-parallel groups.

## Motivation

With DP attention, the full TP group and attention-TP group may differ. For example, a 16-rank DP4 x attention-TP4 launch creates a full TP16 group plus four attention-TP4 subgroups. The attention groups were constructed with `use_custom_allreduce=False`, so eligible node-local subgroups could never select CustomAllReduceV2.

The server-side MNNVL auto-enable logic also used the full `tp_size` as a global gate. That suppressed eligible derived groups before their own topology and world-size checks could run.

## Changes

- Let derived attention-TP groups inherit the global custom-all-reduce policy.
- Remove the server-level `tp_size <= 8` gate from MNNVL auto-enable.
- Leave final selection to `can_use_custom_all_reduce_v2(group, device)` for each process group.
- Add focused tests for TP16 launches with derived groups and attention-TP group construction.

## Behavior

For a DP4 x attention-TP4 launch:

- Full TP16 independently rejects or falls back downstream.
- Each eligible attention-TP4 subgroup can select CustomAllReduceV2.
- Explicit custom-all-reduce disable settings remain respected.

## Validation

- Python syntax compilation passed.
- `git diff --check` passed.
- Added CPU unit coverage for the changed selection behavior.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32145778328](https://github.com/sgl-project/sglang/actions/runs/32145778328)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32145777749](https://github.com/sgl-project/sglang/actions/runs/32145777749)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->