### PR TITLE
fix: guard top-logprobs and token-ids logprob rows against missing data

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -2678,7 +2678,11 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             )
 
         if top_logprobs_num > 0:
-            if len(recv_obj.input_top_logprobs_val) > 0:
+            if (
+                recv_obj.input_top_logprobs_val is not None
+                and len(recv_obj.input_top_logprobs_val) > 0
+                and recv_obj.input_top_logprobs_val[recv_obj_index] is not None
+            ):
                 state.input_top_logprobs_val.extend(
                     recv_obj.input_top_logprobs_val[recv_obj_index]
                 )
@@ -2694,27 +2698,39 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                     recv_obj.input_top_logprobs_idx_flat[recv_obj_index],
                     recv_obj.input_top_logprobs_flat_null_prefix[recv_obj_index],
                 )
-            state.output_top_logprobs_val.extend(
-                recv_obj.output_top_logprobs_val[recv_obj_index]
-            )
-            state.output_top_logprobs_idx.extend(
-                recv_obj.output_top_logprobs_idx[recv_obj_index]
-            )
+            if (
+                recv_obj.output_top_logprobs_val is not None
+                and recv_obj.output_top_logprobs_val[recv_obj_index] is not None
+            ):
+                state.output_top_logprobs_val.extend(
+                    recv_obj.output_top_logprobs_val[recv_obj_index]
+                )
+                state.output_top_logprobs_idx.extend(
+                    recv_obj.output_top_logprobs_idx[recv_obj_index]
+                )
 
         if token_ids_logprob is not None:
-            if len(recv_obj.input_token_ids_logprobs_val) > 0:
+            if (
+                recv_obj.input_token_ids_logprobs_val is not None
+                and len(recv_obj.input_token_ids_logprobs_val) > 0
+                and recv_obj.input_token_ids_logprobs_val[recv_obj_index] is not None
+            ):
                 state.input_token_ids_logprobs_val.extend(
                     recv_obj.input_token_ids_logprobs_val[recv_obj_index]
                 )
                 state.input_token_ids_logprobs_idx.extend(
                     recv_obj.input_token_ids_logprobs_idx[recv_obj_index]
                 )
