### PR TITLE
[diffusion] fix: unblock the ComfyUI passthrough denoise path

### DIFF
--- a/python/sglang/multimodal_gen/apps/ComfyUI_SGLDiffusion/test/test_flux_pipeline.py
+++ b/python/sglang/multimodal_gen/apps/ComfyUI_SGLDiffusion/test/test_flux_pipeline.py
@@ -9,10 +9,12 @@ import torch
 from sglang.multimodal_gen.configs.sample.sampling_params import SamplingParams
 from sglang.multimodal_gen.runtime.entrypoints.diffusion_generator import DiffGenerator
 from sglang.multimodal_gen.runtime.entrypoints.utils import prepare_request
+from sglang.multimodal_gen.runtime.platforms import current_platform
 
 
 def test_comfyui_flux_pipeline_direct() -> None:
     """Test ComfyUIFluxPipeline with custom inputs."""
+    device = current_platform.device_type
     model_path = os.environ.get(
         "SGLANG_TEST_FLUX_MODEL_PATH",
         "black-forest-labs/FLUX.1-dev",  # Supports both safetensors file and diffusers format
@@ -39,7 +41,7 @@ def test_comfyui_flux_pipeline_direct() -> None:
         batch_size,
         hidden_states_seq_len,
         hidden_states_dim,
-        device="cuda",
+        device=device,
         dtype=torch.bfloat16,
     )
 
@@ -47,18 +49,18 @@ def test_comfyui_flux_pipeline_direct() -> None:
         batch_size,
         encoder_seq_len,
         encoder_dim,
-        device="cuda",
+        device=device,
         dtype=torch.bfloat16,
     )
 
     pooled_projections = torch.ones(
         batch_size,
         pooled_dim,
-        device="cuda",
+        device=device,
         dtype=torch.bfloat16,
     )
 
