### PR TITLE
[CI] Gate `/rerun-test` on commenter trust and remove `/rerun-stage`

### DIFF
--- a/.claude/skills/ci-workflow-guide/SKILL.md
+++ b/.claude/skills/ci-workflow-guide/SKILL.md
@@ -139,7 +139,7 @@ This skill covers the CI **infrastructure** layer — how tests are dispatched, 
 
 ## Execution Modes
 
-| Aspect | PR (`pull_request`) | Scheduled (`cron`, every 6h) | `/rerun-stage` (`workflow_dispatch`) |
+| Aspect | PR (`pull_request`) | Scheduled (`cron`, every 6h) | Manual dispatch (`workflow_dispatch`) |
 |--------|---------------------|------------------------------|--------------------------------------|
 | **Stage ordering** | Sequential: A → B → C via `wait-for-base-*` | Parallel (all at once) | Single target stage only |
 | **Cross-job fast-fail** | Yes (`check-pr-test-health`) | Yes | Yes |
@@ -175,7 +175,7 @@ This skill covers the CI **infrastructure** layer — how tests are dispatched, 
 
 > **Critical**: `expected_count` must match the matrix size. If you add/remove matrix entries, update the wait job's spec accordingly.
 
-**PR only**: Condition `github.event_name == 'pull_request' && !inputs.target_stage` — scheduled runs and `/rerun-stage` skip these entirely, allowing parallel execution.
+**PR only**: Condition `github.event_name == 'pull_request' && !inputs.target_stage` — scheduled runs and manual dispatches skip these entirely, allowing parallel execution.
 
 ---
 
@@ -341,7 +341,7 @@ group: pr-test-{event_name}-{branch}-{pr_sha}-{stage}
 |---------|--------|---------|
 | `event_name` | `github.event_name` | Prevents scheduled runs colliding with fork PRs named `main` |
 | `branch` | `github.head_ref \|\| github.ref_name` | Per-branch isolation |
-| `pr_sha` | `inputs.pr_head_sha \|\| 'current'` | Isolates `/rerun-stage` from main runs |
+| `pr_sha` | `inputs.pr_head_sha \|\| 'current'` | Isolates manual dispatches from main runs |
 | `stage` | `inputs.target_stage \|\| 'all'` | Allows parallel stage dispatches |
 
 `cancel-in-progress: true` for `pull_request` events (new push cancels old run), `false` for `workflow_call`.
@@ -388,7 +388,6 @@ group: pr-test-{event_name}-{branch}-{pr_sha}-{stage}
 | `/rerun-failed-ci` | Reruns failed jobs in the latest workflow run |
 | `/tag-and-rerun-ci` | Adds `run-ci` label + reruns failed |
 | `/tag-and-rerun-ci extra` | Adds both `run-ci` and `run-ci-extra` labels + reruns failed |
-| `/rerun-stage <stage>` | Deprecated; posts deprecation notice |
 | `/rerun-test <test-file> [<test-file> ...]` | Reruns specific test file(s) via `rerun-test.yml`. A file arg containing a glob metacharacter (`*`, `?`, `[...]`) expands against `test/registered/` and the multimodal test dir to every matching `test_*.py` (e.g. `/rerun-test test_*backend*.py` — wrap in backticks so GitHub doesn't italicize the `*`); matches are deduped, grouped by dispatch shape, and can't carry a `::test` selector. No match → single ⛔ reply, nothing dispatched. Each reply echoes its originating command (`Results for …`) so concurrent commands stay distinguishable |
 | `/rerun-group <group> [<group> ...]` | Expands registered test groups, then reuses `/rerun-test` |
 

--- a/.github/CI_PERMISSIONS.json
+++ b/.github/CI_PERMISSIONS.json
@@ -2,1687 +2,1687 @@
     "1pikachu": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "842974287": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "AgainstEntropy": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "Alcanderian": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "Alisehen": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "AniZpZ": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "BBuf": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "BHZ-BER": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "ByronHsu": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "CaoE": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "CatherineSue": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "Chen-0210": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "Chillee": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "ClawSeven": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "ConnorLi96": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "DarkSharpness": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "DevashishLal-CB": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "Edwardf0t1": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "FlamingoPg": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "FrankLeeeee": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "Fridge003": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "HaiShaw": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "HanHan009527": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "HandH1998": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "Hanrui-Wang": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "Hexq0210": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "HydraQYH": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "JeremieMelo": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "Jialin": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "Jiminator": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "Johnsonms": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "JonnyKong": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "JustinTong0323": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "Kangyan-Zhou": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "LorrinWWW": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "Makcum888e": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "MeowMiaoJ": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "MingxuZh": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "Oasis-Git": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "OrangeRedeng": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "Prozac614": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "Qiaolin-Yu": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "Qihang-Zhang": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "Ratish1": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "RubiaCx": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "ShangmingCai": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "Shunkangz": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "SimonCqk": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "TianQiLin666666": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "UNIDY2002": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "Ubospica": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "Valentine233": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "Xia-Weiwen": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "XiaotongJiang": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "XucSh": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "YAMY1234": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "YangKai0616": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "YazhiGao": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "Ying1123": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "Yuxingwang-intel": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "ZYHowell": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "ZailiWang": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "ZhengWG": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "ZhengdQin": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "acelyc111": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "adarshxs": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "airMeng": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "alexnails": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "alisonshao": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "alphabetc1": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "amysaq2023": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "attack204": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "aurickq": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "ayrnb": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "azhurkevich": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "b8zhong": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "bingxche": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "blzheng": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "byjiang1996": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "caihuali95": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "cctry": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "ch-wan": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "charlotte12l": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "chenxu214": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "chunyuan-w": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "cicirori": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "cyb70289": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "cyxlily": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "dongjiyingdjy": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "dougyster": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "ekzhang": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "elfiegg": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "fortunecookiee": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "fy1214": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "fzyzcjy": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "gaopengff": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "glenliu21": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "gongwei-130": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "gongy": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "guapisolo": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "guoyuhong": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "hanming-lu": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "harrisonlimh": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "harvenstar": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "hebiao064": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "hlu1": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "hnyls2002": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "houseroad": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "htzo": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "huangtingwei9988": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "hubertlu-tw": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "hyhieu": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "hzh0425": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "iforgetmyname": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "ishandhanani": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "ispobock": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "jason-fxz": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "jasonjk-park": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "jasperjiaguo": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "jhinpan": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "jianan-gu": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "jiayisunx": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "jinleic": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "jinmingyi1998": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "jybsuper": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "kaixih": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "kevin85421": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "key4ng": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "kkHuang-amd": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "klshuster": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "kpham-sgl": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "kssteven418": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "kushanam": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "lanking520": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "lawrence-harmonic": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "liangan1": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "libertyeagle": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "lifuhuang": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "liupeng374": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "liusy58": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "liz-badada": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "luccafong": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "maocheng23": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "merrymercy": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "michaelzhang-ai": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "mickqian": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "mingfeima": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "minleminzui": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "minosfuture": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "mmangkad": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "narutolhy": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "netanel-haber": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "nvcastet": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "nvpohanh": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "nzr-niu": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "ocss884": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "oulgen": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "pansicheng": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "paulzhang-tm": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "pavanimajety": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "pdasgup": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "pengwu22": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "ping1jing2": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "ppraneth": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "prajjwal1": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "pranavm-nvidia": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "pranjalssh": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 30,
         "reason": "custom override"
     },
     "pyc96": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "qimcis": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "qingquansong": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "qywu": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "rainj-me": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "ravi03071991": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "rkooo567": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "roikoren755": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "saienduri": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "samuellees": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "satyamk7054": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "scottjlee": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "sglang-bot": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "sglang-npu-bot": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "shaharmor98": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "shanyu-sys": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "shenxiul": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "shuaills": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "siju-samuel": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "sleepcoo": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "slin1237": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "sshleifer": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "stmatengss": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "strgrb": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "sufeng-buaa": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "sundar24295s": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "sunjiweiswift": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "sunxxuns": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "tanujtiwari1998": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "thanhhao98": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "thecodingwizard": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "timmy-feng": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "trevor-m": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "vincentzed": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "wangfakang": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 30,
         "reason": "custom override"
     },
     "weireweire": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "wenscarl": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "whybeyoung": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "wisclmy0611": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "xiezhq-hermann": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "xinguozhu-2026": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "xutizhou": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "xyjixyjixyji": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "yanbing-j": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "yangsijia-serena": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "yaof20": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "yctseng0211": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "yeahdongcn": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "yhyang201": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "yilian49": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "yinghai": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "yingluosanqian": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "yizhang2077": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "ykcombat": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "ynwang007": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "yuan-luo": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "yuchengliu1": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "yueming-yuan": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "yundai424": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "yushengsu-thu": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "yyihuang": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "yzh119": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "zRzRzRzRzRzRzR": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "zcnrex": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "zhaochenyang20": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "zhendonghua": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "zhijian-liu": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "zhuzilin": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "zhyncs": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "zianglih": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "zminglei": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "zx3xyy": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "zyksir": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "zyzshishui": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_stage": true,
