### PR TITLE
Improving Agentic RL Rollout Inference Efficiency with Uniboost Scheduler Policy

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -533,6 +533,22 @@ class Envs:
     # Internal/testing only - users should not need to change this.
     SGLANG_PREFILL_TILE_BUDGET_MODE = EnvStr("compact")
     SGLANG_PREFILL_DELAYER_MAX_PREFILL_BS_WINDOW_SIZE = EnvInt(16)
+    # UniBoost tail-aware prefill admission boosting (--schedule-policy uniboost).
+    # Boost decay rate gamma (1/s); <= 0 falls back to fcfs.
+    SGLANG_UNIBOOST_GAMMA = EnvFloat(10.0)
+    # Estimated prefill cost per uncached prompt token, in microseconds.
+    SGLANG_UNIBOOST_ALPHA_US_PER_TOKEN = EnvFloat(64.0)
+    # Allow uniboost with tp_size > 1 (experimental; see schedule_policy.py).
+    SGLANG_UNIBOOST_ALLOW_TP = EnvBool(False)
+    # gamma-Ada: adapt gamma online to the observed latency-tail shape.
+    SGLANG_UNIBOOST_GAMMA_ADA = EnvBool(False)
+    SGLANG_UNIBOOST_GAMMA_MIN = EnvFloat(1.0)
+    SGLANG_UNIBOOST_GAMMA_MAX = EnvFloat(200.0)
+    SGLANG_UNIBOOST_GAMMA_ADA_INTERVAL_S = EnvFloat(5.0)
+    SGLANG_UNIBOOST_GAMMA_ADA_WINDOW = EnvInt(2000)
+    SGLANG_UNIBOOST_GAMMA_ADA_MIN_SAMPLES = EnvInt(200)
+    SGLANG_UNIBOOST_GAMMA_ADA_BETA = EnvFloat(0.3)
+    SGLANG_UNIBOOST_TAIL_SENSITIVITY = EnvFloat(4.0)
 
     # ===================================================================
     # Scheduler polling, timeouts, and output

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -538,8 +538,16 @@ class Envs:
     SGLANG_UNIBOOST_GAMMA = EnvFloat(10.0)
     # Estimated prefill cost per uncached prompt token, in microseconds.
     SGLANG_UNIBOOST_ALPHA_US_PER_TOKEN = EnvFloat(64.0)
-    # Allow uniboost with tp_size > 1 (experimental; see schedule_policy.py).
+    # Deprecated no-op: rank-invariant uniboost is now the default for
+    # tp_size > 1 (see schedule_policy.py). Kept so existing deployments that
+    # set it keep working; setting it only logs a deprecation notice.
     SGLANG_UNIBOOST_ALLOW_TP = EnvBool(False)
+    # Escape hatch: force the legacy fcfs fallback for tp_size > 1 instead of
+    # the rank-invariant uniboost mode.
+    SGLANG_UNIBOOST_FORCE_FCFS_TP = EnvBool(False)
+    # Rank-invariant mode (tp_size > 1): pseudo-seconds per arrival sequence
+    # step, so the arrival term trades sanely against the boost b_gamma.
+    SGLANG_UNIBOOST_TP_ARRIVAL_STEP_S = EnvFloat(0.01)
     # gamma-Ada: adapt gamma online to the observed latency-tail shape.
     SGLANG_UNIBOOST_GAMMA_ADA = EnvBool(False)
     SGLANG_UNIBOOST_GAMMA_MIN = EnvFloat(1.0)
@@ -549,6 +557,10 @@ class Envs:
     SGLANG_UNIBOOST_GAMMA_ADA_MIN_SAMPLES = EnvInt(200)
     SGLANG_UNIBOOST_GAMMA_ADA_BETA = EnvFloat(0.3)
     SGLANG_UNIBOOST_TAIL_SENSITIVITY = EnvFloat(4.0)
+    # Rank-invariant mode (tp_size > 1): gamma-Ada refits synchronously every
+    # K recorded completions (a deterministic completion-count trigger)
+    # instead of on the wall-clock daemon thread.
+    SGLANG_UNIBOOST_GAMMA_ADA_REFIT_EVERY_K = EnvInt(256)
     # Frontier-K cheap matching: per scheduling pass, re-run radix prefix
     # matching only for the top-K sorted candidates (the admission frontier);
     # deeper entries keep their last-known match. <=0 = full-queue matching.

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -549,6 +549,10 @@ class Envs:
     SGLANG_UNIBOOST_GAMMA_ADA_MIN_SAMPLES = EnvInt(200)
     SGLANG_UNIBOOST_GAMMA_ADA_BETA = EnvFloat(0.3)
     SGLANG_UNIBOOST_TAIL_SENSITIVITY = EnvFloat(4.0)
+    # Frontier-K cheap matching: per scheduling pass, re-run radix prefix
+    # matching only for the top-K sorted candidates (the admission frontier);
+    # deeper entries keep their last-known match. <=0 = full-queue matching.
+    SGLANG_UNIBOOST_MATCH_TOPK = EnvInt(64)
 
     # ===================================================================
     # Scheduler polling, timeouts, and output

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1003,6 +1003,9 @@ class Req(ReqDllmMixin):
         # time and used to estimate uncached tokens / sort by longest prefix for
         # load reporting.
         self.num_matched_prefix_tokens = 0
+        # Whether the UniBoost gamma-Ada controller already recorded this
+        # request's end-to-end latency (set in uniboost_record_finished).
+        self.uniboost_latency_recorded = False
         # Tokens loaded from storage backend (L3) during prefetch for this request
         self.storage_hit_length = 0
         # The node to lock until for swa radix tree lock ref

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1006,6 +1006,12 @@ class Req(ReqDllmMixin):
         # Whether the UniBoost gamma-Ada controller already recorded this
         # request's end-to-end latency (set in uniboost_record_finished).
         self.uniboost_latency_recorded = False
+        # UniBoost rank-invariant mode (tp_size > 1): arrival sequence number
+        # and forward-step count at first scheduling pass; assigned by
+        # SchedulePolicy._uniboost_assign_arrival_seq, identical on every TP
+        # rank because the broadcast request stream order is identical.
+        self.uniboost_arrival_seq: Optional[int] = None
+        self.uniboost_enqueue_step: Optional[int] = None
         # Tokens loaded from storage backend (L3) during prefetch for this request
         self.storage_hit_length = 0
         # The node to lock until for swa radix tree lock ref

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -139,6 +139,13 @@ def estimate_prefill_extend_tile_metrics(
     }
 
 
+# Quantization step for the UniBoost priority Phi in the rank-invariant
+# (tp_size > 1) mode: Phi is floored to this grid and ties are broken by the
+# rank-invariant arrival sequence number, so residual float noise can never
+# flip a pair of requests on one TP rank but not another.
+UNIBOOST_PHI_QUANTUM_S = 1e-4
+
+
 class GammaAdaController:
     """Online estimator for the UniBoost boost parameter ``gamma`` (gamma-Ada).
 
@@ -175,6 +182,18 @@ class GammaAdaController:
       percentile math. ``self.gamma = ...`` in the refit thread is likewise a
       single attribute store, so readers see either the old or the new float,
       never a torn value.
+
+    Deterministic step-clocked mode (rank-invariant UniBoost, tp_size > 1):
+
+    * instead of ``start()``, the scheduler calls ``record_completion()`` with
+      latencies measured in *scheduler forward-step counts* (integers,
+      identical on every TP rank) and a refit runs synchronously every
+      ``refit_every_k`` completions -- a completion-count trigger instead of
+      the wall-clock daemon, so every rank refits at the same point in the
+      request stream on the same samples. ``r = t99/t95`` is scale-free, so
+      steps work as well as seconds for the tail-shape proxy, and fixed-order
+      float arithmetic over identical inputs makes the resulting gamma
+      trajectory bit-identical across ranks.
     """
 
     __slots__ = (
@@ -185,8 +204,10 @@ class GammaAdaController:
         "tail_sensitivity",
         "interval_s",
         "min_samples",
+        "refit_every_k",
         "refit_count",
         "_samples",
+        "_completions_since_refit",
         "_last_update_t",
         "_thread",
         "_stop_event",
@@ -203,6 +224,7 @@ class GammaAdaController:
         interval_s: float = 5.0,
         window: int = 2000,
         min_samples: int = 200,
+        refit_every_k: int = 0,
     ) -> None:
         # gamma_min must stay strictly positive: b_gamma divides by gamma.
         self.gamma_min = max(float(gamma_min), 1e-6)
@@ -212,7 +234,9 @@ class GammaAdaController:
         self.tail_sensitivity = max(float(tail_sensitivity), 0.0)
         self.interval_s = max(float(interval_s), 0.0)
         self.min_samples = max(int(min_samples), 1)
+        self.refit_every_k = max(int(refit_every_k), 0)
         self._samples = deque(maxlen=max(int(window), self.min_samples))
+        self._completions_since_refit = 0
         self._last_update_t = 0.0
         self.refit_count = 0
         self._thread: Optional[threading.Thread] = None
