### PR TITLE
[XPU CI] Guardian bot: auto-disable PR on 2-run XPU regression (draft)

### DIFF
--- a/.github/workflows/xpu-ci-guardian.yml
+++ b/.github/workflows/xpu-ci-guardian.yml
@@ -1,0 +1,246 @@
+name: XPU CI Guardian
+
+# Watches PR Test (XPU) on main. When two consecutive runs fail, opens an
+# auto-disable PR against main for the failing test files (via `disabled=` on
+# their `register_xpu_ci(...)` marker) and pings the owner. Never fixes code
+# on its own; the goal is a fast unblock while a human writes the real fix.
+#
+# Design notes:
+#   * Only touches CI-registration (`register_xpu_ci(..., disabled="...")`),
+#     never test bodies or kernel code.
+#   * Requires TWO consecutive failing XPU runs on main before acting — the
+#     `enable_retry` path in run_suite.py already covers single flakes.
+#   * At most one open guardian PR at a time (dedup via label).
+#   * Companion job (`sweep-when-green`) closes any open guardian PR once
+#     XPU CI on main is green again.
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Detect only; do not open a PR."
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+env:
+  UPSTREAM: sgl-project/sglang
+  FORK: arathi-hlab/sglang
+  WORKFLOW: "PR Test (XPU)"
+  PING_USER: arathi-hlab
+  GUARDIAN_LABEL: xpu-ci-guardian
+
+jobs:
+  # ------------------------------------------------------------------ #
+  # 1. Detect a real (non-flake) XPU CI regression on main             #
+  # ------------------------------------------------------------------ #
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      act: ${{ steps.classify.outputs.act }}
+      run_id: ${{ steps.classify.outputs.run_id }}
+      failing_files: ${{ steps.parse.outputs.failing_files }}
+    steps:
+      - name: Fetch last two runs on main
+        id: classify
+        env: { GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}" }
+        run: |
+          set -euo pipefail
+          gh run list --repo "$UPSTREAM" --workflow "$WORKFLOW" \
+            --branch main --limit 2 \
+            --json databaseId,conclusion,createdAt > runs.json
+          count=$(jq 'length' runs.json)
+          [ "$count" = "2" ] || { echo "act=false" >>"$GITHUB_OUTPUT"; exit 0; }
+          last=$(jq -r '.[0].conclusion' runs.json)
+          prev=$(jq -r '.[1].conclusion' runs.json)
+          echo "last=$last prev=$prev"
+          if [ "$last" = "failure" ] && [ "$prev" = "failure" ]; then
+            echo "act=true" >>"$GITHUB_OUTPUT"
+            echo "run_id=$(jq -r '.[0].databaseId' runs.json)" >>"$GITHUB_OUTPUT"
+          else
+            echo "act=false" >>"$GITHUB_OUTPUT"
+          fi
+
+      - name: Extract failing test file paths
+        id: parse
+        if: steps.classify.outputs.act == 'true'
+        env: { GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}" }
+        run: |
+          set -euo pipefail
+          gh run view "${{ steps.classify.outputs.run_id }}" --repo "$UPSTREAM" \
+            --log-failed > log.txt || true
+          # Match `test/registered/**/*.py` mentioned as a target of a Fail line
+          grep -oE 'test/registered/[A-Za-z0-9_./-]+\.py' log.txt \
+            | sort -u > failing.txt || true
+          # Filter to files whose failure looks correctness-shaped, not infra
+          if grep -qE 'UR_RESULT_ERROR_OUT_OF_RESOURCES|Server failed to start|XPU out of memory' log.txt; then
+            echo "infra-flake pattern in log; skipping"
+            : > failing.txt
+          fi
+          test -s failing.txt || { echo "no failing files to disable"; echo "failing_files=" >>"$GITHUB_OUTPUT"; exit 0; }
+          {
+            echo "failing_files<<EOF"
+            cat failing.txt
+            echo "EOF"
+          } >>"$GITHUB_OUTPUT"
+
+  # ------------------------------------------------------------------ #
+  # 2. Open (or skip) an auto-disable PR against upstream main         #
+  # ------------------------------------------------------------------ #
+  open-pr:
+    needs: detect
+    if: needs.detect.outputs.act == 'true' && needs.detect.outputs.failing_files != '' && inputs.dry_run != true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Skip if a guardian PR is already open
+        id: gate
+        env: { GH_TOKEN: "${{ secrets.BOT_PR_TOKEN }}" }
+        run: |
+          open=$(gh pr list --repo "$UPSTREAM" \
+            --label "$GUARDIAN_LABEL" --state open --json number --jq 'length')
+          echo "open_prs=$open"
+          if [ "$open" != "0" ]; then
+            echo "skip=true" >>"$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout upstream main into fork branch
+        if: steps.gate.outputs.skip != 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.UPSTREAM }}
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.BOT_PR_TOKEN }}
+
+      - name: Add fork remote
+        if: steps.gate.outputs.skip != 'true'
+        env: { BOT_PR_TOKEN: "${{ secrets.BOT_PR_TOKEN }}" }
+        run: |
+          git remote add fork "https://x-access-token:${BOT_PR_TOKEN}@github.com/${FORK}.git"
+
+      - name: Inject `disabled=` for each failing file
+        if: steps.gate.outputs.skip != 'true'
+        env:
+          RUN_ID: ${{ needs.detect.outputs.run_id }}
+          FAILING: ${{ needs.detect.outputs.failing_files }}
+        run: |
+          python3 - <<'PY'
+          import os, re, pathlib
+          run_id = os.environ["RUN_ID"]
+          reason = f"auto-disabled by xpu-ci-guardian: run {run_id}"
+          files = [f.strip() for f in os.environ["FAILING"].splitlines() if f.strip()]
+          touched = []
+          for f in files:
+              p = pathlib.Path(f)
+              if not p.exists():
+                  print(f"skip missing: {f}"); continue
+              src = p.read_text()
+              if not re.search(r"register_xpu_ci\(", src):
+                  print(f"skip no register_xpu_ci: {f}"); continue
+              if re.search(r"register_xpu_ci\([^)]*disabled\s*=", src):
+                  print(f"skip already disabled: {f}"); continue
+              src = re.sub(
+                  r"register_xpu_ci\(([^)]*)\)",
+                  lambda m: 'register_xpu_ci(' + m.group(1).rstrip().rstrip(",")
+                  + f',\n    disabled="{reason}",\n)',
+                  src, count=1,
+              )
+              p.write_text(src)
+              touched.append(f)
+          pathlib.Path("touched.txt").write_text("\n".join(touched) + "\n")
+          PY
+          test -s touched.txt || { echo "nothing to disable after filtering"; exit 78; }
+
+      - name: Compose commit and PR bodies
+        if: steps.gate.outputs.skip != 'true'
+        env:
+          RUN_ID: ${{ needs.detect.outputs.run_id }}
+        run: |
+          set -euo pipefail
+          FILES_LIST=$(sed 's|^|- |' touched.txt)
+          {
+            printf '[XPU CI] auto-disable regressing tests (run %s)\n\n' "$RUN_ID"
+            printf 'The last two `%s` runs on main failed on the tests below.\n' "$WORKFLOW"
+            printf 'Auto-disabling them via `register_xpu_ci(..., disabled=...)`\n'
+            printf 'as a temporary unblock; the underlying fix still needs to be\n'
+            printf 'raised manually.\n\n'
+            printf 'Failing run: https://github.com/%s/actions/runs/%s\n\n' "$UPSTREAM" "$RUN_ID"
+            printf 'Files touched:\n%s\n' "$FILES_LIST"
+          } > /tmp/commit_msg.txt
+
+          {
+            printf '@%s — `%s` on main failed twice in a row.\n' "$PING_USER" "$WORKFLOW"
+            printf 'I have auto-disabled the failing tests at `register_xpu_ci`\n'
+            printf 'as a temporary unblock. Please investigate the underlying\n'
+            printf 'cause and re-enable when fixed.\n\n'
+            printf 'Failing run:\nhttps://github.com/%s/actions/runs/%s\n\n' "$UPSTREAM" "$RUN_ID"
+            printf 'Files touched:\n%s\n\n' "$FILES_LIST"
+            printf 'Recent commits on these files (probable culprits):\n'
+            while read -r f; do
+              [ -z "$f" ] && continue
+              printf '\n### %s\n```\n' "$f"
+              git log --oneline -5 -- "$f" || true
+              printf '```\n'
+            done < touched.txt
+            printf '\nI am a draft PR — the guardian bot never merges itself.\n'
+            printf 'Convert to "Ready for review" only after a human confirms\n'
+            printf 'the disable is the right unblock.\n'
+          } > /tmp/pr_body.txt
+
+      - name: Commit, push, open draft PR
+        if: steps.gate.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.BOT_PR_TOKEN }}
+          RUN_ID: ${{ needs.detect.outputs.run_id }}
+        run: |
+          set -euo pipefail
+          BR="xpu-ci-guardian/$(date -u +%Y%m%d-%H%M)-run-${RUN_ID}"
+          git config user.name "xpu-ci-guardian[bot]"
+          git config user.email "xpu-ci-guardian@users.noreply.github.com"
+          git checkout -b "$BR"
+          git add -A
+          git commit -F /tmp/commit_msg.txt
+          git push fork "$BR"
+
+          gh pr create --repo "$UPSTREAM" \
+            --draft \
+            --title "[XPU CI] auto-disable regressing tests (run ${RUN_ID})" \
+            --head "${FORK%/*}:$BR" \
+            --base main \
+            --label "$GUARDIAN_LABEL,auto-generated" \
+            --reviewer "$PING_USER" \
+            --body-file /tmp/pr_body.txt
+
+  # ------------------------------------------------------------------ #
+  # 3. When main goes green, close any lingering guardian PR           #
+  # ------------------------------------------------------------------ #
+  sweep-when-green:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Check latest run
+        id: last
+        env: { GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}" }
+        run: |
+          conc=$(gh run list --repo "$UPSTREAM" --workflow "$WORKFLOW" \
+            --branch main --limit 1 --json conclusion --jq '.[0].conclusion')
+          echo "conclusion=$conc" >>"$GITHUB_OUTPUT"
+      - name: Close open guardian PRs
+        if: steps.last.outputs.conclusion == 'success'
+        env: { GH_TOKEN: "${{ secrets.BOT_PR_TOKEN }}" }
+        run: |
+          for n in $(gh pr list --repo "$UPSTREAM" --label "$GUARDIAN_LABEL" \
+                       --state open --json number --jq '.[].number'); do
+            gh pr comment "$n" --repo "$UPSTREAM" \
+              --body "XPU CI on main is green again — auto-closing this guardian PR."
+            gh pr close "$n" --repo "$UPSTREAM"
+          done


