### PR TITLE
[NVIDIA] Fix SM107 MXFP8 activation prep

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -485,13 +485,18 @@ if is_blackwell_supported() and is_flashinfer_available():
         alignment: int = 32,
         backend: str = "cute-dsl",
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        # Fake mode only needs dtypes and output rank to propagate compile graph.
-        # The scale tensor shape is not consumed before the following fake mm op.
         k_aligned = ((input.shape[1] + alignment - 1) // alignment) * alignment
         q_input = input.new_empty(
             (input.shape[0], k_aligned), dtype=torch.float8_e4m3fn
         )
-        scale = input.new_empty((1,), dtype=torch.uint8)
+        sf_columns = k_aligned // 32
+        if _is_sf_swizzled_layout:
+            padded_rows = ((input.shape[0] + 127) // 128) * 128
+            padded_sf_columns = ((sf_columns + 3) // 4) * 4
+            scale_size = padded_rows * padded_sf_columns
+        else:
+            scale_size = input.shape[0] * sf_columns
+        scale = input.new_empty((scale_size,), dtype=torch.uint8)
         return q_input, scale
 
     @register_custom_op(

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -425,9 +425,7 @@ def _fake_flashinfer_mxfp8_quantize(
     backend: str = "cute-dsl",
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     k_aligned = ((input.shape[1] + alignment - 1) // alignment) * alignment
-    q_input = input.new_empty(
-        (input.shape[0], k_aligned), dtype=torch.float8_e4m3fn
-    )
+    q_input = input.new_empty((input.shape[0], k_aligned), dtype=torch.float8_e4m3fn)
     sf_columns = k_aligned // 32
     if _is_sf_swizzled_layout:
         padded_rows = ((input.shape[0] + 127) // 128) * 128

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -424,15 +424,16 @@ def _fake_flashinfer_mxfp8_quantize(
     alignment: int = 32,
     backend: str = "cute-dsl",
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    k_aligned = ((input.shape[1] + alignment - 1) // alignment) * alignment
-    q_input = input.new_empty((input.shape[0], k_aligned), dtype=torch.float8_e4m3fn)
+    m = input.numel() // input.shape[-1]
+    k_aligned = ((input.shape[-1] + alignment - 1) // alignment) * alignment
+    q_input = input.new_empty((m, k_aligned), dtype=torch.float8_e4m3fn)
     sf_columns = k_aligned // 32
     if _is_sf_swizzled_layout:
-        padded_rows = ((input.shape[0] + 127) // 128) * 128
+        padded_rows = ((m + 127) // 128) * 128
         padded_sf_columns = ((sf_columns + 3) // 4) * 4
         scale_size = padded_rows * padded_sf_columns
     else:
-        scale_size = input.shape[0] * sf_columns
+        scale_size = m * sf_columns
     scale = input.new_empty((scale_size,), dtype=torch.uint8)
     return q_input, scale
 

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -418,6 +418,27 @@ if flashinfer_per_tensor_fp8_supported():
         ).view(m, n)
 
 
+def _fake_flashinfer_mxfp8_quantize(
+    input: torch.Tensor,
+    _is_sf_swizzled_layout: bool = True,
+    alignment: int = 32,
+    backend: str = "cute-dsl",
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    k_aligned = ((input.shape[1] + alignment - 1) // alignment) * alignment
+    q_input = input.new_empty(
+        (input.shape[0], k_aligned), dtype=torch.float8_e4m3fn
+    )
+    sf_columns = k_aligned // 32
+    if _is_sf_swizzled_layout:
+        padded_rows = ((input.shape[0] + 127) // 128) * 128
+        padded_sf_columns = ((sf_columns + 3) // 4) * 4
+        scale_size = padded_rows * padded_sf_columns
+    else:
+        scale_size = input.shape[0] * sf_columns
+    scale = input.new_empty((scale_size,), dtype=torch.uint8)
+    return q_input, scale
+
+
 if is_blackwell_supported() and is_flashinfer_available():
     from flashinfer import SfLayout
     from flashinfer import mm_mxfp8 as _raw_flashinfer_mm_mxfp8
@@ -479,26 +500,6 @@ if is_blackwell_supported() and is_flashinfer_available():
 
     # Wrap MXFP8 ops as custom ops so torch.compile does not trace into
     # flashinfer's JIT compilation path (filesystem checks/cubin loader).
-    def _fake_flashinfer_mxfp8_quantize(
-        input: torch.Tensor,
-        _is_sf_swizzled_layout: bool = True,
-        alignment: int = 32,
-        backend: str = "cute-dsl",
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
-        k_aligned = ((input.shape[1] + alignment - 1) // alignment) * alignment
-        q_input = input.new_empty(
-            (input.shape[0], k_aligned), dtype=torch.float8_e4m3fn
-        )
-        sf_columns = k_aligned // 32
-        if _is_sf_swizzled_layout:
-            padded_rows = ((input.shape[0] + 127) // 128) * 128
-            padded_sf_columns = ((sf_columns + 3) // 4) * 4
-            scale_size = padded_rows * padded_sf_columns
-        else:
-            scale_size = input.shape[0] * sf_columns
-        scale = input.new_empty((scale_size,), dtype=torch.uint8)
-        return q_input, scale
-
     @register_custom_op(
         op_name="flashinfer_mxfp8_quantize",
         mutates_args=[],

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import replace
+from functools import lru_cache
 from typing import TYPE_CHECKING, List, Optional
 
 import torch
@@ -75,6 +76,11 @@ has_triton_kernels = is_triton_kernels_available()
 _UE8M0_ONE = 127
 
 
+@lru_cache(maxsize=1)
+def _is_sm107_supported() -> bool:
+    return get_device_capability() == (10, 7)
+
+
 def _prepare_flashinfer_mxfp8_activations(
     x: torch.Tensor, hidden_size: int
 ) -> tuple[torch.Tensor, Optional[torch.Tensor], torch.Tensor, torch.Tensor]:
@@ -92,7 +98,7 @@ def _prepare_flashinfer_mxfp8_activations(
     if prepared is not None:
         prepared_packed_topk, x_quant, x_scale = prepared
         x_scale = x_scale.view(torch.float8_e4m3fn)
-    elif x.shape[-1] != hidden_size or get_device_capability() == (10, 7):
+    elif x.shape[-1] != hidden_size or _is_sm107_supported():
         from sglang.srt.layers.quantization.fp8_utils import (
             flashinfer_mxfp8_quantize,
         )

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -98,9 +98,7 @@ def _prepare_flashinfer_mxfp8_activations(
         )
 
         prepared_packed_topk = None
-        x_quant, x_scale = flashinfer_mxfp8_quantize(
-            x, False, alignment=hidden_size
-        )
+        x_quant, x_scale = flashinfer_mxfp8_quantize(x, False, alignment=hidden_size)
         x_scale = x_scale.view(torch.float8_e4m3fn).reshape(*x.shape[:-1], -1)
     else:
         from sglang.kernels.ops.quantization.per_token_group_quant import (
@@ -108,9 +106,7 @@ def _prepare_flashinfer_mxfp8_activations(
         )
 
         prepared_packed_topk = None
-        x_quant, x_scale = per_token_group_quant(
-            x, group_size=32, scale_ue8m0=True
-        )
+        x_quant, x_scale = per_token_group_quant(x, group_size=32, scale_ue8m0=True)
         x_scale = x_scale.view(torch.float8_e4m3fn)
 
     return x, prepared_packed_topk, x_quant, x_scale

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -51,6 +51,7 @@ from sglang.srt.layers.quantization.utils import is_layer_skipped
 from sglang.srt.runtime_context import get_exec
 from sglang.srt.utils import (
     cpu_has_amx_support,
+    get_device_capability,
     is_cpu,
     is_flashinfer_available,
     is_gfx95_supported,
@@ -72,6 +73,47 @@ has_triton_kernels = is_triton_kernels_available()
 # Serialized MXFP4 scales use raw UE8M0 bytes. Keep fresh parameters valid for
 # post-load transforms and dummy initialization; 127 is the neutral scale (1.0).
 _UE8M0_ONE = 127
+
+
+def _prepare_flashinfer_mxfp8_activations(
+    x: torch.Tensor, hidden_size: int
+) -> tuple[torch.Tensor, Optional[torch.Tensor], torch.Tensor, torch.Tensor]:
+    prepared = None
+    if x.shape[-1] == hidden_size:
+        if x.dim() > 2:
+            x = x.view(-1, x.shape[-1])
+        # K3's routing dispatch may already have quantized these rows and
+        # packed the topk ids. Other models use FlashInfer's own activation
+        # preparation so the producer matches the fused-MoE input contract.
+        from sglang.srt.layers.moe import route_quant_handoff
+
+        prepared = route_quant_handoff.take(x)
+
+    if prepared is not None:
+        prepared_packed_topk, x_quant, x_scale = prepared
+        x_scale = x_scale.view(torch.float8_e4m3fn)
+    elif x.shape[-1] != hidden_size or get_device_capability() == (10, 7):
+        from sglang.srt.layers.quantization.fp8_utils import (
+            flashinfer_mxfp8_quantize,
+        )
+
+        prepared_packed_topk = None
+        x_quant, x_scale = flashinfer_mxfp8_quantize(
+            x, False, alignment=hidden_size
+        )
+        x_scale = x_scale.view(torch.float8_e4m3fn).reshape(*x.shape[:-1], -1)
+    else:
+        from sglang.kernels.ops.quantization.per_token_group_quant import (
+            per_token_group_quant,
+        )
+
+        prepared_packed_topk = None
+        x_quant, x_scale = per_token_group_quant(
+            x, group_size=32, scale_ue8m0=True
+        )
+        x_scale = x_scale.view(torch.float8_e4m3fn)
+
+    return x, prepared_packed_topk, x_quant, x_scale
 
 
 if is_flashinfer_available():
@@ -1464,40 +1506,9 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                         value=0.0,
                     )
             elif self.flashinfer_mxfp4_moe_precision == "default":
-                if x.shape[-1] == self.hidden_size:
-                    if x.dim() > 2:
-                        x = x.view(-1, x.shape[-1])
-                    # K3 staged fusion (route_quant_handoff): the routing
-                    # dispatch already quantized these rows and packed the
-                    # topk ids in the fused route launch — consume both and
-                    # skip the two standalone kernels. Identity-verified;
-                    # a miss runs the unfused chain below.
-                    from sglang.srt.layers.moe import route_quant_handoff
-
-                    prepared = route_quant_handoff.take(x)
-                    if prepared is not None:
-                        prepared_packed_topk, x_quant, x_scale = prepared
-                        x_scale = x_scale.view(torch.float8_e4m3fn)
-                    else:
-                        from sglang.kernels.ops.quantization.per_token_group_quant import (
-                            per_token_group_quant,
-                        )
-
-                        x_quant, x_scale = per_token_group_quant(
-                            x, group_size=32, scale_ue8m0=True
-                        )
-                        x_scale = x_scale.view(torch.float8_e4m3fn)
-                else:
-                    from sglang.srt.layers.quantization.fp8_utils import (
-                        flashinfer_mxfp8_quantize,
-                    )
-
-                    x_quant, x_scale = flashinfer_mxfp8_quantize(
-                        x, False, alignment=self.hidden_size
-                    )
-                    x_scale = x_scale.view(torch.float8_e4m3fn).reshape(
-                        *x.shape[:-1], -1
-                    )
+                x, prepared_packed_topk, x_quant, x_scale = (
+                    _prepare_flashinfer_mxfp8_activations(x, self.hidden_size)
+                )
             else:
                 raise NotImplementedError()
 

--- a/test/registered/unit/layers/quantization/test_fp8_utils_mxfp4.py
+++ b/test/registered/unit/layers/quantization/test_fp8_utils_mxfp4.py
@@ -1,16 +1,42 @@
+"""CPU unit tests for MXFP4 conversion and MXFP8 fake-output metadata."""
+
 import unittest
 
 import torch
 
 from sglang.srt.layers.quantization.fp8_utils import (
+    _fake_flashinfer_mxfp8_quantize,
     quantize_block_fp8_weight_to_mxfp4,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=4, suite="base-a-test-cpu")
 
 
-class TestFp8UtilsMxfp4(unittest.TestCase):
+class TestFp8UtilsMxfp4(CustomTestCase):
+    def test_fake_flashinfer_mxfp8_quantize_linear_scale_shape(self):
+        input = torch.empty((3, 60), dtype=torch.bfloat16)
+
+        quantized, scale = _fake_flashinfer_mxfp8_quantize(
+            input, False, alignment=64
+        )
+
+        self.assertEqual(quantized.shape, torch.Size([3, 64]))
+        self.assertEqual(quantized.dtype, torch.float8_e4m3fn)
+        self.assertEqual(scale.shape, torch.Size([6]))
+        self.assertEqual(scale.dtype, torch.uint8)
+
+    def test_fake_flashinfer_mxfp8_quantize_swizzled_scale_shape(self):
+        input = torch.empty((3, 64), dtype=torch.bfloat16)
+
+        quantized, scale = _fake_flashinfer_mxfp8_quantize(
+            input, True, alignment=64
+        )
+
+        self.assertEqual(quantized.shape, torch.Size([3, 64]))
+        self.assertEqual(scale.shape, torch.Size([512]))
+
     def test_quantize_block_fp8_weight_to_mxfp4_shapes_and_dtype(self):
         fp8_weight = (
             torch.linspace(-2.0, 2.0, 32 * 32, dtype=torch.float32)

--- a/test/registered/unit/layers/quantization/test_fp8_utils_mxfp4.py
+++ b/test/registered/unit/layers/quantization/test_fp8_utils_mxfp4.py
@@ -16,13 +16,13 @@ register_cpu_ci(est_time=4, suite="base-a-test-cpu")
 
 class TestFp8UtilsMxfp4(CustomTestCase):
     def test_fake_flashinfer_mxfp8_quantize_linear_scale_shape(self):
-        input = torch.empty((3, 60), dtype=torch.bfloat16)
+        input = torch.empty((2, 3, 60), dtype=torch.bfloat16)
 
         quantized, scale = _fake_flashinfer_mxfp8_quantize(input, False, alignment=64)
 
-        self.assertEqual(quantized.shape, torch.Size([3, 64]))
+        self.assertEqual(quantized.shape, torch.Size([6, 64]))
         self.assertEqual(quantized.dtype, torch.float8_e4m3fn)
-        self.assertEqual(scale.shape, torch.Size([6]))
+        self.assertEqual(scale.shape, torch.Size([12]))
         self.assertEqual(scale.dtype, torch.uint8)
 
     def test_fake_flashinfer_mxfp8_quantize_swizzled_scale_shape(self):

--- a/test/registered/unit/layers/quantization/test_fp8_utils_mxfp4.py
+++ b/test/registered/unit/layers/quantization/test_fp8_utils_mxfp4.py
@@ -16,13 +16,14 @@ register_cpu_ci(est_time=4, suite="base-a-test-cpu")
 
 class TestFp8UtilsMxfp4(CustomTestCase):
     def test_fake_flashinfer_mxfp8_quantize_linear_scale_shape(self):
-        input = torch.empty((2, 3, 60), dtype=torch.bfloat16)
+        """The fake op must flatten leading dimensions and preserve scale groups."""
+        input = torch.empty((2, 3, 96), dtype=torch.bfloat16)
 
-        quantized, scale = _fake_flashinfer_mxfp8_quantize(input, False, alignment=64)
+        quantized, scale = _fake_flashinfer_mxfp8_quantize(input, False, alignment=128)
 
-        self.assertEqual(quantized.shape, torch.Size([6, 64]))
+        self.assertEqual(quantized.shape, torch.Size([6, 128]))
         self.assertEqual(quantized.dtype, torch.float8_e4m3fn)
-        self.assertEqual(scale.shape, torch.Size([12]))
+        self.assertEqual(scale.shape, torch.Size([24]))
         self.assertEqual(scale.dtype, torch.uint8)
 
     def test_fake_flashinfer_mxfp8_quantize_swizzled_scale_shape(self):

--- a/test/registered/unit/layers/quantization/test_fp8_utils_mxfp4.py
+++ b/test/registered/unit/layers/quantization/test_fp8_utils_mxfp4.py
@@ -18,9 +18,7 @@ class TestFp8UtilsMxfp4(CustomTestCase):
     def test_fake_flashinfer_mxfp8_quantize_linear_scale_shape(self):
         input = torch.empty((3, 60), dtype=torch.bfloat16)
 
-        quantized, scale = _fake_flashinfer_mxfp8_quantize(
-            input, False, alignment=64
-        )
+        quantized, scale = _fake_flashinfer_mxfp8_quantize(input, False, alignment=64)
 
         self.assertEqual(quantized.shape, torch.Size([3, 64]))
         self.assertEqual(quantized.dtype, torch.float8_e4m3fn)
@@ -30,9 +28,7 @@ class TestFp8UtilsMxfp4(CustomTestCase):
     def test_fake_flashinfer_mxfp8_quantize_swizzled_scale_shape(self):
         input = torch.empty((3, 64), dtype=torch.bfloat16)
 
-        quantized, scale = _fake_flashinfer_mxfp8_quantize(
-            input, True, alignment=64
-        )
+        quantized, scale = _fake_flashinfer_mxfp8_quantize(input, True, alignment=64)
 
         self.assertEqual(quantized.shape, torch.Size([3, 64]))
         self.assertEqual(scale.shape, torch.Size([512]))

--- a/test/registered/unit/layers/quantization/test_mxfp4_flashinfer_activation_prep.py
+++ b/test/registered/unit/layers/quantization/test_mxfp4_flashinfer_activation_prep.py
@@ -1,5 +1,6 @@
 """CPU unit tests for MXFP8 activation-preparation dispatch."""
 
+import importlib
 import unittest
 from unittest.mock import patch
 
@@ -12,6 +13,10 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+per_token_group_quant_module = importlib.import_module(
+    "sglang.kernels.ops.quantization.per_token_group_quant"
+)
 
 
 class TestMxfp4FlashinferActivationPrep(CustomTestCase):
@@ -51,8 +56,8 @@ class TestMxfp4FlashinferActivationPrep(CustomTestCase):
         ), patch(
             "sglang.srt.layers.quantization.mxfp4._is_sm107_supported",
             return_value=False,
-        ), patch(
-            "sglang.kernels.ops.quantization.per_token_group_quant."
+        ), patch.object(
+            per_token_group_quant_module,
             "per_token_group_quant",
             return_value=(x_quant, x_scale),
         ) as quantize, patch(

--- a/test/registered/unit/layers/quantization/test_mxfp4_flashinfer_activation_prep.py
+++ b/test/registered/unit/layers/quantization/test_mxfp4_flashinfer_activation_prep.py
@@ -76,9 +76,10 @@ class TestMxfp4FlashinferActivationPrep(CustomTestCase):
         self.assertTrue(torch.equal(actual_scale.view(torch.uint8), x_scale))
 
     def test_padded_input_keeps_flashinfer_quantizer(self):
-        x = torch.randn(3, 60, dtype=torch.bfloat16)
-        x_quant = torch.empty(3, 64, dtype=torch.float8_e4m3fn)
-        x_scale = torch.arange(6, dtype=torch.uint8)
+        """A group-aligned input must use hidden-size-aligned quantization."""
+        x = torch.randn(3, 96, dtype=torch.bfloat16)
+        x_quant = torch.empty(3, 128, dtype=torch.float8_e4m3fn)
+        x_scale = torch.arange(12, dtype=torch.uint8)
 
         with patch(
             "sglang.srt.layers.quantization.fp8_utils.flashinfer_mxfp8_quantize",
@@ -86,15 +87,15 @@ class TestMxfp4FlashinferActivationPrep(CustomTestCase):
             create=True,
         ) as quantize, patch("sglang.srt.layers.moe.route_quant_handoff.take") as take:
             actual_x, packed_topk, actual_quant, actual_scale = (
-                _prepare_flashinfer_mxfp8_activations(x, 64)
+                _prepare_flashinfer_mxfp8_activations(x, 128)
             )
 
         take.assert_not_called()
-        quantize.assert_called_once_with(x, False, alignment=64)
+        quantize.assert_called_once_with(x, False, alignment=128)
         self.assertIs(actual_x, x)
         self.assertIsNone(packed_topk)
         self.assertIs(actual_quant, x_quant)
-        self.assertEqual(actual_scale.shape, torch.Size([3, 2]))
+        self.assertEqual(actual_scale.shape, torch.Size([3, 4]))
 
     def test_kimi_handoff_skips_flashinfer_quantizer(self):
         x = torch.randn(2, 64, dtype=torch.bfloat16)

--- a/test/registered/unit/layers/quantization/test_mxfp4_flashinfer_activation_prep.py
+++ b/test/registered/unit/layers/quantization/test_mxfp4_flashinfer_activation_prep.py
@@ -1,0 +1,121 @@
+import unittest
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.layers.quantization.mxfp4 import (
+    _prepare_flashinfer_mxfp8_activations,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestMxfp4FlashinferActivationPrep(unittest.TestCase):
+    def test_sm107_handoff_miss_uses_flashinfer_quantizer(self):
+        x = torch.randn(3, 64, dtype=torch.bfloat16)
+        x_quant = torch.empty(3, 64, dtype=torch.float8_e4m3fn)
+        x_scale = torch.arange(6, dtype=torch.uint8).reshape(3, 2)
+
+        with patch(
+            "sglang.srt.layers.moe.route_quant_handoff.take", return_value=None
+        ) as take, patch(
+            "sglang.srt.layers.quantization.mxfp4.get_device_capability",
+            return_value=(10, 7),
+        ), patch(
+            "sglang.srt.layers.quantization.fp8_utils.flashinfer_mxfp8_quantize",
+            return_value=(x_quant, x_scale),
+            create=True,
+        ) as quantize:
+            actual_x, packed_topk, actual_quant, actual_scale = (
+                _prepare_flashinfer_mxfp8_activations(x, 64)
+            )
+
+        take.assert_called_once_with(x)
+        quantize.assert_called_once_with(x, False, alignment=64)
+        self.assertIs(actual_x, x)
+        self.assertIsNone(packed_topk)
+        self.assertIs(actual_quant, x_quant)
+        self.assertTrue(torch.equal(actual_scale.view(torch.uint8), x_scale))
+
+    def test_other_sm10x_handoff_miss_keeps_triton_quantizer(self):
+        x = torch.randn(3, 64, dtype=torch.bfloat16)
+        x_quant = torch.empty(3, 64, dtype=torch.float8_e4m3fn)
+        x_scale = torch.arange(6, dtype=torch.uint8).reshape(3, 2)
+
+        with patch(
+            "sglang.srt.layers.moe.route_quant_handoff.take", return_value=None
+        ), patch(
+            "sglang.srt.layers.quantization.mxfp4.get_device_capability",
+            return_value=(10, 0),
+        ), patch(
+            "sglang.kernels.ops.quantization.per_token_group_quant."
+            "per_token_group_quant",
+            return_value=(x_quant, x_scale),
+        ) as quantize, patch(
+            "sglang.srt.layers.quantization.fp8_utils.flashinfer_mxfp8_quantize",
+            create=True,
+        ) as flashinfer_quantize:
+            actual_x, packed_topk, actual_quant, actual_scale = (
+                _prepare_flashinfer_mxfp8_activations(x, 64)
+            )
+
+        quantize.assert_called_once_with(x, group_size=32, scale_ue8m0=True)
+        flashinfer_quantize.assert_not_called()
+        self.assertIs(actual_x, x)
+        self.assertIsNone(packed_topk)
+        self.assertIs(actual_quant, x_quant)
+        self.assertTrue(torch.equal(actual_scale.view(torch.uint8), x_scale))
+
+    def test_padded_input_keeps_flashinfer_quantizer(self):
+        x = torch.randn(3, 60, dtype=torch.bfloat16)
+        x_quant = torch.empty(3, 64, dtype=torch.float8_e4m3fn)
+        x_scale = torch.arange(6, dtype=torch.uint8)
+
+        with patch(
+            "sglang.srt.layers.quantization.mxfp4.get_device_capability",
+            return_value=(10, 0),
+        ), patch(
+            "sglang.srt.layers.quantization.fp8_utils.flashinfer_mxfp8_quantize",
+            return_value=(x_quant, x_scale),
+            create=True,
+        ) as quantize, patch(
+            "sglang.srt.layers.moe.route_quant_handoff.take"
+        ) as take:
+            actual_x, packed_topk, actual_quant, actual_scale = (
+                _prepare_flashinfer_mxfp8_activations(x, 64)
+            )
+
+        take.assert_not_called()
+        quantize.assert_called_once_with(x, False, alignment=64)
+        self.assertIs(actual_x, x)
+        self.assertIsNone(packed_topk)
+        self.assertIs(actual_quant, x_quant)
+        self.assertEqual(actual_scale.shape, torch.Size([3, 2]))
+
+    def test_kimi_handoff_skips_flashinfer_quantizer(self):
+        x = torch.randn(2, 64, dtype=torch.bfloat16)
+        packed_topk = torch.zeros(2, 4, dtype=torch.int32)
+        x_quant = torch.empty(2, 64, dtype=torch.float8_e4m3fn)
+        x_scale = torch.arange(4, dtype=torch.uint8).reshape(2, 2)
+
+        with patch(
+            "sglang.srt.layers.moe.route_quant_handoff.take",
+            return_value=(packed_topk, x_quant, x_scale),
+        ), patch(
+            "sglang.srt.layers.quantization.fp8_utils.flashinfer_mxfp8_quantize",
+            create=True,
+        ) as quantize:
+            actual_x, actual_packed, actual_quant, actual_scale = (
+                _prepare_flashinfer_mxfp8_activations(x, 64)
+            )
+
+        quantize.assert_not_called()
+        self.assertIs(actual_x, x)
+        self.assertIs(actual_packed, packed_topk)
+        self.assertIs(actual_quant, x_quant)
+        self.assertTrue(torch.equal(actual_scale.view(torch.uint8), x_scale))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/quantization/test_mxfp4_flashinfer_activation_prep.py
+++ b/test/registered/unit/layers/quantization/test_mxfp4_flashinfer_activation_prep.py
@@ -23,8 +23,8 @@ class TestMxfp4FlashinferActivationPrep(CustomTestCase):
         with patch(
             "sglang.srt.layers.moe.route_quant_handoff.take", return_value=None
         ) as take, patch(
-            "sglang.srt.layers.quantization.mxfp4.get_device_capability",
-            return_value=(10, 7),
+            "sglang.srt.layers.quantization.mxfp4._is_sm107_supported",
+            return_value=True,
         ), patch(
             "sglang.srt.layers.quantization.fp8_utils.flashinfer_mxfp8_quantize",
             return_value=(x_quant, x_scale),
@@ -49,8 +49,8 @@ class TestMxfp4FlashinferActivationPrep(CustomTestCase):
         with patch(
             "sglang.srt.layers.moe.route_quant_handoff.take", return_value=None
         ), patch(
-            "sglang.srt.layers.quantization.mxfp4.get_device_capability",
-            return_value=(10, 0),
+            "sglang.srt.layers.quantization.mxfp4._is_sm107_supported",
+            return_value=False,
         ), patch(
             "sglang.kernels.ops.quantization.per_token_group_quant."
             "per_token_group_quant",
@@ -76,15 +76,10 @@ class TestMxfp4FlashinferActivationPrep(CustomTestCase):
         x_scale = torch.arange(6, dtype=torch.uint8)
 
         with patch(
-            "sglang.srt.layers.quantization.mxfp4.get_device_capability",
-            return_value=(10, 0),
-        ), patch(
             "sglang.srt.layers.quantization.fp8_utils.flashinfer_mxfp8_quantize",
             return_value=(x_quant, x_scale),
             create=True,
-        ) as quantize, patch(
-            "sglang.srt.layers.moe.route_quant_handoff.take"
-        ) as take:
+        ) as quantize, patch("sglang.srt.layers.moe.route_quant_handoff.take") as take:
             actual_x, packed_topk, actual_quant, actual_scale = (
                 _prepare_flashinfer_mxfp8_activations(x, 64)
             )

--- a/test/registered/unit/layers/quantization/test_mxfp4_flashinfer_activation_prep.py
+++ b/test/registered/unit/layers/quantization/test_mxfp4_flashinfer_activation_prep.py
@@ -1,3 +1,5 @@
+"""CPU unit tests for MXFP8 activation-preparation dispatch."""
+
 import unittest
 from unittest.mock import patch
 
@@ -7,11 +9,12 @@ from sglang.srt.layers.quantization.mxfp4 import (
     _prepare_flashinfer_mxfp8_activations,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=2, suite="base-a-test-cpu")
 
 
-class TestMxfp4FlashinferActivationPrep(unittest.TestCase):
+class TestMxfp4FlashinferActivationPrep(CustomTestCase):
     def test_sm107_handoff_miss_uses_flashinfer_quantizer(self):
         x = torch.randn(3, 64, dtype=torch.bfloat16)
         x_quant = torch.empty(3, 64, dtype=torch.float8_e4m3fn)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Fix MXFP8 activation preparation for the FlashInfer MXFP4 MoE backend on SM107.

GPT-OSS on SM107 can reach the FlashInfer MXFP4 MoE kernel without a pre-quantized route handoff. Previously, SGLang used the Triton per-token-group quantizer in this case. This does not reliably produce the activation representation expected by the FlashInfer SM107 path.

The quantizer producing the activations must follow the same MXFP8 and UE8M0 layout contract as the FlashInfer MoE kernel consuming them. Using FlashInfer for both operations on SM107 avoids the incompatible producer/consumer path.
The fake custom-op implementation also needs the real scale-buffer shape. Returning a placeholder one-element tensor can produce incorrect metadata during `torch.compile`.

## Modifications

<!-- Detail the changes made in this pull request. -->
- Use FlashInfer's MXFP8 quantizer on SM107 when no route/quant handoff is available.
- Preserve Kimi K3's existing fused route/quant handoff.
- Preserve the existing Triton activation-quantization path on other SM10x architectures.
- Preserve FlashInfer quantization for padded hidden dimensions.
- Correct the FlashInfer custom-op fake scale-buffer size for both linear and swizzled layouts so `torch.compile` metadata matches the real quantizer.
- Add CPU regression tests covering dispatch behavior, padded inputs, route handoff, and fake output shapes.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
* Validated GPT-OSS with real weights on SM107 with 4 focused regression tests passed on SM107.
* Verified the fake quantizer reports the expected scale shape.
* Python compilation and `git diff --check` passed.

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32610396899](https://github.com/sgl-project/sglang/actions/runs/32610396899)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32610396767](https://github.com/sgl-project/sglang/actions/runs/32610396767)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #32610396864](https://github.com/sgl-project/sglang/actions/runs/32610396864)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->