### PR TITLE
[mem_cache] test: ratchet the allocator and pool_host layout

### DIFF
--- a/.claude/rules/modify-component-must-read.md
+++ b/.claude/rules/modify-component-must-read.md
@@ -7,3 +7,4 @@ Before modifying the following components, read the listed skill first.
 - **Any edit to a frozen core file** (currently `python/sglang/srt/model_executor/model_runner.py`) → [`large-class-style`](../skills/large-class-style/SKILL.md)
 - **Environment variables** (adding, renaming, or reviewing any `SGLANG_*` env var, migrating a legacy `SGL_*` alias, or touching `python/sglang/srt/environ.py`) → [`env-var-conventions`](../skills/env-var-conventions/SKILL.md)
 - **Scripted runtime** (anything related to the scripted runtime) → [`scripted-runtime-notes`](../skills/scripted-runtime-notes/SKILL.md)
+- **KV-cache allocators / device pools / host pools** (adding, moving, or renaming any `BaseTokenToKVPoolAllocator`, `KVCache`, or `HostKVCache` subclass, or adding a module under `python/sglang/srt/mem_cache/`) → [`mem-cache-layout`](../skills/mem-cache-layout/SKILL.md)

--- a/.claude/skills/mem-cache-layout/SKILL.md
+++ b/.claude/skills/mem-cache-layout/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: mem-cache-layout
+description: Where KV-cache allocators, device pools, and host pools live under `python/sglang/srt/mem_cache/`, and how to name them. Use when adding, moving, or reviewing any `BaseTokenToKVPoolAllocator`, `KVCache`, or `HostKVCache` subclass, when adding a module under `mem_cache/`, or when a `test_mem_cache_layout_ratchet` failure needs fixing.
+---
+
+# mem_cache — Layout and Naming
+
+`mem_cache/` is being restructured from catch-all modules into per-family layer
+packages ([issue #25371](https://github.com/sgl-project/sglang/issues/25371)). The
+migration is incremental: `allocator/` is done, `pool_host/` is nearly done, `pool/`
+has not started. `test/registered/unit/mem_cache/test_mem_cache_layout_ratchet.py`
+enforces what has landed.
+
+Read the issue for the full target tree before starting a move. This skill covers
+what to do when *writing* code that touches the layout.
+
+## Rule 1 — File a class by its layer, not by its feature
+
+| Base class (transitive) | Layer | Home |
+|---|---|---|
+| `BaseTokenToKVPoolAllocator` | slot indexing | `mem_cache/allocator/<family>.py` |
+| `KVCache`, `BaseSWAKVPool`, `ReqToTokenPool`, `MambaPool` | device storage | `mem_cache/pool/<family>.py` |
+| `HostKVCache` | host mirror | `mem_cache/pool_host/<family>.py` |
+
+`<family>` is the attention or state family: `mha`, `mla`, `dsa`, `mamba`, `swa`,
+`hisparse`, `deepseek_v4`. A new quantization or layout variant of an existing family
+is a new *file in that family's package*, not a new class in a catch-all module.
+
+**`pool/` does not exist yet.** Until the first `pool/` PR lands, a new device-pool
+class has no correct home, so the ratchet does not demand one — but it does refuse to
+let the class land in `memory_pool.py` (Rule 3). If you need a new device pool now,
+say so in review; the resolution is usually to create the family file under `pool/`
+as part of your PR, which is also the roadmap's next step.
+
+## Rule 2 — `Allocator` means two different things
+
+- **Slot allocator** — a `BaseTokenToKVPoolAllocator` subclass. Answers "which KV
+  slots are free". Lives in `allocator/`.
+- **Host tensor allocator** — `HostTensorAllocator` and its subclasses
+  (`ShmHostTensorAllocator`, `MooncakeHostTensorAllocator`, `UMBPHostTensorAllocator`).
+  Answers "give me pinned host memory". Lives in `pool_host/common.py` and `storage/`.
+
+Never file the second kind under `allocator/`. The ratchet classifies by base class
+precisely so the name cannot mislead it — don't reintroduce the ambiguity by hand.
+
+## Rule 3 — Don't add to a module scheduled for deletion
+
+These modules are being emptied out; the ratchet freezes their class lists:
+
+```
+memory_pool.py          memory_pool_host.py      deepseek_v4_memory_pool.py
+deepseek_v4_compress_state.py                    swa_memory_pool.py
+base_swa_memory_pool.py hisparse_memory_pool.py  unified_memory_pool.py
+multi_ended_allocator.py                         mamba_checkpoint_pool.py
+dsa_cache_layer_split.py                         index_key_cache.py
+```
+
+Adding a class to any of them fails the ratchet. This is the rule that matters most in
+practice: `memory_pool.py` grew from 2257 to 5042 lines *after* the restructure was
+agreed, entirely through classes appended to a file everyone knew was being split.
+
+## Rule 4 — No new top-level modules
+
+`mem_cache/*.py` is a frozen list. A new module goes under `allocator/`, `pool/`,
+`pool_host/`, `storage/`, or another existing package. Growing the pin is allowed but
+needs a stated reason in review — that conversation is the point of the rule.
+
+## Rule 5 — Names drop affixes that don't differentiate
+
+If every file in a directory shares the role the directory already names, the affix
+carries no information.
+
+```
+pool_host/mha.py                   not  pool_host/mha_pool_host.py
+hybrid_cache/controller.py         not  hybrid_cache/hybrid_cache_controller.py
+unified_cache/components/full.py   not  unified_cache/components/full_component.py
+```
+
+Keep a role affix only where same-directory siblings have *different* roles
+(`_backend` next to `_controller`).
+
+## Rule 6 — A family is a module; a module may be a package
+
+One file per family is the default. Past ~1500 lines, the family becomes a package —
+`pool/deepseek_v4/` already is, and `pool/mha/` will be (6 classes, ~1900 lines).
+Splitting a family into a package is not a violation of "one file per family"; it is
+the same rule at the next size.
+
+## Rule 7 — Layers don't import upwards
+
+- `pool/` and `pool_host/` must not import `allocator/`, `hybrid_cache/`, or
+  `allocation.py`.
+- `pool_host/` must not import `pool/` implementation classes.
+- `allocator/` may hold a reference to the pool it allocates into; the reverse is
+  forbidden.
+- None of the three may import the construction layer (`kv_cache_configurator.py`,
+  `kv_cache_builder.py`, `cache_init_params.py`, `allocation_sizing.py`,
+  `kv_cache_dtype.py`, `kv_vmm_backing.py`). Construction depends on them.
+
+## Fixing a ratchet failure
+
+The failure message names the rule and the target file. Two shapes:
+
+- **"belongs in mem_cache/<layer>/..."** or **"is slated for deletion but gained
+  ..."** — move the code. Growing the pin instead needs an explicit reason in review.
+- **"drop it from _LEGACY_HOMES" / "shrink _TOP_LEVEL_MODULES" / "drop its
+  _SHRINKING_MODULES entry"** — you moved something; shrink the pin in the same PR.
+  Every migration PR is expected to do this, and it is how the roadmap tracks progress.
+
+## Moving code under this issue
+
+Title the PR `[mem_cache][N/N]` and state whether it is a Mechanical Move. Mechanical
+Moves must satisfy [`mechanical-refactor-verify`](../mechanical-refactor-verify/SKILL.md).
+No compatibility shims — update every importer in the same PR, the way `allocator.py`
+was deleted outright rather than left re-exporting.

--- a/test/registered/unit/mem_cache/test_mem_cache_layout_ratchet.py
+++ b/test/registered/unit/mem_cache/test_mem_cache_layout_ratchet.py
@@ -1,0 +1,380 @@
+"""Ratchet guard: the ``mem_cache`` allocator / pool / pool_host layout may only
+improve.
+
+Four pins, each shrink-only, each covering a way the layout regressed after the
+restructure was agreed:
+
+- ``_LEGACY_HOMES`` -- a class filed under the wrong layer directory.
+- ``_TOP_LEVEL_MODULES`` -- a new catch-all module at the ``mem_cache`` root.
+- ``_SHRINKING_MODULES`` -- a new class appended to a module already slated for
+  deletion, which is how ``memory_pool.py`` grew from 2257 to 5042 lines while
+  the split was in progress.
+- ``_FORBIDDEN_DEPS`` -- an import that reverses a layer boundary.
+
+Target tree and roadmap: https://github.com/sgl-project/sglang/issues/25371
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import ast
+import unittest
+from pathlib import Path
+
+import sglang.srt
+from sglang.test.test_utils import CustomTestCase
+
+_MEM_CACHE = Path(next(iter(sglang.srt.__path__))) / "mem_cache"
+_ROADMAP = "https://github.com/sgl-project/sglang/issues/25371"
+
+# A class belongs to a layer by what it inherits, never by what it is named:
+# HostTensorAllocator is named Allocator but hands out pinned host memory, not
+# KV slots, and stays in pool_host/ and storage/.
+_ROLE_ROOTS = {
+    "allocator": frozenset({"BaseTokenToKVPoolAllocator"}),
+    "pool_host": frozenset({"HostKVCache"}),
+    "pool": frozenset({"KVCache", "BaseSWAKVPool", "ReqToTokenPool", "MambaPool"}),
+}
+
+# "pool" is deliberately absent: mem_cache/pool/ does not exist yet, and an error
+# telling someone to file a class into a package nobody has created is a trap,
+# not a rule. _SHRINKING_MODULES holds the device pools until the first pool/ PR
+# lands, at which point "pool" joins this tuple and its classes move from
+# _SHRINKING_MODULES to _LEGACY_HOMES.
+_ENFORCED_ROLES = ("allocator", "pool_host")
+
+_LEGACY_HOMES = {
+    "MultiEndedAllocator": "multi_ended_allocator.py",
+    "UnifiedMambaTokenToKVPoolAllocator": "multi_ended_allocator.py",
+    "UnifiedSWATokenToKVPoolAllocator": "multi_ended_allocator.py",
+    # Landed after this pin was first written; recorded as debt, not endorsed.
+    "FloatMultiEndedAllocator": "multi_ended_allocator.py",
+    "UnifiedMambaSWATokenToKVPoolAllocator": "multi_ended_allocator.py",
+    "DeepSeekV4PagedHostPool": "memory_pool_host.py",
+    "DeepSeekV4StateHostPool": "memory_pool_host.py",
+}
+
+_TOP_LEVEL_MODULES = frozenset(
+    {
+        "allocation.py",
+        "allocation_sizing.py",
+        "base_prefix_cache.py",
+        "base_swa_memory_pool.py",
+        "cache_init_params.py",
+        "chunk_cache.py",
+        "common.py",
+        "deepseek_v4_compress_state.py",
+        "deepseek_v4_memory_pool.py",
+        "dsa_cache_layer_split.py",
+        "embedding_cache_controller.py",
+        "embedding_store.py",
+        "events.py",
+        "evict_policy.py",
+        "flush_cache.py",
+        "hicache_storage.py",
+        "hiradix_cache.py",
+        "hisparse_memory_pool.py",
+        "index_key_cache.py",
+        # Landed after this pin was first written; recorded as debt, not endorsed.
+        "kv_index_translator.py",
+        "kv_cache_builder.py",
+        "kv_cache_configurator.py",
+        "kv_cache_dtype.py",
+        "kv_vmm_backing.py",
+        "l2_transfer.py",
+        "mamba_checkpoint_pool.py",
+        "mamba_radix_cache.py",
+        "mamba_slot_fused.py",
+        "memory_pool.py",
+        "memory_pool_host.py",
+        "multi_ended_allocator.py",
+        "multimodal_cache.py",
+        "pure_swa_radix_cache.py",
+        "radix_cache.py",
+        "radix_cache_cpp.py",
+        "registry.py",
+        "swa_memory_pool.py",
+        "swa_radix_cache.py",
+        "unified_memory_pool.py",
+        "unified_radix_cache.py",
+        "utils.py",
+    }
+)
+
+# Modules the roadmap deletes outright. Their class lists are frozen so the
+# not-yet-guarded pool layer cannot keep growing inside them.
+_SHRINKING_MODULES = {
+    "memory_pool.py": frozenset(
+        {
+            "DSATokenToKVPool",
+            "HybridLinearKVPool",
+            "HybridReqToTokenPool",
+            "KVCache",
+            "KVWriteLoc",
+            "KvBufferDesc",
+            "MHATokenToKOnlyPool",
+            "MHATokenToKVPool",
+            "MHATokenToKVPoolFP4",
+            "MHATokenToKVPoolMXFP8",
+            "MLATokenToKVPool",
+            "MLATokenToKVPoolFP4",
+            "MambaPool",
+            "MiniMaxSparseKVPool",
+            "NoOpMHATokenToKVPool",
+            "PageMajorMHATokenToKVPool",
+            "ReqToTokenPool",
+        }
+    ),
+    "memory_pool_host.py": frozenset(
+        {
+            "DeepSeekV4PagedHostPool",
+            "DeepSeekV4StateHostPool",
+            "LogicalHostPool",
+        }
+    ),
+    "deepseek_v4_memory_pool.py": frozenset(
+        {
+            "DeepSeekV4IndexerPool",
+            "DeepSeekV4LayerItem",
+            "DeepSeekV4SingleKVPool",
+            "DeepSeekV4TokenToKVPool",
+            "DeepSeekV4UnifiedKVPool",
+            "HiSparseC4DevicePool",
+        }
+    ),
+    "deepseek_v4_compress_state.py": frozenset({"CompressStatePool", "KVAndScore"}),
+    "swa_memory_pool.py": frozenset({"SWAKVPool"}),
+    "base_swa_memory_pool.py": frozenset({"BaseSWAKVPool"}),
+    "hisparse_memory_pool.py": frozenset({"HiSparseDSATokenToKVPool"}),
+    "unified_memory_pool.py": frozenset(
+        {
+            "MHASubPoolSpec",
+            "MLASubPoolSpec",
+            "MambaSubPoolSpec",
+            "SubPoolSpec",
+            "UnifiedHybridLinearKVPool",
+            "UnifiedHybridReqToTokenPool",
+            "UnifiedKVPool",
+            "UnifiedMHATokenToKVPool",
+            "UnifiedMLATokenToKVPool",
+            "UnifiedMambaPool",
+            "UnifiedMambaSlotAllocator",
+            "UnifiedPoolBundle",
+            "UnifiedSWAKVPool",
+            "UnifiedSWAPoolBundle",
+        }
+    ),
+    "multi_ended_allocator.py": frozenset(
+        {
+            "MultiEndedAllocator",
+            "UnifiedMambaTokenToKVPoolAllocator",
+            "UnifiedSWATokenToKVPoolAllocator",
+            # The three below landed after this pin was first written. Recorded
+            # as debt, not endorsed -- this module gained three classes in the
+            # two weeks the pin sat unmerged, which is the drift it exists for.
+            "FloatMultiEndedAllocator",
+            "UnifiedMambaSWATokenToKVPoolAllocator",
+            "_CapacityField",
+        }
+    ),
+    "mamba_checkpoint_pool.py": frozenset(
+        {"Int8CheckpointStore", "MambaCheckpointPool"}
+    ),
+    "dsa_cache_layer_split.py": frozenset(
+        {"LayerSplitDSATokenToKVPool", "LayerSplitIndexKeyCache"}
+    ),
+    "index_key_cache.py": frozenset({"IndexKeyCache"}),
+}
+
+# Storage layers never reach back up into indexing or orchestration, and none of
+# the three reach into the construction layer that builds them.
+_CONSTRUCTION = (
+    "allocation_sizing",
+    "cache_init_params",
+    "kv_cache_builder",
+    "kv_cache_configurator",
+    "kv_cache_dtype",
+    "kv_vmm_backing",
+)
+_FORBIDDEN_DEPS = {
+    "allocator": ("allocation", "hybrid_cache") + _CONSTRUCTION,
+    "pool_host": ("allocation", "allocator", "hybrid_cache") + _CONSTRUCTION,
+    "pool": ("allocation", "allocator", "hybrid_cache") + _CONSTRUCTION,
+}
+
+
+def _modules():
+    """Relative posix path -> parsed module, for every module under mem_cache/."""
+    return {
+        path.relative_to(_MEM_CACHE).as_posix(): ast.parse(path.read_text())
+        for path in sorted(_MEM_CACHE.rglob("*.py"))
+    }
+
+
+def _base_names(node: ast.ClassDef) -> list[str]:
+    names = []
+    for base in node.bases:
+        if isinstance(base, ast.Name):
+            names.append(base.id)
+        elif isinstance(base, ast.Attribute):
+            names.append(base.attr)
+    return names
+
+
+def _class_defs(modules) -> list[tuple[str, str]]:
+    """(defining module, class name) for every module-level class.
+
+    Nested classes are skipped: MambaPool.State is part of MambaPool, not a peer
+    that could be filed anywhere else.
+    """
+    return [
+        (rel, node.name)
+        for rel, tree in sorted(modules.items())
+        for node in tree.body
+        if isinstance(node, ast.ClassDef)
+    ]
+
+
+def _bases_by_name(modules) -> dict[str, set[str]]:
+    """Class name -> union of the direct bases of every class with that name.
+
+    Bases are matched by name because resolving them properly would mean
+    resolving imports. Names do collide (three modules define TreeNode), and
+    unioning over-approximates ancestry rather than dropping all but one
+    definition -- for a guard, a false positive is a review conversation and a
+    false negative is a silent miss.
+    """
+    bases = {}
+    for rel, tree in modules.items():
+        for node in tree.body:
+            if isinstance(node, ast.ClassDef):
+                bases.setdefault(node.name, set()).update(_base_names(node))
+    return bases
+
+
+def _ancestors(name: str, bases, seen=None) -> set[str]:
+    """Transitive base names. Inheritance crosses modules, so a direct base name
+    is not enough to tell a KVCache subclass from an unrelated class."""
+    seen = seen or set()
+    found = {name}
+    for base in bases.get(name, ()):
+        if base not in seen:
+            found |= _ancestors(base, bases, seen | {base})
+    return found
+
+
+def _role(name: str, bases) -> str | None:
+    ancestry = _ancestors(name, bases)
+    for role, roots in _ROLE_ROOTS.items():
+        if ancestry & roots:
+            return role
+    return None
+
+
+def _imported_submodules(tree: ast.Module, rel: str) -> set[str]:
+    """mem_cache-relative dotted module paths this module imports."""
+    prefix = "sglang.srt.mem_cache."
+    package = rel.rsplit("/", 1)[0] if "/" in rel else ""
+    found = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            if node.level:
+                parts = package.split("/") if package else []
+                parts = parts[: len(parts) - node.level + 1]
+                target = ".".join(filter(None, parts + [node.module or ""]))
+                if target:
+                    found.add(target)
+            elif node.module and node.module.startswith(prefix):
+                found.add(node.module[len(prefix) :])
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.startswith(prefix):
+                    found.add(alias.name[len(prefix) :])
+    return found
+
+
+class TestMemCacheLayoutRatchet(CustomTestCase):
+    """See module docstring; every failure here is fixed by moving code, not by
+    growing a pin -- unless review agrees the pin should grow."""
+
+    def setUp(self):
+        self.modules = _modules()
+        self.bases = _bases_by_name(self.modules)
+
+    def test_layer_classes_live_in_their_layer_package(self):
+        for rel, name in _class_defs(self.modules):
+            role = _role(name, self.bases)
+            if role not in _ENFORCED_ROLES:
+                continue
+            if rel.startswith(f"{role}/"):
+                self.assertNotIn(
+                    name,
+                    _LEGACY_HOMES,
+                    f"{name} now lives in {rel}; drop it from _LEGACY_HOMES to "
+                    "lock in the progress.",
+                )
+                continue
+            self.assertEqual(
+                _LEGACY_HOMES.get(name),
+                rel,
+                f"{name} inherits from {sorted(_ROLE_ROOTS[role])}, so it belongs "
+                f"in mem_cache/{role}/<family>.py, not {rel}. See {_ROADMAP}.",
+            )
+
+    def test_no_new_top_level_modules(self):
+        found = {path.name for path in _MEM_CACHE.glob("*.py")}
+        added = found - _TOP_LEVEL_MODULES
+        self.assertFalse(
+            added,
+            f"new top-level mem_cache modules {sorted(added)}; file them under "
+            f"allocator/, pool/, pool_host/, or storage/ instead. Growing this "
+            f"pin needs an explicit reason in review. See {_ROADMAP}.",
+        )
+        removed = _TOP_LEVEL_MODULES - found
+        self.assertFalse(
+            removed,
+            f"{sorted(removed)} no longer exist; shrink _TOP_LEVEL_MODULES to "
+            "lock in the progress.",
+        )
+
+    def test_modules_slated_for_deletion_only_shrink(self):
+        for rel, pinned in _SHRINKING_MODULES.items():
+            tree = self.modules.get(rel)
+            if tree is None:
+                self.fail(
+                    f"{rel} is gone; drop its _SHRINKING_MODULES entry to lock in "
+                    "the progress."
+                )
+            declared = {n.name for n in tree.body if isinstance(n, ast.ClassDef)}
+            added = declared - pinned
+            self.assertFalse(
+                added,
+                f"{rel} is slated for deletion but gained {sorted(added)}; put new "
+                f"classes in their layer package. See {_ROADMAP}.",
+            )
+            removed = pinned - declared
+            self.assertFalse(
+                removed,
+                f"{rel} no longer defines {sorted(removed)}; shrink its "
+                "_SHRINKING_MODULES entry to lock in the progress.",
+            )
+
+    def test_layer_packages_do_not_import_upwards(self):
+        for rel, tree in self.modules.items():
+            layer = rel.split("/", 1)[0]
+            forbidden = _FORBIDDEN_DEPS.get(layer)
+            if forbidden is None or "/" not in rel:
+                continue
+            for imported in _imported_submodules(tree, rel):
+                head = imported.split(".", 1)[0]
+                self.assertNotIn(
+                    head,
+                    forbidden,
+                    f"{rel} imports {imported}: {layer}/ is below it and must not "
+                    f"depend on it. See {_ROADMAP}.",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Part of #25371. A directory is not a rule.

`allocator/` landed in May and `pool_host/` has been landing since June, but nothing
stops new code from ignoring them. #29678 added `multi_ended_allocator.py` — 2559
lines, 3 allocator classes — at the `mem_cache/` top level two months *after*
`allocator/` existed. And while the split was being agreed, `memory_pool.py` grew from
2257 to 5042 lines and from 11 to 17 classes.

The restructure only converges if the layout cannot regress while it is in progress.
This adds that guard, plus the skill that tells coding agents the same rules.

## Modifications

`test/registered/unit/mem_cache/test_mem_cache_layout_ratchet.py` — four shrink-only
pins, each covering one way the layout regressed:

| | Pin | Catches |
|---|---|---|
| R1 | `_LEGACY_HOMES` | a class filed under the wrong layer directory |
| R2 | `_TOP_LEVEL_MODULES` | a new catch-all module at the `mem_cache/` root |
| R3 | `_SHRINKING_MODULES` | a new class appended to a module slated for deletion |
| R4 | `_FORBIDDEN_DEPS` | an import that reverses a layer boundary |

Role is decided by **transitive base class, never by class name** — `HostTensorAllocator`
is named `Allocator` but hands out pinned host memory, not KV slots. Class names do
collide (three modules define `TreeNode`), so ancestry is unioned across same-named
definitions: over-approximating turns a collision into a review conversation, where
keeping only one definition would turn it into a silent miss.

**R1 covers `allocator/` and `pool_host/` only.** `mem_cache/pool/` does not exist yet,
and an error telling someone to file a class into a package nobody has created is a
trap, not a rule. R3 stands in for the pool layer meanwhile — it needs no target
package to exist, and it is the rule that catches the case R1 and R2 both miss: a class
appended to a file that already exists, which is exactly how `memory_pool.py` gained
`PageMajorMHATokenToKVPool`, `MHATokenToKVPoolMXFP8`, `MHATokenToKOnlyPool`,
`MiniMaxSparseKVPool` and `DSATokenToKVPool`. When the first `pool/` PR lands, `pool`
joins the enforced roles and its classes move from R3's pin into `_LEGACY_HOMES`.

Every pin also fails when it **rots** — a class that has moved, a module that is gone.
So each migration PR under #25371 shrinks a pin, and the pins double as the roadmap's
progress ledger.

R4 passes on `main` today, so it locks in a property the code already has rather than
demanding new work. Scope is `python/sglang/srt/mem_cache/` only; `hardware_backend/`
is explicitly excluded as a separate device axis.

Also adds `.claude/skills/mem-cache-layout/SKILL.md` and its trigger line in
`.claude/rules/modify-component-must-read.md`. The skill teaches; only the ratchet
blocks — human PRs never read `.claude/skills/`.

## Accuracy Test

Not applicable — no runtime code changes. The test is AST-only and reads no tensors.

## Benchmark and Profiling Results

Not applicable.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/developer_guide/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/developer_guide/benchmark_and_profiling.html).
- [x] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [x] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.

---

**Stacked on #35306** (`[mem_cache][9/N] DSAIndexerPoolHost`). The pins are generated
against a tree with that move applied. Draft until #35306 merges; landing this first
instead would only mean adding `DSAIndexerPoolHost` back to `_LEGACY_HOMES` and
`_SHRINKING_MODULES["memory_pool_host.py"]`.

### Verification

Run on a GB300 devbox against the real package (`PYTHONPATH` shadowing confirmed via
`sglang.srt.__path__`, so the test reads the working tree, not the image's copy):

```
4 passed, 16 warnings in 17.75s
```

A guard nobody has seen go red is not a guard, so all six failure paths were exercised
by injecting the violation into a scratch copy of the tree — the four rules above, plus
the two rot cases (a pinned class that moved, a pinned module that was deleted). Each
fired with an actionable message naming the target file. The `HostKVCache`-subclass
injection was additionally reproduced on the devbox and the tree restored (md5 checked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33621060344](https://github.com/sgl-project/sglang/actions/runs/33621060344)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33621060175](https://github.com/sgl-project/sglang/actions/runs/33621060175)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33621060311](https://github.com/sgl-project/sglang/actions/runs/33621060311)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->