### PR TITLE
perf: optimize small-M NVFP4 MoE on SM120 (v0.5.15)

### DIFF
--- a/python/sglang/jit_kernel/nvfp4.py
+++ b/python/sglang/jit_kernel/nvfp4.py
@@ -131,6 +131,38 @@ def _jit_nvfp4_blockwise_moe_module() -> Module:
         )
 
 
+_nvfp4_small_moe_cutlass_params: dict[tuple, object] = {}
+
+
+def _get_nvfp4_small_moe_cutlass_params(
+    input: torch.Tensor, num_experts: int, intermediate_size: int
+):
+    """Return persistent grouped-CUTLASS metadata for a small-M shape."""
+    from sglang.srt.layers.moe.cutlass_moe_params import (
+        CutlassMoEParams,
+        CutlassMoEType,
+    )
+
+    key = (
+        input.device.type,
+        input.device.index,
+        num_experts,
+        intermediate_size,
+        input.shape[1],
+    )
+    params = _nvfp4_small_moe_cutlass_params.get(key)
+    if params is None:
+        params = CutlassMoEParams(
+            CutlassMoEType.BlockscaledFP4,
+            input.device,
+            num_experts=num_experts,
+            intermediate_size_per_partition=intermediate_size,
+            hidden_size=input.shape[1],
+        )
+        _nvfp4_small_moe_cutlass_params[key] = params
+    return params
+
+
 @debug_kernel_api
 def cutlass_scaled_fp4_mm(
     a: torch.Tensor,
@@ -211,6 +243,124 @@ def cutlass_fp4_group_mm(
         layout_sfa,
         layout_sfb,
     )
+    return output
+
+
+@debug_kernel_api
+def nvfp4_small_moe(
+    input: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    w13: torch.Tensor,
+    w13_scales: torch.Tensor,
+    g1_alpha: torch.Tensor,
+    g1_scale: torch.Tensor,
+    w2: torch.Tensor,
+    w2_scales: torch.Tensor,
+    g2_alpha: torch.Tensor,
+    g2_scale: torch.Tensor,
+    gemm1_clamp: Optional[torch.Tensor] = None,
+    routed_scaling_factor: float = 1.0,
+    w1_up_first: bool = True,
+) -> torch.Tensor:
+    """Small-M routed NVFP4 W4A4 path backed by CUTLASS grouped GEMM.
+
+    Production calls use the same block-scaled Tensor Core grouped GEMM as the
+    regular CUTLASS MoE path; this is both numerically faithful to the W4A4
+    contract and fast enough for the M=1/2 decode workload.  ``w1_up_first``
+    selects whether W13 is stored as [Up; Gate] (the FlashInfer/ModelOpt
+    TRT-LLM layout) or the historical [Gate; Up] layout.
+    """
+    assert input.dtype == torch.bfloat16
+    assert input.ndim == 2 and input.shape[0] <= 8 and input.shape[1] == 2048
+    assert topk_ids.dtype == torch.int32 and topk_ids.ndim == 2
+    assert topk_weights.dtype == torch.float32
+    assert topk_weights.shape == topk_ids.shape
+    assert topk_ids.shape[1] <= 8
+    assert w13.dtype == torch.uint8 and w2.dtype == torch.uint8
+    assert w13.ndim == 3 and w13.shape[1:] == (1024, 1024)
+    assert w2.ndim == 3 and w2.shape[1:] == (2048, 256)
+    assert w13.shape[0] == w2.shape[0]
+    assert w13_scales.dtype == torch.float8_e4m3fn
+    assert w2_scales.dtype == torch.float8_e4m3fn
+    assert g1_alpha.dtype == torch.float32 and g2_alpha.dtype == torch.float32
+    assert g1_scale.dtype == torch.float32 and g2_scale.dtype == torch.float32
+    if gemm1_clamp is None:
+        gemm1_clamp = torch.empty(0, dtype=torch.float32, device=input.device)
+    else:
+        assert gemm1_clamp.dtype == torch.float32
+
+    if gemm1_clamp.numel() != 0:
+        raise NotImplementedError("small-M CUTLASS path does not support GEMM1 clamp")
+
+    if w1_up_first:
+        # FlashInfer's SM120 CUTLASS kernel is the production Tensor Core
+        # implementation for the already-packed [Up; Gate] ModelOpt layout.
+        # Keep this fast path here so callers can opt in without rebuilding or
+        # copying the several-hundred-megabyte expert weight tensors.
+        from flashinfer.fused_moe import cutlass_fused_moe
+        from flashinfer.fused_moe.core import ActivationType
+
+        quant_scales = [
+            g1_scale,
+            w13_scales.view(torch.int32),
+            g1_alpha,
+            g2_scale,
+            w2_scales.view(torch.int32),
+            g2_alpha,
+        ]
+        output = cutlass_fused_moe(
+            input=input,
+            token_selected_experts=topk_ids.to(torch.int),
+            token_final_scales=topk_weights,
+            fc1_expert_weights=w13.view(torch.long),
+            fc2_expert_weights=w2.view(torch.long),
+            output_dtype=input.dtype,
+            quant_scales=quant_scales,
+            input_sf=None,
+            tp_size=1,
+            tp_rank=0,
+            ep_size=1,
+            ep_rank=0,
+            tune_max_num_tokens=max(1, int(input.shape[0])),
+            activation_type=ActivationType.Swiglu,
+        )[0]
+        if routed_scaling_factor != 1.0:
+            output = output * routed_scaling_factor
+        return output
+
+    num_experts = int(w13.shape[0])
+    intermediate_size = int(w13.shape[1] // 2)
+    params = _get_nvfp4_small_moe_cutlass_params(input, num_experts, intermediate_size)
+
+    def _per_expert_scale(scale: torch.Tensor) -> torch.Tensor:
+        if scale.numel() == 1:
+            return scale.reshape(1).expand(num_experts).contiguous()
+        assert (
+            scale.numel() == num_experts
+        ), f"expected scalar or {num_experts} activation scales, got {tuple(scale.shape)}"
+        return scale.reshape(num_experts).contiguous()
+
+    from sglang.srt.layers.moe.cutlass_moe import cutlass_moe_fp4
+
+    output = cutlass_moe_fp4(
+        input,
+        _per_expert_scale(g1_scale),
+        w13,
+        w13_scales,
+        g1_alpha,
+        _per_expert_scale(g2_scale),
+        w2,
+        w2_scales,
+        g2_alpha,
+        topk_weights,
+        topk_ids,
+        params,
+        no_combine=False,
+        w1_up_first=w1_up_first,
+    )
+    if routed_scaling_factor != 1.0:
+        output = output * routed_scaling_factor
     return output
 
 

--- a/python/sglang/srt/layers/moe/cutlass_moe.py
+++ b/python/sglang/srt/layers/moe/cutlass_moe.py
@@ -361,6 +361,7 @@ def cutlass_moe_fp4(
     params: CutlassMoEParams,
     apply_router_weight_on_input: bool = False,
     no_combine: bool = False,
+    w1_up_first: bool = False,
 ):
     """
     MoE implementation for FP4 Inputs
@@ -468,6 +469,15 @@ def cutlass_moe_fp4(
         params.to_gemm1_args(),
     )
     del rep_a_fp4, rep_a_blockscale
+
+    if w1_up_first:
+        # Some ModelOpt/FlashInfer checkpoints store W13 as [Up; Gate],
+        # whereas the historical CUTLASS path consumes [Gate; Up].  Swap the
+        # small GEMM output instead of copying every expert weight tensor.
+        c1 = c1.reshape(m_a * num_topk, 2, params.intermediate_size_per_partition)
+        c1 = c1.flip(dims=[1]).reshape(
+            m_a * num_topk, 2 * params.intermediate_size_per_partition
+        )
 
     # fused: SiLU + mul then FP4 quant (expert-packed)
     int_fp4, int_blockscale = silu_and_mul_scaled_fp4_experts_quant_packed(

--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextvars
+import os
 from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Generator, Optional, cast
@@ -44,6 +45,12 @@ from sglang.srt.utils.common import (
 _SGLANG_EXPERIMENTAL_LORA_OPTI = envs.SGLANG_EXPERIMENTAL_LORA_OPTI.get()
 
 logger = __import__("logging").getLogger(__name__)
+
+
+def _small_nvfp4_moe_enabled() -> bool:
+    """Opt-in gate for the experimental small-M CUTLASS path."""
+    return os.environ.get("SGLANG_NVFP4_SMALL_MOE", "0") == "1"
+
 
 _deferred_finalize_enabled: contextvars.ContextVar[bool] = contextvars.ContextVar(
     "flashinfer_trtllm_deferred_finalize_enabled", default=False
@@ -936,6 +943,53 @@ def fused_experts_none_to_flashinfer_trtllm_fp4(
 
     hidden_states = dispatch_output.hidden_states
     topk_output = dispatch_output.topk_output
+
+    # The TRT-LLM path has already converted ModelOpt weights to the
+    # FlashInfer-compatible packed W4A4 representation ([Up; Gate]).  For the
+    # decode-sized shapes used by Qwen3.6, the small-M FlashInfer CUTLASS path
+    # avoids the relatively expensive TRT-LLM dispatch setup.  Keep this
+    # explicitly
+    # opt-in until it has been validated on a particular deployment.
+    if (
+        _small_nvfp4_moe_enabled()
+        and not quant_info.use_per_token_activation
+        and getattr(dispatch_output, "hidden_states_scale", None) is None
+        and hidden_states.dtype == torch.bfloat16
+        and hidden_states.ndim == 2
+        and hidden_states.shape[0] <= 8
+        and hidden_states.shape[1] == 2048
+        and quant_info.intermediate_size_per_partition == 512
+        and quant_info.gemm1_clamp_limit is None
+        and not getattr(runner_config, "no_combine", False)
+        and TopKOutputChecker.format_is_standard(topk_output)
+        and topk_output.topk_ids.shape[1] <= 8
+    ):
+        from sglang.jit_kernel.nvfp4 import nvfp4_small_moe
+
+        # g1_scale_c = w2_input_scale_quant * g1_alphas_up.  Serialized
+        # ModelOpt checkpoints use a shared GEMM1 scale for gate/up, so this
+        # recovers the W2 input quantization scale without retaining another
+        # large parameter tensor in the runner metadata.
+        g2_scale = quant_info.g1_scale_c / quant_info.g1_alphas
+        output = nvfp4_small_moe(
+            hidden_states,
+            topk_output.topk_ids.to(torch.int32),
+            topk_output.topk_weights.to(torch.float32),
+            quant_info.w13_weight,
+            quant_info.w13_weight_scale,
+            quant_info.g1_alphas,
+            quant_info.w13_input_scale_quant,
+            quant_info.w2_weight,
+            quant_info.w2_weight_scale,
+            quant_info.g2_alphas,
+            g2_scale,
+            routed_scaling_factor=(
+                runner_config.routed_scaling_factor
+                if runner_config.routed_scaling_factor is not None
+                else 1.0
+            ),
+        )
+        return StandardCombineInput(hidden_states=output)
 
     # Quantize hidden states to FP4
     hidden_states_scale = (


### PR DESCRIPTION
## Motivation

On GB10 / SM121 with SGLang v0.5.15, decode-heavy ModelOpt NVFP4 MoE workloads use very small token counts (typically M=1/2, with M<=8 during CUDA Graph capture). The regular FlashInfer TRT-LLM route has non-trivial dispatch setup at these sizes.

This PR adds an explicit opt-in path for the Qwen3.6-35B-A3B NVFP4 shape. It reuses the FlashInfer SM120 CUTLASS fused MoE kernel and the already packed ModelOpt W4A4 weights. The default path is unchanged.

This PR targets `release/v0.5.15` because the relevant NVFP4 JIT and runner interfaces have since been refactored on `main`; a main-branch port needs separate validation against the new weight preparation path.

## Modifications

- Add `nvfp4_small_moe` for BF16, M<=8, hidden size 2048, intermediate size 512, and top-k<=8.
- Dispatch eligible ModelOpt NVFP4 decode calls when `SGLANG_NVFP4_SMALL_MOE=1`.
- Preserve the existing TRT-LLM path for all unsupported shapes and configurations.
- Support both `[Up; Gate]` and historical `[Gate; Up]` W13 layouts without copying expert weight tensors.
- Reject GEMM1 clamp and per-token activation cases from the opt-in route.

## Accuracy Tests

Tested on NVIDIA GB10 / SM121 with Torch 2.11.0+cu130 and FlashInfer 0.6.12.

| Case | Relative L2 error vs W4A4 reference | Max abs diff |
|---|---:|---:|
| M=1 | 0.36% | <=8.96e-4 |
| M=2 | 0.64% | <=8.96e-4 |
| M=4 | 0.51% | <=8.96e-4 |

Additional validation:

- Five deterministic prompts produced identical outputs.
- CUDA Graph capture succeeded for decode batch sizes 1/2/4.
- `pytest`: 27 supported NVFP4 tests passed.
- The full blockwise MoE parameterization has one pre-existing FP16 failure on SM120: the kernel explicitly supports only BF16 output. The BF16 case passes.

## Speed Tests and Profiling

Direct fused MoE latency:

| Tokens | Latency |
|---|---:|
| M=1 | 80.6 us |
| M=2 | 81.9 us |
| M=4 | 74.8 us |

End-to-end validation, Qwen3.6-35B-A3B-NVFP4, 2048 input tokens to 200 output tokens, concurrency 1, n=20:

- Output throughput: 61.07 tok/s
- Mean TPOT: 15.11 ms
- Mean TTFT: 267.80 ms
- Success: 20/20
- Concurrency 4 smoke test: 8/8 successful

These end-to-end numbers validate stability and integration; they are not presented as an isolated speedup attributable only to this dispatch change.

## Checklist

- [x] Format code with pre-commit (all modified-file hooks pass).
- [ ] Add new CI unit tests. Existing NVFP4 tests and model-level validation are included above.
- [ ] Update documentation. The path remains experimental and opt-in.
- [x] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style guidance.