### PR TITLE
[Diffusion] Fix calling init_npu_backend  in diffusion models

### DIFF
--- a/python/sglang/srt/models/clip.py
+++ b/python/sglang/srt/models/clip.py
@@ -2,7 +2,7 @@
 # https://github.com/huggingface/transformers/blob/af9b2eaa54c150741f298d6db939af6328e1dc38/src/transformers/models/clip/modeling_clip.py
 
 from functools import partial
-from typing import Iterable, List, Optional, Tuple, Type, Union
+from typing import TYPE_CHECKING, Iterable, List, Optional, Tuple, Type, Union
 
 import torch
 import torch.nn as nn
@@ -19,10 +19,12 @@ from sglang.srt.layers.linear import (
 from sglang.srt.layers.pooler import EmbeddingPoolerOutput, Pooler, PoolingType
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.managers.schedule_batch import MultimodalInputs
-from sglang.srt.model_executor.model_runner import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.runtime_context import get_parallel
 from sglang.srt.utils import add_prefix, flatten_nested_list
+
+if TYPE_CHECKING:
+    from sglang.srt.model_executor.model_runner import ForwardBatch
 
 
 def prepare_clip_attention_mask(
@@ -556,7 +558,7 @@ class CLIPModel(nn.Module):
         self,
         input_ids: torch.Tensor,
         positions: torch.Tensor,
-        forward_batch: ForwardBatch,
+        forward_batch: "ForwardBatch",
         get_embedding: bool = True,
     ):
         assert get_embedding, "CLIPEmbeddingModel is only used for embedding"


### PR DESCRIPTION
## Motivation

Recently tried to serve dit models (MOVA, QwenImage), found a new warning `No module named 'custom_ops'` and the performance degradation in MOVA denoising stage. The problem in listed bellowe block of imports in file sglang/python/sglang/multimodal_gen/runtime/models/encoders/clip.py 
```
from sglang.srt.models.clip import (
    CLIPEncoder,
    CLIPTextEmbeddings,
    CLIPVisionEmbeddings,
    prepare_clip_attention_mask,
)
```
It calls the srt.models.clip, where the import from sglang.srt.model_executor.model_runner is calling this code 
```
if _is_npu:
    from sglang.srt.hardware_backend.npu.utils import init_npu_backend

    init_npu_backend()
```

## Modifications

Added check for TYPE_CHECKING value to avoid calling the `init_npu_backend` in this case. Changed the annotation type for forward_batch to avoid runtime NameErrors.

## Accuracy Tests

Checked on MOVA (the same result as before changes):

https://github.com/user-attachments/assets/0e80091d-030a-443d-aa56-33ac8500cc80

## Speed Tests and Profiling

### For MOVA testing were used listed below commands:

### 1. SGLang Server Launch Command
```bash
sglang serve --model-path $(pwd)/mova_video_360p --pipeline-class-name MOVAPipeline --num-gpus 4 --ring-degree 1 --ulysses-degree 4 --performance-mode memory --dit-layerwise-offload --dit-offload-prefetch-size 0.1 --text-encoder-cpu-offload true --vae-cpu-offload true --enable-torch-compile --warmup-mode server --vae-tiling --vae-sp
```

### 2. Video Generation Request

```bash
curl -X POST "http://localhost:30000/v1/videos" -F "prompt=A curious raccoon" -F "input_reference=@/.../images/raccoon.png" -F "size=640x352"  -F "num_frames=49" -F "fps=24" -F "num_inference_steps=25" -F "guidance_scale=5.0" -o create_video.json
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #32258138622](https://github.com/sgl-project/sglang/actions/runs/32258138622)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #32258138291](https://github.com/sgl-project/sglang/actions/runs/32258138291)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->