### PR TITLE
[Qwen3.5][MTP] Preserve online NVFP4 draft quantization for mixed checkpoints

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -1516,14 +1516,14 @@ class ModelConfig:
                 "quant_method", "" if not self.quantization else self.quantization
             ).lower()
 
-            # ModelOpt FP4 checkpoints quantize only the target model; an
-            # embedded MTP draft may stay unquantized, so an explicit
+            # ModelOpt FP4 and mixed checkpoints can quantize only the target
+            # model; an embedded MTP draft may stay unquantized, so an explicit
             # nvfp4_online opt-in for the draft wins over checkpoint detection.
             # The online loader rejects already-packed weights at load time.
             preserve_online_draft_quantization = (
                 self.is_draft_model
                 and self.quantization == "nvfp4_online"
-                and quant_method == "modelopt_fp4"
+                and quant_method in ("modelopt_fp4", "modelopt_mixed")
             )
             # An explicit online-requantization request (e.g. quark_mxfp4 on top
             # of an NVFP4/mixed checkpoint) must not be overridden back to the


### PR DESCRIPTION
## Motivation

When a mixed ModelOpt checkpoint is used with an explicitly configured `nvfp4_online` speculative draft model, checkpoint detection currently overwrites the explicit draft quantization choice with `modelopt_mixed`. This prevents the MTP draft MoE from using the intended load-time NVFP4 conversion and FlashInfer CuTeDSL execution path.

## Modifications

- Preserve an explicitly selected `nvfp4_online` draft quantization mode for both `modelopt_fp4` and `modelopt_mixed` checkpoints.
- Keep the existing default behavior unchanged: when the user does not explicitly select draft quantization, the draft model still inherits the target model quantization.
- Do not change the speculative decoding algorithm or automatically enable online NVFP4 on unsupported configurations.

## Accuracy Tests

- The Blackwell production serving validation completed 112/112 identical requests with HTTP 200, fixed input length 88,786 tokens, exact output length 860 tokens, all four ranks at achieved batch 28, all CUDA graph captures enabled, zero queueing/retractions/errors, and natural mean acceptance length 4.79792.
- This path is explicitly opt-in and limited by the existing SM100+ and FlashInfer MoE backend checks.

## Speed Tests and Profiling

- Setup: Qwen3.5-397B-A17B-NVFP4 on one node with 4 GB300 GPUs in DP4, fixed ISL 88,786, exact OSL 860, 112 identical requests, MTP with 6 draft tokens, TRTLLM-MHA split 1, ReplaySSM circular history, and no request replenishment during the pure-generation measurement window.
- Patch-level result with the same candidate command: before this change, checkpoint detection overwrites the explicit `nvfp4_online` draft setting with `modelopt_mixed`, which creates an incompatible draft runner/dispatcher combination and fails before serving; after this change, the command completes 112/112 requests. Because the unpatched control does not reach the benchmark, there is no patch-only throughput ratio.
- The throughput numbers below compare two valid end-to-end draft backend configurations and are not an apple-to-apple attribution of the three-line compatibility fix.
- Valid legacy baseline command; orchestration-only and identical arguments are omitted:

```bash
python -m sglang.launch_server --model-path <Qwen3.5-397B-A17B-NVFP4> --dp-size 4 --ep-size 4 --attention-backend trtllm_mha --moe-runner-backend flashinfer_cutedsl --moe-a2a-backend flashinfer --speculative-algorithm NEXTN --speculative-num-steps 5 --speculative-eagle-topk 1 --speculative-num-draft-tokens 6 --speculative-moe-runner-backend deep_gemm --speculative-moe-a2a-backend deepep
```

- Candidate command enabled by this fix:

```bash
python -m sglang.launch_server --model-path <Qwen3.5-397B-A17B-NVFP4> --dp-size 4 --ep-size 4 --attention-backend trtllm_mha --moe-runner-backend flashinfer_cutedsl --moe-a2a-backend flashinfer --speculative-algorithm NEXTN --speculative-num-steps 5 --speculative-eagle-topk 1 --speculative-num-draft-tokens 6 --speculative-moe-runner-backend flashinfer_cutedsl --speculative-moe-a2a-backend flashinfer --speculative-draft-model-quantization nvfp4_online
```

- Full configuration change used by the throughput experiment:

```diff
--- baseline
+++ candidate
- --speculative-moe-runner-backend deep_gemm --speculative-moe-a2a-backend deepep
+ --speculative-moe-runner-backend flashinfer_cutedsl --speculative-moe-a2a-backend flashinfer --speculative-draft-model-quantization nvfp4_online
```

| Valid configuration | Natural mean acceptance length | Target-step time (ms) | Output tokens/s/GPU | Configuration-level change | SGL/TRT ratio |
| --- | ---: | ---: | ---: | ---: | ---: |
| DeepGEMM + DeepEP draft baseline | 4.80208 | 31.13983 | 4,317.890 | — | 90.1891% |
| FlashInfer CuTeDSL + FlashInfer A2A + online-NVFP4 draft | 4.79792 | 30.71904 | 4,373.238 | +1.282% | 91.3452% |
| TRT-LLM reference | 4.8 (forced) | 28.07256 | 4,787.594 | Reference | 100% |

- Relative to the legacy configuration, profiling of the complete candidate tuple removes approximately 1.3672 ms/target-step of draft DeepGEMM work and 0.4218 ms/target-step of draft DeepEP communication; overlap limits the end-to-end gain, so these times are not added arithmetically.
- The measured +1.282% belongs to the full runner, A2A backend, and draft-quantization tuple. This PR only preserves the explicit quantization request so that tuple can start; it does not establish an online-NVFP4-only or same-backend speedup.
- `Output tokens/s/GPU` is measured only from the all-rank fixed-B28 pure-generation interval after the final prefill and before the first request completion; it is not a service-level AIPerf total-throughput metric.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
