### PR TITLE
docker: fix CUDA-13 build — rename NCCL_VERSION ARG to avoid base image ENV collision

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ ARG SGL_VERSION
 ARG SGL_DEEP_GEMM_VERSION=0.1.5.post2
 ARG USE_LATEST_SGLANG=0
 ARG GDRCOPY_VERSION=2.5.1
-ARG NCCL_VERSION=2.30.7
+ARG SGL_NCCL_VERSION=2.30.7
 ARG PIP_DEFAULT_INDEX
 ARG UBUNTU_MIRROR
 ARG GITHUB_ARTIFACTORY=github.com
@@ -173,7 +173,11 @@ ARG CUDA_VERSION
 ARG BUILD_TYPE
 ARG SGL_KERNEL_VERSION
 ARG GITHUB_ARTIFACTORY
-ARG NCCL_VERSION
+# Renamed from NCCL_VERSION: the nvidia/cuda base image sets ENV NCCL_VERSION
+# (Debian apt format, e.g. 2.28.3-1), which shadows a same-named ARG inside RUN,
+# so the CUDA-13 nvidia-nccl-cu13 pip install below resolved an invalid PyPI
+# version. A distinct ARG name avoids the collision.
+ARG SGL_NCCL_VERSION
 
 WORKDIR /sgl-workspace
 
@@ -251,7 +255,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     && python3 -m pip install --extra-index-url https://download.pytorch.org/whl/cu${CUINDEX} ".[${BUILD_TYPE}]" \
     && if [ "${CUDA_VERSION%%.*}" = "13" ]; then \
            python3 -m pip install --force-reinstall --no-deps \
-               "nvidia-nccl-cu13==${NCCL_VERSION}"; \
+               "nvidia-nccl-cu13==${SGL_NCCL_VERSION}"; \
        fi \
     && if [ "${CUDA_VERSION%%.*}" = "12" ]; then \
            pip list --format=freeze | awk -F'==' '/-cu13(==|$)/ {print $1}' \


### PR DESCRIPTION
## Problem
The CUDA-13 branch in `docker/Dockerfile` runs:
```
pip install --force-reinstall --no-deps "nvidia-nccl-cu13==${NCCL_VERSION}"
```
The `nvidia/cuda:13.0.3-cudnn-devel-ubuntu24.04` base image sets `ENV NCCL_VERSION=2.28.3-1` (Debian/apt format), which **shadows** the Dockerfile's `ARG NCCL_VERSION=2.30.7` at `RUN` time. So pip requests `2.28.3-1`, which is not a valid PyPI version, and the build fails:
```
ERROR: No matching distribution found for nvidia-nccl-cu13==2.28.3-1
```

## Fix
Rename the ARG to `SGL_NCCL_VERSION` so it no longer collides with the base image's `ENV NCCL_VERSION`; the intended `2.30.7` is used. This matches `scripts/ci/cuda/ci_install_dependency.sh`'s `install_nccl()`, which already hardcodes `2.30.7`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32316009906](https://github.com/sgl-project/sglang/actions/runs/32316009906)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32316009800](https://github.com/sgl-project/sglang/actions/runs/32316009800)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->