### PR TITLE
[Fix] LLaVA-hf checkpoints: five sequential fixes for Transformers-fallback vision-tower loading

### DIFF
--- a/python/sglang/srt/models/llava.py
+++ b/python/sglang/srt/models/llava.py
@@ -875,6 +875,8 @@ class LlavaForConditionalGeneration(LlavaBaseForCausalLM):
             for part in ("language_model", "vision_tower"):
                 if name.startswith(part):
                     name = name[len(part + ".") :]
+                    if part == "vision_tower" and name.startswith("vision_model."):
+                        name = name[len("vision_model.") :]
                     getattr(self, part).load_weights([(name, loaded_weight)])
                     break
             else:

--- a/python/sglang/srt/models/llava.py
+++ b/python/sglang/srt/models/llava.py
@@ -858,10 +858,7 @@ class LlavaForConditionalGeneration(LlavaBaseForCausalLM):
         weight name remapping as the weights are already properly structured with
         'language_model' and 'vision_tower' prefixes in the safetensors files.
         """
-        if (
-            self.vision_feature_select_strategy == "patch"
-            or self.vision_feature_select_strategy == "full"
-        ):
+        if self.vision_feature_select_strategy in ("default", "patch", "full"):
             pass
         elif self.vision_feature_select_strategy == "cls_patch":
             self.image_feature_len += 1

--- a/python/sglang/srt/models/llava.py
+++ b/python/sglang/srt/models/llava.py
@@ -61,20 +61,17 @@ _KNOWN_BROKEN_AUTOMODEL_ERROR = "Could not find VoxtralRealtimeTextModel"
 
 
 class LlavaBaseForCausalLM(nn.Module):
-    @staticmethod
-    def _infer_image_aspect_ratio(mm_items):
+    def _infer_image_aspect_ratio(self, mm_items):
         """Determine image_aspect_ratio from processor metadata or item count."""
-        # Check if processor stored the aspect_ratio it used
         for item in mm_items:
             ar = item.model_specific_data.get("image_aspect_ratio")
             if ar is not None:
                 return ar
-        # Fallback: multi-image or video → pad, single image → anyres
         image_items = [item for item in mm_items if item.is_image()]
         has_video = any(item.is_video() for item in mm_items)
         if len(image_items) > 1 or has_video:
             return "pad"
-        return "anyres"
+        return self.image_aspect_ratio
 
     def pad_input_ids(
         self, input_ids: array[int], image_inputs: MultimodalInputs
@@ -739,18 +736,9 @@ class LlavaForConditionalGeneration(LlavaBaseForCausalLM):
         if not hasattr(self.config, "vocab_size"):
             self.config.vocab_size = self.text_config.vocab_size
         if not hasattr(self.config, "image_aspect_ratio"):
-            self.config.image_aspect_ratio = "anyres"
+            self.config.image_aspect_ratio = "pad"
         if not hasattr(self.config, "image_grid_pinpoints"):
-            # from transformers.models.llava_onevision.configuration_llava_onevision import LlavaOnevisionConfig
-            # self.config.image_grid_pinpoints = LlavaOnevisionConfig().image_grid_pinpoints
-            self.config.image_grid_pinpoints = [
-                [96, 96],
-                [224, 224],
-                [384, 384],
-                [512, 512],
-                [768, 768],
-                [1024, 1024],
-            ]
+            self.config.image_grid_pinpoints = None
         if not hasattr(self.config, "mm_patch_merge_type"):
             self.config.mm_patch_merge_type = "flat"
         if not hasattr(self.config, "image_token_index"):

--- a/python/sglang/srt/models/transformers.py
+++ b/python/sglang/srt/models/transformers.py
@@ -625,15 +625,15 @@ class TransformersBase(nn.Module):
                 "requires custom attention support."
             )
 
-        self.vocab_size = getattr(
-            self.text_config,
-            "vocab_size",
-            self.model.get_input_embeddings().num_embeddings,
-        )
+        input_embeddings = self.model.get_input_embeddings()
+        if hasattr(self.text_config, "vocab_size"):
+            self.vocab_size = self.text_config.vocab_size
+        elif isinstance(input_embeddings, nn.Embedding):
+            self.vocab_size = input_embeddings.num_embeddings
+        else:
+            self.vocab_size = 0
         self.unpadded_vocab_size = self.vocab_size
 
-        # Embedding scale (e.g. Whisper)
-        input_embeddings = self.model.get_input_embeddings()
         self.embed_scale = getattr(input_embeddings, "embed_scale", None)
 
         self.start_layer = 0

--- a/python/sglang/srt/models/transformers.py
+++ b/python/sglang/srt/models/transformers.py
@@ -955,6 +955,8 @@ class TransformersBase(nn.Module):
         old_module = self.model.get_input_embeddings()
         if old_module is None or isinstance(old_module, PPMissingLayer):
             return
+        if not isinstance(old_module, nn.Embedding):
+            return
         embedding_dim = getattr(old_module, "embedding_dim", None)
         if embedding_dim is None:
             embedding_dim = _getattr_first(


### PR DESCRIPTION
## Summary

Five sequential fixes that let `llava-hf/llava-1.5-7b-hf` reach model.forward on the current transformers release. Each was surfaced by the next after the prior was applied; all are localized. A sixth blocker (a multimodal-scheduler mismatch, `items_offset` handed as `None` to `_count_mm_tokens_in_extend`) is a different subsystem — not in scope for this PR, will follow up separately.

### 1. `TransformersBase.__init__` — guard `vocab_size` lookup for vision encoders

The initializer dereferences the input embeddings unconditionally as the `getattr()` default:

```python
self.vocab_size = getattr(
    self.text_config,
    "vocab_size",
    self.model.get_input_embeddings().num_embeddings,
)
```

Python 3 evaluates the default eagerly, so `self.model.get_input_embeddings().num_embeddings` fires even when `text_config.vocab_size` is set. For a vision-only backbone (e.g. `CLIPVisionModel` routed through the fallback as the vision tower of a native LLaVA impl), `get_input_embeddings()` returns the patch-embedding `Conv2d`, which has no `num_embeddings`:

```
AttributeError: 'Conv2d' object has no attribute 'num_embeddings'
```

**Fix:** restructure the lookup so the fallback only runs when actually needed, and treats a non-`nn.Embedding` input-embedding module as "no vocab" (vision case). `input_embeddings` is now computed once and reused for the subsequent `embed_scale` probe.

### 2. `LlavaForConditionalGeneration.load_weights` — accept HF's `"default"` select strategy

`load_weights` guards on `vision_feature_select_strategy` (decides whether to bump `image_feature_len` for a leading CLS token). It accepted `"patch"` / `"full"` / `"cls_patch"` and raised on anything else. HF's own `LlavaConfig` — used by every `llava-hf/*` checkpoint — sets this to `"default"` (equivalent to `"patch"`: take all patch tokens after CLS, no length bump):

```
ValueError: Unexpected select feature: default
```

The sibling `get_image_feature` paths on the same class already treat `"default"` as an alias for `"patch"`. This is a stale gap in one location, not a semantic change.

### 3. `LlavaForConditionalGeneration.load_weights` — strip legacy `vision_model.` wrapper

`llava-hf/*` checkpoints serialize the vision tower under `vision_tower.vision_model.*` — the historical HF nesting for `CLIPVisionModel.vision_model = CLIPVisionTransformer(...)`. transformers ≥ 5.6 flattens that layout: `CLIPVisionModel.named_children()` returns `embeddings`, `pre_layrnorm`, `encoder`, `post_layernorm` directly, and the `vision_model` wrapper is gone.

When SGLang's native LLaVA impl routes the vision tower through the Transformers fallback (`_get_sgl_model_cls(vision_config, AutoModel)` → `TransformersForCausalLM`), the fallback wraps that same flattened HF class, so `self.model` has no `vision_model` submodule. After the LLaVA dispatcher strips `vision_tower.`, the residual names still lead with `vision_model.` and the loader trips at descend time:

```
ValueError: No module or parameter named 'model.vision_model' in TransformersForCausalLM.
```

**Fix:** strip the residual `vision_model.` prefix at the LLaVA dispatcher — the same place other post-`vision_tower` renames belong. Sibling model `llavavid.py` already carries this rewrite in its projector-weight map for the same reason (see the `transformers 5.6.0` comment there); this is the base-class counterpart.

### 4. `TransformersBase.replace_vocab_embed_class` — skip non-`nn.Embedding` input embeddings

`replace_vocab_embed_class` swaps the model's input embedding with a `VocabParallelEmbedding` sized to `self.vocab_size`. That is correct for language-model backbones (`nn.Embedding`, `num_embeddings == vocab_size`), but wrong for vision encoders: HF vision models return the patch-embedding `Conv2d` from `get_input_embeddings()`, which is a pixel→patch projection, not a lookup.

Compounding it, HF's `LlavaConfig.__init__` copies `text_config.vocab_size` onto `vision_config`, so a plain `CLIPVisionConfig()` has no `vocab_size` but the `LlavaConfig`-nested one carries `vocab_size = 32000`. The result:

- `self.vocab_size` resolves to 32000 (from `vision_config.vocab_size`)
- `new_module = VocabParallelEmbedding(32000, 1024)` replaces the `Conv2d`
- weight load of `vision_tower.vision_model.embeddings.patch_embedding.weight` (shape `[1024, 3, 14, 14]`) into the `VocabParallelEmbedding` trips its shape guard:

```
AssertionError: self.org_vocab_size=32000
    self.use_presharded_weights=False
    loaded_weight.shape[output_dim]=1024
```

Even if the guard didn't fire, forward would break: a `Conv2d(pixels→patches)` cannot be an `nn.Embedding` lookup.

**Fix:** bail out early when the input embedding is not an `nn.Embedding` subclass — vision encoders keep their `Conv2d` patch embedding untouched. Text models (`nn.Embedding` + optional `embed_scale` subclasses) are unchanged.

### 5. `LlavaForConditionalGeneration.__init__` + `_infer_image_aspect_ratio` — use configured aspect ratio, drop LLaVA-Onevision fallback

The initializer injects LLaVA-Onevision-shaped defaults when the HF config is missing `image_aspect_ratio` or `image_grid_pinpoints`:

```python
if not hasattr(self.config, "image_aspect_ratio"):
    self.config.image_aspect_ratio = "anyres"
if not hasattr(self.config, "image_grid_pinpoints"):
    self.config.image_grid_pinpoints = [
        [96, 96], [224, 224], [384, 384],
        [512, 512], [768, 768], [1024, 1024],
    ]
```

`llava-hf/llava-1.5-7b-hf` sets neither, so it gets forced into an anyres regime with LLaVA-Onevision pinpoints. `pad_input_ids` then computes an anyres grid via `get_anyres_image_grid_shape` and passes it to `unpad_image_shape`, which trips a `ZeroDivisionError` (or an `ast.literal_eval(None)` with a `None`-pinpoints default).

Compounding it, the base-class helper that decides the branch has the same LLaVA-Onevision bias:

```python
@staticmethod
def _infer_image_aspect_ratio(mm_items):
    ...
    return "anyres"    # single-image fallback
```

Two changes, same root cause:

- `_infer_image_aspect_ratio` becomes an instance method whose single-image fallback returns `self.image_aspect_ratio` instead of hard-coding `"anyres"`. Each subclass now propagates its own configured aspect ratio; processor-supplied per-item overrides still win.
- Missing-config defaults switch to `"pad"` and pinpoints `None`, the correct behavior for LLaVA-1.5-style single-grid checkpoints. Real anyres models (LLaVA-Onevision, LLaVA-NeXT) set both fields explicitly on their HF config, so the `hasattr` guards leave them untouched.

## Test plan

- [x] `pre-commit run --files <changed>` — passes locally for both files.
- [x] `llava-hf/llava-1.5-7b-hf` (TP=1, `intel_xpu` attention backend, `mem-fraction-static=0.80`) — on `main`, scheduler init dies at `AttributeError: 'Conv2d' object has no attribute 'num_embeddings'` before weight load; with fix 1 it progresses to the strategy-alias `ValueError`; fix 2 to the `vision_model.` descend `ValueError`; fix 3 to the `VocabParallelEmbedding` shape assertion; fix 4 to the anyres `ZeroDivisionError`; with all five fixes the server boots end-to-end (`Load weight end`, `KV Cache is allocated`, `Uvicorn running`), `/model_info` returns 200, `pad_input_ids` completes, and control reaches `model.forward` before the next-distinct blocker (see below).
- [ ] Not yet reaching output: a further `TypeError: cannot unpack non-iterable NoneType object` fires in `mm_schedule._count_mm_tokens_in_extend` (`items_offset` is `None`). Distinct subsystem — multimodal-scheduler expects a `[(start, end), ...]` list that the LLaVA `pad_input_ids` path isn't populating on this route. Follow-up separately.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32227380720](https://github.com/sgl-project/sglang/actions/runs/32227380720)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32227380550](https://github.com/sgl-project/sglang/actions/runs/32227380550)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->