### PR TITLE
Add Cloud Agent dev environment (CPU: lint + Rust services)

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "name": "SGLang (CPU: lint + Rust services)",
+  "install": "bash .cursor/install.sh"
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Idempotent Cloud Agent bootstrap for SGLang.
+#
+# This VM is CPU-only, so it targets the parts of SGLang that build and run
+# without a GPU: the contributor lint/CI toolchain (pre-commit) and the Rust
+# workspaces (rust/ services and the sgl-model-gateway router). The full
+# CUDA serving stack (torch==2.13.0, flashinfer, sgl-kernel, ...) requires an
+# NVIDIA GPU and the lmsysorg/sglang image and is intentionally not installed
+# here.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# pip --user installs console scripts here.
+export PATH="$HOME/.local/bin:$PATH"
+# Make the system rust toolchain manager available to every phase.
+export PATH="${CARGO_HOME:-$HOME/.cargo}/bin:$PATH"
+
+echo "==> [1/5] System build dependencies"
+# The rust/ workspace compiles C++ deps (e.g. esaxx-rs, pulled in by the
+# HuggingFace tokenizers crate) through clang, which targets the gcc-14
+# libstdc++ headers. The base image ships only libstdc++-13-dev, so <cstdint>
+# and friends are missing without this. libssl-dev/pkg-config cover any
+# openssl-sys build. apt-get is a no-op when the packages are already present.
+if command -v sudo >/dev/null 2>&1 && command -v apt-get >/dev/null 2>&1; then
+  sudo apt-get update -qq
+  # protobuf-compiler + libprotobuf-dev: sgl-model-gateway's smg-grpc-client
+  # builds .proto files via prost-build, which needs a system protoc (no
+  # vendored fallback) plus the well-known types (google/protobuf/*.proto)
+  # that ship in libprotobuf-dev.
+  # redis-server: the gateway's Redis history-backend integration tests spawn a
+  # local redis-server on a random port (tests/common/redis_test_server.rs).
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends \
+    libstdc++-14-dev libssl-dev pkg-config protobuf-compiler libprotobuf-dev redis-server
+fi
+
+echo "==> [2/5] Python lint/CI tooling (pre-commit)"
+python3 -m pip install --user --quiet --upgrade pre-commit
+# Warm every hook environment (isort, ruff, black, codespell, clang-format,
+# nbstripout, ...) so the first real `pre-commit run` is fast. Safe to re-run.
+pre-commit install-hooks
+# Install the git hook so commits are linted locally.
+pre-commit install >/dev/null 2>&1 || true
+
+echo "==> [3/5] Rust toolchains"
+# rust/ pins 1.92 and sgl-model-gateway pins 1.90 via rust-toolchain.toml, so
+# rustup fetches them on first cargo invocation. The fmt pre-commit hooks use a
+# nightly rustfmt; install it up front so linting works offline afterwards.
+rustup toolchain install nightly --profile minimal --component rustfmt 2>/dev/null || \
+  rustup component add --toolchain nightly rustfmt 2>/dev/null || true
+
+echo "==> [4/5] Build rust/ workspace (gRPC, mm, server)"
+( cd rust && cargo build --workspace )
+
+echo "==> [5/5] Build sgl-model-gateway (router/control plane)"
+( cd sgl-model-gateway && cargo build )
+
+echo "==> SGLang Cloud Agent environment ready."
+echo "    Lint:            pre-commit run --all-files"
+echo "    Rust tests:      (cd rust && cargo test --workspace)"
+echo "    Gateway tests:   (cd sgl-model-gateway && cargo test)"
+echo "    Run the router:  (cd sgl-model-gateway && cargo run --bin sgl-model-gateway -- --help)"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Cursor Cloud Agent development environment for SGLang via `.cursor/environment.json` (repo-managed) + an idempotent `.cursor/install.sh`. It uses Cursor's default base image and installs everything from the install script, so merging this PR activates the environment for future Cloud Agents on `main` automatically (no dashboard Save needed).

The Cloud Agent VM is CPU-only, so this environment targets the parts of SGLang that build and run without a GPU:

- The contributor lint/CI toolchain (`pre-commit`), mirroring the `Lint` GitHub Actions workflow (isort, ruff, black, codespell, clang-format, nbstripout, the local lint-script unit tests, and all Rust `rustfmt`/`clippy` hooks).
- The Rust workspaces: `rust/` (gRPC / multimodal / server crates) and `sgl-model-gateway/` (the router / control plane), both buildable and testable on CPU.

The full CUDA serving stack (`torch==2.13.0`, flashinfer, sgl-kernel, ...) needs an NVIDIA GPU and the `lmsysorg/sglang` image, and is intentionally out of scope for this CPU environment.

## What `install.sh` does

1. Installs the system build deps the default image is missing:
   - `libstdc++-14-dev` — `esaxx-rs` (pulled in by the HuggingFace `tokenizers` crate) is compiled by clang, which targets the gcc-14 libstdc++ headers; the base image ships only `libstdc++-13-dev`, so `<cstdint>` is otherwise unresolved.
   - `libssl-dev` / `pkg-config` — cover any `openssl-sys` build.
   - `protobuf-compiler` + `libprotobuf-dev` — the gateway's `smg-grpc-client` uses `prost-build` with a system `protoc` (no vendored fallback) plus the well-known types (`google/protobuf/*.proto`).
   - `redis-server` — the gateway's Redis history-backend integration test spawns a local instance.
2. Installs `pre-commit` and warms all hook environments.
3. Installs a nightly `rustfmt` (used by the fmt hooks) and builds the `rust/` workspace and `sgl-model-gateway`.

## Validation

Validated on the CPU VM:

- `pre-commit run --all-files` — all hooks pass (Python + clang-format + Rust fmt/clippy).
- `cd rust && cargo test --workspace` — 287 tests pass.
- `cd sgl-model-gateway && cargo test` — 840 tests pass.
- Install idempotence — re-running `install.sh` is a clean no-op (~9s).
- End-to-end: launched `sgl-model-gateway`, confirmed `/liveness` returns `200 OK`, `/parse/reasoning` splits `<think>` reasoning from the answer, and `/parse/function_call` extracts the tool call.

Validated via a prebuilt environment build (fresh cold build on the default image from this branch, then verified in a fresh Cloud Agent booted from that exact build):

- Build `bld-20260820-9eb4ff4e` (default image + `install.sh`, cold) — SUCCEEDED, all 5 install phases green.
- Fresh Cloud Agent from that build — 6/6 checks pass: toolchains present, all gateway binaries + rust libs built, `pre-commit run --all-files` all-pass, `rust/` tests 287/0, and the gateway `/liveness` + `/parse/reasoning` e2e both return HTTP 200.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c39c2658-9553-42f7-8ef2-59d9fe2ad66f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c39c2658-9553-42f7-8ef2-59d9fe2ad66f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32425609825](https://github.com/sgl-project/sglang/actions/runs/32425609825)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32425609914](https://github.com/sgl-project/sglang/actions/runs/32425609914)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->