### PR TITLE
[NPU] DeepSeek-V4 adapt sgl-kernel-npu ops (compressor/sparse-attn/sparse-attn-metadata)

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
@@ -89,6 +89,9 @@ class ForwardMetadata:
     seq_lens: Optional[torch.Tensor] = None
     actual_seq_lengths_q: Optional[torch.Tensor] = None
     actual_seq_lengths_q_pa: Optional[torch.Tensor] = None
+    # CPU mirror of actual_seq_lengths_q_pa for the host metadata op
+    # (torch.ops.npu.sparse_attn_sharedkv_metadata_host reads CPU int32 inputs).
+    actual_seq_lengths_q_pa_cpu: Optional[torch.Tensor] = None
     actual_seq_lengths_kv: Optional[torch.Tensor] = None
 
     # swa attention mask for graph mode decode

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_dsv4_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_dsv4_backend.py
@@ -1537,19 +1537,19 @@ class DeepseekV4AscendAttnBackend(
         c1a_kwargs = base_kwargs | common
         if self._is_dspark_draft_worker:
             seq_lens_cpu = getattr(fm, "seq_lens_cpu_int", None)
-            max_seqlen_kv = (
-                int(seq_lens_cpu[:bs].max().item())
-                if seq_lens_cpu is not None and bs > 0
-                else int(actual_seq_lengths_kv[:bs].max().item())
+            # do sparse_attn_sharedkv_metadata on CPU, Simple but with better performance, data movement can be ignored
+            cu_q_cpu = actual_seq_lengths_q_pa[: bs + 1].to("cpu", torch.int32)
+            seq_kv_cpu = (
+                seq_lens_cpu[:bs].int()
+                if seq_lens_cpu is not None
+                else actual_seq_lengths_kv[:bs].to("cpu", torch.int32)
             )
-            c1a_kwargs.update(
-                cu_seqlens_ori_kv=actual_seq_lengths_q_pa,
-                max_seqlen_q=max_seqlen_q,
-                max_seqlen_kv=max_seqlen_kv,
-            )
-            c1a_metadata = torch.ops._C_ascend.npu_sparse_attn_sharedkv_metadata(
-                device=str(actual_seq_lengths_kv.device),
-                **c1a_kwargs,
+            c1a_metadata = torch.ops.npu.sparse_attn_sharedkv_metadata_host(
+                **c1a_kwargs
+                | {
+                    "cu_seqlens_q": cu_q_cpu,
+                    "seqused_kv": seq_kv_cpu,
+                }
             )
         else:
             c1a_metadata = torch.ops.custom.npu_sparse_attn_sharedkv_metadata(

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_dsv4_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_dsv4_backend.py
@@ -1445,7 +1445,10 @@ class DeepseekV4AscendAttnBackend(
                 dim=0,
             )
             fm.actual_seq_lengths_q_pa_cpu = torch.cat(
-                [torch.zeros(1, dtype=torch.int32), torch.cumsum(seq_lens_cpu, dim=0).int()],
+                [
+                    torch.zeros(1, dtype=torch.int32),
+                    torch.cumsum(seq_lens_cpu, dim=0).int(),
+                ],
                 dim=0,
             )
         elif forward_batch.forward_mode.is_decode():

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_dsv4_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_dsv4_backend.py
@@ -989,6 +989,15 @@ class DeepseekV4AscendAttnBackend(
             dtype=torch.int32,
             device=device,
         )
+        if self._use_host_sparse_metadata:
+            # q_pa is constant per graph shape (never rewritten at replay), so the
+            # CPU mirror for the host metadata op is built once here.
+            metadata.actual_seq_lengths_q_pa_cpu = torch.arange(
+                0,
+                bs * tokens_per_req + tokens_per_req,
+                tokens_per_req,
+                dtype=torch.int32,
+            )
 
         # init >=1 so the captured kernel records valid attention work; replay overwrites in-place
         metadata.actual_seq_lengths_kv = torch.ones(
@@ -1189,6 +1198,10 @@ class DeepseekV4AscendAttnBackend(
                 fm.seq_lens_cpu_int,
                 ctx.live_seq_lens_cpu.int(),
             )
+        elif self._use_host_sparse_metadata:
+            # CPU mirror of the kv buffer written below, from its CPU source — the
+            # host metadata op reads this instead of a D2H sync.
+            fm.seq_lens_cpu_int = ctx.final_seq_lens_cpu[: ctx.bs].int().clamp(min=1)
         fm.actual_seq_lengths_kv.copy_(attn_seq_lens.clamp(min=1))
 
     def _refresh_graph_compress_page_tables_direct(self, ctx) -> None:
@@ -1432,6 +1445,14 @@ class DeepseekV4AscendAttnBackend(
                 [torch.zeros(1, dtype=torch.int32, device=device), actual_q],
                 dim=0,
             )
+            if self._use_host_sparse_metadata:
+                fm.actual_seq_lengths_q_pa_cpu = torch.cat(
+                    [
+                        torch.zeros(1, dtype=torch.int32),
+                        torch.cumsum(seq_lens_cpu, dim=0).int(),
+                    ],
+                    dim=0,
+                )
         elif forward_batch.forward_mode.is_decode():
             B = forward_batch.batch_size
             fm.actual_seq_lengths_q = torch.arange(
@@ -1440,6 +1461,10 @@ class DeepseekV4AscendAttnBackend(
             fm.actual_seq_lengths_q_pa = torch.arange(
                 0, B + 1, dtype=torch.int32, device=device
             )
+            if self._use_host_sparse_metadata:
+                fm.actual_seq_lengths_q_pa_cpu = torch.arange(
+                    0, B + 1, dtype=torch.int32
+                )
         elif (
             forward_batch.forward_mode.is_target_verify()
             or forward_batch.forward_mode.is_draft_extend_v2()
@@ -1458,6 +1483,16 @@ class DeepseekV4AscendAttnBackend(
                 [torch.zeros(1, dtype=torch.int32, device=device), actual_q],
                 dim=0,
             )
+            if self._use_host_sparse_metadata:
+                fm.actual_seq_lengths_q_pa_cpu = torch.cat(
+                    [
+                        torch.zeros(1, dtype=torch.int32),
+                        torch.arange(
+                            n_draft, B * n_draft + 1, n_draft, dtype=torch.int32
+                        ),
+                    ],
+                    dim=0,
+                )
         else:
             fm.actual_seq_lengths_q = None
             fm.actual_seq_lengths_q_pa = None
@@ -1537,8 +1572,11 @@ class DeepseekV4AscendAttnBackend(
         c1a_kwargs = base_kwargs | common
         if self._is_dspark_draft_worker:
             seq_lens_cpu = getattr(fm, "seq_lens_cpu_int", None)
-            # do sparse_attn_sharedkv_metadata on CPU, Simple but with better performance, data movement can be ignored
-            cu_q_cpu = actual_seq_lengths_q_pa[: bs + 1].to("cpu", torch.int32)
+            cu_q_cpu = getattr(fm, "actual_seq_lengths_q_pa_cpu", None)
+            if cu_q_cpu is None or cu_q_cpu.numel() < bs + 1:
+                cu_q_cpu = actual_seq_lengths_q_pa[: bs + 1].to("cpu", torch.int32)
+            else:
+                cu_q_cpu = cu_q_cpu[: bs + 1]
             seq_kv_cpu = (
                 seq_lens_cpu[:bs].int()
                 if seq_lens_cpu is not None

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_dsv4_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_dsv4_backend.py
@@ -1559,19 +1559,25 @@ class DeepseekV4AscendAttnBackend(
         }
         # The host metadata op reads CPU int32 mirrors — never a D2H sync of the
         # device tensors (that would drain the stream and stall overlapped prep).
-        # cu_q mirror is sized for its graph bucket; slice down to this batch.
-        cu_q_cpu = fm.actual_seq_lengths_q_pa_cpu
-        if cu_q_cpu is not None and cu_q_cpu.numel() > bs + 1:
-            cu_q_cpu = cu_q_cpu[: bs + 1]
-        host_inputs = {"seqused_kv": fm.seq_lens_cpu_int[:bs].int()}
-        if cu_q_cpu is not None:
-            host_inputs["cu_seqlens_q"] = cu_q_cpu
-        c1a_kwargs = base_kwargs | common | host_inputs
-        kernel_metadata = {
-            "c1a_metadata": torch.ops.npu.sparse_attn_sharedkv_metadata_host(
-                **c1a_kwargs
-            )
-        }
+        c1a_kwargs = base_kwargs | common
+        if self._use_host_sparse_metadata:
+            cu_q_cpu = fm.actual_seq_lengths_q_pa_cpu
+            if cu_q_cpu is not None and cu_q_cpu.numel() > bs + 1:
+                cu_q_cpu = cu_q_cpu[: bs + 1]
+            host_inputs = {"seqused_kv": fm.seq_lens_cpu_int[:bs].int()}
+            if cu_q_cpu is not None:
+                host_inputs["cu_seqlens_q"] = cu_q_cpu
+            c1a_kwargs = c1a_kwargs | host_inputs
+            metadata_op = torch.ops.npu.sparse_attn_sharedkv_metadata_host
+        else:
+            # The device-side op requires tensor args for backend dispatch; pass
+            # the device mirrors just like the pre-refactor call did.
+            c1a_kwargs = c1a_kwargs | {
+                "cu_seqlens_q": actual_seq_lengths_q_pa,
+                "seqused_kv": actual_seq_lengths_kv,
+            }
+            metadata_op = torch.ops.custom.npu_sparse_attn_sharedkv_metadata
+        kernel_metadata = {"c1a_metadata": metadata_op(**c1a_kwargs)}
 
         if self._dsv4_has_c4:
             c4a_overrides = {

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_dsv4_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_dsv4_backend.py
@@ -1682,7 +1682,7 @@ class DeepseekV4AscendAttnBackend(
             attn_kwargs["ori_sparse_indices"] = ori_sparse_indices
         q_arg = attn_kwargs.pop("q")
         if self._is_dspark_draft_worker:
-            out, _ = torch.ops._C_ascend.npu_sparse_attn_sharedkv(q_arg, **attn_kwargs)
+            out, _ = torch.ops.npu.sparse_attn_sharedkv(q_arg, **attn_kwargs)
         else:
             out, _ = torch.ops.custom.npu_sparse_attn_sharedkv(q_arg, **attn_kwargs)
         return out

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_dsv4_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_dsv4_backend.py
@@ -1681,10 +1681,7 @@ class DeepseekV4AscendAttnBackend(
         if ori_sparse_indices is not None:
             attn_kwargs["ori_sparse_indices"] = ori_sparse_indices
         q_arg = attn_kwargs.pop("q")
-        if self._is_dspark_draft_worker:
-            out, _ = torch.ops.npu.sparse_attn_sharedkv(q_arg, **attn_kwargs)
-        else:
-            out, _ = torch.ops.custom.npu_sparse_attn_sharedkv(q_arg, **attn_kwargs)
+        out, _ = torch.ops.npu.sparse_attn_sharedkv(q_arg, **attn_kwargs)
         return out
 
     def _forward_compressed(
@@ -1755,7 +1752,7 @@ class DeepseekV4AscendAttnBackend(
         else:
             attn_kwargs["cmp_sparse_indices"] = None
         q_arg = attn_kwargs.pop("q")
-        out, _ = torch.ops.custom.npu_sparse_attn_sharedkv(q_arg, **attn_kwargs)
+        out, _ = torch.ops.npu.sparse_attn_sharedkv(q_arg, **attn_kwargs)
         return out
 
     def get_swa_out_cache_loc(self, forward_batch: ForwardBatch) -> torch.Tensor:

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_dsv4_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_dsv4_backend.py
@@ -1563,7 +1563,7 @@ class DeepseekV4AscendAttnBackend(
         # The host metadata op reads CPU int32 mirrors — never a D2H sync of the
         # device tensors (that would drain the stream and stall overlapped prep).
         c1a_kwargs = base_kwargs | common
-        if self._use_host_sparse_metadata:
+        if self._is_dspark_draft_worker:
             cu_q_cpu = fm.actual_seq_lengths_q_pa_cpu
             if cu_q_cpu is not None and cu_q_cpu.numel() > bs + 1:
                 cu_q_cpu = cu_q_cpu[: bs + 1]
@@ -1590,7 +1590,7 @@ class DeepseekV4AscendAttnBackend(
             }
             c4a_kwargs = c1a_kwargs | c4a_overrides
             kernel_metadata["c4a_metadata"] = (
-                torch.ops.npu.sparse_attn_sharedkv_metadata_host(**c4a_kwargs)
+                torch.ops.custom.npu_sparse_attn_sharedkv_metadata(**c4a_kwargs)
             )
 
             if actual_seq_lengths_q_pa is not None:
@@ -1620,7 +1620,7 @@ class DeepseekV4AscendAttnBackend(
             c128a_overrides = {"cmp_ratio": 128, "has_cmp_kv": True}
             c128a_kwargs = c1a_kwargs | c128a_overrides
             kernel_metadata["c128a_metadata"] = (
-                torch.ops.npu.sparse_attn_sharedkv_metadata_host(**c128a_kwargs)
+                torch.ops.custom.npu_sparse_attn_sharedkv_metadata(**c128a_kwargs)
             )
 
         return kernel_metadata

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_dsv4_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_dsv4_backend.py
@@ -817,6 +817,10 @@ class DeepseekV4AscendAttnBackend(
             getattr(model_runner, "is_draft_worker", False)
             and self._is_dspark_algorithm
         )
+        # The host metadata op is selected in _kernel_metadata_from_parts exactly
+        # on the DSpark draft worker; the CPU mirrors that feed it are built under
+        # the same condition.
+        self._use_host_sparse_metadata = self._is_dspark_draft_worker
         self._dsv4_graph_tokens_per_req = int(model_runner.decode_num_tokens_per_req())
         self._dsv4_state_pools_by_ratio = {
             pool.ratio: pool

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_dsv4_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_dsv4_backend.py
@@ -398,7 +398,7 @@ class CompressorAscendBackendMixin:
             allow_build=False,
         )
 
-        cmp_kv = torch.ops.custom.compressor(
+        cmp_kv = torch.ops.npu.compressor(
             x,
             compressor._fused_wkv_w,
             compressor._fused_wgate_w,

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_dsv4_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_dsv4_backend.py
@@ -817,10 +817,6 @@ class DeepseekV4AscendAttnBackend(
             getattr(model_runner, "is_draft_worker", False)
             and self._is_dspark_algorithm
         )
-        # The host metadata op is selected in _kernel_metadata_from_parts exactly
-        # on the DSpark draft worker; the CPU mirrors that feed it are built under
-        # the same condition.
-        self._use_host_sparse_metadata = self._is_dspark_draft_worker
         self._dsv4_graph_tokens_per_req = int(model_runner.decode_num_tokens_per_req())
         self._dsv4_state_pools_by_ratio = {
             pool.ratio: pool
@@ -993,15 +989,14 @@ class DeepseekV4AscendAttnBackend(
             dtype=torch.int32,
             device=device,
         )
-        if self._use_host_sparse_metadata:
-            # q_pa is constant per graph shape (never rewritten at replay), so the
-            # CPU mirror for the host metadata op is built once here.
-            metadata.actual_seq_lengths_q_pa_cpu = torch.arange(
-                0,
-                bs * tokens_per_req + tokens_per_req,
-                tokens_per_req,
-                dtype=torch.int32,
-            )
+        # q_pa is constant per graph shape (never rewritten at replay), so the
+        # CPU mirror for the host metadata op is built once here.
+        metadata.actual_seq_lengths_q_pa_cpu = torch.arange(
+            0,
+            bs * tokens_per_req + tokens_per_req,
+            tokens_per_req,
+            dtype=torch.int32,
+        )
 
         # init >=1 so the captured kernel records valid attention work; replay overwrites in-place
         metadata.actual_seq_lengths_kv = torch.ones(
@@ -1202,7 +1197,7 @@ class DeepseekV4AscendAttnBackend(
                 fm.seq_lens_cpu_int,
                 ctx.live_seq_lens_cpu.int(),
             )
-        elif self._use_host_sparse_metadata:
+        else:
             # CPU mirror of the kv buffer written below, from its CPU source — the
             # host metadata op reads this instead of a D2H sync.
             fm.seq_lens_cpu_int = ctx.final_seq_lens_cpu[: ctx.bs].int().clamp(min=1)
@@ -1449,14 +1444,10 @@ class DeepseekV4AscendAttnBackend(
                 [torch.zeros(1, dtype=torch.int32, device=device), actual_q],
                 dim=0,
             )
-            if self._use_host_sparse_metadata:
-                fm.actual_seq_lengths_q_pa_cpu = torch.cat(
-                    [
-                        torch.zeros(1, dtype=torch.int32),
-                        torch.cumsum(seq_lens_cpu, dim=0).int(),
-                    ],
-                    dim=0,
-                )
+            fm.actual_seq_lengths_q_pa_cpu = torch.cat(
+                [torch.zeros(1, dtype=torch.int32), torch.cumsum(seq_lens_cpu, dim=0).int()],
+                dim=0,
+            )
         elif forward_batch.forward_mode.is_decode():
             B = forward_batch.batch_size
             fm.actual_seq_lengths_q = torch.arange(
@@ -1465,10 +1456,7 @@ class DeepseekV4AscendAttnBackend(
             fm.actual_seq_lengths_q_pa = torch.arange(
                 0, B + 1, dtype=torch.int32, device=device
             )
-            if self._use_host_sparse_metadata:
-                fm.actual_seq_lengths_q_pa_cpu = torch.arange(
-                    0, B + 1, dtype=torch.int32
-                )
+            fm.actual_seq_lengths_q_pa_cpu = torch.arange(0, B + 1, dtype=torch.int32)
         elif (
             forward_batch.forward_mode.is_target_verify()
             or forward_batch.forward_mode.is_draft_extend_v2()
@@ -1487,19 +1475,17 @@ class DeepseekV4AscendAttnBackend(
                 [torch.zeros(1, dtype=torch.int32, device=device), actual_q],
                 dim=0,
             )
-            if self._use_host_sparse_metadata:
-                fm.actual_seq_lengths_q_pa_cpu = torch.cat(
-                    [
-                        torch.zeros(1, dtype=torch.int32),
-                        torch.arange(
-                            n_draft, B * n_draft + 1, n_draft, dtype=torch.int32
-                        ),
-                    ],
-                    dim=0,
-                )
+            fm.actual_seq_lengths_q_pa_cpu = torch.cat(
+                [
+                    torch.zeros(1, dtype=torch.int32),
+                    torch.arange(n_draft, B * n_draft + 1, n_draft, dtype=torch.int32),
+                ],
+                dim=0,
+            )
         else:
             fm.actual_seq_lengths_q = None
             fm.actual_seq_lengths_q_pa = None
+            fm.actual_seq_lengths_q_pa_cpu = None
 
         fm.swa_page_table = (
             fm.block_tables_swa if fm.block_tables_swa is not None else fm.block_tables
@@ -1553,8 +1539,6 @@ class DeepseekV4AscendAttnBackend(
     ) -> dict:
         fm = self.forward_metadata
         common = {
-            "cu_seqlens_q": actual_seq_lengths_q_pa,
-            "seqused_kv": actual_seq_lengths_kv,
             "cmp_ratio": 1,
             "ori_mask_mode": 4,
             "cmp_mask_mode": 3,
@@ -1573,31 +1557,21 @@ class DeepseekV4AscendAttnBackend(
             "has_ori_kv": True,
             "has_cmp_kv": False,
         }
-        c1a_kwargs = base_kwargs | common
-        if self._is_dspark_draft_worker:
-            seq_lens_cpu = getattr(fm, "seq_lens_cpu_int", None)
-            cu_q_cpu = getattr(fm, "actual_seq_lengths_q_pa_cpu", None)
-            if cu_q_cpu is None or cu_q_cpu.numel() < bs + 1:
-                cu_q_cpu = actual_seq_lengths_q_pa[: bs + 1].to("cpu", torch.int32)
-            else:
-                cu_q_cpu = cu_q_cpu[: bs + 1]
-            seq_kv_cpu = (
-                seq_lens_cpu[:bs].int()
-                if seq_lens_cpu is not None
-                else actual_seq_lengths_kv[:bs].to("cpu", torch.int32)
-            )
-            c1a_metadata = torch.ops.npu.sparse_attn_sharedkv_metadata_host(
+        # The host metadata op reads CPU int32 mirrors — never a D2H sync of the
+        # device tensors (that would drain the stream and stall overlapped prep).
+        # cu_q mirror is sized for its graph bucket; slice down to this batch.
+        cu_q_cpu = fm.actual_seq_lengths_q_pa_cpu
+        if cu_q_cpu is not None and cu_q_cpu.numel() > bs + 1:
+            cu_q_cpu = cu_q_cpu[: bs + 1]
+        host_inputs = {"seqused_kv": fm.seq_lens_cpu_int[:bs].int()}
+        if cu_q_cpu is not None:
+            host_inputs["cu_seqlens_q"] = cu_q_cpu
+        c1a_kwargs = base_kwargs | common | host_inputs
+        kernel_metadata = {
+            "c1a_metadata": torch.ops.npu.sparse_attn_sharedkv_metadata_host(
                 **c1a_kwargs
-                | {
-                    "cu_seqlens_q": cu_q_cpu,
-                    "seqused_kv": seq_kv_cpu,
-                }
             )
-        else:
-            c1a_metadata = torch.ops.custom.npu_sparse_attn_sharedkv_metadata(
-                **c1a_kwargs,
-            )
-        kernel_metadata = {"c1a_metadata": c1a_metadata}
+        }
 
         if self._dsv4_has_c4:
             c4a_overrides = {
@@ -1607,7 +1581,7 @@ class DeepseekV4AscendAttnBackend(
             }
             c4a_kwargs = c1a_kwargs | c4a_overrides
             kernel_metadata["c4a_metadata"] = (
-                torch.ops.custom.npu_sparse_attn_sharedkv_metadata(**c4a_kwargs)
+                torch.ops.npu.sparse_attn_sharedkv_metadata_host(**c4a_kwargs)
             )
 
             if actual_seq_lengths_q_pa is not None:
@@ -1637,7 +1611,7 @@ class DeepseekV4AscendAttnBackend(
             c128a_overrides = {"cmp_ratio": 128, "has_cmp_kv": True}
             c128a_kwargs = c1a_kwargs | c128a_overrides
             kernel_metadata["c128a_metadata"] = (
-                torch.ops.custom.npu_sparse_attn_sharedkv_metadata(**c128a_kwargs)
+                torch.ops.npu.sparse_attn_sharedkv_metadata_host(**c128a_kwargs)
             )
 
         return kernel_metadata

--- a/python/sglang/srt/hardware_backend/npu/dsv4/dsv4_memory_pool.py
+++ b/python/sglang/srt/hardware_backend/npu/dsv4/dsv4_memory_pool.py
@@ -97,7 +97,7 @@ class NPUCompressStatePool(CompressStatePool):
             128,
         ), f"NPUCompressStatePool only supports ratio in (4, 128); got {ratio}"
         assert dtype == torch.float32, (
-            "Atlas A3 custom.compressor requires FP32 state_cache, "
+            "Atlas A3 npu.compressor requires FP32 state_cache, "
             f"but NPUCompressStatePool got {dtype}."
         )
         assert ring_size > 0, f"ring_size must be positive, got {ring_size}"
@@ -404,7 +404,7 @@ class DSV4NPUTokenToKVPool(DeepSeekV4TokenToKVPool):
     def get_state_cache(self, layer_id: int, from_indexer: bool) -> torch.Tensor:
         """FP32 ``[block_num, ring_size, 2*coff*D]`` view of this layer's
         kv+score buffer — the fused compressor op
-        (``torch.ops.custom.compressor``)'s ``state_cache`` argument."""
+        (``torch.ops.npu.compressor``)'s ``state_cache`` argument."""
         return self._get_state_pool(layer_id, from_indexer).state_cache_3d
 
     # ------------------------------------------------------------------

--- a/python/sglang/srt/hardware_backend/npu/extra_ops_loader.py
+++ b/python/sglang/srt/hardware_backend/npu/extra_ops_loader.py
@@ -106,14 +106,3 @@ class TorchOpLoader:
         logger.info("Registered %s operators from %s", self._spec.name, library_path)
         return library_path
 
-
-def initialize_dspark_sparse_attn_ops() -> Optional[Path]:
-    """Register the DSpark sparse-attention ops before backend execution."""
-    spec = OpLibSpec(
-        name="DSpark sparse-attention",
-        so_env="SGLANG_DSPARK_EXTRA_OPS_SO",
-        namespace="_C_ascend",
-        required_ops=("npu_sparse_attn_sharedkv",),
-        pre_load_imports=("torch_npu",),
-    )
-    return TorchOpLoader(spec).initialize()

--- a/python/sglang/srt/hardware_backend/npu/extra_ops_loader.py
+++ b/python/sglang/srt/hardware_backend/npu/extra_ops_loader.py
@@ -25,7 +25,36 @@ class OpLibSpec:
 
 
 class TorchOpLoader:
-    """Load a standalone .so into ``torch.ops`` and validate its operators."""
+    """
+    Loader for PyTorch custom operators from shared libraries.
+    
+    This class handles the registration and initialization of custom PyTorch
+    operators (Ops) from dynamically linked shared object (.so) files. It supports
+    environment-based library path discovery, dependency pre-loading, and
+    operator existence validation.
+    
+    Usage:
+        1. Create an OpLibSpec with operator metadata
+        2. Instantiate TorchOpLoader with the spec
+        3. Call initialize() to load and register the operators
+        
+    Example:
+        >>> spec = OpLibSpec(
+        ...     name="My custom ops",
+        ...     so_env="MY_LIB_SO_PATH",
+        ...     namespace="_C_my_lib",
+        ...     required_ops=("op1", "op2"),
+        ...     pre_load_imports=("torch", "other_dep"),
+        ... )
+        >>> loader = TorchOpLoader(spec)
+        >>> lib_path = loader.initialize()
+        >>> # Ops are now registered under namespace: _C_my_lib.op1()
+    
+    The loader will raise appropriate exceptions if:
+        - The shared library cannot be found (via SO_PATH env var or default paths)
+        - Pre-load imports fail
+        - Required operators are missing after loading
+    """
 
     def __init__(self, spec: OpLibSpec) -> None:
         self._spec = spec

--- a/python/sglang/srt/hardware_backend/npu/extra_ops_loader.py
+++ b/python/sglang/srt/hardware_backend/npu/extra_ops_loader.py
@@ -27,17 +27,17 @@ class OpLibSpec:
 class TorchOpLoader:
     """
     Loader for PyTorch custom operators from shared libraries.
-    
+
     This class handles the registration and initialization of custom PyTorch
     operators (Ops) from dynamically linked shared object (.so) files. It supports
     environment-based library path discovery, dependency pre-loading, and
     operator existence validation.
-    
+
     Usage:
         1. Create an OpLibSpec with operator metadata
         2. Instantiate TorchOpLoader with the spec
         3. Call initialize() to load and register the operators
-        
+
     Example:
         >>> spec = OpLibSpec(
         ...     name="My custom ops",
@@ -49,7 +49,7 @@ class TorchOpLoader:
         >>> loader = TorchOpLoader(spec)
         >>> lib_path = loader.initialize()
         >>> # Ops are now registered under namespace: _C_my_lib.op1()
-    
+
     The loader will raise appropriate exceptions if:
         - The shared library cannot be found (via SO_PATH env var or default paths)
         - Pre-load imports fail
@@ -134,4 +134,3 @@ class TorchOpLoader:
         self._loaded_library = library_path
         logger.info("Registered %s operators from %s", self._spec.name, library_path)
         return library_path
-

--- a/python/sglang/srt/hardware_backend/npu/extra_ops_loader.py
+++ b/python/sglang/srt/hardware_backend/npu/extra_ops_loader.py
@@ -113,10 +113,7 @@ def initialize_dspark_sparse_attn_ops() -> Optional[Path]:
         name="DSpark sparse-attention",
         so_env="SGLANG_DSPARK_EXTRA_OPS_SO",
         namespace="_C_ascend",
-        required_ops=(
-            "npu_sparse_attn_sharedkv_metadata",
-            "npu_sparse_attn_sharedkv",
-        ),
+        required_ops=("npu_sparse_attn_sharedkv",),
         pre_load_imports=("torch_npu",),
     )
     return TorchOpLoader(spec).initialize()

--- a/python/sglang/srt/layers/attention/xpu_backend.py
+++ b/python/sglang/srt/layers/attention/xpu_backend.py
@@ -16,6 +16,7 @@ from sglang.srt.mem_cache.memory_pool import KVWriteLoc
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.runtime_context import (
+    get_exec,
     get_schedule,
     get_spec,
 )
@@ -106,7 +107,7 @@ class XPUAttentionBackend(AttentionBackend):
         # when deterministic inference is enabled to keep attention reduction
         # order fixed. This mirrors the flash-attention (fa3) backend.
         self.num_splits = (
-            1 if model_runner.server_args.enable_deterministic_inference else 0
+            1 if get_exec().deterministic.enable_deterministic_inference else 0
         )
         self.is_encoder_decoder = model_runner.model_config.is_encoder_decoder
 

--- a/python/sglang/srt/mem_cache/allocation.py
+++ b/python/sglang/srt/mem_cache/allocation.py
@@ -113,11 +113,8 @@ def get_last_loc(
         "ascend",
         "torch_native",
     ) and decode_backend not in ("ascend", "torch_native")
-    uses_safe_last_loc = _is_hip or (
-        _is_npu and "dsv4" in (prefill_backend, decode_backend)
-    )
 
-    if uses_safe_last_loc and uses_triton_dispatch:
+    if (_is_hip or _is_npu) and uses_triton_dispatch:
         # HIP and NPU DSV4: the legacy get_last_loc_triton kernel emits a
         # mixed-width int32->int64 store that Triton mis-compiles on HIP,
         # producing out-of-range last_loc values under EAGLE +

--- a/python/sglang/srt/mem_cache/allocation.py
+++ b/python/sglang/srt/mem_cache/allocation.py
@@ -113,17 +113,19 @@ def get_last_loc(
         "ascend",
         "torch_native",
     ) and decode_backend not in ("ascend", "torch_native")
+    uses_safe_last_loc = _is_hip or (
+        _is_npu and "dsv4" in (prefill_backend, decode_backend)
+    )
 
-    if _is_hip and uses_triton_dispatch:
-        # HIP-only: the legacy get_last_loc_triton kernel emits a
+    if uses_safe_last_loc and uses_triton_dispatch:
+        # HIP and NPU DSV4: the legacy get_last_loc_triton kernel emits a
         # mixed-width int32->int64 store that Triton mis-compiles on HIP,
         # producing out-of-range last_loc values under EAGLE +
         # page_size>1 (e.g. with aiter unified attention or the triton
-        # attention backend). The bug is in the Triton HIP codegen, not
-        # in any particular attention backend, so route every HIP path
-        # that would otherwise use get_last_loc_triton through the
-        # int32-safe variant. Non-HIP hardware keeps the original
-        # dispatcher below.
+        # attention backend), and can fault in the equivalent NPU DSV4
+        # allocation path. Route those paths through the variant whose
+        # in-kernel result remains int32 and is promoted only after launch.
+        # Other hardware/backends keep the original dispatcher below.
         return get_last_loc_triton_safe(
             req_to_token, req_pool_indices_tensor, prefix_lens_tensor
         )

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -349,12 +349,6 @@ class DSparkWorkerV2(BaseSpecWorker):
 
     def init_attention_backends(self):
         with self._draft_context():
-            if _is_npu:
-                from sglang.srt.hardware_backend.npu.extra_ops_loader import (
-                    initialize_dspark_sparse_attn_ops,
-                )
-
-                initialize_dspark_sparse_attn_ops()
             self._draft_worker.init_attention_backends()
         self._need_mamba_verify_commit = mambaish_config(
             self.model_runner.model_config

--- a/test/registered/unit/npu/attention/test_npu_ascend_backend.py
+++ b/test/registered/unit/npu/attention/test_npu_ascend_backend.py
@@ -153,6 +153,7 @@ class TestForwardMetadata(unittest.TestCase):
             "seq_lens",
             "actual_seq_lengths_q",
             "actual_seq_lengths_q_pa",
+            "actual_seq_lengths_q_pa_cpu",
             "actual_seq_lengths_kv",
             "swa_mask",
             "prefix_lens",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Adaptation of  DSV4 sparse attention for NPU platforms, with host-side metadata computation and a unified op namespace.

## Modifications

<!-- Detail the changes made in this pull request. -->

1. Compute sparse_attn_sharedkv_metadata on the CPU host instead of the NPU device: device tensors are mirrored to CPU (actual_seq_lengths_q_pa_cpu, seq_lens_cpu_int), and the new host op torch.ops.npu.sparse_attn_sharedkv_metadata_host reads CPU int32 inputs directly, eliminating the D2H sync that drains/stalls the stream and hurts overlapped scheduling.
2. Unify the DSV4 op namespace — replace torch.ops.custom.* and torch.ops._C_ascend.* calls with the shared torch.ops.npu.* namespace, covering the DSpark draft-worker path, so normal and draft paths use identical kernels.
3. Adapt the fused compressor to torch.ops.npu.compressor (including the FP32 state-cache constraint in the memory pool).
4. Update extra_ops_loader to drop npu_sparse_attn_sharedkv_metadata from the DSpark _C_ascend required ops, since metadata is now produced on host.
5. Fix _use_host_sparse_metadata definition and the seq_lens_cpu_int fallback when the flag is off.

| Op | Description | PR |
|---|---|---|
| `compressor` | FP16/BF16 KV cache compression kernel with TH/BSH layouts, cache_mode 1/2, coff 1/2, and host-side tiling logic | https://github.com/sgl-project/sgl-kernel-npu/pull/689 |
| `sparse_attn_sharedkv` | FP16/BF16 sparse shared-KV attention kernel with host-side tiling logic, supporting SWA/CFA/SCFA dispatch modes | https://github.com/sgl-project/sgl-kernel-npu/pull/708 |
| `sparse_attn_sharedkv_metadata_host` | Providing our own definitions of the dsv4 spark‑related operators in the sglang kernel repository | https://github.com/sgl-project/sgl-kernel-npu/pull/699 |

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
DSPARK ON

| Model                       | Dataset | Metric   | Subset  | Num | Score  | Cat.0   |
|-----------------------------|---------|----------|---------|-----|--------|---------|
| DeepSeek-V4-Flash-0731-w8a8 | aime26  | mean_acc | default | 30  | 0.9667 | default |

DSPARK OFF

| Model                       | Dataset | Metric   | Subset  | Num | Score  | Cat.0   |
|-----------------------------|---------|----------|---------|-----|--------|---------|
| DeepSeek-V4-Flash-0731-w8a8 | aime26  | mean_acc | default | 30  | 0.9667 | default |


## Speed Tests and Profiling

Use the replaced operator after：
```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 192       
Successful requests:                     192       
Benchmark duration (s):                  66.31     
Total input tokens:                      1572864   
Total input text tokens:                 1572864   
Total generated tokens:                  196608    
Total generated tokens (retokenized):    196606    
Request throughput (req/s):              2.90      
Input token throughput (tok/s):          23721.03  
Output token throughput (tok/s):         2965.13   
Peak output token throughput (tok/s):    11374.00  
Peak concurrent requests:                192       
Total token throughput (tok/s):          26686.16  
Concurrency:                             152.83    
Accept length:                           5.80      
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   52781.00  
Median E2E Latency (ms):                 52799.70  
P90 E2E Latency (ms):                    55790.27  
P95 E2E Latency (ms):                    56329.18  
P99 E2E Latency (ms):                    63927.59  
---------------Time to First Token----------------
Mean TTFT (ms):                          22112.76  
Median TTFT (ms):                        23301.02  
P90 TTFT (ms):                           33777.70  
P95 TTFT (ms):                           34083.57  
P99 TTFT (ms):                           52313.57  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          29.98     
Median TPOT (ms):                        29.19     
P90 TPOT (ms):                           42.61     
P95 TPOT (ms):                           44.66     
P99 TPOT (ms):                           47.34     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           29.98     
Median ITL (ms):                         15.94     
P90 ITL (ms):                            20.60     
P95 ITL (ms):                            24.24     
P99 ITL (ms):                            44.67     
Max ITL (ms):                            19164.49  
==================================================
```


<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.




<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32697863563](https://github.com/sgl-project/sglang/actions/runs/32697863563)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32697864017](https://github.com/sgl-project/sglang/actions/runs/32697864017)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32697863643](https://github.com/sgl-project/sglang/actions/runs/32697863643)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->