### PR TITLE
fix: skip singleton sampler token sync

### DIFF
--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -70,9 +70,11 @@ _BUILT_IN_SAMPLING_BACKENDS = {"flashinfer", "pytorch", "ascend"}
 class Sampler(nn.Module):
     def __init__(self):
         super().__init__()
-        self.tp_sync_group = get_tp_group().device_group
+        tp_sync_group = get_tp_group()
         if is_dp_attention_enabled():
-            self.tp_sync_group = get_parallel().attn_tp_group.device_group
+            tp_sync_group = get_parallel().attn_tp_group
+        self.tp_sync_group = tp_sync_group.device_group
+        self.tp_sync_group_world_size = tp_sync_group.world_size
 
         self.rl_on_policy_target = get_exec().deterministic.rl_on_policy_target
         # In RL on-policy mode, deterministic inference is automatically enabled.
@@ -493,7 +495,9 @@ class Sampler(nn.Module):
     def _sync_token_ids_across_tp(
         self, batch_next_token_ids: torch.Tensor, sampling_info: SamplingBatchInfo
     ):
-        if SYNC_TOKEN_IDS_ACROSS_TP or sampling_info.grammars:
+        if (
+            SYNC_TOKEN_IDS_ACROSS_TP or sampling_info.grammars
+        ) and self.tp_sync_group_world_size > 1:
             # For performance reasons, SGLang does not sync the final token IDs across TP ranks by default.
             # This saves one all-reduce, but the correctness of this approach depends on the determinism of several operators:
             # the last all-reduce, the last lm_head matmul, and all sampling kernels.

--- a/test/registered/unit/layers/test_sampler_tp_sync.py
+++ b/test/registered/unit/layers/test_sampler_tp_sync.py
@@ -1,0 +1,50 @@
+import types
+import unittest
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.layers import sampler as sampler_module
+from sglang.srt.layers.sampler import Sampler
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestSamplerTpSync(CustomTestCase):
+    def _sync(self, world_size: int):
+        group = object()
+        sampler = types.SimpleNamespace(
+            tp_sync_group=group,
+            tp_sync_group_world_size=world_size,
+        )
+        token_ids = torch.tensor([7], dtype=torch.int64)
+        sampling_info = types.SimpleNamespace(grammars=[object()])
+
+        with (
+            patch.object(sampler_module, "SYNC_TOKEN_IDS_ACROSS_TP", False),
+            patch.object(torch.distributed, "all_reduce") as all_reduce,
+        ):
+            Sampler._sync_token_ids_across_tp(sampler, token_ids, sampling_info)
+
+        return all_reduce, token_ids, group
+
+    def test_skips_single_rank_group(self):
+        all_reduce, token_ids, _ = self._sync(world_size=1)
+
+        all_reduce.assert_not_called()
+        torch.testing.assert_close(token_ids, torch.tensor([7]))
+
+    def test_syncs_multi_rank_group(self):
+        all_reduce, token_ids, group = self._sync(world_size=2)
+
+        all_reduce.assert_called_once_with(
+            token_ids,
+            op=torch.distributed.ReduceOp.MIN,
+            group=group,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- skip sampler token-ID synchronization when the selected TP sync group has world size one
- preserve the existing `ReduceOp.MIN` synchronization for multi-rank groups
- add CPU unit coverage for singleton and multi-rank behavior

## Motivation

With DP attention, the sampler may select an attention TP group whose world size is one. Grammar sampling currently calls `torch.distributed.all_reduce` directly for that group. Although the collective is an identity, its first use can lazily initialize a singleton NCCL communicator and allocate a large NET shared P2P pool.

The group membership is fixed, so skipping a singleton collective cannot suppress a future multi-rank operation.

Fixes #35826.

Related: #8400 and NVIDIA/nccl#2363.

## Testing

```text
PYTHONPATH=python python -m pytest -q test/registered/unit/layers/test_sampler_tp_sync.py
2 passed
```

`pre-commit run --files python/sglang/srt/layers/sampler.py test/registered/unit/layers/test_sampler_tp_sync.py` also passes.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32463145686](https://github.com/sgl-project/sglang/actions/runs/32463145686)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32463145834](https://github.com/sgl-project/sglang/actions/runs/32463145834)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32463145638](https://github.com/sgl-project/sglang/actions/runs/32463145638)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->