### PR TITLE
[CI] Skip fast-fail for scheduled stages

### DIFF
--- a/.github/workflows/_pr-test-stage.yml
+++ b/.github/workflows/_pr-test-stage.yml
@@ -92,7 +92,7 @@ env:
   # default times out on a cold cache.
   HF_HUB_DOWNLOAD_TIMEOUT: 300
   HF_HUB_ETAG_TIMEOUT: 300
-  SKIP_PR_TEST_HEALTH_CHECK: ${{ (fromJson(inputs.caller_inputs).skip_pr_test_health_check || fromJson(inputs.caller_inputs).test_parallel_dispatch || fromJson(inputs.caller_inputs).run_all_tests) && 'true' || 'false' }}
+  SKIP_PR_TEST_HEALTH_CHECK: ${{ (inputs.scheduled || fromJson(inputs.caller_inputs).skip_pr_test_health_check || fromJson(inputs.caller_inputs).test_parallel_dispatch || fromJson(inputs.caller_inputs).run_all_tests) && 'true' || 'false' }}
   PR_TEST_BYPASS_MAINTENANCE_ON_MAIN: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
   USE_VENV: false
 


### PR DESCRIPTION
## Summary

- Skip the cross-job PR health fast-fail when a reusable test stage is invoked with `scheduled: true`.
- Keep the existing skip behavior for explicit health-check bypasses, parallel dispatches, and run-all requests.

## Root cause

Release Branch Cut invokes the nightly workflow through `workflow_dispatch`. The reusable stage therefore cannot rely on `github.event_name == 'schedule'`. Although the nightly workflow passes `scheduled: true`, `SKIP_PR_TEST_HEALTH_CHECK` previously ignored that input, so later nightly jobs could cascade fast-fail after an earlier failure.

## Impact

Nightly and weekly stages using `inputs.scheduled` will continue running to collect all failures. Regular PR stages retain fast-fail behavior.

## Validation

- Evaluated the workflow expression for regular PR, scheduled, explicit skip, parallel dispatch, and run-all inputs.
- Ran `actionlint -ignore SC2086 .github/workflows/_pr-test-stage.yml`.
- Ran repository pre-commit checks.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32190496623](https://github.com/sgl-project/sglang/actions/runs/32190496623)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32190496419](https://github.com/sgl-project/sglang/actions/runs/32190496419)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->