### PR TITLE
Cap anthropic dependency to <1

### DIFF
--- a/3rdparty/amd/wheel/sglang/pyproject.toml
+++ b/3rdparty/amd/wheel/sglang/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = ["aiohttp", "requests", "tqdm", "numpy", "IPython", "setproctitle
 runtime_common = [
   "IPython",
   "aiohttp",
-  "anthropic>=0.20.0",
+  "anthropic>=0.20.0,<1",
   "blobfile==3.0.0",
   "build",
   "compressed-tensors",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 # Please keep dependency lists in this file sorted alphabetically by package name.
 dependencies = [
   "aiohttp",
-  "anthropic>=0.20.0",
+  "anthropic>=0.20.0,<1",
   "apache-tvm-ffi==0.1.11",
   "av==16.1.0 ; sys_platform == 'linux' and (platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'armv7l')",
   "blobfile==3.0.0",


### PR DESCRIPTION
Hey! We're releasing v1 of the `anthropic` SDK shortly. Your `anthropic` dependency has no upper bound, so your users will start getting 1.0, which would break `sglang`.

This PR adds an `anthropic<1` constraint to prevent any potential breakage until you can fully migrate to v1.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32279159906](https://github.com/sgl-project/sglang/actions/runs/32279159906)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32279159578](https://github.com/sgl-project/sglang/actions/runs/32279159578)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->