### PR TITLE
[diffusion] fix: stop reserving NCCL device buffers for single-rank groups

### DIFF
--- a/python/sglang/multimodal_gen/runtime/cache/cache_dit_integration.py
+++ b/python/sglang/multimodal_gen/runtime/cache/cache_dit_integration.py
@@ -77,7 +77,9 @@ def _patch_cache_dit_similarity():
         tp_sp_group = getattr(self, "_sglang_tp_sp_group", None)
         target_group = tp_sp_group or sp_group or tp_group
 
-        if target_group is None:
+        # Averaging over a one-rank group returns the input, so skip the
+        # collective rather than pay for a round trip that cannot change it.
+        if target_group is None or dist.get_world_size(target_group) == 1:
             return _original_similarity(
                 self,
                 t1,

--- a/python/sglang/multimodal_gen/runtime/distributed/group_coordinator.py
+++ b/python/sglang/multimodal_gen/runtime/distributed/group_coordinator.py
@@ -123,6 +123,18 @@ class GraphCaptureContext:
     stream: torch.cuda.Stream | None
 
 
+def new_device_group(ranks, backend=None):
+    """Create a process group for device collectives.
+
+    A single-rank group never runs one: every collective short-circuits on
+    world_size == 1. NCCL would still allocate its per-channel device buffers
+    for it, which costs ~390 MiB a group.
+    """
+    return torch.distributed.new_group(
+        ranks, backend="gloo" if len(ranks) == 1 else backend
+    )
+
+
 class GroupCoordinator:
     """
     PyTorch ProcessGroup wrapper for a group of processes.
@@ -169,9 +181,7 @@ class GroupCoordinator:
         self.cpu_group = None
 
         for ranks in group_ranks:
-            device_group = torch.distributed.new_group(
-                ranks, backend=torch_distributed_backend
-            )
+            device_group = new_device_group(ranks, torch_distributed_backend)
             # a group with `gloo` backend, to allow direct coordination between
             # processes through the CPU.
             with suppress_stdout():
@@ -863,9 +873,7 @@ class PipelineGroupCoordinator(GroupCoordinator):
         self.device_groups = []
         if len(group_ranks[0]) > 2 or len(group_ranks[0]) == 1:
             for ranks in group_ranks:
-                device_group = torch.distributed.new_group(
-                    ranks, backend=torch_distributed_backend
-                )
+                device_group = new_device_group(ranks, torch_distributed_backend)
                 # a group with `gloo` backend, to allow direct coordination between
                 # processes through the CPU.
                 with suppress_stdout():
@@ -927,9 +935,7 @@ class PipelineGroupCoordinator(GroupCoordinator):
         ] = None
         self.skip_device_group = None
         for ranks in group_ranks:
-            skip_device_group = torch.distributed.new_group(
-                ranks, backend=torch_distributed_backend
-            )
+            skip_device_group = new_device_group(ranks, torch_distributed_backend)
             if self.rank in ranks:
                 self.skip_device_group = skip_device_group
         assert self.skip_device_group is not None

--- a/python/sglang/multimodal_gen/runtime/distributed/parallel_groups.py
+++ b/python/sglang/multimodal_gen/runtime/distributed/parallel_groups.py
@@ -1,8 +1,6 @@
 # Reference: https://github.com/feifeibear/long-context-attention/blob/main/yunchang/globals.py
 
 
-import torch
-
 from .group_coordinator import new_device_group
 
 
@@ -58,7 +56,7 @@ def set_seq_parallel_pg_by_sp_groups(
     def _map_indices_to_ranks(ranks: list[int], indices: list[int]) -> list[int]:
         return [ranks[i] for i in indices]
 
-    # Important: call torch.distributed.new_group in the same order on all ranks.
+    # Important: create the groups in the same order on all ranks.
     for sp_ranks in sp_groups:
         if use_ulysses_low:
             for i in range(num_ulysses_pgs):

--- a/python/sglang/multimodal_gen/runtime/distributed/parallel_groups.py
+++ b/python/sglang/multimodal_gen/runtime/distributed/parallel_groups.py
@@ -3,6 +3,8 @@
 
 import torch
 
+from .group_coordinator import new_device_group
+
 
 class Singleton:
     _instance = None
@@ -62,28 +64,28 @@ def set_seq_parallel_pg_by_sp_groups(
             for i in range(num_ulysses_pgs):
                 idx = list(range(i * sp_ulysses_degree, (i + 1) * sp_ulysses_degree))
                 ulysses_ranks = _map_indices_to_ranks(sp_ranks, idx)
-                group = torch.distributed.new_group(ulysses_ranks)
+                group = new_device_group(ulysses_ranks)
                 if rank in ulysses_ranks:
                     ulyssess_pg = group
 
             for i in range(num_ring_pgs):
                 idx = list(range(i, sp_degree, num_ring_pgs))
                 ring_ranks = _map_indices_to_ranks(sp_ranks, idx)
-                group = torch.distributed.new_group(ring_ranks)
+                group = new_device_group(ring_ranks)
                 if rank in ring_ranks:
                     ring_pg = group
         else:
             for i in range(num_ring_pgs):
                 idx = list(range(i * sp_ring_degree, (i + 1) * sp_ring_degree))
                 ring_ranks = _map_indices_to_ranks(sp_ranks, idx)
-                group = torch.distributed.new_group(ring_ranks)
+                group = new_device_group(ring_ranks)
                 if rank in ring_ranks:
                     ring_pg = group
 
             for i in range(num_ulysses_pgs):
                 idx = list(range(i, sp_degree, num_ulysses_pgs))
                 ulysses_ranks = _map_indices_to_ranks(sp_ranks, idx)
-                group = torch.distributed.new_group(ulysses_ranks)
+                group = new_device_group(ulysses_ranks)
                 if rank in ulysses_ranks:
                     ulyssess_pg = group
 

--- a/python/sglang/multimodal_gen/runtime/distributed/parallel_state.py
+++ b/python/sglang/multimodal_gen/runtime/distributed/parallel_state.py
@@ -53,6 +53,7 @@ from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 from ..utils.distributed import RankGenerator
 from .group_coordinator import (
     GroupCoordinator,
+    new_device_group,
     PipelineGroupCoordinator,
     SequenceParallelGroupCoordinator,
     get_local_torch_device,
@@ -999,9 +1000,7 @@ def init_dit_group(
 ) -> None:
     global _DIT
     assert _DIT is None, "DIT group is already initialized"
-    _DIT = torch.distributed.new_group(
-        ranks=list(range(dit_parallel_size)), backend=backend
-    )
+    _DIT = new_device_group(list(range(dit_parallel_size)), backend)
 
 
 def get_dit_group() -> ProcessGroup:
@@ -1018,7 +1017,7 @@ def init_vae_group(
     global _VAE
     assert _VAE is None, "VAE parallel group is already initialized"
     vae_ranks = list(range(dit_parallel_size, dit_parallel_size + vae_parallel_size))
-    _VAE = torch.distributed.new_group(ranks=vae_ranks, backend=backend)
+    _VAE = new_device_group(vae_ranks, backend)
 
 
 def destroy_model_parallel() -> None:

--- a/python/sglang/multimodal_gen/runtime/distributed/parallel_state.py
+++ b/python/sglang/multimodal_gen/runtime/distributed/parallel_state.py
@@ -53,10 +53,10 @@ from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 from ..utils.distributed import RankGenerator
 from .group_coordinator import (
     GroupCoordinator,
-    new_device_group,
     PipelineGroupCoordinator,
     SequenceParallelGroupCoordinator,
     get_local_torch_device,
+    new_device_group,
 )
 
 logger = init_logger(__name__)

--- a/python/sglang/multimodal_gen/test/unit/test_single_rank_device_group.py
+++ b/python/sglang/multimodal_gen/test/unit/test_single_rank_device_group.py
@@ -1,0 +1,35 @@
+"""Single-rank groups get gloo, so NCCL does not reserve device buffers for them."""
+
+import unittest
+from unittest.mock import patch
+
+from sglang.multimodal_gen.runtime.distributed.group_coordinator import (
+    new_device_group,
+)
+
+NEW_GROUP_PATH = "torch.distributed.new_group"
+
+
+class TestSingleRankDeviceGroup(unittest.TestCase):
+    def test_single_rank_group_avoids_the_device_backend(self):
+        for ranks, requested in [([0], "nccl"), ([3], "hccl"), ([0], None)]:
+            with self.subTest(ranks=ranks, requested=requested):
+                with patch(NEW_GROUP_PATH) as new_group:
+                    new_device_group(ranks, requested)
+                new_group.assert_called_once_with(ranks, backend="gloo")
+
+    def test_multi_rank_group_keeps_the_requested_backend(self):
+        for ranks, requested in [([0, 1], "nccl"), ([0, 1, 2, 3], None)]:
+            with self.subTest(ranks=ranks, requested=requested):
+                with patch(NEW_GROUP_PATH) as new_group:
+                    new_device_group(ranks, requested)
+                new_group.assert_called_once_with(ranks, backend=requested)
+
+    def test_backend_defaults_to_none_for_multi_rank(self):
+        with patch(NEW_GROUP_PATH) as new_group:
+            new_device_group([0, 1])
+        new_group.assert_called_once_with([0, 1], backend=None)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

On a single GPU, ~5 GiB of VRAM is gone before a single weight is loaded. On a 12 GiB consumer card that is 44% of the device, and it makes VAE decode fail at any resolution.

The cause is that a single-GPU run still builds every parallel group — DP, CFG, TP, SP, PP, VAE_DECODE, DIT, VAE, ulysses, ring — each with one rank, and each got an NCCL-backed process group. NCCL sizes its per-channel device buffers when the communicator is created, so every one of those groups reserved ~390 MiB (the first, the world group, ~470 MiB).

None of that memory can ever be used. Every collective in `GroupCoordinator` returns early on `world_size == 1` ("Bypass the function if we are using only 1 GPU"), and the device communicator is only constructed when `world_size > 1`. `pynccl` already skips communicator creation for single-rank groups; the underlying `torch.distributed.new_group` did not.

Measured on an RTX 3060 12 GiB with a bare `torch.distributed` repro:

| | device memory |
|---|---|
| CUDA context only | 114 MiB |
| + world group | 584 MiB |
| each additional `new_group([0])` | **+388 MiB** |

`NCCL_MAX_NCHANNELS=1` drops the per-group cost to 10 MiB, which confirms these are
per-channel buffers for channels a one-rank communicator can never use.

## Modifications

Add `new_device_group()` in `group_coordinator.py`, which gives single-rank groups the gloo backend and leaves multi-rank groups on the requested backend. Route the nine device-group creation sites through it: `GroupCoordinator.__init__`, the`PipelineGroupCoordinator` single-rank branch and its `skip_device_group`, `_DIT` and `_VAE` in `parallel_state.py`, and the four ulysses/ring groups in `parallel_groups.py`.

The two-rank `device_group_0_1` / `device_group_1_0` pipeline pair is left alone; it is only reached when the group has exactly two ranks.

One consumer needed a matching guard. cache-dit averages its residual-difference statistics across the TP x SP slice using the DIT group, and that all-reduce had no world-size check, so on a single GPU it would now stage device tensors through the host on every cached block of every step. Averaging over one rank returns the input, so the patched `similarity` returns the local value instead of running the collective.

Every other consumer of these groups already short-circuits: collectives in `GroupCoordinator` return early on `world_size == 1`, the device communicator is built only above 1, the ulysses/ring groups are reached only under `sp_size > 1` in `attention/layer.py` and behind `world_size <= 1` early returns in `usp.py`, and the VAE group has no consumer outside its getter.

## Accuracy Tests

Bit-exact. RTX 3060 12 GiB, `Wan-AI/Wan2.1-T2V-1.3B-Diffusers`, layerwise offload of dit/text_encoder/vae, 320x576, 9 frames, 8 steps, seed 1234.

| | free VRAM after load | peak VRAM | VAE decode | output SHA-256 |
|---|---|---|---|---|
| before | 6.51 GiB | 11552 MiB | **OOM** | no output produced |
| `NCCL_MAX_NCHANNELS=1` control | 11.31 GiB | 6886 MiB | ok | `78a2a963…` |
| this PR | 11.06 GiB | 6830 MiB | ok | `78a2a963…` |

Two-GPU regression on the same box, `--num-gpus 2`: patched and unpatched produce the same output, SHA-256 `361bb915…`, so the multi-rank path is unaffected.

New unit test `test_single_rank_device_group.py` covers backend selection for single-rank and multi-rank groups (3 tests, 5 subtests). Existing `test_cache_dit_integration.py` passes with the guard (12 tests together).

CI note: `multimodal-gen-test-1-npu-a3` is red here, but every diffusion testcase on that runner is red on unrelated branches too (see #35511, where `ernie_image_t2i_1npu`, `flux_image_t2i_npu`, `flux_2_klein_4b_t2i_1npu`, `z_image_t2i_1npu` and `wan2_1_t2v_1.3b_1_npu` all fail and the job ends with `Executing the custom container implementation failed`). The NPU lane cannot vet this change right now.

## Speed Tests and Profiling

No change to per-step time — 1.10 s/step before, 1.06 s/step after, within the run-to-run noise band measured across this configuration. The groups involved never carried traffic.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32291208968](https://github.com/sgl-project/sglang/actions/runs/32291208968)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32291208893](https://github.com/sgl-project/sglang/actions/runs/32291208893)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->