### PR TITLE
[Fix] DCP: reject fa3 for MLA and stop defaulting to it on Hopper

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3978,6 +3978,18 @@ class ServerArgs:
                 "final group. Got "
                 f"tp_size={self.tp_size}, dcp_size={self.dcp_size}."
             )
+        if (
+            self.dcp_size > 1
+            and self.disaggregation_mode != "prefill"
+            and (self.decode_attention_backend or self.attention_backend) == "fa3"
+            and self.use_mla_backend()
+        ):
+            raise ValueError(
+                "--attention-backend fa3 has no DCP decode path for MLA "
+                "models (it returns no LSE for the cross-dcp-rank reduction) "
+                "and crashes at decode cuda-graph capture. With --dcp-size > 1 "
+                "use a DCP-aware backend such as flashinfer or triton."
+            )
         if self.dcp_comm_backend in ("a2a", "fi_a2a") and self.dcp_size <= 1:
             raise ValueError(
                 f"--dcp-comm-backend {self.dcp_comm_backend} only affects the "
@@ -5917,6 +5929,9 @@ class ServerArgs:
         else:
             # MLA architecture
             if is_hopper_with_cuda_12_3():
+                # fa3 has no DCP decode path; flashinfer's MLA backend does.
+                if self.dcp_size > 1:
+                    return "flashinfer"
                 return "fa3"
             elif is_sm100_supported():
                 return "flashinfer"

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3971,6 +3971,13 @@ class ServerArgs:
                 "--decode-context-parallel-size) must be >= 1, but got "
                 f"dcp_size={self.dcp_size}."
             )
+        if self.dcp_size > 1 and self.tp_size % self.dcp_size != 0:
+            raise ValueError(
+                "--dcp-size must divide --tp-size: DCP groups are contiguous "
+                "slices of each TP group, so a non-divisor leaves a short "
+                "final group. Got "
+                f"tp_size={self.tp_size}, dcp_size={self.dcp_size}."
+            )
         if self.dcp_comm_backend in ("a2a", "fi_a2a") and self.dcp_size <= 1:
             raise ValueError(
                 f"--dcp-comm-backend {self.dcp_comm_backend} only affects the "
@@ -9589,6 +9596,17 @@ class ServerArgs:
         ``--speculative-draft-load-format`` needs its own transfer engine."""
         return remote_instance_transfer_engine_of(self, load_format)
 
+    @property
+    def kv_event_block_size(self) -> int:
+        """Width KV events are emitted at.
+
+        DCP widens the allocator page to ``page_size * dcp_size``
+        (``mem_cache/kv_cache_configurator.py``) and the radix tree inherits
+        it, so events are chunked at that logical width rather than the
+        configured ``page_size``. Must track the allocator's formula.
+        """
+        return self.page_size * self.dcp_size
+
     def describe_kv_events_publisher(self) -> Optional[dict]:
         """Return a structured description of this server's KV-event
         publisher, or `None` if publishing is disabled / misconfigured.
@@ -9614,10 +9632,13 @@ class ServerArgs:
                 "topic": "",                      # ZMQ topic prefix on the
                                                   # SUB filter (empty =
                                                   # subscribe-all)
-                "block_size": <page_size>,        # subscribers MUST hash
-                                                  # prompts at this size
-                "dp_size": <dp_size>,             # number of SUB sockets
-                                                  # to open
+                "block_size": <kv_event_block_size>,  # subscribers MUST
+                                                  # hash prompts at this size
+                "dp_size": <dp_size>,             # number of SUB sockets to
+                                                  # open; not DCP-scaled, as
+                                                  # DCP shards within a rank
+                                                  # rather than adding
+                                                  # publishers
             }
 
         Returns None (i.e. "no publisher to describe") when any of:
@@ -9672,7 +9693,7 @@ class ServerArgs:
             "endpoint_host": host,
             "endpoint_port_base": port,
             "topic": cfg.topic,
-            "block_size": page_size,
+            "block_size": self.kv_event_block_size,
             "dp_size": self.dp_size,
         }
 

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -2264,5 +2264,53 @@ class TestDcpKvEventContract(CustomTestCase):
             args._handle_dcp_validation()
 
 
+class TestDcpAttentionBackend(CustomTestCase):
+    """fa3 has no DCP decode path for MLA models: it returns no LSE for the
+    cross-dcp-rank reduction, so a DCP run crashed at decode cuda-graph
+    capture instead of at args time. fa3 is also the Hopper MLA auto-default,
+    so every Hopper DCP launch without an explicit --attention-backend hit
+    it."""
+
+    def test_explicit_fa3_with_dcp_rejected_for_mla(self):
+        for field in ("attention_backend", "decode_attention_backend"):
+            args = ServerArgs(
+                model_path="dummy", tp_size=4, dcp_size=4, **{field: "fa3"}
+            )
+            with patch.object(ServerArgs, "use_mla_backend", return_value=True):
+                with self.assertRaisesRegex(ValueError, "DCP decode"):
+                    args._handle_dcp_validation()
+
+    def test_fa3_with_dcp_allowed_for_prefill_only_worker(self):
+        # Prefill-only workers never run the DCP decode path.
+        args = ServerArgs(
+            model_path="dummy",
+            tp_size=4,
+            dcp_size=4,
+            attention_backend="fa3",
+            disaggregation_mode="prefill",
+        )
+        args._handle_dcp_validation()
+
+    def test_fa3_with_dcp_allowed_for_mha(self):
+        args = ServerArgs(
+            model_path="dummy", tp_size=4, dcp_size=4, attention_backend="fa3"
+        )
+        with patch.object(ServerArgs, "use_mla_backend", return_value=False):
+            args._handle_dcp_validation()
+
+    def test_mla_default_backend_avoids_fa3_under_dcp_on_hopper(self):
+        model_config = MagicMock()
+        model_config.hf_config.architectures = []
+        with patch.object(
+            server_args_module, "is_hopper_with_cuda_12_3", return_value=True
+        ):
+            args = ServerArgs(model_path="dummy", tp_size=4, dcp_size=4)
+            self.assertEqual(
+                args._get_default_attn_backend(True, model_config), "flashinfer"
+            )
+            args = ServerArgs(model_path="dummy", tp_size=4, dcp_size=1)
+            self.assertEqual(args._get_default_attn_backend(True, model_config), "fa3")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -2212,5 +2212,57 @@ class TestTwoBatchOverlapBackend(CustomTestCase):
         args._check_two_batch_overlap()
 
 
