### PR TITLE
[MiniMax-M3-MXFP8] Fuse the ~20-kernel decode elementwise/fill/copy small-op tail

### DIFF
--- a/python/sglang/kernels/ops/attention/minimax_sparse/prefill/topk_sparse.py
+++ b/python/sglang/kernels/ops/attention/minimax_sparse/prefill/topk_sparse.py
@@ -1,12 +1,25 @@
 # Copyright 2025 XunhaoLai. All rights reserved.
 
+import os
 from typing import Optional
 
 import torch
 import triton
 import triton.language as tl
 
-from ..common.utils import check_sparse_kv_fp8, get_cu_seqblocks, robust_allocator
+from ..common.utils import (
+    SPARSE_KV_FP8_DTYPES,
+    check_sparse_kv_fp8,
+    get_cu_seqblocks,
+    robust_allocator,
+)
+
+# Prefill M-bucket split for per-length autotune pinning (SILOTIGER-762). The
+# observed prefill passes cluster into a small partial-chunk tail and a large
+# ~16k chunk; the threshold sits in the empty gap between them so the autotuner
+# caches/pins one winning occupancy config per prefill-length bucket instead of
+# reusing one winner across all M.
+_PREFILL_M_BUCKET_THRESHOLD = 2048
 
 
 @triton.heuristics(
@@ -25,12 +38,16 @@ from ..common.utils import check_sparse_kv_fp8, get_cu_seqblocks, robust_allocat
     }
 )
 @triton.autotune(
-    # Configs that fail to compile on the target arch are skipped, so widening
-    # the num_warps x num_stages grid only adds candidates, never a bad kernel.
+    # num_stages is capped at 3. With the bq8 prefill tile, num_stages=4 drives the
+    # ROCm `tritonamdgpu-block-pingpong` pass to crash the compiler HARD on gfx950
+    # (RuntimeError: PassManager::run failed) instead of being pruned -- that
+    # exception is not caught by the autotuner and takes the whole scheduler down.
+    # ns 2/3 are verified to compile and cover the useful pipeline depth for this
+    # gather-bound sparse kernel; deeper stages don't help here (SILOTIGER-762).
     configs=[
         triton.Config({}, num_warps=nw, num_stages=ns)
         for nw in (2, 4, 8)
-        for ns in (2, 3, 4)
+        for ns in (2, 3)
     ],
     key=[
         "BLOCK_SIZE_Q",
@@ -38,6 +55,10 @@ from ..common.utils import check_sparse_kv_fp8, get_cu_seqblocks, robust_allocat
         "qk_head_dim",
         "v_head_dim",
         "gqa_group_size",
+        # M-bucket (0=small tail, 1=large ~16k chunk): the best occupancy config
+        # differs by prefill-pass length, so cache/pin the autotune winner per
+        # bucket instead of reusing one winner across all M (SILOTIGER-762).
+        "m_bucket",
     ],
 )
 @triton.jit
