### PR TITLE
Let the lint hooks run on the python3 a contributor actually has

### DIFF
--- a/scripts/lint/check_no_bare_pytest_main.py
+++ b/scripts/lint/check_no_bare_pytest_main.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# `python3` is whatever the contributor's PATH resolves to -- 3.9 on a stock
+# macOS -- so annotations must not be evaluated at definition time.
+from __future__ import annotations
+
 import ast
 import pathlib
 import re

--- a/scripts/lint/test_check_lint_scripts_annotations.py
+++ b/scripts/lint/test_check_lint_scripts_annotations.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import ast
+import pathlib
+import unittest
+
+_LINT_DIR = pathlib.Path(__file__).resolve().parent
+
+
+def uses_pep604_annotation(tree: ast.AST) -> bool:
+    """Whether any annotation in the tree is an `X | Y` union."""
+    annotations: list[ast.expr] = []
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            annotations.extend(
+                a.annotation
+                for a in (
+                    *node.args.args,
+                    *node.args.posonlyargs,
+                    *node.args.kwonlyargs,
+                )
+                if a.annotation is not None
+            )
+            if node.returns is not None:
+                annotations.append(node.returns)
+        elif isinstance(node, ast.AnnAssign):
+            annotations.append(node.annotation)
+
+    return any(
+        isinstance(inner, ast.BinOp) and isinstance(inner.op, ast.BitOr)
+        for annotation in annotations
+        for inner in ast.walk(annotation)
+    )
+
+
+def has_future_annotations(tree: ast.AST) -> bool:
+    return any(
+        isinstance(node, ast.ImportFrom)
+        and node.module == "__future__"
+        and any(alias.name == "annotations" for alias in node.names)
+        for node in ast.walk(tree)
+    )
+
+
+class TestLintScriptsRunOnOldPython(unittest.TestCase):
+    """These scripts run under whatever `python3` a contributor's PATH resolves to.
+
+    A stock macOS resolves it to 3.9, where `int | None` in an annotation is
+    evaluated at definition time and raises TypeError -- which blocks every
+    commit rather than reporting a lint error. `from __future__ import
+    annotations` defers the evaluation, so a script using those unions needs it.
+    CI runs a newer interpreter and cannot catch this on its own.
+    """
+
+    def test_pep604_annotations_come_with_the_future_import(self):
+        for path in sorted(_LINT_DIR.glob("*.py")):
+            with self.subTest(script=path.name):
+                tree = ast.parse(path.read_text())
+                if uses_pep604_annotation(tree):
+                    self.assertTrue(
+                        has_future_annotations(tree),
+                        f"{path.name} annotates with `X | Y`; add "
+                        "`from __future__ import annotations` so it still runs "
+                        "on the oldest python3 a contributor might have",
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/lint/test_check_no_bare_pytest_main.py
+++ b/scripts/lint/test_check_no_bare_pytest_main.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 import tempfile
 import unittest


### PR DESCRIPTION
### What happens today

Two pre-commit hooks are `language: system` with `entry: python3 ...`, so they run under whatever the contributor's PATH resolves to. On a stock macOS that is 3.9, and `scripts/lint/check_no_bare_pytest_main.py:101` annotates a return as `int | None`, which 3.9 evaluates at definition time:

```
TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
```

That is not a lint error anyone can act on — it takes down `check-no-bare-pytest-main` *and* `check-lint-script-tests` (which imports the same module) and blocks every commit until you pass `--no-verify`, which is exactly the wrong habit to hand a new contributor. On 3.9 that second hook collapsed from **10 passing tests to 1 import error**, so the lint checkers' own tests were not running there at all.

I hit this myself while working on PaddleOCR-VL: several commits went in with `--no-verify`, and one of them then failed `lint` in CI for a formatting nit the hook would have caught locally.

### The fix

`from __future__ import annotations` in the two affected files. It defers annotation evaluation, costs nothing on newer interpreters, and changes no behaviour.

Plus a guard, because **CI cannot catch this by running** — CI's interpreter is new enough that the file imports fine. So the new test asserts the property structurally: any script under `scripts/lint/` whose annotations use a PEP 604 `X | Y` union must carry the future import. It walks annotations only, so an unrelated `a | b` expression in the body does not trigger it.

### Verified

Under `/usr/bin/python3` (3.9.6) on macOS:

| | before | after |
|---|---|---|
| `check_no_bare_pytest_main.py` on a real file | TypeError | exit 0 |
| `python3 -m unittest discover -s scripts/lint` | `Ran 1 test — FAILED (errors=1)` | `Ran 11 tests — OK` |

And the guard earns its place: deleting the future import again makes it fail with the actionable message, restoring it makes it pass. This PR's own commit went in with hooks **enabled**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32226248706](https://github.com/sgl-project/sglang/actions/runs/32226248706)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32226268422](https://github.com/sgl-project/sglang/actions/runs/32226268422)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->