### PR TITLE
[PD] Bound mooncake failed-session blacklist with a TTL

### DIFF
--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -211,6 +211,19 @@ class MooncakeKVManager(CommonKVManager):
             self.start_prefill_thread()
             self.session_failures = defaultdict(int)
             self.failed_sessions = set()
+            # A session that fails once is blacklisted until this TTL
+            # expires, not permanently. A single aborted request can cause
+            # exactly one transfer failure without indicating the session
+            # itself is dead; without an expiry, every future request routed
+            # through that session is silently dropped until the periodic
+            # probe (SGLANG_ENABLE_FAILED_SESSION_PROBE) happens to succeed,
+            # which can wedge decode in KVPoll.WaitingForInput for its full
+            # timeout. A session that is genuinely dead will simply fail
+            # again on the next attempt and get re-blacklisted.
+            self.failed_session_expiry = {}
+            self.failed_session_blacklist_ttl = (
+                envs.SGLANG_FAILED_SESSION_BLACKLIST_TTL_S.get()
+            )
             # Per-room count of chunks not yet transferred; teardown waits for
             # zero so a deferred chunk is not dropped by an early conclude.
             self._staging_outstanding = defaultdict(int)
@@ -1693,7 +1706,7 @@ class MooncakeKVManager(CommonKVManager):
                     if not req.is_dummy:
                         # Early exit if the request has failed
                         with self.session_lock:
