### PR TITLE
[Kernel] Tune Kimi-K3 Marlin MoE block sizes on H200

### DIFF
--- a/python/sglang/srt/layers/moe/fused_moe_triton/fused_marlin_moe.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/fused_marlin_moe.py
@@ -10,6 +10,12 @@ from sglang.srt.utils import is_cuda
 from sglang.srt.utils.custom_op import register_custom_op
 
 _is_cuda = is_cuda()
+_MARLIN_MOE_BLOCK_SIZES = (8, 16, 32, 48, 64)
+_H200_MARLIN_MOE_BLOCK_SIZE_CONFIGS = {
+    # Kimi-K3 TP16/EP16 and TP32/EP32.
+    (896, 56, 16): ((128, 8), (512, 16), (1024, 32), (4096, 48)),
+    (896, 28, 16): ((64, 8), (256, 16), (512, 32), (2048, 48)),
+}
 
 if _is_cuda:
     from sgl_kernel import moe_sum_reduce
@@ -131,6 +137,29 @@ def swiglu_gpt_oss_sigmoid_alpha_contiguous(
     output.copy_(gate * torch.sigmoid(gate * gemm1_alpha) * (up + 1))
 
 
+def _select_moe_block_size(
+    num_tokens: int,
+    num_experts: int,
+    top_k: int,
+    global_num_experts: int = -1,
+    device_name: str = "",
+) -> int:
+    if device_name.startswith("NVIDIA H200"):
+        config = _H200_MARLIN_MOE_BLOCK_SIZE_CONFIGS.get(
+            (global_num_experts, num_experts, top_k)
+        )
+        if config is not None:
+            for max_tokens, block_size_m in config:
+                if num_tokens <= max_tokens:
+                    return block_size_m
+            return _MARLIN_MOE_BLOCK_SIZES[-1]
+
+    for block_size_m in _MARLIN_MOE_BLOCK_SIZES:
+        if num_tokens * top_k / num_experts / block_size_m < 0.9:
+            return block_size_m
+    return _MARLIN_MOE_BLOCK_SIZES[-1]
+
+
 @register_custom_op(out_shape="hidden_states")
 def fused_marlin_moe(
     hidden_states: torch.Tensor,
@@ -235,14 +264,15 @@ def fused_marlin_moe(
     topk = topk_ids.shape[1]
     gemm1_n = 2 * N if is_gated else N
 
-    # M block size selection logic
-    # TODO: tune this further for specific models
-    for block_size_m in [8, 16, 32, 48, 64]:
-        if M * topk / E / block_size_m < 0.9:
-            break
-
     if global_num_experts == -1:
         global_num_experts = E
+    block_size_m = _select_moe_block_size(
+        M,
+        E,
+        topk,
+        global_num_experts=global_num_experts,
+        device_name=torch.cuda.get_device_name(hidden_states.device),
+    )
     if (
         M == 1
         and topk <= 32

--- a/test/registered/quant/test_marlin_moe.py
+++ b/test/registered/quant/test_marlin_moe.py
@@ -6,7 +6,10 @@ import torch
 from sgl_kernel.scalar_type import scalar_types
 
 from sglang.srt.layers.activation import SiluAndMul
-from sglang.srt.layers.moe.fused_moe_triton.fused_marlin_moe import fused_marlin_moe
+from sglang.srt.layers.moe.fused_moe_triton.fused_marlin_moe import (
+    _select_moe_block_size,
+    fused_marlin_moe,
+)
 from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_marlin_utils import awq_marlin_quantize, marlin_quantize
@@ -140,6 +143,66 @@ def marlin_moe_generate_valid_test_cases():
         if is_valid(*case):
             cases.append(case)
     return cases
+
+
+class TestMarlinMoeBlockSizeSelection(unittest.TestCase):
+    def test_kimi_k3_h200_tp16_ep16(self):
+        expected = {
+            128: 8,
+            256: 16,
+            512: 16,
+            1024: 32,
+            2048: 48,
+            4096: 48,
+            8192: 64,
+        }
+        for num_tokens, block_size in expected.items():
+            with self.subTest(num_tokens=num_tokens):
+                self.assertEqual(
+                    _select_moe_block_size(
+                        num_tokens,
+                        num_experts=56,
+                        top_k=16,
+                        global_num_experts=896,
+                        device_name="NVIDIA H200",
+                    ),
+                    block_size,
+                )
+
+    def test_kimi_k3_h200_tp32_ep32(self):
+        expected = {
+            64: 8,
+            128: 16,
+            256: 16,
+            512: 32,
+            1024: 48,
+            2048: 48,
+            4096: 64,
+        }
+        for num_tokens, block_size in expected.items():
+            with self.subTest(num_tokens=num_tokens):
+                self.assertEqual(
+                    _select_moe_block_size(
+                        num_tokens,
+                        num_experts=28,
+                        top_k=16,
+                        global_num_experts=896,
+                        device_name="NVIDIA H200",
+                    ),
+                    block_size,
+                )
+
+    def test_other_devices_keep_default_heuristic(self):
+        self.assertEqual(
+            _select_moe_block_size(
+                64,
+                num_experts=56,
+                top_k=16,
+                global_num_experts=896,
+                device_name="NVIDIA H100 80GB HBM3",
+            ),
+            32,
+        )
 
 
 class TestFusedMarlinMoe(CustomTestCase):


### PR DESCRIPTION
## Summary

Tune the Marlin MoE `BLOCK_SIZE_M` selector for the documented Kimi-K3 H200 deployment topologies:

- TP16 / EP16: 896 global experts, 56 local experts per rank, top-k 16
- TP32 / EP32: 896 global experts, 28 local experts per rank, top-k 16

Kimi-K3's H200 recipes explicitly use `--moe-runner-backend marlin`, so Triton fused-MoE JSON configs are not consulted. This change adds H200-only Marlin block-size tables while preserving the existing heuristic for every other device and shape.

Base commit: `955704544c`

## Environment

- 2x NVIDIA H200
- PyTorch `2.11.0+cu130`
- CUDA runtime `13.0`
- CUDA compiler `13.1`
- Triton `3.6.0`
- Python `3.12`

```bash
ROOT=/shared/user/vjhaveri/sglang-kimi-h200-tuning
VENV=/shared/user/qwen35-9ms-sla/venvs/sglang-v0.5.16-cu130
export PATH="$VENV/bin:$PATH"
export PYTHONPATH=python
export CPATH=/shared/user/qwen35-9ms-sla/system-deps/python3-devel/root/usr/include/python3.12
cd "$ROOT"
```

## Tuning commands

The benchmark uses random packed MXFP4 weights with Kimi-K3's exact rank-local dimensions:

- hidden size: 3584 (`routed_expert_hidden_size`)
- intermediate size: 3072
- global experts: 896
- top-k: 16
- remote expert ids mapped to the standard dispatcher's `-1` sentinel
- three repetitions per candidate; each repetition is the median of 30 timed calls after 10 warmups

Both H200s were used concurrently:

```bash
CUDA_VISIBLE_DEVICES=0 \
SGLANG_JIT_CACHE_DIR=/shared/user/vjhaveri/.cache/sglang-jit-kimi-gpu0 \
"$VENV/bin/python" /shared/user/vjhaveri/tune_kimi_k3_marlin_block_size.py \
  --shape k3-tp16-ep16 \
  --tokens 1 4 16 32 64 128 256 512 1024 2048 4096 \
  --blocks 8 16 32 48 64 \
  --alignments global \
  --warmup 10 \
  --iterations 30 \
  --repeats 3 \
  --output /shared/user/vjhaveri/sglang-kimi-h200-results/k3-extended-tp16.json

CUDA_VISIBLE_DEVICES=1 \
SGLANG_JIT_CACHE_DIR=/shared/user/vjhaveri/.cache/sglang-jit-kimi-gpu1 \
"$VENV/bin/python" /shared/user/vjhaveri/tune_kimi_k3_marlin_block_size.py \
  --shape k3-tp32-ep32 \
  --tokens 1 4 16 32 64 128 256 512 1024 2048 4096 \
  --blocks 8 16 32 48 64 \
  --alignments global \
  --warmup 10 \
  --iterations 30 \
  --repeats 3 \
  --output /shared/user/vjhaveri/sglang-kimi-h200-results/k3-extended-tp32.json
```

Large-token fallback validation:

```bash
CUDA_VISIBLE_DEVICES=0 \
"$VENV/bin/python" /shared/user/vjhaveri/tune_kimi_k3_marlin_block_size.py \
  --shape k3-tp16-ep16 \
  --tokens 8192 16384 \
  --blocks 32 48 64 \
  --alignments global \
  --warmup 5 \
  --iterations 20 \
  --repeats 3 \
  --output /shared/user/vjhaveri/sglang-kimi-h200-results/k3-tail-tp16.json

CUDA_VISIBLE_DEVICES=1 \
"$VENV/bin/python" /shared/user/vjhaveri/tune_kimi_k3_marlin_block_size.py \
  --shape k3-tp32-ep32 \
  --tokens 8192 16384 \
  --blocks 32 48 64 \
  --alignments global \
  --warmup 5 \
  --iterations 20 \
  --repeats 3 \
  --output /shared/user/vjhaveri/sglang-kimi-h200-results/k3-tail-tp32.json
```

## Final baseline versus tuned validation

The baseline forces the previous heuristic's block. The tuned path calls the selector normally, including the new H200 table. Each result is the median of three repetitions, with 50 timed calls per repetition after 10 warmups.

```bash
CUDA_VISIBLE_DEVICES=0 \
SGLANG_JIT_CACHE_DIR=/shared/user/vjhaveri/.cache/sglang-jit-kimi-gpu0 \
"$VENV/bin/python" /shared/user/vjhaveri/validate_kimi_k3_marlin_tuning.py \
  --tuner /shared/user/vjhaveri/tune_kimi_k3_marlin_block_size.py \
  --shape k3-tp16-ep16 \
  --tokens 32 64 128 256 512 1024 2048 4096 \
  --warmup 10 \
  --iterations 50 \
  --repeats 3 \
  --output /shared/user/vjhaveri/sglang-kimi-h200-results/k3-final-tp16.json

CUDA_VISIBLE_DEVICES=1 \
SGLANG_JIT_CACHE_DIR=/shared/user/vjhaveri/.cache/sglang-jit-kimi-gpu1 \
"$VENV/bin/python" /shared/user/vjhaveri/validate_kimi_k3_marlin_tuning.py \
  --tuner /shared/user/vjhaveri/tune_kimi_k3_marlin_block_size.py \
  --shape k3-tp32-ep32 \
  --tokens 32 64 128 256 512 1024 2048 4096 \
  --warmup 10 \
  --iterations 50 \
  --repeats 3 \
  --output /shared/user/vjhaveri/sglang-kimi-h200-results/k3-final-tp32.json
```

### TP16 / EP16

| Tokens | Baseline block | Tuned block | Baseline (ms) | Tuned (ms) | Reduction |
|---:|---:|---:|---:|---:|---:|
| 32 | 16 | 8 | 0.285248 | 0.270016 | 5.34% |
| 64 | 32 | 8 | 0.593280 | 0.446304 | 24.77% |
| 128 | 48 | 8 | 0.742240 | 0.479968 | 35.34% |
| 256 | 64 | 16 | 0.910304 | 0.551712 | 39.39% |
| 512 | 64 | 16 | 0.987008 | 0.653952 | 33.74% |
| 1024 | 64 | 32 | 1.136192 | 0.903392 | 20.49% |
| 2048 | 64 | 48 | 1.431456 | 1.308736 | 8.57% |
| 4096 | 64 | 48 | 2.846432 | 2.584288 | 9.21% |

### TP32 / EP32

| Tokens | Baseline block | Tuned block | Baseline (ms) | Tuned (ms) | Reduction |
|---:|---:|---:|---:|---:|---:|
| 32 | 32 | 8 | 0.317440 | 0.242080 | 23.74% |
| 64 | 48 | 8 | 0.394720 | 0.260736 | 33.94% |
| 128 | 64 | 16 | 0.478624 | 0.290528 | 39.30% |
| 256 | 64 | 16 | 0.519264 | 0.345600 | 33.44% |
| 512 | 64 | 32 | 0.594496 | 0.475520 | 20.01% |
| 1024 | 64 | 48 | 0.745024 | 0.681664 | 8.50% |
| 2048 | 64 | 48 | 1.452384 | 1.311200 | 9.72% |
| 4096 | 64 | 64 | 2.422336 | 2.421856 | 0.02% |

The maximum relative L2 difference observed between the previous and tuned block schedules was `9.20e-05`.

## Kimi-K2.7-Code audit

Kimi-K2.7-Code uses compressed-tensors INT4 W4A16 with Marlin at the documented H200 TP8 topology (`E=384`, rank-local intermediate size `256`, top-k 8).

```bash
CUDA_VISIBLE_DEVICES=1 \
SGLANG_JIT_CACHE_DIR=/shared/user/vjhaveri/.cache/sglang-jit-kimi-k27-gpu1 \
"$VENV/bin/python" /shared/user/vjhaveri/tune_kimi_k27_marlin_block_size.py \
  --tokens 1 4 16 32 64 128 256 512 1024 2048 4096 8192 \
  --warmup 10 \
  --iterations 30 \
  --repeats 3 \
  --output /shared/user/vjhaveri/sglang-kimi-h200-results/k27-sweep.json
```

No K2.7 config is added:

- The existing selector was already optimal at the H200 default 8192-token prefill chunk.
- It was also optimal at the broadly useful 32-2048 token points.
- Block 48 improved the isolated 4096-token point by about 14%, but regressed 3072 tokens by about 42% on both H200s, so a narrow override would not be robust.

Kimi-K2.6 was released on April 14, 2026 and was excluded by the post-April model cutoff.

## Non-quantized audit

- Kimi-K2.7-Code has no official non-quantized checkpoint; the official checkpoint is compressed-tensors INT4.
- Kimi-K3 has no official non-quantized checkpoint; routed experts are MXFP4.
- Kimi-K3's unquantized shared experts are separate dense MLPs and do not use this Marlin MoE block-size selector.

## Tests

Block-selection tests:

```bash
CUDA_VISIBLE_DEVICES=0 \
"$VENV/bin/python" \
  test/registered/quant/test_marlin_moe.py \
  TestMarlinMoeBlockSizeSelection
```

Full Marlin MoE GPU tests:

```bash
CUDA_VISIBLE_DEVICES=0 \
SGLANG_JIT_CACHE_DIR=/shared/user/vjhaveri/.cache/sglang-jit-kimi-tests \
"$VENV/bin/python" \
  test/registered/quant/test_marlin_moe.py \
  TestFusedMarlinMoe
```

Result: 2 tests passed in 649.064 seconds.

Focused lint:

```bash
uvx pre-commit run --files \
  python/sglang/srt/layers/moe/fused_moe_triton/fused_marlin_moe.py \
  test/registered/quant/test_marlin_moe.py
```

All focused pre-commit hooks passed.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32191093029](https://github.com/sgl-project/sglang/actions/runs/32191093029)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32191092794](https://github.com/sgl-project/sglang/actions/runs/32191092794)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->