### PR TITLE
feat(kimi-k3): support DFLASH speculative decoding

### DIFF
--- a/python/sglang/srt/models/kimi_k3.py
+++ b/python/sglang/srt/models/kimi_k3.py
@@ -2814,6 +2814,10 @@ class KimiK3LinearForCausalLM(nn.Module):
         self.capture_aux_hidden_states = True
         self.model.dspark_layers_to_capture = list(layer_ids)
 
+    def set_dflash_layers_to_capture(self, layer_ids: list[int]) -> None:
+        # DFLASH uses the same aux-hidden capture mechanism as DSPARK.
+        self.set_dspark_layers_to_capture(layer_ids)
+
     @torch.no_grad()
     def forward(
         self,
@@ -3232,6 +3236,10 @@ class KimiK3ForConditionalGeneration(nn.Module):
                 "DSPARK layer capture is not available in encoder-only mode"
             )
         self.language_model.set_dspark_layers_to_capture(layer_ids)
+
+    def set_dflash_layers_to_capture(self, layer_ids: list[int]) -> None:
+        # DFLASH uses the same aux-hidden capture mechanism as DSPARK.
+        self.language_model.set_dflash_layers_to_capture(layer_ids)
 
     def preprocess_mm_for_encoder(
         self,


### PR DESCRIPTION
## Summary

Add `set_dflash_layers_to_capture` to both the inner `KimiK3` language model and the outer `KimiK3ForConditionalGeneration` wrapper so the DFLASH draft path can register aux hidden-state capture. DFLASH and DSPARK share the same aux-hidden capture mechanism; the methods are thin aliases of the existing `set_dspark_layers_to_capture`.

The official DFLASH draft checkpoint for Kimi-K3 ([`modal-labs/Kimi-K3-DFlash`](https://huggingface.co/modal-labs/Kimi-K3-DFlash)) currently fails to start with:

```
ValueError: Model KimiK3ForConditionalGeneration implements neither set_dspark_layers_to_capture nor set_dflash_layers_to_capture, one of which is required for DFLASH/DSPARK.
```

## Test Plan

Verified on RTX 6000D (sm_120) with sglang 0.5.16 (same code shape as main):

```
--speculative-algorithm DFLASH \
--speculative-draft-model-path /data/hf_models/Kimi-K3-DFlash \
--speculative-dflash-block-size 16 \
--speculative-draft-attention-backend trtllm_mha
```

- Server starts; `DFLASH draft runner ready. mask_token=<|MASK|>, mask_token_id=163592`
- GSM8K c8 (40 req, osl 256): **accept length 6.49** (vs DSPARK bs3 1.82 / bs7 1.42), TPOT 43 ms, output throughput 129 tok/s (+18% vs non-spec 109 tok/s)
- SPEED-Bench 16k c8 with block-size 8: accept length 3.56, output 17.2 tok/s (vs non-spec 17.9)
- Note: this build's DFLASH path for K3 does not use the `--enable-gdn-replayssm-spec` flag (not present in this version); the verify path runs correctly without it.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32443225702](https://github.com/sgl-project/sglang/actions/runs/32443225702)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32443225449](https://github.com/sgl-project/sglang/actions/runs/32443225449)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32443225592](https://github.com/sgl-project/sglang/actions/runs/32443225592)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->