### PR TITLE
Fix Qwen3.5 mRoPE positions silently dropped by fused QK RMSNorm+RoPE kernel

### DIFF
--- a/python/sglang/kernels/ops/attention/fused_qk_rmsnorm_rope_gate.py
+++ b/python/sglang/kernels/ops/attention/fused_qk_rmsnorm_rope_gate.py
@@ -3,11 +3,15 @@
 Single kernel launch fusing per-head GemmaRMSNorm, partial NeoX RoPE,
 and gate deinterleave for Qwen3.5's interleaved Q+Gate layout.
 
+Positions are either [T] (plain RoPE) or [3, T] mRoPE positions, in which
+case each rotary pair takes its angle from the temporal, height or width
+row as selected by ``mrope_section``.
+
 2D grid (T, num_q_heads + num_kv_heads) — each program handles one
 (token, head) pair. Q programs also copy the gate slice.
 """
 
-from typing import Optional, Tuple
+from typing import Optional, Sequence, Tuple
 
 import torch
 import triton
@@ -45,6 +49,7 @@ def _fused_qk_rmsnorm_rope_gate_kernel(
     stride_ko_t,
     stride_gate_t,
     stride_cos_t,
+    stride_pos_m,
     NUM_Q_HEADS: tl.constexpr,
     NUM_KV_HEADS: tl.constexpr,
     HEAD_DIM: tl.constexpr,
@@ -56,6 +61,11 @@ def _fused_qk_rmsnorm_rope_gate_kernel(
     FP16: tl.constexpr,
     HAS_PASS: tl.constexpr,
     HAS_GATE: tl.constexpr,
+    MROPE: tl.constexpr,
+    MROPE_SECTION_T: tl.constexpr,
+    MROPE_SECTION_H: tl.constexpr,
+    MROPE_SECTION_W: tl.constexpr,
+    MROPE_INTERLEAVED: tl.constexpr,
     ENABLE_PDL: tl.constexpr,
 ):
     token = tl.program_id(0)
@@ -104,14 +114,46 @@ def _fused_qk_rmsnorm_rope_gate_kernel(
     xr1 = (xr1 * inv_rms * (wr1 + 1.0)).to(out_dtype).to(tl.float32)
     xr2 = (xr2 * inv_rms * (wr2 + 1.0)).to(out_dtype).to(tl.float32)
 
-    pos = tl.load(positions_ptr + token).to(tl.int64)
-    cache_off = pos * stride_cos_t
-    cos = tl.load(
-        cos_sin_cache_ptr + cache_off + rot_offs, mask=rot_mask, other=0.0
-    ).to(tl.float32)
-    sin = tl.load(
-        cos_sin_cache_ptr + cache_off + HALF_ROTARY + rot_offs, mask=rot_mask, other=0.0
-    ).to(tl.float32)
+    if MROPE:
+        # Masks are ANDed with rot_mask so padded lanes (ROT_HALF_BLOCK >
+        # HALF_ROTARY) never address past the end of a cos_sin_cache row.
+        pos_t = tl.load(positions_ptr + 0 * stride_pos_m + token).to(tl.int64)
+        pos_h = tl.load(positions_ptr + 1 * stride_pos_m + token).to(tl.int64)
+        pos_w = tl.load(positions_ptr + 2 * stride_pos_m + token).to(tl.int64)
+        if MROPE_INTERLEAVED:
+            h_mask = ((rot_offs % 3) == 1) & (rot_offs < 3 * MROPE_SECTION_H)
+            w_mask = ((rot_offs % 3) == 2) & (rot_offs < 3 * MROPE_SECTION_W)
+        else:
+            h_end = MROPE_SECTION_T + MROPE_SECTION_H
+            h_mask = (rot_offs >= MROPE_SECTION_T) & (rot_offs < h_end)
+            w_mask = rot_offs >= h_end
+        h_mask = h_mask & rot_mask
+        w_mask = w_mask & rot_mask
+        t_mask = rot_mask & ~(h_mask | w_mask)
+        t_off = pos_t * stride_cos_t + rot_offs
+        h_off = pos_h * stride_cos_t + rot_offs
+        w_off = pos_w * stride_cos_t + rot_offs
+        cos = (
+            tl.load(cos_sin_cache_ptr + t_off, mask=t_mask, other=0.0)
+            + tl.load(cos_sin_cache_ptr + h_off, mask=h_mask, other=0.0)
+            + tl.load(cos_sin_cache_ptr + w_off, mask=w_mask, other=0.0)
+        ).to(tl.float32)
+        sin = (
+            tl.load(cos_sin_cache_ptr + HALF_ROTARY + t_off, mask=t_mask, other=0.0)
+            + tl.load(cos_sin_cache_ptr + HALF_ROTARY + h_off, mask=h_mask, other=0.0)
+            + tl.load(cos_sin_cache_ptr + HALF_ROTARY + w_off, mask=w_mask, other=0.0)
+        ).to(tl.float32)
+    else:
+        pos = tl.load(positions_ptr + token).to(tl.int64)
+        cache_off = pos * stride_cos_t
+        cos = tl.load(
+            cos_sin_cache_ptr + cache_off + rot_offs, mask=rot_mask, other=0.0
+        ).to(tl.float32)
+        sin = tl.load(
+            cos_sin_cache_ptr + cache_off + HALF_ROTARY + rot_offs,
+            mask=rot_mask,
+            other=0.0,
+        ).to(tl.float32)
     tl.store(out_base + rot_offs, (xr1 * cos - xr2 * sin), mask=rot_mask)
     tl.store(out_base + HALF_ROTARY + rot_offs, (xr2 * cos + xr1 * sin), mask=rot_mask)
 
@@ -128,6 +170,64 @@ def _fused_qk_rmsnorm_rope_gate_kernel(
         tl.extra.cuda.gdc_launch_dependents()
 
 
+def _check_positions_contract(
+    positions: torch.Tensor,
+    num_tokens: int,
+    half_rotary: int,
+    mrope_section: Optional[Sequence[int]],
+    mrope_interleaved: bool,
+    mrope_interleaved_glm: bool,
+) -> bool:
+    """Validate the positions contract; return True iff the mRoPE path applies.
+
+    Raises rather than asserts: these guard against silently computing the
+    wrong RoPE, and asserts vanish under ``python -O``.
+    """
+    if mrope_interleaved_glm:
+        raise ValueError(
+            "fused_qk_gemma_rmsnorm_rope_gate does not implement GLM-interleaved "
+            "mRoPE (mrope_interleaved_glm=True); use the unfused RoPE path."
+        )
+    if positions.ndim not in (1, 2):
+        raise ValueError(
+            f"positions must be [T] or [3, T], got shape {tuple(positions.shape)}"
+        )
+    if positions.shape[-1] != num_tokens:
+        raise ValueError(
+            f"positions has {positions.shape[-1]} tokens but q_gate has {num_tokens}"
+        )
+    if positions.ndim == 1:
+        if mrope_section is not None or mrope_interleaved:
+            raise ValueError(
+                "mRoPE arguments require [3, T] positions, got 1D [T] positions"
+            )
+        return False
+    if positions.shape[0] != 3:
+        raise ValueError(
+            "2D positions must be [3, T] (temporal, height, width), got "
+            f"{tuple(positions.shape)}"
+        )
+    if mrope_section is None:
+        raise ValueError(
+            "[3, T] positions require mrope_section; without it this kernel would "
+            "read only the temporal row and silently drop height/width RoPE."
+        )
+    if len(mrope_section) != 3:
+        raise ValueError(
+            f"mrope_section must have 3 entries, got {list(mrope_section)}"
+        )
+    if sum(mrope_section) != half_rotary:
+        raise ValueError(
+            f"sum(mrope_section)={sum(mrope_section)} != rotary_dim // 2 = {half_rotary}"
+        )
+    if positions.stride(1) != 1:
+        raise ValueError(
+            "[3, T] positions must be contiguous along the token dim "
+            f"(stride(1) == 1), got strides {positions.stride()}"
+        )
+    return True
+
+
 def fused_qk_gemma_rmsnorm_rope_gate(
     q_gate: torch.Tensor,
     k: torch.Tensor,
@@ -141,6 +241,9 @@ def fused_qk_gemma_rmsnorm_rope_gate(
     head_dim: int,
     rotary_dim: int,
     has_gate: bool = True,
+    mrope_section: Optional[Sequence[int]] = None,
+    mrope_interleaved: bool = False,
+    mrope_interleaved_glm: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
     """Fused QK GemmaRMSNorm + NeoX RoPE + gate deinterleave.
 
