### PR TITLE
[diffusion] keep the checkpoint mapping as the host store when pinning is off

### DIFF
--- a/python/sglang/multimodal_gen/runtime/loader/utils.py
+++ b/python/sglang/multimodal_gen/runtime/loader/utils.py
@@ -357,6 +357,47 @@ def _read_process_mappings() -> tuple[list[int], list[int], list[bool]] | None:
     return [r[0] for r in rows], [r[1] for r in rows], [r[2] for r in rows]
 
 
+class ProcessMappings:
+    """One snapshot of this process's address space.
+
+    Built once and asked many times: re-reading /proc/self/maps per tensor would
+    dominate a loop over a checkpoint's worth of weights. Linux only; elsewhere
+    every tensor simply reports as not file-backed.
+    """
+
+    def __init__(self) -> None:
+        self._mappings = _read_process_mappings()
+
+    def is_file_backed(self, tensor: torch.Tensor) -> bool:
+        """Whether this tensor's bytes live in a file mapping.
+
+        File-backed pages are the only host memory the kernel can reclaim
+        without swap, so this is the question that decides whether a host copy
+        costs the process anything it cannot give back.
+        """
+        if self._mappings is None or tensor.device.type != "cpu":
+            return False
+        try:
+            pointer = tensor.untyped_storage().data_ptr()
+        except Exception:
+            return False
+        if pointer == 0:
+            return False
+        # CUDA's host allocator sits behind a mapping that carries a pathname,
+        # so the check below would call pinned memory file-backed. It is not:
+        # the kernel cannot reclaim it at all.
+        try:
+            if tensor.is_pinned():
+                return False
+        except Exception:
+            pass
+        starts, ends, backed = self._mappings
+        index = bisect.bisect_right(starts, pointer) - 1
+        if index < 0 or pointer >= ends[index]:
+            return False
+        return backed[index]
+
+
 def component_residency_bytes(module) -> Dict[str, int]:
     """Where a component's weights actually sit, in bytes.
 
@@ -380,16 +421,7 @@ def component_residency_bytes(module) -> Dict[str, int]:
 
     totals = {"vram": 0, "host_pinned": 0, "host_mapped": 0, "host": 0}
     seen: set[int] = set()
-    mappings = _read_process_mappings()
-
-    def is_file_backed(pointer: int) -> bool:
-        if mappings is None:
-            return False
-        starts, ends, backed = mappings
-        index = bisect.bisect_right(starts, pointer) - 1
-        if index < 0 or pointer >= ends[index]:
-            return False
-        return backed[index]
+    mappings = ProcessMappings()
 
     def add(tensor: torch.Tensor) -> None:
         try:
@@ -410,7 +442,7 @@ def component_residency_bytes(module) -> Dict[str, int]:
             pinned = False
         if pinned:
             bucket = "host_pinned"
-        elif is_file_backed(pointer):
+        elif mappings.is_file_backed(tensor):
             bucket = "host_mapped"
         else:
             bucket = "host"

--- a/python/sglang/multimodal_gen/runtime/managers/memory_managers/layerwise_offload.py
+++ b/python/sglang/multimodal_gen/runtime/managers/memory_managers/layerwise_offload.py
@@ -1,5 +1,6 @@
 import bisect
 import re
+import time
 from collections.abc import Mapping, Sequence
 from contextlib import nullcontext
 from typing import Any, Dict, List, Set, Tuple
@@ -524,11 +525,17 @@ class LayerwiseOffloadManager:
         self.register_forward_hooks()
         self._configured = True
         if self._kept_mappings:
+            started = time.perf_counter()
+            faulted = self.prefault_mapped_weights()
             logger.info(
                 "Layerwise offload kept %d of this module's weights on the "
                 "checkpoint mapping instead of copying them; those pages stay "
-                "reclaimable, which without swap anonymous ones are not.",
+                "reclaimable, which without swap anonymous ones are not. "
+                "Faulted in %.2f GB of them in %.1fs so the first request does "
+                "not read them from disk.",
                 self._kept_mappings,
+                faulted / 1024**3,
+                time.perf_counter() - started,
             )
         logger.debug(
             f"LayerwiseOffloadManager initialized with num prefetched layer: {self.prefetch_size}, num resident layers: {self.resident_layers}, total num layers: {self.num_layers}, residency policy: {self.residency_policy}"
@@ -582,6 +589,40 @@ class LayerwiseOffloadManager:
         logger.info(
             f"Initialized synchronous MPS layerwise offload with {self.num_layers} layers"
         )
+
+    def prefault_mapped_weights(self) -> int:
+        """Read every kept mapping once, so the first request does not pay for it.
+
+        A mapped page is faulted in on first touch, and until then a copy out of
+        it runs at disk speed rather than memory speed: measured on one RTX 4090,
+        2.63 GB/s cold against 12.38 GB/s once resident, which is within 8% of
+        pinned memory. Touching one byte per page here is enough to fault the
+        whole page in, and moves that cost from the first request to startup.
+
+        `MADV_WILLNEED` was tried instead and bought nothing -- it returns in
+        milliseconds and the readahead has not happened by the time the copy
+        starts, so the copy still ran at 2.62 GB/s.
+
+        Best-effort by nature: these pages are reclaimable, which is the reason
+        the mapping was kept. Under memory pressure the kernel may drop them
+        again, and the next copy pays the fault. That is the trade, not a bug.
+
+        Returns the number of bytes faulted in.
+        """
+        if not self._kept_mappings:
+            return 0
+        page = 4096
+        touched = 0
+        for by_name in self._standalone_cpu_weights.values():
+            for tensor in by_name.values():
+                if not self._process_mappings.is_file_backed(tensor):
+                    continue
+                storage = tensor.untyped_storage()
+                # a byte view over the whole storage, whatever the tensor layout
+                as_bytes = torch.empty(0, dtype=torch.uint8).set_(storage)
+                as_bytes[::page].sum()
+                touched += storage.nbytes()
+        return touched
 
     def prepare_for_next_req(self, non_blocking=True):
         """

