### PR TITLE
Fix mamba radix cache ghost node and clamp spec track step

### DIFF
--- a/python/sglang/srt/mem_cache/mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/mamba_radix_cache.py
@@ -574,8 +574,20 @@ class MambaRadixCache(BasePrefixCache):
                 if write_pos_buf is not None:
                     cache_len -= int(write_pos_buf[req.mamba_pool_idx].item())
                     write_pos_buf[req.mamba_pool_idx] = 0
-            if cache_len is None:
-                cache_len = 0
+            if cache_len is None or cache_len == 0:
+                # Nothing to cache: free KV and mamba slots without inserting
+                # a key_len=0 ghost node into the radix tree. Such empty nodes
+                # poison subsequent match_prefix calls by serving as a stale
+                # mamba COW source with best_value_len=0 (see cache_finished_req
+                # of a short request with no track boundary). Only free the
+                # unprotected part of kv_indices.
+                self.token_to_kv_pool_allocator.free_segment(
+                    kv_indices[req.cache_protected_len :],
+                    start_pos=req.cache_protected_len,
+                )
+                self.req_to_token_pool.free_mamba_cache(req)
+                self.dec_lock_ref(req.last_node)
+                return
             if cache_len != len(token_ids):
                 cache_end_idx = max(cache_len, req.cache_protected_len)
                 self.token_to_kv_pool_allocator.free_segment(

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -817,9 +817,10 @@ def _verify_commit_step_indices(
         != seq_lens_post_verify // mamba_track_interval
     )
     tracking_point = seq_lens_post_verify // mamba_track_interval * mamba_track_interval
-    to_track_ith = torch.clamp(tracking_point - seq_lens_pre_verify - 1, min=0).to(
-        torch.int64
-    )
+    to_track_ith = torch.clamp(
+        torch.minimum(tracking_point - seq_lens_pre_verify, accept_lens - 1),
+        min=0,
+    ).to(torch.int64)
     candidate_track_steps = accept_index[req_idx, to_track_ith] - accept_indices_offset
     mamba_steps_to_track = torch.where(
         to_track_mask,


### PR DESCRIPTION
Ports two fixes from #30451:

- `mamba_radix_cache.py`: when `cache_len` is 0 (or `None`), free the unprotected KV + mamba slots and return early instead of inserting an empty `key_len=0` ghost node. Such empty nodes would otherwise serve as a stale mamba COW source (`best_value_len=0`) and poison later `match_prefix` calls.
- `spec_utils.py`: clamp `to_track_ith` with `torch.minimum(tracking_point - seq_lens_pre_verify, accept_lens - 1)`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32459468123](https://github.com/sgl-project/sglang/actions/runs/32459468123)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32459467816](https://github.com/sgl-project/sglang/actions/runs/32459467816)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32459467951](https://github.com/sgl-project/sglang/actions/runs/32459467951)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->