### PR TITLE
[rust-server][2/4] Share Rust text request preparation

### DIFF
--- a/rust/sglang-server/src/tokenizer.rs
+++ b/rust/sglang-server/src/tokenizer.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use crate::error::Error;
 use crate::fsm::Event;
-use crate::message::{Request, RequestKind, TokenIds};
+use crate::message::{GenerateRequest, Request, RequestKind, TokenIds};
 use crate::runtime::Runnable;
 use crate::tokenizer_manager::TmEvent;
 
@@ -152,6 +152,37 @@ fn strip_auto_specials(mut ids: Vec<i32>, auto_specials: &[i32]) -> Vec<i32> {
     ids
 }
 
+/// Apply the text-tokenization stage to one generate request. Both the normal
+/// tokenizer worker and the standalone renderer call this function so stop
+/// sizing and special-token handling cannot drift between the two paths.
+pub(crate) fn tokenize_generate_request(
+    request: &mut GenerateRequest,
+    tokenizer: &dyn TextTokenizer,
+    auto_specials: &[i32],
+) -> Result<(), Error> {
+    // Size the scheduler's stop-match window in TOKENS, as Python's
+    // `normalize(tokenizer)` does.
+    if let Some(stop_tokens) = request
+        .sampling_params
+        .stop_strs
+        .iter()
+        // A stop that won't encode falls back to its byte length rather
+        // than failing the request: still an over-estimate, never an
+        // under-estimate, so the scheduler cannot miss that stop.
+        .map(|stop| tokenizer.encode(stop).map_or(stop.len(), |ids| ids.len()))
+        .max()
+    {
+        request.sampling_params.stop_str_max_len = stop_tokens;
+    }
+    let ids = tokenizer.encode(request.text.as_deref().unwrap_or(""))?;
+    request.input_ids = Some(if request.skip_special_tokens {
+        strip_auto_specials(ids, auto_specials)
+    } else {
+        ids
+    });
+    Ok(())
+}
+
 /// One tokenizer worker: pulls a `Request` off the shared inbox, fills
 /// `input_ids`, returns it to the TokenizerManager. Pinned; backend shared.
 ///
@@ -192,29 +223,8 @@ impl Runnable for TokenizerWorker {
                     tracing::error!("tokenizer pool received a non-generate request");
                     continue;
                 };
-                // Size the scheduler's stop-match window in TOKENS, as Python's
-                // `normalize(tokenizer)` does.
-                let stop_tokens = g
-                    .sampling_params
-                    .stop_strs
-                    .iter()
-                    // A stop that won't encode falls back to its byte length rather
-                    // than failing the request: still an over-estimate, never an
-                    // under-estimate, so the scheduler cannot miss that stop.
-                    .map(|s| self.tokenizer.encode(s).map_or(s.len(), |ids| ids.len()))
-                    .max();
-                if let Some(n) = stop_tokens {
-                    g.sampling_params.stop_str_max_len = n;
-                }
-                match self.tokenizer.encode(g.text.as_deref().unwrap_or("")) {
-                    Ok(ids) => {
-                        g.input_ids = Some(if g.skip_special_tokens {
-                            strip_auto_specials(ids, &self.auto_specials)
-                        } else {
-                            ids
-                        });
-                        Event::TokenizeDone
-                    }
+                match tokenize_generate_request(g, self.tokenizer.as_ref(), &self.auto_specials) {
+                    Ok(()) => Event::TokenizeDone,
                     Err(err) => Event::Error(err),
                 }
             };

