### PR TITLE
fix: resolve CPU device compatibility issues of LTX and Hy model

### DIFF
--- a/python/sglang/multimodal_gen/runtime/models/vocoder/ltx_2_vocoder.py
+++ b/python/sglang/multimodal_gen/runtime/models/vocoder/ltx_2_vocoder.py
@@ -713,7 +713,10 @@ class LTX2Vocoder(ABC, nn.Module, LayerwiseOffloadableModuleMixin):
                 else nullcontext()
             )
             with autocast_ctx:
-                waveform = self.vocoder(hidden_states.float())
+                vocoder_input = hidden_states.to(
+                    dtype=self.vocoder.conv_pre.weight.dtype
+                )
+                waveform = self.vocoder(vocoder_input)
                 length_low_rate = waveform.shape[-1]
                 output_length = (
                     length_low_rate
@@ -724,7 +727,10 @@ class LTX2Vocoder(ABC, nn.Module, LayerwiseOffloadableModuleMixin):
                 if remainder != 0:
                     waveform = F.pad(waveform, (0, self.hop_length - remainder))
                 mel = self._compute_ltx23_mel(waveform)
-                residual = self.bwe_generator(mel.transpose(2, 3))
+                bwe_input = mel.transpose(2, 3).to(
+                    dtype=self.bwe_generator.conv_pre.weight.dtype
+                )
+                residual = self.bwe_generator(bwe_input)
                 skip = self.resampler(waveform)
                 assert residual.shape == skip.shape
                 waveform = torch.clamp(residual + skip, -1, 1)[..., :output_length]

--- a/python/sglang/multimodal_gen/runtime/pipelines/ltx_2_pipeline.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines/ltx_2_pipeline.py
@@ -671,14 +671,10 @@ class LTX2TwoStagePipeline(_BaseLTX2Pipeline):
             # request-time merge/unmerge without keeping another DiT resident.
             if distilled_lora_strength is None:
                 distilled_lora_strength = float(self.STAGE_2_DISTILLED_LORA_STRENGTH)
-            if self._stage1_lora_path is not None and distilled_lora_strength != 0.0:
+            if self._stage1_lora_path and distilled_lora_strength != 0.0:
                 # Dynamic LoRA supports only one adapter per target, but
                 # original stage2 may need both the user LoRA and the
                 # distilled LoRA on the same transformer.
-                logger.info(
-                    "LTX2 original stage2 requires multiple adapters on "
-                    "transformer; forcing merge_weights=True."
-                )
                 return True
             return False
         return self._should_merge_stage2_distilled_lora(self.server_args)

--- a/python/sglang/multimodal_gen/runtime/pipelines/ltx_2_pipeline.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines/ltx_2_pipeline.py
@@ -661,10 +661,25 @@ class LTX2TwoStagePipeline(_BaseLTX2Pipeline):
             server_args.pipeline_config.vae_config.arch_config
         )
 
-    def _should_merge_lora_for_phase(self, phase: str) -> bool:
+    def _should_merge_lora_for_phase(
+        self,
+        phase: str,
+        distilled_lora_strength: float | None = None,
+    ) -> bool:
         if phase == "stage2" and self._ltx2_residency.mode == "original":
             # original mode reuses one DiT for both phases; dynamic LoRA avoids
-            # request-time merge/unmerge without keeping another DiT resident
+            # request-time merge/unmerge without keeping another DiT resident.
+            if distilled_lora_strength is None:
+                distilled_lora_strength = float(self.STAGE_2_DISTILLED_LORA_STRENGTH)
+            if self._stage1_lora_path is not None and distilled_lora_strength != 0.0:
+                # Dynamic LoRA supports only one adapter per target, but
+                # original stage2 may need both the user LoRA and the
+                # distilled LoRA on the same transformer.
+                logger.info(
+                    "LTX2 original stage2 requires multiple adapters on "
+                    "transformer; forcing merge_weights=True."
+                )
+                return True
             return False
         return self._should_merge_stage2_distilled_lora(self.server_args)
 
@@ -982,20 +997,9 @@ class LTX2TwoStagePipeline(_BaseLTX2Pipeline):
             if phase == "stage2":
                 # premerged modes keep official LTX-2.3 fused stage-2 LoRA; original
                 # avoids single-DiT request-time merge/unmerge with dynamic LoRA
