### PR TITLE
[MiniMax-M3] Add FlashInfer TRTLLM-GEN block-sparse decode attention

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1409,6 +1409,10 @@ class Envs:
     # ===================================================================
     SGLANG_OPT_USE_BF16_ROUTER_GEMM = EnvBool(True)
     SGLANG_OPT_USE_MINIMAX_DENSE_SPARSE_DECODE = EnvBool(False)
+    # Experimental MiniMax-M3 decode step-3 replacement using FlashInfer's
+    # TRTLLM-GEN native block-sparse attention (flashinfer#3955). The initial
+    # integration targets TP configurations with one local index/KV head.
+    SGLANG_OPT_USE_MINIMAX_TRTLLM_SPARSE_DECODE = EnvBool(False)
     SGLANG_DISABLE_MSA = EnvBool(False)
     SGLANG_OPT_USE_MSA_DECODE_UNDER_GRAPH = EnvBool(False)
     # Kill switch for the derived fp8 attention-GEMM mode (m3_fp8_attn_gemm_enabled):

--- a/python/sglang/srt/layers/attention/minimax_sparse_backend.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_backend.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import logging
 import os
 from types import SimpleNamespace
@@ -21,7 +22,7 @@ from sglang.srt.layers.attention.base_attn_backend import (
 from sglang.srt.mem_cache.memory_pool import MiniMaxSparseKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.server_args import m3_fp8_attn_gemm_enabled
-from sglang.srt.utils import is_npu
+from sglang.srt.utils import is_cuda, is_npu
 
 if is_npu():
     from sglang.kernels.ops.attention.minimax_sparse.common.index import (
@@ -49,6 +50,51 @@ if TYPE_CHECKING:
     from sglang.srt.model_executor.model_runner import ModelRunner
 
 logger = logging.getLogger(__name__)
+
+_MINIMAX_TRTLLM_SPARSE_WORKSPACE_BYTES = 256 * 1024 * 1024
+_MINIMAX_FUSED_TOPK_MAX_BLOCKS = 4096
+_MINIMAX_TRTLLM_SPARSE_REQUIRED_PARAMS = frozenset(
+    {
+        "backend",
+        "enable_block_sparse_attention",
+        "multi_ctas_kv_counter_buffer",
+        "out_dtype",
+        "q_len_per_req",
+    }
+)
+
+
+def _load_trtllm_sparse_decode_api():
+    """Load and validate FlashInfer's TRTLLM-GEN block-sparse decode API."""
+    try:
+        from flashinfer.decode import trtllm_batch_decode_with_kv_cache
+    except Exception as err:
+        raise RuntimeError(
+            "MiniMax-M3 TRTLLM sparse decode requires FlashInfer >= 0.6.17"
+        ) from err
+
+    parameters = inspect.signature(trtllm_batch_decode_with_kv_cache).parameters
+    missing = _MINIMAX_TRTLLM_SPARSE_REQUIRED_PARAMS.difference(parameters)
+    if missing:
+        raise RuntimeError(
+            "Installed FlashInfer does not expose TRTLLM-GEN block-sparse "
+            f"decode parameters {sorted(missing)}. Install matching "
+            "flashinfer-python/cubin/jit-cache 0.6.17 packages."
+        )
+    return trtllm_batch_decode_with_kv_cache
+
+
+def _positive_python_scale(value: Optional[float], name: str) -> float:
+    """Resolve a graph-stable per-tensor descale stored as a Python scalar."""
+    if value is None:
+        return 1.0
+    if isinstance(value, torch.Tensor):
+        raise TypeError(
+            f"MiniMax-M3 TRTLLM sparse decode requires {name} to be a Python "
+            "scalar, not a Tensor"
+        )
+    scale = float(value)
+    return scale if scale > 0.0 else 1.0
 
 
 def _kv_cache_to_bnsd(
@@ -231,14 +277,99 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
             self._msa_cg: dict[int, tuple] = {}
 
         self.page_size = self.kv_pool.page_size
+        self.model_dtype = runner.dtype
+        dense_sparse_decode_requested = (
+            envs.SGLANG_OPT_USE_MINIMAX_DENSE_SPARSE_DECODE.get()
+        )
+        trtllm_sparse_decode_requested = (
+            envs.SGLANG_OPT_USE_MINIMAX_TRTLLM_SPARSE_DECODE.get()
+        )
+        if dense_sparse_decode_requested and trtllm_sparse_decode_requested:
+            raise ValueError(
+                "SGLANG_OPT_USE_MINIMAX_DENSE_SPARSE_DECODE and "
+                "SGLANG_OPT_USE_MINIMAX_TRTLLM_SPARSE_DECODE are mutually "
+                "exclusive"
+            )
+        if trtllm_sparse_decode_requested and not is_cuda():
+            raise ValueError(
+                "SGLANG_OPT_USE_MINIMAX_TRTLLM_SPARSE_DECODE is only supported "
+                "on CUDA"
+            )
+
         self.use_dense_sparse_decode = (
             (not self.is_npu)
-            and envs.SGLANG_OPT_USE_MINIMAX_DENSE_SPARSE_DECODE.get()
+            and dense_sparse_decode_requested
             and self.block_size_k % self.page_size == 0
             # _dense_sparse_main_decode calls trtllm decode with a bf16 q and
             # unit bmm scales — no fp8 handling yet (follow-up).
             and not self.fp8_attn_gemm
         )
+        self.use_trtllm_sparse_decode = False
+        self._trtllm_sparse_decode_fn = None
+        self._trtllm_sparse_workspace: Optional[torch.Tensor] = None
+        self._trtllm_sparse_multi_ctas_kv_counter_buffer: Optional[torch.Tensor] = None
+        if trtllm_sparse_decode_requested:
+            from sglang.srt.runtime_context import get_parallel
+
+            attn_tp_size = get_parallel().attn_tp_size
+            num_q_heads = runner.model_config.num_attention_heads // attn_tp_size
+            num_kv_heads = self.kv_pool.main_pool.head_num
+            total_idx_heads = sparse_cfg["sparse_num_index_heads"]
+            idx_head_tp_size = min(attn_tp_size, total_idx_heads)
+            num_idx_heads = total_idx_heads // idx_head_tp_size
+            capability = torch.cuda.get_device_capability(runner.device)
+            unsupported = []
+            if capability not in ((10, 0), (10, 3)):
+                unsupported.append(f"compute capability {capability}")
+            if self.block_size_k != 128 or self.page_size != 128:
+                unsupported.append(
+                    f"block/page size {self.block_size_k}/{self.page_size}"
+                )
+            if num_kv_heads != 1 or num_idx_heads != 1:
+                unsupported.append(
+                    "local KV/index heads "
+                    f"{num_kv_heads}/{num_idx_heads} (expected 1/1)"
+                )
+            if num_q_heads <= num_kv_heads:
+                unsupported.append(
+                    "local Q/KV heads "
+                    f"{num_q_heads}/{num_kv_heads} "
+                    "(TRTLLM-GEN block-sparse decode requires GQA)"
+                )
+            if self.kv_pool.main_pool.head_dim != 128:
+                unsupported.append(
+                    f"head dim {self.kv_pool.main_pool.head_dim} (expected 128)"
+                )
+            if self.topk_blocks > 64:
+                unsupported.append(f"top-k {self.topk_blocks} (> 64)")
+            main_kv_dtype = self.kv_pool.main_pool.dtype
+            if main_kv_dtype not in (torch.bfloat16, torch.float8_e4m3fn):
+                unsupported.append(f"KV dtype {main_kv_dtype}")
+            if main_kv_dtype == torch.float8_e4m3fn and not self.fp8_attn_gemm:
+                unsupported.append("FP8 KV cache without FP8 attention-GEMM mode")
+            if self.model_dtype != torch.bfloat16:
+                unsupported.append(
+                    f"model/output dtype {self.model_dtype} (expected bfloat16)"
+                )
+            if unsupported:
+                raise ValueError(
+                    "MiniMax-M3 TRTLLM sparse decode was requested but this "
+                    "configuration is unsupported: " + "; ".join(unsupported)
+                )
+
+            self._trtllm_sparse_decode_fn = _load_trtllm_sparse_decode_api()
+            from sglang.srt.layers.attention.trtllm_mla_backend import (
+                make_persistent_multi_ctas_kv_counter_buffer,
+            )
+
+            self._trtllm_sparse_multi_ctas_kv_counter_buffer = (
+                make_persistent_multi_ctas_kv_counter_buffer(
+                    torch.device(runner.device),
+                    num_q_heads=runner.model_config.num_attention_heads,
+                    max_batch_size=runner.max_running_requests + 1,
+                )
+            )
+            self.use_trtllm_sparse_decode = True
         from sglang.srt.model_executor.cuda_graph_config import (
             Backend,
             Phase,
@@ -269,15 +400,25 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
                 "disable speculative decoding."
             )
         self._msa_owns_decode = self._use_msa_decode and not (
-            self.use_dense_sparse_decode and self.kv_pool.main_pool.head_num == 1
+            self.use_trtllm_sparse_decode
+            or (self.use_dense_sparse_decode and self.kv_pool.main_pool.head_num == 1)
         )
         self.dense_backend: Optional[AttentionBackend] = None
 
+        if self.use_trtllm_sparse_decode:
+            decode_attn = "flashinfer_trtllm_block_sparse"
+        elif self.use_dense_sparse_decode:
+            decode_attn = "flashinfer_trtllm_compact_dense"
+        elif self._use_msa_decode:
+            decode_attn = "MSA"
+        else:
+            decode_attn = "triton"
         logger.info(
             f"[MiniMaxSparse] Backend initialized "
             f"(score_type={self.score_type!r}, "
             f"main_attn={'MSA' if self.use_msa else 'triton'}, "
             f"msa_decode={self._use_msa_decode}, "
+            f"decode_attn={decode_attn}, "
             f"msa_owns_decode={self._msa_owns_decode}, "
             f"decode_cuda_graph={_decode_cuda_graph}, "
             f"fp8_attn_gemm={self.fp8_attn_gemm}, "
@@ -290,6 +431,40 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
                 "JIT-compile fmha_sm100 fp8 kernel variants (cold cache can "
                 "take minutes; compiles serialize across TP ranks)."
             )
+
+    def bind_dense_backend(self, dense_backend: AttentionBackend) -> None:
+        """Bind shared resources after the hybrid backend is assembled."""
+        self.dense_backend = dense_backend
+        if not self.use_trtllm_sparse_decode:
+            return
+
+        counter = self._trtllm_sparse_multi_ctas_kv_counter_buffer
+        assert counter is not None
+        workspace = getattr(dense_backend, "workspace_buffer", None)
+        workspace_bytes = (
+            workspace.numel() * workspace.element_size()
+            if isinstance(workspace, torch.Tensor)
+            else 0
+        )
+        workspace_usable = (
+            isinstance(workspace, torch.Tensor)
+            and workspace.dtype == torch.uint8
+            and workspace.device == counter.device
+            and workspace_bytes >= _MINIMAX_TRTLLM_SPARSE_WORKSPACE_BYTES
+        )
+        if not workspace_usable:
+            from sglang.srt.runtime_context import get_buffer
+
+            workspace_size = max(
+                _MINIMAX_TRTLLM_SPARSE_WORKSPACE_BYTES,
+                envs.SGLANG_FLASHINFER_WORKSPACE_SIZE.get(),
+            )
+            device = counter.device
+            workspace = get_buffer(
+                "minimax_trtllm_block_sparse_workspace",
+                lambda: torch.zeros(workspace_size, dtype=torch.uint8, device=device),
+            )
+        self._trtllm_sparse_workspace = workspace
 
     @staticmethod
     def _choose_decode_score_max_chunks(batch_size: int) -> int:
@@ -346,6 +521,16 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
             self._max_seqlen_k = self.max_context_len
         else:
             self._max_seqlen_k = int(forward_batch.seq_lens_cpu.max().item())
+        if self.use_trtllm_sparse_decode and not in_capture:
+            fused_topk_token_limit = _MINIMAX_FUSED_TOPK_MAX_BLOCKS * self.block_size_k
+            if self._max_seqlen_k > fused_topk_token_limit:
+                raise RuntimeError(
+                    "MiniMax-M3 TRTLLM sparse decode currently supports live "
+                    f"sequences up to {fused_topk_token_limit} tokens, got "
+                    f"{self._max_seqlen_k}. Disable "
+                    "SGLANG_OPT_USE_MINIMAX_TRTLLM_SPARSE_DECODE for longer "
+                    "requests."
+                )
 
         # Build plan + page table eager (outside capture) so captured forward_decode
         # runs only device-side ops; host-side code can't be captured.
@@ -1446,6 +1631,67 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
             o.reshape(original_num_tokens, -1).contiguous(),
         )
 
+    def _trtllm_sparse_main_decode(
+        self,
+        q: torch.Tensor,
+        page_table: torch.Tensor,
+        real_seq_lens: torch.Tensor,
+        k_cache: torch.Tensor,
+        v_cache: torch.Tensor,
+        layer,
+    ) -> torch.Tensor:
+        """Run MiniMax decode step 3 with native TRTLLM block sparsity."""
+        from sglang.kernels.ops.attention.utils import canonicalize_stride
+
+        run = self._trtllm_sparse_decode_fn
+        workspace = self._trtllm_sparse_workspace
+        counter = self._trtllm_sparse_multi_ctas_kv_counter_buffer
+        if run is None or workspace is None or counter is None:
+            raise RuntimeError(
+                "MiniMax-M3 TRTLLM sparse decode resources were not initialized"
+            )
+
+        batch_size = q.shape[0]
+        if page_table.shape[0] != batch_size or real_seq_lens.shape != (batch_size,):
+            raise RuntimeError(
+                "Unexpected fused sparse metadata shapes: "
+                f"page_table={tuple(page_table.shape)}, "
+                f"seq_lens={tuple(real_seq_lens.shape)}, batch={batch_size}"
+            )
+
+        head_dim = q.shape[-1]
+        k_cache_hnd = k_cache.view(-1, self.page_size, 1, head_dim).permute(0, 2, 1, 3)
+        v_cache_hnd = v_cache.view(-1, self.page_size, 1, head_dim).permute(0, 2, 1, 3)
+        k_cache_hnd = canonicalize_stride(k_cache_hnd)
+        v_cache_hnd = canonicalize_stride(v_cache_hnd)
+
+        if self.fp8_attn_gemm:
+            q_scale = _positive_python_scale(layer.q_scale_float, "q_scale")
+            k_scale = _positive_python_scale(layer.k_scale_float, "k_scale")
+            v_scale = _positive_python_scale(layer.v_scale_float, "v_scale")
+            bmm1_scale = q_scale * k_scale * layer.scaling
+            bmm2_scale = v_scale
+        else:
+            bmm1_scale = layer.scaling
+            bmm2_scale = 1.0
+
+        return run(
+            query=q,
+            kv_cache=(k_cache_hnd, v_cache_hnd),
+            workspace_buffer=workspace,
+            block_tables=page_table.view(1, batch_size, -1),
+            seq_lens=real_seq_lens.view(1, batch_size),
+            max_seq_len=self.topk_blocks * self.block_size_k,
+            bmm1_scale=bmm1_scale,
+            bmm2_scale=bmm2_scale,
+            out_dtype=self.model_dtype,
+            kv_layout="HND",
+            backend="trtllm-gen",
+            q_len_per_req=1,
+            multi_ctas_kv_counter_buffer=counter,
+            enable_block_sparse_attention=True,
+        )
+
     def _dense_sparse_main_decode(
         self,
         q: torch.Tensor,
@@ -1518,7 +1764,19 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
             idx_k_cache, idx_v_cache = self.kv_pool.get_index_kv_buffer(layer.layer_id)
 
         attn_fn = None
-        if self.use_dense_sparse_decode and k_cache.shape[1] == 1:
+        if self.use_trtllm_sparse_decode:
+
+            def attn_fn(main_q, page_table, real_seq_lens):
+                return self._trtllm_sparse_main_decode(
+                    main_q,
+                    page_table,
+                    real_seq_lens,
+                    k_cache,
+                    v_cache,
+                    layer,
+                )
+
+        elif self.use_dense_sparse_decode and k_cache.shape[1] == 1:
 
             def attn_fn(main_q, page_table, real_seq_lens):
                 return self._dense_sparse_main_decode(
@@ -1615,7 +1873,7 @@ class MiniMaxHybridAttnBackend(AttentionBackend):
         self.sparse = sparse_backend
         self.sparse_layer_ids = sparse_layer_ids
         # Let the sparse decode reuse the dense paged backend (page table + workspace).
-        self.sparse.dense_backend = dense_backend
+        self.sparse.bind_dense_backend(dense_backend)
         self.extend_dummy_seqs_capped_by_req_pool = getattr(
             dense_backend, "extend_dummy_seqs_capped_by_req_pool", False
         ) or getattr(sparse_backend, "extend_dummy_seqs_capped_by_req_pool", False)

--- a/test/registered/kernels/ops/attention/test_minimax_flashinfer_trtllm_sparse_decode.py
+++ b/test/registered/kernels/ops/attention/test_minimax_flashinfer_trtllm_sparse_decode.py
@@ -1,0 +1,180 @@
+import sys
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang.srt.layers.attention.minimax_sparse_backend import (
+    MiniMaxSparseAttnBackend,
+    _positive_python_scale,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=20, stage="base-b-kernel-unit", runner_config="4-gpu-b200")
+
+
+@pytest.mark.parametrize("fp8", [False, True])
+def test_trtllm_sparse_decode_dispatch_contract(fp8: bool):
+    backend = object.__new__(MiniMaxSparseAttnBackend)
+    backend.page_size = 128
+    backend.topk_blocks = 16
+    backend.block_size_k = 128
+    backend.model_dtype = torch.bfloat16
+    backend.fp8_attn_gemm = fp8
+    backend._trtllm_sparse_workspace = torch.empty(32, dtype=torch.uint8)
+    backend._trtllm_sparse_multi_ctas_kv_counter_buffer = torch.zeros(
+        16, dtype=torch.uint8
+    )
+
+    calls = []
+
+    def fake_decode(**kwargs):
+        calls.append(kwargs)
+        return torch.empty_like(kwargs["query"], dtype=kwargs["out_dtype"])
+
+    backend._trtllm_sparse_decode_fn = fake_decode
+
+    batch_size, num_q_heads, head_dim = 2, 16, 128
+    q_dtype = torch.float8_e4m3fn if fp8 else torch.bfloat16
+    kv_dtype = q_dtype
+    # Match MiniMax's split QKV projection: q is a strided view in BF16 mode.
+    q_storage = torch.empty((batch_size, num_q_heads, head_dim + 8), dtype=q_dtype)
+    q = q_storage[..., :head_dim]
+    assert not q.is_contiguous()
+    k_cache = torch.empty((4 * 128, 1, head_dim), dtype=kv_dtype)
+    v_cache = torch.empty_like(k_cache)
+    page_table = torch.arange(batch_size * 16, dtype=torch.int32).view(batch_size, 16)
+    seq_lens = torch.tensor([2048, 1937], dtype=torch.int32)
+    layer = SimpleNamespace(
+        scaling=head_dim**-0.5,
+        q_scale_float=0.5 if fp8 else None,
+        k_scale_float=0.25 if fp8 else None,
+        v_scale_float=0.75 if fp8 else None,
+    )
+
+    out = backend._trtllm_sparse_main_decode(
+        q, page_table, seq_lens, k_cache, v_cache, layer
+    )
+
+    assert out.shape == q.shape
+    assert out.dtype == torch.bfloat16
+    assert len(calls) == 1
+    call = calls[0]
+    assert call["query"].data_ptr() == q.data_ptr()
+    assert call["query"].stride() == q.stride()
+    assert call["enable_block_sparse_attention"] is True
+    assert call["backend"] == "trtllm-gen"
+    assert call["kv_layout"] == "HND"
+    assert call["q_len_per_req"] == 1
+    assert call["max_seq_len"] == 2048
+    assert call["block_tables"].shape == (1, batch_size, 16)
+    assert call["seq_lens"].shape == (1, batch_size)
+    assert call["block_tables"].data_ptr() == page_table.data_ptr()
+    assert call["seq_lens"].data_ptr() == seq_lens.data_ptr()
+    assert call["multi_ctas_kv_counter_buffer"] is (
+        backend._trtllm_sparse_multi_ctas_kv_counter_buffer
+    )
+    assert call["workspace_buffer"] is backend._trtllm_sparse_workspace
+
+    k_hnd, v_hnd = call["kv_cache"]
+    assert k_hnd.shape == (4, 1, 128, 128)
+    assert v_hnd.shape == k_hnd.shape
+    assert k_hnd.stride() == (128 * 128, 128 * 128, 128, 1)
+    assert v_hnd.stride() == k_hnd.stride()
+    if fp8:
+        assert call["bmm1_scale"] == pytest.approx(0.5 * 0.25 * layer.scaling)
+        assert call["bmm2_scale"] == pytest.approx(0.75)
+    else:
+        assert call["bmm1_scale"] == pytest.approx(layer.scaling)
+        assert call["bmm2_scale"] == 1.0
+
+
+def test_trtllm_sparse_decode_kernel_matches_reference():
+    flashinfer = pytest.importorskip("flashinfer")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+    if torch.cuda.get_device_capability() not in ((10, 0), (10, 3)):
+        pytest.skip("TRTLLM-GEN block-sparse decode requires SM100 or SM103")
+
+    from sglang.srt.layers.attention.trtllm_mla_backend import (
+        make_persistent_multi_ctas_kv_counter_buffer,
+    )
+
+    device = torch.device("cuda")
+    batch_size, num_q_heads, head_dim = 2, 16, 128
+    page_size, topk_blocks, num_pages = 128, 4, 8
+    torch.manual_seed(42)
+
+    backend = object.__new__(MiniMaxSparseAttnBackend)
+    backend.page_size = page_size
+    backend.topk_blocks = topk_blocks
+    backend.block_size_k = page_size
+    backend.model_dtype = torch.bfloat16
+    backend.fp8_attn_gemm = False
+    backend._trtllm_sparse_decode_fn = (
+        flashinfer.decode.trtllm_batch_decode_with_kv_cache
+    )
+    backend._trtllm_sparse_workspace = torch.empty(
+        256 * 1024 * 1024, dtype=torch.uint8, device=device
+    )
+    backend._trtllm_sparse_multi_ctas_kv_counter_buffer = (
+        make_persistent_multi_ctas_kv_counter_buffer(
+            device, num_q_heads=num_q_heads, max_batch_size=batch_size
+        )
+    )
+
+    q_storage = torch.randn(
+        batch_size,
+        num_q_heads,
+        head_dim + 8,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    q = q_storage[..., :head_dim]
+    k_cache = torch.randn(
+        num_pages * page_size, 1, head_dim, dtype=torch.bfloat16, device=device
+    )
+    v_cache = torch.randn_like(k_cache)
+    page_table = torch.tensor(
+        [[0, 2, 4, 6], [1, 3, 5, 7]], dtype=torch.int32, device=device
+    )
+    seq_lens = torch.tensor([512, 397], dtype=torch.int32, device=device)
+    layer = SimpleNamespace(
+        scaling=head_dim**-0.5,
+        q_scale_float=None,
+        k_scale_float=None,
+        v_scale_float=None,
+    )
+
+    out = backend._trtllm_sparse_main_decode(
+        q, page_table, seq_lens, k_cache, v_cache, layer
+    )
+
+    paged_k = k_cache.view(num_pages, page_size, head_dim)
+    paged_v = v_cache.view(num_pages, page_size, head_dim)
+    refs = []
+    for batch_idx in range(batch_size):
+        length = int(seq_lens[batch_idx])
+        k = paged_k[page_table[batch_idx].long()].reshape(-1, head_dim)[:length]
+        v = paged_v[page_table[batch_idx].long()].reshape(-1, head_dim)[:length]
+        scores = torch.matmul(q[batch_idx].float(), k.float().transpose(0, 1))
+        probs = torch.softmax(scores * layer.scaling, dim=-1)
+        refs.append(torch.matmul(probs, v.float()))
+    ref = torch.stack(refs)
+
+    cosine = torch.nn.functional.cosine_similarity(
+        out.float().flatten(), ref.flatten(), dim=0
+    ).item()
+    assert cosine > 0.999, f"cosine similarity: {cosine}"
+
+
+def test_positive_python_scale_is_graph_stable():
+    assert _positive_python_scale(None, "scale") == 1.0
+    assert _positive_python_scale(-1.0, "scale") == 1.0
+    assert _positive_python_scale(0.5, "scale") == 0.5
+    with pytest.raises(TypeError, match="Python scalar"):
+        _positive_python_scale(torch.tensor(0.5), "scale")
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
MiniMax-M3 sparse decode first runs the indexer and top-k selection, then executes the main sparse attention over the selected KV blocks.

  The fused top-k path already produces a compact physical page table, but the final attention step still uses the existing MSA/Triton path. FlashInfer [PR #3955](https://github.com/
  flashinfer-ai/flashinfer/pull/3955) adds native block-sparse support to the TRTLLM-GEN decode kernel, allowing the generated page table to be consumed directly.

  This PR integrates that kernel as an experimental, opt-in MiniMax-M3 decode backend. It only replaces the final sparse attention step; the indexer, top-k selection, KV cache update, and
  prefill paths remain unchanged.

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

| cc | original decode attention | new flashinfer sparse attn | improvement |
|---:|---:|---:|---:|
| 1 | 125.96 | 133.29 | +5.81% |
| 2 | 225.48 | 238.59 | +5.81% |
| 4 | 414.71 | 433.55 | +4.54% |
| 8 | 708.95 | 743.07 | +4.81% |
| 16 | 1,192.78 | 1,227.50 | +2.91% |
| 32 | 1,935.90 | 2,017.49 | +4.21% |
| 64 | 3,187.31 | 3,364.25 | +5.55% |
| 128 | 5,152.81 | 5,432.51 | +5.43% |
| 256 | 8,131.62 | 8,570.12 | +5.39% |

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32341374532](https://github.com/sgl-project/sglang/actions/runs/32341374532)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32341374418](https://github.com/sgl-project/sglang/actions/runs/32341374418)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32341374485](https://github.com/sgl-project/sglang/actions/runs/32341374485)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->