### PR TITLE
[Fix] Stop unparsed Kimi K3 template syntax from leaking into responses

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -1701,15 +1701,16 @@ class ResponsesRequest(BaseModel):
         if isinstance(item.get("id"), str) and item.get("content") is not None:
             item = {k: v for k, v in item.items() if k != "id"}
 
-        content = item.get("content")
-        if not isinstance(content, list):
-            return item
-
-        item = dict(item)
-        item["content"] = [
-            ResponsesRequest._normalize_content_part_for_validation(part)
-            for part in content
-        ]
+        # tool-output items carry their parts under "output" instead of "content".
+        for key in ("content", "output"):
+            parts = item.get(key)
+            if not isinstance(parts, list):
+                continue
+            item = dict(item)
+            item[key] = [
+                ResponsesRequest._normalize_content_part_for_validation(part)
+                for part in parts
+            ]
         return item
 
     @staticmethod

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -1926,8 +1926,8 @@ class OpenAIServingChat(OpenAIServingBase):
             stripped_text = self._strip_template_artifacts(
                 text, reasoning_separated=reasoning_text is not None
             )
-            # Only the cleanup above is span deletion, so realigning text the other
-            # parsers already reshaped would drop logprobs they used to return.
+            # Only this cleanup is span deletion; text the other parsers reshaped
+            # cannot be realigned.
             if choice_logprobs is not None and stripped_text != text:
                 aligned = align_token_logprobs_to_text(
                     choice_logprobs.content, stripped_text

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -65,6 +65,7 @@ from sglang.srt.entrypoints.openai.serving_base import OpenAIServingBase
 from sglang.srt.entrypoints.openai.sse_utils import build_sse_content
 from sglang.srt.entrypoints.openai.usage_processor import UsageProcessor
 from sglang.srt.entrypoints.openai.utils import (
+    align_token_logprobs_to_text,
     cached_tokens_details_from_dict,
     process_cached_tokens_details_from_ret,
     process_hidden_states_for_response,
@@ -77,6 +78,7 @@ from sglang.srt.entrypoints.openai.utils import (
 )
 from sglang.srt.entrypoints.request_headers import apply_header_overrides
 from sglang.srt.environ import envs
+from sglang.srt.function_call.base_format_detector import BaseFormatDetector
 from sglang.srt.function_call.core_types import ToolCallItem
 from sglang.srt.function_call.function_call_parser import FunctionCallParser
 from sglang.srt.function_call.json_array_parser import JsonArrayParser
@@ -223,6 +225,14 @@ class OpenAIServingChat(OpenAIServingBase):
         self.default_chat_template_kwargs = (
             self.tokenizer_manager.server_args.default_chat_template_kwargs or {}
         )
+        # Detector used only to clean text, so it needs no tools.
+        self._artifact_detector: Optional[BaseFormatDetector] = None
+        if self.tool_call_parser in FunctionCallParser.ToolCallParserEnum:
+            self._artifact_detector = FunctionCallParser(
+                [],
+                self.tool_call_parser,
+                tokenizer=self.tokenizer_manager.tokenizer,
+            ).detector
         self._reasoning_detector = None
         if self.reasoning_parser:
             try:
@@ -1913,6 +1923,22 @@ class OpenAIServingChat(OpenAIServingBase):
             choice_meta_info = (
                 ret_item["meta_info"] if request.return_meta_info else None
             )
+            stripped_text = self._strip_template_artifacts(
+                text, reasoning_separated=reasoning_text is not None
+            )
+            # Only the cleanup above is span deletion, so realigning text the other
+            # parsers already reshaped would drop logprobs they used to return.
+            if choice_logprobs is not None and stripped_text != text:
+                aligned = align_token_logprobs_to_text(
+                    choice_logprobs.content, stripped_text
+                )
+                choice_logprobs = (
+                    None if aligned is None else ChoiceLogprobs(content=aligned)
+                )
+            text = stripped_text
+            if reasoning_text:
+                reasoning_text = self._strip_template_markers(reasoning_text)
+
             # NOTE: content should not be None but empty string to make sure retokenize consistency.
             reasoning_text, tool_calls = self._get_parsed_response_fields(
                 reasoning_text, tool_calls
@@ -2045,6 +2071,21 @@ class OpenAIServingChat(OpenAIServingBase):
             f"Process tool call idx, parser: {self.tool_call_parser}, tool_call_id: {tool_call_id}, history_cnt: {history_tool_calls_cnt}"
         )
         return tool_call_id
+
+    def _strip_template_artifacts(
+        self, text: str, reasoning_separated: bool = False
+    ) -> str:
+        """Keep chat-template syntax no parser consumed out of assistant text."""
+        if self._artifact_detector is None:
+            return text
+        return self._artifact_detector.strip_template_artifacts(
+            text, reasoning_separated=reasoning_separated
+        )
+
+    def _strip_template_markers(self, text: str) -> str:
+        if self._artifact_detector is None:
+            return text
+        return self._artifact_detector.strip_template_markers(text)
 
     def _process_tool_calls(
         self,

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -1923,14 +1923,14 @@ class OpenAIServingChat(OpenAIServingBase):
             choice_meta_info = (
                 ret_item["meta_info"] if request.return_meta_info else None
             )
-            stripped_text = self._strip_template_artifacts(
+            stripped_text, kept_spans = self._strip_template_artifacts_spans(
                 text, reasoning_separated=reasoning_text is not None
             )
             # Only this cleanup is span deletion; text the other parsers reshaped
             # cannot be realigned.
             if choice_logprobs is not None and stripped_text != text:
                 aligned = align_token_logprobs_to_text(
-                    choice_logprobs.content, stripped_text
+                    choice_logprobs.content, text, stripped_text, kept_spans
                 )
                 choice_logprobs = (
                     None if aligned is None else ChoiceLogprobs(content=aligned)
@@ -2079,6 +2079,15 @@ class OpenAIServingChat(OpenAIServingBase):
         if self._artifact_detector is None:
             return text
         return self._artifact_detector.strip_template_artifacts(
+            text, reasoning_separated=reasoning_separated
+        )
+
+    def _strip_template_artifacts_spans(
+        self, text: str, reasoning_separated: bool = False
+    ) -> tuple[str, list[tuple[int, int]]]:
+        if self._artifact_detector is None:
+            return text, [(0, len(text))] if text else []
+        return self._artifact_detector.strip_template_artifacts_spans(
             text, reasoning_separated=reasoning_separated
         )
 

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -65,7 +65,6 @@ from sglang.srt.entrypoints.openai.serving_base import OpenAIServingBase
 from sglang.srt.entrypoints.openai.sse_utils import build_sse_content
 from sglang.srt.entrypoints.openai.usage_processor import UsageProcessor
 from sglang.srt.entrypoints.openai.utils import (
-    align_token_logprobs_to_text,
     cached_tokens_details_from_dict,
     process_cached_tokens_details_from_ret,
     process_hidden_states_for_response,
@@ -1923,18 +1922,15 @@ class OpenAIServingChat(OpenAIServingBase):
             choice_meta_info = (
                 ret_item["meta_info"] if request.return_meta_info else None
             )
-            stripped_text, kept_spans = self._strip_template_artifacts_spans(
+            stripped_text = self._strip_template_artifacts(
                 text, reasoning_separated=reasoning_text is not None
             )
-            # Only this cleanup is span deletion; text the other parsers reshaped
-            # cannot be realigned.
             if choice_logprobs is not None and stripped_text != text:
-                aligned = align_token_logprobs_to_text(
-                    choice_logprobs.content, text, stripped_text, kept_spans
+                logger.debug(
+                    "Dropping chat logprobs because template artifacts were "
+                    "stripped from the response text"
                 )
-                choice_logprobs = (
-                    None if aligned is None else ChoiceLogprobs(content=aligned)
-                )
+                choice_logprobs = None
             text = stripped_text
             if reasoning_text:
                 reasoning_text = self._strip_template_markers(reasoning_text)
@@ -2079,15 +2075,6 @@ class OpenAIServingChat(OpenAIServingBase):
         if self._artifact_detector is None:
             return text
         return self._artifact_detector.strip_template_artifacts(
-            text, reasoning_separated=reasoning_separated
-        )
-
-    def _strip_template_artifacts_spans(
-        self, text: str, reasoning_separated: bool = False
-    ) -> tuple[str, list[tuple[int, int]]]:
-        if self._artifact_detector is None:
-            return text, [(0, len(text))] if text else []
-        return self._artifact_detector.strip_template_artifacts_spans(
             text, reasoning_separated=reasoning_separated
         )
 

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -935,8 +935,8 @@ class OpenAIServingResponses(OpenAIServingChat):
             cleaned = self._strip_template_artifacts(
                 content, reasoning_separated=reasoning_content is not None
             )
-            # Only the cleanup above is span deletion, so realigning text the other
-            # parsers already reshaped would drop logprobs they used to return.
+            # Only this cleanup is span deletion; text the other parsers reshaped
+            # cannot be realigned.
             if output_logprobs is not None and cleaned != content:
                 output_logprobs = align_token_logprobs_to_text(output_logprobs, cleaned)
             content = cleaned

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -68,7 +68,10 @@ from sglang.srt.entrypoints.openai.protocol import (
 )
 from sglang.srt.entrypoints.openai.serving_chat import OpenAIServingChat
 from sglang.srt.entrypoints.openai.tool_server import MCPToolServer, ToolServer
-from sglang.srt.entrypoints.openai.utils import to_openai_style_logprobs
+from sglang.srt.entrypoints.openai.utils import (
+    align_token_logprobs_to_text,
+    to_openai_style_logprobs,
+)
 from sglang.srt.function_call.function_call_parser import FunctionCallParser
 from sglang.srt.function_call.json_array_parser import JsonArrayParser
 from sglang.srt.managers.io_struct import GenerateReqInput
@@ -826,6 +829,8 @@ class OpenAIServingResponses(OpenAIServingChat):
                 ),
             )
             reasoning_content, content = reasoning_parser.parse_non_stream(final_output)
+            if reasoning_content:
+                reasoning_content = self._strip_template_markers(reasoning_content)
         else:
             reasoning_content = None
             content = final_output
@@ -927,21 +932,31 @@ class OpenAIServingResponses(OpenAIServingChat):
                 logger.error("Required tool JSON parse error: %s", e)
 
         if content:
-            output_text = ResponseOutputText(
-                text=content,
-                annotations=[],  # TODO
-                type="output_text",
-                # logprobs cover all generated tokens, not just the stripped content.
-                logprobs=output_logprobs,
+            cleaned = self._strip_template_artifacts(
+                content, reasoning_separated=reasoning_content is not None
             )
-            message = ResponseOutputMessage(
-                id=f"msg_{random_uuid()}",
-                content=[output_text],
-                role="assistant",
-                status="completed",
-                type="message",
-            )
-            output_items.append(message)
+            # Only the cleanup above is span deletion, so realigning text the other
+            # parsers already reshaped would drop logprobs they used to return.
+            if output_logprobs is not None and cleaned != content:
+                output_logprobs = align_token_logprobs_to_text(output_logprobs, cleaned)
+            content = cleaned
+            # Text that was nothing but template syntax still gets a message, so
+            # a stop-finished response never comes back without any output item.
+            if content or not tool_call_items:
+                output_text = ResponseOutputText(
+                    text=content,
+                    annotations=[],  # TODO
+                    type="output_text",
+                    logprobs=output_logprobs,
+                )
+                message = ResponseOutputMessage(
+                    id=f"msg_{random_uuid()}",
+                    content=[output_text],
+                    role="assistant",
+                    status="completed",
+                    type="message",
+                )
+                output_items.append(message)
         output_items.extend(tool_call_items)
         return output_items
 

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -932,13 +932,15 @@ class OpenAIServingResponses(OpenAIServingChat):
                 logger.error("Required tool JSON parse error: %s", e)
 
         if content:
-            cleaned = self._strip_template_artifacts(
+            cleaned, kept_spans = self._strip_template_artifacts_spans(
                 content, reasoning_separated=reasoning_content is not None
             )
             # Only this cleanup is span deletion; text the other parsers reshaped
             # cannot be realigned.
             if output_logprobs is not None and cleaned != content:
-                output_logprobs = align_token_logprobs_to_text(output_logprobs, cleaned)
+                output_logprobs = align_token_logprobs_to_text(
+                    output_logprobs, content, cleaned, kept_spans
+                )
             content = cleaned
             # Text that was nothing but template syntax still gets a message, so
             # a stop-finished response never comes back without any output item.

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -68,10 +68,7 @@ from sglang.srt.entrypoints.openai.protocol import (
 )
 from sglang.srt.entrypoints.openai.serving_chat import OpenAIServingChat
 from sglang.srt.entrypoints.openai.tool_server import MCPToolServer, ToolServer
-from sglang.srt.entrypoints.openai.utils import (
-    align_token_logprobs_to_text,
-    to_openai_style_logprobs,
-)
+from sglang.srt.entrypoints.openai.utils import to_openai_style_logprobs
 from sglang.srt.function_call.function_call_parser import FunctionCallParser
 from sglang.srt.function_call.json_array_parser import JsonArrayParser
 from sglang.srt.managers.io_struct import GenerateReqInput
@@ -932,15 +929,15 @@ class OpenAIServingResponses(OpenAIServingChat):
                 logger.error("Required tool JSON parse error: %s", e)
 
         if content:
-            cleaned, kept_spans = self._strip_template_artifacts_spans(
+            cleaned = self._strip_template_artifacts(
                 content, reasoning_separated=reasoning_content is not None
             )
-            # Only this cleanup is span deletion; text the other parsers reshaped
-            # cannot be realigned.
             if output_logprobs is not None and cleaned != content:
-                output_logprobs = align_token_logprobs_to_text(
-                    output_logprobs, content, cleaned, kept_spans
+                logger.debug(
+                    "Dropping response logprobs because template artifacts were "
+                    "stripped from the response text"
                 )
+                output_logprobs = None
             content = cleaned
             # Text that was nothing but template syntax still gets a message, so
             # a stop-finished response never comes back without any output item.

--- a/python/sglang/srt/entrypoints/openai/utils.py
+++ b/python/sglang/srt/entrypoints/openai/utils.py
@@ -72,22 +72,50 @@ _TokenLogprobT = TypeVar("_TokenLogprobT", bound=_TokenLogprob)
 
 
 def align_token_logprobs_to_text(
-    entries: Sequence[_TokenLogprobT], text: str
+    entries: Sequence[_TokenLogprobT],
+    strip_input: str,
+    cleaned: str,
+    kept_spans: Sequence[tuple[int, int]],
 ) -> Optional[List[_TokenLogprobT]]:
-    """Keep the logprob entries whose token survives text sanitization.
+    """Keep entries whose positional spans survive text sanitization.
 
-    Sanitization only deletes spans, so ``text`` is a subsequence of the
-    concatenated generated tokens: walk both in order and drop the entries whose
-    token was removed. Returns ``None`` when the two cannot be reconciled, since
-    a partially aligned array misleads more than a missing one.
+    The generated tokens must either equal ``strip_input`` or end with it;
+    the latter accounts for reasoning tokens emitted before content. Entries
+    are retained only when their full positional span lies inside one kept
+    span. Return ``None`` when exact alignment is impossible, since a partial
+    array is more misleading than omitting logprobs entirely.
     """
+    full_parts = []
+    for entry in entries:
+        if entry.token is None:
+            return None
+        full_parts.append(entry.token)
+    full = "".join(full_parts)
+    if full == strip_input:
+        offset = 0
+    elif strip_input and full.endswith(strip_input):
+        offset = len(full) - len(strip_input)
+    else:
+        return None
+
     aligned: List[_TokenLogprobT] = []
     cursor = 0
     for entry in entries:
-        if entry.token and text.startswith(entry.token, cursor):
+        token = entry.token
+        end = cursor + len(token)
+        shifted_start = cursor - offset
+        shifted_end = end - offset
+        if (
+            token
+            and end > offset
+            and any(
+                span_start <= shifted_start and shifted_end <= span_end
+                for span_start, span_end in kept_spans
+            )
+        ):
             aligned.append(entry)
-            cursor += len(entry.token)
-    return aligned if cursor == len(text) else None
+        cursor = end
+    return aligned if "".join(entry.token for entry in aligned) == cleaned else None
 
 
 def process_hidden_states_from_ret(

--- a/python/sglang/srt/entrypoints/openai/utils.py
+++ b/python/sglang/srt/entrypoints/openai/utils.py
@@ -88,6 +88,10 @@ def align_token_logprobs_to_text(
     full_parts = []
     for entry in entries:
         if entry.token is None:
+            logger.debug(
+                "Dropping logprobs because sanitized text could not be realigned: "
+                "token stream contains a None token"
+            )
             return None
         full_parts.append(entry.token)
     full = "".join(full_parts)
@@ -96,6 +100,10 @@ def align_token_logprobs_to_text(
     elif strip_input and full.endswith(strip_input):
         offset = len(full) - len(strip_input)
     else:
+        logger.debug(
+            "Dropping logprobs because sanitized text could not be realigned: "
+            "token stream failed the positional anchor check"
+        )
         return None
 
     aligned: List[_TokenLogprobT] = []
@@ -115,7 +123,13 @@ def align_token_logprobs_to_text(
         ):
             aligned.append(entry)
         cursor = end
-    return aligned if "".join(entry.token for entry in aligned) == cleaned else None
+    if "".join(entry.token for entry in aligned) != cleaned:
+        logger.debug(
+            "Dropping logprobs because sanitized text could not be realigned: "
+            "retained tokens failed the reconstruction check"
+        )
+        return None
+    return aligned
 
 
 def process_hidden_states_from_ret(

--- a/python/sglang/srt/entrypoints/openai/utils.py
+++ b/python/sglang/srt/entrypoints/openai/utils.py
@@ -1,5 +1,15 @@
 import logging
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import (
+    Any,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Protocol,
+    Sequence,
+    TypeVar,
+    Union,
+)
 
 import torch
 
@@ -50,6 +60,34 @@ def to_openai_style_logprobs(
         append_top_logprobs(output_top_logprobs)
 
     return ret_logprobs
+
+
+class _TokenLogprob(Protocol):
+    """Shared shape of the per-token logprob entries of both APIs."""
+
+    token: str
+
+
+_TokenLogprobT = TypeVar("_TokenLogprobT", bound=_TokenLogprob)
+
+
+def align_token_logprobs_to_text(
+    entries: Sequence[_TokenLogprobT], text: str
+) -> Optional[List[_TokenLogprobT]]:
+    """Keep the logprob entries whose token survives text sanitization.
+
+    Sanitization only deletes spans, so ``text`` is a subsequence of the
+    concatenated generated tokens: walk both in order and drop the entries whose
+    token was removed. Returns ``None`` when the two cannot be reconciled, since
+    a partially aligned array misleads more than a missing one.
+    """
+    aligned: List[_TokenLogprobT] = []
+    cursor = 0
+    for entry in entries:
+        if entry.token and text.startswith(entry.token, cursor):
+            aligned.append(entry)
+            cursor += len(entry.token)
+    return aligned if cursor == len(text) else None
 
 
 def process_hidden_states_from_ret(

--- a/python/sglang/srt/entrypoints/openai/utils.py
+++ b/python/sglang/srt/entrypoints/openai/utils.py
@@ -5,9 +5,6 @@ from typing import (
     List,
     Literal,
     Optional,
-    Protocol,
-    Sequence,
-    TypeVar,
     Union,
 )
 
@@ -60,76 +57,6 @@ def to_openai_style_logprobs(
         append_top_logprobs(output_top_logprobs)
 
     return ret_logprobs
-
-
-class _TokenLogprob(Protocol):
-    """Shared shape of the per-token logprob entries of both APIs."""
-
-    token: str
-
-
-_TokenLogprobT = TypeVar("_TokenLogprobT", bound=_TokenLogprob)
-
-
-def align_token_logprobs_to_text(
-    entries: Sequence[_TokenLogprobT],
-    strip_input: str,
-    cleaned: str,
-    kept_spans: Sequence[tuple[int, int]],
-) -> Optional[List[_TokenLogprobT]]:
-    """Keep entries whose positional spans survive text sanitization.
-
-    The generated tokens must either equal ``strip_input`` or end with it;
-    the latter accounts for reasoning tokens emitted before content. Entries
-    are retained only when their full positional span lies inside one kept
-    span. Return ``None`` when exact alignment is impossible, since a partial
-    array is more misleading than omitting logprobs entirely.
-    """
-    full_parts = []
-    for entry in entries:
-        if entry.token is None:
-            logger.debug(
-                "Dropping logprobs because sanitized text could not be realigned: "
-                "token stream contains a None token"
-            )
-            return None
-        full_parts.append(entry.token)
-    full = "".join(full_parts)
-    if full == strip_input:
-        offset = 0
-    elif strip_input and full.endswith(strip_input):
-        offset = len(full) - len(strip_input)
-    else:
-        logger.debug(
-            "Dropping logprobs because sanitized text could not be realigned: "
-            "token stream failed the positional anchor check"
-        )
-        return None
-
-    aligned: List[_TokenLogprobT] = []
-    cursor = 0
-    for entry in entries:
-        token = entry.token
-        end = cursor + len(token)
-        shifted_start = cursor - offset
-        shifted_end = end - offset
-        if (
-            token
-            and end > offset
-            and any(
-                span_start <= shifted_start and shifted_end <= span_end
-                for span_start, span_end in kept_spans
-            )
-        ):
-            aligned.append(entry)
-        cursor = end
-    if "".join(entry.token for entry in aligned) != cleaned:
-        logger.debug(
-            "Dropping logprobs because sanitized text could not be realigned: "
-            "retained tokens failed the reconstruction check"
-        )
-        return None
-    return aligned
 
 
 def process_hidden_states_from_ret(

--- a/python/sglang/srt/entrypoints/openai/utils.py
+++ b/python/sglang/srt/entrypoints/openai/utils.py
@@ -1,12 +1,5 @@
 import logging
-from typing import (
-    Any,
-    Dict,
-    List,
-    Literal,
-    Optional,
-    Union,
-)
+from typing import Any, Dict, List, Literal, Optional, Union
 
 import torch
 

--- a/python/sglang/srt/function_call/base_format_detector.py
+++ b/python/sglang/srt/function_call/base_format_detector.py
@@ -370,6 +370,12 @@ class BaseFormatDetector(ABC):
         """
         return text
 
+    def strip_template_artifacts_spans(
+        self, text: str, reasoning_separated: bool = False
+    ) -> tuple[str, list[tuple[int, int]]]:
+        """Return cleaned text and the original-coordinate spans it kept."""
+        return text, [(0, len(text))] if text else []
+
     def strip_template_markers(self, text: str) -> str:
         """Remove stray template markers, keeping the text they surrounded.
 

--- a/python/sglang/srt/function_call/base_format_detector.py
+++ b/python/sglang/srt/function_call/base_format_detector.py
@@ -358,6 +358,26 @@ class BaseFormatDetector(ABC):
         """
         return StreamingParseResult()
 
+    def strip_template_artifacts(
+        self, text: str, reasoning_separated: bool = False
+    ) -> str:
+        """Remove chat-template syntax that tool-call parsing did not consume.
+
+        ``reasoning_separated`` says a reasoning parser already pulled the
+        thinking trace into its own field, so it may be dropped here instead of
+        merely unwrapped. Formats whose tool channel is literal text override
+        this; the default leaves ``text`` untouched.
+        """
+        return text
+
+    def strip_template_markers(self, text: str) -> str:
+        """Remove stray template markers, keeping the text they surrounded.
+
+        Used for text that is already routed to its own field, such as
+        reasoning, where the content must survive but the syntax must not.
+        """
+        return text
+
     def supports_structural_tag(self) -> bool:
         """Return True if this detector supports structural tag format."""
         return True

--- a/python/sglang/srt/function_call/base_format_detector.py
+++ b/python/sglang/srt/function_call/base_format_detector.py
@@ -361,21 +361,11 @@ class BaseFormatDetector(ABC):
     def strip_template_artifacts(
         self, text: str, reasoning_separated: bool = False
     ) -> str:
-        """Remove chat-template syntax that tool-call parsing did not consume.
-
-        ``reasoning_separated`` says a reasoning parser already pulled the
-        thinking trace into its own field, so it may be dropped here instead of
-        merely unwrapped. Formats whose tool channel is literal text override
-        this; the default leaves ``text`` untouched.
-        """
+        """Remove chat-template syntax that tool-call parsing did not consume."""
         return text
 
     def strip_template_markers(self, text: str) -> str:
-        """Remove stray template markers, keeping the text they surrounded.
-
-        Used for text that is already routed to its own field, such as
-        reasoning, where the content must survive but the syntax must not.
-        """
+        """Remove stray template markers, keeping the text they surrounded."""
         return text
 
     def supports_structural_tag(self) -> bool:

--- a/python/sglang/srt/function_call/base_format_detector.py
+++ b/python/sglang/srt/function_call/base_format_detector.py
@@ -370,12 +370,6 @@ class BaseFormatDetector(ABC):
         """
         return text
 
-    def strip_template_artifacts_spans(
-        self, text: str, reasoning_separated: bool = False
-    ) -> tuple[str, list[tuple[int, int]]]:
-        """Return cleaned text and the original-coordinate spans it kept."""
-        return text, [(0, len(text))] if text else []
-
     def strip_template_markers(self, text: str) -> str:
         """Remove stray template markers, keeping the text they surrounded.
 

--- a/python/sglang/srt/function_call/function_call_parser.py
+++ b/python/sglang/srt/function_call/function_call_parser.py
@@ -142,14 +142,15 @@ class FunctionCallParser:
             - A list of tool calls parsed from the text
         """
         if not self.tools:
-            return full_text, []
+            return self.detector.strip_template_artifacts(full_text), []
         has_tool_call = self.detector.has_tool_call(full_text)
         parsed_result = self.detector.detect_and_parse(full_text, self.tools)
         tool_call_list = parsed_result.calls
         if tool_call_list or has_tool_call:
             return parsed_result.normal_text, tool_call_list
         else:
-            return full_text, []
+            # Detection missed, so nothing consumed the format's markers.
+            return self.detector.strip_template_artifacts(full_text), []
 
     def parse_stream_chunk(self, chunk_text: str) -> Tuple[str, list[ToolCallItem]]:
         """

--- a/python/sglang/srt/function_call/kimik3_detector.py
+++ b/python/sglang/srt/function_call/kimik3_detector.py
@@ -22,9 +22,11 @@ from sglang.srt.function_call.kimik3_format import (
     THINK_OPEN,
     TOOLS_CLOSE,
     TOOLS_OPEN,
+    _SpanTracker,
     partial_suffix_len,
     strip_partial_marker_suffix,
     strip_response_wrappers,
+    strip_response_wrappers_in_place,
 )
 from sglang.srt.function_call.kimik3_structural_tag import (
     get_kimik3_auto_tool_call_structural_tag,
@@ -72,17 +74,34 @@ def _parse_attrs(attrs: str) -> dict:
 
 
 def _strip_template_markers(text: str) -> str:
+    return _strip_template_markers_spans(text)[0]
+
+
+def _strip_template_markers_spans(text: str) -> tuple[str, list[tuple[int, int]]]:
+    tracker = _SpanTracker(text)
+    _strip_template_markers_in_place(tracker)
+    return tracker.result(collapse_blank=True)
+
+
+def _strip_template_markers_in_place(tracker: _SpanTracker) -> None:
+    text = tracker.text
     # Cut markers first: their surviving half looks like plain text to the
     # regexes below. Two characters minimum keeps a reply ending in ``<``.
     holdback = partial_suffix_len(text, ALL_MARKERS, min_len=2)
     if holdback:
-        text = text[:-holdback]
-    text = _CHANNEL_MARKER_RE.sub("", text)
-    text = _SPECIAL_TOKEN_RE.sub("", text)
-    return "" if not text.strip() else text
+        tracker.delete_suffix(len(text) - holdback)
+    tracker.delete_regex_matches(_CHANNEL_MARKER_RE)
+    tracker.delete_regex_matches(_SPECIAL_TOKEN_RE)
 
 
 def _strip_template_artifacts(text: str, reasoning_separated: bool = False) -> str:
+    return _strip_template_artifacts_spans(text, reasoning_separated)[0]
+
+
+def _strip_template_artifacts_spans(
+    text: str, reasoning_separated: bool = False
+) -> tuple[str, list[tuple[int, int]]]:
+    tracker = _SpanTracker(text)
     # An unparsed tool channel: everything from it on is call syntax, not a reply.
     call_match = _CALL_OPEN_RE.search(text)
     tool_starts = [
@@ -94,17 +113,18 @@ def _strip_template_artifacts(text: str, reasoning_separated: bool = False) -> s
         if i != -1
     ]
     if tool_starts:
-        text = text[: min(tool_starts)]
+        tracker.truncate_at(min(tool_starts))
     if reasoning_separated:
-        text = _THINK_CHANNEL_RE.sub("", text)
+        tracker.delete_regex_matches(_THINK_CHANNEL_RE)
         # A close without its prefilled open leaves the whole trace ahead of it.
-        close_idx = text.find(THINK_CLOSE)
+        close_idx = tracker.text.find(THINK_CLOSE)
         if close_idx != -1:
-            text = text[close_idx + len(THINK_CLOSE) :]
+            tracker.delete_prefix(close_idx + len(THINK_CLOSE))
         # Only safe once the trace is gone: otherwise this drops it along with
         # the wrappers, even though the caller wanted it inline.
-        text = strip_response_wrappers(text)
-    return _strip_template_markers(text)
+        strip_response_wrappers_in_place(tracker)
+    _strip_template_markers_in_place(tracker)
+    return tracker.result(collapse_blank=True)
 
 
 class KimiK3Detector(BaseFormatDetector):
@@ -141,6 +161,13 @@ class KimiK3Detector(BaseFormatDetector):
     ) -> str:
         """Drop channel syntax the tool-call parser left in client-bound text."""
         return _strip_template_artifacts(text, reasoning_separated=reasoning_separated)
+
+    def strip_template_artifacts_spans(
+        self, text: str, reasoning_separated: bool = False
+    ) -> tuple[str, list[tuple[int, int]]]:
+        return _strip_template_artifacts_spans(
+            text, reasoning_separated=reasoning_separated
+        )
 
     def strip_template_markers(self, text: str) -> str:
         return _strip_template_markers(text)

--- a/python/sglang/srt/function_call/kimik3_detector.py
+++ b/python/sglang/srt/function_call/kimik3_detector.py
@@ -72,8 +72,8 @@ def _parse_attrs(attrs: str) -> dict:
 
 
 def _strip_template_markers(text: str) -> str:
-    # Before whole markers, or the surviving half of a cut one stays glued to the
-    # text as ``tool``. Two characters minimum keeps a reply ending in ``<``.
+    # Cut markers first: their surviving half looks like plain text to the
+    # regexes below. Two characters minimum keeps a reply ending in ``<``.
     holdback = partial_suffix_len(text, ALL_MARKERS, min_len=2)
     if holdback:
         text = text[:-holdback]
@@ -101,7 +101,8 @@ def _strip_template_artifacts(text: str, reasoning_separated: bool = False) -> s
         close_idx = text.find(THINK_CLOSE)
         if close_idx != -1:
             text = text[close_idx + len(THINK_CLOSE) :]
-        # Unwrapping would also cut the trace the caller asked to keep inline.
+        # Only safe once the trace is gone: otherwise this drops it along with
+        # the wrappers, even though the caller wanted it inline.
         text = strip_response_wrappers(text)
     return _strip_template_markers(text)
 

--- a/python/sglang/srt/function_call/kimik3_detector.py
+++ b/python/sglang/srt/function_call/kimik3_detector.py
@@ -13,9 +13,13 @@ from sglang.srt.function_call.core_types import (
     _GetInfoFunc,
 )
 from sglang.srt.function_call.kimik3_format import (
+    ALL_MARKERS,
+    CALL_OPEN,
     MESSAGE_CLOSE,
     RESPONSE_CLOSE,
     RESPONSE_OPEN,
+    THINK_CLOSE,
+    THINK_OPEN,
     TOOLS_CLOSE,
     TOOLS_OPEN,
     partial_suffix_len,
@@ -40,6 +44,23 @@ _ARG_RE = re.compile(
     re.DOTALL,
 )
 _ATTR_RE = re.compile(r'(?P<k>\w+)="(?P<v>[^"]*)"')
+_CHANNEL_MARKER_RE = re.compile(
+    r"<\|(?:open|close)\|>(?:think|response|tools|message|call|argument)"
+    # A cut attribute list has no closing quote, so allow the last pair to run
+    # to the end of the text rather than leaving ``tool="rea`` behind.
+    r'(?:\s+\w+="[^"]*")*(?:\s+\w+(?:="[^"]*)?$|<\|sep\|>)?'
+)
+_SPECIAL_TOKEN_RE = re.compile(r"<\|(?:open|close|sep)\|>")
+# A think channel with its content, closed or cut off: reasoning is delivered in
+# its own field, never folded into the reply. The open marker is prefilled by the
+# template, so generation usually starts inside the channel and only closes it.
+_THINK_CHANNEL_RE = re.compile(
+    re.escape(THINK_OPEN) + r".*?(?:" + re.escape(THINK_CLOSE) + r"|$)",
+    re.DOTALL,
+)
+# ``CALL_OPEN`` carries attributes instead of an immediate separator, so require
+# one to avoid truncating a reply that merely quotes the token.
+_CALL_OPEN_RE = re.compile(re.escape(CALL_OPEN) + r"(?=\s|<\|sep\|>)")
 
 
 def _unescape_attr(value: str) -> str:
@@ -48,6 +69,41 @@ def _unescape_attr(value: str) -> str:
 
 def _parse_attrs(attrs: str) -> dict:
     return {m["k"]: _unescape_attr(m["v"]) for m in _ATTR_RE.finditer(attrs)}
+
+
+def _strip_template_markers(text: str) -> str:
+    # Before whole markers, or the surviving half of a cut one stays glued to the
+    # text as ``tool``. Two characters minimum keeps a reply ending in ``<``.
+    holdback = partial_suffix_len(text, ALL_MARKERS, min_len=2)
+    if holdback:
+        text = text[:-holdback]
+    text = _CHANNEL_MARKER_RE.sub("", text)
+    text = _SPECIAL_TOKEN_RE.sub("", text)
+    return "" if not text.strip() else text
+
+
+def _strip_template_artifacts(text: str, reasoning_separated: bool = False) -> str:
+    # An unparsed tool channel: everything from it on is call syntax, not a reply.
+    call_match = _CALL_OPEN_RE.search(text)
+    tool_starts = [
+        i
+        for i in (
+            text.find(TOOLS_OPEN),
+            -1 if call_match is None else call_match.start(),
+        )
+        if i != -1
+    ]
+    if tool_starts:
+        text = text[: min(tool_starts)]
+    if reasoning_separated:
+        text = _THINK_CHANNEL_RE.sub("", text)
+        # A close without its prefilled open leaves the whole trace ahead of it.
+        close_idx = text.find(THINK_CLOSE)
+        if close_idx != -1:
+            text = text[close_idx + len(THINK_CLOSE) :]
+        # Unwrapping would also cut the trace the caller asked to keep inline.
+        text = strip_response_wrappers(text)
+    return _strip_template_markers(text)
 
 
 class KimiK3Detector(BaseFormatDetector):
@@ -78,6 +134,15 @@ class KimiK3Detector(BaseFormatDetector):
 
     def has_tool_call(self, text: str) -> bool:
         return self.bot_token in text
+
+    def strip_template_artifacts(
+        self, text: str, reasoning_separated: bool = False
+    ) -> str:
+        """Drop channel syntax the tool-call parser left in client-bound text."""
+        return _strip_template_artifacts(text, reasoning_separated=reasoning_separated)
+
+    def strip_template_markers(self, text: str) -> str:
+        return _strip_template_markers(text)
 
     def supports_structural_tag(self) -> bool:
         return True

--- a/python/sglang/srt/function_call/kimik3_detector.py
+++ b/python/sglang/srt/function_call/kimik3_detector.py
@@ -22,11 +22,10 @@ from sglang.srt.function_call.kimik3_format import (
     THINK_OPEN,
     TOOLS_CLOSE,
     TOOLS_OPEN,
-    _SpanTracker,
+    _strip_response_wrappers,
     partial_suffix_len,
     strip_partial_marker_suffix,
     strip_response_wrappers,
-    strip_response_wrappers_in_place,
 )
 from sglang.srt.function_call.kimik3_structural_tag import (
     get_kimik3_auto_tool_call_structural_tag,
@@ -74,34 +73,27 @@ def _parse_attrs(attrs: str) -> dict:
 
 
 def _strip_template_markers(text: str) -> str:
-    return _strip_template_markers_spans(text)[0]
+    return _strip_template_markers_with_deletion(text)
 
 
-def _strip_template_markers_spans(text: str) -> tuple[str, list[tuple[int, int]]]:
-    tracker = _SpanTracker(text)
-    _strip_template_markers_in_place(tracker)
-    return tracker.result(collapse_blank=True)
-
-
-def _strip_template_markers_in_place(tracker: _SpanTracker) -> None:
-    text = tracker.text
+def _strip_template_markers_with_deletion(text: str, deleted: bool = False) -> str:
     # Cut markers first: their surviving half looks like plain text to the
     # regexes below. Two characters minimum keeps a reply ending in ``<``.
     holdback = partial_suffix_len(text, ALL_MARKERS, min_len=2)
     if holdback:
-        tracker.delete_suffix(len(text) - holdback)
-    tracker.delete_regex_matches(_CHANNEL_MARKER_RE)
-    tracker.delete_regex_matches(_SPECIAL_TOKEN_RE)
+        text = text[:-holdback]
+        deleted = True
+    if _CHANNEL_MARKER_RE.search(text):
+        text = _CHANNEL_MARKER_RE.sub("", text)
+        deleted = True
+    if _SPECIAL_TOKEN_RE.search(text):
+        text = _SPECIAL_TOKEN_RE.sub("", text)
+        deleted = True
+    return "" if deleted and not text.strip() else text
 
 
 def _strip_template_artifacts(text: str, reasoning_separated: bool = False) -> str:
-    return _strip_template_artifacts_spans(text, reasoning_separated)[0]
-
-
-def _strip_template_artifacts_spans(
-    text: str, reasoning_separated: bool = False
-) -> tuple[str, list[tuple[int, int]]]:
-    tracker = _SpanTracker(text)
+    deleted = False
     # An unparsed tool channel: everything from it on is call syntax, not a reply.
     call_match = _CALL_OPEN_RE.search(text)
     tool_starts = [
@@ -113,18 +105,22 @@ def _strip_template_artifacts_spans(
         if i != -1
     ]
     if tool_starts:
-        tracker.truncate_at(min(tool_starts))
+        text = text[: min(tool_starts)]
+        deleted = True
     if reasoning_separated:
-        tracker.delete_regex_matches(_THINK_CHANNEL_RE)
+        if _THINK_CHANNEL_RE.search(text):
+            text = _THINK_CHANNEL_RE.sub("", text)
+            deleted = True
         # A close without its prefilled open leaves the whole trace ahead of it.
-        close_idx = tracker.text.find(THINK_CLOSE)
+        close_idx = text.find(THINK_CLOSE)
         if close_idx != -1:
-            tracker.delete_prefix(close_idx + len(THINK_CLOSE))
+            text = text[close_idx + len(THINK_CLOSE) :]
+            deleted = True
         # Only safe once the trace is gone: otherwise this drops it along with
         # the wrappers, even though the caller wanted it inline.
-        strip_response_wrappers_in_place(tracker)
-    _strip_template_markers_in_place(tracker)
-    return tracker.result(collapse_blank=True)
+        text, wrappers_deleted = _strip_response_wrappers(text)
+        deleted = deleted or wrappers_deleted
+    return _strip_template_markers_with_deletion(text, deleted)
 
 
 class KimiK3Detector(BaseFormatDetector):
@@ -161,13 +157,6 @@ class KimiK3Detector(BaseFormatDetector):
     ) -> str:
         """Drop channel syntax the tool-call parser left in client-bound text."""
         return _strip_template_artifacts(text, reasoning_separated=reasoning_separated)
-
-    def strip_template_artifacts_spans(
-        self, text: str, reasoning_separated: bool = False
-    ) -> tuple[str, list[tuple[int, int]]]:
-        return _strip_template_artifacts_spans(
-            text, reasoning_separated=reasoning_separated
-        )
 
     def strip_template_markers(self, text: str) -> str:
         return _strip_template_markers(text)

--- a/python/sglang/srt/function_call/kimik3_format.py
+++ b/python/sglang/srt/function_call/kimik3_format.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Sequence
 
 THINK_OPEN = "<|open|>think<|sep|>"
 THINK_CLOSE = "<|close|>think<|sep|>"
@@ -9,6 +9,7 @@ TOOLS_CLOSE = "<|close|>tools<|sep|>"
 MESSAGE_CLOSE = "<|close|>message<|sep|>"
 CALL_OPEN = "<|open|>call"
 CALL_CLOSE = "<|close|>call<|sep|>"
+ARGUMENT_OPEN = "<|open|>argument"
 ARGUMENT_CLOSE = "<|close|>argument<|sep|>"
 
 # max_tokens can stop after an XTML control token or channel name, before <|sep|>.
@@ -24,14 +25,29 @@ _PARTIAL_MARKER_SUFFIXES = (
 )
 
 
-def partial_suffix_len(text: str, markers: List[str]) -> int:
-    best = 0
+ALL_MARKERS = (
+    THINK_OPEN,
+    THINK_CLOSE,
+    RESPONSE_OPEN,
+    RESPONSE_CLOSE,
+    TOOLS_OPEN,
+    TOOLS_CLOSE,
+    MESSAGE_CLOSE,
+    CALL_OPEN,
+    CALL_CLOSE,
+    ARGUMENT_OPEN,
+    ARGUMENT_CLOSE,
+)
+
+
+def partial_suffix_len(text: str, markers: Sequence[str], min_len: int = 1) -> int:
+    best = min_len - 1
     for marker in markers:
         for length in range(min(len(marker) - 1, len(text)), best, -1):
             if text.endswith(marker[:length]):
                 best = length
                 break
-    return best
+    return best if best >= min_len else 0
 
 
 def strip_partial_marker_suffix(text: str) -> str:

--- a/python/sglang/srt/function_call/kimik3_format.py
+++ b/python/sglang/srt/function_call/kimik3_format.py
@@ -61,12 +61,15 @@ def strip_partial_marker_suffix(text: str) -> str:
 class _SpanTracker:
     def __init__(self, text: str):
         self._chars = list(zip(text, range(len(text))))
+        self._deleted = False
 
     @property
     def text(self) -> str:
         return "".join(char for char, _ in self._chars)
 
     def delete(self, current_start: int, current_end: int) -> None:
+        if current_start < current_end and self._chars[current_start:current_end]:
+            self._deleted = True
         del self._chars[current_start:current_end]
 
     def truncate_at(self, current_end: int) -> None:
@@ -84,7 +87,7 @@ class _SpanTracker:
 
     def result(self, collapse_blank: bool = False) -> tuple[str, list[tuple[int, int]]]:
         text = self.text
-        if collapse_blank and not text.strip():
+        if collapse_blank and self._deleted and not text.strip():
             return "", []
         spans = []
         for _, original_index in self._chars:

--- a/python/sglang/srt/function_call/kimik3_format.py
+++ b/python/sglang/srt/function_call/kimik3_format.py
@@ -1,3 +1,4 @@
+import re
 from typing import Sequence
 
 THINK_OPEN = "<|open|>think<|sep|>"
@@ -57,15 +58,60 @@ def strip_partial_marker_suffix(text: str) -> str:
     return text
 
 
-def strip_response_wrappers(text: str) -> str:
+class _SpanTracker:
+    def __init__(self, text: str):
+        self._chars = list(zip(text, range(len(text))))
+
+    @property
+    def text(self) -> str:
+        return "".join(char for char, _ in self._chars)
+
+    def delete(self, current_start: int, current_end: int) -> None:
+        del self._chars[current_start:current_end]
+
+    def truncate_at(self, current_end: int) -> None:
+        self.delete(current_end, len(self._chars))
+
+    def delete_prefix(self, current_end: int) -> None:
+        self.delete(0, current_end)
+
+    def delete_suffix(self, current_start: int) -> None:
+        self.delete(current_start, len(self._chars))
+
+    def delete_regex_matches(self, pattern: re.Pattern[str]) -> None:
+        for match in reversed(list(pattern.finditer(self.text))):
+            self.delete(match.start(), match.end())
+
+    def result(self, collapse_blank: bool = False) -> tuple[str, list[tuple[int, int]]]:
+        text = self.text
+        if collapse_blank and not text.strip():
+            return "", []
+        spans = []
+        for _, original_index in self._chars:
+            if spans and spans[-1][1] == original_index:
+                spans[-1] = (spans[-1][0], original_index + 1)
+            else:
+                spans.append((original_index, original_index + 1))
+        return text, spans
+
+
+def strip_response_wrappers_in_place(tracker: _SpanTracker) -> None:
+    text = tracker.text
     open_idx = text.find(RESPONSE_OPEN)
     if open_idx != -1:
         close_idx = text.find(RESPONSE_CLOSE, open_idx + len(RESPONSE_OPEN))
+        tracker.delete_prefix(open_idx + len(RESPONSE_OPEN))
         if close_idx != -1:
-            text = text[open_idx + len(RESPONSE_OPEN) : close_idx]
-        else:
-            text = text[open_idx + len(RESPONSE_OPEN) :]
+            tracker.delete_suffix(close_idx - open_idx - len(RESPONSE_OPEN))
     else:
-        text = text.replace(RESPONSE_CLOSE, "")
-    text = text.replace(MESSAGE_CLOSE, "")
-    return strip_partial_marker_suffix(text)
+        tracker.delete_regex_matches(re.compile(re.escape(RESPONSE_CLOSE)))
+    tracker.delete_regex_matches(re.compile(re.escape(MESSAGE_CLOSE)))
+    stripped = strip_partial_marker_suffix(tracker.text)
+    if stripped != tracker.text:
+        tracker.delete_suffix(len(stripped))
+
+
+def strip_response_wrappers(text: str) -> str:
+    tracker = _SpanTracker(text)
+    strip_response_wrappers_in_place(tracker)
+    return tracker.text

--- a/python/sglang/srt/function_call/kimik3_format.py
+++ b/python/sglang/srt/function_call/kimik3_format.py
@@ -1,4 +1,3 @@
-import re
 from typing import Sequence
 
 THINK_OPEN = "<|open|>think<|sep|>"
@@ -58,63 +57,28 @@ def strip_partial_marker_suffix(text: str) -> str:
     return text
 
 
-class _SpanTracker:
-    def __init__(self, text: str):
-        self._chars = list(zip(text, range(len(text))))
-        self._deleted = False
-
-    @property
-    def text(self) -> str:
-        return "".join(char for char, _ in self._chars)
-
-    def delete(self, current_start: int, current_end: int) -> None:
-        if current_start < current_end and self._chars[current_start:current_end]:
-            self._deleted = True
-        del self._chars[current_start:current_end]
-
-    def truncate_at(self, current_end: int) -> None:
-        self.delete(current_end, len(self._chars))
-
-    def delete_prefix(self, current_end: int) -> None:
-        self.delete(0, current_end)
-
-    def delete_suffix(self, current_start: int) -> None:
-        self.delete(current_start, len(self._chars))
-
-    def delete_regex_matches(self, pattern: re.Pattern[str]) -> None:
-        for match in reversed(list(pattern.finditer(self.text))):
-            self.delete(match.start(), match.end())
-
-    def result(self, collapse_blank: bool = False) -> tuple[str, list[tuple[int, int]]]:
-        text = self.text
-        if collapse_blank and self._deleted and not text.strip():
-            return "", []
-        spans = []
-        for _, original_index in self._chars:
-            if spans and spans[-1][1] == original_index:
-                spans[-1] = (spans[-1][0], original_index + 1)
-            else:
-                spans.append((original_index, original_index + 1))
-        return text, spans
-
-
-def strip_response_wrappers_in_place(tracker: _SpanTracker) -> None:
-    text = tracker.text
+def _strip_response_wrappers(text: str) -> tuple[str, bool]:
+    deleted = False
     open_idx = text.find(RESPONSE_OPEN)
     if open_idx != -1:
         close_idx = text.find(RESPONSE_CLOSE, open_idx + len(RESPONSE_OPEN))
-        tracker.delete_prefix(open_idx + len(RESPONSE_OPEN))
         if close_idx != -1:
-            tracker.delete_suffix(close_idx - open_idx - len(RESPONSE_OPEN))
-    else:
-        tracker.delete_regex_matches(re.compile(re.escape(RESPONSE_CLOSE)))
-    tracker.delete_regex_matches(re.compile(re.escape(MESSAGE_CLOSE)))
-    stripped = strip_partial_marker_suffix(tracker.text)
-    if stripped != tracker.text:
-        tracker.delete_suffix(len(stripped))
+            text = text[open_idx + len(RESPONSE_OPEN) : close_idx]
+        else:
+            text = text[open_idx + len(RESPONSE_OPEN) :]
+        deleted = True
+    elif RESPONSE_CLOSE in text:
+        text = text.replace(RESPONSE_CLOSE, "")
+        deleted = True
+    if MESSAGE_CLOSE in text:
+        text = text.replace(MESSAGE_CLOSE, "")
+        deleted = True
+    stripped = strip_partial_marker_suffix(text)
+    if stripped != text:
+        text = stripped
+        deleted = True
+    return text, deleted
 
 
 def strip_response_wrappers(text: str) -> str:
-    tracker = _SpanTracker(text)
-    strip_response_wrappers_in_place(tracker)
-    return tracker.text
+    return _strip_response_wrappers(text)[0]

--- a/test/registered/function_call/test_kimik3_detector.py
+++ b/test/registered/function_call/test_kimik3_detector.py
@@ -6,6 +6,7 @@ from openai.types.responses.response_output_text import Logprob
 
 from sglang.srt.entrypoints.openai.protocol import Function, ResponsesRequest, Tool
 from sglang.srt.entrypoints.openai.serving_responses import OpenAIServingResponses
+from sglang.srt.entrypoints.openai.utils import align_token_logprobs_to_text
 from sglang.srt.function_call.core_types import ToolCallItem
 from sglang.srt.function_call.function_call_parser import FunctionCallParser
 from sglang.srt.function_call.kimik3_detector import KimiK3Detector
@@ -17,6 +18,7 @@ from sglang.srt.function_call.kimik3_format import (
     THINK_OPEN,
     TOOLS_CLOSE,
     TOOLS_OPEN,
+    strip_response_wrappers,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 
@@ -264,6 +266,28 @@ def _strip(text: str, reasoning_separated: bool = True) -> str:
     return KimiK3Detector().strip_template_artifacts(text, reasoning_separated)
 
 
+def test_stripped_spans_reconstruct_cleaned_text() -> None:
+    detector = KimiK3Detector()
+    cases = [
+        ("plain response", False),
+        (f"{RESPONSE_OPEN}visible{RESPONSE_CLOSE}{MESSAGE_CLOSE}", False),
+        (f"{THINK_OPEN}secret{THINK_CLOSE}visible", True),
+        (f"visible{LEAKED_TOOLS_SECTION}", False),
+        ("   ", False),
+    ]
+    for original, reasoning_separated in cases:
+        cleaned, kept_spans = detector.strip_template_artifacts_spans(
+            original, reasoning_separated
+        )
+        assert "".join(original[start:end] for start, end in kept_spans) == cleaned
+
+
+def test_strip_response_wrappers_preserves_whitespace() -> None:
+    text = " \t\n "
+
+    assert strip_response_wrappers(text) == text
+
+
 @pytest.mark.parametrize(
     "text",
     [
@@ -423,6 +447,37 @@ def test_logprobs_dropped_when_they_cannot_be_reconciled() -> None:
         f"trace{THINK_CLOSE}answer", output_logprobs=_logprobs("something", "else")
     )
     assert items[0].content[0].logprobs is None
+
+
+def test_alignment_drops_ambiguous_marker_inner_token() -> None:
+    original = f"{RESPONSE_OPEN}response visible"
+    entries = _logprobs("<|open|>", "response", "<|sep|>", "response", " visible")
+    cleaned, kept_spans = KimiK3Detector().strip_template_artifacts_spans(original)
+
+    aligned = align_token_logprobs_to_text(entries, original, cleaned, kept_spans)
+
+    assert cleaned == "response visible"
+    assert [entry.token for entry in aligned or []] == ["response", " visible"]
+
+
+def test_alignment_handles_reasoning_prefix() -> None:
+    strip_input = f"{THINK_CLOSE}visible"
+    entries = _logprobs("secret", THINK_CLOSE, "visible")
+    cleaned, kept_spans = KimiK3Detector().strip_template_artifacts_spans(
+        strip_input, reasoning_separated=True
+    )
+
+    aligned = align_token_logprobs_to_text(entries, strip_input, cleaned, kept_spans)
+
+    assert [entry.token for entry in aligned or []] == ["visible"]
+
+
+def test_alignment_returns_none_for_irreconcilable_input() -> None:
+    entries = _logprobs("prefix", "visible")
+
+    assert (
+        align_token_logprobs_to_text(entries, "expected", "expected", [(0, 8)]) is None
+    )
 
 
 if __name__ == "__main__":

--- a/test/registered/function_call/test_kimik3_detector.py
+++ b/test/registered/function_call/test_kimik3_detector.py
@@ -269,17 +269,33 @@ def _strip(text: str, reasoning_separated: bool = True) -> str:
 def test_stripped_spans_reconstruct_cleaned_text() -> None:
     detector = KimiK3Detector()
     cases = [
-        ("plain response", False),
-        (f"{RESPONSE_OPEN}visible{RESPONSE_CLOSE}{MESSAGE_CLOSE}", False),
-        (f"{THINK_OPEN}secret{THINK_CLOSE}visible", True),
-        (f"visible{LEAKED_TOOLS_SECTION}", False),
-        ("   ", False),
+        ("plain response", False, "plain response"),
+        (f"{RESPONSE_OPEN}visible{RESPONSE_CLOSE}{MESSAGE_CLOSE}", False, "visible"),
+        (f"{THINK_OPEN}secret{THINK_CLOSE}visible", True, "visible"),
+        (f"visible{LEAKED_TOOLS_SECTION}", False, "visible"),
+        ("   ", False, "   "),
     ]
-    for original, reasoning_separated in cases:
+    for original, reasoning_separated, expected in cases:
         cleaned, kept_spans = detector.strip_template_artifacts_spans(
             original, reasoning_separated
         )
+        assert cleaned == expected
         assert "".join(original[start:end] for start, end in kept_spans) == cleaned
+
+
+def test_strip_template_artifacts_whitespace_behavior() -> None:
+    detector = KimiK3Detector()
+
+    cleaned, kept_spans = detector.strip_template_artifacts_spans("   ")
+    assert cleaned == "   "
+    assert kept_spans == [(0, 3)]
+    assert detector.strip_template_artifacts("   ") == "   "
+
+    marker_only = f"{RESPONSE_OPEN}   {RESPONSE_CLOSE}"
+    cleaned, kept_spans = detector.strip_template_artifacts_spans(marker_only)
+    assert cleaned == ""
+    assert kept_spans == []
+    assert detector.strip_template_artifacts(marker_only) == ""
 
 
 def test_strip_response_wrappers_preserves_whitespace() -> None:

--- a/test/registered/function_call/test_kimik3_detector.py
+++ b/test/registered/function_call/test_kimik3_detector.py
@@ -2,8 +2,10 @@ import json
 import sys
 
 import pytest
+from openai.types.responses.response_output_text import Logprob
 
-from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.entrypoints.openai.protocol import Function, ResponsesRequest, Tool
+from sglang.srt.entrypoints.openai.serving_responses import OpenAIServingResponses
 from sglang.srt.function_call.core_types import ToolCallItem
 from sglang.srt.function_call.function_call_parser import FunctionCallParser
 from sglang.srt.function_call.kimik3_detector import KimiK3Detector
@@ -11,6 +13,8 @@ from sglang.srt.function_call.kimik3_format import (
     MESSAGE_CLOSE,
     RESPONSE_CLOSE,
     RESPONSE_OPEN,
+    THINK_CLOSE,
+    THINK_OPEN,
     TOOLS_CLOSE,
     TOOLS_OPEN,
 )
@@ -247,6 +251,178 @@ def test_detector_capabilities_and_registration() -> None:
     parser = FunctionCallParser([_make_tool("python")], "kimi_k3")
     assert isinstance(parser.detector, KimiK3Detector)
     assert parser.get_structure_constraint("required") is not None
+
+
+LEAKED_TOOLS_SECTION = (
+    f'{TOOLS_OPEN}<|open|>call tool="read_agent" index="1"<|sep|>'
+    f'<|open|>argument key="id" type="string"<|sep|>worker_1'
+    f"<|close|>argument<|sep|><|close|>call<|sep|>{TOOLS_CLOSE}{MESSAGE_CLOSE}"
+)
+
+
+def _strip(text: str, reasoning_separated: bool = True) -> str:
+    return KimiK3Detector().strip_template_artifacts(text, reasoning_separated)
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "<|open|>",
+        "<|close|>",
+        "<|",
+        "<|open|>tools",
+        "<|close|>response",
+        f"{RESPONSE_OPEN}<|close|",
+    ],
+)
+def test_truncated_markers_leave_no_text(text: str) -> None:
+    assert _strip(text) == ""
+
+
+def test_unparsed_tools_section_dropped_with_reply_kept() -> None:
+    assert _strip(LEAKED_TOOLS_SECTION) == ""
+    assert (
+        _strip(f"{RESPONSE_OPEN}on it{RESPONSE_CLOSE}{LEAKED_TOOLS_SECTION}") == "on it"
+    )
+
+
+def test_narration_before_truncated_marker_survives() -> None:
+    assert (
+        _strip("I am delegating the docs subagent.<|close|>response")
+        == "I am delegating the docs subagent."
+    )
+
+
+def test_think_channel_content_is_dropped_not_unwrapped() -> None:
+    assert _strip(f"{THINK_OPEN}secret{THINK_CLOSE}visible") == "visible"
+    assert _strip(f"{THINK_OPEN}cut off mid-thought") == ""
+
+
+def test_think_content_kept_when_reasoning_is_not_separated() -> None:
+    assert (
+        _strip(f"weighing{THINK_CLOSE}visible", reasoning_separated=False)
+        == "weighingvisible"
+    )
+    assert (
+        _strip(f"{THINK_OPEN}weighing{THINK_CLOSE}visible", reasoning_separated=False)
+        == "weighingvisible"
+    )
+
+
+def test_response_channel_kept_inline_when_reasoning_is_not_separated() -> None:
+    assert (
+        _strip(
+            f"trace{THINK_CLOSE}{RESPONSE_OPEN}answer{RESPONSE_CLOSE}",
+            reasoning_separated=False,
+        )
+        == "traceanswer"
+    )
+    assert (
+        _strip(f"trace{THINK_CLOSE}{RESPONSE_OPEN}answer{RESPONSE_CLOSE}") == "answer"
+    )
+
+
+def test_think_close_without_open_drops_reasoning() -> None:
+    assert _strip(f"deliberating{THINK_CLOSE}visible") == "visible"
+    assert _strip(f"deliberating{THINK_CLOSE}{LEAKED_TOOLS_SECTION}") == ""
+
+
+def test_quoted_call_token_without_attributes_survives() -> None:
+    assert (
+        _strip("calls open with <|open|>call, then attributes")
+        == "calls open with , then attributes"
+    )
+
+
+def test_markers_only_strip_keeps_reasoning_text() -> None:
+    detector = KimiK3Detector()
+    assert (
+        detector.strip_template_markers(f"weighing options{THINK_CLOSE}")
+        == "weighing options"
+    )
+    assert (
+        detector.strip_template_markers("weighing options<|open|>argu")
+        == "weighing options"
+    )
+    assert detector.strip_template_markers('weighing <|open|>call tool="rea') == (
+        "weighing "
+    )
+
+
+@pytest.mark.parametrize(
+    "text", ["", "hello world", "a < b and c |> d", "is 3 < 4? yes <"]
+)
+def test_plain_text_is_untouched(text: str) -> None:
+    assert _strip(text) == text
+
+
+def test_parser_strips_when_detection_misses() -> None:
+    parser = FunctionCallParser([_make_tool("python")], "kimi_k3")
+    assert parser.parse_non_stream("done<|open|>tool") == ("done", [])
+
+
+def test_parser_strips_when_no_tools_declared() -> None:
+    parser = FunctionCallParser([], "kimi_k3")
+    assert parser.parse_non_stream(LEAKED_TOOLS_SECTION) == ("", [])
+
+
+def _logprobs(*tokens: str) -> list[Logprob]:
+    return [
+        Logprob(
+            token=token,
+            logprob=-0.5,
+            bytes=list(token.encode("utf-8")),
+            top_logprobs=[],
+        )
+        for token in tokens
+    ]
+
+
+def _output_items(text: str, output_logprobs: list[Logprob] | None = None):
+    server = object.__new__(OpenAIServingResponses)
+    server.reasoning_parser = None
+    server.tool_call_parser = None
+    server._artifact_detector = KimiK3Detector()
+    return server._make_response_output_items(
+        ResponsesRequest(input="hi"),
+        text,
+        tokenizer=None,
+        output_logprobs=output_logprobs,
+        require_reasoning=False,
+    )
+
+
+def test_syntax_only_text_still_yields_a_message() -> None:
+    items = _output_items(f"{RESPONSE_OPEN}<|close|")
+    assert len(items) == 1
+    assert items[0].content[0].text == ""
+
+
+def test_logprobs_drop_the_entries_of_removed_tokens() -> None:
+    items = _output_items(
+        f"trace{THINK_CLOSE}answer",
+        output_logprobs=_logprobs("trace", THINK_CLOSE, "answer"),
+    )
+    assert items[0].content[0].text == "traceanswer"
+    assert [entry.token for entry in items[0].content[0].logprobs] == [
+        "trace",
+        "answer",
+    ]
+
+
+def test_logprobs_kept_verbatim_when_cleanup_changes_nothing() -> None:
+    items = _output_items("answer", output_logprobs=_logprobs("something", "else"))
+    assert [entry.token for entry in items[0].content[0].logprobs] == [
+        "something",
+        "else",
+    ]
+
+
+def test_logprobs_dropped_when_they_cannot_be_reconciled() -> None:
+    items = _output_items(
+        f"trace{THINK_CLOSE}answer", output_logprobs=_logprobs("something", "else")
+    )
+    assert items[0].content[0].logprobs is None
 
 
 if __name__ == "__main__":

--- a/test/registered/function_call/test_kimik3_detector.py
+++ b/test/registered/function_call/test_kimik3_detector.py
@@ -6,7 +6,6 @@ from openai.types.responses.response_output_text import Logprob
 
 from sglang.srt.entrypoints.openai.protocol import Function, ResponsesRequest, Tool
 from sglang.srt.entrypoints.openai.serving_responses import OpenAIServingResponses
-from sglang.srt.entrypoints.openai.utils import align_token_logprobs_to_text
 from sglang.srt.function_call.core_types import ToolCallItem
 from sglang.srt.function_call.function_call_parser import FunctionCallParser
 from sglang.srt.function_call.kimik3_detector import KimiK3Detector
@@ -266,35 +265,12 @@ def _strip(text: str, reasoning_separated: bool = True) -> str:
     return KimiK3Detector().strip_template_artifacts(text, reasoning_separated)
 
 
-def test_stripped_spans_reconstruct_cleaned_text() -> None:
-    detector = KimiK3Detector()
-    cases = [
-        ("plain response", False, "plain response"),
-        (f"{RESPONSE_OPEN}visible{RESPONSE_CLOSE}{MESSAGE_CLOSE}", False, "visible"),
-        (f"{THINK_OPEN}secret{THINK_CLOSE}visible", True, "visible"),
-        (f"visible{LEAKED_TOOLS_SECTION}", False, "visible"),
-        ("   ", False, "   "),
-    ]
-    for original, reasoning_separated, expected in cases:
-        cleaned, kept_spans = detector.strip_template_artifacts_spans(
-            original, reasoning_separated
-        )
-        assert cleaned == expected
-        assert "".join(original[start:end] for start, end in kept_spans) == cleaned
-
-
 def test_strip_template_artifacts_whitespace_behavior() -> None:
     detector = KimiK3Detector()
 
-    cleaned, kept_spans = detector.strip_template_artifacts_spans("   ")
-    assert cleaned == "   "
-    assert kept_spans == [(0, 3)]
     assert detector.strip_template_artifacts("   ") == "   "
 
     marker_only = f"{RESPONSE_OPEN}   {RESPONSE_CLOSE}"
-    cleaned, kept_spans = detector.strip_template_artifacts_spans(marker_only)
-    assert cleaned == ""
-    assert kept_spans == []
     assert detector.strip_template_artifacts(marker_only) == ""
 
 
@@ -438,16 +414,13 @@ def test_syntax_only_text_still_yields_a_message() -> None:
     assert items[0].content[0].text == ""
 
 
-def test_logprobs_drop_the_entries_of_removed_tokens() -> None:
+def test_logprobs_dropped_when_cleanup_changes_text() -> None:
     items = _output_items(
         f"trace{THINK_CLOSE}answer",
         output_logprobs=_logprobs("trace", THINK_CLOSE, "answer"),
     )
     assert items[0].content[0].text == "traceanswer"
-    assert [entry.token for entry in items[0].content[0].logprobs] == [
-        "trace",
-        "answer",
-    ]
+    assert items[0].content[0].logprobs is None
 
 
 def test_logprobs_kept_verbatim_when_cleanup_changes_nothing() -> None:
@@ -463,37 +436,6 @@ def test_logprobs_dropped_when_they_cannot_be_reconciled() -> None:
         f"trace{THINK_CLOSE}answer", output_logprobs=_logprobs("something", "else")
     )
     assert items[0].content[0].logprobs is None
-
-
-def test_alignment_drops_ambiguous_marker_inner_token() -> None:
-    original = f"{RESPONSE_OPEN}response visible"
-    entries = _logprobs("<|open|>", "response", "<|sep|>", "response", " visible")
-    cleaned, kept_spans = KimiK3Detector().strip_template_artifacts_spans(original)
-
-    aligned = align_token_logprobs_to_text(entries, original, cleaned, kept_spans)
-
-    assert cleaned == "response visible"
-    assert [entry.token for entry in aligned or []] == ["response", " visible"]
-
-
-def test_alignment_handles_reasoning_prefix() -> None:
-    strip_input = f"{THINK_CLOSE}visible"
-    entries = _logprobs("secret", THINK_CLOSE, "visible")
-    cleaned, kept_spans = KimiK3Detector().strip_template_artifacts_spans(
-        strip_input, reasoning_separated=True
-    )
-
-    aligned = align_token_logprobs_to_text(entries, strip_input, cleaned, kept_spans)
-
-    assert [entry.token for entry in aligned or []] == ["visible"]
-
-
-def test_alignment_returns_none_for_irreconcilable_input() -> None:
-    entries = _logprobs("prefix", "visible")
-
-    assert (
-        align_token_logprobs_to_text(entries, "expected", "expected", [(0, 8)]) is None
-    )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/entrypoints/openai/test_responses_protocol.py
+++ b/test/registered/unit/entrypoints/openai/test_responses_protocol.py
@@ -377,6 +377,43 @@ class InputItemStringIdTestCase(CustomTestCase):
         )
 
 
+class ToolOutputImageDetailTestCase(CustomTestCase):
+    """input_image.detail is required by the SDK types but omitted by clients
+    such as Codex, so it is defaulted for tool-output parts too."""
+
+    def test_detail_defaulted_under_output_as_well_as_content(self):
+        norm = ResponsesRequest._normalize_input_item_for_validation
+        item = norm(
+            {
+                "type": "function_call_output",
+                "call_id": "call_1",
+                "output": [
+                    {"type": "input_image", "image_url": "data:image/png;base64,iVB"}
+                ],
+            }
+        )
+        self.assertEqual(item["output"][0]["detail"], "auto")
+
+    def test_request_accepts_image_tool_output_without_detail(self):
+        # Construction must not raise (the bug returned 400).
+        ResponsesRequest(
+            model="x",
+            store=False,
+            input=[
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": [
+                        {
+                            "type": "input_image",
+                            "image_url": "data:image/png;base64,iVB",
+                        }
+                    ],
+                }
+            ],
+        )
+
+
 class ToolChoiceObjectFormTestCase(CustomTestCase):
     def test_echoed_choice_is_what_the_server_honors(self):
         import openai.types.responses as ort

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -37,6 +37,7 @@ from sglang.srt.entrypoints.openai.serving_chat import (
     normalize_tool_content,
 )
 from sglang.srt.environ import envs
+from sglang.srt.function_call.function_call_parser import FunctionCallParser
 from sglang.srt.function_call.kimik3_format import TOOLS_CLOSE, TOOLS_OPEN
 from sglang.srt.managers.io_struct import GenerateReqInput
 from sglang.srt.parser.template_detection import ReasoningToggleConfig
@@ -1680,6 +1681,40 @@ class ServingChatTestCase(unittest.TestCase):
                 self.assertEqual(remaining, "")
                 self.assertEqual(finish_reason["type"], "stop")
                 self.assertIn("no complete call", "\n".join(logs.output))
+
+    def test_unparsed_template_syntax_never_reaches_the_client(self):
+        """K3 emits its tool channel as literal text, so a reply generated with
+        parsing off (no tools / tool_choice="none") used to be returned raw."""
+        self.chat.tool_call_parser = "kimi_k3"
+        self.chat._artifact_detector = FunctionCallParser([], "kimi_k3").detector
+        leaked = (
+            "on it"
+            + TOOLS_OPEN
+            + '<|open|>call tool="get_weather" index="1"<|sep|>'
+            + TOOLS_CLOSE
+        )
+        for label, text in (("unparsed tools", leaked), ("truncated", "on it<|open")):
+            with self.subTest(payload=label):
+                req = ChatCompletionRequest(
+                    model="x",
+                    messages=[{"role": "user", "content": "Hi?"}],
+                    tool_choice="none",
+                )
+                ret = [
+                    {
+                        "text": text,
+                        "meta_info": {
+                            "id": "chatcmpl-leak",
+                            "prompt_tokens": 3,
+                            "completion_tokens": 5,
+                            "cached_tokens": 0,
+                            "finish_reason": {"type": "stop", "matched": None},
+                            "weight_version": "default",
+                        },
+                    }
+                ]
+                response = self.chat._build_chat_response(req, ret, created=123)
+                self.assertEqual(response.choices[0].message.content, "on it")
 
     def test_required_tool_choice_json_fallback_tolerates_odd_shapes(self):
         """Parsers without a structural tag keep the JSON array fallback, but a


### PR DESCRIPTION
## Motivation

Kimi K3 emits its channels (`<|open|>tools<|sep|>`, `<|open|>call ...`, `<|close|>message<|sep|>`, ...) as literal text, so any path that does not run the tool-call parser hands that syntax straight to the client. Two such paths exist today:

- **Parsing disabled.** With `tool_choice="none"` or no tools, `serving_chat` / `serving_responses` skip the parser and `FunctionCallParser.parse_non_stream` returns `full_text` verbatim. Measured on a K3 deployment: ~10% of `tool_choice="none"` completions came back containing a raw tools section.
- **Truncation.** `KimiK3Detector.has_tool_call` is `self.bot_token in text`, so output cut mid-marker (`...<|open|>too`) misses detection and `parse_non_stream` again returns the raw text. With small `max_output_tokens` this reproduced in 97-100% of samples.

Separately, `ResponsesRequest._normalize_input_item_for_validation` defaults the SDK-required `input_image.detail` only under `item["content"]`. Tool-output items carry their parts under `item["output"]`, so an image tool result without `detail` (what Codex sends) fails validation with a 400.

## Modifications

- `base_format_detector.py`: two identity-by-default hooks, `strip_template_artifacts(text, reasoning_separated)` and `strip_template_markers(text)`. Formats whose tool channel is literal text override them; every other detector is unaffected.
- `kimik3_detector.py`: implements both. Artifact stripping cuts from an unparsed `TOOLS_OPEN` / `CALL_OPEN` onward, drops the think channel when a reasoning parser already routed the trace to its own field, unwraps the response channel, and removes whole and cut-off markers. Marker stripping only removes syntax, keeping the text it wrapped — used for reasoning content.
- `kimik3_format.py`: `ALL_MARKERS`, `ARGUMENT_OPEN`, and a `min_len` on `partial_suffix_len` so a reply legitimately ending in `<` is not truncated.
- `function_call_parser.py`: the two paths that returned `full_text` unchanged (no tools, detection missed) now route it through `strip_template_artifacts`.
- `serving_chat.py` / `serving_responses.py`: apply the hooks to non-streaming assistant text and reasoning content, regardless of whether parsing ran. A Responses turn whose text was nothing but syntax still emits an `output_text` item (empty) rather than an output array with no message.
- `utils.py`: `align_token_logprobs_to_text`. The cleanup is pure span deletion, so the cleaned text is a subsequence of the concatenated tokens; entries whose token was removed are dropped, and the array becomes `None` if the two cannot be reconciled rather than being returned misaligned. Applied only when cleanup actually changed the text, so logprobs on paths this PR does not touch are unchanged.
- `protocol.py`: normalize `input_image.detail` under `output` as well as `content`.

Streaming is out of scope: the chunk handlers can still emit markers verbatim, and fixing that needs cross-chunk marker buffering.

## Accuracy Tests

No change to model forward or kernels — this only affects post-generation text handling in the OpenAI entrypoints.

## Speed Tests and Profiling

N/A; the added work is a few regex passes over the response text.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33032659972](https://github.com/sgl-project/sglang/actions/runs/33032659972)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33032659826](https://github.com/sgl-project/sglang/actions/runs/33032659826)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33032659882](https://github.com/sgl-project/sglang/actions/runs/33032659882)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->