@@ -226,6 +250,28 @@ class GammaAdaController:
         """
         if latency_s > 0.0:
             self._samples.append(float(latency_s))
+
+    def record_completion(self, latency: float) -> Optional[float]:
+        """Deterministic step-clocked path (rank-invariant mode, tp_size > 1).
+
+        Records one completion latency (measured in scheduler forward-step
+        counts, though any rank-invariant unit works: ``r = t99/t95`` is
+        scale-free) and refits synchronously every ``refit_every_k``
+        completions. No daemon thread and no wall clock anywhere, so given the
+        identical completion stream every TP rank refits at the same points on
+        the same samples and computes bit-identical gammas. Returns the new
+        gamma when a refit ran, else ``None``.
+        """
+        self.record(latency)
+        self._completions_since_refit += 1
+        if (
+            self.refit_every_k > 0
+            and self._completions_since_refit >= self.refit_every_k
+            and len(self._samples) >= self.min_samples
+        ):
+            self._completions_since_refit = 0
+            return self._refit_once()
+        return None
 
     # -- async refit thread (keeps percentile math off the scheduler) -------
 
@@ -439,6 +485,13 @@ class SchedulePolicy:
         )
         self.uniboost_gamma_controller: Optional[GammaAdaController] = None
         self.uniboost_match_topk = envs.SGLANG_UNIBOOST_MATCH_TOPK.get()
+        # Rank-invariant mode (tp_size > 1): Phi is computed from a
+        # rank-invariant arrival sequence number and gamma-Ada is step-clocked
+        # instead of wall-clocked, so all TP ranks sort identically.
+        self.uniboost_tp_invariant = False
+        self.uniboost_tp_arrival_step_s = envs.SGLANG_UNIBOOST_TP_ARRIVAL_STEP_S.get()
+        self._uniboost_next_arrival_seq = 0
+        self._uniboost_step = 0
         if self.policy == CacheAwarePolicy.UNIBOOST:
             self._init_uniboost()
 
@@ -668,19 +721,34 @@ class SchedulePolicy:
     # UniBoost (tail-aware admission boosting, ICML'26 "beyond prediction")
     # ------------------------------------------------------------------
     def _init_uniboost(self) -> None:
-        """Validate/arm UniBoost; falls back to fcfs when unsafe or misconfigured."""
+        """Validate/arm UniBoost; falls back to fcfs when misconfigured.
+
+        tp_size > 1 selects the rank-invariant mode: Phi uses a rank-invariant
+        arrival sequence number instead of per-rank ``perf_counter`` stamps,
+        gamma-Ada is step-clocked instead of wall-clocked, and the sort key is
+        quantized with a rank-invariant tie-break -- so every TP rank computes
+        the same queue order from the same broadcast request stream without
+        any cross-rank communication. ``SGLANG_UNIBOOST_FORCE_FCFS_TP=1`` is
+        the escape hatch back to the old fcfs fallback.
+        """
         tp_size = get_global_server_args().tp_size
-        if tp_size > 1 and not envs.SGLANG_UNIBOOST_ALLOW_TP.get():
-            logger.warning(
-                "UniBoost is disabled for tp_size=%s: the boost priority mixes "
-                "per-rank wall-clock arrival stamps with request-dependent "
-                "offsets, so TP ranks could disagree on queue order and break "
-                "lockstep scheduling. Falling back to fcfs. Set "
-                "SGLANG_UNIBOOST_ALLOW_TP=1 to override (experimental).",
-                tp_size,
-            )
-            self.policy = CacheAgnosticPolicy.FCFS
-            return
+        if tp_size > 1:
+            if envs.SGLANG_UNIBOOST_FORCE_FCFS_TP.get():
+                logger.warning(
+                    "UniBoost disabled for tp_size=%s by "
+                    "SGLANG_UNIBOOST_FORCE_FCFS_TP=1; falling back to fcfs.",
+                    tp_size,
+                )
+                self.policy = CacheAgnosticPolicy.FCFS
+                return
+            if envs.SGLANG_UNIBOOST_ALLOW_TP.get():
+                logger.info(
+                    "SGLANG_UNIBOOST_ALLOW_TP is deprecated and now a no-op: "
+                    "rank-invariant UniBoost is the default for tp_size > 1 "
+                    "(set SGLANG_UNIBOOST_FORCE_FCFS_TP=1 to fall back to "
+                    "fcfs)."
+                )
+            self.uniboost_tp_invariant = True
         if self.uniboost_gamma <= 0.0:
             logger.warning(
                 "UniBoost requested but SGLANG_UNIBOOST_GAMMA=%s is not > 0; "
@@ -699,16 +767,26 @@ class SchedulePolicy:
                 interval_s=envs.SGLANG_UNIBOOST_GAMMA_ADA_INTERVAL_S.get(),
                 window=envs.SGLANG_UNIBOOST_GAMMA_ADA_WINDOW.get(),
                 min_samples=envs.SGLANG_UNIBOOST_GAMMA_ADA_MIN_SAMPLES.get(),
+                refit_every_k=(
+                    envs.SGLANG_UNIBOOST_GAMMA_ADA_REFIT_EVERY_K.get()
+                    if self.uniboost_tp_invariant
+                    else 0
+                ),
             )
-            # Percentile scans + refits happen on this daemon thread; the
-            # scheduler's critical path only appends samples and reads gamma.
-            self.uniboost_gamma_controller.start()
+            if not self.uniboost_tp_invariant:
+                # Percentile scans + refits happen on this daemon thread; the
+                # scheduler's critical path only appends samples and reads
+                # gamma. Rank-invariant mode must NOT use the daemon: per-rank
+                # refit timing would let gammas drift apart across TP ranks,
+                # so refits are step-clocked via record_completion instead.
+                self.uniboost_gamma_controller.start()
         logger.info(
             "UniBoost tail-aware admission boosting ENABLED: gamma=%.4g /s, "
-            "alpha=%.1f us/token, gamma-Ada=%s",
+            "alpha=%.1f us/token, gamma-Ada=%s, mode=%s",
             self.uniboost_gamma,
             self.uniboost_alpha_s_per_token * 1e6,
             "on" if self.uniboost_gamma_controller is not None else "off",
+            "rank-invariant (tp>1)" if self.uniboost_tp_invariant else "wall-clock",
         )
 
     def _uniboost_boost_value(self, work_tokens: int) -> float:
@@ -743,13 +821,58 @@ class SchedulePolicy:
         uncached = prompt_len - int(req.num_matched_prefix_tokens)
         return arrival - self._uniboost_boost_value(uncached)
 
+    def _uniboost_assign_arrival_seq(self, waiting_queue: List[Req]) -> None:
+        """Assign each newly seen request its rank-invariant arrival stamps.
+
+        Rank-invariant arrival: the tokenizer-side ``created_time`` is
+        deliberately stripped before serialization to the scheduler
+        (``APIServerReqTimeStats.__getstate__``), so no pre-broadcast wall
+        stamp reaches the scheduler; instead each request gets a per-scheduler
+        monotonically increasing sequence number on first sighting. TP ranks
+        consume the same broadcast request stream, so the waiting queue holds
+        the same requests in the same order on every rank and the assigned
+        sequence numbers match. ``uniboost_enqueue_step`` (the current
+        forward-step count) is stamped at the same moment for the step-clocked
+        latency measurement.
+        """
+        for r in waiting_queue:
+            if r.uniboost_arrival_seq is None:
+                r.uniboost_arrival_seq = self._uniboost_next_arrival_seq
+                self._uniboost_next_arrival_seq += 1
+                r.uniboost_enqueue_step = self._uniboost_step
+
+    def _uniboost_invariant_key(self, req: Req):
+        """Rank-invariant, deterministic-in-data UniBoost sort key.
+
+        Pseudo-arrival = ``arrival_seq * SGLANG_UNIBOOST_TP_ARRIVAL_STEP_S``
+        (a fixed constant converts queue positions to pseudo-seconds so the
+        arrival term trades sanely against b_gamma). Phi is quantized to
+        ``UNIBOOST_PHI_QUANTUM_S`` and ties break on the arrival sequence
+        number, so residual float noise can never flip a pair of requests on
+        one rank but not another. No wall clock anywhere in this key.
+        """
+        arrival = req.uniboost_arrival_seq * self.uniboost_tp_arrival_step_s
+        prompt_len = len(req.origin_input_ids) + len(req.output_ids)
+        uncached = prompt_len - int(req.num_matched_prefix_tokens)
+        phi = arrival - self._uniboost_boost_value(uncached)
+        return (int(round(phi / UNIBOOST_PHI_QUANTUM_S)), req.uniboost_arrival_seq)
+
     def _sort_by_uniboost(self, waiting_queue: List[Req]) -> None:
         """Reorder the prefill waiting queue by tail-aware boost priority.
 
         Sorts in place ahead of the PrefillAdder admission loop (which consumes
         ``waiting_queue`` order). Recomputed each pass so a waiting request's
-        boost reflects the current clock and cache state.
+        boost reflects the current clock and cache state. In rank-invariant
+        mode (tp_size > 1) the key never touches the per-rank wall clock.
         """
+        if self.uniboost_tp_invariant:
+            # Stamp before the length check: a single request can be admitted
+            # without a sort but still needs its enqueue step for gamma-Ada.
+            self._uniboost_assign_arrival_seq(waiting_queue)
+            if len(waiting_queue) < 2:
+                return
+            waiting_queue.sort(key=self._uniboost_invariant_key)
+            return
         if len(waiting_queue) < 2:
             return
         now = time.perf_counter()
@@ -774,10 +897,15 @@ class SchedulePolicy:
         for r in waiting_queue[:k]:
             match_prefix_for_req(self.tree_cache, r, include_req=True)
         if k > 1:
-            now = time.perf_counter()
-            waiting_queue[:k] = sorted(
-                waiting_queue[:k], key=lambda r: self._uniboost_priority(r, now)
-            )
+            if self.uniboost_tp_invariant:
+                waiting_queue[:k] = sorted(
+                    waiting_queue[:k], key=self._uniboost_invariant_key
+                )
+            else:
+                now = time.perf_counter()
+                waiting_queue[:k] = sorted(
+                    waiting_queue[:k], key=lambda r: self._uniboost_priority(r, now)
+                )
 
     def _refresh_uniboost_gamma(self) -> None:
         """gamma-Ada: pick up the latest gamma computed by the refit thread.
@@ -798,11 +926,36 @@ class SchedulePolicy:
         Called from Scheduler.process_batch_result. Each request is recorded at
         most once; aborted requests are excluded so cancellations do not skew
         the tail estimate. No-op unless gamma-Ada is enabled. Recording is an
