### PR TITLE
[Speculative] Derive the DSpark verify-budget cost table at CUDA graph capture

### DIFF
--- a/docs/docs/references/environment_variables.mdx
+++ b/docs/docs/references/environment_variables.mdx
@@ -1709,6 +1709,11 @@ SGLang supports various environment variables that can be used to configure its 
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Sanitize NaN logits before sampling kernels and emit a throttled warning.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>true</code></td>
     </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>SGLANG_DSPARK_ENABLE_CAPTURE_DERIVED_SPS</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Measure the DSpark verify-budget SPS cost table by timing the CUDA graphs at the end of capture, instead of the uninitialized flat table that pins the budget to verify-all. Applies only to <code>SGLANG_RAGGED_VERIFY_MODE=compact</code>; a table supplied with <code>--speculative-dspark-sps-table-path</code> takes precedence and disables it. Adds a few seconds to startup and nothing to serving.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>false</code></td>
+    </tr>
   </tbody>
 </table>
 

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -481,6 +481,11 @@ class Envs:
     SGLANG_DSPARK_BLOCK_ACCEPT_ESTIMATE_PATH = EnvStr("")
     SGLANG_DSPARK_BLOCK_ACCEPT_ONLINE_INTERVAL = EnvInt(0)
     SGLANG_DSPARK_ENABLE_SPS_RECORD = EnvBool(False)
+    # Measure the ragged-verify cost table from the captured verify/draft CUDA graphs at startup,
+    # instead of shipping the uninitialized flat table that pins the budget to verify-all. Compact mode only.
+    # --speculative-dspark-sps-table-path wins: a table loaded from disk is not uninitialized, so
+    # the derivation is never armed and this flag has no effect.
+    SGLANG_DSPARK_ENABLE_CAPTURE_DERIVED_SPS = EnvBool(False)
     SGLANG_DSPARK_FAST_KERNEL = EnvBool(True)
     SGLANG_DSPARK_FP32_LM_HEAD = EnvBool(False)
     SGLANG_DSPARK_FAST_SAMPLING = EnvBool(True)

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -128,6 +128,19 @@ if TYPE_CHECKING:
     from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 
 
+def _subsample_keeping_ends(values: list[int], limit: int) -> list[int]:
+    """At most `limit` evenly spaced entries, always including the first and the last.
+
+    The widest shape must survive: consumers treat it as the top of the measured range, and dropping
+    it would silently shrink what the curve covers.
+    """
+    if limit < 2 or len(values) <= limit:
+        return list(values)
+    step = (len(values) - 1) / (limit - 1)
+    picked = sorted({int(round(i * step)) for i in range(limit)} | {0, len(values) - 1})
+    return [values[i] for i in picked]
+
+
 def ragged_verify_compact_graphs_enabled(spec_algorithm: SpeculativeAlgorithm) -> bool:
     if not spec_algorithm.supports_ragged_verify():
         return False
@@ -512,6 +525,109 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         buckets = sorted({bs * self.captured_req_width for bs in self.capture_bs})
         assert buckets and buckets[0] > 0, f"{buckets=}"
         return buckets
