### PR TITLE
[Kernel] Use Cake source Router GEMM for DeepSeek, GLM, and Mistral

### DIFF
--- a/python/sglang/kernels/ops/gemm/flashinfer_router_gemm.py
+++ b/python/sglang/kernels/ops/gemm/flashinfer_router_gemm.py
@@ -1,0 +1,109 @@
+"""FlashInfer-backed small-M Router GEMM dispatch for datacenter Blackwell."""
+
+from __future__ import annotations
+
+import functools
+from typing import Callable, NamedTuple, Optional
+
+import torch
+
+from sglang.srt.environ import envs
+from sglang.srt.utils import (
+    get_device_sm,
+    is_flashinfer_available,
+    print_info_once,
+)
+
+
+class _RouterGemmSpec(NamedTuple):
+    op_name: str
+    out_dtype: torch.dtype
+
+
+_ROUTER_GEMM_SPECS = {
+    (7168, 128): _RouterGemmSpec(
+        "mm_M1_16_K7168_N128", torch.bfloat16
+    ),
+    (7168, 256): _RouterGemmSpec("mm_M1_16_K7168_N256", torch.float32),
+    (6144, 256): _RouterGemmSpec("mm_M1_16_K6144_N256", torch.float32),
+}
+
+
+@functools.lru_cache(maxsize=1)
+def _get_flashinfer_router_gemm_ops() -> dict[str, Callable]:
+    if (
+        not envs.SGLANG_ENABLE_FLASHINFER_ROUTER_GEMM.get()
+        or get_device_sm() not in (100, 103)
+        or not is_flashinfer_available()
+    ):
+        return {}
+
+    try:
+        from flashinfer import gemm as flashinfer_gemm
+    except ImportError:
+        return {}
+
+    ops = {}
+    for spec in _ROUTER_GEMM_SPECS.values():
+        op = getattr(flashinfer_gemm, spec.op_name, None)
+        if op is None:
+            return {}
+        ops[spec.op_name] = op
+    return ops
+
+
+def try_flashinfer_router_gemm(
+    hidden_states: torch.Tensor,
+    router_weights: torch.Tensor,
+    *,
+    launch_with_pdl: bool = True,
+) -> Optional[torch.Tensor]:
+    """Run a fixed-shape FlashInfer Router GEMM, or return ``None``.
+
+    FlashInfer owns the source-built kernel, while SGLang retains allocation
+    ownership and supplies the column-major transpose view required by its
+    public API. Unsupported shapes and installations preserve the existing
+    model-specific fallback paths.
+    """
+
+    if not envs.SGLANG_ENABLE_FLASHINFER_ROUTER_GEMM.get():
+        return None
+    if hidden_states.ndim != 2 or router_weights.ndim != 2:
+        return None
+    if not 1 <= hidden_states.shape[0] <= 16:
+        return None
+    if hidden_states.shape[1] != router_weights.shape[1]:
+        return None
+    if hidden_states.dtype != torch.bfloat16:
+        return None
+    if router_weights.dtype != torch.bfloat16:
+        return None
+    if hidden_states.device != router_weights.device:
+        return None
+    if hidden_states.stride(1) != 1 or router_weights.stride(1) != 1:
+        return None
+
+    hidden_dim = hidden_states.shape[1]
+    num_experts = router_weights.shape[0]
+    spec = _ROUTER_GEMM_SPECS.get((hidden_dim, num_experts))
+    if spec is None:
+        return None
+
+    op = _get_flashinfer_router_gemm_ops().get(spec.op_name)
+    if op is None:
+        return None
+
+    output = torch.empty(
+        (hidden_states.shape[0], num_experts),
+        dtype=spec.out_dtype,
+        device=hidden_states.device,
+    )
+    op(hidden_states, router_weights.t(), output, launch_with_pdl)
+    print_info_once(
+        "Using FlashInfer Router GEMM for eligible DeepSeek, Mistral Large 3, "
+        "and GLM small-token shapes."
+    )
+    return output
+
+
+__all__ = ["try_flashinfer_router_gemm"]