-                            if req.mooncake_session_id in self.failed_sessions:
+                            if self._session_blacklisted(req.mooncake_session_id):
                                 self.record_failure(
                                     kv_chunk.room,
                                     f"Decode instance could be dead, remote mooncake session {req.mooncake_session_id} is not alive",
@@ -1834,9 +1847,9 @@ class MooncakeKVManager(CommonKVManager):
                         if ret != 0:
                             with self.session_lock:
                                 self.session_failures[req.mooncake_session_id] += 1
-                                # Failures should never happen if the session is not dead, if the session fails once, mark it as failed
+                                # Failures should never happen if the session is not dead, if the session fails once, blacklist it for failed_session_blacklist_ttl
                                 if self.session_failures[req.mooncake_session_id] >= 1:
-                                    self.failed_sessions.add(req.mooncake_session_id)
+                                    self._blacklist_session(req.mooncake_session_id)
                                     logger.error(
                                         f"Session {req.mooncake_session_id} failed."
                                     )
@@ -1868,9 +1881,7 @@ class MooncakeKVManager(CommonKVManager):
                                         self.session_failures[
                                             req.mooncake_session_id
                                         ] += 1
-                                        self.failed_sessions.add(
-                                            req.mooncake_session_id
-                                        )
+                                        self._blacklist_session(req.mooncake_session_id)
                                     self.record_failure(
                                         kv_chunk.room,
                                         f"Failed to send state components of {kv_chunk.room} to "
@@ -2080,6 +2091,7 @@ class MooncakeKVManager(CommonKVManager):
                             self.failed_sessions.remove(mooncake_session_id)
                         if mooncake_session_id in self.session_failures:
                             del self.session_failures[mooncake_session_id]
+                        self.failed_session_expiry.pop(mooncake_session_id, None)
                     logger.debug(
                         f"Register KVArgs from {mooncake_session_id} successfully"
                     )
@@ -2245,6 +2257,30 @@ class MooncakeKVManager(CommonKVManager):
             if bootstrap_room not in self.request_status:
                 self.addr_to_rooms_tracker[bootstrap_addr].discard(bootstrap_room)
 
+    def _blacklist_session(self, session_id: str) -> None:
+        # Caller must hold self.session_lock.
+        self.failed_sessions.add(session_id)
+        self.failed_session_expiry[session_id] = (
+            time.time() + self.failed_session_blacklist_ttl
+        )
+
+    def _session_blacklisted(self, session_id: str) -> bool:
+        # Caller must hold self.session_lock. Self-clears on TTL expiry so a
+        # transient failure only blocks the session for a bounded window; a
+        # session that is still actually dead fails the next attempt and is
+        # re-blacklisted by _blacklist_session.
+        if session_id not in self.failed_sessions:
+            return False
+        expiry = self.failed_session_expiry.get(session_id)
+        if expiry is not None and time.time() >= expiry:
+            self.failed_sessions.discard(session_id)
+            self.failed_session_expiry.pop(session_id, None)
+            logger.warning(
+                "Session %s blacklist TTL expired; allowing retry", session_id
+            )
+            return False
+        return True
+
     def _run_one_probe_pass(self) -> None:
         with self.session_lock:
             snapshot = list(self.failed_sessions)
@@ -2263,6 +2299,7 @@ class MooncakeKVManager(CommonKVManager):
                     was_blacklisted = session_id in self.failed_sessions
                     self.failed_sessions.discard(session_id)
                     self.session_failures.pop(session_id, None)
+                    self.failed_session_expiry.pop(session_id, None)
                 if was_blacklisted:
                     logger.info(
                         "Session %s recovered via probe; un-blacklisted",

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -703,6 +703,7 @@ class Envs:
     SGLANG_MOONCAKE_SEND_AUX_TCP = EnvBool(False)
     SGLANG_ENABLE_FAILED_SESSION_PROBE = EnvBool(False)
     SGLANG_FAILED_SESSION_PROBE_INTERVAL_S = EnvFloat(30.0)
+    SGLANG_FAILED_SESSION_BLACKLIST_TTL_S = EnvFloat(120.0)
 
     # ===================================================================
     # Mooncake store

--- a/test/registered/unit/disaggregation/test_mooncake_failed_session_ttl.py
+++ b/test/registered/unit/disaggregation/test_mooncake_failed_session_ttl.py
@@ -1,0 +1,62 @@
+import threading
+import time
+import unittest
+
+from sglang.srt.disaggregation.mooncake.conn import MooncakeKVManager
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+def _make_manager(ttl: float) -> MooncakeKVManager:
+    mgr = MooncakeKVManager.__new__(MooncakeKVManager)
+    mgr.session_lock = threading.Lock()
+    mgr.failed_sessions = set()
+    mgr.failed_session_expiry = {}
+    mgr.failed_session_blacklist_ttl = ttl
+    return mgr
+
+
+class TestMooncakeFailedSessionTTL(unittest.TestCase):
+    def test_blacklisted_session_is_reported_before_ttl_expires(self):
+        mgr = _make_manager(ttl=60.0)
+        with mgr.session_lock:
+            mgr._blacklist_session("session-a")
+
+        with mgr.session_lock:
+            self.assertTrue(mgr._session_blacklisted("session-a"))
+        self.assertIn("session-a", mgr.failed_sessions)
+
+    def test_blacklist_self_clears_after_ttl_expires(self):
+        mgr = _make_manager(ttl=60.0)
+        with mgr.session_lock:
+            mgr._blacklist_session("session-a")
+            # Simulate TTL elapsing without waiting in real time.
+            mgr.failed_session_expiry["session-a"] = time.time() - 1
+
+        with mgr.session_lock:
+            self.assertFalse(mgr._session_blacklisted("session-a"))
+        self.assertNotIn("session-a", mgr.failed_sessions)
+        self.assertNotIn("session-a", mgr.failed_session_expiry)
+
+    def test_unrelated_session_is_never_blacklisted(self):
+        mgr = _make_manager(ttl=60.0)
+        with mgr.session_lock:
+            mgr._blacklist_session("session-a")
+            self.assertFalse(mgr._session_blacklisted("session-b"))
+
+    def test_repeated_failure_after_ttl_expiry_re_blacklists(self):
+        # A genuinely dead session keeps failing on retry and must be
+        # blacklisted again -- the TTL only bounds a single transient
+        # failure, it does not permanently whitelist a session.
+        mgr = _make_manager(ttl=60.0)
+        with mgr.session_lock:
+            mgr._blacklist_session("session-a")
+            mgr.failed_session_expiry["session-a"] = time.time() - 1
+            self.assertFalse(mgr._session_blacklisted("session-a"))
+            mgr._blacklist_session("session-a")
+            self.assertTrue(mgr._session_blacklisted("session-a"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`MooncakeKVManager.failed_sessions` blacklists a `mooncake_session_id` permanently on the first transfer failure (`self.failed_sessions.add(...)`, in the `transfer_worker` loop's `if ret != 0:` branch — i.e. the actual RDMA/network send call returned an error, which in practice means a genuine network issue or a dead remote), and there is no expiry other than the optional periodic probe (`SGLANG_ENABLE_FAILED_SESSION_PROBE`) succeeding or a fresh registration for that session.

**Edit:** an earlier version of this description incorrectly said a client-side `AbortReq` triggers this. It does not — `abort()` in `common/conn.py` only calls `record_failure`/`update_status(KVPoll.Failed)` for that one room and never touches `failed_sessions`/`session_failures`. Thanks @ShangmingCai for the correction. The actual trigger is any transfer send that returns non-zero, which is dominated by real network issues / a dead remote, but nothing about that failure indicates the *session* itself (as opposed to that one request, or that moment in time) is unrecoverable — see below.

Regardless of what triggers the first failure, once a session is blacklisted every subsequent request routed through it is silently skipped by the early-exit check in the transfer worker (`if req.mooncake_session_id in self.failed_sessions: continue` / `record_failure(... "is not alive")`). Decode never receives its KV chunk for those requests and eventually times out in `KVPoll.WaitingForInput` after its full timeout, while `/health` and the detokenizer heartbeat stay green the entire time. This is the same shape as #21837.

`SGLANG_ENABLE_FAILED_SESSION_PROBE` exists to recover from this, but recovery depends on `send_probe` succeeding against the same session. If the probe does not succeed for any reason, the blacklist has no other way to clear and the outage is unbounded — a transient network blip that would have cleared on the next real request is instead permanent until something else (probe, or a fresh registration from a worker restart) clears it.

We hit this on a live PD deployment: a decode instance's session got permanently blacklisted (we saw connection-refused errors against that decode instance around the same time, consistent with a real network/remote issue rather than an abort), `SGLANG_ENABLE_FAILED_SESSION_PROBE=1` was already set but did not recover it, and it took roughly 4 hours (until someone manually restarted the decode worker) before it was noticed and fixed, because health checks and heartbeats gave no signal that anything was wrong.

## Modifications

Adds a bounded, self-clearing TTL on top of the existing blacklist/probe mechanism:

- New env `SGLANG_FAILED_SESSION_BLACKLIST_TTL_S` (default `120.0`).
- `_blacklist_session()` / `_session_blacklisted()` helpers centralize the blacklist add/check logic (both call sites that used to do `self.failed_sessions.add(...)` directly now go through `_blacklist_session`; the one read site now calls `_session_blacklisted`). Both must be called with `self.session_lock` held, matching the existing locking convention at each call site.
- A session is still blacklisted immediately on failure, exactly as before. `_session_blacklisted()` additionally checks whether the TTL has elapsed and, if so, discards the entry and allows the next request to retry.
- A session that is genuinely dead simply fails the retry and gets re-blacklisted by `_blacklist_session()` — this only bounds the outage caused by a *transient* failure, it does not mask a persistently broken session.
- The three places that already clear `failed_sessions`/`session_failures` (successful re-registration, probe success) now also clear the new `failed_session_expiry` entry, so there's no stale expiry left behind after an explicit recovery.

## Accuracy Tests

N/A — logic-only change to failure bookkeeping, no effect on model output.

## Speed Tests and Profiling

N/A — the added TTL check is an O(1) dict lookup guarded by the same lock already taken on every call site; no new locks or hot-path allocations.

## Checklist

- [x] Format code with pre-commit — ran `isort==7.0.0`, `black==26.1.0`, `ruff==0.15.1` (pinned versions from `.pre-commit-config.yaml`) against the changed files; no further changes needed.
- [x] Add unit tests — added `test/registered/unit/disaggregation/test_mooncake_failed_session_ttl.py` covering: blacklisted-before-TTL, self-clear-after-TTL, unrelated session unaffected, and re-blacklist-after-TTL-expiry-on-repeat-failure. **I could not actually execute this test locally** (torch/torchvision ABI mismatch in my environment, unrelated to this change) — verified with `python -m py_compile` only. Please let CI run it; happy to fix if it doesn't pass as expected.
- [ ] Update documentation — no user-facing docs reference `SGLANG_ENABLE_FAILED_SESSION_PROBE`/blacklist behavior that I could find to update; let me know if I missed one.
- N/A Accuracy/Speed benchmarks (see above).
- [x] Code style guidance followed (matches surrounding style/locking convention in this file).