### PR TITLE
feat: support custom OTLP trace service name

### DIFF
--- a/python/sglang/multimodal_gen/runtime/server_args/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args/server_args.py
@@ -585,6 +585,7 @@ class ServerArgs(DisaggServerArgsMixin):
     # Tracing
     enable_trace: bool = False
     otlp_traces_endpoint: str = "localhost:4317"
+    otlp_service_name: str | None = None
 
     # SGLang backend for encoder stage
     srt_encoder_url: str | None = None
@@ -2886,6 +2887,13 @@ class ServerArgs(DisaggServerArgsMixin):
             type=str,
             default=ServerArgs.otlp_traces_endpoint,
             help="OTLP collector endpoint when --enable-trace is set. Format: <host>:<port>",
+        )
+        parser.add_argument(
+            "--otlp-service-name",
+            type=str,
+            default=ServerArgs.otlp_service_name,
+            help="Service name for OTLP traces (displayed as 'service.name' in trace backends). "
+            "If unset, falls back to the OTEL_SERVICE_NAME env var, then to 'sglang-diffusion'.",
         )
         parser.add_argument(
             "--log-requests",

--- a/python/sglang/multimodal_gen/runtime/utils/trace_wrapper.py
+++ b/python/sglang/multimodal_gen/runtime/utils/trace_wrapper.py
@@ -7,6 +7,7 @@ start/end bookkeeping.
 
 from __future__ import annotations
 
+import os
 from contextlib import contextmanager
 from dataclasses import dataclass
 
@@ -37,10 +38,17 @@ def init_diffusion_tracing(server_args, thread_label: str):
         trace_set_thread_info,
     )
 
+    # Priority: --otlp-service-name > OTEL_SERVICE_NAME > "sglang-diffusion"
+    service_name = (
+        server_args.otlp_service_name
+        or os.getenv("OTEL_SERVICE_NAME")
+        or "sglang-diffusion"
+    )
+
     # srt owns TraceReqContext and filters spans through its trace_modules list
     process_tracing_init(
         server_args.otlp_traces_endpoint,
-        "sglang-diffusion",
+        service_name,
         trace_modules=DIFFUSION_TRACE_MODULE,
     )
     trace_set_thread_info(thread_label)

--- a/python/sglang/srt/arg_groups/fields/observability.py
+++ b/python/sglang/srt/arg_groups/fields/observability.py
@@ -177,6 +177,11 @@ class Observability(msgspec.Struct):
         str,
         "Config opentelemetry collector endpoint if --enable-trace is set. format: <ip>:<port>",
     ] = "localhost:4317"
