### PR TITLE
[AMD][DI][CI] Run MI355X disagg nightly at 2am US Central Time

### DIFF
--- a/.github/workflows/nightly-amd-mi355x-disagg.yml
+++ b/.github/workflows/nightly-amd-mi355x-disagg.yml
@@ -6,7 +6,7 @@ name: Nightly Test (AMD MI355X 2N 1P1D Disagg)
 # scripts/ci/slurm/launch_mi355x.sh.
 on:
   schedule:
-    - cron: '0 8 * * *'  # 2:00 a.m. US Central Time (CST, UTC-6)
+    - cron: '0 7 * * *' 
   workflow_dispatch:
     inputs:
       image:

--- a/.github/workflows/nightly-amd-mi355x-disagg.yml
+++ b/.github/workflows/nightly-amd-mi355x-disagg.yml
@@ -6,7 +6,8 @@ name: Nightly Test (AMD MI355X 2N 1P1D Disagg)
 # scripts/ci/slurm/launch_mi355x.sh.
 on:
   schedule:
-    - cron: '17 3 * * *'  # 03:17 UTC
+    - cron: '0 2 * * *'  # 2:00 a.m. US Central Time (Texas)
+      timezone: 'America/Chicago'
   workflow_dispatch:
     inputs:
       image:

--- a/.github/workflows/nightly-amd-mi355x-disagg.yml
+++ b/.github/workflows/nightly-amd-mi355x-disagg.yml
@@ -6,8 +6,7 @@ name: Nightly Test (AMD MI355X 2N 1P1D Disagg)
 # scripts/ci/slurm/launch_mi355x.sh.
 on:
   schedule:
-    - cron: '0 2 * * *'  # 2:00 a.m. US Central Time (Texas)
-      timezone: 'America/Chicago'
+    - cron: '0 8 * * *'  # 2:00 a.m. US Central Time (CST, UTC-6)
   workflow_dispatch:
     inputs:
       image:


### PR DESCRIPTION
## Summary
- Reschedule `nightly-amd-mi355x-disagg.yml` from `03:17 UTC` to **2:00 a.m. US Central Time (Texas)**.
- Use GitHub Actions `timezone: America/Chicago` so the cron runs at 2am local time year-round, including automatic DST handling.

## Test plan
- [ ] Merge and confirm the next scheduled run appears at 2:00 a.m. Central in the Actions schedule UI.
- [ ] Optionally trigger `workflow_dispatch` to verify the workflow still runs end-to-end.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32222831147](https://github.com/sgl-project/sglang/actions/runs/32222831147)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32222830993](https://github.com/sgl-project/sglang/actions/runs/32222830993)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->