+        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     }

--- a/.github/CI_PERMISSIONS.json
+++ b/.github/CI_PERMISSIONS.json
@@ -2,1687 +2,1446 @@
     "1pikachu": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "842974287": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "AgainstEntropy": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "Alcanderian": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "Alisehen": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "AniZpZ": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "BBuf": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "BHZ-BER": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "ByronHsu": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "CaoE": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "CatherineSue": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "Chen-0210": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "Chillee": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "ClawSeven": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "ConnorLi96": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "DarkSharpness": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "DevashishLal-CB": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "Edwardf0t1": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "FlamingoPg": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "FrankLeeeee": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "Fridge003": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "HaiShaw": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "HanHan009527": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "HandH1998": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "Hanrui-Wang": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "Hexq0210": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "HydraQYH": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "JeremieMelo": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "Jialin": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "Jiminator": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "Johnsonms": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "JonnyKong": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "JustinTong0323": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "Kangyan-Zhou": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "LorrinWWW": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "Makcum888e": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "MeowMiaoJ": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "MingxuZh": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "Oasis-Git": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "OrangeRedeng": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "Prozac614": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "Qiaolin-Yu": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "Qihang-Zhang": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "Ratish1": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "RubiaCx": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "ShangmingCai": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "Shunkangz": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "SimonCqk": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "TianQiLin666666": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "UNIDY2002": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "Ubospica": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "Valentine233": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "Xia-Weiwen": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "XiaotongJiang": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "XucSh": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "YAMY1234": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "YangKai0616": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "YazhiGao": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "Ying1123": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "Yuxingwang-intel": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "ZYHowell": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "ZailiWang": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "ZhengWG": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "ZhengdQin": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "acelyc111": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "adarshxs": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "airMeng": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "alexnails": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "alisonshao": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "alphabetc1": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "amysaq2023": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "attack204": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "aurickq": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "ayrnb": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "azhurkevich": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "b8zhong": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "bingxche": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "blzheng": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "byjiang1996": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "caihuali95": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "cctry": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "ch-wan": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "charlotte12l": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "chenxu214": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "chunyuan-w": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "cicirori": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "cyb70289": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "cyxlily": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "dongjiyingdjy": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "dougyster": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "ekzhang": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "elfiegg": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "fortunecookiee": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "fy1214": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "fzyzcjy": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "gaopengff": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "glenliu21": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "gongwei-130": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "gongy": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "guapisolo": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "guoyuhong": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "hanming-lu": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "harrisonlimh": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "harvenstar": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "hebiao064": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "hlu1": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "hnyls2002": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "houseroad": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "htzo": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "huangtingwei9988": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "hubertlu-tw": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "hyhieu": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "hzh0425": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "iforgetmyname": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "ishandhanani": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "ispobock": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "jason-fxz": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "jasonjk-park": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "jasperjiaguo": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "jhinpan": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "jianan-gu": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "jiayisunx": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "jinleic": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "jinmingyi1998": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "jybsuper": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "kaixih": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "kevin85421": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "key4ng": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "kkHuang-amd": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "klshuster": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "kpham-sgl": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "kssteven418": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "kushanam": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "lanking520": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "lawrence-harmonic": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "liangan1": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "libertyeagle": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "lifuhuang": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "liupeng374": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "liusy58": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "liz-badada": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "luccafong": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "maocheng23": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "merrymercy": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "michaelzhang-ai": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "mickqian": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "mingfeima": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "minleminzui": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "minosfuture": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "mmangkad": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "narutolhy": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "netanel-haber": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "nvcastet": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "nvpohanh": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "nzr-niu": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "ocss884": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "oulgen": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "pansicheng": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "paulzhang-tm": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "pavanimajety": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "pdasgup": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "pengwu22": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "ping1jing2": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "ppraneth": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "prajjwal1": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "pranavm-nvidia": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "pranjalssh": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 30,
         "reason": "custom override"
     },
     "pyc96": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "qimcis": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "qingquansong": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "qywu": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "rainj-me": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "ravi03071991": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "rkooo567": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "roikoren755": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "saienduri": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "samuellees": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "satyamk7054": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "scottjlee": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "sglang-bot": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "sglang-npu-bot": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "shaharmor98": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "shanyu-sys": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "shenxiul": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "shuaills": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "siju-samuel": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "sleepcoo": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "slin1237": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "sshleifer": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "stmatengss": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "strgrb": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "sufeng-buaa": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "sundar24295s": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "sunjiweiswift": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "sunxxuns": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "tanujtiwari1998": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "thanhhao98": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "thecodingwizard": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "timmy-feng": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "trevor-m": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "vincentzed": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "wangfakang": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 30,
         "reason": "custom override"
     },
     "weireweire": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "wenscarl": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "whybeyoung": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "wisclmy0611": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "xiezhq-hermann": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "xinguozhu-2026": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "xutizhou": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "xyjixyjixyji": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "yanbing-j": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "yangsijia-serena": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "yaof20": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "yctseng0211": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "yeahdongcn": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "yhyang201": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "yilian49": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "yinghai": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "yingluosanqian": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "yizhang2077": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "ykcombat": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "ynwang007": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "yuan-luo": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "yuchengliu1": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "yueming-yuan": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "yundai424": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "yushengsu-thu": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "yyihuang": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "yzh119": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "zRzRzRzRzRzRzR": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "zcnrex": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "zhaochenyang20": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "zhendonghua": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     },
     "zhijian-liu": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "zhuzilin": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "zhyncs": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "zianglih": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "zminglei": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "top contributor"
     },
     "zx3xyy": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "zyksir": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
     "zyzshishui": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
