### PR TITLE
[AMD] Improve K3 dspark draft attn kernel perf

### DIFF
--- a/python/sglang/kernels/ops/attention/verify_mla.py
+++ b/python/sglang/kernels/ops/attention/verify_mla.py
@@ -504,7 +504,7 @@ class VerifyMLA:
         qo_indptr,
         kv_indptr,
         sm_scale,
-        draft_block_causal=True,
+        is_causal=True,
     ):
         grid = (bs, self.h_q)
         _verify_mla_combine_stage2[grid](
@@ -541,7 +541,7 @@ class VerifyMLA:
             BLOCK_N=self.block_n,
             KV_GROUP_NUM=self.kv_group_num,
             HAS_KV_HEADS=self.has_kv_heads,
-            IS_CAUSAL=draft_block_causal,
+            IS_CAUSAL=is_causal,
             num_warps=4,
             num_stages=1,
         )

--- a/python/sglang/kernels/ops/attention/verify_mla.py
+++ b/python/sglang/kernels/ops/attention/verify_mla.py
@@ -30,6 +30,7 @@ _BLOCK_CONFIG = {
     # head_dim: (BLOCK_H, BLOCK_N, num_warps)
     256: (4, 64, 8),  # Qwen3.5 TP2 / TP4 / TP8
     576: (4, 64, 8),  # K3 MLA (kv_lora_rank 512 + qk_rope 64)
+    64: (4, 256, 4),  # K3 GQA (dspark draft attention)
 }
 
 
