### PR TITLE
Fix M-RoPE positions when an extend reaches past the precomputed mm table

### DIFF
--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -1243,9 +1243,31 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
                     :,
                     extend_prefix_len : extend_prefix_len + extend_seq_len,
                 ]
-                if mrope_positions.numel() == 0:
-                    mrope_positions = self._expand_mrope_from_input(
-                        mm_input, seq_lens_cpu[batch_idx]
+                if mrope_positions.shape[1] < extend_seq_len:
+                    # A continuation of a held request (e.g. a session) can
+                    # extend past the precomputed table; the uncovered span is
+                    # text after the last mm item, whose positions continue
+                    # sequentially from mrope_position_delta, the same rule
+                    # the decode path applies. This also covers the fully
+                    # uncovered case, where the previous fallback returned a
+                    # single-column tensor for a multi-token extend.
+                    if mm_input.mrope_position_delta_repeated_cache is None:
+                        mm_input.mrope_position_delta_repeated_cache = (
+                            (mm_input.mrope_position_delta - 1)
+                            .flatten()
+                            .unsqueeze(0)
+                            .repeat(3, 1)
+                        )
+                    covered = mrope_positions.shape[1]
+                    lengths = torch.arange(
+                        extend_prefix_len + covered + 1,
+                        extend_prefix_len + extend_seq_len + 1,
+                    ).unsqueeze(0)
+                    tail = (
+                        mm_input.mrope_position_delta_repeated_cache[:, :1] + lengths
+                    )
+                    mrope_positions = torch.cat(
+                        [mrope_positions.to(tail.dtype), tail], dim=1
                     )
             mrope_positions_list[batch_idx] = mrope_positions
 


### PR DESCRIPTION
## Motivation

Fixes #35482.

A continuation of a held request (a session extension via `session_params: {id, rid}`) can have
an extend window that reaches past the mm input's precomputed `mrope_positions` table. The
extend branch of `ForwardBatch._compute_mrope_positions` sliced that table without checking
coverage: a partially covered window silently truncated to the overlapping columns, producing a
wrong-width `(3, N)` position tensor that crashes the whole engine in the batch loader
(`torch._foreach_copy_` size mismatch, all TP schedulers exit). The `numel() == 0` guard only
caught the fully uncovered case, and its fallback returned a single-column tensor for a
multi-token extend, which hits the same crash.

Instrumented crash batch on Qwen3.8-27B (tp4, BF16), text-only session continuation:

```
extend_lens=[50] prefix_lens=[896] -> sliced mrope width (3, 2)
copy mismatch dst=(3, 50) src=(3, 2)
RuntimeError: The size of tensor a (50) must match the size of tensor b (2) at non-singleton dimension 1
```

On GDN hybrids the window is widened further because the continuation resumes from the last
mamba state checkpoint (`prefix_lens` snaps down to a multiple of `mamba_track_interval`),
making the overrun easy to hit, but the defect is reachable by any M-RoPE model served with
sessions. We reproduced the engine death 6/6 times across native and streaming session modes,
with and without prefill CUDA graphs, with multimodal and text-only continuations.

## Modifications

In the extend branch, when the sliced window is narrower than `extend_seq_len`, fill the
uncovered span with sequential positions continuing from `mrope_position_delta`, the same rule
the decode path applies. The span past the table is text after the last mm item, for which
sequential positions are the correct M-RoPE assignment. This replaces the `numel() == 0`
fallback and covers the fully uncovered case with correct width.

## Accuracy Tests

Validated on the reproduction pod (Qwen3.8-27B, tp4, BF16, 32k context):

- The 6/6-fatal reproduction now completes: the rid-chained continuation answers correctly
  (turn 2 "Say one word." -> "Book", stop matched `<|im_end|>`).
- Two 16-turn multimodal session conversations (one native, one streaming mode), growing to 26
  images, completed with coherent, history-aware answers: turn 5 correctly recalls the book
  cover shown at turn 1, turn 12 retrieves content from the start of the conversation, turn 14
  summarizes the full browse. This checks that the filled-in positions are semantically right,
  not merely shape-compatible.

## Speed Tests and Profiling

Session-continuation TTFT on the fixed build stays flat with depth: 16 turns growing 2 -> 26
images, TTFT 212ms (turn 1) -> 178ms (turn 16, ~24k resident tokens) in native session mode,
181 -> 176ms in streaming mode. The identical conversation served statelessly on the same pod
rises to 440ms (radix-cached) / 1259ms (uncached tail layout) at turn 16.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Happy to add a unit test for `_compute_mrope_positions` partial coverage if maintainers can
point at the preferred harness for `ForwardBatch`-level tests.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32231303625](https://github.com/sgl-project/sglang/actions/runs/32231303625)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32231303546](https://github.com/sgl-project/sglang/actions/runs/32231303546)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->