--- a/python/sglang/kernels/ops/gemm/flashinfer_router_gemm.py
+++ b/python/sglang/kernels/ops/gemm/flashinfer_router_gemm.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import functools
+import importlib
 from typing import Callable, NamedTuple, Optional
 
 import torch
@@ -39,6 +40,7 @@ def _get_flashinfer_router_gemm_ops() -> dict[str, Callable]:
         return {}
 
     try:
+        importlib.import_module("flashinfer.jit.cake_router_gemm")
         from flashinfer import gemm as flashinfer_gemm
     except ImportError:
         return {}

--- a/python/sglang/kernels/ops/gemm/flashinfer_router_gemm.py
+++ b/python/sglang/kernels/ops/gemm/flashinfer_router_gemm.py
@@ -22,9 +22,7 @@ class _RouterGemmSpec(NamedTuple):
 
 
 _ROUTER_GEMM_SPECS = {
-    (7168, 128): _RouterGemmSpec(
-        "mm_M1_16_K7168_N128", torch.bfloat16
-    ),
+    (7168, 128): _RouterGemmSpec("mm_M1_16_K7168_N128", torch.bfloat16),
     (7168, 256): _RouterGemmSpec("mm_M1_16_K7168_N256", torch.float32),
     (6144, 256): _RouterGemmSpec("mm_M1_16_K6144_N256", torch.float32),
 }

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1023,6 +1023,11 @@ class Envs:
     SGLANG_NIXL_EP_NUM_MAX_DISPATCH_TOKENS_PER_RANK = EnvInt(128)
     SGLANG_PPLX_NUM_MAX_DISPATCH_TOKENS_PER_RANK = EnvInt(128)
     SGLANG_ENABLE_MOE_DEFERRED_FINALIZE = EnvBool(True)
+    # Use FlashInfer's source-built Cake Router GEMM for the fixed DeepSeek,
+    # Mistral Large 3, and GLM small-token shapes on SM100/SM103. Missing APIs,
+    # unsupported shapes, and this kill switch all retain the existing model
+    # fallback without importing FlashInfer at module load time.
+    SGLANG_ENABLE_FLASHINFER_ROUTER_GEMM = EnvBool(True)
     # DeepSeek/GLM MoE (deepseek_v2.py): quantize the (dp-gathered) MoE input
     # to per-token-group-128 fp8 ONCE and feed both the fused shared-expert
     # GEMM (cutlass w8a8 linear) and the routed experts' triton fused runner,

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -245,6 +245,9 @@ from sglang.kernels.ops.gemm.fused_a_gemm import (
     fused_a_gemm_weight_eligible,
     linear_with_fused_a_gemm,
 )