--- a/python/sglang/multimodal_gen/runtime/managers/memory_managers/layerwise_offload.py
+++ b/python/sglang/multimodal_gen/runtime/managers/memory_managers/layerwise_offload.py
@@ -8,6 +8,7 @@ import torch
 from torch.distributed.tensor import DTensor
 
 from sglang.multimodal_gen.runtime.disaggregation.roles import RoleType
+from sglang.multimodal_gen.runtime.loader.utils import ProcessMappings
 from sglang.multimodal_gen.runtime.managers.memory_managers.component_residency import (
     COMPONENT_RESIDENCY_GROUPS,
     LAYERWISE_OFFLOAD,
@@ -261,9 +262,14 @@ class LayerwiseOffloadManager:
         # layer_idx -> {dtype: consolidated_pinned_cpu_tensor}
         # stores the consolidated weight from a same layer, of same dtype
         self._consolidated_cpu_weights: Dict[int, Dict[torch.dtype, torch.Tensor]] = {}
-        # layer_idx -> {name: pinned_cpu_tensor_with_original_stride}
-        # stores tensors whose original non-contiguous stride/layout must be preserved
-        self._strided_cpu_weights: Dict[int, Dict[str, torch.Tensor]] = {}
+        # layer_idx -> {name: this weight's own host tensor}
+        # for weights that cannot be a slice of the flat buffer: a layout that
+        # has to survive, or a checkpoint mapping worth keeping
+        self._standalone_cpu_weights: Dict[int, Dict[str, torch.Tensor]] = {}
+        # Asked once per weight during initialization, so snapshot the address
+        # space rather than re-reading /proc for each one.
+        self._process_mappings = ProcessMappings()
+        self._kept_mappings = 0
         # mps keeps the original CPU tensor for each layer instead of building a
         # second flattened host copy
         self._mps_cpu_weights: Dict[int, Dict[str, torch.Tensor]] = {}
@@ -334,6 +340,19 @@ class LayerwiseOffloadManager:
     ) -> torch.Tensor:
         return self._wrap_for_target(target, self._get_shared_empty_tensor(dtype))
 
