### PR TITLE
[diffusion] feat: make the MiniMax-H3 ref2va reference-image short edge configurable

### DIFF
--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/minimax_h3/prequeue.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/minimax_h3/prequeue.py
@@ -238,6 +238,22 @@ def _preserve_prequeue_material_dirs(batch: Any) -> None:
                 prequeue_paths.append(path)
 
 
+def _configured_reference_image_short_edge() -> int | None:
+    """Server-configured ref2va image short edge, ``None`` for the 2048 default.
+
+    Pre-queue admission runs outside the stage machinery, so it reads the global
+    server args directly; callers without a server keep the released default.
+    """
+
+    from sglang.multimodal_gen.runtime.server_args import get_global_server_args
+
+    try:
+        server_args = get_global_server_args()
+    except ValueError:
+        return None
+    return getattr(server_args, "minimax_h3_reference_image_short_edge", None)
+
+
 def minimax_h3_prepare_for_queue(batch: Any) -> MiniMaxH3ResolvedPlan:
     """Freeze MiniMax H3 media/shape facts before queue admission."""
 
@@ -312,6 +328,7 @@ def minimax_h3_prepare_for_queue(batch: Any) -> MiniMaxH3ResolvedPlan:
                 resolved = minimax_h3_resolve_reference_image_shape(
                     width=width,
                     height=height,
+                    short_edge=_configured_reference_image_short_edge(),
                 )
             else:
                 continue

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/minimax_h3/reference_encoding.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/minimax_h3/reference_encoding.py
@@ -121,18 +121,54 @@ def _nearest_multiple(value: float, multiple: int) -> int:
     return max(multiple, int(round(float(value) / multiple)) * multiple)
 
 
+def minimax_h3_validate_reference_image_short_edge(value: Any) -> int:
+    """Validate a reference-image short edge against the 32px grid contract."""
+
+    try:
+        short_edge = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"reference image short edge must be an integer, got {value!r}"
+        ) from exc
+    if value != short_edge:
+        raise ValueError(
+            f"reference image short edge must be an integer, got {value!r}"
+        )
+    if short_edge <= 0:
+        raise ValueError(
+            f"reference image short edge must be positive, got {short_edge}"
+        )
+    if short_edge % MINIMAX_H3_REFERENCE_IMAGE_MULTIPLE:
+        raise ValueError(
+            "reference image short edge must be a multiple of "
+            f"{MINIMAX_H3_REFERENCE_IMAGE_MULTIPLE}, got {short_edge}"
+        )
+    return short_edge
+
+
 def minimax_h3_resolve_reference_image_shape(
     *,
     width: int | float,
     height: int | float,
+    short_edge: int | None = None,
 ) -> dict[str, Any]:
     """Resolve a ref2va image independently from the target canvas.
 
-    The image keeps its display ratio, always targets a 2048px short edge (even
-    when that requires upscaling), and rounds both dimensions independently to
-    the nearest 32px grid. Unlike target/video ``adapt_shape_v1``, reference
-    images have no area-cap branch.
+    The image keeps its display ratio, always targets ``short_edge`` px on its
+    short side (even when that requires upscaling), and rounds both dimensions
+    independently to the nearest 32px grid. Unlike target/video
+    ``adapt_shape_v1``, reference images have no area-cap branch.
+
+    ``short_edge`` defaults to the released 2048px contract. Lowering it cuts
+    token count with the square of the ratio, departing from the checkpoint's
+    audited preprocessing to trade conditioning fidelity for memory.
     """
+
+    resolved_short_edge = (
+        MINIMAX_H3_REFERENCE_IMAGE_SHORT_EDGE
+        if short_edge is None
+        else minimax_h3_validate_reference_image_short_edge(short_edge)
+    )
 
     try:
         source_width = float(width)
@@ -156,7 +192,7 @@ def minimax_h3_resolve_reference_image_shape(
             f"1:4 to 4:1, got {source_width:g}x{source_height:g}"
         )
 
-    scale = MINIMAX_H3_REFERENCE_IMAGE_SHORT_EDGE / min(source_width, source_height)
+    scale = resolved_short_edge / min(source_width, source_height)
     target_width = _nearest_multiple(
         source_width * scale, MINIMAX_H3_REFERENCE_IMAGE_MULTIPLE
     )
