### PR TITLE
[AMD] cookbook: serve Qwen3.5 MXFP4 on MI355X with an fp8_e4m3 KV cache

### DIFF
--- a/docs/src/snippets/autoregressive/qwen35-deployment.jsx
+++ b/docs/src/snippets/autoregressive/qwen35-deployment.jsx
@@ -480,6 +480,7 @@ export const Qwen35Deployment = () => {
         // (this recipe uses quick all-reduce instead of AITER allreduce fusion).
         // Add the FP4-specific flags here.
         cmd += ' \\\n  --disable-radix-cache';
+        cmd += ' \\\n  --kv-cache-dtype fp8_e4m3';
         // Cap concurrency under MTP to avoid OOM at tp=2.
         if (speculative === 'enabled') {
           cmd += ' \\\n  --max-running-requests 128';


### PR DESCRIPTION
## Motivation

The Qwen3.5 cookbook's MXFP4-on-MI355X recipe is benchmarked with an FP8 KV cache, but the generated deployment command does not emit `--kv-cache-dtype fp8_e4m3`, so anyone copying the command out of the cookbook gets a different configuration from the one the published MI355X numbers were measured with. The B200 NVFP4 recipe already emits this flag; this brings the AMD FP4 recipe in line.

## Modifications

`docs/src/snippets/autoregressive/qwen35-deployment.jsx`: add `--kv-cache-dtype fp8_e4m3` to the `mi355x` branch of the FP4-specific backend settings, next to the existing `--disable-radix-cache`. No other recipe is touched — the flag is emitted only for MXFP4 on MI355X, exactly as it already is for NVFP4 on B200. One line, one file.

## Accuracy Tests

No runtime code is touched; this changes only the command string the cookbook renders. The accuracy trade-off of an FP8 KV cache is unchanged and remains documented in the warning above the deployment table.

## Benchmarking

No benchmark impact from this PR itself — it documents the configuration the existing MI355X MXFP4 measurements already use.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32214963791](https://github.com/sgl-project/sglang/actions/runs/32214963791)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32214963382](https://github.com/sgl-project/sglang/actions/runs/32214963382)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->