### PR TITLE
[Spec] Fix CDF boundary handling in `TreeSpeculativeSamplingTargetOnly`

### DIFF
--- a/python/sglang/kernels/aot/csrc/speculative/speculative_sampling.cuh
+++ b/python/sglang/kernels/aot/csrc/speculative/speculative_sampling.cuh
@@ -77,7 +77,8 @@ __global__ void TreeSpeculativeSamplingTargetOnly(
       DType target_prob_single = target_probs[cur_prob_offset + draft_token_id];
       prob_acc += target_prob_single;
 
-      if (coin <= prob_acc / threshold_acc || target_prob_single >= threshold_single) {
+      const bool has_target_mass = target_prob_single > DType(0);
+      if (has_target_mass && (coin < prob_acc / threshold_acc || target_prob_single >= threshold_single)) {
         // accept token
         prob_acc = 0.;
         cur_prob_offset = (bx * num_draft_tokens + cur_index) * d;

--- a/python/sglang/kernels/aot/tests/speculative/test_speculative_sampling.py
+++ b/python/sglang/kernels/aot/tests/speculative/test_speculative_sampling.py
@@ -16,9 +16,9 @@ test_cases = [
     (
         0,  # threshold_single
         0,  # threshold_acc
-        [1, 2, 18, -1, -1, -1, 11, -1, -1, -1, 12, 18],
-        [[0, 1, 2, -1], [6, 10, 11, -1]],
-        [2, 2],
+        [3, -1, -1, 4, 5, 18, 11, -1, -1, -1, 12, 18],
+        [[0, 3, 4, 5], [6, 10, 11, -1]],
+        [3, 2],
     ),
 ]
 
@@ -125,6 +125,86 @@ def test_tree_speculative_sampling_target_only(
     assert (
         accept_token_num.tolist() == expected_accept_token_num
     ), f"Accept token num mismatch for thresholds ({threshold_single}, {threshold_acc})"
+
+
+@pytest.mark.parametrize(
+    "candidate_tokens,target_probabilities,coin,threshold_single,expected_token,expected_accept_token_num",
+    [
+        ([2], [0.0, 1.0, 0.0], 0.0, 0.0, 1, 0),
+        ([2], [0.0, 1.0, 0.0], 0.0, 1.0, 1, 0),
+        ([1, 2, 3], [0.0, 0.25, 0.0, 0.75], 0.25, 1.0, 3, 1),
+        ([1], [0.0, 0.25, 0.75], 0.0, 1.0, 1, 1),
+        ([1], [0.0, 1.0], 1.0 - 2**-24, 1.0, 1, 1),
+    ],
+    ids=[
+        "zero-mass-zero-threshold",
+        "zero-mass-default-threshold",
+        "interior-boundary",
+        "lower-endpoint",
+        "upper-endpoint",
+    ],
+)
+def test_target_only_sampling_cdf_boundaries(
+    candidate_tokens,
+    target_probabilities,
+    coin,
+    threshold_single,
+    expected_token,
+    expected_accept_token_num,
+):
+    num_candidates = len(candidate_tokens)
+    candidates = torch.tensor(
+        [[0, *candidate_tokens]], dtype=torch.int64, device="cuda"
+    )
+    num_draft_tokens = candidates.shape[1]
+    retrive_index = torch.arange(
+        num_draft_tokens, dtype=torch.int64, device="cuda"
+    ).unsqueeze(0)
+    retrive_next_token = torch.full_like(retrive_index, -1)
+    retrive_next_token[0, 0] = 1
+    retrive_next_sibling = torch.full_like(retrive_index, -1)
+    if num_candidates > 1:
+        retrive_next_sibling[0, 1:num_candidates] = torch.arange(
+            2, num_candidates + 1, dtype=torch.int64, device="cuda"
+        )
+
+    target_probs = torch.zeros(
+        (1, num_draft_tokens, len(target_probabilities)),
+        dtype=torch.float32,
+        device="cuda",
+    )
+    target_probs[0, 0] = torch.tensor(
+        target_probabilities, dtype=torch.float32, device="cuda"
+    )
+    target_probs[0, 1:, 0] = 1.0
+    draft_probs = torch.zeros_like(target_probs)
+    predicts = torch.full((num_draft_tokens,), -1, dtype=torch.int32, device="cuda")
+    accept_index = torch.full((1, 2), -1, dtype=torch.int32, device="cuda")
+    accept_token_num = torch.zeros((1,), dtype=torch.int32, device="cuda")
+    coins = torch.zeros((1, num_draft_tokens), dtype=torch.float32, device="cuda")
+    coins[0, 0] = coin
+
+    tree_speculative_sampling_target_only(
+        predicts=predicts,
+        accept_index=accept_index,
+        accept_token_num=accept_token_num,
+        candidates=candidates,
+        retrive_index=retrive_index,
+        retrive_next_token=retrive_next_token,
+        retrive_next_sibling=retrive_next_sibling,
+        uniform_samples=coins,
+        uniform_samples_for_final_sampling=torch.zeros(
+            (1,), dtype=torch.float32, device="cuda"
+        ),
+        target_probs=target_probs,
+        draft_probs=draft_probs,
+        threshold_single=threshold_single,
+        threshold_acc=1.0,
+        deterministic=True,
+    )
+
+    assert predicts[0].item() == expected_token
+    assert accept_token_num.item() == expected_accept_token_num
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

`TreeSpeculativeSamplingTargetOnly` draws coins from `[0, 1)` but selects a target CDF bucket with `coin <= cumulative_probability`. At the lower endpoint (`coin == 0`) that accepts a draft token whose target probability is zero, and exact interior CDF boundaries land in the preceding bucket instead of the next positive-mass one.

Fixes #35771.

## Modifications

- Use the half-open condition `coin < prob_acc / threshold_acc` and require `target_prob_single > 0` before either acceptance path can take a draft, in the shared device header `sgl_kernel/speculative/sampling.cuh`.
- Add regression cases for zero-mass drafts (permissive and default thresholds), an exact interior CDF boundary, and both coin endpoints; update the zero-threshold expectation, which previously encoded the zero-mass acceptance.

Single-site change: the shared header backs the CUDA/ROCm JIT launchers and the MUSA AOT build, so all three pick the fix up. Rebased onto #40033, which moved these kernels to JIT — CUDA compiles them at runtime, so the fix ships without an `sgl-kernel` release.

## Accuracy Tests

- `test/registered/kernels/ops/speculative/test_speculative_sampling.py`: `7 passed`.
- Reverting only the kernel predicate turns that into `4 failed, 3 passed` — `zero-mass-zero-threshold`, `zero-mass-default-threshold`, `interior-boundary`, and the zero-threshold tree case all regress, confirming the new coverage is what guards the fix.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (No documentation change needed.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
