### PR TITLE
fix(jit): pin nvcc to the fingerprinted host compiler

### DIFF
--- a/python/sglang/kernels/jit/utils/compile/ninja.py
+++ b/python/sglang/kernels/jit/utils/compile/ninja.py
@@ -53,15 +53,15 @@ def _arg(path: str) -> str:
 
 
 def _quote_path_flags(flags: List[str]) -> List[str]:
-    """Shell-quote the directory carried by every ``-I``/``-L`` flag.
+    """Shell-quote the path carried by compiler path flags.
 
     Applied once, at the end, wherever the flag came from -- this layer, the
-    toolchain, or the caller -- so a directory with a space in it stays one
-    argument. Anything else is passed through untouched.
+    toolchain, or the caller -- so a path with spaces or shell metacharacters
+    stays one argument. Anything else is passed through untouched.
     """
     quoted: List[str] = []
     for flag in flags:
-        for prefix in ("-I", "-L"):
+        for prefix in ("-I", "-L", "-ccbin="):
             if flag.startswith(prefix) and len(flag) > len(prefix):
                 quoted.append(prefix + _arg(flag[len(prefix) :]))
                 break

--- a/python/sglang/kernels/jit/utils/compile/toolchain.py
+++ b/python/sglang/kernels/jit/utils/compile/toolchain.py
@@ -137,7 +137,10 @@ def base_cxx_flags() -> List[str]:
 def base_cuda_flags() -> List[str]:
     if is_hip_runtime():
         return ["-fPIC", "-D__HIP_PLATFORM_AMD__=1", "-fno-gpu-rdc"]
-    return ["-Xcompiler", "-fPIC"]
+    # nvcc does not honor CC/CXX/CUDAHOSTCXX when selecting its host compiler.
+    # Pin the same compiler that we fingerprint and use for the final link;
+    # otherwise nvcc silently falls back to the system default compiler.
+    return ["-Xcompiler", "-fPIC", f"-ccbin={host_compiler_path()}"]
 
 
 def base_include_paths() -> List[str]:

--- a/test/registered/kernels/test_jit_cache.py
+++ b/test/registered/kernels/test_jit_cache.py
@@ -14,7 +14,7 @@ import sys
 import msgspec
 import pytest
 
-from sglang.kernels.jit.utils.compile import cache, ninja
+from sglang.kernels.jit.utils.compile import cache, ninja, toolchain
 from sglang.kernels.jit.utils.compile.paths import KERNEL_PATH
 from sglang.kernels.jit.utils.compile.spec import BuildSpec
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -50,6 +50,26 @@ def _spec(**overrides) -> BuildSpec:
     )
     base.update(overrides)
     return BuildSpec(**base)
+
+
+def test_nvcc_uses_the_fingerprinted_host_compiler(monkeypatch):
+    host_compiler = "/opt/compiler $tool/g++"
+    quoted_compiler = "'/opt/compiler $$tool/g++'"
+    monkeypatch.setattr(toolchain, "is_hip_runtime", lambda: False)
+    monkeypatch.setattr(toolchain, "host_compiler_path", lambda: host_compiler)
+
+    build_file = ninja.generate(
+        _spec(
+            cpp_wrappers=(),
+            cuda_wrappers=(("run", "Kernel::run"),),
+        )
+    )
+
+    assert f"cxx = {quoted_compiler}" in build_file
+    assert f"-ccbin={quoted_compiler}" in build_file
+    assert "command = $nvcc -MD -MF" in build_file
+    assert "$cudaflags -c" in build_file
+    assert "build cuda_0.o: compile_cuda cuda.cu" in build_file
 
 
 def _build_key(**overrides) -> str:


### PR DESCRIPTION
## Motivation

The SGLang JIT cache fingerprints `CXX`, and the final host link uses that
compiler, but nvcc otherwise selects its own default host compiler. CUDA host
code can consequently be compiled with a compiler different from both the JIT
cache identity and final linker.

## Modifications

- Pass the resolved host compiler to nvcc through `-ccbin`.
- Add CPU coverage with a generated CUDA wrapper translation unit, proving the
  same compiler reaches both the Ninja host command and nvcc `-ccbin` flags.
- Leave the HIP flags unchanged.
- Quote the `-ccbin` path with the same Ninja/shell rules as the host compiler,
  including executable paths containing spaces or `$`.

## Accuracy Tests

- Focused generated-Ninja CUDA-edge assertion passed.
- Path-quoting coverage includes both a space and `$`.
- `test/registered/kernels/test_jit_cache.py`: passed 43/43 under pytest.
- The active native build and runtime JIT path have been exercised with GCC/G++
  15 on CUDA 13 and SM120.

## Speed Tests and Profiling

Build-correctness change only; no inference performance claim.

## Checklist

- [x] Run pinned Black, Ruff, and isort checks.
- [x] Add focused unit coverage.
- [x] Verify that a CUDA compile edge consumes the generated cudaflags.
- [x] Run the complete upstream JIT cache test file.
- [ ] Run upstream CI.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32310940208](https://github.com/sgl-project/sglang/actions/runs/32310940208)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32310940350](https://github.com/sgl-project/sglang/actions/runs/32310940350)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->