### PR TITLE
Fix reasoning metrics and add TPOT to bench_multiturn

### DIFF
--- a/benchmark/hicache/bench_multiturn.py
+++ b/benchmark/hicache/bench_multiturn.py
@@ -17,6 +17,7 @@ from sglang.benchmark.utils import get_tokenizer
 from sglang.test.kits.cache_hit_kit import (
     async_request_openai_chat_completions,
     async_request_sglang_generate,
+    calculate_tpot_statistics,
     gen_payload,
     gen_payload_openai,
 )
@@ -362,6 +363,7 @@ class WorkloadGenerator:
         self.pbar = tqdm(total=self.total_requests)
         self.performance_metrics = {
             "ttft": [],
+            "tpot": [],
             "itl": [],
             "latency": [],
             "prompt_len": [],
@@ -457,16 +459,20 @@ class WorkloadGenerator:
                     )
                 current_round = self.client_records[client_id]["round"]
                 self.client_records[client_id]["round"] += 1
-                self.performance_metrics["ttft"].append(response.ttft)
+                if response.ttft > 0:
+                    self.performance_metrics["ttft"].append(response.ttft)
+                if getattr(response, "tpot", None) is not None:
+                    self.performance_metrics["tpot"].append(response.tpot)
                 self.performance_metrics["itl"].extend(response.itl)
                 self.performance_metrics["latency"].append(response.latency)
                 self.performance_metrics["prompt_len"].append(response.prompt_len)
                 self.performance_metrics["cached_tokens"].append(response.cached_tokens)
                 self.performance_metrics["generated_len"].append(response.generated_len)
                 if self.enable_round_barrier:
-                    self.performance_metrics[f"round_{current_round}"]["ttft"].append(
-                        response.ttft
-                    )
+                    if response.ttft > 0:
+                        self.performance_metrics[f"round_{current_round}"][
+                            "ttft"
+                        ].append(response.ttft)
                     self.performance_metrics[f"round_{current_round}"][
                         "latency"
                     ].append(response.latency)
@@ -582,9 +588,13 @@ class WorkloadGenerator:
         def max_or_zero(sorted_vals):
             return sorted_vals[-1] if sorted_vals else 0.0
 
