### PR TITLE
[AMD][CI] Fix ROCm 7.0's dead apt index fail the MORI dependency install

### DIFF
--- a/scripts/ci/amd/amd_ci_install_dependency.sh
+++ b/scripts/ci/amd/amd_ci_install_dependency.sh
@@ -265,14 +265,15 @@ if docker exec ci_sglang test -d /sgl-workspace/mori; then
   fi
 
   echo "[MORI] Reinstalling MORI ${MORI_COMMIT} (MORI_GPU_ARCHS=${MORI_GPU_ARCHS})"
-  # Neither apt step may be fatal. libgrpc++-dev is optional -- rocm.Dockerfile
-  # builds MORI without it -- and the ROCm base image carries an AMD-internal
-  # artifactory source (rocm-osdb) whose index 404s whenever a ROCm build is
-  # rotated out. apt-get update exits 100 on that while still keeping every
-  # index it did fetch, so under set -e one dead third-party source we do not
-  # even install from takes out the dependency install on every AMD runner at
-  # once. Retries are already configured image-wide (Acquire::Retries) and do
-  # not help against a 404.
+  # Only the rocm724 (noble) base is missing libgrpc++-dev; 7.0 and 7.2.0 built
+  # MORI without it for months before this step existed, so skip the apt round
+  # trip there. Where it does run, neither step may be fatal: apt-get update
+  # exits 100 for a single unreachable index while still keeping every index it
+  # did fetch, which under set -e is enough to take out the dependency install
+  # on every AMD runner at once. Six external apt hosts are in play, so the
+  # guard is not specific to the rocm-osdb source that first triggered this.
+  # Retries are already configured image-wide (Acquire::Retries) and do not
+  # help against a 404.
   docker exec ci_sglang bash -c "
     set -euo pipefail
     export MORI_GPU_ARCHS='${MORI_GPU_ARCHS}'
@@ -281,8 +282,10 @@ if docker exec ci_sglang test -d /sgl-workspace/mori; then
     cd /sgl-workspace/mori
     git checkout '${MORI_COMMIT}'
     git submodule update --init --recursive
-    apt-get update || echo '[MORI] apt-get update reported errors; continuing with the indexes it did fetch'
-    apt-get install -y --no-install-recommends libgrpc++-dev || echo '[MORI] libgrpc++-dev unavailable; building MORI without it'
+    if [ '${IMAGE_STAGE_SUFFIX}' = '-rocm724' ]; then
+      apt-get update || echo '[MORI] apt-get update reported errors; continuing with the indexes it did fetch'
+      apt-get install -y --no-install-recommends libgrpc++-dev || echo '[MORI] libgrpc++-dev unavailable; building MORI without it'
+    fi
     python3 setup.py develop
     python3 -c 'import os, torch; print(os.path.join(os.path.dirname(torch.__file__), \"lib\"))' > /etc/ld.so.conf.d/torch.conf
     ldconfig

--- a/scripts/ci/amd/amd_ci_install_dependency.sh
+++ b/scripts/ci/amd/amd_ci_install_dependency.sh
@@ -261,6 +261,14 @@ if docker exec ci_sglang test -d /sgl-workspace/mori; then
   fi
 
   echo "[MORI] Reinstalling MORI ${MORI_COMMIT} (MORI_GPU_ARCHS=${MORI_GPU_ARCHS})"
+  # Neither apt step may be fatal. libgrpc++-dev is optional -- rocm.Dockerfile
+  # builds MORI without it -- and the ROCm base image carries an AMD-internal
+  # artifactory source (rocm-osdb) whose index 404s whenever a ROCm build is
+  # rotated out. apt-get update exits 100 on that while still keeping every
+  # index it did fetch, so under set -e one dead third-party source we do not
+  # even install from takes out the dependency install on every AMD runner at
+  # once. Retries are already configured image-wide (Acquire::Retries) and do
+  # not help against a 404.
   docker exec ci_sglang bash -c "
     set -euo pipefail
     export MORI_GPU_ARCHS='${MORI_GPU_ARCHS}'
@@ -269,8 +277,8 @@ if docker exec ci_sglang test -d /sgl-workspace/mori; then
     cd /sgl-workspace/mori
     git checkout '${MORI_COMMIT}'
     git submodule update --init --recursive
