### PR TITLE
[AMD] Increase gfx950 DSA model indexer topk_transform kernel occupancy

### DIFF
--- a/python/sglang/kernels/aot/setup_rocm.py
+++ b/python/sglang/kernels/aot/setup_rocm.py
@@ -87,8 +87,9 @@ fp8_macro = (
 # Dynamic shared-memory budget for the TopK kernels.
 # - gfx942 (MI300/MI325): LDS is typically 64KB per workgroup -> keep dynamic smem <= ~48KB
 #   (leaves room for static shared allocations in the kernel).
-# - gfx95x (MI350) and gfx1250: LDS is larger -> allow the original 128KB dynamic smem.
-topk_dynamic_smem_bytes = 48 * 1024 if amdgpu_target == "gfx942" else 32 * 1024 * 4
+# - gfx95x (MI350) and gfx1250: LDS is larger. Large dynamic budget wastes LDS
+#   and pins occupancy to 1 block/CU. Keep it small (40KB) for better occupancy.
+topk_dynamic_smem_bytes = 48 * 1024 if amdgpu_target == "gfx942" else 40 * 1024
 
 hipcc_flags = [
     "-DNDEBUG",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
Improve gfx950 DSA model indexer topk_transform kernel performance.

- dsv4 : deepseek_v4_topk_transform_512

- dsv3.2/glm5:  fast_topk

On gfx95x (MI350/MI355) the dsv4 top-k kernels requested a 128KB dynamic LDS budget, which pinned occupancy to **1 block/CU** and left ~2/3 of the CU's thread capacity idle. The large buffer is unnecessary: it only backs the radix tie-candidate list, which needs ~`length/256` entries. Shrinking the per-arch budget to **40KB** lifts the 512-thread block to **3 blocks/CU** while keeping a `SMEM_INPUT_SIZE` of 5120 entries — enough to cover ~1.3M-token sequences, comfortably clear of DeepSeek-V4's 1M-token default context. 

This is the **performance/precision balance point**: it captures ~2x of the ~2.5x available speedup on gfx950 without shrinking the tie buffer onto that 1M correctness boundary.

gfx942 (MI300, 64KB LDS/CU) is left at 48KB — it is capacity-bound at 1 block/CUeither way.

#### LDS usage
gfx950: 160KB LDS/CU, 2048 threads/CU

LDS/block = static (~7KB: `_s_histogram_buf[2][288]` + `s_topk_indices[1024]`
+ a few `alignas(128)` scalars) + dynamic `kSMEM`.

| kSMEM | LDS/block | LDS limit | thread limit | occupancy |
|-------|-----------|-----------|--------------|-----------|
| 128KB | ~135KB    | 1         | 4            | **1 block/CU** (LDS-bound) |
| 48KB  | ~55KB     | 2         | 4            | **2 blocks/CU** (LDS-bound) |
| 40KB  | ~47KB     | 3         | 4            | **3 blocks/CU** (LDS-bound) — chosen |
| 32KB  | ~39KB     | 4         | 4            | **4 blocks/CU** (thread-bound) |

#### covered kv length
| kSMEM | entries/half | covers kv length up to | note |
|-------|--------------|---------------------|------|
| 128KB | 16384        | ~4.2M               | massive |
| 40KB  | 5120         | ~1.3M               | chosen: margin over DSV4 1M |
| 32KB  | 4096         | ~1.05M              | fastest, but margin sits on the 1M context floor |
<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->
`setup_rocm.py`: for gfx95x/gfx1250, `topk_dynamic_smem_bytes` 128KB -> 40KB; 
## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
This change does not affect accuracy.
## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
gfx950, deepseek_v4_topk_transform_512, page_size=256

Swept four dynamic-LDS budgets — 128KB (baseline), **40KB (chosen)**
— each a full rebuild. Latencies in us; speedup columns are vs the 128KB baseline.

| B | S | 128KB | **40KB** | 40KB speedup |
|---|---|-------|----------|--------------|
| 256  | 8192   | 16.1    | 16.2   | 0.99x |
| 512  | 8192   | 30.4    | 17.2   | 1.77x |
| 1024 | 8192   | 65.7    | 35.6   | 1.85x |
| 8192 | 8192   | 599.5   | 248.9  | 2.41x |
| 8192 | 65536  | 4102.5  | 1738.6 | 2.36x |
| 8192 | 262144 | 15405.4 | 6766.7 | 2.28x |
## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32329247571](https://github.com/sgl-project/sglang/actions/runs/32329247571)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32329247474](https://github.com/sgl-project/sglang/actions/runs/32329247474)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->