### PR TITLE
[MoonEP] Destroy communication buffers on runtime reset

### DIFF
--- a/python/sglang/srt/layers/moe/token_dispatcher/moonep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/moonep.py
@@ -15,10 +15,8 @@ from sglang.srt.layers.moe.token_dispatcher.base import (
     DispatchOutput,
     DispatchOutputFormat,
 )
-from sglang.srt.layers.moe.topk import TopKOutput
-from sglang.srt.layers.moe.topk import TopKOutputChecker
+from sglang.srt.layers.moe.topk import TopKOutput, TopKOutputChecker
 from sglang.srt.layers.moe.utils import DeepEPMode
-
 
 _MOONEP_UNSUPPORTED_MESSAGE = (
     "MoonEP MoE A2A is recognized by SGLang, but the runtime dispatcher is not "
@@ -112,13 +110,15 @@ class MoonEPBuffer:
 
         from sglang.srt.runtime_context import get_resources
 
-        buffers = get_resources().buffers
+        resources = get_resources()
+        buffers = resources.buffers
         state = buffers.get("moonep_ep_state")
         if state is None:
             state = SimpleNamespace(
                 buffers={},
                 active_key=None,
             )
+            resources.register_finalizer("moonep_ep_buffers", cls.destroy_all_buffers)
             buffers["moonep_ep_state"] = state
         return state
 
@@ -451,9 +451,7 @@ def run_moonep_bf16_expert(
             f"shape {cu_seqlens.shape}"
         )
     if route_weights_nvs is not None and route_weights_nvs.ndim != 1:
-        raise ValueError(
-            f"route_weights_nvs must be 1D, got {route_weights_nvs.shape}"
-        )
+        raise ValueError(f"route_weights_nvs must be 1D, got {route_weights_nvs.shape}")
 
     output = torch.empty_like(hidden_states)
     prev = 0

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -51,7 +51,7 @@ import functools
 import os
 import sys
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable
 
 if TYPE_CHECKING:
     from sglang.srt.server_args import ServerArgs
@@ -460,6 +460,35 @@ class Resources(_FlagGroupBase):
     tcp_store: Any = None
     # Trace verbosity; the accessor seeds it lazily from SGLANG_TRACE_LEVEL.
     trace_level: Any = None
+    # Named teardown callbacks for process-level resources. Resource-owning
+    # modules register once when they allocate; reset runs them in reverse
+    # construction order before dropping the registry.
+    _finalizers: dict[str, Callable[[], None]] = dataclasses.field(
+        default_factory=dict, repr=False
+    )
+
+    def register_finalizer(self, name: str, finalizer: Callable[[], None]) -> None:
+        if name in self._finalizers:
+            raise ValueError(f"resource finalizer {name!r} is already registered")
+        self._finalizers[name] = finalizer
+
+    def cleanup(self) -> None:
+        finalizers = tuple(self._finalizers.items())
+        self._finalizers.clear()
+        failures = []
+        for name, finalizer in reversed(finalizers):
+            try:
+                finalizer()
+            except Exception as exc:
+                failures.append((name, exc))
+
+        if failures:
+            details = ", ".join(
+                f"{name}: {type(exc).__name__}({exc})" for name, exc in failures
+            )
+            raise RuntimeError(
+                f"{len(failures)} resource finalizer(s) failed: {details}"
+            ) from failures[0][1]
 
 
 class ForwardFlags:
@@ -1384,6 +1413,12 @@ def reset_context() -> None:
 
     Wrapper subsystems (``parallel``) hold no state and are unaffected.
     """
+    cleanup_error = None
+    try:
+        _CONTEXT.resources.cleanup()
+    except RuntimeError as exc:
+        cleanup_error = exc
+
     _CONTEXT._server_args = None
     _CONTEXT._config_bags = None
     _adaptive_draft_token_bound.cache_clear()
@@ -1394,6 +1429,8 @@ def reset_context() -> None:
     _CONTEXT.resources = Resources()
     _CONTEXT.forward = ForwardFlags()
     set_global_dwdp_manager(None)
+    if cleanup_error is not None:
+        raise cleanup_error
 
 
 def mamba_extra_buffer_enabled() -> bool:

--- a/test/registered/unit/layers/moe/test_moonep_buffer.py
+++ b/test/registered/unit/layers/moe/test_moonep_buffer.py
@@ -177,6 +177,37 @@ class TestMoonEPBuffer(unittest.TestCase):
         self.assertEqual(buffer.destroy_calls, 1)
         self.assertIsNone(MoonEPBuffer.get_existing_buffer())
 
+    def test_reset_context_destroys_all_cached_buffers_once(self):
+        group = object()
+
+        with (
+            patch.dict(sys.modules, {"moonep": _fake_moonep_module()}),
+            patch(
+                "sglang.srt.layers.moe.token_dispatcher.moonep.dist.get_world_size",
+                return_value=4,
+            ),
+        ):
+            prefill_buffer = MoonEPBuffer.get_moonep_buffer(
+                group=group,
+                hidden_size=1024,
+                router_topk=8,
+                num_experts=64,
+                num_max_dispatch_tokens_per_rank=512,
+            )
+            decode_buffer = MoonEPBuffer.get_moonep_buffer(
+                group=group,
+                hidden_size=1024,
+                router_topk=8,
+                num_experts=64,
+                num_max_dispatch_tokens_per_rank=64,
+            )
+
+        reset_context()
+        reset_context()
+
+        self.assertEqual(prefill_buffer.destroy_calls, 1)
+        self.assertEqual(decode_buffer.destroy_calls, 1)
+
 
 class TestMoonEPExpertWeightLayout(unittest.TestCase):
     def _fake_layer(self):
@@ -289,9 +320,7 @@ class TestMoonEPBf16ExpertRunner(unittest.TestCase):
         for start, end, expert in [(0, 2, 0), (2, 3, 1)]:
             x = hidden_states[start:end]
             y = torch.nn.functional.linear(
-                torch.nn.functional.silu(
-                    torch.nn.functional.linear(x, gate[expert])
-                )
+                torch.nn.functional.silu(torch.nn.functional.linear(x, gate[expert]))
                 * torch.nn.functional.linear(x, up[expert]),
                 down[expert],
             )

--- a/test/registered/unit/test_runtime_context.py
+++ b/test/registered/unit/test_runtime_context.py
@@ -625,6 +625,47 @@ class TestNamedStreams(_IsolatedServerArgs):
         reset_context()
         self.assertEqual(get_context().resources.streams, {})
 
+    def test_reset_runs_resource_finalizers_in_lifo_order(self):
+        reset_context()
+        finalized = []
+        resources = get_context().resources
+        resources.register_finalizer("first", lambda: finalized.append("first"))
+        resources.register_finalizer("second", lambda: finalized.append("second"))
+
+        reset_context()
+
+        self.assertEqual(finalized, ["second", "first"])
+
+    def test_resource_finalizer_names_are_unique(self):
+        reset_context()
+        resources = get_context().resources
+        resources.register_finalizer("shared", lambda: None)
+
+        with self.assertRaisesRegex(ValueError, "shared.*already registered"):
+            resources.register_finalizer("shared", lambda: None)
+
+    def test_reset_reports_cleanup_failures_after_running_every_finalizer(self):
+        reset_context()
+        finalized = []
+        resources = get_context().resources
+        resources.register_finalizer("first", lambda: finalized.append("first"))
+
+        def fail_cleanup():
+            finalized.append("broken")
+            raise ValueError("boom")
+
+        resources.register_finalizer("broken", fail_cleanup)
+        resources.register_finalizer("last", lambda: finalized.append("last"))
+
+        with self.assertRaisesRegex(RuntimeError, "broken") as cm:
+            reset_context()
+
+        self.assertIsInstance(cm.exception.__cause__, ValueError)
+        self.assertEqual(finalized, ["last", "broken", "first"])
+        self.assertIsNot(get_context().resources, resources)
+        resources.cleanup()
+        self.assertEqual(finalized, ["last", "broken", "first"])
+
     def test_capturer_slots_roundtrip_and_reset(self):
         from sglang.srt.state_capturer.indexer_topk import (
             get_global_indexer_capturer,


### PR DESCRIPTION
## Motivation

Part of #35783.

MoonEP communication buffers own NVLink/VMM resources and already expose explicit destruction, but `reset_context()` currently drops the runtime resource store without invoking that cleanup. This draft makes reset/test teardown deterministic for the communication-buffer path already present on the `moonep` branch.

This is intentionally the first narrow lifecycle PR. It does not cover the symmetric weight pool from #34874, observability, autotuning, model reload, production graceful shutdown, or GPU/multi-rank teardown validation.

## Modifications

- Add a named finalizer registry to runtime `Resources`.
- Run finalizers once in LIFO order during `reset_context()`.
- Reject duplicate finalizer names.
- Continue cleanup after individual failures, install fresh runtime resources, then raise an aggregate error chained from the first failure.
- Register `MoonEPBuffer.destroy_all_buffers()` when the process-local MoonEP buffer state is first created.
- Add unit coverage for finalizer ordering, uniqueness, failure handling, fresh reset state, and destruction of multiple MoonEP capacity buffers exactly once.

## Accuracy Tests

Not applicable. This change does not alter model outputs or the dispatch/combine data path.

## Speed Tests and Profiling

Not applicable. Cleanup runs only from `reset_context()`; no inference hot path was changed.

## Tests

- `test/registered/unit/test_runtime_context.py`: 72 passed, 35 subtests passed. The local environment used an import-only stub for the unrelated optional `datasets` dependency during collection.
- `test/registered/unit/layers/moe/test_moonep_buffer.py`: 9 passed.
- Black, isort, Ruff (`F401,F821,UP037`), `git diff --check`, and `scripts/ci/check_registered_tests.py` passed.

GPU and multi-rank teardown validation has not been run for this draft.

## Checklist

- [x] Format code according to the repository pre-commit configuration.
- [x] Add focused unit tests.
- [x] Follow the SGLang code style guidance.
- [ ] Documentation update — not applicable to this internal lifecycle seam.
- [ ] Accuracy and speed benchmarks — not applicable to reset-only cleanup.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32463957071](https://github.com/sgl-project/sglang/actions/runs/32463957071)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32463956581](https://github.com/sgl-project/sglang/actions/runs/32463956581)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32463956855](https://github.com/sgl-project/sglang/actions/runs/32463956855)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->