### PR TITLE
[DSA] Bound the indexer MQA-logits chunk: read free memory live, and cap the chunk absolutely

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1376,6 +1376,18 @@ class Envs:
         False, deprecated_name="SGLANG_NSA_HIP_DISABLE_PRESHUFFLE"
     )
     SGLANG_DSA_MQA_LOGITS_FREE_MEM_FRACTION = EnvFloat(0.2)
+    # Absolute ceiling on ONE MQA-logits chunk in the DSA indexer's ragged
+    # prefill path. The fraction above is applied to free memory, which cannot
+    # tell you whether one large CONTIGUOUS block is obtainable, and which in
+    # the opposite regime would authorize a tens-of-GiB allocation on a
+    # nearly-empty device. A chunk this size is servable from the allocator's
+    # existing free blocks. 0 disables the cap.
+    SGLANG_DSA_MQA_LOGITS_MAX_CHUNK_BYTES = EnvInt(256 * 1024 * 1024)
+    # How long a free-memory reading may be reused, in seconds. 0 (default)
+    # never reuses one; > 0 reuses for that long; < 0 reuses forever (the
+    # previous behavior). Reading live is affordable because the budget is only
+    # requested for logits matrices above _MQA_LOGITS_STATIC_SKIP_ELEMS.
+    SGLANG_DSA_MQA_LOGITS_BUDGET_CACHE_S = EnvFloat(0.0)
     SGLANG_ENABLE_PCG_DSV2_DUAL_STREAM = EnvBool(False)
     SGLANG_DSA_TOPK_BROADCAST = EnvBool(False)
     SGLANG_DISABLE_DSA_INDEXER_FUSION = EnvBool(False)

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import time
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 import torch
@@ -202,10 +203,38 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
     _MQA_LOGITS_STATIC_SKIP_ELEMS = 8_000_000
     _MQA_LOGITS_TOTAL_MEM_FRACTION = 0.3
     _mqa_logits_budget_bytes: Dict[int, int] = {}
+    # device_index -> time.monotonic() when _mqa_logits_budget_bytes was measured.
+    _mqa_logits_budget_at: Dict[int, float] = {}
 
     @staticmethod
     def _mqa_logits_free_mem_fraction() -> float:
         return envs.SGLANG_DSA_MQA_LOGITS_FREE_MEM_FRACTION.get()