+
+    def measure_captured_replay_seconds(
+        self, *, max_probes: int, warmup: int, reps: int
+    ) -> list[tuple[int, float, float]]:
+        """Replay cost of captured graphs, as (shape, median_seconds, spread_seconds) triples.
+
+        The shape key is the token count for compact ragged verify graphs and the batch size
+        otherwise, matching how each family is captured and keyed.
+
+        **The work is identical on every rank by construction**: the same subsampled shapes in the
+        same order, and a fixed replay count per shape. A captured graph contains the model's
+        collectives, so a rank that replays a different number of times leaves its peers waiting
+        forever. Nothing here may depend on a locally measured value -- an adaptive replay count or
+        a wall-clock early exit deadlocks tensor-parallel startup, which is not a hypothetical.
+
+        Cost is bounded by subsampling rather than by timing: at most `max_probes` shapes, always
+        including the widest, since callers use it as the top of their range. The total is
+        `max_probes * (warmup + reps)` graph replays, i.e. a fixed multiple of one decode step.
+
+        `spread_seconds` is the full range of the samples: how well this measurement resolves a cost
+        difference at all. Callers need it, because cost curves are nearly flat across the narrow
+        shapes and would otherwise encode replay noise as signal. The range rather than a percentile
+        stays meaningful at small sample counts, and it errs wide, which makes consumers flatten
+        rather than sharpen.
+
+        Returns an empty list when there is nothing to measure, so callers keep their cost model.
+        """
+        shapes = self.capture_num_tokens if self.ragged_verify_mode else self.capture_bs
+        if not shapes:
+            return []
+        probes = _subsample_keeping_ends(sorted(shapes), max_probes)
+
+        measurements: list[tuple[int, float, float]] = []
+        for shape in probes:
+            shape_key = self._make_graph_key(shape)
+            try:
+                self._stage_serving_shaped_layout(shape)
+                for _ in range(warmup):
+                    self.backend.replay_captured_shape(shape_key)
+                self.device_module.synchronize()
+                samples_ms = [self._time_one_replay_ms(shape_key) for _ in range(reps)]
+            except (NotImplementedError, KeyError):
+                # Backend cannot replay a bare shape, or this shape was never captured. Both are
+                # properties of the captured set, so every rank takes this branch at the same
+                # shape. A partial curve is worse than none, so give the caller nothing.
+                return []
+            finally:
+                self._restore_capture_shaped_layout(shape)
+            samples_ms.sort()
+            measurements.append(
+                (
+                    int(shape),
+                    samples_ms[len(samples_ms) // 2] / 1000.0,
+                    (samples_ms[-1] - samples_ms[0]) / 1000.0,
+                )
+            )
+        return measurements
+
+    def _stage_serving_shaped_layout(self, num_tokens: int) -> None:
+        """Point a captured verify graph at the row layout serving will actually use.
+
+        Capture packs a tier into `min(num_tokens, max_bs)` rows, so at the wide tiers it is many
+        rows of one or two tokens -- a shape no verify step ever runs. Serving refreshes
+        verify_lens / qo_indptr in place before every replay, so timing must do the same or it
+        prices the wrong work: for a tier of `m` tokens it would measure `min(m, max_bs)` rows where
+        a full verify step has `m / width`, and the cost of a row is not the cost of a token.
+
+        The chosen shape, `m / width` rows of `width` tokens, is a verify-all step at that width --
+        the same conditioning the offline profiler documents itself as measuring.
+        """
+        self._restage_ragged_layout(num_tokens, num_tokens // self.captured_req_width)
+
+    def _restore_capture_shaped_layout(self, num_tokens: int) -> None:
+        """Put the capture-time layout back, so timing leaves no state behind."""
+        self._restage_ragged_layout(num_tokens, self._ragged_capture_slots(num_tokens))
+
+    def _restage_ragged_layout(self, num_tokens: int, num_slots: int) -> None:
+        if not self.ragged_verify_mode or num_slots < 1:
+            return
+        from sglang.srt.speculative.ragged_verify import (
+            RaggedVerifyLayout,
+            build_capture_verify_lens,
+        )
+
+        layout = RaggedVerifyLayout.from_verify_lens(
+            verify_lens_cpu=build_capture_verify_lens(
+                num_tokens=num_tokens,
+                num_slots=num_slots,
+                num_draft_tokens=self.captured_req_width,
+            ),
+            device=self.device,
+            grid=self.capture_num_tokens,
+        )
+        self._stage_ragged_verify_layout(layout, num_tokens)
+
+    def _time_one_replay_ms(self, shape_key: ShapeKey) -> float:
+        start = self.device_module.Event(enable_timing=True)
+        end = self.device_module.Event(enable_timing=True)
+        start.record()
+        self.backend.replay_captured_shape(shape_key)
+        end.record()
+        end.synchronize()
+        return start.elapsed_time(end)
 
     def _autotune_buffers(self):
         """Reuse these static decode buffers (sized to max_bs) for the warmup

--- a/python/sglang/srt/model_executor/runner_backend/base_cuda_graph_backend.py
+++ b/python/sglang/srt/model_executor/runner_backend/base_cuda_graph_backend.py
@@ -79,5 +79,23 @@ class BaseCudaGraphBackend(ABC):
         **kwargs,
     ) -> Any: ...
 
+    def replay_captured_shape(self, shape_key: ShapeKey) -> None:
+        """Replay one captured graph as-is, leaving the static buffers as capture left them.
+
+        For capture-time cost measurement, where there is no ForwardBatch to bind. A captured graph
+        replays a fixed kernel DAG, so its launch configuration is a property of the captured shape
+        and not of the buffer contents.
+
+        Duration is a weaker claim than launch configuration, and it does not hold everywhere. Where
+        a kernel's work depends on values read from device memory -- MoE routing being the clear case,
+        since token-to-expert assignment drives per-expert GEMM extents and dispatch volume -- the
+        replay is timed under whatever distribution capture happened to leave behind, which is not
+        the one serving produces. Treat a curve derived this way as approximate on such models.
+
+        Backends that cannot replay without a bound batch leave this unimplemented and the caller
+        falls back to not measuring.
+        """
+        raise NotImplementedError
+
     @abstractmethod
     def cleanup(self) -> None: ...

--- a/python/sglang/srt/model_executor/runner_backend/full_cuda_graph_backend.py
+++ b/python/sglang/srt/model_executor/runner_backend/full_cuda_graph_backend.py
@@ -150,6 +150,9 @@ class FullCudaGraphBackend(BaseCudaGraphBackend):
         self._graphs[shape_key].replay()
         return self._outputs[shape_key]
 
+    def replay_captured_shape(self, shape_key: ShapeKey) -> None:
+        self._graphs[shape_key].replay()
+
     def cleanup(self) -> None:
         self._graphs.clear()
         self._outputs.clear()

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2126,9 +2126,14 @@ class ServerArgs:
         Optional[str],
         "DSPARK only. Path to a pre-profiled SPS cost table (JSON) built offline with "
         "sglang.benchmark.dspark_sps_profiler, consumed by the ragged-verify "
-        "scheduler (cap-accept / compact). Omit for an uninitialized flat "
-        "constant-SPS table: the budget degenerates to verify-all (zero throughput "
-        "gain by itself).",
+        "scheduler (cap-accept / compact). Takes precedence over "
+        "SGLANG_DSPARK_ENABLE_CAPTURE_DERIVED_SPS: a table loaded from this path is "
+        "not the uninitialized flat table, so the capture-time derivation is never armed and "
+        "that variable has no effect. Omit it unless you want to pin a specific "
+        "curve. With neither -- in cap-accept mode, with the derivation disabled, or "
+        "when the measurement is unusable -- the table stays an uninitialized flat "
+        "constant-SPS curve and the budget degenerates to verify-all (zero "
+        "throughput gain by itself).",
         NS("spec"),
     ] = None
     speculative_dspark_confidence_sts_path: A[

--- a/python/sglang/srt/speculative/dspark_components/dspark_planner.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_planner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from typing import Optional, Union
 
 import msgspec
@@ -28,6 +29,7 @@ from sglang.srt.speculative.dspark_components.dspark_sps import (
     SpsAdditiveCostTable,
     SpsCostTable,
     _interp_clamped,
+    build_capture_derived_sps_table,
     build_uninitialized_sps_table,
     is_uninitialized_sps_table,
     load_sps_table_from_path,
@@ -52,6 +54,43 @@ from sglang.srt.utils.invariants import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Bounds on the capture-time cost sweep. Spend it on PROBE DENSITY rather than on repeats: the
+# lookup is a floor step function, so a sparse grid becomes wide plateaus and the chosen budget
+# quantises to the end of whichever plateau it lands in, while a replay is reproducible enough that
+# a median over five samples is already tight (measured spread is well under 1% of the median). A
+# coarser grid also errs toward the cheaper neighbour, i.e. toward wider budgets and so toward
+# today's verify-all, which is the safe direction to be wrong in.
+#
+# The counts are fixed rather than adaptive so that every rank performs exactly the same replays:
+# captured graphs carry the model's collectives, and a rank that replays a different number of times
+# hangs its peers.
+
+# A derived curve only earns the right to trim when it predicts a win worth having. How much a
+# deployment can win was read directly, by forcing each budget fraction at a fixed load through
+# /set_internal_state -- that measures the objective rather than modelling it. On a Qwen3-4B target
+# at concurrency 48 every fraction from 0.3 to 1.0 lands within noise of verifying everything, so
+# trimming there is a small net loss; on Qwen3-14B the same sweep has a clear interior peak.
+#
+# The threshold separates "the model sees a real win" from "the model sees rounding". It is a regime
+# separator rather than a tuned constant: swept over 0.05-0.35, the deployments that gain move by
+# less than the run-to-run spread between 0.05 and 0.20, and only start giving the gain back beyond
+# that. Raising it is the safe direction -- behaviour moves monotonically towards verify-all, so a
+# threshold set too high forfeits gain but cannot introduce a regression.
+CAPTURE_DERIVED_SPS_MIN_GAIN = 0.05
+CAPTURE_DERIVED_SPS_MAX_PROBES = 40
+CAPTURE_DERIVED_SPS_WARMUP = 2
+CAPTURE_DERIVED_SPS_REPS = 5
+
+
+def _rows_to_probes(*, rows: list[list[float]]) -> list[tuple[int, float, float]]:
+    """Read back (shape, seconds, spread) rows, dropping the ones nobody measured."""
+    return [
+        (int(shape), seconds, spread)
+        for shape, seconds, spread in rows
+        if shape >= 1.0 and seconds > 0.0
+    ]
+
 
 # DSpark confidence is a per-token score that must stay in [0, 1].
 _CONFIDENCE = Invariant(
@@ -83,6 +122,7 @@ class DSparkVerifyPlanner:
         self.gamma = gamma
         self.model_runner = model_runner
         self.device = device
+        self.tp_rank = tp_rank
         self.server_args = server_args
         self.verify_num_draft_tokens = verify_num_draft_tokens
         self._align_verify_tokens_to_graph_tier = (
@@ -136,6 +176,13 @@ class DSparkVerifyPlanner:
         self._dp_tier_gather_enabled = False
         self._is_verify_all = True
         self._uniform_layout_cache: dict = {}
+        # Set only when this planner installs a table it measured itself. The full-window fast path
+        # below keys off it so that a deployment which did not opt in -- including one running a
+        # profiled table from disk -- keeps exactly the scheduling path it has today.
+        self._derived_sps_installed = False
+        # Assigned before the mode branch: install_capture_derived_sps_table() is called
+        # unconditionally after capture, including in static mode where the branch below never runs.
+        self._derive_sps_at_capture = False
         if self._ragged_verify_mode is not RaggedVerifyMode.STATIC:
             if self._confidence_head is None:
                 raise ValueError(
@@ -154,6 +201,25 @@ class DSparkVerifyPlanner:
             self._is_verify_all = (
                 self._ragged_verify_mode is RaggedVerifyMode.COMPACT
                 and is_uninitialized_sps_table(sps_table)
+            )
+            # A cost model can be measured from the verify graphs the compact path already
+            # captures, which happens after this constructor runs. Decide here, install later.
+            #
+            # --speculative-dspark-sps-table-path wins, and does so by construction rather than by
+            # an explicit branch: a table loaded from disk is not uninitialized, so
+            # is_uninitialized_sps_table is False, _is_verify_all is False, and the derivation is
+            # never armed. An operator who pinned a curve keeps exactly that curve.
+            #
+            # Compact only, via _is_verify_all above, and deliberately: cap-accept runs its target
+            # forward at full uniform width and its budget only caps acceptance afterwards, so a
+            # cost curve there could lose accepted tokens without saving any compute.
+            # Excluded when a simulated acceptance length is forcing a verify-all schedule: the
+            # validation below keys off is_verify_all, so deriving a table would silently
+            # invalidate a check that has already passed.
+            self._derive_sps_at_capture = (
+                self._is_verify_all
+                and envs.SGLANG_DSPARK_ENABLE_CAPTURE_DERIVED_SPS.get()
+                and not simulate_acc_len_needs_verify_all()
             )
             relay_lag_steps = (
                 0
@@ -198,14 +264,226 @@ class DSparkVerifyPlanner:
                         )
                     ),
                 )
-                if isinstance(sps_table, SpsCostTable) and is_uninitialized_sps_table(
-                    sps_table
+                if (
+                    isinstance(sps_table, SpsCostTable)
+                    and is_uninitialized_sps_table(sps_table)
+                    and not self._derive_sps_at_capture
                 ):
                     logger.warning(
                         "DSpark SPS table is uninitialized (flat): the verify "
                         "budget degenerates to verify-all (zero scheduling gain). "
                         "Pass a profiled --speculative-dspark-sps-table-path."
                     )
+
+    def install_capture_derived_sps_table(self, *, draft_model_runner) -> None:
+        """Replace the uninitialized cost model with one measured from the captured graphs.
+
+        Runs after CUDA graph capture, because that is the earliest point the measurement exists:
+        this planner is constructed during worker init, which happens before capture.
+
+        Without a profiled table the cost model is a single probe reporting the same steps-per-sec
+        for every batch size, i.e. "a step costs the same no matter how wide it is". Under that
+        model the budget objective is strictly increasing and argmax always lands on verify-all, so
+        the planner cannot trim however good its confidence estimates are. The compact path already
+        captures one verify graph per token tier, so replaying those tiers yields a real cost curve
+        over exactly the axis the planner looks up.
+
+        Opt-in via SGLANG_DSPARK_ENABLE_CAPTURE_DERIVED_SPS: whether trimming pays is a property of
+        the deployment, not of the cost model. Where the throughput-versus-budget curve is flat,
+        acting on a predicted gain costs accepted tokens for a time saving that does not materialise,
+        so a deployment should measure before enabling this.
+
+        Every failure leaves the uninitialized table in place: this is a startup optimisation and must never
+        be able to stop the engine from starting.
+        """
+        if not self._derive_sps_at_capture:
+            return
+        self._derive_sps_at_capture = False
+
+        if not ragged_verify_graphs_are_replayable(model_runner=self.model_runner):
+            # The captured graphs will never be replayed on this backend, so timing them would price
+            # a path the engine does not take. Keep the uninitialized table: verify-all, exactly as today.
+            if self.tp_rank == 0:
+                runner = self.model_runner.decode_cuda_graph_runner
+                reason = (
+                    "decode CUDA graphs are disabled"
+                    if runner is None
+                    else f"{type(runner.attn_backend).__name__} does not replay ragged verify graphs"
+                )
+                logger.info(
+                    "DSpark capture-derived SPS table skipped: %s, so replay time does not "
+                    "describe a verify step. The verify budget stays at verify-all.",
+                    reason,
+                )
+            return
+
+        started = time.perf_counter()
+        try:
+            verify_probes, draft_probes = self._measure_step_cost_probes(
+                draft_model_runner=draft_model_runner
+            )
+        except Exception:
+            # A startup optimisation must never stop the engine starting. The collective inside is
+            # deliberately outside this guard -- see _measure_step_cost_probes.
+            logger.warning(
+                "DSpark capture-time SPS derivation failed; keeping the uninitialized table.",
+                exc_info=True,
+            )
+            verify_probes, draft_probes = [], []
+        elapsed = time.perf_counter() - started
+
+        sps_table = build_capture_derived_sps_table(
+            verify_probes=verify_probes, draft_probes=draft_probes
+        )
+        if sps_table is None:
+            if self.tp_rank == 0:
+                logger.warning(
+                    "DSpark SPS table is uninitialized (flat) and could not be derived from the "
+                    "captured verify graphs (%d usable probes): the verify budget degenerates to "
+                    "verify-all (zero scheduling gain). Pass a profiled "
+                    "--speculative-dspark-sps-table-path.",
+                    len(verify_probes),
+                )
+            return
+
+        self._budget_planner.sps_table = sps_table
+        self._schedule_cfg.min_predicted_gain = CAPTURE_DERIVED_SPS_MIN_GAIN
+        self._derived_sps_installed = True
+        # The verify-all fast path short-circuits schedule_layout before the budget is consulted,
+        # and its cached uniform layouts were built for that path, so both must go with the table.
+        self._is_verify_all = False
+        self._uniform_layout_cache = {}
+        if self.tp_rank == 0:
+            logger.info(
+                "DSpark SPS table derived from %d verify tiers and %d draft batch sizes in %.2f s; "
+                "the verify budget is now scheduled. Verify cost (tokens: ms) %s. Draft cost "
+                "(requests: ms) %s. Unset SGLANG_DSPARK_ENABLE_CAPTURE_DERIVED_SPS to restore "
+                "verify-all.",
+                len(sps_table.m_probes),
+                len(sps_table.bs_probes),
+                elapsed,
+                ", ".join(
+                    f"{tokens}: {seconds * 1000.0:.2f}"
+                    for tokens, seconds in zip(
+                        sps_table.m_probes, sps_table.theta_seconds
+                    )
+                ),
+                ", ".join(
+                    f"{reqs}: {seconds * 1000.0:.2f}"
+                    for reqs, seconds in zip(
+                        sps_table.bs_probes, sps_table.alpha_seconds
+                    )
+                ),
+            )
+
+    def _measure_step_cost_probes(
+        self, *, draft_model_runner
+    ) -> tuple[list[tuple[int, float, float]], list[tuple[int, float, float]]]:
+        """Measure both axes of the step cost, replicated identically across ranks.
+
+        A verify graph replay covers the target forward, whose cost tracks the token count. The step
+        the planner prices also runs the draft model, whose cost tracks the request count and is
+        already spent by the time a budget is chosen. Both ladders are captured, so both terms are
+        measurable here, and they are returned separately -- see build_capture_derived_sps_table for
+        why collapsing them onto one axis is what makes the curve wrong.
+
+        The result is broadcast from rank 0: the chosen budget selects which captured graph a step
+        replays, so ranks planning against different curves would replay different shapes and their
+        in-graph collectives would not match.
+
+        Only the local measurement may fail. The broadcast is unconditional, because a rank that
+        skipped it would leave its peers blocked in the collective for the distributed timeout --
+        a worse failure than the one the measurement was guarded against. A rank that measured
+        nothing contributes zeros and takes rank 0's curves; if rank 0 is the one that failed, every
+        rank ends up with zeros and keeps the uninitialized table together.
+        """
+        tiers = ragged_capture_num_tokens(model_runner=self.model_runner)
+        if not tiers:
+            return [], []
+
+        # Shape depends only on the tier list and a constant -- never on what this rank measured --
+        # which is what keeps the collective below deadlock-free.
+        costs = torch.zeros(
+            (len(tiers) + CAPTURE_DERIVED_SPS_MAX_PROBES, 3),
+            dtype=torch.float64,
+            device=self.device,
+        )
+        try:
+            self._fill_local_step_costs(
+                costs=costs, tiers=tiers, draft_model_runner=draft_model_runner
+            )
+        except Exception:
+            logger.warning(
+                "DSpark capture-time cost measurement failed on this rank; falling back to "
+                "whatever rank 0 measured.",
+                exc_info=True,
+            )
+
+        broadcast_group, group_size = verify_lens_broadcast_group(
+            tp_size=get_parallel().tp_size
+        )
+        if group_size > 1:
+            broadcast_group.broadcast(costs, src=0)
+
+        rows = costs.tolist()
+        return _rows_to_probes(rows=rows[: len(tiers)]), _rows_to_probes(
+            rows=rows[len(tiers) :]
+        )
+
+    def _fill_local_step_costs(
+        self, *, costs: torch.Tensor, tiers: list[int], draft_model_runner
+    ) -> None:
+        """Time this rank's captured graphs into `costs` as (shape, seconds, spread) rows.
+
+        Verify tiers take the first `len(tiers)` rows, keyed by total verify tokens; draft batch
+        sizes take the rest, keyed by request count. Rows this rank could not measure stay zero and
+        are dropped after the broadcast.
+
+        The fixed shape is what makes the broadcast deadlock-free: it does not depend on how many
+        probes this rank managed to measure.
+        """
+        measure_kwargs = dict(
+            max_probes=CAPTURE_DERIVED_SPS_MAX_PROBES,
+            warmup=CAPTURE_DERIVED_SPS_WARMUP,
+            reps=CAPTURE_DERIVED_SPS_REPS,
+        )
+        verify_measured = (
+            self.model_runner.decode_cuda_graph_runner.measure_captured_replay_seconds(
+                **measure_kwargs
+            )
+        )
+        tier_index = {tier: i for i, tier in enumerate(tiers)}
+        for tier, seconds, spread in verify_measured:
+            self._write_cost_row(
+                costs=costs,
+                row=tier_index[tier],
+                shape=tier,
+                seconds=seconds,
+                spread=spread,
+            )
+
+        draft_runner = draft_model_runner.decode_cuda_graph_runner
+        if draft_runner is None:
+            return
+        draft_measured = draft_runner.measure_captured_replay_seconds(**measure_kwargs)
+        for offset, (batch_size, seconds, spread) in enumerate(
+            draft_measured[:CAPTURE_DERIVED_SPS_MAX_PROBES]
+        ):
+            self._write_cost_row(
+                costs=costs,
+                row=len(tiers) + offset,
+                shape=batch_size,
+                seconds=seconds,
+                spread=spread,
+            )
+
+    @staticmethod
+    def _write_cost_row(
+        *, costs: torch.Tensor, row: int, shape: int, seconds: float, spread: float
+    ) -> None:
+        costs[row, 0] = float(shape)
+        costs[row, 1] = seconds
+        costs[row, 2] = spread
 
     @property
     def carries_confidence(self) -> bool:
@@ -404,6 +682,25 @@ class DSparkVerifyPlanner:
             )
         )
 
+    def _budget_covers_full_window(self, *, bs: int, budget: Optional[int]) -> bool:
+        """Would this budget let every request verify its whole window?
+
+        A real cost table makes `_is_verify_all` False for the engine's lifetime, but the planner
+        still returns a full-width budget whenever trimming does not pay -- on a deployment with no
+        headroom, that is every step. Without this the engine would pay the per-step schedule and its
+        host<->device round-trips to arrive at the layout the cache already holds, which is a
+        measured regression on models that gain nothing from trimming.
+
+        The test is deliberately the *sufficient* one: at this budget the top-k can fill every
+        window, so the uniform layout is what verify-all serves today. Anything less falls through
+        to the scheduler.
+        """
+        if budget is None:
+            return False
+        cfg = self._schedule_cfg
+        widest = cfg.resolved_max_verify_len() - cfg.min_verify_len
+        return budget >= bs * widest
+
     def schedule_layout(
         self,
         *,
@@ -417,7 +714,13 @@ class DSparkVerifyPlanner:
     ) -> Optional[RaggedVerifyLayout]:
         if self._ragged_verify_mode is RaggedVerifyMode.STATIC:
             return None
-        if self._is_verify_all and self._ragged_verify_mode is RaggedVerifyMode.COMPACT:
+        serves_full_window = self._is_verify_all or (
+            self._derived_sps_installed
+            and self._budget_covers_full_window(
+                bs=int(req_pool_indices.shape[0]), budget=budget
+            )
+        )
+        if serves_full_window and self._ragged_verify_mode is RaggedVerifyMode.COMPACT:
             # Verify-all: the uniform layout (or None, past the captured grid)
             # is constant per (bs, tier); serve it from cache instead of paying
             # the per-step schedule and its host<->device round-trips.
@@ -808,6 +1111,25 @@ def ragged_capture_max_slots(*, model_runner) -> Optional[int]:
     return runner.max_bs
 
 
+def ragged_verify_graphs_are_replayable(*, model_runner) -> bool:
+    """Will a verify step ever replay one of the captured ragged graphs?
+
+    Capture records a verify graph per token tier regardless, but the runner's admission test starts
+    at `attn_backend.supports_ragged_verify_graph`, and a backend that does not implement the ragged
+    metadata path fails it on every step -- hybrid linear-attention targets, for instance, whose GDN
+    backend leaves the base class default of False.
+
+    On such a target the captured graphs are recorded and never replayed, so a cost model derived by
+    timing them describes a path the engine does not take. Deriving one there is worse than useless:
+    it spends the measurement, and then hands the planner a curve with no bearing on the step it is
+    pricing.
+    """
+    runner = model_runner.decode_cuda_graph_runner
+    if runner is None or not runner.ragged_verify_mode:
+        return False
+    return bool(runner.attn_backend.supports_ragged_verify_graph)
+
+
 def ragged_layout_exceeds_captured_grid(
     *,
     num_reqs: int,
@@ -916,6 +1238,9 @@ class DSparkScheduleConfig(msgspec.Struct):
     min_verify_len: int = 1
     max_verify_len: int = 0
     survival_eps: float = 1e-6
+    # Smallest predicted throughput gain, relative to verifying everything, that justifies trimming
+    # at all. Zero keeps the historical behaviour of always taking the argmax.
+    min_predicted_gain: float = 0.0
 
     def resolved_max_verify_len(self) -> int:
         return self.max_verify_len or (self.gamma + 1)
@@ -937,6 +1262,18 @@ class VerifyBudgetDecision(msgspec.Struct):
     budget: int
     predicted_step_seconds: Optional[float] = None
     predicted_theta: Optional[float] = None
+
+
+def simulate_acc_len_needs_verify_all() -> bool:
+    """True when SGLANG_SIMULATE_ACC_LEN pins the schedule to verify-all.
+
+    A constant simulated correct_len > 0 can exceed a trimmed request's verify budget and break the
+    cutoff accounting, so DSparkWorkerV2 refuses that combination at construction. Deriving a cost
+    table happens afterwards and would flip the planner off verify-all, so both the admission check
+    and the derivation read this one predicate rather than each carrying a copy.
+    """
+    simulate_acc_len = float(envs.SGLANG_SIMULATE_ACC_LEN.get())
+    return simulate_acc_len > 0.0 and simulate_acc_len != 1.0
 
 
 def compute_verify_token_budget(
@@ -963,13 +1300,13 @@ def compute_verify_token_budget(
             num_budgets=int(tau_star.numel()),
         )
         theta = tau_star / step_time
-        idx = int(torch.argmax(theta))
+        idx = _argmax_worth_trimming(theta=theta, min_gain=cfg.min_predicted_gain)
         predicted_step_seconds = float(step_time[idx])
     else:
         batch_tokens = num_requests + torch.arange(tau_star.numel(), dtype=torch.int64)
         sps = _lookup_sps_tensor(sps_table=sps_table, batch_tokens=batch_tokens)
         theta = tau_star * sps
-        idx = int(torch.argmax(theta))
+        idx = _argmax_worth_trimming(theta=theta, min_gain=cfg.min_predicted_gain)
         sps_at_idx = float(sps[idx])
         predicted_step_seconds = 1.0 / sps_at_idx if sps_at_idx > 0 else None
     return VerifyBudgetDecision(
@@ -977,6 +1314,27 @@ def compute_verify_token_budget(
         predicted_step_seconds=predicted_step_seconds,
         predicted_theta=float(theta[idx]),
     )
+
+
+def _argmax_worth_trimming(*, theta: torch.Tensor, min_gain: float) -> int:
+    """Best budget, unless the predicted win over verifying everything is too small to be worth it.
+
+    Trimming is not free even when the cost model likes it: fewer drafted tokens are verified, so a
+    step that would have committed them has to earn the loss back in reduced step time. Where the
+    cost curve is nearly flat -- small models, low load -- the predicted win shrinks to noise while
+    the accepted-token loss stays real, and acting on it is a measured throughput regression.
+
+    Verify-all is the last index because tau_star is strictly increasing, so it is also the baseline
+    to beat. `min_gain` of zero reproduces a plain argmax.
+    """
+    idx = int(torch.argmax(theta))
+    if min_gain <= 0.0:
+        return idx
+    verify_all = int(theta.numel()) - 1
+    baseline = float(theta[verify_all])
+    if baseline <= 0.0 or float(theta[idx]) < baseline * (1.0 + min_gain):
+        return verify_all
+    return idx
 
 
 def _lookup_sps_tensor(
@@ -1013,7 +1371,7 @@ class HostConfidenceBudgetPlanner:
     def __init__(
         self,
         *,
-        sps_table: SpsCostTable,
+        sps_table: Union[SpsCostTable, SpsAdditiveCostTable],
         cfg: DSparkScheduleConfig,
         model_runner,
         relay_lag_steps: int = 1,

--- a/python/sglang/srt/speculative/dspark_components/dspark_sps.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_sps.py
@@ -150,6 +150,126 @@ def load_sps_table_from_path(path: str):
     return SpsCostTable.from_json(data)
 
 
+MIN_DERIVED_PROBES = 2
+MIN_DERIVED_DYNAMIC_RANGE = 1.5
+# SpsAdditiveCostTable requires a positive bias. The two terms that dominate a step -- the draft
+# forward and the target verify -- are both measured below, and what remains is host-side work no
+# captured graph covers. Rather than invent a value for it, the bias carries a floor only.
+DERIVED_BIAS_SECONDS = 1e-9
+
+
+def _monotone_non_decreasing(values: list[float]) -> list[float]:
+    """Pool adjacent violators until the sequence never falls.
+
+    Neither term of the cost model can get cheaper as its axis grows: a verify step does not speed
+    up as it gets wider, and a draft step does not speed up as requests are added. Replay timings
+    are noisy enough to violate that locally, and a curve that dips tells the planner a bigger step
+    is faster -- the one lie that can make it choose a worse budget than verify-all.
+    """
+    pooled: list[float] = []
+    weights: list[float] = []
+    for value in values:
+        pooled.append(value)
+        weights.append(1.0)
+        while len(pooled) > 1 and pooled[-2] > pooled[-1]:
+            total = weights[-2] + weights[-1]
+            merged = (pooled[-2] * weights[-2] + pooled[-1] * weights[-1]) / total
+            pooled[-2:] = [merged]
+            weights[-2:] = [total]
+    out: list[float] = []
+    for value, weight in zip(pooled, weights):
+        out.extend([value] * int(weight))
+    return out
+
+
+def _pool_within_resolution(seconds: list[float], spreads: list[float]) -> list[float]:
+    """Flatten runs of neighbours whose cost difference the measurement cannot resolve.
+
+    A cost model must not encode a difference smaller than its own uncertainty. Over the low-token
+    tiers the real verify cost is nearly flat, so without this the planner reads replay noise as a
+    reason to trim -- and trimming where there is nothing to win is exactly the case that costs
+    someone throughput for no gain. Pooling makes those tiers equal-cost, under which the budget
+    objective is strictly increasing again and the planner declines to trim, which is the behaviour
+    the flat region should produce.
+    """
+    pooled = list(seconds)
+    start = 0
+    for i in range(1, len(pooled) + 1):
+        resolvable = i < len(pooled) and abs(pooled[i] - pooled[start]) > max(
+            spreads[i], spreads[start]
+        )
+        if i == len(pooled) or resolvable:
+            if i - start > 1:
+                mean = sum(pooled[start:i]) / (i - start)
+                pooled[start:i] = [mean] * (i - start)
+            start = i
+    return pooled
+
+
+def _clean_cost_axis(
+    *, probes: list[tuple[int, float, float]]
+) -> Optional[tuple[list[int], list[float]]]:
+    """Order one axis of the cost model and strip what the measurement cannot resolve."""
+    unique: dict[int, tuple[float, float]] = {}
+    for point, seconds, spread_seconds in probes:
+        if point >= 1 and seconds > 0.0:
+            unique[int(point)] = (float(seconds), abs(float(spread_seconds)))
+    if not unique:
+        return None
+    points = sorted(unique)
+    resolved = _pool_within_resolution(
+        [unique[point][0] for point in points],
+        [unique[point][1] for point in points],
+    )
+    return points, _monotone_non_decreasing(resolved)
+
+
+def build_capture_derived_sps_table(
+    *,
+    verify_probes: list[tuple[int, float, float]],
+    draft_probes: list[tuple[int, float, float]],
+    bias_seconds: float = DERIVED_BIAS_SECONDS,
+) -> Optional[SpsAdditiveCostTable]:
+    """Build an additive cost model from measured (shape, seconds, spread_seconds) triples.
+
+    `verify_probes` are keyed by total verify tokens and `draft_probes` by request count -- the two
+    axes SpsAdditiveCostTable already separates, and the two graph ladders capture already provides.
+
+    Keeping them apart is what makes the model correct rather than merely populated. The planner
+    varies the budget at a *fixed* request count, and the draft forward has already run, at full
+    width, for every one of those requests before a budget is chosen: it costs the same whichever
+    budget wins. Folding it into a single token-indexed curve prices it as though trimming removed
+    requests, which understates what trimming costs and biases the argmax towards it. A sunk
+    constant is not neutral here, because the objective is a ratio.
+
+    Returns None when the measurement cannot support a usable curve. That is a first-class outcome:
+    the caller keeps the uninitialized table and the engine behaves exactly as it does today.
+    """
+    verify_axis = _clean_cost_axis(probes=verify_probes)
+    if verify_axis is None:
+        return None
+    m_probes, theta_seconds = verify_axis
+    if len(m_probes) < MIN_DERIVED_PROBES:
+        return None
+    if max(theta_seconds) / min(theta_seconds) < MIN_DERIVED_DYNAMIC_RANGE:
+        # Too flat to carry a scheduling signal; a near-constant curve is the degenerate case this
+        # replaces, so shipping it would add risk for no gain.
+        return None
+
+    # An unmeasurable draft ladder is not fatal: a zero per-request term is exactly the verify-only
+    # model, which is a worse cost model but still a real curve, and still beats the uninitialized flat table.
+    draft_axis = _clean_cost_axis(probes=draft_probes)
+    bs_probes, alpha_seconds = draft_axis if draft_axis is not None else ([1], [0.0])
+
+    return SpsAdditiveCostTable(
+        bias_seconds=max(bias_seconds, DERIVED_BIAS_SECONDS),
+        bs_probes=bs_probes,
+        alpha_seconds=alpha_seconds,
+        m_probes=m_probes,
+        theta_seconds=theta_seconds,
+    )
+
+
 def build_uninitialized_sps_table(*, max_batch_tokens: int) -> SpsCostTable:
     return SpsCostTable(
         sample_batch_tokens=[1],

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -53,6 +53,7 @@ from sglang.srt.speculative.dspark_components.dspark_planner import (
     alloc_verify_window,
     dp_global_verify_tier_num_tokens,
     idle_ragged_layout,
+    simulate_acc_len_needs_verify_all,
 )
 from sglang.srt.speculative.dspark_components.dspark_verify import (
     CommitInjectCtx,
@@ -255,8 +256,7 @@ class DSparkWorkerV2(BaseSpecWorker):
 
         self._simulate_acc_len = float(envs.SGLANG_SIMULATE_ACC_LEN.get())
         if (
-            self._simulate_acc_len > 0
-            and self._simulate_acc_len != 1.0
+            simulate_acc_len_needs_verify_all()
             and not self._verify_planner.is_verify_all
         ):
             raise ValueError(
@@ -380,6 +380,12 @@ class DSparkWorkerV2(BaseSpecWorker):
             self._draft_worker.init_cuda_graphs(
                 capture_decode_cuda_graph=capture_decode_cuda_graph
             )
+        # Outside the draft context on purpose: the cost curve is measured from the TARGET worker's
+        # verify graphs. This is the first point at which they exist, and the planner was built
+        # before capture, so it cannot have derived anything itself.
+        self._verify_planner.install_capture_derived_sps_table(
+            draft_model_runner=self.draft_model_runner
+        )
 
     def _maybe_build_draft_sampler(self):
         return maybe_build_draft_sampler(

--- a/test/registered/spec/dspark/test_dspark_capture_derived_sps_tp2.py
+++ b/test/registered/spec/dspark/test_dspark_capture_derived_sps_tp2.py
@@ -1,0 +1,119 @@
+"""Tensor-parallel startup for the capture-derived DSpark SPS table.
+
+The cost table is measured from captured CUDA graphs, and captured graphs carry the model's
+collectives. Three failure modes live only at tp>1, and all of them are fatal at startup rather than
+wrong at runtime, so no single-GPU test can see them:
+
+  * ranks that derive their own curves choose different graph tiers for the same batch, replay
+    different shapes, and take an illegal memory access on a non-zero rank;
+  * ranks that decide locally how many times to replay issue mismatched collective counts and hang
+    in the sweep;
+  * a rank whose local measurement raises skips the broadcast and strands its peers in the
+    collective until the distributed timeout.
+
+All three are prevented by construction -- rank 0's measurement is broadcast, the sweep performs the
+same replays on every rank, and the broadcast sits outside the failure guard with a shape that does
+not depend on what any rank measured. This test is the regression guard for that construction: it
+asserts the server starts and serves — all three failure modes are fatal before that point.
+"""
+
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_cuda_ci(est_time=300, stage="base-b", runner_config="2-gpu-large")
+
+TARGET_MODEL = "Qwen/Qwen3-14B"
+DRAFT_MODEL = "deepseek-ai/dspark_qwen3_14b_block7"
+
+
+class TestDSparkCaptureDerivedSpsTp2(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            TARGET_MODEL,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--tp",
+                "2",
+                "--trust-remote-code",
+                "--attention-backend",
+                "fa3",
+                "--speculative-algorithm",
+                "DSPARK",
+                "--speculative-draft-model-path",
+                DRAFT_MODEL,
+                "--speculative-draft-attention-backend",
+                "fa3",
+                "--mem-fraction-static",
+                "0.7",
+                "--page-size",
+                "1",
+                "--cuda-graph-max-bs-decode",
+                "32",
+            ],
+            env={
+                # Compact is the only mode that captures per-token-tier verify graphs, so it is the
+                # only mode the derivation runs in, and the derivation is opt-in. Without BOTH the
+                # server would start with the uninitialized table and this test would pass while
+                # exercising none of the code it exists to guard.
+                "SGLANG_RAGGED_VERIFY_MODE": "compact",
+                "SGLANG_DSPARK_ENABLE_CAPTURE_DERIVED_SPS": "1",
+            },
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "process") and cls.process:
+            kill_process_tree(cls.process.pid)
+
+    def test_server_serves_after_deriving_the_cost_table(self):
+        # Reaching this point already covers the hang: setUpClass would have timed out.
+        response = requests.post(
+            self.base_url + "/generate",
+            json={
+                "text": "Speculative decoding is",
+                "sampling_params": {"max_new_tokens": 32, "temperature": 0},
+            },
+            timeout=120,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()["text"])
+
+    def test_both_ranks_kept_planning_after_the_first_steps(self):
+        """A cross-rank disagreement shows up as a dead scheduler on the next batch, not at launch,
+        so drive several requests that are genuinely in flight together — serial requests would only
+        ever schedule single-request batches and never exercise a multi-request tier choice.
+        """
+
+        def _generate(i):
+            return requests.post(
+                self.base_url + "/generate",
+                json={
+                    "text": f"Count to ten starting from {i}:",
+                    "sampling_params": {"max_new_tokens": 48, "temperature": 0},
+                },
+                timeout=120,
+            )
+
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            for _ in range(2):
+                responses = list(pool.map(_generate, range(8)))
+                for response in responses:
+                    self.assertEqual(response.status_code, 200)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=3)

--- a/test/registered/spec/dspark/test_dspark_sps_table.py
+++ b/test/registered/spec/dspark/test_dspark_sps_table.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from sglang.srt.speculative.dspark_components.dspark_sps import (
     SpsAdditiveCostTable,
     SpsCostTable,
+    build_capture_derived_sps_table,
     build_uninitialized_sps_table,
     is_uninitialized_sps_table,
     load_sps_table_from_path,
@@ -13,7 +14,7 @@ from sglang.srt.speculative.dspark_components.dspark_sps import (
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
-register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=24, suite="base-a-test-cpu")
 
 
 def _make_table() -> SpsCostTable:
@@ -201,6 +202,587 @@ class TestIsUninitializedSpsTable(CustomTestCase):
 
     def test_real_diagonal_table_is_initialized(self):
         self.assertFalse(is_uninitialized_sps_table(_make_table()))
+
+
+class TestBuildCaptureDerivedSpsTable(CustomTestCase):
+    """The capture-time cost model, built from two ladders of (shape, seconds, spread) triples.
+
+    Verify graphs are keyed by total verify tokens and draft graphs by request count -- the two axes
+    SpsAdditiveCostTable separates. Returning None is the contract for "unusable measurement": the
+    caller then keeps the uninitialized table, i.e. the engine behaves exactly as it did before the
+    derivation existed.
+    """
+
+    def test_rejects_too_few_probes(self):
+        self.assertIsNone(
+            build_capture_derived_sps_table(verify_probes=[], draft_probes=[])
+        )
+        self.assertIsNone(
+            build_capture_derived_sps_table(
+                verify_probes=[(8, 0.01, 0.0)], draft_probes=[]
+            )
+        )
+
+    def test_rejects_non_positive_timings(self):
+        self.assertIsNone(
+            build_capture_derived_sps_table(
+                verify_probes=[(8, 0.0, 0.0), (64, -1.0, 0.0)], draft_probes=[]
+            )
+        )
+
+    def test_rejects_curve_with_too_little_dynamic_range(self):
+        # A near-constant cost curve carries no scheduling signal, which is the degenerate case the
+        # derivation exists to replace.
+        flat = [(8, 0.010, 0.0), (64, 0.0102, 0.0), (128, 0.0104, 0.0)]
+        self.assertIsNone(
+            build_capture_derived_sps_table(verify_probes=flat, draft_probes=[])
+        )
+
+    def test_emits_the_additive_form(self):
+        """The additive table is the point, not an implementation detail: it is the only one of the
+        two shapes whose per-request term the planner holds fixed while it sweeps the budget.
+        """
+        table = build_capture_derived_sps_table(
+            verify_probes=[
+                (8, 0.00873, 3e-5),
+                (64, 0.00964, 5e-5),
+                (128, 0.01016, 5e-5),
+                (384, 0.01980, 1e-4),
+            ],
+            draft_probes=[(1, 0.00120, 1e-5), (48, 0.00460, 1e-5)],
+        )
+        self.assertIsInstance(table, SpsAdditiveCostTable)
+        self.assertEqual(table.m_probes, [8, 64, 128, 384])
+        self.assertEqual(table.bs_probes, [1, 48])
+        self.assertFalse(is_uninitialized_sps_table(table))
+
+    def test_draft_cost_stays_on_the_request_axis(self):
+        """The draft forward has already run, at full width, for every request by the time a budget
+        is chosen. Folding its cost into the token axis instead would price trimming as
+        though it also removed requests, so the verify term must come through untouched.
+        """
+        table = build_capture_derived_sps_table(
+            verify_probes=[(48, 0.010, 0.0), (96, 0.015, 0.0), (288, 0.030, 0.0)],
+            draft_probes=[(8, 0.004, 0.0), (48, 0.009, 0.0)],
+        )
+        for measured, stored in zip([0.010, 0.015, 0.030], table.theta_seconds):
+            self.assertAlmostEqual(stored, measured, places=9)
+        self.assertEqual(table.alpha_seconds, [0.004, 0.009])
+
+    def test_trimming_the_budget_does_not_discount_the_draft(self):
+        """The behavioural consequence, at a fixed request count: only the verify term may move.
+        A draft term that shrinks with the budget is not a harmless constant, because the objective
+        is a ratio -- it moves the argmax toward trimming."""
+        table = build_capture_derived_sps_table(
+            verify_probes=[(48, 0.010, 0.0), (96, 0.015, 0.0), (288, 0.030, 0.0)],
+            draft_probes=[(8, 0.004, 0.0), (48, 0.009, 0.0)],
+        )
+        verify_all = table.step_time(num_reqs=48, budget=240)
+        trimmed = table.step_time(num_reqs=48, budget=48)
+        self.assertAlmostEqual(verify_all - trimmed, 0.030 - 0.015, places=9)
+
+    def test_builds_without_a_draft_ladder(self):
+        """A draft model with no captured graphs must not sink the derivation: a zero per-request
+        term is the verify-only model, worse than the additive one but still a real curve.
+        """
+        table = build_capture_derived_sps_table(
+            verify_probes=[(8, 0.010, 0.0), (64, 0.020, 0.0)], draft_probes=[]
+        )
+        self.assertIsNotNone(table)
+        self.assertEqual(table.alpha_seconds, [0.0])
+
+    def test_sorts_and_deduplicates_probes(self):
+        table = build_capture_derived_sps_table(
+            verify_probes=[
+                (128, 0.02, 0.0),
+                (8, 0.01, 0.0),
+                (8, 0.011, 0.0),
+                (64, 0.015, 0.0),
+            ],
+            draft_probes=[],
+        )
+        self.assertEqual(table.m_probes, [8, 64, 128])
+
+    def test_repairs_a_non_monotone_curve(self):
+        # A curve that says a wider step is cheaper can make the planner prefer the wider step, so
+        # cost must never fall as tokens are added.
+        table = build_capture_derived_sps_table(
+            verify_probes=[(8, 0.010, 0.0), (64, 0.008, 0.0), (128, 0.020, 0.0)],
+            draft_probes=[],
+        )
+        theta = table.theta_seconds
+        self.assertTrue(all(theta[i] <= theta[i + 1] for i in range(len(theta) - 1)))
+
+    def test_repairs_a_non_monotone_draft_ladder(self):
+        # The request axis carries the same invariant: adding requests cannot make the draft cheaper.
+        table = build_capture_derived_sps_table(
+            verify_probes=[(8, 0.010, 0.0), (128, 0.020, 0.0)],
+            draft_probes=[(1, 0.004, 0.0), (8, 0.002, 0.0), (48, 0.009, 0.0)],
+        )
+        alpha = table.alpha_seconds
+        self.assertTrue(all(alpha[i] <= alpha[i + 1] for i in range(len(alpha) - 1)))
+
+    def test_pools_differences_the_measurement_cannot_resolve(self):
+        # Neighbours closer together than the measurement spread must come out equal-cost, so the
+        # planner cannot trim on noise in a region where the true cost is flat.
+        table = build_capture_derived_sps_table(
+            verify_probes=[
+                (8, 0.01000, 0.0005),
+                (16, 0.01002, 0.0005),
+                (24, 0.01004, 0.0005),
+                (384, 0.02000, 0.0005),
+            ],
+            draft_probes=[],
+        )
+        unresolvable = table.theta_seconds[:3]
+        self.assertAlmostEqual(min(unresolvable), max(unresolvable), places=9)
+
+    def test_keeps_differences_the_measurement_does_resolve(self):
+        table = build_capture_derived_sps_table(
+            verify_probes=[
+                (8, 0.01000, 1e-5),
+                (16, 0.01200, 1e-5),
+                (24, 0.01400, 1e-5),
+                (384, 0.02000, 1e-5),
+            ],
+            draft_probes=[],
+        )
+        theta = table.theta_seconds
+        self.assertLess(theta[0], theta[1])
+        self.assertLess(theta[1], theta[2])
+
+
+class TestDerivationSkippedWhenGraphsAreNeverReplayed(CustomTestCase):
+    """Capture records a verify graph per token tier on any backend, but the runner's admission test
+    begins at `attn_backend.supports_ragged_verify_graph`. A backend that leaves the base-class
+    default of False -- a hybrid linear-attention target, whose GDN backend does not override it --
+    fails that test on every step, so the captured graphs are recorded and never replayed.
+
+    Timing them there prices a path the engine does not take. Worse than useless: on a Qwen3.6-27B
+    hybrid-GDN target the derivation installed a curve, the planner began trimming, and the first
+    decode step died with an illegal memory access inside the eager compact verify path. This guard
+    is therefore a crash guard, not only a performance one, and it must key on the capability flag
+    rather than on whether graphs were captured.
+    """
+
+    def _skips(self, *, supports_ragged, ragged_mode=True, runner_present=True):
+        from unittest.mock import MagicMock
+
+        from sglang.srt.speculative.dspark_components.dspark_planner import (
+            ragged_verify_graphs_are_replayable,
+        )
+
+        model_runner = MagicMock()
+        if not runner_present:
+            model_runner.decode_cuda_graph_runner = None
+        else:
+            runner = model_runner.decode_cuda_graph_runner
+            runner.ragged_verify_mode = ragged_mode
+            runner.attn_backend.supports_ragged_verify_graph = supports_ragged
+        return not ragged_verify_graphs_are_replayable(model_runner=model_runner)
+
+    def test_backend_without_ragged_verify_support_is_skipped(self):
+        self.assertTrue(self._skips(supports_ragged=False))
+
+    def test_backend_with_ragged_verify_support_proceeds(self):
+        self.assertFalse(self._skips(supports_ragged=True))
+
+    def test_non_ragged_mode_is_skipped(self):
+        # Static mode captures fixed-width verify graphs on a different axis; the derived table is a
+        # compact-mode object and must not be built from them.
+        self.assertTrue(self._skips(supports_ragged=True, ragged_mode=False))
+
+    def test_absent_runner_is_skipped(self):
+        self.assertTrue(self._skips(supports_ragged=True, runner_present=False))
+
+    def test_install_survives_an_absent_runner(self):
+        """The rank-0 skip log must not dereference the runner the guard just found missing.
+
+        A server launched with decode CUDA graphs disabled and the derivation enabled has
+        `decode_cuda_graph_runner is None`; the guard correctly declines, but an earlier revision's
+        skip message then read `.attn_backend` off that None and turned a clean decline into an
+        AttributeError at startup.
+        """
+        from unittest.mock import MagicMock
+
+        from sglang.srt.environ import envs
+        from sglang.srt.runtime_context import get_context, get_server_args
+        from sglang.srt.speculative.dspark_components.dspark_planner import (
+            DSparkVerifyPlanner,
+        )
+
+        override = get_context().override_server_args(
+            speculative_dspark_align_verify_tokens_to_graph_tier=False,
+            speculative_dspark_confidence_sts_path=None,
+            speculative_dspark_sps_table_path=None,
+            max_running_requests=4,
+        )
+        override.install()
+        self.addCleanup(override.restore)
+        # Compact-mode construction requires a confidence head; the MagicMock default (non-None)
+        # satisfies it without loading weights.
+        draft_model = MagicMock()
+        model_runner = MagicMock()
+        model_runner.decode_cuda_graph_runner = None
+        with envs.SGLANG_RAGGED_VERIFY_MODE.override(
+            "compact"
+        ), envs.SGLANG_DSPARK_ENABLE_CAPTURE_DERIVED_SPS.override(True):
+            planner = DSparkVerifyPlanner(
+                draft_model=draft_model,
+                gamma=8,
+                model_runner=model_runner,
+                device="cpu",
+                tp_rank=0,
+                server_args=get_server_args(),
+                verify_num_draft_tokens=8,
+            )
+            planner.install_capture_derived_sps_table(draft_model_runner=None)
+        self.assertTrue(planner.is_verify_all)
+
+
+class TestFullWindowBudgetKeepsTheFastPath(CustomTestCase):
+    """Installing a real cost table clears `_is_verify_all` for the engine's lifetime, because the
+    planner *can* now trim. But on a deployment with no headroom it chooses a full-width budget on
+    every step, and without this the engine pays the per-step top-k schedule and its host<->device
+    round-trips to reproduce the layout the uniform cache already holds.
+    """
+
+    def _covers(self, *, bs, budget, gamma=7, min_verify_len=1, max_verify_len=0):
+        from sglang.srt.speculative.dspark_components.dspark_planner import (
+            DSparkScheduleConfig,
+            DSparkVerifyPlanner,
+        )
+
+        planner = DSparkVerifyPlanner.__new__(DSparkVerifyPlanner)
+        planner._schedule_cfg = DSparkScheduleConfig(
+            gamma=gamma, min_verify_len=min_verify_len, max_verify_len=max_verify_len
+        )
+        return planner._budget_covers_full_window(bs=bs, budget=budget)
+
+    def test_the_fast_path_is_inert_until_a_derived_table_is_installed(self):
+        """Drives the real `schedule_layout`, not a copy of its condition.
+
+        A deployment running a profiled table from disk, or one that simply did not opt in, must keep
+        the scheduling path it has today. An earlier revision of this guard re-stated the gate inline,
+        which would have stayed green if someone dropped `_derived_sps_installed` from the production
+        expression -- exactly the regression it exists to catch.
+        """
+        from unittest.mock import patch
+
+        import torch
+
+        from sglang.srt.speculative.dspark_components import dspark_planner as mod
+        from sglang.srt.speculative.dspark_components.dspark_planner import (
+            DSparkScheduleConfig,
+            DSparkVerifyPlanner,
+        )
+        from sglang.srt.speculative.ragged_verify import RaggedVerifyMode
+
+        bs, gamma = 4, 7
+        first_step = {}
+
+        def _record(kind):
+            # Only the FIRST branch entered per run is the gate's decision. A miss then falls back
+            # to a uniform layout further down, which is correct but not what is under test.
+            def _fn(**kwargs):
+                first_step.setdefault(installed, kind)
+                return "uniform-layout" if kind == "fast-path" else None
+
+            return _fn
+
+        for installed in (False, True):
+            planner = DSparkVerifyPlanner.__new__(DSparkVerifyPlanner)
+            planner._schedule_cfg = DSparkScheduleConfig(gamma=gamma)
+            planner._ragged_verify_mode = RaggedVerifyMode.COMPACT
+            planner._is_verify_all = False
+            planner._derived_sps_installed = installed
+            planner._uniform_layout_cache = {}
+            planner.verify_num_draft_tokens = gamma + 1
+            planner.model_runner = None
+            planner._schedule_verify_lens = _record("scheduler")
+            planner._budget_aligned_to_graph_tier = lambda **kwargs: kwargs["budget"]
+
+            with patch.object(mod, "uniform_ragged_layout", _record("fast-path")):
+                planner.schedule_layout(
+                    req_pool_indices=torch.zeros(bs, dtype=torch.int64),
+                    prefix_lens=torch.zeros(bs, dtype=torch.int64),
+                    device="cpu",
+                    confidence=torch.zeros(bs, gamma),
+                    budget=bs * gamma,
+                )
+
+        # Not installed -> the scheduler runs, as it does upstream today.
+        # Installed -> the cached uniform layout is served instead.
+        self.assertEqual(first_step[False], "scheduler")
+        self.assertEqual(first_step[True], "fast-path")
+
+    def test_budget_that_fills_every_window_takes_the_fast_path(self):
+        # gamma=7 -> window 8, minus the always-verified anchor -> 7 selectable slots per request.
+        self.assertTrue(self._covers(bs=48, budget=48 * 7))
+        self.assertTrue(self._covers(bs=48, budget=48 * 7 + 1))
+
+    def test_one_token_short_falls_through_to_the_scheduler(self):
+        # The boundary is the whole point: a budget that cannot fill every window must be scheduled,
+        # or requests that should have been trimmed would silently verify their full window.
+        self.assertFalse(self._covers(bs=48, budget=48 * 7 - 1))
+
+    def test_absent_budget_is_not_treated_as_full(self):
+        # `budget=None` reaches here from paths that never consulted the planner; treating it as
+        # full-window would turn "no decision yet" into "verify everything".
+        self.assertFalse(self._covers(bs=48, budget=None))
+
+    def test_honours_a_capped_max_verify_len(self):
+        # With max_verify_len capping the window, fewer slots per request are selectable, so the
+        # fast path must engage at a proportionally smaller budget.
+        self.assertTrue(self._covers(bs=10, budget=10 * 3, gamma=7, max_verify_len=4))
+        self.assertFalse(
+            self._covers(bs=10, budget=10 * 3 - 1, gamma=7, max_verify_len=4)
+        )
+
+
+class TestCaptureDerivedInstallIsInertInStaticMode(CustomTestCase):
+    """Static is the DEFAULT ragged-verify mode, and the install hook runs on every DSpark start.
+
+    The compact-only branch of DSparkVerifyPlanner.__init__ is where the derivation decision is
+    made, so a regression that leaves the decision attribute unset there does not show up in any
+    compact-mode test -- it shows up as a startup crash for every default user.
+    """
+
+    def _planner_in_static_mode(self):
+        from unittest.mock import MagicMock
+
+        from sglang.srt.environ import envs
+        from sglang.srt.runtime_context import get_context, get_server_args
+        from sglang.srt.speculative.dspark_components.dspark_planner import (
+            DSparkVerifyPlanner,
+        )
+
+        # The planner reads the spec/schedule bags as well as the handed record,
+        # so the case publishes; the record it is handed is the published one.
+        override = get_context().override_server_args(
+            speculative_dspark_align_verify_tokens_to_graph_tier=False,
+            speculative_dspark_confidence_sts_path=None,
+            speculative_dspark_sps_table_path=None,
+            max_running_requests=4,
+        )
+        override.install()
+        self.addCleanup(override.restore)
+        draft_model = MagicMock()
+        draft_model.confidence_head = None
+        with envs.SGLANG_RAGGED_VERIFY_MODE.override("static"):
+            return DSparkVerifyPlanner(
+                draft_model=draft_model,
+                gamma=8,
+                model_runner=MagicMock(),
+                device="cpu",
+                tp_rank=0,
+                server_args=get_server_args(),
+                verify_num_draft_tokens=8,
+            )
+
+    def test_planner_constructs_and_install_is_a_no_op(self):
+        planner = self._planner_in_static_mode()
+        # Must not raise: the hook is called unconditionally from DSparkWorkerV2.init_cuda_graphs.
+        planner.install_capture_derived_sps_table(draft_model_runner=None)
+        self.assertTrue(planner.is_verify_all)
+
+
+class TestMinPredictedGainGuard(CustomTestCase):
+    """Trimming has to earn its keep: fewer verified tokens is a real loss, so a predicted win
+    smaller than the threshold must leave the schedule at verify-all."""
+
+    _STEEP = [1000.0, 700.0, 400.0, 100.0]
+    _NEARLY_FLAT = [1000.0, 999.5, 999.0, 998.5]
+    _VERIFY_ALL = 8 * 7  # 8 requests x 7 survival columns, all clearing survival_eps
+
+    @staticmethod
+    def _survival():
+        import torch
+
+        return torch.tensor([[0.5**k for k in range(1, 8)]] * 8, dtype=torch.float32)
+
+    @staticmethod
+    def _table(steps_per_sec):
+        return SpsCostTable(
+            sample_batch_tokens=[8, 64, 128, 384],
+            sample_steps_per_sec=steps_per_sec,
+            max_batch_tokens=384,
+        )
+
+    def _budget(self, *, min_predicted_gain, steps_per_sec):
+        from sglang.srt.speculative.dspark_components.dspark_planner import (
+            DSparkScheduleConfig,
+            compute_verify_token_budget,
+        )
+
+        cfg = DSparkScheduleConfig(gamma=8, min_predicted_gain=min_predicted_gain)
+        return compute_verify_token_budget(
+            history_survival_probs=self._survival(),
+            sps_table=self._table(steps_per_sec),
+            cfg=cfg,
+        ).budget
+
+    def _unguarded_argmax(self, steps_per_sec):
+        """The objective's argmax, rebuilt here independently of the code under test."""
+        import torch
+
+        from sglang.srt.speculative.dspark_components.dspark_planner import (
+            _lookup_sps_tensor,
+        )
+
+        survival = self._survival()
+        num_requests = survival.shape[0]
+        candidates = torch.sort(
+            survival.flatten().to(torch.float64), descending=True
+        ).values
+        tau_star = num_requests + torch.cat(
+            [torch.zeros(1, dtype=torch.float64), torch.cumsum(candidates, dim=0)]
+        )
+        batch_tokens = num_requests + torch.arange(tau_star.numel(), dtype=torch.int64)
+        sps = _lookup_sps_tensor(
+            sps_table=self._table(steps_per_sec), batch_tokens=batch_tokens
+        )
+        return int(torch.argmax(tau_star * sps))
+
+    def test_zero_threshold_is_exactly_the_unguarded_argmax(self):
+        for steps_per_sec in (self._STEEP, self._NEARLY_FLAT):
+            self.assertEqual(
+                self._budget(min_predicted_gain=0.0, steps_per_sec=steps_per_sec),
+                self._unguarded_argmax(steps_per_sec),
+            )
+
+    def test_a_steep_curve_still_trims_under_the_threshold(self):
+        self.assertLess(
+            self._budget(min_predicted_gain=0.05, steps_per_sec=self._STEEP),
+            self._VERIFY_ALL,
+        )
+
+    def test_a_nearly_flat_curve_declines_to_trim(self):
+        # Precondition: without the guard this curve does trim, so the guard is what changes the
+        # answer rather than the curve being uninteresting.
+        self.assertLess(
+            self._budget(min_predicted_gain=0.0, steps_per_sec=self._NEARLY_FLAT),
+            self._VERIFY_ALL,
+        )
+        self.assertEqual(
+            self._budget(min_predicted_gain=0.05, steps_per_sec=self._NEARLY_FLAT),
+            self._VERIFY_ALL,
+        )
+
+    def test_raising_the_threshold_never_trims_more(self):
+        budgets = [
+            self._budget(min_predicted_gain=g, steps_per_sec=self._STEEP)
+            for g in (0.0, 0.05, 0.2, 0.9)
+        ]
+        self.assertEqual(budgets, sorted(budgets))
+        self.assertEqual(budgets[-1], self._VERIFY_ALL)
+
+
+class TestSimulateAccLenGate(CustomTestCase):
+    """SGLANG_SIMULATE_ACC_LEN > 1 requires a verify-all schedule: a constant simulated
+    correct_len can exceed a trimmed request's budget and break the cutoff accounting.
+    DSparkWorkerV2 refuses that combination at construction, and deriving a cost table afterwards
+    would flip the planner off verify-all behind that check. Both the admission check and the
+    derivation read this predicate, so these cases pin the boundary it draws -- in particular that
+    exactly 1.0 is safe (it yields correct_len 0) while anything else above 0 is not."""
+
+    def _needs_verify_all(self, value):
+        from sglang.srt.environ import envs
+        from sglang.srt.speculative.dspark_components.dspark_planner import (
+            simulate_acc_len_needs_verify_all,
+        )
+
+        if value is None:
+            with envs.SGLANG_SIMULATE_ACC_LEN.override(0.0):
+                return simulate_acc_len_needs_verify_all()
+        with envs.SGLANG_SIMULATE_ACC_LEN.override(value):
+            return simulate_acc_len_needs_verify_all()
+
+    def test_matches_the_worker_admission_rule(self):
+        # DSparkWorkerV2 raises for `acc_len > 0 and acc_len != 1.0` unless the schedule is
+        # verify-all, so those are exactly the values that must block derivation.
+        for value, blocked in (
+            (None, False),
+            (0.0, False),
+            (1.0, False),
+            (1.5, True),
+            (2.0, True),
+            (3.5, True),
+        ):
+            with self.subTest(simulate_acc_len=value):
+                self.assertEqual(self._needs_verify_all(value), blocked)
+
+
+class TestStepCostProbeBroadcastIsDeadlockFree(CustomTestCase):
+    """The cost measurement ends in a collective, and a rank that skips it strands its peers.
+
+    The shape broadcast must therefore depend only on the captured tier list, which every rank
+    derives identically -- never on how many probes this rank managed to measure -- and the
+    broadcast must still happen when the local measurement fails outright. Both properties are
+    invisible on one GPU and fatal on two, which is why they are pinned here.
+    """
+
+    def _planner_with(self, measured, *, raises=False):
+        from unittest.mock import MagicMock, patch
+
+        from sglang.srt.speculative.dspark_components import dspark_planner as mod
+
+        planner = mod.DSparkVerifyPlanner.__new__(mod.DSparkVerifyPlanner)
+        planner.model_runner = MagicMock()
+        planner.device = "cpu"
+        planner.verify_num_draft_tokens = 8
+        runner = planner.model_runner.decode_cuda_graph_runner
+        if raises:
+            runner.measure_captured_replay_seconds.side_effect = RuntimeError("boom")
+        else:
+            runner.measure_captured_replay_seconds.return_value = measured
+        draft_runner = MagicMock()
+        draft_runner.decode_cuda_graph_runner = None
+
+        group = MagicMock()
+        tiers = [8, 16, 24, 32]
+        with patch.object(
+            mod, "ragged_capture_num_tokens", return_value=tiers
+        ), patch.object(
+            mod, "verify_lens_broadcast_group", return_value=(group, 2)
+        ), patch.object(
+            mod, "get_parallel", return_value=MagicMock(tp_size=2)
+        ):
+            probes = planner._measure_step_cost_probes(draft_model_runner=draft_runner)
+        return tiers, group, probes
+
+    def test_broadcast_shape_is_fixed_however_little_was_measured(self):
+        from sglang.srt.speculative.dspark_components import dspark_planner as mod
+
+        for measured in ([], [(8, 0.01, 0.0)], [(8, 0.01, 0.0), (32, 0.02, 0.0)]):
+            with self.subTest(num_measured=len(measured)):
+                tiers, group, _ = self._planner_with(measured)
+                group.broadcast.assert_called_once()
+                sent = group.broadcast.call_args.args[0]
+                self.assertEqual(
+                    tuple(sent.shape),
+                    (len(tiers) + mod.CAPTURE_DERIVED_SPS_MAX_PROBES, 3),
+                )
+
+    def test_broadcast_still_happens_when_the_local_measurement_raises(self):
+        _, group, (verify_probes, draft_probes) = self._planner_with([], raises=True)
+        group.broadcast.assert_called_once()
+        self.assertEqual(verify_probes, [])
+        self.assertEqual(draft_probes, [])
+
+    def test_only_measured_tiers_are_returned(self):
+        _, _, (verify_probes, _) = self._planner_with(
+            [(8, 0.01, 0.001), (32, 0.02, 0.002)]
+        )
+        self.assertEqual([tier for tier, _, _ in verify_probes], [8, 32])
+
+    def test_a_draft_runner_without_captured_graphs_yields_no_request_axis(self):
+        """`decode_cuda_graph_runner is None` is the real shape of a draft model whose graphs were
+        never captured. The measurement must return an empty draft ladder rather than fail, because
+        the builder degrades to the verify-only model on it."""
+        _, _, (verify_probes, draft_probes) = self._planner_with([(8, 0.01, 0.0)])
+        self.assertEqual(draft_probes, [])
+        self.assertTrue(verify_probes)
 
 
 if __name__ == "__main__":

--- a/test/registered/spec/dspark/test_ragged_verify_backend_capability.py
+++ b/test/registered/spec/dspark/test_ragged_verify_backend_capability.py
@@ -9,7 +9,7 @@ import unittest
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
 
-register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-small")
+register_cuda_ci(est_time=12, stage="base-b", runner_config="1-gpu-small")
 
 
 class TestRaggedVerifyGraphCapability(CustomTestCase):
@@ -37,6 +37,37 @@ class TestRaggedVerifyGraphCapability(CustomTestCase):
         ):
             with self.subTest(backend=backend.__name__):
                 self.assertTrue(backend.supports_ragged_verify_graph)
+
+
+class TestReplayCapturedShapeCapability(CustomTestCase):
+    """Capture-time cost measurement replays a captured graph with no ForwardBatch bound.
+
+    Only backends that can do that opt in; the rest inherit a NotImplementedError and the caller
+    silently keeps its existing cost model. A backend that gained the ability but not the override
+    would leave the DSpark verify budget degenerate with nothing going red, which is what this
+    checks.
+    """
+
+    def test_base_backend_does_not_implement_it(self):
+        from sglang.srt.model_executor.runner_backend.base_cuda_graph_backend import (
+            BaseCudaGraphBackend,
+        )
+
+        with self.assertRaises(NotImplementedError):
+            BaseCudaGraphBackend.replay_captured_shape(object(), shape_key=None)
+
+    def test_full_backend_overrides_it(self):
+        from sglang.srt.model_executor.runner_backend.base_cuda_graph_backend import (
+            BaseCudaGraphBackend,
+        )
+        from sglang.srt.model_executor.runner_backend.full_cuda_graph_backend import (
+            FullCudaGraphBackend,
+        )
+
+        self.assertIsNot(
+            FullCudaGraphBackend.replay_captured_shape,
+            BaseCudaGraphBackend.replay_captured_shape,
+        )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/model_executor/runner/test_decode_cuda_graph_runner.py
+++ b/test/registered/unit/model_executor/runner/test_decode_cuda_graph_runner.py
@@ -36,7 +36,7 @@ from sglang.srt.utils import profile_utils as putils
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
-register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+register_cpu_ci(est_time=12, suite="base-a-test-cpu")
 
 _CAPTURE_TRACE = "SGLANG_ENABLE_CUDA_GRAPH_CAPTURE_TRACE"
 _BATCH_CAPTURE = "SGLANG_GRAPH_BATCH_CAPTURE"
@@ -288,6 +288,47 @@ class TestOriginalTraceExport(CustomTestCase):
                     putils.graph_capture_profile_dir(),
                     os.path.join(tmp, "graph_capture_profile"),
                 )
