### PR TITLE
fix(encode-server): do not forward None video metadata to the processor

### DIFF
--- a/python/sglang/srt/disaggregation/encode_server.py
+++ b/python/sglang/srt/disaggregation/encode_server.py
@@ -802,7 +802,21 @@ class MMEncoder:
             ]
             videos, video_metadata = map(list, zip(*video_processed))
             video_processor_kwargs["do_sample_frames"] = False
-            if video_metadata:
+            # preprocess_video returns (video, None) for input that was already
+            # decoded upstream, so video_metadata can contain Nones -- and such a
+            # list is still truthy. transformers' make_batched_metadata only
+            # converts a list whose first element is a list or a dict; one that
+            # holds None falls through both branches and is returned unchanged,
+            # so the consumer dereferences None ("'NoneType' object has no
+            # attribute 'fps'"). Passing nothing is strictly better than passing
+            # Nones: make_batched_metadata then synthesizes total_num_frames,
+            # width, height and frames_indices from the video itself. The list is
+            # positionally parallel to `videos`, so individual entries cannot be
+            # dropped without breaking alignment -- forward it only when every
+            # entry is present.
+            if video_metadata and all(
+                metadata is not None for metadata in video_metadata
+            ):
                 video_processor_kwargs["video_metadata"] = video_metadata
             return videos, video_processor_kwargs
         else:

--- a/test/registered/unit/multimodal/test_encode_server_video_metadata.py
+++ b/test/registered/unit/multimodal/test_encode_server_video_metadata.py
@@ -1,0 +1,88 @@
+"""Unit tests for the video_metadata kwarg built by ``_flatten_and_load_videos``.
+
+``preprocess_video`` returns ``(video, None)`` for input that was already decoded
+upstream, so the metadata list can hold ``None``. Such a list must not reach the
+processor: transformers' ``make_batched_metadata`` passes it through unchanged
+and the consumer then dereferences ``None``. Omitting the kwarg is better --
+transformers synthesizes the fields from the video itself.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import asyncio
+import unittest
+from concurrent.futures import Future
+from unittest.mock import patch
+
+from sglang.srt.disaggregation.encode_server import MMEncoder
+from sglang.test.test_utils import CustomTestCase
+
+_META = {
+    "fps": 24.0,
+    "duration": 1.0,
+    "total_num_frames": 24,
+    "frames_indices": list(range(24)),
+}
+
+
+class _StubEncoder:
+    """Carries only what _flatten_and_load_videos touches -- no model, no GPU."""
+
+    model_type = "qwen2_5_vl"
+    vision_config = {"video": {}}
+
+    def submit_data_loading_tasks(self, items, modalities):
+        futures = []
+        for item in items:
+            future: Future = Future()
+            future.set_result(item)
+            futures.append(future)
+        return futures, None
+
+    # Exercise the real implementation, bound to the stub.
+    _flatten_and_load_videos = MMEncoder._flatten_and_load_videos
+
+
+def _run(videos, metadata):
+    """Run _flatten_and_load_videos with preprocess_video yielding `metadata`."""
+    calls = iter(metadata)
+
+    async def _fake_preprocess_video(video, video_config=None):
+        return video, next(calls)
+
+    async def _go():
+        with patch(
+            "sglang.srt.disaggregation.encode_server.preprocess_video",
+            _fake_preprocess_video,
+        ):
+            return await _StubEncoder()._flatten_and_load_videos(videos)
+
+    return asyncio.run(_go())
+
+
+class TestFlattenAndLoadVideosMetadata(CustomTestCase):
+    def test_all_none_metadata_is_not_forwarded(self):
+        # The regression: [None] is truthy, so an emptiness-only guard forwards it.
+        _, kwargs = _run(["a", "b"], [None, None])
+        self.assertNotIn("video_metadata", kwargs)
+        self.assertIs(kwargs["do_sample_frames"], False)
+
+    def test_real_metadata_is_forwarded(self):
+        _, kwargs = _run(["a", "b"], [_META, _META])
+        self.assertEqual(kwargs["video_metadata"], [_META, _META])
+
+    def test_mixed_metadata_is_not_forwarded(self):
+        # The list is positionally parallel to `videos`, so a None entry cannot
+        # be dropped without misaligning the rest -- omit the kwarg instead.
+        _, kwargs = _run(["a", "b"], [_META, None])
+        self.assertNotIn("video_metadata", kwargs)
+
+    def test_videos_are_returned_in_order(self):
+        videos, _ = _run(["a", "b", "c"], [None, None, None])
+        self.assertEqual(videos, ["a", "b", "c"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`MMEncoder._flatten_and_load_videos` guards the `video_metadata` kwarg with `if video_metadata:`, which tests the list for **emptiness** rather than for content:

```python
videos, video_metadata = map(list, zip(*video_processed))
video_processor_kwargs["do_sample_frames"] = False
if video_metadata:
    video_processor_kwargs["video_metadata"] = video_metadata
```

`preprocess_video` returns `(video, None)` whenever its input is not a `VideoDecoderWrapper` — i.e. for video that was already decoded upstream and handed over as frames. The guard then sees `[None]` (or `[None, None, ...]`), finds it truthy, and forwards it.

transformers' `make_batched_metadata` converts the value only when it is `None` (synthesizing defaults), or when it is a list whose first element is a `list` or a `dict`. A list holding `None` matches neither branch and is returned unchanged, so the consumer dereferences `None`.

Measured against transformers 5.12.1:

```
video_metadata=None    -> [VideoMetadata(total_num_frames=4, width=8, height=8,
                           frames_indices=[0, 1, 2, 3], ...)]
video_metadata=[None]  -> [None]         -> .fps raises
                          AttributeError: 'NoneType' object has no attribute 'fps'
video_metadata=[{...}] -> [VideoMetadata(..., fps=24.0)]
```

So omitting the kwarg is strictly *better* than forwarding `None`s: transformers then derives `total_num_frames`, `width`, `height` and `frames_indices` from the video itself.

## Modifications

- `python/sglang/srt/disaggregation/encode_server.py`: forward `video_metadata` only when every entry is present. The list is positionally parallel to `videos`, so individual entries cannot be dropped without misaligning the rest — hence `all(...)` rather than `any(...)`; a partially-populated list is omitted entirely.
- Added `test/registered/unit/multimodal/test_encode_server_video_metadata.py` covering all-`None`, all-real, mixed, and ordering (CPU, no model or GPU required).

## Accuracy Tests

Not applicable — no change to model outputs. When metadata is present the behavior is unchanged; when it is absent the processor now receives no kwarg instead of `None` entries.

## Speed Tests and Profiling

Not applicable — one pass over a list whose length is the number of videos in the request.

## Validation

Verified against `lmsysorg/sglang:nightly-dev-cu13-20260818-c0b6474b` by patching the image's own source tree at `/sgl-workspace/sglang` (editable install, so source and binaries match), torch 2.13.0+cu130, transformers 5.12.1.

New unit test against the shipped `encode_server.py`: **2 failed, 2 passed** — the failures are exactly `test_all_none_metadata_is_not_forwarded` and `test_mixed_metadata_is_not_forwarded`, while the real-metadata and ordering controls pass. After the fix: **4 passed**.

## Checklist

- [x] Format your code according to the Format code with pre-commit.
- [x] Add unit tests according to the Run and add unit tests.
- [ ] Update documentation according to Write documentations.
- [ ] Provide accuracy and speed benchmark results — not applicable, see above.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32196854673](https://github.com/sgl-project/sglang/actions/runs/32196854673)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32196854541](https://github.com/sgl-project/sglang/actions/runs/32196854541)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->