### PR TITLE
[AMD] Pass USE_PDL explicitly to Triton kernel launches

### DIFF
--- a/python/sglang/kernels/ops/elementwise/elementwise.py
+++ b/python/sglang/kernels/ops/elementwise/elementwise.py
@@ -534,7 +534,8 @@ def fused_gate_sigmoid_mul_add(
     if num_tokens >= 1024:
         config["num_warps"] = min(config["num_warps"], 8)
 
-    pdl_kwargs = {"USE_PDL": True, "launch_pdl": True} if is_arch_support_pdl() else {}
+    use_pdl = is_arch_support_pdl()
+    pdl_kwargs = {"launch_pdl": True} if use_pdl else {}
 
     _fused_gate_sigmoid_mul_add_kernel[(num_tokens,)](
         hidden_states,
@@ -542,6 +543,7 @@ def fused_gate_sigmoid_mul_add(
         shared_output,
         final_hidden_states,
         hidden_dim=hidden_dim,
+        USE_PDL=use_pdl,
         **config,
         **pdl_kwargs,
     )

--- a/python/sglang/kernels/ops/moe/inkling_moe.py
+++ b/python/sglang/kernels/ops/moe/inkling_moe.py
@@ -357,6 +357,7 @@ def silu_and_mul_triton(
     ).multi_processor_count
     grid_size = min(num_sms * 4, max_grid_size)
 
+    use_pdl = is_arch_support_pdl()
     _silu_and_mul_triton_kernel[(grid_size,)](
         gateup_out_ptr=gateup_output,
         topk_weights_ptr=topk_weights,
@@ -370,7 +371,8 @@ def silu_and_mul_triton(
         BLOCK_SIZE_N=BLOCK_SIZE_N,
         EVEN_N=N % BLOCK_SIZE_N == 0,
         INT64_INDEX=gateup_output.nbytes >= 2**31,
-        **({"USE_PDL": True, "launch_pdl": True} if is_arch_support_pdl() else {}),
+        USE_PDL=use_pdl,
+        **({"launch_pdl": True} if use_pdl else {}),
     )
 
     return down_input

--- a/python/sglang/kernels/ops/moe/pack_topk_ids.py
+++ b/python/sglang/kernels/ops/moe/pack_topk_ids.py
@@ -53,15 +53,15 @@ class PackTopkIds:
 
         BLOCK_SIZE = 1024
         grid = (triton.cdiv(numel, BLOCK_SIZE),)
-        pdl_kwargs = (
-            {"USE_PDL": True, "launch_pdl": True} if is_arch_support_pdl() else {}
-        )
+        use_pdl = is_arch_support_pdl()
+        pdl_kwargs = {"launch_pdl": True} if use_pdl else {}
         _pack_topk_ids_triton_kernel[grid](
             topk_ids,
             topk_weights,
             out,
             numel,
             BLOCK_SIZE=BLOCK_SIZE,
+            USE_PDL=use_pdl,
             **pdl_kwargs,
         )
         return out

--- a/python/sglang/kernels/ops/quantization/fp8_kernel.py
+++ b/python/sglang/kernels/ops/quantization/fp8_kernel.py
@@ -910,7 +910,8 @@ def static_quant_fp8(
     # heuristics for number of warps
     num_warps = min(max(BLOCK // 256, 1), 8)
     num_stages = 1
-    pdl_kwargs = {"USE_PDL": True, "launch_pdl": True} if is_arch_support_pdl() else {}
+    use_pdl = is_arch_support_pdl()
+    pdl_kwargs = {"launch_pdl": True} if use_pdl else {}
     _static_quant_fp8[(M,)](
         x,
         x_q.view(torch.uint8),
@@ -923,6 +924,7 @@ def static_quant_fp8(
         BLOCK=BLOCK,
         FP8_DTYPE=fp8_dtype_to_triton(fp8_dtype),
         REPEAT_SCALE=repeat_scale,
+        USE_PDL=use_pdl,
         num_warps=num_warps,
         num_stages=num_stages,
         **pdl_kwargs,

--- a/test/registered/unit/kernels/test_pdl_launch_kwargs.py
+++ b/test/registered/unit/kernels/test_pdl_launch_kwargs.py
@@ -1,0 +1,92 @@
+"""CPU-only contracts for Triton PDL-aware launcher calls."""
+
+import ast
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+
+# Load the CI marker directly so this source-only test does not import the full
+# sglang package (or any GPU-only dependencies) during collection.
+_CI_REGISTER_PATH = _REPO_ROOT / "python/sglang/test/ci/ci_register.py"
+_CI_REGISTER_SPEC = importlib.util.spec_from_file_location(
+    "sglang_ci_register", _CI_REGISTER_PATH
+)
+assert _CI_REGISTER_SPEC is not None
+assert _CI_REGISTER_SPEC.loader is not None
+_ci_register = importlib.util.module_from_spec(_CI_REGISTER_SPEC)
+_CI_REGISTER_SPEC.loader.exec_module(_ci_register)
+register_cpu_ci = _ci_register.register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+_PDL_LAUNCHES = (
+    (
+        "python/sglang/kernels/ops/elementwise/elementwise.py",
+        "fused_gate_sigmoid_mul_add",
+        "_fused_gate_sigmoid_mul_add_kernel",
+    ),
+    (
+        "python/sglang/kernels/ops/moe/pack_topk_ids.py",
+        "triton",
+        "_pack_topk_ids_triton_kernel",
+    ),
+    (
+        "python/sglang/kernels/ops/moe/inkling_moe.py",
+        "silu_and_mul_triton",
+        "_silu_and_mul_triton_kernel",
+    ),
+    (
+        "python/sglang/kernels/ops/quantization/fp8_kernel.py",
+        "static_quant_fp8",
+        "_static_quant_fp8",
+    ),
+)
+
+
+def _find_function(tree: ast.AST, function_name: str) -> ast.FunctionDef:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == function_name:
+            return node
+    raise AssertionError(f"function {function_name!r} was not found")
+
+
+def _find_kernel_launch(function: ast.FunctionDef, kernel_name: str) -> ast.Call:
+    for node in ast.walk(function):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Subscript):
+            continue
+        if isinstance(node.func.value, ast.Name) and node.func.value.id == kernel_name:
+            return node
+    raise AssertionError(
+        f"launch of {kernel_name!r} was not found in {function.name!r}"
+    )
+
+
+class TestPdlLaunchKwargs(unittest.TestCase):
+    def test_pdl_is_explicitly_passed_to_each_pdl_aware_launch(self):
+        for source_path, function_name, kernel_name in _PDL_LAUNCHES:
+            with self.subTest(source_path=source_path):
+                source = (_REPO_ROOT / source_path).read_text()
+                function = _find_function(ast.parse(source), function_name)
+                launch = _find_kernel_launch(function, kernel_name)
+                use_pdl = next(
+                    (
+                        keyword.value.id
+                        for keyword in launch.keywords
+                        if keyword.arg == "USE_PDL"
+                        and isinstance(keyword.value, ast.Name)
+                    ),
+                    None,
+                )
+                self.assertEqual(
+                    use_pdl,
+                    "use_pdl",
+                    f"{source_path}:{function_name} must pass USE_PDL=use_pdl",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/kernels/test_pdl_launch_kwargs.py
+++ b/test/registered/unit/kernels/test_pdl_launch_kwargs.py
@@ -5,7 +5,6 @@ import importlib.util
 import unittest
 from pathlib import Path
 
-
 _REPO_ROOT = Path(__file__).resolve().parents[4]
 
 # Load the CI marker directly so this source-only test does not import the full


### PR DESCRIPTION
## Motivation

Fixes #35348. On ROCm with torch 2.11 and Triton 3.7, torch.compile can generate an Inductor launcher whose signature does not match the call when a Triton kernel constexpr USE_PDL is omitted on non-PDL architectures.

## Modifications

- Pass USE_PDL explicitly for the fused MoE gate, static FP8 quantization, top-k packing, and Inkling SiLU-and-mul Triton launches.
- Keep launch_pdl enabled only when the architecture supports PDL.
- Add a CPU-only source contract test covering all four PDL-aware launch sites.

## Accuracy Tests

- CPU-only PDL launcher contract: passed.
- Python compile checks: passed.
- Registered-test lint check: passed.
- ROCm 7.2.4 torch.compile integration: not run locally; requires AMD CI hardware and the unpublished ROCm 7.2.4 environment.

## Checklist

- [x] Add focused regression tests.
- [x] Keep the change limited to the PDL launcher argument handling.
- [ ] Run the ROCm 7.2.4 integration test in CI.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32357311812](https://github.com/sgl-project/sglang/actions/runs/32357311812)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32357311631](https://github.com/sgl-project/sglang/actions/runs/32357311631)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32357311886](https://github.com/sgl-project/sglang/actions/runs/32357311886)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->