### PR TITLE
[NPU] Reduce graph replay host overhead

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/graph_runner/npu_cudagraph_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/graph_runner/npu_cudagraph_backend.py
@@ -12,7 +12,7 @@ non-NPU hosts.
 
 from __future__ import annotations
 
-import threading
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import AbstractContextManager, contextmanager
 from functools import partial
 from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
@@ -62,6 +62,15 @@ class NPUCudaGraphBackend(BaseCudaGraphBackend):
         )
         self._enable_torch_compile = getattr(
             cuda_graph_runner, "enable_torch_compile", False
+        )
+        # NPUGraph.update must overlap with replay, but creating a fresh OS thread
+        # for every replay is expensive on the latency-sensitive decode path.
+        # Keep one device-bound worker per graph backend instead.
+        self._update_executor = ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix="npu-graph-update",
+            initializer=self._device_module.set_device,
+            initargs=(self._device_id,),
         )
 
     @contextmanager
@@ -166,17 +175,15 @@ class NPUCudaGraphBackend(BaseCudaGraphBackend):
 
         graph = self._graphs[shape_key]
 
-        def _update():
-            self._device_module.set_device(self._device_id)
-            graph.update(cpu_update_input=cpu_update_input)
-
-        thread = threading.Thread(target=_update)
-        thread.start()
+        update_future = self._update_executor.submit(
+            graph.update, cpu_update_input=cpu_update_input
+        )
         graph.replay()
-        thread.join()
+        update_future.result()
         return self._outputs[shape_key]
 
     def cleanup(self) -> None:
+        self._update_executor.shutdown(wait=True, cancel_futures=True)
         self._graphs.clear()
         self._outputs.clear()
         self._pool = None

--- a/python/sglang/srt/hardware_backend/npu/graph_runner/npu_graph_runner.py
+++ b/python/sglang/srt/hardware_backend/npu/graph_runner/npu_graph_runner.py
@@ -239,13 +239,18 @@ class NPUGraphRunner(DecodeCudaGraphRunner):
             is_deepseek_dsa(self.model_runner.model_config.hf_config)
             or is_deepseek_v4(self.model_runner.model_config.hf_config)
         ):
-            if forward_batch.forward_mode.is_target_verify():
-                seq_lens_cpu = forward_batch.seq_lens.cpu() + self.captured_req_width
-                seq_lens = seq_lens_cpu.tolist() + [0] * (self.bs - self.raw_bs)
+            # Speculative decoding already relays a CPU mirror of seq_lens for
+            # the NPU attention backends. Reuse it here instead of introducing
+            # another blocking D2H copy on every graph replay. Keep the device
+            # fallback for callers that do not publish the host mirror.
+            seq_lens_cpu = forward_batch.seq_lens_cpu
+            if seq_lens_cpu is None:
+                seq_lens_cpu = forward_batch.seq_lens[: self.raw_bs].cpu()
             else:
-                seq_lens = forward_batch.seq_lens.cpu().tolist() + [0] * (
-                    self.bs - self.raw_bs
-                )
+                seq_lens_cpu = seq_lens_cpu[: self.raw_bs]
+            if forward_batch.forward_mode.is_target_verify():
+                seq_lens_cpu = seq_lens_cpu + self.captured_req_width
+            seq_lens = seq_lens_cpu.tolist() + [0] * (self.bs - self.raw_bs)
             output = self.backend.replay_with_input_update(
                 graph_key,
                 seq_lens=seq_lens,


### PR DESCRIPTION
## Summary

- reuse a persistent, device-bound worker for NPU graph input updates instead of creating an OS thread on every replay
- reuse the existing CPU mirror of speculative-decoding sequence lengths to avoid a blocking device-to-host copy per replay
- preserve the device-copy fallback for callers without a host mirror

## Root cause

A same-code container comparison showed that the 813 CANN/PTA/TA/Python stack exposed a host-side decode bottleneck: throughput dropped from 186.07 tok/s on 723 to 173.09 tok/s on 813. The replay path created three short-lived threads per speculative round and redundantly copied sequence lengths from device to host. The upgraded runtime amplified this latent main-code overhead.

## Performance impact

On the 813 stack after this change:

- exact registered test throughput: 184.52 tok/s (baseline 177.49, required >173.94)
- TPOT: 5.29 ms (required <10 ms)
- three manual runs averaged 182.25 tok/s

## Validation

- `test/registered/npu/performance/qwen3_30b_a3b/test_npu_qwen3_30b_w8a8_1p_in3k5_out1k5_10ms.py` on CANN 9.1, torch_npu 2.10.0.post4, Python 3.12: passed
- `git diff --check`: passed
- Python bytecode compilation for both changed modules: passed with the workspace runtime

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32206847096](https://github.com/sgl-project/sglang/actions/runs/32206847096)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32206846900](https://github.com/sgl-project/sglang/actions/runs/32206846900)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->