### PR TITLE
opt: bind native Qwen MTP embed/lm_head before memory pool allocation

### DIFF
--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -1,4 +1,5 @@
 import contextlib
+import gc
 import logging
 import time
 from dataclasses import replace
@@ -189,6 +190,22 @@ class EagleDraftWorker(EagleDraftWorkerBase):
         )
         self.tree_mask_mode = default_tree_mask_mode()
 
+        # Bind the native-Qwen MTP embed/lm_head as early as safely possible.
+        #
+        # Both the target and the draft models are fully loaded at this point
+        # (TpModelWorker.__init__ -> ModelRunner.initialize -> load_model), and
+        # the target's embed/lm_head exist. Qwen3_5ForCausalLMMTP allocates
+        # BF16 skeleton embed_tokens/lm_head during construction; neither is
+        # checkpoint-backed (load_weights only processes mtp.* keys), so they
+        # are pure duplicates of the target's tensors. Releasing them here,
+        # before the scheduler allocates the target and draft memory pools,
+        # removes a multi-GiB transient residency peak during KV allocation.
+        #
+        # The result is consumed by alloc_memory_pool(), which skips the
+        # original post-pool init when the early bind ran. Token-mapped heads
+        # (hot_token_id) bail here and keep the original post-pool ordering.
+        self._early_mtp_alias_bound = self._bind_native_qwen_mtp_before_pool()
+
         self.plan_stream, self.plan_stream_ctx = get_plan_stream(self.device)
 
     def alloc_memory_pool(
@@ -200,13 +217,15 @@ class EagleDraftWorker(EagleDraftWorkerBase):
         """Allocate draft KV cache pools (called by scheduler)."""
         self.req_to_token_pool = req_to_token_pool
         self.token_to_kv_pool_allocator = token_to_kv_pool_allocator
+        early_mtp_alias = getattr(self, "_early_mtp_alias_bound", False)
         self.draft_worker.alloc_memory_pool(
             memory_pool_config=memory_pool_config,
             req_to_token_pool=req_to_token_pool,
             token_to_kv_pool_allocator=token_to_kv_pool_allocator,
         )
-        self.init_token_map()
-        self.init_lm_head()
+        if not early_mtp_alias:
+            self.init_token_map()
+            self.init_lm_head()
 
         if get_spec().speculative_use_rejection_sampling:
             target_vocab_size = self.target_worker.model_config.vocab_size
@@ -263,6 +282,79 @@ class EagleDraftWorker(EagleDraftWorkerBase):
         self.seed_dsa_topk_from_draft_extend = (
             self.index_share_for_mtp_iteration and self.dsa_index_topk is not None
         )
+
+    def _bind_native_qwen_mtp_before_pool(self) -> bool:
+        """Bind native-Qwen MTP embed/lm_head to the target tensors.
+
+        ``Qwen3_5ForCausalLMMTP`` constructs BF16 skeleton
+        ``model.embed_tokens.weight`` and ``lm_head.weight`` tensors during
+        draft-model construction. Neither is checkpoint-backed (``load_weights``
+        only processes ``mtp.*`` keys), so both are transient duplicates of the
+        target model's tensors. The existing ``init_lm_head()`` already deletes
+        them and rebinds the draft to the target via ``set_embed_and_head`` /
+        ``set_lm_head_from_target``; this method runs that existing logic at the
+        earliest safe point (right after both models finish loading, before the
+        scheduler allocates any memory pools).
+
+        The guard is intentionally narrow: only the native Qwen MTP draft model
+        type (``Qwen3_5ForCausalLMMTP`` from ``sglang.srt.models.qwen3_5_mtp``)
+        takes the early path. EAGLE3 / standalone / external-draft / token-mapped
+        (hot-token) workers keep the original post-pool ordering.
+
+        Returns True when the early bind ran; ``alloc_memory_pool()`` then skips
+        the later ``init_token_map()`` / ``init_lm_head()`` calls (idempotent).
+        """
+        draft_model = self.draft_runner.model
+        if (
+            type(draft_model).__name__ != "Qwen3_5ForCausalLMMTP"
+            or type(draft_model).__module__ != "sglang.srt.models.qwen3_5_mtp"
+        ):
+            return False
+
+        self.init_token_map()
+        if self.hot_token_id is not None:
+            # Token-mapped heads clone/reorder the head; the early alias is not
+            # safe there. Fall back to the original post-pool ordering.
+            return False
+        self.init_lm_head()
+
+        target_model = self.target_worker.model_runner.model
+        target_embed = target_model.model.embed_tokens.weight
+        draft_embed = draft_model.model.embed_tokens.weight
+        target_head = target_model.lm_head
+        draft_head = draft_model.lm_head
+        same_embed_storage = (
+            target_embed.untyped_storage().data_ptr()
+            == draft_embed.untyped_storage().data_ptr()
+        )
+        same_head_storage = (
+            target_head.weight.untyped_storage().data_ptr()
+            == draft_head.weight.untyped_storage().data_ptr()
+        )
+        duplicate_bytes = 0
+        if not same_embed_storage:
+            duplicate_bytes += draft_embed.numel() * draft_embed.element_size()
+        if not same_head_storage:
+            duplicate_bytes += (
+                draft_head.weight.numel() * draft_head.weight.element_size()
+            )
+
+        logger.info(
+            "Native Qwen MTP: early-bound draft embed/lm_head to target "
+            "(embed_storage_shared=%s lm_head_storage_shared=%s "
+            "duplicate_bytes=%s)",
+            same_embed_storage,
+            same_head_storage,
+            duplicate_bytes,
+        )
+        assert same_embed_storage, "native Qwen MTP embedding alias failed"
+        assert draft_head is target_head, "native Qwen MTP lm_head alias failed"
+        assert duplicate_bytes == 0, "native Qwen MTP duplicate weights remain"
+
+        # Release the deleted Parameter objects now that the alias is confirmed.
+        gc.collect()
+        torch.cuda.empty_cache()
+        return True
 
     def init_token_map(self):
         # Load hot token ids

--- a/test/registered/unit/spec/test_native_mtp_early_alias.py
+++ b/test/registered/unit/spec/test_native_mtp_early_alias.py
@@ -1,0 +1,224 @@
+"""Unit tests for the native-Qwen MTP early embed/lm_head bind.
+
+``EagleDraftWorker.__init__`` binds the draft's BF16 skeleton
+``embed_tokens``/``lm_head`` to the target's tensors as soon as both models
+are loaded, before the scheduler allocates any memory pools. ``alloc_memory_pool``
+consumes the precomputed result and skips the original post-pool init when the
+early bind ran.
+
+These tests run on CPU — they never allocate real CUDA tensors. They verify:
+
+1. the guard is narrow (only ``Qwen3_5ForCausalLMMTP`` from
+   ``sglang.srt.models.qwen3_5_mtp`` takes the early path);
+2. the alias runs during construction (before ``alloc_memory_pool``);
+3. embed/lm_head storage is shared with the target after the bind;
+4. token-mapped (hot-token) heads fall back to the post-pool ordering;
+5. genuine MTP decoder/fc/norm weights are untouched by the bind.
+"""
+
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from sglang.srt.speculative.eagle_worker_v2 import EagleDraftWorker
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+def _qwen35_mtp_class():
+    """A class whose __name__/__module__ match the native Qwen3.5 MTP guard."""
+    return type(
+        "Qwen3_5ForCausalLMMTP",
+        (object,),
+        {"__module__": "sglang.srt.models.qwen3_5_mtp"},
+    )
+
+
+class _Storage:
+    def __init__(self, ptr):
+        self._ptr = ptr
+
+    def data_ptr(self):
+        return self._ptr
+
+
+def _tensor_like(ptr, numel=1, element_size=2):
+    t = MagicMock()
+    t.untyped_storage.return_value = _Storage(ptr)
+    t.numel.return_value = numel
+    t.element_size.return_value = element_size
+    return t
+
+
+def _make_worker(draft_model=None, *, shared=True):
+    """Worker double with mock draft/target models.
+
+    shared=True wires the draft embed/head to the same storage as the target
+    (the state the early bind is supposed to produce), so the positive path
+    passes its assertions.
+    """
+    worker = object.__new__(EagleDraftWorker)
+    worker.device = "cpu"
+
+    target_model = MagicMock()
+    target_model.model.embed_tokens.weight = _tensor_like(100, numel=3, element_size=2)
+    target_model.lm_head = MagicMock()
+    target_model.lm_head.weight = _tensor_like(200, numel=3, element_size=2)
+
+    if draft_model is None:
+        draft_model = _qwen35_mtp_class()()
+    draft_model.model.embed_tokens.weight = (
+        _tensor_like(100, numel=3, element_size=2) if shared else _tensor_like(500)
+    )
+    draft_model.lm_head = target_model.lm_head if shared else MagicMock()
+    if not shared:
+        draft_model.lm_head.weight = _tensor_like(600, numel=3, element_size=2)
+
+    worker.draft_runner = SimpleNamespace(model=draft_model)
+    worker.target_worker = SimpleNamespace(
+        model_runner=SimpleNamespace(model=target_model)
+    )
+    worker.init_token_map = MagicMock()
+    worker.init_lm_head = MagicMock()
+    worker.hot_token_id = None
+    return worker
+
+
+def _patch_spec():
+    """alloc_memory_pool reads get_spec().speculative_use_rejection_sampling;
+    patch it so the test needs no runtime context."""
+    return patch(
+        "sglang.srt.speculative.eagle_worker_v2.get_spec",
+        return_value=SimpleNamespace(speculative_use_rejection_sampling=False),
+    )
+
+
+class TestNativeQwenMtpEarlyBindGuard(CustomTestCase):
+    def test_qwen35_mtp_takes_early_path(self):
+        """The narrow guard accepts exactly the native Qwen3.5 MTP draft."""
+        worker = _make_worker()
+        result = worker._bind_native_qwen_mtp_before_pool()
+        self.assertTrue(result)
+        worker.init_token_map.assert_called_once()
+        worker.init_lm_head.assert_called_once()
+
+    def test_other_drafts_do_not_take_early_path(self):
+        """EAGLE3 / other MTP wrappers / plain Qwen keep post-pool ordering."""
+        for name, module in [
+            ("Qwen3NextForCausalLMMTP", "sglang.srt.models.qwen3_next_mtp"),
+            ("Qwen3MoeForCausalLMMTP", "sglang.srt.models.qwen3_moe_mtp"),
+            ("EagleDraftModel", "sglang.srt.models.some_eagle3"),
+            ("Qwen3_5ForCausalLM", "sglang.srt.models.qwen3_5"),
+        ]:
+            with self.subTest(name=name):
+                draft = type(name, (object,), {"__module__": module})()
+                worker = _make_worker(draft)
+                result = worker._bind_native_qwen_mtp_before_pool()
+                self.assertFalse(result, f"{name} must not take the early path")
+                worker.init_lm_head.assert_not_called()
+
+    def test_wrong_module_does_not_take_early_path(self):
+        """Same class name from a different module is not the native MTP."""
+        draft = type(
+            "Qwen3_5ForCausalLMMTP", (object,), {"__module__": "some.other.module"}
+        )()
+        worker = _make_worker(draft)
+        result = worker._bind_native_qwen_mtp_before_pool()
+        self.assertFalse(result)
+
+    def test_token_map_falls_back_to_post_pool(self):
+        """A hot-token (token-mapped) head must keep the post-pool ordering."""
+        worker = _make_worker()
+        worker.hot_token_id = object()  # any non-None value
+        result = worker._bind_native_qwen_mtp_before_pool()
+        self.assertFalse(result)
+        worker.init_lm_head.assert_not_called()
+
+
+class TestNativeQwenMtpEarlyBindTiming(CustomTestCase):
+    def test_bind_runs_during_init_before_any_pool(self):
+        """The early bind runs at construction time, before alloc_memory_pool.
+
+        ``EagleDraftWorker.__init__`` computes ``_early_mtp_alias_bound`` via
+        ``_bind_native_qwen_mtp_before_pool``; ``alloc_memory_pool`` only
+        consumes that precomputed result and never re-binds.
+        """
+        worker = _make_worker()
+        worker._early_mtp_alias_bound = True
+        worker.draft_worker = MagicMock()
+        worker._bind_native_qwen_mtp_before_pool = MagicMock(return_value=True)
+        worker.init_token_map = MagicMock()
+        worker.init_lm_head = MagicMock()
+
+        with _patch_spec():
+            worker.alloc_memory_pool(
+                memory_pool_config=None,
+                req_to_token_pool=None,
+                token_to_kv_pool_allocator=None,
+            )
+
+        # The precomputed flag is consumed, not recomputed, and the post-pool
+        # init is skipped (the bind already ran in __init__).
+        worker._bind_native_qwen_mtp_before_pool.assert_not_called()
+        worker.draft_worker.alloc_memory_pool.assert_called_once()
+        worker.init_token_map.assert_not_called()
+        worker.init_lm_head.assert_not_called()
+
+    def test_alloc_memory_pool_fallback_ordering_preserved(self):
+        """Non-MTP drafts still run init_token_map + init_lm_head AFTER the pool."""
+        worker = _make_worker()
+        worker._early_mtp_alias_bound = False
+        worker.draft_worker = MagicMock()
+        worker.init_token_map = MagicMock()
+        worker.init_lm_head = MagicMock()
+
+        with _patch_spec():
+            worker.alloc_memory_pool(
+                memory_pool_config=None,
+                req_to_token_pool=None,
+                token_to_kv_pool_allocator=None,
+            )
+
+        # Pool first, alias after.
+        worker.draft_worker.alloc_memory_pool.assert_called_once()
+        worker.init_token_map.assert_called_once()
+        worker.init_lm_head.assert_called_once()
+
+    def test_storage_shared_after_bind(self):
+        """After the early bind, draft embed/head share target storage."""
+        worker = _make_worker(shared=True)
+        result = worker._bind_native_qwen_mtp_before_pool()
+        self.assertTrue(result)
+        draft_model = worker.draft_runner.model
+        target_model = worker.target_worker.model_runner.model
+        self.assertEqual(
+            draft_model.model.embed_tokens.weight.untyped_storage().data_ptr(),
+            target_model.model.embed_tokens.weight.untyped_storage().data_ptr(),
+        )
+        self.assertIs(draft_model.lm_head, target_model.lm_head)
+
+    def test_genuine_mtp_weights_untouched(self):
+        """The bind must not modify MTP decoder/fc/norm parameters.
+
+        It only rebinds embed_tokens/lm_head; the MTP layer modules (fc,
+        norms, decoder layers) are separate nn.Module attributes that the
+        alias never touches.
+        """
+        draft_model = _qwen35_mtp_class()()
+        draft_model.fc = MagicMock()
+        draft_model.pre_fc_norm_embedding = MagicMock()
+        draft_model.pre_fc_norm_hidden = MagicMock()
+        draft_model.layers = MagicMock()
+        worker = _make_worker(draft_model, shared=True)
+        worker._bind_native_qwen_mtp_before_pool()
+        # No attribute on the genuine MTP modules is deleted or reassigned.
+        draft_model.fc.assert_not_called()
+        draft_model.pre_fc_norm_embedding.assert_not_called()
+        draft_model.pre_fc_norm_hidden.assert_not_called()
+
+
+if __name__ == "__main__":
+    sys.exit(unittest.main())


### PR DESCRIPTION
## Problem

`Qwen3_5ForCausalLMMTP` (the native-Qwen MTP wrapper, `sglang.srt.models.qwen3_5_mtp`) allocates **BF16 skeleton tensors** for the draft model's `model.embed_tokens.weight` and `lm_head.weight` during construction:

- `model.embed_tokens.weight` `[248320, 5120]` = 2,542,796,800 bytes
- `lm_head.weight` `[248320, 5120]` = 2,542,796,800 bytes
- **5,085,593,600 bytes nominal (~4.7 GiB)** combined

These are **not independent learned MTP weights**: the checkpoint does not ship separate MTP embed/head tensors (only `mtp.*` keys exist), and they are ultimately intended to share the target model's embedding and `lm_head`. `EagleDraftWorker.init_lm_head()` already deletes them and rebinds the draft to the target via `set_embed_and_head` / `set_lm_head_from_target` — but it only ran **after** `draft_worker.alloc_memory_pool()`, i.e. after both the target and draft KV pools were allocated, so the multi-GiB duplicate residency coexisted with pool construction.

## Initialization-order root cause

```
scheduler.init_model_worker()
  -> init_tp_model_worker()
     -> target TpModelWorker.__init__()
        -> ModelRunner.initialize() -> load_model()      # target weights resident
  -> maybe_init_draft_worker()
     -> EAGLEWorkerV2.__init__()
        -> EagleDraftWorker.__init__()
           -> draft TpModelWorker(is_draft_worker=True)  # native-MTP weights resident
           -> self.draft_runner assigned
           >>> EARLY NATIVE-QWEN MTP ALIAS (this PR) <<<
  -> init_memory_pools()
     -> init_target_memory_pool()                        # target Mamba / KV alloc
     -> draft pool allocation
```

The alias previously happened at the end of `EagleDraftWorker.alloc_memory_pool()`. Both the target and draft models are already fully loaded by the time `EagleDraftWorker.__init__` finishes — so the earliest safe point is right after `self.draft_runner = self.draft_worker.model_runner`, **before** the scheduler allocates any memory pools.

## Change

- In `EagleDraftWorker.__init__`, immediately after `self.draft_runner` is assigned, run the existing embed/head-sharing logic via `_bind_native_qwen_mtp_before_pool()` and store the result in `self._early_mtp_alias_bound`.
- `alloc_memory_pool()` now **consumes** the precomputed flag and skips the original post-pool `init_token_map()` / `init_lm_head()` calls when the early bind ran (the alias is idempotent).
- The bind reuses the existing `init_lm_head()` path (`set_embed_and_head` + `set_lm_head_from_target`).

## Safety / guarding

- Narrow guard: only `Qwen3_5ForCausalLMMTP` from `sglang.srt.models.qwen3_5_mtp` takes the early path.
- **Token-mapped (hot-token) heads bail** (`hot_token_id is not None`) and keep the original post-pool ordering — the early bind is unsafe when the head is cloned/reordered.
- EAGLE3 / standalone / external-draft / multi-layer workers are untouched (they never construct this class or keep their own ordering).
- Genuine MTP decoder / `fc` / norm parameters are never modified — only the embed/head aliases are rebound.
- The bind asserts embed storage is shared, `lm_head` module is shared, and zero duplicate bytes remain before pool allocation.
- Startup weight-load overlap (`--startup-weight-load-mode=overlap`) is not supported for speculative decoding / hybrid-GDN configs (rejected in `startup_weight_load.py`), so serial weight load always completes before this code runs.

## Memory impact

On an RTX 5090 (32 GB, Qwen3.8-27B NVFP4 + native MTP + ReplaySSM EAGLE):

| step | free VRAM |
|---|---|
| pre-alias (both models loaded) | ~8.9 GiB |
| after early bind | ~14.0 GiB |
| released before target KV alloc | **5,054,136,320 bytes (~4.707 GiB)** |

Target KV allocation now sees the freed headroom (Gittensor checkpoint: 14.04 GiB free at the target pool step vs ~8.9 GiB before; RadixArk checkpoint: ~10.9 GiB).

## Deterministic parity

Same prompt + `temperature 0.0`:

```text
output_ids: [271, 9419, 271, 248068, 198, 760, 1156, 1018]
```

Bit-identical to the unpatched control and to the previous pre-draft-KV alias patch — the alias rebinds tensors, it never changes logits.

## Before / after real-world initialization evidence

| checkpoint | previous alias timing (pre-draft-KV) | this PR (init-time) |
|---|---|---|
| Gittensor Qwen3.8-27B-NVFP4, 262144 ctx, MTP3, 4 Mamba slots | boot + `/generate` 200 | boot + `/generate` 200 |
| RadixArk Qwen3.8-27B-NVFP4, 230k/250k/260k ctx | **OOM during target KV construction** (~220k/230k) | boot + `/generate` 200 at 230k, 250k, 260k |

Heavier checkpoints (RadixArk) OOMed during **target** KV allocation with the earlier pre-draft-KV patch because the skeleton duplicates were still resident while the target pool profiled and allocated; moving the alias to `__init__` eliminates them first. These are measured single-hardware cases, not universal guarantees.

## Tests

`test/registered/unit/spec/test_native_mtp_early_alias.py` (CPU, `register_cpu_ci`):

- guard narrowness: only `Qwen3_5ForCausalLMMTP` / `sglang.srt.models.qwen3_5_mtp` takes the early path; same-name-different-module rejected;
- alias timing: `alloc_memory_pool` consumes the precomputed `_early_mtp_alias_bound`, never re-binds, and skips post-pool init when it ran;
- fallback ordering preserved: non-MTP drafts still run `init_token_map` + `init_lm_head` after the pool;
- storage sharing: draft embed/head share target storage after the bind;
- genuine MTP weights untouched.

## Untested (honest)

- EAGLE3 with native-Qwen MTP (aux-hidden-state path) — not exercised; the guard excludes it from the early path by construction.
- Standalone / external EAGLE draft models — not exercised.
- TP/PP configurations — not exercised.
- Token-map / hot-token heads — covered by the fallback (bail), but not end-to-end.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32307446680](https://github.com/sgl-project/sglang/actions/runs/32307446680)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32307446611](https://github.com/sgl-project/sglang/actions/runs/32307446611)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->