### PR TITLE
[Fix] Preserve PD bootstrap fields in Anthropic requests

### DIFF
--- a/python/sglang/srt/entrypoints/anthropic/protocol.py
+++ b/python/sglang/srt/entrypoints/anthropic/protocol.py
@@ -379,6 +379,12 @@ class AnthropicMessagesRequest(BaseModel):
     output_config: Optional[AnthropicOutputConfig] = None
     betas: Optional[list[str]] = None
 
+    # SGLang extension for PD disaggregation. External routers attach these
+    # fields before the request reaches the Anthropic compatibility endpoint.
+    bootstrap_host: Optional[Union[list[str], str]] = None
+    bootstrap_port: Optional[Union[list[Optional[int]], int]] = None
+    bootstrap_room: Optional[Union[list[int], int]] = None
+
     @field_validator("model")
     @classmethod
     def _validate_model(cls, v):

--- a/python/sglang/srt/entrypoints/anthropic/serving.py
+++ b/python/sglang/srt/entrypoints/anthropic/serving.py
@@ -565,6 +565,12 @@ class AnthropicServing:
             request_data["top_k"] = anthropic_request.top_k
         if anthropic_request.stop_sequences is not None:
             request_data["stop"] = anthropic_request.stop_sequences
+        if anthropic_request.bootstrap_host is not None:
+            request_data["bootstrap_host"] = anthropic_request.bootstrap_host
+        if anthropic_request.bootstrap_port is not None:
+            request_data["bootstrap_port"] = anthropic_request.bootstrap_port
+        if anthropic_request.bootstrap_room is not None:
+            request_data["bootstrap_room"] = anthropic_request.bootstrap_room
 
         # Enable usage in stream so we can report it
         if anthropic_request.stream:

--- a/test/registered/unit/entrypoints/anthropic/test_serving.py
+++ b/test/registered/unit/entrypoints/anthropic/test_serving.py
@@ -191,6 +191,23 @@ class TestAnthropicServing(unittest.TestCase):
             overrides["tools"] = tools
         return self._anthropic_request(**overrides)
 
+    def test_pd_bootstrap_fields_are_preserved_during_conversion(self):
+        request = self._anthropic_request(
+            stream=False,
+            bootstrap_host="127.0.0.1",
+            bootstrap_port=9100,
+            bootstrap_room=123456789,
+        )
+
+        chat_request = self._serving()._convert_to_chat_completion_request(request)
+
+        self.assertEqual(request.bootstrap_host, "127.0.0.1")
+        self.assertEqual(request.bootstrap_port, 9100)
+        self.assertEqual(request.bootstrap_room, 123456789)
+        self.assertEqual(chat_request.bootstrap_host, "127.0.0.1")
+        self.assertEqual(chat_request.bootstrap_port, 9100)
+        self.assertEqual(chat_request.bootstrap_room, 123456789)
+
     def test_stream_closes_tool_block_before_text_delta(self):
         serving = self._serving(
             [


### PR DESCRIPTION
## Motivation

The Anthropic `/v1/messages` endpoint drops PD coordination metadata while converting `AnthropicMessagesRequest` to `ChatCompletionRequest`, causing decode workers to reject disaggregated requests without a bootstrap room ID. Fixes #35229.

## Modifications

- Add `bootstrap_host`, `bootstrap_port`, and `bootstrap_room` to `AnthropicMessagesRequest` using the same types as the OpenAI request model.
- Forward non-null bootstrap fields during Anthropic-to-OpenAI request conversion.
- Add a unit test covering request parsing and conversion.

## Accuracy Tests

Not applicable. This change only preserves request metadata and does not affect model outputs.

## Speed Tests and Profiling

Not applicable. The change adds only three conditional field assignments during request conversion.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32224372215](https://github.com/sgl-project/sglang/actions/runs/32224372215)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32224371649](https://github.com/sgl-project/sglang/actions/runs/32224371649)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->