-        "can_rerun_test": true,
         "cooldown_interval_minutes": 0,
         "reason": "custom override"
     }

--- a/.github/FOLDER_README.md
+++ b/.github/FOLDER_README.md
@@ -8,5 +8,23 @@ This folder contains tools and workflows for automating maintenance tasks.
 Maintainers can directly edit the file to add entries with `"reason": "custom override"`.
 Maintainers can also run `update_ci_permission.py` to update it with some auto rules (e.g., top contributors in the last 90 days get full permissions).
 
+Recognized permission keys:
+
+| Key | Grants |
+| --- | --- |
+| `can_tag_run_ci_label` | `/tag-run-ci-label`, `/tag-and-rerun-ci` |
+| `can_rerun_failed_ci` | `/rerun-failed-ci`, `/tag-and-rerun-ci` |
+| `can_rerun_stage` | `/rerun-test`, `/rerun-group` -- on same-repo PRs only |
+| `can_rerun_test` | `/rerun-test`, `/rerun-group` -- including PRs from forks |
+
+`can_rerun_test` is the only key that clears a fork PR. Grant it deliberately:
+these commands check out the PR head and execute it on the self-hosted GPU
+runners, so it lets the holder run fork code on CI hardware. Everyone else needs
+write permission on the repo to use these commands on a fork PR.
+
+PR authors can always use `/rerun-failed-ci`, `/rerun-test`, and `/rerun-group`
+on their own same-repo PRs without an entry here, but authorship alone never
+clears a fork PR.
+
 ## Others
 - `MAINTAINER.md` defines the code maintenance model.

--- a/.github/FOLDER_README.md
+++ b/.github/FOLDER_README.md
@@ -14,18 +14,21 @@ Recognized permission keys:
 | --- | --- |
 | `can_tag_run_ci_label` | `/tag-run-ci-label`, `/tag-and-rerun-ci` |
 | `can_rerun_failed_ci` | `/rerun-failed-ci`, `/tag-and-rerun-ci` |
-| `can_rerun_test` | `/rerun-test`, `/rerun-group` on same-repo PRs |
-| `can_rerun_test_on_fork` | additionally allows them on PRs from forks |
+| `cooldown_interval_minutes` | rate limit in `pr-gate.yml`; `0` also grants `/rerun-test`, `/rerun-group` |
 
-`can_rerun_test_on_fork` is the only key that clears a fork PR, and it is an
-add-on to `can_rerun_test` rather than a replacement. Grant it deliberately:
-these commands check out the PR head and execute it on the self-hosted GPU
-runners, so it lets the holder run fork code on CI hardware. Everyone else needs
-write permission on the repo to use these commands on a fork PR.
+`/rerun-test` and `/rerun-group` are gated on the commenter alone: either
+`cooldown_interval_minutes: 0`, or `write`/`admin` permission on the repo. Where
+the PR comes from makes no difference, and authoring it grants nothing.
 
-PR authors can always use `/rerun-failed-ci`, `/rerun-test`, and `/rerun-group`
-on their own same-repo PRs without an entry here, but authorship alone never
-clears a fork PR.
+Those are the same two signals `pr-gate.yml` already uses to waive its rate
+limit, and that is the point -- a selective rerun dispatches `rerun-test.yml`
+directly, which never passes through `pr-gate.yml`, so it bypasses the rate limit
+by construction. Anyone allowed to run one is therefore unthrottled in practice,
+which is exactly what a zero cooldown already declares.
+
+Set a cooldown deliberately: `0` lets the holder run PR-head code on the
+self-hosted GPU runners, and raising it above `0` takes that away again along
+with their rate-limit waiver.
 
 ## Others
 - `MAINTAINER.md` defines the code maintenance model.

--- a/.github/FOLDER_README.md
+++ b/.github/FOLDER_README.md
@@ -14,10 +14,11 @@ Recognized permission keys:
 | --- | --- |
 | `can_tag_run_ci_label` | `/tag-run-ci-label`, `/tag-and-rerun-ci` |
 | `can_rerun_failed_ci` | `/rerun-failed-ci`, `/tag-and-rerun-ci` |
-| `can_rerun_stage` | `/rerun-test`, `/rerun-group` -- on same-repo PRs only |
-| `can_rerun_test` | `/rerun-test`, `/rerun-group` -- including PRs from forks |
+| `can_rerun_test` | `/rerun-test`, `/rerun-group` on same-repo PRs |
+| `can_rerun_test_on_fork` | additionally allows them on PRs from forks |
 
-`can_rerun_test` is the only key that clears a fork PR. Grant it deliberately:
+`can_rerun_test_on_fork` is the only key that clears a fork PR, and it is an
+add-on to `can_rerun_test` rather than a replacement. Grant it deliberately:
 these commands check out the PR head and execute it on the self-hosted GPU
 runners, so it lets the holder run fork code on CI hardware. Everyone else needs
 write permission on the repo to use these commands on a fork PR.

--- a/.github/update_ci_permission.py
+++ b/.github/update_ci_permission.py
@@ -35,10 +35,8 @@ Permissions are assigned according to the following rules:
     - For all other cases, preserve the original configuration unchanged.
 3. All other users receive no permissions and a 120-minute cooldown (they are omitted from the file).
 
-`cooldown_interval_minutes` is not only a rate limit: a value of 0 also authorizes
-`/rerun-test` and `/rerun-group`, which bypass the `pr-gate.yml` rate limit by
-construction. See `_check_rerun_test_permissions` in
-`scripts/ci/utils/slash_command_handler.py`.
+`cooldown_interval_minutes` is not only a rate limit: 0 also authorizes
+`/rerun-test` and `/rerun-group`, which never pass through `pr-gate.yml`.
 
 Usage:
     export GH_TOKEN="your_github_token"

--- a/.github/update_ci_permission.py
+++ b/.github/update_ci_permission.py
@@ -203,7 +203,7 @@ def main():
         new_permissions[user] = {
             "can_tag_run_ci_label": True,
             "can_rerun_failed_ci": True,
-            "can_rerun_stage": True,
+            "can_rerun_test": True,
             "cooldown_interval_minutes": 0,
             "reason": "top contributor",
         }