+
+    @staticmethod
+    def _mqa_logits_max_chunk_bytes() -> int:
+        return envs.SGLANG_DSA_MQA_LOGITS_MAX_CHUNK_BYTES.get()
+
+    @staticmethod
+    def _mqa_logits_budget_cache_s() -> float:
+        return envs.SGLANG_DSA_MQA_LOGITS_BUDGET_CACHE_S.get()
+
+    @classmethod
+    def _clamp_mqa_logits_budget(cls, budget_bytes: int) -> int:
+        """Apply the absolute per-chunk cap, then the 1-byte floor.
+
+        This is the part a live free-memory reading cannot provide:
+        contiguity. "Free" bytes may be split across segments the allocator
+        cannot merge, so a large contiguous request fails while free memory
+        looks ample. The cap also bounds the opposite regime, where a fraction
+        of a nearly-empty device would authorize a tens-of-GiB allocation.
+        <= 0 disables it. The floor keeps _get_topk_ragged's
+        max_rows = max(1, budget // bytes_per_row) making progress even when the
+        cap is smaller than one row of the logits matrix.
+        """
+        max_chunk_bytes = cls._mqa_logits_max_chunk_bytes()
+        if max_chunk_bytes > 0:
+            budget_bytes = min(budget_bytes, max_chunk_bytes)
+        return max(1, budget_bytes)
 
     def __init__(
         self,
@@ -957,9 +986,24 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
 
     def _get_mqa_logits_budget_bytes(self, device_index: int) -> int:
         free_mem_fraction = self._mqa_logits_free_mem_fraction()
+        cache_s = self._mqa_logits_budget_cache_s()
         cached_budget = self._mqa_logits_budget_bytes.get(device_index)
-        if cached_budget is not None:
-            return cached_budget
+        # This budget IS the chunk allocation size (see _get_topk_ragged), so a
+        # reading that is allowed to go stale eventually over-states what can be
+        # allocated: one plentiful-memory snapshot would authorize that same
+        # allocation for the life of the process. Default to taking a fresh
+        # reading every time (cache_s == 0). That is affordable because the only
+        # caller, _should_chunk_mqa_logits, returns before asking unless the
+        # logits matrix exceeds _MQA_LOGITS_STATIC_SKIP_ELEMS -- so free memory
+        # is queried only when a large GEMM is about to run anyway.
+        # cache_s > 0 reuses a reading for that long; cache_s < 0 forever.
+        if cached_budget is not None and cache_s != 0.0:
+            if (
+                cache_s < 0.0
+                or time.monotonic() - self._mqa_logits_budget_at.get(device_index, 0.0)
+                < cache_s
+            ):
+                return cached_budget
 
         total_mem = torch.cuda.get_device_properties(device_index).total_memory
 
@@ -979,7 +1023,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         # caching it. The first non-capture prefill path will cache the real
         # free-memory budget below.
         if get_is_capture_mode():
-            return static_budget
+            return self._clamp_mqa_logits_budget(static_budget)
 
         # Match the original free-memory guard: logits_bytes * 2 > free_mem.
         # torch.cuda.mem_get_info synchronizes the host, so cache the result,
@@ -987,8 +1031,9 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         free_mem, _ = torch.cuda.mem_get_info(device_index)
         budget_bytes = min(int(free_mem * free_mem_fraction), static_budget)
 
-        budget_bytes = max(1, budget_bytes)
+        budget_bytes = self._clamp_mqa_logits_budget(budget_bytes)
         self._mqa_logits_budget_bytes[device_index] = budget_bytes
+        self._mqa_logits_budget_at[device_index] = time.monotonic()
         return budget_bytes
 
     def _should_chunk_mqa_logits(

--- a/test/registered/attention/test_dsa_mqa_logits_budget.py
+++ b/test/registered/attention/test_dsa_mqa_logits_budget.py
@@ -1,0 +1,206 @@
+"""Unit tests for the DSA indexer's MQA-logits chunk budget.
+
+``Indexer._get_topk_ragged`` derives ``max_rows`` by dividing the budget by the
+logits row size, so **the budget is the chunk allocation size**. Two properties
+therefore matter and are pinned here:
+
+* the free-memory reading behind it is taken fresh, so a reading from when
+  memory was plentiful cannot keep authorizing that allocation forever;
+* it never exceeds ``SGLANG_DSA_MQA_LOGITS_MAX_CHUNK_BYTES`` -- the part a live
+  reading cannot give you, since free bytes may be too fragmented to serve one
+  large contiguous request, and since a fraction of a nearly-empty device would
+  authorize a tens-of-GiB allocation.
+
+The numbers are from a real crash: a DSA + EAGLE-MTP prefill on a 178.35 GiB
+device where the cached snapshot authorized a 2.63 GiB chunk while 2.20 GiB was
+free, and the scheduler died inside ``deep_gemm.fp8_mqa_logits``.
+"""
+
+import types
+import unittest
+from unittest import mock
+
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=15, stage="base-b", runner_config="1-gpu-small")
+
+GiB = 1 << 30
+MiB = 1 << 20
+
+TOTAL_MEM = int(178.35 * GiB)
+FREE_AT_SNAPSHOT = int(13.15 * GiB)
+FREE_AT_CRASH = int(2.20 * GiB)
+MEM_FRACTION_STATIC = 0.92
+FRAC = 0.2
+CRASH_ALLOC = int(2.63 * GiB)
+CAP = 256 * MiB
+CACHE_S = 30.0  # only the reuse tests opt into a window
+DEVICE = 0
+
+# The crashing call: a 32768-token prefill chunk with no cached prefix, i.e. a
+# 32768 x 32768 fp32 logits matrix (4.00 GiB).
+Q_OFFSET = 32768
+K_OFFSET = 32768
+
+
+class _FreeMem:
+    """Scriptable ``torch.cuda.mem_get_info`` that counts its calls."""
+
+    def __init__(self, free):
+        self.free = free
+        self.calls = 0
+
+    def __call__(self, device_index=None):
+        self.calls += 1
+        return (self.free, TOTAL_MEM)
+
+
+class TestDSAMqaLogitsBudget(CustomTestCase):
+    def setUp(self):
+        import sglang.srt.layers.attention.dsa.dsa_indexer as dsa_mod
+        from sglang.srt.environ import envs
+
+        self.dsa_mod = dsa_mod
+        self.envs = envs
+        self.Indexer = dsa_mod.Indexer
+        # No __init__: only class attributes and the budget methods are needed.
+        self.obj = self.Indexer.__new__(self.Indexer)
+
+        self.Indexer._mqa_logits_budget_bytes.clear()
+        self.Indexer._mqa_logits_budget_at.clear()
+        self.addCleanup(self.Indexer._mqa_logits_budget_bytes.clear)
+        self.addCleanup(self.Indexer._mqa_logits_budget_at.clear)
+
+        envs.SGLANG_DSA_MQA_LOGITS_FREE_MEM_FRACTION.set(FRAC)
+        envs.SGLANG_DSA_MQA_LOGITS_MAX_CHUNK_BYTES.set(CAP)
+        envs.SGLANG_DSA_MQA_LOGITS_BUDGET_CACHE_S.set(0.0)  # live, the default
+        self.addCleanup(envs.SGLANG_DSA_MQA_LOGITS_FREE_MEM_FRACTION.clear)
+        self.addCleanup(envs.SGLANG_DSA_MQA_LOGITS_MAX_CHUNK_BYTES.clear)
+        self.addCleanup(envs.SGLANG_DSA_MQA_LOGITS_BUDGET_CACHE_S.clear)
+
+        # Deterministic clock, scoped to the module under test.
+        self.now = 1000.0
+        clock = mock.patch.object(
+            dsa_mod, "time", types.SimpleNamespace(monotonic=lambda: self.now)
+        )
+        clock.start()
+        self.addCleanup(clock.stop)
+
+        props = mock.patch.object(
+            dsa_mod.torch.cuda,
+            "get_device_properties",
+            lambda idx: types.SimpleNamespace(total_memory=TOTAL_MEM),
+        )
+        props.start()
+        self.addCleanup(props.stop)
+
+        self._set_mem_fraction_static(MEM_FRACTION_STATIC)
+        capture = mock.patch.object(dsa_mod, "get_is_capture_mode", lambda: False)
+        capture.start()
+        self.addCleanup(capture.stop)
+
+    def _set_mem_fraction_static(self, value):
+        patcher = mock.patch.object(
+            self.dsa_mod,
+            "get_schedule",
+            lambda: types.SimpleNamespace(mem_fraction_static=value),
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def _budget(self, free):
+        fm = _FreeMem(free)
+        with mock.patch.object(self.dsa_mod.torch.cuda, "mem_get_info", fm):
+            return self.obj._get_mqa_logits_budget_bytes(DEVICE), fm
+
+    def test_premise_uncapped_snapshot_would_authorize_the_crashing_chunk(self):
+        """Without the cap, this snapshot authorizes the 2.63 GiB allocation."""
+        self.envs.SGLANG_DSA_MQA_LOGITS_MAX_CHUNK_BYTES.set(0)
+        budget, _ = self._budget(FREE_AT_SNAPSHOT)
+        self.assertGreaterEqual(budget, CRASH_ALLOC)
+        self.assertGreater(budget, FREE_AT_CRASH)
+
+    def test_budget_respects_the_absolute_cap(self):
+        budget, _ = self._budget(FREE_AT_SNAPSHOT)
+        self.assertLessEqual(budget, CAP)
+        self.assertLess(budget, FREE_AT_CRASH)
+
+    def test_chunk_rows_fit_the_cap(self):
+        need_chunk, budget = self.obj._should_chunk_mqa_logits(
+            Q_OFFSET, K_OFFSET, DEVICE
+        )
+        self.assertTrue(need_chunk, "a 4 GiB logits matrix must be chunked")
+        # Mirror _get_topk_ragged's own sizing.
+        bytes_per_row = K_OFFSET * self.obj._MQA_LOGITS_BYTES_PER_ELEM
+        max_rows = min(max(1, budget // bytes_per_row), Q_OFFSET)
+        self.assertLessEqual(max_rows * bytes_per_row, CAP)
+        self.assertGreaterEqual(max_rows, 1)
+
+    def test_small_matrices_still_skip_the_budget_entirely(self):
+        self.assertEqual(
+            self.obj._should_chunk_mqa_logits(1000, 1000, DEVICE), (False, 0)
+        )
+
+    def test_default_takes_a_fresh_reading_every_call(self):
+        first, fm1 = self._budget(FREE_AT_SNAPSHOT)
+        self.assertEqual(fm1.calls, 1)
+        second, fm2 = self._budget(FREE_AT_CRASH)
+        self.assertEqual(fm2.calls, 1, "the default must not reuse a reading")
+        self.assertLessEqual(first, CAP)
+        self.assertLessEqual(second, int(FREE_AT_CRASH * FRAC))
+
+    def test_reading_is_reused_inside_an_explicit_window(self):
+        self.envs.SGLANG_DSA_MQA_LOGITS_BUDGET_CACHE_S.set(CACHE_S)
+        first, _ = self._budget(FREE_AT_SNAPSHOT)
+        self.now += CACHE_S - 1.0
+        second, fm = self._budget(FREE_AT_CRASH)
+        self.assertEqual(first, second)
+        self.assertEqual(fm.calls, 0, "mem_get_info syncs the host; do not re-query")
+
+    def test_window_expires_and_the_budget_shrinks(self):
+        self.envs.SGLANG_DSA_MQA_LOGITS_BUDGET_CACHE_S.set(CACHE_S)
+        first, _ = self._budget(FREE_AT_SNAPSHOT)
+        self.now += CACHE_S + 1.0
+        second, fm = self._budget(int(0.5 * GiB))
+        self.assertEqual(fm.calls, 1)
+        self.assertLess(second, first)
+        self.assertLessEqual(second, int(0.5 * GiB * FRAC))
+
+    def test_capture_mode_neither_queries_nor_caches(self):
+        with mock.patch.object(self.dsa_mod, "get_is_capture_mode", lambda: True):
+            budget, fm = self._budget(FREE_AT_SNAPSHOT)
+        self.assertEqual(fm.calls, 0)
+        self.assertLessEqual(budget, CAP)
+        _, fm2 = self._budget(FREE_AT_SNAPSHOT)
+        self.assertEqual(fm2.calls, 1, "capture must not seed the cache")
+
+    def test_both_knobs_off_restore_the_previous_behaviour(self):
+        self.envs.SGLANG_DSA_MQA_LOGITS_MAX_CHUNK_BYTES.set(0)
+        self.envs.SGLANG_DSA_MQA_LOGITS_BUDGET_CACHE_S.set(-1.0)
+        first, _ = self._budget(FREE_AT_SNAPSHOT)
+        self.now += 10_000.0
+        second, fm = self._budget(FREE_AT_CRASH)
+        self.assertEqual(first, int(FREE_AT_SNAPSHOT * FRAC))
+        self.assertEqual(first, second)
+        self.assertEqual(fm.calls, 0)
+
+    def test_budget_floor_keeps_the_chunk_loop_progressing(self):
+        self.envs.SGLANG_DSA_MQA_LOGITS_MAX_CHUNK_BYTES.set(1)
+        budget, _ = self._budget(FREE_AT_SNAPSHOT)
+        self.assertGreaterEqual(budget, 1)
+        # One row of a 512k-token context is 1.95 MiB, far above the cap.
+        self.assertGreaterEqual(max(1, budget // (512_000 * 4)), 1)
+
+    def test_no_free_memory_still_yields_a_positive_budget(self):
+        budget, _ = self._budget(0)
+        self.assertGreaterEqual(budget, 1)
+
+    def test_unset_mem_fraction_static_falls_back_to_the_total_mem_cap(self):
+        self._set_mem_fraction_static(None)
+        budget, _ = self._budget(FREE_AT_SNAPSHOT)
+        self.assertLessEqual(budget, CAP)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`_get_topk_ragged` chunks the MQA-logits matrix to avoid OOM, and sizes each chunk as

```python
bytes_per_row = k_offset * self._MQA_LOGITS_BYTES_PER_ELEM
max_rows = max(1, int(logits_budget_bytes // max(bytes_per_row, 1)))
```

so **`_get_mqa_logits_budget_bytes()` is the size of every chunk allocation**. That budget comes
from a single `torch.cuda.mem_get_info` reading, taken on the first non-capture prefill past
`_MQA_LOGITS_STATIC_SKIP_ELEMS`, cached in a **class-level** dict shared by every `Indexer`
instance in the process, and never revalidated. A reading taken while memory was plentiful
therefore keeps authorizing that same multi-GiB allocation for the life of the process.

Observed on a DSA + EAGLE-MTP prefill (178.35 GiB device, TP8, `--chunked-prefill-size 32768`,
`--mem-fraction-static 0.92`):

```
tvm.error.InternalError: CUDA out of memory. Tried to allocate 2.63 GiB.
GPU 3 has a total capacity of 178.35 GiB of which 2.20 GiB is free.
... 4.70 GiB allocated in private pools (e.g., CUDA Graphs), and 6.46 GiB
is reserved by PyTorch but unallocated.
[...] Received SIGQUIT. Scheduler failed/hung; shutting down.
```

with the traceback landing on the **chunked** branch:

```
dsa_indexer.py  _get_topk_ragged
  logits_chunk = deep_gemm.fp8_mqa_logits(   <-- the guard fired, and still
deep_gemm/__init__.py  fp8_mqa_logits            asked for 6x the free memory
  -> torch::empty -> CUDACachingAllocator::malloc
```

`token usage: 0.06` on the same log line — this is not KV pressure. Working backwards from the
log alone: a 2.63 GiB allocation implies a budget ≥ 2.63 GiB, hence ≥ 13.15 GiB free when it was
measured (`frac` 0.2); free at crash was 2.20 GiB. The missing 10.95 GiB matches the log's
4.70 GiB of CUDA-graph private pools plus 6.46 GiB reserved-but-unallocated (11.16 GiB) to
within 2%.

**Speculative decoding makes this systematically worse.** `_draft_extend_for_prefill` builds its
batch with `ForwardBatch.init_new(...)`, which keeps the prefill batch's `EXTEND` mode, so it
misses the `is_draft_extend_v2() -> _get_topk_paged` path and issues the same ragged chunk the
target model just issued — except now the target's prefill activations are still live and the
overlap scheduler has two batches in flight. The target's identical allocation succeeding
moments earlier is not evidence that the draft's will.

Two secondary factors, both addressed by the cap below: the chunk size varies per request (it
depends on `k_offset`), so the caching allocator accumulates large, oddly-sized segments that
cannot be recycled — which is exactly what "6.46 GiB reserved but unallocated" is, enough memory
in the wrong shapes for a request needing 2.63 GiB *contiguous*.

## Modifications

The cache was introduced deliberately in #25299 (replacing a live per-call check) because
`mem_get_info` synchronizes the host. This keeps that intent and closes both holes:

| Env | Default | Effect |
|---|---|---|
| `SGLANG_DSA_MQA_LOGITS_BUDGET_CACHE_S` | `0` = never reuse a reading | Kills the staleness outright. `> 0` reuses a reading for that long, `< 0` reuses forever (today's behaviour). |
| `SGLANG_DSA_MQA_LOGITS_MAX_CHUNK_BYTES` | 256 MiB | Caps one chunk absolutely — the part a live reading **cannot** give you. `0` disables. |

**Why reading live is affordable here.** `_should_chunk_mqa_logits` returns before asking for a
budget unless the logits matrix exceeds `_MQA_LOGITS_STATIC_SKIP_ELEMS` (32 MB), so the query
only happens when the engine is about to spend milliseconds on a large GEMM. The gate was
already there; this change just stops caching across it.

**Why the cap is still needed once the reading is live.** Two things `mem_get_info` cannot tell
you:

1. *Contiguity.* The 6.46 GiB "reserved by PyTorch but unallocated" above is enough free bytes in
   the wrong shapes — segments the allocator cannot merge for one large contiguous request. A
   256 MiB chunk is servable out of those existing blocks.
2. *The opposite regime.* 20% of free memory on a nearly-empty 178 GiB device is a **35 GiB single
   allocation**. Correct by the budget's own logic, and a fragmentation and latency disaster.

So the two bind in different regimes — the cap normally, the live reading once free memory falls
below it. Capture mode is unchanged: static budget, no query, no caching. Setting the cap to `0`
and the cache to `-1` restores today's behaviour exactly, so there is no separate feature-off
path to maintain.

**Prior art, corrected.** I initially cited the DSV4 indexer's `_QUERY_CHUNK = 1024` as
precedent for a fixed cap — that was wrong, and I'd rather flag it than leave it standing: that
constant is in `fp8_paged_mqa_logits_torch_sm120`, a pure-torch SM120 fallback for *paged
decode* that chunks the batch dimension, not a peer of this path. `main`'s C4/DSV4 non-paged
path has no budget at all. The real prior art is **#33288** (unmerged, on
`origin/image/dev20260805-211ee642-swafix`), which hit this same stale-cache bug in the C4
indexer and also chose to re-read live, with the comment:

> The cached budget is calculated once (typically right after CUDA-graph capture when free memory
> is near its peak) and never updated. At prefill time the actual free memory can be
> significantly lower due to KV-cache occupancy and prefill activations, so a chunk sized from
> the stale cache can still OOM.

It uses `0.5 × free` capped at `0.3 × total` and no absolute cap, and it additionally routes
per-request so the `k` axis is one request's padded length rather than the concatenated batch —
a bigger, orthogonal win for multi-request prefill that I have deliberately not attempted here.
Happy to align the two indexers on whatever shape reviewers prefer.

Deliberately out of scope to keep this reviewable, happy to follow up:

- retrying with a halved chunk on `torch.OutOfMemoryError` (+ `empty_cache()`) so a transient
  allocator state costs latency rather than the whole server;
- `_get_topk_ragged_with_cp`, which calls `fp8_mqa_logits` with **no chunking guard at all**.

## Accuracy Tests

No numerical change, by construction: the chunk loop slices strictly per row —
`ks[start:end]`, `seq_lens_expanded[start:end]`, `global_topk_offset[start:end]`,
`token_to_batch_idx[start:end]` — and `topk_transform` is called per chunk with those slices, so
results do not depend on how the query axis is partitioned. Only the number of partitions
changes. The `not need_chunk` fast path is untouched for any matrix that fits the cap.

## Benchmarking and Profiling

Not measured, and I would rather say so than guess: total logits work is unchanged (same matrix,
same FLOPs), so only the launch count moves. For the crashing shape (`q = k = 32768`, a 4.00 GiB
fp32 matrix) that is **2 chunks of 2630 MiB → 16 chunks of 256 MiB**. Raising
`SGLANG_DSA_MQA_LOGITS_MAX_CHUNK_BYTES` recovers the old chunking exactly if a regression does
show up on some shape.

## Checklist

- [x] Format your code according to the pre-commit config
- [x] Add unit tests — `test/registered/attention/test_dsa_mqa_logits_budget.py`, 12 cases
      driving the real methods with the numbers from the crash log:
      the uncapped premise (a test that *asserts the bug*, so the regression cannot silently
      stop being one), the capped budget, the derived chunk-row count, the
      `_MQA_LOGITS_STATIC_SKIP_ELEMS` fast path, snapshot reuse inside the window vs. expiry
      after it, capture mode (asserts `mem_get_info` is **not** called and the cache is not
      seeded), both knobs off, the ≥1-row floor at a 512k context, zero free memory, and
      `mem_fraction_static = None`. Registered
      `register_cuda_ci(est_time=15, stage="base-b", runner_config="1-gpu-small")`.
- [ ] Update documentation — no user-facing docs; both knobs are documented where they are
      declared in `srt/environ.py`.
- [ ] Provide accuracy and speed benchmark results — see the two sections above.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32432387561](https://github.com/sgl-project/sglang/actions/runs/32432387561)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32432386894](https://github.com/sgl-project/sglang/actions/runs/32432386894)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32432387461](https://github.com/sgl-project/sglang/actions/runs/32432387461)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->