### PR TITLE
[AMD] Fix Qwen3.5 MTP dropping fused shared-expert weights

### DIFF
--- a/python/sglang/srt/models/qwen3_5_mtp.py
+++ b/python/sglang/srt/models/qwen3_5_mtp.py
@@ -39,9 +39,12 @@ from sglang.srt.runtime_context import (
     get_parallel,
     get_spec,
 )
-from sglang.srt.utils import add_prefix, is_npu
+from sglang.srt.utils import add_prefix, get_bool_env_var, is_hip, is_npu
 
 logger = logging.getLogger(__name__)
+
+_is_hip = is_hip()
+_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 
 
 def _mtp_quant_config(quant_config):
@@ -244,12 +247,20 @@ class Qwen3_5ForCausalLMMTP(nn.Module):
 
         # Params for MoE experts (non-fused/fused)
         num_experts = getattr(self.config, "num_experts", None)
+        # A fused shared expert lives in routed slot `num_experts`.
+        num_fused_shared_experts = 0
+        if _use_aiter:
+            for module in self.modules():
+                fused = getattr(module, "num_fused_shared_experts", 0)
+                if fused:
+                    num_fused_shared_experts = fused
+                    break
         if num_experts is not None:
             expert_params_mapping = FusedMoE.make_expert_params_mapping(
                 ckpt_gate_proj_name="gate_proj",
                 ckpt_down_proj_name="down_proj",
                 ckpt_up_proj_name="up_proj",
-                num_experts=num_experts,
+                num_experts=num_experts + num_fused_shared_experts,
             )
         else:
             expert_params_mapping = []
@@ -316,6 +327,17 @@ class Qwen3_5ForCausalLMMTP(nn.Module):
 
             if ".self_attn." in name:
                 name = name.replace(".self_attn", "")
+
+            if (
+                _use_aiter
+                and num_fused_shared_experts > 0
+                and "mlp.shared_expert." in name
+            ):
+                # Map mlp.shared_expert.xx_proj to mlp.experts.{num_experts}.xx_proj
+                name = name.replace(
+                    "mlp.shared_expert.",
+                    f"mlp.experts.{num_experts}.",
+                )
 
             # 1) Process stacked parameters (q_proj/k_proj/v_proj & gate_proj/up_proj)
             for param_name, weight_name, shard_id in stacked_params_mapping:


### PR DESCRIPTION
## Motivation

Since #33889, Qwen3.5 MXFP4 with MTP speculative decoding on MI355X lost about 12% throughput. The cause is that the MTP draft model is loaded without its shared-expert weights.

**What fusion does to the weight layout.** When a Qwen3.5 MoE layer fuses its shared expert, it deliberately does not build a separate `shared_expert` module — the shared expert becomes one more routed expert, living in slot `num_experts`. Any loader for such a layer therefore has to route `mlp.shared_expert.*` into that slot. `qwen3_5.py` does exactly that; `qwen3_5_mtp.py` never learned to.

**Why the target model is unaffected.** In this checkpoint the target's routed experts are MXFP4 while its shared expert stays bf16. Fusing them would push a higher-precision tensor through the quantized routed-expert path, so `can_fuse_shared_expert()` refuses. The target therefore always takes the unfused path, keeps its `shared_expert` module, and loads normally — the gap in the MTP loader is invisible from here.

**Why the draft model is affected, and only recently.** The MTP module is excluded from quantization in full: all 1536 `mtp.*` routed-expert tensors and its shared expert alike. The draft is thus uniformly bf16, nothing is mixed-precision, and fusing it is perfectly valid — the gate correctly says yes. It simply never had the chance before. Until #33889, the target's Quark config installed a single process-wide `disable_shared_experts_fusion` override, which switched fusion off for every runner, draft included. #33889 made that decision per-runner, so the draft started fusing for the first time and immediately ran into the loader gap.

**Why nobody noticed.** With fusion on there is no `shared_expert` module to load into, and the expert mapping only covers slots `0 .. num_experts-1`, so each `mlp.shared_expert.{gate,up,down}_proj.weight` matches nothing and ends at `logger.warning_once("Parameter ... not found in params_dict, skip loading")` — three tensors per TP rank, one suppressed log line, no error. The draft then runs with an uninitialized shared expert. Since a speculative draft cannot corrupt verified output, accuracy is unaffected; the damage appears only as a fall in accept rate, from 0.65 to 0.51, and hence in throughput.

This PR teaches the MTP loader to place those weights into the fused slot, so the draft that #33889 legitimately enabled actually receives them.

## Modifications

