### PR TITLE
fix(gemma4): set lm_head_is_tied for Gemma4UnifiedForConditionalGeneration

### DIFF
--- a/python/sglang/srt/models/gemma4_unified.py
+++ b/python/sglang/srt/models/gemma4_unified.py
@@ -190,7 +190,9 @@ class Gemma4UnifiedForConditionalGeneration(Gemma4ForConditionalGeneration):
         )
 
         text_tie = getattr(text_config, "tie_word_embeddings", True)
-        if self.pp_group.world_size == 1 and text_tie:
+        # The tower-based parent's forward() reads lm_head_is_tied.
+        self.lm_head_is_tied = self.pp_group.world_size == 1 and text_tie
+        if self.lm_head_is_tied:
             self.lm_head = self.language_model.embed_tokens
         elif self.pp_group.is_last_rank:
             self.lm_head = ParallelLMHead(

--- a/test/registered/eval/test_vlms_mmmu_eval.py
+++ b/test/registered/eval/test_vlms_mmmu_eval.py
@@ -27,6 +27,7 @@ MODEL_THRESHOLDS = {
     ModelLaunchSettings("deepseek-ai/deepseek-vl2-small"): (0.320, 56.1),
     ModelLaunchSettings("deepseek-ai/Janus-Pro-7B"): (0.285, 40.3),
     ModelLaunchSettings("google/gemma-4-E4B-it"): (0.26, 24.0),
+    ModelLaunchSettings("google/gemma-4-12B-it"): (0.150, 100.0),
     ModelLaunchSettings("google/gemma-4-26B-A4B-it", extra_args=["--tp=2"]): (
         0.27,
         32.0,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Fixes #38673 

`google/gemma-4-12B-it` fails during startup. Weights load and the KV cache is allocated, then the scheduler dies with the following error:

    File "python/sglang/srt/models/gemma4_unified.py", line 234, in forward
        out = super().forward(*args, **kwargs)
    File "python/sglang/srt/models/gemma4_mm.py", line 685, in forward
        self.language_model.embed_tokens if self.lm_head_is_tied else self.lm_head
    AttributeError: 'Gemma4UnifiedForConditionalGeneration' object has no attribute 'lm_head_is_tied'

`Gemma4UnifiedForConditionalGeneration` deliberately skips `Gemma4ForConditionalGeneration.__init__` but it inherits the parent's `forward()`.

#22498 rewrote that `forward()` to read `self.lm_head_is_tied` where it had previously recomputed the condition inline.

## Modifications

* `Gemma4UnifiedForConditionalGeneration.__init__` now assigns `lm_head_is_tied`, derived from the same condition it already used to choose its head.
* Also registers `google/gemma-4-12B-it` in the VLM MMMU eval. 12B is the only Gemma 4 size on the encoder-free unified architecture and had no entry.

## Accuracy Tests

- Before the fix: server never reaches `Application startup complete` and exits with the `AttributeError` above.
- After the fix: 3 MMMU eval runs on 1x H100 (default server args, 100 examples, 64 threads, 1024 max tokens)

| Run | Score | Latency (s) |
|---|---|---|
| 0 (cold) | 0.530 | 31.6 |
| 1 | 0.550 | 28.8 |
| 2 | 0.510 | 28.5 |

## Speed Tests and Profiling

Not needed for the fix itself. This restores an attribute the inherited `forward()` already expected and computes it from values `__init__` had already resolved.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.




<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35029190936](https://github.com/sgl-project/sglang/actions/runs/35029190936)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35029190539](https://github.com/sgl-project/sglang/actions/runs/35029190539)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35029190701](https://github.com/sgl-project/sglang/actions/runs/35029190701)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->