### PR TITLE
Fix compressed-tensors dispatch for quantized lm_head

### DIFF
--- a/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -164,6 +164,7 @@ class CompressedTensorsConfig(QuantizationConfig):
         prefix: str,
     ) -> Optional[QuantizeMethodBase]:
         from sglang.srt.layers.linear import LinearBase
+        from sglang.srt.layers.vocab_parallel_embedding import ParallelLMHead
 
         if isinstance(layer, LinearBase):
             # If linear_fp8_config is set, use FP8 for linear layers
@@ -175,6 +176,17 @@ class CompressedTensorsConfig(QuantizationConfig):
                 return UnquantizedLinearMethod()
             layer.scheme = scheme
             return CompressedTensorsLinearMethod(self)
+
+        # ParallelLMHead inherits VocabParallelEmbedding, but its weights are
+        # consumed as a linear projection by the sampler. Quantized checkpoints
+        # therefore provide packed linear weights rather than an embedding weight.
+        if isinstance(layer, ParallelLMHead):
+            scheme = self.get_linear_scheme(layer=layer, layer_name=prefix)
+            if scheme is None:
+                return UnquantizedLinearMethod()
+            layer.scheme = scheme
+            return CompressedTensorsLinearMethod(self)
+
         from sglang.srt.layers.moe.fused_moe_triton import FusedMoE
 
         if isinstance(layer, FusedMoE):

--- a/test/registered/unit/layers/quantization/test_compressed_tensors_mixed_precision.py
+++ b/test/registered/unit/layers/quantization/test_compressed_tensors_mixed_precision.py
@@ -18,6 +18,7 @@ import torch
 
 from sglang.srt.layers.quantization.compressed_tensors.compressed_tensors import (
     CompressedTensorsConfig,
+    CompressedTensorsLinearMethod,
 )
 from sglang.srt.layers.quantization.compressed_tensors.schemes import (
     CompressedTensorsWNA16,
@@ -26,6 +27,7 @@ from sglang.srt.layers.quantization.compressed_tensors.utils import (
     check_equal_or_regex_match,
     should_ignore_layer,
 )
+from sglang.srt.layers.vocab_parallel_embedding import ParallelLMHead
 from sglang.test.test_utils import CustomTestCase
 
 EXPERTS_LAYER = "model.language_model.layers.0.mlp.experts"
@@ -186,6 +188,51 @@ class TestMixedPrecisionFormat(CustomTestCase):
         self.assertEqual(scheme.pack_factor, 32 // 4)
         self.assertEqual(scheme.strategy, "group")
         self.assertEqual(scheme.group_size, 128)
+
+
+class TestQuantizedParallelLMHead(CustomTestCase):
+    """A quantized lm_head must use the linear compressed-tensors path."""
+
+    def test_quantized_lm_head_uses_linear_method(self):
+        config = _mixed_precision_config(
+            {
+                **WNA16_GROUP,
+                "targets": ["lm_head"],
+            }
+        )
+        quant_config = CompressedTensorsConfig.from_config(config)
+
+        with mock.patch.object(
+            CompressedTensorsConfig, "_check_scheme_supported", return_value=True
+        ):
+            lm_head = ParallelLMHead(
+                64,
+                128,
+                params_dtype=torch.float16,
+                quant_config=quant_config,
+                prefix="lm_head",
+                enable_tp=False,
+            )
+
+        self.assertIsInstance(lm_head.quant_method, CompressedTensorsLinearMethod)
+        self.assertIsInstance(lm_head.scheme, CompressedTensorsWNA16)
+        self.assertFalse(hasattr(lm_head, "weight"))
+
+        loaded_weight = torch.arange(
+            lm_head.weight_packed.numel(), dtype=torch.int32
+        ).reshape_as(lm_head.weight_packed)
+        loaded_scale = torch.arange(
+            lm_head.weight_scale.numel(), dtype=torch.float16
+        ).reshape_as(lm_head.weight_scale)
+        loaded_shape = torch.tensor([64, 128], dtype=torch.int64)
+
+        for param, loaded in (
+            (lm_head.weight_packed, loaded_weight),
+            (lm_head.weight_scale, loaded_scale),
+            (lm_head.weight_shape, loaded_shape),
+        ):
+            param.weight_loader(param, loaded)
+            self.assertTrue(torch.equal(param, loaded))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Fixes #35358. A quantized compressed-tensors `lm_head` was treated as an embedding, so packed checkpoint tensors (`weight_packed` and `weight_scale`) were never loaded and inference used uninitialized logits.

## Modifications

- Dispatch `ParallelLMHead` through the compressed-tensors linear path.
- Add a CPU regression test that constructs a quantized `ParallelLMHead` and loads its packed checkpoint tensors through the registered weight loaders.

## Accuracy Tests

Not applicable: this is a loader/dispatch correction. The regression verifies quantized parameter creation and loading.

## Speed Tests and Profiling

Not applicable: this does not change an inference kernel or performance path.

## Checklist

- [x] Format touched code according to project conventions.
- [x] Add a unit test.
- [ ] Update documentation (not applicable).
- [x] Provide validation results; accuracy and speed benchmarks are not applicable.
- [x] Follow SGLang code style guidance.

## Validation

- `PYTHONPATH=$PWD/python python -m pytest test/registered/unit/layers/quantization/test_compressed_tensors_mixed_precision.py -q` : 6 passed (WSL, Python 3.12).
- Regression constructs `ParallelLMHead`, confirms it has CUDA-compatible packed parameters rather than a plain `weight`, and loads `weight_packed`, `weight_scale`, and `weight_shape` through their registered loaders.
- CUDA construction check on an NVIDIA GeForce RTX 3050 OEM: confirmed `CompressedTensorsLinearMethod`, `CompressedTensorsWNA16`, and CUDA-resident `weight_packed` / `weight_scale` parameters, with no plain `weight`.
- `git diff --check` passed.

## CI Status

The current Base and Extra PR test runs are failing. These results have not been used as validation; they need separate CI-log review.