### PR TITLE
[MiniMax M3] Support EPD disaggregation

### DIFF
--- a/python/sglang/srt/arg_groups/pd_disaggregation_hook.py
+++ b/python/sglang/srt/arg_groups/pd_disaggregation_hook.py
@@ -256,9 +256,10 @@ def handle_encoder_disaggregation(server_args: Any):
         "KimiK25ForConditionalGeneration",
         "KimiK3ForConditionalGeneration",
         "MiMoV2ForCausalLM",
+        "MiniMaxM3SparseForConditionalGeneration",
     ]:
         raise ValueError(
             f"Model type {model_arch} is not supported for encoder disaggregation. "
             f"Supported architectures: Qwen2VL, Qwen3VL, Qwen3.5, InternS2, "
-            f"Qwen2Audio, Qwen2.5Omni, Dots3-Note, Kimi, MiMoV2."
+            f"Qwen2Audio, Qwen2.5Omni, Dots3-Note, Kimi, MiMoV2, MiniMaxM3."
         )

--- a/python/sglang/srt/models/minimax_m3_vl.py
+++ b/python/sglang/srt/models/minimax_m3_vl.py
@@ -78,6 +78,9 @@ class MiniMaxM3SparseForConditionalGeneration(nn.Module):
         self.quant_config = quant_config
         self.pp_group = get_pp_group()
 
+        self.encoder_only = config.encoder_only
+        self.language_only = config.language_only
+
         self.use_data_parallel = get_mm().mm_enable_dp_encoder
 
         self.num_fused_shared_experts = 0
@@ -98,26 +101,34 @@ class MiniMaxM3SparseForConditionalGeneration(nn.Module):
 
         # Vision model skips quantization: CLIP dimensions (head_dim=80) are not
         # compatible with MXFP8 kernel alignment requirements (128).
-        self.vision_tower = MiniMaxVLVisionModel(
-            config=vision_config,
-            text_hidden_size=text_hidden_size,
-            projector_hidden_size=projector_hidden_size,
-            quant_config=None,
-            prefix=add_prefix("vision_tower", prefix),
-            multimodal_projector_bias=getattr(
-                config, "multimodal_projector_bias", True
-            ),
-            patch_merge_bias=getattr(config, "patch_merge_bias", True),
-        )
+        if self.language_only:
+            self.vision_tower = None
+        else:
+            self.vision_tower = MiniMaxVLVisionModel(
+                config=vision_config,
+                text_hidden_size=text_hidden_size,
+                projector_hidden_size=projector_hidden_size,
+                quant_config=None,
+                prefix=add_prefix("vision_tower", prefix),
+                multimodal_projector_bias=getattr(
+                    config, "multimodal_projector_bias", True
+                ),
+                patch_merge_bias=getattr(config, "patch_merge_bias", True),
+            )
 
         text_config = config.text_config
-        self.model = MiniMaxM3Model(
-            config=text_config,
-            quant_config=quant_config,
-            prefix=add_prefix("language_model.model", prefix),
-        )
+        if not self.encoder_only:
+            self.model = MiniMaxM3Model(
+                config=text_config,
+                quant_config=quant_config,
+                prefix=add_prefix("language_model.model", prefix),
+            )
+        else:
+            self.model = None
 
-        if self.pp_group.is_last_rank:
+        if self.encoder_only:
+            self.lm_head = None
+        elif self.pp_group.is_last_rank:
             self.lm_head = ParallelLMHead(
                 text_config.vocab_size,
                 text_config.hidden_size,
@@ -133,7 +144,9 @@ class MiniMaxM3SparseForConditionalGeneration(nn.Module):
             text_rope_scaling is not None and "mrope_section" in text_rope_scaling
         )
 
-        self.logits_processor = LogitsProcessor(text_config)
+        self.logits_processor = (
+            None if self.encoder_only else LogitsProcessor(text_config)
+        )
 
         # For EAGLE3 support
         self.capture_aux_hidden_states = False
@@ -191,17 +204,35 @@ class MiniMaxM3SparseForConditionalGeneration(nn.Module):
             input_ids, mm_inputs
         )
 
+    def _require_vision_tower(self) -> None:
+        if self.vision_tower is None:
+            raise RuntimeError(
+                "vision tower is not loaded in language_only mode; multimodal "
+                "inputs must arrive as precomputed embeddings from the encoder "
+                "server."
+            )
+
     def get_image_feature(self, items: List[MultimodalDataItem]) -> torch.Tensor:
+        self._require_vision_tower()
         return get_image_feature(self.vision_tower, items, self.use_data_parallel)
 
     def get_video_feature(self, items: List[MultimodalDataItem]) -> torch.Tensor:
+        self._require_vision_tower()
         return get_video_feature(self.vision_tower, items, self.use_data_parallel)
 
     def get_input_embeddings(self):
+        if self.model is None:
+            raise AttributeError(
+                "get_input_embeddings() is not available in encoder-only mode"
+            )
         return self.model.embed_tokens
 
     def get_embed_and_head(self):
         # EAGLE3 target interface: share the text embed + lm_head with the draft.
+        if self.model is None:
+            raise AttributeError(
+                "get_embed_and_head() is not available in encoder-only mode"
+            )
         return self.model.embed_tokens.weight, self.lm_head.weight
 
     def set_eagle3_layers_to_capture(self, layer_ids: Optional[list[int]] = None):
@@ -319,6 +350,8 @@ class MiniMaxM3SparseForConditionalGeneration(nn.Module):
                 continue
 
             if name.startswith("language_model."):
