### PR TITLE
[Quant] SM120: opt-in NVFP4 (W4A4) serving for ModelOpt FP8 column-parallel projections

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -872,6 +872,9 @@ class Envs:
     SGLANG_CPU_QUANTIZATION = EnvBool(False)
     SGLANG_USE_DYNAMIC_MXFP4_LINEAR = EnvBool(False)
     SGLANG_FORCE_FP8_MARLIN = EnvBool(False)
+    # Opt-in: requantize ModelOpt FP8 column-parallel projections to NVFP4 at
+    # load time and serve them W4A4 through the FP4 GEMM path (SM120 only).
+    SGLANG_ENABLE_MODELOPT_FP8_PROJ_NVFP4 = EnvBool(False)
     SGLANG_MOE_NVFP4_DISPATCH = EnvBool(False)
     SGLANG_NVFP4_CKPT_FP8_GEMM_IN_ATTN = EnvBool(False)
     SGLANG_NVFP4_CKPT_FP8_NEXTN_MOE = EnvBool(False)

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -485,6 +485,50 @@ class ModelOptFp8Config(ModelOptQuantConfig):
         )
 
 
+def _maybe_convert_fp8_proj_to_nvfp4(layer: torch.nn.Module) -> None:
+    """Opt-in: requantize an FP8 column-parallel projection to NVFP4 at load time
+    so apply() serves it W4A4 through the FP4 GEMM path instead of the FP8 one.
+
+    On SM120 these GEMMs stream their weights at the DRAM wall, so halving the
+    weight bytes is the speed lever kernel choice cannot provide. Only
+    column-parallel projections qualify: their inputs come out of layernorm and
+    tolerate the extra quantization error, while converting row-parallel output
+    projections (which read heavy-tailed attention outputs) collapses generation
+    quality. Enable with SGLANG_ENABLE_MODELOPT_FP8_PROJ_NVFP4 and gate the
+    deployment on an accuracy eval; quality is checkpoint-dependent.
+    """
+    layer.fp8_proj_nvfp4 = None
+    if not envs.SGLANG_ENABLE_MODELOPT_FP8_PROJ_NVFP4.get():
+        return
+    if not (is_cuda() and is_sm120_supported() and enable_flashinfer_fp4_gemm):
+        return
+    from sglang.srt.layers.linear import ColumnParallelLinear
+
+    if not isinstance(layer, ColumnParallelLinear):
+        return
+    if layer.input_scale is None or layer.input_scale.numel() != 1:
+        return
+    # layer.weight is the [K, N] transposed view of an [N, K]-contiguous buffer.
+    w_t = layer.weight.t()
+    n, k = w_t.shape
+    # FlashInfer CUTLASS FP4 alignment: scale rows pad to 128, K/16 groups to 4.
+    if n % 128 != 0 or k % 64 != 0 or (k // 16) % 4 != 0:
+        return
+    scale = layer.weight_scale.float()
+    w = w_t.float() * (scale.view(-1, 1) if scale.numel() > 1 else scale)
+    w = w.to(torch.bfloat16)
+    weight_scale_2 = (w.abs().amax().float() / (448.0 * 6.0)).reshape(1)
+    wq, wsf = fp4_quantize(w, (1.0 / weight_scale_2).to(torch.float32))
+    input_scale_2 = (layer.input_scale.float() / 6.0).reshape(1)
+    layer.fp8_proj_nvfp4 = (
+        wq.T,
+        wsf.view(torch.float8_e4m3fn).T,
+        (input_scale_2 * weight_scale_2).to(torch.float32).reshape(1),
+        (1.0 / input_scale_2).to(torch.float32).reshape(1),
+        n,
+    )
+
+
 class ModelOptFp8LinearMethod(LinearMethodBase):
     """Linear method for ModelOpt static FP8 quantization.
 
@@ -597,6 +641,7 @@ class ModelOptFp8LinearMethod(LinearMethodBase):
                 .reshape(1)
                 .contiguous()
             )
+        _maybe_convert_fp8_proj_to_nvfp4(layer)
         if self.use_marlin:
             prepare_fp8_layer_for_marlin(layer)
             # Marlin uses FP8 weights with unquantized activations.
@@ -618,6 +663,12 @@ class ModelOptFp8LinearMethod(LinearMethodBase):
                 size_n=layer.output_size_per_partition,
                 size_k=layer.input_size_per_partition,
                 bias=bias,
+            )
+        if layer.fp8_proj_nvfp4 is not None and bias is None and x.dim() == 2:
+            wq_t, wsf_t, alpha, input_scale_inv, out_features = layer.fp8_proj_nvfp4
+            x_fp4, x_scale_interleaved = fp4_quantize(x, input_scale_inv)
+            return fp4_gemm(
+                x_fp4, wq_t, x_scale_interleaved, wsf_t, alpha, x.dtype, out_features
             )
         if (
             self.use_sm120_gemv


### PR DESCRIPTION
# [Quant] SM120: opt-in NVFP4 (W4A4) serving for ModelOpt FP8 column-parallel projections

## Motivation

On SM120 (RTX PRO 6000 Blackwell), bs=1 decode of a ModelOpt `MIXED_PRECISION`
checkpoint (NVFP4 MLP + FP8 attention/linear-attention projections) is weight-bandwidth
bound: in torch-profiler traces the FP8 projection GEMMs stream their weights at
1.18-1.35 TB/s, i.e. at this card's practical DRAM wall. At the wall, kernel selection
cannot buy speed; halving the weight bytes can.

This PR adds an **opt-in** that requantizes the FP8 **column-parallel** projections
(qkv-style input projections) to NVFP4 at load time and serves them W4A4 through the
existing FlashInfer FP4 GEMM path. **No new kernels** — it reuses `fp4_quantize` and the
`fp4_gemm` custom op that the checkpoint's NVFP4 layers already use.

Why only column-parallel: their inputs come out of layernorm and tolerate the extra
quantization error, while converting the row-parallel output projections (which read
heavy-tailed attention / linear-attention core outputs) collapses generation quality
outright (GSM8K goes to ~0). The `isinstance(layer, ColumnParallelLinear)` gate encodes
that boundary.

## Mechanism

- Load time (`_maybe_convert_fp8_proj_to_nvfp4`): dequantize the fp8 weight, NVFP4-quantize
  with per-16 block scales (`weight_scale_2 = amax / (448*6)`), derive the activation
  global scale from the checkpoint's per-tensor `input_scale`
  (`input_scale_2 = input_scale / 6`), store `alpha = input_scale_2 * weight_scale_2`.
- `apply()`: `fp4_quantize(x)` + `fp4_gemm(...)` — identical code path to the NVFP4 layers,
  backend autotuned.
- Guards: SM120 + FlashInfer FP4 available, per-tensor `input_scale`, N % 128 == 0,
  K % 64 == 0, (K/16) % 4 == 0. Anything else keeps the FP8 path.
- Off by default (`SGLANG_ENABLE_MODELOPT_FP8_PROJ_NVFP4`); accuracy is
  checkpoint-dependent, gate deployments on an eval.

## Benchmarks

RTX PRO 6000 Blackwell (SM120), single GPU, 27B hybrid (GDN + full attention) model with
a ModelOpt mixed NVFP4/FP8 checkpoint; `bench_serving --dataset-name random
--random-input-len 1024 --random-output-len 512 --num-prompts 10 --max-concurrency 1`,
seed-paired lanes on the same GPU, this PR's branch.

**Plain autoregressive decode (bs=1, fixed 512-token outputs — deterministic length,
so the delta is pure speed):**

| seed | baseline (FP8 proj) | this PR (NVFP4 proj) | speedup |
|---|---|---|---|
| 1234 | 66.99 tok/s (TPOT 14.71 ms) | 74.29 tok/s (TPOT 13.26 ms) | +10.9% |
| 42 | 67.56 tok/s (TPOT 14.68 ms) | 74.65 tok/s (TPOT 13.26 ms) | +10.5% |

**Accuracy (GSM8K, 1319 questions, `sglang.test.run_eval`):** baseline 0.964 vs this PR 0.962 (and 0.965 vs 0.968 in an earlier pre-rebase round) - within run-to-run noise in both directions.

## Limitations

- SM120 only: the converted weights use the FlashInfer CUTLASS SM120 FP4 layout. Other
  Blackwell parts default to a different FP4 backend layout and are not covered here.
- Requires per-tensor activation `input_scale` from the checkpoint.
- Expert opt-in flag, not a default: whether the column-parallel projections tolerate
  W4A4 is a property of the checkpoint's calibration; validate with an eval before use.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add benchmarks in this PR description.
- [x] Accuracy validated (GSM8K, both lanes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
