### PR TITLE
[Model] Add deepseek v3 bidirectional embedding

### DIFF
--- a/docs/docs/supported-models/embedding_models.mdx
+++ b/docs/docs/supported-models/embedding_models.mdx
@@ -168,6 +168,12 @@ print("Embedding:", response["data"][0]["embedding"])
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Bare <code>Qwen3Model</code> backbone (no LM head); served natively on SGLang's fused Qwen3 kernels and auto-classified as an embedding model</td>
     </tr>
     <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>Giga-Embeddings (DeepSeek-V3)</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>`ai-sage/Giga-Embeddings-instruct-10B-A1.8B-0826`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>N/A</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Bidirectional (encoder-style) DeepSeek-V3 MoE embedding model (<code>DeepseekV3BidirectionalModel</code>, <code>is_causal=false</code>); mean pooling + L2 normalization, auto-classified as an embedding model</td>
+    </tr>
+    <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>BGE</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>`BAAI/bge-large-en-v1.5`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>N/A</td>

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -2704,3 +2704,18 @@ def _hrm_text_attention_force(view: Any) -> dict:
             "attention."
         )
     return {"attention_backend": "triton"}
+
+
+def _deepseek_bidirectional_attention_force(view: Any) -> dict:
+    """DeepseekV3BidirectionalModel serves encoder-style (bidirectional)
+    embeddings through the MLA MHA prefill path. Only the Triton backend honors
+    non-causal (ENCODER_ONLY) attention on that path; the flashinfer MLA prefill
+    ignores it and silently runs causal, producing wrong embeddings."""
+    if view.attention_backend not in (None, "triton"):
+        logger.warning(
+            f"Overriding --attention-backend "
+            f"{view.attention_backend!r} -> 'triton': only the "
+            "Triton backend supports DeepseekV3BidirectionalModel's "
+            "bidirectional (encoder-style) attention."
+        )
+    return {"attention_backend": "triton"}

