### PR TITLE
[diffusion] chore: reduce per-request log noise

### DIFF
--- a/python/sglang/multimodal_gen/runtime/models/adapter/ltx_2_duration_head.py
+++ b/python/sglang/multimodal_gen/runtime/models/adapter/ltx_2_duration_head.py
@@ -180,13 +180,6 @@ class LTX2DurationHead(nn.Module):
                 num_frames,
                 frame_rate,
             )
-        else:
-            logger.info(
-                "Predicted duration %.2fs (%d frames @ %.2f fps)",
-                seconds,
-                num_frames,
-                frame_rate,
-            )
         return num_frames
 
 

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -544,7 +544,7 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
             apply_attention_backend_override(layer, target)
         self.attn_backend = stage_backend
         self._attention_backend_active_override = target
-        logger.info(
+        logger.debug(
             "Attention backend for this batch: %s (%d layers switched)",
             target.name.lower() if target else "server default",
             len(layers),

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/longcat_image.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/longcat_image.py
@@ -285,7 +285,7 @@ class LongCatPromptRewriteStage(PipelineStage):
             self.text_encoder = text_encoder
 
             if enable_prompt_rewrite:
-                logger.info(
+                logger.debug(
                     "Prompt rewriting is enabled (enable_prompt_rewrite=True). "
                     "This runs autoregressive decoding on the Qwen2.5-VL text "
                     "encoder (up to %d tokens). Pass --enable-prompt-rewrite "

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/ltx_2/duration.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/ltx_2/duration.py
@@ -84,7 +84,7 @@ class LTX2DurationStage(PipelineStage):
                 max_seconds=float(batch.auto_duration_max_seconds),
             )
 
-        logger.info(
+        logger.debug(
             "Auto-duration: %d frames (requested %d) @ %.2f fps",
             num_frames,
             int(batch.num_frames),


### PR DESCRIPTION
## Motivation

Several recently added diffusion logs run once per request or batch at info level, duplicating outcomes or reporting request-level implementation detail to operators.

## Modifications

- Move per-request LongCat prompt-rewrite and attention-backend selection messages to debug.
- Remove the duplicate successful LTX-2 duration prediction log from the model helper.
- Keep the stage-level duration summary at debug and preserve clamp/bounds warnings.

## Accuracy Tests

Not applicable. No inference behavior changes.

## Speed Tests and Profiling

Not applicable. This only reduces logging on request paths.

## Checklist

- [x] Format your code with pre-commit.
- [x] Unit tests are not required for log-level-only changes.
- [x] Documentation is not required for internal log levels.
- [x] Accuracy and speed impact documented above.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32325385285](https://github.com/sgl-project/sglang/actions/runs/32325385285)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32325385220](https://github.com/sgl-project/sglang/actions/runs/32325385220)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->