-                merge_weights = self._should_merge_lora_for_phase(phase)
-                if (
-                    not merge_weights
-                    and self._stage1_lora_path is not None
-                    and distilled_lora_strength != 0.0
-                ):
-                    # Dynamic LoRA supports only one adapter per target, but
-                    # original stage2 may need both the user LoRA and the
-                    # distilled LoRA on the same transformer.
-                    merge_weights = True
-                    logger.info(
-                        "LTX2 original stage2 requires multiple adapters on "
-                        "transformer; forcing merge_weights=True."
-                    )
+                merge_weights = self._should_merge_lora_for_phase(
+                    phase, distilled_lora_strength=distilled_lora_strength
+                )
                 set_lora_kwargs["merge_weights"] = merge_weights
             elif phase == "stage1" and self.pipeline_name == "LTX2TwoStageHQPipeline":
                 # Official HQ also builds stage 1 with distilled LoRA fused.

--- a/python/sglang/multimodal_gen/runtime/pipelines/ltx_2_pipeline.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines/ltx_2_pipeline.py
@@ -982,9 +982,21 @@ class LTX2TwoStagePipeline(_BaseLTX2Pipeline):
             if phase == "stage2":
                 # premerged modes keep official LTX-2.3 fused stage-2 LoRA; original
                 # avoids single-DiT request-time merge/unmerge with dynamic LoRA
-                set_lora_kwargs["merge_weights"] = self._should_merge_lora_for_phase(
-                    phase
-                )
+                merge_weights = self._should_merge_lora_for_phase(phase)
+                if (
+                    not merge_weights
+                    and self._stage1_lora_path is not None
+                    and distilled_lora_strength != 0.0
+                ):
+                    # Dynamic LoRA supports only one adapter per target, but
+                    # original stage2 may need both the user LoRA and the
+                    # distilled LoRA on the same transformer.
+                    merge_weights = True
+                    logger.info(
+                        "LTX2 original stage2 requires multiple adapters on "
+                        "transformer; forcing merge_weights=True."
+                    )
+                set_lora_kwargs["merge_weights"] = merge_weights
             elif phase == "stage1" and self.pipeline_name == "LTX2TwoStageHQPipeline":
                 # Official HQ also builds stage 1 with distilled LoRA fused.
                 set_lora_kwargs["merge_weights"] = self._should_merge_lora_for_phase(

--- a/python/sglang/multimodal_gen/runtime/pipelines/ltx_2_pipeline.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines/ltx_2_pipeline.py
@@ -661,21 +661,10 @@ class LTX2TwoStagePipeline(_BaseLTX2Pipeline):
             server_args.pipeline_config.vae_config.arch_config
         )
 
-    def _should_merge_lora_for_phase(
-        self,
-        phase: str,
-        distilled_lora_strength: float | None = None,
-    ) -> bool:
+    def _should_merge_lora_for_phase(self, phase: str) -> bool:
         if phase == "stage2" and self._ltx2_residency.mode == "original":
             # original mode reuses one DiT for both phases; dynamic LoRA avoids
-            # request-time merge/unmerge without keeping another DiT resident.
-            if distilled_lora_strength is None:
-                distilled_lora_strength = float(self.STAGE_2_DISTILLED_LORA_STRENGTH)
-            if self._stage1_lora_path and distilled_lora_strength != 0.0:
-                # Dynamic LoRA supports only one adapter per target, but
-                # original stage2 may need both the user LoRA and the
-                # distilled LoRA on the same transformer.
-                return True
+            # request-time merge/unmerge without keeping another DiT resident
             return False
         return self._should_merge_stage2_distilled_lora(self.server_args)
 
@@ -993,10 +982,9 @@ class LTX2TwoStagePipeline(_BaseLTX2Pipeline):
             if phase == "stage2":
                 # premerged modes keep official LTX-2.3 fused stage-2 LoRA; original
                 # avoids single-DiT request-time merge/unmerge with dynamic LoRA
