### PR TITLE
[Bugfix] Fix TVM FFI tuple access in CUDA IPC JIT

### DIFF
--- a/python/sglang/kernels/jit/csrc/distributed/ipc.cuh
+++ b/python/sglang/kernels/jit/csrc/distributed/ipc.cuh
@@ -80,8 +80,8 @@ struct IPCManager : public tvm::ffi::Object {
     tvm::ffi::Array<uintptr_t> result;
     result.reserve(handles.size());
     for (const auto& pair : handles) {
-      const auto ipc_handle = to_ipc_handle(get<0>(pair));
-      const auto offset = get<1>(pair);
+      const auto ipc_handle = to_ipc_handle(pair.get<0>());
+      const auto offset = pair.get<1>();
       result.push_back(open_handle(ipc_handle) + offset);
     }
     return result;


### PR DESCRIPTION
## Motivation

The CUDA IPC JIT module can fail to compile with NVCC 12.8 and `apache-tvm-ffi==0.1.11`:

```text
error: no matching function for call to 'get(const tvm::ffi::Tuple<...>&)'
note: couldn't deduce template parameter 'I'
```

`get<I>(pair)` relies on unqualified lookup and ADL. In this toolchain combination, NVCC finds the TVM FFI overloads but does not resolve the explicit tuple index. The exception is caught during custom all-reduce setup, so the server continues after falling back to NCCL.

## Modifications

Use the existing `tvm::ffi::Tuple::get<I>()` member accessor for the CUDA IPC handle and offset. This bypasses the problematic free-function lookup without changing the tuple values or custom all-reduce behavior.

## Accuracy Tests

Not applicable. This only changes how two fields are accessed during CUDA IPC manager initialization; it does not change model outputs or kernel arithmetic.

Focused regression validation with Python 3.12.13, PyTorch `2.13.0+cu129`, NVCC 12.8, and `apache-tvm-ffi==0.1.11`:

```python
from sglang.kernels.ops.communication.all_reduce import IPCManager

manager = IPCManager()
manager.destroy()
print("jit_ipc_ok")
```

The test used an empty `SGLANG_JIT_CACHE_DIR`, compiled the `cuda_ipc` module, instantiated `IPCManager`, and printed `jit_ipc_ok`.

## Speed Tests and Profiling

Not applicable. This is a JIT compiler compatibility fix and does not modify the generated custom all-reduce kernel.

## Checklist

- [x] Format the code according to the project style; `git diff --check` passes.
- [x] Exercise the affected JIT compilation and registration path with an empty cache.
- [x] Documentation is unchanged because there is no user-facing API change.
- [x] Accuracy and speed benchmarks are not applicable to this lookup-only change.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32394345576](https://github.com/sgl-project/sglang/actions/runs/32394345576)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32394345229](https://github.com/sgl-project/sglang/actions/runs/32394345229)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32394345470](https://github.com/sgl-project/sglang/actions/runs/32394345470)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->