### PR TITLE
[dLLM] Don't cache the in-flight denoise block in the radix tree

### DIFF
--- a/python/sglang/srt/dllm/mixin/req.py
+++ b/python/sglang/srt/dllm/mixin/req.py
@@ -40,6 +40,23 @@ class ReqDllmMixin:
             DllmReqPhase.INCOMING_PREFILL,
         ]
 
+    def get_cacheable_fill_ids(self: Req) -> array:
+        """The fill ids a prefix cache may take ownership of.
+
+        A dLLM request's in-flight denoise block is rewritten in full on every
+        step (``dllm_incomplete_ids`` is reassigned in the scheduler mixin), so
+        its token ids are not final. Because the dLLM page size is pinned to the
+        block size, that block is a whole trailing page of the radix key: caching
+        it makes the next step's key diverge there, which drives the match below
+        ``cache_protected_len`` and leaves the tree owning two nodes for the same
+        pages. Only the settled prefix is cacheable; the block is inserted on a
+        later step, once it resolves and moves into the committed fill ids.
+        """
+        fill_ids = self.get_fill_ids()
+        if self.dllm_incomplete_ids:
+            return fill_ids[: len(fill_ids) - len(self.dllm_incomplete_ids)]
+        return fill_ids
+
     def determine_dllm_phase(self: Req):
         if self.dllm_incomplete_ids:
             self.dllm_phase = DllmReqPhase.STAGING_DECODE

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -540,7 +540,11 @@ class RadixCache(BasePrefixCache):
         if self.disable:
             return
 
-        token_ids = req.get_fill_ids()
+        # Not get_fill_ids(): a dLLM request's trailing in-flight denoise block
+        # is rewritten every step, so it must not enter the tree (see
+        # ReqDllmMixin.get_cacheable_fill_ids). For every other request this is
+        # the same value.
+        token_ids = req.get_cacheable_fill_ids()
         kv_indices = self.req_to_token_pool.req_to_token[
             req.kv.req_pool_idx, : len(token_ids)
         ]

--- a/test/registered/unit/mem_cache/test_decode_radix_lock_ref.py
+++ b/test/registered/unit/mem_cache/test_decode_radix_lock_ref.py
@@ -33,6 +33,7 @@ import torch
 
 from sglang.srt.disaggregation.decode import DecodePreallocQueue
 from sglang.srt.disaggregation.decode_hicache_mixin import DecodePrefixMatch
