### PR TITLE
[Router] Add abort_request fan-out support

### DIFF
--- a/experimental/sgl-router/src/server/app.rs
+++ b/experimental/sgl-router/src/server/app.rs
@@ -76,6 +76,10 @@ pub fn build_router(ctx: Arc<AppContext>) -> Router {
             "/flush_cache",
             post(crate::server::routes::cache::flush_cache),
         )
+        .route(
+            "/abort_request",
+            post(crate::server::routes::abort::abort_request),
+        )
         // After routing, so MatchedPath is set for every route.
         .layer(middleware::from_fn_with_state(ctx.clone(), count_requests))
         .with_state(ctx)

--- a/experimental/sgl-router/src/server/routes/abort.rs
+++ b/experimental/sgl-router/src/server/routes/abort.rs
@@ -80,10 +80,7 @@ impl AbortRequestResult {
 /// Status: `200 OK` when every worker handled the request (or the fleet is
 /// empty); `502 BAD_GATEWAY` when at least one worker failed. The JSON body
 /// always carries the full breakdown so a partial failure is actionable.
-pub async fn abort_request(
-    State(ctx): State<Arc<AppContext>>,
-    body: Bytes,
-) -> Response {
+pub async fn abort_request(State(ctx): State<Arc<AppContext>>, body: Bytes) -> Response {
     let workers = ctx.registry.all();
     let total_workers = workers.len();
 
@@ -99,13 +96,8 @@ pub async fn abort_request(
             .into_response();
     }
 
-    let (successful, failed) = fan_out_abort(
-        &workers,
-        &ctx.proxy.client,
-        ctx.proxy.request_timeout,
-        body,
-    )
-    .await;
+    let (successful, failed) =
+        fan_out_abort(&workers, &ctx.proxy.client, ctx.proxy.request_timeout, body).await;
 
     // Partial failure is an operational event an operator needs to see at the
     // common production log level — match the rest of the router, which warns
@@ -225,11 +217,8 @@ mod tests {
         (format!("http://127.0.0.1:{port}"), tx)
     }
 
-    async fn spawn_recording_abort_worker() -> (
-        String,
-        oneshot::Sender<()>,
-        mpsc::UnboundedReceiver<Bytes>,
-    ) {
+    async fn spawn_recording_abort_worker(
+    ) -> (String, oneshot::Sender<()>, mpsc::UnboundedReceiver<Bytes>) {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let port = listener.local_addr().unwrap().port();
         let (body_tx, body_rx) = mpsc::unbounded_channel();
@@ -251,11 +240,7 @@ mod tests {
                 })
                 .await;
         });
-        (
-            format!("http://127.0.0.1:{port}"),
-            shutdown_tx,
-            body_rx,
-        )
+        (format!("http://127.0.0.1:{port}"), shutdown_tx, body_rx)
     }
 
     /// Reserve a port then drop the listener so a connect attempt fails fast

--- a/experimental/sgl-router/src/server/routes/abort.rs
+++ b/experimental/sgl-router/src/server/routes/abort.rs
@@ -1,0 +1,438 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Request-abortion admin endpoint.
+
+use crate::server::app_context::AppContext;
+use crate::workers::worker::Worker;
+use axum::body::Bytes;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use futures::stream::{self, StreamExt};
+use reqwest::Client;
+use serde::Serialize;
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Cap on concurrent in-flight `/abort_request` requests. Bounds how many
+/// aborts are issued at once when a large fleet is targeted; the rest queue
+/// and run as slots free up.
+const MAX_CONCURRENT_ABORTS: usize = 32;
+
+/// One worker that failed to process the abort, with a human-readable reason.
+#[derive(Serialize)]
+pub struct FailedWorker {
+    pub worker: String,
+    pub error: String,
+}
+
+/// Per-worker breakdown of a `/abort_request` fan-out. `total_workers` is the
+/// registry size snapshotted at call time; every registered worker is
+/// attempted, so `successful.len() + failed.len() == total_workers`.
+/// `message` is a human/log summary — the HTTP status is authoritative.
+#[derive(Serialize)]
+pub struct AbortRequestResult {
+    pub successful: Vec<String>,
+    pub failed: Vec<FailedWorker>,
+    pub total_workers: usize,
+    pub message: String,
+}
+
+impl AbortRequestResult {
+    /// Build a result from a completed fan-out, deriving `message` from the
+    /// outcome counts so the count/message coherence lives in one place
+    /// rather than at each call site.
+    fn from_outcomes(
+        total_workers: usize,
+        successful: Vec<String>,
+        failed: Vec<FailedWorker>,
+    ) -> Self {
+        let message = if total_workers == 0 {
+            "No workers registered; nothing to abort".to_string()
+        } else if failed.is_empty() {
+            format!("Abort request reached all {} workers", total_workers)
+        } else {
+            format!(
+                "Abort request: {} succeeded, {} failed",
+                successful.len(),
+                failed.len()
+            )
+        };
+        Self {
+            successful,
+            failed,
+            total_workers,
+            message,
+        }
+    }
+}
+
+/// `POST /abort_request` - fan SGLang's `/abort_request` call out to every
+/// registered worker and report a per-worker breakdown.
+///
+/// The router does not track which worker owns a request ID, so it targets the
+/// whole fleet. Workers that do not own the request treat the abort as a no-op.
+/// This deliberately bypasses the circuit breaker so an abort still reaches a
+/// worker whose breaker is open without changing request-routing health state.
+///
+/// Status: `200 OK` when every worker handled the request (or the fleet is
+/// empty); `502 BAD_GATEWAY` when at least one worker failed. The JSON body
+/// always carries the full breakdown so a partial failure is actionable.
+pub async fn abort_request(
+    State(ctx): State<Arc<AppContext>>,
+    body: Bytes,
+) -> Response {
+    let workers = ctx.registry.all();
+    let total_workers = workers.len();
+
+    if workers.is_empty() {
+        // An abort against an empty fleet is a no-op, but it usually means a
+        // discovery/config problem (the router knows of no workers), so warn
+        // rather than stay silent.
+        tracing::warn!("abort_request called but no workers are registered");
+        return (
+            StatusCode::OK,
+            Json(AbortRequestResult::from_outcomes(0, Vec::new(), Vec::new())),
+        )
+            .into_response();
+    }
+
+    let (successful, failed) = fan_out_abort(
+        &workers,
+        &ctx.proxy.client,
+        ctx.proxy.request_timeout,
+        body,
+    )
+    .await;
+
+    // Partial failure is an operational event an operator needs to see at the
+    // common production log level — match the rest of the router, which warns
+    // on upstream failures.
+    if failed.is_empty() {
+        tracing::info!(total_workers, "abort_request: all workers reached");
+    } else {
+        tracing::warn!(
+            total_workers,
+            succeeded = successful.len(),
+            failed = failed.len(),
+            "abort_request: some workers failed to flush",
+        );
+    }
+
+    let status = if failed.is_empty() {
+        StatusCode::OK
+    } else {
+        StatusCode::BAD_GATEWAY
+    };
+
+    (
+        status,
+        Json(AbortRequestResult::from_outcomes(
+            total_workers,
+            successful,
+            failed,
+        )),
+    )
+        .into_response()
+}
+
+/// POST `/abort_request` to each worker concurrently (bounded by
+/// [`MAX_CONCURRENT_ABORTS`]) and partition the outcomes into
+/// (successful URLs, failed workers). A non-2xx status or a transport
+/// error both count as failures.
+async fn fan_out_abort(
+    workers: &[Arc<Worker>],
+    client: &Client,
+    timeout: Duration,
+    body: Bytes,
+) -> (Vec<String>, Vec<FailedWorker>) {
+    // Snapshot the URLs into owned Strings up front so the per-worker stream
+    // does not borrow the `workers` slice across the await points.
+    let urls: Vec<String> = workers.iter().map(|w| w.url.clone()).collect();
+
+    let outcomes = stream::iter(urls)
+        .map(|url| {
+            let client = client.clone();
+            let body = body.clone();
+            async move {
+                let abort_url = format!("{}/abort_request", url.trim_end_matches('/'));
+                let result = client
+                    .post(&abort_url)
+                    .header(reqwest::header::CONTENT_TYPE, "application/json")
+                    .body(body)
+                    .timeout(timeout)
+                    .send()
+                    .await;
+                (url, result)
+            }
+        })
+        .buffer_unordered(MAX_CONCURRENT_ABORTS)
+        .collect::<Vec<_>>()
+        .await;
+
+    let mut successful = Vec::new();
+    let mut failed = Vec::new();
+    for (url, result) in outcomes {
+        match result {
+            Ok(resp) if resp.status().is_success() => successful.push(url),
+            Ok(resp) => failed.push(FailedWorker {
+                worker: url,
+                error: format!("HTTP {}", resp.status()),
+            }),
+            // Render the full source chain (`{:#}`), not just reqwest's outer
+            // message, so a connect-refused / DNS / TLS / timeout cause is
+            // visible in the per-worker error rather than collapsed away.
+            Err(e) => failed.push(FailedWorker {
+                worker: url,
+                error: format!("{:#}", anyhow::Error::new(e)),
+            }),
+        }
+    }
+    (successful, failed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::discovery::{ModelId, WorkerId, WorkerMode, WorkerSpec};
+    use crate::server::app_context::AppContext;
+    use axum::body::Body;
+    use axum::http::Request;
+    use axum::routing::post;
+    use axum::Router;
+    use http_body_util::BodyExt;
+    use serde_json::Value;
+    use tokio::net::TcpListener;
+    use tokio::sync::{mpsc, oneshot};
+    use tower::ServiceExt;
+
+    /// Spawn a fake worker that answers `POST /abort_request` with `status`.
+    /// Returns its base URL and a shutdown handle (drop or send to stop).
+    async fn spawn_fake_abort_worker(status: StatusCode) -> (String, oneshot::Sender<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let app = Router::new().route("/abort_request", post(move || async move { status }));
+        let (tx, rx) = oneshot::channel::<()>();
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app)
+                .with_graceful_shutdown(async move {
+                    let _ = rx.await;
+                })
+                .await;
+        });
+        (format!("http://127.0.0.1:{port}"), tx)
+    }
+
+    async fn spawn_recording_abort_worker() -> (
+        String,
+        oneshot::Sender<()>,
+        mpsc::UnboundedReceiver<Bytes>,
+    ) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let (body_tx, body_rx) = mpsc::unbounded_channel();
+        let app = Router::new().route(
+            "/abort_request",
+            post(move |body: Bytes| {
+                let body_tx = body_tx.clone();
+                async move {
+                    let _ = body_tx.send(body);
+                    StatusCode::OK
+                }
+            }),
+        );
+        let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app)
+                .with_graceful_shutdown(async move {
+                    let _ = shutdown_rx.await;
+                })
+                .await;
+        });
+        (
+            format!("http://127.0.0.1:{port}"),
+            shutdown_tx,
+            body_rx,
+        )
+    }
+
+    /// Reserve a port then drop the listener so a connect attempt fails fast
+    /// with ConnectionRefused (no waiting on the connect timeout).
+    fn unused_port() -> u16 {
+        use std::net::TcpListener;
+        let l = TcpListener::bind("127.0.0.1:0").unwrap();
+        l.local_addr().unwrap().port()
+    }
+
+    fn ctx_with_workers(urls: &[&str]) -> Arc<AppContext> {
+        let ctx = AppContext::stub();
+        for (i, url) in urls.iter().enumerate() {
+            ctx.registry
+                .add(WorkerSpec {
+                    id: WorkerId(format!("w-{i}")),
+                    url: (*url).to_string(),
+                    mode: WorkerMode::Plain,
+                    model_ids: vec![ModelId("stub-model".into())],
+                    bootstrap_port: None,
+                })
+                .expect("worker accepted");
+        }
+        Arc::new(ctx)
+    }
+
+    async fn post_abort(ctx: Arc<AppContext>) -> (StatusCode, Value) {
+        let app = crate::server::app::build_router(ctx);
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/abort_request")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"rid":"request-1"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = res.status();
+        let bytes = res.into_body().collect().await.unwrap().to_bytes();
+        let body: Value = serde_json::from_slice(&bytes).unwrap();
+        (status, body)
+    }
+
+    #[tokio::test]
+    async fn all_workers_succeed_returns_200() {
+        let (u1, _s1) = spawn_fake_abort_worker(StatusCode::OK).await;
+        let (u2, _s2) = spawn_fake_abort_worker(StatusCode::OK).await;
+        let (status, body) = post_abort(ctx_with_workers(&[&u1, &u2])).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["total_workers"], 2);
+        assert_eq!(body["successful"].as_array().unwrap().len(), 2);
+        assert!(body["failed"].as_array().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn forwards_request_body_to_worker() {
+        let (url, _shutdown, mut received_bodies) = spawn_recording_abort_worker().await;
+
+        let (status, _) = post_abort(ctx_with_workers(&[&url])).await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            received_bodies.recv().await.unwrap(),
+            Bytes::from_static(br#"{"rid":"request-1"}"#)
+        );
+    }
+
+    #[tokio::test]
+    async fn partial_failure_returns_502_with_breakdown() {
+        let (ok_url, _s1) = spawn_fake_abort_worker(StatusCode::OK).await;
+        let (err_url, _s2) = spawn_fake_abort_worker(StatusCode::INTERNAL_SERVER_ERROR).await;
+        let (status, body) = post_abort(ctx_with_workers(&[&ok_url, &err_url])).await;
+        assert_eq!(status, StatusCode::BAD_GATEWAY);
+        assert_eq!(body["total_workers"], 2);
+        assert_eq!(
+            body["successful"].as_array().unwrap(),
+            &vec![Value::String(ok_url.clone())]
+        );
+        let failed = body["failed"].as_array().unwrap();
+        assert_eq!(failed.len(), 1);
+        assert_eq!(failed[0]["worker"], err_url);
+        assert!(failed[0]["error"].as_str().unwrap().contains("500"));
+    }
+
+    #[tokio::test]
+    async fn empty_registry_returns_200_with_zero_workers() {
+        let (status, body) = post_abort(Arc::new(AppContext::stub())).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["total_workers"], 0);
+        assert!(body["successful"].as_array().unwrap().is_empty());
+        assert!(body["failed"].as_array().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn unreachable_worker_is_reported_failed() {
+        let url = format!("http://127.0.0.1:{}", unused_port());
+        let (status, body) = post_abort(ctx_with_workers(&[&url])).await;
+        assert_eq!(status, StatusCode::BAD_GATEWAY);
+        let failed = body["failed"].as_array().unwrap();
+        assert_eq!(failed.len(), 1);
+        assert_eq!(failed[0]["worker"], url);
+    }
+
+    /// A non-5xx, non-2xx status (e.g. 404) is still a failure and still
+    /// drives the top-level 502, with the status echoed in the error.
+    #[tokio::test]
+    async fn non_5xx_error_status_is_reported_failed() {
+        let (ok_url, _s1) = spawn_fake_abort_worker(StatusCode::OK).await;
+        let (nf_url, _s2) = spawn_fake_abort_worker(StatusCode::NOT_FOUND).await;
+        let (status, body) = post_abort(ctx_with_workers(&[&ok_url, &nf_url])).await;
+        assert_eq!(status, StatusCode::BAD_GATEWAY);
+        let failed = body["failed"].as_array().unwrap();
+        assert_eq!(failed.len(), 1);
+        assert_eq!(failed[0]["worker"], nf_url);
+        assert!(failed[0]["error"].as_str().unwrap().contains("404"));
+    }
+
+    /// A worker URL with a trailing slash must still resolve to
+    /// `<url>/abort_request` (not `<url>//abort_request`). Guards the
+    /// `trim_end_matches('/')` in `fan_out_abort` against a regression that
+    /// would 404 every slash-suffixed worker.
+    #[tokio::test]
+    async fn worker_url_with_trailing_slash_is_reached() {
+        let (base, _s) = spawn_fake_abort_worker(StatusCode::OK).await;
+        let url = format!("{base}/");
+        let (status, body) = post_abort(ctx_with_workers(&[&url])).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            body["successful"].as_array().unwrap(),
+            &vec![Value::String(url.clone())]
+        );
+        assert!(body["failed"].as_array().unwrap().is_empty());
+    }
+
+    /// The fan-out targets the whole fleet, not one model's pool: prefill
+    /// and decode workers must both receive the abort.
+    /// Asserted through the handler — `registry::all()` returning mixed modes
+    /// is necessary but not sufficient if a mode filter ever slips into the
+    /// handler path.
+    #[tokio::test]
+    async fn reaches_prefill_and_decode_workers() {
+        let (p_url, _s1) = spawn_fake_abort_worker(StatusCode::OK).await;
+        let (d_url, _s2) = spawn_fake_abort_worker(StatusCode::OK).await;
+        let ctx = AppContext::stub();
+        ctx.registry
+            .add(WorkerSpec {
+                id: WorkerId("p".into()),
+                url: p_url.clone(),
+                mode: WorkerMode::Prefill,
+                model_ids: vec![ModelId("stub-model".into())],
+                bootstrap_port: Some(8998),
+            })
+            .expect("prefill accepted");
+        ctx.registry
+            .add(WorkerSpec {
+                id: WorkerId("d".into()),
+                url: d_url.clone(),
+                mode: WorkerMode::Decode,
+                model_ids: vec![ModelId("stub-model".into())],
+                bootstrap_port: None,
+            })
+            .expect("decode accepted");
+
+        let (status, body) = post_abort(Arc::new(ctx)).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["total_workers"], 2);
+        let mut succeeded: Vec<&str> = body["successful"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        succeeded.sort_unstable();
+        let mut expected = [p_url.as_str(), d_url.as_str()];
+        expected.sort_unstable();
+        assert_eq!(succeeded, expected);
+    }
+}

