### PR TITLE
[XPU] fix: drop CUDA assumptions from the mamba/GDN and weight-load paths

### DIFF
--- a/python/sglang/kernels/ops/mamba/mamba_state_scatter_triton.py
+++ b/python/sglang/kernels/ops/mamba/mamba_state_scatter_triton.py
@@ -11,6 +11,17 @@ import triton
 import triton.language as tl
 
 
+def _require_triton_device(dst: torch.Tensor, src: torch.Tensor, fn_name: str) -> None:
+    """Both tensors must share one Triton-capable device (i.e. not CPU)."""
+    if dst.device != src.device:
+        raise ValueError(
+            f"{fn_name}: dst and src must be on the same device. "
+            f"{dst.device=} {src.device=}"
+        )
+    if dst.device.type == "cpu":
+        raise ValueError(f"{fn_name}: CPU tensors are not supported.")
+
+
 def _require_entry_contiguous_dst(
     dst: torch.Tensor, entry_start_dim: int, fn_name: str
 ) -> None:
@@ -244,14 +255,7 @@ def fused_mamba_state_scatter_with_mask(
     if total_requests == 0:
         return
 
-    if dst.device != src.device:
-        raise ValueError(
-            f"dst and src must be on the same device. {dst.device=} {src.device=}"
-        )
-    if not dst.is_cuda or not src.is_cuda:
-        raise ValueError(
-            "fused_mamba_state_scatter_with_mask only supports CUDA tensors."
-        )
+    _require_triton_device(dst, src, "fused_mamba_state_scatter_with_mask")
     if dst.ndim < 2 or src.ndim < 3:
         raise ValueError(f"Unexpected tensor ranks: {dst.ndim=} {src.ndim=}")
     if dst.shape[0] != src.shape[0]:
@@ -408,11 +412,7 @@ def fused_conv_window_scatter_with_mask(
     if total_requests == 0:
         return
 
-    if not (dst.is_cuda and src.is_cuda and dst.device == src.device):
-        raise ValueError(
-            "fused_conv_window_scatter_with_mask requires dst and src to be CUDA "
-            f"tensors on the same device ({dst.device=}, {src.device=})."
-        )
+    _require_triton_device(dst, src, "fused_conv_window_scatter_with_mask")
     if dst.ndim != 4 or src.ndim != 5:
         raise ValueError(f"Unexpected ranks: {dst.ndim=} (want 4) {src.ndim=} (want 5)")
     if dst.shape[0] != src.shape[0]:

--- a/python/sglang/srt/hardware_backend/xpu/kernels/fla/fused_sigmoid_gating_recurrent.py
+++ b/python/sglang/srt/hardware_backend/xpu/kernels/fla/fused_sigmoid_gating_recurrent.py
@@ -93,6 +93,10 @@ def fused_sigmoid_gating_delta_rule_update(
         o=o,
         h0_source=initial_state_source,
         h0_indices=initial_state_indices,
+        # Envelope-strided pools have a per-slot pitch != HV*K*V.
+        stride_h0_source=(
+            initial_state_source.stride(0) if initial_state_source is not None else 0
+        ),
         cu_seqlens=cu_seqlens,
         intermediate_states_buffer=intermediate_states_buffer,
         intermediate_state_indices=intermediate_state_indices,

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -440,7 +440,7 @@ class MambaPool:
                 *physical_conv_shape,
             ),
             dtype=conv_dtype,
-            device="cuda",
+            device=self.device,
         )
         physical_conv_strides = phys.stride()[2:]
         window_stride = physical_conv_strides[window_axis]
@@ -712,7 +712,7 @@ class MambaPool:
                             temporal_state_shape[2],
                         ),
                         dtype=ssm_dtype,
-                        device="cuda",
+                        device=device,
                     )
                 # Cache intermediate conv windows (last K-1 inputs) per draft token
                 # during target verify.
