### PR TITLE
[Scheduler] Reclaim committed KV without token IDs

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1237,11 +1237,14 @@ class Req(ReqDllmMixin):
         )
 
     def effective_kv_committed_len(self) -> int:
+        # Prefix-cache entries require corresponding token IDs.
+        committed_len = min(self.kv_committed_len, self.seqlen)
+
         # Report only the prompt prefix so thinking + answer fall into the
         # overallocated range and are reclaimed by release_kv_cache. #22373.
         if get_serving().strip_thinking_cache and self.reasoning_tokens > 0:
-            return min(self.kv_committed_len, len(self.origin_input_ids))
-        return self.kv_committed_len
+            return min(committed_len, len(self.origin_input_ids))
+        return committed_len
 
     def update_spec_correct_drafts_histogram(self, num_correct_drafts: int):
         """Record one step accepted draft count (excludes bonus token) into the histogram."""

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -248,12 +248,11 @@ def _release_overallocated_kv_indices(
     page_size = allocator.page_size
     spec_algo = get_spec().speculative_algorithm
 
-    # strip_thinking_cache intentionally reports output tokens as overallocated
-    # so they fall into the free path below (#22373).
+    # The cacheable prefix can be shorter than the physical committed KV.
     if spec_algo is None and not get_serving().strip_thinking_cache:
         assert (
-            start_p == end_p
-        ), f"Unexpected overallocated KV cache, {req.kv_committed_len=}, {req.kv.kv_allocated_len=}"
+            req.kv_committed_len == end_p
+        ), f"Unexpected overallocated KV cache, {req.kv_committed_len=}, {req.kv.kv_allocated_len=}, {req.seqlen=}"
 
     if page_size > 1:
         start_p = ceil_align(start_p, page_size)

--- a/test/registered/unit/mem_cache/test_kv_cache_release.py
+++ b/test/registered/unit/mem_cache/test_kv_cache_release.py
@@ -1,0 +1,75 @@
+"""Regression test for finished-request KV cache release."""
+
+import unittest
+from array import array
+
+import torch
+
+from sglang.srt.managers.schedule_batch import Req, ReqKvInfo
+from sglang.srt.mem_cache.allocator.token import TokenToKVPoolAllocator
+from sglang.srt.mem_cache.common import release_kv_cache
+from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
+from sglang.srt.mem_cache.radix_cache import RadixCache
+from sglang.srt.runtime_context import get_context
+from sglang.srt.sampling.sampling_params import SamplingParams
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestKVCacheRelease(CustomTestCase):
+    def test_release_frees_committed_kv_without_token_id(self):
+        """Finishing a request returns KV slots beyond its token sequence."""
+        req = Req(
+            rid="overlap-abort",
+            origin_input_text="",
+            origin_input_ids=array("q", [1, 2]),
+            sampling_params=SamplingParams(max_new_tokens=2),
+        )
+        req.output_ids = array("q", [3])
+        allocated_len = req.seqlen + 1
+        req.kv_committed_len = allocated_len
+        req.kv = ReqKvInfo(kv_allocated_len=allocated_len, swa_evicted_seqlen=0)
+        req.cache_protected_len = 0
+
+        allocator = TokenToKVPoolAllocator(
+            size=16,
+            dtype=torch.float16,
+            device="cpu",
+            kvcache=None,
+            need_sort=False,
+        )
+        request_indices = allocator.alloc(allocated_len)
+        self.assertIsNotNone(request_indices)
+
+        req_to_token_pool = ReqToTokenPool(
+            size=1,
+            max_context_len=allocated_len,
+            device="cpu",
+            enable_memory_saver=False,
+        )
+        self.assertIsNotNone(req_to_token_pool.alloc([req]))
+        req_to_token_pool.write(
+            (req.req_pool_idx, slice(0, allocated_len)), request_indices
+        )
+
+        cache = RadixCache.create_simulated(mock_allocator=allocator)
+        cache.req_to_token_pool = req_to_token_pool
+        req.last_node = cache.root_node
+
+        available_before = allocator.available_size()
+        with get_context().override_server_args(
+            speculative_algorithm=None,
+            strip_thinking_cache=False,
+        ):
+            allocator.free_group_begin()
+            release_kv_cache(req, cache)
+            allocator.free_group_end()
+
+        self.assertEqual(cache.total_size(), req.seqlen)
+        self.assertEqual(allocator.available_size(), available_before + 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

A prefix cache can only insert KV positions that have corresponding token IDs. Under overlap scheduling, physical `kv_committed_len` can transiently lead the request token sequence by one. Passing that physical length to an insertion path can therefore describe a KV span longer than its radix key.

Current rejection paths use no-insert cleanup. This PR makes the insertion boundary independently correct: cacheable KV is bounded by known token IDs, while physical committed KV remains the ownership boundary.

## Change

- Bound the insertion length by the request token sequence.
- When insertion is disabled, pass the full physical committed length through the ownership-based cleanup added by #35204.
- Keep the non-speculative allocation invariant based on physical committed KV, then use the existing tail-release path for any committed but uncacheable KV.

The normal path is unchanged when committed KV and the token sequence have equal lengths.

## Validation

- The focused regression fails without the token bound with allocator capacity `12 != 13` and passes with this change.
- 29 focused and related KV-release tests passed after rebasing onto current `main`.
- Repository pre-commit checks passed for all three changed files.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #35291008699](https://github.com/sgl-project/sglang/actions/runs/35291008699)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35291008402](https://github.com/sgl-project/sglang/actions/runs/35291008402)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35291008635](https://github.com/sgl-project/sglang/actions/runs/35291008635)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->