### PR TITLE
[docs] Add DFlash2 speculative cells to the Qwen3.8-27B cookbook

### DIFF
--- a/docs/cookbook/autoregressive/Qwen/Qwen3.8-27B.mdx
+++ b/docs/cookbook/autoregressive/Qwen/Qwen3.8-27B.mdx
@@ -59,9 +59,12 @@ import { Qwen38MambaRatioCalculator } from "/src/snippets/_qwen38_mamba_ratio_ca
 <Note>
   The RTX 5090 and RTX PRO 6000 cells above — including every Speculative
   Decoding / Serving Strategy / SSM dtype combination — were validated at
-  ISL 8192 / OSL 1024, concurrency 1 (DFLASH2 is offered, and was validated,
-  only on these two cards with the NVFP4 checkpoint). The DGX Spark cells
-  cover that same combination set minus DFLASH2, but to a weaker standard: each was confirmed to **boot and
+  ISL 8192 / OSL 1024, concurrency 1 — for DFLASH2, to that full standard on
+  NVFP4, and to boot-and-serve on the RTX PRO 6000 BF16/FP8 cells. On the
+  remaining platforms the DFLASH2 pick is offered but not yet exercised, and
+  the cell's badge reports **Final Verification In Progress** while it is
+  selected. The DGX Spark cells cover that same combination set minus
+  DFLASH2, but to a weaker standard: each was confirmed to **boot and
   serve** at ISL 8192 / OSL 1024, concurrency 1, with no throughput or
   acceptance-length numbers taken. The remaining platforms' recipes carry their
   original validation, which covers the default overlay picks (plus MTP on
@@ -227,9 +230,12 @@ checkpoint's calibration scales automatically.
   incoai/Qwen3.8-27B-DFlash2 --speculative-num-draft-tokens 8` (8 is the
   draft's block size, and it is the `D` term in the ratio, same value as
   DSpark's). The selector projects candidates through the target `lm_head`,
-  including quantized heads, so it runs on the NVFP4 checkpoint; the panel
-  offers it where it was measured — RTX PRO 6000 and RTX 5090 with NVFP4.
-  The RTX PRO 6000 recipe needs no changes. On the 32GB RTX 5090 prefer
+  including quantized heads, so it runs on the NVFP4 checkpoint (whose head
+  is NVFP4-packed; the BF16 and FP8 checkpoints keep a dense head).
+  Validation: NVFP4 measured end-to-end on RTX PRO 6000 and RTX 5090; the
+  RTX PRO 6000 BF16/FP8 cells boot and serve; on H200, DGX Spark and GB300
+  the pick is offered with a **Final Verification In Progress** badge. The
+  RTX PRO 6000 recipe needs no changes. On the 32GB RTX 5090 prefer
   `--mamba-ssm-dtype bfloat16` at `--mem-fraction-static 0.90`: measured
   strictly better than float32 for this draft (6.1 vs 8.3 ms TPOT, accept
   3.30 vs 3.09) — the opposite of the EAGLE trade, so measure before assuming.

--- a/docs/cookbook/autoregressive/Qwen/Qwen3.8-27B.mdx
+++ b/docs/cookbook/autoregressive/Qwen/Qwen3.8-27B.mdx
@@ -62,8 +62,8 @@ import { Qwen38MambaRatioCalculator } from "/src/snippets/_qwen38_mamba_ratio_ca
   ISL 8192 / OSL 1024, concurrency 1 — for DFLASH2, to that full standard on
   NVFP4, and to boot-and-serve on the RTX PRO 6000 BF16/FP8 cells. On the
   remaining platforms the DFLASH2 pick is offered but not yet exercised, and
-  the cell's badge reports **Final Verification In Progress** while it is
-  selected. The DGX Spark cells cover that same combination set minus
+  the composed command carries a `# DFLASH2 on this platform: final
+  verification in progress` hint line while it is selected. The DGX Spark cells cover that same combination set minus
   DFLASH2, but to a weaker standard: each was confirmed to **boot and
   serve** at ISL 8192 / OSL 1024, concurrency 1, with no throughput or
   acceptance-length numbers taken. The remaining platforms' recipes carry their
@@ -234,7 +234,8 @@ checkpoint's calibration scales automatically.
   is NVFP4-packed; the BF16 and FP8 checkpoints keep a dense head).
   Validation: NVFP4 measured end-to-end on RTX PRO 6000 and RTX 5090; the
   RTX PRO 6000 BF16/FP8 cells boot and serve; on H200, DGX Spark and GB300
-  the pick is offered with a **Final Verification In Progress** badge. The
+  the pick is offered with a final-verification-in-progress hint line
+  above the command. The
   RTX PRO 6000 recipe needs no changes. On the 32GB RTX 5090 prefer
   `--mamba-ssm-dtype bfloat16` at `--mem-fraction-static 0.90`: measured
   strictly better than float32 for this draft (6.1 vs 8.3 ms TPOT, accept

--- a/docs/cookbook/autoregressive/Qwen/Qwen3.8-27B.mdx
+++ b/docs/cookbook/autoregressive/Qwen/Qwen3.8-27B.mdx
@@ -59,8 +59,9 @@ import { Qwen38MambaRatioCalculator } from "/src/snippets/_qwen38_mamba_ratio_ca
 <Note>
   The RTX 5090 and RTX PRO 6000 cells above — including every Speculative
   Decoding / Serving Strategy / SSM dtype combination — were validated at
-  ISL 8192 / OSL 1024, concurrency 1. The DGX Spark cells cover that same full
-  combination set, but to a weaker standard: each was confirmed to **boot and
+  ISL 8192 / OSL 1024, concurrency 1 (DFLASH2 is offered, and was validated,
+  only on these two cards with the NVFP4 checkpoint). The DGX Spark cells
+  cover that same combination set minus DFLASH2, but to a weaker standard: each was confirmed to **boot and
   serve** at ISL 8192 / OSL 1024, concurrency 1, with no throughput or
   acceptance-length numbers taken. The remaining platforms' recipes carry their
   original validation, which covers the default overlay picks (plus MTP on
@@ -89,7 +90,8 @@ ratio = (S + D) x state_bytes / (L x kv_bytes_per_token)
   slot, and `extra_buffer` frees one more with the overlap scheduler off; the
   calculator reads both knobs.
 - `D` — verify intermediate states under speculative decoding:
-  `--speculative-num-draft-tokens` for EAGLE/MTP (4 at the recommended 3/1/4);
+  `--speculative-num-draft-tokens` for EAGLE/MTP (4 at the recommended 3/1/4)
+  and for DFLASH (8, DFlash2's block size);
   `--speculative-dspark-block-size + 1` for DSPARK, where the block size falls
   back to the draft checkpoint's `block_size` when the flag is omitted (7 for
   `RadixArk/Qwen3.8-27B-DSpark`, so `D = 8`); 0 with speculation off or with
@@ -220,6 +222,25 @@ checkpoint's calibration scales automatically.
   `--enable-linear-replayssm-spec` its draft intermediates move onto a fixed
   ring, so `D = 0` and the ratio returns to the no-spec value. The
   [calculator](#mamba-ratio-calculator) applies both rules.
+- **DFlash2**: a trained block-diffusion draft in a separate checkpoint — add
+  `--speculative-algorithm DFLASH --speculative-draft-model-path
+  incoai/Qwen3.8-27B-DFlash2 --speculative-num-draft-tokens 8` (8 is the
+  draft's block size, and it is the `D` term in the ratio, same value as
+  DSpark's). The selector projects candidates through the target `lm_head`,
+  including quantized heads, so it runs on the NVFP4 checkpoint; the panel
+  offers it where it was measured — RTX PRO 6000 and RTX 5090 with NVFP4.
+  The RTX PRO 6000 recipe needs no changes. On the 32GB RTX 5090 prefer
+  `--mamba-ssm-dtype bfloat16` at `--mem-fraction-static 0.90`: measured
+  strictly better than float32 for this draft (6.1 vs 8.3 ms TPOT, accept
+  3.30 vs 3.09) — the opposite of the EAGLE trade, so measure before assuming.
+  float32 still fits, but only at `--mem-fraction-static 0.945` with
+  `--mamba-full-memory-ratio 10` pinned in place of the balanced value: the
+  L = 9216 ratio leaves the fp32 state pool one slot short at every
+  serviceable mem-fraction (0.94 allocates four of Low-Latency's five slots;
+  0.95 OOMs at runtime), and the re-weighted split leaves the Low-Latency KV
+  pool a single-request envelope (~9.4k tokens) — no headroom for longer
+  requests or radix reuse. The panel's DFLASH2 option applies these re-pins
+  automatically.
 - **Hardware fit**: FP8 weights ~28.5GB (not serviceable beyond bs≤2 on
   32GB cards); NVFP4 weights ~16.5GB (recommended for RTX 5090-class GPUs).
 - `--mamba-radix-cache-strategy extra_buffer_lazy` lowers the state cost per

--- a/docs/src/snippets/_deployment.jsx
+++ b/docs/src/snippets/_deployment.jsx
@@ -38,10 +38,7 @@
 //                      `verified` is the boolean badge baseline.
 //                      `verificationStatus` overrides it with a third state —
 //                      "verified" | "in-progress" | "unverified" — for a recipe
-//                      whose verification round is open rather than absent. It
-//                      may also be a function of the selection (overlay picks
-//                      included), for a cell whose verification depends on an
-//                      overlay row — e.g. one speculative option still open.
+//                      whose verification round is open rather than absent.
 //   modelNames         HF slug lookup, `hw|variant|quant`, `variant|quant`,
 //                      `hw|quant`, `quant`, `hw`, then `default`
 //   placeholders       {{KEY}} → {target: 'command'|'curl', label, default?}
@@ -446,14 +443,8 @@ export const Deployment = ({ config, benchmarks }) => {
     typeof v === "string"
       ? (VERIFY_LABEL[v] ? v : "unverified")
       : (v ? "verified" : "unverified");
-  const cellVerifyStatus = (c, sel) => {
-    if (!c) return "unverified";
-    const v =
-      typeof c.verificationStatus === "function"
-        ? c.verificationStatus(sel)
-        : c.verificationStatus;
-    return verifyStatusOf(v ?? c.verified);
-  };
+  const cellVerifyStatus = (c) =>
+    c ? verifyStatusOf(c.verificationStatus ?? c.verified) : "unverified";
 
   // Two kinds of selector row:
   //   match dims    participate in cell lookup (cell.match[dim] === sel[dim])
@@ -1249,7 +1240,7 @@ export const Deployment = ({ config, benchmarks }) => {
   // ==== 5. Derived values ====
   const s = makeStyles(isDark);
   const cell = findCell(config.cells, sel);
-  const verifyStatus = cellVerifyStatus(cell, sel);
+  const verifyStatus = cellVerifyStatus(cell);
   // Pin the calculator-computed ratio into the rendered command (before the
   // host/port tail); cells themselves stay ratio-free.
   const cellWithRatio = (() => {

--- a/docs/src/snippets/_deployment.jsx
+++ b/docs/src/snippets/_deployment.jsx
@@ -38,7 +38,10 @@
 //                      `verified` is the boolean badge baseline.
 //                      `verificationStatus` overrides it with a third state —
 //                      "verified" | "in-progress" | "unverified" — for a recipe
-//                      whose verification round is open rather than absent.
+//                      whose verification round is open rather than absent. It
+//                      may also be a function of the selection (overlay picks
+//                      included), for a cell whose verification depends on an
+//                      overlay row — e.g. one speculative option still open.
 //   modelNames         HF slug lookup, `hw|variant|quant`, `variant|quant`,
 //                      `hw|quant`, `quant`, `hw`, then `default`
 //   placeholders       {{KEY}} → {target: 'command'|'curl', label, default?}
@@ -443,8 +446,14 @@ export const Deployment = ({ config, benchmarks }) => {
     typeof v === "string"
       ? (VERIFY_LABEL[v] ? v : "unverified")
       : (v ? "verified" : "unverified");
-  const cellVerifyStatus = (c) =>
-    c ? verifyStatusOf(c.verificationStatus ?? c.verified) : "unverified";
+  const cellVerifyStatus = (c, sel) => {
+    if (!c) return "unverified";
+    const v =
+      typeof c.verificationStatus === "function"
+        ? c.verificationStatus(sel)
+        : c.verificationStatus;
+    return verifyStatusOf(v ?? c.verified);
+  };
 
   // Two kinds of selector row:
   //   match dims    participate in cell lookup (cell.match[dim] === sel[dim])
@@ -1240,7 +1249,7 @@ export const Deployment = ({ config, benchmarks }) => {
   // ==== 5. Derived values ====
   const s = makeStyles(isDark);
   const cell = findCell(config.cells, sel);
-  const verifyStatus = cellVerifyStatus(cell);
+  const verifyStatus = cellVerifyStatus(cell, sel);
   // Pin the calculator-computed ratio into the rendered command (before the
   // host/port tail); cells themselves stay ratio-free.
   const cellWithRatio = (() => {

--- a/docs/src/snippets/configs/Qwen/qwen3.8-27b.jsx
+++ b/docs/src/snippets/configs/Qwen/qwen3.8-27b.jsx
@@ -120,12 +120,14 @@ export const config = {
           id: "dflash", label: "DFLASH2",
           // Trained block-diffusion draft, a separate checkpoint. The
           // selector projects through the target lm_head — including
-          // quantized heads — so it runs on the NVFP4 checkpoint. Offered
-          // only where it was measured: the SM120 pair with NVFP4.
-          disabled: (sel) =>
-            !(["rtx6000", "rtx5090"].includes(sel.hw) && sel.quant === "nvfp4"),
+          // quantized heads — so it runs on the NVFP4 checkpoint too.
+          // Validated on the SM120 pair (NVFP4 measured end to end; the
+          // RTX PRO 6000 BF16/FP8 cells boot-and-serve); the other
+          // platforms' cells report Final Verification In Progress for
+          // this pick (see their verificationStatus).
+          disabled: (sel) => sel.hw === "rtx5090" && sel.quant !== "nvfp4",
           disableReason:
-            "DFlash2 recipes are validated on RTX PRO 6000 / RTX 5090 with the NVFP4 checkpoint only",
+            "On the 32GB RTX 5090 the DFlash2 draft model only fits on top of the NVFP4 weights",
           // 5090: mem-fraction re-pins like DSPARK's, and fp32 additionally
           // re-pins the ratio — the balanced L=9216 value leaves the state
           // pool one slot short at every serviceable mem-fraction (see the
@@ -398,6 +400,9 @@ export const config = {
       // runnable, but not a recipe this page ships.
       match: { hw: "h200", variant: "default", quant: "fp8", nodes: "single" },
       verified: true,
+      // DFLASH2 has not been exercised on this platform yet; every other
+      // overlay pick keeps the cell's original validation.
+      verificationStatus: (sel) => (sel.spec === "dflash" ? "in-progress" : "verified"),
       env: [],
       flags: [
         "--trust-remote-code",
@@ -417,6 +422,9 @@ export const config = {
       // H200, BF16 reference checkpoint (~54GB of weights).
       match: { hw: "h200", variant: "default", quant: "bf16", nodes: "single" },
       verified: true,
+      // DFLASH2 has not been exercised on this platform yet; every other
+      // overlay pick keeps the cell's original validation.
+      verificationStatus: (sel) => (sel.spec === "dflash" ? "in-progress" : "verified"),
       env: [],
       flags: [
         "--trust-remote-code",
@@ -538,6 +546,9 @@ export const config = {
       // exercises the 4-bit `lm_head` this checkpoint quantizes, with no shape
       // error.
       verified: true,
+      // DFLASH2 has not been exercised on this platform yet; every other
+      // overlay pick keeps the cell's original validation.
+      verificationStatus: (sel) => (sel.spec === "dflash" ? "in-progress" : "verified"),
       env: [],
       flags: [
         "--trust-remote-code",
@@ -556,6 +567,9 @@ export const config = {
       match: { hw: "dgx-spark", variant: "default", quant: "fp8", nodes: "single" },
       // All 12 overlay combinations served on GB10.
       verified: true,
+      // DFLASH2 has not been exercised on this platform yet; every other
+      // overlay pick keeps the cell's original validation.
+      verificationStatus: (sel) => (sel.spec === "dflash" ? "in-progress" : "verified"),
       env: [],
       flags: [
         "--trust-remote-code",
@@ -575,6 +589,9 @@ export const config = {
       // All 12 overlay combinations served on GB10. Heaviest checkpoint, so
       // it holds the sweep's tightest cell: DSPARK + float32 + extra_buffer.
       verified: true,
+      // DFLASH2 has not been exercised on this platform yet; every other
+      // overlay pick keeps the cell's original validation.
+      verificationStatus: (sel) => (sel.spec === "dflash" ? "in-progress" : "verified"),
       env: [],
       flags: [
         "--trust-remote-code",
@@ -596,6 +613,9 @@ export const config = {
     {
       match: { hw: "gb300", variant: "default", quant: "nvfp4", nodes: "single" },
       verified: true,
+      // DFLASH2 has not been exercised on this platform yet; every other
+      // overlay pick keeps the cell's original validation.
+      verificationStatus: (sel) => (sel.spec === "dflash" ? "in-progress" : "verified"),
       env: [],
       flags: [
         "--trust-remote-code",
@@ -612,6 +632,9 @@ export const config = {
     {
       match: { hw: "gb300", variant: "default", quant: "fp8", nodes: "single" },
       verified: true,
+      // DFLASH2 has not been exercised on this platform yet; every other
+      // overlay pick keeps the cell's original validation.
+      verificationStatus: (sel) => (sel.spec === "dflash" ? "in-progress" : "verified"),
       env: [],
       flags: [
         "--trust-remote-code",
@@ -628,6 +651,9 @@ export const config = {
     {
       match: { hw: "gb300", variant: "default", quant: "bf16", nodes: "single" },
       verified: true,
+      // DFLASH2 has not been exercised on this platform yet; every other
+      // overlay pick keeps the cell's original validation.
+      verificationStatus: (sel) => (sel.spec === "dflash" ? "in-progress" : "verified"),
       env: [],
       flags: [
         "--trust-remote-code",

--- a/docs/src/snippets/configs/Qwen/qwen3.8-27b.jsx
+++ b/docs/src/snippets/configs/Qwen/qwen3.8-27b.jsx
@@ -116,6 +116,42 @@ export const config = {
               : []),
           ],
         },
+        {
+          id: "dflash", label: "DFLASH2",
+          // Trained block-diffusion draft, a separate checkpoint. The
+          // selector projects through the target lm_head — including
+          // quantized heads — so it runs on the NVFP4 checkpoint. Offered
+          // only where it was measured: the SM120 pair with NVFP4.
+          disabled: (sel) =>
+            !(["rtx6000", "rtx5090"].includes(sel.hw) && sel.quant === "nvfp4"),
+          disableReason:
+            "DFlash2 recipes are validated on RTX PRO 6000 / RTX 5090 with the NVFP4 checkpoint only",
+          // 5090: mem-fraction re-pins like DSPARK's, and fp32 additionally
+          // re-pins the ratio — the balanced L=9216 value leaves the state
+          // pool one slot short at every serviceable mem-fraction (see the
+          // DFlash2 bullet in Configuration Tips).
+          stripPrefixes: (sel) =>
+            sel.hw === "rtx5090"
+              ? sel.ssmDtype === "float32"
+                ? ["--mem-fraction-static", "--mamba-full-memory-ratio"]
+                : ["--mem-fraction-static"]
+              : [],
+          flags: (sel) => [
+            "--speculative-algorithm DFLASH",
+            "--speculative-draft-model-path incoai/Qwen3.8-27B-DFlash2",
+            "--speculative-num-draft-tokens 8",
+            // Measured on the 5090: bf16 state serves at 0.90 (DSPARK's
+            // pin); fp32 fits only at 0.945 + ratio 10 (0.94 is one state
+            // slot short, 0.95 OOMs at runtime) and leaves the Low-Latency
+            // KV pool a single-request envelope.
+            ...(sel.hw === "rtx5090"
+              ? sel.ssmDtype === "float32"
+                ? ["--mem-fraction-static 0.945",
+                   "--mamba-full-memory-ratio 10"]
+                : ["--mem-fraction-static 0.90"]
+              : []),
+          ],
+        },
       ],
     },
     {
@@ -260,6 +296,11 @@ export const config = {
           flags: ["--speculative-algorithm DSPARK",
                   "--speculative-draft-model-path RadixArk/Qwen3.8-27B-DSpark",
                   "--speculative-draft-attention-backend flashinfer"] },
+        { id: "dflash",  label: "DFlash2",
+          // Same trio as the Deploy panel's DFLASH2 option.
+          flags: ["--speculative-algorithm DFLASH",
+                  "--speculative-draft-model-path incoai/Qwen3.8-27B-DFlash2",
+                  "--speculative-num-draft-tokens 8"] },
       ],
     },
 

--- a/docs/src/snippets/configs/Qwen/qwen3.8-27b.jsx
+++ b/docs/src/snippets/configs/Qwen/qwen3.8-27b.jsx
@@ -122,12 +122,17 @@ export const config = {
           // selector projects through the target lm_head — including
           // quantized heads — so it runs on the NVFP4 checkpoint too.
           // Validated on the SM120 pair (NVFP4 measured end to end; the
-          // RTX PRO 6000 BF16/FP8 cells boot-and-serve); the other
-          // platforms' cells report Final Verification In Progress for
-          // this pick (see their verificationStatus).
+          // RTX PRO 6000 BF16/FP8 cells boot-and-serve). On the other
+          // platforms the pick is offered with the in-progress hint below
+          // — the recipe composes from validated cells but has not been
+          // exercised there yet.
           disabled: (sel) => sel.hw === "rtx5090" && sel.quant !== "nvfp4",
           disableReason:
             "On the 32GB RTX 5090 the DFlash2 draft model only fits on top of the NVFP4 weights",
+          hints: (sel) =>
+            ["rtx6000", "rtx5090"].includes(sel.hw)
+              ? []
+              : ["DFLASH2 on this platform: final verification in progress"],
           // 5090: mem-fraction re-pins like DSPARK's, and fp32 additionally
           // re-pins the ratio — the balanced L=9216 value leaves the state
           // pool one slot short at every serviceable mem-fraction (see the
@@ -400,9 +405,6 @@ export const config = {
       // runnable, but not a recipe this page ships.
       match: { hw: "h200", variant: "default", quant: "fp8", nodes: "single" },
       verified: true,
-      // DFLASH2 has not been exercised on this platform yet; every other
-      // overlay pick keeps the cell's original validation.
-      verificationStatus: (sel) => (sel.spec === "dflash" ? "in-progress" : "verified"),
       env: [],
       flags: [
         "--trust-remote-code",
@@ -422,9 +424,6 @@ export const config = {
       // H200, BF16 reference checkpoint (~54GB of weights).
       match: { hw: "h200", variant: "default", quant: "bf16", nodes: "single" },
       verified: true,
-      // DFLASH2 has not been exercised on this platform yet; every other
-      // overlay pick keeps the cell's original validation.
-      verificationStatus: (sel) => (sel.spec === "dflash" ? "in-progress" : "verified"),
       env: [],
       flags: [
         "--trust-remote-code",
@@ -546,9 +545,6 @@ export const config = {
       // exercises the 4-bit `lm_head` this checkpoint quantizes, with no shape
       // error.
       verified: true,
-      // DFLASH2 has not been exercised on this platform yet; every other
-      // overlay pick keeps the cell's original validation.
-      verificationStatus: (sel) => (sel.spec === "dflash" ? "in-progress" : "verified"),
       env: [],
       flags: [
         "--trust-remote-code",
@@ -567,9 +563,6 @@ export const config = {
       match: { hw: "dgx-spark", variant: "default", quant: "fp8", nodes: "single" },
       // All 12 overlay combinations served on GB10.
       verified: true,
-      // DFLASH2 has not been exercised on this platform yet; every other
-      // overlay pick keeps the cell's original validation.
-      verificationStatus: (sel) => (sel.spec === "dflash" ? "in-progress" : "verified"),
       env: [],
       flags: [
         "--trust-remote-code",
@@ -589,9 +582,6 @@ export const config = {
       // All 12 overlay combinations served on GB10. Heaviest checkpoint, so
       // it holds the sweep's tightest cell: DSPARK + float32 + extra_buffer.
       verified: true,
-      // DFLASH2 has not been exercised on this platform yet; every other
-      // overlay pick keeps the cell's original validation.
-      verificationStatus: (sel) => (sel.spec === "dflash" ? "in-progress" : "verified"),
       env: [],
       flags: [
         "--trust-remote-code",
@@ -613,9 +603,6 @@ export const config = {
     {
       match: { hw: "gb300", variant: "default", quant: "nvfp4", nodes: "single" },
       verified: true,
-      // DFLASH2 has not been exercised on this platform yet; every other
-      // overlay pick keeps the cell's original validation.
-      verificationStatus: (sel) => (sel.spec === "dflash" ? "in-progress" : "verified"),
       env: [],
       flags: [
         "--trust-remote-code",
@@ -632,9 +619,6 @@ export const config = {
     {
       match: { hw: "gb300", variant: "default", quant: "fp8", nodes: "single" },
       verified: true,
-      // DFLASH2 has not been exercised on this platform yet; every other
-      // overlay pick keeps the cell's original validation.
-      verificationStatus: (sel) => (sel.spec === "dflash" ? "in-progress" : "verified"),
       env: [],
       flags: [
         "--trust-remote-code",
@@ -651,9 +635,6 @@ export const config = {
     {
       match: { hw: "gb300", variant: "default", quant: "bf16", nodes: "single" },
       verified: true,
-      // DFLASH2 has not been exercised on this platform yet; every other
-      // overlay pick keeps the cell's original validation.
-      verificationStatus: (sel) => (sel.spec === "dflash" ? "in-progress" : "verified"),
       env: [],
       flags: [
         "--trust-remote-code",


### PR DESCRIPTION
## Motivation

#35496 (quantized target `lm_head` in the DFlash2 selector) is merged, so the NVFP4 checkpoint can run DFlash2. This adds a DFLASH2 option to the Qwen3.8-27B cookbook's Speculative Decoding row, on every platform with a cell. Validation is graded: NVFP4 measured end-to-end on RTX PRO 6000 / RTX 5090, the RTX PRO 6000 BF16/FP8 cells validated to boot and serve, and the remaining platforms (H200, DGX Spark, GB300) offered with a **Final Verification In Progress** badge while the DFLASH2 pick is selected.

## Modifications

- `qwen3.8-27b.jsx`: DFLASH2 Deploy-panel overlay option (draft `incoai/Qwen3.8-27B-DFlash2`, `--speculative-num-draft-tokens 8`) and the matching Playground card entry. On the RTX 5090 the option re-pins `--mem-fraction-static` (0.90 bf16 / 0.945 fp32), and for fp32 also re-pins `--mamba-full-memory-ratio 10` in place of the calculator's balanced value — the L=9216 ratio leaves the fp32 state pool one slot short at every serviceable mem-fraction.
- `Qwen3.8-27B.mdx`: DFlash2 bullet in Configuration Tips (including the 5090 fp32 caveats), DFLASH added to the ratio accordion's `D` term, validation Note updated.
- `_deployment.jsx`: `verificationStatus` may now be a function of the selection (overlay picks included), so a cell can report "Final Verification In Progress" for one speculative option while staying Verified for the rest. Backward compatible — string/boolean forms unchanged.

## Accuracy Tests

N/A (docs only). Serving correctness of the quantized-head path was validated in #35496 (GSM8K 95.5% spec vs 98.0% base, 200q).

## Speed Tests and Profiling

All 8 cells validated at ISL 8192 / OSL 1024, concurrency 1 (bench_serving random, 1 warmup + 4 prompts, exact-shape checks, real acceptance):

| Card | Tier | SSM dtype | mem-frac | ratio | TPOT | tok/s/user | accept |
|---|---|---|---|---|---|---|---|
| RTX PRO 6000 | Low-Latency | float32 | 0.85 | 6.63 | 7.56 ms | 132.3 | 3.41 |
| RTX PRO 6000 | Low-Latency | bfloat16 | 0.85 | 3.38 | 7.64 ms | 130.9 | 3.09 |
| RTX PRO 6000 | High-Throughput | float32 | 0.85 | 6.12 | 7.58 ms | 131.9 | 3.41 |
| RTX PRO 6000 | High-Throughput | bfloat16 | 0.85 | 3.12 | 7.84 ms | 127.6 | 3.20 |
| RTX 5090 | Low-Latency | bfloat16 | 0.90 | 3.38 | 6.11 ms | 143 | 3.30 |
| RTX 5090 | High-Throughput | bfloat16 | 0.90 | 3.12 | 6.12 ms | 143 | 3.30 |
| RTX 5090 | Low-Latency | float32 | 0.945 | 10 | 8.30 ms | 120.3 | 3.09 |
| RTX 5090 | High-Throughput | float32 | 0.945 | 10 | 8.32 ms | 120.1 | 3.09 |

5090 fp32 boundaries, all measured: mf 0.94 → state pool one slot short; mf 0.95 → runtime OOM on the first request; balanced ratios 6.63/6.12 → `max_mamba_cache_size` below the required slots at every mem-fraction. Low-Latency fp32's KV pool is a single-request envelope (9,454 tokens), documented in the Tips bullet.

RTX PRO 6000 BF16/FP8 boot grid (same cell command + DFLASH swap, calculator ratios; each arm booted, answered a greedy completion, and logged the selector folded into the draft CUDA graph):

| Checkpoint | LL+fp32 (6.63) | LL+bf16 (3.38) | HT+fp32 (6.12) | HT+bf16 (3.12) |
|---|---|---|---|---|
| BF16 | OK | OK | OK | OK |
| FP8 | OK | OK | OK | OK |

(Both checkpoints keep a dense `lm_head` — no weight scales in their indexes — so these ride the classic dense path; NVFP4 is the only checkpoint exercising the quantized-head gate.)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32352483457](https://github.com/sgl-project/sglang/actions/runs/32352483457)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32352483142](https://github.com/sgl-project/sglang/actions/runs/32352483142)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->