### PR TITLE
[Test] Add unit tests for TokenSequenceMatcher

### DIFF
--- a/test/registered/unit/utils/test_token_sequence_matcher.py
+++ b/test/registered/unit/utils/test_token_sequence_matcher.py
@@ -1,0 +1,109 @@
+"""Unit tests for srt/utils/token_sequence_matcher.py -- CPU, no server."""
+
+import unittest
+from typing import Optional, Sequence
+
+from sglang.srt.utils.token_sequence_matcher import TokenSequenceMatcher
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def _first_match_end(
+    matcher: TokenSequenceMatcher, tokens: Sequence[int]
+) -> Optional[int]:
+    """Exclusive end index of the first full match, or None."""
+    matched = 0
+    for index, token in enumerate(tokens):
+        matched = matcher.advance(matched, token)
+        if matched == len(matcher):
+            return index + 1
+    return None
+
+
+class TestTokenSequenceMatcher(CustomTestCase):
+    def test_empty_pattern_raises(self):
+        for pattern in ([], (), range(0)):
+            with self.subTest(pattern=pattern):
+                with self.assertRaisesRegex(ValueError, "at least one token"):
+                    TokenSequenceMatcher(pattern)
+
+    def test_stores_an_independent_tuple_copy(self):
+        src = [7, 8, 9]
+        matcher = TokenSequenceMatcher(src)
+        self.assertEqual(matcher.pattern, (7, 8, 9))
+        self.assertEqual(len(matcher), 3)
+        src[0] = 0
+        self.assertEqual(matcher.pattern, (7, 8, 9))
+
+    def test_prefix_lengths_no_self_overlap(self):
+        matcher = TokenSequenceMatcher([1, 2, 3])
+        self.assertEqual(matcher.prefix_lengths, (0, 0, 0))
+
+    def test_prefix_lengths_repeated_token(self):
+        # AAA -> LPS [0, 1, 2]
+        matcher = TokenSequenceMatcher([1, 1, 1])
+        self.assertEqual(matcher.prefix_lengths, (0, 1, 2))
+
+    def test_prefix_lengths_periodic_prefix(self):
+        # ABABC -> LPS [0, 0, 1, 2, 0]
+        matcher = TokenSequenceMatcher([1, 2, 1, 2, 3])
+        self.assertEqual(matcher.prefix_lengths, (0, 0, 1, 2, 0))
+
+    def test_prefix_lengths_classic_kmp(self):
+        # AABAACAABAA -> LPS [0, 1, 0, 1, 2, 0, 1, 2, 3, 4, 5]
+        matcher = TokenSequenceMatcher([1, 1, 2, 1, 1, 3, 1, 1, 2, 1, 1])
+        self.assertEqual(matcher.prefix_lengths, (0, 1, 0, 1, 2, 0, 1, 2, 3, 4, 5))
+
+    def test_single_token_match_and_miss(self):
+        matcher = TokenSequenceMatcher([42])
+        self.assertEqual(matcher.prefix_lengths, (0,))
+        self.assertEqual(matcher.advance(0, 41), 0)
+        self.assertEqual(matcher.advance(0, 42), 1)
+        self.assertEqual(_first_match_end(matcher, [41, 41, 42]), 3)
+
+    def test_contiguous_match(self):
+        matcher = TokenSequenceMatcher([10, 20, 30])
+        self.assertEqual(_first_match_end(matcher, [1, 10, 20, 30, 99]), 4)
+        self.assertIsNone(_first_match_end(matcher, [10, 20, 31]))
+
+    def test_mismatch_falls_back_to_prefix(self):
+        # ABABC in ABABABC: after ABAB the next A continues as prefix AB, not 0.
+        matcher = TokenSequenceMatcher([1, 2, 1, 2, 3])
+        self.assertEqual(_first_match_end(matcher, [1, 2, 1, 2, 1, 2, 3]), 7)
+
+    def test_mismatch_walks_prefix_chain(self):
+        # ABAC in ABAABAC: mismatch at C walks LPS twice (3 -> 1 -> 0+1).
+        matcher = TokenSequenceMatcher([1, 2, 1, 3])
+        self.assertEqual(matcher.prefix_lengths, (0, 0, 1, 0))
+        self.assertEqual(_first_match_end(matcher, [1, 2, 1, 1, 2, 1, 3]), 7)
+
+    def test_self_overlapping_run_reports_first_full_match(self):
+        matcher = TokenSequenceMatcher([1, 1, 1])
+        self.assertEqual(_first_match_end(matcher, [1, 1, 1, 1]), 3)
+
+    def test_false_start_then_real_match(self):
+        matcher = TokenSequenceMatcher([1, 2, 3])
+        self.assertEqual(_first_match_end(matcher, [1, 2, 1, 2, 3]), 5)
+
+    def test_partial_state_survives_across_chunks(self):
+        # Callers keep matched between separately arriving token chunks.
+        matcher = TokenSequenceMatcher([8, 9])
+        matched = matcher.advance(0, 8)
+        self.assertEqual(matched, 1)
+        matched = matcher.advance(matched, 7)
+        self.assertEqual(matched, 0)
+        matched = matcher.advance(matched, 8)
+        self.assertEqual(matched, 1)
+        matched = matcher.advance(matched, 9)
+        self.assertEqual(matched, 2)
+        self.assertEqual(matched, len(matcher))
+
+    def test_mismatch_at_first_token_stays_zero(self):
+        matcher = TokenSequenceMatcher([5, 6])
+        self.assertEqual(matcher.advance(0, 6), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation
`TokenSequenceMatcher` is a KMP matcher used to detect think-end token sequences in `schedule_batch.update_reasoning_tokens` and `ReasonerGrammarObject`. It had no dedicated unit coverage.

Refs #20865
## Modifications
Added `test/registered/unit/utils/test_token_sequence_matcher.py` (CPU-only, `register_cpu_ci(est_time=1, suite="base-a-test-cpu")`).
Coverage:
- empty pattern raises `ValueError`
- constructor stores an independent tuple copy
- KMP prefix table for no-overlap, repeated-token, periodic, and classic AABAACAABAA patterns
- `advance()`: hit, miss, prefix fallback, LPS chain walk, false start then real match
- `matched` state kept across separately arriving token chunks

No production code changes.

## Accuracy Tests
Not applicable. Test-only change; no model execution.
Local:
```bash
python3 test/registered/unit/utils/test_token_sequence_matcher.py
```
Result: 14 passed.

## Speed Tests and Profiling
Not applicable.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32367163790](https://github.com/sgl-project/sglang/actions/runs/32367163790)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32367163541](https://github.com/sgl-project/sglang/actions/runs/32367163541)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32367163610](https://github.com/sgl-project/sglang/actions/runs/32367163610)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->