### PR TITLE
[CI] Fix the invalid suite on the routed-experts readback test

### DIFF
--- a/test/registered/ep/test_routed_experts_dp_readback.py
+++ b/test/registered/ep/test_routed_experts_dp_readback.py
@@ -95,6 +95,10 @@ class _ReadbackMixin:
             "--disable-radix-cache",
             "--mem-fraction-static",
             "0.5",
+            # dp2 halves this to a per-rank 256 to match the dispatch-token
+            # caps below; DeepEP v2 rejects a larger per-rank prefill budget.
+            "--chunked-prefill-size",
+            "512",
             *cls.backend_args,
         ]
         cls.process = popen_launch_server(

--- a/test/registered/ep/test_routed_experts_dp_readback.py
+++ b/test/registered/ep/test_routed_experts_dp_readback.py
@@ -39,7 +39,7 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
-register_cuda_ci(est_time=900, stage="base-c", runner_config="deepep-8-gpu-h200")
+register_cuda_ci(est_time=900, stage="base-c", runner_config="8-gpu-h200")
 
 _MODEL = os.environ.get("SGLANG_ROUTED_EXPERTS_TEST_MODEL", "deepseek-ai/DeepSeek-V3")
 _NUM_EXPERTS = 24


### PR DESCRIPTION
`runner_config="deepep-8-gpu-h200"` resolves to a suite that is in neither `run_suite.py`'s tables nor any workflow job, so `validate_all_suites` raises at load time and every suite fails, not just that one. Point it at `8-gpu-h200`, which already runs DeepEP tests (`test/registered/ep/test_deepep_large.py`). Introduced in #29525.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #32302350211](https://github.com/sgl-project/sglang/actions/runs/32302350211)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32302349896](https://github.com/sgl-project/sglang/actions/runs/32302349896)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->