### PR TITLE
fix(multimodal): let load_video accept an already-constructed decoder

### DIFF
--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -1962,12 +1962,21 @@ def get_video_bytes(video_file: Union[str, bytes, VideoData]) -> bytes:
     raise ValueError(f"Unsupported video input type: {type(video_file)}")
 
 
-def load_video(video_file: Union[str, bytes, VideoData], use_gpu: bool = True):
+def load_video(
+    video_file: Union[str, bytes, VideoData, VideoDecoderWrapper], use_gpu: bool = True
+):
     if isinstance(video_file, VideoData):
         # preprocess_kwargs is consumed by the multimodal processor, not here.
         video_file = video_file.url
 
     if isinstance(video_file, (list, tuple, torch.Tensor, np.ndarray)):
+        return video_file
+
+    # Already-decoded input: a caller that constructed the decoder itself (or is
+    # re-entering with this function's own return value) must not be rejected.
+    # _normalize_video_input has no case for VideoDecoderWrapper, so without this
+    # the call falls through to "Unsupported video input type".
+    if isinstance(video_file, VideoDecoderWrapper):
         return video_file
 
     source = _normalize_video_input(video_file)

--- a/test/registered/unit/multimodal/test_load_video_passthrough.py
+++ b/test/registered/unit/multimodal/test_load_video_passthrough.py
@@ -1,0 +1,57 @@
+"""Unit tests for ``load_video`` accepting an already-constructed decoder.
+
+``load_video`` returns a ``VideoDecoderWrapper`` for a URL/path/bytes source, so
+handing that value back to it must be a no-op rather than an error. Callers that
+build the decoder themselves (a custom backend, a caller that already fetched the
+bytes under its own network policy) depend on the same behaviour.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+from unittest.mock import patch
+
+import numpy as np
+import torch
+
+from sglang.srt.utils.common import load_video
+from sglang.test.test_utils import CustomTestCase
+
+
+class _StubDecoder:
+    """Stands in for VideoDecoderWrapper so the test needs no decoder backend."""
+
+
+class TestLoadVideoAcceptsDecoder(CustomTestCase):
+    def test_decoder_instance_passes_through(self):
+        decoder = _StubDecoder()
+        with patch("sglang.srt.utils.common.VideoDecoderWrapper", _StubDecoder):
+            self.assertIs(load_video(decoder), decoder)
+
+    def test_passthrough_is_idempotent(self):
+        decoder = _StubDecoder()
+        with patch("sglang.srt.utils.common.VideoDecoderWrapper", _StubDecoder):
+            self.assertIs(load_video(load_video(decoder)), decoder)
+
+    def test_pre_decoded_frame_types_still_pass_through(self):
+        # Regression guard: the new branch must not shadow the existing ones.
+        for frames in (
+            [1, 2, 3],
+            (1, 2, 3),
+            np.zeros((2, 4, 4, 3), dtype=np.uint8),
+            torch.zeros(2, 4, 4, 3, dtype=torch.uint8),
+        ):
+            with self.subTest(kind=type(frames).__name__):
+                self.assertIs(load_video(frames), frames)
+
+    def test_unsupported_type_still_raises(self):
+        # The passthrough must not turn every unknown object into a valid input.
+        with patch("sglang.srt.utils.common.VideoDecoderWrapper", _StubDecoder):
+            with self.assertRaises(ValueError):
+                load_video(object())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`load_video` returns a `VideoDecoderWrapper` for a URL/path/bytes source, but rejects one on the way in. `_normalize_video_input` has no case for that type and returns `None`, so the call raises `ValueError: Unsupported video input type`. The function is therefore not idempotent with respect to its own return value.

This blocks any caller that constructs the decoder itself — a custom decode backend, or a caller that fetched the bytes under its own network policy and wants SGLang to keep owning frame selection via `smart_nframes`. Today such a caller has to pre-sample frames and hand over a bare `ndarray`, which takes the `not is_video_obj` early return in `preprocess_video` and bypasses the `video_config` policy (`fps` / `nframes` / `min_frames` / `max_frames`) entirely.

## Modifications

- `python/sglang/srt/utils/common.py`: pass a `VideoDecoderWrapper` through, next to the existing `list`/`tuple`/`Tensor`/`ndarray` passthrough, and widen the type hint. Unsupported types still raise.
- Added `test/registered/unit/multimodal/test_load_video_passthrough.py` (CPU, no decoder backend needed — `VideoDecoderWrapper` is patched with a stub).

## Accuracy Tests

Not applicable — no change to model outputs. This only widens accepted input types on the decode path.

## Speed Tests and Profiling

Not applicable — one `isinstance` check on a non-hot path.

## Validation

Verified against `lmsysorg/sglang:nightly-dev-cu13-20260818-c0b6474b` by patching the image's own source tree at `/sgl-workspace/sglang` (editable install, so source and binaries match), torch 2.13.0+cu130, transformers 5.12.1:

```
BEFORE  RAISED ValueError: Unsupported video input type: <class 'Stub'>
AFTER   passthrough returned Stub, is-same: True
```

New unit test: 2 failed / 2 passed before the fix (the two failures being the passthrough cases, the passes being the regression guards for the existing types), 4 passed after. Also reproduced on `v0.5.16-cu130-runtime` and `v0.5.17-cu130-runtime`.

## Checklist

- [x] Format your code according to the Format code with pre-commit.
- [x] Add unit tests according to the Run and add unit tests.
- [ ] Update documentation according to Write documentations.
- [ ] Provide accuracy and speed benchmark results — not applicable, see above.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32196807882](https://github.com/sgl-project/sglang/actions/runs/32196807882)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32196807536](https://github.com/sgl-project/sglang/actions/runs/32196807536)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->