+
+
+class TestSubsampleKeepingEnds(CustomTestCase):
+    """Bounding the capture-time cost sweep must never silently shrink the range it covers.
+
+    Consumers use the last entry as the top of the measured range, so dropping it would quietly
+    narrow the cost curve; and the sample must stay ordered and unique because the cost table it
+    feeds rejects anything else.
+    """
+
+    @staticmethod
+    def _subsample(values, limit):
+        from sglang.srt.model_executor.runner.decode_cuda_graph_runner import (
+            _subsample_keeping_ends,
+        )
+
+        return _subsample_keeping_ends(values, limit)
+
+    def test_identity_when_already_within_the_limit(self):
+        values = [8, 16, 32, 64]
+        self.assertEqual(self._subsample(values, 4), values)
+        self.assertEqual(self._subsample(values, 99), values)
+
+    def test_never_exceeds_the_limit_and_keeps_both_ends(self):
+        values = list(range(8, 8 * 41, 8))
+        for limit in (2, 3, 5, 8, 12, 40):
+            picked = self._subsample(values, limit)
+            self.assertLessEqual(len(picked), limit, f"limit={limit}")
+            self.assertEqual(picked[0], values[0], f"limit={limit}")
+            self.assertEqual(picked[-1], values[-1], f"limit={limit}")
+
+    def test_output_is_sorted_unique_and_a_subset(self):
+        values = list(range(8, 8 * 41, 8))
+        picked = self._subsample(values, 8)
+        self.assertEqual(picked, sorted(set(picked)))
+        self.assertTrue(set(picked).issubset(values))
+
+    def test_degenerate_limits_return_the_input(self):
+        values = [8, 16, 32]
+        for limit in (0, 1):
+            self.assertEqual(self._subsample(values, limit), values)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Co-authored-by: Weiwei Zhang (@jerrynlp)

