### PR TITLE
fix(spec): build mRoPE positions for ragged verify

### DIFF
--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -1080,7 +1080,15 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
         # passes its own positions (uniform num_draft_tokens per request).
         if seq_positions is None:
             seq_positions = batch.spec_info.positions
-        seq_positions = seq_positions.view(batch_size, -1)
+        ragged_layout = getattr(batch.spec_info, "ragged_verify_layout", None)
+        if ragged_layout is None:
+            seq_positions = seq_positions.view(batch_size, -1)
+        else:
+            # Compact verify packs a variable number of positions per request;
+            # graph-tier padding follows the packed real-token prefix. Keep the
+            # original live layout so padding receives zero mRoPE delta rather
+            # than inheriting the final request's delta.
+            seq_positions = seq_positions.reshape(-1)
         # Split text-only and mixed batches here because SpecV2 text-only batches can avoid an extra D2H.
         if all(mm_input is None for mm_input in mm_inputs):
             mrope_delta_tensor = torch.zeros(
@@ -1096,9 +1104,23 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
                 for i in range(batch_size)
             ]
             mrope_delta_tensor = torch.stack(mrope_deltas, dim=0).to(device=device)
-        next_input_positions = (
-            (seq_positions + mrope_delta_tensor).flatten().unsqueeze(0).repeat(3, 1)
-        )
+        if ragged_layout is None:
+            next_input_positions = (seq_positions + mrope_delta_tensor).flatten()
+        else:
+            token_indices = torch.arange(
+                seq_positions.numel(), dtype=torch.int32, device=device
+            )
+            request_indices = torch.searchsorted(
+                ragged_layout.qo_indptr_device[1:], token_indices, right=True
+            )
+            is_real_token = request_indices < ragged_layout.bs
+            safe_request_indices = request_indices.clamp(max=batch_size - 1).long()
+            token_deltas = mrope_delta_tensor.flatten()[safe_request_indices]
+            token_deltas = torch.where(
+                is_real_token, token_deltas, torch.zeros_like(token_deltas)
+            )
+            next_input_positions = seq_positions + token_deltas
+        next_input_positions = next_input_positions.unsqueeze(0).repeat(3, 1)
 
         self.mrope_positions = next_input_positions
 

--- a/test/registered/spec/dspark/test_ragged_mrope_positions.py
+++ b/test/registered/spec/dspark/test_ragged_mrope_positions.py
@@ -1,0 +1,87 @@
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.speculative.ragged_verify import RaggedVerifyLayout
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-small")
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA is required")
+class TestRaggedMropePositions(unittest.TestCase):
+    def test_bucket_padding_uses_the_real_ragged_layout(self):
+        device = torch.device("cuda")
+        forward_batch = ForwardBatch.__new__(ForwardBatch)
+        forward_batch.seq_lens = torch.tensor(
+            [100, 200, 300], dtype=torch.int32, device=device
+        )
+        layout = RaggedVerifyLayout.from_verify_lens(
+            verify_lens_cpu=[1, 3, 2],
+            device=device,
+            grid=[8],
+        )
+        self.assertEqual(layout.bs, 3)
+        self.assertEqual(layout.graph_num_tokens, 8)
+        batch = SimpleNamespace(
+            spec_info=SimpleNamespace(
+                positions=torch.tensor(
+                    [100, 200, 201, 202, 300, 301, 0, 1],
+                    dtype=torch.int64,
+                    device=device,
+                ),
+                ragged_verify_layout=layout,
+            ),
+            multimodal_inputs=[
+                SimpleNamespace(mrope_position_delta=torch.tensor([[10]])),
+                None,
+                SimpleNamespace(mrope_position_delta=torch.tensor([[-2]])),
+            ],
+        )
+
+        forward_batch.compute_spec_mrope_positions(
+            SimpleNamespace(device=device), batch
+        )
+
+        expected = torch.tensor(
+            [110, 200, 201, 202, 298, 299, 0, 1],
+            dtype=torch.int64,
+            device=device,
+        )
+        torch.testing.assert_close(
+            forward_batch.mrope_positions, expected.unsqueeze(0).repeat(3, 1)
+        )
+
+    def test_dense_verify_layout_is_unchanged(self):
+        device = torch.device("cuda")
+        forward_batch = ForwardBatch.__new__(ForwardBatch)
+        forward_batch.seq_lens = torch.tensor(
+            [100, 200], dtype=torch.int32, device=device
+        )
+        batch = SimpleNamespace(
+            spec_info=SimpleNamespace(
+                positions=torch.tensor(
+                    [100, 101, 200, 201], dtype=torch.int64, device=device
+                ),
+                ragged_verify_layout=None,
+            ),
+            multimodal_inputs=[
+                SimpleNamespace(mrope_position_delta=torch.tensor([[10]])),
+                SimpleNamespace(mrope_position_delta=torch.tensor([[-2]])),
+            ],
+        )
+
+        forward_batch.compute_spec_mrope_positions(
+            SimpleNamespace(device=device), batch
+        )
+
+        expected = torch.tensor([110, 111, 198, 199], dtype=torch.int64, device=device)
+        torch.testing.assert_close(
+            forward_batch.mrope_positions, expected.unsqueeze(0).repeat(3, 1)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Compact speculative verification packs a variable number of tokens per
request. `compute_spec_mrope_positions` currently reshapes those positions as a
dense `[batch, tokens]` tensor. The reshape fails when request lengths differ;
when graph padding makes it divisible, deltas can instead be assigned to the
wrong request.

## Modifications

- Detect a compact ragged verification layout.
- Map packed real tokens through the live ragged offsets and apply each
  request's mRoPE delta.
- Preserve zero delta for invalid graph-tier tail padding.
- Preserve the existing dense verification path.
- Add CUDA regression coverage using a real bucket-rounded layout with tail
  padding, plus the unchanged dense path.

## Accuracy Tests

- `test/registered/spec/dspark/test_ragged_mrope_positions.py`: passed 2/2 on
  local CUDA. It covers the usual `batch_size == layout.bs` bucket-rounded case
  with a negative final-request delta and verifies tail padding remains zero.
- Historical Qwen3.8+DSpARK compact qualification reproduced the original
  failure when the live batch shrank 4→3 with ten packed verify tokens.
- After the correction, ordinary OpenAI-compatible requests completed
  4→3→2→1 CUDA-graph transitions and a 454,685-token request recovered all
  three needles exactly.

The historical integrated run used the composite local SM120 runtime branch,
which also carried the required XQA/GDN support. It demonstrates the observed
failure and corrected behavior, not one-commit standalone runtime deployment.

The later DFlash2 qualification is deliberately excluded: DFlash2 did not emit
ragged verify layouts and therefore did not exercise this code path.

## Speed Tests and Profiling

No speed claim. The patch replaces an invalid dense-layout assumption with
fixed-shape device-side offset lookup, gather, and masking during speculative
metadata construction.

## Checklist

- [x] Run pinned Black, Ruff, and isort checks.
- [x] Add a registered CUDA test with real graph-bucket rounding.
- [x] Validate the affected DSpARK compact runtime shape on SM120.
- [ ] Run upstream CI.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32311114796](https://github.com/sgl-project/sglang/actions/runs/32311114796)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32311114743](https://github.com/sgl-project/sglang/actions/runs/32311114743)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->