+from sglang.kernels.ops.gemm.flashinfer_router_gemm import (
+    try_flashinfer_router_gemm,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -525,6 +528,11 @@ class MoEGate(nn.Module):
                 return linear_bf16_fp32(hidden_states, self.weight)
             return F.linear(hidden_states, self.weight, None)
         else:
+            logits = None
+            if not self.is_deepseek_v4:
+                logits = try_flashinfer_router_gemm(hidden_states, self.weight)
+            if logits is not None:
+                return logits
             # NOTE(b8zhong): this threshold has been empirically verified
             max_router_gemm_tokens = 4 if _device_sm in (100, 103) else 16
             if (

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -241,12 +241,12 @@ elif _is_npu:
 else:
     pass
 
+from sglang.kernels.ops.gemm.flashinfer_router_gemm import (
+    try_flashinfer_router_gemm,
+)
 from sglang.kernels.ops.gemm.fused_a_gemm import (
     fused_a_gemm_weight_eligible,
     linear_with_fused_a_gemm,
-)
-from sglang.kernels.ops.gemm.flashinfer_router_gemm import (
-    try_flashinfer_router_gemm,
 )
 
 logger = logging.getLogger(__name__)

--- a/python/sglang/srt/models/glm4_moe.py
+++ b/python/sglang/srt/models/glm4_moe.py
@@ -23,6 +23,9 @@ import torch.nn.functional as F
 from torch import nn
 from transformers import PretrainedConfig
 
+from sglang.kernels.ops.gemm.flashinfer_router_gemm import (
+    try_flashinfer_router_gemm,
+)
 from sglang.kernels.ops.quantization.fp8_kernel import is_fp8_fnuz
 from sglang.srt.batch_overlap.single_batch_overlap import SboFlags
 from sglang.srt.batch_overlap.two_batch_overlap import model_forward_maybe_tbo
@@ -378,6 +381,9 @@ class Glm4MoeGate(nn.Module):
         self.register_buffer("_weight_fp32", None, persistent=False)
 
     def forward(self, hidden_states):
+        logits = try_flashinfer_router_gemm(hidden_states, self.weight)
+        if logits is not None:
+            return logits
         if self._weight_fp32 is None:
             self._weight_fp32 = self.weight.data.to(torch.float32)
         logits = F.linear(hidden_states.to(torch.float32), self._weight_fp32, None)

--- a/python/sglang/srt/models/glm4_moe_lite.py
+++ b/python/sglang/srt/models/glm4_moe_lite.py
@@ -23,6 +23,9 @@ import torch.nn.functional as F
 from torch import nn
 from transformers import PretrainedConfig
 
+from sglang.kernels.ops.gemm.flashinfer_router_gemm import (
+    try_flashinfer_router_gemm,
+)
 from sglang.srt.batch_overlap.single_batch_overlap import SboFlags
 from sglang.srt.batch_overlap.two_batch_overlap import model_forward_maybe_tbo
 from sglang.srt.distributed import (
@@ -166,6 +169,9 @@ class Glm4MoeLiteGate(nn.Module):
         self.register_buffer("_weight_fp32", None, persistent=False)
 
     def forward(self, hidden_states):
+        logits = try_flashinfer_router_gemm(hidden_states, self.weight)
+        if logits is not None:
+            return logits
         if self._weight_fp32 is None:
             self._weight_fp32 = self.weight.data.to(torch.float32)
         logits = F.linear(hidden_states.to(torch.float32), self._weight_fp32, None)

--- a/test/srt/test_flashinfer_router_gemm.py
+++ b/test/srt/test_flashinfer_router_gemm.py
@@ -95,6 +95,23 @@ def test_flashinfer_router_gemm_kill_switch(monkeypatch):
         )
 
 
+def test_flashinfer_router_gemm_requires_cake_source_backend(monkeypatch):
+    router_gemm._get_flashinfer_router_gemm_ops.cache_clear()
+    monkeypatch.setattr(router_gemm, "get_device_sm", lambda: 103)
+    monkeypatch.setattr(router_gemm, "is_flashinfer_available", lambda: True)
+
+    def missing_cake_source_backend(_name):
+        raise ModuleNotFoundError("flashinfer.jit.cake_router_gemm")
+
+    monkeypatch.setattr(
+        router_gemm.importlib, "import_module", missing_cake_source_backend
+    )
+    try:
+        assert router_gemm._get_flashinfer_router_gemm_ops() == {}
+    finally:
+        router_gemm._get_flashinfer_router_gemm_ops.cache_clear()
+
+
 @pytest.mark.parametrize(
     "gate_cls,module",
     [

--- a/test/srt/test_flashinfer_router_gemm.py
+++ b/test/srt/test_flashinfer_router_gemm.py
@@ -1,0 +1,139 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang.kernels.ops.gemm import flashinfer_router_gemm as router_gemm
+from sglang.srt.environ import envs
+from sglang.srt.models import deepseek_v2, glm4_moe, glm4_moe_lite
+
+
+@pytest.mark.parametrize(
+    "hidden_dim,num_experts,out_dtype,op_name",
+    [
+        (7168, 128, torch.bfloat16, "mm_M1_16_K7168_N128"),
+        (7168, 256, torch.float32, "mm_M1_16_K7168_N256"),
+        (6144, 256, torch.float32, "mm_M1_16_K6144_N256"),
+    ],
+)
+def test_flashinfer_router_gemm_dispatch(
+    monkeypatch, hidden_dim, num_experts, out_dtype, op_name
+):
+    calls = []
+
+    def fake_op(mat_a, mat_b, out, launch_with_pdl):
+        calls.append((mat_a, mat_b, out, launch_with_pdl))
+        assert mat_b.shape == (hidden_dim, num_experts)
+        assert mat_b.stride(0) == 1
+        assert out.is_contiguous()
+        out.zero_()
+
+    monkeypatch.setattr(
+        router_gemm,
+        "_get_flashinfer_router_gemm_ops",
+        lambda: {op_name: fake_op},
+    )
+    hidden_states = torch.randn(7, hidden_dim, dtype=torch.bfloat16)
+    router_weights = torch.randn(num_experts, hidden_dim, dtype=torch.bfloat16)
+
+    out = router_gemm.try_flashinfer_router_gemm(
+        hidden_states, router_weights, launch_with_pdl=False
+    )
+
+    assert out.shape == (7, num_experts)
+    assert out.dtype == out_dtype
+    assert len(calls) == 1
+    assert calls[0][3] is False
+
+
+@pytest.mark.parametrize(
+    "hidden_states,router_weights",
+    [
+        (
+            torch.empty(0, 7168, dtype=torch.bfloat16),
+            torch.empty(256, 7168, dtype=torch.bfloat16),
+        ),
+        (
+            torch.empty(17, 7168, dtype=torch.bfloat16),
+            torch.empty(256, 7168, dtype=torch.bfloat16),
+        ),
+        (
+            torch.empty(4, 4096, dtype=torch.bfloat16),
+            torch.empty(256, 4096, dtype=torch.bfloat16),
+        ),
+        (
+            torch.empty(4, 7168, dtype=torch.float32),
+            torch.empty(256, 7168, dtype=torch.bfloat16),
+        ),
+    ],
+)
+def test_flashinfer_router_gemm_preserves_unsupported_fallbacks(
+    monkeypatch, hidden_states, router_weights
+):
+    monkeypatch.setattr(
+        router_gemm,
+        "_get_flashinfer_router_gemm_ops",
+        lambda: pytest.fail("unsupported inputs must not resolve FlashInfer ops"),
+    )
+    assert (
+        router_gemm.try_flashinfer_router_gemm(hidden_states, router_weights) is None
+    )
+
+
+def test_flashinfer_router_gemm_kill_switch(monkeypatch):
+    monkeypatch.setattr(
+        router_gemm,
+        "_get_flashinfer_router_gemm_ops",
+        lambda: pytest.fail("disabled dispatch must not resolve FlashInfer ops"),
+    )
+    hidden_states = torch.empty(1, 7168, dtype=torch.bfloat16)
+    router_weights = torch.empty(256, 7168, dtype=torch.bfloat16)
+    with envs.SGLANG_ENABLE_FLASHINFER_ROUTER_GEMM.override(False):
+        assert (
+            router_gemm.try_flashinfer_router_gemm(hidden_states, router_weights)
+            is None
+        )
+
+
+@pytest.mark.parametrize(
+    "gate_cls,module",
+    [
+        (glm4_moe.Glm4MoeGate, glm4_moe),
+        (glm4_moe_lite.Glm4MoeLiteGate, glm4_moe_lite),
+    ],
+)
+def test_glm_gate_uses_flashinfer_router_gemm(monkeypatch, gate_cls, module):
+    sentinel = torch.empty(3, 256, dtype=torch.float32)
+    monkeypatch.setattr(
+        module, "try_flashinfer_router_gemm", lambda *_args, **_kwargs: sentinel
+    )
+    gate = gate_cls(SimpleNamespace(n_routed_experts=256, hidden_size=6144))
+
+    assert gate(torch.empty(3, 6144, dtype=torch.bfloat16)) is sentinel
+    assert gate._weight_fp32 is None
+
+
+def test_deepseek_gate_uses_flashinfer_router_gemm(monkeypatch):
+    sentinel = torch.empty(3, 256, dtype=torch.float32)
+    monkeypatch.setattr(
+        deepseek_v2,
+        "try_flashinfer_router_gemm",
+        lambda *_args, **_kwargs: sentinel,
+    )
+    monkeypatch.setattr(
+        deepseek_v2,
+        "get_exec",
+        lambda: SimpleNamespace(
+            deterministic=SimpleNamespace(enable_deterministic_inference=False)
+        ),
+    )
+    gate = deepseek_v2.MoEGate.__new__(deepseek_v2.MoEGate)
+    torch.nn.Module.__init__(gate)
+    gate.weight = torch.nn.Parameter(
+        torch.empty(256, 7168, dtype=torch.bfloat16)
+    )
+    gate.is_deepseek_v4 = False
+    gate.dsa_enable_prefill_cp = False
+    gate.mla_enable_prefill_cp = False
+
+    assert gate(torch.empty(3, 7168, dtype=torch.bfloat16)) is sentinel

--- a/test/srt/test_flashinfer_router_gemm.py
+++ b/test/srt/test_flashinfer_router_gemm.py
@@ -75,9 +75,7 @@ def test_flashinfer_router_gemm_preserves_unsupported_fallbacks(
         "_get_flashinfer_router_gemm_ops",
         lambda: pytest.fail("unsupported inputs must not resolve FlashInfer ops"),
     )
-    assert (
-        router_gemm.try_flashinfer_router_gemm(hidden_states, router_weights) is None
-    )
+    assert router_gemm.try_flashinfer_router_gemm(hidden_states, router_weights) is None
 
 
 def test_flashinfer_router_gemm_kill_switch(monkeypatch):
@@ -146,9 +144,7 @@ def test_deepseek_gate_uses_flashinfer_router_gemm(monkeypatch):
     )
     gate = deepseek_v2.MoEGate.__new__(deepseek_v2.MoEGate)
     torch.nn.Module.__init__(gate)
-    gate.weight = torch.nn.Parameter(
-        torch.empty(256, 7168, dtype=torch.bfloat16)
-    )
+    gate.weight = torch.nn.Parameter(torch.empty(256, 7168, dtype=torch.bfloat16))
     gate.is_deepseek_v4 = False
     gate.dsa_enable_prefill_cp = False
     gate.mla_enable_prefill_cp = False


### PR DESCRIPTION
## Motivation

Use FlashInfer's source-built Cake Router GEMM for the small-token router projections used by DeepSeek V2/V3, GLM-4 MoE/Lite, and Mistral Large 3 on SM100/SM103. This fills the M=1..16 shape boundary while preserving the existing SGLang fallbacks.

Dependencies and trackers: [FlashInfer #4594](https://github.com/flashinfer-ai/flashinfer/pull/4594), Cake !581, Cake issue #11, and [FlashInfer issue #4254](https://github.com/flashinfer-ai/flashinfer/issues/4254).

## Modifications

- Add a lazy Router GEMM adapter that only activates when the Cake source backend from FlashInfer #4594 is present on SM100/SM103.
- Preserve SGLang's caller-owned row-major output ABI and pass the model's row-major `[N, K]` parameter as the column-major `[K, N]` transpose view expected by FlashInfer.
- Route the supported model gates through the adapter before their existing fallbacks, excluding DeepSeek V4.
- Add `SGLANG_ENABLE_FLASHINFER_ROUTER_GEMM=0` as a kill switch.

| Model path | Shape | Input / weight | Output | M range |
|---|---|---|---|---:|
| DeepSeek V2/V3 | K=7168, N=256 | BF16 / BF16 | FP32 | 1..16 |
| GLM-4 MoE/Lite | K=6144, N=256 | BF16 / BF16 | FP32 | 1..16 |
| Mistral Large 3 | K=7168, N=128 | BF16 / BF16 | BF16 | 1..16 |

Missing source APIs, unsupported shapes/dtypes/layouts/devices, and a disabled kill switch return to the existing model-specific path.

## Accuracy Tests

- `pytest -q test/srt/test_flashinfer_router_gemm.py`: 12 passed.
- GB300/SM103 public-API matrix: 96/96 passed (3 APIs x M=1..16 x PDL on/off); maximum absolute difference `1.90735e-6`.
- Real DeepSeek-V3-0324 FP8 checkpoint (163 shards), TP4/EP4 on 4x GB300: M=1..16 source prewarm passed against FP32 reference at `atol=rtol=1e-2`; maximum absolute difference `1.22070e-4`.
- Eight fixed 64-token prompts produced the same first greedy token for baseline and candidate (8/8). At 32 generated tokens, 4/8 sequences remained exactly equal; later divergence is retained in the evidence because autoregressive decoding amplifies contract-valid Router GEMM rounding differences.

## GSM8K End-to-End

Full 1,319-question GSM8K test with the real 163-shard DeepSeek-V3-0324 FP8 checkpoint: 5-shot, temperature 0, top-p 1, 512 maximum new tokens, 16 concurrent requests, TP4/EP4, and 4x NVIDIA GB300. The dataset is pinned to commit `3101c7d5072418e28b9008a6636bde82a006892c` with SHA256 `3730d312f6e3440559ace48831e51066acaca737f6eabec99bccb9e4b3c39d14`.

| Two-run aggregate | Baseline | Cake Router GEMM | Delta / speedup |
|---|---:|---:|---:|
| Correct answers | 2,465 / 2,638 | 2,491 / 2,638 | +26 |
| Accuracy | 93.442% | 94.428% | +0.986 pp |
| Invalid answers | 0 | 0 | 0 |
| Mean latency | 1,933.515 s | 1,931.454 s | 1.0011x |
| Mean output throughput | 68.672 tok/s | 68.876 tok/s | 1.0030x |

The two full A/B runs reversed execution order. Output-throughput speedup was 0.9895x for baseline-then-Cake (Slurm `3141143`) and 1.0169x for Cake-then-baseline (Slurm `3142227`), so the approximately 0.3% aggregate throughput change is within the observed order/run noise. Accuracy improved in both runs (+12 and +14 correct answers). Both candidate runs logged the Cake Router path on all four ranks; both baselines logged zero Cake markers.

## Speed Tests and Profiling

DeepSeek-V3-0324 FP8, TP4/EP4, 4x NVIDIA GB300 (SM103), 16 concurrent requests, 64 input IDs and 64 output tokens per request, five measured rounds after warmup:

| Metric | Baseline | Cake Router GEMM | Speedup |
|---|---:|---:|---:|
| Median output throughput | 77.445 tok/s | 81.474 tok/s | 1.0520x |
| Profiler GPU active-union | 16,302.874 ms | 14,635.903 ms | 1.1139x |
| Attributed Router path | 113.482 ms | 99.124 ms | 1.1449x |

The candidate trace contains 14,848 `kernel_cake_blackwell_router_gemm_m16_k7168` launches. The baseline has 14,848 old Router main launches plus 14,848 attributable split-K reduction launches; the Cake path removes that reduction. Run: Slurm `3138717`, SGLang `20127f12c92c0eb7cf4182bd1b1f02158f84dba5`, FlashInfer source `2cbaf76fbcb90ce7befc0ef6dc5e4cfd70e43102`.

## Checklist

- [x] Format the changed files with pre-commit.
- [x] Add unit tests.
- [x] Document the environment switch and fallback behavior inline.
- [x] Provide accuracy, speed, and profiler results.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32201569541](https://github.com/sgl-project/sglang/actions/runs/32201569541)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32201569312](https://github.com/sgl-project/sglang/actions/runs/32201569312)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
