### PR TITLE
fix: bound FlashInfer DeepSeek routing shapes

### DIFF
--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -1373,6 +1373,42 @@ def is_power_of_two(n):
     return n > 0 and math.log2(n).is_integer()
 
 
+def _can_use_flashinfer_fused_topk_deepseek(
+    num_experts: int,
+    num_expert_group: Optional[int],
+    topk_group: Optional[int],
+    topk_routed: int,
+) -> bool:
+    """Return whether FlashInfer's native DeepSeek router supports this shape."""
+    if (
+        num_expert_group is None
+        or topk_group is None
+        or not is_power_of_two(num_experts)
+        or num_experts <= 0
+        or num_expert_group <= 0
+        or num_experts % num_expert_group != 0
+        or topk_routed <= 0
+        or topk_routed > 8
+        or topk_routed > num_experts
+        or topk_group <= 0
+        or topk_group > num_expert_group
+        or topk_group * num_expert_group < topk_routed
+    ):
+        return False
+
+    if num_expert_group == 1:
+        return num_experts <= 384
+
+    experts_per_group = num_experts // num_expert_group
+    return (
+        num_expert_group <= 8
+        and topk_group <= 4
+        and num_experts <= 256
+        and 2 <= experts_per_group <= 32
+        and experts_per_group * topk_group <= 128
+    )
+
+
 def _eplb_remap_enabled() -> bool:
     # A real logical->physical mapping only exists when EPLB is enabled, the
     # initial expert placement is non-trivial, or there are redundant physical
@@ -1487,15 +1523,11 @@ def biased_grouped_topk_gpu(
     if (
         _is_cuda
         and fused_topk_deepseek is not None
-        and is_power_of_two(num_experts)
-        # flashinfer constraints (applied to routed experts only)
-        and topk_routed <= 8
-        and topk_group <= num_expert_group
-        and topk_group * num_expert_group >= topk_routed
-        and (
-            (experts_per_group <= 32 and experts_per_group * topk_group <= 128)
-            if num_expert_group > 1
-            else num_experts <= 384
+        and _can_use_flashinfer_fused_topk_deepseek(
+            num_experts,
+            num_expert_group,
+            topk_group,
+            topk_routed,
         )
     ):
         # Pre-allocate output tensors (flashinfer mutates them in-place)

--- a/test/registered/kernels/ops/moe/test_fused_topk_deepseek.py
+++ b/test/registered/kernels/ops/moe/test_fused_topk_deepseek.py
@@ -21,7 +21,7 @@ register_cuda_ci(est_time=40, stage="nightly", runner_config="1-gpu-large")
         (128, 4, 2, 4),
         (256, 8, 4, 8),
         (64, 2, 2, 4),
-        (256, 1, 1, 8),
+        (256, 1, 1, 1),
     ],
 )
 def test_flashinfer_fused_topk_deepseek_accepts_contract_shapes(params):
@@ -37,6 +37,7 @@ def test_flashinfer_fused_topk_deepseek_accepts_contract_shapes(params):
         (512, 8, 4, 8),  # too many grouped experts
         (256, 8, 4, 9),  # too many routed experts
         (96, 3, 2, 5),  # FlashInfer route requires power-of-two expert count
+        (256, 1, 1, 8),  # source API requires groups * topk_group >= topk
     ],
 )
 def test_flashinfer_fused_topk_deepseek_rejects_outside_contract(params):

--- a/test/registered/kernels/ops/moe/test_fused_topk_deepseek.py
+++ b/test/registered/kernels/ops/moe/test_fused_topk_deepseek.py
@@ -3,11 +3,91 @@ import sys
 import pytest
 import torch
 
