### PR TITLE
fix(multimodal): resolve image token counts for decoded image tensors

### DIFF
--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -190,6 +190,24 @@ class MultimodalSpecialTokens:
         return self.combined_regex
 
 
+def _image_height_width(image) -> Tuple[int, int]:
+    """Return ``(height, width)`` for a PIL image or a decoded image tensor.
+
+    ``gpu_image_decode`` is on by default and routes JPEG payloads through
+    ``torchvision.io.decode_jpeg``, which yields a CHW ``uint8`` tensor. Such a
+    tensor has no PIL ``height``/``width`` attributes, so callers that assume
+    them raise ``AttributeError`` on the most common image format.
+    """
+    if isinstance(image, torch.Tensor):
+        if image.ndim < 2:
+            raise ValueError(f"Invalid image tensor shape: {tuple(image.shape)}")
+        # Decoded image tensors are channels-first (CHW / NCHW), so the spatial
+        # dimensions are always the trailing two.
+        height, width = image.shape[-2:]
+        return int(height), int(width)
+    return int(image.height), int(image.width)
+
+
 class BaseMultimodalProcessor(ABC):
     models = []
     gpu_image_decode = True  # Enable GPU decoding by default
@@ -1524,7 +1542,7 @@ class BaseMultimodalProcessor(ABC):
 
         """
         assert images is not None
-        image_sizes = [(image.height, image.width) for image in images]
+        image_sizes = [_image_height_width(image) for image in images]
         num_image_tokens = self._processor._get_num_multimodal_tokens(
             image_sizes=image_sizes
         ).num_image_tokens

--- a/test/registered/unit/multimodal/test_resolve_image_token_counts_tensor.py
+++ b/test/registered/unit/multimodal/test_resolve_image_token_counts_tensor.py
@@ -1,0 +1,85 @@
+"""Unit tests for image-size resolution on decoded image tensors.
+
+``gpu_image_decode`` is on by default and returns a CHW ``uint8`` tensor for
+JPEG payloads. ``resolve_image_token_counts`` must read the dimensions off such
+a tensor, not only off PIL images, or ``SGLANG_MM_AVOID_RETOKENIZE`` silently
+falls back to decode+retokenize for the most common image format.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import torch
+
+from sglang.srt.multimodal.processors.base_processor import (
+    BaseMultimodalProcessor,
+    _image_height_width,
+)
+from sglang.test.test_utils import CustomTestCase
+
+
+class _StubProcessor(BaseMultimodalProcessor):
+    # Only resolve_image_token_counts is exercised, so no model or GPU is
+    # required -- but BaseMultimodalProcessor is an ABC, so the abstract method
+    # still has to exist for the class to be instantiable.
+    async def process_mm_data_async(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def __init__(self, num_image_tokens):
+        self._processor = MagicMock()
+        self._processor._get_num_multimodal_tokens.return_value = SimpleNamespace(
+            num_image_tokens=num_image_tokens
+        )
+
+
+class TestImageHeightWidth(CustomTestCase):
+    def test_chw_tensor(self):
+        self.assertEqual(_image_height_width(torch.zeros(3, 480, 640)), (480, 640))
+
+    def test_nchw_tensor(self):
+        self.assertEqual(_image_height_width(torch.zeros(1, 3, 480, 640)), (480, 640))
+
+    def test_pil_like_object(self):
+        self.assertEqual(
+            _image_height_width(SimpleNamespace(height=480, width=640)), (480, 640)
+        )
+
+    def test_degenerate_tensor_rejected(self):
+        with self.assertRaises(ValueError):
+            _image_height_width(torch.zeros(7))
+
+
+class TestResolveImageTokenCounts(CustomTestCase):
+    def test_tensor_images_resolve_without_error(self):
+        # Before the fix this raised AttributeError: 'Tensor' object has no
+        # attribute 'height', which the caller swallowed into a retokenize
+        # fallback.
+        processor = _StubProcessor([12, 34])
+        images = [torch.zeros(3, 480, 640), torch.zeros(3, 224, 224)]
+
+        counts = processor.resolve_image_token_counts(images)
+
+        self.assertEqual(counts, [12, 34])
+        processor._processor._get_num_multimodal_tokens.assert_called_once_with(
+            image_sizes=[(480, 640), (224, 224)]
+        )
+
+    def test_mixed_pil_and_tensor_images(self):
+        processor = _StubProcessor([1, 2])
+        images = [SimpleNamespace(height=32, width=64), torch.zeros(3, 480, 640)]
+
+        counts = processor.resolve_image_token_counts(images)
+
+        self.assertEqual(counts, [1, 2])
+        processor._processor._get_num_multimodal_tokens.assert_called_once_with(
+            image_sizes=[(32, 64), (480, 640)]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`BaseMultimodalProcessor.resolve_image_token_counts` reads `image.height` / `image.width`, which only exist on PIL images. But `gpu_image_decode` is `True` by default (`base_processor.py`), and `load_image` routes JPEG payloads through `torchvision.io.decode_jpeg(..., device="cuda")`, which returns a CHW `uint8` tensor. So the **default** configuration feeds this method a value it cannot read:

```
AttributeError: 'Tensor' object has no attribute 'height'
```

The failure is easy to miss because the call site wraps the block in `except Exception` and logs:

> `Due to {e}, falling back to decode+retokenize, which may change prompt length (token drift).`

The practical effect is that `SGLANG_MM_AVOID_RETOKENIZE` — whose entire purpose is to avoid that drift — silently does nothing for JPEG images whenever GPU decode is on. It degrades to a warning rather than an error, so the feature looks enabled while never taking effect on the most common image format.

## Modifications

- `python/sglang/srt/multimodal/processors/base_processor.py`: add a small `_image_height_width` helper that reads the trailing two axes for a `torch.Tensor` (decoded image tensors are channels-first, so the spatial dims are always last) and keeps the PIL attribute path otherwise. `resolve_image_token_counts` uses it.
- Added `test/registered/unit/multimodal/test_resolve_image_token_counts_tensor.py` (CPU, no model or GPU required).

Mixed lists of PIL images and tensors are handled, and a degenerate tensor (`ndim < 2`) raises `ValueError` rather than silently producing a wrong size.

## Accuracy Tests

This change *restores* accuracy rather than affecting it: with the fix, `SGLANG_MM_AVOID_RETOKENIZE` can keep the user's exact tokens for JPEG images instead of falling back to decode+retokenize, which is the path that can change prompt length.

## Speed Tests and Profiling

Not applicable — an `isinstance` check per image, off the hot path. It does avoid an unnecessary retokenize when the flag is enabled.

## Validation

Verified against `lmsysorg/sglang:nightly-dev-cu13-20260818-c0b6474b` by patching the image's own source tree at `/sgl-workspace/sglang` (editable install, so source and binaries match), torch 2.13.0+cu130, transformers 5.12.1:

```
BEFORE  RAISED AttributeError: 'Tensor' object has no attribute 'height'
AFTER   [7]
```

New unit test: fails to even import before the fix, 6 passed after. Also reproduced on `v0.5.16-cu130-runtime` and `v0.5.17-cu130-runtime`.

## Checklist

- [x] Format your code according to the Format code with pre-commit.
- [x] Add unit tests according to the Run and add unit tests.
- [ ] Update documentation according to Write documentations.
- [ ] Provide accuracy and speed benchmark results — not applicable, see above.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32196829036](https://github.com/sgl-project/sglang/actions/runs/32196829036)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32196828914](https://github.com/sgl-project/sglang/actions/runs/32196828914)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->