### PR TITLE
[Scheduler][PD][Perf] Add deficit-aware minimum-transfer victim selection for decode retraction

### DIFF
--- a/python/sglang/srt/managers/retraction_policy.py
+++ b/python/sglang/srt/managers/retraction_policy.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import cmp_to_key
+from typing import Optional, Sequence
+
+
+@dataclass(frozen=True)
+class BackupCostCandidate:
+    """CPU-only inputs used to choose a decode-retraction victim."""
+
+    index: int
+    backup_tokens: int
+    estimated_relief: int
+    priority: Optional[int] = None
+
+
+def compute_decode_shortfall(required_tokens: int, available_tokens: int) -> int:
+    return max(0, required_tokens - available_tokens)
+
+
+def make_backup_cost_candidate(
+    *,
+    index: int,
+    sequence_length: int,
+    kv_allocated_len: int,
+    next_decode_tokens: int,
+    page_size: int,
+    priority: Optional[int] = None,
+) -> BackupCostCandidate:
+    """Build a logical target-KV cost proxy for deterministic selection.
+
+    Page-aligned tokens are monotonic with target-only backup bytes. Specialized
+    sidecars and cache layouts can change the absolute physical byte count.
+    """
+    if page_size <= 0:
+        raise ValueError(f"page_size must be positive, got {page_size}")
+    unaligned_backup_tokens = max(sequence_length - 1, 0)
+    backup_tokens = (unaligned_backup_tokens + page_size - 1) // page_size * page_size
+    return BackupCostCandidate(
+        index=index,
+        backup_tokens=backup_tokens,
+        estimated_relief=kv_allocated_len + next_decode_tokens,
+        priority=priority,
+    )
+
+
+def select_single_sufficient_victim(
+    candidates: Sequence[BackupCostCandidate], shortfall: int
+) -> Optional[BackupCostCandidate]:
+    sufficient = [
+        candidate for candidate in candidates if candidate.estimated_relief >= shortfall
+    ]
+    if not sufficient:
+        return None
+    return min(
+        sufficient,
+        key=lambda candidate: (
+            candidate.backup_tokens,
+            -candidate.estimated_relief,
+            candidate.index,
+        ),
+    )
+
+
+def _compare_transfer_efficiency(
+    lhs: BackupCostCandidate, rhs: BackupCostCandidate
+) -> int:
+    """Compare cost/relief ratios using integers for cross-rank stability."""
+    lhs_relief = max(lhs.estimated_relief, 0)
+    rhs_relief = max(rhs.estimated_relief, 0)
+    if lhs_relief == 0 or rhs_relief == 0:
+        if lhs_relief != rhs_relief:
+            return 1 if lhs_relief == 0 else -1
+    else:
+        cross_lhs = lhs.backup_tokens * rhs_relief
+        cross_rhs = rhs.backup_tokens * lhs_relief
+        if cross_lhs != cross_rhs:
+            return -1 if cross_lhs < cross_rhs else 1
+
+    lhs_key = (lhs.backup_tokens, -lhs.estimated_relief, lhs.index)
+    rhs_key = (rhs.backup_tokens, -rhs.estimated_relief, rhs.index)
+    return (lhs_key > rhs_key) - (lhs_key < rhs_key)
+
+
+def select_greedy_victims(
+    candidates: Sequence[BackupCostCandidate], shortfall: int
+) -> list[BackupCostCandidate]:
+    selected = []
+    covered = 0
+    for candidate in sorted(candidates, key=cmp_to_key(_compare_transfer_efficiency)):
+        selected.append(candidate)
+        covered += max(candidate.estimated_relief, 0)
+        if covered >= shortfall:
+            break
+    return selected
+
+
+def _priority_tier_key(
+    priority: Optional[int], schedule_low_priority_values_first: bool
+) -> tuple[int, int]:
+    # A missing priority is least preferred in the existing priority policy.
+    if priority is None:
+        return (0, 0)
+    if schedule_low_priority_values_first:
+        return (1, -priority)
+    return (1, priority)
+
+
+def select_backup_cost_victims(
+    candidates: Sequence[BackupCostCandidate],
+    shortfall: int,
+    *,
+    respect_priority: bool = False,
+    schedule_low_priority_values_first: bool = False,
+) -> list[BackupCostCandidate]:
+    """Choose the estimated minimum-transfer victim prefix for a shortfall.
+
+    Priority-aware selection exhausts less-preferred tiers before considering a
+    more-preferred tier. Within a tier, a single sufficient request is the fast
+    path; otherwise deterministic cost/relief greedy selection is used.
+    """
+    if shortfall <= 0 or not candidates:
+        return []
+
+    if respect_priority:
+        tier_keys = sorted(
+            {
+                _priority_tier_key(
+                    candidate.priority, schedule_low_priority_values_first
+                )
+                for candidate in candidates
+            }
+        )
+    else:
+        tier_keys = [(0, 0)]
+
+    selected = []
+    remaining_shortfall = shortfall
+    for tier_key in tier_keys:
+        tier = [
+            candidate
+            for candidate in candidates
+            if not respect_priority
+            or _priority_tier_key(
+                candidate.priority, schedule_low_priority_values_first
+            )
+            == tier_key
+        ]
+        single = select_single_sufficient_victim(tier, remaining_shortfall)
+        tier_selected = (
+            [single]
+            if single is not None
+            else select_greedy_victims(tier, remaining_shortfall)
+        )
+        selected.extend(tier_selected)
+        remaining_shortfall -= sum(
+            max(candidate.estimated_relief, 0) for candidate in tier_selected
+        )
+        if remaining_shortfall <= 0:
+            break
+    return selected
+
+
+def build_backup_cost_retraction_order(
+    candidates: Sequence[BackupCostCandidate],
+    shortfall: int,
+    *,
+    respect_priority: bool = False,
+    schedule_low_priority_values_first: bool = False,
+) -> list[int]:
+    """Return a complete victim-first order, including estimation fallbacks."""
+    selected = select_backup_cost_victims(
+        candidates,
+        shortfall,
+        respect_priority=respect_priority,
+        schedule_low_priority_values_first=schedule_low_priority_values_first,
+    )
+    selected_indices = {candidate.index for candidate in selected}
+
+    def fallback_key(candidate: BackupCostCandidate):
+        priority_key = (
+            _priority_tier_key(candidate.priority, schedule_low_priority_values_first)
+            if respect_priority
+            else (0, 0)
+        )
+        return (
+            priority_key,
+            candidate.backup_tokens,
+            -candidate.estimated_relief,
+            candidate.index,
+        )
+
+    fallback = sorted(
+        (
+            candidate
+            for candidate in candidates
+            if candidate.index not in selected_indices
+        ),
+        key=fallback_key,
+    )
+    return [candidate.index for candidate in (*selected, *fallback)]

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -83,6 +83,11 @@ from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST, DisaggregationM
 from sglang.srt.dllm.mixin.req import ReqDllmMixin
 from sglang.srt.environ import envs
 from sglang.srt.managers.embed_types import PositionalEmbeds
