### PR TITLE
[diffusion] ci: use canonical residency selector

### DIFF
--- a/scripts/ci/utils/diffusion/comparison_configs.json
+++ b/scripts/ci/utils/diffusion/comparison_configs.json
@@ -13,7 +13,7 @@
             "num_gpus": 2,
             "frameworks": {
                 "sglang": {
-                    "serve_args": "--warmup-mode server --dit-layerwise-offload false --tp-size 2",
+                    "serve_args": "--warmup-mode server --component-residency dit=resident --tp-size 2",
                     "extra_env": {}
                 }
             }
@@ -29,7 +29,7 @@
             "num_gpus": 2,
             "frameworks": {
                 "sglang": {
-                    "serve_args": "--warmup-mode server --dit-layerwise-offload false --tp-size 2",
+                    "serve_args": "--warmup-mode server --component-residency dit=resident --tp-size 2",
                     "extra_env": {}
                 }
             }


### PR DESCRIPTION
## Motivation

The FLUX comparison jobs still express resident DiT placement through the compatibility flag `--dit-layerwise-offload false`. Nightly configurations should exercise the canonical residency selector while legacy CLI flags remain supported for users.

## Modifications

- Replace `--dit-layerwise-offload false` with `--component-residency dit=resident` in the FLUX.1 and FLUX.2 comparison configurations.
- Do not remove or change the legacy CLI compatibility path.

## Accuracy Tests

Not run locally, following the repository-local SGLang-Diffusion development guidance. The two arguments resolve to resident DiT placement.

## Speed Tests and Profiling

No benchmark behavior change is intended. NVIDIA CI is requested to validate the canonical argument path.

## Checklist

- [x] Format the changed file with pre-commit.
- [x] Existing nightly jobs provide coverage for this configuration-only change.
- [x] Documentation already describes the canonical selector and legacy compatibility.
- [x] Accuracy and speed impact documented above.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32325392009](https://github.com/sgl-project/sglang/actions/runs/32325392009)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #32325603135](https://github.com/sgl-project/sglang/actions/runs/32325603135)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->