-from sglang.srt.layers.moe.topk import biased_grouped_topk_gpu, biased_grouped_topk_impl
+from sglang.srt.layers.moe import topk as topk_module
+from sglang.srt.layers.moe.topk import (
+    _can_use_flashinfer_fused_topk_deepseek,
+    biased_grouped_topk_gpu,
+    biased_grouped_topk_impl,
+)
 from sglang.srt.utils import get_device
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=40, stage="nightly", runner_config="1-gpu-large")
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        (128, 4, 2, 4),
+        (256, 8, 4, 8),
+        (64, 2, 2, 4),
+        (256, 1, 1, 8),
+    ],
+)
+def test_flashinfer_fused_topk_deepseek_accepts_contract_shapes(params):
+    assert _can_use_flashinfer_fused_topk_deepseek(*params)
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        (256, 16, 4, 8),  # too many groups
+        (256, 8, 5, 8),  # too many selected groups
+        (8, 8, 4, 8),  # fewer than two experts per group
+        (512, 8, 4, 8),  # too many grouped experts
+        (256, 8, 4, 9),  # too many routed experts
+        (96, 3, 2, 5),  # FlashInfer route requires power-of-two expert count
+    ],
+)
+def test_flashinfer_fused_topk_deepseek_rejects_outside_contract(params):
+    assert not _can_use_flashinfer_fused_topk_deepseek(*params)
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        (256, 16, 4, 8),
+        (256, 8, 5, 8),
+        (8, 8, 4, 8),
+    ],
+)
+def test_outside_contract_falls_back_without_calling_flashinfer(monkeypatch, params):
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("out-of-contract shape called FlashInfer")
+
+    monkeypatch.setattr(topk_module, "fused_topk_deepseek", fail_if_called)
+
+    num_experts, num_expert_group, topk_group, topk = params
+    device = get_device()
+    torch.manual_seed(num_experts + num_expert_group + topk_group + topk)
+    hidden_states = torch.randn(8, 128, dtype=torch.float32, device=device)
+    gating_output = torch.randn(8, num_experts, dtype=torch.float32, device=device)
+    correction_bias = torch.randn(num_experts, dtype=torch.float32, device=device)
+
+    output, indices = biased_grouped_topk_gpu(
+        hidden_states,
+        gating_output,
+        correction_bias,
+        topk=topk,
+        renormalize=True,
+        num_expert_group=num_expert_group,
+        topk_group=topk_group,
+    )
+    ref_output, ref_indices = biased_grouped_topk_impl(
+        hidden_states,
+        gating_output,
+        correction_bias,
+        topk=topk,
+        renormalize=True,
+        num_expert_group=num_expert_group,
+        topk_group=topk_group,
+    )
+
+    result = torch.zeros(8, num_experts, dtype=torch.float32, device=device)
+    reference = torch.zeros_like(result)
+    result.scatter_(1, indices.long(), output)
+    reference.scatter_(1, ref_indices.long(), ref_output)
+    torch.testing.assert_close(result, reference, rtol=1e-3, atol=1e-3)
 
 
 @pytest.mark.parametrize(

--- a/test/registered/kernels/ops/moe/test_fused_topk_deepseek.py
+++ b/test/registered/kernels/ops/moe/test_fused_topk_deepseek.py
@@ -49,7 +49,7 @@ def test_flashinfer_fused_topk_deepseek_rejects_outside_contract(params):
     [
         (256, 16, 4, 8),
         (256, 8, 5, 8),
-        (8, 8, 4, 8),
+        (512, 8, 4, 8),
     ],
 )
 def test_outside_contract_falls_back_without_calling_flashinfer(monkeypatch, params):


### PR DESCRIPTION
## Motivation

