### PR TITLE
fix(security): tighten multimodal media trust boundaries

### DIFF
--- a/python/sglang/srt/multimodal/cache/identity.py
+++ b/python/sglang/srt/multimodal/cache/identity.py
@@ -128,16 +128,20 @@ def _read_media_bytes(media: str | bytes) -> bytes:
     if isinstance(media, bytes):
         return bytes(media)
 
-    from sglang.srt.utils import get_image_bytes, image_extension_names
+    from sglang.srt.utils import (
+        get_image_bytes,
+        image_extension_names,
+        resolve_local_media_path,
+    )
 
     if media.startswith("file://"):
-        media = unquote(urlparse(media).path)
+        media = resolve_local_media_path(media)
     elif media.startswith(("http://", "https://", "data:")):
         return get_image_bytes(media)
     # ``load_image`` accepts relative local paths only by image extension.
     # Match that contract instead of probing arbitrary base64 as a filename.
     if media.lower().endswith(image_extension_names) and Path(media).is_file():
-        return Path(media).read_bytes()
+        return Path(resolve_local_media_path(media)).read_bytes()
     return get_image_bytes(media)
 
 

--- a/python/sglang/srt/multimodal/inkling/feature_extraction.py
+++ b/python/sglang/srt/multimodal/inkling/feature_extraction.py
@@ -14,6 +14,8 @@ import torch.nn.functional as F
 import torchaudio.functional as AF
 from transformers.feature_extraction_utils import BatchFeature, FeatureExtractionMixin
 
+from sglang.srt.utils.common import resolve_local_media_path
+
 
 @dataclass
 class InklingAudioEncoderParams:
@@ -40,7 +42,7 @@ def _load_audio_bytes(audio) -> bytes:
     if hasattr(audio, "read"):
         return audio.read()
     if isinstance(audio, str):
-        path = audio[len("file://") :] if audio.startswith("file://") else audio
+        path = resolve_local_media_path(audio)
         with open(path, "rb") as f:
             return f.read()
     raise TypeError(

--- a/python/sglang/srt/multimodal/inkling/image_processing.py
+++ b/python/sglang/srt/multimodal/inkling/image_processing.py
@@ -12,6 +12,8 @@ from numba import njit
 from transformers.image_processing_utils import BaseImageProcessor, BatchFeature
 from transformers.image_utils import ImageInput
 
+from sglang.srt.utils.common import resolve_local_media_path
+
 IMAGE_MEAN = np.array([0.48145466, 0.4578275, 0.40821073], dtype=np.float32)
 IMAGE_STD = np.array([0.26862954, 0.2613026, 0.2757771], dtype=np.float32)
 PAD_RAW_VALUE = np.float32(-1.0 / 255.0)
@@ -85,7 +87,7 @@ def _load_image_bytes(image) -> bytes:
                 "InklingImageProcessor received a URL/data: image; resolve it to bytes "
                 "upstream (e.g. via SGLang load_mm_data) before preprocessing."
             )
-        path = image[len("file://") :] if image.startswith("file://") else image
+        path = resolve_local_media_path(image)
         with open(path, "rb") as f:
             return f.read()
 

--- a/python/sglang/srt/multimodal/processors/mimo_v2.py
+++ b/python/sglang/srt/multimodal/processors/mimo_v2.py
@@ -41,7 +41,7 @@ from sglang.srt.multimodal.processors.mimo_audio import (
 from sglang.srt.multimodal.processors.qwen_vl import smart_nframes
 from sglang.srt.runtime_context import get_device
 from sglang.srt.utils import ImageData, VideoData
-from sglang.srt.utils.common import download_remote_media
+from sglang.srt.utils.common import download_remote_media, resolve_local_media_path
 from sglang.utils import logger
 
 
@@ -505,7 +505,7 @@ class MiMoProcessor:
         ):
             source = BytesIO(base64.b64decode(path_or_data.split(";base64,")[1]))
         else:
-            source = path_or_data  # local path or file://
+            source = resolve_local_media_path(path_or_data)
         try:
             AudioDecoder(source)
             return True
@@ -1453,7 +1453,7 @@ class MiMoProcessor:
                 with BytesIO(download_remote_media(image, timeout=3)) as bio:
                     image_obj = copy.deepcopy(Image.open(bio))
             elif image.startswith("file://"):
-                image_obj = Image.open(image[7:])
+                image_obj = Image.open(resolve_local_media_path(image))
             elif image.startswith("data:image"):
                 if "base64," in image:
                     _, base64_data = image.split("base64,", 1)
@@ -1461,7 +1461,7 @@ class MiMoProcessor:
                     with BytesIO(data) as bio:
                         image_obj = copy.deepcopy(Image.open(bio))
             else:
-                image_obj = Image.open(image)
+                image_obj = Image.open(resolve_local_media_path(image))
         else:
             image_obj = Image.open(BytesIO(image))
         if image_obj is None:

--- a/python/sglang/srt/multimodal/processors/moss_vl.py
+++ b/python/sglang/srt/multimodal/processors/moss_vl.py
@@ -20,7 +20,7 @@ from sglang.srt.multimodal.processors.base_processor import (
 from sglang.srt.multimodal.processors.base_processor import (
     MultimodalSpecialTokens,
 )
-from sglang.srt.utils.common import download_remote_media
+from sglang.srt.utils.common import download_remote_media, resolve_local_media_path
 
 
 class MossVLImageProcessor(SGLangBaseProcessor):
@@ -419,10 +419,10 @@ class MossVLImageProcessor(SGLangBaseProcessor):
 
     def _normalize_video_string(self, value: str) -> Tuple[str, Optional[str]]:
         if value.startswith("file://"):
-            return self._resolve_file_url(value), None
+            return resolve_local_media_path(self._resolve_file_url(value)), None
 
         if os.path.isfile(value):
-            return value, None
+            return resolve_local_media_path(value), None
 
         if value.startswith(("http://", "https://")):
             timeout = int(os.getenv("REQUEST_TIMEOUT", "10"))

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2833,6 +2833,17 @@ class ServerArgs:
         "allowlist. When unset, remote media from any domain is allowed.",
         NS("mm"),
     ] = dataclasses.field(default_factory=list)
