### PR TITLE
fix(overrides): default moe_runner_backend to flashinfer_trtllm_routed for minimax-m3 nvfp4 on b200

### DIFF
--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -824,7 +824,8 @@ def _minimax_m3_overrides(server_args: Any, hf_config: Any) -> dict:
             overrides["moe_runner_backend"] = "deep_gemm"
         elif (
             server_args.moe_runner_backend == "auto"
-            and quant_resolved == "modelopt_mixed"
+            and server_args.get_model_config().quantization
+            in ("modelopt_mixed", "modelopt_fp4")
         ):
             overrides["moe_runner_backend"] = "flashinfer_trtllm_routed"
         logger.info(


### PR DESCRIPTION
# Default moe_runner_backend to flashinfer_trtllm_routed for MiniMax-M3 NVFP4 on B200

Default moe runner backend should be `flashinfer_trtllm_routed` (https://github.com/sgl-project/sglang/pull/31989)

The raw HF quant_method "modelopt" never matched "modelopt_mixed" in the `moe_runner_backend` condition, so the override was silently skipped for `nvidia/MiniMax-M3-NVFP4`. Use `server_args.get_model_config().quantization` (the fully resolved variant) directly in the condition, matching the pattern in `_minimax_m2_overrides`, and cover both `modelopt_mixed` and `modelopt_fp4`.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

`python/sglang/srt/arg_groups/overrides.py`

<!-- Detail the changes made in this pull request. -->

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #32227833975](https://github.com/sgl-project/sglang/actions/runs/32227833975)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #32227833720](https://github.com/sgl-project/sglang/actions/runs/32227833720)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->