### PR TITLE
[AMD] Enable chunked prefix KV on the aiter backend

### DIFF
--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -1907,6 +1907,57 @@ class AiterAttnBackend(AttentionBackend):
             and layer.qk_head_dim == layer.v_head_dim
         )
 
+    def _forward_extend_mha_chunk(
+        self,
+        *,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        layer: RadixAttention,
+        forward_batch: ForwardBatch,
+        qo_indptr: torch.Tensor,
+        max_q_len: int,
+    ):
+        """One slice of an AttnForwardMethod.MHA_CHUNKED_KV extend.
+
+        forward_normal_chunked_kv_core has already run kv_b_proj for this slice
+        alone -- either the new tokens or a single prefix chunk -- and merges the
+        per-slice LSEs itself, so we only attend the k/v we were handed. Falling
+        through to the unchunked path instead would re-gather and up-project the
+        whole prefix (~13.2 KiB/token/layer).
+        """
+        if forward_batch.attn_attend_prefix_cache:
+            chunk_idx = forward_batch.prefix_chunk_idx
+            assert chunk_idx >= 0
+            # The chunk lies entirely in the queries' past, so no causal mask.
+            kv_indptr = forward_batch.prefix_chunk_cu_seq_lens[chunk_idx]
+            max_kv_len = forward_batch.prefix_chunk_max_seq_lens[chunk_idx]
+            causal = False
+        else:
+            kv_indptr = qo_indptr
+            max_kv_len = max_q_len
+            causal = True
+
+        attn_out = flash_attn_varlen_func(
+            q,
+            k,
+            v,
+            qo_indptr,
+            kv_indptr,
+            max_q_len,
+            max_kv_len,
+            softmax_scale=layer.scaling,
+            causal=causal,
+            return_lse=forward_batch.mha_return_lse,
+        )
+        if not forward_batch.mha_return_lse:
+            return attn_out
+        # aiter returns the softmax lse heads-first [num_heads, num_tokens];
+        # merge_state sizes its grid off the output's token/head axes and so
+        # indexes [num_tokens, num_heads]. Transpose on the way out.
+        o, lse = attn_out
+        return o, lse.transpose(0, 1).contiguous()
+
     def forward_extend(
         self,
         q: torch.Tensor,
@@ -2029,6 +2080,19 @@ class AiterAttnBackend(AttentionBackend):
                 and not forward_batch.forward_mode.is_target_verify()
                 and not forward_batch.forward_mode.is_draft_extend_v2()
             ):
+                if forward_batch.attn_attend_prefix_cache is not None and any(
+                    forward_batch.extend_prefix_lens_cpu
+                ):  # MHA Chunk
+                    return self._forward_extend_mha_chunk(
+                        q=q,
+                        k=k,
+                        v=v,
+                        layer=layer,
+                        forward_batch=forward_batch,
+                        qo_indptr=qo_indptr,
+                        max_q_len=max_q_len,
+                    )
+
                 extend_no_prefix = not any(forward_batch.extend_prefix_lens_cpu)
                 if kv_indices.shape[0] == 0 or extend_no_prefix:
                     if _use_fp8_prefill_attn:

--- a/python/sglang/srt/models/deepseek_common/attention_backend_handler.py
+++ b/python/sglang/srt/models/deepseek_common/attention_backend_handler.py
@@ -190,6 +190,13 @@ def handle_attention_aiter(attn, forward_batch):
     if is_in_tc_piecewise_cuda_graph() or is_in_breakable_cuda_graph():
         return AttnForwardMethod.MHA
     if forward_batch.forward_mode.is_extend_without_speculative():
+        sum_extend_prefix_lens = _get_sum_extend_prefix_lens(forward_batch)
+        if (
+            sum_extend_prefix_lens > 0
+            and not attn.disable_chunked_prefix_cache
+            and sum_extend_prefix_lens >= attn.chunked_prefix_cache_threshold
+        ):
+            return AttnForwardMethod.MHA_CHUNKED_KV
         return AttnForwardMethod.MHA
     else:
         return AttnForwardMethod.MLA

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
@@ -41,6 +41,8 @@ if _is_cuda:
     from sglang.kernels.ops.attention.concat_mla import concat_mla_k
 elif _is_musa:
     from sgl_kernel import concat_mla_k
