### PR TITLE
Fix Prometheus name[] filtering for multiprocess metrics

### DIFF
--- a/3rdparty/amd/wheel/sglang/pyproject.toml
+++ b/3rdparty/amd/wheel/sglang/pyproject.toml
@@ -44,7 +44,7 @@ runtime_common = [
   "packaging",
   "partial_json_parser",
   "pillow",
-  "prometheus-client>=0.20.0",
+  "prometheus-client>=0.25.0",
   "psutil",
   "py-spy",
   "pybase64",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
   "packaging",
   "partial_json_parser",
   "pillow",
-  "prometheus-client>=0.20.0",
+  "prometheus-client>=0.25.0",
   "psutil",
   "py-spy",
   "pybase64",

--- a/python/pyproject_cpu.toml
+++ b/python/pyproject_cpu.toml
@@ -43,7 +43,7 @@ dependencies = [
   "packaging",
   "partial_json_parser",
   "pillow",
-  "prometheus-client>=0.20.0",
+  "prometheus-client>=0.25.0",
   "psutil",
   "py-spy",
   "pybase64",

--- a/python/pyproject_npu.toml
+++ b/python/pyproject_npu.toml
@@ -45,7 +45,7 @@ dependencies = [
   "packaging",
   "partial_json_parser",
   "pillow",
-  "prometheus-client>=0.20.0",
+  "prometheus-client>=0.25.0",
   "psutil",
   "py-spy",
   "pybase64",

--- a/python/pyproject_other.toml
+++ b/python/pyproject_other.toml
@@ -46,7 +46,7 @@ runtime_base = [
   "packaging",
   "partial_json_parser",
   "pillow",
-  "prometheus-client>=0.20.0",
+  "prometheus-client>=0.25.0",
   "psutil",
   "py-spy",
   "pybase64",

--- a/python/pyproject_xpu.toml
+++ b/python/pyproject_xpu.toml
@@ -43,7 +43,7 @@ dependencies = [
   "packaging",
   "partial_json_parser",
   "pillow",
-  "prometheus-client>=0.20.0",
+  "prometheus-client>=0.25.0",
   "psutil",
   "py-spy",
   "pybase64",

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -2539,7 +2539,7 @@ def add_prometheus_middleware(app):
     # We need to import prometheus_client after setting the env variable `PROMETHEUS_MULTIPROC_DIR`
     from prometheus_client import CollectorRegistry, make_asgi_app, multiprocess
 
-    registry = CollectorRegistry()
+    registry = CollectorRegistry(support_collectors_without_names=True)
     multiprocess.MultiProcessCollector(registry)
     metrics_route = Mount("/metrics", make_asgi_app(registry=registry))
 

--- a/test/registered/observability/test_metrics.py
+++ b/test/registered/observability/test_metrics.py
@@ -160,10 +160,25 @@ class TestEnableMetrics(CustomTestCase):
 
             metrics = _parse_prometheus_metrics(metrics_text)
             self._verify_metrics_common(metrics_text, metrics, expect_mfu_metrics)
+            self._verify_metrics_query_filter()
             if verify_metrics_extra is not None:
                 verify_metrics_extra(metrics)
         finally:
             kill_process_tree(process.pid)
+
+    def _verify_metrics_query_filter(self):
+        requested_names = [
+            "sglang:num_running_reqs",
+            "sglang:prompt_tokens_total",
+        ]
+        response = requests.get(
+            f"{DEFAULT_URL_FOR_TEST}/metrics",
+            params=[("name[]", name) for name in requested_names],
+        )
+        self.assertEqual(response.status_code, 200)
+
+        metrics = _parse_prometheus_metrics(response.text)
+        self.assertEqual(set(metrics), set(requested_names))
 
     def _verify_metrics_common(self, metrics_text, metrics, expect_mfu_metrics: bool):
         essential_metrics = [


### PR DESCRIPTION
## Motivation

Closes #35752.

Upper-layer schedulers and resource managers such as llm-d and AIBrix may request only selected SGLang metrics from `/metrics` using repeated `name[]` query parameters. In multiprocess mode, SGLang's Prometheus registry could omit `MultiProcessCollector` during restricted collection, causing filtered requests to return no SGLang samples even though unfiltered scrapes work.

This PR preserves upstream `prometheus_client` name-based filtering behavior for SGLang multiprocess metrics.

## Modifications

- Bump the minimum `prometheus-client` version from `0.20.0` to `0.25.0` across package variants.
- Create the metrics registry with `CollectorRegistry(support_collectors_without_names=True)` so restricted registries can still include multiprocess collectors.
- Add registered observability coverage for `/metrics?name[]=...` requests, verifying that only the requested SGLang metric names are returned.

## Accuracy Tests

N/A. This change only affects Prometheus metrics exposition and does not affect model outputs.

## Speed Tests and Profiling

N/A. This change does not affect inference speed.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). No documentation update is needed for this internal metrics behavior fix.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Not applicable.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32429803230](https://github.com/sgl-project/sglang/actions/runs/32429803230)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32429803238](https://github.com/sgl-project/sglang/actions/runs/32429803238)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32429803309](https://github.com/sgl-project/sglang/actions/runs/32429803309)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->