### PR TITLE
[Fix] Clear full-to-SWA mapping with `index_fill_` to avoid a blocking H2D copy

### DIFF
--- a/python/sglang/srt/mem_cache/allocator/swa.py
+++ b/python/sglang/srt/mem_cache/allocator/swa.py
@@ -344,14 +344,10 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         self.full_to_swa_index_mapping[full_indices] = swa_indices
 
     def clear_full_to_swa_mapping(self, full_indices: torch.Tensor) -> None:
-        """Reset these full slots to the padding-slot sentinel.
-
-        index_fill_ passes the 0 as a kernel argument, whereas
-        ``mapping[full_indices] = 0`` copies a host-resident scalar and blocks
-        until every kernel already queued on the stream has drained.
-        """
         if full_indices.numel() == 0:
             return
+        # index_fill_ passes the 0 as a kernel argument; mapping[idx] = 0 copies a
+        # host-resident scalar and blocks until the stream drains.
         self.full_to_swa_index_mapping.index_fill_(0, full_indices.to(torch.int64), 0)
 
     def free_swa(self, free_index: torch.Tensor):

--- a/python/sglang/srt/mem_cache/allocator/swa.py
+++ b/python/sglang/srt/mem_cache/allocator/swa.py
@@ -280,9 +280,7 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             alloc_full_indices[-swa_tail_len:], alloc_swa_indices
         )
         if swa_tail_len < extend_num_tokens:
