### PR TITLE
[npu] Run selected NPU nightly suites (multi-node + nightly-1/4-npu-a3)

### DIFF
--- a/.github/workflows/_npu-single-node-test-stage.yml
+++ b/.github/workflows/_npu-single-node-test-stage.yml
@@ -13,10 +13,15 @@ on:
         default: perf
         description: perf or accuracy
       test_suite:
-        required: true
+        required: false
         type: string
         default: ''
         description: name of test suite to run via run_suite.py (mutually exclusive with test_case)
+      test_case:
+        required: false
+        type: string
+        default: ''
+        description: repo-relative path of a single test file to run directly (mutually exclusive with test_suite)
       image:
         required: true
         type: string
@@ -63,12 +68,12 @@ env:
   SKIP_PR_TEST_HEALTH_CHECK: ${{ inputs.skip_pr_test_health_check }}
 
 concurrency:
-  group: ascend-nightly-e2e-singlenode-${{ github.workflow_ref }}-${{ github.ref }}-${{ inputs.test_suite }}
+  group: ascend-nightly-e2e-singlenode-${{ github.workflow_ref }}-${{ github.ref }}-${{ inputs.test_suite }}${{ inputs.test_case }}
   cancel-in-progress: true
 
 jobs:
   e2e:
-    name: ${{ inputs.test_suite }}
+    name: ${{ inputs.test_suite }}${{ inputs.test_case }}
     strategy:
       fail-fast: false
       matrix:
@@ -226,10 +231,17 @@ jobs:
           echo "Source code path: ${sglang_source_path}"
           ln -sf ${sglang_source_path} /root/sglang
 
-          # Determine test mode: suite (run_suite.py --suite) or single case file.
+          # Determine test mode: suite (run_suite.py --suite) or single case file (python3 <file> -f).
           test_suite="${{ inputs.test_suite }}"
