### PR TITLE
[AMD][bugfix] Add moe_ep_size/moe_tp_size to the allreduce-fusion gate test stub

### DIFF
--- a/test/registered/ops/test_aiter_allreduce_fusion_amd.py
+++ b/test/registered/ops/test_aiter_allreduce_fusion_amd.py
@@ -409,11 +409,15 @@ class TestAiterAllreduceFusionGate(CustomTestCase):
                 )
             )
             stack.enter_context(mock.patch.object(comm, "_use_aiter", use_aiter))
+            # moe_ep_size/moe_tp_size of 1 keep the hybrid EP+TP guard inactive
+            # so the aiter branch is what decides.
             stack.enter_context(
                 mock.patch.object(
                     comm,
                     "get_parallel",
-                    lambda: types.SimpleNamespace(tp_size=tp_world_size),
+                    lambda: types.SimpleNamespace(
+                        tp_size=tp_world_size, moe_ep_size=1, moe_tp_size=1
+                    ),
                 )
             )
             # the gate reads get_exec().comm.enable_aiter_allreduce_fusion


### PR DESCRIPTION
## Motivation

#30700 added a hybrid EP+TP guard to `should_fuse_mlp_allreduce_with_next_layer` that reads `get_parallel().moe_ep_size` and `get_parallel().moe_tp_size`.

`TestAiterAllreduceFusionGate` replaces `get_parallel()` with a `SimpleNamespace` containing only `tp_size`. This stale test double now raises `AttributeError` before any Aiter-specific condition is evaluated. Production is unaffected because `ParallelContext` provides both fields.

## Modifications

Add `moe_ep_size=1` and `moe_tp_size=1` to the test stub. These neutral values keep the unrelated hybrid EP+TP guard inactive, preserving the seven existing gate tests' purpose: isolate the Aiter branch.

No production code or assertions are changed.

## Testing

- [ROCm 7.2 target shard](https://github.com/sgl-project/sglang/actions/runs/32149237375/job/95750803272): `test_aiter_allreduce_fusion_amd.py` ran 10 tests, all passed.
- Lint passed.

## Accuracy Tests

Not applicable — test-only change; no kernel or model-forward code is modified.

## Speed Tests and Profiling

Not applicable — test-only change.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32149134311](https://github.com/sgl-project/sglang/actions/runs/32149134311)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32149134025](https://github.com/sgl-project/sglang/actions/runs/32149134025)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32149134444](https://github.com/sgl-project/sglang/actions/runs/32149134444)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->