@@ -149,7 +252,13 @@ def fused_qk_gemma_rmsnorm_rope_gate(
         k: [T, num_kv_heads * head_dim]
         q_weight, k_weight: [head_dim] — raw GemmaRMSNorm weights (kernel adds +1.0)
         cos_sin_cache: [max_seq_len, rotary_dim] — [cos..., sin...]
-        positions: [T] — token positions
+        positions: [T] token positions, or [3, T] mRoPE (temporal, height, width)
+            positions, which require ``mrope_section``.
+        mrope_section: 3 entries summing to rotary_dim // 2, selecting which
+            rotary pairs follow the temporal, height and width axes.
+        mrope_interleaved: round-robin axis assignment (Qwen3-VL / Qwen3.5)
+            instead of contiguous per-axis sections.
+        mrope_interleaved_glm: unsupported here; passing True raises.
     """
     T = q_gate.shape[0]
     q_size = num_q_heads * head_dim
@@ -164,6 +273,16 @@ def fused_qk_gemma_rmsnorm_rope_gate(
     )
 
     half_rotary = rotary_dim // 2
+    use_mrope = _check_positions_contract(
+        positions=positions,
+        num_tokens=T,
+        half_rotary=half_rotary,
+        mrope_section=mrope_section,
+        mrope_interleaved=mrope_interleaved,
+        mrope_interleaved_glm=mrope_interleaved_glm,
+    )
+    stride_pos_m = positions.stride(0) if use_mrope else 0
+    sec_t, sec_h, sec_w = tuple(mrope_section) if use_mrope else (0, 0, 0)
     head_block = triton.next_power_of_2(head_dim)
     rot_half_block = triton.next_power_of_2(half_rotary)
 
@@ -184,6 +303,7 @@ def fused_qk_gemma_rmsnorm_rope_gate(
         k_out.stride(0),
         gate_out.stride(0),
         cos_sin_cache.stride(0),
+        stride_pos_m,
         NUM_Q_HEADS=num_q_heads,
         NUM_KV_HEADS=num_kv_heads,
         HEAD_DIM=head_dim,
@@ -195,6 +315,11 @@ def fused_qk_gemma_rmsnorm_rope_gate(
         FP16=q_gate.dtype == torch.float16,
         HAS_PASS=rotary_dim < head_dim,
         HAS_GATE=has_gate,
+        MROPE=use_mrope,
+        MROPE_SECTION_T=sec_t,
+        MROPE_SECTION_H=sec_h,
+        MROPE_SECTION_W=sec_w,
+        MROPE_INTERLEAVED=bool(mrope_interleaved),
         ENABLE_PDL=_ENABLE_PDL,
     )
 

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -68,7 +68,7 @@ from sglang.srt.layers.parameter import (
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.layers.radix_linear_attention import RadixLinearAttention
-from sglang.srt.layers.rotary_embedding import get_rope
+from sglang.srt.layers.rotary_embedding import MRotaryEmbedding, get_rope
 from sglang.srt.layers.utils import PPMissingLayer, get_layer_id
 from sglang.srt.layers.vocab_parallel_embedding import VocabParallelEmbedding
 from sglang.srt.model_executor.cuda_graph_config import (
@@ -876,6 +876,35 @@ class Qwen3_5LinearDecoderLayer(nn.Module):
         return hidden_states, residual
 
 
+def _fused_mrope_kwargs(rotary_emb, positions) -> Optional[dict]:
+    """Kernel kwargs for `positions`: {} for 1D, None when it must not fuse.
+
+    None means the caller falls back to the unfused RoPE path; it is not an
+    error. Anything the fused kernel does not implement must return None rather
+    than let [3, T] positions reach 1D indexing, which reads the temporal row
+    and silently drops height/width.
+    """
+    if positions.ndim == 1:
+        return {}
+    if positions.ndim != 2 or positions.shape[0] != 3:
+        return None
+    if not isinstance(rotary_emb, MRotaryEmbedding):
+        return None
+    if rotary_emb.mrope_interleaved_glm:
+        return None
+    mrope_section = rotary_emb.mrope_section
+    if not mrope_section or len(mrope_section) != 3:
+        return None
+    if sum(mrope_section) != rotary_emb.rotary_dim // 2:
+        return None
+    if positions.stride(1) != 1:
+        return None
+    return {
+        "mrope_section": list(mrope_section),
+        "mrope_interleaved": bool(rotary_emb.mrope_interleaved),
+    }
+
+
 class Qwen3_5AttentionDecoderLayer(nn.Module):
     """Qwen3.5 Decoder Layer with Full Attention."""
 
@@ -1073,7 +1102,7 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
         k = k_by_head.view(k.shape)
         return q, k
 
-    def forward_prepare_cuda_fused(self, positions, hidden_states):
+    def forward_prepare_cuda_fused(self, positions, hidden_states, mrope_kwargs=None):
         """Fused QK GemmaRMSNorm + NeoX RoPE + gate deinterleave."""
         qkv, _ = self.qkv_proj(hidden_states)
         if self.attn_output_gate:
@@ -1095,6 +1124,7 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
             self.head_dim,
             self.rotary_emb.rotary_dim,
             has_gate=self.attn_output_gate,
+            **(mrope_kwargs or {}),
         )
         seq_len = hidden_states.shape[0]
         q = q_out.view(seq_len, -1)
@@ -1183,10 +1213,16 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
         forward_batch: ForwardBatch,
     ) -> torch.Tensor:
         """Full attention forward pass."""
-        if _is_cuda and self.attn_output_gate:
+        fused_mrope_kwargs = (
+            _fused_mrope_kwargs(rotary_emb=self.rotary_emb, positions=positions)
+            if _is_cuda and self.attn_output_gate
+            else None
+        )
+        if fused_mrope_kwargs is not None:
             q, k, v, gate = self.forward_prepare_cuda_fused(
                 positions=positions,
                 hidden_states=hidden_states,
+                mrope_kwargs=fused_mrope_kwargs,
             )
         elif (_is_hip or _is_xpu or _is_cpu) and self.attn_output_gate:
             q, k, v, gate = self.forward_prepare_fused_gate(

--- a/test/registered/kernels/ops/attention/test_fused_qk_rmsnorm_rope_gate.py
+++ b/test/registered/kernels/ops/attention/test_fused_qk_rmsnorm_rope_gate.py
@@ -1,0 +1,447 @@
+"""Correctness for the fused Qwen3.5 Gemma-RMSNorm + NeoX RoPE + gate kernel.
+
+Covers both position contracts: the 1D ``[T]`` form the kernel was written for,
+and the ``[3, T]`` mRoPE form used by the multimodal Qwen3.5 checkpoints
+(Qwen3.6-27B / Qwen3.8-27B), whose image and video tokens carry genuinely
+distinct temporal / height / width rows.
+
+Regression for the case where ``[3, T]`` positions reached 1D indexing and only
+the temporal row was applied, silently dropping height/width rotary dims for
+visual tokens.
+
+The reference builds cos/sin from an explicit per-dim axis map and a gather, so
+it is an independent formulation rather than a transcription of the kernel's
+mask arithmetic.
+"""
+
+import sys
+
+import pytest
+import torch
+
+from sglang.kernels.ops.attention.fused_qk_rmsnorm_rope_gate import (
+    fused_qk_gemma_rmsnorm_rope_gate,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="4-gpu-b200")
+
+DEV = "cuda"
+DTYPE = torch.bfloat16
+EPS = 1e-6
+BASE = 10_000_000
+MAX_POS = 512
+
+# Qwen3.6-27B / Qwen3.8-27B geometry: head_dim 256, partial_rotary_factor 0.25.
+QWEN35_HEAD_DIM, QWEN35_ROTARY_DIM = 256, 64
+QWEN35_SECTION = [11, 11, 10]
+
+
+def _build_cache(rotary_dim):
+    inv_freq = 1.0 / (
+        BASE
+        ** (torch.arange(0, rotary_dim, 2, dtype=torch.float, device=DEV) / rotary_dim)
+    )
+    t = torch.arange(MAX_POS, dtype=torch.float, device=DEV)
+    freqs = torch.outer(t, inv_freq)
+    return torch.cat([freqs.cos(), freqs.sin()], dim=-1).contiguous()
+
+
+def _axis_map(mrope_section, interleaved, half):
+    """Which position row (0=T, 1=H, 2=W) each rotary pair draws its angle from."""
+    axes = torch.zeros(half, dtype=torch.long, device=DEV)
+    d = torch.arange(half, device=DEV)
+    if interleaved:
+        axes[(d % 3 == 1) & (d < 3 * mrope_section[1])] = 1
+        axes[(d % 3 == 2) & (d < 3 * mrope_section[2])] = 2
+    else:
+        t_end = mrope_section[0]
+        h_end = t_end + mrope_section[1]
+        axes[t_end:h_end] = 1
+        axes[h_end:] = 2
+    return axes
+
+
+def _ref_cos_sin(cache, positions, mrope_section, interleaved, half):
+    cs = cache[positions].float()
+    if positions.ndim == 1:
+        return cs[:, :half], cs[:, half:]
+    # cs: [3, T, rotary_dim] -> per-token [T, half] picked axis by axis.
+    num_tokens = positions.shape[1]
+    axes = _axis_map(mrope_section, interleaved, half)
+    idx = axes.view(1, half, 1).expand(num_tokens, half, 1)
+    cos = torch.gather(cs[..., :half].permute(1, 2, 0), 2, idx).squeeze(-1)
+    sin = torch.gather(cs[..., half:].permute(1, 2, 0), 2, idx).squeeze(-1)
+    return cos, sin
+
+
+def _ref(
+    q_gate,
+    k,
+    q_weight,
+    k_weight,
+    cache,
+    positions,
+    num_q_heads,
+    num_kv_heads,
+    head_dim,
+    rotary_dim,
+    has_gate,
+    mrope_section=None,
+    mrope_interleaved=False,
+):
+    num_tokens = q_gate.shape[0]
+    half = rotary_dim // 2
+    cos, sin = _ref_cos_sin(cache, positions, mrope_section, mrope_interleaved, half)
+    cos, sin = cos.unsqueeze(1), sin.unsqueeze(1)  # [T, 1, half]
+
+    def gemma_norm(x, weight, num_heads):
+        x = x.reshape(num_tokens, num_heads, head_dim)
+        xf = x.float()
+        var = xf.pow(2).mean(-1, keepdim=True)
+        normed = xf * torch.rsqrt(var + EPS) * (1.0 + weight.float())
+        # The kernel rounds to the output dtype before applying RoPE.
+        return normed.to(x.dtype).float()
+
+    def rope(xn):
+        out = xn.clone()
+        x1, x2 = xn[..., :half], xn[..., half:rotary_dim]
+        out[..., :half] = x1 * cos - x2 * sin
+        out[..., half:rotary_dim] = x2 * cos + x1 * sin
+        return out
+
+    if has_gate:
+        qg = q_gate.reshape(num_tokens, num_q_heads, 2, head_dim)
+        q_in, gate = qg[:, :, 0, :].contiguous(), qg[:, :, 1, :].contiguous()
+    else:
+        q_in, gate = q_gate, None
+
+    q_ref = rope(gemma_norm(q_in, q_weight, num_q_heads)).to(q_gate.dtype)
+    k_ref = rope(gemma_norm(k, k_weight, num_kv_heads)).to(k.dtype)
+    return q_ref.reshape(num_tokens, -1), k_ref.reshape(num_tokens, -1), gate
+
+
+def _inputs(num_tokens, num_q_heads, num_kv_heads, head_dim, has_gate, seed=0):
+    torch.manual_seed(seed)
+    q_width = num_q_heads * (2 if has_gate else 1) * head_dim
+    return (
+        torch.randn(num_tokens, q_width, device=DEV, dtype=DTYPE),
+        torch.randn(num_tokens, num_kv_heads * head_dim, device=DEV, dtype=DTYPE),
+        torch.randn(head_dim, device=DEV, dtype=DTYPE),
+        torch.randn(head_dim, device=DEV, dtype=DTYPE),
+    )
+
+
+def _run_case(
+    positions,
+    head_dim=QWEN35_HEAD_DIM,
+    rotary_dim=QWEN35_ROTARY_DIM,
+    num_q_heads=4,
+    num_kv_heads=2,
+    has_gate=True,
+    mrope_section=None,
+    mrope_interleaved=False,
+    seed=0,
+):
+    num_tokens = positions.shape[-1]
+    q_gate, k, q_weight, k_weight = _inputs(
+        num_tokens, num_q_heads, num_kv_heads, head_dim, has_gate, seed
+    )
+    cache = _build_cache(rotary_dim)
+    kwargs = {}
+    if mrope_section is not None:
+        kwargs = {
+            "mrope_section": mrope_section,
+            "mrope_interleaved": mrope_interleaved,
+        }
+    q_out, k_out, gate_out = fused_qk_gemma_rmsnorm_rope_gate(
+        q_gate,
+        k,
+        q_weight,
+        k_weight,
+        cache,
+        positions,
+        EPS,
+        num_q_heads,
+        num_kv_heads,
+        head_dim,
+        rotary_dim,
+        has_gate=has_gate,
+        **kwargs,
+    )
+    q_ref, k_ref, gate_ref = _ref(
+        q_gate,
+        k,
+        q_weight,
+        k_weight,
+        cache,
+        positions,
+        num_q_heads,
+        num_kv_heads,
+        head_dim,
+        rotary_dim,
+        has_gate,
+        mrope_section,
+        mrope_interleaved,
+    )
+    return (q_out, k_out, gate_out), (q_ref, k_ref, gate_ref)
+
+
+def _assert_close(got, ref, name):
+    torch.testing.assert_close(
+        got.float(), ref.float(), atol=2e-2, rtol=2e-2, msg=lambda m: f"{name}: {m}"
+    )
+
+
+def _mrope_positions(num_tokens, seed=0):
+    """[3, T] positions whose three rows genuinely differ, as for image tokens."""
+    generator = torch.Generator(device=DEV).manual_seed(seed)
+    return torch.randint(
+        0, MAX_POS, (3, num_tokens), device=DEV, dtype=torch.int64, generator=generator
+    )
+
+
+def test_positions_1d_matches_reference():
+    """The pre-existing [T] contract still holds."""
+    positions = torch.arange(17, device=DEV, dtype=torch.int64)
+    (q, k, gate), (q_ref, k_ref, gate_ref) = _run_case(positions)
+    _assert_close(q, q_ref, "q")
+    _assert_close(k, k_ref, "k")
+    assert torch.equal(gate, gate_ref)
+
+
+def test_mrope_equal_rows_matches_1d():
+    """[3, T] with identical rows must reduce exactly to the 1D result."""
+    positions_1d = torch.arange(17, device=DEV, dtype=torch.int64)
+    positions_3d = positions_1d.unsqueeze(0).repeat(3, 1).contiguous()
+    (q_1d, k_1d, _), _ = _run_case(positions_1d)
+    (q_3d, k_3d, _), _ = _run_case(
+        positions_3d, mrope_section=QWEN35_SECTION, mrope_interleaved=True
+    )
+    assert torch.equal(q_1d, q_3d)
+    assert torch.equal(k_1d, k_3d)
+
+
+def test_mrope_interleaved_qwen35():
+    """The reported bug: distinct T/H/W rows with Qwen3.5's interleaved sections."""
+    positions = _mrope_positions(33)
+    (q, k, gate), (q_ref, k_ref, gate_ref) = _run_case(
+        positions, mrope_section=QWEN35_SECTION, mrope_interleaved=True
+    )
+    _assert_close(q, q_ref, "q")
+    _assert_close(k, k_ref, "k")
+    assert torch.equal(gate, gate_ref)
+
+
+def test_mrope_interleaved_differs_from_temporal_only():
+    """Keeps the mRoPE cases non-degenerate.
+
+    If the sampled positions ever stopped differing across rows, the fused-vs-
+    reference cases above would still pass while guarding nothing, which is
+    exactly how the temporal-only bug survived text-only validation.
+    """
+    positions = _mrope_positions(33, seed=3)
+    (q_mrope, _, _), _ = _run_case(
+        positions, mrope_section=QWEN35_SECTION, mrope_interleaved=True
+    )
+    (q_temporal_only, _, _), _ = _run_case(positions[0].contiguous())
+    assert not torch.allclose(q_mrope.float(), q_temporal_only.float(), atol=1e-3)
+
+
+def test_mrope_sectioned():
+    """Non-interleaved mRoPE: contiguous per-axis sections."""
+    positions = _mrope_positions(21, seed=1)
+    (q, k, _), (q_ref, k_ref, _) = _run_case(
+        positions, mrope_section=[12, 10, 10], mrope_interleaved=False
+    )
+    _assert_close(q, q_ref, "q")
+    _assert_close(k, k_ref, "k")
+
+
+@pytest.mark.parametrize("mrope_interleaved", [True, False])
+def test_mrope_padded_half_rotary(mrope_interleaved):
+    """half_rotary=24 pads to ROT_HALF_BLOCK=32, exercising the masked loads."""
+    positions = _mrope_positions(13, seed=2)
+    (q, k, _), (q_ref, k_ref, _) = _run_case(
+        positions,
+        rotary_dim=48,
+        mrope_section=[8, 8, 8],
+        mrope_interleaved=mrope_interleaved,
+    )
+    _assert_close(q, q_ref, "q")
+    _assert_close(k, k_ref, "k")
+
+
+def test_mrope_positions_sliced_from_graph_buffer():
+    """Row stride must come from the tensor, not be assumed equal to T.
+
+    CUDA graph replay passes ``buffers.mrope_positions[:, :num_tokens]`` and two
+    batch overlap passes ``[:, start:end]``, so the production tensor is a
+    window into a wider buffer with a storage offset.
+    """
+    num_tokens, offset = 12, 8
+    buffer = _mrope_positions(64, seed=7)
+    positions = buffer[:, offset : offset + num_tokens]
+    assert positions.stride(0) != num_tokens and positions.stride(1) == 1
+
+    (q, k, _), _ = _run_case(
+        positions, mrope_section=QWEN35_SECTION, mrope_interleaved=True
+    )
+    (q_contig, k_contig, _), (q_ref, k_ref, _) = _run_case(
+        positions.contiguous(), mrope_section=QWEN35_SECTION, mrope_interleaved=True
+    )
+    assert torch.equal(q, q_contig)
+    assert torch.equal(k, k_contig)
+    _assert_close(q, q_ref, "q")
+    _assert_close(k, k_ref, "k")
+
+
+def test_no_gate():
+    positions = _mrope_positions(11, seed=5)
+    (q, k, gate), (q_ref, k_ref, _) = _run_case(
+        positions,
+        has_gate=False,
+        mrope_section=QWEN35_SECTION,
+        mrope_interleaved=True,
+    )
+    assert gate is None
+    _assert_close(q, q_ref, "q")
+    _assert_close(k, k_ref, "k")
+
+
+def _call_with(positions, **kwargs):
+    num_tokens = positions.shape[-1]
+    q_gate, k, q_weight, k_weight = _inputs(num_tokens, 4, 2, QWEN35_HEAD_DIM, True)
+    return fused_qk_gemma_rmsnorm_rope_gate(
+        q_gate,
+        k,
+        q_weight,
+        k_weight,
+        _build_cache(QWEN35_ROTARY_DIM),
+        positions,
+        EPS,
+        4,
+        2,
+        QWEN35_HEAD_DIM,
+        QWEN35_ROTARY_DIM,
+        **kwargs,
+    )
+
+
+def test_contract_2d_positions_without_mrope_section_raises():
+    """The original bug: [3, T] must never be accepted as 1D positions."""
+    with pytest.raises(ValueError, match="require mrope_section"):
+        _call_with(_mrope_positions(8))
+
+
+def test_contract_rejections():
+    positions = _mrope_positions(8)
+    section = {"mrope_section": QWEN35_SECTION, "mrope_interleaved": True}
+
+    with pytest.raises(ValueError, match="must be \\[3, T\\]"):
+        _call_with(positions[:2].contiguous(), **section)
+
+    with pytest.raises(ValueError, match="require \\[3, T\\] positions"):
+        _call_with(torch.arange(8, device=DEV, dtype=torch.int64), **section)
+
+    with pytest.raises(ValueError, match="must have 3 entries"):
+        _call_with(positions, mrope_section=[16, 16], mrope_interleaved=True)
+
+    with pytest.raises(ValueError, match="!= rotary_dim // 2"):
+        _call_with(positions, mrope_section=[11, 11, 11], mrope_interleaved=True)
+
+    with pytest.raises(ValueError, match="stride\\(1\\) == 1"):
+        _call_with(_mrope_positions(16)[:, ::2], **section)
+
+    with pytest.raises(ValueError, match="GLM-interleaved"):
+        _call_with(positions, mrope_interleaved_glm=True, **section)
+
+    with pytest.raises(ValueError, match="must be \\[T\\] or \\[3, T\\]"):
+        _call_with(positions.unsqueeze(0), **section)
+
+
+def test_dispatch_forwards_mrope_metadata():
+    """qwen3_5 must hand the kernel the metadata, not just the tensor.
+
+    The reported bug was in this dispatch, not in the kernel, so assert the
+    metadata derived from a real MRotaryEmbedding and that feeding it to the
+    kernel reproduces that embedding's own RoPE.
+    """
+    from sglang.srt.layers.rotary_embedding import MRotaryEmbedding
+    from sglang.srt.models.qwen3_5 import _fused_mrope_kwargs
+
+    rotary_emb = MRotaryEmbedding(
+        head_size=QWEN35_HEAD_DIM,
+        rotary_dim=QWEN35_ROTARY_DIM,
+        max_position_embeddings=MAX_POS,
+        base=BASE,
+        is_neox_style=True,
+        dtype=DTYPE,
+        mrope_section=QWEN35_SECTION,
+        mrope_interleaved=True,
+    ).to(DEV)
+
+    positions = _mrope_positions(12, seed=6)
+    kwargs = _fused_mrope_kwargs(rotary_emb=rotary_emb, positions=positions)
+    assert kwargs == {
+        "mrope_section": QWEN35_SECTION,
+        "mrope_interleaved": True,
+    }
+
+    # Cases the fused kernel must not be handed at all.
+    assert (
+        _fused_mrope_kwargs(rotary_emb=rotary_emb, positions=positions[:, ::2]) is None
+    )
+    assert (
+        _fused_mrope_kwargs(
+            rotary_emb=rotary_emb, positions=torch.arange(4, device=DEV)
+        )
+        == {}
+    )
+    rotary_emb.mrope_interleaved_glm = True
+    assert _fused_mrope_kwargs(rotary_emb=rotary_emb, positions=positions) is None
+    rotary_emb.mrope_interleaved_glm = False
+
+    # End to end: kernel + dispatch metadata == the embedding's own RoPE.
+    num_q_heads, num_kv_heads, num_tokens = 4, 2, positions.shape[1]
+    q_gate, k, q_weight, k_weight = _inputs(
+        num_tokens, num_q_heads, num_kv_heads, QWEN35_HEAD_DIM, True, seed=6
+    )
+    cache = rotary_emb.cos_sin_cache.float().contiguous()
+    q_out, k_out, _ = fused_qk_gemma_rmsnorm_rope_gate(
+        q_gate,
+        k,
+        q_weight,
+        k_weight,
+        cache,
+        positions,
+        EPS,
+        num_q_heads,
+        num_kv_heads,
+        QWEN35_HEAD_DIM,
+        QWEN35_ROTARY_DIM,
+        has_gate=True,
+        **kwargs,
+    )
+
+    def gemma_norm(x, weight, num_heads):
+        x = x.reshape(num_tokens, num_heads, QWEN35_HEAD_DIM)
+        xf = x.float()
+        var = xf.pow(2).mean(-1, keepdim=True)
+        return (xf * torch.rsqrt(var + EPS) * (1.0 + weight.float())).to(x.dtype)
+
+    q_in = q_gate.reshape(num_tokens, num_q_heads, 2, QWEN35_HEAD_DIM)[
+        :, :, 0, :
+    ].contiguous()
+    q_normed = gemma_norm(q_in, q_weight, num_q_heads).reshape(num_tokens, -1)
+    k_normed = gemma_norm(k, k_weight, num_kv_heads).reshape(num_tokens, -1)
+    q_expected, k_expected = rotary_emb.forward_native(
+        positions, q_normed.clone(), k_normed.clone()
+    )
+    _assert_close(q_out, q_expected, "q vs MRotaryEmbedding")
+    _assert_close(k_out, k_expected, "k vs MRotaryEmbedding")
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Motivation

Fixes #35345.

On CUDA, `Qwen3_5AttentionDecoderLayer.self_attention` selected
`fused_qk_gemma_rmsnorm_rope_gate` whenever `attn_output_gate` was set, with no
check on the shape of `positions`. That kernel indexed positions as 1D `[T]`
(`pos = tl.load(positions_ptr + token)`).

Multimodal Qwen3.5 checkpoints supply `[3, T]` mRoPE positions. Reading them as
1D picks up only the temporal row, so the height and width rotary dimensions
were silently wrong for visual tokens — no error, no warning, just degraded
multimodal quality. Affects Qwen3.6-27B, Qwen3.8-27B and Qwen3.8-27B-FP8.

## Modifications

The issue suggested a conservative `positions.ndim == 1` guard. This PR instead
extends the kernel to real mRoPE, so multimodal batches keep the fused path
rather than falling back for every image request.

**`fused_qk_rmsnorm_rope_gate.py`**
- The kernel takes a positions row stride plus `mrope_section` /
  `mrope_interleaved` constexprs, and selects each rotary pair's angle from the
  temporal, height or width row. Both the interleaved (round-robin) and
  sectioned (contiguous) layouts are supported, using the same
  masked-load-and-sum idiom as `rotary_triton.py:60-73`.
- Axis masks are ANDed with `rot_mask`, so padded lanes
  (`ROT_HALF_BLOCK > HALF_ROTARY`) never address past the end of a
  `cos_sin_cache` row.
- `_check_positions_contract` validates shape, token count, section length and
  sum, and token-dim contiguity. It raises `ValueError` rather than asserting —
  these guard against silently computing the wrong RoPE, and `assert` vanishes
  under `python -O`.
- GLM-interleaved mRoPE is explicitly rejected rather than silently mishandled.

**`qwen3_5.py`**
- `_fused_mrope_kwargs` derives the kernel metadata from the `MRotaryEmbedding`
  itself and returns `None` for anything the kernel does not implement.
- `None` falls back to `forward_prepare_native`, which handles
  `attn_output_gate` in full and applies the unfused mRoPE correctly — so an
  unfusable configuration loses the fused RMSNorm's speed but never correctness.

**Text-only path is untouched.** The `MROPE=False` specialization's PTX
instruction stream is byte-identical to before; the only difference in the
compiled module is one unused `.param .u32` slot.

## Accuracy Tests

New `test/registered/kernels/ops/attention/test_fused_qk_rmsnorm_rope_gate.py`
(12 cases). The reference is an independent `torch.gather` formulation over a
permuted `[T, half, 3]` tensor, deliberately *not* a restatement of the kernel's
mask arithmetic.

Coverage: 1D positions; equal-axis `[3, T]` (must reproduce the 1D result);
real interleaved Qwen3.5 geometry (`head_dim=256`, `rotary_dim=64`,
`mrope_section=[11, 11, 10]`); a temporal-only negative control; sectioned
mRoPE; non-power-of-two half-rotary (`rotary_dim=48`); positions sliced from a
wider CUDA-graph buffer (`stride(0) != T`, as produced by
`base_runner.py:468`); the no-gate path; the contract rejections; and the
dispatch metadata against a real `MRotaryEmbedding`.

The regression case was confirmed **red before the fix** (`max |q - ref| = 9.19`)
and green after.

Results: **12/12 pass** in a CUDA container (torch 2.13.0+cu130). 11/12 also
pass on a local SM 8.6 card across a second, independent stack
(torch 2.11.0+cu128 / Triton 3.7.1); the 12th needs `sglang.srt`, which does not
import on Windows.

## Speed Tests and Profiling

**Not measured — I do not have Hopper hardware, and would appreciate a
maintainer running CI on this.** What I can state:

- The text-only path cannot regress: its PTX instruction stream is unchanged.
- The mRoPE path issues 4 extra masked `cos_sin_cache` loads per program versus
  the 1D path, matching what `rotary_triton.py` already does.
- The PDL branch (`ENABLE_PDL`, sm_90+) is unreachable on my hardware, so I
  verified it by cross-compiling for `sm_90`: `MROPE=True` with PDL enabled
  compiles and emits `griddepcontrol`, and an `sm_86` + PDL control correctly
  fails ptxas. That is compile-time evidence only — it is not a runtime result.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — no user-facing behavior change to document
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). — no Hopper hardware available; see above

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32416088090](https://github.com/sgl-project/sglang/actions/runs/32416088090)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32416087751](https://github.com/sgl-project/sglang/actions/runs/32416087751)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32416088138](https://github.com/sgl-project/sglang/actions/runs/32416088138)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->