### PR TITLE
[GDN] Validate FlashInfer Cake CP prefill on Blackwell

### DIFF
--- a/python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py
@@ -351,6 +351,7 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
             state_checkpoints=state_checkpoints,
             checkpoint_cu_starts=state_checkpoint_cu_starts,
             checkpoint_every_n_tokens=state_checkpoint_every_n_tokens,
+            use_cp="auto",
         )
 
         # Write back state to pool

--- a/test/registered/attention/unittests/gdn/test_flashinfer.py
+++ b/test/registered/attention/unittests/gdn/test_flashinfer.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 
 import torch
 
@@ -8,6 +9,7 @@ from sglang.srt.utils import is_flashinfer_available
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.kits.attention_unittest.attention_methods.gdn_attention import (
     GDNAttentionCase,
+    _cache_indices,
     build_gdn_attention_fixture,
     make_gdn_cases,
     run_gdn_attention_case,
@@ -346,6 +348,100 @@ class TestFlashInferLinearGDNBackendCorrectness(CustomTestCase):
         prefix_lens=(0, 64, 128),
         extend_lens=(64, 65, 129),
     )
+    CAKE_CP_CASE = GDNAttentionCase(
+        name="flashinfer_cake_gdn_cp_prefill",
+        backend="triton",
+        linear_attn_prefill_backend="flashinfer",
+        forward_mode=ForwardMode.EXTEND,
+        num_k_heads=2,
+        num_v_heads=4,
+        page_size=16,
+        prefix_lens=(0,),
+        extend_lens=(65,),
+    )
+
+    def test_cake_cp_prefill_route_matches_non_cp(self):
+        if _sm_major != 10:
+            self.skipTest("FlashInfer Cake GDN CP prefill requires SM100/SM103")
+
+        import flashinfer.gdn_prefill as flashinfer_gdn_prefill
+
+        cake_prefill = getattr(
+            flashinfer_gdn_prefill, "_chunk_gated_delta_rule_cake_sm100", None
+        )
+        if cake_prefill is None:
+            self.skipTest("FlashInfer build does not contain PR #4539 Cake GDN CP")
+
+        fixture = build_gdn_attention_fixture(
+            self,
+            self.CAKE_CP_CASE,
+            head_k_dim=self.HEAD_DIM,
+            head_v_dim=self.HEAD_DIM,
+            max_context_len=128,
+        )
+        cache = fixture.runner.req_to_token_pool.mamba2_layer_cache(0)
+        initial_conv = cache.conv[0].clone()
+        initial_ssm = cache.temporal.clone()
+        mixed_qkv = fixture.mixed_qkv.clone()
+        a = fixture.a.clone()
+        b = fixture.b.clone()
+        cake_calls = 0
+
+        def observed_cake(*args, **kwargs):
+            nonlocal cake_calls
+            cake_calls += 1
+            return cake_prefill(*args, **kwargs)
+
+        def unexpected_non_cp(*_args, **_kwargs):
+            raise AssertionError("SGLang FlashInfer prefill left the Cake CP route")
+
+        with (
+            patch.object(
+                flashinfer_gdn_prefill,
+                "_chunk_gated_delta_rule_cake_sm100",
+                observed_cake,
+            ),
+            patch.object(
+                flashinfer_gdn_prefill,
+                "chunk_gated_delta_rule_sm100",
+                unexpected_non_cp,
+            ),
+        ):
+            cake_output = run_gdn_fixture_eager(fixture)
+        cake_state = cache.temporal.clone()
+
+        self.assertEqual(cake_calls, 1)
+        torch.testing.assert_close(fixture.mixed_qkv, mixed_qkv, atol=0, rtol=0)
+        torch.testing.assert_close(fixture.a, a, atol=0, rtol=0)
+        torch.testing.assert_close(fixture.b, b, atol=0, rtol=0)
+
+        cache.conv[0].copy_(initial_conv)
+        cache.temporal.copy_(initial_ssm)
+        flashinfer_kernel = (
+            fixture.backend.linear_attn_backend.kernel_dispatcher.extend_kernel
+        )
+        public_prefill = flashinfer_kernel._prefill_fn
+
+        def non_cp_prefill(*args, **kwargs):
+            kwargs["use_cp"] = False
+            return public_prefill(*args, **kwargs)
+
+        flashinfer_kernel._prefill_fn = non_cp_prefill
+        non_cp_output = run_gdn_fixture_eager(fixture)
+        non_cp_state = cache.temporal.clone()
+
+        torch.testing.assert_close(cake_output, non_cp_output, atol=1e-2, rtol=1e-2)
+        selected = _cache_indices(fixture).long()
+        torch.testing.assert_close(
+            cake_state[selected], non_cp_state[selected], atol=1e-2, rtol=1e-2
+        )
+        untouched = torch.ones(
+            initial_ssm.shape[0], dtype=torch.bool, device=initial_ssm.device
+        )
+        untouched[selected] = False
+        torch.testing.assert_close(
+            cake_state[untouched], initial_ssm[untouched], atol=0, rtol=0
+        )
 
     def test_prefill_tracked_state_checkpoints(self):
         fixture = build_gdn_attention_fixture(


### PR DESCRIPTION
## Motivation

FlashInfer [#4539](https://github.com/flashinfer-ai/flashinfer/pull/4539) adds a Blackwell context-parallel GDN prefill backend while preserving the public `chunk_gated_delta_rule` API and `use_cp="auto"` policy. SGLang already calls that API; this PR makes the policy explicit and adds SGLang-level route and contract coverage.

This PR depends on FlashInfer #4539 and a subsequent supported FlashInfer release. It intentionally does not pin SGLang production dependencies to an unreleased commit.

## Intended changes

- Pass `use_cp="auto"` explicitly from `FlashInferGDNKernel.extend`.
- Add an SM100/SM103 BF16 GQA generic-tail test through the real SGLang fixture and adapter.
- Require the targeted test to enter the intended CP route and reject an unexpected fallback.
- Compare output and selected final-state rows at `atol=rtol=1e-2`.
- Verify inputs, metadata, and unselected state rows remain unchanged.

## Validation status

The branch and evidence are being refreshed for the exact FlashInfer #4539 head. Before this draft is ready, the body will be replaced with sealed results for:

- Targeted adapter correctness and a direct long-context invocation.
- A frozen 200-example, five-shot GSM8K comparison.
- Native and exported-backend CUPTI measurements.
- Exact route attribution and zero unexpected fallback.

Historical measurements and infrastructure identifiers were removed because they do not prove the current exact-final integration.

## Review and merge process

This remains a draft until FlashInfer #4539 is merged and available in an SGLang-supported release.

