### PR TITLE
[mem_cache] SWA radix cache: evict branch tail sliding window last

### DIFF
--- a/python/sglang/srt/mem_cache/swa_radix_cache.py
+++ b/python/sglang/srt/mem_cache/swa_radix_cache.py
@@ -649,14 +649,32 @@ class SWARadixCache(BasePrefixCache):
                 x = x_next
 
         if swa_num_evicted < swa_num_tokens:
+            # Evict the last sliding window of a branch only as a last resort:
+            # tombstoning it makes the whole branch unmatchable, because
+            # `_match_prefix_helper` needs `sliding_window_size` consecutive
+            # non-tombstone tokens after a tombstone, while evicting a node
+            # closer to the root only costs that prefix. This is a preference,
+            # not a reservation, so the eviction target is still met.
+            skip_branch_tail = True
             # get the least recently used node that is not locked, doesn't have to be a leaf
             x = self.swa_lru_list.get_lru_no_lock()
 
-            # evict lru leaf nodes until swa_num_tokens is reached
-            while swa_num_evicted < swa_num_tokens and (self.swa_lru_list.in_list(x)):
+            while swa_num_evicted < swa_num_tokens:
+                if not self.swa_lru_list.in_list(x):
+                    if not skip_branch_tail:
+                        break
+                    # Every non-tail candidate is gone, retry the branch tails.
+                    skip_branch_tail = False
+                    x = self.swa_lru_list.get_lru_no_lock()
+                    continue
+
                 assert not x.swa_tombstone, f"duplicate swa tombstone node, {x.id=}"
                 assert x != self.root_node, f"root node is not evictable, {x.id=}"
                 assert x.swa_lock_ref == 0, f"node is in use by swa kv indices, {x.id=}"
+
+                if skip_branch_tail and self._is_swa_branch_tail(x):
+                    x = self.swa_lru_list.get_prev_no_lock(x)
+                    continue
 
                 if len(x.children) > 0:
                     # 1. an internal node, free swa tokens.
@@ -1082,11 +1100,7 @@ class SWARadixCache(BasePrefixCache):
             return leaf
 
         # Smallest page-aligned size that still covers the sliding window.
-        tail_size = (
-            (self.sliding_window_size + self.page_size - 1)
-            // self.page_size
-            * self.page_size
-        )
+        tail_size = self._swa_tail_size()
         if len(leaf.value) <= tail_size:
             return leaf
 
@@ -1101,6 +1115,41 @@ class SWARadixCache(BasePrefixCache):
 
         self._split_node(leaf.key, leaf, split_at)
         return leaf
+
+    def _swa_tail_size(self) -> int:
+        """Smallest page-aligned size that still covers the sliding window."""
+        return (
+            (self.sliding_window_size + self.page_size - 1)
+            // self.page_size
+            * self.page_size
+        )
+
+    def _is_swa_branch_tail(self, node: TreeNode) -> bool:
+        """Whether ``node`` holds part of the last window of some branch.
+
+        A branch end is a leaf or the node right before a tombstone: both are
+        stop points ``_match_prefix_helper`` can return. If the nearest branch
+        end below ``node`` is less than one (page-aligned) window away, freeing
+        ``node`` breaks the only reusable window of that branch. The walk is
+        pruned by the window size, so it visits at most the tail of the branch
+        rather than the whole subtree.
+        """
+        cap = self._swa_tail_size()
+        best = cap
+        stack = [(node, 0)]
+        while stack:
+            cur, distance = stack.pop()
+            if distance >= best:
+                continue
+            if len(cur.children) == 0:
+                best = distance
+                continue
+            for child in cur.children.values():
+                if child.swa_tombstone:
+                    best = min(best, distance)
+                else:
+                    stack.append((child, distance + len(child.value)))
+        return best < cap
 
     def _split_node(self, key: RadixKey, child: TreeNode, split_len: int) -> TreeNode:
         # new_node -> child

