### PR TITLE
fix(grpc): derive choice count before normalization

### DIFF
--- a/python/sglang/srt/entrypoints/grpc_bridge.py
+++ b/python/sglang/srt/entrypoints/grpc_bridge.py
@@ -299,7 +299,9 @@ class RuntimeHandle:
             gen = self.tokenizer_manager.generate_request(obj, request=request)
             if stream:
                 completed_choices = set()
-                expected_choices = obj.batch_size * obj.parallel_sample_num
+                # generate_request does not normalize obj until iteration begins.
+                sampling_params = obj.sampling_params or {}
+                expected_choices = max(1, int(sampling_params.get("n", 1)))
                 async for chunk in gen:
                     choice_finished = (
                         chunk.get("meta_info", {}).get("finish_reason") is not None

--- a/test/registered/unit/entrypoints/test_grpc_bridge.py
+++ b/test/registered/unit/entrypoints/test_grpc_bridge.py
@@ -93,7 +93,7 @@ class TestNativeGrpcParallelResponses(CustomTestCase):
             },
         ]
         handle = _make_runtime_handle(responses)
-        obj = SimpleNamespace(rid="logical", batch_size=1, parallel_sample_num=2)
+        obj = SimpleNamespace(rid="logical", sampling_params={"n": 2})
 
         asyncio.run(
             handle._run_generate(


### PR DESCRIPTION
## Motivation

Native streaming gRPC requests currently fail before producing their first token because `RuntimeHandle._run_generate` reads `GenerateReqInput.batch_size` and `parallel_sample_num` immediately after creating the `TokenizerManager.generate_request` async generator. Request normalization initializes those fields only when that generator is first advanced, so the bridge raises `AttributeError` for every streaming request.

This ordering came from the `n > 1` lifecycle work in #32588. The initial implementation calculated the expected choice count inside the stream loop, after the generator had started and normalization had run. A later cleanup hoisted that loop-invariant calculation above the loop, unintentionally moving it before normalization.

## Before and after

| | Before this PR | After this PR |
|---|---|---|
| Choice-count source | `obj.batch_size * obj.parallel_sample_num`, read before either derived field exists | `sampling_params["n"]`, read from the original request with a default of 1 |
| Streaming result | Every request fails before tokenization or scheduler dispatch | The generator starts normally and existing per-choice completion tracking remains active |
| gRPC error | `Generate: 'GenerateReqInput' object has no attribute 'batch_size' (Internal)` | No bridge lifecycle error |
| Dynamo-visible result | HTTP 500 for every attempted sidecar request | 83/83 successful requests across all serving-ready GPU scenarios |
| KV/disaggregation impact | No generation, KV-event publication, cache affinity, invalidation, or NIXL handoff can occur | Aggregated and disaggregated KV routing, invalidation, cancellation, and NIXL handoff complete successfully |

The native gRPC `GenerateRequest` carries one logical prompt, so its expected response-choice count is `n`. This does not constrain GPU execution to batch size 1: independent gRPC requests remain concurrent and SGLang continues to batch their sequences internally through continuous batching.

## Modifications

- Derive the expected streaming choice count directly from the pre-normalization sampling parameters.
- Keep the existing one-terminal-after-all-choices behavior for `n > 1`.
- Tighten the existing bridge test so its request fixture matches production and deliberately lacks post-normalization fields.

## Validation status

- `python3 scripts/lint/check_registered_tests.py`: passed.
- `ruff check python/sglang/srt/entrypoints/grpc_bridge.py test/registered/unit/entrypoints/test_grpc_bridge.py`: passed.
- `python3 test/registered/unit/entrypoints/test_grpc_bridge.py` in a dependency-complete SGLang container: 2 passed.
- Commit `f5f5baaeca555c83d95b34d91fc72df70eb7e372` is GitHub-verified (`valid`).

## Accuracy Tests

The patch does not alter model computation or output values. The GPU validation above verified complete token counts and successful responses across aggregated and disaggregated serving paths.

## Speed Tests and Profiling

Not applicable; this replaces two unavailable derived-field reads with one sampling-parameter lookup performed once per request.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (No documentation change is required.)
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Not applicable.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #32439274369](https://github.com/sgl-project/sglang/actions/runs/32439274369)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32439274214](https://github.com/sgl-project/sglang/actions/runs/32439274214)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #32439274381](https://github.com/sgl-project/sglang/actions/runs/32439274381)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
