### PR TITLE
[Fix] Support 128-aligned hidden sizes in the W4AFP8 DeepEP low-latency requant kernel

### DIFF
--- a/python/sglang/kernels/ops/moe/ep_moe_kernels.py
+++ b/python/sglang/kernels/ops/moe/ep_moe_kernels.py
@@ -1944,6 +1944,7 @@ def _fp8_per_token_quant_to_per_tensor_quant_kernel(
     k,
     K_SCALE_BLOCK_SIZE: tl.constexpr,
     K_BLOCK_SIZE: tl.constexpr,
+    HAS_K_TAIL: tl.constexpr,
 ):
     pid_k, pid_m, pid_e = (
         tl.program_id(axis=0),
@@ -1959,6 +1960,11 @@ def _fp8_per_token_quant_to_per_tensor_quant_kernel(
         return
     output_scale_val_inv = 1.0 / tl.load(output_scale_ptr).to(tl.float32)
     k_offsets = pid_k * K_BLOCK_SIZE + tl.arange(0, K_BLOCK_SIZE)
+    # k only has to be a multiple of the 128-wide scale group (e.g. 3584), so the
+    # last k block can be partial.  Specialize on it: hidden sizes that fill
+    # every block keep the unmasked loads, and their codegen is unchanged.
+    if HAS_K_TAIL:
+        k_mask = k_offsets < k
     scale_offsets = (k_offsets // K_SCALE_BLOCK_SIZE) * x_scale_stride2
 
     x_ptrs = x_ptr + pid_e * m * k + k_offsets
@@ -1966,10 +1972,22 @@ def _fp8_per_token_quant_to_per_tensor_quant_kernel(
     x_scale_ptrs = x_scale_ptr + pid_e * x_scale_stride0 + scale_offsets
 
     for tok_idx in tl.range(token_id, last_effective_id, pid_m_dim):
-        hidden = tl.load(x_ptrs + tok_idx * k).to(tl.float32)
-        scale_fp32 = tl.load(x_scale_ptrs + tok_idx * x_scale_stride1).to(tl.float32)
+        if HAS_K_TAIL:
+            hidden = tl.load(x_ptrs + tok_idx * k, mask=k_mask, other=0.0)
+            x_scale = tl.load(
+                x_scale_ptrs + tok_idx * x_scale_stride1, mask=k_mask, other=0.0
+            )
+        else:
+            hidden = tl.load(x_ptrs + tok_idx * k)
+            x_scale = tl.load(x_scale_ptrs + tok_idx * x_scale_stride1)
+        hidden = hidden.to(tl.float32)
+        scale_fp32 = x_scale.to(tl.float32)
         hidden = hidden * scale_fp32 * output_scale_val_inv
-        tl.store(output_ptrs + tok_idx * k, hidden.to(output_ptr.dtype.element_ty))
+        quantized = hidden.to(output_ptr.dtype.element_ty)
+        if HAS_K_TAIL:
+            tl.store(output_ptrs + tok_idx * k, quantized, mask=k_mask)
+        else:
+            tl.store(output_ptrs + tok_idx * k, quantized)
 
 
 def fp8_per_token_to_per_tensor_quant_triton(
@@ -1986,8 +2004,7 @@ def fp8_per_token_to_per_tensor_quant_triton(
     assert output_scale.numel() == 1
 
     K_BLOCK_SIZE = 1024
-    assert x.size(2) % K_BLOCK_SIZE == 0
-    grid = (x.size(2) // K_BLOCK_SIZE, 32, x.size(0))
+    grid = (triton.cdiv(x.size(2), K_BLOCK_SIZE), 32, x.size(0))
     _fp8_per_token_quant_to_per_tensor_quant_kernel[grid](
         x,
         x_scale,
@@ -1999,6 +2016,7 @@ def fp8_per_token_to_per_tensor_quant_triton(
         x.size(2),
         K_SCALE_BLOCK_SIZE=K_SCALE_BLOCK_SIZE,
         K_BLOCK_SIZE=K_BLOCK_SIZE,
+        HAS_K_TAIL=x.size(2) % K_BLOCK_SIZE != 0,
         num_warps=8,
     )
 

--- a/test/registered/kernels/ops/moe/test_fp8_per_token_to_per_tensor_quant.py
+++ b/test/registered/kernels/ops/moe/test_fp8_per_token_to_per_tensor_quant.py
@@ -1,0 +1,82 @@
+"""Unit test for ``fp8_per_token_to_per_tensor_quant_triton`` across hidden sizes.
+
+W4AFP8 DeepEP low-latency requantizes the fp8 dispatch payload with this kernel
+before the first CUTLASS grouped GEMM.  The payload's hidden size is only
+guaranteed to be a multiple of the fp8 scale-group size (128) -- e.g. 3584 for
+Kimi-K3 -- so the kernel must handle a ``k`` tail that does not fill a whole
+``K_BLOCK_SIZE`` (1024) block, and must still leave the rows past ``masked_m``
+untouched.
+"""
+
+import pytest
+import torch
+
+from sglang.kernels.ops.moe.ep_moe_kernels import (
+    fp8_per_token_to_per_tensor_quant_triton,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=20, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+dev = "cuda"
+FP8 = torch.float8_e4m3fn
+K_SCALE_BLOCK_SIZE = 128
+# Every value the kernel can produce below is a multiple of 0.25, so this
+# sentinel cannot be matched by a kernel that wrongly writes a padding row.
+SENTINEL = 0.375
+OUTPUT_SCALE = 2.0
+
+
+def _build(num_experts, m, k, seed):
+    g = torch.Generator(device="cpu").manual_seed(seed)
+    # Integers in [-8, 8] with power-of-two per-token-group scales keep every
+    # intermediate exactly representable in e4m3, so the reference below matches
+    # bit-for-bit regardless of the rounding mode of the final cast.
+    x = torch.randint(-8, 9, (num_experts, m, k), generator=g).float()
+    exps = torch.randint(-1, 2, (num_experts, m, k // K_SCALE_BLOCK_SIZE), generator=g)
+    x_scale = torch.pow(2.0, exps.float())
+    return x.to(dev).to(FP8), x_scale.to(dev)
+
+
+def _ref(x, x_scale):
+    dequant = x.float() * x_scale.repeat_interleave(K_SCALE_BLOCK_SIZE, dim=2)
+    return (dequant * (1.0 / OUTPUT_SCALE)).to(FP8)
+
+
+# 7168: exact multiple of K_BLOCK_SIZE (the DeepSeek-V3 hidden size).
+# 3584 / 1152: only 128-aligned, so the last k block is partially masked.
+@pytest.mark.parametrize("k", [7168, 3584, 1152])
+def test_masked_rows_and_k_tail(k):
+    num_experts, m = 4, 48
+    masked = [0, 1, 17, m]
+
+    x, x_scale = _build(num_experts, m, k, seed=k)
+    masked_m = torch.tensor(masked, dtype=torch.int32, device=dev)
+    output_scale = torch.tensor([OUTPUT_SCALE], dtype=torch.float32, device=dev)
+    output = torch.full((num_experts, m, k), SENTINEL, device=dev).to(FP8)
+
+    fp8_per_token_to_per_tensor_quant_triton(
+        x=x,
+        x_scale=x_scale,
+        masked_m=masked_m,
+        output_scale=output_scale,
+        output=output,
+    )
+
+    ref = _ref(x, x_scale)
+    for e, valid in enumerate(masked):
+        torch.testing.assert_close(
+            output[e, :valid].float(), ref[e, :valid].float(), rtol=0, atol=0
+        )
+        # Padding rows are not part of any expert's GEMM problem size and must
+        # stay as the caller left them.
+        padding = output[e, valid:].float()
+        torch.testing.assert_close(
+            padding, torch.full_like(padding, SENTINEL), rtol=0, atol=0
+        )
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v", "-s"]))


### PR DESCRIPTION
## Motivation

`fp8_per_token_to_per_tensor_quant_triton()` requantizes DeepEP low-latency's per-token-group
fp8 payload into the per-tensor fp8 that the first CUTLASS W4A8 grouped GEMM consumes. It
required the hidden size to fill a whole number of 1024-element blocks:

```python
K_BLOCK_SIZE = 1024
assert x.size(2) % K_BLOCK_SIZE == 0
grid = (x.size(2) // K_BLOCK_SIZE, 32, x.size(0))
```

so it rejected any expert hidden size that is only 128-aligned — 3584, for example. Since
`W4AFp8MoEMethod` pins the low-latency wire format to fp8
(`python/sglang/srt/layers/quantization/w4afp8.py:286-295`) and `apply_deepep_ll()` rejects a
payload that carries no per-token-group scales (`w4afp8.py:347-351`), such a model has no
working low-latency path at all: the fp8 payload it is handed trips the assert during decode
CUDA-graph capture.

1024 was the only constraint of its kind on that path. `w1_scale` is `[E, K // 512, N * 8]`, so
512-alignment is genuinely required; DeepEP's low-latency fp8 scales are `[E, M, hidden // 128]`
(column-major in the last two dims for TMA), so the payload is always a whole number of 128-wide
scale groups. A hidden size of 3584 satisfies both — 7 × 512, 28 groups — and was rejected only
by the 1024 block.

## Modifications

`python/sglang/kernels/ops/moe/ep_moe_kernels.py`:

- Take the grid from `triton.cdiv` and drop the assert.
- Mask the k lanes in `_fp8_per_token_quant_to_per_tensor_quant_kernel`: on the hidden load, on
  the store, and on the scale load, whose offsets derive from `k_offsets` and would otherwise
  read past the scale tensor in the tail block.
- Put the masked form behind `HAS_K_TAIL: tl.constexpr`, so hidden sizes that fill every block
  keep the original unmasked loads and the same launch geometry. This mirrors
  `_silu_and_mul_post_per_tensor_quant_kernel` in the same file, which already pairs a `cdiv`
  grid with a masked fast axis.

Adds `test/registered/kernels/ops/moe/test_fp8_per_token_to_per_tensor_quant.py`
(`base-b-kernel-unit`, `1-gpu-large`).

## Accuracy Tests

The new test checks k ∈ {7168, 3584, 1152} — one exact multiple of 1024 and two tailed, so both
specializations compile — against a torch reference, and asserts that rows past `masked_m` are
left exactly as the caller wrote them. Inputs are integers in [-8, 8] with power-of-two group
scales, so every intermediate is exactly representable in e4m3 and the comparison can be
`rtol=0, atol=0`.

(The kernel saturates fp8 overflow — `cvt.rn.satfinite`, clamping to 448.0 — where
`Tensor.to(torch.float8_e4m3fn)` produces NaN, so a torch-reference test has to stay inside range
deliberately.)

One H200, torch 2.11.0+cu130 / triton 3.6.0:

```
test_masked_rows_and_k_tail[7168] PASSED
test_masked_rows_and_k_tail[3584] PASSED
test_masked_rows_and_k_tail[1152] PASSED
3 passed in 16.75s
```

Swapping this commit's kernel for the current `main` file makes the two tailed cases fail while
7168 still passes, so the test covers the change rather than just passing alongside it.

A wider matrix run out of tree — both scale layouts (contiguous and DeepEP's column-major) ×
`masked_m` ∈ {0, 1, 17, m} × E ∈ {4, 8, 56} × K_BLOCK ∈ {1024, 2048} × num_warps ∈ {1, 2, 4, 8} —
is bit-exact against the reference everywhere, with padding rows untouched.

## Speed Tests and Profiling

Hidden sizes that already worked are unaffected, checked two ways on H200 and B200 (torch 2.11 /
triton 3.6; kernel timed inside a CUDA graph so Triton's Python launch cost is excluded; DeepEP
scale layout, `K_BLOCK_SIZE=1024`, m-grid 32).

Codegen: the compiled kernel has the same opcode multiset as before at num_warps ∈ {2, 4, 8},
differing only in instruction scheduling order. Access widths are unchanged in the tail path too
(warps=2 → `ld/st.global.v4.b32`, warps=4 → `v2.b32`, warps=8 → scalar `b32`), so the mask costs
no vectorization.

Timing at k=7168, relative to the kernel this replaces:

| live rows / expert | H200 w8 | H200 w4 | B200 w8 | B200 w4 |
| --- | --- | --- | --- | --- |
| 32 | −0.18% | −0.38% | −0.59% | +1.11% |
| 256 | −0.65% | −0.10% | −1.66% | +1.46% |
| 1024 | +0.09% | +0.20% | −0.32% | 0.00% |

For reference, a newly-working shape (no prior number — it asserted): k=3584, 8 experts, 1024
live rows per expert — 25.4 µs on H200, 14.6 µs on B200.

Reproduction note: in a CUDA-graph A/B loop the first variant measured reads roughly 10% fast on
sub-2 µs shapes; interleave the variants and swap their order before trusting a small gap.

Not covered here: a multi-node end-to-end decode run on a model whose routed-expert hidden size
isn't 1024-divisible. This change unblocks the fp8 low-latency path for those models at the
kernel level; that e2e run is still outstanding.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — no user-facing behaviour or flags change.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #32324979864](https://github.com/sgl-project/sglang/actions/runs/32324979864)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32324979753](https://github.com/sgl-project/sglang/actions/runs/32324979753)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->