### PR TITLE
Add FlashBoot load format integration

### DIFF
--- a/docker/Dockerfile_flashboot
+++ b/docker/Dockerfile_flashboot
@@ -1,0 +1,830 @@
+ARG CUDA_VERSION=13.0.3
+FROM nvidia/cuda:${CUDA_VERSION}-cudnn-devel-ubuntu24.04 AS base
+
+ARG TARGETARCH
+ARG BUILD_TYPE=all
+ARG BRANCH_TYPE=remote
+ARG SGL_KERNEL_VERSION=0.4.6.post1
+ARG SGL_VERSION
+ARG SGL_DEEP_GEMM_VERSION=0.1.5.post2
+ARG USE_LATEST_SGLANG=0
+ARG GDRCOPY_VERSION=2.5.1
+ARG SGL_NCCL_VERSION=2.30.7
+ARG PIP_DEFAULT_INDEX
+ARG UBUNTU_MIRROR
+ARG GITHUB_ARTIFACTORY=github.com
+ARG INSTALL_FLASHINFER_JIT_CACHE=0
+ARG FLASHINFER_VERSION=0.6.17
+ARG MOONCAKE_VERSION=0.3.12.post1
+ARG MSCCLPP_VERSION=sglang-v0.9.1
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    CUDA_HOME=/usr/local/cuda \
+    GDRCOPY_HOME=/usr/src/gdrdrv-${GDRCOPY_VERSION}/ \
+    FLASHINFER_VERSION=${FLASHINFER_VERSION}
+
+# Add GKE default lib and bin locations
+ENV PATH="${PATH}:/usr/local/nvidia/bin" \
+    LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/nvidia/lib:/usr/local/nvidia/lib64"
+
+# Replace Ubuntu sources if specified
+RUN if [ -n "$UBUNTU_MIRROR" ]; then \
+    sed -i "s|http://.*archive.ubuntu.com|$UBUNTU_MIRROR|g" /etc/apt/sources.list && \
+    sed -i "s|http://.*security.ubuntu.com|$UBUNTU_MIRROR|g" /etc/apt/sources.list; \
+fi
+
+# Python setup (combined with apt update to reduce layers)
+# Ubuntu 24.04 ships Python 3.12 in main, so we no longer need the deadsnakes
+# PPA. Dropping it avoids transient Launchpad 504s in `add-apt-repository`.
+RUN --mount=type=cache,target=/var/cache/apt,id=base-apt \
+    apt update && apt install -y --no-install-recommends wget software-properties-common \
+    && apt install -y --no-install-recommends python3.12-full python3.12-dev \
+    && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 2 \
+    && update-alternatives --set python3 /usr/bin/python3.12 \
+    # Fix for apt-add-repository
+    && cd /usr/lib/python3/dist-packages/ \
+    && ln -s apt_pkg.cpython-312-*-linux-gnu.so apt_pkg.so
+
+# create virtual env for sglang to avoid conflict with system python packages
+RUN python3 -m venv /opt/sglang
+ENV PATH="/opt/sglang/bin:${PATH}"
+
+# Install system dependencies (organized by category for better caching)
+RUN --mount=type=cache,target=/var/cache/apt,id=base-apt \
+    apt-get update && apt-get install -y --no-install-recommends \
+    # Core system utilities
+    ca-certificates \
+    software-properties-common \
+    netcat-openbsd \
+    kmod \
+    unzip \
+    openssh-server \
+    curl \
+    wget \
+    lsof \
+    locales \
+    # Build essentials (needed for framework stage)
+    build-essential \
+    cmake \
+    perl \
+    patchelf \
+    ccache \
+    git-lfs \
+    # MPI and NUMA
+    libopenmpi-dev \
+    libnuma1 \
+    libnuma-dev \
+    numactl \
+    # transformers multimodal VLM
+    ffmpeg \
+    # InfiniBand/RDMA
+    libibverbs-dev \
+    libibverbs1 \
+    libibumad3 \
+    librdmacm1 \
+    libnl-3-200 \
+    libnl-route-3-200 \
+    libnl-route-3-dev \
+    libnl-3-dev \
+    ibverbs-providers \
+    infiniband-diags \
+    perftest \
+    # Development libraries
+    libgoogle-glog-dev \
+    libgtest-dev \
+    libjsoncpp-dev \
+    libunwind-dev \
+    libboost-all-dev \
+    libssl-dev \
+    libgrpc-dev \
+    libgrpc++-dev \
+    libprotobuf-dev \
+    protobuf-compiler \
+    protobuf-compiler-grpc \
+    pybind11-dev \
+    libhiredis-dev \
+    libcurl4-openssl-dev \
+    libczmq4 \
+    libczmq-dev \
+    libfabric-dev \
+    linux-libc-dev \
+    # Package building tools
+    devscripts \
+    debhelper \
+    fakeroot \
+    dkms \
+    check \
+    libsubunit0 \
+    libsubunit-dev \
+    && ln -sf /usr/bin/python3.12 /usr/bin/python \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
+
+# Replace pip global cache if specified
+RUN if [ -n "${PIP_DEFAULT_INDEX}" ]; then \
+    python3 -m pip config set global.index-url ${PIP_DEFAULT_INDEX}; \
+fi
+
+# GDRCopy installation
+RUN mkdir -p /tmp/gdrcopy && cd /tmp \
+    && curl --retry 3 --retry-delay 2 -fsSL -o v${GDRCOPY_VERSION}.tar.gz \
+        https://${GITHUB_ARTIFACTORY}/NVIDIA/gdrcopy/archive/refs/tags/v${GDRCOPY_VERSION}.tar.gz \
+    && tar -xzf v${GDRCOPY_VERSION}.tar.gz && rm v${GDRCOPY_VERSION}.tar.gz \
+    && cd gdrcopy-${GDRCOPY_VERSION}/packages \
+    && CUDA=/usr/local/cuda ./build-deb-packages.sh \
+    && dpkg -i gdrdrv-dkms_*.deb libgdrapi_*.deb gdrcopy-tests_*.deb gdrcopy_*.deb \
+    && cd / && rm -rf /tmp/gdrcopy
+
+# Fix DeepEP IBGDA symlink
+RUN ln -sf /usr/lib/$(uname -m)-linux-gnu/libmlx5.so.1 /usr/lib/$(uname -m)-linux-gnu/libmlx5.so
+
+# Set up locale
+RUN locale-gen en_US.UTF-8
+ENV LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \
+    LC_ALL=en_US.UTF-8
+
+########################################################
+########## PARALLEL BUILDER STAGES ####################
+########################################################
+#
+# These stages run IN PARALLEL via BuildKit:
+#
+#   base
+#     |
+#     +-- torch_deps ------> flashinfer_cache (needs flashinfer)
+#     |                  \-> hpc_ops_builder (cmake-only build)
+#     |
+#     +-- devtools_builder (independent)
+#     +-- gateway_builder  (independent, only needs gateway source)
+#     |
+#     v
+#   framework (combines all artifacts)
+#
+
+########################################################
+# PARALLEL STAGE 1: Torch/Deps Builder (starts from base)
+########################################################
+FROM base AS torch_deps
+
+ARG CUDA_VERSION
+ARG BUILD_TYPE
+ARG SGL_KERNEL_VERSION
+ARG GITHUB_ARTIFACTORY
+# Renamed from NCCL_VERSION: the nvidia/cuda base image sets ENV NCCL_VERSION
+# (Debian apt format, e.g. 2.28.3-1), which shadows a same-named ARG inside RUN,
+# so the CUDA-13 nvidia-nccl-cu13 pip install below resolved an invalid PyPI
+# version. A distinct ARG name avoids the collision.
+ARG SGL_NCCL_VERSION
+
+WORKDIR /sgl-workspace
+
+# Rust toolchain for setuptools-rust extensions (e.g. sglang-grpc).
+# Requires >= 1.85 (edition 2024). Inherited by framework via FROM torch_deps.
+ENV PATH="/root/.cargo/bin:${PATH}"
+RUN curl --proto '=https' --tlsv1.2 --retry 3 --retry-delay 2 -sSf https://sh.rustup.rs \
+        | sh -s -- -y --no-modify-path --profile minimal \
+    && rustc --version && cargo --version
+
+# Install sgl-kernel (from pre-built wheel)
+RUN --mount=type=cache,target=/root/.cache/pip \
+    python3 -m pip install --upgrade pip setuptools wheel html5lib six \
+    && case "$CUDA_VERSION" in \
+        12.6.3) CUINDEX=126 ;; \
+        12.9.2) CUINDEX=129 ;; \
+        13.0.3) CUINDEX=130 ;; \
+        *) echo "Unsupported CUDA version: $CUDA_VERSION" && exit 1 ;; \
+    esac \
+    && if [ "$CUDA_VERSION" = "12.6.3" ]; then \
+        python3 -m pip install https://${GITHUB_ARTIFACTORY}/sgl-project/whl/releases/download/v${SGL_KERNEL_VERSION}/sglang_kernel-${SGL_KERNEL_VERSION}+cu124-cp310-abi3-manylinux2014_$(uname -m).whl --force-reinstall --no-deps \
+    ; \
+    elif [ "$CUDA_VERSION" = "12.9.2" ]; then \
+        python3 -m pip install https://${GITHUB_ARTIFACTORY}/sgl-project/whl/releases/download/v${SGL_KERNEL_VERSION}/sglang_kernel-${SGL_KERNEL_VERSION}+cu129-cp310-abi3-manylinux2014_$(uname -m).whl --force-reinstall --no-deps \
+    ; \
+    elif [ "$CUDA_VERSION" = "13.0.3" ]; then \
+        # --no-deps prevents pip from pulling torch from default PyPI
+        python3 -m pip install sglang-kernel==${SGL_KERNEL_VERSION} --force-reinstall --no-deps \
+    ; \
+    else \
+        echo "Unsupported CUDA version: $CUDA_VERSION" && exit 1 \
+    ; \
+    fi
+
+# Copy dep spec + Rust crate source + proto files. setuptools-rust compiles the
+# Rust extension during the stub wheel build; the crate's build.rs references
+# ../../proto for tonic_build. Split from the pip install so source changes to
+# these paths invalidate the dep-install layer, but Python source changes don't.
+COPY python/pyproject.toml /tmp/sglang_deps/python/pyproject.toml
+COPY rust/sglang-grpc      /tmp/sglang_deps/rust/sglang-grpc
+COPY rust/sglang-mm        /tmp/sglang_deps/rust/sglang-mm
+COPY proto                 /tmp/sglang_deps/proto
+
+# Install sglang dependencies (torch, transformers, etc.). CUDA 12 DeepEP
+# wheels live only on the SGLang index, so preinstall the local-version wheel;
+# it satisfies the public-version pyproject pin during the full dependency solve.
+# Generate constraints.txt to prevent reinstalling these deps in later stages.
+RUN --mount=type=cache,target=/root/.cache/pip \
+    --mount=type=cache,target=/root/.cargo/registry \
+    case "$CUDA_VERSION" in \
+        12.6.3) CUINDEX=126 ;; \
+        12.9.2) CUINDEX=129 ;; \
+        13.0.3) CUINDEX=130 ;; \
+        *) echo "Unsupported CUDA version: $CUDA_VERSION" && exit 1 ;; \
+    esac \
+    && cd /tmp/sglang_deps/python \
+    && mkdir -p sglang \
+    && touch sglang/__init__.py \
+    && echo '__version__ = "0.0.0"' > sglang/version.py \
+    && touch README.md \
+    && touch LICENSE \
+    && SGL_DEEP_EP_VERSION="$(sed -n 's/^[[:space:]]*"sgl-deep-ep==\([^"]*\)",/\1/p' pyproject.toml)" \
+    && test -n "${SGL_DEEP_EP_VERSION}" \
+    && if [ "${CUDA_VERSION%%.*}" = "12" ]; then \
+           python3 -m pip install \
+               "sgl-deep-ep==${SGL_DEEP_EP_VERSION}+cu129" \
+               --index-url "https://docs.sglang.ai/whl/cu129/" \
+               --no-deps; \
+       fi \
+    && if [ "${CUDA_VERSION%%.*}" = "12" ]; then \
+           sed -i 's/cuda-python>=13\.0/cuda-python>=12,<13/' pyproject.toml && \
+           sed -i 's/flashinfer_python\[cu13\]/flashinfer_python[cu12]/' pyproject.toml && \
+           sed -i 's/nvidia-cutlass-dsl\[cu13\]/nvidia-cutlass-dsl/' pyproject.toml; \
+       fi \
+    && python3 -m pip install --extra-index-url https://download.pytorch.org/whl/cu${CUINDEX} ".[${BUILD_TYPE}]" \
+    && FLASHBOOT_CUDA_ARCH="$(if [ "${CUDA_VERSION%%.*}" = "12" ]; then echo "9.0"; else echo "9.0;10.0"; fi)" \
+       python3 -m pip install --no-build-isolation "flashboot @ git+https://${GITHUB_ARTIFACTORY}/scitix/flashboot-release.git" \
+    && if [ "${CUDA_VERSION%%.*}" = "13" ]; then \
+           python3 -m pip install --force-reinstall --no-deps \
+               "nvidia-nccl-cu13==${SGL_NCCL_VERSION}"; \
+       fi \
+    && if [ "${CUDA_VERSION%%.*}" = "12" ]; then \
+           pip list --format=freeze | awk -F'==' '/-cu13(==|$)/ {print $1}' \
+               | xargs -r python3 -m pip uninstall -y && \
+           python3 -m pip install --index-url https://download.pytorch.org/whl/cu${CUINDEX} \
+               torch==2.13.0 torchvision==0.28.0 torchaudio==2.11.0 --force-reinstall; \
+           python3 -m pip install https://github.com/sgl-project/whl/releases/download/v${SGL_DEEP_GEMM_VERSION}/sgl_deep_gemm-${SGL_DEEP_GEMM_VERSION}+cu129-py3-none-manylinux2014_$(uname -m).whl --force-reinstall; \
+       fi \
+    && cd /sgl-workspace \
+    && rm -rf /tmp/sglang_deps \
+    && pip freeze | grep -v "^sglang==" > /sgl-workspace/constraints.txt
+
+# distro resolves to the apt python3-distro under /usr/lib/python3, which the runtime
+# stage does not COPY; force a pip copy into /usr/local so it survives the stage split.
+RUN python3 -m pip install --ignore-installed --no-deps distro
+
+########################################################
+# PARALLEL STAGE 2: HPC-Ops Builder (needs torch_deps)
+########################################################
+FROM torch_deps AS hpc_ops_builder
+
+# HPC-Ops (https://github.com/Tencent/hpc-ops, MIT): fused attention / MoE /
+# RoPE kernels from the Tencent Hunyuan AI Infra team, consumed by the opt-in
+# hpc_ops attention and MoE runner backends.
+ARG HPC_OPS_COMMIT=ab1a402724635507037426068f6cddc3d30dc0a8
+
+WORKDIR /build
+
+# The kernels target Hopper (sm90a) only, so skip non-x86_64 images.
+# setup.py derives the version from `git rev-parse`, so keep the .git dir
+# (a source zip archive would not build).
+RUN --mount=type=cache,target=/root/.cache/pip \
+    mkdir -p /wheels && \
+    if [ "$(uname -m)" = "x86_64" ]; then \
+        git clone https://github.com/Tencent/hpc-ops.git && \
+        cd hpc-ops && \
+        git checkout ${HPC_OPS_COMMIT} && \
+        python3 setup.py bdist_wheel -d /wheels; \
+    fi
+
+########################################################
+# PARALLEL STAGE 3: FlashInfer Cache (needs torch_deps)
+########################################################
+FROM torch_deps AS flashinfer_cache
+
+ARG CUDA_VERSION
+ARG INSTALL_FLASHINFER_JIT_CACHE
+ARG FLASHINFER_VERSION
+
+# Stage jit-cache/cubin artifacts into /flashinfer_jit_output for clean COPY later
+RUN --mount=type=cache,target=/root/.cache/pip \
+    case "$CUDA_VERSION" in \
+        12.6.3) CUINDEX=126 ;; \
+        12.9.2) CUINDEX=129 ;; \
+        13.0.3) CUINDEX=130 ;; \
+        *) echo "Unsupported CUDA version: $CUDA_VERSION" && exit 1 ;; \
+    esac \
+    && mkdir -p /flashinfer_jit_output \
+    # flashinfer-cubin is CUDA-version-agnostic, unlike jit-cache, so its index-url has no cu${CUINDEX} suffix
+    && python3 -m pip install flashinfer-cubin==${FLASHINFER_VERSION} --index-url https://flashinfer.ai/whl \
+    && cp -r /opt/sglang/lib/python3.12/site-packages/flashinfer_cubin /flashinfer_jit_output/ \
+    && cp -r /opt/sglang/lib/python3.12/site-packages/flashinfer_cubin-*.dist-info /flashinfer_jit_output/ \
+    && if [ "$INSTALL_FLASHINFER_JIT_CACHE" = "1" ]; then \
+        python3 -m pip install flashinfer-jit-cache==${FLASHINFER_VERSION} --index-url https://flashinfer.ai/whl/cu${CUINDEX} \
+        && cp -r /opt/sglang/lib/python3.12/site-packages/flashinfer_jit_cache /flashinfer_jit_output/ \
+        && cp -r /opt/sglang/lib/python3.12/site-packages/flashinfer_jit_cache-*.dist-info /flashinfer_jit_output/ ; \
+    fi
+
+########################################################
+# PARALLEL STAGE 4: Dev Tools Builder (starts from base)
+########################################################
+FROM base AS devtools_builder
+
+ARG GITHUB_ARTIFACTORY
+
+WORKDIR /tools
+
+# Minimal apt deps needed for oh-my-zsh install in this stage
+# Full dev apt packages (gdb, vim, tmux, nsight, etc.) are installed in the framework stage
+RUN --mount=type=cache,target=/var/cache/apt,id=devtools-apt \
+    apt-get update && apt-get install -y --no-install-recommends zsh git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Download CLI tools (each in its own layer for parallel downloads)
+RUN curl --retry 3 --retry-delay 2 -LSso /tools/diff-so-fancy \
+        https://${GITHUB_ARTIFACTORY}/so-fancy/diff-so-fancy/releases/download/v1.4.4/diff-so-fancy \
+    && chmod +x /tools/diff-so-fancy
+
+RUN curl --retry 3 --retry-delay 2 -LSso /tools/clang-format \
+        https://${GITHUB_ARTIFACTORY}/muttleyxd/clang-tools-static-binaries/releases/download/master-32d3ac78/clang-format-16_linux-amd64 \
+    && chmod +x /tools/clang-format
+
+RUN curl --retry 3 --retry-delay 2 -fsSL -o /tmp/clangd.zip \
+        https://${GITHUB_ARTIFACTORY}/clangd/clangd/releases/download/18.1.3/clangd-linux-18.1.3.zip \
+    && unzip -q /tmp/clangd.zip -d /tmp \
+    && cp /tmp/clangd_18.1.3/bin/* /tools/ \
+    && mkdir -p /tools/lib && cp -r /tmp/clangd_18.1.3/lib/* /tools/lib/ \
+    && rm -rf /tmp/clangd.zip /tmp/clangd_18.1.3
+
+RUN CMAKE_VERSION=3.31.1 \
+    && ARCH=$(uname -m) \
+    && CMAKE_INSTALLER="cmake-${CMAKE_VERSION}-linux-${ARCH}" \
+    && curl --retry 3 --retry-delay 2 -fsSL -o "/tmp/${CMAKE_INSTALLER}.tar.gz" \
+        "https://${GITHUB_ARTIFACTORY}/Kitware/CMake/releases/download/v${CMAKE_VERSION}/${CMAKE_INSTALLER}.tar.gz" \
+    && tar -xzf "/tmp/${CMAKE_INSTALLER}.tar.gz" -C /tmp \
+    && cp -r "/tmp/${CMAKE_INSTALLER}/bin/"* /tools/ \
+    && mkdir -p /tools/share && cp -r "/tmp/${CMAKE_INSTALLER}/share/"* /tools/share/ \
+    && rm -rf "/tmp/${CMAKE_INSTALLER}" "/tmp/${CMAKE_INSTALLER}.tar.gz"
+
+RUN curl --proto '=https' --tlsv1.2 --retry 3 --retry-delay 2 -sSf https://just.systems/install.sh | \
+    sed "s|https://github.com|https://${GITHUB_ARTIFACTORY}|g" | \
+    bash -s -- --tag 1.42.4 --to /tools
+
+# Install oh-my-zsh and plugins
+RUN sh -c "$(curl --retry 3 --retry-delay 2 -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended \
+    && git clone --depth 1 https://github.com/zsh-users/zsh-autosuggestions ${ZSH_CUSTOM:-/root/.oh-my-zsh/custom}/plugins/zsh-autosuggestions \
+    && git clone --depth 1 https://github.com/zsh-users/zsh-syntax-highlighting.git ${ZSH_CUSTOM:-/root/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting
+
+########################################################
+# PARALLEL STAGE 5: Gateway Builder (starts from base)
+########################################################
+# Builds sgl-model-gateway in isolation so Python-only changes
+# don't trigger a full Rust recompilation.
+FROM base AS gateway_builder
+
+ARG GITHUB_ARTIFACTORY
+ARG BRANCH_TYPE
+ARG SGL_VERSION
+ARG USE_LATEST_SGLANG
+
+WORKDIR /build
+
+# Copy ONLY the gateway source (not the full repo)
+COPY sgl-model-gateway /build/sgl-model-gateway
+
+# Install Rust, build gateway binary and Python bindings, then clean up Rust toolchain
+RUN --mount=type=cache,target=/root/.cache/pip \
+    curl --proto '=https' --tlsv1.2 --retry 3 --retry-delay 2 -sSf https://sh.rustup.rs | sh -s -- -y \
+    && export PATH="/root/.cargo/bin:${PATH}" \
+    && python3 -m pip install maturin \
+    && cd /build/sgl-model-gateway/bindings/python \
+    && ulimit -n 65536 && maturin build --release --features vendored-openssl --out /build/gateway_wheels \
+    && cd /build/sgl-model-gateway \
+    && cargo build --release --bin sgl-model-gateway --features vendored-openssl \
+    && cp target/release/sgl-model-gateway /build/sgl-model-gateway-bin \
+    && rm -rf /root/.cargo /root/.rustup /build/sgl-model-gateway/target /build/sgl-model-gateway/bindings/python/target
+
+########################################################
+########## Final Framework Image ######################
+########################################################
+#
+# Combines all artifacts from parallel builder stages
+#
+FROM torch_deps AS framework
+
+ARG BRANCH_TYPE
+ARG BUILD_TYPE
+ARG CUDA_VERSION
+ARG SGL_VERSION
+ARG USE_LATEST_SGLANG
+ARG GITHUB_ARTIFACTORY
+ARG MOONCAKE_VERSION
+ARG MSCCLPP_VERSION
+
+WORKDIR /sgl-workspace
+
+# =============================================================================
+# Copy artifacts from parallel builders
+# =============================================================================
+
+# Copy HPC-Ops wheel and install (empty on non-x86_64; kernels are sm90a-only)
+COPY --from=hpc_ops_builder /wheels /tmp/wheels/hpc-ops
+RUN --mount=type=cache,target=/root/.cache/pip \
+    if ls /tmp/wheels/hpc-ops/*.whl >/dev/null 2>&1; then \
+        pip install --no-deps /tmp/wheels/hpc-ops/*.whl; \
+    fi && rm -rf /tmp/wheels/hpc-ops
+
+# Copy flashinfer cubin (always) and jit-cache (if installed) packages
+COPY --from=flashinfer_cache /flashinfer_jit_output/ /opt/sglang/lib/python3.12/site-packages/
+
+# Copy dev tools
+COPY --from=devtools_builder /tools/diff-so-fancy /usr/local/bin/
+COPY --from=devtools_builder /tools/clang-format /usr/local/bin/
+COPY --from=devtools_builder /tools/clangd /usr/local/bin/
+COPY --from=devtools_builder /tools/lib /usr/local/lib/
+COPY --from=devtools_builder /tools/cmake /usr/local/bin/
+COPY --from=devtools_builder /tools/ctest /usr/local/bin/
+COPY --from=devtools_builder /tools/cpack /usr/local/bin/
+COPY --from=devtools_builder /tools/share/cmake-3.31 /usr/local/share/cmake-3.31
+COPY --from=devtools_builder /tools/just /usr/local/bin/
+COPY --from=devtools_builder /root/.oh-my-zsh /root/.oh-my-zsh
+
+# Install dev apt packages (need to re-run since we're in a different stage)
+RUN --mount=type=cache,target=/var/cache/apt,id=framework-apt \
+    apt-get update && apt-get install -y --no-install-recommends \
+    gdb \
+    ninja-build \
+    vim \
+    tmux \
+    htop \
+    zsh \
+    tree \
+    silversearcher-ag \
+    cloc \
+    pkg-config \
+    bear \
+    less \
+    rdma-core \
+    openssh-server \
+    gnuplot \
+    infiniband-diags \
+    perftest \
+    ibverbs-providers \
+    libibumad3 \
+    libibverbs1 \
+    libnl-3-200 \
+    libnl-route-3-200 \
+    librdmacm1 \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
+
+# Install NVIDIA development tools
+RUN --mount=type=cache,target=/var/cache/apt,id=framework-apt \
+    apt update -y \
+    && apt install -y --no-install-recommends gnupg \
+    && echo "deb http://developer.download.nvidia.com/devtools/repos/ubuntu2004/$(if [ "$(uname -m)" = "aarch64" ]; then echo "arm64"; else echo "amd64"; fi) /" | tee /etc/apt/sources.list.d/nvidia-devtools.list \
+    && apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/$(if [ "$(uname -m)" = "aarch64" ]; then echo "arm64"; else echo "x86_64"; fi)/7fa2af80.pub \
+    && apt update -y \
+    && apt install -y --no-install-recommends nsight-systems-cli \
+    && rm -rf /var/lib/apt/lists/*
+
+# =============================================================================
+# Python packages and tools (before source copy for better caching)
+# =============================================================================
+
+# Install Mooncake
+RUN --mount=type=cache,target=/root/.cache/pip \
+    CUDA_MAJOR="${CUDA_VERSION%%.*}" && \
+    if [ "$CUDA_MAJOR" -ge 13 ]; then \
+        python3 -m pip install mooncake-transfer-engine-cuda13==${MOONCAKE_VERSION}; \
+    else \
+        python3 -m pip install mooncake-transfer-engine==${MOONCAKE_VERSION}; \
+    fi
+
+# Install MSCCL++ Python dependencies and package (builds extension via CMake through pip)
+RUN --mount=type=cache,target=/root/.cache/pip \
+    git clone --depth=1 --branch ${MSCCLPP_VERSION} https://${GITHUB_ARTIFACTORY}/microsoft/mscclpp.git /tmp/mscclpp \
+    && case "${CUDA_VERSION}" in \
+           12.*) \
+               CMAKE_ARGS="-DMSCCLPP_BYPASS_GPU_CHECK=ON -DMSCCLPP_USE_CUDA=ON -DMSCCLPP_GPU_ARCHS=80,90,100,100a,103,103a" \
+               python3 -m pip install "/tmp/mscclpp[cuda12]"; \
+               ;; \
+           13.*) \
+               CMAKE_ARGS="-DMSCCLPP_BYPASS_GPU_CHECK=ON -DMSCCLPP_USE_CUDA=ON -DMSCCLPP_GPU_ARCHS=80,90,100,100a,103,103a" \
+               python3 -m pip install "/tmp/mscclpp[cuda13]"; \
+               ;; \
+           *) \
+               echo "Unsupported CUDA version for MSCCL++: ${CUDA_VERSION}" && exit 1; \
+               ;; \
+       esac \
+    && rm -rf /tmp/mscclpp
+
+# Install essential Python packages (use constraints to prevent conflicts)
+RUN --mount=type=cache,target=/root/.cache/pip \
+    python3 -m pip install -c /sgl-workspace/constraints.txt \
+    datamodel_code_generator \
+    pre-commit \
+    pytest \
+    black \
+    isort \
+    icdiff \
+    uv \
+    wheel \
+    scikit-build-core \
+    py-spy \
+    cubloaty \
+    google-cloud-storage \
+    pandas \
+    matplotlib \
+    tabulate \
+    termplotlib \
+    "runai-model-streamer[s3,gcs,azure]>=0.15.7"
+
+# Per-CUDA-major package installs. The `nixl` stub package is needed (it owns
+# the `nixl` import path) but unconditionally requires nixl-cu12, so we install
+# it with --no-deps and pair it with the matching nixl-cu12 / nixl-cu13 binary
+# to avoid shipping wrong-CUDA libs on cu13 images.
+RUN --mount=type=cache,target=/root/.cache/pip if [ "${CUDA_VERSION%%.*}" = "12" ]; then \
+    python3 -m pip install nixl nixl-cu12 --no-deps ; \
+    python3 -m pip install "cuda-python>=12,<13" ; \
+elif [ "${CUDA_VERSION%%.*}" = "13" ]; then \
+    python3 -m pip install nixl nixl-cu13 --no-deps ; \
+    python3 -m pip install "cuda-python>=13,<14" ; \
+fi
+
+# Add yank script
+COPY --chown=root:root --chmod=755 docker/configs/yank /usr/local/bin/yank
+
+# These configs are optional; users can override them by mounting their own files
+COPY docker/configs/opt/.vimrc /opt/sglang/.vimrc
+COPY docker/configs/opt/.tmux.conf /opt/sglang/.tmux.conf
+COPY docker/configs/opt/.gitconfig /opt/sglang/.gitconfig
+
+# Configure development environment
+COPY docker/configs/.zshrc /root/.zshrc
+
+# Fix Trivy-reported CVEs
+# pip:             urllib3 (CVE-2025-43859), pillow (CVE-2026-25990)
+# binutils family: CVE-2025-{1147,1148,3198,5244,5245,7545,7546,8225,11082,11083,11412,11413,11414,11494,11839,11840}
+# libgnutls30t64:  CVE-2025-{9820,14831}
+# libpam:          CVE-2024-10963
+# libsqlite3-0:    CVE-2025-{6965,7709}
+# libtasn1-6:      CVE-2025-13151
+# dpkg:            CVE-2025-6297
+RUN python3 -m pip install --upgrade "urllib3>=2.6.3" "pillow>=12.1.1"
+RUN --mount=type=cache,target=/var/cache/apt,id=framework-apt \
+    apt-get update && apt-get install -y --only-upgrade \
+    binutils binutils-common binutils-x86-64-linux-gnu libbinutils \
+    libctf0 libctf-nobfd0 libgprofng0 libsframe1 \
+    libgnutls30t64 \
+    libpam-modules libpam-modules-bin libpam-runtime libpam0g \
+    libsqlite3-0 libtasn1-6 \
+    dpkg dpkg-dev libdpkg-perl \
+    && rm -rf /var/lib/apt/lists/*
+
+# =============================================================================
+# Copy sglang source and do editable install (LAST for better caching)
+# =============================================================================
+
+# Copy local source if building from local
+FROM scratch AS local_src
+COPY . /src
+
+FROM framework AS framework_final
+
+ARG BRANCH_TYPE
+ARG BUILD_TYPE
+ARG CUDA_VERSION
+ARG SGL_VERSION
+ARG USE_LATEST_SGLANG
+
+WORKDIR /sgl-workspace
+
+COPY --from=local_src /src /tmp/local_src
+RUN if [ "$BRANCH_TYPE" = "local" ]; then \
+        cp -r /tmp/local_src /sgl-workspace/sglang; \
+    elif [ "$USE_LATEST_SGLANG" = "1" ]; then \
+        git clone --depth=1 https://github.com/sgl-project/sglang.git /sgl-workspace/sglang; \
+    elif [ -z "$SGL_VERSION" ]; then \
+        echo "ERROR: SGL_VERSION must be set when USE_LATEST_SGLANG=0 and BRANCH_TYPE!=local" && exit 1; \
+    else \
+        git clone --depth=1 --branch v${SGL_VERSION} https://github.com/sgl-project/sglang.git /sgl-workspace/sglang; \
+    fi \
+    && rm -rf /tmp/local_src
+
+# Editable install (fast - dependencies already installed via constraints)
+# Clean up __pycache__/tests/pyc in same RUN to avoid writing ~28k files to layer
+RUN --mount=type=cache,target=/root/.cache/pip \
+    cd /sgl-workspace/sglang \
+    && if [ "${CUDA_VERSION%%.*}" = "12" ]; then \
+           sed -i 's/cuda-python>=13\.0/cuda-python>=12,<13/' python/pyproject.toml && \
+           sed -i 's/flashinfer_python\[cu13\]/flashinfer_python[cu12]/' python/pyproject.toml && \
+           sed -i 's/nvidia-cutlass-dsl\[cu13\]/nvidia-cutlass-dsl/' python/pyproject.toml; \
+       fi \
+    && python3 -m pip install --no-deps -e "python[${BUILD_TYPE}]" \
+    && kernels lock python \
+    && ( success=0; \
+         # aarch64: kernels-community/sgl-flash-attn3 ships no arm variants; JIT-compile at runtime.
+         # Remove this branch once arm cubins are published upstream.
+         if [ "$(uname -m)" = "aarch64" ]; then \
+             echo "Skipping kernels-community/sgl-flash-attn3 cubin download on aarch64 (no variants published upstream); kernels will be JIT-compiled at runtime"; \
+             success=1; \
+         else \
+             for i in 1 2 3; do \
+                 echo "Attempt $i/3: downloading sgl-kernel cubins..." && \
+                 kernels download python && \
+                 success=1 && break; \
+                 echo "sgl-kernel cubin download failed, retrying in 30s..." && sleep 30; \
+             done; \
+             # x86: if no prebuilt sgl-flash-attn3 variant matches this torch+CUDA \
+             # combo (e.g. cu129 publishes no torch>=2.10 cubin), fall back to \
+             # runtime JIT instead of failing the build, mirroring the aarch64 branch. \
+             if [ "$success" != "1" ]; then \
+                 echo "WARNING: no matching sgl-flash-attn3 cubin variant for this torch+CUDA; kernels will be JIT-compiled at runtime"; \
+                 success=1; \
+             fi; \
+         fi; \
+         [ "$success" = "1" ] ) \
+    && mkdir -p /root/.cache/huggingface /root/.cache/sglang \
+    && ( if [ -f python/kernels.lock ]; then mv python/kernels.lock /root/.cache/sglang/; fi ) \
+    && ( find /opt/sglang/lib/python3.12/site-packages -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true )
+
+
+# Install pre-built gateway artifacts from parallel builder
+COPY --from=gateway_builder /build/sgl-model-gateway-bin /opt/sglang/bin/sgl-model-gateway
+COPY --from=gateway_builder /build/gateway_wheels /tmp/gateway_wheels
+RUN --mount=type=cache,target=/root/.cache/pip \
+    python3 -m pip install --force-reinstall /tmp/gateway_wheels/*.whl \
+    && rm -rf /tmp/gateway_wheels
+
+# Set workspace directory
+WORKDIR /sgl-workspace/sglang
+
+# Keep build provenance at the end so metadata changes do not invalidate build layers.
+ARG SGLANG_BUILD_COMMIT=unknown
+ARG SGLANG_BUILD_URL=
+ARG SGLANG_IMAGE_TAG=local/sglang:dev
+ENV SGLANG_BUILD_COMMIT=${SGLANG_BUILD_COMMIT:-unknown} \
+    SGLANG_BUILD_URL=${SGLANG_BUILD_URL:-} \
+    SGLANG_IMAGE_TAG=${SGLANG_IMAGE_TAG:-local/sglang:dev}
+LABEL org.opencontainers.image.source="https://github.com/sgl-project/sglang" \
+      org.opencontainers.image.revision="${SGLANG_BUILD_COMMIT}" \
+      org.opencontainers.image.version="${SGLANG_IMAGE_TAG}" \
+      org.opencontainers.image.url="${SGLANG_BUILD_URL}" \
+      ai.sglang.build.commit="${SGLANG_BUILD_COMMIT}" \
+      ai.sglang.build.url="${SGLANG_BUILD_URL}" \
+      ai.sglang.image.tag="${SGLANG_IMAGE_TAG}"
+
+########################################################
+########## Runtime Image ##############################
+########################################################
+#
+# PURPOSE: Production runtime environment with JIT support
+#
+# This stage creates a production-ready image containing:
+# - Pre-installed SGLang and CUDA dependencies
+# - Full CUDA toolchain for JIT compilation (DeepGEMM, Triton, FlashInfer)
+# - Optimized for inference workloads and deployment
+# - Smaller than framework (no dev tools like vim, tmux, nsight, etc.)
+#
+# Use this stage when you need:
+# - Production deployment of SGLang
+# - JIT compilation support for FP8/microscaling kernels
+# - Ready-to-run inference server environment
+#
+# Note: Uses devel base for complete NVCC toolchain required by DeepGEMM JIT
+FROM nvidia/cuda:${CUDA_VERSION}-cudnn-devel-ubuntu24.04 AS runtime
+
+ARG CUDA_VERSION
+ARG TARGETARCH
+ARG GDRCOPY_VERSION=2.5.1
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    CUDA_HOME=/usr/local/cuda \
+    GDRCOPY_HOME=/usr/src/gdrdrv-${GDRCOPY_VERSION}/
+
+# Add GKE default lib and bin locations + CUDA compiler paths for FlashInfer JIT
+ENV PATH="${PATH}:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/cuda/nvvm/bin" \
+    LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/nvidia/lib:/usr/local/nvidia/lib64"
+
+# Install runtime dependencies (devel base provides gcc/g++/build tools)
+# Python 3.12 ships in Ubuntu 24.04 main, so no deadsnakes PPA needed.
+RUN --mount=type=cache,target=/var/cache/apt,id=runtime-apt \
+    apt-get update && apt-get install -y --no-install-recommends --allow-change-held-packages \
+    # Python runtime
+    python3.12-full \
+    python3.12-dev \
+    wget \
+    # Core system utilities
+    ca-certificates \
+    netcat-openbsd \
+    curl \
+    git \
+    # Runtime libraries
+    libopenmpi3 \
+    libnuma1 \
+    libibverbs1 \
+    libibumad3 \
+    librdmacm1 \
+    libnl-3-200 \
+    libnl-route-3-200 \
+    ibverbs-providers \
+    libgoogle-glog0v6t64 \
+    libunwind8 \
+    libboost-system1.83.0 \
+    libboost-thread1.83.0 \
+    libboost-filesystem1.83.0 \
+    libgrpc++1.51t64 \
+    libprotobuf32t64 \
+    libhiredis1.1.0 \
+    libcurl4 \
+    libczmq4 \
+    libfabric1 \
+    libssl-dev \
+    # RDMA runtime
+    rdma-core \
+    infiniband-diags \
+    perftest \
+    # Build tools for JIT compilation
+    ninja-build \
+    # NCCL packages needed for pynccl_allocator JIT compilation (-lnccl)
+    libnccl2 \
+    libnccl-dev \
+    # GPG key verification
+    gnupg2 \
+    linux-libc-dev \
+    && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 2 \
+    && update-alternatives --set python3 /usr/bin/python3.12 \
+    && ln -sf /usr/bin/python3.12 /usr/bin/python \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
+
+# create virtual env for sglang to avoid conflict with system python packages
+RUN python3 -m venv /opt/sglang
+ENV PATH="/opt/sglang/bin:${PATH}"
+
+# Set up locale
+RUN apt-get update && apt-get install -y --no-install-recommends locales \
+    && locale-gen en_US.UTF-8 \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \
+    LC_ALL=en_US.UTF-8
+
+# Fix Trivy-reported CVEs (see framework stage for full CVE list)
+RUN --mount=type=cache,target=/var/cache/apt,id=runtime-apt \
+    apt-get update && apt-get install -y --only-upgrade \
+    binutils binutils-common binutils-x86-64-linux-gnu libbinutils \
+    libctf0 libctf-nobfd0 libgprofng0 libsframe1 \
+    libgnutls30t64 \
+    libpam-modules libpam-modules-bin libpam-runtime libpam0g \
+    libsqlite3-0 libtasn1-6 \
+    dpkg dpkg-dev libdpkg-perl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy Python site-packages from framework (already cleaned of __pycache__/tests/pyc files)
+COPY --from=framework_final /opt/sglang/lib/python3.12/site-packages /opt/sglang/lib/python3.12/site-packages
+
+# Copy SGLang workspace
+COPY --from=framework_final /sgl-workspace /sgl-workspace
+
+# Copy sgl-model-gateway binary
+COPY --from=framework_final /opt/sglang/bin/sgl-model-gateway /opt/sglang/bin/sgl-model-gateway
+
+# Copy sglang binary
+COPY --from=framework_final /opt/sglang/bin/sglang /opt/sglang/bin/sglang
+
+# Copy py-spy binary
+COPY --from=framework_final /opt/sglang/bin/py-spy /opt/sglang/bin/py-spy
+
+# Copy cache for kernels from kernels community
+COPY --from=framework_final /root/.cache/huggingface /root/.cache/huggingface
+COPY --from=framework_final /root/.cache/sglang /root/.cache/sglang
+
+# Copy GDRCopy runtime libraries (but not the build artifacts)
+COPY --from=framework_final /usr/lib/libgdrapi.so* /usr/lib/
+COPY --from=framework_final /usr/bin/gdrcopy_* /usr/bin/
+COPY --from=framework_final /usr/src/gdrdrv-2.5.1 /usr/src/gdrdrv-2.5.1
+
+# Fix DeepEP IBGDA symlink in runtime
+RUN ln -sf /usr/lib/$(uname -m)-linux-gnu/libmlx5.so.1 /usr/lib/$(uname -m)-linux-gnu/libmlx5.so
+
+WORKDIR /sgl-workspace/sglang
+
+# Keep build provenance at the end so metadata changes do not invalidate build layers.
+ARG SGLANG_BUILD_COMMIT=unknown
+ARG SGLANG_BUILD_URL=
+ARG SGLANG_IMAGE_TAG=local/sglang:dev
+ENV SGLANG_BUILD_COMMIT=${SGLANG_BUILD_COMMIT:-unknown} \
+    SGLANG_BUILD_URL=${SGLANG_BUILD_URL:-} \
+    SGLANG_IMAGE_TAG=${SGLANG_IMAGE_TAG:-local/sglang:dev}
+LABEL org.opencontainers.image.source="https://github.com/sgl-project/sglang" \
+      org.opencontainers.image.revision="${SGLANG_BUILD_COMMIT}" \
+      org.opencontainers.image.version="${SGLANG_IMAGE_TAG}" \
+      org.opencontainers.image.url="${SGLANG_BUILD_URL}" \
+      ai.sglang.build.commit="${SGLANG_BUILD_COMMIT}" \
+      ai.sglang.build.url="${SGLANG_BUILD_URL}" \
+      ai.sglang.image.tag="${SGLANG_IMAGE_TAG}"
+
+# Default command
+CMD ["/bin/bash"]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -963,6 +963,7 @@
               "docs/advanced_features/deterministic_inference",
               "docs/advanced_features/observability",
               "docs/advanced_features/model_loading",
+              "docs/advanced_features/flashboot",
               "docs/advanced_features/object_storage",
               "docs/advanced_features/checkpoint_engine",
               "docs/advanced_features/sglang_for_rl"

--- a/docs/docs/advanced_features/flashboot.mdx
+++ b/docs/docs/advanced_features/flashboot.mdx
@@ -1,0 +1,56 @@
+---
+title: "FlashBoot integration"
+description: "Use FlashBoot load formats from the external FlashBoot package."
+---
+
+SGLang exposes `flashload` and `flashclone` as load formats for the external FlashBoot package.
+
+## Install FlashBoot
+
+Install SGLang with the FlashBoot extra:
+
+```bash
+pip install "sglang[flashboot]"
+```
+
+The FlashBoot implementation lives in the third-party repository `https://github.com/scitix/flashboot-release`. SGLang keeps only the integration points for load-format registration, loader dispatch, and optional sharded-state export.
+
+## Build a Docker image with FlashBoot
+
+The default SGLang Dockerfile does not install FlashBoot. Build the FlashBoot-specific Dockerfile to include the external package:
+
+```bash
+docker build \
+  -f docker/Dockerfile_flashboot \
+  --target runtime \
+  --build-arg BRANCH_TYPE=local \
+  -t sglang-flashboot .
+```
+
+## Load with FlashBoot
+
+After you install FlashBoot, SGLang dispatches `flashload` and `flashclone` to `flashboot.sglang_plugin.get_flashboot_loader`.
+
+```bash
+python -m sglang.launch_server \
+  --model-path /path/to/flashboot/export \
+  --load-format flashload
+```
+
+Use `flashclone` on clone instances and pass FlashBoot-specific options through `--model-loader-extra-config`.
+
+## Export sharded state
+
+Set `FB_SHARD_SAVE_DIR` to export per-rank sharded state after the model loads. SGLang writes files with the pattern `model-rank-{rank}-part-{part}.safetensors`.
+
+```bash
+FB_SHARD_SAVE_DIR=/path/to/flashboot/export \
+python -m sglang.launch_server \
+  --model-path /path/to/model \
+  --load-format sharded_state
+```
+
+Optional environment variables:
+
+- `FB_SHARD_SAVE_MAXSIZE`: Maximum bytes per shard part. Defaults to `5 GiB`.
+- `FB_SHARD_PAD_ALIGNMENT`: Byte alignment for padding tensors in exported shard files. Defaults to `0`, which disables padding.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -100,6 +100,7 @@ default = true
 
 [project.optional-dependencies]
 checkpoint-engine = ["checkpoint-engine==0.1.2"]
+flashboot = ["flashboot @ git+https://github.com/scitix/flashboot-release.git"]
 runai = ["runai-model-streamer[s3,gcs,azure]>=0.15.7"]
 diffusion = [
   "addict==2.4.0",

--- a/python/sglang/srt/configs/load_config.py
+++ b/python/sglang/srt/configs/load_config.py
@@ -34,6 +34,8 @@ class LoadFormat(str, enum.Enum):
     LOCAL_CACHED = "local_cached"
     FASTSAFETENSORS = "fastsafetensors"
     PRIVATE = "private"
+    FLASHLOAD = "flashload"
+    FLASHCLONE = "flashclone"
     RUNAI_STREAMER = "runai_streamer"
     IPC_CACHE = "ipc_cache"
 

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import contextlib
 import inspect
 import logging
+import os
 import time
 from dataclasses import dataclass
 from typing import Optional, Union
@@ -628,6 +629,7 @@ class ModelRunner:
         self.init_token_oracle()
         self.sampler = create_sampler()
         self.load_model()
+        self.maybe_save_flashboot_shard()
         prepare_moe_topk(
             model=self.model,
             model_config=self.model_config,
@@ -660,6 +662,34 @@ class ModelRunner:
         self.maybe_init_lora_manager()
         self.maybe_enable_batch_invariant_mode()
         self.configure_kv_cache_dtype()
+
+    def maybe_save_flashboot_shard(self):
+        shard_save_directory = os.environ.get("FB_SHARD_SAVE_DIR")
+        if not shard_save_directory:
+            return
+
+        from sglang.srt.model_loader.loader import ShardedStateLoader
+
+        shard_save_max_size_bytes = int(
+            os.environ.get("FB_SHARD_SAVE_MAXSIZE", str(5 * 1024**3))
+        )
+        if self.is_draft_worker:
+            shard_save_directory = os.path.join(shard_save_directory, "nextn")
+            os.makedirs(shard_save_directory, exist_ok=True)
+        shard_file_pattern = (
+            f"model-rank-{dist.get_rank()}-part-{{part}}.safetensors"
+        )
+        ShardedStateLoader.save_model(
+            self.model,
+            shard_save_directory,
+            shard_file_pattern,
+            shard_save_max_size_bytes,
+        )
+        logger.info(
+            "[flashboot] wrote %s to %s",
+            shard_file_pattern,
+            shard_save_directory,
+        )
 
     def init_memory_saver_adapter(self):
         self.memory_saver_adapter = TorchMemorySaverAdapter.create(

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -1664,6 +1664,7 @@ class ShardedStateLoader(BaseModelLoader):
     """
 
     DEFAULT_PATTERN = "model-rank-{rank}-part-{part}.safetensors"
+    PADDING_KEY_SUFFIX = "!__pad__"
 
     def __init__(self, load_config: LoadConfig):
         super().__init__(load_config)
@@ -1725,6 +1726,31 @@ class ShardedStateLoader(BaseModelLoader):
                     result[k] = t
         return result
 
+    @staticmethod
+    def add_alignment_padding(
+        state_dict: Dict[str, torch.Tensor], alignment: int
+    ) -> Dict[str, torch.Tensor]:
+        if alignment <= 0:
+            return state_dict
+        padded_state_dict = dict(state_dict)
+        for key, tensor in state_dict.items():
+            tensor_size_bytes = tensor.nelement() * tensor.element_size()
+            padding_size_bytes = (-tensor_size_bytes) % alignment
+            if padding_size_bytes % tensor.element_size():
+                raise ValueError(
+                    f"FB_SHARD_PAD_ALIGNMENT={alignment} is incompatible with "
+                    f"{tensor.dtype}"
+                )
+            if padding_size_bytes:
+                padded_state_dict[key + ShardedStateLoader.PADDING_KEY_SUFFIX] = (
+                    torch.zeros(
+                        padding_size_bytes // tensor.element_size(),
+                        dtype=tensor.dtype,
+                        device=tensor.device,
+                    )
+                )
+        return padded_state_dict
+
     def _prepare_weights(self, model_name_or_path: str, revision: Optional[str]):
         if os.path.isdir(model_name_or_path):
             return model_name_or_path
@@ -1778,6 +1804,8 @@ class ShardedStateLoader(BaseModelLoader):
             for path in filepaths:
                 with safe_open(path, framework="pt") as f:
                     for key in f.keys():  # noqa: SIM118
+                        if key.endswith(ShardedStateLoader.PADDING_KEY_SUFFIX):
+                            continue
                         tensor = f.get_tensor(key)
                         # If loading with LoRA enabled, additional padding may
                         # be added to certain parameters. We only load into a
@@ -1819,13 +1847,16 @@ class ShardedStateLoader(BaseModelLoader):
         part_idx = 0
         total_size = 0
         state_dict = ShardedStateLoader._filter_subtensors(model.state_dict())
+        padding_alignment = int(os.environ.get("FB_SHARD_PAD_ALIGNMENT", "0"))
         state_dict_part: Dict[str, torch.Tensor] = {}
         for key, tensor in state_dict.items():
             param_size = tensor.nelement() * tensor.element_size()
             if max_size is not None and total_size + param_size > max_size:
                 filename = pattern.format(rank=rank, part=part_idx)
                 save_file(
-                    state_dict_part,
+                    ShardedStateLoader.add_alignment_padding(
+                        state_dict_part, padding_alignment
+                    ),
                     os.path.join(path, filename),
                 )
                 part_idx += 1
@@ -1836,7 +1867,9 @@ class ShardedStateLoader(BaseModelLoader):
         if len(state_dict_part) > 0:
             filename = pattern.format(rank=rank, part=part_idx)
             save_file(
-                state_dict_part,
+                ShardedStateLoader.add_alignment_padding(
+                    state_dict_part, padding_alignment
+                ),
                 os.path.join(path, filename),
             )
 
@@ -4280,6 +4313,17 @@ def get_model_loader(
 
     if isinstance(load_config.load_format, type):
         return load_config.load_format(load_config)
+
+    if load_config.load_format in (LoadFormat.FLASHLOAD, LoadFormat.FLASHCLONE):
+        try:
+            from flashboot.sglang_plugin import get_flashboot_loader
+        except ImportError as exc:
+            raise ImportError(
+                "FlashBoot load formats require the external flashboot package. "
+                'Install it with `pip install "sglang[flashboot]"`.'
+            ) from exc
+
+        return get_flashboot_loader(load_config, model_config)
 
     if model_config and model_config.quantization in ["auto-round-int8"]:
         logger.info("Using IncModelLoader due to AutoRound quantization config.")

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -131,6 +131,8 @@ LOAD_FORMAT_CHOICES = [
     "remote_instance",
     "fastsafetensors",
     "private",
+    "flashload",
+    "flashclone",
     "runai_streamer",
 ]
 # NOTE: LoadFormat.IPC_CACHE intentionally has no public --load-format choice.


### PR DESCRIPTION
## Paper

- FlashBoot: Sub-Second Weight Loading for Large Models at Rack Scale: https://arxiv.org/abs/2608.08482

## Motivation

Current model loading and cloning paths operate primarily at tensor granularity.

The Hugging Face auto loading path loads and copies tensors individually. For large MoE models such as DSV4 Pro, the large number of expert tensors introduces substantial per-tensor overhead and makes large, contiguous I/O difficult.

Existing clone implementations have a similar limitation: many small tensor transfers cannot fully utilize NVLink or RDMA bandwidth. NCCL-based cloning also incurs significant communicator setup overhead. In our DSV4 Pro experiments on GB300, NCCL communicator initialization takes more than 10 seconds, while the actual clone transfer takes only about 0.3 seconds.

FlashBoot instead treats each rank-local checkpoint as a contiguous storage arena. It copies checkpoint data in large file-level blocks and rebinds model parameters to tensor views within the loaded arena. The same arena can then be cloned as large contiguous ranges over NVLink or RDMA, avoiding per-tensor loading and transfer overhead while making better use of the available link bandwidth.

## Summary
- add `flashload` and `flashclone` load formats
- dispatch FlashBoot loading to the external `flashboot` package from https://github.com/scitix/flashboot-release
- add optional sharded-state export hooks and documentation
- add `docker/Dockerfile_flashboot` for images that include FlashBoot, without changing the default `docker/Dockerfile`

## Validation
- `python -m py_compile python/sglang/srt/configs/load_config.py python/sglang/srt/server_args.py python/sglang/srt/model_loader/loader.py python/sglang/srt/model_executor/model_runner.py`
- `python -m json.tool docs/docs.json`
- parsed `python/pyproject.toml` with `tomllib`
- installed FlashBoot from `git+https://github.com/scitix/flashboot-release.git` in a local CUDA 13 / H100 environment with `FLASHBOOT_CUDA_ARCH=9.0 FB_BUILD_RDMA=auto`
- imported `flashboot._C` after importing `torch` and verified the RDMA `Endpoint` binding exists
- verified `get_model_loader` dispatches both `flashload` and `flashclone` to the external FlashBoot loader
- checked that `docker/Dockerfile` does not contain FlashBoot install logic


## Benchmark Results

| Startup scenario | Model | Hardware | Distributed layout | Weight/rank | Connection or setup | Data movement | Observed startup result |
|---|---|---|---|---|---|---|---|
| H100 SGLang R-Fork (NCCL) | DeepSeek-V4-Flash | Two H100 nodes; 4 × 400 Gb/s RDMA NICs | TP8; 1 seed → 1 clone | 20.825 GB | 0.545 s communicator build | 1.298 s; 128.3 GB/s TP8 logical aggregate | 1.843 s |
| H100 FlashBoot | DeepSeek-V4-Flash | Two H100 nodes; 4 × 400 Gb/s RDMA NICs | TP8; 1 seed → 1 clone | 20.825 GB | 50 ms for the 128-MiB transfer buffer MR and message connection | 0.836 s; 199.4 GB/s TP8 logical aggregate | 0.874 s |
| H100 standard checkpoint load | DeepSeek-V4-Flash | One 8-GPU H100 node | TP8; one replica; auto loader | 20.825 GB | Included in loader interval | Per-tensor standard load | 29.76 s |
| H100 FlashLoad | DeepSeek-V4-Flash | One 8-GPU H100 node | TP8; one replica; flashload loader | 20.825 GB | Included in loader interval | Contiguous arena load | 7.70 s |
| GB300 FlashClone, 1→1 | DeepSeek-V4-Pro | GB300 NVL72; one 4-GPU node per replica; one IMEX/NVLink-Switch domain | TP4; 1 seed + 1 clone; 2 nodes | 217.0 GB | 7–13 ms remote map | 826 GB/s | 0.29 s |
| GB300 R-Fork (NCCL), 1→1 | DeepSeek-V4-Pro | GB300 NVL72; one 4-GPU node per replica; one IMEX/NVLink-Switch domain | TP4; 1 seed + 1 clone; 2 nodes | 217.0 GB | NCCL group build 10.9 s | NCCL broadcast is 657 GB/s | 10.9 s |
| GB300 FlashClone chain, 1→8 | DeepSeek-V4-Pro | GB300 NVL72; one 4-GPU node per replica; one IMEX/NVLink-Switch domain | TP4; 1 seed + 8 clones; 9 nodes | 217.0 GB | 7–13 ms remote map per clone | 303 ms; 715.4 GB/s/clone | 0.32 s |
| GB300 production R-Fork (NCCL), 1→8 | DeepSeek-V4-Pro | GB300 NVL72; one 4-GPU node per replica; one IMEX/NVLink-Switch domain | TP4; 1 seed + 8 serially served clones; 9 nodes | 217.0 GB | Full NCCL standup 10–110 s | NCCL broadcast reference is 637 GB/s | 87.2 s |
| GB300 single-node FlashLoad | DeepSeek-V4-Pro | One 4-GPU GB300 node | TP4; one replica; from RAM | 217.0 GB | Included | PIN + H2D at 181–187 GB/s | 2.1 s |
| GB300 single-node SafeTensors load | DeepSeek-V4-Pro | One 4-GPU GB300 node | TP4; one replica; from RAM | 217.0 GB | Included | Per-tensor load | 67.4 s |

The PR intentionally does not vendor the FlashBoot implementation.

