### PR TITLE
[sampling] Fix int32 offset overflow in top-k renorm Triton kernels

### DIFF
--- a/python/sglang/kernels/ops/sampling/renorm_triton.py
+++ b/python/sglang/kernels/ops/sampling/renorm_triton.py
@@ -25,7 +25,7 @@ def _mask_and_partial_sum_kernel(
     chunk = tl.program_id(1)
     offsets = chunk * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     mask = offsets < vocab_size
-    row_offsets = row * vocab_size + offsets
+    row_offsets = row.to(tl.int64) * vocab_size + offsets
 
     probs = tl.load(probs_ptr + row_offsets, mask=mask, other=0.0).to(tl.float32)
     pivot = tl.load(pivots_ptr + row)
@@ -43,7 +43,7 @@ def _normalize_kernel(
     vocab_size: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
 ):
-    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    offsets = tl.program_id(0).to(tl.int64) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     mask = offsets < numel
     row = offsets // vocab_size
     values = tl.load(out_ptr + offsets, mask=mask, other=0.0).to(tl.float32)


### PR DESCRIPTION
## Motivation

The top-k renorm Triton kernels in `python/sglang/kernels/ops/sampling/renorm_triton.py` compute flattened element offsets as `row * vocab_size + offsets` and `program_id * BLOCK_SIZE + arange(...)`. Both products are computed in int32, so for large `batch x vocab_size` tensors the offsets can silently overflow, corrupting loads/stores.

## Modifications

Cast the row / program id to `tl.int64` before the multiplication in `_mask_and_partial_sum_kernel` and `_normalize_kernel`, so offset arithmetic is done in 64-bit.

## Checklist

- Ran `pre-commit` on the changed file (passed).
- Verified on an internal setup exercising the top-k renorm path.

## Original commits

- `49831150a`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #32306179456](https://github.com/sgl-project/sglang/actions/runs/32306179456)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32306179103](https://github.com/sgl-project/sglang/actions/runs/32306179103)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->