+from sglang.srt.dllm.mixin.req import ReqDllmMixin
 from sglang.srt.mem_cache.base_prefix_cache import (
     DecLockRefParams,
     InsertParams,
@@ -65,10 +66,15 @@ def _make_cache_with_pools(page_size=1):
     return cache, req_to_token
 
 
-class MockReq:
-    """Minimal mock Req with fields needed by cache_unfinished/finished_req."""
+class MockReq(ReqDllmMixin):
+    """Minimal mock Req with fields needed by cache_unfinished/finished_req.
+
+    Inherits ReqDllmMixin for the same reason Req does: the prefix caches call
+    get_cacheable_fill_ids(), which the mixin supplies.
+    """
 
     def __init__(self, fill_ids, req_pool_idx=0, cache_protected_len=0, last_node=None):
+        self.dllm_incomplete_ids = array("q")
         self.full_untruncated_fill_ids = array("q", fill_ids)
         self.extend_range = Range(0, len(self.full_untruncated_fill_ids))
         self.origin_input_ids = array(

--- a/test/registered/unit/mem_cache/test_radix_cache_dllm_volatile_block.py
+++ b/test/registered/unit/mem_cache/test_radix_cache_dllm_volatile_block.py
@@ -18,12 +18,16 @@ from array import array
 import torch
 
 from sglang.srt.dllm.mixin.req import ReqDllmMixin
+from sglang.srt.managers.schedule_batch import ReqKvInfo
 from sglang.srt.mem_cache.allocator.paged import PagedTokenToKVPoolAllocator
 from sglang.srt.mem_cache.cache_init_params import CacheInitParams
 from sglang.srt.mem_cache.memory_pool import MHATokenToKVPool, ReqToTokenPool
 from sglang.srt.mem_cache.radix_cache import RadixCache
 from sglang.srt.utils.common import Range
 from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 PAGE_SIZE = 32
 
@@ -35,8 +39,7 @@ class _MockDllmReq(ReqDllmMixin):
         self.full_untruncated_fill_ids = array("q", fill_ids)
         self.extend_range = Range(0, len(self.full_untruncated_fill_ids))
         self.dllm_incomplete_ids = array("q", incomplete_ids)
-        self.req_pool_idx = req_pool_idx
-        self.cache_protected_len = 0
+        self.kv = ReqKvInfo(req_pool_idx=req_pool_idx)
         self.last_node = None
         self.extra_key = None
         self.cache_salt = None
@@ -94,7 +97,7 @@ def _tree_pages(cache, page_size=PAGE_SIZE):
     return pages
 
 
-class TestDllmVolatileBlockNotCached(unittest.TestCase):
+class TestDllmVolatileBlockNotCached(CustomTestCase):
     def test_in_flight_block_is_excluded_from_cacheable_ids(self):
         stable, block = list(range(64)), list(range(900, 932))
         req = _MockDllmReq(stable + block, incomplete_ids=block)
@@ -130,8 +133,6 @@ class TestDllmVolatileBlockNotCached(unittest.TestCase):
             f"tree actually owns -- the same pages are counted under two nodes",
         )
 
-
-register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/mem_cache/test_radix_cache_dllm_volatile_block.py
+++ b/test/registered/unit/mem_cache/test_radix_cache_dllm_volatile_block.py
@@ -1,0 +1,137 @@
+"""A dLLM request's in-flight denoise block must not be cached.
+
+``dllm_incomplete_ids`` is reassigned in full on every denoise step, and the
+dLLM page size is pinned to the block size, so that block is a whole trailing
+page of the radix key. Caching it makes the next step's key diverge there: the
+match drops below ``cache_protected_len``, ``cache_unfinished_req``'s
+``free_segment`` slice inverts to empty (freeing nothing), and the new node
+claims pages the previous node still owns -- inflating ``evictable_size()``
+past what the pool physically holds and tripping the idle pool invariant.
+
+Regression test for the over-count reported in #35270 (distinct from the
+deficit-shaped leak in #32992).
+"""
+
+import unittest
+from array import array
+
+import torch
+
+from sglang.srt.dllm.mixin.req import ReqDllmMixin
+from sglang.srt.mem_cache.allocator.paged import PagedTokenToKVPoolAllocator
+from sglang.srt.mem_cache.cache_init_params import CacheInitParams
+from sglang.srt.mem_cache.memory_pool import MHATokenToKVPool, ReqToTokenPool
+from sglang.srt.mem_cache.radix_cache import RadixCache
+from sglang.srt.utils.common import Range
+from sglang.test.ci.ci_register import register_cpu_ci
+
+PAGE_SIZE = 32
+
+
+class _MockDllmReq(ReqDllmMixin):
+    """Minimal Req carrying only what cache_unfinished_req touches."""
+
+    def __init__(self, fill_ids, incomplete_ids=(), req_pool_idx=0):
+        self.full_untruncated_fill_ids = array("q", fill_ids)
+        self.extend_range = Range(0, len(self.full_untruncated_fill_ids))
+        self.dllm_incomplete_ids = array("q", incomplete_ids)
+        self.req_pool_idx = req_pool_idx
+        self.cache_protected_len = 0
+        self.last_node = None
+        self.extra_key = None
+        self.cache_salt = None
+        self.prefix_indices = torch.empty(0, dtype=torch.int64)
+        self.priority = 0
+
+    def get_fill_ids(self):
+        return self.full_untruncated_fill_ids[: self.extend_range.end]
+
+
+def _make_cache(page_size=PAGE_SIZE, pool_tokens=1024):
+    """Real paged pools: page-aligned KV indices are essential to this bug."""
+    kv = MHATokenToKVPool(
+        size=pool_tokens,
+        page_size=page_size,
+        dtype=torch.float16,
+        head_num=1,
+        head_dim=8,
+        layer_num=1,
+        device="cpu",
+        enable_memory_saver=False,
+    )
+    allocator = PagedTokenToKVPoolAllocator(
+        size=pool_tokens,
+        page_size=page_size,
+        dtype=torch.float16,
+        device="cpu",
+        kvcache=kv,
+        need_sort=False,
+    )
+    req_to_token_pool = ReqToTokenPool(
+        size=4, max_context_len=512, device="cpu", enable_memory_saver=False
+    )
+    cache = RadixCache(
+        CacheInitParams(
+            disable=False,
+            req_to_token_pool=req_to_token_pool,
+            token_to_kv_pool_allocator=allocator,
+            page_size=page_size,
+            eviction_policy="lru",
+            enable_kv_cache_events=False,
+        )
+    )
+    return cache, allocator, req_to_token_pool.req_to_token
+
+
+def _tree_pages(cache, page_size=PAGE_SIZE):
+    """Distinct physical pages referenced anywhere in the tree."""
+    pages, stack = set(), [cache.root_node]
+    while stack:
+        node = stack.pop()
+        if node is not cache.root_node:
+            pages.update(v // page_size for v in node.value.tolist())
+        stack.extend(node.children.values())
+    return pages
+
+
+class TestDllmVolatileBlockNotCached(unittest.TestCase):
+    def test_in_flight_block_is_excluded_from_cacheable_ids(self):
+        stable, block = list(range(64)), list(range(900, 932))
+        req = _MockDllmReq(stable + block, incomplete_ids=block)
+        self.assertEqual(list(req.get_cacheable_fill_ids()), stable)
+
+    def test_resolved_block_is_cacheable(self):
+        """With no block in flight the cacheable ids are the full fill ids."""
+        fill = list(range(96))
+        req = _MockDllmReq(fill, incomplete_ids=())
+        self.assertEqual(list(req.get_cacheable_fill_ids()), fill)
+
+    def test_accounting_does_not_exceed_owned_pages(self):
+        cache, allocator, req_to_token = _make_cache()
+        stable = list(range(64))
+
+        req = _MockDllmReq(stable, incomplete_ids=[])
+        req.last_node = cache.root_node
+        # Settled prefix + the block's slots, allocated once (denoised in place).
+        req_to_token[0, :96] = allocator.alloc(96).to(torch.int64)
+
+        for block in (list(range(900, 932)), list(range(800, 832))):
+            req.full_untruncated_fill_ids = array("q", stable + block)
+            req.extend_range = Range(0, len(req.full_untruncated_fill_ids))
+            req.dllm_incomplete_ids = array("q", block)
+            cache.cache_unfinished_req(req)
+
+        owned = len(_tree_pages(cache)) * PAGE_SIZE
+        accounted = cache.evictable_size() + cache.protected_size()
+        self.assertLessEqual(
+            accounted,
+            owned,
+            f"evictable+protected={accounted} exceeds the {owned} tokens the "
+            f"tree actually owns -- the same pages are counted under two nodes",
+        )
+
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_radix_cache_unit.py
+++ b/test/registered/unit/mem_cache/test_radix_cache_unit.py
@@ -525,6 +525,8 @@ class TestRadixCache(unittest.TestCase):
             last_node=cache.root_node,
         )
         req.get_fill_ids.return_value = token_ids
+        # No block in flight, so the cacheable ids are the full fill ids.
+        req.get_cacheable_fill_ids.return_value = token_ids
 
         available_before_free = allocator.available_size()
         allocator.free_group_begin()


### PR DESCRIPTION
## Motivation

Fixes #35270.

With radix cache on, a dLLM run trips the idle pool invariant once the server drains. Every request completes, then `on_idle()` raises:

```
ValueError: pool memory leak detected! [full]
total=469952, available=96, evictable=470016, protected=0, session_held=0, uncached=0
```

`available + evictable` is **160 tokens (5 pages) more** than the pool holds. Reported on Ascend NPU and since reproduced on CUDA/A100 by @TrigonW, so it is not device-specific.

Nothing actually leaks. `_check_pool_invariant` compares with `!=`, so it reports both directions as a "leak"; the sign is the tell. This one is an **excess** — the radix tree counts the same pages under two nodes. That makes it distinct from the deficit-shaped FDFO abort leak in #32992 (`-32`), which is a separate fix and does not address this.

## Root cause

`ReqDllmMixin._init_fill_ids_for_dllm` rebuilds the fill ids as `settled_prefix + dllm_incomplete_ids`, and `dllm_incomplete_ids` is reassigned **in full on every denoise step**. Since `_dllm_page_size` pins `page_size` to the dLLM `block_size`, that in-flight block is a whole trailing page of the radix key.

So `cache_unfinished_req` caches a page whose token ids are not final:

1. Step N inserts `[settled][block_v1]`; the write-back at the end points the request's `req_to_token` row at the **tree's** canonical indices, and `cache_protected_len` covers the block.
2. Step N+1 denoises in place, so the key becomes `[settled][block_v2]` over the same KV slots. The match during `insert` now diverges at the block boundary and returns `prefix_len = len(settled)`, which is **below** `cache_protected_len`.
3. `free_segment(kv_indices[cache_protected_len : new_prefix_len], ...)` is therefore an inverted range. It hits the `numel() == 0` guard and silently frees nothing.
4. The node inserted for `block_v2` takes `kv_indices[prefix_len:]` — which, after step N's write-back, are pages the step-N node still owns. `evictable_size_ += len(key)` counts them a second time.

This matches every observation in the issue: pages balance physically, `OVERLAP(tree, free) = 0`, no use-after-free, and autoregressive models are clean because their committed token ids never change retroactively.

## Change

Add `ReqDllmMixin.get_cacheable_fill_ids()` — the fill ids a prefix cache may take ownership of — and use it in `RadixCache.cache_unfinished_req`. It drops the in-flight block; for every other request it returns `get_fill_ids()` unchanged.

No reuse is lost: the block is inserted on a later step, once it resolves and moves into the committed fill ids.

## Tests

`test/registered/unit/mem_cache/test_radix_cache_dllm_volatile_block.py` (CPU, no accelerator). It drives the real `RadixCache` over real paged pools across two denoise steps and asserts the tree never accounts more tokens than the pages it owns. Without the fix it fails with `128 > 96` — one page double-counted, the same shape as the reported `+160`.

Two existing test doubles stub `get_fill_ids` but not the new accessor, so they are updated: `MockReq` in `test_decode_radix_lock_ref.py` now inherits `ReqDllmMixin` (as the real `Req` does), and the `Mock` in `test_radix_cache_unit.py` stubs the new return value.

Full `test/registered/unit/mem_cache` run against a clean-`main` baseline on the same machine: 690 failed / 968 passed before, 690 failed / 971 passed after — identical failure set, the +3 being the new tests. (The 690 are pre-existing environment failures on this macOS/CPU box.)

## Notes for reviewers

- Scoped to `RadixCache`. Four other caches (`swa_radix_cache`, `mamba_radix_cache`, `unified_radix_cache`, `radix_cache_cpp`) call `req.get_fill_ids()` in `cache_unfinished_req` and carry the same latent assumption. dLLM does not exercise them today, so I left them alone rather than change paths I cannot test — happy to extend if you'd prefer them consistent.
- Separately: `_check_pool_invariant` reporting an over-count as "memory leak detected" is what made this look like #32992. Reporting the signed delta would make the two immediately distinguishable. Left out of this PR to keep it focused.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33982357419](https://github.com/sgl-project/sglang/actions/runs/33982357419)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33982357339](https://github.com/sgl-project/sglang/actions/runs/33982357339)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33982357538](https://github.com/sgl-project/sglang/actions/runs/33982357538)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
