### PR TITLE
[Fix] Assert the page-aligned SWA evict floor on both PD decode prealloc paths

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -1766,7 +1766,12 @@ def alloc_for_decode_prealloc(
                 swa_tail_len=swa_tail_len,
                 **extra_kwargs,
             )
-            req.kv.swa_evicted_seqlen = fill_len - swa_tail_len
+            swa_evicted_seqlen = fill_len - swa_tail_len
+            assert (
+                swa_evicted_seqlen >= 0
+                and swa_evicted_seqlen % allocator.page_size == 0
+            )
+            req.kv.swa_evicted_seqlen = swa_evicted_seqlen
         else:
             kv_loc = allocator.alloc_extend(
                 prefix_lens=torch.tensor(

--- a/test/registered/unit/mem_cache/test_hisparse_allocator.py
+++ b/test/registered/unit/mem_cache/test_hisparse_allocator.py
@@ -80,7 +80,10 @@ class TestDeepSeekV4HiSparseAllocator(CustomTestCase):
         from sglang.srt.disaggregation.decode import DecodePreallocQueue
 
         fill_len = 512
-        swa_tail_len = 128
+        sliding_window_size = 200
+        # _swa_tail_len floors the window start to a page boundary:
+        # floor_align(512 - 200, 256) = 256, so the tail is one whole page.
+        swa_tail_len = 256
         kv_loc = torch.arange(512, 512 + fill_len, dtype=torch.int64)
         host_indices = torch.arange(1000, 1128, dtype=torch.int64)
 
@@ -134,9 +137,9 @@ class TestDeepSeekV4HiSparseAllocator(CustomTestCase):
             enable_hisparse=True,
             hisparse_coordinator=coordinator,
             server_args=SimpleNamespace(disaggregation_decode_enable_radix_cache=False),
+            sliding_window_size=sliding_window_size,
         )
         queue._uses_swa_tail_prealloc = MagicMock(return_value=True)
-        queue._swa_tail_len = MagicMock(return_value=swa_tail_len)
 
         result = queue._pre_alloc(req)
 


### PR DESCRIPTION
Mirrors the assert added in #35286 onto the non-hisparse prealloc path, and repairs the hisparse fixture that mocked `_swa_tail_len` to an unaligned value (currently failing on main in `base-a-test-cpu`).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #32193214273](https://github.com/sgl-project/sglang/actions/runs/32193214273)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32193214129](https://github.com/sgl-project/sglang/actions/runs/32193214129)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->