+    def _can_keep_mapping(self, local_weight: torch.Tensor) -> bool:
+        """Whether this weight's host store can just be the checkpoint mapping.
+
+        Only when pinning is off. A pinned host copy is what lets the copy
+        stream run ahead of compute, and a mapping cannot be pinned and stay
+        reclaimable at the same time, so with pinning on the copy earns its
+        cost. With pinning off the copy earns nothing: it moves the same bytes
+        at the same speed into memory the kernel can no longer drop.
+        """
+        if self.pin_cpu_memory or self._synchronous_mps:
+            return False
+        return self._process_mappings.is_file_backed(local_weight)
+
     @staticmethod
     def _get_alignment_numel(dtype: torch.dtype, alignment_bytes: int = 32) -> int:
         element_size = torch.empty((), dtype=dtype).element_size()
@@ -394,19 +413,46 @@ class LayerwiseOffloadManager:
         # 2. concat and offload (in pinned memory)
         for layer_idx, dtype_to_params in layer_groups.items():
             self._consolidated_cpu_weights[layer_idx] = {}
-            self._strided_cpu_weights[layer_idx] = {}
+            self._standalone_cpu_weights[layer_idx] = {}
             self._weight_metadata[layer_idx] = {}
 
             for dtype, weights in dtype_to_params.items():
                 contiguous_weights: List[Tuple[str, torch.Tensor, torch.Tensor]] = []
                 for name, weight in weights:
                     local_weight = self._to_local_tensor(weight)
+
+                    if self._can_keep_mapping(local_weight):
+                        # The checkpoint is already mapped and these bytes are
+                        # exactly what the copy needs, so keep the mapping as
+                        # the host store. Copying it into anonymous memory would
+                        # buy nothing and cost the kernel its ability to reclaim
+                        # those pages, which without swap it otherwise has.
+                        # detach first: the line below rebinds weight.data, and
+                        # local_weight may be that same object, so storing it
+                        # directly would hand the placeholder back as the weight
+                        self._standalone_cpu_weights[layer_idx][
+                            name
+                        ] = local_weight.detach()
+                        self._weight_metadata[layer_idx][name] = {
+                            "dtype": dtype,
+                            "shape": local_weight.shape,
+                            "stride": local_weight.stride(),
+                            "standalone_host_store": True,
+                        }
+                        weight.data = self._get_shared_empty_tensor_for_target(
+                            weight, dtype
+                        )
+                        self._kept_mappings += 1
+                        continue
+
                     if local_weight.is_contiguous():
                         contiguous_weights.append((name, weight, local_weight))
                         continue
 
-                    # Preserve non-contiguous layouts such as the transposed FP8
-                    # weight views expected by CUTLASS kernels.
+                    # A weight gets its own host tensor when it cannot live as a
+                    # slice of the flat buffer -- here because a non-contiguous
+                    # layout has to survive, such as the transposed FP8 weight
+                    # views CUTLASS kernels expect.
                     cpu_tensor = torch.empty_strided(
                         size=local_weight.shape,
                         stride=local_weight.stride(),
@@ -414,12 +460,12 @@ class LayerwiseOffloadManager:
                         pin_memory=self.pin_cpu_memory,
                     )
                     cpu_tensor.copy_(local_weight)