-        O(1) lock-free deque append per finished request; all percentile math
-        happens later on the controller's own refit thread.
+        O(1) lock-free deque append per finished request; percentile math
+        happens on the controller's refit thread (wall-clock mode) or on this
+        thread every ``refit_every_k`` completions (rank-invariant mode).
+
+        Rank-invariant mode measures latency in scheduler forward-step counts
+        (``finish_step - enqueue_step``): process_batch_result runs once per
+        forward batch in lockstep on every TP rank and decode completion is
+        token-determined, so the integer latencies -- and therefore the
+        gamma-Ada trajectory -- are identical across ranks. No wall clock.
         """
+        if self.uniboost_tp_invariant:
+            # One tick per processed batch result: the shared step clock.
+            self._uniboost_step += 1
         controller = self.uniboost_gamma_controller
         if controller is None:
+            return
+        if self.uniboost_tp_invariant:
+            for req in reqs:
+                if not req.finished():
+                    continue
+                if req.uniboost_latency_recorded:
+                    continue
+                req.uniboost_latency_recorded = True
+                if isinstance(req.finished_reason, FINISH_ABORT):
+                    continue
+                if req.uniboost_enqueue_step is None:
+                    # Never passed a scheduling pass (should not happen).
+                    continue
+                latency_steps = max(self._uniboost_step - req.uniboost_enqueue_step, 1)
+                controller.record_completion(float(latency_steps))
             return
         now = time.perf_counter()
         for req in reqs:

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -26,9 +26,12 @@ logger = logging.getLogger(__name__)
 # ==============================================================================
 """Request scheduler policy"""
 
+import math
 import os
 import random
-from collections import Counter, defaultdict
+import threading
+import time
+from collections import Counter, defaultdict, deque
 from contextlib import contextmanager
 from enum import Enum, auto
 from typing import TYPE_CHECKING, Dict, List, Optional, Set, Union
@@ -39,6 +42,7 @@ from sglang.srt.dllm.config import DllmConfig
 from sglang.srt.layers.attention.dsa.utils import is_dsa_prefill_cp_in_seq_split
 from sglang.srt.layers.utils.cp_utils import is_prefill_context_parallel_enabled
 from sglang.srt.managers.schedule_batch import (
+    FINISH_ABORT,
     Req,
     ScheduleBatch,
     split_cached_prefix_by_tier,
@@ -61,7 +65,7 @@ from sglang.srt.mem_cache.multi_ended_allocator import (
     UnifiedMambaTokenToKVPoolAllocator,
 )
 from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey, TreeNode
-from sglang.srt.server_args import ServerArgs
+from sglang.srt.server_args import ServerArgs, get_global_server_args
 
 if TYPE_CHECKING:
     from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
@@ -135,6 +139,198 @@ def estimate_prefill_extend_tile_metrics(
     }
 
 
+class GammaAdaController:
+    """Online estimator for the UniBoost boost parameter ``gamma`` (gamma-Ada).
+
+    Watches the observed end-to-end response-time distribution and adapts
+    ``gamma`` to the workload's tail shape, so the scheduler need not have a
+    per-workload gamma tuned by hand:
+
+    * a **heavy** tail (a few requests far slower than the p95 body) means
+      shortest-job-first-style boosting helps, so gamma is pushed **down**
+      toward ``gamma_min`` (more SJF);
+    * a **light/flat** tail (p99 close to p95) means reordering buys little and
+      FCFS best protects the tail, so gamma is pushed **up** toward
+      ``gamma_max``.
+
+    The tail shape is summarized by the log-linear slope of the response-time
+    CDF over the paper's ``[t95, t99]`` band. With ``r = t99 / t95 >= 1`` the
+    excess ``r - 1`` is the slope proxy (0 for a flat tail, growing as the
+    tail fattens); a heavier tail implies a smaller target gamma via
+
+        target = gamma_max / (1 + tail_sensitivity * max(r - 1, 0)).
+
+    The target is EMA-smoothed into the live gamma so the control loop cannot
+    oscillate. Pure and side-effect free apart from its own ring buffer, so it
+    is unit-testable without a scheduler or GPU.
+
+    Threading model (async refit, off the scheduler's critical path):
+
+    * ``record()`` runs on the scheduler thread and is a single bounded
+      ``deque.append`` -- O(1), lock-free, GIL-atomic in CPython;
+    * ``start()`` spawns one daemon thread that wakes every ``interval_s``
+      seconds and does the percentile scan + EMA re-fit there;
+    * the scheduler only *reads* ``self.gamma`` -- a plain float attribute
+      load, atomic in CPython -- so the hot path takes no locks and does no
+      percentile math. ``self.gamma = ...`` in the refit thread is likewise a
+      single attribute store, so readers see either the old or the new float,
+      never a torn value.
+    """
+
+    __slots__ = (
+        "gamma",
+        "gamma_min",
+        "gamma_max",
+        "beta",
+        "tail_sensitivity",
+        "interval_s",
+        "min_samples",
+        "refit_count",
+        "_samples",
+        "_last_update_t",
+        "_thread",
+        "_stop_event",
+    )
+
+    def __init__(
+        self,
+        *,
+        gamma_init: float,
+        gamma_min: float = 1.0,
+        gamma_max: float = 200.0,
+        beta: float = 0.3,
+        tail_sensitivity: float = 4.0,
+        interval_s: float = 5.0,
+        window: int = 2000,
+        min_samples: int = 200,
+    ) -> None:
+        # gamma_min must stay strictly positive: b_gamma divides by gamma.
+        self.gamma_min = max(float(gamma_min), 1e-6)
+        self.gamma_max = max(float(gamma_max), self.gamma_min)
+        self.gamma = min(max(float(gamma_init), self.gamma_min), self.gamma_max)
+        self.beta = min(max(float(beta), 0.0), 1.0)
+        self.tail_sensitivity = max(float(tail_sensitivity), 0.0)
+        self.interval_s = max(float(interval_s), 0.0)
+        self.min_samples = max(int(min_samples), 1)
+        self._samples = deque(maxlen=max(int(window), self.min_samples))
+        self._last_update_t = 0.0
+        self.refit_count = 0
+        self._thread: Optional[threading.Thread] = None
+        self._stop_event = threading.Event()
+
+    def record(self, latency_s: float) -> None:
+        """Record one completed request's end-to-end latency (seconds).
+
+        Scheduler-thread hot path: a single bounded ``deque.append`` (O(1),
+        no lock; safe against the refit thread under the GIL).
+        """
+        if latency_s > 0.0:
+            self._samples.append(float(latency_s))
+
+    # -- async refit thread (keeps percentile math off the scheduler) -------
+
+    def start(self) -> None:
+        """Start the background refit daemon thread. Idempotent."""
+        if self._thread is not None and self._thread.is_alive():
+            return
+        self._stop_event.clear()
+        self._thread = threading.Thread(
+            target=self._run, name="uniboost-gamma-ada", daemon=True
+        )
+        self._thread.start()
+
+    def stop(self, timeout: float = 2.0) -> None:
+        """Stop the background refit thread (used by tests; daemon otherwise)."""
+        self._stop_event.set()
+        thread = self._thread
+        if thread is not None:
+            thread.join(timeout)
+        self._thread = None
+
+    def _run(self) -> None:
+        # Wait *first* so startup never refits an empty window; a non-positive
+        # interval still yields a short sleep instead of a busy loop.
+        wait_s = self.interval_s if self.interval_s > 0.0 else 0.05
+        while not self._stop_event.wait(wait_s):
+            try:
+                self._refit_once()
+            except Exception:
+                logger.exception(
+                    "UniBoost gamma-Ada refit failed; keeping gamma=%.4g",
+                    self.gamma,
+                )
+
+    @staticmethod
+    def _percentile(sorted_vals, q: float) -> float:
+        """Linear-interpolated percentile q in [0,1] over a sorted list."""
+        n = len(sorted_vals)
+        if n == 1:
+            return sorted_vals[0]
+        pos = q * (n - 1)
+        lo = int(pos)
+        hi = min(lo + 1, n - 1)
+        frac = pos - lo
+        return sorted_vals[lo] * (1.0 - frac) + sorted_vals[hi] * frac
+
+    def _target_gamma(self) -> float:
+        # sorted(deque) snapshots in one C call, so concurrent appends from
+        # the scheduler thread cannot interleave mid-copy under the GIL.
+        vals = sorted(self._samples)
+        t95 = self._percentile(vals, 0.95)
+        t99 = self._percentile(vals, 0.99)
+        if t95 <= 0.0:
+            return self.gamma_max
+        ratio = t99 / t95
+        excess = ratio - 1.0 if ratio > 1.0 else 0.0
+        target = self.gamma_max / (1.0 + self.tail_sensitivity * excess)
+        if target < self.gamma_min:
+            return self.gamma_min
+        if target > self.gamma_max:
+            return self.gamma_max
+        return target
+
+    def _refit_once(self):
+        """One percentile scan + EMA re-fit; runs on the refit thread.
+
+        Returns the new (EMA-smoothed, clamped) gamma, or ``None`` when fewer
+        than ``min_samples`` latencies have been observed (clean no-op).
+        """
+        if len(self._samples) < self.min_samples:
+            return None
+        target = self._target_gamma()
+        gamma = (1.0 - self.beta) * self.gamma + self.beta * target
+        # Stay strictly positive and in range regardless of float drift.
+        if gamma < self.gamma_min:
+            gamma = self.gamma_min
+        elif gamma > self.gamma_max:
+            gamma = self.gamma_max
+        # Single attribute store: atomic for scheduler-thread readers.
+        self.gamma = gamma
+        self.refit_count += 1
+        logger.info(
+            "UniBoost gamma-Ada refit #%d: gamma=%.4g /s (target %.4g, n=%d)",
+            self.refit_count,
+            gamma,
+            target,
+            len(self._samples),
+        )
+        return gamma
+
+    def maybe_update(self, now: float):
+        """Synchronous, interval-gated re-fit with an explicit clock.
+
+        Kept for tests and manual driving; the production path is the
+        ``start()`` daemon thread, whose wake cadence provides the interval.
+        Returns the new gamma when it updates, else ``None``.
+        """
+        if now - self._last_update_t < self.interval_s:
+            return None
+        if len(self._samples) < self.min_samples:
+            return None
+        self._last_update_t = now
+        return self._refit_once()
+
+
 def match_prefix_for_req(
     tree_cache: BasePrefixCache,
     req: Req,
@@ -202,6 +398,7 @@ class CacheAwarePolicy(Enum):
 
     LPM = "lpm"  # longest prefix match
     DFS_WEIGHT = "dfs-weight"  # depth-first search weighting
+    UNIBOOST = "uniboost"  # tail-aware admission boosting (UniBoost)
 
 
 class CacheAgnosticPolicy(Enum):
@@ -234,6 +431,16 @@ class SchedulePolicy:
         # It is used to find the matching prefix for in-batch prefix caching.
         self.waiting_queue_radix_tree = RadixCache.create_simulated()
 
+        # UniBoost (tail-aware admission boosting) state; inert unless the
+        # schedule policy is "uniboost".
+        self.uniboost_gamma = envs.SGLANG_UNIBOOST_GAMMA.get()
+        self.uniboost_alpha_s_per_token = (
+            envs.SGLANG_UNIBOOST_ALPHA_US_PER_TOKEN.get() / 1e6
+        )
+        self.uniboost_gamma_controller: Optional[GammaAdaController] = None
+        if self.policy == CacheAwarePolicy.UNIBOOST:
+            self._init_uniboost()
+
     def calc_priority(
         self, waiting_queue: List[Req], running_batch: Optional[ScheduleBatch] = None
     ) -> None:
@@ -259,6 +466,14 @@ class SchedulePolicy:
             return
 
         if isinstance(policy, CacheAwarePolicy):
+            if policy == CacheAwarePolicy.UNIBOOST:
+                self._refresh_uniboost_gamma()
+                if not self.tree_cache.disable:
+                    # Populates req.num_matched_prefix_tokens for the
+                    # cache-aware effective-work estimate.
+                    self._compute_prefix_matches(waiting_queue, policy)
+                self._sort_by_uniboost(waiting_queue)
+                return
             temporary_deprioritized = self._compute_prefix_matches(
                 waiting_queue, policy
             )
@@ -302,6 +517,10 @@ class SchedulePolicy:
         try:
             policy_enum = CacheAwarePolicy(policy)
             if getattr(tree_cache, "disable", True):
+                if policy_enum == CacheAwarePolicy.UNIBOOST:
+                    # UniBoost still works without a prefix cache: every
+                    # prompt token counts as uncached work.
+                    return policy_enum
                 # If tree_cache is disabled, using CacheAgnosticPolicy policy
                 return CacheAgnosticPolicy.FCFS
             return policy_enum
@@ -439,6 +658,139 @@ class SchedulePolicy:
                 x.time_stats.wait_queue_entry_time,
             )
         )
+
+    # ------------------------------------------------------------------
+    # UniBoost (tail-aware admission boosting, ICML'26 "beyond prediction")
+    # ------------------------------------------------------------------
+    def _init_uniboost(self) -> None:
+        """Validate/arm UniBoost; falls back to fcfs when unsafe or misconfigured."""
+        tp_size = get_global_server_args().tp_size
+        if tp_size > 1 and not envs.SGLANG_UNIBOOST_ALLOW_TP.get():
+            logger.warning(
+                "UniBoost is disabled for tp_size=%s: the boost priority mixes "
+                "per-rank wall-clock arrival stamps with request-dependent "
+                "offsets, so TP ranks could disagree on queue order and break "
+                "lockstep scheduling. Falling back to fcfs. Set "
+                "SGLANG_UNIBOOST_ALLOW_TP=1 to override (experimental).",
+                tp_size,
+            )
+            self.policy = CacheAgnosticPolicy.FCFS
+            return
+        if self.uniboost_gamma <= 0.0:
+            logger.warning(
+                "UniBoost requested but SGLANG_UNIBOOST_GAMMA=%s is not > 0; "
+                "falling back to fcfs",
+                self.uniboost_gamma,
+            )
+            self.policy = CacheAgnosticPolicy.FCFS
+            return
+        if envs.SGLANG_UNIBOOST_GAMMA_ADA.get():
+            self.uniboost_gamma_controller = GammaAdaController(
+                gamma_init=self.uniboost_gamma,
+                gamma_min=envs.SGLANG_UNIBOOST_GAMMA_MIN.get(),
+                gamma_max=envs.SGLANG_UNIBOOST_GAMMA_MAX.get(),
+                beta=envs.SGLANG_UNIBOOST_GAMMA_ADA_BETA.get(),
+                tail_sensitivity=envs.SGLANG_UNIBOOST_TAIL_SENSITIVITY.get(),
+                interval_s=envs.SGLANG_UNIBOOST_GAMMA_ADA_INTERVAL_S.get(),
+                window=envs.SGLANG_UNIBOOST_GAMMA_ADA_WINDOW.get(),
+                min_samples=envs.SGLANG_UNIBOOST_GAMMA_ADA_MIN_SAMPLES.get(),
+            )
+            # Percentile scans + refits happen on this daemon thread; the
+            # scheduler's critical path only appends samples and reads gamma.
+            self.uniboost_gamma_controller.start()
+        logger.info(
+            "UniBoost tail-aware admission boosting ENABLED: gamma=%.4g /s, "
+            "alpha=%.1f us/token, gamma-Ada=%s",
+            self.uniboost_gamma,
+            self.uniboost_alpha_s_per_token * 1e6,
+            "on" if self.uniboost_gamma_controller is not None else "off",
+        )
+
+    def _uniboost_boost_value(self, work_tokens: int) -> float:
+        """Soft priority boost b_gamma(w) in seconds (UniBoost).
+
+        ``b_gamma(w) = (1/gamma) * ln(1 / (1 - e^{-gamma w}))`` on the effective
+        work ``w = alpha * uncached_tokens`` (in seconds). Decreasing and convex
+        in w: large when little work remains (short jobs get pulled forward),
+        decaying to ~0 as work grows (long jobs drift back to their FCFS rank so
+        they are never starved).
+        """
+        w = self.uniboost_alpha_s_per_token * max(work_tokens, 0)
+        if w <= 0.0:
+            # No uncached work => maximal boost; clamp to a large finite value
+            # so the sort key stays orderable.
+            return 1e9
+        gamma = self.uniboost_gamma
+        gw = gamma * w
+        # 1 - e^{-gw} in (0, 1]; guard the tiny-gw underflow with expm1.
+        denom = -math.expm1(-gw)  # == 1 - e^{-gw}, accurate for small gw
+        if denom <= 0.0:
+            return 1e9
+        return -math.log(denom) / gamma
+
+    def _uniboost_priority(self, req: Req, now: float) -> float:
+        """Phi(i) = arrival_i - b_gamma(effective_work_i); lower = serve sooner."""
+        arrival = req.time_stats.wait_queue_entry_time or now
+        prompt_len = len(req.origin_input_ids) + len(req.output_ids)
+        # Cache-aware effective work: subtract the radix-matched prefix so a
+        # request whose prompt is mostly a cache hit is treated as short work
+        # (UniBoost cache extension w_tilde = max(w, s_pre - h)).
+        uncached = prompt_len - int(req.num_matched_prefix_tokens)
+        return arrival - self._uniboost_boost_value(uncached)
+
+    def _sort_by_uniboost(self, waiting_queue: List[Req]) -> None:
+        """Reorder the prefill waiting queue by tail-aware boost priority.
+
+        Sorts in place ahead of the PrefillAdder admission loop (which consumes
+        ``waiting_queue`` order). Recomputed each pass so a waiting request's
+        boost reflects the current clock and cache state.
+        """
+        if len(waiting_queue) < 2:
+            return
+        now = time.perf_counter()
+        waiting_queue.sort(key=lambda r: self._uniboost_priority(r, now))
+
+    def _refresh_uniboost_gamma(self) -> None:
+        """gamma-Ada: pick up the latest gamma computed by the refit thread.
+
+        Called once per prefill scheduling pass. This is a single float
+        attribute read (atomic in CPython) -- no locks and no percentile math
+        on the scheduler's critical path; the heavy lifting runs on the
+        controller's daemon thread (see GammaAdaController.start).
+        """
+        controller = self.uniboost_gamma_controller
+        if controller is None:
+            return
+        self.uniboost_gamma = controller.gamma
+
+    def uniboost_record_finished(self, reqs: List[Req]) -> None:
+        """gamma-Ada hook: record end-to-end latencies of finished requests.
+
+        Called from Scheduler.process_batch_result. Each request is recorded at
+        most once; aborted requests are excluded so cancellations do not skew
+        the tail estimate. No-op unless gamma-Ada is enabled. Recording is an
+        O(1) lock-free deque append per finished request; all percentile math
+        happens later on the controller's own refit thread.
+        """
+        controller = self.uniboost_gamma_controller
+        if controller is None:
+            return
+        now = time.perf_counter()
+        for req in reqs:
+            if not req.finished():
+                continue
+            if req.uniboost_latency_recorded:
+                continue
+            req.uniboost_latency_recorded = True
+            if isinstance(req.finished_reason, FINISH_ABORT):
+                continue
+            arrival = req.time_stats.wait_queue_entry_time
+            if arrival <= 0.0:
+                continue
+            end = req.time_stats.completion_time
+            if end <= 0.0:
+                end = now
+            controller.record(end - arrival)
 
     @staticmethod
     def _sort_by_routing_key(

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -438,6 +438,7 @@ class SchedulePolicy:
             envs.SGLANG_UNIBOOST_ALPHA_US_PER_TOKEN.get() / 1e6
         )
         self.uniboost_gamma_controller: Optional[GammaAdaController] = None
+        self.uniboost_match_topk = envs.SGLANG_UNIBOOST_MATCH_TOPK.get()
         if self.policy == CacheAwarePolicy.UNIBOOST:
             self._init_uniboost()
 
@@ -468,11 +469,15 @@ class SchedulePolicy:
         if isinstance(policy, CacheAwarePolicy):
             if policy == CacheAwarePolicy.UNIBOOST:
                 self._refresh_uniboost_gamma()
-                if not self.tree_cache.disable:
-                    # Populates req.num_matched_prefix_tokens for the
-                    # cache-aware effective-work estimate.
+                tree_disabled = self.tree_cache.disable
+                if not tree_disabled and self.uniboost_match_topk <= 0:
+                    # Legacy: full per-pass prefix matching over the queue
+                    # (populates req.num_matched_prefix_tokens for the
+                    # cache-aware effective-work estimate).
                     self._compute_prefix_matches(waiting_queue, policy)
                 self._sort_by_uniboost(waiting_queue)
+                if not tree_disabled and self.uniboost_match_topk > 0:
+                    self._uniboost_refresh_frontier(waiting_queue)
                 return
             temporary_deprioritized = self._compute_prefix_matches(
                 waiting_queue, policy
@@ -749,6 +754,30 @@ class SchedulePolicy:
             return
         now = time.perf_counter()
         waiting_queue.sort(key=lambda r: self._uniboost_priority(r, now))
+
+    def _uniboost_refresh_frontier(self, waiting_queue: List[Req]) -> None:
+        """Frontier-K refresh: re-match only the top-K sorted candidates.
+
+        Policy-side matches are advisory (admission re-matches authoritatively
+        when building the prefill batch), and stale matches are conservative:
+        a waiting request's cached prefix can only have grown since its last
+        match (barring eviction), so a stale value under-boosts but never
+        starves. Deep-queue entries therefore keep their last-known
+        num_matched_prefix_tokens (new arrivals: 0 = all work uncached) and
+        per-pass radix walks are bounded to K regardless of queue depth.
+        Full-queue per-pass matching cost the hybrid-mamba radix cache 20-40%
+        goodput at 1000+ queued requests in real-trace replay.
+        """
+        k = min(self.uniboost_match_topk, len(waiting_queue))
+        if k <= 0:
+            return
+        for r in waiting_queue[:k]:
+            match_prefix_for_req(self.tree_cache, r, include_req=True)
+        if k > 1:
+            now = time.perf_counter()
+            waiting_queue[:k] = sorted(
+                waiting_queue[:k], key=lambda r: self._uniboost_priority(r, now)
+            )
 
     def _refresh_uniboost_gamma(self) -> None:
         """gamma-Ada: pick up the latest gamma computed by the refit thread.

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3943,6 +3943,10 @@ class Scheduler(
         elif batch.forward_mode.is_idle():
             self.batch_result_processor.process_batch_result_idle(batch, result)
 
+        # UniBoost gamma-Ada: observe finished request latencies for the
+        # adaptive boost-gamma controller (no-op unless enabled).
+        self.policy.uniboost_record_finished(batch.reqs)
+
         self._record_step_counters(batch, result)
 
         self.metrics_reporter.log_batch_result_stats(batch, result)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -837,6 +837,7 @@ class ServerArgs:
                 "lof",
                 "priority",
                 "routing-key",
+                "uniboost",
             ],
         ),
         NS("schedule"),

