### PR TITLE
Bound DSpark rejection sampling workspace

### DIFF
--- a/python/sglang/kernels/ops/speculative/dspark/dspark_accept.py
+++ b/python/sglang/kernels/ops/speculative/dspark/dspark_accept.py
@@ -40,6 +40,8 @@ class AcceptSampling:
         gamma: int,
         verify_num_draft_tokens: int,
         cutoff_verify_lens: Optional[torch.Tensor] = None,
+        uniform_samples: Optional[torch.Tensor] = None,
+        uniform_samples_final: Optional[torch.Tensor] = None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         return accept_sampling(
             candidates=candidates,
@@ -50,6 +52,8 @@ class AcceptSampling:
             gamma=gamma,
             verify_num_draft_tokens=verify_num_draft_tokens,
             cutoff_verify_lens=cutoff_verify_lens,
+            uniform_samples=uniform_samples,
+            uniform_samples_final=uniform_samples_final,
         )
 
     @classmethod
@@ -64,6 +68,8 @@ class AcceptSampling:
         gamma: int,
         verify_num_draft_tokens: int,
         cutoff_verify_lens: Optional[torch.Tensor] = None,
+        uniform_samples: Optional[torch.Tensor] = None,
+        uniform_samples_final: Optional[torch.Tensor] = None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         return accept_sampling_triton(
             candidates=candidates,
@@ -74,6 +80,8 @@ class AcceptSampling:
             gamma=gamma,
             verify_num_draft_tokens=verify_num_draft_tokens,
             cutoff_verify_lens=cutoff_verify_lens,
+            uniform_samples=uniform_samples,
+            uniform_samples_final=uniform_samples_final,
         )
 
 
