### PR TITLE
[Docs]: clarify chunked_prefill_size and max_prefill_tokens semantics

### DIFF
--- a/docs/docs/advanced_features/hyperparameter_tuning.mdx
+++ b/docs/docs/advanced_features/hyperparameter_tuning.mdx
@@ -60,7 +60,7 @@ Another straightforward approach is to increase `--mem-fraction-static` in incre
 
 If you encounter out-of-memory (OOM) errors, you can adjust the following parameters:
 
-- If OOM occurs during prefill, try reducing `--chunked-prefill-size` to `4096` or `2048`. This saves memory but slows down the prefill speed for long prompts.
+- If OOM occurs during prefill, try reducing `--chunked-prefill-size` to `4096` or `2048`. This saves memory but slows down the prefill speed for long prompts. Note that this is a shared per-batch budget, not a per-request cap — see [`--chunked-prefill-size`](./server_arguments) for its interaction with `--max-prefill-tokens`.
 - If OOM occurs during decoding, try lowering `--max-running-requests`.
 - You can also reduce `--mem-fraction-static` to a smaller value, such as 0.8 or 0.7. This decreases the memory usage of the KV cache memory pool and helps prevent OOM errors during both prefill and decoding. However, it limits maximum concurrency and reduces peak throughput.
 

--- a/docs/docs/advanced_features/server_arguments.mdx
+++ b/docs/docs/advanced_features/server_arguments.mdx
@@ -462,7 +462,7 @@ Please consult the documentation below and [server_args.py](https://github.com/s
     </tr>
         <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--chunked-prefill-size`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>The maximum number of tokens in a chunk for the chunked prefill. Setting this to -1 means disabling chunked prefill.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>The maximum number of tokens in a chunk for the chunked prefill. Setting this to -1 means disabling chunked prefill. This is a per-batch shared budget (not a per-request cap): it is decremented as requests are admitted and also triggers truncation when a single request's remaining input exceeds the remaining budget. Works together with `--max-prefill-tokens`; whichever is tighter bounds the batch. The default auto-scales with GPU memory. With `--enable-dp-attention`, the effective value is `chunked_prefill_size // dp_size`.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`None`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Type: int</td>
     </tr>
@@ -480,7 +480,7 @@ Please consult the documentation below and [server_args.py](https://github.com/s
     </tr>
         <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--max-prefill-tokens`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>The maximum number of tokens in a prefill batch. The real bound will be the maximum of this value and the model's maximum context length.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>The maximum number of tokens in a prefill batch. The real bound will be the maximum of this value and the model's maximum context length. Unlike `--chunked-prefill-size`, this does not truncate individual requests — it only stops admitting additional requests once the budget is exhausted. Both budgets are decremented together; whichever is tighter bounds the batch.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`16384`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Type: int</td>
     </tr>


### PR DESCRIPTION
## Motivation

Re-lands #23416, which was closed as obsolete after the docs tree was reorganized (the edited files were renamed to `.mdx`). Same clarification, applied to the current files. Originally raised in #20018.

`--chunked-prefill-size` and `--max-prefill-tokens` are both per-batch token budgets decremented together as requests are admitted, but the docs describe them as independent limits. The `dp_size` division under `--enable-dp-attention` and the truncation semantics are also undocumented.

## Modifications

- `docs/docs/advanced_features/server_arguments.mdx`: clarify that both flags are shared per-batch budgets (not per-request caps), that `--chunked-prefill-size` additionally truncates individual requests, that the tighter budget bounds the batch, and that the effective value is `chunked_prefill_size // dp_size` with DP attention.
- `docs/docs/advanced_features/hyperparameter_tuning.mdx`: point the OOM tuning bullet to the server arguments reference for the interaction between the two flags.

Docs-only change.

## Checklist

- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
