### PR TITLE
[Test] Add unit tests for jinja_template_utils

### DIFF
--- a/test/registered/unit/parser/test_jinja_template_utils.py
+++ b/test/registered/unit/parser/test_jinja_template_utils.py
@@ -432,6 +432,39 @@ class TestTemplateContentFormatDetection(CustomTestCase):
         self.assertEqual(len(modalities), 1)
         self.assertEqual(modalities[0], ["video"])
 
+    def test_process_content_preserves_tool_reference(self):
+        """Test that tool_reference is preserved in processed content."""
+        msg_dict = {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Use this tool:"},
+                {
+                    "type": "tool_reference",
+                    "name": "get_weather",
+                },
+            ],
+        }
+
+        image_data = []
+        video_data = []
+        audio_data = []
+        modalities = []
+
+        result = process_content_for_template_format(
+            msg_dict, "openai", image_data, video_data, audio_data, modalities
+        )
+
+        self.assertEqual(
+            result["content"],
+            [
+                {"type": "text", "text": "Use this tool:"},
+                {
+                    "type": "tool_reference",
+                    "name": "get_weather",
+                },
+            ],
+        )
+
     def test_detect_template_with_filter(self):
         """Test that content access through a Jinja filter is detected as openai."""
         # Template with | trim filter on content iteration


### PR DESCRIPTION
## Motivation

Add regression coverage for the GLM-specific `tool_reference` content path in `jinja_template_utils.py`.

Related to #20865.

## Modifications

- Add a unit test verifying that `tool_reference` content is preserved when processing OpenAI-format messages.
- Coverage for `jinja_template_utils.py` increases from 93% to 95%.

## Accuracy Tests

```bash
pytest test/registered/unit/parser/test_jinja_template_utils.py -v

24 passed, 18 warnings in 12.49s

python/sglang/srt/parser/jinja_template_utils.py   98   5   95%
Missing: 32, 61, 118-120

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32298819359](https://github.com/sgl-project/sglang/actions/runs/32298819359)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32298818934](https://github.com/sgl-project/sglang/actions/runs/32298818934)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->