@@ -64,6 +85,9 @@ def _gqa_share_sparse_fwd_kernel(
     max_topk,
     # q loop num
     num_q_loop,
+    # M-bucket id: unused in the kernel body, present only so @triton.autotune
+    # keys on it and caches the best config per prefill-length bucket.
+    m_bucket,
     # sm_scale
     sm_scale,
     # stride
@@ -97,8 +121,15 @@ def _gqa_share_sparse_fwd_kernel(
     HAS_SINK: tl.constexpr,
     USE_TMA: tl.constexpr,
     IS_FP8: tl.constexpr,
+    FP8_PV: tl.constexpr,
+    FP8_QK: tl.constexpr,
+    Q_IS_FP8: tl.constexpr,
 ):
     sm_scale_log2e = sm_scale * 1.4426950409
+    # bf16/fp16 compute dtype for internal casts (e.g. widening the fp8 K/V
+    # cache). Taken from the OUTPUT element type rather than q.dtype so the "Q
+    # arrives as fp8" fast path (Q_IS_FP8) still widens K/V to bf16, not fp8.
+    compute_dtype = o_ptr.dtype.element_ty
     # get batch id and head id
     pid_q = tl.program_id(0)
     pid_kh = tl.program_id(1)
@@ -177,6 +208,27 @@ def _gqa_share_sparse_fwd_kernel(
             lse_i = tl.full((BLOCK_SIZE_QH,), float("-inf"), dtype=tl.float32)
         acc_o = tl.full((BLOCK_SIZE_QH, BLOCK_SIZE_VD), 0, dtype=tl.float32)
         q = tl.reshape(q, BLOCK_SIZE_QH, BLOCK_SIZE_KD)
+        # Select the Q operand + score scale for the Q@K dot (SILOTIGER-762):
+        #   Q_IS_FP8 -- Q already fp8 (unit-scaled like the fp8 K cache): consume
+        #     it natively, no in-kernel rounding (the lossless "no upcast" path).
+        #   FP8_QK   -- Q arrives bf16: per-tensor quantize it so amax(|Q|) maps
+        #     to the e4m3 finite max (448), then fold the inverse scale into
+        #     qk_scale. Overflow-safe (max->448, no NaN); the amax+cast run once
+        #     per q-block (not per K tile), so the cost is negligible.
+        #   else     -- keep Q at the bf16 compute dtype (K is widened to match).
+        # q_qk is kept separate from `q` so the sink dot still uses bf16.
+        qk_scale = sm_scale_log2e
+        if Q_IS_FP8:
+            if IS_FP8:
+                q_qk = q  # fp8 Q x fp8 K -> native fp8 MFMA, lossless in-kernel
+            else:
+                q_qk = q.to(compute_dtype)  # fp8 Q, bf16 K -> widen Q to match
+        elif FP8_QK and IS_FP8:
+            q_scale = 448.0 / tl.maximum(tl.max(tl.abs(q)), 1e-9)
+            q_qk = (q * q_scale).to(tl.float8e4nv)
+            qk_scale = sm_scale_log2e / q_scale
+        else:
+            q_qk = q
         # sparse attention
         for i in range(real_topk):
             # get current block start index (absolute K position)
@@ -201,26 +253,27 @@ def _gqa_share_sparse_fwd_kernel(
                 other=0.0,
             )
             if IS_FP8:
-                # fp8 main K cache is unit-scaled; widen to the Q compute dtype
-                # before the tl.dot (compiled out when the cache is bf16).
-                k = k.to(q.dtype)
+                if Q_IS_FP8:
+                    # Q already fp8 -> native fp8 Q@K, keep K fp8 (no widen).
+                    pass
+                elif FP8_QK:
+                    # in-kernel fp8 Q@K -> keep K fp8 (drops the widen cvt).
+                    pass
+                else:
+                    # fp8 main K cache is unit-scaled; widen to the compute dtype
+                    # before the tl.dot (compiled out when the cache is bf16).
+                    k = k.to(compute_dtype)
             # compute qk
             qk = tl.zeros((BLOCK_SIZE_Q, BLOCK_SIZE_H, BLOCK_SIZE_K), dtype=tl.float32)
             # causal mask
             qk += tl.where(off_q_k[:, None, :] >= c, 0, float("-inf"))
             qk = tl.reshape(qk, BLOCK_SIZE_QH, BLOCK_SIZE_K)
             # [BLOCK_SIZE_QH, qk_head_dim] @ [qk_head_dim, BLOCK_SIZE_K]
-            #   -> [BLOCK_SIZE_QH, BLOCK_SIZE_K]
-            qk += tl.dot(q, k) * sm_scale_log2e
+            #   -> [BLOCK_SIZE_QH, BLOCK_SIZE_K]. qk_scale folds the FP8_QK
+            # Q-scale inverse into sm_scale (== sm_scale_log2e when FP8_QK is off).
+            qk += tl.dot(q_qk, k) * qk_scale
             # K boundary mask: positions beyond seq_len contribute -inf
             qk += tl.where(pos_mask[None, :], 0, float("-inf"))
-            # compute m_ij and l_ij
-            m_ij = tl.maximum(m_i, tl.max(qk, axis=1))
-            p = tl.exp2(qk - m_ij[:, None])
-            l_ij = tl.sum(p, axis=1)
-            # scale acc_o
-            acc_o_scale = tl.exp2(m_i - m_ij)
-            acc_o = acc_o * acc_o_scale[:, None]
             # paged load V
             v = tl.load(
                 v_cache_ptr
@@ -231,11 +284,26 @@ def _gqa_share_sparse_fwd_kernel(
                 other=0.0,
             )
             if IS_FP8:
-                # Widen V so `p.to(v.dtype)` casts P to the compute dtype rather
-                # than to fp8 (which would wreck attention-weight precision).
-                v = v.to(q.dtype)
-            p = p.to(v.dtype)
-            acc_o += tl.dot(p, v)
+                if FP8_PV:
+                    # keep V in fp8 for a fp8 P@V MFMA (drops the widen cvt).
+                    pass
+                else:
+                    # Widen V so `p.to(v.dtype)` casts P to the compute dtype
+                    # rather than fp8 (which would wreck attn-weight precision).
+                    v = v.to(compute_dtype)
+            # online softmax: running max + per-tile acc_o rescale.
+            m_ij = tl.maximum(m_i, tl.max(qk, axis=1))
+            p = tl.exp2(qk - m_ij[:, None])
+            l_ij = tl.sum(p, axis=1)
+            acc_o_scale = tl.exp2(m_i - m_ij)
+            acc_o = acc_o * acc_o_scale[:, None]
+            if FP8_PV and IS_FP8:
+                # cast P to fp8 for the P@V MFMA (V kept fp8 above). P in [0, 1]
+                # here, so the clamp only guards a stray rounding overflow.
+                p_cast = tl.minimum(p, 448.0).to(v.dtype)
+            else:
+                p_cast = p.to(v.dtype)
+            acc_o += tl.dot(p_cast, v)
             # update statistics
             m_i = m_ij
             lse_i = m_ij + tl.log2(tl.exp2(lse_i - m_ij) + l_ij)
@@ -276,6 +344,11 @@ def flash_prefill_with_gqa_share_sparse(
 ) -> torch.Tensor:
     triton.set_allocator(robust_allocator)
     is_fp8 = check_sparse_kv_fp8(q, k_cache, v_cache, label="prefill")
+    # SILOTIGER-762: Q normally arrives bf16/fp16 (enforced by check_sparse_kv_fp8),
+    # so this is False today and the native-fp8-Q "no rounding" path stays dormant
+    # (Q_IS_FP8 is compiled out). Detect it anyway so a future pre-quantized-Q
+    # caller lights up the lossless path without another kernel change.
+    q_is_fp8 = q.dtype in SPARSE_KV_FP8_DTYPES
     assert block_size_q in {1, 2, 4, 8, 16, 32, 64}
     assert block_size_k in {16, 32, 64, 128}
     # shape
@@ -296,14 +369,29 @@ def flash_prefill_with_gqa_share_sparse(
         cu_seqblocks_q, max_seqblock_q, _, _, _, _ = get_cu_seqblocks(
             cu_seqlens, max_seqlen_q, block_size_q, block_size_k
         )
-    # output tensor
-    o = torch.empty(total_q, num_q_heads, v_head_dim, device=q.device, dtype=q.dtype)
+    # output tensor. Output stays a real compute dtype even when Q is fp8-storage.
+    out_dtype = (
+        q.dtype if q.dtype in (torch.bfloat16, torch.float16) else torch.bfloat16
+    )
+    o = torch.empty(
+        total_q, num_q_heads, v_head_dim, device=q.device, dtype=out_dtype
+    )
     # launch kernel
     num_q_loop = (
         max_seqblock_q // 131072 + 1
     )  # calculate multiple queries in one kernel if seqlence length is too long
     BLOCK_SIZE_Q = triton.next_power_of_2(block_size_q)
     BLOCK_SIZE_K = triton.next_power_of_2(block_size_k)
+    # M-bucket for per-length autotune pinning (SILOTIGER-762): the best occupancy
+    # config differs between the small partial-chunk tail and the large ~16k
+    # prefill chunk. Two buckets; the threshold sits in the gap between them.
+    m_bucket = 0 if max_seqlen_q <= _PREFILL_M_BUCKET_THRESHOLD else 1
+    # SILOTIGER-762 fp8 attention datapath. Both flags consume the already-fp8 KV
+    # cache natively instead of upcasting it to bf16, and default ON; disable
+    # either with SGLANG_MINIMAX_SPARSE_FP8_PV=0 / SGLANG_MINIMAX_SPARSE_FP8_QK=0.
+    # Both are no-ops unless the KV cache is fp8.
+    fp8_pv = os.environ.get("SGLANG_MINIMAX_SPARSE_FP8_PV", "1") == "1"
+    fp8_qk = os.environ.get("SGLANG_MINIMAX_SPARSE_FP8_QK", "1") == "1"
     grid = (
         triton.cdiv(triton.cdiv(max_seqlen_q, block_size_q), num_q_loop),
         num_k_heads,
@@ -329,6 +417,7 @@ def flash_prefill_with_gqa_share_sparse(
         v_head_dim,
         topk,
         num_q_loop,
+        m_bucket,
         sm_scale,
         q.stride(0),
         q.stride(1),
@@ -352,5 +441,8 @@ def flash_prefill_with_gqa_share_sparse(
         BLOCK_SIZE_K=BLOCK_SIZE_K,
         USE_TMA=use_tma,
         IS_FP8=is_fp8,
+        FP8_PV=fp8_pv,
+        FP8_QK=fp8_qk,
+        Q_IS_FP8=q_is_fp8,
     )
     return o

--- a/python/sglang/kernels/ops/attention/minimax_sparse/prefill/topk_sparse.py
+++ b/python/sglang/kernels/ops/attention/minimax_sparse/prefill/topk_sparse.py
@@ -373,9 +373,7 @@ def flash_prefill_with_gqa_share_sparse(
     out_dtype = (
         q.dtype if q.dtype in (torch.bfloat16, torch.float16) else torch.bfloat16
     )
-    o = torch.empty(
-        total_q, num_q_heads, v_head_dim, device=q.device, dtype=out_dtype
-    )
+    o = torch.empty(total_q, num_q_heads, v_head_dim, device=q.device, dtype=out_dtype)
     # launch kernel
     num_q_loop = (
         max_seqblock_q // 131072 + 1

--- a/python/sglang/kernels/ops/kvcache/cache_move.py
+++ b/python/sglang/kernels/ops/kvcache/cache_move.py
@@ -316,19 +316,16 @@ def store_k_slots_kernel(
     ROW_DIM: tl.constexpr,  # head_num * head_dim
     BLOCK: tl.constexpr,
 ):
-    """Token-parallel scatter of one K tensor into a slot-major buffer.
+    """Writes ``k_buffer[loc[i]] = src[i]``, one program per (token, row block).
 
-    Grid: ``(N, ceil(ROW_DIM / BLOCK))`` -- one program per (token, row block).
-    Writes ``k_buffer[loc[i]] = src[i]`` for ``i in [0, N)``.
-
-    Cuda-graph safe: no host branching on tensor values and no ``.item()``.
+    Grid ``(N, ceil(ROW_DIM / BLOCK))``. CUDA-graph safe: no host branching on tensor
+    values, no ``.item()``.
     """
     pid_n = tl.program_id(0)
     pid_b = tl.program_id(1)
 
     loc = tl.load(loc_ptr + pid_n).to(tl.int64)
-    # Padded / inactive rows are signalled by a negative slot; skipping them
-    # matches reshape_and_cache_flash, which consumes the same `loc`.
+    # Negative slot = padded row, as in reshape_and_cache_flash, which shares this `loc`.
     if loc < 0:
         return
 
@@ -339,19 +336,10 @@ def store_k_slots_kernel(
 
 
 def store_k_slots(k_buffer: torch.Tensor, src: torch.Tensor, loc: torch.Tensor) -> None:
-    """Scatter ``src[i]`` into ``k_buffer[loc[i]]`` in one launch.
+    """Scatter ``src[i]`` into slot-major ``k_buffer[loc[i]]`` in place, one launch.
 
-    Replaces ``k_buffer[loc] = src`` (ATen advanced indexing, which dispatches
-    an ``index_put`` kernel) for a K-only cache.
-
-    Contract:
-        - ``k_buffer``: slot-major ``(num_slots, head_num, head_dim)``.
-        - ``src``: ``(N, head_num, head_dim)`` with the same dtype.
-        - both contiguous in the trailing ``(head_num, head_dim)`` dims, so the
-          kernel can address them as one flat ``ROW_DIM`` axis.
-        - ``loc``: 1-D, N elements; negative entries are skipped.
-
-    Returns nothing; writes in place.
+    Negative ``loc`` entries are skipped. The trailing ``(head_num, head_dim)`` dims must
+    be contiguous, so the kernel can treat them as one flat axis.
     """
     if loc.numel() == 0:
         return

--- a/python/sglang/kernels/ops/kvcache/cache_move.py
+++ b/python/sglang/kernels/ops/kvcache/cache_move.py
@@ -304,3 +304,86 @@ def store_cache_4d(
         BLOCK=BLOCK,
         num_warps=4,
     )
+
+
+@triton.jit
+def store_k_slots_kernel(
+    k_buffer_ptr,
+    src_ptr,
+    loc_ptr,
+    stride_dst_slot,
+    stride_src_row,
+    ROW_DIM: tl.constexpr,  # head_num * head_dim
+    BLOCK: tl.constexpr,
+):
+    """Token-parallel scatter of one K tensor into a slot-major buffer.
+
+    Grid: ``(N, ceil(ROW_DIM / BLOCK))`` -- one program per (token, row block).
+    Writes ``k_buffer[loc[i]] = src[i]`` for ``i in [0, N)``.
+
+    Cuda-graph safe: no host branching on tensor values and no ``.item()``.
+    """
+    pid_n = tl.program_id(0)
+    pid_b = tl.program_id(1)
+
+    loc = tl.load(loc_ptr + pid_n).to(tl.int64)
+    # Padded / inactive rows are signalled by a negative slot; skipping them
+    # matches reshape_and_cache_flash, which consumes the same `loc`.
+    if loc < 0:
+        return
+
+    off = pid_b * BLOCK + tl.arange(0, BLOCK)
+    mask = off < ROW_DIM
+    src = tl.load(src_ptr + pid_n * stride_src_row + off, mask=mask)
+    tl.store(k_buffer_ptr + loc * stride_dst_slot + off, src, mask=mask)
+
+
+def store_k_slots(k_buffer: torch.Tensor, src: torch.Tensor, loc: torch.Tensor) -> None:
+    """Scatter ``src[i]`` into ``k_buffer[loc[i]]`` in one launch.
+
+    Replaces ``k_buffer[loc] = src`` (ATen advanced indexing, which dispatches
+    an ``index_put`` kernel) for a K-only cache.
+
+    Contract:
+        - ``k_buffer``: slot-major ``(num_slots, head_num, head_dim)``.
+        - ``src``: ``(N, head_num, head_dim)`` with the same dtype.
+        - both contiguous in the trailing ``(head_num, head_dim)`` dims, so the
+          kernel can address them as one flat ``ROW_DIM`` axis.
+        - ``loc``: 1-D, N elements; negative entries are skipped.
+
+    Returns nothing; writes in place.
+    """
+    if loc.numel() == 0:
+        return
+    assert k_buffer.ndim == src.ndim == 3, (
+        f"store_k_slots: k_buffer/src must be 3-D, got {k_buffer.ndim}/{src.ndim}"
+    )
+    assert k_buffer.dtype == src.dtype, (
+        f"store_k_slots: dtype mismatch: {k_buffer.dtype} vs {src.dtype}"
+    )
+    assert k_buffer.shape[1:] == src.shape[1:], (
+        f"store_k_slots: row shape mismatch: {tuple(k_buffer.shape)} vs "
+        f"{tuple(src.shape)}"
+    )
+    assert src.shape[0] == loc.numel(), (
+        f"store_k_slots: src/loc batch mismatch: {src.shape[0]} vs {loc.numel()}"
+    )
+    for name, t in (("k_buffer", k_buffer), ("src", src)):
+        assert t.stride(-1) == 1 and t.stride(-2) == t.shape[-1], (
+            f"store_k_slots: {name} trailing dims must be contiguous; "
+            f"got stride={t.stride()}, shape={tuple(t.shape)}"
+        )
+
+    ROW_DIM = k_buffer.shape[1] * k_buffer.shape[2]
+    BLOCK = 128
+    grid = (loc.numel(), triton.cdiv(ROW_DIM, BLOCK))
+    store_k_slots_kernel[grid](
+        k_buffer,
+        src,
+        loc,
+        k_buffer.stride(0),
+        src.stride(0),
+        ROW_DIM=ROW_DIM,
+        BLOCK=BLOCK,
+        num_warps=4,
+    )

--- a/python/sglang/kernels/ops/moe/mxfp8_moe_amd_gfx95.py
+++ b/python/sglang/kernels/ops/moe/mxfp8_moe_amd_gfx95.py
@@ -140,10 +140,8 @@ def _grouped_gemm_mxfp8(
     M_routed = num_valid_tokens
     E, N, K = w.shape
     assert K % 128 == 0, f"MXFP8 native MoE requires K%128==0, got K={K}"
-    # A route filtered to expert -1 can have its row left untouched -- its block sits in
-    # the extra bucket moe_align_block_size reserves, which the kernel may skip -- so the
-    # row has to start at zero. When no route can be filtered, every row is written by the
-    # GEMM and the fill is dead: one full-tensor kernel per GEMM per layer.
+    # Rows for routes filtered to expert -1 can be left unwritten, so they must start at
+    # zero. When nothing can be filtered, the GEMM writes every row and the fill is dead.
     alloc = torch.zeros if may_filter_routes else torch.empty
     out = alloc((M_routed, N), dtype=out_dtype, device=a_q.device)
     if a_div == top_k and M_routed <= 32 and K >= 3072:
@@ -285,13 +283,11 @@ def fused_moe_mxfp8_native(
         topk_ids = topk_ids.to(torch.int32, copy=True)
         topk_ids.masked_fill_((topk_ids < 0) | (topk_ids >= local_num_experts), -1)
     else:
-        # Every expert is local, so router ids are already valid local ids and the
-        # clamp above cannot change any of them. Skipping it drops 5 tiny kernels
-        # per MoE layer; `to` is a no-op when the ids are already int32.
+        # Every expert is local, so the clamp above cannot change any id. Keep the int32
+        # conversion: it is free once the ids already are int32, unlike `copy=True`.
         topk_ids = topk_ids.to(torch.int32)
 
-    # Only the two branches above can drop a route to expert -1. When neither can fire,
-    # every routed row is written by the grouped GEMM and its output zero-fill is dead.
+    # Only the branches above can drop a route to -1.
     may_filter_routes = expert_map is not None or filter_expert
 
     block_m = 64

--- a/python/sglang/kernels/ops/moe/mxfp8_moe_amd_gfx95.py
+++ b/python/sglang/kernels/ops/moe/mxfp8_moe_amd_gfx95.py
@@ -135,13 +135,17 @@ def _grouped_gemm_mxfp8(
     out_dtype: torch.dtype,
     a_div: int,
     mul_weight_by: Optional[torch.Tensor] = None,
+    may_filter_routes: bool = True,
 ) -> torch.Tensor:
     M_routed = num_valid_tokens
     E, N, K = w.shape
     assert K % 128 == 0, f"MXFP8 native MoE requires K%128==0, got K={K}"
-    # Keep zero-fill: moe_align_block_size reserves an extra expert bucket for
-    # filtered routes, which should contribute zeros if present.
-    out = torch.zeros((M_routed, N), dtype=out_dtype, device=a_q.device)
+    # A route filtered to expert -1 can have its row left untouched -- its block sits in
+    # the extra bucket moe_align_block_size reserves, which the kernel may skip -- so the
+    # row has to start at zero. When no route can be filtered, every row is written by the
+    # GEMM and the fill is dead: one full-tensor kernel per GEMM per layer.
+    alloc = torch.zeros if may_filter_routes else torch.empty
+    out = alloc((M_routed, N), dtype=out_dtype, device=a_q.device)
     if a_div == top_k and M_routed <= 32 and K >= 3072:
         BLOCK_N = 64
         num_warps = 4
@@ -286,6 +290,10 @@ def fused_moe_mxfp8_native(
         # per MoE layer; `to` is a no-op when the ids are already int32.
         topk_ids = topk_ids.to(torch.int32)
 
+    # Only the two branches above can drop a route to expert -1. When neither can fire,
+    # every routed row is written by the grouped GEMM and its output zero-fill is dead.
+    may_filter_routes = expert_map is not None or filter_expert
+
     block_m = 64
     sorted_ids, expert_ids, num_post = moe_align_block_size(
         topk_ids, block_m, local_num_experts
@@ -307,6 +315,7 @@ def fused_moe_mxfp8_native(
         block_m,
         hidden_states.dtype,
         a_div=top_k,
+        may_filter_routes=may_filter_routes,
     )  # [M, 2I]
 
     if envs.SGLANG_MINIMAX_M3_FUSED_SWIGLU_MXFP8.get():
@@ -336,6 +345,7 @@ def fused_moe_mxfp8_native(
             block_m,
             hidden_states.dtype,
             a_div=1,
+            may_filter_routes=may_filter_routes,
         )
         return g2.view(T, top_k, H)
 
@@ -354,6 +364,7 @@ def fused_moe_mxfp8_native(
         torch.float32,
         a_div=1,
         mul_weight_by=topk_weights.reshape(-1).to(torch.float32),
+        may_filter_routes=may_filter_routes,
     )  # [M, H] == [T*top_k, H]
 
     if envs.SGLANG_MINIMAX_M3_FUSED_MOE_COMBINE.get():

--- a/python/sglang/kernels/ops/moe/mxfp8_moe_amd_gfx95.py
+++ b/python/sglang/kernels/ops/moe/mxfp8_moe_amd_gfx95.py
@@ -258,6 +258,7 @@ def fused_moe_mxfp8_native(
     limit: Optional[float],
     no_combine: bool = False,
     expert_map: Optional[torch.Tensor] = None,
+    filter_expert: bool = True,
 ) -> torch.Tensor:
     # Lazy import: the jit_kernel package pulls in Triton at first use; importing
     # at call time avoids any import-time cycle with the moe runner package.
@@ -276,9 +277,14 @@ def fused_moe_mxfp8_native(
         topk_ids.masked_fill_(
             ~valid_global | (topk_ids < 0) | (topk_ids >= local_num_experts), -1
         )
-    else:
+    elif filter_expert:
         topk_ids = topk_ids.to(torch.int32, copy=True)
         topk_ids.masked_fill_((topk_ids < 0) | (topk_ids >= local_num_experts), -1)
+    else:
+        # Every expert is local, so router ids are already valid local ids and the
+        # clamp above cannot change any of them. Skipping it drops 5 tiny kernels
+        # per MoE layer; `to` is a no-op when the ids are already int32.
+        topk_ids = topk_ids.to(torch.int32)
 
     block_m = 64
     sorted_ids, expert_ids, num_post = moe_align_block_size(
@@ -377,6 +383,7 @@ def fused_experts_mxfp8(
     swiglu_limit: Optional[float] = None,
     gate_up_interleaved: bool = True,
     expert_map: Optional[torch.Tensor] = None,
+    filter_expert: bool = True,
 ) -> torch.Tensor:
     """Native MXFP8 MoE entry (CDNA4 ``dot_scaled``).
 
@@ -423,6 +430,7 @@ def fused_experts_mxfp8(
         limit=limit,
         no_combine=no_combine,
         expert_map=expert_map,
+        filter_expert=filter_expert,
     )
 
     if no_combine:

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -626,7 +626,10 @@ class GroupCoordinator:
 
         In addition, PyTorch custom ops do not support mutation or returning
         a new tensor in the same op. So we need to figure out if the op is
-        in-place or out-of-place ahead of time.
+        in-place or out-of-place ahead of time — except under Dynamo tracing,
+        where the method selection would guard on the symbolic shape; there we
+        always emit the out-of-place op with method "auto" and resolve the
+        method at runtime inside the op.
         """
         # Bypass the function if we are using only 1 GPU.
         if self.world_size == 1:
@@ -656,6 +659,32 @@ class GroupCoordinator:
         if self.npu_communicator is not None and not self.npu_communicator.disabled:
             return self.npu_communicator.all_reduce(input_)
 
+        if torch.compiler.is_compiling():
+            # Byte-size thresholds in method selection (e.g. `_pick_algo` or
+            # `should_mscclpp_allreduce`) would guard on the symbolic token dim
+            # and recompile per shape; defer the selection to runtime inside
+            # the opaque custom op. Groups without any accelerated
+            # communicator keep the inplace split op so their collective
+            # stays outside captured graphs. The symmetric-memory in-place
+            # path below is deliberately bypassed under compile: its raw
+            # pynccl call is untraceable (hard error with fullgraph, graph
+            # break otherwise) and its in-place contract does not fit the
+            # outplace custom op.
+            if (
+                self.ca_comm is None
+                and self.qr_comm is None
+                and self.pymscclpp_comm is None
+                and self.torch_symm_mem_comm is None
+                and self.pynccl_comm is None
+            ):
+                inplace_all_reduce(input_, group_name=self.unique_name)
+                return input_
+            return outplace_all_reduce(
+                input_,
+                group_name=self.unique_name,
+                outplace_all_reduce_method="auto",
+            )
+
         should_use_pymscclpp_allreduce = (
             self.pymscclpp_comm is not None
             and self.pymscclpp_comm.should_mscclpp_allreduce(input_)
@@ -670,31 +699,10 @@ class GroupCoordinator:
                 self.pynccl_comm.all_reduce(input_)
                 return input_
 
-        outplace_all_reduce_method = None
-        if (
-            self.ca_comm is not None
-            and not self.ca_comm.disabled
-            and not should_use_pymscclpp_allreduce
-            and self.ca_comm.should_custom_ar(input_)
-        ):
-            outplace_all_reduce_method = "ca"
-        elif (
-            self.qr_comm is not None
-            and not self.qr_comm.disabled
-            and self.qr_comm.should_quick_allreduce(input_)
-        ):
-            outplace_all_reduce_method = "qr"
-        elif self.pymscclpp_comm is not None and should_use_pymscclpp_allreduce:
-            outplace_all_reduce_method = "pymscclpp"
-        elif (
-            self.torch_symm_mem_comm is not None
-            and not self.torch_symm_mem_comm.disabled
-            and self.torch_symm_mem_comm.should_torch_symm_mem_allreduce(input_)
-        ):
-            outplace_all_reduce_method = "torch_symm_mem"
-        elif is_in_tc_piecewise_cuda_graph() and self.pynccl_comm is not None:
-            # For piecewise cuda graph, we use pynccl outplace allreduce
-            outplace_all_reduce_method = "pynccl"
+        outplace_all_reduce_method = self._resolve_outplace_all_reduce_method(
+            input_=input_,
+            should_use_pymscclpp_allreduce=should_use_pymscclpp_allreduce,
+        )
         if outplace_all_reduce_method is not None:
             return outplace_all_reduce(
                 input_,
@@ -780,9 +788,63 @@ class GroupCoordinator:
         )
         return fused_outputs
 
+    def _resolve_outplace_all_reduce_method(
+        self,
+        input_: torch.Tensor,
+        should_use_pymscclpp_allreduce: Optional[bool] = None,
+    ) -> Optional[str]:
+        if should_use_pymscclpp_allreduce is None:
+            should_use_pymscclpp_allreduce = (
+                self.pymscclpp_comm is not None
+                and self.pymscclpp_comm.should_mscclpp_allreduce(input_)
+            )
+        if (
+            self.ca_comm is not None
+            and not self.ca_comm.disabled
+            and not should_use_pymscclpp_allreduce
+            and self.ca_comm.should_custom_ar(input_)
+        ):
+            return "ca"
+        if (
+            self.qr_comm is not None
+            and not self.qr_comm.disabled
+            and self.qr_comm.should_quick_allreduce(input_)
+        ):
+            return "qr"
+        if self.pymscclpp_comm is not None and should_use_pymscclpp_allreduce:
+            return "pymscclpp"
+        if (
+            self.torch_symm_mem_comm is not None
+            and not self.torch_symm_mem_comm.disabled
+            and self.torch_symm_mem_comm.should_torch_symm_mem_allreduce(input_)
+        ):
+            return "torch_symm_mem"
+        if is_in_tc_piecewise_cuda_graph() and self.pynccl_comm is not None:
+            # For piecewise cuda graph, we use pynccl outplace allreduce
+            return "pynccl"
+        return None
+
     def _all_reduce_out_place(
         self, input_: torch.Tensor, outplace_all_reduce_method: str
     ) -> torch.Tensor:
+        if outplace_all_reduce_method == "auto":
+            outplace_all_reduce_method = self._resolve_outplace_all_reduce_method(
+                input_
+            )
+            if outplace_all_reduce_method == "pymscclpp":
+                # pymscclpp reduces in place and returns its input; feed it a
+                # clone to honor the op's no-mutation contract.
+                input_ = input_.clone()
+            elif outplace_all_reduce_method is None:
+                # Force pynccl over the in-place fallback: it is graph-capture
+                # safe and NCCL is natively out-of-place, avoiding the clone
+                # the in-place fallback needs.
+                if self.pynccl_comm is not None:
+                    outplace_all_reduce_method = "pynccl"
+                else:
+                    out = input_.clone()
+                    self._all_reduce_in_place(out)
+                    return out
         ca_comm = self.ca_comm
         qr_comm = self.qr_comm
         pymscclpp_comm = self.pymscclpp_comm

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -265,6 +265,7 @@ async def init_multi_tokenizer() -> ServerArgs:
 @asynccontextmanager
 async def lifespan(fast_api_app: FastAPI):
     grpc_handle = None
+    sidecar = None
     warmup_thread = None
     if getattr(fast_api_app, "is_single_tokenizer_mode", False):
         server_args = fast_api_app.server_args
@@ -397,6 +398,10 @@ async def lifespan(fast_api_app: FastAPI):
                 template_manager=_global_state.template_manager,
                 scheduler_info=_global_state.scheduler_info,
             )
+            if server_args.sidecar is not None:
+                from sglang.srt.entrypoints.sidecar import start_sidecar
+
+                sidecar = start_sidecar(server_args)
 
         # Execute the general warmup
         warmup_thread = threading.Thread(
@@ -408,6 +413,11 @@ async def lifespan(fast_api_app: FastAPI):
         # Start the HTTP server
         yield
     finally:
+        if sidecar is not None:
+            try:
+                sidecar.stop()
+            except Exception:
+                logger.exception("Failed to stop sidecar")
         _shutdown_native_grpc_server(grpc_handle)
         if tool_server is not None and hasattr(tool_server, "aclose"):
             await tool_server.aclose()

--- a/python/sglang/srt/entrypoints/sidecar.py
+++ b/python/sglang/srt/entrypoints/sidecar.py
@@ -1,0 +1,130 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Lifecycle management for an optional local native gRPC sidecar."""
+
+import argparse
+import importlib
+import logging
+import multiprocessing as mp
+import os
+
+from sglang.srt.utils.common import kill_itself_when_parent_died, kill_process_tree
+from sglang.srt.utils.network import NetworkAddress
+from sglang.srt.utils.watchdog import SubprocessWatchdog
+
+logger = logging.getLogger(__name__)
+
+SGLANG_GRPC_ENDPOINT_ENV = "SGLANG_GRPC_ENDPOINT"
+_DEFAULT_SIDECAR_SHUTDOWN_TIMEOUT = 45.0
+
+
+def _loopback_host(host: str) -> str:
+    if not host or host == "0.0.0.0":
+        return "127.0.0.1"
+    if host in ("::", "[::]"):
+        return "::1"
+    return host
+
+
+def build_sidecar_endpoint(server_args) -> str:
+    return NetworkAddress(
+        _loopback_host(server_args.host), server_args.grpc_port
+    ).to_url()
+
+
+def _parse_sidecar_args(args: list[str] | None) -> tuple[list[str], float]:
+    parser = argparse.ArgumentParser(add_help=False, allow_abbrev=False)
+    parser.add_argument(
+        "--sidecar-shutdown-timeout",
+        type=float,
+        default=_DEFAULT_SIDECAR_SHUTDOWN_TIMEOUT,
+    )
+    parsed, provider_args = parser.parse_known_args(args or [])
+    if parsed.sidecar_shutdown_timeout <= 0:
+        raise ValueError("--sidecar-shutdown-timeout must be greater than 0.")
+    return provider_args, parsed.sidecar_shutdown_timeout
+
+
+def _run_sidecar(module_name: str, args: list[str], endpoint: str) -> None:
+    kill_itself_when_parent_died()
+    os.environ[SGLANG_GRPC_ENDPOINT_ENV] = endpoint
+    try:
+        main = getattr(importlib.import_module(module_name), "main")
+    except (AttributeError, ImportError) as e:
+        raise RuntimeError(
+            f"--sidecar requires importable module {module_name!r} "
+            "with a main(argv) function."
+        ) from e
+
+    if not callable(main):
+        raise RuntimeError(
+            f"--sidecar requires module {module_name!r} to expose "
+            "a callable main(argv)."
+        )
+
+    main(args)
+
+
+class Sidecar:
+    def __init__(
+        self,
+        proc,
+        module_name: str,
+        shutdown_timeout: float,
+    ):
+        self.proc = proc
+        self.module_name = module_name
+        self.shutdown_timeout = shutdown_timeout
+        self._watchdog = SubprocessWatchdog(
+            processes=[proc], process_names=[module_name]
+        )
+
+    def start(self) -> None:
+        self.proc.start()
+        self._watchdog.start()
+        logger.info(
+            "Sidecar module %s started pid=%s",
+            self.module_name,
+            self.proc.pid,
+        )
+
+    def stop(self) -> None:
+        self._watchdog.stop()
+        if self.proc.is_alive():
+            self.proc.terminate()
+            self.proc.join(timeout=self.shutdown_timeout)
+        else:
+            self.proc.join(timeout=0)
+
+        if self.proc.is_alive():
+            logger.warning("Sidecar module did not terminate; killing process tree")
+            kill_process_tree(self.proc.pid, wait_timeout=self.shutdown_timeout)
+
+
+def start_sidecar(server_args) -> Sidecar:
+    module_name = server_args.sidecar
+    assert module_name is not None
+    sidecar_args, shutdown_timeout = _parse_sidecar_args(server_args.sidecar_args)
+    endpoint = build_sidecar_endpoint(server_args)
+    proc = mp.get_context("spawn").Process(
+        name=f"sglang_sidecar_{module_name}",
+        target=_run_sidecar,
+        args=(module_name, sidecar_args, endpoint),
+    )
+    sidecar = Sidecar(
+        proc,
+        module_name,
+        shutdown_timeout=shutdown_timeout,
+    )
+    sidecar.start()
+    return sidecar

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1075,6 +1075,18 @@ class Envs:
     SGLANG_MINIMAX_M3_FUSED_SWIGLU_MXFP8 = EnvBool(False)
     SGLANG_MINIMAX_M3_FUSED_MOE_COMBINE = EnvBool(False)
 
+    # MiniMax-M3 sparse prefill tile overrides (SILOTIGER-762). PREFILL-ONLY tile
+    # sizes for the sparse fwd kernel + prefill indexer; decode is untouched (it
+    # keeps block_size_q=1 and the checkpoint block_size_k / init / local blocks).
+    # 0 = derived default (block_size_q=1; block_size_k=sparse_block_size).
+    #   block_size_q in {1,2,4,8,16,32,64}; queries sharing one top-k selection.
+    #     Larger amortizes the paged K/V gather (~linear) but coarsens selection.
+    #     Constraint: gqa_group_size * block_size_q <= 128.
+    #   block_size_k in {16,32,64,128}; tokens attended/query = topk*block_size_k.
+    # Both change model outputs -> accuracy-gate (GSM8K) before committing.
+    SGLANG_MINIMAX_SPARSE_BLOCK_SIZE_Q = EnvInt(0)
+    SGLANG_MINIMAX_SPARSE_BLOCK_SIZE_K = EnvInt(0)
+
     # GEMM / kernel fusion
     SGLANG_OPT_FP8_WO_A_GEMM = EnvBool(True)
     SGLANG_OPT_BF16_FP32_GEMM_ALGO = EnvStr("cublas")

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -216,6 +216,17 @@ class Envs:
     # must go through ServerArgs.override() (enabled by the test harness).
     SGLANG_STRICT_CONFIG_MUTATION = EnvBool(False)
 
+    # MiniMax-M3 IndexCache (SILOTIGER-721): reuse the sparse block selection
+    # (topk_idx) across sparse layers during DECODE, recomputing the lightning
+    # indexer only on 1 of every STRIDE sparse layers and reusing the last
+    # selection on the other STRIDE-1. 0/1 = OFF (stock, indexer every layer).
+    # Any value > 1 is an approximation, so gate on accuracy (e.g. GSM8K).
+    SGLANG_MINIMAX_INDEXCACHE_STRIDE = EnvInt(0)
+    # IndexCache reuse mode (only used when STRIDE > 1): "full" reuses idx_o +
+    # topk_idx on reuse layers (max speedup); "topk" recomputes idx_o but reuses
+    # only the block selection (accuracy-isolation A/B).
+    SGLANG_MINIMAX_INDEXCACHE_MODE = EnvStr("full")
+
     # Model & File Download
     SGLANG_USE_MODELSCOPE = EnvBool(False)
     # Controls weight-file ordering for load-time I/O optimization.

--- a/python/sglang/srt/layers/attention/minimax_sparse_backend.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_backend.py
@@ -607,9 +607,7 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
             if indexcache_on:
                 self._indexcache_state = (idx_o, main_topk_idx, real_seq_lens)
         else:
-            cached_idx_o, cached_topk_idx, cached_real_seq_lens = (
-                self._indexcache_state
-            )
+            cached_idx_o, cached_topk_idx, cached_real_seq_lens = self._indexcache_state
             if self.indexcache_mode == "topk":
                 # Recompute idx_o; reuse only the block selection.
                 idx_o, o = minimax_sparse_decode(

--- a/python/sglang/srt/layers/attention/minimax_sparse_backend.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_backend.py
@@ -119,6 +119,37 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
             ) // self.block_size_k_prefill + 1
         self.topk_blocks = sparse_cfg["sparse_topk_blocks"]
 
+        # ---- IndexCache (SILOTIGER-721) ----
+        # Reuse the decode block selection (topk_idx) across sparse layers:
+        # recompute the lightning indexer only on 1 of every `stride` sparse
+        # layers (the "cadence" layers) and reuse the last selection on the rest.
+        from sglang.srt.environ import envs as _ic_envs
+
+        self.indexcache_stride = _ic_envs.SGLANG_MINIMAX_INDEXCACHE_STRIDE.get() or 0
+        self.indexcache_mode = (
+            _ic_envs.SGLANG_MINIMAX_INDEXCACHE_MODE.get() or "full"
+        ).lower()
+        # Execution-order position of each sparse layer (0,1,2,... over the sorted
+        # sparse layer ids). A layer is a cadence layer iff pos % stride == 0.
+        self._sparse_layer_pos = {
+            lid: i for i, lid in enumerate(sorted(self.sparse_layer_ids))
+        }
+        # Per-forward cache of the last computed index state
+        # (idx_o, main_topk_idx, real_seq_lens); reset every forward in
+        # init_forward_metadata_out_graph. Reused within a single forward only,
+        # so it is CUDA-graph safe (cadence layers run before reuse layers).
+        self._indexcache_state = None
+        if self.indexcache_stride and self.indexcache_stride > 1:
+            logger.warning(
+                "[MiniMaxSparse] IndexCache ENABLED: stride=%d mode=%r "
+                "(decode indexer reused on %d of every %d sparse layers; "
+                "accuracy-gate this change, e.g. GSM8K).",
+                self.indexcache_stride,
+                self.indexcache_mode,
+                self.indexcache_stride - 1,
+                self.indexcache_stride,
+            )
+
         # MSA (fmha_sm100) is SM100-only; fall back to the Triton sparse path when
         # the kernel is unavailable or its constraints don't hold.
         from sglang.srt.environ import envs
@@ -221,6 +252,9 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
         # cuda-graph replay views are a SimpleNamespace without extend_seq_lens_cpu,
         # and TARGET_VERIFY sets it to None despite is_extend() — getattr covers both.
         self._msa_dec_meta = None
+        # New forward -> drop the IndexCache selection so the first (cadence)
+        # sparse layer of this forward recomputes it.
+        self._indexcache_state = None
         extend_lens = getattr(forward_batch, "extend_seq_lens_cpu", None)
         if extend_lens is not None:
             self._max_seqlen_q = int(max(extend_lens))
@@ -512,7 +546,31 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
                     "did not prepare the plan for this forward (gate mismatch)."
                 )
 
-        idx_o, o = minimax_sparse_decode(
+        # ---- IndexCache (SILOTIGER-721): recompute (cadence) vs reuse ----
+        # A sparse layer recomputes the lightning indexer iff it is a cadence
+        # layer (pos % stride == 0) or IndexCache is off; otherwise it reuses the
+        # last cached selection. All sparse layers of a forward run in order
+        # (cadence before reuse), so within-forward reuse is CUDA-graph safe.
+        stride = self.indexcache_stride
+        indexcache_on = bool(stride and stride > 1)
+        pos = self._sparse_layer_pos.get(layer.layer_id, 0)
+        is_reuse = (
+            indexcache_on
+            and (pos % stride != 0)
+            and (self._indexcache_state is not None)
+        )
+        # "full" mode reuses the cached idx_o; if this layer needs a real idx_o
+        # (index value enabled) but the cadence layer had none, recompute instead
+        # so index_o_proj never receives a stale/None idx_o. Static per layer.
+        if (
+            is_reuse
+            and self.indexcache_mode != "topk"
+            and not disable_value
+            and self._indexcache_state[0] is None
+        ):
+            is_reuse = False
+
+        common_args = (
             q,
             None,
             k_cache,
@@ -530,6 +588,8 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
             self.topk_blocks,
             self.init_blocks,
             self.local_blocks,
+        )
+        common_kwargs = dict(
             score_type=self.score_type,
             disable_index_value=disable_value,
             dense_main_attn_fn=attn_fn,
@@ -538,6 +598,36 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
             msa_kv_indices=msa_kv_indices,
             msa_plan=msa_plan,
         )
+
+        if not is_reuse:
+            # Cadence layer (or IndexCache off): run the indexer, cache its state.
+            idx_o, o, main_topk_idx, real_seq_lens = minimax_sparse_decode(
+                *common_args, return_index_state=True, **common_kwargs
+            )
+            if indexcache_on:
+                self._indexcache_state = (idx_o, main_topk_idx, real_seq_lens)
+        else:
+            cached_idx_o, cached_topk_idx, cached_real_seq_lens = (
+                self._indexcache_state
+            )
+            if self.indexcache_mode == "topk":
+                # Recompute idx_o; reuse only the block selection.
+                idx_o, o = minimax_sparse_decode(
+                    *common_args,
+                    reuse_main_topk_idx=cached_topk_idx,
+                    reuse_real_seq_lens=cached_real_seq_lens,
+                    **common_kwargs,
+                )
+            else:
+                # "full": skip the indexer entirely, reuse idx_o + selection.
+                idx_o, o = minimax_sparse_decode(
+                    *common_args,
+                    skip_indexer=True,
+                    reuse_idx_o=(None if disable_value else cached_idx_o),
+                    reuse_main_topk_idx=cached_topk_idx,
+                    reuse_real_seq_lens=cached_real_seq_lens,
+                    **common_kwargs,
+                )
         return (
             None if idx_o is None else idx_o.reshape(q.shape[0], -1).contiguous(),
             o.reshape(q.shape[0], -1).contiguous(),

--- a/python/sglang/srt/layers/attention/minimax_sparse_backend.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_backend.py
@@ -63,6 +63,60 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
             self.local_blocks = (
                 local_tokens + self.block_size_k - 1
             ) // self.block_size_k + 1
+
+        # Prefill-only tile overrides (SILOTIGER-762). These affect ONLY the
+        # sparse prefill path (the fwd kernel _gqa_share_sparse_fwd_kernel + the
+        # prefill indexer, both fanned out from minimax_sparse_prefill); decode is
+        # deliberately left untouched (its call passes block_size_q=1 and the
+        # checkpoint block_size_k / init_blocks / local_blocks), so tuning prefill
+        # never changes decode behavior or timing. The forced-include init/local
+        # windows are re-blocked to the prefill granularity from the checkpoint
+        # token counts. Any change alters prefill outputs -> gate on GSM8K.
+        from sglang.srt.environ import envs as _envs
+
+        self.block_size_q_prefill = self.block_size_q
+        self.block_size_k_prefill = self.block_size_k
+        self.init_blocks_prefill = self.init_blocks
+        self.local_blocks_prefill = self.local_blocks
+        _bq_override = _envs.SGLANG_MINIMAX_SPARSE_BLOCK_SIZE_Q.get()
+        if _bq_override and _bq_override > 0:
+            assert _bq_override in {1, 2, 4, 8, 16, 32, 64}, (
+                f"SGLANG_MINIMAX_SPARSE_BLOCK_SIZE_Q must be in "
+                f"{{1,2,4,8,16,32,64}}, got {_bq_override}"
+            )
+            logger.warning(
+                "[MiniMaxSparse] Prefill block_size_q %d -> %d "
+                "(SGLANG_MINIMAX_SPARSE_BLOCK_SIZE_Q, prefill-only); "
+                "accuracy-gate this change.",
+                self.block_size_q_prefill,
+                _bq_override,
+            )
+            self.block_size_q_prefill = _bq_override
+        _bk_override = _envs.SGLANG_MINIMAX_SPARSE_BLOCK_SIZE_K.get()
+        if _bk_override and _bk_override > 0:
+            assert _bk_override in {16, 32, 64, 128}, (
+                f"SGLANG_MINIMAX_SPARSE_BLOCK_SIZE_K must be in "
+                f"{{16,32,64,128}}, got {_bk_override}"
+            )
+            logger.warning(
+                "[MiniMaxSparse] Prefill block_size_k %d -> %d "
+                "(SGLANG_MINIMAX_SPARSE_BLOCK_SIZE_K, prefill-only); "
+                "accuracy-gate this change.",
+                self.block_size_k_prefill,
+                _bk_override,
+            )
+            self.block_size_k_prefill = _bk_override
+            # Re-block the forced-include init/local windows at the prefill
+            # granularity, from the checkpoint token counts, so they cover the
+            # same token span as decode's stock windows.
+            init_tokens = self.init_blocks * self.block_size_k
+            local_tokens = max(0, self.local_blocks - 1) * self.block_size_k
+            self.init_blocks_prefill = (
+                init_tokens + self.block_size_k_prefill - 1
+            ) // self.block_size_k_prefill
+            self.local_blocks_prefill = (
+                local_tokens + self.block_size_k_prefill - 1
+            ) // self.block_size_k_prefill + 1
         self.topk_blocks = sparse_cfg["sparse_topk_blocks"]
 
         # MSA (fmha_sm100) is SM100-only; fall back to the Triton sparse path when
@@ -337,11 +391,11 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
             prefix_lens,
             self._max_seqlen_q,
             self._max_seqlen_k,
-            self.block_size_q,
-            self.block_size_k,
+            self.block_size_q_prefill,
+            self.block_size_k_prefill,
             self.topk_blocks,
-            self.init_blocks,
-            self.local_blocks,
+            self.init_blocks_prefill,
+            self.local_blocks_prefill,
             score_type=self.score_type,
             disable_index_value=disable_value,
             use_msa=self.use_msa,

--- a/python/sglang/srt/layers/attention/minimax_sparse_ops/minimax_sparse.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_ops/minimax_sparse.py
@@ -1,7 +1,7 @@
 # Copyright 2025 XunhaoLai. All rights reserved.
 
 import logging
-from typing import Callable, List, Optional, Tuple
+from typing import Callable, List, Optional
 
 import torch
 
@@ -210,9 +210,15 @@ def minimax_sparse_decode(
     msa_plan=None,  # per-forward MSA fmha_sm100 plan (cached)
     # ---- IndexCache (SILOTIGER-721) ----
     skip_indexer: bool = False,  # "full" reuse: do NOT launch the indexer at all
-    reuse_idx_o: Optional[torch.Tensor] = None,  # "full" reuse: index-head output to reuse
-    reuse_main_topk_idx: Optional[torch.Tensor] = None,  # reuse this block selection for main attn
-    reuse_real_seq_lens: Optional[torch.Tensor] = None,  # reuse effective KV lengths (dense path)
+    reuse_idx_o: Optional[
+        torch.Tensor
+    ] = None,  # "full" reuse: index-head output to reuse
+    reuse_main_topk_idx: Optional[
+        torch.Tensor
+    ] = None,  # reuse this block selection for main attn
+    reuse_real_seq_lens: Optional[
+        torch.Tensor
+    ] = None,  # reuse effective KV lengths (dense path)
     return_index_state: bool = False,  # also return (idx_o, main_topk_idx, real_seq_lens) for caching
 ):
     # Step 1: Flash decode with topk index (using index head). When the dense main

--- a/python/sglang/srt/layers/attention/minimax_sparse_ops/minimax_sparse.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_ops/minimax_sparse.py
@@ -208,76 +208,93 @@ def minimax_sparse_decode(
         torch.Tensor
     ] = None,  # per-forward MSA page table (cached)
     msa_plan=None,  # per-forward MSA fmha_sm100 plan (cached)
-) -> Tuple[torch.Tensor, torch.Tensor]:
+    # ---- IndexCache (SILOTIGER-721) ----
+    skip_indexer: bool = False,  # "full" reuse: do NOT launch the indexer at all
+    reuse_idx_o: Optional[torch.Tensor] = None,  # "full" reuse: index-head output to reuse
+    reuse_main_topk_idx: Optional[torch.Tensor] = None,  # reuse this block selection for main attn
+    reuse_real_seq_lens: Optional[torch.Tensor] = None,  # reuse effective KV lengths (dense path)
+    return_index_state: bool = False,  # also return (idx_o, main_topk_idx, real_seq_lens) for caching
+):
     # Step 1: Flash decode with topk index (using index head). When the dense main
     # attention is used, the indexer emits the page table directly (fused
     # transform) instead of block ids, plus the per-query effective KV length.
-    idx_o, topk_idx, real_seq_lens = flash_decode_with_topk_idx(
-        q=idx_q,
-        sink=idx_sink,
-        k_cache=idx_k_cache,
-        v_cache=idx_v_cache,
-        req_to_token=req_to_token,
-        seq_lens=seq_lens,
-        max_seqlen=max_seqlen,
-        slot_ids=slot_ids,
-        block_size=block_size_k,
-        topk=topk,
-        init_blocks=init_blocks,
-        local_blocks=local_blocks,
-        sm_scale=idx_sm_scale,
-        score_type=score_type,
-        disable_index_value=disable_index_value,
-        use_dense_main_attn=dense_main_attn_fn is not None,
-        page_size=page_size,
-    )
+    #
+    # IndexCache: `main_topk_idx` is the selection actually consumed by the main
+    # sparse attention below (post GQA reduce, or the dense page table). A cadence
+    # layer computes it here and hands it back (return_index_state=True); a reuse
+    # layer either skips the indexer entirely (skip_indexer, "full" mode) or
+    # recomputes idx_o but substitutes the cached selection ("topk" mode).
     num_idx_heads = idx_q.shape[1]
     num_kv_heads = k_cache.shape[1]
     idx_group_size = num_idx_heads // num_kv_heads
+    real_seq_lens = reuse_real_seq_lens
+
+    if skip_indexer:
+        # "full"-mode reuse layer: no indexer launch at all.
+        idx_o = reuse_idx_o
+        main_topk_idx = reuse_main_topk_idx
+    else:
+        idx_o, topk_idx, real_seq_lens = flash_decode_with_topk_idx(
+            q=idx_q,
+            sink=idx_sink,
+            k_cache=idx_k_cache,
+            v_cache=idx_v_cache,
+            req_to_token=req_to_token,
+            seq_lens=seq_lens,
+            max_seqlen=max_seqlen,
+            slot_ids=slot_ids,
+            block_size=block_size_k,
+            topk=topk,
+            init_blocks=init_blocks,
+            local_blocks=local_blocks,
+            sm_scale=idx_sm_scale,
+            score_type=score_type,
+            disable_index_value=disable_index_value,
+            use_dense_main_attn=dense_main_attn_fn is not None,
+            page_size=page_size,
+        )
+        if dense_main_attn_fn is not None:
+            # topk_idx is the page table; real_seq_lens is the per-query cache_seqlens
+            assert idx_group_size == 1
+            main_topk_idx = topk_idx
+        else:
+            # Step 2: Reduce topk idx if num_idx_heads > num_kv_heads
+            if idx_group_size > 1:
+                topk_idx = topk_index_reduce(
+                    topk_idx.view(num_kv_heads, idx_group_size, -1, topk), dim=1
+                )
+            main_topk_idx = topk_idx
+        # "topk"-mode reuse: keep the freshly computed idx_o but override the
+        # block selection (and dense effective KV lengths) with the cached ones.
+        if reuse_main_topk_idx is not None:
+            main_topk_idx = reuse_main_topk_idx
+            if reuse_real_seq_lens is not None:
+                real_seq_lens = reuse_real_seq_lens
+
+    # Step 3: Sparse attention using the (possibly cached) topk selection. The
+    # MSA path only replaces this step; keep the Triton path when sink is present.
     if dense_main_attn_fn is not None:
         # topk_idx is the page table; real_seq_lens is the per-query cache_seqlens
-        assert idx_group_size == 1
-        o = dense_main_attn_fn(q, topk_idx, real_seq_lens)
-    else:
-        # Step 2: Reduce topk idx if num_idx_heads > num_kv_heads
-        if idx_group_size > 1:
-            topk_idx = topk_index_reduce(
-                topk_idx.view(num_kv_heads, idx_group_size, -1, topk), dim=1
-            )
-        # Step 3: Sparse attention using topk index (main head). The MSA path
-        # only replaces this step; keep the Triton path when sink is present.
-        if use_msa and sink is None:
-            from .msa import MSAUnavailableError, msa_sparse_decode_main
+        o = dense_main_attn_fn(q, main_topk_idx, real_seq_lens)
+    elif use_msa and sink is None:
+        from .msa import MSAUnavailableError, msa_sparse_decode_main
 
-            try:
-                o = msa_sparse_decode_main(
-                    q=q,
-                    k_cache=k_cache,
-                    v_cache=v_cache,
-                    topk_idx=topk_idx,
-                    req_to_token=req_to_token,
-                    slot_ids=slot_ids,
-                    seq_lens=seq_lens,
-                    block_size_k=block_size_k,
-                    sm_scale=sm_scale,
-                    kv_indices=msa_kv_indices,
-                    plan=msa_plan,
-                )
-            except MSAUnavailableError as err:
-                _warn_msa_fallback(err)
-                o = flash_decode_with_gqa_share_sparse(
-                    q=q,
-                    sink=sink,
-                    k_cache=k_cache,
-                    v_cache=v_cache,
-                    req_to_token=req_to_token,
-                    seq_lens=seq_lens,
-                    slot_ids=slot_ids,
-                    block_size=block_size_k,
-                    topk_idx=topk_idx,
-                    sm_scale=sm_scale,
-                )
-        else:
+        try:
+            o = msa_sparse_decode_main(
+                q=q,
+                k_cache=k_cache,
+                v_cache=v_cache,
+                topk_idx=main_topk_idx,
+                req_to_token=req_to_token,
+                slot_ids=slot_ids,
+                seq_lens=seq_lens,
+                block_size_k=block_size_k,
+                sm_scale=sm_scale,
+                kv_indices=msa_kv_indices,
+                plan=msa_plan,
+            )
+        except MSAUnavailableError as err:
+            _warn_msa_fallback(err)
             o = flash_decode_with_gqa_share_sparse(
                 q=q,
                 sink=sink,
@@ -287,7 +304,23 @@ def minimax_sparse_decode(
                 seq_lens=seq_lens,
                 slot_ids=slot_ids,
                 block_size=block_size_k,
-                topk_idx=topk_idx,
+                topk_idx=main_topk_idx,
                 sm_scale=sm_scale,
             )
+    else:
+        o = flash_decode_with_gqa_share_sparse(
+            q=q,
+            sink=sink,
+            k_cache=k_cache,
+            v_cache=v_cache,
+            req_to_token=req_to_token,
+            seq_lens=seq_lens,
+            slot_ids=slot_ids,
+            block_size=block_size_k,
+            topk_idx=main_topk_idx,
+            sm_scale=sm_scale,
+        )
+
+    if return_index_state:
+        return idx_o, o, main_topk_idx, real_seq_lens
     return idx_o, o

--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -814,8 +814,17 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
         llama_4_scaling: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
 
+        # The fallback belongs to genuine extend forwards only. Target-verify /
+        # draft-extend must never honor it: `forward_prefill_metadata` is a
+        # stale leftover from the last prefill there (eager init clears it,
+        # but decode-graph capture does not), and capturing verify through the
+        # flashinfer path binds the graph to prefill-planned wrapper buffers,
+        # which fault (illegal address) at replay.
         if (
-            self.forward_prefill_metadata is not None
+            forward_batch.forward_mode.is_extend()
+            and not forward_batch.forward_mode.is_target_verify()
+            and not forward_batch.forward_mode.is_draft_extend_v2()
+            and self.forward_prefill_metadata is not None
             and self.forward_prefill_metadata.fallback_to_flashinfer_impl
         ):
             return super().forward_extend(

--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -167,11 +167,14 @@ def apply_flashinfer_allreduce_fusion(batch_size: int):
         # Ref: https://github.com/sgl-project/sglang/issues/17237
         (_is_sm90_supported or _is_sm100_supported)
         and _is_flashinfer_available
-        and batch_size > 0
-        and batch_size <= FUSE_ALLREDUCE_MAX_BATCH_SIZE
         and not is_dp_attention_enabled()
         and get_server_args().flashinfer_allreduce_fusion_backend is not None
         and not is_flashinfer_allreduce_unavailable()
+        # Symbolic size checks stay last: under Dynamo tracing they guard on
+        # the dynamic token dim, so statically-off configs must short-circuit
+        # before reaching them.
+        and batch_size > 0
+        and batch_size <= FUSE_ALLREDUCE_MAX_BATCH_SIZE
     )
 
 

--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
@@ -965,9 +965,15 @@ def fused_experts_none_to_flashinfer_trtllm_fp4(
         ):
             e4m3_max = 256.0
 
+        global_scale_inv = torch.full(
+            (1,),
+            1.0 / (e4m3_max * 6.0),
+            dtype=torch.float32,
+            device=hidden_states.device,
+        )
         hs_fp4_bytes, hs_sf_bytes, per_token_scale = nvfp4_quantize(
             hidden_states,
-            1.0 / (e4m3_max * 6.0),
+            global_scale_inv,
             sfLayout=SfLayout.layout_linear,
             per_token_activation=True,
             backend="cute-dsl",

--- a/python/sglang/srt/layers/moe/moe_runner/triton.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton.py
@@ -71,6 +71,15 @@ class TritonMoeQuantInfo(MoeQuantInfo):
     block_shape: Optional[List[int]] = None
 
 
+def _needs_expert_filter(config: MoeRunnerConfig) -> bool:
+    """Whether topk ids can address a non-local expert and must be filtered.
+
+    False only when every expert is local, so the router's global ids are already
+    valid local ids. An unknown expert count is treated as needing the filter.
+    """
+    return config.num_experts is None or config.num_experts != config.num_local_experts
+
+
 class TritonRunnerCore(MoeRunnerCore):
 
     def __init__(self, config: MoeRunnerConfig):
@@ -108,6 +117,7 @@ class TritonRunnerCore(MoeRunnerCore):
                 gemm1_limit=self.config.gemm1_clamp_limit,
                 swiglu_limit=self.config.swiglu_limit,
                 gate_up_interleaved=self.config.gate_up_interleaved,
+                filter_expert=_needs_expert_filter(self.config),
             )
             return TritonRunnerOutput(hidden_states=out)
 
@@ -121,10 +131,7 @@ class TritonRunnerCore(MoeRunnerCore):
             _fused_moe_kernel_sequence,
         )
 
-        filter_expert = (
-            self.config.num_experts is None
-            or self.config.num_experts != self.config.num_local_experts
-        )
+        filter_expert = _needs_expert_filter(self.config)
 
         out = _fused_moe_kernel_sequence(
             runner_input.hidden_states,
@@ -206,6 +213,7 @@ def fused_experts_none_to_triton(
             gemm1_limit=runner_config.gemm1_clamp_limit,
             swiglu_limit=runner_config.swiglu_limit,
             gate_up_interleaved=runner_config.gate_up_interleaved,
+            filter_expert=_needs_expert_filter(runner_config),
         )
     else:
         if quant_info.use_mxfp8 and is_cuda():

--- a/python/sglang/srt/layers/moe/moe_runner/triton.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton.py
@@ -74,8 +74,7 @@ class TritonMoeQuantInfo(MoeQuantInfo):
 def _needs_expert_filter(config: MoeRunnerConfig) -> bool:
     """Whether topk ids can address a non-local expert and must be filtered.
 
-    False only when every expert is local, so the router's global ids are already
-    valid local ids. An unknown expert count is treated as needing the filter.
+    False only when every expert is local. An unknown expert count needs the filter.
     """
     return config.num_experts is None or config.num_experts != config.num_local_experts
 

--- a/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4_moe.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4_moe.py
@@ -263,9 +263,10 @@ class QuarkW4A4MXFp4MoE(QuarkMoEScheme):
             # gemm1_clamp_limit>0) need this; leave plain-SwiGLU models (GLM,
             # limit==0) on activation='silu' to avoid changing their path.
             from dataclasses import replace as _dc_replace
+
             _mm3_clamp = (
-                getattr(moe_runner_config, 'gemm1_clamp_limit', None)
-                or getattr(moe_runner_config, 'swiglu_limit', None)
+                getattr(moe_runner_config, "gemm1_clamp_limit", None)
+                or getattr(moe_runner_config, "swiglu_limit", None)
                 or 0.0
             )
             _mm3_cfg = (
@@ -302,8 +303,8 @@ class QuarkW4A4MXFp4MoE(QuarkMoEScheme):
         # QUARK_MXFP4_SWIGLU_LIMIT_FIX: forward the GPT-OSS clamped-SwiGLU limit so the aiter
         # MoE runner selects the clamped-SwiGLU kernel instead of plain SiLU.
         _mm3_swiglu_limit = (
-            getattr(self.moe_runner_config, 'gemm1_clamp_limit', None)
-            or getattr(self.moe_runner_config, 'swiglu_limit', None)
+            getattr(self.moe_runner_config, "gemm1_clamp_limit", None)
+            or getattr(self.moe_runner_config, "swiglu_limit", None)
             or 0.0
         )
         quant_info = AiterMoeQuantInfo(

--- a/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4_moe.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4_moe.py
@@ -258,7 +258,22 @@ class QuarkW4A4MXFp4MoE(QuarkMoEScheme):
             moe_runner_backend = MoeRunnerBackend.AITER
 
         if moe_runner_backend.is_aiter():
-            self.runner = MoeRunner(moe_runner_backend, moe_runner_config)
+            # QUARK_MXFP4_SWIGLU_ACTIVATION_FIX: aiter MXFP4 per_1x32 kernel/dtype selection keys on
+            # activation==Swiglu. Only clamped-SwiGLU models (e.g. MiniMax-M3,
+            # gemm1_clamp_limit>0) need this; leave plain-SwiGLU models (GLM,
+            # limit==0) on activation='silu' to avoid changing their path.
+            from dataclasses import replace as _dc_replace
+            _mm3_clamp = (
+                getattr(moe_runner_config, 'gemm1_clamp_limit', None)
+                or getattr(moe_runner_config, 'swiglu_limit', None)
+                or 0.0
+            )
+            _mm3_cfg = (
+                _dc_replace(moe_runner_config, activation="swiglu")
+                if _mm3_clamp > 0
+                else moe_runner_config
+            )
+            self.runner = MoeRunner(moe_runner_backend, _mm3_cfg)
         else:
             # TODO(cwan): refactor other backends
             pass
@@ -284,6 +299,13 @@ class QuarkW4A4MXFp4MoE(QuarkMoEScheme):
             w13_weight.is_shuffled = True
             w2_weight.is_shuffled = True
 
+        # QUARK_MXFP4_SWIGLU_LIMIT_FIX: forward the GPT-OSS clamped-SwiGLU limit so the aiter
+        # MoE runner selects the clamped-SwiGLU kernel instead of plain SiLU.
+        _mm3_swiglu_limit = (
+            getattr(self.moe_runner_config, 'gemm1_clamp_limit', None)
+            or getattr(self.moe_runner_config, 'swiglu_limit', None)
+            or 0.0
+        )
         quant_info = AiterMoeQuantInfo(
             w13_weight=w13_weight,
             w2_weight=w2_weight,
@@ -291,5 +313,6 @@ class QuarkW4A4MXFp4MoE(QuarkMoEScheme):
             w13_scale=layer.w13_weight_scale,
             w2_scale=layer.w2_weight_scale,
             expert_mask=layer.dispatcher.expert_mask_gpu,
+            swiglu_limit=_mm3_swiglu_limit,
         )
         return self.runner.run(dispatch_output, quant_info)

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -40,6 +40,7 @@ from sglang.srt.utils import (
     use_intel_amx_backend,
     use_intel_xpu_backend,
 )
+from sglang.srt.utils.custom_op import register_custom_op
 
 if TYPE_CHECKING:
     from sglang.srt.layers.moe.token_dispatcher import (
@@ -102,6 +103,25 @@ def initialize_bf16_gemm_config(server_args: ServerArgs) -> None:
         _use_cutedsl_bf16_gemm = use_cutedsl_bf16_gemm
 
     _BF16_GEMM_BACKEND = backend
+
+
+def _bf16_gemm_dispatch_fake(
+    x: torch.Tensor, weight: torch.Tensor, bias: Optional[torch.Tensor]
+) -> torch.Tensor:
+    return x.new_empty((*x.shape[:-1], weight.shape[0]))
+
+
+@register_custom_op(fake_impl=_bf16_gemm_dispatch_fake)
+def bf16_gemm_dispatch(
+    x: torch.Tensor, weight: torch.Tensor, bias: Optional[torch.Tensor]
+) -> torch.Tensor:
+    if _use_cutedsl_bf16_gemm is not None and _use_cutedsl_bf16_gemm(
+        x.numel() // x.shape[-1], weight.shape[0], weight.shape[1]
+    ):
+        return _cutedsl_bf16_gemm(x.view(-1, x.shape[-1]), weight, bias).view(
+            *x.shape[:-1], -1
+        )
+    return F.linear(x, weight, bias)
 
 
 def get_bf16_gemm_backend() -> Bf16GemmBackend:
@@ -207,15 +227,24 @@ class UnquantizedLinearMethod(LinearMethodBase):
             and x.dtype == torch.bfloat16
             and layer.weight.dtype == torch.bfloat16
             and (bias is None or bias.dtype == torch.bfloat16)
-            and _use_cutedsl_bf16_gemm(
+        ):
+            if torch.compiler.is_compiling():
+                # The m-dependent kernel heuristic would guard on the symbolic
+                # token dim under Dynamo and recompile per shape bucket; the
+                # opaque op resolves it at runtime with concrete shapes,
+                # keeping the per-shape kernel choice.
+                return bf16_gemm_dispatch(x, layer.weight, bias)
+            if _use_cutedsl_bf16_gemm(
                 x.numel() // x.shape[-1],
                 layer.weight.shape[0],
                 layer.weight.shape[1],
-            )
-        ):
-            x_shapes = x.shape
-            output = _cutedsl_bf16_gemm(x.view(-1, x_shapes[-1]), layer.weight, bias)
-            return output.view(*x_shapes[:-1], -1)
+            ):
+                x_shapes = x.shape
+                output = _cutedsl_bf16_gemm(
+                    x.view(-1, x_shapes[-1]), layer.weight, bias
+                )
+                return output.view(*x_shapes[:-1], -1)
+            return F.linear(x, layer.weight, bias)
 
         return F.linear(x, layer.weight, bias)
 

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -30,7 +30,7 @@ import math
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass, fields
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple, TypeGuard, Union
 
 import numpy as np
 import torch
@@ -132,23 +132,16 @@ def get_tensor_size_bytes(t: Union[torch.Tensor, List[torch.Tensor]]):
     return np.prod(t.shape) * t.dtype.itemsize
 
 
-def _is_noop_kv_scale(scale) -> bool:
-    """Whether dividing by ``scale`` can be skipped as an exact identity.
-
-    Only host-side scalars are inspected: reading a device tensor would force a
-    device sync and is illegal under CUDA-graph capture, so a tensor scale always
-    takes the normal division path.
-    """
-    return scale is None or (isinstance(scale, (int, float)) and float(scale) == 1.0)
+def _kv_scale_divides(scale: Optional[float]) -> TypeGuard[float]:
+    """Host scalar only: reading a device tensor would sync, illegal under graph capture."""
+    return scale is not None and scale != 1.0
 
 
 def _has_dense_kv_rows(t: torch.Tensor, head_num: int, head_dim: int) -> bool:
     """Whether ``t`` is addressable as ``token * t.stride(0) + head * head_dim + dim``.
 
-    That is all ``reshape_and_cache_flash`` needs, because it takes each source's token
-    stride as a kernel argument: only the (head, dim) block of one token has to be dense
-    and head-major. Whole-tensor contiguity is stricter than the kernel, and rejects the
-    ``dim=-1`` slice of a fused QKV projection that the decode path actually passes.
+    That is all ``reshape_and_cache_flash`` needs, since it takes the token stride per
+    source. So a ``dim=-1`` slice of fused QKV qualifies; ``is_contiguous`` would not.
     """
     row = head_num * head_dim
     if t.is_contiguous():
@@ -168,9 +161,8 @@ def _has_dense_kv_rows(t: torch.Tensor, head_num: int, head_dim: int) -> bool:
 def _as_token_head_dim(t: torch.Tensor, head_num: int, head_dim: int) -> torch.Tensor:
     """View ``t`` as ``[tokens, head_num, head_dim]`` without moving data.
 
-    Splits only the trailing block, so a strided token dimension keeps its own stride
-    rather than being flattened, which would need a copy. Pair with
-    :func:`_has_dense_kv_rows`, which establishes that these views are legal.
+    Splits only the trailing block, so a strided token dimension survives. Guard with
+    :func:`_has_dense_kv_rows`.
     """
     if t.dim() == 3 and t.shape[1] == head_num and t.shape[2] == head_dim:
         return t
@@ -2296,15 +2288,11 @@ class MHATokenToKVPool(KVCache):
         k_scale=None,
         v_scale=None,
     ) -> bool:
-        """Whether a pending dtype cast can be folded into the paged write.
+        """Whether the pending dtype cast can be folded into the paged write.
 
-        ``reshape_and_cache_flash`` converts on store, so the separate
-        ``.to(self.dtype)`` pass -- one full-tensor elementwise kernel per tensor
-        per layer -- is only needed when this returns False. The kernel reuses K's
-        head geometry for V and needs each token's (head, dim) block dense, but it
-        takes the token stride per source, so K and V may be strided views with
-        different strides. It can only take a device-tensor scale, so a non-unit
-        host scalar falls back.
+        ``reshape_and_cache_flash`` converts on store, so the separate ``.to(self.dtype)``
+        is only needed when this returns False. It reuses K's head geometry for V and
+        applies no scale, so mismatched shapes or a real scale fall back.
         """
         if self.kv_cache_layout != "nhd" or self.use_hnd:
             return False
@@ -2314,7 +2302,7 @@ class MHATokenToKVPool(KVCache):
             return False
         if self.head_dim != self.v_head_dim:
             return False
-        if not (_is_noop_kv_scale(k_scale) and _is_noop_kv_scale(v_scale)):
+        if _kv_scale_divides(k_scale) or _kv_scale_divides(v_scale):
             return False
         return (
             _has_dense_kv_rows(cache_k, self.head_num, self.head_dim)
@@ -2329,12 +2317,14 @@ class MHATokenToKVPool(KVCache):
         cache_k: torch.Tensor,
         cache_v: torch.Tensor,
     ) -> None:
-        """Cast K/V to the cache dtype and scatter both into the paged buffers in
-        one launch. Guard with :meth:`can_store_kv_fused_cast`."""
+        """Cast K/V to the cache dtype and scatter both in one launch.
+
+        Guard with :meth:`can_store_kv_fused_cast`.
+        """
         from sglang.kernels.ops.attention.utils import launch_reshape_and_cache_flash
 
-        # unsqueeze(1) presents the flat slot-indexed buffer as a page-size-1
-        # paged cache, which is the layout the kernel indexes with `loc`.
+        # The kernel indexes `loc` into a paged cache; unsqueeze(1) presents the flat
+        # slot-indexed buffer as page-size 1.
         launch_reshape_and_cache_flash(
             _as_token_head_dim(cache_k, self.head_num, self.head_dim),
             _as_token_head_dim(cache_v, self.head_num, self.head_dim),
@@ -2378,9 +2368,9 @@ class MHATokenToKVPool(KVCache):
             return
 
         if cache_k.dtype != self.dtype:
-            if not _is_noop_kv_scale(k_scale):
+            if _kv_scale_divides(k_scale):
                 cache_k.div_(k_scale)
-            if not _is_noop_kv_scale(v_scale):
+            if _kv_scale_divides(v_scale):
                 cache_v.div_(v_scale)
             cache_k = cache_k.to(self.dtype)
             cache_v = cache_v.to(self.dtype)
@@ -2751,9 +2741,9 @@ class MHATokenToKVPool(KVCache):
             )
 
         if cache_k.dtype != self.dtype:
-            if not _is_noop_kv_scale(k_scale):
+            if _kv_scale_divides(k_scale):
                 cache_k.div_(k_scale)
-            if not _is_noop_kv_scale(v_scale):
+            if _kv_scale_divides(v_scale):
                 cache_v.div_(v_scale)
             cache_k = cache_k.to(self.dtype)
             cache_v = cache_v.to(self.dtype)
@@ -3099,9 +3089,9 @@ class MHATokenToKVPoolFP4(MHATokenToKVPool):
         else:
             layer_id = layer.layer_id
         if cache_k.dtype != self.dtype:
-            if not _is_noop_kv_scale(k_scale):
+            if _kv_scale_divides(k_scale):
                 cache_k.div_(k_scale)
-            if not _is_noop_kv_scale(v_scale):
+            if _kv_scale_divides(v_scale):
                 cache_v.div_(v_scale)
 
             from sglang.srt.layers.quantization.kvfp4_tensor import (
@@ -4953,10 +4943,9 @@ class MiniMaxSparseKVPool(KVCache):
             cache_idx_k = cache_idx_k.view(sub_pool.store_dtype)
         k_buffer = sub_pool.k_buffer[mapped_id]
         if cache_idx_k.is_contiguous():
-            # A plain scatter instead of ATen advanced indexing, whose index_put
-            # pays for broadcast/index machinery this store does not need.
             store_k_slots(k_buffer, cache_idx_k.view(-1, *k_buffer.shape[1:]), loc)
         else:
+            # store_k_slots requires contiguous rows.
             k_buffer[loc] = cache_idx_k
 
     def _can_fuse_kv_index_store(
@@ -5026,9 +5015,7 @@ class MiniMaxSparseKVPool(KVCache):
             )
             return
 
-        # Fallback: separate stores (identical semantics). The main K/V write
-        # still folds its bf16 -> cache-dtype cast into the scatter when the
-        # layout allows, which is what the ROCm decode path takes.
+        # Fallback: separate stores (identical semantics).
         main = self.main_pool
         if main.can_store_kv_fused_cast(cache_k, cache_v):
             main.store_kv_fused_cast(layer.layer_id, loc, cache_k, cache_v)

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -142,6 +142,43 @@ def _is_noop_kv_scale(scale) -> bool:
     return scale is None or (isinstance(scale, (int, float)) and float(scale) == 1.0)
 
 
+def _has_dense_kv_rows(t: torch.Tensor, head_num: int, head_dim: int) -> bool:
+    """Whether ``t`` is addressable as ``token * t.stride(0) + head * head_dim + dim``.
+
+    That is all ``reshape_and_cache_flash`` needs, because it takes each source's token
+    stride as a kernel argument: only the (head, dim) block of one token has to be dense
+    and head-major. Whole-tensor contiguity is stricter than the kernel, and rejects the
+    ``dim=-1`` slice of a fused QKV projection that the decode path actually passes.
+    """
+    row = head_num * head_dim
+    if t.is_contiguous():
+        return t.numel() % row == 0
+    if t.dim() == 2:
+        return t.shape[1] == row and t.stride(1) == 1
+    if t.dim() == 3:
+        return (
+            t.shape[1] == head_num
+            and t.shape[2] == head_dim
+            and t.stride(1) == head_dim
+            and t.stride(2) == 1
+        )
+    return False
+
+
+def _as_token_head_dim(t: torch.Tensor, head_num: int, head_dim: int) -> torch.Tensor:
+    """View ``t`` as ``[tokens, head_num, head_dim]`` without moving data.
+
+    Splits only the trailing block, so a strided token dimension keeps its own stride
+    rather than being flattened, which would need a copy. Pair with
+    :func:`_has_dense_kv_rows`, which establishes that these views are legal.
+    """
+    if t.dim() == 3 and t.shape[1] == head_num and t.shape[2] == head_dim:
+        return t
+    if t.dim() == 2 and t.shape[1] == head_num * head_dim:
+        return t.unflatten(1, (head_num, head_dim))
+    return t.view(-1, head_num, head_dim)
+
+
 def _set_kv_buffer_impl(
     k: torch.Tensor,
     v: torch.Tensor,
@@ -2264,9 +2301,10 @@ class MHATokenToKVPool(KVCache):
         ``reshape_and_cache_flash`` converts on store, so the separate
         ``.to(self.dtype)`` pass -- one full-tensor elementwise kernel per tensor
         per layer -- is only needed when this returns False. The kernel reuses K's
-        head geometry for V and assumes each token's (head, dim) block is dense,
-        and it can only take a device-tensor scale, so a non-unit host scalar
-        falls back.
+        head geometry for V and needs each token's (head, dim) block dense, but it
+        takes the token stride per source, so K and V may be strided views with
+        different strides. It can only take a device-tensor scale, so a non-unit
+        host scalar falls back.
         """
         if self.kv_cache_layout != "nhd" or self.use_hnd:
             return False
@@ -2278,12 +2316,10 @@ class MHATokenToKVPool(KVCache):
             return False
         if not (_is_noop_kv_scale(k_scale) and _is_noop_kv_scale(v_scale)):
             return False
-        row = self.head_num * self.head_dim
         return (
-            cache_k.is_contiguous()
-            and cache_v.is_contiguous()
+            _has_dense_kv_rows(cache_k, self.head_num, self.head_dim)
+            and _has_dense_kv_rows(cache_v, self.head_num, self.head_dim)
             and cache_k.shape == cache_v.shape
-            and cache_k.numel() % row == 0
         )
 
     def store_kv_fused_cast(
@@ -2297,12 +2333,11 @@ class MHATokenToKVPool(KVCache):
         one launch. Guard with :meth:`can_store_kv_fused_cast`."""
         from sglang.kernels.ops.attention.utils import launch_reshape_and_cache_flash
 
-        shape = (-1, self.head_num, self.head_dim)
         # unsqueeze(1) presents the flat slot-indexed buffer as a page-size-1
         # paged cache, which is the layout the kernel indexes with `loc`.
         launch_reshape_and_cache_flash(
-            cache_k.view(shape),
-            cache_v.view(shape),
+            _as_token_head_dim(cache_k, self.head_num, self.head_dim),
+            _as_token_head_dim(cache_v, self.head_num, self.head_dim),
             self._get_key_buffer(layer_id).unsqueeze(1),
             self._get_value_buffer(layer_id).unsqueeze(1),
             loc,

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -131,6 +131,16 @@ def get_tensor_size_bytes(t: Union[torch.Tensor, List[torch.Tensor]]):
     return np.prod(t.shape) * t.dtype.itemsize
 
 
+def _is_noop_kv_scale(scale) -> bool:
+    """Whether dividing by ``scale`` can be skipped as an exact identity.
+
+    Only host-side scalars are inspected: reading a device tensor would force a
+    device sync and is illegal under CUDA-graph capture, so a tensor scale always
+    takes the normal division path.
+    """
+    return scale is None or (isinstance(scale, (int, float)) and float(scale) == 1.0)
+
+
 def _set_kv_buffer_impl(
     k: torch.Tensor,
     v: torch.Tensor,
@@ -2241,6 +2251,62 @@ class MHATokenToKVPool(KVCache):
     def get_kv_buffer(self, layer_id: int):
         return self.get_key_buffer(layer_id), self.get_value_buffer(layer_id)
 
+    def can_store_kv_fused_cast(
+        self,
+        cache_k: torch.Tensor,
+        cache_v: torch.Tensor,
+        k_scale=None,
+        v_scale=None,
+    ) -> bool:
+        """Whether a pending dtype cast can be folded into the paged write.
+
+        ``reshape_and_cache_flash`` converts on store, so the separate
+        ``.to(self.dtype)`` pass -- one full-tensor elementwise kernel per tensor
+        per layer -- is only needed when this returns False. The kernel reuses K's
+        head geometry for V and assumes each token's (head, dim) block is dense,
+        and it can only take a device-tensor scale, so a non-unit host scalar
+        falls back.
+        """
+        if self.kv_cache_layout != "nhd" or self.use_hnd:
+            return False
+        if self.is_quantized_kv_cache or self.store_dtype != torch.uint8:
+            return False
+        if cache_k.dtype == self.dtype or cache_k.dtype != cache_v.dtype:
+            return False
+        if self.head_dim != self.v_head_dim:
+            return False
+        if not (_is_noop_kv_scale(k_scale) and _is_noop_kv_scale(v_scale)):
+            return False
+        row = self.head_num * self.head_dim
+        return (
+            cache_k.is_contiguous()
+            and cache_v.is_contiguous()
+            and cache_k.shape == cache_v.shape
+            and cache_k.numel() % row == 0
+        )
+
+    def store_kv_fused_cast(
+        self,
+        layer_id: int,
+        loc: torch.Tensor,
+        cache_k: torch.Tensor,
+        cache_v: torch.Tensor,
+    ) -> None:
+        """Cast K/V to the cache dtype and scatter both into the paged buffers in
+        one launch. Guard with :meth:`can_store_kv_fused_cast`."""
+        from sglang.kernels.ops.attention.utils import launch_reshape_and_cache_flash
+
+        shape = (-1, self.head_num, self.head_dim)
+        # unsqueeze(1) presents the flat slot-indexed buffer as a page-size-1
+        # paged cache, which is the layout the kernel indexes with `loc`.
+        launch_reshape_and_cache_flash(
+            cache_k.view(shape),
+            cache_v.view(shape),
+            self._get_key_buffer(layer_id).unsqueeze(1),
+            self._get_value_buffer(layer_id).unsqueeze(1),
+            loc,
+        )
+
     def set_kv_buffer(
         self,
         layer: RadixAttention,
@@ -2276,9 +2342,9 @@ class MHATokenToKVPool(KVCache):
             return
 
         if cache_k.dtype != self.dtype:
-            if k_scale is not None:
+            if not _is_noop_kv_scale(k_scale):
                 cache_k.div_(k_scale)
-            if v_scale is not None:
+            if not _is_noop_kv_scale(v_scale):
                 cache_v.div_(v_scale)
             cache_k = cache_k.to(self.dtype)
             cache_v = cache_v.to(self.dtype)
@@ -2649,9 +2715,9 @@ class MHATokenToKVPool(KVCache):
             )
 
         if cache_k.dtype != self.dtype:
-            if k_scale is not None:
+            if not _is_noop_kv_scale(k_scale):
                 cache_k.div_(k_scale)
-            if v_scale is not None:
+            if not _is_noop_kv_scale(v_scale):
                 cache_v.div_(v_scale)
             cache_k = cache_k.to(self.dtype)
             cache_v = cache_v.to(self.dtype)
@@ -2997,9 +3063,9 @@ class MHATokenToKVPoolFP4(MHATokenToKVPool):
         else:
             layer_id = layer.layer_id
         if cache_k.dtype != self.dtype:
-            if k_scale is not None:
+            if not _is_noop_kv_scale(k_scale):
                 cache_k.div_(k_scale)
-            if v_scale is not None:
+            if not _is_noop_kv_scale(v_scale):
                 cache_v.div_(v_scale)
 
             from sglang.srt.layers.quantization.kvfp4_tensor import (
@@ -4918,8 +4984,14 @@ class MiniMaxSparseKVPool(KVCache):
             )
             return
 
-        # Fallback: separate stores (identical semantics).
-        self.set_kv_buffer(layer, loc, cache_k, cache_v)
+        # Fallback: separate stores (identical semantics). The main K/V write
+        # still folds its bf16 -> cache-dtype cast into the scatter when the
+        # layout allows, which is what the ROCm decode path takes.
+        main = self.main_pool
+        if main.can_store_kv_fused_cast(cache_k, cache_v):
+            main.store_kv_fused_cast(layer.layer_id, loc, cache_k, cache_v)
+        else:
+            self.set_kv_buffer(layer, loc, cache_k, cache_v)
         if disable_value:
             self.set_index_k_buffer(layer, loc, cache_idx_k)
         else:

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -47,6 +47,7 @@ from sglang.kernels.ops.kvcache.cache_move import (
     copy_all_layer_kv_cache_func,
     set_kv_buffer_prefix_valid_tiled,
     store_cache_4d,
+    store_k_slots,
 )
 from sglang.kernels.ops.quantization.fp8_kernel import fp8_dtype, is_fp8_fnuz
 from sglang.srt.configs.mamba_utils import BaseLinearStateParams
@@ -4915,7 +4916,13 @@ class MiniMaxSparseKVPool(KVCache):
             cache_idx_k = cache_idx_k.to(sub_pool.dtype)
         if sub_pool.store_dtype != sub_pool.dtype:
             cache_idx_k = cache_idx_k.view(sub_pool.store_dtype)
-        sub_pool.k_buffer[mapped_id][loc] = cache_idx_k
+        k_buffer = sub_pool.k_buffer[mapped_id]
+        if cache_idx_k.is_contiguous():
+            # A plain scatter instead of ATen advanced indexing, whose index_put
+            # pays for broadcast/index machinery this store does not need.
+            store_k_slots(k_buffer, cache_idx_k.view(-1, *k_buffer.shape[1:]), loc)
+        else:
+            k_buffer[loc] = cache_idx_k
 
     def _can_fuse_kv_index_store(
         self,

--- a/python/sglang/srt/models/minimax_m3_vl.py
+++ b/python/sglang/srt/models/minimax_m3_vl.py
@@ -54,6 +54,15 @@ _device_sm = get_device_sm()
 
 
 class MiniMaxM3SparseForConditionalGeneration(nn.Module):
+    # MINIMAX_M3_PACKED_MODULES_FIX: route the MXFP4 checkpoint's separate q/k/v + gate/up
+    # shards into the model's fused qkv_proj / index_qkv_proj / gate_up_proj
+    # params. Without this the loader hands a merged tensor to a half-width
+    # param and crashes with a param/loaded shape-mismatch AssertionError.
+    packed_modules_mapping = {
+        "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+        "index_qkv_proj": ["index_q_proj", "index_k_proj"],
+        "gate_up_proj": ["gate_proj", "up_proj"],
+    }
     def __init__(
         self,
         config,

--- a/python/sglang/srt/models/minimax_m3_vl.py
+++ b/python/sglang/srt/models/minimax_m3_vl.py
@@ -63,6 +63,7 @@ class MiniMaxM3SparseForConditionalGeneration(nn.Module):
         "index_qkv_proj": ["index_q_proj", "index_k_proj"],
         "gate_up_proj": ["gate_proj", "up_proj"],
     }
+
     def __init__(
         self,
         config,

--- a/python/sglang/srt/multimodal/processors/minimax_m3_vl.py
+++ b/python/sglang/srt/multimodal/processors/minimax_m3_vl.py
@@ -214,7 +214,15 @@ class MiniMaxM3VLProcessor(BaseMultimodalProcessor):
     def __init__(self, hf_config, server_args, _processor, *args, **kwargs):
         super().__init__(hf_config, server_args, _processor, *args, **kwargs)
 
-        tokenizer = _processor.tokenizer
+        # MINIMAX_M3_PROCESSOR_TOKENIZER_FALLBACK_FIX: some base images resolve the HF processor to a bare
+        # tokenizer (TokenizersBackend) instead of a full MiniMaxM3VLProcessor,
+        # so `.tokenizer` is absent. Fall back to the processor object itself --
+        # the TokenizersBackend has convert_tokens_to_ids (used by _token_id);
+        # do NOT unwrap to `._tokenizer`, which is the raw tokenizers.Tokenizer
+        # and lacks convert_tokens_to_ids. Text path + special token IDs work.
+        tokenizer = getattr(_processor, "tokenizer", None)
+        if tokenizer is None:
+            tokenizer = _processor
         assert tokenizer is not None, "tokenizer is required"
 
         self.IM_TOKEN_ID = self._token_id(tokenizer, self.IMAGE_TOKEN)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1070,6 +1070,22 @@ class ServerArgs:
         "default. In legacy --smg-grpc-mode this is the SMG server port and "
         "defaults to --port + 10000.",
     ] = None
+    sidecar: A[
+        Optional[str],
+        "Start a locally managed sidecar against the native gRPC server. "
+        "The selected module must expose main(argv) and read the resolved "
+        "native gRPC endpoint from SGLANG_GRPC_ENDPOINT. Requires --grpc-port "
+        "or SGLANG_GRPC_PORT.",
+    ] = None
+    sidecar_args: A[
+        Optional[List[str]],
+        Arg(
+            help="JSON array passed to the selected sidecar module's "
+            "main(argv) function. --sidecar-shutdown-timeout SECONDS is "
+            "consumed by SGLang.",
+            type_parser=json_list_type,
+        ),
+    ] = None
     skip_server_warmup: A[bool, "If set, skip warmup."] = False
     warmups: A[
         Optional[str],
@@ -3325,6 +3341,23 @@ class ServerArgs:
         # Native gRPC is incompatible with launch paths it doesn't wire into.
         # Legacy takes precedence over grpc_port, keeping re-runs idempotent.
         native_grpc = self.grpc_port is not None and not legacy_grpc
+        if self.sidecar_args is not None:
+            if self.sidecar is None:
+                raise ValueError("--sidecar-args requires --sidecar.")
+            if not isinstance(self.sidecar_args, list) or not all(
+                isinstance(arg, str) for arg in self.sidecar_args
+            ):
+                raise ValueError("--sidecar-args must be a JSON array of strings.")
+        if self.sidecar is not None:
+            if not self.sidecar.strip():
+                raise ValueError("--sidecar must not be empty.")
+            if legacy_grpc:
+                raise ValueError(
+                    "--sidecar requires SGLang's native gRPC server; "
+                    "it cannot be combined with --smg-grpc-mode/--grpc-mode."
+                )
+            if self.grpc_port is None:
+                raise ValueError("--sidecar requires --grpc-port or SGLANG_GRPC_PORT.")
         if native_grpc:
             if self.use_ray:
                 raise ValueError(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3755,6 +3755,19 @@ class ServerArgs:
                 "decode context parallel (dcp_size > 1)",
                 lambda: self.dcp_size > 1,
             ),
+            # TcPiecewise makes the trtllm_mla prefill fall back to the
+            # flashinfer-MLA implementation, which faults (illegal address)
+            # on an FP8 KV cache.
+            (
+                "MLA attention with FP8 KV cache",
+                lambda: self.kv_cache_dtype.startswith("fp8")
+                and (
+                    _resolved_view(self).attention_backend
+                    in ("trtllm_mla", "flashinfer_mla")
+                    or _resolved_view(self).prefill_attention_backend
+                    in ("trtllm_mla", "flashinfer_mla")
+                ),
+            ),
         ]
         for _name, predicate in rules:
             if predicate():

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3755,19 +3755,6 @@ class ServerArgs:
                 "decode context parallel (dcp_size > 1)",
                 lambda: self.dcp_size > 1,
             ),
-            # TcPiecewise makes the trtllm_mla prefill fall back to the
-            # flashinfer-MLA implementation, which faults (illegal address)
-            # on an FP8 KV cache.
-            (
-                "MLA attention with FP8 KV cache",
-                lambda: self.kv_cache_dtype.startswith("fp8")
-                and (
-                    _resolved_view(self).attention_backend
-                    in ("trtllm_mla", "flashinfer_mla")
-                    or _resolved_view(self).prefill_attention_backend
-                    in ("trtllm_mla", "flashinfer_mla")
-                ),
-            ),
         ]
         for _name, predicate in rules:
             if predicate():

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -673,8 +673,12 @@ class MultiLayerEagleDraftWorker(EagleDraftWorkerBase):
         # Batch 2: Draft extend
         draft_extend_input = EagleDraftExtendInput(
             hidden_states=batch_result.logits_output.hidden_states,
-            # Actual width: the multi-layer chain fills num_steps + 1 rows/req.
-            num_tokens_per_req=self.speculative_num_steps + 1,
+            # Actual width: the multi-layer chain fills num_steps + 1 rows/req,
+            # plus the boundary-KV front rows when the widened window is active
+            # (must match the capture width in the draft-extend graph runner).
+            num_tokens_per_req=self.speculative_num_steps
+            + 1
+            + self.draft_extend_num_front_tokens,
             num_tokens_for_logprob_per_req=1,
             num_front_tokens=self.draft_extend_num_front_tokens,
         )

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -9,6 +9,13 @@ from unittest.mock import MagicMock, patch
 
 import sglang.srt.server_args as server_args_module
 from sglang.srt.arg_groups.speculative_hook import handle_speculative_decoding
+from sglang.srt.entrypoints.sidecar import (
+    SGLANG_GRPC_ENDPOINT_ENV,
+    Sidecar,
+    _run_sidecar,
+    build_sidecar_endpoint,
+    start_sidecar,
+)
 from sglang.srt.environ import envs
 from sglang.srt.layers.cp.base import is_cp_enabled, is_interleave
 from sglang.srt.model_executor.cuda_graph_config import (
@@ -1535,6 +1542,133 @@ class TestGrpcServerArgs(CustomTestCase):
         with envs.SGLANG_GRPC_PORT.override(45000):
             sa._handle_deprecated_args()
         self.assertEqual(sa.grpc_port, 45000)
+
+    @staticmethod
+    def _sidecar_parser():
+        parser = server_args_module.argparse.ArgumentParser()
+        ServerArgs.add_cli_args(parser)
+        return parser
+
+    def test_sidecar_builds_loopback_grpc_endpoints(self):
+        self.assertEqual(
+            build_sidecar_endpoint(SimpleNamespace(host="0.0.0.0", grpc_port=50051)),
+            "http://127.0.0.1:50051",
+        )
+        self.assertEqual(
+            build_sidecar_endpoint(SimpleNamespace(host="::", grpc_port=50051)),
+            "http://[::1]:50051",
+        )
+        self.assertEqual(
+            build_sidecar_endpoint(SimpleNamespace(host="[::]", grpc_port=50051)),
+            "http://[::1]:50051",
+        )
+
+    def test_sidecar_args_parse_as_exact_json_argv(self):
+        argv = ["--flag", "value"]
+        parsed = self._sidecar_parser().parse_args(
+            ["--model-path", "dummy", "--sidecar-args", json.dumps(argv)]
+        )
+        self.assertEqual(parsed.sidecar_args, argv)
+
+    def test_start_sidecar_passes_endpoint_and_provider_argv_separately(self):
+        server_args = SimpleNamespace(
+            sidecar="example.sidecar",
+            sidecar_args=[
+                "--sidecar-shutdown-timeout",
+                "42",
+                "--grpc-connections",
+                "2",
+            ],
+            host="127.0.0.1",
+            grpc_port=50051,
+        )
+        with (
+            patch("sglang.srt.entrypoints.sidecar.mp.get_context") as get_context,
+            patch("sglang.srt.entrypoints.sidecar.Sidecar") as sidecar_class,
+        ):
+            start_sidecar(server_args)
+
+        process_kwargs = get_context.return_value.Process.call_args.kwargs
+        self.assertEqual(process_kwargs["name"], "sglang_sidecar_example.sidecar")
+        self.assertEqual(process_kwargs["target"], _run_sidecar)
+        self.assertEqual(
+            process_kwargs["args"],
+            (
+                "example.sidecar",
+                ["--grpc-connections", "2"],
+                "http://127.0.0.1:50051",
+            ),
+        )
+        sidecar_class.assert_called_once_with(
+            get_context.return_value.Process.return_value,
+            "example.sidecar",
+            shutdown_timeout=42.0,
+        )
+
+    def test_sidecar_requires_native_grpc(self):
+        sa = self._args(sidecar="example.sidecar")
+        with self.assertRaisesRegex(ValueError, "requires --grpc-port"):
+            sa._handle_deprecated_args()
+
+    def test_sidecar_rejects_legacy_grpc(self):
+        sa = self._args(sidecar="example.sidecar", smg_grpc_mode=True)
+        with self.assertRaisesRegex(ValueError, "native gRPC server"):
+            sa._handle_deprecated_args()
+
+    def test_sidecar_rejects_empty_value(self):
+        sa = self._args(sidecar="", grpc_port=50051)
+        with self.assertRaisesRegex(ValueError, "must not be empty"):
+            sa._handle_deprecated_args()
+
+    def test_sidecar_sets_endpoint_env_before_import_and_calls_main(self):
+        main = MagicMock()
+
+        def import_module(module_name):
+            self.assertEqual(module_name, "example.sidecar")
+            self.assertEqual(
+                os.environ[SGLANG_GRPC_ENDPOINT_ENV],
+                "http://127.0.0.1:50051",
+            )
+            self.assertEqual(os.environ["DYN_NAMESPACE"], "pluh")
+            return SimpleNamespace(main=main)
+
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    SGLANG_GRPC_ENDPOINT_ENV: "http://stale.example:1",
+                    "DYN_NAMESPACE": "pluh",
+                },
+            ),
+            patch("sglang.srt.entrypoints.sidecar.kill_itself_when_parent_died"),
+            patch(
+                "sglang.srt.entrypoints.sidecar.importlib.import_module",
+                side_effect=import_module,
+            ),
+        ):
+            _run_sidecar(
+                "example.sidecar",
+                ["--provider-flag", "value"],
+                "http://127.0.0.1:50051",
+            )
+
+        main.assert_called_once_with(["--provider-flag", "value"])
+
+    def test_sidecar_stop_uses_configured_shutdown_timeout(self):
+        proc = MagicMock(pid=1234)
+        proc.is_alive.side_effect = [True, True]
+        sidecar = Sidecar(
+            proc,
+            "example.sidecar",
+            shutdown_timeout=42.0,
+        )
+
+        with patch("sglang.srt.entrypoints.sidecar.kill_process_tree") as kill_tree:
+            sidecar.stop()
+
+        proc.terminate.assert_called_once_with()
+        proc.join.assert_called_once_with(timeout=42.0)
+        kill_tree.assert_called_once_with(1234, wait_timeout=42.0)
 
     def test_legacy_smg_derives_grpc_port_from_http_port(self):
         sa = self._args(port=30000, smg_grpc_mode=True)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

On MiniMax-M3-MXFP8 (TP4/EP1, MI355X/gfx950) a long tail of elementwise/fill/copy kernels is 17.5% of decode compute (5.11 ms/step), ~1150 launches/step over 57 sparse layers, and is launch- and overhead-bound, which makes it the largest single decode kernel lever. The task is to shrink that tail: fewer launches per decode step, at no cost to model output.

Most of those kernels do no useful work. One divides every K/V value by exactly 1.0. One clamps expert ids into a range they are already inside. One zeroes a buffer that the next GEMM overwrites in full. This PR cuts the measured tail launches per decode step, maintains GSM8K, and gates change so that other configurations keep their current behavior.

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->