### PR TITLE
[Kimi K3] Select FlashInfer MXFP4 for SM107 auto MoE

### DIFF
--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -574,17 +574,17 @@ def _is_mxfp4_pack_quantized(hf_config: Any) -> bool:
 def _kimi_k3_moe_runner_overrides(server_args: Any, hf_config: Any) -> dict:
     # MoE runner default, independent of the attention-backend gate above.
     # trtllm-gen fused MoE (flashinfer_mxfp4) beats marlin on both the decode
-    # (M=bs) and the target-verify (M=bs*(gamma+1)) regimes on SM100/SM103;
-    # FlashInfer 0.6.17+ ships the required SiTU kernels and is a pinned
-    # project dependency.
+    # (M=bs) and the target-verify (M=bs*(gamma+1)) regimes on SM100/SM103.
+    # SM107 uses the same packed-MXFP4 runner; leaving auto unresolved falls
+    # back to BF16 weight materialization during model loading.
     if server_args.moe_runner_backend != "auto":
         return {}
-    if not (is_sm100_supported() and get_device_sm() in (100, 103)):
+    if not (is_sm100_supported() and get_device_sm() in (100, 103, 107)):
         return {}
     if not _is_mxfp4_pack_quantized(hf_config):
         return {}
     logger.info(
-        "Kimi-K3 on SM100/SM103: moe_runner_backend=flashinfer_mxfp4 "
+        "Kimi-K3 on SM100/SM103/SM107: moe_runner_backend=flashinfer_mxfp4 "
         "(FlashInfer SiTU kernels)."
     )
     return {"moe_runner_backend": "flashinfer_mxfp4"}

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -394,67 +394,6 @@ class TestGoldenModelOverrides(_IsolatedPublish):
         self._publish(nvfp4)
         self.assertEqual(get_exec().moe.moe_runner_backend, "flashinfer_trtllm_routed")
 
-    def test_kimi_k3_sm107_mxfp4_auto_selects_flashinfer(self):
-        from sglang.srt.arg_groups.overrides import _kimi_k3_moe_runner_overrides
-
-        packed_mxfp4 = SimpleNamespace(
-            text_config=SimpleNamespace(
-                quantization_config={
-                    "config_groups": {"group_0": {"format": "mxfp4-pack-quantized"}}
-                }
-            )
-        )
-        non_mxfp4 = SimpleNamespace(
-            text_config=SimpleNamespace(
-                quantization_config={"config_groups": {"group_0": {"format": "fp8"}}}
-            )
-        )
-
-        def _args(moe_runner_backend):
-            return SimpleNamespace(moe_runner_backend=moe_runner_backend)
-
-        with (
-            patch.object(overrides_module, "is_sm100_supported", return_value=True),
-            patch.object(overrides_module, "get_device_sm", return_value=107),
-        ):
-            self.assertEqual(
-                _kimi_k3_moe_runner_overrides(_args("auto"), packed_mxfp4),
-                {"moe_runner_backend": "flashinfer_mxfp4"},
-            )
-            self.assertIn(
-                (
-                    _kimi_k3_moe_runner_overrides.__qualname__,
-                    {"moe_runner_backend": "flashinfer_mxfp4"},
-                ),
-                collect_model_override_declarations(
-                    "KimiK3ForConditionalGeneration", _args("auto"), packed_mxfp4
-                ),
-            )
-            self.assertEqual(
-                _kimi_k3_moe_runner_overrides(_args("auto"), non_mxfp4), {}
-            )
-
-            explicit_flashinfer = _args("flashinfer_mxfp4")
-            self.assertEqual(
-                _kimi_k3_moe_runner_overrides(explicit_flashinfer, packed_mxfp4),
-                {},
-            )
-            self.assertEqual(explicit_flashinfer.moe_runner_backend, "flashinfer_mxfp4")
-
-            explicit_alternative = _args("marlin")
-            self.assertEqual(
-                _kimi_k3_moe_runner_overrides(explicit_alternative, packed_mxfp4), {}
-            )
-            self.assertEqual(explicit_alternative.moe_runner_backend, "marlin")
-
-        with (
-            patch.object(overrides_module, "is_sm100_supported", return_value=True),
-            patch.object(overrides_module, "get_device_sm", return_value=110),
-        ):
-            self.assertEqual(
-                _kimi_k3_moe_runner_overrides(_args("auto"), packed_mxfp4), {}
-            )
-
     def test_mimo_v2_declarations(self):
         # Callable-level golden: MiMoV2 archs are hybrid (config-shape heavy),
         # so the declaration is pinned directly for both provider inputs.

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -394,6 +394,67 @@ class TestGoldenModelOverrides(_IsolatedPublish):
         self._publish(nvfp4)
         self.assertEqual(get_exec().moe.moe_runner_backend, "flashinfer_trtllm_routed")
 
