### PR TITLE
[Feature] Support partial-page prefix reuse in RadixCache

### DIFF
--- a/benchmark/radix_cache/README.md
+++ b/benchmark/radix_cache/README.md
@@ -1,0 +1,41 @@
+# Partial-page prefix reuse benchmark
+
+This benchmark compares the same checkout with
+`--enable-partial-prefix-reuse` disabled and enabled. It uses SGLang's
+`sglang.benchmark.serving` client; the local adapter only constructs a
+deterministic token-ID workload with a known partial-page LCP.
+
+The cached topology contains an aligned prefix and a child spanning at least
+two pages. A measured request matches the first page of that child, matches
+exactly `R` tokens in its next page, and then diverges. No match metadata is
+injected.
+
+By default, `suffix_len = page_size + 1`, so baseline and reuse allocate the
+same number of private pages. This isolates private-page KV copy cost from
+page-boundary allocation effects.
+
+Example:
+
+```bash
+python benchmark/radix_cache/run_partial_prefix_serving_matrix.py \
+  --model-name qwen3-32b \
+  --model-path /path/to/Qwen3-32B \
+  --output-root /tmp/partial-prefix-p32 \
+  --page-size 32 \
+  --configs baseline reuse \
+  --concurrencies 1 8 16 \
+  --partial-lens 1 8 16 24 31
+```
+
+Run page sizes 16, 32, and 64 separately. The matrix driver starts each server,
+performs excluded exact-shape warmups, invokes
+`bench_partial_prefix_serving.py`, validates cached-token counts, and stores the
+official serving metrics as JSONL. Reverse the configuration order for a paired
+order-bias check:
+
+```bash
+--configs reuse baseline
+```
+
+Report request throughput and mean/median/P90/P99 TTFT and E2E latency, together
+with the validated cached-token and computed-prefill-token counts.