+class TestDcpKvEventContract(CustomTestCase):
+    """DCP widens the radix-tree page to page_size * dcp_size, so the two
+    values every external consumer depends on -- the advertised KV-event
+    block size and the tp/dcp topology -- must reflect that."""
+
+    KV_EVENTS = '{"publisher":"zmq","topic":"kv","endpoint":"tcp://*:5557"}'
+
+    def test_kv_events_descriptor_reports_logical_block_size(self):
+        """Advertising the physical page_size made every KV-aware router hash
+        prompts at a width no emitted block can match, silently pinning its
+        hit rate to zero while stores kept applying cleanly."""
+        args = ServerArgs(
+            model_path="dummy",
+            tp_size=4,
+            dcp_size=4,
+            page_size=64,
+            kv_events_config=self.KV_EVENTS,
+        )
+        self.assertEqual(args.describe_kv_events_publisher()["block_size"], 256)
+        args = ServerArgs(
+            model_path="dummy", page_size=64, kv_events_config=self.KV_EVENTS
+        )
+        self.assertEqual(args.describe_kv_events_publisher()["block_size"], 64)
+
+    def test_kv_event_block_size_widens_a_single_token_page(self):
+        # page_size=1 + DCP is a real deployment shape: the allocator is still
+        # paged, at dcp_size.
+        args = ServerArgs(model_path="dummy", tp_size=8, dcp_size=8, page_size=1)
+        self.assertEqual(args.kv_event_block_size, 8)
+
+    def test_dcp_larger_than_tp_rejected(self):
+        """dcp_size > tp_size left a zero-sized KV group, surfacing as a
+        ZeroDivisionError in get_num_kv_heads during model init."""
+        for tp, dcp in [(1, 2), (2, 4)]:
+            args = ServerArgs(model_path="dummy", tp_size=tp, dcp_size=dcp)
+            with self.assertRaisesRegex(ValueError, "must divide --tp-size"):
+                args._handle_dcp_validation()
+
+    def test_dcp_non_divisor_of_tp_rejected(self):
+        """The worse half: tp=4, dcp=3 tiles the TP group as [0,1,2] and [3],
+        leaving a 1-rank DCP group. Nothing raised -- get_num_kv_heads returns
+        a plausible 32 -- so the run silently mis-grouped instead."""
+        args = ServerArgs(model_path="dummy", tp_size=4, dcp_size=3)
+        with self.assertRaisesRegex(ValueError, "must divide --tp-size"):
+            args._handle_dcp_validation()
+
+    def test_dcp_divisor_of_tp_accepted(self):
+        for tp, dcp in [(4, 4), (4, 2), (8, 4), (4, 1)]:
+            args = ServerArgs(model_path="dummy", tp_size=tp, dcp_size=dcp)
+            args._handle_dcp_validation()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
> Stacked on #35298 (base: `fix-dcp-args-validation`). This PR's own diff is the last commit; GitHub will retarget it to `main` once #35298 merges.

## Motivation

`fa3` has no DCP decode path for MLA models: it returns no LSE for the cross-dcp-rank reduction, so `forward_mla`'s `attn_mqa_for_dcp_decode` unpacks two values from a single return and a `--dcp-size > 1` run dies at decode cuda-graph capture with `ValueError: too many values to unpack` — far from the actual misconfiguration.

`fa3` is also the **Hopper MLA auto-default**, so every Hopper DCP launch without an explicit `--attention-backend` hits this. Blackwell is unaffected because its MLA default is already `flashinfer`, which carries the DCP metadata.

## Modifications

- `_handle_dcp_validation`: reject an explicit `fa3` (`--attention-backend` or `--decode-attention-backend`) with `dcp_size > 1` on MLA models, naming DCP-aware alternatives. Prefill-only disaggregation workers are exempt — they never run the DCP decode path.
- `_get_default_attn_backend`: Hopper MLA under DCP defaults to `flashinfer` instead of `fa3`, matching the Blackwell branch.

No working configuration changes behavior: the rejected combination previously crashed at capture, and the default change replaces a guaranteed crash with a backend that works.

## Verification

- Reproduced on 4x H200 with Kimi-Linear-48B-A3B-Instruct (`tp=4 dcp=4`): the capture crash on the fa3 auto-default, and a clean start on `flashinfer`.
- **Unit tests** (`TestDcpAttentionBackend`): verified red on pre-fix code, green post-fix. Negative branches pin that prefill-only workers and MHA models still accept fa3, and that the non-DCP Hopper MLA default stays `fa3`.
- `pre-commit run` passes.

## Checklist

- [x] Format your code with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation as needed.
- [x] Provide verification results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32194002702](https://github.com/sgl-project/sglang/actions/runs/32194002702)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32194002504](https://github.com/sgl-project/sglang/actions/runs/32194002504)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32194002582](https://github.com/sgl-project/sglang/actions/runs/32194002582)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->