--- a/test/registered/unit/mem_cache/test_swa_unittest.py
+++ b/test/registered/unit/mem_cache/test_swa_unittest.py
@@ -1235,6 +1235,147 @@ class TestCacheUnfinishedReqEvictedPrefix(CustomTestCase):
             tree.swa_evictable_size_ + tree.swa_protected_size_,
             num_tokens - evicted,
         )
+
+
+# Optimization: SWA eviction deprioritizes the trailing sliding window of each
+# branch. Tombstoning a node inside that window makes the whole branch
+# unmatchable (_match_prefix_helper needs `sliding_window_size` consecutive
+# non-tombstone tokens after a tombstone), while evicting a node closer to the
+# root only costs that prefix.
+class TestSWADeprioritizeBranchTailEviction(CustomTestCase):
+    def _match_len(self, tree, token_ids):
+        match = tree.match_prefix(
+            MatchPrefixParams(key=RadixKey(array("q", token_ids)))
+        )
+        return match.device_indices.shape[0]
+
+    def _two_branch_tree(self, *, window, page_size, unit):
+        """shared -> tail1 / shared -> other, with tail1 as the SWA LRU node.
+
+        `unit` scales every segment so the shape stays page-aligned.
+        """
+        tree, allocator, _ = _build_swa_tree(
+            is_eagle=False,
+            kv_size=256,
+            kv_size_swa=128,
+            max_context_len=128,
+            sliding_window_size=window,
+            page_size=page_size,
+        )
+        shared = list(range(0, 2 * unit))
+        branch1 = shared + list(range(100, 100 + unit))
+        branch2 = shared + list(range(200, 200 + 2 * unit))
+
+        _insert(tree, allocator, shared)
+        _insert(tree, allocator, branch1)
+        _insert(tree, allocator, branch2)
+        # Refresh branch2 so `shared` becomes MRU and branch1's tail is the
+        # least recently used SWA node -- the agentic "parked in a tool call"
+        # ordering that used to get the tail evicted first.
+        self._match_len(tree, branch2)
+        return tree, shared, branch1, branch2
+
+    def test_tail_survives_and_prefix_stays_reusable(self):
+        window, unit = 4, 4
+        tree, shared, branch1, branch2 = self._two_branch_tree(
+            window=window, page_size=1, unit=unit
+        )
+        self.assertEqual(self._match_len(tree, branch1), len(branch1))
+
+        result = tree.evict(EvictParams(num_tokens=0, swa_num_tokens=window))
+
+        # The `shared` internal node is tombstoned instead of the tail, which
+        # frees more SWA tokens than requested and keeps both branches
+        # matchable: one full window of non-tombstone tokens still follows the
+        # tombstone.
+        self.assertGreaterEqual(result.swa_num_tokens_evicted, window)
+        self.assertEqual(result.num_tokens_evicted, 0)
+        self.assertEqual(self._match_len(tree, branch1), len(branch1))
+        self.assertEqual(self._match_len(tree, branch2), len(branch2))
+        tree.sanity_check()
+
+    def test_tail_split_across_several_small_nodes_is_protected(self):
+        # shared(8) -> t1(2) -> t2(2): neither tail node alone covers the
+        # window, so both must be skipped until the accumulated distance from
+        # a branch end reaches `sliding_window_size`.
+        window = 4
+        tree, allocator, _ = _build_swa_tree(
+            is_eagle=False,
+            kv_size=256,
+            kv_size_swa=128,
+            max_context_len=128,
+            sliding_window_size=window,
+            page_size=1,
+        )
+        shared = list(range(8))
+        branch1_short = shared + [101, 102]
+        branch1 = branch1_short + [103, 104]
+        branch2 = shared + list(range(200, 208))
+
+        _insert(tree, allocator, shared)
+        _insert(tree, allocator, branch1_short)
+        _insert(tree, allocator, branch1)
+        _insert(tree, allocator, branch2)
+        self._match_len(tree, branch2)
+
+        result = tree.evict(EvictParams(num_tokens=0, swa_num_tokens=2))
+
+        self.assertGreaterEqual(result.swa_num_tokens_evicted, 2)
+        self.assertEqual(self._match_len(tree, branch1), len(branch1))
+        self.assertEqual(self._match_len(tree, branch2), len(branch2))
+        tree.sanity_check()
+
+    def test_page_aligned_tail_is_protected(self):
+        # page_size > 1: the protected tail rounds up to a page boundary, so
+        # the shape is scaled by `unit` to stay page-aligned.
+        for window, page_size, unit in [(4, 2, 4), (4, 4, 4), (3, 2, 4)]:
+            with self.subTest(window=window, page_size=page_size):
+                tree, _, branch1, branch2 = self._two_branch_tree(
+                    window=window, page_size=page_size, unit=unit
+                )
+                tail_size = _expected_tail_size(window, page_size)
+
+                result = tree.evict(EvictParams(num_tokens=0, swa_num_tokens=tail_size))
+
+                self.assertGreaterEqual(result.swa_num_tokens_evicted, tail_size)
+                self.assertEqual(self._match_len(tree, branch1), len(branch1))
+                self.assertEqual(self._match_len(tree, branch2), len(branch2))
+                tree.sanity_check()
+
+    def test_fallback_evicts_tail_when_nothing_else_is_left(self):
+        # A single branch: every SWA-evictable node is a branch tail, so the
+        # first pass finds no candidate and the fallback must still meet the
+        # eviction target instead of returning short.
+        window = 4
+        tree, allocator, _ = _build_swa_tree(
+            is_eagle=False,
+            kv_size=128,
+            kv_size_swa=64,
+            sliding_window_size=window,
+            page_size=1,
+        )
+        token_ids = list(range(window))
+        _insert(tree, allocator, token_ids)
+        self.assertEqual(tree.swa_evictable_size(), window)
+
+        result = tree.evict(EvictParams(num_tokens=0, swa_num_tokens=window))
+
+        self.assertGreaterEqual(result.swa_num_tokens_evicted, window)
+        self.assertEqual(tree.swa_evictable_size(), 0)
+        tree.sanity_check()
+
+    def test_evictable_size_balances_after_full_eviction(self):
+        window, unit = 4, 4
+        tree, _, branch1, _ = self._two_branch_tree(
+            window=window, page_size=1, unit=unit
+        )
+        total_swa = tree.swa_evictable_size()
+
+        result = tree.evict(EvictParams(num_tokens=0, swa_num_tokens=total_swa))
+
+        self.assertEqual(result.swa_num_tokens_evicted, total_swa)
+        self.assertEqual(tree.swa_evictable_size(), 0)
+        self.assertEqual(tree.swa_protected_size_, 0)
         tree.sanity_check()
 
 


