### PR TITLE
Drop null `required`/`properties` in tool schema normalization

### DIFF
--- a/python/sglang/srt/function_call/utils.py
+++ b/python/sglang/srt/function_call/utils.py
@@ -133,6 +133,16 @@ def normalize_json_schema_types(schema: Any) -> None:
     if not isinstance(schema, dict):
         return
 
+    # ``required`` (array) and ``properties`` (object) are sometimes emitted as
+    # ``null`` by SDKs that initialize optional fields to None. That is
+    # semantically equivalent to omitting the keyword, but JSON Schema
+    # validation rejects the null value ("None is not of type 'array'"/
+    # "'object'") and the whole tool definition is turned into a 400. Drop the
+    # null so an otherwise-usable schema keeps validating.
+    for key in ("required", "properties"):
+        if key in schema and schema[key] is None:
+            del schema[key]
+
     if "type" in schema:
         t = schema["type"]
         if isinstance(t, str):

--- a/test/registered/unit/function_call/test_normalize_json_schema_types.py
+++ b/test/registered/unit/function_call/test_normalize_json_schema_types.py
@@ -345,6 +345,56 @@ class TestNormalizeJsonSchemaTypes(CustomTestCase):
         normalize_json_schema_types(schema)
         self.assertEqual(schema, once)
 
+    def test_null_required_dropped(self):
+        """``required: null`` (emitted by some SDKs when there are no required
+        fields) must be dropped rather than 400 with "None is not of type
+        'array'" -- it is semantically equivalent to omitting ``required``."""
+        schema = {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": None,
+        }
+        normalize_json_schema_types(schema)
+        self.assertNotIn("required", schema)
+        self._assert_accepts(schema)
+
+    def test_null_properties_dropped(self):
+        """``properties: null`` is likewise dropped instead of 400 with "None
+        is not of type 'object'"."""
+        schema = {"type": "object", "properties": None}
+        normalize_json_schema_types(schema)
+        self.assertNotIn("properties", schema)
+        self._assert_accepts(schema)
+
+    def test_null_required_dropped_in_nested_defs(self):
+        """The null-strip applies at every level the walker visits, including
+        ``$defs`` sub-schemas."""
+        schema = {
+            "type": "object",
+            "$defs": {
+                "Row": {
+                    "type": "object",
+                    "properties": {"id": {"type": "int"}},
+                    "required": None,
+                }
+            },
+        }
+        normalize_json_schema_types(schema)
+        self.assertNotIn("required", schema["$defs"]["Row"])
+        self.assertEqual(schema["$defs"]["Row"]["properties"]["id"]["type"], "integer")
+        self._assert_accepts(schema)
+
+    def test_valid_required_list_preserved(self):
+        """A genuine ``required`` array is left untouched (only null is dropped)."""
+        schema = {
+            "type": "object",
+            "properties": {"a": {"type": "string"}},
+            "required": ["a"],
+        }
+        normalize_json_schema_types(schema)
+        self.assertEqual(schema["required"], ["a"])
+        self._assert_accepts(schema)
+
     def test_non_string_type_values_pass_through(self):
         """``type`` that isn't str/list is left for the real validator to reject."""
         for bad in (None, 42, {"$ref": "#/$defs/Foo"}, ["string", 1, None]):


### PR DESCRIPTION
## Motivation

Closes #35242.

When a tool is served through the OpenAI-compatible endpoint, `serving_chat` validates each tool's `parameters` with `Draft202012Validator.check_schema` (after running the `normalize_json_schema_types` compatibility pass).

Some client SDKs emit `"required": null` (and `"properties": null`) for a tool that has no required fields / no properties, instead of omitting the keyword. JSON Schema requires `required` to be an array and `properties` to be an object, so `check_schema` raises `SchemaError: None is not of type 'array'` and the entire request fails with:

```
400 Tool 17 function has invalid 'parameters' schema: None is not of type 'array'
```

`required: null` is semantically equivalent to omitting `required` ("no required fields"), so rejecting it breaks real clients for no semantic gain. This was reported in #35242 with qwen3.8-27b.

## Modifications

`normalize_json_schema_types` (`python/sglang/srt/function_call/utils.py`) is already the documented compatibility layer whose job is to keep otherwise-usable tool schemas validating (it rewrites DB/ORM type aliases such as `varchar` -> `string`). This PR extends it to drop `required` / `properties` when their value is `null`, at every schema level the walker already visits:

```python
for key in ("required", "properties"):
    if key in schema and schema[key] is None:
        del schema[key]
```

Scope is deliberately limited to `required` and `properties` (the two container-typed keywords SDKs most commonly null out) rather than a blanket "strip all null keywords", which could mask genuine schema mistakes. Only a `null` value is dropped; a genuine `required: [...]` array or `properties: {...}` object is left untouched, so real validation errors still surface.

## Accuracy Tests

Not applicable — this only changes tool-parameter schema normalization on the request path; it does not touch model forward / kernel code, so model outputs are unaffected.

## Speed Tests and Profiling

Not applicable — the change is a constant-time key check per schema node on the request-validation path, no inference-speed impact.

## Tests

Added to `test/registered/unit/function_call/test_normalize_json_schema_types.py`:

- `test_null_required_dropped` — `required: null` is dropped and the schema validates.
- `test_null_properties_dropped` — `properties: null` is dropped and the schema validates.
- `test_null_required_dropped_in_nested_defs` — the strip applies inside `$defs` sub-schemas.
- `test_valid_required_list_preserved` — control: a genuine `required: [...]` array is NOT dropped (guards against an over-broad fix).

```
$ python -m pytest test/registered/unit/function_call/test_normalize_json_schema_types.py -q
27 passed
```

fail-before / pass-after verified: with the fix removed, the three null-strip cases fail with `None is not of type 'array'` / `'object'`; the control case passes both ways.

## Checklist

- [x] Format your code according to the Format code with pre-commit.
- [x] Add unit tests according to the Run and add unit tests.
- [ ] Update documentation according to Write documentations.
- [ ] Provide accuracy and speed benchmark results (N/A — request-path schema normalization only, no model-output or speed impact).
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32330584227](https://github.com/sgl-project/sglang/actions/runs/32330584227)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32330584189](https://github.com/sgl-project/sglang/actions/runs/32330584189)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->