### PR TITLE
[Feature] Support Kimi-K3 FlashInfer MXFP4 MoE on SM120

### DIFF
--- a/python/sglang/srt/layers/attn_residual.py
+++ b/python/sglang/srt/layers/attn_residual.py
@@ -8,7 +8,7 @@
 #   fast  — warp-specialized TMA kernel: cp.async.bulk producer +
 #           online-softmax consumers over a double-buffered chunk ring, out
 #           norm fused, per-nvb tuned launch config, one persistent CTA per
-#           SM. Taken on SM100+ with H=7168.
+#           SM. Taken on GB100/GB200/GB300 (SM100/SM103/SM110) with H=7168.
 #   hip   — single Triton kernel, everything in one launch; taken on ROCm
 #           within its register budget.
 #   fused — Triton 2-kernel pipeline with full H-parallelism; the fallback
@@ -34,14 +34,17 @@ _HIP_SHAPE_GATE = None
 
 
 def _use_fast(hidden_size: int) -> bool:
-    """The TMA kernel needs SM100+ (tcgen05, cp.async.bulk) and its H=7168
-    template instantiation; everything else takes the triton pipeline."""
+    """Select the tcgen05 TMA kernel only on supported data-center Blackwell.
+
+    RTX 6000D is SM120 but does not support this GB100/GB200/GB300-specific
+    kernel. It must use the Triton pipeline.
+    """
     global _FAST_SUPPORTED
     if is_npu():
         return False
     if _FAST_SUPPORTED is None:
         major, _ = torch.cuda.get_device_capability()
-        _FAST_SUPPORTED = major >= 10
+        _FAST_SUPPORTED = major in (10, 11)
     return _FAST_SUPPORTED and hidden_size == 7168
 
 

--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_cutlass.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_cutlass.py
@@ -8,6 +8,7 @@ Quantization methods prepare a small quant_info payload and route through
 
 from __future__ import annotations
 
+import inspect
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional
 
@@ -89,6 +90,10 @@ class FlashInferCutlassMxfp4MoeQuantInfo(MoeQuantInfo):
     swiglu_beta: Optional[torch.Tensor] = None
     swiglu_limit: Optional[torch.Tensor] = None
 
+    # Optional per-expert SiTU scales, fp32 [E] (FlashInfer PR #4460).
+    situ_beta: Optional[torch.Tensor] = None
+    situ_linear_beta: Optional[torch.Tensor] = None
+
     # TP/EP topology (forwarded to the FlashInfer kernel)
     moe_tp_size: int = 1
     moe_tp_rank: int = 0
@@ -109,6 +114,20 @@ def _flashinfer_cutlass_fused_moe():
     from flashinfer.fused_moe.core import ActivationType
 
     return cutlass_fused_moe, ActivationType
+
+
+def flashinfer_cutlass_supports_situ() -> bool:
+    """Return whether the installed FlashInfer exposes the PR #4460 API."""
+    try:
+        cutlass_fused_moe, activation_type = _flashinfer_cutlass_fused_moe()
+        parameters = inspect.signature(cutlass_fused_moe).parameters
+    except (ImportError, RuntimeError, TypeError, ValueError):
+        return False
+    return (
+        hasattr(activation_type, "Situ")
+        and "situ_beta" in parameters
+        and "situ_linear_beta" in parameters
+    )
 
 
 def _activation_type(runner_config: MoeRunnerConfig):
