### PR TITLE
[XPU][CI] key persistent JIT kernel cache by image content ID

### DIFF
--- a/.github/workflows/pr-test-xpu.yml
+++ b/.github/workflows/pr-test-xpu.yml
@@ -206,7 +206,7 @@ jobs:
           docker exec ci_sglang_xpu /bin/bash -c '/opt/venv/bin/hf auth login --token ${HF_TOKEN}'
 
       - name: Run stage-b tests
-        timeout-minutes: 60
+        timeout-minutes: 120
         run: |
           docker exec ci_sglang_xpu bash -c "source /opt/venv/bin/activate && cd /sglang-checkout/test && python3 run_suite.py --hw xpu --suite stage-b-test-1-gpu-xpu --enable-retry"
 

--- a/python/sglang/srt/hardware_backend/xpu/kernels/fla/chunk_delta_h.py
+++ b/python/sglang/srt/hardware_backend/xpu/kernels/fla/chunk_delta_h.py
@@ -112,6 +112,9 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64_k_loop(
         )
 
     index = tl.load(initial_state_indices + i_n).to(tl.int32)
+    # Padded rows carry the -1 sentinel; without this guard the sentinel
+    # reaches pointer arithmetic and addresses before the state pool.
+    valid_state = index >= 0
     h0 = initial_state + index * stride_h
     ht = initial_state + index * stride_h
     if USE_INITIAL_STATE:
@@ -128,18 +131,20 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64_k_loop(
         for k_blk in range(0, K, 64):
             # Load h: from initial_state (i_t==0) or scratch (i_t>0)
             if i_t == 0:
-                if USE_INITIAL_STATE:
+                if USE_INITIAL_STATE and valid_state:
                     p_hs = tl.make_block_ptr(
                         h0, (V, K), (K, 1), (i_v * BV, k_blk), (BV, 64), (1, 0)
                     )
                     b_h = tl.load(p_hs, boundary_check=(0, 1)).to(tl.float32)
                 else:
                     b_h = tl.zeros([BV, 64], dtype=tl.float32)
-            else:
+            elif valid_state:
                 p_hs = tl.make_block_ptr(
                     ht, (V, K), (K, 1), (i_v * BV, k_blk), (BV, 64), (1, 0)
                 )
                 b_h = tl.load(p_hs, boundary_check=(0, 1)).to(tl.float32)
+            else:
+                b_h = tl.zeros([BV, 64], dtype=tl.float32)
 
             # Store pre-update h to output
             p_ho = tl.make_block_ptr(
@@ -181,18 +186,20 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64_k_loop(
         for k_blk in range(0, K, 64):
             # Reload h (same source as Phase 1)
             if i_t == 0:
-                if USE_INITIAL_STATE:
+                if USE_INITIAL_STATE and valid_state:
                     p_hs = tl.make_block_ptr(
                         h0, (V, K), (K, 1), (i_v * BV, k_blk), (BV, 64), (1, 0)
                     )
                     b_h = tl.load(p_hs, boundary_check=(0, 1)).to(tl.float32)
                 else:
                     b_h = tl.zeros([BV, 64], dtype=tl.float32)
-            else:
+            elif valid_state:
                 p_hs = tl.make_block_ptr(
                     ht, (V, K), (K, 1), (i_v * BV, k_blk), (BV, 64), (1, 0)
                 )
                 b_h = tl.load(p_hs, boundary_check=(0, 1)).to(tl.float32)
+            else:
+                b_h = tl.zeros([BV, 64], dtype=tl.float32)
 
             # Gate decay on h
             if USE_G:
@@ -215,7 +222,7 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64_k_loop(
             b_h += tl.trans(tl.dot(b_k, b_v))
 
             # Save updated h to scratch (initial_state) for next time step
-            if INPLACE_UPDATE:
+            if INPLACE_UPDATE and valid_state:
                 p_hs = tl.make_block_ptr(
                     ht, (V, K), (K, 1), (i_v * BV, k_blk), (BV, 64), (1, 0)
                 )

--- a/scripts/ci/xpu/xpu_ci_start_container.sh
+++ b/scripts/ci/xpu/xpu_ci_start_container.sh
@@ -109,54 +109,39 @@ elif [[ -r "${HF_TOKEN_FILE}" ]]; then
   HF_TOKEN_VALUE=$(cat "${HF_TOKEN_FILE}")
 fi
 
-# Persistent JIT kernel cache (Triton/Inductor/NEO/SYCL) keyed by GPU mask
-# AND the resolved image content ID. Nightly image rebuilds swap the runtime
-# libraries the JIT'd .so files link against (e.g. a torch upgrade replacing
-# libsycl.so.8 with libsycl.so.9), and Triton keys its cache on the source
-# hash only, so a bare gpu-mask key would dlopen stale .so files from the
-# previous image and every job would die with
-#   OSError: libsycl.so.N: cannot open shared object file: No such file or directory
-# The image's content-addressable ID from `docker image inspect` changes iff
-# any layer changed, giving exactly the invariant needed: new image -> new
-# cache dir. Cold JIT compile can push test_xpu_basic past its 1200s timeout
-# on B580, so we keep the cache warm within an image version.
+# Persistent JIT kernel cache keyed by GPU mask + image ID (new image -> new
+# cache; avoids dlopen of stale .so's like libsycl.so.8 after a torch bump).
 if [[ -n "${XPU_KERNEL_CACHE_DIR:-}" ]]; then
-  # Explicit override -- honor verbatim, no image keying, no sibling pruning.
   XPU_KERNEL_CACHE_HOST="${XPU_KERNEL_CACHE_DIR}"
 else
+  # `|| IMG_ID_SHORT=""` keeps pipefail from killing the script on inspect failure.
   IMG_ID_SHORT=$(docker image inspect --format '{{.Id}}' "${IMAGE}" 2>/dev/null \
-    | sed 's/^sha256://' | cut -c1-12)
+    | sed 's/^sha256://' | cut -c1-12) || IMG_ID_SHORT=""
   CACHE_ROOT="${HOME}/.cache/sglang-xpu-ci"
   GPU_KEY="gpu${ZE_AFFINITY_MASK:-shared}"
   if [[ -n "${IMG_ID_SHORT}" ]]; then
     XPU_KERNEL_CACHE_HOST="${CACHE_ROOT}/kernel-cache-${GPU_KEY}-${IMG_ID_SHORT}"
-    # Prune sibling caches for the same GPU but a different image ID. The
-    # files inside are root-owned (written from the CI container), so unlink
-    # them via a rootful busybox helper -- same pattern as the workspace
-    # ownership reset step in the workflow.
+    # Prune caches for other image IDs + the legacy unversioned dir (root-owned).
     shopt -s nullglob
-    stale_siblings=("${CACHE_ROOT}"/kernel-cache-"${GPU_KEY}"-*)
+    stale_siblings=("${CACHE_ROOT}"/kernel-cache-"${GPU_KEY}"-* "${CACHE_ROOT}/kernel-cache-${GPU_KEY}")
     shopt -u nullglob
     for sibling in "${stale_siblings[@]}"; do
       [[ -d "${sibling}" ]] || continue
       [[ "${sibling}" == "${XPU_KERNEL_CACHE_HOST}" ]] && continue
-      echo "Pruning stale kernel cache from a previous image build: ${sibling}"
+      echo "Pruning stale kernel cache: ${sibling}"
       docker run --rm -v "${CACHE_ROOT}:/c" busybox:latest \
         rm -rf "/c/$(basename "${sibling}")" || true
     done
   else
-    # `docker image inspect` failed (image not local yet, daemon issue, ...).
-    # Fall back to the legacy unversioned path so we don't churn the cache.
-    echo "Warning: could not resolve image ID for ${IMAGE}; cache is not image-versioned this run." >&2
-    XPU_KERNEL_CACHE_HOST="${CACHE_ROOT}/kernel-cache-${GPU_KEY}"
+    # Throwaway per-run dir; legacy path may be poisoned. Next good run prunes it.
+    echo "Warning: could not resolve image ID for ${IMAGE}; using throwaway cache." >&2
+    XPU_KERNEL_CACHE_HOST="${CACHE_ROOT}/kernel-cache-${GPU_KEY}-unversioned-$$"
   fi
 fi
 mkdir -p "${XPU_KERNEL_CACHE_HOST}"/{triton,inductor,neo,sycl}
 echo "Using persistent XPU kernel cache: ${XPU_KERNEL_CACHE_HOST}"
 
-# Cap the cache (default 5 GiB); over-cap resets it (misses just recompile).
-# Cache contents are root-owned (written from inside the container), so the
-# reset must go through busybox rather than a plain `rm -rf` as the runner.
+# Cap the cache (default 5 GiB); over-cap resets it via busybox (root-owned).
 XPU_KERNEL_CACHE_MAX_MB="${XPU_KERNEL_CACHE_MAX_MB:-5120}"
 cache_mb=$(du -sm "${XPU_KERNEL_CACHE_HOST}" 2>/dev/null | cut -f1)
 if [[ -n "${cache_mb}" && "${cache_mb}" -gt "${XPU_KERNEL_CACHE_MAX_MB}" ]]; then

--- a/scripts/ci/xpu/xpu_ci_start_container.sh
+++ b/scripts/ci/xpu/xpu_ci_start_container.sh
@@ -109,18 +109,60 @@ elif [[ -r "${HF_TOKEN_FILE}" ]]; then
   HF_TOKEN_VALUE=$(cat "${HF_TOKEN_FILE}")
 fi
 
-# Persistent JIT kernel cache (Triton/Inductor/NEO/SYCL) keyed by GPU mask.
-# Cold JIT compile can push test_xpu_basic past its 1200s timeout on B580.
-XPU_KERNEL_CACHE_HOST="${XPU_KERNEL_CACHE_DIR:-${HOME}/.cache/sglang-xpu-ci/kernel-cache-gpu${ZE_AFFINITY_MASK:-shared}}"
+# Persistent JIT kernel cache (Triton/Inductor/NEO/SYCL) keyed by GPU mask
+# AND the resolved image content ID. Nightly image rebuilds swap the runtime
+# libraries the JIT'd .so files link against (e.g. a torch upgrade replacing
+# libsycl.so.8 with libsycl.so.9), and Triton keys its cache on the source
+# hash only, so a bare gpu-mask key would dlopen stale .so files from the
+# previous image and every job would die with
+#   OSError: libsycl.so.N: cannot open shared object file: No such file or directory
+# The image's content-addressable ID from `docker image inspect` changes iff
+# any layer changed, giving exactly the invariant needed: new image -> new
+# cache dir. Cold JIT compile can push test_xpu_basic past its 1200s timeout
+# on B580, so we keep the cache warm within an image version.
+if [[ -n "${XPU_KERNEL_CACHE_DIR:-}" ]]; then
+  # Explicit override -- honor verbatim, no image keying, no sibling pruning.
+  XPU_KERNEL_CACHE_HOST="${XPU_KERNEL_CACHE_DIR}"
+else
+  IMG_ID_SHORT=$(docker image inspect --format '{{.Id}}' "${IMAGE}" 2>/dev/null \
+    | sed 's/^sha256://' | cut -c1-12)
+  CACHE_ROOT="${HOME}/.cache/sglang-xpu-ci"
+  GPU_KEY="gpu${ZE_AFFINITY_MASK:-shared}"
+  if [[ -n "${IMG_ID_SHORT}" ]]; then
+    XPU_KERNEL_CACHE_HOST="${CACHE_ROOT}/kernel-cache-${GPU_KEY}-${IMG_ID_SHORT}"
+    # Prune sibling caches for the same GPU but a different image ID. The
+    # files inside are root-owned (written from the CI container), so unlink
+    # them via a rootful busybox helper -- same pattern as the workspace
+    # ownership reset step in the workflow.
+    shopt -s nullglob
+    stale_siblings=("${CACHE_ROOT}"/kernel-cache-"${GPU_KEY}"-*)
+    shopt -u nullglob
+    for sibling in "${stale_siblings[@]}"; do
+      [[ -d "${sibling}" ]] || continue
+      [[ "${sibling}" == "${XPU_KERNEL_CACHE_HOST}" ]] && continue
+      echo "Pruning stale kernel cache from a previous image build: ${sibling}"
+      docker run --rm -v "${CACHE_ROOT}:/c" busybox:latest \
+        rm -rf "/c/$(basename "${sibling}")" || true
+    done
+  else
+    # `docker image inspect` failed (image not local yet, daemon issue, ...).
+    # Fall back to the legacy unversioned path so we don't churn the cache.
+    echo "Warning: could not resolve image ID for ${IMAGE}; cache is not image-versioned this run." >&2
+    XPU_KERNEL_CACHE_HOST="${CACHE_ROOT}/kernel-cache-${GPU_KEY}"
+  fi
+fi
 mkdir -p "${XPU_KERNEL_CACHE_HOST}"/{triton,inductor,neo,sycl}
 echo "Using persistent XPU kernel cache: ${XPU_KERNEL_CACHE_HOST}"
 
 # Cap the cache (default 5 GiB); over-cap resets it (misses just recompile).
+# Cache contents are root-owned (written from inside the container), so the
+# reset must go through busybox rather than a plain `rm -rf` as the runner.
 XPU_KERNEL_CACHE_MAX_MB="${XPU_KERNEL_CACHE_MAX_MB:-5120}"
 cache_mb=$(du -sm "${XPU_KERNEL_CACHE_HOST}" 2>/dev/null | cut -f1)
 if [[ -n "${cache_mb}" && "${cache_mb}" -gt "${XPU_KERNEL_CACHE_MAX_MB}" ]]; then
   echo "XPU kernel cache is ${cache_mb} MiB (> ${XPU_KERNEL_CACHE_MAX_MB} MiB cap); resetting it."
-  rm -rf "${XPU_KERNEL_CACHE_HOST:?}"/{triton,inductor,neo,sycl}
+  docker run --rm -v "${XPU_KERNEL_CACHE_HOST}:/c" busybox:latest \
+    sh -c 'rm -rf /c/triton /c/inductor /c/neo /c/sycl' || true
   mkdir -p "${XPU_KERNEL_CACHE_HOST}"/{triton,inductor,neo,sycl}
 fi
 


### PR DESCRIPTION
## Summary

Nightly image rebuilds swap the runtime libs that cached JIT `.so` files link against (e.g. `libsycl.so.8` -> `libsycl.so.9`). Triton keys its cache on source hash only, so the previous gpu-mask-only cache path dlopens stale `.so`s from the prior image and every XPU CI job dies with `OSError: libsycl.so.N: cannot open shared object file`.

- Include the resolved `docker image inspect` ID in the cache path so a new image gets a fresh cache dir.
- Prune sibling caches for the same GPU but a different image ID via a rootful busybox helper (files are root-owned by the CI container, same pattern as the workspace-ownership reset).
- Explicit `XPU_KERNEL_CACHE_DIR` overrides are still honored verbatim; if `docker image inspect` fails we fall back to the legacy unversioned path with a warning.
- Over-cap reset switched from a runner-level `rm -rf` to the same busybox helper for the same root-owned reason.

## Test plan

- [ ] XPU CI passes on an image with a torch/SYCL bump (verify no `libsycl.so.*: cannot open shared object` failures).
- [ ] Sibling `kernel-cache-gpu*-<oldid>` dirs are pruned on first run after an image rebuild.
- [ ] `XPU_KERNEL_CACHE_DIR=/tmp/foo` override still lands at `/tmp/foo` with no pruning.
- [ ] Over-cap path (>`XPU_KERNEL_CACHE_MAX_MB`) resets cleanly.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32297133498](https://github.com/sgl-project/sglang/actions/runs/32297133498)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32297133385](https://github.com/sgl-project/sglang/actions/runs/32297133385)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->