-    timesteps = torch.tensor([1000], dtype=torch.long, device="cuda")
+    timesteps = torch.tensor([1000], dtype=torch.long, device=device)
 
     sampling_params = SamplingParams.from_user_sampling_params_args(
         generator.server_args.model_path,
@@ -89,14 +91,14 @@ def test_comfyui_flux_pipeline_direct() -> None:
             batch_size,
             77,
             clip_dim,
-            device="cuda",
+            device=device,
             dtype=torch.bfloat16,
         )
         negative_encoder_hidden_states = torch.ones(
             batch_size,
             encoder_seq_len,
             encoder_dim,
-            device="cuda",
+            device=device,
             dtype=torch.bfloat16,
         )
         req.negative_prompt_embeds = [
@@ -107,7 +109,12 @@ def test_comfyui_flux_pipeline_direct() -> None:
         req.negative_prompt_embeds = None
 
     req.pooled_embeds = [pooled_projections]
-    req.neg_pooled_embeds = []
+    # Flux time_text_embed needs a pooled projection on every CFG branch.
+    req.neg_pooled_embeds = (
+        [torch.zeros_like(pooled_projections)]
+        if req.negative_prompt_embeds is not None
+        else []
+    )
 
     if (
         req.guidance_scale > 1.0
@@ -120,14 +127,14 @@ def test_comfyui_flux_pipeline_direct() -> None:
 
     if req.seed is not None:
         generator_device = req.generator_device
-        device_str = "cuda" if generator_device == "cuda" else "cpu"
+        device_str = device if generator_device == device else "cpu"
         req.generator = [
             torch.Generator(device_str).manual_seed(req.seed + i)
             for i in range(req.num_outputs_per_prompt)
         ]
     else:
         req.generator = [
-            torch.Generator("cuda") for _ in range(req.num_outputs_per_prompt)
+            torch.Generator(device) for _ in range(req.num_outputs_per_prompt)
         ]
 
     output_batch = generator._send_to_scheduler_and_wait_for_response([req])
@@ -136,8 +143,8 @@ def test_comfyui_flux_pipeline_direct() -> None:
     assert noise_pred is not None, "noise_pred should not be None in OutputBatch"
     assert isinstance(noise_pred, torch.Tensor), "noise_pred should be a torch.Tensor"
     assert (
-        noise_pred.device.type == "cuda"
-    ), f"noise_pred should be on cuda, got {noise_pred.device}"
+        noise_pred.device.type == device
+    ), f"noise_pred should be on {device}, got {noise_pred.device}"
     assert (
         noise_pred.dtype == torch.bfloat16
     ), f"noise_pred should be bfloat16, got {noise_pred.dtype}"

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/base.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/base.py
@@ -650,6 +650,13 @@ class PipelineConfig:
             raise ValueError("text conditioning mask must have shape [batch, seq]")
         return torch.count_nonzero(mask, dim=1).tolist()
 
+    @staticmethod
+    def seq_lens_from_prompt_embeds(prompt_embeds: "torch.Tensor") -> list[int]:
+        """Text lengths for maskless embeddings; 2-D (seq x dim) means batch=1."""
+        if prompt_embeds.ndim == 2:
+            return [int(prompt_embeds.shape[0])]
+        return [int(prompt_embeds.shape[1])] * int(prompt_embeds.shape[0])
+
     def require_text_seq_lens(
         self,
         batch,

--- a/python/sglang/multimodal_gen/runtime/managers/memory_managers/component_residency_strategies.py
+++ b/python/sglang/multimodal_gen/runtime/managers/memory_managers/component_residency_strategies.py
@@ -174,7 +174,12 @@ class ComponentOffloadStrategy(ComponentResidencyStrategy):
         self.wait_for_use(module, use, state)
         tensor = _module_reference_tensor(module)
         if tensor is not None and tensor.device.type != "cpu":
-            module.to("cpu", non_blocking=True)
+            # XPU: an async copy into pageable host memory can reach the backend
+            # memcpy with a null argument, and cannot overlap anything anyway.
+            _non_blocking = True
+            if current_platform.is_xpu():
+                _non_blocking = False
+            module.to("cpu", non_blocking=_non_blocking)
         self._ready_events.pop(use.component_name, None)
 
     def finish_request(

--- a/python/sglang/multimodal_gen/runtime/models/schedulers/scheduling_comfyui_passthrough.py
+++ b/python/sglang/multimodal_gen/runtime/models/schedulers/scheduling_comfyui_passthrough.py
@@ -112,7 +112,10 @@ class ComfyUIPassThroughScheduler(BaseScheduler, ConfigMixin, SchedulerMixin):
         Returns:
             The input sample unchanged (prev_sample = sample)
         """
-        # Increment step index for tracking
+        # DenoisingStage clears _step_index before the loop; re-seed it.
+        if self._step_index is None:
+            begin_index = self._begin_index
+            self._step_index = begin_index if begin_index is not None else 0
         self._step_index += 1
 
         # Simply return the input sample unchanged

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/comfyui_latent_preparation.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/comfyui_latent_preparation.py
@@ -23,6 +23,11 @@ from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 logger = init_logger(__name__)
 
 
+def _seq_lens_per_encoder(pipeline_config, embeds) -> list[list[int]]:
+    """Per-encoder text lengths; ComfyUI embeds arrive unpadded and maskless."""
+    return [pipeline_config.seq_lens_from_prompt_embeds(e) for e in embeds]
+
+
 class ComfyUILatentPreparationStage(LatentPreparationStage):
     """
     ComfyUI-specific latent preparation stage with device mismatch fix.
@@ -98,6 +103,20 @@ class ComfyUILatentPreparationStage(LatentPreparationStage):
                                     setattr(batch, attr_name, fixed_value)
                             except (AttributeError, TypeError):
                                 continue
+
+        # No TextEncodingStage here, so back-fill require_text_seq_lens' input.
+        pipeline_config = server_args.pipeline_config
+        if batch.prompt_embeds is not None and batch.prompt_seq_lens is None:
+            batch.prompt_seq_lens = _seq_lens_per_encoder(
+                pipeline_config, batch.prompt_embeds
+            )
+        if (
+            batch.negative_prompt_embeds is not None
+            and batch.negative_prompt_seq_lens is None
+        ):
+            batch.negative_prompt_seq_lens = _seq_lens_per_encoder(
+                pipeline_config, batch.negative_prompt_embeds
+            )
 
         original_latents_shape = None
         if batch.latents is not None:

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -92,6 +92,9 @@ from sglang.multimodal_gen.runtime.managers.memory_managers.layerwise_offload im
     LayerwiseOffloadableModuleMixin,
     is_layerwise_offloaded_module,
 )
+from sglang.multimodal_gen.runtime.pipelines_core.diffusion_scheduler_utils import (
+    get_or_create_request_scheduler,
+)
 from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import Req
 from sglang.multimodal_gen.runtime.pipelines_core.stages.base import (
     PipelineStage,
@@ -868,7 +871,8 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
 
         assert self.transformer is not None
         pipeline = self.pipeline() if self.pipeline else None
-        scheduler = batch.scheduler
+        # Pipelines that skip timestep prep leave batch.scheduler unset.
+        scheduler = get_or_create_request_scheduler(batch, self.scheduler)
         assert scheduler is not None
 
         dual_transformer_mode = self._dual_transformer_execution_mode()

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/text_encoding.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/text_encoding.py
@@ -806,11 +806,11 @@ class TextEncodingStage(ConditionEncodingStage):
                             embeds_mask
                         )
                     )
-                elif prompt_embeds.ndim == 2:
-                    seq_lens_list.append([int(prompt_embeds.shape[0])])
                 else:
                     seq_lens_list.append(
-                        [int(prompt_embeds.shape[1])] * int(prompt_embeds.shape[0])
+                        server_args.pipeline_config.seq_lens_from_prompt_embeds(
+                            prompt_embeds
+                        )
                     )
 
         # Shape results according to return_type


### PR DESCRIPTION
## Motivation

The ComfyUI passthrough pipeline feeds pre-encoded embeddings straight to the transformer, so it runs neither `TextEncodingStage` nor timestep preparation. Three downstream consumers assume those stages have run, so the passthrough denoise path cannot complete:

- `require_text_seq_lens()` reads `batch.prompt_seq_lens`, which only `TextEncodingStage` populates.
- `DenoisingStage` reads `batch.scheduler`, which is left unset without timestep prep.
- `ComfyUIPassThroughScheduler.step()` increments `self._step_index`, but `DenoisingStage` clears it to `None` before the loop, so the increment fails on the first step.

Running the Flux passthrough test off CUDA surfaced two more issues: the test hard-codes `device="cuda"`, and it passes `negative_prompt_embeds` with an empty `neg_pooled_embeds`.

## Modifications

- `comfyui_latent_preparation.py`: back-fill `batch.prompt_seq_lens` / `batch.negative_prompt_seq_lens` from the incoming embeddings, since there is no `TextEncodingStage` to do it.
- `denoising.py`: resolve the scheduler through `get_or_create_request_scheduler()` instead of reading `batch.scheduler` directly.
- `scheduling_comfyui_passthrough.py`: re-seed `_step_index` from `_begin_index` when `DenoisingStage` has cleared it.
- `configs/pipeline_configs/base.py`: add `PipelineConfig.seq_lens_from_prompt_embeds()` — the "seq lens from maskless embeddings" rule (2-D means `batch=1`), previously inline in `TextEncodingStage`.
- `text_encoding.py`: use the shared helper, so the new back-fill and the text-encoding path share one definition.
- `test_flux_pipeline.py`: use `current_platform.device_type` instead of hard-coded `"cuda"`, and pass a zeroed `neg_pooled_embeds` when `negative_prompt_embeds` is set — Flux `time_text_embed` needs a pooled projection on every CFG branch.
- `component_residency_strategies.py`: offload synchronously on XPU. An async copy into pageable host memory can reach the backend memcpy with a null argument there, and cannot overlap anything anyway.

## Accuracy Tests

Nothing here changes model math on the existing CUDA paths. The forward-affecting changes are scoped to the ComfyUI passthrough pipeline, which previously could not run to completion, and to the CFG negative branch of the Flux passthrough test, which previously supplied no pooled projection at all.

The `text_encoding.py` change is intended to be a pure no-op refactor: `seq_lens_from_prompt_embeds()` reproduces the removed `ndim == 2` / else branches exactly.

Local test logs are not attached yet — please run the diffusion suite in CI, and I will add XPU `test_flux_pipeline.py` output.

## Speed Tests and Profiling

No expected impact. The XPU offload change trades an async copy for a synchronous one on XPU only, where the async path could not overlap work regardless; CUDA offload behavior is unchanged. The remaining changes are one-time per-request setup, not per-step work.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). — `black`, `isort`, `ruff` (repo rule set) and `codespell` all clean.
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). — existing `test_flux_pipeline.py` updated; no new test file added.
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — n/a, no user-facing API or flag change.
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). — rationale above; numbers to follow if reviewers want them.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32168791851](https://github.com/sgl-project/sglang/actions/runs/32168791851)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32168791670](https://github.com/sgl-project/sglang/actions/runs/32168791670)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->