+from sglang.srt.managers.retraction_policy import (
+    build_backup_cost_retraction_order,
+    compute_decode_shortfall,
+    make_backup_cost_candidate,
+)
 from sglang.srt.managers.scheduler_components.new_token_ratio_tracker import (
     NewTokenRatioTracker,
 )
@@ -2820,7 +2825,12 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         self, server_args: ServerArgs
     ) -> Tuple[List[Req], float, List[Req]]:
         """Retract the decoding requests when there is not enough memory."""
-        sorted_indices = self._get_decode_retraction_order(self.reqs, server_args)
+        available_tokens = self.token_to_kv_pool_allocator.available_size()
+        required_tokens = self.new_tokens_required_next_decode()
+        shortfall = compute_decode_shortfall(required_tokens, available_tokens)
+        sorted_indices = self._get_decode_retraction_order_for_shortfall(
+            server_args, shortfall
+        )
 
         retracted_reqs = []
         reqs_to_abort: List[Req] = []
@@ -2919,6 +2929,40 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             reverse=True,
         )
         return sorted_indices
+
+    def _get_decode_retraction_order_for_shortfall(
+        self, server_args: ServerArgs, shortfall: int
+    ) -> List[int]:
+        # TEST_RETRACT enters here without a real shortfall. Preserve its legacy
+        # length ordering so the test injection does not change semantics.
+        if server_args.retraction_policy != "backup-cost" or shortfall <= 0:
+            return self._get_decode_retraction_order(self.reqs, server_args)
+
+        page_size = self.token_to_kv_pool_allocator.page_size
+        candidates = [
+            make_backup_cost_candidate(
+                index=i,
+                sequence_length=req.seqlen,
+                kv_allocated_len=req.kv.kv_allocated_len,
+                next_decode_tokens=self.new_tokens_required_next_decode([i]),
+                page_size=page_size,
+                priority=req.priority,
+            )
+            for i, req in enumerate(self.reqs)
+        ]
+        # kv_allocated_len can overestimate releasable memory for shared radix
+        # prefixes and specialized pools. The order is only a cost heuristic;
+        # retract_decode still calls check_decode_mem after every actual release.
+        victim_first = build_backup_cost_retraction_order(
+            candidates,
+            shortfall,
+            respect_priority=server_args.enable_priority_scheduling,
+            schedule_low_priority_values_first=(
+                server_args.schedule_low_priority_values_first
+            ),
+        )
+        # The retraction loop pops from the end.
+        return list(reversed(victim_first))
 
     def release_req(
         self,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -315,7 +315,7 @@ FP4_GEMM_RUNNER_BACKEND_CHOICES = [
 BF16_GEMM_BACKEND_CHOICES = ["auto", "cutedsl", "gemv", "torch"]
 
 RADIX_EVICTION_POLICY_CHOICES = ["lru", "lfu", "slru", "priority"]
-RETRACTION_POLICY_CHOICES = ["length", "priority"]
+RETRACTION_POLICY_CHOICES = ["length", "priority", "backup-cost"]
 
 RL_ON_POLICY_TARGET_CHOICES = ["fsdp"]
 
@@ -888,7 +888,8 @@ class ServerArgs:
                 "'length' preserves the existing behavior and retracts short-output, "
                 "long-input requests first. 'priority' retracts lower-priority "
                 "requests first, using the same priority direction as priority "
-                "scheduling."
+                "scheduling. 'backup-cost' uses the current memory shortfall to "
+                "prefer victims with a smaller page-aligned KV backup footprint."
             ),
             choices=RETRACTION_POLICY_CHOICES,
         ),

