### PR TITLE
[NPU] Use fused Triton MRoPE for Qwen3.x

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -1548,6 +1548,7 @@ async def load_lora_adapter(
 
 
 @app.api_route("/load_lora_adapter_from_tensors", methods=["POST"])
+@auth_level(AuthLevel.ADMIN_OPTIONAL)
 async def load_lora_adapter_from_tensors(
     obj: Annotated[LoadLoRAAdapterFromTensorsReqInput, Body()], request: Request
 ):

--- a/python/sglang/srt/entrypoints/http_server_engine.py
+++ b/python/sglang/srt/entrypoints/http_server_engine.py
@@ -1,14 +1,16 @@
+import base64
 import multiprocessing
 import time
 from typing import List, Optional, Tuple
 
 import requests
+import safetensors.torch
 import torch
 
 from sglang.srt.entrypoints.EngineBase import EngineBase
 from sglang.srt.entrypoints.http_server import launch_server
 from sglang.srt.server_args import ServerArgs
-from sglang.srt.utils import MultiprocessingSerializer, kill_process_tree
+from sglang.srt.utils import kill_process_tree
 
 
 def launch_server_process(server_args: ServerArgs) -> multiprocessing.Process:
@@ -91,7 +93,9 @@ class HttpServerEngineAdapter(EngineBase):
             "update_weights_from_tensor",
             {
                 "serialized_named_tensors": [
-                    MultiprocessingSerializer.serialize(named_tensors, output_str=True)
+                    base64.b64encode(
+                        safetensors.torch.save(dict(named_tensors))
+                    ).decode()
                     for _ in range(self.server_args.tp_size)
                 ],
                 "load_format": load_format,

--- a/python/sglang/srt/hardware_backend/npu/memory_pool_npu.py
+++ b/python/sglang/srt/hardware_backend/npu/memory_pool_npu.py
@@ -105,7 +105,11 @@ class NPUMHATokenToKVPool(MHATokenToKVPool):
             # The padded slot 0 is used for writing dummy outputs from padded tokens.
             # Continuous memory improves the efficiency of Ascend`s transmission backend,
             # while other backends remain unchanged.
-            self.k_buffer = torch.zeros(
+            # FIA exposes the KV cache as per-layer Python views so graph
+            # capture does not retain the full multi-layer tensor. HiCache's
+            # NPU exchange operator still requires the original contiguous
+            # [layer, page, token, head, dim] allocation.
+            self._hicache_k_buffer = torch.zeros(
                 (
                     self.layer_num,
                     self.size // self.page_size + 1,
@@ -116,7 +120,7 @@ class NPUMHATokenToKVPool(MHATokenToKVPool):
                 dtype=self.store_dtype,
                 device=self.device,
             )
-            self.v_buffer = torch.zeros(
+            self._hicache_v_buffer = torch.zeros(
                 (
                     self.layer_num,
                     self.size // self.page_size + 1,
@@ -128,19 +132,28 @@ class NPUMHATokenToKVPool(MHATokenToKVPool):
                 device=self.device,
             )
 
+            self.k_buffer = self._hicache_k_buffer
+            self.v_buffer = self._hicache_v_buffer
+
             if self.use_fia:
                 # Use per-layer Python lists to avoid torch.compile capturing
                 # the entire multi-layer tensor (OOM during graph capture).
                 # Each layer view: [P*ps, 1, H, D], sharing the contiguous
                 # storage allocated above.
                 self.k_buffer = [
-                    self.k_buffer[i].view(-1, 1, self.head_num, self.head_dim)
+                    self._hicache_k_buffer[i].view(-1, 1, self.head_num, self.head_dim)
                     for i in range(self.layer_num)
                 ]
                 self.v_buffer = [
-                    self.v_buffer[i].view(-1, 1, self.head_num, self.v_head_dim)
+                    self._hicache_v_buffer[i].view(
+                        -1, 1, self.head_num, self.v_head_dim
+                    )
                     for i in range(self.layer_num)
                 ]
+
+    def get_hicache_transfer_buffers(self):
+        """Return contiguous all-layer KV tensors for NPU HiCache IO."""
+        return self._hicache_k_buffer, self._hicache_v_buffer
 
     def _init_kv_copy_and_warmup(self):
         # implementation relies on self.data_strides / self.data_ptrs, which the

--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -328,7 +328,7 @@ class MambaAttnBackendBase(AttentionBackend):
         chunk boundary."""
         chunk_size = mamba_cache_chunk_size()
         if is_npu():
-            chunk_size = FLA_CHUNK_SIZE_NPU
+            h_chunk_size = FLA_CHUNK_SIZE_NPU
         # CPU to avoid kernel launches for the masking ops
         mamba_track_mask = forward_batch.mamba_track_mask.cpu()
         extend_seq_lens = forward_batch.extend_seq_lens.cpu()
@@ -341,6 +341,8 @@ class MambaAttnBackendBase(AttentionBackend):
             num_h_states = extend_seq_lens // chunk_size
         else:
             num_h_states = (extend_seq_lens - 1) // chunk_size + 1
+            if is_npu():
+                num_h_states = (extend_seq_lens - 1) // h_chunk_size + 1
 
         track_ssm_src_offset = torch.zeros_like(num_h_states)
         track_ssm_src_offset[1:] = torch.cumsum(num_h_states[:-1], dim=0)
@@ -362,6 +364,12 @@ class MambaAttnBackendBase(AttentionBackend):
         track_ssm_h_src = offset_masked[not_aligned] + (
             lens_masked[not_aligned] // chunk_size
         )
+        if is_npu():
+            track_ssm_h_src = (
+                offset_masked[not_aligned]
+                + ((lens_masked[not_aligned] // chunk_size) * chunk_size)
+                // h_chunk_size
+            )
         track_ssm_h_dst = dst_masked[not_aligned]
 
         return (

--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -38,8 +38,11 @@ from sglang.srt.speculative.spec_info import SpecInput
 
 if TYPE_CHECKING:
     from sglang.srt.layers.attention.verify_mask import VerifyMask
+from sglang.srt.utils import is_npu
 
 logger = logging.getLogger(__name__)
+if is_npu():
+    FLA_CHUNK_SIZE_NPU = 64
 
 
 class MambaAttnBackendBase(AttentionBackend):
@@ -324,6 +327,8 @@ class MambaAttnBackendBase(AttentionBackend):
         cache last_recurrent_state, unaligned cache intermediate `h` at the last
         chunk boundary."""
         chunk_size = mamba_cache_chunk_size()
+        if is_npu():
+            chunk_size = FLA_CHUNK_SIZE_NPU
         # CPU to avoid kernel launches for the masking ops
         mamba_track_mask = forward_batch.mamba_track_mask.cpu()
         extend_seq_lens = forward_batch.extend_seq_lens.cpu()

--- a/python/sglang/srt/layers/attention/vision.py
+++ b/python/sglang/srt/layers/attention/vision.py
@@ -263,6 +263,16 @@ def resolve_max_seqlen(
     return int(seq_lens.max().item())
 
 
+def resolve_ascend_actual_seq_lengths(
+    forward_metadata: VisionAttentionMetadata,
+) -> torch.Tensor:
+    """Return cumulative sequence ends required by Ascend TND attention."""
+    cu_seqlens = forward_metadata.cu_seqlens
+    if cu_seqlens.is_npu:
+        cu_seqlens = cu_seqlens.to("cpu")
+    return cu_seqlens[1:].to(torch.int32)
+
+
 def resolve_precomputed_max_seqlen(
     cu_seqlens: torch.Tensor, max_seqlen: int | torch.Tensor | None
 ) -> int:
@@ -862,11 +872,8 @@ class VisionAscendAttention(nn.Module):
             )
 
         if forward_metadata is not None:
-            # TND fused attention expects cumulative seqlens (cu_seqlens[1:]),
-            # not per-sequence lengths in forward_metadata.seq_lens.
-            cu = forward_metadata.cu_seqlens.to("cpu")
             output = torch.empty_like(q)
-            seq_len_arg = cu[1:].to(torch.int32)
+            seq_len_arg = resolve_ascend_actual_seq_lengths(forward_metadata)
         elif envs.SGLANG_VIT_ENABLE_CUDA_GRAPH.get():
             if "output_ws" not in kwargs:
                 raise RuntimeError("output_ws should be prepared for npu-graph mode")

--- a/python/sglang/srt/layers/rotary_embedding/mrope.py
+++ b/python/sglang/srt/layers/rotary_embedding/mrope.py
@@ -283,20 +283,7 @@ class MRotaryEmbedding(RotaryEmbedding):
         assert (
             fused_set_kv_buffer_arg is None
         ), "fused_set_kv_buffer_arg is not supported for npu implementation"
-        if query.shape[1] > 4096:
-            return self.forward_native(positions, query, key, fused_set_kv_buffer_arg)
-        rotary_mode = "half" if self.is_neox_style else "interleave"
-        mrope_section = [0, 0, 0]
-        query_out, key_out = torch_npu.npu_mrope(
-            positions,
-            query,
-            key,
-            self.cos_sin_cache,
-            self.head_size,
-            mrope_section=mrope_section,
-            rotary_mode=rotary_mode,
-        )
-        return query_out, key_out
+        return self.forward_native(positions, query, key, fused_set_kv_buffer_arg)
 
     def forward_xpu(
         self,

--- a/python/sglang/srt/layers/rotary_embedding/mrope.py
+++ b/python/sglang/srt/layers/rotary_embedding/mrope.py
@@ -22,21 +22,16 @@ from sglang.srt.runtime_context import attention_backends
 from sglang.srt.utils import (
     cpu_has_amx_support,
     is_cuda,
-    is_npu,
     is_xpu,
     support_triton,
 )
 
 _is_cuda = is_cuda()
-_is_npu = is_npu()
 _is_xpu = is_xpu()
 _is_cpu_amx_available = cpu_has_amx_support()
 
 if _is_cuda:
     from sglang.kernels.ops.attention.rope import apply_rope_with_cos_sin_cache_inplace
-
-if _is_npu:
-    import torch_npu
 
 if _is_xpu:
     from sgl_kernel import multimodal_rotary_embedding

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -507,6 +507,30 @@ class MultimodalDataItem(msgspec.Struct, kw_only=True, dict=True, array_like=Tru
         return min(requested_count, proxy_count)
 
 
+def compute_image_patch_tokens(mm_items: List[MultimodalDataItem]) -> List[int]:
+    """Return post-alignment raw ViT patch counts for all image items."""
+    patch_tokens = []
+    for item in mm_items:
+        if not item.is_image():
+            continue
+
+        grid_thw = item.model_specific_data.get("image_grid_thw")
+        if grid_thw is None:
+            grid_thw = item.model_specific_data.get("image_grid_hws")
+        if grid_thw is None:
+            continue
+
+        if isinstance(grid_thw, torch.Tensor):
+            grid_thw = grid_thw.detach().cpu().numpy()
+        else:
+            grid_thw = np.asarray(grid_thw)
+        if grid_thw.ndim == 1:
+            grid_thw = grid_thw.reshape(1, -1)
+        patch_tokens.extend(np.prod(grid_thw, axis=-1, dtype=np.int64).tolist())
+
+    return [int(value) for value in patch_tokens]
+
+
 class MultimodalProcessorOutput(
     msgspec.Struct, kw_only=True, dict=True, array_like=True, weakref=True
 ):
@@ -546,6 +570,11 @@ class MultimodalProcessorOutput(
     media_nums_per_sample: Optional[List[int]] = None
     visible_frame_counts: Optional[torch.Tensor] = None
 
+    # Raw ViT patch counts for every image in this request. This is populated
+    # after image resizing/alignment, so it is a better admission signal than
+    # image count or encoded file size.
+    image_patch_tokens: Optional[List[int]] = None
+
     # for transformers-compatibility
     token_type_ids: Optional[torch.Tensor] = None
 
@@ -569,6 +598,7 @@ class MultimodalProcessorOutput(
             vision_position_ids=d.get("vision_position_ids"),
             media_nums_per_sample=d.get("media_nums_per_sample"),
             visible_frame_counts=d.get("visible_frame_counts"),
+            image_patch_tokens=d.get("image_patch_tokens"),
         )
 
     @staticmethod
@@ -626,6 +656,7 @@ class MultimodalInputs:
     vision_position_ids: Optional[torch.Tensor] = None
     media_nums_per_sample: Optional[List[int]] = None
     visible_frame_counts: Optional[torch.Tensor] = None
+    image_patch_tokens: Optional[List[int]] = None
 
     def release_features(self):
         """Release feature tensors to free GPU memory."""
@@ -696,6 +727,7 @@ class MultimodalInputs:
             "vision_position_ids",
             "media_nums_per_sample",
             "visible_frame_counts",
+            "image_patch_tokens",
         ]
         for arg in optional_args:
             val = getattr(obj, arg, None)
@@ -715,6 +747,11 @@ class MultimodalInputs:
 
     def contains_mm_input(self) -> bool:
         return any(True for item in self.mm_items if item.is_valid())
+
+    def total_image_patch_tokens(self) -> int:
+        if self.image_patch_tokens is None:
+            self.image_patch_tokens = compute_image_patch_tokens(self.mm_items)
+        return sum(self.image_patch_tokens)
 
     def compute_mm_token_counts(self) -> Tuple[int, int, int]:
         """Count prompt tokens consumed by each modality (image, audio, video).
@@ -741,6 +778,7 @@ class MultimodalInputs:
         optional_args = [
             "mm_items",
             "image_pad_len",
+            "image_patch_tokens",
         ]
         for arg in optional_args:
             self_arg = getattr(self, arg, None)

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -523,6 +523,7 @@ class PrefillAdder:
         max_prefill_bs: int = 0,
         max_running_requests: Optional[int] = None,
         prefill_max_requests: Optional[int] = None,
+        max_prefill_mm_patch_tokens: Optional[int] = None,
         prefill_delayer_single_pass: Optional[PrefillDelayerSinglePassExecutor] = None,
         dllm_config: Optional[DllmConfig] = None,
         waiting_queue_len: int = 0,
@@ -616,6 +617,7 @@ class PrefillAdder:
         self.max_running_requests = max_running_requests
         self.prefill_context_parallel_enabled = is_prefill_context_parallel_enabled()
         self.prefill_max_requests = prefill_max_requests
+        self.max_prefill_mm_patch_tokens = max_prefill_mm_patch_tokens
         self.prefill_delayer_single_pass = prefill_delayer_single_pass
         self.max_prefill_bs = max_prefill_bs
         # Snapshot of scheduler waiting_queue length at the start of this
@@ -1216,6 +1218,23 @@ class PrefillAdder:
 
         if (x := self.prefill_max_requests) is not None and len(self.can_run_list) >= x:
             return AddReqResult.OTHER
+
+        if self.max_prefill_mm_patch_tokens is not None and self.can_run_list:
+            request_mm_patch_tokens = (
+                req.multimodal_inputs.total_image_patch_tokens()
+                if req.multimodal_inputs is not None
+                else 0
+            )
+            admitted_mm_patch_tokens = sum(
+                admitted_req.multimodal_inputs.total_image_patch_tokens()
+                for admitted_req in self.can_run_list
+                if admitted_req.multimodal_inputs is not None
+            )
+            if (
+                admitted_mm_patch_tokens + request_mm_patch_tokens
+                > self.max_prefill_mm_patch_tokens
+            ):
+                return AddReqResult.OTHER
 
         if req.sampling_params.ignore_eos and getattr(self.tree_cache, "disable", True):
             return self.add_one_req_ignore_eos(req)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -4892,8 +4892,15 @@ class Scheduler(
         self, recv_req: LoadLoRAAdapterFromTensorsReqInput
     ) -> LoadLoRAAdapterFromTensorsReqOutput:
         """In-place loading a new lora adapter from serialized tensors."""
-
-        result = self.tp_worker.load_lora_adapter_from_tensors(recv_req)
+        try:
+            result = self.tp_worker.load_lora_adapter_from_tensors(recv_req)
+        except Exception as e:
+            # A malformed/malicious serialized payload (e.g. one rejected by
+            # SafeUnpickler) must not take down the scheduler event loop.
+            logger.error("Failed to load LoRA adapter from tensors: %s", e)
+            return LoadLoRAAdapterFromTensorsReqOutput(
+                success=False, error_message=str(e)
+            )
         return result
 
     def unload_lora_adapter(

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3332,6 +3332,7 @@ class Scheduler(
             max_prefill_bs=int(self.max_prefill_bs),
             max_running_requests=self.max_running_requests,
             prefill_max_requests=get_schedule().prefill_max_requests,
+            max_prefill_mm_patch_tokens=self.server_args.max_prefill_mm_patch_tokens,
             prefill_delayer_single_pass=prefill_delayer_single_pass,
             dllm_config=self.dllm_config,
             waiting_queue_len=len(self.waiting_queue),

--- a/python/sglang/srt/managers/scheduler_components/weight_updater.py
+++ b/python/sglang/srt/managers/scheduler_components/weight_updater.py
@@ -157,7 +157,13 @@ class SchedulerWeightUpdaterManager:
                 worker = self.tp_worker
             else:
                 worker = self.draft_worker or self.tp_worker
-            success, message = worker.update_weights_from_tensor(recv_req)
+            try:
+                success, message = worker.update_weights_from_tensor(recv_req)
+            except Exception as e:
+                # A malformed/malicious serialized payload (e.g. one rejected by
+                # SafeUnpickler) must not take down the scheduler event loop.
+                logger.error("Failed to update weights from tensor: %s", e)
+                success, message = False, str(e)
             if success:
                 self.flush_cache_after_weight_update(recv_req)
             else:

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -93,6 +93,7 @@ from sglang.srt.managers.mm_utils import TensorTransportMode, wrap_shm_features
 from sglang.srt.managers.multimodal_processor import get_mm_processor, import_processors
 from sglang.srt.managers.schedule_batch import (
     MultimodalDataItem,
+    compute_image_patch_tokens,
     get_request_return_hidden_states_mode,
 )
 from sglang.srt.managers.scheduler_input_blocker import input_blocker_guard_region
@@ -1068,6 +1069,31 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                     input_text=mm_processor_input,
                     request_obj=obj,
                     max_req_input_len=self.max_req_input_len,
+                )
+
+            if mm_inputs:
+                image_patch_tokens = compute_image_patch_tokens(mm_inputs.mm_items)
+                mm_inputs.image_patch_tokens = image_patch_tokens
+                total_image_patch_tokens = sum(image_patch_tokens)
+                max_image_patch_tokens = max(image_patch_tokens, default=0)
+                request_limit = self.server_args.max_mm_patch_tokens_per_request
+                if (
+                    request_limit is not None
+                    and total_image_patch_tokens > request_limit
+                ):
+                    raise ValueError(
+                        "The multimodal input requires "
+                        f"{total_image_patch_tokens} raw ViT patch tokens after "
+                        f"image alignment, exceeding the per-request limit of "
+                        f"{request_limit}. Reduce the total image resolution."
+                    )
+                logger.debug(
+                    "Multimodal visual cost: rid=%s, images=%d, "
+                    "total_patch_tokens=%d, max_image_patch_tokens=%d",
+                    getattr(obj, "rid", "anonymous_rid"),
+                    len(image_patch_tokens),
+                    total_image_patch_tokens,
+                    max_image_patch_tokens,
                 )
 
             if mm_inputs and mm_inputs.input_ids is not None:

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -54,7 +54,11 @@ from sglang.srt.model_executor.graph_memory_usage import (
 from sglang.srt.model_executor.pool_configurator import MemoryPoolConfig
 from sglang.srt.runtime_context import get_exec, get_model, get_schedule, get_spec
 from sglang.srt.server_args import ServerArgs
-from sglang.srt.utils import MultiprocessingSerializer, broadcast_pyobj, set_random_seed
+from sglang.srt.utils import (
+    broadcast_pyobj,
+    deserialize_tensor_payload,
+    set_random_seed,
+)
 from sglang.srt.utils.hf_transformers_utils import (
     get_processor,
     get_tokenizer,
@@ -201,13 +205,16 @@ class BaseTpWorker(ABC):
         deserializing another rank's copy would break producer-side CUDA-IPC
         refcounting."""
         monkey_patch_torch_reductions()
-        return MultiprocessingSerializer.deserialize(
-            serialized_named_tensors[self.ps.tp_rank]
-        )
+        return deserialize_tensor_payload(serialized_named_tensors[self.ps.tp_rank])
 
     def update_weights_from_tensor(self, recv_req: UpdateWeightsFromTensorReqInput):
+        named_tensors = self._deserialize_own_rank(recv_req.serialized_named_tensors)
+        # safetensors payloads deserialize to a dict; the weight updater expects
+        # an iterable of (name, tensor) pairs.
+        if isinstance(named_tensors, dict):
+            named_tensors = list(named_tensors.items())
         success, message = self.model_runner.weight_updater.update_weights_from_tensor(
-            named_tensors=self._deserialize_own_rank(recv_req.serialized_named_tensors),
+            named_tensors=named_tensors,
             load_format=recv_req.load_format,
         )
         return success, message

--- a/python/sglang/srt/mem_cache/mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/mamba_radix_cache.py
@@ -574,8 +574,20 @@ class MambaRadixCache(BasePrefixCache):
                 if write_pos_buf is not None:
                     cache_len -= int(write_pos_buf[req.mamba_pool_idx].item())
                     write_pos_buf[req.mamba_pool_idx] = 0
-            if cache_len is None:
-                cache_len = 0
+            if cache_len is None or cache_len == 0:
+                # Nothing to cache: free KV and mamba slots without inserting
+                # a key_len=0 ghost node into the radix tree. Such empty nodes
+                # poison subsequent match_prefix calls by serving as a stale
+                # mamba COW source with best_value_len=0 (see cache_finished_req
+                # of a short request with no track boundary). Only free the
+                # unprotected part of kv_indices.
+                self.token_to_kv_pool_allocator.free_segment(
+                    kv_indices[req.cache_protected_len :],
+                    start_pos=req.cache_protected_len,
+                )
+                self.req_to_token_pool.free_mamba_cache(req)
+                self.dec_lock_ref(req.last_node)
+                return
             if cache_len != len(token_ids):
                 cache_end_idx = max(cache_len, req.cache_protected_len)
                 self.token_to_kv_pool_allocator.free_segment(

--- a/python/sglang/srt/mem_cache/pool_host/mamba.py
+++ b/python/sglang/srt/mem_cache/pool_host/mamba.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import threading
 from typing import Optional
 
@@ -18,10 +19,13 @@ from sglang.srt.mem_cache.pool_host.common import (
     ALLOC_MEMORY_FUNCS,
     get_allocator_from_storage,
 )
-from sglang.srt.utils import is_cuda, is_hip
+from sglang.srt.utils import is_cuda, is_hip, is_npu
 
 _is_cuda = is_cuda()
 _is_hip = is_hip()
+_is_npu = is_npu()
+transfer_state_per_layer_direct_pf_lf = None
+transfer_state_all_layer_direct_lf_pf = None
 if _is_cuda or _is_hip:
     from sgl_kernel.kvcacheio import (
         transfer_kv_all_layer_direct_lf_pf,
@@ -34,8 +38,30 @@ if _is_cuda or _is_hip:
         transfer_kv_mamba_lf_pf,
         transfer_kv_mamba_pf_lf,
     )
+if _is_npu:
+    try:
+        from sgl_kernel_npu.kvcacheio import (
+            transfer_state_all_layer_direct_lf_pf,
+            transfer_state_per_layer_direct_pf_lf,
+        )
+    except ImportError:
+        pass
 
 logger = logging.getLogger(__name__)
+
+
+_NPU_HICACHE_MAMBA_IO_ENV = "SGLANG_NPU_HICACHE_MAMBA_IO"
+_NPU_HICACHE_MAMBA_IO_MODES = {"sync", "async"}
+
+
+def _npu_hicache_mamba_io_mode() -> str:
+    mode = os.getenv(_NPU_HICACHE_MAMBA_IO_ENV, "sync").strip().lower()
+    if mode not in _NPU_HICACHE_MAMBA_IO_MODES:
+        raise ValueError(
+            f"{_NPU_HICACHE_MAMBA_IO_ENV} must be one of "
+            f"{sorted(_NPU_HICACHE_MAMBA_IO_MODES)}, got {mode!r}."
+        )
+    return mode
 
 
 class MambaPoolHost(HostKVCache):
@@ -128,9 +154,35 @@ class MambaPoolHost(HostKVCache):
         ]
 
         self.kv_buffer = self.init_kv_buffer()
+        self._configure_npu_mamba_io()
         self._init_write_back_staging_buffers()
         self.lock = threading.RLock()
         self.clear()
+
+    def _configure_npu_mamba_io(self) -> None:
+        mode = _npu_hicache_mamba_io_mode()
+        if mode == "sync":
+            logger.info("NPU HiCache Mamba state transfer mode: sync torch fallback.")
+            return
+
+        required_ops = (
+            transfer_state_per_layer_direct_pf_lf,
+            transfer_state_all_layer_direct_lf_pf,
+        )
+        required_torch_ops = (
+            "transfer_state_per_layer_direct_pf_lf",
+            "transfer_state_all_layer_direct_lf_pf",
+        )
+        if any(op is None for op in required_ops) or any(
+            not hasattr(torch.ops.npu, op_name) for op_name in required_torch_ops
+        ):
+            raise RuntimeError(
+                "NPU HiCache Mamba async state transfer requires "
+                "the per-layer PF->LF and all-layer LF->PF direct operators "
+                "from sgl-kernel-npu."
+            )
+
+        logger.info("NPU HiCache Mamba state transfer mode: native async.")
 
     def init_kv_buffer(self):
         _host_alloc = ALLOC_MEMORY_FUNCS[self.device_pool.device]
@@ -358,6 +410,22 @@ class MambaPoolHost(HostKVCache):
                 layer_id=layer_id,
                 page_size=1,
             )
+        elif io_backend == "kernel_ascend":
+            if _npu_hicache_mamba_io_mode() == "async":
+                transfer_state_per_layer_direct_pf_lf(
+                    src=src,
+                    dst=dst,
+                    src_indices=src_indices,
+                    dst_indices=dst_indices,
+                    layer_id=layer_id,
+                )
+            else:
+                host_indices = src_indices.to(dtype=torch.int64, device=src.device)
+                device_indices = dst_indices.to(dtype=torch.int64, device=dst.device)
+                values = (
+                    src.select(1, layer_id).index_select(0, host_indices).select(1, 0)
+                )
+                dst.index_copy_(0, device_indices, values.to(device=dst.device))
         else:
             raise ValueError(f"Unsupported io_backend: {io_backend}")
 
@@ -401,6 +469,27 @@ class MambaPoolHost(HostKVCache):
                 dst_indices=dst_indices,
                 page_size=1,
             )
+        elif io_backend == "kernel_ascend":
+            if _npu_hicache_mamba_io_mode() == "async":
+                transfer_state_all_layer_direct_lf_pf(
+                    device_states=[src_layers],
+                    host_states=[dst],
+                    device_indices=src_indices,
+                    host_indices=dst_indices,
+                )
+            else:
+                device_indices = src_indices.to(
+                    dtype=torch.int64, device=src_layers.device
+                )
+                host_indices = dst_indices.to(dtype=torch.int64, device=dst.device)
+                values = (
+                    src_layers.index_select(1, device_indices)
+                    .movedim(0, 1)
+                    .unsqueeze(2)
+                    .contiguous()
+                    .to(device=dst.device)
+                )
+                dst.index_copy_(0, host_indices, values)
         else:
             raise ValueError(f"Unsupported io_backend: {io_backend}")
 

--- a/python/sglang/srt/mem_cache/pool_host/mha.py
+++ b/python/sglang/srt/mem_cache/pool_host/mha.py
@@ -350,9 +350,12 @@ class MHATokenToKVPoolHost(HostKVCache):
             if self.layout == "page_first_direct":
                 # Ascend-specific: transfer KV data for all layers when layer_id == 0
                 if host_layer_id == 0:
-                    for device_k, device_v, host_k, host_v in self._npu_transfer_buffers(
-                        device_pool
-                    ):
+                    for (
+                        device_k,
+                        device_v,
+                        host_k,
+                        host_v,
+                    ) in self._npu_transfer_buffers(device_pool):
                         transfer_kv_dim_exchange(
                             device_indices=device_indices,
                             host_indices=host_indices,

--- a/python/sglang/srt/mem_cache/pool_host/mha.py
+++ b/python/sglang/srt/mem_cache/pool_host/mha.py
@@ -126,7 +126,7 @@ class MHATokenToKVPoolHost(HostKVCache):
             dtype=torch.uint64,
             device=self.device_pool.device,
         )
-        if self.mtp_draft_device_pools:
+        if self.mtp_draft_device_pools and not _is_npu:
             device_pools = (self.device_pool, *self.mtp_draft_device_pools)
             self.packed_device_k_data_ptrs = torch.cat(
                 [pool.k_data_ptrs for pool in device_pools]
@@ -350,16 +350,19 @@ class MHATokenToKVPoolHost(HostKVCache):
             if self.layout == "page_first_direct":
                 # Ascend-specific: transfer KV data for all layers when layer_id == 0
                 if host_layer_id == 0:
-                    transfer_kv_dim_exchange(
-                        device_indices=device_indices,
-                        host_indices=host_indices,
-                        device_k=device_pool.k_buffer,
-                        host_k=self.k_buffer,
-                        device_v=device_pool.v_buffer,
-                        host_v=self.v_buffer,
-                        page_size=self.page_size,
-                        direction=TransferDirection.H2D,
-                    )
+                    for device_k, device_v, host_k, host_v in self._npu_transfer_buffers(
+                        device_pool
+                    ):
+                        transfer_kv_dim_exchange(
+                            device_indices=device_indices,
+                            host_indices=host_indices,
+                            device_k=device_k,
+                            host_k=host_k,
+                            device_v=device_v,
+                            host_v=host_v,
+                            page_size=self.page_size,
+                            direction=TransferDirection.H2D,
+                        )
             else:
                 raise ValueError(f"Unsupported layout: {self.layout}")
         else:
@@ -379,6 +382,19 @@ class MHATokenToKVPoolHost(HostKVCache):
             device_pool.k_buffer,
             device_pool.v_buffer,
         )
+
+    def _npu_transfer_buffers(self, target_device_pool):
+        layer_start = 0
+        for pool in (target_device_pool, *self.mtp_draft_device_pools):
+            device_k, device_v = pool.get_hicache_transfer_buffers()
+            layer_end = layer_start + device_k.shape[0]
+            yield (
+                device_k,
+                device_v,
+                self.k_buffer[:, layer_start:layer_end],
+                self.v_buffer[:, layer_start:layer_end],
+            )
+            layer_start = layer_end
 
     def backup_from_device_all_layer(
         self, device_pool, host_indices, device_indices, io_backend
@@ -482,16 +498,19 @@ class MHATokenToKVPoolHost(HostKVCache):
                 raise ValueError(f"Unsupported layout: {self.layout}")
         elif io_backend == "kernel_ascend":
             if self.layout == "page_first_direct":
-                transfer_kv_dim_exchange(
-                    device_indices=device_indices,
-                    host_indices=host_indices,
-                    device_k=device_pool.k_buffer,
-                    host_k=self.k_buffer,
-                    device_v=device_pool.v_buffer,
-                    host_v=self.v_buffer,
-                    page_size=self.page_size,
-                    direction=TransferDirection.D2H,
-                )
+                for device_k, device_v, host_k, host_v in self._npu_transfer_buffers(
+                    device_pool
+                ):
+                    transfer_kv_dim_exchange(
+                        device_indices=device_indices,
+                        host_indices=host_indices,
+                        device_k=device_k,
+                        host_k=host_k,
+                        device_v=device_v,
+                        host_v=host_v,
+                        page_size=self.page_size,
+                        direction=TransferDirection.D2H,
+                    )
             else:
                 raise ValueError(f"Unsupported layout: {self.layout}")
         else:

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -250,8 +250,8 @@ def _select_fused_ar_input_for_linear(hidden_states, linear: nn.Module):
 
 
 if _is_npu:
-    from sgl_kernel_npu.norm.split_qkv_rmsnorm_rope import (
-        split_qkvgate_gemma_rmsnorm_rope,
+    from sgl_kernel_npu.norm.split_qkv_rmsnorm_mrope import (
+        triton_split_qkv_rmsnorm_mrope,
     )
 
 
@@ -1158,21 +1158,23 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
 
     def forward_prepare_npu(self, positions, hidden_states, forward_batch):
         qkv, _ = self.qkv_proj(hidden_states)
-        # Calculate first full attention layer ID based on config
-        if self.attn.layer_id == (self.config.full_attention_interval - 1):
-            self.rotary_emb.get_cos_sin_with_position(positions)
+        cos_sin = self.rotary_emb.cos_sin_cache[positions]
+        if cos_sin.device != qkv.device or cos_sin.dtype != qkv.dtype:
+            cos_sin = cos_sin.to(device=qkv.device, dtype=qkv.dtype)
 
-        q, k, v, gate = split_qkvgate_gemma_rmsnorm_rope(
-            qkv,
-            self.rotary_emb.position_sin,
-            self.rotary_emb.position_cos,
-            self.q_size,
-            self.kv_size,
-            self.head_dim,
-            int(self.head_dim * self.partial_rotary_factor),
+        q, k, v, gate = triton_split_qkv_rmsnorm_mrope(
+            qkv=qkv,
+            q_weight=self.q_norm.gemma_weight,
+            k_weight=self.k_norm.gemma_weight,
+            cos_sin=cos_sin,
+            num_q_heads=self.num_heads,
+            num_kv_heads=self.num_kv_heads,
+            head_size=self.head_dim,
             eps=self.q_norm.variance_epsilon,
-            q_weight=self.q_norm.weight,
-            k_weight=self.k_norm.weight,
+            mrope_section=self.rotary_emb.mrope_section,
+            is_interleaved=self.rotary_emb.mrope_interleaved,
+            rope_dim=self.rotary_emb.rotary_dim,
+            has_gate=self.attn_output_gate,
         )
         return q, k, v, gate
 
@@ -1193,11 +1195,7 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
                 positions=positions,
                 hidden_states=hidden_states,
             )
-        elif (
-            not _is_npu
-            or forward_batch.forward_mode.is_extend_or_draft_extend_or_mixed()
-            or not self.attn_output_gate
-        ):
+        elif not _is_npu or not self.attn_output_gate:
             q, k, v, gate = self.forward_prepare_native(
                 positions=positions,
                 hidden_states=hidden_states,

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -250,8 +250,8 @@ def _select_fused_ar_input_for_linear(hidden_states, linear: nn.Module):
 
 
 if _is_npu:
-    from sgl_kernel_npu.norm.split_qkv_rmsnorm_mrope import (
-        triton_split_qkv_rmsnorm_mrope,
+    from sgl_kernel_npu.norm.split_qkv_rmsnorm_rope import (
+        split_qkvgate_gemma_rmsnorm_rope,
     )
 
 
@@ -1158,23 +1158,21 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
 
     def forward_prepare_npu(self, positions, hidden_states, forward_batch):
         qkv, _ = self.qkv_proj(hidden_states)
-        cos_sin = self.rotary_emb.cos_sin_cache[positions]
-        if cos_sin.device != qkv.device or cos_sin.dtype != qkv.dtype:
-            cos_sin = cos_sin.to(device=qkv.device, dtype=qkv.dtype)
+        # Calculate first full attention layer ID based on config
+        if self.attn.layer_id == (self.config.full_attention_interval - 1):
+            self.rotary_emb.get_cos_sin_with_position(positions)
 
-        q, k, v, gate = triton_split_qkv_rmsnorm_mrope(
-            qkv=qkv,
-            q_weight=self.q_norm.gemma_weight,
-            k_weight=self.k_norm.gemma_weight,
-            cos_sin=cos_sin,
-            num_q_heads=self.num_heads,
-            num_kv_heads=self.num_kv_heads,
-            head_size=self.head_dim,
+        q, k, v, gate = split_qkvgate_gemma_rmsnorm_rope(
+            qkv,
+            self.rotary_emb.position_sin,
+            self.rotary_emb.position_cos,
+            self.q_size,
+            self.kv_size,
+            self.head_dim,
+            int(self.head_dim * self.partial_rotary_factor),
             eps=self.q_norm.variance_epsilon,
-            mrope_section=self.rotary_emb.mrope_section,
-            is_interleaved=self.rotary_emb.mrope_interleaved,
-            rope_dim=self.rotary_emb.rotary_dim,
-            has_gate=self.attn_output_gate,
+            q_weight=self.q_norm.weight,
+            k_weight=self.k_norm.weight,
         )
         return q, k, v, gate
 
@@ -1195,7 +1193,11 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
                 positions=positions,
                 hidden_states=hidden_states,
             )
-        elif not _is_npu or not self.attn_output_gate:
+        elif (
+            not _is_npu
+            or forward_batch.forward_mode.is_extend_or_draft_extend_or_mixed()
+            or not self.attn_output_gate
+        ):
             q, k, v, gate = self.forward_prepare_native(
                 positions=positions,
                 hidden_states=hidden_states,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -836,6 +836,28 @@ class ServerArgs:
         "The maximum number of requests in a prefill batch. If not specified, there is no limit.",
         NS("schedule"),
     ] = None
+    max_mm_patch_tokens_per_request: A[
+        Optional[int],
+        Arg(
+            help=(
+                "The maximum number of post-alignment raw ViT patch tokens in one "
+                "request. Unlike image-count limits, this allows arbitrary mixes "
+                "of large and small images within the same visual-work budget."
+            ),
+            type_parser=human_readable_int,
+        ),
+    ] = None
+    max_prefill_mm_patch_tokens: A[
+        Optional[int],
+        Arg(
+            help=(
+                "The maximum total number of post-alignment raw ViT patch tokens "
+                "admitted to one prefill batch. Requests that do not fit remain "
+                "queued for a later batch."
+            ),
+            type_parser=human_readable_int,
+        ),
+    ] = None
     schedule_policy: A[
         str,
         Arg(
@@ -3659,6 +3681,7 @@ class ServerArgs:
 
         # Validate mm_process_config.
         self._handle_multimodal()
+        self._validate_mm_patch_budgets()
         # Validate SSL arguments early.
         self._handle_ssl_validation()
         # Validate transcription/ASR-specific server args.
@@ -4125,6 +4148,15 @@ class ServerArgs:
                     "Granian does not support SSL certificate hot-reloading. "
                     "Use Uvicorn (the default) or handle certificate rotation externally."
                 )
+
+    def _validate_mm_patch_budgets(self):
+        for name in (
+            "max_mm_patch_tokens_per_request",
+            "max_prefill_mm_patch_tokens",
+        ):
+            value = getattr(self, name)
+            if value is not None and value <= 0:
+                raise ValueError(f"--{name.replace('_', '-')} must be positive")
 
     def _handle_multimodal(self):
         """Validate mm_process_config structure before model loading."""

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -817,9 +817,10 @@ def _verify_commit_step_indices(
         != seq_lens_post_verify // mamba_track_interval
     )
     tracking_point = seq_lens_post_verify // mamba_track_interval * mamba_track_interval
-    to_track_ith = torch.clamp(tracking_point - seq_lens_pre_verify - 1, min=0).to(
-        torch.int64
-    )
+    to_track_ith = torch.clamp(
+        torch.minimum(tracking_point - seq_lens_pre_verify, accept_lens - 1),
+        min=0,
+    ).to(torch.int64)
     candidate_track_steps = accept_index[req_idx, to_track_ith] - accept_indices_offset
     mamba_steps_to_track = torch.where(
         to_track_mask,

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -2934,6 +2934,35 @@ def _looks_like_pickle_payload(data: bytes) -> bool:
     return len(data) >= 2 and data[0] == 0x80 and data[1] <= pickle.HIGHEST_PROTOCOL
 
 
+def _looks_like_safetensors_payload(data: bytes) -> bool:
+    """safetensors blobs start with an 8-byte little-endian JSON header length
+    followed by the JSON header itself (which begins with '{')."""
+    if len(data) < 8:
+        return False
+    header_len = int.from_bytes(data[:8], "little")
+    if header_len <= 0 or 8 + header_len > len(data):
+        return False
+    return data[8] == 0x7B  # '{'
+
+
+def deserialize_tensor_payload(data) -> Dict[str, torch.Tensor]:
+    """Deserialize a serialized tensor payload sent over the wire.
+
+    Prefers the safetensors format (no code-execution semantics); falls back to
+    the legacy MultiprocessingSerializer pickle for backward compatibility with
+    old clients (the pickle path remains constrained by SafeUnpickler).
+    """
+    if isinstance(data, str):
+        data = pybase64.b64decode(data, validate=True)
+
+    if _looks_like_safetensors_payload(data):
+        import safetensors.torch
+
+        return safetensors.torch.load(data)
+
+    return MultiprocessingSerializer.deserialize(data)
+
+
 def normalize_serialized_named_tensor_payload(data: SerializedTensorPayload) -> bytes:
     """Normalize a serialized tensor payload to raw MultiprocessingSerializer bytes."""
     if isinstance(data, str):
@@ -2961,16 +2990,17 @@ def normalize_serialized_named_tensor_payloads(
 
 
 class SafeUnpickler(pickle.Unpickler):
+    # Prefix allowlisting remains ONLY for trusted third-party libraries whose
+    # payloads SGLang itself serializes (torch tensors/state, multiprocessing
+    # reductions, NPU storage, peft/transformers objects). SGLang's own
+    # `sglang.srt.*` modules are NOT prefix-trusted anymore: prefix allowlisting
+    # there let an attacker reach reflective primitives
+    # (sglang.srt.utils.common.dynamic_import) and even nested unrestricted
+    # `pickle.loads` helpers (sglang.srt.managers.io_struct._maybe_unwrap_pickle
+    # + PickleWrapper) that defeat the whole sandbox. Internal classes that
+    # legitimate payloads actually reference are instead listed exactly in
+    # ALLOWED_SGLANG_CLASSES.
     ALLOWED_MODULE_PREFIXES = {
-        # --- Python types ---
-        "builtins.",
-        "collections.",
-        "copyreg.",
-        "functools.",
-        "itertools.",
-        "operator.",
-        "types.",
-        "weakref.",
         # --- PyTorch types ---
         "torch.",
         "torch._tensor.",
@@ -2987,20 +3017,95 @@ class SafeUnpickler(pickle.Unpickler):
         # --- multiprocessing ---
         "multiprocessing.resource_sharer.",
         "multiprocessing.reduction.",
-        "pickletools.",
-        # --- PEFT / LoRA ---
+        # --- PEFT / LoRA / tokenizer payloads ---
         "peft.",
         "transformers.",
         "huggingface_hub.",
-        # --- SGLang & Unitest ---
-        "sglang.srt.weight_sync.tensor_bucket.",
-        "sglang.srt.model_executor.model_runner.",
-        "sglang.srt.model_executor.model_runner_components.weight_updater.",
-        "sglang.srt.layers.",
-        "sglang.srt.utils.",
-        "sglang.srt.disaggregation.",
-        "sglang.srt.managers.",
         "torch_npu.",
+    }
+
+    # Exact (module, symbol) allowlist for SGLang-internal classes that real
+    # payloads reference. Nothing else under sglang.srt.* may be loaded.
+    ALLOWED_SGLANG_CLASSES = {
+        ("sglang.srt.weight_sync.tensor_bucket", "FlattenedTensorBucket"),
+        ("sglang.srt.weight_sync.tensor_bucket", "FlattenedTensorMetadata"),
+        (
+            "sglang.srt.model_executor.model_runner_components.weight_updater",
+            "LocalSerializedTensor",
+        ),
+    }
+
+    # Modules whose members must match an exact name allowlist instead of being
+    # allowlisted by module prefix. Only the side-effect-free primitives that
+    # SGLang's own serialized payloads actually need are permitted. Anything
+    # reflective or reachable-to-syscalls (getattr, __import__, eval, open,
+    # operator.attrgetter/itemgetter, pickletools.*, types.CodeType/...,
+    # types.FunctionType/...) is rejected.
+    ALLOWED_CLASSES = {
+        "builtins": {
+            "bool",
+            "bytearray",
+            "bytes",
+            "complex",
+            "dict",
+            "enumerate",
+            "filter",
+            "float",
+            "frozenset",
+            "int",
+            "iter",
+            "list",
+            "map",
+            "object",
+            "range",
+            "reversed",
+            "set",
+            "slice",
+            "str",
+            "tuple",
+            "type",
+            "zip",
+        },
+        "collections": {
+            "Counter",
+            "OrderedDict",
+            "defaultdict",
+            "deque",
+            "namedtuple",
+        },
+        "copyreg": {
+            "_reconstructor",
+            "__newobj__",
+            "__newobj_ex__",
+            "_slotnames",
+        },
+        "functools": {
+            "partial",
+            "reduce",
+        },
+        "itertools": {
+            "chain",
+            "count",
+            "cycle",
+            "islice",
+            "repeat",
+            "starmap",
+            "takewhile",
+            "zip_longest",
+        },
+        # operator.attrgetter / itemgetter / getitem / methodcaller are RCE
+        # primitives; nothing in SGLang's own payloads needs them.
+        "operator": {},
+        # pickletools is only a debugging utility and exposes module refs
+        # (e.g. sys) that enable bypass chains.
+        "pickletools": {},
+        "types": {
+            "ModuleType",
+            "SimpleNamespace",
+        },
+        "weakref": {
+            "ref",
+        },
     }
 
     DENY_CLASSES = {
@@ -3013,6 +3118,15 @@ class SafeUnpickler(pickle.Unpickler):
         ("codecs", "decode"),
         ("types", "CodeType"),
         ("types", "FunctionType"),
+        # High-risk code-loading entry points inside the otherwise-trusted
+        # torch.* prefix (defense in depth): torch.load / torch.hub.load /
+        # torch.utils.cpp_extension.load* can load files or execute code, and
+        # nothing SGLang serializes references them.
+        ("torch", "load"),
+        ("torch.hub", "load"),
+        ("torch.utils.cpp_extension", "load"),
+        ("torch.utils.cpp_extension", "load_inline"),
+        ("torch.jit", "load"),
     }
 
     def find_class(self, module, name):
@@ -3022,6 +3136,21 @@ class SafeUnpickler(pickle.Unpickler):
                 f"Blocked unsafe class loading ({module}.{name}), "
                 f"to prevent exploitation of CVE-2025-10164"
             )
+        # Exact-name allowlist for generic building-block modules.
+        allowed_names = self.ALLOWED_CLASSES.get(module)
+        if allowed_names is not None:
+            if name in allowed_names:
+                return super().find_class(module, name)
+            raise RuntimeError(
+                f"Blocked unsafe class loading ({module}.{name}), "
+                f"to prevent exploitation of CVE-2025-10164"
+            )
+        # Exact (module, symbol) allowlist for SGLang-internal classes that
+        # legitimate payloads reference. No sglang.srt.* module is
+        # prefix-trusted, so reflective helpers (dynamic_import) and nested
+        # pickle.loads helpers (io_struct._maybe_unwrap_pickle) are unreachable.
+        if (module, name) in self.ALLOWED_SGLANG_CLASSES:
+            return super().find_class(module, name)
         # Allowlist of safe-to-load modules.
         if any(
             (module + ".").startswith(prefix) for prefix in self.ALLOWED_MODULE_PREFIXES

--- a/test/registered/ascend/basic_function/HiCache/test_npu_hicache_mamba.py
+++ b/test/registered/ascend/basic_function/HiCache/test_npu_hicache_mamba.py
@@ -1,0 +1,185 @@
+"""NPU HiCache L3 coverage for hybrid Mamba models."""
+
+import os
+import shutil
+import tempfile
+import time
+import unittest
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=400, suite="nightly-1-npu-a3", nightly=True)
+
+TEST_MODEL_MATRIX = {
+    "/root/.cache/modelscope/hub/models/Qwen/Qwen3.5-0.8B": {
+        "target_token_id": 1000,
+    },
+}
+
+
+class TestNPUMambaHiCache(CustomTestCase):
+    """Exercise Mamba state write-back and L3 load-back on NPU."""
+
+    # A reusable Mamba checkpoint must be strictly inside the prompt. Ending the
+    # prompt exactly at 1024 does not make that boundary reusable by a second
+    # identical request. 3200 leaves the 3072 checkpoint inside the prompt and
+    # also exercises the configured 1024-token chunked-prefill path.
+    prompt_tokens = 3200
+
+    @classmethod
+    def setUpClass(cls):
+        cls.models = TEST_MODEL_MATRIX.keys()
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.common_args = [
+            "--tp-size",
+            "1",
+            "--mem-fraction-static",
+            "0.20",
+            "--chunked-prefill-size",
+            "1024",
+            "--page-size",
+            "64",
+            "--enable-hierarchical-cache",
+            "--enable-cache-report",
+            "--hicache-size",
+            "1",
+            "--hicache-storage-backend",
+            "file",
+            "--hicache-storage-prefetch-policy",
+            "wait_complete",
+            "--hicache-write-policy",
+            "write_through",
+            "--hicache-io-backend",
+            "kernel",
+            "--hicache-mem-layout",
+            "page_first_direct",
+        ]
+
+    def _generate(self, token_id: int) -> dict:
+        response = requests.post(
+            f"{self.base_url}/generate",
+            json={
+                "input_ids": [token_id] * self.prompt_tokens,
+                "sampling_params": {
+                    "temperature": 0,
+                    "max_new_tokens": 16,
+                    "ignore_eos": True,
+                },
+            },
+            timeout=120,
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+        return response.json()
+
+    @staticmethod
+    def _storage_files(storage_dir: str) -> set[str]:
+        return {
+            os.path.relpath(os.path.join(root, name), storage_dir)
+            for root, _, names in os.walk(storage_dir)
+            for name in names
+            if os.path.getsize(os.path.join(root, name)) > 0
+        }
+
+    def _wait_for_mamba_storage_file(
+        self, storage_dir: str, files_before: set[str], timeout: float = 30
+    ) -> set[str]:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            files_after = self._storage_files(storage_dir)
+            new_files = files_after - files_before
+            if any("mamba" in name.lower() for name in new_files):
+                return files_after
+            time.sleep(0.1)
+        self.fail("Timed out waiting for a new Mamba HiCache storage file.")
+
+    def test_mamba_state_restores_from_l3(self):
+        for model in self.models:
+            with self.subTest(model=model):
+                storage_dir = tempfile.mkdtemp(prefix="npu_mamba_hicache_")
+                process = None
+                try:
+                    process = popen_launch_server(
+                        model,
+                        self.base_url,
+                        timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+                        other_args=self.common_args,
+                        env={
+                            **os.environ,
+                            "CUDA_VISIBLE_DEVICES": "0",
+                            "SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR": storage_dir,
+                        },
+                    )
+                    target_token_id = TEST_MODEL_MATRIX[model]["target_token_id"]
+                    storage_files_before = self._storage_files(storage_dir)
+                    first = self._generate(target_token_id)
+                    first_meta = first["meta_info"]
+                    self.assertEqual(int(first_meta.get("cached_tokens", 0)), 0)
+
+                    # The first cache hit reaches write_through's hit-count
+                    # threshold and starts the asynchronous L1 -> L2 -> L3 copy.
+                    warm = self._generate(target_token_id)
+                    warm_details = warm["meta_info"].get("cached_tokens_details") or {}
+                    self.assertGreater(
+                        int(warm_details.get("device", 0) or 0),
+                        0,
+                        "Expected an L1 device hit; "
+                        f"got meta_info={warm['meta_info']}",
+                    )
+                    self.assertEqual(
+                        int(warm_details.get("host", 0) or 0),
+                        0,
+                        f"Expected no L2 contribution: {warm_details}",
+                    )
+                    self.assertEqual(
+                        int(warm_details.get("storage", 0) or 0),
+                        0,
+                        f"Expected no L3 contribution: {warm_details}",
+                    )
+
+                    # Do not infer persistence from the request response: wait
+                    # until the Mamba sidecar has physically reached the file
+                    # backend before clearing the in-memory cache levels.
+                    storage_files_after = self._wait_for_mamba_storage_file(
+                        storage_dir, storage_files_before
+                    )
+                    self.assertTrue(storage_files_after - storage_files_before)
+
+                    # Remove L1/L2 residency without clearing the file backend.
+                    flush = requests.post(
+                        f"{self.base_url}/flush_cache",
+                        params={"timeout": 30},
+                        timeout=40,
+                    )
+                    flush.raise_for_status()
+
+                    restored = self._generate(target_token_id)
+                    restored_meta = restored["meta_info"]
+                    details = restored_meta.get("cached_tokens_details") or {}
+
+                    self.assertGreater(
+                        int(details.get("storage", 0) or 0),
+                        0,
+                        "Expected an L3 storage hit; " f"got meta_info={restored_meta}",
+                    )
+                    self.assertEqual(
+                        restored["text"],
+                        first["text"],
+                        "Mamba L3 restore changed deterministic generation output.",
+                    )
+                finally:
+                    if process:
+                        kill_process_tree(process.pid)
+                    shutil.rmtree(storage_dir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/attention/test_vision_seqlens.py
+++ b/test/registered/unit/layers/attention/test_vision_seqlens.py
@@ -1,7 +1,12 @@
 import pytest
 import torch
 
-from sglang.srt.layers.attention.vision import SingletonCache, resolve_max_seqlen
+from sglang.srt.layers.attention.vision import (
+    SingletonCache,
+    prepare_vision_attention_metadata,
+    resolve_ascend_actual_seq_lengths,
+    resolve_max_seqlen,
+)
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=2, suite="base-a-test-cpu")
@@ -19,6 +24,17 @@ def test_resolve_max_seqlen_caches_on_singleton_carrier():
 
     assert resolve_max_seqlen(source, cu_seqlens) == 5
     assert source._max_seqlen == 5
+
+
+def test_resolve_ascend_actual_seq_lengths_uses_cumulative_ends():
+    metadata = prepare_vision_attention_metadata(
+        torch.tensor([0, 3, 8, 10], dtype=torch.int32),
+        device=torch.device("cpu"),
+    )
+
+    # Per-image lengths are not valid actual_seq_lengths for the TND layout.
+    assert metadata.seq_lens.tolist() == [3, 5, 2]
+    assert resolve_ascend_actual_seq_lengths(metadata).tolist() == [3, 8, 10]
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/mem_cache/test_hicache_staged_write_back_dispatch.py
+++ b/test/registered/unit/mem_cache/test_hicache_staged_write_back_dispatch.py
@@ -515,6 +515,57 @@ class TestHiCacheStagedWriteBackDispatch(CustomTestCase):
                 torch.equal(host.v_buffer[host_indices, layer_id], expected_v[layer_id])
             )
 
+    def test_npu_mha_transfer_uses_contiguous_hicache_backing(self):
+        host = MHATokenToKVPoolHost.__new__(MHATokenToKVPoolHost)
+        host.layout = "page_first_direct"
+        host.page_size = 2
+        host.kv_buffer = torch.empty(2, 2, 2, 2, 1, 1)
+
+        device_k = torch.empty(2, 3, 2, 1, 1)
+        device_v = torch.empty_like(device_k)
+        device_pool = SimpleNamespace(
+            # FIA exposes lists here; these must not be sent to the operator.
+            k_buffer=[device_k[layer].reshape(-1, 1, 1, 1) for layer in range(2)],
+            v_buffer=[device_v[layer].reshape(-1, 1, 1, 1) for layer in range(2)],
+            get_hicache_transfer_buffers=mock.Mock(return_value=(device_k, device_v)),
+        )
+        host_indices = _indices(0, 2)
+        device_indices = _indices(2, 4)
+        directions = SimpleNamespace(H2D="H2D", D2H="D2H")
+
+        with (
+            mock.patch(
+                f"{MHA_POOL_HOST_MODULE}.TransferDirection",
+                directions,
+                create=True,
+            ),
+            mock.patch(
+                f"{MHA_POOL_HOST_MODULE}.transfer_kv_dim_exchange",
+                create=True,
+            ) as transfer,
+        ):
+            host.backup_from_device_all_layer(
+                device_pool,
+                host_indices,
+                device_indices,
+                io_backend="kernel_ascend",
+            )
+            host.load_to_device_per_layer(
+                device_pool,
+                host_indices,
+                device_indices,
+                layer_id=0,
+                io_backend="kernel_ascend",
+            )
+
+        self.assertEqual(device_pool.get_hicache_transfer_buffers.call_count, 2)
+        self.assertEqual(transfer.call_count, 2)
+        for call in transfer.call_args_list:
+            self.assertIs(call.kwargs["device_k"], device_k)
+            self.assertIs(call.kwargs["device_v"], device_v)
+        self.assertEqual(transfer.call_args_list[0].kwargs["direction"], "D2H")
+        self.assertEqual(transfer.call_args_list[1].kwargs["direction"], "H2D")
+
     def test_mla_backup_then_load_roundtrip_uses_staged(self):
         layer_num = 2
         kv_cache_dim = 5
@@ -677,6 +728,79 @@ class TestHiCacheStagedWriteBackDispatch(CustomTestCase):
         self.assertTrue(
             torch.equal(
                 device_pool.mamba_cache.conv[0][:, device_indices], expected_conv
+            )
+        )
+
+    def test_mamba_kernel_npu_backup_then_load_roundtrip(self):
+        num_layers = 2
+        host_indices = torch.tensor([1, 3], dtype=torch.int64)
+        device_indices = torch.tensor([2, 5], dtype=torch.int64)
+        temporal = torch.arange(num_layers * 8 * 3, dtype=torch.float32).reshape(
+            num_layers, 8, 3
+        )
+        conv = (
+            torch.arange(num_layers * 8 * 2, dtype=torch.float32).reshape(
+                num_layers, 8, 2
+            )
+            / 8
+        ).to(torch.bfloat16)
+        device_pool = SimpleNamespace(
+            mamba_cache=SimpleNamespace(temporal=temporal.clone(), conv=[conv.clone()])
+        )
+        expected_temporal = device_pool.mamba_cache.temporal[:, device_indices].clone()
+        expected_conv = device_pool.mamba_cache.conv[0][:, device_indices].clone()
+
+        host = MambaPoolHost.__new__(MambaPoolHost)
+        host.layout = "page_first_direct"
+        host.num_mamba_layers = num_layers
+        host.temporal_state_elem_size = 3
+        host.temporal_buffer = torch.zeros(8, num_layers, 1, 3, dtype=torch.float32)
+        host.conv_state_shapes = [(2,)]
+        host.conv_buffer = [torch.zeros(8, num_layers, 1, 2, dtype=torch.bfloat16)]
+        host.temporal_staging_buffer = None
+        host.conv_staging_buffers = [None]
+        host._temporal_can_use_jit = False
+        host._conv_can_use_jit = [False]
+        host.temporal_device_ptrs = torch.empty(0, dtype=torch.uint64)
+        host.conv_device_ptrs = [torch.empty(0, dtype=torch.uint64)]
+
+        host.backup_from_device_all_layer(
+            device_pool,
+            host_indices,
+            device_indices,
+            io_backend="kernel_ascend",
+        )
+        device_pool.mamba_cache.temporal.zero_()
+        device_pool.mamba_cache.conv[0].zero_()
+        for layer_id in range(num_layers):
+            host.load_to_device_per_layer(
+                device_pool,
+                host_indices,
+                device_indices,
+                layer_id,
+                io_backend="kernel_ascend",
+            )
+
+        self.assertTrue(
+            torch.equal(
+                device_pool.mamba_cache.temporal[:, device_indices], expected_temporal
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                device_pool.mamba_cache.conv[0][:, device_indices], expected_conv
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                host.temporal_buffer[host_indices].squeeze(2).transpose(0, 1),
+                expected_temporal,
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                host.conv_buffer[0][host_indices].squeeze(2).transpose(0, 1),
+                expected_conv,
             )
         )
 

--- a/test/registered/unit/mem_cache/test_npu_mamba_async_layout.py
+++ b/test/registered/unit/mem_cache/test_npu_mamba_async_layout.py
@@ -1,0 +1,184 @@
+import os
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+
+import sglang.srt.mem_cache.pool_host.mamba as mamba_pool_host
+from sglang.srt.mem_cache.pool_host.mamba import (
+    MambaPoolHost,
+    _npu_hicache_mamba_io_mode,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestNPUMambaAsyncConfig(unittest.TestCase):
+    def test_accepts_explicit_sync_and_async_modes(self):
+        for mode in ("sync", "async"):
+            with self.subTest(mode=mode), patch.dict(
+                os.environ, {"SGLANG_NPU_HICACHE_MAMBA_IO": mode}
+            ):
+                self.assertEqual(_npu_hicache_mamba_io_mode(), mode)
+
+    def test_rejects_auto_mode(self):
+        with patch.dict(
+            os.environ, {"SGLANG_NPU_HICACHE_MAMBA_IO": "auto"}
+        ), self.assertRaisesRegex(ValueError, "must be one of"):
+            _npu_hicache_mamba_io_mode()
+
+    @patch.object(mamba_pool_host, "_is_npu", True)
+    @patch.object(
+        mamba_pool_host,
+        "_npu_hicache_mamba_io_mode",
+        return_value="async",
+    )
+    @patch.object(mamba_pool_host, "transfer_state_per_layer_direct_pf_lf", None)
+    @patch.object(mamba_pool_host, "transfer_state_all_layer_direct_lf_pf", None)
+    def test_async_requires_native_operator(self, _mock_mode):
+        pool = MambaPoolHost.__new__(MambaPoolHost)
+
+        with self.assertRaisesRegex(
+            RuntimeError, "per-layer PF->LF and all-layer LF->PF"
+        ):
+            pool._configure_npu_mamba_io()
+
+    def test_async_h2d_is_dispatched_per_component_from_copy_helper(self):
+        pool = MambaPoolHost.__new__(MambaPoolHost)
+        host = torch.empty(4, 3, 1, 2, 4)
+        device_layers = torch.empty(3, 5, 2, 4)
+        host_indices = torch.tensor([1, 3])
+        device_indices = torch.tensor([0, 4])
+
+        transfer_op = MagicMock()
+        with patch.object(
+            mamba_pool_host,
+            "transfer_state_per_layer_direct_pf_lf",
+            transfer_op,
+        ), patch.object(
+            mamba_pool_host,
+            "_npu_hicache_mamba_io_mode",
+            return_value="async",
+        ):
+            pool._copy_tensor_pf_lf(
+                src=host,
+                dst=device_layers[2],
+                src_indices=host_indices,
+                dst_indices=device_indices,
+                layer_id=2,
+                num_layers=3,
+                io_backend="kernel_ascend",
+            )
+
+        transfer_op.assert_called_once()
+        call = transfer_op.call_args.kwargs
+        self.assertIs(call["src"], host)
+        self.assertEqual(call["dst"].data_ptr(), device_layers[2].data_ptr())
+        self.assertIs(call["src_indices"], host_indices)
+        self.assertIs(call["dst_indices"], device_indices)
+        self.assertEqual(call["layer_id"], 2)
+
+    def test_async_d2h_is_dispatched_per_component_from_copy_helper(self):
+        pool = MambaPoolHost.__new__(MambaPoolHost)
+        device_layers = torch.empty(3, 5, 2, 4)
+        host = torch.empty(4, 3, 1, 2, 4)
+        device_indices = torch.tensor([0, 4])
+        host_indices = torch.tensor([1, 3])
+
+        transfer_op = MagicMock()
+        with patch.object(
+            mamba_pool_host,
+            "transfer_state_all_layer_direct_lf_pf",
+            transfer_op,
+        ), patch.object(
+            mamba_pool_host,
+            "_npu_hicache_mamba_io_mode",
+            return_value="async",
+        ):
+            pool._copy_tensor_all_layers_lf_pf(
+                src_layers=device_layers,
+                dst=host,
+                src_indices=device_indices,
+                dst_indices=host_indices,
+                num_layers=3,
+                io_backend="kernel_ascend",
+                src_ptrs=torch.empty(0),
+            )
+
+        transfer_op.assert_called_once_with(
+            device_states=[device_layers],
+            host_states=[host],
+            device_indices=device_indices,
+            host_indices=host_indices,
+        )
+
+    def test_sync_h2d_torch_fallback_is_preserved(self):
+        pool = MambaPoolHost.__new__(MambaPoolHost)
+        host = torch.arange(4 * 3 * 1 * 2, dtype=torch.float32).reshape(4, 3, 1, 2)
+        device_layers = torch.zeros(3, 5, 2)
+        host_indices = torch.tensor([1, 3])
+        device_indices = torch.tensor([0, 4])
+
+        with patch.object(
+            mamba_pool_host,
+            "_npu_hicache_mamba_io_mode",
+            return_value="sync",
+        ):
+            pool._copy_tensor_pf_lf(
+                src=host,
+                dst=device_layers[2],
+                src_indices=host_indices,
+                dst_indices=device_indices,
+                layer_id=2,
+                num_layers=3,
+                io_backend="kernel_ascend",
+            )
+
+        torch.testing.assert_close(
+            device_layers[2, device_indices], host[host_indices, 2, 0]
+        )
+
+    def test_copy_helpers_keep_static_signatures(self):
+        self.assertIsInstance(
+            MambaPoolHost.__dict__["_copy_tensor_pf_lf"], staticmethod
+        )
+        self.assertIsInstance(
+            MambaPoolHost.__dict__["_copy_tensor_all_layers_lf_pf"], staticmethod
+        )
+
+    def test_conv_only_load_skips_empty_temporal_component(self):
+        pool = MambaPoolHost.__new__(MambaPoolHost)
+        pool.layout = "page_first_direct"
+        pool.temporal_state_elem_size = 0
+        pool.num_mamba_layers = 3
+        pool.temporal_buffer = torch.empty(4, 3, 1, 0)
+        pool.conv_state_shapes = [torch.Size([2, 4])]
+        pool.conv_buffer = [torch.empty(4, 3, 1, 2, 4)]
+        pool._copy_tensor_pf_lf = MagicMock()
+        device_pool = SimpleNamespace(
+            mamba_cache=SimpleNamespace(
+                temporal=torch.empty(3, 4, 0),
+                conv=[torch.empty(3, 4, 2, 4)],
+            )
+        )
+
+        pool.load_to_device_per_layer(
+            device_pool=device_pool,
+            host_indices=torch.tensor([1]),
+            device_indices=torch.tensor([2]),
+            layer_id=1,
+            io_backend="kernel_ascend",
+        )
+
+        pool._copy_tensor_pf_lf.assert_called_once()
+        call = pool._copy_tensor_pf_lf.call_args.kwargs
+        self.assertIs(call["src"], pool.conv_buffer[0])
+        self.assertEqual(
+            call["dst"].data_ptr(), device_pool.mamba_cache.conv[0][1].data_ptr()
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/utils/test_safe_unpickler.py
+++ b/test/registered/unit/utils/test_safe_unpickler.py
@@ -1,0 +1,295 @@
+"""Unit tests for SafeUnpickler exact-name allowlist hardening.
+
+Covers CVE-2026-15969 (GHSA-h74r-pwx2-6qr2): the previous prefix-based
+allowlist let an attacker chain builtins.getattr + builtins.__import__ (or
+operator.attrgetter + pickletools.sys) into os.system() even though
+("os", "system") was on the deny-list.
+"""
+
+import io
+import operator
+import pickle
+import unittest
+
+from sglang.srt.utils.common import (
+    SafeUnpickler,
+    _looks_like_safetensors_payload,
+    deserialize_tensor_payload,
+    safe_pickle_loads,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _Reduce:
+    """Pickles as callable(*args) so we can emit a GLOBAL for any callable."""
+
+    def __init__(self, func, args):
+        self._func = func
+        self._args = args
+
+    def __reduce__(self):
+        return (self._func, self._args)
+
+
+def _pglob(module, name):
+    return b"c" + module.encode() + b"\n" + name.encode() + b"\n"
+
+
+def _pstr(s):
+    b = s.encode()
+    return b"\x8c" + bytes([len(b)]) + b
+
+
+_PROTO = b"\x80\x04"
+_T1, _T2, _REDUCE, _STOP = b"\x85", b"\x86", b"R", b"."
+
+
+def _build_rce_chain(cmd):
+    """Full CVE-2026-15969 chain: getattr(__import__('os'), 'system')(cmd)."""
+    return (
+        _PROTO
+        + _pglob("builtins", "getattr")
+        + _pglob("builtins", "__import__")
+        + _pstr("os")
+        + _T1
+        + _REDUCE
+        + _pstr("system")
+        + _T2
+        + _REDUCE
+        + _pstr(cmd)
+        + _T1
+        + _REDUCE
+        + _STOP
+    )
+
+
+def _build_operator_bypass_chain(cmd):
+    """operator.attrgetter/itemgetter + pickletools.sys chain."""
+    return (
+        _PROTO
+        + _pglob("operator", "attrgetter")
+        + _pstr("system")
+        + _T1
+        + _REDUCE
+        + _pglob("operator", "itemgetter")
+        + _pstr("os")
+        + _T1
+        + _REDUCE
+        + _pglob("operator", "attrgetter")
+        + _pstr("modules")
+        + _T1
+        + _REDUCE
+        + _pglob("pickletools", "sys")
+        + _T1
+        + _REDUCE
+        + _T1
+        + _REDUCE
+        + _T1
+        + _REDUCE
+        + _pstr(cmd)
+        + _T1
+        + _REDUCE
+        + _STOP
+    )
+
+
+def _build_io_struct_nested_pickle_chain(evil: bytes) -> bytes:
+    """io_struct nested-pickle bypass:
+    _maybe_unwrap_pickle(PickleWrapper(evil)) -> plain pickle.loads(evil)."""
+    assert len(evil) < 256
+    return (
+        _PROTO
+        + _pglob("sglang.srt.managers.io_struct", "_maybe_unwrap_pickle")
+        + _pglob("sglang.srt.managers.io_struct", "PickleWrapper")
+        + b"\x43"
+        + bytes([len(evil)])
+        + evil  # SHORT_BINBYTES
+        + _T1
+        + _REDUCE
+        + _T1
+        + _REDUCE
+        + _STOP
+    )
+
+
+class TestSafeUnpickler(CustomTestCase):
+    def _blocked(self, func, args):
+        payload = pickle.dumps(_Reduce(func, args))
+        with self.assertRaises(RuntimeError):
+            safe_pickle_loads(payload)
+
+    def test_import_blocked(self):
+        # __import__("os") is the first half of the RCE chain
+        self._blocked(__import__, ("os",))
+
+    def test_getattr_blocked(self):
+        # getattr(os, "system") is the second half of the RCE chain
+        self._blocked(getattr, (object(), "__class__"))
+
+    def test_operator_primitives_blocked(self):
+        # operator.attrgetter / itemgetter / getitem bypass primitives
+        self._blocked(operator.attrgetter, ("system",))
+        self._blocked(operator.itemgetter, ("os",))
+        self._blocked(operator.getitem, (dict(), "k"))
+
+    def test_pickletools_blocked(self):
+        with self.assertRaises(RuntimeError):
+            safe_pickle_loads(_pglob("pickletools", "sys") + _STOP)
+
+    def test_dangerous_builtins_blocked(self):
+        for func, args in [
+            (setattr, (object(), "x", 1)),
+            (eval, ("1",)),
+            (exec, ("pass",)),
+            (open, ("/etc/passwd",)),
+        ]:
+            self._blocked(func, args)
+
+    def test_full_rce_chain_blocked(self):
+        with self.assertRaises(RuntimeError):
+            SafeUnpickler(
+                io.BytesIO(_build_rce_chain("touch /tmp/sglang_pwned"))
+            ).load()
+
+    def test_full_operator_bypass_chain_blocked(self):
+        with self.assertRaises(RuntimeError):
+            SafeUnpickler(
+                io.BytesIO(_build_operator_bypass_chain("touch /tmp/sglang_pwned2"))
+            ).load()
+
+    def test_dynamic_import_blocked(self):
+        # sglang.srt.utils prefix is not trusted anymore: GLOBAL to the
+        # reflective dynamic_import helper must be rejected (would otherwise
+        # return os.system for dynamic_import("os.system") -> RCE).
+        with self.assertRaises(RuntimeError):
+            SafeUnpickler(
+                io.BytesIO(
+                    _PROTO
+                    + _pglob("sglang.srt.utils.common", "dynamic_import")
+                    + _pstr("os.system")
+                    + _T1
+                    + _REDUCE
+                    + _STOP
+                )
+            ).load()
+
+    def test_dynamic_import_blocked_via_weight_updater(self):
+        # Same function re-exported into another previously-prefix-trusted module.
+        with self.assertRaises(RuntimeError):
+            SafeUnpickler(
+                io.BytesIO(
+                    _PROTO
+                    + _pglob(
+                        "sglang.srt.model_executor.model_runner_components.weight_updater",
+                        "dynamic_import",
+                    )
+                    + _pstr("os.system")
+                    + _T1
+                    + _REDUCE
+                    + _STOP
+                )
+            ).load()
+
+    def test_io_struct_nested_pickle_blocked(self):
+        # Nested unrestricted pickle.loads bypass: outer GLOBALs to
+        # io_struct._maybe_unwrap_pickle / PickleWrapper must be rejected now
+        # that sglang.srt.managers. is not prefix-trusted.
+        evil = _build_rce_chain("touch /tmp/sglang_pwned_nested")
+        with self.assertRaises(RuntimeError):
+            SafeUnpickler(io.BytesIO(_build_io_struct_nested_pickle_chain(evil))).load()
+
+    def test_torch_load_entry_points_blocked(self):
+        for module, name in [
+            ("torch", "load"),
+            ("torch.hub", "load"),
+            ("torch.utils.cpp_extension", "load"),
+            ("torch.utils.cpp_extension", "load_inline"),
+            ("torch.jit", "load"),
+        ]:
+            with self.assertRaises(RuntimeError):
+                SafeUnpickler(io.BytesIO(_PROTO + _pglob(module, name) + _STOP)).load()
+
+    def test_sglang_internal_class_not_allowlisted_blocked(self):
+        # A random sglang.srt class (e.g. under managers) must not be loadable.
+        with self.assertRaises(RuntimeError):
+            SafeUnpickler(
+                io.BytesIO(
+                    _PROTO
+                    + _pglob("sglang.srt.managers.io_struct", "PickleWrapper")
+                    + _STOP
+                )
+            ).load()
+
+    def test_benign_payloads_still_load(self):
+        for obj in [
+            {"a": 1, "b": [1, 2, 3]},
+            [1, 2, 3],
+            (1, "x"),
+            b"bytes",
+            {1, 2, 3},
+            frozenset({1, 2}),
+            "hello",
+            42,
+            3.14,
+            True,
+        ]:
+            self.assertEqual(safe_pickle_loads(pickle.dumps(obj)), obj)
+
+    def test_tensor_roundtrip(self):
+        import torch
+
+        t = torch.zeros(2, 3)
+        restored = safe_pickle_loads(pickle.dumps(t))
+        torch.testing.assert_close(restored, t)
+
+    def test_flattened_tensor_bucket_roundtrip(self):
+        import torch
+
+        from sglang.srt.weight_sync.tensor_bucket import FlattenedTensorBucket
+
+        ftb = FlattenedTensorBucket(flattened_tensor=torch.randn(10), metadata={"a": 1})
+        restored = safe_pickle_loads(pickle.dumps(ftb))
+        torch.testing.assert_close(restored.flattened_tensor, ftb.flattened_tensor)
+        self.assertEqual(restored.metadata, ftb.metadata)
+
+    def test_local_serialized_tensor_roundtrip(self):
+        import torch
+
+        from sglang.srt.model_executor.model_runner_components.weight_updater import (
+            LocalSerializedTensor,
+        )
+
+        lst = LocalSerializedTensor(
+            values=[pickle.dumps(torch.randn(2)) for _ in range(2)]
+        )
+        restored = safe_pickle_loads(pickle.dumps(lst))
+        torch.testing.assert_close(restored.get(0), lst.get(0))
+
+    def test_safetensors_wire_format_roundtrip(self):
+        import safetensors.torch
+        import torch
+
+        payload = safetensors.torch.save({"a": torch.randn(2, 3), "b": torch.ones(4)})
+        self.assertTrue(_looks_like_safetensors_payload(payload))
+        self.assertFalse(_looks_like_safetensors_payload(pickle.dumps({"x": 1})))
+
+        restored = deserialize_tensor_payload(payload)
+        self.assertEqual(set(restored), {"a", "b"})
+        torch.testing.assert_close(restored["a"], safetensors.torch.load(payload)["a"])
+
+    def test_legacy_pickle_still_accepted_via_wire_helper(self):
+        # Backward-compat: old pickle clients still work through the hardened
+        # SafeUnpickler path (no reflection primitives reachable anymore).
+        import torch
+
+        t = torch.zeros(2, 3)
+        blob = pickle.dumps({"x": t})
+        restored = deserialize_tensor_payload(blob)
+        torch.testing.assert_close(restored["x"], t)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

The existing NPU MRoPE path cannot correctly handle multimodal position embeddings, causing accuracy issues in image grounding tasks.

This PR replaces `split_qkvgate_gemma_rmsnorm_rope` with the fused `triton_split_qkv_rmsnorm_mrope` kernel used by vLLM Ascend. The new kernel supports Q/K RMSNorm, QKV/Gate splitting, and MRoPE in a single operation. It is also enabled during the prefill/extend phase, avoiding the problematic `npu_mrope` path for multimodal tokens.

## Modifications

- Use `triton_split_qkv_rmsnorm_mrope` in the Qwen3.5/Qwen3.6 NPU attention path.
- Enable the fused NPU path during prefill/extend as well as decode.

## Accuracy Tests

Validated with an image-grounding case on Ascend NPU. The model now returns the expected coordinates:


## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32582997060](https://github.com/sgl-project/sglang/actions/runs/32582997060)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32582996931](https://github.com/sgl-project/sglang/actions/runs/32582996931)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32582997029](https://github.com/sgl-project/sglang/actions/runs/32582997029)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->