### PR TITLE
[Spec] Avoid multi-layer EAGLE SWA scheduler synchronization

### DIFF
--- a/python/sglang/srt/mem_cache/allocator/swa.py
+++ b/python/sglang/srt/mem_cache/allocator/swa.py
@@ -374,6 +374,21 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             self.swa_free_group = []
             self.free_swa(torch.cat(swa_free_group))
 
+    def free_swa_segment(self, free_index: torch.Tensor, *, start_pos: int):
+        """Free a complete page-aligned request segment without device unique."""
+        if free_index.numel() == 0:
+            return
+
+        if self.page_size == 1:
+            self.free_swa(free_index)
+            return
+
+        assert start_pos % self.page_size == 0
+        assert free_index.numel() % self.page_size == 0
+        swa_indices = self.full_to_swa_index_mapping[free_index]
+        self.swa_attn_allocator.free_segment(swa_indices, start_pos=start_pos)
+        self.full_to_swa_index_mapping.index_fill_(0, free_index.to(torch.int64), 0)
+
     def _expand_to_full_pages(self, indices: torch.Tensor) -> torch.Tensor:
         pages = torch.unique(indices // self.page_size)
         page_offsets = torch.arange(

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -97,10 +97,16 @@ def free_swa_out_of_window_slots(
         new_swa_evicted_seqlen = (new_swa_evicted_seqlen // page_size) * page_size
 
     if new_swa_evicted_seqlen > req.kv.swa_evicted_seqlen:
+        old_swa_evicted_seqlen = req.kv.swa_evicted_seqlen
         free_slots = req_to_token_pool.req_to_token[
-            req.req_pool_idx, req.kv.swa_evicted_seqlen : new_swa_evicted_seqlen
+            req.req_pool_idx, old_swa_evicted_seqlen:new_swa_evicted_seqlen
         ]
-        token_to_kv_pool_allocator.free_swa(free_slots)
+        if isinstance(token_to_kv_pool_allocator, SWATokenToKVPoolAllocator):
+            token_to_kv_pool_allocator.free_swa_segment(
+                free_slots, start_pos=old_swa_evicted_seqlen
+            )
+        else:
+            token_to_kv_pool_allocator.free_swa(free_slots)
         req.kv.swa_evicted_seqlen = new_swa_evicted_seqlen
 
 

--- a/python/sglang/srt/mem_cache/multi_ended_allocator.py
+++ b/python/sglang/srt/mem_cache/multi_ended_allocator.py
@@ -2489,6 +2489,11 @@ class UnifiedSWATokenToKVPoolAllocator(SWATokenToKVPoolAllocator):
         self.swa_attn_allocator.free(live)
         self.swa_attn_allocator.clear_inverse_history()
 
+    def free_swa_segment(self, free_index: torch.Tensor, *, start_pos: int) -> None:
+        # Unified allocation has no static full-to-SWA token mapping, so retain
+        # its virtual-page liveness filtering instead of the fixed-shape path.
+        self.free_swa(free_index)
+
     def set_full_to_swa_mapping(
         self, full_indices: torch.Tensor, swa_indices: torch.Tensor
     ) -> None:

--- a/python/sglang/srt/speculative/multi_layer_eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_draft_extend_cuda_graph_runner.py
@@ -806,6 +806,7 @@ class MultiLayerEagleMultiStepDraftExtendCudaGraphRunner:
         out = runner.replay(
             self.bs, self.seq_lens_sum, self._replay_spec_info, self.seq_lens_cpu
         )
+        self._publish_shared_read_done(step)
         raw_bs = self.raw_bs
         raw_num_tokens = self.raw_num_tokens
         num_logit_rows = raw_bs if self.prune_draft_extend_logits else raw_num_tokens
@@ -822,6 +823,14 @@ class MultiLayerEagleMultiStepDraftExtendCudaGraphRunner:
             out.topk_p[:raw_bs],
             out.topk_index[:raw_bs],
         )
+
+    def _publish_shared_read_done(self, step: int) -> None:
+        if step != self.speculative_num_steps - 1:
+            return
+        runner = self.runners[step]
+        read_done = runner.device_module.Event()
+        read_done.record()
+        runner.model_runner.shared_read_done_event = read_done
 
     def clone_draft_probs(self) -> torch.Tensor:
         """Materialize the in-graph-written proposal q [raw_bs, num_steps, vocab]
@@ -983,4 +992,6 @@ class OneGraphMultiLayerEagleMultiStepDraftExtendCudaGraphRunner(
                     out.topk_p[:raw_bs],
                     out.topk_index[:raw_bs],
                 )
-        return self._cached[step]
+        result = self._cached[step]
+        self._publish_shared_read_done(step)
+        return result

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -958,7 +958,7 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
     @property
     def last_shared_read_runner(self):
         # Multi-layer eagle has no draft forward, only draft extend.
-        return self._draft_worker.draft_runner
+        return self._draft_worker.draft_runner_list[-1]
 
     @property
     def spec_v2_attn_backends(self) -> tuple:

--- a/test/registered/unit/mem_cache/test_swa_unittest.py
+++ b/test/registered/unit/mem_cache/test_swa_unittest.py
@@ -261,6 +261,60 @@ class TestSWA(unittest.TestCase):
             available_before_free + original_indices.numel(),
         )
 
+    def test_swa_memory_pool_paged_free_segment(self):
+        page_size = 4
+        _, allocator, _ = _build_swa_tree(
+            is_eagle=False,
+            page_size=page_size,
+            kv_size=16,
+            kv_size_swa=16,
+            sliding_window_size=page_size,
+        )
+
+        full_indices = _swa_alloc(allocator, 3 * page_size)
+        self.assertEqual(allocator.swa_available_size(), page_size)
+
+        allocator.free_swa_segment(full_indices[:page_size], start_pos=0)
+        self.assertEqual(allocator.swa_available_size(), 2 * page_size)
+        self.assertTrue(
+            torch.all(
+                allocator.full_to_swa_index_mapping[
+                    full_indices[:page_size].to(torch.int64)
+                ]
+                == 0
+            )
+        )
+        self.assertTrue(
+            torch.all(
+                allocator.full_to_swa_index_mapping[
+                    full_indices[page_size:].to(torch.int64)
+                ]
+                > 0
+            )
+        )
+
+        allocator.free_swa_segment(full_indices[page_size:], start_pos=page_size)
+        self.assertEqual(allocator.swa_available_size(), 16)
+        self.assertTrue(
+            torch.all(
+                allocator.full_to_swa_index_mapping[full_indices.to(torch.int64)] == 0
+            )
+        )
+
+    def test_swa_memory_pool_token_free_segment_falls_back(self):
+        _, allocator, _ = _build_swa_tree(
+            is_eagle=False,
+            page_size=1,
+            kv_size=16,
+            kv_size_swa=16,
+            sliding_window_size=4,
+        )
+
+        full_indices = _swa_alloc(allocator, 4)
+        self.assertEqual(allocator.swa_available_size(), 12)
+        allocator.free_swa_segment(full_indices, start_pos=0)
+        self.assertEqual(allocator.swa_available_size(), 16)
+
     def test_swa_radix_cache_1(self):
         # args
         req_size = 10

--- a/test/registered/unit/spec/test_multi_layer_eagle_shared_read_event.py
+++ b/test/registered/unit/spec/test_multi_layer_eagle_shared_read_event.py
@@ -1,0 +1,39 @@
+from types import SimpleNamespace
+
+from sglang.srt.speculative.multi_layer_eagle_draft_extend_cuda_graph_runner import (
+    MultiLayerEagleMultiStepDraftExtendCudaGraphRunner,
+)
+from sglang.srt.speculative.multi_layer_eagle_worker_v2 import MultiLayerEagleWorkerV2
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def test_last_shared_read_runner_is_final_draft_runner():
+    worker = MultiLayerEagleWorkerV2.__new__(MultiLayerEagleWorkerV2)
+    draft_runners = [object(), object(), object()]
+    worker._draft_worker = SimpleNamespace(draft_runner_list=draft_runners)
+
+    assert worker.last_shared_read_runner is draft_runners[-1]
+
+
+def test_only_final_draft_step_publishes_shared_read_event():
+    recorded = []
+    event = SimpleNamespace(record=lambda: recorded.append("record"))
+    final_runner = SimpleNamespace(
+        device_module=SimpleNamespace(Event=lambda: event),
+        model_runner=SimpleNamespace(shared_read_done_event=None),
+    )
+    runner = MultiLayerEagleMultiStepDraftExtendCudaGraphRunner.__new__(
+        MultiLayerEagleMultiStepDraftExtendCudaGraphRunner
+    )
+    runner.runners = [SimpleNamespace(), final_runner]
+    runner.speculative_num_steps = 2
+
+    runner._publish_shared_read_done(0)
+    assert recorded == []
+    assert final_runner.model_runner.shared_read_done_event is None
+
+    runner._publish_shared_read_done(1)
+    assert recorded == ["record"]
+    assert final_runner.model_runner.shared_read_done_event is event


### PR DESCRIPTION
## Motivation

Paged sliding-window KV eviction performs a data-dependent uniqueness pass for request segments that are already complete and page-aligned. Multi-layer EAGLE also leaves the scheduler without the final draft graph's shared-read completion event, forcing a broader stream synchronization before the shared buffers can be reused.

## Modifications

- Add a fixed-shape SWA segment-free path for page-aligned request prefixes, with the existing token path retained for page size 1 and unified allocation.
- Route sliding-window eviction through that path when the allocator supports it.
- Publish `shared_read_done_event` after the final multi-layer draft graph step, including the single-graph replay path.
- Point the worker's last shared-read runner at the final draft runner.
- Add allocator and CPU event-publication regression tests.

## Accuracy Tests

No model-output behavior changes. The relevant unit suites pass:

```text
14 SWA allocator tests passed (plus 15 subtests)
14 SWA eviction-boundary tests passed
2 shared-read event tests passed
```

## Speed Tests and Profiling

Not benchmarked independently. The allocator change removes a device-side uniqueness operation from complete page-aligned SWA segments, and the event publication lets the scheduler use its event-scoped shared-read barrier for multi-layer EAGLE.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Documentation is not required for this internal implementation change.
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

-Robot

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32182552708](https://github.com/sgl-project/sglang/actions/runs/32182552708)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32182552201](https://github.com/sgl-project/sglang/actions/runs/32182552201)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->