### PR TITLE
[docs] add a ComfyUI section for every diffusion cookbook page

### DIFF
--- a/.claude/skills/cookbook-add-model/SKILL.md
+++ b/.claude/skills/cookbook-add-model/SKILL.md
@@ -154,6 +154,27 @@ this table (RTX PRO 6000, GH200, future chips) goes in the model's own `config.h
    a guessed release; key by `hw`, or `hw|quant` when one quant on a shared GPU needs its own
    image), `multiNodeHints` only for fabric-specific hw (e.g. gb200).
 
+5. **Diffusion pages: add the ComfyUI section.** Every diffusion cookbook page ends with
+   a `## <n>. Run in ComfyUI` section so a reader never has to guess whether the model is
+   reachable from ComfyUI. It is one component; the per-model facts live in the component,
+   not the page:
+
+   ```mdx
+   ## <n>. Run in ComfyUI
+
+   import { ComfyUISupport } from '/src/snippets/diffusion/comfyui-support.jsx';
+
+   <ComfyUISupport model="<key>" />
+   ```
+
+   Pick `model` from the table in
+   `docs/src/snippets/diffusion/comfyui-support.jsx`. Use the model's own key when it has
+   an entry (its executor or dedicated node differs); otherwise use the generic `image` or
+   `video`. A model gets its own key only when the plugin actually treats it specially —
+   an entry in `executor_class_dict`
+   (`python/sglang/multimodal_gen/apps/ComfyUI_SGLDiffusion/core/generator.py`) or a
+   dedicated node. Adding a key without the matching plugin support makes the page lie.
+
 ### Site-wiring (do all three)
 
 - **`docs/docs.json`** — add the page under Cookbook → `<category>` → `<Vendor>`, at

--- a/.claude/skills/cookbook-review-pr/SKILL.md
+++ b/.claude/skills/cookbook-review-pr/SKILL.md
@@ -147,6 +147,18 @@ than restating.
   equal what the engine emits from the corresponding cell — same flags, same order. Drift
   here is the most common review miss.
 
+### 5b. ComfyUI section (diffusion pages)
+- A diffusion page ends with `## <n>. Run in ComfyUI` rendering `<ComfyUISupport />`. A
+  reader must not have to guess whether the model is reachable from ComfyUI.
+- The `model` prop is a key that exists in `docs/src/snippets/diffusion/comfyui-support.jsx`.
+  A model-specific key is only correct when the plugin really treats it specially — an entry
+  in `executor_class_dict`
+  (`python/sglang/multimodal_gen/apps/ComfyUI_SGLDiffusion/core/generator.py`) or a dedicated
+  node. Otherwise the generic `image` / `video` key is the honest one; a model-specific key
+  without matching plugin support makes the page claim support that does not exist.
+- Prose describing ComfyUI support inline instead of using the component is a finding: the
+  facts drift from the plugin.
+
 ### 6. Commands / port
 - Launch uses `sglang serve` — flag any `python -m sglang.launch_server` /
   `python3 -m sglang.launch_server` (deprecated). The engine already emits `sglang serve`;

--- a/docs/cookbook/diffusion/Cosmos/Cosmos3.mdx
+++ b/docs/cookbook/diffusion/Cosmos/Cosmos3.mdx
@@ -349,3 +349,9 @@ Put model-specific compatibility knobs in `extra_params` for video requests, or 
 - `use_resolution_template`: accepted for vLLM-Omni request compatibility.
 - `use_system_prompt`: whether to add the Cosmos3 system prompt to the chat template.
 - `guardrails` or `use_guardrails`: per-request guardrail toggle when the server started with guardrails enabled.
+
+## 6. Run in ComfyUI
+
+import { ComfyUISupport } from '/src/snippets/diffusion/comfyui-support.jsx';
+
+<ComfyUISupport model="video" />

--- a/docs/cookbook/diffusion/Ernie-Image/Ernie-Image.mdx
+++ b/docs/cookbook/diffusion/Ernie-Image/Ernie-Image.mdx
@@ -79,3 +79,9 @@ with open("ernie_image.png", "wb") as f:
 - `--performance-mode auto` keeps conservative defaults while preserving explicit user flags.
 - If the checkpoint includes a PE component, SGLang loads it automatically with the native Ministral3 runtime. Use `--layerwise-offload-components pe` when the local PE decoder needs to trade latency for lower GPU memory usage.
 - Treat FSDP, SP/Ulysses/Ring, and TP as explicit benchmark knobs. Measure the target resolution, step count, and GPU type before making them production defaults.
