### PR TITLE
[AMD] MiniMax-M3: fuse sparse QK norm, RoPE and cache writes with AITER

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -749,6 +749,10 @@ class Envs:
     # AMD, ROCm, and AITER
     # ===================================================================
     SGLANG_USE_AITER = EnvBool(False)
+    # Fuse MiniMax-M3 main/index QK norm + RoPE with main KV and index-K cache
+    # insertion. Requires an AITER build with the fp8_e4m3_unit cache contract.
+    # Kept opt-in so SGLang remains compatible with older installed AITER wheels.
+    SGLANG_M3_USE_AITER_FUSED_QKNORM = EnvBool(False)
     SGLANG_USE_AITER_AG = EnvBool(True)
     # Use reduce_scatter (instead of all_reduce + dp_scatter) for the equal-chunk
     # MAX_LEN DP-MoE combine. Default ON for ROCm/HIP (uses the aiter custom

--- a/python/sglang/srt/layers/attention/minimax_sparse_backend.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_backend.py
@@ -1498,18 +1498,22 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
     ):
         assert len(kwargs) == 0
         disable_value = layer.layer_id in self.disable_value_layer_ids
-        self.kv_pool.set_fused_kv_index_buffer(
-            layer,
-            forward_batch.out_cache_loc,
-            k,
-            v,
-            idx_k,
-            None if disable_value else idx_v,
-            layer.k_scale_float,
-            layer.v_scale_float,
-            layer.idx_k_scale_float,
-            layer.idx_v_scale_float,
+        kv_cached_by_fusion = self._is_sparse_kv_cached_by_fusion(
+            forward_batch, layer.layer_id
         )
+        if not kv_cached_by_fusion:
+            self.kv_pool.set_fused_kv_index_buffer(
+                layer,
+                forward_batch.out_cache_loc,
+                k,
+                v,
+                idx_k,
+                None if disable_value else idx_v,
+                layer.k_scale_float,
+                layer.v_scale_float,
+                layer.idx_k_scale_float,
+                layer.idx_v_scale_float,
+            )
         k_cache, v_cache = self.kv_pool.get_kv_buffer(layer.layer_id)
         if disable_value:
             idx_k_cache = self.kv_pool.get_index_k_buffer(layer.layer_id)

--- a/python/sglang/srt/models/minimax_m3.py
+++ b/python/sglang/srt/models/minimax_m3.py
@@ -136,6 +136,17 @@ if _is_npu:
         wait_share_stream,
     )
 
+_aiter = None
+_has_aiter_fused_qknorm = False
+if _is_hip and envs.SGLANG_USE_AITER.get():
+    try:
+        import aiter as _aiter
+
+        _has_aiter_fused_qknorm = hasattr(_aiter, "fused_qknorm_idxrqknorm")
+    except ImportError:
+        _aiter = None
+        _has_aiter_fused_qknorm = False
+
 logger = logging.getLogger(__name__)
 
 
@@ -779,6 +790,23 @@ class MiniMaxM3Attention(nn.Module):
             and self.index_k_norm.variance_epsilon == self.q_norm.variance_epsilon
             and self.index_rotary_emb is self.rotary_emb
         )
