### PR TITLE
[reasoning] Strip an echoed think-start token when streaming

### DIFF
--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -1467,6 +1467,7 @@ class CohereCommand4Detector(BaseReasoningFormatDetector):
         self._saw_text_start = False
         self._saw_text_end = False
         self._in_action_mode = False
+        self._echoed_think_start_settled = False
 
     @classmethod
     def _strip_text_markers(cls, raw: str) -> str:
@@ -1540,6 +1541,24 @@ class CohereCommand4Detector(BaseReasoningFormatDetector):
             )
         )
 
+    def _consume_echoed_think_start(self) -> bool:
+        """Drop a ``<|START_THINKING|>`` the model echoed back, once.
+
+        Returns False while the buffer is still only a prefix of the token, so
+        the caller waits instead of streaming half a marker to the client.
+        """
+        if self._echoed_think_start_settled:
+            return True
+        token = self.think_start_token + self.think_start_self_label
+        if self._buffer.startswith(token):
+            self._buffer = self._strip_leading_think_start(self._buffer)
+            self._echoed_think_start_settled = True
+            return True
+        if self._buffer and token.startswith(self._buffer):
+            return False
+        self._echoed_think_start_settled = bool(self._buffer)
+        return self._echoed_think_start_settled
+
     def parse_streaming_increment(self, new_text: str) -> StreamingParseResult:
         """Streaming parse. Custom state machine -- we don't reuse the base
         class because Cohere's "reasoning=False" path (the model emits no
@@ -1547,6 +1566,8 @@ class CohereCommand4Detector(BaseReasoningFormatDetector):
         is fundamentally incompatible with the base detector's
         ``force_reasoning`` semantics."""
         self._buffer += new_text
+        if not self._reasoning_done and not self._consume_echoed_think_start():
+            return StreamingParseResult()
         buf = self._buffer
 
         if not self._reasoning_done:

--- a/test/registered/unit/parser/test_reasoning_streaming_parity.py
+++ b/test/registered/unit/parser/test_reasoning_streaming_parity.py
@@ -1,0 +1,122 @@
+"""A reasoning detector must split reasoning from content the same way however
+the output is chunked, since chunk boundaries come from detokenization.
+
+Boundaries fall on token boundaries, and these markers are single vocabulary
+tokens, so the sample is chunked with markers kept whole -- splitting inside one
+is stricter than anything a real stream produces.
+"""
+
+import re
+from typing import List, Tuple
+
+from sglang.srt.parser.reasoning_parser import ReasoningParser
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+REASONING = "checking the answer"
+CONTENT = "Done."
+
+Parsed = Tuple[str, str]
+
+
+def _detector(kind: str):
+    return ReasoningParser(model_type=kind).detector
+
+
+def _sample(kind: str) -> Tuple[str, List[str]]:
+    """Build a valid generation for ``kind`` from the detector's own markers."""
+    d = _detector(kind)
+    start = d.think_start_token + (d.think_start_self_label or "")
+    end = d.think_end_token
+    # Cohere wraps its answer in START_TEXT/END_TEXT rather than trailing text.
+    text_start = getattr(type(d), "TEXT_START_TOKEN", None)
+    text_end = getattr(type(d), "TEXT_END_TOKEN", None)
+    tail = f"{text_start}{CONTENT}{text_end}" if text_start else CONTENT
+    text = f"{start}{REASONING}{end}{tail}"
+    return text, [m for m in (start, end, text_start, text_end) if m]
+
+
+def _oneshot(kind: str, text: str) -> Parsed:
+    r = _detector(kind).detect_and_parse(text)
+    return (r.reasoning_text or "", r.normal_text or "")
+
+
+def _streamed(kind: str, chunks: List[str]) -> Parsed:
+    d = _detector(kind)
+    reasoning = normal = ""
+    for chunk in list(chunks) + ["", ""]:
+        r = d.parse_streaming_increment(chunk)
+        reasoning += r.reasoning_text or ""
+        normal += r.normal_text or ""
+    # The serving layer flushes the detector when generation ends; without this a
+    # held-back marker suffix is never emitted.
+    r = d.finish()
+    reasoning += r.reasoning_text or ""
+    normal += r.normal_text or ""
+    return (reasoning, normal)
+
+
+def _by_token(text: str, markers: List[str]) -> List[str]:
+    """Markers whole, everything else in small pieces -- as detokenization emits."""
+    pattern = "(" + "|".join(re.escape(m) for m in markers) + ")"
+    out: List[str] = []
+    for part in [p for p in re.split(pattern, text) if p]:
+        if part in markers:
+            out.append(part)
+        else:
+            out.extend(part[i : i + 4] for i in range(0, len(part), 4))
+    return out
+
+
+class TestReasoningStreamingParity(CustomTestCase):
+    def test_token_chunking_matches_one_shot(self):
+        for kind in sorted(ReasoningParser.DetectorMap):
+            with self.subTest(parser=kind):
+                text, markers = _sample(kind)
+                self.assertEqual(
+                    _streamed(kind, _by_token(text, markers)), _oneshot(kind, text)
+                )
+
+    def test_single_chunk_matches_one_shot(self):
+        for kind in sorted(ReasoningParser.DetectorMap):
+            with self.subTest(parser=kind):
+                text, _ = _sample(kind)
+                self.assertEqual(_streamed(kind, [text]), _oneshot(kind, text))
+
+
+class TestCohereEchoedThinkStart(CustomTestCase):
+    """Cohere's chat template emits ``<|START_THINKING|>`` in the prefix, but some
+    checkpoints echo it back. It must not reach the client either way.
+    """
+
+    TEXT = (
+        "<|START_THINKING|>checking the answer<|END_THINKING|>"
+        "<|START_TEXT|>Done.<|END_TEXT|>"
+    )
+
+    MARKERS = [
+        "<|START_THINKING|>",
+        "<|END_THINKING|>",
+        "<|START_TEXT|>",
+        "<|END_TEXT|>",
+    ]
+
+    def test_echoed_marker_is_stripped_when_streaming(self):
+        self.assertEqual(
+            _streamed("cohere_command4", _by_token(self.TEXT, self.MARKERS)),
+            ("checking the answer", "Done."),
+        )
+
+    def test_marker_split_across_chunks_is_not_leaked(self):
+        head, tail = "<|START", "_THINKING|>checking the answer<|END_THINKING|>"
+        self.assertEqual(
+            _streamed("cohere_command4", [head, tail]), ("checking the answer", "")
+        )
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
> **Draft: hardening, not a reproduced failure.**
> The two parse paths genuinely disagree, and the fix is tested. But the case they
> disagree about is one I constructed. `git log -S` traces the
> `# Some checkpoints echo the START_THINKING token` comment to #26106 ("model: support
> Command A plus"), where it was written while adding the model rather than in response to
> a reported bug — so I have no evidence that any real Cohere checkpoint echoes the token.
> Leaving this as a draft rather than asking for review time on a hypothetical input.
> Happy to mark it ready if an echo is ever observed in the wild.

