### PR TITLE
Skip empty linear-attention state buffers in PD transfer

### DIFF
--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -288,20 +288,12 @@ class MooncakeKVManager(CommonKVManager):
         Deduped because the unified memory pool reports one raw buffer as both
         its KV and its mamba state component, and double registration fails in
         the engine.
-
-        Zero-length regions are dropped: a hybrid model interleaves attention
-        and linear-attention layers, so each state component reports an empty
-        buffer for every layer of the other kind. The transfer engine rejects a
-        zero-length region, and that failure leaves the whole batch -- real
-        buffers included -- unregistered.
         """
         regions: List[Tuple[int, int]] = []
         seen: Set[Tuple[int, int]] = set()
 
         def add(ptrs: List[int], lens: List[int]) -> None:
             for ptr, length in zip(ptrs or [], lens or []):
-                if length == 0:
-                    continue
                 if (ptr, length) not in seen:
                     seen.add((ptr, length))
                     regions.append((ptr, length))

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -288,12 +288,20 @@ class MooncakeKVManager(CommonKVManager):
         Deduped because the unified memory pool reports one raw buffer as both
         its KV and its mamba state component, and double registration fails in
         the engine.
+
+        Zero-length regions are dropped: a hybrid model interleaves attention
+        and linear-attention layers, so each state component reports an empty
+        buffer for every layer of the other kind. The transfer engine rejects a
+        zero-length region, and that failure leaves the whole batch -- real
+        buffers included -- unregistered.
         """
         regions: List[Tuple[int, int]] = []
         seen: Set[Tuple[int, int]] = set()
 
         def add(ptrs: List[int], lens: List[int]) -> None:
             for ptr, length in zip(ptrs or [], lens or []):
+                if length == 0:
+                    continue
                 if (ptr, length) not in seen:
                     seen.add((ptr, length))
                     regions.append((ptr, length))

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -1075,7 +1075,7 @@ class MambaPool:
             slice_axis = self.conv_slice_axis if field == "conv" else 0
             for state_tensor in tensors:
                 # A ShortConv layer has no temporal state, so that buffer is
-                # empty; advertising it fails the whole batch registration.
+                # empty. Advertising it fails the whole batch registration.
                 if state_tensor.numel() == 0:
                     continue
                 yield field, state_tensor, slice_axis

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -1074,6 +1074,12 @@ class MambaPool:
             tensors = value if isinstance(value, list) else [value]
             slice_axis = self.conv_slice_axis if field == "conv" else 0
             for state_tensor in tensors:
+                # A conv-only linear layer carries no recurrent temporal state,
+                # so that buffer is allocated with a degenerate shape. It holds
+                # nothing to transfer, and advertising it makes the RDMA engine
+                # reject the batch registration that carries the real buffers.
+                if state_tensor.numel() == 0:
+                    continue
                 yield field, state_tensor, slice_axis
 
     def get_contiguous_buf_infos(self):

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -1074,10 +1074,8 @@ class MambaPool:
             tensors = value if isinstance(value, list) else [value]
             slice_axis = self.conv_slice_axis if field == "conv" else 0
             for state_tensor in tensors:
-                # A conv-only linear layer carries no recurrent temporal state,
-                # so that buffer is allocated with a degenerate shape. It holds
-                # nothing to transfer, and advertising it makes the RDMA engine
-                # reject the batch registration that carries the real buffers.
+                # A ShortConv layer has no temporal state, so that buffer is
+                # empty; advertising it fails the whole batch registration.
                 if state_tensor.numel() == 0:
                     continue
                 yield field, state_tensor, slice_axis

