### PR TITLE
[Model] Add qwen3 bidirectional embedding

### DIFF
--- a/docs/docs/supported-models/embedding_models.mdx
+++ b/docs/docs/supported-models/embedding_models.mdx
@@ -168,6 +168,12 @@ print("Embedding:", response["data"][0]["embedding"])
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Bare <code>Qwen3Model</code> backbone (no LM head); served natively on SGLang's fused Qwen3 kernels and auto-classified as an embedding model</td>
     </tr>
     <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>Giga-Embeddings (Qwen3)</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>`ai-sage/Giga-Embeddings-instruct-3B-0826`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>N/A</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Bidirectional (encoder-style) Qwen3 embedding model (<code>Qwen3BidirectionalModel</code>, <code>is_causal=false</code>); mean pooling + L2 normalization, auto-classified as an embedding model</td>
+    </tr>
+    <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>BGE</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>`BAAI/bge-large-en-v1.5`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>N/A</td>

--- a/python/sglang/srt/configs/embedding_model_spec.py
+++ b/python/sglang/srt/configs/embedding_model_spec.py
@@ -133,6 +133,11 @@ _EMBEDDING_ARCHITECTURES = {
         EmbeddingExecution.DECODER_POOLING,
         PoolingStrategy.LAST,
     ),
+    "Qwen3BidirectionalModel": (
+        "qwen3_bidirectional",
+        EmbeddingExecution.ENCODER_ONLY,
+        PoolingStrategy.MEAN,
+    ),
     "XLMRobertaModel": (
         "xlm_roberta",
         EmbeddingExecution.ENCODER_ONLY,

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -1788,6 +1788,7 @@ def is_generation_model(model_architectures: List[str], is_embedding: bool = Fal
         or "Qwen2ForSequenceClassification" in model_architectures
         or "Qwen3ForSequenceClassification" in model_architectures
         or "Qwen3Model" in model_architectures
+        or "Qwen3BidirectionalModel" in model_architectures
         or "CLIPModel" in model_architectures
         or "BertModel" in model_architectures
         or "Contriever" in model_architectures

--- a/python/sglang/srt/models/qwen3.py
+++ b/python/sglang/srt/models/qwen3.py
@@ -14,7 +14,7 @@ from sglang.srt.layers.linear import QKVParallelLinear, RowParallelLinear
 from sglang.srt.layers.logits_processor import LogitsProcessor
 from sglang.srt.layers.pooler import Pooler, PoolingType
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
-from sglang.srt.layers.radix_attention import RadixAttention
+from sglang.srt.layers.radix_attention import AttentionType, RadixAttention
 from sglang.srt.layers.rotary_embedding import get_rope
 from sglang.srt.layers.rotary_embedding.mrope import MRotaryEmbedding
 from sglang.srt.layers.utils import PPMissingLayer, get_layer_id
@@ -77,6 +77,7 @@ class Qwen3Attention(nn.Module):
         attention_bias: bool = False,
         prefix: str = "",
         alt_stream: Optional[torch.cuda.Stream] = None,
+        attn_type: AttentionType = AttentionType.DECODER,
     ) -> None:
         super().__init__()
         self.hidden_size = hidden_size
@@ -153,6 +154,7 @@ class Qwen3Attention(nn.Module):
             num_kv_heads=self.num_kv_heads,
             layer_id=layer_id,
             prefix=add_prefix("attn", prefix),
+            attn_type=attn_type,
         )
         self.alt_stream = alt_stream
 
@@ -331,6 +333,14 @@ class Qwen3DecoderLayer(nn.Module):
             rope_scaling = getattr(config, "rope_scaling", None)
         max_position_embeddings = getattr(config, "max_position_embeddings", 32768)
         head_dim = getattr(config, "head_dim", None)
