### PR TITLE
[XPU] Fix device assumptions and the ComfyUI passthrough denoise path

### DIFF
--- a/python/sglang/kernels/ops/mamba/mamba_state_scatter_triton.py
+++ b/python/sglang/kernels/ops/mamba/mamba_state_scatter_triton.py
@@ -11,6 +11,17 @@ import triton
 import triton.language as tl
 
 
+def _require_triton_device(dst: torch.Tensor, src: torch.Tensor, fn_name: str) -> None:
+    """Both tensors must share one Triton-capable device (i.e. not CPU)."""
+    if dst.device != src.device:
+        raise ValueError(
+            f"{fn_name}: dst and src must be on the same device. "
+            f"{dst.device=} {src.device=}"
+        )
+    if dst.device.type == "cpu":
+        raise ValueError(f"{fn_name}: CPU tensors are not supported.")
+
+
 def _require_entry_contiguous_dst(
     dst: torch.Tensor, entry_start_dim: int, fn_name: str
 ) -> None:
@@ -244,14 +255,7 @@ def fused_mamba_state_scatter_with_mask(
     if total_requests == 0:
         return
 
-    if dst.device != src.device:
-        raise ValueError(
-            f"dst and src must be on the same device. {dst.device=} {src.device=}"
-        )
-    if not dst.is_cuda or not src.is_cuda:
-        raise ValueError(
-            "fused_mamba_state_scatter_with_mask only supports CUDA tensors."
-        )
+    _require_triton_device(dst, src, "fused_mamba_state_scatter_with_mask")
     if dst.ndim < 2 or src.ndim < 3:
         raise ValueError(f"Unexpected tensor ranks: {dst.ndim=} {src.ndim=}")
     if dst.shape[0] != src.shape[0]:
@@ -408,11 +412,7 @@ def fused_conv_window_scatter_with_mask(
     if total_requests == 0:
         return
 
-    if not (dst.is_cuda and src.is_cuda and dst.device == src.device):
-        raise ValueError(
-            "fused_conv_window_scatter_with_mask requires dst and src to be CUDA "
-            f"tensors on the same device ({dst.device=}, {src.device=})."
-        )
+    _require_triton_device(dst, src, "fused_conv_window_scatter_with_mask")
     if dst.ndim != 4 or src.ndim != 5:
         raise ValueError(f"Unexpected ranks: {dst.ndim=} (want 4) {src.ndim=} (want 5)")
     if dst.shape[0] != src.shape[0]:

--- a/python/sglang/multimodal_gen/apps/ComfyUI_SGLDiffusion/test/test_flux_pipeline.py
+++ b/python/sglang/multimodal_gen/apps/ComfyUI_SGLDiffusion/test/test_flux_pipeline.py
@@ -9,10 +9,12 @@ import torch
 from sglang.multimodal_gen.configs.sample.sampling_params import SamplingParams
 from sglang.multimodal_gen.runtime.entrypoints.diffusion_generator import DiffGenerator
 from sglang.multimodal_gen.runtime.entrypoints.utils import prepare_request
+from sglang.multimodal_gen.runtime.platforms import current_platform
 
 
 def test_comfyui_flux_pipeline_direct() -> None:
     """Test ComfyUIFluxPipeline with custom inputs."""
+    device = current_platform.device_type
     model_path = os.environ.get(
         "SGLANG_TEST_FLUX_MODEL_PATH",
         "black-forest-labs/FLUX.1-dev",  # Supports both safetensors file and diffusers format
@@ -39,7 +41,7 @@ def test_comfyui_flux_pipeline_direct() -> None:
         batch_size,
         hidden_states_seq_len,
         hidden_states_dim,
-        device="cuda",
+        device=device,
         dtype=torch.bfloat16,
     )
 
@@ -47,18 +49,18 @@ def test_comfyui_flux_pipeline_direct() -> None:
         batch_size,
         encoder_seq_len,
         encoder_dim,
-        device="cuda",
+        device=device,
         dtype=torch.bfloat16,
     )
 
     pooled_projections = torch.ones(
         batch_size,
         pooled_dim,
-        device="cuda",
+        device=device,
         dtype=torch.bfloat16,
     )
 
-    timesteps = torch.tensor([1000], dtype=torch.long, device="cuda")
+    timesteps = torch.tensor([1000], dtype=torch.long, device=device)
 
     sampling_params = SamplingParams.from_user_sampling_params_args(
         generator.server_args.model_path,
@@ -89,14 +91,14 @@ def test_comfyui_flux_pipeline_direct() -> None:
             batch_size,
             77,
             clip_dim,
-            device="cuda",
+            device=device,
             dtype=torch.bfloat16,
         )
         negative_encoder_hidden_states = torch.ones(
             batch_size,
             encoder_seq_len,
             encoder_dim,
-            device="cuda",
+            device=device,
             dtype=torch.bfloat16,
         )
         req.negative_prompt_embeds = [
@@ -107,7 +109,12 @@ def test_comfyui_flux_pipeline_direct() -> None:
         req.negative_prompt_embeds = None
 
     req.pooled_embeds = [pooled_projections]
-    req.neg_pooled_embeds = []
+    # Flux time_text_embed needs a pooled projection on every CFG branch.
+    req.neg_pooled_embeds = (
+        [torch.zeros_like(pooled_projections)]
+        if req.negative_prompt_embeds is not None
+        else []
+    )
 
     if (
         req.guidance_scale > 1.0
@@ -120,14 +127,14 @@ def test_comfyui_flux_pipeline_direct() -> None:
 
     if req.seed is not None:
         generator_device = req.generator_device
-        device_str = "cuda" if generator_device == "cuda" else "cpu"
+        device_str = device if generator_device == device else "cpu"
         req.generator = [
             torch.Generator(device_str).manual_seed(req.seed + i)
             for i in range(req.num_outputs_per_prompt)
         ]
     else:
         req.generator = [
-            torch.Generator("cuda") for _ in range(req.num_outputs_per_prompt)
+            torch.Generator(device) for _ in range(req.num_outputs_per_prompt)
         ]
 
     output_batch = generator._send_to_scheduler_and_wait_for_response([req])
@@ -136,8 +143,8 @@ def test_comfyui_flux_pipeline_direct() -> None:
     assert noise_pred is not None, "noise_pred should not be None in OutputBatch"
     assert isinstance(noise_pred, torch.Tensor), "noise_pred should be a torch.Tensor"
     assert (
-        noise_pred.device.type == "cuda"
-    ), f"noise_pred should be on cuda, got {noise_pred.device}"
+        noise_pred.device.type == device
+    ), f"noise_pred should be on {device}, got {noise_pred.device}"
     assert (
         noise_pred.dtype == torch.bfloat16
     ), f"noise_pred should be bfloat16, got {noise_pred.dtype}"

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/base.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/base.py
@@ -650,6 +650,13 @@ class PipelineConfig:
             raise ValueError("text conditioning mask must have shape [batch, seq]")
         return torch.count_nonzero(mask, dim=1).tolist()
 
+    @staticmethod
+    def seq_lens_from_prompt_embeds(prompt_embeds: "torch.Tensor") -> list[int]:
+        """Text lengths for maskless embeddings; 2-D (seq x dim) means batch=1."""
+        if prompt_embeds.ndim == 2:
+            return [int(prompt_embeds.shape[0])]
+        return [int(prompt_embeds.shape[1])] * int(prompt_embeds.shape[0])
+
     def require_text_seq_lens(
         self,
         batch,

--- a/python/sglang/multimodal_gen/runtime/managers/memory_managers/component_residency_strategies.py
+++ b/python/sglang/multimodal_gen/runtime/managers/memory_managers/component_residency_strategies.py
@@ -174,7 +174,12 @@ class ComponentOffloadStrategy(ComponentResidencyStrategy):
         self.wait_for_use(module, use, state)
         tensor = _module_reference_tensor(module)
         if tensor is not None and tensor.device.type != "cpu":
-            module.to("cpu", non_blocking=True)
+            # XPU: an async copy into pageable host memory can reach the backend
+            # memcpy with a null argument, and cannot overlap anything anyway.
+            _non_blocking = True
+            if current_platform.is_xpu():
+                _non_blocking = False
+            module.to("cpu", non_blocking=_non_blocking)
         self._ready_events.pop(use.component_name, None)
 
     def finish_request(

--- a/python/sglang/multimodal_gen/runtime/models/schedulers/scheduling_comfyui_passthrough.py
+++ b/python/sglang/multimodal_gen/runtime/models/schedulers/scheduling_comfyui_passthrough.py
@@ -112,7 +112,10 @@ class ComfyUIPassThroughScheduler(BaseScheduler, ConfigMixin, SchedulerMixin):
         Returns:
             The input sample unchanged (prev_sample = sample)
         """
-        # Increment step index for tracking
+        # DenoisingStage clears _step_index before the loop; re-seed it.
+        if self._step_index is None:
+            begin_index = self._begin_index
+            self._step_index = begin_index if begin_index is not None else 0
         self._step_index += 1
 
         # Simply return the input sample unchanged

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/comfyui_latent_preparation.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/comfyui_latent_preparation.py
@@ -23,6 +23,11 @@ from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 logger = init_logger(__name__)
 
 
+def _seq_lens_per_encoder(pipeline_config, embeds) -> list[list[int]]:
+    """Per-encoder text lengths; ComfyUI embeds arrive unpadded and maskless."""
+    return [pipeline_config.seq_lens_from_prompt_embeds(e) for e in embeds]
+
+
 class ComfyUILatentPreparationStage(LatentPreparationStage):
     """
     ComfyUI-specific latent preparation stage with device mismatch fix.
@@ -98,6 +103,20 @@ class ComfyUILatentPreparationStage(LatentPreparationStage):
                                     setattr(batch, attr_name, fixed_value)
                             except (AttributeError, TypeError):
                                 continue
+
+        # No TextEncodingStage here, so back-fill require_text_seq_lens' input.
+        pipeline_config = server_args.pipeline_config
+        if batch.prompt_embeds is not None and batch.prompt_seq_lens is None:
+            batch.prompt_seq_lens = _seq_lens_per_encoder(
+                pipeline_config, batch.prompt_embeds
+            )
+        if (
+            batch.negative_prompt_embeds is not None
+            and batch.negative_prompt_seq_lens is None
+        ):
+            batch.negative_prompt_seq_lens = _seq_lens_per_encoder(
+                pipeline_config, batch.negative_prompt_embeds
+            )
 
         original_latents_shape = None
         if batch.latents is not None:

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -92,6 +92,9 @@ from sglang.multimodal_gen.runtime.managers.memory_managers.layerwise_offload im
     LayerwiseOffloadableModuleMixin,
     is_layerwise_offloaded_module,
 )
+from sglang.multimodal_gen.runtime.pipelines_core.diffusion_scheduler_utils import (
+    get_or_create_request_scheduler,
+)
 from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import Req
 from sglang.multimodal_gen.runtime.pipelines_core.stages.base import (
     PipelineStage,
@@ -868,7 +871,8 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
 
         assert self.transformer is not None
         pipeline = self.pipeline() if self.pipeline else None
-        scheduler = batch.scheduler
+        # Pipelines that skip timestep prep leave batch.scheduler unset.
+        scheduler = get_or_create_request_scheduler(batch, self.scheduler)
         assert scheduler is not None
 
         dual_transformer_mode = self._dual_transformer_execution_mode()

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/text_encoding.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/text_encoding.py
@@ -806,11 +806,11 @@ class TextEncodingStage(ConditionEncodingStage):
                             embeds_mask
                         )
                     )
-                elif prompt_embeds.ndim == 2:
-                    seq_lens_list.append([int(prompt_embeds.shape[0])])
                 else:
                     seq_lens_list.append(
-                        [int(prompt_embeds.shape[1])] * int(prompt_embeds.shape[0])
+                        server_args.pipeline_config.seq_lens_from_prompt_embeds(
+                            prompt_embeds
+                        )
                     )
 
         # Shape results according to return_type

--- a/python/sglang/srt/hardware_backend/xpu/kernels/fla/fused_sigmoid_gating_recurrent.py
+++ b/python/sglang/srt/hardware_backend/xpu/kernels/fla/fused_sigmoid_gating_recurrent.py
@@ -93,6 +93,10 @@ def fused_sigmoid_gating_delta_rule_update(
         o=o,
         h0_source=initial_state_source,
         h0_indices=initial_state_indices,
+        # Envelope-strided pools have a per-slot pitch != HV*K*V.
+        stride_h0_source=(
+            initial_state_source.stride(0) if initial_state_source is not None else 0
+        ),
         cu_seqlens=cu_seqlens,
         intermediate_states_buffer=intermediate_states_buffer,
         intermediate_state_indices=intermediate_state_indices,

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -440,7 +440,7 @@ class MambaPool:
                 *physical_conv_shape,
             ),
             dtype=conv_dtype,
-            device="cuda",
+            device=self.device,
         )
         physical_conv_strides = phys.stride()[2:]
         window_stride = physical_conv_strides[window_axis]
@@ -712,7 +712,7 @@ class MambaPool:
                             temporal_state_shape[2],
                         ),
                         dtype=ssm_dtype,
