### PR TITLE
[docs] Point the Qwen3.8-27B DFLASH2 note back at the rolling dev image tag

### DIFF
--- a/docs/cookbook/autoregressive/Qwen/Qwen3.8-27B.mdx
+++ b/docs/cookbook/autoregressive/Qwen/Qwen3.8-27B.mdx
@@ -36,7 +36,7 @@ docker pull lmsysorg/sglang:qwen38-27b
 
 # For the DFLASH2 cells only — that tag predates DFlash2 selector support,
 # so pull a nightly built from main instead:
-# docker pull lmsysorg/sglang:dev-nightly-0820
+# docker pull lmsysorg/sglang:dev
 ```
 
 For how to launch the image, see [Install → Method 3: Using Docker](../../../docs/get-started/install#method-3-using-docker). Substitute the inner `sglang serve ...` with what the command generator below produces.


### PR DESCRIPTION
## Motivation

#35753 pinned the DFLASH2 install note to `lmsysorg/sglang:dev-nightly-0820` because `:dev` was not picking up new builds at the time. A dated nightly goes stale by design — it stops being "a build from main" the day after it is cut — so this points the note back at the rolling tag.

## Modifications

One line in `Qwen3.8-27B.mdx`: the commented-out pull in the Docker install block goes from `lmsysorg/sglang:dev-nightly-0820` back to `lmsysorg/sglang:dev`.

Everything else from #35753 is unchanged: the warnings still name #35371 (DFlash2) and #35496 (DFlash2 + NVFP4), and still say the pinned `qwen38-27b` tag predates both.

## Accuracy Tests

N/A (docs only).

## Speed Tests and Profiling

N/A (docs only). `docs/scripts/check_cookbook_configs.mjs` passes.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32429387480](https://github.com/sgl-project/sglang/actions/runs/32429387480)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32429387231](https://github.com/sgl-project/sglang/actions/runs/32429387231)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->