### PR TITLE
[function_call] Make streaming tool-call parsing agree with non-streaming

### DIFF
--- a/python/sglang/srt/function_call/base_format_detector.py
+++ b/python/sglang/srt/function_call/base_format_detector.py
@@ -89,7 +89,9 @@ class BaseFormatDetector(ABC):
 
             results.append(
                 ToolCallItem(
-                    tool_index=tool_indices.get(name, -1),
+                    # The OpenAI `index` field: the call's position in the
+                    # response, not the tool's in the tools list. Ids derive from it.
+                    tool_index=len(results) if name in tool_indices else -1,
                     name=name,
                     parameters=json.dumps(
                         act.get("parameters") or act.get("arguments", {}),
@@ -153,8 +155,19 @@ class BaseFormatDetector(ABC):
                 and current_text.startswith(self.tool_call_separator)
             )
         ):
-            # Only clear buffer if we're sure no tool call is starting
-            if not self._ends_with_partial_token(self._buffer, self.bot_token):
+            # Only clear buffer if we're sure no tool call is starting.
+            # Mid-sequence the separator introduces the next call, so a buffer
+            # holding just a prefix of it -- "," before " " -- is not prose.
+            partial_bot_token = self._ends_with_partial_token(
+                self._buffer, self.bot_token
+            )
+            partial_separator = (
+                self.current_tool_id > 0
+                and self._ends_with_partial_token(
+                    self._buffer, self.tool_call_separator
+                )
+            )
+            if not partial_bot_token and not partial_separator:
                 normal_text = self._buffer
                 self._buffer = ""
                 if self.eot_token in normal_text:

--- a/python/sglang/srt/function_call/gemma4_detector.py
+++ b/python/sglang/srt/function_call/gemma4_detector.py
@@ -290,7 +290,7 @@ class Gemma4Detector(BaseFormatDetector):
                 arguments = _parse_gemma4_args(args_str)
                 calls.append(
                     ToolCallItem(
-                        tool_index=tool_indices.get(func_name, -1),
+                        tool_index=(len(calls) if func_name in tool_indices else -1),
                         name=func_name,
                         parameters=json.dumps(arguments, ensure_ascii=False),
                     )
@@ -377,8 +377,10 @@ class Gemma4Detector(BaseFormatDetector):
 
                                 calls.append(
                                     ToolCallItem(
-                                        tool_index=self._tool_indices.get(
-                                            func_name, -1
+                                        tool_index=(
+                                            self.current_tool_id
+                                            if func_name in self._tool_indices
+                                            else -1
                                         ),
                                         name=func_name,
                                         parameters="",
@@ -408,8 +410,10 @@ class Gemma4Detector(BaseFormatDetector):
 
                             calls.append(
                                 ToolCallItem(
-                                    tool_index=self._tool_indices.get(
-                                        self.current_func_name, -1
+                                    tool_index=(
+                                        self.current_tool_id
+                                        if self.current_func_name in self._tool_indices
+                                        else -1
                                     ),
                                     parameters=json.dumps(
                                         arguments, ensure_ascii=False

--- a/python/sglang/srt/function_call/glm47_moe_detector.py
+++ b/python/sglang/srt/function_call/glm47_moe_detector.py
@@ -403,8 +403,9 @@ class Glm47MoeDetector(BaseFormatDetector):
                     self._current_value = ""
                     self._xml_tag_buffer = ""
                     self._value_started = False
-                    # Determine and cache the value type at the start
-                    self._cached_value_type = self._get_value_type(
+                    # Cache only the declared type: _get_value_type falls back to
+                    # auto-detection from self._current_value, empty at this point.
+                    self._cached_value_type = get_argument_type(
                         func_name, self._current_key, tools
                     )
 
@@ -413,8 +414,11 @@ class Glm47MoeDetector(BaseFormatDetector):
                     final_value = self._xml_tag_buffer[:-12]
                     self._current_value += final_value
 
-                    # Use cached value type for consistency
-                    value_type = self._cached_value_type or "string"
+                    # An undeclared type can only be inferred from the finished
+                    # literal, which is complete exactly here.
+                    value_type = self._cached_value_type or self._get_value_type(
+                        func_name, self._current_key, tools
+                    )
 
                     if self._value_started:
                         # Output any remaining content
@@ -445,10 +449,12 @@ class Glm47MoeDetector(BaseFormatDetector):
                         closing_tag
                     ) and closing_tag.startswith(self._xml_tag_buffer)
 
-                    if not is_potential_closing:
+                    # With no declared type the literal must be seen whole
+                    # before it can be typed, so hold it in the tag buffer
+                    # instead of committing to a guess one character at a time.
+                    if not is_potential_closing and self._cached_value_type:
                         content = self._xml_tag_buffer
-                        # Use cached value type for consistency
-                        value_type = self._cached_value_type or "string"
+                        value_type = self._cached_value_type
 
                         if value_type == "string":
                             if not self._value_started:

--- a/python/sglang/srt/function_call/glm4_moe_detector.py
+++ b/python/sglang/srt/function_call/glm4_moe_detector.py
@@ -357,8 +357,9 @@ class Glm4MoeDetector(BaseFormatDetector):
                     self._current_value = ""
                     self._xml_tag_buffer = ""
                     self._value_started = False
-                    # Determine and cache the value type at the start
-                    self._cached_value_type = self._get_value_type(
+                    # Cache only the declared type: _get_value_type falls back to
+                    # auto-detection from self._current_value, empty at this point.
+                    self._cached_value_type = get_argument_type(
                         func_name, self._current_key, tools
                     )
 
@@ -367,8 +368,11 @@ class Glm4MoeDetector(BaseFormatDetector):
                     final_value = self._xml_tag_buffer[:-12]
                     self._current_value += final_value
 
-                    # Use cached value type for consistency
-                    value_type = self._cached_value_type or "string"
+                    # An undeclared type can only be inferred from the finished
+                    # literal, which is complete exactly here.
+                    value_type = self._cached_value_type or self._get_value_type(
+                        func_name, self._current_key, tools
+                    )
 
                     if self._value_started:
                         # Output any remaining content
@@ -399,10 +403,12 @@ class Glm4MoeDetector(BaseFormatDetector):
                         closing_tag
                     ) and closing_tag.startswith(self._xml_tag_buffer)
 
-                    if not is_potential_closing:
+                    # With no declared type the literal must be seen whole
+                    # before it can be typed, so hold it in the tag buffer
+                    # instead of committing to a guess one character at a time.
+                    if not is_potential_closing and self._cached_value_type:
                         content = self._xml_tag_buffer
-                        # Use cached value type for consistency
-                        value_type = self._cached_value_type or "string"
+                        value_type = self._cached_value_type
 
                         if value_type == "string":
                             if not self._value_started:

--- a/python/sglang/srt/function_call/minimax_m2.py
+++ b/python/sglang/srt/function_call/minimax_m2.py
@@ -235,10 +235,19 @@ class MinimaxM2Detector(BaseFormatDetector):
             self._tool_indices = self._get_tool_indices(tools)
 
         while True:
-            # If we're not in a tool call and don't see a start token, return normal text
+            # If we're not in a tool call and don't see a start token, return normal text.
+            # Hold back a trailing prefix of the start token; streamed one
+            # character at a time it would otherwise never accumulate.
             if not self._in_tool_call and self.tool_call_start_token not in self._buf:
-                normal += self._buf
-                self._buf = ""
+                partial = self._ends_with_partial_token(
+                    self._buf, self.tool_call_start_token
+                )
+                if partial:
+                    normal += self._buf[:-partial]
+                    self._buf = self._buf[-partial:]
+                else:
+                    normal += self._buf
+                    self._buf = ""
                 break
 
             # Look for tool call start
@@ -340,6 +349,17 @@ class MinimaxM2Detector(BaseFormatDetector):
                             self.streamed_args_for_tool[self.current_tool_id] = (
                                 current_streamed + "}"
                             )
+                    else:
+                        # A call with no <parameter> blocks still has arguments:
+                        # the empty object. Emitting nothing leaves them pending.
+                        calls.append(
+                            ToolCallItem(
+                                tool_index=self.current_tool_id,
+                                name=None,
+                                parameters="{}",
+                            )
+                        )
+                        self.streamed_args_for_tool[self.current_tool_id] = "{}"
 
                     # Complete the tool call
                     self._buf = self._buf[

--- a/python/sglang/srt/function_call/mistral_detector.py
+++ b/python/sglang/srt/function_call/mistral_detector.py
@@ -126,7 +126,14 @@ class MistralDetector(BaseFormatDetector):
         current_text = self._buffer
 
         # No marker: either flush as normal text or keep buffering a partial marker.
-        if self._tool_calls_marker not in current_text:
+        # The marker only appears once per JSON-array sequence, so once a call has
+        # completed the remaining calls arrive behind the separator instead. Treat
+        # that (and any prefix of it) as "still a tool call" rather than prose.
+        mid_sequence = self.current_tool_id > 0 and (
+            current_text.startswith(self.tool_call_separator)
+            or self._ends_with_partial_token(current_text, self.tool_call_separator)
+        )
+        if self._tool_calls_marker not in current_text and not mid_sequence:
             if not self._ends_with_partial_token(self._buffer, self._tool_calls_marker):
                 normal_text = self._buffer
                 self._buffer = ""
@@ -189,7 +196,7 @@ class MistralDetector(BaseFormatDetector):
             return StreamingParseResult(normal_text="", calls=calls)
 
         # Canonical format delegates to the BaseFormatDetector JSON streaming logic.
-        if self.bot_token in current_text:
+        if self.bot_token in current_text or mid_sequence:
             return super().parse_streaming_increment(new_text="", tools=tools)
 
         # Otherwise, keep buffering.

--- a/python/sglang/srt/function_call/step3_detector.py
+++ b/python/sglang/srt/function_call/step3_detector.py
@@ -68,7 +68,7 @@ class Step3Detector(BaseFormatDetector):
 
         # Regex for parsing steptml invocations
         self.invoke_regex = re.compile(
-            r'<steptml:invoke name="([^"]+)">(.+?)</steptml:invoke>', re.DOTALL
+            r'<steptml:invoke name="([^"]+)">(.*?)</steptml:invoke>', re.DOTALL
         )
         self.param_regex = re.compile(
             r'<steptml:parameter name="([^"]+)">([^<]*)</steptml:parameter>', re.DOTALL
@@ -152,9 +152,14 @@ class Step3Detector(BaseFormatDetector):
 
                 func_name, params = self._parse_steptml_invoke(invoke_part, tools)
                 if func_name:
-                    # Use parse_base_json to create the ToolCallItem
+                    # parse_base_json is called once per invoke, so it cannot know
+                    # the call's position in the response; renumber against the
+                    # calls collected so far to match the streaming path.
                     action = {"name": func_name, "arguments": params}
-                    calls.extend(self.parse_base_json(action, tools))
+                    for item in self.parse_base_json(action, tools):
+                        if item.tool_index != -1:
+                            item.tool_index = len(calls)
+                        calls.append(item)
 
             # Combine pre and post text
             normal_text = pre_text + post_text
@@ -204,54 +209,59 @@ class Step3Detector(BaseFormatDetector):
                     self._buffer = ""
                     return StreamingParseResult(normal_text=normal_text)
 
-        # We're inside the tool block
+        # Loop rather than one state transition per increment: how many
+        # increments arrive is set by detokenization, not by the format. The
+        # block end counts only once no tool call precedes it in the buffer.
         calls: List[ToolCallItem] = []
 
-        # Check if tool block is ending
-        if self.eot_token in self._buffer:
-            idx = self._buffer.find(self.eot_token)
+        while True:
+            if not self._in_tool_call:
+                begin_idx = self._buffer.find(self.tool_call_begin)
+                eot_idx = self._buffer.find(self.eot_token)
 
-            # If we're in the middle of a tool call, we need to handle it
-            if self._in_tool_call:
-                # The buffer before eot_token might contain the end of the current tool call
-                before_eot = self._buffer[:idx]
-                if self.tool_call_end in before_eot:
-                    # Parse this final tool call
-                    result = self._parse_partial_tool_call(tools)
-                    calls.extend(result.calls)
-                else:
-                    # Incomplete tool call - log warning
-                    logger.warning("Tool block ended with incomplete tool call")
+                if eot_idx != -1 and (begin_idx == -1 or eot_idx < begin_idx):
+                    return self._finish_tool_block(eot_idx, calls)
 
-            remaining = self._buffer[idx + len(self.eot_token) :]
-            self._buffer = ""
-            self._tool_block_finished = True
+                if begin_idx == -1:
+                    # Wait for a tool call to begin
+                    return StreamingParseResult(calls=calls)
 
-            # Reset any partial tool call state
-            self._reset_streaming_state()
-
-            return StreamingParseResult(normal_text=remaining, calls=calls)
-
-        # Check if we're in a tool call or need to start one
-        if not self._in_tool_call:
-            if self.tool_call_begin in self._buffer:
-                idx = self._buffer.find(self.tool_call_begin)
-                # Remove any content before tool call begin (shouldn't happen but be safe)
-                self._buffer = self._buffer[idx + len(self.tool_call_begin) :]
+                # Drop any content before the marker (shouldn't happen; be safe)
+                self._buffer = self._buffer[begin_idx + len(self.tool_call_begin) :]
                 self._in_tool_call = True
                 self._function_name_sent = False
                 self._current_function_name = ""
                 self._current_parameters = {}
-                # Fall through to parse the partial tool call
-            else:
-                # Wait for tool call to begin
-                return StreamingParseResult()
 
-        # Parse partial tool call
-        if self._in_tool_call:
-            return self._parse_partial_tool_call(tools)
+            progress_before = (
+                len(self._buffer),
+                self._in_tool_call,
+                self._function_name_sent,
+            )
+            calls.extend(self._parse_partial_tool_call(tools).calls)
+            progress_after = (
+                len(self._buffer),
+                self._in_tool_call,
+                self._function_name_sent,
+            )
+            if progress_after == progress_before:
+                # The rest of this call has not arrived. If the block end already
+                # has, the rest is never coming, so close the block out.
+                eot_idx = self._buffer.find(self.eot_token)
+                if eot_idx != -1:
+                    logger.warning("Tool block ended with incomplete tool call")
+                    return self._finish_tool_block(eot_idx, calls)
+                return StreamingParseResult(calls=calls)
 
-        return StreamingParseResult()
+    def _finish_tool_block(
+        self, eot_idx: int, calls: List[ToolCallItem]
+    ) -> StreamingParseResult:
+        """Close the tool block, returning whatever followed it as normal text."""
+        remaining = self._buffer[eot_idx + len(self.eot_token) :]
+        self._buffer = ""
+        self._tool_block_finished = True
+        self._reset_streaming_state()
+        return StreamingParseResult(normal_text=remaining, calls=calls)
 
     def _parse_partial_tool_call(self, tools: List[Tool]) -> StreamingParseResult:
         """Parse partial tool call for streaming scenarios."""
@@ -262,6 +272,11 @@ class Step3Detector(BaseFormatDetector):
             return StreamingParseResult(calls=calls)  # Wait for more text
 
         type_part, invoke_part = self._buffer.split(self.tool_sep, 1)
+        # Bound the parse to this call: with several buffered at once an
+        # unbounded invoke_part reaches into the next one's parameters.
+        this_call_end = invoke_part.find(self.tool_call_end)
+        if this_call_end != -1:
+            invoke_part = invoke_part[:this_call_end]
         if type_part.strip() != "function":
             # Invalid tool type, skip this tool call
             self._reset_streaming_state()
@@ -380,6 +395,16 @@ class Step3Detector(BaseFormatDetector):
                         )
                     )
                     self.streamed_args_for_tool[self.current_tool_id] += "}"
+                else:
+                    # A call with no <steptml:parameter> blocks still has
+                    # arguments: the empty object. Emitting nothing leaves them pending.
+                    calls.append(
+                        ToolCallItem(
+                            tool_index=self.current_tool_id,
+                            parameters="{}",
+                        )
+                    )
+                    self.streamed_args_for_tool[self.current_tool_id] = "{}"
 
                 # Find the end position
                 end_idx = self._buffer.find(self.tool_call_end)

--- a/test/registered/unit/function_call/test_streaming_parity.py
+++ b/test/registered/unit/function_call/test_streaming_parity.py
@@ -1,0 +1,183 @@
+"""A detector must report the same tool calls however the output is chunked.
+
+Chunk boundaries come from detokenization, so a client that streams cannot
+avoid them: any disagreement with ``detect_and_parse`` reaches the caller.
+"""
+
+import json
+from typing import Dict, List, Tuple
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.function_call_parser import FunctionCallParser
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(2.0, "base-a-test-cpu")
+
+
+def _tool(name: str, properties: dict = None) -> Tool:
+    return Tool(
+        type="function",
+        function=Function(
+            name=name,
+            parameters={"type": "object", "properties": properties or {}},
+        ),
+    )
+
+
+# The second tool exists so that a call to it would get a non-zero index if a
+# detector keyed tool_index off the tools list instead of the call order.
+TOOLS = [_tool("get_weather"), _tool("f")]
+
+# One generation per detector, each containing a tool call with empty or simple
+# arguments -- the shape that used to be lost, mistyped, or misindexed.
+CASES: Dict[str, str] = {
+    "cohere_command4": (
+        '<|START_ACTION|>[{"tool_name": "f", "parameters": {}}]<|END_ACTION|>'
+    ),
+    "gemma4": "<|tool_call>call:f{}<tool_call|>",
+    "glm": (
+        "<tool_call>get_weather\n"
+        "<arg_key>get_weather</arg_key>\n"
+        "<arg_value>123</arg_value>\n"
+        "</tool_call>"
+    ),
+    "glm45": (
+        "<tool_call>get_weather\n"
+        "<arg_key>get_weather</arg_key>\n"
+        "<arg_value>123</arg_value>\n"
+        "</tool_call>"
+    ),
+    "glm47": (
+        "<tool_call>get_weather"
+        "<arg_key>get_weather</arg_key>"
+        "<arg_value>123</arg_value>"
+        "</tool_call>"
+    ),
+    "minimax-m2": (
+        '<minimax:tool_call><invoke name="get_weather"></invoke></minimax:tool_call>'
+    ),
+    "mistral": (
+        '[TOOL_CALLS] [{"name": "get_weather", "arguments": {}}, '
+        '{"name": "get_weather", "arguments": {}}]'
+    ),
+    "step3": (
+        "<｜tool_calls_begin｜>"
+        "<｜tool_call_begin｜>function<｜tool_sep｜>"
+        '<steptml:invoke name="get_weather"></steptml:invoke>'
+        "<｜tool_call_end｜>"
+        "<｜tool_call_begin｜>function<｜tool_sep｜>"
+        '<steptml:invoke name="get_weather">'
+        '<steptml:parameter name="get_weather">hello</steptml:parameter>'
+        "</steptml:invoke>"
+        "<｜tool_call_end｜>"
+        "<｜tool_calls_end｜>"
+    ),
+}
+
+Call = Tuple[int, str, object]
+
+
+def _oneshot(parser_name: str, text: str) -> List[Call]:
+    detector = FunctionCallParser.ToolCallParserEnum[parser_name]()
+    calls = detector.detect_and_parse(text, TOOLS).calls
+    return [(c.tool_index, c.name, json.loads(c.parameters or "{}")) for c in calls]
+
+
+def _streamed(parser_name: str, chunks: List[str]) -> List[Call]:
+    """Feed ``chunks`` in order and reassemble the calls the way a client does."""
+    detector = FunctionCallParser.ToolCallParserEnum[parser_name]()
+    names: Dict[int, str] = {}
+    args: Dict[int, str] = {}
+    order: List[int] = []
+    # The trailing empty increments mirror the flushes the serving layer sends
+    # when generation ends.
+    for chunk in list(chunks) + ["", ""]:
+        for call in detector.parse_streaming_increment(chunk, TOOLS).calls:
+            if call.tool_index not in args:
+                order.append(call.tool_index)
+                args[call.tool_index] = ""
+            if call.name:
+                names[call.tool_index] = call.name
+            if call.parameters:
+                args[call.tool_index] += call.parameters
+    return [(i, names.get(i), json.loads(args[i] or "{}")) for i in order]
+
+
+class TestStreamingParity(CustomTestCase):
+    def test_char_by_char_matches_one_shot(self):
+        """One character per increment must not change the parsed calls."""
+        for name, text in CASES.items():
+            with self.subTest(parser=name):
+                self.assertEqual(_streamed(name, list(text)), _oneshot(name, text))
+
+    def test_single_chunk_matches_one_shot(self):
+        """A whole generation in one increment must not be dropped."""
+        for name, text in CASES.items():
+            with self.subTest(parser=name):
+                self.assertEqual(_streamed(name, [text]), _oneshot(name, text))
+
+    def test_two_chunk_splits_match_one_shot(self):
+        """No split point may change the parsed calls."""
+        for name, text in CASES.items():
+            expected = _oneshot(name, text)
+            for cut in range(1, len(text)):
+                with self.subTest(parser=name, cut=cut):
+                    self.assertEqual(
+                        _streamed(name, [text[:cut], text[cut:]]), expected
+                    )
+
+
+class TestParameterlessCalls(CustomTestCase):
+    """A call with no arguments is still a call, and its arguments are ``{}``."""
+
+    def test_step3_one_shot_keeps_parameterless_call(self):
+        text = (
+            "<｜tool_calls_begin｜><｜tool_call_begin｜>function<｜tool_sep｜>"
+            '<steptml:invoke name="get_weather"></steptml:invoke>'
+            "<｜tool_call_end｜><｜tool_calls_end｜>"
+        )
+        self.assertEqual(_oneshot("step3", text), [(0, "get_weather", {})])
+
+    def test_minimax_m2_streams_empty_arguments(self):
+        text = (
+            '<minimax:tool_call><invoke name="get_weather"></invoke>'
+            "</minimax:tool_call>"
+        )
+        self.assertEqual(_streamed("minimax-m2", list(text)), [(0, "get_weather", {})])
+
+
+class TestToolIndexIsCallPosition(CustomTestCase):
+    """``tool_index`` is the OpenAI ``index`` field: the call's position in the
+    response. Tool-call ids derive from it, so two calls must never share one.
+    """
+
+    def test_repeated_tool_gets_distinct_indices(self):
+        text = (
+            '[TOOL_CALLS] [{"name": "get_weather", "arguments": {}}, '
+            '{"name": "get_weather", "arguments": {}}]'
+        )
+        self.assertEqual([c[0] for c in _oneshot("mistral", text)], [0, 1])
+
+    def test_first_call_is_index_zero_for_a_later_tool(self):
+        text = '<|START_ACTION|>[{"tool_name": "f", "parameters": {}}]<|END_ACTION|>'
+        # "f" is TOOLS[1], but it is the first (and only) call in the response.
+        self.assertEqual(_oneshot("cohere_command4", text), [(0, "f", {})])
+
+
+class TestUndeclaredArgumentTypes(CustomTestCase):
+    """A value whose type the schema does not declare is typed from the literal,
+    so an undeclared number must not reach the client quoted as a string.
+    """
+
+    def test_glm_number_survives_streaming(self):
+        for parser in ("glm", "glm45", "glm47"):
+            with self.subTest(parser=parser):
+                streamed = _streamed(parser, list(CASES[parser]))
+                self.assertEqual(streamed[0][2], {"get_weather": 123})
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #35564.

A tool-call detector has two entry points that must report the same calls:
`detect_and_parse` sees the whole generation, `parse_streaming_increment` sees it in
pieces. Where the pieces fall is decided by detokenization, not by the model or the
caller — so any disagreement between the two is a bug a client cannot work around. A
user who streams gets different tool calls than one who does not.

All 8 parsers named in the issue reproduce on current `main` (CPU, no server, no
weights). Working through them turned up a few things worth flagging, since the issue's
diagnosis and mine differ in places.

## Root causes

**`parse_base_json` used the wrong index base** (affects every detector built on it).
`tool_index` was `tool_indices.get(name)` — the tool's position in the request's `tools`
list. But it is the OpenAI `index` field: the call's position in the response. It also
feeds `_process_tool_call_id`, so two calls to the same function shared an index *and*
the generated id. `pythonic_detector` and `lfm2_detector` already do this correctly and
carry the comment `# Use the call index in the response, not tool position`; this brings
the shared helper in line with them. The `-1` sentinel for forwarded unknown tools is
preserved.

This is what the issue saw as an "index shift" on `cohere_command4` / `gemma4`. Those two
were not actually a streaming-vs-non-streaming divergence — both paths agreed with each
other and both were wrong.

**Separator holdback was missing** (base, and again in `mistral`, which duplicates the
guard). After a call completes, the buffer holds the separator that introduces the next
one. Holdback covered a partial `bot_token` but not a partial separator, so a buffer
holding `","` before `" "` arrived was flushed as prose — taking every remaining call
with it.

**`minimax-m2` had no start-marker holdback at all.** Streaming
`<minimax:tool_call>` one character at a time never accumulated it, so the whole tool
call was emitted as assistant content and no call was ever produced.

**`glm` / `glm45` / `glm47` decided the value type too early.** `_get_value_type` was
called when `<arg_value>` opened — before any of the value existed. Its auto-detection
branch inspects `self._current_value`, which is empty at that moment, so it answered
`"string"` every time and quoted every undeclared number. Now the declared type is cached
if there is one, and an undeclared value is held back and typed from the finished literal.

**`step3` had three separate bugs**, and the issue described its symptom backwards — it
is `detect_and_parse` that was losing a call, not streaming inventing one:

1. `<steptml:invoke name="([^"]+)">(.+?)</steptml:invoke>` requires at least one character
   between the tags. A call with no parameters — `get_time()`, `list_files()` — matched
   nothing and was **dropped outright** by `detect_and_parse`. One character: `(.*?)`.
2. Streaming advanced one state transition per increment and honoured the block-end
   marker on sight, so a generation arriving in one chunk finalized the block with its
   calls still unparsed. Draining the buffer per increment and only ending the block once
   no call precedes the end marker fixes it.
3. `invoke_part` was unbounded, so with several calls buffered the next call's parameters
   were attributed to the current one.

**Empty arguments never arrived** (`minimax-m2`, `step3`). A call with no parameters
streamed its name and then nothing, leaving the client with arguments permanently
pending. It now streams `{}`.

## Tests

`test/registered/unit/function_call/test_streaming_parity.py` asserts the invariant
directly: for every affected parser, the streamed result must equal the one-shot parse.
It runs each generation char-by-char, whole, and at **all 317 two-chunk split points** —
890 subtests. Plus targeted tests for each named bug (parameterless calls, index
assignment, undeclared numeric arguments).

The exhaustive split-point test is what caught `step3` bugs 2 and 3; char-by-char alone
passes them.

Verification, all on CPU:
- the issue's own repro script: 8/8 `BUG` → 8/8 `OK`
- `test/registered/unit/function_call`: 464 passed before, 472 after (the +8 are new), no
  regressions
- `test/registered/unit/{parser,managers,multimodal}` diffed against a stashed baseline:
  identical failure sets, zero new
- the repro from #35563 stays clean

## Reachability of each fix

Chunk boundaries in production fall on token boundaries, and these formats' markers are
single vocabulary tokens — so char-by-char is stricter than anything detokenization
produces. I re-checked each fix against realistic chunking (markers whole, ordinary text
split into small pieces) to separate demonstrated failures from defensive hardening:

| fix | reachable in production |
|---|---|
| `glm` / `glm45` / `glm47` undeclared number quoted | **yes** — the value is ordinary text |
| `mistral` second call lost | **yes** — the separator is ordinary text |
| `step3` parameterless call dropped | **yes** — `detect_and_parse`, no chunking involved |
| `parse_base_json` index / id collision | **yes** — no chunking involved |
| `minimax-m2` / `step3` empty `{}` never sent | **yes** — no chunking involved |
| `minimax-m2` start-marker holdback | **defensive** — needs a split inside `<minimax:tool_call>` |

The last row is hardening rather than a reproduced production failure. I kept it because
every other detector in the tree (`base`, `cohere_command4`, `mistral`) already holds back
a partial marker, and being the one that does not is a trap for the next format change.
The parity test asserts the stricter char-by-char invariant for all of them.

For the same reason I did **not** file bugs for `deepseekv3` and `kimi_k2`: both fail
char-by-char, but only when the split lands inside a single-token marker, and both are
correct under realistic chunking.

## Notes for reviewers

- The `parse_base_json` index change is the one with reach beyond the 8 parsers. It is a
  behaviour change for any response with two calls to the same function — previously they
  collided on index and id. I believe that is strictly a fix, but it is the piece worth
  the closest look.
- #35563 (the sibling issue, `deepseekv32`/`deepseekv4` two-chunk streaming) **no longer
  reproduces** on current `main`. Nothing here was needed for it.
- `step3`'s streaming rework is the largest single diff. It is covered by the exhaustive
  split-point test, but it is a control-flow change, not a local patch.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32329592134](https://github.com/sgl-project/sglang/actions/runs/32329592134)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32329591998](https://github.com/sgl-project/sglang/actions/runs/32329591998)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
