### PR TITLE
[docs] Retune the Qwen3.8-27B RTX 5090 DFLASH2 cells against 1cf2b8c

### DIFF
--- a/docs/cookbook/autoregressive/Qwen/Qwen3.8-27B.mdx
+++ b/docs/cookbook/autoregressive/Qwen/Qwen3.8-27B.mdx
@@ -22,7 +22,11 @@ pip install uv
 uv pip install sglang
 
 # For the DFLASH2 cells only — DFlash2 selector support is newer than the
-# latest release, so install from source (Method 2) instead of the line above.
+# latest release, so build from the commit those cells were validated on
+# instead of the line above:
+# git clone https://github.com/sgl-project/sglang.git && cd sglang
+# git checkout 1cf2b8c54d81802abc15dcf23a29b9cc687bc01e   # PR #35496
+# uv pip install -e "python[all]"
 ```
 
 Then run the **Python** output of the command panel below in that environment.
@@ -34,9 +38,11 @@ Then run the **Python** output of the command panel below in that environment.
 ```bash Command
 docker pull lmsysorg/sglang:qwen38-27b
 
-# For the DFLASH2 cells only — that tag predates DFlash2 selector support,
-# so pull a nightly built from main instead:
-# docker pull lmsysorg/sglang:dev
+# For the DFLASH2 cells only — that tag predates DFlash2 selector support.
+# Build the image from the commit those cells were validated on instead:
+# git clone https://github.com/sgl-project/sglang.git && cd sglang
+# git checkout 1cf2b8c54d81802abc15dcf23a29b9cc687bc01e   # PR #35496
+# docker build -t sglang:dflash2 -f docker/Dockerfile .
 ```
 
 For how to launch the image, see [Install → Method 3: Using Docker](../../../docs/get-started/install#method-3-using-docker). Substitute the inner `sglang serve ...` with what the command generator below produces.
@@ -46,14 +52,16 @@ For how to launch the image, see [Install → Method 3: Using Docker](../../../d
 </Tabs>
 
 <Warning>
-**DFLASH2 needs a build that tracks main.** DFlash2 landed in
-[#35371](https://github.com/sgl-project/sglang/pull/35371), and DFlash2 + NVFP4
-— the quantized `lm_head` path — in
-[#35496](https://github.com/sgl-project/sglang/pull/35496). Both are newer than
-the pinned `lmsysorg/sglang:qwen38-27b` tag and than the latest PyPI release; a
-build without #35496 fails on the NVFP4 cells at boot with `requires a dense
-FP16/BF16/FP32 target lm_head`. Every other recipe on this page — no
-speculation, MTP, DSpark — runs on the pinned tag as written.
+**DFLASH2 needs a build from `1cf2b8c` (PR
+[#35496](https://github.com/sgl-project/sglang/pull/35496)) or newer.** DFlash2
+landed in [#35371](https://github.com/sgl-project/sglang/pull/35371) and its
+quantized-`lm_head` path — what the NVFP4 cells need — in #35496, both newer
+than the pinned `lmsysorg/sglang:qwen38-27b` tag and than the latest PyPI
+release. A build without #35496 fails on the NVFP4 cells at boot with `requires
+a dense FP16/BF16/FP32 target lm_head`. The DFLASH2 pins on this page were
+measured on `1cf2b8c` exactly, which is why both install paths above check that
+commit out rather than tracking a moving branch. Every other recipe on this
+page — no speculation, MTP, DSpark — runs on the pinned tag as written.
 </Warning>
 
 </Accordion>
@@ -269,16 +277,18 @@ checkpoint's calibration scales automatically.
   RTX PRO 6000 BF16/FP8 cells boot and serve; on H200, DGX Spark and GB300
   those cells carry the **Final Verification In Progress**
   badge. The
-  RTX PRO 6000 recipe needs no changes. On the 32GB RTX 5090 the SSM dtype row
-  greys float32 out for this pick, and the recipe runs `--mamba-ssm-dtype
-  bfloat16` at `--mem-fraction-static 0.88`, which the panel re-pins
-  automatically. fp32 has no serviceable mem-fraction on that card: with the
-  ratio pinned at 10 so state slots are not the binding term, 0.945 and 0.92
-  OOM inside the prefill CUDA-graph capture, 0.90 OOMs on the first request,
-  and 0.88 and below size the state pool below the five (Low-Latency) or four
-  (High-Throughput) slots a single request needs. bf16 is the better operating
-  point there regardless — measured faster than fp32 for this draft, the
-  opposite of the EAGLE trade, so measure before assuming.
+  RTX PRO 6000 recipe needs no changes. On the 32GB RTX 5090 the pins differ per
+  state dtype, and the panel applies them automatically. bfloat16 serves at
+  `--mem-fraction-static 0.88` on the balanced ratio (0.90, DSpark's pin, OOMs
+  on the first request). float32 reaches only the High-Throughput tier, at
+  `--mem-fraction-static 0.895` with `--mamba-full-memory-ratio 10` overriding
+  the balanced value — these cells pin `--max-running-requests 1`, so the
+  balanced ratio provisions KV for concurrency the recipe never uses and
+  starves the state pool of the slots fp32 needs. The Low-Latency tier is
+  greyed out for float32: it needs five fp32 slots plus a full request's KV,
+  and no mem-fraction holds both — buying the fifth slot cuts KV to 7,752
+  tokens against the 9,216 one 8192/1024 request needs, while every
+  mem-fraction with a large enough pool dies in prefill graph capture.
 - **Hardware fit**: FP8 weights ~28.5GB (not serviceable beyond bs≤2 on
   32GB cards); NVFP4 weights ~16.5GB (recommended for RTX 5090-class GPUs).
 - `--mamba-radix-cache-strategy extra_buffer_lazy` lowers the state cost per

--- a/docs/cookbook/autoregressive/Qwen/Qwen3.8-27B.mdx
+++ b/docs/cookbook/autoregressive/Qwen/Qwen3.8-27B.mdx
@@ -269,18 +269,16 @@ checkpoint's calibration scales automatically.
   RTX PRO 6000 BF16/FP8 cells boot and serve; on H200, DGX Spark and GB300
   those cells carry the **Final Verification In Progress**
   badge. The
-  RTX PRO 6000 recipe needs no changes. On the 32GB RTX 5090 prefer
-  `--mamba-ssm-dtype bfloat16` at `--mem-fraction-static 0.90`: measured
-  strictly better than float32 for this draft (6.1 vs 8.3 ms TPOT, accept
-  3.30 vs 3.09) — the opposite of the EAGLE trade, so measure before assuming.
-  float32 still fits, but only at `--mem-fraction-static 0.945` with
-  `--mamba-full-memory-ratio 10` pinned in place of the balanced value: the
-  L = 9216 ratio leaves the fp32 state pool one slot short at every
-  serviceable mem-fraction (0.94 allocates four of Low-Latency's five slots;
-  0.95 OOMs at runtime), and the re-weighted split leaves the Low-Latency KV
-  pool a single-request envelope (~9.4k tokens) — no headroom for longer
-  requests or radix reuse. The panel's DFLASH2 option applies these re-pins
-  automatically.
+  RTX PRO 6000 recipe needs no changes. On the 32GB RTX 5090 the SSM dtype row
+  greys float32 out for this pick, and the recipe runs `--mamba-ssm-dtype
+  bfloat16` at `--mem-fraction-static 0.88`, which the panel re-pins
+  automatically. fp32 has no serviceable mem-fraction on that card: with the
+  ratio pinned at 10 so state slots are not the binding term, 0.945 and 0.92
+  OOM inside the prefill CUDA-graph capture, 0.90 OOMs on the first request,
+  and 0.88 and below size the state pool below the five (Low-Latency) or four
+  (High-Throughput) slots a single request needs. bf16 is the better operating
+  point there regardless — measured faster than fp32 for this draft, the
+  opposite of the EAGLE trade, so measure before assuming.
 - **Hardware fit**: FP8 weights ~28.5GB (not serviceable beyond bs≤2 on
   32GB cards); NVFP4 weights ~16.5GB (recommended for RTX 5090-class GPUs).
 - `--mamba-radix-cache-strategy extra_buffer_lazy` lowers the state cost per

--- a/docs/src/snippets/configs/Qwen/qwen3.8-27b.jsx
+++ b/docs/src/snippets/configs/Qwen/qwen3.8-27b.jsx
@@ -133,25 +133,16 @@ export const config = {
           // pool one slot short at every serviceable mem-fraction (see the
           // DFlash2 bullet in Configuration Tips).
           stripPrefixes: (sel) =>
-            sel.hw === "rtx5090"
-              ? sel.ssmDtype === "float32"
-                ? ["--mem-fraction-static", "--mamba-full-memory-ratio"]
-                : ["--mem-fraction-static"]
-              : [],
+            sel.hw === "rtx5090" ? ["--mem-fraction-static"] : [],
           flags: (sel) => [
             "--speculative-algorithm DFLASH",
             "--speculative-draft-model-path incoai/Qwen3.8-27B-DFlash2",
             "--speculative-num-draft-tokens 8",
-            // Measured on the 5090: bf16 state serves at 0.90 (DSPARK's
-            // pin); fp32 fits only at 0.945 + ratio 10 (0.94 is one state
-            // slot short, 0.95 OOMs at runtime) and leaves the Low-Latency
-            // KV pool a single-request envelope.
-            ...(sel.hw === "rtx5090"
-              ? sel.ssmDtype === "float32"
-                ? ["--mem-fraction-static 0.945",
-                   "--mamba-full-memory-ratio 10"]
-                : ["--mem-fraction-static 0.90"]
-              : []),
+            // Measured on the 5090 against main: the bf16 state pool serves at
+            // 0.88 (0.90, DSPARK's pin, OOMs on the first request). fp32 has no
+            // serviceable mem-fraction here at all, so the SSM dtype row greys
+            // it out for this pick.
+            ...(sel.hw === "rtx5090" ? ["--mem-fraction-static 0.88"] : []),
           ],
         },
       ],
@@ -186,9 +177,22 @@ export const config = {
       title: "Mamba SSM Dtype",
       default: "float32",
       options: [
-        // Open on every platform, including with DSPARK on the 5090 (serves
-        // at mem-fraction 0.92 with the engine-default 2048 prefill chunk).
-        { id: "float32", label: "float32", flags: ["--mamba-ssm-dtype float32"] },
+        // Open on every platform except the 32GB RTX 5090 under DFLASH2:
+        // there the fp32 state pool and the prefill CUDA-graph capture cannot
+        // both fit, at any mem-fraction. Measured on main (2026-08-21, ratio
+        // pinned at 10 so slots are not the binding term): 0.945 and 0.92 OOM
+        // inside `Capture target prefill CUDA graph`, 0.90 OOMs on the first
+        // request, and 0.88 / 0.86 / 0.84 size the state pool below the 5 (LL)
+        // / 4 (HT) slots one request needs. bf16 state halves the pool and
+        // serves, and is the faster cell there anyway.
+        {
+          id: "float32", label: "float32",
+          disabled: (sel) => sel.hw === "rtx5090" && sel.spec === "dflash",
+          disableReason:
+            "On the 32GB RTX 5090 the fp32 GDN state pool and the prefill CUDA-graph " +
+            "capture do not both fit alongside the DFlash2 draft — use bfloat16",
+          flags: ["--mamba-ssm-dtype float32"],
+        },
         {
           id: "bfloat16", label: "bfloat16",
           disabled: (sel) => sel.hw === "rtx5090" && sel.quant !== "nvfp4",

--- a/docs/src/snippets/configs/Qwen/qwen3.8-27b.jsx
+++ b/docs/src/snippets/configs/Qwen/qwen3.8-27b.jsx
@@ -128,21 +128,32 @@ export const config = {
           disabled: (sel) => sel.hw === "rtx5090" && sel.quant !== "nvfp4",
           disableReason:
             "On the 32GB RTX 5090 the DFlash2 draft model only fits on top of the NVFP4 weights",
-          // 5090: mem-fraction re-pins like DSPARK's, and fp32 additionally
-          // re-pins the ratio — the balanced L=9216 value leaves the state
-          // pool one slot short at every serviceable mem-fraction (see the
-          // DFlash2 bullet in Configuration Tips).
+          // fp32 is the one case that needs the balanced ratio overridden, so
+          // that family is stripped too and re-emitted below.
           stripPrefixes: (sel) =>
-            sel.hw === "rtx5090" ? ["--mem-fraction-static"] : [],
+            sel.hw === "rtx5090"
+              ? sel.ssmDtype === "float32"
+                ? ["--mem-fraction-static", "--mamba-full-memory-ratio"]
+                : ["--mem-fraction-static"]
+              : [],
           flags: (sel) => [
             "--speculative-algorithm DFLASH",
             "--speculative-draft-model-path incoai/Qwen3.8-27B-DFlash2",
             "--speculative-num-draft-tokens 8",
-            // Measured on the 5090 against main: the bf16 state pool serves at
-            // 0.88 (0.90, DSPARK's pin, OOMs on the first request). fp32 has no
-            // serviceable mem-fraction here at all, so the SSM dtype row greys
-            // it out for this pick.
-            ...(sel.hw === "rtx5090" ? ["--mem-fraction-static 0.88"] : []),
+            // Measured on the 5090 at commit 1cf2b8c, the build the Install
+            // accordion pins for this pick. bf16 serves at 0.88 on the balanced
+            // ratio (0.90, DSPARK's pin, OOMs on the first request). fp32 needs
+            // 0.895 AND the balanced ratio overridden to 10: these cells pin
+            // --max-running-requests 1, so the balanced value provisions KV for
+            // concurrency this recipe never uses, starving the state pool of the
+            // slots fp32 needs. Only High-Throughput reaches fp32 (S=4); the SSM
+            // dtype row greys fp32 out for Low-Latency (S=5).
+            ...(sel.hw === "rtx5090"
+              ? sel.ssmDtype === "float32"
+                ? ["--mem-fraction-static 0.895",
+                   "--mamba-full-memory-ratio 10"]
+                : ["--mem-fraction-static 0.88"]
+              : []),
           ],
         },
       ],
@@ -187,10 +198,21 @@ export const config = {
         // serves, and is the faster cell there anyway.
         {
           id: "float32", label: "float32",
-          disabled: (sel) => sel.hw === "rtx5090" && sel.spec === "dflash",
+          // Only the Low-Latency tier is out of reach: it needs S=5 fp32 slots
+          // (735MB) plus >=9216 KV tokens for one request, and no mem-fraction
+          // holds both -- at 0.8975/r14 the pool buys the 5th slot but KV falls
+          // to 7752 tokens and generation stops after one token, while every
+          // mem-fraction with a big enough pool (>=0.90) dies in graph capture.
+          // High-Throughput needs one slot fewer and does fit; see the DFLASH2
+          // option's pins.
+          disabled: (sel) =>
+            sel.hw === "rtx5090" &&
+            sel.spec === "dflash" &&
+            sel.tier === "low-latency",
           disableReason:
-            "On the 32GB RTX 5090 the fp32 GDN state pool and the prefill CUDA-graph " +
-            "capture do not both fit alongside the DFlash2 draft — use bfloat16",
+            "On the 32GB RTX 5090 the Low-Latency tier cannot hold five fp32 state " +
+            "slots and a full request's KV at once — use bfloat16, or the " +
+            "High-Throughput tier which fits fp32",
           flags: ["--mamba-ssm-dtype float32"],
         },
         {


### PR DESCRIPTION
## Motivation

The DFLASH2 cells added in #35663 carry RTX 5090 pins that were measured on a build the page never tells anyone to install. Re-testing each recipe **against the build its own users are pointed at** shows the DFLASH2 5090 pins fail there, while every DSPARK cell is fine.

Targeting, which is what makes the difference:

- **DSPARK** → the pinned `lmsysorg/sglang:qwen38-27b` container. Re-verified: **all four cells serve exactly as shipped, no change in this PR.**
- **DFLASH2** → a build with the DFlash2 selector, which the container does not have (it registers `DFlashDraftModel`/`DFlashLagunaForCausalLM`, while the checkpoint declares `DFlash2DraftModel`). The install instructions now pin commit `1cf2b8c` (#35496), and every DFLASH2 pin below was measured there.

## Modifications

- Install accordion: both paths (pip and Docker) now check out `1cf2b8c` explicitly rather than tracking a moving branch, since the pins are commit-specific.
- DFLASH2 RTX 5090 bfloat16: mem-fraction **0.90 → 0.88** (balanced ratio unchanged).
- DFLASH2 RTX 5090 float32, High-Throughput: **0.895** with `--mamba-full-memory-ratio 10` overriding the balanced value. These cells pin `--max-running-requests 1`, so the balanced ratio provisions KV for concurrency the recipe never uses and starves the state pool of the slots fp32 needs.
- DFLASH2 RTX 5090 float32, Low-Latency: greyed out — the only unreachable cell.
- Configuration Tips bullet rewritten to match. No `_deployment.jsx` change; the existing `reseatHiddenPicks` moves the selection to bfloat16 when the greyed combination is picked.

## Accuracy Tests

N/A (docs only).

## Speed Tests and Profiling

RTX 5090 32GB, `RadixArk/Qwen3.8-27B-NVFP4`, ISL 8192 / OSL 1024, concurrency 1, exact-shape checks.

**DSPARK on the container build — shipped pins, all pass:**

| cell | pin | result |
|---|---|---|
| fp32 LL | 0.92 / r 6.63 | OK — pool 17,745, K=5, 10.17 ms, accept 2.29 |
| fp32 HT | 0.92 / r 6.12 | OK — pool 21,324, K=4, 10.18 ms, accept 2.29 |
| bf16 LL | 0.90 / r 3.38 | OK — pool 33,699, K=9, 7.57 ms, accept 2.59 |
| bf16 HT | 0.90 / r 3.12 | OK — pool 35,523, K=8, 7.62 ms, accept 2.59 |

**DFLASH2 on `1cf2b8c`:**

| cell | shipped | result | new pin |
|---|---|---|---|
| bf16 LL | 0.90 | OOM on first request | **0.88** — pool 27,452, 7.01 ms, accept 3.01 |
| bf16 HT | 0.90 | OOM on first request | **0.88** — pool 29,276, 7.01 ms, accept 3.01 |
| fp32 HT | 0.945 / r 10 | capture OOM | **0.895 / r 10** — pool 9,410, K=4, 7.46 ms, accept 3.09 (reproduced twice) |
| fp32 LL | 0.945 / r 10 | capture OOM | greyed — see below |

**Why fp32 Low-Latency is unreachable.** With the balanced ratio, every mem-fraction from 0.89 to 0.93 fails: 0.91–0.93 in graph capture, 0.90 and below with a state pool under the five slots the tier needs. With the ratio overridden to buy that fifth slot, the pool is bought out of KV and generation stops after one token:

| override | K | KV tokens (need 9,216) | outcome |
|---|---|---|---|
| 0.8975 / r 14 | 5 | 7,752 | boots, 1 token per request |
| 0.895 / r 20 | 5 | 5,831 | boots, 1 token per request |
| 0.899 / r 12, 0.899 / r 16, 0.90 / r 12 | — | — | runtime OOM |

High-Throughput needs one slot fewer (S=4), which is exactly why it fits and Low-Latency does not.

## Note for maintainers

The underlying cause of the DFLASH2 retune is #33352, which removed the 4 GiB free-memory gate on automatic prefill CUDA-graph capture that #31204 added. Builds carrying that gate fall back to eager prefill when headroom is short; builds without it attempt the capture and fail with `num_active_captures_ > 0 INTERNAL ASSERT FAILED ... please report a bug to PyTorch`, which gives no hint that `--mem-fraction-static` is the knob. That is worth a friendlier diagnostic independently of this PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32448088614](https://github.com/sgl-project/sglang/actions/runs/32448088614)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32448088509](https://github.com/sgl-project/sglang/actions/runs/32448088509)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->