### PR TITLE
[diffusion] add tiered MiniMax-H3 AdaLN cache

### DIFF
--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/transformer_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/transformer_loader.py
@@ -260,8 +260,14 @@ class TransformerLoader(ComponentLoader):
             # Keep the weights off-device; the model rebuilds the AdaLN
             # outputs from the checkpoint for each request's timestep plan.
             init_params["adaln_weight_files"] = safetensors_list
+            init_params["adaln_max_plans"] = (
+                component_server_args.minimax_h3_adaln_max_plans
+            )
             init_params["adaln_plan_width"] = (
                 component_server_args.minimax_h3_adaln_plan_width
+            )
+            init_params["adaln_host_cache_max_bytes"] = int(
+                component_server_args.minimax_h3_adaln_host_cache_gb * 2**30
             )
             checkpoint_key_filter = _minimax_h3_adaln_cache_key_filter
 

--- a/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
@@ -10,8 +10,10 @@ from __future__ import annotations
 import math
 import os
 import struct
+from collections import OrderedDict
 from contextlib import ExitStack
-from typing import Any, Callable
+from dataclasses import dataclass
+from typing import Any, Callable, Literal
 
 import torch
 import torch.nn as nn
@@ -71,6 +73,7 @@ from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph import (
     eager_on_graph,
 )
+from sglang.srt.utils.common import is_pin_memory_available
 
 logger = init_logger(__name__)
 
@@ -961,7 +964,7 @@ class MiniMaxH3AdalnProj(nn.Module):
 # A ref2va request carrying both a visual and an audio reference reaches four
 # distinct timesteps in one step: video, audio, the imgvid condition and the
 # audio reference. That is the widest case, so it is the default; a deployment
-# serving only narrower tasks (t2va reaches 2, fl2va 3) can shrink the slab
+# serving only narrower tasks (t2va reaches 2, fl2va 3) can shrink the workspace
 # proportionally via --minimax-h3-adaln-plan-width.
 MINIMAX_H3_ADALN_MAX_PLAN_WIDTH = 4
 
@@ -974,8 +977,95 @@ def _plan_key(timesteps: torch.Tensor) -> tuple[int, ...]:
     )
 
 
+MiniMaxH3AdalnScheduleKey = tuple[tuple[int, ...], ...]
+
+
+@dataclass(frozen=True)
+class MiniMaxH3AdalnAccess:
+    tier: Literal["gpu_hit", "host_hit", "rebuild"]
+    h2d_bytes: int = 0
+    d2h_bytes: int = 0
+    h2d_transfers: int = 0
+    d2h_transfers: int = 0
+    gpu_hits: int = 0
+    host_hits: int = 0
+    host_misses: int = 0
+    admissions: int = 0
+    evictions: int = 0
+    rebuilds: int = 0
+
+
+@dataclass(frozen=True)
+class _MiniMaxH3AdalnScheduleEntry:
+    plan_timesteps: torch.Tensor
+    block_params: torch.Tensor
+    final_params: torch.Tensor
+
+    @property
+    def nbytes(self) -> int:
+        return (
+            self.plan_timesteps.numel() * self.plan_timesteps.element_size()
+            + self.block_params.numel() * self.block_params.element_size()
+            + self.final_params.numel() * self.final_params.element_size()
+        )
+
+
+class MiniMaxH3AdalnHostCache:
+    """Byte-bounded LRU of complete AdaLN schedules in host memory."""
+
+    def __init__(self, max_bytes: int) -> None:
+        if max_bytes < 0:
+            raise ValueError("MiniMax H3 AdaLN host cache max_bytes cannot be negative")
+        self.max_bytes = max_bytes
+        self.current_bytes = 0
+        self.hits = 0
+        self.misses = 0
+        self.admissions = 0
+        self.evictions = 0
+        self._entries: OrderedDict[
+            MiniMaxH3AdalnScheduleKey, _MiniMaxH3AdalnScheduleEntry
+        ] = OrderedDict()
+
+    @property
+    def enabled(self) -> bool:
+        return self.max_bytes > 0
+
+    def get(
+        self, key: MiniMaxH3AdalnScheduleKey
+    ) -> _MiniMaxH3AdalnScheduleEntry | None:
+        entry = self._entries.get(key)
+        if entry is None:
+            self.misses += 1
+            return None
+        self._entries.move_to_end(key)
+        self.hits += 1
+        return entry
+
+    def put(
+        self,
+        key: MiniMaxH3AdalnScheduleKey,
+        entry: _MiniMaxH3AdalnScheduleEntry,
+    ) -> bool:
+        if not self.enabled or entry.nbytes > self.max_bytes:
+            return False
+        previous = self._entries.pop(key, None)
+        if previous is not None:
+            self.current_bytes -= previous.nbytes
+        while self.current_bytes + entry.nbytes > self.max_bytes:
+            _, evicted = self._entries.popitem(last=False)
+            self.current_bytes -= evicted.nbytes
+            self.evictions += 1
+        self._entries[key] = entry
+        self.current_bytes += entry.nbytes
+        self.admissions += 1
+        return True
+
+    def __len__(self) -> int:
+        return len(self._entries)
+
+
 class MiniMaxH3AdalnCache(nn.Module):
-    """Precomputed AdaLN outputs for fixed FP32 timestep plans."""
+    """AdaLN outputs backed by a sidecar or an online schedule cache."""
 
     _FORMAT_VERSION = "2"
     plan_timesteps: torch.Tensor
@@ -992,6 +1082,7 @@ class MiniMaxH3AdalnCache(nn.Module):
         weight_files: list[str] | None = None,
         max_plans: int = 64,
         max_plan_width: int = MINIMAX_H3_ADALN_MAX_PLAN_WIDTH,