+        self._aiter_cos_sin_cache = None
+        self._can_use_aiter_fused_qknorm_static = (
+            self.is_sparse_attention_layer
+            and self.disable_index_value
+            and _has_aiter_fused_qknorm
+            and envs.SGLANG_M3_USE_AITER_FUSED_QKNORM.get()
+            and self.qk_norm_type == "per_head"
+            and self.use_gemma_norm
+            and self.head_dim == 128
+            and self.idx_head_dim == 128
+            and self.rotary_dim <= self.head_dim
+            and getattr(self.rotary_emb, "is_neox_style", False)
+            and self.index_rotary_emb is self.rotary_emb
+            and self.q_norm.variance_epsilon == self.k_norm.variance_epsilon
+            and self.index_q_norm.variance_epsilon == self.q_norm.variance_epsilon
+            and self.index_k_norm.variance_epsilon == self.q_norm.variance_epsilon
+        )
 
     def _can_use_rocm_qk_norm_rope(
         self, positions: torch.Tensor, q: torch.Tensor, k: torch.Tensor
@@ -1008,6 +1036,158 @@ class MiniMaxM3Attention(nn.Module):
         sparse_backend = getattr(attn_backend, "sparse", None)
         return getattr(sparse_backend, "kv_pool", None)
 
+    def _get_aiter_cos_sin_cache(self, packed_qkv: torch.Tensor) -> torch.Tensor:
+        source = self.rotary_emb.cos_sin_cache
+        cached = self._aiter_cos_sin_cache
+        if (
+            cached is not None
+            and cached.dtype == packed_qkv.dtype
+            and cached.device == packed_qkv.device
+            and cached.shape == source.shape
+        ):
+            return cached
+
+        cached = source.to(
+            device=packed_qkv.device, dtype=packed_qkv.dtype
+        ).contiguous()
+        if not torch.compiler.is_compiling():
+            self._aiter_cos_sin_cache = cached
+        return cached
+
+    def _aiter_sparse_qknorm_cache(
+        self,
+        packed_qkv: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+    ) -> Optional[
+        Tuple[
+            torch.Tensor,
+            torch.Tensor,
+            torch.Tensor,
+            torch.Tensor,
+            torch.Tensor,
+            Optional[torch.Tensor],
+        ]
+    ]:
+        """Run AITER's packed MiniMax-M3 producer with SGLang cache semantics.
+
+        The SGLang contract is page-major NHD storage, unit-scale main FP8, and
+        a BF16 index-K cache. The sparse attention consumer reads those caches
+        directly, so K/V/index-K tensor outputs are intentionally left raw and
+        must not be stored a second time by the backend.
+        """
+        if not self._can_use_aiter_fused_qknorm_static:
+            return None
+
+        kv_pool = self._get_sparse_kv_pool()
+        main_pool = getattr(kv_pool, "main_pool", None)
+        out_cache_loc = getattr(forward_batch, "out_cache_loc", None)
+        if (
+            kv_pool is None
+            or main_pool is None
+            or getattr(main_pool, "kv_cache_layout", None) != "nhd"
+            or out_cache_loc is None
+            or positions.dim() != 1
+            or positions.dtype != torch.int64
+            or not positions.is_contiguous()
+            or out_cache_loc.dim() != 1
+            or out_cache_loc.dtype != torch.int64
+            or not out_cache_loc.is_contiguous()
+            or packed_qkv.dim() != 2
+            or packed_qkv.dtype not in (torch.bfloat16, torch.float16)
+        ):
+            return None
+
+        num_tokens = packed_qkv.shape[0]
+        expected_width = (
+            self.num_heads + 2 * self.num_kv_heads + self.num_idx_heads + 1
+        ) * self.head_dim
+        if (
+            packed_qkv.shape[1] != expected_width
+            or positions.shape[0] < num_tokens
+            or out_cache_loc.shape[0] < num_tokens
+        ):
+            return None
+
+        layer_id = self.attn.layer_id
+        k_cache, v_cache = kv_pool.get_kv_buffer(layer_id)
+        idx_k_cache = kv_pool.get_index_k_buffer(layer_id)
+        page_size = int(kv_pool.page_size)
+        if (
+            page_size <= 0
+            or k_cache.dim() != 3
+            or v_cache.dim() != 3
+            or idx_k_cache.dim() != 3
+            or not k_cache.is_contiguous()
+            or not v_cache.is_contiguous()
+            or not idx_k_cache.is_contiguous()
+            or k_cache.shape != v_cache.shape
+            or k_cache.shape[1:] != (self.num_kv_heads, self.head_dim)
+            or idx_k_cache.shape[1:] != (1, self.idx_head_dim)
+            or k_cache.shape[0] % page_size != 0
+            or idx_k_cache.dtype != packed_qkv.dtype
+        ):
+            return None
+
+        fp8_e4m3_dtypes = (torch.float8_e4m3fn, torch.float8_e4m3fnuz)
+        if k_cache.dtype in fp8_e4m3_dtypes:
+            kv_cache_dtype = "fp8_e4m3_unit"
+        elif k_cache.dtype == packed_qkv.dtype:
+            kv_cache_dtype = "auto"
+        else:
+            return None
+
+        num_blocks = k_cache.shape[0] // page_size
+        k_cache_pages = k_cache.view(
+            num_blocks, page_size, self.num_kv_heads, self.head_dim
+        )
+        v_cache_pages = v_cache.view(
+            num_blocks, page_size, self.num_kv_heads, self.head_dim
+        )
+        q_out = torch.empty(
+            (num_tokens, self.q_size),
+            dtype=packed_qkv.dtype,
+            device=packed_qkv.device,
+        )
+        idx_q_out = torch.empty(
+            (num_tokens, self.num_idx_heads * self.idx_head_dim),
+            dtype=packed_qkv.dtype,
+            device=packed_qkv.device,
+        )
+
+        _aiter.fused_qknorm_idxrqknorm(
+            packed_qkv.contiguous(),
+            self.q_norm.weight.data,
+            self.k_norm.weight.data,
+            self._get_aiter_cos_sin_cache(packed_qkv),
+            positions,
+            self.num_heads,
+            self.num_kv_heads,
+            self.rotary_dim,
+            self.q_norm.variance_epsilon,
+            self.index_q_norm.weight.data,
+            self.index_k_norm.weight.data,
+            self.num_idx_heads,
+            out_cache_loc,
+            k_cache_pages,
+            v_cache_pages,
+            idx_k_cache,
+            page_size,
+            q_out,
+            idx_q_out,
+            out_cache_loc,
+            kv_cache_dtype=kv_cache_dtype,
+            index_cache_dtype="auto",
+            asm_layout=False,
+        )
+
+        main_qkv = packed_qkv[:, : self._fused_main_size]
+        _, k, v = main_qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+        idx_qkv = packed_qkv[:, self._fused_main_size :]
+        _, idx_k, idx_v = self._split_index_qkv(idx_qkv)
+        self._mark_sparse_kv_cached_by_fusion(forward_batch, layer_id)
+        return q_out, k, v, idx_q_out, idx_k, idx_v
+
     def _sparse_qk_index_norm_rope_cache(
         self,
         positions: torch.Tensor,
@@ -1111,6 +1291,14 @@ class MiniMaxM3Attention(nn.Module):
         if self._fused_qkv_index is not None:
             fused_out = self.fused_qkv_index_proj(hidden_states)
             qkv = fused_out[:, : self._fused_main_size]
+
+            aiter_prepared = self._aiter_sparse_qknorm_cache(
+                fused_out, positions, forward_batch
+            )
+            if aiter_prepared is not None:
+                q, k, v, idx_q, idx_k, idx_v = aiter_prepared
+                inner_state = (q, k, v, idx_q, idx_k, idx_v, forward_batch)
+                return None, forward_batch, inner_state
 
             if self._combined_qknorm_ok:
                 from sglang.kernels.ops.attention.minimax_qknorm_rope import (


### PR DESCRIPTION
## Motivation

After the packed QKV+index projection from #32099, every MiniMax-M3 sparse attention layer still launches separate kernels for Q/K and index Q/K norm + RoPE, followed by main K/V and index-K cache writes.

This PR connects AITER `fused_qknorm_idxrqknorm` to the SGLang MiniMax-M3 sparse path. It keeps the current SGLang cache contract and is opt-in:

```bash
SGLANG_M3_USE_AITER_FUSED_QKNORM=1
```

Default behavior is unchanged when the env is unset.

## Changes

- Fuse main/index per-head Gemma RMSNorm, partial NeoX RoPE, main K/V cache write and index-K cache write.
- Use SGLang's existing page-1 NHD, unit-scale FP8 main KV and BF16 index-K contract.
- Skip the old duplicate cache-store path in both prefill and decode when the fused producer has already written the cache.
- Fall back to the existing path if the AITER op, packed projection, dtype, layout or model shape is not compatible.
- Keep the integration opt-in for compatibility with older AITER wheels.

This only changes the sparse attention preparation/cache stage. Dense attention layers, index score/top-k, sparse GQA, output projection, MoE and all-reduce are unchanged.

## Results

MiniMax-M3-MXFP8, MI355X, TP4, BF16, FP8 E4M3 KV, fixed ISL 8192 / OSL 1024. The baseline and candidate use the same four-PR stack (#32036, #32099, #32190, #32230); the fused env is the only functional difference.

| concurrency | total tok/s/GPU | median TTFT (s) | median TPOT (s) | uplift vs. four-PR baseline |
|---:|---:|---:|---:|---:|
| 1 | 188.27 | 0.33 | 0.01 | **+5.50%** |
| 2 | 343.66 | 0.53 | 0.01 | **+6.77%** |
| 4 | 614.34 | 0.88 | 0.01 | **+5.95%** |
| 8 | 991.32 | 1.48 | 0.02 | **+4.78%** |
| 16 | 1640.26 | 2.69 | 0.02 | **+5.74%** |
| 32 | 2330.60 | 5.11 | 0.03 | **+5.99%** |
| 64 | 3236.21 | 9.96 | 0.03 | **+3.89%** |
| 128 | 4041.67 | 19.77 | 0.05 | **+3.26%** |
| 256 | 4758.47 | 39.16 | 0.08 | **+3.05%** |

The fused path is faster at every tested concurrency from 1 to 256.

## Accuracy

MiniMax-M3-MXFP8, MI355X TP4, 5-shot GSM8K, 1319 questions, `temperature=0`:

| path | accuracy | correct | invalid |
|---|---:|---:|---:|
| Existing path | 0.846 | 1116/1319 | 0.001 |
| Fused path | 0.864 | 1140/1319 | 0.001 |

Both runs completed successfully with no runtime traceback during evaluation. The fused path did not regress aggregate GSM8K accuracy.

## Test configuration

```bash
HIP_VISIBLE_DEVICES=4,5,6,7 \
SGLANG_USE_AITER=1 \
SGLANG_M3_USE_AITER_FUSED_QKNORM=1 \
SGLANG_OPT_USE_BF16_ROUTER_GEMM=0 \
SGLANG_FORCE_MXFP8_BLOCK_CONVERT=1 \
SGLANG_MXFP8_MOE_KEEP_NATIVE=1 \
SGLANG_USE_AITER_MOE_GU_ITLV=1 \
SGLANG_M3_ALLOW_CUSTOM_AR=1 \
ROCM_QUICK_REDUCE_QUANTIZATION=INT4 \
ROCM_QUICK_REDUCE_CAST_BF16_TO_FP16=1 \
python3 -m sglang.launch_server \
  --model-path /models/MiniMaxAI/MiniMax-M3-MXFP8 \
  --quantization mxfp8 --dtype bfloat16 --tp 4 --trust-remote-code \
  --attention-backend aiter --kv-cache-dtype fp8_e4m3 \
  --moe-runner-backend aiter --disable-radix-cache \
  --chunked-prefill-size 8192 --mem-fraction-static 0.90 \
  --context-length 32768 --watchdog-timeout 1200 \
  --host 127.0.0.1 --port 30000
```

Benchmark workload: random dataset, request rate `inf`, ignore EOS, 10x concurrency prompts and 2x concurrency warmups.

## Dependencies and scope

- Uses the unit-scale AITER contract landed in `ROCm/aiter#4362`.
- The packed projection from #32099 is already in `main`; this PR is rebased directly on `main`.
- Supersedes #32265, which was closed when its temporary base branch was removed after #32099 merged.
- Tested on top of #32036, #32099, #32190 and #32230.
- The tested SGLang version resolves `moe_runner_backend` to Triton in both baseline and candidate, so the numbers above only claim the fused attention producer change.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35656272385](https://github.com/sgl-project/sglang/actions/runs/35656272385)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35656271823](https://github.com/sgl-project/sglang/actions/runs/35656271823)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35656272320](https://github.com/sgl-project/sglang/actions/runs/35656272320)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->