--- a/test/registered/unit/managers/test_uniboost_policy.py
+++ b/test/registered/unit/managers/test_uniboost_policy.py
@@ -11,13 +11,20 @@ Coverage (each case guards a distinct failure mode):
     idempotent, no refit below min_samples, interval_s=0 does not busy-loop;
   * uniboost waiting-queue ordering -- SJF pull-forward, FCFS tie-break,
     bounded boost (anti-starvation), cache-aware effective work;
-  * fallback gating -- tp_size > 1 without SGLANG_UNIBOOST_ALLOW_TP,
-    gamma <= 0, and the tree-cache-disabled carve-out;
+  * fallback gating -- gamma <= 0, the tree-cache-disabled carve-out, and the
+    tp_size > 1 mode selection (rank-invariant by default,
+    SGLANG_UNIBOOST_FORCE_FCFS_TP escape hatch, deprecated no-op ALLOW_TP);
   * the finished-request recording hook -- aborts excluded, each request
     recorded once, and calc_priority never refits synchronously;
   * frontier-K matching -- per pass, radix prefix matching is bounded to the
     top-K sorted candidates (deep queues keep last-known matches), and <=0
-    restores full-queue matching.
+    restores full-queue matching;
+  * rank-invariant mode (tp_size > 1) -- two simulated TP ranks fed the
+    identical request stream but different per-rank wall clocks and daemon
+    timings produce identical queue orderings on every pass and bit-identical
+    gamma trajectories under the step-clocked controller, the sort key is
+    wall-clock-free with a quantized/tie-broken total order, and the legacy
+    tp == 1 wall-clock behavior is unchanged.
 """
 
 import random
@@ -64,6 +71,8 @@ class FakeReq:
         self.output_ids = []
         self.num_matched_prefix_tokens = cached
         self.uniboost_latency_recorded = False
+        self.uniboost_arrival_seq = None
+        self.uniboost_enqueue_step = None
         self.time_stats = FakeTimeStats(arrival, completion_time)
         self._finished = finished
         self.finished_reason = finished_reason
@@ -302,17 +311,31 @@ class TestUniboostFallbacks(UniboostTestBase):
         self.assertEqual([r.rid for r in q], ["a", "b"])
 
     def test_tp_gating(self):
+        # tp_size > 1 now defaults to the rank-invariant uniboost mode (no
+        # more silent fcfs fallback); SGLANG_UNIBOOST_FORCE_FCFS_TP is the
+        # escape hatch and SGLANG_UNIBOOST_ALLOW_TP a deprecated no-op.
         fake_args = SimpleNamespace(tp_size=2)
         with patch(
             "sglang.srt.managers.schedule_policy.get_global_server_args",
             return_value=fake_args,
         ):
             pol = make_policy()
-            self.assertEqual(pol.policy, CacheAgnosticPolicy.FCFS)
+            self.assertEqual(pol.policy, CacheAwarePolicy.UNIBOOST)
+            self.assertTrue(pol.uniboost_tp_invariant)
+
+            with envs.SGLANG_UNIBOOST_FORCE_FCFS_TP.override(True):
+                pol = make_policy()
+                self.assertEqual(pol.policy, CacheAgnosticPolicy.FCFS)
 
             with envs.SGLANG_UNIBOOST_ALLOW_TP.override(True):
                 pol = make_policy()
                 self.assertEqual(pol.policy, CacheAwarePolicy.UNIBOOST)
+                self.assertTrue(pol.uniboost_tp_invariant)
+
+        # tp == 1 keeps the validated wall-clock mode.
+        pol = make_policy()
+        self.assertEqual(pol.policy, CacheAwarePolicy.UNIBOOST)
+        self.assertFalse(pol.uniboost_tp_invariant)
 
     def test_gamma_zero_falls_back_to_fcfs(self):
         with envs.SGLANG_UNIBOOST_GAMMA.override(0.0):
@@ -436,6 +459,287 @@ class TestGammaAdaWiring(UniboostTestBase):
         done = FakeReq("done", 10, 5.0, finished=True, completion_time=8.5)
         pol.uniboost_record_finished([done])  # must not raise
         self.assertFalse(done.uniboost_latency_recorded)
+
+
+def make_tp_policy(tree_cache=None):
+    """A SchedulePolicy constructed as one rank of a tp_size=2 group."""
+    with patch(
+        "sglang.srt.managers.schedule_policy.get_global_server_args",
+        return_value=SimpleNamespace(tp_size=2),
+    ):
+        return make_policy(tree_cache=tree_cache)
+
+
+class RankClock:
+    """One rank's simulated ``time.perf_counter``: distinct offset and drift.
+
+    Two RankClocks with different offsets/drifts model TP ranks whose local
+    wall clocks disagree -- the failure injection for the rank-invariance
+    tests: any code path that reads the patched clock produces different
+    values on the two simulated ranks.
+    """
+
+    def __init__(self, offset, drift):
+        self.now = offset
+        self.drift = drift
+
+    def __call__(self):
+        self.now += self.drift
+        return self.now
+
+
+class TestUniboostTpInvariant(UniboostTestBase):
+    """Rank-invariant UniBoost under tensor parallelism (tp_size > 1).
+
+    Simulates two TP ranks as two SchedulePolicy instances fed the identical
+    broadcast request stream, but with injected per-rank differences: each
+    rank's FakeReqs carry different wall-clock arrival stamps and each rank's
+    passes run under a different monkeypatched ``perf_counter``. Any use of
+    scheduler-local wall time in Phi or in gamma-Ada would make these tests
+    red by diverging the two ranks' queue orders or gamma trajectories --
+    exactly the TP desync (mismatched batch shapes -> NCCL hang) the
+    rank-invariant mode exists to prevent.
+    """
+
+    # (rid, prompt_len, cached) -- identical on both ranks, like the
+    # broadcast request stream. Mixes long, medium, short, and a mostly
+    # cached long prompt (cache-aware effective work).
+    STREAM = [
+        ("L0", 20000, 0),
+        ("L1", 20000, 0),
+        ("L2", 18000, 0),
+        ("M3", 5000, 0),
+        ("S4", 100, 0),
+        ("L5", 20000, 0),
+        ("H6", 20000, 19900),
+        ("M7", 4000, 0),
+        ("S8", 200, 0),
+        ("L9", 17000, 0),
+        ("M10", 6000, 0),
+        ("S11", 150, 0),
+    ]
+
+    def _rank_pass(self, pol, queue, clock):
+        """Run one scheduling pass for one rank under its own wall clock."""
+        with patch(
+            "sglang.srt.managers.schedule_policy.time.perf_counter",
+            side_effect=clock,
+        ):
+            pol.calc_priority(queue)
+        return [r.rid for r in queue]
+
+    def test_two_ranks_agree_on_queue_order(self):
+        pols = [make_tp_policy(), make_tp_policy()]
+        clocks = [RankClock(1_000.0, 0.013), RankClock(50_000.0, 0.007)]
+        queues = [[], []]
+        for pol in pols:
+            self.assertTrue(pol.uniboost_tp_invariant)
+
+        cursor = 0
+        orders_seen = []
+        for admitted_per_pass in (2, 2, 2):
+            wave = self.STREAM[cursor : cursor + 4]
+            cursor += 4
+            pass_orders = []
+            for rank in range(2):
+                # Per-rank wall stamps differ; rids/lengths/cache are shared.
+                queues[rank].extend(
+                    FakeReq(rid, plen, clocks[rank](), cached=cached)
+                    for rid, plen, cached in wave
+                )
+                pass_orders.append(
+                    self._rank_pass(pols[rank], queues[rank], clocks[rank])
+                )
+            # (a) identical queue orderings on every pass.
+            self.assertEqual(pass_orders[0], pass_orders[1])
+            orders_seen.append(pass_orders[0])
+            for rank in range(2):
+                # Admit the head of the queue, in lockstep on both ranks.
+                del queues[rank][:admitted_per_pass]
+
+        # The agreed order is uniboost, not plain FCFS: the short job S4
+        # arrived after three long jobs but is admitted ahead of them, and
+        # the mostly cached long prompt H6 outranks the earlier cold L2.
+        second_pass = orders_seen[1]
+        self.assertLess(second_pass.index("S4"), second_pass.index("L2"))
+        self.assertLess(second_pass.index("H6"), second_pass.index("L2"))
+
+    def test_two_ranks_identical_gamma_trajectories(self):
+        with (
+            envs.SGLANG_UNIBOOST_GAMMA_ADA.override(True),
+            envs.SGLANG_UNIBOOST_GAMMA_ADA_MIN_SAMPLES.override(20),
+            envs.SGLANG_UNIBOOST_GAMMA_ADA_REFIT_EVERY_K.override(10),
+        ):
+            pols = [make_tp_policy(), make_tp_policy()]
+        clocks = [RankClock(0.0, 0.031), RankClock(7_777.0, 0.005)]
+
+        n = 80
+        # Token-determined completion schedule, identical on both ranks:
+        # a 3..7-step body plus a heavy tail every 10th request.
+        finish_after = [3 + (i % 5) for i in range(n)]
+        for i in range(0, n, 10):
+            finish_after[i] = 60 + i
+
+        trajectories = []
+        for rank, pol in enumerate(pols):
+            ctl = pol.uniboost_gamma_controller
+            self.assertIsNotNone(ctl)
+            # (b) step-clocked mode: no wall-clock daemon on either rank
+            # (per-rank daemon wake timing is exactly the drift source).
+            self.assertIsNone(ctl._thread)
+            self.assertEqual(ctl.refit_every_k, 10)
+
+            reqs = [
+                FakeReq(f"r{i}", 100 + (i % 7) * 500, clocks[rank]()) for i in range(n)
+            ]
+            with patch(
+                "sglang.srt.managers.schedule_policy.time.perf_counter",
+                side_effect=clocks[rank],
+            ):
+                pol.calc_priority(list(reqs))
+                gammas = []
+                for step in range(1, 201):
+                    finished = [reqs[i] for i in range(n) if finish_after[i] == step]
+                    for req in finished:
+                        req._finished = True
+                        # Per-rank garbage wall stamp: must be ignored.
+                        req.time_stats.completion_time = clocks[rank]()
+                    pol.uniboost_record_finished(finished)
+                    gammas.append(ctl.gamma)
+            trajectories.append(gammas)
+            self.assertGreaterEqual(ctl.refit_count, 3)
+
+        # Bit-identical gamma trajectories despite different per-rank clocks.
+        self.assertEqual(trajectories[0], trajectories[1])
+        # And the controller actually adapted (not a frozen-gamma tautology).
+        self.assertNotEqual(trajectories[0][-1], trajectories[0][0])
+
+    def test_invariant_mode_never_reads_wall_clock(self):
+        with (
+            envs.SGLANG_UNIBOOST_GAMMA_ADA.override(True),
+            envs.SGLANG_UNIBOOST_GAMMA_ADA_MIN_SAMPLES.override(1),
+            envs.SGLANG_UNIBOOST_GAMMA_ADA_REFIT_EVERY_K.override(1),
+        ):
+            pol = make_tp_policy()
+        req = FakeReq("r", 100, 5.0)
+        other = FakeReq("s", 9000, 6.0)
+        boom = patch(
+            "sglang.srt.managers.schedule_policy.time.perf_counter",
+            side_effect=AssertionError(
+                "rank-invariant uniboost read the per-rank wall clock"
+            ),
+        )
+        with boom:
+            q = [req, other]
+            pol.calc_priority(q)
+            req._finished = True
+            pol.uniboost_record_finished([req])
+        self.assertEqual(pol.uniboost_gamma_controller.refit_count, 1)
+
+    def test_invariant_arrival_is_seq_not_wall_stamp(self):
+        # Stream position decides arrival: a request whose per-rank wall
+        # stamp says "much older" but that came later in the broadcast
+        # stream must NOT jump ahead (equal work => FCFS by sequence).
+        pol = make_tp_policy()
+        first = FakeReq("first", 5000, 999_999.0)  # huge per-rank stamp
+        second = FakeReq("second", 5000, 1.0)  # tiny stamp, later in stream
+        q = [first, second]
+        pol.calc_priority(q)
+        self.assertEqual([r.rid for r in q], ["first", "second"])
+        self.assertEqual(first.uniboost_arrival_seq, 0)
+        self.assertEqual(second.uniboost_arrival_seq, 1)
+        # Sequence numbers are sticky across passes; new arrivals extend.
+        third = FakeReq("third", 5000, 0.5)
+        q.append(third)
+        pol.calc_priority(q)
+        self.assertEqual([r.rid for r in q], ["first", "second", "third"])
+        self.assertEqual(third.uniboost_arrival_seq, 2)
+
+    def test_phi_quantization_tie_breaks_on_seq(self):
+        # (3) deterministic total order: sub-quantum Phi differences cannot
+        # reorder requests -- the rank-invariant sequence breaks the tie --
+        # while super-quantum differences still do.
+        pol = make_tp_policy()
+        a = FakeReq("a", 100, 1.0)
+        b = FakeReq("b", 200, 2.0)
+        q = [a, b]
+        pol._uniboost_assign_arrival_seq(q)  # a -> seq 0, b -> seq 1
+
+        def sort_with_boosts(boosts):
+            with patch.object(
+                pol, "_uniboost_boost_value", side_effect=lambda w: boosts[w]
+            ):
+                return [r.rid for r in sorted(q, key=pol._uniboost_invariant_key)]
+
+        # Raw phi_b is 2e-5 BELOW phi_a (b "won" by float noise), but the
+        # difference is under the 1e-4 quantum: seq order must hold.
+        self.assertEqual(sort_with_boosts({100: 0.5, 200: 0.51002}), ["a", "b"])
+        # A real (super-quantum) difference still reorders.
+        self.assertEqual(sort_with_boosts({100: 0.5, 200: 0.5102}), ["b", "a"])
+
+    def test_invariant_step_latency_recording(self):
+        with (
+            envs.SGLANG_UNIBOOST_GAMMA_ADA.override(True),
+            envs.SGLANG_UNIBOOST_GAMMA_ADA_MIN_SAMPLES.override(100),
+            envs.SGLANG_UNIBOOST_GAMMA_ADA_REFIT_EVERY_K.override(100),
+        ):
+            pol = make_tp_policy()
+        ctl = pol.uniboost_gamma_controller
+        req = FakeReq("done", 100, 5.0)
+        aborted = FakeReq("aborted", 100, 5.0, finished_reason=FINISH_ABORT())
+        pol.calc_priority([req, aborted])  # enqueue_step = 0 for both
+        for _ in range(3):
+            pol.uniboost_record_finished([])  # three empty batch results
+        req._finished = True
+        aborted._finished = True
+        pol.uniboost_record_finished([req, aborted])
+        # Latency is in forward steps (4 batch results since enqueue), not
+        # seconds; the abort is excluded but still marked as recorded.
+        self.assertEqual(list(ctl._samples), [4.0])
+        self.assertTrue(aborted.uniboost_latency_recorded)
+        # Double-record guard holds in the invariant path too.
+        pol.uniboost_record_finished([req])
+        self.assertEqual(len(ctl._samples), 1)
+
+    def test_step_clocked_refit_cadence(self):
+        # Completion-count trigger: refits every K completions, wall clock
+        # irrelevant (interval_s huge), min_samples still gates.
+        ctl = GammaAdaController(
+            gamma_init=50.0, interval_s=1e9, min_samples=5, refit_every_k=5
+        )
+        results = [ctl.record_completion(float(3 + (i % 4))) for i in range(4)]
+        self.assertEqual(results, [None] * 4)
+        self.assertEqual(ctl.refit_count, 0)
+        self.assertIsNotNone(ctl.record_completion(30.0))
+        self.assertEqual(ctl.refit_count, 1)
+        for _ in range(4):
+            self.assertIsNone(ctl.record_completion(3.0))
+        self.assertIsNotNone(ctl.record_completion(40.0))
+        self.assertEqual(ctl.refit_count, 2)
+
+    def test_tp1_wall_clock_path_unchanged(self):
+        # (c) legacy behavior: tp == 1 keeps per-rank wall-clock arrivals and
+        # the daemon-thread controller; none of the invariant bookkeeping
+        # engages.
+        pol = make_policy()
+        self.assertFalse(pol.uniboost_tp_invariant)
+        a = FakeReq("late", 5000, 100.0)
+        b = FakeReq("early", 5000, 50.0)
+        q = [a, b]
+        pol.calc_priority(q)
+        # Wall-clock FCFS: the earlier *stamp* wins, not the stream position.
+        self.assertEqual([r.rid for r in q], ["early", "late"])
+        self.assertIsNone(a.uniboost_arrival_seq)
+        self.assertIsNone(a.uniboost_enqueue_step)
+
+        with envs.SGLANG_UNIBOOST_GAMMA_ADA.override(True):
+            pol_ada = make_policy()
+        ctl = pol_ada.uniboost_gamma_controller
+        self.addCleanup(ctl.stop)
+        # Daemon refit thread on; completion-count trigger off.
+        self.assertIsNotNone(ctl._thread)
+        self.assertTrue(ctl._thread.is_alive())
+        self.assertEqual(ctl.refit_every_k, 0)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/managers/test_uniboost_policy.py
+++ b/test/registered/unit/managers/test_uniboost_policy.py
@@ -1,0 +1,387 @@
+"""Unit tests for the UniBoost schedule policy and its gamma-Ada controller.
+
+No GPU or server launch: exercises the real SchedulePolicy / GammaAdaController
+with mock Req objects.
+
+Coverage (each case guards a distinct failure mode):
+  * GammaAdaController control law -- heavy tail drives gamma down (more SJF),
+    light tail drives it up (more FCFS), always clamped into
+    [gamma_min, gamma_max] (derived property of the target formula);
+  * the async refit thread -- refits happen on the daemon thread, start() is
+    idempotent, no refit below min_samples, interval_s=0 does not busy-loop;
+  * uniboost waiting-queue ordering -- SJF pull-forward, FCFS tie-break,
+    bounded boost (anti-starvation), cache-aware effective work;
+  * fallback gating -- tp_size > 1 without SGLANG_UNIBOOST_ALLOW_TP,
+    gamma <= 0, and the tree-cache-disabled carve-out;
+  * the finished-request recording hook -- aborts excluded, each request
+    recorded once, and calc_priority never refits synchronously.
+"""
+
+import random
+import threading
+import time
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.srt.environ import envs
+from sglang.srt.managers.schedule_batch import FINISH_ABORT
+from sglang.srt.managers.schedule_policy import (
+    CacheAgnosticPolicy,
+    CacheAwarePolicy,
+    GammaAdaController,
+    SchedulePolicy,
+)
+from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=25, suite="base-a-test-cpu")
+
+
+class FakeTimeStats:
+    def __init__(self, wait_queue_entry_time=0.0, completion_time=0.0):
+        self.wait_queue_entry_time = wait_queue_entry_time
+        self.completion_time = completion_time
+
+
+class FakeReq:
+    def __init__(
+        self,
+        rid,
+        prompt_len,
+        arrival,
+        cached=0,
+        finished=False,
+        finished_reason=None,
+        completion_time=0.0,
+    ):
+        self.rid = rid
+        self.origin_input_ids = list(range(prompt_len))
+        self.output_ids = []
+        self.num_matched_prefix_tokens = cached
+        self.uniboost_latency_recorded = False
+        self.time_stats = FakeTimeStats(arrival, completion_time)
+        self._finished = finished
+        self.finished_reason = finished_reason
+        self.extra_key = None
+        self.priority = 0
+
+    def finished(self):
+        return self._finished
+
+
+class FakeDisabledTreeCache:
+    disable = True
+
+    def supports_fast_match_prefix(self):
+        return False
+
+
+def make_policy(policy_name="uniboost"):
+    return SchedulePolicy(
+        policy_name,
+        FakeDisabledTreeCache(),
+        enable_hierarchical_cache=False,
+        enable_priority_scheduling=False,
+        schedule_low_priority_values_first=False,
+    )
+
+
+def drive(ctl, ticks=30):
+    for k in range(ticks):
+        ctl.maybe_update(now=k + 1)
+
+
+def wait_until(cond, timeout=5.0, step=0.02):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if cond():
+            return True
+        time.sleep(step)
+    return cond()
+
+
+class UniboostTestBase(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # SchedulePolicy._init_uniboost reads tp_size off the published args.
+        set_global_server_args_for_scheduler(ServerArgs(model_path="dummy"))
+
+
+class TestGammaAdaController(CustomTestCase):
+    def test_no_update_before_interval(self):
+        ctl = GammaAdaController(gamma_init=50.0, interval_s=5.0, min_samples=100)
+        for _ in range(200):
+            ctl.record(1.0)
+        self.assertIsNone(ctl.maybe_update(now=1.0))
+        self.assertIsNotNone(ctl.maybe_update(now=10.0))
+
+    def test_no_update_below_min_samples(self):
+        ctl = GammaAdaController(gamma_init=50.0, interval_s=0.0, min_samples=200)
+        for _ in range(199):
+            ctl.record(1.0)
+        self.assertIsNone(ctl.maybe_update(now=1.0))
+
+    def test_heavy_tail_lowers_gamma(self):
+        ctl = GammaAdaController(
+            gamma_init=100.0,
+            gamma_min=1.0,
+            gamma_max=200.0,
+            interval_s=0.0,
+            min_samples=100,
+        )
+        rng = random.Random(0)
+        for i in range(1000):
+            ctl.record(1.0 + (100.0 if i % 33 == 0 else rng.uniform(0, 0.05)))
+        drive(ctl)
+        self.assertLess(ctl.gamma, 20.0)
+        self.assertGreaterEqual(ctl.gamma, ctl.gamma_min)
+
+    def test_light_tail_raises_gamma(self):
+        ctl = GammaAdaController(
+            gamma_init=20.0,
+            gamma_min=1.0,
+            gamma_max=200.0,
+            interval_s=0.0,
+            min_samples=100,
+        )
+        rng = random.Random(1)
+        for _ in range(1000):
+            ctl.record(1.0 + rng.uniform(0, 0.02))
+        drive(ctl)
+        self.assertGreater(ctl.gamma, 150.0)
+        self.assertLessEqual(ctl.gamma, ctl.gamma_max)
+
+    def test_gamma_stays_positive_and_bounded(self):
+        ctl = GammaAdaController(
+            gamma_init=1.0,
+            gamma_min=1.0,
+            gamma_max=200.0,
+            interval_s=0.0,
+            min_samples=10,
+        )
+        for _ in range(100):
+            ctl.record(1e6)
+        for k in range(50):
+            g = ctl.maybe_update(now=k + 1)
+            if g is not None:
+                self.assertGreater(g, 0.0)
+                self.assertGreaterEqual(g, ctl.gamma_min)
+                self.assertLessEqual(g, ctl.gamma_max)
+
+    def test_gamma_min_clamped_strictly_positive(self):
+        # b_gamma divides by gamma, so a 0 gamma_min must be clamped away.
+        ctl = GammaAdaController(gamma_init=0.0, gamma_min=0.0, gamma_max=10.0)
+        self.assertGreater(ctl.gamma_min, 0.0)
+        self.assertGreater(ctl.gamma, 0.0)
+
+
+class TestGammaAdaAsyncController(CustomTestCase):
+    def test_refit_runs_on_daemon_thread(self):
+        ctl = GammaAdaController(
+            gamma_init=100.0,
+            gamma_min=1.0,
+            gamma_max=200.0,
+            interval_s=0.05,
+            min_samples=50,
+            window=1000,
+        )
+        self.addCleanup(ctl.stop)
+        rng = random.Random(2)
+        for i in range(500):
+            ctl.record(1.0 + (100.0 if i % 25 == 0 else rng.uniform(0, 0.05)))
+        before = threading.active_count()
+        ctl.start()
+        t1 = ctl._thread
+        self.assertIsNotNone(t1)
+        self.assertTrue(t1.daemon)
+        self.assertTrue(t1.is_alive())
+        # Idempotent start: no second thread.
+        ctl.start()
+        self.assertIs(ctl._thread, t1)
+        self.assertEqual(threading.active_count(), before + 1)
+        self.assertTrue(wait_until(lambda: ctl.refit_count >= 3), ctl.refit_count)
+        # Heavy tail: gamma driven down, always within bounds.
+        self.assertLess(ctl.gamma, 100.0)
+        self.assertGreaterEqual(ctl.gamma, ctl.gamma_min)
+        self.assertLessEqual(ctl.gamma, ctl.gamma_max)
+        # Keep recording while the thread refits (lock-free append vs scan).
+        for _ in range(2000):
+            ctl.record(1.0 + rng.uniform(0, 0.05))
+        self.assertTrue(wait_until(lambda: ctl.refit_count >= 6))
+        self.assertGreaterEqual(ctl.gamma, ctl.gamma_min)
+        self.assertLessEqual(ctl.gamma, ctl.gamma_max)
+        ctl.stop()
+        self.assertFalse(t1.is_alive())
+
+    def test_thread_never_refits_without_samples(self):
+        ctl = GammaAdaController(gamma_init=42.0, interval_s=0.02, min_samples=10)
+        self.addCleanup(ctl.stop)
+        ctl.start()
+        time.sleep(0.3)
+        self.assertEqual(ctl.refit_count, 0)
+        self.assertEqual(ctl.gamma, 42.0)
+
+    def test_zero_interval_does_not_busy_loop(self):
+        # interval_s=0 must fall back to a short sleep cadence, still refit,
+        # and stay bounded.
+        ctl = GammaAdaController(gamma_init=50.0, interval_s=0.0, min_samples=5)
+        self.addCleanup(ctl.stop)
+        for _ in range(50):
+            ctl.record(1.0)
+        ctl.start()
+        self.assertTrue(wait_until(lambda: ctl.refit_count >= 2))
+        self.assertGreaterEqual(ctl.gamma, ctl.gamma_min)
+        self.assertLessEqual(ctl.gamma, ctl.gamma_max)
+
+
+class TestUniboostOrdering(UniboostTestBase):
+    def setUp(self):
+        self.pol = make_policy()
+        self.assertEqual(self.pol.policy, CacheAwarePolicy.UNIBOOST)
+        self.assertEqual(self.pol.uniboost_gamma, 10.0)
+        # Note: 0.0 arrival means "unset" in sglang time stats (the sort falls
+        # back to the current clock), so keep mock arrivals strictly positive.
+        self.t0 = 10000.0
+
+    def rids_after_sort(self, q):
+        self.pol.calc_priority(q)
+        return [r.rid for r in q]
+
+    def test_short_job_jumps_ahead_at_same_arrival(self):
+        q = [FakeReq("long", 20000, self.t0), FakeReq("short", 100, self.t0)]
+        self.assertEqual(self.rids_after_sort(q), ["short", "long"])
+
+    def test_equal_work_preserves_fcfs(self):
+        a = FakeReq("first", 5000, self.t0)
+        b = FakeReq("second", 5000, self.t0 + 0.5)
+        self.assertEqual(self.rids_after_sort([b, a]), ["first", "second"])
+
+    def test_anti_starvation(self):
+        # A much older long job stays ahead of a fresh short job: the boost is
+        # bounded, so age eventually dominates.
+        old_long = FakeReq("old_long", 20000, self.t0 - 1000.0)
+        new_short = FakeReq("new_short", 100, self.t0)
+        self.assertEqual(
+            self.rids_after_sort([new_short, old_long]), ["old_long", "new_short"]
+        )
+
+    def test_cache_aware_effective_work(self):
+        # A mostly-cached long prompt counts as short work.
+        cold = FakeReq("cold", 20000, self.t0)
+        hot = FakeReq("hot", 20000, self.t0, cached=19900)
+        self.assertEqual(self.rids_after_sort([cold, hot]), ["hot", "cold"])
+
+    def test_boost_value_decreasing_and_bounded(self):
+        b1 = self.pol._uniboost_boost_value(10)
+        b2 = self.pol._uniboost_boost_value(1000)
+        b3 = self.pol._uniboost_boost_value(100000)
+        self.assertGreater(b1, b2)
+        self.assertGreater(b2, b3)
+        self.assertGreaterEqual(b3, 0.0)
+        self.assertEqual(self.pol._uniboost_boost_value(0), 1e9)
+
+
+class TestUniboostFallbacks(UniboostTestBase):
+    def test_fcfs_policy_unaffected(self):
+        pol = make_policy("fcfs")
+        self.assertEqual(pol.policy, CacheAgnosticPolicy.FCFS)
+        a = FakeReq("a", 10, 1.0)
+        b = FakeReq("b", 10, 2.0)
+        q = [a, b]
+        pol.calc_priority(q)
+        self.assertEqual([r.rid for r in q], ["a", "b"])
+
+    def test_tp_gating(self):
+        fake_args = SimpleNamespace(tp_size=2)
+        with patch(
+            "sglang.srt.managers.schedule_policy.get_global_server_args",
+            return_value=fake_args,
+        ):
+            pol = make_policy()
+            self.assertEqual(pol.policy, CacheAgnosticPolicy.FCFS)
+
+            with envs.SGLANG_UNIBOOST_ALLOW_TP.override(True):
+                pol = make_policy()
+                self.assertEqual(pol.policy, CacheAwarePolicy.UNIBOOST)
+
+    def test_gamma_zero_falls_back_to_fcfs(self):
+        with envs.SGLANG_UNIBOOST_GAMMA.override(0.0):
+            pol = make_policy()
+            self.assertEqual(pol.policy, CacheAgnosticPolicy.FCFS)
+
+    def test_disabled_tree_cache_keeps_uniboost(self):
+        # The tree-cache-disabled carve-out: uniboost still runs (all prompt
+        # tokens count as uncached), unlike lpm/dfs-weight which fall to FCFS.
+        self.assertEqual(make_policy().policy, CacheAwarePolicy.UNIBOOST)
+        self.assertEqual(make_policy("lpm").policy, CacheAgnosticPolicy.FCFS)
+
+
+class TestGammaAdaWiring(UniboostTestBase):
+    def make_ada_policy(self):
+        with envs.SGLANG_UNIBOOST_GAMMA_ADA.override(True):
+            pol = make_policy()
+        self.assertIsNotNone(pol.uniboost_gamma_controller)
+        self.addCleanup(pol.uniboost_gamma_controller.stop)
+        return pol
+
+    def test_calc_priority_only_reads_gamma(self):
+        pol = self.make_ada_policy()
+        ctl = pol.uniboost_gamma_controller
+        # The controller thread was started by _init_uniboost.
+        self.assertIsNotNone(ctl._thread)
+        self.assertTrue(ctl._thread.is_alive())
+        self.assertTrue(ctl._thread.daemon)
+
+        # calc_priority must not refit: it only reads controller.gamma.
+        ctl.gamma = 123.0  # pretend the refit thread updated it
+        q = [FakeReq("a", 100, 10.0), FakeReq("b", 200, 10.0)]
+        n_refits = ctl.refit_count
+        pol.calc_priority(q)
+        self.assertEqual(pol.uniboost_gamma, 123.0)
+        self.assertEqual(ctl.refit_count, n_refits)
+
+    def test_recording_hook(self):
+        pol = self.make_ada_policy()
+        ctl = pol.uniboost_gamma_controller
+
+        done = FakeReq("done", 10, 5.0, finished=True, completion_time=8.5)
+        aborted = FakeReq(
+            "aborted",
+            10,
+            5.0,
+            finished=True,
+            finished_reason=FINISH_ABORT(),
+            completion_time=6.0,
+        )
+        pending = FakeReq("pending", 10, 5.0, finished=False)
+
+        pol.uniboost_record_finished([done, aborted, pending])
+        self.assertEqual(list(ctl._samples), [3.5])
+
+        # Double-record guard.
+        pol.uniboost_record_finished([done])
+        self.assertEqual(len(ctl._samples), 1)
+
+    def test_env_knob_defaults_land_on_controller(self):
+        ctl = self.make_ada_policy().uniboost_gamma_controller
+        self.assertEqual(ctl.gamma_min, 1.0)
+        self.assertEqual(ctl.gamma_max, 200.0)
+        self.assertEqual(ctl.interval_s, 5.0)
+        self.assertEqual(ctl.min_samples, 200)
+        self.assertAlmostEqual(ctl.beta, 0.3)
+        self.assertEqual(ctl.tail_sensitivity, 4.0)
+
+    def test_recording_noop_without_gamma_ada(self):
+        # Without gamma-Ada the scheduler hook must be a clean no-op.
+        pol = make_policy()
+        self.assertIsNone(pol.uniboost_gamma_controller)
+        done = FakeReq("done", 10, 5.0, finished=True, completion_time=8.5)
+        pol.uniboost_record_finished([done])  # must not raise
+        self.assertFalse(done.uniboost_latency_recorded)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_uniboost_policy.py
+++ b/test/registered/unit/managers/test_uniboost_policy.py
@@ -14,7 +14,10 @@ Coverage (each case guards a distinct failure mode):
   * fallback gating -- tp_size > 1 without SGLANG_UNIBOOST_ALLOW_TP,
     gamma <= 0, and the tree-cache-disabled carve-out;
   * the finished-request recording hook -- aborts excluded, each request
-    recorded once, and calc_priority never refits synchronously.
+    recorded once, and calc_priority never refits synchronously;
+  * frontier-K matching -- per pass, radix prefix matching is bounded to the
+    top-K sorted candidates (deep queues keep last-known matches), and <=0
+    restores full-queue matching.
 """
 
 import random
