### PR TITLE
 fix: initialize reasoning parser from prefilled think token

### DIFF
--- a/sgl-model-gateway/src/routers/grpc/context.rs
+++ b/sgl-model-gateway/src/routers/grpc/context.rs
@@ -69,6 +69,9 @@ pub(crate) struct ProcessingState {
     // Stage 1: Preparation outputs
     pub preparation: Option<PreparationOutput>,
 
+    /// Whether the rendered generation prompt already opened a reasoning block.
+    pub reasoning_started_in_prefill: bool,
+
     /// Resolved tokenizer (set once in preparation, reused in response processing)
     /// This avoids redundant registry lookups across pipeline stages.
     pub tokenizer: Option<Arc<dyn Tokenizer>>,

--- a/sgl-model-gateway/src/routers/grpc/regular/processor.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/processor.rs
@@ -68,6 +68,7 @@ impl ResponseProcessor {
         history_tool_calls_count: usize,
         reasoning_parser_available: bool,
         tool_parser_available: bool,
+        reasoning_started_in_prefill: bool,
     ) -> Result<ChatChoice, String> {
         stop_decoder.reset();
         // Decode tokens
@@ -99,13 +100,14 @@ impl ResponseProcessor {
         let mut processed_text = final_text;
 
         if original_request.separate_reasoning && reasoning_parser_available {
-            let pooled_parser = utils::get_reasoning_parser(
+            let mut parser = utils::create_reasoning_parser(
                 &self.reasoning_parser_factory,
                 self.configured_reasoning_parser.as_deref(),
                 &original_request.model,
-            );
+                reasoning_started_in_prefill,
+            )
+            .ok_or_else(|| "Reasoning parser is unavailable".to_string())?;
 
-            let mut parser = pooled_parser.lock().await;
             match parser.detect_and_parse_reasoning(&processed_text) {
                 Ok(result) => {
                     if !result.reasoning_text.is_empty() {
@@ -209,6 +211,7 @@ impl ResponseProcessor {
     }
 
     /// Process non-streaming chat response (collects all responses and builds final response)
+    #[allow(clippy::too_many_arguments)]
     pub async fn process_non_streaming_chat_response(
         &self,
         execution_result: ExecutionResult,
@@ -217,6 +220,7 @@ impl ResponseProcessor {
         tokenizer: Arc<dyn Tokenizer>,
         stop_decoder: &mut StopSequenceDecoder,
         request_logprobs: bool,
+        reasoning_started_in_prefill: bool,
     ) -> Result<ChatCompletionResponse, axum::response::Response> {
         // Collect all responses from the execution result
         let all_responses =
@@ -273,6 +277,7 @@ impl ResponseProcessor {
                     history_tool_calls_count,
                     reasoning_parser_available,
                     tool_parser_available,
+                    reasoning_started_in_prefill,
                 )
                 .await
             {
@@ -461,5 +466,124 @@ impl ResponseProcessor {
         }
 
         Ok(result_array)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+    use llm_tokenizer::{
+        stop::StopSequenceDecoderBuilder,
+        traits::{Decoder, Encoder, Encoding, SpecialTokens, Tokenizer},
+    };
+    use serde_json::json;
+    use smg_grpc_client::sglang_proto::GenerateComplete;
+
+    use super::*;
+
+    struct PrefillReasoningTokenizer {
+        special_tokens: SpecialTokens,
+    }
+
+    impl PrefillReasoningTokenizer {
+        fn new() -> Self {
+            Self {
+                special_tokens: SpecialTokens::default(),
+            }
+        }
+    }
+
+    impl Encoder for PrefillReasoningTokenizer {
+        fn encode(&self, _input: &str, _add_special_tokens: bool) -> Result<Encoding> {
+            Ok(Encoding::Plain(Vec::new()))
+        }
+
+        fn encode_batch(
+            &self,
+            inputs: &[&str],
+            _add_special_tokens: bool,
+        ) -> Result<Vec<Encoding>> {
+            Ok(inputs.iter().map(|_| Encoding::Plain(Vec::new())).collect())
+        }
+    }
+
+    impl Decoder for PrefillReasoningTokenizer {
+        fn decode(&self, token_ids: &[u32], _skip_special_tokens: bool) -> Result<String> {
+            Ok(token_ids
+                .iter()
+                .filter_map(|token_id| match token_id {
+                    1 => Some("reasoning without an opening tag"),
+                    2 => Some("</think>"),
+                    3 => Some("final answer"),
+                    _ => None,
+                })
+                .collect())
+        }
+    }
+
+    impl Tokenizer for PrefillReasoningTokenizer {
+        fn vocab_size(&self) -> usize {
+            3
+        }
+
+        fn get_special_tokens(&self) -> &SpecialTokens {
+            &self.special_tokens
+        }
+
+        fn token_to_id(&self, _token: &str) -> Option<u32> {
+            None
+        }
+
+        fn id_to_token(&self, _id: u32) -> Option<String> {
+            None
+        }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    #[tokio::test]
+    async fn prefilled_think_token_is_reflected_in_non_streaming_chat_choice() {
+        let tokenizer: Arc<dyn Tokenizer> = Arc::new(PrefillReasoningTokenizer::new());
+        let mut stop_decoder = StopSequenceDecoderBuilder::new(tokenizer.clone()).build();
+        let request: ChatCompletionRequest = serde_json::from_value(json!({
+            "model": "qwen3",
+            "messages": [{"role": "user", "content": "Why?"}]
+        }))
+        .unwrap();
+        let complete = ProtoGenerateComplete::Sglang(GenerateComplete {
+            output_ids: vec![1, 2, 3],
+            finish_reason: "stop".to_string(),
+            completion_tokens: 3,
+            ..Default::default()
+        });
+        let processor = ResponseProcessor::new(
+            ToolParserFactory::new(),
+            ReasoningParserFactory::new(),
+            None,
+            Some("qwen3".to_string()),
+        );
+
+        let choice = processor
+            .process_single_choice(
+                &complete,
+                0,
+                &request,
+                &tokenizer,
+                &mut stop_decoder,
+                0,
+                true,
+                false,
+                true,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            choice.message.reasoning_content.as_deref(),
+            Some("reasoning without an opening tag")
+        );
+        assert_eq!(choice.message.content.as_deref(), Some("final answer"));
     }
 }

--- a/sgl-model-gateway/src/routers/grpc/regular/stages/chat/preparation.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/stages/chat/preparation.rs
@@ -93,6 +93,9 @@ impl ChatPreparationStage {
             request.no_stop_trim,
         );
 
+        ctx.state.reasoning_started_in_prefill =
+            utils::reasoning_started_in_prefill(&processed_messages.text);
+
         // Store results in context
         ctx.state.preparation = Some(PreparationOutput {
             original_text: Some(processed_messages.text.clone()),

--- a/sgl-model-gateway/src/routers/grpc/regular/stages/chat/response_processing.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/stages/chat/response_processing.rs
@@ -91,6 +91,7 @@ impl ChatResponseProcessingStage {
                 "Tokenizer not cached in context - preparation stage may have been skipped",
             )
         })?;
+        let reasoning_started_in_prefill = ctx.state.reasoning_started_in_prefill;
 
         if is_streaming {
             // Streaming: Use StreamingProcessor and return SSE response
@@ -99,6 +100,7 @@ impl ChatResponseProcessingStage {
                 ctx.chat_request_arc(), // Cheap Arc clone (8 bytes)
                 dispatch,
                 tokenizer,
+                reasoning_started_in_prefill,
             );
 
             // Attach load guards to response body for proper RAII lifecycle
@@ -135,6 +137,7 @@ impl ChatResponseProcessingStage {
                 tokenizer,
                 stop_decoder,
                 request_logprobs,
+                reasoning_started_in_prefill,
             )
             .await?;
 

--- a/sgl-model-gateway/src/routers/grpc/regular/streaming.rs
+++ b/sgl-model-gateway/src/routers/grpc/regular/streaming.rs
@@ -89,6 +89,7 @@ impl StreamingProcessor {
         chat_request: Arc<ChatCompletionRequest>,
         dispatch: context::DispatchMetadata,
         tokenizer: Arc<dyn Tokenizer>,
+        reasoning_started_in_prefill: bool,
     ) -> Response {
         use bytes::Bytes;
         use tokio::sync::mpsc;
@@ -117,6 +118,7 @@ impl StreamingProcessor {
                             tokenizer_clone,
                             stop_params,
                             chat_request,
+                            reasoning_started_in_prefill,
                             &tx,
                         )
                         .await;
@@ -149,6 +151,7 @@ impl StreamingProcessor {
                             tokenizer_clone,
                             stop_params,
                             chat_request,
+                            reasoning_started_in_prefill,
                             &tx,
                         )
                         .await;
@@ -188,6 +191,7 @@ impl StreamingProcessor {
     }
 
     /// Process streaming chunks from a single stream (Regular mode)
+    #[allow(clippy::too_many_arguments)]
     pub async fn process_streaming_chunks(
         &self,
         mut grpc_stream: ProtoStream,
@@ -195,6 +199,7 @@ impl StreamingProcessor {
         tokenizer: Arc<dyn Tokenizer>,
         stop_params: (Option<StringOrArray>, Option<Vec<u32>>, bool, bool),
         original_request: Arc<ChatCompletionRequest>,
+        reasoning_started_in_prefill: bool,
         tx: &UnboundedSender<Result<Bytes, io::Error>>,
     ) -> Result<(), String> {
         // Metrics timing
@@ -362,6 +367,7 @@ impl StreamingProcessor {
                                 model,
                                 created,
                                 system_fingerprint,
+                                reasoning_started_in_prefill,
                             )
                             .await;
                         if let Some(chunk) = reasoning_chunk {
@@ -614,6 +620,7 @@ impl StreamingProcessor {
         tokenizer: Arc<dyn Tokenizer>,
         stop_params: (Option<StringOrArray>, Option<Vec<u32>>, bool, bool),
         original_request: Arc<ChatCompletionRequest>,
+        reasoning_started_in_prefill: bool,
         tx: &UnboundedSender<Result<Bytes, io::Error>>,
     ) -> Result<(), String> {
         // Phase 1.5: Collect input_logprobs from prefill stream if requested
@@ -643,6 +650,7 @@ impl StreamingProcessor {
                 tokenizer,
                 stop_params,
                 original_request,
+                reasoning_started_in_prefill,
                 tx,
             )
             .await;
@@ -1105,6 +1113,7 @@ impl StreamingProcessor {
         model: &str,
         created: u64,
         system_fingerprint: Option<&str>,
+        reasoning_started_in_prefill: bool,
     ) -> (String, Option<ChatCompletionStreamResponse>, bool) {
         // Create fresh parser for this index (not pooled, to avoid state pollution)
         reasoning_parsers.entry(index).or_insert_with(|| {
@@ -1112,6 +1121,7 @@ impl StreamingProcessor {
                 &self.reasoning_parser_factory,
                 self.configured_reasoning_parser.as_deref(),
                 model,
+                reasoning_started_in_prefill,
             )
             .expect("Parser should be available - checked upfront");
             Arc::new(tokio::sync::Mutex::new(parser))

--- a/sgl-model-gateway/src/routers/grpc/utils.rs
+++ b/sgl-model-gateway/src/routers/grpc/utils.rs
@@ -26,10 +26,7 @@ use crate::{
         },
         generate::GenerateFinishReason,
     },
-    reasoning_parser::{
-        ParserFactory as ReasoningParserFactory, PooledParser as ReasoningPooledParser,
-        ReasoningParser,
-    },
+    reasoning_parser::{ParserFactory as ReasoningParserFactory, ReasoningParser},
     routers::{error, grpc::proto_wrapper::ProtoResponseVariant},
     tokenizer::{
         cache::CachedTokenizer,
@@ -42,6 +39,8 @@ use crate::{
         ParserFactory as ToolParserFactory, PooledParser as ToolPooledParser, ToolParser,
     },
 };
+
+const THINK_START_TOKEN: &str = "<think>";
 
 /// Resolve tokenizer from registry and cache it in request context.
 ///
@@ -516,6 +515,14 @@ pub(crate) fn process_chat_messages(
     })
 }
 
+/// Return whether the rendered generation prompt opened a reasoning block.
+///
+/// Some chat templates place `<think>` in the prefill, so generated text begins
+/// with reasoning content and only contains the closing `</think>` marker.
+pub(crate) fn reasoning_started_in_prefill(prompt: &str) -> bool {
+    prompt.trim_end().ends_with(THINK_START_TOKEN)
+}
+
 /// Create a StopSequenceDecoder from stop parameters
 pub(crate) fn create_stop_decoder(
     tokenizer: &Arc<dyn Tokenizer>,
@@ -766,41 +773,14 @@ pub(crate) fn check_tool_parser_availability(
     }
 }
 
-/// Get the appropriate reasoning parser for a model
-///
-/// If a parser name is explicitly configured, use that parser.
-/// Otherwise, auto-detect based on the model name.
-/// Get a pooled reasoning parser (for non-streaming where state doesn't matter)
-pub(crate) fn get_reasoning_parser(
-    reasoning_parser_factory: &ReasoningParserFactory,
-    configured_parser: Option<&str>,
-    model: &str,
-) -> ReasoningPooledParser {
-    if let Some(parser_name) = configured_parser {
-        // Use configured parser if specified
-        reasoning_parser_factory
-            .registry()
-            .get_pooled_parser(parser_name)
-            .unwrap_or_else(|| {
-                warn!(
-                    "Configured reasoning parser '{}' not found, falling back to model-based selection",
-                    parser_name
-                );
-                reasoning_parser_factory.get_pooled(model)
-            })
-    } else {
-        // Auto-detect based on model
-        reasoning_parser_factory.get_pooled(model)
-    }
-}
-
 /// Create a fresh reasoning parser instance (for streaming where state isolation is needed)
 pub(crate) fn create_reasoning_parser(
     reasoning_parser_factory: &ReasoningParserFactory,
     configured_parser: Option<&str>,
     model: &str,
+    reasoning_started_in_prefill: bool,
 ) -> Option<Box<dyn ReasoningParser>> {
-    if let Some(parser_name) = configured_parser {
+    let mut parser = if let Some(parser_name) = configured_parser {
         // Use configured parser if specified
         reasoning_parser_factory
             .registry()
@@ -815,7 +795,17 @@ pub(crate) fn create_reasoning_parser(
     } else {
         // Auto-detect based on model
         reasoning_parser_factory.registry().create_for_model(model)
+    }?;
+
+    if reasoning_started_in_prefill {
+        // The parser API in reasoning-parser 1.0 has no state setter. Feeding the
+        // already-consumed marker initializes the same state without emitting it.
+        if let Err(e) = parser.parse_reasoning_streaming_incremental(THINK_START_TOKEN) {
+            warn!("Failed to initialize reasoning parser from prefill: {}", e);
+        }
     }
+
+    Some(parser)
 }
 
 /// Get the appropriate tool parser for a model
@@ -1237,5 +1227,51 @@ mod tests {
         assert_eq!(content_array.len(), 2);
         assert_eq!(content_array[0]["type"], "text");
         assert_eq!(content_array[1], json!({"type": "image"}));
+    }
+
+    #[test]
+    fn test_reasoning_started_in_prefill_detection() {
+        assert!(reasoning_started_in_prefill(
+            "<|im_start|>assistant\n<think>\n"
+        ));
+        assert!(!reasoning_started_in_prefill(
+            "<|im_start|>assistant\n<think>\n\n</think>\n\n"
+        ));
+        assert!(!reasoning_started_in_prefill(
+            "<think>reasoning from history</think>\n<|im_start|>assistant\n"
+        ));
+    }
+
+    #[test]
+    fn test_qwen3_prefill_reasoning_non_streaming() {
+        let factory = ReasoningParserFactory::new();
+        let mut parser = create_reasoning_parser(&factory, Some("qwen3"), "qwen3", true)
+            .expect("qwen3 parser should be available");
+
+        let result = parser
+            .detect_and_parse_reasoning("reasoning without an opening tag</think>final answer")
+            .unwrap();
+
+        assert_eq!(result.reasoning_text, "reasoning without an opening tag");
+        assert_eq!(result.normal_text, "final answer");
+    }
+
+    #[test]
+    fn test_qwen3_prefill_reasoning_streaming() {
+        let factory = ReasoningParserFactory::new();
+        let mut parser = create_reasoning_parser(&factory, Some("qwen3"), "qwen3", true)
+            .expect("qwen3 parser should be available");
+
+        let reasoning = parser
+            .parse_reasoning_streaming_incremental("reasoning without an opening tag")
+            .unwrap();
+        let answer = parser
+            .parse_reasoning_streaming_incremental("</think>final answer")
+            .unwrap();
+
+        assert_eq!(reasoning.reasoning_text, "reasoning without an opening tag");
+        assert!(reasoning.normal_text.is_empty());
+        assert!(answer.reasoning_text.is_empty());
+        assert_eq!(answer.normal_text, "final answer");
     }
 }


### PR DESCRIPTION
## Motivation

Fixes #35148.

Qwen3.8's chat template injects the opening `<think>` token into the generation prefill when thinking is enabled. The generated output therefore starts directly with reasoning text and contains only the closing `</think>` token.

The gateway's Rust `qwen3` parser starts outside reasoning mode and previously waited for an opening `<think>` token in the generated output. Because that token was already consumed as part of the prompt, the gateway returned the reasoning text in `content` and left `reasoning_content` empty.

## Modifications

- Detect whether the rendered generation prompt ends with a prefilled `<think>` token. Inspecting the rendered prompt also respects request-level chat template kwargs, including explicitly disabling thinking.
- Propagate the prefill reasoning state through regular and PD-disaggregated chat response processing.
- Initialize fresh reasoning parser instances from that state in both streaming and non-streaming paths.
- Use an isolated parser for each non-streaming choice instead of sharing a stateful pooled parser.
- Add parser-level and response-processing regression tests for Qwen3 output that begins with reasoning text and contains `</think>` without a generated `<think>` token.

## Upstream Compatibility / Maintainer Input

The latest upstream SMG implementation already supports this case explicitly: newer `reasoning-parser` versions expose parser state methods such as `mark_reasoning_started()` and `mark_think_start_stripped()`, while newer `llm-tokenizer` versions expose whether a chat template injects thinking into the prefill.

This repository currently pins `reasoning-parser = 1.0.0` and `llm-tokenizer = 1.3.2`, which do not provide those APIs. This PR intentionally does not upgrade either dependency because doing so would introduce a much larger dependency and integration change for a narrowly scoped bug fix. Instead, it detects the state from the rendered prompt and initializes the existing parser through its incremental parsing interface, which is equivalent for the `<think>` format used here.

Maintainers: would you prefer to keep this targeted compatibility fix, or update the gateway to newer upstream parser/tokenizer versions and use their explicit prefill-thinking APIs instead? I am happy to adjust the implementation based on the preferred dependency-upgrade strategy.

## Accuracy Tests

Added four CPU-only Rust regression tests covering:

- rendered-prefill detection, including prompts that end with `<think>`, prompts where the reasoning block is already closed, and historical reasoning that must not affect the new response;
- complete non-streaming Qwen3 parsing when generated output contains reasoning text and `</think>` but no generated `<think>`;
- incremental streaming Qwen3 parsing for the same output format; and
- the non-streaming response-processing path using an in-memory tokenizer and a synthetic gRPC `GenerateComplete`, asserting that reasoning is returned in `reasoning_content` and the final answer is returned in `content`.

Executed:

```bash
cd sgl-model-gateway
cargo test --lib --quiet
cargo test --lib prefill
cargo fmt --all -- --check
```

The full library test suite reported 396 passed and 0 failed. The filtered `prefill` run reported 13 passed and 0 failed, including all four new regression tests.

These tests do not load a real tokenizer or model and do not download model weights. The parser-level tests use fixed strings, while the response-processing test uses an in-memory tokenizer and a synthetic gRPC response. Cargo may download Rust crate dependencies on a clean development environment.

A Qwen3.8-27B model end-to-end test was not run because the change is confined to gateway response parsing and is directly covered by deterministic unit tests.

## Speed Tests and Profiling

Not applicable. The change adds one suffix check to the rendered prompt and initializes per-response parser state; it does not modify model execution or the token generation path.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Documentation update is not required because there is no user-facing API change.
- [x] Accuracy and speed benchmarks are not applicable to this response-parsing fix.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32153080147](https://github.com/sgl-project/sglang/actions/runs/32153080147)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32153079822](https://github.com/sgl-project/sglang/actions/runs/32153079822)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->