### PR TITLE
[CPU] Support Qwen3.8 text+video: adding torchcodec, ffmpeg and removing pin_memory

### DIFF
--- a/docker/xeon.Dockerfile
+++ b/docker/xeon.Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && \
     apt-get full-upgrade -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     ca-certificates \
+    ffmpeg \
     git \
     curl \
     wget \

--- a/docker/xeon.Dockerfile
+++ b/docker/xeon.Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
     apt-get full-upgrade -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     ca-certificates \
-    ffmpeg \
+    ffmpeg=7:8.0.1-3ubuntu2 \
     git \
     curl \
     wget \

--- a/docker/xeon.Dockerfile
+++ b/docker/xeon.Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
     apt-get full-upgrade -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
     ca-certificates \
-    ffmpeg=7:8.0.1-3ubuntu2 \
+    ffmpeg \
     git \
     curl \
     wget \

--- a/python/pyproject_cpu.toml
+++ b/python/pyproject_cpu.toml
@@ -62,6 +62,7 @@ dependencies = [
   "timm==1.0.16",
   "torch==2.12.0",
   "torchaudio==2.11.0",
+  "torchcodec==0.12.0 ; sys_platform != 'linux' or (sys_platform == 'linux' and platform_machine != 'aarch64' and platform_machine != 'arm64' and platform_machine != 'armv7l')",
   "torchvision==0.27.0",
   "tqdm",
   "transformers==5.12.1",

--- a/python/sglang/srt/multimodal/processors/qwen_vl.py
+++ b/python/sglang/srt/multimodal/processors/qwen_vl.py
@@ -267,7 +267,8 @@ async def preprocess_video(
         [resized_height, resized_width],
         interpolation=InterpolationMode.BILINEAR,
     )
-    video = video.pin_memory()
+    if not is_cpu():
+        video = video.pin_memory()
     video_metadata = {
         "fps": video_fps,
         "duration": total_frames / video_fps,

--- a/python/sglang/srt/utils/video_decoder.py
+++ b/python/sglang/srt/utils/video_decoder.py
@@ -48,6 +48,7 @@ class VideoDecoderWrapper:
             multiple decoders in parallel threads.
         """
         self._source = source
+        self._device = device
         self._num_decode_threads = num_decode_threads
         self._source_bytes = source if isinstance(source, bytes) else None
         self._source_path = source if isinstance(source, str) else None
@@ -140,10 +141,13 @@ class VideoDecoderWrapper:
 
         if _BACKEND == "torchcodec":
             batch = self._decoder.get_frames_at(indices)
+            if self._device == "cpu":
+                return batch.data
             return batch.data if batch.data.is_cuda else batch.data.pin_memory()
         else:
             arr = self._decoder.get_batch(indices).asnumpy()
-            return torch.from_numpy(arr).pin_memory()
+            output = torch.from_numpy(arr)
+            return output if self._device == "cpu" else output.pin_memory()
 
     def _parallel_decode(self, indices, num_threads):
         """Decode frames using multiple VideoDecoder instances in parallel threads."""
@@ -177,6 +181,8 @@ class VideoDecoderWrapper:
                 results[idx] = future.result()
 
         output = torch.cat(results, dim=0)
+        if self._device == "cpu":
+            return output
         return output if output.is_cuda else output.pin_memory()
 
     @property

--- a/python/sglang/srt/utils/video_decoder.py
+++ b/python/sglang/srt/utils/video_decoder.py
@@ -33,6 +33,13 @@ def _try_cuda_backend() -> bool:
     return _cuda_backend_enabled
 
 
+def _is_cpu_engine() -> bool:
+    # Lazy import to avoid circular dependency issues and unnecessary imports on module load
+    from sglang.srt.utils.common import is_cpu
+
+    return is_cpu()
+
+
 class VideoDecoderWrapper:
     """Unified video decoder that uses torchcodec when available, decord as fallback.
 
@@ -48,7 +55,6 @@ class VideoDecoderWrapper:
             multiple decoders in parallel threads.
         """
         self._source = source
-        self._device = device
         self._num_decode_threads = num_decode_threads
         self._source_bytes = source if isinstance(source, bytes) else None
         self._source_path = source if isinstance(source, str) else None
@@ -141,13 +147,13 @@ class VideoDecoderWrapper:
 
         if _BACKEND == "torchcodec":
             batch = self._decoder.get_frames_at(indices)
-            if self._device == "cpu":
+            if _is_cpu_engine():
                 return batch.data
             return batch.data if batch.data.is_cuda else batch.data.pin_memory()
         else:
             arr = self._decoder.get_batch(indices).asnumpy()
             output = torch.from_numpy(arr)
-            return output if self._device == "cpu" else output.pin_memory()
+            return output if _is_cpu_engine() else output.pin_memory()
 
     def _parallel_decode(self, indices, num_threads):
         """Decode frames using multiple VideoDecoder instances in parallel threads."""
@@ -181,7 +187,7 @@ class VideoDecoderWrapper:
                 results[idx] = future.result()
 
         output = torch.cat(results, dim=0)
-        if self._device == "cpu":
+        if _is_cpu_engine():
             return output
         return output if output.is_cuda else output.pin_memory()
 


### PR DESCRIPTION


<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
This PR is to support Qwen3.8 text+video, by adding torchcodec, ffmpeg and removing pin_memory.
Current, torch is 2.12, torchcodec uses 0.12.0 accordingly. ffmpeg needs <9. Default ffmpeg version in ubuntu 26.04 of xeon.dockerfile is 8.0.1, can meet the requirement.

## Reproduce
Launch server:
`sglang serve --model-path Qwen/Qwen3.8-27B  --device cpu  --disable-overlap-schedule  --tp 6  --reasoning-parser qwen3  --tool-call-parser qwen3_coder --mem-fraction-static 0.8`

Client:
```
from openai import OpenAI
client = OpenAI(
    base_url="http://localhost:30000/v1",
    api_key="EMPTY"
)
response = client.chat.completions.create(
    model="Qwen/Qwen3.8-27B",
    messages=[
        {
            "role": "user",
            "content": [
                {
                    "type": "video_url",
                    "video_url": {
                        "url": "https://qianwen-res.oss-accelerate.aliyuncs.com/Qwen3.5/demo/video/N1cdUjctpG8.mp4"
                    }
                },
                {
                    "type": "text",
                    "text": "Describe what happens in this video."
                }
            ]
        }
    ],
    max_tokens=2048,
    stream=True
)
thinking_started = False
has_thinking = False
has_answer = False
for chunk in response:
    if chunk.choices and len(chunk.choices) > 0:
        delta = chunk.choices[0].delta
        if hasattr(delta, 'reasoning_content') and delta.reasoning_content:
            if not thinking_started:
                print("=============== Thinking =================", flush=True)
                thinking_started = True
            has_thinking = True
            print(delta.reasoning_content, end="", flush=True)
        if delta.content:
            if has_thinking and not has_answer:
                print("\n=============== Content =================", flush=True)
                has_answer = True
            print(delta.content, end="", flush=True)
print()

```
## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34189963274](https://github.com/sgl-project/sglang/actions/runs/34189963274)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34191317185](https://github.com/sgl-project/sglang/actions/runs/34191317185)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34189963237](https://github.com/sgl-project/sglang/actions/runs/34189963237)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->