@@ -166,7 +202,7 @@ def minimax_h3_resolve_reference_image_shape(
     return {
         "geometry": "reference_image_resolved",
         "shape_policy_version": "reference_image_short_edge_v1",
-        "base_short_edge": MINIMAX_H3_REFERENCE_IMAGE_SHORT_EDGE,
+        "base_short_edge": resolved_short_edge,
         "effective_short_edge": min(target_width, target_height),
         "size_mode": "short_edge",
         "multiple": MINIMAX_H3_REFERENCE_IMAGE_MULTIPLE,
@@ -919,4 +955,5 @@ __all__ = [
     "minimax_h3_prepared_reference_videos",
     "minimax_h3_resolve_reference_image_shape",
     "minimax_h3_sample_reference_video_frames",
+    "minimax_h3_validate_reference_image_short_edge",
 ]

--- a/python/sglang/multimodal_gen/runtime/server_args/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args/server_args.py
@@ -347,6 +347,8 @@ class ServerArgs(DisaggServerArgsMixin):
     use_fsdp_inference: bool | None = None
     pin_cpu_memory: bool = True
     ltx2_two_stage_device_mode: str | None = None
+    # MiniMax-H3 ref2va reference images; None keeps the released 2048px contract
+    minimax_h3_reference_image_short_edge: int | None = None
     _explicit_arg_names: set[str] = field(default_factory=set, repr=False)
     _required_resident_components: set[str] = field(
         default_factory=set, init=False, repr=False
@@ -564,7 +566,22 @@ class ServerArgs(DisaggServerArgsMixin):
         self._validate_cfg_parallel()
         self._validate_batching()
         self._validate_breakable_cuda_graph()
+        self._validate_minimax_h3_reference_image_short_edge()
         self.pipeline_config.validate_server_args(self)
+
+    def _validate_minimax_h3_reference_image_short_edge(self) -> None:
+        if self.minimax_h3_reference_image_short_edge is None:
+            return
+        from sglang.multimodal_gen.runtime.pipelines_core.stages.model_specific_stages.minimax_h3.reference_encoding import (
+            minimax_h3_validate_reference_image_short_edge,
+        )
+
+        # fail at launch rather than on the first ref2va request
+        self.minimax_h3_reference_image_short_edge = (
+            minimax_h3_validate_reference_image_short_edge(
+                self.minimax_h3_reference_image_short_edge
+            )
+        )
 
     def _validate_scheduler_rpc_timeout(self) -> None:
         timeout = self.scheduler_rpc_timeout
@@ -2206,6 +2223,19 @@ class ServerArgs(DisaggServerArgsMixin):
                 "'original' keeps official two-stage semantics without premerged stage2, "
                 "'resident' keeps both transformers resident on GPU. "
                 "Default is auto: resident on H200/high-memory CUDA GPUs, otherwise original."
+            ),
+        )
+        parser.add_argument(
+            "--minimax-h3-reference-image-short-edge",
+            type=int,
+            default=ServerArgs.minimax_h3_reference_image_short_edge,
+            help=(
+                "MiniMax-H3 ref2va only: short edge every reference image is "
+                "resized to before Qwen3-VL and the video VAE, as a positive "
+                "multiple of 32. Token count scales with the square of this "
+                "value, so 1024 costs a quarter of the 2048 default and trades "
+                "conditioning fidelity for memory. Unset keeps the released "
+                "2048px contract; reference videos are unaffected."
             ),
         )
         parser.add_argument(

--- a/python/sglang/multimodal_gen/test/unit/test_minimax_h3_reference_image_short_edge.py
+++ b/python/sglang/multimodal_gen/test/unit/test_minimax_h3_reference_image_short_edge.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Configurable ref2va reference-image short edge.
+
+The released contract resizes every reference image to a 2048px short edge.
+That default is pinned here; the override exists only to trade conditioning
+fidelity for the memory those tokens cost, so it must keep every other property
+of the shape policy (display ratio, 32px grid, upscaling) intact.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sglang.multimodal_gen.runtime.pipelines_core.stages.model_specific_stages.minimax_h3.reference_encoding import (
+    MINIMAX_H3_REFERENCE_IMAGE_MULTIPLE,
+    MINIMAX_H3_REFERENCE_IMAGE_SHORT_EDGE,
+    minimax_h3_resolve_reference_image_shape,
+    minimax_h3_validate_reference_image_short_edge,
+)
+
+
+def test_default_short_edge_is_the_released_contract():
+    """Omitting the override must resolve exactly as before."""
+    shape = minimax_h3_resolve_reference_image_shape(width=1920, height=1080)
+    assert shape["base_short_edge"] == MINIMAX_H3_REFERENCE_IMAGE_SHORT_EDGE == 2048
+    assert min(shape["width"], shape["height"]) == 2048
+    assert shape["shape_policy_version"] == "reference_image_short_edge_v1"
+
+
+def test_explicit_default_matches_the_implicit_one():
+    implicit = minimax_h3_resolve_reference_image_shape(width=1280, height=720)
+    explicit = minimax_h3_resolve_reference_image_shape(
+        width=1280, height=720, short_edge=2048
+    )
+    assert implicit == explicit
+
+
+@pytest.mark.parametrize("short_edge", (1024, 1280, 1440, 2048))
+def test_short_edge_lands_on_the_requested_tier(short_edge):
+    shape = minimax_h3_resolve_reference_image_shape(
+        width=1920, height=1080, short_edge=short_edge
+    )
+    assert shape["base_short_edge"] == short_edge
+    assert min(shape["width"], shape["height"]) == short_edge
+    assert shape["effective_short_edge"] == short_edge
+    assert not shape["width"] % MINIMAX_H3_REFERENCE_IMAGE_MULTIPLE
+    assert not shape["height"] % MINIMAX_H3_REFERENCE_IMAGE_MULTIPLE
+
+
+@pytest.mark.parametrize("short_edge", (1024, 1440, 2048))
+def test_display_ratio_survives_the_override(short_edge):
+    shape = minimax_h3_resolve_reference_image_shape(
+        width=1920, height=1080, short_edge=short_edge
+    )
+    assert shape["width"] / shape["height"] == pytest.approx(1920 / 1080, rel=0.02)
+
+
+def test_upscaling_still_applies_below_the_tier():
+    """A small source is still upscaled -- shrinking inputs client-side is not
+    a way to save memory, only the server-side tier is."""
+    shape = minimax_h3_resolve_reference_image_shape(
+        width=256, height=256, short_edge=1024
+    )
+    assert (shape["width"], shape["height"]) == (1024, 1024)
+    assert shape["allow_upscale"] is True
+
+
+def test_token_count_scales_with_the_square_of_the_tier():
+    """The whole point of the knob: halving the edge quarters the tokens."""
+
+    def dit_tokens(shape):
+        # VAE spatial_compression_ratio=16, DiT patch_size=(1, 2, 2)
+        return (shape["width"] // 32) * (shape["height"] // 32)
+
+    full = minimax_h3_resolve_reference_image_shape(
+        width=1024, height=1024, short_edge=2048
+    )
+    half = minimax_h3_resolve_reference_image_shape(
+        width=1024, height=1024, short_edge=1024
+    )
+    assert dit_tokens(full) == 4096
+    assert dit_tokens(half) == 1024
+
+
+@pytest.mark.parametrize("bad", (0, -32, 1000, 1023, 2049))
+def test_off_grid_and_non_positive_values_are_rejected(bad):
+    with pytest.raises(ValueError):
+        minimax_h3_validate_reference_image_short_edge(bad)
+    with pytest.raises(ValueError):
+        minimax_h3_resolve_reference_image_shape(
+            width=1920, height=1080, short_edge=bad
+        )
+
+
+@pytest.mark.parametrize("bad", ("1024", None, 3.5))
+def test_non_integer_values_are_rejected(bad):
+    with pytest.raises(ValueError):
+        minimax_h3_validate_reference_image_short_edge(bad)
+
+
+def test_server_args_validation_rejects_off_grid_values():
+    from sglang.multimodal_gen.runtime.server_args import ServerArgs
+
+    args = ServerArgs.__new__(ServerArgs)
+    args.minimax_h3_reference_image_short_edge = 1000
+    with pytest.raises(ValueError):
+        args._validate_minimax_h3_reference_image_short_edge()
+
+
+def test_server_args_validation_accepts_none_and_valid_tiers():
+    from sglang.multimodal_gen.runtime.server_args import ServerArgs
+
+    args = ServerArgs.__new__(ServerArgs)
+    args.minimax_h3_reference_image_short_edge = None
+    args._validate_minimax_h3_reference_image_short_edge()
+    assert args.minimax_h3_reference_image_short_edge is None
+
+    args.minimax_h3_reference_image_short_edge = 1440
+    args._validate_minimax_h3_reference_image_short_edge()
+    assert args.minimax_h3_reference_image_short_edge == 1440


### PR DESCRIPTION
MiniMax-H3 ref2va resizes every reference image to a hard-coded 2048px short edge before Qwen3-VL and the video VAE. Reference-image token count grows with the square of that edge, and the resulting latents are patchified into the conditioning sequence that every denoising step attends over, so a request carrying several references is expensive in both memory and time with no knob to reach for. This adds `--minimax-h3-reference-image-short-edge` to pin that short edge server-wide. The flag is opt-in and off by default; left unset the resolver takes the same path it does today, and an end-to-end run confirms the output is byte-identical to the parent commit.

## Motivation

`minimax_h3_resolve_reference_image_shape` always targets `MINIMAX_H3_REFERENCE_IMAGE_SHORT_EDGE = 2048`, **including when that requires upscaling**. The cost is not addressable from the outside, and it is paid twice: once in the Qwen3-VL and video-VAE encode, and again on every denoising step, because the reference latents are patchified `[1, 2, 2]` into the conditioning sequence.

For the six-reference case measured below, the resolver's own numbers:

| short edge | tokens per image | 6 images | relative |
|---|---|---|---|
| 2048 (default) | 7264 | 43584 | 1.00x |
| 1440 | 3592 | 21555 | 0.49x |
| 1280 | 2833 | 17000 | 0.39x |
| 1024 | 1818 | 10912 | **0.25x** |

Those reference images have native short edges of 1290–1440px, so the released default is **upscaling every one of them** to 2048 and then charging the sequence for the extra tokens. That is the case this flag is for: a deployment that knows its references are not natively 2048px can stop paying for interpolated detail. Deployments whose references genuinely carry 2048px of detail keep the default and are unaffected.

## Modifications

- `minimax_h3_resolve_reference_image_shape` takes an optional `short_edge`; `None` keeps the released 2048px contract. Display ratio, the 32px grid, and the upscale behaviour are unchanged.
- `minimax_h3_validate_reference_image_short_edge` enforces the contract: a positive integer that is a multiple of 32, the same grid the resolver already rounds both dimensions to.
- `ServerArgs._validate_minimax_h3_reference_image_short_edge` runs that validator at launch, so a bad value fails before the model loads rather than on the first ref2va request:

```
$ sglang serve ... --minimax-h3-reference-image-short-edge 1000
ValueError: reference image short edge must be a multiple of 32, got 1000
```

- Pre-queue admission reads the server args directly (it runs outside the stage machinery) and falls back to the released default when there is no server.
- Reference **videos** are untouched on every path.

Files:`.../minimax_h3/reference_encoding.py`,`.../minimax_h3/prequeue.py`,`.../server_args/server_args.py`, `.../test/unit/test_minimax_h3_reference_image_short_edge.py`.

## Accuracy Tests

**The default path is unchanged, end to end.** The same ref2va request — 6 reference images, 12.25s, 16:9, seed 42, 10 steps — served twice with the flag unset: once on this branch, once on the parent commit (`21c88f862`). Byte-identical output:

**Lowering the tier does not degrade the output.** Same request, same seed, one tier per server. Frame statistics sampled at frames 24 / 96 / 192 / 264:

| short edge | contrast (std) | sharpness (edge) |
|---|---|---|
| 2048 (default) | 44.03 | 7.72 |
| 1440 | 44.63 | 7.90 |
| 1280 | 44.69 | 7.79 |
| 1024 | **45.19** | **7.79** |

<img width="2560" height="820" alt="comparison" src="https://github.com/user-attachments/assets/60723243-f016-45b4-93cc-45205f907459" />


The two arms render the same shots, the same composition, the same English title cards (`MIDNIGHT LINE`, `MIRA HOLT`, `MAYA CROSS`, `REN KATO`, `NOAH VOSS`) and the same colour grade. They are not pixel-identical — different conditioning means a different sampling trajectory — but the differences are drift, not loss.

**Unit tests.** `test_minimax_h3_reference_image_short_edge.py` adds 21 cases covering the default contract, explicit-default equivalence, ratio and grid preservation, the retained upscale behaviour, square token scaling, and the rejected values (off-grid, non-positive, non-integer) at both the resolver and `ServerArgs` layers. The H3 and server-args suites under `python/sglang/multimodal_gen/test/unit/` pass (270 passed).

## Speed Tests and Profiling

2x RTX 5090, TP=2, BF16 Ref2VA transformer, layerwise offload for `dit` and `text_encoder` with `--dit-layerwise-resident-layers 0`, `sage_attn`, torch.compile off. Same request as above; **denoise latency** is the primary metric, end-to-end and peak memory are the sanity checks.

**6 reference images** — the case the flag exists for:

| short edge | denoise | s/it | end to end | peak GPU |
|---|---|---|---|---|
| 2048 (default) | 523s | 58.2 | 606s | 27.2 GiB |
| 1440 | 329s | 36.6 | 380s | 23.1 GiB |
| 1280 | 296s | 32.9 | 346s | 22.2 GiB |
| 1024 | **251s (2.08x)** | **27.9** | **296s** | **20.9 GiB (-6.3)** |

**1 reference image** — the same sweep, showing where the flag does *not* help:

| short edge | denoise | s/it | end to end | peak GPU |
|---|---|---|---|---|
| 2048 (default) | 224s | 24.9 | 265s | 20.7 GiB |
| 1440 | 201s | 22.4 | 240s | 19.4 GiB |
| 1280 | 198s | 22.0 | 235s | 19.5 GiB |
| 1024 | 191s (1.17x) | 21.3 | 230s | 19.0 GiB |

With one reference the conditioning is a small fraction of the sequence and the tier buys 1.17x; with six it buys 2.08x and 6.3 GiB.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — the flag is self-describing in `--help`; no separate doc page covers ref2va preprocessing.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32453893760](https://github.com/sgl-project/sglang/actions/runs/32453893760)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32453893560](https://github.com/sgl-project/sglang/actions/runs/32453893560)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32453893638](https://github.com/sgl-project/sglang/actions/runs/32453893638)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->