-          echo "Test mode: suite (${test_suite})"
-          tc_name="${test_suite}"
+          test_case="${{ inputs.test_case }}"
+          if [ -n "${test_case}" ]; then
+            echo "Test mode: single case (${test_case})"
+            tc_name=${test_case##*/}
+            tc_name=${tc_name%.*}
+          else
+            echo "Test mode: suite (${test_suite})"
+            tc_name="${test_suite}"
+          fi
 
           # The ID is used to locate the current job instance,
           # size determines whether parallel execution is enabled.
@@ -387,10 +399,20 @@ jobs:
             LOG_TEE_TARGETS+=("${log_path}/${tc_name}.log")
           fi
 
-          # Run NPU test suite with run_suite.py.
-          # Capture mode (--enable-retry --max-attempts 1) keeps test subprocesses off the
-          # tee pipe, so leftover server processes cannot block the pipeline on exit.
-          ${PYTHON_FOR_SGLANG} -u run_suite.py --hw npu --suite ${test_suite} ${NIGHTLY_FLAG} ${PARTITION_ARGS} ${TIMEOUT_FLAG} --enable-retry --max-attempts 1 --timeout-per-file 7200 2>&1 | tee "${LOG_TEE_TARGETS[@]}" || test_exit_code=$?
+          # Run a single test case directly (unittest script with -f failfast), or the
+          # full suite via run_suite.py.
+          if [ -n "${test_case}" ]; then
+            test_case_path="${sglang_source_path}/${test_case}"
+            if [ ! -f "${test_case_path}" ]; then
+              echo "Test case not found: ${test_case_path}"
+              exit 1
+            fi
+            ${PYTHON_FOR_SGLANG} -u "${test_case_path}" -f 2>&1 | tee "${LOG_TEE_TARGETS[@]}" || test_exit_code=$?
+          else
+            # Capture mode (--enable-retry --max-attempts 1) keeps test subprocesses off the
+            # tee pipe, so leftover server processes cannot block the pipeline on exit.
+            ${PYTHON_FOR_SGLANG} -u run_suite.py --hw npu --suite ${test_suite} ${NIGHTLY_FLAG} ${PARTITION_ARGS} ${TIMEOUT_FLAG} --enable-retry --max-attempts 1 --timeout-per-file 7200 2>&1 | tee "${LOG_TEE_TARGETS[@]}" || test_exit_code=$?
+          fi
 
           echo "Finished test: ${tc_name}"
 

--- a/.github/workflows/nightly-test-npu.yml
+++ b/.github/workflows/nightly-test-npu.yml
@@ -124,7 +124,7 @@ jobs:
 
   nightly-1-npu-a2:
     name: nightly-1-npu-a2
-    if: ${{ !cancelled() }}
+    if: false  # disabled for focused verification
     needs: [set-image-config]
     uses: ./.github/workflows/_npu-single-node-test-stage.yml
     with:
@@ -155,7 +155,7 @@ jobs:
 
   nightly-2-npu-a3:
     name: nightly-2-npu-a3
-    if: ${{ !cancelled() }}
+    if: false  # disabled for focused verification
     needs: [set-image-config]
     uses: ./.github/workflows/_npu-pr-test-stage.yml
     with:
@@ -187,7 +187,7 @@ jobs:
 
   nightly-8-npu-a3:
     name: nightly-8-npu-a3
-    if: ${{ !cancelled() }}
+    if: false  # disabled for focused verification
     needs: [set-image-config]
     uses: ./.github/workflows/_npu-pr-test-stage.yml
     with:
@@ -202,7 +202,7 @@ jobs:
 
   nightly-16-npu-a3:
     name: nightly-16-npu-a3
-    if: ${{ !cancelled() }}
+    if: false  # disabled for focused verification
     needs: [set-image-config]
     uses: ./.github/workflows/_npu-pr-test-stage.yml
     with:
@@ -217,7 +217,7 @@ jobs:
 
   nightly-perf-2-npu-a3:
     name: nightly-perf-2-npu-a3
-    if: ${{ !cancelled() }}
+    if: false  # disabled for focused verification
     needs: [set-image-config]
     uses: ./.github/workflows/_npu-single-node-test-stage.yml
     with:
@@ -233,7 +233,7 @@ jobs:
 
   nightly-perf-4-npu-a3:
     name: nightly-perf-4-npu-a3
-    if: ${{ !cancelled() }}
+    if: false  # disabled for focused verification
     needs: [set-image-config]
     uses: ./.github/workflows/_npu-single-node-test-stage.yml
     with:
@@ -249,7 +249,7 @@ jobs:
 
   nightly-perf-8-npu-a3:
     name: nightly-perf-8-npu-a3
-    if: ${{ !cancelled() }}
+    if: false  # disabled for focused verification
     needs: [set-image-config]
     uses: ./.github/workflows/_npu-single-node-test-stage.yml
     with:
@@ -330,7 +330,7 @@ jobs:
   # The acc-2 suite is split across 4 parallel partition jobs via the single `partitions` input.
   nightly-acc-2-npu-a3:
     name: nightly-acc-2-npu-a3
-    if: ${{ !cancelled() }}
+    if: false  # disabled for focused verification
     needs: [set-image-config]
     uses: ./.github/workflows/_npu-single-node-test-stage.yml
     with:
@@ -347,7 +347,7 @@ jobs:
 
   nightly-acc-4-npu-a3:
     name: nightly-acc-4-npu-a3
-    if: ${{ !cancelled() }}
+    if: false  # disabled for focused verification
     needs: [set-image-config]
     uses: ./.github/workflows/_npu-single-node-test-stage.yml
     with:
@@ -363,7 +363,7 @@ jobs:
 
   nightly-acc-16-npu-a3:
     name: nightly-acc-16-npu-a3
-    if: ${{ !cancelled() }}
+    if: false  # disabled for focused verification
     needs: [set-image-config]
     uses: ./.github/workflows/_npu-single-node-test-stage.yml
     with:
@@ -379,7 +379,7 @@ jobs:
 
   nightly-poc-multi-node-tests:
     name: multi-node-poc
-    if: ${{ !cancelled() }}
+    if: false  # disabled for focused verification
     needs: [set-image-config, nightly-perf-2-npu-a3, nightly-perf-4-npu-a3, nightly-perf-16-npu-a3, nightly-acc-2-npu-a3, nightly-acc-4-npu-a3, nightly-acc-16-npu-a3]
     strategy:
       fail-fast: false
@@ -441,7 +441,7 @@ jobs:
 
   nightly-poc-multi-node-mix-tests:
     name: multi-node-mix-poc
-    if: ${{ !cancelled() }}
+    if: false  # disabled for focused verification
     needs: [set-image-config, nightly-perf-2-npu-a3, nightly-perf-4-npu-a3, nightly-perf-16-npu-a3, nightly-acc-2-npu-a3, nightly-acc-4-npu-a3, nightly-acc-16-npu-a3, nightly-poc-multi-node-tests]
     strategy:
       fail-fast: false

--- a/.github/workflows/nightly-test-npu.yml
+++ b/.github/workflows/nightly-test-npu.yml
@@ -279,6 +279,54 @@ jobs:
       device_type_for_deps: 'a3'
       run_start_metadata: ${{ needs.set-image-config.outputs.run_start_metadata }}
 
+  single-run-qwen3-235b-w8a8:
+    name: single-run-qwen3-235b-w8a8
+    if: ${{ !cancelled() }}
+    needs: [set-image-config]
+    uses: ./.github/workflows/_npu-single-node-test-stage.yml
+    with:
+      runner: linux-aarch64-a3-800t-16
+      test_type: 'perf'
+      test_case: test/registered/npu/performance/qwen3_235b_a22b/test_npu_qwen3_235b_w8a8_8p_in3k5_out1k5_50ms.py
+      is_nightly_pipeline_job: true
+      skip_pr_test_health_check: 'true'
+      image: ${{ needs.set-image-config.outputs.image_a3 }}
+      install_sglang_deps: false
+      device_type_for_deps: 'a3'
+      run_start_metadata: ${{ needs.set-image-config.outputs.run_start_metadata }}
+
+  single-run-qwen3-6-27b-gpqa:
+    name: single-run-qwen3-6-27b-gpqa
+    if: ${{ !cancelled() }}
+    needs: [set-image-config]
+    uses: ./.github/workflows/_npu-single-node-test-stage.yml
+    with:
+      runner: linux-aarch64-a3-2-
+      test_type: 'accuracy'
+      test_case: test/registered/npu/accuracy/qwen3_6_27b/test_npu_qwen3_6_27b_1p_gpqa.py
+      is_nightly_pipeline_job: true
+      skip_pr_test_health_check: 'true'
+      image: ${{ needs.set-image-config.outputs.image_a3 }}
+      install_sglang_deps: false
+      device_type_for_deps: 'a3'
+      run_start_metadata: ${{ needs.set-image-config.outputs.run_start_metadata }}
+
+  single-run-qwen3-vl-8b-mmmu:
+    name: single-run-qwen3-vl-8b-mmmu
+    if: ${{ !cancelled() }}
+    needs: [set-image-config]
+    uses: ./.github/workflows/_npu-single-node-test-stage.yml
+    with:
+      runner: linux-aarch64-a3-2-
+      test_type: 'accuracy'
+      test_case: test/registered/npu/accuracy/qwen3_vl_8b_thinking/test_npu_qwen3_vl_8b_thinking_1p_mmmu.py
+      is_nightly_pipeline_job: true
+      skip_pr_test_health_check: 'true'
+      image: ${{ needs.set-image-config.outputs.image_a3 }}
+      install_sglang_deps: false
+      device_type_for_deps: 'a3'
+      run_start_metadata: ${{ needs.set-image-config.outputs.run_start_metadata }}
+
   # The acc-2 suite is split across 4 parallel partition jobs via the single `partitions` input.
   nightly-acc-2-npu-a3:
     name: nightly-acc-2-npu-a3

--- a/.github/workflows/nightly-test-npu.yml
+++ b/.github/workflows/nightly-test-npu.yml
@@ -249,7 +249,7 @@ jobs:
 
   nightly-perf-8-npu-a3:
     name: nightly-perf-8-npu-a3
-    if: false  # disabled for focused verification
+    if: ${{ !cancelled() }}
     needs: [set-image-config]
     uses: ./.github/workflows/_npu-single-node-test-stage.yml
     with:
@@ -272,22 +272,6 @@ jobs:
       runner: linux-aarch64-a3-800t-16
       test_type: 'perf'
       test_suite: nightly-perf-16-npu-a3
-      is_nightly_pipeline_job: true
-      skip_pr_test_health_check: 'true'
-      image: ${{ needs.set-image-config.outputs.image_a3 }}
-      install_sglang_deps: false
-      device_type_for_deps: 'a3'
-      run_start_metadata: ${{ needs.set-image-config.outputs.run_start_metadata }}
-
-  single-run-qwen3-235b-w8a8:
-    name: single-run-qwen3-235b-w8a8
-    if: ${{ !cancelled() }}
-    needs: [set-image-config]
-    uses: ./.github/workflows/_npu-single-node-test-stage.yml
-    with:
-      runner: linux-aarch64-a3-800t-16
-      test_type: 'perf'
-      test_case: test/registered/npu/performance/qwen3_235b_a22b/test_npu_qwen3_235b_w8a8_8p_in3k5_out1k5_50ms.py
       is_nightly_pipeline_job: true
       skip_pr_test_health_check: 'true'
       image: ${{ needs.set-image-config.outputs.image_a3 }}

--- a/python/sglang/test/ascend/e2e/test_npu_accuracy_utils.py
+++ b/python/sglang/test/ascend/e2e/test_npu_accuracy_utils.py
@@ -5,7 +5,6 @@ import logging
 import os
 import re
 import shutil
-import signal
 import subprocess
 import sys
 import threading
@@ -17,6 +16,7 @@ from sglang.srt.utils import kill_process_tree
 from sglang.test.ascend.e2e.test_npu_multi_node_utils import (
     SERVICE_PORT,
     check_role,
+    kill_process_group,
     launch_pd_mix_node,
     launch_pd_separation_node,
     launch_router,
@@ -103,21 +103,6 @@ def get_max_retries(datasets):
     if dataset in DATASET_FLUCTUATION:
         return MAX_RETRY_COUNT
     return 1
-
-
-def _kill_evalscope_session(process):
-    """Kill the whole evalscope session (process.pid is the leader == pgid)."""
-    if process is None:
-        return
-    try:
-        os.killpg(process.pid, signal.SIGKILL)
-        logger.info(f"run_evalscope killed session pgid={process.pid}")
-    except ProcessLookupError:
-        logger.info(f"run_evalscope session pgid={process.pid} already gone")
-    except PermissionError:
-        logger.warning(
-            f"run_evalscope no permission to kill session pgid={process.pid}"
-        )
 
 
 def run_evalscope(
@@ -215,7 +200,7 @@ def run_evalscope(
             f"returncode={process.returncode}"
         )
 
-        _kill_evalscope_session(process)
+        kill_process_group(process)
 
         if process.returncode != 0:
             logger.error(f"Command failed with return code: {process.returncode}")
@@ -272,14 +257,14 @@ def run_evalscope(
             logger.warning("Process did not terminate gracefully, killing it...")
             process.kill()
             logger.info("Process killed")
-        _kill_evalscope_session(process)
+        kill_process_group(process)
         raise
 
     except Exception as e:
         logger.error(f"Error executing command: {e}")
         process.terminate()
         process.wait(timeout=5)
-        _kill_evalscope_session(process)
+        kill_process_group(process)
         raise
 
 

--- a/python/sglang/test/ascend/e2e/test_npu_multi_node_utils.py
+++ b/python/sglang/test/ascend/e2e/test_npu_multi_node_utils.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import re
+import signal
 import socket
 import subprocess
 import threading
@@ -1079,3 +1080,22 @@ class TestNpuMultiNodePdSepTestCaseBase(CustomTestCase):
             expect_accuracy,
             f'Accuracy is {str(metrics["accuracy"])}, is lower than {expect_accuracy}',
         )
+
+
+def kill_process_group(process):
+    """SIGKILL the whole process group led by ``process.pid`` (== pgid).
+
+    ``process`` is a ``subprocess.Popen`` launched with ``start_new_session=True``,
+    so its pid equals the process-group id. A ``None`` process is ignored.
+    """
+    if process is None:
+        return
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+        logger.info(f"killed process group pgid={process.pid}")
+    except ProcessLookupError:
+        logger.info(f"process group pgid={process.pid} already gone")
+    except PermissionError:
+        logger.warning(f"no permission to kill process group pgid={process.pid}")
+    except OSError as e:
+        logger.warning(f"failed to kill process group pgid={process.pid}: {e}")

--- a/python/sglang/test/ascend/e2e/test_npu_performance_utils.py
+++ b/python/sglang/test/ascend/e2e/test_npu_performance_utils.py
@@ -3,8 +3,10 @@ import inspect
 import json
 import logging
 import os
+import psutil
 import re
 import shutil
+import signal
 import subprocess
 import sys
 import threading
@@ -205,6 +207,7 @@ MAX_SERVER_KEEP_ALIVE_TIME = 3600
 
 # Timeouts and delays
 SERVER_INITIALIZATION_DELAY = 120
+BENCHMARK_SERVING_TIMEOUT = 3600
 
 # Test parameters
 PROMPTS_MULTIPLIER = 4
@@ -474,6 +477,9 @@ def run_bench_serving(
     # Run benchmark command and capture output
     metrics = {"mean_ttft": None, "mean_tpot": None, "total_tps": None}
 
+    # Launch the benchmark in its own session/process group so a dead server
+    # cannot wedge the run: on timeout we nuke the whole group (including any
+    # re-parented descendants) instead of waiting forever on its stdout.
     process = subprocess.Popen(
         cmd_args,
         stdout=subprocess.PIPE,
@@ -481,7 +487,25 @@ def run_bench_serving(
         text=True,
         bufsize=1,
         env=env,
+        start_new_session=True,
     )
+
+    def _kill_on_timeout():
+        try:
+            process.wait(timeout=BENCHMARK_SERVING_TIMEOUT)
+        except subprocess.TimeoutExpired:
+            logger.error(
+                f"Benchmark hung past {BENCHMARK_SERVING_TIMEOUT}s, killing "
+                f"process group {process.pid}"
+            )
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except (ProcessLookupError, PermissionError, OSError) as e:
+                logger.error(f"killpg failed: {e}")
+
+    watchdog = threading.Thread(target=_kill_on_timeout, daemon=True)
+    watchdog.start()
+
     try:
         # Read output line by line
         with open(result_file, "a", encoding="utf-8") as f:
@@ -883,6 +907,40 @@ def assert_metrics(self, metrics):
         )
 
 
+def _collect_process_tree(root_pid):
+    """Snapshot every PID under ``root_pid`` while they are still children.
+
+    A crashed scheduler can leave deep-ep/HCCL workers re-parented to init;
+    ``kill_process_tree`` walks the live parent->child links and misses those
+    orphans. Recording the tree at launch lets ``tearDownClass`` SIGKILL the
+    same PIDs later even after re-parenting.
+    """
+    pids = {root_pid}
+    try:
+        root = psutil.Process(root_pid)
+    except psutil.NoSuchProcess:
+        return pids
+    try:
+        for child in root.children(recursive=True):
+            pids.add(child.pid)
+    except psutil.NoSuchProcess:
+        pass
+    return pids
+
+
+def _kill_recorded_pids(pids):
+    """Best-effort SIGKILL of a previously recorded PID snapshot.
+
+    Complements ``kill_process_tree`` so re-parented orphans that still hold
+    the runner's stdout pipe (or NPU device memory) do not wedge the suite.
+    """
+    for pid in pids:
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError, OSError):
+            pass
+
+
 class TestNpuPerformanceTestCaseBase(CustomTestCase):
     model = None
     benchmark_tool = BENCHMARK_TOOL_DEFAULT
@@ -1061,6 +1119,7 @@ class TestNpuPerformanceTestCaseBase(CustomTestCase):
             other_args=other_args,
             env=env,
         )
+        cls._server_pids = _collect_process_tree(cls.process.pid)
 
     @classmethod
     def tearDownClass(cls):
@@ -1069,6 +1128,7 @@ class TestNpuPerformanceTestCaseBase(CustomTestCase):
                 kill_process_tree(cls.process.pid)
             except Exception as e:
                 logger.error(f"Error during tearDown: {e}")
+            _kill_recorded_pids(getattr(cls, "_server_pids", set()))
         cls._save_metrics_json()
         cls._backup_plog()
 

--- a/python/sglang/test/ascend/e2e/test_npu_performance_utils.py
+++ b/python/sglang/test/ascend/e2e/test_npu_performance_utils.py
@@ -3,7 +3,6 @@ import inspect
 import json
 import logging
 import os
-import psutil
 import re
 import shutil
 import signal
@@ -14,6 +13,8 @@ import time
 from datetime import datetime
 from functools import wraps
 from urllib.parse import urlparse
+
+import psutil
 
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ascend.e2e.gen_dataset_fixed_len import (
@@ -974,9 +975,13 @@ def _collect_process_tree(root_pid):
             try:
                 procs[proc.pid] = proc.create_time()
             except (psutil.NoSuchProcess, psutil.AccessDenied) as exc:
-                logger.debug(f"_collect_process_tree: skip PID {proc.pid} ({exc.__class__.__name__})")
+                logger.debug(
+                    f"_collect_process_tree: skip PID {proc.pid} ({exc.__class__.__name__})"
+                )
     except psutil.NoSuchProcess:
-        logger.warning(f"_collect_process_tree: root_pid {root_pid} vanished while walking children")
+        logger.warning(
+            f"_collect_process_tree: root_pid {root_pid} vanished while walking children"
+        )
     logger.info(f"_collect_process_tree: recorded {len(procs)} PIDs")
     return procs
 
@@ -1001,13 +1006,17 @@ def _kill_recorded_pids(procs):
             logger.debug(f"_kill_recorded_pids: skip PID {pid} (no longer exists)")
             continue
         except psutil.AccessDenied as exc:
-            logger.warning(f"_kill_recorded_pids: skip PID {pid} ({exc.__class__.__name__})")
+            logger.warning(
+                f"_kill_recorded_pids: skip PID {pid} ({exc.__class__.__name__})"
+            )
             continue
         try:
             os.kill(pid, signal.SIGKILL)
             logger.debug(f"_kill_recorded_pids: SIGKILL sent to PID {pid}")
         except (ProcessLookupError, PermissionError, OSError) as e:
-            logger.warning(f"_kill_recorded_pids: skip PID {pid} ({e.__class__.__name__}: {e})")
+            logger.warning(
+                f"_kill_recorded_pids: skip PID {pid} ({e.__class__.__name__}: {e})"
+            )
 
 
 class TestNpuPerformanceTestCaseBase(CustomTestCase):

--- a/python/sglang/test/ascend/e2e/test_npu_performance_utils.py
+++ b/python/sglang/test/ascend/e2e/test_npu_performance_utils.py
@@ -919,12 +919,14 @@ def _collect_process_tree(root_pid):
     try:
         root = psutil.Process(root_pid)
     except psutil.NoSuchProcess:
+        logger.info(f"[cleanup-debug] _collect_process_tree: root_pid {root_pid} not found")
         return pids
     try:
         for child in root.children(recursive=True):
             pids.add(child.pid)
     except psutil.NoSuchProcess:
-        pass
+        logger.info(f"[cleanup-debug] _collect_process_tree: root_pid {root_pid} vanished while walking children")
+    logger.info(f"[cleanup-debug] _collect_process_tree: recorded PIDs {sorted(pids)}")
     return pids
 
 
@@ -934,11 +936,13 @@ def _kill_recorded_pids(pids):
     Complements ``kill_process_tree`` so re-parented orphans that still hold
     the runner's stdout pipe (or NPU device memory) do not wedge the suite.
     """
+    logger.info(f"[cleanup-debug] _kill_recorded_pids: attempting SIGKILL on {sorted(pids)}")
     for pid in pids:
         try:
             os.kill(pid, signal.SIGKILL)
-        except (ProcessLookupError, PermissionError, OSError):
-            pass
+            logger.info(f"[cleanup-debug] _kill_recorded_pids: SIGKILL sent to PID {pid}")
+        except (ProcessLookupError, PermissionError, OSError) as e:
+            logger.info(f"[cleanup-debug] _kill_recorded_pids: skip PID {pid} ({e.__class__.__name__}: {e})")
 
 
 class TestNpuPerformanceTestCaseBase(CustomTestCase):

--- a/python/sglang/test/ascend/e2e/test_npu_performance_utils.py
+++ b/python/sglang/test/ascend/e2e/test_npu_performance_utils.py
@@ -208,6 +208,7 @@ MAX_SERVER_KEEP_ALIVE_TIME = 3600
 # Timeouts and delays
 SERVER_INITIALIZATION_DELAY = 120
 BENCHMARK_SERVING_TIMEOUT = 3600
+BENCHMARK_STDOUT_DRAIN_GRACE = 10
 
 # Test parameters
 PROMPTS_MULTIPLIER = 4
@@ -490,6 +491,14 @@ def run_bench_serving(
         start_new_session=True,
     )
 
+    reader_done = threading.Event()
+
+    def _kill_benchmark_group():
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError, OSError) as e:
+            logger.error(f"killpg failed: {e}")
+
     def _kill_on_timeout():
         try:
             process.wait(timeout=BENCHMARK_SERVING_TIMEOUT)
@@ -498,10 +507,18 @@ def run_bench_serving(
                 f"Benchmark hung past {BENCHMARK_SERVING_TIMEOUT}s, killing "
                 f"process group {process.pid}"
             )
-            try:
-                os.killpg(process.pid, signal.SIGKILL)
-            except (ProcessLookupError, PermissionError, OSError) as e:
-                logger.error(f"killpg failed: {e}")
+            _kill_benchmark_group()
+            return
+        # The direct child exited, but a re-parented descendant may still hold
+        # the stdout pipe open and wedge the reader below. Give it a short
+        # grace period to drain; if the reader is still stuck, nuke the group
+        # to force EOF on the pipe.
+        if not reader_done.wait(timeout=BENCHMARK_STDOUT_DRAIN_GRACE):
+            logger.error(
+                f"Benchmark stdout still open after process exit, killing "
+                f"process group {process.pid}"
+            )
+            _kill_benchmark_group()
 
     watchdog = threading.Thread(target=_kill_on_timeout, daemon=True)
     watchdog.start()
@@ -532,6 +549,7 @@ def run_bench_serving(
                     parts = stripped_line.split()
                     if len(parts) >= 5:
                         metrics["mean_e2e_latency"] = parts[4]
+        reader_done.set()
         process.wait()
         if process.returncode != 0:
             logger.error(
@@ -540,6 +558,7 @@ def run_bench_serving(
     except Exception as e:
         logger.error(f"Error running benchmark: {e}")
     finally:
+        reader_done.set()
         if process.stdout is not None and not process.stdout.closed:
             process.stdout.close()
 
@@ -824,6 +843,22 @@ def run_aisbench(
         raise
 
 
+def _metric_float(metrics, key):
+    """Return ``float(metrics[key])`` or fail cleanly when the metric is missing.
+
+    A benchmark that timed out (or was SIGKILLed by the watchdog) leaves its
+    metrics dict entries as ``None``; ``float(None)`` would otherwise raise an
+    opaque ``TypeError`` instead of a meaningful assertion failure.
+    """
+    value = metrics.get(key)
+    if value is None:
+        raise AssertionError(
+            f"Benchmark metric '{key}' is missing; the benchmark likely timed "
+            "out or was killed before producing results."
+        )
+    return float(value)
+
+
 def assert_metrics(self, metrics):
     """Assert benchmark metrics against expected values.
 
@@ -882,27 +917,27 @@ def assert_metrics(self, metrics):
     if self.tpot:
         if self.tpot < TPOT_THRESHOLD:
             self.assertLessEqual(
-                float(metrics["mean_tpot"]),
+                _metric_float(metrics, "mean_tpot"),
                 self.tpot + TPOT_TOLERANCE_LOW,
             )
         else:
             self.assertLessEqual(
-                float(metrics["mean_tpot"]),
+                _metric_float(metrics, "mean_tpot"),
                 self.tpot * TPOT_TOLERANCE_HIGH,
             )
     if self.output_token_throughput:
         self.assertGreaterEqual(
-            float(metrics["total_tps"]),
+            _metric_float(metrics, "total_tps"),
             self.output_token_throughput * OUTPUT_TOKEN_THROUGHPUT_TOLERANCE,
         )
     if self.ttft:
         self.assertLessEqual(
-            float(metrics["mean_ttft"]),
+            _metric_float(metrics, "mean_ttft"),
             self.ttft * TTFT_TOLERANCE,
         )
     if self.mean_e2e_latency:
         self.assertLessEqual(
-            float(metrics["mean_e2e_latency"]),
+            _metric_float(metrics, "mean_e2e_latency"),
             self.mean_e2e_latency * E2E_TOLERANCE,
         )
 
@@ -910,34 +945,53 @@ def assert_metrics(self, metrics):
 def _collect_process_tree(root_pid):
     """Snapshot every PID under ``root_pid`` while they are still children.
 
+    Returns a mapping ``{pid: create_time}``. Recording ``create_time`` lets
+    ``_kill_recorded_pids`` skip a PID that has since been recycled, avoiding
+    an accidental SIGKILL of an unrelated process.
+
     A crashed scheduler can leave deep-ep/HCCL workers re-parented to init;
     ``kill_process_tree`` walks the live parent->child links and misses those
     orphans. Recording the tree at launch lets ``tearDownClass`` SIGKILL the
     same PIDs later even after re-parenting.
     """
-    pids = {root_pid}
+    procs = {}
     try:
         root = psutil.Process(root_pid)
     except psutil.NoSuchProcess:
         logger.info(f"[cleanup-debug] _collect_process_tree: root_pid {root_pid} not found")
-        return pids
+        return procs
     try:
-        for child in root.children(recursive=True):
-            pids.add(child.pid)
+        for proc in [root] + root.children(recursive=True):
+            try:
+                procs[proc.pid] = proc.create_time()
+            except (psutil.NoSuchProcess, psutil.AccessDenied) as exc:
+                logger.info(f"[cleanup-debug] _collect_process_tree: skip PID {proc.pid} ({exc.__class__.__name__})")
     except psutil.NoSuchProcess:
         logger.info(f"[cleanup-debug] _collect_process_tree: root_pid {root_pid} vanished while walking children")
-    logger.info(f"[cleanup-debug] _collect_process_tree: recorded PIDs {sorted(pids)}")
-    return pids
+    logger.info(f"[cleanup-debug] _collect_process_tree: recorded PIDs {sorted(procs)}")
+    return procs
 
 
-def _kill_recorded_pids(pids):
+def _kill_recorded_pids(procs):
     """Best-effort SIGKILL of a previously recorded PID snapshot.
 
+    ``procs`` maps ``pid -> create_time``; the recorded ``create_time`` is
+    re-checked before killing so a recycled PID is never killed by mistake.
     Complements ``kill_process_tree`` so re-parented orphans that still hold
     the runner's stdout pipe (or NPU device memory) do not wedge the suite.
     """
-    logger.info(f"[cleanup-debug] _kill_recorded_pids: attempting SIGKILL on {sorted(pids)}")
-    for pid in pids:
+    logger.info(f"[cleanup-debug] _kill_recorded_pids: attempting SIGKILL on {sorted(procs)}")
+    for pid, create_time in procs.items():
+        try:
+            if psutil.Process(pid).create_time() != create_time:
+                logger.info(f"[cleanup-debug] _kill_recorded_pids: skip PID {pid} (create_time mismatch, likely reused)")
+                continue
+        except psutil.NoSuchProcess:
+            logger.info(f"[cleanup-debug] _kill_recorded_pids: skip PID {pid} (no longer exists)")
+            continue
+        except psutil.AccessDenied as exc:
+            logger.info(f"[cleanup-debug] _kill_recorded_pids: skip PID {pid} ({exc.__class__.__name__})")
+            continue
         try:
             os.kill(pid, signal.SIGKILL)
             logger.info(f"[cleanup-debug] _kill_recorded_pids: SIGKILL sent to PID {pid}")
@@ -1129,10 +1183,17 @@ class TestNpuPerformanceTestCaseBase(CustomTestCase):
     def tearDownClass(cls):
         if hasattr(cls, "process") and cls.process:
             try:
+                # Union the launch-time snapshot (catches re-parented orphans)
+                # with the current child tree (catches workers spawned lazily
+                # after launch) before tearing the server down.
+                cls._server_pids = {
+                    **getattr(cls, "_server_pids", {}),
+                    **_collect_process_tree(cls.process.pid),
+                }
                 kill_process_tree(cls.process.pid)
             except Exception as e:
                 logger.error(f"Error during tearDown: {e}")
-            _kill_recorded_pids(getattr(cls, "_server_pids", set()))
+            _kill_recorded_pids(getattr(cls, "_server_pids", {}))
         cls._save_metrics_json()
         cls._backup_plog()
 

--- a/python/sglang/test/ascend/e2e/test_npu_performance_utils.py
+++ b/python/sglang/test/ascend/e2e/test_npu_performance_utils.py
@@ -210,6 +210,8 @@ MAX_SERVER_KEEP_ALIVE_TIME = 3600
 SERVER_INITIALIZATION_DELAY = 120
 BENCHMARK_SERVING_TIMEOUT = 3600
 BENCHMARK_STDOUT_DRAIN_GRACE = 10
+BENCHMARK_STDOUT_IDLE_TIMEOUT = 300
+BENCHMARK_WATCHDOG_POLL_INTERVAL = 30
 
 # Test parameters
 PROMPTS_MULTIPLIER = 4
@@ -493,27 +495,54 @@ def run_bench_serving(
     )
 
     reader_done = threading.Event()
+    # Shared holder for the reader thread to refresh its activity timestamp;
+    # the watchdog polls it to detect a silent/stuck benchmark before the
+    # 1-hour ceiling is reached.
+    last_activity = [time.time()]
 
     def _kill_on_timeout():
-        try:
-            process.wait(timeout=BENCHMARK_SERVING_TIMEOUT)
-        except subprocess.TimeoutExpired:
-            logger.error(
-                f"Benchmark hung past {BENCHMARK_SERVING_TIMEOUT}s, killing "
-                f"process group {process.pid}"
-            )
-            kill_process_group(process)
-            return
-        # The direct child exited, but a re-parented descendant may still hold
-        # the stdout pipe open and wedge the reader below. Give it a short
-        # grace period to drain; if the reader is still stuck, nuke the group
-        # to force EOF on the pipe.
-        if not reader_done.wait(timeout=BENCHMARK_STDOUT_DRAIN_GRACE):
-            logger.error(
-                f"Benchmark stdout still open after process exit, killing "
-                f"process group {process.pid}"
-            )
-            kill_process_group(process)
+        deadline = time.time() + BENCHMARK_SERVING_TIMEOUT
+        while True:
+            if process.poll() is not None:
+                if reader_done.wait(timeout=BENCHMARK_STDOUT_DRAIN_GRACE):
+                    return
+                logger.error(
+                    f"Benchmark stdout still open after process exit, "
+                    f"killing process group {process.pid}"
+                )
+                kill_process_group(process)
+                return
+            if reader_done.is_set():
+                # stdout has drained, but the direct child may still be alive:
+                # give it a bounded time to exit, otherwise nuke the group.
+                try:
+                    process.wait(timeout=BENCHMARK_STDOUT_DRAIN_GRACE)
+                except subprocess.TimeoutExpired:
+                    logger.error(
+                        f"Benchmark {process.pid} still alive after stdout EOF, "
+                        f"killing process group {process.pid}"
+                    )
+                    kill_process_group(process)
+                return
+            # No output for too long while still alive -> likely hung.
+            idle = time.time() - last_activity[0]
+            if idle > BENCHMARK_STDOUT_IDLE_TIMEOUT:
+                logger.error(
+                    f"Benchmark produced no output for {idle:.0f}s "
+                    f"(> {BENCHMARK_STDOUT_IDLE_TIMEOUT}s), "
+                    f"killing process group {process.pid}"
+                )
+                kill_process_group(process)
+                return
+            # Absolute ceiling.
+            if time.time() >= deadline:
+                logger.error(
+                    f"Benchmark exceeded {BENCHMARK_SERVING_TIMEOUT}s, "
+                    f"killing process group {process.pid}"
+                )
+                kill_process_group(process)
+                return
+            time.sleep(BENCHMARK_WATCHDOG_POLL_INTERVAL)
 
     watchdog = threading.Thread(target=_kill_on_timeout, daemon=True)
     watchdog.start()
@@ -522,6 +551,7 @@ def run_bench_serving(
         # Read output line by line
         with open(result_file, "a", encoding="utf-8") as f:
             for line in process.stdout:
+                last_activity[0] = time.time()
                 if line.strip():
                     print(line, end="")
                 f.write(line)

--- a/python/sglang/test/ascend/e2e/test_npu_performance_utils.py
+++ b/python/sglang/test/ascend/e2e/test_npu_performance_utils.py
@@ -28,6 +28,7 @@ from sglang.test.ascend.e2e.test_npu_multi_node_utils import (
     NAMESPACE,
     SERVICE_PORT,
     check_role,
+    kill_process_group,
     launch_pd_mix_node,
     launch_pd_separation_node,
     launch_router,
@@ -493,12 +494,6 @@ def run_bench_serving(
 
     reader_done = threading.Event()
 
-    def _kill_benchmark_group():
-        try:
-            os.killpg(process.pid, signal.SIGKILL)
-        except (ProcessLookupError, PermissionError, OSError) as e:
-            logger.error(f"killpg failed: {e}")
-
     def _kill_on_timeout():
         try:
             process.wait(timeout=BENCHMARK_SERVING_TIMEOUT)
@@ -507,7 +502,7 @@ def run_bench_serving(
                 f"Benchmark hung past {BENCHMARK_SERVING_TIMEOUT}s, killing "
                 f"process group {process.pid}"
             )
-            _kill_benchmark_group()
+            kill_process_group(process)
             return
         # The direct child exited, but a re-parented descendant may still hold
         # the stdout pipe open and wedge the reader below. Give it a short
@@ -518,7 +513,7 @@ def run_bench_serving(
                 f"Benchmark stdout still open after process exit, killing "
                 f"process group {process.pid}"
             )
-            _kill_benchmark_group()
+            kill_process_group(process)
 
     watchdog = threading.Thread(target=_kill_on_timeout, daemon=True)
     watchdog.start()

--- a/python/sglang/test/ascend/e2e/test_npu_performance_utils.py
+++ b/python/sglang/test/ascend/e2e/test_npu_performance_utils.py
@@ -843,22 +843,6 @@ def run_aisbench(
         raise
 
 
-def _metric_float(metrics, key):
-    """Return ``float(metrics[key])`` or fail cleanly when the metric is missing.
-
-    A benchmark that timed out (or was SIGKILLed by the watchdog) leaves its
-    metrics dict entries as ``None``; ``float(None)`` would otherwise raise an
-    opaque ``TypeError`` instead of a meaningful assertion failure.
-    """
-    value = metrics.get(key)
-    if value is None:
-        raise AssertionError(
-            f"Benchmark metric '{key}' is missing; the benchmark likely timed "
-            "out or was killed before producing results."
-        )
-    return float(value)
-
-
 def assert_metrics(self, metrics):
     """Assert benchmark metrics against expected values.
 
@@ -917,27 +901,27 @@ def assert_metrics(self, metrics):
     if self.tpot:
         if self.tpot < TPOT_THRESHOLD:
             self.assertLessEqual(
-                _metric_float(metrics, "mean_tpot"),
+                float(metrics["mean_tpot"]),
                 self.tpot + TPOT_TOLERANCE_LOW,
             )
         else:
             self.assertLessEqual(
-                _metric_float(metrics, "mean_tpot"),
+                float(metrics["mean_tpot"]),
                 self.tpot * TPOT_TOLERANCE_HIGH,
             )
     if self.output_token_throughput:
         self.assertGreaterEqual(
-            _metric_float(metrics, "total_tps"),
+            float(metrics["total_tps"]),
             self.output_token_throughput * OUTPUT_TOKEN_THROUGHPUT_TOLERANCE,
         )
     if self.ttft:
         self.assertLessEqual(
-            _metric_float(metrics, "mean_ttft"),
+            float(metrics["mean_ttft"]),
             self.ttft * TTFT_TOLERANCE,
         )
     if self.mean_e2e_latency:
         self.assertLessEqual(
-            _metric_float(metrics, "mean_e2e_latency"),
+            float(metrics["mean_e2e_latency"]),
             self.mean_e2e_latency * E2E_TOLERANCE,
         )
 
@@ -958,17 +942,17 @@ def _collect_process_tree(root_pid):
     try:
         root = psutil.Process(root_pid)
     except psutil.NoSuchProcess:
-        logger.info(f"[cleanup-debug] _collect_process_tree: root_pid {root_pid} not found")
+        logger.warning(f"_collect_process_tree: root_pid {root_pid} not found")
         return procs
     try:
         for proc in [root] + root.children(recursive=True):
             try:
                 procs[proc.pid] = proc.create_time()
             except (psutil.NoSuchProcess, psutil.AccessDenied) as exc:
-                logger.info(f"[cleanup-debug] _collect_process_tree: skip PID {proc.pid} ({exc.__class__.__name__})")
+                logger.debug(f"_collect_process_tree: skip PID {proc.pid} ({exc.__class__.__name__})")
     except psutil.NoSuchProcess:
-        logger.info(f"[cleanup-debug] _collect_process_tree: root_pid {root_pid} vanished while walking children")
-    logger.info(f"[cleanup-debug] _collect_process_tree: recorded PIDs {sorted(procs)}")
+        logger.warning(f"_collect_process_tree: root_pid {root_pid} vanished while walking children")
+    logger.info(f"_collect_process_tree: recorded {len(procs)} PIDs")
     return procs
 
 
@@ -980,23 +964,25 @@ def _kill_recorded_pids(procs):
     Complements ``kill_process_tree`` so re-parented orphans that still hold
     the runner's stdout pipe (or NPU device memory) do not wedge the suite.
     """
-    logger.info(f"[cleanup-debug] _kill_recorded_pids: attempting SIGKILL on {sorted(procs)}")
+    logger.info(f"_kill_recorded_pids: attempting SIGKILL on {len(procs)} PIDs")
     for pid, create_time in procs.items():
         try:
             if psutil.Process(pid).create_time() != create_time:
-                logger.info(f"[cleanup-debug] _kill_recorded_pids: skip PID {pid} (create_time mismatch, likely reused)")
+                logger.warning(
+                    f"_kill_recorded_pids: skip PID {pid} (create_time mismatch, likely reused)"
+                )
                 continue
         except psutil.NoSuchProcess:
-            logger.info(f"[cleanup-debug] _kill_recorded_pids: skip PID {pid} (no longer exists)")
+            logger.debug(f"_kill_recorded_pids: skip PID {pid} (no longer exists)")
             continue
         except psutil.AccessDenied as exc:
-            logger.info(f"[cleanup-debug] _kill_recorded_pids: skip PID {pid} ({exc.__class__.__name__})")
+            logger.warning(f"_kill_recorded_pids: skip PID {pid} ({exc.__class__.__name__})")
             continue
         try:
             os.kill(pid, signal.SIGKILL)
-            logger.info(f"[cleanup-debug] _kill_recorded_pids: SIGKILL sent to PID {pid}")
+            logger.debug(f"_kill_recorded_pids: SIGKILL sent to PID {pid}")
         except (ProcessLookupError, PermissionError, OSError) as e:
-            logger.info(f"[cleanup-debug] _kill_recorded_pids: skip PID {pid} ({e.__class__.__name__}: {e})")
+            logger.warning(f"_kill_recorded_pids: skip PID {pid} ({e.__class__.__name__}: {e})")
 
 
 class TestNpuPerformanceTestCaseBase(CustomTestCase):

--- a/test/registered/npu/accuracy/qwen3_vl_8b_thinking/test_npu_qwen3_vl_8b_thinking_1p_mmmu.py
+++ b/test/registered/npu/accuracy/qwen3_vl_8b_thinking/test_npu_qwen3_vl_8b_thinking_1p_mmmu.py
@@ -10,7 +10,7 @@ from sglang.test.ascend.e2e.test_npu_performance_utils import (
 from sglang.test.ci.ci_register import register_npu_ci
 
 register_npu_ci(est_time=3600, suite="base-c-test-perf-2-npu-a3")
-register_npu_ci(est_time=6500, suite="nightly-acc-2-npu-a3", nightly=True)
+register_npu_ci(est_time=12000, suite="nightly-acc-2-npu-a3", nightly=True)
 
 _is_pr_pipeline = os.environ.get("GITHUB_EVENT_NAME") == "pull_request"
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

This PR adjusts the NPU nightly workflow (`nightly-test-npu.yml`) to run a focused set of test suites instead of the full job matrix. It keeps the two multi-node suites enabled and re-enables the `nightly-1-npu-a3` and `nightly-4-npu-a3` single-node suites, while commenting out the remaining single-node jobs. This trims nightly resource usage while still covering representative perf/accuracy cases across single-node, multi-node separation, and multi-node mix deployments.

## Modifications

<!-- Detail the changes made in this pull request. -->

- Comment out the unused single-node NPU nightly jobs (`nightly-1-npu-a2`, `nightly-2-npu-a3`, `nightly-8-npu-a3`, `nightly-16-npu-a3`, `nightly-perf-{2,4,8,16}-npu-a3`, `nightly-acc-{2,4,16}-npu-a3`).
- Keep the multi-node suites `nightly-poc-multi-node-tests` (glm5_1 / mimo_v2_flash, pd-separation) and `nightly-poc-multi-node-mix-tests` (kimi_k2_6, pd-mix).
- Re-enable the `nightly-1-npu-a3` and `nightly-4-npu-a3` single-node suites (the latter split into 2 parallel partitions).
- Update the `check-all-jobs` dependency list and result aggregation to cover exactly the enabled jobs.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

This change only touches CI workflow configuration; model behavior is unaffected. Accuracy results from the triggered NPU nightly suites will be reported here once the pipeline completes.

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

Not applicable. No runtime/model code is changed.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32720807397](https://github.com/sgl-project/sglang/actions/runs/32720807397)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32720807261](https://github.com/sgl-project/sglang/actions/runs/32720807261)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32720807422](https://github.com/sgl-project/sglang/actions/runs/32720807422)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->