### PR TITLE
[Fix] Monitor scheduler subprocesses owned by the DP controller

### DIFF
--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -68,7 +68,7 @@ from sglang.srt.utils.network import (
     get_zmq_socket_on_host,
 )
 from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
-from sglang.srt.utils.watchdog import Watchdog
+from sglang.srt.utils.watchdog import SubprocessWatchdog, Watchdog
 from sglang.utils import TypeBasedDispatcher, get_exception_traceback
 
 logger = logging.getLogger(__name__)
@@ -839,26 +839,36 @@ def run_data_parallel_controller_process(
         controller = DataParallelController(
             server_args, port_args, run_scheduler_process_func
         )
+        subprocess_watchdog = SubprocessWatchdog(
+            processes=controller.scheduler_procs,
+            process_names=[
+                f"scheduler_{rank}" for rank in range(len(controller.scheduler_procs))
+            ],
+        )
+        subprocess_watchdog.start()
         scheduler_pids = [
             proc.pid for proc in controller.scheduler_procs if proc is not None
         ]
-        pipe_writer.send(
-            {
-                "status": "ready",
-                "max_total_num_tokens": controller.max_total_num_tokens,
-                "max_req_input_len": controller.max_req_input_len,
-                "startup_time": controller.startup_time,
-                SCHEDULER_PIDS_ARG: scheduler_pids,
-            }
-        )
-        # The primary owns routing for the expanded scheduler set.
-        if server_args.node_rank == 0 and not server_args.is_ep_scale_joiner:
-            controller.event_loop()
-        for proc in controller.scheduler_procs:
-            proc.join()
-            logger.error(
-                f"Scheduler or DataParallelController {proc.pid} terminated with {proc.exitcode}"
+        try:
+            pipe_writer.send(
+                {
+                    "status": "ready",
+                    "max_total_num_tokens": controller.max_total_num_tokens,
+                    "max_req_input_len": controller.max_req_input_len,
+                    "startup_time": controller.startup_time,
+                    SCHEDULER_PIDS_ARG: scheduler_pids,
+                }
             )
+            # The primary owns routing for the expanded scheduler set.
+            if server_args.node_rank == 0 and not server_args.is_ep_scale_joiner:
+                controller.event_loop()
+            for proc in controller.scheduler_procs:
+                proc.join()
+                logger.error(
+                    f"Scheduler or DataParallelController {proc.pid} terminated with {proc.exitcode}"
+                )
+        finally:
+            subprocess_watchdog.stop()
     except Exception:
         traceback = get_exception_traceback()
         logger.error(f"DataParallelController hit an exception: {traceback}")

--- a/test/registered/unit/managers/test_data_parallel_controller.py
+++ b/test/registered/unit/managers/test_data_parallel_controller.py
@@ -13,7 +13,7 @@ is exercised as the real method, no mock.
 
 import unittest
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import msgspec.structs
 
@@ -26,6 +26,7 @@ from sglang.srt.managers.data_parallel_controller import (
     DataParallelController,
     DPBudget,
     LoadBalanceMethod,
+    run_data_parallel_controller_process,
 )
 from sglang.srt.managers.load_snapshot import LoadSnapshot
 
@@ -277,6 +278,58 @@ class TestStatusAwarenessInconsistency(CustomTestCase):
         ctl.total_requests_scheduler(_req())
         # Current behaviour: still dispatches to the inactive worker.
         ctl.workers[2].send_pyobj.assert_called_once()
+
+
+class TestDataParallelControllerProcess(CustomTestCase):
+    def test_monitors_scheduler_processes_during_controller_lifetime(self):
+        scheduler_procs = [MagicMock(pid=10), MagicMock(pid=11)]
+        controller = MagicMock(
+            scheduler_procs=scheduler_procs,
+            max_total_num_tokens=1024,
+            max_req_input_len=512,
+            startup_time={},
+        )
+        server_args = SimpleNamespace(
+            enable_trace=False,
+            node_rank=0,
+            is_ep_scale_joiner=False,
+        )
+
+        with (
+            patch(
+                "sglang.srt.managers.data_parallel_controller.DataParallelController",
+                return_value=controller,
+            ),
+            patch(
+                "sglang.srt.managers.data_parallel_controller.SubprocessWatchdog"
+            ) as watchdog_type,
+            patch("sglang.srt.managers.data_parallel_controller.psutil.Process"),
+            patch(
+                "sglang.srt.managers.data_parallel_controller."
+                "kill_itself_when_parent_died"
+            ),
+            patch("sglang.srt.managers.data_parallel_controller.publish"),
+            patch("sglang.srt.managers.data_parallel_controller.configure_logger"),
+            patch("sglang.srt.managers.data_parallel_controller.faulthandler.enable"),
+            patch(
+                "sglang.srt.managers.data_parallel_controller.setproctitle.setproctitle"
+            ),
+        ):
+            run_data_parallel_controller_process(
+                server_args,
+                MagicMock(),
+                MagicMock(),
+            )
+
+        watchdog_type.assert_called_once_with(
+            processes=scheduler_procs,
+            process_names=["scheduler_0", "scheduler_1"],
+        )
+        watchdog_type.return_value.start.assert_called_once_with()
+        watchdog_type.return_value.stop.assert_called_once_with()
+        controller.event_loop.assert_called_once_with()
+        for proc in scheduler_procs:
+            proc.join.assert_called_once_with()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

SGLang already uses `SubprocessWatchdog` to detect abnormal scheduler and detokenizer exits that bypass Python exception handling, such as a native NCCL or CUDA abort. In data-parallel mode, however, the Engine directly owns only the `DataParallelController`; the scheduler processes are children of that controller and are not covered by the Engine watchdog.

If one of those scheduler processes exits abnormally, the controller can remain blocked in `event_loop()`. The Engine still sees a live controller, leaving a service process that is alive but cannot make inference progress.

This closes that process-tree gap using the existing SGLang watchdog primitive.

Previous related work:

- #15997 identified the same DP-controller child-monitoring gap. Review requested a watchdog thread rather than polling inside the controller event loop.
- #18582 introduced and merged `SubprocessWatchdog` for Engine-owned subprocesses.

This PR applies that established primitive to scheduler processes owned by the DP controller.

## Modifications

- Start a `SubprocessWatchdog` for the controller-owned scheduler processes after scheduler initialization and before publishing controller readiness.
- Stop the watchdog when the controller exits.
- Add a unit test covering watchdog ownership and lifecycle in `run_data_parallel_controller_process`.

The existing `SubprocessWatchdog` behavior is unchanged: normal child exits are ignored, while abnormal exits trigger the existing SIGQUIT cleanup path.

## Accuracy Tests

Not applicable. This changes process-failure detection only.

## Speed Tests and Profiling

No inference-path work is added. In DP mode, one daemon thread checks each local scheduler process once per second. There are no GPU operations, collectives, tensor allocations, or request-path changes.

## Validation

- `uvx pre-commit run --from-ref origin/main --to-ref HEAD`
- `python -m pytest -q test/registered/unit/utils/test_subprocess_watchdog.py test/registered/unit/managers/test_data_parallel_controller.py` — 27 passed

## Checklist

- [x] Format code according to the project pre-commit configuration.
- [x] Add unit tests.
- [ ] Update documentation — not applicable; no user-facing configuration or API change.
- [x] Follow the existing SGLang subprocess-watchdog primitive and code style.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35291644421](https://github.com/sgl-project/sglang/actions/runs/35291644421)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35291644124](https://github.com/sgl-project/sglang/actions/runs/35291644124)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35291644477](https://github.com/sgl-project/sglang/actions/runs/35291644477)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->