### PR TITLE
fix(sgl-kernel): route below-SM90 GPUs to sm90 build in load_utils

### DIFF
--- a/python/sglang/kernels/aot/python/sgl_kernel/load_utils.py
+++ b/python/sglang/kernels/aot/python/sgl_kernel/load_utils.py
@@ -56,10 +56,18 @@ def _load_architecture_specific_ops():
     sgl_kernel_dir = Path(__file__).parent
     logger.debug(f"[sgl_kernel] sgl_kernel directory: {sgl_kernel_dir}")
 
-    # Determine which version to load based on GPU architecture
-    if compute_capability == 90:
+    # Determine which version to load based on GPU architecture.
+    # The sm90 artifact is the compatibility build: it carries gencode for
+    # sm_80/86/87/89 in addition to sm_90 (see ENABLE_BELOW_SM90 in
+    # CMakeLists.txt), so every GPU below SM100 must load it. Routing only
+    # cc==90 here sends sm_89 (Ada, e.g. L40S/RTX 4090) to the sm100
+    # directory, which fails whenever that artifact lacks below-SM90
+    # gencode.
+    if compute_capability is not None and compute_capability < 100:
         ops_subdir = "sm90"
-        variant_name = "SM90 (Hopper/H100 with fast math optimization)"
+        variant_name = (
+            f"SM{compute_capability} (sm90 build with fast math optimization)"
+        )
     elif compute_capability is not None:
         ops_subdir = "sm100"
         variant_name = f"SM{compute_capability} (precise math for compatibility)"


### PR DESCRIPTION
## Problem

`_load_architecture_specific_ops()` routes only `compute_capability == 90` to the `sm90/` directory; every other GPU falls into the `sm100/` branch.

However, the sm90 artifact is the compatibility build: `ENABLE_BELOW_SM90` (default ON on x86_64) appends `compute_80`/`compute_89` gencode (and `compute_87` on aarch64) to the shared `SGL_KERNEL_CUDA_FLAGS` used by `common_ops_sm90_build` (see `python/sglang/kernels/aot/CMakeLists.txt`). Below-SM90 GPUs (sm_80/86/87/89, e.g. L40S / RTX 4090) are therefore sent to the wrong directory and fail to `import sgl_kernel` whenever the sm100 artifact does not carry below-SM90 gencode — reproduced on an sm_89 GPU with CUDA 12.1 and sglang-kernel 0.4.5, where import failed until cc=89 was routed to the sm90 directory.

This currently happens to work on recent x86_64 wheels only because both builds share the same flags and the sm100 artifact incidentally contains sm_89 cubins; any divergence of the two builds' flag sets (or a wheel built with `ENABLE_BELOW_SM90=OFF`) breaks below-SM90 users immediately.

## Fix

Route every GPU with `compute_capability < 100` to the sm90 build. cc >= 100 and the no-GPU path are unchanged. `variant_name` now reports the actual cc instead of hardcoding "SM90".

Note: sm_89 is **not** a subset of sm_90 (Ada 8.x vs Hopper 9.x) — this works because the sm90 artifact is compiled with below-SM90 gencode, not because sm90 cubins run on sm89.

## Test

- `python -m py_compile` passes.
- Verified on an sm_89 GPU: `import sgl_kernel` succeeds with cc=89 routed to the sm90 directory.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32255261048](https://github.com/sgl-project/sglang/actions/runs/32255261048)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32255260792](https://github.com/sgl-project/sglang/actions/runs/32255260792)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->