### PR TITLE
fix(speculative): reject zero-probability draft tokens

### DIFF
--- a/python/sglang/kernels/aot/csrc/speculative/speculative_sampling.cuh
+++ b/python/sglang/kernels/aot/csrc/speculative/speculative_sampling.cuh
@@ -77,7 +77,8 @@ __global__ void TreeSpeculativeSamplingTargetOnly(
       DType target_prob_single = target_probs[cur_prob_offset + draft_token_id];
       prob_acc += target_prob_single;
 
-      if (coin <= prob_acc / threshold_acc || target_prob_single >= threshold_single) {
+      const bool has_target_mass = target_prob_single > DType(0);
+      if (has_target_mass && (coin < prob_acc / threshold_acc || target_prob_single >= threshold_single)) {
         // accept token
         prob_acc = 0.;
         cur_prob_offset = (bx * num_draft_tokens + cur_index) * d;

--- a/python/sglang/kernels/aot/tests/speculative/test_speculative_sampling.py
+++ b/python/sglang/kernels/aot/tests/speculative/test_speculative_sampling.py
@@ -16,9 +16,11 @@ test_cases = [
     (
         0,  # threshold_single
         0,  # threshold_acc
-        [1, 2, 18, -1, -1, -1, 11, -1, -1, -1, 12, 18],
-        [[0, 1, 2, -1], [6, 10, 11, -1]],
-        [2, 2],
+        # Zero-probability candidates must not be accepted just because the
+        # single-token threshold is zero.
+        [3, -1, -1, 4, 5, 18, 11, -1, -1, -1, 12, 18],
+        [[0, 3, 4, 5], [6, 10, 11, -1]],
+        [3, 2],
     ),
 ]
 
@@ -125,6 +127,109 @@ def test_tree_speculative_sampling_target_only(
     assert (
         accept_token_num.tolist() == expected_accept_token_num
     ), f"Accept token num mismatch for thresholds ({threshold_single}, {threshold_acc})"
+
+
+def _run_target_only_sampling(
+    candidates,
+    retrive_next_token,
+    retrive_next_sibling,
+    target_probs,
+    uniform_samples,
+    threshold_single=1.0,
+    threshold_acc=1.0,
+):
+    device = "cuda"
+    num_draft_tokens = len(candidates)
+
+    candidates = torch.tensor([candidates], dtype=torch.int64, device=device)
+    retrive_index = torch.arange(
+        num_draft_tokens, dtype=torch.int64, device=device
+    ).unsqueeze(0)
+    retrive_next_token = torch.tensor(
+        [retrive_next_token], dtype=torch.int64, device=device
+    )
+    retrive_next_sibling = torch.tensor(
+        [retrive_next_sibling], dtype=torch.int64, device=device
+    )
+    uniform_samples = torch.tensor(
+        [uniform_samples], dtype=torch.float32, device=device
+    )
+    target_probs = torch.tensor([target_probs], dtype=torch.float32, device=device)
+    draft_probs = torch.zeros_like(target_probs)
+    predicts = torch.full((num_draft_tokens,), -1, dtype=torch.int32, device=device)
+    accept_index = torch.full((1, 2), -1, dtype=torch.int32, device=device)
+    accept_token_num = torch.zeros(1, dtype=torch.int32, device=device)
+
+    tree_speculative_sampling_target_only(
+        predicts=predicts,
+        accept_index=accept_index,
+        accept_token_num=accept_token_num,
+        candidates=candidates,
+        retrive_index=retrive_index,
+        retrive_next_token=retrive_next_token,
+        retrive_next_sibling=retrive_next_sibling,
+        uniform_samples=uniform_samples,
+        uniform_samples_for_final_sampling=torch.zeros(
+            1, dtype=torch.float32, device=device
+        ),
+        target_probs=target_probs,
+        draft_probs=draft_probs,
+        threshold_single=threshold_single,
+        threshold_acc=threshold_acc,
+        deterministic=True,
+    )
+
+    return predicts, accept_index, accept_token_num
+
+
+@pytest.mark.parametrize("threshold_single", [0.0, 1.0])
+def test_zero_probability_candidate_is_never_accepted(threshold_single):
+    _, _, accept_token_num = _run_target_only_sampling(
+        candidates=[0, 1],
+        retrive_next_token=[1, -1],
+        retrive_next_sibling=[-1, -1],
+        target_probs=[
+            [0.0, 0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0],
+        ],
+        uniform_samples=[0.0, 0.0],
+        threshold_single=threshold_single,
+    )
+
+    assert accept_token_num.item() == 0
+
+
+def test_zero_coin_accepts_positive_probability_candidate():
+    _, _, accept_token_num = _run_target_only_sampling(
+        candidates=[0, 1],
+        retrive_next_token=[1, -1],
+        retrive_next_sibling=[-1, -1],
+        target_probs=[
+            [0.0, 0.25, 0.75, 0.0],
+            [0.0, 0.0, 1.0, 0.0],
+        ],
+        uniform_samples=[0.0, 0.0],
+    )
+
+    assert accept_token_num.item() == 1
+
+
+def test_coin_at_bucket_boundary_skips_zero_mass_bucket():
+    predicts, _, accept_token_num = _run_target_only_sampling(
+        candidates=[0, 1, 2, 3],
+        retrive_next_token=[1, -1, -1, -1],
+        retrive_next_sibling=[-1, 2, 3, -1],
+        target_probs=[
+            [0.0, 0.25, 0.0, 0.75],
+            [0.0, 0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0],
+        ],
+        uniform_samples=[0.25, 0.0, 0.0, 0.0],
+    )
+
+    assert accept_token_num.item() == 1
+    assert predicts[0].item() == 3
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Fixes #35771. The target-only speculative sampler can accept a draft token
with zero target probability when the RNG sample lands on a CDF boundary.

## Modifications

- Require positive target probability before accepting a draft token.
- Use a strict CDF comparison so a sample on a bucket boundary skips zero-mass buckets.
- Add focused regression coverage for zero-probability candidates, zero RNG
  samples, threshold boundaries, and CDF boundary behavior.

## Tests

- Source-compiled native CUDA binding: 6 focused regression scenarios passed.
- `pre-commit run --files python/sglang/kernels/aot/csrc/speculative/speculative_sampling.cuh python/sglang/kernels/aot/tests/speculative/test_speculative_sampling.py`

## Checklist

- [x] Format code with the repository pre-commit configuration.
- [x] Add focused regression tests.
- [x] No documentation update is required.
- [x] No speed benchmark is required.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32447506452](https://github.com/sgl-project/sglang/actions/runs/32447506452)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32447506354](https://github.com/sgl-project/sglang/actions/runs/32447506354)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32447506429](https://github.com/sgl-project/sglang/actions/runs/32447506429)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->