### PR TITLE
[Fix][Profiler] Count target verify as decode stage

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/profiler_manager.py
+++ b/python/sglang/srt/managers/scheduler_components/profiler_manager.py
@@ -411,14 +411,17 @@ class SchedulerProfilerManager:
             return
 
         if self.profile_by_stage:
-            if batch.forward_mode.is_prefill():
+            is_decode_stage = (
+                batch.forward_mode.is_decode() or batch.forward_mode.is_target_verify()
+            )
+            if batch.forward_mode.is_prefill() and not is_decode_stage:
                 if self.profiler_prefill_ct == 0:
                     self._start_profile(batch.forward_mode)
                 self.profiler_prefill_ct += 1
                 if self.profiler_prefill_ct > self.profiler_target_prefill_ct:
                     if self.profile_in_progress:
                         self._stop_profile(stage=ForwardMode.EXTEND)
-            elif batch.forward_mode.is_decode():
+            elif is_decode_stage:
                 if self.profiler_decode_ct == 0:
                     if self.profile_in_progress:
                         # force trace flush

--- a/test/registered/unit/managers/scheduler_components/test_profiler_manager.py
+++ b/test/registered/unit/managers/scheduler_components/test_profiler_manager.py
@@ -1,0 +1,59 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call, patch
+
+from sglang.srt.environ import envs
+from sglang.srt.managers.scheduler_components.profiler_manager import (
+    SchedulerProfilerManager,
+)
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestSchedulerProfilerManager(unittest.TestCase):
+    def test_target_verify_counts_as_decode_stage(self):
+        with patch.object(envs.SGLANG_PROFILE_V2, "get", return_value=False):
+            manager = SchedulerProfilerManager(
+                ps=SimpleNamespace(),
+                dp_tp_cpu_group=None,
+                get_forward_ct=lambda: 0,
+            )
+
+        manager.profile_by_stage = True
+        manager.profiler_prefill_ct = 0
+        manager.profiler_decode_ct = 0
+        manager.profiler_target_prefill_ct = 1
+        manager.profiler_target_decode_ct = 1
+
+        def start_profile(_stage):
+            manager.profile_in_progress = True
+
+        def stop_profile(*, stage):
+            manager.profile_in_progress = False
+
+        manager._start_profile = MagicMock(side_effect=start_profile)
+        manager._stop_profile = MagicMock(side_effect=stop_profile)
+
+        for mode in (
+            ForwardMode.EXTEND,
+            ForwardMode.TARGET_VERIFY,
+            ForwardMode.TARGET_VERIFY,
+        ):
+            manager._profile_batch_predicate(SimpleNamespace(forward_mode=mode))
+
+        self.assertEqual(manager.profiler_prefill_ct, 1)
+        self.assertEqual(manager.profiler_decode_ct, 2)
+        self.assertEqual(
+            manager._start_profile.call_args_list,
+            [call(ForwardMode.EXTEND), call(ForwardMode.TARGET_VERIFY)],
+        )
+        self.assertEqual(
+            manager._stop_profile.call_args_list,
+            [call(stage=ForwardMode.EXTEND), call(stage=ForwardMode.DECODE)],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Partially addresses #34943 and complements #35115, which handles asynchronous trace export.

During speculative decoding, scheduler batches use `ForwardMode.TARGET_VERIFY`. That mode is intentionally extend-shaped and therefore satisfies `is_prefill()`, so the legacy by-stage profiler counted verify iterations as prefill and never advanced or completed its decode-stage window. The unfinished profile could then stop during a later request.

## Modifications

- Treat both `DECODE` and `TARGET_VERIFY` as decode-stage work in the legacy by-stage profiler.
- Give that lifecycle classification precedence over the extend-shaped `is_prefill()` classification.
- Add a CPU regression test covering the `EXTEND -> TARGET_VERIFY -> TARGET_VERIFY` transition and its stage start/stop calls.

## Accuracy Tests

No model computation or output values are changed.

- `pytest -q test/registered/unit/managers/scheduler_components/test_profiler_manager.py` (`1 passed`)
- Black, isort, and focused Ruff checks pass for both changed files.
- `python scripts/lint/check_registered_tests.py`

## Speed Tests and Profiling

No benchmark was run. The change only affects profiler stage bookkeeping when legacy `profile_by_stage` is enabled; normal inference scheduling is unchanged.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32360780520](https://github.com/sgl-project/sglang/actions/runs/32360780520)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32360780393](https://github.com/sgl-project/sglang/actions/runs/32360780393)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32360780528](https://github.com/sgl-project/sglang/actions/runs/32360780528)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->