### PR TITLE
fix(anthropic): preserve deferred ToolSearch on generic templates

### DIFF
--- a/python/sglang/srt/entrypoints/anthropic/serving.py
+++ b/python/sglang/srt/entrypoints/anthropic/serving.py
@@ -43,6 +43,11 @@ from sglang.srt.entrypoints.anthropic.protocol import (
     ToolUseBlock,
     is_server_tool,
 )
+from sglang.srt.entrypoints.anthropic.tool_reference import (
+    make_tool_reference_part,
+    should_forward_tool,
+    template_supports_deferred_tool_loading,
+)
 from sglang.srt.entrypoints.openai.protocol import (
     ChatCompletionRequest,
     ChatCompletionResponse,
@@ -190,8 +195,10 @@ class AnthropicServing:
 
     def __init__(self, openai_serving_chat: OpenAIServingChat):
         self.openai_serving_chat = openai_serving_chat
-        self._merge_inline_system = not detect_inline_system_support(
-            self._chat_template()
+        chat_template = self._chat_template()
+        self._merge_inline_system = not detect_inline_system_support(chat_template)
+        self._native_deferred_tool_loading = template_supports_deferred_tool_loading(
+            chat_template
         )
 
     def _chat_template(self) -> Optional[str]:
@@ -231,6 +238,7 @@ class AnthropicServing:
     ) -> ChatCompletionRequest:
         """Convert an Anthropic Messages request to an OpenAI ChatCompletion request."""
         openai_messages = []
+        referenced_tool_names: set[str] = set()
 
         def _convert_anthropic_image_source_to_openai_part(
             source: Any,
@@ -330,8 +338,12 @@ class AnthropicServing:
                         # matches on `name`. Translate at the boundary.
                         ref_name = item.get("tool_name") or item.get("name")
                         if ref_name:
+                            referenced_tool_names.add(ref_name)
                             tool_content_parts.append(
-                                {"type": "tool_reference", "name": ref_name}
+                                make_tool_reference_part(
+                                    ref_name,
+                                    native_support=self._native_deferred_tool_loading,
+                                )
                             )
                     elif item_type == "search_result":
                         search_text = _text_from_search_result(item)
@@ -651,9 +663,11 @@ class AnthropicServing:
                 anthropic_request.betas,
             )
 
-        # Convert tools. Deferred tools stay in the list with defer_loading=True;
-        # the chat template hides them from the initial <tools> block and renders
-        # them on demand when a tool_reference block names them.
+        # Native templates receive the full deferred catalog and expand schemas
+        # inline at tool_reference blocks. Generic templates cannot do that, so
+        # expose only non-deferred tools and deferred tools referenced by prior
+        # ToolSearch results. This preserves discovery semantics without sending
+        # an unsupported structured content part to the template.
         if anthropic_request.tools:
             converted_tools = []
             for tool in anthropic_request.tools:
@@ -671,12 +685,24 @@ class AnthropicServing:
                     )
                     continue
 
