### PR TITLE
[Diffusion] Fix MiniMax H3 reference audio forward context

### DIFF
--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/minimax_h3/reference_encoding.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/minimax_h3/reference_encoding.py
@@ -35,6 +35,7 @@ from sglang.multimodal_gen.configs.models.vaes.minimax_h3_video import (
     MiniMaxH3VideoVAEArchConfig,
 )
 from sglang.multimodal_gen.runtime.distributed.parallel_state import get_world_group
+from sglang.multimodal_gen.runtime.managers.forward_context import set_forward_context
 from sglang.multimodal_gen.runtime.pipelines_core.stages.model_specific_stages.minimax_h3.constants import (
     MINIMAX_H3_SUPPORTED_FPS,
 )
@@ -321,7 +322,10 @@ def minimax_h3_encode_reference_audio_rows(
         waveform = _audio_resampler(int(source_rate))(waveform)
     waveform = waveform.to(device)
 
-    with _AudioVAEDeterminismContext():
+    with (
+        _AudioVAEDeterminismContext(),
+        set_forward_context(current_timestep=0, attn_metadata=None),
+    ):
         audio_data = model.preprocess(
             waveform.unsqueeze(1), MINIMAX_H3_AUDIO_SAMPLE_RATE
         )

--- a/python/sglang/multimodal_gen/test/unit/test_minimax_h3_media.py
+++ b/python/sglang/multimodal_gen/test/unit/test_minimax_h3_media.py
@@ -11,6 +11,7 @@ import numpy as np
 import pytest
 import torch
 
+from sglang.multimodal_gen.runtime.managers.forward_context import get_forward_context
 from sglang.multimodal_gen.runtime.pipelines_core.stages.model_specific_stages.minimax_h3 import (
     material_io,
     reference_encoding,
@@ -256,3 +257,42 @@ def test_audio_decode_is_bounded_float_pcm_without_temp_files(monkeypatch):
     assert ffmpeg[ffmpeg.index("-ss") + 1] == "2.25"
     assert ffmpeg.index("-ss") < ffmpeg.index("-i")
     assert ffmpeg[-3:] == ["-f", "f32le", "pipe:1"]
+
+
+def test_reference_audio_encode_sets_forward_context(monkeypatch):
+    class FakeAudioVAE(torch.nn.Module):
+        attn_proj = True
+
+        def __init__(self):
+            super().__init__()
+            self.anchor = torch.nn.Parameter(torch.zeros(1))
+            self.mean_proj = torch.nn.Identity()
+
+        def preprocess(self, waveform, _sample_rate):
+            return waveform
+
+        def encoder(self, _audio_data):
+            return torch.ones(2, 32, 4)
+
+        def pre_block(self, hidden_states):
+            assert get_forward_context().current_timestep == 0
+            return hidden_states
+
+    monkeypatch.setattr(
+        reference_encoding,
+        "_load_waveform",
+        lambda *_args, **_kwargs: (torch.ones(2, 320), 32000),
+    )
+
+    result = reference_encoding.minimax_h3_encode_reference_audio_rows(
+        FakeAudioVAE(),
+        "/input/ref.wav",
+        SimpleNamespace(
+            latent_channels=32,
+            latents_mean=[0.0] * 32,
+            latents_std=[1.0] * 32,
+        ),
+    )
+
+    assert result["rows"].shape == (8, 32)
+    assert result["ref_audio_t"] == 4


### PR DESCRIPTION
## Summary

- establish the standard diffusion forward context while MiniMax H3 encodes reference audio
- add a CPU regression test covering the audio VAE `pre_block` context requirement

## Root cause

#34949 routed MiniMax H3 audio VAE attention through `USPAttention`, which reads `ForwardContext`. The reference-audio encoding helper still invoked `pre_block` outside `set_forward_context`, so ref2va requests with audio failed with `Forward context is not set`.

The helper now uses the same `current_timestep=0, attn_metadata=None` context as the existing MiniMax H3 text-encoding and video-VAE paths.

## Validation

- regression test fails on current `upstream/main` with the reported assertion and passes with this patch
- CPU contract reproduction through `CausalAttention -> USPAttention` passes with the patch
- `ruff check --select=F401,F821,UP037` on both changed files
- `black --check` on both changed files
- `python -m compileall` and `git diff --check`

Full MiniMax-H3 GPU/model end-to-end validation was not available locally.

Fixes #35447

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32230246810](https://github.com/sgl-project/sglang/actions/runs/32230246810)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32230246424](https://github.com/sgl-project/sglang/actions/runs/32230246424)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->