--- a/rust/sglang-server/src/tokenizer_manager/ingress.rs
+++ b/rust/sglang-server/src/tokenizer_manager/ingress.rs
@@ -573,11 +573,32 @@ impl Ingress {
 /// generate request must already carry token ids (no tokenizer to byte-encode
 /// text); control requests carry none and are exempt.
 fn validate(req: &mut Request, limits: &Limits) -> Result<(), Error> {
-    let (skip_tokenizer_init, vocab_size) = (limits.skip_tokenizer_init, limits.vocab_size);
     let _ = req
         .state
         .apply(Event::Validated(ValidationOutcome::NeedsTokenize));
 
+    match &req.kind {
+        RequestKind::Generate(request) => {
+            validate_generate_request(&req.rid, request, limits)?;
+        }
+        RequestKind::Control(_) => validate_rid(&req.rid)?,
+        RequestKind::Detokenize { token_ids } => {
+            validate_rid(&req.rid)?;
+            // Detokenize ids must fit the shard's `&[u32]` decode domain. No vocab
+            // bound — parity with the retired direct decode service: an unknown id is
+            // the tokenizer's error to report, and nothing here reaches the scheduler's
+            // embedding lookup.
+            for &id in token_ids {
+                if u32::try_from(id).is_err() {
+                    return Err(Error::Validation(format!("Token ID {id} is out of range")));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_rid(rid: &Rid) -> Result<(), Error> {
     // The rid is the request's identity everywhere downstream: it keys the detok
     // table, and it rides on EVERY chunk of EVERY decode step. An unbounded
     // client-supplied rid is therefore a per-step cost, not a one-off. Python's is
@@ -585,15 +606,26 @@ fn validate(req: &mut Request, limits: &Limits) -> Result<(), Error> {
     // Measured on the CLIENT-facing form: the uniquifier `Rid::from_client` appends
     // is this server's own overhead, and charging the client for bytes it did not
     // send would reject a rid exactly at the documented limit.
-    let client_rid_len = req.rid.client_facing().len();
+    let client_rid_len = rid.client_facing().len();
     if client_rid_len > MAX_RID_LEN {
         return Err(Error::Validation(format!(
             "rid is {client_rid_len} bytes, over the {MAX_RID_LEN}-byte limit"
         )));
     }
-    if skip_tokenizer_init
-        && matches!(&req.kind, RequestKind::Generate(g) if !g.already_tokenized())
-    {
+    Ok(())
+}
+
+/// Validate the generate-specific fields checked when normal ingress receives
+/// a request. The standalone renderer calls the same function before it runs
+/// normalization and tokenization.
+pub(crate) fn validate_generate_request(
+    rid: &Rid,
+    request: &GenerateRequest,
+    limits: &Limits,
+) -> Result<(), Error> {
+    validate_rid(rid)?;
+    let vocab_size = limits.vocab_size;
+    if limits.skip_tokenizer_init && !request.already_tokenized() {
         // `Validation` (400), not `Tokenize` (500): the client sent a request this
         // server cannot serve, which is their error to fix — Python 400s it too.
         return Err(Error::Validation(
@@ -604,37 +636,23 @@ fn validate(req: &mut Request, limits: &Limits) -> Result<(), Error> {
     // Client-supplied token ids must be in-vocabulary: an out-of-range id
     // reaches the embedding lookup and kills the scheduler process, so 400
     // here instead — mirroring the Python `TokenizerManager` validation.
-    if let RequestKind::Generate(g) = &req.kind {
-        if let Some(ids) = &g.input_ids {
-            for &id in ids {
-                if id < 0 || id as u64 >= vocab_size {
-                    return Err(Error::Validation(format!(
-                        "input_ids contains out-of-vocabulary token id {id}; \
-                         valid range is [0, {vocab_size})"
-                    )));
-                }
-            }
-        }
-        if let Some(ids) = &g.token_ids_logprob {
-            for &id in ids {
-                if id < 0 || id as u64 >= vocab_size {
-                    return Err(Error::Validation(format!(
-                        "token_ids_logprob contains out-of-vocabulary token id \
-                         {id}; valid range is [0, {vocab_size})"
-                    )));
-                }
+    if let Some(ids) = &request.input_ids {
+        for &id in ids {
+            if id < 0 || id as u64 >= vocab_size {
+                return Err(Error::Validation(format!(
+                    "input_ids contains out-of-vocabulary token id {id}; \
+                     valid range is [0, {vocab_size})"
+                )));
             }
         }
     }
-
-    // Detokenize ids must fit the shard's `&[u32]` decode domain. No vocab
-    // bound — parity with the retired direct decode service: an unknown id is
-    // the tokenizer's error to report, and nothing here reaches the scheduler's
-    // embedding lookup.
-    if let RequestKind::Detokenize { token_ids } = &req.kind {
-        for &id in token_ids {
-            if u32::try_from(id).is_err() {
-                return Err(Error::Validation(format!("Token ID {id} is out of range")));
+    if let Some(ids) = &request.token_ids_logprob {
+        for &id in ids {
+            if id < 0 || id as u64 >= vocab_size {
+                return Err(Error::Validation(format!(
+                    "token_ids_logprob contains out-of-vocabulary token id \
+                     {id}; valid range is [0, {vocab_size})"
+                )));
             }
         }
     }
@@ -642,9 +660,7 @@ fn validate(req: &mut Request, limits: &Limits) -> Result<(), Error> {
     // The scheduler only computes hidden states when launched for it, so without
     // this the request would 200 with `meta_info.hidden_states` silently absent
     // (Python `TokenizerManager._validate_one_request`).
-    if !limits.enable_return_hidden_states
-        && matches!(&req.kind, RequestKind::Generate(g) if g.return_hidden_states)
-    {
+    if request.return_hidden_states && !limits.enable_return_hidden_states {
         return Err(Error::Validation(
             "The server is not configured to return the hidden states. \
              Please set `--enable-return-hidden-states` to enable this feature."
@@ -663,7 +679,7 @@ fn validate(req: &mut Request, limits: &Limits) -> Result<(), Error> {
 ///
 /// Under `allow_auto_truncate` both clamp instead of rejecting — the launch flag
 /// opted into that.
-fn check_total_tokens(g: &mut GenerateRequest, limits: &Limits) -> Result<(), Error> {
+pub(crate) fn check_total_tokens(g: &mut GenerateRequest, limits: &Limits) -> Result<(), Error> {
     let max_req_len = limits.context_len;
     // Python counts the reserved slots as part of the input, so a request can be
     // rejected for them even when the prompt alone fits.


### PR DESCRIPTION
WIP

Extracts the generate-request validation, preprocessing logic and tokenization  already used by normal inference.

The tokenizer-manager stages call the shared operations in the same order. No endpoint or wire schema changes, and `/tokenize` is unchanged.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32256828378](https://github.com/sgl-project/sglang/actions/runs/32256828378)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32256827705](https://github.com/sgl-project/sglang/actions/runs/32256827705)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->