--- a/experimental/sgl-router/src/server/routes/mod.rs
+++ b/experimental/sgl-router/src/server/routes/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod abort;
 pub mod cache;
 pub mod chat;
 pub mod health;


### PR DESCRIPTION
## Summary

Add an `/abort_request` endpoint to the SGLang router.

The router does not currently track which worker owns a particular request ID. To ensure that an abort reaches the correct worker, the endpoint forwards the original request body to every registered worker. Workers that do not own the request can safely treat it as a no-op.

## Changes

- Add `POST /abort_request` to the router.
- Forward the original JSON request body to all registered workers.
- Preserve the `application/json` content type when forwarding requests.
- Limit concurrent worker requests to avoid unbounded fan-out.
- Handle plain, prefill, and decode workers consistently.
- Return a per-worker success and failure breakdown.
- Return `502 Bad Gateway` when one or more workers cannot process the request.
- Add coverage for successful fan-out, partial failures, unreachable workers, trailing-slash URLs, empty registries, mixed worker modes, and request-body forwarding.

## Testing

- Verified the patch with `git diff --check`.
- Rust tests could not be executed locally because the Rust toolchain is not available in the current environment.

Fixes #6531

## AI Assistance

OpenAI Codex assisted with the implementation and test preparation. I reviewed the proposed behavior and code changes and take responsibility for the contribution.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32479001030](https://github.com/sgl-project/sglang/actions/runs/32479001030)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32479000825](https://github.com/sgl-project/sglang/actions/runs/32479000825)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->