### PR TITLE
[Docker] Defer CUDA 13 NCCL override until after dependency resolution

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -171,11 +171,6 @@ ARG CUDA_VERSION
 ARG BUILD_TYPE
 ARG SGL_KERNEL_VERSION
 ARG GITHUB_ARTIFACTORY
-# Renamed from NCCL_VERSION: the nvidia/cuda base image sets ENV NCCL_VERSION
-# (Debian apt format, e.g. 2.28.3-1), which shadows a same-named ARG inside RUN,
-# so the CUDA-13 nvidia-nccl-cu13 pip install below resolved an invalid PyPI
-# version. A distinct ARG name avoids the collision.
-ARG SGL_NCCL_VERSION
 
 WORKDIR /sgl-workspace
 
@@ -251,10 +246,6 @@ RUN --mount=type=cache,target=/root/.cache/pip \
            sed -i 's/nvidia-cutlass-dsl\[cu13\]/nvidia-cutlass-dsl/' pyproject.toml; \
        fi \
     && python3 -m pip install --extra-index-url https://download.pytorch.org/whl/cu${CUINDEX} ".[${BUILD_TYPE}]" \
-    && if [ "${CUDA_VERSION%%.*}" = "13" ]; then \
-           python3 -m pip install --force-reinstall --no-deps \
-               "nvidia-nccl-cu13==${SGL_NCCL_VERSION}"; \
-       fi \
     && if [ "${CUDA_VERSION%%.*}" = "12" ]; then \
            pip list --format=freeze | awk -F'==' '/-cu13(==|$)/ {print $1}' \
                | xargs -r python3 -m pip uninstall -y && \
@@ -417,6 +408,9 @@ ARG USE_LATEST_SGLANG
 ARG GITHUB_ARTIFACTORY
 ARG MOONCAKE_VERSION
 ARG MSCCLPP_VERSION
+# Renamed from NCCL_VERSION: the nvidia/cuda base image sets ENV NCCL_VERSION
+# (Debian apt format, e.g. 2.28.3-1), which shadows a same-named ARG inside RUN.
+ARG SGL_NCCL_VERSION
 
 WORKDIR /sgl-workspace
 
@@ -536,6 +530,15 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     tabulate \
     termplotlib \
     "runai-model-streamer[s3,gcs,azure]>=0.15.7"
+
+# PyTorch 2.13 requires nvidia-nccl-cu13==2.29.7, so keep that version while
+# resolving dependencies and generating constraints.txt. DeepEP needs 2.30.7
+# at runtime; apply the override only after the constrained dependency solve.
+RUN --mount=type=cache,target=/root/.cache/pip \
+    if [ "${CUDA_VERSION%%.*}" = "13" ]; then \
+        python3 -m pip install --force-reinstall --no-deps \
+            "nvidia-nccl-cu13==${SGL_NCCL_VERSION}"; \
+    fi
 
 # Per-CUDA-major package installs. The `nixl` stub package is needed (it owns
 # the `nixl` import path) but unconditionally requires nixl-cu12, so we install


### PR DESCRIPTION
## Motivation

The CUDA 13 development image build fails during the constrained installation of development packages and `runai-model-streamer`:
https://github.com/sgl-project/sglang/actions/runs/32400623762/job/96527778687

PyTorch 2.13 requires `nvidia-nccl-cu13==2.29.7`, but the Dockerfile previously force-installed 2.30.7 before generating `constraints.txt`. The resulting constraint conflicts with Torch metadata when pip resolves the later package installation, causing extensive backtracking and eventually an unrelated-looking Matplotlib build failure.

## Modifications

- Keep the Torch-required NCCL 2.29.7 while generating `constraints.txt` and resolving the constrained development dependencies.
- Move the CUDA 13 NCCL 2.30.7 override after that dependency solve so the final image still satisfies the DeepEP runtime requirement.
- Move `SGL_NCCL_VERSION` into the Docker stage where it is consumed.
- Leave CUDA 12 behavior unchanged.

## Accuracy Tests

Not applicable. This changes Docker dependency installation order only.

## Speed Tests and Profiling

Not applicable.

## Validation

- Existing Docker metadata unit tests: 7 passed.
- `pre-commit run --files docker/Dockerfile`: passed.
- Dockerfile parser and NCCL ordering/ARG-scope checks: passed.
- A full CUDA 13 image build was not run locally because Docker is unavailable; CI will validate the complete build.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). Not added for this Dockerfile-only ordering fix.
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). No documentation update is needed.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Not applicable.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32420957493](https://github.com/sgl-project/sglang/actions/runs/32420957493)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32420957530](https://github.com/sgl-project/sglang/actions/runs/32420957530)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->