### PR TITLE
[AMD] Recalibrate the Quark MXFP4 MoE GSM8K threshold 0.92 -> 0.89

### DIFF
--- a/test/registered/quant/test_quark_mxfp4.py
+++ b/test/registered/quant/test_quark_mxfp4.py
@@ -286,8 +286,6 @@ class TestFP8ToMXFP4MOETP1(TestOnlineQuantizationMemoryLoad):
 
     def test_gsm8k(self):
         # Original Qwen/Qwen3-30B-A3B-Instruct-2507-FP8 reference accuracy: ~0.948.
-        # MI355X: mean 0.916 over 10 runs (min 0.898, max 0.926), so 0.92 clears
-        # only about 1 run in 10.
         self._test_gsm8k(accuracy_threshold=0.89)
 
 

--- a/test/registered/quant/test_quark_mxfp4.py
+++ b/test/registered/quant/test_quark_mxfp4.py
@@ -285,8 +285,10 @@ class TestFP8ToMXFP4MOETP1(TestOnlineQuantizationMemoryLoad):
         )
 
     def test_gsm8k(self):
-        # Original Qwen/Qwen3-30B-A3B-Instruct-2507-FP8 reference accuracy: ~0.948
-        self._test_gsm8k(accuracy_threshold=0.92)
+        # Original Qwen/Qwen3-30B-A3B-Instruct-2507-FP8 reference accuracy: ~0.948.
+        # MI355X: mean 0.916 over 10 runs (min 0.898, max 0.926), so 0.92 clears
+        # only about 1 run in 10.
+        self._test_gsm8k(accuracy_threshold=0.89)
 
 
 @unittest.skipIf(is_in_ci(), "local test only")

--- a/test/registered/quant/test_quark_mxfp4.py
+++ b/test/registered/quant/test_quark_mxfp4.py
@@ -285,7 +285,7 @@ class TestFP8ToMXFP4MOETP1(TestOnlineQuantizationMemoryLoad):
         )
 
     def test_gsm8k(self):
-        # Original Qwen/Qwen3-30B-A3B-Instruct-2507-FP8 reference accuracy: ~0.948.
+        # Original Qwen/Qwen3-30B-A3B-Instruct-2507-FP8 reference accuracy: ~0.948
         self._test_gsm8k(accuracy_threshold=0.89)
 
 


### PR DESCRIPTION
`test_quark_mxfp4.py::TestFP8ToMXFP4MOETP1::test_gsm8k` fails most nights on `stage-b-test-1-gpu-small-amd-mi35x-rocm720` ([example](https://github.com/sgl-project/sglang/actions/runs/31916881653/job/95090118512)):

```
AssertionError: 0.912 not greater than 0.92
```

The 0.92 threshold was set in #18182 given unquant FP8 ref abt ~0.948, an assumed quant buffer

## Measure offline by MI355X m12-17

10 repeat runs
image `rocm/sgl-dev:v0.5.17-rocm720-mi35x-20260818`, 
serving `Qwen/Qwen3-30B-A3B-Instruct-2507-FP8` with same args 
(`--quantization quark_mxfp4 --context-length 3000 --tensor-parallel-size 1`) and 
same `run_eval` call (500 questions, 8-shot, 512 max tokens, para 128):

see res below
```
0.8980  0.9200  0.9160  0.9260  0.9140
0.9180  0.9200  0.9180  0.9120  0.9180

mean 0.9160   std 0.0070   min 0.8980   max 0.9260
```
in short Only 1 / 10 runs above 0.92. 
Two runs hit on 0.9200, since the test uses `assertGreater` these 2 fail as well

0.89 clears the observed minimum with a small margin. The repo's `measured - 0.05` convention would give 0.866, which is also defensible if a looser gate is preferred; I picked the tighter of the two so the test still catches a real regression.

## Scope

This is threshold calibration only, no behaviour change. The accuracy itself looks healthy for MXFP4 — 0.916 against a 0.948 bf16 reference is about 3 points of quantization loss, which is in line with the other classes in this file.

Measured on MI355X because that is the runner for this job. The same cluster is also reported on `pr-test-amd`; if that leg runs different hardware the distribution there is unverified.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

cc @fxmarty-amd (#18182 set this threshold) @ColinZ22


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32243903869](https://github.com/sgl-project/sglang/actions/runs/32243903869)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32243903752](https://github.com/sgl-project/sglang/actions/runs/32243903752)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->