@@ -221,7 +221,7 @@ def main():
             new_permissions[user] = {
                 "can_tag_run_ci_label": True,
                 "can_rerun_failed_ci": True,
-                "can_rerun_stage": True,
+                "can_rerun_test": True,
                 "cooldown_interval_minutes": 60,
                 "reason": "custom override",
             }

--- a/.github/update_ci_permission.py
+++ b/.github/update_ci_permission.py
@@ -35,6 +35,11 @@ Permissions are assigned according to the following rules:
     - For all other cases, preserve the original configuration unchanged.
 3. All other users receive no permissions and a 120-minute cooldown (they are omitted from the file).
 
+`cooldown_interval_minutes` is not only a rate limit: a value of 0 also authorizes
+`/rerun-test` and `/rerun-group`, which bypass the `pr-gate.yml` rate limit by
+construction. See `_check_rerun_test_permissions` in
+`scripts/ci/utils/slash_command_handler.py`.
+
 Usage:
     export GH_TOKEN="your_github_token"
     python3 update_ci_permission.py
@@ -203,7 +208,6 @@ def main():
         new_permissions[user] = {
             "can_tag_run_ci_label": True,
             "can_rerun_failed_ci": True,
-            "can_rerun_test": True,
             "cooldown_interval_minutes": 0,
             "reason": "top contributor",
         }
@@ -221,7 +225,6 @@ def main():
             new_permissions[user] = {
                 "can_tag_run_ci_label": True,
                 "can_rerun_failed_ci": True,
-                "can_rerun_test": True,
                 "cooldown_interval_minutes": 60,
                 "reason": "custom override",
             }

--- a/.github/workflows/pr-test-amd-rocm720.yml
+++ b/.github/workflows/pr-test-amd-rocm720.yml
@@ -1,5 +1,5 @@
 name: PR Test ROCm 7.2 (AMD)
-# Dynamic run-name for /rerun-stage commands to enable URL lookup
+# Dynamic run-name for manual stage dispatches to enable URL lookup
 # Format: "[stage-name] sha" for fork PRs, "[stage-name]" for non-fork, default for normal runs
 run-name: ${{ (inputs.target_stage || inputs.target_stage_select) && (inputs.pr_head_sha && format('[{0}] {1}', inputs.target_stage || inputs.target_stage_select, inputs.pr_head_sha) || format('[{0}]', inputs.target_stage || inputs.target_stage_select)) || '' }}
 
@@ -56,7 +56,7 @@ on:
         type: string
         default: ""
       pr_head_sha:
-        description: "PR head SHA to checkout (for /rerun-stage on fork PRs)"
+        description: "PR head SHA to checkout (for stage dispatches on fork PRs)"
         required: false
         type: string
         default: ""
@@ -239,7 +239,7 @@ jobs:
   # pr-test.yml's `call-pr-test-extra`. On `schedule` (and run_all_tests
   # dispatch) the extra suite runs on `main` without needing the
   # `run-ci-extra` label (pr-gate.yml only enforces labels on pull_request
-  # events). Targeted /rerun-stage dispatches (target_stage set) are excluded.
+  # events). Targeted stage dispatches (target_stage set) are excluded.
   # Not added to `pr-test-amd-rocm720-finish` so the base AMD gate never depends on
   # the opt-in extra suite.
   call-pr-test-amd-extra-rocm720:

--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -1,5 +1,5 @@
 name: PR Test ROCm 7.0 (AMD)
-# Dynamic run-name for /rerun-stage commands to enable URL lookup
+# Dynamic run-name for manual stage dispatches to enable URL lookup
 # Format: "[stage-name] sha" for fork PRs, "[stage-name]" for non-fork, default for normal runs
 run-name: ${{ (inputs.target_stage || inputs.target_stage_select) && (inputs.pr_head_sha && format('[{0}] {1}', inputs.target_stage || inputs.target_stage_select, inputs.pr_head_sha) || format('[{0}]', inputs.target_stage || inputs.target_stage_select)) || '' }}
 
@@ -43,7 +43,7 @@ on:
         type: string
         default: ""
       pr_head_sha:
-        description: "PR head SHA to checkout (for /rerun-stage on fork PRs)"
+        description: "PR head SHA to checkout (for stage dispatches on fork PRs)"
         required: false
         type: string
         default: ""
@@ -209,7 +209,7 @@ jobs:
   # pr-test.yml's `call-pr-test-extra`. On `schedule` (and run_all_tests
   # dispatch) the extra suite runs on `main` without needing the
   # `run-ci-extra` label (pr-gate.yml only enforces labels on pull_request
-  # events). Targeted /rerun-stage dispatches (target_stage set) are excluded.
+  # events). Targeted stage dispatches (target_stage set) are excluded.
   # Not added to `pr-test-amd-finish` so the base AMD gate never depends on
   # the opt-in extra suite.
   call-pr-test-amd-extra:

--- a/.github/workflows/rerun-test.yml
+++ b/.github/workflows/rerun-test.yml
@@ -72,8 +72,9 @@ env:
   # every run, so a rerun holding the write token could become everyone's next
   # comparison baseline. Without the repo var it fails fast instead.
 
+# Every job below sets its own `permissions`, which replaces rather than merges
+# with a workflow-level block -- so keep the floor here minimal and grant per job.
 permissions:
-  actions: write
   contents: read
   issues: read
 
@@ -93,6 +94,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.pr_head_sha || github.sha }}
+          # This checkout can hold a fork's code, and the steps below execute it.
+          # Without this, checkout leaves the job's token in .git/config, where
+          # that code could read it; nothing here runs git, and the steps that
+          # need the token take it from secrets explicitly.
+          persist-credentials: false
 
       - name: Mark runner picked up
         if: inputs.reply_comment_id != '' && inputs.reply_marker != ''
@@ -188,6 +194,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.pr_head_sha || github.sha }}
+          # This checkout can hold a fork's code, and the steps below execute it.
+          # Without this, checkout leaves the job's token in .git/config, where
+          # that code could read it; nothing here runs git, and the steps that
+          # need the token take it from secrets explicitly.
+          persist-credentials: false
 
       - name: Mark runner picked up
         if: inputs.reply_comment_id != '' && inputs.reply_marker != ''
@@ -262,6 +273,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.pr_head_sha || github.sha }}
+          # This checkout can hold a fork's code, and the steps below execute it.
+          # Without this, checkout leaves the job's token in .git/config, where
+          # that code could read it; nothing here runs git, and the steps that
+          # need the token take it from secrets explicitly.
+          persist-credentials: false
 
       - name: Mark runner picked up
         if: inputs.reply_comment_id != '' && inputs.reply_marker != ''