+
+## 6. Run in ComfyUI
+
+import { ComfyUISupport } from '/src/snippets/diffusion/comfyui-support.jsx';
+
+<ComfyUISupport model="image" />

--- a/docs/cookbook/diffusion/FLUX/FLUX.mdx
+++ b/docs/cookbook/diffusion/FLUX/FLUX.mdx
@@ -387,3 +387,9 @@ Test Environment:
     ```
   </Tab>
 </Tabs>
+
+## 6. Run in ComfyUI
+
+import { ComfyUISupport } from '/src/snippets/diffusion/comfyui-support.jsx';
+
+<ComfyUISupport model="flux" />

--- a/docs/cookbook/diffusion/Ideogram/Ideogram4.mdx
+++ b/docs/cookbook/diffusion/Ideogram/Ideogram4.mdx
@@ -187,3 +187,9 @@ response = client.images.generate(
 ```
 
 Base Ideogram 4 presets are `V4_DEFAULT_20`, `V4_QUALITY_48`, and `V4_TURBO_12`. The fal variants automatically select `V4_FAST_20` and `V4_INSTANT_8`, respectively. A preset controls both `num_inference_steps` and guidance, so do not set those fields directly.
+
+## 5. Run in ComfyUI
+
+import { ComfyUISupport } from '/src/snippets/diffusion/comfyui-support.jsx';
+
+<ComfyUISupport model="image" />

--- a/docs/cookbook/diffusion/JoyEcho/JoyEcho.mdx
+++ b/docs/cookbook/diffusion/JoyEcho/JoyEcho.mdx
@@ -175,3 +175,9 @@ Set `enable_memory_bank=false` when you want independent shots without cross-sho
 - For **2-GPU latency**, try **Ulysses SP** (`--num-gpus 2 --ulysses-degree 2`) on both single-shot and multi-shot runs. Use **TP** when you need a different sharding strategy or more than two GPUs.
 - Set `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` for long multi-shot SP sessions.
 - JoyEcho outputs per-shot mp4 files with synchronized audio. There is no built-in two-stage HQ upscaling path like LTX-2.3 HQ.
+
+## 6. Run in ComfyUI
+
+import { ComfyUISupport } from '/src/snippets/diffusion/comfyui-support.jsx';
+
+<ComfyUISupport model="video" />

