### PR TITLE
[Test] Add unit tests for FunctionCallParser and BaseFormatDetector (#20865)

### DIFF
--- a/test/registered/unit/function_call/test_base_format_detector.py
+++ b/test/registered/unit/function_call/test_base_format_detector.py
@@ -1,0 +1,135 @@
+"""CPU-only tests for shared BaseFormatDetector behavior."""
+
+import json
+from unittest.mock import patch
+
+from sglang.srt.entrypoints.openai.protocol import (
+    Function,
+    Tool,
+    ToolChoice,
+    ToolChoiceFuncName,
+)
+from sglang.srt.function_call.base_format_detector import BaseFormatDetector
+from sglang.srt.function_call.core_types import StructureInfo
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class _ConcreteDetector(BaseFormatDetector):
+    def __init__(self):
+        super().__init__()
+        self.bot_token = "<tool>"
+        self.eot_token = "</tool>"
+
+    def has_tool_call(self, text: str) -> bool:
+        return self.bot_token in text
+
+    def detect_and_parse(self, text: str, tools: list[Tool]):
+        return super().detect_and_parse(text, tools)
+
+    def structure_info(self):
+        return lambda name: StructureInfo(
+            begin=f'<tool name="{name}">',
+            end="</tool>",
+            trigger="<tool",
+        )
+
+
+class _NativeTagDetector(_ConcreteDetector):
+    def get_structural_tag_name(self):
+        return "test-native-format"
+
+
+class TestBaseFormatDetectorCore(CustomTestCase):
+    def setUp(self):
+        self.tools = [
+            Tool(
+                function=Function(
+                    name="weather",
+                    description="Get weather",
+                    parameters={
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                    },
+                )
+            )
+        ]
+
+    def test_base_json_parsing_normalizes_object_list_and_argument_keys(self):
+        detector = _ConcreteDetector()
+        payload = [
+            {"name": "weather", "arguments": {"city": "杭州"}},
+            {"name": "weather", "parameters": {"city": "Singapore"}},
+        ]
+
+        list_result = detector.detect_and_parse(
+            json.dumps(payload, ensure_ascii=False), self.tools
+        )
+        object_result = detector.detect_and_parse(
+            json.dumps(payload[0], ensure_ascii=False), self.tools
+        )
+
+        self.assertEqual(len(list_result.calls), 2)
+        self.assertEqual(
+            [json.loads(call.parameters) for call in list_result.calls],
+            [{"city": "杭州"}, {"city": "Singapore"}],
+        )
+        self.assertEqual(len(object_result.calls), 1)
+        self.assertIn("杭州", object_result.calls[0].parameters)
+
+    def test_partial_token_helper_finds_only_a_suffix_prefix(self):
+        detector = _ConcreteDetector()
+
+        self.assertEqual(detector._ends_with_partial_token("plain<too", "<tool>"), 4)
+        self.assertEqual(detector._ends_with_partial_token("plain", "<tool>"), 0)
+        self.assertEqual(detector._ends_with_partial_token("<tool>", "<tool>"), 0)
+
+    def test_native_structural_tag_serializes_tools_and_string_choice(self):
+        detector = _NativeTagDetector()
+        native_tag = object()
+
+        with patch(
+            "sglang.srt.function_call.base_format_detector.get_model_structural_tag",
+            return_value=native_tag,
+        ) as get_model_structural_tag:
+            result = detector.get_structural_tag(
+                tools=self.tools,
+                tool_choice="required",
+                thinking_mode=True,
+                parallel_tool_calls=False,
+            )
+
+        self.assertIs(result, native_tag)
+        get_model_structural_tag.assert_called_once_with(
+            model="test-native-format",
+            tools=[self.tools[0].model_dump()],
+            tool_choice="required",
+            reasoning=True,
+        )
+
+    def test_native_structural_tag_serializes_named_tool_choice(self):
+        detector = _NativeTagDetector()
+        named_choice = ToolChoice(function=ToolChoiceFuncName(name="weather"))
+
+        with patch(
+            "sglang.srt.function_call.base_format_detector.get_model_structural_tag",
+            return_value="native-tag",
+        ) as get_model_structural_tag:
+            result = detector.get_structural_tag(
+                tools=self.tools,
+                tool_choice=named_choice,
+            )
+
+        self.assertEqual(result, "native-tag")
+        self.assertEqual(
+            get_model_structural_tag.call_args.kwargs["tool_choice"],
+            named_choice.model_dump(),
+        )
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()

--- a/test/registered/unit/function_call/test_function_call_parser_core.py
+++ b/test/registered/unit/function_call/test_function_call_parser_core.py
@@ -1,0 +1,165 @@
+"""CPU-only tests for the shared FunctionCallParser orchestration layer."""
+
+from unittest.mock import Mock, patch
+
+from sglang.srt.entrypoints.openai.protocol import (
+    Function,
+    Tool,
+)
+from sglang.srt.function_call.base_format_detector import BaseFormatDetector
+from sglang.srt.function_call.core_types import (
+    StreamingParseResult,
+    StructureInfo,
+    ToolCallItem,
+)
+from sglang.srt.function_call.function_call_parser import FunctionCallParser
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class _StubDetector(BaseFormatDetector):
+    def has_tool_call(self, text: str) -> bool:
+        return "<tool>" in text
+
+    def detect_and_parse(self, text: str, tools: list[Tool]) -> StreamingParseResult:
+        return StreamingParseResult(normal_text=text)
+
+    def structure_info(self):
+        return lambda name: StructureInfo(
+            begin=f'<tool name="{name}">',
+            end="</tool>",
+            trigger="<tool",
+        )
+
+
+class _TokenizerDetector(_StubDetector):
+    def __init__(self, tokenizer):
+        super().__init__()
+        self.tokenizer = tokenizer
+
+
+class TestFunctionCallParserCore(CustomTestCase):
+    def setUp(self):
+        self.tools = [
+            Tool(
+                function=Function(
+                    name="weather",
+                    parameters={
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                    },
+                )
+            ),
+            Tool(
+                function=Function(
+                    name="search",
+                    parameters={
+                        "type": "object",
+                        "properties": {"query": {"type": "string"}},
+                    },
+                )
+            ),
+        ]
+
+    def make_parser(self, tools=None, detector_class=_StubDetector):
+        effective_tools = self.tools if tools is None else tools
+        with patch.dict(
+            FunctionCallParser.ToolCallParserEnum,
+            {"test_stub": detector_class},
+        ):
+            return FunctionCallParser(effective_tools, "test_stub")
+
+    def test_rejects_unsupported_parser(self):
+        with self.assertRaisesRegex(ValueError, "Unsupported tool_call_parser"):
+            FunctionCallParser(self.tools, "not-a-parser")
+
+    def test_passes_tokenizer_only_to_supported_detector(self):
+        tokenizer = object()
+        with patch.dict(
+            FunctionCallParser.ToolCallParserEnum,
+            {
+                "with_tokenizer": _TokenizerDetector,
+                "without_tokenizer": _StubDetector,
+            },
+        ):
+            parser = FunctionCallParser(
+                self.tools, "with_tokenizer", tokenizer=tokenizer
+            )
+            parser_without_tokenizer = FunctionCallParser(
+                self.tools, "without_tokenizer", tokenizer=tokenizer
+            )
+
+        self.assertIs(parser.detector.tokenizer, tokenizer)
+        self.assertIsInstance(parser_without_tokenizer.detector, _StubDetector)
+
+    def test_no_tools_short_circuits_every_parse_path(self):
+        parser = self.make_parser(tools=[])
+        parser.detector.has_tool_call = Mock()
+        parser.detector.detect_and_parse = Mock()
+        parser.detector.parse_streaming_increment = Mock()
+        parser.detector.finish = Mock()
+
+        self.assertFalse(parser.has_tool_call("<tool>"))
+        self.assertEqual(parser.parse_non_stream("plain"), ("plain", []))
+        self.assertEqual(parser.parse_stream_chunk("chunk"), ("chunk", []))
+        self.assertEqual(parser.parse_stream_end(), ("", []))
+
+        parser.detector.has_tool_call.assert_not_called()
+        parser.detector.detect_and_parse.assert_not_called()
+        parser.detector.parse_streaming_increment.assert_not_called()
+        parser.detector.finish.assert_not_called()
+
+    def test_non_stream_fallback_depends_on_marker_or_calls(self):
+        parser = self.make_parser()
+        parser.detector.has_tool_call = Mock(return_value=False)
+        parser.detector.detect_and_parse = Mock(
+            return_value=StreamingParseResult(normal_text="detector fallback")
+        )
+
+        self.assertEqual(parser.parse_non_stream("original"), ("original", []))
+
+        parser.detector.has_tool_call.return_value = True
+        self.assertEqual(
+            parser.parse_non_stream("<tool>malformed"),
+            ("detector fallback", []),
+        )
+
+        parsed_call = ToolCallItem(
+            tool_index=0,
+            name="weather",
+            parameters='{"city":"Singapore"}',
+        )
+        parser.detector.has_tool_call.return_value = False
+        parser.detector.detect_and_parse.return_value = StreamingParseResult(
+            normal_text="", calls=[parsed_call]
+        )
+        self.assertEqual(parser.parse_non_stream("model output"), ("", [parsed_call]))
+
+    def test_stream_chunk_and_end_delegate_to_detector(self):
+        parser = self.make_parser()
+        parsed_call = ToolCallItem(
+            tool_index=0,
+            name="weather",
+            parameters="",
+        )
+        parser.detector.parse_streaming_increment = Mock(
+            return_value=StreamingParseResult(normal_text="before", calls=[parsed_call])
+        )
+        parser.detector.finish = Mock(
+            return_value=StreamingParseResult(normal_text="held-back")
+        )
+
+        self.assertEqual(parser.parse_stream_chunk("delta"), ("before", [parsed_call]))
+        self.assertEqual(parser.parse_stream_end(), ("held-back", []))
+        parser.detector.parse_streaming_increment.assert_called_once_with(
+            "delta", self.tools
+        )
+        parser.detector.finish.assert_called_once_with(self.tools)
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
## Motivation

Part of #20865.

`FunctionCallParser` and `BaseFormatDetector` provide shared orchestration, parsing, streaming state, and structural-constraint behavior for model-specific function-call detectors. Existing tests primarily exercise individual detector formats, while several shared control-flow and serialization contracts were not covered directly.

This PR adds focused CPU-only coverage for those shared contracts. It makes no production-code changes.

## Modifications

Adds `test/registered/unit/function_call/test_function_call_parser_core.py`, covering:

- unsupported parser names
- conditional tokenizer forwarding based on the detector constructor signature
- no-tools short-circuiting across detection, non-streaming, streaming, and stream-finalization paths
- non-streaming fallback behavior when markers or parsed calls are absent or present
- streaming chunk and stream-end delegation to the detector

Adds `test/registered/unit/function_call/test_base_format_detector.py`, covering:

- single-object and list JSON tool-call payloads
- both `arguments` and `parameters` keys
- Unicode argument preservation
- partial tool-marker suffix detection
- native structural-tag serialization for string and named tool choices

Both modules use `CustomTestCase` and `register_cpu_ci()`. They do not start a server, load model weights, require a GPU, or access the network.

## Accuracy Tests

N/A — test-only change.

Local focused test run:

```text
$ .venv/bin/python -m pytest test/registered/unit/function_call/test_function_call_parser_core.py test/registered/unit/function_call/test_base_format_detector.py -v --disable-warnings
============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-9.1.1, pluggy-1.6.0 -- /Users/huiming.qiu/code/sglang/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/huiming.qiu/code/sglang/test
configfile: pytest.ini
plugins: cov-7.1.0, anyio-4.14.2
collecting ... collected 9 items

test/registered/unit/function_call/test_function_call_parser_core.py::TestFunctionCallParserCore::test_no_tools_short_circuits_every_parse_path PASSED [ 11%]
test/registered/unit/function_call/test_function_call_parser_core.py::TestFunctionCallParserCore::test_non_stream_fallback_depends_on_marker_or_calls PASSED [ 22%]
test/registered/unit/function_call/test_function_call_parser_core.py::TestFunctionCallParserCore::test_passes_tokenizer_only_to_supported_detector PASSED [ 33%]
test/registered/unit/function_call/test_function_call_parser_core.py::TestFunctionCallParserCore::test_rejects_unsupported_parser PASSED [ 44%]
test/registered/unit/function_call/test_function_call_parser_core.py::TestFunctionCallParserCore::test_stream_chunk_and_end_delegate_to_detector PASSED [ 55%]
test/registered/unit/function_call/test_base_format_detector.py::TestBaseFormatDetectorCore::test_base_json_parsing_normalizes_object_list_and_argument_keys PASSED [ 66%]
test/registered/unit/function_call/test_base_format_detector.py::TestBaseFormatDetectorCore::test_native_structural_tag_serializes_named_tool_choice PASSED [ 77%]
test/registered/unit/function_call/test_base_format_detector.py::TestBaseFormatDetectorCore::test_native_structural_tag_serializes_tools_and_string_choice PASSED [ 88%]
test/registered/unit/function_call/test_base_format_detector.py::TestBaseFormatDetectorCore::test_partial_token_helper_finds_only_a_suffix_prefix PASSED [100%]

======================= 9 passed, 17 warnings in 17.83s ========================
```

The complete function-call unit-test directory also passes:

```text
$ .venv/bin/python -m pytest test/registered/unit/function_call/ -q
473 passed, 17 warnings, 14 subtests passed in 94.81s (0:01:34)
```

## Speed Tests and Profiling

N/A — test-only change with no production runtime impact.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). *(N/A — test-only change with no user-facing behavior.)*
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). *(N/A — no model-output or performance changes.)*
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32226410267](https://github.com/sgl-project/sglang/actions/runs/32226410267)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32226409977](https://github.com/sgl-project/sglang/actions/runs/32226409977)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->