-            self.full_to_swa_index_mapping[
-                alloc_full_indices[:-swa_tail_len].to(torch.int64)
-            ] = 0
+            self.clear_full_to_swa_mapping(alloc_full_indices[:-swa_tail_len])
         return alloc_full_indices
 
     def alloc_decode(
@@ -345,6 +343,17 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         swa_indices = swa_indices.to(self.full_to_swa_index_mapping.dtype)
         self.full_to_swa_index_mapping[full_indices] = swa_indices
 
+    def clear_full_to_swa_mapping(self, full_indices: torch.Tensor) -> None:
+        """Reset these full slots to the padding-slot sentinel.
+
+        index_fill_ passes the 0 as a kernel argument, whereas
+        ``mapping[full_indices] = 0`` copies a host-resident scalar and blocks
+        until every kernel already queued on the stream has drained.
+        """
+        if full_indices.numel() == 0:
+            return
+        self.full_to_swa_index_mapping.index_fill_(0, full_indices.to(torch.int64), 0)
+
     def free_swa(self, free_index: torch.Tensor):
         if free_index.numel() == 0:
             return
@@ -361,7 +370,7 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         swa_indices = self.full_to_swa_index_mapping[mapping_indices]
         swa_indices = swa_indices[swa_indices > 0]
         self.swa_attn_allocator.free(swa_indices)
-        self.full_to_swa_index_mapping[mapping_indices] = 0
+        self.clear_full_to_swa_mapping(mapping_indices)
 
     def free_group_begin(self):
         super().free_group_begin()

--- a/python/sglang/srt/mem_cache/multi_ended_allocator.py
+++ b/python/sglang/srt/mem_cache/multi_ended_allocator.py
@@ -2498,6 +2498,12 @@ class UnifiedSWATokenToKVPoolAllocator(SWATokenToKVPoolAllocator):
         """
         return
 
+    def clear_full_to_swa_mapping(self, full_indices: torch.Tensor) -> None:
+        """No-op stub, paired with set_full_to_swa_mapping: no mapping tensor to
+        clear in shared mode.
+        """
+        return
+
     # -- free-group --
 
     def free_group_begin(self) -> None:

--- a/python/sglang/srt/mem_cache/multi_ended_allocator.py
+++ b/python/sglang/srt/mem_cache/multi_ended_allocator.py
@@ -2499,9 +2499,7 @@ class UnifiedSWATokenToKVPoolAllocator(SWATokenToKVPoolAllocator):
         return
 
     def clear_full_to_swa_mapping(self, full_indices: torch.Tensor) -> None:
-        """No-op stub, paired with set_full_to_swa_mapping: no mapping tensor to
-        clear in shared mode.
-        """
+        # Paired with set_full_to_swa_mapping: shared mode has no mapping tensor.
         return
 
     # -- free-group --

--- a/python/sglang/srt/mem_cache/swa_radix_cache.py
+++ b/python/sglang/srt/mem_cache/swa_radix_cache.py
@@ -1301,7 +1301,7 @@ class SWARadixCache(BasePrefixCache):
         allocator = self.token_to_kv_pool_allocator
         swa_value = allocator.translate_loc_from_full_to_swa(incoming_full)
         allocator.set_full_to_swa_mapping(node.value, swa_value)
-        allocator.full_to_swa_index_mapping[incoming_full.to(torch.int64)] = 0
+        allocator.clear_full_to_swa_mapping(incoming_full)
         allocator.full_attn_allocator.free(incoming_full)
 
         node.swa_tombstone = False

--- a/python/sglang/srt/mem_cache/unified_cache/components/swa_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/swa_component.py
@@ -1148,7 +1148,7 @@ class SWAComponent(TreeComponent):
             # freeing only the incoming full, then store the swa on the node.
             swa_value = self._translate_full_to_swa(action.incoming_full)
             alloc.set_full_to_swa_mapping(action.kept_full, swa_value)
-            alloc.full_to_swa_index_mapping[action.incoming_full.to(torch.int64)] = 0
+            alloc.clear_full_to_swa_mapping(action.incoming_full)
             alloc.full_attn_allocator.free(action.incoming_full)
             self.tree_core.set_component_device_value(
                 action.node_id, self.component_type, swa_value

--- a/test/registered/unit/mem_cache/test_swa_unittest.py
+++ b/test/registered/unit/mem_cache/test_swa_unittest.py
@@ -226,6 +226,46 @@ class TestSWA(unittest.TestCase):
         allocator.free_swa(full_indices[1:2])
         self.assertEqual(allocator.swa_available_size(), 16)
 
+    @unittest.skipUnless(torch.cuda.is_available(), "sync detection needs CUDA")
+    @unittest.skipUnless(
+        torch.version.hip is None,
+        "sync debug mode does not flag a blocking H2D copy on HIP",
+    )
+    def test_clearing_the_mapping_does_not_synchronize(self):
+        """``mapping[idx] = 0`` copies a host-resident scalar, which blocks until
+        every kernel queued on the stream has drained; index_fill_ passes the 0 as
+        a kernel argument. torch's sync debug mode raises on the former, so it
+        distinguishes the two forms.
+        """
+        _, allocator, _ = _build_swa_tree(is_eagle=False)
+        full_indices = _swa_alloc(allocator, 4)
+        mapping = allocator.full_to_swa_index_mapping
+
+        # Warm up outside the window: a first-time cudaMalloc can synchronize on
+        # its own, which the detector would report as this call's fault.
+        allocator.clear_full_to_swa_mapping(full_indices)
+
+        def sync_error(fn):
+            torch.cuda.synchronize()
+            torch.cuda.set_sync_debug_mode("error")
+            try:
+                fn()
+            except RuntimeError as exc:
+                return exc
+            finally:
+                torch.cuda.set_sync_debug_mode("default")
+                torch.cuda.synchronize()
+            return None
+
+        self.assertIsNone(
+            sync_error(lambda: allocator.clear_full_to_swa_mapping(full_indices))
+        )
+        # Negative control: a detector that never fires would pass the assert
+        # above no matter how the mapping is cleared.
+        self.assertIsNotNone(
+            sync_error(lambda: mapping.__setitem__(full_indices.to(torch.int64), 0))
+        )
+
     def test_free_swa_group_owns_deferred_indices(self):
         _, allocator, _ = _build_swa_tree(
             is_eagle=False,

--- a/test/registered/unit/mem_cache/test_swa_unittest.py
+++ b/test/registered/unit/mem_cache/test_swa_unittest.py
@@ -227,15 +227,9 @@ class TestSWA(unittest.TestCase):
         self.assertEqual(allocator.swa_available_size(), 16)
 
     @unittest.skipUnless(torch.cuda.is_available(), "sync detection needs CUDA")
-    @unittest.skipUnless(
-        torch.version.hip is None,
-        "sync debug mode does not flag a blocking H2D copy on HIP",
-    )
     def test_clearing_the_mapping_does_not_synchronize(self):
-        """``mapping[idx] = 0`` copies a host-resident scalar, which blocks until
-        every kernel queued on the stream has drained; index_fill_ passes the 0 as
-        a kernel argument. torch's sync debug mode raises on the former, so it
-        distinguishes the two forms.
+        """Clearing the full-to-SWA mapping must not block the stream; writing a
+        host-resident scalar into it does.
         """
         _, allocator, _ = _build_swa_tree(is_eagle=False)
         full_indices = _swa_alloc(allocator, 4)
@@ -257,13 +251,16 @@ class TestSWA(unittest.TestCase):
                 torch.cuda.synchronize()
             return None
 
+        # Gate on the pre-fix form: a detector blind to this sync class would pass
+        # the assert below no matter how the mapping is cleared.
+        pre_fix_error = sync_error(
+            lambda: mapping.__setitem__(full_indices.to(torch.int64), 0)
+        )
+        if pre_fix_error is None:
+            self.skipTest("sync debug mode does not flag a blocking H2D copy here")
+
         self.assertIsNone(
             sync_error(lambda: allocator.clear_full_to_swa_mapping(full_indices))
-        )
-        # Negative control: a detector that never fires would pass the assert
-        # above no matter how the mapping is cleared.
-        self.assertIsNotNone(
-            sync_error(lambda: mapping.__setitem__(full_indices.to(torch.int64), 0))
         )
 
     def test_free_swa_group_owns_deferred_indices(self):

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -6147,9 +6147,7 @@ class TestUnifiedRadixCacheActionRouting(CustomTestCase):
         alloc.translate_loc_from_full_to_swa.assert_called_once_with(incoming_full)
         alloc.set_full_to_swa_mapping.assert_called_once_with(kept_full, swa_value)
         # the incoming full's stale mapping is cleared, then its slot freed (full-only)
-        key, val = alloc.full_to_swa_index_mapping.__setitem__.call_args.args
-        self.assertTrue(torch.equal(key, incoming_full))
-        self.assertEqual(val, 0)
+        alloc.clear_full_to_swa_mapping.assert_called_once_with(incoming_full)
         alloc.full_attn_allocator.free.assert_called_once_with(incoming_full)
         alloc.free.assert_not_called()
         cache.tree_core.set_component_device_value.assert_called_once_with(


### PR DESCRIPTION
`full_to_swa_index_mapping[indices] = 0` takes the zero from host memory, making the write a blocking H2D copy ordered behind everything already queued on the stream. Route all four clear sites -- `free_swa`, the PD decode prealloc path, and tombstone recovery in both trees -- through a new `clear_full_to_swa_mapping` that uses `index_fill_` instead.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #32435858063](https://github.com/sgl-project/sglang/actions/runs/32435858063)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32435857850](https://github.com/sgl-project/sglang/actions/runs/32435857850)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:no_entry_sign: [Run #32435858082](https://github.com/sgl-project/sglang/actions/runs/32435858082)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->

