### PR TITLE
VLM: feed the packed qkv projection output to vision backends uncopied

### DIFF
--- a/python/sglang/srt/layers/attention/vision.py
+++ b/python/sglang/srt/layers/attention/vision.py
@@ -1012,6 +1012,10 @@ QKV_BACKEND_IMPL = {
     "xpu_attn": VisionIntelXPUAttention,
 }
 
+# backends that read q/k/v through explicit per-dim strides, and so accept the
+# strided views of the packed qkv projection output instead of dense copies
+STRIDED_QKV_BACKENDS = frozenset({"fa3", "fa4", "triton_attn", "amx_attn"})
+
 
 class VisionAttention(nn.Module):
     r"""
@@ -1126,6 +1130,19 @@ class VisionAttention(nn.Module):
         )
 
         self.use_qkv_parallel = use_qkv_parallel
+        # `qkv_proj` writes q, k and v interleaved into a single buffer, so slicing
+        # it back apart yields views whose only non-unit stride is over tokens.
+        # Backends in `STRIDED_QKV_BACKENDS` consume those views directly, which
+        # saves copying the whole projection output once per layer. Two consumers
+        # sitting between the projection and the backend need a dense layout and
+        # so opt out: the internvl qk-norm, which normalizes q/k in place, and the
+        # model-supplied position embedding appliers, which reshape q/k freely.
+        self.pass_strided_qkv = (
+            use_qkv_parallel
+            and self.qkv_backend_name in STRIDED_QKV_BACKENDS
+            and not qk_normalization
+            and customized_position_embedding_applier is None
+        )
         if use_qkv_parallel:
             self.qkv_proj = QKVParallelLinear(
                 hidden_size=embed_dim,
@@ -1374,7 +1391,7 @@ class VisionAttention(nn.Module):
             # [s, b, head, head_size] --> [b, s, head, head_size]
             q, k, v = [rearrange(x, "s b ... -> b s ...") for x in (q, k, v)]
 
-        if not (_is_cpu and _is_cpu_amx_available):
+        if not self.pass_strided_qkv:
             q = q.contiguous()
             k = k.contiguous()
             v = v.contiguous()

--- a/test/registered/unit/layers/attention/test_vision_strided_qkv.py
+++ b/test/registered/unit/layers/attention/test_vision_strided_qkv.py
@@ -1,0 +1,162 @@
+"""CPU coverage for handing the packed qkv projection output to the backend uncopied."""
+
+import os
+import socket
+
+import pytest
+import torch
+import torch.nn as nn
+
+from sglang.srt.distributed.parallel_state import (
+    destroy_distributed_environment,
+    destroy_model_parallel,
+    init_distributed_environment,
+    initialize_model_parallel,
+)
+from sglang.srt.layers.attention import vision
+from sglang.srt.runtime_context import get_context, get_parallel
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+EMBED_DIM = 32
+NUM_HEADS = 4
+TOKENS = 6
+CU_SEQLENS = torch.tensor([0, TOKENS], dtype=torch.int32)
+
+
+class _RecordingBackend(nn.Module):
+    """stands in for a real backend to observe what the layer hands it"""
+
+    def __init__(self, **kwargs):
+        super().__init__()
+        self.received = None
+
+    def forward(self, q, k, v, **kwargs):
+        self.received = (q, k, v)
+        return q
+
+
+@pytest.fixture(scope="module")
+def gloo_world():
+    """a one-rank cpu process group, so the row-parallel proj can run"""
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        port = probe.getsockname()[1]
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    init_distributed_environment(
+        world_size=1,
+        rank=0,
+        local_rank=0,
+        distributed_init_method=f"tcp://127.0.0.1:{port}",
+        backend="gloo",
+    )
+    initialize_model_parallel(tensor_model_parallel_size=1, backend="gloo")
+    yield
+    destroy_model_parallel()
+    destroy_distributed_environment()
+
+
+@pytest.fixture
+def single_rank(monkeypatch, gloo_world):
+    # only the resolved backend name is consulted for gating, so a backend does
+    # not need its platform present to be built here
+    monkeypatch.setattr(
+        vision.VisionAttention,
+        "_determine_attention_backend",
+        lambda self, passed_backend: passed_backend,
+    )
+    with get_parallel().override(
+        tp_size=1, tp_rank=0, attn_tp_size=1, attn_tp_rank=0
+    ), get_context().override_server_args():
+        yield
+
+
+def _build(backend, **kwargs):
+    """VisionAttention leaves its parameters uninitialized, so fill them in here"""
+    layer = vision.VisionAttention(
+        embed_dim=EMBED_DIM,
+        num_heads=NUM_HEADS,
+        projection_size=EMBED_DIM,
+        use_qkv_parallel=True,
+        qkv_backend=backend,
+        flatten_batch=True,
+        **kwargs,
+    )
+    for parameter in layer.parameters():
+        torch.nn.init.normal_(parameter, std=0.05)
+    return layer
+
+
+@pytest.mark.parametrize(
+    ("backend", "extra", "expected"),
+    [
+        ("fa3", {}, True),
+        ("fa4", {}, True),
+        ("triton_attn", {}, True),
+        ("amx_attn", {}, True),
+        ("sdpa", {}, False),
+        ("flashinfer_cudnn", {}, False),
+        ("xpu_attn", {}, False),
+        ("aiter_attn", {}, False),
+        # internvl normalizes q/k in place through a view that assumes a dense layout
+        ("fa3", {"qk_normalization": True}, False),
+        # the model-supplied applier owns the q/k layout, so it must get dense inputs
+        ("fa3", {"customized_position_embedding_applier": lambda *args: None}, False),
+        # this variant reshapes q/k into a dense copy of its own, so views are fine
+        ("fa3", {"qk_normalization_by_head_size": True}, True),
+    ],
+)
+def test_pass_strided_qkv_gating(monkeypatch, single_rank, backend, extra, expected):
+    monkeypatch.setitem(vision.QKV_BACKEND_IMPL, backend, _RecordingBackend)
+
+    assert _build(backend, **extra).pass_strided_qkv is expected
+
+
+@pytest.mark.parametrize("num_kv_heads", [NUM_HEADS, 1])
+def test_strided_qkv_carries_the_dense_values(monkeypatch, single_rank, num_kv_heads):
+    """the strided views must hold exactly what the copies used to hold"""
+    monkeypatch.setitem(vision.QKV_BACKEND_IMPL, "fa3", _RecordingBackend)
+    monkeypatch.setitem(vision.QKV_BACKEND_IMPL, "sdpa", _RecordingBackend)
+    torch.manual_seed(0)
+    strided = _build("fa3", num_kv_heads=num_kv_heads)
+    dense = _build("sdpa", num_kv_heads=num_kv_heads)
+    dense.load_state_dict(strided.state_dict())
+    assert strided.pass_strided_qkv and not dense.pass_strided_qkv
+    x = torch.randn(1, TOKENS, EMBED_DIM)
+
+    with torch.no_grad():
+        strided(x, cu_seqlens=CU_SEQLENS)
+        dense(x, cu_seqlens=CU_SEQLENS)
+
+    packed = strided.qkv_backend.received[0].untyped_storage().data_ptr()
+    for strided_tensor, dense_tensor in zip(
+        strided.qkv_backend.received, dense.qkv_backend.received
+    ):
+        # one non-unit stride, over tokens, into the single buffer qkv_proj wrote
+        assert not strided_tensor.is_contiguous()
+        assert strided_tensor.stride(-1) == 1
+        assert strided_tensor.untyped_storage().data_ptr() == packed
+        assert dense_tensor.is_contiguous()
+        assert torch.equal(strided_tensor, dense_tensor)
+
+
+def test_strided_qkv_keeps_attention_output_bit_identical(monkeypatch, single_rank):
+    monkeypatch.setitem(vision.QKV_BACKEND_IMPL, "fa3", vision.VisionSdpaAttention)
+    torch.manual_seed(0)
+    strided = _build("fa3")
+    dense = _build("sdpa")
+    dense.load_state_dict(strided.state_dict())
+    assert strided.pass_strided_qkv and not dense.pass_strided_qkv
+    x = torch.randn(1, TOKENS, EMBED_DIM)
+
+    with torch.no_grad():
+        strided_output = strided(x, cu_seqlens=CU_SEQLENS)
+        dense_output = dense(x, cu_seqlens=CU_SEQLENS)
+
+    torch.testing.assert_close(strided_output, dense_output, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Motivation

In `VisionAttention.forward`, the `use_qkv_parallel` branch slices `qkv_proj`'s output into q/k/v and then copies all three dense:

```python
qkv, _ = self.qkv_proj(x)
q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
q = q.reshape(bsz * s, head, -1)          # a view, still strided
...
q = q.contiguous(); k = k.contiguous(); v = v.contiguous()   # three full copies
```

`qkv_proj` writes q, k and v interleaved into one buffer, so those slices are views whose only non-unit stride is over tokens — the last dimension stays contiguous. Backends that read q/k/v through explicit per-dim strides accept them as they are, so the copies move the whole projection output twice through HBM per layer for nothing. On a PaddleOCR-VL page (10764 patches, 16 heads, head_dim 72, bf16) that is 3.74 GiB of HBM traffic per request across 27 layers.

## Modifications

- Add `STRIDED_QKV_BACKENDS` next to `QKV_BACKEND_IMPL`, listing the backends
  that read q/k/v through explicit strides: `fa3`, `fa4`, `triton_attn`,
  `amx_attn`. `flashinfer_cudnn` stays out because its packed element indptrs
  assume a dense layout; `sdpa`, `ascend_attn`, `aiter_attn` and `xpu_attn` stay
  out because their kernels were not verified against a non-unit token stride.
- Compute `self.pass_strided_qkv` in `__init__` and skip the three
  `.contiguous()` calls when it holds. This replaces the previous
  `_is_cpu and _is_cpu_amx_available` predicate; `amx_attn` is in the set, so
  the CPU-AMX default path is unchanged.
- Two consumers sit between the projection and the backend and need a dense
  layout, so they keep the copies:
  - `qk_normalization` (internvl) — `apply_qk_norm` normalizes q/k **in place**
    through `q.view(N, -1, embed)`. That view succeeds on the strided tensor,
    and the kernel then writes per its dense stride assumption, corrupting the
    k/v regions of the shared buffer.
  - `customized_position_embedding_applier` — model-supplied callables reshape
    q/k however they like (e.g. `mllama4` views to 4D).
  - `qk_normalization_by_head_size` (GLM-OCR) does **not** need to opt out: its
    `reshape(-1, head_size)` materialises a dense copy of q/k on its own.
- No GQA special case is needed. `qkv.view(tokens, 3, head, head_dim)[:, i]` is
  byte-identical to what `split` + `reshape` already produce, and a GQA tower's
  k/v slices have the same stride shape, so nothing has to change for
  `num_kv_heads != num_heads`.

New CPU unit test `test/registered/unit/layers/attention/test_vision_strided_qkv.py`
covers the gating matrix (8 backends plus the three qk-norm / applier variants),
asserts the tensors reaching the backend are non-contiguous views into a single
storage carrying byte-identical values to the dense path (MHA and GQA), and
asserts the layer output is bit-identical between the two paths.

## Accuracy Tests

All on one H200, bf16, `fa3`.

- `flash_attn_varlen_func` and the Triton `context_attention_fwd` produce
  **bit-identical** output from strided views vs dense copies across 8 shapes:
  PaddleOCR-VL SigLIP (10764 patches, 1 and 8 sequences), Qwen2.5-VL ViT
  (8192 / head_dim 80), Qwen3-VL ViT (6400 / head_dim 128), InternViT-like
  (25 heads / head_dim 64), a GQA tower (16 q heads / 4 kv heads), a
  non-multiple token count (1023), and fp16.
- The full PaddleOCR-VL SigLIP encoder (27 layers, 12000 patches) output is
  **bit-identical** between the two paths.
- Greedy output over 3 prompts on the same image is **byte-identical** before
  and after, for **PaddleOCR-VL**, **Qwen2.5-VL-3B-Instruct** and
  **Qwen3-VL-2B-Instruct**.
- The 14 new unit tests pass.

Not covered: no released vision tower is GQA (`mimo_vl` is the only call site
that can pass `num_kv_heads`, and only when its vision config sets
`num_key_value_heads`), so GQA is covered at the unit-test and kernel level
only. The `qk_normalization` opt-out is covered by the unit test —
InternVL2_5-2B has `qk_normalization: false`, so it is not an end-to-end
exercise of that branch.

## Speed Tests and Profiling

PaddleOCR-VL SigLIP encoder, 27 layers, 12000 patches, bf16, H200, `fa3`,
in-process CUDA-event timing, the two modes interleaved over 7 rounds each:

| | dense copies | strided views | delta |
|---|---|---|---|
| encoder forward | 66.42 ms | 64.88 ms | **−1.54 ms (−2.3%)** |
| one `VisionAttention.forward` (10764 patches) | 1565.2 us | 1455.3 us | −109.9 us (−7.0%) |
| peak allocated, one layer | 306.1 MiB | 234.1 MiB | −72 MiB |

Sample ranges do not overlap (strided 64.78–65.58 ms, dense 66.34–66.66 ms).
The three `.contiguous()` calls alone measure 96.8 us per layer at that shape,
i.e. 2.6 ms of pure copy time per request over 27 layers.

**No end-to-end win is claimed yet.** Single-page latency (197.9–200.9 ms vs
197.9–199.0 ms) and saturated page throughput (9.62/9.90/9.65 vs
10.24/9.91/9.76 pages/s over 3 rounds of 96 pages at concurrency 8) both came
out inside the noise band. Sampling GPU utilisation during the throughput run
showed a mean of **17.4%** — that harness was CPU-bound on image preprocessing,
so it cannot resolve a GPU-side saving of this size either way. Marking this a
draft until a GPU-bound page-throughput benchmark either confirms or rules out
the end-to-end effect; the encoder-level number above is the measured result.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #32147235077](https://github.com/sgl-project/sglang/actions/runs/32147235077)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #32147674741](https://github.com/sgl-project/sglang/actions/runs/32147674741)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->