--- a/docs/cookbook/diffusion/Krea/Krea-2.mdx
+++ b/docs/cookbook/diffusion/Krea/Krea-2.mdx
@@ -340,3 +340,9 @@ Peak Memory Mean (MB):                   37466.40
 Peak Memory Median (MB):                 37466.00
 ============================================================
 ```
+
+## 6. Run in ComfyUI
+
+import { ComfyUISupport } from '/src/snippets/diffusion/comfyui-support.jsx';
+
+<ComfyUISupport model="image" />

--- a/docs/cookbook/diffusion/LTX/LTX2 & LTX2.3.mdx
+++ b/docs/cookbook/diffusion/LTX/LTX2 & LTX2.3.mdx
@@ -246,3 +246,9 @@ Some community LoRAs only include weights for transformer blocks. In that case, 
 - Use `--ltx2-two-stage-device-mode resident` on high-VRAM GPUs if latency matters more than memory usage.
 - Use `--ltx2-two-stage-device-mode original` when comparing against official two-stage behavior.
 - Keep `--width` and `--height` aligned with the target model resolution; for LTX models, these are output video dimensions.
+
+## 6. Run in ComfyUI
+
+import { ComfyUISupport } from '/src/snippets/diffusion/comfyui-support.jsx';
+
+<ComfyUISupport model="video" />

--- a/docs/cookbook/diffusion/LingBot-World/LingBot-World-2.0.mdx
+++ b/docs/cookbook/diffusion/LingBot-World/LingBot-World-2.0.mdx
@@ -183,3 +183,9 @@ LingBot World 2.0 uses raw-frame websocket GT plus per-chunk latency guards for 
 - Use the realtime endpoint for interactive sessions: `/v1/realtime_video/generate`.
 - Prefer WebP preview transport for interactive testing; use raw-frame transport for consistency checks.
 - Long-running sessions should be validated with raw-frame consistency before changing causal cache, condition sampling, or VAE decode behavior.
+
+## 7. Run in ComfyUI
+
+import { ComfyUISupport } from '/src/snippets/diffusion/comfyui-support.jsx';
+
+<ComfyUISupport model="video" />

--- a/docs/cookbook/diffusion/LingBot-World/LingBot-World.mdx
+++ b/docs/cookbook/diffusion/LingBot-World/LingBot-World.mdx
@@ -158,3 +158,9 @@ LingBot World uses raw-frame websocket GT plus per-chunk latency guards for cons
 - Use the realtime endpoint for interactive sessions: `/v1/realtime_video/generate`.
 - Prefer WebP preview transport for interactive testing; use raw-frame transport for consistency checks.
 - Long-running sessions should be validated with raw-frame consistency before changing causal cache, condition sampling, or VAE decode behavior.
+
+## 7. Run in ComfyUI
+
+import { ComfyUISupport } from '/src/snippets/diffusion/comfyui-support.jsx';
+
+<ComfyUISupport model="video" />

--- a/docs/cookbook/diffusion/LongLive/LongLive-2.0.mdx
+++ b/docs/cookbook/diffusion/LongLive/LongLive-2.0.mdx
@@ -110,3 +110,9 @@ The image is used as the first-frame condition.
 - SGLang supports T2V sizes 1280x704, 704x1280, 832x480, and 480x832.
 - I2V request images follow the Wan TI2V preprocessing path in SGLang. This is different from the original LongLive dataset resize path.
 - For multi-shot runs, set `num_frames` to match `len(shot_prompts) * chunks_per_shot * 8` latent frames, that is `num_frames = (len(shot_prompts) * chunks_per_shot * 8 - 1) * 4 + 1`.
+
+## 6. Run in ComfyUI
+
+import { ComfyUISupport } from '/src/snippets/diffusion/comfyui-support.jsx';
+
+<ComfyUISupport model="video" />

--- a/docs/cookbook/diffusion/MOVA/MOVA.mdx
+++ b/docs/cookbook/diffusion/MOVA/MOVA.mdx
@@ -270,3 +270,9 @@ python3 -m sglang.multimodal_gen.benchmarks.bench_serving \
     --task image-to-video --dataset vbench --num-prompts 20 --max-concurrency 20 \
     --port 30002
 ```
+
+## 6. Run in ComfyUI
+
+import { ComfyUISupport } from '/src/snippets/diffusion/comfyui-support.jsx';
+
+<ComfyUISupport model="video" />

--- a/docs/cookbook/diffusion/MiniMax/MiniMax-H3.mdx
+++ b/docs/cookbook/diffusion/MiniMax/MiniMax-H3.mdx
@@ -1112,3 +1112,9 @@ For a measured lower-count AMD deployment, set both `--num-gpus` and
 `--ulysses-degree` to 4, 2, or 1. AITER packed attention matched segment-wise
 BF16 SDPA at cosine similarity `0.9999991655` on MI355X and `0.9999991059` on
 MI300X.
+
+## 10. Run in ComfyUI
+
+import { ComfyUISupport } from '/src/snippets/diffusion/comfyui-support.jsx';
+
+<ComfyUISupport model="minimax-h3" />

--- a/docs/cookbook/diffusion/Qwen-Image/Qwen-Image-Edit.mdx
+++ b/docs/cookbook/diffusion/Qwen-Image/Qwen-Image-Edit.mdx
@@ -279,3 +279,9 @@ Peak Memory Mean (MB):                   47971.49
 Peak Memory Median (MB):                 47971.29
 ============================================================
 ```
+
+## 6. Run in ComfyUI
+
+import { ComfyUISupport } from '/src/snippets/diffusion/comfyui-support.jsx';
+
+<ComfyUISupport model="qwen-image-edit" />

--- a/docs/cookbook/diffusion/Qwen-Image/Qwen-Image.mdx
+++ b/docs/cookbook/diffusion/Qwen-Image/Qwen-Image.mdx
@@ -381,3 +381,9 @@ Test Environment:
     ```
   </Tab>
 </Tabs>