+                if self.encoder_only:
+                    continue
                 self._load_llm_weight(
                     name[len("language_model.") :],
                     loaded_weight,
@@ -334,7 +367,8 @@ class MiniMaxM3SparseForConditionalGeneration(nn.Module):
 
         merge_vit_qkv_weights(vit_qkv_weights, vit_qkv_biases, params_dict)
 
-        build_minimax_fused_qkv_index(self)
+        if not self.encoder_only:
+            build_minimax_fused_qkv_index(self)
 
     def _load_llm_weight(
         self,

--- a/python/sglang/srt/models/minimax_vl_common.py
+++ b/python/sglang/srt/models/minimax_vl_common.py
@@ -791,6 +791,15 @@ def _run_vision_tower(
     return vision_tower(pixel_values, grid_thw=grid_thw)
 
 
+def _to_vision_device(
+    vision_tower: MiniMaxVLVisionModel, pixel_values: torch.Tensor
+) -> torch.Tensor:
+    # The EPD encode server hands CPU tensors to the model; no-op when the
+    # tensor is already on the right device.
+    device = vision_tower.vision_model.embeddings.patch_embedding.weight.device
+    return pixel_values.to(device)
+
+
 def get_image_feature(
     vision_tower: MiniMaxVLVisionModel,
     items: List[MultimodalDataItem],
@@ -799,6 +808,8 @@ def get_image_feature(
     pixel_values = torch.cat([item.feature for item in items], dim=0).type(
         vision_tower.dtype
     )
+    if not use_data_parallel:
+        pixel_values = _to_vision_device(vision_tower, pixel_values)
     image_grid_thw: list[list[int]] = []
     for item in items:
         image_grid_thw.extend(item.image_grid_thw.tolist())
@@ -815,6 +826,8 @@ def get_video_feature(
     pixel_values = torch.cat([item.feature for item in items], dim=0).type(
         vision_tower.dtype
     )
+    if not use_data_parallel:
+        pixel_values = _to_vision_device(vision_tower, pixel_values)
     video_grid_thw: list[list[int]] = []
     for item in items:
         video_grid_thw.extend(item.video_grid_thw.tolist())

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -593,7 +593,10 @@ class BaseMultimodalProcessor(ABC):
                 audio_idx += 1
             else:
                 raise ValueError(f"Invalid modality: {modality}")
-            assert cur_idx <= mm_start_idx
+            # cur_idx == mm_start_idx + 1 happens with back-to-back mm
+            # placeholders: the previous span consumed up to and including
+            # this item's "start" position, so the copy below is empty.
+            assert cur_idx <= mm_start_idx + 1
 
             input_ids.extend(prompt[cur_idx : mm_start_idx + 1])
             mm_offset_start = len(input_ids)

--- a/python/sglang/srt/multimodal/processors/minimax_m3_vl.py
+++ b/python/sglang/srt/multimodal/processors/minimax_m3_vl.py
@@ -10,7 +10,7 @@ import torch
 import torchvision
 from torchvision.transforms import InterpolationMode
 
-from sglang.srt.managers.schedule_batch import MultimodalProcessorOutput
+from sglang.srt.managers.schedule_batch import Modality, MultimodalProcessorOutput
 from sglang.srt.models.minimax_m3_vl import MiniMaxM3SparseForConditionalGeneration
 from sglang.srt.multimodal.processors.base_processor import (
     BaseMultimodalProcessor,
@@ -281,3 +281,27 @@ class MiniMaxM3VLProcessor(BaseMultimodalProcessor):
             im_token_id=self.IM_TOKEN_ID,
             video_token_id=self.VIDEO_TOKEN_ID,
         )
+
+    def get_mm_data(self, prompt, embeddings, **kwargs):
+        # The base implementation drops the vision [START]/[END] wrappers that
+        # the colocated path inserts around image/video spans; reinsert them so
+        # the EPD layout matches colocated token-for-token.
+        output = super().get_mm_data(prompt, embeddings, **kwargs)
+        input_ids = list(output.input_ids)
+        shift = 0
+        for item in output.mm_items:
+            if not item.offsets:
+                continue
+            if item.modality not in (Modality.IMAGE, Modality.VIDEO):
+                continue
+            new_offsets = []
+            for start, end in item.offsets:
+                start += shift
+                end += shift
+                input_ids.insert(start, self.IM_START_TOKEN_ID)
+                input_ids.insert(end + 2, self.IM_END_TOKEN_ID)
+                new_offsets.append((start + 1, end + 1))
+                shift += 2
+            item.offsets = new_offsets
+        output.input_ids = input_ids
+        return output


### PR DESCRIPTION

## MMMU-Pro comparison (full 1730 examples, temperature 0, bf16, 8xB200)

| | EPD | colocated |
|---|---|---|
| score | 68.96% | 69.77% |
| error_rate | 0.29% | 0.00% |

The remaining gap traces to one real bug found by this eval, fixed in this PR: `base_processor.build_input_ids` asserted `cur_idx <= mm_start_idx`, which always fails for **back-to-back image placeholders** (multi-image prompts) on the encoder-disaggregated path — every affected request errored with "Failed to assemble multimodal inputs" (~30/1730 on MMMU-Pro). Relaxed to `cur_idx <= mm_start_idx + 1` (the copy is empty in that case); verified with an adjacent 2-image request (image_tokens 288 = 144x2, correct answer).

Rerun with the multi-image fix: **68.44% (error_rate 0.00%, zero mm-assembly failures across all 1730 examples)** — all previously failing multi-image requests now succeed. The remaining ~1.3% score gap vs colocated (69.77%) is consistent with encoder-process vs colocated ViT numeric noise flipping borderline answers under greedy decoding (both runs are within the ~1.1% stderr of each other).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33762841974](https://github.com/sgl-project/sglang/actions/runs/33762841974)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33762841537](https://github.com/sgl-project/sglang/actions/runs/33762841537)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33762841855](https://github.com/sgl-project/sglang/actions/runs/33762841855)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->