-    apt-get update
-    apt-get install -y --no-install-recommends libgrpc++-dev 2>/dev/null || true
+    apt-get update || echo '[MORI] apt-get update reported errors; continuing with the indexes it did fetch'
+    apt-get install -y --no-install-recommends libgrpc++-dev || echo '[MORI] libgrpc++-dev unavailable; building MORI without it'
     python3 setup.py develop
     python3 -c 'import os, torch; print(os.path.join(os.path.dirname(torch.__file__), \"lib\"))' > /etc/ld.so.conf.d/torch.conf
     ldconfig

--- a/test/registered/unit/tools/test_amd_ci_install_dependency.py
+++ b/test/registered/unit/tools/test_amd_ci_install_dependency.py
@@ -1,0 +1,136 @@
+"""Regression tests for scripts/ci/amd/amd_ci_install_dependency.sh.
+
+The MORI reinstall runs its apt steps inside `docker exec ... bash -c` under
+`set -euo pipefail`, where a bare `apt-get` is fatal. `apt-get update` exits
+100 when any single index is unreachable, even though it keeps every index it
+did fetch -- so one dead source in the ROCm base image fails the whole
+"Install dependencies" step on every AMD runner at once. That is what took
+out ~25 of 27 jobs in pr-test-amd run 32399046576 when AMD's internal
+rocm-osdb artifactory started 404ing.
+
+The packages those steps install are optional (rocm.Dockerfile builds MORI
+without them), so none of them may abort the run.
+"""
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+INSTALL_SCRIPT = REPO_ROOT / "scripts" / "ci" / "amd" / "amd_ci_install_dependency.sh"
+
+BUILD_MARKER = "MORI_BUILD_REACHED"
+INSTALL_MARKER = "APT_INSTALL_RAN"
+
+# Replays the observed failure: the rocm-osdb index 404s, every other index is
+# fetched fine, and apt-get update still exits 100. APT_UPDATE_OK /
+# APT_INSTALL_OK select which half of the world is healthy.
+APT_STUB = """#!/bin/bash
+case "$1" in
+  update)
+    echo "Get:1 https://archive.ubuntu.com/ubuntu jammy InRelease [270 kB]"
+    echo "Fetched 48.0 MB in 3s (18.2 MB/s)"
+    [ "${APT_UPDATE_OK}" = 1 ] && exit 0
+    echo "Err:13 http://compute-artifactory.amd.com/artifactory/list/rocm-osdb-22.04-deb compute-rocm-rel-7.0/38 amd64 Packages" >&2
+    echo "  404  Not Found [IP: 10.216.51.87 80]" >&2
+    echo "E: Some index files failed to download. They have been ignored, or old ones used instead." >&2
+    exit 100
+    ;;
+  install)
+    [ "${APT_INSTALL_OK}" = 1 ] || { echo "E: Unable to locate package" >&2; exit 100; }
+    echo "APT_INSTALL_RAN"
+    ;;
+esac
+"""
+
+
+def _mori_shell_body(script: str) -> str:
+    """Body of the `docker exec ... bash -c "..."` that reinstalls MORI."""
+    marker = 'docker exec ci_sglang bash -c "'
+    start = script.index(marker, script.index("[MORI] Reinstalling MORI")) + len(marker)
+    body = script[start:]
+    return body[: body.index('\n  "')]
+
+
+class TestAmdCiInstallDependencyApt(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        body = _mori_shell_body(INSTALL_SCRIPT.read_text())
+        cls.apt_lines = [
+            line for line in body.splitlines() if line.strip().startswith("apt-get")
+        ]
+        # Without this the tests below would pass vacuously if the block were
+        # ever restructured out from under them.
+        assert cls.apt_lines, "found no apt-get lines in the MORI reinstall block"
+        # The block is a double-quoted host string, so a `$` in these lines
+        # would be expanded before the container ever sees them; replaying them
+        # verbatim would then not reflect what really runs.
+        assert not any("$" in line for line in cls.apt_lines), cls.apt_lines
+
+    def run_apt_lines(self, *, update_ok: str, install_ok: str):
+        """Run the real apt lines in the context the container gives them."""
+        with tempfile.TemporaryDirectory() as stub_dir:
+            stub = Path(stub_dir) / "apt-get"
+            stub.write_text(APT_STUB)
+            stub.chmod(0o755)
+            return subprocess.run(
+                [
+                    "bash",
+                    "-c",
+                    "set -euo pipefail\n"
+                    + "\n".join(self.apt_lines)
+                    + f"\necho {BUILD_MARKER}\n",
+                ],
+                env={
+                    **os.environ,
+                    "PATH": stub_dir + os.pathsep + os.environ["PATH"],
+                    "APT_UPDATE_OK": update_ok,
+                    "APT_INSTALL_OK": install_ok,
+                },
+                capture_output=True,
+                text=True,
+            )
+
+    def test_dead_apt_index_does_not_abort_the_dependency_install(self):
+        result = self.run_apt_lines(update_ok="0", install_ok="1")
+        self.assertIn(
+            BUILD_MARKER,
+            result.stdout,
+            f"a 404 on one apt index aborted the MORI build:\n{result.stderr}",
+        )
+        self.assertEqual(result.returncode, 0)
+
+    def test_unavailable_optional_package_does_not_abort_the_dependency_install(self):
+        result = self.run_apt_lines(update_ok="0", install_ok="0")
+        self.assertIn(
+            BUILD_MARKER,
+            result.stdout,
+            f"an unavailable optional package aborted the MORI build:\n{result.stderr}",
+        )
+        self.assertEqual(result.returncode, 0)
+
+    def test_healthy_apt_still_installs_the_optional_packages(self):
+        result = self.run_apt_lines(update_ok="1", install_ok="1")
+        self.assertIn(INSTALL_MARKER, result.stdout)
+        self.assertIn(BUILD_MARKER, result.stdout)
+        self.assertEqual(result.returncode, 0)
+
+    def test_every_mori_apt_line_stays_guarded(self):
+        for line in self.apt_lines:
+            self.assertIn(
+                "||",
+                line,
+                "unguarded apt step under `set -e` will fail every AMD job "
+                f"whenever a single apt source is unreachable: {line.strip()}",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/tools/test_amd_ci_install_dependency.py
+++ b/test/registered/unit/tools/test_amd_ci_install_dependency.py
@@ -1,135 +1,44 @@
-"""Regression tests for scripts/ci/amd/amd_ci_install_dependency.sh.
+"""Guard on the apt calls in scripts/ci/amd/amd_ci_install_dependency.sh.
 
-The MORI reinstall runs its apt steps inside `docker exec ... bash -c` under
-`set -euo pipefail`, where a bare `apt-get` is fatal. `apt-get update` exits
-100 when any single index is unreachable, even though it keeps every index it
-did fetch -- so one dead source in the ROCm base image fails the whole
-"Install dependencies" step on every AMD runner at once. That is what took
-out ~25 of 27 jobs in pr-test-amd run 32399046576 when AMD's internal
-rocm-osdb artifactory started 404ing.
+Those calls run under `set -euo pipefail`, and `apt-get update` exits 100 when
+any single index is unreachable -- even though it keeps every index it did
+fetch. An unguarded call therefore fails the whole "Install dependencies" step
+on every AMD runner at once, which is what took out ~25 of 27 jobs in
+pr-test-amd run 32399046576 when AMD's internal rocm-osdb artifactory started
+404ing on an index this repo never installs from.
 
-The packages those steps install are optional (rocm.Dockerfile builds MORI
-without them), so none of them may abort the run.
+The packages involved are optional -- rocm.Dockerfile builds MORI without them
+-- so no apt call here may be able to abort the run.
 """
 
-import os
-import subprocess
-import tempfile
+import re
 import unittest
 from pathlib import Path
 
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
-register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
 
-REPO_ROOT = Path(__file__).resolve().parents[4]
-INSTALL_SCRIPT = REPO_ROOT / "scripts" / "ci" / "amd" / "amd_ci_install_dependency.sh"
-
-BUILD_MARKER = "MORI_BUILD_REACHED"
-INSTALL_MARKER = "APT_INSTALL_RAN"
-
-# Replays the observed failure: the rocm-osdb index 404s, every other index is
-# fetched fine, and apt-get update still exits 100. APT_UPDATE_OK /
-# APT_INSTALL_OK select which half of the world is healthy.
-APT_STUB = """#!/bin/bash
-case "$1" in
-  update)
-    echo "Get:1 https://archive.ubuntu.com/ubuntu jammy InRelease [270 kB]"
-    echo "Fetched 48.0 MB in 3s (18.2 MB/s)"
-    [ "${APT_UPDATE_OK}" = 1 ] && exit 0
-    echo "Err:13 http://compute-artifactory.amd.com/artifactory/list/rocm-osdb-22.04-deb compute-rocm-rel-7.0/38 amd64 Packages" >&2
-    echo "  404  Not Found [IP: 10.216.51.87 80]" >&2
-    echo "E: Some index files failed to download. They have been ignored, or old ones used instead." >&2
-    exit 100
-    ;;
-  install)
-    [ "${APT_INSTALL_OK}" = 1 ] || { echo "E: Unable to locate package" >&2; exit 100; }
-    echo "APT_INSTALL_RAN"
-    ;;
-esac
-"""
-
-
-def _mori_shell_body(script: str) -> str:
-    """Body of the `docker exec ... bash -c "..."` that reinstalls MORI."""
-    marker = 'docker exec ci_sglang bash -c "'
-    start = script.index(marker, script.index("[MORI] Reinstalling MORI")) + len(marker)
-    body = script[start:]
-    return body[: body.index('\n  "')]
+INSTALL_SCRIPT = (
+    Path(__file__).resolve().parents[4] / "scripts/ci/amd/amd_ci_install_dependency.sh"
+)
 
 
 class TestAmdCiInstallDependencyApt(CustomTestCase):
-    @classmethod
-    def setUpClass(cls):
-        body = _mori_shell_body(INSTALL_SCRIPT.read_text())
-        cls.apt_lines = [
-            line for line in body.splitlines() if line.strip().startswith("apt-get")
+    def test_apt_calls_cannot_abort_the_dependency_install(self):
+        unguarded = [
+            line.strip()
+            for line in INSTALL_SCRIPT.read_text().splitlines()
+            if re.match(r"\s*(sudo\s+)?apt-get\b", line) and "||" not in line
         ]
-        # Without this the tests below would pass vacuously if the block were
-        # ever restructured out from under them.
-        assert cls.apt_lines, "found no apt-get lines in the MORI reinstall block"
-        # The block is a double-quoted host string, so a `$` in these lines
-        # would be expanded before the container ever sees them; replaying them
-        # verbatim would then not reflect what really runs.
-        assert not any("$" in line for line in cls.apt_lines), cls.apt_lines
-
-    def run_apt_lines(self, *, update_ok: str, install_ok: str):
-        """Run the real apt lines in the context the container gives them."""
-        with tempfile.TemporaryDirectory() as stub_dir:
-            stub = Path(stub_dir) / "apt-get"
-            stub.write_text(APT_STUB)
-            stub.chmod(0o755)
-            return subprocess.run(
-                [
-                    "bash",
-                    "-c",
-                    "set -euo pipefail\n"
-                    + "\n".join(self.apt_lines)
-                    + f"\necho {BUILD_MARKER}\n",
-                ],
-                env={
-                    **os.environ,
-                    "PATH": stub_dir + os.pathsep + os.environ["PATH"],
-                    "APT_UPDATE_OK": update_ok,
-                    "APT_INSTALL_OK": install_ok,
-                },
-                capture_output=True,
-                text=True,
-            )
-
-    def test_dead_apt_index_does_not_abort_the_dependency_install(self):
-        result = self.run_apt_lines(update_ok="0", install_ok="1")
-        self.assertIn(
-            BUILD_MARKER,
-            result.stdout,
-            f"a 404 on one apt index aborted the MORI build:\n{result.stderr}",
+        self.assertEqual(
+            unguarded,
+            [],
+            "an unguarded apt-get under `set -e` fails the dependency install on "
+            "every AMD runner whenever one apt source is unreachable; give it an "
+            "`|| echo ...` fallback",
         )
-        self.assertEqual(result.returncode, 0)
-
-    def test_unavailable_optional_package_does_not_abort_the_dependency_install(self):
-        result = self.run_apt_lines(update_ok="0", install_ok="0")
-        self.assertIn(
-            BUILD_MARKER,
-            result.stdout,
-            f"an unavailable optional package aborted the MORI build:\n{result.stderr}",
-        )
-        self.assertEqual(result.returncode, 0)
-
-    def test_healthy_apt_still_installs_the_optional_packages(self):
-        result = self.run_apt_lines(update_ok="1", install_ok="1")
-        self.assertIn(INSTALL_MARKER, result.stdout)
-        self.assertIn(BUILD_MARKER, result.stdout)
-        self.assertEqual(result.returncode, 0)
-
-    def test_every_mori_apt_line_stays_guarded(self):
-        for line in self.apt_lines:
-            self.assertIn(
-                "||",
-                line,
-                "unguarded apt step under `set -e` will fail every AMD job "
-                f"whenever a single apt source is unreachable: {line.strip()}",
-            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Fixes cluster **R387** from the Aug-20 AMD CI monitor report: all 27 jobs in [PR Test ROCm 7.0 (AMD) run 32399046576](https://github.com/sgl-project/sglang/actions/runs/32399046576), plus the nightly-7.0 kimi-k26 job, died identically in "Install dependencies".

The report filed this as pure infra needing an AMD artifactory restore. **It is also a code regression, it is specific to ROCm 7.0, and the code half is fixable here.** From the failing [job log](https://github.com/sgl-project/sglang/actions/runs/32399046576/job/96522664507):

```
Err:13 http://compute-artifactory.amd.com/artifactory/list/rocm-osdb-22.04-deb compute-rocm-rel-7.0/38 amd64 Packages
  404  Not Found [IP: 10.216.51.87 80]
Fetched 48.0 MB in 3s (18.2 MB/s)
E: Some index files failed to download. They have been ignored, or old ones used instead.
##[error]Process completed with exit code 100.
```

### Where it came from

The `apt-get update` is new. It was added on 2026-08-20 by c7478228dd (#30984, the ROCm 7.2.4 / Python 3.12 / torch 2.11 upgrade), inside a `docker exec ... bash -c` that runs under `set -euo pipefail`:

```bash
git submodule update --init --recursive
apt-get update
apt-get install -y --no-install-recommends libgrpc++-dev 2>/dev/null || true
```

Every *other* change that PR made to this script is gated on the image flavor — the extras swap (`dev_hip` → `dev_hip_rocm724`), the AITER `torch.Stream` patch, and the AITER commit lookup all sit behind `IMAGE_STAGE_SUFFIX == "-rocm724"`. These two apt lines are the only ungated change in the PR, so a 7.2.4 fix also began running on ROCm 7.0. Before that commit the MORI reinstall did no apt work at all and was immune.

### Why only ROCm 7.0

Not because the code path is 7.0-specific — the identical path runs on 7.2.4 and passes. It is purely base-image lineage:

| Flavor | Base image | `rocm-osdb` source |
|---|---|---|
| 7.0 | `rocm/sgl-dev:rocm7-vllm-20250904` (AMD-internal dev image) | **yes** |
| 7.2.0 | `rocm/pytorch:rocm7.2_ubuntu22.04_py3.10_pytorch_release_2.9.1` | no |
| 7.2.4 | `rocm/pytorch:rocm7.2.4_ubuntu24.04_py3.12_pytorch_release_2.10.0` | no |

Only 7.0 builds on an AMD-internal image, which is what drags in `compute-artifactory.amd.com/.../rocm-osdb-22.04-deb`. The dead index name encodes it exactly: `compute-rocm-rel-7.0/38` is the internal ROCm 7.0 release channel, build 38.

Confirmed against a real 7.2.4 job from the same day ([96420374950](https://github.com/sgl-project/sglang/actions/runs/32367546070/job/96420375378)), which runs the same MORI reinstall and the same `apt-get update` and succeeds, fetching 40.1 MB cleanly. Its apt hosts are entirely public, with no `compute-artifactory.amd.com` entry. (7.2.0 is inferred from the same public lineage rather than observed — nothing currently runs it, since the PR gate defaults to `rocm724`.)

### Why the guard is not just about rocm-osdb

That step reaches **six** external apt hosts:

```
http://compute-artifactory.amd.com     ← the one that died
https://apt.llvm.org
https://archive.ubuntu.com
https://packages.broadcom.com
https://ppa.launchpadcontent.net
https://repo.radeon.com
```

`apt-get update` returns non-zero if *any* index fails, so under `set -e` each of those six is a single point of failure for the whole AMD fleet — for a package that is optional. This is not hypothetical: R391, the cluster that turned the AMD docker build red the same day, was an `apt.llvm.org` GPG/curl failure, also on that list.

Note too that apt itself treated the failure as recoverable — "They have been ignored, or old ones used instead" — and every index we actually use fetched fine. Nothing in this repo installs from `rocm-osdb`; it is inherited from the base image.

## Modifications

`scripts/ci/amd/amd_ci_install_dependency.sh` only. Two changes, addressing the root cause and the blast radius separately:

**1. Run the apt step only on `rocm724`.** Only that base actually lacks the package — its job log shows `libgrpc++-dev` "previously unselected", downloaded from `noble/universe` and unpacked. ROCm 7.0 and 7.2.0 built MORI without it for months before #30984, so there the apt round trip is pure risk, and 7.0 is precisely the image carrying the dead source. This restores pre-#30984 behaviour on 7.0/7.2.0 rather than merely tolerating the failure there.

**2. Keep both apt steps non-fatal where they do run**, and log which one degraded:

```bash
if [ '${IMAGE_STAGE_SUFFIX}' = '-rocm724' ]; then
  apt-get update || echo '[MORI] apt-get update reported errors; continuing with the indexes it did fetch'
  apt-get install -y --no-install-recommends libgrpc++-dev || echo '[MORI] libgrpc++-dev unavailable; building MORI without it'
fi
```

The gate alone would fix the reported incident but leave 7.2.4 exposed to the other five hosts; the guard alone would tolerate a failure that 7.0 and 7.2.0 need not risk at all. Dropping `2>/dev/null` in favour of an explicit message keeps a degraded install visible instead of swallowing it.

No retry logic is added: the image already sets `Acquire::Retries "5"` via `/etc/apt/apt.conf.d/80-net-hardening` (visible in the log as the repeated `Ign:13` attempts), and a 404 is not retryable.

This was the only unguarded `apt-get update` left in the AMD CI path; every other one under `scripts/ci/` is already `|| true` or wrapped in a retry loop, matching `scripts/ci/cuda/ci_install_dependency.sh`.

**`test/registered/unit/tools/test_amd_ci_install_dependency.py`** — a 45-line guard asserting that no `apt-get` call in this script can abort the run. It runs on `base-a-test-cpu` (no docker, no ROCm, no GPU) alongside the existing CI-tooling tests in `test/registered/unit/tools/`.

It carries more weight than it looks, because **no pull-request-triggered workflow can catch this regression**. `pr-test-amd.yml` (ROCm 7.0) was demoted to a daily shadow in #34204 and now has only `schedule` / `workflow_dispatch` / `workflow_call` triggers — no `pull_request`. The PR gate is `pr-test-amd-rocm720.yml`, which defaults to `rocm724`. So the image carrying the dead index is never exercised pre-merge, and the static check is the only pre-merge signal on this invariant.

### Not addressed here

Removing the `rocm-osdb` source from the ROCm 7.0 image itself would be the cleanest cleanup, but it needs a `docker/rocm.Dockerfile` change plus an image rebuild — and `release-docker-amd-nightly` is currently red (R391), so it could not ship now. It would also only remove one of the six hosts. Worth a separate PR once the image pipeline is healthy.

## Accuracy Tests

Not applicable — CI dependency-install script and its test only; no runtime or model code touched.

## Speed Tests and Profiling

Not applicable.

## Verification

The unit test fails against the pre-fix script, naming the offending line, and passes against the fix:

```
# against the pre-fix script
AssertionError: Lists differ: ['apt-get update'] != []

# against this branch
1 passed
```

The flavor gate was verified by expanding it for each `IMAGE_STAGE_SUFFIX` value against a stub `apt-get` that exits 100, checking both whether apt ran and whether the MORI build after it is still reached:

```
PASS  flavor='<7.0>'      apt ran: no   build reached: yes
PASS  flavor='-rocm720'   apt ran: no   build reached: yes
PASS  flavor='-rocm724'   apt ran: yes  build reached: yes
```

While developing the original guard I also replayed the incident end to end — a stub `apt-get` reproducing the 404 and exit 100, driving the apt lines extracted from the script inside the same `set -euo pipefail` context — confirming the MORI build is still reached both when `libgrpc++-dev` remains resolvable and when it does not, with no regression on the healthy path.

Also run: the full `test/registered/unit/tools/` directory (12 passed), `run_suite.py` collection with `sanity_check=True` plus `validate_all_suites` over all registered files (clean; the new test resolves into `base-a-test-cpu`), `shellcheck -S warning` (no new findings — the only remaining warning is a pre-existing `SC2034`), `bash -n`, `black`, `isort`, `ruff`, `codespell`, and the `check-registered-tests` / `check-no-bare-pytest-main` lint hooks.

**Note for reviewers:** this PR's own AMD CI cannot reproduce R387 — it runs 7.2.4, whose public base has no `rocm-osdb` source. In-situ validation needs the daily `pr-test-amd.yml` cron (17:30 UTC) or a manual `workflow_dispatch` of it.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — n/a.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). — n/a.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32442764695](https://github.com/sgl-project/sglang/actions/runs/32442764695)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32442764522](https://github.com/sgl-project/sglang/actions/runs/32442764522)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32442764708](https://github.com/sgl-project/sglang/actions/runs/32442764708)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->