### PR TITLE
[Docs] Fix three stale references: llama4 tool-call parser, --target-lora-modules, /update_weights route

### DIFF
--- a/docs/docs/advanced_features/lora.mdx
+++ b/docs/docs/advanced_features/lora.mdx
@@ -159,7 +159,7 @@ lora1 = "algoprog/fact-generation-llama-3.1-8b-instruct-lora"  # rank - 64, targ
 lora0_new = "philschmid/code-llama-3-1-8b-text-to-sql-lora"  # rank - 256, target modules - q_proj, k_proj, v_proj, o_proj, gate_proj, up_proj, down_proj
 
 
-# The `--target-lora-modules` param below is technically not needed, as the server will infer it from lora0 which already has all the target modules specified.
+# The `--lora-target-modules` param below is technically not needed, as the server will infer it from lora0 which already has all the target modules specified.
 # We are adding it here just to demonstrate usage.
 server_process, port = launch_server_cmd(
     """

--- a/docs/docs/advanced_features/tool_parser.mdx
+++ b/docs/docs/advanced_features/tool_parser.mdx
@@ -63,11 +63,6 @@ This guide demonstrates how to use SGLang’s [Function calling](https://platfor
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}></td>
     </tr>
     <tr>
-      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`llama4`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Llama 4 (e.g. `meta-llama/Llama-4-Scout-17B-16E-Instruct`)</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}></td>
-    </tr>
-    <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`mistral`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Mistral (e.g. `mistralai/Mistral-7B-Instruct-v0.3`, `mistralai/Mistral-Nemo-Instruct-2407`, `mistralai/Mistral-7B-v0.3`)</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}></td>

--- a/docs/docs/basic_usage/native_api.mdx
+++ b/docs/docs/basic_usage/native_api.mdx
@@ -11,7 +11,7 @@ Apart from the OpenAI compatible APIs, the SGLang Runtime also provides its nati
 - `/health`
 - `/health_generate`
 - `/flush_cache`
-- `/update_weights`
+- `/update_weights_from_disk`
 - `/encode`(embedding model)
 - `/v1/rerank`(cross encoder rerank model)
 - `/v1/score`(decoder-only scoring)
@@ -124,7 +124,7 @@ print_highlight(response.text)
 
 ## Flush Cache
 
-Flush the radix cache. It will be automatically triggered when the model weights are updated by the `/update_weights` API.
+Flush the radix cache. It will be automatically triggered when the model weights are updated by the `/update_weights_from_disk` API.
 
 Parameters:
 - `timeout` (query, float, default `0`, unit: seconds): Wait time for idle state before flushing. `0` means fail fast if not idle. When HiCache async operations are in-flight, a non-zero timeout allows the server to wait until idle before flushing, avoiding unnecessary 400 errors.


### PR DESCRIPTION

Three stale references in the docs, each directly checkable against current runtime sources:

- `tool_parser.mdx` lists `llama4` as a `--tool-call-parser` value, but `ToolCallParserEnum` has no such key and `server_args.py` builds the argparse choices from those keys, so `--tool-call-parser llama4` is rejected during argument parsing. It is not a deprecated alias (`deprecated_tool_call_parsers` maps only `qwen25`, `glm45`). Llama 4 uses `pythonic`, which the same table already documents; this drops the dead row.
- `lora.mdx` calls a flag `--target-lora-modules` in a comment; the real flag is `--lora-target-modules` (`server_args.py`). Surrounding prose already uses the correct name.
- `native_api.mdx` references `/update_weights`, which is not a registered route (`http_server.py` has `/update_weights_from_disk`, `_from_tensor`, `_from_distributed`, `_from_ipc`), so a POST 404s. The page's own example already uses `/update_weights_from_disk`; this points both stale references at it.

Docs-only, 3 files, +3/−8.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32448676795](https://github.com/sgl-project/sglang/actions/runs/32448676795)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32448676674](https://github.com/sgl-project/sglang/actions/runs/32448676674)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->