### PR TITLE
Avoid MAX_LEN padding for prefill BCG when a DP rank is idle

### DIFF
--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -1318,12 +1318,25 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
         # graph; larger prefills fall back to eager and keep the
         # memory-efficient SUM_LEN. global_num_tokens is identical across ranks
         # (all-gathered), so the decision is consistent cluster-wide.
+        #
+        # Also require every DP rank to hold real tokens. Under MAX_LEN an
+        # idle rank fabricates a dummy EXTEND request whose tokens are
+        # counted as real (num_token_non_padded, deliberately: a zero-token
+        # rank starves the MoE all-to-all), so they bypass the topk_ids=-1
+        # dispatch mask and enter the shared EP grouped GEMMs. That changes
+        # per-expert batch sizes for every rank's real tokens; the resulting
+        # reduction-order noise flips near-boundary top-k routing decisions
+        # and compounds across layers into nats-scale, run-to-run
+        # nondeterministic logit shifts on LIVE requests (#31125). Fall back
+        # to SUM_LEN (eager prefill) for idle-rank steps until a zero-token
+        # rank can participate in the A2A with masked padding.
         prefill_cg = model_runner.server_args.cuda_graph_config.prefill
         if (
             self.can_run_dp_breakable_cuda_graph
             and self.is_extend_in_batch
             and prefill_cg.bs
             and max(global_num_tokens) <= max(prefill_cg.bs)
+            and min(global_num_tokens) > 0
         ):
             dp_padding_mode = DpPaddingMode.MAX_LEN
         self.dp_padding_mode = dp_padding_mode

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -1320,16 +1320,11 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
         # (all-gathered), so the decision is consistent cluster-wide.
         #
         # Also require every DP rank to hold real tokens. Under MAX_LEN an
