### PR TITLE
Return 400 for multimodal token/data mismatches

### DIFF
--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -915,10 +915,9 @@ class BaseMultimodalProcessor(ABC):
                 try:
                     data = next(data_iterator)
                 except StopIteration:
-                    logger.warning(
+                    raise ValueError(
                         f"Mismatch: More '{modality.name}' tokens found than corresponding data provided."
                     )
-                    return futures, task_info
 
                 frame_count_limit = None
                 if modality == Modality.IMAGE and image_estimated_frames_iter:

--- a/test/registered/unit/multimodal/test_base_processor_bad_input.py
+++ b/test/registered/unit/multimodal/test_base_processor_bad_input.py
@@ -15,7 +15,10 @@ from unittest.mock import MagicMock, patch
 import requests
 
 from sglang.srt.managers.schedule_batch import Modality
-from sglang.srt.multimodal.processors.base_processor import BaseMultimodalProcessor
+from sglang.srt.multimodal.processors.base_processor import (
+    BaseMultimodalProcessor,
+    MultimodalSpecialTokens,
+)
 from sglang.srt.utils.common import CLIENT_MEDIA_EXCEPTIONS
 from sglang.test.test_utils import CustomTestCase
 
@@ -26,6 +29,9 @@ class _StubProcessor(BaseMultimodalProcessor):
     # gpu_image_decode=False keeps the decode on PIL so the test needs no GPU. The
     # abstract methods are never called: only the _load_single_item classmethod is.
     gpu_image_decode = False
+
+    async def process_mm_data_async(self, *args, **kwargs):
+        raise NotImplementedError
 
 
 def _session_raising(exc):
@@ -102,6 +108,23 @@ class TestClientMediaExceptions(CustomTestCase):
         ):
             with self.subTest(exc_type=exc_type.__name__):
                 self.assertTrue(issubclass(exc_type, CLIENT_MEDIA_EXCEPTIONS))
+
+
+class TestMultimodalTokenDataMismatch(CustomTestCase):
+    def test_missing_image_data_is_a_client_error(self):
+        processor = _StubProcessor.__new__(_StubProcessor)
+        tokens = MultimodalSpecialTokens(image_token="<image>").build(processor)
+        data_iterators = MagicMock()
+        data_iterators.get.return_value = iter(())
+
+        with self.assertRaisesRegex(
+            ValueError, "More 'IMAGE' tokens found than corresponding data provided"
+        ):
+            processor.submit_data_loading_tasks(
+                ["", "<image>", ""],
+                tokens,
+                data_iterators,
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Return a `ValueError` as soon as a rendered multimodal placeholder has no corresponding media item. The OpenAI serving layer already maps `ValueError` to HTTP 400.

## Why

A Qwen-VL request with a valid image plus ordinary text that happens to contain a Qwen vision marker currently reaches `legacy_load_mm_data()` with more image markers than image data. The previous code logged the mismatch, returned partial work, and later raised an uncaught `RuntimeError`, producing HTTP 500.

This PR makes the malformed request a clear client error and adds a regression test. It does not attempt to define a lossless escaping scheme for literal reserved model tokens; that broader design question is tracked in #35582.

## Validation

`PYTHONPATH=python:. /home/ozgur/venvs/sglang16/bin/python test/registered/unit/multimodal/test_base_processor_bad_input.py`

Result: 9 tests passed.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32310944848](https://github.com/sgl-project/sglang/actions/runs/32310944848)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32310944781](https://github.com/sgl-project/sglang/actions/runs/32310944781)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->