## Summary

Under `SGLANG_RAGGED_VERIFY_MODE=compact` and without `--speculative-dspark-sps-table-path`,
DSpark's verify-budget scheduler runs on the **uninitialized (flat) SPS table**, and under it the
scheduler's `argmax` is provably pinned to verify-all: present, wired, and mathematically unable to
trim. **This PR makes that configuration fast**, by measuring the real capacity curve from the CUDA
graphs that capture has *already recorded* and installing it into the additive cost model SGLang
already defines, so the scheduler starts making the decisions it was written to make.

**What the planner maximises — `theta = tau_star × sps` — and the additive cost model that supplies
the step time behind it both already exist upstream, and neither changes here.** This fills in the
table they were written for, and adds one guard (`min_predicted_gain`, default 0.0, so a table
loaded from disk still gets a plain argmax). A pinned `--speculative-dspark-sps-table-path` keeps
precedence. It is opt-in via `SGLANG_DSPARK_ENABLE_CAPTURE_DERIVED_SPS=1`, and every new code path
is gated on a table this PR measured itself, so with the variable unset the engine behaves exactly
as it does today.

- **Performance** (H200, compact ragged verify): Qwen3-14B tp1 **+14.4%** at concurrency 48 and
  **+24.1%** at 64; Qwen3-8B tp1 **+8.3%** and **+5.6%**. On shorter trend runs at concurrency 128,
  Qwen3-8B reaches +22.9% and Qwen3-4B +11.8%. At concurrency 1–16 the deltas are within **±1.8%**,
  inside run-to-run variation, with accept length unchanged — the planner finds no reason to trim
  there, so it doesn't. The one measured regression is DeepSeek-V4-Flash tp4, **−6.3% / −8.0%** at
  mid load — the model on which the derived table recovers the least of the real step (quantified
  below) — and it is why the feature defaults off. **The shape across the sweep is the mechanism:
  trimming buys time only when the step is compute-bound, so the busier the engine, the more a token
  removed from the verify batch is worth** — and tensor parallelism moves a deployment back out of
  that regime, so the gain is largest exactly where throughput is scarcest.
