### PR TITLE
fix: select FlashInfer CUTLASS for ModelOpt mixed MoE on SM120

### DIFF
--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -2505,13 +2505,13 @@ def _moe_runner_backend_quant_constraints(view: Any) -> dict:
             moe_runner_backend = mxfp8_default
     if (
         moe_runner_backend == "auto"
-        and view.quantization == "modelopt_fp4"
+        and view.quantization in ("modelopt_fp4", "modelopt_mixed")
         and is_sm120_supported()
     ):
         moe_runner_backend = "flashinfer_cutlass"
         logger.info(
             "Use flashinfer_cutlass as MoE runner backend on SM120 for "
-            "modelopt_fp4 (trtllm-gen MoE kernels are SM100-only)"
+            f"{view.quantization} (trtllm-gen MoE kernels are SM100-only)"
         )
     if moe_runner_backend != view.moe_runner_backend:
         return {"moe_runner_backend": moe_runner_backend}

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -1766,11 +1766,29 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             {"moe_runner_backend": "flashinfer_trtllm"},
         )
         with patch.object(overrides_module, "is_sm120_supported", return_value=True):
+            for quantization in ("modelopt_fp4", "modelopt_mixed"):
+                with self.subTest(quantization=quantization):
+                    self.assertEqual(
+                        _moe_runner_backend_quant_constraints(
+                            _view(quantization=quantization)
+                        ),
+                        {"moe_runner_backend": "flashinfer_cutlass"},
+                    )
             self.assertEqual(
                 _moe_runner_backend_quant_constraints(
-                    _view(quantization="modelopt_fp4")
+                    _view(
+                        quantization="modelopt_mixed",
+                        moe_runner_backend="flashinfer_trtllm",
+                    )
                 ),
-                {"moe_runner_backend": "flashinfer_cutlass"},
+                {},
+            )
+        with patch.object(overrides_module, "is_sm120_supported", return_value=False):
+            self.assertEqual(
+                _moe_runner_backend_quant_constraints(
+                    _view(quantization="modelopt_mixed")
+                ),
+                {},
             )
         self.assertEqual(_moe_runner_backend_quant_constraints(_view()), {})
 


### PR DESCRIPTION
## Motivation

On SM120, the quantization-driven MoE backend resolver selects `flashinfer_cutlass` for `modelopt_fp4`, but not for `modelopt_mixed`.

A mixed-precision checkpoint with NVFP4 MoE experts therefore leaves `--moe-runner-backend auto` unresolved. The NVFP4 MoE layer can then fall through to the TRT-LLM runner, although the trtllm-gen FP4 MoE kernels are SM100-only and use a different shuffled weight layout. Users currently have to pass `--moe-runner-backend flashinfer_cutlass` explicitly on SM120.

This supersedes #35422. Current `main` already has a dedicated FlashInfer CUTLASS runner, so selecting that runner before weight preparation is safer than switching kernels at runtime.

## Modifications

- Resolve `modelopt_mixed + SM120 + auto` to `flashinfer_cutlass`, matching the existing `modelopt_fp4` behavior.
- Preserve explicit backend selections.
- Preserve existing behavior on non-SM120 devices.
- Extend the model override unit test to cover both ModelOpt modes and the fallback boundaries.

## Accuracy Tests

This change only selects an existing runner before weight preparation; it does not modify kernel math or quantization scales.

```
71 passed, 1 skipped, 4 subtests passed
```

The focused backend-resolution test covers:

- `modelopt_fp4` and `modelopt_mixed` on SM120 -> `flashinfer_cutlass`
- explicit `flashinfer_trtllm` -> unchanged
- `modelopt_mixed` on non-SM120 -> unchanged

## Speed Tests and Profiling

No kernel implementation changes are included. After this patch, the automatic configuration selects the same FlashInfer CUTLASS path as an explicit `--moe-runner-backend flashinfer_cutlass` launch.

## Checklist

- [x] Format code with pre-commit.
- [x] Add unit tests.
- [x] No documentation update is required because no public option is added or changed.
- [x] Accuracy impact reviewed; no numerical path is modified.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32325693849](https://github.com/sgl-project/sglang/actions/runs/32325693849)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32325693438](https://github.com/sgl-project/sglang/actions/runs/32325693438)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->