### PR TITLE
feat(grpc): expose KV event discovery metadata

### DIFF
--- a/python/sglang/srt/entrypoints/grpc_bridge.py
+++ b/python/sglang/srt/entrypoints/grpc_bridge.py
@@ -419,6 +419,9 @@ class RuntimeHandle:
     def get_server_info(self) -> str:
         result: Dict[str, Any] = dataclasses.asdict(self.tokenizer_manager.server_args)
         result.update(self.scheduler_info)
+        result["kv_events"] = (
+            self.tokenizer_manager.server_args.describe_kv_events_publisher()
+        )
         return json.dumps(msgspec_to_builtins(result), default=str)
 
     def health_check(self) -> bool:

--- a/test/registered/unit/entrypoints/test_grpc_bridge.py
+++ b/test/registered/unit/entrypoints/test_grpc_bridge.py
@@ -110,5 +110,6 @@ class TestNativeGrpcParallelResponses(CustomTestCase):
         )
         self.assertEqual([call[1] for call in callback.calls], [False, False, True])
 
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/test/registered/unit/entrypoints/test_grpc_bridge.py
+++ b/test/registered/unit/entrypoints/test_grpc_bridge.py
@@ -1,11 +1,9 @@
 import asyncio
 import enum
-import json
 import unittest
 from types import SimpleNamespace
 
 from sglang.srt.entrypoints.grpc_bridge import RuntimeHandle
-from sglang.srt.server_args import ServerArgs
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -111,36 +109,6 @@ class TestNativeGrpcParallelResponses(CustomTestCase):
             [[1], [2], [3]],
         )
         self.assertEqual([call[1] for call in callback.calls], [False, False, True])
-
-
-class TestNativeGrpcServerInfo(CustomTestCase):
-    def test_exposes_structured_kv_events_descriptor(self):
-        server_args = ServerArgs(
-            model_path="dummy",
-            kv_events_config=(
-                '{"publisher":"zmq","endpoint":"tcp://*:5557","topic":"kv"}'
-            ),
-            page_size=64,
-            dp_size=2,
-        )
-        handle = RuntimeHandle.__new__(RuntimeHandle)
-        handle.tokenizer_manager = SimpleNamespace(server_args=server_args)
-        handle.scheduler_info = {"max_req_input_len": 1024}
-
-        info = json.loads(handle.get_server_info())
-
-        self.assertEqual(
-            info["kv_events"],
-            {
-                "publisher": "zmq",
-                "endpoint_host": "*",
-                "endpoint_port_base": 5557,
-                "topic": "kv",
-                "block_size": 64,
-                "dp_size": 2,
-            },
-        )
-
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/test/registered/unit/entrypoints/test_grpc_bridge.py
+++ b/test/registered/unit/entrypoints/test_grpc_bridge.py
@@ -1,9 +1,11 @@
 import asyncio
 import enum
+import json
 import unittest
 from types import SimpleNamespace
 
 from sglang.srt.entrypoints.grpc_bridge import RuntimeHandle
+from sglang.srt.server_args import ServerArgs
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -109,6 +111,35 @@ class TestNativeGrpcParallelResponses(CustomTestCase):
             [[1], [2], [3]],
         )
         self.assertEqual([call[1] for call in callback.calls], [False, False, True])
+
+
+class TestNativeGrpcServerInfo(CustomTestCase):
+    def test_exposes_structured_kv_events_descriptor(self):
+        server_args = ServerArgs(
+            model_path="dummy",
+            kv_events_config=(
+                '{"publisher":"zmq","endpoint":"tcp://*:5557","topic":"kv"}'
+            ),
+            page_size=64,
+            dp_size=2,
+        )
+        handle = RuntimeHandle.__new__(RuntimeHandle)
+        handle.tokenizer_manager = SimpleNamespace(server_args=server_args)
+        handle.scheduler_info = {"max_req_input_len": 1024}
+
+        info = json.loads(handle.get_server_info())
+
+        self.assertEqual(
+            info["kv_events"],
+            {
+                "publisher": "zmq",
+                "endpoint_host": "*",
+                "endpoint_port_base": 5557,
+                "topic": "kv",
+                "block_size": 64,
+                "dp_size": 2,
+            },
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Dynamo's native SGLang sidecar needs a validated description of SGLang's ZMQ KV-event publisher to subscribe each registered data-parallel rank for event-driven KV routing.

SGLang already exposes this structured `kv_events` descriptor through HTTP `/server_info`, but native gRPC `GetServerInfo` currently returns only the raw `ServerArgs` fields. Consumers would otherwise need to duplicate SGLang's endpoint validation and DCP-aware block-size calculation.

## Modifications

- Add the existing `ServerArgs.describe_kv_events_publisher()` result to native gRPC `GetServerInfo.json_info` under `kv_events`.
- Preserve all existing flat server-information fields.
- Keep the protobuf contract unchanged; this is an additive field inside the existing JSON payload.
- Keep the high-volume KV-event stream on SGLang's existing ZMQ publisher rather than proxying it through request/response gRPC.

## Accuracy Tests

Not applicable. This change does not affect model execution or generated outputs.

Validation:

- `python3 test/registered/unit/entrypoints/test_grpc_bridge.py` — 3 passed.
- `python3 scripts/lint/check_registered_tests.py` — passed.
- Two-H100 using this source branch and the Dynamo consumer PR:
  - Two native gRPC sidecars discovered independent SGLang KV-event publishers.
  - Dynamo connected both event streams and initialized event-driven KV routing.
  - An initial 242-token request reported `overlap_blocks=0`.
  - The identical repeated request selected the same worker with `overlap_blocks=15`.
  - Both requests completed successfully.

## Speed Tests and Profiling

Not applicable. The descriptor is computed only when `GetServerInfo` is called and is not on the inference path.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). Existing bridge coverage exercises the `GetServerInfo` response path; a redundant field-presence test was intentionally not retained.
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). No documentation change is required for this additive discovery field.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Not applicable; this is not on the inference path.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #32377579690](https://github.com/sgl-project/sglang/actions/runs/32377579690)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32377579890](https://github.com/sgl-project/sglang/actions/runs/32377579890)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #32377579619](https://github.com/sgl-project/sglang/actions/runs/32377579619)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->