### PR TITLE
[DSv4] Split draft SWA into committed sidecar KV and verify scratch

### DIFF
--- a/python/sglang/kernels/ops/attention/dsv4/unified_kv_kernels/runtime.py
+++ b/python/sglang/kernels/ops/attention/dsv4/unified_kv_kernels/runtime.py
@@ -291,6 +291,115 @@ def build_decode_streams(
     return swa_i, swa_p, hca_i, hca_p, csa_i, csa_p
 
 
+@triton.jit
+def _build_dspark_sidecar_indices_kernel(
+    req_to_token_ptr,
+    full_to_swa_ptr,
+    state_slot_ptr,
+    chunk_start_ptr,
+    final_pos_ptr,
+    indptr_ptr,
+    indices_ptr,
+    req_to_token_stride,
+    scratch_base,
+    scratch_width,
+    N,
+    win: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    row = tl.program_id(0)
+    if row >= N:
+        return
+
+    slot = tl.load(state_slot_ptr + row).to(tl.int64)
+    chunk_start = tl.load(chunk_start_ptr + row).to(tl.int64)
+    final_pos = tl.load(final_pos_ptr + row).to(tl.int64)
+    context_len = tl.minimum(chunk_start, win).to(tl.int32)
+    block_len = (final_pos - chunk_start + 1).to(tl.int32)
+    length = context_len + block_len
+    out_base = tl.load(indptr_ptr + row).to(tl.int64)
+
+    offsets = tl.arange(0, BLOCK)
+    valid = offsets < length
+    in_step = offsets >= context_len
+    absolute_pos = chunk_start - context_len + offsets
+
+    full_loc = tl.load(
+        req_to_token_ptr + slot * req_to_token_stride + absolute_pos,
+        mask=valid & ~in_step,
+        other=0,
+    ).to(tl.int64)
+    committed_loc = tl.load(
+        full_to_swa_ptr + full_loc,
+        mask=valid & ~in_step,
+        other=0,
+    ).to(tl.int32)
+    scratch_loc = (
+        scratch_base + slot * scratch_width + offsets - context_len
+    ).to(tl.int32)
+    loc = tl.where(in_step, scratch_loc, committed_loc)
+    tl.store(indices_ptr + out_base + offsets, loc, mask=valid)
+
+
+def build_dspark_sidecar_decode_stream(
+    *,
+    req_to_token: torch.Tensor,
+    full_to_swa_mapping: torch.Tensor,
+    state_slot: torch.Tensor,
+    chunk_start: torch.Tensor,
+    final_pos: torch.Tensor,
+    win: int,
+    scratch_base: int,
+    scratch_width: int,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Build ``history window + full verify block`` for every DSpark query."""
+    N = state_slot.shape[0]
+    assert chunk_start.shape[0] >= N
+    assert final_pos.shape[0] >= N
+    context_len = torch.clamp(chunk_start[:N], max=win).to(torch.int32)
+    block_len = (final_pos[:N] - chunk_start[:N] + 1).to(torch.int32)
+    lengths = context_len + block_len
+    indptr = _lengths_to_indptr(lengths)
+    indices = torch.empty(
+        N * (win + scratch_width), dtype=torch.int32, device=state_slot.device
+    )
+    if state_slot.device.type == "cpu":
+        for row in range(N):
+            history = int(context_len[row])
+            verify = int(block_len[row])
+            length = history + verify
+            start = int(indptr[row])
+            slot = int(state_slot[row])
+            step_start = int(chunk_start[row])
+            for offset in range(length):
+                if offset >= history:
+                    loc = scratch_base + slot * scratch_width + offset - history
+                else:
+                    absolute_pos = step_start - history + offset
+                    full_loc = int(req_to_token[slot, absolute_pos])
+                    loc = int(full_to_swa_mapping[full_loc])
+                indices[start + offset] = loc
+        return indices, indptr
+    if N:
+        _build_dspark_sidecar_indices_kernel[(N,)](
+            req_to_token,
+            full_to_swa_mapping,
+            state_slot,
+            chunk_start,
+            final_pos,
+            indptr,
+            indices,
+            req_to_token.stride(0),
+            scratch_base,
+            scratch_width,
+            N,
+            win=win,
+            BLOCK=triton.next_power_of_2(win + scratch_width),
+            num_warps=4,
+        )
+    return indices, indptr
+
+
 # ---------------------------------------------------------------------------
 # Prefill index builder (ragged-packed: paged prefix + flat extend)
 # ---------------------------------------------------------------------------

--- a/python/sglang/kernels/ops/speculative/dspark/dspark_attn_metadata.py
+++ b/python/sglang/kernels/ops/speculative/dspark/dspark_attn_metadata.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Tuple
+from typing import Optional, Tuple
 
 import msgspec
 import torch
@@ -81,6 +81,7 @@ class BuildDsparkSwaPageIndices:
         block_size: int,
         swa_window: int,
         page_index_aligned_size: int,
+        block_swa_locs: Optional[torch.Tensor] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         return build_dspark_swa_page_indices(
             req_to_token=req_to_token,
@@ -93,6 +94,7 @@ class BuildDsparkSwaPageIndices:
             block_size=block_size,
             swa_window=swa_window,
             page_index_aligned_size=page_index_aligned_size,
+            block_swa_locs=block_swa_locs,
         )
 
     @classmethod
@@ -109,6 +111,7 @@ class BuildDsparkSwaPageIndices:
         block_size: int,
         swa_window: int,
         page_index_aligned_size: int,
+        block_swa_locs: Optional[torch.Tensor] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         return build_dspark_swa_page_indices_triton(
             req_to_token=req_to_token,
@@ -120,6 +123,7 @@ class BuildDsparkSwaPageIndices:
             block_size=block_size,
             swa_window=swa_window,
             page_index_aligned_size=page_index_aligned_size,
+            block_swa_locs=block_swa_locs,
         )
 
 
@@ -240,6 +244,7 @@ def build_dspark_swa_page_indices(
     block_size: int,
     swa_window: int,
     page_index_aligned_size: int,
+    block_swa_locs: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     if offsets.ndim != 2 or offsets.shape[1] != swa_window:
         raise ValueError(
@@ -257,8 +262,13 @@ def build_dspark_swa_page_indices(
     window_swa_locs = full_to_swa_mapping[window_full_locs].to(torch.int32)
     window_swa_locs = window_swa_locs.masked_fill(invalid, -1)
 
-    block_full_locs = out_loc[: bs * block_size].view(bs, block_size)
-    block_swa_locs = full_to_swa_mapping[block_full_locs].to(torch.int32)
+    if block_swa_locs is None:
+        block_full_locs = out_loc[: bs * block_size].view(bs, block_size)
+        block_swa_locs = full_to_swa_mapping[block_full_locs].to(torch.int32)
+    else:
+        block_swa_locs = block_swa_locs[: bs * block_size].view(
+            bs, block_size
+        ).to(torch.int32)
 
     target_width = ceil_align(swa_window + block_size, page_index_aligned_size)
 
@@ -330,6 +340,7 @@ def _swa_page_indices_kernel(
     swa_window,
     block_size,
     target_width,
+    block_locs_are_swa: tl.constexpr,
     TW_BLOCK: tl.constexpr,
 ):
     q = tl.program_id(0)
@@ -355,7 +366,12 @@ def _swa_page_indices_kernel(
     blk_full = tl.load(out_loc_ptr + i * block_size + bcol, mask=bmask, other=0).to(
         tl.int64
     )
-    blk_swa = tl.load(full_to_swa_ptr + blk_full, mask=bmask, other=-1).to(tl.int32)
+    if block_locs_are_swa:
+        blk_swa = blk_full.to(tl.int32)
+    else:
+        blk_swa = tl.load(full_to_swa_ptr + blk_full, mask=bmask, other=-1).to(
+            tl.int32
+        )
 
     val = tl.where(in_window, win_swa, tl.where(in_block, blk_swa, -1))
     tl.store(out_ptr + q * target_width + k, val.to(tl.int32), mask=kmask)
@@ -373,6 +389,7 @@ def build_dspark_swa_page_indices_triton(
     block_size: int,
     swa_window: int,
     page_index_aligned_size: int,
+    block_swa_locs: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     if offsets.ndim != 2 or offsets.shape[1] != swa_window:
         raise ValueError(
@@ -383,7 +400,9 @@ def build_dspark_swa_page_indices_triton(
     device = offsets.device
     req_pool = req_pool_indices_per_request.to(device=device).contiguous()
     offsets = offsets.to(torch.int64).contiguous()
-    out_loc = out_loc[: bs * block_size].contiguous()
+    block_locs_are_swa = block_swa_locs is not None
+    block_locs = block_swa_locs if block_locs_are_swa else out_loc
+    block_locs = block_locs[: bs * block_size].contiguous()
     context_lens = context_lens.to(device=device, dtype=torch.int32).contiguous()
     rt_stride = req_to_token.stride(0)
     target_width = ceil_align(swa_window + block_size, page_index_aligned_size)
@@ -398,7 +417,7 @@ def build_dspark_swa_page_indices_triton(
         full_to_swa_mapping,
         req_pool,
         offsets,
-        out_loc,
+        block_locs,
         context_lens,
         swa_page_indices,
         swa_topk_lengths,
@@ -406,6 +425,7 @@ def build_dspark_swa_page_indices_triton(
         swa_window,
         block_size,
         target_width,
+        block_locs_are_swa=block_locs_are_swa,
         TW_BLOCK=TW_BLOCK,
     )
     return swa_page_indices, swa_topk_lengths

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -1447,6 +1447,8 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                         dst_data_indices=np.array(dst_indices_local, dtype=np.int32),
                         executor=executor,
                         state_type=st,
+                        src_layer_ids=src_state_layer_ids,
+                        dst_layer_ids=dst_state_layer_ids,
                     )
                     or rc
                 )

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -1480,6 +1480,8 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
         dst_mem_kind: str = "VRAM",
         force_flat: bool = False,
         bypass_prepped: bool = False,
+        src_layer_ids: Optional[List[int]] = None,
+        dst_layer_ids: Optional[List[int]] = None,
     ):
         """Generic KV cache transfer supporting both MHA and MLA architectures.
         Used by both send_kvcache and maybe_send_extra.
@@ -1541,17 +1543,32 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
         logger.debug(f"sending kvcache to {peer_name} with notif {notif}")
         # Make descs
         if self.is_mla_backend or force_flat:
-            src_kv_ptrs, dst_kv_ptrs, layers_current_pp_stage = (
-                self.get_mla_kv_ptrs_with_pp(src_data_ptrs, dst_data_ptrs, state_type)
-            )
-            layers_params = [
-                (
-                    src_kv_ptrs[layer_id],
-                    dst_kv_ptrs[layer_id],
-                    item_lens[layer_id],
+            if src_layer_ids or dst_layer_ids:
+                pairs = build_transfer_entry_pairs(
+                    src_layer_ids or [],
+                    dst_layer_ids or [],
+                    len(src_data_ptrs),
+                    len(dst_data_ptrs),
+                    allow_positional_fallback=self.pp_size == 1,
                 )
-                for layer_id in range(layers_current_pp_stage)
-            ]
+                layers_params = [
+                    (src_data_ptrs[i], dst_data_ptrs[j], item_lens[i])
+                    for i, j in pairs
+                ]
+            else:
+                src_kv_ptrs, dst_kv_ptrs, layers_current_pp_stage = (
+                    self.get_mla_kv_ptrs_with_pp(
+                        src_data_ptrs, dst_data_ptrs, state_type
+                    )
+                )
+                layers_params = [
+                    (
+                        src_kv_ptrs[layer_id],
+                        dst_kv_ptrs[layer_id],
+                        item_lens[layer_id],
+                    )
+                    for layer_id in range(layers_current_pp_stage)
+                ]
         else:
             src_k_ptrs, src_v_ptrs, dst_k_ptrs, dst_v_ptrs, layers_current_pp_stage = (
                 self.get_mha_kv_ptrs_with_pp(src_data_ptrs, dst_data_ptrs)
@@ -2380,6 +2397,8 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
                     dst_gpu_id=dst_gpu_id,
                     notif=comp_notif,
                     state_type=st,
+                    src_layer_ids=src_lids,
+                    dst_layer_ids=dst_lids,
                 )
             elif st == StateType.MINIMAX_INDEX_K:
                 # Equal-TP / PP=1 only. Sub-pools are compacted sparse-layer

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -1239,9 +1239,9 @@ def setup_state_kv_args(
             )
 
     # DSV4 NextN shares the target allocator, so target and draft use the same
-    # local SWA indices. Keep draft buffers in a separate positional component
-    # to avoid mixing them into the target's heterogeneous state layout, while
-    # reusing the existing SWA transport dispatch on both GPU and NPU.
+    # local SWA indices. Keep draft buffers in a separate state component to
+    # avoid mixing them into the target's heterogeneous layout. Explicit stage
+    # IDs preserve this separation when prefill and decode use different PP.
     if isinstance(token_to_kv_pool, DeepSeekV4TokenToKVPool) and isinstance(
         draft_token_to_kv_pool, DeepSeekV4TokenToKVPool
     ):
@@ -1315,12 +1315,21 @@ def setup_state_kv_args(
             draft_state_type = StateType.SWA
 
         if draft_ptrs:
+            draft_layer_ids = (
+                draft_token_to_kv_pool.get_draft_swa_state_layer_ids()
+            )
+            if len(draft_layer_ids) != len(draft_ptrs):
+                raise RuntimeError(
+                    "DSV4 draft SWA state layer IDs do not match buffer count: "
+                    f"layers={len(draft_layer_ids)}, buffers={len(draft_ptrs)}"
+                )
             append_state_component(
                 kv_args,
                 draft_state_type,
                 draft_ptrs,
                 draft_lens,
                 draft_item_lens,
+                layer_ids=draft_layer_ids,
             )
 
     if (

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -1256,7 +1256,19 @@ def setup_state_kv_args(
                 "DSV4 target and draft pools must use the same unified-KV mode"
             )
 
-        if token_to_kv_pool._unified_kv:
+        if draft_token_to_kv_pool.unified_swa_is_sidecar:
+            if (
+                token_to_kv_pool.full_to_swa_index_mapping
+                is not draft_token_to_kv_pool.full_to_swa_index_mapping
+            ):
+                raise RuntimeError(
+                    "DSV4 target and draft pools must share the SWA index mapping"
+                )
+            draft_ptrs, draft_lens, draft_item_lens = (
+                draft_token_to_kv_pool.get_state_buf_infos()
+            )
+            draft_state_type = StateType.SWA
+        elif token_to_kv_pool._unified_kv:
             target_geometry = (
                 token_to_kv_pool.unified_swa_window,
                 token_to_kv_pool.unified_swa_ring_size,

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -1132,14 +1132,20 @@ class DeepseekV4AttnBackend(
                     self.topk,
                     self.speculative_num_steps,
                 )[self.speculative_step_id]
-            metadata.core_attn_metadata.swa_out_cache_loc = (
-                self.token_to_kv_pool.translate_loc_from_full_to_swa(out_cache_loc).to(
-                    torch.int32
-                )
-            )
-
             if self.is_dspark_draft and forward_batch.forward_mode.is_target_verify():
                 block_size = int(forward_batch.spec_info.draft_token_num)
+                if self.token_to_kv_pool.has_draft_swa_scratch:
+                    metadata.core_attn_metadata.swa_out_cache_loc = (
+                        self.token_to_kv_pool.get_draft_swa_scratch_locs(
+                            forward_batch.req_pool_indices, block_size
+                        ).to(torch.int32)
+                    )
+                else:
+                    metadata.core_attn_metadata.swa_out_cache_loc = (
+                        self.token_to_kv_pool.translate_loc_from_full_to_swa(
+                            out_cache_loc
+                        ).to(torch.int32)
+                    )
                 seq_lens_casual = self._dspark_seq_lens_casual(
                     seq_lens=forward_batch.seq_lens, block_size=block_size
                 )
@@ -1157,6 +1163,12 @@ class DeepseekV4AttnBackend(
                 )
                 metadata.core_attn_metadata.swa_page_indices = swa_page_indices
                 metadata.core_attn_metadata.swa_topk_lengths = swa_topk_lengths
+            else:
+                metadata.core_attn_metadata.swa_out_cache_loc = (
+                    self.token_to_kv_pool.translate_loc_from_full_to_swa(
+                        out_cache_loc
+                    ).to(torch.int32)
+                )
 
     def _dspark_seq_lens_casual(
         self, *, seq_lens: torch.Tensor, block_size: int
@@ -1651,6 +1663,15 @@ class DeepseekV4AttnBackend(
             and cached.shape[0] == out_cache_loc.shape[0]
         ):
             return cached
+        if (
+            self.is_dspark_draft
+            and forward_batch.forward_mode.is_target_verify()
+            and self.token_to_kv_pool.has_draft_swa_scratch
+        ):
+            block_size = int(forward_batch.spec_info.draft_token_num)
+            return self.token_to_kv_pool.get_draft_swa_scratch_locs(
+                forward_batch.req_pool_indices, block_size
+            ).to(torch.int32)
         return self.token_to_kv_pool.translate_loc_from_full_to_swa(out_cache_loc).to(
             torch.int32
         )
@@ -2288,6 +2309,13 @@ class DeepseekV4AttnBackend(
             block_size=block_size,
             swa_window=SWA_WINDOW,
             page_index_aligned_size=PAGE_INDEX_ALIGNED_SIZE,
+            block_swa_locs=(
+                self.token_to_kv_pool.get_draft_swa_scratch_locs(
+                    gather.req_pool_indices_per_request, block_size
+                )
+                if self.token_to_kv_pool.has_draft_swa_scratch
+                else None
+            ),
         )
         return swa_page_indices, swa_topk_lengths
 

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
@@ -1160,12 +1160,40 @@ class DeepseekV4HipRadixBackend(
             ring_stride=pool.unified_swa_ring_size,
             swa_pages=pool.unified_swa_pages,
         )
-        # SWA ring write target, same value for every layer this forward.
         req_slot = state_slot.to(torch.int64)
-        core.unified.swa_loc = (
-            req_slot * pool.unified_swa_ring_size
-            + core.positions_casual.to(torch.int64) % pool.unified_swa_ring_size
-        ).to(torch.int32)
+        if pool.unified_swa_is_sidecar:
+            if not self.is_dspark_draft:
+                raise RuntimeError(
+                    "Unified draft SWA sidecar is only valid on a DSpark draft worker."
+                )
+            chunk_start = core.unified.pf_chunk_start
+            final_pos = core.unified.pf_final_pos
+            if chunk_start is None or final_pos is None:
+                raise RuntimeError(
+                    "Unified draft SWA sidecar requires verify chunk boundaries."
+                )
+            (
+                core.unified.swa_indices,
+                core.unified.swa_indptr,
+            ) = runtime.build_dspark_sidecar_decode_stream(
+                req_to_token=self.req_to_token,
+                full_to_swa_mapping=pool.full_to_swa_index_mapping,
+                state_slot=req_slot,
+                chunk_start=chunk_start,
+                final_pos=final_pos,
+                win=pool.unified_swa_window,
+                scratch_base=pool.draft_swa_layout.scratch_base,
+                scratch_width=pool.draft_swa_layout.scratch_width,
+            )
+            core.unified.swa_loc = pool.get_draft_swa_scratch_locs_for_tokens(
+                req_slot, core.positions_casual.to(torch.int64) - chunk_start
+            ).to(torch.int32)
+        else:
+            # Target unified SWA keeps its original request-slot ring.
+            core.unified.swa_loc = (
+                req_slot * pool.unified_swa_ring_size
+                + core.positions_casual.to(torch.int64) % pool.unified_swa_ring_size
+            ).to(torch.int32)
         # Per-token req-slot map for the SWA ring store, read directly by the
         # forward store (target-verify) instead of recomputing a repeat_interleave
         # per layer. Harmless for plain decode (its store reads req_pool_indices).
@@ -1258,15 +1286,22 @@ class DeepseekV4HipRadixBackend(
             else:
                 state_slot = forward_batch.req_pool_indices[:T]
             if save_kv_cache:
-                runtime.store_swa_into_unified(
-                    kv=kv,
-                    state_slot=state_slot,
-                    positions=positions,
-                    unified_kv=unified,
-                    win=win,
-                    ring_stride=ring_stride,
-                    final_pos=positions,
-                )
+                if pool.unified_swa_is_sidecar:
+                    runtime.scatter_bf16_into_unified(
+                        kv=kv,
+                        loc=core_attn_metadata.unified.swa_loc[:T],
+                        unified_kv=unified,
+                    )
+                else:
+                    runtime.store_swa_into_unified(
+                        kv=kv,
+                        state_slot=state_slot,
+                        positions=positions,
+                        unified_kv=unified,
+                        win=win,
+                        ring_stride=ring_stride,
+                        final_pos=positions,
+                    )
             unified_metadata = core_attn_metadata.unified
             if compress_ratio == 0:
                 kv_indices = unified_metadata.swa_indices
@@ -1446,10 +1481,24 @@ class DeepseekV4HipRadixBackend(
             cached is not None
             and not forward_batch.forward_mode.is_idle()
             and cached.shape[0] == positions.shape[0]
-            and not is_multistep_draft_decode
+            and (
+                self.token_to_kv_pool.unified_swa_is_sidecar
+                or not is_multistep_draft_decode
+            )
         ):
             result = cached
         else:
+            if self.token_to_kv_pool.unified_swa_is_sidecar:
+                if forward_batch.forward_mode.is_idle():
+                    return torch.full_like(
+                        positions,
+                        self.token_to_kv_pool.draft_swa_layout.scratch_base,
+                        dtype=torch.int32,
+                    )
+                raise RuntimeError(
+                    "Unified draft SWA scratch locations were not prepared for "
+                    "this forward."
+                )
             ring = self.token_to_kv_pool.unified_swa_ring_size
             req_slot = forward_batch.req_pool_indices.to(torch.int64)
             if req_slot.shape[0] != positions.shape[0]:

--- a/python/sglang/srt/mem_cache/cache_init_params.py
+++ b/python/sglang/srt/mem_cache/cache_init_params.py
@@ -45,6 +45,7 @@ class CacheInitParams:
     chunked_prefill_size: Optional[int] = None
 
     sliding_window_size: Optional[int] = None
+    enable_draft_swa_sidecar: bool = False
 
     # Time-to-live for cache entries in seconds. If None, TTL is disabled.
     cache_ttl_seconds: Optional[float] = None

--- a/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
@@ -22,7 +22,7 @@ from sglang.srt.mem_cache.base_swa_memory_pool import BaseSWAKVPool
 from sglang.srt.mem_cache.deepseek_v4_compress_state import CompressStatePool
 from sglang.srt.mem_cache.memory_pool import KVCache
 from sglang.srt.runtime_context import get_exec, get_spec
-from sglang.srt.utils import ceil_div, is_hip
+from sglang.srt.utils import ceil_align, ceil_div, is_hip
 
 logger = logging.getLogger(__name__)
 
@@ -497,9 +497,26 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         enable_hisparse: bool = False,
         online_mtp_max_draft_tokens: int = 0,
         num_req_slots: Optional[int] = None,
+        draft_swa_scratch_width: int = 0,
     ):
+        resolved_num_req_slots = (
+            num_req_slots if num_req_slots is not None else max_num_reqs + 1
+        )
+        self.draft_swa_scratch_width = int(draft_swa_scratch_width)
+        self.draft_swa_committed_size = int(swa_size)
+        self.draft_swa_scratch_base = 0
+        physical_swa_size = int(swa_size)
+        if self.draft_swa_scratch_width:
+            self.draft_swa_scratch_base = ceil_align(
+                self.draft_swa_committed_size + 1, swa_page_size
+            )
+            physical_swa_size = (
+                self.draft_swa_scratch_base
+                + resolved_num_req_slots * self.draft_swa_scratch_width
+            )
+
         super().__init__(
-            swa_size,
+            physical_swa_size,
             page_size,
             dtype,
             layer_num,
@@ -521,9 +538,7 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         # SWA ring needs one slot per addressable req_pool_idx. PD decode inflates
         # req_to_token past max_num_reqs (pre-alloc), so the caller passes the real
         # capacity; sizing as max_num_reqs+1 overflows ("length out of range").
-        self.num_req_slots = (
-            num_req_slots if num_req_slots is not None else max_num_reqs + 1
-        )
+        self.num_req_slots = resolved_num_req_slots
         self.c4_size = c4_size
         self.c4_logical_size = c4_logical_size
         self.c128_size = c128_size
@@ -567,7 +582,8 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         assert page_size % swa_page_size == 0
         self.sliding_window = sliding_window
 
-        self.swa_size = swa_size
+        # Allocator/radix/HiCache capacity excludes the appended step workspace.
+        self.swa_size = self.draft_swa_committed_size
         self.swa_window_size = swa_page_size
         self.swa_page_size = swa_page_size
         self.scale_pad = 1
@@ -587,6 +603,10 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         )
 
         self._unified_kv = is_unified_kv_triton()
+        if self._unified_kv and self.draft_swa_scratch_width:
+            raise NotImplementedError(
+                "DSV4 DSpark draft SWA scratch is not supported by unified_kv yet."
+            )
 
         if self._unified_kv:
             self.swa_kv_pool = None
@@ -616,7 +636,7 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         else:
             self.unified_kv_pool = None
             self.swa_kv_pool = self._make_kv_pool(
-                size=swa_size,
+                size=physical_swa_size,
                 page_size=swa_page_size,
                 dtype=dtype,
                 layer_num=stage_layer_num,
@@ -680,6 +700,31 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
     def translate_loc_from_full_to_swa(self, kv_indices: torch.Tensor):
         assert self.full_to_swa_index_mapping is not None
         return self.full_to_swa_index_mapping[kv_indices]
+
+    @property
+    def has_draft_swa_scratch(self) -> bool:
+        return self.draft_swa_scratch_width > 0
+
+    def get_draft_swa_scratch_locs(
+        self, req_pool_indices: torch.Tensor, block_size: int
+    ) -> torch.Tensor:
+        """Return step-local rows outside the committed sidecar address space."""
+        if not self.has_draft_swa_scratch:
+            raise RuntimeError("DSV4 draft SWA scratch is not enabled.")
+        if block_size > self.draft_swa_scratch_width:
+            raise ValueError(
+                f"Draft block size {block_size} exceeds scratch width "
+                f"{self.draft_swa_scratch_width}."
+            )
+        offsets = torch.arange(
+            block_size, dtype=torch.int64, device=req_pool_indices.device
+        )
+        return (
+            self.draft_swa_scratch_base
+            + req_pool_indices.to(torch.int64).unsqueeze(1)
+            * self.draft_swa_scratch_width
+            + offsets.unsqueeze(0)
+        ).reshape(-1)
 
     def get_contiguous_buf_infos(self) -> Tuple[List[int], List[int], List[int]]:
         data_ptrs: List[int] = []
@@ -800,8 +845,17 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
             for buf in self.swa_kv_pool.kv_buffer:
                 assert buf.ndim == 2, f"expected 2D buffer, got {buf.ndim}D"
                 data_ptrs.append(buf.data_ptr())
-                data_lens.append(buf.nbytes)
-                item_lens.append(buf[0].nbytes)
+                item_len = buf[0].nbytes
+                item_lens.append(item_len)
+                if self.has_draft_swa_scratch:
+                    committed_pages = (
+                        self.draft_swa_committed_size
+                        + self.swa_page_size
+                        + 1
+                    ) // self.swa_page_size
+                    data_lens.append(committed_pages * item_len)
+                else:
+                    data_lens.append(buf.nbytes)
 
         for pools in [
             self.compress_state_pools,

--- a/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
@@ -31,6 +31,18 @@ _is_hip = is_hip()
 ONLINE_C128 = not _is_hip and envs.SGLANG_OPT_USE_ONLINE_COMPRESS.get()
 
 
+def get_dsv4_packed_kv_bytes_per_token(
+    *, qk_nope_head_dim: int, qk_rope_head_dim: int
+) -> int:
+    """Bytes per token in the packed DSV4 SWA/compressed KV layout."""
+    return (
+        int(qk_nope_head_dim)
+        + int(qk_rope_head_dim) * torch.bfloat16.itemsize
+        + int(qk_nope_head_dim) // 64
+        + 1
+    )
+
+
 def get_compress_state_ring_size(
     compress_ratio: int, is_speculative: bool = False
 ) -> int:
@@ -104,13 +116,10 @@ class DeepSeekV4SingleKVPool(KVCache):
                 ]
 
     def get_bytes_per_token(self) -> int:
-        dim_per_token = (
-            self.qk_nope_head_dim
-            + self.qk_rope_head_dim * self.rope_storage_dtype.itemsize
-            + self.qk_nope_head_dim // self.quantize_block_size
-            + self.scale_pad
+        return get_dsv4_packed_kv_bytes_per_token(
+            qk_nope_head_dim=self.qk_nope_head_dim,
+            qk_rope_head_dim=self.qk_rope_head_dim,
         )
-        return dim_per_token
 
     def create_buffer(self, *, num_pages: int):
         bytes_per_token = self.get_bytes_per_token()

--- a/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
@@ -81,7 +81,9 @@ class DraftSWASidecarLayout:
                 physical_size=committed_size,
                 committed_pages=committed_pages,
             )
-        scratch_base = ceil_align(committed_size + 1, page_size)
+        # Keep the complete allocator guard page on the committed side. HiCache
+        # exposes exactly committed_pages, so scratch must begin after that view.
+        scratch_base = committed_pages * page_size
         return cls(
             committed_size=committed_size,
             scratch_width=scratch_width,
@@ -124,15 +126,9 @@ def use_dsv4_dspark_draft_swa_sidecar(server_args, spec_algorithm) -> bool:
     requested = getattr(
         server_args, "speculative_dspark_draft_swa_sidecar", None
     )
-    from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.env_gate import (
-        is_unified_kv_triton,
-    )
-
     unsupported_reason = None
     if is_npu():
         unsupported_reason = "NPU uses a separate DSV4 cache implementation"
-    elif is_unified_kv_triton():
-        unsupported_reason = "unified_kv still uses a request-scoped SWA ring"
 
     if unsupported_reason is not None:
         if requested is True:
@@ -509,7 +505,7 @@ class DeepSeekV4UnifiedKVPool:
     """
     Layout:
     unified_kv[L]: ``[swa_pages + padded_compress_rows, head_dim]`` bf16
-    - rows ``[0, swa_pages)``   = SWA ring (``req_pool_indices * swa_window + pos % swa_window``)
+    - rows ``[0, swa_pages)``   = SWA ring or draft sidecar + scratch
     - rows ``[swa_pages, ...)`` = compressed (``swa_pages + page_index``)
     """
 
@@ -528,11 +524,16 @@ class DeepSeekV4UnifiedKVPool:
         memory_saver_adapter,
         custom_mem_pool,
         swa_ring_size: int,
+        swa_rows: Optional[int] = None,
     ):
         self.swa_ring_size = swa_ring_size
         self.head_dim = qk_nope_head_dim + qk_rope_head_dim
         self.num_slots = num_slots
-        self.swa_pages = num_slots * self.swa_ring_size
+        self.swa_pages = (
+            int(swa_rows)
+            if swa_rows is not None
+            else num_slots * self.swa_ring_size
+        )
         self.num_blocks = num_blocks
         self.page_size = page_size
         self.k_per_block = dict(self.K_PER_BLOCK)
@@ -699,10 +700,9 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         )
 
         self._unified_kv = is_unified_kv_triton()
-        if self._unified_kv and self.draft_swa_layout.has_scratch:
-            raise NotImplementedError(
-                "DSV4 DSpark draft SWA scratch is not supported by unified_kv yet."
-            )
+        self.unified_swa_is_sidecar = (
+            self._unified_kv and self.draft_swa_layout.has_scratch
+        )
 
         if self._unified_kv:
             self.swa_kv_pool = None
@@ -724,6 +724,9 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
                 memory_saver_adapter=self.memory_saver_adapter,
                 custom_mem_pool=self.custom_mem_pool,
                 swa_ring_size=self.sliding_window + spec_extra,
+                swa_rows=(
+                    physical_swa_size + 1 if self.unified_swa_is_sidecar else None
+                ),
             )
 
             self.unified_swa_window = self.sliding_window
@@ -806,6 +809,17 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
     ) -> torch.Tensor:
         return self.draft_swa_layout.scratch_locs(req_pool_indices, block_size)
 
+    def get_draft_swa_scratch_locs_for_tokens(
+        self, req_pool_indices: torch.Tensor, step_offsets: torch.Tensor
+    ) -> torch.Tensor:
+        if not self.has_draft_swa_scratch:
+            raise RuntimeError("DSV4 draft SWA scratch is not enabled.")
+        return (
+            self.draft_swa_layout.scratch_base
+            + req_pool_indices.to(torch.int64) * self.draft_swa_layout.scratch_width
+            + step_offsets.to(torch.int64)
+        )
+
     def translate_draft_committed_loc(
         self, full_indices: torch.Tensor
     ) -> torch.Tensor:
@@ -815,9 +829,19 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
     def get_draft_swa_committed_buffers(self) -> List[torch.Tensor]:
         """Views exposed to cache/transfer layers; scratch pages are excluded."""
         if self._unified_kv:
-            raise NotImplementedError(
-                "Unified KV does not expose a content-scoped draft SWA sidecar."
-            )
+            if not self.unified_swa_is_sidecar:
+                raise NotImplementedError(
+                    "Request-scoped unified KV has no draft SWA sidecar."
+                )
+            pages = self.draft_swa_layout.committed_pages
+            page_size = self.draft_swa_layout.page_size
+            head_dim = self.unified_kv_pool.head_dim
+            return [
+                buf.narrow(0, 0, pages * page_size)
+                .reshape(pages, page_size * head_dim)
+                .view(torch.uint8)
+                for buf in self.unified_kv_pool.kv_buffer
+            ]
         if not self.has_draft_swa_scratch:
             return list(self.swa_kv_pool.kv_buffer)
         pages = self.draft_swa_layout.committed_pages
@@ -885,7 +909,7 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         data_ptrs: List[int] = []
         data_lens: List[int] = []
         item_lens: List[int] = []
-        if not self._unified_kv:
+        if not self._unified_kv or self.unified_swa_is_sidecar:
             return data_ptrs, data_lens, item_lens
         swa_pages = self.unified_kv_pool.swa_pages
         for buf in self.unified_kv_pool.kv_buffer:
@@ -938,7 +962,12 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         data_lens: List[int] = []
         item_lens: List[int] = []
 
-        if not self._unified_kv:
+        if self.unified_swa_is_sidecar:
+            for buf in self.get_draft_swa_committed_buffers():
+                data_ptrs.append(buf.data_ptr())
+                data_lens.append(buf.nbytes)
+                item_lens.append(buf[0].nbytes)
+        elif not self._unified_kv:
             for buf in self.swa_kv_pool.kv_buffer:
                 assert buf.ndim == 2, f"expected 2D buffer, got {buf.ndim}D"
                 data_ptrs.append(buf.data_ptr())

--- a/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from contextlib import nullcontext
+from dataclasses import dataclass
 from typing import List, Literal, NamedTuple, Optional, Tuple
 
 import torch
@@ -22,7 +23,7 @@ from sglang.srt.mem_cache.base_swa_memory_pool import BaseSWAKVPool
 from sglang.srt.mem_cache.deepseek_v4_compress_state import CompressStatePool
 from sglang.srt.mem_cache.memory_pool import KVCache
 from sglang.srt.runtime_context import get_exec, get_spec
-from sglang.srt.utils import ceil_align, ceil_div, is_hip
+from sglang.srt.utils import ceil_align, ceil_div, is_hip, is_npu
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +42,106 @@ def get_dsv4_packed_kv_bytes_per_token(
         + int(qk_nope_head_dim) // 64
         + 1
     )
+
+
+@dataclass(frozen=True)
+class DraftSWASidecarLayout:
+    """Physical split between cache-owned draft SWA and step-local scratch."""
+
+    committed_size: int
+    scratch_width: int
+    num_req_slots: int
+    page_size: int
+    scratch_base: int
+    physical_size: int
+    committed_pages: int
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        committed_size: int,
+        scratch_width: int,
+        num_req_slots: int,
+        page_size: int,
+    ) -> "DraftSWASidecarLayout":
+        committed_size = int(committed_size)
+        scratch_width = int(scratch_width)
+        num_req_slots = int(num_req_slots)
+        if scratch_width < 0:
+            raise ValueError(f"scratch_width must be non-negative, got {scratch_width}.")
+        committed_pages = (committed_size + page_size + 1) // page_size
+        if scratch_width == 0:
+            return cls(
+                committed_size=committed_size,
+                scratch_width=0,
+                num_req_slots=num_req_slots,
+                page_size=page_size,
+                scratch_base=0,
+                physical_size=committed_size,
+                committed_pages=committed_pages,
+            )
+        scratch_base = ceil_align(committed_size + 1, page_size)
+        return cls(
+            committed_size=committed_size,
+            scratch_width=scratch_width,
+            num_req_slots=num_req_slots,
+            page_size=page_size,
+            scratch_base=scratch_base,
+            physical_size=scratch_base + num_req_slots * scratch_width - 1,
+            committed_pages=committed_pages,
+        )
+
+    @property
+    def has_scratch(self) -> bool:
+        return self.scratch_width > 0
+
+    def scratch_locs(
+        self, req_pool_indices: torch.Tensor, block_size: int
+    ) -> torch.Tensor:
+        if not self.has_scratch:
+            raise RuntimeError("DSV4 draft SWA scratch is not enabled.")
+        if block_size > self.scratch_width:
+            raise ValueError(
+                f"Draft block size {block_size} exceeds scratch width "
+                f"{self.scratch_width}."
+            )
+        offsets = torch.arange(
+            block_size, dtype=torch.int64, device=req_pool_indices.device
+        )
+        return (
+            self.scratch_base
+            + req_pool_indices.to(torch.int64).unsqueeze(1) * self.scratch_width
+            + offsets.unsqueeze(0)
+        ).reshape(-1)
+
+
+def use_dsv4_dspark_draft_swa_sidecar(server_args, spec_algorithm) -> bool:
+    """Resolve the rollout flag without silently weakening cache semantics."""
+    if not spec_algorithm.is_dspark():
+        return False
+
+    requested = getattr(
+        server_args, "speculative_dspark_draft_swa_sidecar", None
+    )
+    from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.env_gate import (
+        is_unified_kv_triton,
+    )
+
+    unsupported_reason = None
+    if is_npu():
+        unsupported_reason = "NPU uses a separate DSV4 cache implementation"
+    elif is_unified_kv_triton():
+        unsupported_reason = "unified_kv still uses a request-scoped SWA ring"
+
+    if unsupported_reason is not None:
+        if requested is True:
+            raise NotImplementedError(
+                "DSV4 DSpark draft SWA sidecar was explicitly enabled, but "
+                f"{unsupported_reason}."
+            )
+        return False
+    return requested is not False
 
 
 def get_compress_state_ring_size(
@@ -502,18 +603,13 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         resolved_num_req_slots = (
             num_req_slots if num_req_slots is not None else max_num_reqs + 1
         )
-        self.draft_swa_scratch_width = int(draft_swa_scratch_width)
-        self.draft_swa_committed_size = int(swa_size)
-        self.draft_swa_scratch_base = 0
-        physical_swa_size = int(swa_size)
-        if self.draft_swa_scratch_width:
-            self.draft_swa_scratch_base = ceil_align(
-                self.draft_swa_committed_size + 1, swa_page_size
-            )
-            physical_swa_size = (
-                self.draft_swa_scratch_base
-                + resolved_num_req_slots * self.draft_swa_scratch_width
-            )
+        self.draft_swa_layout = DraftSWASidecarLayout.build(
+            committed_size=swa_size,
+            scratch_width=draft_swa_scratch_width,
+            num_req_slots=resolved_num_req_slots,
+            page_size=swa_page_size,
+        )
+        physical_swa_size = self.draft_swa_layout.physical_size
 
         super().__init__(
             physical_swa_size,
@@ -583,7 +679,7 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         self.sliding_window = sliding_window
 
         # Allocator/radix/HiCache capacity excludes the appended step workspace.
-        self.swa_size = self.draft_swa_committed_size
+        self.swa_size = self.draft_swa_layout.committed_size
         self.swa_window_size = swa_page_size
         self.swa_page_size = swa_page_size
         self.scale_pad = 1
@@ -603,7 +699,7 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         )
 
         self._unified_kv = is_unified_kv_triton()
-        if self._unified_kv and self.draft_swa_scratch_width:
+        if self._unified_kv and self.draft_swa_layout.has_scratch:
             raise NotImplementedError(
                 "DSV4 DSpark draft SWA scratch is not supported by unified_kv yet."
             )
@@ -703,28 +799,29 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
 
     @property
     def has_draft_swa_scratch(self) -> bool:
-        return self.draft_swa_scratch_width > 0
+        return self.draft_swa_layout.has_scratch
 
     def get_draft_swa_scratch_locs(
         self, req_pool_indices: torch.Tensor, block_size: int
     ) -> torch.Tensor:
-        """Return step-local rows outside the committed sidecar address space."""
-        if not self.has_draft_swa_scratch:
-            raise RuntimeError("DSV4 draft SWA scratch is not enabled.")
-        if block_size > self.draft_swa_scratch_width:
-            raise ValueError(
-                f"Draft block size {block_size} exceeds scratch width "
-                f"{self.draft_swa_scratch_width}."
+        return self.draft_swa_layout.scratch_locs(req_pool_indices, block_size)
+
+    def translate_draft_committed_loc(
+        self, full_indices: torch.Tensor
+    ) -> torch.Tensor:
+        """Map content-owned full locations into the committed sidecar only."""
+        return self.translate_loc_from_full_to_swa(full_indices)
+
+    def get_draft_swa_committed_buffers(self) -> List[torch.Tensor]:
+        """Views exposed to cache/transfer layers; scratch pages are excluded."""
+        if self._unified_kv:
+            raise NotImplementedError(
+                "Unified KV does not expose a content-scoped draft SWA sidecar."
             )
-        offsets = torch.arange(
-            block_size, dtype=torch.int64, device=req_pool_indices.device
-        )
-        return (
-            self.draft_swa_scratch_base
-            + req_pool_indices.to(torch.int64).unsqueeze(1)
-            * self.draft_swa_scratch_width
-            + offsets.unsqueeze(0)
-        ).reshape(-1)
+        if not self.has_draft_swa_scratch:
+            return list(self.swa_kv_pool.kv_buffer)
+        pages = self.draft_swa_layout.committed_pages
+        return [buf.narrow(0, 0, pages) for buf in self.swa_kv_pool.kv_buffer]
 
     def get_contiguous_buf_infos(self) -> Tuple[List[int], List[int], List[int]]:
         data_ptrs: List[int] = []
@@ -848,12 +945,9 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
                 item_len = buf[0].nbytes
                 item_lens.append(item_len)
                 if self.has_draft_swa_scratch:
-                    committed_pages = (
-                        self.draft_swa_committed_size
-                        + self.swa_page_size
-                        + 1
-                    ) // self.swa_page_size
-                    data_lens.append(committed_pages * item_len)
+                    data_lens.append(
+                        self.draft_swa_layout.committed_pages * item_len
+                    )
                 else:
                     data_lens.append(buf.nbytes)
 

--- a/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
@@ -847,6 +847,13 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         pages = self.draft_swa_layout.committed_pages
         return [buf.narrow(0, 0, pages) for buf in self.swa_kv_pool.kv_buffer]
 
+    def get_draft_swa_state_layer_ids(self) -> List[int]:
+        if self._unified_kv:
+            layer_num = len(self.unified_kv_pool.kv_buffer)
+        else:
+            layer_num = len(self.swa_kv_pool.kv_buffer)
+        return list(range(self._stage_start, self._stage_start + layer_num))
+
     def get_contiguous_buf_infos(self) -> Tuple[List[int], List[int], List[int]]:
         data_ptrs: List[int] = []
         data_lens: List[int] = []

--- a/python/sglang/srt/mem_cache/hicache_storage.py
+++ b/python/sglang/srt/mem_cache/hicache_storage.py
@@ -8,7 +8,7 @@ import uuid
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING, Any, List, Optional, Set
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, Set
 
 import torch
 
@@ -85,10 +85,13 @@ class PoolHitPolicy(str, Enum):
 
     ALL_PAGES      : every page in [0, kv_hit) must exist (e.g. DSA).
     TRAILING_PAGES : only the last N pages must exist (e.g. Mamba/SWA states).
+    RECOMPUTE_TRAILING : if the trailing sidecar is missing, reuse the prefix
+                         before that tail and regenerate the tail.
     """
 
     ALL_PAGES = "all_pages"
     TRAILING_PAGES = "trailing_pages"
+    RECOMPUTE_TRAILING = "recompute_trailing"
 
 
 @dataclass
@@ -118,16 +121,41 @@ class SidecarPoolSpec:
     hit_policy: PoolHitPolicy = PoolHitPolicy.ALL_PAGES
 
 
+def resolve_pool_hit_boundary(
+    *,
+    kv_pages: int,
+    transfer: PoolTransfer,
+    has_component: Callable[[int], bool],
+) -> tuple[int, bool]:
+    """Return reusable prefix pages and whether the sidecar itself is present."""
+    if transfer.hit_policy == PoolHitPolicy.ALL_PAGES:
+        boundary = next((i for i in range(kv_pages) if not has_component(i)), kv_pages)
+        return boundary, boundary > 0
+
+    trailing = max(1, len(transfer.keys) if transfer.keys else 1)
+    for prefix_len in range(kv_pages, 0, -1):
+        if all(
+            has_component(i)
+            for i in range(max(0, prefix_len - trailing), prefix_len)
+        ):
+            return prefix_len, True
+
+    if transfer.hit_policy == PoolHitPolicy.RECOMPUTE_TRAILING:
+        return max(0, kv_pages - trailing), False
+    return 0, False
+
+
 @dataclass
 class PoolTransferResult:
     """Tracks how many pages were successfully processed per pool."""
 
     kv_hit_pages: int
     extra_pool_hit_pages: dict[str, int]
+    recompute_tail_pages: int = 0
 
     @classmethod
     def empty(cls) -> PoolTransferResult:
-        return cls(0, {})
+        return cls(0, {}, 0)
 
     def update_kv_hit_pages(self, kv_hit_pages: int) -> None:
         """Accumulate kv_hit_pages across batches (max = last successful batch)."""
@@ -626,30 +654,26 @@ class HiCacheFile(HiCacheStorage):
 
         hit_count: dict[str, int] = {PoolName.KV: kv_pages} if kv_pages else {}
         final_pages = kv_pages
+        recompute_tail_pages = 0
 
         for transfer in pool_transfers or []:
             if final_pages == 0:
                 break
             name = transfer.name
-            if transfer.hit_policy == PoolHitPolicy.ALL_PAGES:
-                boundary = next(
-                    (i for i in range(kv_pages) if not has_component(i, name)), kv_pages
-                )
-            else:  # trailing_pages
-                trailing = max(1, len(transfer.keys) if transfer.keys else 1)
-                boundary = 0
-                for prefix_len in range(kv_pages, 0, -1):
-                    if all(
-                        has_component(i, name)
-                        for i in range(max(0, prefix_len - trailing), prefix_len)
-                    ):
-                        boundary = prefix_len
-                        break
-            if boundary:
+            boundary, sidecar_hit = resolve_pool_hit_boundary(
+                kv_pages=kv_pages,
+                transfer=transfer,
+                has_component=lambda i: has_component(i, name),
+            )
+            if sidecar_hit:
                 hit_count[name] = boundary
+            elif transfer.hit_policy == PoolHitPolicy.RECOMPUTE_TRAILING:
+                recompute_tail_pages = max(
+                    recompute_tail_pages, kv_pages - boundary
+                )
             final_pages = min(final_pages, boundary)
 
-        return PoolTransferResult(final_pages, hit_count)
+        return PoolTransferResult(final_pages, hit_count, recompute_tail_pages)
 
     def _log_key(self, pool_name: str, key: str) -> str:
         return key if pool_name == PoolName.KV else f"{key}.{pool_name}"

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
@@ -596,6 +596,10 @@ class HybridCacheController(BaseHiCacheController):
 
         kv_hit_pages = hit_result.kv_hit_pages
         operation.pool_storage_result.update_kv_hit_pages(kv_hit_pages)
+        operation.pool_storage_result.recompute_tail_pages = max(
+            operation.pool_storage_result.recompute_tail_pages,
+            hit_result.recompute_tail_pages,
+        )
 
         return (
             hash_value[:kv_hit_pages],

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
@@ -1079,6 +1079,46 @@ def build_swa_draft_pools(
 ) -> tuple[list[SidecarPoolSpec], list[PoolEntry]]:
     """Build a draft SWA sidecar whose indices follow target SWA."""
     draft_swa_pool = draft_kv_pool.swa_kv_pool
+    if getattr(draft_kv_pool, "unified_swa_is_sidecar", False):
+        controller = tree_cache.cache_controller
+        host_pool_group = controller.mem_pool_host
+        anchor = host_pool_group.anchor_entry
+        full_allocator = tree_cache.token_to_kv_pool_allocator.full_attn_allocator
+        committed_pages = draft_kv_pool.draft_swa_layout.committed_pages
+        num_host_pages = max(
+            1,
+            (
+                committed_pages * anchor.host_pool.logical_size
+                + full_allocator.size
+                - 1
+            )
+            // full_allocator.size,
+        )
+        device_buffers = draft_kv_pool.get_draft_swa_committed_buffers()
+        host_pool = DeepSeekV4PagedHostPool(
+            pool_name=str(PoolName.SWA),
+            device_buffers=device_buffers,
+            item_bytes=device_buffers[0][0].nbytes,
+            num_host_pages=num_host_pages,
+            slot_page_size=draft_kv_pool.swa_page_size,
+            layout=anchor.host_pool.layout,
+            allocator_type=_get_allocator_type(server_args),
+        )
+        swa_allocator = tree_cache.token_to_kv_pool_allocator.swa_attn_allocator
+        layer_mapping = {i: i for i in range(len(device_buffers))}
+        entry = build_pool_entry(
+            name=PoolName.SWA,
+            host_pool=host_pool,
+            device_pool=draft_kv_pool,
+            layer_mapping=layer_mapping,
+            transfer_layer_num=host_pool.layer_num,
+            device_alloc_fn=swa_allocator.alloc,
+            device_free_fn=swa_allocator.free,
+        )
+        # In unified mode the logical SWA component itself owns the draft
+        # committed sidecar; the target request ring remains backend-private.
+        return [], [entry]
+
     if draft_swa_pool is None:
         raise NotImplementedError(
             "HiCache draft SWA sidecar requires a non-unified draft SWA pool."

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
@@ -1114,7 +1114,7 @@ def build_swa_draft_pools(
     spec = SidecarPoolSpec(
         pool_name=PoolName.DRAFT_SWA,
         indices_from_pool=PoolName.SWA,
-        hit_policy=PoolHitPolicy.TRAILING_PAGES,
+        hit_policy=PoolHitPolicy.RECOMPUTE_TRAILING,
     )
     entry = build_pool_entry(
         name=PoolName.DRAFT_SWA,

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
@@ -1090,9 +1090,10 @@ def build_swa_draft_pools(
     target_swa_host_pool = host_pool_group.entry_map[PoolName.SWA].host_pool
 
     if isinstance(target_swa_host_pool, DeepSeekV4PagedHostPool):
+        device_buffers = draft_kv_pool.get_draft_swa_committed_buffers()
         host_pool = DeepSeekV4PagedHostPool(
             pool_name=str(PoolName.DRAFT_SWA),
-            device_buffers=draft_swa_pool.kv_buffer,
+            device_buffers=device_buffers,
             item_bytes=draft_swa_pool.bytes_per_page_padded,
             num_host_pages=target_swa_host_pool.num_host_pages,
             slot_page_size=draft_swa_pool.page_size,

--- a/python/sglang/srt/mem_cache/kv_cache_builder.py
+++ b/python/sglang/srt/mem_cache/kv_cache_builder.py
@@ -112,8 +112,7 @@ def maybe_register_hicache_draft(
         draft_device_pools=draft_plan.device_pools,
         tree_cache=tree_cache,
     )
-    for spec, entry in zip(specs, entries, strict=True):
-        tree_cache.register_sidecar_pool(spec, entry)
+    tree_cache.register_hicache_draft_pools(specs, entries)
 
 
 # Host slots a backup-only retraction pool gets, as a fraction of the device
@@ -236,6 +235,7 @@ def build_kv_cache(
 
     req_to_token_pool, token_to_kv_pool_allocator = tp_worker.get_memory_pool()
     mtp_draft_device_pools = tp_worker.model_runner.mtp_draft_device_pools
+    target_kv_pool = token_to_kv_pool_allocator.get_kvcache()
 
     retraction_backup = resolve_decode_retraction_backup(tp_worker=tp_worker)
 
@@ -322,6 +322,9 @@ def build_kv_cache(
         enable_draft_swa_sidecar=(
             is_deepseek_v4(model_config.hf_config)
             and use_dsv4_dspark_draft_swa_sidecar(server_args, spec_algorithm)
+            # With unified_kv, the logical SWA component itself owns the draft
+            # committed sidecar. Paged target SWA needs the dependent tracker.
+            and not getattr(target_kv_pool, "_unified_kv", False)
         ),
         mtp_draft_device_pools=mtp_draft_device_pools,
     )

--- a/python/sglang/srt/mem_cache/kv_cache_builder.py
+++ b/python/sglang/srt/mem_cache/kv_cache_builder.py
@@ -31,11 +31,14 @@ from sglang.srt.configs.hybrid_arch import (
     linear_attn_model_spec,
     mamba2_config,
 )
-from sglang.srt.configs.model_config import ModelImpl, is_deepseek_dsa
+from sglang.srt.configs.model_config import ModelImpl, is_deepseek_dsa, is_deepseek_v4
 from sglang.srt.environ import envs
 from sglang.srt.hardware_backend.mlx.runtime import use_mlx
 from sglang.srt.managers.mm_schedule import init_mm_embedding_cache
 from sglang.srt.mem_cache.cache_init_params import CacheInitParams
+from sglang.srt.mem_cache.deepseek_v4_memory_pool import (
+    use_dsv4_dspark_draft_swa_sidecar,
+)
 from sglang.srt.mem_cache.memory_pool import MHATokenToKVPool
 from sglang.srt.mem_cache.registry import TreeCacheBuildContext, create_tree_cache
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
@@ -316,6 +319,10 @@ def build_kv_cache(
         pp_size=ps.pp_size,
         chunked_prefill_size=effective_chunked_prefill_size,
         sliding_window_size=sliding_window_size,
+        enable_draft_swa_sidecar=(
+            is_deepseek_v4(model_config.hf_config)
+            and use_dsv4_dspark_draft_swa_sidecar(server_args, spec_algorithm)
+        ),
         mtp_draft_device_pools=mtp_draft_device_pools,
     )
 

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -1128,6 +1128,19 @@ class KVCacheConfigurator:
         else:
             pool_cls = DeepSeekV4TokenToKVPool
 
+        draft_swa_scratch_width = 0
+        if (
+            self.is_draft_worker
+            and self.spec_algorithm.is_dspark()
+            and not _is_npu
+            and getattr(
+                self.server_args, "speculative_dspark_draft_swa_sidecar", False
+            )
+        ):
+            draft_swa_scratch_width = max(
+                (max_speculative_num_draft_tokens() or 0) - 1, 0
+            )
+
         token_to_kv_pool = pool_cls(
             max_num_reqs=max_running_requests,
             # SWA ring is indexed by req_pool_idx; PD decode inflates req_to_token
@@ -1155,6 +1168,7 @@ class KVCacheConfigurator:
             end_layer=self.layer_info.end_layer,
             enable_hisparse=get_memory().enable_hisparse,
             online_mtp_max_draft_tokens=(max_speculative_num_draft_tokens() or 0),
+            draft_swa_scratch_width=draft_swa_scratch_width,
         )
         return token_to_kv_pool
 

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -47,7 +47,10 @@ from sglang.srt.mem_cache.allocator.swa import (
     PureSWATokenToKVPoolAllocator,
     SWATokenToKVPoolAllocator,
 )
-from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
+from sglang.srt.mem_cache.deepseek_v4_memory_pool import (
+    DeepSeekV4TokenToKVPool,
+    use_dsv4_dspark_draft_swa_sidecar,
+)
 from sglang.srt.mem_cache.hisparse_memory_pool import HiSparseDSATokenToKVPool
 from sglang.srt.mem_cache.memory_pool import (
     DSATokenToKVPool,
@@ -1131,10 +1134,8 @@ class KVCacheConfigurator:
         draft_swa_scratch_width = 0
         if (
             self.is_draft_worker
-            and self.spec_algorithm.is_dspark()
-            and not _is_npu
-            and getattr(
-                self.server_args, "speculative_dspark_draft_swa_sidecar", False
+            and use_dsv4_dspark_draft_swa_sidecar(
+                self.server_args, self.spec_algorithm
             )
         ):
             draft_swa_scratch_width = max(

--- a/python/sglang/srt/mem_cache/storage/hf3fs/storage_hf3fs.py
+++ b/python/sglang/srt/mem_cache/storage/hf3fs/storage_hf3fs.py
@@ -21,6 +21,7 @@ from sglang.srt.mem_cache.hicache_storage import (
     PoolName,
     PoolTransfer,
     PoolTransferResult,
+    resolve_pool_hit_boundary,
 )
 from sglang.srt.mem_cache.pool_host import HostKVCache
 from sglang.srt.mem_cache.storage.hf3fs.hf3fs_client import Hf3fsClient
@@ -683,6 +684,7 @@ class HiCacheHF3FS(HiCacheStorage):
 
         hit_count: dict = {PoolName.KV: kv_pages} if kv_pages else {}
         final_pages = kv_pages
+        recompute_tail_pages = 0
 
         for transfer in pool_transfers or []:
             if final_pages == 0:
@@ -699,27 +701,20 @@ class HiCacheHF3FS(HiCacheStorage):
                 self.rank, component_keys, namespace=ctx.namespace
             )
 
-            boundary = 0
-            if transfer.hit_policy == PoolHitPolicy.ALL_PAGES:
-                try:
-                    boundary = exists_results.index(False)
-                except ValueError:
-                    boundary = kv_pages
-            elif transfer.hit_policy == PoolHitPolicy.TRAILING_PAGES:
-                trailing = max(1, len(transfer.keys) if transfer.keys else 1)
-                for prefix_len in range(kv_pages, 0, -1):
-                    if all(
-                        exists_results[i]
-                        for i in range(max(0, prefix_len - trailing), prefix_len)
-                    ):
-                        boundary = prefix_len
-                        break
-
-            if boundary:
+            boundary, sidecar_hit = resolve_pool_hit_boundary(
+                kv_pages=kv_pages,
+                transfer=transfer,
+                has_component=lambda i: exists_results[i],
+            )
+            if sidecar_hit:
                 hit_count[pool_name] = boundary
+            elif transfer.hit_policy == PoolHitPolicy.RECOMPUTE_TRAILING:
+                recompute_tail_pages = max(
+                    recompute_tail_pages, kv_pages - boundary
+                )
             final_pages = min(final_pages, boundary)
 
-        return PoolTransferResult(final_pages, hit_count)
+        return PoolTransferResult(final_pages, hit_count, recompute_tail_pages)
 
     def _pool_batch_get(self, transfer: PoolTransfer) -> List[bool]:
         pool_name = transfer.name

--- a/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
+++ b/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
@@ -20,6 +20,7 @@ from sglang.srt.mem_cache.hicache_storage import (
     PoolName,
     PoolTransfer,
     PoolTransferResult,
+    resolve_pool_hit_boundary,
 )
 from sglang.srt.mem_cache.pool_host import HostKVCache, HostTensorAllocator
 from sglang.srt.mem_cache.pool_host.mla import MLATokenToKVPoolHost
@@ -841,6 +842,7 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
 
         hit_count: dict = {PoolName.KV: kv_pages} if kv_pages else {}
         final_pages = kv_pages
+        recompute_tail_pages = 0
 
         for transfer in pool_transfers or []:
             if final_pages == 0:
@@ -860,26 +862,20 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
                 ]
             else:
                 page_exists = [False] * kv_pages
-            boundary = 0
-            if transfer.hit_policy == PoolHitPolicy.ALL_PAGES:
-                try:
-                    boundary = page_exists.index(False)
-                except ValueError:
-                    boundary = kv_pages
-            elif transfer.hit_policy == PoolHitPolicy.TRAILING_PAGES:
-                trailing = max(1, len(transfer.keys) if transfer.keys else 1)
-                for prefix_len in range(kv_pages, 0, -1):
-                    if all(
-                        page_exists[i]
-                        for i in range(max(0, prefix_len - trailing), prefix_len)
-                    ):
-                        boundary = prefix_len
-                        break
-            if boundary:
+            boundary, sidecar_hit = resolve_pool_hit_boundary(
+                kv_pages=kv_pages,
+                transfer=transfer,
+                has_component=lambda i: page_exists[i],
+            )
+            if sidecar_hit:
                 hit_count[transfer.name] = boundary
+            elif transfer.hit_policy == PoolHitPolicy.RECOMPUTE_TRAILING:
+                recompute_tail_pages = max(
+                    recompute_tail_pages, kv_pages - boundary
+                )
             final_pages = min(final_pages, boundary)
 
-        return PoolTransferResult(final_pages, hit_count)
+        return PoolTransferResult(final_pages, hit_count, recompute_tail_pages)
 
     def _batch_io_v2(self, transfers: List[PoolTransfer], is_set: bool):
         # Unified v2 I/O path: each PoolTransfer can expand to one or more

--- a/python/sglang/srt/mem_cache/storage/nixl/hicache_nixl.py
+++ b/python/sglang/srt/mem_cache/storage/nixl/hicache_nixl.py
@@ -17,6 +17,7 @@ from sglang.srt.mem_cache.hicache_storage import (
     PoolName,
     PoolTransfer,
     PoolTransferResult,
+    resolve_pool_hit_boundary,
 )
 from sglang.srt.mem_cache.pool_host import HostKVCache
 from sglang.srt.mem_cache.storage.mmap import alloc_mmap
@@ -889,6 +890,7 @@ class HiCacheNixl(HiCacheStorage):
         kv_pages = self.batch_exists(keys, extra_info)
         hit_count: dict = {PoolName.KV: kv_pages} if kv_pages else {}
         final_pages = kv_pages
+        recompute_tail_pages = 0
 
         for transfer in pool_transfers or []:
             if final_pages == 0:
@@ -912,27 +914,20 @@ class HiCacheNixl(HiCacheStorage):
             exists_results = self._query_keys_exist(component_keys)
             page_exists = self._page_results(exists_results, key_multiplier)
 
-            boundary = 0
-            if transfer.hit_policy == PoolHitPolicy.ALL_PAGES:
-                try:
-                    boundary = page_exists.index(False)
-                except ValueError:
-                    boundary = kv_pages
-            elif transfer.hit_policy == PoolHitPolicy.TRAILING_PAGES:
-                trailing = max(1, len(transfer.keys) if transfer.keys else 1)
-                for prefix_len in range(kv_pages, 0, -1):
-                    if all(
-                        page_exists[i]
-                        for i in range(max(0, prefix_len - trailing), prefix_len)
-                    ):
-                        boundary = prefix_len
-                        break
-
-            if boundary:
+            boundary, sidecar_hit = resolve_pool_hit_boundary(
+                kv_pages=kv_pages,
+                transfer=transfer,
+                has_component=lambda i: page_exists[i],
+            )
+            if sidecar_hit:
                 hit_count[transfer.name] = boundary
+            elif transfer.hit_policy == PoolHitPolicy.RECOMPUTE_TRAILING:
+                recompute_tail_pages = max(
+                    recompute_tail_pages, kv_pages - boundary
+                )
             final_pages = min(final_pages, boundary)
 
-        return PoolTransferResult(final_pages, hit_count)
+        return PoolTransferResult(final_pages, hit_count, recompute_tail_pages)
 
     @staticmethod
     def _page_results(results: List[bool], key_multiplier: int) -> List[bool]:

--- a/python/sglang/srt/mem_cache/storage/umbp/umbp_store.py
+++ b/python/sglang/srt/mem_cache/storage/umbp/umbp_store.py
@@ -22,6 +22,7 @@ from sglang.srt.mem_cache.hicache_storage import (
     PoolName,
     PoolTransfer,
     PoolTransferResult,
+    resolve_pool_hit_boundary,
 )
 from sglang.srt.mem_cache.memory_pool_host import HostKVCache
 
@@ -1277,6 +1278,7 @@ class UMBPStore(HiCacheStorage):
 
         hit_count: dict = {PoolName.KV: kv_pages} if kv_pages else {}
         final_pages = kv_pages
+        recompute_tail_pages = 0
 
         for transfer in pool_transfers or []:
             if final_pages == 0:
@@ -1301,26 +1303,21 @@ class UMBPStore(HiCacheStorage):
                 for i in range(final_pages)
             ]
 
-            boundary = 0
-            if transfer.hit_policy == PoolHitPolicy.ALL_PAGES:
-                try:
-                    boundary = page_exists.index(False)
-                except ValueError:
-                    boundary = final_pages
-            elif transfer.hit_policy == PoolHitPolicy.TRAILING_PAGES:
-                trailing = max(1, len(transfer.keys) if transfer.keys else 1)
-                for prefix_len in range(final_pages, 0, -1):
-                    if all(
-                        page_exists[i]
-                        for i in range(max(0, prefix_len - trailing), prefix_len)
-                    ):
-                        boundary = prefix_len
-                        break
-            if boundary:
+            source_pages = final_pages
+            boundary, sidecar_hit = resolve_pool_hit_boundary(
+                kv_pages=source_pages,
+                transfer=transfer,
+                has_component=lambda i: page_exists[i],
+            )
+            if sidecar_hit:
                 hit_count[transfer.name] = boundary
+            elif transfer.hit_policy == PoolHitPolicy.RECOMPUTE_TRAILING:
+                recompute_tail_pages = max(
+                    recompute_tail_pages, source_pages - boundary
+                )
             final_pages = min(final_pages, boundary)
 
-        return PoolTransferResult(final_pages, hit_count)
+        return PoolTransferResult(final_pages, hit_count, recompute_tail_pages)
 
     def _batch_io_v2(self, transfers: List[PoolTransfer], is_set: bool) -> dict:
         """Unified per-pool zero-copy I/O. Returns {pool_name: per-page bools}."""

--- a/python/sglang/srt/mem_cache/unified_cache/components/__init__.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/__init__.py
@@ -1,3 +1,6 @@
+from sglang.srt.mem_cache.unified_cache.components.draft_swa_sidecar_component import (
+    DraftSWASidecarComponent,
+)
 from sglang.srt.mem_cache.unified_cache.components.full_component import FullComponent
 from sglang.srt.mem_cache.unified_cache.components.mamba_component import MambaComponent
 from sglang.srt.mem_cache.unified_cache.components.swa_component import SWAComponent
@@ -20,6 +23,7 @@ __all__ = [
     "BASE_COMPONENT_TYPE",
     "ComponentData",
     "ComponentType",
+    "DraftSWASidecarComponent",
     "EvictLayer",
     "FullComponent",
     "CacheTransferPhase",

--- a/python/sglang/srt/mem_cache/unified_cache/components/draft_swa_sidecar_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/draft_swa_sidecar_component.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sglang.srt.mem_cache.hicache_storage import PoolName, PoolTransferResult
+from sglang.srt.mem_cache.unified_cache.component_type import ComponentType
+
+if TYPE_CHECKING:
+    from sglang.srt.mem_cache.unified_radix_cache import (
+        UnifiedRadixCache,
+        UnifiedTreeNode,
+    )
+
+
+class DraftSWASidecarComponent:
+    """Coverage tracker for draft SWA that depends on target SWA slots."""
+
+    _DEVICE_KEY = "draft_swa_device_covered"
+    _HOST_KEY = "draft_swa_host_covered"
+
+    def __init__(self, cache: UnifiedRadixCache):
+        self.cache = cache
+
+    def _metadata(self, node: UnifiedTreeNode) -> dict:
+        return node.component_data[ComponentType.SWA].metadata
+
+    @property
+    def window_span(self) -> int:
+        page_size = self.cache.page_size
+        return (
+            self.cache.sliding_window_size + page_size - 1
+        ) // page_size * page_size
+
+    def mark_device(self, node: UnifiedTreeNode) -> None:
+        self._metadata(node)[self._DEVICE_KEY] = True
+
+    def mark_host(self, node: UnifiedTreeNode) -> None:
+        self._metadata(node)[self._HOST_KEY] = True
+
+    def clear_device(self, node: UnifiedTreeNode) -> None:
+        self._metadata(node).pop(self._DEVICE_KEY, None)
+
+    def clear_host(self, node: UnifiedTreeNode) -> None:
+        self._metadata(node).pop(self._HOST_KEY, None)
+
+    def has_host_window(self, node: UnifiedTreeNode) -> bool:
+        return self._window_covered(node, host=True)
+
+    def has_device_window(self, node: UnifiedTreeNode) -> bool:
+        return self._window_covered(node, host=False)
+
+    def has_loadable_window(self, node: UnifiedTreeNode) -> bool:
+        covered = 0
+        root = self.cache.tree_core.root_node
+        cur = node
+        while cur is not root and covered < self.window_span:
+            cd = cur.component_data[ComponentType.SWA]
+            if cd.value is not None:
+                if not cd.metadata.get(self._DEVICE_KEY, False):
+                    return False
+                covered += len(cd.value)
+            elif cd.host_value is not None:
+                if not cd.metadata.get(self._HOST_KEY, False):
+                    return False
+                covered += len(cd.host_value)
+            else:
+                return False
+            cur = cur.parent
+        return covered >= self.window_span
+
+    def _window_covered(self, node: UnifiedTreeNode, *, host: bool) -> bool:
+        key = self._HOST_KEY if host else self._DEVICE_KEY
+        covered = 0
+        target = self.window_span
+        root = self.cache.tree_core.root_node
+        cur = node
+        while cur is not root and covered < target:
+            cd = cur.component_data[ComponentType.SWA]
+            value = cd.host_value if host else cd.value
+            if value is None or not cd.metadata.get(key, False):
+                return False
+            covered += len(value)
+            cur = cur.parent
+        return covered >= target
+
+    def redistribute_on_node_split(
+        self, new_parent: UnifiedTreeNode, child: UnifiedTreeNode
+    ) -> None:
+        child_meta = self._metadata(child)
+        parent_meta = self._metadata(new_parent)
+        for key in (self._DEVICE_KEY, self._HOST_KEY):
+            if child_meta.get(key, False):
+                parent_meta[key] = True
+
+    def mark_host_backup(self, node: UnifiedTreeNode, transferred: bool) -> None:
+        if transferred:
+            self.mark_host(node)
+
+    def mark_device_load(self, node: UnifiedTreeNode, transferred: bool) -> None:
+        if not transferred:
+            return
+        root = self.cache.tree_core.root_node
+        covered = 0
+        target = self.window_span
+        cur = node
+        while cur is not root and covered < target:
+            cd = cur.component_data[ComponentType.SWA]
+            if cd.value is not None:
+                self.mark_device(cur)
+                covered += len(cd.value)
+            cur = cur.parent
+
+    def commit_prefetch(
+        self,
+        node: UnifiedTreeNode,
+        transfer,
+        result: PoolTransferResult,
+    ) -> None:
+        if transfer is None or transfer.keys is None:
+            return
+        hit_pages = result.extra_pool_hit_pages.get(PoolName.DRAFT_SWA, 0)
+        if hit_pages < len(transfer.keys):
+            return
+        root = self.cache.tree_core.root_node
+        covered = 0
+        target = self.window_span
+        cur = node
+        while cur is not root and covered < target:
+            cd = cur.component_data[ComponentType.SWA]
+            if cd.host_value is not None:
+                self.mark_host(cur)
+                covered += len(cd.host_value)
+            cur = cur.parent

--- a/python/sglang/srt/mem_cache/unified_cache/components/swa_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/swa_component.py
@@ -306,6 +306,10 @@ class SWAComponent(TreeComponent):
 
         is_tombstone = node.component_data[self.component_type].value is None
         if not is_tombstone:
+            # This overlap is beyond prev_prefix_len, so the model recomputed
+            # the node and populated its canonical draft sidecar.
+            if self.draft_swa_sidecar is not None:
+                self.draft_swa_sidecar.mark_device(node)
             return prefix_len
 
         full_cd = node.component_data[BASE_COMPONENT_TYPE]

--- a/python/sglang/srt/mem_cache/unified_cache/components/swa_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/swa_component.py
@@ -74,6 +74,7 @@ class SWAComponent(TreeComponent):
         self.full_window_pages = (
             self.sliding_window_size + params.page_size - 1
         ) // params.page_size
+        self.draft_swa_sidecar = getattr(cache, "draft_swa_sidecar", None)
         # HiCache state: set to host SWA pool when HiCache enabled
         self._swa_kv_pool_host = None
 
@@ -203,9 +204,21 @@ class SWAComponent(TreeComponent):
     def create_match_validator(
         self, match_device_only: bool = False
     ) -> Callable[[UnifiedTreeNode], bool]:
+        return self.create_match_validator_for_key(
+            match_device_only=match_device_only,
+            match_key_len=None,
+        )
+
+    def create_match_validator_for_key(
+        self,
+        *,
+        match_device_only: bool,
+        match_key_len: Optional[int],
+    ) -> Callable[[UnifiedTreeNode], bool]:
         sliding_window_size = self.sliding_window_size
         ct = self.component_type
         state = {"len": float("inf")}
+        matched_len = 0
 
         # unified_kv never caches the SWA ring (per-request, not content-stable),
         # so SWA bookkeeping must not gate the match here.
@@ -214,6 +227,8 @@ class SWAComponent(TreeComponent):
         )
 
         def validator(node: UnifiedTreeNode) -> bool:
+            nonlocal matched_len
+            matched_len += len(node.key)
             cd = node.component_data[ct]
             # HiCache: a host-only tombstone is a valid match boundary too
             # — load_back will restore SWA from host before use.
@@ -223,7 +238,23 @@ class SWAComponent(TreeComponent):
                     return True
                 return False
             state["len"] += len(node.key)
-            return state["len"] >= sliding_window_size
+            if state["len"] < sliding_window_size:
+                return False
+            if self.draft_swa_sidecar is None:
+                return True
+
+            covered = (
+                self.draft_swa_sidecar.has_device_window(node)
+                if match_device_only
+                else self.draft_swa_sidecar.has_loadable_window(node)
+            )
+            if covered:
+                return True
+            return (
+                match_key_len is not None
+                and match_key_len - matched_len
+                >= self.draft_swa_sidecar.window_span
+            )
 
         return validator
 
@@ -469,6 +500,8 @@ class SWAComponent(TreeComponent):
             child.component_data[self.component_type].metadata.get("uuid")
         )
         child.component_data[self.component_type].metadata.pop("uuid", None)
+        if self.draft_swa_sidecar is not None:
+            self.draft_swa_sidecar.redistribute_on_node_split(new_parent, child)
 
     def evict_component(
         self,
@@ -493,6 +526,8 @@ class SWAComponent(TreeComponent):
             freed = len(cd.value)
             self.tree_core.component_evictable_size_[ct] -= freed
             cd.value = None
+            if self.draft_swa_sidecar is not None:
+                self.draft_swa_sidecar.clear_device(node)
 
         # Host layer
         host_lru = self.tree_core.host_lru_lists[ct]
@@ -500,6 +535,8 @@ class SWAComponent(TreeComponent):
             host_freed = len(cd.host_value)
             host_frees[ct].append(cd.host_value)
             cd.host_value = None
+            if self.draft_swa_sidecar is not None:
+                self.draft_swa_sidecar.clear_host(node)
             if host_lru.in_list(node):
                 host_lru.remove_node(node)
 
@@ -1160,6 +1197,10 @@ class SWAComponent(TreeComponent):
             self.tree_core.set_component_device_value(
                 action.node_id, self.component_type, swa_value
             )
+            if self.draft_swa_sidecar is not None:
+                self.draft_swa_sidecar.mark_device(
+                    self.tree_core.node_by_id(action.node_id)
+                )
             return
         if isinstance(action, SWARebuild):
             # Translate the node's source full value to SWA and store it on the node.
@@ -1167,6 +1208,10 @@ class SWAComponent(TreeComponent):
             self.tree_core.set_component_device_value(
                 action.node_id, self.component_type, swa_value
             )
+            if self.draft_swa_sidecar is not None:
+                self.draft_swa_sidecar.mark_device(
+                    self.tree_core.node_by_id(action.node_id)
+                )
             return
         raise AssertionError(
             f"SWAComponent: unhandled ComponentAction {type(action).__name__}"

--- a/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
+++ b/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
@@ -686,17 +686,31 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         full_kv_hit_length = 0
         action: Optional[CacheAction | ComponentAction] = None
         separate_device_match = self.enable_hicache
+
+        def _validator(component, *, match_device_only: bool):
+            keyed_factory = getattr(
+                component, "create_match_validator_for_key", None
+            )
+            if keyed_factory is not None:
+                return keyed_factory(
+                    match_device_only=match_device_only,
+                    match_key_len=len(key),
+                )
+            return component.create_match_validator(
+                match_device_only=match_device_only
+            )
+
         if separate_device_match:
             validators = tuple(
-                comp.create_match_validator() for comp in self.components
+                _validator(comp, match_device_only=False) for comp in self.components
             )
             device_validators = tuple(
-                comp.create_match_validator(match_device_only=True)
+                _validator(comp, match_device_only=True)
                 for comp in self.components
             )
         else:
             validators = tuple(
-                comp.create_match_validator(match_device_only=True)
+                _validator(comp, match_device_only=True)
                 for comp in self.components
             )
 

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -500,6 +500,31 @@ class UnifiedRadixCache(BasePrefixCache):
             self.cache_controller.register_host_pool_entry(entry)
         self.sidecar_pool_specs.append(spec)
 
+    def register_hicache_draft_pools(
+        self, specs: list[SidecarPoolSpec], entries: list[PoolEntry]
+    ) -> None:
+        if self.cache_controller is None:
+            raise RuntimeError("HiCache controller is not attached.")
+        unified_draft_swa = (
+            not specs and len(entries) == 1 and entries[0].name == PoolName.SWA
+        )
+        if not unified_draft_swa and len(specs) != len(entries):
+            raise ValueError(
+                "HiCache draft sidecar specs and entries must be paired, except "
+                "for the unified draft SWA component."
+            )
+        for entry in entries:
+            self.cache_controller.register_host_pool_entry(entry)
+            if (
+                entry.name == PoolName.SWA
+                and self.supports_swa()
+                and self.components[ComponentType.SWA]._swa_kv_pool_host is None
+            ):
+                self.swa_kv_pool_host = entry.host_pool
+                self.components[ComponentType.SWA]._swa_kv_pool_host = entry.host_pool
+                self.tree_core.has_swa_host_pool = True
+        self.sidecar_pool_specs.extend(specs)
+
     def release_host_resources(self) -> None:
         if self.host_pool_group is not None:
             self.host_pool_group.destroy()

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -61,6 +61,7 @@ from sglang.srt.mem_cache.unified_cache.components import (
     BASE_COMPONENT_TYPE,
     CacheTransferPhase,
     ComponentType,
+    DraftSWASidecarComponent,
     FullComponent,
     MambaComponent,
     PrepareLoadBackResult,
@@ -164,6 +165,15 @@ class UnifiedRadixCache(BasePrefixCache):
 
         assert params.tree_components is not None
         self.tree_components = tuple(params.tree_components)
+        if params.enable_draft_swa_sidecar:
+            assert ComponentType.SWA in self.tree_components, (
+                "Draft SWA sidecar coverage requires the target SWA component."
+            )
+        self.draft_swa_sidecar = (
+            DraftSWASidecarComponent(self)
+            if params.enable_draft_swa_sidecar
+            else None
+        )
         self.enable_session_radix_cache = params.enable_session_radix_cache
         component_registry = COMPONENT_REGISTRY
         if params.component_registry_override:
@@ -1321,13 +1331,20 @@ class UnifiedRadixCache(BasePrefixCache):
             # backed up. Skip only when no transfer remains.
             if device_value.numel() == 0 and not comp_xfers:
                 continue
-            sidecar_xfers = self._build_backup_sidecar(device_value, comp_xfers)
+            sidecar_xfers = self._build_backup_sidecar(
+                node_id, device_value, comp_xfers
+            )
             host_indices = self._execute_kv_backup(
                 node_id, device_value, comp_xfers, sidecar_xfers
             )
             if host_indices is None:
                 return 0
             self.tree_core.commit_backup(node_id, host_indices, comp_xfers)
+            if self.draft_swa_sidecar is not None:
+                self.draft_swa_sidecar.mark_host_backup(
+                    self.tree_core.node_by_id(node_id),
+                    any(x.name == PoolName.DRAFT_SWA for x in sidecar_xfers),
+                )
             lock_params = None
             if not write_back:
                 lock_params = self.inc_lock_ref(node_id).to_dec_params()
@@ -1335,11 +1352,14 @@ class UnifiedRadixCache(BasePrefixCache):
             written = len(host_indices)
         return written
 
-    def _build_backup_sidecar(self, device_value, comp_xfers):
+    def _build_backup_sidecar(self, node_id, device_value, comp_xfers):
         """Gather sidecar transfer spec."""
         kv_xfer = PoolTransfer(name=PoolName.KV, device_indices=device_value)
         return self._build_sidecar_transfers(
-            CacheTransferPhase.BACKUP_HOST, kv_xfer, comp_xfers
+            CacheTransferPhase.BACKUP_HOST,
+            kv_xfer,
+            comp_xfers,
+            node=self.tree_core.node_by_id(node_id),
         )
 
     def _execute_kv_backup(self, node_id, device_value, comp_xfers, sidecar_xfers):
@@ -1460,7 +1480,10 @@ class UnifiedRadixCache(BasePrefixCache):
         kv_xfer, comp_xfers = self.tree_core.build_load_back_spec(node_id, req=req)
         kv_tokens = len(kv_xfer.host_indices)
         sidecar_xfers = self._build_sidecar_transfers(
-            CacheTransferPhase.LOAD_BACK, kv_xfer, comp_xfers
+            CacheTransferPhase.LOAD_BACK,
+            kv_xfer,
+            comp_xfers,
+            node=self.tree_core.node_by_id(node_id),
         )
 
         # Skip if there is nothing to load, or if the Full-KV transfer is too
@@ -1504,6 +1527,11 @@ class UnifiedRadixCache(BasePrefixCache):
                 node_id, device_indices, kv_xfer, comp_xfers
             )
         )
+        if self.draft_swa_sidecar is not None:
+            self.draft_swa_sidecar.mark_device_load(
+                self.tree_core.node_by_id(node_id),
+                any(x.name == PoolName.DRAFT_SWA for x in sidecar_xfers),
+            )
 
         self.ongoing_load_back[node_id] = _OngoingLoadBack(
             node_id,
@@ -1518,9 +1546,32 @@ class UnifiedRadixCache(BasePrefixCache):
         phase: CacheTransferPhase,
         kv_xfer: PoolTransfer,
         comp_xfers: dict[ComponentType, list[PoolTransfer]],
+        *,
+        node=None,
     ) -> list[PoolTransfer]:
         transfers: list[PoolTransfer] = []
         for spec in self.sidecar_pool_specs:
+            if (
+                spec.pool_name == PoolName.DRAFT_SWA
+                and self.draft_swa_sidecar is not None
+            ):
+                if node is None and phase != CacheTransferPhase.PREFETCH:
+                    continue
+                if (
+                    phase == CacheTransferPhase.BACKUP_HOST
+                    and not self.draft_swa_sidecar.has_device_window(node)
+                ):
+                    continue
+                if (
+                    phase == CacheTransferPhase.LOAD_BACK
+                    and not self.draft_swa_sidecar.has_loadable_window(node)
+                ):
+                    continue
+                if (
+                    phase == CacheTransferPhase.BACKUP_STORAGE
+                    and not self.draft_swa_sidecar.has_host_window(node)
+                ):
+                    continue
             if spec.indices_from_pool == PoolName.KV:
                 indices_source = kv_xfer
             else:
@@ -1560,6 +1611,7 @@ class UnifiedRadixCache(BasePrefixCache):
                     keys=indices_source.keys,
                     hit_policy=spec.hit_policy,
                     indices_from_pool=spec.indices_from_pool,
+                    nodes_to_load=indices_source.nodes_to_load,
                 )
             )
         return transfers
@@ -1579,7 +1631,10 @@ class UnifiedRadixCache(BasePrefixCache):
             keys=spec.hash_value,
         )
         sidecar_xfers = self._build_sidecar_transfers(
-            CacheTransferPhase.BACKUP_STORAGE, kv_xfer, spec.comp_xfers
+            CacheTransferPhase.BACKUP_STORAGE,
+            kv_xfer,
+            spec.comp_xfers,
+            node=self.tree_core.node_by_id(node_id),
         )
         aux_xfers = [x for xfers in spec.comp_xfers.values() for x in xfers]
         aux_xfers.extend(sidecar_xfers)
@@ -1873,9 +1928,7 @@ class UnifiedRadixCache(BasePrefixCache):
             comp_xfers,
         ) = self.ongoing_prefetch[req_id]
 
-        # All PP/TP ranks will get the same `min_completed_tokens`, because `completed_tokens`
-        # and `pool_hits` in their operations are same.  No need to sync cross-rank here.
-        if not self._check_hybrid_prefetch_result(
+        usable_tokens = self._check_hybrid_prefetch_result(
             req_id,
             operation,
             completed_tokens,
@@ -1884,25 +1937,26 @@ class UnifiedRadixCache(BasePrefixCache):
             last_host_node_id,
             anchor_lock_params,
             prefetch_key,
-        ):
+        )
+        if usable_tokens is None:
             # Hybrid all-or-nothing check failed; result already discarded.
             return
 
         if self.buffer_pipeline is not None:
-            # No graft: release the rank-local tail beyond the synced usable
-            # length, then park the bounce for admission-time consumption.
+            self.cache_controller.append_host_mem_release(
+                host_indices[usable_tokens:completed_tokens]
+            )
             return self.buffer_pipeline.stage_completed_prefetch(
-                req_id, completed_tokens, hash_value
+                req_id, usable_tokens, hash_value
             )
 
-        fetched_key = prefetch_key[:completed_tokens]
+        fetched_key = prefetch_key[:usable_tokens]
         insert_result = self.tree_core.insert_host(
             last_host_node_id,
             fetched_key,
-            host_indices[:completed_tokens],
-            hash_value[: completed_tokens // self.page_size],
+            host_indices[:usable_tokens],
+            hash_value[: usable_tokens // self.page_size],
         )
-
         # Apply the host-insert walk's actions before the transfer commit.
         self._apply_cache_actions(insert_result.cache_actions)
 
@@ -1923,13 +1977,33 @@ class UnifiedRadixCache(BasePrefixCache):
                 pool_storage_result=operation.pool_storage_result,
             )
             self._apply_cache_actions(commit_actions)
+            if (
+                self.draft_swa_sidecar is not None
+                and insert_result.inserted_host_node is not None
+            ):
+                draft_transfer = next(
+                    (
+                        transfer
+                        for transfer in operation.pool_transfers or ()
+                        if transfer.name == PoolName.DRAFT_SWA
+                    ),
+                    None,
+                )
+                self.draft_swa_sidecar.commit_prefetch(
+                    self.tree_core.node_by_id(insert_result.inserted_host_node),
+                    draft_transfer,
+                    operation.pool_storage_result,
+                )
             # The commit emits via commit_actions only; the walk's were applied above.
             assert not insert_result.cache_actions
 
             self.cache_controller.mem_pool_host.free(
                 host_indices[: insert_result.prefix_len]
             )
-            loaded_from_storage = completed_tokens - insert_result.prefix_len
+            self.cache_controller.append_host_mem_release(
+                host_indices[usable_tokens:completed_tokens]
+            )
+            loaded_from_storage = usable_tokens - insert_result.prefix_len
 
         self.dec_host_lock_ref(last_host_node_id, anchor_lock_params)
         del self.ongoing_prefetch[req_id]
@@ -1959,7 +2033,7 @@ class UnifiedRadixCache(BasePrefixCache):
         last_host_node_id: NodeId,
         anchor_lock_params: DecLockRefParams,
         prefetch_key: RadixKey,
-    ) -> bool:
+    ) -> Optional[int]:
         """Decide the length of usable prefix.
 
         Two strategies depending on the hybrid layout:
@@ -1968,12 +2042,14 @@ class UnifiedRadixCache(BasePrefixCache):
           DSA / MiniMax indexer): *clamp* to the minimum fetched prefix shared by
           the Full KV pool and every sidecar. A partial prefix is still usable
           because the sidecar is page-aligned with KV and required for every page.
+        * Draft SWA with RECOMPUTE_TRAILING: reuse the target prefix before the
+          missing tail; normal prefill regenerates that tail and its sidecar.
         * Everything else (SWA / Mamba components, mixed DeepSeekV4 stacks):
           *all-or-nothing*. Their pools only cover a window / tail and cannot be
           truncated page by page, so any shortfall discards the whole prefetch.
 
-        Returns true if prefetch success, or false when an all-or-nothing prefetch
-        was discarded (the caller should then treat the prefetch as finished).
+        Returns the synced usable token count, or ``None`` when an all-or-nothing
+        prefetch was discarded.
         """
         # Sync completed tokens and per-pool hit pages across ATTN groups, taking
         # the minimum so every rank agrees on the same usable prefix length.
@@ -1989,13 +2065,55 @@ class UnifiedRadixCache(BasePrefixCache):
             operation.pool_storage_result.extra_pool_hit_pages if pool_transfers else {}
         )
         pool_hit_pages = [hit_pages.get(t.name, 0) for t in pool_transfers]
-        completed_tokens = operation.completed_tokens
-        # Hybrid cache state is all-or-nothing: every extra pool (SWA / Mamba / ...)
-        # must cover the same fetched prefix. If any pool falls short the whole
-        # prefetch result is unusable, so discard it and release everything.
-        expected_tokens = len(hash_value) * self.page_size
-        all_succeeded = completed_tokens == expected_tokens and all(
-            transfer.keys is not None and count == len(transfer.keys)
+        packed = torch.tensor([completed_tokens, *pool_hit_pages], dtype=torch.int)
+        self._all_reduce_attn_groups(packed, torch.distributed.ReduceOp.MIN)
+        min_completed_tokens = int(packed[0].item())
+        pool_hit_pages = list(map(int, packed[1:].tolist()))
+        trim_pages = torch.tensor(
+            [operation.pool_storage_result.recompute_tail_pages], dtype=torch.int
+        )
+        self._all_reduce_attn_groups(trim_pages, torch.distributed.ReduceOp.MAX)
+        lookup_trim_pages = int(trim_pages.item())
+        for transfer, count in zip(pool_transfers, pool_hit_pages):
+            hit_pages[transfer.name] = count
+
+        # DSA-style clamp: every sidecar is KV-derived and required for the whole
+        # prefix (ALL_PAGES), so the usable length is simply the shared minimum of
+        # the Full KV completion and each sidecar hit.
+        clampable = bool(pool_transfers) and all(
+            t.hit_policy == PoolHitPolicy.ALL_PAGES
+            and t.indices_from_pool == PoolName.KV
+            for t in pool_transfers
+        )
+        if clampable:
+            usable_pages = min(min_completed_tokens // self.page_size, *pool_hit_pages)
+            return usable_pages * self.page_size
+
+        requested_tokens = len(hash_value) * self.page_size
+        recompute_tail_pages = 0
+        if lookup_trim_pages == 0:
+            # The lookup saw the sidecar, but the subsequent read can still
+            # lose a race with storage eviction. Fall back to tail recompute.
+            recompute_tail_pages = max(
+                (
+                    len(transfer.keys or ())
+                    for transfer, count in zip(pool_transfers, pool_hit_pages)
+                    if transfer.hit_policy == PoolHitPolicy.RECOMPUTE_TRAILING
+                    and count < len(transfer.keys or ())
+                ),
+                default=0,
+            )
+        expected_tokens = max(
+            0, requested_tokens - recompute_tail_pages * self.page_size
+        )
+        min_completed_tokens = min(min_completed_tokens, expected_tokens)
+
+        # Required hybrid state remains all-or-nothing. A recomputable trailing
+        # sidecar may be absent; in that case the returned prefix is shortened
+        # above so normal prefill regenerates it.
+        all_succeeded = min_completed_tokens == expected_tokens and all(
+            transfer.hit_policy == PoolHitPolicy.RECOMPUTE_TRAILING
+            or (transfer.keys is not None and count == len(transfer.keys))
             for transfer, count in zip(pool_transfers, pool_hit_pages)
         )
         if pool_transfers and not all_succeeded:
@@ -2038,8 +2156,8 @@ class UnifiedRadixCache(BasePrefixCache):
                 expected_tokens,
                 keep_pages,
             )
-            return False
-        return True
+            return None
+        return min_completed_tokens
 
     def pop_prefetch_loaded_tokens(self, req_id: str) -> int:
         # The request is being scheduled; a still-unserved miss marker is moot.

--- a/python/sglang/srt/model_executor/model_runner_components/spec_aux_hidden_state.py
+++ b/python/sglang/srt/model_executor/model_runner_components/spec_aux_hidden_state.py
@@ -198,6 +198,13 @@ def _resolve_dflash_aux_hidden_state(
                 )
             if dspark_draft_config.target_layer_ids is not None:
                 target_layer_ids = list(dspark_draft_config.target_layer_ids)
+                draft_num_layers = len(target_layer_ids)
+            else:
+                draft_num_layers = int(draft_model_config.num_nextn_predict_layers or 1)
+                target_layer_ids = dflash_draft_config.resolve_target_layer_ids(
+                    target_num_layers=target_num_layers,
+                    draft_num_layers=draft_num_layers,
+                )
 
         config.dflash_use_aux_hidden_state = True
         config.dflash_draft_num_layers = int(draft_num_layers)

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -772,6 +772,16 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
             qk_nope_head_dim=self.qk_nope_head_dim,
             qk_rope_head_dim=self.qk_rope_head_dim,
         )
+        from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.env_gate import (
+            is_unified_kv_triton,
+        )
+
+        self.draft_swa_kv_bytes_per_token = (
+            (self.qk_nope_head_dim + self.qk_rope_head_dim)
+            * torch.bfloat16.itemsize
+            if is_unified_kv_triton()
+            else self.swa_kv_bytes_per_token
+        )
         self.context_len = kvc.model_config.context_len
         # PP-local slice; matches DeepSeekV4TokenToKVPool's stage_ratios.
         self.compression_ratios = cfg.compress_ratios[
@@ -879,7 +889,11 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
                 )
             # Only committed draft KV enters the persistent sidecar. Verify
             # candidates remain step-scoped until commit_lens gates the write.
-            return self.swa_ratio * self.swa_kv_bytes_per_token * draft_layers
+            return (
+                self.swa_ratio
+                * self.draft_swa_kv_bytes_per_token
+                * draft_layers
+            )
 
         # Preserve the existing single-average-layer reservation for other
         # speculative algorithms until their draft pool geometry is explicit.
@@ -1011,9 +1025,16 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
         num_req_slots = self._get_num_req_slots(max_running_requests)
         scratch_rows = num_req_slots * self.draft_swa_scratch_width
         scratch_pages = ceil_div(scratch_rows, self.draft_swa_storage_page_size)
-        bytes_per_page = ceil_align(
-            self.draft_swa_storage_page_size * self.swa_kv_bytes_per_token, 576
-        )
+        if self.draft_swa_kv_bytes_per_token == self.swa_kv_bytes_per_token:
+            bytes_per_page = ceil_align(
+                self.draft_swa_storage_page_size * self.swa_kv_bytes_per_token,
+                576,
+            )
+        else:
+            bytes_per_page = (
+                self.draft_swa_storage_page_size
+                * self.draft_swa_kv_bytes_per_token
+            )
         return scratch_pages * bytes_per_page * self.draft_swa_num_layers
 
     def _get_draft_swa_scratch_fixed_bytes_for_token_capacity(

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -36,6 +36,7 @@ from sglang.srt.mem_cache.allocation_sizing import get_alloc_len_per_decode
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import (
     get_compress_state_ring_size,
     get_compress_state_write_pad,
+    get_dsv4_packed_kv_bytes_per_token,
 )
 from sglang.srt.mem_cache.memory_pool import DSATokenToKVPool
 from sglang.srt.runtime_context import (
@@ -756,8 +757,8 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
     """Configurator for DSV4 compressed-attention models.
 
     Splits available memory across full / swa / c4 / c128 + c4_state / c128_state
-    pools. coeff is bytes_per_full_token (inflated by (T+D)/T when speculative
-    decode reserves a draft worker, mirroring dflash's cell_size scaling); bias = 0.
+    pools. A DSpark draft owns a content-scoped SWA sidecar, priced from its
+    packed SWA geometry rather than the target's average layer cost.
     """
 
     def __init__(self, kvc: KVCacheConfigurator):
@@ -766,6 +767,10 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
         self.qk_nope_head_dim = cfg.qk_nope_head_dim
         self.qk_rope_head_dim = cfg.qk_rope_head_dim
         self.indexer_head_dim = cfg.index_head_dim
+        self.swa_kv_bytes_per_token = get_dsv4_packed_kv_bytes_per_token(
+            qk_nope_head_dim=self.qk_nope_head_dim,
+            qk_rope_head_dim=self.qk_rope_head_dim,
+        )
         self.context_len = kvc.model_config.context_len
         # PP-local slice; matches DeepSeekV4TokenToKVPool's stage_ratios.
         self.compression_ratios = cfg.compress_ratios[
@@ -819,13 +824,7 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
 
         self.bytes_per_full_token = self._get_bytes_per_full_token()
         if self.is_speculative:
-            # Reserve memory for the speculative draft worker by inflating
-            # per-token bytes by (target+draft)/target. Equivalent to dflash's
-            # scale_kv_cell_size_per_token_for_dflash but applied to
-            # bytes_per_full_token: tokens = avail / (bpft * (T+D)/T).
-            draft_layers = 1
-            target_layers = self.num_layers_total
-            self.bytes_per_full_token *= (target_layers + draft_layers) / target_layers
+            self.bytes_per_full_token += self._get_draft_bytes_per_full_token(kvc)
 
         # Online c128 keeps a single in-progress (max, sum, kv) state per index
         # and assumes a strict forward-only schedule. Speculative decode (MTP)
@@ -857,6 +856,21 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
                     "DSV4 compressed attention: online c128 enabled (ring_size=1)"
                 )
 
+    def _get_draft_bytes_per_full_token(self, kvc: KVCacheConfigurator) -> float:
+        if kvc.spec_algorithm.is_dspark():
+            draft_layers = int(kvc.spec_aux_config.dflash_draft_num_layers or 0)
+            if draft_layers <= 0:
+                raise ValueError(
+                    "DSV4 DSpark draft SWA budgeting requires a positive stage count."
+                )
+            # Only committed draft KV enters the persistent sidecar. Verify
+            # candidates remain step-scoped until commit_lens gates the write.
+            return self.swa_ratio * self.swa_kv_bytes_per_token * draft_layers
+
+        # Preserve the existing single-average-layer reservation for other
+        # speculative algorithms until their draft pool geometry is explicit.
+        return self.bytes_per_full_token / self.num_layers_total
+
     def _assert_ring_serves_draft_tokens(self, num_draft_tokens: int) -> None:
         """A verify batch writes its whole optimistic tail into the ring, so ring
         capacity bounds the draft count."""
@@ -878,7 +892,7 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
             )
 
     def _get_bytes_per_full_token(self) -> float:
-        kv_bytes = self.qk_nope_head_dim + self.qk_rope_head_dim * 2 + 8
+        kv_bytes = self.swa_kv_bytes_per_token
 
         quant_block_size = 128
         indexer_bytes = (

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -37,6 +37,7 @@ from sglang.srt.mem_cache.deepseek_v4_memory_pool import (
     get_compress_state_ring_size,
     get_compress_state_write_pad,
     get_dsv4_packed_kv_bytes_per_token,
+    use_dsv4_dspark_draft_swa_sidecar,
 )
 from sglang.srt.mem_cache.memory_pool import DSATokenToKVPool
 from sglang.srt.runtime_context import (
@@ -50,7 +51,6 @@ from sglang.srt.utils.common import (
     ceil_align,
     ceil_div,
     is_float4_e2m1fn_x2,
-    is_npu,
     spec_decode_alloc_len_per_request,
 )
 
@@ -799,11 +799,9 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
             get_disagg().disaggregation_decode_extra_slots or 0
         )
         self.use_draft_swa_scratch = (
-            kvc.spec_algorithm.is_dspark()
-            and not kvc.is_draft_worker
-            and not is_npu()
-            and getattr(
-                kvc.server_args, "speculative_dspark_draft_swa_sidecar", False
+            not kvc.is_draft_worker
+            and use_dsv4_dspark_draft_swa_sidecar(
+                kvc.server_args, kvc.spec_algorithm
             )
         )
         self.draft_swa_scratch_width = max(
@@ -1012,9 +1010,7 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
             return 0
         num_req_slots = self._get_num_req_slots(max_running_requests)
         scratch_rows = num_req_slots * self.draft_swa_scratch_width
-        scratch_pages = (
-            ceil_div(scratch_rows, self.draft_swa_storage_page_size) + 1
-        )
+        scratch_pages = ceil_div(scratch_rows, self.draft_swa_storage_page_size)
         bytes_per_page = ceil_align(
             self.draft_swa_storage_page_size * self.swa_kv_bytes_per_token, 576
         )

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -50,6 +50,7 @@ from sglang.srt.utils.common import (
     ceil_align,
     ceil_div,
     is_float4_e2m1fn_x2,
+    is_npu,
     spec_decode_alloc_len_per_request,
 )
 
@@ -797,6 +798,21 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
         self.disaggregation_decode_extra_slots = (
             get_disagg().disaggregation_decode_extra_slots or 0
         )
+        self.use_draft_swa_scratch = (
+            kvc.spec_algorithm.is_dspark()
+            and not kvc.is_draft_worker
+            and not is_npu()
+            and getattr(
+                kvc.server_args, "speculative_dspark_draft_swa_sidecar", False
+            )
+        )
+        self.draft_swa_scratch_width = max(
+            (kvc.server_args.max_speculative_num_draft_tokens or 0) - 1, 0
+        )
+        self.draft_swa_num_layers = int(
+            kvc.spec_aux_config.dflash_draft_num_layers or 0
+        )
+        self.draft_swa_storage_page_size = kvc.page_size
         if get_memory().enable_hisparse:
             from sglang.srt.mem_cache.sparsity import parse_hisparse_config
 
@@ -985,6 +1001,37 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
         max_running_requests = min(estimated, token_capacity // 2)
         return self._get_c128_state_fixed_bytes(max_running_requests)
 
+    def _get_draft_swa_scratch_fixed_bytes(
+        self, max_running_requests: int
+    ) -> int:
+        if (
+            not self.use_draft_swa_scratch
+            or self.draft_swa_scratch_width == 0
+            or self.draft_swa_num_layers == 0
+        ):
+            return 0
+        num_req_slots = self._get_num_req_slots(max_running_requests)
+        scratch_rows = num_req_slots * self.draft_swa_scratch_width
+        scratch_pages = (
+            ceil_div(scratch_rows, self.draft_swa_storage_page_size) + 1
+        )
+        bytes_per_page = ceil_align(
+            self.draft_swa_storage_page_size * self.swa_kv_bytes_per_token, 576
+        )
+        return scratch_pages * bytes_per_page * self.draft_swa_num_layers
+
+    def _get_draft_swa_scratch_fixed_bytes_for_token_capacity(
+        self, token_capacity: int
+    ) -> int:
+        if self.requested_max_running_requests_per_worker is not None:
+            return self._get_draft_swa_scratch_fixed_bytes(
+                self.requested_max_running_requests_per_worker
+            )
+        estimated = int(token_capacity / self.context_len * 512)
+        estimated = max(min(estimated, 4096), 2048)
+        max_running_requests = min(estimated, token_capacity // 2)
+        return self._get_draft_swa_scratch_fixed_bytes(max_running_requests)
+
     def _to_config(self, sizes: _DSV4PoolSizes) -> MemoryPoolConfig:
         full = sizes.full_max_total_num_tokens
         swa = sizes.swa_max_total_num_tokens
@@ -1027,13 +1074,26 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
             c128_state_fixed_bytes = self._get_c128_state_fixed_bytes(
                 self.requested_max_running_requests_per_worker
             )
+            draft_swa_scratch_fixed_bytes = (
+                self._get_draft_swa_scratch_fixed_bytes(
+                    self.requested_max_running_requests_per_worker
+                )
+            )
         else:
             full_token = int(available_bytes / self.bytes_per_full_token)
             c128_state_fixed_bytes = (
                 self._get_c128_state_fixed_bytes_for_token_capacity(full_token)
             )
+            draft_swa_scratch_fixed_bytes = (
+                self._get_draft_swa_scratch_fixed_bytes_for_token_capacity(full_token)
+            )
 
-        available_bytes_for_tokens = max(available_bytes - c128_state_fixed_bytes, 0)
+        available_bytes_for_tokens = max(
+            available_bytes
+            - c128_state_fixed_bytes
+            - draft_swa_scratch_fixed_bytes,
+            0,
+        )
         full_token = int(available_bytes_for_tokens / self.bytes_per_full_token)
 
         sizes = self._compute_dsv4_sizes(full_token, page_size)
@@ -1042,6 +1102,8 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
             f"bytes_per_full_token={self.bytes_per_full_token:.2f}, "
             f"available_bytes={available_bytes / (1 << 30):.2f} GB, "
             f"c128_state_fixed={c128_state_fixed_bytes / (1 << 30):.2f} GB, "
+            f"draft_swa_scratch_fixed="
+            f"{draft_swa_scratch_fixed_bytes / (1 << 30):.2f} GB, "
             f"full_token={sizes.full_max_total_num_tokens}"
         )
         return self._to_config(sizes)

--- a/python/sglang/srt/models/deepseek_v4_dspark.py
+++ b/python/sglang/srt/models/deepseek_v4_dspark.py
@@ -154,9 +154,8 @@ class DSparkAttention(MqaAttentionBase):
         pool: DeepSeekV4TokenToKVPool,
     ) -> None:
         if is_unified_kv_triton():
-            # unified_kv: SWA K lives in the shared bf16 ring (swa_kv_pool is
-            # None). Use the unified ring write target -- get_unified_swa_loc
-            # recomputes it from live positions for multi-step draft decode.
+            # unified_kv stores draft proposal K in the step scratch when the
+            # sidecar layout is enabled, otherwise in the legacy request ring.
             pool.set_unified_key_buffer_radix_fused_norm_rope(
                 layer_id=self.layer_id,
                 swa_loc=attn_backend.get_unified_swa_loc(forward_batch),
@@ -799,10 +798,9 @@ class DeepseekV4ForCausalLMDSpark(nn.Module):
             main_x=main_x,
             wkv_linears=[stage.self_attn.wkv for stage in self.stages],
         )
-        # Under unified_kv the swa_kv_pool is None; the caller passes a unified
-        # ring loc (state_slot * ring + pos % ring, -1 for uncommitted) so the
-        # store just needs to target the bf16 ring instead of the fp8 flashmla
-        # buffer. Same swa_loc/positions contract either way.
+        # Under unified_kv the swa_kv_pool is None. The caller passes either a
+        # legacy ring row or a content-sidecar row, with -1 for uncommitted
+        # candidates. The store contract is otherwise identical.
         store_kv = (
             pool.set_unified_key_buffer_radix_fused_norm_rope
             if is_unified_kv_triton()

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2155,7 +2155,8 @@ class ServerArgs:
         Arg(
             help="DSPARK DSV4 only. Keep committed draft SWA in the content-scoped "
             "sidecar cache while routing optimistic proposal KV through step-scoped "
-            "scratch. Defaults to enabled on supported paged backends. Use "
+            "scratch. Defaults to enabled on supported paged and unified_kv "
+            "backends. Use "
             "--no-speculative-dspark-draft-swa-sidecar to restore the legacy path.",
             action=argparse.BooleanOptionalAction,
         ),

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2151,12 +2151,16 @@ class ServerArgs:
         NS("spec"),
     ] = False
     speculative_dspark_draft_swa_sidecar: A[
-        bool,
-        "DSPARK DSV4 only. Keep committed draft SWA in the content-scoped sidecar "
-        "cache while routing optimistic proposal KV through step-scoped scratch. "
-        "The scratch is never inserted into radix cache or transferred by PD/HiCache.",
+        Optional[bool],
+        Arg(
+            help="DSPARK DSV4 only. Keep committed draft SWA in the content-scoped "
+            "sidecar cache while routing optimistic proposal KV through step-scoped "
+            "scratch. Defaults to enabled on supported paged backends. Use "
+            "--no-speculative-dspark-draft-swa-sidecar to restore the legacy path.",
+            action=argparse.BooleanOptionalAction,
+        ),
         NS("spec"),
-    ] = False
+    ] = None
     speculative_accept_threshold_single: A[
         float,
         "Accept a draft token if its probability in the target model is greater than this threshold.",

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2150,6 +2150,13 @@ class ServerArgs:
         "off the schedule is byte-for-byte unchanged.",
         NS("spec"),
     ] = False
+    speculative_dspark_draft_swa_sidecar: A[
+        bool,
+        "DSPARK DSV4 only. Keep committed draft SWA in the content-scoped sidecar "
+        "cache while routing optimistic proposal KV through step-scoped scratch. "
+        "The scratch is never inserted into radix cache or transferred by PD/HiCache.",
+        NS("spec"),
+    ] = False
     speculative_accept_threshold_single: A[
         float,
         "Accept a draft token if its probability in the target model is greater than this threshold.",

--- a/python/sglang/srt/speculative/dspark_components/dspark_kv_inject.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_kv_inject.py
@@ -105,7 +105,9 @@ class TargetHiddenKvInjector:
         state_slot: Optional[torch.Tensor] = None,
         final_pos: Optional[torch.Tensor] = None,
     ) -> None:
-        if is_unified_kv_triton():
+        if is_unified_kv_triton() and not getattr(
+            pool, "unified_swa_is_sidecar", False
+        ):
             swa_loc = self._unified_inject_loc(
                 pool=pool,
                 positions=positions,
@@ -190,7 +192,9 @@ class TargetHiddenKvInjector:
         if hasattr(pool, "set_swa_key_buffer_radix_fused_norm_rope"):
             if hidden_strided.numel() == 0:
                 return
-            if is_unified_kv_triton():
+            if is_unified_kv_triton() and not getattr(
+                pool, "unified_swa_is_sidecar", False
+            ):
                 inject_layout = build_unified_commit_inject_layout(
                     req_pool_indices=batch.req_pool_indices,
                     prefix_lens=prefix_lens,

--- a/python/sglang/srt/speculative/dspark_components/dspark_kv_inject.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_kv_inject.py
@@ -117,6 +117,8 @@ class TargetHiddenKvInjector:
         else:
             swa_loc = pool.translate_loc_from_full_to_swa(cache_loc).to(torch.int32)
             if commit_lens is not None and cache_loc_2d is not None:
+                # Verify candidates are step-scoped. Only the committed prefix
+                # is materialized into the content-scoped draft SWA sidecar.
                 bs, verify_len = cache_loc_2d.shape
                 col = torch.arange(verify_len, device=cache_loc.device).view(1, -1)
                 committed_mask = (col < commit_lens.to(torch.long).view(-1, 1)).reshape(

--- a/python/sglang/srt/speculative/dspark_components/dspark_kv_inject.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_kv_inject.py
@@ -115,7 +115,7 @@ class TargetHiddenKvInjector:
                 final_pos=final_pos,
             )
         else:
-            swa_loc = pool.translate_loc_from_full_to_swa(cache_loc).to(torch.int32)
+            swa_loc = pool.translate_draft_committed_loc(cache_loc).to(torch.int32)
             if commit_lens is not None and cache_loc_2d is not None:
                 # Verify candidates are step-scoped. Only the committed prefix
                 # is materialized into the content-scoped draft SWA sidecar.

--- a/test/registered/spec/dspark/test_dspark_kernel_parity.py
+++ b/test/registered/spec/dspark/test_dspark_kernel_parity.py
@@ -286,8 +286,7 @@ def _case_swa_page_indices(tc):
         block_size=block_size,
         swa_window=128,
     )
-    tc._parity(
-        dspark_attn_metadata.BuildDsparkSwaPageIndices,
+    kwargs = dict(
         req_to_token=_ri(0, n_full, (max_reqs, 400), torch.int32),
         full_to_swa_mapping=_ri(0, 20000, (n_full,), torch.int32),
         req_pool_indices_per_request=gather.req_pool_indices_per_request,
@@ -298,6 +297,13 @@ def _case_swa_page_indices(tc):
         block_size=block_size,
         swa_window=128,
         page_index_aligned_size=64,
+    )
+    kernel = dspark_attn_metadata.BuildDsparkSwaPageIndices
+    tc._parity(kernel, **kwargs)
+    tc._parity(
+        kernel,
+        **kwargs,
+        block_swa_locs=_ri(20000, 30000, (num_q,), torch.int32),
     )
 
 

--- a/test/registered/unit/model_executor/model_runner_components/test_spec_aux_hidden_state.py
+++ b/test/registered/unit/model_executor/model_runner_components/test_spec_aux_hidden_state.py
@@ -43,7 +43,13 @@ def test_explicit_dspark_target_layers_define_draft_stage_count():
         speculative_draft_model_path="/model",
         speculative_draft_model_revision=None,
     )
-    model_config = SimpleNamespace(hf_text_config=SimpleNamespace(num_hidden_layers=43))
+    target_hf_config = SimpleNamespace(
+        num_hidden_layers=43, model_type="deepseek_v4"
+    )
+    model_config = SimpleNamespace(
+        hf_config=target_hf_config,
+        hf_text_config=target_hf_config,
+    )
     draft_model_config = SimpleNamespace(
         hf_config=SimpleNamespace(
             num_hidden_layers=43,

--- a/test/registered/unit/model_executor/model_runner_components/test_spec_aux_hidden_state.py
+++ b/test/registered/unit/model_executor/model_runner_components/test_spec_aux_hidden_state.py
@@ -1,10 +1,13 @@
 import sys
 from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from sglang.srt.model_executor.model_runner_components.spec_aux_hidden_state import (
+    SpecAuxHiddenStateConfig,
     _map_muse_target_layer_ids,
+    _resolve_dflash_aux_hidden_state,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 
@@ -32,6 +35,53 @@ def test_muse_target_layer_id_mapping(target_model_type, draft_architecture, exp
         )
         == expected
     )
+
+
+def test_explicit_dspark_target_layers_define_draft_stage_count():
+    """The sidecar must cover every DSpark stage, not the HF MTP count."""
+    server_args = SimpleNamespace(
+        speculative_draft_model_path="/model",
+        speculative_draft_model_revision=None,
+    )
+    model_config = SimpleNamespace(hf_text_config=SimpleNamespace(num_hidden_layers=43))
+    draft_model_config = SimpleNamespace(
+        hf_config=SimpleNamespace(
+            num_hidden_layers=43,
+            num_nextn_predict_layers=1,
+            dspark_block_size=5,
+            dspark_markov_rank=256,
+            dspark_noise_token_id=128799,
+            dspark_target_layer_ids=[40, 41, 42],
+        ),
+        num_nextn_predict_layers=1,
+    )
+    spec_algorithm = MagicMock()
+    spec_algorithm.is_dflash_family.return_value = True
+    spec_algorithm.is_dspark.return_value = True
+    config = SpecAuxHiddenStateConfig()
+
+    with (
+        patch(
+            "sglang.srt.model_executor.model_runner_components."
+            "spec_aux_hidden_state.ModelConfig.from_server_args",
+            return_value=draft_model_config,
+        ),
+        patch(
+            "sglang.srt.model_executor.model_runner_components."
+            "spec_aux_hidden_state._resolve_dflash_draft_cell_size",
+            return_value=123,
+        ),
+    ):
+        _resolve_dflash_aux_hidden_state(
+            config=config,
+            server_args=server_args,
+            model_config=model_config,
+            spec_algorithm=spec_algorithm,
+            is_draft_worker=False,
+        )
+
+    assert config.dflash_draft_num_layers == 3
+    assert config.dflash_target_layer_ids == [40, 41, 42]
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/model_executor/test_pool_configurator.py
+++ b/test/registered/unit/model_executor/test_pool_configurator.py
@@ -1048,6 +1048,54 @@ class TestDflashDraftKvBudget(CustomTestCase):
         expected_page_bytes = 260 * 576  # ceil(256 * 584 / 576) * 576
         self.assertEqual(scratch_bytes, expected_pages * expected_page_bytes * 3)
 
+    def test_dsv4_dspark_unified_budget_uses_bf16_row_stride(self):
+        from sglang.srt.model_executor.pool_configurator import DSV4PoolConfigurator
+
+        mr = _make_model_runner(
+            self,
+            num_layers=3,
+            is_hybrid_swa=True,
+            swa_full_tokens_ratio=0.8,
+            speculative_algorithm="DSPARK",
+            speculative_num_draft_tokens=6,
+            max_running_requests=8,
+            page_size=256,
+        )
+        mr.model_config.qk_nope_head_dim = 448
+        mr.model_config.qk_rope_head_dim = 64
+        mr.model_config.index_head_dim = 128
+        mr.model_config.window_size = 128
+        mr.model_config.compress_ratios = [0, 4, 128]
+        mr.spec_algorithm.is_dspark.return_value = True
+        mr.server_args.speculative_dspark_draft_swa_sidecar = True
+        mr.spec_aux_config = SimpleNamespace(
+            eagle_draft_num_layers=None,
+            dflash_draft_num_layers=3,
+            dflash_draft_cell_size_per_token=None,
+        )
+
+        with (
+            mock_cpu_env(),
+            patch(
+                "sglang.kernels.ops.attention.dsv4.unified_kv_kernels.env_gate."
+                "is_unified_kv_triton",
+                return_value=True,
+            ),
+        ):
+            configurator = DSV4PoolConfigurator(mr)
+
+        self.assertEqual(configurator.draft_swa_kv_bytes_per_token, 1024)
+        self.assertEqual(
+            configurator.bytes_per_full_token,
+            configurator._get_bytes_per_full_token() + 0.8 * 1024 * 3,
+        )
+        expected_pages = 1
+        expected_page_bytes = 256 * 1024
+        self.assertEqual(
+            configurator._get_draft_swa_scratch_fixed_bytes(8),
+            expected_pages * expected_page_bytes * 3,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/model_executor/test_pool_configurator.py
+++ b/test/registered/unit/model_executor/test_pool_configurator.py
@@ -160,6 +160,7 @@ def _make_model_runner(
     spec.is_standalone.return_value = False
     spec.is_dflash.return_value = False
     spec.is_dflash_family.return_value = False
+    spec.is_dspark.return_value = False
     spec.is_none.return_value = True
     mr.spec_algorithm = spec
 
@@ -1004,6 +1005,42 @@ class TestDflashDraftKvBudget(CustomTestCase):
             return config.full_max_total_num_tokens
 
         self.assertLess(_tokens(10240), _tokens(None))
+
+    def test_dsv4_dspark_budget_prices_committed_swa_sidecar(self):
+        """DSV4 draft stages own SWA-only sidecars, not average target layers."""
+        from sglang.srt.model_executor.pool_configurator import DSV4PoolConfigurator
+
+        mr = _make_model_runner(
+            self,
+            num_layers=3,
+            is_hybrid_swa=True,
+            swa_full_tokens_ratio=0.8,
+            speculative_algorithm="DSPARK",
+            speculative_num_draft_tokens=6,
+            max_running_requests=8,
+        )
+        mr.model_config.qk_nope_head_dim = 448
+        mr.model_config.qk_rope_head_dim = 64
+        mr.model_config.index_head_dim = 128
+        mr.model_config.window_size = 128
+        mr.model_config.compress_ratios = [0, 4, 128]
+        mr.spec_algorithm.is_dspark.return_value = True
+        mr.spec_aux_config = SimpleNamespace(
+            eagle_draft_num_layers=None,
+            dflash_draft_num_layers=3,
+            dflash_draft_cell_size_per_token=None,
+        )
+
+        with mock_cpu_env():
+            configurator = DSV4PoolConfigurator(mr)
+
+        target_only_bytes = configurator._get_bytes_per_full_token()
+        draft_sidecar_bytes = 0.8 * 584 * 3
+        self.assertEqual(configurator.swa_kv_bytes_per_token, 584)
+        self.assertEqual(
+            configurator.bytes_per_full_token,
+            target_only_bytes + draft_sidecar_bytes,
+        )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/model_executor/test_pool_configurator.py
+++ b/test/registered/unit/model_executor/test_pool_configurator.py
@@ -1044,7 +1044,7 @@ class TestDflashDraftKvBudget(CustomTestCase):
             target_only_bytes + draft_sidecar_bytes,
         )
         scratch_bytes = configurator._get_draft_swa_scratch_fixed_bytes(8)
-        expected_pages = 2  # ceil((8 + null slot) * gamma=5 / 256) + guard
+        expected_pages = 1  # ceil((8 + null slot) * gamma=5 / 256)
         expected_page_bytes = 260 * 576  # ceil(256 * 584 / 576) * 576
         self.assertEqual(scratch_bytes, expected_pages * expected_page_bytes * 3)
 

--- a/test/registered/unit/model_executor/test_pool_configurator.py
+++ b/test/registered/unit/model_executor/test_pool_configurator.py
@@ -1018,6 +1018,7 @@ class TestDflashDraftKvBudget(CustomTestCase):
             speculative_algorithm="DSPARK",
             speculative_num_draft_tokens=6,
             max_running_requests=8,
+            page_size=256,
         )
         mr.model_config.qk_nope_head_dim = 448
         mr.model_config.qk_rope_head_dim = 64
@@ -1025,6 +1026,7 @@ class TestDflashDraftKvBudget(CustomTestCase):
         mr.model_config.window_size = 128
         mr.model_config.compress_ratios = [0, 4, 128]
         mr.spec_algorithm.is_dspark.return_value = True
+        mr.server_args.speculative_dspark_draft_swa_sidecar = True
         mr.spec_aux_config = SimpleNamespace(
             eagle_draft_num_layers=None,
             dflash_draft_num_layers=3,
@@ -1041,6 +1043,10 @@ class TestDflashDraftKvBudget(CustomTestCase):
             configurator.bytes_per_full_token,
             target_only_bytes + draft_sidecar_bytes,
         )
+        scratch_bytes = configurator._get_draft_swa_scratch_fixed_bytes(8)
+        expected_pages = 2  # ceil((8 + null slot) * gamma=5 / 256) + guard
+        expected_page_bytes = 260 * 576  # ceil(256 * 584 / 576) * 576
+        self.assertEqual(scratch_bytes, expected_pages * expected_page_bytes * 3)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/speculative/test_dsv4_draft_swa_sidecar.py
+++ b/test/registered/unit/speculative/test_dsv4_draft_swa_sidecar.py
@@ -1,0 +1,79 @@
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.kernels.ops.speculative.dspark.dspark_attn_metadata import (
+    build_dspark_swa_page_indices,
+)
+from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestDSV4DraftSWASidecar(unittest.TestCase):
+    def test_scratch_rows_are_outside_committed_sidecar(self):
+        pool = object.__new__(DeepSeekV4TokenToKVPool)
+        pool.draft_swa_scratch_width = 5
+        pool.draft_swa_committed_size = 1024
+        pool.draft_swa_scratch_base = 1280
+
+        locs = pool.get_draft_swa_scratch_locs(
+            torch.tensor([0, 3], dtype=torch.int64), block_size=5
+        )
+
+        self.assertEqual(
+            locs.tolist(),
+            [1280, 1281, 1282, 1283, 1284, 1295, 1296, 1297, 1298, 1299],
+        )
+        self.assertTrue(torch.all(locs > pool.draft_swa_committed_size))
+        with self.assertRaisesRegex(ValueError, "exceeds scratch width"):
+            pool.get_draft_swa_scratch_locs(
+                torch.tensor([0], dtype=torch.int64), block_size=6
+            )
+
+    def test_pd_buffer_range_excludes_scratch_pages(self):
+        pool = object.__new__(DeepSeekV4TokenToKVPool)
+        pool._unified_kv = False
+        pool.draft_swa_scratch_width = 5
+        pool.draft_swa_committed_size = 1024
+        pool.swa_page_size = 256
+        pool.swa_kv_pool = SimpleNamespace(
+            kv_buffer=[torch.empty((10, 8), dtype=torch.uint8)]
+        )
+        pool.compress_state_pools = []
+        pool.indexer_compress_state_pools = []
+
+        _, data_lens, item_lens = pool.get_state_buf_infos()
+
+        self.assertEqual(item_lens, [8])
+        self.assertEqual(data_lens, [5 * 8])
+        self.assertLess(data_lens[0], pool.swa_kv_pool.kv_buffer[0].nbytes)
+
+    def test_page_indices_read_direct_scratch_rows(self):
+        req_to_token = torch.tensor([[10, 11, 12, 13]], dtype=torch.int64)
+        full_to_swa = torch.arange(64, dtype=torch.int64) + 20
+
+        indices, lengths = build_dspark_swa_page_indices(
+            req_to_token=req_to_token,
+            full_to_swa_mapping=full_to_swa,
+            req_pool_indices_per_request=torch.tensor([0]),
+            offsets=torch.tensor([[0, 1, 2, 3]], dtype=torch.int64),
+            invalid=torch.zeros((1, 4), dtype=torch.bool),
+            out_loc=torch.tensor([50, 51], dtype=torch.int64),
+            context_lens=torch.tensor([3], dtype=torch.int32),
+            block_size=2,
+            swa_window=4,
+            page_index_aligned_size=8,
+            block_swa_locs=torch.tensor([100, 101], dtype=torch.int64),
+        )
+
+        self.assertEqual(indices.shape, (2, 8))
+        self.assertEqual(indices[0, :5].tolist(), [31, 32, 33, 100, 101])
+        self.assertTrue(torch.equal(indices[0], indices[1]))
+        self.assertEqual(lengths.tolist(), [5, 5])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/speculative/test_dsv4_draft_swa_sidecar.py
+++ b/test/registered/unit/speculative/test_dsv4_draft_swa_sidecar.py
@@ -1,23 +1,73 @@
 import unittest
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import torch
 
 from sglang.kernels.ops.speculative.dspark.dspark_attn_metadata import (
     build_dspark_swa_page_indices,
 )
-from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
+from sglang.srt.mem_cache.deepseek_v4_memory_pool import (
+    DeepSeekV4TokenToKVPool,
+    DraftSWASidecarLayout,
+    use_dsv4_dspark_draft_swa_sidecar,
+)
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=1, suite="base-a-test-cpu")
 
 
 class TestDSV4DraftSWASidecar(unittest.TestCase):
+    def test_rollout_defaults_on_and_keeps_explicit_fallback(self):
+        spec = SimpleNamespace(is_dspark=lambda: True)
+        with (
+            patch(
+                "sglang.srt.mem_cache.deepseek_v4_memory_pool.is_npu",
+                return_value=False,
+            ),
+            patch(
+                "sglang.kernels.ops.attention.dsv4.unified_kv_kernels.env_gate."
+                "is_unified_kv_triton",
+                return_value=False,
+            ),
+        ):
+            self.assertTrue(
+                use_dsv4_dspark_draft_swa_sidecar(
+                    SimpleNamespace(speculative_dspark_draft_swa_sidecar=None), spec
+                )
+            )
+            self.assertFalse(
+                use_dsv4_dspark_draft_swa_sidecar(
+                    SimpleNamespace(speculative_dspark_draft_swa_sidecar=False), spec
+                )
+            )
+
+    def test_explicit_enable_rejects_request_scoped_unified_kv(self):
+        spec = SimpleNamespace(is_dspark=lambda: True)
+        with (
+            patch(
+                "sglang.srt.mem_cache.deepseek_v4_memory_pool.is_npu",
+                return_value=False,
+            ),
+            patch(
+                "sglang.kernels.ops.attention.dsv4.unified_kv_kernels.env_gate."
+                "is_unified_kv_triton",
+                return_value=True,
+            ),
+            self.assertRaisesRegex(NotImplementedError, "request-scoped SWA ring"),
+        ):
+            use_dsv4_dspark_draft_swa_sidecar(
+                SimpleNamespace(speculative_dspark_draft_swa_sidecar=True), spec
+            )
+
     def test_scratch_rows_are_outside_committed_sidecar(self):
         pool = object.__new__(DeepSeekV4TokenToKVPool)
-        pool.draft_swa_scratch_width = 5
-        pool.draft_swa_committed_size = 1024
-        pool.draft_swa_scratch_base = 1280
+        pool.draft_swa_layout = DraftSWASidecarLayout.build(
+            committed_size=1024,
+            scratch_width=5,
+            num_req_slots=4,
+            page_size=256,
+        )
 
         locs = pool.get_draft_swa_scratch_locs(
             torch.tensor([0, 3], dtype=torch.int64), block_size=5
@@ -27,7 +77,9 @@ class TestDSV4DraftSWASidecar(unittest.TestCase):
             locs.tolist(),
             [1280, 1281, 1282, 1283, 1284, 1295, 1296, 1297, 1298, 1299],
         )
-        self.assertTrue(torch.all(locs > pool.draft_swa_committed_size))
+        self.assertEqual(pool.draft_swa_layout.committed_pages, 5)
+        self.assertEqual(pool.draft_swa_layout.physical_size, 1299)
+        self.assertTrue(torch.all(locs > pool.draft_swa_layout.committed_size))
         with self.assertRaisesRegex(ValueError, "exceeds scratch width"):
             pool.get_draft_swa_scratch_locs(
                 torch.tensor([0], dtype=torch.int64), block_size=6
@@ -36,8 +88,12 @@ class TestDSV4DraftSWASidecar(unittest.TestCase):
     def test_pd_buffer_range_excludes_scratch_pages(self):
         pool = object.__new__(DeepSeekV4TokenToKVPool)
         pool._unified_kv = False
-        pool.draft_swa_scratch_width = 5
-        pool.draft_swa_committed_size = 1024
+        pool.draft_swa_layout = DraftSWASidecarLayout.build(
+            committed_size=1024,
+            scratch_width=5,
+            num_req_slots=4,
+            page_size=256,
+        )
         pool.swa_page_size = 256
         pool.swa_kv_pool = SimpleNamespace(
             kv_buffer=[torch.empty((10, 8), dtype=torch.uint8)]
@@ -50,6 +106,24 @@ class TestDSV4DraftSWASidecar(unittest.TestCase):
         self.assertEqual(item_lens, [8])
         self.assertEqual(data_lens, [5 * 8])
         self.assertLess(data_lens[0], pool.swa_kv_pool.kv_buffer[0].nbytes)
+
+    def test_hicache_view_excludes_scratch_pages(self):
+        pool = object.__new__(DeepSeekV4TokenToKVPool)
+        pool._unified_kv = False
+        pool.draft_swa_layout = DraftSWASidecarLayout.build(
+            committed_size=1024,
+            scratch_width=5,
+            num_req_slots=4,
+            page_size=256,
+        )
+        backing = torch.empty((10, 8), dtype=torch.uint8)
+        pool.swa_kv_pool = SimpleNamespace(kv_buffer=[backing])
+
+        committed = pool.get_draft_swa_committed_buffers()
+
+        self.assertEqual(committed[0].shape, (5, 8))
+        self.assertEqual(committed[0].data_ptr(), backing.data_ptr())
+        self.assertLess(committed[0].nbytes, backing.nbytes)
 
     def test_page_indices_read_direct_scratch_rows(self):
         req_to_token = torch.tensor([[10, 11, 12, 13]], dtype=torch.int64)

--- a/test/registered/unit/speculative/test_dsv4_draft_swa_sidecar.py
+++ b/test/registered/unit/speculative/test_dsv4_draft_swa_sidecar.py
@@ -154,6 +154,40 @@ class TestDSV4DraftSWASidecar(unittest.TestCase):
         )
         self.assertTrue(covered_exact_match(node))
 
+    def test_recomputed_overlap_commits_sidecar_coverage(self):
+        root = SimpleNamespace(parent=None, component_data=[None, None, None])
+        swa_data = SimpleNamespace(
+            metadata={},
+            value=torch.arange(256),
+            host_value=None,
+        )
+        node = SimpleNamespace(
+            id=1,
+            parent=root,
+            component_data=[None, swa_data, None],
+        )
+        cache = SimpleNamespace(
+            page_size=256,
+            sliding_window_size=128,
+            tree_core=SimpleNamespace(root_node=root),
+        )
+        sidecar = DraftSWASidecarComponent(cache)
+        swa = object.__new__(SWAComponent)
+        swa.draft_swa_sidecar = sidecar
+        swa.component_type = ComponentType.SWA
+
+        consumed = swa.update_component_on_insert_overlap(
+            node=node,
+            prefix_len=256,
+            total_prefix_len=256,
+            value_slice=torch.arange(256),
+            params=SimpleNamespace(prev_prefix_len=256),
+            cache_actions=[],
+        )
+
+        self.assertEqual(consumed, 256)
+        self.assertTrue(sidecar.has_device_window(node))
+
     def test_rollout_defaults_on_and_keeps_explicit_fallback(self):
         spec = SimpleNamespace(is_dspark=lambda: True)
         with (
@@ -336,6 +370,7 @@ class TestDSV4DraftSWASidecar(unittest.TestCase):
             head_dim=4,
             kv_buffer=[backing],
         )
+        pool._stage_start = 40
         pool.compress_state_pools = []
         pool.indexer_compress_state_pools = []
 
@@ -348,6 +383,7 @@ class TestDSV4DraftSWASidecar(unittest.TestCase):
         self.assertLess(committed[0].nbytes, backing.nbytes)
         self.assertEqual(data_lens, [committed[0].nbytes])
         self.assertEqual(item_lens, [committed[0][0].nbytes])
+        self.assertEqual(pool.get_draft_swa_state_layer_ids(), [40])
 
     def test_unified_hicache_uses_logical_swa_component(self):
         device_buffers = [torch.empty((5, 2048), dtype=torch.uint8)]

--- a/test/registered/unit/speculative/test_dsv4_draft_swa_sidecar.py
+++ b/test/registered/unit/speculative/test_dsv4_draft_swa_sidecar.py
@@ -1,9 +1,12 @@
 import unittest
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import torch
 
+from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.runtime import (
+    build_dspark_sidecar_decode_stream,
+)
 from sglang.kernels.ops.speculative.dspark.dspark_attn_metadata import (
     build_dspark_swa_page_indices,
 )
@@ -18,10 +21,15 @@ from sglang.srt.mem_cache.hicache_storage import (
     PoolTransfer,
     resolve_pool_hit_boundary,
 )
+from sglang.srt.mem_cache.hybrid_cache.hybrid_pool_assembler import (
+    build_swa_draft_pools,
+)
+from sglang.srt.mem_cache.unified_cache.component_type import ComponentType
 from sglang.srt.mem_cache.unified_cache.components.draft_swa_sidecar_component import (
     DraftSWASidecarComponent,
 )
 from sglang.srt.mem_cache.unified_cache.components.swa_component import SWAComponent
+from sglang.srt.mem_cache.unified_radix_cache import UnifiedRadixCache
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=1, suite="base-a-test-cpu")
@@ -170,22 +178,16 @@ class TestDSV4DraftSWASidecar(unittest.TestCase):
                 )
             )
 
-    def test_explicit_enable_rejects_request_scoped_unified_kv(self):
+    def test_unified_kv_uses_draft_only_sidecar_extension(self):
         spec = SimpleNamespace(is_dspark=lambda: True)
-        with (
-            patch(
-                "sglang.srt.mem_cache.deepseek_v4_memory_pool.is_npu",
-                return_value=False,
-            ),
-            patch(
-                "sglang.kernels.ops.attention.dsv4.unified_kv_kernels.env_gate."
-                "is_unified_kv_triton",
-                return_value=True,
-            ),
-            self.assertRaisesRegex(NotImplementedError, "request-scoped SWA ring"),
+        with patch(
+            "sglang.srt.mem_cache.deepseek_v4_memory_pool.is_npu",
+            return_value=False,
         ):
-            use_dsv4_dspark_draft_swa_sidecar(
-                SimpleNamespace(speculative_dspark_draft_swa_sidecar=True), spec
+            self.assertTrue(
+                use_dsv4_dspark_draft_swa_sidecar(
+                    SimpleNamespace(speculative_dspark_draft_swa_sidecar=True), spec
+                )
             )
 
     def test_scratch_rows_are_outside_committed_sidecar(self):
@@ -212,6 +214,72 @@ class TestDSV4DraftSWASidecar(unittest.TestCase):
             pool.get_draft_swa_scratch_locs(
                 torch.tensor([0], dtype=torch.int64), block_size=6
             )
+
+    def test_scratch_starts_after_unaligned_committed_guard_page(self):
+        layout = DraftSWASidecarLayout.build(
+            committed_size=1023,
+            scratch_width=5,
+            num_req_slots=1,
+            page_size=256,
+        )
+
+        self.assertEqual(layout.committed_pages, 5)
+        self.assertEqual(layout.scratch_base, 5 * 256)
+        self.assertGreaterEqual(
+            layout.scratch_base, layout.committed_pages * layout.page_size
+        )
+
+    def test_per_token_scratch_locations_support_ragged_verify(self):
+        pool = object.__new__(DeepSeekV4TokenToKVPool)
+        pool.draft_swa_layout = DraftSWASidecarLayout.build(
+            committed_size=1024,
+            scratch_width=5,
+            num_req_slots=4,
+            page_size=256,
+        )
+
+        locs = pool.get_draft_swa_scratch_locs_for_tokens(
+            torch.tensor([1, 1, 3], dtype=torch.int64),
+            torch.tensor([0, 2, 4], dtype=torch.int64),
+        )
+
+        self.assertEqual(locs.tolist(), [1285, 1287, 1299])
+
+    def test_unified_stream_combines_committed_prefix_and_step_scratch(self):
+        req_to_token = torch.tensor(
+            [[10, 11, 12, 13, 14, 15]], dtype=torch.int64
+        )
+        full_to_swa = torch.arange(64, dtype=torch.int64) + 100
+
+        indices, indptr = build_dspark_sidecar_decode_stream(
+            req_to_token=req_to_token,
+            full_to_swa_mapping=full_to_swa,
+            state_slot=torch.tensor([0, 0], dtype=torch.int64),
+            chunk_start=torch.tensor([3, 3], dtype=torch.int64),
+            final_pos=torch.tensor([5, 5], dtype=torch.int64),
+            win=5,
+            scratch_base=1000,
+            scratch_width=5,
+        )
+
+        self.assertEqual(indptr.tolist(), [0, 6, 12])
+        self.assertEqual(
+            indices[:12].tolist(),
+            [
+                110,
+                111,
+                112,
+                1000,
+                1001,
+                1002,
+                110,
+                111,
+                112,
+                1000,
+                1001,
+                1002,
+            ],
+        )
 
     def test_pd_buffer_range_excludes_scratch_pages(self):
         pool = object.__new__(DeepSeekV4TokenToKVPool)
@@ -252,6 +320,102 @@ class TestDSV4DraftSWASidecar(unittest.TestCase):
         self.assertEqual(committed[0].shape, (5, 8))
         self.assertEqual(committed[0].data_ptr(), backing.data_ptr())
         self.assertLess(committed[0].nbytes, backing.nbytes)
+
+    def test_unified_hicache_view_excludes_scratch_rows(self):
+        pool = object.__new__(DeepSeekV4TokenToKVPool)
+        pool._unified_kv = True
+        pool.unified_swa_is_sidecar = True
+        pool.draft_swa_layout = DraftSWASidecarLayout.build(
+            committed_size=1024,
+            scratch_width=5,
+            num_req_slots=4,
+            page_size=256,
+        )
+        backing = torch.empty((1300, 4), dtype=torch.bfloat16)
+        pool.unified_kv_pool = SimpleNamespace(
+            head_dim=4,
+            kv_buffer=[backing],
+        )
+        pool.compress_state_pools = []
+        pool.indexer_compress_state_pools = []
+
+        committed = pool.get_draft_swa_committed_buffers()
+        _, data_lens, item_lens = pool.get_state_buf_infos()
+
+        self.assertEqual(committed[0].shape, (5, 2048))
+        self.assertEqual(committed[0].data_ptr(), backing.data_ptr())
+        self.assertEqual(committed[0].nbytes, 5 * 256 * 4 * 2)
+        self.assertLess(committed[0].nbytes, backing.nbytes)
+        self.assertEqual(data_lens, [committed[0].nbytes])
+        self.assertEqual(item_lens, [committed[0][0].nbytes])
+
+    def test_unified_hicache_uses_logical_swa_component(self):
+        device_buffers = [torch.empty((5, 2048), dtype=torch.uint8)]
+        draft_pool = SimpleNamespace(
+            swa_kv_pool=None,
+            unified_swa_is_sidecar=True,
+            draft_swa_layout=SimpleNamespace(committed_pages=5),
+            get_draft_swa_committed_buffers=lambda: device_buffers,
+            swa_page_size=256,
+        )
+        swa_allocator = SimpleNamespace(alloc=MagicMock(), free=MagicMock())
+        tree_cache = SimpleNamespace(
+            cache_controller=SimpleNamespace(
+                mem_pool_host=SimpleNamespace(
+                    anchor_entry=SimpleNamespace(
+                        host_pool=SimpleNamespace(logical_size=2048, layout="layer_first")
+                    )
+                )
+            ),
+            token_to_kv_pool_allocator=SimpleNamespace(
+                full_attn_allocator=SimpleNamespace(size=1024),
+                swa_attn_allocator=swa_allocator,
+            ),
+        )
+        fake_host_pool = SimpleNamespace(layer_num=1)
+
+        with patch(
+            "sglang.srt.mem_cache.hybrid_cache.hybrid_pool_assembler."
+            "DeepSeekV4PagedHostPool",
+            return_value=fake_host_pool,
+        ) as host_pool_cls:
+            specs, entries = build_swa_draft_pools(
+                draft_kv_pool=draft_pool,
+                tree_cache=tree_cache,
+                server_args=SimpleNamespace(hicache_storage_backend="default"),
+            )
+
+        self.assertEqual(specs, [])
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0].name, PoolName.SWA)
+        self.assertIs(entries[0].device_pool, draft_pool)
+        host_pool_cls.assert_called_once_with(
+            pool_name=str(PoolName.SWA),
+            device_buffers=device_buffers,
+            item_bytes=device_buffers[0][0].nbytes,
+            num_host_pages=10,
+            slot_page_size=256,
+            layout="layer_first",
+            allocator_type="default",
+        )
+
+    def test_dynamic_unified_swa_host_pool_attaches_to_component(self):
+        cache = object.__new__(UnifiedRadixCache)
+        cache.cache_controller = MagicMock()
+        cache.sidecar_pool_specs = []
+        cache.supports_swa = lambda: True
+        swa_component = SimpleNamespace(_swa_kv_pool_host=None)
+        cache.components = {ComponentType.SWA: swa_component}
+        cache.tree_core = SimpleNamespace(has_swa_host_pool=False)
+        host_pool = object()
+        entry = SimpleNamespace(name=PoolName.SWA, host_pool=host_pool)
+
+        cache.register_hicache_draft_pools([], [entry])
+
+        cache.cache_controller.register_host_pool_entry.assert_called_once_with(entry)
+        self.assertIs(cache.swa_kv_pool_host, host_pool)
+        self.assertIs(swa_component._swa_kv_pool_host, host_pool)
+        self.assertTrue(cache.tree_core.has_swa_host_pool)
 
     def test_page_indices_read_direct_scratch_rows(self):
         req_to_token = torch.tensor([[10, 11, 12, 13]], dtype=torch.int64)

--- a/test/registered/unit/speculative/test_dsv4_draft_swa_sidecar.py
+++ b/test/registered/unit/speculative/test_dsv4_draft_swa_sidecar.py
@@ -12,12 +12,140 @@ from sglang.srt.mem_cache.deepseek_v4_memory_pool import (
     DraftSWASidecarLayout,
     use_dsv4_dspark_draft_swa_sidecar,
 )
+from sglang.srt.mem_cache.hicache_storage import (
+    PoolHitPolicy,
+    PoolName,
+    PoolTransfer,
+    resolve_pool_hit_boundary,
+)
+from sglang.srt.mem_cache.unified_cache.components.draft_swa_sidecar_component import (
+    DraftSWASidecarComponent,
+)
+from sglang.srt.mem_cache.unified_cache.components.swa_component import SWAComponent
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=1, suite="base-a-test-cpu")
 
 
 class TestDSV4DraftSWASidecar(unittest.TestCase):
+    def test_all_pages_keeps_partial_prefix_semantics(self):
+        transfer = PoolTransfer(
+            name=PoolName.DRAFT_SWA,
+            hit_policy=PoolHitPolicy.ALL_PAGES,
+        )
+
+        boundary, sidecar_hit = resolve_pool_hit_boundary(
+            kv_pages=10,
+            transfer=transfer,
+            has_component=lambda i: i < 6,
+        )
+
+        self.assertEqual(boundary, 6)
+        self.assertTrue(sidecar_hit)
+
+    def test_storage_miss_recomputes_one_trailing_page(self):
+        transfer = PoolTransfer(
+            name=PoolName.DRAFT_SWA,
+            keys=["tail"],
+            hit_policy=PoolHitPolicy.RECOMPUTE_TRAILING,
+        )
+
+        boundary, sidecar_hit = resolve_pool_hit_boundary(
+            kv_pages=10,
+            transfer=transfer,
+            has_component=lambda _: False,
+        )
+
+        self.assertEqual(boundary, 9)
+        self.assertFalse(sidecar_hit)
+
+    def test_storage_hit_reuses_full_prefix(self):
+        transfer = PoolTransfer(
+            name=PoolName.DRAFT_SWA,
+            keys=["tail"],
+            hit_policy=PoolHitPolicy.RECOMPUTE_TRAILING,
+        )
+
+        boundary, sidecar_hit = resolve_pool_hit_boundary(
+            kv_pages=10,
+            transfer=transfer,
+            has_component=lambda i: i == 9,
+        )
+
+        self.assertEqual(boundary, 10)
+        self.assertTrue(sidecar_hit)
+
+    def test_dependent_component_tracks_coverage_without_owning_slots(self):
+        root = SimpleNamespace(parent=None, component_data=[None, None, None])
+        swa_data = SimpleNamespace(
+            metadata={},
+            value=torch.arange(256),
+            host_value=torch.arange(256),
+        )
+        node = SimpleNamespace(
+            parent=root,
+            component_data=[None, swa_data, None],
+        )
+        cache = SimpleNamespace(
+            page_size=256,
+            sliding_window_size=128,
+            tree_core=SimpleNamespace(root_node=root),
+        )
+        component = DraftSWASidecarComponent(cache)
+
+        component.mark_device(node)
+        component.mark_host(node)
+
+        self.assertTrue(component.has_device_window(node))
+        self.assertTrue(component.has_host_window(node))
+        component.clear_device(node)
+        self.assertFalse(component.has_device_window(node))
+        self.assertIsNotNone(swa_data.value)
+
+    def test_missing_sidecar_match_requires_recomputable_tail(self):
+        root = SimpleNamespace(parent=None, component_data=[None, None, None])
+        swa_data = SimpleNamespace(
+            metadata={},
+            value=torch.arange(256),
+            host_value=None,
+        )
+        node = SimpleNamespace(
+            parent=root,
+            key=list(range(256)),
+            component_data=[None, swa_data, None],
+        )
+        cache = SimpleNamespace(
+            page_size=256,
+            sliding_window_size=128,
+            tree_core=SimpleNamespace(root_node=root),
+        )
+        sidecar = DraftSWASidecarComponent(cache)
+        swa = object.__new__(SWAComponent)
+        swa.sliding_window_size = 128
+        swa.tree_core = SimpleNamespace(
+            has_swa_host_pool=False,
+            enable_hicache=False,
+        )
+        swa.draft_swa_sidecar = sidecar
+
+        exact_match = swa.create_match_validator_for_key(
+            match_device_only=True,
+            match_key_len=256,
+        )
+        match_with_tail = swa.create_match_validator_for_key(
+            match_device_only=True,
+            match_key_len=512,
+        )
+
+        self.assertFalse(exact_match(node))
+        self.assertTrue(match_with_tail(node))
+        sidecar.mark_device(node)
+        covered_exact_match = swa.create_match_validator_for_key(
+            match_device_only=True,
+            match_key_len=256,
+        )
+        self.assertTrue(covered_exact_match(node))
+
     def test_rollout_defaults_on_and_keeps_explicit_fallback(self):
         spec = SimpleNamespace(is_dspark=lambda: True)
         with (


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Summary

Fixes https://github.com/sgl-project/sglang/issues/35789

This PR re-layers DSV4 DSpark draft SWA into two explicitly managed regions:

- **Committed sidecar KV**: content-scoped, radix-cache-visible, reusable, and transferable.
- **Verify scratch**: step-scoped workspace that never enters the content cache.

The change preserves model numerics and keeps the target `unified_kv` ring, C4/C128 layout, and target attention kernels unchanged.

## Motivation

Committed draft SWA is deterministically derived from the committed prefix and model weights, so it should be reusable across prefix-cache hits.

Speculative verify KV may contain rejected tokens and therefore must not become a cache artifact.

The existing pool accounting also treats draft layers as target average layers, although DSpark draft stages are SWA-only and contain no C4, C128, indexer, or compression state.

## Design

Draft SWA is split into:

- `committed sidecar KV`
  - Content-scoped.
  - Coupled to target SWA allocation and prefix lifecycle.
  - Reused by radix cache.
  - Participates in PD and HiCache.
- `verify scratch`
  - Request-slot-addressed but step-scoped.
  - Reused after each verify step.
  - Excluded from radix cache, PD, and HiCache.
  - Rejected tokens leave no cache artifact.

Accepted canonical KV is produced from target hidden states and written directly to committed sidecar locations. Proposal scratch is not promoted because it is not guaranteed to be numerically equivalent to canonical target-hidden-derived KV.

## Main Changes

- Replace target-average-layer draft accounting with SWA-only accounting.
- Derive draft stage count from actual DSpark target capture layers.
- Add explicit committed/scratch physical boundaries.
- Add radix sidecar coverage tracking and lifecycle handling.
- Recompute only the trailing SWA window on a sidecar miss.
- Commit sidecar coverage after fallback recomputation.
- Exclude scratch pages from PD and HiCache transfer.
- Support HF3FS, Mooncake, NIXL, and UMBP sidecar hit semantics.
- Add draft-only `unified_kv` support:
  - Target unified layout remains unchanged.
  - Draft unified storage uses committed rows plus scratch rows.
  - Attention reads committed prefix rows and the complete verify scratch block.
  - PD transfers draft sidecar as content-addressed `SWA`, while target remains `SWA_RING`.
  - HiCache attaches draft sidecar storage to the logical SWA component.
- Add explicit draft stage IDs for PP-aware NIXL/Mooncake state transfer.
- Fix scratch placement for non-page-aligned committed capacities.

## Compatibility

- Model numerics are unchanged.
- Existing target SWA, C4, C128, and target unified kernels are unchanged.
- The feature is controlled by `--speculative-dspark-draft-swa-sidecar`.
- `--no-speculative-dspark-draft-swa-sidecar` restores the legacy path.
- NPU remains explicitly unsupported because it uses a separate DSV4 cache implementation.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33241841272](https://github.com/sgl-project/sglang/actions/runs/33241841272)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33241841124](https://github.com/sgl-project/sglang/actions/runs/33241841124)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33241841240](https://github.com/sgl-project/sglang/actions/runs/33241841240)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->