@@ -87,6 +95,8 @@ def _accept_sampling_core(
     gamma: int,
     verify_num_draft_tokens: int,
     cutoff_verify_lens: Optional[torch.Tensor],
+    uniform_samples: Optional[torch.Tensor],
+    uniform_samples_final: Optional[torch.Tensor],
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     bs = candidates.shape[0]
     device = candidates.device
@@ -117,8 +127,10 @@ def _accept_sampling_core(
         draft_token_num=verify_num_draft_tokens,
         device=device,
     )
-    uniform_samples = torch.rand((bs, gamma), dtype=torch.float32, device=device)
-    uniform_samples_final = torch.rand((bs,), dtype=torch.float32, device=device)
+    if uniform_samples is None:
+        uniform_samples = torch.rand((bs, gamma), dtype=torch.float32, device=device)
+    if uniform_samples_final is None:
+        uniform_samples_final = torch.rand((bs,), dtype=torch.float32, device=device)
     chain_speculative_sampling_triton(
         predicts=predicts,
         accept_index=accept_index,
@@ -155,6 +167,8 @@ def accept_sampling(
     gamma: int,
     verify_num_draft_tokens: int,
     cutoff_verify_lens: Optional[torch.Tensor] = None,
+    uniform_samples: Optional[torch.Tensor] = None,
+    uniform_samples_final: Optional[torch.Tensor] = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     bs = candidates.shape[0]
     device = candidates.device
@@ -167,6 +181,8 @@ def accept_sampling(
         gamma=gamma,
         verify_num_draft_tokens=verify_num_draft_tokens,
         cutoff_verify_lens=cutoff_verify_lens,
+        uniform_samples=uniform_samples,
+        uniform_samples_final=uniform_samples_final,
     )
     row_ids = torch.arange(bs, dtype=torch.long, device=device)
     accept_pos = accept_index[row_ids, correct_len.to(torch.long)].to(torch.long)
@@ -223,6 +239,8 @@ def accept_sampling_triton(
     gamma: int,
     verify_num_draft_tokens: int,
     cutoff_verify_lens: Optional[torch.Tensor] = None,
+    uniform_samples: Optional[torch.Tensor] = None,
+    uniform_samples_final: Optional[torch.Tensor] = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     correct_len, cap_trim_lens, accept_index, predicts = _accept_sampling_core(
         candidates=candidates,
@@ -233,6 +251,8 @@ def accept_sampling_triton(
         gamma=gamma,
         verify_num_draft_tokens=verify_num_draft_tokens,
         cutoff_verify_lens=cutoff_verify_lens,
+        uniform_samples=uniform_samples,
+        uniform_samples_final=uniform_samples_final,
     )
     bonus = gather_two_level_bonus_triton(
         accept_index=accept_index, predicts=predicts, correct_len=correct_len

--- a/python/sglang/srt/speculative/dspark_components/dspark_verify.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_verify.py
@@ -31,6 +31,7 @@ from sglang.kernels.ops.speculative.dspark.dspark_verify_window import (
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode, ForwardMode
+from sglang.srt.sampling.sampling_params import TOP_K_ALL
 from sglang.srt.speculative.dflash_info import DFlashVerifyInput
 from sglang.srt.speculative.dflash_info_v2 import DFlashDraftInputV2
 from sglang.srt.speculative.dflash_utils import apply_dflash_verify_logits_adjustments
@@ -49,7 +50,6 @@ from sglang.srt.speculative.spec_utils import (
 )
 from sglang.srt.utils import is_npu
 from sglang.srt.utils.invariants import Bucket, Invariant, NotNaN, expect
-from sglang.srt.sampling.sampling_params import TOP_K_ALL
 
 _is_npu = is_npu()
 
@@ -734,9 +734,7 @@ def _dspark_rs_dynamic_memory_enabled() -> bool:
 
 
 def _dspark_rs_memory_headroom_bytes() -> int:
-    value = os.environ.get(
-        "SGLANG_DSPARK_RS_MEMORY_HEADROOM_BYTES", str(512 * 1024**2)
-    )
+    value = os.environ.get("SGLANG_DSPARK_RS_MEMORY_HEADROOM_BYTES", str(512 * 1024**2))
     try:
         return max(int(value), 0)
     except ValueError:
@@ -966,9 +964,7 @@ def _accept_sampling_chunked(
     for start in range(0, bs, chunk_size):
         end = min(start + chunk_size, bs)
         chunk_bs = end - start
-        chunk_sampling_info = _dspark_slice_sampling_info(
-            sampling_info, start, end
-        )
+        chunk_sampling_info = _dspark_slice_sampling_info(sampling_info, start, end)
         chunk_draft_input = _dspark_slice_draft_input(
             draft_input, sampling_info, start, end
         )
@@ -986,9 +982,7 @@ def _accept_sampling_chunked(
             start * verify_num_draft_tokens : end * verify_num_draft_tokens
         ]
         chunk_cutoff = (
-            None
-            if cutoff_verify_lens is None
-            else cutoff_verify_lens[start:end]
+            None if cutoff_verify_lens is None else cutoff_verify_lens[start:end]
         )
         sampling_len, sampling_bonus, sampling_trim = AcceptSampling.execute(
             candidates=candidates[start:end],
@@ -1070,14 +1064,12 @@ def accept_draft_tokens(
             cutoff_verify_lens=cutoff_verify_lens,
         )
     bs, gamma_rows, vocab = draft_block.corrected_logits.shape
-    chunk_size, full_workspace_bytes, max_workspace_bytes = (
-        _dspark_rs_plan_chunk_size(
-            bs=bs,
-            gamma_rows=gamma_rows,
-            verify_num_draft_tokens=verify_num_draft_tokens,
-            vocab=vocab,
-            device=target_logits.device,
-        )
+    chunk_size, full_workspace_bytes, max_workspace_bytes = _dspark_rs_plan_chunk_size(
+        bs=bs,
+        gamma_rows=gamma_rows,
+        verify_num_draft_tokens=verify_num_draft_tokens,
+        vocab=vocab,
+        device=target_logits.device,
     )
     _dspark_rs_trace(
         bs=bs,

--- a/python/sglang/srt/speculative/dspark_components/dspark_verify.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_verify.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import dataclasses
+import os
 from typing import Optional
 
 import msgspec
@@ -47,6 +49,7 @@ from sglang.srt.speculative.spec_utils import (
 )
 from sglang.srt.utils import is_npu
 from sglang.srt.utils.invariants import Bucket, Invariant, NotNaN, expect
+from sglang.srt.sampling.sampling_params import TOP_K_ALL
 
 _is_npu = is_npu()
 
@@ -694,6 +697,357 @@ class DsparkVerifyEpilogue:
             )
 
 
+def _dspark_rs_chunk_size() -> int:
+    value = os.environ.get("SGLANG_DSPARK_RS_CHUNK_SIZE", "0")
+    try:
+        return max(int(value), 0)
+    except ValueError:
+        return 0
+
+
+def _dspark_rs_full_batch_max() -> int:
+    """Keep small batches on the original full-batch path.
+
+    Chunking is intended to cap the probability workspace for large batches.
+    Repeating the sampling kernel for small batches only adds launch and
+    Python scheduling overhead, so callers can set this threshold explicitly.
+    """
+    value = os.environ.get("SGLANG_DSPARK_RS_FULL_BATCH_MAX", "0")
+    try:
+        return max(int(value), 0)
+    except ValueError:
+        return 0
+
+
+def _dspark_rs_max_workspace_bytes() -> int:
+    """Return the probability-workspace budget, or zero when disabled."""
+    value = os.environ.get("SGLANG_DSPARK_RS_MAX_WORKSPACE_BYTES", "0")
+    try:
+        return max(int(value), 0)
+    except ValueError:
+        return 0
+
+
+def _dspark_rs_dynamic_memory_enabled() -> bool:
+    """Use current CUDA free memory when choosing the verification chunk."""
+    return os.environ.get("SGLANG_DSPARK_RS_DYNAMIC_MEMORY", "1") == "1"
+
+
+def _dspark_rs_memory_headroom_bytes() -> int:
+    value = os.environ.get(
+        "SGLANG_DSPARK_RS_MEMORY_HEADROOM_BYTES", str(512 * 1024**2)
+    )
+    try:
+        return max(int(value), 0)
+    except ValueError:
+        return 512 * 1024**2
+
+
+def _dspark_rs_available_workspace_bytes(device: Optional[torch.device]) -> int:
+    """Return free CUDA memory available for probability workspaces."""
+    if (
+        not _dspark_rs_dynamic_memory_enabled()
+        or device is None
+        or device.type != "cuda"
+        or not torch.cuda.is_available()
+    ):
+        return 0
+    try:
+        free_bytes, _ = torch.cuda.mem_get_info(device)
+        reserved_bytes = torch.cuda.memory_reserved(device)
+        allocated_bytes = torch.cuda.memory_allocated(device)
+    except RuntimeError:
+        return 0
+    allocator_reusable = max(int(reserved_bytes) - int(allocated_bytes), 0)
+    return max(
+        int(free_bytes) + allocator_reusable - _dspark_rs_memory_headroom_bytes(),
+        0,
+    )
+
+
+def _dspark_rs_trace_enabled() -> bool:
+    return os.environ.get("SGLANG_DSPARK_RS_TRACE", "0") == "1"
+
+
+def _dspark_rs_memory_trace_enabled() -> bool:
+    return os.environ.get("SGLANG_DSPARK_RS_MEMORY_TRACE", "0") == "1"
+
+
+def _dspark_rs_memory_snapshot(stage: str) -> None:
+    if not _dspark_rs_memory_trace_enabled() or not torch.cuda.is_available():
+        return
+    torch.cuda.synchronize()
+    print(
+        "[DSPARK_RS_MEMORY] "
+        f"stage={stage} "
+        f"allocated={torch.cuda.memory_allocated()} "
+        f"reserved={torch.cuda.memory_reserved()} "
+        f"peak_allocated={torch.cuda.max_memory_allocated()} "
+        f"peak_reserved={torch.cuda.max_memory_reserved()}",
+        flush=True,
+    )
+
+
+def _dspark_rs_estimate_workspace_bytes(
+    *, bs: int, gamma_rows: int, verify_num_draft_tokens: int, vocab: int
+) -> int:
+    """Estimate simultaneous FP32 draft/target probability workspace."""
+    return (
+        bs
+        * (gamma_rows + verify_num_draft_tokens)
+        * vocab
+        * 4  # FP32 probability workspace
+    )
+
+
+def _dspark_rs_plan_chunk_size(
+    *,
+    bs: int,
+    gamma_rows: int,
+    verify_num_draft_tokens: int,
+    vocab: int,
+    device: Optional[torch.device] = None,
+    available_workspace_bytes: Optional[int] = None,
+) -> tuple[int, int, int]:
+    """Return (chunk_size, full_workspace_bytes, max_workspace_bytes).
+
+    A positive ``SGLANG_DSPARK_RS_MAX_WORKSPACE_BYTES`` sets the target budget for the estimated
+    simultaneous draft/target probability tensors.  With dynamic memory
+    planning enabled, current free CUDA memory is also considered; the
+    full-batch fast path is retained whenever it fits.  A positive fixed
+    chunk size remains an upper bound for controlled tests.
+    """
+    full_workspace_bytes = _dspark_rs_estimate_workspace_bytes(
+        bs=bs,
+        gamma_rows=gamma_rows,
+        verify_num_draft_tokens=verify_num_draft_tokens,
+        vocab=vocab,
+    )
+    max_workspace_bytes = _dspark_rs_max_workspace_bytes()
+    fixed_chunk_size = _dspark_rs_chunk_size()
+    full_batch_max = _dspark_rs_full_batch_max()
+    if available_workspace_bytes is None:
+        available_workspace_bytes = (
+            _dspark_rs_available_workspace_bytes(device)
+            if max_workspace_bytes > 0
+            else 0
+        )
+
+    planned_chunk_size = bs
+    effective_workspace_bytes = max_workspace_bytes
+    if available_workspace_bytes > 0:
+        if full_workspace_bytes <= available_workspace_bytes:
+            effective_workspace_bytes = 0
+        elif effective_workspace_bytes <= 0:
+            effective_workspace_bytes = available_workspace_bytes
+        else:
+            effective_workspace_bytes = min(
+                effective_workspace_bytes, available_workspace_bytes
+            )
+    if effective_workspace_bytes > 0:
+        per_request_bytes = _dspark_rs_estimate_workspace_bytes(
+            bs=1,
+            gamma_rows=gamma_rows,
+            verify_num_draft_tokens=verify_num_draft_tokens,
+            vocab=vocab,
+        )
+        budget_chunk_size = max(1, effective_workspace_bytes // per_request_bytes)
+        planned_chunk_size = min(planned_chunk_size, budget_chunk_size)
+    if fixed_chunk_size > 0:
+        planned_chunk_size = min(planned_chunk_size, fixed_chunk_size)
+
+    if planned_chunk_size >= bs:
+        if full_batch_max > 0 and bs > full_batch_max:
+            planned_chunk_size = full_batch_max
+        else:
+            return 0, full_workspace_bytes, max_workspace_bytes
+
+    if planned_chunk_size <= 0:
+        return 0, full_workspace_bytes, max_workspace_bytes
+    return planned_chunk_size, full_workspace_bytes, max_workspace_bytes
+
+
+def _dspark_rs_trace(
+    *,
+    bs: int,
+    gamma_rows: int,
+    verify_num_draft_tokens: int,
+    vocab: int,
+    chunk_size: int,
+    full_workspace_bytes: int,
+    max_workspace_bytes: int,
+) -> None:
+    if not _dspark_rs_trace_enabled():
+        return
+    num_chunks = 1 if chunk_size == 0 else (bs + chunk_size - 1) // chunk_size
+    print(
+        "[DSPARK_RS_TRACE] "
+        f"bs={bs} gamma_rows={gamma_rows} verify_rows={verify_num_draft_tokens} "
+        f"vocab={vocab} chunk_size={chunk_size or bs} chunks={num_chunks} "
+        f"full_workspace_bytes={full_workspace_bytes} "
+        f"max_workspace_bytes={max_workspace_bytes}",
+        flush=True,
+    )
+
+
+def _dspark_can_slice_sampling_info(sampling_info) -> bool:
+    if sampling_info is None:
+        return False
+    if getattr(sampling_info, "need_min_p_sampling", False):
+        return False
+    if getattr(sampling_info, "has_custom_logit_processor", False):
+        return False
+    if getattr(sampling_info, "grammar_mask", None) is not None:
+        return False
+    if getattr(sampling_info, "logit_bias", None) is not None:
+        return False
+    if getattr(sampling_info, "grammars", None):
+        return False
+    penalizer = getattr(sampling_info, "penalizer_orchestrator", None)
+    if penalizer is not None and getattr(penalizer, "is_required", False):
+        return False
+    return True
+
+
+def _dspark_slice_sampling_info(sampling_info, start: int, end: int):
+    sliced = dataclasses.replace(sampling_info)
+    for name in ("temperatures", "top_ps", "top_ks", "min_ps", "sampling_seed"):
+        value = getattr(sampling_info, name, None)
+        if value is not None:
+            setattr(sliced, name, value[start:end])
+    if getattr(sampling_info, "return_sampling_masks", None) is not None:
+        sliced.return_sampling_masks = sampling_info.return_sampling_masks[start:end]
+    sliced.is_all_greedy = bool(torch.all(sliced.top_ks <= 1).item())
+    sliced.is_any_greedy = bool(torch.any(sliced.top_ks <= 1).item())
+    sliced.need_top_p_sampling = bool(torch.any(sliced.top_ps != 1.0).item())
+    sliced.need_top_k_sampling = bool(torch.any(sliced.top_ks != TOP_K_ALL).item())
+    return sliced
+
+
+def _dspark_slice_draft_input(draft_input, sampling_info, start: int, end: int):
+    """Keep DSpark top-k metadata local to the current request chunk."""
+    if draft_input is None:
+        return None
+    chunk_top_ks = sampling_info.top_ks[start:end]
+    chunk_max_top_k = max(int(chunk_top_ks.max().item()), 1)
+    uniform_top_k_value = None
+    if bool(torch.all(chunk_top_ks == chunk_top_ks[0]).item()):
+        uniform_top_k_value = int(chunk_top_ks[0].item())
+    return dataclasses.replace(
+        draft_input,
+        max_top_k=chunk_max_top_k,
+        uniform_top_k_value=uniform_top_k_value,
+    )
+
+
+def _accept_sampling_chunked(
+    *,
+    candidates: torch.Tensor,
+    target_logits: torch.Tensor,
+    draft_block: DraftBlockResult,
+    sampling_info,
+    draft_input: DFlashDraftInputV2,
+    gamma: int,
+    verify_num_draft_tokens: int,
+    cutoff_verify_lens: Optional[torch.Tensor],
+    chunk_size: int,
+    greedy_mask: Optional[torch.Tensor],
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    bs, gamma_rows, vocab = draft_block.corrected_logits.shape
+    uniform_samples = torch.rand(
+        (bs, gamma), dtype=torch.float32, device=target_logits.device
+    )
+    uniform_samples_final = torch.rand(
+        (bs,), dtype=torch.float32, device=target_logits.device
+    )
+    correct_out = None
+    bonus_out = None
+    trim_out = None
+    for start in range(0, bs, chunk_size):
+        end = min(start + chunk_size, bs)
+        chunk_bs = end - start
+        chunk_sampling_info = _dspark_slice_sampling_info(
+            sampling_info, start, end
+        )
+        chunk_draft_input = _dspark_slice_draft_input(
+            draft_input, sampling_info, start, end
+        )
+        draft_probs = SoftmaxTemp.execute(
+            logits=draft_block.corrected_logits[start:end].reshape(
+                chunk_bs * gamma_rows, vocab
+            ),
+            temperatures=draft_block.temperatures[start:end],
+            rows_per_request=gamma_rows,
+        ).view(chunk_bs, gamma_rows, vocab)
+        expect(_VERIFY_DRAFT_PROBS, draft_probs)
+        if start == 0:
+            _dspark_rs_memory_snapshot("after_first_draft_probs")
+        chunk_target_logits = target_logits[
+            start * verify_num_draft_tokens : end * verify_num_draft_tokens
+        ]
+        chunk_cutoff = (
+            None
+            if cutoff_verify_lens is None
+            else cutoff_verify_lens[start:end]
+        )
+        sampling_len, sampling_bonus, sampling_trim = AcceptSampling.execute(
+            candidates=candidates[start:end],
+            target_logits=chunk_target_logits,
+            draft_probs=draft_probs,
+            sampling_info=chunk_sampling_info,
+            draft_input=chunk_draft_input,
+            gamma=gamma,
+            verify_num_draft_tokens=verify_num_draft_tokens,
+            cutoff_verify_lens=chunk_cutoff,
+            uniform_samples=uniform_samples[start:end],
+            uniform_samples_final=uniform_samples_final[start:end],
+        )
+        if chunk_sampling_info.is_any_greedy:
+            # Keep the mixed-batch semantics of the original full path: run
+            # both acceptors for the chunk, then select per request.
+            greedy_len, greedy_bonus, greedy_trim = AcceptGreedy.execute(
+                candidates=candidates[start:end],
+                target_logits=chunk_target_logits,
+                verify_num_draft_tokens=verify_num_draft_tokens,
+                cutoff_verify_lens=chunk_cutoff,
+            )
+            selected = SelectMixedAccept.execute(
+                greedy_mask=greedy_mask[start:end],
+                greedy_len=greedy_len,
+                greedy_bonus=greedy_bonus,
+                greedy_trim=greedy_trim,
+                sampling_len=sampling_len,
+                sampling_bonus=sampling_bonus,
+                sampling_trim=sampling_trim,
+            )
+            correct_len, bonus, cap_trim_lens = (
+                selected.correct_len,
+                selected.bonus,
+                selected.cap_trim_lens,
+            )
+        else:
+            correct_len, bonus, cap_trim_lens = (
+                sampling_len,
+                sampling_bonus,
+                sampling_trim,
+            )
+        if start == 0:
+            _dspark_rs_memory_snapshot("after_first_accept_sampling")
+        if correct_out is None:
+            correct_out = torch.empty(
+                (bs,), dtype=correct_len.dtype, device=correct_len.device
+            )
+            bonus_out = torch.empty((bs,), dtype=bonus.dtype, device=bonus.device)
+            trim_out = torch.empty(
+                (bs,), dtype=cap_trim_lens.dtype, device=cap_trim_lens.device
+            )
+        correct_out[start:end].copy_(correct_len)
+        bonus_out[start:end].copy_(bonus)
+        trim_out[start:end].copy_(cap_trim_lens)
+    _dspark_rs_memory_snapshot("after_chunked_accept_sampling")
+    return correct_out, bonus_out, trim_out
+
+
 def accept_draft_tokens(
     *,
     candidates: torch.Tensor,
@@ -716,14 +1070,53 @@ def accept_draft_tokens(
             cutoff_verify_lens=cutoff_verify_lens,
         )
     bs, gamma_rows, vocab = draft_block.corrected_logits.shape
+    chunk_size, full_workspace_bytes, max_workspace_bytes = (
+        _dspark_rs_plan_chunk_size(
+            bs=bs,
+            gamma_rows=gamma_rows,
+            verify_num_draft_tokens=verify_num_draft_tokens,
+            vocab=vocab,
+            device=target_logits.device,
+        )
+    )
+    _dspark_rs_trace(
+        bs=bs,
+        gamma_rows=gamma_rows,
+        verify_num_draft_tokens=verify_num_draft_tokens,
+        vocab=vocab,
+        chunk_size=chunk_size,
+        full_workspace_bytes=full_workspace_bytes,
+        max_workspace_bytes=max_workspace_bytes,
+    )
+    if _dspark_rs_memory_trace_enabled():
+        torch.cuda.reset_peak_memory_stats()
+        _dspark_rs_memory_snapshot("before_draft_probs")
+    if (
+        chunk_size > 0
+        and bs > chunk_size
+        and _dspark_can_slice_sampling_info(sampling_info)
+    ):
+        return _accept_sampling_chunked(
+            candidates=candidates,
+            target_logits=target_logits,
+            draft_block=draft_block,
+            sampling_info=sampling_info,
+            draft_input=draft_input,
+            gamma=gamma,
+            verify_num_draft_tokens=verify_num_draft_tokens,
+            cutoff_verify_lens=cutoff_verify_lens,
+            chunk_size=chunk_size,
+            greedy_mask=greedy_mask,
+        )
     draft_probs = SoftmaxTemp.execute(
         logits=draft_block.corrected_logits.reshape(bs * gamma_rows, vocab),
         temperatures=draft_block.temperatures,
         rows_per_request=gamma_rows,
     ).view(bs, gamma_rows, vocab)
     expect(_VERIFY_DRAFT_PROBS, draft_probs)
+    _dspark_rs_memory_snapshot("after_full_draft_probs")
     if not sampling_info.is_any_greedy:
-        return AcceptSampling.execute(
+        result = AcceptSampling.execute(
             candidates=candidates,
             target_logits=target_logits,
             draft_probs=draft_probs,
@@ -733,6 +1126,8 @@ def accept_draft_tokens(
             verify_num_draft_tokens=verify_num_draft_tokens,
             cutoff_verify_lens=cutoff_verify_lens,
         )
+        _dspark_rs_memory_snapshot("after_full_accept_sampling")
+        return result
     greedy_len, greedy_bonus, greedy_trim = AcceptGreedy.execute(
         candidates=candidates,
         target_logits=target_logits,
@@ -758,4 +1153,6 @@ def accept_draft_tokens(
         sampling_bonus=sampling_bonus,
         sampling_trim=sampling_trim,
     )
-    return selected.correct_len, selected.bonus, selected.cap_trim_lens
+    result = selected.correct_len, selected.bonus, selected.cap_trim_lens
+    _dspark_rs_memory_snapshot("after_mixed_accept_sampling")
+    return result

--- a/test/registered/spec/dspark/test_dspark_chunked_rejection_sampling.py
+++ b/test/registered/spec/dspark/test_dspark_chunked_rejection_sampling.py
@@ -1,0 +1,137 @@
+import pytest
+import torch
+
+from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
+from sglang.srt.sampling.sampling_params import TOP_K_ALL
+from sglang.srt.speculative.dflash_info_v2 import DFlashDraftInputV2
+from sglang.srt.speculative.dspark_components.dspark_draft import DraftBlockResult
+from sglang.srt.speculative.dspark_components.dspark_verify import (
+    _dspark_rs_estimate_workspace_bytes,
+    _dspark_rs_plan_chunk_size,
+    accept_draft_tokens,
+)
+
+
+def test_dspark_rs_planner_respects_workspace_budget(monkeypatch):
+    bytes_per_request = _dspark_rs_estimate_workspace_bytes(
+        bs=1, gamma_rows=7, verify_num_draft_tokens=8, vocab=151936
+    )
+    budget = 2 * 1024**3
+    monkeypatch.setenv("SGLANG_DSPARK_RS_MAX_WORKSPACE_BYTES", str(budget))
+    monkeypatch.setenv("SGLANG_DSPARK_RS_CHUNK_SIZE", "0")
+    chunk_size, full_bytes, max_bytes = _dspark_rs_plan_chunk_size(
+        bs=511, gamma_rows=7, verify_num_draft_tokens=8, vocab=151936
+    )
+    assert max_bytes == budget
+    assert full_bytes > budget
+    assert chunk_size == budget // bytes_per_request
+    assert chunk_size < 511
+    monkeypatch.setenv("SGLANG_DSPARK_RS_MAX_WORKSPACE_BYTES", "0")
+    chunk_size, _, _ = _dspark_rs_plan_chunk_size(
+        bs=511, gamma_rows=7, verify_num_draft_tokens=8, vocab=151936
+    )
+    assert chunk_size == 0
+
+
+def test_dspark_rs_planner_keeps_full_path_when_free_memory_is_sufficient(
+    monkeypatch,
+):
+    budget = 2 * 1024**3
+    monkeypatch.setenv("SGLANG_DSPARK_RS_MAX_WORKSPACE_BYTES", str(budget))
+    monkeypatch.setenv("SGLANG_DSPARK_RS_CHUNK_SIZE", "0")
+    chunk_size, full_bytes, _ = _dspark_rs_plan_chunk_size(
+        bs=255,
+        gamma_rows=7,
+        verify_num_draft_tokens=8,
+        vocab=151936,
+        available_workspace_bytes=3 * 1024**3,
+    )
+    assert full_bytes < 3 * 1024**3
+    assert chunk_size == 0
+
+
+def test_dspark_rs_planner_uses_free_memory_as_additional_limit(monkeypatch):
+    bytes_per_request = _dspark_rs_estimate_workspace_bytes(
+        bs=1, gamma_rows=7, verify_num_draft_tokens=8, vocab=151936
+    )
+    monkeypatch.setenv("SGLANG_DSPARK_RS_MAX_WORKSPACE_BYTES", str(2 * 1024**3))
+    monkeypatch.setenv("SGLANG_DSPARK_RS_CHUNK_SIZE", "0")
+    chunk_size, _, _ = _dspark_rs_plan_chunk_size(
+        bs=511,
+        gamma_rows=7,
+        verify_num_draft_tokens=8,
+        vocab=151936,
+        available_workspace_bytes=512 * 1024**2,
+    )
+    assert chunk_size == (512 * 1024**2) // bytes_per_request
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_dspark_rs_full_and_chunked_sampling_match(monkeypatch):
+    device = torch.device("cuda")
+    batch_size, gamma, verify_tokens, vocab = 8, 3, 4, 128
+    torch.manual_seed(20260819)
+    draft_logits = torch.randn(
+        (batch_size, gamma, vocab), device=device, dtype=torch.bfloat16
+    )
+    target_logits = torch.randn(
+        (batch_size * verify_tokens, vocab), device=device, dtype=torch.bfloat16
+    )
+    candidates = torch.randint(
+        0, vocab, (batch_size, verify_tokens), device=device, dtype=torch.int64
+    )
+    temperatures = torch.full(
+        (batch_size, 1), 0.8, device=device, dtype=torch.float32
+    )
+    sampling_info = SamplingBatchInfo(
+        temperatures=temperatures,
+        top_ps=torch.ones(batch_size, device=device),
+        top_ks=torch.full(
+            (batch_size,), TOP_K_ALL, device=device, dtype=torch.int32
+        ),
+        min_ps=torch.zeros(batch_size, device=device),
+        is_all_greedy=False,
+        is_any_greedy=False,
+        need_top_p_sampling=False,
+        need_top_k_sampling=False,
+        need_min_p_sampling=False,
+        vocab_size=vocab,
+        device="cuda",
+    )
+    draft_input = DFlashDraftInputV2.create_idle_input(device)
+    draft_block = DraftBlockResult(
+        draft_tokens=candidates[:, :gamma],
+        corrected_logits=draft_logits,
+        greedy_mask=torch.zeros(batch_size, device=device, dtype=torch.bool),
+        temperatures=temperatures,
+    )
+
+    monkeypatch.setenv("SGLANG_DSPARK_RS_MAX_WORKSPACE_BYTES", "0")
+    torch.manual_seed(777)
+    full = accept_draft_tokens(
+        candidates=candidates,
+        target_logits=target_logits,
+        draft_block=draft_block,
+        sampling_info=sampling_info,
+        draft_input=draft_input,
+        gamma=gamma,
+        verify_num_draft_tokens=verify_tokens,
+    )
+    torch.cuda.synchronize()
+    full = tuple(value.clone() for value in full)
+
+    monkeypatch.setenv("SGLANG_DSPARK_RS_MAX_WORKSPACE_BYTES", "8192")
+    torch.manual_seed(777)
+    chunked = accept_draft_tokens(
+        candidates=candidates,
+        target_logits=target_logits,
+        draft_block=draft_block,
+        sampling_info=sampling_info,
+        draft_input=draft_input,
+        gamma=gamma,
+        verify_num_draft_tokens=verify_tokens,
+    )
+    torch.cuda.synchronize()
+    chunked = tuple(value.clone() for value in chunked)
+
+    assert all(torch.equal(lhs, rhs) for lhs, rhs in zip(full, chunked))

--- a/test/registered/spec/dspark/test_dspark_chunked_rejection_sampling.py
+++ b/test/registered/spec/dspark/test_dspark_chunked_rejection_sampling.py
@@ -10,6 +10,9 @@ from sglang.srt.speculative.dspark_components.dspark_verify import (
     _dspark_rs_plan_chunk_size,
     accept_draft_tokens,
 )
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=60, stage="base-b", runner_config="1-gpu-small")
 
 
 def test_dspark_rs_planner_respects_workspace_budget(monkeypatch):
@@ -80,15 +83,11 @@ def test_dspark_rs_full_and_chunked_sampling_match(monkeypatch):
     candidates = torch.randint(
         0, vocab, (batch_size, verify_tokens), device=device, dtype=torch.int64
     )
-    temperatures = torch.full(
-        (batch_size, 1), 0.8, device=device, dtype=torch.float32
-    )
+    temperatures = torch.full((batch_size, 1), 0.8, device=device, dtype=torch.float32)
     sampling_info = SamplingBatchInfo(
         temperatures=temperatures,
         top_ps=torch.ones(batch_size, device=device),
-        top_ks=torch.full(
-            (batch_size,), TOP_K_ALL, device=device, dtype=torch.int32
-        ),
+        top_ks=torch.full((batch_size,), TOP_K_ALL, device=device, dtype=torch.int32),
         min_ps=torch.zeros(batch_size, device=device),
         is_all_greedy=False,
         is_any_greedy=False,


### PR DESCRIPTION
## Motivation

DSpark's non-greedy verification path materializes full-vocabulary probability tensors for rejection sampling:

- draft probabilities: [B, gamma_rows, V]
- target probabilities: [B, verify_num_draft_tokens, V]
- probability dtype: FP32

The simultaneous workspace therefore scales as:

B x (gamma_rows + verify_num_draft_tokens) x V x 4 bytes

For Qwen3-8B (V=151,936) and DSpark block7, this workspace becomes the dominant peak-memory allocation at large batches. In local RTX PRO 6000 pressure tests, the original path did not complete reliably at B=3072 and B=4096 and reported CUDA illegal memory access.

This PR bounds the probability workspace by splitting verification at request boundaries.

This is related to [vLLM #48630](https://github.com/vllm-project/vllm/pull/48630), which bounds rejection-sampling workspace for large batches. This PR targets SGLang DSpark specifically, reuses the existing rejection sampler, and does not change the acceptance rule.

## Design

### Request-boundary chunked verification

The batch is divided into request-aligned chunks. Each chunk independently constructs draft probabilities and invokes the existing rejection sampler. A request is never split across chunks, so its candidate tokens, target logits, sampling metadata, and cutoff lengths remain aligned.

The original full-batch path is retained when the estimated workspace fits the available memory. Chunking is therefore only used when the configured budget or current memory pressure requires it.

### Workspace-aware planner

The planner estimates the simultaneous FP32 draft/target probability workspace and selects a safe chunk size from:

- the configured workspace target;
- current CUDA free memory;
- reusable bytes held by the CUDA caching allocator;
- a configurable memory headroom.

The planner also supports a fixed chunk size for deterministic tests. With the default workspace budget of zero, the existing full-batch behavior remains unchanged.

### Sampling and performance preservation

Chunking must not change rejection-sampling randomness or add unnecessary tensor copies. The implementation therefore:

- generates the complete batch of random uniforms once and slices the corresponding ranges for each chunk;
- reuses sliced sampling metadata and output buffers;
- threads optional random samples through the existing DSpark acceptance path;
- keeps the existing accept/reject kernels and only changes the batch dimension passed to them.

This avoids regenerating random streams per chunk and limits additional Python scheduling, tensor allocation, and result concatenation overhead.

## Reproduction

The PR-specific unit and parity tests can be run with:

~~~bash
python -m pytest -q test/registered/spec/dspark/test_dspark_chunked_rejection_sampling.py
~~~

For the service experiment, set the model paths and start two separate server instances. The first command is the unchanged full-batch baseline; the second enables the 4 GiB workspace planner.

~~~bash
export MODEL_PATH=/path/to/Qwen3-8B
export DRAFT_PATH=/path/to/dspark_qwen3_8b_block7

# Baseline
SGLANG_DSPARK_RS_MAX_WORKSPACE_BYTES=0 \
python -m sglang.launch_server \
  --model-path ${MODEL_PATH} \
  --speculative-algorithm DSPARK \
  --speculative-draft-model-path ${DRAFT_PATH} \
  --speculative-dspark-block-size 7 \
  --host 0.0.0.0 --port 30000

# Chunked planner
SGLANG_DSPARK_RS_MAX_WORKSPACE_BYTES=4294967296 \
SGLANG_DSPARK_RS_DYNAMIC_MEMORY=1 \
SGLANG_DSPARK_RS_MEMORY_HEADROOM_BYTES=536870912 \
python -m sglang.launch_server \
  --model-path ${MODEL_PATH} \
  --speculative-algorithm DSPARK \
  --speculative-draft-model-path ${DRAFT_PATH} \
  --speculative-dspark-block-size 7 \
  --host 0.0.0.0 --port 30000
~~~

After each server is ready, run the same workload command and sweep --max-concurrency:

~~~bash
python -m sglang.benchmark.serving --backend sglang --host 127.0.0.1 --port 30000 --model ${MODEL_PATH} --dataset-name random --num-prompts 1000 --random-input-len 1024 --random-output-len 1024 --max-concurrency 1024 --output-file result.json
~~~

## Correctness

The chunked path continues to use the existing target distribution, draft distribution, and rejection-sampling kernels. Under the same random inputs, local parity tests verify:

- acceptance length;
- bonus token;
- trim length;
- sampled output;
- mixed full-batch/chunked execution behavior.

Unsupported configurations retain the existing path rather than silently changing sampling semantics.

## Local validation

Environment: Qwen3-8B + DSpark block7, SGLang main, RTX PRO 6000.

### Memory and throughput

The following results come from three independent service runs with a 4 GiB workspace target. Throughput is shown relative to the unchanged full-batch baseline.

| Metric | Original full-batch path | Chunked planner | Result |
|---|---:|---:|---:|
| GPU memory high-water mark | 73.0 GiB | 58.3 GiB | -20.1% |
| B=128 throughput | 100% | 98.92% | -1.08% |
| B=256 throughput | 100% | 101.15% | +1.15% |
| B=512 throughput | 100% | 92.29% | -7.71% |
| B=1024 throughput | 100% | 97.22% | -2.78% |

| Batch | Original full-batch path | Chunked planner | Result |
|---:|---|---|---|
| B=3072 | CUDA illegal memory access | HTTP 200 | completes |
| B=4096 | CUDA illegal memory access | HTTP 200 | completes |

### Accuracy and sampling parity

On a 100-question GSM8K regression:

| Check | Original full-batch path | Chunked planner | Result |
|---|---:|---:|---|
| GSM8K accuracy | 90/100 | 90/100 | unchanged |
| Parse success | 100/100 | 100/100 | unchanged |
| Final answers | identical reference | identical reference | identical |
| Complete output text | identical reference | identical reference | identical |
| Output SHA256 | identical reference | identical reference | identical |

Fixed-random-input parity tests also matched acceptance length, bonus token, trim length, and sampled output. The local GPU unit and parity suite passed 5 tests with 22 subtests.

## Configuration used for experiments

The current prototype exposes environment controls for experimentation:

- SGLANG_DSPARK_RS_MAX_WORKSPACE_BYTES
- SGLANG_DSPARK_RS_DYNAMIC_MEMORY
- SGLANG_DSPARK_RS_MEMORY_HEADROOM_BYTES
- SGLANG_DSPARK_RS_CHUNK_SIZE
- SGLANG_DSPARK_RS_FULL_BATCH_MAX

The public configuration surface and naming should be aligned with SGLang conventions after review.

## Scope and follow-up

This PR targets DSpark's rejection-sampling verification path. It does not change the rejection rule or introduce a new sampler. Follow-up work can add framework-level configuration, broader logprob/grammar coverage, and larger standardized benchmark matrices after the core design is reviewed.

## Review focus

Please review:

1. whether the workspace estimate covers the allocations that should be bounded;
2. whether allocator-reusable memory should be included in the planner;
3. whether random-uniform and output-buffer reuse preserve existing sampling semantics;
4. the preferred public configuration and test placement.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32335684428](https://github.com/sgl-project/sglang/actions/runs/32335684428)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32335684260](https://github.com/sgl-project/sglang/actions/runs/32335684260)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32335684445](https://github.com/sgl-project/sglang/actions/runs/32335684445)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
