### PR TITLE
[Quant] Load compressed-tensors kv_cache_scheme scales

### DIFF
--- a/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -64,6 +64,7 @@ from sglang.srt.layers.quantization.compressed_tensors.utils import (
     should_ignore_layer,
 )
 from sglang.srt.layers.quantization.fp8 import Fp8LinearMethod
+from sglang.srt.layers.quantization.kv_cache import BaseKVCacheMethod
 from sglang.srt.layers.quantization.unquant import (
     UnquantizedFusedMoEMethod,
     UnquantizedLinearMethod,
@@ -131,6 +132,17 @@ class CompressedTensorsConfig(QuantizationConfig):
         self.packed_modules_mapping = packed_modules_mapping or {}
         self.linear_fp8_config = linear_fp8_config
 
+    @property
+    def kv_cache_quant_algo(self) -> Optional[str]:
+        """Duck-typed by configure_kv_cache_dtype to resolve --kv-cache-dtype
+        auto: loaded scales need the fp8 pool they calibrate, never bf16."""
+        if (
+            self.kv_cache_scheme is not None
+            and CompressedTensorsKVCacheMethod.is_supported_scheme(self.kv_cache_scheme)
+        ):
+            return "FP8"
+        return None
+
     def get_linear_method(self) -> CompressedTensorsLinearMethod:
         return CompressedTensorsLinearMethod(self)
 
@@ -156,8 +168,9 @@ class CompressedTensorsConfig(QuantizationConfig):
         self.sparsity_ignore_list = hf_to_sglang_mapper.apply_list(
             self.sparsity_ignore_list
         )
-        if self.kv_cache_scheme is not None:
-            self.kv_cache_scheme = hf_to_sglang_mapper.apply_dict(self.kv_cache_scheme)
+        # kv_cache_scheme is deliberately not remapped: it holds schema fields
+        # (type/num_bits/strategy), never module names, and apply_dict drops
+        # keys a mapper deletion rule happens to match.
 
     def get_quant_method(
         self,
@@ -186,6 +199,23 @@ class CompressedTensorsConfig(QuantizationConfig):
                 return None
             layer.scheme = scheme
             return CompressedTensorsLinearMethod(self)
+
+        from sglang.srt.layers.radix_attention import RadixAttention
+
+        if isinstance(layer, RadixAttention):
+            if self.kv_cache_scheme is None:
+                return None
+            if not CompressedTensorsKVCacheMethod.is_supported_scheme(
+                self.kv_cache_scheme
+            ):
+                # Degrade, don't refuse to boot: unquantized-scale KV serves fine.
+                logger.warning_once(
+                    f"Ignoring compressed-tensors kv_cache_scheme "
+                    f"{self.kv_cache_scheme}: only static symmetric "
+                    f"per-tensor FP8 scales are supported."
+                )
+                return None
+            return CompressedTensorsKVCacheMethod(self)
 
         from sglang.srt.layers.moe.fused_moe_triton import FusedMoE
 
@@ -271,6 +301,7 @@ class CompressedTensorsConfig(QuantizationConfig):
             quant_format=quant_format,
             sparsity_scheme_map=sparsity_scheme_map,
             sparsity_ignore_list=sparsity_ignore_list,
+            kv_cache_scheme=config.get("kv_cache_scheme"),
             config=config,
             packed_modules_mapping=packed_modules_mapping,
             linear_fp8_config=linear_fp8_config,
@@ -1083,6 +1114,27 @@ class CompressedTensorsConfig(QuantizationConfig):
             return False
 
         return weight_quant.num_bits == input_quant.num_bits == 8
+
+
+class CompressedTensorsKVCacheMethod(BaseKVCacheMethod):
+    """Load calibrated k_scale / v_scale from a compressed-tensors checkpoint
+    that declares a ``kv_cache_scheme`` (static per-tensor FP8)."""
+
+    def __init__(self, quant_config: CompressedTensorsConfig):
+        assert self.is_supported_scheme(quant_config.kv_cache_scheme)
+        super().__init__(quant_config)
+
+    @staticmethod
+    def is_supported_scheme(kv_cache_scheme: Dict[str, Any]) -> bool:
+        """Static symmetric per-tensor FP8 — all BaseKVCacheMethod can
+        represent. Dynamic schemes serialize no k_scale/v_scale tensors."""
+        return (
+            kv_cache_scheme.get("type") == "float"
+            and kv_cache_scheme.get("num_bits") == 8
+            and kv_cache_scheme.get("strategy") == "tensor"
+            and kv_cache_scheme.get("symmetric", True)
+            and not kv_cache_scheme.get("dynamic", False)
+        )
 
 
 class CompressedTensorsLinearMethod(LinearMethodBase):

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -1293,6 +1293,9 @@ QWEN3_5_KV_SCALE_MAPPER = WeightsMapper(
     orig_to_new_substr={
         ".self_attn.k_proj.k_scale": ".attn.k_scale",
         ".self_attn.v_proj.v_scale": ".attn.v_scale",
+        # compressed-tensors stores kv_cache_scheme scales on the attention module.
+        ".self_attn.k_scale": ".attn.k_scale",
+        ".self_attn.v_scale": ".attn.v_scale",
     },
 )
 

--- a/python/sglang/srt/models/qwen3_5_mtp.py
+++ b/python/sglang/srt/models/qwen3_5_mtp.py
@@ -33,7 +33,7 @@ from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
 from sglang.srt.layers.vocab_parallel_embedding import ParallelLMHead
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
-from sglang.srt.models.qwen3_5 import Qwen3_5ForCausalLM
+from sglang.srt.models.qwen3_5 import QWEN3_5_KV_SCALE_MAPPER, Qwen3_5ForCausalLM
 from sglang.srt.runtime_context import (
     get_model,
     get_parallel,
@@ -232,6 +232,7 @@ class Qwen3_5ForCausalLMMTP(nn.Module):
     def load_weights(
         self, weights: Iterable[Tuple[str, torch.Tensor]], is_mtp: bool = False
     ):
+        weights = QWEN3_5_KV_SCALE_MAPPER.apply(weights)
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             ("qkv_proj", "q_proj", "q"),

--- a/test/registered/unit/layers/quantization/test_compressed_tensors_kv_cache.py
+++ b/test/registered/unit/layers/quantization/test_compressed_tensors_kv_cache.py
@@ -1,0 +1,98 @@
+"""Unit tests for compressed-tensors KV cache scale loading — CPU-only."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+
+from sglang.srt.layers.quantization.compressed_tensors.compressed_tensors import (
+    CompressedTensorsConfig,
+    CompressedTensorsKVCacheMethod,
+)
+from sglang.srt.layers.radix_attention import RadixAttention
+from sglang.test.test_utils import CustomTestCase
+
+_FP8_TENSOR_KV_SCHEME = {
+    "type": "float",
+    "num_bits": 8,
+    "strategy": "tensor",
+    "symmetric": True,
+    "dynamic": False,
+}
+
+
+def _config(kv_cache_scheme):
+    cfg = {
+        "format": "float-quantized",
+        "quant_method": "compressed-tensors",
+        "ignore": [],
+        "config_groups": {
+            "group_0": {
+                "targets": ["Linear"],
+                "weights": {
+                    "num_bits": 8,
+                    "type": "float",
+                    "strategy": "channel",
+                    "symmetric": True,
+                    "dynamic": False,
+                },
+                "input_activations": {
+                    "num_bits": 8,
+                    "type": "float",
+                    "strategy": "token",
+                    "symmetric": True,
+                    "dynamic": True,
+                },
+            }
+        },
+    }
+    if kv_cache_scheme is not None:
+        cfg["kv_cache_scheme"] = kv_cache_scheme
+    return CompressedTensorsConfig.from_config(cfg)
+
+
+def _attn():
+    # __new__ is enough: get_quant_method only isinstance-checks the layer.
+    return RadixAttention.__new__(RadixAttention)
+
+
+class TestCompressedTensorsKVCacheMethod(CustomTestCase):
+    def test_declared_scheme_gets_kv_cache_method(self):
+        """A declared supported scheme must produce the KV cache method;
+        without it the calibrated k_scale/v_scale have no parameters to
+        load into and fp8 KV runs unscaled."""
+        config = _config(_FP8_TENSOR_KV_SCHEME)
+        method = config.get_quant_method(_attn(), "model.layers.0.attn")
+        self.assertIsInstance(method, CompressedTensorsKVCacheMethod)
+
+    def test_no_scheme_returns_none(self):
+        config = _config(None)
+        self.assertIsNone(config.get_quant_method(_attn(), "model.layers.0.attn"))
+
+    def test_kv_cache_quant_algo_resolves_auto_dtype(self):
+        """configure_kv_cache_dtype duck-types this field for --kv-cache-dtype
+        auto: supported schemes must report FP8, everything else None, so
+        loaded scales always meet an fp8 pool."""
+        self.assertEqual(_config(_FP8_TENSOR_KV_SCHEME).kv_cache_quant_algo, "FP8")
+        self.assertIsNone(_config(None).kv_cache_quant_algo)
+        self.assertIsNone(
+            _config(dict(_FP8_TENSOR_KV_SCHEME, dynamic=True)).kv_cache_quant_algo
+        )
+
+    def test_unsupported_scheme_degrades_to_none(self):
+        """Unsupported declared schemes must skip the method, not fail
+        the boot: such checkpoints serve with an unquantized-scale cache."""
+        for bad in (
+            dict(_FP8_TENSOR_KV_SCHEME, type="int"),
+            dict(_FP8_TENSOR_KV_SCHEME, strategy="channel"),
+            dict(_FP8_TENSOR_KV_SCHEME, symmetric=False),
+            dict(_FP8_TENSOR_KV_SCHEME, dynamic=True),
+        ):
+            self.assertIsNone(
+                _config(bad).get_quant_method(_attn(), "model.layers.0.attn")
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

compressed-tensors checkpoints that declare a `kv_cache_scheme` ship calibrated per-tensor attention `k_scale` / `v_scale` tensors, but they are silently dropped at load (`Parameter model.layers.N.k_scale not found in params_dict`), so `--kv-cache-dtype fp8_e4m3` runs the cache unscaled. Three gaps compound:

- `CompressedTensorsConfig.from_config` never forwarded `kv_cache_scheme`, leaving it `None` even when declared.
- `get_quant_method` had no `RadixAttention` branch, so the `k_scale` / `v_scale` parameters were never created (ModelOpt has `ModelOptFp8KVCacheMethod` for this; the compressed-tensors equivalent was missing).
- The qwen3_5 weight mapper only knew the ModelOpt-style `.k_proj.k_scale` serialization; compressed-tensors stores the scales on the attention module (`.self_attn.k_scale`).

## Modifications

- Forward `kv_cache_scheme` in `from_config`.
- New `CompressedTensorsKVCacheMethod(BaseKVCacheMethod)`, returned for `RadixAttention` when a `kv_cache_scheme` is declared. It accepts only what `BaseKVCacheMethod` can represent — static, symmetric, per-tensor FP8. A declared-but-unsupported scheme is skipped with a warning instead of failing the boot: such checkpoints serve correctly with an unquantized-scale KV cache, so refusing to load them would regress working deployments.
- A `kv_cache_quant_algo` property on the config: `configure_kv_cache_dtype` duck-types this field to resolve `--kv-cache-dtype auto`, so a declared supported scheme gets the fp8 pool its scales calibrate (ModelOpt parity). Without this, an auto-resolved bf16 pool would store unscaled entries while the attention backends apply the loaded scales on read.
- Two `orig_to_new_substr` entries in `QWEN3_5_KV_SCALE_MAPPER` for the attention-level scale names, and the mapper applied in the Qwen3.5 MTP loader for symmetry.
- Unit test: `test/registered/unit/layers/quantization/test_compressed_tensors_kv_cache.py` (CPU, `base-a-test-cpu`).
- The pre-existing `kv_cache_scheme` remap in `apply_weight_name_mapper` (dead until this PR forwarded the scheme) is removed: the scheme holds schema fields, never module names, and `apply_dict` drops keys that match a mapper deletion rule.

Checkpoints without a `kv_cache_scheme` are unaffected (`get_quant_method` returns `None` for `RadixAttention` as before), and unloaded scales keep the existing default-to-1.0 behavior in `BaseKVCacheMethod.process_weights_after_loading`.

## Accuracy Tests

RTX PRO 6000 Blackwell, Qwen3.8-27B mixed-precision compressed-tensors checkpoint with a declared FP8 `kv_cache_scheme`, `--kv-cache-dtype fp8_e4m3`, `sglang.test.few_shot_gsm8k --num-questions 200`:

- Before: 32 `k_scale`/`v_scale` drop warnings at load; GSM8K 0.960 (cache unscaled — accuracy-benign on this checkpoint because the calibrated scales are near 1, but incorrect).
- After: zero drop warnings; GSM8K 0.965, invalid 0.000. Parity within the script's documented variance — this is a correctness fix for the calibration path, not an accuracy rescue.
- With `--kv-cache-dtype` left as `auto`: the pool now auto-resolves to `float8_e4m3fn` (previously bf16, ignoring the checkpoint's declared KV calibration); zero drop warnings; GSM8K 0.940 / 0.960 across two runs — statistically identical to the explicit-fp8 lane, as expected since both resolve to the same pool and scales.

Note: an MTP draft loaded from the same checkpoint carries the same config, so the draft worker's pool auto-resolves to fp8 as well (its scales default to 1.0; write/read stay symmetric). A standalone bf16 draft export without a `quantization_config` keeps a bf16 pool.

Known limit: an explicit bf16 `--kv-cache-dtype` override on a checkpoint with declared scales attaches scales to an unquantized pool — the same pre-existing exposure ModelOpt has today; a shared fix belongs in `BaseKVCacheMethod`.

## Speed Tests and Profiling

No runtime impact: scale resolution happens once at init; the scales feed the existing fp8 KV cache path.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32309974666](https://github.com/sgl-project/sglang/actions/runs/32309974666)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32309974540](https://github.com/sgl-project/sglang/actions/runs/32309974540)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->