### PR TITLE
[docker] cu13 build fails with ResolutionImpossible installing runai-model-streamer: torch pins nvidia-nccl-cu13==2.29.7   but constraints.txt carries SGL_NCCL_VERSION (2.30.7)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -417,6 +417,7 @@ ARG USE_LATEST_SGLANG
 ARG GITHUB_ARTIFACTORY
 ARG MOONCAKE_VERSION
 ARG MSCCLPP_VERSION
+ARG SGL_NCCL_VERSION
 
 WORKDIR /sgl-workspace
 
@@ -517,8 +518,15 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     && rm -rf /tmp/mscclpp
 
 # Install essential Python packages (use constraints to prevent conflicts)
+# runai-model-streamer depends on torch, and torch pins nvidia-nccl-cu13==2.29.7
+# exactly. constraints.txt carries the overridden ${SGL_NCCL_VERSION} (e.g. 2.30.7)
+# from the torch_deps stage, which makes pip's resolver hit ResolutionImpossible
+# (torch's ==2.29.7 vs constraint ==2.30.7). Drop the nccl pin from constraints for
+# this solve so pip can pick a consistent nccl, then force-reinstall the overridden
+# version back afterwards.
 RUN --mount=type=cache,target=/root/.cache/pip \
-    python3 -m pip install -c /sgl-workspace/constraints.txt \
+    sed -i '/^nvidia-nccl-cu13==/d' /sgl-workspace/constraints.txt \
+    && python3 -m pip install -c /sgl-workspace/constraints.txt \
     datamodel_code_generator \
     pre-commit \
     pytest \
@@ -535,7 +543,8 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     matplotlib \
     tabulate \
     termplotlib \
-    "runai-model-streamer[s3,gcs,azure]>=0.15.7"
+    "runai-model-streamer[s3,gcs,azure]>=0.15.7" \
+    && python3 -m pip install --no-deps --force-reinstall "nvidia-nccl-cu13==${SGL_NCCL_VERSION}"
 
 # Per-CUDA-major package installs. The `nixl` stub package is needed (it owns
 # the `nixl` import path) but unconditionally requires nixl-cu12, so we install


### PR DESCRIPTION


## Motivation

  On the cu13 (CUDA_VERSION=13.0.3) build path with BUILD_TYPE=all (default), the framework stage aborts at the "Install essential Python packages" step:

  ERROR: Cannot install torch==2.13.0+cu130 because these package versions have conflicting dependencies.
  The conflict is caused by:
      torch 2.13.0+cu130 depends on nvidia-nccl-cu13==2.29.7
      The user requested (constraint) nvidia-nccl-cu13==2.30.7
  ERROR: ResolutionImpossible

  Root cause is a mismatch between torch's nccl pin and the Dockerfile's nccl override:

  1. runai-model-streamer[s3,gcs,azure] (installed at the framework stage, Dockerfile ~line 538) depends on
     torch<3.0.0,>=2.0.0 (https://pypi.org/project/runai-model-streamer/). Pulling runai therefore makes pip resolve the
     runai → torch → nvidia-nccl-cu13 chain.

  2. torch-2.13.0+cu130 pins nccl exactly: Requires-Dist: nvidia-nccl-cu13==2.29.7 (verified directly from the wheel's
     METADATA).

  3. In the torch_deps stage the Dockerfile overrides nccl with --no-deps --force-reinstall (only for cu13):

     && if [ "${CUDA_VERSION%%.*}" = "13" ]; then \
            python3 -m pip install --force-reinstall --no-deps \
                "nvidia-nccl-cu13==${SGL_NCCL_VERSION}"; \   # default 2.30.7
        fi
     and then freezes it into constraints.txt:

     && pip freeze | grep -v "^sglang==" > /sgl-workspace/constraints.txt
     so constraints.txt carries nvidia-nccl-cu13==2.30.7.

  4. The framework-stage install runs under -c /sgl-workspace/constraints.txt. pip's resolver back-traces torch's transitive     nvidia-nccl-cu13==2.29.7 and finds it unsatisfiable alongside the constraint ==2.30.7 → ResolutionImpossible.

   So whenever SGL_NCCL_VERSION (default 2.30.7) differs from torch's own pin (2.29.7 for torch 2.13.0+cu130), the cu13 image  build fails. The cu12 path is unaffected (the nccl override only runs for cu13).
  
## Modifications

  Keep nccl out of the constraint solve for the affected install, then restore the override afterwards (commit 854a2e96).
  1. Expose SGL_NCCL_VERSION in the framework stage so the restore step can reference it (the ARG was previously only visible in base/torch_deps):
```
     ARG MSCCLPP_VERSION
     ARG SGL_NCCL_VERSION
```

  2. In the "Install essential Python packages" RUN, drop the nccl line from constraints.txt before the constrained install, so pip can pick a nccl consistent with torch's pin:
```
     RUN --mount=type=cache,target=/root/.cache/pip \
         sed -i '/^nvidia-nccl-cu13==/d' /sgl-workspace/constraints.txt \
         && python3 -m pip install -c /sgl-workspace/constraints.txt \
             datamodel_code_generator \
             ... \
             "runai-model-streamer[s3,gcs,azure]>=0.15.7" \
         && python3 -m pip install --no-deps --force-reinstall "nvidia-nccl-cu13==${SGL_NCCL_VERSION}"
```

+ sed removes only the nvidia-nccl-cu13== line, so the rest of constraints.txt still pins torch/transformers/etc. as intended.
+ With the nccl constraint gone, pip install -c succeeds; pip will satisfy torch by (down)loading nccl 2.29.7.
+ The trailing --no-deps --force-reinstall nvidia-nccl-cu13==${SGL_NCCL_VERSION} puts nccl back to the intended override (2.30.7), matching the pre-fix end state.



## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32363742569](https://github.com/sgl-project/sglang/actions/runs/32363742569)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32363742219](https://github.com/sgl-project/sglang/actions/runs/32363742219)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->