### PR TITLE
fix(security): harden diffusion orchestrator pickle loads

### DIFF
--- a/python/sglang/multimodal_gen/runtime/disaggregation/orchestrator.py
+++ b/python/sglang/multimodal_gen/runtime/disaggregation/orchestrator.py
@@ -32,6 +32,7 @@ from sglang.multimodal_gen.runtime.disaggregation.transport.protocol import (
     is_transfer_message,
 )
 from sglang.multimodal_gen.runtime.utils.common import get_zmq_socket
+from sglang.multimodal_gen.runtime.utils.common import safe_runtime_pickle_loads
 
 logger = logging.getLogger(__name__)
 
@@ -340,8 +341,8 @@ class DiffusionServer:
         payload = parts[-1]
 
         try:
-            reqs = pickle.loads(payload)
-        except (pickle.UnpicklingError, EOFError):
+            reqs = safe_runtime_pickle_loads(payload)
+        except (pickle.UnpicklingError, EOFError, RuntimeError):
             logger.warning("DiffusionServer: failed to deserialize request")
             return
 

--- a/python/sglang/multimodal_gen/runtime/utils/common.py
+++ b/python/sglang/multimodal_gen/runtime/utils/common.py
@@ -1,8 +1,10 @@
 # Copied and adapted from: https://github.com/hao-ai-lab/FastVideo
 
+import io
 import ipaddress
 import logging
 import os
+import pickle
 import platform
 import signal
 import socket
@@ -17,6 +19,58 @@ import zmq
 
 # use the native logger to avoid circular import
 logger = logging.getLogger(__name__)
+
+
+class SafeRuntimeUnpickler(pickle.Unpickler):
+    ALLOWED_MODULE_PREFIXES = {
+        "builtins.",
+        "collections.",
+        "copyreg.",
+        "functools.",
+        "itertools.",
+        "operator.",
+        "types.",
+        "weakref.",
+        "numpy.",
+        "PIL.",
+        "torch.",
+        "torch._tensor.",
+        "torch.storage.",
+        "torch.nn.parameter.",
+        "torch.autograd.function.",
+        "sglang.multimodal_gen.configs.",
+        "sglang.multimodal_gen.runtime.",
+    }
+
+    DENY_CLASSES = {
+        ("builtins", "eval"),
+        ("builtins", "exec"),
+        ("builtins", "compile"),
+        ("builtins", "__import__"),
+        ("builtins", "getattr"),
+        ("os", "system"),
+        ("subprocess", "Popen"),
+        ("subprocess", "run"),
+        ("types", "CodeType"),
+        ("types", "FunctionType"),
+    }
+
+    def find_class(self, module, name):
+        if (module, name) in self.DENY_CLASSES:
+            raise RuntimeError(f"Blocked unsafe class loading ({module}.{name})")
+        if any(
+            (module + ".").startswith(prefix) for prefix in self.ALLOWED_MODULE_PREFIXES
+        ):
+            return super().find_class(module, name)
+        raise RuntimeError(f"Blocked unsafe class loading ({module}.{name})")
+
+
+def safe_runtime_pickle_loads(data: bytes | bytearray | memoryview) -> Any:
+    if isinstance(data, (bytes, bytearray, memoryview)):
+        buf = bytes(data)
+    else:
+        buf = bytes(memoryview(data))
+    return SafeRuntimeUnpickler(io.BytesIO(buf)).load()
 
 
 def kill_process_tree(parent_pid, include_parent: bool = True, skip_pid: int = None):

--- a/python/sglang/multimodal_gen/test/unit/test_safe_runtime_pickle.py
+++ b/python/sglang/multimodal_gen/test/unit/test_safe_runtime_pickle.py
@@ -1,0 +1,39 @@
+import pickle
+import unittest
+
+from sglang.multimodal_gen.runtime.entrypoints.post_training.io_struct import (
+    UpdateWeightFromDiskReqInput,
+)
+from sglang.multimodal_gen.runtime.utils.common import safe_runtime_pickle_loads
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestSafeRuntimePickle(unittest.TestCase):
+    def test_blocks_builtin_import_gadget_chain(self):
+        payload = (
+            b"cbuiltins\n__import__\n(S'os'\ntRp0\n"
+            b"cbuiltins\ngetattr\n(g0\nS'system'\ntR"
+            b"(S'touch /tmp/sglang-safe-runtime-pickle-test-marker'\ntR."
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "Blocked unsafe class loading"):
+            safe_runtime_pickle_loads(payload)
+
+    def test_preserves_runtime_control_requests(self):
+        req = UpdateWeightFromDiskReqInput(
+            model_path="demo/model",
+            flush_cache=False,
+            target_modules=["unet"],
+        )
+
+        restored = safe_runtime_pickle_loads(
+            pickle.dumps(req, protocol=pickle.HIGHEST_PROTOCOL)
+        )
+
+        self.assertEqual(restored, req)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

The diffusion disaggregation orchestrator currently deserializes frontend payloads with raw `pickle.loads(payload)`.

Vulnerable code path:
- `python/sglang/multimodal_gen/runtime/disaggregation/orchestrator.py`

PoC shape:
- A crafted pickle sent to the frontend ROUTER socket can execute a builtin gadget chain through `__import__('os')` and `getattr(..., 'system')`

This keeps remote code execution reachable on the current `main` branch when the disaggregation frontend accepts untrusted traffic.

## Modifications

- Add `safe_runtime_pickle_loads()` in `python/sglang/multimodal_gen/runtime/utils/common.py`
- Add a runtime-scoped unpickler allowlist for expected `torch`, `numpy`, `PIL`, and `sglang.multimodal_gen` objects
- Explicitly deny common gadget entry points such as `builtins.__import__`, `builtins.getattr`, `os.system`, and `subprocess.Popen`
- Replace `pickle.loads(payload)` with `safe_runtime_pickle_loads(payload)` in the orchestrator
- Add unit tests covering both gadget rejection and a valid `UpdateWeightFromDiskReqInput` round trip

## Accuracy Tests

N/A. This change only constrains unsafe pickle deserialization on the control plane.

## Speed Tests and Profiling

N/A. The change does not affect model forward paths.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

Validation run:
- `pytest --noconftest python/sglang/multimodal_gen/test/unit/test_safe_runtime_pickle.py -q`
- `python -m py_compile python/sglang/multimodal_gen/runtime/utils/common.py python/sglang/multimodal_gen/runtime/disaggregation/orchestrator.py python/sglang/multimodal_gen/test/unit/test_safe_runtime_pickle.py`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32339057319](https://github.com/sgl-project/sglang/actions/runs/32339057319)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32339057139](https://github.com/sgl-project/sglang/actions/runs/32339057139)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32339057277](https://github.com/sgl-project/sglang/actions/runs/32339057277)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->