+    otlp_service_name: A[
+        Optional[str],
+        "Service name for OTLP traces (displayed as 'service.name' in trace backends). "
+        "If unset, falls back to the OTEL_SERVICE_NAME env var, then to 'sglang'.",
+    ] = None
     # RequestMetricsExporter configuration
     export_metrics_to_file: A[
         bool,

--- a/python/sglang/srt/disaggregation/encoder/runtime.py
+++ b/python/sglang/srt/disaggregation/encoder/runtime.py
@@ -1775,7 +1775,7 @@ def launch_local_runtime(server_args: ServerArgs) -> EncoderRuntime:
     if get_observability().enable_trace:
         process_tracing_init(
             get_observability().otlp_traces_endpoint,
-            "sglang",
+            get_observability().otlp_service_name,
             trace_modules=get_observability().trace_modules,
         )
         trace_set_thread_info("Encoder")

--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -329,7 +329,7 @@ class Engine(EngineScoreMixin, EngineBase):
         if get_observability().enable_trace:
             process_tracing_init(
                 get_observability().otlp_traces_endpoint,
-                "sglang",
+                get_observability().otlp_service_name,
                 trace_modules=get_observability().trace_modules,
             )
             thread_label = "Tokenizer"

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -293,7 +293,7 @@ async def lifespan(fast_api_app: FastAPI):
     if get_observability().enable_trace:
         process_tracing_init(
             get_observability().otlp_traces_endpoint,
-            "sglang",
+            get_observability().otlp_service_name,
             trace_modules=get_observability().trace_modules,
         )
         if get_disagg().disaggregation_mode == "prefill":

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -839,7 +839,7 @@ def run_data_parallel_controller_process(
     if get_observability().enable_trace:
         process_tracing_init(
             get_observability().otlp_traces_endpoint,
-            "sglang",
+            get_observability().otlp_service_name,
             trace_modules=get_observability().trace_modules,
         )
         thread_label = "DP Controller"

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -5789,7 +5789,7 @@ def run_scheduler_process(
     if get_observability().enable_trace:
         process_tracing_init(
             get_observability().otlp_traces_endpoint,
-            "sglang",
+            get_observability().otlp_service_name,
             trace_modules=get_observability().trace_modules,
         )
         thread_label = "Scheduler"

--- a/python/sglang/srt/observability/trace.py
+++ b/python/sglang/srt/observability/trace.py
@@ -227,9 +227,12 @@ def process_tracing_init(
         )
 
     try:
+        # Priority: explicit server_name > OTEL_SERVICE_NAME > "sglang"
+        service_name = server_name or os.getenv("OTEL_SERVICE_NAME", "sglang")
+
         resource = Resource.create(
             attributes={
-                SERVICE_NAME: server_name,
+                SERVICE_NAME: service_name,
             }
         )
         tracer_provider = TracerProvider(
@@ -259,7 +262,7 @@ def process_tracing_init(
     if envs.SGLANG_TRACE_ASYNC.get():
         from sglang.srt.observability.trace_async import start_trace_exporter
 
-        start_trace_exporter(otlp_endpoint, server_name, trace_modules=trace_modules)
+        start_trace_exporter(otlp_endpoint, service_name, trace_modules=trace_modules)
 
 
 def get_global_tracing_enabled():

--- a/test/registered/unit/observability/test_trace.py
+++ b/test/registered/unit/observability/test_trace.py
@@ -175,6 +175,48 @@ class TestProcessTracingInit(unittest.TestCase):
         finally:
             mod.opentelemetry_imported = orig
 
+    @unittest.skipIf(not _has_otel, "OpenTelemetry not installed")
+    def test_service_name_priority_explicit(self):
+        """Service name priority: explicit parameter > env var > default."""
+        with patch.dict(os.environ, {"OTEL_SERVICE_NAME": "from-env"}):
+            with patch.object(mod, "TracerProvider"):
+                with patch.object(mod, "Resource") as mock_resource:
+                    process_tracing_init("localhost:4317", "explicit-name")
+                    # Verify Resource.create was called with the explicit name
+                    mock_resource.create.assert_called_once()
+                    call_kwargs = mock_resource.create.call_args[1]
+                    self.assertEqual(
+                        call_kwargs["attributes"][mod.SERVICE_NAME], "explicit-name"
+                    )
+
+    @unittest.skipIf(not _has_otel, "OpenTelemetry not installed")
+    def test_service_name_priority_env_var(self):
+        """Service name falls back to OTEL_SERVICE_NAME when explicit is None."""
+        with patch.dict(os.environ, {"OTEL_SERVICE_NAME": "from-env"}):
+            with patch.object(mod, "TracerProvider"):
+                with patch.object(mod, "Resource") as mock_resource:
+                    process_tracing_init("localhost:4317", None)
+                    # Verify Resource.create was called with env var value
+                    mock_resource.create.assert_called_once()
+                    call_kwargs = mock_resource.create.call_args[1]
+                    self.assertEqual(
+                        call_kwargs["attributes"][mod.SERVICE_NAME], "from-env"
+                    )
+
+    @unittest.skipIf(not _has_otel, "OpenTelemetry not installed")
+    def test_service_name_priority_default(self):
+        """Service name falls back to 'sglang' when both explicit and env are unset."""
+        with patch.dict(os.environ, {}, clear=True):
+            with patch.object(mod, "TracerProvider"):
+                with patch.object(mod, "Resource") as mock_resource:
+                    process_tracing_init("localhost:4317", None)
+                    # Verify Resource.create was called with default value
+                    mock_resource.create.assert_called_once()
+                    call_kwargs = mock_resource.create.call_args[1]
+                    self.assertEqual(
+                        call_kwargs["attributes"][mod.SERVICE_NAME], "sglang"
+                    )
+
 
 class TestTraceReqContextDisabled(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

When running multiple SGLang instances (staging vs production, different models, disaggregation setups, multi-tenant deployments), all traces report with the hardcoded service name `"sglang"` or `"sglang-diffusion"`, making it difficult to distinguish instances in OTLP trace backends like Jaeger, Tempo, or other OpenTelemetry collectors.

This PR adds `--otlp-service-name` CLI flag to allow users to customize the service name, with fallback support for the standard OpenTelemetry `OTEL_SERVICE_NAME` environment variable.

**Use cases:**
- **Multi-environment deployments:** `qwen-prod` vs `qwen-staging` vs `qwen-dev`
- **Multi-model serving:** Distinguish between `Qwen/Qwen3.8-27B` and `DeepSeek-V4-Flash-0731` instances
- **Disaggregation setups:** Separate prefill and decode instances (`sglang-prefill` vs `sglang-decode`)
- **Multi-tenant deployments:** Different teams/tenants with isolated observability

## Modifications

### SGLang (LLM Runtime)

**Added CLI parameter** (`python/sglang/srt/arg_groups/fields/observability.py`):
- `otlp_service_name: Optional[str] = None` with help text explaining priority

**Updated trace initialization** (`python/sglang/srt/observability/trace.py`):
- Added resolution logic: `service_name = server_name or os.getenv("OTEL_SERVICE_NAME", "sglang")`
- Pass resolved `service_name` to OpenTelemetry Resource and async trace exporter

**Updated all 5 call sites** to pass `get_observability().otlp_service_name`:
- `python/sglang/srt/entrypoints/http_server.py`
- `python/sglang/srt/managers/scheduler.py`
- `python/sglang/srt/entrypoints/engine.py`
- `python/sglang/srt/disaggregation/encoder/runtime.py` (encoder server)
- `python/sglang/srt/managers/data_parallel_controller.py`

### SGLang-Diffusion

**Added CLI parameter** (`python/sglang/multimodal_gen/runtime/server_args/server_args.py`):
- Field: `otlp_service_name: str | None = None`
- CLI argument with help text

**Updated trace wrapper** (`python/sglang/multimodal_gen/runtime/utils/trace_wrapper.py`):
- Added resolution logic with diffusion-specific default: `service_name = server_args.otlp_service_name or os.getenv("OTEL_SERVICE_NAME") or "sglang-diffusion"`
- Added `import os`

### Resolution Priority

`--otlp-service-name` (CLI) > `OTEL_SERVICE_NAME` (env var) > default (`"sglang"` or `"sglang-diffusion"`)

The CLI parameter defaults to `None` (not the final service name) so that when unset, the standard `OTEL_SERVICE_NAME` environment variable can be respected. If the default were a non-empty string, it would shadow the env var.

### Backward Compatibility

✅ Fully backward compatible:
- LLM default remains `"sglang"`
- Diffusion default remains `"sglang-diffusion"`
- No changes required to existing deployments

### Usage Examples

**CLI parameter:**
```bash
# LLM Runtime
python -m sglang.launch_server \
  --model-path Qwen/Qwen3.8-27B \
  --enable-trace \
  --otlp-service-name "sglang-qwen-prod"

# Diffusion Runtime
sglang serve \
  --model-path Wan-AI/Wan2.1-T2V-1.3B-Diffusers \
  --enable-trace \
  --otlp-service-name "sglang-diffusion-wan-prod"
```

**Environment variable:**
```bash
# Use standard OpenTelemetry env var (no CLI flag needed)
export OTEL_SERVICE_NAME="sglang-staging"
python -m sglang.launch_server --model-path Qwen/Qwen3.8-27B --enable-trace
```

**CLI takes precedence:**
```bash
# CLI overrides environment variable
export OTEL_SERVICE_NAME="from-env"
python -m sglang.launch_server \
  --model-path Qwen/Qwen3.8-27B \
  --enable-trace \
  --otlp-service-name "from-cli"
# Result: service.name = "from-cli"
```

## Unit Tests

Added `test/registered/unit/observability/test_trace.py` covering the service-name resolution priority:
- Explicit CLI parameter wins over `OTEL_SERVICE_NAME` and the default
- Falls back to `OTEL_SERVICE_NAME` when the CLI parameter is unset
- Falls back to `"sglang"` when both are unset

## Accuracy Tests

N/A - This PR only affects observability metadata (trace service names) and does not modify model outputs, kernels, or model forward code.

## Speed Tests and Profiling

N/A - This PR does not impact inference speed. The service name resolution happens once at server startup during trace initialization, with negligible overhead (a single `os.getenv()` call and string `or` short-circuit evaluation).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.




<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35009833963](https://github.com/sgl-project/sglang/actions/runs/35009833963)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35009833581](https://github.com/sgl-project/sglang/actions/runs/35009833581)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35009833648](https://github.com/sgl-project/sglang/actions/runs/35009833648)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->