--- a/benchmark/radix_cache/bench_partial_prefix_serving.py
+++ b/benchmark/radix_cache/bench_partial_prefix_serving.py
@@ -1,0 +1,269 @@
+"""Run SGLang's serving benchmark on an exact partial-page prefix workload.
+
+This is a thin dataset/preparation adapter around
+``sglang.benchmark.serving``.  The official serving benchmark still owns the
+async HTTP client, request-rate/concurrency control, timing, and metrics.
+
+The adapter builds a production RadixCache topology with a shared aligned
+prefix, one fully matching child page, and a token-exact match of ``r`` tokens
+inside the following page.  It then supplies unique divergent requests so a
+measured request cannot accidentally become a full cache hit on an earlier
+measured request.
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import random
+import sys
+from typing import Any
+
+import requests
+
+from sglang.benchmark import serving
+from sglang.benchmark.datasets.common import DatasetRow
+
+
+def deterministic_tokens(seed: int, length: int) -> list[int]:
+    rng = random.Random(seed)
+    return [rng.randrange(1000, 29000) for _ in range(length)]
+
+
+def force_different(value: int, forbidden: int) -> int:
+    if value != forbidden:
+        return value
+    return 1000 + ((value - 999) % 28000)
+
+
+def make_divergent_suffix(
+    *, seed: int, sample_index: int, length: int, forbidden: int
+) -> list[int]:
+    suffix = deterministic_tokens(seed + sample_index * 1009, length)
+    candidate = 1000 + (sample_index % 13000)
+    if candidate == forbidden:
+        candidate = 15000 + (sample_index % 13000)
+    suffix[0] = candidate
+    return suffix
+
+
+def post_generate(
+    base_url: str,
+    input_ids: list[int],
+    output_len: int,
+    cache_salt: str,
+    timeout: float,
+) -> dict[str, Any]:
+    response = requests.post(
+        f"{base_url}/generate",
+        json={
+            "input_ids": input_ids,
+            "cache_salt": cache_salt,
+            "sampling_params": {
+                "temperature": 0.0,
+                "max_new_tokens": output_len,
+                "ignore_eos": True,
+            },
+            "stream": False,
+        },
+        timeout=timeout,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def resolve_base_url(args: argparse.Namespace) -> str:
+    if args.base_url:
+        return args.base_url.rstrip("/")
+    host = args.host
+    if host in ("0.0.0.0", "::"):
+        host = "127.0.0.1"
+    port = args.port or 30000
+    return f"http://{host}:{port}"
+
+
+def parse_adapter_args() -> tuple[argparse.Namespace, list[str]]:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--pp-page-size", type=int, required=True)
+    parser.add_argument("--pp-aligned-prefix-tokens", type=int, required=True)
+    parser.add_argument("--pp-partial-len", type=int, required=True)
+    parser.add_argument("--pp-suffix-len", type=int, required=True)
+    parser.add_argument("--pp-output-len", type=int, default=1)
+    parser.add_argument("--pp-cache-salt", required=True)
+    parser.add_argument("--pp-manual-warmups", type=int, default=3)
+    parser.add_argument("--pp-concurrent-warmups", type=int, default=0)
+    parser.add_argument("--pp-sample-offset", type=int, default=0)
+    parser.add_argument("--pp-expected-cached-tokens", type=int, required=True)
+    parser.add_argument("--pp-request-timeout", type=float, default=900)
+    adapter_args, serving_argv = parser.parse_known_args()
+    if adapter_args.pp_page_size <= 1:
+        parser.error("--pp-page-size must be greater than one")
+    if not 0 < adapter_args.pp_partial_len < adapter_args.pp_page_size:
+        parser.error("--pp-partial-len must be in [1, page_size)")
+    if adapter_args.pp_aligned_prefix_tokens % adapter_args.pp_page_size:
+        parser.error("--pp-aligned-prefix-tokens must be page aligned")
+    if adapter_args.pp_suffix_len < 1:
+        parser.error("--pp-suffix-len must be positive")
+    if adapter_args.pp_concurrent_warmups < 0:
+        parser.error("--pp-concurrent-warmups must be non-negative")
+    return adapter_args, serving_argv
+
+
+def main() -> None:
+    adapter_args, serving_argv = parse_adapter_args()
+    original_get_dataset = serving.get_dataset
+
+    def get_exact_partial_dataset(args, tokenizer, model_id=None):
+        del tokenizer, model_id
+        if args.backend != "sglang":
+            raise ValueError(
+                "The exact partial-prefix adapter requires --backend sglang"
+            )
+        # The adapter replaces the CLI-selected built-in dataset. Keep the
+        # persisted result metadata honest instead of reporting the parser's
+        # default (usually ``sharegpt``).
+        args.dataset_name = "exact-partial-prefix"
+        if args.warmup_requests != 0:
+            raise ValueError(
+                "Pass --warmup-requests 0: this adapter performs exact-shape "
+                "manual warmups that are excluded from the timed request list."
+            )
+
+        page_size = adapter_args.pp_page_size
+        aligned_prefix = adapter_args.pp_aligned_prefix_tokens
+        partial_len = adapter_args.pp_partial_len
+        suffix_len = adapter_args.pp_suffix_len
+        seed = 91_000_000 + aligned_prefix * 17 + page_size
+
+        common = deterministic_tokens(seed, aligned_prefix)
+        target_p0 = deterministic_tokens(seed + 10_000, page_size)
+        target_p1 = deterministic_tokens(seed + 20_000, page_size)
+        sibling_p0 = deterministic_tokens(seed + 30_000, page_size)
+        sibling_p1 = deterministic_tokens(seed + 40_000, page_size)
+        sibling_p0[0] = force_different(sibling_p0[0], target_p0[0])
+        target_guard = deterministic_tokens(seed + 50_000, 1)
+        sibling_guard = deterministic_tokens(seed + 60_000, 1)
+
+        base_url = resolve_base_url(args)
+        target_prompt = common + target_p0 + target_p1 + target_guard
+        sibling_prompt = common + sibling_p0 + sibling_p1 + sibling_guard
+        post_generate(
+            base_url,
+            target_prompt,
+            1,
+            adapter_args.pp_cache_salt,
+            adapter_args.pp_request_timeout,
+        )
+        post_generate(
+            base_url,
+            sibling_prompt,
+            1,
+            adapter_args.pp_cache_salt,
+            adapter_args.pp_request_timeout,
+        )
+
+        forbidden = target_p1[partial_len]
+        for warmup_index in range(adapter_args.pp_manual_warmups):
+            sample_index = adapter_args.pp_sample_offset + warmup_index
+            suffix = make_divergent_suffix(
+                seed=seed + 70_000,
+                sample_index=sample_index,
+                length=suffix_len,
+                forbidden=forbidden,
+            )
+            prompt = common + target_p0 + target_p1[:partial_len] + suffix
+            output = post_generate(
+                base_url,
+                prompt,
+                adapter_args.pp_output_len,
+                adapter_args.pp_cache_salt,
+                adapter_args.pp_request_timeout,
+            )
+            cached = int((output.get("meta_info") or {}).get("cached_tokens", -1))
+            if cached != adapter_args.pp_expected_cached_tokens:
+                raise RuntimeError(
+                    f"Warmup cached-token mismatch: expected "
+                    f"{adapter_args.pp_expected_cached_tokens}, got {cached}"
+                )
+
+        concurrent_start = (
+            adapter_args.pp_sample_offset + adapter_args.pp_manual_warmups
+        )
+
+        def run_concurrent_warmup(concurrent_index: int) -> None:
+            sample_index = concurrent_start + concurrent_index
+            suffix = make_divergent_suffix(
+                seed=seed + 70_000,
+                sample_index=sample_index,
+                length=suffix_len,
+                forbidden=forbidden,
+            )
+            prompt = common + target_p0 + target_p1[:partial_len] + suffix
+            output = post_generate(
+                base_url,
+                prompt,
+                adapter_args.pp_output_len,
+                adapter_args.pp_cache_salt,
+                adapter_args.pp_request_timeout,
+            )
+            cached = int((output.get("meta_info") or {}).get("cached_tokens", -1))
+            if cached != adapter_args.pp_expected_cached_tokens:
+                raise RuntimeError(
+                    f"Concurrent warmup cached-token mismatch: expected "
+                    f"{adapter_args.pp_expected_cached_tokens}, got {cached}"
+                )
+
+        if adapter_args.pp_concurrent_warmups:
+            with concurrent.futures.ThreadPoolExecutor(
+                max_workers=adapter_args.pp_concurrent_warmups
+            ) as executor:
+                list(
+                    executor.map(
+                        run_concurrent_warmup,
+                        range(adapter_args.pp_concurrent_warmups),
+                    )
+                )
+
+        rows: list[DatasetRow] = []
+        first_measured = concurrent_start + adapter_args.pp_concurrent_warmups
+        for request_index in range(args.num_prompts):
+            sample_index = first_measured + request_index
+            suffix = make_divergent_suffix(
+                seed=seed + 70_000,
+                sample_index=sample_index,
+                length=suffix_len,
+                forbidden=forbidden,
+            )
+            prompt = common + target_p0 + target_p1[:partial_len] + suffix
+            rows.append(
+                DatasetRow(
+                    prompt=prompt,
+                    prompt_len=len(prompt),
+                    output_len=adapter_args.pp_output_len,
+                    extra_request_body={"cache_salt": adapter_args.pp_cache_salt},
+                )
+            )
+
+        aligned_match = aligned_prefix + page_size
+        exact_match = aligned_match + partial_len
+        print(
+            "Exact partial-prefix workload prepared: "
+            f"page_size={page_size}, aligned_base={aligned_prefix}, "
+            f"aligned_match={aligned_match}, exact_match={exact_match}, "
+            f"prompt_len={len(rows[0].prompt)}, requests={len(rows)}, "
+            f"manual_warmups={adapter_args.pp_manual_warmups}, "
+            f"concurrent_warmups={adapter_args.pp_concurrent_warmups}, "
+            f"expected_cached={adapter_args.pp_expected_cached_tokens}"
+        )
+        return rows
+
+    serving.get_dataset = get_exact_partial_dataset
+    try:
+        sys.argv = [sys.argv[0], *serving_argv]
+        serving.cli_main()
+    finally:
+        serving.get_dataset = original_get_dataset
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/radix_cache/run_partial_prefix_serving_matrix.py
+++ b/benchmark/radix_cache/run_partial_prefix_serving_matrix.py
@@ -1,0 +1,443 @@
+"""Run a resumable official bench_serving matrix for partial-page KV reuse.
+
+This driver starts an ordinary CUDA FULL-attention SGLang server, invokes
+``bench_partial_prefix_serving.py`` for deterministic exact-R requests, and
+validates every persisted result before moving to the next case.
+
+The aligned reusable prefix is expressed as the *actual* page-aligned match
+length.  For example, ``--aligned-match-tokens 4096 --page-size 32`` builds a
+4064-token common prefix followed by a fully matching 32-token child page, so
+the legacy aligned match is exactly 4096 rather than 4096 + page_size.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import requests
+
+PARTIALS_BY_PAGE = {
+    16: [1, 4, 8, 12, 15],
+    32: [1, 8, 16, 24, 31],
+    64: [1, 8, 16, 32, 48, 63],
+}
+SUPPORTED_CONCURRENCIES = (1, 8, 16)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model-name", required=True)
+    parser.add_argument("--model-path", required=True)
+    parser.add_argument("--output-root", required=True)
+    parser.add_argument("--page-size", type=int, choices=(16, 32, 64), required=True)
+    parser.add_argument(
+        "--configs",
+        nargs="+",
+        choices=("baseline", "reuse"),
+        default=["baseline", "reuse"],
+    )
+    parser.add_argument("--aligned-match-tokens", type=int, default=4096)
+    parser.add_argument("--concurrencies", type=int, nargs="+", default=[1, 8, 16])
+    parser.add_argument("--num-prompts-c1", type=int, default=50)
+    parser.add_argument("--num-prompts-c8", type=int, default=80)
+    parser.add_argument("--num-prompts-c16", type=int, default=80)
+    parser.add_argument(
+        "--sparse-c8",
+        action="store_true",
+        help="For C=8, measure only R=1, page_size/2, and page_size-1.",
+    )
+    parser.add_argument("--partial-lens", type=int, nargs="+")
+    parser.add_argument("--output-len", type=int, default=1)
+    parser.add_argument("--suffix-len", type=int)
+    parser.add_argument("--tp", type=int, default=2)
+    parser.add_argument("--cuda-visible-devices", default="0,1")
+    parser.add_argument("--port", type=int, default=30000)
+    parser.add_argument("--mem-fraction-static", type=float, default=0.8)
+    parser.add_argument("--server-timeout", type=float, default=1200)
+    parser.add_argument("--request-timeout", type=float, default=900)
+    parser.add_argument("--manual-warmups", type=int, default=3)
+    parser.add_argument("--extra-server-args", nargs=argparse.REMAINDER, default=[])
+    args = parser.parse_args()
+
+    if args.aligned_match_tokens % args.page_size:
+        parser.error("--aligned-match-tokens must be divisible by --page-size")
+    if args.aligned_match_tokens <= args.page_size:
+        parser.error("--aligned-match-tokens must exceed one page")
+    if any(c not in SUPPORTED_CONCURRENCIES for c in args.concurrencies):
+        parser.error("supported concurrencies are 1, 8, and 16")
+    partials = args.partial_lens or PARTIALS_BY_PAGE[args.page_size]
+    if any(r <= 0 or r >= args.page_size for r in partials):
+        parser.error("every partial length must satisfy 0 < R < page_size")
+    args.partial_lens = partials
+    args.suffix_len = args.suffix_len or args.page_size + 1
+    args.num_prompts_by_concurrency = {
+        1: args.num_prompts_c1,
+        8: args.num_prompts_c8,
+        16: args.num_prompts_c16,
+    }
+    for concurrency in args.concurrencies:
+        if args.num_prompts_by_concurrency[concurrency] < 5 * concurrency:
+            parser.error(
+                f"C={concurrency} requires at least {5 * concurrency} prompts "
+                "to follow the bench_serving steady-state guidance"
+            )
+    return args
+
+
+def runtime_env(cuda_visible_devices: str) -> dict[str, str]:
+    env = os.environ.copy()
+    venv_root = Path(sys.prefix)
+    cuda_home = venv_root / "lib/python3.12/site-packages/nvidia/cu13"
+    env.update(
+        {
+            "CUDA_HOME": str(cuda_home),
+            "CUDA_VISIBLE_DEVICES": cuda_visible_devices,
+            "LD_LIBRARY_PATH": str(cuda_home / "lib64"),
+            "SGLANG_ENABLE_UNIFIED_RADIX_TREE": "0",
+            "SGLANG_EXPERIMENTAL_CPP_RADIX_TREE": "0",
+            "SGLANG_USE_HND_KVCACHE": "0",
+            "PYTHONUNBUFFERED": "1",
+        }
+    )
+    env["PATH"] = f"{cuda_home / 'bin'}:{venv_root / 'bin'}:{env.get('PATH', '')}"
+    return env
+
+
+def wait_for_server(base_url: str, process: subprocess.Popen, timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise RuntimeError(f"server exited early with code {process.returncode}")
+        try:
+            response = requests.get(f"{base_url}/v1/models", timeout=2)
+            if response.ok:
+                return
+        except requests.RequestException as exc:
+            last_error = exc
+        time.sleep(1)
+    raise TimeoutError(f"server did not become ready: {last_error}")
+
+
+def stop_server(process: subprocess.Popen) -> None:
+    if process.poll() is not None:
+        return
+    os.killpg(process.pid, signal.SIGINT)
+    try:
+        process.wait(timeout=30)
+    except subprocess.TimeoutExpired:
+        os.killpg(process.pid, signal.SIGKILL)
+        process.wait(timeout=10)
+
+
+def load_last_json(path: Path) -> dict[str, Any]:
+    lines = [line for line in path.read_text().splitlines() if line.strip()]
+    if not lines:
+        raise RuntimeError(f"empty result file: {path}")
+    return json.loads(lines[-1])
+
+
+def validate_result(
+    path: Path,
+    *,
+    expected_cached: int,
+    expected_requests: int,
+    expected_prompt_len: int,
+    expected_tag: str,
+) -> dict[str, Any]:
+    result = load_last_json(path)
+    cached = result.get("cached_tokens") or []
+    input_lens = result.get("input_lens") or []
+    errors = result.get("errors") or []
+    if result.get("tag") != expected_tag:
+        raise RuntimeError(f"tag mismatch in {path}: {result.get('tag')!r}")
+    if result.get("completed") != expected_requests:
+        raise RuntimeError(
+            f"completed mismatch in {path}: {result.get('completed')} != {expected_requests}"
+        )
+    if len(cached) != expected_requests or set(cached) != {expected_cached}:
+        raise RuntimeError(
+            f"cached-token mismatch in {path}: expected {expected_cached}, "
+            f"observed {sorted(set(cached))}, count={len(cached)}"
+        )
+    if len(input_lens) != expected_requests or set(input_lens) != {expected_prompt_len}:
+        raise RuntimeError(
+            f"input-length mismatch in {path}: expected {expected_prompt_len}, "
+            f"observed {sorted(set(input_lens))}, count={len(input_lens)}"
+        )
+    if any(errors):
+        raise RuntimeError(f"request errors in {path}: {[e for e in errors if e][:3]}")
+    return result
+
+
+def result_is_valid(path: Path, **expected: Any) -> bool:
+    if not path.exists():
+        return False
+    try:
+        validate_result(path, **expected)
+    except (OSError, ValueError, RuntimeError, json.JSONDecodeError):
+        return False
+    return True
+
+
+def case_offset(
+    page_size: int, partial_len: int, concurrency: int, warmup: bool
+) -> int:
+    return (
+        page_size * 1_000_000
+        + partial_len * 10_000
+        + concurrency * 100
+        + (1 if warmup else 50)
+    )
+
+
+def run_case(
+    args: argparse.Namespace,
+    *,
+    config: str,
+    partial_len: int,
+    concurrency: int,
+    warmup: bool,
+    config_dir: Path,
+    env: dict[str, str],
+) -> dict[str, Any] | None:
+    expected_cached = args.aligned_match_tokens + (
+        partial_len if config == "reuse" else 0
+    )
+    num_prompts = (
+        max(16, 2 * concurrency)
+        if warmup
+        else args.num_prompts_by_concurrency[concurrency]
+    )
+    phase = "shape_warmup" if warmup else "measured"
+    tag = (
+        f"{args.model_name}-p{args.page_size}-r{partial_len}-c{concurrency}-"
+        f"o{args.output_len}-{config}-{phase}"
+    )
+    result_dir = config_dir / ("warmups" if warmup else "cases")
+    result_dir.mkdir(parents=True, exist_ok=True)
+    result_path = (
+        result_dir
+        / f"p{args.page_size}_r{partial_len}_c{concurrency}_o{args.output_len}.jsonl"
+    )
+    log_path = result_path.with_suffix(".log")
+    prompt_len = args.aligned_match_tokens + partial_len + args.suffix_len
+    expected = {
+        "expected_cached": expected_cached,
+        "expected_requests": num_prompts,
+        "expected_prompt_len": prompt_len,
+        "expected_tag": tag,
+    }
+    if result_is_valid(result_path, **expected):
+        print(f"SKIP valid {tag}", flush=True)
+        return None if warmup else validate_result(result_path, **expected)
+
+    result_path.unlink(missing_ok=True)
+    cache_salt = f"pp-{tag}-{time.time_ns()}"
+    adapter = Path(__file__).with_name("bench_partial_prefix_serving.py")
+    command = [
+        sys.executable,
+        str(adapter),
+        "--pp-page-size",
+        str(args.page_size),
+        "--pp-aligned-prefix-tokens",
+        str(args.aligned_match_tokens - args.page_size),
+        "--pp-partial-len",
+        str(partial_len),
+        "--pp-suffix-len",
+        str(args.suffix_len),
+        "--pp-output-len",
+        str(args.output_len),
+        "--pp-cache-salt",
+        cache_salt,
+        "--pp-manual-warmups",
+        str(args.manual_warmups),
+        "--pp-concurrent-warmups",
+        str(concurrency if not warmup and concurrency > 1 else 0),
+        "--pp-sample-offset",
+        str(case_offset(args.page_size, partial_len, concurrency, warmup)),
+        "--pp-expected-cached-tokens",
+        str(expected_cached),
+        "--pp-request-timeout",
+        str(args.request_timeout),
+        "--backend",
+        "sglang",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        str(args.port),
+        "--model",
+        args.model_path,
+        "--tokenizer",
+        args.model_path,
+        "--num-prompts",
+        str(num_prompts),
+        "--max-concurrency",
+        str(concurrency),
+        "--output-file",
+        str(result_path),
+        "--output-details",
+        "--cache-report",
+        "--disable-tqdm",
+        "--warmup-requests",
+        "0",
+        "--temperature",
+        "0",
+        "--tag",
+        tag,
+    ]
+    print(f"RUN {tag}", flush=True)
+    with log_path.open("w") as log_file:
+        completed = subprocess.run(
+            command,
+            cwd=Path(__file__).resolve().parents[2],
+            env=env,
+            stdout=log_file,
+            stderr=subprocess.STDOUT,
+            timeout=args.request_timeout + 300,
+            check=False,
+            text=True,
+        )
+    if completed.returncode:
+        tail = "\n".join(log_path.read_text(errors="replace").splitlines()[-80:])
+        raise RuntimeError(
+            f"benchmark failed ({completed.returncode}) for {tag}:\n{tail}"
+        )
+    result = validate_result(result_path, **expected)
+    print(
+        f"DONE {tag}: throughput={result['request_throughput']:.3f} req/s "
+        f"ttft={result['mean_ttft_ms']:.3f} ms",
+        flush=True,
+    )
+    return None if warmup else result
+
+
+def run_config(
+    args: argparse.Namespace,
+    *,
+    config: str,
+    page_dir: Path,
+    env: dict[str, str],
+) -> None:
+    config_dir = page_dir / config
+    config_dir.mkdir(parents=True, exist_ok=True)
+    server_log_path = config_dir / "server.log"
+    command = [
+        sys.executable,
+        "-m",
+        "sglang.launch_server",
+        "--model-path",
+        args.model_path,
+        "--tp",
+        str(args.tp),
+        "--page-size",
+        str(args.page_size),
+        "--attention-backend",
+        "triton",
+        "--mem-fraction-static",
+        str(args.mem_fraction_static),
+        "--random-seed",
+        "0",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        str(args.port),
+    ]
+    if config == "reuse":
+        command.append("--enable-partial-prefix-reuse")
+    command.extend(args.extra_server_args)
+
+    print(f"START server {args.model_name} p{args.page_size} {config}", flush=True)
+    with server_log_path.open("a") as server_log:
+        process = subprocess.Popen(
+            command,
+            cwd=Path(__file__).resolve().parents[2],
+            env=env,
+            stdout=server_log,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+            text=True,
+        )
+        try:
+            wait_for_server(
+                f"http://127.0.0.1:{args.port}", process, args.server_timeout
+            )
+            summary: dict[str, Any] = {}
+            for partial_len in args.partial_lens:
+                for concurrency in args.concurrencies:
+                    if (
+                        concurrency == 8
+                        and args.sparse_c8
+                        and partial_len
+                        not in {1, args.page_size // 2, args.page_size - 1}
+                    ):
+                        continue
+                    result = run_case(
+                        args,
+                        config=config,
+                        partial_len=partial_len,
+                        concurrency=concurrency,
+                        warmup=False,
+                        config_dir=config_dir,
+                        env=env,
+                    )
+                    if result is not None:
+                        summary[f"r{partial_len}_c{concurrency}"] = {
+                            "request_throughput": result["request_throughput"],
+                            "mean_ttft_ms": result["mean_ttft_ms"],
+                            "median_ttft_ms": result["median_ttft_ms"],
+                            "p90_ttft_ms": result["p90_ttft_ms"],
+                            "p99_ttft_ms": result["p99_ttft_ms"],
+                            "mean_e2e_latency_ms": result["mean_e2e_latency_ms"],
+                            "median_e2e_latency_ms": result["median_e2e_latency_ms"],
+                            "p90_e2e_latency_ms": result["p90_e2e_latency_ms"],
+                            "p99_e2e_latency_ms": result["p99_e2e_latency_ms"],
+                        }
+            (config_dir / "summary.json").write_text(
+                json.dumps(summary, indent=2, sort_keys=True) + "\n"
+            )
+        finally:
+            stop_server(process)
+    print(f"STOP server {args.model_name} p{args.page_size} {config}", flush=True)
+
+
+def main() -> None:
+    args = parse_args()
+    output_root = Path(args.output_root).resolve()
+    page_dir = output_root / args.model_name / f"page_{args.page_size}"
+    page_dir.mkdir(parents=True, exist_ok=True)
+    metadata = {
+        "model_name": args.model_name,
+        "model_path": str(Path(args.model_path).resolve()),
+        "page_size": args.page_size,
+        "aligned_match_tokens": args.aligned_match_tokens,
+        "partial_lens": args.partial_lens,
+        "concurrencies": args.concurrencies,
+        "num_prompts_by_concurrency": args.num_prompts_by_concurrency,
+        "sparse_c8": args.sparse_c8,
+        "suffix_len": args.suffix_len,
+        "output_len": args.output_len,
+        "tp": args.tp,
+        "cuda_visible_devices": args.cuda_visible_devices,
+        "mem_fraction_static": args.mem_fraction_static,
+        "configs": args.configs,
+        "timestamp": time.time(),
+    }
+    (page_dir / "metadata.json").write_text(
+        json.dumps(metadata, indent=2, sort_keys=True) + "\n"
+    )
+    env = runtime_env(args.cuda_visible_devices)
+    for config in args.configs:
+        run_config(args, config=config, page_dir=page_dir, env=env)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -2759,7 +2759,14 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                 continue
             src = state.source_indices
             dst = state.destination_indices
-            assert src is not None and dst is not None and len(src) == len(dst)
+            if src is None or dst is None:
+                # Overlap scheduling can prepare a later chunk of the same
+                # request before the result that releases the source lock is
+                # processed. The copy was already transferred to the earlier
+                # ForwardBatch, so there is nothing to collect again.
+                assert src is None and dst is None
+                continue
+            assert len(src) == len(dst)
             assert state.source_node is not None
             src_tensors.append(src)
             dst_tensors.append(dst)

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1390,6 +1390,9 @@ class Req(ReqDllmMixin):
             else:
                 self.cache_protected_len = len(self.prefix_indices)
 
+            if tree_cache.enable_partial_prefix_reuse:
+                tree_cache.materialize_partial_prefix(self, match_result)
+
             if self.is_dllm():
                 self._update_block_offset_for_dllm()
 
@@ -2109,6 +2112,9 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
     mamba_cow_src_indices: torch.Tensor = None
     mamba_cow_dst_indices: torch.Tensor = None
     mamba_clear_indices: torch.Tensor = None
+    # Deferred paged-FULL partial-prefix copy pairs (performed on forward stream).
+    partial_prefix_copy_src_indices: torch.Tensor = None
+    partial_prefix_copy_dst_indices: torch.Tensor = None
 
     # Encoder-decoder device tensors (host fields in the host metadata group)
     encoder_lens: Optional[torch.Tensor] = None
@@ -2621,6 +2627,8 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         # Collect mamba init info for deferred ops on forward stream
         if any(req.mamba_pool_idx is not None for req in reqs):
             self._collect_deferred_mamba_cow_and_clear(reqs)
+        if self.tree_cache.enable_partial_prefix_reuse:
+            self._collect_deferred_partial_prefix_copy(reqs)
 
         if self.model_config.is_encoder_decoder:
             self.prepare_encoder_info_extend(input_ids, seq_lens)
@@ -2740,6 +2748,31 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             torch.cat(cow_dst_tensors) if cow_dst_tensors else None
         )
         self.mamba_clear_indices = torch.cat(clear_tensors) if clear_tensors else None
+
+    def _collect_deferred_partial_prefix_copy(self, reqs):
+        """Collect token-granular KV copy pairs for the forward stream."""
+        src_tensors = []
+        dst_tensors = []
+        for req in reqs:
+            state = getattr(req, "_partial_prefix_copy_state", None)
+            if state is None:
+                continue
+            src = state.source_indices
+            dst = state.destination_indices
+            assert src is not None and dst is not None and len(src) == len(dst)
+            assert state.source_node is not None
+            src_tensors.append(src)
+            dst_tensors.append(dst)
+            state.source_indices = None
+            state.destination_indices = None
+            # The page is now owned by req.prefix_indices / req_to_token.
+            state.page_indices = None
+        self.partial_prefix_copy_src_indices = (
+            torch.cat(src_tensors) if src_tensors else None
+        )
+        self.partial_prefix_copy_dst_indices = (
+            torch.cat(dst_tensors) if dst_tensors else None
+        )
 
     def prepare_for_split_prefill(self):
         self.prepare_for_extend()
@@ -3189,6 +3222,8 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         self.mamba_cow_src_indices = None
         self.mamba_cow_dst_indices = None
         self.mamba_clear_indices = None
+        self.partial_prefix_copy_src_indices = None
+        self.partial_prefix_copy_dst_indices = None
         self.return_logprob = any(req.return_logprob for req in self.reqs)
         if self.return_logprob:
             self.top_logprobs_nums = [self.top_logprobs_nums[i] for i in keep_indices]

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3418,6 +3418,8 @@ class Scheduler(
                 # lifecycle and freeing them here causes double-free.
                 added = len(adder.can_run_list) > 0 and req is adder.can_run_list[-1]
                 if not added:
+                    if self.server_args.enable_partial_prefix_reuse:
+                        self.tree_cache.abort_partial_prefix(req)
                     # init_next_round_input() may stage deferred Mamba COW/clear
                     # metadata before add_one_req() rejects the request.
                     req.mamba_cow_src_index = None

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -222,6 +222,12 @@ class SchedulerBatchResultProcessor:
 
             # Move next_token_ids and logprobs to cpu
             next_token_ids = next_token_ids.tolist()
+            if self.server_args.enable_partial_prefix_reuse:
+                # The KV copy is ordered before attention on the same forward
+                # stream. Materializing its dependent output on CPU above makes
+                # the source page safe to unlock and recycle.
+                for req in batch.reqs:
+                    self.tree_cache.release_partial_prefix_source(req)
             self.move_logprobs_to_cpu(batch=batch, logits_output=logits_output)
 
             self._validate_pp_skip_output_comm(batch, result)
@@ -337,6 +343,12 @@ class SchedulerBatchResultProcessor:
                     phs = [t.cpu().detach() for t in phs]
                 else:
                     phs = phs.cpu().detach()
+
+            if self.server_args.enable_partial_prefix_reuse:
+                # The embedding output CPU transfer likewise synchronizes the
+                # forward stream that consumed the copied prefix.
+                for req in batch.reqs:
+                    self.tree_cache.release_partial_prefix_source(req)
 
             # Check finish conditions
             for i, req in enumerate(batch.reqs):

--- a/python/sglang/srt/mem_cache/base_prefix_cache.py
+++ b/python/sglang/srt/mem_cache/base_prefix_cache.py
@@ -45,6 +45,7 @@ class PrefixCacheTrait(Protocol):
     token_to_kv_pool_allocator: BaseTokenToKVPoolAllocator
     page_size: int
     disable: bool
+    enable_partial_prefix_reuse: bool
 
 
 @dataclasses.dataclass
@@ -168,6 +169,16 @@ class InitLoadBackParams:
     req: Optional[Req] = None
 
 
+@dataclasses.dataclass(frozen=True)
+class PartialPrefixMatch:
+    """Read-only metadata for a token-level match beyond the tree boundary."""
+
+    exact_match_len: int
+    source_indices: torch.Tensor
+    source_node: Any
+    match_kind: str
+
+
 class MatchResult(NamedTuple):
     """Result of a prefix match operation.
 
@@ -195,6 +206,9 @@ class MatchResult(NamedTuple):
                                 exists a mamba state.
         full_kv_hit_length: Longest Full-KV prefix available on either device or
                             host, independent of other components.
+        partial_prefix_match: Optional token-level match beyond the page-aligned
+                            tree boundary. Its source slots remain read-only
+                            until materialized into a private request page.
     """
 
     device_indices: torch.Tensor
@@ -207,6 +221,7 @@ class MatchResult(NamedTuple):
     mamba_branching_seqlen: Optional[int] = None
     cache_protected_len: Optional[int] = None
     full_kv_hit_length: int = 0
+    partial_prefix_match: Optional[PartialPrefixMatch] = None
     # Actions the Controller applies: CacheActions itself, ComponentActions routed to the owning component.
     cache_actions: Sequence[CacheAction | ComponentAction] = ()
 
@@ -229,11 +244,14 @@ def zero_match_result(
         swa_host_hit_length=0,
         mamba_host_hit_length=0,
         full_kv_hit_length=0,
+        partial_prefix_match=None,
     )
 
 
 class BasePrefixCache(ABC, PrefixCacheTrait):
     """Cache can be indexed by either rid or key."""
+
+    enable_partial_prefix_reuse = False
 
     metrics_collector: Optional[RadixCacheMetricsCollector] = (
         None  # metrics collector for the cache
@@ -280,6 +298,16 @@ class BasePrefixCache(ABC, PrefixCacheTrait):
 
     def supports_fast_match_prefix(self) -> bool:
         return False
+
+    def materialize_partial_prefix(self, req: Req, match_result: MatchResult) -> bool:
+        """Materialize an optional request-private partial-page prefix."""
+        return False
+
+    def abort_partial_prefix(self, req: Req) -> None:
+        """Roll back request-private partial-prefix state after admission fails."""
+
+    def release_partial_prefix_source(self, req: Req) -> None:
+        """Release the temporary source lifetime lock after the copy is safe."""
 
     def resolve_node_handle(self, node_handle: Any) -> Any:
         """Map a node handle to its node -- e.g. UnifiedRadixCache looks up the

--- a/python/sglang/srt/mem_cache/cache_init_params.py
+++ b/python/sglang/srt/mem_cache/cache_init_params.py
@@ -32,6 +32,7 @@ class CacheInitParams:
     enable_metrics: bool = False
     enable_kv_cache_events: bool = False
     enable_session_radix_cache: bool = False
+    enable_partial_prefix_reuse: bool = False
 
     enable_mamba_extra_buffer: bool = False
     enable_mamba_extra_buffer_lazy: bool = False

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -1825,7 +1825,9 @@ class HiRadixCache(RadixCache):
         while len(key) > 0 and child_key in node.children.keys():
             node = node.children[child_key]
             node.last_access_time = time.monotonic()
-            prefix_len = node.key.match(key, page_size=self.page_size)
+            prefix_len = node.key.match(
+                key, page_size=self.page_size, first_page_matched=True
+            )
             key = key[prefix_len:]
             host_value = host_value[prefix_len:]
             hash_value = hash_value[prefix_len // self.page_size :]
@@ -1863,7 +1865,9 @@ class HiRadixCache(RadixCache):
         while len(key) > 0 and child_key in node.children.keys():
             child = node.children[child_key]
             child.last_access_time = time.monotonic()
-            prefix_len = child.key.match(key, page_size=self.page_size)
+            prefix_len = child.key.match(
+                key, page_size=self.page_size, first_page_matched=True
+            )
             if prefix_len < len(child.key):
                 new_node = self._split_node(child.key, child, prefix_len)
                 if not new_node.evicted:
@@ -1940,7 +1944,9 @@ class HiRadixCache(RadixCache):
             node = node.children[child_key]
             node.last_access_time = time.monotonic()
             node.priority = max(node.priority, priority)
-            prefix_len = node.key.match(key, page_size=self.page_size)
+            prefix_len = node.key.match(
+                key, page_size=self.page_size, first_page_matched=True
+            )
 
             if prefix_len == len(node.key):
                 if node.evicted:

--- a/python/sglang/srt/mem_cache/kv_cache_builder.py
+++ b/python/sglang/srt/mem_cache/kv_cache_builder.py
@@ -294,6 +294,7 @@ def build_kv_cache(
         enable_metrics=enable_metrics,
         enable_kv_cache_events=enable_kv_cache_events,
         enable_session_radix_cache=get_memory().enable_session_radix_cache,
+        enable_partial_prefix_reuse=server_args.enable_partial_prefix_reuse,
         enable_mamba_extra_buffer=server_args.enable_mamba_extra_buffer(),
         enable_mamba_extra_buffer_lazy=server_args.enable_mamba_extra_buffer_lazy(),
         pp_rank=ps.pp_rank,

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -1598,7 +1598,10 @@ class KVCacheConfigurator:
             start_layer=self.layer_info.start_layer,
             end_layer=self.layer_info.end_layer,
             enable_alt_stream=not get_disagg().enable_pdmux,
-            enable_kv_cache_copy=(get_spec().speculative_algorithm is not None),
+            enable_kv_cache_copy=(
+                get_spec().speculative_algorithm is not None
+                or self.server_args.enable_partial_prefix_reuse
+            ),
             **pool_kwargs,
         )
         return token_to_kv_pool

--- a/python/sglang/srt/mem_cache/mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/mamba_radix_cache.py
@@ -1106,7 +1106,9 @@ class MambaRadixCache(BasePrefixCache):
                 best_value_len = len(value)
                 best_last_node = node
 
-            prefix_len = child.key.match(key, page_size=self.page_size)
+            prefix_len = child.key.match(
+                key, page_size=self.page_size, first_page_matched=True
+            )
             if prefix_len < len(child.key):
                 new_node = self._split_node(child.key, child, prefix_len)
                 value.append(new_node.value)
@@ -1268,7 +1270,9 @@ class MambaRadixCache(BasePrefixCache):
             node = node.children[child_key]
             node.last_access_time = get_last_access_time()
             self.full_lru_list.reset_node_mru(node)
-            prefix_len = node.key.match(key, page_size=self.page_size)
+            prefix_len = node.key.match(
+                key, page_size=self.page_size, first_page_matched=True
+            )
 
             if prev_prefix_len < total_prefix_length + prefix_len:
                 start = max(0, prev_prefix_len - total_prefix_length)

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -27,6 +27,7 @@ import sys
 import time
 from array import array
 from collections import defaultdict
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Iterator, List, Optional, Tuple, Union
 
 import torch
@@ -44,6 +45,7 @@ from sglang.srt.mem_cache.base_prefix_cache import (
     InsertResult,
     MatchPrefixParams,
     MatchResult,
+    PartialPrefixMatch,
 )
 from sglang.srt.mem_cache.events import KVCacheEventRecorder
 from sglang.srt.mem_cache.utils import (
@@ -183,12 +185,13 @@ class RadixKey:
         other: RadixKey,
         page_size: int = 1,
         first_page_matched: bool = False,
+        return_exact: bool = False,
     ) -> int:
         """Return the logical-unit prefix length shared with ``other``.
 
         ``first_page_matched`` means the caller has already proved that the first
         ``page_size`` logical units match, so the galloping search can start after
-        that page. The result remains page aligned.
+        that page. The result remains page aligned unless ``return_exact=True``.
         """
         self._check_compatible(other)
         if page_size < 1:
@@ -229,7 +232,7 @@ class RadixKey:
         else:
             matched = min(matched_tokens, len(self), len(other))
 
-        if page_size == 1:
+        if return_exact or page_size == 1:
             return matched
         return matched // page_size * page_size
 
@@ -319,12 +322,21 @@ class TreeNode:
         return self.last_access_time < other.last_access_time
 
 
+@dataclass
+class _PartialPrefixCopyState:
+    source_indices: Optional[torch.Tensor]
+    destination_indices: Optional[torch.Tensor]
+    source_node: Optional[TreeNode]
+    page_indices: Optional[torch.Tensor]
+
+
 class RadixCache(BasePrefixCache):
     def __init__(self, params: CacheInitParams):
         self.disable = params.disable
         self.req_to_token_pool = params.req_to_token_pool
         self.token_to_kv_pool_allocator = params.token_to_kv_pool_allocator
         self.page_size = params.page_size
+        self.enable_partial_prefix_reuse = params.enable_partial_prefix_reuse
         self.is_eagle = params.is_eagle
         self.disable_finished_insert = params.disable_finished_insert
         self.eviction_policy = params.eviction_policy.lower()
@@ -345,6 +357,8 @@ class RadixCache(BasePrefixCache):
         else:
             self.device = torch.device("cpu")
 
+        self._validate_partial_prefix_reuse_support(params)
+
         self.eviction_strategy = get_eviction_strategy(self.eviction_policy)
 
         self.evictable_leaves = set()
@@ -357,6 +371,7 @@ class RadixCache(BasePrefixCache):
         mock_allocator: Optional[Any] = None,
         page_size: int = 1,
         enable_kv_cache_events: bool = False,
+        enable_partial_prefix_reuse: bool = False,
     ) -> RadixCache:
         """Init a radix cache without memory pools for simulation purpose."""
         params = CacheInitParams(
@@ -365,6 +380,7 @@ class RadixCache(BasePrefixCache):
             token_to_kv_pool_allocator=mock_allocator,
             page_size=page_size,
             enable_kv_cache_events=enable_kv_cache_events,
+            enable_partial_prefix_reuse=enable_partial_prefix_reuse,
         )
         return RadixCache(params)
 
@@ -410,9 +426,9 @@ class RadixCache(BasePrefixCache):
         Args:
             params (MatchPrefixParams): Parameters containing the lookup key
                 with a list of token ids and an optional ``extra_key`` namespace tag.
-                If ``page_size > 1`` the length is internally truncated to a multiple
-                of ``page_size`` before matching. Passing an empty key returns an
-                empty result with the root as the last node.
+                Unless partial-prefix reuse is enabled, a ``page_size > 1`` key
+                is internally truncated to a page multiple. Passing an empty key
+                returns an empty result with the root as the last node.
 
         Returns:
             MatchResult: ``device_indices`` is a 1-D ``torch.int64`` tensor of
@@ -436,12 +452,25 @@ class RadixCache(BasePrefixCache):
         if self.disable or len(key) == 0:
             return self._empty_match_result
 
-        key = key.page_aligned(self.page_size)
+        if not self.enable_partial_prefix_reuse:
+            key = key.page_aligned(self.page_size)
+            if len(key) == 0:
+                return self._empty_match_result
+            value, last_node = self._match_prefix_helper(self.root_node, key)
+            if value:
+                value = torch.cat(value)
+            else:
+                value = self._empty_match_result.device_indices
+            return MatchResult(
+                device_indices=value,
+                last_device_node=last_node,
+                last_host_node=last_node,
+                best_match_node=last_node,
+            )
 
-        if len(key) == 0:
-            return self._empty_match_result
-
-        value, last_node = self._match_prefix_helper(self.root_node, key)
+        value, last_node, partial_prefix_match = (
+            self._match_prefix_with_partial_page_helper(self.root_node, key)
+        )
         if value:
             value = torch.cat(value)
         else:
@@ -451,7 +480,122 @@ class RadixCache(BasePrefixCache):
             last_device_node=last_node,
             last_host_node=last_node,
             best_match_node=last_node,
+            partial_prefix_match=partial_prefix_match,
         )
+
+    def materialize_partial_prefix(self, req: Req, match_result: MatchResult) -> bool:
+        if not self.enable_partial_prefix_reuse:
+            return False
+
+        partial_match = match_result.partial_prefix_match
+        if partial_match is None:
+            return False
+
+        aligned_match_len = len(match_result.device_indices)
+        partial_len = len(partial_match.source_indices)
+        assert self.page_size > 1
+        assert 0 < partial_len < self.page_size
+        assert partial_match.exact_match_len == aligned_match_len + partial_len
+        assert len(req.prefix_indices) == aligned_match_len
+        assert req.cache_protected_len == aligned_match_len
+        assert not hasattr(req, "_partial_prefix_copy_state")
+
+        # Keep the cached source page alive until the deferred GPU copy is done.
+        self.inc_lock_ref(partial_match.source_node)
+        try:
+            dst_page = self.token_to_kv_pool_allocator.alloc(self.page_size)
+            if dst_page is None:
+                self.evict(EvictParams(num_tokens=self.page_size))
+                dst_page = self.token_to_kv_pool_allocator.alloc(self.page_size)
+        except Exception:
+            self.dec_lock_ref(partial_match.source_node)
+            raise
+        if dst_page is None:
+            self.dec_lock_ref(partial_match.source_node)
+            return False
+
+        assert len(dst_page) == self.page_size
+        dst_prefix = dst_page[:partial_len]
+        req.prefix_indices = torch.cat([req.prefix_indices, dst_prefix])
+        req._partial_prefix_copy_state = _PartialPrefixCopyState(
+            source_indices=partial_match.source_indices,
+            destination_indices=dst_prefix,
+            source_node=partial_match.source_node,
+            page_indices=dst_page,
+        )
+        return True
+
+    def abort_partial_prefix(self, req: Req) -> None:
+        state = getattr(req, "_partial_prefix_copy_state", None)
+        if state is None:
+            return
+        if state.page_indices is not None:
+            self.token_to_kv_pool_allocator.free_segment(
+                state.page_indices, start_pos=0
+            )
+            req.prefix_indices = req.prefix_indices[: req.cache_protected_len]
+        if state.source_node is not None:
+            self.dec_lock_ref(state.source_node)
+        del req._partial_prefix_copy_state
+
+    def release_partial_prefix_source(self, req: Req) -> None:
+        state = getattr(req, "_partial_prefix_copy_state", None)
+        if state is None:
+            return
+        if state.source_node is not None:
+            self.dec_lock_ref(state.source_node)
+            state.source_node = None
+        if (
+            state.source_indices is None
+            and state.destination_indices is None
+            and state.page_indices is None
+        ):
+            del req._partial_prefix_copy_state
+
+    def _validate_partial_prefix_reuse_support(self, params: CacheInitParams) -> None:
+        if not self.enable_partial_prefix_reuse or self.page_size == 1:
+            return
+        # Simulated caches intentionally skip production pool/backend validation.
+        if params.req_to_token_pool is None:
+            return
+
+        from sglang.srt.mem_cache.allocator.paged import PagedTokenToKVPoolAllocator
+        from sglang.srt.mem_cache.memory_pool import MHATokenToKVPool
+
+        allocator = self.token_to_kv_pool_allocator
+        unsupported = []
+        if torch.version.hip is not None or self.device.type != "cuda":
+            unsupported.append(f"device {self.device} is not standard CUDA")
+        if type(allocator) is not PagedTokenToKVPoolAllocator:
+            unsupported.append(
+                f"allocator is {type(allocator).__name__}, not PagedTokenToKVPoolAllocator"
+            )
+            kv_pool = None
+        else:
+            kv_pool = allocator.get_kvcache()
+        if type(kv_pool) is not MHATokenToKVPool:
+            unsupported.append(
+                f"KV pool is {type(kv_pool).__name__}, not MHATokenToKVPool"
+            )
+        else:
+            if kv_pool.kv_cache_layout != "nhd" or kv_pool.use_hnd:
+                unsupported.append(
+                    f"KV layout is {kv_pool.kv_cache_layout!r}, not standard NHD"
+                )
+            if kv_pool.is_quantized_kv_cache:
+                unsupported.append("quantized KV cache is enabled")
+            if kv_pool._kv_copy_config is None:
+                unsupported.append("the all-layer KV copy primitive is not initialized")
+        if self.is_eagle:
+            unsupported.append("EAGLE/bigram radix keys are enabled")
+        if params.pp_size != 1:
+            unsupported.append(f"pipeline parallel size is {params.pp_size}, not 1")
+        if unsupported:
+            raise ValueError(
+                "enable_partial_prefix_reuse is unsupported for this cache setup: "
+                + "; ".join(unsupported)
+                + "."
+            )
 
     def insert(self, params: InsertParams) -> InsertResult:
         if self.disable:
@@ -724,6 +868,79 @@ class RadixCache(BasePrefixCache):
                     child_key = key.child_key(self.page_size)
 
         return value, node
+
+    def _match_prefix_with_partial_page_helper(self, node: TreeNode, key: RadixKey):
+        access_time = time.monotonic()
+        node.last_access_time = access_time
+
+        value = []
+        aligned_match_len = 0
+        partial_prefix_match = None
+
+        while len(key) >= self.page_size:
+            child_key = key.child_key(self.page_size)
+            if child_key not in node.children:
+                break
+            child = node.children[child_key]
+            child.last_access_time = access_time
+            exact_prefix_len = child.key.match(
+                key,
+                page_size=self.page_size,
+                first_page_matched=True,
+                return_exact=True,
+            )
+            prefix_len = exact_prefix_len // self.page_size * self.page_size
+            assert prefix_len >= self.page_size
+            if prefix_len < len(child.key):
+                new_node = self._split_node(child.key, child, prefix_len)
+                value.append(new_node.value)
+                aligned_match_len += prefix_len
+                node = new_node
+                key = key[prefix_len:]
+                partial_len = exact_prefix_len - prefix_len
+                if partial_len:
+                    partial_prefix_match = PartialPrefixMatch(
+                        exact_match_len=aligned_match_len + partial_len,
+                        source_indices=child.value[:partial_len].clone(),
+                        source_node=child,
+                        match_kind="legacy_reachable",
+                    )
+                break
+            else:
+                value.append(child.value)
+                aligned_match_len += prefix_len
+                node = child
+                key = key[prefix_len:]
+
+        if partial_prefix_match is None and self.page_size > 1 and len(key) > 0:
+            best_partial_len = 0
+            best_partial_node = None
+            for child in node.children.values():
+                if (
+                    child.key.extra_key != key.extra_key
+                    or child.key.cache_salt != key.cache_salt
+                ):
+                    continue
+                exact_prefix_len = child.key.match(
+                    key,
+                    page_size=self.page_size,
+                    return_exact=True,
+                )
+                if exact_prefix_len > best_partial_len:
+                    best_partial_len = exact_prefix_len
+                    best_partial_node = child
+
+            if best_partial_len:
+                assert best_partial_len < self.page_size
+                best_partial_node.last_access_time = access_time
+                partial_prefix_match = PartialPrefixMatch(
+                    exact_match_len=aligned_match_len + best_partial_len,
+                    source_indices=best_partial_node.value[:best_partial_len].clone(),
+                    source_node=best_partial_node,
+                    match_kind="fine_lookup",
+                )
+
+        return value, node, partial_prefix_match
 
     def _split_node(self, key: RadixKey, child: TreeNode, split_len: int):
         # new_node -> child

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -178,19 +178,38 @@ class RadixKey:
                 f"{self.cache_salt=} != {other.cache_salt=}"
             )
 
-    def match(self, other: RadixKey, page_size: int = 1) -> int:
-        """Logical-unit prefix length shared with ``other``. Result is rounded down to ``page_size``."""
+    def match(
+        self,
+        other: RadixKey,
+        page_size: int = 1,
+        first_page_matched: bool = False,
+    ) -> int:
+        """Return the logical-unit prefix length shared with ``other``.
+
+        ``first_page_matched`` means the caller has already proved that the first
+        ``page_size`` logical units match, so the galloping search can start after
+        that page. The result remains page aligned.
+        """
         self._check_compatible(other)
+        if page_size < 1:
+            raise ValueError(f"page_size must be >= 1, got {page_size}")
         t0, t1 = self.token_ids, other.token_ids
         assert type(t0) is type(t1), (type(t0), type(t1))
         n = min(len(t0), len(t1))
+
+        if first_page_matched:
+            assert min(len(self), len(other)) >= page_size, (
+                "first_page_matched=True requires at least one complete logical "
+                f"page in both keys, got {len(self)=}, {len(other)=}, {page_size=}"
+            )
 
         # Exponential search for the first diverging token: gallop in doubling
         # windows (one C-level slice compare each), then binary-search the window
         # holding the divergence -- no per-token Python loop on long shared prefixes.
         matched_tokens = n
-        lo = 0
-        step = 1
+        # One page of bigrams spans page_size + 1 raw tokens.
+        lo = page_size + int(self.is_bigram) if first_page_matched else 0
+        step = page_size if first_page_matched else 1
         while lo < n:
             hi = lo + step if lo + step < n else n
             if t0[lo:hi] != t1[lo:hi]:
@@ -207,12 +226,12 @@ class RadixKey:
 
         if self.is_bigram:
             matched = max(0, min(matched_tokens - 1, len(self), len(other)))
-            return (matched // page_size) * page_size if page_size > 1 else matched
+        else:
+            matched = min(matched_tokens, len(self), len(other))
 
-        matched_tokens = min(matched_tokens, len(self), len(other))
         if page_size == 1:
-            return matched_tokens
-        return (matched_tokens // page_size) * page_size
+            return matched
+        return matched // page_size * page_size
 
     def child_key(self, page_size: int = 1):
         """Hashable dict-key for the first ``page_size`` logical units, namespaced by ``extra_key``."""
@@ -686,7 +705,11 @@ class RadixCache(BasePrefixCache):
         while len(key) > 0 and child_key in node.children.keys():
             child = node.children[child_key]
             child.last_access_time = access_time
-            prefix_len = child.key.match(key, page_size=self.page_size)
+            prefix_len = child.key.match(
+                key,
+                page_size=self.page_size,
+                first_page_matched=True,
+            )
             if prefix_len < len(child.key):
                 new_node = self._split_node(child.key, child, prefix_len)
                 value.append(new_node.value)
@@ -759,7 +782,11 @@ class RadixCache(BasePrefixCache):
         while len(key) > 0 and child_key in node.children.keys():
             node = node.children[child_key]
             node.last_access_time = access_time
-            prefix_len = node.key.match(key, page_size=self.page_size)
+            prefix_len = node.key.match(
+                key,
+                page_size=self.page_size,
+                first_page_matched=True,
+            )
             total_prefix_length += prefix_len
             key = key[prefix_len:]
             value = value[prefix_len:]

--- a/python/sglang/srt/mem_cache/registry.py
+++ b/python/sglang/srt/mem_cache/registry.py
@@ -237,6 +237,31 @@ def create_tree_cache(ctx: TreeCacheBuildContext) -> BasePrefixCache:
         cache = default_radix_cache_factory(ctx)
         source = "default"
 
+    if ctx.server_args.enable_partial_prefix_reuse:
+        from sglang.srt.mem_cache.radix_cache import RadixCache
+
+        unsupported_reasons = []
+        if ctx.server_args.radix_cache_backend is not None:
+            unsupported_reasons.append("a custom --radix-cache-backend is selected")
+        if type(cache) is not RadixCache:
+            unsupported_reasons.append(
+                f"the selected cache is {type(cache).__name__}, not ordinary RadixCache"
+            )
+        if ctx.disable_radix_cache:
+            unsupported_reasons.append("radix caching is disabled")
+        if ctx.server_args.disaggregation_mode != "null":
+            unsupported_reasons.append("disaggregation is enabled")
+        if ctx.server_args.speculative_algorithm is not None:
+            unsupported_reasons.append("speculative decoding is enabled")
+        if ctx.server_args.enable_streaming_session:
+            unsupported_reasons.append("streaming sessions are enabled")
+        if unsupported_reasons:
+            raise ValueError(
+                "Experimental partial-page prefix reuse currently supports only the "
+                "ordinary non-disaggregated, non-speculative Python RadixCache "
+                "path; " + "; ".join(unsupported_reasons) + "."
+            )
+
     if (
         ctx.server_args.enable_hierarchical_cache
         and ctx.server_args.hicache_host_memory_mode == "buffer_only"

--- a/python/sglang/srt/mem_cache/swa_radix_cache.py
+++ b/python/sglang/srt/mem_cache/swa_radix_cache.py
@@ -929,7 +929,9 @@ class SWARadixCache(BasePrefixCache):
                 # reset match_len_since_tombstone if we hit a tombstone node
                 match_len_since_tombstone = 0
 
-            prefix_len = child.key.match(key, page_size=self.page_size)
+            prefix_len = child.key.match(
+                key, page_size=self.page_size, first_page_matched=True
+            )
             if prefix_len < len(child.key):
                 new_node = self._split_node(child.key, child, prefix_len)
                 value.append(new_node.value)
@@ -1160,7 +1162,9 @@ class SWARadixCache(BasePrefixCache):
             self.full_lru_list.reset_node_mru(node)
             if not node.swa_tombstone:
                 self.swa_lru_list.reset_node_mru(node)
-            prefix_len = node.key.match(key, page_size=self.page_size)
+            prefix_len = node.key.match(
+                key, page_size=self.page_size, first_page_matched=True
+            )
 
             if prefix_len < len(node.key):
                 new_node = self._split_node(node.key, node, prefix_len)

--- a/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
+++ b/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
@@ -725,7 +725,9 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
             if child.evicted and not child.backuped:
                 break
 
-            prefix_len = child.key.match(key, page_size=self.page_size)
+            prefix_len = child.key.match(
+                key, page_size=self.page_size, first_page_matched=True
+            )
             full_kv_hit_length += prefix_len
             if prefix_len < len(child.key):
                 node, action = self._split_node(child.key, child, prefix_len)
@@ -951,7 +953,9 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         step_actions = state.pending_actions
         node = state.node.children[child_key]
         self._touch_node(node)
-        prefix_len = node.key.match(key, page_size=self.page_size)
+        prefix_len = node.key.match(
+            key, page_size=self.page_size, first_page_matched=True
+        )
         if prefix_len < len(node.key):
             node, action = self._split_node(node.key, node, prefix_len)
             if action is not None:
@@ -1755,7 +1759,9 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         while len(key) > 0 and child_key in node.children:
             node = node.children[child_key]
             self._touch_node(node)
-            prefix_len = node.key.match(key, page_size=self.page_size)
+            prefix_len = node.key.match(
+                key, page_size=self.page_size, first_page_matched=True
+            )
 
             key = key[prefix_len:]
             host_value = host_value[prefix_len:]

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -415,6 +415,9 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
     mamba_cow_src_indices: Optional[torch.Tensor] = None
     mamba_cow_dst_indices: Optional[torch.Tensor] = None
     mamba_clear_indices: Optional[torch.Tensor] = None
+    # Deferred paged-FULL partial-prefix KV copy pairs.
+    partial_prefix_copy_src_indices: Optional[torch.Tensor] = None
+    partial_prefix_copy_dst_indices: Optional[torch.Tensor] = None
 
     # For input embeddings
     input_embeds: Optional[torch.Tensor] = None
@@ -777,6 +780,8 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             mamba_cow_src_indices=batch.mamba_cow_src_indices,
             mamba_cow_dst_indices=batch.mamba_cow_dst_indices,
             mamba_clear_indices=batch.mamba_clear_indices,
+            partial_prefix_copy_src_indices=batch.partial_prefix_copy_src_indices,
+            partial_prefix_copy_dst_indices=batch.partial_prefix_copy_dst_indices,
             encoder_lens=batch.encoder_lens,
             encoder_out_cache_loc=batch.encoder_out_cache_loc,
             input_embeds=batch.input_embeds,

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1638,6 +1638,18 @@ class ModelRunner:
         forward_batch.mamba_cow_src_indices = None
         forward_batch.mamba_cow_dst_indices = None
 
+    def _execute_partial_prefix_copy(self, forward_batch: ForwardBatch) -> None:
+        """Copy a matched partial KV page on the forward stream before use."""
+        src = forward_batch.partial_prefix_copy_src_indices
+        if src is None or len(src) == 0:
+            return
+        dst = forward_batch.partial_prefix_copy_dst_indices
+        assert dst is not None and len(src) == len(dst)
+        with profile_range(f"partial_prefix_copy[len={len(src)}]"):
+            self.token_to_kv_pool.move_kv_cache(dst, src)
+        forward_batch.partial_prefix_copy_src_indices = None
+        forward_batch.partial_prefix_copy_dst_indices = None
+
     def _forward_raw(
         self,
         forward_batch: ForwardBatch,
@@ -1687,6 +1699,8 @@ class ModelRunner:
 
             # Deferred mamba COW/clear on the forward stream, before the extend
             # dispatch below reads the pool.
+            if self.server_args.enable_partial_prefix_reuse:
+                self._execute_partial_prefix_copy(forward_batch)
             self._maybe_execute_deferred_mamba_cow_and_clear(forward_batch)
 
             dwdp_mgr = get_global_dwdp_manager()

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -909,6 +909,14 @@ class ServerArgs:
         "The physical page size of the NPU DSV4 C128 KV cache. Must be a positive multiple of 16.",
         NS("schedule"),
     ] = 16
+    enable_partial_prefix_reuse: A[
+        bool,
+        "Experimentally discover token-level partial-page prefix matches and "
+        "materialize them into a private request page with a KV copy so model "
+        "forward can skip those tokens. Initially supported only by ordinary "
+        "CUDA FULL-attention Python RadixCache.",
+        NS("memory"),
+    ] = False
     swa_full_tokens_ratio: A[
         float,
         Arg(

--- a/test/registered/unit/mem_cache/test_radix_cache_unit.py
+++ b/test/registered/unit/mem_cache/test_radix_cache_unit.py
@@ -39,6 +39,7 @@ from sglang.srt.disaggregation.kv_events import (
     BlockStoredWithMetadata,
     StorageMedium,
 )
+from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.mem_cache import kv_cache_configurator
 from sglang.srt.mem_cache.allocator.paged import (
     PagedTokenToKVPoolAllocator,
@@ -1319,6 +1320,38 @@ class TestRadixCache(unittest.TestCase):
             req_to_token.req_to_token[0, :10], req.prefix_indices
         )
         torch.testing.assert_close(req_to_token.req_to_token[0, 10:12], dst_page[2:4])
+
+    def test_deferred_partial_prefix_copy_collection_is_overlap_safe(self):
+        source_node = object()
+        state = SimpleNamespace(
+            source_indices=torch.tensor([10, 11], dtype=torch.int64),
+            destination_indices=torch.tensor([20, 21], dtype=torch.int64),
+            source_node=source_node,
+            page_indices=torch.tensor([20, 21, 22, 23], dtype=torch.int64),
+        )
+        req = SimpleNamespace(_partial_prefix_copy_state=state)
+        batch = SimpleNamespace()
+
+        ScheduleBatch._collect_deferred_partial_prefix_copy(batch, [req])
+        torch.testing.assert_close(
+            batch.partial_prefix_copy_src_indices,
+            torch.tensor([10, 11], dtype=torch.int64),
+        )
+        torch.testing.assert_close(
+            batch.partial_prefix_copy_dst_indices,
+            torch.tensor([20, 21], dtype=torch.int64),
+        )
+        self.assertIsNone(state.source_indices)
+        self.assertIsNone(state.destination_indices)
+        self.assertIsNone(state.page_indices)
+        self.assertIs(state.source_node, source_node)
+
+        # A later chunk may be prepared before the earlier forward result
+        # releases source_node. Collection must be idempotent in that window.
+        ScheduleBatch._collect_deferred_partial_prefix_copy(batch, [req])
+        self.assertIsNone(batch.partial_prefix_copy_src_indices)
+        self.assertIsNone(batch.partial_prefix_copy_dst_indices)
+        self.assertIs(state.source_node, source_node)
 
     @unittest.skipUnless(
         torch.cuda.is_available() and torch.version.hip is None,

--- a/test/registered/unit/mem_cache/test_radix_cache_unit.py
+++ b/test/registered/unit/mem_cache/test_radix_cache_unit.py
@@ -27,6 +27,7 @@ import random
 import unittest
 import unittest.mock
 from array import array
+from types import SimpleNamespace
 
 import torch
 
@@ -38,6 +39,11 @@ from sglang.srt.disaggregation.kv_events import (
     BlockStoredWithMetadata,
     StorageMedium,
 )
+from sglang.srt.mem_cache import kv_cache_configurator
+from sglang.srt.mem_cache.allocator.paged import (
+    PagedTokenToKVPoolAllocator,
+    alloc_extend_naive,
+)
 from sglang.srt.mem_cache.allocator.token import TokenToKVPoolAllocator
 from sglang.srt.mem_cache.base_prefix_cache import (
     EvictParams,
@@ -45,13 +51,41 @@ from sglang.srt.mem_cache.base_prefix_cache import (
     InsertParams,
     MatchPrefixParams,
 )
+from sglang.srt.mem_cache.cache_init_params import CacheInitParams
 from sglang.srt.mem_cache.events import KVCacheEventRecorder
+from sglang.srt.mem_cache.kv_cache_configurator import KVCacheConfigurator
 from sglang.srt.mem_cache.mamba_radix_cache import TreeNode as MambaTreeNode
+from sglang.srt.mem_cache.memory_pool import MHATokenToKVPool
 from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey, TreeNode
 from sglang.srt.utils import get_device
 
 # Test constants
 DEFAULT_PAGE_SIZE = 4
+
+
+class _FakeKVCache:
+    def __init__(self, size: int, page_size: int):
+        self.k = torch.full((size + page_size, 2), -1, dtype=torch.int64)
+        self.v = torch.full((size + page_size, 2), -1, dtype=torch.int64)
+
+    def move_kv_cache(self, tgt_loc: torch.Tensor, src_loc: torch.Tensor):
+        self.k[tgt_loc] = self.k[src_loc].clone()
+        self.v[tgt_loc] = self.v[src_loc].clone()
+
+
+class _ReqToTokenPool:
+    def __init__(self, width: int):
+        self.req_to_token = torch.full((1, width), -1, dtype=torch.int64)
+
+    def write(self, indices, values):
+        self.req_to_token[indices] = values
+
+
+def _make_partial_prefix_req(prefix_indices: torch.Tensor):
+    return SimpleNamespace(
+        prefix_indices=prefix_indices,
+        cache_protected_len=len(prefix_indices),
+    )
 
 
 class TestKVCacheEventQueue(unittest.TestCase):
@@ -202,10 +236,19 @@ class TestRadixKey(unittest.TestCase):
         with self.assertRaises(IndexError):
             _ = key[10]  # Out of bounds
 
-    def _assert_match(self, a, b, page_size, expected, is_bigram=False):
+    def _assert_match(
+        self, a, b, page_size, expected, is_bigram=False, return_exact=False
+    ):
         key_a = RadixKey(array("q", a), is_bigram=is_bigram)
         key_b = RadixKey(array("q", b), is_bigram=is_bigram)
-        self.assertEqual(key_a.match(key_b, page_size=page_size), expected)
+        self.assertEqual(
+            key_a.match(
+                key_b,
+                page_size=page_size,
+                return_exact=return_exact,
+            ),
+            expected,
+        )
 
     def test_match_page_size_1(self):
         """match() with page_size=1: full, partial, none, prefix, and empty keys."""
@@ -217,21 +260,35 @@ class TestRadixKey(unittest.TestCase):
         self._assert_match([1, 2], [], 1, 0)  # empty other
         self._assert_match([], [], 1, 0)  # both empty
 
-    def test_match_page_size_gt_1_rounds_down(self):
-        """match() with page_size>1 rounds the shared length down to a page."""
+    def test_match_page_size_gt_1_is_aligned_by_default(self):
         self._assert_match([1, 2, 3, 4, 5, 6, 7, 8], [1, 2, 3, 4, 5, 6, 9, 8], 4, 4)
-        self._assert_match(
-            [1, 2, 3, 4], [1, 9, 3, 4], 4, 0
-        )  # diverge inside first page
+        self._assert_match([1, 2, 3, 4], [1, 9, 3, 4], 4, 0)
         self._assert_match([1, 2, 3, 4, 5, 6, 7, 8], [1, 2, 3, 4, 9, 6, 7, 8], 4, 4)
         self._assert_match([1, 2, 3, 4, 5, 6, 7, 8], [1, 2, 3, 4, 5, 6, 7, 8], 4, 8)
-        self._assert_match([1, 2, 3], [1, 2, 3], 4, 0)  # shorter than one page
+        self._assert_match([1, 2, 3], [1, 2, 3], 4, 0)
+
+    def test_match_can_return_exact_lcp(self):
+        self._assert_match(
+            [1, 2, 3, 4, 5, 6, 7, 8],
+            [1, 2, 3, 4, 5, 6, 9, 8],
+            4,
+            6,
+            return_exact=True,
+        )
+        self._assert_match(
+            [1, 2, 3, 4],
+            [1, 9, 3, 4],
+            4,
+            1,
+            return_exact=True,
+        )
+        self._assert_match([1, 2, 3], [1, 2, 3], 4, 3, return_exact=True)
 
     def test_match_long_keys_exponential_search(self):
         """Deep divergences exercise the doubling gallop windows + binary search.
 
         ``base`` has distinct values, so flipping one position diverges the prefix
-        exactly there; the shared length is that index rounded down to the page.
+        exactly there; the shared length is that exact index.
         """
         base = list(range(2000))
         for div in (1, 2, 63, 64, 65, 127, 128, 511, 512, 513, 1234, 1999):
@@ -239,22 +296,46 @@ class TestRadixKey(unittest.TestCase):
             b[div] = -1
             for page_size in (1, 4, 64):
                 with self.subTest(div=div, page_size=page_size):
-                    self._assert_match(
-                        base, b, page_size, (div // page_size) * page_size
-                    )
+                    self._assert_match(base, b, page_size, div, return_exact=True)
         # Full match of a long key: the gallop must reach the end.
-        self._assert_match(base, base[:], 64, (2000 // 64) * 64)
+        self._assert_match(base, base[:], 64, 2000, return_exact=True)
 
     def test_match_bigram(self):
         """is_bigram: L matching raw tokens imply L-1 matching bigrams."""
         self._assert_match([1, 2, 3, 4, 5], [1, 2, 3, 9, 5], 1, 2, is_bigram=True)
         self._assert_match([1, 2, 3, 4, 5], [1, 2, 3, 4, 5], 1, 4, is_bigram=True)
         self._assert_match([1, 2], [1, 2], 1, 1, is_bigram=True)
-        # Raw diverge at token 70 -> 69 matching bigrams -> rounded down to 64.
+        # Raw diverge at token 70 -> 69 matching bigrams.
         long_a = list(range(130))
         long_b = list(range(130))
         long_b[70] = -1
-        self._assert_match(long_a, long_b, 64, 64, is_bigram=True)
+        self._assert_match(
+            long_a,
+            long_b,
+            64,
+            69,
+            is_bigram=True,
+            return_exact=True,
+        )
+
+    def test_first_page_matched_hint_preserves_lcp(self):
+        base = list(range(257))
+        for div in (4, 5, 7, 8, 31, 32, 127, 256, len(base)):
+            other = base[:]
+            if div < len(other):
+                other[div] = -1
+            expected = div
+            generic = RadixKey(array("q", base)).match(
+                RadixKey(array("q", other)), page_size=4, return_exact=True
+            )
+            hinted = RadixKey(array("q", base)).match(
+                RadixKey(array("q", other)),
+                page_size=4,
+                first_page_matched=True,
+                return_exact=True,
+            )
+            self.assertEqual(generic, expected)
+            self.assertEqual(hinted, expected)
 
 
 class TestTreeNode(unittest.TestCase):
@@ -374,6 +455,85 @@ class TestRadixCache(unittest.TestCase):
         """Set up test fixtures."""
         TreeNode.counter = 0
 
+    def _build_partial_prefix_cache(self, *, enabled: bool = True):
+        page_size = 4
+        pool_size = 64
+        kv_cache = _FakeKVCache(pool_size, page_size)
+        allocator = PagedTokenToKVPoolAllocator(
+            size=pool_size,
+            page_size=page_size,
+            dtype=torch.float16,
+            device="cpu",
+            kvcache=kv_cache,
+            need_sort=False,
+        )
+        cache = RadixCache.create_simulated(
+            mock_allocator=allocator,
+            page_size=page_size,
+            enable_partial_prefix_reuse=enabled,
+        )
+        cached_tokens = array("q", range(1, 13))
+        cached_indices = allocator.alloc(len(cached_tokens))
+        assert cached_indices is not None
+        kv_cache.k[cached_indices] = torch.arange(24, dtype=torch.int64).view(12, 2)
+        kv_cache.v[cached_indices] = torch.arange(100, 124, dtype=torch.int64).view(
+            12, 2
+        )
+        cache.insert(
+            InsertParams(
+                key=RadixKey(cached_tokens),
+                value=cached_indices,
+            )
+        )
+        query_tokens = array("q", [*range(1, 11), 101, 102, 103])
+        result = cache.match_prefix(MatchPrefixParams(key=RadixKey(query_tokens)))
+        return cache, allocator, kv_cache, cached_indices, query_tokens, result
+
+    def _build_split_child_partial_cache(
+        self,
+        *,
+        workload: str,
+        partial_reuse: bool,
+    ):
+        page_size = 4
+        pool_size = 128
+        kv_cache = _FakeKVCache(pool_size, page_size)
+        allocator = PagedTokenToKVPoolAllocator(
+            size=pool_size,
+            page_size=page_size,
+            dtype=torch.float16,
+            device="cpu",
+            kvcache=kv_cache,
+            need_sort=False,
+        )
+        cache = RadixCache.create_simulated(
+            mock_allocator=allocator,
+            page_size=page_size,
+            enable_partial_prefix_reuse=partial_reuse,
+        )
+        common = [1, 2, 3, 4]
+        if workload == "lookup_limited":
+            target_tail = [5, 6, 7, 8]
+            sibling_tail = [105, 106, 107, 108]
+            query_tokens = array("q", common + target_tail[:2] + [999, 1000, 1001])
+        elif workload == "legacy_reachable":
+            target_tail = [5, 6, 7, 8, 9, 10, 11, 12]
+            sibling_tail = [105, 106, 107, 108, 109, 110, 111, 112]
+            query_tokens = array("q", common + target_tail[:6] + [999, 1000, 1001])
+        else:
+            raise AssertionError(f"unknown workload {workload!r}")
+
+        target_tokens = array("q", common + target_tail)
+        sibling_tokens = array("q", common + sibling_tail)
+        target_indices = allocator.alloc(len(target_tokens))
+        sibling_indices = allocator.alloc(len(sibling_tokens))
+        self.assertIsNotNone(target_indices)
+        self.assertIsNotNone(sibling_indices)
+        cache.insert(InsertParams(key=RadixKey(target_tokens), value=target_indices))
+        cache.insert(InsertParams(key=RadixKey(sibling_tokens), value=sibling_indices))
+        result = cache.match_prefix(MatchPrefixParams(key=RadixKey(query_tokens)))
+        return cache, target_indices, query_tokens, result
+
     def test_init_variations(self):
         """Test cache initialization with different parameters."""
         test_cases = [
@@ -398,6 +558,104 @@ class TestRadixCache(unittest.TestCase):
                 self.assertEqual(cache.device, torch.device("cpu"))
                 self.assertIsNotNone(cache.root_node)
                 self.assertEqual(len(cache.root_node.key), 0)
+
+    def test_partial_prefix_rejects_unsupported_production_pool(self):
+        allocator = PagedTokenToKVPoolAllocator(
+            size=16,
+            page_size=4,
+            dtype=torch.float16,
+            device="cpu",
+            kvcache=_FakeKVCache(size=16, page_size=4),
+            need_sort=False,
+        )
+        with self.assertRaisesRegex(
+            ValueError,
+            "enable_partial_prefix_reuse is unsupported.*device cpu.*_FakeKVCache",
+        ):
+            RadixCache(
+                CacheInitParams(
+                    disable=False,
+                    req_to_token_pool=object(),
+                    token_to_kv_pool_allocator=allocator,
+                    page_size=4,
+                    enable_partial_prefix_reuse=True,
+                )
+            )
+
+    def test_partial_prefix_enables_copy_primitive_for_ordinary_mha_pool(self):
+        for partial_reuse, speculative, expected in (
+            (False, None, False),
+            (True, None, True),
+            (False, object(), True),
+        ):
+            with self.subTest(
+                partial_reuse=partial_reuse,
+                speculative=speculative is not None,
+            ):
+                captured = {}
+
+                def pool_cls(*args, **kwargs):
+                    captured.update(kwargs)
+                    return object()
+
+                configurator = SimpleNamespace(
+                    kv_cache_dtype_str="bfloat16",
+                    pool_page_size=4,
+                    kv_cache_dtype=torch.bfloat16,
+                    model_config=SimpleNamespace(
+                        get_num_kv_heads=lambda *_: 8,
+                        head_dim=128,
+                        v_head_dim=128,
+                    ),
+                    layer_info=SimpleNamespace(
+                        num_effective_layers=32,
+                        start_layer=0,
+                        end_layer=32,
+                    ),
+                    device="cuda",
+                    post_capture_kv_active=False,
+                    server_args=SimpleNamespace(
+                        enable_partial_prefix_reuse=partial_reuse
+                    ),
+                )
+                with (
+                    unittest.mock.patch.object(
+                        kv_cache_configurator,
+                        "get_schedule",
+                        return_value=SimpleNamespace(
+                            prefill_only_disable_kv_cache=False
+                        ),
+                    ),
+                    unittest.mock.patch.object(
+                        kv_cache_configurator,
+                        "get_parallel",
+                        return_value=SimpleNamespace(attn_tp_size=1, attn_dcp_size=1),
+                    ),
+                    unittest.mock.patch.object(
+                        kv_cache_configurator,
+                        "get_exec",
+                        return_value=SimpleNamespace(
+                            features=SimpleNamespace(enable_memory_saver=False)
+                        ),
+                    ),
+                    unittest.mock.patch.object(
+                        kv_cache_configurator,
+                        "get_disagg",
+                        return_value=SimpleNamespace(enable_pdmux=False),
+                    ),
+                    unittest.mock.patch.object(
+                        kv_cache_configurator,
+                        "get_spec",
+                        return_value=SimpleNamespace(speculative_algorithm=speculative),
+                    ),
+                ):
+                    KVCacheConfigurator._build_mha_kv_pool(
+                        configurator,
+                        max_total_num_tokens=64,
+                        mha_pool_class=pool_cls,
+                    )
+
+                self.assertEqual(captured["enable_kv_cache_copy"], expected)
 
     def test_reset(self):
         """Test reset method."""
@@ -875,6 +1133,489 @@ class TestRadixCache(unittest.TestCase):
                 # Match length should be page-aligned
                 match_len = len(result.device_indices)
                 self.assertEqual(match_len % page_size, 0)
+
+    def test_partial_prefix_match_reports_exact_lcp_without_unaligned_tree_split(self):
+        cache, _, _, cached_indices, _, result = self._build_partial_prefix_cache()
+
+        self.assertEqual(len(result.device_indices), 8)
+        partial_match = result.partial_prefix_match
+        self.assertIsNotNone(partial_match)
+        self.assertEqual(partial_match.exact_match_len, 10)
+        torch.testing.assert_close(partial_match.source_indices, cached_indices[8:10])
+
+        aligned_node = result.last_device_node
+        self.assertEqual(len(aligned_node.key), 8)
+        self.assertEqual(len(aligned_node.children), 1)
+        source_node = next(iter(aligned_node.children.values()))
+        self.assertIs(partial_match.source_node, source_node)
+        self.assertEqual(len(source_node.key), 4)
+        self.assertTrue(
+            all(len(node.key) % 4 == 0 for node in (aligned_node, source_node))
+        )
+        self.assertEqual(cache.total_size(), 12)
+
+    def test_partial_reuse_bundles_discovery_and_private_page_copy(self):
+        for workload in ("lookup_limited", "legacy_reachable"):
+            for partial_reuse in (False, True):
+                with self.subTest(workload=workload, partial_reuse=partial_reuse):
+                    cache, target_indices, _, result = (
+                        self._build_split_child_partial_cache(
+                            workload=workload,
+                            partial_reuse=partial_reuse,
+                        )
+                    )
+                    req = _make_partial_prefix_req(result.device_indices)
+                    copied = cache.materialize_partial_prefix(req, result)
+
+                    if workload == "lookup_limited":
+                        expected_exact = 6 if partial_reuse else 4
+                        expected_kind = "fine_lookup" if partial_reuse else None
+                        expected_source = target_indices[4:6] if partial_reuse else None
+                        expected_copy = partial_reuse
+                        expected_prefix_len = 6 if expected_copy else 4
+                    else:
+                        expected_exact = 10 if partial_reuse else 8
+                        expected_kind = "legacy_reachable" if partial_reuse else None
+                        expected_source = (
+                            target_indices[8:10] if partial_reuse else None
+                        )
+                        expected_copy = partial_reuse
+                        expected_prefix_len = 10 if expected_copy else 8
+
+                    partial_match = result.partial_prefix_match
+                    actual_exact = (
+                        partial_match.exact_match_len
+                        if partial_match is not None
+                        else len(result.device_indices)
+                    )
+                    actual_kind = (
+                        partial_match.match_kind if partial_match is not None else None
+                    )
+                    self.assertEqual(actual_exact, expected_exact)
+                    self.assertEqual(actual_kind, expected_kind)
+                    self.assertEqual(copied, expected_copy)
+                    self.assertEqual(len(req.prefix_indices), expected_prefix_len)
+                    if expected_source is None:
+                        self.assertIsNone(partial_match)
+                    else:
+                        torch.testing.assert_close(
+                            partial_match.source_indices, expected_source
+                        )
+
+                    # Tree-owned match output remains page aligned in all modes.
+                    self.assertEqual(len(result.device_indices) % 4, 0)
+                    cache.abort_partial_prefix(req)
+
+    def test_radix_cache_child_lookup_uses_first_page_hint(self):
+        seen_hints = []
+        original_match = RadixKey.match
+
+        def recording_match(
+            key,
+            other,
+            page_size=1,
+            first_page_matched=False,
+            return_exact=False,
+        ):
+            seen_hints.append(first_page_matched)
+            return original_match(
+                key,
+                other,
+                page_size=page_size,
+                first_page_matched=first_page_matched,
+                return_exact=return_exact,
+            )
+
+        with unittest.mock.patch.object(RadixKey, "match", new=recording_match):
+            self._build_split_child_partial_cache(
+                workload="legacy_reachable",
+                partial_reuse=False,
+            )
+
+        self.assertTrue(seen_hints)
+        self.assertTrue(all(seen_hints))
+
+    def test_exact_matching_and_child_scan_are_feature_gated(self):
+        for enabled in (False, True):
+            with self.subTest(enabled=enabled):
+                exact_requests = []
+                original_match = RadixKey.match
+
+                def recording_match(
+                    key,
+                    other,
+                    page_size=1,
+                    first_page_matched=False,
+                    return_exact=False,
+                    _exact_requests=exact_requests,
+                    _original_match=original_match,
+                ):
+                    _exact_requests.append(return_exact)
+                    return _original_match(
+                        key,
+                        other,
+                        page_size=page_size,
+                        first_page_matched=first_page_matched,
+                        return_exact=return_exact,
+                    )
+
+                with unittest.mock.patch.object(RadixKey, "match", new=recording_match):
+                    _, _, _, result = self._build_split_child_partial_cache(
+                        workload="lookup_limited",
+                        partial_reuse=enabled,
+                    )
+
+                self.assertEqual(any(exact_requests), enabled)
+                self.assertEqual(result.partial_prefix_match is not None, enabled)
+
+    def test_partial_prefix_copy_continuation_and_req_mapping(self):
+        cache, allocator, kv_cache, cached_indices, _, result = (
+            self._build_partial_prefix_cache()
+        )
+        req = _make_partial_prefix_req(result.device_indices)
+        source_k_before = kv_cache.k[cached_indices[8:12]].clone()
+        source_v_before = kv_cache.v[cached_indices[8:12]].clone()
+        available_before = allocator.available_size()
+
+        self.assertTrue(cache.materialize_partial_prefix(req, result))
+        self.assertEqual(len(req.prefix_indices), 10)
+        self.assertEqual(req.cache_protected_len, 8)
+        self.assertEqual(allocator.available_size(), available_before - 4)
+        self.assertEqual(cache.total_size(), 12)
+
+        state = req._partial_prefix_copy_state
+        dst_page = state.page_indices
+        src = state.source_indices
+        dst = state.destination_indices
+        self.assertFalse(torch.equal(dst_page, cached_indices[8:12]))
+        self.assertEqual(int(dst_page[0]) // 4, int(dst_page[-1]) // 4)
+
+        kv_cache.move_kv_cache(dst, src)
+        torch.testing.assert_close(kv_cache.k[dst], kv_cache.k[src])
+        torch.testing.assert_close(kv_cache.v[dst], kv_cache.v[src])
+        torch.testing.assert_close(kv_cache.k[cached_indices[8:12]], source_k_before)
+        torch.testing.assert_close(kv_cache.v[cached_indices[8:12]], source_v_before)
+
+        continuation = torch.empty(2, dtype=torch.int64)
+        alloc_extend_naive(
+            prefix_lens=torch.tensor([10]),
+            seq_lens=torch.tensor([12]),
+            last_loc=dst[-1:].clone(),
+            free_pages=allocator.free_pages,
+            out_indices=continuation,
+            page_size=4,
+            device="cpu",
+        )
+        torch.testing.assert_close(continuation, dst_page[2:4])
+        kv_cache.k[continuation] = torch.tensor([[1001, 1002], [1003, 1004]])
+        kv_cache.v[continuation] = torch.tensor([[2001, 2002], [2003, 2004]])
+        torch.testing.assert_close(kv_cache.k[dst_page[2:4]], kv_cache.k[continuation])
+        torch.testing.assert_close(kv_cache.k[cached_indices[8:12]], source_k_before)
+
+        req_to_token = _ReqToTokenPool(width=16)
+        req_to_token.write((0, slice(0, 10)), req.prefix_indices)
+        req_to_token.write((0, slice(10, 12)), continuation)
+        torch.testing.assert_close(
+            req_to_token.req_to_token[0, :10], req.prefix_indices
+        )
+        torch.testing.assert_close(req_to_token.req_to_token[0, 10:12], dst_page[2:4])
+
+    @unittest.skipUnless(
+        torch.cuda.is_available() and torch.version.hip is None,
+        "requires standard CUDA",
+    )
+    def test_partial_prefix_uses_real_cuda_all_layer_copy(self):
+        page_size = 4
+        pool_size = 64
+        kv_cache = MHATokenToKVPool(
+            size=pool_size,
+            page_size=page_size,
+            dtype=torch.float16,
+            head_num=2,
+            head_dim=16,
+            layer_num=2,
+            device="cuda",
+            enable_memory_saver=False,
+            enable_alt_stream=False,
+            enable_kv_cache_copy=True,
+            kv_cache_layout="nhd",
+        )
+        allocator = PagedTokenToKVPoolAllocator(
+            size=pool_size,
+            page_size=page_size,
+            dtype=torch.float16,
+            device="cuda",
+            kvcache=kv_cache,
+            need_sort=False,
+        )
+        cache = RadixCache(
+            CacheInitParams(
+                disable=False,
+                req_to_token_pool=object(),
+                token_to_kv_pool_allocator=allocator,
+                page_size=page_size,
+                enable_partial_prefix_reuse=True,
+            )
+        )
+
+        cached_indices = allocator.alloc(12)
+        self.assertIsNotNone(cached_indices)
+        for layer_id, (k_buffer, v_buffer) in enumerate(
+            zip(kv_cache.k_buffer, kv_cache.v_buffer, strict=True)
+        ):
+            values = torch.arange(12 * 2 * 16, dtype=torch.float16, device="cuda").view(
+                12, 2, 16
+            )
+            k_buffer[cached_indices] = values + layer_id * 1000
+            v_buffer[cached_indices] = values + layer_id * 2000 + 500
+
+        cache.insert(
+            InsertParams(
+                key=RadixKey(array("q", range(1, 13))),
+                value=cached_indices,
+            )
+        )
+        result = cache.match_prefix(
+            MatchPrefixParams(key=RadixKey(array("q", [*range(1, 11), 101, 102])))
+        )
+        req = _make_partial_prefix_req(result.device_indices)
+        self.assertTrue(cache.materialize_partial_prefix(req, result))
+        source_before = [
+            (k[cached_indices[8:12]].clone(), v[cached_indices[8:12]].clone())
+            for k, v in zip(kv_cache.k_buffer, kv_cache.v_buffer, strict=True)
+        ]
+
+        kv_cache.move_kv_cache(
+            req._partial_prefix_copy_state.destination_indices,
+            req._partial_prefix_copy_state.source_indices,
+        )
+        torch.cuda.synchronize()
+
+        for (k_buffer, v_buffer), (source_k, source_v) in zip(
+            zip(kv_cache.k_buffer, kv_cache.v_buffer, strict=True),
+            source_before,
+            strict=True,
+        ):
+            torch.testing.assert_close(
+                k_buffer[req._partial_prefix_copy_state.destination_indices],
+                source_k[:2],
+            )
+            torch.testing.assert_close(
+                v_buffer[req._partial_prefix_copy_state.destination_indices],
+                source_v[:2],
+            )
+            torch.testing.assert_close(k_buffer[cached_indices[8:12]], source_k)
+            torch.testing.assert_close(v_buffer[cached_indices[8:12]], source_v)
+
+        cache.release_partial_prefix_source(req)
+
+    def test_partial_prefix_source_lock_blocks_eviction_until_copy_release(self):
+        cache, _, kv_cache, _, _, result = self._build_partial_prefix_cache()
+        req = _make_partial_prefix_req(result.device_indices)
+        self.assertEqual(cache.evictable_size(), 12)
+        self.assertEqual(cache.protected_size(), 0)
+        self.assertTrue(cache.materialize_partial_prefix(req, result))
+        state = req._partial_prefix_copy_state
+        source_node = state.source_node
+        self.assertGreater(source_node.lock_ref, 0)
+        self.assertEqual(cache.total_size(), 12)
+        self.assertEqual(cache.evictable_size(), 0)
+        self.assertEqual(cache.protected_size(), 12)
+
+        evicted = cache.evict(EvictParams(num_tokens=cache.total_size()))
+        self.assertEqual(evicted.num_tokens_evicted, 0)
+        self.assertEqual(cache.total_size(), 12)
+
+        kv_cache.move_kv_cache(
+            state.destination_indices,
+            state.source_indices,
+        )
+        cache.release_partial_prefix_source(req)
+        self.assertEqual(source_node.lock_ref, 0)
+        self.assertEqual(cache.evictable_size(), 12)
+        self.assertEqual(cache.protected_size(), 0)
+        evicted = cache.evict(EvictParams(num_tokens=cache.total_size()))
+        self.assertEqual(evicted.num_tokens_evicted, 12)
+        self.assertEqual(cache.total_size(), 0)
+
+    def test_partial_prefix_allocation_failure_falls_back_without_lock_leak(self):
+        page_size = 4
+        kv_cache = _FakeKVCache(size=12, page_size=page_size)
+        allocator = PagedTokenToKVPoolAllocator(
+            size=12,
+            page_size=page_size,
+            dtype=torch.float16,
+            device="cpu",
+            kvcache=kv_cache,
+            need_sort=False,
+        )
+        cache = RadixCache.create_simulated(
+            mock_allocator=allocator,
+            page_size=page_size,
+            enable_partial_prefix_reuse=True,
+        )
+        cached_indices = allocator.alloc(12)
+        self.assertIsNotNone(cached_indices)
+        cache.insert(
+            InsertParams(
+                key=RadixKey(array("q", range(1, 13))),
+                value=cached_indices,
+            )
+        )
+        result = cache.match_prefix(
+            MatchPrefixParams(key=RadixKey(array("q", [*range(1, 11), 101, 102])))
+        )
+        req = _make_partial_prefix_req(result.device_indices)
+
+        self.assertEqual(allocator.available_size(), 0)
+        self.assertFalse(cache.materialize_partial_prefix(req, result))
+        self.assertEqual(len(req.prefix_indices), 8)
+        self.assertFalse(hasattr(req, "_partial_prefix_copy_state"))
+        self.assertEqual(cache.evictable_size(), 12)
+        self.assertEqual(cache.protected_size(), 0)
+
+    def test_partial_prefix_finish_inserts_private_page_once(self):
+        cache, allocator, kv_cache, _, query_tokens, result = (
+            self._build_partial_prefix_cache()
+        )
+        req = _make_partial_prefix_req(result.device_indices)
+        self.assertTrue(cache.materialize_partial_prefix(req, result))
+        state = req._partial_prefix_copy_state
+        dst_page = state.page_indices
+        kv_cache.move_kv_cache(
+            state.destination_indices,
+            state.source_indices,
+        )
+        continuation = dst_page[2:4]
+        kv_cache.k[continuation] = torch.tensor([[3001, 3002], [3003, 3004]])
+        kv_cache.v[continuation] = torch.tensor([[4001, 4002], [4003, 4004]])
+        cache.release_partial_prefix_source(req)
+
+        req_to_token = _ReqToTokenPool(width=16)
+        req_to_token.write((0, slice(0, 10)), req.prefix_indices)
+        req_to_token.write((0, slice(10, 12)), continuation)
+        cache.req_to_token_pool = req_to_token
+        cache.inc_lock_ref(result.last_device_node)
+        req.req_pool_idx = 0
+        req.last_node = result.last_device_node
+        req.origin_input_ids = query_tokens[:12]
+        req.output_ids = array("q")
+        req.extra_key = None
+        req.cache_salt = None
+        req.priority = 0
+
+        cache.cache_finished_req(req, kv_len_to_handle=12)
+        self.assertEqual(cache.total_size(), 16)
+        self.assertEqual(allocator.available_size() + cache.total_size(), 64)
+        new_match = cache.match_prefix(
+            MatchPrefixParams(key=RadixKey(query_tokens[:12]))
+        )
+        self.assertEqual(len(new_match.device_indices), 12)
+        torch.testing.assert_close(new_match.device_indices[8:12], dst_page)
+
+    def test_partial_prefix_flag_changes_extend_start_only_after_copy(self):
+        off_cache, _, _, _, query_tokens, off_result = self._build_partial_prefix_cache(
+            enabled=False
+        )
+        self.assertEqual(len(off_result.device_indices), 8)
+        self.assertIsNone(off_result.partial_prefix_match)
+        self.assertEqual(
+            list(query_tokens[len(off_result.device_indices) :])[:2], [9, 10]
+        )
+        self.assertEqual(off_cache.total_size(), 12)
+
+        on_cache, _, _, _, _, on_result = self._build_partial_prefix_cache(enabled=True)
+        req = _make_partial_prefix_req(on_result.device_indices)
+        on_cache.materialize_partial_prefix(req, on_result)
+        self.assertEqual(len(req.prefix_indices), 10)
+        self.assertEqual(list(query_tokens[len(req.prefix_indices) :])[:2], [101, 102])
+        on_cache.abort_partial_prefix(req)
+
+    def test_schedule_batch_flag_controls_exact_reuse_extend_start(self):
+        from sglang.srt.managers.schedule_batch import ScheduleBatch
+        from sglang.srt.utils.common import Range
+
+        class _StopBeforeAllocation(Exception):
+            pass
+
+        for enabled, expected_prefix_len, expected_input_ids in (
+            (False, 8, [9, 10, 101, 102, 103]),
+            (True, 10, [101, 102, 103]),
+        ):
+            with self.subTest(enabled=enabled):
+                cache, _, _, _, query_tokens, result = self._build_partial_prefix_cache(
+                    enabled=enabled
+                )
+                req = _make_partial_prefix_req(result.device_indices)
+                cache.materialize_partial_prefix(req, result)
+                req.origin_input_ids = query_tokens
+                req.full_untruncated_fill_ids = query_tokens
+                req.extend_range = Range(len(req.prefix_indices), len(query_tokens))
+                req.logprob_start_len = -1
+                req.get_fill_ids = lambda query_tokens=query_tokens: query_tokens
+                batch = ScheduleBatch(reqs=[req], tree_cache=cache, device="cpu")
+                captured = {}
+                query_len = len(query_tokens)
+
+                def capture_input_ids(input_ids, _pin, captured=captured):
+                    captured["input_ids"] = [list(ids) for ids in input_ids]
+                    return torch.tensor(
+                        [token for ids in input_ids for token in ids],
+                        dtype=torch.int64,
+                    )
+
+                def stop_at_allocation(
+                    batch_to_allocate,
+                    expected_prefix_len=expected_prefix_len,
+                    query_len=query_len,
+                ):
+                    self.assertEqual(
+                        batch_to_allocate.prefix_lens, [expected_prefix_len]
+                    )
+                    self.assertEqual(
+                        batch_to_allocate.extend_lens,
+                        [query_len - expected_prefix_len],
+                    )
+                    self.assertEqual(
+                        batch_to_allocate.extend_num_tokens,
+                        query_len - expected_prefix_len,
+                    )
+                    raise _StopBeforeAllocation
+
+                with (
+                    unittest.mock.patch(
+                        "sglang.srt.managers.schedule_batch.flatten_arrays_to_pinned_cpu",
+                        side_effect=capture_input_ids,
+                    ),
+                    unittest.mock.patch(
+                        "sglang.srt.managers.schedule_batch.alloc_for_extend",
+                        side_effect=stop_at_allocation,
+                    ),
+                    self.assertRaises(_StopBeforeAllocation),
+                ):
+                    batch.prepare_for_extend()
+
+                self.assertEqual(captured["input_ids"], [expected_input_ids])
+                if enabled:
+                    cache.release_partial_prefix_source(req)
+
+    def test_page_size_one_needs_no_partial_copy(self):
+        cache = RadixCache.create_simulated(
+            page_size=1, enable_partial_prefix_reuse=True
+        )
+        cache.insert(
+            InsertParams(
+                key=RadixKey(array("q", [1, 2, 3, 4])),
+                value=torch.tensor([11, 12, 13, 14]),
+            )
+        )
+        result = cache.match_prefix(
+            MatchPrefixParams(key=RadixKey(array("q", [1, 2, 3, 9])))
+        )
+        self.assertEqual(len(result.device_indices), 3)
+        self.assertIsNone(result.partial_prefix_match)
+        req = _make_partial_prefix_req(result.device_indices)
+        self.assertFalse(cache.materialize_partial_prefix(req, result))
 
     def test_advanced_prefix_match_with_node_splits(self):
         """Advanced prefix matching: splits inside nodes and across pages."""


### PR DESCRIPTION
## Motivation

SGLang's paged RadixCache keeps radix-tree ownership page aligned. Before this change, when the logical longest common prefix ended inside a page, only the page-aligned portion was reused and up to `page_size - 1` already-computed tokens were sent through model forward again.

This issue is negligible at `page_size=1`, but becomes increasingly relevant with larger physical page sizes such as 16, 32, and 64. With larger practical page sizes such as 16, 32, and 64, treating the physical page boundary as the only logical reuse boundary can discard a meaningful amount of already-computed work. At those sizes, treating the physical page boundary as the only logical reuse boundary can discard a meaningful amount of already-computed work. If the divergence position is uniformly distributed within a page, the average missed reuse is `(page_size - 1) / 2`: 7.5, 15.5, and 31.5 tokens for page sizes 16, 32, and 64 respectively.

The page boundary should therefore remain the radix tree's physical ownership boundary, but it is no longer always the best logical prefix-reuse boundary.

This PR experimentally reuses those partial-page KV entries without changing the page-aligned radix-tree structure or ownership model. The matched KV entries are copied into a new request-private physical page, allowing the allocator to continue writing into the remainder of that page.

The feature is disabled by default and initially targets the ordinary CUDA FULL-attention Python RadixCache path.

## Modifications

1. Optimize `RadixKey.match()` when the first page is already known to match.

   - Add the `first_page_matched` hint.
   - Start the galloping search at `page_size` with a `page_size` step instead of rechecking tokens from zero.
   - Use the hint only at call sites where radix child selection has already proved that the first page matches.
   - Preserve the existing page-aligned return behavior.

2. Add experimental partial-page prefix reuse behind `--enable-partial-prefix-reuse` (default: disabled).

   - Add an opt-in `return_exact=True` mode to `RadixKey.match()` while keeping its default return value page aligned.
   - Keep every legacy tree/split caller on the default page-aligned result; only the experimental partial-reuse path requests the exact LCP.
   - Preserve both the exact token-level LCP and its page-aligned boundary.
   - Keep tree splitting, ownership, insertion, eviction, and accounting page aligned.
   - When enabled, discover partial matches either within a legacy-reachable child or, after a child-key miss, by scanning direct children.
   - Allocate a new request-private physical page and copy the matched KV slots using the existing all-layer `move_kv_cache()` implementation.
   - Extend `req.prefix_indices` to the exact match length so the matched tokens are removed from EXTEND/model-forward work.
   - Continue normal paged allocation in the unused portion of the private destination page.
   - Protect the source radix node with `lock_ref` until the GPU copy and its dependent forward work are safely ordered before source-page reuse.
   - Clean up private pages and locks on allocation failure, request rejection, unfinished caching, and normal request completion.

3. Restrict the initial implementation to supported configurations.

   - CUDA
   - ordinary Python RadixCache
   - FULL attention
   - `PagedTokenToKVPoolAllocator`
   - unquantized NHD `MHATokenToKVPool`
   - pipeline parallel size 1
   - non-EAGLE requests

Unsupported configurations fail with an explicit error when the experimental feature is enabled.

4. Add focused unit tests and a reproducible serving benchmark for page sizes 16, 32, and 64.

## Accuracy Tests

Relevant cache unit suite:

```bash
pytest -q \
  test/registered/unit/mem_cache/test_radix_cache_unit.py \
  test/registered/unit/mem_cache/test_hiradix_cache_unit.py \
  test/registered/unit/mem_cache/test_mamba_unittest.py \
  test/registered/unit/mem_cache/test_swa_unittest.py
```

Result:

```text
78 passed
87 subtests passed
```

The tests cover exact LCP calculation, page-aligned tree splitting and accounting, source-page lifetime, private-page allocation and KV copying, continuation within the copied page, `req_to_token` mappings, scheduler EXTEND lengths, allocation failure, eviction, request completion, and `page_size=1`.

End-to-end deterministic generation parity was also tested with Qwen3-32B BF16, TP=2, generating 32 output tokens:

| Page size | Partial tokens | Baseline cached | Reuse cached | Exact output parity |
|---:|---:|---:|---:|---:|
| 16 | 8 | 1024 | 1032 | 5/5 |
| 32 | 16 | 1024 | 1040 | 5/5 |
| 64 | 32 | 1024 | 1056 | 5/5 |

Overall: 15/15 generated outputs were exactly equal, with no request errors.

A separate upstream-versus-current, feature-disabled A/B/B/A comparison produced 160/160 identical generated outputs.

## Speed Tests and Profiling

All serving measurements used 2 x NVIDIA A100 80 GB, TP=2, ordinary CUDA FULL-attention Python RadixCache, and unquantized NHD paged KV. Baseline and reuse runs used the same checkout; only `--enable-partial-prefix-reuse` changed. Cache construction and exact-shape warmups were excluded.

### TL;DR

- On SGLang's `generated-shared-prefix` workload, the representative Qwen3-32B page 64 / C=16 / Uniform result improves throughput by 2.08%, **mean TTFT by 8.71%, median TTFT by 15.38%**, and mean E2E by 2.04%.  Controlled experiments show larger gains as the cost and amount of avoided model work increase.
- Across the complete official-workload matrix, throughput improves by 0.24%-2.08% and **mean TTFT by 0.51%-10.01%**; P90/P99 remain mixed.
- Controlled experiments on Qwen3-8B and Qwen3-32B show substantial gains when partial-page recomputation constitutes a meaningful fraction of EXTEND work. At half-page reuse on Qwen3-32B, throughput improves by 12.0%, 26.5%, and 34.5% for page sizes 16, 32, and 64 respectively at C=16. These output-length-1 experiments isolate the cost/benefit of partial-page reuse and should not be interpreted as production-traffic gains.
- The controlled results support the hypothesis that the optimization becomes more valuable as the amount and cost of avoided model work increase: larger page sizes provide more reusable partial tokens, larger models save more absolute TTFT, and higher concurrency compounds the removed EXTEND work. For Qwen3-32B at half-page R, throughput gain grows from 2.3%/4.7%/10.2% at C=1 to 12.0%/26.5%/34.5% at C=16 for page sizes 16/32/64.
- With the feature disabled, upstream-master A/B/B/A testing showed no measurable performance regression on code changs within observed run-to-run variance.

### 1. SGLang `generated-shared-prefix` workload

This uses SGLang's existing `sglang.benchmark.serving` path and `generated-shared-prefix` dataset without injecting partial matches:

- Qwen3-32B BF16, TP=2
- 64 groups x 16 prompts = 1024 requests
- requested system/question/output lengths: 2048 / 128 / 256
- uniform and Zipf (`alpha=1.2`) group popularity
- official warmup and cache flush behavior

Each metric cell reports `reuse disabled -> reuse enabled (relative improvement)`. Throughput is in requests/second and latency is in milliseconds. Positive percentages favor partial-page reuse; negative percentages are regressions.

| Page | C | Distribution | Throughput, req/s | Mean TTFT, ms | Median TTFT, ms | P90 TTFT, ms | P99 TTFT, ms | Mean E2E, ms |
|---:|---:|---|---:|---:|---:|---:|---:|---:|
| 16 | 16 | Uniform | 1.3618 -> 1.3651 (+0.24%) | 2464.98 -> 2452.30 (+0.51%) | 1521.98 -> 1493.90 (+1.85%) | 6524.62 -> 6515.02 (+0.15%) | 14927.03 -> 15002.09 (-0.50%) | 11742.33 -> 11714.58 (+0.24%) |
| 16 | 16 | Zipf | 1.3632 -> 1.3673 (+0.30%) | 2593.92 -> 2564.83 (+1.12%) | 1655.91 -> 1891.26 (-14.21%) | 5010.27 -> 4850.01 (+3.20%) | 12339.15 -> 12470.60 (-1.07%) | 11730.73 -> 11695.36 (+0.30%) |
| 32 | 16 | Uniform | 1.3444 -> 1.3650 (+1.54%) | 2605.67 -> 2452.81 (+5.87%) | 1595.34 -> 1497.16 (+6.15%) | 6764.00 -> 6501.80 (+3.88%) | 16116.10 -> 15968.84 (+0.91%) | 11894.96 -> 11714.52 (+1.52%) |
| 32 | 16 | Zipf | 1.3565 -> 1.3712 (+1.08%) | 2638.40 -> 2545.48 (+3.52%) | 1860.77 -> 1907.94 (-2.53%) | 4885.87 -> 4904.34 (-0.38%) | 12512.70 -> 12264.54 (+1.98%) | 11788.46 -> 11662.04 (+1.07%) |
| 64 | 8 | Uniform | 0.8767 -> 0.8878 (+1.27%) | 1411.44 -> 1270.16 (+10.01%) | 938.25 -> 761.34 (+18.86%) | 3327.26 -> 3306.45 (+0.63%) | 9697.80 -> 9764.46 (-0.69%) | 9122.19 -> 9007.33 (+1.26%) |
| 64 | 16 | Uniform | 1.3410 -> 1.3689 (+2.08%) | 2655.54 -> 2424.26 (+8.71%) | 1792.84 -> 1517.10 (+15.38%) | 6760.16 -> 6676.21 (+1.24%) | 14123.07 -> 14652.62 (-3.75%) | 11925.26 -> 11681.62 (+2.04%) |
| 64 | 8 | Zipf | 0.8784 -> 0.8893 (+1.24%) | 1399.78 -> 1260.38 (+9.96%) | 949.34 -> 768.61 (+19.04%) | 2541.69 -> 2566.58 (-0.98%) | 6551.88 -> 6573.17 (-0.33%) | 9103.76 -> 8992.50 (+1.22%) |
| 64 | 16 | Zipf | 1.3468 -> 1.3598 (+0.97%) | 2726.34 -> 2606.81 (+4.38%) | 2140.50 -> 1956.04 (+8.62%) | 4958.26 -> 5008.23 (-1.01%) | 12379.58 -> 12962.30 (-4.71%) | 11873.79 -> 11760.36 (+0.96%) |

The official workload confirms positive mean TTFT, mean E2E, and throughput results in every measured configuration. On the uniform C=16 workload, disabled mean TTFT increases from 2464.98 ms at page 16 to 2655.54 ms at page 64 because coarse page alignment loses more cached tokens. With partial-page reuse enabled, mean TTFT instead changes from 2452.30 ms at page 16 to 2424.26 ms at page 64, recovering that degradation. This shows that larger pages create more recoverable partial-prefix work; it does not imply that increasing page size universally improves absolute performance. The run generates approximately 2.34M input tokens and 262K output tokens, so the long decode phase dilutes prefill savings in end-to-end throughput.

The page-32 uniform result was repeated with launch order reversed. Each metric cell again reports `reuse disabled -> reuse enabled (relative improvement)` regardless of launch order.

| Launch order | Throughput, req/s | Mean TTFT, ms | Median TTFT, ms | P90 TTFT, ms | P99 TTFT, ms | Mean E2E, ms |
|---|---:|---:|---:|---:|---:|---:|
| Disabled -> enabled | 1.3444 -> 1.3650 (+1.54%) | 2605.67 -> 2452.81 (+5.87%) | 1595.34 -> 1497.16 (+6.15%) | 6764.00 -> 6501.80 (+3.88%) | 16116.10 -> 15968.84 (+0.91%) | 11894.96 -> 11714.52 (+1.52%) |
| Enabled -> disabled | 1.3407 -> 1.3585 (+1.33%) | 2627.53 -> 2488.85 (+5.28%) | 1621.18 -> 1511.87 (+6.74%) | 6610.19 -> 6758.90 (-2.25%) | 16192.44 -> 16180.94 (+0.07%) | 11927.81 -> 11771.20 (+1.31%) |

Mean improvements survive order reversal at similar magnitudes. P90/P99 move in both directions, so this PR does not claim a stable tail-latency improvement.

### 2. Controlled hypothesis test: model size, page size, R, and concurrency

The controlled workload has a 4096-token page-aligned cached prefix, followed by exactly `R` matching tokens inside the next page and then a divergent suffix. `suffix_len = page_size + 1`, so disabled and enabled runs allocate the same number of private physical pages. Concurrency is 16 and output length is 1.

Positive TTFT reduction and throughput gain favor partial-page reuse.

At half-page R on Qwen3-32B, throughput gain increases with concurrency:

| Page / R | C=1 | C=8 | C=16 |
|---:|---:|---:|---:|
| 16 / 8 | +2.3% | +11.7% | +12.0% |
| 32 / 16 | +4.7% | +20.4% | +26.5% |
| 64 / 32 | +10.2% | +30.9% | +34.5% |

#### Llama-3.2-1B-Instruct

**Only for experiement. partial-page perfix reuse in small model cannot provide improvment** 
| Page | R | EXTEND disabled -> enabled | Baseline TTFT | Reuse TTFT | TTFT reduction | Baseline throughput | Reuse throughput | Throughput gain |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 16 | 1 | 18 -> 17 | 106.80 ms | 147.81 ms | -38.4% | 139.97 req/s | 101.35 req/s | -27.6% |
| 16 | 4 | 21 -> 17 | 76.64 ms | 69.59 ms | +9.2% | 189.62 req/s | 206.93 req/s | +9.1% |
| 16 | 8 | 25 -> 17 | 83.15 ms | 174.62 ms | -110.0% | 172.15 req/s | 86.45 req/s | -49.8% |
| 16 | 12 | 29 -> 17 | 64.78 ms | 96.36 ms | -48.8% | 222.19 req/s | 150.56 req/s | -32.2% |
| 16 | 15 | 32 -> 17 | 82.32 ms | 80.32 ms | +2.4% | 163.84 req/s | 171.78 req/s | +4.8% |
| 32 | 1 | 34 -> 33 | 201.60 ms | 197.20 ms | +2.2% | 71.10 req/s | 75.11 req/s | +5.7% |
| 32 | 8 | 41 -> 33 | 70.34 ms | 79.35 ms | -12.8% | 193.45 req/s | 166.16 req/s | -14.1% |
| 32 | 16 | 49 -> 33 | 157.01 ms | 74.79 ms | +52.4% | 84.37 req/s | 179.22 req/s | +112.4% |
| 32 | 24 | 57 -> 33 | 76.39 ms | 88.95 ms | -16.5% | 177.75 req/s | 156.21 req/s | -12.1% |
| 32 | 31 | 64 -> 33 | 76.80 ms | 90.35 ms | -17.6% | 174.58 req/s | 151.10 req/s | -13.4% |
| 64 | 1 | 66 -> 65 | 281.33 ms | 84.74 ms | +69.9% | 54.06 req/s | 160.84 req/s | +197.5% |
| 64 | 8 | 73 -> 65 | 94.69 ms | 94.04 ms | +0.7% | 148.63 req/s | 148.51 req/s | -0.1% |
| 64 | 16 | 81 -> 65 | 95.76 ms | 91.46 ms | +4.5% | 144.71 req/s | 149.53 req/s | +3.3% |
| 64 | 32 | 97 -> 65 | 105.72 ms | 88.24 ms | +16.5% | 132.12 req/s | 157.60 req/s | +19.3% |
| 64 | 48 | 113 -> 65 | 109.16 ms | 96.71 ms | +11.4% | 128.25 req/s | 144.05 req/s | +12.3% |
| 64 | 63 | 128 -> 65 | 121.21 ms | 83.80 ms | +30.9% | 115.67 req/s | 164.40 req/s | +42.1% |


The 1B forward path is too short relative to TP=2, launch, and compilation overhead. Its results vary sharply in both directions, so it is retained as a negative/noise control rather than performance evidence.

#### Qwen3-8B

| Page | R | EXTEND disabled -> enabled | Baseline TTFT | Reuse TTFT | TTFT reduction | Baseline throughput | Reuse throughput | Throughput gain |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 16 | 1 | 18 -> 17 | 154.51 ms | 159.53 ms | -3.2% | 94.11 req/s | 91.20 req/s | -3.1% |
| 16 | 4 | 21 -> 17 | 161.93 ms | 154.89 ms | +4.4% | 88.97 req/s | 91.67 req/s | +3.0% |
| 16 | 8 | 25 -> 17 | 176.17 ms | 149.74 ms | +15.0% | 81.56 req/s | 96.49 req/s | +18.3% |
| 16 | 12 | 29 -> 17 | 172.38 ms | 175.38 ms | -1.7% | 82.77 req/s | 79.97 req/s | -3.4% |
| 16 | 15 | 32 -> 17 | 181.53 ms | 163.08 ms | +10.2% | 79.31 req/s | 88.30 req/s | +11.3% |
| 32 | 1 | 34 -> 33 | 189.94 ms | 205.78 ms | -8.3% | 76.16 req/s | 70.88 req/s | -6.9% |
| 32 | 8 | 41 -> 33 | 205.52 ms | 215.46 ms | -4.8% | 70.12 req/s | 67.18 req/s | -4.2% |
| 32 | 16 | 49 -> 33 | 235.79 ms | 176.45 ms | +25.2% | 61.35 req/s | 80.97 req/s | +32.0% |
| 32 | 24 | 57 -> 33 | 270.96 ms | 201.01 ms | +25.8% | 52.70 req/s | 70.27 req/s | +33.4% |
| 32 | 31 | 64 -> 33 | 290.68 ms | 177.90 ms | +38.8% | 50.74 req/s | 80.17 req/s | +58.0% |
| 64 | 1 | 66 -> 65 | 301.73 ms | 295.95 ms | +1.9% | 48.49 req/s | 50.43 req/s | +4.0% |
| 64 | 8 | 73 -> 65 | 319.48 ms | 278.14 ms | +12.9% | 45.53 req/s | 51.47 req/s | +13.0% |
| 64 | 16 | 81 -> 65 | 373.49 ms | 287.44 ms | +23.0% | 39.82 req/s | 50.73 req/s | +27.4% |
| 64 | 32 | 97 -> 65 | 416.50 ms | 290.38 ms | +30.3% | 35.64 req/s | 50.41 req/s | +41.5% |
| 64 | 48 | 113 -> 65 | 532.14 ms | 295.05 ms | +44.6% | 28.40 req/s | 49.25 req/s | +73.5% |
| 64 | 63 | 128 -> 65 | 548.93 ms | 317.59 ms | +42.1% | 27.92 req/s | 46.54 req/s | +66.7% |

Uniform-integer-R estimate:

| Page | R distribution | Estimated TTFT saved | Estimated TTFT reduction | Estimated throughput gain |
|---:|---|---:|---:|---:|
| 16 | Uniform over 1...15 | +9.8 ms | +5.5% | +5.9% |
| 32 | Uniform over 1...31 | +42.3 ms | +15.5% | +21.9% |
| 64 | Uniform over 1...63 | +141.4 ms | +30.1% | +44.1% |

For Qwen3-8B, both expected TTFT reduction and throughput gain grow strongly with page size because a uniformly random partial match contains more reusable tokens on larger pages.

#### Qwen3-32B

| Page | R | EXTEND disabled -> enabled | Baseline TTFT | Reuse TTFT | TTFT reduction | Baseline throughput | Reuse throughput | Throughput gain |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 16 | 1 | 18 -> 17 | 354.24 ms | 359.17 ms | -1.4% | 41.54 req/s | 41.99 req/s | +1.1% |
| 16 | 4 | 21 -> 17 | 398.83 ms | 355.70 ms | +10.8% | 37.52 req/s | 41.89 req/s | +11.7% |
| 16 | 8 | 25 -> 17 | 407.41 ms | 360.86 ms | +11.4% | 37.31 req/s | 41.79 req/s | +12.0% |
| 16 | 12 | 29 -> 17 | 440.62 ms | 356.62 ms | +19.1% | 34.14 req/s | 41.64 req/s | +22.0% |
| 16 | 15 | 32 -> 17 | 472.39 ms | 355.24 ms | +24.8% | 32.21 req/s | 41.48 req/s | +28.8% |
| 32 | 1 | 34 -> 33 | 494.94 ms | 501.36 ms | -1.3% | 30.75 req/s | 30.32 req/s | -1.4% |
| 32 | 8 | 41 -> 33 | 539.85 ms | 471.75 ms | +12.6% | 27.85 req/s | 31.95 req/s | +14.7% |
| 32 | 16 | 49 -> 33 | 637.31 ms | 500.44 ms | +21.5% | 24.00 req/s | 30.36 req/s | +26.5% |
| 32 | 24 | 57 -> 33 | 839.65 ms | 489.43 ms | +41.7% | 17.97 req/s | 30.29 req/s | +68.6% |
| 32 | 31 | 64 -> 33 | 829.43 ms | 473.59 ms | +42.9% | 18.67 req/s | 31.14 req/s | +66.8% |
| 64 | 1 | 66 -> 65 | 952.92 ms | 946.15 ms | +0.7% | 16.27 req/s | 16.42 req/s | +0.9% |
| 64 | 8 | 73 -> 65 | 911.87 ms | 815.49 ms | +10.6% | 16.83 req/s | 18.72 req/s | +11.2% |
| 64 | 16 | 81 -> 65 | 966.82 ms | 855.44 ms | +11.5% | 15.85 req/s | 17.83 req/s | +12.5% |
| 64 | 32 | 97 -> 65 | 1082.83 ms | 799.67 ms | +26.1% | 14.16 req/s | 19.05 req/s | +34.5% |
| 64 | 48 | 113 -> 65 | 1361.36 ms | 820.40 ms | +39.7% | 11.31 req/s | 18.63 req/s | +64.7% |
| 64 | 63 | 128 -> 65 | 1421.35 ms | 830.67 ms | +41.6% | 10.97 req/s | 18.61 req/s | +69.7% |

Uniform-integer-R estimate:

| Page | R distribution | Estimated TTFT saved | Estimated TTFT reduction | Estimated throughput gain |
|---:|---|---:|---:|---:|
| 16 | Uniform over 1...15 | +57.0 ms | +13.1% | +15.0% |
| 32 | Uniform over 1...31 | +181.6 ms | +24.1% | +35.4% |
| 64 | Uniform over 1...63 | +313.1 ms | +25.2% | +37.3% |

For Qwen3-32B, the estimated absolute TTFT saving grows from 57 ms at page 16 to 313 ms at page 64. Comparing Qwen3-8B with Qwen3-32B also shows that the larger model saves substantially more absolute prefill time at every page size. Relative percentages are not strictly monotonic by parameter count because batching and kernel shapes differ, so the data supports the model-cost hypothesis in absolute saved work rather than a universal percentage ordering.

The copy is real model-work elimination, not metadata only. For Qwen3-32B, page 32 / R=16, the trace changes from 49 EXTEND tokens to one approximately 8.5 microsecond `copy_all_layer_kv_cache_tiled` operation plus 33 EXTEND tokens.

The independent first-page matcher optimization is a CPU micro-optimization:

| Measurement | Relative improvement | Absolute saving |
|---|---:|---:|
| Direct `RadixKey.match()` | 21.54% mean / 21.26% median | 1.2-2.5 us |
| Complete RadixCache lookup | 6.30% median | 2.2-6.4 us |

No standalone serving-latency improvement is claimed for the matcher fast path.

### 3. Feature-disabled comparison against upstream master

Latest upstream and the current branch with partial-page reuse disabled were compared on Qwen3-32B using A/B/B/A launch order. Each run used page 32, R=16, C=8, a 1024-token aligned hot prefix, suffix length 33, output length 1, and 40 measured requests.

| Metric | Upstream master | Current branch, reuse disabled | Difference |
|---|---:|---:|---:|
| Throughput | 24.254 req/s | 24.576 req/s | +1.33% |
| Mean TTFT | 310.959 ms | 306.040 ms | -1.58% |
| Cached prefix tokens | 1024 | 1024 | identical |
| EXTEND/model-forward tokens | 49 | 49 | identical |
| Partial-page copies | 0 | 0 | identical |
| Generated-output parity | 160/160 | 160/160 | exact match |

The small measured difference favors the current branch but is treated as run-to-run variation, not a speedup claim. The important result is that disabling the experimental feature preserves cached-token counts, model-forward work, generated outputs, and shows no measured performance regression.

## Known Limitations and Follow-ups

1. **High-fanout fallback cost.** Although scanning direct children should become more expensive as fanout grows, I plan to first measure the actual regression and identify the fanout range where it becomes material. I will then evaluate whether the observed cost justifies additional lookup structure, balancing lower worst-case CPU overhead against extra indexing and maintenance complexity.
2. **Write-side partial-tail retention.** Finished requests still cache only page-aligned prefixes and free the final incomplete page. A follow-up will explore retaining this tail as an immutable, separately accounted partial source, while keeping radix-tree ownership page aligned. This would make partial-page reuse available even when the reusable suffix was produced by a request that ended inside a page, potentially increasing the hit rate and benefit of the read-side mechanism introduced here.
3. **Unified Cache support.** The initial implementation targets the ordinary Python RadixCache path. After the read/write semantics are stabilized, I plan to port the design to Unified Cache, starting with device-resident FULL-attention KV before extending it to HiCache or hybrid components.


## Checklist

- [x] Format the code according to [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). A short user-facing description of `--enable-partial-prefix-reuse`, its default-disabled experimental status, and its supported RadixCache path is still pending.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32335912496](https://github.com/sgl-project/sglang/actions/runs/32335912496)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32335912507](https://github.com/sgl-project/sglang/actions/runs/32335912507)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32335912631](https://github.com/sgl-project/sglang/actions/runs/32335912631)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->