### PR TITLE
[AMD] Create the hipBLAS handle before CUDA graph capture

### DIFF
--- a/python/sglang/srt/model_executor/runner/base_runner.py
+++ b/python/sglang/srt/model_executor/runner/base_runner.py
@@ -283,26 +283,16 @@ class BaseRunner(ABC):
 
     def _pre_initialize_hipblas_handle(self):
         """Force hipBLAS handle creation before CUDA graph capture on ROCm.
-
-        hipBLAS creates its handle lazily on first use. When a GEMM has no
-        tuned aiter config, aiter falls back to ``F.linear``, and if that first
-        call happens inside an active HIP graph capture the lazy
-        ``hipblasCreate`` is illegal: it returns
-        ``HIPBLAS_STATUS_INTERNAL_ERROR`` and invalidates the capture, which
-        then fails later with confusing errors (Triton "operation not permitted
-        when stream is capturing", or an abort in the aiter custom all-reduce).
-
         Running one tiny matmul here creates the handle on a normal stream so
         the fallback inside capture reuses it.
         """
         if not _is_hip:
             return
-
         try:
             a = torch.zeros((1, 1), dtype=self.model_runner.dtype, device="cuda")
             torch.matmul(a, a)
             torch.cuda.synchronize()
-        except Exception as e:  # pragma: no cover - warmup must never be fatal
+        except Exception as e:
             logger.warning(f"hipBLAS handle pre-initialization skipped: {e}")
 
     def _pre_initialize_fi_a2a_workspace(self):

--- a/python/sglang/srt/model_executor/runner/base_runner.py
+++ b/python/sglang/srt/model_executor/runner/base_runner.py
@@ -50,6 +50,7 @@ from sglang.srt.runtime_context import get_flags, get_parallel
 from sglang.srt.speculative.spec_info import create_dummy_verify_input
 from sglang.srt.utils import (
     empty_context,
+    is_hip,
     log_info_on_rank0,
     require_attn_tp_gather,
     require_gathered_buffer,
@@ -60,6 +61,8 @@ if TYPE_CHECKING:
     from sglang.srt.model_executor.model_runner import ModelRunner
 
 logger = logging.getLogger(__name__)
+
+_is_hip = is_hip()
 
 
 def _allocate_decode_buffers(
@@ -238,6 +241,7 @@ class BaseRunner(ABC):
 
         self._pre_initialize_flashinfer_allreduce_workspace()
         self._pre_initialize_fi_a2a_workspace()
+        self._pre_initialize_hipblas_handle()
 
         if should_run_flashinfer_autotune(self.model_runner):
             buffers, batch_size = self._autotune_buffers()
@@ -276,6 +280,30 @@ class BaseRunner(ABC):
             hidden_dim=mr.model_config.hidden_size,
             dtype=mr.dtype,
         )
+
+    def _pre_initialize_hipblas_handle(self):
+        """Force hipBLAS handle creation before CUDA graph capture on ROCm.
+
+        hipBLAS creates its handle lazily on first use. When a GEMM has no
+        tuned aiter config, aiter falls back to ``F.linear``, and if that first
+        call happens inside an active HIP graph capture the lazy
+        ``hipblasCreate`` is illegal: it returns
+        ``HIPBLAS_STATUS_INTERNAL_ERROR`` and invalidates the capture, which
+        then fails later with confusing errors (Triton "operation not permitted
+        when stream is capturing", or an abort in the aiter custom all-reduce).
+
+        Running one tiny matmul here creates the handle on a normal stream so
+        the fallback inside capture reuses it.
+        """
+        if not _is_hip:
+            return
+
+        try:
+            a = torch.zeros((1, 1), dtype=self.model_runner.dtype, device="cuda")
+            torch.matmul(a, a)
+            torch.cuda.synchronize()
+        except Exception as e:  # pragma: no cover - warmup must never be fatal
+            logger.warning(f"hipBLAS handle pre-initialization skipped: {e}")
 
     def _pre_initialize_fi_a2a_workspace(self):
         """Allocate the FlashInfer MNNVL all-to-all workspace for the fi_a2a DCP


### PR DESCRIPTION
`stage-b-test-2-gpu-large-amd-rocm720` has fails on and off since Aug-15th (5 / 7 scheduled runs) with `AssertionError: -1 not greater than 200` in `test_bench_one_batch_2gpu.py`. The `-1` means no throughput was measured because the server is died. see [this log](https://github.com/sgl-project/sglang/actions/runs/31916881653/job/95090118554), is:

```
[aiter] shape is M:1, N:14336, K:4096 ... not found tuned config in
        /tmp/aiter_configs/bf16_tuned_gemm.csv, will use default config!
aiter/tuned_gemm.py:514: bgemm_internal_cublaslt error:
        HIPBLAS_STATUS_INTERNAL_ERROR when calling hipblasLtMatmul
  out = F.linear(inp, weights, bias)
RuntimeError: Triton Error [HIP]: Code: 900, operation not permitted when stream is capturing
torch.AcceleratorError: HIP error: operation failed due to a previous error during capture
[AITER] custom_all_reduce.cuh:3412 fail to call hipIpcOpenMemHandle(...)
Fatal Python error: Aborted
```

The benchmarks Llama-3.1-8B and Mixtral-8x7B, and the aiter config merge this image pulled `llama70B`, `dsv3`, `dsv4`, `glm47`, `glm5`, `gptoss`, `kimi*`, `minimax_m3_eagle` and `qwen3_5_397b` — no configs to covere these two models. Thus the M:1 decode shapes have no tuned entry, and aiter takes the `F.linear` fallback.

hipBLAS handle on first use. When first use is the fallback inside an active HIP graph triggered, `hipblasCreate` is illegal, it returns `HIPBLAS_STATUS_INTERNAL_ERROR`. Everything after it is down.

This help function _pre_initialize_hipblas_handle(self), "Force hipBLAS handle creation before CUDA graph capture on ROCm
Running one tiny matmul here creates the handle on a normal stream such that the fallback inside capture reuses it.
it helps to pre-initialize hipblas handle.
## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32244967520](https://github.com/sgl-project/sglang/actions/runs/32244967520)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32244967029](https://github.com/sgl-project/sglang/actions/runs/32244967029)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->