@@ -70,6 +71,8 @@ def _verify_mla_prefix_stage1(
     stride_qh,
     stride_buf_kbs,
     stride_buf_vbs,
+    stride_buf_kh,
+    stride_buf_vh,
     stride_ob,
     stride_oh,
     stride_os,
@@ -80,6 +83,8 @@ def _verify_mla_prefix_stage1(
     H_Q: tl.constexpr,
     L_EXT: tl.constexpr,
     BLOCK_H: tl.constexpr,
+    KV_GROUP_NUM: tl.constexpr,
+    HAS_KV_HEADS: tl.constexpr,
     NOPE_DIM: tl.constexpr,
     PE_DIM: tl.constexpr,
     V_HEAD_DIM: tl.constexpr,
@@ -103,6 +108,16 @@ def _verify_mla_prefix_stage1(
     if split_kv_id < active:
         head_start = head_block * BLOCK_H
         offs_h = head_start + tl.arange(0, BLOCK_H)
+        # The caller guarantees KV_GROUP_NUM % BLOCK_H == 0, so every query head
+        # in this block maps to the same KV head and the K/V tiles stay 2D loads.
+        # MLA has a single latent head; keeping the offset out of that path
+        # entirely preserves the original address arithmetic in the inner loop.
+        if HAS_KV_HEADS:
+            kv_head_off_k = (head_start // KV_GROUP_NUM) * stride_buf_kh
+            kv_head_off_v = (head_start // KV_GROUP_NUM) * stride_buf_vh
+        else:
+            kv_head_off_k = 0
+            kv_head_off_v = 0
         offs_l = tl.arange(0, L_EXT)
         offs_dn = tl.arange(0, BLOCK_DNOPE)
         offs_dp = tl.arange(0, BLOCK_DPE)
@@ -149,7 +164,7 @@ def _verify_mla_prefix_stage1(
             kv_loc = tl.load(
                 kv_indices + cur_batch_kv_start_idx + offs_n, mask=n_mask, other=0
             )
-            base = kv_loc[None, :] * stride_buf_kbs
+            base = kv_loc[None, :] * stride_buf_kbs + kv_head_off_k
             k_nope = tl.load(
                 K_Buffer + base + offs_dn[:, None],
                 mask=(offs_dn[:, None] < NOPE_DIM) & n_mask[None, :],
@@ -169,7 +184,10 @@ def _verify_mla_prefix_stage1(
             # MLA exposes its latent V through V_Buffer; ordinary shared-KV
             # attention has an independent V cache. Both use this same load.
             v = tl.load(
-                V_Buffer + kv_loc[:, None] * stride_buf_vbs + offs_dv[None, :],
+                V_Buffer
+                + kv_loc[:, None] * stride_buf_vbs
+                + kv_head_off_v
+                + offs_dv[None, :],
                 mask=n_mask[:, None] & (offs_dv[None, :] < V_HEAD_DIM),
                 other=0.0,
             )
@@ -228,6 +246,8 @@ def _verify_mla_combine_stage2(
     stride_qh,
     stride_kebs,
     stride_vebs,
+    stride_keh,
+    stride_veh,
     stride_oobs,
     stride_ooh,
     L_EXT: tl.constexpr,
@@ -236,9 +256,18 @@ def _verify_mla_combine_stage2(
     BLOCK_DMODEL: tl.constexpr,
     BLOCK_DV: tl.constexpr,
     BLOCK_N: tl.constexpr,
+    KV_GROUP_NUM: tl.constexpr,
+    HAS_KV_HEADS: tl.constexpr,
+    IS_CAUSAL: tl.constexpr,
 ):
     cur_batch = tl.program_id(0)
     cur_head = tl.program_id(1)
+    if HAS_KV_HEADS:
+        kv_head_off_ke = (cur_head // KV_GROUP_NUM) * stride_keh
+        kv_head_off_ve = (cur_head // KV_GROUP_NUM) * stride_veh
+    else:
+        kv_head_off_ke = 0
+        kv_head_off_ve = 0
 
     offs_d = tl.arange(0, BLOCK_DMODEL)
     offs_dv = tl.arange(0, BLOCK_DV)
@@ -294,13 +323,19 @@ def _verify_mla_combine_stage2(
     q = tl.load(
         Q + offs_q, mask=mask_l[:, None] & (offs_d[None, :] < HEAD_DIM), other=0.0
     ).to(tl.float32)
-    offs_ke = (cur_q_start + offs_l)[:, None] * stride_kebs + offs_d[None, :]
+    offs_ke = (
+        (cur_q_start + offs_l)[:, None] * stride_kebs + kv_head_off_ke + offs_d[None, :]
+    )
     ke = tl.load(
         K_Extend + offs_ke,
         mask=mask_l[:, None] & (offs_d[None, :] < HEAD_DIM),
         other=0.0,
     ).to(tl.float32)
-    offs_ve = (cur_q_start + offs_l)[:, None] * stride_vebs + offs_dv[None, :]
+    offs_ve = (
+        (cur_q_start + offs_l)[:, None] * stride_vebs
+        + kv_head_off_ve
+        + offs_dv[None, :]
+    )
     ve = tl.load(
         V_Extend + offs_ve,
         mask=mask_l[:, None] & (offs_dv[None, :] < V_HEAD_DIM),
@@ -309,9 +344,14 @@ def _verify_mla_combine_stage2(
 
     # scores[i,j] = q_i . k_j  (i query, j key)  -> [L_EXT, L_EXT]
     qk = tl.sum(q[:, None, :] * ke[None, :, :], 2) * sm_scale
-    # causal among drafts: query i sees key j iff j <= i, and both valid
-    causal = (offs_l[None, :] <= offs_l[:, None]) & mask_l[None, :] & mask_l[:, None]
-    qk = tl.where(causal, qk, float("-inf"))
+    # causal: query i sees key j iff j <= i
+    # non-causal: query i sees all keys
+    both_valid = mask_l[None, :] & mask_l[:, None]
+    if IS_CAUSAL:
+        vis = (offs_l[None, :] <= offs_l[:, None]) & both_valid
+    else:
+        vis = both_valid
+    qk = tl.where(vis, qk, float("-inf"))
     m_d = tl.max(qk, 1)
     pd = tl.exp(qk - m_d[:, None])
     denom_d = tl.sum(pd, 1)
@@ -348,8 +388,16 @@ class VerifyMLA:
         block_h=DEFAULT_BLOCK_H,
         block_n=DEFAULT_BLOCK_N,
         num_warps=DEFAULT_NUM_WARPS,
+        kv_group_num=None,
     ):
         self.h_q = h_q
+        # MLA is the h_kv == 1 case (kv_group_num == h_q); a GQA draft passes a
+        # smaller group. block_h must divide it so a head block maps to one KV
+        # head -- can_handle enforces that before this is constructed.
+        self.kv_group_num = h_q if kv_group_num is None else kv_group_num
+        # h_kv == 1 (MLA / MQA) needs no KV-head offset at all; making that a
+        # constexpr keeps the inner-loop addressing identical to the original.
+        self.has_kv_heads = self.kv_group_num < h_q
         self.head_dim = head_dim
         self.v_head_dim = v_head_dim
         self.nope_dim = v_head_dim
@@ -419,6 +467,8 @@ class VerifyMLA:
             q_extend.stride(1),
             k_buffer.stride(0),
             v_buffer.stride(0),
+            k_buffer.stride(1),
+            v_buffer.stride(1),
             self.att_out.stride(0),
             self.att_out.stride(1),
             self.att_out.stride(2),
@@ -429,6 +479,8 @@ class VerifyMLA:
             H_Q=self.h_q,
             L_EXT=self.l_pad,
             BLOCK_H=self.block_h,
+            KV_GROUP_NUM=self.kv_group_num,
+            HAS_KV_HEADS=self.has_kv_heads,
             NOPE_DIM=self.nope_dim,
             PE_DIM=self.pe_dim,
             V_HEAD_DIM=self.v_head_dim,
@@ -452,6 +504,7 @@ class VerifyMLA:
         qo_indptr,
         kv_indptr,
         sm_scale,
+        draft_block_causal=True,
     ):
         grid = (bs, self.h_q)
         _verify_mla_combine_stage2[grid](
@@ -476,6 +529,8 @@ class VerifyMLA:
             q_extend.stride(1),
             k_extend.stride(0),
             v_extend.stride(0),
+            k_extend.stride(1),
+            v_extend.stride(1),
             o_out.stride(0),
             o_out.stride(1),
             L_EXT=self.l_pad,
@@ -484,6 +539,9 @@ class VerifyMLA:
             BLOCK_DMODEL=triton.next_power_of_2(self.head_dim),
             BLOCK_DV=triton.next_power_of_2(self.v_head_dim),
             BLOCK_N=self.block_n,
+            KV_GROUP_NUM=self.kv_group_num,
+            HAS_KV_HEADS=self.has_kv_heads,
+            IS_CAUSAL=draft_block_causal,
             num_warps=4,
             num_stages=1,
         )
@@ -502,6 +560,7 @@ class VerifyMLA:
         o_out=None,
         k_scale=1.0,
         v_scale=1.0,
+        is_causal=True,
     ):
         if o_out is None:
             o_out = torch.empty(
@@ -535,6 +594,7 @@ class VerifyMLA:
             qo_indptr,
             kv_indptr,
             sm_scale,
+            is_causal=is_causal,
         )
         return o_out
 
@@ -542,11 +602,20 @@ class VerifyMLA:
 _VMLA_CACHE = {}
 
 
-def _get_vmla(max_bs, h_q, head_dim, v_head_dim, l_ext, device):
-    key = (h_q, head_dim, v_head_dim, l_ext, str(device))
+def _get_vmla(max_bs, h_q, head_dim, v_head_dim, l_ext, device, kv_group_num=None):
+    key = (h_q, head_dim, v_head_dim, l_ext, str(device), kv_group_num)
     vk = _VMLA_CACHE.get(key)
     if vk is None:
         block_h, block_n, num_warps = block_config(head_dim)
+        if (
+            kv_group_num is not None
+            and kv_group_num < h_q  # i.e. h_kv > 1, so the offset is live
+            and kv_group_num % block_h != 0
+        ):
+            # Shrink the head block so it stays inside one KV head. can_handle
+            # only admits power-of-two groups in that case, so this stays valid
+            # for tl.arange(0, BLOCK_H).
+            block_h = kv_group_num
         vk = VerifyMLA(
             max_bs,
             h_q,
@@ -557,6 +626,7 @@ def _get_vmla(max_bs, h_q, head_dim, v_head_dim, l_ext, device):
             block_h=block_h,
             block_n=block_n,
             num_warps=num_warps,
+            kv_group_num=kv_group_num,
         )
         _VMLA_CACHE[key] = vk
     else:
@@ -588,8 +658,9 @@ def can_handle(
     baseline.
 
     IMPORTANT: ``custom_mask`` is intentionally NOT inspected (its values can't
-    be read inside a captured HIP graph without a host sync). The kernel always
-    computes pure-causal attention, which equals the tree mask ONLY at
+    be read inside a captured HIP graph without a host sync). Every draft query
+    sees the whole committed prefix and, when ``is_causal``, only its own
+    predecessors among the draft tokens -- that is the tree mask ONLY at
     speculative topk == 1. The caller therefore MUST gate enablement on topk == 1
     (TritonAttnBackend does: ``use_verify_shared_kv = ... and self.topk == 1``).
     At topk > 1 the tree is not causal and this path must stay disabled."""
@@ -602,7 +673,7 @@ def can_handle(
         return False
     if xai_temperature_len is not None and xai_temperature_len > 0:
         return False
-    if not is_causal:
+    if not is_causal and custom_mask is not None:
         return False
     # q layout must be [tokens, H_Q, D]; head dims handled by power-of-2 pad.
     if q_extend.dim() != 3 or k_extend.dim() != 3 or v_extend.dim() != 3:
@@ -611,6 +682,9 @@ def can_handle(
     h_q = q_extend.shape[1]
     h_kv = k_extend.shape[1]
     if h_kv == 0 or h_q % h_kv != 0:
+        return False
+    kv_group_num = h_q // h_kv
+    if h_kv > 1 and (kv_group_num & (kv_group_num - 1)) != 0:
         return False
     # head dims must match buffers.
     if k_buffer.shape[1] != h_kv or v_buffer.shape[1] != h_kv:
@@ -676,7 +750,8 @@ def verify_shared_kv_fwd(
     """
     Grouped-head drop-in for extend_attention_fwd on a topk==1 target-verify
     shape. Returns True if it ran (o_extend written), False if unsupported
-    (caller falls back). Requires exactly one TP-local KV head.
+    (caller falls back). A single TP-local KV head needs no offset at all;
+    several are served when the group size is a power of two.
     """
     if not can_handle(
         q_extend,
@@ -697,8 +772,6 @@ def verify_shared_kv_fwd(
         xai_temperature_len=xai_temperature_len,
     ):
         return False
-    if k_extend.shape[1] != 1:
-        return False
     if q_extend.shape[2] < v_extend.shape[2]:
         return False
     if kv_indices.numel() == 0:
@@ -706,9 +779,11 @@ def verify_shared_kv_fwd(
 
     bs = qo_indptr.shape[0] - 1
     h_q = q_extend.shape[1]
+    h_kv = k_extend.shape[1]
     head_dim = q_extend.shape[2]
     v_head_dim = v_extend.shape[2]
     l_ext = int(max_len_extend)
+    kv_group_num = h_q // h_kv
 
     if sm_scale is None:
         sm_scale = 1.0 / (head_dim**0.5)
@@ -723,7 +798,9 @@ def verify_shared_kv_fwd(
 
     if max_bs is None or max_bs < bs:
         max_bs = bs
-    vk = _get_vmla(max_bs, h_q, head_dim, v_head_dim, l_ext, q_extend.device)
+    vk = _get_vmla(
+        max_bs, h_q, head_dim, v_head_dim, l_ext, q_extend.device, kv_group_num
+    )
     vk(
         q_extend,
         k_extend.contiguous(),
@@ -737,5 +814,6 @@ def verify_shared_kv_fwd(
         o_out=o_extend,
         k_scale=k_scale,
         v_scale=v_scale,
+        is_causal=is_causal,
     )
     return True

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -125,6 +125,10 @@ def is_kimi_k3(config) -> bool:
     return _hf_arch(config) == "KimiK3ForConditionalGeneration"
 
 
+def is_dspark_draft(config) -> bool:
+    return _hf_arch(config) == "DSparkDraftModel"
+
+
 def is_qwen3_5(config) -> bool:
     return _hf_arch(config) in (
         "Qwen3_5ForConditionalGeneration",

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -11,7 +11,12 @@ from sglang.kernels.ops.kvcache.kv_indices import (
     create_flashinfer_kv_indices_triton,
 )
 from sglang.srt.configs.hybrid_arch import mambaish_config
-from sglang.srt.configs.model_config import AttentionArch, is_kimi_k3, is_qwen3_5
+from sglang.srt.configs.model_config import (
+    AttentionArch,
+    is_dspark_draft,
+    is_kimi_k3,
+    is_qwen3_5,
+)
 from sglang.srt.distributed.device_communicators.pynccl_allocator import (
     use_symmetric_memory,
 )
@@ -81,6 +86,10 @@ def _should_use_verify_shared_kv(model_config, topk, use_mla, use_verify_splitkv
         return False
     if use_mla:
         return is_kimi_k3(model_config.hf_config)
+    if is_dspark_draft(model_config.hf_config):
+        # Added for the K3 DSpark draft model, which is qwen3 type attention,
+        # and using bidirectional (non-causal) mode.
+        return use_verify_splitkv
     return (
         use_verify_splitkv
         and is_qwen3_5(model_config.hf_config)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

With DSpark on Kimi-K3, every step runs 5 draft attn layers (qwen-style, non-causal). 
Draft attn dominates their cost. In a trace study, the 5 draft layers took 2.368 ms, of which the 5 attn kernels alone accounted for 1.244 ms (>50%).

<img width="1207" height="344" alt="image" src="https://github.com/user-attachments/assets/3aee2eae-f02e-44cd-a5d1-1c2b82a41f31" />

The reason is that this falls back to `extend_attention_fwd`. This generic extend kernel is a poor fit for a shared-KV shape.

> Note that draft attn is a common path. `--attention-backend` only selects the target-verify kernel. `aiter` is not among the draft worker's supported backends, so on ROCm the draft always falls back to `triton`. Both `--attention-backend triton` and `aiter` therefore reach the kernel this PR changes.

## Modifications

<!-- Detail the changes made in this pull request. -->

Route DSpark draft attn to `verify_shared_kv`, and extend that kernel to cover the two cases it previously rejected.
- **Non-causal situation**: The prefix loop never applies a causal mask, so only modify the stage-2 kernel.
- **`h_kv > 1`**: Both stages add a KV-head offset (`head // kv_group_num * stride_h`). A `HAS_KV_HEADS` constexpr keeps the single-KV-head (MLA/MQA) path free of that arithmetic, so the existing Kimi-K3 target-verify path compiles exactly as before.

Also adds a tuning entry for `head_dim=64` (`BLOCK_N=256`, 4 warps) and `is_dspark_draft()` in `model_config.py` for the gate.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

GSM8k, 1319:
```
100%|███████████| 1319/1319 [02:00<00:00, 10.98it/s]
Accuracy: 0.955
Invalid: 0.001
Latency: 120.085 s
Output throughput: 1108.066 token/s
```

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

Tested with docker image `rocm/sgl-dev:v0.5.17-rocm720-mi35x-20260818`. 
Since draft attn is a common code path and this change is independent of other work, the numbers are measured directly on `main`, with no other non-merged PRs applied.

Perf (isl=8k/16k/32k, cc=4, 32):
- On cc=4, ITL improves by 4-12% and TTT by 2-6%.
- On cc=32, ITL improves by 1-5% and TTT by 1-2%.

The gain grows with input length, from 8k to 32k, in both cases.
May be larger with aiter backend, because aiter accelerates target-verify attn, so draft attn takes a larger share of each step.

| isl/osl | Concurrency | TP | TTT (tok/s) | Median TPOT (ms) | Median ITL (ms) | acc len | TTT speedup | ITL speedup |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| 8k/1k | 4 | 8 | 4994.24 | 5.57 | 4.42 | 4.71 | 1.02x | 1.04x |
| | 32 | 8 | 10026.19 | 23.88 | 10.12 | 5.54 | 1.01x | 1.01x |
| 16k/1k | 4 | 8 | 7207.37 | 7.53 | 4.65 | 5.60 | 1.04x | 1.07x |
| | 32 | 8 | 11215.29 | 39.36 | 11.70 | 5.90 | 1.01x | 1.02x |
| 32k/1k | 4 | 8 | 8924.78 | 10.76 | 5.15 | 5.92 | 1.06x | 1.12x |
| | 32 | 8 | 11170.47 | 72.99 | 16.30 | 5.98 | 1.02x | 1.05x |

Server script:
```
#!/bin/bash
export SGLANG_USE_AITER=1
export SGLANG_AITER_K3_OPT=1
export AITER_FLYDSL_FORCE=1
export AITER_SITUV2_A8W4=1
export SGLANG_K3_FLYDSL_AR_NORM=1

sglang serve \
  --model-path /models/Kimi-K3 \
  --trust-remote-code \
  --model-loader-extra-config '{"enable_multithread_load": true}' \
  --tp 8 \
  --attention-backend triton \
  --dtype bfloat16 \
  --mem-fraction-static 0.85 \
  --cuda-graph-max-bs-decode 128 \
  --host 127.0.0.1 \
  --port 8000 \
  --reasoning-parser kimi_k3 \
  --tool-call-parser kimi_k3 \
  --kv-cache-dtype fp8_e4m3 \
  --mamba-full-memory-ratio 1.64 \
  --mamba-ssm-dtype bfloat16 \
  --enable-int8-mamba-checkpoint \
  --mamba-track-interval 1024 \
  --chunked-prefill-size 32768 \
  --max-prefill-tokens 32768 \
  --disable-radix-cache \
  --speculative-draft-model-path /models/Kimi-K3-DSpark \
  --speculative-algorithm DSPARK
```

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #32236859654](https://github.com/sgl-project/sglang/actions/runs/32236859654)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #32320955474](https://github.com/sgl-project/sglang/actions/runs/32320955474)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32236859503](https://github.com/sgl-project/sglang/actions/runs/32236859503)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->