--- a/.github/workflows/rerun-test.yml
+++ b/.github/workflows/rerun-test.yml
@@ -94,10 +94,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.pr_head_sha || github.sha }}
-          # This checkout can hold a fork's code, and the steps below execute it.
-          # Without this, checkout leaves the job's token in .git/config, where
-          # that code could read it; nothing here runs git, and the steps that
-          # need the token take it from secrets explicitly.
+          # This checkout can hold a fork's code that the steps below execute;
+          # without this the job token stays in .git/config, readable by it.
           persist-credentials: false
 
       - name: Mark runner picked up
@@ -194,10 +192,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.pr_head_sha || github.sha }}
-          # This checkout can hold a fork's code, and the steps below execute it.
-          # Without this, checkout leaves the job's token in .git/config, where
-          # that code could read it; nothing here runs git, and the steps that
-          # need the token take it from secrets explicitly.
+          # This checkout can hold a fork's code that the steps below execute;
+          # without this the job token stays in .git/config, readable by it.
           persist-credentials: false
 
       - name: Mark runner picked up
@@ -273,10 +269,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.pr_head_sha || github.sha }}
-          # This checkout can hold a fork's code, and the steps below execute it.
-          # Without this, checkout leaves the job's token in .git/config, where
-          # that code could read it; nothing here runs git, and the steps that
-          # need the token take it from secrets explicitly.
+          # This checkout can hold a fork's code that the steps below execute;
+          # without this the job token stays in .git/config, readable by it.
           persist-credentials: false
 
       - name: Mark runner picked up

--- a/.github/workflows/slash-command-handler.yml
+++ b/.github/workflows/slash-command-handler.yml
@@ -19,7 +19,6 @@ jobs:
       (contains(github.event.comment.body, '/tag-run-ci-label') ||
        contains(github.event.comment.body, '/rerun-failed-ci') ||
        contains(github.event.comment.body, '/tag-and-rerun-ci') ||
-       contains(github.event.comment.body, '/rerun-stage') ||
        contains(github.event.comment.body, '/rerun-group') ||
        contains(github.event.comment.body, '/rerun-test'))
     runs-on: ubuntu-latest

--- a/docs/docs/developer_guide/contribution_guide.mdx
+++ b/docs/docs/developer_guide/contribution_guide.mdx
@@ -130,7 +130,7 @@ The rerun commands have the following permission rules:
 | Command | PR author | Other users | Additional rule for fork PRs |
 | --- | --- | --- | --- |
 | `/rerun-failed-ci` | Always allowed on their own PR | Must have `can_rerun_failed_ci` in `CI_PERMISSIONS.json` | None |
-| `/rerun-test`, `/rerun-group` | Always allowed on their own same-repo PR | Must have `can_rerun_test` in `CI_PERMISSIONS.json` | The commenter must have `can_rerun_test_on_fork` in `CI_PERMISSIONS.json`, or `write`/`admin` repository permission. Authoring the PR does not by itself clear a fork PR. |
+| `/rerun-test`, `/rerun-group` | No special allowance; judged as any other commenter | Must have `cooldown_interval_minutes: 0` in `CI_PERMISSIONS.json`, or `write`/`admin` repository permission | None -- the same rule applies wherever the PR comes from |
 
 <Warning>
 Selective reruns do not build or install a PR-local `sglang-kernel` wheel. If a PR changes `python/sglang/kernels/aot/` or code that depends on that AOT change, use the normal/full PR CI workflow. A `/rerun-test` or `/rerun-group` result may use the pinned released kernel and does not validate the combined change.

--- a/docs/docs/developer_guide/contribution_guide.mdx
+++ b/docs/docs/developer_guide/contribution_guide.mdx
@@ -130,7 +130,7 @@ The rerun commands have the following permission rules:
 | Command | PR author | Other users | Additional rule for fork PRs |
 | --- | --- | --- | --- |
 | `/rerun-failed-ci` | Always allowed on their own PR | Must have `can_rerun_failed_ci` in `CI_PERMISSIONS.json` | None |
-| `/rerun-test`, `/rerun-group` | Automatically receives `can_rerun_test` on their own PR | Must have `can_rerun_test` or the legacy `can_rerun_stage` permission in `CI_PERMISSIONS.json` | The commenter must also have `write` or `admin` repository permission. A fork PR author already has the automatic `can_rerun_test` grant; other fork commenters need both repository permission and a configured selective-rerun permission. |
+| `/rerun-test`, `/rerun-group` | Always allowed on their own same-repo PR | Must have `can_rerun_test` in `CI_PERMISSIONS.json` | The commenter must have `can_rerun_test_on_fork` in `CI_PERMISSIONS.json`, or `write`/`admin` repository permission. Authoring the PR does not by itself clear a fork PR. |
 
 <Warning>
 Selective reruns do not build or install a PR-local `sglang-kernel` wheel. If a PR changes `python/sglang/kernels/aot/` or code that depends on that AOT change, use the normal/full PR CI workflow. A `/rerun-test` or `/rerun-group` result may use the pinned released kernel and does not validate the combined change.

--- a/docs/docs/hardware-platforms/ascend-npus/development/contribution_guide.mdx
+++ b/docs/docs/hardware-platforms/ascend-npus/development/contribution_guide.mdx
@@ -146,14 +146,11 @@ For CI to run on a pull request, it must have the "run-ci" label. Authorized use
 - `/tag-run-ci-label`: Adds the "run-ci" label. Only **future** commits trigger CI; the current commit is unaffected. Add the `extra` argument (`/tag-run-ci-label extra`) to additionally apply the "run-ci-extra" label, opting the PR into the extra test workflow (`pr-test-extra.yml`).
 - `/rerun-failed-ci`: Reruns workflows from the latest commit with conclusion **failed, flaky, or skipped**.
 - `/tag-and-rerun-ci`: Runs both. Use this on a fresh PR to kick off CI on the current commit — `/tag-run-ci-label` alone won't. Accepts the same `extra` argument (`/tag-and-rerun-ci extra`).
