### PR TITLE
Fix EnvField.override() leaking the env var when the with body raises

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -88,12 +88,16 @@ class EnvField:
         backup_value = os.environ.get(self.name)
         backup_set_to_none = self._set_to_none
         self.set(value)
-        yield
-        if backup_present:
-            os.environ[self.name] = backup_value
-        else:
-            os.environ.pop(self.name, None)
-        self._set_to_none = backup_set_to_none
+        try:
+            yield
+        finally:
+            # Restore even when the `with` body raises, otherwise the env var
+            # leaks into os.environ for the rest of the process.
+            if backup_present:
+                os.environ[self.name] = backup_value
+            else:
+                os.environ.pop(self.name, None)
+            self._set_to_none = backup_set_to_none
 
     def clear(self):
         os.environ.pop(self.name, None)

--- a/test/registered/unit/test_environ.py
+++ b/test/registered/unit/test_environ.py
@@ -53,6 +53,22 @@ class TestEnvField(unittest.TestCase):
         self.assertTrue(envs.SGLANG_TEST_RETRACT.is_set())
         self.assertIsNone(envs.SGLANG_TEST_RETRACT.get())
 
+    def test_override_restores_on_exception(self):
+        # The env var must be restored even when the `with` body raises;
+        # otherwise it leaks into os.environ for the rest of the process.
+        envs.SGLANG_TEST_RETRACT.set(True)
+        with self.assertRaises(RuntimeError):
+            with envs.SGLANG_TEST_RETRACT.override(False):
+                self.assertIs(envs.SGLANG_TEST_RETRACT.get(), False)
+                raise RuntimeError("boom")
+        self.assertIs(envs.SGLANG_TEST_RETRACT.get(), True)
+
+        envs.SGLANG_TEST_RETRACT.clear()
+        with self.assertRaises(RuntimeError):
+            with envs.SGLANG_TEST_RETRACT.override(False):
+                raise RuntimeError("boom")
+        self.assertFalse(envs.SGLANG_TEST_RETRACT.is_set())
+
     def test_override_with_exit_stack(self):
         envs.SGLANG_TEST_RETRACT.set(None)
         exit_stack = ExitStack()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Problem
EnvField.override() is a @contextmanager that temporarily sets an env var and restores it on exit. The restore logic sits after yield with no try/finally:

When the with body raises, contextlib.contextmanager throws the exception into the generator at the yield point. Because there is no try/finally, the code after yield is skipped, so the env var is never restored and permanently leaks into os.environ for the rest of the process.

Impact
Any code that does with envs.X.override(...): <raises> permanently contaminates the process environment. This is a real, general bug — it was surfaced by the NPU soft-watchdog test where scenario 4 intentionally fails the launch inside an override(350) block; the leaked SGLANG_TEST_STUCK_DETOKENIZER=350 was then inherited by every later server subprocess, causing cross-scenario contamination and a multi-minute slowdown.

## Modifications

<!-- Detail the changes made in this pull request. -->
Wrap the post-yield restore in try/finally so it runs on both the normal and the exception path:
self.set(value)
try:
    yield
finally:
    if backup_present:
        os.environ[self.name] = backup_value
    else:
        os.environ.pop(self.name, None)
    self._set_to_none = backup_set_to_none
The normal path is byte-for-byte equivalent; only the exception path changes (now it restores instead of leaking).
Test
Add test_override_restores_on_exception to test/registered/unit/test_environ.py, covering both cases:
- the var existed before the override → restored to its previous value after an exception;
- the var did not exist before → removed after an exception.
This regression test fails against the old code and passes with the fix.
## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32341832821](https://github.com/sgl-project/sglang/actions/runs/32341832821)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32341832238](https://github.com/sgl-project/sglang/actions/runs/32341832238)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32341832351](https://github.com/sgl-project/sglang/actions/runs/32341832351)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->