### PR TITLE
fix: FA4 paged-KV zero-size page-table registers on SM90

### DIFF
--- a/python/sglang/kernels/ops/attention/flash_attn/cute/paged_kv.py
+++ b/python/sglang/kernels/ops/attention/flash_attn/cute/paged_kv.py
@@ -93,7 +93,8 @@ class PagedKVManager(ParamsBase):
             atom_async_copy, thr_layout, val_layout
         )
         gmem_thr_copy_KV = gmem_tiled_copy_KV.get_slice(thread_idx)
-        page_entry_per_thread = n_block_size // num_threads
+        # Round up: tile_n can be smaller than num_threads (SM90 head_dim 256 -> 80).
+        page_entry_per_thread = cute.ceil_div(n_block_size, num_threads)
 
         if const_expr(mSFK_paged is not None or mSFV_paged is not None):
             atom_async_copy_sf = cute.make_copy_atom(


### PR DESCRIPTION
## Motivation

Serving `Qwen/Qwen3.8-27B-FP8` with `--attention-backend fa4` on a GH200 (Hopper, SM90) crashes in the scheduler during startup warmup, before the server ever accepts a request:

```
Generate warm up request for compiling DeepGEMM...
[2026-08-20 14:09:01] Scheduler hit an exception: Traceback (most recent call last):
  File "sglang/srt/managers/scheduler.py", line 5174, in run_scheduler_process
    scheduler.run_event_loop()
  [...]
  File "sglang/srt/models/qwen3_5.py", line 1212, in self_attention
    attn_output = self.attn(q, k, v, forward_batch)
  File "sglang/srt/layers/attention/hybrid_linear_attn_backend.py", line 1134, in forward_extend
    return self.full_attn_backend.forward_extend(
  File "sglang/srt/layers/attention/flashattention_backend.py", line 1496, in forward_extend
    result = flash_attn_with_kvcache(
  File "sglang/kernels/ops/attention/flash_attention_v4.py", line 276, in flash_attn_with_kvcache
    result = flash_attn_varlen_func(
  File "sglang/kernels/ops/attention/flash_attn/cute/interface.py", line 1628, in _flash_attn_fwd
    _flash_attn_fwd.compile_cache[compile_key] = cute.compile(
  [... CUTLASS DSL trace-building frames elided ...]
  File "sglang/kernels/ops/attention/flash_attn/cute/flash_fwd_sm90.py", line 806, in then_block_9
    self.load(
  File "sglang/kernels/ops/attention/flash_attn/cute/flash_fwd_sm90.py", line 983, in while_after_block_2
    paged_kv_manager = PagedKVManager.create(
  File "sglang/kernels/ops/attention/flash_attn/cute/paged_kv.py", line 119, in create
    tPrPage = cute.make_rmem_tensor((page_entry_per_thread,), Int32)
  [...]
  File "nvidia_cutlass_dsl/dsl_packages/cutlass/cute/core.py", line 339, in _check_shape
    raise ValueError(
        f"Expected size in shape to be strictly positive, but got {shape}"
    )
ValueError: Expected size in shape to be strictly positive, but got 0
```

Environment: GH200 480GB (SM90), CUDA 13.2, `nvidia-cutlass-dsl` 4.6.2, sglang built from source at `eac91ac36` (line numbers above are from that commit). Reproduced with:

```
python -m sglang.launch_server --model-path Qwen/Qwen3.8-27B-FP8 \
  --attention-backend fa4 --kv-cache-dtype auto \
  --speculative-algorithm DFLASH \
  --speculative-draft-model-path z-lab/Qwen3.8-27B-DFlash2 \
  --speculative-num-draft-tokens 8
```

### Root cause

`PagedKVManager.create()` sizes its per-thread page-table registers with a floor division:

```python
page_entry_per_thread = n_block_size // num_threads   # num_threads = 128
```

When `tile_n < 128` this evaluates to `0`, and `cute.make_rmem_tensor((0,), Int32)` fails the shape check above.

Qwen3.8-27B's full-attention layers have `head_dim=256`, and `_tile_size_fwd_sm90()` returns `tile_n = 80` for that head dim (64 with a sliding window). sglang's default `page_size=1` never equals `tile_n`, so the non-TMA cp.async path — the one that stages the page table in registers — is always the one selected. So every paged-KV FA4 run on SM90 at `head_dim=256` hits this; `head_dim=192` is affected too (`tile_n` 112 / 96).

This is the same assertion seen in #32118 (merged) and #31903, but those addressed the SM100 diff-headdim split-KV case by not shrinking `tile_n` to 64 in `interface.py`; the division itself was left as-is. That doesn't cover SM90, where `tile_n = 80` is not a conditional shrink but the tile the heuristic picks unconditionally — there is no configuration that steers around it.

Upstream FA4 (`Dao-AILab/flash-attention`, `flash_attn/cute/paged_kv.py`) already uses ceiling division here, with a comment about counting the final partially populated wave of rows. sglang's vendored copy diverged.

## Modifications

One line in `python/sglang/kernels/ops/attention/flash_attn/cute/paged_kv.py`: use `cute.ceil_div` instead of floor division.

Why `ceil` is the right size rather than merely non-zero: `load_KV()` indexes `tPrXPtr[m // gmem_threads_per_row]` for `m` in `range(n_block_size * gmem_threads_per_row / num_threads)`, so the largest index used needs exactly `ceil(n_block_size / num_threads)` entries. The entries this over-allocates when `n_block_size < num_threads` are already predicated off by the `row < n_block_size` check in `load_page_table()` (which writes `page = 0`), and are never consumed by the `shuffle_sync` in `load_KV()`.

Risk is limited to configurations that cannot currently run: `ceil == floor` whenever `n_block_size % num_threads == 0`, which is true of every tile that compiles today, so those kernels are bit-identical.

## Accuracy Tests

Standalone script calling `flash_attn_with_kvcache` on the paged path, checked against an fp32 SDPA reference, on GH200 (SM90). Deliberately shuffled page tables so page-index/offset mix-ups can't hide. Every case fails to compile on `main` and passes with this change:

| case | page_size | causal | window | max abs err |
|---|---|---|---|---|
| b1, s_q=s_k=512 | 1 | yes | – | 0.0156 |
| b3 ragged, s_q=[300,17,128], s_k=[300,1000,128] | 1 | yes | – | 0.0156 |
| b4 spec-decode, s_q=8, s_k=[513,80,81,1024] | 1 | yes | – | 0.0039 |
| b2, non-causal | 1 | no | – | 0.0039 |
| b2, multi-token pages | 64 | yes | – | 0.0156 |
| b2, sliding window (tile_n=64) | 1 | yes | (256, 0) | 0.0078 |

(`ref_absmax` ≈ 1.3–4.1, so these are bf16 rounding.)

End-to-end: `Qwen/Qwen3.8-27B-FP8` on GH200 with `--attention-backend fa4` now completes startup warmup and serves. A 7044-token prompt with a needle placed mid-context returned the needle exactly, which exercises many `n_block` iterations of the cp.async page-table path rather than just compilation.

Not covered: SM100. `ceil == floor` for the tiles that arch uses, so no behavior change is expected there, but I don't have Blackwell hardware to confirm.

## Speed Tests and Profiling

No impact. `page_entry_per_thread` is a compile-time constant and the generated kernel is unchanged for every configuration that compiles today.

## Follow-up (deliberately not in this PR)

With the root cause fixed, the `not (page_table is not None and q_stage == 1)` guard added by #32118 could likely be relaxed to restore its SMEM-saving `tile_n = 64` for SM100 diff-headdim decode. I can't validate that without Blackwell, so I've left it alone.

## Note on test coverage

`test/registered/attention/unittests/dense/test_fa4.py` runs `HEAD_DIM = 64` only, which is why this went unnoticed — no FA4 test exercises a `tile_n` that isn't a multiple of 128. Precedent: #32118 fixed the same assertion in this subsystem and validated it with a standalone repro rather than a committed test. Happy to add a regression case (here or under `test/registered/kernels/ops/attention/`) gated to SM90 if reviewers want one; `1-gpu-large` is an H100 runner, so it would genuinely guard this.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32422366336](https://github.com/sgl-project/sglang/actions/runs/32422366336)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32422366126](https://github.com/sgl-project/sglang/actions/runs/32422366126)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32422366252](https://github.com/sgl-project/sglang/actions/runs/32422366252)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->