### PR TITLE
Make HiSparse's logical KV pool a pluggable backing, and add the HiCa…

### DIFF
--- a/python/sglang/kernels/jit/csrc/hisparse.cuh
+++ b/python/sglang/kernels/jit/csrc/hisparse.cuh
@@ -185,7 +185,11 @@ __device__ __forceinline__ void copy_miss_item(
     void* __restrict__ device_buffer_v,
     int64_t src_loc,
     int64_t dst_loc,
-    int64_t item_size_bytes) {
+    int64_t item_size_bytes,
+    // Distance between consecutive host rows: item_size_bytes for a layer-first
+    // host pool, a multiple of the cell for one that interleaves layers within a
+    // token (HiCache's page_first). Either way the copy moves item_size_bytes.
+    int64_t host_row_bytes) {
   static_assert(!IsDsv4Layout || IsMLA, "DSv4 page-padded layout is K-only (MLA).");
   if constexpr (IsDsv4Layout) {
 #ifdef USE_ROCM
@@ -210,13 +214,14 @@ __device__ __forceinline__ void copy_miss_item(
         /*src_index=*/static_cast<int32_t>(src_loc));
 #endif
   } else {
-    // Generic path: device + host both linear, stride = item_size_bytes.
-    const auto src_k = static_cast<const char*>(host_cache_k) + src_loc * item_size_bytes;
+    // Generic path: device linear at item_size_bytes, host linear at
+    // host_row_bytes (the same for a layer-first host pool).
+    const auto src_k = static_cast<const char*>(host_cache_k) + src_loc * host_row_bytes;
     auto dst_k = static_cast<char*>(device_buffer_k) + dst_loc * item_size_bytes;
     transfer_item_warp(lane_id, src_k, dst_k, item_size_bytes);
 
     if constexpr (!IsMLA) {
-      const auto src_v = static_cast<const char*>(host_cache_v) + src_loc * item_size_bytes;
+      const auto src_v = static_cast<const char*>(host_cache_v) + src_loc * host_row_bytes;
       auto dst_v = static_cast<char*>(device_buffer_v) + dst_loc * item_size_bytes;
       transfer_item_warp(lane_id, src_v, dst_v, item_size_bytes);
     }
@@ -298,12 +303,17 @@ __device__ __forceinline__ int warp_inclusive_scan(int* s_data, int lane_id, int
 
 // Shared memory size calculation for dynamic allocation.
 // Layout: int32_t region (4-byte aligned) followed by int16_t region (2-byte aligned).
-template <int NUM_TOP_K, int HOT_BUFFER_SIZE>
+template <int NUM_TOP_K, int HOT_BUFFER_SIZE, bool HasPassThroughCounter = false>
 struct SmemLayout {
   static constexpr int HASH_SIZE = NUM_TOP_K * 2;
   static constexpr int NUM_BUFFER_CHUNKS = (HOT_BUFFER_SIZE + WARP_SIZE - 1) / WARP_SIZE;
-  // int32_t region: top_k_tokens + chunk_offset + evict_chunk_offset + hash_keys + total_hits + newest_hit
-  static constexpr int TOTAL_INT32 = NUM_TOP_K + (NUM_BUFFER_CHUNKS + 1) + (NUM_BUFFER_CHUNKS + 1) + HASH_SIZE + 2;
+  // Counters after the hash table: total_hits, newest_hit, and pass_through_hits
+  // only for a caller with a pool source, so the two-source instantiation
+  // requests exactly the shared memory it always did.
+  static constexpr int NUM_COUNTERS = HasPassThroughCounter ? 3 : 2;
+  // int32_t region: top_k_tokens + chunk_offset + evict_chunk_offset + hash_keys + counters
+  static constexpr int TOTAL_INT32 =
+      NUM_TOP_K + (NUM_BUFFER_CHUNKS + 1) + (NUM_BUFFER_CHUNKS + 1) + HASH_SIZE + NUM_COUNTERS;
   // int16_t region: lru_slots_out + hash_vals
   static constexpr int TOTAL_INT16 = HOT_BUFFER_SIZE + HASH_SIZE;
   static constexpr size_t BYTES = TOTAL_INT32 * sizeof(int32_t) + TOTAL_INT16 * sizeof(int16_t);
@@ -321,8 +331,22 @@ struct SmemLayout {
 // RecordMissPlan records this step's miss plan (miss_src/dst = host/device loc
 // per miss, miss_count per request) for shared-index skip layers to replay via
 // copy_cache_planned_kernel. SkipIO elides only the KV byte movement (timing
-// probe; output is garbage). Both are compile-time flags so the production
-// (false, false) instantiation stays byte-identical.
+// probe, or the plan-only half when the caller replays the plan itself).
+//
+// LateBoundHostBase reads the host pool's base address AND row stride out of a
+// two-element device tensor at run time instead of taking them as arguments,
+// which a caller whose host tier attaches AFTER cuda-graph capture needs:
+// neither value is known when the launch is recorded. Callers that own their
+// host pool from init pass the buffer, and their rows are one cell apart.
+//
+// PassThroughDeviceLocs adds a third source per top-k lane, for callers whose
+// logical KV pool can still own the position: device_locs[token] >= 0 means the
+// KV is live in the pool, so that slot is emitted as-is -- no hot-buffer slot, no
+// hash entry, no copy. Only positions the pool gave up (sentinel) fall through to
+// the buffer/host paths below.
+//
+// All four are compile-time flags, so the all-false private-host instantiation
+// stays byte-identical.
 template <
     int BLOCK_SIZE,
     int NUM_TOP_K,
@@ -331,6 +355,8 @@ template <
     bool IsDsv4Layout,
     bool RecordMissPlan,
     bool SkipIO,
+    bool PassThroughDeviceLocs,
+    bool LateBoundHostBase,
     typename SeqLensT,
     typename ReqPoolIndicesT>
 __global__ void load_cache_to_device_buffer_kernel(
@@ -338,6 +364,14 @@ __global__ void load_cache_to_device_buffer_kernel(
     int32_t* __restrict__ device_buffer_tokens,
     const int64_t* __restrict__ host_cache_locs,
     const int32_t* __restrict__ device_buffer_locs,
+    // [max_reqs, max_positions] pool slot per position, or < 0 once the pool has
+    // given the position up. Read only when PassThroughDeviceLocs.
+    const int32_t* __restrict__ device_locs,
+    int64_t device_locs_stride,
+    // [base address, row stride in bytes] of the host pool, read at run time.
+    // Only when LateBoundHostBase; otherwise host_cache_k below is the base and
+    // its rows are item_size_bytes apart.
+    const int64_t* __restrict__ host_binding,
     const void* __restrict__ host_cache_k,
     const void* __restrict__ host_cache_v,
     void* __restrict__ device_buffer_k,
@@ -367,6 +401,9 @@ __global__ void load_cache_to_device_buffer_kernel(
   const int bid = blockIdx.x;
   const int tid = threadIdx.x;
   int32_t* req_top_k_device_locs = top_k_device_locs + bid * top_k_device_locs_stride;
+  // Resolved once per block for the copy phase below.
+  const void* const host_base = LateBoundHostBase ? reinterpret_cast<const void*>(host_binding[0]) : host_cache_k;
+  const int64_t host_row_bytes = LateBoundHostBase ? host_binding[1] : item_size_bytes;
 
   // CUDA graph pads the batch to a captured size. Keep padded output rows
   // invalid without a separate fill kernel.
@@ -392,9 +429,12 @@ __global__ void load_cache_to_device_buffer_kernel(
   const int32_t* req_device_buffer_locs = device_buffer_locs + buffer_offset;
   const int64_t* req_host_cache_locs = host_cache_locs + rid * host_stride;
   int16_t* req_lru_slots = lru_slots + rid * lru_slot_stride_0;
+  const int32_t* req_device_locs = PassThroughDeviceLocs ? device_locs + rid * device_locs_stride : nullptr;
 
-  // Fast path: short sequences have all tokens in the device buffer in order.
-  if (seq_len <= HOT_BUFFER_SIZE) {
+  // Fast path: short sequences have all tokens in the device buffer in order,
+  // so position == buffer slot. A pass-through caller keeps most positions in the
+  // pool, leaving the buffer an unrelated subset, and would get wrong slots here.
+  if (!PassThroughDeviceLocs && seq_len <= HOT_BUFFER_SIZE) {
     const int count = (seq_len < NUM_TOP_K) ? static_cast<int>(seq_len) : NUM_TOP_K;
     for (int i = tid; i < NUM_TOP_K; i += BLOCK_SIZE) {
       int32_t device_loc = -1;
@@ -417,7 +457,7 @@ __global__ void load_cache_to_device_buffer_kernel(
 
   // Dynamic shared memory layout: int32_t arrays first, then int16_t arrays.
   extern __shared__ char smem_raw[];
-  using Layout = SmemLayout<NUM_TOP_K, HOT_BUFFER_SIZE>;
+  using Layout = SmemLayout<NUM_TOP_K, HOT_BUFFER_SIZE, PassThroughDeviceLocs>;
   constexpr int HASH_SIZE = Layout::HASH_SIZE;
 
   int32_t* smem_i32 = reinterpret_cast<int32_t*>(smem_raw);
@@ -432,6 +472,12 @@ __global__ void load_cache_to_device_buffer_kernel(
   // Scalar counters
   int32_t& s_total_hits = s_hash_keys[HASH_SIZE];
   int32_t& s_newest_hit = s_hash_keys[HASH_SIZE + 1];
+  // Lanes retired by the pass-through pass (pool-resident, or masked because the
+  // selector left them unfilled). They mark themselves TOKEN_HIT, but the miss
+  // TOTAL below is recomputed from the counters rather than from that pass's
+  // ballot, so they need a counter too -- otherwise the copy phase reads host
+  // locations for positions it never planned. Last of the gated counters.
+  int32_t& s_pass_through_hits = s_hash_keys[HASH_SIZE + Layout::NUM_COUNTERS - 1];
 
   int16_t* smem_i16 = reinterpret_cast<int16_t*>(smem_i32 + Layout::TOTAL_INT32);
   // Compacted slot ordering: [hits fwd->  ...  <-evictables bwd]
@@ -443,6 +489,9 @@ __global__ void load_cache_to_device_buffer_kernel(
   if (tid == 0) {
     s_total_hits = 0;
     s_newest_hit = 0;
+    if constexpr (PassThroughDeviceLocs) {
+      s_pass_through_hits = 0;
+    }
   }
   for (int i = tid; i < HASH_SIZE; i += BLOCK_SIZE) {
     s_hash_keys[i] = HASH_EMPTY;
@@ -457,9 +506,38 @@ __global__ void load_cache_to_device_buffer_kernel(
   const int32_t newest_token = seq_len - 1;
 
   // Insert top-k tokens into shared-memory hash table.
+  int my_pass_through_count = 0;
   for (int i = tid; i < NUM_TOP_K; i += BLOCK_SIZE) {
     int32_t token_idx = req_top_k_tokens[i];
-    if (token_idx == newest_token) {
+    if constexpr (PassThroughDeviceLocs) {
+      // Still owned by the pool: emit its slot and take nothing. Marking it
+      // TOKEN_HIT keeps the miss pass from assigning it a buffer slot, and
+      // staying out of the hash keeps a buffer resident from claiming this lane.
+      if (token_idx < 0) {
+        // Lane the selector left unfilled -- routine below NUM_TOP_K positions,
+        // which only a pass-through caller sees (the fast path that used to
+        // absorb them is off). Retire it as masked; left as a miss it would send
+        // the copy phase into the host table at a negative position.
+        s_top_k_tokens[i] = TOKEN_HIT;
+        req_top_k_device_locs[i] = -1;
+        ++my_pass_through_count;
+        continue;
+      }
+      const int32_t pool_loc = req_device_locs[token_idx];
+      if (pool_loc >= 0) {
+        s_top_k_tokens[i] = TOKEN_HIT;
+        req_top_k_device_locs[i] = pool_loc;
+        ++my_pass_through_count;
+        continue;
+      }
+      // Sentinel: the pool gave this position up, so fall through to the
+      // buffer/host paths. Every selected position has a home by construction
+      // (the caller reserves host space before releasing a pool slot), so a
+      // broken invariant faults on the host index rather than degrading the
+      // output silently. The newest token is never given up, so its special case
+      // below is unreachable here and compiles out.
+    }
+    if (!PassThroughDeviceLocs && token_idx == newest_token) {
       // If topk includes the latest token, bind its canonical occurrence to newest_slot (at HOT_BUFFER_SIZE) and mark
       // it as a hit. newest_slot is at the first position of the extra page, excluded from LRU tracking.
       s_top_k_tokens[i] = TOKEN_HIT;
@@ -476,6 +554,13 @@ __global__ void load_cache_to_device_buffer_kernel(
         slot = (slot + 1) % HASH_SIZE;
       }
       s_top_k_tokens[i] = token_idx;
+    }
+  }
+  // One atomic per thread, not per lane: with NUM_TOP_K in the thousands and most
+  // lanes pool-resident, per-lane atomics on one address serialize badly.
+  if constexpr (PassThroughDeviceLocs) {
+    if (my_pass_through_count > 0) {
+      atomicAdd(&s_pass_through_hits, my_pass_through_count);
     }
   }
   __syncthreads();
@@ -631,7 +716,12 @@ __global__ void load_cache_to_device_buffer_kernel(
   }
   __syncthreads();
 
+  // Recomputed from the counters (not from the pass above, whose ballot total is
+  // only valid in warp 0) so every warp in the copy phase agrees on it.
   total_misses = NUM_TOP_K - s_total_hits - s_newest_hit;
+  if constexpr (PassThroughDeviceLocs) {
+    total_misses -= s_pass_through_hits;
+  }
   if constexpr (RecordMissPlan) {
     if (tid == 0) {
       miss_count_out[bid] = total_misses;
@@ -683,7 +773,15 @@ __global__ void load_cache_to_device_buffer_kernel(
       const int64_t dst_loc = static_cast<int64_t>(req_device_buffer_locs[evict_slot]);
 
       copy_miss_item<IsMLA, IsDsv4Layout>(
-          lane_id, host_cache_k, host_cache_v, device_buffer_k, device_buffer_v, src_loc, dst_loc, item_size_bytes);
+          lane_id,
+          host_base,
+          host_cache_v,
+          device_buffer_k,
+          device_buffer_v,
+          src_loc,
+          dst_loc,
+          item_size_bytes,
+          host_row_bytes);
     }
   }
 }
@@ -695,12 +793,16 @@ template <
     bool IsMLA,
     bool IsDsv4Layout,
     bool RecordMissPlan,
-    bool SkipIO>
+    bool SkipIO,
+    bool PassThroughDeviceLocs,
+    bool LateBoundHostBase>
 void load_cache_to_device_buffer(
     tvm::ffi::TensorView top_k_tokens,
     tvm::ffi::TensorView device_buffer_tokens,
     tvm::ffi::TensorView host_cache_locs,
     tvm::ffi::TensorView device_buffer_locs,
+    tvm::ffi::TensorView device_locs,
+    tvm::ffi::TensorView host_binding,
     tvm::ffi::TensorView host_cache_k,
     tvm::ffi::TensorView host_cache_v,
     tvm::ffi::TensorView device_buffer_k,
@@ -727,6 +829,13 @@ void load_cache_to_device_buffer(
   if (RecordMissPlan && miss_dst_out.strides()[0] != plan_stride) {
     throw std::runtime_error("load_cache_to_device_buffer: miss_src/miss_dst row strides differ");
   }
+  // 0-dim sentinel when the caller has no pool source (private-host backing).
+  const int32_t* const device_locs_ptr =
+      PassThroughDeviceLocs ? static_cast<const int32_t*>(device_locs.data_ptr()) : nullptr;
+  const int64_t device_locs_stride = PassThroughDeviceLocs ? device_locs.strides()[0] : 0;
+  // 0-dim sentinel when the caller owns its host pool up front.
+  const int64_t* const host_binding_arg =
+      LateBoundHostBase ? static_cast<const int64_t*>(host_binding.data_ptr()) : nullptr;
   const int64_t buffer_stride_0 = device_buffer_tokens.strides()[0];
   const int64_t lru_slot_stride_0 = lru_slots.strides()[0];
   const int64_t top_k_tokens_stride = top_k_tokens.strides()[0];
@@ -736,7 +845,7 @@ void load_cache_to_device_buffer(
   // Generic lambda: int32/int64 kernel variants are compiled for both
   // seq_lens and req_pool_indices; the correct combo is selected at runtime.
   auto launch = [&](auto kernel_fn, const auto* seq_lens_ptr, const auto* req_pool_indices_ptr) {
-    constexpr size_t smem_bytes = SmemLayout<NUM_TOP_K, HOT_BUFFER_SIZE>::BYTES;
+    constexpr size_t smem_bytes = SmemLayout<NUM_TOP_K, HOT_BUFFER_SIZE, PassThroughDeviceLocs>::BYTES;
 #ifndef USE_ROCM
     if constexpr (smem_bytes > 48u * 1024u) {
       cudaFuncSetAttribute(kernel_fn, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_bytes);
@@ -748,6 +857,9 @@ void load_cache_to_device_buffer(
         static_cast<int32_t*>(device_buffer_tokens.data_ptr()),
         static_cast<const int64_t*>(host_cache_locs.data_ptr()),
         static_cast<const int32_t*>(device_buffer_locs.data_ptr()),
+        device_locs_ptr,
+        device_locs_stride,
+        host_binding_arg,
         host_cache_k.data_ptr(),
         (IsMLA || host_cache_v.ndim() == 0) ? (const void*)nullptr : host_cache_v.data_ptr(),
         device_buffer_k.data_ptr(),
@@ -785,6 +897,8 @@ void load_cache_to_device_buffer(
             IsDsv4Layout,
             RecordMissPlan,
             SkipIO,
+            PassThroughDeviceLocs,
+            LateBoundHostBase,
             int64_t,
             int64_t>,
         static_cast<const int64_t*>(seq_lens.data_ptr()),
@@ -799,6 +913,8 @@ void load_cache_to_device_buffer(
             IsDsv4Layout,
             RecordMissPlan,
             SkipIO,
+            PassThroughDeviceLocs,
+            LateBoundHostBase,
             int64_t,
             int32_t>,
         static_cast<const int64_t*>(seq_lens.data_ptr()),
@@ -813,6 +929,8 @@ void load_cache_to_device_buffer(
             IsDsv4Layout,
             RecordMissPlan,
             SkipIO,
+            PassThroughDeviceLocs,
+            LateBoundHostBase,
             int32_t,
             int64_t>,
         static_cast<const int32_t*>(seq_lens.data_ptr()),
@@ -827,6 +945,8 @@ void load_cache_to_device_buffer(
             IsDsv4Layout,
             RecordMissPlan,
             SkipIO,
+            PassThroughDeviceLocs,
+            LateBoundHostBase,
             int32_t,
             int32_t>,
         static_cast<const int32_t*>(seq_lens.data_ptr()),
@@ -884,7 +1004,8 @@ __global__ __launch_bounds__(BLOCK_SIZE, 1) void copy_cache_planned_kernel(
             device_buffer_v,
             src_row[m],
             static_cast<int64_t>(dst_row[m]),
-            item_size_bytes);
+            item_size_bytes,
+            /*host_row_bytes=*/item_size_bytes);
       }
       start += cnt;
     }

--- a/python/sglang/kernels/ops/kvcache/hisparse.py
+++ b/python/sglang/kernels/ops/kvcache/hisparse.py
@@ -21,9 +21,11 @@ def _jit_sparse_module(
     is_dsv4_layout: bool = False,
     record_miss_plan: bool = False,
     skip_io: bool = False,
+    pass_through_device_locs: bool = False,
+    late_bound_host_base: bool = False,
 ) -> Module:
-    # record_miss_plan / skip_io are compile-time kernel flags; the
-    # (False, False) production instantiation stays byte-identical.
+    # The four bool flags are compile-time kernel flags; the all-False
+    # private-host instantiation stays byte-identical.
     template_args = make_cpp_args(
         block_size,
         num_top_k,
@@ -32,6 +34,8 @@ def _jit_sparse_module(
         is_dsv4_layout,
         record_miss_plan,
         skip_io,
+        pass_through_device_locs,
+        late_bound_host_base,
     )
     cache_args = make_cpp_args(
         item_size_bytes,
@@ -42,6 +46,8 @@ def _jit_sparse_module(
         is_dsv4_layout,
         record_miss_plan,
         skip_io,
+        pass_through_device_locs,
+        late_bound_host_base,
     )
     return load_jit(
         "sparse_cache",
@@ -120,7 +126,7 @@ def _load_cache_to_device_buffer_mla(
     device_buffer_tokens: torch.Tensor,
     host_cache_locs: torch.Tensor,
     device_buffer_locs: torch.Tensor,
-    host_cache: torch.Tensor,
+    host_cache: torch.Tensor | None,
     device_buffer: torch.Tensor,
     top_k_device_locs: torch.Tensor,
     req_pool_indices: torch.Tensor,
@@ -136,12 +142,18 @@ def _load_cache_to_device_buffer_mla(
     miss_dst: torch.Tensor | None,
     miss_count: torch.Tensor | None,
     skip_io: bool,
+    device_locs: torch.Tensor | None,
+    host_binding: torch.Tensor | None,
 ) -> None:
     assert (
         hot_buffer_size >= num_top_k
     ), f"hot_buffer_size ({hot_buffer_size}) must be >= num_top_k ({num_top_k})"
 
     record_miss_plan = miss_src is not None
+    # Both extra sources are opt-in per caller: passing the tensor compiles that
+    # branch in, omitting it keeps the two-source private-host kernel.
+    pass_through_device_locs = device_locs is not None
+    late_bound_host_base = host_binding is not None
     module = _jit_sparse_module(
         item_size_bytes,
         block_size,
@@ -151,6 +163,8 @@ def _load_cache_to_device_buffer_mla(
         is_dsv4_layout=is_dsv4_layout,
         record_miss_plan=record_miss_plan,
         skip_io=skip_io,
+        pass_through_device_locs=pass_through_device_locs,
+        late_bound_host_base=late_bound_host_base,
     )
 
     empty = torch.empty(0)
@@ -170,11 +184,37 @@ def _load_cache_to_device_buffer_mla(
         # Unused sentinels; the RecordMissPlan=false instantiation never reads them.
         miss_src = miss_dst = miss_count = empty
 
+    if pass_through_device_locs:
+        assert device_locs.dtype == torch.int32, (
+            "device_locs must be int32 (it is the pool's own index table), got "
+            f"{device_locs.dtype}"
+        )
+    else:
+        # Unused sentinel; the PassThroughDeviceLocs=false instantiation never
+        # reads it.
+        device_locs = empty
+
+    if late_bound_host_base:
+        # Both elements are read on the device at launch time, so a short tensor
+        # is a silently wrong stride rather than an error.
+        assert host_binding.dtype == torch.int64 and host_binding.numel() == 2, (
+            "host_binding must be a two-element int64 tensor [base address, row "
+            f"stride in bytes], got {host_binding.dtype} {host_binding.numel()=}"
+        )
+    else:
+        assert host_cache is not None, "no host source: pass host_cache or host_binding"
+        # Unused sentinel; the LateBoundHostBase=false instantiation never reads it.
+        host_binding = empty
+    # None only under the binding, whose caller has no per-layer view to pass.
+    host_cache = empty if host_cache is None else host_cache
+
     module.load_cache_to_device_buffer(
         top_k_tokens,
         device_buffer_tokens,
         host_cache_locs,
         device_buffer_locs,
+        device_locs,
+        host_binding,
         host_cache,
         empty,
         device_buffer,
@@ -197,7 +237,7 @@ def load_cache_to_device_buffer_mla(
     device_buffer_tokens: torch.Tensor,
     host_cache_locs: torch.Tensor,
     device_buffer_locs: torch.Tensor,
-    host_cache: torch.Tensor,
+    host_cache: torch.Tensor | None,
     device_buffer: torch.Tensor,
     top_k_device_locs: torch.Tensor,
     req_pool_indices: torch.Tensor,
@@ -213,13 +253,29 @@ def load_cache_to_device_buffer_mla(
     miss_dst: torch.Tensor | None = None,
     miss_count: torch.Tensor | None = None,
     skip_io: bool = False,
+    device_locs: torch.Tensor | None = None,
+    host_binding: torch.Tensor | None = None,
 ) -> None:
     """Generic MLA hisparse swap-in: device + host both linear (stride=item_size_bytes).
 
     Optional miss_src/miss_dst/miss_count record the miss plan for replay by
-    copy_cache_planned_mla; skip_io elides only the KV bytes (timing probe).
+    copy_cache_planned_mla; skip_io elides only the KV bytes (timing probe, or the
+    plan-only half when the caller replays the recorded plan itself).
+
+    Optional device_locs adds the pool as a third source: `device_locs[req, pos]`
+    >= 0 means the position is live in the regular pool, so that slot is returned
+    with no hot-buffer slot and no copy; it also masks (-1) a lane the selector
+    left unfilled. Callers whose staging freed every pool slot leave it None.
+
+    Optional host_binding replaces `host_cache` as the source layout, reading the
+    host pool's [base address, row stride in bytes] from a two-element int64
+    tensor at run time: required when the host tier attaches after cuda-graph
+    capture, or when its rows are not one cell apart (HiCache's page_first
+    interleaves layers within a token).
     """
     _load_cache_to_device_buffer_mla(
+        device_locs=device_locs,
+        host_binding=host_binding,
         is_dsv4_layout=False,
         top_k_tokens=top_k_tokens,
         device_buffer_tokens=device_buffer_tokens,
@@ -262,6 +318,8 @@ def copy_cache_planned_mla(
 
     IO-only, no planning; the small fixed grid keeps the SM footprint low while
     overlapped on a side stream. The anchor's slot table stays valid (lockstep).
+    Only the private-host backing plans, and it owns its host pool from init, so
+    there is no late-bound host source here.
     """
     assert miss_src.dtype == torch.int64 and miss_dst.dtype == torch.int32
     assert miss_count.dtype == torch.int32
@@ -286,7 +344,7 @@ def load_cache_to_device_buffer_dsv4_mla(
     device_buffer_tokens: torch.Tensor,
     host_cache_locs: torch.Tensor,
     device_buffer_locs: torch.Tensor,
-    host_cache: torch.Tensor,
+    host_cache: torch.Tensor | None,
     device_buffer: torch.Tensor,
     top_k_device_locs: torch.Tensor,
     req_pool_indices: torch.Tensor,
@@ -303,8 +361,14 @@ def load_cache_to_device_buffer_dsv4_mla(
     miss_count: torch.Tensor | None = None,
     skip_io: bool = False,
 ) -> None:
-    """DSv4 hisparse swap-in: page-padded device + page-padded host C4 layout."""
+    """DSv4 hisparse swap-in: page-padded device + page-padded host C4 layout.
+
+    No pool source: DeepSeek V4 is private-host only, so every selected position
+    is either in the request's hot buffer or on host.
+    """
     _load_cache_to_device_buffer_mla(
+        device_locs=None,
+        host_binding=None,
         is_dsv4_layout=True,
         top_k_tokens=top_k_tokens,
         device_buffer_tokens=device_buffer_tokens,

--- a/python/sglang/srt/arg_groups/hisparse_hook.py
+++ b/python/sglang/srt/arg_groups/hisparse_hook.py
@@ -78,30 +78,44 @@ def validate_hisparse_kv_cache_dtype(server_args: ServerArgs) -> None:
 
 
 def validate_hisparse(server_args: ServerArgs) -> None:
-    """Validate --enable-hisparse constraints (model class, radix cache, DSA backend)."""
-    if not server_args.enable_hisparse:
-        return
+    """Validate --enable-hisparse against the backing the cache config resolves to.
 
-    from sglang.srt.configs.model_config import (
-        is_deepseek_dsa,
-        is_deepseek_v4,
+    The resolution itself rejects a cache configuration HiSparse cannot back (see
+    `mem_cache/sparsity/factory.py`); what is left here is per-backing: which
+    model classes, parallelism and feature combinations that backing supports.
+    """
+    from sglang.srt.mem_cache.sparsity.factory import (
+        HiSparseBacking,
+        hisparse_backing,
     )
 
+    backing = hisparse_backing(server_args)
+    if backing is None:
+        return
+
     hf_config = server_args.get_model_config().hf_config
+    if backing is HiSparseBacking.PRIVATE_HOST:
+        if _validate_private_host_backing(server_args, hf_config):
+            return
+    else:
+        _validate_hicache_backing(server_args, hf_config)
+
+    _validate_dsa_dtype_and_backends(server_args)
+
+
+def _validate_private_host_backing(server_args: ServerArgs, hf_config) -> bool:
+    """Constraints for the private-host backing. True = skip the DSA pairing checks."""
+    from sglang.srt.configs.model_config import is_deepseek_dsa, is_deepseek_v4
+
     is_v4_hisparse = is_deepseek_v4(hf_config)
-    is_hip = _is_hip()
     assert is_deepseek_dsa(hf_config) or is_v4_hisparse, (
         "--enable-hisparse is only supported for DSA (DeepSeek Sparse Attention) "
         "models (e.g., DeepSeek V3.2, GLM-5) and DeepSeek V4 now. "
     )
 
-    assert (
-        server_args.disable_radix_cache
-    ), "Hierarchical sparse attention currently requires --disable-radix-cache."
-
     # DSv4 hisparse handles its own dtype/backend pairing elsewhere; the dtype-
-    # aware checks below only apply to the DSA hisparse path.
-    if is_hip and is_v4_hisparse:
+    # aware checks only apply to the DSA hisparse path.
+    if _is_hip() and is_v4_hisparse:
         # TEMPORARY GUARD: DSv4 HiSparse is not supported on the unified-KV path.
         # In unified-KV mode c4_kv_pool is None, so DeepSeekV4HiSparseTokenToKVPoolAllocator
         # cannot attach and pool init dies with a cryptic AssertionError. Fail fast
@@ -118,8 +132,74 @@ def validate_hisparse(server_args: ServerArgs) -> None:
                 "Either set SGLANG_HACK_FLASHMLA_BACKEND=triton, or run without "
                 "--enable-hisparse."
             )
-        return
+        return True
 
+    return False
+
+
+def _validate_hicache_backing(server_args: ServerArgs, hf_config) -> None:
+    """Constraints for the HiCache backing.
+
+    Everything rejected here is a path that reaches HiSparse's decode without
+    going through its admission, its swap-in, or its eviction bookkeeping -- so
+    it would read masked or reused KV rather than fail.
+    """
+    from sglang.srt.configs.model_config import is_deepseek_dsa
+
+    if not is_deepseek_dsa(hf_config):
+        raise ValueError(
+            "--enable-hisparse on the HiCache backing only supports DSA models "
+            "(e.g. DeepSeek V3.2, GLM-5). DeepSeek V4 is private-host only: add "
+            "--disable-radix-cache."
+        )
+
+    if server_args.speculative_algorithm is not None:
+        raise ValueError(
+            "--enable-hisparse on the HiCache backing does not support "
+            f"speculative decoding (--speculative-algorithm={server_args.speculative_algorithm}) "
+            "yet: the draft worker shares req_to_token with the target, so it "
+            "would read the eviction sentinel or a reused slot for any prefix "
+            "the tree evicted. Use --disable-radix-cache for the private-host "
+            "backing, or drop speculative decoding."
+        )
+
+    if server_args.enable_mixed_chunk:
+        raise ValueError(
+            "--enable-hisparse on the HiCache backing does not support "
+            "--enable-mixed-chunk (mixed batches route decode through "
+            "forward_extend, which lacks the dual-source swap-in)."
+        )
+
+    if server_args.enable_streaming_session or server_args.enable_session_radix_cache:
+        raise ValueError(
+            "--enable-hisparse on the HiCache backing does not support streaming "
+            "sessions (session lock ownership conflicts with releasing the tree "
+            "lock at admission)."
+        )
+
+    if server_args.disaggregation_mode != "null":
+        raise ValueError(
+            "--enable-hisparse on the HiCache backing does not support PD "
+            "disaggregation (the decode side bypasses admission). Use "
+            "--disable-radix-cache for the private-host backing, which has a "
+            "direct-to-host admission path."
+        )
+
+    if server_args.pp_size > 1:
+        raise ValueError(
+            "--enable-hisparse on the HiCache backing does not support pipeline "
+            "parallelism (pp_size > 1) yet."
+        )
+
+    if server_args.hicache_mem_layout not in ("page_first", "layer_first"):
+        raise ValueError(
+            "--enable-hisparse requires --hicache-mem-layout page_first or "
+            f"layer_first (got '{server_args.hicache_mem_layout}'; "
+            "page_first_direct breaks the swap-in host addressing)."
+        )
+
+
+def _validate_dsa_dtype_and_backends(server_args: ServerArgs) -> None:
     from sglang.srt.arg_groups.overrides import resolved_view
 
     if resolved_view(server_args).kv_cache_dtype not in (

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -754,6 +754,73 @@ class DeepseekSparseAttnBackend(
         )
         return page_table[:, strided_indices] // page_size
 
+    def _hisparse_indexer_page_table(
+        self, *, req_pool_indices: torch.Tensor, num_pages: int
+    ) -> Optional[torch.Tensor]:
+        """HiSparse's replacement for the indexer's page table, or None.
+
+        Non-None only for a backing whose logical KV pool can move a live
+        request's attention KV out of the pool: those pages carry the -1 sentinel
+        in req_to_token, so the standard table would stride them into a negative
+        page id, and their indexer KV lives at a request-private page instead.
+        Rows of untracked requests come back unchanged, so the whole table can be
+        substituted in a mixed batch. One row per request.
+        """
+        if self.hisparse_coordinator is None or num_pages <= 0:
+            return None
+        return self.hisparse_coordinator.indexer_page_table(
+            req_pool_indices=req_pool_indices, num_pages=num_pages
+        )
+
+    def _real_page_table(
+        self, *, page_table: torch.Tensor, req_pool_indices: torch.Tensor
+    ) -> torch.Tensor:
+        """The page table the indexer scores against, HiSparse-aware."""
+        standard = self._transform_table_1_to_real(page_table)
+        hybrid = self._hisparse_indexer_page_table(
+            req_pool_indices=req_pool_indices, num_pages=standard.shape[1]
+        )
+        if hybrid is None:
+            return standard
+        assert hybrid.shape[0] == standard.shape[0], (
+            "the indexer table has one row per request; a mode that fans a request "
+            "out into per-position rows has to repeat_interleave it to match"
+        )
+        return hybrid
+
+    def _patch_graph_indexer_page_table(
+        self,
+        *,
+        req_pool_indices: torch.Tensor,
+        metadata: DSAMetadata,
+    ) -> None:
+        """Substitute HiSparse's indexer page table into the graph-static buffer.
+
+        The metadata kernels rebuild real_page_table from req_to_token every
+        replay, sentinels included, so the substitution has to happen after them
+        and in place -- a fresh tensor would not be the one the captured graph
+        reads.
+        """
+        if self.hisparse_coordinator is None:
+            return
+        real_page_table = metadata.real_page_table
+        assert real_page_table is not metadata.page_table_1, (
+            "HiSparse would have to patch the indexer page table in place, but "
+            "this backend shares one table with attention (real_page_size == 1)."
+        )
+        # The row's whole static width, not this step's length (which is only on
+        # the device here): a row's tail keeps stale values by contract and
+        # consumers bound their reads by cache_seqlens.
+        hybrid = self._hisparse_indexer_page_table(
+            req_pool_indices=req_pool_indices, num_pages=real_page_table.shape[1]
+        )
+        if hybrid is None:
+            return
+        # A backing that substitutes the table rejects speculative decoding at
+        # startup, so nothing here fans a request out into per-position rows.
+        assert not self.speculative_num_draft_tokens
+        real_page_table[: hybrid.shape[0], : hybrid.shape[1]].copy_(hybrid)
+
     def init_forward_metadata_out_graph(
         self,
         forward_batch: ForwardBatch,
@@ -1062,7 +1129,10 @@ class DeepseekSparseAttnBackend(
             dsa_cu_seqlens_k=dsa_cu_seqlens_k,
             dsa_seqlens_expanded=seqlens_expanded,
             dsa_extend_seq_lens_list=extend_seq_lens_cpu,
-            real_page_table=self._transform_table_1_to_real(page_table),
+            real_page_table=self._real_page_table(
+                page_table=page_table,
+                req_pool_indices=forward_batch.req_pool_indices,
+            ),
             dsa_max_seqlen_q=1,
             topk_indices_offset=topk_indices_offset,
             indexer_k_start_end=indexer_k_start_end,
@@ -1695,6 +1765,12 @@ class DeepseekSparseAttnBackend(
         else:
             assert metadata.real_page_table is metadata.page_table_1
 
+        # After both table-building paths above, since it overrides what they
+        # wrote for pages HiSparse moved off the device pool.
+        self._patch_graph_indexer_page_table(
+            req_pool_indices=req_pool_indices, metadata=metadata
+        )
+
         if self.dsa_decode_impl == "flashmla_kv":
             flashmla_metadata = metadata.flashmla_metadata.slice(
                 slice(0, seqlens_expanded_size + 1)
@@ -2005,10 +2081,7 @@ class DeepseekSparseAttnBackend(
 
         # todo hisparse: to cover more backends
         if self.hisparse_coordinator is not None:
-            # flash_mla_sparse_fwd / tilelang require int32 page indices.
-            page_table_1 = self.token_to_kv_pool.translate_loc_to_hisparse_device(
-                page_table_1
-            ).to(torch.int32)
+            page_table_1 = self.hisparse_coordinator.translate_page_table(page_table_1)
 
         if dsa_impl == "tilelang":
             if q_rope is not None:
@@ -2257,10 +2330,10 @@ class DeepseekSparseAttnBackend(
 
         if self.hisparse_coordinator is not None:
             page_table_1 = self.hisparse_coordinator.swap_in_selected_pages(
-                forward_batch.req_pool_indices,
-                forward_batch.seq_lens,
-                topk_indices,
-                layer.layer_id,
+                req_pool_indices=forward_batch.req_pool_indices,
+                compressed_seq_lens=forward_batch.seq_lens,
+                top_k_result=topk_indices,
+                layer_id=layer.layer_id,
             )
         elif self.use_fused_topk:
             page_table_1 = self._get_fused_topk_page_table(topk_indices)

--- a/python/sglang/srt/managers/hisparse_coordinator.py
+++ b/python/sglang/srt/managers/hisparse_coordinator.py
@@ -1,4 +1,11 @@
-# to be combined with the sparse coordinator class and sparse algorithm family
+"""The private-host HiSparse backing: a per-request pinned host pool.
+
+The whole prefix is staged out to this coordinator's own host pool when prefill
+finishes, so a swapped-out token always has exactly one home and nothing can
+evict it -- at the cost of bypassing the regular GPU pool and the radix tree.
+See `mem_cache/sparsity/factory.py` for the alternative and how one is chosen,
+and `managers/hisparse_protocol.py` for the interface both must satisfy.
+"""
 
 import logging
 from typing import Dict, List, NamedTuple, Optional, Tuple, Union
@@ -12,6 +19,7 @@ from sglang.kernels.ops.kvcache.hisparse import (
 )
 from sglang.srt.configs.model_config import dsa_layer_skips_topk, is_deepseek_dsa
 from sglang.srt.environ import envs
+from sglang.srt.managers.hisparse_protocol import HiSparseTokenStats
 from sglang.srt.managers.schedule_batch import Req
 from sglang.srt.mem_cache.allocator.hisparse import (
     DeepSeekV4HiSparseTokenToKVPoolAllocator,
@@ -23,6 +31,7 @@ from sglang.srt.mem_cache.hisparse_memory_pool import (
 from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
 from sglang.srt.mem_cache.memory_pool_host import DeepSeekV4PagedHostPool
 from sglang.srt.mem_cache.pool_host.mla import MLATokenToKVPoolHost
+from sglang.srt.mem_cache.sparsity.factory import HiSparseBacking
 from sglang.srt.utils import get_device_module, is_hip
 
 device_module = get_device_module()
@@ -36,13 +45,6 @@ class HiSparseAct(NamedTuple):
     start_event: device_module.Event
     finish_event: device_module.Event
     req: Req
-
-
-class HiSparseTokenStats(NamedTuple):
-    device_tokens: int
-    device_token_usage: float
-    host_tokens: int
-    host_token_usage: float
 
 
 def resolve_shared_index_layers(
@@ -108,7 +110,17 @@ def _build_prefetch_groups(
     return groups, slot
 
 
-class HiSparseCoordinator:
+class PrivateHostHiSparseCoordinator:
+    """`HiSparseCoordinator` over a coordinator-owned pinned host pool.
+
+    Implements `managers/hisparse_protocol.py`; the extra entry points below the
+    protocol (`admit_request_direct`, `mem_pool_host`, `padded_buffer_size`,
+    shared-index prefetch) are private-host-only and their callers reach them
+    through the concrete class after checking `backing`.
+    """
+
+    backing = HiSparseBacking.PRIVATE_HOST
+
     def __init__(
         self,
         req_to_token_pool: ReqToTokenPool,
@@ -345,6 +357,17 @@ class HiSparseCoordinator:
             ),
         )
 
+    def on_prefill_complete(self, req: Req) -> bool:
+        """Stage the request's KV out to the host pool; it runs once that lands.
+
+        Always True for this backing: staging is what makes the KV reachable at
+        all, so there is no "declined, run as standard" path and no quota to
+        exhaust -- capacity was already reserved at prefill entry. The request is
+        not runnable until `collect_ready_reqs` returns it.
+        """
+        self.admit_request_into_staging(req)
+        return True
+
     def admit_request_into_staging(self, req: Req) -> None:
         req.hisparse_staging = True
 
@@ -561,6 +584,26 @@ class HiSparseCoordinator:
     def has_ongoing_staging(self) -> bool:
         return len(self.ack_staging_queue) > 0
 
+    # ------------------------------------------------------------------
+    # Protocol members with nothing to do on this backing
+    # ------------------------------------------------------------------
+
+    def admit_budget(self) -> None:
+        """No admission quota: every prefill that fits the pool is staged."""
+        return None
+
+    def set_tree_cache(self, tree_cache) -> None:
+        """This backing runs with the radix cache disabled -- there is no tree."""
+
+    def on_prefill_finished_early(self, req: Req) -> None:
+        """Nothing to settle: this backing holds no claim until staging starts,
+        and `request_finished` would add stream syncs this path never needs."""
+
+    def admit_pending(self) -> None:
+        """Nothing is deferred: `on_prefill_complete` starts the staging copy
+        itself, and what it allocates (host slots) is not the device pool the
+        result pass batches its frees for."""
+
     def collect_ready_reqs(self) -> List[Req]:
         ready_reqs: List[Req] = []
         if len(self.ack_staging_queue) == 0:
@@ -590,14 +633,17 @@ class HiSparseCoordinator:
             ready_reqs.append(req)
         return ready_reqs
 
-    def map_last_loc_to_buffer(
+    def prepare_decode_batch(
         self,
+        *,
         seq_lens: torch.Tensor,
         out_cache_loc: torch.Tensor,
         req_pool_indices: torch.Tensor,
         seq_lens_cpu: torch.Tensor,
         req_pool_indices_cpu: torch.Tensor,
     ) -> None:
+        """Back up the token the previous step produced, then point this step's
+        newest token at the request's reserved device-buffer slot."""
         self._eager_backup_previous_token(
             seq_lens, req_pool_indices, seq_lens_cpu, req_pool_indices_cpu
         )
@@ -1002,8 +1048,32 @@ class HiSparseCoordinator:
             skip_io=self.skip_io,
         )
 
+    # ------------------------------------------------------------------
+    # Data plane
+    # ------------------------------------------------------------------
+
+    def indexer_page_table(
+        self, *, req_pool_indices: torch.Tensor, num_pages: int
+    ) -> None:
+        """The standard table is already right: this backing's logical token
+        index space IS the (expanded) indexer space, and nothing rewrites a live
+        request's `req_to_token` row, so no hybrid table is needed."""
+        return None
+
+    def translate_page_table(self, page_table: torch.Tensor) -> torch.Tensor:
+        """Resolve logical indices to attention-KV slots for the sparse kernels.
+
+        Attention KV lives in the small hot buffer, reached through the pool's
+        full -> device mapping. int32 because flash_mla_sparse_fwd / tilelang
+        require it.
+        """
+        return self.mem_pool_device.translate_loc_to_hisparse_device(page_table).to(
+            torch.int32
+        )
+
     def swap_in_selected_pages(
         self,
+        *,
         req_pool_indices: torch.Tensor,
         compressed_seq_lens: torch.Tensor,
         top_k_result: torch.Tensor,

--- a/python/sglang/srt/managers/hisparse_hicache_admission.py
+++ b/python/sglang/srt/managers/hisparse_hicache_admission.py
@@ -1,0 +1,413 @@
+"""Admission accounting for the HiCache HiSparse backing.
+
+The backing hands a request's prefix to the radix tree and lets HiCache evict it
+to host; the swap-in kernel then reads whichever tier holds a selected position.
+That only works while every admitted prefix token keeps ONE home, so admission
+has to be rationed -- and rationed *before* the prefill forward runs, because by
+the time a request is offered to the coordinator its KV is already in the pool.
+
+Integer bookkeeping over three quantities: expanded indexer pages (one per prefix
+page, for the request's lifetime), host + usable device tokens (the "one home per
+token" ceiling), and the temp device buffer each admitted request pins.
+
+Split out of the coordinator because it is the half with no tensors in it -- the
+ceiling arithmetic is where over-admission bugs live, and it is testable without a
+GPU. See `managers/hisparse_hicache_coordinator.py` for the half that moves KV.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, Optional
+
+import msgspec
+
+from sglang.srt.mem_cache.unified_cache.component_type import ComponentType
+
+logger = logging.getLogger(__name__)
+
+# Slack beyond the named reserves below, for the one thing no capacity term can
+# express: admission is instantaneous, write-back is bandwidth-bound. One page per
+# live request is the whole margin -- the reserves are upper bounds already, and
+# retraction handles a genuine device shortfall.
+_ALIGNMENT_SLACK_PAGES_PER_REQ = 1
+
+
+class _NodeClaim(msgspec.Struct):
+    """One tree node's residency claim, shared by every request referencing it.
+
+    `tokens` is counted once per node however many requests hold it, so a shared
+    prefix bills once; `host_locked` is sticky for the entry's lifetime and marks
+    the node's tokens as pinned in host by an eviction taken on some request's
+    behalf.
+    """
+
+    refs: int
+    tokens: int
+    host_locked: bool
+
+
+class _ActiveRequest(msgspec.Struct):
+    """One admitted request's residency accounting, established and dropped as a
+    unit -- as parallel dicts, every exit path had to pop each one."""
+
+    # Tree-owned page-aligned prefix, the span that must keep a home.
+    tree_len: int
+    # Output tokens still to come, device-only until write-back takes them.
+    decode_reserve: int
+    # Prefix positions already on host, no longer blocking a device eviction.
+    evicted_positions: int = 0
+
+
+class HiCacheAdmitBudget:
+    """One `PrefillAdder` round's view of the admission quotas.
+
+    PREDICTS admission so the adder can pick each candidate's device reservation;
+    the authoritative accounting stays in `AdmissionLedger` and is re-snapshotted
+    into every new adder. Within a round the quotas act as shadow copies, drawn
+    down on commit.
+    """
+
+    def __init__(
+        self,
+        *,
+        page_size: int,
+        temp_slot_tokens: int,
+        expanded_pages_left: int,
+        host_tokens_left: int,
+        device_pool_tokens: int,
+        device_evictable_overhang: int,
+        ledger: Optional[AdmissionLedger] = None,
+    ):
+        self._page_size = page_size
+        self.temp_slot_tokens = temp_slot_tokens
+        self._expanded_left = expanded_pages_left
+        self._host_left = host_tokens_left
+        self._device_pool_tokens = device_pool_tokens
+        self.device_evictable_overhang = device_evictable_overhang
+        # Committed reservations are published here so the next round's snapshot
+        # sees them; this round's local _host_left already accounts for them.
+        self._ledger = ledger
+
+    def _infeasible(self, total_seq_len: int, max_new: int) -> bool:
+        """True when the candidate's reservation cannot fit the device pool even
+        at full idle, so it must be budgeted as a standard request.
+
+        The entry-side max_new clamp only guarantees the STANDARD budget fits, so
+        adding the temp buffer on top could push the adder's total past
+        rem_total_tokens forever -- a livelock on an idle system. The coordinator
+        may still admit such a request later; with the
+        `tree_len >= temp_slot_tokens` gate its footprint never exceeds the
+        standard reservation made here, so this stays sound.
+        """
+        return (
+            total_seq_len + self.temp_slot_tokens + max_new + self._page_size
+            >= self._device_pool_tokens
+        )
+
+    def _ineligible(self, total_seq_len: int, max_new: int) -> bool:
+        """Reasons a candidate gains nothing from admission, quotas aside."""
+        num_pages = total_seq_len // self._page_size
+        return (
+            # Nothing page-aligned to hand the tree, so nothing evictable.
+            num_pages <= 0
+            # A prefix smaller than the temp buffer makes admission a net
+            # capacity LOSS: the buffer is pinned for the request's lifetime
+            # while only tree_len becomes evictable.
+            or num_pages * self._page_size < self.temp_slot_tokens
+            or self._infeasible(total_seq_len, max_new)
+        )
+
+    def future_tokens(
+        self, total_seq_len: int, max_new: int, commit: bool, req=None
+    ) -> int:
+        """Device-pool tokens to reserve for this candidate.
+
+        Predicted admission -> `temp_slot_tokens + max_new` (the temp device
+        buffer comes out of the regular pool at admission and is held for the
+        request's lifetime); predicted rejection -> the standard `max_new`.
+        """
+        num_pages = total_seq_len // self._page_size
+        tree_len = num_pages * self._page_size
+        # In-flight candidates are billed their FULL footprint, with no credit for
+        # an already-resident match, even though per-node claims DO dedup shared
+        # prefixes once admitted. Crediting the match is accurate for capacity and
+        # CRASHES: a re-hit burst admits ~2x as deep and write_back cannot drain
+        # fast enough -- prefill alloc OOMs with the pool at 45%. The binding
+        # constraint there is eviction RATE, which no ceiling expresses, so this
+        # basis is the pacing margin. Do not tighten it without a rate limiter.
+        if (
+            self._ineligible(total_seq_len, max_new)
+            or num_pages > self._expanded_left
+            or tree_len > self._host_left
+        ):
+            return max_new
+        if commit:
+            self._expanded_left -= num_pages
+            self._host_left -= tree_len
+            if self._ledger is not None and req is not None:
+                self._ledger.note_pending(req.rid, tree_len)
+        return self.temp_slot_tokens + max_new
+
+    def admission_exhausted(self, total_seq_len: int, max_new: int) -> bool:
+        """True when only a depleted quota blocks admission.
+
+        Such a candidate should stay queued rather than run as standard: the
+        quota frees up when an admitted request finishes. A candidate that is
+        ineligible on its own merits is not "exhausted" -- it runs as standard
+        and nothing it waits for would change that.
+        """
+        if self._ineligible(total_seq_len, max_new):
+            return False
+        num_pages = total_seq_len // self._page_size
+        # Same basis as future_tokens, or the gate would queue candidates that
+        # future_tokens would happily admit.
+        return (
+            num_pages > self._expanded_left
+            or num_pages * self._page_size > self._host_left
+        )
+
+
+class AdmissionLedger:
+    """What admitted and in-flight requests have promised the two KV tiers.
+
+    Two quantities with no overlap: admitted requests are charged their per-node
+    claims (deduped, so a shared prefix bills once no matter how many requests
+    reference it -- and a re-hit prefix still bills, which is what un-accounted
+    let a re-hit burst do until its evictions pinned the host tier solid), and
+    in-flight candidates are charged their pending footprint until admission
+    resolves one way or the other.
+    """
+
+    def __init__(
+        self,
+        *,
+        device_pool_tokens: int,
+        temp_slot_tokens: int,
+        page_size: int,
+        chunk_tokens: int,
+    ):
+        self.temp_slot_tokens = temp_slot_tokens
+        # Participates in the ceiling: see reservable_left.
+        self._device_pool_tokens = device_pool_tokens
+        self._page_size = page_size
+        # Tokens one prefill step writes before its request can be admitted; 0
+        # when chunked prefill is off, where the prompt is charged as pending.
+        self._chunk_tokens = max(0, chunk_tokens)
+        # Host tier size in tokens; 0 until the tree cache attaches.
+        self._host_capacity_tokens = 0
+        # req_pool_idx -> residency accounting of every admitted request.
+        self.active_reqs: Dict[int, _ActiveRequest] = {}
+        # rid -> tokens claimed at prefill-admission time but not yet resolved by
+        # the coordinator, so a later adder round cannot re-promise the space: the
+        # request's KV is in the pool but not yet on host. Summed on demand -- a
+        # running total is derived state, and the way it can drift (a charge
+        # dropped twice) raises the ceiling and over-admits.
+        self._pending: Dict[str, int] = {}
+        self._node_claims: Dict[int, _NodeClaim] = {}
+        self._claimed_tokens = 0
+        self._host_locked_tokens = 0
+
+    # ---- attachment ---------------------------------------------------
+
+    def set_host_capacity(self, host_capacity_tokens: int) -> None:
+        self._host_capacity_tokens = host_capacity_tokens
+
+    # ---- per-node claims ----------------------------------------------
+
+    @staticmethod
+    def _node_token_len(node) -> int:
+        cd = node.component_data[ComponentType.FULL]
+        if cd.value is not None:
+            return len(cd.value)
+        if cd.host_value is not None:
+            return len(cd.host_value)
+        return 0
+
+    def claim_node(self, node, *, host_locked: bool = False) -> None:
+        """Register one residency claim on a node.
+
+        Two sources share this registry so they can never double-bill a node:
+        admission (every matched-path node of an admitted request, for its
+        lifetime) and eviction attribution (a node evicted to host on that
+        request's behalf, which flips `host_locked`).
+        """
+        claim = self._node_claims.get(node.id)
+        if claim is None:
+            claim = _NodeClaim(
+                refs=0, tokens=self._node_token_len(node), host_locked=False
+            )
+            self._node_claims[node.id] = claim
+            self._claimed_tokens += claim.tokens
+        claim.refs += 1
+        if host_locked and not claim.host_locked:
+            claim.host_locked = True
+            self._host_locked_tokens += claim.tokens
+
+    def release_node(self, node) -> None:
+        claim = self._node_claims[node.id]
+        claim.refs -= 1
+        if claim.refs == 0:
+            del self._node_claims[node.id]
+            self._claimed_tokens -= claim.tokens
+            if claim.host_locked:
+                self._host_locked_tokens -= claim.tokens
+
+    # ---- in-flight claims ---------------------------------------------
+
+    def note_pending(self, rid: str, tokens: int) -> None:
+        """Record a prefill-time claim so later adder rounds see it.
+
+        The coordinator only records the real reservation after the prefill
+        forward completes, so without this a round snapshots stale headroom and
+        re-promises capacity an earlier round already claimed. Idempotent per
+        request: chunked prefill re-budgets the same request across rounds.
+        """
+        if rid in self._pending:
+            return
+        self._pending[rid] = tokens
+
+    def drop_pending(self, rid: str) -> None:
+        """Release a request's prefill-time claim once admission resolves.
+
+        Both outcomes release it: on success `activate` calls this itself, the
+        charge having been converted into per-node claims; on rejection the
+        request runs as a standard fallback and holds no host space. Callers
+        settle the paths that reach neither -- an abort during prefill.
+        """
+        self._pending.pop(rid, None)
+
+    # ---- admitted requests --------------------------------------------
+
+    def activate(
+        self, req_pool_idx: int, tree_len: int, *, rid: str, decode_reserve: int
+    ) -> None:
+        """Record a successful admission, superseding its in-flight charge.
+
+        The pending charge and the per-node claims stand for the SAME tokens, so
+        an admitted request must never carry both -- it bills its prefix twice and
+        the ceiling runs out a whole request early. Dropped here rather than at
+        the caller so "pending XOR active" is the ledger's invariant instead of
+        call-site discipline.
+
+        `decode_reserve` is held for the request's lifetime rather than decayed
+        per step: tokens it already produced still occupy pool pages, so releasing
+        the reserve as they land would just stop counting them.
+        """
+        self.drop_pending(rid)
+        self.active_reqs[req_pool_idx] = _ActiveRequest(
+            tree_len=tree_len, decode_reserve=decode_reserve
+        )
+
+    def deactivate(self, req_pool_idx: int) -> None:
+        self.active_reqs.pop(req_pool_idx, None)
+
+    def note_evicted_positions(self, req_pool_idx: int, count: int) -> None:
+        self.active_reqs[req_pool_idx].evicted_positions += count
+
+    # ---- ceilings ------------------------------------------------------
+
+    def reservable_left(self) -> int:
+        """Tokens still reservable for new admissions, across both tiers.
+
+        A prefix token needs exactly ONE home -- device or host -- because the
+        swap-in kernel reads whichever holds it. Demanding a host slot for tokens
+        sitting on device double-books the device tier and caps admission at the
+        host size alone, which left the pool ~84% idle while admission stalled.
+
+        Reservation-based, not measured availability: HiCache keeps written-back KV
+        as reusable cache, so measured availability stays low even though eviction
+        can reclaim it on demand, and budgeting against it starves admission.
+        Safety comes from eviction time instead -- the copy-less-drop veto keeps
+        data backing an active request on device, and device pressure resolves by
+        retraction.
+        """
+        if self._host_capacity_tokens <= 0:
+            # No host tier attached yet (the tree cache brings it). Nowhere to
+            # evict to means this ceiling is not what protects the pool, so it
+            # must not bind; 0 would read as "quota exhausted" and stop prefill.
+            # An int, not inf: the round's shadow quota is decremented from it.
+            return 1 << 60
+        return (
+            self._host_capacity_tokens
+            + self._usable_device_tokens()
+            - self._claimed_tokens
+            - sum(self._pending.values())
+        )
+
+    def _usable_device_tokens(self) -> int:
+        """Device tokens available to hold resident prefixes.
+
+        A device token counts toward "every admitted prefix token keeps one home"
+        only if it will still be free when the prefix needs it, so everything with
+        a prior claim comes off first. Each term is an upper bound on something
+        host CANNOT stand in for: one temp buffer per live request plus one for
+        this round's admission (pinned before the request enters `active_reqs`),
+        the decode tail every admitted request may still append, the chunk being
+        prefilled right now, and one page per request for alignment.
+        """
+        if self._device_pool_tokens <= 0:
+            return 0
+        live_reqs = len(self.active_reqs) + 1
+        reserve = (
+            live_reqs * self.temp_slot_tokens
+            + sum(a.decode_reserve for a in self.active_reqs.values())
+            + self._chunk_tokens
+            + live_reqs * _ALIGNMENT_SLACK_PAGES_PER_REQ * self._page_size
+        )
+        return max(0, self._device_pool_tokens - reserve)
+
+    def device_evictable_overhang(self, tree_evictable_tokens: int) -> int:
+        """Device-evictable tokens the `PrefillAdder` must NOT budget against.
+
+        Under write_back a demotion needs host space for the backup; without it
+        the copy-less drop is vetoed for data backing active requests and the node
+        stays device-resident. Whatever exceeds what host can absorb is therefore
+        not reclaimable, and counting it in rem_total_tokens over-admits until
+        prefill allocation hard-fails.
+
+        Only tokens BACKING ACTIVE REQUESTS are blocked -- the veto does not
+        protect unrelated cache nodes. The blocked set is bounded by each active
+        request's still-device-resident positions, clamped by the tree-wide
+        evictable size, plus slack for backups landing after this snapshot.
+
+        A deliberate upper bound, not the exact veto-blocked set: host copies are
+        not pinned until eviction time, so a span that looks host-backed can have
+        its copy reclaimed by the host LRU before the demotion that needs it.
+        Deducting such spans was tried and reproducibly ended in prefill-alloc OOM
+        under a re-hit burst. Over-estimation only throttles prefill earlier; it
+        never corrupts.
+        """
+        if self._host_capacity_tokens <= 0 or not self.active_reqs:
+            return 0
+        active_backing = sum(
+            a.tree_len - a.evicted_positions for a in self.active_reqs.values()
+        )
+        blocked = min(active_backing, tree_evictable_tokens)
+        slack = self.temp_slot_tokens * (len(self.active_reqs) + 1)
+        absorbable = self._host_capacity_tokens - self._host_locked_tokens - slack
+        return max(0, blocked - max(0, absorbable))
+
+    def make_budget(
+        self,
+        *,
+        expanded_pages_left: int,
+        tree_evictable_tokens: int,
+    ) -> HiCacheAdmitBudget:
+        """Snapshot the quotas for one `PrefillAdder` round.
+
+        Page and pool sizes come from the ledger's own fields: taking them per
+        round let `_infeasible`'s threshold disagree with the ceiling it is
+        compared against.
+        """
+        return HiCacheAdmitBudget(
+            page_size=self._page_size,
+            temp_slot_tokens=self.temp_slot_tokens,
+            expanded_pages_left=expanded_pages_left,
+            host_tokens_left=self.reservable_left(),
+            device_pool_tokens=self._device_pool_tokens,
+            device_evictable_overhang=self.device_evictable_overhang(
+                tree_evictable_tokens
+            ),
+            ledger=self,
+        )

--- a/python/sglang/srt/managers/hisparse_hicache_coordinator.py
+++ b/python/sglang/srt/managers/hisparse_hicache_coordinator.py
@@ -1,0 +1,1111 @@
+"""The HiCache HiSparse backing: the radix tree and its host tier own the KV.
+
+Attention KV stays in the regular GPU pool, so prefixes are shared and hot KV
+stays in HBM; HiCache writes a prefix back to host only when the tree evicts it.
+The indexer keeps scoring the whole history from GPU -- prefill indexer KV is
+copied once into a private expanded region at admission, and decode-written
+indexer KV lives in pool pages, which are never evicted (only the page-aligned
+prefill prefix is tree-owned, and only tree nodes are evictable).
+
+    prefill      -> KV and indexer written to the same page indices
+    admit        -> copy the prefix's indexer pages into the expanded region,
+                    take a temp device buffer, release the tree lock
+    decode       -> indexer scores through a hybrid page table (expanded page for
+                    an evicted prefix page, the original otherwise); the swap-in
+                    kernel fetches the selected positions HiCache moved to host
+    finish       -> release expanded pages, temp slots, node claims, host locks
+
+Where a position lives is therefore per-position and changes over time -- the
+whole difference from the private-host backing, whose staging makes the host copy
+complete by construction. Two consequences shape everything below:
+
+- **Eviction has to be coordinated.** `req_to_token` carries a `-1` sentinel for
+  an evicted position and `req_to_host_pool` its host row; the tree reports
+  evictions on the scheduler thread, and `_sync_evictions` applies the writes at
+  the one controlled point between two forwards, so no in-flight forward sees a
+  sentinel without its host index.
+- **Admission has to be rationed** before the prefill forward runs; that half
+  lives in `managers/hisparse_hicache_admission.py`.
+
+CUDA-graph safety: every tensor a captured kernel reads is persistent, including
+the host pool's base address -- HiCache attaches its host tier after capture, so
+the address travels through a device tensor rather than a kernel argument.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Dict, List, Optional
+
+import msgspec
+import torch
+
+from sglang.kernels.ops.kvcache.hisparse import load_cache_to_device_buffer_mla
+from sglang.srt.environ import envs
+from sglang.srt.managers.hisparse_hicache_admission import (
+    AdmissionLedger,
+    HiCacheAdmitBudget,
+)
+from sglang.srt.managers.hisparse_protocol import (
+    HiSparseEvictionHooks,
+    HiSparseTokenStats,
+)
+from sglang.srt.managers.schedule_batch import Req
+from sglang.srt.managers.schedule_policy import remaining_max_new
+from sglang.srt.mem_cache.hicache_storage import PoolName
+from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
+from sglang.srt.mem_cache.memory_pool_host import HostPoolGroup
+from sglang.srt.mem_cache.sparsity.factory import (
+    HiSparseBacking,
+    hisparse_indexer_regions,
+)
+from sglang.srt.mem_cache.unified_cache.component_type import ComponentType
+from sglang.srt.mem_cache.unified_radix_cache import UnifiedRadixCache
+from sglang.srt.runtime_context import get_schedule
+from sglang.srt.utils import get_device_module
+
+if TYPE_CHECKING:
+    from sglang.srt.mem_cache.memory_pool import DSATokenToKVPool
+
+device_module = get_device_module()
+
+logger = logging.getLogger(__name__)
+
+# How many times a deferred admission is retried before the request is left to
+# run standard for good. Each attempt evicts for real, so an unbounded retry
+# would keep paying device-to-host traffic for a request the pool has no room
+# for; a couple of tries is enough to cover a write-back that acks late.
+_MAX_ADMISSION_ATTEMPTS = 3
+
+
+class _EvictionEvent(msgspec.Struct):
+    """One node eviction, snapshotted for `_sync_evictions` to apply.
+
+    `sorted_dev` / `sorted_host` are the node's device and host index arrays
+    sorted together, so a request row matches against them with a searchsorted.
+    `sorted_host` is None when the node was dropped without a host copy -- an
+    invariant violation for any position backing an active request, reported as
+    one.
+
+    The node is held under one temporary host lock until the event is applied.
+    `lock_params` replays the acquire-time skip set at release: components without
+    a host_value (MAMBA) skipped the increment, so the decrement must skip them
+    too or their host_lock_ref underflows.
+    """
+
+    sorted_dev: torch.Tensor
+    sorted_host: Optional[torch.Tensor]
+    node: object
+    lock_params: object
+
+
+class _PendingAdmission(msgspec.Struct):
+    """A request whose admission was deferred out of the prefill-result pass."""
+
+    req: Req
+    # Attempts spent so far; each one evicts for real, hence the cap.
+    attempts: int = 0
+
+
+class _AdmittedNodes(msgspec.Struct):
+    """The tree nodes an admitted request holds, released together at finish.
+
+    `matched` is its whole prefix path, claimed at admission so the ledger bills
+    the residency once per node. `host_locks` are the nodes evicted on its behalf
+    afterwards, each with the params to replay at release. Two lists, one
+    lifetime, one dict entry -- the ledger holds the token counts, this holds the
+    objects.
+    """
+
+    matched: tuple
+    host_locks: list = []
+
+
+class _ExpandedIndexerPages:
+    """Free list over the indexer buffer's expanded region.
+
+    Page ids are region-local; the coordinator adds the region offset before
+    writing them into a page table. A plain list is enough: allocation happens
+    once per admitted request, of `tree_len // page_size` pages.
+    """
+
+    def __init__(self, *, num_pages: int, device: str):
+        self._free = list(range(num_pages))
+        self._device = device
+
+    def alloc(self, num_pages: int) -> Optional[torch.Tensor]:
+        if len(self._free) < num_pages:
+            return None
+        pages = self._free[-num_pages:]
+        del self._free[-num_pages:]
+        return torch.tensor(pages, dtype=torch.int32, device=self._device)
+
+    def free(self, pages: torch.Tensor) -> None:
+        self._free.extend(pages.tolist())
+
+    def available(self) -> int:
+        return len(self._free)
+
+
+class HiCacheHiSparseCoordinator:
+    """`HiSparseCoordinator` over the radix tree plus the HiCache host tier.
+
+    Implements `managers/hisparse_protocol.py`. The entry points below the
+    protocol (`on_node_evicted`, `node_backs_active_request`) are the tree cache's
+    hooks; it reaches them through the concrete class after checking `backing`.
+    """
+
+    backing = HiSparseBacking.HICACHE
+
+    def __init__(
+        self,
+        *,
+        req_to_token_pool: ReqToTokenPool,
+        token_to_kv_pool_allocator,
+        top_k: int,
+        device_buffer_size: int,
+        device: str,
+        tp_group,
+        swap_in_block_size: int = 960,
+    ):
+        self.req_to_token_pool = req_to_token_pool
+        self.token_to_kv_pool_allocator = token_to_kv_pool_allocator
+        self.token_to_kv_pool: DSATokenToKVPool = (
+            token_to_kv_pool_allocator.get_kvcache()
+        )
+        self.top_k = top_k
+        self.device = device
+        self.tp_group = tp_group
+        self.tp_world_size = torch.distributed.get_world_size(group=self.tp_group)
+        self.swap_in_block_size = swap_in_block_size
+        # Timing probe: skip the host->device KV bytes to measure the "IO is free"
+        # floor. Produces garbage output; benchmarking only.
+        self.skip_io = envs.SGLANG_DEBUG_HISPARSE_SKIP_IO.get()
+
+        self.page_size = self.token_to_kv_pool.page_size
+        self.layer_num = self.token_to_kv_pool.layer_num
+        self.start_layer = self.token_to_kv_pool.start_layer
+        # The per-request device buffer, in tokens. Whole pages, because it is
+        # allocated from the paged pool; at least top_k, because one decode step
+        # can need every selected position swapped in at once.
+        self.device_buffer_size = device_buffer_size
+        assert (
+            device_buffer_size >= top_k and device_buffer_size % self.page_size == 0
+        ), (
+            f"HiSparse on the HiCache backing needs device_buffer_size "
+            f"({device_buffer_size}) >= top_k ({top_k}) and a multiple of "
+            f"page_size ({self.page_size}): the buffer is allocated as whole "
+            "pages and must hold one step's whole selection."
+        )
+        # The swap-in kernel tracks slots in an int16 LRU order.
+        assert device_buffer_size <= 32767, (
+            f"device_buffer_size ({device_buffer_size}) exceeds the int16 slot "
+            "ordering the swap-in kernel keeps"
+        )
+
+        self._init_kv_views()
+        self._init_request_state()
+        self._init_expanded_indexer_region()
+
+        self.tree_cache = None
+        self._host_kv_cache = None
+        self.decode_producer_stream = None
+        self._eviction_queue: List[_EvictionEvent] = []
+        self._announced_first_eviction = False
+        # req_pool_idx -> admission deferred out of the prefill-result pass.
+        self._pending_admission: Dict[int, _PendingAdmission] = {}
+        # req_pool_idx -> tree nodes an admitted request holds. See _AdmittedNodes.
+        self._req_nodes: Dict[int, _AdmittedNodes] = {}
+        self.ledger = AdmissionLedger(
+            # The ALLOCATOR's size, not the pool's: it is what hands out tokens,
+            # and the two differ under attention DCP (the allocator covers
+            # dcp_size shards of the pool).
+            device_pool_tokens=int(self.token_to_kv_pool_allocator.size),
+            temp_slot_tokens=device_buffer_size,
+            page_size=self.page_size,
+            # -1 when chunked prefill is disabled; the ledger reads that as "no
+            # chunk reserve", which is right -- an unchunked prefill's whole
+            # prompt is charged as pending instead.
+            chunk_tokens=get_schedule().chunked_prefill_size,
+        )
+
+    def _init_kv_views(self) -> None:
+        """Byte views and layout constants the swap-in kernel addresses through.
+
+        KV rows hold mixed content (fp8 payload, scales, rope bytes), so the
+        swap-in copy has to be bit-exact: a uint8 view gives byte-sized
+        addressing without reinterpreting anything.
+        """
+        kv_u8 = [buf.view(torch.uint8) for buf in self.token_to_kv_pool.kv_buffer]
+        self.item_size_bytes = kv_u8[0].stride(0)
+        strides = {buf.stride(0) for buf in kv_u8}
+        assert len(strides) == 1, f"KV layers must share a row stride, got {strides}"
+        # [layer, 2] = the host pool's [base address, row stride in bytes], filled
+        # when the host tier attaches (set_tree_cache). Persistent and read on the
+        # device at launch time: cuda graphs are captured BEFORE attachment, so a
+        # kernel argument would bake in a stale address. One row per layer because
+        # each layer is a separate host allocation; the row's address is fixed at
+        # capture, its contents are not.
+        self._host_binding = torch.zeros(
+            (self.layer_num, 2), dtype=torch.int64, device=self.device
+        )
+
+    def _init_request_state(self) -> None:
+        """Per-request swap-in state, all persistent for cuda-graph replay."""
+        max_num_req_slots = self.req_to_token_pool.req_to_token.shape[0]
+        max_context_len = self.req_to_token_pool.max_context_len
+
+        # The request's temp device buffer: pool rows it owns for swapped-in KV.
+        # int32 because it is the kernel's `device_buffer_locs`; one row for all
+        # layers, since a slot names the same pool row in every layer (the kernel
+        # takes one row stride for this and the residency map below, so the two
+        # must stay the same width).
+        self.req_device_buffer_locs = torch.full(
+            (max_num_req_slots, self.device_buffer_size),
+            -1,
+            dtype=torch.int32,
+            device=self.device,
+        )
+        # Which position each buffer slot currently holds (-1 = empty), per layer:
+        # every layer's indexer selects its own top-k, so residency diverges.
+        self.req_device_buffer_tokens = torch.full(
+            (self.layer_num, max_num_req_slots, self.device_buffer_size),
+            -1,
+            dtype=torch.int32,
+            device=self.device,
+        )
+        # LRU order over the buffer slots, per layer. The kernel rewrites it in
+        # place: evictables at the front, this step's hits at the back.
+        self._lru_init = torch.arange(
+            self.device_buffer_size, dtype=torch.int16, device=self.device
+        )
+        self.lru_slots = (
+            self._lru_init.view(1, 1, -1)
+            .repeat(self.layer_num, max_num_req_slots, 1)
+            .contiguous()
+        )
+        # Host row per (request, position), -1 = no host copy. Same shape, dtype
+        # and sentinel as the private-host backing's table: it is the swap-in
+        # kernel's `host_cache_locs` ABI, not a private choice.
+        self.req_to_host_pool = torch.full(
+            (max_num_req_slots, max_context_len),
+            -1,
+            dtype=torch.int64,
+            device=self.device,
+        )
+        # Pre-allocated swap-in output (cuda-graph safe).
+        self.top_k_device_locs_buffer = torch.full(
+            (max_num_req_slots, self.top_k), -1, dtype=torch.int32, device=self.device
+        )
+        # Number of real (non-padded) requests in the batch, as a device scalar so
+        # padded blocks early-return on replay.
+        self.num_real_reqs = torch.zeros(1, dtype=torch.int32, device=self.device)
+
+    def _init_expanded_indexer_region(self) -> None:
+        """Carve the indexer buffer and set up the per-request page table.
+
+        The buffer covers more tokens than the attention pool holds (see
+        `hisparse_indexer_expansion_ratio`). Its base region is co-addressed with
+        the pool -- a KV page id IS its indexer page id -- and the expanded region
+        is handed out per request, because a page the tree evicts goes back to the
+        allocator and the next request writes over it, indexer rows included.
+        """
+        indexer_bufs = self.token_to_kv_pool.index_k_with_scale_buffer
+        base_pages, expanded_pages = hisparse_indexer_regions(
+            page_size=self.page_size,
+            num_indexer_pages=len(indexer_bufs[0]),
+            device_pool_size=self.token_to_kv_pool.size,
+        )
+        self._indexer_bufs = indexer_bufs
+        # Expanded page ids start where the base region ends.
+        self._indexer_page_offset = base_pages
+        self._indexer_pages = _ExpandedIndexerPages(
+            num_pages=expanded_pages, device=self.device
+        )
+        max_pages_per_req = (
+            self.req_to_token_pool.max_context_len + self.page_size - 1
+        ) // self.page_size
+        # Per-request expanded page per prefix page (-1 = the original page is
+        # still valid).
+        self.req_to_indexer_page = torch.full(
+            (self.req_to_token_pool.req_to_token.shape[0], max_pages_per_req),
+            -1,
+            dtype=torch.int32,
+            device=self.device,
+        )
+        logger.info(
+            "HiSparse: indexer buffer holds %d pages, %d taken by the attention "
+            "pool, %d expanded (%.1f MB/layer)",
+            base_pages + expanded_pages,
+            base_pages,
+            expanded_pages,
+            expanded_pages * indexer_bufs[0][0].nbytes / 1e6,
+        )
+
+    # ------------------------------------------------------------------
+    # Setup / teardown
+    # ------------------------------------------------------------------
+
+    def set_tree_cache(self, tree_cache) -> None:
+        """Attach the tree cache, register the eviction hooks, publish the host
+        pool's address so captured swap-ins can reach it."""
+        self.tree_cache = tree_cache
+        self._host_kv_cache = None
+        if tree_cache is None:
+            return
+
+        assert isinstance(tree_cache, UnifiedRadixCache), (
+            "HiSparse on the HiCache backing needs the unified radix cache (it is "
+            "what carries the host tier and the device-eviction hooks), got "
+            f"{type(tree_cache).__name__}"
+        )
+        tree_cache.set_hisparse_eviction_hooks(
+            HiSparseEvictionHooks(
+                on_device_released=self.on_node_evicted,
+                backs_live_request=self.node_backs_active_request,
+            )
+        )
+        host_pool = tree_cache.cache_controller.mem_pool_host
+        if isinstance(host_pool, HostPoolGroup):
+            host_pool = host_pool.get_pool(PoolName.KV)
+        self._host_kv_cache = host_pool
+        self.ledger.set_host_capacity(int(host_pool.size))
+        self._publish_host_binding(host_pool)
+
+    def _publish_host_binding(self, host_pool) -> None:
+        """Fill the per-layer [base address, row stride] the kernel reads.
+
+        `data_refs` is the host pool's per-layer view of its buffer, which for the
+        page_first layout is a transpose of [token, layer, cell]: its rows are
+        layer_num cells apart, not one. Both the base and that stride have to
+        reach the kernel through device memory, since the graph that reads them
+        was captured before this pool existed.
+        """
+        refs = [ref.view(torch.uint8) for ref in host_pool.data_refs]
+        assert len(refs) >= self.layer_num, (
+            f"host pool exposes {len(refs)} layers, fewer than the device pool's "
+            f"{self.layer_num}"
+        )
+        strides = {ref.stride(0) for ref in refs[: self.layer_num]}
+        assert len(strides) == 1, f"inconsistent host row strides: {strides}"
+        row_bytes = strides.pop()
+        # The kernel copies exactly item_size_bytes at each host row offset, so a
+        # host cell that is not the device row is a silent overread or a partial
+        # write, and a row stride off a cell boundary corrupts every fetch.
+        assert host_pool.token_stride_size == self.item_size_bytes, (
+            f"host KV cell is {host_pool.token_stride_size} bytes but the device "
+            f"row is {self.item_size_bytes}"
+        )
+        assert row_bytes % self.item_size_bytes == 0, (
+            f"host row stride {row_bytes} is not a multiple of the KV cell "
+            f"{self.item_size_bytes}"
+        )
+        self._host_binding.copy_(
+            torch.tensor(
+                [[ref.data_ptr(), row_bytes] for ref in refs[: self.layer_num]],
+                dtype=torch.int64,
+            )
+        )
+        logger.info(
+            "HiSparse: host pool attached, %d layers, row stride %d bytes over a "
+            "%d-byte KV cell",
+            self.layer_num,
+            row_bytes,
+            self.item_size_bytes,
+        )
+
+    def set_decode_producer_stream(self, stream) -> None:
+        self.decode_producer_stream = stream
+
+    def destroy(self) -> None:
+        """Drop the host addresses. HiCache owns and tears down the pool itself;
+        what must not survive it is this coordinator's non-owning pointers, which
+        a late swap-in would otherwise dereference."""
+        self._host_binding.zero_()
+
+    # ------------------------------------------------------------------
+    # Request lifecycle
+    # ------------------------------------------------------------------
+
+    def on_prefill_complete(self, req: Req) -> bool:
+        """Take over the request's prefix, or decline and let it run standard.
+
+        Only the tree-owned page-aligned prefix `[0, cache_protected_len)` can
+        ever be evicted, so only those pages need expanded indexer copies; the
+        unaligned prefill tail and every decode token are request-owned and stay
+        in regular pool pages.
+
+        Declining is a normal outcome (nothing evictable, a quota spent), and it
+        costs nothing: the request keeps its KV in the pool and its tree lock.
+        """
+        req_pool_idx = req.req_pool_idx
+        # At most ONCE per active slot, an invariant the CALLER holds up (last
+        # chunk only, and retraction tears down first). Asserted rather than
+        # trusted because a second call is silent: it takes fresh pages, buffer
+        # and claims, overwrites the tables holding the previous ones, and leaks
+        # them for the server's lifetime.
+        assert req_pool_idx not in self.ledger.active_reqs, (
+            "HiSparse: on_prefill_complete re-entered for an already-admitted "
+            f"request slot {req_pool_idx} (recorded "
+            f"{self.ledger.active_reqs.get(req_pool_idx)}, now tree_len "
+            f"{req.cache_protected_len}). The caller must finalize a slot "
+            "(request_finished / retract_req) before re-admitting it."
+        )
+        tree_len = req.cache_protected_len
+
+        num_pages = tree_len // self.page_size
+        if num_pages == 0:
+            # Nothing page-aligned reached the tree, so nothing is evictable.
+            self.ledger.drop_pending(req.rid)
+            return False
+        if tree_len < self.device_buffer_size:
+            # Net capacity LOSS: the temp buffer is pinned for the request's
+            # lifetime while only tree_len becomes evictable, which would exceed
+            # the scheduler's standard-path reservation (retract/OOM on long
+            # outputs). Such a short prefix gains nothing from eviction anyway.
+            self.ledger.drop_pending(req.rid)
+            return False
+
+        # Eligible, but NOT admitted here: everything below allocates, and this
+        # runs inside the prefill-result pass, whose batched frees hide the pages
+        # an eviction would hand back (measured: `avail 384 -> 384` with a device
+        # leaf and 20480 evictable tokens right there). `admit_pending` does the
+        # allocation once that pass has flushed. The request needs nothing in the
+        # meantime -- it is an ordinary request until then, and the deferral is
+        # resolved before its first decode forward.
+        self._pending_admission[req_pool_idx] = _PendingAdmission(req=req)
+        return True
+
+    def admit_pending(self) -> None:
+        """Admit the deferred requests. See the protocol for why it is separate."""
+        if not self._pending_admission:
+            return
+        # The whole point of deferring. If a future change wraps this call in a
+        # free group the way #33475 wrapped on_prefill_complete, admission would
+        # silently stop working again (concurrency quietly drops to one and
+        # throughput falls back to the dense baseline), so refuse to run instead.
+        assert self.token_to_kv_pool_allocator.is_not_in_free_group, (
+            "HiSparse: admit_pending must run outside the allocator's free "
+            "group; inside one, the pages an eviction frees are parked where "
+            "alloc() cannot see them and every admission fails."
+        )
+        for req_pool_idx, pending in list(self._pending_admission.items()):
+            if self._try_admit(pending.req):
+                self._pending_admission.pop(req_pool_idx, None)
+                continue
+            pending.attempts += 1
+            if pending.attempts >= _MAX_ADMISSION_ATTEMPTS:
+                # Give up: each attempt evicts for real, so retrying forever
+                # would keep paying device-to-host traffic for a request the
+                # pool has no room for.
+                self._cancel_pending(req_pool_idx, rid=pending.req.rid)
+
+    def _try_admit(self, req: Req) -> bool:
+        """One admission attempt; False leaves the request exactly as it was."""
+        req_pool_idx = req.req_pool_idx
+        tree_len = req.cache_protected_len
+        num_pages = tree_len // self.page_size
+
+        # No host gate here: the request is already in the tree, so a match-based
+        # check would compare against its own freshly inserted prefix. Host space
+        # is enforced where it can be acted on -- at prefill admission
+        # (HiCacheAdmitBudget) and at eviction, where the copy-less-drop veto
+        # keeps a full host tier from dropping data an active request needs.
+
+        # Apply pending evictions BEFORE activating this request: queued events
+        # predate it, and its freshly allocated prefill indices may collide with
+        # device indices those events freed.
+        self._sync_evictions()
+
+        pages = self._indexer_pages.alloc(num_pages)
+        if pages is None:
+            logger.warning(
+                "HiSparse: expanded indexer alloc failed for req_pool_idx=%d "
+                "(need %d pages, %d available); running standard",
+                req_pool_idx,
+                num_pages,
+                self._indexer_pages.available(),
+            )
+            return False
+
+        temp_slots, before, after = self._alloc_temp_buffer()
+        if temp_slots is None:
+            # Not an edge case: under load the pool sits at its eviction
+            # low-water mark, so this is the normal retry path. Each number below
+            # separates one cause from another -- avail unchanged with no
+            # evictable leaf means a write-back has not landed yet (the retry
+            # covers it); avail up but short means the eviction under-delivered;
+            # free_group_open means a broken contract.
+            allocator = self.token_to_kv_pool_allocator
+            leaves = self.tree_cache.tree_core.evictable_device_leaves
+            logger.warning(
+                "HiSparse: temp buffer alloc failed for req_pool_idx=%d "
+                "(%d tokens; avail %d -> %d, evictable=%d protected=%d, "
+                "%d device leaves, free_group_open=%s, %d admitted); "
+                "running standard",
+                req_pool_idx,
+                self.device_buffer_size,
+                before,
+                after,
+                self.tree_cache.full_evictable_size(),
+                self.tree_cache.full_protected_size(),
+                len(leaves),
+                not allocator.is_not_in_free_group,
+                len(self.ledger.active_reqs),
+            )
+            self._indexer_pages.free(pages)
+            return False
+
+        self._copy_indexer_to_expanded_pages(
+            req_pool_idx=req_pool_idx, tree_len=tree_len, pages=pages
+        )
+        self._reset_request_state(req_pool_idx)
+        self.req_device_buffer_locs[req_pool_idx] = temp_slots.to(torch.int32)
+
+        # Claim the whole tree-resident prefix: it must keep ONE home (device or
+        # host) for the request's lifetime. Deduped per node, so requests sharing
+        # a prefix bill it once, and a re-hit prefix is billed even though it
+        # added nothing new to the tree.
+        prefix_nodes = self._prefix_path_nodes(req)
+        for node in prefix_nodes:
+            self.ledger.claim_node(node)
+        self._req_nodes[req_pool_idx] = _AdmittedNodes(matched=tuple(prefix_nodes))
+        # After the claims, so the ledger goes straight from billing this prefix
+        # as in-flight to billing it as claimed, never both (activate drops the
+        # pending charge) and never neither.
+        self.ledger.activate(
+            req_pool_idx,
+            tree_len,
+            rid=req.rid,
+            # Device pages this request will still take for its own output, on
+            # the same basis the adder budgets with.
+            decode_reserve=remaining_max_new(req),
+        )
+
+        # Last, once every allocation has succeeded: this is what makes the
+        # prefix evictable, and it cannot be taken back.
+        self._release_lock_for_eviction(req)
+        # The eviction this admission just triggered queued its own events; the
+        # forward must not launch with rows that still point at pages the temp
+        # buffer above may already own.
+        self._sync_evictions()
+        return True
+
+    def _alloc_temp_buffer(self):
+        """Reserve the request's private device buffer out of the regular pool.
+
+        Returns (slots, available before the eviction, available after it): the
+        caller reports the pair on failure, because "the eviction freed nothing"
+        and "the eviction freed some but not enough" are different bugs.
+        """
+        from sglang.srt.mem_cache.common import evict_from_tree_cache
+
+        allocator = self.token_to_kv_pool_allocator
+        before = allocator.available_size()
+        evict_from_tree_cache(self.tree_cache, self.device_buffer_size)
+        after = allocator.available_size()
+        return allocator.alloc(self.device_buffer_size), before, after
+
+    def _copy_indexer_to_expanded_pages(
+        self, *, req_pool_idx: int, tree_len: int, pages: torch.Tensor
+    ) -> None:
+        """Copy the prefix's indexer rows into the request's private pages.
+
+        A KV page id doubles as its base-region indexer page id, so the source is
+        just the prefix's page ids. After this the indexer can score the prefix
+        from GPU whatever the tree does with its attention KV.
+        """
+        token_indices = self.req_to_token_pool.req_to_token[req_pool_idx, :tree_len]
+        orig_pages = (token_indices[:: self.page_size] // self.page_size).long()
+        expanded = (pages + self._indexer_page_offset).long()
+        for indexer_buf in self._indexer_bufs:
+            indexer_buf[expanded] = indexer_buf[orig_pages]
+        self.req_to_indexer_page[req_pool_idx, : pages.numel()] = (
+            pages + self._indexer_page_offset
+        )
+
+    def _reset_request_state(self, req_pool_idx: int) -> None:
+        """Clear whatever the slot's previous tenant left in the swap-in tables.
+
+        The attention backend hands the swap-in the WHOLE batch's
+        req_pool_indices, so a stale residency row would let this request "hit" a
+        slot it does not own and have that top-k position masked.
+        """
+        self.req_device_buffer_tokens[:, req_pool_idx, :] = -1
+        self.lru_slots[:, req_pool_idx, :].copy_(self._lru_init)
+        self.req_to_host_pool[req_pool_idx] = -1
+
+    def request_finished(self, req: Req) -> None:
+        # Apply pending evictions while this request is still active: the
+        # prefix-intact check in cache_finished_req (which runs right after) must
+        # see up-to-date sentinels.
+        self._sync_evictions()
+        # Both stages, in order, because a request can finish in either: a
+        # deferred admission that never ran, and the charge it was budgeted at
+        # prefill entry (released here or it starves host headroom for the
+        # server's lifetime).
+        self._cancel_pending(req.req_pool_idx, rid=req.rid)
+        if req.req_pool_idx in self.ledger.active_reqs:
+            self._release_active(req.req_pool_idx)
+
+    def _cancel_pending(self, req_pool_idx: int, *, rid: str) -> None:
+        """Drop a deferred admission and the prefill-time charge behind it.
+
+        The two are one step everywhere: a request whose admission never
+        completes must hold neither, and the charge is what the adder's ceiling
+        counts.
+        """
+        self._pending_admission.pop(req_pool_idx, None)
+        self.ledger.drop_pending(rid)
+
+    def _release_active(self, req_pool_idx: int) -> None:
+        """Give back everything an admitted request holds, in one place.
+
+        Ordered: the fence first, then accounting, then the device resources the
+        forward may still be reading.
+        """
+        # After the potentially overlapped forward: under overlap scheduling the
+        # batch launched one step ahead still contains this request, and its
+        # kernels read req_to_indexer_page, req_to_host_pool and the temp buffer
+        # freed below. (_sync_evictions in the caller only waits when the eviction
+        # queue is non-empty.)
+        if self.decode_producer_stream is not None:
+            device_module.current_stream().wait_stream(self.decode_producer_stream)
+
+        self.ledger.deactivate(req_pool_idx)
+        nodes = self._req_nodes.pop(req_pool_idx, None)
+        if nodes is not None:
+            # The host locks taken at eviction time on this request's behalf...
+            for node, dec_params in nodes.host_locks:
+                self.tree_cache.dec_host_lock_ref(node.id, dec_params)
+                self.ledger.release_node(node)
+            # ... and the matched-path claims taken at admission.
+            for node in nodes.matched:
+                self.ledger.release_node(node)
+
+        # The whole temp buffer, always fully allocated at admission. The
+        # int32 -> int64 conversion materializes a copy, so overwriting the row
+        # with -1 below cannot reach what free() holds (free() also copies for
+        # itself when deferring into a free group).
+        temp_slots = self.req_device_buffer_locs[req_pool_idx].to(torch.int64)
+        self.token_to_kv_pool_allocator.free(temp_slots)
+        self.req_device_buffer_locs[req_pool_idx] = -1
+        self._reset_request_state(req_pool_idx)
+
+        pages = self.req_to_indexer_page[req_pool_idx]
+        allocated = pages[pages >= 0]
+        if allocated.numel() > 0:
+            self._indexer_pages.free(allocated - self._indexer_page_offset)
+        self.req_to_indexer_page[req_pool_idx] = -1
+
+    def retract_req(self, req: Req) -> None:
+        """Retraction and completion tear down the same state, at every stage:
+        `request_finished` drops a deferred admission and a pending charge before
+        it looks at `active_reqs`, so a request retracted between the deferral and
+        the admission leaves nothing behind either."""
+        self.request_finished(req)
+
+    # ------------------------------------------------------------------
+    # Protocol members with nothing to do on this backing
+    # ------------------------------------------------------------------
+
+    def on_prefill_finished_early(self, req: Req) -> None:
+        """Settle the prefill-time claim of a request that never reaches
+        on_prefill_complete (max_new == 0, or EOS on the first token)."""
+        self._cancel_pending(req.req_pool_idx, rid=req.rid)
+
+    def collect_ready_reqs(self) -> List[Req]:
+        """Nothing is ever waiting here: a deferred request is runnable while it
+        waits, because it runs as an ordinary request until `admit_pending` takes
+        its KV over. Only a staging backing has requests that cannot run yet."""
+        return []
+
+    def has_ongoing_staging(self) -> bool:
+        return False
+
+    def wait_for_pending_backup(self) -> None:
+        """Device-to-host copies belong to HiCache's cache controller, which
+        orders them against the tree operations that depend on them."""
+
+    # ------------------------------------------------------------------
+    # Data plane
+    # ------------------------------------------------------------------
+
+    def indexer_page_table(
+        self, *, req_pool_indices: torch.Tensor, num_pages: int
+    ) -> Optional[torch.Tensor]:
+        """Build the hybrid indexer page table (vectorized, no host syncs).
+
+        Per page slot, keyed on the page's first `req_to_token` entry: `>= 0` ->
+        the original page id (same page in the KV buffer and the indexer's base
+        region); `-1`, an evicted prefix page -> the request's private expanded
+        page, copied at admission and GPU-resident for its lifetime.
+
+        Expanded ids fall outside the KV buffer's page range, so the result is
+        only valid for indexer scoring -- attention resolves its own positions
+        through `swap_in_selected_pages`. Rows of requests this coordinator never
+        admitted come out bit-identical to the standard table, so a mixed batch
+        can substitute the whole thing. None while nothing is admitted.
+        """
+        if not self.ledger.active_reqs:
+            return None
+
+        rows = req_pool_indices.long()
+        firsts = self.req_to_token_pool.req_to_token[
+            rows, : num_pages * self.page_size : self.page_size
+        ]
+        # A strided slice past the row's end silently returns fewer columns, and
+        # the caller writes this table into a fixed-width buffer.
+        assert firsts.shape[1] == num_pages, (
+            f"{num_pages} indexer pages asked for, but req_to_token only covers "
+            f"{firsts.shape[1]} pages of {self.page_size} tokens"
+        )
+        orig_pages = firsts // self.page_size
+        expanded = self.req_to_indexer_page[rows, :num_pages]
+        table = torch.where((firsts < 0) & (expanded >= 0), expanded, orig_pages)
+        # A negative id would read out of bounds: a sentinelled position with no
+        # expanded page is a broken invariant, but not one to chase into the
+        # indexer's address arithmetic.
+        return table.clamp_(min=0).to(torch.int32)
+
+    def translate_page_table(self, page_table: torch.Tensor) -> torch.Tensor:
+        """Identity: attention KV stays in the regular pool, so a logical page id
+        already addresses it, and `req_to_token` is the int32 the sparse kernels
+        want."""
+        return page_table
+
+    def swap_in_selected_pages(
+        self,
+        *,
+        req_pool_indices: torch.Tensor,
+        compressed_seq_lens: torch.Tensor,
+        top_k_result: torch.Tensor,
+        layer_id: int,
+    ) -> torch.Tensor:
+        """Make one layer's selected KV device-resident; return its slot table.
+
+        Three sources per selected position, resolved by the kernel: still in the
+        pool (`req_to_token >= 0`, which covers every position of every request
+        this coordinator did not admit) passes through with no copy; an
+        already-resident temp slot is reused; anything else is DMA'd from host into
+        a slot the kernel evicts by LRU. Only persistent tensors are read, so this
+        is overlap- and graph-safe.
+
+        `compressed_seq_lens` goes unused: residency here is per position, not per
+        length, and the kernel's length-driven shortcuts are compiled out by the
+        pool source.
+        """
+        num_reqs = req_pool_indices.size(0)
+        top_k_device_locs = self.top_k_device_locs_buffer[:num_reqs]
+        local_layer = layer_id - self.start_layer
+        assert 0 <= local_layer < self.layer_num, (
+            f"layer {layer_id} maps to local layer {local_layer}, outside "
+            f"[0, {self.layer_num})"
+        )
+        load_cache_to_device_buffer_mla(
+            top_k_tokens=top_k_result,
+            device_buffer_tokens=self.req_device_buffer_tokens[local_layer],
+            host_cache_locs=self.req_to_host_pool,
+            device_buffer_locs=self.req_device_buffer_locs,
+            # The host source travels through host_binding instead: this pool is
+            # attached after cuda-graph capture, and its rows are not one KV cell
+            # apart under the page_first layout.
+            host_cache=None,
+            device_buffer=self.token_to_kv_pool.kv_buffer[local_layer],
+            top_k_device_locs=top_k_device_locs,
+            req_pool_indices=req_pool_indices,
+            seq_lens=compressed_seq_lens,
+            lru_slots=self.lru_slots[local_layer],
+            item_size_bytes=self.item_size_bytes,
+            num_top_k=self.top_k,
+            hot_buffer_size=self.device_buffer_size,
+            page_size=1,
+            block_size=self.swap_in_block_size,
+            num_real_reqs=self.num_real_reqs,
+            skip_io=self.skip_io,
+            device_locs=self.req_to_token_pool.req_to_token,
+            host_binding=self._host_binding[local_layer],
+        )
+        return top_k_device_locs
+
+    def prepare_decode_batch(
+        self,
+        *,
+        seq_lens: torch.Tensor,
+        out_cache_loc: torch.Tensor,
+        req_pool_indices: torch.Tensor,
+        seq_lens_cpu: torch.Tensor,
+        req_pool_indices_cpu: torch.Tensor,
+    ) -> None:
+        """Apply queued eviction events before the next forward launches.
+
+        Nothing to route into a buffer: decode tokens live in pool pages, which
+        are never evicted. What MUST happen is the eviction sync -- an evicted page
+        goes straight back to the allocator, so the next forward must not launch
+        with a `req_to_token` entry still pointing at it. This is the last
+        controlled point between two forwards, and also the retry point for an
+        admission whose device buffer only frees up once a write-back is acked.
+        """
+        self._sync_evictions()
+        self.admit_pending()
+
+    # ------------------------------------------------------------------
+    # Eviction handling
+    # ------------------------------------------------------------------
+
+    def on_node_evicted(self, node) -> None:
+        """Tree-cache hook: this node's device KV is about to be released.
+
+        Contract the caller owes: device indices still in
+        `component_data[FULL].value`, the host copy (if any) in `.host_value`, and
+        the device indices not yet handed back to the allocator.
+
+        Runs on the scheduler thread and only SNAPSHOTS those arrays -- no GPU
+        writes, so it is safe against an in-flight forward. `_sync_evictions`
+        matches them against request rows later, in FIFO order: a device index
+        freed, reused and evicted again cannot mis-attribute host indices, because
+        the first event already sentinelled the old row positions.
+        """
+        if not self.ledger.active_reqs:
+            return
+
+        cd = node.component_data[ComponentType.FULL]
+        device_values = cd.value
+        if device_values is None or len(device_values) == 0:
+            return
+        device_values = device_values.to(device=self.device, dtype=torch.int64)
+        host_values = cd.host_value
+        if host_values is not None:
+            host_values = host_values.to(device=self.device, dtype=torch.int64)
+
+        sorted_dev, order = torch.sort(device_values)
+        sorted_host = host_values[order] if host_values is not None else None
+
+        # One TEMPORARY host lock keeps host_value alive until the event is
+        # applied. It is taken here and not at admission because under write_back
+        # host_value only exists after the first device eviction, and the lock
+        # silently no-ops without it. _sync_evictions attributes ownership --
+        # requests whose rows actually hold these indices get their own lock, then
+        # this one is dropped -- so an unrelated churn node is never pinned for the
+        # lifetime of a long decode.
+        locked_node = None
+        lock_params = None
+        if sorted_host is not None:
+            lock_params = self.tree_cache.inc_host_lock_ref(node.id).to_dec_params()
+            locked_node = node
+        self._eviction_queue.append(
+            _EvictionEvent(
+                sorted_dev=sorted_dev,
+                sorted_host=sorted_host,
+                node=locked_node,
+                lock_params=lock_params,
+            )
+        )
+
+    def node_backs_active_request(self, node) -> bool:
+        """Tree-cache hook: whether dropping this node would mask live positions.
+
+        The write-back drop fallback (host full, backup failed) asks before
+        dropping a node's KV without a host copy. For a node backing an admitted
+        request that drop is unrecoverable -- the position has no home left --
+        so the tree keeps it on device instead. Rare path, so the active-row
+        concat is rebuilt per call.
+        """
+        active = self.ledger.active_reqs
+        if not active:
+            return False
+        device_values = node.component_data[ComponentType.FULL].value
+        if device_values is None or len(device_values) == 0:
+            return False
+        rows = torch.cat(
+            [
+                self.req_to_token_pool.req_to_token[
+                    req_pool_idx, : state.tree_len
+                ].long()
+                for req_pool_idx, state in active.items()
+            ]
+        )
+        rows = rows[rows >= 0]
+        if rows.numel() == 0:
+            return False
+        rows, _ = torch.sort(rows)
+        values = device_values.to(device=rows.device, dtype=torch.int64)
+        # Sort once, then binary-search the node's values into it. `torch.isin`
+        # reads better and needs no sorted input, but measured 2.3x slower here
+        # (433 us vs 185 us at 4 admitted prefixes against a 512-token node): it
+        # redoes this sort internally, over the larger operand.
+        pos = torch.searchsorted(rows, values).clamp_(max=rows.numel() - 1)
+        return bool((rows[pos] == values).any().item())
+
+    def _sync_evictions(self) -> None:
+        """Apply queued evictions: sentinel `req_to_token`, record the host rows.
+
+        Waits on the forward stream first, so an in-flight forward never observes
+        a sentinel without its host index (or loses a device index it is still
+        reading). Runs before the next forward launches, whose own
+        wait_stream makes these writes visible to it.
+        """
+        if not self._eviction_queue:
+            return
+
+        if self.decode_producer_stream is not None:
+            device_module.current_stream().wait_stream(self.decode_producer_stream)
+
+        # Per (event, request) hit counts, read back in one batch below: a
+        # per-pair .item() would sync once per pair.
+        attributions: List[tuple] = []
+        hit_counts: List[torch.Tensor] = []
+        dropped: List[tuple] = []
+        for event_idx, event in enumerate(self._eviction_queue):
+            num_indices = len(event.sorted_dev)
+            for req_pool_idx, state in self.ledger.active_reqs.items():
+                tree_len = state.tree_len
+                row = self.req_to_token_pool.req_to_token[req_pool_idx, :tree_len]
+                row64 = row.long()
+                pos = torch.searchsorted(event.sorted_dev, row64).clamp_(
+                    max=num_indices - 1
+                )
+                match = (event.sorted_dev[pos] == row64) & (row64 >= 0)
+                if event.sorted_host is not None:
+                    host_row = self.req_to_host_pool[req_pool_idx, :tree_len]
+                    host_row.copy_(torch.where(match, event.sorted_host[pos], host_row))
+                else:
+                    dropped.append((req_pool_idx, match.sum()))
+                row.masked_fill_(match, -1)
+                if event.node is not None:
+                    attributions.append((event_idx, req_pool_idx))
+                    hit_counts.append(match.sum())
+
+        self._report_dropped_without_host(dropped)
+        self._attribute_host_locks(attributions, hit_counts)
+        for event in self._eviction_queue:
+            if event.node is not None:
+                self.tree_cache.dec_host_lock_ref(event.node.id, event.lock_params)
+        self._eviction_queue.clear()
+
+    @staticmethod
+    def _report_dropped_without_host(dropped: List[tuple]) -> None:
+        """Fail loud on a position that ended up with no home at all.
+
+        The admission ceiling plus the copy-less-drop veto are supposed to make
+        this unreachable. Continuing would mask those positions in attention and
+        return silently degraded output, which is worse than a crash: nothing
+        downstream can tell that answer from a good one.
+        """
+        if not dropped:
+            return
+        counts = torch.stack([count for _, count in dropped]).cpu().tolist()
+        for (req_pool_idx, _), count in zip(dropped, counts):
+            if count > 0:
+                raise RuntimeError(
+                    f"HiSparse ACCURACY LOSS: {count} active positions of "
+                    f"req_pool_idx={req_pool_idx} were evicted without a host "
+                    "copy, and would be masked in attention. The admission gate / "
+                    "drop veto invariant is broken."
+                )
+
+    def _attribute_host_locks(
+        self, attributions: List[tuple], hit_counts: List[torch.Tensor]
+    ) -> None:
+        """Give each request its own host lock on the nodes it actually holds.
+
+        One batched readback (on eviction steps only), then a lock per real hit;
+        the events' temporary locks are dropped by the caller right after.
+        """
+        if not hit_counts:
+            return
+        counts = torch.stack(hit_counts).cpu().tolist()
+        for (event_idx, req_pool_idx), hits in zip(attributions, counts):
+            if not hits or req_pool_idx not in self.ledger.active_reqs:
+                continue
+            if not self._announced_first_eviction:
+                # One-shot, because the host source is otherwise unobservable: a
+                # run where the tree never evicted a live prefix exercises only
+                # the pass-through path, and looks exactly like a run where the
+                # swap-in works.
+                self._announced_first_eviction = True
+                logger.info(
+                    "HiSparse: first eviction of an admitted prefix -- %d "
+                    "positions of req_pool_idx=%d are now host-resident, and "
+                    "decode will fetch them back per step.",
+                    hits,
+                    req_pool_idx,
+                )
+            self.ledger.note_evicted_positions(req_pool_idx, hits)
+            node = self._eviction_queue[event_idx].node
+            dec_params = self.tree_cache.inc_host_lock_ref(node.id).to_dec_params()
+            self._req_nodes[req_pool_idx].host_locks.append((node, dec_params))
+            self.ledger.claim_node(node, host_locked=True)
+
+    # ------------------------------------------------------------------
+    # Tree locking
+    # ------------------------------------------------------------------
+
+    def _prefix_path_nodes(self, req: Req) -> list:
+        """The request's tree-resident prefix nodes, leaf first.
+
+        Walks from `req.last_node` -- the node covering its cached prefix after
+        the insert -- and NOT from `req.best_match_node`, which is a match-time id
+        the tree may already have split or freed by the time admission runs.
+        """
+        if self.tree_cache is None or req.last_node is None:
+            return []
+        try:
+            node = self.tree_cache.tree_core.node_by_id(req.last_node)
+        except KeyError:
+            return []
+        nodes = []
+        while node is not None and node.parent is not None:
+            nodes.append(node)
+            node = node.parent
+        return nodes
+
+    def _release_lock_for_eviction(self, req: Req) -> None:
+        """Release the tree lock the insert took, so the prefix can be evicted.
+
+        Host locks are NOT taken in its place: under write_back a node has no
+        host_value until its first device eviction, and the host lock silently
+        no-ops without one. They are taken in `on_node_evicted`, where the host
+        copy is guaranteed live.
+        """
+        if self.tree_cache is None or req.last_node is None:
+            return
+        # The tree's own entry point, not a hand-rolled dec_lock_ref: it also
+        # replays the components the request skipped locking, and releasing one it
+        # never took underflows that component's ref count.
+        self.tree_cache.dec_req_lock(req, skip_swa=req.swa_prefix_lock_released)
+        # The scheduler's own release must not run a second time.
+        req.hisparse_prefix_lock_released = True
+
+    # ------------------------------------------------------------------
+    # Scheduler hooks
+    # ------------------------------------------------------------------
+
+    def admit_budget(self) -> Optional[HiCacheAdmitBudget]:
+        return self.ledger.make_budget(
+            expanded_pages_left=self._indexer_pages.available(),
+            tree_evictable_tokens=(
+                0 if self.tree_cache is None else self.tree_cache.full_evictable_size()
+            ),
+        )
+
+    def get_token_stats(self) -> HiSparseTokenStats:
+        allocator = self.token_to_kv_pool_allocator
+        device_capacity = allocator.size
+        device_tokens = device_capacity - allocator.available_size()
+        host_capacity = 0 if self._host_kv_cache is None else self._host_kv_cache.size
+        host_tokens = (
+            0
+            if self._host_kv_cache is None
+            else host_capacity - self._host_kv_cache.available_size()
+        )
+        return HiSparseTokenStats(
+            device_tokens=device_tokens,
+            device_token_usage=(
+                device_tokens / device_capacity if device_capacity > 0 else 0.0
+            ),
+            host_tokens=host_tokens,
+            host_token_usage=(
+                host_tokens / host_capacity if host_capacity > 0 else 0.0
+            ),
+        )

--- a/python/sglang/srt/managers/hisparse_protocol.py
+++ b/python/sglang/srt/managers/hisparse_protocol.py
@@ -1,0 +1,253 @@
+"""The interface every HiSparse coordinator implements, whatever backs it.
+
+HiSparse keeps the indexer KV GPU-resident over an expanded region, holds a
+small hot attention working set per request, and fetches the rest per decode
+step by top-k swap-in. Only the *logical KV pool* -- where a token's attention
+KV lives while it is not in that hot set -- differs between deployments; see
+`mem_cache/sparsity/factory.py` for the two backings and how one is chosen.
+
+Everything in this module is the part both backings must answer, so scheduler,
+model runner and attention backends can drive HiSparse without knowing which
+one they got. Paths only one backing has (PD-disaggregation direct-to-host,
+DeepSeek V4, shared-index prefetch) deliberately stay off the protocol: they
+key on `coordinator.backing` and talk to the concrete class, so this interface
+does not grow a member with exactly one real implementation.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable, List, NamedTuple, Optional, Protocol
+
+if TYPE_CHECKING:
+    import torch
+
+    from sglang.srt.managers.hisparse_hicache_admission import HiCacheAdmitBudget
+    from sglang.srt.managers.schedule_batch import Req
+    from sglang.srt.mem_cache.sparsity.factory import HiSparseBacking
+    from sglang.srt.mem_cache.unified_cache.unified_tree_core import UnifiedTreeNode
+
+
+class HiSparseTokenStats(NamedTuple):
+    """Device / host occupancy of the logical KV pool, for pool-stats logging."""
+
+    device_tokens: int
+    device_token_usage: float
+    host_tokens: int
+    host_token_usage: float
+
+
+class HiSparseEvictionHooks(NamedTuple):
+    """What the tree owes HiSparse when it moves a node's KV, and nothing more.
+
+    The other direction of the seam from `HiSparseCoordinator` below: what the
+    cache layer calls on HiSparse rather than what the scheduler calls. The tree
+    core only annotates against this, so it imports it under TYPE_CHECKING and
+    nothing in `mem_cache` gains a runtime dependency on `managers`.
+
+    The HiCache HiSparse backing lets the tree evict the attention KV of a request
+    that is still decoding, which no other feature does. Two things therefore have
+    to cross from the tree to the coordinator, and they are two callables rather
+    than a coordinator reference so the tree can only do these two. Registered as
+    one value so the pair cannot be half-installed: with the veto missing, a
+    copy-less drop would strand a live request's positions silently.
+
+    `on_device_released` gets the node whose device KV is about to be freed, while
+    `component_data[FULL].value` still holds its device indices and `.host_value`
+    its host indices (None when it is being dropped without a host copy). It must
+    not write to the GPU: it runs on the scheduler thread, possibly with a forward
+    in flight. `backs_live_request` answers whether a node's device KV is part of a
+    live HiSparse request's prefix.
+
+    The private-host backing registers neither: its staging owns the only copy.
+    """
+
+    on_device_released: Callable[[UnifiedTreeNode], None]
+    backs_live_request: Callable[[UnifiedTreeNode], bool]
+
+
+class HiSparseCoordinator(Protocol):
+    """Owns HiSparse's per-request KV residency for one backing."""
+
+    # ---- identity -----------------------------------------------------
+    backing: HiSparseBacking
+
+    # ---- data plane ---------------------------------------------------
+    # Number of real (non-padded) requests in the batch, as a device scalar the
+    # swap-in kernels read at graph-replay time so padded blocks early-return.
+    num_real_reqs: torch.Tensor
+
+    def indexer_page_table(
+        self, *, req_pool_indices: torch.Tensor, num_pages: int
+    ) -> Optional[torch.Tensor]:
+        """The page table the indexer must score against, or None.
+
+        None means the standard `req_to_token`-derived table is already correct
+        -- true whenever the logical token index space *is* the indexer space.
+        A backing that lets the tree evict attention KV out from under a live
+        request returns a hybrid table instead, resolving evicted prefix pages
+        to the request's private expanded-region indexer pages.
+
+        The result is only valid against the indexer buffer: expanded page ids
+        are outside the attention KV buffer's range. Attention resolves its own
+        positions through `swap_in_selected_pages`.
+        """
+        ...
+
+    def translate_page_table(self, page_table: torch.Tensor) -> torch.Tensor:
+        """Map logical page ids to attention-KV page ids for the sparse kernels.
+
+        Identity for a backing whose logical ids already address the attention
+        pool; the private-host backing resolves its extra indirection here.
+        """
+        ...
+
+    def swap_in_selected_pages(
+        self,
+        *,
+        req_pool_indices: torch.Tensor,
+        compressed_seq_lens: torch.Tensor,
+        top_k_result: torch.Tensor,
+        layer_id: int,
+    ) -> torch.Tensor:
+        """Make one layer's top-k KV device-resident; return its slot table.
+
+        Every returned entry is either an already-resident slot (zero copy) or a
+        slot this call DMAs into; -1 marks a position with no copy anywhere,
+        which the sparse attention kernels treat as masked. `compressed_seq_lens`
+        is in the indexer's compressed space and is unused by backings that
+        derive residency per position instead of per length.
+        """
+        ...
+
+    def prepare_decode_batch(
+        self,
+        *,
+        seq_lens: torch.Tensor,
+        out_cache_loc: torch.Tensor,
+        req_pool_indices: torch.Tensor,
+        seq_lens_cpu: torch.Tensor,
+        req_pool_indices_cpu: torch.Tensor,
+    ) -> None:
+        """The one controlled point between two decode forwards.
+
+        Each backing does its own pre-forward bookkeeping here: routing the new
+        decode token into the hot buffer, or applying queued eviction events
+        before the allocator can hand a freed slot to someone else.
+        """
+        ...
+
+    # ---- request lifecycle --------------------------------------------
+    def on_prefill_complete(self, req: Req) -> bool:
+        """Offer a finished prefill to HiSparse; True when HiSparse takes it.
+
+        Called once per request, after its last chunk and after the request has
+        been inserted into the tree cache, so the prefix it reports is final.
+
+        False means declined -- nothing evictable, prefix too short, a quota
+        exhausted -- and the request runs as an ordinary non-HiSparse request.
+        That is a normal outcome, not an error; a backing that declines for a
+        reason worth acting on warns for itself.
+
+        True carries no promise about *when*: a backing may still be copying the
+        KV out (the scheduler keeps such a request out of the running batch until
+        `collect_ready_reqs()` returns it) or may not have taken it over yet, in
+        which case it stays an ordinary request until `admit_pending()` runs.
+        Both are invisible here on purpose -- the scheduler drives them through
+        `collect_ready_reqs` / `has_ongoing_staging` and `admit_pending`, so a
+        richer return value would be a second description of the same state,
+        free to drift from the one the scheduler acts on.
+        """
+        ...
+
+    def on_prefill_finished_early(self, req: Req) -> None:
+        """Release what a request reserved when it finishes *during* prefill.
+
+        `max_new == 0`, or EOS/stop on the first token: the request was budgeted
+        at prefill admission but never reaches `on_prefill_complete` or
+        `request_finished`, so a backing that charged it anything has to settle
+        up here or leak that charge for the server's lifetime. A backing that
+        holds nothing until admission does nothing here.
+        """
+        ...
+
+    def admit_pending(self) -> None:
+        """Finish admitting the requests that `on_prefill_complete` deferred.
+
+        Called once per prefill-result pass, AFTER that pass has flushed its
+        batched frees -- which is the whole reason a backing defers. Admission
+        allocates from the device pool and may have to evict to get there, and
+        inside the result pass the pages an eviction frees are parked in the
+        allocator's free group, where neither `available_size()` nor `alloc()`
+        can see them. It also has to run before the next scheduling round, or the
+        next prefill takes the pages first.
+
+        No-op for a backing that admits synchronously.
+        """
+        ...
+
+    def collect_ready_reqs(self) -> List[Req]:
+        """Requests whose staging copy has landed and that may now run.
+
+        Empty for a backing that admits synchronously.
+        """
+        ...
+
+    def has_ongoing_staging(self) -> bool:
+        """True while any request is still waiting on a staging copy.
+
+        The scheduler must not go idle while this holds. False for a backing
+        that admits synchronously.
+        """
+        ...
+
+    def request_finished(self, req: Req) -> None:
+        """Release everything the request holds (slots, host space, claims)."""
+        ...
+
+    def retract_req(self, req: Req) -> None:
+        """Undo admission for a retracted request, at whatever stage it is in."""
+        ...
+
+    # ---- scheduler hooks ----------------------------------------------
+    def admit_budget(self) -> Optional[HiCacheAdmitBudget]:
+        """This round's admission budget, or None when the backing has no quota.
+
+        None rather than a permissive stub, so the scheduler's fast path stays
+        free of per-candidate calls. Takes no pool size: a backing that rations
+        knows its own, and passing one in let the round's feasibility threshold
+        be computed against a different number than the ceiling it is compared
+        with.
+
+        The one member typed against a backing's own class, against the rule
+        above: only the HiCache backing rations, and its budget is two methods a
+        second Protocol would restate. If a second rationing backing appears,
+        that Protocol is what to reintroduce.
+        """
+        ...
+
+    def wait_for_pending_backup(self) -> None:
+        """Block until in-flight device-to-host copies are visible on this stream."""
+        ...
+
+    def get_token_stats(self) -> HiSparseTokenStats:
+        """Device / host occupancy for pool-stats logging."""
+        ...
+
+    # ---- setup / teardown ---------------------------------------------
+    def set_decode_producer_stream(self, stream) -> None:
+        """Register the forward stream that produces decode KV.
+
+        Release and backup paths order themselves after it, so a freed slot is
+        never reused while an overlapped forward is still reading it.
+        """
+        ...
+
+    def set_tree_cache(self, tree_cache) -> None:
+        """Attach the tree cache. No-op for a backing that runs without one."""
+        ...
+
+    def destroy(self) -> None:
+        """Release whatever must not outlive the coordinator (in-flight
+        transfers, host registrations, non-owning pointers into pools torn
+        down by their real owner)."""
+        ...

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -135,7 +135,7 @@ if TYPE_CHECKING:
     from typing import Any, Dict
 
     from sglang.srt.configs.model_config import ModelConfig
-    from sglang.srt.managers.hisparse_coordinator import HiSparseCoordinator
+    from sglang.srt.managers.hisparse_protocol import HiSparseCoordinator
     from sglang.srt.managers.scheduler_components.metrics_reporter import PrefillStats
     from sglang.srt.session.session_controller import Session
     from sglang.srt.speculative.spec_info import SpecInput, SpeculativeAlgorithm
@@ -1196,6 +1196,8 @@ class Req(ReqDllmMixin):
 
         # For hisparse
         self.hisparse_staging = False
+        # The HiCache backing releases the tree lock at admission, not at finish.
+        self.hisparse_prefix_lock_released = False
 
     @property
     def seqlen(self) -> int:
@@ -1678,6 +1680,7 @@ class Req(ReqDllmMixin):
         self.num_matched_prefix_tokens = 0
         self.swa_uuid_for_lock = None
         self.swa_prefix_lock_released = False
+        self.hisparse_prefix_lock_released = False
         self.skip_lock_node_ids = {}
         self.extend_range = None
         self.dllm_initialized = False
@@ -3082,12 +3085,12 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         self.seq_lens_sum = None
 
         if self.hisparse_coordinator is not None:
-            self.hisparse_coordinator.map_last_loc_to_buffer(
-                self.seq_lens,
-                self.out_cache_loc,
-                self.req_pool_indices,
-                self.seq_lens_cpu,
-                self.req_pool_indices_cpu,
+            self.hisparse_coordinator.prepare_decode_batch(
+                seq_lens=self.seq_lens,
+                out_cache_loc=self.out_cache_loc,
+                req_pool_indices=self.req_pool_indices,
+                seq_lens_cpu=self.seq_lens_cpu,
+                req_pool_indices_cpu=self.req_pool_indices_cpu,
             )
 
         if mamba_extra_buffer_enabled():

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -64,6 +64,7 @@ from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey, TreeNode
 from sglang.srt.server_args import ServerArgs
 
 if TYPE_CHECKING:
+    from sglang.srt.managers.hisparse_hicache_admission import HiCacheAdmitBudget
     from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
 
 # Clip the estimation of max_new_tokens for the request whose max_new_tokens is very large.
@@ -73,6 +74,23 @@ if TYPE_CHECKING:
 CLIP_MAX_NEW_TOKENS = int(
     os.environ.get("SGLANG_CLIP_MAX_NEW_TOKENS_ESTIMATION", "4096")
 )
+
+
+def remaining_max_new(req: Req) -> int:
+    """The request's remaining output budget, clipped.
+
+    The one basis every HiSparse admission decision uses -- probe, quota commit,
+    and the coordinator's decode reserve -- because `_infeasible()` is a
+    threshold on `total_seq_len + temp_buffer + max_new`, so two of them on
+    different bases can land on opposite sides of it. Differs from
+    `min(max_new_tokens, CLIP_MAX_NEW_TOKENS)`, the scheduler's own reservation
+    basis, only for a request re-prefilled after retraction.
+    """
+    return min(
+        max(req.sampling_params.max_new_tokens - len(req.output_ids), 0),
+        CLIP_MAX_NEW_TOKENS,
+    )
+
 
 # Threshold for in-batch prefix cache.
 # If a request has a matched prefix length (against existing cache) less than this value,
@@ -527,6 +545,7 @@ class PrefillAdder:
         dllm_config: Optional[DllmConfig] = None,
         waiting_queue_len: int = 0,
         prefill_tile_block_m: int = 64,
+        hisparse_budget: Optional[HiCacheAdmitBudget] = None,
     ):
         self.page_size = page_size
         self.prefill_tile_block_m = prefill_tile_block_m
@@ -534,6 +553,9 @@ class PrefillAdder:
         self.token_to_kv_pool_allocator = token_to_kv_pool_allocator
         self.running_batch = running_batch
         self.new_token_ratio = new_token_ratio
+        # Per-round quota snapshot from the HiSparse coordinator, which owns all
+        # of the logic. None when HiSparse is off or its backing rations nothing.
+        self._hisparse_budget = hisparse_budget
         self.rem_input_tokens = rem_input_tokens - num_mixed_decode_tokens
         self.rem_chunk_tokens = rem_chunk_tokens
         self.dllm_config = dllm_config
@@ -545,6 +567,12 @@ class PrefillAdder:
             self.rem_chunk_tokens -= num_mixed_decode_tokens
         self.rem_total_token_offset = num_mixed_decode_tokens
         self.cur_rem_token_offset = num_mixed_decode_tokens
+        # Tokens that count as evictable but cannot be reclaimed right now (a
+        # write_back demotion needs host space, and HiSparse vetoes the copy-less
+        # drop for a live request); budgeting against them ends in a hard prefill
+        # allocation failure.
+        if hisparse_budget is not None:
+            self.rem_total_token_offset += hisparse_budget.device_evictable_overhang
 
         self.req_states = None
         self.can_run_list = []
@@ -835,6 +863,42 @@ class PrefillAdder:
             return self._mamba_slot_cost
         return 0
 
+    def _future_tokens(self, req: Req, *, commit: bool, standard: int) -> int:
+        """Device tokens to reserve for this request's decode tail.
+
+        `standard` is what the scheduler reserves on its own. HiSparse admission
+        replaces it with an admission-aware count (an admitted request's prefix
+        leaves the pool), and commit=True also draws down the round's quota. Its
+        basis is `remaining_max_new` on both calls.
+        """
+        if self._hisparse_budget is None:
+            return standard
+        return self._hisparse_budget.future_tokens(
+            len(req.full_untruncated_fill_ids),
+            remaining_max_new(req),
+            commit=commit,
+            req=req,
+        )
+
+    def _hisparse_defers(self, req: Req, max_new: int) -> bool:
+        """Whether to keep a candidate queued until HiSparse can admit it.
+
+        Running it standard would pin its whole prefix on device for its lifetime
+        and starve the admitted requests of eviction headroom, so it waits for
+        quota (batch_is_full resets every pass, so it is retried) -- unless
+        nothing else is running, where standard is the progress guarantee (e.g. a
+        prompt larger than the whole expanded region).
+        """
+        if self._hisparse_budget is None:
+            return False
+        if not self._hisparse_budget.admission_exhausted(
+            len(req.full_untruncated_fill_ids), max_new
+        ):
+            return False
+        return len(self.can_run_list) > 0 or (
+            self.running_batch is not None and self.running_batch.batch_size() > 0
+        )
+
     def ceil_paged_tokens(self, tokens: int) -> int:
         return -(-tokens // self.page_size) * self.page_size
 
@@ -1041,7 +1105,14 @@ class PrefillAdder:
             0,
             req.extend_range.length,
             (
-                min(req.sampling_params.max_new_tokens, CLIP_MAX_NEW_TOKENS)
+                # Final chunk: commits the round's quota like the non-chunked path.
+                self._future_tokens(
+                    req,
+                    commit=True,
+                    standard=min(
+                        req.sampling_params.max_new_tokens, CLIP_MAX_NEW_TOKENS
+                    ),
+                )
                 if not truncated
                 else 0
             ),
@@ -1223,14 +1294,14 @@ class PrefillAdder:
         # Reserve page_size for page-alignment overhead: the paged allocator may
         # consume one extra page per request (see alloc_extend), which
         # _update_prefill_budget also deducts.
-        max_new = min(
-            max(req.sampling_params.max_new_tokens - len(req.output_ids), 0),
-            CLIP_MAX_NEW_TOKENS,
-        )
+        max_new = remaining_max_new(req)
         cand_extend_input_len = len(req.full_untruncated_fill_ids) - len(
             req.prefix_indices
         )
-        total_tokens = cand_extend_input_len + max_new + self.page_size
+        cand_future = self._future_tokens(req, commit=False, standard=max_new)
+        if self._hisparse_defers(req, max_new):
+            return AddReqResult.OTHER
+        total_tokens = cand_extend_input_len + cand_future + self.page_size
         # Shared Mamba pool: fold the new mamba state's shared-gap cost into
         # `total_tokens` so both `rem_total_tokens` gates reflect the joint budget.
         total_tokens += self._mamba_gap_budget_for_req(req)
@@ -1374,9 +1445,14 @@ class PrefillAdder:
                 self._update_prefill_budget(
                     prefix_len,
                     input_tokens,
-                    min(
-                        req.sampling_params.max_new_tokens,
-                        CLIP_MAX_NEW_TOKENS,
+                    # Commits the round's quota; the cand_future probe above only read it.
+                    self._future_tokens(
+                        req,
+                        commit=True,
+                        standard=min(
+                            req.sampling_params.max_new_tokens,
+                            CLIP_MAX_NEW_TOKENS,
+                        ),
                     ),
                     req.retracted_stain,
                     mamba_gap_reserve=self._mamba_gap_budget_for_req(req),

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -111,7 +111,7 @@ from sglang.srt.layers.quantization.unquant import initialize_bf16_gemm_config
 from sglang.srt.lora.lora_drainer import LoRADrainer
 from sglang.srt.lora.lora_overlap_loader import LoRAOverlapLoader
 from sglang.srt.managers.disagg_service import maybe_create_ascend_config_store
-from sglang.srt.managers.hisparse_coordinator import HiSparseCoordinator
+from sglang.srt.managers.hisparse_protocol import HiSparseCoordinator
 from sglang.srt.managers.io_struct import (
     AbortReq,
     ActiveRanksOutput,
@@ -274,6 +274,7 @@ from sglang.srt.mem_cache.common import (
     release_kv_cache,
     retraction_discard,
 )
+from sglang.srt.mem_cache.sparsity import HiSparseBacking
 from sglang.srt.model_executor.forward_batch_info import PPProxyTensors
 from sglang.srt.model_loader.utils import get_resolved_model_impl
 from sglang.srt.multiplex.multiplexing_mixin import SchedulerMultiplexMixin
@@ -1131,9 +1132,11 @@ class Scheduler(
         if not self.enable_hisparse:
             return
 
-        # Coordinator was created inside ModelRunner.initialize() before CUDA graph capture.
+        # Coordinator was created inside ModelRunner.initialize() before CUDA graph
+        # capture, for whichever backing the cache configuration resolved to.
         self.hisparse_coordinator = self.tp_worker.model_runner.hisparse_coordinator
         self.hisparse_coordinator.set_decode_producer_stream(self.forward_stream)
+        self.hisparse_coordinator.set_tree_cache(self.tree_cache)
 
     def init_running_status(self):
         # Set by the ShutdownReq handler to break the event loop for graceful shutdown.
@@ -3076,7 +3079,17 @@ class Scheduler(
             if self.chunked_req.extend_range.end > len(self.chunked_req.prefix_indices):
                 self.stash_chunked_request(self.chunked_req)
 
-        # HiSparse has its own prefill-to-decode transition; skip last_batch merge.
+        # A HiSparse backing that admits ASYNCHRONOUSLY brings its own
+        # prefill-to-decode transition: the request may not decode until its
+        # staging copy has landed, so it joins the running batch through
+        # collect_ready_reqs() and the standard last_batch merge below must not
+        # also run. A backing that admits synchronously (nothing is ever
+        # collectable) uses the standard merge -- skipping it there would drop
+        # every finished prefill on the floor.
+        hisparse_defers_prefill_merge = (
+            self.enable_hisparse
+            and self.hisparse_coordinator.backing is HiSparseBacking.PRIVATE_HOST
+        )
         if self.enable_hisparse:
             ready_reqs = self.hisparse_coordinator.collect_ready_reqs()
             if len(ready_reqs) > 0:
@@ -3085,12 +3098,11 @@ class Scheduler(
                     running_batch = new_batch
                 else:
                     running_batch.merge_batch(new_batch)
-                running_batch.hisparse_coordinator = self.hisparse_coordinator
             # Reset batch_is_full so the scheduler can schedule more prefills.
             running_batch.batch_is_full = False
 
         if (
-            not self.enable_hisparse
+            not hisparse_defers_prefill_merge
             and last_batch
             and last_batch.forward_mode.is_extend()
         ):
@@ -3115,6 +3127,12 @@ class Scheduler(
                 else:
                     # Merge running_batch with prefill batch
                     running_batch.merge_batch(last_batch)
+
+        if self.enable_hisparse:
+            # After every merge above, whichever batch object survived them: the
+            # decode path reaches HiSparse through the batch (pre-forward hook,
+            # request release), so a batch without it silently skips both.
+            running_batch.hisparse_coordinator = self.hisparse_coordinator
 
         # For prefill-only batch, filter out finished requests since they
         # won't go through the decode step. This keeps running_batch accurate
@@ -3178,6 +3196,18 @@ class Scheduler(
         res = get_parallel().pp_max_micro_batch_size - running_bs
         res = min(res, self.req_to_token_pool.available_size())
         return res
+
+    def _hisparse_admit_budget(self):
+        """This prefill round's HiSparse admission quotas, or None.
+
+        None when HiSparse is off, and also when its backing rations nothing (the
+        private-host one reserves its capacity at prefill entry instead), which
+        keeps the adder's per-candidate path free of calls that would always
+        answer the same.
+        """
+        if not self.enable_hisparse:
+            return None
+        return self.hisparse_coordinator.admit_budget()
 
     def get_new_batch_prefill(self, running_batch: ScheduleBatch) -> NextBatchPlan:
         prefill_delayer_single_pass = None
@@ -3296,6 +3326,7 @@ class Scheduler(
             dllm_config=self.dllm_config,
             waiting_queue_len=len(self.waiting_queue),
             prefill_tile_block_m=prefill_tile_block_m,
+            hisparse_budget=self._hisparse_admit_budget(),
         )
 
         if self.chunked_req is not None:

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
     from sglang.srt.disaggregation.decode_kvcache_offload_manager import (
         DecodeKVCacheOffloadManager,
     )
-    from sglang.srt.managers.hisparse_coordinator import HiSparseCoordinator
+    from sglang.srt.managers.hisparse_protocol import HiSparseCoordinator
     from sglang.srt.managers.scheduler_components.logprob_result_processor import (
         SchedulerLogprobResultProcessor,
     )
@@ -274,12 +274,23 @@ class SchedulerBatchResultProcessor:
                     if req.finished():
                         self._maybe_collect_routed_experts(req)
                         self._maybe_collect_indexer_topk(req)
+                        if get_memory().enable_hisparse:
+                            self.hisparse_coordinator.on_prefill_finished_early(req)
                         release_kv_cache(req, self.tree_cache)
                         req.time_stats.set_completion_time()
                     elif not batch.decoding_reqs or req not in batch.decoding_reqs:
                         maybe_cache_unfinished_req(req, self.tree_cache)
                         if get_memory().enable_hisparse:
-                            self.hisparse_coordinator.admit_request_into_staging(req)
+                            if not self.hisparse_coordinator.on_prefill_complete(req):
+                                # Routine on a backing that rations admission (a
+                                # short prefix gains nothing from eviction); the
+                                # coordinator warns for the declines that are not.
+                                logger.debug(
+                                    "HiSparse declined req %s (%s backing); it "
+                                    "will run as a standard request.",
+                                    req.rid,
+                                    self.hisparse_coordinator.backing,
+                                )
 
                     self._maybe_collect_customized_info(i, req, logits_output)
 
@@ -363,6 +374,13 @@ class SchedulerBatchResultProcessor:
                     req.time_stats.set_last_chunked_prefill_finish_time()
 
         self.token_to_kv_pool_allocator.free_group_end()
+        if get_memory().enable_hisparse:
+            # After the free group, deliberately: a backing that has to allocate
+            # (and evict) to take a request over cannot do it above, where this
+            # pass parks its frees out of the allocator's sight. Before the next
+            # scheduling round, also deliberately: otherwise the next prefill
+            # takes the pages the eviction just freed.
+            self.hisparse_coordinator.admit_pending()
         self.output_streamer.stream_output(
             batch.reqs, batch.return_logprob, skip_stream_req
         )

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -1311,14 +1311,34 @@ class KVCacheConfigurator:
             dsa_cp_layer_shard_rank,
             dsa_cp_layer_shard_size,
         ) = get_glm_dsa_cp_layer_shard_info(self)
-        pool_kwargs = {}
-        if get_memory().enable_hisparse:
-            PoolCls = HiSparseDSATokenToKVPool
-            from sglang.srt.mem_cache.sparsity import parse_hisparse_config
+        from sglang.srt.mem_cache.sparsity import (
+            HiSparseBacking,
+            hisparse_backing,
+            hisparse_indexer_expansion_ratio,
+        )
 
-            pool_kwargs["host_to_device_ratio"] = parse_hisparse_config(
-                self.server_args
-            ).host_to_device_ratio
+        pool_kwargs = {}
+        backing = hisparse_backing(self.server_args)
+        if backing is HiSparseBacking.PRIVATE_HOST:
+            # The attention KV pool becomes a small hot working set and the
+            # logical token space is the (expanded) indexer space, addressed
+            # through the pool's own full -> device index mapping.
+            PoolCls = HiSparseDSATokenToKVPool
+            pool_kwargs["host_to_device_ratio"] = int(
+                hisparse_indexer_expansion_ratio(self.server_args)
+            )
+        elif backing is HiSparseBacking.HICACHE:
+            # HiCache backing leaves attention KV in the regular radix-owned
+            # pool, so the pool class stays standard; only the indexer region
+            # grows, so the indexer can still score a prefix whose attention KV
+            # was evicted to host. IndexKeyCache rounds the size up to whole
+            # pages itself; P2's unit geometry derives the expanded region's
+            # offset from the resulting page count.
+            PoolCls = DSATokenToKVPool
+            pool_kwargs["index_buf_size"] = int(
+                hisparse_indexer_expansion_ratio(self.server_args)
+                * max_total_num_tokens
+            )
         elif dsa_cp_layer_shard_rank is not None:
             # DSA cache layer split: shard KV/indexer layers across CP ranks.
             from sglang.srt.mem_cache.dsa_cache_layer_split import (
@@ -1612,6 +1632,11 @@ class KVCacheConfigurator:
         req_to_token_pool: ReqToTokenPool,
         token_to_kv_pool_allocator: Optional[BaseTokenToKVPoolAllocator],
     ) -> BaseTokenToKVPoolAllocator:
+        from sglang.srt.mem_cache.sparsity import HiSparseBacking, hisparse_backing
+
+        hisparse_private_host = (
+            hisparse_backing(self.server_args) is HiSparseBacking.PRIVATE_HOST
+        )
         # Initialize token_to_kv_pool_allocator
         need_sort = get_disagg().disaggregation_mode in ("decode", "prefill")
         if token_to_kv_pool_allocator is None:
@@ -1684,7 +1709,10 @@ class KVCacheConfigurator:
                         need_sort=need_sort,
                     )
                 else:
-                    if get_memory().enable_hisparse:
+                    # Only the private-host backing splits the device pool into a
+                    # per-request hot buffer; the HiCache backing leaves the pool
+                    # radix-owned, so it takes the standard allocator below.
+                    if hisparse_private_host:
                         from sglang.srt.mem_cache.sparsity import (
                             parse_hisparse_config,
                         )
@@ -1720,7 +1748,9 @@ class KVCacheConfigurator:
                             need_sort=need_sort,
                         )
 
-            if get_memory().enable_hisparse and is_dsv4_model:
+            # DeepSeek V4 HiSparse is private-host only (validation rejects it on
+            # the HiCache backing), so this wrap keys on the backing too.
+            if hisparse_private_host and is_dsv4_model:
                 assert self.is_hybrid_swa, "DeepSeek V4 HiSparse requires SWA mode."
                 token_to_kv_pool_allocator = DeepSeekV4HiSparseTokenToKVPoolAllocator(
                     token_to_kv_pool_allocator

--- a/python/sglang/srt/mem_cache/sparsity/__init__.py
+++ b/python/sglang/srt/mem_cache/sparsity/__init__.py
@@ -7,10 +7,17 @@ from sglang.srt.mem_cache.sparsity.algorithms import (
 from sglang.srt.mem_cache.sparsity.backend import BackendAdaptor, FlashAttentionAdaptor
 from sglang.srt.mem_cache.sparsity.core import SparseConfig, SparseCoordinator
 from sglang.srt.mem_cache.sparsity.factory import (
+    HiSparseBacking,
+    create_hisparse_coordinator,
     create_sparse_coordinator,
     get_sparse_coordinator,
+    hisparse_backing,
+    hisparse_indexer_expansion_ratio,
+    hisparse_indexer_regions,
+    hisparse_indexer_top_k,
     parse_hisparse_config,
     register_sparse_coordinator,
+    resolve_hisparse_backing,
 )
 
 __all__ = [
@@ -20,10 +27,17 @@ __all__ = [
     "DeepSeekDSAAlgorithm",
     "BackendAdaptor",
     "FlashAttentionAdaptor",
+    "HiSparseBacking",
     "SparseConfig",
     "SparseCoordinator",
+    "create_hisparse_coordinator",
     "create_sparse_coordinator",
     "get_sparse_coordinator",
+    "hisparse_backing",
+    "hisparse_indexer_expansion_ratio",
+    "hisparse_indexer_regions",
+    "hisparse_indexer_top_k",
     "parse_hisparse_config",
     "register_sparse_coordinator",
+    "resolve_hisparse_backing",
 ]

--- a/python/sglang/srt/mem_cache/sparsity/factory.py
+++ b/python/sglang/srt/mem_cache/sparsity/factory.py
@@ -1,8 +1,12 @@
 import json
 import logging
-from typing import Optional
+from enum import Enum
+from typing import TYPE_CHECKING, Optional
 
 import torch
+
+if TYPE_CHECKING:
+    from sglang.srt.managers.hisparse_protocol import HiSparseCoordinator
 
 from sglang.srt.mem_cache.sparsity.algorithms.base_algorithm import BaseSparseAlgorithm
 from sglang.srt.mem_cache.sparsity.algorithms.deepseek_dsa import DeepSeekDSAAlgorithm
@@ -17,6 +21,92 @@ from sglang.srt.mem_cache.sparsity.core.sparse_coordinator import (
 )
 
 logger = logging.getLogger(__name__)
+
+# The two documented ways to run HiSparse, quoted back at the user whenever the
+# cache configuration matches neither.
+_PRIVATE_HOST_RECIPE = "--enable-hisparse --disable-radix-cache"
+_HICACHE_RECIPE = (
+    "--enable-hisparse --enable-hierarchical-cache --hicache-write-policy write_back"
+)
+
+
+class HiSparseBacking(str, Enum):
+    """The logical KV pool that backs HiSparse's swapped-out attention KV.
+
+    HiSparse keeps the indexer KV GPU-resident over an expanded region and holds
+    only a small hot attention working set per request; everything else is
+    fetched per decode step by top-k swap-in. What differs between deployments is
+    *where a token's attention KV lives when it is not in that hot working set*:
+
+    - `PRIVATE_HOST`: the coordinator owns a private pinned host pool and stages
+      a request's whole prefix into it at admission, so the host copy is complete
+      by construction and no eviction protocol is needed. The regular GPU pool is
+      bypassed, and the radix cache must be off (there is nothing to share).
+    - `HICACHE`: the radix tree plus the HiCache host tier own the KV. Attention
+      KV stays in the regular GPU pool (full prefix reuse, hot KV kept in HBM)
+      and is written back to host only under memory pressure, so host residency
+      changes over time and eviction has to be coordinated.
+
+    The backing is a startup decision resolved from the cache configuration
+    rather than from a flag of its own -- `--enable-hisparse` is the only switch
+    users write. It lives here, below `managers/`, because its consumers sit on
+    both sides of that line: pool construction and the capacity model read it to
+    size memory, and the coordinator factory reads it to pick an implementation.
+    """
+
+    PRIVATE_HOST = "private_host"
+    HICACHE = "hicache"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+def resolve_hisparse_backing(
+    *,
+    enable_hisparse: bool,
+    disable_radix_cache: bool,
+    enable_hierarchical_cache: bool,
+    hicache_write_policy: str,
+) -> Optional[HiSparseBacking]:
+    """Resolve the HiSparse backing, or None when HiSparse is off.
+
+    Raises ValueError on a cache configuration that HiSparse cannot back, with
+    both legal recipes in the message. Pure: callers include server-args
+    validation, the KV cache / pool configurators and the coordinator factory,
+    and they must all agree, so this is the single place the rule is written
+    down. `hisparse_backing` below is the same rule for a caller holding a
+    `server_args`.
+    """
+    if not enable_hisparse:
+        return None
+
+    if disable_radix_cache:
+        # No tree, so nothing can evict KV to host on demand: the coordinator
+        # stages each prefix into its own host pool instead.
+        return HiSparseBacking.PRIVATE_HOST
+
+    if not enable_hierarchical_cache:
+        raise ValueError(
+            "--enable-hisparse with the radix cache enabled requires "
+            "--enable-hierarchical-cache: with a radix tree but no host tier, "
+            "evicted attention KV has nowhere to go. Run either "
+            f"'{_HICACHE_RECIPE}' (HiCache backs the evicted KV, prefixes are "
+            f"shared) or '{_PRIVATE_HOST_RECIPE}' (private host pool, no prefix "
+            "reuse)."
+        )
+
+    if hicache_write_policy != "write_back":
+        raise ValueError(
+            "--enable-hisparse with hierarchical cache requires "
+            "--hicache-write-policy write_back (got "
+            f"'{hicache_write_policy}'): HiSparse reads evicted attention KV "
+            "back from the host tier, which only holds a copy of every evicted "
+            f"page under write_back. Run '{_HICACHE_RECIPE}', or "
+            f"'{_PRIVATE_HOST_RECIPE}' for the private-host backing."
+        )
+
+    return HiSparseBacking.HICACHE
+
 
 _global_sparse_coordinator: Optional[SparseCoordinator] = None
 
@@ -116,6 +206,99 @@ def parse_hisparse_config(server_args) -> SparseConfig:
     return _parse_sparse_config(server_args)
 
 
+def hisparse_backing(server_args) -> Optional[HiSparseBacking]:
+    """Which logical KV pool backs HiSparse for this configuration (None if off).
+
+    The one resolution entry point for code holding a `server_args`: startup
+    validation, the pool / KV cache configurators and the coordinator factory
+    all go through here so they cannot disagree. Runtime consumers read
+    `coordinator.backing` instead of re-resolving.
+    """
+    return resolve_hisparse_backing(
+        enable_hisparse=server_args.enable_hisparse,
+        disable_radix_cache=server_args.disable_radix_cache,
+        enable_hierarchical_cache=server_args.enable_hierarchical_cache,
+        hicache_write_policy=server_args.hicache_write_policy,
+    )
+
+
+def _indexer_top_k(*, config, model_config) -> int:
+    """`hisparse_indexer_top_k` for a caller that already parsed the config."""
+    # HF configs are dynamic and only DSA checkpoints carry index_topk, so its
+    # absence is a fact about the model, not a missing attribute on our own type.
+    return getattr(model_config.hf_text_config, "index_topk", config.top_k)
+
+
+def hisparse_indexer_top_k(*, server_args, model_config) -> int:
+    """The operative indexer top-k, shared by every backing.
+
+    A model that publishes its own `index_topk` wins over the config default: the
+    DSA indexer selects that many positions whatever was asked for, and both
+    backings size their swap-in geometry from this number, so they must agree on
+    it.
+    """
+    return _indexer_top_k(
+        config=_parse_sparse_config(server_args), model_config=model_config
+    )
+
+
+def hisparse_indexer_expansion_ratio(server_args) -> float:
+    """Indexer region size as a multiple of the attention pool's token capacity.
+
+    HiSparse keeps the indexer KV GPU-resident for the whole history while the
+    attention KV of an evicted prefix lives elsewhere, so the region covers more
+    tokens than the attention pool holds. How many more depends on the backing:
+
+    - `PRIVATE_HOST`: `host_to_device_ratio`, the size of the private host pool
+      and the only place a swapped-out token can be. The indexer index IS the
+      logical token index, so the region is exactly the logical space.
+    - `HICACHE`: `2 + hicache_ratio` -- one pool for the base region (a KV page id
+      is its indexer page id) plus `1 + hicache_ratio` for the expanded region,
+      which holds a copy of every admitted prefix and is bounded by the two tiers
+      those prefixes live in. `1 + hicache_ratio` is the natural misreading, since
+      that IS the two tiers; it leaves the expanded region one pool short and
+      silently halves admission depth (measured: 3 admitted 30.8K-token requests
+      per rank where 5 fit). `hisparse_config {"expansion_ratio": R}` overrides,
+      and sets the TOTAL multiple.
+
+    Returns 1.0 when HiSparse is off. The capacity model
+    (`model_executor/pool_configurator.py`, indexer overhead cell) and the pool
+    construction (`mem_cache/kv_cache_configurator.py`, `index_buf_size`) MUST
+    both derive from this helper, or the reserved memory and the allocated
+    buffer disagree and the pool overruns the budget it was sized against.
+    """
+    backing = hisparse_backing(server_args)
+    if backing is None:
+        return 1.0
+
+    config = _parse_sparse_config(server_args)
+    if backing is HiSparseBacking.PRIVATE_HOST:
+        ratio = config.host_to_device_ratio
+        # The private-host pool multiplies token counts by this, so a fraction
+        # would produce a non-integral buffer size deep inside pool allocation.
+        if int(ratio) != ratio:
+            raise ValueError(
+                "hisparse_config host_to_device_ratio must be an integer for the "
+                f"private-host backing, got {ratio!r}."
+            )
+        return float(ratio)
+
+    override = config.sparse_extra_config.get("expansion_ratio")
+    if override is not None:
+        ratio = float(override)
+        if ratio <= 0:
+            raise ValueError(f"expansion_ratio must be > 0, got {ratio}")
+        return ratio
+    if server_args.hicache_size:
+        logger.warning(
+            "HiSparse: --hicache-size is set, so the default indexer expansion "
+            "(2 + hicache_ratio = %.1f) may not match the actual host capacity; "
+            "set hisparse_config expansion_ratio explicitly.",
+            2.0 + server_args.hicache_ratio,
+        )
+    return 2.0 + float(server_args.hicache_ratio)
+
+
 def create_sparse_coordinator(
     device: torch.device,
     req_to_token_pool,
@@ -152,3 +335,108 @@ def register_sparse_coordinator(coordinator: SparseCoordinator) -> None:
 
 def get_sparse_coordinator() -> Optional[SparseCoordinator]:
     return _global_sparse_coordinator
+
+
+def hisparse_indexer_regions(
+    *,
+    page_size: int,
+    num_indexer_pages: int,
+    device_pool_size: int,
+) -> tuple[int, int]:
+    """Split the HiCache backing's indexer buffer: (base_pages, expanded_pages).
+
+    The buffer covers more tokens than the attention pool holds (see
+    `hisparse_indexer_expansion_ratio`). Its base region holds one page per
+    attention KV page, so a KV page id *is* its indexer page id -- no mapping
+    table. The expanded region, which starts at `base_pages`, is handed out per
+    request at admission: a page the tree evicts goes back to the allocator and
+    the next request writes over it, base indexer page included, so an evicting
+    request's indexer rows must be copied somewhere private first.
+
+    `num_indexer_pages` is the buffer's own first-dimension length and
+    `device_pool_size` the attention pool's token capacity. Both consumers -- the
+    expanded-page allocator and the hybrid page table -- must derive page ids from
+    here, or two page tables disagree on what a page id means and the indexer
+    scores another request's keys.
+
+    The private-host backing needs no split: its indexer index is the logical
+    token index, nobody else can claim it, so nothing is copied or carved.
+    """
+    # Paged allocators hand out page ids from 1, so a token loc reaches
+    # device_pool_size + page_size - 1 and the base region spans that many pages.
+    base_pages = (device_pool_size + page_size) // page_size
+    if num_indexer_pages <= base_pages:
+        raise ValueError(
+            f"indexer buffer has {num_indexer_pages} pages but the attention pool "
+            f"alone needs {base_pages}; HiSparse on the HiCache backing needs an "
+            "expanded region on top (raise hisparse_config expansion_ratio or "
+            "--hicache-ratio)."
+        )
+    return base_pages, num_indexer_pages - base_pages
+
+
+def create_hisparse_coordinator(
+    *,
+    server_args,
+    model_config,
+    req_to_token_pool,
+    token_to_kv_pool_allocator,
+    device: str,
+    tp_group,
+    pp_size: int,
+    is_speculative: bool,
+) -> Optional["HiSparseCoordinator"]:
+    """The HiSparse coordinator for this configuration, or None when it is off.
+
+    The one place that turns configuration into a coordinator, so the choice of
+    logical KV pool is made once instead of at every call site. Callers get a
+    `managers/hisparse_protocol.py` implementation and never need to know which
+    backing they got.
+    """
+    backing = hisparse_backing(server_args)
+    if backing is None:
+        return None
+
+    config = _parse_sparse_config(server_args)
+    top_k = _indexer_top_k(config=config, model_config=model_config)
+
+    if backing is HiSparseBacking.PRIVATE_HOST:
+        # Imported here, not at module scope: the coordinator imports this module
+        # back for HiSparseBacking, and it pulls in torch + the swap-in kernels
+        # that a config-only caller (startup validation) has no use for.
+        from sglang.srt.managers.hisparse_coordinator import (
+            PrivateHostHiSparseCoordinator,
+            resolve_shared_index_layers,
+        )
+
+        return PrivateHostHiSparseCoordinator(
+            req_to_token_pool=req_to_token_pool,
+            token_to_kv_pool_allocator=token_to_kv_pool_allocator,
+            top_k=top_k,
+            device_buffer_size=config.device_buffer_size,
+            device=device,
+            tp_group=tp_group,
+            host_to_device_ratio=config.host_to_device_ratio,
+            swap_in_block_size=config.swap_in_block_size,
+            shared_index_layers=resolve_shared_index_layers(
+                hf_text_config=model_config.hf_text_config,
+                pp_size=pp_size,
+                is_speculative=is_speculative,
+            ),
+        )
+
+    # Imported here for the same reason as above: this module is also read by
+    # startup validation, which must not pull in torch and the swap-in kernels.
+    from sglang.srt.managers.hisparse_hicache_coordinator import (
+        HiCacheHiSparseCoordinator,
+    )
+
+    return HiCacheHiSparseCoordinator(
+        req_to_token_pool=req_to_token_pool,
+        token_to_kv_pool_allocator=token_to_kv_pool_allocator,
+        top_k=top_k,
+        device_buffer_size=config.device_buffer_size,
+        device=device,
+        tp_group=tp_group,
+        swap_in_block_size=config.swap_in_block_size,
+    )

--- a/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
+++ b/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
@@ -80,6 +80,7 @@ from sglang.srt.mem_cache.utils import (
 )
 
 if TYPE_CHECKING:
+    from sglang.srt.managers.hisparse_protocol import HiSparseEvictionHooks
     from sglang.srt.managers.schedule_batch import Req
     from sglang.srt.mem_cache.cache_init_params import CacheInitParams
 
@@ -422,6 +423,10 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
             enabled=params.enable_kv_cache_events, page_size=self.page_size
         )
 
+        # Set only by HiSparse's HiCache backing, which lets the tree evict the
+        # KV of a still-decoding request; see `HiSparseEvictionHooks`.
+        self.hisparse_eviction_hooks: Optional[HiSparseEvictionHooks] = None
+
         self.reset()
 
     # ==== Tree API ====
@@ -485,6 +490,29 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
             last_host_node=self.root_node.id,
             best_match_node=self.root_node.id,
             cache_actions=[],
+        )
+
+    def set_hisparse_eviction_hooks(
+        self, hooks: Optional[HiSparseEvictionHooks]
+    ) -> None:
+        """Let HiSparse follow this tree's device evictions; see
+        `HiSparseEvictionHooks` for what the two callbacks owe each other."""
+        self.hisparse_eviction_hooks = hooks
+
+    def _notify_hisparse_device_released(self, node: UnifiedTreeNode) -> None:
+        """Called wherever a node's device KV is about to be freed, and only
+        there: HiSparse reads the node's device and host index arrays, so firing
+        this after the release would hand it an empty node, and firing it twice
+        would double-count the eviction against a request."""
+        if self.hisparse_eviction_hooks is not None:
+            self.hisparse_eviction_hooks.on_device_released(node)
+
+    def _hisparse_backs_live_request(self, node: UnifiedTreeNode) -> bool:
+        """Whether dropping this node's KV without a host copy would strand a
+        live HiSparse request."""
+        return (
+            self.hisparse_eviction_hooks is not None
+            and self.hisparse_eviction_hooks.backs_live_request(node)
         )
 
     def node_by_id(self, node_id: NodeId) -> UnifiedTreeNode:
@@ -1263,6 +1291,12 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         assert not node.backuped and node.write_through_pending_id is None
         if any(cd.host_lock_ref > 0 for cd in node.component_data):
             return result
+        if self._hisparse_backs_live_request(node):
+            # Dropping this KV is unrecoverable for a HiSparse request decoding
+            # against it: the position would have no home in either tier and
+            # attention would silently mask it. Declining keeps the node on
+            # device, which the caller reports and resolves by retraction.
+            return result
         descendants: list[UnifiedTreeNode] = []
         stack = list(node.children.values())
         while stack:
@@ -1326,6 +1360,7 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         host_frees: dict[ComponentType, list[torch.Tensor]],
     ) -> None:
         """Delete a device leaf that has no host backup, freeing all layers."""
+        self._notify_hisparse_device_released(node)
         self._release_all_component_layers(
             node, StorageMedium.GPU, tracker, device_frees, host_frees
         )
@@ -1484,6 +1519,7 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         host_frees: dict[ComponentType, list[torch.Tensor]],
     ) -> None:
         assert not node.evicted and node.backuped
+        self._notify_hisparse_device_released(node)
         trigger = self.components_by_type[BASE_COMPONENT_TYPE]
         self._evict_component_and_detach_lru(
             node,

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -87,6 +87,7 @@ from sglang.srt.utils.common import ceil_align
 
 if TYPE_CHECKING:
     from sglang.srt.managers.cache_controller import HiCacheAck
+    from sglang.srt.managers.hisparse_protocol import HiSparseEvictionHooks
     from sglang.srt.managers.schedule_batch import Req
     from sglang.srt.mem_cache.cache_init_params import CacheInitParams
     from sglang.srt.mem_cache.hybrid_cache.hybrid_cache_controller import (
@@ -692,9 +693,13 @@ class UnifiedRadixCache(BasePrefixCache):
             return DecLockRefResult()
         return self.tree_core.dec_lock_ref(node_id, params, skip_swa)
 
-    def _dec_req_lock(self, req: Req, *, skip_swa: bool = False) -> None:
+    def dec_req_lock(self, req: Req, *, skip_swa: bool = False) -> None:
         """Release the tree lock a request holds on its last_node, honoring the
-        components it skipped locking so it never drops a lock it never took."""
+        components it skipped locking so it never drops a lock it never took.
+
+        Public because HiSparse's HiCache backing releases this lock early, at
+        admission, so that the prefix becomes evictable while the request decodes;
+        it must release exactly what the scheduler otherwise would."""
         self.dec_lock_ref(
             req.last_node,
             DecLockRefParams(
@@ -729,6 +734,48 @@ class UnifiedRadixCache(BasePrefixCache):
             return DecLockRefResult()
         return self.tree_core.dec_host_lock_ref(node_id, params)
 
+    def set_hisparse_eviction_hooks(
+        self, hooks: Optional[HiSparseEvictionHooks]
+    ) -> None:
+        """Register HiSparse's device-eviction callbacks (HiCache backing only).
+
+        Lives on the tree core, which is where device KV is actually released;
+        see `HiSparseEvictionHooks`.
+        """
+        self.tree_core.set_hisparse_eviction_hooks(hooks)
+
+    def _hisparse_evicted_prefix_blocks_insert(
+        self, req: Req, kv_len_to_handle: int
+    ) -> bool:
+        """Handle a finishing HiSparse request whose prefix has eviction holes.
+
+        Its protected prefix [0, cache_protected_len) is tree-owned and HiCache
+        may have demoted part of it, leaving a -1 sentinel in `req_to_token`. The
+        standard insert cannot run on such a row: the walk would dedup-free and
+        un-evict against -1 values and splice them into the tree as real KV. The
+        request-owned tail is still valid device KV, but with the prefix chain
+        holed there is nothing to attach it under, so it is freed.
+
+        Returns False when the prefix is intact -- then the standard path runs and
+        the decode output becomes a reusable prefix, which is the common case and
+        what makes multi-turn reuse work.
+
+        TODO: when the prefix IS holed, the tail could still be salvaged as a host
+        node under the demoted prefix instead of freed, recovering decode-output
+        reuse for those requests.
+        """
+        kv_indices = self.req_to_token_pool.req_to_token[
+            req.req_pool_idx, :kv_len_to_handle
+        ]
+        if not bool((kv_indices[: req.cache_protected_len] < 0).any().item()):
+            return False
+        tail = kv_indices[req.cache_protected_len :]
+        if tail.numel() > 0:
+            self.token_to_kv_pool_allocator.free(tail)
+        for comp in self._components_tuple:
+            comp.cleanup_after_caching_req(req, is_finished=True)
+        return True
+
     def cache_finished_req(
         self, req: Req, is_insert: bool = True, *, kv_len_to_handle: int, **kwargs
     ) -> None:
@@ -742,6 +789,13 @@ class UnifiedRadixCache(BasePrefixCache):
             self.token_to_kv_pool_allocator.free_segment(kv_indices, start_pos=0)
             for comp in self._components_tuple:
                 comp.cleanup_after_caching_req(req, is_finished=True)
+            return
+
+        if (
+            is_insert
+            and req.hisparse_prefix_lock_released
+            and self._hisparse_evicted_prefix_blocks_insert(req, kv_len_to_handle)
+        ):
             return
 
         token_ids = (req.origin_input_ids + req.output_ids)[:kv_len_to_handle]
@@ -803,7 +857,11 @@ class UnifiedRadixCache(BasePrefixCache):
                 start_pos=req.cache_protected_len,
             )
 
-        self._dec_req_lock(req, skip_swa=req.swa_prefix_lock_released)
+        if not req.hisparse_prefix_lock_released:
+            # HiSparse's HiCache backing released this lock at admission, so that
+            # the prefix it had just inserted could be evicted while the request
+            # decoded; releasing it again would underflow the node's ref count.
+            self.dec_req_lock(req, skip_swa=req.swa_prefix_lock_released)
 
         if is_insert and result is not None and result.last_device_node is not None:
             req.last_node = result.last_device_node
@@ -906,7 +964,7 @@ class UnifiedRadixCache(BasePrefixCache):
             new_indices[req.cache_protected_len :],
         )
 
-        self._dec_req_lock(req)
+        self.dec_req_lock(req)
         # Opt-in: leave the matched-prefix mamba evictable during decode (it is
         # already COW'd to the request's own slot, never read from this node again).
         # Safe only because any future COW source is the COWing request's own

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -842,36 +842,21 @@ class ModelRunner:
         self.graph_shared_output = None
 
     def maybe_init_hisparse_coordinator(self):
-        if not self.enable_hisparse:
-            return
-        from sglang.srt.managers.hisparse_coordinator import (
-            HiSparseCoordinator,
-            resolve_shared_index_layers,
-        )
-        from sglang.srt.mem_cache.sparsity import parse_hisparse_config
+        from sglang.srt.mem_cache.sparsity import create_hisparse_coordinator
 
-        hisparse_cfg = parse_hisparse_config(self.server_args)
-        hisparse_top_k = getattr(
-            self.model_config.hf_text_config, "index_topk", hisparse_cfg.top_k
-        )
-        self.hisparse_coordinator = HiSparseCoordinator(
+        self.hisparse_coordinator = create_hisparse_coordinator(
+            server_args=self.server_args,
+            model_config=self.model_config,
             req_to_token_pool=self.req_to_token_pool,
             token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
-            top_k=hisparse_top_k,
-            device_buffer_size=hisparse_cfg.device_buffer_size,
             device=self.device,
             tp_group=(
                 self.attention_tp_group.cpu_group
                 if get_parallel().enable_dp_attention
                 else self.tp_group.cpu_group
             ),
-            host_to_device_ratio=hisparse_cfg.host_to_device_ratio,
-            swap_in_block_size=hisparse_cfg.swap_in_block_size,
-            shared_index_layers=resolve_shared_index_layers(
-                hf_text_config=self.model_config.hf_text_config,
-                pp_size=self.ps.pp_size,
-                is_speculative=self.spec_algorithm.is_speculative(),
-            ),
+            pp_size=self.ps.pp_size,
+            is_speculative=self.spec_algorithm.is_speculative(),
         )
 
     def post_capture_resize_kv_pool(self):

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -366,9 +366,14 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
         memory_config = get_memory()
         indexer_ratio = 1
         if memory_config.enable_hisparse:
-            from sglang.srt.mem_cache.sparsity import parse_hisparse_config
+            # The multiple depends on the backing, and MUST match
+            # kv_cache_configurator's index_buf_size exactly or the reserved
+            # memory and the allocated buffer disagree.
+            from sglang.srt.mem_cache.sparsity import (
+                hisparse_indexer_expansion_ratio,
+            )
 
-            indexer_ratio = parse_hisparse_config(kvc.server_args).host_to_device_ratio
+            indexer_ratio = hisparse_indexer_expansion_ratio(kvc.server_args)
 
         from sglang.srt.mem_cache.kv_cache_configurator import (
             _should_elide_dsa_index_k,

--- a/test/registered/kernels/ops/kvcache/test_hisparse.py
+++ b/test/registered/kernels/ops/kvcache/test_hisparse.py
@@ -101,6 +101,8 @@ def _run_kernel(
     req_pool_indices: torch.Tensor | None = None,
     num_real_reqs: int | None = None,
     output_fill_value: int = -1,
+    device_locs: torch.Tensor | None = None,
+    host_binding: torch.Tensor | None = None,
 ) -> torch.Tensor:
     batch_size = top_k_tokens.shape[0]
     if req_pool_indices is None:
@@ -130,6 +132,8 @@ def _run_kernel(
         page_size=1,
         block_size=256,
         num_real_reqs=torch.tensor([num_real_reqs], dtype=torch.int32, device=DEVICE),
+        device_locs=device_locs,
+        host_binding=host_binding,
     )
     torch.cuda.synchronize()
     return out
@@ -489,6 +493,205 @@ def test_load_cache_to_device_buffer_multiple_misses_copy_all_slots() -> None:
         assert torch.equal(
             state["device_buffer"][loc].cpu(), state["host_cache"][token]
         )
+
+
+def _pool_source(rows: list[list[int]]) -> torch.Tensor:
+    """`device_locs`: pool slot per position, or -1 once the pool gave it up."""
+    return torch.tensor(rows, dtype=torch.int32, device=DEVICE)
+
+
+def test_pass_through_returns_pool_slots_without_copying() -> None:
+    """A position the pool still owns costs no hot-buffer slot and no DMA.
+
+    This is the source the HiCache backing needs and the private-host backing
+    does not have: its staging frees every pool slot, so without the flag the
+    kernel would treat a live pool position as a miss, evict a resident to make
+    room, and DMA a host copy that is not even guaranteed to exist.
+    """
+    state = _make_state([[9, 7, 3, 5, 11]], [[0, 1, 2, 3, -1]], [8])
+    buffer_before = state["device_buffer"].clone()
+    lru_before = state["lru_slots"].clone()
+    tokens_before = state["device_buffer_tokens"].clone()
+
+    # Tokens 4..7 are NOT in the buffer (it holds 0..3), so without the pool
+    # source every lane would miss. Here the pool still owns all four.
+    device_locs = _pool_source([[-1] * 4 + [12, 13, 14, 15] + [-1] * 8])
+    out = _run_kernel(
+        top_k_tokens=torch.tensor([[4, 5, 6, 7]], dtype=torch.int32, device=DEVICE),
+        seq_len=9,
+        device_locs=device_locs,
+        **state,
+    )
+
+    # Pool slots come straight back...
+    assert torch.equal(out.cpu(), torch.tensor([[12, 13, 14, 15]], dtype=torch.int32))
+    # ... and nothing else moved: no bytes copied, no residency change, no LRU churn.
+    assert torch.equal(state["device_buffer"], buffer_before)
+    assert torch.equal(state["device_buffer_tokens"], tokens_before)
+    assert torch.equal(state["lru_slots"], lru_before)
+
+
+def test_pass_through_mixes_all_three_sources() -> None:
+    """One row, one lane per source: pool / buffer hit / host miss.
+
+    The mix is the interesting case -- a pool lane must consume neither the hash
+    entry nor the buffer slot that the other two need, so getting any one of the
+    three right in isolation does not imply the row is right.
+    """
+    state = _make_state([[9, 7, 3, 5, 11]], [[0, 1, 2, 3, -1]], [8])
+    # Positions: 5 -> pool slot 13; 2 -> resident in buffer slot 2 (loc 3);
+    # 6 and 7 -> given up by the pool, both have host copies.
+    device_locs = _pool_source([[-1] * 5 + [13] + [-1] * 10])
+
+    out = _run_kernel(
+        top_k_tokens=torch.tensor([[5, 2, 6, 7]], dtype=torch.int32, device=DEVICE),
+        seq_len=9,
+        device_locs=device_locs,
+        **state,
+    ).cpu()
+
+    assert out[0, 0].item() == 13, "pool lane must return the pool slot"
+    assert out[0, 1].item() == 3, "buffer-resident lane must return its slot"
+    # The two evicted lanes take distinct buffer slots and their bytes must land.
+    miss_slots = {out[0, 2].item(), out[0, 3].item()}
+    assert len(miss_slots) == 2, f"evicted lanes must get distinct slots: {miss_slots}"
+    resident = state["device_buffer_tokens"].cpu()[0, :HOT_BUFFER_SIZE].tolist()
+    for token in (6, 7):
+        assert token in resident, f"token {token} should be resident: {resident}"
+        loc = state["device_buffer_locs"].cpu()[0, resident.index(token)].item()
+        assert torch.equal(
+            state["device_buffer"][loc].cpu(), state["host_cache"][token]
+        ), f"token {token}'s bytes must be byte-exact from host"
+    # Position 2 must still be resident: a pool lane must not have evicted it.
+    assert 2 in resident, f"buffer hit was evicted by a pool lane: {resident}"
+
+
+def test_pass_through_masks_a_lane_the_selector_left_unfilled() -> None:
+    """An unfilled lane (position < 0) must come back masked, taking nothing.
+
+    The two-source kernel never sees one: it only reaches the slow path when
+    seq_len exceeds the hot buffer, hence exceeds top_k, so the selector filled
+    every lane. A pool-backed caller has no such floor (a short standard request
+    shares the batch), and an unfilled lane that falls through counts as a miss:
+    it would evict a resident, index the host table at a negative position, and
+    return a real slot for a position that does not exist.
+    """
+    state = _make_state([[9, 7, 3, 5, 11]], [[0, 1, 2, 3, -1]], [8])
+    buffer_before = state["device_buffer"].clone()
+    lru_before = state["lru_slots"].clone()
+    tokens_before = state["device_buffer_tokens"].clone()
+    device_locs = _pool_source([[-1] * 5 + [13] + [-1] * 10])
+
+    out = _run_kernel(
+        top_k_tokens=torch.tensor([[5, -1, -1, -1]], dtype=torch.int32, device=DEVICE),
+        seq_len=9,
+        device_locs=device_locs,
+        **state,
+    )
+
+    assert torch.equal(out.cpu(), torch.tensor([[13, -1, -1, -1]], dtype=torch.int32))
+    assert torch.equal(state["device_buffer"], buffer_before)
+    assert torch.equal(state["device_buffer_tokens"], tokens_before)
+    assert torch.equal(state["lru_slots"], lru_before)
+
+
+def test_late_bound_host_binding_matches_the_direct_tensor() -> None:
+    """Taking the host base from device memory must copy the same bytes.
+
+    A caller whose host tier is attached only after cuda-graph capture cannot pass
+    the pool as an argument -- the recorded launch would carry whatever address the
+    tensor had at capture time. Reading it from a persistent tensor at run time is
+    the alternative, and it is only useful if it addresses identically.
+    """
+    direct = _make_state([[9, 7, 3, 5, 11]], [[0, 1, 2, 3, -1]], [8])
+    late = _make_state([[9, 7, 3, 5, 11]], [[0, 1, 2, 3, -1]], [8])
+    top_k = torch.tensor([[4, 5]], dtype=torch.int32, device=DEVICE)
+
+    out_direct = _run_kernel(top_k_tokens=top_k.clone(), seq_len=9, **direct)
+    # The holder is filled before the launch here; in production it is filled once
+    # the host pool exists, after the graph that reads it was captured.
+    host_binding = torch.tensor(
+        [late["host_cache"].data_ptr(), ITEM_SIZE_BYTES],
+        dtype=torch.int64,
+        device=DEVICE,
+    )
+    out_late = _run_kernel(
+        top_k_tokens=top_k.clone(), seq_len=9, host_binding=host_binding, **late
+    )
+
+    assert torch.equal(out_direct.cpu(), out_late.cpu())
+    assert torch.equal(direct["device_buffer"].cpu(), late["device_buffer"].cpu())
+    for token in (4, 5):
+        resident = late["device_buffer_tokens"].cpu()[0, :HOT_BUFFER_SIZE].tolist()
+        loc = late["device_buffer_locs"].cpu()[0, resident.index(token)].item()
+        assert torch.equal(
+            late["device_buffer"][loc].cpu(), late["host_cache"][token]
+        ), f"token {token} must be byte-exact through the late-bound base"
+
+
+def test_late_bound_host_binding_honours_a_wider_row_stride() -> None:
+    """A host pool that interleaves layers within a token spaces its rows wider.
+
+    HiCache's default page_first layout stores [token, layer, cell], so one
+    layer's per-token rows are layer_num cells apart. Reusing item_size_bytes as
+    the source stride there reads a blend of neighbouring tokens -- plausible KV
+    bytes, no fault, wrong values. The stride travels with the base for the same
+    reason the base does: neither is known at capture time.
+    """
+    state = _make_state([[9, 7, 3, 5, 11]], [[0, 1, 2, 3, -1]], [8])
+    layers = 3
+    # [token, layer, cell]: layer 0's rows are `layers` cells apart. Every layer
+    # gets distinct bytes, so reading the wrong stride cannot coincide.
+    interleaved = torch.empty(
+        (HOST_CACHE_SIZE, layers, KV_DIM), dtype=DTYPE, device="cpu", pin_memory=True
+    )
+    interleaved.copy_(
+        torch.arange(interleaved.numel(), dtype=DTYPE).view_as(interleaved)
+    )
+    state["host_cache"] = interleaved
+    host_binding = torch.tensor(
+        [interleaved.data_ptr(), layers * ITEM_SIZE_BYTES],
+        dtype=torch.int64,
+        device=DEVICE,
+    )
+
+    out = _run_kernel(
+        top_k_tokens=torch.tensor([[4, 5]], dtype=torch.int32, device=DEVICE),
+        seq_len=9,
+        host_binding=host_binding,
+        **state,
+    )
+
+    resident = state["device_buffer_tokens"].cpu()[0, :HOT_BUFFER_SIZE].tolist()
+    for token in (4, 5):
+        loc = state["device_buffer_locs"].cpu()[0, resident.index(token)].item()
+        assert torch.equal(
+            state["device_buffer"][loc].cpu(), interleaved[token, 0:1]
+        ), f"token {token} must read layer 0's row, not a stride-1 blend"
+    assert (out.cpu() >= 0).all()
+
+
+def test_pass_through_skips_the_short_sequence_fast_path() -> None:
+    """The fast path reads device_buffer_locs[position], i.e. position == slot.
+
+    That holds only when the buffer carries the whole sequence, which a pool-backed
+    caller never guarantees. With the flag on, a seq_len below the buffer size must
+    still resolve through the pool rather than through that shortcut -- otherwise
+    every lane would come back with an unrelated slot.
+    """
+    state = _make_state([[9, 7, 3, 5, 11]], [[0, 1, 2, 3, -1]], [2])
+    # seq_len 3 <= HOT_BUFFER_SIZE would take the fast path and return
+    # device_buffer_locs[0..2] = [9, 7, 3]; the pool says otherwise.
+    device_locs = _pool_source([[14, 15, 12] + [-1] * 13])
+
+    out = _run_kernel(
+        top_k_tokens=torch.tensor([[0, 1, 2]], dtype=torch.int32, device=DEVICE),
+        seq_len=3,
+        device_locs=device_locs,
+        **state,
+    )
+
+    assert torch.equal(out.cpu(), torch.tensor([[14, 15, 12]], dtype=torch.int32))
 
 
 def test_load_cache_to_device_buffer_batched_with_padding() -> None:

--- a/test/registered/unit/managers/test_hisparse_hicache_admission.py
+++ b/test/registered/unit/managers/test_hisparse_hicache_admission.py
@@ -1,0 +1,367 @@
+"""Unit tests for the HiCache HiSparse backing's admission accounting.
+
+The coordinator hands the radix tree the KV of a request that is still decoding,
+so admission has to be rationed before the prefill forward runs -- and the
+rationing is what decides whether the two tiers can keep one home for every
+admitted token. The arithmetic is small and entirely integer, which is why it
+lives apart from the coordinator and is tested here without a GPU.
+
+What the cases below pin down is the reasoning, not the formulas:
+
+- a candidate predicted to run standard must not be charged the device buffer it
+  will not take, and one that cannot fit the pool at all must be budgeted as
+  standard even if every quota is free (otherwise the adder reserves more than
+  rem_total_tokens forever and the system livelocks on an idle pool);
+- "only a quota blocks it" and "it gains nothing from admission" are different
+  answers with opposite scheduler actions -- queue versus run now;
+- shared prefixes bill once, and an in-flight candidate bills its full footprint
+  until admission resolves, which is the pacing margin that keeps write-back
+  able to drain.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.managers.hisparse_hicache_admission import AdmissionLedger
+from sglang.srt.mem_cache.unified_cache.component_type import ComponentType
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+PAGE_SIZE = 64
+TEMP_SLOTS = 4096
+CHUNK_TOKENS = 4096
+# Big enough that _infeasible never fires unless a case asks for it.
+DEVICE_POOL = 1_000_000
+HOST_TOKENS = 500_000
+
+
+def _node(node_id: int, tokens: int, *, on_host: bool = False):
+    """A tree node stub with just the fields the ledger reads."""
+    values = list(range(tokens))
+    data = SimpleNamespace(
+        value=None if on_host else values,
+        host_value=values if on_host else None,
+    )
+    return SimpleNamespace(id=node_id, component_data={ComponentType.FULL: data})
+
+
+def _ledger(
+    *,
+    device_pool_tokens=DEVICE_POOL,
+    host_tokens=HOST_TOKENS,
+    chunk_tokens=CHUNK_TOKENS,
+):
+    ledger = AdmissionLedger(
+        device_pool_tokens=device_pool_tokens,
+        temp_slot_tokens=TEMP_SLOTS,
+        page_size=PAGE_SIZE,
+        chunk_tokens=chunk_tokens,
+    )
+    ledger.set_host_capacity(host_tokens)
+    return ledger
+
+
+def _budget(ledger, *, expanded_pages_left=10_000, tree_evictable_tokens=0):
+    return ledger.make_budget(
+        expanded_pages_left=expanded_pages_left,
+        tree_evictable_tokens=tree_evictable_tokens,
+    )
+
+
+def _req(rid="r0"):
+    return SimpleNamespace(rid=rid)
+
+
+class TestFutureTokenReservation(CustomTestCase):
+    def test_admissible_candidate_reserves_the_device_buffer(self):
+        budget = _budget(_ledger())
+        reserved = budget.future_tokens(30_000, 512, commit=False)
+        # The temp buffer comes out of the regular pool and is held for the
+        # request's lifetime, so the adder has to see it now.
+        self.assertEqual(reserved, TEMP_SLOTS + 512)
+
+    def test_short_prefix_is_budgeted_as_standard(self):
+        # Below the temp buffer, admission would be a net capacity LOSS, so the
+        # coordinator declines -- and charging the buffer here would reserve
+        # device tokens the request never takes.
+        budget = _budget(_ledger())
+        self.assertEqual(budget.future_tokens(TEMP_SLOTS - 1, 512, commit=False), 512)
+
+    def test_sub_page_prompt_is_budgeted_as_standard(self):
+        budget = _budget(_ledger())
+        self.assertEqual(budget.future_tokens(PAGE_SIZE - 1, 512, commit=False), 512)
+
+    def test_pool_infeasible_candidate_is_budgeted_as_standard(self):
+        """A reservation larger than the whole pool must not be made.
+
+        The entry-side max_new clamp only guarantees the STANDARD budget fits, so
+        adding the temp buffer on top can push the adder's total past
+        rem_total_tokens on an *idle* system -- which never clears, because
+        nothing is running that could free anything.
+        """
+        budget = _budget(_ledger(device_pool_tokens=40_000))
+        self.assertEqual(budget.future_tokens(30_000, 8_000, commit=False), 8_000)
+
+    def test_commit_depletes_the_round_for_later_candidates(self):
+        # One page of expanded region left: the second candidate in the same
+        # round must see it gone, or the adder over-promises within one pass.
+        budget = _budget(_ledger(), expanded_pages_left=TEMP_SLOTS // PAGE_SIZE)
+        first = budget.future_tokens(TEMP_SLOTS, 512, commit=True, req=_req("a"))
+        second = budget.future_tokens(TEMP_SLOTS, 512, commit=False, req=_req("b"))
+        self.assertEqual(first, TEMP_SLOTS + 512)
+        self.assertEqual(second, 512)
+
+    def test_probe_does_not_deplete(self):
+        budget = _budget(_ledger(), expanded_pages_left=TEMP_SLOTS // PAGE_SIZE)
+        budget.future_tokens(TEMP_SLOTS, 512, commit=False, req=_req("a"))
+        self.assertEqual(
+            budget.future_tokens(TEMP_SLOTS, 512, commit=False, req=_req("b")),
+            TEMP_SLOTS + 512,
+        )
+
+    def test_commit_publishes_the_claim_to_the_next_round(self):
+        """Without this, a round snapshots headroom an earlier round promised.
+
+        The coordinator only records the real reservation after the prefill
+        forward, so the pending claim is the only thing standing between two
+        rounds and a double promise.
+        """
+        ledger = _ledger(host_tokens=TEMP_SLOTS * 2)
+        before = ledger.reservable_left()
+        _budget(ledger).future_tokens(TEMP_SLOTS, 512, commit=True, req=_req("a"))
+        self.assertEqual(ledger.reservable_left(), before - TEMP_SLOTS)
+
+
+class TestAdmissionExhausted(CustomTestCase):
+    """Queue the candidate, or let it run standard? Opposite actions.
+
+    A candidate blocked only by a spent quota should wait: the quota frees when an
+    admitted request finishes. One that gains nothing from admission should run
+    now -- reporting it as exhausted would keep it queued behind a condition that
+    never changes.
+    """
+
+    def test_exhausted_when_only_the_expanded_region_is_spent(self):
+        budget = _budget(_ledger(), expanded_pages_left=0)
+        self.assertTrue(budget.admission_exhausted(30_000, 512))
+
+    def test_exhausted_when_the_two_tiers_are_already_promised(self):
+        # Both tiers count toward one ceiling (a prefix token needs one home), so
+        # what spends it is what admitted requests already hold -- here one huge
+        # claimed node.
+        ledger = _ledger()
+        ledger.claim_node(_node(1, ledger.reservable_left() - 1_000))
+        self.assertTrue(_budget(ledger).admission_exhausted(30_000, 512))
+
+    def test_not_exhausted_for_a_short_prefix(self):
+        budget = _budget(_ledger(), expanded_pages_left=0)
+        self.assertFalse(budget.admission_exhausted(TEMP_SLOTS - 1, 512))
+
+    def test_not_exhausted_for_a_pool_infeasible_candidate(self):
+        budget = _budget(_ledger(device_pool_tokens=40_000), expanded_pages_left=0)
+        self.assertFalse(budget.admission_exhausted(30_000, 8_000))
+
+    def test_not_exhausted_when_quotas_are_free(self):
+        self.assertFalse(_budget(_ledger()).admission_exhausted(30_000, 512))
+
+    def test_agrees_with_future_tokens(self):
+        """The gate and the reservation must read the same quotas.
+
+        Disagreement is a livelock either way: queueing candidates future_tokens
+        would admit, or admitting candidates the gate wants queued.
+        """
+        for expanded, promised in ((0, 0), (10_000, HOST_TOKENS), (10_000, 0)):
+            with self.subTest(expanded=expanded, promised=promised):
+                ledger = _ledger()
+                if promised:
+                    ledger.claim_node(_node(1, promised))
+                budget = _budget(ledger, expanded_pages_left=expanded)
+                admitted = budget.future_tokens(30_000, 512, commit=False) != 512
+                self.assertEqual(admitted, not budget.admission_exhausted(30_000, 512))
+
+
+class TestPendingClaims(CustomTestCase):
+    def test_pending_is_idempotent_per_request(self):
+        # Chunked prefill re-budgets the same request in every round it spans; a
+        # second charge would shrink headroom for a request already counted.
+        ledger = _ledger()
+        before = ledger.reservable_left()
+        ledger.note_pending("a", 10_000)
+        ledger.note_pending("a", 10_000)
+        self.assertEqual(ledger.reservable_left(), before - 10_000)
+
+    def test_dropping_an_unknown_request_is_a_no_op(self):
+        # Every finish path drops, including requests that were never budgeted.
+        ledger = _ledger()
+        before = ledger.reservable_left()
+        ledger.drop_pending("never-seen")
+        self.assertEqual(ledger.reservable_left(), before)
+
+    def test_drop_releases_exactly_once(self):
+        ledger = _ledger()
+        before = ledger.reservable_left()
+        ledger.note_pending("a", 10_000)
+        ledger.drop_pending("a")
+        ledger.drop_pending("a")
+        self.assertEqual(ledger.reservable_left(), before)
+
+    def test_admission_supersedes_the_in_flight_charge(self):
+        # The pending charge and the per-node claims stand for the SAME tokens,
+        # so an admitted request must carry one or the other, never both. It did
+        # carry both: with the real 60K-pool / 30.8K-prompt geometry that made
+        # the ceiling run out one request early -- the third candidate was
+        # reported as admission_exhausted (29552 left of the 30784 it needed),
+        # which stops the adder outright instead of falling back to standard, and
+        # per-rank concurrency sat at two with six requests queued.
+        tree_len = 30_784
+        ledger = _ledger(device_pool_tokens=59_968, host_tokens=120_000)
+        for idx, rid in enumerate(("a", "b")):
+            ledger.note_pending(rid, tree_len)
+            ledger.claim_node(_node(idx, tree_len))
+            ledger.activate(idx, tree_len, rid=rid, decode_reserve=512)
+        self.assertFalse(_budget(ledger).admission_exhausted(tree_len, 512))
+        device_reserve = (
+            3 * TEMP_SLOTS  # two admitted plus the next admission
+            + 2 * 512  # their output tails
+            + CHUNK_TOKENS  # whatever is being prefilled
+            + 3 * PAGE_SIZE  # alignment
+        )
+        self.assertEqual(
+            ledger.reservable_left(),
+            120_000 + (59_968 - device_reserve) - 2 * tree_len,
+        )
+
+
+class TestNodeClaims(CustomTestCase):
+    def test_a_shared_node_bills_once(self):
+        # Two requests on the same prefix: the data needs one home, not two.
+        ledger = _ledger()
+        before = ledger.reservable_left()
+        node = _node(1, 1_000)
+        ledger.claim_node(node)
+        ledger.claim_node(node)
+        self.assertEqual(ledger.reservable_left(), before - 1_000)
+
+    def test_the_last_release_gives_the_tokens_back(self):
+        ledger = _ledger()
+        before = ledger.reservable_left()
+        node = _node(1, 1_000)
+        ledger.claim_node(node)
+        ledger.claim_node(node)
+        ledger.release_node(node)
+        self.assertEqual(ledger.reservable_left(), before - 1_000)
+        ledger.release_node(node)
+        self.assertEqual(ledger.reservable_left(), before)
+
+    def test_a_host_only_node_is_measured_by_its_host_copy(self):
+        # A node the tree already demoted has no device value; billing it zero
+        # would let a re-hit prefix be admitted for free -- exactly the pattern
+        # that saturated host with locks until backups failed.
+        ledger = _ledger()
+        before = ledger.reservable_left()
+        ledger.claim_node(_node(1, 1_000, on_host=True))
+        self.assertEqual(ledger.reservable_left(), before - 1_000)
+
+    def test_reservable_is_unbounded_without_a_host_tier(self):
+        ledger = AdmissionLedger(
+            device_pool_tokens=DEVICE_POOL,
+            temp_slot_tokens=TEMP_SLOTS,
+            page_size=PAGE_SIZE,
+            chunk_tokens=CHUNK_TOKENS,
+        )
+        self.assertGreater(ledger.reservable_left(), 1 << 50)
+
+
+class TestDeviceReserve(CustomTestCase):
+    """What the device tier withholds from the ceiling, and what it scales with.
+
+    This used to be a flat 25% of the pool. The fraction was the wrong shape, not
+    just the wrong value: everything it stood in for scales with concurrency,
+    chunk size and output length, and none of those scale with the pool. Both
+    cases below are red under any pool-proportional reserve.
+    """
+
+    def test_a_bigger_pool_is_usable_in_full(self):
+        # Same concurrency, same chunk, same outputs -> the same reserve, so the
+        # extra pool is available down to the last token. A 25% fraction would
+        # keep back a quarter of the increase.
+        base = _ledger(device_pool_tokens=60_000)
+        big = _ledger(device_pool_tokens=120_000)
+        self.assertEqual(big.reservable_left() - base.reservable_left(), 60_000)
+
+    def test_a_long_output_request_withholds_its_own_tail(self):
+        # Output tokens are device-only until write-back takes them, so a request
+        # asking for 8k of output withholds 8k -- where a pool fraction withholds
+        # the same amount whether the request emits one token or ten thousand.
+        short, long = _ledger(), _ledger()
+        short.activate(1, 30_000, rid="r1", decode_reserve=0)
+        long.activate(1, 30_000, rid="r1", decode_reserve=8_192)
+        self.assertEqual(short.reservable_left() - long.reservable_left(), 8_192)
+
+
+class TestDeviceEvictableOverhang(CustomTestCase):
+    """Device tokens counted evictable that eviction cannot actually reclaim.
+
+    Under write_back a demotion needs host space, and the coordinator vetoes the
+    copy-less drop for data backing a live request, so those tokens stay on
+    device. Budgeting against them over-admits until prefill allocation
+    hard-fails, which is not a recoverable condition.
+    """
+
+    def test_zero_without_active_requests(self):
+        # The veto only protects live requests; every other node is droppable.
+        ledger = _ledger()
+        self.assertEqual(ledger.device_evictable_overhang(1_000_000), 0)
+
+    def test_zero_while_host_can_absorb_the_backing_set(self):
+        ledger = _ledger()
+        ledger.activate(1, 30_000, rid="r1", decode_reserve=0)
+        self.assertEqual(ledger.device_evictable_overhang(30_000), 0)
+
+    def test_positive_once_host_cannot_absorb(self):
+        ledger = _ledger(host_tokens=20_000)
+        ledger.activate(1, 100_000, rid="r1", decode_reserve=0)
+        # 100k backed by 20k of host, minus the concurrency slack.
+        self.assertGreater(ledger.device_evictable_overhang(100_000), 0)
+
+    def test_clamped_by_the_tree_evictable_size(self):
+        # Shared prefixes double-count in the per-request sum, so the tree's own
+        # number is the ceiling; without the clamp the adder throttles on tokens
+        # the tree never held.
+        ledger = _ledger(host_tokens=1)
+        ledger.activate(1, 100_000, rid="r1", decode_reserve=0)
+        ledger.activate(2, 100_000, rid="r2", decode_reserve=0)
+        self.assertLessEqual(ledger.device_evictable_overhang(50_000), 50_000)
+
+    def test_evicted_positions_shrink_the_blocked_set(self):
+        # A position already on host is no longer blocking device eviction.
+        ledger = _ledger(host_tokens=20_000)
+        ledger.activate(1, 100_000, rid="r1", decode_reserve=0)
+        blocked = ledger.device_evictable_overhang(100_000)
+        ledger.note_evicted_positions(1, 50_000)
+        self.assertLess(ledger.device_evictable_overhang(100_000), blocked)
+
+    def test_deactivate_releases_the_whole_record(self):
+        # Everything a request holds goes back in one step. While these were
+        # parallel dicts every exit path had to pop each one by hand, and a
+        # forgotten pop is a permanent quota leak that surfaces only as
+        # unexplained admission pressure, nowhere near the path that leaked it.
+        ledger = _ledger()
+        before = ledger.reservable_left()
+        ledger.activate(1, 30_000, rid="r1", decode_reserve=8_192)
+        ledger.note_evicted_positions(1, 1_000)
+        ledger.deactivate(1)
+        self.assertEqual(ledger.reservable_left(), before)
+        self.assertEqual(ledger.device_evictable_overhang(100_000), 0)
+
+    def test_deactivate_clears_the_request(self):
+        ledger = _ledger(host_tokens=1)
+        ledger.activate(1, 100_000, rid="r1", decode_reserve=0)
+        ledger.deactivate(1)
+        self.assertEqual(ledger.device_evictable_overhang(100_000), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_hisparse_unit.py
+++ b/test/registered/unit/managers/test_hisparse_unit.py
@@ -140,10 +140,12 @@ class TestHiSparseUnit(unittest.TestCase):
             enable_memory_saver=False,
         )
 
-        from sglang.srt.managers.hisparse_coordinator import HiSparseCoordinator
+        from sglang.srt.managers.hisparse_coordinator import (
+            PrivateHostHiSparseCoordinator,
+        )
 
         cls.page_size = global_page_size
-        cls.coordinator = HiSparseCoordinator(
+        cls.coordinator = PrivateHostHiSparseCoordinator(
             req_to_token_pool=cls.req_to_token_pool,
             token_to_kv_pool_allocator=cls.allocator,
             top_k=TOP_K,
@@ -270,7 +272,7 @@ class TestHiSparseUnit(unittest.TestCase):
 
         For long-sequence tests (fill_len > DEVICE_BUFFER_SIZE) where the
         "newest token" reserved slot is not populated (it requires an actual
-        decode step + map_last_loc_to_buffer), callers should pass
+        decode step + prepare_decode_batch), callers should pass
         ``fill_len - 1`` as the effective pool size so position fill_len-1 is
         never randomly selected.
         """
@@ -346,7 +348,12 @@ class TestHiSparseUnit(unittest.TestCase):
         pass.  Tests must replicate that to get correct kernel behaviour.
         """
         self.coordinator.num_real_reqs[0] = rpi.shape[0]
-        return self.coordinator.swap_in_selected_pages(rpi, sls, batch, layer_id)
+        return self.coordinator.swap_in_selected_pages(
+            req_pool_indices=rpi,
+            compressed_seq_lens=sls,
+            top_k_result=batch,
+            layer_id=layer_id,
+        )
 
     def _cleanup_req(self, req, kv_loc, *, logical_only=False):
         """request_finished -> free KV -> free req slot."""
@@ -420,7 +427,7 @@ class TestHiSparseUnit(unittest.TestCase):
 
         # Pass fill_len-1 so position fill_len-1 ("newest token") is never
         # randomly selected — its reserved device-buffer slot is only valid
-        # after map_last_loc_to_buffer in a real decode step.
+        # after prepare_decode_batch in a real decode step.
         tokens = self._build_topk_tokens(fill_len - 1)
         batch = tokens.unsqueeze(0)
         rpi, sls = self._make_batch_tensors([req], [fill_len])
@@ -455,7 +462,7 @@ class TestHiSparseUnit(unittest.TestCase):
         rpi, sls = self._make_batch_tensors([req], [fill_len])
 
         # Step 1: load the first TOP_K positions from host (no newest token —
-        # the reserved slot is only valid after map_last_loc_to_buffer which is
+        # the reserved slot is only valid after prepare_decode_batch which is
         # called during an actual decode step, not modelled here).
         tokens_s1 = torch.arange(TOP_K, dtype=torch.int32, device="cuda")
         locs1 = self._swap_in_selected_pages(
@@ -555,7 +562,7 @@ class TestHiSparseUnit(unittest.TestCase):
         self._assert_sizes_restored(initial, "page_size_one_alloc_free_cycle")
 
     def test_decode_remap_frees_stale_page_size_one_mapping(self):
-        """map_last_loc_to_buffer frees the temporary alloc() hisparse slot."""
+        """prepare_decode_batch frees the temporary alloc() hisparse slot."""
         if self.page_size != 1:
             self.skipTest("page_size=1 decode remap path is ROCm-specific")
 
@@ -581,7 +588,7 @@ class TestHiSparseUnit(unittest.TestCase):
         req.kv.kv_allocated_len = seq_len
         req.kv_committed_len = seq_len
 
-        self.coordinator.map_last_loc_to_buffer(
+        self.coordinator.prepare_decode_batch(
             seq_lens=torch.tensor([seq_len], dtype=torch.int64, device=device),
             out_cache_loc=out_loc,
             req_pool_indices=torch.tensor(

--- a/test/registered/unit/managers/test_prefill_adder.py
+++ b/test/registered/unit/managers/test_prefill_adder.py
@@ -35,6 +35,24 @@ class _RecordingDelayer:
         return self.allow
 
 
+class _RecordingHiSparseBudget:
+    """Duck-typed HiCacheAdmitBudget that records the max_new of every call."""
+
+    device_evictable_overhang = 0
+
+    def __init__(self):
+        self.probes = []
+        self.commits = []
+
+    def future_tokens(self, total_seq_len, max_new, commit, req=None):
+        (self.commits if commit else self.probes).append(max_new)
+        # Budget as standard, so the gate arithmetic stays the plain one.
+        return max_new
+
+    def admission_exhausted(self, total_seq_len, max_new, req=None):
+        return False
+
+
 class TestPrefillAdder(CustomTestCase):
     def setUp(self):
         set_global_server_args_for_scheduler(ServerArgs(model_path="dummy"))
@@ -889,6 +907,41 @@ class TestPrefillAdder(CustomTestCase):
                 size_swa=4096, sliding_window=128
             )._swa_req_never_fits(**req)
         )
+
+    def test_hisparse_probe_and_commit_agree_on_a_retracted_request(self):
+        """One max_new basis for the admission probe and the quota commit.
+
+        A request re-prefilled after retraction carries output_ids, so its
+        remaining output budget and the scheduler's own reservation basis
+        (`min(max_new_tokens, CLIP)`) differ. Billing the commit on the
+        reservation basis can report a candidate the probe called admissible as
+        standard -- `_infeasible()` is a threshold on
+        `total_seq_len + temp_buffer + max_new`, so the two values can land on
+        opposite sides of it. The round's quota then goes unspent while the
+        coordinator admits the request anyway, and later candidates in the same
+        round are offered headroom that is already promised.
+        """
+        budget = _RecordingHiSparseBudget()
+        self.mock_token_allocator.available_size.return_value = 100_000
+        self.mock_token_allocator.full_available_size.return_value = 100_000
+        adder = self.create_adder(self.create_running_batch(), hisparse_budget=budget)
+        req = self.create_mock_req(
+            "resumed", priority=0, max_new_tokens=512, output_len=100
+        )
+        req.full_untruncated_fill_ids = list(range(4096))
+        req.last_node = MagicMock()
+        req.set_extend_range = MagicMock(
+            side_effect=lambda start, end: setattr(
+                req, "extend_range", Range(start, end)
+            )
+        )
+        req.sampling_params = SimpleNamespace(max_new_tokens=512, ignore_eos=False)
+
+        adder.add_one_req(req, has_chunked_req=False, truncation_align_size=None)
+
+        self.assertIn(req, adder.can_run_list)
+        self.assertEqual(budget.probes, [412])
+        self.assertEqual(budget.commits, [412])
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/managers/test_schedule_batch_req_pool_indices.py
+++ b/test/registered/unit/managers/test_schedule_batch_req_pool_indices.py
@@ -9,7 +9,9 @@ from sglang.test.test_utils import maybe_stub_sgl_kernel
 
 maybe_stub_sgl_kernel()
 
-from sglang.srt.managers.hisparse_coordinator import HiSparseCoordinator  # noqa: E402
+from sglang.srt.managers.hisparse_coordinator import (  # noqa: E402
+    PrivateHostHiSparseCoordinator,
+)
 from sglang.srt.managers.scheduler import Scheduler  # noqa: E402
 from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode  # noqa: E402
 
@@ -34,7 +36,7 @@ class TestHisparseDecodeBatchReqPoolCpu(unittest.TestCase):
         # _build_hisparse_decode_batch builds a ScheduleBatch off the normal
         # extend path, so it must populate the req_pool_indices_cpu host mirror
         # in lockstep with the device tensor. A missing mirror crashes hisparse
-        # decode bookkeeping (map_last_loc_to_buffer -> _grow_device_buffers
+        # decode bookkeeping (prepare_decode_batch -> _grow_device_buffers
         # indexes req_pool_indices_cpu).
         scheduler = Scheduler.__new__(Scheduler)
         scheduler.device = "cpu"
@@ -71,22 +73,22 @@ class TestHisparseCoordinatorReqPoolCpu(unittest.TestCase):
     def test_host_bookkeeping_requires_req_pool_indices_cpu(self):
         # Why the mirror must exist: hisparse host bookkeeping indexes
         # req_pool_indices_cpu element-wise (int(req_pool_indices_cpu[i]) in
-        # _eager_backup_previous_token, the first thing map_last_loc_to_buffer
+        # _eager_backup_previous_token, the first thing prepare_decode_batch
         # runs each decode step). A missing mirror (None) raises TypeError there
         # -- the exact nightly failure the scheduler-side fix prevents. Asserting
         # the crash directly keeps the "mirror is required" contract honest, with
         # no mocked attributes (the crash precedes any self access).
-        coord = HiSparseCoordinator.__new__(HiSparseCoordinator)
+        coord = PrivateHostHiSparseCoordinator.__new__(PrivateHostHiSparseCoordinator)
         seq_lens = torch.tensor([10], dtype=torch.int64)
         seq_lens_cpu = torch.tensor([10], dtype=torch.int64)
         req_pool_indices = torch.tensor([0], dtype=torch.int64)
         out_cache_loc = torch.tensor([0], dtype=torch.int64)
         with self.assertRaises(TypeError):
-            coord.map_last_loc_to_buffer(
-                seq_lens,
-                out_cache_loc,
-                req_pool_indices,
-                seq_lens_cpu,
+            coord.prepare_decode_batch(
+                seq_lens=seq_lens,
+                out_cache_loc=out_cache_loc,
+                req_pool_indices=req_pool_indices,
+                seq_lens_cpu=seq_lens_cpu,
                 req_pool_indices_cpu=None,
             )
 

--- a/test/registered/unit/mem_cache/test_hisparse_backing.py
+++ b/test/registered/unit/mem_cache/test_hisparse_backing.py
@@ -1,0 +1,370 @@
+"""Unit tests for the HiSparse backing seam.
+
+HiSparse has one user-facing switch (`--enable-hisparse`) and picks its logical
+KV pool from the cache configuration. Two things must hold for that to be safe:
+
+- the resolution matrix -- every cache configuration either resolves to exactly
+  one backing or is rejected at startup with both legal recipes named, so a
+  half-supported combination can never boot;
+- one indexer expansion ratio per backing -- the capacity model and the pool
+  construction read the same helper, or the pool overruns the memory that was
+  reserved for it.
+
+Plus a drift guard: whatever the protocol declares, every backing implements.
+"""
+
+import inspect
+import unittest
+from types import SimpleNamespace
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.hisparse_coordinator import (  # noqa: E402
+    PrivateHostHiSparseCoordinator,
+)
+from sglang.srt.managers.hisparse_hicache_coordinator import (  # noqa: E402
+    HiCacheHiSparseCoordinator,
+)
+from sglang.srt.managers.hisparse_protocol import HiSparseCoordinator  # noqa: E402
+from sglang.srt.mem_cache.sparsity import (  # noqa: E402
+    HiSparseBacking,
+    create_hisparse_coordinator,
+    hisparse_backing,
+    hisparse_indexer_expansion_ratio,
+    hisparse_indexer_regions,
+    hisparse_indexer_top_k,
+    resolve_hisparse_backing,
+)
+from sglang.srt.server_args import ServerArgs  # noqa: E402
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+def _resolve(**overrides):
+    """Resolve a HiCache-shaped configuration with the given fields replaced."""
+    kwargs = dict(
+        enable_hisparse=True,
+        disable_radix_cache=False,
+        enable_hierarchical_cache=True,
+        hicache_write_policy="write_back",
+    )
+    kwargs.update(overrides)
+    return resolve_hisparse_backing(**kwargs)
+
+
+def _flags_for(backing: HiSparseBacking) -> dict:
+    """The minimal server-args flags that resolve to `backing`."""
+    if backing is HiSparseBacking.PRIVATE_HOST:
+        return dict(enable_hisparse=True, disable_radix_cache=True)
+    return dict(
+        enable_hisparse=True,
+        enable_hierarchical_cache=True,
+        hicache_write_policy="write_back",
+    )
+
+
+def _callable_parameters(signature: inspect.Signature) -> list[tuple[str, str]]:
+    """(name, kind) per parameter, ignoring annotations and defaults.
+
+    Callers bind by name, so a rename or a positional-only parameter breaks them;
+    a differing annotation or default does not.
+    """
+    return [
+        (name, param.kind.name)
+        for name, param in signature.parameters.items()
+        if name != "self"
+    ]
+
+
+def _server_args(**overrides) -> ServerArgs:
+    """A lightweight record: model_path="dummy" early-returns __post_init__, so
+    the resolution pipeline never runs and the fields stay writable."""
+    server_args = ServerArgs(model_path="dummy")
+    for name, value in overrides.items():
+        setattr(server_args, name, value)
+    return server_args
+
+
+class TestHiSparseBackingResolution(CustomTestCase):
+    def test_off_resolves_to_no_backing(self):
+        self.assertIsNone(_resolve(enable_hisparse=False))
+        # ... whatever the cache configuration says.
+        self.assertIsNone(_resolve(enable_hisparse=False, disable_radix_cache=True))
+
+    def test_radix_disabled_is_private_host(self):
+        self.assertIs(_resolve(disable_radix_cache=True), HiSparseBacking.PRIVATE_HOST)
+        # The radix-off branch wins before any hicache field is consulted, so a
+        # stale --hicache-write-policy cannot flip it.
+        self.assertIs(
+            _resolve(
+                disable_radix_cache=True,
+                enable_hierarchical_cache=False,
+                hicache_write_policy="write_through",
+            ),
+            HiSparseBacking.PRIVATE_HOST,
+        )
+
+    def test_radix_plus_write_back_hicache_is_hicache(self):
+        self.assertIs(_resolve(), HiSparseBacking.HICACHE)
+
+    def test_radix_without_host_tier_is_rejected(self):
+        with self.assertRaises(ValueError) as caught:
+            _resolve(enable_hierarchical_cache=False)
+        message = str(caught.exception)
+        # Both legal recipes must be in the message: the user has to be able to
+        # pick one without reading the source.
+        self.assertIn("--enable-hierarchical-cache", message)
+        self.assertIn("--disable-radix-cache", message)
+
+    def test_write_through_is_rejected(self):
+        for policy in ("write_through", "write_through_selective"):
+            with self.subTest(policy=policy):
+                with self.assertRaises(ValueError) as caught:
+                    _resolve(hicache_write_policy=policy)
+                self.assertIn("write_back", str(caught.exception))
+
+
+class TestIndexerExpansionRatio(CustomTestCase):
+    def test_off_needs_no_expansion(self):
+        self.assertEqual(hisparse_indexer_expansion_ratio(_server_args()), 1.0)
+
+    def test_private_host_uses_host_to_device_ratio(self):
+        server_args = _server_args(
+            enable_hisparse=True,
+            disable_radix_cache=True,
+            hisparse_config='{"top_k": 2048, "host_to_device_ratio": 3}',
+        )
+        self.assertIs(hisparse_backing(server_args), HiSparseBacking.PRIVATE_HOST)
+        self.assertEqual(hisparse_indexer_expansion_ratio(server_args), 3.0)
+
+    def test_private_host_rejects_a_fractional_ratio(self):
+        # The private-host pool multiplies a token count by this; a fraction
+        # would surface as a non-integral buffer size inside pool allocation.
+        server_args = _server_args(
+            enable_hisparse=True,
+            disable_radix_cache=True,
+            hisparse_config='{"host_to_device_ratio": 2.5}',
+        )
+        with self.assertRaises(ValueError):
+            hisparse_indexer_expansion_ratio(server_args)
+
+    def test_hicache_covers_the_base_region_plus_both_tiers(self):
+        """`2 + hicache_ratio`, and the leading 2 is the part that gets lost.
+
+        One pool for the base region (a KV page id IS its indexer page id) plus
+        `1 + hicache_ratio` for the expanded region, which holds a copy of every
+        admitted prefix and is therefore bounded by the two tiers that can hold
+        those prefixes. Sizing the total at `1 + hicache_ratio` -- the natural
+        misreading, since that IS the two tiers -- leaves the expanded region one
+        pool short and silently halves admission depth.
+        """
+        server_args = _server_args(
+            enable_hisparse=True,
+            enable_hierarchical_cache=True,
+            hicache_write_policy="write_back",
+            hicache_ratio=4.0,
+        )
+        self.assertIs(hisparse_backing(server_args), HiSparseBacking.HICACHE)
+        self.assertEqual(hisparse_indexer_expansion_ratio(server_args), 6.0)
+
+    def test_hicache_expansion_ratio_override_wins(self):
+        server_args = _server_args(
+            enable_hisparse=True,
+            enable_hierarchical_cache=True,
+            hicache_write_policy="write_back",
+            hicache_ratio=4.0,
+            hisparse_config='{"expansion_ratio": 2.5}',
+        )
+        self.assertEqual(hisparse_indexer_expansion_ratio(server_args), 2.5)
+
+    def test_hicache_rejects_a_non_positive_override(self):
+        server_args = _server_args(
+            enable_hisparse=True,
+            enable_hierarchical_cache=True,
+            hicache_write_policy="write_back",
+            hisparse_config='{"expansion_ratio": 0}',
+        )
+        with self.assertRaises(ValueError):
+            hisparse_indexer_expansion_ratio(server_args)
+
+
+# Every implemented backing, keyed by the enum member it answers for. A further
+# backing lands by adding one row; the conformance tests then cover it.
+BACKING_IMPLEMENTATIONS = {
+    HiSparseBacking.PRIVATE_HOST: PrivateHostHiSparseCoordinator,
+    HiSparseBacking.HICACHE: HiCacheHiSparseCoordinator,
+}
+
+# Backings the configuration layer already accepts -- they resolve, size the pool
+# and pass startup validation -- but that no coordinator implements yet. Listing
+# one here is what keeps the completeness check meaningful while a port is in
+# progress, and `test_pending_backings_fail_loudly` makes the list
+# self-tightening: implementing a backing without moving it out turns that test
+# red.
+PENDING_BACKINGS = set()
+
+
+class TestIndexerTopK(CustomTestCase):
+    """One top-k rule for both backings: the model's `index_topk` wins.
+
+    Both backings size their swap-in geometry from this number, so resolving it in
+    two places is how they would end up with two different geometries for the same
+    checkpoint.
+    """
+
+    @staticmethod
+    def _model_config(index_topk=None):
+        text_config = SimpleNamespace()
+        if index_topk is not None:
+            text_config.index_topk = index_topk
+        return SimpleNamespace(hf_text_config=text_config)
+
+    def test_config_top_k_used_when_the_model_declares_none(self):
+        top_k = hisparse_indexer_top_k(
+            server_args=_server_args(hisparse_config='{"top_k": 1024}'),
+            model_config=self._model_config(),
+        )
+        self.assertEqual(top_k, 1024)
+
+    def test_the_model_value_wins_over_the_config(self):
+        # Not a mirror of the one-liner: this is the direction of precedence both
+        # backings' geometry depends on, and flipping it would size every buffer
+        # from a number the indexer does not use.
+        top_k = hisparse_indexer_top_k(
+            server_args=_server_args(hisparse_config='{"top_k": 512}'),
+            model_config=self._model_config(index_topk=2048),
+        )
+        self.assertEqual(top_k, 2048)
+
+
+class TestIndexerRegions(CustomTestCase):
+    """The base/expanded split of the indexer buffer.
+
+    Every consumer -- the expanded-page allocator and the hybrid page table --
+    derives page ids from this one place, so an off-by-one here does not raise:
+    the indexer silently scores whatever keys live at the wrong page.
+    """
+
+    def test_base_region_covers_the_whole_attention_pool(self):
+        # A KV page id doubles as its base indexer page id, so the base region has
+        # to span every page the allocator can hand out. Paged allocators start at
+        # 1, so a token loc reaches device_pool_size + page_size - 1. The two
+        # counts must also partition the buffer: a gap wastes pages, an overlap
+        # aliases two requests onto one page.
+        base_pages, expanded_pages = hisparse_indexer_regions(
+            page_size=64, num_indexer_pages=400, device_pool_size=64 * 100
+        )
+        self.assertEqual(base_pages, 101)
+        self.assertEqual(expanded_pages, 400 - 101)
+        self.assertEqual(base_pages + expanded_pages, 400)
+
+    def test_buffer_without_room_for_an_expanded_region_is_rejected(self):
+        # Sized for the pool alone: admission would have no private pages to copy
+        # an evicted prefix into, which must fail at startup rather than at the
+        # first eviction.
+        with self.assertRaises(ValueError) as caught:
+            hisparse_indexer_regions(
+                page_size=64, num_indexer_pages=101, device_pool_size=64 * 100
+            )
+        self.assertIn("expansion_ratio", str(caught.exception))
+
+
+class TestBackingsImplementTheProtocol(CustomTestCase):
+    """The compatibility guard between the backings.
+
+    Two implementations behind one protocol only stay interchangeable if nothing
+    drifts, and structural typing is not checked at runtime: a backing can lag a
+    method, or keep a stale positional signature, and every call site still
+    imports fine -- the failure shows up as a TypeError mid-forward on whichever
+    configuration exercises that path.
+    """
+
+    @staticmethod
+    def _protocol_methods():
+        return sorted(
+            name
+            for name, value in vars(HiSparseCoordinator).items()
+            if callable(value) and not name.startswith("_")
+        )
+
+    def test_the_protocol_is_not_vacuous(self):
+        # A renamed/emptied protocol would make every check below trivially pass.
+        self.assertGreater(len(self._protocol_methods()), 10)
+
+    def test_every_backing_is_accounted_for(self):
+        # The factory dispatches on this enum, so a member that is neither
+        # implemented nor listed as pending is a backing whose conformance
+        # nothing checks.
+        self.assertEqual(
+            sorted(b.value for b in HiSparseBacking),
+            sorted(b.value for b in (set(BACKING_IMPLEMENTATIONS) | PENDING_BACKINGS)),
+        )
+        self.assertEqual(
+            set(BACKING_IMPLEMENTATIONS) & PENDING_BACKINGS,
+            set(),
+            "a backing cannot be both implemented and pending",
+        )
+
+    def test_pending_backings_fail_loudly(self):
+        """A pending backing must refuse construction, not half-build something.
+
+        Its configuration already resolves and sizes the pool, so without this the
+        failure would surface as an AttributeError deep in a forward. This also
+        makes PENDING_BACKINGS self-tightening: once a backing is implemented the
+        factory stops raising, and this test fails until the row moves.
+        """
+        for backing in PENDING_BACKINGS:
+            with self.subTest(backing=backing):
+                with self.assertRaises(NotImplementedError):
+                    create_hisparse_coordinator(
+                        server_args=_server_args(**_flags_for(backing)),
+                        # Not a config stand-in: the factory only reads the model's
+                        # own indexer top-k off this, and no bag carries it.
+                        model_config=SimpleNamespace(hf_text_config=SimpleNamespace()),
+                        req_to_token_pool=None,
+                        token_to_kv_pool_allocator=None,
+                        device="cuda",
+                        tp_group=None,
+                        pp_size=1,
+                        is_speculative=False,
+                    )
+
+    def test_backings_implement_every_protocol_method(self):
+        for backing, impl in BACKING_IMPLEMENTATIONS.items():
+            missing = [
+                name
+                for name in self._protocol_methods()
+                if not callable(getattr(impl, name, None))
+            ]
+            with self.subTest(backing=backing):
+                self.assertEqual(missing, [], f"{impl.__name__} is missing {missing}")
+
+    def test_backings_match_the_protocol_signatures(self):
+        """Presence is not enough: a caller passes keywords, so a backing that
+        kept positional-only parameters -- or renamed one -- breaks only when that
+        configuration actually runs."""
+        for backing, impl in BACKING_IMPLEMENTATIONS.items():
+            for name in self._protocol_methods():
+                expected = inspect.signature(getattr(HiSparseCoordinator, name))
+                actual = inspect.signature(getattr(impl, name))
+                with self.subTest(backing=backing, method=name):
+                    self.assertEqual(
+                        _callable_parameters(expected),
+                        _callable_parameters(actual),
+                        f"{impl.__name__}.{name} does not match the protocol",
+                    )
+
+    def test_backings_declare_their_identity(self):
+        # Runtime consumers read coordinator.backing instead of re-resolving the
+        # configuration, so a backing that forgot to declare it -- or copied a
+        # sibling's value -- would silently send every caller down the wrong branch.
+        for backing, impl in BACKING_IMPLEMENTATIONS.items():
+            with self.subTest(backing=backing):
+                self.assertIs(impl.backing, backing)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/model_executor/test_hisparse_pool_configurator.py
+++ b/test/registered/unit/model_executor/test_hisparse_pool_configurator.py
@@ -31,6 +31,9 @@ class TestHiSparsePoolConfigurator(CustomTestCase):
         override = get_context().override_server_args(
             enable_hisparse=enable_hisparse,
             hisparse_config=f'{{"host_to_device_ratio": {host_to_device_ratio}}}',
+            # Resolves the backing to private-host, whose indexer expansion is
+            # host_to_device_ratio -- the ratio these cases scale.
+            disable_radix_cache=True,
             enable_hierarchical_cache=False,
             disaggregation_mode="null",
             dsa_prefill_backend="flashmla_sparse",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

A compatible implementation of https://github.com/sgl-project/sglang/pull/32314.

HiSparse enables high-concurrency long-context decode for Sparse Attention models.
Today the KV that is *not* in that hot set can live in exactly one place — a private pinned host pool owned by the coordinator. That single choice carries two structural drawbacks:

1. **The radix cache must be off** (`--disable-radix-cache` is required), so shared-prefix and multi-turn workloads get no prefix reuse at all;
2. **The regular GPU KV pool is bypassed**, so HBM that could hold hot KV goes unused.

This PR names the axis those drawbacks live on — *where a token's attention KV is while it is not in the hot working set* — and makes it a **pluggable backing** resolved from the cache configuration, so `--enable-hisparse` remains the only switch users write:

| radix cache | hierarchical cache | write policy | resolved backing |
|---|---|---|---|
| off | – | – | `private_host` (today's behaviour, bit-for-bit) |
| on | on | `write_back` | `hicache` (new) |
| on | off | – | rejected at startup, naming both legal recipes |
| on | on | other | rejected at startup, requires `write_back` |


## Modifications

<!-- Detail the changes made in this pull request. -->

`--enable-hisparse` off (default) is untouched; the private-host backing is behaviour-preserving.

- **`managers/hisparse_protocol.py`** (new): the coordinator interface both backings answer, so call sites never learn which one they got. Paths a single backing has stay off the protocol (PD direct-to-host, DeepSeek V4, shared-index prefetch key on `coordinator.backing` and talk to the concrete class), so the protocol never grows a member with one real implementation.
- **`managers/hisparse_hicache_coordinator.py`** (new): the HiCache backing. Admission (expanded indexer pages + temp device buffer, then early tree-lock release so the prefix becomes evictable), eviction application at the one controlled point between two forwards, hybrid indexer page table, swap-in, finish/retract release.
- **`managers/hisparse_hicache_admission.py`** (new): the admission ledger and per-round quota. Pure integer arithmetic, no tensors, so it is unit-testable on CPU.
- **`mem_cache/sparsity/factory.py`**: `HiSparseBacking` + `resolve_hisparse_backing` (pure, no torch, so startup validation can import it), the coordinator factory, and one sizing helper.
- **`kernels/jit/csrc/hisparse.cuh` / `kernels/ops/kvcache/hisparse.py`**: the existing fused swap-in kernel gains two compile-time flags — a third *pass-through* source (`req_to_token >= 0` means the pool still owns the position, so emit its slot with no copy and no buffer slot) and a late-bound host base+row-stride (HiCache attaches its host tier after CUDA-graph capture, and its `page_first` rows are `layer_num` cells apart). The all-false private-host instantiation stays byte-identical.
- **`layers/attention/dsa_backend.py`**: the indexer's page table becomes backing-aware (evicted prefix pages resolve to request-private expanded pages), including an in-place substitution into the graph-static buffer after the metadata kernels rebuild it.
- **`mem_cache/unified_cache/unified_tree_core.py` / `unified_radix_cache.py`**: eviction hooks (a `NamedTuple` of two callables, not a monkey-patch), a copy-less-drop veto for data backing a live request, and the early-lock-release bookkeeping on the finish path.
- **Scheduler / budget**: admission-aware future-token reservation and a quota gate that keeps a candidate queued rather than letting it run standard and pin its whole prefix on device.
- **Capacity model**: `hisparse_indexer_expansion_ratio` is the single source for both the reserved memory and the allocated `index_buf_size`, so they cannot drift. For the HiCache backing the total is `2 + hicache_ratio`: one pool for the base region (a KV page id doubles as its indexer page id) plus `1 + hicache_ratio` for the expanded region, which holds a copy of every admitted prefix and is bounded by the two tiers those prefixes can live in. `1 + hicache_ratio` is the natural misreading, and it silently halves admission depth.



## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

DSv3.2 FP8, 4x GB200, `--tp 4 --enable-dp-attention --dp 4`, `temperature=0`.

- **gsm8k** (`sglang.test.few_shot_gsm8k`, 200 questions, parallel 64, `--temperature 0`):

| shots (prompt) | Baseline | HiSparse `hicache` |
|---|---|---|
| 32-shot (~5K) | 0.980 | 0.980 |
| 128-shot (~19K) | 0.990 | **0.995** |


## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

Setup: DSv3.2 FP8 (KV cache `fp8_e4m3`, auto-selected for DSA on SM10x), 4x GB200, `--tp 4 --enable-dp-attention --dp 4`, `--max-total-tokens 60000`, `--mem-fraction-static 0.95`. Host budget equalized at 2x the device pool on both backings (`host_to_device_ratio: 2` / `--hicache-ratio 2`). Three numbers per workload: end-to-end output throughput (client wall clock, includes prefill), the server-reported decode-phase `gen throughput` summed over the 4 DP ranks, and the peak concurrent requests per DP rank.

| Workload | Metric | Baseline | HiSparse `private_host` | HiSparse `hicache` |
|---|---|---|---|---|
| 32 x unique 30.8K, out 512 | output tok/s (e2e) | 139.2 | 182.1 | **217.6** |
| | gen tok/s (decode, Σ4 ranks) | 227 | 399 | **563** |
| | max running-req / rank | 1 | 3 | **4** |
| 64 x unique 30.8K, out 1024 (working set ~9.8x pool) | output tok/s (e2e) | 168.8 | 233.0 | **309.8** |
| | gen tok/s (decode, Σ4 ranks) | 223 | 394 | **557** |
| | max running-req / rank | 1 | 3 | **4** |
| 64 x shared 26K + unique 15K (~42K, near pool cap), out 1024 | output tok/s (e2e) | 227.1 | 182.5 | **260.4** |
| | gen tok/s (decode, Σ4 ranks) | 221 | 313 | **335** |
| | max running-req / rank | 2 | 2 | **3** |

<details>
<summary>Server launch commands</summary>

Common prefix (all three configs):

```bash
python -m sglang.launch_server --model-path <DeepSeek-V3.2, FP8> \
    --tp 4 --enable-dp-attention --dp 4 \
    --dsa-prefill-backend flashmla_kv --dsa-decode-backend flashmla_kv \
    --mem-fraction-static 0.95 --max-total-tokens 60000 \
    --cuda-graph-max-bs-decode 16 --cuda-graph-backend-prefill disabled \
    --moe-runner-backend triton --disable-flashinfer-autotune
```

Baseline: common prefix only.

HiSparse, `private_host` backing (radix cache must be off; explicit `--max-running-requests` required — the per-request tables are sized by the req-slot count):

```bash
    --enable-hisparse --disable-radix-cache \
    --hisparse-config '{"top_k": 2048, "device_buffer_size": 4096, "host_to_device_ratio": 2}' \
    --max-running-requests 64
```

HiSparse, `hicache` backing:

```bash
    --enable-hisparse \
    --enable-hierarchical-cache --hicache-write-policy write_back --hicache-ratio 2 \
    --hisparse-config '{"top_k": 2048}' \
    --max-running-requests 64
```

</details>


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #32230751929](https://github.com/sgl-project/sglang/actions/runs/32230751929)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #32230751863](https://github.com/sgl-project/sglang/actions/runs/32230751863)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->