@@ -78,10 +81,14 @@ class FakeDisabledTreeCache:
         return False
 
 
-def make_policy(policy_name="uniboost"):
+class FakeEnabledTreeCache(FakeDisabledTreeCache):
+    disable = False
+
+
+def make_policy(policy_name="uniboost", tree_cache=None):
     return SchedulePolicy(
         policy_name,
-        FakeDisabledTreeCache(),
+        tree_cache if tree_cache is not None else FakeDisabledTreeCache(),
         enable_hierarchical_cache=False,
         enable_priority_scheduling=False,
         schedule_low_priority_values_first=False,
@@ -317,6 +324,54 @@ class TestUniboostFallbacks(UniboostTestBase):
         # tokens count as uncached), unlike lpm/dfs-weight which fall to FCFS.
         self.assertEqual(make_policy().policy, CacheAwarePolicy.UNIBOOST)
         self.assertEqual(make_policy("lpm").policy, CacheAgnosticPolicy.FCFS)
+
+
+class TestUniboostFrontierK(UniboostTestBase):
+    """Frontier-K: per-pass radix matching is bounded to the top-K candidates.
+
+    Guards the fix for the full-queue-matching scheduler tax (20-40% goodput
+    loss at 1000+ queued requests on the hybrid-mamba radix cache in
+    real-trace replay): a future diff that re-matches the whole queue per
+    pass, or that stops matching the admission frontier, turns these red.
+    """
+
+    def queue(self, n):
+        # Higher index = later arrival; equal work so FCFS order is stable.
+        return [FakeReq(f"r{i}", 1000, 100.0 + i) for i in range(n)]
+
+    def test_matching_bounded_to_top_k(self):
+        with envs.SGLANG_UNIBOOST_MATCH_TOPK.override(8):
+            pol = make_policy(tree_cache=FakeEnabledTreeCache())
+        matched = []
+        with patch(
+            "sglang.srt.managers.schedule_policy.match_prefix_for_req",
+            side_effect=lambda tc, r, **kw: matched.append(r.rid),
+        ):
+            q = self.queue(50)
+            pol.calc_priority(q)
+        self.assertEqual(len(matched), 8)
+        # The frontier is the head of the sorted queue.
+        self.assertEqual(matched, [r.rid for r in q[:8]])
+
+    def test_zero_topk_restores_full_queue_matching(self):
+        with envs.SGLANG_UNIBOOST_MATCH_TOPK.override(0):
+            pol = make_policy(tree_cache=FakeEnabledTreeCache())
+        calls = []
+        with patch.object(
+            SchedulePolicy,
+            "_compute_prefix_matches",
+            side_effect=lambda wq, policy: calls.append(len(wq)),
+        ):
+            q = self.queue(50)
+            pol.calc_priority(q)
+        self.assertEqual(calls, [50])
+
+    def test_disabled_tree_cache_never_matches(self):
+        pol = make_policy()  # disabled cache; topk default
+        with patch("sglang.srt.managers.schedule_policy.match_prefix_for_req") as m:
+            q = self.queue(20)
+            pol.calc_priority(q)
+        m.assert_not_called()
 
 
 class TestGammaAdaWiring(UniboostTestBase):

--- a/test/registered/unit/test_server_args_cli_metadata.py
+++ b/test/registered/unit/test_server_args_cli_metadata.py
@@ -111,7 +111,16 @@ class TestServerArgsMigratedCliMetadata(CustomTestCase):
         )
         self.assertEqual(
             self.actions_by_option["--schedule-policy"].choices,
-            ["lpm", "random", "fcfs", "dfs-weight", "lof", "priority", "routing-key"],
+            [
+                "lpm",
+                "random",
+                "fcfs",
+                "dfs-weight",
+                "lof",
+                "priority",
+                "routing-key",
+                "uniboost",
+            ],
         )
         self.assertEqual(
             self.actions_by_option["--load-balance-method"].choices,


### PR DESCRIPTION
## Motivation

This PR adds **UniBoost**, an opt-in tail-aware schedule policy (from *[Beyond Prediction: Tail-Aware Scheduling for LLM Inference*, ICML 2026](https://openreview.net/challenge?redirect=%2Fforum%3Fid%3DV40F5O5N85)). Before each prefill admission pass, the waiting queue is re-sorted by a soft priority. 

Agentic / RL-rollout serving is **prefill-dominated with heavy tails**: in a production SWE-agent trace we measured (7.6k requests), input length p50 is 11.8k tokens vs output p50 of ~90 (≈100:1), turns append a median of 169 tokens of tool output but p99 = 9.1k (test-log dumps), and per-request work varies by two orders of magnitude. Under FCFS, short or cache-hot prefills routinely wait behind cold 30k-token prompts, inflating P90+ latency exactly in the moderate-overload regime that RL rollout bursts create.


`Phi(i) = arrival_i − b_γ(w_i)`,  `w_i = α · uncached_tokens_i`

where the boost `b_γ(w) = (1/γ)·ln(1/(1−e^{−γw}))` is bounded, decreasing and convex: short / radix-cache-hot jobs are pulled forward, long jobs decay to their FCFS rank (bounded boost ⇒ **no starvation**), and γ interpolates FCFS (γ→∞) ↔ SJF (γ→0) **without any output-length prediction**. An optional **gamma-Ada** controller adapts γ online from the observed latency tail ratio (t99/t95). Sampling and refitting are **fully off the scheduler critical path**: completion recording is a lock-free O(1) `deque.append`, the percentile scan + EMA refit run on a daemon thread, and the scheduler hot loop only performs an atomic float read of the current γ.

## Modifications

Small, additive, and inert unless `--schedule-policy uniboost` is selected (default `fcfs` behavior is byte-identical):

- `python/sglang/srt/managers/schedule_policy.py`
  - `UNIBOOST` added to `CacheAwarePolicy` (reuses the existing `_compute_prefix_matches` radix machinery so `w_i` counts only *uncached* work);
  - `_sort_by_uniboost` / `_uniboost_priority` / `_uniboost_boost_value` (pure math);
  - `GammaAdaController`: self-contained, `__slots__`, daemon-thread refit (`start()`/`stop()`, idempotent), bounded γ ∈ [γ_min, γ_max], EMA smoothing, abort exclusion;
  - configuration via env knobs (`SGLANG_UNIBOOST_GAMMA`, `_ALPHA_US_PER_TOKEN`, `_GAMMA_ADA*`, `_TAIL_SENSITIVITY`, …) — no ServerArgs schema change.
- `python/sglang/srt/managers/scheduler.py`: one hook in `process_batch_result` recording finished-request latency (no-op unless gamma-Ada is on).
- `python/sglang/srt/server_args.py`: `"uniboost"` added to the `--schedule-policy` choices.

**Scheduler-cost bound (frontier-K):** naively re-matching radix prefixes for the whole waiting queue each pass regresses throughput at deep saturation (measured −23…−35% completions at ~1700 queued requests on a hybrid-attention model, where `match_prefix` is expensive). UniBoost therefore bounds per-pass matching to the **admission frontier**: sort on last-known match estimates (stale estimates are conservative — a cached prefix only grows while waiting, so staleness under-boosts and can never starve), then re-match only the top `SGLANG_UNIBOOST_MATCH_TOPK` candidates (default 64; ≤0 restores full matching). This restored FCFS-level throughput and kept the latency win in an A/B replay of the same trace (regression reproduced with the knob off, eliminated with it on).

**Tensor parallelism — rank-invariant mode (default under `tp_size > 1`):** TP schedulers stay in lockstep only if every rank computes the identical batch, so under TP the policy switches to inputs that are byte-identical on all ranks with zero added communication: (1) the arrival term becomes a monotonic per-scheduler sequence number (identical everywhere because the broadcast request stream is identical; scaled by `SGLANG_UNIBOOST_TP_ARRIVAL_STEP_S`) — scheduler-local `perf_counter` never enters Φ (enforced by a tripwire test); (2) gamma-Ada measures latency in **forward-step counts** (integers; valid because the tail ratio t99/t95 is scale-free) and refits every K completions instead of on a wall-clock daemon → bit-identical γ trajectories on every rank; (3) Φ is quantized (1e-4 s) with an arrival-seq tie-break so float noise can never flip a pair. Unit tests simulate two ranks with divergent injected clocks and assert identical queue orderings and `==`-equal γ series. `SGLANG_UNIBOOST_FORCE_FCFS_TP=1` remains as an escape hatch.

*Live TP validation:* tp=8 on **DeepSeek-V4-Flash** (291B MoE, `DeepseekV4ForCausalLM`, 8×B300, `flashinfer_mxfp4` MoE runner): all 8 ranks engaged the rank-invariant mode by default, and through a 400-request full-drain replay of a real Claude-Code trace (8.4 req/s offered, deep waiting queues) every rank computed **byte-identical scheduling state** — 6/6 step-clocked gamma-Ada refit tuples and 50/50 logged admission orders identical across ranks; zero NCCL timeouts/desyncs; server healthy end-to-end; 400/400 completions. Against an FCFS control on the identical replay, UniBoost+γ-Ada cut **makespan 22% (323 s vs 416 s)** and **TTFT p50 from 155 s to 36 s**. (Reproducer note: sglang's MoE auto-backend selection doesn't yet cover `DeepseekV4`, so pass `--moe-runner-backend flashinfer_mxfp4` explicitly on Blackwell.)

## Accuracy Tests

No kernel or model-forward changes — the policy only reorders *admission of waiting requests*, so per-request outputs are unchanged. Verified in an end-to-end RL setting (GRPO on SWE-Gym via a rollout framework, 912 agent sessions per run): training-vs-rollout token logprob divergence (0.052), truncated-importance-sampling ratio (0.974) and clip fraction (0.0013, lowest of all tested configs) are indistinguishable from FCFS baselines, and reward curves pairwise-track the FCFS run on the identical task/shuffle sequence.

Unit tests cover: boost monotonicity/bounds, short-before-long ordering with anti-starvation of aged long jobs, cache-hit prompts treated as short work, γ≤0 → FCFS fallback, the FORCE_FCFS_TP escape hatch, gamma-Ada refit math (heavy tail lowers γ, flat tail raises it), interval/min-sample gating, abort exclusion, double-record guard, and the async controller lifecycle (idempotent thread start, refit with zero scheduler calls, clean no-samples behavior).

## Speed Tests and Profiling

**Claude-Code-trace replay** — 24 real Claude Code sessions from `semianalysisai/cc-traces-weka-062126` (1,753 requests / 41 prefix streams; per-stream prefix-*growing* prompts so the radix cache sees authentic multi-turn extension hits; ISL ≤ 100k, OSL ≤ 2k), replayed with identical wall-clock arrivals against one Qwen3.5-4B server per GPU on a B300 node (hybrid GatedDeltaNet attention — expensive `match_prefix`, limited prefix reuse, so a real admission queue forms). **Full-drain protocol**: arrivals fire on the recorded schedule and every request runs to completion — no deadline, no cancellations (the 1-4 missing completions per row are transient client disconnects, seen on FCFS too). Throughput = completed ÷ makespan (first arrival → last completion). Two independent replicas per arm ran concurrently on separate GPUs of one node; values are replica means (± half-range shown where it matters). All values absolute; latency in seconds.

| load (req/s) | policy | completed | makespan (s) | req/s | out tok/s | e2e mean / p90 / p99 | TTFT mean / p90 |
|---|---|---|---|---|---|---|---|
| 1.72 | fcfs | 1750-1751/1753 | 1736 ±5 | 1.01 | 771 | 782 / 1196 / 1417 | 341 / 636 |
| 1.72 | γ=10 frontier-K | 1752-1753/1753 | 1735 ±18 | 1.01 | 772 | 782 / 1199 / 1417 | 336 / 642 |
| 1.72 | γ-Ada frontier-K | 1749-1751/1753 | **1714 ±32** | **1.02** | **781** | 783 / **1185 / 1402** | 341 / 646 |


Reading: both loads saturate this engine, so full-drain makespan is work-bound and **frontier-K matches FCFS throughput exactly (±2%, within replica spread) while improving latencies** — at 3.43 req/s γ=10 cuts e2e mean 974 → 942 s and TTFT mean 552 → 508 s; at 1.72 req/s γ-Ada is nominally ahead on makespan and tail percentiles. I.e., **the policy costs nothing under saturation and helps the mean/short-request experience**. The controller correctly declines to reorder when reordering cannot help. No frontier-K configuration regresses against FCFS.

**DeepSeek-V4-Flash, tp=8 (291B MoE, single server, 8×B300)** — 400-request CC-trace slice (OSL ≤ 512), full drain, offered 8.42 req/s on B300: a deeply admission-queue-bound regime with highly variable uncached prefill work. One replica per arm (sequential rounds), zero errors:

| load (req/s) | policy | completed | makespan (s) | req/s | out tok/s | e2e mean / p90 / p99 | TTFT mean / p50 / p90 |
|---|---|---|---|---|---|---|---|
| 8.42 | fcfs | 400/400 | 416 | 0.96 | 314 | 328 / 366 / 377 | 181 / 155 / 303 |
| 8.42 | uniboost γ-Ada | 400/400 | **323 (−22%)** | **1.24** | **405 (+29%)** | **262 / 303 / 316** | **95 / 36 / 262** |

Under deep queueing with expensive MoE prefill, ordering by uncached work pays directly: **makespan −22%, throughput +29%, e2e mean −20%, TTFT p50 155 → 36 s**. (Same run that provided the rank-invariance validation above.)

**In-pipeline (async GRPO rollouts, 4 engines + 4 training GPUs, 912 sessions/config, all other settings identical):** vs the same stack without uniboost — end-to-end Σ of 13 optimizer-step intervals 1773 s → **1582 s (−10.8%)**, trainer data-wait 80.9 → **64.0 s/step**, generated throughput 714 → **849 tok/GPU/s**, effective (loss-token) throughput +27%, engine radix hit-rate 93–98% (the effective-work term composes with cache-aware routing). Scheduler-side overhead of the policy itself: the hot loop adds one float read + an O(n log n) sort of the waiting queue per admission pass; refit cost is on a background thread (measured refit cadence 5 s, ≤2000-sample percentile scan).

*Benchmark provenance note:* all GPU measurements above were taken on a port of this exact logic to sglang v0.5.13 (the newest version runnable on the test cluster's kernels); this PR's code against `main` is unit-tested (33 tests, including a regression test that fails on pre-frontier-K code and two-simulated-rank TP-invariance tests) but the perf numbers should be read as evidence from the 0.5.13 port.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32332880740](https://github.com/sgl-project/sglang/actions/runs/32332880740)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32332880653](https://github.com/sgl-project/sglang/actions/runs/32332880653)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->