-                merge_weights = self._should_merge_lora_for_phase(
-                    phase, distilled_lora_strength=distilled_lora_strength
+                set_lora_kwargs["merge_weights"] = self._should_merge_lora_for_phase(
+                    phase
                 )
-                set_lora_kwargs["merge_weights"] = merge_weights
             elif phase == "stage1" and self.pipeline_name == "LTX2TwoStageHQPipeline":
                 # Official HQ also builds stage 1 with distilled LoRA fused.
                 set_lora_kwargs["merge_weights"] = self._should_merge_lora_for_phase(

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/lora/pipeline.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/lora/pipeline.py
@@ -288,10 +288,12 @@ class LoRAPipeline(ComposedPipelineBase):
             yield []
             return
 
-        # clear device cache to free up unused memory
-        if torch.get_device_module().is_available():
-            torch.get_device_module().synchronize()
-            torch.get_device_module().empty_cache()
+        # Clear device cache to free unused memory on backends that expose it.
+        device_module = torch.get_device_module()
+        if device_module.is_available() and hasattr(device_module, "empty_cache"):
+            if hasattr(device_module, "synchronize"):
+                device_module.synchronize()
+            device_module.empty_cache()
 
         offload_disabled_modules = []
         for module_name in module_names:

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/lora/pipeline.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/lora/pipeline.py
@@ -41,6 +41,7 @@ from sglang.multimodal_gen.runtime.pipelines_core.lora.peft_adapter import (
 from sglang.multimodal_gen.runtime.server_args import LORA_MERGE_MODES, ServerArgs
 from sglang.multimodal_gen.runtime.utils.hf_diffusers_utils import maybe_download_lora
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+from sglang.srt.platforms import current_platform
 
 # to avoid deadlocks when forking
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
@@ -289,11 +290,8 @@ class LoRAPipeline(ComposedPipelineBase):
             return
 
         # Clear device cache to free unused memory on backends that expose it.
-        device_module = torch.get_device_module()
-        if device_module.is_available() and hasattr(device_module, "empty_cache"):
-            if hasattr(device_module, "synchronize"):
-                device_module.synchronize()
-            device_module.empty_cache()
+        current_platform.synchronize()
+        current_platform.empty_cache()
 
         offload_disabled_modules = []
         for module_name in module_names:

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/lora/pipeline.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/lora/pipeline.py
@@ -38,10 +38,10 @@ from sglang.multimodal_gen.runtime.pipelines_core.lora.peft_adapter import (
     load_peft_config,
     scale_fused_sections,
 )
+from sglang.multimodal_gen.runtime.platforms import current_platform
 from sglang.multimodal_gen.runtime.server_args import LORA_MERGE_MODES, ServerArgs
 from sglang.multimodal_gen.runtime.utils.hf_diffusers_utils import maybe_download_lora
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
-from sglang.srt.platforms import current_platform
 
 # to avoid deadlocks when forking
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
@@ -290,8 +290,9 @@ class LoRAPipeline(ComposedPipelineBase):
             return
 
         # Clear device cache to free unused memory on backends that expose it.
-        current_platform.synchronize()
-        current_platform.empty_cache()
+        if not current_platform.is_cpu():
+            torch.get_device_module().synchronize()
+            torch.get_device_module().empty_cache()
 
         offload_disabled_modules = []
         for module_name in module_names:


### PR DESCRIPTION

## Motivation

This PR fixes two runtime failures in the LTX-2.3 two-stage serving path and one dtype failure in the LTX-2.3 vocoder path.

First, LoRA offload management previously used backend-specific cache APIs that were not portable across all device backends in this call site.

Second, LTX-2.3 two-stage original mode can build a stage-2 LoRA switch spec that applies both:
- user-provided LoRA
- built-in distilled LoRA

to the same transformer target.

Dynamic LoRA supports only one adapter per target, so this could trigger:
ValueError: Dynamic LoRA currently supports only one adapter per target

Additionally, the LTX-2.3 vocoder BWE path could hit:
Input type (float) and bias type (c10::BFloat16) should be the same
when input was forced to float32 but module weights/bias were bf16.

## Modifications

1. fix: portable cache-management calls in LoRA offload path
- Update cache clear logic in lora_pipeline.py
- Replace backend-specific torch device-module calls with platform abstraction:
  - `current_platform.synchronize()`
  - `current_platform.empty_cache()`
- This keeps behavior consistent across backends and avoids unsupported direct backend API assumptions in this path.

2. fix: Dynamic LoRA one-adapter-per-target conflict in stage2 original mode
- Update two-stage LoRA merge decision flow in `ltx_2_pipeline.py`
- Keep original default behavior: prefer dynamic LoRA in original mode to avoid request-time merge/unmerge on a single DiT
- Add narrow fallback: when stage2 needs both user LoRA and distilled LoRA on the same transformer target, force `merge_weights=true`
- Refactor this fallback into `_should_merge_lora_for_phase`, with a new optional parameter `distilled_lora_strength` that has a default value, so existing callers remain compatible without explicit argument passing.

3. fix: vocoder dtype mismatch in BWE path
- Update dtype handling in `ltx_2_vocoder.py`
- Align vocoder input dtype to `vocoder.conv_pre` weight dtype
- Align bwe_generator input dtype to `bwe_generator.conv_pre` weight dtype
- Preserve output cast-back behavior

## Accuracy Tests

- Verified LTX-2.3 two-stage generation runs successfully in original mode.
- The previous Dynamic LoRA multi-adapter stage2 failure is no longer reproducible.
- Verified vocoder decode path no longer reproduces the float vs bf16 conv dtype mismatch.
- Static checks on modified files report no new errors.





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32828152733](https://github.com/sgl-project/sglang/actions/runs/32828152733)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32828152450](https://github.com/sgl-project/sglang/actions/runs/32828152450)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32828152799](https://github.com/sgl-project/sglang/actions/runs/32828152799)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->