+        host_cache_max_bytes: int = 0,
     ) -> None:
         super().__init__()
         if (path is None) == (weight_files is None):
@@ -1015,9 +1106,10 @@ class MiniMaxH3AdalnCache(nn.Module):
         self.hidden_size = arch.hidden_size
         self.block_width = 6 * MINIMAX_H3_ADALN_MODALITY_NUM * arch.hidden_size
         self.final_width = 2 * arch.hidden_size
-        # Rebuild path only: plan bit pattern -> slot, tracked on the host.
-        self._slots: dict[tuple[int, ...], int] = {}
+        self.host_cache = MiniMaxH3AdalnHostCache(host_cache_max_bytes)
+        self._active_schedule_key: MiniMaxH3AdalnScheduleKey | None = None
         self.rebuilds = 0
+        self.gpu_hits = 0
 
     def load(self, device: torch.device) -> None:
         if self.path is None:
@@ -1074,7 +1166,7 @@ class MiniMaxH3AdalnCache(nn.Module):
         self.register_buffer("final_params", final_params.to(device))
 
     def _allocate(self, device: torch.device) -> None:
-        """Empty slab for the rebuild path; its pointers must never move.
+        """Allocate the request workspace once so its pointers never move.
 
         ``plan_lengths`` starts at zero and that is what keeps unused slots out
         of ``lookup``: a real plan always has at least one timestep, so a zero
@@ -1107,18 +1199,28 @@ class MiniMaxH3AdalnCache(nn.Module):
             ),
         )
         logger.info(
-            "MiniMax H3 AdaLN rebuild slab: %d plans x %d timesteps = %.2f GiB",
+            "MiniMax H3 AdaLN workspace: %d plans x %d timesteps = %.2f GiB",
             self.max_plans,
             width,
-            self.block_params.numel() * 2 / 2**30,
+            sum(
+                tensor.numel() * tensor.element_size()
+                for tensor in (
+                    self.plan_timesteps,
+                    self.plan_lengths,
+                    self.block_params,
+                    self.final_params,
+                )
+            )
+            / 2**30,
         )
 
