### PR TITLE
[Bugfix] Prevent hybrid-SWA mixed-chunk decode over-admission

### DIFF
--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -520,6 +520,7 @@ class PrefillAdder:
         dllm_config: Optional[DllmConfig] = None,
         waiting_queue_len: int = 0,
         prefill_tile_block_m: int = 64,
+        num_mixed_decode_swa_tokens: int = 0,
     ):
         self.page_size = page_size
         self.prefill_tile_block_m = prefill_tile_block_m
@@ -572,7 +573,10 @@ class PrefillAdder:
         )
         self.is_hybrid_ssm_cache = self.tree_cache.supports_mamba()
 
-        self.rem_swa_token_offset = 0
+        # Mixed chunk prefill runs the existing decode batch immediately after
+        # admission. Reserve the exact page-aligned SWA demand for that decode
+        # step so prefill admission cannot consume its pages.
+        self.rem_swa_token_offset = num_mixed_decode_swa_tokens
 
         # Unified-pool joint budget: a new mamba state consumes shared-gap bytes
         # that `rem_total_tokens` (full KV) otherwise counts as free, so reserve

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3254,6 +3254,12 @@ class Scheduler(
         else:
             prefill_tile_block_m = 64  # Fallback for non-Triton backends
 
+        mixed_decode_swa_tokens = (
+            running_batch.new_tokens_required_next_decode()
+            if self.is_mixed_chunk and self.tree_cache.supports_swa()
+            else 0
+        )
+
         adder = PrefillAdder(
             self.page_size,
             self.tree_cache,
@@ -3271,6 +3277,7 @@ class Scheduler(
             dllm_config=self.dllm_config,
             waiting_queue_len=len(self.waiting_queue),
             prefill_tile_block_m=prefill_tile_block_m,
+            num_mixed_decode_swa_tokens=mixed_decode_swa_tokens,
         )
 
         if self.chunked_req is not None:

--- a/python/sglang/srt/mem_cache/allocator/swa.py
+++ b/python/sglang/srt/mem_cache/allocator/swa.py
@@ -292,6 +292,15 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         last_loc: torch.Tensor,  # last_loc for full layers
     ):
         assert self.page_size > 1
+
+        num_new_pages = get_num_new_pages(
+            seq_lens=seq_lens_cpu,
+            page_size=self.page_size,
+            decode=True,
+        )
+        if not self.new_pages_available(num_new_pages, num_new_pages):
+            return None
+
         swa_last_loc = self.translate_loc_from_full_to_swa(last_loc)
 
         alloc_full_indices = self.full_attn_allocator.alloc_decode(


### PR DESCRIPTION
## Motivation

Hybrid-SWA mixed-chunk scheduling admits new prefill tokens while an existing
decode batch is executed in the same forward pass.

The mixed-chunk path does not perform the regular decode memory check before
admission. However, the existing decode batch still requires SWA KV pages
immediately after admission. Since `PrefillAdder` did not reserve this SWA
demand, prefill admission could consume pages required by decode.

This can cause decode allocation failure under SWA memory pressure.

## Root Cause

For a running batch, `new_tokens_required_next_decode()` returns the
page-aligned token demand for the next decode step. The mixed-chunk admission
path previously ignored this demand and initialized the SWA reservation offset
to zero.

The composite SWA allocator had a second issue: full-attention pages were
allocated before SWA pages. If the SWA allocation failed, the full allocator
had already consumed pages, leaving a partial allocation state.

## Fix

Reserve the current decode batch's SWA demand during mixed-chunk admission:

```python
mixed_decode_swa_tokens = (
    running_batch.new_tokens_required_next_decode()
    if self.is_mixed_chunk and self.tree_cache.supports_swa()
    else 0
)
```

Pass this value to `PrefillAdder` as the initial SWA reservation.

Make hybrid SWA decode allocation preflight both underlying allocators before
performing either allocation:

```python
num_new_pages = get_num_new_pages(
    seq_lens=seq_lens_cpu,
    page_size=self.page_size,
    decode=True,
)
if not self.new_pages_available(num_new_pages, num_new_pages):
    return None
```

This prevents full-KV pages from being consumed when the corresponding SWA
allocation cannot succeed.

## Validation

- Existing scheduler and allocator tests pass:
  `45 passed, 27 subtests passed`.
- On A100, a decode batch requiring 8 new pages with only 4 SWA pages
  available:
  - before the fix, full-KV allocation consumed all 8 pages before SWA failed;
  - after the fix, allocation returned `None` without changing either pool.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32148300784](https://github.com/sgl-project/sglang/actions/runs/32148300784)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32148300620](https://github.com/sgl-project/sglang/actions/runs/32148300620)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->