### PR TITLE
fix(disagg): allow fake transfer with decode DCP

### DIFF
--- a/python/sglang/srt/arg_groups/pd_disaggregation_hook.py
+++ b/python/sglang/srt/arg_groups/pd_disaggregation_hook.py
@@ -44,7 +44,7 @@ def handle_pd_disaggregation(server_args: ServerArgs) -> None:
         ):
             raise ValueError(
                 "PD decode DCP requires --disaggregation-transfer-backend "
-                "mooncake or nixl (or fake for synthetic benchmarking), got "
+                "mooncake, nixl, or fake for synthetic benchmarking, got "
                 f"{server_args.disaggregation_transfer_backend!r}."
             )
         if server_args.disaggregation_decode_enable_radix_cache:

--- a/python/sglang/srt/arg_groups/pd_disaggregation_hook.py
+++ b/python/sglang/srt/arg_groups/pd_disaggregation_hook.py
@@ -35,10 +35,16 @@ def handle_pd_disaggregation(server_args: ServerArgs) -> None:
         )
 
     if server_args.disaggregation_mode == "decode" and server_args.dcp_size > 1:
-        if server_args.disaggregation_transfer_backend not in ("mooncake", "nixl"):
+        # Fake transfer moves no KV and is only used for synthetic decode
+        # benchmarks, so it does not need the DCP relayout from Mooncake/NIXL.
+        if server_args.disaggregation_transfer_backend not in (
+            "mooncake",
+            "nixl",
+            "fake",
+        ):
             raise ValueError(
                 "PD decode DCP requires --disaggregation-transfer-backend "
-                "mooncake or nixl, got "
+                "mooncake or nixl (or fake for synthetic benchmarking), got "
                 f"{server_args.disaggregation_transfer_backend!r}."
             )
         if server_args.disaggregation_decode_enable_radix_cache:

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -519,7 +519,9 @@ class TestLoadBalanceMethod(unittest.TestCase):
             disaggregation_transfer_backend="mori",
             dcp_size=4,
         )
-        with self.assertRaisesRegex(ValueError, "mooncake or nixl"):
+        with self.assertRaisesRegex(
+            ValueError, "mooncake, nixl, or fake for synthetic benchmarking"
+        ):
             server_args._handle_pd_disaggregation()
 
     def test_pd_decode_dcp_allows_fake_transfer_backend(self):

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -516,11 +516,19 @@ class TestLoadBalanceMethod(unittest.TestCase):
         server_args = ServerArgs(
             model_path="dummy",
             disaggregation_mode="decode",
-            disaggregation_transfer_backend="fake",
+            disaggregation_transfer_backend="mori",
             dcp_size=4,
         )
         with self.assertRaisesRegex(ValueError, "mooncake or nixl"):
             server_args._handle_pd_disaggregation()
+
+    def test_pd_decode_dcp_allows_fake_transfer_backend(self):
+        server_args = self._load_balance_args(
+            disaggregation_mode="decode",
+            disaggregation_transfer_backend="fake",
+            dcp_size=4,
+        )
+        self.assertTrue(server_args.disable_radix_cache)
 
     def test_pd_decode_dcp_rejects_radix_cache(self):
         server_args = ServerArgs(


### PR DESCRIPTION
## Motivation

Decode-only synthetic benchmarks use the fake disaggregation backend, which moves no KV data. The decode-DCP validation currently rejects it because production transfer backends require DCP KV relayout.

## Modifications

- Allow the fake transfer backend with decode DCP.
- Keep the existing chunk-cache and hierarchical-cache restrictions unchanged.
- Preserve rejection coverage for unsupported transfer backends and add coverage for the fake path.

## Accuracy Tests

Not applicable; this changes server-argument validation only.

## Speed Tests and Profiling

Not applicable.

## Checklist

- [x] Format the changed code according to the project style.
- [x] Add unit-test coverage for the changed validation behavior.
- [x] No documentation update is required for this internal synthetic-benchmark backend.
- [x] No accuracy or speed result changes are expected.
- [x] Follow the SGLang code-style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32293570242](https://github.com/sgl-project/sglang/actions/runs/32293570242)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32293570010](https://github.com/sgl-project/sglang/actions/runs/32293570010)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->