### PR DESCRIPTION
## Motivation

`SWARadixCache.evict()` walks the SWA LRU list without any notion of where a branch
ends, so it can tombstone (or delete) a node that sits inside the last
`sliding_window_size` tokens of a branch.

Because `_match_prefix_helper` can only stop at a node that has `sliding_window_size`
**consecutive non-tombstone** tokens in front of it (the `match_len_since_tombstone`
check), tombstoning a single node inside that trailing window makes the *entire*
branch unmatchable: the reusable prefix collapses from tens of thousands of tokens to
0, while the branch's full KV stays allocated in the full pool until full-side LRU
reclaims it. This is a cliff, not a gradual degradation — the tail window is the only
part of a branch whose SWA KV is load-bearing for reuse.

Idle branches are hit first. `_match_post_processor` uses
`reset_node_and_parents_mru`, which makes root-side nodes least-recently-used *within*
a branch, but ordering *across* branches is still by last access time. A request that
is parked in a tool call has its whole branch older than any active branch, so its
tail nodes are evicted before the root-side nodes of busy branches — the opposite of
what we want.

Impact: agentic / multi-turn tool-calling workloads on SWA models (e.g. window 128)
with a small SWA pool re-prefill their whole history when they come back from a tool
call, even though (a) their full KV is still cached and (b) decode only needs the last
`sliding_window_size` SWA tokens.