-                        device="cuda",
+                        device=device,
                     )
                 # Cache intermediate conv windows (last K-1 inputs) per draft token
                 # during target verify.
@@ -780,7 +780,7 @@ class MambaPool:
                                 conv_shape[1],
                             ),
                             dtype=conv_dtype,
-                            device="cuda",
+                            device=device,
                         )
                         for conv_shape in dense_conv_shapes
                     ]

--- a/python/sglang/srt/models/qwen3_5_mtp.py
+++ b/python/sglang/srt/models/qwen3_5_mtp.py
@@ -34,6 +34,7 @@ from sglang.srt.layers.vocab_parallel_embedding import ParallelLMHead
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.qwen3_5 import Qwen3_5ForCausalLM
+from sglang.srt.platforms import current_platform
 from sglang.srt.runtime_context import (
     get_model,
     get_parallel,
@@ -157,8 +158,8 @@ class Qwen3_5ForCausalLMMTP(nn.Module):
 
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        current_platform.empty_cache()
+        current_platform.synchronize()
 
     def set_lm_head_from_target(self, target_lm_head):
         if self.config.tie_word_embeddings:

--- a/test/registered/model_loading/test_load_weights_from_remote_instance.py
+++ b/test/registered/model_loading/test_load_weights_from_remote_instance.py
@@ -20,10 +20,11 @@ import unittest
 
 import numpy as np
 import requests
-import torch
 import torch.multiprocessing as mp
 
 import sglang as sgl
+from sglang.srt.platforms import current_platform
+from sglang.srt.utils import get_device_count
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.test_utils import (
     DEFAULT_PORT_FOR_SRT_TEST_RUNNER,
@@ -68,7 +69,7 @@ def init_process(
     event_dst_ready_list,
     remote_instance_loader_backend,
 ):
-    torch.cuda.set_device(rank)
+    current_platform.set_device(current_platform.get_device(rank))
 
     if rank == 0:
         init_process_seed(
@@ -111,12 +112,13 @@ def init_process_seed(
 ):
     # These two environment variables are very important
     # to avoid unexpected behaviors of CUDA and NCCL.
-    os.environ["NCCL_CUMEM_ENABLE"] = "0"
-    os.environ["NCCL_NVLS_ENABLE"] = "0"
+    if current_platform.is_cuda_alike():
+        os.environ["NCCL_CUMEM_ENABLE"] = "0"
+        os.environ["NCCL_NVLS_ENABLE"] = "0"
 
     # Load model and get parameters
-    torch.cuda.set_device(rank)
-    torch.cuda.synchronize()
+    current_platform.set_device(current_platform.get_device(rank))
+    current_platform.synchronize()
 
     url = DEFAULT_URL_FOR_TEST
     process = popen_launch_server(
@@ -131,7 +133,7 @@ def init_process_seed(
             "--remote-instance-weight-loader-start-seed-via-transfer-engine",
         ),
     )
-    torch.cuda.synchronize()
+    current_platform.synchronize()
 
     seed_params = []
     # Get the weights of seed instance for correctness check.
@@ -168,9 +170,9 @@ def init_process_dst(
     event_dst_ready_list,
     remote_instance_loader_backend,
 ):
-    torch.cuda.set_device(rank * tp_size)
-    torch.cuda.synchronize()
     base_gpu_id = rank * tp_size
+    current_platform.set_device(current_platform.get_device(base_gpu_id))
+    current_platform.synchronize()
 
     event_seed_ready.wait()
     print(f"rank {rank}, seed ready")
@@ -230,7 +232,7 @@ def init_process_dst(
                 str(6789 + rank),
             ),
         )
-    torch.cuda.synchronize()
+    current_platform.synchronize()
 
     event_dst_ready_list[rank - 1].set()
 
@@ -346,14 +348,14 @@ def test_load_weights_from_remote_instance(
     param_queue.close()
     param_queue.join_thread()
     gc.collect()
-    torch.cuda.empty_cache()
+    current_platform.empty_cache()
 
 
 class TestLoadWeightsFromRemoteInstance(CustomTestCase):
 
     def test_load_weights_from_remote_instance(self):
 
-        assert torch.cuda.device_count() >= 2, "At least 2 GPUs are required"
+        assert get_device_count() >= 2, "At least 2 GPUs are required"
         # test_suits : tp, dp, model_name, backend, dst_instance_id
         if is_in_ci():
             # FIXME: refactor this test to have less random behavior


### PR DESCRIPTION
> Supersedes #35365 and #35366, which were the same changes split by area. Combined here at the author's request; both are fallout from the same XPU test bring-up. The PR still needs CODEOWNER approval from **both** areas it touches — `/python/sglang/multimodal_gen` and `/python/sglang/srt/mem_cache` — and the two concerns are kept as separate commits so they can be reviewed (or reverted) independently.

## Motivation

Bringing up the SGLang unit tests on XPU surfaced two classes of failure. Neither is XPU-only in nature: one is code that hard-codes CUDA where a device is already available, the other is device-independent bugs that only the XPU run happened to execute.

**1. CUDA-hardcoded paths** (`srt`, mamba/GDN state and weight loading). The Triton kernels and pool allocations involved are not CUDA-specific, but they name CUDA explicitly, so they fail off CUDA. One of these is a latent bug on *any* device: the XPU `fused_sigmoid_gating_delta_rule_update` wrapper never passes `stride_h0_source`, which the shared kernel in `python/sglang/kernels/ops/attention/fla/fused_sigmoid_gating_recurrent.py` takes as a required argument (the CUDA caller passes it), so the wrapper cannot reach the kernel at all.

**2. The ComfyUI passthrough denoise path** (`multimodal_gen`). This pipeline feeds pre-encoded embeddings straight to the transformer, so it runs neither `TextEncodingStage` nor timestep preparation — but three downstream consumers assume those stages have run:

- `require_text_seq_lens()` reads `batch.prompt_seq_lens`, which only `TextEncodingStage` populates.
- `DenoisingStage` reads `batch.scheduler`, which is left unset without timestep prep.
- `ComfyUIPassThroughScheduler.step()` increments `self._step_index`, but `DenoisingStage` clears it to `None` before the loop, so the increment fails on the first step.

These three are device-independent; the passthrough pipeline could not complete on CUDA either.

## Modifications

### Commit 1 — `[XPU] drop CUDA assumptions from the mamba/GDN and weight-load paths`

- `srt/hardware_backend/xpu/kernels/fla/fused_sigmoid_gating_recurrent.py`: pass `stride_h0_source=initial_state_source.stride(0)` (0 when the source is `None`). Envelope-strided state pools have a per-slot pitch `!= HV*K*V`, so the stride has to come from the caller.
- `kernels/ops/mamba/mamba_state_scatter_triton.py`: `fused_mamba_state_scatter_with_mask` and `fused_conv_window_scatter_with_mask` rejected any tensor that was not `.is_cuda`. They now share a `_require_triton_device()` helper enforcing a common, non-CPU device — the guarantee the Triton kernels actually need. Error messages now name the calling function.
- `srt/mem_cache/memory_pool.py`: three `MambaPool` buffers were allocated with `device="cuda"` while every sibling allocation in the same methods uses the configured device. They now use it too.
- `srt/models/qwen3_5_mtp.py`: `torch.cuda.empty_cache()` / `synchronize()` after rebinding the embedding and LM head become `current_platform` calls.
- `test/registered/model_loading/test_load_weights_from_remote_instance.py`: `torch.cuda.set_device/synchronize/empty_cache` become `current_platform` equivalents, the 2-GPU precondition uses `get_device_count()`, and `NCCL_CUMEM_ENABLE` / `NCCL_NVLS_ENABLE` are only set on cuda-alike platforms. The `init_process_dst` `set_device` moved below `base_gpu_id` so it can use it — previously it called `set_device(rank * tp_size)` and then recomputed the same value.

### Commit 2 — `[diffusion] unblock the ComfyUI passthrough denoise path`

- `comfyui_latent_preparation.py`: back-fill `batch.prompt_seq_lens` / `batch.negative_prompt_seq_lens` from the incoming embeddings, since there is no `TextEncodingStage` to do it.
- `denoising.py`: resolve the scheduler through `get_or_create_request_scheduler()` instead of reading `batch.scheduler` directly.
- `scheduling_comfyui_passthrough.py`: re-seed `_step_index` from `_begin_index` when `DenoisingStage` has cleared it.
- `configs/pipeline_configs/base.py`: add `PipelineConfig.seq_lens_from_prompt_embeds()` — the "seq lens from maskless embeddings" rule (2-D means `batch=1`), previously inline in `TextEncodingStage`.
- `text_encoding.py`: use the shared helper, so the new back-fill and the text-encoding path share one definition.
- `test_flux_pipeline.py`: use `current_platform.device_type` instead of hard-coded `"cuda"`, and pass a zeroed `neg_pooled_embeds` when `negative_prompt_embeds` is set — Flux `time_text_embed` needs a pooled projection on every CFG branch.
- `component_residency_strategies.py`: offload synchronously on XPU. An async copy into pageable host memory can reach the backend memcpy with a null argument there, and cannot overlap anything anyway.

## Accuracy Tests

Nothing here changes model math on the existing CUDA paths:

- `current_platform.empty_cache()` / `synchronize()` / `set_device()` dispatch to the `torch.cuda` equivalents on CUDA.
- The `device="cuda"` → configured-device changes are no-ops when the configured device is CUDA, which it was in every path that previously worked.
- `_require_triton_device()` only relaxes a precondition; the accepted CUDA inputs and the kernel bodies are untouched.
- The `text_encoding.py` change is intended as a pure no-op refactor: `seq_lens_from_prompt_embeds()` reproduces the removed `ndim == 2` / else branches exactly.

Two behavioral changes, both in paths that previously could not run:

- `stride_h0_source` makes the XPU wrapper match the CUDA caller, which already passes the same expression.
- The Flux passthrough test's CFG negative branch previously supplied no pooled projection at all.

Local test logs are not attached yet. `test_load_weights_from_remote_instance` is registered CUDA/AMD CI, so its existing coverage exercises the loader refactor directly — please trigger CI, and I will add XPU `test_flux_pipeline.py` output.

## Speed Tests and Profiling

No expected impact. No kernel body, launch configuration, grid, or allocation shape changes; `stride_h0_source` is computed once per call from an existing tensor. The XPU offload change trades an async copy for a synchronous one on XPU only, where the async path could not overlap work regardless — CUDA offload behavior is unchanged. The remaining diffusion changes are one-time per-request setup, not per-step work.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). — `black`, `isort`, `ruff` (repo rule set) and `codespell` all clean on the 12 files.
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). — covered by the existing registered `test_load_weights_from_remote_instance` and by `test_flux_pipeline.py`, which is updated here; no new test file added.
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — n/a, no user-facing API or flag change.
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). — rationale above; numbers to follow if reviewers want them.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32169094379](https://github.com/sgl-project/sglang/actions/runs/32169094379)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32169093830](https://github.com/sgl-project/sglang/actions/runs/32169093830)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->