+                if not should_forward_tool(
+                    name=tool.name,
+                    defer_loading=tool.defer_loading,
+                    referenced_names=referenced_tool_names,
+                    native_support=self._native_deferred_tool_loading,
+                ):
+                    continue
+
                 # Custom tools always have a validated input_schema
                 # (enforced at Pydantic parse time).
                 converted_tools.append(
                     Tool(
                         type="function",
-                        defer_loading=tool.defer_loading,
+                        defer_loading=(
+                            tool.defer_loading
+                            if self._native_deferred_tool_loading
+                            else None
+                        ),
                         function={
                             "name": tool.name,
                             "description": tool.description or "",

--- a/python/sglang/srt/entrypoints/anthropic/tool_reference.py
+++ b/python/sglang/srt/entrypoints/anthropic/tool_reference.py
@@ -1,0 +1,79 @@
+"""Tool-reference compatibility decisions for Anthropic requests.
+
+CALLING SPEC:
+    native = template_supports_deferred_tool_loading(chat_template)
+    part = make_tool_reference_part(name, native_support=native)
+    visible = should_forward_tool(
+        name=name,
+        defer_loading=defer_loading,
+        referenced_names=referenced_names,
+        native_support=native,
+    )
+
+Inputs and outputs are plain values. Functions are deterministic and have no
+side effects, so template capability and deferred-tool routing can be tested
+without constructing a serving stack.
+"""
+
+from collections.abc import Mapping
+from typing import Any
+
+import jinja2
+import transformers.utils.chat_template_utils as hf_chat_utils
+
+
+def _template_sources(chat_template: Any) -> list[str]:
+    """Return string template sources from tokenizer template configuration."""
+    if isinstance(chat_template, str):
+        return [chat_template]
+    if isinstance(chat_template, Mapping):
+        return [value for value in chat_template.values() if isinstance(value, str)]
+    return []
+
+
+def template_supports_deferred_tool_loading(chat_template: Any) -> bool:
+    """Return whether a template implements native deferred-tool expansion.
+
+    Jinja comments are absent from the parsed AST, avoiding the false positive
+    caused by a raw substring check. Requiring both protocol fields also keeps
+    templates that merely render a reference as text on the generic path.
+    """
+    for source in _template_sources(chat_template):
+        try:
+            compiled = hf_chat_utils._compile_jinja_template(source)
+            template_ast = compiled.environment.parse(source)
+        except (jinja2.TemplateError, TypeError, ValueError):
+            continue
+        constants = {
+            node.value
+            for node in template_ast.find_all(jinja2.nodes.Const)
+            if isinstance(node.value, str)
+        }
+        attributes = {node.attr for node in template_ast.find_all(jinja2.nodes.Getattr)}
+        identifiers = constants | attributes
+        if {"tool_reference", "defer_loading"} <= identifiers:
+            return True
+    return False
+
+
+def make_tool_reference_part(name: str, *, native_support: bool) -> dict[str, str]:
+    """Build a native reference or a text marker for a generic template."""
+    if native_support:
+        return {"type": "tool_reference", "name": name}
+    return {"type": "text", "text": f"[tool reference: {name}]"}
+
+
+def should_forward_tool(
+    *,
+    name: str,
+    defer_loading: bool | None,
+    referenced_names: set[str],
+    native_support: bool,
+) -> bool:
+    """Return whether a tool belongs in the converted request.
+
+    Native templates receive the complete catalog and expand referenced tools
+    inline. Generic templates receive only immediately available tools plus
+    deferred tools already discovered in the conversation history.
+    """
+    return native_support or defer_loading is not True or name in referenced_names

--- a/test/registered/unit/entrypoints/anthropic/test_serving.py
+++ b/test/registered/unit/entrypoints/anthropic/test_serving.py
@@ -147,6 +147,9 @@ class TestAnthropicServing(unittest.TestCase):
         "{%- endfor %}"
     )
     GLM_TOOL_RESULT_TEMPLATE = """
+{%- for tool in tools if not tool.function.defer_loading -%}
+{{ tool.function.name }}
+{%- endfor -%}
 {%- for message in messages if message.role == "tool" -%}
 {%- if loop.first -%}<|observation|>{%- endif -%}
 {%- if message.content is string -%}
@@ -424,7 +427,9 @@ class TestAnthropicServing(unittest.TestCase):
             ]
         )
 
-        chat_request = self._serving()._convert_to_chat_completion_request(request)
+        chat_request = self._serving(
+            chat_template=self.GLM_TOOL_RESULT_TEMPLATE
+        )._convert_to_chat_completion_request(request)
         messages = chat_request.model_dump(exclude_none=True)["messages"]
 
         self.assertEqual([message["role"] for message in messages], ["tool"] * 3)
@@ -455,7 +460,9 @@ class TestAnthropicServing(unittest.TestCase):
             ],
         )
 
-        chat_request = self._serving()._convert_to_chat_completion_request(request)
+        chat_request = self._serving(
+            chat_template=self.GLM_TOOL_RESULT_TEMPLATE
+        )._convert_to_chat_completion_request(request)
         payload = chat_request.model_dump(exclude_none=True)
         prompt = template.render(messages=payload["messages"], tools=payload["tools"])
 
@@ -471,7 +478,9 @@ class TestAnthropicServing(unittest.TestCase):
             ]
         )
 
-        chat_request = self._serving()._convert_to_chat_completion_request(request)
+        chat_request = self._serving(
+            chat_template=self.GLM_TOOL_RESULT_TEMPLATE
+        )._convert_to_chat_completion_request(request)
         messages = chat_request.model_dump(exclude_none=True)["messages"]
 
         self.assertEqual(len(messages), 1)
@@ -480,6 +489,50 @@ class TestAnthropicServing(unittest.TestCase):
             [
                 {"type": "tool_reference", "name": "Bash"},
                 {"type": "tool_reference", "name": "Read"},
+            ],
+        )
+
+    def test_tool_reference_degrades_to_text_without_template_support(self):
+        request = self._tool_result_request(
+            [
+                {"type": "text", "text": "Tool loaded: Bash"},
+                {"type": "tool_reference", "tool_name": "Bash"},
+            ]
+        )
+
+        chat_request = self._serving(
+            chat_template=self.INLINE_SYSTEM_TEMPLATE
+        )._convert_to_chat_completion_request(request)
+        messages = chat_request.model_dump(exclude_none=True)["messages"]
+
+        self.assertEqual([message["role"] for message in messages], ["tool"])
+        self.assertEqual(
+            messages[0]["content"],
+            [
+                {"type": "text", "text": "Tool loaded: Bash"},
+                {"type": "text", "text": "[tool reference: Bash]"},
+            ],
+        )
+
+    def test_reference_only_tool_result_degrades_to_text_without_template_support(self):
+        request = self._tool_result_request(
+            [
+                {"type": "tool_reference", "tool_name": "Bash"},
+                {"type": "tool_reference", "tool_name": "Read"},
+            ]
+        )
+
+        chat_request = self._serving(
+            chat_template=self.INLINE_SYSTEM_TEMPLATE
+        )._convert_to_chat_completion_request(request)
+        messages = chat_request.model_dump(exclude_none=True)["messages"]
+
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(
+            messages[0]["content"],
+            [
+                {"type": "text", "text": "[tool reference: Bash]"},
+                {"type": "text", "text": "[tool reference: Read]"},
             ],
         )
 

--- a/test/registered/unit/entrypoints/anthropic/test_tool_reference.py
+++ b/test/registered/unit/entrypoints/anthropic/test_tool_reference.py
@@ -1,0 +1,244 @@
+"""Regression coverage for Anthropic deferred-tool compatibility.
+
+CALLING SPEC:
+    python3 test/registered/unit/entrypoints/anthropic/test_tool_reference.py
+
+Runs CPU-only tests for native template expansion, generic-template deferred
+tool routing, and Qwen-style strict content rendering. No external services or
+model weights are required.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()  # must precede imports that may pull in sgl_kernel
+
+from jinja2 import Environment  # noqa: E402
+
+from sglang.srt.entrypoints.anthropic.protocol import (  # noqa: E402
+    AnthropicMessagesRequest,
+)
+from sglang.srt.entrypoints.anthropic.serving import AnthropicServing  # noqa: E402
+from sglang.srt.entrypoints.anthropic.tool_reference import (  # noqa: E402
+    template_supports_deferred_tool_loading,
+)
+from sglang.test.ci.ci_register import register_cpu_ci  # noqa: E402
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+NATIVE_TEMPLATE = """
+{%- for tool in tools if not tool.function.defer_loading -%}
+{{ tool.function.name }}
+{%- endfor -%}
+{%- for message in messages if message.role == "tool" -%}
+{%- if message.content is not string and message.content.0.type == "tool_reference" -%}
+{%- for reference in message.content -%}
+{%- for tool in tools if tool.function.name == reference.name -%}
+{{ tool.function.name }}
+{%- endfor -%}
+{%- endfor -%}
+{%- endif -%}
+{%- endfor -%}
+"""
+
+QWEN_LIKE_TEMPLATE = """
+{%- macro render_content(content) -%}
+    {%- if content is string -%}
+        {{- content -}}
+    {%- else -%}
+        {%- for item in content -%}
+            {%- if item.type == "text" -%}
+                {{- item.text -}}
+            {%- else -%}
+                {{- raise_exception("Unexpected item type in content.") -}}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- endif -%}
+{%- endmacro -%}
+{%- for tool in tools -%}{{ tool.function.name }} {% endfor -%}
+{%- for message in messages -%}{{ render_content(message.content) }}{% endfor -%}
+"""
+
+
+class _FakeOpenAIServingChat:
+    def __init__(self, chat_template):
+        self.tokenizer_manager = SimpleNamespace(
+            tokenizer=SimpleNamespace(chat_template=chat_template)
+        )
+
+
+def _tool(name: str, *, defer_loading: bool) -> dict:
+    return {
+        "name": name,
+        "description": f"The {name} tool",
+        "input_schema": {"type": "object", "properties": {}},
+        "defer_loading": defer_loading,
+    }
+
+
+def _request(
+    *,
+    references: list[str] | None = None,
+    tool_choice: dict | None = None,
+) -> AnthropicMessagesRequest:
+    if references is None:
+        messages = [{"role": "user", "content": "Find a useful tool"}]
+    else:
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "tool_search_1",
+                        "content": [
+                            {
+                                "type": "tool_reference",
+                                "tool_name": name,
+                            }
+                            for name in references
+                        ],
+                    }
+                ],
+            }
+        ]
+    request = {
+        "model": "test-model",
+        "max_tokens": 16,
+        "messages": messages,
+        "tools": [
+            _tool("ToolSearch", defer_loading=False),
+            _tool("Bash", defer_loading=True),
+            _tool("Read", defer_loading=True),
+        ],
+    }
+    if tool_choice is not None:
+        request["tool_choice"] = tool_choice
+    return AnthropicMessagesRequest.model_validate(request)
+
+
+def _convert(chat_template: str, *, references: list[str] | None = None) -> dict:
+    serving = AnthropicServing(_FakeOpenAIServingChat(chat_template))
+    request = serving._convert_to_chat_completion_request(
+        _request(references=references)
+    )
+    return request.model_dump(exclude_none=True)
+
+
+def _raise_exception(message: str) -> None:
+    raise ValueError(message)
+
+
+class TestTemplateCapabilityDetection(unittest.TestCase):
+    def test_detects_native_deferred_tool_expansion(self):
+        self.assertTrue(template_supports_deferred_tool_loading(NATIVE_TEMPLATE))
+
+    def test_ignores_jinja_comment(self):
+        self.assertFalse(
+            template_supports_deferred_tool_loading(
+                "{# tool_reference and defer_loading are unsupported #}"
+            )
+        )
+
+    def test_reference_text_rendering_is_not_native_expansion(self):
+        marker_only_template = """
+        {% if item.type == "tool_reference" %}
+        [tool reference: {{ item.name }}]
+        {% endif %}
+        """
+        self.assertFalse(template_supports_deferred_tool_loading(marker_only_template))
+
+    def test_checks_each_named_template(self):
+        self.assertTrue(
+            template_supports_deferred_tool_loading(
+                {"default": "{{ message.content }}", "tool_use": NATIVE_TEMPLATE}
+            )
+        )
+
+
+class TestGenericTemplateDeferredTools(unittest.TestCase):
+    def test_hides_deferred_tools_before_discovery(self):
+        payload = _convert(QWEN_LIKE_TEMPLATE)
+
+        self.assertEqual(
+            [tool["function"]["name"] for tool in payload["tools"]],
+            ["ToolSearch"],
+        )
+
+    def test_forwards_only_referenced_deferred_tools(self):
+        payload = _convert(QWEN_LIKE_TEMPLATE, references=["Bash"])
+
+        self.assertEqual(
+            [tool["function"]["name"] for tool in payload["tools"]],
+            ["ToolSearch", "Bash"],
+        )
+        self.assertNotIn("defer_loading", payload["tools"][1])
+        self.assertNotIn("defer_loading", payload["tools"][1]["function"])
+
+    def test_qwen_style_render_receives_text_and_unlocked_schema(self):
+        payload = _convert(QWEN_LIKE_TEMPLATE, references=["Bash"])
+        environment = Environment()
+        environment.globals["raise_exception"] = _raise_exception
+
+        prompt = environment.from_string(QWEN_LIKE_TEMPLATE).render(
+            messages=payload["messages"],
+            tools=payload["tools"],
+        )
+
+        self.assertIn("ToolSearch Bash", prompt)
+        self.assertNotIn("Read", prompt)
+        self.assertIn("[tool reference: Bash]", prompt)
+
+    def test_unknown_reference_does_not_unlock_a_tool(self):
+        payload = _convert(QWEN_LIKE_TEMPLATE, references=["Unknown"])
+
+        self.assertEqual(
+            [tool["function"]["name"] for tool in payload["tools"]],
+            ["ToolSearch"],
+        )
+        self.assertEqual(
+            payload["messages"][0]["content"],
+            "[tool reference: Unknown]",
+        )
+
+    def test_forced_deferred_tool_requires_prior_discovery(self):
+        serving = AnthropicServing(_FakeOpenAIServingChat(QWEN_LIKE_TEMPLATE))
+        request = _request(tool_choice={"type": "tool", "name": "Bash"})
+
+        with self.assertRaisesRegex(ValueError, "not in the forwarded tools list"):
+            serving._convert_to_chat_completion_request(request)
+
+    def test_discovered_deferred_tool_can_be_forced(self):
+        serving = AnthropicServing(_FakeOpenAIServingChat(QWEN_LIKE_TEMPLATE))
+        request = _request(
+            references=["Bash"],
+            tool_choice={"type": "tool", "name": "Bash"},
+        )
+
+        payload = serving._convert_to_chat_completion_request(request).model_dump(
+            exclude_none=True
+        )
+
+        self.assertEqual(payload["tool_choice"]["function"]["name"], "Bash")
+
+
+class TestNativeTemplateDeferredTools(unittest.TestCase):
+    def test_preserves_structured_reference_and_full_catalog(self):
+        payload = _convert(NATIVE_TEMPLATE, references=["Bash"])
+
+        self.assertEqual(
+            [tool["function"]["name"] for tool in payload["tools"]],
+            ["ToolSearch", "Bash", "Read"],
+        )
+        self.assertTrue(payload["tools"][1]["function"]["defer_loading"])
+        self.assertEqual(
+            payload["messages"][0]["content"],
+            [{"type": "tool_reference", "name": "Bash"}],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #35692.

The Anthropic endpoint receives `tool_reference` blocks from Claude Code ToolSearch results. SGLang previously forwarded those blocks as structured message content unconditionally. Templates without native deferred-tool support, including the stock Qwen3.8-27B template, reject that content type and return HTTP 500. Because the reference remains in conversation history, every later request in the session also fails.

A text-only fallback prevents the crash but loses ToolSearch semantics if all deferred schemas remain visible from the first turn. This revision preserves discovery gating for templates that cannot expand references themselves.

## Modifications

- Templates with native deferred loading, such as GLM, still receive the complete tool catalog and structured `tool_reference` parts. Their template performs filtering and inline schema expansion.
- Generic templates receive only non-deferred tools initially.
- When conversation history contains a `tool_reference`, the matching deferred tool is added to the current request's normal tool list and the history block is rendered as a text marker.
- Unreferenced deferred tools remain hidden, and a forced deferred `tool_choice` is rejected until that tool has been discovered.
- Deterministic capability detection and routing live in `anthropic/tool_reference.py`.
- Jinja AST inspection requires executable references to both `tool_reference` and `defer_loading`, avoiding false positives from comments or marker-only templates.
- Referenced tool names are collected while converting message history, and deferred-loading metadata is stripped before an unlocked tool reaches a generic template.

Generic templates cannot preserve Anthropic's exact inline-placement and prompt-cache behavior, but they preserve the functional contract: a deferred tool becomes callable only after ToolSearch discovers it.

## Accuracy Tests

Not applicable to model numerical accuracy: this change only affects Anthropic request conversion and tool-schema visibility.

Functional regression coverage:

- New `test_tool_reference.py`: 11/11 passed.
- Existing `test_serving.py`: 63/63 passed after rebasing onto current `main`.
- The stock Qwen3.8-27B template renders successfully: initial tools are `[ToolSearch]`; after a Bash reference they are `[ToolSearch, Bash]`; unreferenced Read remains hidden.
- Native GLM deferred-reference behavior remains covered.

## Speed Tests and Profiling

Not applicable: the change is request-conversion logic and does not modify inference kernels or the model execution hot path.

## Validation

- Ruff 0.15.1: passed.
- Black 26.1.0: passed.
- isort 7.0.0: passed.
- `git diff --check`: passed.
- Branch rebased onto current `main` and contains the repository's required `MIN_BASE_SHA`.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (Not applicable: no user-facing API or configuration changes.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Not applicable; rationale provided above.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32686400532](https://github.com/sgl-project/sglang/actions/runs/32686400532)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32686400450](https://github.com/sgl-project/sglang/actions/runs/32686400450)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32686400861](https://github.com/sgl-project/sglang/actions/runs/32686400861)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->