@@ -385,6 +404,8 @@ def fused_experts_none_to_flashinfer_mxfp4(
         swiglu_alpha=quant_info.swiglu_alpha,
         swiglu_beta=quant_info.swiglu_beta,
         swiglu_limit=quant_info.swiglu_limit,
+        situ_beta=quant_info.situ_beta,
+        situ_linear_beta=quant_info.situ_linear_beta,
         tp_size=quant_info.moe_tp_size,
         tp_rank=quant_info.moe_tp_rank,
         ep_size=quant_info.moe_ep_size,

--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_cutlass.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_cutlass.py
@@ -134,8 +134,11 @@ def _activation_type(runner_config: MoeRunnerConfig):
     from sglang.srt.layers.moe.moe_runner.flashinfer_trtllm import get_activation_type
 
     _, ActivationType = _flashinfer_cutlass_fused_moe()
+    situ_type = getattr(ActivationType, "Situ", None)
     if runner_config.activation == "situ" and runner_config.is_gated:
-        activation = ActivationType.Situ
+        if situ_type is None:
+            raise RuntimeError("FlashInfer CUTLASS SiTU support is not available.")
+        activation = situ_type
     else:
         activation = ActivationType(
             get_activation_type(
@@ -148,8 +151,9 @@ def _activation_type(runner_config: MoeRunnerConfig):
         ActivationType.Geglu,
         ActivationType.Relu2,
         ActivationType.Identity,
-        ActivationType.Situ,
     }
+    if situ_type is not None:
+        supported.add(situ_type)
     assert activation in supported, (
         f"Activation {runner_config.activation!r} "
         f"(is_gated={runner_config.is_gated}) maps to {activation.name}, "

--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_cutlass.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_cutlass.py
@@ -90,7 +90,7 @@ class FlashInferCutlassMxfp4MoeQuantInfo(MoeQuantInfo):
     swiglu_beta: Optional[torch.Tensor] = None
     swiglu_limit: Optional[torch.Tensor] = None
 
-    # Optional per-expert SiTU scales, fp32 [E] (FlashInfer PR #4460).
+    # Optional per-expert SiTU scales, fp32 [E].
     situ_beta: Optional[torch.Tensor] = None
     situ_linear_beta: Optional[torch.Tensor] = None
 
@@ -117,7 +117,7 @@ def _flashinfer_cutlass_fused_moe():
 
 
 def flashinfer_cutlass_supports_situ() -> bool:
-    """Return whether the installed FlashInfer exposes the PR #4460 API."""
+    """Return whether the installed FlashInfer exposes the CUTLASS SiTU API."""
     try:
         cutlass_fused_moe, activation_type = _flashinfer_cutlass_fused_moe()
         parameters = inspect.signature(cutlass_fused_moe).parameters

--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_cutlass.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_cutlass.py
@@ -115,17 +115,21 @@ def _activation_type(runner_config: MoeRunnerConfig):
     from sglang.srt.layers.moe.moe_runner.flashinfer_trtllm import get_activation_type
 
     _, ActivationType = _flashinfer_cutlass_fused_moe()
-    activation = ActivationType(
-        get_activation_type(
-            runner_config.activation,
-            is_gated=runner_config.is_gated,
+    if runner_config.activation == "situ" and runner_config.is_gated:
+        activation = ActivationType.Situ
+    else:
+        activation = ActivationType(
+            get_activation_type(
+                runner_config.activation,
+                is_gated=runner_config.is_gated,
+            )
         )
-    )
     supported = {
         ActivationType.Swiglu,
         ActivationType.Geglu,
         ActivationType.Relu2,
         ActivationType.Identity,
+        ActivationType.Situ,
     }
     assert activation in supported, (
         f"Activation {runner_config.activation!r} "
@@ -308,7 +312,7 @@ def fused_experts_none_to_flashinfer_mxfp4(
         quant_info, FlashInferCutlassMxfp4MoeQuantInfo
     ), f"Unexpected quant_info type for flashinfer_mxfp4: {type(quant_info)}"
 
-    flashinfer_cutlass_fused_moe, ActivationType = _flashinfer_cutlass_fused_moe()
+    flashinfer_cutlass_fused_moe, _ = _flashinfer_cutlass_fused_moe()
 
     x = dispatch_output.hidden_states
     topk_output = dispatch_output.topk_output
@@ -386,7 +390,7 @@ def fused_experts_none_to_flashinfer_mxfp4(
         ep_rank=quant_info.moe_ep_rank,
         use_w4_group_scaling=not use_mxfp8_act_scaling,
         use_mxfp8_act_scaling=use_mxfp8_act_scaling,
-        activation_type=ActivationType.Swiglu,
+        activation_type=_activation_type(runner_config),
         tune_max_num_tokens=next_power_of_2(x.shape[0]),
         output=out,
         use_fused_finalize=envs.SGLANG_FLASHINFER_MOE_FUSED_FINALIZE.get(),

--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_cutlass.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_cutlass.py
@@ -346,6 +346,7 @@ def fused_experts_none_to_flashinfer_mxfp4(
     if weight_global_scale is not None:
         from flashinfer import mxfp8_quantize
 
+        x = x.contiguous()
         x, input_sf = mxfp8_quantize(
             x,
             is_sf_swizzled_layout=True,

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -1153,15 +1153,14 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         torch.cuda.empty_cache()
 
     def _process_weights_for_sm120_cutlass(self, layer):
-        """Prepare GPT-OSS MXFP4 experts for FlashInfer CUTLASS on SM120.
+        """Prepare MXFP4 experts for FlashInfer CUTLASS on SM120.
 
-        GPT-OSS stores gate/up rows pair-wise as
-        ``[gate_0, up_0, gate_1, up_1, ...]``. FlashInfer's fused MoE consumes
-        two contiguous halves in ``[up; gate]`` order. Build that layout after
-        checkpoint loading so padding cannot move the split, pad both GEMMs to
-        CUTLASS's 128-element alignment, and swizzle the native E8M0 scales for
-        the SM120 MXFP8-by-MXFP4 kernels. Packed FP4 weight bytes themselves do
-        not need an SM120 permutation.
+        FlashInfer consumes two contiguous halves in ``[up; gate]`` order.
+        GPT-OSS checkpoints store pair-interleaved ``[gate_i, up_i]`` rows,
+        while Kimi-K3 stores contiguous ``[gate; up]`` halves. Normalize either
+        layout after loading, pad both GEMMs to CUTLASS's 128-element alignment,
+        and swizzle the native E8M0 scales. Packed FP4 bytes need no additional
+        SM120 permutation.
         """
         from flashinfer import block_scale_interleave
 
@@ -1173,9 +1172,15 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         E = layer.num_local_experts
         device = layer.w13_weight.device
 
+        gate_up_interleaved = self.moe_runner_config.gate_up_interleaved
+
+        def _split_gate_up(unpadded):
+            if gate_up_interleaved:
+                return unpadded[:, 0::2, :], unpadded[:, 1::2, :]
+            return unpadded[:, :N_un, :], unpadded[:, N_un : 2 * N_un, :]
+
         def _stack_up_gate_w13(unpadded, last_pad, last_un):
-            gate_rows = unpadded[:, 0::2, :]
-            up_rows = unpadded[:, 1::2, :]
+            gate_rows, up_rows = _split_gate_up(unpadded)
             out = torch.zeros(
                 E, 2 * N_pad, last_pad, dtype=unpadded.dtype, device=device
             )
@@ -1192,8 +1197,14 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
 
         bias_dtype = layer.w13_weight_bias.dtype
         w13_bias_padded = torch.zeros(E, 2 * N_pad, dtype=bias_dtype, device=device)
-        w13_bias_padded[:, :N_un] = layer.w13_weight_bias.data[:, 1::2]
-        w13_bias_padded[:, N_pad : N_pad + N_un] = layer.w13_weight_bias.data[:, 0::2]
+        if gate_up_interleaved:
+            gate_bias = layer.w13_weight_bias.data[:, 0::2]
+            up_bias = layer.w13_weight_bias.data[:, 1::2]
+        else:
+            gate_bias = layer.w13_weight_bias.data[:, :N_un]
+            up_bias = layer.w13_weight_bias.data[:, N_un : 2 * N_un]
+        w13_bias_padded[:, :N_un] = up_bias
+        w13_bias_padded[:, N_pad : N_pad + N_un] = gate_bias
 
         def _pad_w2_3d(unpadded, last_pad, last_un):
             out = torch.zeros(E, K_pad, last_pad, dtype=unpadded.dtype, device=device)
@@ -1225,17 +1236,34 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         layer.w13_weight_bias = Parameter(w13_bias_padded, requires_grad=False)
         layer.w2_weight_bias = Parameter(w2_bias_padded, requires_grad=False)
 
+        activation = self.moe_runner_config.activation
+        alpha = self.moe_runner_config.gemm1_alpha
+        beta = self.moe_runner_config.gemm1_beta
+        limit = self.moe_runner_config.gemm1_clamp_limit
+        if activation == "situ":
+            alpha = 4.0 if alpha is None else alpha
+            beta = 25.0 if limit is None else limit
+            limit = None
+        else:
+            alpha = 1.702 if alpha is None else alpha
+            beta = 1.0 if beta is None else beta
+            limit = 7.0 if limit is None else limit
+
         layer.swiglu_alpha = Parameter(
-            torch.full((E,), 1.702, dtype=torch.float32, device=device),
+            torch.full((E,), alpha, dtype=torch.float32, device=device),
             requires_grad=False,
         )
         layer.swiglu_beta = Parameter(
-            torch.ones(E, dtype=torch.float32, device=device),
+            torch.full((E,), beta, dtype=torch.float32, device=device),
             requires_grad=False,
         )
-        layer.swiglu_limit = Parameter(
-            torch.full((E,), 7.0, dtype=torch.float32, device=device),
-            requires_grad=False,
+        layer.swiglu_limit = (
+            None
+            if limit is None
+            else Parameter(
+                torch.full((E,), limit, dtype=torch.float32, device=device),
+                requires_grad=False,
+            )
         )
         # The MXFP4 ABI uses a neutral global weight scale for each GEMM.
         layer.mxfp4_weight_global_scale = Parameter(
@@ -1278,6 +1306,20 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             "cutlass_sm90",
             "cutlass_sm120",
         ):
+            if (
+                self._fi_kernel == "cutlass_sm120"
+                and moe_runner_config.activation == "situ"
+            ):
+                from flashinfer.fused_moe import core as flashinfer_moe_core
+
+                if not getattr(
+                    flashinfer_moe_core, "CUTLASS_FUSED_MOE_SUPPORTS_SITU", False
+                ):
+                    raise RuntimeError(
+                        "Kimi-K3 FlashInfer MXFP4 MoE on SM120 requires a "
+                        "FlashInfer build with CUTLASS SiTU support. Upgrade "
+                        "FlashInfer or restart with --moe-runner-backend marlin."
+                    )
             # Register the fused func at runner construction so the FusedOpPool
             # lookup at `MoeRunner.__init__` finds it.
             import sglang.srt.layers.moe.moe_runner.flashinfer_cutlass  # noqa: F401
@@ -1338,7 +1380,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         )
 
     def _apply_sm120_cutlass(self, layer, dispatch_output):
-        """SM120 GPT-OSS MXFP8 x MXFP4 MoE via FlashInfer CUTLASS."""
+        """SM120 MXFP8 x MXFP4 MoE via FlashInfer CUTLASS."""
         from sglang.srt.layers.moe.moe_runner.flashinfer_cutlass import (
             FlashInferCutlassMxfp4MoeQuantInfo,
         )
@@ -1349,8 +1391,8 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             w13_weight_scale=layer.w13_weight_scale,
             w2_weight_scale=layer.w2_weight_scale,
             mxfp4_weight_global_scale=layer.mxfp4_weight_global_scale,
-            w13_bias=layer.w13_weight_bias,
-            w2_bias=layer.w2_weight_bias,
+            w13_bias=layer.w13_weight_bias if self.with_bias else None,
+            w2_bias=layer.w2_weight_bias if self.with_bias else None,
             swiglu_alpha=layer.swiglu_alpha,
             swiglu_beta=layer.swiglu_beta,
             swiglu_limit=layer.swiglu_limit,

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -1342,7 +1342,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 if not flashinfer_cutlass_supports_situ():
                     raise RuntimeError(
                         "Kimi-K3 FlashInfer MXFP4 MoE on SM120 requires a "
-                        "FlashInfer build with CUTLASS SiTU support from PR #4460 "
+                        "FlashInfer build with CUTLASS SiTU support "
                         "(ActivationType.Situ plus situ_beta/situ_linear_beta). "
                         "Upgrade FlashInfer or restart with "
                         "--moe-runner-backend marlin."

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -1241,27 +1241,52 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         beta = self.moe_runner_config.gemm1_beta
         limit = self.moe_runner_config.gemm1_clamp_limit
         if activation == "situ":
-            alpha = 4.0 if alpha is None else alpha
-            beta = 25.0 if limit is None else limit
-            limit = None
+            situ_beta = 4.0 if alpha is None else alpha
+            situ_linear_beta = 25.0 if limit is None else limit
+            alpha = beta = limit = None
         else:
+            situ_beta = situ_linear_beta = None
             alpha = 1.702 if alpha is None else alpha
             beta = 1.0 if beta is None else beta
             limit = 7.0 if limit is None else limit
 
-        layer.swiglu_alpha = Parameter(
-            torch.full((E,), alpha, dtype=torch.float32, device=device),
-            requires_grad=False,
+        layer.swiglu_alpha = (
+            None
+            if alpha is None
+            else Parameter(
+                torch.full((E,), alpha, dtype=torch.float32, device=device),
+                requires_grad=False,
+            )
         )
-        layer.swiglu_beta = Parameter(
-            torch.full((E,), beta, dtype=torch.float32, device=device),
-            requires_grad=False,
+        layer.swiglu_beta = (
+            None
+            if beta is None
+            else Parameter(
+                torch.full((E,), beta, dtype=torch.float32, device=device),
+                requires_grad=False,
+            )
         )
         layer.swiglu_limit = (
             None
             if limit is None
             else Parameter(
                 torch.full((E,), limit, dtype=torch.float32, device=device),
+                requires_grad=False,
+            )
+        )
+        layer.situ_beta = (
+            None
+            if situ_beta is None
+            else Parameter(
+                torch.full((E,), situ_beta, dtype=torch.float32, device=device),
+                requires_grad=False,
+            )
+        )
+        layer.situ_linear_beta = (
+            None
+            if situ_linear_beta is None
+            else Parameter(
+                torch.full((E,), situ_linear_beta, dtype=torch.float32, device=device),
                 requires_grad=False,
             )
         )
@@ -1310,15 +1335,17 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 self._fi_kernel == "cutlass_sm120"
                 and moe_runner_config.activation == "situ"
             ):
-                from flashinfer.fused_moe import core as flashinfer_moe_core
+                from sglang.srt.layers.moe.moe_runner.flashinfer_cutlass import (
+                    flashinfer_cutlass_supports_situ,
+                )
 
-                if not getattr(
-                    flashinfer_moe_core, "CUTLASS_FUSED_MOE_SUPPORTS_SITU", False
-                ):
+                if not flashinfer_cutlass_supports_situ():
                     raise RuntimeError(
                         "Kimi-K3 FlashInfer MXFP4 MoE on SM120 requires a "
-                        "FlashInfer build with CUTLASS SiTU support. Upgrade "
-                        "FlashInfer or restart with --moe-runner-backend marlin."
+                        "FlashInfer build with CUTLASS SiTU support from PR #4460 "
+                        "(ActivationType.Situ plus situ_beta/situ_linear_beta). "
+                        "Upgrade FlashInfer or restart with "
+                        "--moe-runner-backend marlin."
                     )
             # Register the fused func at runner construction so the FusedOpPool
             # lookup at `MoeRunner.__init__` finds it.
@@ -1396,6 +1423,8 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             swiglu_alpha=layer.swiglu_alpha,
             swiglu_beta=layer.swiglu_beta,
             swiglu_limit=layer.swiglu_limit,
+            situ_beta=layer.situ_beta,
+            situ_linear_beta=layer.situ_linear_beta,
             moe_tp_size=layer.moe_tp_size,
             moe_tp_rank=layer.moe_tp_rank,
             moe_ep_size=layer.moe_ep_size,

--- a/test/registered/unit/layers/quantization/test_mxfp4_sm120_cutlass.py
+++ b/test/registered/unit/layers/quantization/test_mxfp4_sm120_cutlass.py
@@ -458,7 +458,7 @@ def test_gpt_oss_sm120_padding_layout_and_kernel(monkeypatch):
     assert torch.equal(actual, expected[:, :hidden].contiguous())
 
 
-def test_kimi_k3_sm120_contiguous_situ_layout_and_kernel(monkeypatch):
+def test_kimi_k3_sm120_situ_layout_and_noncontiguous_input(monkeypatch):
     if not torch.cuda.is_available():
         pytest.skip("CUDA required")
     if torch.cuda.get_device_capability() != (12, 0):
@@ -559,14 +559,16 @@ def test_kimi_k3_sm120_contiguous_situ_layout_and_kernel(monkeypatch):
 
     x = (
         torch.randn(
-            8,
             hidden,
+            8,
             dtype=torch.bfloat16,
             device="cuda",
             generator=generator,
         )
+        .t()
         * 0.1
     )
+    assert not x.is_contiguous()
     logits = torch.randn(
         8,
         num_experts,
@@ -583,8 +585,10 @@ def test_kimi_k3_sm120_contiguous_situ_layout_and_kernel(monkeypatch):
     )
     actual = method._apply_sm120_cutlass(layer, dispatch_output).hidden_states
 
-    x_quant, x_scale = mxfp8_quantize(x, is_sf_swizzled_layout=True, alignment=32)
-    expected = torch.empty_like(x)
+    x_quant, x_scale = mxfp8_quantize(
+        x.contiguous(), is_sf_swizzled_layout=True, alignment=32
+    )
+    expected = torch.empty_like(x, memory_format=torch.contiguous_format)
     cutlass_fused_moe(
         input=x_quant,
         token_selected_experts=topk_ids.to(torch.int32),

--- a/test/registered/unit/layers/quantization/test_mxfp4_sm120_cutlass.py
+++ b/test/registered/unit/layers/quantization/test_mxfp4_sm120_cutlass.py
@@ -106,9 +106,8 @@ def test_dsv4_sm120_load_contract(monkeypatch):
 
 
 def test_kimi_k3_sm120_situ_requires_patched_flashinfer(monkeypatch):
-    from flashinfer.fused_moe import core as flashinfer_moe_core
-
     import sglang.srt.layers.quantization.mxfp4 as mxfp4_module
+    import sglang.srt.layers.moe.moe_runner.flashinfer_cutlass as runner_module
     from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
     from sglang.srt.layers.moe.utils import MoeRunnerBackend
     from sglang.srt.layers.quantization.mxfp4 import Mxfp4MoEMethod
@@ -118,8 +117,8 @@ def test_kimi_k3_sm120_situ_requires_patched_flashinfer(monkeypatch):
         "get_moe_runner_backend",
         lambda: MoeRunnerBackend.FLASHINFER_MXFP4,
     )
-    monkeypatch.delattr(
-        flashinfer_moe_core, "CUTLASS_FUSED_MOE_SUPPORTS_SITU", raising=False
+    monkeypatch.setattr(
+        runner_module, "flashinfer_cutlass_supports_situ", lambda: False
     )
 
     method = Mxfp4MoEMethod.__new__(Mxfp4MoEMethod)
@@ -466,12 +465,8 @@ def test_kimi_k3_sm120_situ_layout_and_noncontiguous_input(monkeypatch):
     pytest.importorskip("flashinfer.fused_moe")
 
     from flashinfer import block_scale_interleave, mxfp8_quantize
-    from flashinfer.fused_moe import core as flashinfer_moe_core
     from flashinfer.fused_moe import cutlass_fused_moe
     from flashinfer.fused_moe.core import ActivationType
-
-    if not getattr(flashinfer_moe_core, "CUTLASS_FUSED_MOE_SUPPORTS_SITU", False):
-        pytest.skip("FlashInfer CUTLASS SiTU support required")
 
     import sglang.srt.layers.moe.moe_runner.flashinfer_cutlass as runner_module
     from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
@@ -480,6 +475,9 @@ def test_kimi_k3_sm120_situ_layout_and_noncontiguous_input(monkeypatch):
     from sglang.srt.layers.moe.topk import StandardTopKOutput
     from sglang.srt.layers.moe.utils import MoeRunnerBackend
     from sglang.srt.layers.quantization.mxfp4 import Mxfp4MoEMethod
+
+    if not runner_module.flashinfer_cutlass_supports_situ():
+        pytest.skip("FlashInfer CUTLASS SiTU support from PR #4460 required")
 
     monkeypatch.setattr(
         runner_module, "use_symmetric_memory", lambda *args, **kwargs: nullcontext()
@@ -552,9 +550,11 @@ def test_kimi_k3_sm120_situ_layout_and_noncontiguous_input(monkeypatch):
     ).reshape_as(layer.w13_weight_scale)
     assert torch.equal(layer.w13_weight, expected_w13)
     assert torch.equal(layer.w13_weight_scale, expected_w13_scale)
-    assert torch.all(layer.swiglu_alpha == 4.0)
-    assert torch.all(layer.swiglu_beta == 25.0)
+    assert layer.swiglu_alpha is None
+    assert layer.swiglu_beta is None
     assert layer.swiglu_limit is None
+    assert torch.all(layer.situ_beta == 4.0)
+    assert torch.all(layer.situ_linear_beta == 25.0)
     assert runner_module._activation_type(config) == ActivationType.Situ
 
     x = (
@@ -603,9 +603,8 @@ def test_kimi_k3_sm120_situ_layout_and_noncontiguous_input(monkeypatch):
             layer.mxfp4_weight_global_scale,
         ],
         input_sf=x_scale,
-        swiglu_alpha=layer.swiglu_alpha,
-        swiglu_beta=layer.swiglu_beta,
-        swiglu_limit=None,
+        situ_beta=layer.situ_beta,
+        situ_linear_beta=layer.situ_linear_beta,
         use_w4_group_scaling=False,
         use_mxfp8_act_scaling=True,
         activation_type=ActivationType.Situ,

--- a/test/registered/unit/layers/quantization/test_mxfp4_sm120_cutlass.py
+++ b/test/registered/unit/layers/quantization/test_mxfp4_sm120_cutlass.py
@@ -105,6 +105,30 @@ def test_dsv4_sm120_load_contract(monkeypatch):
     assert captured["fp4_scale_dtype"] == torch.float8_e8m0fnu
 
 
+def test_kimi_k3_sm120_situ_requires_patched_flashinfer(monkeypatch):
+    from flashinfer.fused_moe import core as flashinfer_moe_core
+
+    import sglang.srt.layers.quantization.mxfp4 as mxfp4_module
+    from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+    from sglang.srt.layers.moe.utils import MoeRunnerBackend
+    from sglang.srt.layers.quantization.mxfp4 import Mxfp4MoEMethod
+
+    monkeypatch.setattr(
+        mxfp4_module,
+        "get_moe_runner_backend",
+        lambda: MoeRunnerBackend.FLASHINFER_MXFP4,
+    )
+    monkeypatch.delattr(
+        flashinfer_moe_core, "CUTLASS_FUSED_MOE_SUPPORTS_SITU", raising=False
+    )
+
+    method = Mxfp4MoEMethod.__new__(Mxfp4MoEMethod)
+    method._fi_kernel = "cutlass_sm120"
+    config = MoeRunnerConfig(activation="situ", is_gated=True)
+    with pytest.raises(RuntimeError, match="--moe-runner-backend marlin"):
+        method.create_moe_runner(SimpleNamespace(), config)
+
+
 def test_dsv4_sm120_matches_direct_flashinfer(monkeypatch):
     if not torch.cuda.is_available():
         pytest.skip("CUDA required")
@@ -317,6 +341,7 @@ def test_gpt_oss_sm120_padding_layout_and_kernel(monkeypatch):
     method.intermediate_size_per_partition = intermediate
     method._padded_hidden = padded_hidden
     method._padded_intermediate = padded_intermediate
+    method.with_bias = True
     config = MoeRunnerConfig(
         num_experts=num_experts,
         num_local_experts=num_experts,
@@ -431,6 +456,159 @@ def test_gpt_oss_sm120_padding_layout_and_kernel(monkeypatch):
         output=expected,
     )
     assert torch.equal(actual, expected[:, :hidden].contiguous())
+
+
+def test_kimi_k3_sm120_contiguous_situ_layout_and_kernel(monkeypatch):
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+    if torch.cuda.get_device_capability() != (12, 0):
+        pytest.skip("SM120 required")
+    pytest.importorskip("flashinfer.fused_moe")
+
+    from flashinfer import block_scale_interleave, mxfp8_quantize
+    from flashinfer.fused_moe import core as flashinfer_moe_core
+    from flashinfer.fused_moe import cutlass_fused_moe
+    from flashinfer.fused_moe.core import ActivationType
+
+    if not getattr(flashinfer_moe_core, "CUTLASS_FUSED_MOE_SUPPORTS_SITU", False):
+        pytest.skip("FlashInfer CUTLASS SiTU support required")
+
+    import sglang.srt.layers.moe.moe_runner.flashinfer_cutlass as runner_module
+    from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+    from sglang.srt.layers.moe.moe_runner.runner import MoeRunner
+    from sglang.srt.layers.moe.token_dispatcher.standard import StandardDispatchOutput
+    from sglang.srt.layers.moe.topk import StandardTopKOutput
+    from sglang.srt.layers.moe.utils import MoeRunnerBackend
+    from sglang.srt.layers.quantization.mxfp4 import Mxfp4MoEMethod
+
+    monkeypatch.setattr(
+        runner_module, "use_symmetric_memory", lambda *args, **kwargs: nullcontext()
+    )
+    monkeypatch.setattr(runner_module, "is_allocation_symmetric", lambda: False)
+    monkeypatch.setattr(runner_module, "get_tp_group", lambda: None)
+
+    num_experts, hidden, intermediate = 4, 256, 256
+    w13, w2, w13_scale, w2_scale = _random_weights(num_experts, hidden, intermediate)
+    gate, up = w13.chunk(2, dim=1)
+    gate_scale, up_scale = w13_scale.chunk(2, dim=1)
+    generator = torch.Generator(device="cuda").manual_seed(3)
+    layer = SimpleNamespace(
+        w13_weight=torch.nn.Parameter(w13.view(torch.uint8), requires_grad=False),
+        w2_weight=torch.nn.Parameter(w2.view(torch.uint8), requires_grad=False),
+        w13_weight_scale=torch.nn.Parameter(
+            w13_scale.view(torch.uint8), requires_grad=False
+        ),
+        w2_weight_scale=torch.nn.Parameter(
+            w2_scale.view(torch.uint8), requires_grad=False
+        ),
+        # CUDA weight creation keeps zero placeholders even for bias-free models.
+        w13_weight_bias=torch.nn.Parameter(
+            torch.zeros(
+                num_experts,
+                2 * intermediate,
+                dtype=torch.bfloat16,
+                device="cuda",
+            ),
+            requires_grad=False,
+        ),
+        w2_weight_bias=torch.nn.Parameter(
+            torch.zeros(num_experts, hidden, dtype=torch.bfloat16, device="cuda"),
+            requires_grad=False,
+        ),
+        num_local_experts=num_experts,
+        moe_tp_size=1,
+        moe_tp_rank=0,
+        moe_ep_size=1,
+        moe_ep_rank=0,
+    )
+
+    method = Mxfp4MoEMethod.__new__(Mxfp4MoEMethod)
+    method._fi_kernel = "cutlass_sm120"
+    method.num_experts = num_experts
+    method.hidden_size = hidden
+    method.intermediate_size_per_partition = intermediate
+    method._padded_hidden = hidden
+    method._padded_intermediate = intermediate
+    method.with_bias = False
+    config = MoeRunnerConfig(
+        num_experts=num_experts,
+        num_local_experts=num_experts,
+        hidden_size=hidden,
+        intermediate_size_per_partition=intermediate,
+        top_k=2,
+        activation="situ",
+        is_gated=True,
+        gemm1_alpha=4.0,
+        gemm1_clamp_limit=25.0,
+        gate_up_interleaved=False,
+    )
+    method.moe_runner_config = config
+    method.runner = MoeRunner(MoeRunnerBackend.FLASHINFER_MXFP4, config)
+    method._process_weights_for_sm120_cutlass(layer)
+
+    expected_w13 = torch.cat((up, gate), dim=1).view(torch.uint8)
+    expected_w13_scale = block_scale_interleave(
+        torch.cat((up_scale.view(torch.uint8), gate_scale.view(torch.uint8)), dim=1)
+    ).reshape_as(layer.w13_weight_scale)
+    assert torch.equal(layer.w13_weight, expected_w13)
+    assert torch.equal(layer.w13_weight_scale, expected_w13_scale)
+    assert torch.all(layer.swiglu_alpha == 4.0)
+    assert torch.all(layer.swiglu_beta == 25.0)
+    assert layer.swiglu_limit is None
+    assert runner_module._activation_type(config) == ActivationType.Situ
+
+    x = (
+        torch.randn(
+            8,
+            hidden,
+            dtype=torch.bfloat16,
+            device="cuda",
+            generator=generator,
+        )
+        * 0.1
+    )
+    logits = torch.randn(
+        8,
+        num_experts,
+        dtype=torch.float32,
+        device="cuda",
+        generator=generator,
+    )
+    topk_weights, topk_ids = torch.topk(torch.softmax(logits, dim=-1), 2, dim=-1)
+    topk_weights /= topk_weights.sum(dim=-1, keepdim=True)
+    dispatch_output = StandardDispatchOutput(
+        x,
+        None,
+        StandardTopKOutput(topk_weights, topk_ids.to(torch.int32), logits),
+    )
+    actual = method._apply_sm120_cutlass(layer, dispatch_output).hidden_states
+
+    x_quant, x_scale = mxfp8_quantize(x, is_sf_swizzled_layout=True, alignment=32)
+    expected = torch.empty_like(x)
+    cutlass_fused_moe(
+        input=x_quant,
+        token_selected_experts=topk_ids.to(torch.int32),
+        token_final_scales=topk_weights,
+        fc1_expert_weights=layer.w13_weight.view(torch.int64),
+        fc2_expert_weights=layer.w2_weight.view(torch.int64),
+        output_dtype=torch.bfloat16,
+        quant_scales=[
+            layer.w13_weight_scale.view(torch.int32),
+            layer.mxfp4_weight_global_scale,
+            layer.w2_weight_scale.view(torch.int32),
+            layer.mxfp4_weight_global_scale,
+        ],
+        input_sf=x_scale,
+        swiglu_alpha=layer.swiglu_alpha,
+        swiglu_beta=layer.swiglu_beta,
+        swiglu_limit=None,
+        use_w4_group_scaling=False,
+        use_mxfp8_act_scaling=True,
+        activation_type=ActivationType.Situ,
+        tune_max_num_tokens=8,
+        output=expected,
+    )
+    assert torch.equal(actual, expected)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/layers/quantization/test_mxfp4_sm120_cutlass.py
+++ b/test/registered/unit/layers/quantization/test_mxfp4_sm120_cutlass.py
@@ -107,8 +107,8 @@ def test_dsv4_sm120_load_contract(monkeypatch):
 
 
 def test_kimi_k3_sm120_situ_requires_flashinfer_cutlass_situ_api(monkeypatch):
-    import sglang.srt.layers.quantization.mxfp4 as mxfp4_module
     import sglang.srt.layers.moe.moe_runner.flashinfer_cutlass as runner_module
+    import sglang.srt.layers.quantization.mxfp4 as mxfp4_module
     from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
     from sglang.srt.layers.moe.utils import MoeRunnerBackend
     from sglang.srt.layers.quantization.mxfp4 import Mxfp4MoEMethod
@@ -590,8 +590,7 @@ def test_kimi_k3_sm120_situ_layout_and_noncontiguous_input(monkeypatch):
             dtype=torch.bfloat16,
             device="cuda",
             generator=generator,
-        )
-        .t()
+        ).t()
         * 0.1
     )
     assert not x.is_contiguous()

--- a/test/registered/unit/layers/quantization/test_mxfp4_sm120_cutlass.py
+++ b/test/registered/unit/layers/quantization/test_mxfp4_sm120_cutlass.py
@@ -105,7 +105,7 @@ def test_dsv4_sm120_load_contract(monkeypatch):
     assert captured["fp4_scale_dtype"] == torch.float8_e8m0fnu
 
 
-def test_kimi_k3_sm120_situ_requires_patched_flashinfer(monkeypatch):
+def test_kimi_k3_sm120_situ_requires_flashinfer_cutlass_situ_api(monkeypatch):
     import sglang.srt.layers.quantization.mxfp4 as mxfp4_module
     import sglang.srt.layers.moe.moe_runner.flashinfer_cutlass as runner_module
     from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
@@ -477,7 +477,7 @@ def test_kimi_k3_sm120_situ_layout_and_noncontiguous_input(monkeypatch):
     from sglang.srt.layers.quantization.mxfp4 import Mxfp4MoEMethod
 
     if not runner_module.flashinfer_cutlass_supports_situ():
-        pytest.skip("FlashInfer CUTLASS SiTU support from PR #4460 required")
+        pytest.skip("FlashInfer CUTLASS SiTU support required")
 
     monkeypatch.setattr(
         runner_module, "use_symmetric_memory", lambda *args, **kwargs: nullcontext()

--- a/test/registered/unit/layers/quantization/test_mxfp4_sm120_cutlass.py
+++ b/test/registered/unit/layers/quantization/test_mxfp4_sm120_cutlass.py
@@ -6,6 +6,7 @@ import builtins
 import importlib
 import sys
 from contextlib import nullcontext
+from enum import IntEnum
 from types import SimpleNamespace
 
 import pytest
@@ -126,6 +127,31 @@ def test_kimi_k3_sm120_situ_requires_flashinfer_cutlass_situ_api(monkeypatch):
     config = MoeRunnerConfig(activation="situ", is_gated=True)
     with pytest.raises(RuntimeError, match="--moe-runner-backend marlin"):
         method.create_moe_runner(SimpleNamespace(), config)
+
+
+def test_non_situ_activation_supports_legacy_flashinfer(monkeypatch):
+    import sglang.srt.layers.moe.moe_runner.flashinfer_cutlass as runner_module
+    import sglang.srt.layers.moe.moe_runner.flashinfer_trtllm as trtllm_module
+
+    class LegacyActivationType(IntEnum):
+        Swiglu = 0
+        Geglu = 1
+        Relu2 = 2
+        Identity = 3
+
+    monkeypatch.setattr(
+        runner_module,
+        "_flashinfer_cutlass_fused_moe",
+        lambda: (object(), LegacyActivationType),
+    )
+    monkeypatch.setattr(
+        trtllm_module,
+        "get_activation_type",
+        lambda *args, **kwargs: LegacyActivationType.Swiglu.value,
+    )
+
+    config = SimpleNamespace(activation="silu", is_gated=True)
+    assert runner_module._activation_type(config) == LegacyActivationType.Swiglu
 
 
 def test_dsv4_sm120_matches_direct_flashinfer(monkeypatch):

--- a/test/registered/unit/layers/test_attn_residual_arch_gate.py
+++ b/test/registered/unit/layers/test_attn_residual_arch_gate.py
@@ -5,6 +5,9 @@ from unittest.mock import patch
 import pytest
 
 import sglang.srt.layers.attn_residual as attn_residual
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-small")
 
 
 @pytest.mark.parametrize(

--- a/test/registered/unit/layers/test_attn_residual_arch_gate.py
+++ b/test/registered/unit/layers/test_attn_residual_arch_gate.py
@@ -1,0 +1,43 @@
+"""Architecture gate tests for Kimi-K3's fused attention residual."""
+
+from unittest.mock import patch
+
+import pytest
+
+import sglang.srt.layers.attn_residual as attn_residual
+
+
+@pytest.mark.parametrize(
+    ("capability", "expected"),
+    [
+        ((10, 0), True),
+        ((10, 3), True),
+        ((11, 0), True),
+        ((12, 0), False),
+        ((9, 0), False),
+    ],
+)
+def test_fast_attn_residual_arch_gate(capability, expected):
+    with (
+        patch.object(attn_residual, "_FAST_SUPPORTED", None),
+        patch.object(attn_residual, "is_npu", return_value=False),
+        patch.object(
+            attn_residual.torch.cuda,
+            "get_device_capability",
+            return_value=capability,
+        ),
+    ):
+        assert attn_residual._use_fast(7168) is expected
+
+
+def test_fast_attn_residual_requires_kimi_hidden_size():
+    with (
+        patch.object(attn_residual, "_FAST_SUPPORTED", None),
+        patch.object(attn_residual, "is_npu", return_value=False),
+        patch.object(
+            attn_residual.torch.cuda,
+            "get_device_capability",
+            return_value=(10, 0),
+        ),
+    ):
+        assert not attn_residual._use_fast(4096)


### PR DESCRIPTION
> Draft: depends on flashinfer-ai/flashinfer#4460. The dependency is not
> vendored or pinned by this PR, and the default MoE backend is unchanged.

## Motivation

SGLang already supports the FlashInfer CUTLASS MXFP4 MoE path for GPT-OSS on
SM120, but Kimi-K3 needs additional model-specific integration:

- Kimi stores gate and up projections as contiguous halves, while the CUTLASS
  kernel consumes the opposite half order. This differs from GPT-OSS's
  pair-interleaved layout.
- Kimi-K3 uses SiTU with independent parameters
  `situ_beta=4.0` and `situ_linear_beta=25.0`.
- Chunked Prefill can pass non-contiguous hidden states to the MXFP8
  quantizer.
- RTX 6000D (SM120) must not enter the tcgen05 fused attention-residual path
  intended for GB100/GB200/GB300-class architectures.

FlashInfer PR #4460 owns the public CUTLASS SiTU kernel and API. This PR only
adds the SGLang-side Kimi-K3 integration and should remain Draft until #4460
is available in an official RC or release.

## Modifications

- Detect the public FlashInfer CUTLASS SiTU capability without making the new
  enum or function parameters mandatory at SGLang import time.
- Dispatch Kimi-K3 MXFP8-activation-by-MXFP4-weight MoE to FlashInfer CUTLASS
  on SM120 only when `--moe-runner-backend flashinfer_mxfp4` is selected.
- Convert Kimi's contiguous `[gate; up]` weight and scale halves to CUTLASS's
  `[up; gate]` order while preserving the existing GPT-OSS interleaved path.
- Forward `situ_beta` and `situ_linear_beta` independently through the
  FlashInfer #4460 API.
- Materialize non-contiguous hidden states immediately before MXFP8
  quantization.
- Exclude SM120 from the tcgen05 attention-residual architecture gate.
- Add registered unit tests for capability fallback, legacy FlashInfer
  compatibility, Kimi/GPT-OSS layouts, SiTU parameters, non-contiguous input,
  numerical parity, and the architecture gate.

The PR does not copy FlashInfer C++ code, pin an unmerged commit, alter the
default MoE backend, or remove the Marlin fallback.

## Accuracy Tests

Target hardware: NVIDIA RTX 6000D, compute capability 12.0. FlashInfer was
built from a snapshot of PR #4460 fetched on 2026-08-18.

```bash
pytest -q -s \
  test/registered/unit/layers/quantization/test_mxfp4_sm120_cutlass.py \
  test/registered/unit/layers/test_attn_residual_arch_gate.py
```

Result with the FlashInfer kernel enabled:

```text
8 passed, 17 warnings in 559.87s
```

The GPU test covers the exact Kimi combination of SM120, MXFP8 activations,
MXFP4 weights, SiTU `(4.0, 25.0)`, Kimi gate/up layout, and non-contiguous
input. It compares the SGLang adapter output directly with the public
FlashInfer CUTLASS API.

After syncing the fork and rebasing the seven-patch series onto SGLang main
`593b1a9b8aeedb908ee21870c02a0fd1a3dc30a5`, the non-JIT subset was rerun
from the final Draft head `b95b5341ab9555ba5ea53f5828f6de203d749cce`:

```bash
pytest -q -s \
  test/registered/unit/layers/quantization/test_mxfp4_sm120_cutlass.py \
  test/registered/unit/layers/test_attn_residual_arch_gate.py \
  -k "not matches_direct_flashinfer and not padding_layout_and_kernel and not situ_layout_and_noncontiguous_input"
```

```text
10 passed, 3 deselected, 17 warnings in 33.30s
```

## Speed Tests and Profiling

This is a compatibility PR, so the following result is a target-hardware
validation point rather than a general speed claim. Marlin and
`flashinfer_mxfp4` used the same SGLang commit, image, model, service flags,
requests, and three-repeat protocol.

```text
Hardware: 4 nodes / 32 NVIDIA RTX 6000D GPUs (SM120)
Model: Kimi-K3
Parallelism: TP32 / EP4 / DP1
Workload: ISL=16384, OSL=1, concurrency=8, 40 requests
Chunked Prefill: 8192 tokens
SGLang patch series used for the run: 300c87a431ac40d3e7817246376b7fe20932db09
Final rebased Draft head: b95b5341ab9555ba5ea53f5828f6de203d749cce
Final SGLang main base: 593b1a9b8aeedb908ee21870c02a0fd1a3dc30a5
FlashInfer: PR #4460 implementation b525c513fef7c1d162efd3ce8636fcc8760de66a
Repeats: 3 per backend
```

The service benchmark was collected before the fork sync. `git range-diff`
reports all seven commits as patch-equivalent after the rebase, and the
directed tests above were rerun from the final Draft head. The performance
result is therefore retained without claiming that the benchmark container
contained the new commit object.

| Backend | Median Input TPS | Median TTFT P50 | Median TTFT P95 |
|---|---:|---:|---:|
| Marlin | 2930.03 | 43.587 s | 46.287 s |
| FlashInfer MXFP4 | 3251.25 | 39.267 s | 41.694 s |
| Change | +10.96% | -9.91% | -9.92% |

All six repeats completed 40/40 requests, all outputs contained exactly one
token, and no request errors, OOM, traceback, NCCL error, or engine-death
event was observed. The result only establishes this exact configuration;
the default backend remains unchanged.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (N/A for this Draft: it does not expose a stable released capability or change defaults; user-facing documentation should be added after #4460 is released.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Full pre-commit validation was run on all five changed files and every hook
passed. The two test files are registered with CUDA CI in `base-b` using the
`1-gpu-small` runner.

## Dependency and Merge Order

1. FlashInfer #4460 merges and publishes an RC or release with a stable API.
2. This Draft updates its version gate to that released package if required.
3. SGLang CI runs with the released FlashInfer dependency.
4. The Draft becomes Ready for Review.

The SM120 attention-residual guard is kept as a separate commit so reviewers
can split it into a `[BugFix]` PR if preferred.

References:

- https://github.com/flashinfer-ai/flashinfer/pull/4460
- https://github.com/sgl-project/sglang/pull/24816
- https://github.com/sgl-project/sglang/pull/33997

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32222567738](https://github.com/sgl-project/sglang/actions/runs/32222567738)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32222567605](https://github.com/sgl-project/sglang/actions/runs/32222567605)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->