+    def test_kimi_k3_sm107_mxfp4_auto_selects_flashinfer(self):
+        from sglang.srt.arg_groups.overrides import _kimi_k3_moe_runner_overrides
+
+        packed_mxfp4 = SimpleNamespace(
+            text_config=SimpleNamespace(
+                quantization_config={
+                    "config_groups": {"group_0": {"format": "mxfp4-pack-quantized"}}
+                }
+            )
+        )
+        non_mxfp4 = SimpleNamespace(
+            text_config=SimpleNamespace(
+                quantization_config={"config_groups": {"group_0": {"format": "fp8"}}}
+            )
+        )
+
+        def _args(moe_runner_backend):
+            return SimpleNamespace(moe_runner_backend=moe_runner_backend)
+
+        with (
+            patch.object(overrides_module, "is_sm100_supported", return_value=True),
+            patch.object(overrides_module, "get_device_sm", return_value=107),
+        ):
+            self.assertEqual(
+                _kimi_k3_moe_runner_overrides(_args("auto"), packed_mxfp4),
+                {"moe_runner_backend": "flashinfer_mxfp4"},
+            )
+            self.assertIn(
+                (
+                    _kimi_k3_moe_runner_overrides.__qualname__,
+                    {"moe_runner_backend": "flashinfer_mxfp4"},
+                ),
+                collect_model_override_declarations(
+                    "KimiK3ForConditionalGeneration", _args("auto"), packed_mxfp4
+                ),
+            )
+            self.assertEqual(
+                _kimi_k3_moe_runner_overrides(_args("auto"), non_mxfp4), {}
+            )
+
+            explicit_flashinfer = _args("flashinfer_mxfp4")
+            self.assertEqual(
+                _kimi_k3_moe_runner_overrides(explicit_flashinfer, packed_mxfp4),
+                {},
+            )
+            self.assertEqual(explicit_flashinfer.moe_runner_backend, "flashinfer_mxfp4")
+
+            explicit_alternative = _args("marlin")
+            self.assertEqual(
+                _kimi_k3_moe_runner_overrides(explicit_alternative, packed_mxfp4), {}
+            )
+            self.assertEqual(explicit_alternative.moe_runner_backend, "marlin")
+
+        with (
+            patch.object(overrides_module, "is_sm100_supported", return_value=True),
+            patch.object(overrides_module, "get_device_sm", return_value=110),
+        ):
+            self.assertEqual(
+                _kimi_k3_moe_runner_overrides(_args("auto"), packed_mxfp4), {}
+            )
+
     def test_mimo_v2_declarations(self):
         # Callable-level golden: MiMoV2 archs are hybrid (config-shape heavy),
         # so the declaration is pinned directly for both provider inputs.


### PR DESCRIPTION
## Motivation

Kimi-K3 packed-MXFP4 models automatically select the FlashInfer MXFP4 MoE runner on SM100 and SM103, but the current exact-architecture gate excludes SM107. Consequently, `--moe-runner-backend auto` can fall through to BF16 weight materialization during model loading and exhaust device memory.

This is a policy follow-up to #33997. It remains a draft until SGLang's stock FlashInfer artifacts are qualified for the SM107 SiTU MXFP4 path.

## Modifications

- Extend Kimi-K3 packed-MXFP4 auto MoE selection from SM100/SM103 to exact SM107.
- Preserve every explicit `--moe-runner-backend` choice.
- Add unit coverage for the SM107 positive case, a neighboring-architecture negative case, non-MXFP4 input, registry wiring, and explicit backend choices.

## Accuracy Tests

SM107 stock-artifact launch, numerics, and memory qualification is pending. This PR must remain in draft and must not merge until that qualification passes, with the pinned FlashInfer artifact/version updated if required.

## Speed Tests and Profiling

Pending the same SM107 stock-artifact qualification. The intended comparison is `auto` against explicit `flashinfer_mxfp4`; this change should make those routes identical.

## Checklist

- [x] Format the changed files with the repository pre-commit hooks.
- [x] Add focused CPU unit coverage.
- [x] No user-facing documentation change is required for this model-specific auto-selection extension.
- [ ] Provide SM107 stock-artifact accuracy, memory, and performance results before marking ready.
- [x] Follow the SGLang code-style guidance.

## Dependency / merge gate

Do not merge until the stock FlashInfer artifacts used by SGLang are qualified for SM107 SiTU MXFP4, updating the pinned artifact/version if required.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32379276724](https://github.com/sgl-project/sglang/actions/runs/32379276724)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32379276396](https://github.com/sgl-project/sglang/actions/runs/32379276396)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32379276739](https://github.com/sgl-project/sglang/actions/runs/32379276739)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->