@@ -780,7 +780,7 @@ class MambaPool:
                                 conv_shape[1],
                             ),
                             dtype=conv_dtype,
-                            device="cuda",
+                            device=device,
                         )
                         for conv_shape in dense_conv_shapes
                     ]

--- a/python/sglang/srt/models/qwen3_5_mtp.py
+++ b/python/sglang/srt/models/qwen3_5_mtp.py
@@ -34,6 +34,7 @@ from sglang.srt.layers.vocab_parallel_embedding import ParallelLMHead
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.qwen3_5 import Qwen3_5ForCausalLM
+from sglang.srt.platforms import current_platform
 from sglang.srt.runtime_context import (
     get_model,
     get_parallel,
@@ -157,8 +158,8 @@ class Qwen3_5ForCausalLMMTP(nn.Module):
 
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        current_platform.empty_cache()
+        current_platform.synchronize()
 
     def set_lm_head_from_target(self, target_lm_head):
         if self.config.tie_word_embeddings:

--- a/test/registered/model_loading/test_load_weights_from_remote_instance.py
+++ b/test/registered/model_loading/test_load_weights_from_remote_instance.py
@@ -20,10 +20,11 @@ import unittest
 
 import numpy as np
 import requests
-import torch
 import torch.multiprocessing as mp
 
 import sglang as sgl
+from sglang.srt.platforms import current_platform
+from sglang.srt.utils import get_device_count
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.test_utils import (
     DEFAULT_PORT_FOR_SRT_TEST_RUNNER,
@@ -68,7 +69,7 @@ def init_process(
     event_dst_ready_list,
     remote_instance_loader_backend,
 ):
-    torch.cuda.set_device(rank)
+    current_platform.set_device(current_platform.get_device(rank))
 
     if rank == 0:
         init_process_seed(
@@ -111,12 +112,13 @@ def init_process_seed(
 ):
     # These two environment variables are very important
     # to avoid unexpected behaviors of CUDA and NCCL.
-    os.environ["NCCL_CUMEM_ENABLE"] = "0"
-    os.environ["NCCL_NVLS_ENABLE"] = "0"
+    if current_platform.is_cuda_alike():
+        os.environ["NCCL_CUMEM_ENABLE"] = "0"
+        os.environ["NCCL_NVLS_ENABLE"] = "0"
 
     # Load model and get parameters
-    torch.cuda.set_device(rank)
-    torch.cuda.synchronize()
+    current_platform.set_device(current_platform.get_device(rank))
+    current_platform.synchronize()
 
     url = DEFAULT_URL_FOR_TEST
     process = popen_launch_server(
@@ -131,7 +133,7 @@ def init_process_seed(
             "--remote-instance-weight-loader-start-seed-via-transfer-engine",
         ),
     )
-    torch.cuda.synchronize()
+    current_platform.synchronize()
 
     seed_params = []
     # Get the weights of seed instance for correctness check.
@@ -168,9 +170,9 @@ def init_process_dst(
     event_dst_ready_list,
     remote_instance_loader_backend,
 ):
-    torch.cuda.set_device(rank * tp_size)
-    torch.cuda.synchronize()
     base_gpu_id = rank * tp_size
+    current_platform.set_device(current_platform.get_device(base_gpu_id))
+    current_platform.synchronize()
 
     event_seed_ready.wait()
     print(f"rank {rank}, seed ready")
@@ -230,7 +232,7 @@ def init_process_dst(
                 str(6789 + rank),
             ),
         )
-    torch.cuda.synchronize()
+    current_platform.synchronize()
 
     event_dst_ready_list[rank - 1].set()
 
@@ -346,14 +348,14 @@ def test_load_weights_from_remote_instance(
     param_queue.close()
     param_queue.join_thread()
     gc.collect()
-    torch.cuda.empty_cache()
+    current_platform.empty_cache()
 
 
 class TestLoadWeightsFromRemoteInstance(CustomTestCase):
 
     def test_load_weights_from_remote_instance(self):
 
-        assert torch.cuda.device_count() >= 2, "At least 2 GPUs are required"
+        assert get_device_count() >= 2, "At least 2 GPUs are required"
         # test_suits : tp, dp, model_name, backend, dst_instance_id
         if is_in_ci():
             # FIXME: refactor this test to have less random behavior


### PR DESCRIPTION
## Motivation

Several mamba/GDN state paths and the remote-instance weight loader hard-code CUDA even though nothing about them is CUDA-specific — the kernels are plain Triton, and the allocations already have a configured device to hand. On a non-CUDA device they fail rather than run.

One of these is a latent bug on any device: the XPU `fused_sigmoid_gating_delta_rule_update` wrapper does not pass `stride_h0_source`, which the shared kernel in `python/sglang/kernels/ops/attention/fla/fused_sigmoid_gating_recurrent.py` takes as a required argument (the CUDA caller passes it).

## Modifications

- `srt/hardware_backend/xpu/kernels/fla/fused_sigmoid_gating_recurrent.py`: pass `stride_h0_source=initial_state_source.stride(0)` (0 when the source is `None`). Envelope-strided state pools have a per-slot pitch `!= HV*K*V`, so the stride has to come from the caller.
- `kernels/ops/mamba/mamba_state_scatter_triton.py`: `fused_mamba_state_scatter_with_mask` and `fused_conv_window_scatter_with_mask` rejected any tensor that was not `.is_cuda`. They now share a `_require_triton_device()` helper that requires a common, non-CPU device — the same guarantee the Triton kernels actually need. Error messages now name the calling function.
- `srt/mem_cache/memory_pool.py`: three `MambaPool` buffers were allocated with `device="cuda"` while every sibling allocation in the same methods uses the configured device. They now use it too.
- `srt/models/qwen3_5_mtp.py`: `torch.cuda.empty_cache()` / `torch.cuda.synchronize()` after rebinding the embedding and LM head become `current_platform` calls.
- `test/registered/model_loading/test_load_weights_from_remote_instance.py`: `torch.cuda.set_device/synchronize/empty_cache` become `current_platform` equivalents, the 2-GPU precondition uses `get_device_count()`, and `NCCL_CUMEM_ENABLE` / `NCCL_NVLS_ENABLE` are only set on cuda-alike platforms. The `init_process_dst` `set_device` moved below `base_gpu_id` so it can use it — previously it called `set_device(rank * tp_size)` and then recomputed the same value.

## Accuracy Tests

No numerical change on CUDA:

- `current_platform.empty_cache()` / `synchronize()` / `set_device()` dispatch to the `torch.cuda` equivalents on CUDA.
- The `device="cuda"` → configured-device changes are no-ops when the configured device is CUDA, which it was in every path that previously worked.
- `_require_triton_device()` only relaxes a precondition; the accepted CUDA inputs and the kernels themselves are untouched.

The `stride_h0_source` fix is the one behavioral change. It makes the XPU wrapper match the CUDA caller, which already passes the same expression; the wrapper could not previously reach the kernel at all.

`test_load_weights_from_remote_instance` is registered CUDA/AMD CI, so its existing coverage exercises this refactor directly — please trigger it.

## Speed Tests and Profiling

No expected impact: no kernel body, launch configuration, grid, or allocation shape changes. The `stride_h0_source` value is computed once per call from an existing tensor.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). — `black`, `isort`, `ruff` (repo rule set) and `codespell` all clean.
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). — covered by the existing registered `test_load_weights_from_remote_instance`; no new test file added.
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — n/a, no user-facing API or flag change.
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). — rationale above; numbers to follow if reviewers want them.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32168852958](https://github.com/sgl-project/sglang/actions/runs/32168852958)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32168852494](https://github.com/sgl-project/sglang/actions/runs/32168852494)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->