### PR TITLE
fix(moe): handle bf16 DeepEP low_latency dispatch (a_scales=None) in cutlass W4A8

### DIFF
--- a/python/sglang/srt/layers/moe/cutlass_w4a8_moe.py
+++ b/python/sglang/srt/layers/moe/cutlass_w4a8_moe.py
@@ -526,13 +526,18 @@ def cutlass_w4a8_moe_deepep_ll(
     )
 
     gateup_input = torch.empty(a_states.shape, dtype=torch.float8_e4m3fn, device=device)
-    fp8_per_token_to_per_tensor_quant_triton(
-        x=a_states,
-        x_scale=a_scales,
-        masked_m=masked_m,
-        output_scale=a1_scale,
-        output=gateup_input,
-    )
+    if a_scales is None:
+        # DeepEP low_latency dispatches bf16 (no per-token scales) -> quantize to per-tensor
+        # fp8 with the static input scale, as cutlass_w4a8_moe_deepep_normal() does.
+        per_tensor_quant_fp8(a_states, gateup_input, a1_scale.float(), True)
+    else:
+        fp8_per_token_to_per_tensor_quant_triton(
+            x=a_states,
+            x_scale=a_scales,
+            masked_m=masked_m,
+            output_scale=a1_scale,
+            output=gateup_input,
+        )
     c1 = torch.empty((num_experts, m, n * 2), device=device, dtype=torch.bfloat16)
     c2 = torch.empty((num_experts, m, k), device=device, dtype=torch.bfloat16)
 


### PR DESCRIPTION
### Problem
`cutlass_w4a8_moe_deepep_ll()` unconditionally calls
`fp8_per_token_to_per_tensor_quant_triton(x_scale=a_scales, ...)`. Under DeepEP
**low_latency**, the cutlass W4A8 backend dispatches in **bf16** (its default; also
forced by `--deepep-dispatcher-output-dtype bf16`), so the dispatch returns bf16
tokens with **no per-token fp8 scales** — `a_scales is None`. The unconditional call
then dereferences `None`:

```
AttributeError: 'NoneType' object has no attribute 'size'
```

at decode cuda-graph capture → scheduler dies (exit -3). Hit on Kimi-K3-W4AFP8 with
`--deepep-mode auto` (normal prefill + low_latency decode), cuda-graph ON.

### Fix
When `a_scales is None`, quantize the bf16 masked tokens to per-tensor fp8 in-place
with the static input scale via `per_tensor_quant_fp8(...)` — byte-for-byte the same
quantization `cutlass_w4a8_moe_deepep_normal()` already applies to its bf16 input.

Forcing fp8 dispatch instead is not a general fix: the per-token triton kernel asserts
`hidden % 1024 == 0`, which fails for models whose routed-expert hidden size isn't
1024-divisible (e.g. Kimi-K3 = 3584).

### Validation
mini-K3 (2 nodes, EP16, `--deepep-mode auto`, cuda-graph ON) passes decode capture and
serves completions without the crash. Draft pending upstream CI + a full multi-node run.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32190125293](https://github.com/sgl-project/sglang/actions/runs/32190125293)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32190125037](https://github.com/sgl-project/sglang/actions/runs/32190125037)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->