+
+## 6. Run in ComfyUI
+
+import { ComfyUISupport } from '/src/snippets/diffusion/comfyui-support.jsx';
+
+<ComfyUISupport model="qwen-image" />

--- a/docs/cookbook/diffusion/SANA-WM/SANA-WM.mdx
+++ b/docs/cookbook/diffusion/SANA-WM/SANA-WM.mdx
@@ -500,3 +500,9 @@ At WebSocket `init` the realtime adapter fills SANA-WM defaults that differ from
 <Note>
 `guidance_scale` applies to the dense path (§4) only; the distilled streaming path uses `streaming_cfg_scale` (default `1.0`, i.e. no CFG) so a `guidance_scale` override never accidentally enables CFG on the streaming stage. `denoising_step_list = (1000, 960, 889, 727, 0)` is the official 4-step streaming schedule (it must end in 0).
 </Note>
+
+## 10. Run in ComfyUI
+
+import { ComfyUISupport } from '/src/snippets/diffusion/comfyui-support.jsx';
+
+<ComfyUISupport model="video" />

--- a/docs/cookbook/diffusion/Wan/Wan2.1.mdx
+++ b/docs/cookbook/diffusion/Wan/Wan2.1.mdx
@@ -392,3 +392,9 @@ You can use the built-in SGLang diffusion benchmark script to evaluate Wan2.1 pe
     ```
   </Tab>
 </Tabs>
+
+## 6. Run in ComfyUI
+
+import { ComfyUISupport } from '/src/snippets/diffusion/comfyui-support.jsx';
+
+<ComfyUISupport model="video" />

--- a/docs/cookbook/diffusion/Wan/Wan2.2.mdx
+++ b/docs/cookbook/diffusion/Wan/Wan2.2.mdx
@@ -460,3 +460,9 @@ Test Environment:
     ```
   </Tab>
 </Tabs>
+
+## 6. Run in ComfyUI
+
+import { ComfyUISupport } from '/src/snippets/diffusion/comfyui-support.jsx';
+
+<ComfyUISupport model="video" />

