### PR TITLE
docker: pin matplotlib>=3.8 to fix CUDA-13 Python 3.12 build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -532,7 +532,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     cubloaty \
     google-cloud-storage \
     pandas \
-    matplotlib \
+    "matplotlib>=3.8" \
     tabulate \
     termplotlib \
     "runai-model-streamer[s3,gcs,azure]>=0.15.7"


### PR DESCRIPTION
## Problem
On the CUDA-13 image (`nvidia/cuda:13.0.3-...-ubuntu24.04`, Python 3.12) the `framework` stage fails at the "Install essential Python packages" step:

```
  File "/tmp/pip-install-.../matplotlib_.../versioneer.py", line 401, in get_config_from_root
    parser = configparser.SafeConfigParser()
AttributeError: module 'configparser' has no attribute 'SafeConfigParser'
ERROR: Failed to build 'matplotlib' when getting requirements to build wheel
```

## Root cause
That step installs dev/plotting tools with `-c /sgl-workspace/constraints.txt`, where the runtime packages are pinned but `matplotlib` is not. Under the fully-pinned constraints, pip backtracks `matplotlib` through every release trying to satisfy the solve, descending past the cp312-wheel versions into **pre-3.8 releases that ship no Python 3.12 wheels**. pip then builds those from sdist, and their bundled `versioneer.py` calls `configparser.SafeConfigParser()` — removed in Python 3.12 — so the build dies. (Observed pip walking 3.11.1 → ... → 3.4.3 before failing.)

## Fix
Pin `matplotlib>=3.8`. matplotlib 3.8 is the first release providing Python 3.12 (cp312) wheels, so pip stays on wheels and never falls back to the unbuildable legacy sdists. This mirrors the existing style in the same install list (e.g. `"runai-model-streamer[...]>=0.15.7"`).

## Testing
Full CUDA-13 image build (`BUILD_TYPE=all CUDA_VERSION=13.0.3`) completes past the framework stage with this change.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32404767651](https://github.com/sgl-project/sglang/actions/runs/32404767651)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32404767507](https://github.com/sgl-project/sglang/actions/runs/32404767507)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->