### PR TITLE
Fix stale batch fullness after chunked prefill

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3247,9 +3247,8 @@ class Scheduler(
         if self.enable_hierarchical_cache or get_memory().enable_flexkv:
             self.tree_cache.check_hicache_events()
 
-        if self.enable_priority_preemption or self.is_hybrid_swa:
-            # Reset batch_is_full to try preemption with a prefill adder.
-            running_batch.batch_is_full = False
+        # Reset batch_is_full to retry admission with a prefill adder.
+        running_batch.batch_is_full = False
 
         if (
             running_batch.batch_is_full or len(self.waiting_queue) == 0

--- a/test/registered/unit/managers/test_scheduler_chunked_req_gate.py
+++ b/test/registered/unit/managers/test_scheduler_chunked_req_gate.py
@@ -3,7 +3,7 @@
 import unittest
 from array import array
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import torch
 
@@ -178,6 +178,36 @@ class TestStashGatePreservesPrefixIndices(CustomTestCase):
             s, running_batch=s.running_batch, last_batch=s.last_batch
         )
         self.assertIsNone(s.chunked_req)
+
+
+class TestChunkedPrefillBatchFullReset(CustomTestCase):
+    def test_stale_batch_full_reconsiders_waiting_request(self):
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.grammar_manager = MagicMock()
+        scheduler.grammar_manager.has_waiting_grammars.return_value = False
+        scheduler.enable_hierarchical_cache = False
+        scheduler.enable_priority_preemption = False
+        scheduler.is_hybrid_swa = False
+        scheduler.waiting_queue = [MagicMock()]
+        scheduler.chunked_req = None
+        scheduler.min_free_slots_delayer = None
+        scheduler.get_num_allocatable_reqs = MagicMock(return_value=1)
+        scheduler.policy = MagicMock()
+        scheduler.policy.calc_priority.side_effect = RuntimeError("admission attempted")
+
+        running_batch = MagicMock()
+        running_batch.batch_is_full = True
+        running_batch.reqs = [MagicMock(), MagicMock(), MagicMock()]
+
+        with patch(
+            "sglang.srt.managers.scheduler.get_memory",
+            return_value=SimpleNamespace(enable_flexkv=False),
+        ), self.assertRaisesRegex(RuntimeError, "admission attempted"):
+            Scheduler._get_new_batch_prefill_raw(
+                scheduler,
+                prefill_delayer_single_pass=None,
+                running_batch=running_batch,
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Fixes #35537.

`batch_is_full` could remain set after the final chunked-prefill pass. The next scheduler pass returned before recalculating available request slots, which left a waiting request queued until a running request finished.

Thanks to @atlantistony for the report and detailed trace.

## Modifications

Reset `batch_is_full` at the start of each prefill admission pass. Add a regression test that starts with the stale post-chunk state and verifies that the waiting request reaches admission.

## Accuracy Tests

Not applicable. This does not change model output computation.

## Speed Tests and Profiling

Not run. The focused scheduler test passed on a Linux node with 8 NVIDIA A40 GPUs, with CUDA hidden for the CPU unit test. The full reported Qwen3.8 NVFP4 setup could not run because A40 is sm_86.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). Not needed for this internal scheduler fix.
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Not applicable to model accuracy, and the reported NVFP4 setup is unsupported on A40.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32324063947](https://github.com/sgl-project/sglang/actions/runs/32324063947)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32324063871](https://github.com/sgl-project/sglang/actions/runs/32324063871)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->