`python/sglang/srt/models/qwen3_5_mtp.py`, mirroring `qwen3_5.py`:

- Size the expert mapping as `num_experts + num_fused_shared_experts` so slot `num_experts` has an entry. The fusion count is read from the constructed modules, because `num_fused_shared_experts` is set on `Qwen3_5MoeForConditionalGeneration` and the MTP wraps a `Qwen3_5ForCausalLM`, which does not carry it.
- Rewrite `mlp.shared_expert.` to `mlp.experts.{num_experts}.` before the mapping loops.

Both are keyed on the model's actual fusion state rather than on a platform check. When nothing fuses, `num_fused_shared_experts` is `0`, the mapping size is unchanged and the rewrite never fires, so this is a no-op for every non-fusing configuration.

Not covered: the fused-checkpoint variant (a single `experts.gate_up_proj` tensor). `qwen3_5.py` handles that with a dedicated branch that chunks the tensor into `w1`/`w3`; the MTP loader's `load_fused_expert_weights` indexes per expert id and cannot serve a single shared-expert tensor. Adding that path untested seemed worse than leaving it, since no checkpoint on hand exercises it.

## Accuracy Tests

No accuracy change is expected: only the draft model changes, and a speculative draft cannot alter verified output. The visible effect is the accept rate. Measured over ~100 decode-batch samples per point.

| conc | accept_len before | after | accept_rate before | after |
|---:|---:|---:|---:|---:|
| 4 | 2.5278 | 2.9533 | 0.5097 | 0.6509 |
| 8 | 2.5507 | 2.9374 | 0.5168 | 0.6457 |
| 16 | 2.5144 | 2.9508 | 0.5054 | 0.6501 |

Skipped weights during load go from 3 per TP rank to 0.

## Speed Tests and Profiling

### Summary at conc=4

| Config | Total Throughput | Median E2E (ms) | Median TTFT (ms) | Median TPOT (ms) |
|---|---:|---:|---:|---:|
| `eda0ddc260d4` (last good) | 5365.74 | 5992.71 | 326.84 | 6.25 |
| `b61a06921e` (#33889) | 4716.15 | 6662.60 | 322.72 | 7.05 |
| `b61a06921e` + PR #35719 | 5429.77 | 5912.64 | 326.93 | 6.11 |

The third row was obtained by switching shared-expert fusion off on `b61a06921e`, which removes the unloaded-shared-expert condition from the draft; this PR removes the same condition by loading the fused weights instead of dropping them.

### Full sweep

MI355X, `amd/Qwen3.5-397B-A17B-MXFP4`, TP=2, EAGLE MTP (3 steps / topk 1 / 4 draft tokens), page-size 16, `fp8_e4m3` KV, `--attention-backend aiter`, ISL=8192 / OSL=1024, `num_prompts = 10 x conc`, server relaunched per concurrency with `--max-running-requests = conc`. Server flags follow `benchmarks/single_node/fixed_seq_len/qwen3.5_fp4_mi355x_mtp.sh`. Before and after were run back to back on the same GPU pair, both at `7f8f030000`.

| conc | Total Throughput before | after | Delta | Median E2E (ms) before | after | Median TTFT (ms) before | after | Median TPOT (ms) before | after |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 4 | 4746.11 | 5417.31 | **+14.14%** | 6726.7 | 5969.1 | 333.3 | 336.7 | 7.07 | 6.22 |
| 8 | 6835.64 | 7626.54 | **+11.57%** | 9243.7 | 8370.3 | 336.4 | 335.9 | 9.67 | 8.82 |
| 16 | 9011.82 | 10141.08 | **+12.53%** | 13997.8 | 12840.5 | 346.1 | 361.6 | 14.86 | 13.48 |

The gain is decode-side, as expected from an accept-rate change: TTFT is flat, TPOT improves by 9–12%.

This restores the configuration to its previously published InferenceX level. The last sweep on image `lmsysorg/sglang-rocm:v0.5.16-rocm720-mi35x-20260730` recorded 582.84 / 852.30 / 1130.14 output tok/s at conc 4 / 8 / 16; with this patch the same setup measures 602.47 / 857.12 / 1123.38. Bisecting `accept len` over the 759 commits between that image's sglang and `63d783bbe0` lands on #33889, with a clean split (2.84–2.92 before, 2.50–2.57 after, no intermediate values).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32651352300](https://github.com/sgl-project/sglang/actions/runs/32651352300)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32651352287](https://github.com/sgl-project/sglang/actions/runs/32651352287)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32651352289](https://github.com/sgl-project/sglang/actions/runs/32651352289)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->