### PR TITLE
feat(spec): allow independent draft model config overrides

### DIFF
--- a/docs/docs/advanced_features/speculative_decoding.mdx
+++ b/docs/docs/advanced_features/speculative_decoding.mdx
@@ -213,6 +213,11 @@ To enable EAGLE speculative decoding the following parameters are relevant:
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>None</code> (auto-set to <code>"main"</code> when <code>--speculative-draft-model-path</code> is set and revision is omitted)</td>
     </tr>
     <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-draft-model-override-args</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>JSON configuration overrides for the draft checkpoint.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Same as <code>--json-model-override-args</code></td>
+    </tr>
+    <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-draft-load-format</code></td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Load format for the draft model weights.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>None</code></td>
@@ -759,6 +764,12 @@ Below is a comprehensive list of all speculative decoding parameters available i
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>str</code></td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>None</code></td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Specific revision/commit of the draft model (<code>"main"</code> is auto-used when draft path is set and revision is omitted)</td>
+    </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-draft-model-override-args</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>str</code> (JSON)</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Same as target</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Configuration overrides for the draft checkpoint. When unset, inherits <code>--json-model-override-args</code>.</td>
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-draft-load-format</code></td>

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -99,7 +99,9 @@ def handle_speculative_decoding(server_args: ServerArgs) -> None:
             "select the non-overlap (synchronous) path."
         )
 
-    kwargs = _draft_config_kwargs(server_args)
+    kwargs = {}
+    if server_args.speculative_draft_model_path:
+        kwargs = _draft_config_kwargs(server_args)
 
     server_args.speculative_algorithm = _resolve_speculative_algorithm_alias(
         server_args.speculative_algorithm,

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -11,6 +11,16 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _draft_config_kwargs(server_args: ServerArgs) -> dict:
+    kwargs = {
+        "model_override_args": json.loads(server_args.get_draft_model_override_args())
+    }
+    override_config_file = server_args.decrypted_draft_config_file
+    if override_config_file and override_config_file.strip():
+        kwargs["_configuration_file"] = override_config_file.strip()
+    return kwargs
+
+
 def _disable_overlap_schedule_for_cpu(server_args: ServerArgs) -> None:
     if server_args.device != "cpu" or server_args.disable_overlap_schedule:
         return
@@ -89,11 +99,7 @@ def handle_speculative_decoding(server_args: ServerArgs) -> None:
             "select the non-overlap (synchronous) path."
         )
 
-    kwargs = {}
-
-    override_config_file = server_args.decrypted_draft_config_file
-    if override_config_file and override_config_file.strip():
-        kwargs["_configuration_file"] = override_config_file.strip()
+    kwargs = _draft_config_kwargs(server_args)
 
     server_args.speculative_algorithm = _resolve_speculative_algorithm_alias(
         server_args.speculative_algorithm,
@@ -214,7 +220,7 @@ def _handle_dflash(server_args: ServerArgs) -> None:
             parse_dflash_draft_config,
         )
 
-        model_override_args = json.loads(server_args.json_model_override_args)
+        model_override_args = json.loads(server_args.get_draft_model_override_args())
         inferred_block_size = None
         try:
             from sglang.srt.utils.hf_transformers_utils import get_config
@@ -487,7 +493,7 @@ def _resolve_dflash_draft_attention_backend(server_args: ServerArgs) -> None:
             server_args.speculative_draft_model_path,
             trust_remote_code=server_args.trust_remote_code,
             revision=server_args.speculative_draft_model_revision,
-            model_override_args=json.loads(server_args.json_model_override_args),
+            model_override_args=json.loads(server_args.get_draft_model_override_args()),
         )
         draft_text_config = (
             getattr(draft_hf_config, "text_config", None) or draft_hf_config

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -587,7 +587,11 @@ class ModelConfig:
                 if context_length is not None
                 else server_args.context_length
             ),
-            model_override_args=server_args.json_model_override_args,
+            model_override_args=(
+                server_args.get_draft_model_override_args()
+                if is_draft_model
+                else server_args.json_model_override_args
+            ),
             is_embedding=server_args.is_embedding,
             enable_multimodal=server_args.enable_multimodal,
             dtype=server_args.dtype,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2094,6 +2094,13 @@ class ServerArgs:
         "The specific draft model version to use. It can be a branch name, a tag name, or a commit id. If unspecified, will use the default version.",
         NS("spec"),
     ] = None
