### PR TITLE
[AMD] Update ROCm AITER pin to c16d44b

### DIFF
--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -46,7 +46,7 @@ ENV BUILD_TRITON="0"
 ENV BUILD_LLVM="0"
 ENV BUILD_AITER_ALL="1"
 ENV BUILD_MOONCAKE="1"
-ENV AITER_COMMIT_DEFAULT="d9e5ef7ce08ee7045d583aed768cff41aa9210fe"
+ENV AITER_COMMIT_DEFAULT="c16d44b93a528b2a4bfd6d8d3409116d465872a9"
 
 # ===============================
 # Base image 942 with rocm720 and args
@@ -56,7 +56,7 @@ ENV BUILD_TRITON="1"
 ENV BUILD_LLVM="0"
 ENV BUILD_AITER_ALL="1"
 ENV BUILD_MOONCAKE="1"
-ENV AITER_COMMIT_DEFAULT="d9e5ef7ce08ee7045d583aed768cff41aa9210fe"
+ENV AITER_COMMIT_DEFAULT="c16d44b93a528b2a4bfd6d8d3409116d465872a9"
 
 # ===============================
 # Base image 942 with rocm724 and args (Python 3.12 + torch 2.11)
@@ -66,7 +66,7 @@ ENV BUILD_TRITON="1"
 ENV BUILD_LLVM="0"
 ENV BUILD_AITER_ALL="1"
 ENV BUILD_MOONCAKE="1"
-ENV AITER_COMMIT_DEFAULT="d9e5ef7ce08ee7045d583aed768cff41aa9210fe"
+ENV AITER_COMMIT_DEFAULT="c16d44b93a528b2a4bfd6d8d3409116d465872a9"
 # Pin the ROCm torch stack for every pip invocation in this flavor. The file is
 # filled in after the torch 2.11 upgrade below; it must already exist (empty is
 # valid) because pip reads PIP_CONSTRAINT from the first pip call onwards.
@@ -90,7 +90,7 @@ ENV BUILD_TRITON="0"
 ENV BUILD_LLVM="0"
 ENV BUILD_AITER_ALL="1"
 ENV BUILD_MOONCAKE="1"
-ENV AITER_COMMIT_DEFAULT="d9e5ef7ce08ee7045d583aed768cff41aa9210fe"
+ENV AITER_COMMIT_DEFAULT="c16d44b93a528b2a4bfd6d8d3409116d465872a9"
 
 # ===============================
 # Base image 950 with rocm720 and args
@@ -100,7 +100,7 @@ ENV BUILD_TRITON="1"
 ENV BUILD_LLVM="0"
 ENV BUILD_AITER_ALL="1"
 ENV BUILD_MOONCAKE="1"
-ENV AITER_COMMIT_DEFAULT="d9e5ef7ce08ee7045d583aed768cff41aa9210fe"
+ENV AITER_COMMIT_DEFAULT="c16d44b93a528b2a4bfd6d8d3409116d465872a9"
 
 # ===============================
 # Base image 950 with rocm724 and args (Python 3.12 + torch 2.11)
@@ -110,7 +110,7 @@ ENV BUILD_TRITON="1"
 ENV BUILD_LLVM="0"
 ENV BUILD_AITER_ALL="1"
 ENV BUILD_MOONCAKE="1"
-ENV AITER_COMMIT_DEFAULT="d9e5ef7ce08ee7045d583aed768cff41aa9210fe"
+ENV AITER_COMMIT_DEFAULT="c16d44b93a528b2a4bfd6d8d3409116d465872a9"
 # Pin the ROCm torch stack for every pip invocation in this flavor. The file is
 # filled in after the torch 2.11 upgrade below; it must already exist (empty is
 # valid) because pip reads PIP_CONSTRAINT from the first pip call onwards.
@@ -351,9 +351,9 @@ ENV AITER_USE_SYSTEM_TRITON=1
 RUN pip uninstall -y aiter
 # Use `checkout -f` so the smudge-filter-induced "dirty" working tree from
 # AITER's .gitattributes (*.csv text eol=lf, added in ROCm/aiter#3370) does not
-# block switching to commits that predate that rule (e.g. the current default
-# AITER_COMMIT_DEFAULT). The working tree was just produced by a fresh
-# `git clone` above, so there are no real user changes to preserve.
+# block AITER_COMMIT overrides that predate that rule. The working tree was just
+# produced by a fresh `git clone` above, so there are no real user changes to
+# preserve.
 RUN git clone ${AITER_REPO} \
  && cd aiter \
  && git checkout -f ${AITER_COMMIT} \


### PR DESCRIPTION
## Motivation

Update the ROCm images from AITER `d9e5ef7ce` to [ROCm/aiter@c16d44b](https://github.com/ROCm/aiter/commit/c16d44b93a528b2a4bfd6d8d3409116d465872a9). The new pin is 186 upstream commits ahead and includes the requested GLM-5 FP8 decode retuning.

This AITER range also moves FlyDSL from 0.2.4 to 0.3.1. This PR is blocked by [#34536](https://github.com/sgl-project/sglang/pull/34536), which adds compatibility with FlyDSL 0.3.x's removal of `flydsl.expr.buffer_ops`.

## Modifications

- Update `AITER_COMMIT_DEFAULT` for all six gfx942/gfx950 ROCm image flavors.

## Accuracy Tests

Not run locally; this Docker dependency update requires AMD GPU image/accuracy CI. Docker is not available in the local environment.


## Speed Tests and Profiling

Not run locally. The target commit contains upstream GLM-5 FP8 decode kernel retuning.

## Checklist

- [x] Format your code according to the [formatting guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [testing guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). <!-- N/A: Docker dependency pin -->
- [ ] Update documentation according to the [documentation guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). <!-- N/A -->
- [ ] Provide accuracy and speed benchmark results according to the [accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [benchmark](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed) guidance. <!-- Pending AMD CI -->
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32455114226](https://github.com/sgl-project/sglang/actions/runs/32455114226)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32455114046](https://github.com/sgl-project/sglang/actions/runs/32455114046)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32455114179](https://github.com/sgl-project/sglang/actions/runs/32455114179)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->