- **Startup cost, and only when enabled:** with the variable unset the derivation returns before it
  measures anything. When enabled it costs **2.4 s on Qwen3-4B tp1** and **9.0 s on
  DeepSeek-V4-Flash tp4**, bounded by `40 shapes × (2 warmup + 5 timed) replays` per ladder. Capture
  itself is untouched, and nothing is measured after startup.

## Motivation

DSpark drafts a fixed block of tokens per request, then the target verifies them. How many of
those drafted tokens each request actually gets verified is what `SGLANG_RAGGED_VERIFY_MODE`
selects. Under the default, `static`, every request is verified over its full window and there is no
budget to schedule. Under `compact` the layout is packed ragged and trimmed to a token budget, and a
per-step scheduler decides that budget by maximising predicted throughput against an SPS (steps per
second) cost table.

**In `compact` mode, launched without `--speculative-dspark-sps-table-path`, that scheduler cannot
trim.** It is not a tuning shortfall — with no table supplied, the one it reads reports the same
steps-per-second for every batch width, which makes the objective strictly increasing in the budget,
so its `argmax` lands on verify-all for every possible input. The confidence head, the survival
probabilities, the batch-global top-k allocator and the ragged packing all still run, and none of
them changes the outcome: every step verifies the full window, exactly as `static` would.

