### PR TITLE
fix: handle multimodal Kimi-K3 Responses prompts

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -593,7 +593,10 @@ class OpenAIServingResponses(OpenAIServingChat):
         is_multimodal = self.tokenizer_manager.model_config.is_multimodal
         processed_messages = self._process_messages(chat_request, is_multimodal)
 
-        if is_multimodal:
+        if is_multimodal and self.chat_encoding_spec == "kimi_k3":
+            request_prompts = [processed_messages.prompt_ids]
+            engine_prompts = [processed_messages.prompt_ids]
+        elif is_multimodal:
             request_prompts = [processed_messages.prompt]
             engine_prompts = [processed_messages.prompt]
         else:

--- a/test/registered/unit/entrypoints/openai/test_serving_responses.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_responses.py
@@ -246,6 +246,44 @@ class ChatToolForwardingTestCase(CustomTestCase):
         self.assertEqual(request_prompts, [[4, 5, 6]])
         self.assertEqual(engine_prompts, [[4, 5, 6]])
 
+    def test_multimodal_kimi_k3_request_uses_prompt_ids(self):
+        serving = make_serving(is_multimodal=True)
+        serving.chat_encoding_spec = "kimi_k3"
+        serving._process_messages = Mock(
+            return_value=MessageProcessingResult(
+                prompt="",
+                prompt_ids=[4, 5, 6],
+                image_data=["http://example.com/cat.png"],
+                audio_data=None,
+                video_data=None,
+                modalities=["image"],
+                stop=[],
+            )
+        )
+        request = ResponsesRequest(
+            model="x",
+            input=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": "describe it"},
+                        {
+                            "type": "input_image",
+                            "image_url": "http://example.com/cat.png",
+                        },
+                    ],
+                }
+            ],
+            store=False,
+        )
+
+        _, request_prompts, engine_prompts, _ = asyncio.run(
+            serving._make_request(request, None, serving.tokenizer_manager.tokenizer)
+        )
+
+        self.assertEqual(request_prompts, [[4, 5, 6]])
+        self.assertEqual(engine_prompts, [[4, 5, 6]])
+
 
 class ReasoningRequestForwardingTestCase(unittest.TestCase):
     def test_create_responses_uses_processed_reasoning_state(self):


### PR DESCRIPTION
## Motivation

Fixes #35460. The `/v1/responses` endpoint returns HTTP 400 for multimodal Kimi-K3 requests because its custom encoder produces usable `prompt_ids` while leaving the decoded `prompt` empty.

## Modifications

- Route multimodal Kimi-K3 Responses requests through `processed_messages.prompt_ids`, matching the existing Chat Completions path.
- Add a registered CPU unit regression test covering the empty-text/non-empty-token-ID case.

## Accuracy Tests

Not applicable. This change only fixes prompt forwarding; it does not change model computation.

## Speed Tests and Profiling

Not applicable. No performance-sensitive path was changed.

## Validation

- Targeted pre-commit passed on the remote test host for both changed files.
- `test/registered/unit/entrypoints/openai/test_serving_responses.py`: 34 passed.

## Checklist

- [x] Format code with pre-commit.
- [x] Add a unit regression test.
- [x] Documentation changes are not needed for this internal routing fix.
- [x] Accuracy and speed benchmarks are not applicable.
- [x] Follow the SGLang code style.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32231421058](https://github.com/sgl-project/sglang/actions/runs/32231421058)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32231420776](https://github.com/sgl-project/sglang/actions/runs/32231420776)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->