### PR TITLE
fix(function_call): preserve leading JSON in llama3 parser when no tool call is found

### DIFF
--- a/python/sglang/srt/function_call/llama32_detector.py
+++ b/python/sglang/srt/function_call/llama32_detector.py
@@ -55,6 +55,10 @@ class Llama32Detector(BaseFormatDetector):
         if "<|python_tag|>" not in text and not text.startswith("{"):
             return StreamingParseResult(normal_text=text, calls=[])
 
+        # Remember if the text started with a raw JSON object so we can fall
+        # back to preserving it when no actual tool call is found.
+        starts_with_json = text.startswith("{")
+
         if "<|python_tag|>" in text:
             normal_text, action_text = text.split("<|python_tag|>", maxsplit=1)
         else:
@@ -104,6 +108,13 @@ class Llama32Detector(BaseFormatDetector):
 
         # Only process if we found valid JSON objects
         calls = self.parse_base_json(all_actions, tools) if all_actions else []
+
+        # If the input began with a plain JSON object but we did not extract any
+        # actual tool call, preserve the original text instead of silently
+        # dropping the leading JSON object.
+        if starts_with_json and not calls:
+            return StreamingParseResult(normal_text=text, calls=[])
+
         # Use safe_idx to avoid idx containing the last part of an invalid JSON object
         trailing_text = (
             action_text[safe_idx:].strip() if safe_idx < action_text_len else ""

--- a/test/registered/unit/function_call/test_llama32_detector.py
+++ b/test/registered/unit/function_call/test_llama32_detector.py
@@ -93,6 +93,20 @@ class TestLlama32Detector(CustomTestCase):
         self.assertEqual(len(result.calls), 0)
         self.assertEqual(result.normal_text, "The weather is nice today.")
 
+    def test_no_tool_call_preserves_empty_json_object(self):
+        """Regression test for #35562: '{}' must not be stripped."""
+        text = "{}"
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 0)
+        self.assertEqual(result.normal_text, "{}")
+
+    def test_no_tool_call_preserves_leading_json_object(self):
+        """Regression test for #35562: leading non-tool JSON must be preserved."""
+        text = '{"a": 1} is a dict'
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 0)
+        self.assertEqual(result.normal_text, '{"a": 1} is a dict')
+
     def test_multiple_json_objects(self):
         text = '<|python_tag|>{"name": "get_weather", "arguments": {"city": "Beijing"}};{"name": "search", "arguments": {"query": "restaurants"}}'
         result = self.detector.detect_and_parse(text, self.tools)


### PR DESCRIPTION
Fixes #35562.

The llama3 tool-call parser (Llama32Detector) stripped any leading JSON object from message content even when that JSON did not represent an actual tool call, so inputs like '{}' and '{"a": 1} is a dict' lost their leading JSON.

Change: when the input starts with a plain JSON object but no tool call is extracted, return the original text unchanged.

Added CPU-only regression tests for the two repro inputs from the issue.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32323651668](https://github.com/sgl-project/sglang/actions/runs/32323651668)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32323651474](https://github.com/sgl-project/sglang/actions/runs/32323651474)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->