+    @torch.inference_mode()
     def build(
         self,
         step_timesteps: list[torch.Tensor],
         *,
         embed: Callable[[torch.Tensor], torch.Tensor],
-    ) -> None:
+    ) -> MiniMaxH3AdalnAccess:
         """Fill every plan this request will look up, in one streaming pass.
 
         Each plan keeps its own timestep count as the GEMM batch size, because
@@ -1135,9 +1237,12 @@ class MiniMaxH3AdalnCache(nn.Module):
         wanted: dict[tuple[int, ...], torch.Tensor] = {}
         for timesteps in step_timesteps:
             wanted.setdefault(_plan_key(timesteps), timesteps)
-        missing = {k: v for k, v in wanted.items() if k not in self._slots}
-        if not missing:
-            return
+        if not wanted:
+            raise ValueError("MiniMax H3 AdaLN rebuild needs at least one plan")
+        schedule_key = tuple(wanted)
+        if schedule_key == self._active_schedule_key:
+            self.gpu_hits += 1
+            return self._access("gpu_hit")
         if len(wanted) > self.max_plans:
             raise ValueError(
                 f"MiniMax H3 AdaLN rebuild needs {len(wanted)} plans but "
@@ -1151,22 +1256,31 @@ class MiniMaxH3AdalnCache(nn.Module):
                 "--minimax-h3-adaln-plan-width (t2va needs 2, fl2va 3, ref2va 4)"
             )
 
-        reset = len(self._slots) + len(missing) > self.max_plans
-        # A reset also evicts this request's cache hits, so rebuild its complete
-        # plan set rather than only the plans that were initially missing.
-        plans_to_build = wanted if reset else missing
-        if reset:
-            self._slots.clear()
-            self.plan_lengths.zero_()
+        host_entry = (
+            self.host_cache.get(schedule_key) if self.host_cache.enabled else None
+        )
+        self._invalidate_workspace()
+        if host_entry is not None:
+            self._load_host_entry(wanted, schedule_key, host_entry)
+            logger.info(
+                "MiniMax H3 AdaLN: loaded %d-plan schedule from host cache "
+                "(%d entries, %.2f GiB)",
+                len(wanted),
+                len(self.host_cache),
+                self.host_cache.current_bytes / 2**30,
+            )
+            return self._access(
+                "host_hit",
+                h2d_bytes=host_entry.nbytes,
+                h2d_transfers=1,
+            )
 
         device = self.block_params.device
         slots = []
-        pending_slots: dict[tuple[int, ...], int] = {}
-        for offset, (key, timesteps) in enumerate(plans_to_build.items()):
-            slot = len(self._slots) + offset
-            pending_slots[key] = slot
-            slots.append((slot, timesteps.numel(), embed(timesteps.to(device))))
-            self.plan_timesteps[slot, : timesteps.numel()] = timesteps.to(device)
+        for slot, timesteps in enumerate(wanted.values()):
+            device_timesteps = timesteps.to(device)
+            slots.append((slot, timesteps.numel(), embed(device_timesteps)))
+            self.plan_timesteps[slot, : timesteps.numel()] = device_timesteps
 
         # adaln_proj is a ColumnParallelLinear: each rank owns a slice of the
         # output features and all-gathers afterwards. The rebuild has to do the
@@ -1212,18 +1326,141 @@ class MiniMaxH3AdalnCache(nn.Module):
 
         for slot, length, _ in slots:
             self.plan_lengths[slot] = length
-        # Commit host metadata only after every layer has been written. If a
-        # checkpoint read or projection raises, the zero-length slots remain
-        # invisible and a later request can retry the rebuild.
-        self._slots.update(pending_slots)
+        self._active_schedule_key = schedule_key
         self.rebuilds += 1
+        admitted_bytes = self._admit_active_schedule(
+            schedule_key, plan_count=len(wanted), width=widest
+        )
         logger.info(
-            "MiniMax H3 AdaLN: rebuilt %d plan(s), %d/%d resident, pass #%d",
-            len(plans_to_build),
-            len(self._slots),
+            "MiniMax H3 AdaLN: rebuilt %d-plan schedule, %d/%d workspace slots "
+            "active, pass #%d",
+            len(wanted),
+            len(wanted),
             self.max_plans,
             self.rebuilds,
         )
+        return self._access(
+            "rebuild",
+            d2h_bytes=admitted_bytes,
+            d2h_transfers=1 if admitted_bytes else 0,
+        )
+
+    def _access(
+        self,
+        tier: Literal["gpu_hit", "host_hit", "rebuild"],
+        **kwargs: int,
+    ) -> MiniMaxH3AdalnAccess:
+        return MiniMaxH3AdalnAccess(
+            tier=tier,
+            gpu_hits=self.gpu_hits,
+            host_hits=self.host_cache.hits,
+            host_misses=self.host_cache.misses,
+            admissions=self.host_cache.admissions,
+            evictions=self.host_cache.evictions,
+            rebuilds=self.rebuilds,
+            **kwargs,
+        )
+
+    def _invalidate_workspace(self) -> None:
+        self._active_schedule_key = None
+        self.plan_lengths.zero_()
+
+    def _load_host_entry(
+        self,
+        wanted: dict[tuple[int, ...], torch.Tensor],
+        schedule_key: MiniMaxH3AdalnScheduleKey,
+        entry: _MiniMaxH3AdalnScheduleEntry,
+    ) -> None:
+        device = self.block_params.device
+        plan_count, width = entry.block_params.shape[:2]
+        if (
+            plan_count != len(wanted)
+            or width > self.max_plan_width
+            or entry.plan_timesteps.shape != (plan_count, width)
+            or entry.block_params.shape[2:] != (self.num_layers, self.block_width)
+            or entry.final_params.shape != (plan_count, width, self.final_width)
+        ):
+            raise RuntimeError("MiniMax H3 AdaLN host cache entry has invalid shape")
+        non_blocking = entry.block_params.is_pinned() and device.type == "cuda"
+        self.plan_timesteps[:plan_count, :width].copy_(
+            entry.plan_timesteps, non_blocking=non_blocking
+        )
+        self.block_params[:plan_count, :width].copy_(
+            entry.block_params, non_blocking=non_blocking
+        )
+        self.final_params[:plan_count, :width].copy_(
+            entry.final_params, non_blocking=non_blocking
+        )
+        for slot, timesteps in enumerate(wanted.values()):
+            self.plan_lengths[slot] = timesteps.numel()
+        self._active_schedule_key = schedule_key
+
+    def _admit_active_schedule(
+        self,
+        schedule_key: MiniMaxH3AdalnScheduleKey,
+        plan_count: int,
+        width: int,
+    ) -> int:
+        if not self.host_cache.enabled:
+            return 0
+        entry_nbytes = (
+            plan_count * width * torch.empty((), dtype=_FP32_DTYPE).element_size()
+            + plan_count
+            * width
+            * (self.num_layers * self.block_width + self.final_width)
+            * torch.empty((), dtype=_BF16_DTYPE).element_size()
+        )
+        if entry_nbytes > self.host_cache.max_bytes:
+            return 0
+        pin_memory = is_pin_memory_available(self.block_params.device)
+        try:
+            plan_timesteps = torch.zeros(
+                (plan_count, width),
+                dtype=_FP32_DTYPE,
+                device="cpu",
+                pin_memory=pin_memory,
+            )
+            block_params = torch.empty(
+                (plan_count, width, self.num_layers, self.block_width),
+                dtype=_BF16_DTYPE,
+                device="cpu",
+                pin_memory=pin_memory,
+            )
+            final_params = torch.empty(
+                (plan_count, width, self.final_width),
+                dtype=_BF16_DTYPE,
+                device="cpu",
+                pin_memory=pin_memory,
+            )
+            plan_timesteps.copy_(
+                self.plan_timesteps[:plan_count, :width],
+                non_blocking=pin_memory,
+            )
+            block_params.copy_(
+                self.block_params[:plan_count, :width],
+                non_blocking=pin_memory,
+            )
+            final_params.copy_(
+                self.final_params[:plan_count, :width],
+                non_blocking=pin_memory,
+            )
+            if pin_memory:
+                torch.cuda.current_stream(self.block_params.device).synchronize()
+        except RuntimeError:
+            logger.warning(
+                "MiniMax H3 AdaLN: failed to allocate host schedule cache entry",
+                exc_info=True,
+            )
+            return 0
+        admitted = self.host_cache.put(
+            schedule_key,
+            _MiniMaxH3AdalnScheduleEntry(
+                plan_timesteps=plan_timesteps,
+                block_params=block_params,
+                final_params=final_params,
+            ),
+        )
+        return entry_nbytes if admitted else 0
 
     def lookup(self, unique_timesteps: torch.Tensor) -> torch.Tensor:
         num_timesteps = unique_timesteps.shape[0]
@@ -1559,7 +1796,9 @@ class MiniMaxH3DiTModel(BaseDiT, LayerwiseOffloadableModuleMixin):
     reverse_param_names_mapping = _ARCH_DEFAULTS.reverse_param_names_mapping
     lora_param_names_mapping = _ARCH_DEFAULTS.lora_param_names_mapping
 
-    def prepare_adaln_plans(self, step_timesteps: list[torch.Tensor]) -> None:
+    def prepare_adaln_plans(
+        self, step_timesteps: list[torch.Tensor]
+    ) -> MiniMaxH3AdalnAccess | None:
         """Fill the AdaLN cache for this request before denoising starts.
 
         No-op for a prebuilt sidecar; the rebuild path needs the model's own
