### PR TITLE
[AMD] Make ROCm 7.2.4 images profile HIP-graph kernels, and check that they do

### DIFF
--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -820,6 +820,59 @@ RUN if [ "$BUILD_TRITON" = "1" ]; then \
 RUN case "${GPU_ARCH}" in *-rocm724) python3 -c "import pathlib,re,importlib.metadata as m; p=pathlib.Path(m.distribution('torch')._path)/'METADATA'; v=m.version('triton'); t,n=re.subn(r'^Requires-Dist: (?:triton|triton-rocm)==[^ ;]+', 'Requires-Dist: triton=='+v, p.read_text(), count=1, flags=re.M); assert n==1, n; p.write_text(t)" ;; esac
 
 # -----------------------
+# Point torch at the image's ROCm runtime.
+#
+# The wheels vendor their own HIP and roctracer under torch/lib, and
+# libtorch_hip.so carries RPATH $ORIGIN, so those copies win over /opt/rocm
+# whatever LD_LIBRARY_PATH says. A ROCm 7.2.4 image consequently profiles
+# through 7.2.0 libraries and loses kernel events under hipGraphLaunch
+# (ROCm/ROCm#6102, fixed in 7.2.2): 448 of 512 graph-replay kernels reached the
+# trace on both MI300X and MI355X, against 512 of 512 with the ROCm copies
+# preloaded, and 87% of decode kernels went missing in a real server trace.
+#
+# Replacing the vendored files makes the working configuration the default
+# instead of something every user has to know to preload. Keyed on whether the
+# wheel vendors them at all, so flavors whose torch already links /opt/rocm are
+# left alone. Replaced by rename: the running interpreter has the old files
+# mapped, and writing through them would corrupt it.
+RUN python3 - <<'PY'
+import os
+import pathlib
+import shutil
+import sys
+
+import torch
+
+torch_lib = pathlib.Path(torch.__file__).resolve().parent / "lib"
+rocm_lib = pathlib.Path("/opt/rocm/lib")
+replaced = []
+
+for name in ("libamdhip64", "libroctracer64"):
+    vendored = torch_lib / f"{name}.so"
+    if not vendored.exists():
+        print(f"{name}: not vendored by the wheel, nothing to replace")
+        continue
+    versioned = sorted(p for p in rocm_lib.glob(f"{name}.so.*") if not p.is_symlink())
+    if not versioned:
+        sys.exit(f"FATAL: {name} is vendored but {rocm_lib} has no copy to use")
+    source = versioned[-1]
+    staged = vendored.with_name(f"{vendored.name}.rocm")
+    shutil.copy2(source, staged)
+    staged.chmod(vendored.stat().st_mode & 0o7777)
+    os.replace(staged, vendored)
+    replaced.append((vendored, source))
+    print(f"{name}: {vendored} <- {source} ({source.stat().st_size} bytes)")
+
+for vendored, source in replaced:
+    if vendored.stat().st_size != source.stat().st_size:
+        sys.exit(f"FATAL: {vendored} does not match {source}")
+PY
+
+# A fresh interpreter, so this loads the libraries just swapped in: an ABI or
+# soname mismatch fails the build here rather than at a user's first profile.
+RUN python3 -c "import torch; assert torch.version.hip is not None, torch.__version__; print(f'[ROCm runtime] torch {torch.__version__}, hip {torch.version.hip}')"
+
+# -----------------------
 # Performance environment variable.
 
 # Skip CuDNN compatibility check - not applicable for ROCm (uses MIOpen instead)