-        # idle rank fabricates a dummy EXTEND request whose tokens are
-        # counted as real (num_token_non_padded, deliberately: a zero-token
-        # rank starves the MoE all-to-all), so they bypass the topk_ids=-1
-        # dispatch mask and enter the shared EP grouped GEMMs. That changes
-        # per-expert batch sizes for every rank's real tokens; the resulting
-        # reduction-order noise flips near-boundary top-k routing decisions
-        # and compounds across layers into nats-scale, run-to-run
-        # nondeterministic logit shifts on LIVE requests (#31125). Fall back
-        # to SUM_LEN (eager prefill) for idle-rank steps until a zero-token
-        # rank can participate in the A2A with masked padding.
+        # idle rank fabricates a dummy request whose tokens are counted as
+        # real, and we measure nondeterministic accuracy degradation on the
+        # live ranks' logits when those dummy tokens enter the shared MoE
+        # ops (#31125). Fall back to SUM_LEN for idle-rank steps, which runs
+        # the prefill eagerly instead of with the breakable CUDA graphs.
         prefill_cg = model_runner.server_args.cuda_graph_config.prefill
         if (
             self.can_run_dp_breakable_cuda_graph

--- a/test/registered/models_e2e/test_deepseek_v4_flash_fp4_b200.py
+++ b/test/registered/models_e2e/test_deepseek_v4_flash_fp4_b200.py
@@ -170,17 +170,6 @@ class TestDSV4FlashFP4BreakableCudaGraphB200(
 
     gsm8k_accuracy_thres = 0.93
 
-    @unittest.skip(
-        "Flaky: temp-0 outputs are nondeterministic under this recipe "
-        "(sparse-DP prefill replays the breakable CUDA graph with a "
-        "fabricated idle-rank dummy extend; its hidden states vary run to "
-        "run and perturb real tokens' logits through the shared EP grouped "
-        "GEMMs at capture buckets 4/16). Introduced by #30898; disabled "
-        "pending a proper fix that keeps BCG enabled. See #31125."
-    )
-    def test_determinism_temp_zero(self):
-        pass
-
     @classmethod
     def setUpClass(cls):
         cls.model = try_cached_model(MODEL)


### PR DESCRIPTION
Under MAX_LEN a zero-token rank fabricates a dummy EXTEND request whose tokens are counted as real (deliberately, to avoid starving the MoE all-to-all), so they bypass the dispatch mask and enter the shared EP grouped GEMMs. The changed per-expert batch sizes perturb live requests' logits nondeterministically (up to 0.21 nats measured). Fall back to SUM_LEN (eager prefill) for idle-rank steps and re-enable the determinism test that was skipped for this bug.

## Motivation & Modifications

Adds a fix to avoid breakable prefill cuda graph replay with DP attention where at least one rank has zero tokens. Follows the chain of #30898, #31125, #31487, #31705.

When using breakable cuda graphs + DP attention for prefill, we pad data to match the expected replay graph shape for collective ops under MAX_LEN mode. A mask will keep track of which tokens are non-padded. However, when a rank is idle, we fabricate a request set to max_len and set `num_token_non_padded` to this max_len (see comment [here](https://github.com/sgl-project/sglang/blob/f3beb2c52903ad77202a1e307017996d1ada22a1/python/sglang/srt/model_executor/forward_batch_info.py#L1465-L1470) explaining why). This seems to perturb downstream MoE operations for live ranks and ultimately corrupt the resulting logits.

The solution is to check for an idle rank and not enable MAX_LEN mode in this case. Under the current logic, this will hence run eagerly instead of with BCG. Also Re-enables the determinism test skipped in #31125.

It seems like this failsafe already [exists](https://github.com/sgl-project/sglang/blob/54c44fef73e784a1390308d7cc3732d635244a8d/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py#L743-L752) but doesn't function as intended because of how `global_num_tokens_cpu` is re-written after padding by `prepare_mlp_sync_batch` under MAX_LEN mode (see below): https://github.com/sgl-project/sglang/blob/f3beb2c52903ad77202a1e307017996d1ada22a1/python/sglang/srt/model_executor/forward_batch_info.py#L1373 and https://github.com/sgl-project/sglang/blob/f3beb2c52903ad77202a1e307017996d1ada22a1/python/sglang/srt/model_executor/forward_batch_info.py#L1494

## Additional Explanation (from Claude)

Two different kinds of padding result:

- A rank with fewer tokens than the max appends **pad token rows**. These
  are masked out of MoE dispatch (`topk_ids[i >= num_token_non_padded] = -1`)
  and excluded from attention output. Harmless.
- A rank with **zero** tokens has no request to pad, so it **fabricates a
  dummy EXTEND request** -- and then deliberately counts its tokens as real
  (`num_token_non_padded.fill_(num_tokens)`), because a rank contributing
  zero tokens to the MoE all-to-all starves the EP layers (see the comment
  at the fill site). The dummy's tokens therefore bypass the dispatch mask
  and enter the shared DeepEP expert buffers alongside every other rank's
  real tokens.

## Why unmasked dummy tokens perturb OTHER requests' logits

Per-token MoE math is independent in exact arithmetic; the coupling is
numerical, and it compounds:

1. **Dummy tokens change each expert's batch size.** Expert parallelism
   physically groups tokens from all DP ranks by expert into shared buffers
   and runs one grouped GEMM per expert segment. Dispatched dummy tokens
   occupy rows in those segments, so the per-expert token counts (the M
   dimensions of the grouped GEMM) differ from the no-dummy execution.
2. **GEMM outputs are not batch-size-invariant.** deep_gemm/grouped kernels
   pick tilings, split strategies, and accumulation orders as a function of
   segment sizes. A real token's output row is mathematically identical
   under any order, but in FP8/BF16 the floating-point sum differs at the
   last-bits level when the reduction order changes. (This is the ordinary
   reason temp-0 outputs vary with batch composition; masked padding does
   NOT trigger it precisely because masked rows are never dispatched.)
3. **MoE routing turns tiny noise into discrete divergence.** The router is
   a top-k over expert scores: a last-bits perturbation flips the expert
   choice of any real token near a top-k boundary. A flipped token computes
   through a different expert -- a macroscopically different value -- and
   feeds the next layer. Over ~60 MoE layers these flips compound.
4. **The dummy content itself varies run to run** (fabricated request state
   is not derived from any real workload), so its routing -- and hence the
   perturbation pattern of steps 1-3 -- differs per run: nondeterminism, not
   just bias. Measured effect: around 0.21 nats on live tokens' output
   logprobs (a ~23% probability change; reduction-order noise alone is
   ~1e-6), enough to flip greedy argmax mid-generation. Up to 0.459 on DSv4-Pro.

The #31125 skip message reached the same conclusion ("its hidden states
vary run to run and perturb real tokens' logits through the shared EP
grouped GEMMs"); this PR fixes the cause instead of skipping the test.

Severity depends on the attention backend only in degree: FlashMLA shows
nondeterministic-but-plausible outputs; the trtllm DSV4 backend (PR #30805)
showed reliably EMPTY generations under the same mechanism, which is how it
resurfaced.

## Evidence

Protocol: same prompt 8 times at temperature 0, one request at a time (so
peer DP ranks are idle during each prefill), `/flush_cache` between runs so
every run re-prefills. A correct server is bit-deterministic here. Recipe =
the BCG CI class (DeepSeek-V4-Flash, tp4 dp4, DeepEP, breakable prefill
graphs), default FlashMLA backend, clean sgl-project main (b956e916ae) --
no trtllm code involved.

| Run | Configuration | Distinct outputs | First divergence | Max delta logprob (shared prefix) |
|-----|---------------|------------------|------------------|-----------------------------------|
| 1 | clean main | 2 / 8 | token 45 | 0.206 |
| 2 | clean main + this gate (only change) | 1 / 8 (bit-identical) | none | 0.000000 |
| 3 | clean main (gate absent), DeepSeek-V4-Pro tp8 dp2 (model generality) | 4 / 8 | token 5 | 0.459 |

Run 1 proves the bug on the default backend on upstream main; run 2 proves
this one-line gate eliminates it; run 3 shows it is not model-specific.
Repro scripts: `idle_probe.py`, `launch_idle_repro.sh` (this directory).

## Cost, and the path to keeping BCG on idle-rank steps

The gate does NOT disable BCG+DP globally: steps where every rank has real
tokens keep MAX_LEN and the breakable graph. Only steps where some rank is
idle fall back to SUM_LEN (eager prefill). At high load idle ranks are rare;
the affected regime is low-concurrency traffic.

The root enabler of the bug is that a zero-token rank cannot currently
participate safely in the MoE all-to-all, which is why the fabricated
tokens were unmasked in the first place. The follow-up that would restore
BCG for idle-rank steps is: make zero-token (or fully-masked) ranks safe in
the dispatch/combine path, then keep the dummy request but MASK its tokens
like ordinary padding (`num_token_non_padded = 0`) -- restoring the
invariant that batch composition seen by the experts is a pure function of
the real workload. Until then, this gate trades a graph replay on rare
idle-rank steps for correct and deterministic logits.

## Accuracy Tests

Local validation on 4x B200 (`python -m unittest test_deepseek_v4_flash_fp4_b200.<Class>`):                         
                                                                                                                   
  | Class | Result | GSM8K | Spec accept len |                                                                     
  |---|---|---|---|                                                                                                
  | TestDSV4FlashFP4B200 (LowLatency, TP4+MTP) | OK (9 tests) | 0.98 | 2.77 |                                      
  | TestDSV4FlashFP4B200Balanced (MTP+DP4) | OK (9 tests) | 0.97 | 1.95 |                                          
  | TestDSV4FlashFP4NonMTPB200 (DP4) | OK (8 tests) | 0.975 | n/a |                                                
  | TestDSV4FlashFP4BreakableCudaGraphB200 (DP4+BCG, the fix's target) | OK (8 tests, 1 pre-existing skip) | 0.97 | n/a |

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32537489709](https://github.com/sgl-project/sglang/actions/runs/32537489709)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32537489639](https://github.com/sgl-project/sglang/actions/runs/32537489639)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32537489734](https://github.com/sgl-project/sglang/actions/runs/32537489734)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->