### PR TITLE
Add --speculative-draft-model-subfolder

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -444,6 +444,47 @@ def add_linear_attn_kernel_backend_choices(choices):
     LINEAR_ATTN_KERNEL_BACKEND_CHOICES.extend(choices)
 
 
+def resolve_model_subfolder(
+    path: str, subfolder: Optional[str], revision: Optional[str] = None
+) -> str:
+    """Return the local directory holding the model inside `subfolder` of `path`.
+
+    `path` is a local directory or a Hugging Face repo ID. Collapsing both to
+    one real directory here means every later consumer -- config loading,
+    ModelConfig, the weight loader -- is handed a single plain path, so the
+    config and the weights cannot be read from different places.
+
+    The Hub has no single-string form for this: a repo ID may contain at most
+    one "/", so "org/repo/subdir" is not a valid ID and the sub-path has to be
+    carried separately.
+    """
+    if not subfolder:
+        return path
+    subfolder = subfolder.strip("/")
+    if not subfolder:
+        return path
+
+    if os.path.isdir(path):
+        resolved = os.path.join(path, subfolder)
+    else:
+        # Hub repo: fetch only the subtree, not the whole (often huge) repo.
+        from huggingface_hub import snapshot_download
+
+        local_root = snapshot_download(
+            path,
+            allow_patterns=[f"{subfolder}/*"],
+            revision=revision,
+        )
+        resolved = os.path.join(local_root, subfolder)
+
+    if not os.path.isdir(resolved):
+        raise ValueError(
+            f"Subfolder {subfolder!r} was not found in {path!r} "
+            f"(expected a directory at {resolved})."
+        )
+    return resolved
+
+
 @dataclasses.dataclass
 class ServerArgs:
     """Server-wide configuration for SGLang.
@@ -2087,6 +2128,11 @@ class ServerArgs:
     speculative_draft_model_revision: A[
         Optional[str],
         "The specific draft model version to use. It can be a branch name, a tag name, or a commit id. If unspecified, will use the default version.",
+        NS("spec"),
+    ] = None
+    speculative_draft_model_subfolder: A[
+        Optional[str],
+        "The subfolder of --speculative-draft-model-path that holds the draft weights and config. Use this to serve a draft bundled inside its target model's repository or directory instead of published as its own repo, e.g. --speculative-draft-model-path org/target --speculative-draft-model-subfolder DFlash.",
         NS("spec"),
     ] = None
     speculative_draft_load_format: A[
@@ -3965,7 +4011,7 @@ class ServerArgs:
             )
 
     def _handle_model_source_paths(self):
-        """Prepare metadata for model paths backed by remote object stores."""
+        """Resolve model paths: remote object stores, GGUF, then draft subfolders."""
         self._resolve_hf_gguf_model_path()
 
         seen_paths = set()
@@ -3981,6 +4027,16 @@ class ServerArgs:
             ):
                 ObjectStorageModel.download_and_get_path(model_path)
                 seen_paths.add(model_path)
+
+        # Fold a draft-model subfolder into the draft path itself. This runs in
+        # the path-resolution phase, before the speculative hook reads the
+        # draft config, so every consumer downstream sees the same directory.
+        if self.speculative_draft_model_subfolder and self.speculative_draft_model_path:
+            self.speculative_draft_model_path = resolve_model_subfolder(
+                self.speculative_draft_model_path,
+                self.speculative_draft_model_subfolder,
+                self.speculative_draft_model_revision,
+            )
 
     def _handle_pd_disaggregation(self):
         from sglang.srt.arg_groups.pd_disaggregation_hook import (

--- a/test/registered/unit/spec/test_draft_model_subfolder.py
+++ b/test/registered/unit/spec/test_draft_model_subfolder.py
@@ -1,0 +1,71 @@
+"""A draft bundled inside its target's repo is addressed by subfolder.
+
+The Hub has no single-string form for this: a repo ID may contain at most one
+"/", so "org/target/DFlash" is not a valid ID and the sub-path has to travel
+separately. `resolve_model_subfolder` collapses the pair back to one real
+directory during path resolution, before the speculative hook reads the draft
+config, so config loading and the weight loader cannot end up reading from
+different places.
+
+These are directory-only cases; the Hub branch needs the network and is left to
+integration coverage.
+"""
+
+import os
+import tempfile
+import unittest
+
+from sglang.srt.server_args import ServerArgs, resolve_model_subfolder
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestResolveModelSubfolder(CustomTestCase):
+    def _target_with_draft(self):
+        """A target directory holding its draft in ./DFlash, as we publish them."""
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        root = tmp.name
+        draft = os.path.join(root, "DFlash")
+        os.makedirs(draft)
+        with open(os.path.join(root, "config.json"), "w") as f:
+            f.write('{"model_type": "target"}')
+        with open(os.path.join(draft, "config.json"), "w") as f:
+            f.write('{"model_type": "draft"}')
+        return root, draft
+
+    def test_a_subfolder_resolves_to_the_directory_inside_the_target(self):
+        root, draft = self._target_with_draft()
+        self.assertEqual(resolve_model_subfolder(root, "DFlash"), draft)
+        # Surrounding slashes are the same request.
+        self.assertEqual(resolve_model_subfolder(root, "/DFlash/"), draft)
+
+    def test_an_absent_subfolder_returns_the_path_untouched(self):
+        root, _ = self._target_with_draft()
+        for absent in (None, "", "/"):
+            self.assertEqual(resolve_model_subfolder(root, absent), root)
+
+    def test_a_missing_subfolder_fails_loudly(self):
+        """Silently falling back to the target would load the wrong weights."""
+        root, _ = self._target_with_draft()
+        with self.assertRaises(ValueError) as ctx:
+            resolve_model_subfolder(root, "NotThere")
+        self.assertIn("NotThere", str(ctx.exception))
+
+    def test_the_draft_path_is_folded_during_server_args_resolution(self):
+        """The contract: the draft path collapses to the subfolder and the
+        target is untouched, so every downstream consumer sees one plain dir."""
+        root, draft = self._target_with_draft()
+        args = ServerArgs(
+            model_path=root,
+            speculative_draft_model_path=root,
+            speculative_draft_model_subfolder="DFlash",
+        )
+        self.assertEqual(args.speculative_draft_model_path, draft)
+        self.assertEqual(args.model_path, root)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
Lets a speculative draft live in a subfolder of its target model's repo or directory. The Hub has no single-string form for this, since a repo ID may hold at most one slash. The subfolder is folded into the draft path once, during path resolution, so config and weights are always read from the same directory.

The rationale is that we've had lots of confusion about storing the DFlashes separately from the base model ie. we currently list models like this:

```
poolside/Laguna-S-2.1-NVFP4
poolside/Laguna-S-2.1-DFlash-NVFP4
```

Since really they're not separate models, it makes sense to instead be able to bundle them in one place:


```
poolside/Laguna-S-2.1-NVFP4
poolside/Laguna-S-2.1-NVFP4/DFlash
```

This PR enables this sort of bundling. We also plan to upstream this to vLLM & TRT-LLM too. 

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

SGLang almost supports this already: it turns out that the standard HF downloader already has subfolder downloading support. This PR mostly plumbs it into the loading path.


## Accuracy Tests

We made a small bundled model of this form available [here](https://huggingface.co/poolside/spec-decoding-subfolder-fixture). We are happy to incorporate this into the CI if necessary, but we did some manual testing in the meantime & it seems to work well.

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32248389672](https://github.com/sgl-project/sglang/actions/runs/32248389672)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32248389103](https://github.com/sgl-project/sglang/actions/runs/32248389103)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->