### PR TITLE
fix(security): load RIFE weights with weights_only

### DIFF
--- a/python/sglang/multimodal_gen/runtime/postprocess/rife_interpolator.py
+++ b/python/sglang/multimodal_gen/runtime/postprocess/rife_interpolator.py
@@ -32,6 +32,15 @@ _MODEL_CACHE: dict[str, "Model"] = {}
 _MAX_RIFE_BATCH_PAIRS = 16
 
 
+def _load_rife_state_dict(flownet_path: str) -> dict[str, torch.Tensor]:
+    state = torch.load(flownet_path, map_location="cpu", weights_only=True)
+    if not isinstance(state, dict):
+        raise ValueError(
+            f"RIFE weights must deserialize to a state_dict mapping, got {type(state)}"
+        )
+    return state
+
+
 # ---------------------------------------------------------------------------
 # Vendored RIFE 4.22.lite model code
 # (IFBlock, IFNet_HDv3 backbone, Model wrapper)
@@ -300,7 +309,7 @@ class Model:
             else:
                 return {k: v for k, v in param.items() if "module." not in k}
 
-        state = torch.load(flownet_path, map_location="cpu", weights_only=False)
+        state = _load_rife_state_dict(flownet_path)
         self.flownet.load_state_dict(convert(state), strict=False)
         logger.info("Loaded RIFE weights from %s", flownet_path)
 

--- a/python/sglang/multimodal_gen/test/unit/test_rife_safe_load.py
+++ b/python/sglang/multimodal_gen/test/unit/test_rife_safe_load.py
@@ -1,0 +1,47 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+import torch
+
+from sglang.multimodal_gen.runtime.postprocess.rife_interpolator import (
+    _load_rife_state_dict,
+)
+
+
+class _UnsafePayload:
+    def __reduce__(self):
+        return (eval, ("1 + 1",))
+
+
+class TestRifeSafeLoad(unittest.TestCase):
+    def test_loads_plain_state_dict_with_weights_only(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "flownet.pkl"
+            expected = {"module.weight": torch.arange(4, dtype=torch.float32)}
+            torch.save(expected, path)
+
+            restored = _load_rife_state_dict(str(path))
+
+            self.assertEqual(restored.keys(), expected.keys())
+            torch.testing.assert_close(restored["module.weight"], expected["module.weight"])
+
+    def test_rejects_unsafe_pickle_payloads(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "flownet.pkl"
+            torch.save(_UnsafePayload(), path)
+
+            with self.assertRaises(Exception):
+                _load_rife_state_dict(str(path))
+
+    def test_rejects_non_mapping_payloads(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "flownet.pkl"
+            torch.save(torch.arange(4, dtype=torch.float32), path)
+
+            with self.assertRaisesRegex(ValueError, "state_dict mapping"):
+                _load_rife_state_dict(str(path))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

The RIFE interpolator currently loads `flownet.pkl` with `torch.load(..., weights_only=False)`.

Vulnerable code path:
- `python/sglang/multimodal_gen/runtime/postprocess/rife_interpolator.py`

PoC shape:
- A malicious checkpoint serialized with `torch.save` can execute pickle payloads when `frame_interpolation_model_path` points to attacker-controlled content

This keeps checkpoint-triggered code execution reachable on the current `main` branch.

## Modifications

- Add `_load_rife_state_dict()` to load checkpoints with `weights_only=True`
- Reject non-mapping payloads before they reach `load_state_dict`
- Keep normal state-dict loading behavior intact for valid RIFE weights
- Add unit tests for valid state-dict loading, unsafe pickle rejection, and non-mapping payload rejection

## Accuracy Tests

N/A. This change only affects checkpoint loading safety.

## Speed Tests and Profiling

N/A. The change does not affect inference kernels or forward logic.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

Validation run:
- `pytest --noconftest python/sglang/multimodal_gen/test/unit/test_rife_safe_load.py -q`
- `python -m py_compile python/sglang/multimodal_gen/runtime/postprocess/rife_interpolator.py python/sglang/multimodal_gen/test/unit/test_rife_safe_load.py`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32339082231](https://github.com/sgl-project/sglang/actions/runs/32339082231)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32339081730](https://github.com/sgl-project/sglang/actions/runs/32339081730)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32339082160](https://github.com/sgl-project/sglang/actions/runs/32339082160)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->