+    speculative_draft_model_override_args: A[
+        Optional[str],
+        "A dictionary in JSON string format used to override the speculative "
+        "draft model configuration. When unset, the draft inherits "
+        "--json-model-override-args for backward compatibility.",
+        NS("spec"),
+    ] = None
     speculative_draft_load_format: A[
         Optional[str],
         Arg(
@@ -3595,6 +3602,13 @@ class ServerArgs:
         "The path of the JSON configuration file for msProbe. If specified, enables msProbe dump.",
         NS("observability"),
     ] = None
+
+    def get_draft_model_override_args(self) -> str:
+        return (
+            self.speculative_draft_model_override_args
+            if self.speculative_draft_model_override_args is not None
+            else self.json_model_override_args
+        )
 
     def __post_init__(self):
         self._run_resolution_pipeline()

--- a/python/sglang/srt/speculative/dspark_components/dspark_config.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_config.py
@@ -32,7 +32,7 @@ def draft_is_deepseek_v4(*, server_args: ServerArgs) -> bool:
         draft_model_path,
         trust_remote_code=server_args.trust_remote_code,
         revision=server_args.speculative_draft_model_revision,
-        model_override_args=json.loads(server_args.json_model_override_args),
+        model_override_args=json.loads(server_args.get_draft_model_override_args()),
         model_config_parser=server_args.model_config_parser,
     )
     return draft_hf_config is not None and is_deepseek_v4(draft_hf_config)
@@ -133,7 +133,7 @@ def read_draft_checkpoint_gamma(*, server_args: ServerArgs) -> Optional[int]:
         server_args.speculative_draft_model_path,
         trust_remote_code=server_args.trust_remote_code,
         revision=server_args.speculative_draft_model_revision,