--- a/docs/docs/developer_guide/benchmark_and_profiling.mdx
+++ b/docs/docs/developer_guide/benchmark_and_profiling.mdx
@@ -378,6 +378,36 @@ export SGLANG_PROFILE_WITH_STACK=False
 python -m sglang.bench_offline_throughput --model-path meta-llama/Llama-3.1-8B-Instruct --dataset-name random --num-prompts 10 --profile --mem-frac=0.8
 ```
 
+### Missing GPU kernels on ROCm 7.2.0 images
+
+On ROCm 7.2.0, the roctracer backend behind PyTorch Profiler drops kernel-dispatch events for work submitted through `hipGraphLaunch`. Traces then under-report the decode steps, which run from replayed graphs: prefill kernels and the host-side graph launches are there, but kernels are missing underneath. The loss is partial rather than total, so a trace can look plausible and still be wrong. The same combination can also deadlock the HIP runtime inside the replay. ROCm resolved the reporting failure in 7.2.2 ([ROCm/ROCm#6102](https://github.com/ROCm/ROCm/issues/6102)).
+
+To check whether an image traces graph-launched kernels, run this inside it on a GPU host:
+
+```bash Command
+python3 scripts/ci/amd/check_hip_graph_profiling.py
+```
+
+Use a `rocm724` image (`lmsysorg/sglang-rocm:*-rocm724-*` daily, `lmsysorg/sglang:*-rocm724-*` per release). Those install ROCm 7.2.4 and point torch at it, so graph-launched kernels are traced with CUDA graphs left on.
+
+Installing 7.2.4 is not by itself enough, which matters for images built before that was addressed: the torch wheel vendors its own HIP and roctracer under `torch/lib`, and `libtorch_hip.so` has `RPATH $ORIGIN`, so the profiler runs through those 7.2.0 copies and `LD_LIBRARY_PATH` cannot override an `RPATH`. On such an image, overwrite the two files the wheel vendors:
+
+```bash Command
+TORCH_LIB=$(python3 -c 'import pathlib, torch; print(pathlib.Path(torch.__file__).resolve().parent / "lib")')
+cp -a /opt/rocm/lib/libamdhip64.so.7.2.70204 "$TORCH_LIB/libamdhip64.so"
+cp -a /opt/rocm/lib/libroctracer64.so.4.1.70204 "$TORCH_LIB/libroctracer64.so"
+```
+
+Prefer that over `LD_PRELOAD`ing the same libraries. A preload leaves both copies mapped in the process, which is harmless for a quick check but has been seen to abort server startup during CUDA-graph capture, inside Triton's AMD launcher.
+
+The probe above prints which libraries torch actually mapped, so use it to tell the two situations apart rather than assuming.
+
+On a `rocm720` image, or wherever preloading is not an option, profile with CUDA graphs disabled so that every kernel is launched eagerly and reaches the trace. Decode numbers collected this way exclude the graph-replay path, so use them to attribute kernel time rather than to measure decode latency.
+
+```bash Command
+python -m sglang.launch_server --model-path meta-llama/Llama-3.1-8B-Instruct --disable-cuda-graph
+```
+
 ### View traces
 
 Trace files can be loaded and visualized from:

--- a/scripts/ci/amd/check_hip_graph_profiling.py
+++ b/scripts/ci/amd/check_hip_graph_profiling.py
@@ -1,0 +1,453 @@
+#!/usr/bin/env python3
+"""Check that torch.profiler records device kernels launched by HIP/CUDA graph replay.
+
+ROCm 7.2.0 (roctracer 4.1.70200) loses kernel-dispatch events for work submitted
+through hipGraphLaunch: a trace captured while SGLang decodes -- which replays HIP
+graphs -- comes back missing kernels. ROCm resolved the roctracer reporting failure
+in 7.2.2 (https://github.com/ROCm/ROCm/issues/6102).
+
+Having the fix in the image is not the same as running it. The torch wheels vendor
+their own HIP and roctracer in torch/lib, and libtorch_hip.so carries RPATH $ORIGIN,
+so a ROCm 7.2.4 image can still profile through 7.2.0 libraries; LD_LIBRARY_PATH
+does not override that. This probe reports which libraries torch actually mapped and
+prints the LD_PRELOAD that forces the ROCm install's copies.
+
+Run inside the image under evaluation, on a machine with at least one GPU:
+
+    python3 scripts/ci/amd/check_hip_graph_profiling.py
+
+The loss is partial, not total: on ROCm 7.2.0 a 4-node graph is traced correctly
+while a 64-node graph drops events, so the check counts every dispatch it asked
+for rather than looking for a non-empty trace. The eager phase is a control,
+separating "this runtime cannot trace graph replay" from "this runtime cannot
+trace anything", and each phase runs in a child process under a timeout because
+7.2.0 can also wedge inside hipGraphLaunch instead of losing events.
+
+Exit status is 0 when every graph-replay kernel reaches the trace, 1 otherwise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import re
+import signal
+import subprocess
+import sys
+import tempfile
+
+RESULT_MARKER = "PROBE_RESULT "
+DEVICE_CATEGORIES = ("kernel", "gpu_memcpy", "gpu_memset")
+TRACING_LIB_PATTERN = re.compile(
+    r"\S*lib(?:amdhip64|roctracer64|rocprofiler-sdk|rocprofiler-register|hsa-runtime64)[^/\s]*\.so[^/\s]*"
+)
+# The libraries whose version decides whether graph replay is traced.
+RUNTIME_LIBS = ("libamdhip64", "libroctracer64")
+# Options that shape the workload, so the phase children need all of them.
+PHASE_OPTIONS = ("replays", "matmul_size", "graph_nodes")
+
+
+def loaded_tracing_libs() -> list[str]:
+    """Paths of the HIP/tracing libraries mapped into this process.
+
+    Paths, not sonames: a ROCm 7.2.4 image can still be running the 7.2.0 copies
+    that the torch wheel vendors in torch/lib, and only the path shows that.
+    """
+    try:
+        with open("/proc/self/maps") as f:
+            maps = f.read()
+    except OSError:
+        return []
+    return sorted({m.group(0) for m in TRACING_LIB_PATTERN.finditer(maps)})
+
+
+def vendored_runtime_libs(
+    libs: list[str], rocm_lib_dir: str = "/opt/rocm/lib"
+) -> list[str]:
+    """Mapped HIP/tracing libraries that are not the ROCm install's build.
+
+    `libtorch_hip.so` carries `RPATH $ORIGIN` and needs `libamdhip64.so` /
+    `libroctracer64.so`, so the loader takes the wheel's copies and
+    LD_LIBRARY_PATH does not override them. The image's ROCm version then says
+    nothing about what torch.profiler is actually using.
+
+    Neither the path nor the file name settles it, so both are checked against
+    the ROCm install: a preload maps its copy alongside the wheel's and
+    interposes, and an image can have the ROCm library copied over the wheel's
+    path, where only the size gives it away.
+    """
+    rocm_sizes: dict[str, set[int]] = {}
+    for name in RUNTIME_LIBS:
+        sizes = set()
+        for path in glob.glob(os.path.join(rocm_lib_dir, f"{name}.so.*")):
+            if not os.path.islink(path):
+                try:
+                    sizes.add(os.path.getsize(path))
+                except OSError:
+                    pass
+        rocm_sizes[name] = sizes
+
+    flagged = []
+    for name in RUNTIME_LIBS:
+        mapped = [lib for lib in libs if name in lib]
+        if not mapped or any(lib.startswith("/opt/rocm") for lib in mapped):
+            continue
+        for lib in mapped:
+            try:
+                is_rocm_build = os.path.getsize(lib) in rocm_sizes[name]
+            except OSError:
+                is_rocm_build = False
+            if not is_rocm_build:
+                flagged.append(lib)
+    return flagged
+
+
+def rocm_runtime_preload(lib_dir: str = "/opt/rocm/lib") -> str | None:
+    """LD_PRELOAD value that forces the ROCm install's HIP and roctracer."""
+    resolved = []
+    for name in RUNTIME_LIBS:
+        # The unversioned names are symlinks; preload needs the real files, and
+        # naming them keeps the value correct across ROCm patch releases.
+        versioned = [
+            path
+            for path in sorted(glob.glob(os.path.join(lib_dir, f"{name}.so.*")))
+            if not os.path.islink(path)
+        ]
+        if not versioned:
+            return None
+        resolved.append(versioned[-1])
+    return ":".join(resolved)
+
+
+def rocm_version() -> str | None:
+    for path in ("/opt/rocm/.info/version", "/opt/rocm/.info/version-dev"):
+        try:
+            with open(path) as f:
+                return f.read().strip()
+        except OSError:
+            continue
+    return None
+
+
+def phase_env() -> dict:
+    import torch
+
+    info: dict = {
+        "python": sys.version.split()[0],
+        "torch": torch.__version__,
+        "torch_hip": torch.version.hip,
+        "torch_cuda": torch.version.cuda,
+        "rocm_version": rocm_version(),
+        "device_count": 0,
+    }
+    if not torch.cuda.is_available():
+        info["error"] = "no GPU visible to torch"
+        return info
+
+    torch.cuda.init()
+    props = torch.cuda.get_device_properties(0)
+    info.update(
+        device_count=torch.cuda.device_count(),
+        device_name=torch.cuda.get_device_name(0),
+        gcn_arch=getattr(props, "gcnArchName", None),
+        libs=loaded_tracing_libs(),
+    )
+    return info
+
+
+def count_device_events(events: list[dict]) -> dict[str, int]:
+    """Device-side event counts per Chrome-trace category, as Perfetto would show them."""
+    counts: dict[str, int] = {}
+    for event in events:
+        category = str(event.get("cat", "")).lower()
+        if category in DEVICE_CATEGORIES:
+            counts[category] = counts.get(category, 0) + 1
+    return counts
+
+
+def phase_profile(use_graph: bool, replays: int, size: int, nodes: int) -> dict:
+    import torch
+
+    if not torch.cuda.is_available():
+        return {"error": "no GPU visible to torch"}
+
+    device = torch.device("cuda", 0)
+    torch.cuda.set_device(device)
+    a = torch.randn((size, size), device=device, dtype=torch.float16)
+    b = torch.randn((size, size), device=device, dtype=torch.float16)
+    out = torch.empty_like(a)
+
+    # Graph capture requires the workload to have run on a non-default stream first.
+    warmup_stream = torch.cuda.Stream()
+    warmup_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(warmup_stream):
+        for _ in range(3):
+            torch.matmul(a, b, out=out)
+    torch.cuda.current_stream().wait_stream(warmup_stream)
+    torch.cuda.synchronize()
+
+    if use_graph:
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            for _ in range(nodes):
+                torch.matmul(a, b, out=out)
+        launch = graph.replay
+    else:
+
+        def launch() -> None:
+            for _ in range(nodes):
+                torch.matmul(a, b, out=out)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        trace_path = os.path.join(tmpdir, "probe.json")
+        with torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ]
+        ) as prof:
+            for _ in range(replays):
+                launch()
+            torch.cuda.synchronize()
+        prof.export_chrome_trace(trace_path)
+        with open(trace_path) as f:
+            events = json.load(f)["traceEvents"]
+
+    counts = count_device_events(events)
+    device_time_us = sum(
+        getattr(item, "self_device_time_total", 0)
+        or getattr(item, "self_cuda_time_total", 0)
+        for item in prof.key_averages()
+    )
+    return {
+        "kernels": counts.get("kernel", 0),
+        # One matmul is one dispatch, so a healthy runtime reports every one of
+        # them. Loss under graph replay is partial -- 448 of 512 in the ROCm
+        # 7.2.0 measurement on #35390 -- so a threshold of "more than zero"
+        # would call a broken runtime healthy.
+        "expected_kernels": nodes * replays,
+        "event_counts": counts,
+        "trace_events": len(events),
+        "self_device_time_us": device_time_us,
+        "libs": loaded_tracing_libs(),
+    }
+
+
+def child_command(phase: str, args: argparse.Namespace) -> list[str]:
+    """The child invocation for one phase, carrying every workload option.
+
+    Built from PHASE_OPTIONS rather than by hand: a knob that the parent accepts
+    and forgets to forward is silently ignored, and the child's own default then
+    stands in for it.
+    """
+    cmd = [sys.executable, os.path.abspath(__file__), "--phase", phase]
+    for name in PHASE_OPTIONS:
+        cmd += [f"--{name.replace('_', '-')}", str(getattr(args, name))]
+    return cmd
+
+
+def run_child(phase: str, args: argparse.Namespace) -> dict:
+    cmd = child_command(phase, args)
+    # New session so a HIP runtime wedged past SIGTERM can still be killed as a group.
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        start_new_session=True,
+    )
+    try:
+        output = proc.communicate(timeout=args.timeout)[0]
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        output = proc.communicate()[0]
+        return {"status": "timeout", "output": output}
+
+    result = {"status": "ok" if proc.returncode == 0 else "error", "output": output}
+    for line in output.splitlines():
+        if line.startswith(RESULT_MARKER):
+            result.update(json.loads(line[len(RESULT_MARKER) :]))
+    return result
+
+
+def report(label: str, result: dict) -> None:
+    prefix = f"{label:<14}"
+    if result.get("status") == "timeout":
+        print(f"{prefix}TIMEOUT (no result within the phase timeout)")
+    elif result.get("kernels") is None:
+        print(f"{prefix}ERROR {result.get('error', '')}".rstrip())
+    else:
+        print(
+            f"{prefix}{result['kernels']}/{result['expected_kernels']} kernel events, "
+            f"{result['self_device_time_us']:.0f} us device time, "
+            f"{result['trace_events']} trace events"
+        )
+        return
+    if result.get("output"):
+        print("--- phase output ---")
+        print(result["output"].rstrip())
+        print("--- end phase output ---")
+
+
+def traced_everything(result: dict) -> bool:
+    kernels, expected = result.get("kernels"), result.get("expected_kernels")
+    return kernels is not None and expected is not None and kernels >= expected
+
+
+PARENT_ONLY_OPTIONS = ("phase", "timeout", "print_ld_preload")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--phase",
+        choices=("all", "env", "eager", "graph"),
+        default="all",
+        help="internal: 'all' orchestrates the others in child processes",
+    )
+    parser.add_argument("--replays", type=int, default=8)
+    parser.add_argument("--matmul-size", type=int, default=1024)
+    parser.add_argument(
+        "--graph-nodes",
+        type=int,
+        default=64,
+        help="dispatches per graph. 64 is the calibrated value: ROCm 7.2.0 traces a "
+        "4-node graph completely and only starts dropping around 16, while 7.2.4 is "
+        "complete at 64 across repeated runs. Raising it much further is not a "
+        "stricter test -- 7.2.4 has been seen dropping events at 256 -- so a failure "
+        "there does not mean the same thing",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=300.0,
+        help="seconds allowed per phase; a wedged graph launch is reported as a timeout",
+    )
+    parser.add_argument(
+        "--print-ld-preload",
+        action="store_true",
+        help="print the LD_PRELOAD that forces the ROCm install's HIP and roctracer, "
+        "for callers that have to set it before starting the process, and exit",
+    )
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    if args.print_ld_preload:
+        preload = rocm_runtime_preload()
+        if not preload:
+            print("no versioned HIP/roctracer under /opt/rocm/lib", file=sys.stderr)
+            return 1
+        print(preload)
+        return 0
+
+    if args.phase == "env":
+        info = phase_env()
+        print(RESULT_MARKER + json.dumps(info))
+        return 1 if "error" in info else 0
+    if args.phase in ("eager", "graph"):
+        result = phase_profile(
+            args.phase == "graph", args.replays, args.matmul_size, args.graph_nodes
+        )
+        print(RESULT_MARKER + json.dumps(result))
+        return 1 if "error" in result else 0
+
+    env = run_child("env", args)
+    if env.get("status") != "ok" or not env.get("device_count"):
+        reason = env.get("error") or "the environment phase did not report a usable GPU"
+        print(f"environment: unusable -- {reason}")
+        if env.get("output"):
+            print(env["output"].rstrip())
+        return 1
+
+    print(f"torch {env['torch']} (hip {env['torch_hip']}), rocm {env['rocm_version']}")
+    print(f"device: {env.get('device_name')!r} ({env.get('gcn_arch')})")
+    print("hip/tracing libs: " + ", ".join(env.get("libs") or ["<none mapped>"]))
+    if not (env.get("device_name") or "").strip():
+        print(
+            "warning: the device reports no marketing name, so device-name-keyed tuned "
+            "configs will not resolve. The image is missing libdrm-amdgpu-common "
+            "(https://github.com/ROCm/ROCm/issues/5992)."
+        )
+
+    eager = run_child("eager", args)
+    report("eager launch:", eager)
+    graph = run_child("graph", args)
+    report("graph replay:", graph)
+
+    vendored = vendored_runtime_libs(graph.get("libs") or env.get("libs") or [])
+    if graph.get("libs") and graph["libs"] != env.get("libs"):
+        print("tracing libs while profiling: " + ", ".join(graph["libs"]))
+    if vendored:
+        preload = rocm_runtime_preload()
+        print(
+            "note: torch is using its own HIP/roctracer, not the ROCm install's: "
+            + ", ".join(vendored)
+        )
+        if preload:
+            print(
+                "      to fix the image, overwrite those two files with the ROCm ones:"
+            )
+            for name, source in zip(RUNTIME_LIBS, preload.split(":")):
+                for destination in (lib for lib in vendored if name in lib):
+                    print(f"        cp -a {source} {destination}")
+            print(f'      to check this one run only: LD_PRELOAD="{preload}"')
+            print(
+                "      a preload leaves both copies mapped, which is fine here but has"
+            )
+            print("      been seen to break a full server run during graph capture")
+
+    if not traced_everything(eager):
+        print(
+            "\nVERDICT: FAIL -- the profiler did not record every eager launch, so this "
+            "runtime cannot trace GPU work reliably at all and the graph phase says "
+            "nothing about graph support."
+        )
+        return 1
+    if graph.get("status") == "timeout":
+        print(
+            "\nVERDICT: FAIL -- graph replay under the profiler never finished. "
+            "ROCm 7.2.0 can deadlock in hipGraphLaunch while a profiler session is "
+            "attached; use a ROCm 7.2.2 or newer runtime."
+        )
+        return 1
+    if graph.get("kernels") is None:
+        print(
+            "\nVERDICT: FAIL -- graph replay under the profiler did not complete; see the "
+            "phase output above."
+        )
+        return 1
+    if not traced_everything(graph):
+        missing = graph["expected_kernels"] - graph["kernels"]
+        print(
+            f"\nVERDICT: FAIL -- eager launches are traced in full but {missing} of "
+            f"{graph['expected_kernels']} graph-replay kernels never reached the trace. "
+            "That is the roctracer reporting failure fixed in ROCm 7.2.2 "
+            "(https://github.com/ROCm/ROCm/issues/6102)."
+        )
+        if vendored:
+            print(
+                "The ROCm install is not what torch loaded, so replace the wheel's copies "
+                "as printed above and re-run before concluding the image is unfixable."
+            )
+        else:
+            print(
+                "Profile with --disable-cuda-graph on this image, or move to a ROCm 7.2.2 "
+                "or newer runtime."
+            )
+        return 1
+
+    print("\nVERDICT: PASS -- every graph-replay kernel reached the trace.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/registered/unit/ci/test_hip_graph_profiling_probe.py
+++ b/test/registered/unit/ci/test_hip_graph_profiling_probe.py
@@ -1,0 +1,291 @@
+"""Unit tests for scripts/ci/amd/check_hip_graph_profiling.py — no GPU, no server.
+
+The probe decides whether a ROCm image's torch.profiler records kernels launched
+by HIP graph replay. Its verdict logic is what makes a red run actionable, so it
+is pinned here: a trace holding no device events must never read as a pass, and a
+wedged graph launch must be reported as the HIP deadlock it is rather than as a
+missing-kernel gap.
+"""
+
+import contextlib
+import importlib.util
+import io
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+PROBE_PATH = (
+    Path(__file__).resolve().parents[4] / "scripts/ci/amd/check_hip_graph_profiling.py"
+)
+
+ROCM_LIBS = [
+    "/opt/rocm-7.2.4/lib/libamdhip64.so.7.2.70204",
+    "/opt/rocm-7.2.4/lib/libroctracer64.so.4.1.70204",
+]
+# What a rocm724 image maps by default: the wheel's own 7.2.0 copies.
+VENDORED_LIBS = [
+    "/opt/venv/lib/python3.12/site-packages/torch/lib/libamdhip64.so",
+    "/opt/venv/lib/python3.12/site-packages/torch/lib/libroctracer64.so",
+]
+ENV_OK = {
+    "status": "ok",
+    "device_count": 8,
+    "torch": "2.11.0+rocm7.2",
+    "torch_hip": "7.2.41134",
+    "rocm_version": "7.2.4",
+    "device_name": "AMD Instinct MI355X",
+    "gcn_arch": "gfx950",
+    "libs": ROCM_LIBS,
+}
+TRACED = {
+    "status": "ok",
+    "kernels": 512,
+    "expected_kernels": 512,
+    "self_device_time_us": 1234.5,
+    "trace_events": 9000,
+    "libs": ROCM_LIBS,
+}
+# The measured ROCm 7.2.0 result: most kernels traced, some silently dropped.
+PARTIAL = dict(TRACED, kernels=448, self_device_time_us=1000.0)
+UNTRACED = dict(TRACED, kernels=0, self_device_time_us=0.0)
+TIMED_OUT = {"status": "timeout", "output": "(no output before the kill)"}
+CRASHED = {"status": "error", "output": "Segmentation fault"}
+
+
+def _load_probe():
+    """Fresh module per test: the verdict tests monkeypatch its run_child."""
+    spec = importlib.util.spec_from_file_location("hip_graph_probe", PROBE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestDeviceEventCounting(CustomTestCase):
+    def test_counts_device_categories_case_insensitively(self):
+        probe = _load_probe()
+        events = [
+            {"ph": "X", "cat": "kernel", "name": "gemm"},
+            {"ph": "X", "cat": "Kernel", "name": "gemm"},
+            {"ph": "X", "cat": "gpu_memcpy", "name": "Memcpy DtoD"},
+            {"ph": "X", "cat": "gpu_memset", "name": "Memset"},
+        ]
+        self.assertEqual(
+            probe.count_device_events(events),
+            {"kernel": 2, "gpu_memcpy": 1, "gpu_memset": 1},
+        )
+
+    def test_host_side_events_are_not_device_events(self):
+        # A trace of a broken graph launch is full of these and nothing else,
+        # which is exactly the failure the probe has to catch.
+        probe = _load_probe()
+        events = [
+            {"ph": "X", "cat": "cpu_op", "name": "aten::mm"},
+            {"ph": "X", "cat": "cuda_runtime", "name": "hipGraphLaunch"},
+            {"ph": "X", "cat": "ac2g", "name": "flow"},
+            {"ph": "M", "name": "process_name"},
+            {"name": "no category at all"},
+        ]
+        self.assertEqual(probe.count_device_events(events), {})
+
+
+class TestVerdict(CustomTestCase):
+    def _verdict(self, env=ENV_OK, eager=TRACED, graph=TRACED):
+        probe = _load_probe()
+        phases = {"env": env, "eager": eager, "graph": graph}
+        probe.run_child = lambda phase, args, p=phases: p[phase]
+        out = io.StringIO()
+        with mock.patch.object(sys, "argv", ["check_hip_graph_profiling"]):
+            with contextlib.redirect_stdout(out):
+                code = probe.main()
+        return code, out.getvalue()
+
+    def test_passes_when_graph_replay_kernels_reach_the_trace(self):
+        code, out = self._verdict()
+        self.assertEqual(code, 0)
+        self.assertIn("VERDICT: PASS", out)
+
+    def test_untraced_graph_replay_cites_the_roctracer_bug(self):
+        code, out = self._verdict(graph=UNTRACED)
+        self.assertEqual(code, 1)
+        self.assertIn("VERDICT: FAIL", out)
+        self.assertIn("6102", out)
+
+    def test_partial_graph_loss_fails_and_reports_the_shortfall(self):
+        # The whole reason the check counts dispatches: 448 of 512 kernels is the
+        # broken runtime, and "some kernels arrived" must not read as healthy.
+        code, out = self._verdict(graph=PARTIAL)
+        self.assertEqual(code, 1)
+        self.assertIn("64 of 512", out)
+        self.assertIn("6102", out)
+
+    def test_untraced_eager_launches_invalidate_the_graph_result(self):
+        code, out = self._verdict(eager=UNTRACED, graph=UNTRACED)
+        self.assertEqual(code, 1)
+        self.assertIn("cannot trace GPU work reliably at all", out)
+
+    def test_wedged_graph_replay_is_reported_as_a_deadlock(self):
+        code, out = self._verdict(graph=TIMED_OUT)
+        self.assertEqual(code, 1)
+        self.assertIn("hipGraphLaunch", out)
+
+    def test_crashed_graph_phase_is_not_reported_as_missing_kernels(self):
+        code, out = self._verdict(graph=CRASHED)
+        self.assertEqual(code, 1)
+        self.assertIn("did not complete", out)
+        self.assertNotIn("6102", out)
+
+    def test_unusable_environment_stops_before_probing(self):
+        code, out = self._verdict(env={"status": "error", "error": "no GPU visible"})
+        self.assertEqual(code, 1)
+        self.assertIn("environment: unusable", out)
+
+    def test_missing_marketing_name_is_flagged(self):
+        # An image without libdrm-amdgpu resolves no device name, which silently
+        # disables every device-name-keyed tuned config.
+        code, out = self._verdict(env=dict(ENV_OK, device_name=""))
+        self.assertEqual(code, 0)
+        self.assertIn("libdrm-amdgpu-common", out)
+
+    def test_vendored_runtime_is_named_when_graph_replay_is_lossy(self):
+        # A rocm724 image failing this way has the fix installed but is not
+        # loading it, so the remedy is the preload, not a different image.
+        code, out = self._verdict(
+            env=dict(ENV_OK, libs=VENDORED_LIBS),
+            eager=dict(TRACED, libs=VENDORED_LIBS),
+            graph=dict(PARTIAL, libs=VENDORED_LIBS),
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("torch is using its own HIP/roctracer", out)
+        self.assertIn("torch/lib/libamdhip64.so", out)
+        self.assertNotIn("--disable-cuda-graph", out)
+
+    def test_rocm_install_libs_are_not_reported_as_vendored(self):
+        code, out = self._verdict()
+        self.assertEqual(code, 0)
+        self.assertNotIn("torch is using its own", out)
+
+
+class TestVendoredRuntimeDetection(CustomTestCase):
+    def test_wheel_copies_are_flagged_when_no_rocm_copy_is_mapped(self):
+        probe = _load_probe()
+        libs = VENDORED_LIBS + ["/opt/venv/.../torch/lib/libtorch_hip.so"]
+        self.assertEqual(probe.vendored_runtime_libs(libs), VENDORED_LIBS)
+
+    def test_nothing_flagged_when_the_rocm_install_is_in_use(self):
+        probe = _load_probe()
+        self.assertEqual(probe.vendored_runtime_libs(ROCM_LIBS), [])
+
+    def test_a_preload_maps_both_copies_and_is_not_a_finding(self):
+        # LD_PRELOAD leaves the wheel's copies mapped too; the preloaded ones
+        # interpose, so reporting them would contradict the PASS they produced.
+        probe = _load_probe()
+        self.assertEqual(probe.vendored_runtime_libs(ROCM_LIBS + VENDORED_LIBS), [])
+
+    def test_a_partial_preload_still_flags_the_library_left_behind(self):
+        probe = _load_probe()
+        libs = [ROCM_LIBS[0]] + VENDORED_LIBS
+        self.assertEqual(probe.vendored_runtime_libs(libs), [VENDORED_LIBS[1]])
+
+    def test_the_rocm_library_copied_over_the_wheel_path_is_not_a_finding(self):
+        # What the image build leaves behind: the ROCm build sitting at the
+        # wheel's path. Reporting it would tell the reader to redo a fix that is
+        # already in place, so the size decides rather than the location.
+        probe = _load_probe()
+        with tempfile.TemporaryDirectory() as tmp:
+            rocm_dir = Path(tmp) / "rocm"
+            torch_dir = Path(tmp) / "torch-lib"
+            rocm_dir.mkdir()
+            torch_dir.mkdir()
+            mapped = []
+            for name, payload in (
+                ("libamdhip64", b"rocm-hip-build"),
+                ("libroctracer64", b"rocm-tracer"),
+            ):
+                (rocm_dir / f"{name}.so.7.2.70204").write_bytes(payload)
+                vendored = torch_dir / f"{name}.so"
+                vendored.write_bytes(payload)
+                mapped.append(str(vendored))
+            self.assertEqual(
+                probe.vendored_runtime_libs(mapped, str(rocm_dir)),
+                [],
+            )
+
+    def test_the_wheel_build_at_the_wheel_path_is_still_a_finding(self):
+        probe = _load_probe()
+        with tempfile.TemporaryDirectory() as tmp:
+            rocm_dir = Path(tmp) / "rocm"
+            torch_dir = Path(tmp) / "torch-lib"
+            rocm_dir.mkdir()
+            torch_dir.mkdir()
+            (rocm_dir / "libamdhip64.so.7.2.70204").write_bytes(b"rocm-hip-build")
+            vendored = torch_dir / "libamdhip64.so"
+            vendored.write_bytes(b"a wheel copy of a different size")
+            self.assertEqual(
+                probe.vendored_runtime_libs([str(vendored)], str(rocm_dir)),
+                [str(vendored)],
+            )
+
+
+class TestChildCommand(CustomTestCase):
+    def test_workload_options_reach_the_phase_children(self):
+        # --graph-nodes was accepted by the parent and dropped here, so a
+        # calibration run at 4 nodes silently measured the default 64.
+        probe = _load_probe()
+        args = probe.build_parser().parse_args(
+            ["--graph-nodes", "4", "--replays", "2", "--matmul-size", "256"]
+        )
+        cmd = probe.child_command("graph", args)
+        self.assertEqual(
+            cmd[-8:],
+            [
+                "--phase",
+                "graph",
+                "--replays",
+                "2",
+                "--matmul-size",
+                "256",
+                "--graph-nodes",
+                "4",
+            ],
+        )
+
+    def test_every_option_is_either_forwarded_or_parent_only(self):
+        # The guard that keeps the bug above from coming back with the next knob.
+        probe = _load_probe()
+        options = {
+            action.dest
+            for action in probe.build_parser()._actions
+            if action.dest != "help"
+        }
+        accounted = set(probe.PHASE_OPTIONS) | set(probe.PARENT_ONLY_OPTIONS)
+        self.assertEqual(options - accounted, set())
+
+
+class TestPreloadValue(CustomTestCase):
+    def test_names_the_real_files_and_skips_the_symlinks(self):
+        # Preloading the unversioned symlink is not what was measured, and the
+        # versioned name is what pins the ROCm patch level in the value.
+        probe = _load_probe()
+        with tempfile.TemporaryDirectory() as lib_dir:
+            hip = Path(lib_dir) / "libamdhip64.so.7.2.70204"
+            tracer = Path(lib_dir) / "libroctracer64.so.4.1.70204"
+            hip.touch()
+            tracer.touch()
+            (Path(lib_dir) / "libamdhip64.so.7").symlink_to(hip)
+            self.assertEqual(probe.rocm_runtime_preload(lib_dir), f"{hip}:{tracer}")
+
+    def test_no_value_when_the_image_has_no_rocm_runtime(self):
+        probe = _load_probe()
+        with tempfile.TemporaryDirectory() as lib_dir:
+            self.assertIsNone(probe.rocm_runtime_preload(lib_dir))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

AMD/Silo reported that on the `lmsysorg/sglang*` ROCm 7.2 images, `torch.profiler` traces contain no GPU kernels for work launched through hipGraph. The cause is upstream and fixed upstream — ROCTracer drops kernel-dispatch events under `hipGraphLaunch` ([ROCm/ROCm#6102](https://github.com/ROCm/ROCm/issues/6102), fixed in ROCm 7.2.2) — and #30984 has since published `rocm724` images that install ROCm 7.2.4.

Installing it turned out not to be the same as using it. The torch wheels vendor their own HIP and roctracer under `torch/lib`, and `libtorch_hip.so` carries `RPATH $ORIGIN`, so the published 7.2.4 images profile through 7.2.0 libraries and `LD_LIBRARY_PATH` cannot override an `RPATH`. Measured on `rocm/sgl-dev:v0.5.17-rocm724-*-20260820`:

| image | GPU | eager | graph replay | verdict |
| --- | --- | --- | --- | --- |
| as shipped | MI355X | 512/512 | **448/512** | FAIL |
| ROCm copies in use | MI355X | 512/512 | 512/512 | PASS |
| as shipped | MI300X | 512/512 | **448/512** | FAIL |
| ROCm copies in use | MI300X | 512/512 | 512/512 | PASS |

On a real server trace the gap is larger: gpt-oss-20b-bf16 with `/start_profile num_steps=10` records 513 device kernel events with CUDA graphs on, against 3924 with `--disable-cuda-graph` and 3933 on a working runtime — 87% of decode kernels missing from a trace that otherwise looks complete.

So this PR does three things: makes the images use the ROCm runtime they install, adds the check that tells the two states apart, and documents it.

## Modifications

### `docker/rocm.Dockerfile` — use the ROCm runtime the image installs

One step at the end of the torch work replaces `torch/lib/libamdhip64.so` and `torch/lib/libroctracer64.so` with the ROCm install's versioned copies, plus a verification step. Three details worth review:

- **Keyed on whether the wheel vendors them**, not on the ROCm flavor. Where torch already links `/opt/rocm` — the rocm720 stack on torch 2.9.1 — there is nothing to replace and the step says so and moves on, so there is no version guard to update for the next flavor. A wheel that vendors them with no ROCm copy available is a broken image, and the build fails.
- **Replaced by rename.** The interpreter doing the replacing has those libraries mapped; writing through them would corrupt it. It stages a copy and `os.replace`s.
- **Verified in a fresh interpreter**, which loads the swapped-in libraries, so a soname or ABI mismatch fails the build rather than a user's first profile.

`LD_PRELOAD` of the same two libraries is *not* an equivalent workaround: @devalshahamd found it aborts server startup on 7.2.4 inside Triton's AMD launcher during CUDA-graph capture, while this replacement leaves both the probe and a real workload with clean profiles. That fits the mechanism — a preload leaves both HIP copies mapped and only interposes symbols, so a component resolving them independently can end up on the other runtime with its own state.

### `scripts/ci/amd/check_hip_graph_profiling.py` — the check

Captures a graph, replays it under `torch.profiler`, and counts device events in the exported trace against the dispatches it asked for. Counting matters: the loss is partial (448 of 512), and a 4-node graph is traced correctly even on 7.2.0, so both a "non-empty trace" threshold and a small graph would call a broken runtime healthy. The default is 64 nodes replayed 8 times — a calibrated point, since 7.2.0 is complete at 4 and lossy from about 16 while 7.2.4 has been seen dropping at 256.

An eager control run separates "cannot trace graph replay" from "cannot trace anything", and each phase runs in its own process under a timeout because 7.2.0 can also wedge inside `hipGraphLaunch`. It reports the **paths** of the libraries torch mapped, flags any the ROCm install is not backing, and prints the commands to fix that; `--print-ld-preload` exposes the value for a single-run check.

Not registered in the AMD suites: on a rocm720 image it is expected to fail and, per #34452, can take the process down with it.

### `test/registered/unit/ci/test_hip_graph_profiling_probe.py`

The probe's value is that a red run says *which* failure happened, and a GPU job only ever exercises whichever case its image is in. 18 CPU tests drive `main()` with canned phase results: every verdict and exit code, the partial-loss shortfall, vendored-runtime detection including the half-preloaded case, the preload value naming real files rather than symlinks, and the trace parser, where counting a host-only trace as device work would turn the check into a false pass. Registered as `base-a-test-cpu`.

### `docs/docs/developer_guide/benchmark_and_profiling.mdx`

Records the symptom, how to check an image, the `rocm724` images as the answer, how to repair an older image, and `--disable-cuda-graph` where neither applies.

## Accuracy Tests

No model or kernel code changes. The Dockerfile step swaps two shared libraries for the same libraries at the version the image already installs.

## Speed Tests and Profiling

The point of the change is that `torch.profiler` reports what the GPU ran. No throughput effect is expected: HIP and roctracer are replaced with the ROCm 7.2.4 build the image ships and that the rest of the stack was validated against.

## Measured

**The fix, on the published image.** The Dockerfile step's own code, extracted from `docker/rocm.Dockerfile` at runtime, applied to `rocm/sgl-dev:v0.5.17-rocm724-mi35x-20260820` on MI355X, probing either side of it with nothing preloaded — [run 32517873558](https://github.com/sgl-project/sglang/actions/runs/32517873558):

| | mapped runtime | eager | graph replay | verdict |
| --- | --- | --- | --- | --- |
| as published | `torch/lib` copies | 512/512 | **448/512** | FAIL |
| after the step | ROCm 7.2.4 build | 512/512 | **512/512** | PASS |

`torch` still imports afterwards (`2.11.0+rocm7.2`, `hip 7.2.26015`), and the step copied 27,193,296 and 347,896 bytes — the ROCm file sizes exactly.

**Both published flavors, on the GPU each targets**, `448/512` FAIL as shipped and `512/512` PASS with the ROCm runtime in use: MI355X [32337394284](https://github.com/sgl-project/sglang/actions/runs/32337394284), MI300X [32422850894](https://github.com/sgl-project/sglang/actions/runs/32422850894). `torch.cuda.get_device_name(0)` resolves on both, and torch reports `hip 7.2.26015` — the 7.2.0 build — inside a 7.2.4 image.

**Real server trace**, gpt-oss-20b-bf16 with `/start_profile num_steps=10`, identical workload across runs: 513 device kernel events with CUDA graphs on against 3924 with `--disable-cuda-graph` and 3933 on a working runtime, i.e. 87% of decode kernels missing.

**Independently**, @devalshahamd ran the probe on ROCm 7.0.0, 7.2.0 and 7.2.4 and reported it behaves as expected on all three, and that replacing the wheel's libraries gives a real SGLang workload a clean profile.

**The Dockerfile step's logic** exercised against a simulated `torch/lib` and `/opt/rocm/lib`: both vendored, idempotent re-run, nothing vendored, vendored with no ROCm copy (fails loudly), symlinks never chosen as the source.

**CI**: gate green and `base-a-test-cpu` green with the probe's tests collected and run ([32421463756](https://github.com/sgl-project/sglang/actions/runs/32421463756) for the earlier 18; 22 now). `PR Test Extra` / `PR Test Extra (AMD)` fail on the missing `run-ci-extra` label, not on tests.

## Review findings addressed

- **`LD_PRELOAD` aborts server startup on 7.2.4** (@devalshahamd) — inside Triton's AMD launcher during CUDA-graph capture. That is why the Dockerfile replaces the files instead of documenting a preload, and why the probe marks the preload as a single-run check. #35806 proposed the Dockerfile change separately and is folded in here.
- **`run_child` dropped `--graph-nodes`** (@devalshahamd) — the parent accepted the flag and the children used their own default, so a `--graph-nodes 4` calibration run measured 64. The child command is now built from a declared option set, with a test that fails if a future option is neither forwarded nor parent-only. Default runs were unaffected, so the numbers above stand.
- **A 4-node graph passes on 7.2.0, and the loss is partial** — the probe counted `kernels > 0` on a 4-node graph and would have called every broken image healthy. It now counts every dispatch at 64 nodes.
- **The runtime report keyed on paths** — after the Dockerfile step the ROCm build sits at the wheel's path, so the probe told readers to redo a fix already applied. It now decides by file size.


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). <!-- N/A: image packaging + tooling -->
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Notes

- #35806 proposed the Dockerfile change on its own and is folded in here; it can be closed.
- #35398 (nightly verification of the published images) is closed. Once this lands, the probe can be wired into the nightly against the default configuration if that regression guard is wanted.

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32682707842](https://github.com/sgl-project/sglang/actions/runs/32682707842)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32682707619](https://github.com/sgl-project/sglang/actions/runs/32682707619)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32682707786](https://github.com/sgl-project/sglang/actions/runs/32682707786)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