--- a/docs/cookbook/diffusion/Z-Image/Z-Image-Turbo.mdx
+++ b/docs/cookbook/diffusion/Z-Image/Z-Image-Turbo.mdx
@@ -369,3 +369,9 @@ Test Environment:
     ```
   </Tab>
 </Tabs>
+
+## 6. Run in ComfyUI
+
+import { ComfyUISupport } from '/src/snippets/diffusion/comfyui-support.jsx';
+
+<ComfyUISupport model="z-image" />

--- a/docs/src/snippets/diffusion/comfyui-support.jsx
+++ b/docs/src/snippets/diffusion/comfyui-support.jsx
@@ -1,0 +1,95 @@
+// ComfyUI support statement for a diffusion cookbook page.
+//
+// The per-model facts live here rather than in each page so they stay in sync
+// with the plugin. `integrated` must match a key in `executor_class_dict`
+// (python/sglang/multimodal_gen/apps/ComfyUI_SGLDiffusion/core/generator.py);
+// a model absent from that dict has no integrated mode.
+
+const PLUGIN_PATH = "python/sglang/multimodal_gen/apps/ComfyUI_SGLDiffusion";
+const PLUGIN_URL =
+  "https://github.com/sgl-project/sglang/tree/main/" + PLUGIN_PATH;
+
+const MODELS = {
+  flux: {
+    serverNode: "SGLDiffusion Generate Image",
+    integratedKey: "flux",
+    workflow: "flux_sgld_sp.json",
+  },
+  "z-image": {
+    serverNode: "SGLDiffusion Generate Image",
+    integratedKey: "lumina2",
+    workflow: "z-image_sgld.json",
+  },
+  "qwen-image": {
+    serverNode: "SGLDiffusion Generate Image",
+    integratedKey: "qwen_image",
+    workflow: "qwen_image_sgld.json",
+  },
+  "qwen-image-edit": {
+    serverNode: "SGLDiffusion Generate Image",
+    integratedKey: "qwen_image_edit",
+    note: "Image editing through the integrated path is experimental.",
+  },
+  "minimax-h3": {
+    serverNode: "SGLDiffusion Generate H3",
+    verified: true,
+    integratedBlockedBecause:
+      "H3 denoises a packed video-and-audio sequence in one pass and routes " +
+      "conditioning by task, while ComfyUI's KSampler drives a single latent " +
+      "tensor and has no audio branch",
+  },
+  image: { serverNode: "SGLDiffusion Generate Image" },
+  video: { serverNode: "SGLDiffusion Generate Video" },
+};
+
+export const ComfyUISupport = ({ model = "video", note }) => {
+  const spec = MODELS[model] || MODELS.video;
+  const extraNote = note || spec.note;
+
+  return (
+    <div>
+      <p>
+        Run this model from ComfyUI with the{" "}
+        <a href={PLUGIN_URL}>SGLDiffusion plugin</a>, which ships in the SGLang
+        repository at <code>{PLUGIN_PATH}</code>.
+      </p>
+
+      <p>
+        <strong>Server mode</strong> — SGLang runs the pipeline and ComfyUI
+        sends the request. Start a server as shown above, point the{" "}
+        <code>SGLDiffusion Server Model</code> node at it, then generate with{" "}
+        <code>{spec.serverNode}</code>.
+        {spec.verified
+          ? " This path has been run end to end against a live server."
+          : ""}
+      </p>
+
+      {spec.integratedKey ? (
+        <p>
+          <strong>Integrated mode</strong> — ComfyUI's own sampler, CLIP, and
+          VAE drive the loop while SGLang replaces the model forward. Load the
+          checkpoint with <code>SGLDiffusion UNET Loader</code> and set{" "}
+          <code>model_type</code> to <code>{spec.integratedKey}</code> on the{" "}
+          <code>SGLDiffusion Options</code> node.
+          {spec.workflow ? (
+            <>
+              {" "}
+              A reference workflow is included at{" "}
+              <code>{`${PLUGIN_PATH}/workflows/${spec.workflow}`}</code>.
+            </>
+          ) : null}
+        </p>
+      ) : (
+        <p>
+          <strong>Integrated mode</strong> — not available for this model
+          {spec.integratedBlockedBecause
+            ? `: ${spec.integratedBlockedBecause}`
+            : ", which has no executor in the plugin"}
+          . Use server mode.
+        </p>
+      )}
+
+      {extraNote ? <p>{extraNote}</p> : null}
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
Whether a model can be driven from ComfyUI was not answerable from its cookbook page — a reader had to go read the plugin source. All 18 diffusion pages now end with a `Run in ComfyUI` section.

The per-model facts live in one shared component (`docs/src/snippets/diffusion/comfyui-support.jsx`) rather than eighteen copies of prose, because they derive from a single source of truth in the plugin: a model has an integrated mode only if it appears in `executor_class_dict`. Prose per page would drift the moment the plugin gains or loses an executor. It also means changing the wording later is a one-file edit instead of eighteen.

Three shapes fall out of that table:

| | Server mode | Integrated mode |
|---|---|---|
| FLUX, Z-Image, Qwen-Image, Qwen-Image-Edit | generic image node | executor + reference workflow |
| MiniMax-H3 | dedicated `SGLDiffusion Generate H3` node | not available — packed video+audio in one pass, no audio branch in KSampler |
| everything else | generic image / video node | not available, stated explicitly |

Only H3 is marked as run end to end against a live server; the others state the mechanism without claiming per-model verification.

Enforcement so this does not rot:
- `cookbook-add-model` now requires the section when adding a diffusion page.
- `cookbook-review-pr` flags a missing section, inline prose instead of the component, and — the one that would actually mislead readers — a model-specific key without matching plugin support.

## Test plan
- [x] Purely additive: 21 files, 236 insertions, **0 deletions**.
- [x] Section number derived per page from its existing headings, so no renumbering and no broken anchors (pages end at 4, 5, 6, or 9 today).
- [x] Every `model` key used resolves in the component's table; the four integrated-mode keys match `executor_class_dict` exactly (`flux`, `lumina2`, `qwen_image`, `qwen_image_edit`).
- [x] Image/video classification taken from each page's own `DiffusionModelTags`, not guessed.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #35573603293](https://github.com/sgl-project/sglang/actions/runs/35573603293)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #35573602963](https://github.com/sgl-project/sglang/actions/runs/35573602963)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->