Reproduction sketch (window = 4, two branches sharing an 8-token prefix):

```
shared(8) -> tail1(4)      # branch 1, parked in a tool call
shared(8) -> other(8)      # branch 2, just matched
```

`evict(swa_num_tokens=4)` picks `tail1` (the LRU node) and deletes it, so
`match_prefix(branch1)` can no longer return the branch. Tombstoning the 8-token
`shared` internal node instead frees 2x more SWA tokens *and* keeps branch 1 fully
matchable, because 4 (== window) non-tombstone tokens still follow the tombstone.

## Modifications

`python/sglang/srt/mem_cache/swa_radix_cache.py`:

- The SWA eviction loop now skips a candidate whose nearest branch end is less than
  one page-aligned window away, and retries those nodes only once no other candidate
  is left. This is a **deprioritization, not a reservation** — the eviction target is
  still met when the SWA pool is genuinely exhausted, and `swa_evictable_size_`
  accounting plus the scheduler contract are unchanged, so there is no new OOM /
  retract risk.
- New `_is_swa_branch_tail()` computes the shortest token distance from a candidate
  down to the nearest branch end, where a branch end is a leaf **or** the node right
  before an existing tombstone (both are valid stop points for
  `_match_prefix_helper`). The walk is pruned by the window size, so it visits at most
  the tail of the branch rather than the whole subtree, and it is iterative so a long
  chunked-prefill chain cannot exhaust the recursion limit.
- New `_swa_tail_size()` factors out the `ceil(window / page) * page` formula that
  `_maybe_split_leaf_for_swa_lock()` already used, so both paths agree on page
  alignment.

Cost of the deprioritized set is `#branch_ends * sliding_window_size` (128 tokens per
branch for a 128-token window), negligible against a few hundred K SWA slots.

### Scope: legacy `SWARadixCache` only

`unified_cache/components/swa_component.py` has a parallel SWA eviction walk with the
same shape — `_evict_device_next_node()` scans the SWA LRU from the tail via
`get_lru_no_lock()` / `get_prev_no_lock()`, tombstones internal nodes inline and
cascade-deletes leaves (see `unified_cache/components/README.md`) — so it has the same
blind spot. This PR intentionally changes only the legacy `SWARadixCache` to keep the
diff reviewable: the unified walk is cursor-based (`cursor_begin` / `cursor_next`, plus
the `enable_session_radix_cache` path), so skipping a candidate there also needs
cursor-recovery semantics rather than the plain `get_prev_no_lock` step used here.

Happy to port it in a follow-up, or to fold it into this PR if maintainers would rather
land both paths together — please say which you prefer.

## Accuracy Tests

Not applicable — this only changes which cache entry is evicted first, not any model
output.

## Speed Tests and Profiling

Not included yet. I do not have a GPU environment attached right now, so the SWA unit
tests have not been executed and I have no workload numbers to report. Both are being
added to this PR:

- unit tests in `test/registered/unit/mem_cache/test_swa_unittest.py` covering
  (1) the branch tail surviving and the prefix staying fully reusable, (2) the
  previous behavior as a regression baseline, (3) the fallback pass still meeting the
  eviction target when only tails remain, and (4) `page_size` equal to, below and
  above the window;
- cache hit rate / TTFT / SWA eviction counts for a tool-calling workload under SWA
  pool pressure.

Review feedback on the approach in the meantime is very welcome — in particular
whether maintainers would prefer this gated behind a `SGLANG_OPT_SWA_*` env flag (as
with `SGLANG_OPT_SWA_SPLIT_LEAF_ON_INSERT`) rather than being on by default.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34078600585](https://github.com/sgl-project/sglang/actions/runs/34078600585)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34078600324](https://github.com/sgl-project/sglang/actions/runs/34078600324)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34078600513](https://github.com/sgl-project/sglang/actions/runs/34078600513)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->