### PR TITLE
[Bug] Seeded sampling changes token when a batchmate enables top-k/top-p

### DIFF
--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -564,6 +564,22 @@ def create_sampler(backend: Optional[str] = None) -> "Sampler":
     )
 
 
+def _seeded_sample_from_masked_sorted(
+    probs: torch.Tensor,
+    probs_sort: torch.Tensor,
+    probs_idx: torch.Tensor,
+    sampling_seed: torch.Tensor,
+    positions: torch.Tensor,
+) -> torch.Tensor:
+    # murmur_hash32 keys noise by column index; scatter so column j is token j,
+    # otherwise a seeded row's token changes when a batchmate triggers this path.
+    weights = torch.zeros_like(probs).scatter_(-1, probs_idx, probs_sort)
+    # Masked entries are 0; log_softmax on the unmasked logits would revive them.
+    return multinomial_with_seed(
+        logprobs=torch.log(weights), seed=sampling_seed, positions=positions
+    )
+
+
 def top_k_top_p_min_p_sampling_from_probs_torch(
     probs: torch.Tensor,
     top_ks: torch.Tensor,
@@ -596,20 +612,20 @@ def top_k_top_p_min_p_sampling_from_probs_torch(
 
     if sampling_seed is None:
         sampled_index = torch.multinomial(probs_sort, num_samples=1)
-    else:
-        # NOTE: when using top-k/top-p/min-p sampling, we need to modify probs before we
-        # apply log to get logprobs. Therefore, we cannot use log_softmax directly.
-        # For now, we use log to the modified probs to get logprobs, but for numerical
-        # stability, we'd better come up with a solution to use log_softmax.
-        logprobs = probs_sort.to(torch.float64)  # Using float64 for numerical stability
-        del probs_sort
-        logprobs.log_()
-        sampled_index = multinomial_with_seed(logprobs, sampling_seed, positions)
+        probs_idx = probs_idx.to(torch.int32)
+        return torch.gather(probs_idx, dim=1, index=sampled_index).view(-1)
 
-    # int32 range is enough to represent the token ids
-    probs_idx = probs_idx.to(torch.int32)
-    batch_next_token_ids = torch.gather(probs_idx, dim=1, index=sampled_index).view(-1)
-    return batch_next_token_ids
+    return (
+        _seeded_sample_from_masked_sorted(
+            probs=probs,
+            probs_sort=probs_sort,
+            probs_idx=probs_idx,
+            sampling_seed=sampling_seed,
+            positions=positions,
+        )
+        .view(-1)
+        .to(torch.int32)
+    )
 
 
 def top_k_top_p_min_p_sampling_from_logits_ascend(
@@ -671,15 +687,16 @@ def top_k_top_p_min_p_sampling_from_logits_ascend(
 
         if sampling_seed is None:
             sampled_index = torch.multinomial(probs_sort, num_samples=1)
+            probs_idx = probs_idx.to(torch.int32)
+            batch_next_token_ids = torch.gather(probs_idx, dim=1, index=sampled_index)
         else:
-            logprobs = probs_sort.to(
-                torch.float64
-            )  # Using float64 for numerical stability
-            del probs_sort
-            logprobs.log_()
-            sampled_index = multinomial_with_seed(logprobs, sampling_seed, positions)
-        probs_idx = probs_idx.to(torch.int32)
-        batch_next_token_ids = torch.gather(probs_idx, dim=1, index=sampled_index)
+            batch_next_token_ids = _seeded_sample_from_masked_sorted(
+                probs=probs,
+                probs_sort=probs_sort,
+                probs_idx=probs_idx,
+                sampling_seed=sampling_seed,
+                positions=positions,
+            )
 
     return batch_next_token_ids.view(-1)
 

--- a/test/registered/sampling/test_deterministic_vocab_id_noise.py
+++ b/test/registered/sampling/test_deterministic_vocab_id_noise.py
@@ -1,0 +1,110 @@
+"""Seeded sampling hashes Gumbel noise by token id, even when the batch took
+the top-k/top-p sort path."""
+
+import unittest
+
+import torch
+
+from sglang.srt.layers.sampler import (
+    sampling_from_probs_torch,
+    top_k_top_p_min_p_sampling_from_probs_torch,
+)
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=15, stage="base-b", runner_config="1-gpu-small")
+register_amd_ci(est_time=15, suite="stage-b-test-1-gpu-small-amd")
+
+VOCAB = 32
+DEVICE = "cuda"
+# Near-uniform so Gumbel noise, not the distribution, picks the token.
+LOGIT_SCALE = 0.05
+
+
+def _seeded_simple(probs: torch.Tensor, seed: int, position: int) -> int:
+    device = probs.device
+    return int(
+        sampling_from_probs_torch(
+            probs,
+            sampling_seed=torch.tensor([seed], device=device, dtype=torch.int64),
+            positions=torch.tensor([position], device=device, dtype=torch.int64),
+        ).item()
+    )
+
+
+def _seeded_complex(
+    probs: torch.Tensor,
+    top_ks: list[int],
+    seeds: list[int],
+    positions: list[int],
+) -> torch.Tensor:
+    batch = probs.shape[0]
+    device = probs.device
+    return top_k_top_p_min_p_sampling_from_probs_torch(
+        probs=probs,
+        top_ks=torch.tensor(top_ks, device=device, dtype=torch.int32),
+        top_ps=torch.ones(batch, device=device, dtype=torch.float32),
+        min_ps=torch.zeros(batch, device=device, dtype=torch.float32),
+        need_min_p_sampling=False,
+        sampling_seed=torch.tensor(seeds, device=device, dtype=torch.int64),
+        positions=torch.tensor(positions, device=device, dtype=torch.int64),
+    )
+
+
+class TestDeterministicVocabIdNoise(CustomTestCase):
+    def test_seeded_row_unaffected_by_batchmate_filtering(self):
+        """A seeded unfiltered row must pick the same token when a batchmate
+        triggers the top-k sort path."""
+        torch.manual_seed(0)
+        seeded_probs = torch.softmax(
+            torch.randn(1, VOCAB, device=DEVICE) * LOGIT_SCALE, dim=-1
+        )
+        mate_probs = torch.softmax(torch.randn(1, VOCAB, device=DEVICE) * 3.0, dim=-1)
+        seed, position = 4321, 6
+        solo = _seeded_simple(seeded_probs, seed=seed, position=position)
+        mixed = _seeded_complex(
+            probs=torch.cat([seeded_probs, mate_probs], dim=0),
+            top_ks=[VOCAB, 2],
+            seeds=[seed, seed + 1],
+            positions=[position, position + 5],
+        )
+        self.assertEqual(int(mixed[0].item()), solo)
+
+    def test_noop_topk_matches_simple_path(self):
+        """top_k equal to vocab size masks nothing, so the complex path must
+        still match the simple path."""
+        torch.manual_seed(1)
+        probs = torch.softmax(
+            torch.randn(1, VOCAB, device=DEVICE) * LOGIT_SCALE, dim=-1
+        )
+        seed, position = 12345, 4
+        simple = _seeded_simple(probs, seed=seed, position=position)
+        complex_tok = int(
+            _seeded_complex(
+                probs=probs,
+                top_ks=[VOCAB],
+                seeds=[seed],
+                positions=[position],
+            ).item()
+        )
+        self.assertEqual(complex_tok, simple)
+
+    def test_seeded_topk_never_samples_masked_token(self):
+        """Tokens zeroed by top-k must stay unreachable under seeded Gumbel-max."""
+        logits = torch.zeros(1, VOCAB, device=DEVICE)
+        logits[0, 7] = 5.0
+        logits[0, 3] = 4.0
+        logits[0, 11] = 3.0
+        tok = int(
+            _seeded_complex(
+                probs=torch.softmax(logits, dim=-1),
+                top_ks=[2],
+                seeds=[0],
+                positions=[0],
+            ).item()
+        )
+        self.assertIn(tok, {3, 7})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation
`--enable-deterministic-inference` forces the pytorch sampling backend. Seeded Gumbel noise is hashed as `murmur_hash32(seed, position, column_index)`.

The simple path (`sampling_from_probs_torch`) hashes **token ids**. The top-k/top-p/min-p path sorted first and hashed **rank**, then gathered back to token ids. `need_top_k/top_p/min_p` is a batch-level `any()`, so one filtering request (including greedy `temperature=0` → `top_k=1`) switched every row onto the rank-space path. Same `(seed, distribution, position)` could therefore sample a different token depending on who else was in the batch. Homogeneous batch-size tests do not catch this; mixed sampling params do.

The MLX backend already enforces vocab-id noise (`test_seeded_row_unaffected_by_batchmate_filtering`). This ports that contract to the CUDA pytorch path and the Ascend sort fallback.

Does not touch the `min_p` + seed assert; that is #33699.

## Modifications
- After top-k/top-p/min-p masking, scatter weights back to vocab order, then call `multinomial_with_seed`. The argmax is already a token id.
- Same helper on the Ascend sort fallback. The `npu_top_k_top_p` branch was already in vocab order.
- Unseeded `torch.multinomial` is unchanged.
- Tests in `test/registered/sampling/test_deterministic_vocab_id_noise.py`:
  - unfiltered row matches the simple path when a batchmate has `top_k=2`
  - `top_k == vocab_size` (no-op mask) matches the simple path
  - top-k zeros stay unreachable under Gumbel-max
 
**Compatibility:** seeded + top-k/top-p outputs will change versus previous versions (rank-space → vocab-id-space). Mixed-batch results now match the solo simple path. Replay of old seeded+filter rollouts will not bit-match.

## Accuracy Tests
Unit tests only (Triton `murmur_hash32`, no server):
```bash
python3 test/registered/sampling/test_deterministic_vocab_id_noise.py
python3 test/registered/sampling/test_deterministic_gumbel_u1.py
```
Pre-fix the first two cases failed (6 != 23, 8 != 12). Post-fix all three pass; existing gumbel u=1 tests still pass.

No model-forward change for greedy-only or unseeded sampling.

## Speed Tests and Profiling
No speed benchmark. The extra work is a [B, vocab] scatter after a full-vocab sort that this path already does.

## Checklist
- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Docs/bench left unchecked: the documented seed contract does not need a wording change; this is not a throughput-sensitive kernel.

## Review and Merge Process
cc sampling / deterministic-inference: @Fridge003

- Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
- Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
- Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
  - Common commands include /tag-and-rerun-ci, /tag-run-ci-label, /rerun-failed-ci
- After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32365219565](https://github.com/sgl-project/sglang/actions/runs/32365219565)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32365219295](https://github.com/sgl-project/sglang/actions/runs/32365219295)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32365219450](https://github.com/sgl-project/sglang/actions/runs/32365219450)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->