### PR TITLE
[Docs] Note the asymmetric-K/V `fa4` default in the Blackwell MHA selection guide

### DIFF
--- a/docs/docs/advanced_features/attention_backend.mdx
+++ b/docs/docs/advanced_features/attention_backend.mdx
@@ -525,7 +525,7 @@ If the `--attention-backend` argument is not specified, SGLang automatically sel
 
 **1. MHA Models (e.g., Llama, Qwen)**
 - **Hopper (e.g., H100, H200)**: Defaults to `fa3` if using CUDA 12.3+ and the model configuration is supported.
-- **Blackwell (e.g., B200)**: Defaults to `trtllm_mha`, unless using speculative decoding with `topk > 1`.
+- **Blackwell (e.g., B200)**: Defaults to `trtllm_mha`, unless using speculative decoding with `topk > 1`. On the SM100/SM103 branch that otherwise selects `trtllm_mha`, models with asymmetric K/V row widths (e.g., MiMoV2, 192 / 128) use `fa4` instead.
 - **Other Architectures (Ampere, Ada, etc.)**: Defaults to `flashinfer` if available; otherwise falls back to `triton`.
 
 **2. MLA Models (e.g., DeepSeek V3)**


### PR DESCRIPTION
### What

The CUDA attention-backend selection guide says Blackwell MHA models default to `trtllm_mha`, with speculative decoding (`topk > 1`) as the only caveat. Since #32818, on the SM100/SM103 branch that otherwise selects `trtllm_mha`, models with asymmetric K/V row widths use `fa4` instead, because `trtllm_mha` requires equal K/V row widths. #32818 updated the MiMo-V2.5 cookbook page but not this selection guide, so a user reading the guide for an asymmetric-K/V model expects the wrong backend on that path.

### Verification

Checked against `sgl-project/sglang` at `d287880a`:

- `python/sglang/srt/server_args.py#L5937-L5949` — inside the SM100 Blackwell MHA branch (gated by `is_sm100_supported()` and the speculative-decoding guards), `if model_config.has_asymmetric_kv: return "fa4"` precedes `return "trtllm_mha"`; the inline comment states the K/V row-width constraint.
- `python/sglang/srt/configs/model_config.py#L790` — `has_asymmetric_kv` is `head_dim != v_head_dim or swa_head_dim != swa_v_head_dim`, with MiMoV2's 192 / 128 named in the docstring.

Both are one-grep checks; the whole claim verifies in about 15 seconds.

### Scope

Docs-only. 1 file, 1 changed line (`docs/docs/advanced_features/attention_backend.mdx`). No `python/`, `test/`, `scripts/`, or `.github/` path is touched.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32341341684](https://github.com/sgl-project/sglang/actions/runs/32341341684)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32341341473](https://github.com/sgl-project/sglang/actions/runs/32341341473)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->