--- a/test/registered/unit/managers/test_backup_cost_retraction.py
+++ b/test/registered/unit/managers/test_backup_cost_retraction.py
@@ -1,0 +1,209 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from sglang.srt.managers.retraction_policy import (
+    BackupCostCandidate,
+    build_backup_cost_retraction_order,
+    compute_decode_shortfall,
+    make_backup_cost_candidate,
+    select_backup_cost_victims,
+)
+from sglang.srt.managers.schedule_batch import ScheduleBatch
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+def _candidate(index, cost, relief, priority=None):
+    return BackupCostCandidate(
+        index=index,
+        backup_tokens=cost,
+        estimated_relief=relief,
+        priority=priority,
+    )
+
+
+def _req(input_len, output_len, *, allocated=None, committed=None, priority=None):
+    seqlen = input_len + output_len
+    return SimpleNamespace(
+        rid=f"req-{input_len}-{output_len}-{priority}",
+        origin_input_ids=[0] * input_len,
+        output_ids=[0] * output_len,
+        seqlen=seqlen,
+        kv=SimpleNamespace(
+            kv_allocated_len=seqlen - 1 if allocated is None else allocated
+        ),
+        kv_committed_len=seqlen - 1 if committed is None else committed,
+        cache_protected_len=0,
+        priority=priority,
+        sampling_params=SimpleNamespace(max_new_tokens=128),
+    )
+
+
+def _args(policy="backup-cost", *, priority=False, low_first=False):
+    return SimpleNamespace(
+        retraction_policy=policy,
+        enable_priority_scheduling=priority,
+        schedule_low_priority_values_first=low_first,
+    )
+
+
+class TestBackupCostRetraction(CustomTestCase):
+    def test_small_deficit_prefers_4k_over_32k(self):
+        candidates = [_candidate(0, 4096, 4097), _candidate(1, 32768, 32769)]
+        selected = select_backup_cost_victims(candidates, shortfall=1)
+        self.assertEqual([candidate.index for candidate in selected], [0])
+
+    def test_smallest_insufficient_uses_smallest_sufficient_candidate(self):
+        candidates = [
+            _candidate(0, 4, 4),
+            _candidate(1, 8, 12),
+            _candidate(2, 16, 20),
+        ]
+        selected = select_backup_cost_victims(candidates, shortfall=10)
+        self.assertEqual([candidate.index for candidate in selected], [1])
+
+    def test_multi_victim_fallback_is_deterministic(self):
+        candidates = [
+            _candidate(2, 4, 5),
+            _candidate(0, 6, 6),
+            _candidate(1, 8, 7),
+        ]
+        selected = select_backup_cost_victims(candidates, shortfall=11)
+        self.assertEqual([candidate.index for candidate in selected], [2, 0])
+        self.assertEqual(
+            build_backup_cost_retraction_order(candidates, shortfall=11),
+            [2, 0, 1],
+        )
+
+    def test_page_alignment_and_non_spec_next_decode_allocation(self):
+        candidate = make_backup_cost_candidate(
+            index=0,
+            sequence_length=18,
+            kv_allocated_len=17,
+            next_decode_tokens=8,
+            page_size=8,
+        )
+        self.assertEqual(candidate.backup_tokens, 24)
+        self.assertEqual(candidate.estimated_relief, 25)
+
+        batch = ScheduleBatch(
+            reqs=[
+                _req(16, 1, allocated=16, committed=16),
+                _req(16, 2, allocated=17, committed=17),
+            ],
+            token_to_kv_pool_allocator=SimpleNamespace(page_size=8),
+            spec_algorithm=SimpleNamespace(is_none=lambda: True),
+        )
+        self.assertEqual(batch.new_tokens_required_next_decode([0]), 8)
+        self.assertEqual(batch.new_tokens_required_next_decode([1]), 0)
+
+    def test_speculative_reserve_is_included_in_relief(self):
+        req = _req(14, 1, allocated=16, committed=14)
+        batch = ScheduleBatch(
+            reqs=[req],
+            token_to_kv_pool_allocator=SimpleNamespace(page_size=8),
+            spec_algorithm=SimpleNamespace(is_none=lambda: False),
+        )
+        with patch(
+            "sglang.srt.managers.schedule_batch.get_alloc_reserve_per_decode",
+            return_value=5,
+        ):
+            next_tokens = batch.new_tokens_required_next_decode([0])
+        self.assertEqual(next_tokens, 8)
+        candidate = make_backup_cost_candidate(
+            index=0,
+            sequence_length=req.seqlen,
+            kv_allocated_len=req.kv.kv_allocated_len,
+            next_decode_tokens=next_tokens,
+            page_size=8,
+        )
+        self.assertEqual(candidate.estimated_relief, 24)
+
+    def test_tie_break_uses_stable_integer_index(self):
+        candidates = [_candidate(3, 8, 12), _candidate(1, 8, 12)]
+        selected = select_backup_cost_victims(candidates, shortfall=4)
+        self.assertEqual([candidate.index for candidate in selected], [1])
+
+    def test_priority_tier_is_not_crossed_for_lower_transfer_cost(self):
+        candidates = [
+            _candidate(0, 1, 100, priority=0),
+            _candidate(1, 100, 100, priority=2),
+            _candidate(2, 200, 100, priority=None),
+        ]
+        selected = select_backup_cost_victims(
+            candidates,
+            shortfall=1,
+            respect_priority=True,
+            schedule_low_priority_values_first=True,
+        )
+        self.assertEqual([candidate.index for candidate in selected], [2])
+
+    def test_legacy_length_and_priority_orders_are_unchanged(self):
+        reqs = [
+            _req(8, 5, priority=2),
+            _req(20, 1, priority=0),
+            _req(8, 3, priority=None),
+        ]
+        self.assertEqual(
+            ScheduleBatch._get_decode_retraction_order(reqs, _args("length")),
+            [0, 2, 1],
+        )
+        self.assertEqual(
+            ScheduleBatch._get_decode_retraction_order(
+                reqs, _args("priority", priority=True, low_first=True)
+            ),
+            [1, 0, 2],
+        )
+
+    def test_zero_shortfall_keeps_test_retract_length_semantics(self):
+        reqs = [_req(8, 5), _req(32, 1), _req(8, 3)]
+        batch = ScheduleBatch(
+            reqs=reqs,
+            token_to_kv_pool_allocator=SimpleNamespace(page_size=1),
+            spec_algorithm=SimpleNamespace(is_none=lambda: True),
+        )
+        self.assertEqual(
+            batch._get_decode_retraction_order_for_shortfall(
+                _args("backup-cost"), shortfall=0
+            ),
+            [0, 2, 1],
+        )
+
+    def test_shortfall_and_post_release_checks_continue_on_estimation_error(self):
+        self.assertEqual(compute_decode_shortfall(8, 3), 5)
+        self.assertEqual(compute_decode_shortfall(3, 8), 0)
+
+        reqs = [_req(8, 1), _req(16, 1), _req(32, 1)]
+        batch = ScheduleBatch(
+            reqs=reqs,
+            token_to_kv_pool_allocator=SimpleNamespace(
+                page_size=1, available_size=lambda: 0
+            ),
+            spec_algorithm=SimpleNamespace(is_none=lambda: True),
+        )
+        batch.new_tokens_required_next_decode = MagicMock(return_value=1)
+        batch._get_decode_retraction_order_for_shortfall = MagicMock(
+            return_value=[2, 1, 0]
+        )
+        batch.check_decode_mem = MagicMock(side_effect=[False, True, True])
+        batch.release_req = MagicMock(return_value=True)
+        original_reqs = list(reqs)
+
+        def filter_batch(*, keep_indices):
+            batch.reqs = [original_reqs[i] for i in keep_indices]
+
+        batch.filter_batch = MagicMock(side_effect=filter_batch)
+
+        retracted, _, aborted = batch.retract_decode(_args("backup-cost"))
+
+        self.assertEqual(retracted, original_reqs[:2])
+        self.assertEqual(aborted, [])
+        self.assertEqual(batch.release_req.call_count, 2)
+        self.assertEqual(batch.check_decode_mem.call_count, 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR adds an opt-in `backup-cost` decode retraction policy that uses deficit-aware minimum-transfer victim selection. It computes the current KV/token shortfall and chooses a low transfer-cost victim set estimated to be sufficient to fill that deficit, while preserving priority-tier boundaries and deterministic ordering. The existing `length` policy remains the default.

The optimization target is the PD decode retraction critical path: reducing synchronous backup/restore bytes and scheduler stall. It does not claim improved general end-to-end throughput or a benefit for every workload.

## Rebase and validation

- The reported performance evidence uses the pre-rebase baseline `OLD_BASE=b03ac355e795b3a86b26b8732c47c0965fd71bbc`.
- This branch was rebased onto the frozen `REBASE_BASE=04444ee352a6a1f5666bf422a09841650c46194a`.
- The two audited upstream commits changed only the Inkling-Small NVFP4 deterministic test and diffusion benchmark/skill files. They did not touch decode retraction, token-deficit calculation, victim ordering, backup/restore, KV accounting, the four files in this patch, or the experiment configuration.
- `git range-diff` reports the old and rebased patches as equivalent; their stable patch-id and full patch SHA-256 are identical.
- Post-rebase validation: 44 focused/related CPU tests passed, including direct victim-selection and scheduler retraction-loop coverage; `git diff --check`, `py_compile`, isort check, Ruff `F401/F821/UP037`, Black check, registered-test lint, and a `backup-cost` CLI parsing smoke all passed.
- Correctness: **PASS** for the recorded GPU A/B scope and the post-rebase targeted validation above.
- **The full performance matrix was not rerun after the rebase.** The performance numbers below are pre-rebase measurements and are not presented as measurements from the rebased head.

## Recorded performance evidence

- Model: `/mnt/si0260014qra/default/models/Qwen/Qwen3-8B`
- Topology: Prefill TP2 on GPUs 0-1 + Decode TP2 on GPUs 2-3
- Hardware: 4x A100-80GB
- Real retraction events: 22

| Metric | Change |
| --- | ---: |
| Backup bytes | -74.43% |
| Restore bytes | -74.43% |
| Retraction scheduler stall | -72.94% |
| p99 ITL | -0.74% |
| Throughput | -0.0061% (essentially unchanged) |

The throughput result is effectively flat and is not claimed as a throughput improvement. The narrow claim is reduced data movement and stall during real PD decode retraction events for heterogeneous batches.

## Scope and safety

The policy uses a page-aligned logical target-KV footprint as a transfer-cost proxy and still invokes the existing real memory check after every release, so an optimistic relief estimate causes additional victims to be released rather than bypassing the safety path. Shared-prefix physical byte accuracy and universal end-to-end performance gains are not claimed.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32379275794](https://github.com/sgl-project/sglang/actions/runs/32379275794)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32379275146](https://github.com/sgl-project/sglang/actions/runs/32379275146)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32379275435](https://github.com/sgl-project/sglang/actions/runs/32379275435)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->