### PR TITLE
[Bugfix] Manually register kv_b_proj to attn_mha so mla model work with ShardedModelLoader

### DIFF
--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1921,7 +1921,9 @@ class DeepseekV2AttentionMLA(
         )
 
         self.alt_stream = alt_stream
-        self.attn_mha.kv_b_proj = None
+        # Alias for backends that only get the RadixAttention layer. Not registered
+        # as a submodule: a second state_dict name breaks sharded_state round-trips.
+        object.__setattr__(self.attn_mha, "kv_b_proj", self.kv_b_proj)
 
         self.w_kc = None
         self.w_vc = None
@@ -2068,9 +2070,6 @@ class DeepseekV2AttentionMLA(
         llama_4_scaling: Optional[torch.Tensor] = None,
         prev_topk_indices: Optional[torch.Tensor] = None,
     ):
-        if self.attn_mha.kv_b_proj is None:
-            self.attn_mha.kv_b_proj = self.kv_b_proj
-
         # when hidden_states is a tuple of tensors, the tuple will include quantized weight and scale tensor
         if isinstance(hidden_states, tuple):
             if (


### PR DESCRIPTION
## Motivation

address #35702. MLA models now cannot be saved then loaded with `ShardedModelLoader`. The error we get is : 
```
File "python/sglang/srt/model_loader/loader.py", line 1796, in load_model
    param_data = state_dict[key].data
                 ~~~~~~~~~~^^^^^
KeyError: 'model.layers.22.self_attn.attn_mha.kv_b_proj.weight'
```

and the reason is: 

1. `DeepseekV2AttentionMLA.__init__` sets `self.attn_mha.kv_b_proj = None` and `forward_prepare`
   fills it in on first use. Assigning an `nn.Module` goes through `nn.Module.__setattr__`, which
   **registers `kv_b_proj` as a submodule of `attn_mha`** — so after one forward the same weight
   appears in `model.state_dict()` under two names sharing one storage.
2. `ShardedStateLoader.save_model` dumps `_filter_subtensors(model.state_dict())`, which dedups
   tensors sharing storage and keeps the lexicographically smaller key. `...attn_mha.kv_b_proj.weight`
   sorts before `...kv_b_proj.weight`, so the canonical name is dropped from the checkpoint.
3. On load, `load_model` iterates the checkpoint's keys and indexes a **fresh** model's state dict,
   which has never forwarded and therefore has no `attn_mha.kv_b_proj` — `KeyError`.


## Modifications

We mannually register `kv_b_proj` as attribute of `self.attn_mha` without making it a module. This means, it will not be present in `model.state_dict()` and will not cause the eviction of our beloved `self.kv_b_proj`. 

## Accuracy Tests

Using DeepSeek-V2-Lite on GH200 node. 

```

python3 -m sglang.launch_server --model-path '${model}' \
  --trust-remote-code --attention-backend triton \
  --host 127.0.0.1 --port ${PORT}

python3 -m sglang.test.run_eval --host 127.0.0.1 --port ${PORT} \
  --eval-name gsm8k --api completion --num-examples 200

```

results:

```
Total latency: 21.807 s
Score: 0.320
Output throughput: 1987.862 token/s
[METRIC] gsm8k_score=0.32 labels={"model": "/iopsstor/scratch/cscs/yboughizane/.cache/huggingface/hub/models--deepseek-ai--DeepSeek-V2-Lite/snapshots/604d5664dddd88a0433dbae533b7fe9472482de0", "eval": "gsm8k"}
[METRIC] gsm8k_latency=21.806841063982574 labels={"model": "/iopsstor/scratch/cscs/yboughizane/.cache/huggingface/hub/models--deepseek-ai--DeepSeek-V2-Lite/snapshots/604d5664dddd88a0433dbae533b7fe9472482de0", "eval": "gsm8k"}
```

## Speed Tests and Profiling

Not applicable, this PR does not involve performance-related changes.
 
## Validation 

The repro script from #35702 does not fail anymore. 


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32377818375](https://github.com/sgl-project/sglang/actions/runs/32377818375)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32377818227](https://github.com/sgl-project/sglang/actions/runs/32377818227)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32377818453](https://github.com/sgl-project/sglang/actions/runs/32377818453)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->