### PR TITLE
[sglang-miles] have RayDataParallelController take is_custom_pg explicitly

### DIFF
--- a/python/sglang/srt/ray/data_parallel_controller.py
+++ b/python/sglang/srt/ray/data_parallel_controller.py
@@ -51,11 +51,13 @@ class RayDataParallelController(DataParallelController):
         placement_group,
         bundle_for_node: Optional[List[int]],
         rank0_node_ip: str,
+        is_custom_pg: bool = False,
     ):
         # Set Ray-specific attributes BEFORE super().__init__() because the
         # parent constructor calls launch_dp_schedulers / launch_dp_attention_schedulers
         # which we override, and those methods need these attributes.
         self.pg = placement_group
+        self.is_custom_pg = is_custom_pg
         self.bundle_for_node = bundle_for_node
         self.rank0_node_ip = rank0_node_ip
         self.scheduler_actors: List = []
@@ -135,7 +137,7 @@ class RayDataParallelController(DataParallelController):
         nnodes = server_args.nnodes
         batch_start_idx = len(self.scheduler_actors)
 
-        if self.server_args.placement_group is None:
+        if not self.is_custom_pg:
             for node_idx in range(nnodes):
                 bundle_idx = self.bundle_for_node[node_idx]
                 pp_range, tp_range, pp_per_node, tp_per_node = _calculate_rank_ranges(


### PR DESCRIPTION
## Motivation

`RayDataParallelController` decides whether to compute per-node rank ranges by reading `server_args.placement_group` — a dynamic attribute that `dataclasses.replace` silently drops, so it has to be manually re-attached after every rebuild of `ServerArgs`.

## Modifications

Take an explicit `is_custom_pg` constructor argument (default `False`) and branch on that instead of the dynamic attribute.

Split out of #27723, whose `RayEngine._launch_dp_schedulers` passes this flag; the two should land together (this one first or same time).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32287030916](https://github.com/sgl-project/sglang/actions/runs/32287030916)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32287030722](https://github.com/sgl-project/sglang/actions/runs/32287030722)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->