### PR TITLE
model_loader: only open the MTP-head shards for a NextN/MTP draft load

### DIFF
--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -117,6 +117,7 @@ from sglang.srt.model_loader.weight_utils import (
     initialize_capture_safe_weights,
     initialize_dummy_weights,
     maybe_add_mtp_safetensors,
+    maybe_filter_nextn_shards,
     multi_thread_pt_weights_iterator,
     np_cache_weights_iterator,
     pt_weights_iterator,
@@ -599,6 +600,16 @@ class DefaultModelLoader(BaseModelLoader):
             )
             if use_safetensors and source.model_config is not None:
                 hf_weights_files = maybe_add_mtp_safetensors(
+                    hf_weights_files,
+                    hf_folder,
+                    "model.safetensors.index.json",
+                    source.model_config.hf_config,
+                )
+                # For an MTP/NextN draft loaded from the target's combined
+                # checkpoint, keep only the shard(s) holding the MTP head so we
+                # don't open the entire checkpoint (target body) just to read a
+                # small draft head.
+                hf_weights_files = maybe_filter_nextn_shards(
                     hf_weights_files,
                     hf_folder,
                     "model.safetensors.index.json",

--- a/python/sglang/srt/model_loader/weight_utils.py
+++ b/python/sglang/srt/model_loader/weight_utils.py
@@ -809,6 +809,86 @@ def maybe_add_mtp_safetensors(
     return hf_weights_files + [mtp_path]
 
 
+# Modules that exist ONLY in an MTP/NextN speculative layer, never in a normal
+# transformer layer. Their presence under a `model.layers.<i>.` prefix uniquely
+# identifies <i> as the appended NextN layer in a combined target+MTP checkpoint.
+_NEXTN_LAYER_MARKERS = ("eh_proj", "enorm", "hnorm", "shared_head")
+
+
+def maybe_filter_nextn_shards(
+    hf_weights_files: List[str], hf_folder: str, index_file: str, hf_config
+) -> List[str]:
+    """Restrict a NextN/MTP *draft* load to just the shard(s) holding the MTP head.
+
+    An MTP draft (EAGLE next-token head) is loaded from the SAME combined
+    checkpoint as the target, so `_prepare_weights` hands it every shard in the
+    index -- the full ~433G checkpoint -- even though the draft consumes only the
+    appended NextN layer (~a few GB); `embed_tokens` / `shared_head.head` are
+    shared from the already-resident target, not read from disk, and every other
+    tensor is skipped by the NextN weight loader AFTER the iterator has opened it.
+    Opening the whole checkpoint for the head is pure waste (extra I/O + a
+    misleading "0.00/433G" InstantTensor bar on the draft).
+
+    This keeps only the shards that contain the NextN layer's tensors. It is
+    deliberately conservative:
+      * Only acts on a draft config (architecture ends in "NextN"/"MTP").
+      * Discovers the MTP layer index FROM THE CHECKPOINT -- the layer carrying
+        the NextN-only modules (_NEXTN_LAYER_MARKERS) -- rather than from config
+        arithmetic, which some archs rewrite (e.g. num_hidden_layers reset to the
+        nextn count). A wrong guess can't drop needed weights: if no layer shows
+        those markers, or filtering wouldn't reduce the set, it returns the list
+        unchanged.
+      * Keeps any file not described by the index (e.g. a separately-added
+        mtp.safetensors) so nothing the index omits is ever dropped.
+    """
+    arch = (getattr(hf_config, "architectures", None) or [None])[0] or ""
+    if not (arch.endswith("NextN") or arch.endswith("MTP")):
+        return hf_weights_files
+
+    index_path = os.path.join(hf_folder, index_file)
+    if not os.path.isfile(index_path):
+        return hf_weights_files
+    try:
+        with open(index_path) as f:
+            weight_map = json.load(f).get("weight_map", {})
+    except (OSError, ValueError):
+        return hf_weights_files
+    if not weight_map:
+        return hf_weights_files
+
+    # Which layer index(es) carry NextN-only modules? That is the MTP head.
+    mtp_layers = set()
+    for name in weight_map:
+        m = re.match(r"model\.layers\.(\d+)\.", name)
+        if m and any(marker in name for marker in _NEXTN_LAYER_MARKERS):
+            mtp_layers.add(m.group(1))
+    if not mtp_layers:
+        # Not a combined checkpoint we can safely narrow (or markers renamed).
+        return hf_weights_files
+
+    keep_prefixes = tuple(f"model.layers.{i}." for i in mtp_layers)
+    keep = {
+        os.path.join(hf_folder, shard)
+        for name, shard in weight_map.items()
+        if name.startswith(keep_prefixes)
+    }
+    index_shards = {os.path.join(hf_folder, s) for s in weight_map.values()}
+    # Keep MTP shards + anything the index doesn't describe (defensive).
+    filtered = [f for f in hf_weights_files if f in keep or f not in index_shards]
+
+    if not filtered or len(filtered) >= len(hf_weights_files):
+        return hf_weights_files  # nothing to gain / couldn't narrow safely
+
+    logger.info(
+        "NextN draft load: restricting %d checkpoint shard(s) to the %d holding "
+        "MTP layer(s) %s (target body skipped).",
+        len(hf_weights_files),
+        len(filtered),
+        sorted(mtp_layers, key=int),
+    )
+    return filtered
+
+
 def filter_files_not_needed_for_inference(hf_weights_files: List[str]) -> List[str]:
     """
     Exclude files that are not needed for inference.

--- a/test/registered/unit/model_loader/test_weight_utils.py
+++ b/test/registered/unit/model_loader/test_weight_utils.py
@@ -4,8 +4,12 @@ import json
 import os
 import tempfile
 import unittest
+from types import SimpleNamespace
 
-from sglang.srt.model_loader.weight_utils import filter_duplicate_safetensors_files
+from sglang.srt.model_loader.weight_utils import (
+    filter_duplicate_safetensors_files,
+    maybe_filter_nextn_shards,
+)
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -82,6 +86,110 @@ class TestFilterDuplicateSafetensorsFiles(CustomTestCase):
             index_file=INDEX_NAME,
         )
         self.assertEqual(result, [single])
+
+
+class TestMaybeFilterNextnShards(CustomTestCase):
+    """A combined target+MTP checkpoint: 47 shards, main layers 0..77, and the
+    NextN head (layer 78 with eh_proj/enorm/hnorm/shared_head) in shards 45-47.
+    Mirrors palmyra-x6-...-mtp-v2."""
+
+    N = 47
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.folder = self._tmp.name
+        self.shards = [
+            f"model-{i:05d}-of-{self.N:05d}.safetensors" for i in range(1, self.N + 1)
+        ]
+        wm = {}
+        # main body: layers 0..77 spread across shards 1..44
+        for layer in range(78):
+            shard = self.shards[layer % 44]
+            wm[f"model.layers.{layer}.self_attn.q_proj.weight"] = shard
+        wm["model.embed_tokens.weight"] = self.shards[0]  # shard 1 (shared)
+        wm["lm_head.weight"] = self.shards[44]  # shard 45 (shared)
+        wm["model.norm.weight"] = self.shards[44]  # shard 45
+        # NextN head = layer 78, in shards 45/46/47, with the marker modules
+        wm["model.layers.78.eh_proj.weight"] = self.shards[44]
+        wm["model.layers.78.enorm.weight"] = self.shards[44]
+        wm["model.layers.78.hnorm.weight"] = self.shards[45]
+        wm["model.layers.78.self_attn.q_proj.weight"] = self.shards[45]
+        wm["model.layers.78.mlp.experts.0.down_proj.weight"] = self.shards[46]
+        wm["model.layers.78.shared_head.norm.weight"] = self.shards[46]
+        self.weight_map = wm
+        _write_index(self.folder, wm)
+        self.all_files = [_touch(self.folder, s) for s in self.shards]
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _cfg(self, arch, **extra):
+        return SimpleNamespace(architectures=[arch], **extra)
+
+    def test_draft_load_keeps_only_mtp_shards(self):
+        result = maybe_filter_nextn_shards(
+            self.all_files,
+            self.folder,
+            INDEX_NAME,
+            self._cfg("GlmMoeDsaForCausalLMNextN"),
+        )
+        expected = sorted(
+            os.path.join(self.folder, self.shards[i]) for i in (44, 45, 46)
+        )  # shards 45,46,47
+        self.assertEqual(sorted(result), expected)
+
+    def test_target_load_is_untouched(self):
+        # Non-NextN architecture (the target) must load every shard.
+        result = maybe_filter_nextn_shards(
+            self.all_files, self.folder, INDEX_NAME, self._cfg("GlmMoeDsaForCausalLM")
+        )
+        self.assertEqual(result, self.all_files)
+
+    def test_num_hidden_layers_rewrite_does_not_mislead(self):
+        # Some archs reset num_hidden_layers (e.g. to the nextn count). Because we
+        # discover the MTP layer from the checkpoint markers, a bogus config value
+        # cannot make us drop the real head shards.
+        result = maybe_filter_nextn_shards(
+            self.all_files,
+            self.folder,
+            INDEX_NAME,
+            self._cfg("GlmMoeDsaForCausalLMNextN", num_hidden_layers=1),
+        )
+        expected = sorted(
+            os.path.join(self.folder, self.shards[i]) for i in (44, 45, 46)
+        )
+        self.assertEqual(sorted(result), expected)
+
+    def test_no_markers_returns_unchanged(self):
+        # Checkpoint whose MTP modules aren't the known markers -> safe no-op.
+        with tempfile.TemporaryDirectory() as d:
+            wm = {f"model.layers.{i}.w": f"s{i}.safetensors" for i in range(3)}
+            _write_index(d, wm)
+            files = [_touch(d, f"s{i}.safetensors") for i in range(3)]
+            result = maybe_filter_nextn_shards(
+                files, d, INDEX_NAME, self._cfg("SomethingForCausalLMNextN")
+            )
+            self.assertEqual(result, files)
+
+    def test_separately_added_mtp_file_is_kept(self):
+        # A mtp.safetensors not described by the index (GLM4Moe packaging bug,
+        # appended by maybe_add_mtp_safetensors) must survive filtering.
+        extra = _touch(self.folder, "mtp.safetensors")
+        result = maybe_filter_nextn_shards(
+            self.all_files + [extra],
+            self.folder,
+            INDEX_NAME,
+            self._cfg("GlmMoeDsaForCausalLMNextN"),
+        )
+        self.assertIn(extra, result)
+
+    def test_no_index_returns_unchanged(self):
+        with tempfile.TemporaryDirectory() as d:
+            files = [_touch(d, "model.safetensors")]
+            result = maybe_filter_nextn_shards(
+                files, d, INDEX_NAME, self._cfg("FooForCausalLMNextN")
+            )
+            self.assertEqual(result, files)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

An EAGLE/MTP **NextN draft** is loaded from the **same combined checkpoint** as the target, so `DefaultModelLoader._prepare_weights` hands it **every shard in the safetensors index** — the whole checkpoint — even though the draft consumes only the appended NextN layer:

- `embed_tokens` / `shared_head.head` are **shared from the already-resident target** (`deepseek_weight_loader` skips them: `if "shared_head.head" in name or "embed_tokens" in name: continue`), not read from disk;
- every other tensor is skipped by the NextN weight loader (`if not name.startswith(layer_prefix): continue`) **after** the iterator has already opened the file.

Net: a small draft head **re-opens the full multi-hundred-GB checkpoint** — wasted I/O, and a misleading full-checkpoint-size weight-load progress bar on the draft. On a real MTP model (`GlmMoeDsa*`-family, 78 layers + 1 NextN layer, FP4, EAGLE), the NextN head lives in **3 of 47 shards** but the draft opened all 47.

## Modifications

Add `maybe_filter_nextn_shards` (weight_utils.py), called right next to `maybe_add_mtp_safetensors` in `DefaultModelLoader._get_weights_iterator`. For a **draft** config it restricts the shard list to just the shard(s) holding the MTP head. Deliberately conservative:

- **Draft-only** — acts only when the architecture ends in `NextN` / `MTP`; **target loads are untouched**.
- **Checkpoint-discovered MTP layer** — finds the MTP layer by the NextN-only modules it carries (`eh_proj` / `enorm` / `hnorm` / `shared_head`), **not** config arithmetic, since some archs rewrite `num_hidden_layers` (e.g. Longcat resets it to the nextn count). A wrong guess can **never drop needed weights**: no markers / no index / no reduction ⇒ the list is returned unchanged.
- **Keeps index-undescribed files** — e.g. a separately-added `mtp.safetensors` (the `maybe_add_mtp_safetensors` path) is never dropped.

Runs before the weights iterator is chosen, so it benefits every safetensors load path for NextN drafts.

## Accuracy Tests

No output impact: the NextN draft loads the **identical** head weights — the same tensors the loader already kept. This change only avoids *opening* shards whose tensors the NextN loader already skips (target body / main-model layers), so the resulting model state is unchanged. Verified in production: the draft reaches ready and serves normally.

## Speed Tests and Profiling

Measured on a production MTP deployment (`GlmMoeDsa*` FP4, `--speculative-algorithm EAGLE`, 8×B200, cold node), before vs after this change — **same target, same node class**:

| Phase | Before | After |
|---|---|---|
| Target (`role=main`) load | 47.83 s | 47.79 s (unchanged) |
| **Draft (`role=draft`) load** | **41.51 s** | **4.29 s** (**9.7× faster**) |
| Draft shards opened | 47 / 47 | **3 / 47** |
| Draft weight-load bar total | 433 GB | **23.4 GB** |

The log confirms the narrowing:
> `NextN draft load: restricting 47 checkpoint shard(s) to the 3 holding MTP layer(s) ['78'] (target body skipped).`

The target load is unchanged (confirming the filter is draft-only); the draft speedup comes entirely from not re-reading the target body. The win scales with checkpoint size and node coldness.

## Checklist

- [x] Format your code according to Format code with pre-commit (pre-commit run passes: black / isort / ruff / codespell).
- [x] Add unit tests (`test/registered/unit/model_loader/test_weight_utils.py::TestMaybeFilterNextnShards`): draft → MTP-only shards, target untouched, `num_hidden_layers`-rewrite safety, separately-added `mtp.safetensors` kept, no-marker / no-index no-ops.
- [ ] Update documentation — n/a (internal loader optimization, no user-facing flags).
- [x] Provide accuracy and speed benchmark results (above).
- [x] Follow the SGLang code style guidance.

---
*Prepared with AI assistance (Claude Code); validated in production as shown above.*

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32191339576](https://github.com/sgl-project/sglang/actions/runs/32191339576)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32191339452](https://github.com/sgl-project/sglang/actions/runs/32191339452)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->