--- a/test/registered/unit/mem_cache/test_mamba_state_transfer_buffers.py
+++ b/test/registered/unit/mem_cache/test_mamba_state_transfer_buffers.py
@@ -1,0 +1,59 @@
+import unittest
+
+import torch
+
+from sglang.srt.mem_cache.memory_pool import MambaPool
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+NUM_LAYERS = 2
+NUM_SLOTS = 3
+
+
+def _pool(temporal: torch.Tensor, num_conv: int = 2) -> MambaPool:
+    """A MambaPool stub carrying only what the transfer accessors read."""
+    pool = object.__new__(MambaPool)
+    pool.num_mamba_layers = NUM_LAYERS
+    pool.conv_slice_axis = 0
+    pool.mamba_cache = MambaPool.State(
+        conv=[torch.zeros(NUM_LAYERS, NUM_SLOTS, 4, 5) for _ in range(num_conv)],
+        temporal=temporal,
+    )
+    return pool
+
+
+class TestMambaStateTransferBuffers(unittest.TestCase):
+    def test_conv_only_state_advertises_no_empty_buffer(self):
+        """A ShortConv layer declares a degenerate temporal shape, so the pool
+        allocates an empty tensor for it. The RDMA engine rejects a zero-length
+        region and fails the batch registration that carries the real buffers,
+        so an empty buffer must never be advertised."""
+        pool = _pool(torch.zeros(NUM_LAYERS, NUM_SLOTS, 0, 0, 0))
+
+        _, lens, item_lens = pool.get_contiguous_buf_infos()
+
+        self.assertNotIn(0, lens)
+        self.assertNotIn(0, item_lens)
+        self.assertEqual(len(lens), 2 * NUM_LAYERS)
+
+    def test_temporal_state_is_still_advertised(self):
+        pool = _pool(torch.zeros(NUM_LAYERS, NUM_SLOTS, 6, 7, 8))
+
+        _, lens, _ = pool.get_contiguous_buf_infos()
+
+        self.assertNotIn(0, lens)
+        self.assertEqual(len(lens), 3 * NUM_LAYERS)
+
+    def test_dims_stay_aligned_with_buffers(self):
+        """The per-tensor lists are parallel-indexed, so dropping a buffer has to
+        drop its dim too."""
+        pool = _pool(torch.zeros(NUM_LAYERS, NUM_SLOTS, 0, 0, 0))
+
+        _, lens, _ = pool.get_contiguous_buf_infos()
+
+        self.assertEqual(len(pool.get_state_dim_per_tensor()), len(lens))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

PD disaggregation cannot transfer state for Inkling: every request fails with `Failed to send kv chunk`, and once one send fails the session is blacklisted, so every later request reports `remote mooncake session ... is not alive`. The blacklisting hides the first error. With mooncake logging turned up the real order shows:

```
E transfer_engine_impl.cpp:777] Transfer Engine does not support zero length memory region
E rdma_transport.cpp:656]      Memory region not registered by any active device(s): 0x7960b8040000
```

Registration comes first, and it fails on an empty buffer. `MambaPool._iter_transfer_state_tensors` walks the state fields and skips the ones that are `None` or explicitly non-transferable, but a field can also be present and empty: a ShortConv layer has no recurrent temporal state, so its `temporal` shape is declared degenerate and the pool allocates a zero-byte tensor per layer. Those get advertised as transferable state, the engine rejects a zero-length region, and the failed batch registration leaves the real buffers unregistered too, so the transfer then fails on a live buffer with a message that points somewhere else.

Measured on Inkling-Small, per role: the mamba component reports 42 empty entries out of 294, one per layer and all from `temporal`, while `conv` reports 0 out of 252 and the attention and aux buffers report none. A model whose linear layers do carry temporal state never hits this.

The skip goes in the iterator rather than in a transfer backend: five call sites build parallel per-tensor lists from it (pointers, lengths, item lengths, sliceable dims, field names), so filtering there keeps them aligned with each other, and both the mooncake and NIXL registration paths get it. Prefill and decode run the same code, so they skip the same entries and stay in step.

Not a regression: the degenerate `temporal` shape has been there since the initial Inkling support (#31681), the pre-refactor version of this code advertised `temporal` the same way, and the mooncake version is unchanged.

## Accuracy

Single-node PD, one prefill and one decode role, TP=2 each, mooncake transfer over IB, hierarchical cache on the prefill role. Before this change no request completes at all.

`sgl-eval` aime26, thinking on, `max_tokens=131072`:

```
score           = 0.9667
error_rate      = 0.00%
stop_rate       = 1.00
truncated_rate  = 0.00%
total_completion_tokens = 768226
```

Long generations are the load-bearing part here: ~25k completion tokens per problem means the decode role advances the convolution state for tens of thousands of steps off what was transferred, so a lossy or misaligned transfer would not survive it.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #32370515187](https://github.com/sgl-project/sglang/actions/runs/32370515187)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #32370515110](https://github.com/sgl-project/sglang/actions/runs/32370515110)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #32370515225](https://github.com/sgl-project/sglang/actions/runs/32370515225)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->