### PR TITLE
Fix HiCache PP sync test fixture

### DIFF
--- a/test/registered/unit/mem_cache/test_hiradix_pp_sync_drain.py
+++ b/test/registered/unit/mem_cache/test_hiradix_pp_sync_drain.py
@@ -56,6 +56,7 @@ class TestUnifiedPPSyncBatching(unittest.TestCase):
         cache.pp_size = 2
         cache.enable_storage_metrics = False
         cache.storage_metrics_collector = None
+        cache.buffer_pipeline = None
         cache._drain_async_work = MagicMock()
         cache._all_reduce = MagicMock()
         cache.writing_check = MagicMock()


### PR DESCRIPTION
## Summary

- initialize `buffer_pipeline` in the manually constructed `UnifiedRadixCache` test fixture
- restore the HiCache PP synchronization unit test on the current `main` branch

## Root cause

`TestUnifiedPPSyncBatching._make_cache()` bypasses `UnifiedRadixCache.__init__()` with `object.__new__()`. After buffer-only HiCache support added a `buffer_pipeline` access to `check_hicache_events()`, the fixture no longer supplied every field that the method reads, causing:

```text
AttributeError: 'UnifiedRadixCache' object has no attribute 'buffer_pipeline'
```

This surfaced in PR #35306's `base-a-test-cpu (2)` job after PR #33473 and PR #34798 were both present on `main`.

## Validation

- commit pre-commit hooks passed, including Python AST, isort, ruff, codespell, and CI registry validation
- `python3 -m py_compile test/registered/unit/mem_cache/test_hiradix_pp_sync_drain.py`
- `git diff --check`

The full unit test could not run in the local macOS environment because the SGLang Python runtime dependencies are not installed; PR CI will validate it in the supported test environment.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32214486142](https://github.com/sgl-project/sglang/actions/runs/32214486142)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32214486123](https://github.com/sgl-project/sglang/actions/runs/32214486123)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->