## Motivation

A reasoning detector has two entry points that must split reasoning from content the same
way: `detect_and_parse` sees the whole generation, `parse_streaming_increment` sees it in
pieces. Where the pieces fall is decided by detokenization, so a streaming client cannot
work around a disagreement.

`CohereCommand4Detector` disagrees with itself. Its chat template emits
`<|START_THINKING|>` in the assistant prefix, so the generated text normally begins
already inside the thinking block — but some checkpoints echo the token back.
`detect_and_parse` handles that explicitly:

```python
# Some checkpoints echo the START_THINKING token even though the
# chat template put it in the prefix; drop it if so.
think_start_text = self.think_start_token + self.think_start_self_label
if reasoning.startswith(think_start_text):
    reasoning = reasoning[len(think_start_text) :]
```

`parse_streaming_increment` had no equivalent. A streaming client got the literal
`<|START_THINKING|>` at the front of `reasoning_content`; a non-streaming client did not.

The detector's own `finish()` already strips it through `_strip_leading_think_start`, so
the concern was known — the increment path was just the one place it was missing.

## Change

Consume an echoed think-start token once, before any reasoning is emitted, reusing the
existing `_strip_leading_think_start` helper. While the buffer is still only a prefix of
the token the parse waits instead of streaming half a marker, so the fix survives the
marker arriving split across chunks.

## How it was found

I swept **all 26 registered reasoning detectors** for streaming/non-streaming agreement,
building each sample from that detector's own `think_start_token` / `think_end_token` (plus
`think_start_self_label`, and `TEXT_START_TOKEN` for Cohere's answer block). 25 agreed.

Two candidates turned out to be my harness's fault rather than the code's, which is worth
recording because it shaped the test:

- **gemma4** — its real opener is `<|channel>thought\n`, not the bare `think_start_token`;
  it has a `think_start_self_label`. With the correct marker it passes.
- **gpt-oss** — disagrees only when a chunk boundary lands *inside* `<|end|>`. That is one
  vocabulary token, so no real stream splits it.

So the test chunks on **token boundaries with markers kept whole**, which is what
detokenization produces, rather than character-by-character. Char-by-char is stricter than
reality and would encode two false requirements.

The harness also has to call `finish()`, as the serving layer does — without it a held-back
marker suffix is never flushed and every detector looks broken on truncated generations.

## Tests

`test/registered/unit/parser/test_reasoning_streaming_parity.py`:

- token-boundary chunking and single-chunk parity across all 26 registered detectors
- the Cohere echo, and the echo arriving split across two chunks

Verified the tests fail on pre-fix code (4 failed) and pass on the fix. `test/registered/unit/parser`
goes 347 → 351 passed, no regressions.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32333713672](https://github.com/sgl-project/sglang/actions/runs/32333713672)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32333713491](https://github.com/sgl-project/sglang/actions/runs/32333713491)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
