### PR TITLE
feat: add Mooncake GPU-direct SpecForge capture

### DIFF
--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -102,6 +102,9 @@ class LogitsProcessorOutput:
     # Used by speculative decoding (EAGLE)
     # The last hidden layers
     hidden_states: Optional[torch.Tensor] = None
+    # Full post-norm target hidden states retained alongside packed auxiliary
+    # states for GPU-direct speculative-training capture.
+    last_hidden_states: Optional[torch.Tensor] = None
 
     ## Part 2: This part will be assigned in python/sglang/srt/layers/sampler.py::Sampler
     # he log probs of output tokens, if SGLANG_RETURN_ORIGINAL_LOGPROB = True, will get the log probs before applying temperature. If False, will get the log probs before applying temperature.
@@ -391,6 +394,21 @@ class LogitsProcessor(nn.Module):
             sample_indices,
             logits_metadata,
         )
+        last_hidden_states_to_store = (
+            hidden_states
+            if (
+                logits_metadata.capture_hidden_mode.is_full()
+                and aux_hidden_states is not None
+            )
+            else None
+        )
+        logits_mup_width_multiplier = getattr(
+            self.config, "logits_mup_width_multiplier", None
+        )
+        if last_hidden_states_to_store is not None and logits_mup_width_multiplier:
+            last_hidden_states_to_store = (
+                last_hidden_states_to_store * float(logits_mup_width_multiplier)
+            )
         del hidden_states
 
         if not logits_metadata.extend_return_logprob:
@@ -404,6 +422,7 @@ class LogitsProcessor(nn.Module):
             return LogitsProcessorOutput(
                 next_token_logits=sampled_logits,
                 hidden_states=hidden_states_to_store,
+                last_hidden_states=last_hidden_states_to_store,
                 mm_input_embeds=logits_metadata.mm_input_embeds,
             )
 
@@ -421,6 +440,7 @@ class LogitsProcessor(nn.Module):
         logits_output = LogitsProcessorOutput(
             next_token_logits=sampled_logits,
             hidden_states=hidden_states_to_store,
+            last_hidden_states=last_hidden_states_to_store,
             mm_input_embeds=logits_metadata.mm_input_embeds,
         )
         logprobs_result.write_input_to(logits_output)

--- a/python/sglang/srt/managers/detokenizer_manager.py
+++ b/python/sglang/srt/managers/detokenizer_manager.py
@@ -476,6 +476,7 @@ class DetokenizerManager(MultiHttpWorkerDetokenizerMixin):
             output_token_sampling_mask=recv_obj.output_token_sampling_mask,
             output_token_sampling_logprobs=recv_obj.output_token_sampling_logprobs,
             output_hidden_states=recv_obj.output_hidden_states,
+            spec_capture=recv_obj.spec_capture,
             routed_experts=routed_experts,
             indexer_topk=indexer_topk,
             customized_info=recv_obj.customized_info,

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -232,6 +232,8 @@ class GenerateReqInput:
     return_hidden_states: Union[
         List[ReturnHiddenStatesMode], ReturnHiddenStatesMode
     ] = False
+    # Per-request GPU-direct speculative-training capture instructions.
+    spec_capture: Optional[Union[List[Optional[Dict]], Dict]] = None
     # Whether to return captured routed experts
     return_routed_experts: bool = False
     # Absolute start position for returned routings; response covers
@@ -881,6 +883,11 @@ class GenerateReqInput:
                 if isinstance(self.return_hidden_states, list)
                 else self.return_hidden_states
             ),
+            spec_capture=(
+                self.spec_capture[i]
+                if isinstance(self.spec_capture, list)
+                else self.spec_capture
+            ),
             return_routed_experts=self.return_routed_experts,
             routed_experts_start_len=self.routed_experts_start_len,
             return_indexer_topk=self.return_indexer_topk,
@@ -1030,6 +1037,9 @@ class TokenizedGenerateReqInput(BaseReq, kw_only=True):
     # encoder_idx assignments stay consistent in the scheduler subprocess.
     # Internal IPC only.
     encoder_urls: Optional[List[str]] = None
+
+    # GPU-direct speculative-training capture instructions.
+    spec_capture: Optional[Dict] = None
 
     # Pre-computed delimiter indices for multi-item scoring
     multi_item_delimiter_indices: Optional[List[int]] = None
@@ -1462,6 +1472,9 @@ class BatchTokenIDOutput(BaseBatchReq, kw_only=True):
     # Number of times each request was retracted.
     retraction_counts: Optional[List[int]] = None
 
+    # Per-request GPU-direct capture descriptors.
+    spec_capture: Optional[List[Any]] = None
+
     # The trainer step id. Used to know which step's weights are used for sampling.
     token_steps: Optional[List[List[int]]] = None
 
@@ -1552,6 +1565,9 @@ class BatchStrOutput(BaseBatchReq, kw_only=True):
 
     # Number of times each request was retracted.
     retraction_counts: Optional[List[int]] = None
+
+    # Per-request GPU-direct capture descriptors.
+    spec_capture: Optional[List[Any]] = None
 
     # The trainer step id. Used to know which step's weights are used for sampling.
     token_steps: Optional[List[List[int]]] = None

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -846,6 +846,7 @@ class Req(ReqDllmMixin):
             Union[APIServerReqTimeStats, DPControllerReqTimeStats]
         ] = None,
         return_pooled_hidden_states: bool = False,
+        spec_capture: Optional[Dict[str, Any]] = None,
         multi_item_delimiter_indices: Optional[List[int]] = None,
         session_id: Optional[str] = None,
         cache_salt: Optional[str] = None,
@@ -914,10 +915,16 @@ class Req(ReqDllmMixin):
             }
         self.sampling_params = sampling_params
         self.custom_logit_processor = custom_logit_processor
+        self.spec_capture = spec_capture
         self.return_hidden_states = return_hidden_states