The tree already says so, in three places. The runtime warns on every such start:

> `DSpark SPS table is uninitialized (flat): the verify budget degenerates to verify-all (zero
> scheduling gain). Pass a profiled --speculative-dspark-sps-table-path.`

The property belongs to the table, not to any model — nothing in that warning path consults the
model — so it holds for every target launched this way. Upstream's docs say it plainest in the
Kimi-K3 config snippet, which offers the mode as *"Compact (requires SPS table)"* and comments:

> `Compact prunes the verify layout to the SPS budget. SILENT-INERT without`
> `--speculative-dspark-sps-table-path (every step still verifies full width) […]`

And no SPS table ships in the repository, so any compact deployment that has not run the profiler
itself is on the flat table — including `test/registered/core/test_basic_sanity_dspark.py`, which
launches compact with no table path.

`sglang.benchmark.dspark_sps_profiler` exists to produce that table offline, and remains the right
tool when an operator wants to pin a specific curve. But the curve is hardware- and model-specific,
so it is a separate profiling run per deployment — and until someone does it, the scheduler
contributes nothing. **This PR makes compact-without-a-table work without that step**, using
measurements the engine can already take on itself.

That is the paper's own design. DSpark (arXiv:2607.05147 §3.2.2, *Hardware-Aware Prefix Scheduler*)
defines the objective and, in the same passage, says where the curve comes from (emphasis added):