@@ -1567,12 +1806,12 @@ class MiniMaxH3DiTModel(BaseDiT, LayerwiseOffloadableModuleMixin):
         adaln_proj weights would have produced.
         """
         if self.adaln_cache is None or self.adaln_cache.weight_files is None:
-            return
+            return None
 
         def embed(timesteps: torch.Tensor) -> torch.Tensor:
             return nn.functional.silu(self.time_embedder(timesteps)).to(_BF16_DTYPE)
 
-        self.adaln_cache.build(step_timesteps, embed=embed)
+        return self.adaln_cache.build(step_timesteps, embed=embed)
 
     def _can_batch_block_adaln(self) -> bool:
         return (
@@ -1656,7 +1895,9 @@ class MiniMaxH3DiTModel(BaseDiT, LayerwiseOffloadableModuleMixin):
         adaln_cache_path: str | None = None,
         adaln_cache_model_variant: str | None = None,
         adaln_weight_files: list[str] | None = None,
+        adaln_max_plans: int = 64,
         adaln_plan_width: int = MINIMAX_H3_ADALN_MAX_PLAN_WIDTH,
+        adaln_host_cache_max_bytes: int = 0,
     ) -> None:
         super().__init__(config=config, hf_config=hf_config)
         if (
@@ -1747,7 +1988,9 @@ class MiniMaxH3DiTModel(BaseDiT, LayerwiseOffloadableModuleMixin):
                 path=adaln_cache_path,
                 model_variant=adaln_cache_model_variant,
                 weight_files=adaln_weight_files,
+                max_plans=adaln_max_plans,
                 max_plan_width=adaln_plan_width,
+                host_cache_max_bytes=adaln_host_cache_max_bytes,
             )
             if self._adaln_precomputed
             else None

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/minimax_h3/denoise_loop.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/minimax_h3/denoise_loop.py
@@ -371,6 +371,8 @@ def minimax_h3_denoise_loop(
     audio_cond_noise_aug_for_inference: float = MINIMAX_H3_AUDIO_REF_COND_TIMESTEP,
     on_step: Callable[[int, torch.Tensor, torch.Tensor], None] | None = None,
     step_profiler: Callable[[int], AbstractContextManager] | None = None,
+    adaln_prepare_profiler: Callable[[], AbstractContextManager] | None = None,
+    on_adaln_access: Callable[[Any], None] | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Run the full denoise loop; returns final (video_rows, audio_rows).
 
@@ -452,7 +454,15 @@ def minimax_h3_denoise_loop(
     # Every step's timesteps are settled by now. Rebuilding AdaLN reads all
     # 24.2 GiB of adaln_proj whatever is missing, so fill the whole request in
     # one pass here instead of topping up step by step inside the loop.
-    model.prepare_adaln_plans([entry[0] for entry in timestep_plan])
+    adaln_prepare_cm = (
+        adaln_prepare_profiler()
+        if adaln_prepare_profiler is not None
+        else nullcontext()
+    )
+    with adaln_prepare_cm:
+        adaln_access = model.prepare_adaln_plans([entry[0] for entry in timestep_plan])
+    if adaln_access is not None and on_adaln_access is not None:
+        on_adaln_access(adaln_access)
 
     # match the scheduler's device-fp32 math once, then reuse one denoised
     # scratch per modality instead of allocating intermediates every step

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/minimax_h3/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/minimax_h3/stages/denoising.py
@@ -691,6 +691,14 @@ class MiniMaxH3DenoisingStage(DenoisingStage):
                         self._profile_denoising_step,
                         batch=batch,
                     ),
+                    adaln_prepare_profiler=partial(
+                        self._profile_adaln_prepare,
+                        batch=batch,
+                    ),
+                    on_adaln_access=partial(
+                        self._record_adaln_access,
+                        batch=batch,
+                    ),
                 )
         finally:
             self._finish_active_component_use()
@@ -718,6 +726,48 @@ class MiniMaxH3DenoisingStage(DenoisingStage):
             ),
         ):
             yield
+
+    @contextmanager
+    def _profile_adaln_prepare(self, *, batch: Req):
+        with (
+            maybe_nvtx_range(
+                "MiniMaxH3AdalnPrepare",
+                self.current_use_nvtx,
+            ),
+            StageProfiler(
+                "MiniMaxH3AdalnPrepare",
+                logger=logger,
+                metrics=batch.metrics,
+                perf_dump_path_provided=batch.perf_dump_path is not None,
+            ),
+        ):
+            yield
+
+    @staticmethod
+    def _record_adaln_access(access, *, batch: Req) -> None:
+        if batch.metrics is None:
+            return
+        prefix = "minimax_h3_adaln"
+        batch.metrics.record_custom_metric(f"{prefix}.tier", access.tier)
+        batch.metrics.record_custom_metric(f"{prefix}.h2d_bytes", access.h2d_bytes)
+        batch.metrics.record_custom_metric(f"{prefix}.d2h_bytes", access.d2h_bytes)
+        batch.metrics.record_custom_metric(
+            f"{prefix}.h2d_transfers", access.h2d_transfers
+        )
+        batch.metrics.record_custom_metric(
+            f"{prefix}.d2h_transfers", access.d2h_transfers
+        )
+        for name in (
+            "gpu_hits",
+            "host_hits",
+            "host_misses",
+            "admissions",
+            "evictions",
+            "rebuilds",
+        ):
+            batch.metrics.record_custom_metric(
+                f"{prefix}.{name}", getattr(access, name)
+            )
 
     def _forward_dit(
         self,

--- a/python/sglang/multimodal_gen/runtime/server_args/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args/server_args.py
@@ -305,9 +305,13 @@ class ServerArgs(DisaggServerArgsMixin):
     minimax_h3_adaln_cache_path: str | None = None
     # Rebuild AdaLN outputs per request from the checkpoint, no sidecar needed.
     minimax_h3_adaln_online: bool = False
+    # Maximum number of distinct timestep plans in one request-local GPU workspace.
+    minimax_h3_adaln_max_plans: int = 64
     # Widest timestep plan the rebuild slab is sized for; see
     # MINIMAX_H3_ADALN_MAX_PLAN_WIDTH.
     minimax_h3_adaln_plan_width: int = 4
+    # Byte budget in GiB for complete schedules cached in pinned host memory.
+    minimax_h3_adaln_host_cache_gb: float = 0.0
     # Per-component transformer weight overrides (key = model_index.json component name).
     # Pipelines use this when a checkpoint ships separate quantized weights for
     # secondary DiT components; the generic loader consumes it without model-specific
@@ -539,6 +543,7 @@ class ServerArgs(DisaggServerArgsMixin):
         if self.served_model_name is None:
             self.served_model_name = self.model_id or self.model_path
         self._adjust_quant_config()
+        self._adjust_minimax_h3_adaln_graph_compatibility()
         self._adjust_breakable_cuda_graph_support()
         self._adjust_warmup()
         self._adjust_network_ports()
@@ -554,6 +559,7 @@ class ServerArgs(DisaggServerArgsMixin):
     def _validate_parameters(self):
         """check consistency and raise errors for invalid configs"""
         self._validate_scheduler_rpc_timeout()
+        self._validate_minimax_h3_adaln_cache()
         self._validate_pipeline()
         self._validate_offload()
         self._validate_direct_gpu_weight_loading()
@@ -565,6 +571,19 @@ class ServerArgs(DisaggServerArgsMixin):
         self._validate_batching()
         self._validate_breakable_cuda_graph()
         self.pipeline_config.validate_server_args(self)
+
+    def _validate_minimax_h3_adaln_cache(self) -> None:
+        if self.minimax_h3_adaln_max_plans <= 0:
+            raise ValueError("minimax_h3_adaln_max_plans must be positive")
+        if self.minimax_h3_adaln_plan_width <= 0:
+            raise ValueError("minimax_h3_adaln_plan_width must be positive")
+        if (
+            not math.isfinite(self.minimax_h3_adaln_host_cache_gb)
+            or self.minimax_h3_adaln_host_cache_gb < 0
+        ):
+            raise ValueError(
+                "minimax_h3_adaln_host_cache_gb must be finite and non-negative"
+            )
 
     def _validate_scheduler_rpc_timeout(self) -> None:
         timeout = self.scheduler_rpc_timeout
@@ -638,6 +657,29 @@ class ServerArgs(DisaggServerArgsMixin):
             "Tongyi-MAI/Z-Image/Z-Image-Turbo, and zai-org/GLM-Image are "
             "currently supported.",
             pipeline_config_name,
+        )
+        self.enable_breakable_cuda_graph = False
+
+    def _adjust_minimax_h3_adaln_graph_compatibility(self) -> None:
+        """Disable BCG for the online AdaLN path until capture is supported.
+
+        MiniMax-H3 currently invalidates CUDA capture when its online AdaLN
+        path participates in the first forward. Allowing both flags would
+        defer a deterministic incompatibility to warmup/replay. Sidecar and
+        resident AdaLN paths remain unchanged.
+        """
+        if not self.enable_breakable_cuda_graph or not self.minimax_h3_adaln_online:
+            return
+        if (
+            type(getattr(self, "pipeline_config", None)).__name__
+            != "MiniMaxH3PipelineConfig"
+        ):
+            return
+        logger.warning(
+            "[Diffusion BCG] disabled for MiniMax-H3 online AdaLN: "
+            "the online path is not capture-safe yet; serving "
+            "continues eagerly. Use a sidecar or resident AdaLN path to "
+            "enable BCG."
         )
         self.enable_breakable_cuda_graph = False
 
@@ -1672,10 +1714,21 @@ class ServerArgs(DisaggServerArgsMixin):
             action=StoreBoolean,
             default=ServerArgs.minimax_h3_adaln_online,
             help=(
-                "Rebuild MiniMax H3 AdaLN outputs from the checkpoint per "
-                "request instead of keeping the 24.2 GiB of adaln_proj weights "
+                "Build MiniMax H3 AdaLN outputs from the checkpoint on demand "
+                "instead of keeping the 24.2 GiB of adaln_proj weights "
                 "resident. Works with any step count or schedule and needs no "
-                "prebuilt artifact. Requires unquantized weights."
+                "prebuilt artifact. Requires unquantized weights. Breakable "
+                "CUDA graph is disabled until this path is capture-safe."
+            ),
+        )
+        parser.add_argument(
+            "--minimax-h3-adaln-max-plans",
+            type=int,
+            default=ServerArgs.minimax_h3_adaln_max_plans,
+            help=(
+                "Maximum number of distinct timestep plans in the request-local "
+                "MiniMax H3 AdaLN GPU workspace. An N-step schedule normally "
+                "needs at most N plans. Lowering this value reduces GPU memory."
             ),
         )
         parser.add_argument(
@@ -1687,6 +1740,16 @@ class ServerArgs(DisaggServerArgsMixin):
                 "for. The default 4 covers every task; a deployment serving "
                 "only t2va (2) or fl2va (3) can shrink the slab proportionally. "
                 "A request exceeding it is rejected rather than truncated."
+            ),
+        )
+        parser.add_argument(
+            "--minimax-h3-adaln-host-cache-gb",
+            type=float,
+            default=ServerArgs.minimax_h3_adaln_host_cache_gb,
+            help=(
+                "Pinned host-memory budget in GiB for complete MiniMax H3 AdaLN "
+                "schedules. Zero disables the host LRU. A host hit copies only "
+                "the requested schedule to GPU and avoids checkpoint rebuild."
             ),
         )
         parser.add_argument(

--- a/python/sglang/multimodal_gen/runtime/utils/perf_logger.py
+++ b/python/sglang/multimodal_gen/runtime/utils/perf_logger.py
@@ -52,6 +52,7 @@ class RequestMetrics:
         self.request_id = request_id
         self.stages: Dict[str, float] = {}
         self.steps: list[float] = []
+        self.custom_metrics: Dict[str, Any] = {}
         self.total_duration_ms: float = 0.0
         self.suppress_stage_breakdown: bool = False
         # memory tracking: {checkpoint_name: MemorySnapshot}
@@ -73,6 +74,11 @@ class RequestMetrics:
             return
         self.steps.append(duration_s * 1000)
 
+    def record_custom_metric(self, name: str, value: Any) -> None:
+        if self.suppress_stage_breakdown:
+            return
+        self.custom_metrics[name] = value
+
     def record_memory_snapshot(self, checkpoint_name: str, snapshot: MemorySnapshot):
         if self.suppress_stage_breakdown:
             return
@@ -84,6 +90,7 @@ class RequestMetrics:
             "request_id": self.request_id,
             "stages": self.stages,
             "steps": self.steps,
+            "custom_metrics": self.custom_metrics,
             "total_duration_ms": self.total_duration_ms,
             "memory_snapshots": {
                 name: snapshot.to_dict()
@@ -168,6 +175,7 @@ class RequestPerfRecord:
     stages: list[dict]
     steps: list[float]
     total_duration_ms: float
+    custom_metrics: dict[str, Any] = dataclasses.field(default_factory=dict)
     memory_snapshots: dict[str, dict] = dataclasses.field(default_factory=dict)
 
     def __init__(
@@ -178,6 +186,7 @@ class RequestPerfRecord:
         stages,
         steps,
         total_duration_ms,
+        custom_metrics=None,
         memory_snapshots=None,
         timestamp=None,
     ):
@@ -192,6 +201,7 @@ class RequestPerfRecord:
         self.stages = stages
         self.steps = steps
         self.total_duration_ms = total_duration_ms
+        self.custom_metrics = custom_metrics or {}
         self.memory_snapshots = memory_snapshots or {}
 
 
@@ -340,6 +350,7 @@ class PerformanceLogger:
             "total_duration_ms": metrics.total_duration_ms,
             "steps": formatted_steps,
             "denoise_steps_ms": denoise_steps_ms,
+            "custom_metrics": metrics.custom_metrics,
             "memory_checkpoints": memory_checkpoints,
             "meta": meta or {},
         }
@@ -381,6 +392,7 @@ class PerformanceLogger:
             stages=formatted_stages,
             steps=metrics.steps,
             total_duration_ms=metrics.total_duration_ms,
+            custom_metrics=metrics.custom_metrics,
             memory_snapshots=memory_checkpoints,
         )
 

--- a/python/sglang/multimodal_gen/test/unit/test_minimax_h3_adaln_cache.py
+++ b/python/sglang/multimodal_gen/test/unit/test_minimax_h3_adaln_cache.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 from pathlib import Path
 
 import pytest
@@ -16,6 +17,10 @@ from sglang.multimodal_gen.runtime.distributed.parallel_state import (
 )
 from sglang.multimodal_gen.runtime.models.dits.minimax_h3 import (
     MiniMaxH3AdalnCache,
+)
+from sglang.multimodal_gen.runtime.utils.perf_logger import (
+    PerformanceLogger,
+    RequestMetrics,
 )
 from sglang.multimodal_gen.test.single_test_file.component_accuracy.utils import (
     ensure_distributed_env_defaults,
@@ -61,6 +66,7 @@ def _online_cache(
     *,
     max_plans: int = 2,
     max_plan_width: int = 2,
+    host_cache_max_bytes: int = 0,
     omit: str | None = None,
 ) -> MiniMaxH3AdalnCache:
     _ensure_single_process_parallel_runtime()
@@ -71,6 +77,7 @@ def _online_cache(
         weight_files=[str(weight_path)],
         max_plans=max_plans,
         max_plan_width=max_plan_width,
+        host_cache_max_bytes=host_cache_max_bytes,
     )
     cache.load(torch.device("cpu"))
     return cache
@@ -78,6 +85,16 @@ def _online_cache(
 
 def _embed(timesteps: torch.Tensor) -> torch.Tensor:
     return timesteps[:, None].expand(-1, _ARCH.time_embed_dim)
+
+
+def _schedule_bytes(*, plan_count: int = 1, width: int = 1) -> int:
+    return (
+        plan_count * width * torch.empty((), dtype=torch.float32).element_size()
+        + plan_count
+        * width
+        * (_ARCH.num_layers * _BLOCK_WIDTH + _FINAL_WIDTH)
+        * torch.empty((), dtype=torch.bfloat16).element_size()
+    )
 
 
 def test_minimax_h3_adaln_cache_matches_bf16_embedding(tmp_path):
@@ -128,7 +145,7 @@ def test_minimax_h3_adaln_cache_matches_bf16_embedding(tmp_path):
 
 
 def test_online_cache_reset_rebuilds_previously_resident_request_plans(tmp_path):
-    """A capacity reset must not drop plans reused by the current request."""
+    """A new schedule must publish its complete request-local working set."""
     cache = _online_cache(tmp_path, max_plan_width=1)
     plan_a = torch.tensor([1.0])
     plan_b = torch.tensor([2.0])
@@ -139,6 +156,123 @@ def test_online_cache_reset_rebuilds_previously_resident_request_plans(tmp_path)
 
     cache.lookup(plan_a)
     cache.lookup(plan_c)
+    with pytest.raises(ValueError, match="does not cover"):
+        cache.lookup(plan_b)
+
+
+def test_online_cache_reuses_active_gpu_schedule(tmp_path):
+    """Repeating the active schedule must not scan its checkpoint again."""
+    cache = _online_cache(tmp_path)
+    plan_a = torch.tensor([1.0])
+    plan_b = torch.tensor([2.0])
+
+    cache.build([plan_a, plan_b], embed=_embed)
+    hit = cache.build([plan_a, plan_b], embed=_embed)
+
+    assert cache.rebuilds == 1
+    assert hit.tier == "gpu_hit"
+    assert hit.gpu_hits == 1
+
+
+def test_online_cache_workspace_pointers_stay_stable(tmp_path):
+    """Changing schedules must not replace graph-visible GPU buffers."""
+    cache = _online_cache(tmp_path, max_plans=2, max_plan_width=2)
+    pointers = tuple(
+        tensor.data_ptr()
+        for tensor in (
+            cache.plan_timesteps,
+            cache.plan_lengths,
+            cache.block_params,
+            cache.final_params,
+        )
+    )
+
+    cache.build([torch.tensor([1.0]), torch.tensor([2.0])], embed=_embed)
+    cache.build([torch.tensor([3.0]), torch.tensor([4.0])], embed=_embed)
+
+    assert pointers == tuple(
+        tensor.data_ptr()
+        for tensor in (
+            cache.plan_timesteps,
+            cache.plan_lengths,
+            cache.block_params,
+            cache.final_params,
+        )
+    )
+
+
+def test_online_cache_updates_inference_workspace_outside_inference_mode(tmp_path):
+    """A workspace created by model inference must remain writable on rebuild."""
+    _ensure_single_process_parallel_runtime()
+    weight_path = tmp_path / "model.safetensors"
+    _write_online_weights(weight_path)
+    with torch.inference_mode():
+        cache = MiniMaxH3AdalnCache(
+            _ARCH,
+            weight_files=[str(weight_path)],
+            max_plans=1,
+            max_plan_width=1,
+        )
+        cache.load(torch.device("cpu"))
+
+    cache.build([torch.tensor([1.0])], embed=_embed)
+    cache.lookup(torch.tensor([1.0]))
+
+
+def test_online_cache_restores_complete_schedule_from_host_lru(tmp_path):
+    cache = _online_cache(
+        tmp_path,
+        host_cache_max_bytes=2 * _schedule_bytes(),
+    )
+    plan_a = torch.tensor([1.0])
+    plan_b = torch.tensor([2.0])
+
+    cache.build([plan_a], embed=_embed)
+    expected = cache.block_params[0, 0].clone()
+    cache.build([plan_b], embed=_embed)
+    restored = cache.build([plan_a], embed=_embed)
+
+    assert cache.rebuilds == 2
+    assert restored.tier == "host_hit"
+    assert restored.h2d_bytes == _schedule_bytes()
+    assert restored.host_hits == 1
+    assert torch.equal(cache.block_params[0, 0], expected)
+    cache.lookup(plan_a)
+
+
+def test_adaln_access_metrics_are_written_to_perf_dump(tmp_path):
+    """AdaLN tier metrics must survive request-report serialization."""
+    metrics = RequestMetrics("request")
+    metrics.record_custom_metric("minimax_h3_adaln.tier", "host_hit")
+    metrics.record_custom_metric("minimax_h3_adaln.h2d_bytes", 123)
+    output = tmp_path / "perf.json"
+
+    PerformanceLogger.dump_benchmark_report(str(output), metrics)
+
+    report = json.loads(output.read_text())
+    assert report["custom_metrics"] == {
+        "minimax_h3_adaln.tier": "host_hit",
+        "minimax_h3_adaln.h2d_bytes": 123,
+    }
+
+
+def test_online_cache_host_lru_evicts_by_bytes(tmp_path):
+    """Returning after byte-budget eviction must rebuild the schedule."""
+    cache = _online_cache(
+        tmp_path,
+        host_cache_max_bytes=_schedule_bytes(),
+    )
+    plan_a = torch.tensor([1.0])
+    plan_b = torch.tensor([2.0])
+
+    cache.build([plan_a], embed=_embed)
+    cache.build([plan_b], embed=_embed)
+    rebuilt = cache.build([plan_a], embed=_embed)
+
+    assert cache.rebuilds == 3
+    assert rebuilt.tier == "rebuild"
+    assert cache.host_cache.evictions == 2
+    assert cache.host_cache.current_bytes <= cache.host_cache.max_bytes
 
 
 def test_online_cache_failed_rebuild_can_be_retried(tmp_path):

--- a/python/sglang/multimodal_gen/test/unit/test_server_args.py
+++ b/python/sglang/multimodal_gen/test/unit/test_server_args.py
@@ -675,6 +675,19 @@ class TestWarmupModeNormalization(unittest.TestCase):
         sa.bcg_text_buckets = None
         sa._validate_breakable_cuda_graph()  # must not raise
 
+    def test_only_online_minimax_h3_adaln_disables_breakable_cuda_graph(self):
+        """BCG must fail closed for online AdaLN without affecting sidecars."""
+        for online, expected in ((True, False), (False, True)):
+            with self.subTest(online=online):
+                sa = ServerArgs.__new__(ServerArgs)
+                sa.enable_breakable_cuda_graph = True
+                sa.minimax_h3_adaln_online = online
+                sa.pipeline_config = MiniMaxH3PipelineConfig()
+
+                sa._adjust_minimax_h3_adaln_graph_compatibility()
+
+                self.assertEqual(sa.enable_breakable_cuda_graph, expected)
+
     def test_disagg_role_disables_server_warmup(self):
         from sglang.multimodal_gen.runtime.disaggregation.roles import RoleType
 


### PR DESCRIPTION
Related issue: #35495

## Motivation

MiniMax-H3 can avoid keeping the 24.2 GiB `adaln_proj` checkpoint weights resident by rebuilding AdaLN outputs online. The previous online path kept a fixed GPU slab of historical timestep plans. That slab reserved memory for plans that the current request did not use and discarded all resident plans when its capacity was exceeded. Returning to a recently used schedule therefore required another full checkpoint scan.

This change adds a tiered cache manager that keeps only the current request's working set on GPU, stores complete schedules in a bounded pinned-CPU LRU, and rebuilds schedules from checkpoint weights only on CPU misses. Exact FP32 timestep-plan matching is preserved; approximate timestep merging and scheduler changes are out of scope.

## Modifications

- Replaced the historical GPU plan set with a request-local working set backed by stable GPU tensors. The tensor pointers remain stable for CUDA graph compatibility, while only the active request's plans are published through `plan_lengths`.
- Added exact schedule keys containing every timestep plan used by the request. A complete schedule is treated as one cache entry so partial hits cannot expose an inconsistent request.
- Added a byte-bounded pinned-CPU LRU cache for complete projected AdaLN schedules. CPU hits restore the timestep metadata and projected parameters to the GPU workspace without rereading checkpoint weights.
- Added transactional publication for rebuilds and host restores. A failed checkpoint read, projection, allocation, or shape validation leaves the previous request invisible and allows a later request to retry safely.
- Preserved TP sharding semantics by reading only the local AdaLN column shard and using the same all-gather behavior as the existing column-parallel path.
- Added GPU-hit, host-hit, rebuild, transfer, admission, eviction, and miss counters to the request perf dump through custom metrics.
- Added `--minimax-h3-adaln-max-plans` and `--minimax-h3-adaln-host-cache-gb`. The existing default remains `64` plans and width `4` for backwards compatibility; deployments can select a request-sized workspace explicitly, for example `7` plans and width `2` for T2VA or width `3` for FL2VA.
- Added validation for invalid plan capacity, plan width, and non-finite or negative host-cache sizes.
- Online AdaLN now automatically disables breakable CUDA graph capture at startup with an actionable warning because dynamic online rebuild and the current capture path are not replay-safe. Resident-weight and fixed-sidecar paths retain their existing graph behavior.
- Added unit coverage for GPU hits, host hits, byte-based eviction, transactional retry, request reset, pointer stability, shape/width rejection, perf metric serialization, and online-AdaLN graph compatibility.

## Accuracy Tests

- MiniMax-H3 AdaLN unit tests: `10 passed`.
- Server-argument and graph-compatibility tests: `13 passed`, including both online-AdaLN graph downgrade and sidecar graph-preservation cases.
- The audited AdaLN comparison covered `470,367,744` output elements at TP1 and TP2 with zero mismatches.
- A real TP2 MiniMax-H3 FL2VA run completed the full submit, denoise, video/audio decode, MP4 creation, and download path for an `A -> B -> A` schedule sequence. The first and third requests used the same prompt, seed, resolution, duration, and schedule; their MP4 SHA256 values were identical:
  - `91186630bf7862d3892877bd1bacaa4464b3937b5a1f45ee8190be58995104af`
- The third request was served from the pinned host tier and did not rebuild AdaLN outputs.

## Speed Tests and Profiling

Environment: `2 x H200`, MiniMax-H3 FL2VA, TP2, Ulysses 1, 1344x768, 4 seconds, 8 inference steps.

| Request | AdaLN preparation | Tier | E2E wall time |
| --- | ---: | --- | ---: |
| Schedule A, first request | `2753.104 ms` | rebuild | `65.166 s` |
| Schedule B | `2390.848 ms` | rebuild | `50.135 s` |
| Schedule A, return | `7.392 ms` | pinned host hit | `47.115 s` |

The host-hit request transferred `135,776,312` bytes to GPU memory with one H2D transfer, recorded `host_hits=1`, and kept `rebuilds=2` after the three-request sequence. The configured `7`-plan, width-`3` FL2VA workspace used approximately `0.19 GiB` per card for AdaLN buffers.

The cold-miss profile shows that checkpoint movement dominates rebuild cost: approximately `24.3 GiB` of AdaLN checkpoint data is transferred, while the main projection GEMMs account for only a small fraction of the capture. The pinned host transfer avoids that checkpoint scan on repeated schedules.

Validation commands completed:

- `python -m black --check` on all modified Python files.
- `python -m py_compile` on all modified Python modules and tests.
- `git diff --check`.

The pre-commit hook could not download its external environment because the execution environment had no GitHub DNS/network access; this is an environment limitation rather than a formatting failure.

## Checklist

- [x] Code formatting and whitespace checks passed with Black and `git diff --check`.
- [x] Added focused unit tests for cache tiers, transactional failure behavior, metrics, and graph compatibility.
- [x] Added this implementation and benchmark documentation.
- [x] Provided TP2 end-to-end accuracy and speed measurements.
- [x] Reviewed the implementation against SGLang code style and preserved existing sidecar/resident paths.

## Review and Merge Process

1. Ping Merge Oncalls after the PR has received the required CODEOWNERS reviews.
2. Trigger CI with `/tag-and-rerun-ci`, `/tag-run-ci-label`, or `/rerun-failed-ci` when appropriate.
3. Confirm the MiniMax-H3 unit tests and relevant multimodal generation CI jobs are green.
4. After approvals and green CI, ask a Merge Oncall or maintainer with write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32327627623](https://github.com/sgl-project/sglang/actions/runs/32327627623)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32327627456](https://github.com/sgl-project/sglang/actions/runs/32327627456)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->