### PR TITLE
[AMD] Make ROCm 7.2.4 images profile correctly without LD_PRELOAD

### DIFF
--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -820,6 +820,59 @@ RUN if [ "$BUILD_TRITON" = "1" ]; then \
 RUN case "${GPU_ARCH}" in *-rocm724) python3 -c "import pathlib,re,importlib.metadata as m; p=pathlib.Path(m.distribution('torch')._path)/'METADATA'; v=m.version('triton'); t,n=re.subn(r'^Requires-Dist: (?:triton|triton-rocm)==[^ ;]+', 'Requires-Dist: triton=='+v, p.read_text(), count=1, flags=re.M); assert n==1, n; p.write_text(t)" ;; esac
 
 # -----------------------
+# Point torch at the image's ROCm runtime.
+#
+# The wheels vendor their own HIP and roctracer under torch/lib, and
+# libtorch_hip.so carries RPATH $ORIGIN, so those copies win over /opt/rocm
+# whatever LD_LIBRARY_PATH says. A ROCm 7.2.4 image consequently profiles
+# through 7.2.0 libraries and loses kernel events under hipGraphLaunch
+# (ROCm/ROCm#6102, fixed in 7.2.2): 448 of 512 graph-replay kernels reached the
+# trace on both MI300X and MI355X, against 512 of 512 with the ROCm copies
+# preloaded, and 87% of decode kernels went missing in a real server trace.
+#
+# Replacing the vendored files makes the working configuration the default
+# instead of something every user has to know to preload. Keyed on whether the
+# wheel vendors them at all, so flavors whose torch already links /opt/rocm are
+# left alone. Replaced by rename: the running interpreter has the old files
+# mapped, and writing through them would corrupt it.
+RUN python3 - <<'PY'
+import os
+import pathlib
+import shutil
+import sys
+
+import torch
+
+torch_lib = pathlib.Path(torch.__file__).resolve().parent / "lib"
+rocm_lib = pathlib.Path("/opt/rocm/lib")
+replaced = []
+
+for name in ("libamdhip64", "libroctracer64"):
+    vendored = torch_lib / f"{name}.so"
+    if not vendored.exists():
+        print(f"{name}: not vendored by the wheel, nothing to replace")
+        continue
+    versioned = sorted(p for p in rocm_lib.glob(f"{name}.so.*") if not p.is_symlink())
+    if not versioned:
+        sys.exit(f"FATAL: {name} is vendored but {rocm_lib} has no copy to use")
+    source = versioned[-1]
+    staged = vendored.with_name(f"{vendored.name}.rocm")
+    shutil.copy2(source, staged)
+    staged.chmod(vendored.stat().st_mode & 0o7777)
+    os.replace(staged, vendored)
+    replaced.append((vendored, source))
+    print(f"{name}: {vendored} <- {source} ({source.stat().st_size} bytes)")
+
+for vendored, source in replaced:
+    if vendored.stat().st_size != source.stat().st_size:
+        sys.exit(f"FATAL: {vendored} does not match {source}")
+PY
+
+# A fresh interpreter, so this loads the libraries just swapped in: an ABI or
+# soname mismatch fails the build here rather than at a user's first profile.
+RUN python3 -c "import torch; assert torch.version.hip is not None, torch.__version__; print(f'[ROCm runtime] torch {torch.__version__}, hip {torch.version.hip}')"
+
+# -----------------------
 # Performance environment variable.
 
 # Skip CuDNN compatibility check - not applicable for ROCm (uses MIOpen instead)


### PR DESCRIPTION
> **Folded into #35390.** The Dockerfile change here is now a commit on that PR, which also carries the probe that verifies it and the documentation. Nothing to review separately; this can be closed.

## Motivation

The `rocm724` images from #30984 install ROCm 7.2.4, which fixes the roctracer failure that loses kernel-dispatch events under `hipGraphLaunch` ([ROCm/ROCm#6102](https://github.com/ROCm/ROCm/issues/6102), fixed in 7.2.2). They do not use it. The torch wheels vendor their own HIP and roctracer under `torch/lib`, and `libtorch_hip.so` carries `RPATH $ORIGIN`, so the loader takes those 7.2.0 copies and `LD_LIBRARY_PATH` cannot override an `RPATH`.

Measured on the published `v0.5.17-rocm724-*-20260820` images, on both GPU generations:

| image | GPU | eager | graph replay | verdict |
| --- | --- | --- | --- | --- |
| `…-rocm724-mi35x-20260820` as shipped | MI355X | 512/512 | **448/512** | FAIL |
| same, ROCm copies preloaded | MI355X | 512/512 | 512/512 | PASS |
| `…-rocm724-mi30x-20260820` as shipped | MI300X | 512/512 | **448/512** | FAIL |
| same, ROCm copies preloaded | MI300X | 512/512 | 512/512 | PASS |

On a real server trace the gap is larger: gpt-oss-20b-bf16 with `/start_profile num_steps=10` records 513 device kernel events with CUDA graphs on, against 3924 with `--disable-cuda-graph` and 3933 on a fixed runtime — 87% of decode kernels missing from a trace that otherwise looks complete.