> "let SPS(B) denote the engine throughput, measured in steps per second, for a given forward-pass
> batch size B. **Crucially, this capacity curve is profiled once during engine initialization and
> stored as a lightweight cost table.** Our scheduler then aims to maximize the expected system-wide
> token throughput Θ=τ⋅SPS(B) […]"

Although SGLang already implements Θ = τ·SPS(B) faithfully, it does not build that capacity
curve. The DSpark roadmap (#30344) lists the same direction under *What's next*:

> "**Cost model and scheduling** — a stronger, increasingly online/adaptive cost model and further
> improvements to the dynamic scheduler."

## Usage

Opt in with one new environment variable; everything else is unchanged.

```bash
SGLANG_RAGGED_VERIFY_MODE=compact \
SGLANG_DSPARK_ENABLE_CAPTURE_DERIVED_SPS=1 \
python3 -m sglang.launch_server \
  --model-path Qwen/Qwen3-14B \
  --speculative-algorithm DSPARK \
  --speculative-draft-model-path deepseek-ai/dspark_qwen3_14b_block7 \
  --attention-backend fa3 --speculative-draft-attention-backend fa3 \
  --page-size 1 --cuda-graph-max-bs-decode 128
```

Startup reports the derived table, and the budget is scheduled from it:

```
DSpark SPS table derived from 35 verify tiers and 35 draft batch sizes in 5.56 s; the verify budget
is now scheduled. Verify cost (tokens: ms) 8: 8.71, 16: 8.77, [...], 1024: 42.34.
Draft cost (requests: ms) 1: 1.74, 2: 1.78, [...], 128: 7.37. Unset
SGLANG_DSPARK_ENABLE_CAPTURE_DERIVED_SPS to restore verify-all.
```

### Scope: this optimises the no-table path only

**The target is the no-table case** — `SGLANG_RAGGED_VERIFY_MODE=compact` run without
`--speculative-dspark-sps-table-path`, where the budget is pinned to verify-all and the scheduler
contributes nothing. That path is what this PR speeds up. Nothing about the existing architecture
changes:

- **A pinned table keeps precedence.** Pass `--speculative-dspark-sps-table-path` and the derivation
  never arms, whatever the new variable is set to — verified on a live server with both set: the
  scheduler reports `sps_table=<the pinned path>` and emits no derivation line. An operator who
  profiled a curve keeps exactly that curve. This falls out of the existing structure rather than a
  new branch, and is documented in the flag's help text and next to the variable in `environ.py`.
- **`compact` mode only.** `SGLANG_RAGGED_VERIFY_MODE=compact` is what captures per-token-tier verify
  graphs. In `static` mode the hook is a no-op; in `cap-accept` the target forward already runs at full
  uniform width and the budget only caps acceptance afterwards, so a cost curve there could lose
  accepted tokens without saving compute.
- **Backends that can replay the captured ragged graphs only** — see *Key points* below.

All measurements below are from that configuration — compact, no table supplied. A profiled table
is a separate configuration and is not benchmarked here.

### Why it is defaulted off

Whether trimming pays is a property of the deployment rather than of the cost model: the results
below show the same code gaining 24% on one model and losing 8% on another. The conservative default
is therefore to measure nothing and change nothing unless asked — a Qwen3 DSpark deployment under
load should turn this on, a DeepSeek-V4-Flash deployment should leave it off, or pin a
profiled table; the gap behind that advice is quantified in *The derived table versus a profiled
one*.

For what it is worth, vLLM's equivalent feature also ships defaulted off
(`enable_adaptive_verification: bool = False`, vllm-project/vllm#47808) — though for scope rather
than for a measured regression. The more useful precedent from that PR is the design: its
`adaptive_verification.py` takes no table file at all, so a startup-profiled curve is its only cost
model.

## Modifications

### The approach

Compact ragged verify **already captures one verify CUDA graph per token tier**, and the draft
worker's graphs are captured on a batch-size ladder. Those are exactly the two axes the cost model
needs. Replaying a bounded sample of each at the end of capture yields a measured cost model per
model / TP degree / GPU — no offline pass, no separate engine warmup phase, no serving-time
measurement.

The result goes into `SpsAdditiveCostTable`, which **already exists** and which
`compute_verify_token_budget` **already branches on**:

```python
def step_time(self, *, num_reqs: int, budget: int) -> float:
    return (
        self.bias_seconds
        + _interp_clamped(self.bs_probes, self.alpha_seconds, float(num_reqs))
        + _interp_clamped(
            self.m_probes, self.theta_seconds, float(num_reqs + budget)
        )
    )
```

Where the offline profiler must *fit* `alpha` and `theta` by OLS residual back-fit from an
off-diagonal sweep, capture hands both over **directly measured**: the target runner's tier ladder
fills the table's `theta_seconds`, the draft runner's batch-size ladder its `alpha_seconds`.

**Why the two terms must stay on separate axes.** The planner sweeps the budget at a *fixed* request
count, and the draft forward has already run — at full `gamma`, for every one of those requests —
before a budget is chosen. It costs the same whichever budget wins. Fold it into a single
token-indexed curve and a trimmed token count prices the draft as though trimming had also removed
requests; the curve then decays faster than the real step and the argmax over-trims. A sunk constant
is **not** neutral here, because the objective is a ratio.

### The changes

| file | role |
|---|---|
| `dspark_components/dspark_sps.py` | `build_capture_derived_sps_table(verify_probes=…, draft_probes=…)` → `SpsAdditiveCostTable`; per-axis cleaning (`_clean_cost_axis`), pool-adjacent-violators (`_monotone_non_decreasing`), resolution pooling (`_pool_within_resolution`), and the admission gates `MIN_DERIVED_PROBES` / `MIN_DERIVED_DYNAMIC_RANGE` |
| `dspark_components/dspark_planner.py` | `install_capture_derived_sps_table()` orchestration; `_measure_step_cost_probes` / `_fill_local_step_costs` (both ladders, fixed-shape buffer, rank-0 broadcast); `ragged_verify_graphs_are_replayable()` capability guard; `_budget_covers_full_window()` fast-path restore |
| `model_executor/runner/decode_cuda_graph_runner.py` | `measure_captured_replay_seconds()` — subsampled, fixed-count replay timing that always includes the widest shape; stages the row layout serving actually uses, and restores the capture layout afterwards |
| `runner_backend/{base,full}_cuda_graph_backend.py` | `replay_captured_shape()` — replay a captured graph with no `ForwardBatch` bound; the base raises `NotImplementedError`, so a backend that cannot do this simply is not measured |
| `dspark_components/dspark_worker_v2.py` | calls the hook at the end of `init_cuda_graphs()`, outside the draft context — the first point at which the target's verify graphs exist |
| `environ.py`, `server_args.py` | `SGLANG_DSPARK_ENABLE_CAPTURE_DERIVED_SPS` (new, default off); `--speculative-dspark-sps-table-path` help text |
| `test/registered/spec/dspark/`, `test/registered/unit/model_executor/runner/` | builder contract and capability guard (CPU); cross-rank construction on 2 GPUs (`test_dspark_capture_derived_sps_tp2.py`); replay-timing subsampling; backend opt-in coverage |

**Key points:**

- **Tensor parallelism is a cross-rank agreement problem, not just a measurement.** Captured graphs
  carry the model's collectives, so three failure modes are prevented by construction, each of them
  hit during development: ranks deriving their own curves choose different tiers and take an illegal
  memory access on a non-zero rank (rank 0's measurement is broadcast); ranks deciding locally how
  many times to replay issue mismatched collective counts and hang (replay counts are fixed
  constants, never adaptive, never derived from a local timing); and a rank that fails locally and
  skips the broadcast strands its peers until the distributed timeout (the broadcast sits outside the
  `try`/`except`, and the buffer's shape depends only on the tier list and a constant). The tp2 test
  is the regression guard — all three are invisible on one GPU and fatal on two.

- **The derivation declines where its measurement would not describe a step.** The runner's admission
  test begins at `attn_backend.supports_ragged_verify_graph`; a backend that leaves the base-class
  default of `False` — a hybrid linear-attention target, whose GDN backend does not override it —
  fails it on every step, so those graphs are recorded and never replayed. The guard checks that flag
  before measuring anything. On such a target this is not only a cost-model correctness guard:
  without it the derivation installed a curve, the planner began trimming, and the first decode step
  died with an illegal memory access in the eager compact verify path. Verified on hybrid-GDN
  targets: Qwen3.6-27B at tp1 now logs
  `DSpark capture-derived SPS table skipped: HybridLinearAttnBackend does not replay ragged verify
  graphs, so replay time does not describe a verify step. The verify budget stays at verify-all.`
  and serves normally, and a Qwen3.6-35B-A3B hybrid at tp2 does the same.

- **Never encode a difference the measurement cannot resolve.** Neighbouring tiers whose costs differ
  by less than the measured replay spread are pooled to equal cost, so replay noise cannot be read as
  a reason to trim. Neither axis may dip: a verify step does not get cheaper as it gets wider, and a
  draft step does not get cheaper as requests are added.

- **Every failure keeps the uninitialized table.** This is a startup optimisation and must never
  be able to stop the engine from starting. Fewer than two usable probes, or a cost span under
  1.5×, returns `None` — a near-constant curve is the degenerate case being replaced, so shipping
  one would add risk for no gain.

- **A table loaded from disk keeps today's scheduling.** Two things changed in the planner, and both
  are no-ops without a derived table: `DSparkScheduleConfig.min_predicted_gain` — keep verify-all
  unless the predicted win clears a threshold — defaults to **0.0**, which is a plain argmax, and
  only the derived path raises it to 5%; and the uniform-layout fast path is additionally gated on
  the derived table being installed, so a pinned-table deployment keeps the exact scheduling path it
  has now.

## Experimental Results

**Protocol.** 8×H200. Patched tree versus a pristine tree at the same commit;
`SGLANG_RAGGED_VERIFY_MODE=compact` on **both** arms, so the only difference is the cost table. Each
arm asserts its own provenance: the patched arm must print the derivation line carrying both cost
axes, the stock arm must print upstream's "degenerates to verify-all" warning. The first repeat is
discarded as a cold-radix-cache artefact — a stock control established that it reads ~11% low even
when the knob under test does nothing. Bracketed figures are the min–max spread across the retained
repeats, and the spread column carries that variation as a percentage so it can be read against the
delta beside it. **Within a single arm it runs 1.5–6.0% of the mean (median 3.9%)** — that is the
floor below which a delta means nothing.

| model | conc | stock tok/s | patched tok/s | run-to-run spread<br>(stock / patched) | delta | accept length |
|---|---|---|---|---|---|---|
| Qwen3-14B tp1 | 48 | 4644 [4518–4720] | 5313 [5213–5404] | 4.4% / 3.6% | **+14.40%** | 3.33 → 3.09 |
| Qwen3-14B tp1 | 64 | 4858 [4813–4915] | 6026 [5929–6105] | 2.1% / 2.9% | **+24.05%** | 3.32 → 3.01 |
| Qwen3-8B tp1 | 48 | 7476 [7320–7586] | 8096 [7901–8237] | 3.5% / 4.1% | **+8.29%** | 3.76 → 3.61 |
| Qwen3-8B tp1 | 64 | 8511 [8394–8636] | 8990 [8900–9049] | 2.8% / 1.7% | **+5.63%** | 3.78 → 3.48 |
| Qwen3-4B tp1 | 48 | 9929 [9736–10214] | 9820 [9552–10044] | 4.8% / 5.0% | −1.10% — *within noise* | 3.84 → 3.65 |
| Qwen3-4B tp1 | 64 | 10953 [10879–11039] | 11168 [10768–11338] | 1.5% / 5.1% | +1.97% — *within noise* | 3.84 → 3.50 |
| DeepSeek-V4-Flash tp4 | 48 | 1711 [1655–1758] | 1603 [1566–1652] | 6.0% / 5.4% | **−6.30%** | 3.58 → 3.30 |
| DeepSeek-V4-Flash tp4 | 64 | 2016 [2000–2044] | 1856 [1807–1910] | 2.2% / 5.6% | **−7.95%** | 3.56 → 3.16 |

*Run-to-run spread is `(max − min) / mean` for that arm's retained repeats — the variation the same
binary produces against itself. The two rows marked **within noise** are the two whose delta is
smaller than that variation and whose arms' `[min–max]` intervals overlap; they are reported, not
claimed. Every bolded row has the two intervals disjoint, and deltas are computed from unrounded
means.*

### The gain is larger under load

| model | 48 | 64 | 96 | 128 |
|---|---|---|---|---|
| Qwen3-14B tp1 | +14.4% | +24.1% | +17.0% | +23.2% |
| Qwen3-8B tp1 | +8.3% | +5.6% | +11.1% | +22.9% |
| Qwen3-4B tp1 | −1.1% *(noise)* | +2.0% *(noise)* | +4.6% | +11.8% |
| DeepSeek-V4-Flash tp4 | −6.3% | −7.9% | −6.6% | +2.2% |

*The 48 and 64 columns are the runs from the table above, and carry its noise marks. The 96 and 128
columns come from shorter runs with fewer repeats, so none of them is bolded here: read the row
shape, not the individual cell.*

Both directions are the same mechanism. Concurrency makes the step more compute-bound, so a removed
token is worth more; tensor parallelism makes it less so, and the gain shrinks accordingly. The full
parallelism ladder, Qwen3-14B at concurrency 48 / 64: tp1 **+14.4% / +24.1%** → tp2 +7.7% / +12.5%
→ tp4 +4.8% / +5.1%.

The tp2/tp4 figures also come from shorter runs, and are reported as a trend rather than as
separated measurements.

### Low concurrency is unchanged

Qwen3-14B tp1 at concurrency 1 / 4 / 8 / 16: **+0.10% / +0.25% / −0.28% / −1.71%** — every point
inside the noise band above, and accept length identical to stock to within 0.01 at each of them.
Identical accept length is the stronger statement: the planner is not trimming, so there is nothing
for the cost table to have changed.

### The derived table versus a profiled one

`sglang.benchmark.dspark_sps_profiler` measures the whole server-side step; this PR measures the
CUDA graph replays inside it. Scoring one against the other says how much of the step the cheap
measurement recovers — and that number tracks the results above.

| model | derived vs profiled whole-step cost |
|---|---|
| Qwen3-14B tp1 | **86.5–96.5%** |
| DeepSeek-V4-Flash tp4 | **62–82%, median 69%** |

**That gap tracks the regression.** A curve missing a third of the step is still monotone and still
ranks budgets, but it overstates what trimming saves, and the planner acts on the overstatement —
which is exactly what DeepSeek-V4-Flash tp4 does at mid load. Other explanations were ruled out by
measurement: capture-grid coverage (the grid spans `bs=[1…256]`, serving peaks at 136); `page_size`
(absent from the graph-admission path, and a `--page-size 1` A/B is identical); sliding-window
attention; eager fallback (decode replays a captured graph on 100% of steps, on both arms); and
"this model has no headroom" (a forced-fraction sweep at concurrency 64 puts the optimum at 0.7,
not 1.0).

**Why the gap is model-dependent — the mechanism is certain, its share of this regression is
inferred.** A captured graph replays a fixed kernel DAG, so its *launch configuration* is a property
of the shape; but where a kernel's work depends on values read from device memory, its *duration* is
not. MoE routing is the clear case: token-to-expert assignment drives per-expert GEMM extents and
dispatch volume, so the replay is timed under whatever routing distribution capture happened to
leave in the buffers, which is not the distribution serving produces. That much is a property of MoE
kernels, and `replay_captured_shape`'s docstring now records it. What ties it to *this* regression is
circumstantial: every model that gains here is dense, the one that regresses is the only MoE one, and
tensor parallelism is controlled for (Qwen3-14B at tp4 — trend runs — is still +4.8% / +5.1%) —
but no checkpoint
available to us is MoE with a paired DSpark draft *and* high graph coverage, so this could not be
separated experimentally.

**Why a constant will not close it.** On Qwen3-14B the shortfall is 3.5% at 128 batch tokens and
13.5% at 384 — it grows with request count, while `bias_seconds` is by construction a constant. The
bias sweep behaves exactly as that predicts: injecting a flattening constant recovers most of the
concurrency-64 gap in that sweep's own pool (−8.9% → −1.7%) and none of it at 48. No fixed constant
is defensible as a shipped value. (The two also parameterise the additive form differently — the
profiler pins the smallest cell's `alpha` and `theta` to zero and lets the intercept carry them,
this PR uses absolute times and floors the intercept — so the `bias_seconds` fields are not
comparable term by term. The totals above are.)

**So why not just run the profiler?** It stays the right answer when an operator wants to pin an
exact curve, which is why a supplied table keeps precedence. It is a different trade, not a better
one:

| | offline profiler (`--fracs`) | this PR |
|---|---|---|
| measures | whole server-side step (`step_cpu_ms`) under load | CUDA graph replays at capture |
| `alpha` / `theta` | OLS coefficients over a `(bs, frac)` grid | absolute replay time, one probe per captured shape |
| **operator effort** | launch a second server, drive it through the grid, keep the JSON, and remember to redo it | **set one environment variable** |
| **time** | the whole grid, plus that second launch — see below | **2.4 s** (Qwen3-4B tp1) to **9.0 s** (DeepSeek-V4-Flash tp4), automatic |
| tracks the deployment | re-run it after any hardware / model / TP change | re-derived on every start, by construction |

The grid is what makes it expensive. Our one archived profiler run on **Qwen3-14B** took **132 s for
nine cells** end to end, and that was the 1-D diagonal sweep; the 2-D table this PR's cost model is
shaped like needs the request-count sweep crossed with a fraction sweep — on the default grid for
`--max-running-requests 256` that is 19 batch sizes — with, say, four fractions, **roughly 76
cells, on the order of twenty minutes**. Against that, the derived table for the same model costs
**5.6 s**.

Neither end of that comparison improves for a larger model. Each grid cell is gated on a
steady-state wall clock rather than on model speed, so the grid does not shrink; and the second
server launch it sits on top of grows — **82 s on Qwen3-4B tp1 against 246 s on DeepSeek-V4-Flash
tp4**, measured on the runs above. This PR pays neither: it reuses the launch that already happened
and the graphs already captured within it.

## Checklist
- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32198652451](https://github.com/sgl-project/sglang/actions/runs/32198652451)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32198652250](https://github.com/sgl-project/sglang/actions/runs/32198652250)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->