-                    self._strided_cpu_weights[layer_idx][name] = cpu_tensor
+                    self._standalone_cpu_weights[layer_idx][name] = cpu_tensor
                     self._weight_metadata[layer_idx][name] = {
                         "dtype": dtype,
                         "shape": local_weight.shape,
                         "stride": local_weight.stride(),
-                        "preserve_strides": True,
+                        "standalone_host_store": True,
                     }
                     weight.data = self._get_shared_empty_tensor_for_target(
                         weight, dtype
@@ -459,7 +505,7 @@ class LayerwiseOffloadManager:
                         "numel": numel,
                         "shape": local_weight.shape,
                         "stride": local_weight.stride(),
-                        "preserve_strides": False,
+                        "standalone_host_store": False,
                     }
 
                     weight.data = self._get_shared_empty_tensor_for_target(
@@ -477,6 +523,13 @@ class LayerwiseOffloadManager:
 
         self.register_forward_hooks()
         self._configured = True
+        if self._kept_mappings:
+            logger.info(
+                "Layerwise offload kept %d of this module's weights on the "
+                "checkpoint mapping instead of copying them; those pages stay "
+                "reclaimable, which without swap anonymous ones are not.",
+                self._kept_mappings,
+            )
         logger.debug(
             f"LayerwiseOffloadManager initialized with num prefetched layer: {self.prefetch_size}, num resident layers: {self.resident_layers}, total num layers: {self.num_layers}, residency policy: {self.residency_policy}"
         )
@@ -651,12 +704,12 @@ class LayerwiseOffloadManager:
             # so the recorded event covers both flat-buffer and stride-preserving copies.
             for name, meta in self._weight_metadata[layer_idx].items():
                 target = self.get_target_with_name(name)
-                if meta.get("preserve_strides", False):
+                if meta.get("standalone_host_store", False):
                     # Recreate the original view layout instead of flatten+view.
                     # ModelOpt FP8 relies on a transposed runtime weight layout,
                     # so preserving stride is part of correctness, not just an
                     # optimization detail.
-                    cpu_tensor = self._strided_cpu_weights[layer_idx][name]
+                    cpu_tensor = self._standalone_cpu_weights[layer_idx][name]
                     gpu_tensor = torch.empty_strided(
                         size=meta["shape"],
                         stride=meta["stride"],
@@ -762,8 +815,8 @@ class LayerwiseOffloadManager:
         for name, meta in self._weight_metadata.get(layer_idx, {}).items():
             target = self.get_target_with_name(name)
             target_local = self._to_local_tensor(target)
-            if meta.get("preserve_strides", False):
-                self._strided_cpu_weights[layer_idx][name].copy_(target_local.cpu())
+            if meta.get("standalone_host_store", False):
+                self._standalone_cpu_weights[layer_idx][name].copy_(target_local.cpu())
                 continue
 
             gpu_weight = target_local.flatten().cpu()
@@ -859,8 +912,8 @@ class LayerwiseOffloadManager:
                 )
 
             dtype = meta["dtype"]
-            if meta.get("preserve_strides", False):
-                self._strided_cpu_weights[layer_idx][name].copy_(
+            if meta.get("standalone_host_store", False):
+                self._standalone_cpu_weights[layer_idx][name].copy_(
                     local_loaded_weight.to(dtype=dtype)
                 )
             else:
@@ -897,12 +950,11 @@ class LayerwiseOffloadManager:
 
         for layer_idx in sorted(self._weight_metadata):
             for name, meta in self._weight_metadata[layer_idx].items():
-                if meta.get("preserve_strides", False):
-                    # Some quantized weights rely on a non-contiguous layout.
-                    # Yield the strided tensor directly instead of rebuilding it
-                    # from the flat buffer, which would silently lose the
-                    # original stride information.
-                    yield name, self._strided_cpu_weights[layer_idx][name]
+                if meta.get("standalone_host_store", False):
+                    # This weight has its own host tensor, so yield it directly
+                    # rather than rebuilding it from the flat buffer, which
+                    # would silently lose its layout.
+                    yield name, self._standalone_cpu_weights[layer_idx][name]
                     continue
 
                 dtype = meta["dtype"]

--- a/python/sglang/multimodal_gen/test/unit/test_layerwise_offload.py
+++ b/python/sglang/multimodal_gen/test/unit/test_layerwise_offload.py
@@ -1,3 +1,4 @@
+import pathlib
 from contextlib import nullcontext
 from types import SimpleNamespace
 
@@ -12,6 +13,7 @@ from sglang.multimodal_gen.runtime.layers.quantization.modelopt_quant import (
 from sglang.multimodal_gen.runtime.loader.transformer_load_utils import (
     _ModelOptFp8OffloadAdapter,
 )
+from sglang.multimodal_gen.runtime.loader.utils import ProcessMappings
 from sglang.multimodal_gen.runtime.managers.memory_managers import (
     component_residency_strategies as component_residency_strategies_mod,
 )
@@ -237,7 +239,7 @@ def test_layerwise_offload_preserves_non_contiguous_stride(monkeypatch):
     )
 
     meta = manager._weight_metadata[0]["blocks.0.weight"]
-    assert meta["preserve_strides"] is True
+    assert meta["standalone_host_store"] is True
 
     restored_weight = model.blocks[0].weight.data
     assert restored_weight.shape == original_weight.shape
@@ -714,8 +716,8 @@ def test_layerwise_offload_aligns_contiguous_tensor_offsets(monkeypatch):
 
     weight_meta = manager._weight_metadata[0]["blocks.0.weight"]
     bias_meta = manager._weight_metadata[0]["blocks.0.bias"]
-    assert weight_meta["preserve_strides"] is False
-    assert bias_meta["preserve_strides"] is False
+    assert weight_meta["standalone_host_store"] is False
+    assert bias_meta["standalone_host_store"] is False
     assert weight_meta["offset"] == 0
     assert bias_meta["offset"] % 8 == 0
 
@@ -1218,3 +1220,79 @@ def test_strided_forward_leaves_exactly_the_resident_set(monkeypatch):
     resident = set(range(8)) - set(manager._streamed_order)
     assert resident <= manager._gpu_layers
     assert len(manager._gpu_layers) <= len(resident) + manager.prefetch_size
+
+
+def _file_backed_model(tmp_path, monkeypatch):
+    """A model whose block weight is a view into a file, like a mapped checkpoint."""
+    backing = tmp_path / "weights.bin"
+    backing.write_bytes(b"\x00" * 4096)
+    mapped = torch.from_file(str(backing), shared=True, size=256, dtype=torch.float32)
+    mapped.copy_(torch.arange(256, dtype=torch.float32))
+
+    model = torch.nn.Module()
+    block = torch.nn.Module()
+    block.weight = torch.nn.Parameter(mapped.reshape(16, 16), requires_grad=False)
+    model.blocks = torch.nn.ModuleList([block])
+    return model
+
+
+def test_a_mapped_weight_is_kept_rather_than_copied(tmp_path, monkeypatch):
+    if not pathlib.Path("/proc/self/maps").exists():
+        pytest.skip("needs /proc to tell a mapping from anonymous memory")
+    monkeypatch.setattr(
+        layerwise_offload_mod.torch, "get_device_module", lambda: _FakeDeviceModule
+    )
+    monkeypatch.setattr(layerwise_offload_mod.current_platform, "device_type", "cpu")
+
+    model = _file_backed_model(tmp_path, monkeypatch)
+    expected = model.blocks[0].weight.detach().clone()
+
+    manager = LayerwiseOffloadManager(
+        model=model,
+        layers_attr_str="blocks",
+        num_layers=1,
+        enabled=True,
+        pin_cpu_memory=False,
+        prefetch_size=1,
+    )
+
+    assert manager._kept_mappings == 1
+    stored = manager._standalone_cpu_weights[0]["blocks.0.weight"]
+    # still the mapping, which is the whole point: a copy would be anonymous
+    # memory the kernel could not reclaim
+    assert ProcessMappings().is_file_backed(stored)
+    assert manager._weight_metadata[0]["blocks.0.weight"]["standalone_host_store"]
+
+    manager.release_layer(0)
+    manager.prefetch_layer(0, non_blocking=False)
+    assert torch.equal(model.blocks[0].weight.data, expected)
+
+
+def test_pinning_still_copies_a_mapped_weight(tmp_path, monkeypatch):
+    if not pathlib.Path("/proc/self/maps").exists():
+        pytest.skip("needs /proc to tell a mapping from anonymous memory")
+    monkeypatch.setattr(
+        layerwise_offload_mod.torch, "get_device_module", lambda: _FakeDeviceModule
+    )
+    monkeypatch.setattr(layerwise_offload_mod.current_platform, "device_type", "cpu")
+
+    model = _file_backed_model(tmp_path, monkeypatch)
+
+    manager = LayerwiseOffloadManager(
+        model=model,
+        layers_attr_str="blocks",
+        num_layers=1,
+        enabled=True,
+        pin_cpu_memory=True,
+        prefetch_size=1,
+    )
+
+    # pinning is what lets the copy stream run ahead, and a mapping cannot be
+    # pinned and stay reclaimable, so here the copy earns its cost
+    assert manager._kept_mappings == 0
+    buffers = manager._consolidated_cpu_weights[0]
+    assert buffers, "expected the weight to land in a consolidated buffer"
+    for buf in buffers.values():
+        # pinned, therefore not something the kernel can reclaim -- which is
+        # what the mapping would have given up in exchange for async copies
+        assert not ProcessMappings().is_file_backed(buf)

--- a/python/sglang/multimodal_gen/test/unit/test_layerwise_offload.py
+++ b/python/sglang/multimodal_gen/test/unit/test_layerwise_offload.py
@@ -1296,3 +1296,45 @@ def test_pinning_still_copies_a_mapped_weight(tmp_path, monkeypatch):
         # pinned, therefore not something the kernel can reclaim -- which is
         # what the mapping would have given up in exchange for async copies
         assert not ProcessMappings().is_file_backed(buf)
+
+
+def test_kept_mappings_are_faulted_in_at_startup(tmp_path, monkeypatch):
+    if not pathlib.Path("/proc/self/maps").exists():
+        pytest.skip("needs /proc to tell a mapping from anonymous memory")
+    monkeypatch.setattr(
+        layerwise_offload_mod.torch, "get_device_module", lambda: _FakeDeviceModule
+    )
+    monkeypatch.setattr(layerwise_offload_mod.current_platform, "device_type", "cpu")
+
+    model = _file_backed_model(tmp_path, monkeypatch)
+    manager = LayerwiseOffloadManager(
+        model=model,
+        layers_attr_str="blocks",
+        num_layers=1,
+        enabled=True,
+        pin_cpu_memory=False,
+        prefetch_size=1,
+    )
+
+    # initialization already faulted them; asking again reports the same bytes
+    stored = manager._standalone_cpu_weights[0]["blocks.0.weight"]
+    assert manager.prefault_mapped_weights() == stored.untyped_storage().nbytes()
+
+
+def test_prefault_is_a_no_op_without_kept_mappings(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        layerwise_offload_mod.torch, "get_device_module", lambda: _FakeDeviceModule
+    )
+    monkeypatch.setattr(layerwise_offload_mod.current_platform, "device_type", "cpu")
+
+    model = _DummyModel()
+    manager = LayerwiseOffloadManager(
+        model=model,
+        layers_attr_str="blocks",
+        num_layers=1,
+        enabled=True,
+        pin_cpu_memory=False,
+        prefetch_size=1,
+    )
+    assert manager._kept_mappings == 0
+    assert manager.prefault_mapped_weights() == 0


### PR DESCRIPTION
## Motivation

With `--pin-cpu-memory false`, layerwise offload copies every weight out of the checkpoint mapping into anonymous host memory. That copy buys nothing. It moves the same bytes at the same speed, and it costs the kernel its ability to reclaim those pages.

Host memory is three tiers, ordered by what the kernel can do with them:

| tier | reclaimable with swap | reclaimable without swap |
|---|---|---|
| file-backed (mmap) | yes, dropped | **yes, dropped** |
| anonymous pageable | yes, swapped out | **no** |
| anonymous pinned | no | no |

The middle row is the one this PR is about. Container runtimes commonly run without swap -- the rented 4x4090 box used for the measurements below reports `Swap: 0B` -- and their anonymous pageable memory is exactly as unreclaimable as pinned. Copying a mapping into it converts memory the kernel could have dropped into memory it cannot.

## Modifications

When pinning is off and a weight's bytes are already in a file mapping, keep the mapping as the host store instead of allocating and copying.

Three facts make this safe, each checked rather than assumed:

- `safe_open(...).get_tensor(name)` returns a view into the checkpoint. Verified by looking the storage pointer up in `/proc/self/maps`: it lands inside the file-backed mapping of the blob.
- Those views outlive the `safe_open` context that produced them, including a host-to-device copy issued after the context closed.
- Writes to them succeed and do not reach the file -- safetensors maps copy-on-write. So the two write-back paths (`update_weights`, the GPU-to-host writeback) need no special case; a written page silently becomes anonymous and only that page loses its reclaimability.

With pinning on, the copy still earns its cost: pinning is what lets the copy stream run ahead of compute, and a mapping cannot be pinned and stay reclaimable at once.

Two supporting changes:

`preserve_strides` / `_strided_cpu_weights` become `standalone_host_store` /
`_standalone_cpu_weights`. The flag never meant "preserve strides" -- it meant "this
weight has its own host tensor rather than a slice of the flat buffer", and a kept
mapping is the second reason for that. Mechanical rename, six sites.

`ProcessMappings` in `loader/utils.py` replaces the closure `component_residency_bytes` had inlined, and reports pinned memory as *not* file-backed. CUDA's host allocator sits behind a mapping that carries a pathname, so the address-range check on its own calls pinned memory file-backed, which is the opposite of true. A test pins that ordering.

## Accuracy Tests

Output-neutral: this decides where a weight's host copy lives, not what is computed.

Full `test/unit` suite goes from 1730 to 1734 passed -- the new ones covering a mapped weight being kept, a pinned one still being copied, and the prefault reporting the bytes it faulted -- with the same four pre-existing failures (`realtime/`, `sana_wm/`) that fail with this change reverted.

One bug the new tests caught during development: storing the source tensor directly handed back the placeholder, because `weight.data` is rebound on the next line and the stored reference was the same object. It stores a detached alias now.

## Speed Tests and Profiling

Nothing is given up by storing weights per tensor instead of consolidating them into one flat buffer per layer. Measured on one RTX 4090, using a real DiT layer's size distribution (66 tensors, 542.3 MiB, of which 46 are under 64 KiB and carry 0.02% of the bytes), each configuration in its own process so allocator state cannot leak between them:

| host layout | copies | H2D |
|---|---|---|
| one consolidated buffer | 1 | 13.39 GB/s |
| one tensor each | 66 | 13.41 GB/s |
| big tensors alone, small ones merged | 18 | 13.45 GB/s |

Within 0.5%. For reference, the same box moves 2 GiB at 13.09 GB/s from pinned
anonymous memory, 8.84 GB/s from pageable anonymous, and about 8.5 GB/s from a
cache-resident file mapping -- so a mapping is a slower source than pinned, which is
why this only applies where pinning was already off.

## Warmup

A mapped page is read from disk on first touch, so the first request after startup would pay for every page it needs. Initialization now touches one byte per page of every kept mapping, which is enough to fault the whole page in. Measured over 512 MiB on the same box:

| | prefault | H2D that follows | 
|---|---|---|
| cold, nothing done | 0 ms | 2.63 GB/s |
| `MADV_WILLNEED` | 3.7 ms | 2.62 GB/s |
| **touch one byte per page** | 171.8 ms | **12.38 GB/s** |

Two things worth noting. `MADV_WILLNEED` bought nothing -- it returns in milliseconds and the readahead has not happened by the time the copy starts, so an advisory is the wrong tool when the data is wanted immediately. And a fully resident mapping copies at 12.38 GB/s against 13.39 for pinned, so once faulted in the mapping is within 8% of pinned rather than the 1.6x a partially-warm one suggests.

This is best-effort by construction: the pages are reclaimable, which is the reason the mapping was kept, so under pressure the kernel may drop them again and the next copy pays the fault. That is the trade being made, and the docstring says so.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Notes

Scoped to `--pin-cpu-memory false` deliberately, so the condition is one a user can
already reach and the change needs nothing else to be useful. A follow-up can let the
host pin budget in #35641 drive it, so a component that cannot afford pins keeps its
mapping rather than falling back to an anonymous copy.

Not addressed here: the default loader path is the Run:ai streamer
(`SGLANG_USE_RUNAI_MODEL_STREAMER=True`), which copies into anonymous memory, so a
mapping only exists on the `safe_open` route. #35668 names that difference as a reader
capability; wiring the choice to it comes next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #32350796436](https://github.com/sgl-project/sglang/actions/runs/32350796436)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32350795915](https://github.com/sgl-project/sglang/actions/runs/32350795915)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #32350796076](https://github.com/sgl-project/sglang/actions/runs/32350796076)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->