-        self.return_hidden_states_mode = get_return_hidden_states_mode(
-            return_hidden_states
+        self.return_hidden_states_mode = (
+            CaptureHiddenMode.FULL
+            if spec_capture is not None
+            else get_return_hidden_states_mode(return_hidden_states)
         )
+        self.spec_capture_aux: List[torch.Tensor] = []
+        self.spec_capture_last_hidden: List[torch.Tensor] = []
+        self.spec_capture_result: Optional[Dict[str, Any]] = None
 
         # Extra key for caller-defined request classification.
         if lora_id is not None:

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -655,11 +655,26 @@ class Scheduler(
 
         self.init_batch_result_processor()
 
+        self.maybe_init_spec_capture_sink()
+
         self.is_initializing = False
         self.init_startup_timing_summary()
 
     def init_startup_timing_begin(self) -> None:
         self.scheduler_startup_begin = time.perf_counter()
+
+    def maybe_init_spec_capture_sink(self) -> None:
+        if not self.server_args.enable_spec_capture:
+            return
+        if self.server_args.chunked_prefill_size != -1:
+            raise ValueError(
+                "--enable-spec-capture requires --chunked-prefill-size -1"
+            )
+        if self.ps.attn_tp_rank != 0:
+            return
+        from sglang.srt import spec_capture_sink
+
+        spec_capture_sink.maybe_init_sink(self.server_args)
 
     def init_startup_timing_summary(self) -> None:
         self.startup_time = build_scheduler_startup_time(
@@ -2460,6 +2475,7 @@ class Scheduler(
                 dllm_config=self.dllm_config,
                 time_stats=recv_req.time_stats,
                 multi_item_delimiter_indices=recv_req.multi_item_delimiter_indices,
+                spec_capture=recv_req.spec_capture,
             )
             req.tokenizer = self.tokenizer
 
@@ -3691,6 +3707,14 @@ class Scheduler(
             else:
                 batch.sampling_info = sched_sampling_info
 
+    @staticmethod
+    def _should_copy_hidden_states_to_cpu(batch: ScheduleBatch) -> bool:
+        return (
+            batch.return_hidden_states
+            and not any(req.spec_capture is not None for req in batch.reqs)
+            and any(req.return_hidden_states for req in batch.reqs)
+        )
+
     @scheduler_nvtx_method("scheduler.run_batch")
     def run_batch(
         self,
@@ -3795,7 +3819,9 @@ class Scheduler(
                                 # overlaps.
                                 batch_result.copy_to_cpu(
                                     return_logprob=batch.return_logprob,
-                                    return_hidden_states=batch.return_hidden_states,
+                                    return_hidden_states=self._should_copy_hidden_states_to_cpu(
+                                        batch
+                                    ),
                                 )
                             else:
                                 # Result D2H on copy_stream overlaps the next forward
@@ -3805,7 +3831,9 @@ class Scheduler(
                                 with self.copy_stream_ctx:
                                     batch_result.copy_to_cpu(
                                         return_logprob=batch.return_logprob,
-                                        return_hidden_states=batch.return_hidden_states,
+                                        return_hidden_states=self._should_copy_hidden_states_to_cpu(
+                                            batch
+                                        ),
                                     )
                         else:
                             batch_result.future_indices = future_indices
@@ -3844,7 +3872,7 @@ class Scheduler(
                 batch_result.copy_done = self.device_module.Event()
                 batch_result.copy_to_cpu(
                     return_logprob=batch.return_logprob,
-                    return_hidden_states=batch.return_hidden_states,
+                    return_hidden_states=self._should_copy_hidden_states_to_cpu(batch),
                 )
             else:
                 kwargs = (
@@ -3974,7 +4002,9 @@ class Scheduler(
         with self.copy_stream_ctx:
             batch_result.copy_to_cpu(
                 return_logprob=cur_batch.return_logprob,
-                return_hidden_states=cur_batch.return_hidden_states,
+                return_hidden_states=self._should_copy_hidden_states_to_cpu(
+                    cur_batch
+                ),
             )
 
         # Release the closure and large GPU tensors that are no longer needed.
@@ -3993,6 +4023,8 @@ class Scheduler(
         batch: ScheduleBatch,
         result: Union[GenerationBatchResult, EmbeddingBatchResult],
     ):
+        self.batch_result_processor.drain_spec_captures()
+
         # Flush async trace ops here: in overlap mode this CPU work runs while
         # the next batch's GPU forward is in flight, giving free overlap.
         flush_trace_batch(batch.reqs)
@@ -4112,6 +4144,11 @@ class Scheduler(
         # Flush any health-check signal deferred while the engine was busy.
         self.maybe_send_health_check_signal()
 
+        self.batch_result_processor.drain_spec_captures()
+        if self.batch_result_processor.has_pending_spec_captures():
+            time.sleep(0.001)
+            return
+
         if not self.is_fully_idle():
             return
 
@@ -4169,6 +4206,7 @@ class Scheduler(
             and not self.dllm_manager.any_staging_reqs()
             and (self.last_batch is None or self.last_batch.is_empty())
             and (not self.enable_overlap or len(self.result_queue) == 0)
+            and not self.batch_result_processor.has_pending_spec_captures()
             and self._pp_microbatches_drained()
         )
 

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
+import time
+from dataclasses import dataclass, field
 from typing import (
     TYPE_CHECKING,
     Callable,
@@ -93,6 +94,12 @@ class SchedulerBatchResultProcessor:
     logprob_result_processor: SchedulerLogprobResultProcessor
     output_streamer: SchedulerOutputStreamer
     abort_request: Callable
+    _spec_capture_batches: List = field(
+        default_factory=list,
+        init=False,
+        repr=False,
+        compare=False,
+    )
 
     def process_batch_result_prebuilt(self, batch: ScheduleBatch):
         assert self.disaggregation_mode == DisaggregationMode.DECODE
@@ -196,6 +203,7 @@ class SchedulerBatchResultProcessor:
         result: Union[GenerationBatchResult, EmbeddingBatchResult],
     ):
         skip_stream_req = None
+        pending_spec_captures: List = []
         self.token_to_kv_pool_allocator.free_group_begin()
 
         if self.is_generation:
@@ -237,6 +245,17 @@ class SchedulerBatchResultProcessor:
 
             for i, (req, next_token_id) in enumerate(zip(batch.reqs, next_token_ids)):
                 if (
+                    req.spec_capture is not None
+                    and logits_output.hidden_states is not None
+                ):
+                    assert extend_input_len_per_req is not None
+                    hidden_state_offset = self._append_spec_capture_states(
+                        req=req,
+                        logits_output=logits_output,
+                        hidden_state_offset=hidden_state_offset,
+                        extend_input_len=extend_input_len_per_req[i],
+                    )
+                elif (
                     batch.return_hidden_states
                     and logits_output.hidden_states is not None
                 ):
@@ -276,6 +295,10 @@ class SchedulerBatchResultProcessor:
                         self._maybe_collect_indexer_topk(req)
                         release_kv_cache(req, self.tree_cache)
                         req.time_stats.set_completion_time()
+                        if req.spec_capture is not None:
+                            pending = self._stage_spec_capture(req)
+                            if pending is not None:
+                                pending_spec_captures.append(pending)
                     elif not batch.decoding_reqs or req not in batch.decoding_reqs:
                         maybe_cache_unfinished_req(req, self.tree_cache)
                         if get_memory().enable_hisparse:
@@ -363,9 +386,23 @@ class SchedulerBatchResultProcessor:
                     req.time_stats.set_last_chunked_prefill_finish_time()
 
         self.token_to_kv_pool_allocator.free_group_end()
-        self.output_streamer.stream_output(
-            batch.reqs, batch.return_logprob, skip_stream_req
-        )
+        if pending_spec_captures:
+            self._queue_spec_captures(
+                pending_spec_captures,
+                return_logprob=batch.return_logprob,
+            )
+            pending_ids = {id(item[0]) for item in pending_spec_captures}
+            ready = [
+                req
+                for req in batch.reqs
+                if id(req) not in pending_ids and req is not skip_stream_req
+            ]
+            if ready:
+                self.output_streamer.stream_output(ready, batch.return_logprob)
+        else:
+            self.output_streamer.stream_output(
+                batch.reqs, batch.return_logprob, skip_stream_req
+            )
 
         can_run_cuda_graph = result.can_run_cuda_graph
         self.metrics_reporter.report_prefill_stats(
@@ -495,6 +532,112 @@ class SchedulerBatchResultProcessor:
                     f"{batch.contains_last_prefill_chunk}). "
                     f"Placeholder zeros would be appended to output_ids."
                 )
+
+    def _append_spec_capture_states(
+        self,
+        *,
+        req: Req,
+        logits_output: LogitsProcessorOutput,
+        hidden_state_offset: int,
+        extend_input_len: int,
+    ) -> int:
+        start = hidden_state_offset
+        end = start + extend_input_len
+        if self.output_streamer.ps.attn_tp_rank != 0:
+            return end
+        features = dict(req.spec_capture.get("features") or {})
+        if "aux" in features:
+            req.spec_capture_aux.append(logits_output.hidden_states[start:end])
+        if (
+            "last_hidden" in features
+            and logits_output.last_hidden_states is not None
+        ):
+            req.spec_capture_last_hidden.append(
+                logits_output.last_hidden_states[start:end]
+            )
+        return end
+
+    def _stage_spec_capture(self, req: Req):
+        from sglang.srt import spec_capture_sink
+
+        sink = spec_capture_sink.get_sink()
+        if sink is None or self.output_streamer.ps.attn_tp_rank != 0:
+            return None
+        aux = self._coalesce_spec_capture_chunks(req.spec_capture_aux)
+        last_hidden = self._coalesce_spec_capture_chunks(
+            req.spec_capture_last_hidden
+        )
+        req.spec_capture_aux = []
+        req.spec_capture_last_hidden = []
+        return req, req.spec_capture, aux, last_hidden
+
+    def _queue_spec_captures(self, pending, *, return_logprob: bool) -> None:
+        from sglang.srt import spec_capture_sink
+
+        sink = spec_capture_sink.get_sink()
+        if sink is None:
+            raise RuntimeError("spec-capture sink is not initialized")
+        samples = [
+            (spec, aux, last_hidden)
+            for _, spec, aux, last_hidden in pending
+        ]
+        self._spec_capture_batches.append(
+            (pending, sink.submit_samples(samples), return_logprob, time.perf_counter())
+        )
+        max_pending = self.server_args.spec_capture_max_pending_batches
+        if len(self._spec_capture_batches) >= max_pending:
+            self.drain_spec_captures(block=True, max_batches=1)
+
+    def has_pending_spec_captures(self) -> bool:
+        return bool(self._spec_capture_batches)
+
+    def drain_spec_captures(
+        self, *, block: bool = False, max_batches: Optional[int] = None
+    ) -> int:
+        completed = 0
+        while self._spec_capture_batches:
+            if max_batches is not None and completed >= max_batches:
+                break
+            pending, future, return_logprob, queued_at = self._spec_capture_batches[0]
+            if not block and not future.done():
+                break
+            self._spec_capture_batches.pop(0)
+            try:
+                results = future.result()
+                if len(results) != len(pending):
+                    raise RuntimeError(
+                        f"spec-capture sink returned {len(results)} results for "
+                        f"{len(pending)} requests"
+                    )
+            except Exception as exc:
+                logger.error(
+                    "GPU-direct spec-capture batch failed after %.3f ms: %s",
+                    (time.perf_counter() - queued_at) * 1000.0,
+                    exc,
+                )
+                for req, spec, _, _ in pending:
+                    req.spec_capture_result = {
+                        "sample_id": spec.get("sample_id"),
+                        "error": str(exc),
+                    }
+            else:
+                for item, result in zip(pending, results):
+                    item[0].spec_capture_result = result
+            self.output_streamer.stream_output(
+                [item[0] for item in pending], return_logprob
+            )
+            completed += 1
+        return completed
+
+    @staticmethod
+    def _coalesce_spec_capture_chunks(
+        chunks: List[torch.Tensor],
+    ) -> Optional[torch.Tensor]:
+        if not chunks:
+            return None
+        if len(chunks) == 1:
+            return chunks[0]
+        return torch.cat(chunks, dim=0)
 
     def _append_prefill_hidden_states(
         self,

--- a/python/sglang/srt/managers/scheduler_components/output_streamer.py
+++ b/python/sglang/srt/managers/scheduler_components/output_streamer.py
@@ -162,6 +162,13 @@ class SchedulerOutputStreamer:
         for req in reqs:
             if req is skip_req:
                 continue
+            if (
+                self.server_args.enable_spec_capture
+                and req.spec_capture is not None
+                and req.finished()
+                and req.spec_capture_result is None
+            ):
+                continue
             if req.finished() and req.finished_output:
                 # With the overlap schedule, a request will try to output twice and hit this line twice
                 # because of the one additional delayed token. This "continue" prevented the dummy output.
@@ -302,6 +309,7 @@ class _GenerationStreamAccumulator:
     spec_cap_lens_histogram: list = field(default_factory=list)
     retraction_counts: list = field(default_factory=list)
     output_hidden_states: Optional[list] = None
+    spec_capture: list = field(default_factory=list)
     routed_experts: Optional[list] = None
     indexer_topk: Optional[list] = None
     customized_info: dict = field(default_factory=dict)
@@ -579,6 +587,7 @@ class _GenerationStreamAccumulator:
                     self.output_hidden_states.append(hs)
             else:
                 self.output_hidden_states.append(None)
+        self.spec_capture.append(getattr(req, "spec_capture_result", None))
         if self.return_routed_experts:
             self.routed_experts.append(
                 req.routed_experts if req.return_routed_experts else None
@@ -671,6 +680,7 @@ class _GenerationStreamAccumulator:
             output_token_sampling_mask=self.output_token_sampling_mask,
             output_token_sampling_logprobs=self.output_token_sampling_logprobs,
             output_hidden_states=self.output_hidden_states,
+            spec_capture=self.spec_capture or None,
             routed_experts=self.routed_experts,
             indexer_topk=self.indexer_topk,
             customized_info=(

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1259,6 +1259,10 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         # Validate generation-specific fields
         if isinstance(obj, GenerateReqInput):
             self._validate_token_ids_logprob(obj)
+            if obj.spec_capture is not None and not self.server_args.enable_spec_capture:
+                raise ValueError(
+                    "spec_capture requests require --enable-spec-capture"
+                )
             requested_hidden_mode = get_request_return_hidden_states_mode(
                 obj.return_hidden_states
             )
@@ -1450,6 +1454,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 multi_item_delimiter_indices=obj.multi_item_delimiter_indices,
                 mm_data_mooncake=obj.mm_data_mooncake,
                 encoder_urls=obj.encoder_urls,
+                spec_capture=obj.spec_capture,
             )
         elif isinstance(obj, EmbeddingReqInput):
             # Resolve unresolved embed overrides now that input_ids are available
@@ -2322,6 +2327,10 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 hidden_states = recv_obj.output_hidden_states[i]
                 if hidden_states is not None:
                     meta_info["hidden_states"] = hidden_states
+            if getattr(recv_obj, "spec_capture", None):
+                capture = recv_obj.spec_capture[i]
+                if capture is not None:
+                    meta_info["spec_capture"] = capture
             if getattr(recv_obj, "routed_experts", None):
                 val = recv_obj.routed_experts[i]
                 if val is not None:

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -361,6 +361,7 @@ class ModelRunner:
 
         # auxiliary hidden capture mode. TODO: expose this to server args?
         self.init_spec_aux_hidden_state()
+        self.configure_spec_capture_hidden_state()
 
         # Apply the rank zero filter to logger
         if server_args.show_time_cost:
@@ -545,6 +546,18 @@ class ModelRunner:
                 is_draft_worker=self.is_draft_worker,
             )
         )
+
+    def configure_spec_capture_hidden_state(self) -> None:
+        if not self.server_args.enable_spec_capture or self.is_draft_worker:
+            return
+        layer_ids = self.server_args.spec_capture_aux_layer_ids
+        method = self.server_args.spec_capture_method
+        if method == "eagle3":
+            self.spec_aux_config.eagle_use_aux_hidden_state = True
+            self.spec_aux_config.eagle_aux_hidden_state_layer_ids = layer_ids
+            return
+        self.spec_aux_config.dflash_use_aux_hidden_state = True
+        self.spec_aux_config.dflash_target_layer_ids = layer_ids
 
     def init_weight_exporter(self):
         self.weight_exporter = WeightExporter(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3525,6 +3525,57 @@ class ServerArgs:
         ),
         NS("exec.features"),
     ] = None
+    enable_spec_capture: A[
+        bool,
+        "Enable server-side GPU-direct hidden-state capture for SpecForge.",
+        NS("exec.features"),
+    ] = False
+    spec_capture_aux_layer_ids: A[
+        Optional[List[int]],
+        "Target layer ids concatenated into the auxiliary capture tensor.",
+        NS("exec.features"),
+    ] = None
+    spec_capture_method: A[
+        str,
+        Arg(
+            help="Auxiliary hidden-state capture method.",
+            choices=["eagle3", "dflash", "dspark"],
+        ),
+        NS("exec.features"),
+    ] = "eagle3"
+    spec_capture_transfer_backend: A[
+        str,
+        Arg(
+            help="Mooncake GPU-direct transport used by spec capture.",
+            choices=["nvlink", "nvlink_intra", "rdma"],
+        ),
+        NS("exec.features"),
+    ] = "rdma"
+    spec_capture_control_host: A[
+        Optional[str],
+        "Advertised host for Mooncake handshakes and release acknowledgements.",
+        NS("exec.features"),
+    ] = None
+    spec_capture_control_port: A[
+        int,
+        "TCP control port for GPU buffer release acknowledgements; zero selects a free port.",
+        NS("exec.features"),
+    ] = 0
+    spec_capture_ib_device: A[
+        Optional[str],
+        "RDMA HCA list for the spec-capture Mooncake TransferEngine.",
+        NS("exec.features"),
+    ] = None
+    spec_capture_max_resident_bytes: A[
+        Optional[int],
+        "Maximum GPU bytes retained for unacknowledged spec captures.",
+        NS("exec.features"),
+    ] = None
+    spec_capture_max_pending_batches: A[
+        int,
+        "Maximum queued GPU-direct capture batches before scheduler backpressure.",
+        NS("exec.features"),
+    ] = 2
     enable_return_routed_experts: A[
         bool,
         "Enable returning routed experts of each layer with responses.",

--- a/python/sglang/srt/spec_capture_sink.py
+++ b/python/sglang/srt/spec_capture_sink.py
@@ -1,0 +1,555 @@
+# Copyright 2024 SGLang Team
+# Licensed under the Apache License, Version 2.0
+"""GPU-resident Mooncake sink for SpecForge hidden-state capture.
+
+Captured CUDA tensors are copied on-device into publisher-owned buffers and
+remain resident until the trainer acknowledges consumption.  Mooncake carries
+the tensor payload over MNNVL/NVLink or RDMA; a small TCP endpoint carries only
+descriptors and release messages.
+"""
+
+from __future__ import annotations
+
+import atexit
+import ctypes
+import ctypes.util
+import json
+import logging
+import os
+import secrets
+import socketserver
+import threading
+from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+import torch
+
+from sglang.srt.utils.network import get_local_ip_auto
+
+logger = logging.getLogger(__name__)
+
+_DTYPE_STR = {
+    torch.float32: "float32",
+    torch.float64: "float64",
+    torch.float16: "float16",
+    torch.bfloat16: "bfloat16",
+    torch.int64: "int64",
+    torch.int32: "int32",
+    torch.int16: "int16",
+    torch.int8: "int8",
+    torch.uint8: "uint8",
+    torch.bool: "bool",
+}
+_STR_DTYPE = {value: key for key, value in _DTYPE_STR.items()}
+
+
+def _nbytes(tensor: torch.Tensor) -> int:
+    return tensor.numel() * tensor.element_size()
+
+
+def _load_cudart() -> ctypes.CDLL:
+    for name in (
+        ctypes.util.find_library("cudart"),
+        "libcudart.so.13",
+        "libcudart.so.12",
+        "libcudart.so",
+    ):
+        if not name:
+            continue
+        try:
+            library = ctypes.CDLL(name)
+        except OSError:
+            continue
+        library.cudaMemcpyAsync.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_void_p,
+            ctypes.c_size_t,
+            ctypes.c_int,
+            ctypes.c_void_p,
+        ]
+        library.cudaMemcpyAsync.restype = ctypes.c_int
+        return library
+    raise RuntimeError("unable to load libcudart for MNNVL D2D staging")
+
+
+_CUDART: Optional[ctypes.CDLL] = None
+_CUDART_LOCK = threading.Lock()
+
+
+def _copy_to_address(
+    destination: int,
+    source: int,
+    length: int,
+    *,
+    stream: torch.cuda.Stream,
+) -> None:
+    global _CUDART
+    if _CUDART is None:
+        with _CUDART_LOCK:
+            if _CUDART is None:
+                _CUDART = _load_cudart()
+    status = _CUDART.cudaMemcpyAsync(
+        ctypes.c_void_p(destination),
+        ctypes.c_void_p(source),
+        ctypes.c_size_t(length),
+        3,  # cudaMemcpyDeviceToDevice
+        ctypes.c_void_p(stream.cuda_stream),
+    )
+    if status != 0:
+        raise RuntimeError(f"cudaMemcpyAsync D2D failed with status {status}")
+
+
+@dataclass
+class _PublishedBuffer:
+    address: int
+    nbytes: int
+    shape: Tuple[int, ...]
+    dtype: str
+    tensor: Optional[torch.Tensor]
+    registered: bool
+
+    def descriptor(self) -> Dict[str, Any]:
+        return {
+            "address": self.address,
+            "nbytes": self.nbytes,
+            "shape": list(self.shape),
+            "dtype": self.dtype,
+        }
+
+
+@dataclass
+class _ResidentSample:
+    generation: int
+    buffers: Dict[str, _PublishedBuffer]
+    result: Dict[str, Any]
+
+
+class _ControlServer(socketserver.ThreadingTCPServer):
+    allow_reuse_address = True
+    daemon_threads = True
+
+    def __init__(self, address: Tuple[str, int], owner: "SpecCaptureSink"):
+        self.owner = owner
+        super().__init__(address, _ControlHandler)
+
+
+class _ControlHandler(socketserver.StreamRequestHandler):
+    def handle(self) -> None:
+        try:
+            payload = self.rfile.readline(1 << 20)
+            if not payload:
+                return
+            response = self.server.owner.handle_control(  # type: ignore[attr-defined]
+                json.loads(payload.decode("utf-8"))
+            )
+        except BaseException as exc:
+            response = {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
+        self.wfile.write(
+            json.dumps(response, separators=(",", ":")).encode("utf-8") + b"\n"
+        )
+
+
+class SpecCaptureSink:
+    def __init__(self, server_args) -> None:
+        if not torch.cuda.is_available():
+            raise RuntimeError("GPU-direct spec capture requires CUDA")
+        self.backend = str(server_args.spec_capture_transfer_backend)
+        if self.backend not in {"nvlink", "nvlink_intra", "rdma"}:
+            raise ValueError(f"unsupported spec-capture backend {self.backend!r}")
+        self.device = torch.device("cuda", torch.cuda.current_device())
+        self.aux_layer_ids = (
+            list(server_args.spec_capture_aux_layer_ids)
+            if server_args.spec_capture_aux_layer_ids
+            else None
+        )
+        self.max_resident_bytes = server_args.spec_capture_max_resident_bytes
+        if self.max_resident_bytes is not None and self.max_resident_bytes < 1:
+            raise ValueError("spec_capture_max_resident_bytes must be positive")
+        if server_args.spec_capture_max_pending_batches < 1:
+            raise ValueError("spec_capture_max_pending_batches must be positive")
+
+        advertise_host = server_args.spec_capture_control_host or get_local_ip_auto()
+        self._engine = self._initialize_engine(server_args, advertise_host)
+        self.session_id = f"{advertise_host}:{int(self._engine.get_rpc_port())}"
+        self._copy_stream = torch.cuda.Stream(device=self.device)
+        self._executor = ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix="spec-capture-gpudirect",
+        )
+        self._token = secrets.token_hex(24)
+        self._lock = threading.RLock()
+        self._residents: Dict[str, _ResidentSample] = {}
+        self._closed = False
+        self._stats = {
+            "published_samples": 0,
+            "released_samples": 0,
+            "device_staging_bytes": 0,
+            "host_payload_bytes": 0,
+        }
+
+        self._control_server = _ControlServer(
+            (advertise_host, int(server_args.spec_capture_control_port)), self
+        )
+        control_port = int(self._control_server.server_address[1])
+        self.control_endpoint = f"{advertise_host}:{control_port}"
+        self._control_thread = threading.Thread(
+            target=self._control_server.serve_forever,
+            name="spec-capture-control",
+            daemon=True,
+        )
+        self._control_thread.start()
+        atexit.register(self.close)
+        logger.info(
+            "GPU-direct spec-capture sink initialized: backend=%s session=%s control=%s",
+            self.backend,
+            self.session_id,
+            self.control_endpoint,
+        )
+
+    def _initialize_engine(self, server_args, advertise_host: str):
+        try:
+            from mooncake import engine as mooncake_engine
+        except ImportError as exc:
+            raise ImportError(
+                "GPU-direct spec capture requires mooncake-transfer-engine"
+            ) from exc
+        if self.backend == "nvlink":
+            os.environ["MC_FORCE_MNNVL"] = "true"
+            os.environ.pop("MC_INTRA_NVLINK", None)
+            os.environ.pop("MC_FORCE_HCA", None)
+            if not bool(getattr(mooncake_engine, "SUPPORT_MNNVL", False)):
+                raise RuntimeError("installed Mooncake wheel has SUPPORT_MNNVL=False")
+        elif self.backend == "nvlink_intra":
+            os.environ.pop("MC_FORCE_MNNVL", None)
+            os.environ["MC_INTRA_NVLINK"] = "true"
+            os.environ.pop("MC_FORCE_HCA", None)
+            if not bool(
+                getattr(mooncake_engine, "SUPPORT_INTRA_NVLINK", False)
+            ):
+                raise RuntimeError(
+                    "installed Mooncake wheel has SUPPORT_INTRA_NVLINK=False"
+                )
+        else:
+            os.environ.pop("MC_FORCE_MNNVL", None)
+            os.environ.pop("MC_INTRA_NVLINK", None)
+            os.environ["MC_FORCE_HCA"] = "true"
+        engine = mooncake_engine.TransferEngine()
+        ib_device = ""
+        if self.backend == "rdma":
+            ib_device = (
+                server_args.spec_capture_ib_device
+                or server_args.mooncake_ib_device
+                or server_args.disaggregation_ib_device
+                or ""
+            )
+        status = engine.initialize(
+            advertise_host,
+            "P2PHANDSHAKE",
+            self.backend,
+            ib_device,
+        )
+        if int(status) != 0:
+            raise RuntimeError(
+                f"Mooncake {self.backend} TransferEngine initialization failed: {status}"
+            )
+        return engine
+
+    def _resident_bytes_locked(self) -> int:
+        return sum(
+            buffer.nbytes
+            for sample in self._residents.values()
+            for buffer in sample.buffers.values()
+        )
+
+    def _allocate_buffer(self, source: torch.Tensor) -> _PublishedBuffer:
+        source = source.detach().contiguous()
+        nbytes = _nbytes(source)
+        dtype = _DTYPE_STR.get(
+            source.dtype, str(source.dtype).replace("torch.", "")
+        )
+        if self.backend in {"nvlink", "nvlink_intra"}:
+            address = int(self._engine.allocate_managed_buffer(nbytes))
+            if address == 0:
+                raise MemoryError(f"Mooncake MNNVL allocation failed ({nbytes} bytes)")
+            _copy_to_address(
+                address,
+                source.data_ptr(),
+                nbytes,
+                stream=self._copy_stream,
+            )
+            source.record_stream(self._copy_stream)
+            return _PublishedBuffer(
+                address=address,
+                nbytes=nbytes,
+                shape=tuple(source.shape),
+                dtype=dtype,
+                tensor=None,
+                registered=False,
+            )
+
+        staging = torch.empty_like(source, memory_format=torch.contiguous_format)
+        staging.copy_(source, non_blocking=True)
+        source.record_stream(self._copy_stream)
+        status = self._engine.register_memory(staging.data_ptr(), nbytes)
+        if status is not None and int(status) != 0:
+            raise RuntimeError(
+                f"Mooncake RDMA CUDA registration failed with status {status}"
+            )
+        return _PublishedBuffer(
+            address=staging.data_ptr(),
+            nbytes=nbytes,
+            shape=tuple(staging.shape),
+            dtype=dtype,
+            tensor=staging,
+            registered=True,
+        )
+
+    def _free_buffer(self, buffer: _PublishedBuffer) -> None:
+        if self.backend in {"nvlink", "nvlink_intra"}:
+            status = self._engine.free_managed_buffer(buffer.address, buffer.nbytes)
+        elif buffer.registered:
+            status = self._engine.unregister_memory(buffer.address)
+        else:
+            status = 0
+        if status is not None and int(status) != 0:
+            raise RuntimeError(
+                f"Mooncake buffer release failed with status {status}"
+            )
+        buffer.tensor = None
+
+    def _free_sample_locked(self, sample_id: str, generation: int) -> int:
+        resident = self._residents.get(sample_id)
+        if resident is None:
+            return 0
+        if resident.generation != generation:
+            raise RuntimeError(
+                f"stale release for {sample_id!r}: generation {generation} != "
+                f"{resident.generation}"
+            )
+        freed = 0
+        for buffer in resident.buffers.values():
+            self._free_buffer(buffer)
+            freed += buffer.nbytes
+        self._residents.pop(sample_id, None)
+        return freed
+
+    def _prepare_tensors(
+        self,
+        spec: Dict[str, Any],
+        aux: Optional[torch.Tensor],
+        last_hidden: Optional[torch.Tensor],
+    ) -> Dict[str, torch.Tensor]:
+        requested_transport = spec.get("transport")
+        if requested_transport is not None and str(requested_transport) != self.backend:
+            raise ValueError(
+                f"request expects transport {requested_transport!r}; "
+                f"server uses {self.backend!r}"
+            )
+        features = dict(spec.get("features") or {})
+        tensors: Dict[str, torch.Tensor] = {}
+        aux_name = features.get("aux")
+        if aux_name is not None:
+            if aux is None:
+                raise RuntimeError("spec_capture requested aux but none was captured")
+            tensors[str(aux_name)] = aux.unsqueeze(0)
+        last_name = features.get("last_hidden")
+        if last_name is not None:
+            if last_hidden is None:
+                raise RuntimeError(
+                    "spec_capture requested last_hidden but none was captured"
+                )
+            tensors[str(last_name)] = last_hidden.unsqueeze(0)
+
+        for item in spec.get("passthrough") or []:
+            dtype = _STR_DTYPE.get(str(item.get("dtype", "int64")))
+            if dtype is None:
+                raise TypeError(
+                    f"unsupported passthrough dtype {item.get('dtype')!r}"
+                )
+            tensors[str(item["name"])] = torch.tensor(
+                item["data"],
+                dtype=dtype,
+                device=self.device,
+            ).reshape([int(dim) for dim in item["shape"]])
+        if not tensors:
+            raise ValueError("spec_capture request contains no features")
+        return tensors
+
+    def _stage_samples(self, samples):
+        staged = []
+        new_bytes = 0
+        source_stream = torch.cuda.current_stream(self.device)
+        with torch.cuda.device(self.device), torch.cuda.stream(self._copy_stream):
+            self._copy_stream.wait_stream(source_stream)
+            try:
+                for spec, aux, last_hidden in samples:
+                    tensors = self._prepare_tensors(spec, aux, last_hidden)
+                    buffers: Dict[str, _PublishedBuffer] = {}
+                    try:
+                        for name, tensor in tensors.items():
+                            buffers[name] = self._allocate_buffer(tensor)
+                    except BaseException:
+                        self._copy_stream.synchronize()
+                        for buffer in buffers.values():
+                            self._free_buffer(buffer)
+                        raise
+                    new_bytes += sum(buffer.nbytes for buffer in buffers.values())
+                    staged.append((spec, buffers))
+                done = torch.cuda.Event()
+                done.record(self._copy_stream)
+            except BaseException:
+                self._copy_stream.synchronize()
+                for _, buffers in staged:
+                    for buffer in buffers.values():
+                        self._free_buffer(buffer)
+                raise
+
+        try:
+            with self._lock:
+                replacing_bytes = 0
+                for spec, _ in staged:
+                    prior = self._residents.get(str(spec["sample_id"]))
+                    if prior is not None:
+                        if not bool(spec.get("replace", False)):
+                            raise RuntimeError(
+                                f"sample {spec['sample_id']!r} is already resident"
+                            )
+                        replacing_bytes += sum(
+                            buffer.nbytes for buffer in prior.buffers.values()
+                        )
+                projected = (
+                    self._resident_bytes_locked() - replacing_bytes + new_bytes
+                )
+                if (
+                    self.max_resident_bytes is not None
+                    and projected > self.max_resident_bytes
+                ):
+                    raise MemoryError(
+                        f"GPU-direct capture residency {projected} exceeds "
+                        f"{self.max_resident_bytes} bytes"
+                    )
+                for spec, _ in staged:
+                    sample_id = str(spec["sample_id"])
+                    prior = self._residents.get(sample_id)
+                    if prior is not None:
+                        self._free_sample_locked(sample_id, prior.generation)
+        except BaseException:
+            done.synchronize()
+            for _, buffers in staged:
+                for buffer in buffers.values():
+                    self._free_buffer(buffer)
+            raise
+        return done, staged
+
+    def _commit_samples(self, event: torch.cuda.Event, staged):
+        committed_sample_ids = []
+        try:
+            event.synchronize()
+            results = []
+            with self._lock:
+                for spec, buffers in staged:
+                    sample_id = str(spec["sample_id"])
+                    store_id = str(spec["store_id"])
+                    generation = int(spec.get("gen", 1))
+                    result = {
+                        "sample_id": sample_id,
+                        "store_id": store_id,
+                        "gen": generation,
+                        "transport": self.backend,
+                        "session_id": self.session_id,
+                        "control_endpoint": self.control_endpoint,
+                        "control_token": self._token,
+                        "aux_layer_ids": self.aux_layer_ids,
+                        "features": {
+                            name: buffer.descriptor()
+                            for name, buffer in buffers.items()
+                        },
+                    }
+                    self._residents[sample_id] = _ResidentSample(
+                        generation=generation,
+                        buffers=buffers,
+                        result=result,
+                    )
+                    committed_sample_ids.append(sample_id)
+                    results.append(result)
+                    sample_bytes = sum(
+                        buffer.nbytes for buffer in buffers.values()
+                    )
+                    self._stats["published_samples"] += 1
+                    self._stats["device_staging_bytes"] += sample_bytes
+            return results
+        except BaseException:
+            with self._lock:
+                for sample_id in committed_sample_ids:
+                    self._residents.pop(sample_id, None)
+                for _, buffers in staged:
+                    for buffer in buffers.values():
+                        try:
+                            self._free_buffer(buffer)
+                        except Exception:
+                            logger.exception("failed to reclaim staged capture buffer")
+            raise
+
+    def submit_samples(self, samples) -> Future[List[Dict[str, Any]]]:
+        try:
+            event, staged = self._stage_samples(samples)
+        except BaseException as exc:
+            future: Future[List[Dict[str, Any]]] = Future()
+            future.set_exception(exc)
+            return future
+        return self._executor.submit(self._commit_samples, event, staged)
+
+    def health(self) -> Dict[str, Any]:
+        with self._lock:
+            return {
+                "backend": self.backend,
+                "session_id": self.session_id,
+                "control_endpoint": self.control_endpoint,
+                "resident_samples": len(self._residents),
+                "resident_bytes": self._resident_bytes_locked(),
+                **self._stats,
+            }
+
+    def handle_control(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        if request.get("op") == "health":
+            return {"ok": True, "health": self.health()}
+        if request.get("token") != self._token:
+            return {"ok": False, "error": "invalid control token"}
+        if request.get("op") not in {"release", "abort"}:
+            return {"ok": False, "error": "unsupported control operation"}
+        sample_id = str(request["sample_id"])
+        generation = int(request["generation"])
+        with self._lock:
+            freed = self._free_sample_locked(sample_id, generation)
+            self._stats["released_samples"] += 1
+        return {"ok": True, "freed_bytes": freed}
+
+    def close(self) -> None:
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+        self._executor.shutdown(wait=True, cancel_futures=False)
+        with self._lock:
+            for sample_id, resident in list(self._residents.items()):
+                self._free_sample_locked(sample_id, resident.generation)
+        self._control_server.shutdown()
+        self._control_server.server_close()
+        self._control_thread.join(timeout=5.0)
+
+
+_SINK: Optional[SpecCaptureSink] = None
+
+
+def maybe_init_sink(server_args) -> None:
+    global _SINK
+    if server_args.enable_spec_capture and _SINK is None:
+        _SINK = SpecCaptureSink(server_args)
+
+
+def get_sink() -> Optional[SpecCaptureSink]:
+    return _SINK
+
+
+__all__ = ["SpecCaptureSink", "get_sink", "maybe_init_sink"]

--- a/python/sglang/srt/spec_capture_sink.py
+++ b/python/sglang/srt/spec_capture_sink.py
@@ -70,12 +70,48 @@ def _load_cudart() -> ctypes.CDLL:
             ctypes.c_void_p,
         ]
         library.cudaMemcpyAsync.restype = ctypes.c_int
+        library.cudaMalloc.argtypes = [
+            ctypes.POINTER(ctypes.c_void_p),
+            ctypes.c_size_t,
+        ]
+        library.cudaMalloc.restype = ctypes.c_int
+        library.cudaFree.argtypes = [ctypes.c_void_p]
+        library.cudaFree.restype = ctypes.c_int
         return library
-    raise RuntimeError("unable to load libcudart for MNNVL D2D staging")
+    raise RuntimeError("unable to load libcudart for GPU-direct staging")
 
 
 _CUDART: Optional[ctypes.CDLL] = None
 _CUDART_LOCK = threading.Lock()
+
+
+def _get_cudart() -> ctypes.CDLL:
+    global _CUDART
+    if _CUDART is None:
+        with _CUDART_LOCK:
+            if _CUDART is None:
+                _CUDART = _load_cudart()
+    return _CUDART
+
+
+def _cuda_malloc(nbytes: int) -> int:
+    address = ctypes.c_void_p()
+    status = _get_cudart().cudaMalloc(
+        ctypes.byref(address),
+        ctypes.c_size_t(nbytes),
+    )
+    if status != 0 or address.value is None:
+        raise MemoryError(
+            f"cudaMalloc failed for GPU-direct arena ({nbytes} bytes): "
+            f"status {status}"
+        )
+    return int(address.value)
+
+
+def _cuda_free(address: int) -> None:
+    status = _get_cudart().cudaFree(ctypes.c_void_p(address))
+    if status != 0:
+        raise RuntimeError(f"cudaFree failed with status {status}")
 
 
 def _copy_to_address(
@@ -85,12 +121,7 @@ def _copy_to_address(
     *,
     stream: torch.cuda.Stream,
 ) -> None:
-    global _CUDART
-    if _CUDART is None:
-        with _CUDART_LOCK:
-            if _CUDART is None:
-                _CUDART = _load_cudart()
-    status = _CUDART.cudaMemcpyAsync(
+    status = _get_cudart().cudaMemcpyAsync(
         ctypes.c_void_p(destination),
         ctypes.c_void_p(source),
         ctypes.c_size_t(length),
@@ -187,6 +218,8 @@ class SpecCaptureSink:
         self._arena_address = 0
         self._arena_bytes = 0
         self._arena_free: List[Tuple[int, int]] = []
+        self._arena_registered = False
+        self._arena_cuda_allocated = False
         if self.backend in {"nvlink", "nvlink_intra"}:
             if self.max_resident_bytes is None:
                 raise ValueError(
@@ -203,6 +236,31 @@ class SpecCaptureSink:
                     f"Mooncake MNNVL arena allocation failed "
                     f"({self._arena_bytes} bytes)"
                 )
+            self._arena_free = [(0, self._arena_bytes)]
+        elif self.max_resident_bytes is not None:
+            # PyTorch expandable segments use CUDA VMM addresses that
+            # nvidia-peermem may reject. Keep one raw cudaMalloc allocation
+            # registered for the RDMA process lifetime and suballocate it.
+            self._arena_bytes = int(self.max_resident_bytes)
+            self._arena_address = _cuda_malloc(self._arena_bytes)
+            self._arena_cuda_allocated = True
+            try:
+                with self._engine_lock:
+                    status = self._engine.register_memory(
+                        self._arena_address, self._arena_bytes
+                    )
+                if status is not None and int(status) != 0:
+                    raise RuntimeError(
+                        "Mooncake RDMA arena registration failed with status "
+                        f"{status}"
+                    )
+            except BaseException:
+                _cuda_free(self._arena_address)
+                self._arena_address = 0
+                self._arena_bytes = 0
+                self._arena_cuda_allocated = False
+                raise
+            self._arena_registered = True
             self._arena_free = [(0, self._arena_bytes)]
         self._copy_stream = torch.cuda.Stream(device=self.device)
         self._executor = ThreadPoolExecutor(
@@ -359,7 +417,7 @@ class SpecCaptureSink:
         dtype = _DTYPE_STR.get(
             source.dtype, str(source.dtype).replace("torch.", "")
         )
-        if self.backend in {"nvlink", "nvlink_intra"}:
+        if self._arena_address:
             with self._lock:
                 allocation_offset, allocation_nbytes = (
                     self._arena_allocate_locked(nbytes)
@@ -403,7 +461,7 @@ class SpecCaptureSink:
         )
 
     def _free_buffer(self, buffer: _PublishedBuffer) -> None:
-        if self.backend in {"nvlink", "nvlink_intra"}:
+        if self._arena_address and buffer.tensor is None:
             with self._lock:
                 self._arena_free_locked(
                     buffer.allocation_offset,
@@ -701,14 +759,30 @@ class SpecCaptureSink:
             for sample_id, resident in list(self._residents.items()):
                 self._free_sample_locked(sample_id, resident.generation)
         if self._arena_address:
-            with self._engine_lock:
-                status = self._engine.free_managed_buffer(
-                    self._arena_address, self._arena_bytes
-                )
-            if status is not None and int(status) != 0:
-                logger.error(
-                    "Mooncake arena release failed with status %s", status
-                )
+            if self._arena_registered:
+                with self._engine_lock:
+                    status = self._engine.unregister_memory(self._arena_address)
+                if status is not None and int(status) != 0:
+                    logger.error(
+                        "Mooncake RDMA arena unregister failed with status %s",
+                        status,
+                    )
+                self._arena_registered = False
+            if self._arena_cuda_allocated:
+                try:
+                    _cuda_free(self._arena_address)
+                except RuntimeError:
+                    logger.exception("CUDA arena release failed")
+                self._arena_cuda_allocated = False
+            else:
+                with self._engine_lock:
+                    status = self._engine.free_managed_buffer(
+                        self._arena_address, self._arena_bytes
+                    )
+                if status is not None and int(status) != 0:
+                    logger.error(
+                        "Mooncake arena release failed with status %s", status
+                    )
             self._arena_address = 0
         self._control_server.shutdown()
         self._control_server.server_close()

--- a/python/sglang/srt/spec_capture_sink.py
+++ b/python/sglang/srt/spec_capture_sink.py
@@ -42,6 +42,7 @@ _DTYPE_STR = {
     torch.bool: "bool",
 }
 _STR_DTYPE = {value: key for key, value in _DTYPE_STR.items()}
+_MAX_CONTROL_BATCH = 4096
 
 
 def _nbytes(tensor: torch.Tensor) -> int:
@@ -104,6 +105,8 @@ def _copy_to_address(
 class _PublishedBuffer:
     address: int
     nbytes: int
+    allocation_offset: int
+    allocation_nbytes: int
     shape: Tuple[int, ...]
     dtype: str
     tensor: Optional[torch.Tensor]
@@ -135,22 +138,29 @@ class _ControlServer(socketserver.ThreadingTCPServer):
 
 
 class _ControlHandler(socketserver.StreamRequestHandler):
+    disable_nagle_algorithm = True
+
     def handle(self) -> None:
-        try:
-            payload = self.rfile.readline(1 << 20)
-            if not payload:
-                return
-            response = self.server.owner.handle_control(  # type: ignore[attr-defined]
-                json.loads(payload.decode("utf-8"))
+        while True:
+            try:
+                payload = self.rfile.readline(1 << 20)
+                if not payload:
+                    return
+                response = self.server.owner.handle_control(  # type: ignore[attr-defined]
+                    json.loads(payload.decode("utf-8"))
+                )
+            except BaseException as exc:
+                response = {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
+            self.wfile.write(
+                json.dumps(response, separators=(",", ":")).encode("utf-8")
+                + b"\n"
             )
-        except BaseException as exc:
-            response = {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
-        self.wfile.write(
-            json.dumps(response, separators=(",", ":")).encode("utf-8") + b"\n"
-        )
+            self.wfile.flush()
 
 
 class SpecCaptureSink:
+    _ARENA_ALIGNMENT = 256
+
     def __init__(self, server_args) -> None:
         if not torch.cuda.is_available():
             raise RuntimeError("GPU-direct spec capture requires CUDA")
@@ -170,22 +180,47 @@ class SpecCaptureSink:
             raise ValueError("spec_capture_max_pending_batches must be positive")
 
         advertise_host = server_args.spec_capture_control_host or get_local_ip_auto()
+        self._lock = threading.RLock()
+        self._engine_lock = threading.RLock()
         self._engine = self._initialize_engine(server_args, advertise_host)
         self.session_id = f"{advertise_host}:{int(self._engine.get_rpc_port())}"
+        self._arena_address = 0
+        self._arena_bytes = 0
+        self._arena_free: List[Tuple[int, int]] = []
+        if self.backend in {"nvlink", "nvlink_intra"}:
+            if self.max_resident_bytes is None:
+                raise ValueError(
+                    "NVLink GPU-direct capture requires "
+                    "spec_capture_max_resident_bytes for its fixed arena"
+                )
+            self._arena_bytes = int(self.max_resident_bytes)
+            with self._engine_lock:
+                self._arena_address = int(
+                    self._engine.allocate_managed_buffer(self._arena_bytes)
+                )
+            if self._arena_address == 0:
+                raise MemoryError(
+                    f"Mooncake MNNVL arena allocation failed "
+                    f"({self._arena_bytes} bytes)"
+                )
+            self._arena_free = [(0, self._arena_bytes)]
         self._copy_stream = torch.cuda.Stream(device=self.device)
         self._executor = ThreadPoolExecutor(
             max_workers=1,
             thread_name_prefix="spec-capture-gpudirect",
         )
         self._token = secrets.token_hex(24)
-        self._lock = threading.RLock()
         self._residents: Dict[str, _ResidentSample] = {}
+        self._reserved_bytes = 0
         self._closed = False
         self._stats = {
             "published_samples": 0,
             "released_samples": 0,
             "device_staging_bytes": 0,
             "host_payload_bytes": 0,
+            "control_requests": 0,
+            "control_batch_requests": 0,
+            "control_batch_items": 0,
         }
 
         self._control_server = _ControlServer(
@@ -201,10 +236,13 @@ class SpecCaptureSink:
         self._control_thread.start()
         atexit.register(self.close)
         logger.info(
-            "GPU-direct spec-capture sink initialized: backend=%s session=%s control=%s",
+            "GPU-direct spec-capture sink initialized: backend=%s session=%s "
+            "control=%s arena_address=%s arena_bytes=%d",
             self.backend,
             self.session_id,
             self.control_endpoint,
+            hex(self._arena_address) if self._arena_address else None,
+            self._arena_bytes,
         )
 
     def _initialize_engine(self, server_args, advertise_host: str):
@@ -262,6 +300,59 @@ class SpecCaptureSink:
             for buffer in sample.buffers.values()
         )
 
+    def _resident_allocated_bytes_locked(self) -> int:
+        return sum(
+            buffer.allocation_nbytes
+            for sample in self._residents.values()
+            for buffer in sample.buffers.values()
+        )
+
+    @classmethod
+    def _aligned_nbytes(cls, nbytes: int) -> int:
+        alignment = cls._ARENA_ALIGNMENT
+        return (nbytes + alignment - 1) & ~(alignment - 1)
+
+    def _arena_allocate_locked(self, nbytes: int) -> Tuple[int, int]:
+        allocation_nbytes = self._aligned_nbytes(nbytes)
+        candidates = [
+            (length, index, offset)
+            for index, (offset, length) in enumerate(self._arena_free)
+            if length >= allocation_nbytes
+        ]
+        if not candidates:
+            largest = max((length for _, length in self._arena_free), default=0)
+            raise MemoryError(
+                f"GPU-direct arena cannot fit {allocation_nbytes} bytes; "
+                f"largest free span is {largest} bytes"
+            )
+        length, index, offset = min(candidates)
+        remaining = length - allocation_nbytes
+        if remaining:
+            self._arena_free[index] = (
+                offset + allocation_nbytes,
+                remaining,
+            )
+        else:
+            self._arena_free.pop(index)
+        return offset, allocation_nbytes
+
+    def _arena_free_locked(self, offset: int, nbytes: int) -> None:
+        if nbytes == 0:
+            return
+        self._arena_free.append((offset, nbytes))
+        self._arena_free.sort()
+        merged: List[Tuple[int, int]] = []
+        for current_offset, current_length in self._arena_free:
+            if merged and merged[-1][0] + merged[-1][1] == current_offset:
+                prior_offset, prior_length = merged[-1]
+                merged[-1] = (
+                    prior_offset,
+                    prior_length + current_length,
+                )
+            else:
+                merged.append((current_offset, current_length))
+        self._arena_free = merged
+
     def _allocate_buffer(self, source: torch.Tensor) -> _PublishedBuffer:
         source = source.detach().contiguous()
         nbytes = _nbytes(source)
@@ -269,9 +360,11 @@ class SpecCaptureSink:
             source.dtype, str(source.dtype).replace("torch.", "")
         )
         if self.backend in {"nvlink", "nvlink_intra"}:
-            address = int(self._engine.allocate_managed_buffer(nbytes))
-            if address == 0:
-                raise MemoryError(f"Mooncake MNNVL allocation failed ({nbytes} bytes)")
+            with self._lock:
+                allocation_offset, allocation_nbytes = (
+                    self._arena_allocate_locked(nbytes)
+                )
+            address = self._arena_address + allocation_offset
             _copy_to_address(
                 address,
                 source.data_ptr(),
@@ -282,6 +375,8 @@ class SpecCaptureSink:
             return _PublishedBuffer(
                 address=address,
                 nbytes=nbytes,
+                allocation_offset=allocation_offset,
+                allocation_nbytes=allocation_nbytes,
                 shape=tuple(source.shape),
                 dtype=dtype,
                 tensor=None,
@@ -299,6 +394,8 @@ class SpecCaptureSink:
         return _PublishedBuffer(
             address=staging.data_ptr(),
             nbytes=nbytes,
+            allocation_offset=0,
+            allocation_nbytes=nbytes,
             shape=tuple(staging.shape),
             dtype=dtype,
             tensor=staging,
@@ -307,7 +404,13 @@ class SpecCaptureSink:
 
     def _free_buffer(self, buffer: _PublishedBuffer) -> None:
         if self.backend in {"nvlink", "nvlink_intra"}:
-            status = self._engine.free_managed_buffer(buffer.address, buffer.nbytes)
+            with self._lock:
+                self._arena_free_locked(
+                    buffer.allocation_offset,
+                    buffer.allocation_nbytes,
+                )
+                buffer.allocation_nbytes = 0
+            status = 0
         elif buffer.registered:
             status = self._engine.unregister_memory(buffer.address)
         else:
@@ -377,73 +480,85 @@ class SpecCaptureSink:
         return tensors
 
     def _stage_samples(self, samples):
-        staged = []
+        prepared = []
         new_bytes = 0
+        new_allocated_bytes = 0
+        for spec, aux, last_hidden in samples:
+            tensors = self._prepare_tensors(spec, aux, last_hidden)
+            prepared.append((spec, tensors))
+            new_bytes += sum(_nbytes(tensor) for tensor in tensors.values())
+            new_allocated_bytes += sum(
+                self._aligned_nbytes(_nbytes(tensor))
+                for tensor in tensors.values()
+            )
+
+        # Reserve capacity before calling into Mooncake.  The previous ordering
+        # allocated every buffer first and checked the cap afterwards, allowing
+        # the native allocator to exhaust device memory before backpressure.
+        with self._lock:
+            for spec, _ in prepared:
+                prior = self._residents.get(str(spec["sample_id"]))
+                if prior is not None:
+                    if not bool(spec.get("replace", False)):
+                        raise RuntimeError(
+                            f"sample {spec['sample_id']!r} is already resident"
+                        )
+            projected = (
+                self._resident_allocated_bytes_locked()
+                + self._reserved_bytes
+                + new_allocated_bytes
+            )
+            if (
+                self.max_resident_bytes is not None
+                and projected > self.max_resident_bytes
+            ):
+                raise MemoryError(
+                    f"GPU-direct capture residency {projected} exceeds "
+                    f"{self.max_resident_bytes} bytes"
+                )
+            self._reserved_bytes += new_allocated_bytes
+
+        staged = []
         source_stream = torch.cuda.current_stream(self.device)
-        with torch.cuda.device(self.device), torch.cuda.stream(self._copy_stream):
-            self._copy_stream.wait_stream(source_stream)
-            try:
-                for spec, aux, last_hidden in samples:
-                    tensors = self._prepare_tensors(spec, aux, last_hidden)
-                    buffers: Dict[str, _PublishedBuffer] = {}
-                    try:
-                        for name, tensor in tensors.items():
-                            buffers[name] = self._allocate_buffer(tensor)
-                    except BaseException:
-                        self._copy_stream.synchronize()
+        try:
+            with torch.cuda.device(self.device), torch.cuda.stream(self._copy_stream):
+                self._copy_stream.wait_stream(source_stream)
+                try:
+                    for spec, tensors in prepared:
+                        buffers: Dict[str, _PublishedBuffer] = {}
+                        try:
+                            for name, tensor in tensors.items():
+                                buffers[name] = self._allocate_buffer(tensor)
+                        except BaseException:
+                            self._copy_stream.synchronize()
+                            for buffer in buffers.values():
+                                self._free_buffer(buffer)
+                            raise
+                        staged.append((spec, buffers))
+                    done = torch.cuda.Event()
+                    done.record(self._copy_stream)
+                except BaseException:
+                    self._copy_stream.synchronize()
+                    for _, buffers in staged:
                         for buffer in buffers.values():
                             self._free_buffer(buffer)
-                        raise
-                    new_bytes += sum(buffer.nbytes for buffer in buffers.values())
-                    staged.append((spec, buffers))
-                done = torch.cuda.Event()
-                done.record(self._copy_stream)
-            except BaseException:
-                self._copy_stream.synchronize()
-                for _, buffers in staged:
-                    for buffer in buffers.values():
-                        self._free_buffer(buffer)
-                raise
+                    raise
 
-        try:
             with self._lock:
-                replacing_bytes = 0
-                for spec, _ in staged:
-                    prior = self._residents.get(str(spec["sample_id"]))
-                    if prior is not None:
-                        if not bool(spec.get("replace", False)):
-                            raise RuntimeError(
-                                f"sample {spec['sample_id']!r} is already resident"
-                            )
-                        replacing_bytes += sum(
-                            buffer.nbytes for buffer in prior.buffers.values()
-                        )
-                projected = (
-                    self._resident_bytes_locked() - replacing_bytes + new_bytes
-                )
-                if (
-                    self.max_resident_bytes is not None
-                    and projected > self.max_resident_bytes
-                ):
-                    raise MemoryError(
-                        f"GPU-direct capture residency {projected} exceeds "
-                        f"{self.max_resident_bytes} bytes"
-                    )
                 for spec, _ in staged:
                     sample_id = str(spec["sample_id"])
                     prior = self._residents.get(sample_id)
                     if prior is not None:
                         self._free_sample_locked(sample_id, prior.generation)
         except BaseException:
-            done.synchronize()
-            for _, buffers in staged:
-                for buffer in buffers.values():
-                    self._free_buffer(buffer)
+            with self._lock:
+                self._reserved_bytes -= new_allocated_bytes
             raise
-        return done, staged
+        return done, staged, new_allocated_bytes
 
-    def _commit_samples(self, event: torch.cuda.Event, staged):
+    def _commit_samples(self, event: torch.cuda.Event, staged, reserved_bytes: int):
         committed_sample_ids = []
+        reservation_released = False
         try:
             event.synchronize()
             results = []
@@ -478,9 +593,13 @@ class SpecCaptureSink:
                     )
                     self._stats["published_samples"] += 1
                     self._stats["device_staging_bytes"] += sample_bytes
+                self._reserved_bytes -= reserved_bytes
+                reservation_released = True
             return results
         except BaseException:
             with self._lock:
+                if not reservation_released:
+                    self._reserved_bytes -= reserved_bytes
                 for sample_id in committed_sample_ids:
                     self._residents.pop(sample_id, None)
                 for _, buffers in staged:
@@ -493,12 +612,14 @@ class SpecCaptureSink:
 
     def submit_samples(self, samples) -> Future[List[Dict[str, Any]]]:
         try:
-            event, staged = self._stage_samples(samples)
+            event, staged, reserved_bytes = self._stage_samples(samples)
         except BaseException as exc:
             future: Future[List[Dict[str, Any]]] = Future()
             future.set_exception(exc)
             return future
-        return self._executor.submit(self._commit_samples, event, staged)
+        return self._executor.submit(
+            self._commit_samples, event, staged, reserved_bytes
+        )
 
     def health(self) -> Dict[str, Any]:
         with self._lock:
@@ -508,22 +629,67 @@ class SpecCaptureSink:
                 "control_endpoint": self.control_endpoint,
                 "resident_samples": len(self._residents),
                 "resident_bytes": self._resident_bytes_locked(),
+                "resident_allocated_bytes": self._resident_allocated_bytes_locked(),
+                "reserved_bytes": self._reserved_bytes,
+                "arena_address": self._arena_address,
+                "arena_bytes": self._arena_bytes,
+                "arena_free_bytes": sum(length for _, length in self._arena_free),
+                "arena_largest_free_span": max(
+                    (length for _, length in self._arena_free), default=0
+                ),
                 **self._stats,
             }
 
     def handle_control(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        with self._lock:
+            self._stats["control_requests"] += 1
         if request.get("op") == "health":
             return {"ok": True, "health": self.health()}
         if request.get("token") != self._token:
             return {"ok": False, "error": "invalid control token"}
-        if request.get("op") not in {"release", "abort"}:
+        operation = request.get("op")
+        if operation not in {"release", "abort", "release_batch", "abort_batch"}:
             return {"ok": False, "error": "unsupported control operation"}
-        sample_id = str(request["sample_id"])
-        generation = int(request["generation"])
+        if operation in {"release_batch", "abort_batch"}:
+            items = request.get("items")
+            if not isinstance(items, list) or not items:
+                return {"ok": False, "error": "control batch requires items"}
+            if len(items) > _MAX_CONTROL_BATCH:
+                return {
+                    "ok": False,
+                    "error": (
+                        f"control batch has {len(items)} items; "
+                        f"limit is {_MAX_CONTROL_BATCH}"
+                    ),
+                }
+            normalized = [
+                (str(item["sample_id"]), int(item["generation"]))
+                for item in items
+            ]
+        else:
+            normalized = [
+                (str(request["sample_id"]), int(request["generation"]))
+            ]
         with self._lock:
-            freed = self._free_sample_locked(sample_id, generation)
-            self._stats["released_samples"] += 1
-        return {"ok": True, "freed_bytes": freed}
+            # Validate every live generation before mutating any resident entry.
+            # This makes a retry after a failed batch safe and deterministic.
+            for sample_id, generation in normalized:
+                resident = self._residents.get(sample_id)
+                if resident is not None and resident.generation != generation:
+                    raise RuntimeError(
+                        f"stale release for {sample_id!r}: generation "
+                        f"{generation} != {resident.generation}"
+                    )
+            freed = sum(
+                self._free_sample_locked(sample_id, generation)
+                for sample_id, generation in normalized
+            )
+            released = len(normalized)
+            self._stats["released_samples"] += released
+            if operation in {"release_batch", "abort_batch"}:
+                self._stats["control_batch_requests"] += 1
+                self._stats["control_batch_items"] += released
+        return {"ok": True, "freed_bytes": freed, "released_samples": released}
 
     def close(self) -> None:
         with self._lock:
@@ -534,6 +700,16 @@ class SpecCaptureSink:
         with self._lock:
             for sample_id, resident in list(self._residents.items()):
                 self._free_sample_locked(sample_id, resident.generation)
+        if self._arena_address:
+            with self._engine_lock:
+                status = self._engine.free_managed_buffer(
+                    self._arena_address, self._arena_bytes
+                )
+            if status is not None and int(status) != 0:
+                logger.error(
+                    "Mooncake arena release failed with status %s", status
+                )
+            self._arena_address = 0
         self._control_server.shutdown()
         self._control_server.server_close()
         self._control_thread.join(timeout=5.0)


### PR DESCRIPTION
## Summary

- capture auxiliary and final hidden states on GPU for per-request SpecForge requests
- publish source buffers through Mooncake nvlink, nvlink_intra, or rdma transports
- keep hidden-state payloads off host memory and return only GPU buffer descriptors
- retain source buffers until consumer release acknowledgement, with pending-batch and resident-byte bounds
- force MNNVL for NVL72, intra-node NVLink for H200-class nodes, and HCA for RDMA

## Hardware benchmark

Run on 2026-08-21 UTC. The target host had 8x NVIDIA H200 (driver 580.105.08) split into two TP4 replicas. A second H200 host ran the consumer on one GPU. The target was Qwen3.8-27B-FP8 with DSpark taps `[5, 19, 33, 47, 61]`; capture used Mooncake RDMA and a 32 GiB resident cap per replica.

The repository base does not expose the GPU-direct capture endpoint, so the same protocol cannot run there. The controlled comparison uses the first functional implementation (`dbfed03cd8d8`) as the baseline and PR head (`60e519391d59`) as the post-change target. SpecForge was fixed at `9ce0b698c98c`. Each reported value is the median of two completed 512-sample runs with `max_length=8192`, concurrency 64, lease 8, prompt prefetch 4, ingest batch 128, least-tokens replica routing, length-bucketed requests, and overlapped capture/materialization.

| Metric | Baseline | PR head | Change |
| --- | ---: | ---: | ---: |
| Capture throughput (samples/s) | 52.1199 | 67.2924 | +29.11% |
| Active RDMA materialization (samples/s) | 108.8696 | 120.6860 | +10.85% |
| Pipeline throughput (samples/s) | 48.6419 | 61.9381 | +27.33% |
| Pipeline elapsed (s) | 10.5319 | 8.2663 | -21.51% |
| Durable cleanup (s) | 0.9571 | 0.0056 | -99.41% |

Every completed run produced and removed all 512 samples, transferred 40,503,867,376 bytes, and reported zero host payload bytes. After each PR-head run, both control endpoints reported `resident_samples=0`, `resident_bytes=0`, `reserved_bytes=0`, `published_samples == released_samples`, and the full 32 GiB arena free.

The 1024-sample stress case was excluded from throughput statistics: this benchmark retains every sample until its final durable acknowledgement, so two 32 GiB replicas cannot hold the full retained set. Both baseline and head reached the configured per-replica resident cap and returned `GPU-direct capture residency ... exceeds 34359738368 bytes`.

Builds, unit tests, integration tests, and CI were not run as part of this hardware benchmark.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