+        # Embedding variants (e.g. Qwen3BidirectionalModel) run the backbone with
+        # encoder-style bidirectional attention by declaring is_causal=False on
+        # the HF config; the default causal-LM path keeps is_causal=True.
+        attn_type = (
+            AttentionType.DECODER
+            if getattr(config, "is_causal", True)
+            else AttentionType.ENCODER_ONLY
+        )
         self.self_attn = Qwen3Attention(
             hidden_size=self.hidden_size,
             num_heads=config.num_attention_heads,
@@ -346,6 +356,7 @@ class Qwen3DecoderLayer(nn.Module):
             attention_bias=config.attention_bias,
             prefix=add_prefix("self_attn", prefix),
             alt_stream=alt_stream,
+            attn_type=attn_type,
         )
         self.mlp = Qwen3MLP(
             hidden_size=self.hidden_size,

--- a/python/sglang/srt/models/qwen3_embedding.py
+++ b/python/sglang/srt/models/qwen3_embedding.py
@@ -121,4 +121,24 @@ class Qwen3Model(nn.Module):
                     logger.warning(f"Parameter {name} not found in params_dict")
 
 
-EntryClass = Qwen3Model
+class Qwen3BidirectionalModel(Qwen3Model):
+    """Bidirectional Qwen3 encoder for dense embedding models.
+
+    Checkpoints exported as architectures=["Qwen3BidirectionalModel"], e.g.
+    ai-sage/Giga-Embeddings-instruct-3B-0826, run the Qwen3 backbone with
+    encoder-style (bidirectional) attention -- enabled by is_causal=False on
+    the HF config, threaded into the attention layers -- and produce a sentence
+    embedding via mean pooling over non-padding tokens + L2 normalization.
+    """
+
+    def __init__(
+        self,
+        config,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__(config, quant_config=quant_config, prefix=prefix)
+        self.pooler = Pooler(pooling_type=PoolingType.MEAN, normalize=True)
+
+
+EntryClass = [Qwen3Model, Qwen3BidirectionalModel]

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3769,6 +3769,24 @@ class ServerArgs:
                 "prompt attention."
             )
 
+        # Qwen3BidirectionalModel is a Qwen3 backbone served as an encoder-style
+        # embedding model (is_causal=False). Bidirectional attention over the
+        # whole prompt makes prefix reuse and split prefills invalid (K/V depend
+        # on later tokens), and the captured prefill CUDA graph corrupts the
+        # non-causal attention, so disable all three for correctness.
+        if "Qwen3BidirectionalModel" in getattr(hf_config, "architectures", []):
+            self.chunked_prefill_size = -1
+            self.disable_radix_cache = True
+            self.disable_cuda_graph = True
+            self.cuda_graph_config.decode.backend = Backend.DISABLED
+            self.cuda_graph_config.prefill.backend = Backend.DISABLED
+            logger.warning(
+                "Qwen3BidirectionalModel detected: forcing "
+                "--chunked-prefill-size -1, --disable-radix-cache, and "
+                "--disable-cuda-graph for correctness of the bidirectional "
+                "(encoder-style) prompt attention."
+            )
+
         # EmbeddingGemma is a Gemma3TextModel with bidirectional prompt
         # attention. Prefix reuse and split prefills would reuse K/V states
         # whose values depend on later prompt tokens, so both are invalid.

--- a/test/registered/unit/configs/test_embedding_model_spec.py
+++ b/test/registered/unit/configs/test_embedding_model_spec.py
@@ -52,7 +52,11 @@ class TestEmbeddingModelSpec(unittest.TestCase):
         matrix = embedding_support_matrix()
         by_architecture = {row["architecture"]: row for row in matrix}
 
-        self.assertEqual(len(matrix), 7)
+        self.assertEqual(len(matrix), 8)
+        self.assertEqual(
+            by_architecture["Qwen3BidirectionalModel"]["attention"], "bidirectional"
+        )
+        self.assertEqual(by_architecture["Qwen3BidirectionalModel"]["pooling"], "mean")
         self.assertEqual(by_architecture["BertModel"]["family"], "bert")
         self.assertEqual(by_architecture["BertModel"]["attention"], "bidirectional")
         self.assertTrue(by_architecture["CLIPModel"]["supports_multimodal"])

--- a/test/registered/unit/models/test_qwen3_bidirectional_embedding_registration.py
+++ b/test/registered/unit/models/test_qwen3_bidirectional_embedding_registration.py
@@ -1,0 +1,127 @@
+"""Unit tests for the ``Qwen3BidirectionalModel`` embedding architecture.
+
+Checkpoints such as ``ai-sage/Giga-Embeddings-instruct-3B-0826`` declare
+``architectures=["Qwen3BidirectionalModel"]``: a Qwen3 backbone served as an
+encoder-style embedding model (``is_causal=False``). These must resolve to the
+native SGLang implementation, be classified as an embedding model, and use MEAN
+pooling (not the LAST pooling of the plain ``Qwen3Model`` embedding arch).
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.srt.configs.embedding_model_spec import (
+    AttentionPattern,
+    PoolingStrategy,
+    resolve_embedding_model_spec,
+)
+from sglang.srt.configs.model_config import is_generation_model
+from sglang.srt.model_executor.cuda_graph_config import (
+    Backend,
+    CudaGraphConfig,
+    PhaseConfig,
+)
+from sglang.srt.server_args import ServerArgs
+from sglang.test.test_utils import CustomTestCase
+
+
+class TestQwen3BidirectionalRegistration(CustomTestCase):
+    def test_entry_class_registered(self):
+        from sglang.srt.models import qwen3_embedding
+
+        names = {c.__name__ for c in qwen3_embedding.EntryClass}
+        # The bidirectional arch is registered alongside the plain Qwen3Model.
+        self.assertIn("Qwen3BidirectionalModel", names)
+        self.assertIn("Qwen3Model", names)
+
+    def test_registry_resolves_native_class(self):
+        from sglang.srt.models.registry import ModelRegistry
+
+        model_cls, resolved_arch = ModelRegistry.resolve_model_cls(
+            "Qwen3BidirectionalModel"
+        )
+        self.assertEqual(resolved_arch, "Qwen3BidirectionalModel")
+        self.assertEqual(model_cls.__name__, "Qwen3BidirectionalModel")
+        self.assertEqual(
+            model_cls.__module__, "sglang.srt.models.qwen3_embedding"
+        )
+        self.assertNotIn("Transformers", model_cls.__name__)
+
+    def test_classified_as_embedding(self):
+        """Non-generative regardless of the --is-embedding flag."""
+        self.assertFalse(is_generation_model(["Qwen3BidirectionalModel"]))
+        self.assertFalse(
+            is_generation_model(["Qwen3BidirectionalModel"], is_embedding=True)
+        )
+        # The generative arch keeps its prior behavior.
+        self.assertTrue(is_generation_model(["Qwen3ForCausalLM"]))
+
+    def test_uses_mean_pooling_not_last(self):
+        """Giga-Embeddings requires mean pooling; last-token pooling (used by
+        the plain Qwen3Model embedding arch) would produce wrong embeddings.
+        """
+        import inspect
+
+        from sglang.srt.models.qwen3_embedding import (
+            Qwen3BidirectionalModel,
+            Qwen3Model,
+        )
+
+        # The bidirectional class overrides __init__ to swap the pooler to MEAN;
+        # the plain Qwen3Model keeps LAST pooling.
+        self.assertIsNot(Qwen3BidirectionalModel.__init__, Qwen3Model.__init__)
+        src = inspect.getsource(Qwen3BidirectionalModel.__init__)
+        self.assertIn("PoolingType.MEAN", src)
+
+    def test_embedding_spec_is_bidirectional_mean(self):
+        spec = resolve_embedding_model_spec(
+            ["Qwen3BidirectionalModel"],
+            is_embedding_requested=False,
+            is_embedding_gemma=False,
+        )
+        self.assertEqual(spec.attention, AttentionPattern.BIDIRECTIONAL)
+        self.assertEqual(spec.pooling, PoolingStrategy.MEAN)
+        self.assertTrue(spec.bidirectional_attention)
+        self.assertTrue(spec.auto_enable_embedding)
+
+    def test_capability_adjustment_disables_cuda_graph(self):
+        """Regression: the captured prefill CUDA graph corrupts the non-causal
+        attention (embeddings came out wrong / batch-size dependent), and
+        prefix/split-prefill reuse is invalid under bidirectional attention.
+        Serving this arch must disable CUDA graph, radix cache, and chunked
+        prefill.
+        """
+        args = ServerArgs(model_path="dummy")
+        args.model_config = SimpleNamespace(
+            is_embedding_gemma=False,
+            is_multimodal=False,
+            embedding_model_spec=None,
+            hf_config=SimpleNamespace(architectures=["Qwen3BidirectionalModel"]),
+        )
+        args.cuda_graph_config = CudaGraphConfig(
+            decode=PhaseConfig(backend=Backend.FULL),
+            prefill=PhaseConfig(backend=Backend.BREAKABLE),
+        )
+        args.disable_cuda_graph = False
+        args.disable_radix_cache = False
+        args.chunked_prefill_size = 2048
+
+        with patch.object(
+            args, "get_model_config", return_value=args.model_config
+        ):
+            args._handle_model_capability_adjustments()
+
+        self.assertTrue(args.disable_cuda_graph)
+        self.assertTrue(args.disable_radix_cache)
+        self.assertEqual(args.chunked_prefill_size, -1)
+        self.assertEqual(args.cuda_graph_config.decode.backend, Backend.DISABLED)
+        self.assertEqual(args.cuda_graph_config.prefill.backend, Backend.DISABLED)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/models/test_qwen3_embedding_registration.py
+++ b/test/registered/unit/models/test_qwen3_embedding_registration.py
@@ -21,8 +21,10 @@ class TestQwen3ModelEmbeddingRegistration(CustomTestCase):
         """The bare arch string maps to a native EntryClass named 'Qwen3Model'."""
         from sglang.srt.models import qwen3_embedding
 
-        entry = qwen3_embedding.EntryClass
-        self.assertEqual(entry.__name__, "Qwen3Model")
+        entries = qwen3_embedding.EntryClass
+        entries = entries if isinstance(entries, list) else [entries]
+        by_name = {c.__name__: c for c in entries}
+        entry = by_name["Qwen3Model"]
         self.assertEqual(entry.__module__, "sglang.srt.models.qwen3_embedding")
         # It carries a LAST-token / normalized pooler, i.e. an embedding head.
         self.assertTrue(hasattr(entry, "forward"))


### PR DESCRIPTION
## Motivation

Add native SGLang support for **`ai-sage/Giga-Embeddings-instruct-3B-0826`**, a text-embedding model built on the Qwen3 backbone but run with **encoder-style (bidirectional) attention** and mean pooling. Its HF checkpoint declares `architectures=["Qwen3BidirectionalModel"]` with `is_causal=false`; without native support it falls back to the Transformers backend (and, more importantly, SGLang has no bidirectional-attention path wired for Qwen3).

This is one of a pair of PRs adding the Giga-Embeddings models; the DeepSeek-V3 sibling (`DeepseekV3BidirectionalModel`) is submitted separately.

## Modifications

The whole change is driven by the checkpoint's own `is_causal=False` flag (default `True` keeps the existing causal path byte-for-byte identical). It mirrors the merged `Lfm2BidirectionalModel` / `gemma3_causal.py` patterns.

- **`models/qwen3.py`**: thread an `attn_type` through `Qwen3Attention` / `Qwen3DecoderLayer`, selected from `config.is_causal` → `AttentionType.ENCODER_ONLY` when bidirectional, else `AttentionType.DECODER` (unchanged default).
- **`models/qwen3_embedding.py`**: add `Qwen3BidirectionalModel` (reuses the existing bare-backbone embedding wrapper; `Pooler(MEAN, normalize=True)`), registered via the `EntryClass` list.
- **`configs/model_config.py`**: classify `Qwen3BidirectionalModel` as a non-generation (embedding) architecture.
- **`configs/embedding_model_spec.py`**: register it as a bidirectional, mean-pooling embedding architecture (auto-enables embedding mode).
- **`server_args.py`**: for this architecture, force `--disable-cuda-graph`, `--disable-radix-cache`, `--chunked-prefill-size -1`. Bidirectional attention over the whole prompt makes prefix/split-prefill reuse invalid, and — verified below — the captured prefill CUDA graph corrupts the non-causal attention. This mirrors the existing HRM-Text / EmbeddingGemma handling.

Serving is fully automatic:
```bash
python -m sglang.launch_server \
  --model-path ai-sage/Giga-Embeddings-instruct-3B-0826 \
  --is-embedding --trust-remote-code
```

## Accuracy Tests

Reference = HF `AutoModel` (`trust_remote_code`, `is_causal=False`), mean-pool over non-padding tokens + L2 normalize. SGLang served with the out-of-the-box command above (auto-guards applied). Cosine similarity, per text:

| Backend | min cosine vs HF (batched & single) | Result |
|---|---|---|
| triton | 0.997 | ✅ PASS |
| flashinfer | 0.9965 | ✅ PASS |
| torch_native | 0.9976 | ✅ PASS |

Retrieval sanity (query → documents): `Paris` 0.68 ≫ `mitochondria` 0.10 ≫ `photosynthesis` 0.01. Single-request and batched outputs agree (no cross-sequence leakage).

> Note: `fa3` could not be validated on the test GPU (RTX 5090, SM120 — fa3 requires SM 80–90). It is a regular-attention backend that honors `ENCODER_ONLY`, so it is expected to pass on Hopper; a maintainer with Hopper hardware may want to confirm.

**Regression caught during testing:** with the prefill CUDA graph enabled, embeddings were wrong and batch-size-dependent (min cosine ~0.18). Disabling CUDA graph (as this PR does) restores parity. A unit test guards the capability adjustment.

## Speed Tests and Profiling

No changes to existing code paths (the causal Qwen3 path is unchanged). The new path is prefill-only embedding; no decode/CUDA-graph impact on existing models.

## Checklist

- [x] Format your code according to the Format code with pre-commit.
- [x] Add unit tests (`test/registered/unit/models/test_qwen3_bidirectional_embedding_registration.py`; also updated `test_embedding_model_spec.py` and `test_qwen3_embedding_registration.py` for the extended registry).
- [x] Update documentation (`docs/docs/supported-models/embedding_models.mdx`).
- [x] Provide accuracy results (above).
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32259721331](https://github.com/sgl-project/sglang/actions/runs/32259721331)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32259720337](https://github.com/sgl-project/sglang/actions/runs/32259720337)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->