-        model_override_args=json.loads(server_args.json_model_override_args),
+        model_override_args=json.loads(server_args.get_draft_model_override_args()),
     )
     return parse_dspark_draft_config(draft_hf_config=draft_hf_config).resolve_gamma(
         default=None

--- a/test/registered/unit/spec/test_draft_model_override_args.py
+++ b/test/registered/unit/spec/test_draft_model_override_args.py
@@ -1,0 +1,124 @@
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from sglang.srt.arg_groups.speculative_hook import (
+    _draft_config_kwargs,
+    _resolve_speculative_algorithm_alias,
+)
+from sglang.srt.configs.model_config import ModelConfig
+from sglang.srt.server_args import ServerArgs
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _server_args(**kwargs) -> ServerArgs:
+    server_args = ServerArgs.__new__(ServerArgs)
+    defaults = {
+        "model_path": "target",
+        "trust_remote_code": False,
+        "revision": None,
+        "context_length": None,
+        "json_model_override_args": "{}",
+        "speculative_draft_model_override_args": None,
+        "speculative_draft_model_quantization": None,
+        "quantization": None,
+        "decrypted_draft_config_file": None,
+        "decrypted_config_file": None,
+        "is_embedding": False,
+        "enable_multimodal": False,
+        "dtype": "auto",
+        "model_impl": "auto",
+        "sampling_defaults": "model",
+        "quantize_and_serve": None,
+        "enable_multi_layer_eagle": False,
+        "language_only": False,
+        "language_model_only": False,
+        "encoder_only": False,
+        "_speculative_draft_quantization_explicitly_set": False,
+        "disable_hybrid_swa_memory": False,
+        "model_config_parser": None,
+        "speculative_algorithm": None,
+    }
+    defaults.update(kwargs)
+    for name, value in defaults.items():
+        setattr(server_args, name, value)
+    return server_args
+
+
+class TestDraftModelOverrideArgs(unittest.TestCase):
+    def test_draft_override_falls_back_to_target_override(self) -> None:
+        server_args = _server_args(
+            json_model_override_args='{"rope_scaling": "target"}'
+        )
+
+        self.assertEqual(
+            server_args.get_draft_model_override_args(),
+            server_args.json_model_override_args,
+        )
+
+    def test_explicit_draft_override_wins(self) -> None:
+        server_args = _server_args(
+            json_model_override_args='{"rope_scaling": "target"}',
+            speculative_draft_model_override_args='{"draft_window_size": 2048}',
+        )
+
+        self.assertEqual(
+            server_args.get_draft_model_override_args(),
+            '{"draft_window_size": 2048}',
+        )
+
+    def test_model_config_uses_target_and_draft_overrides_independently(
+        self,
+    ) -> None:
+        target_override = '{"rope_scaling": "target"}'
+        draft_override = '{"draft_window_size": 2048}'
+        server_args = _server_args(
+            json_model_override_args=target_override,
+            speculative_draft_model_override_args=draft_override,
+        )
+
+        with mock.patch.object(ModelConfig, "__init__", return_value=None) as init:
+            ModelConfig.from_server_args(server_args, is_draft_model=False)
+            target_kwargs = init.call_args.kwargs
+            ModelConfig.from_server_args(
+                server_args, model_path="draft", is_draft_model=True
+            )
+            draft_kwargs = init.call_args.kwargs
+
+        self.assertEqual(target_kwargs["model_override_args"], target_override)
+        self.assertEqual(draft_kwargs["model_override_args"], draft_override)
+
+    def test_algorithm_detection_receives_draft_overrides(self) -> None:
+        server_args = _server_args(
+            json_model_override_args='{"architectures": ["TargetModel"]}',
+            speculative_draft_model_override_args=(
+                '{"architectures": ["Gemma4AssistantForCausalLM"]}'
+            ),
+            decrypted_draft_config_file="  /tmp/draft-config.json  ",
+        )
+
+        expected_kwargs = {
+            "model_override_args": {"architectures": ["Gemma4AssistantForCausalLM"]},
+            "_configuration_file": "/tmp/draft-config.json",
+        }
+        with mock.patch(
+            "sglang.srt.utils.hf_transformers_utils.get_config",
+            return_value=SimpleNamespace(architectures=["Gemma4AssistantForCausalLM"]),
+        ) as get_config:
+            resolved = _resolve_speculative_algorithm_alias(
+                "EAGLE",
+                "draft",
+                trust_remote_code=False,
+                kwargs=_draft_config_kwargs(server_args),
+            )
+
+        self.assertEqual(resolved, "FROZEN_KV_MTP")
+        get_config.assert_called_once_with(
+            "draft", trust_remote_code=False, **expected_kwargs
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Independent target and speculative checkpoints can require incompatible
Hugging Face configuration overrides. SGLang currently applies
`--json-model-override-args` to both, including DFlash block inference and
DSpARK draft inspection. A target's long-context or multimodal overrides can
therefore corrupt draft configuration loading.

## Modifications

- Add `--speculative-draft-model-override-args`.
- Fall back to `--json-model-override-args` when the draft-specific option is
  unset, preserving current behavior.
- Use the resolved draft override in `ModelConfig`, DFlash config inference,
  DSpARK checkpoint inspection, and speculative algorithm alias detection.
- Only construct draft configuration kwargs when a draft checkpoint exists,
  preserving draftless duck-typed custom algorithm hooks.
- Document the new option in the speculative-decoding parameter reference.
- Add CPU tests for fallback, explicit precedence, and independent target/draft
  `ModelConfig` construction.

## Accuracy Tests

- `test/registered/unit/spec/test_draft_model_override_args.py`: passed 4/4
  under pytest.
- `test/registered/unit/spec/test_spec_registry.py`: passed 28/28, including
  the draftless custom algorithm handler path.
- Coverage includes draft override propagation to Gemma4 assistant architecture
  detection through an actual mocked promotion to `FROZEN_KV_MTP`, including a
  decrypted draft configuration file.
- Integrated with separate Qwen3.8 target and DFlash2 draft checkpoints using
  distinct YaRN override structures at 524K context admission.

## Speed Tests and Profiling

Configuration-only change; no steady-state performance impact.

## Checklist

- [x] Run pinned Black, Ruff, and isort checks.
- [x] Add focused unit tests.
- [x] Update user-facing documentation.
- [x] Preserve backward compatibility.
- [ ] Run upstream CI.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32313060282](https://github.com/sgl-project/sglang/actions/runs/32313060282)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32313060078](https://github.com/sgl-project/sglang/actions/runs/32313060078)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->