+        tpot_statistics = calculate_tpot_statistics(
+            self.performance_metrics["tpot"]
+        )
+
         performance_data = {
             "summary": {
-                "total_requests": len(self.performance_metrics["ttft"]),
+                "total_requests": len(self.performance_metrics["latency"]),
                 "request_rate": self.request_rate,
                 "average_prompt_len": (
                     sum(self.performance_metrics["prompt_len"])
@@ -602,12 +612,17 @@ class WorkloadGenerator:
                 "p99_prompt_len": percentile(sorted_prompt_len, 0.99),
                 "p90_output_len": percentile(sorted_output_len, 0.9),
                 "p99_output_len": percentile(sorted_output_len, 0.99),
-                "average_ttft": sum(self.performance_metrics["ttft"])
-                / len(self.performance_metrics["ttft"]),
+                "average_ttft": (
+                    sum(self.performance_metrics["ttft"])
+                    / len(self.performance_metrics["ttft"])
+                    if self.performance_metrics["ttft"]
+                    else 0.0
+                ),
                 "p90_ttft": percentile(sorted_ttft, 0.9),
                 "p99_ttft": percentile(sorted_ttft, 0.99),
                 "median_ttft": percentile(sorted_ttft, 0.5),
                 "max_ttft": max_or_zero(sorted_ttft),
+                **tpot_statistics,
                 "average_itl": (
                     sum(self.performance_metrics["itl"])
                     / len(self.performance_metrics["itl"])
@@ -656,7 +671,7 @@ class WorkloadGenerator:
                         else sum(round_metrics["cached_tokens"])
                         / sum(round_metrics["prompt_len"])
                     ),
-                    "request_count": len(round_metrics["ttft"]),
+                    "request_count": len(round_metrics["latency"]),
                 }
         print("All requests completed")
         print("Performance metrics summary:")
@@ -686,6 +701,11 @@ class WorkloadGenerator:
         print(f"  P99 TTFT: {performance_data['summary']['p99_ttft']:.2f}")
         print(f"  Median TTFT: {performance_data['summary']['median_ttft']:.2f}")
         print(f"  Max TTFT: {performance_data['summary']['max_ttft']:.2f}")
+        print(f"  Average TPOT: {performance_data['summary']['average_tpot']:.4f}")
+        print(f"  P90 TPOT: {performance_data['summary']['p90_tpot']:.4f}")
+        print(f"  P99 TPOT: {performance_data['summary']['p99_tpot']:.4f}")
+        print(f"  Median TPOT: {performance_data['summary']['median_tpot']:.4f}")
+        print(f"  Max TPOT: {performance_data['summary']['max_tpot']:.4f}")
         print(f"  Average ITL: {performance_data['summary']['average_itl']:.4f}")
         print(f"  P90 ITL: {performance_data['summary']['p90_itl']:.4f}")
         print(f"  P99 ITL: {performance_data['summary']['p99_itl']:.4f}")

--- a/python/sglang/test/kits/cache_hit_kit.py
+++ b/python/sglang/test/kits/cache_hit_kit.py
@@ -3,6 +3,7 @@ import json
 import time
 
 import aiohttp
+import numpy as np
 import requests
 
 from sglang.benchmark.datasets.random import sample_random_requests
@@ -10,6 +11,40 @@ from sglang.benchmark.serving import RequestFuncOutput
 from sglang.benchmark.utils import get_tokenizer, remove_prefix
 
 AIOHTTP_TIMEOUT = aiohttp.ClientTimeout(total=20 * 60 * 60)
+
+
+def get_openai_chat_output_delta(delta):
+    """Return text emitted by an OpenAI-compatible chat streaming delta."""
+    if not delta:
+        return ""
+    reasoning = delta.get("reasoning_content") or delta.get("reasoning") or ""
+    return reasoning + (delta.get("content") or "")
+
+
+def calculate_tpot(latency, ttft, completion_tokens):
+    """Calculate request-level time per output token when inputs are valid."""
+    if ttft <= 0 or completion_tokens <= 1 or latency < ttft:
+        return None
+    return (latency - ttft) / (completion_tokens - 1)
+
+
+def calculate_tpot_statistics(tpots):
+    """Aggregate TPOT samples using the same NumPy definitions as bench_serving."""
+    if not tpots:
+        return {
+            "average_tpot": 0.0,
+            "p90_tpot": 0.0,
+            "p99_tpot": 0.0,
+            "median_tpot": 0.0,
+            "max_tpot": 0.0,
+        }
+    return {
+        "average_tpot": float(np.mean(tpots)),
+        "p90_tpot": float(np.percentile(tpots, 90)),
+        "p99_tpot": float(np.percentile(tpots, 99)),
+        "median_tpot": float(np.median(tpots)),
+        "max_tpot": float(np.max(tpots)),
+    }
 
 
 async def async_request_sglang_generate(
@@ -75,7 +110,10 @@ async def async_request_sglang_generate(
                     output.latency = latency
                     output.prompt_len = prompt_tokens
                     output.cached_tokens = cached_tokens
-                    output.generated_len = len(output.itl) + 1
+                    output.generated_len = len(all_output_ids)
+                    output.tpot = calculate_tpot(
+                        output.latency, output.ttft, output.generated_len
+                    )
                 else:
                     output.error = response.reason or ""
                     output.success = False
@@ -130,9 +168,10 @@ async def async_request_openai_chat_completions(
                             # Streaming token chunks
                             if data.get("choices"):
                                 raw_delta = data["choices"][0].get("delta")
-                                text = raw_delta.get("content", "") if raw_delta else ""
-                                if text:
-                                    generated_text += text
+                                output_delta = get_openai_chat_output_delta(raw_delta)
+                                if output_delta:
+                                    content = raw_delta.get("content") or ""
+                                    generated_text += content
                                     timestamp = time.perf_counter()
 
                                     if ttft == 0.0:
@@ -161,6 +200,9 @@ async def async_request_openai_chat_completions(
                     output.cached_tokens = cached_tokens
                     output.generated_len = (
                         completion_tokens if completion_tokens else len(output.itl) + 1
+                    )
+                    output.tpot = calculate_tpot(
+                        output.latency, output.ttft, output.generated_len
                     )
                 else:
                     output.error = response.reason or ""

--- a/test/registered/unit/test_cache_hit_kit_metrics.py
+++ b/test/registered/unit/test_cache_hit_kit_metrics.py
@@ -1,0 +1,59 @@
+import unittest
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.kits.cache_hit_kit import (
+    calculate_tpot,
+    calculate_tpot_statistics,
+    get_openai_chat_output_delta,
+)
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestCacheHitKitMetrics(CustomTestCase):
+    def test_openai_chat_output_delta(self):
+        self.assertEqual(get_openai_chat_output_delta({"content": "answer"}), "answer")
+        self.assertEqual(
+            get_openai_chat_output_delta({"reasoning_content": "think"}), "think"
+        )
+        self.assertEqual(get_openai_chat_output_delta({"reasoning": "think"}), "think")
+        self.assertEqual(
+            get_openai_chat_output_delta(
+                {"reasoning_content": "think", "content": "answer"}
+            ),
+            "thinkanswer",
+        )
+        self.assertEqual(get_openai_chat_output_delta({"role": "assistant"}), "")
+        self.assertEqual(get_openai_chat_output_delta(None), "")
+
+    def test_calculate_tpot(self):
+        self.assertAlmostEqual(calculate_tpot(1.1, 0.1, 101), 0.01)
+        self.assertIsNone(calculate_tpot(1.1, 0.0, 101))
+        self.assertIsNone(calculate_tpot(1.1, 0.1, 1))
+        self.assertIsNone(calculate_tpot(0.05, 0.1, 101))
+
+    def test_calculate_tpot_statistics(self):
+        stats = calculate_tpot_statistics([0.0024, 0.0025, 0.0026, 0.0035])
+
+        self.assertAlmostEqual(stats["average_tpot"], 0.00275)
+        self.assertAlmostEqual(stats["p90_tpot"], 0.00323)
+        self.assertAlmostEqual(stats["p99_tpot"], 0.003473)
+        self.assertAlmostEqual(stats["median_tpot"], 0.00255)
+        self.assertAlmostEqual(stats["max_tpot"], 0.0035)
+
+    def test_calculate_tpot_statistics_empty(self):
+        self.assertEqual(
+            calculate_tpot_statistics([]),
+            {
+                "average_tpot": 0.0,
+                "p90_tpot": 0.0,
+                "p99_tpot": 0.0,
+                "median_tpot": 0.0,
+                "max_tpot": 0.0,
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`bench_multiturn.py` only handles `delta.content` from OpenAI-compatible
streaming responses. Reasoning output returned through `reasoning_content` or
`reasoning` is ignored, which causes TTFT and ITL to be reported as zero.

The benchmark also does not report request-level TPOT.

Fixes #35438.

## Modifications

- Include `content`, `reasoning_content`, and `reasoning` when measuring TTFT
  and ITL.
- Calculate request-level TPOT using completion token counts.
- Use the same NumPy aggregation as `bench_serving` for Average, Median, P90,
  and P99.
- Report Average, P90, P99, Median, and Max TPOT.
- Add CPU unit tests for reasoning parsing, TPOT calculation, and percentile
  aggregation.

## Accuracy Tests

Tested with Qwen3-0.6B and `--reasoning-parser qwen3`.

Before the fix, all four requests completed with 32 output tokens per request,
but reasoning metrics were zero:

```text
Average TTFT: 0.00
P90 TTFT: 0.00
Average ITL: 0.0000
P90 ITL: 0.0000
```

After the fix:

```text
Average TTFT: 0.03
P90 TTFT: 0.03
Average TPOT: 0.0026
P90 TPOT: 0.0028
P99 TPOT: 0.0028
Median TPOT: 0.0026
Max TPOT: 0.0028
Average ITL: 0.0027
```

The independently calculated average TPOT matched the benchmark result:

```text
reported average_tpot = 0.002609
formula result         = 0.002609
```

Unit tests:

```text
Ran 4 tests in 0.001s

OK
```

## Speed Tests and Profiling

Not applicable. This PR only changes benchmark response parsing and metric
reporting.

## Checklist

- [x] Format code according to the project guidelines.
- [x] Add unit tests.
- [x] Documentation update is not required for this benchmark fix.
- [x] Accuracy results are included above; speed benchmarking is not applicable.
- [x] Follow the SGLang code style guidance.

cc @xiezhq-hermann @hzh0425 @hnyls2002 for review.