-            state.output_token_ids_logprobs_val.extend(
-                recv_obj.output_token_ids_logprobs_val[recv_obj_index]
-            )
-            state.output_token_ids_logprobs_idx.extend(
-                recv_obj.output_token_ids_logprobs_idx[recv_obj_index]
-            )
+            if (
+                recv_obj.output_token_ids_logprobs_val is not None
+                and recv_obj.output_token_ids_logprobs_val[recv_obj_index] is not None
+            ):
+                state.output_token_ids_logprobs_val.extend(
+                    recv_obj.output_token_ids_logprobs_val[recv_obj_index]
+                )
+                state.output_token_ids_logprobs_idx.extend(
+                    recv_obj.output_token_ids_logprobs_idx[recv_obj_index]
+                )
 
         self.add_logprob_to_meta_info(
             meta_info,

--- a/test/registered/unit/managers/test_flat_raw_top_logprobs.py
+++ b/test/registered/unit/managers/test_flat_raw_top_logprobs.py
@@ -569,6 +569,93 @@ class TestTokenizerManagerLogprobs(CustomTestCase):
         self.assertEqual(meta_info["output_token_logprobs"], [(-0.25, 42, None)])
         self.assertEqual(meta_info["output_token_logprobs_length"], 1)
 
+    def test_output_top_logprobs_without_input_logprobs(self):
+        """Output-only logprobs with top_logprobs_num > 0.
+
+        The scheduler leaves ReqLogprob.input_top_logprobs_val at None when the
+        prefill pass did not compute input-side top logprobs, and the output
+        streamer appends that per-request None into the batch list. The nested
+        rows therefore arrive as [None]: len() > 0 passes, so extending the
+        state with the None element must not crash."""
+        state = _make_state(return_logprob=True, top_logprobs_num=2)
+        recv_obj = SimpleNamespace(
+            input_token_logprobs_val=None,
+            input_token_logprobs_idx=None,
+            output_token_logprobs_val=[[-0.25]],
+            output_token_logprobs_idx=[[42]],
+            input_top_logprobs_val=[None],
+            input_top_logprobs_idx=[None],
+            input_top_logprobs_val_flat=None,
+            input_top_logprobs_idx_flat=None,
+            input_top_logprobs_flat_null_prefix=None,
+            output_top_logprobs_val=[[[-0.75, -1.5]]],
+            output_top_logprobs_idx=[[[7, 9]]],
+            input_token_ids_logprobs_val=None,
+            input_token_ids_logprobs_idx=None,
+            output_token_ids_logprobs_val=None,
+            output_token_ids_logprobs_idx=None,
+        )
+        meta_info = {}
+
+        _TokenizerManagerStub().convert_logprob_style(
+            meta_info,
+            state,
+            top_logprobs_num=2,
+            token_ids_logprob=None,
+            return_text_in_logprobs=False,
+            recv_obj=recv_obj,
+            recv_obj_index=0,
+        )
+
+        self.assertEqual(meta_info["input_token_logprobs"], [])
+        self.assertEqual(meta_info["output_token_logprobs"], [(-0.25, 42, None)])
+        self.assertEqual(meta_info["input_top_logprobs"], [])
+        self.assertEqual(
+            meta_info["output_top_logprobs"],
+            [[(-0.75, 7, None), (-1.5, 9, None)]],
+        )
+
+    def test_token_ids_logprobs_without_input_logprobs(self):
+        """token_ids_logprob requests hit the ids block even without input
+        logprobs; the input-side ids rows arrive as [None] and must be skipped
+        while the output-side ids rows are kept."""
+        state = _make_state(
+            return_logprob=True, top_logprobs_num=0, token_ids_logprob=[7]
+        )
+        recv_obj = SimpleNamespace(
+            input_token_logprobs_val=None,
+            input_token_logprobs_idx=None,
+            output_token_logprobs_val=[[-0.25]],
+            output_token_logprobs_idx=[[42]],
+            input_top_logprobs_val=[],
+            input_top_logprobs_idx=[],
+            input_top_logprobs_val_flat=None,
+            input_top_logprobs_idx_flat=None,
+            input_top_logprobs_flat_null_prefix=None,
+            output_top_logprobs_val=[],
+            output_top_logprobs_idx=[],
+            input_token_ids_logprobs_val=[None],
+            input_token_ids_logprobs_idx=[None],
+            output_token_ids_logprobs_val=[[[-0.5]]],
+            output_token_ids_logprobs_idx=[[[7]]],
+        )
+        meta_info = {}
+
+        _TokenizerManagerStub().convert_logprob_style(
+            meta_info,
+            state,
+            top_logprobs_num=0,
+            token_ids_logprob=[7],
+            return_text_in_logprobs=False,
+            recv_obj=recv_obj,
+            recv_obj_index=0,
+        )
+
+        self.assertEqual(meta_info["input_token_logprobs"], [])
+        self.assertEqual(meta_info["output_token_logprobs"], [(-0.25, 42, None)])
+        self.assertEqual(meta_info["input_token_ids_logprobs"], [])
+        self.assertEqual(meta_info["output_token_ids_logprobs"], [[(-0.5, 7, None)]])
+
 
 def _make_batch_token_id_output(**overrides) -> BatchTokenIDOutput:
     """A two-request BatchTokenIDOutput with the required fields stubbed."""


### PR DESCRIPTION
## Motivation

Follow-up to #34627. That PR removed the early return that dropped output logprobs when input logprobs are absent, but the removed return had also been shielding everything below it: with output-only logprob requests, execution now reaches the top-logprobs and token-ids blocks that still assume input-side data is present.

- `return_logprob=True, top_logprobs_num>0` without input logprobs: the scheduler leaves `ReqLogprob.input_top_logprobs_val` at `None` when the prefill pass did not compute input-side top logprobs, and the output streamer appends that per-request `None` into the batch list. `len(recv_obj.input_top_logprobs_val) > 0` therefore passes, and `state.input_top_logprobs_val.extend(None)` raises `TypeError: 'NoneType' object is not iterable`.
- `token_ids_logprob` set without input logprobs: the same shape arrives for the input-side token-ids rows (and the output-side fields can be `None` on paths that never populated them).

## Modifications

Extend each side only when both the batch-level field and the per-request row are present, mirroring the guards #34627 added for the plain logprob fields:

- input top logprobs: `is not None and len(...) > 0 and [i] is not None`
- output top logprobs / token-ids rows: `is not None and [i] is not None`

## Verification

- New regression tests in `test/registered/unit/managers/test_flat_raw_top_logprobs.py` (same stub style as the #34627 regression test):
  - `test_output_top_logprobs_without_input_logprobs`
  - `test_token_ids_logprobs_without_input_logprobs`
- Both fail on current `main` with the predicted `TypeError` at `tokenizer_manager.py` (`extend(None)`) and pass with this change; the pre-existing tests in the file still pass (30 passed, 2 skipped locally).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33903729420](https://github.com/sgl-project/sglang/actions/runs/33903729420)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33903729115](https://github.com/sgl-project/sglang/actions/runs/33903729115)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33903729118](https://github.com/sgl-project/sglang/actions/runs/33903729118)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->