### PR TITLE
[diffusion] Fix MiniMax H3 full-loop denoise on ROCm

### DIFF
--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/minimax_h3/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/minimax_h3/stages/denoising.py
@@ -606,8 +606,14 @@ class MiniMaxH3DenoisingStage(DenoisingStage):
 
         ctx = _resolve_full_loop_context(batch)
 
-        if not (current_platform.is_cuda() or current_platform.is_mps()):
-            raise RuntimeError("MiniMax H3 full-loop denoise requires CUDA or MPS")
+        if not (
+            current_platform.is_cuda()
+            or current_platform.is_hip()
+            or current_platform.is_mps()
+        ):
+            raise RuntimeError(
+                "MiniMax H3 full-loop denoise requires CUDA, ROCm, or MPS"
+            )
         device = current_platform.get_local_torch_device()
         sigmas_video = [float(v) for v in ctx.sigmas["video"]]
         self._maybe_enable_cache_dit_and_torch_compile(


### PR DESCRIPTION
## Summary

- restore ROCm admission for MiniMax H3 full-loop denoising
- keep the CUDA and MPS paths unchanged
- update the unsupported-platform error to name ROCm

## Root cause

#33880 replaced `torch.cuda.is_available()` with explicit platform checks for CUDA and MPS. PyTorch ROCm previously passed through the CUDA-compatible interface, but `current_platform.is_cuda()` is false for ROCm, so MiniMax H3 generation now fails before denoising starts.

## User impact

MiniMax H3 full-loop video/audio generation can run on ROCm again instead of failing with `MiniMax H3 full-loop denoise requires CUDA or MPS`.

## Validation

Local:

- `python3 -m py_compile` on the changed module
- `ruff format --check` on the changed module
- `ruff check --select E9,F63,F7,F82` on the changed module
- `git diff --check`

E2E:

- reuse the existing `minimax_h3_t2va_2gpu_h100` server case on the ROCm 2-GPU CI lane
- the same case reproduced the regression in both #33880 and #35481, so a passing ROCm rerun validates server startup, model loading, request execution, full-loop denoising, and output generation end to end

Fixes #35518

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32254094517](https://github.com/sgl-project/sglang/actions/runs/32254094517)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32254094181](https://github.com/sgl-project/sglang/actions/runs/32254094181)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->