SGLang's `fused_topk_deepseek` dispatch guard admitted grouped shapes outside the executable FlashInfer NoAuxTc boundary. Those shapes can fail in the native backend instead of using SGLang's generic Triton grouped router. This also provides a safe integration boundary for the Cake backend in [FlashInfer #4587](https://github.com/flashinfer-ai/flashinfer/pull/4587), tracked by [FlashInfer #4254](https://github.com/flashinfer-ai/flashinfer/issues/4254).

## Modifications

- Centralize the FlashInfer DeepSeek router shape predicate.
- Preserve the existing power-of-two expert policy and source API top-k/group constraint.
- Match the executable grouped boundary: `G<=8`, `topk_group<=4`, `E<=256`, `2<=E/G<=32`, and `(E/G)*topk_group<=128`.
- Route valid out-of-contract grouped shapes to the existing Triton fallback.
- Add accepted/rejected boundary tests and fail-closed GPU fallback tests.

## Accuracy Tests

NVIDIA B200, SM100, CUDA 13.0, PyTorch 2.13.0:

```bash
python -m pytest -q test/registered/kernels/ops/moe/test_fused_topk_deepseek.py
```

Result: `146 passed` in 29.86s. The file covers the in-contract FlashInfer/Cake route and verifies three legal out-of-contract grouped shapes against the PyTorch reference while monkeypatching FlashInfer to fail if called.

A 24-layer synthetic DeepSeek-V3 service run exercised the production `E=256, G=8, topk_group=4, topk=8` route in baseline/Cake/Cake/baseline order. Three correctness cases with input lengths 7, 31, and 127 produced exact output token IDs and output log probabilities within `atol=1e-4`. A fail-closed route observer recorded `selected_backend=default` for both baseline arms and `selected_backend=cake` for both candidate arms. Evidence SHA256: `55d673ec330854143ddd57e21bce681d158a7e49b4cbf2332f893d953604957c`.

A real DeepSeek-V3-0324 run at revision `e9b33add` used four GB300s, TP4/EP4, and default/Cake/Cake/default order. Each arm evaluated the same 200 official GSM8K test questions with the fixed five-shot prompt, temperature 0, and zero invalid answers. Both default runs scored 193/200 (96.5%); both Cake runs scored 191/200 (95.5%). The paired two-question difference is not statistically significant (two-sided exact McNemar p=0.754 and 0.727 for the two Cake arms versus the first default arm), but exact generated-text parity is not claimed for this FP8 full-model run.

```bash
python benchmark/gsm8k/bench_sglang.py --backend srt --data-path <official-test.jsonl> \
  --num-shots 5 --num-questions 200 --max-new-tokens 512 \
  --temperature 0 --top-p 1 --parallel 16
```

The fail-closed CUDA observer captured only `deepseek_v3_topk_kernel` in both default arms and only `kernel_cake_deepseek_routing_grouped_k8g4_f32_f32` in both Cake arms. The separate launch audit returned exact expert IDs and routing weights within `atol=rtol=1e-4` in every arm. Evidence SHA256: `ad36974732243993c6d84a2a8ee3430b6e21e87979abaddefcc8b55eea33fc16`.

## Speed Tests and Profiling

The B200 synthetic service run used two warmups and five measured requests per server (10 samples per arm after ABBA aggregation). The full-model operation mix dominates the microsecond router, so small client-wall variations are reported rather than filtered out.

| Workload | Client wall / throughput | E2E latency | TTFT | TPOT |
| --- | ---: | ---: | ---: | ---: |
| decode b1, I256/O64 | 0.9970x | 0.9969x | 0.9882x | 1.0012x |
| decode b16, I256/O64 | 1.0001x | 0.9957x | 1.0107x | 1.0022x |
| decode b64, I128/O32 | 0.9972x | 1.0255x | 1.0136x | 1.0956x |

The real-model serving arm used 128 fixed 512-input/128-output requests at concurrency 16:

```bash
python -m sglang.benchmark.serving --backend sglang --dataset-name random-ids \
  --num-prompts 128 --random-input-len 512 --random-output-len 128 \
  --random-range-ratio 1 --request-rate inf --max-concurrency 16 --seed 42
```

| Real DeepSeek-V3 GB300 metric | Default median | Cake median | Cake speedup |
| --- | ---: | ---: | ---: |
| GSM8K wall latency | 275.259 s | 283.131 s | 0.9722x |
| GSM8K output throughput | 71.734 token/s | 71.115 token/s | 0.9914x |
| Serving request throughput | 0.54063 req/s | 0.54117 req/s | 1.0010x |
| Serving output throughput | 69.2005 token/s | 69.2693 token/s | 1.0010x |
| Mean E2E latency | 28045.81 ms | 28029.82 ms | 1.0006x |
| Mean TTFT | 2326.10 ms | 2335.58 ms | 0.9959x |
| Mean TPOT | 202.517 ms | 202.317 ms | 1.0010x |

The linked current FlashInfer source benchmark uses CUPTI cold-L2 timing for one complete routing invocation. On B200 all 15 contract rows pass correctness and improve over the default backend by 1.0194--1.2101x. On GB300 all 15 rows improve by 1.2665--1.5738x. B200 synccheck and memcheck pass with PDL disabled and enabled, both with zero errors.

## Checklist

- [x] Targeted pre-commit passed for both modified files.
- [x] Added unit and GPU correctness tests.
- [x] Verified a real SGLang service selects Cake rather than merely importing it.
- [x] Preserved the existing in-contract fast path and fail-closed out-of-contract fallback.
- [x] Followed the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32227976057](https://github.com/sgl-project/sglang/actions/runs/32227976057)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32227975940](https://github.com/sgl-project/sglang/actions/runs/32227975940)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