### PR DESCRIPTION
## Summary

Draft — putting this up so it can be reviewed / iterated on tomorrow.

Adds a GitHub Actions workflow (`.github/workflows/xpu-ci-guardian.yml`) that watches `PR Test (XPU)` on `main`. When the last two consecutive runs on `main` fail, it opens a **draft** PR that inserts `disabled="..."` on the `register_xpu_ci(...)` marker for each failing test file and pings the XPU CI owner. A separate job auto-closes any open guardian PR once `main` goes green again.

## Design

- **Watch** — schedule every 30 min + manual `workflow_dispatch` with a `dry_run` toggle.
- **Detect (2-run rule)** — only acts when the last two runs on `main` both failed, so single flakes handled by `enable_retry` in `run_suite.py` don't trigger it. Also filters known infra-flake log patterns (`UR_RESULT_ERROR_OUT_OF_RESOURCES`, `Server failed to start`, `XPU out of memory`).
- **Diagnose** — extracts `test/registered/**/*.py` paths from the failing job's `--log-failed`.
- **Unblock (scope-limited)** — inserts `disabled="auto-disabled by xpu-ci-guardian: run <id>"` into the file's `register_xpu_ci(...)`. Never touches kernel code, test bodies, `run_suite.py`, or per-method `@unittest.skipIf`. Skips files that are already disabled and files that don't call `register_xpu_ci`.
- **Dedup** — at most one open guardian PR at a time via the `xpu-ci-guardian` label.
- **PR body** — lists failing files with the last 5 commits on each, so the reviewer can jump straight to the probable culprit (as PR #33431 was in the current fire).
- **Sweep** — companion job closes any open guardian PR when the next main run is green.
- **Never auto-merges** — PR opens as a draft and only a human can promote / merge it.

## Required secrets on the fork's Actions

- `GITHUB_TOKEN` (default; read-only for detection).
- `BOT_PR_TOKEN` — fine-grained PAT with `contents:write` on `arathi-hlab/sglang` and `pull-requests:write` on `sgl-project/sglang`.

## Enablement checklist (before turning it on)

- [ ] Merge (or land into the fork only, if we decide it shouldn't live upstream).
- [ ] Add `BOT_PR_TOKEN` secret on the fork.
- [ ] Manually run once with `dry_run=true` and inspect the workflow's outputs.
- [ ] Manually run once with `dry_run=false` against a known-failing history to confirm the PR body/format looks right.
- [ ] Add the `xpu-ci-guardian` label to the label set on `sgl-project/sglang`.

## Explicitly out of scope for this bot

- Auto-generating actual code / kernel fixes (LLM-authored kernel patches are wrong often enough that reviewing them costs more than writing them from scratch).
- Deep classification (e.g. distinguishing correctness vs. accuracy assertions). The bot just disables; the human writes the fix.
- Alerting for non-XPU CI. This is scoped narrowly on purpose.

## Test plan

- [ ] Run the workflow manually with `dry_run=true` — the `detect` job should classify the current XPU state and set `act` correctly without opening any PR.
- [ ] Run with `dry_run=false` on a synthetic branch where I forcibly log two failing runs, and confirm the PR opens with the right title / labels / reviewer.
- [ ] Trigger `sweep-when-green` manually after a subsequent green run — it should close the previously-opened guardian PR.
- [ ] Confirm the guardian PR does NOT open a second time while another is open (dedup by `xpu-ci-guardian` label).

## Not included yet (defer to follow-up)

- Slack notification hook — trivial to add via `slackapi/slack-github-action` when a channel + token are chosen.
- Nightly weekly-summary email of caught regressions.

---

🤖 Draft raised now so it can be reviewed tomorrow morning; happy to iterate on scope / triggers / notification medium.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32281257858](https://github.com/sgl-project/sglang/actions/runs/32281257858)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32281257526](https://github.com/sgl-project/sglang/actions/runs/32281257526)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->