+    allow_private_media_networks: A[
+        bool,
+        "Allow client-supplied HTTP(S) media URLs to resolve to non-public IP "
+        "addresses such as RFC1918, loopback, or link-local ranges.",
+        NS("mm"),
+    ] = False
+    allow_local_media_paths: A[
+        bool,
+        "Allow client-supplied file:// URIs and local filesystem media paths.",
+        NS("mm"),
+    ] = False
     media_url_max_file_size_mb: A[
         int,
         "Maximum size in MiB for one client-supplied remote media download. "
@@ -4153,6 +4164,8 @@ class ServerArgs:
         self.allowed_media_domains = configure_media_url_security(
             self.allowed_media_domains,
             self.media_url_max_file_size_mb,
+            allow_private_networks=self.allow_private_media_networks,
+            allow_local_file_paths=self.allow_local_media_paths,
         )
 
     def _handle_deprecated_args(self):

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -38,6 +38,7 @@ import re
 import resource
 import shutil
 import signal
+import socket
 import subprocess
 import sys
 import tempfile
@@ -1520,6 +1521,8 @@ _MAX_MEDIA_URL_REDIRECTS = 5
 _MEDIA_URL_REDIRECT_STATUS_CODES = {301, 302, 303, 307, 308}
 _allowed_media_domains: frozenset[str] = frozenset()
 _media_url_max_file_size_bytes = _DEFAULT_MEDIA_URL_MAX_FILE_SIZE_MB * 1024 * 1024
+_allow_private_media_networks = True
+_allow_local_media_paths = True
 
 
 def _normalize_media_domain(domain: str) -> str:
@@ -1557,6 +1560,9 @@ def _normalize_media_domain(domain: str) -> str:
 def configure_media_url_security(
     allowed_media_domains: Optional[Sequence[str]] = None,
     max_file_size_mb: int = _DEFAULT_MEDIA_URL_MAX_FILE_SIZE_MB,
+    *,
+    allow_private_networks: bool = True,
+    allow_local_file_paths: bool = True,
 ) -> list[str]:
     """Configure process-wide safeguards for client-supplied media URLs.
 
@@ -1572,9 +1578,38 @@ def configure_media_url_security(
         {_normalize_media_domain(domain) for domain in allowed_media_domains or []}
     )
     global _allowed_media_domains, _media_url_max_file_size_bytes
+    global _allow_private_media_networks, _allow_local_media_paths
     _allowed_media_domains = frozenset(normalized_domains)
     _media_url_max_file_size_bytes = max_file_size_mb * 1024 * 1024
+    _allow_private_media_networks = allow_private_networks
+    _allow_local_media_paths = allow_local_file_paths
     return normalized_domains
+
+
+def _iter_media_url_ip_addresses(parsed) -> list[ipaddress._BaseAddress]:
+    hostname = parsed.hostname
+    if hostname is None:
+        return []
+
+    try:
+        return [ipaddress.ip_address(hostname)]
+    except ValueError:
+        pass
+
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    seen: set[str] = set()
+    resolved: list[ipaddress._BaseAddress] = []
+    for family, _, _, _, sockaddr in socket.getaddrinfo(
+        hostname, port, type=socket.SOCK_STREAM
+    ):
+        if family not in (socket.AF_INET, socket.AF_INET6):
+            continue
+        ip_text = sockaddr[0].split("%", 1)[0]
+        if ip_text in seen:
+            continue
+        seen.add(ip_text)
+        resolved.append(ipaddress.ip_address(ip_text))
+    return resolved
 
 
 def _assert_media_url_allowed(url: str) -> None:
@@ -1589,6 +1624,28 @@ def _assert_media_url_allowed(url: str) -> None:
             f"Allowed domains: {sorted(_allowed_media_domains)}; "
             f"input domain: {hostname}"
         )
+
+    if not _allow_private_media_networks:
+        for address in _iter_media_url_ip_addresses(parsed):
+            if not address.is_global:
+                raise ValueError(
+                    "Media URL resolves to a non-public IP address. "
+                    f"input host: {hostname}"
+                )
+
+
+def resolve_local_media_path(path_or_uri: str) -> str:
+    resolved = (
+        unquote(urlparse(path_or_uri).path)
+        if path_or_uri.startswith("file://")
+        else path_or_uri
+    )
+    if not _allow_local_media_paths:
+        raise ValueError(
+            "Local media paths are disabled. "
+            "Enable --allow-local-media-paths only for trusted callers."
+        )
+    return resolved
 
 
 def download_remote_media(url: str, timeout: float) -> bytes:
@@ -1707,9 +1764,9 @@ def load_audio(
         timeout = int(os.getenv("REQUEST_TIMEOUT", "5"))
         source = download_remote_media(audio_file, timeout=timeout)
     elif isinstance(audio_file, str) and audio_file.startswith("file://"):
-        source = unquote(urlparse(audio_file).path)
+        source = resolve_local_media_path(audio_file)
     elif isinstance(audio_file, str):
-        source = audio_file
+        source = resolve_local_media_path(audio_file)
     else:
         raise ValueError(f"Invalid audio format: {audio_file}")
 
@@ -1884,13 +1941,16 @@ def load_image(
         image = _load_image(image_file=image_file, gpu_image_decode=gpu_image_decode)
     elif isinstance(image_file, str) and image_file.startswith("file://"):
         image = _load_image(
-            image_file=unquote(urlparse(image_file).path),
+            image_file=resolve_local_media_path(image_file),
             gpu_image_decode=gpu_image_decode,
         )
     elif isinstance(image_file, str) and image_file.lower().endswith(
         image_extension_names
     ):
-        image = _load_image(image_file=image_file, gpu_image_decode=gpu_image_decode)
+        image = _load_image(
+            image_file=resolve_local_media_path(image_file),
+            gpu_image_decode=gpu_image_decode,
+        )
     elif isinstance(image_file, str) and image_file.startswith("data:"):
         image = _load_image(image_file=image_file, gpu_image_decode=gpu_image_decode)
     elif isinstance(
@@ -1910,7 +1970,7 @@ def get_image_bytes(image_file: Union[str, bytes]) -> bytes:
         timeout = int(os.getenv("REQUEST_TIMEOUT", "3"))
         return download_remote_media(image_file, timeout=timeout)
     if image_file.startswith(("file://", "/")):
-        with open(image_file, "rb") as f:
+        with open(resolve_local_media_path(image_file), "rb") as f:
             return f.read()
     if isinstance(image_file, str) and image_file.startswith("data:"):
         _, encoded = image_file.split(",", 1)
@@ -1939,9 +1999,9 @@ def _normalize_video_input(
             _, encoded = video_file.split(",", 1)
             return pybase64.b64decode(encoded, validate=True)
         elif video_file.startswith("file://"):
-            return unquote(urlparse(video_file).path)
+            return resolve_local_media_path(video_file)
         elif os.path.isfile(unquote(urlparse(video_file).path)):
-            return video_file
+            return resolve_local_media_path(video_file)
         else:
             return pybase64.b64decode(video_file, validate=True)
     else:

--- a/test/registered/unit/multimodal/test_media_url_security.py
+++ b/test/registered/unit/multimodal/test_media_url_security.py
@@ -2,6 +2,7 @@
 
 import http.server
 import threading
+import tempfile
 import unittest
 from unittest.mock import patch
 
@@ -163,6 +164,26 @@ class TestMediaURLSecurity(unittest.TestCase):
                 r"https://evil.example\@safe.example.org/media", timeout=5
             )
 
+    def test_non_public_destinations_require_explicit_opt_in(self):
+        configure_media_url_security(
+            [], max_file_size_mb=64, allow_private_networks=False
+        )
+        for url in (
+            self._url("/media"),
+            self._url("/media", host="localhost"),
+            "http://169.254.169.254/latest/meta-data",
+        ):
+            with self.subTest(url=url):
+                with self.assertRaisesRegex(ValueError, "non-public IP"):
+                    download_remote_media(url, timeout=5)
+
+        configure_media_url_security(
+            [], max_file_size_mb=64, allow_private_networks=True
+        )
+        self.assertEqual(
+            download_remote_media(self._url("/media"), timeout=5), b"remote-media"
+        )
+
     def test_all_common_loaders_share_the_policy(self):
         blocked = ValueError("media URL domain is not allowed")
         with patch(
@@ -177,6 +198,36 @@ class TestMediaURLSecurity(unittest.TestCase):
                     with self.assertRaisesRegex(ValueError, "not allowed"):
                         loader("https://blocked.example/media")
             self.assertEqual(download.call_count, 3)
+
+    def test_local_media_paths_require_explicit_opt_in(self):
+        with tempfile.NamedTemporaryFile(suffix=".png") as image_file:
+            image_file.write(b"test-image")
+            image_file.flush()
+            local_path = image_file.name
+            file_uri = f"file://{local_path}"
+
+            configure_media_url_security(
+                [], max_file_size_mb=64, allow_local_file_paths=False
+            )
+            for loader, value in (
+                (get_image_bytes, local_path),
+                (get_image_bytes, file_uri),
+                (_normalize_video_input, local_path),
+                (_normalize_video_input, file_uri),
+                (load_audio, local_path),
+                (load_audio, file_uri),
+            ):
+                with self.subTest(loader=loader.__name__, value=value):
+                    with self.assertRaisesRegex(
+                        ValueError, "Local media paths are disabled"
+                    ):
+                        loader(value)
+
+            configure_media_url_security(
+                [], max_file_size_mb=64, allow_local_file_paths=True
+            )
+            self.assertEqual(get_image_bytes(local_path), b"test-image")
+            self.assertEqual(get_image_bytes(file_uri), b"test-image")
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/test_server_args_migration.py
+++ b/test/registered/unit/test_server_args_migration.py
@@ -87,6 +87,8 @@ class TestServerArgsAnnotatedCli(CustomTestCase):
                     "--allowed-media-domains",
                     "Media.Example.com.",
                     "127.0.0.1",
+                    "--allow-private-media-networks",
+                    "--allow-local-media-paths",
                     "--media-url-max-file-size-mb",
                     "32",
                 ]
@@ -94,6 +96,8 @@ class TestServerArgsAnnotatedCli(CustomTestCase):
             self.assertEqual(
                 sa.allowed_media_domains, ["127.0.0.1", "media.example.com"]
             )
+            self.assertTrue(sa.allow_private_media_networks)
+            self.assertTrue(sa.allow_local_media_paths)
             self.assertEqual(sa.media_url_max_file_size_mb, 32)
         finally:
             configure_media_url_security([], max_file_size_mb=64)


### PR DESCRIPTION
## Motivation

The current multimodal media guard still trusts destinations that should require explicit opt-in:

- non-public network targets reached through HTTP(S), such as `127.0.0.1` and `169.254.169.254`
- direct local file paths and `file://` URIs

Vulnerable code paths:
- `python/sglang/srt/utils/common.py`
- local file consumers under multimodal cache / processors / inkling helpers

PoC shape:
- `image_url` or `video` pointing to `http://127.0.0.1/...`
- `audio_url` pointing to `http://169.254.169.254/...`
- local media inputs such as `file:///etc/passwd` or `/etc/hosts`

This keeps SSRF and local file read reachable on the current `main` branch when multimodal media inputs are accepted from untrusted users.

## Modifications

- Add `allow_private_networks` and `allow_local_file_paths` controls to `configure_media_url_security`
- Add server flags:
  - `--allow-private-media-networks`
  - `--allow-local-media-paths`
- Default both flags to `False`
- Reject non-public resolved IP destinations unless explicitly enabled
- Route local media file access through a shared `resolve_local_media_path()` gate
- Add unit tests for blocked private-network destinations, blocked local paths, and explicit opt-in compatibility

## Accuracy Tests

N/A. This change only constrains media input trust boundaries.

## Speed Tests and Profiling

N/A. This change does not modify model forward paths.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

Validation run:
- `pytest test/registered/unit/multimodal/test_media_url_security.py -q`
- `python -m py_compile python/sglang/srt/utils/common.py python/sglang/srt/server_args.py python/sglang/srt/multimodal/cache/identity.py python/sglang/srt/multimodal/inkling/image_processing.py python/sglang/srt/multimodal/inkling/feature_extraction.py python/sglang/srt/multimodal/processors/moss_vl.py python/sglang/srt/multimodal/processors/mimo_v2.py test/registered/unit/multimodal/test_media_url_security.py test/registered/unit/test_server_args_migration.py`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32339024857](https://github.com/sgl-project/sglang/actions/runs/32339024857)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32339026764](https://github.com/sgl-project/sglang/actions/runs/32339026764)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32339024754](https://github.com/sgl-project/sglang/actions/runs/32339024754)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->