### PR TITLE
[AMD] Verify the nightly ROCm 7.2.4 images trace HIP-graph kernels

### DIFF
--- a/.github/workflows/release-docker-amd-rocm720-nightly.yml
+++ b/.github/workflows/release-docker-amd-rocm720-nightly.yml
@@ -10,6 +10,12 @@ on:
         options:
           - 'all'
           - publish
+          - verify_profiling
+      probe_image:
+        description: 'With job_select=verify_profiling, qualify this image instead of building one, e.g. rocm/sgl-dev:v0.5.17-rocm724-mi35x-20260820. Pair it with gpu_arch to pick the GPU it runs on.'
+        required: false
+        type: string
+        default: ''
       gpu_arch:
         description: 'Select which ROCm 7.2 GPU arch to build'
         required: false
@@ -140,6 +146,125 @@ jobs:
         run: |
           docker tag rocm/sgl-dev:${{ env.IMAGE_TAG }} lmsysorg/sglang-rocm:${{ env.IMAGE_TAG }}
           docker push lmsysorg/sglang-rocm:${{ env.IMAGE_TAG }}
+
+  # The rocm724 flavors exist to restore torch.profiler under HIP graph replay,
+  # which ROCm 7.2.0 drops (ROCm/ROCm#6102, fixed in 7.2.2). Nothing else notices
+  # if that regresses: the loss is partial, so an under-reported trace still looks
+  # like a successful profile, and the profiling suite runs without CUDA graphs on
+  # ROCm (#34452), so it never exercises the replay path. Each flavor is checked on
+  # the GPU it targets, since the behaviour lives in the HIP runtime.
+  #
+  # Two runs per image, because installing the fixed ROCm is not the same as
+  # loading it: the default records what users get, and the preloaded run is what
+  # the image can do and is the one that has to pass.
+  #
+  # Runs after publish rather than gating it: the images should not wait on a GPU
+  # runner queue. A red leg here means the day's rocm724 image traces nothing
+  # under graph replay and should not be recommended for profiling.
+  verify_profiling:
+    # Per leg, like the mirror job below: a rocm720 leg failing in publish must
+    # not stop the rocm724 images from being checked, and a rocm724 leg that
+    # never published has no artifact and fails at the download.
+    if: |
+      always() && !cancelled() && github.repository == 'sgl-project/sglang' &&
+      needs.publish.result != 'cancelled' &&
+      (github.event_name != 'workflow_dispatch' ||
+       ((inputs.job_select == 'all' || inputs.job_select == 'verify_profiling') &&
+        (inputs.gpu_arch == 'all' || inputs.gpu_arch == '' ||
+         contains(inputs.gpu_arch, 'rocm724'))))
+    needs: publish
+    strategy:
+      fail-fast: false
+      matrix:
+        gpu_arch: ${{ fromJson((github.event_name == 'workflow_dispatch' && contains(inputs.gpu_arch, 'rocm724')) && format('["{0}"]', inputs.gpu_arch) || '["gfx942-rocm724", "gfx950-rocm724"]') }}
+    runs-on: ${{ matrix.gpu_arch == 'gfx942-rocm724' && 'linux-mi300-1gpu-sglang' || 'linux-mi35x-gpu-1' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download image tag artifact
+        if: inputs.probe_image == ''
+        uses: actions/download-artifact@v4
+        with:
+          name: image-tag-${{ matrix.gpu_arch }}
+
+      - name: Resolve image
+        env:
+          PROBE_IMAGE: ${{ inputs.probe_image }}
+        run: |
+          if [ -n "${PROBE_IMAGE}" ]; then
+            image="${PROBE_IMAGE}"
+          else
+            image_tag=$(tr -d '[:space:]' < "${{ matrix.gpu_arch }}.txt")
+            if [ -z "${image_tag}" ]; then
+              echo "::error::Image tag artifact is empty"
+              exit 1
+            fi
+            image="rocm/sgl-dev:${image_tag}"
+          fi
+          echo "IMAGE=${image}" >> $GITHUB_ENV
+          echo "Verifying ${image}"
+
+      - name: Ensure VRAM is clear
+        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
+
+      - name: Start CI container
+        run: bash scripts/ci/amd/amd_ci_start_container.sh --custom-image "${IMAGE}"
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+          DOCKERHUB_AMD_USERNAME: ${{ secrets.DOCKERHUB_AMD_USERNAME }}
+          DOCKERHUB_AMD_TOKEN: ${{ secrets.DOCKERHUB_AMD_TOKEN }}
+
+      # No dependency install: this checks the image's own torch and HIP runtime,
+      # which is what was just published.
+      # Out of the box the torch wheel loads the HIP and roctracer it vendors in
+      # torch/lib, which are 7.2.0, so this records what a user gets by default
+      # rather than what the image is capable of. It is expected to fail until
+      # torch stops shadowing the ROCm install, so it does not fail the job.
+      - name: Probe HIP-graph profiling (image default)
+        id: default_probe
+        continue-on-error: true
+        timeout-minutes: 20
+        run: |
+          set -o pipefail
+          docker exec -w /sglang-checkout ci_sglang \
+            python3 scripts/ci/amd/check_hip_graph_profiling.py 2>&1 | tee probe-default.log
+
+      # The image's own 7.2.4 HIP and roctracer, which is the configuration that
+      # traces graph replay in full. LD_PRELOAD has to be set before the process
+      # starts, so it goes on docker exec rather than inside the probe.
+      - name: Probe HIP-graph profiling (ROCm runtime preloaded)
+        timeout-minutes: 20
+        run: |
+          set -o pipefail
+          preload=$(docker exec ci_sglang \
+            python3 /sglang-checkout/scripts/ci/amd/check_hip_graph_profiling.py --print-ld-preload)
+          echo "LD_PRELOAD=${preload}"
+          docker exec -w /sglang-checkout -e LD_PRELOAD="${preload}" ci_sglang \
+            python3 scripts/ci/amd/check_hip_graph_profiling.py 2>&1 | tee probe-preloaded.log
+
+      - name: Summarize
+        if: always()
+        run: |
+          {
+            echo "### ${{ matrix.gpu_arch }}"
+            echo "- **Image:** \`${IMAGE}\`"
+            echo ""
+            echo "**Image default** (\`${{ steps.default_probe.outcome }}\`)"
+            echo '```'
+            cat probe-default.log 2>/dev/null || echo "no probe output"
+            echo '```'
+            echo "**ROCm runtime preloaded**"
+            echo '```'
+            cat probe-preloaded.log 2>/dev/null || echo "no probe output"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # These runners are shared with the AMD test suites, and the container
+      # holds VRAM until something reclaims it.
+      - name: Stop CI container
+        if: always()
+        run: docker rm -f ci_sglang || true
 
   # Mirror the freshly published rocm/sgl-dev image to the in-network Docker
   # registry so AMD CI runners can pull without hitting Docker Hub rate limits.


### PR DESCRIPTION
## Motivation

#30984 landed the `rocm724` flavors and the nightly now publishes them to `rocm/sgl-dev` and `lmsysorg/sglang-rocm`. Those flavors exist because ROCm 7.2.0 drops kernel-dispatch events for work submitted through `hipGraphLaunch` ([ROCm/ROCm#6102](https://github.com/ROCm/ROCm/issues/6102), fixed in 7.2.2), which is what AMD/Silo hit when profiling SGLang decoding on every `*-rocm720-*` image.

Nothing verifies that the published images actually restore it. A trace with no GPU kernels in it still looks like a successful profile, `test/registered/profiling/test_start_profile.py` only asserts the trace directory is non-empty, and since #34452 the profiling suite runs without CUDA graphs on ROCm, so CI never exercises the replay path at all. A future base bump could quietly take the fix away again.

## Modifications

One job in `release-docker-amd-rocm720-nightly.yml`. After publish, each `rocm724` flavor is probed on the GPU it targets — gfx942 on MI300X, gfx950 on MI355X — because the behaviour lives in the HIP runtime rather than in SGLang, so it is worth confirming per device generation. The job pulls the tag the publish job recorded in its artifact, starts the standard CI container against it, and runs `scripts/ci/amd/check_hip_graph_profiling.py` inside the image. No dependency install: the point is to exercise the image's own torch and HIP runtime, which is what was just published.

Gating details:

- **Per leg, not per workflow.** A `rocm720` leg failing in publish must not stop the `rocm724` images from being checked, so the job does not require all of publish to succeed. A `rocm724` leg that never published has no artifact and fails at the download — the same behaviour the mirror job below documents.
- **`rocm720` legs are excluded**, since they are expected to fail; a dispatch selecting a single `rocm720` arch skips the job.
- **`job_select` is respected**, so a `publish`-only dispatch does not run it.
- **`job_select=verify_profiling` + `probe_image`** qualifies an already-published tag without a rebuild; pair it with `gpu_arch` to choose the GPU. That is the quickest way to answer the question for one image, and it is how this should be run first.
- The container is removed at the end, since these runners are shared with the AMD test suites and it would otherwise hold VRAM until something else reclaims it.

This verifies after publish rather than gating it, so the daily images are not held behind a GPU runner queue. A red leg means the day's `rocm724` image traces nothing under graph replay and should not be recommended for profiling. Turning it into a real gate means splitting the publish job's `rocm/sgl-dev` and `lmsysorg` pushes, which is worth doing separately if you want that.

## Accuracy Tests

No model or kernel code changes; this adds a verification job to a release workflow.

## Speed Tests and Profiling

Not applicable. The job measures whether profiling works on the published image.

## Test plan

- `actionlint` reports nothing on the new job; the only findings in the file are the pre-existing self-hosted runner labels and `docker/login-action@v2` in the publish and mirror jobs.
- Job names pass `scripts/lint/check_workflow_job_names.py`.
- The job's gating was simulated across the combinations that matter — schedule, `all`/`all`, `publish`-only, a `rocm720` arch, a single `rocm724` arch, `verify_profiling` with a skipped publish, and publish `failure` vs `cancelled` — confirming it runs exactly the intended legs in each.
- The probe itself is unit-tested in #35390 (trace parsing, every verdict path) and validated for timeout handling and no-GPU behaviour.

`workflow_dispatch` only offers a workflow that exists on the default branch, so this cannot be exercised until it merges. Once it has, the fastest check is one already-published image on one GPU:

```bash
gh workflow run release-docker-amd-rocm720-nightly.yml --ref main \
  -f job_select=verify_profiling \
  -f probe_image=rocm/sgl-dev:v0.5.17-rocm724-mi35x-20260820 \
  -f gpu_arch=gfx950-rocm724
```

Expected `VERDICT: PASS`, against the same probe failing on a `*-rocm720-*` tag. A full `gh workflow run ... --ref main` then covers build plus both GPUs.

## Notes for reviewers

- Depends on #35390, which adds the probe script this job runs. Merge that first.
- This PR previously proposed its own `rocm724` stages, nightly workflow, release-matrix entry, and torch Triton-pin patch. #30984 landed all four, so only the verification remains.

## Measured on hardware

Dispatched against a branch carrying this job plus #35390's probe, targeting today's published image ([run](https://github.com/sgl-project/sglang/actions/runs/32337394284), 4.5 minutes end to end on `linux-mi35x-gpu-1`):

- `publish` and `push_local_registry` skipped, one `verify_profiling (gfx950-rocm724)` leg, artifact download skipped because `probe_image` was set — the gating behaved as intended.
- Image default: `graph replay: 448/512` → step outcome `failure`, job still green (`continue-on-error`), and the summary records it as `**Image default** (failure)`.
- ROCm runtime preloaded: `graph replay: 512/512` → PASS. `--print-ld-preload` inside the image produced `/opt/rocm/lib/libamdhip64.so.7.2.70204:/opt/rocm/lib/libroctracer64.so.4.1.70204`.

`workflow_dispatch` runs the definition from the selected ref, so this is exactly what the job will do once merged.


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). <!-- CI workflow change -->
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). <!-- Documented in #35390 -->
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). <!-- N/A -->
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32331314126](https://github.com/sgl-project/sglang/actions/runs/32331314126)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32422817619](https://github.com/sgl-project/sglang/actions/runs/32422817619)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