-- `/rerun-stage <stage-name>`: Reruns a single test stage without waiting for its dependencies. Useful for quickly validating a specific test fix instead of waiting ~30 minutes for preceding stages.
 - `/rerun-test <test-spec> [<test-spec> ...]`: Reruns one or more specific tests directly, bypassing stage boundaries. Each `<test-spec>` is pytest-style `<file>::<TestClass>[.<test_method>]` (the `::TestClass` and `.<test_method>` parts are optional). The handler resolves each spec, groups specs by their registered runner-label, and dispatches one [Rerun Test workflow](https://github.com/sgl-project/sglang/actions/workflows/rerun-test.yml) per group. Examples: `/rerun-test test_srt_endpoint.py`, `/rerun-test registered/core/test_srt_endpoint.py::TestSRTEndpoint.test_simple_decode`, `/rerun-test test_a.py test_b.py` (multiple at once).
 
 If you have permission, the [Slash Command Handler](https://github.com/sgl-project/sglang/actions/workflows/slash-command-handler.yml) will run your command and react with a 👍 to your comment. It may take up to a few minutes for the reaction to appear. Here’s a usage [example](https://github.com/sgl-project/sglang/pull/14253#issuecomment-3599509302).
 
 To avoid spamming a PR with too many `/rerun-failed-ci` comments, you can also trigger the command by editing an existing comment and adding any suffix (e.g., `/rerun-failed-ci try again`).
-
-Example of rerunning a single test stage: `/rerun-stage unit-test-backend-4-gpu`.
 
 If you don’t have permission, please ask maintainers to trigger CI for you.
 

--- a/scripts/ci/utils/slash_command_handler.py
+++ b/scripts/ci/utils/slash_command_handler.py
@@ -1033,38 +1033,29 @@ def _check_rerun_test_permissions(gh_repo, pr, comment, user_perms, command_name
     """
     Check permissions shared by /rerun-test and /rerun-group.
 
-    `can_rerun_test_on_fork` is the only permission that clears a fork PR, and it
-    counts only when it comes from CI_PERMISSIONS.json -- main() marks PR authors
-    with `_is_pr_author` instead, so opening a fork PR never self-grants the fork
-    exemption.
+    These commands check out the PR head, run it on the self-hosted GPU runners,
+    and never pass through pr-gate.yml, so they bypass its rate limit entirely.
+    They are therefore gated on the same two trust signals pr-gate itself uses: a
+    zero `cooldown_interval_minutes` in CI_PERMISSIONS.json, or write permission
+    on the repo.
     """
-    if not (
-        user_perms.get("can_rerun_test", False)
-        or user_perms.get("_is_pr_author", False)
-    ):
-        print(f"Permission denied: /{command_name} requires can_rerun_test.")
-        return False
+    if user_perms.get("cooldown_interval_minutes") == 0:
+        return True
 
-    # SECURITY: These commands check out and execute code from the PR branch on
-    # self-hosted GPU runners, so a fork PR needs either an explicit
-    # `can_rerun_test_on_fork` grant or a trusted collaborator.
-    is_fork = pr.head.repo is None or pr.head.repo.owner.login != gh_repo.owner.login
-    if is_fork and not user_perms.get("can_rerun_test_on_fork", False):
-        commenter = comment.user.login
-        perm = gh_repo.get_collaborator_permission(commenter)
-        if perm not in ("admin", "write"):
-            print(f"Permission denied: /{command_name} on fork PR by {commenter}.")
-            comment.create_reaction("confused")
-            pr.create_issue_comment(
-                f"⛔ `/{command_name}` is not available for fork PRs unless the commenter "
-                "has `can_rerun_test_on_fork` in `.github/CI_PERMISSIONS.json` or "
-                "write permission on the repo.\n\n"
-                "Please ask a maintainer to run this command, or use the normal CI flow."
-            )
-            return False
-        print(f"Fork PR, but commenter {commenter} has write+ permission. Proceeding.")
+    commenter = comment.user.login
+    perm = gh_repo.get_collaborator_permission(commenter)
+    if perm in ("admin", "write"):
+        print(f"Commenter {commenter} has write+ permission. Proceeding.")
+        return True
 
-    return True
+    print(f"Permission denied: /{command_name} by {commenter} (permission: {perm}).")
+    comment.create_reaction("confused")
+    pr.create_issue_comment(
+        f"⛔ `/{command_name}` requires `cooldown_interval_minutes: 0` in "
+        "`.github/CI_PERMISSIONS.json`, or write permission on the repo.\n\n"
+        "Please ask a maintainer to run this command, or use the normal CI flow."
+    )
+    return False
 
 
 def handle_rerun_test(
@@ -1327,11 +1318,11 @@ def main():
     pr = repo.get_pull(pr_number)
     comment = repo.get_issue(pr_number).get_comment(comment_id)
 
-    # PR authors can always rerun failed CI and rerun individual UTs on their own PRs,
-    # even if they are not listed in CI_PERMISSIONS.json.
+    # PR authors can always rerun failed CI on their own PRs, even if they are not
+    # listed in CI_PERMISSIONS.json.
     # Note: /tag-run-ci-label still requires CI_PERMISSIONS.json.
-    # Note: authorship is marked as `_is_pr_author`, never as a can_rerun_test* key
-    # -- clearing a fork PR requires `can_rerun_test_on_fork` from CI_PERMISSIONS.json.
+    # Note: authorship grants nothing for /rerun-test -- that is gated on the
+    # commenter's own trust level, see _check_rerun_test_permissions.
     if pr.user.login == user_login:
         if user_perms is None:
             print(
@@ -1344,11 +1335,12 @@ def main():
                 f"User {user_login} is the PR author and has existing CI permissions."
             )
         user_perms["can_rerun_failed_ci"] = True
-        user_perms["_is_pr_author"] = True
 
-    if not user_perms:
-        print(f"User {user_login} does not have any configured permissions. Exiting.")
-        return
+    # No early exit on a missing entry: /rerun-test is gated on repo permission
+    # too, so a write-holder absent from the file must still reach its handler.
+    # The other commands re-check their own key and deny silently.
+    if user_perms is None:
+        user_perms = {}
 
     # 4. Parse Command and Execute
     first_line = comment_body.split("\n")[0].strip()

--- a/scripts/ci/utils/slash_command_handler.py
+++ b/scripts/ci/utils/slash_command_handler.py
@@ -1033,16 +1033,13 @@ def _check_rerun_test_permissions(gh_repo, pr, comment, user_perms, command_name
     """
     Check permissions shared by /rerun-test and /rerun-group.
 
-    `can_rerun_test` is the only permission that clears a fork PR, and it counts
-    only when it comes from CI_PERMISSIONS.json -- main() marks PR authors with
-    `_is_pr_author` instead, so opening a fork PR never self-grants the fork
+    `can_rerun_test_on_fork` is the only permission that clears a fork PR, and it
+    counts only when it comes from CI_PERMISSIONS.json -- main() marks PR authors
+    with `_is_pr_author` instead, so opening a fork PR never self-grants the fork
     exemption.
     """
-    can_rerun_test = user_perms.get("can_rerun_test", False)
-
     if not (
-        can_rerun_test
-        or user_perms.get("can_rerun_stage", False)
+        user_perms.get("can_rerun_test", False)
         or user_perms.get("_is_pr_author", False)
     ):
         print(f"Permission denied: /{command_name} requires can_rerun_test.")
@@ -1050,9 +1047,9 @@ def _check_rerun_test_permissions(gh_repo, pr, comment, user_perms, command_name
 
     # SECURITY: These commands check out and execute code from the PR branch on
     # self-hosted GPU runners, so a fork PR needs either an explicit
-    # `can_rerun_test` grant or a trusted collaborator.
+    # `can_rerun_test_on_fork` grant or a trusted collaborator.
     is_fork = pr.head.repo is None or pr.head.repo.owner.login != gh_repo.owner.login
-    if is_fork and not can_rerun_test:
+    if is_fork and not user_perms.get("can_rerun_test_on_fork", False):
         commenter = comment.user.login
         perm = gh_repo.get_collaborator_permission(commenter)
         if perm not in ("admin", "write"):
@@ -1060,8 +1057,8 @@ def _check_rerun_test_permissions(gh_repo, pr, comment, user_perms, command_name
             comment.create_reaction("confused")
             pr.create_issue_comment(
                 f"⛔ `/{command_name}` is not available for fork PRs unless the commenter "
-                "has `can_rerun_test` in `.github/CI_PERMISSIONS.json` or write "
-                "permission on the repo.\n\n"
+                "has `can_rerun_test_on_fork` in `.github/CI_PERMISSIONS.json` or "
+                "write permission on the repo.\n\n"
                 "Please ask a maintainer to run this command, or use the normal CI flow."
             )
             return False
@@ -1333,8 +1330,8 @@ def main():
     # PR authors can always rerun failed CI and rerun individual UTs on their own PRs,
     # even if they are not listed in CI_PERMISSIONS.json.
     # Note: /tag-run-ci-label still requires CI_PERMISSIONS.json.
-    # Note: authorship is marked as `_is_pr_author`, never as `can_rerun_test` --
-    # only the latter clears a fork PR, and it must come from CI_PERMISSIONS.json.
+    # Note: authorship is marked as `_is_pr_author`, never as a can_rerun_test* key
+    # -- clearing a fork PR requires `can_rerun_test_on_fork` from CI_PERMISSIONS.json.
     if pr.user.login == user_login:
         if user_perms is None:
             print(
@@ -1390,31 +1387,6 @@ def main():
             print("Combined command processed successfully; reaction added.")
         else:
             print("Combined command finished, but no actions were taken.")
-
-    elif first_line.startswith("/rerun-stage"):
-        print("/rerun-stage is deprecated; posting deprecation notice.")
-        comment.create_reaction("-1")
-        pr.create_issue_comment(
-            "⚠️ **`/rerun-stage` has been deprecated.**\n\n"
-            "Stage granularity is too coarse — a stage usually doesn't map to one "
-            "feature, so rerunning a stage re-pays the cost of unrelated tests. "
-            "If you don't know which exact test files to rerun, you shouldn't be "
-            "using `/rerun-stage` or `/rerun-test` in the first place.\n\n"
-            "**Use one of these instead:**\n"
-            "- **Selective tests** (you know exactly which files to rerun):\n"
-            "  ```\n"
-            "  /rerun-test test_foo.py test_bar.py\n"
-            "  ```\n"
-            "- **Rerun only failed jobs**:\n"
-            "  ```\n"
-            "  /rerun-failed-ci\n"
-            "  ```\n"
-            "- **Full CI rerun** (with extra coverage): add the `run-ci` or "
-            "`run-ci-extra` label and push a new commit (or use `/tag-and-rerun-ci`).\n\n"
-            "**AMD CI**: stage-level dispatch is still available via "
-            "Actions UI → *PR Test ROCm 7.2 (AMD)* (default) / *PR Test ROCm 7.0 (AMD)* → "
-            "*Run workflow* → pick a stage from the dropdown."
-        )
 
     elif first_line.startswith("/rerun-group"):
         group_names = first_line.split()[1:]

--- a/scripts/ci/utils/slash_command_handler.py
+++ b/scripts/ci/utils/slash_command_handler.py
@@ -1032,13 +1032,9 @@ def _dispatch_batch(gh_repo, pr, batch, token, reply_comment_id="", reply_marker
 def _check_rerun_test_permissions(gh_repo, pr, comment, user_perms, command_name):
     """
     Check permissions shared by /rerun-test and /rerun-group.
-
-    These commands check out the PR head, run it on the self-hosted GPU runners,
-    and never pass through pr-gate.yml, so they bypass its rate limit entirely.
-    They are therefore gated on the same two trust signals pr-gate itself uses: a
-    zero `cooldown_interval_minutes` in CI_PERMISSIONS.json, or write permission
-    on the repo.
     """
+    # A rerun dispatches rerun-test.yml, which never passes through pr-gate.yml,
+    # so it is unthrottled either way; gate on what pr-gate waives the limit for.
     if user_perms.get("cooldown_interval_minutes") == 0:
         return True
 
@@ -1321,8 +1317,7 @@ def main():
     # PR authors can always rerun failed CI on their own PRs, even if they are not
     # listed in CI_PERMISSIONS.json.
     # Note: /tag-run-ci-label still requires CI_PERMISSIONS.json.
-    # Note: authorship grants nothing for /rerun-test -- that is gated on the
-    # commenter's own trust level, see _check_rerun_test_permissions.
+    # Authorship grants nothing for /rerun-test; that gate reads the commenter.
     if pr.user.login == user_login:
         if user_perms is None:
             print(
@@ -1336,9 +1331,8 @@ def main():
             )
         user_perms["can_rerun_failed_ci"] = True
 
-    # No early exit on a missing entry: /rerun-test is gated on repo permission
-    # too, so a write-holder absent from the file must still reach its handler.
-    # The other commands re-check their own key and deny silently.
+    # No early exit on a missing entry: /rerun-test also gates on repo permission,
+    # so a write-holder absent from the file must still reach its handler.
     if user_perms is None:
         user_perms = {}
 

--- a/scripts/ci/utils/slash_command_handler.py
+++ b/scripts/ci/utils/slash_command_handler.py
@@ -1032,11 +1032,27 @@ def _dispatch_batch(gh_repo, pr, batch, token, reply_comment_id="", reply_marker
 def _check_rerun_test_permissions(gh_repo, pr, comment, user_perms, command_name):
     """
     Check permissions shared by /rerun-test and /rerun-group.
+
+    `can_rerun_test` is the only permission that clears a fork PR, and it counts
+    only when it comes from CI_PERMISSIONS.json -- main() marks PR authors with
+    `_is_pr_author` instead, so opening a fork PR never self-grants the fork
+    exemption.
     """
+    can_rerun_test = user_perms.get("can_rerun_test", False)
+
+    if not (
+        can_rerun_test
+        or user_perms.get("can_rerun_stage", False)
+        or user_perms.get("_is_pr_author", False)
+    ):
+        print(f"Permission denied: /{command_name} requires can_rerun_test.")
+        return False
+
     # SECURITY: These commands check out and execute code from the PR branch on
-    # self-hosted GPU runners, so fork PRs require a trusted collaborator.
+    # self-hosted GPU runners, so a fork PR needs either an explicit
+    # `can_rerun_test` grant or a trusted collaborator.
     is_fork = pr.head.repo is None or pr.head.repo.owner.login != gh_repo.owner.login
-    if is_fork:
+    if is_fork and not can_rerun_test:
         commenter = comment.user.login
         perm = gh_repo.get_collaborator_permission(commenter)
         if perm not in ("admin", "write"):
@@ -1044,18 +1060,12 @@ def _check_rerun_test_permissions(gh_repo, pr, comment, user_perms, command_name
             comment.create_reaction("confused")
             pr.create_issue_comment(
                 f"⛔ `/{command_name}` is not available for fork PRs unless the commenter "
-                "has write permission on the repo.\n\n"
+                "has `can_rerun_test` in `.github/CI_PERMISSIONS.json` or write "
+                "permission on the repo.\n\n"
                 "Please ask a maintainer to run this command, or use the normal CI flow."
             )
             return False
         print(f"Fork PR, but commenter {commenter} has write+ permission. Proceeding.")
-
-    if not (
-        user_perms.get("can_rerun_test", False)
-        or user_perms.get("can_rerun_stage", False)
-    ):
-        print("Permission denied: neither can_rerun_test nor can_rerun_stage is true.")
-        return False
 
     return True
 
@@ -1323,7 +1333,8 @@ def main():
     # PR authors can always rerun failed CI and rerun individual UTs on their own PRs,
     # even if they are not listed in CI_PERMISSIONS.json.
     # Note: /tag-run-ci-label still requires CI_PERMISSIONS.json.
-    # Note: /rerun-test is blocked entirely for fork PRs in handle_rerun_test() itself.
+    # Note: authorship is marked as `_is_pr_author`, never as `can_rerun_test` --
+    # only the latter clears a fork PR, and it must come from CI_PERMISSIONS.json.
     if pr.user.login == user_login:
         if user_perms is None:
             print(
@@ -1336,7 +1347,7 @@ def main():
                 f"User {user_login} is the PR author and has existing CI permissions."
             )
         user_perms["can_rerun_failed_ci"] = True
-        user_perms["can_rerun_test"] = True
+        user_perms["_is_pr_author"] = True
 
     if not user_perms:
         print(f"User {user_login} does not have any configured permissions. Exiting.")

--- a/test/README.md
+++ b/test/README.md
@@ -7,7 +7,7 @@ This page covers principles and essentials: folder layout, how to run tests, reg
 
 ## CI Pipeline Overview
 
-The CI pipeline runs in three sequential stages: **A** (pre-flight, ~3 min) → **B** (basic, ~30 min) → **C** (advanced, ~30 min). Kernel and multimodal-gen tests run in parallel with stage B. For details on stage gating, fast-fail mechanisms, execution modes (PR vs scheduled vs `/rerun-stage`), and debugging CI failures, see the [CI workflow guide](../.claude/skills/ci-workflow-guide/SKILL.md).
+The CI pipeline runs in three sequential stages: **A** (pre-flight, ~3 min) → **B** (basic, ~30 min) → **C** (advanced, ~30 min). Kernel and multimodal-gen tests run in parallel with stage B. For details on stage gating, fast-fail mechanisms, execution modes (PR vs scheduled vs manual dispatch), and debugging CI failures, see the [CI workflow guide](../.claude/skills/ci-workflow-guide/SKILL.md).
 
 ## Folder Organization
 


### PR DESCRIPTION
## Summary

- Remove `/rerun-stage` entirely: the command handler, its workflow trigger, the `can_rerun_stage` permission key, and every doc reference. The command has only posted a deprecation notice for a while; stage-level dispatch remains available through the Actions UI on the AMD workflows.
- Gate `/rerun-test` and `/rerun-group` on the commenter alone. Where the PR comes from is no longer part of the decision, and neither is PR authorship.

## Permission matrix

`/rerun-test` and `/rerun-group`, by commenter and PR origin:

| Commenter | Same-repo PR | Fork PR |
| --- | --- | --- |
| `write` / `admin` on the repo | allowed | allowed |
| `cooldown_interval_minutes: 0` | allowed | allowed |
| `cooldown_interval_minutes > 0` | denied | denied |
| Absent from `CI_PERMISSIONS.json` | denied | denied |

The two columns are identical by design. A selective rerun dispatches `rerun-test.yml` directly, which never passes through `pr-gate.yml`, so it bypasses that rate limit by construction -- anyone allowed to run one is unthrottled in practice. That is already what `cooldown_interval_minutes: 0` declares, and it is the same pair of signals `pr-gate.yml` itself uses to waive the limit (write permission, or a zero cooldown). So no new permission key is introduced; the existing cooldown value carries the trust level.

Authoring a PR grants nothing here. Authors keep their automatic `/rerun-failed-ci` allowance, which is unchanged.

## Changes

**Removals**
- Drop the `/rerun-stage` branch in `slash_command_handler.py` and its `contains()` clause in `slash-command-handler.yml`
- Drop `can_rerun_stage` from all 241 entries in `CI_PERMISSIONS.json` and from the `update_ci_permission.py` templates

**Gating**
- `_check_rerun_test_permissions` now checks `cooldown_interval_minutes == 0` first, then repo permission -- so trusted users cost zero extra API calls
- Remove the early exit in `main()` on a missing `CI_PERMISSIONS.json` entry, so a write-holder absent from the file reaches the handler. The other commands re-check their own key and still deny silently.

**Hardening**
- Pass `persist-credentials: false` on the three `rerun-test.yml` checkouts that can hold a fork's code. Without it, checkout leaves the job token in `.git/config`, where the code those jobs go on to execute could read it. The steps that need the token already take it from `secrets` explicitly, and nothing in those jobs runs git.
- Drop the workflow-level `actions: write` in `rerun-test.yml`. Every job declares its own `permissions`, which replaces rather than merges with the workflow-level block, so no job could ever obtain it.

**Docs**
- Record the permission keys and the cooldown/rerun coupling in `.github/FOLDER_README.md`
- Fix a pre-existing error in the `contribution_guide.mdx` permission table, which claimed a fork PR author had an automatic grant -- the fork check ran first, so an author without write was denied
- Retire `/rerun-stage` references in the ascend guide, `test/README.md`, the CI workflow guide, and the AMD workflow comments (where the `target_stage` input itself stays, since it is still dispatched from the Actions UI)

## Impact

Of the 241 entries in `CI_PERMISSIONS.json` (118 accounts hold repo write):

- 174 keep access -- 151 via `cooldown_interval_minutes: 0`, 23 more via write permission
- 67 lose it, all of them `"reason": "custom override"` with a non-zero cooldown. No `"top contributor"` entry is affected. Setting a user's cooldown to `0` restores it.
- 16 accounts with write permission but no entry in the file gain access

Note for #35600, which adds four entries to the same file: under this gating, `can_rerun_stage: true` on those entries has no effect -- granting them selective rerun means setting `cooldown_interval_minutes` to `0`. The two PRs also touch every entry in `CI_PERMISSIONS.json` and will conflict.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32422201099](https://github.com/sgl-project/sglang/actions/runs/32422201099)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32422200850](https://github.com/sgl-project/sglang/actions/runs/32422200850)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32422201197](https://github.com/sgl-project/sglang/actions/runs/32422201197)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->

