### PR TITLE
fix(security): block SafeUnpickler builtins gadget chain

### DIFF
--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -3007,6 +3007,8 @@ class SafeUnpickler(pickle.Unpickler):
         ("builtins", "eval"),
         ("builtins", "exec"),
         ("builtins", "compile"),
+        ("builtins", "__import__"),
+        ("builtins", "getattr"),
         ("os", "system"),
         ("subprocess", "Popen"),
         ("subprocess", "run"),

--- a/test/registered/unit/utils/test_safe_pickle_loads.py
+++ b/test/registered/unit/utils/test_safe_pickle_loads.py
@@ -1,0 +1,36 @@
+import pickle
+import unittest
+
+import torch
+
+from sglang.srt.utils.common import safe_pickle_loads
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestSafePickleLoads(unittest.TestCase):
+    def test_blocks_builtin_import_gadget_chain(self):
+        payload = (
+            b"cbuiltins\n__import__\n(S'os'\ntRp0\n"
+            b"cbuiltins\ngetattr\n(g0\nS'system'\ntR"
+            b"(S'touch /tmp/sglang-safe-unpickler-test-marker'\ntR."
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "Blocked unsafe class loading"):
+            safe_pickle_loads(payload)
+
+    def test_preserves_tensor_round_trip(self):
+        payload = {
+            "weights": torch.arange(4, dtype=torch.float32).reshape(2, 2),
+            "bias": torch.tensor([1.0, 2.0]),
+        }
+
+        restored = safe_pickle_loads(pickle.dumps(payload, protocol=pickle.HIGHEST_PROTOCOL))
+
+        torch.testing.assert_close(restored["weights"], payload["weights"])
+        torch.testing.assert_close(restored["bias"], payload["bias"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

The current `SafeUnpickler` hardening still allows a builtin gadget chain through `builtins.__import__` and `builtins.getattr`.

Vulnerable code path:
- `python/sglang/srt/utils/common.py`
- `SafeUnpickler.find_class()` / `DENY_CLASSES`

PoC shape:
- A crafted pickle can resolve `os.system` through `__import__('os')` and `getattr(..., 'system')`
- The payload is then accepted by `safe_pickle_loads()` before later use

This keeps the issue reachable on the current `main` branch.

## Modifications

- Add `builtins.__import__` and `builtins.getattr` to `SafeUnpickler.DENY_CLASSES`
- Add a unit test that proves the builtin gadget payload is rejected
- Add a round-trip test to confirm normal tensor dictionary payloads still load correctly

## Accuracy Tests

N/A. This change only affects unsafe pickle deserialization guards.

## Speed Tests and Profiling

N/A. The change only adds two denied builtin entries in the unpickler guard.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

Validation run:
- `pytest test/registered/unit/utils/test_safe_pickle_loads.py -q`
- `python -m py_compile python/sglang/srt/utils/common.py test/registered/unit/utils/test_safe_pickle_loads.py`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32338999679](https://github.com/sgl-project/sglang/actions/runs/32338999679)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32338999438](https://github.com/sgl-project/sglang/actions/runs/32338999438)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32338999598](https://github.com/sgl-project/sglang/actions/runs/32338999598)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->