--- a/python/sglang/srt/configs/embedding_model_spec.py
+++ b/python/sglang/srt/configs/embedding_model_spec.py
@@ -117,6 +117,11 @@ class EmbeddingModelSpec:
 
 _EMBEDDING_ARCHITECTURES = {
     "BertModel": ("bert", EmbeddingExecution.ENCODER_ONLY, PoolingStrategy.CLS),
+    "DeepseekV3BidirectionalModel": (
+        "deepseek_v3_bidirectional",
+        EmbeddingExecution.ENCODER_ONLY,
+        PoolingStrategy.MEAN,
+    ),
     "CLIPModel": ("clip", EmbeddingExecution.MULTIMODAL, PoolingStrategy.LAST),
     "Contriever": (
         "contriever",

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -869,6 +869,7 @@ class ModelConfig:
             or "DeepseekV32ForCausalLM" in self.hf_config.architectures
             or "DeepseekV3ForCausalLM" in self.hf_config.architectures
             or "DeepseekV3ForCausalLMNextN" in self.hf_config.architectures
+            or "DeepseekV3BidirectionalModel" in self.hf_config.architectures
             or "Glm4MoeLiteForCausalLM" in self.hf_config.architectures
             or "Glm4MoeLiteForCausalLMNextN" in self.hf_config.architectures
             or "GlmMoeDsaForCausalLM" in self.hf_config.architectures
@@ -1796,6 +1797,7 @@ def is_generation_model(model_architectures: List[str], is_embedding: bool = Fal
         or "XLMRobertaForSequenceClassification" in model_architectures
         or "Gemma2ForSequenceClassification" in model_architectures
         or "Lfm2BidirectionalModel" in model_architectures
+        or "DeepseekV3BidirectionalModel" in model_architectures
     ):
         return False
     else:

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -128,7 +128,7 @@ from sglang.srt.layers.quantization.fp8_utils import (
 from sglang.srt.layers.quantization.mxfp4_flashinfer_trtllm_moe import (
     maybe_fuse_routed_scale_and_shared_add,
 )
-from sglang.srt.layers.radix_attention import RadixAttention
+from sglang.srt.layers.radix_attention import AttentionType, RadixAttention
 from sglang.srt.layers.rotary_embedding import get_rope_wrapper
 from sglang.srt.layers.utils import PPMissingLayer
 from sglang.srt.layers.utils.cp_utils import (
@@ -1913,6 +1913,16 @@ class DeepseekV2AttentionMLA(
                 prefix=add_prefix("attn_mqa", prefix),
             )
 
+        # Embedding variants (e.g. DeepseekV3BidirectionalModel) run the backbone
+        # with encoder-style bidirectional attention by declaring is_causal=False
+        # on the HF config. Only the MHA (non-absorbed) prefill path honors it:
+        # the absorbed-MLA kernels are causal-only, so these models are served
+        # prefill-only through attn_mha. attn_mqa (decode/absorbed) stays causal.
+        mha_attn_type = (
+            AttentionType.DECODER
+            if getattr(config, "is_causal", True)
+            else AttentionType.ENCODER_ONLY
+        )
         self.attn_mha = RadixAttention(
             self.num_local_heads,
             self.qk_nope_head_dim + self.qk_rope_head_dim,
@@ -1922,6 +1932,7 @@ class DeepseekV2AttentionMLA(
             v_head_dim=self.v_head_dim,
             quant_config=quant_config,
             prefix=add_prefix("attn_mha", prefix),
+            attn_type=mha_attn_type,
         )
 
         self.alt_stream = alt_stream

--- a/python/sglang/srt/models/deepseek_v2_embedding.py
+++ b/python/sglang/srt/models/deepseek_v2_embedding.py
@@ -1,0 +1,52 @@
+# Adapted from deepseek_v2.py
+from typing import Optional
+
+import torch
+from transformers import PretrainedConfig
+
+from sglang.srt.layers.pooler import EmbeddingPoolerOutput, Pooler, PoolingType
+from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.models.deepseek_v2 import DeepseekV3ForCausalLM
+
+
+class DeepseekV3BidirectionalModel(DeepseekV3ForCausalLM):
+    """Bidirectional DeepSeek-V3 encoder for dense embedding models.
+
+    Checkpoints exported as architectures=["DeepseekV3BidirectionalModel"], e.g.
+    ai-sage/Giga-Embeddings-instruct-10B-A1.8B-0826, run the DeepSeek-V3 MoE
+    backbone with encoder-style (bidirectional) attention -- enabled by
+    is_causal=False on the HF config, threaded into the MHA prefill path as
+    AttentionType.ENCODER_ONLY -- and produce a sentence embedding via mean
+    pooling over non-padding tokens + L2 normalization.
+
+    The absorbed-MLA attention kernels are causal-only, so these models are
+    served prefill-only through the MHA path (attn_mha). CUDA-graph capture is
+    disabled for them in ServerArgs so prefill never falls back to the absorbed
+    (causal) kernel.
+    """
+
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__(config, quant_config=quant_config, prefix=prefix)
+        self.pooler = Pooler(pooling_type=PoolingType.MEAN, normalize=True)
+
+    @torch.no_grad()
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_embeds: torch.Tensor = None,
+        get_embedding: bool = True,
+    ) -> EmbeddingPoolerOutput:
+        assert get_embedding, f"{self.__class__.__name__} is only used for embedding"
+        hidden_states = self.model(input_ids, positions, forward_batch, input_embeds)
+        return self.pooler(hidden_states, forward_batch)
+
+
+EntryClass = [DeepseekV3BidirectionalModel]

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3735,6 +3735,7 @@ class ServerArgs:
         if parse_connector_type(self.model_path) == ConnectorType.INSTANCE:
             return
         from sglang.srt.arg_groups.overrides import (
+            _deepseek_bidirectional_attention_force,
             _hrm_text_attention_force,
             run_post_process_pass,
         )
@@ -3767,6 +3768,30 @@ class ServerArgs:
                 "triton, --chunked-prefill-size -1, --disable-radix-cache, and "
                 "--disable-cuda-graph for correctness of the bidirectional "
                 "prompt attention."
+            )
+
+        # DeepseekV3BidirectionalModel is a DeepSeek-V3 MoE served as an
+        # encoder-style embedding model (is_causal=False). Bidirectional
+        # attention is only honored on the non-absorbed MHA prefill path, and
+        # only the Triton backend honors ENCODER_ONLY there (flashinfer's MLA
+        # prefill silently runs causal). The absorbed-MLA kernels are causal-
+        # only and are exactly what CUDA-graph capture pins, so disable graph
+        # capture to keep prefill on the MHA path. Prefix reuse and split
+        # prefills reuse K/V that depend on later prompt tokens, so both are
+        # invalid under bidirectional attention.
+        if "DeepseekV3BidirectionalModel" in getattr(hf_config, "architectures", []):
+            run_post_process_pass(self, _deepseek_bidirectional_attention_force)
+            self.chunked_prefill_size = -1
+            self.disable_radix_cache = True
+            self.disable_cuda_graph = True
+            self.cuda_graph_config.decode.backend = Backend.DISABLED
+            self.cuda_graph_config.prefill.backend = Backend.DISABLED
+            logger.warning(
+                "DeepseekV3BidirectionalModel detected: forcing "
+                "--attention-backend triton, --chunked-prefill-size -1, "
+                "--disable-radix-cache, and --disable-cuda-graph for "
+                "correctness of the bidirectional (encoder-style) prompt "
+                "attention on the MHA prefill path."
             )
 
         # EmbeddingGemma is a Gemma3TextModel with bidirectional prompt

--- a/test/registered/unit/configs/test_embedding_model_spec.py
+++ b/test/registered/unit/configs/test_embedding_model_spec.py
@@ -52,7 +52,14 @@ class TestEmbeddingModelSpec(unittest.TestCase):
         matrix = embedding_support_matrix()
         by_architecture = {row["architecture"]: row for row in matrix}
 
-        self.assertEqual(len(matrix), 7)
+        self.assertEqual(len(matrix), 8)
+        self.assertEqual(
+            by_architecture["DeepseekV3BidirectionalModel"]["attention"],
+            "bidirectional",
+        )
+        self.assertEqual(
+            by_architecture["DeepseekV3BidirectionalModel"]["pooling"], "mean"
+        )
         self.assertEqual(by_architecture["BertModel"]["family"], "bert")
         self.assertEqual(by_architecture["BertModel"]["attention"], "bidirectional")
         self.assertTrue(by_architecture["CLIPModel"]["supports_multimodal"])

--- a/test/registered/unit/models/test_deepseek_v3_bidirectional_embedding_registration.py
+++ b/test/registered/unit/models/test_deepseek_v3_bidirectional_embedding_registration.py
@@ -1,0 +1,111 @@
+"""Unit tests for the ``DeepseekV3BidirectionalModel`` embedding architecture.
+
+Checkpoints such as ``ai-sage/Giga-Embeddings-instruct-10B-A1.8B-0826`` declare
+``architectures=["DeepseekV3BidirectionalModel"]``: a DeepSeek-V3 MoE backbone
+served as an encoder-style embedding model (``is_causal=False``). These must
+resolve to the native SGLang implementation, be classified as an embedding
+model, and -- because the absorbed-MLA kernels are causal-only -- force the
+runtime onto the non-absorbed MHA prefill path by disabling CUDA-graph capture.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.srt.configs.embedding_model_spec import (
+    AttentionPattern,
+    PoolingStrategy,
+    resolve_embedding_model_spec,
+)
+from sglang.srt.configs.model_config import is_generation_model
+from sglang.srt.model_executor.cuda_graph_config import (
+    Backend,
+    CudaGraphConfig,
+    PhaseConfig,
+)
+from sglang.srt.server_args import ServerArgs
+from sglang.test.test_utils import CustomTestCase
+
+
+class TestDeepseekV3BidirectionalRegistration(CustomTestCase):
+    def test_registry_resolves_native_class(self):
+        from sglang.srt.models.registry import ModelRegistry
+
+        model_cls, resolved_arch = ModelRegistry.resolve_model_cls(
+            "DeepseekV3BidirectionalModel"
+        )
+        self.assertEqual(resolved_arch, "DeepseekV3BidirectionalModel")
+        self.assertEqual(model_cls.__name__, "DeepseekV3BidirectionalModel")
+        self.assertEqual(
+            model_cls.__module__, "sglang.srt.models.deepseek_v2_embedding"
+        )
+        self.assertNotIn("Transformers", model_cls.__name__)
+        # Reuses the DeepSeek-V3 weight-loading path.
+        self.assertTrue(hasattr(model_cls, "load_weights"))
+
+    def test_classified_as_embedding(self):
+        """Non-generative regardless of the --is-embedding flag."""
+        self.assertFalse(is_generation_model(["DeepseekV3BidirectionalModel"]))
+        self.assertFalse(
+            is_generation_model(["DeepseekV3BidirectionalModel"], is_embedding=True)
+        )
+        # The base causal-LM archs stay generative.
+        self.assertTrue(is_generation_model(["DeepseekV3ForCausalLM"]))
+
+    def test_embedding_spec_is_bidirectional_mean(self):
+        spec = resolve_embedding_model_spec(
+            ["DeepseekV3BidirectionalModel"],
+            is_embedding_requested=False,
+            is_embedding_gemma=False,
+        )
+        self.assertEqual(spec.attention, AttentionPattern.BIDIRECTIONAL)
+        self.assertEqual(spec.pooling, PoolingStrategy.MEAN)
+        self.assertTrue(spec.bidirectional_attention)
+        self.assertTrue(spec.auto_enable_embedding)
+
+    def test_capability_adjustment_forces_triton_and_disables_cuda_graph(self):
+        """Only the Triton backend honors ENCODER_ONLY on the MLA MHA prefill
+        path (flashinfer silently runs causal). The absorbed-MLA kernel is
+        causal-only and is what graph capture pins, so serving this arch must
+        force triton and disable CUDA-graph capture and the prefix/split-prefill
+        reuse that is invalid under bidirectional attention. A regression here
+        would silently produce causal embeddings.
+        """
+        args = ServerArgs(model_path="dummy")
+        args.attention_backend = "flashinfer"
+        args.model_config = SimpleNamespace(
+            is_embedding_gemma=False,
+            is_multimodal=False,
+            embedding_model_spec=None,
+            hf_config=SimpleNamespace(architectures=["DeepseekV3BidirectionalModel"]),
+        )
+        args.cuda_graph_config = CudaGraphConfig(
+            decode=PhaseConfig(backend=Backend.FULL),
+            prefill=PhaseConfig(backend=Backend.TC_PIECEWISE),
+        )
+        args.disable_radix_cache = False
+        args.disable_cuda_graph = False
+        args.chunked_prefill_size = 2048
+
+        with patch.object(args, "get_model_config", return_value=args.model_config):
+            args._handle_model_capability_adjustments()
+
+        # The backend override is declared through the resolution stash (it
+        # materializes onto the field during full server-arg resolution).
+        declared = {}
+        for _, fields in args._resolved_overrides or []:
+            declared.update(fields)
+        self.assertEqual(declared.get("attention_backend"), "triton")
+        self.assertTrue(args.disable_cuda_graph)
+        self.assertTrue(args.disable_radix_cache)
+        self.assertEqual(args.chunked_prefill_size, -1)
+        self.assertEqual(args.cuda_graph_config.decode.backend, Backend.DISABLED)
+        self.assertEqual(args.cuda_graph_config.prefill.backend, Backend.DISABLED)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Add native SGLang support for **`ai-sage/Giga-Embeddings-instruct-10B-A1.8B-0826`**, a text-embedding model built on the **DeepSeek-V3 MoE (MLA)** backbone but run with **encoder-style (bidirectional) attention** and mean pooling. Its HF checkpoint declares `architectures=["DeepseekV3BidirectionalModel"]` with `is_causal=false`.

DeepSeek uses MLA, whose absorbed attention kernels are causal-only, so bidirectional support requires routing through the non-absorbed MHA prefill path. This is one of a pair of PRs adding the Giga-Embeddings models; the Qwen3 sibling (`Qwen3BidirectionalModel`) is submitted separately.

## Modifications

Driven entirely by the checkpoint's own `is_causal=False` (default `True` leaves the causal path unchanged). Since embedding models are **prefill-only**, they are served through `DeepseekV2AttentionMLA`'s non-absorbed MHA prefill path (`attn_mha`), which is a standard `RadixAttention` that honors `attn_type`.

- **`models/deepseek_v2.py`**: set `attn_mha` to `AttentionType.ENCODER_ONLY` when `config.is_causal is False` (the absorbed `attn_mqa` decode path stays causal and is unused for embeddings).
- **`models/deepseek_v2_embedding.py`** (new): `DeepseekV3BidirectionalModel` subclasses `DeepseekV3ForCausalLM` to reuse all MoE/MLA weight loading, replacing the logits path with `Pooler(MEAN, normalize=True)`.
- **`configs/model_config.py`**: register the arch as **MLA** (so an MLA KV pool is allocated, not MHA) and as a non-generation embedding model.
- **`configs/embedding_model_spec.py`**: register as a bidirectional, mean-pooling embedding architecture (auto-enables embedding mode).
- **`server_args.py` / `arg_groups/overrides.py`**: for this architecture, force **`--attention-backend triton`**, `--disable-cuda-graph`, `--disable-radix-cache`, `--chunked-prefill-size -1`. Rationale (all verified below): only Triton honors `ENCODER_ONLY` on the MLA MHA prefill (flashinfer silently runs causal); CUDA-graph capture pins the absorbed causal-only MLA kernel; and prefix/split-prefill reuse is invalid under bidirectional attention. This mirrors the existing HRM-Text handling.

Serving is fully automatic:
```bash
python -m sglang.launch_server \
  --model-path ai-sage/Giga-Embeddings-instruct-10B-A1.8B-0826 \
  --is-embedding --trust-remote-code
```

## Accuracy Tests

Reference = HF `AutoModel` (`trust_remote_code`, `is_causal=False`), mean-pool over non-padding tokens + L2 normalize. (The remote checkpoint stores per-expert MoE weights; the reference loads them fused.) SGLang served with the out-of-the-box command above.

| Backend | min cosine vs HF (batched & single) | Result |
|---|---|---|
| triton (default / forced) | 0.996 | ✅ PASS |
| flashinfer (auto-overridden → triton) | 0.996 | ✅ PASS (after override) |

Retrieval sanity (query → documents): `Paris` 0.68 ≫ `mitochondria` 0.16 ≫ `photosynthesis` 0.05. Single-request and batched outputs agree.

**Regressions caught during testing (all fixed in this PR):**
- Without the MLA registration, startup crashed (`'MHATokenToKVPool' object has no attribute 'set_mla_kv_buffer'`) — an MHA KV pool was allocated for an MLA model.
- With the `flashinfer` backend, the MLA prefill ran **causal** and produced wrong embeddings (min cosine ~0.35). Forcing Triton restores parity; verified that launching with `--attention-backend flashinfer` logs the override to `triton` and yields min cosine 0.9964.

A unit test guards the capability adjustment (triton force + CUDA-graph/radix/chunked disable).

## Speed Tests and Profiling

No changes to existing DeepSeek code paths (the bidirectional branch is gated on `is_causal=False`, which no existing checkpoint sets). The new path is prefill-only embedding.

## Checklist

- [x] Format your code according to the Format code with pre-commit.
- [x] Add unit tests (`test/registered/unit/models/test_deepseek_v3_bidirectional_embedding_registration.py`; also updated `test_embedding_model_spec.py`).
- [x] Update documentation (`docs/docs/supported-models/embedding_models.mdx`).
- [x] Provide accuracy results (above).
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32260138562](https://github.com/sgl-project/sglang/actions/runs/32260138562)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32260137952](https://github.com/sgl-project/sglang/actions/runs/32260137952)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->