### PR TITLE
[AMD] [CI] Fix ROCm aiter attention backend rejecting grouped-query attention

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/attention/backends/aiter.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/backends/aiter.py
@@ -128,13 +128,28 @@ class AITerImpl(AttentionImpl):
         dropout_p: float = 0.0,
         **extra_impl_args,
     ) -> None:
-        if num_kv_heads is not None and num_kv_heads != num_heads:
-            raise NotImplementedError(
-                "AITer backend does not support Grouped Query Attention yet."
+        if num_kv_heads is None:
+            num_kv_heads = num_heads
+        if num_kv_heads <= 0 or num_heads % num_kv_heads != 0:
+            raise ValueError(
+                f"num_heads ({num_heads}) must be a positive multiple of "
+                f"num_kv_heads ({num_kv_heads})."
             )
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        # aiter.flash_attn_func broadcasts KV heads internally (MHA/GQA/MQA);
+        # only the FP8 FMHA ASM kernel is MHA-only, gated below.
+        self.is_gqa = num_kv_heads != num_heads
         self.causal = causal
         self.dropout_p = dropout_p
         self.softmax_scale = softmax_scale
+        if _use_fp8_attn and self.is_gqa:
+            logger.warning_once(
+                "FP8 FMHA prefill requires full MHA; got num_heads=%d, num_kv_heads=%d. "
+                "Using BF16 attention for this layer.",
+                num_heads,
+                num_kv_heads,
+            )
 
     @torch.compiler.disable
     def forward(
@@ -149,16 +164,19 @@ class AITerImpl(AttentionImpl):
           - _fmha_fp8_prefill_attention (FP8, SGLANG_DIFFUSION_AITER_FP8_ATTN=1 when eligible)
           - flash_attn_func (BF16, default or FP8 fallback for unsupported shapes)
 
+        ``num_kv_heads`` may be smaller than ``num_heads`` (GQA/MQA); the KV
+        heads are broadcast inside the aiter kernel.
+
         Args:
             query: Query tensor of shape [batch_size, seq_len, num_heads, head_dim]
-            key: Key tensor of shape [batch_size, seq_len, num_heads, head_dim]
-            value: Value tensor of shape [batch_size, seq_len, num_heads, head_dim]
+            key: Key tensor of shape [batch_size, seq_len, num_kv_heads, head_dim]
+            value: Value tensor of shape [batch_size, seq_len, num_kv_heads, head_dim]
             attn_metadata: Metadata for the attention operation (unused).
 
         Returns:
             Output tensor of shape [batch_size, seq_len, num_heads, head_dim]
         """
-        if _use_fp8_attn:
+        if _use_fp8_attn and not self.is_gqa:
             if query.dtype != _fp8_dtype:
                 q_fp8, q_scale = aiter.per_tensor_quant(query, quant_dtype=_fp8_dtype)
                 k_fp8, k_scale = aiter.per_tensor_quant(key, quant_dtype=_fp8_dtype)
@@ -204,6 +222,7 @@ class AITerImpl(AttentionImpl):
             key,
             value,
             dropout_p=self.dropout_p,
+            softmax_scale=self.softmax_scale,
             causal=self.causal,
             return_attn_probs=False,
             return_lse=True,

--- a/python/sglang/multimodal_gen/test/unit/test_aiter_attention_gqa.py
+++ b/python/sglang/multimodal_gen/test/unit/test_aiter_attention_gqa.py
@@ -1,0 +1,81 @@
+"""The ROCm AITer attention backend must accept grouped-query attention.
+
+Cosmos3's cross-attention is GQA (32 query heads / 8 KV heads). The backend
+used to reject any ``num_kv_heads != num_heads`` at construction time, which
+made every GQA DiT unloadable on ROCm. ``aiter.flash_attn_func`` broadcasts KV
+heads itself, so the only restriction left is the FP8 FMHA ASM kernel, which
+stays MHA-only.
+"""
+
+import unittest
+
+import torch
+
+try:
+    import aiter  # noqa: F401
+
+    from sglang.multimodal_gen.runtime.layers.attention.backends.aiter import AITerImpl
+
+    AITER_AVAILABLE = True
+except ImportError:
+    AITER_AVAILABLE = False
+
+
+HEAD_DIM = 128
+
+
+@unittest.skipUnless(AITER_AVAILABLE, "aiter is unavailable (non-ROCm platform)")
+class TestAITerGroupedQueryAttention(unittest.TestCase):
+    def _impl(self, num_heads: int, num_kv_heads: int | None) -> "AITerImpl":
+        return AITerImpl(
+            num_heads=num_heads,
+            head_size=HEAD_DIM,
+            softmax_scale=HEAD_DIM**-0.5,
+            num_kv_heads=num_kv_heads,
+        )
+
+    def test_gqa_head_counts_are_accepted(self):
+        # Cosmos3-Nano cross-attention.
+        impl = self._impl(num_heads=32, num_kv_heads=8)
+        self.assertEqual(impl.num_kv_heads, 8)
+        self.assertTrue(impl.is_gqa)
+
+    def test_mqa_head_counts_are_accepted(self):
+        impl = self._impl(num_heads=32, num_kv_heads=1)
+        self.assertTrue(impl.is_gqa)
+
+    def test_num_kv_heads_defaults_to_num_heads(self):
+        impl = self._impl(num_heads=32, num_kv_heads=None)
+        self.assertEqual(impl.num_kv_heads, 32)
+        self.assertFalse(impl.is_gqa)
+
+    def test_indivisible_head_counts_are_rejected(self):
+        with self.assertRaises(ValueError):
+            self._impl(num_heads=32, num_kv_heads=7)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "GPU is unavailable")
+    def test_gqa_forward_matches_sdpa(self):
+        torch.manual_seed(0)
+        batch, seq_len, num_heads, num_kv_heads = 1, 512, 32, 8
+        shape_q = (batch, seq_len, num_heads, HEAD_DIM)
+        shape_kv = (batch, seq_len, num_kv_heads, HEAD_DIM)
+        q = torch.randn(shape_q, device="cuda", dtype=torch.bfloat16)
+        k = torch.randn(shape_kv, device="cuda", dtype=torch.bfloat16)
+        v = torch.randn(shape_kv, device="cuda", dtype=torch.bfloat16)
+
+        out = self._impl(num_heads=num_heads, num_kv_heads=num_kv_heads).forward(
+            q, k, v
+        )
+
+        ref = torch.nn.functional.scaled_dot_product_attention(
+            q.transpose(1, 2),
+            k.transpose(1, 2),
+            v.transpose(1, 2),
+            enable_gqa=True,
+        ).transpose(1, 2)
+        self.assertEqual(out.shape, ref.shape)
+        torch.testing.assert_close(out, ref, atol=2e-2, rtol=2e-2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`multimodal-gen-test-1-gpu-amd-rocm720` fails at server startup for `cosmos3_nano_t2v` (and `cosmos3_nano_t2i` in the sibling shard):
[run 32009315390 / job 95325370019](https://github.com/sgl-project/sglang/actions/runs/32009315390/job/95325370019)

```
RuntimeError: Server exited early (code 1).
...
File ".../runtime/layers/attention/backends/aiter.py", line 132, in __init__
  raise NotImplementedError(
NotImplementedError: AITer backend does not support Grouped Query Attention yet.
[Error while loading customized transformer, falling back to native version]
...
AttributeError: module diffusers has no attribute Cosmos3OmniTransformer
```

On ROCm the diffusion server defaults to the `aiter` attention backend, and `AITerImpl.__init__` rejected any `num_kv_heads != num_heads`. Cosmos3's cross-attention is GQA (`num_attention_heads=32`, `num_key_value_heads=8`), so `Cosmos3CrossAttention` → `USPAttention` → `AITerImpl` raised at construction. The component loader swallowed that, fell back to loading the transformer through native diffusers, and died there with the misleading `AttributeError` above. Net effect: the whole 1-GPU AMD diffusion shard is red on a Cosmos3 case that has nothing to do with attention support.

The guard is stale. `aiter.flash_attn_func` documents and implements MQA/GQA by broadcasting KV heads internally; only the FP8 FMHA ASM kernel (`fmha_fwd_hd128_fp8_gfx950`) is MHA-only, and that was already gated separately by `_can_use_fmha_fp8_prefill`.

This failure is unrelated to #34424 — it reproduces on `main`.

## Modifications

- `runtime/layers/attention/backends/aiter.py`
  - Replace the blanket `NotImplementedError` with a `num_heads % num_kv_heads` divisibility check, and store `num_heads` / `num_kv_heads` / `is_gqa` on the impl (other backends, e.g. `flash_attn.py`, already just store and forward).
  - Under `SGLANG_DIFFUSION_AITER_FP8_ATTN=1`, a GQA layer now short-circuits to BF16 before the per-tensor quantization instead of quantizing q/k/v and then discarding the result inside `_can_use_fmha_fp8_prefill`; it warns once at construction instead of per forward.
  - Pass `softmax_scale=self.softmax_scale` to `aiter.flash_attn_func` in the BF16 path. It was silently dropped, so the kernel always used its `head_dim**-0.5` default. That matches `USPAttention`'s default scale, so nothing changes numerically today, but any layer passing a custom scale was computing the wrong attention.
- `test/unit/test_aiter_attention_gqa.py` (new): GQA/MQA head counts are accepted, indivisible counts are rejected, `num_kv_heads=None` defaults to MHA, and the GQA forward matches `scaled_dot_product_attention(enable_gqa=True)`. Auto-discovered by the `unit` suite (`_discover_unit_tests()`), skipped where `aiter` is unavailable.


## Regression origin

The `NotImplementedError` guard has been in `aiter.py` since the first diffusion commit (7bc1dae095, #12484, 2025-11-06) and was never revisited. ROCm started defaulting to the `aiter` backend in 4bf06635fc (#13760, 2025-12-19), and Cosmos3's GQA cross-attention landed in c317beda99 (#24994, 2026-05-27).

What turned this into a red AMD shard is **9450696aa5 (#26963, 2026-06-03)**, which added `cosmos3_nano_t2v` to `ONE_GPU_CASES`. The AMD 1-GPU diffusion job runs that list unfiltered, so the case has been failing on ROCm ever since. Its own CI run already shows it — [job 79235268110](https://github.com/sgl-project/sglang/actions/runs/26867753832/job/79235268110) (shard 2, `cosmos3_nano_t2v`) and [job 79235268130](https://github.com/sgl-project/sglang/actions/runs/26867753832/job/79235268130) (shard 1, `cosmos3_nano_t2i`) both log `NotImplementedError: AITer backend does not support Grouped Query Attention yet.` on 2026-06-03.

## Accuracy Tests

MI355X, ROCm, one GPU.

`python -m pytest python/sglang/multimodal_gen/test/unit/test_aiter_attention_gqa.py` — 5 passed.

GQA forward vs `scaled_dot_product_attention(enable_gqa=True)`, bf16, `[1, 512, 32/8, 128]`:

| Metric | Value |
|---|---|
| max abs diff | 1.95e-3 |

`test_server_1_gpu.py::TestDiffusionServerOneGpu::test_diffusion_generation[cosmos3_nano_t2v]`:

| | Before | After |
|---|---|---|
| Server startup | `NotImplementedError` → exit code 1 | starts, loads the customized `Cosmos3OmniTransformer` |
| Generation | never reached | completes (denoise 111.6 ms, decode 25.6 ms) |

The startup crash this PR targets is gone.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #32224262860](https://github.com/sgl-project/sglang/actions/runs/32224262860)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32224262635](https://github.com/sgl-project/sglang/actions/runs/32224262635)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->