+else:
+    from sglang.srt.layers.attention.merge_state import merge_state as merge_state_v2
 
 
 def resolve_attn_backend(forward_batch: ForwardBatch):

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -221,6 +221,7 @@ CHUNKED_PREFIX_CACHE_SUPPORTED_ATTENTION_BACKENDS = [
     "cutlass_mla",
     "trtllm_mla",
     "tokenspeed_mla",
+    "aiter",
 ]
 
 DETERMINISTIC_ATTENTION_BACKEND_CHOICES = [

--- a/test/registered/kernels/test_aiter_mha_chunked_kv.py
+++ b/test/registered/kernels/test_aiter_mha_chunked_kv.py
@@ -1,0 +1,172 @@
+"""Tests for AttnForwardMethod.MHA_CHUNKED_KV on the aiter (ROCm) backend.
+
+Chunked-prefix attention splits the cached prefix into chunks, attends each
+separately, and merges the per-chunk partial softmaxes. That is only correct if
+three things line up, and each has already been a bug:
+
+1. merge_state must be callable on ROCm. sgl_kernel exports a merge_state_v2
+   wrapper there but never registers the op, so the CUDA-gated import leaves the
+   name undefined and the chunked path dies with NameError.
+2. The lse layout must match. aiter's flash_attn_varlen_func returns the softmax
+   lse heads-first [num_heads, num_tokens]; merge_state sizes its grid off the
+   output's token/head axes and so indexes [num_tokens, num_heads].
+3. The causal flags must be right per slice: causal within the new tokens,
+   NON-causal against a prefix chunk (which lies entirely in the queries' past).
+   Getting this backwards produces plausible-but-wrong output, not a crash.
+
+The check is end-to-end on the math: chunk + merge must reproduce a single-shot
+attention over the whole context. Shapes are Kimi-K3-at-TP8 (12 heads, qk 192,
+v 128), which is where the gqa=12 path actually runs.
+"""
+
+import unittest
+
+import torch
+
+from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_amd_ci(est_time=30, suite="stage-b-test-1-gpu-small-amd")
+
+NUM_HEADS = 12
+QK_HEAD_DIM = 192
+V_HEAD_DIM = 128
+NUM_Q_TOKENS = 512
+SOFTMAX_SCALE = 0.08
+# bf16 reassociation floor: splitting the KV stream reorders accumulation, which
+# shows up around 3e-3 regardless of implementation.
+REL_L2_TOL = 5e-3
+
+
+class TestAiterMHAChunkedKV(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("GPU required")
+        try:
+            from aiter import flash_attn_varlen_func
+        except ImportError:
+            raise unittest.SkipTest("aiter required (ROCm backend test)")
+        from sglang.srt.models.deepseek_common.attention_forward_methods.forward_mha import (
+            merge_state_v2,
+        )
+
+        # staticmethod: a plain function assigned to a class attribute would be
+        # bound, and self would arrive as the first kernel argument.
+        cls.fa = staticmethod(flash_attn_varlen_func)
+        cls.merge = staticmethod(merge_state_v2)
+        cls.device = "cuda"
+
+    def _rand(self, *shape):
+        return torch.randn(*shape, device=self.device, dtype=torch.bfloat16)
+
+    def _cu_seqlens(self, total):
+        return torch.tensor([0, total], device=self.device, dtype=torch.int32)
+
+    def _attend(self, q, k, v, cu_q, cu_kv, max_q, max_kv, causal, return_lse):
+        """One slice, mirroring AiterAttnBackend._forward_extend_mha_chunk."""
+        out = self.fa(
+            q,
+            k,
+            v,
+            cu_q,
+            cu_kv,
+            max_q,
+            max_kv,
+            softmax_scale=SOFTMAX_SCALE,
+            causal=causal,
+            return_lse=return_lse,
+        )
+        if not return_lse:
+            return out
+        o, lse = out
+        # aiter is heads-first; merge_state wants [num_tokens, num_heads].
+        return o, lse.transpose(0, 1).contiguous()
+
+    def _chunked_attention(self, q, k_prefix, v_prefix, k_new, v_new, chunk_lens):
+        cu_q = self._cu_seqlens(NUM_Q_TOKENS)
+        # Phase 1: the new tokens, causal, seeding the accumulator.
+        acc_o, acc_lse = self._attend(
+            q, k_new, v_new, cu_q, cu_q, NUM_Q_TOKENS, NUM_Q_TOKENS, True, True
+        )
+        # Phase 2: one non-causal pass per prefix chunk, merged in.
+        offset = 0
+        for chunk_len in chunk_lens:
+            o, lse = self._attend(
+                q,
+                k_prefix[offset : offset + chunk_len],
+                v_prefix[offset : offset + chunk_len],
+                cu_q,
+                self._cu_seqlens(chunk_len),
+                NUM_Q_TOKENS,
+                chunk_len,
+                False,
+                True,
+            )
+            merged_o = torch.empty_like(acc_o)
+            merged_lse = torch.empty_like(acc_lse)
+            self.merge(o, lse, acc_o, acc_lse, merged_o, merged_lse)
+            acc_o, acc_lse = merged_o, merged_lse
+            offset += chunk_len
+        return acc_o
+
+    def _single_shot_attention(self, q, k_prefix, v_prefix, k_new, v_new):
+        """Reference: one causal pass over [prefix ; new tokens]."""
+        prefix_len = k_prefix.shape[0]
+        return self._attend(
+            q,
+            torch.cat([k_prefix, k_new]),
+            torch.cat([v_prefix, v_new]),
+            self._cu_seqlens(NUM_Q_TOKENS),
+            self._cu_seqlens(prefix_len + NUM_Q_TOKENS),
+            NUM_Q_TOKENS,
+            prefix_len + NUM_Q_TOKENS,
+            True,
+            False,
+        )
+
+    def _assert_matches_single_shot(self, chunk_lens):
+        torch.manual_seed(0)
+        prefix_len = sum(chunk_lens)
+        q = self._rand(NUM_Q_TOKENS, NUM_HEADS, QK_HEAD_DIM)
+        k_prefix = self._rand(prefix_len, NUM_HEADS, QK_HEAD_DIM)
+        v_prefix = self._rand(prefix_len, NUM_HEADS, V_HEAD_DIM)
+        k_new = self._rand(NUM_Q_TOKENS, NUM_HEADS, QK_HEAD_DIM)
+        v_new = self._rand(NUM_Q_TOKENS, NUM_HEADS, V_HEAD_DIM)
+
+        chunked = self._chunked_attention(
+            q, k_prefix, v_prefix, k_new, v_new, chunk_lens
+        )
+        reference = self._single_shot_attention(q, k_prefix, v_prefix, k_new, v_new)
+
+        self.assertTrue(torch.isfinite(chunked).all(), "chunked output has NaN/inf")
+        rel_l2 = (
+            (chunked.float() - reference.float()).norm() / reference.float().norm()
+        ).item()
+        self.assertLess(
+            rel_l2,
+            REL_L2_TOL,
+            f"chunks={chunk_lens}: rel L2 {rel_l2:.3e} exceeds {REL_L2_TOL:.0e}",
+        )
+
+    def test_multiple_chunks_match_single_shot(self):
+        """Merge math: iterated merges must equal one pass over the union.
+
+        Red if the merge is skipped/misordered, if the accumulator is not
+        threaded through the loop, if the per-slice causal flags are swapped, or
+        if the lse layout handed to merge_state stops matching what it indexes
+        (a layout flip corrupts the second and later merges).
+        """
+        self._assert_matches_single_shot([1024, 1024, 1024])
+
+    def test_uneven_final_chunk(self):
+        """Length arithmetic: the last chunk is shorter than the rest.
+
+        Red if a chunk's kv extent is taken from the chunk size rather than the
+        chunk's own length -- which the equal-length case cannot see.
+        """
+        self._assert_matches_single_shot([1024, 1024, 379])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

With a cached prefix, the aiter MHA extend path re-gathers and up-projects the
entire prefix through `kv_b_proj` in one shot — `index_select` -> fp8->bf16
upcast -> `contiguous` -> `kv_b_proj` -> `cat(k, k_pe)` — which costs ~13.2 KiB
per token per MLA layer. On Kimi-K3 at TP8 that is 5.0 GiB/layer at 400k context
and 12.6 GiB/layer at 1M, against ~19.5 GiB free. It aborted the scheduler with
`HSA_STATUS_ERROR_OUT_OF_RESOURCES` three times in 45 minutes at 347k–411k
context.

`AttnForwardMethod.MHA_CHUNKED_KV` already bounds that to one chunk, but was
unreachable: `maybe_disable_chunked_prefix_cache()` force-sets
`disable_chunked_prefix_cache=True` for any backend absent from
`CHUNKED_PREFIX_CACHE_SUPPORTED_ATTENTION_BACKENDS`, so
`--disable-chunked-prefix-cache` was a silent no-op on ROCm.

## Modifications

- **`server_args`**: add `aiter` to the supported-backend list.
- **`attention_backend_handler`**: `handle_attention_aiter` returns
  `MHA_CHUNKED_KV` once the cached prefix passes
  `chunked_prefix_cache_threshold`. Below it, behaviour is unchanged (plain
  MHA), so this is additive — aiter's asm MLA extend has gqa/qseqlen gaps and is
  deliberately still not used for extend.
- **`aiter_backend`**: `_forward_extend_mha_chunk()` honours
  `attn_attend_prefix_cache` (per-chunk indptr, non-causal against a chunk) and
  `mha_return_lse`, mirroring what the musa flashattention backend already does.
  aiter returns the softmax LSE heads-first `[num_heads, num_tokens]`, so it is
  transposed to the `[num_tokens, num_heads]` layout `merge_state` indexes.
- **`forward_mha`**: `sgl_kernel` exports a `merge_state_v2` wrapper on ROCm but
  never registers the op, so the CUDA-gated import left the name undefined and
  the chunked path died with `NameError`. Fall back to `merge_state`, which
  already dispatches to the Triton kernel on AMD — the same alias the musa
  branch uses.

## Accuracy Tests

`test/registered/kernels/test_aiter_mha_chunked_kv.py` asserts chunk + merge
reproduces a single-shot attention over the whole context at Kimi-K3-at-TP8
shapes (12 heads, qk 192, v 128), including an uneven final chunk. It covers the
three things that each have already been a bug: `merge_state` callable on ROCm,
the LSE layout, and the per-slice causal flags (causal within the new tokens,
NON-causal against a prefix chunk — getting this backwards produces
plausible-but-wrong output, not a crash). Tolerance 5e-3 is the bf16
reassociation floor from splitting the KV stream. Registered for
`stage-b-test-1-gpu-small-amd`.

## Speed Tests and Profiling

Kimi-K3 at TP8, 937k-token cold prefill:

| | before | after |
| --- | --- | --- |
| free VRAM at peak | 0.02 GiB | 17.90 GiB |
| transient | 19.3 GiB | 1.99 GiB |
| `kv_b_proj` GEMM M | 394564 | 32768 |

Peak becomes context-independent (237.86 GB at 400k vs 237.79 GB at 937k) for
+1% prefill latency, which is the per-chunk LSE merges.

## Checklist

- [x] Format code with pre-commit
- [x] Add unit tests
- [x] Provide accuracy and speed results
- [x] Follow the SGLang code style guidance

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32254868228](https://github.com/sgl-project/sglang/actions/runs/32254868228)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32254867908](https://github.com/sgl-project/sglang/actions/runs/32254867908)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->