`LD_PRELOAD` repairs it per process, so every user has to know to set it before launch, and no trace can be trusted until you check whether they did. This makes the working configuration the default.

## Modifications

One step at the end of the torch work in `docker/rocm.Dockerfile`, replacing `torch/lib/libamdhip64.so` and `torch/lib/libroctracer64.so` with the ROCm install's versioned copies, plus a verification step.

Three details worth reviewing:

- **Keyed on whether the wheel vendors them**, not on the ROCm flavor. Where torch already links `/opt/rocm` — the rocm720 stack on torch 2.9.1, for instance — there is nothing to replace and the step says so and moves on. No version guard to update when the next flavor arrives. If a wheel vendors them and `/opt/rocm` has no copy, that is a broken image and the build fails.
- **Replaced by rename.** The interpreter doing the replacing has those libraries mapped; writing through them would corrupt it. It stages a copy and `os.replace`s, so the running process keeps the old inode and everything afterwards sees the new file.
- **Verified in a fresh interpreter.** The next step imports torch, which loads the libraries just swapped in, so a soname or ABI mismatch fails the build rather than a user's first profile.

Symlinks are skipped when picking the source, so the value is the real versioned file (`libamdhip64.so.7.2.70204`), which also keeps it correct across ROCm patch releases.

## Independently confirmed

@devalshahamd tested [on #35390](https://github.com/sgl-project/sglang/pull/35390#pullrequestreview-4988124696) across ROCm 7.0.0, 7.2.0 and 7.2.4 and reported that this approach — `cp -a` of the two ROCm libraries over the wheel's copies — gives both the probe and a real SGLang workload a clean profile, while `LD_PRELOAD` of the same two libraries aborts server startup on 7.2.4:

```
File ".../decode_cuda_graph_runner.py", line 1148, in capture_one_shape
  attn_backend.init_forward_metadata_out_graph(forward_batch, in_capture=True)
File ".../triton/backends/amd/driver.py", line 369, in __call__
SystemError: <built-in method __reversed__ of list object at ...> returned a result with an exception set
```

That is consistent with the mechanism: a preload leaves both HIP copies mapped and only interposes symbols, so any component that resolves them independently — Triton's AMD launcher here — can end up on the other runtime with its own state. Replacing the file means the process has one HIP. It also means this PR is not just ergonomics over the preload; the preload is not a viable workaround for a server at all.


## Accuracy Tests

No model or kernel code changes. This swaps two shared libraries for the same libraries at the version the image installs.

## Speed Tests and Profiling

The point of the change is that `torch.profiler` reports what the GPU ran. Not expected to affect throughput: it replaces HIP and roctracer with the ROCm 7.2.4 build the image already ships and that AITER and the rest of the stack were validated against. ROCm 7.2.4 separately lists reduced `hipGraphLaunch` latency for multi-list graphs, which this change makes reachable, but nothing here measures that.

## Test plan

The replacement logic was exercised against a simulated `torch/lib` and `/opt/rocm/lib`:

- both libraries vendored: replaced, content and size match the ROCm copies, mode preserved
- re-run: idempotent
- nothing vendored (the rocm720 case): no-op with a message, exit 0
- vendored but no ROCm copy: exits 1 with `FATAL`
- symlinks (`libamdhip64.so.7`) are never chosen as the source

Needs a GPU host, and this is the check that matters:

```bash
docker build . -f docker/rocm.Dockerfile --build-arg GPU_ARCH=gfx950-rocm724 \
  --build-arg BRANCH_TYPE=local --build-arg ENABLE_MORI=0 --build-arg ENABLE_NIXL=0 \
  -t rocm724-preload-free

# no LD_PRELOAD anywhere: expect 512/512 and VERDICT: PASS
docker run --rm --device=/dev/kfd --device=/dev/dri --group-add video \
  -v "$PWD:/w" -w /w rocm724-preload-free \
  python3 scripts/ci/amd/check_hip_graph_profiling.py
```

The probe is #35390; it prints which libraries torch actually mapped, so it distinguishes "the image was fixed" from "the preload was set". Sizes are a quick manual check too: after this change `torch/lib/libamdhip64.so` should be 27,193,296 bytes rather than the wheel's 26,746,545.

## Relationship to the other two PRs

- #35390 adds that probe and the documentation. Its docs note tells users to set `LD_PRELOAD`; once this lands, that advice applies only to images built before it, and I will adjust the wording.
- #35398 verifies the published nightly images. It currently runs the probe twice — as shipped, expected to fail, and preloaded, which gates. With this change the shipped configuration is the one that should pass, so that job collapses to a single run.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). <!-- Dockerfile change; the behaviour is verified by the build's own import check and by the probe in #35390. -->
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). <!-- Follow-up in #35390 once this lands. -->
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). <!-- N/A -->
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32454339185](https://github.com/sgl-project/sglang/actions/runs/32454339185)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32454338823](https://github.com/sgl-project/sglang/actions/runs/32454338823)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:white_check_mark: [Run #32454339381](https://github.com/sgl-project/sglang/actions/runs/32454339381)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
