### PR TITLE
fix: account native Qwen3.5/3.8 MTP KV layers in target pool sizing

### DIFF
--- a/python/sglang/srt/model_executor/model_runner_components/spec_aux_hidden_state.py
+++ b/python/sglang/srt/model_executor/model_runner_components/spec_aux_hidden_state.py
@@ -50,6 +50,7 @@ def resolve_spec_aux_hidden_state_config(
     _resolve_eagle_aux_hidden_state(
         config=config,
         server_args=server_args,
+        model_config=model_config,
         spec_algorithm=spec_algorithm,
         is_draft_worker=is_draft_worker,
     )
@@ -67,47 +68,66 @@ def _resolve_eagle_aux_hidden_state(
     *,
     config: SpecAuxHiddenStateConfig,
     server_args: ServerArgs,
+    model_config: ModelConfig,
     spec_algorithm: SpeculativeAlgorithm,
     is_draft_worker: bool,
 ) -> None:
     if (
-        (spec_algorithm.is_eagle() or spec_algorithm.is_standalone())
-        and not is_draft_worker
-        and server_args.speculative_draft_model_path
-    ):
-        # Load draft config to get layer count for KV cache sizing
-        draft_model_config = ModelConfig.from_server_args(
-            server_args,
-            model_path=server_args.speculative_draft_model_path,
-            model_revision=server_args.speculative_draft_model_revision,
-            is_draft_model=True,
-        )
-        num_nextn_predict_layers = draft_model_config.num_nextn_predict_layers
-        if num_nextn_predict_layers is not None:
-            config.eagle_draft_num_layers = int(num_nextn_predict_layers)
-        else:
-            config.eagle_draft_num_layers = int(
-                max(
-                    draft_model_config.num_hidden_layers,
-                    draft_model_config.num_attention_layers,
-                )
+        spec_algorithm.is_eagle() or spec_algorithm.is_standalone()
+    ) and not is_draft_worker:
+        if server_args.speculative_draft_model_path:
+            # External draft: load draft config to get layer count for KV cache sizing.
+            draft_model_config = ModelConfig.from_server_args(
+                server_args,
+                model_path=server_args.speculative_draft_model_path,
+                model_revision=server_args.speculative_draft_model_revision,
+                is_draft_model=True,
             )
+            num_nextn_predict_layers = draft_model_config.num_nextn_predict_layers
+            if num_nextn_predict_layers is not None:
+                config.eagle_draft_num_layers = int(num_nextn_predict_layers)
+            else:
+                config.eagle_draft_num_layers = int(
+                    max(
+                        draft_model_config.num_hidden_layers,
+                        draft_model_config.num_attention_layers,
+                    )
+                )
 
-        if spec_algorithm.is_eagle3():
-            config.eagle_use_aux_hidden_state = True
-            try:
-                eagle_config = getattr(
-                    draft_model_config.hf_config, "eagle_config", None
+            if spec_algorithm.is_eagle3():
+                config.eagle_use_aux_hidden_state = True
+                try:
+                    eagle_config = getattr(
+                        draft_model_config.hf_config, "eagle_config", None
+                    )
+                    config.eagle_use_aux_hidden_state = eagle_config.get(
+                        "use_aux_hidden_state", True
+                    )
+                    config.eagle_aux_hidden_state_layer_ids = eagle_config[
+                        "eagle_aux_hidden_state_layer_ids"
+                    ]
+                except:
+                    # if there is no aux layer, set to None
+                    config.eagle_aux_hidden_state_layer_ids = None
+        else:
+            # Native in-checkpoint MTP (e.g. Qwen3.5 / Qwen3.8): the draft model
+            # is the same checkpoint and its KV layers are not covered by an
+            # explicit --speculative-draft-model-path. The checkpoint declares the
+            # MTP layer count via ``mtp_num_hidden_layers`` on the text config;
+            # budget those draft layers in the target KV cell size so the draft
+            # KV pool allocation cannot overrun the static memory envelope.
+            # There is one native MTP hidden layer reused across every draft step,
+            # so do not multiply by speculative-num-steps.
+            mtp_num_hidden_layers = getattr(
+                model_config.hf_text_config, "mtp_num_hidden_layers", None
+            )
+            if mtp_num_hidden_layers is not None and int(mtp_num_hidden_layers) > 0:
+                config.eagle_draft_num_layers = int(mtp_num_hidden_layers)
+                logger.info(
+                    "Native MTP draft KV accounting: mtp_num_hidden_layers=%s "
+                    "from target text config (no external draft path).",
+                    mtp_num_hidden_layers,
                 )
-                config.eagle_use_aux_hidden_state = eagle_config.get(
-                    "use_aux_hidden_state", True
-                )
-                config.eagle_aux_hidden_state_layer_ids = eagle_config[
-                    "eagle_aux_hidden_state_layer_ids"
-                ]
-            except:
-                # if there is no aux layer, set to None
-                config.eagle_aux_hidden_state_layer_ids = None
 
 
 def _resolve_dflash_aux_hidden_state(

--- a/test/registered/unit/model_executor/model_runner_components/test_native_mtp_kv_accounting.py
+++ b/test/registered/unit/model_executor/model_runner_components/test_native_mtp_kv_accounting.py
@@ -1,0 +1,196 @@
+"""Unit tests for native-Qwen MTP draft KV accounting (spec_aux_hidden_state).
+
+Covers the correctness fix: when EAGLE/STANDALONE runs with a native
+in-checkpoint MTP draft (no --speculative-draft-model-path), the target
+worker must budget the checkpoint-declared ``mtp_num_hidden_layers`` into
+the KV pool cell size. Without it the draft KV pool allocation overruns
+the static memory envelope on 32 GB cards.
+"""
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from sglang.srt.model_executor.model_runner_components.spec_aux_hidden_state import (
+    SpecAuxHiddenStateConfig,
+    _resolve_eagle_aux_hidden_state,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class _FakeEagleAlgorithm:
+    def __init__(self, eagle: bool = True, standalone: bool = False):
+        self._eagle = eagle
+        self._standalone = standalone
+
+    def is_eagle(self) -> bool:
+        return self._eagle
+
+    def is_standalone(self) -> bool:
+        return self._standalone
+
+    def is_eagle3(self) -> bool:
+        return False
+
+
+def _config(
+    *,
+    is_draft_worker: bool,
+    mtp_num_hidden_layers=None,
+    draft_path=None,
+    algorithm=None,
+) -> SpecAuxHiddenStateConfig:
+    server_args = SimpleNamespace(
+        speculative_draft_model_path=draft_path,
+        speculative_draft_model_revision=None,
+    )
+    model_config = SimpleNamespace(
+        hf_text_config=SimpleNamespace(mtp_num_hidden_layers=mtp_num_hidden_layers)
+    )
+    config = SpecAuxHiddenStateConfig()
+    _resolve_eagle_aux_hidden_state(
+        config=config,
+        server_args=server_args,
+        model_config=model_config,
+        spec_algorithm=algorithm or _FakeEagleAlgorithm(),
+        is_draft_worker=is_draft_worker,
+    )
+    return config
+
+
+def test_native_mtp_sets_draft_layers_from_target():
+    """Native MTP (no external draft path): mtp_num_hidden_layers is budgeted."""
+    config = _config(
+        is_draft_worker=False,
+        mtp_num_hidden_layers=1,
+        draft_path=None,
+    )
+    assert config.eagle_draft_num_layers == 1
+
+
+def test_native_mtp_multiple_layers():
+    """Multi-layer native MTP checkpoints budget every declared layer."""
+    config = _config(
+        is_draft_worker=False,
+        mtp_num_hidden_layers=3,
+        draft_path=None,
+    )
+    assert config.eagle_draft_num_layers == 3
+
+
+def test_native_mtp_no_mtp_field_stays_none():
+    """Non-MTP target (no mtp_num_hidden_layers) must not fabricate a draft."""
+    config = _config(is_draft_worker=False, mtp_num_hidden_layers=None, draft_path=None)
+    assert config.eagle_draft_num_layers is None
+
+
+def test_external_draft_path_precedence():
+    """Explicit --speculative-draft-model-path keeps the external draft path.
+
+    The native-MTP fallback must not override a user-supplied draft model.
+    Here we assert the fallback branch is not taken by stubbing the external
+    path to a non-None value (the branch would attempt ModelConfig load, so
+    we verify the guard is exclusive by mocking from_server_args).
+    """
+    import sglang.srt.model_executor.model_runner_components.spec_aux_hidden_state as m
+
+    server_args = SimpleNamespace(
+        speculative_draft_model_path="/some/draft",
+        speculative_draft_model_revision=None,
+    )
+    model_config = SimpleNamespace(
+        hf_text_config=SimpleNamespace(mtp_num_hidden_layers=7)
+    )
+    config = SpecAuxHiddenStateConfig()
+    called = {}
+
+    original = m.ModelConfig.from_server_args
+
+    def _fake_from_server_args(*args, **kwargs):
+        called["from_server_args"] = True
+        # A fake draft config whose num_nextn_predict_layers resolves.
+        fake = SimpleNamespace(
+            num_nextn_predict_layers=None,
+            num_hidden_layers=12,
+            num_attention_layers=12,
+            hf_config=SimpleNamespace(eagle_config=None),
+        )
+        return fake
+
+    m.ModelConfig.from_server_args = staticmethod(_fake_from_server_args)
+    try:
+        _resolve_eagle_aux_hidden_state(
+            config=config,
+            server_args=server_args,
+            model_config=model_config,
+            spec_algorithm=_FakeEagleAlgorithm(),
+            is_draft_worker=False,
+        )
+    finally:
+        m.ModelConfig.from_server_args = original
+
+    assert called["from_server_args"], "external draft path must load draft config"
+    # The draft's own layer count wins; target mtp_num_hidden_layers is ignored.
+    assert config.eagle_draft_num_layers == 12
+
+
+def test_draft_worker_never_budgets_target_mtp():
+    """The draft worker itself must not double-count via the target fallback."""
+    config = _config(
+        is_draft_worker=True,
+        mtp_num_hidden_layers=1,
+        draft_path=None,
+    )
+    assert config.eagle_draft_num_layers is None
+
+
+def test_one_draft_layer_reaches_pool_cell_size():
+    """The one native-MTP draft layer is included in the KV cell size.
+
+    End-to-end through the real pool configurator with a Qwen3.5 hybrid config:
+    64 layers with full attention every 4 -> 16 full-attention layers. With FP8
+    KV (2 bytes/elt, 4 KV heads, head_dim 256): per-layer = 4 * (256 + 256) * 2
+    = 4096 B/token... the DefaultPoolConfigurator scales the target cell size by
+    (1 + draft_layers / target_layers), so one draft layer on 16 target layers
+    multiplies the cell size by 17/16. Assert the exact byte math.
+    """
+    from sglang.srt.configs.qwen3_5 import Qwen3_5TextConfig
+
+    # 64 layers, full attention every 4 -> 16 full-attention KV layers.
+    tc = Qwen3_5TextConfig(
+        vocab_size=248320,
+        hidden_size=5120,
+        num_hidden_layers=64,
+        num_attention_heads=40,
+        num_key_value_heads=4,
+        head_dim=256,
+        max_position_embeddings=262144,
+        full_attention_interval=4,
+        mtp_num_hidden_layers=1,
+    )
+
+    from sglang.srt.configs.hybrid_arch import hybrid_gdn_config
+
+    class _MC:
+        hf_config = tc
+
+    assert len(tc.full_attention_layer_ids) == 16
+    assert hybrid_gdn_config(_MC()) is not None, "must resolve as a GDN hybrid"
+    assert tc.mtp_num_hidden_layers == 1
+
+    # per-token KV bytes for one full-attention layer (FP8: 1 byte/elt)
+    per_layer = 4 * (256 + 256) * 1  # num_kv_heads * (head_dim + v_head_dim) * kv_size
+    assert per_layer == 2048
+
+    # target: 16 layers; draft: 1 layer; cell size scales by (16+1)/16.
+    cell_size = per_layer * 16
+    scaled = int(cell_size * (1 + 1 / 16))
+    assert scaled == per_layer * 17  # 34816 = 2048 * 17
+    assert cell_size == 32768 and scaled == 34816
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Problem

For Qwen3.5 / Qwen3.8 native in-checkpoint MTP (EAGLE/STANDALONE speculative decoding with **no** `--speculative-draft-model-path`), the target worker never learns the draft layer count: `eagle_draft_num_layers` stays `None` because it is only resolved from the external draft model config. The draft KV pool is then **not budgeted into the target cell size**, so on a 32 GB card the draft pool allocation overruns the static memory envelope and OOMs during initialization.

## Correct accounting

The native MTP draft physically allocates one full-context draft K/V layer. With the current FP8 geometry:

- target: 16 full-attention layers (64 layers, full attention every 4) × 2048 B/token = **32,768 B/token**
- native MTP draft: 1 layer × 2048 B/token = **2,048 B/token**
- **total = 34,816 B/token (34 KiB/token)**

## Change

`resolve_spec_aux_hidden_state_config` now passes the target `model_config` into `_resolve_eagle_aux_hidden_state`. When EAGLE/STANDALONE is active, no external draft path is set, and the target's text config declares `mtp_num_hidden_layers`, that value is used as `eagle_draft_num_layers`.

```python
mtp_num_hidden_layers = getattr(model_config.hf_text_config, "mtp_num_hidden_layers", None)
if mtp_num_hidden_layers is not None and int(mtp_num_hidden_layers) > 0:
    config.eagle_draft_num_layers = int(mtp_num_hidden_layers)
```

**There is one native MTP hidden layer reused across every draft step, so the count is not multiplied by `speculative_num_steps`.** MTP3 means three speculative steps, not three persistent KV layers.

## Scope / non-behavior-changes

- Narrow and architecture-aware: the fallback only fires for native Qwen MTP (no external draft path). It never overrides a user-supplied `--speculative-draft-model-path`.
- The EAGLE3 aux-hidden-state resolution stays inside the external-draft branch (it needs the external draft config), so the native-MTP path can never reference an undefined `draft_model_config`.
- All other architectures, external EAGLE drafts, and non-speculative runs behave exactly as before (`eagle_draft_num_layers` stays `None` when `mtp_num_hidden_layers` is absent).

## Tests

`test/registered/unit/model_executor/model_runner_components/test_native_mtp_kv_accounting.py` (CPU, `register_cpu_ci`):

1. native Qwen MTP with `eagle_draft_num_layers=None` and `mtp_num_hidden_layers=1` → resolved to 1;
2. multi-layer checkpoints budget every declared layer;
3. **one-layer draft KV inclusion**: end-to-end through the real pool cell-size math — real `Qwen3_5TextConfig` (64 layers, `full_attention_interval=4` → 16 full-attention layers) resolves as a GDN hybrid, per-layer FP8 KV = 2048 B/token, target 32,768 B/token, `(1 + 1/16)` scale → **34,816 B/token**;
4. external EAGLE draft path precedence (draft's own layer count wins, target `mtp_num_hidden_layers` ignored);
5. no regression for non-MTP models (`mtp_num_hidden_layers` absent → `None`, no-op);
6. draft worker exclusion (never double-counts via the target fallback).

## Validation

With this fix plus the standalone pre-draft-KV alias work (separate PR), native-Qwen MTP EAGLE boots at `mem-fraction-static 0.985` and serves 262144-token context on RTX 5090 where the draft KV pool previously OOM'd. This is a correctness fix: the draft KV cost must be part of the memory accounting regardless of hardware.

## Not included

- No `--max-total-tokens` policy override.
- No early-alias / memory-optimization changes (separate PR).
- No hardware-specific hacks or allocator workarounds.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32307465731](https://github.com/sgl-project/sglang/actions/runs/32307465731)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32307465571](https://github.com/sgl-project/sglang/actions/runs/32307465571)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->