### PR TITLE
[CPU] Support speculative decoding for hybrid GDN models

### DIFF
--- a/python/sglang/kernels/aot/csrc/cpu/mamba/conv.cpp
+++ b/python/sglang/kernels/aot/csrc/cpu/mamba/conv.cpp
@@ -440,6 +440,157 @@ void causal_conv1d_update_kernel_impl(
   });
 }
 
+// Store one token's conv window for the post-verify rollback. `cols` lists the
+// window columns oldest-first, each a [dim] slice of a dim-contiguous source;
+// the destination entry is [dim, state_len], so the copy transposes.
+template <typename scalar_t>
+inline void store_intermediate_conv_window(
+    scalar_t* __restrict__ dst, const scalar_t* const* cols, int64_t dim, int64_t state_len) {
+  for (int64_t d = 0; d < dim; ++d) {
+    for (int64_t w = 0; w < state_len; ++w) {
+      dst[d * state_len + w] = cols[w][d];
+    }
+  }
+}
+
+// Tree (topk > 1) target-verify update: each draft token convolves over its
+// ancestor chain in the draft tree. Walking past the root reads the committed
+// conv_states history, which stays untouched here because siblings share it.
+// Also derives retrieve_parent_token for the downstream delta-rule verify.
+//
+// input / out : [batch, seqlen, dim] token-major
+// conv_states : [num_lines, dim, width - 1] with dim contiguous (as_strided)
+// weight      : vnni-packed [dim/BLOCK_N, width/2, BLOCK_N, 2]
+// retrieve_*  : [>= batch, >= seqlen] int64 rows
+// icw         : [cache_size, icw_steps, dim, width - 1] contiguous
+template <typename scalar_t>
+void causal_conv1d_update_tree_kernel_impl(
+    scalar_t* __restrict__ out,
+    const scalar_t* __restrict__ input,
+    const scalar_t* __restrict__ conv_states,
+    const scalar_t* __restrict__ weight,
+    const scalar_t* __restrict__ bias,
+    const int32_t* __restrict__ conv_indices,
+    const int64_t* __restrict__ next_token,
+    const int64_t* __restrict__ next_sibling,
+    int64_t* __restrict__ parent_token,
+    scalar_t* __restrict__ icw,
+    const int32_t* __restrict__ icw_indices,
+    int64_t icw_steps,
+    bool silu_activation,
+    int64_t batch,
+    int64_t dim,
+    int64_t seqlen,
+    int64_t width,
+    int64_t next_token_stride,
+    int64_t next_sibling_stride,
+    int64_t parent_token_stride) {
+  const bool has_conv_indices = conv_indices != nullptr;
+  const int64_t state_len = width - 1;
+
+  // step 1: derive each token's parent. A child or sibling link always points
+  // at a larger index, so ascending order sees parent[t] final before use.
+  at::parallel_for(0, batch, 0, [&](int64_t begin, int64_t end) {
+    for (int64_t bs = begin; bs < end; ++bs) {
+      const int64_t* nt = next_token + bs * next_token_stride;
+      const int64_t* ns = next_sibling + bs * next_sibling_stride;
+      int64_t* parent = parent_token + bs * parent_token_stride;
+      std::fill(parent, parent + seqlen, int64_t(0));
+      for (int64_t t = 0; t < seqlen; ++t) {
+        if (nt[t] != -1) {
+          parent[nt[t]] = t;
+        }
+        if (ns[t] != -1) {
+          parent[ns[t]] = parent[t];
+        }
+      }
+    }
+  });
+
+  // step 2: unpack the vnni-packed weight to per-tap fp32 columns [width, dim]
+  constexpr int64_t BN = block_size_n();
+  const int64_t K2 = width / 2;
+  std::vector<float> w_taps(width * dim);
+  for (int64_t k = 0; k < width; ++k) {
+    for (int64_t d = 0; d < dim; ++d) {
+      w_taps[k * dim + d] = static_cast<float>(weight[(((d / BN) * K2 + (k >> 1)) * BN + d % BN) * 2 + (k & 1)]);
+    }
+  }
+
+  // step 3: convolve each token over its ancestors; tokens are independent
+  using bVec = at::vec::Vectorized<scalar_t>;
+  using fVec = at::vec::Vectorized<float>;
+  constexpr int64_t kVecSize = bVec::size();
+  constexpr int64_t fVecSize = fVec::size();
+  const bool has_bias = bias != nullptr;
+
+  at::parallel_for(0, batch * seqlen, 0, [&](int64_t begin, int64_t end) {
+    std::vector<const scalar_t*> srcs(width);
+    std::vector<const scalar_t*> cols(state_len);
+
+    for (int64_t i = begin; i < end; ++i) {
+      int64_t bs = i / seqlen;
+      int64_t t = i % seqlen;
+
+      // padded rows carry a negative slot and their output is discarded
+      int32_t conv_state_index = has_conv_indices ? conv_indices[bs] : bs;
+      if (conv_state_index < 0) {
+        continue;
+      }
+
+      // sources newest-to-oldest: self, then up the tree; indices <= 0 map
+      // onto the committed history columns (0 -> newest = state_len - 1)
+      const int64_t* parent = parent_token + bs * parent_token_stride;
+      int64_t idx = t;
+      for (int64_t j = 0; j < width; ++j) {
+        srcs[j] = (idx >= 0) ? input + (bs * seqlen + idx) * dim
+                             : conv_states + conv_state_index * state_len * dim + (state_len + idx) * dim;
+        idx = (idx > 0) ? parent[idx] : idx - 1;
+      }
+
+      scalar_t* out_ptr = out + (bs * seqlen + t) * dim;
+      int64_t d = 0;
+      for (; d <= dim - kVecSize; d += kVecSize) {
+        fVec acc0(0.f), acc1(0.f);
+        if (has_bias) {
+          std::tie(acc0, acc1) = load_float_vec2(bias + d);
+        }
+        for (int64_t j = 0; j < width; ++j) {
+          const float* w_ptr = w_taps.data() + (width - 1 - j) * dim + d;
+          auto [x0, x1] = load_float_vec2(srcs[j] + d);
+          acc0 = acc0 + x0 * fVec::loadu(w_ptr);
+          acc1 = acc1 + x1 * fVec::loadu(w_ptr + fVecSize);
+        }
+        if (silu_activation) {
+          acc0 = fast_silu(acc0);
+          acc1 = fast_silu(acc1);
+        }
+        bVec out_vec = at::vec::convert_from_float<scalar_t>(acc0, acc1);
+        out_vec.store(out_ptr + d);
+      }
+      for (; d < dim; ++d) {
+        float acc = has_bias ? static_cast<float>(bias[d]) : 0.f;
+        for (int64_t j = 0; j < width; ++j) {
+          acc += static_cast<float>(srcs[j][d]) * w_taps[(width - 1 - j) * dim + d];
+        }
+        if (silu_activation) {
+          acc = acc / (1.f + std::exp(-acc));
+        }
+        out_ptr[d] = static_cast<scalar_t>(acc);
+      }
+
+      // srcs is newest-first, the window oldest-first
+      if (icw != nullptr && icw_indices[bs] >= 0) {
+        for (int64_t w = 0; w < state_len; ++w) {
+          cols[w] = srcs[state_len - 1 - w];
+        }
+        store_intermediate_conv_window<scalar_t>(
+            icw + (icw_indices[bs] * icw_steps + t) * dim * state_len, cols.data(), dim, state_len);
+      }
+    }
+  });
+}
+
 }  // anonymous namespace
 
 // from [dim, width] or [N, K]
@@ -642,6 +793,12 @@ at::Tensor causal_conv1d_fwd_cpu(
 //   cache_seqlens: (batch,), dtype int32.
 //   conv_state_indices: (batch,), dtype int32
 //   pad_slot_id: int
+//   intermediate_conv_window: (cache_size, steps, dim, state_len); per-step
+//       post-update conv windows for speculative verify rollback
+//   intermediate_state_indices: (>= batch,), dtype int32
+//   retrieve_next_token: (>= batch, >= seqlen), int64 first-child links
+//   retrieve_next_sibling: (>= batch, >= seqlen), int64 sibling links
+//   retrieve_parent_token: (>= batch, >= seqlen), int64; written by this call
 //   out: (batch, dim) or (batch, dim, seqlen)
 //
 at::Tensor causal_conv1d_update_cpu(
@@ -653,18 +810,21 @@ at::Tensor causal_conv1d_update_cpu(
     const std::optional<at::Tensor>& cache_seqlens,
     const std::optional<at::Tensor>& conv_state_indices,
     int64_t pad_slot_id,
-    bool is_vnni) {
-  CHECK_CONTIGUOUS(x);
+    bool is_vnni,
+    const std::optional<at::Tensor>& intermediate_conv_window,
+    const std::optional<at::Tensor>& intermediate_state_indices,
+    const std::optional<at::Tensor>& retrieve_next_token,
+    const std::optional<at::Tensor>& retrieve_next_sibling,
+    const std::optional<at::Tensor>& retrieve_parent_token) {
   CHECK_CONTIGUOUS(weight);
   auto packed_w = is_vnni ? weight : causal_conv1d_weight_pack(weight);
 
-  // TODO: add multi-token prediction support
-  TORCH_CHECK(x.dim() == 2, "causal_conv1d_update_cpu: expect x to be 2D tensor.");
+  TORCH_CHECK(x.dim() == 2 || x.dim() == 3, "causal_conv1d_update_cpu: expect x to be 2D or 3D tensor.");
   TORCH_CHECK(!cache_seqlens.has_value(), "causal_conv1d_update_cpu: don't support cache_seqlens.");
 
   int64_t batch = x.size(0);
   int64_t dim = x.size(1);
-  int64_t seqlen = 1;
+  int64_t seqlen = x.dim() == 3 ? x.size(2) : 1;
   int64_t width = weight.size(-1);
 
   const auto scalar_type = x.scalar_type();
@@ -684,20 +844,148 @@ at::Tensor causal_conv1d_update_cpu(
     conv_states.copy_(conv_states_copy);
   }
 
-  at::Tensor out = at::empty_like(x);
+  const bool is_tree = retrieve_next_token.has_value();
+  TORCH_CHECK(
+      retrieve_next_token.has_value() == retrieve_next_sibling.has_value() &&
+          retrieve_next_token.has_value() == retrieve_parent_token.has_value(),
+      "causal_conv1d_update_cpu: retrieve_next_token, retrieve_next_sibling and "
+      "retrieve_parent_token must be passed together.");
+  TORCH_CHECK(!(is_tree && x.dim() == 2), "causal_conv1d_update_cpu: tree verify expects multi-token input.");
+
+  if (x.dim() == 2) {
+    CHECK_CONTIGUOUS(x);
+    at::Tensor out = at::empty_like(x);
+    AT_DISPATCH_REDUCED_FLOATING_TYPES(scalar_type, "causal_conv1d_update_kernel_impl", [&] {
+      causal_conv1d_update_kernel_impl<scalar_t>(
+          out.data_ptr<scalar_t>(),
+          x.data_ptr<scalar_t>(),
+          conv_states.data_ptr<scalar_t>(),
+          packed_w.data_ptr<scalar_t>(),
+          conditional_data_ptr<scalar_t>(bias),
+          conditional_data_ptr<int32_t>(conv_state_indices),
+          silu_activation,
+          batch,
+          dim,
+          1,
+          width);
+    });
+    return out;
+  }
+
+  TORCH_CHECK(
+      intermediate_conv_window.has_value() == intermediate_state_indices.has_value(),
+      "causal_conv1d_update_cpu: intermediate_conv_window and intermediate_state_indices "
+      "must be passed together.");
+  const bool cache_intermediate = intermediate_conv_window.has_value();
+  const int64_t state_len = width - 1;
+  if (cache_intermediate) {
+    auto& icw = intermediate_conv_window.value();
+    auto& isi = intermediate_state_indices.value();
+    CHECK_DIM(4, icw);
+    CHECK_CONTIGUOUS(icw);
+    CHECK_EQ(icw.scalar_type(), scalar_type);
+    CHECK_GE(icw.size(1), seqlen);
+    CHECK_EQ(icw.size(2), dim);
+    CHECK_EQ(icw.size(3), state_len);
+    CHECK_DIM(1, isi);
+    CHECK_EQ(isi.scalar_type(), at::kInt);
+    CHECK_CONTIGUOUS(isi);
+    CHECK_GE(isi.size(0), batch);
+  }
+  const int32_t* intermediate_indices_ptr =
+      cache_intermediate ? intermediate_state_indices.value().data_ptr<int32_t>() : nullptr;
+  const int64_t icw_steps = cache_intermediate ? intermediate_conv_window.value().size(1) : 0;
+
+  if (is_tree) {
+    auto check_retrieve = [&](const at::Tensor& tensor) {
+      CHECK_DIM(2, tensor);
+      CHECK_EQ(tensor.scalar_type(), at::kLong);
+      CHECK_EQ(tensor.stride(1), 1);
+      CHECK_GE(tensor.size(0), batch);
+      CHECK_GE(tensor.size(1), seqlen);
+    };
+    auto& rnt = retrieve_next_token.value();
+    auto& rns = retrieve_next_sibling.value();
+    auto& rpt = retrieve_parent_token.value();
+    check_retrieve(rnt);
+    check_retrieve(rns);
+    check_retrieve(rpt);
+
+    // no-op for the verify call site's transpose view; copies otherwise
+    at::Tensor x_token_major = x.transpose(1, 2).contiguous();
+
+    at::Tensor out_token_major = at::empty({batch, seqlen, dim}, x.options());
+    AT_DISPATCH_REDUCED_FLOATING_TYPES(scalar_type, "causal_conv1d_update_tree_kernel_impl", [&] {
+      causal_conv1d_update_tree_kernel_impl<scalar_t>(
+          out_token_major.data_ptr<scalar_t>(),
+          x_token_major.data_ptr<scalar_t>(),
+          conv_states.data_ptr<scalar_t>(),
+          packed_w.data_ptr<scalar_t>(),
+          conditional_data_ptr<scalar_t>(bias),
+          conditional_data_ptr<int32_t>(conv_state_indices),
+          rnt.data_ptr<int64_t>(),
+          rns.data_ptr<int64_t>(),
+          rpt.data_ptr<int64_t>(),
+          cache_intermediate ? intermediate_conv_window.value().data_ptr<scalar_t>() : nullptr,
+          intermediate_indices_ptr,
+          icw_steps,
+          silu_activation,
+          batch,
+          dim,
+          seqlen,
+          width,
+          rnt.stride(0),
+          rns.stride(0),
+          rpt.stride(0));
+    });
+    return out_token_major.transpose(1, 2);
+  }
+
+  // Chain (topk <= 1) target verify: one draft token per step, updating
+  // conv_state after each. The output is allocated token-major and returned as
+  // its [batch, dim, seqlen] transpose, so the caller's
+  // `.transpose(1, 2).view(...)` stays a zero-copy view.
+  at::Tensor out_token_major = at::empty({batch, seqlen, dim}, x.options());
   AT_DISPATCH_REDUCED_FLOATING_TYPES(scalar_type, "causal_conv1d_update_kernel_impl", [&] {
-    causal_conv1d_update_kernel_impl<scalar_t>(
-        out.data_ptr<scalar_t>(),
-        x.data_ptr<scalar_t>(),
-        conv_states.data_ptr<scalar_t>(),
-        packed_w.data_ptr<scalar_t>(),
-        conditional_data_ptr<scalar_t>(bias),
-        conditional_data_ptr<int32_t>(conv_state_indices),
-        silu_activation,
-        batch,
-        dim,
-        seqlen,
-        width);
+    const int32_t* csi_ptr = conditional_data_ptr<int32_t>(conv_state_indices);
+    scalar_t* icw_ptr = cache_intermediate ? intermediate_conv_window.value().data_ptr<scalar_t>() : nullptr;
+    const scalar_t* cs_ptr = conv_states.data_ptr<scalar_t>();
+    const int64_t entry_size = dim * state_len;
+
+    for (int64_t t = 0; t < seqlen; ++t) {
+      auto x_t = x.select(2, t).contiguous();
+      auto out_t = at::empty({batch, dim}, x_t.options());
+      causal_conv1d_update_kernel_impl<scalar_t>(
+          out_t.data_ptr<scalar_t>(),
+          x_t.data_ptr<scalar_t>(),
+          conv_states.data_ptr<scalar_t>(),
+          packed_w.data_ptr<scalar_t>(),
+          conditional_data_ptr<scalar_t>(bias),
+          csi_ptr,
+          silu_activation,
+          batch,
+          dim,
+          1,
+          width);
+
+      if (icw_ptr != nullptr) {
+        at::parallel_for(0, batch, 0, [&](int64_t begin, int64_t end) {
+          std::vector<const scalar_t*> cols(state_len);
+          for (int64_t b = begin; b < end; ++b) {
+            int32_t idx = intermediate_indices_ptr[b];
+            if (idx < 0) continue;
+            int32_t cs_idx = csi_ptr ? csi_ptr[b] : static_cast<int32_t>(b);
+            const scalar_t* row = cs_ptr + cs_idx * entry_size;
+            for (int64_t w = 0; w < state_len; ++w) {
+              cols[w] = row + w * dim;
+            }
+            store_intermediate_conv_window<scalar_t>(
+                icw_ptr + (idx * icw_steps + t) * entry_size, cols.data(), dim, state_len);
+          }
+        });
+      }
+      out_token_major.select(1, t).copy_(out_t);
+    }
   });
-  return out;
+  return out_token_major.transpose(1, 2);
 }

--- a/python/sglang/kernels/aot/csrc/cpu/mamba/conv.cpp
+++ b/python/sglang/kernels/aot/csrc/cpu/mamba/conv.cpp
@@ -407,6 +407,13 @@ void causal_conv1d_update_kernel_impl(
         const bool has_initial_states_value = true;
         int32_t conv_state_index = has_conv_indices ? conv_indices[bs] : bs;
 
+        // A padded row carries a negative slot: it owns no conv state, so it
+        // is skipped and its output left alone, as the CUDA kernel does.
+        if (conv_state_index < 0) {
+          data_index_step(bs, batch, nb, NB);
+          continue;
+        }
+
         switch (width << 4 | nb_size >> 4) {
           case 0x42:
             LAUNCH_TINYGEMM_KERNEL(4, 32);
@@ -429,8 +436,11 @@ void causal_conv1d_update_kernel_impl(
   // update conv_states
   at::parallel_for(0, batch, 0, [&](int64_t begin, int64_t end) {
     for (int64_t bs = begin; bs < end; ++bs) {
-      // update old states, range [1, width - 1)
       int32_t conv_state_index = has_conv_indices ? conv_indices[bs] : bs;
+      if (conv_state_index < 0) {
+        continue;
+      }
+      // update old states, range [1, width - 1)
       for (int64_t w = 1; w < width - 1; ++w) {
         std::memcpy(CONV_STATE_INDEXR(w - 1), CONV_STATE_INDEXR(w), dim * sizeof(scalar_t));
       }
@@ -787,11 +797,12 @@ at::Tensor causal_conv1d_fwd_cpu(
 // API aligned with GPUs
 //
 //   x: (batch, dim) or (batch, dim, seqlen)
-//   conv_state: (..., dim, state_len), where state_len >= width - 1
+//   conv_state: (..., dim, state_len), where state_len == width - 1
 //   weight: (dim, width)
 //   bias: (dim,)
 //   cache_seqlens: (batch,), dtype int32.
-//   conv_state_indices: (batch,), dtype int32
+//   conv_state_indices: (batch,), dtype int32; a negative entry marks a padded
+//       row, which owns no conv state and is skipped
 //   pad_slot_id: int
 //   intermediate_conv_window: (cache_size, steps, dim, state_len); per-step
 //       post-update conv windows for speculative verify rollback
@@ -851,6 +862,9 @@ at::Tensor causal_conv1d_update_cpu(
       "causal_conv1d_update_cpu: retrieve_next_token, retrieve_next_sibling and "
       "retrieve_parent_token must be passed together.");
   TORCH_CHECK(!(is_tree && x.dim() == 2), "causal_conv1d_update_cpu: tree verify expects multi-token input.");
+  TORCH_CHECK(
+      !(x.dim() == 2 && intermediate_conv_window.has_value()),
+      "causal_conv1d_update_cpu: the single-token path caches no conv window.");
 
   if (x.dim() == 2) {
     CHECK_CONTIGUOUS(x);
@@ -973,8 +987,9 @@ at::Tensor causal_conv1d_update_cpu(
           std::vector<const scalar_t*> cols(state_len);
           for (int64_t b = begin; b < end; ++b) {
             int32_t idx = intermediate_indices_ptr[b];
-            if (idx < 0) continue;
             int32_t cs_idx = csi_ptr ? csi_ptr[b] : static_cast<int32_t>(b);
+            // a padded row has no window to cache, and no slot to cache it in
+            if (idx < 0 || cs_idx < 0) continue;
             const scalar_t* row = cs_ptr + cs_idx * entry_size;
             for (int64_t w = 0; w < state_len; ++w) {
               cols[w] = row + w * dim;

--- a/python/sglang/kernels/aot/csrc/cpu/mamba/fla.cpp
+++ b/python/sglang/kernels/aot/csrc/cpu/mamba/fla.cpp
@@ -1091,6 +1091,18 @@ inline at::vec::Vectorized<float> softplus(const at::vec::Vectorized<float>& x, 
   return Vec::blendv(Vec::blendv(log1pex, expx, mask_lo), x, mask_hi);
 }
 
+// Varlen recurrent delta-rule update with sigmoid gating.
+//
+// Tokens are flattened over (q.size(0), q.size(1)) and partitioned into
+// sequences by `cu_seqlens` (decode: T == 1 per sequence; target verify:
+// T == draft_token_num). Parallelized over (sequence, v_head); the in-sequence
+// recurrence is sequential on a thread-local fp32 copy `h` of the state slot,
+// written back once at the end (skipped under `disable_state_update`, which
+// target verify uses to keep the persistent pool untouched). When `isb_ptr`
+// is set, the post-step state of every draft token is dumped to the
+// intermediate-states buffer so the accepted step can be committed after
+// verification. With `parent_ptr` (tree verify) each draft starts from its
+// tree parent's cached state rather than the previous draft's.
 template <typename scalar_t, typename param_t>
 void fused_sigmoid_gating_delta_rule_update_kernel_impl(
     const scalar_t* __restrict__ q_ptr,
@@ -1100,144 +1112,195 @@ void fused_sigmoid_gating_delta_rule_update_kernel_impl(
     const scalar_t* __restrict__ a_ptr,
     const scalar_t* __restrict__ dt_bias_ptr,
     const scalar_t* __restrict__ b_ptr,
-    const int32_t* __restrict__ indices_ptr,
+    const int32_t* __restrict__ initial_state_indices_ptr,
     float* __restrict__ state_ptr,
     scalar_t* __restrict__ o_ptr,
     float* __restrict__ qk_scale_buf,
-    int64_t seq_len,
-    int64_t batch_size,
+    const int32_t* __restrict__ cu_seqlens_ptr,
+    float* __restrict__ isb_ptr,
+    const int32_t* __restrict__ isi_ptr,
+    int64_t isb_cache_steps,
+    const int64_t* __restrict__ parent_ptr,
+    int64_t parent_stride,
+    int64_t num_sequences,
+    int64_t total_tokens,
     int64_t num_heads,
     int64_t head_dim,
     int64_t v_num_heads,
     int64_t v_head_dim,
-    int64_t q_strideB,
-    int64_t q_strideS,
-    int64_t q_strideH,
-    int64_t k_strideB,
-    int64_t k_strideS,
-    int64_t k_strideH,
-    int64_t v_strideB,
-    int64_t v_strideS,
-    int64_t v_strideH,
+    int64_t q_stride_token,
+    int64_t q_stride_head,
+    int64_t k_stride_token,
+    int64_t k_stride_head,
+    int64_t v_stride_token,
+    int64_t v_stride_head,
     bool use_qk_l2norm_in_kernel,
+    bool disable_state_update,
     double softplus_threshold) {
   using bVec = at::vec::Vectorized<scalar_t>;
   using fVec = at::vec::Vectorized<float>;
-
   constexpr int64_t VecSize = bVec::size();
   constexpr int64_t fVecSize = fVec::size();
+
   int64_t group_size = v_num_heads / num_heads;
-  double scale = 1 / std::sqrt(head_dim);
-  fVec scale_vec = fVec(scale);
+  double scale = 1.0 / std::sqrt(static_cast<double>(head_dim));
+  fVec scale_vec = fVec(static_cast<float>(scale));
+
+  const int64_t state_entry_size = head_dim * v_head_dim;
+  const int64_t state_slot_stride = v_num_heads * state_entry_size;
+  const int64_t isb_step_stride = state_slot_stride;
+  const int64_t isb_cache_stride = isb_cache_steps * isb_step_stride;
+
   if (use_qk_l2norm_in_kernel) {
-    float eps = 1e-5;
-    at::parallel_for(0, batch_size * seq_len * num_heads, 0, [&](int64_t begin, int64_t end) {
-      int64_t bi{0}, si{0}, ni{0};
-      data_index_init(begin, bi, batch_size, si, seq_len, ni, num_heads);
+    float eps = 1e-5f;
+    at::parallel_for(0, total_tokens * num_heads, 0, [&](int64_t begin, int64_t end) {
+      int64_t ti{0}, ni{0};
+      data_index_init(begin, ti, total_tokens, ni, num_heads);
       for (int64_t i = begin; i < end; ++i) {
-        float sum_q = float(0);
-        float sum_k = float(0);
-        fVec sum_q_fvec = fVec(float(0));
-        fVec sum_k_fvec = fVec(float(0));
-        int64_t q_offset = bi * q_strideB + si * q_strideS + ni * q_strideH;
-        int64_t k_offset = bi * k_strideB + si * k_strideS + ni * k_strideH;
-        int64_t q_scale_offset = bi * seq_len * num_heads + si * num_heads + ni;
-        int64_t k_scale_offset = q_scale_offset + batch_size * seq_len * num_heads;
+        float sum_q = 0, sum_k = 0;
+        fVec sum_q_fvec(0.f), sum_k_fvec(0.f);
+        int64_t q_off = ti * q_stride_token + ni * q_stride_head;
+        int64_t k_off = ti * k_stride_token + ni * k_stride_head;
         int64_t d;
 #pragma GCC unroll 4
         for (d = 0; d <= head_dim - VecSize; d += VecSize) {
-          auto [q_fvec0, q_fvec1] = load_float_vec2(q_ptr + q_offset + d);
+          auto [q_fvec0, q_fvec1] = load_float_vec2(q_ptr + q_off + d);
           sum_q_fvec += q_fvec0 * q_fvec0;
           sum_q_fvec += q_fvec1 * q_fvec1;
-          auto [k_fvec0, k_fvec1] = load_float_vec2(k_ptr + k_offset + d);
+          auto [k_fvec0, k_fvec1] = load_float_vec2(k_ptr + k_off + d);
           sum_k_fvec += k_fvec0 * k_fvec0;
           sum_k_fvec += k_fvec1 * k_fvec1;
         }
 #pragma GCC unroll 4
         for (; d < head_dim; ++d) {
-          float q_val = static_cast<float>(q_ptr[q_offset + d]);
-          sum_q += q_val * q_val;
-          float k_val = static_cast<float>(k_ptr[k_offset + d]);
-          sum_k += k_val * k_val;
+          float qv = static_cast<float>(q_ptr[q_off + d]);
+          sum_q += qv * qv;
+          float kv = static_cast<float>(k_ptr[k_off + d]);
+          sum_k += kv * kv;
         }
-
         sum_q += vec_reduce_sum(sum_q_fvec);
         sum_k += vec_reduce_sum(sum_k_fvec);
-        qk_scale_buf[q_scale_offset] = float(1) / std::sqrt(sum_q + eps);
-        qk_scale_buf[k_scale_offset] = float(1) / std::sqrt(sum_k + eps);
-
-        data_index_step(bi, batch_size, si, seq_len, ni, num_heads);
+        int64_t idx = ti * num_heads + ni;
+        qk_scale_buf[idx] = 1.f / std::sqrt(sum_q + eps);
+        qk_scale_buf[total_tokens * num_heads + idx] = 1.f / std::sqrt(sum_k + eps);
+        data_index_step(ti, total_tokens, ni, num_heads);
       }
     });
   }
-  at::parallel_for(0, batch_size * seq_len * v_num_heads, 0, [&](int64_t begin, int64_t end) {
-    int64_t bi{0}, si{0}, ni{0};
-    data_index_init(begin, bi, batch_size, si, seq_len, ni, v_num_heads);
-    for (int64_t i = begin; i < end; ++i) {
-      int64_t cache_index = indices_ptr[bi];
-      int64_t state_offset = (cache_index * v_num_heads + ni) * head_dim * v_head_dim;
-      float g_val = -std::exp(float(A_log_ptr[ni])) *
-                    softplus(float(a_ptr[bi * v_num_heads + ni]) + float(dt_bias_ptr[ni]), softplus_threshold);
-      float g_val_exp = std::exp(g_val);
-      fVec g_val_exp_vec = fVec(g_val_exp);
-      int64_t q_offset = si * q_strideS + bi * q_strideB + (ni / group_size) * q_strideH;
-      int64_t k_offset = si * k_strideS + bi * k_strideB + (ni / group_size) * k_strideH;
-      int64_t q_scale_offset = bi * seq_len * num_heads + si * num_heads + (ni / group_size);
-      int64_t k_scale_offset = q_scale_offset + batch_size * seq_len * num_heads;
-      float q_scale = use_qk_l2norm_in_kernel ? qk_scale_buf[q_scale_offset] : 1.0f;
-      float k_scale = use_qk_l2norm_in_kernel ? qk_scale_buf[k_scale_offset] : 1.0f;
-      int64_t v_offset = si * v_strideS + bi * v_strideB + ni * v_strideH;
-      int64_t o_offset = ((bi * seq_len + si) * v_num_heads + ni) * v_head_dim;
-      float beta_val = 1 / (1 + std::exp(-b_ptr[bi * v_num_heads + ni]));
-      fVec beta_vec = fVec(beta_val);
-      int64_t dvi = 0;
-      for (; dvi <= v_head_dim - VecSize; dvi += VecSize) {
-        fVec kv_mem_vec0 = fVec(float(0));
-        fVec kv_mem_vec1 = fVec(float(0));
-        for (int di = 0; di < head_dim; ++di) {
-          fVec k_val_vec = fVec(k_ptr[k_offset + di] * k_scale);
-          auto [state_vec0, state_vec1] = load_float_vec2(state_ptr + state_offset + di * v_head_dim + dvi);
-          kv_mem_vec0 = kv_mem_vec0 + state_vec0 * g_val_exp_vec * k_val_vec;
-          kv_mem_vec1 = kv_mem_vec1 + state_vec1 * g_val_exp_vec * k_val_vec;
+
+  at::parallel_for(0, num_sequences * v_num_heads, 0, [&](int64_t begin, int64_t end) {
+    std::vector<float> h_buf(state_entry_size);
+
+    int64_t i_n{0}, ni{0};
+    data_index_init(begin, i_n, num_sequences, ni, v_num_heads);
+
+    for (int64_t idx = begin; idx < end; ++idx) {
+      int64_t bos = cu_seqlens_ptr[i_n];
+      int64_t T = cu_seqlens_ptr[i_n + 1] - bos;
+
+      int32_t state_idx = initial_state_indices_ptr[i_n];
+      float* h = h_buf.data();
+      std::memcpy(
+          h, state_ptr + state_idx * state_slot_stride + ni * state_entry_size, state_entry_size * sizeof(float));
+
+      int32_t cache_idx = (isi_ptr != nullptr) ? isi_ptr[i_n] : -1;
+      int64_t qk_head = ni / group_size;
+
+      for (int64_t t = 0; t < T; ++t) {
+        int64_t pos = bos + t;
+
+        // Tree verify: reload the parent's cached post-step state; a chain
+        // parent (t - 1) is already in `h` bit-identically from its dump below
+        if (parent_ptr != nullptr && t > 0 && cache_idx >= 0) {
+          int64_t parent = parent_ptr[i_n * parent_stride + t];
+          if (parent != t - 1) {
+            std::memcpy(
+                h,
+                isb_ptr + cache_idx * isb_cache_stride + parent * isb_step_stride + ni * state_entry_size,
+                state_entry_size * sizeof(float));
+          }
         }
-        auto [v_vec0, v_vec1] = load_float_vec2(v_ptr + v_offset + dvi);
-        fVec dt_vec0 = (v_vec0 - kv_mem_vec0) * beta_vec;
-        fVec dt_vec1 = (v_vec1 - kv_mem_vec1) * beta_vec;
-        fVec o_vec0 = fVec(float(0));
-        fVec o_vec1 = fVec(float(0));
-        for (int di = 0; di < head_dim; ++di) {
-          fVec q_vec = fVec(q_ptr[q_offset + di] * q_scale);
-          fVec k_vec = fVec(k_ptr[k_offset + di] * k_scale);
-          auto [state_vec0, state_vec1] = load_float_vec2(state_ptr + state_offset + di * v_head_dim + dvi);
-          state_vec0 = state_vec0 * g_val_exp_vec + k_vec * dt_vec0;
-          state_vec1 = state_vec1 * g_val_exp_vec + k_vec * dt_vec1;
-          o_vec0 = o_vec0 + state_vec0 * q_vec * scale_vec;
-          o_vec1 = o_vec1 + state_vec1 * q_vec * scale_vec;
-          state_vec0.store(state_ptr + state_offset + di * v_head_dim + dvi);
-          state_vec1.store(state_ptr + state_offset + di * v_head_dim + dvi + fVecSize);
+
+        float g_val = -std::exp(static_cast<float>(A_log_ptr[ni])) *
+                      softplus(
+                          static_cast<float>(a_ptr[pos * v_num_heads + ni]) + static_cast<float>(dt_bias_ptr[ni]),
+                          softplus_threshold);
+        float g_val_exp = std::exp(g_val);
+        fVec g_val_exp_vec(g_val_exp);
+
+        float beta_val = 1.f / (1.f + std::exp(-static_cast<float>(b_ptr[pos * v_num_heads + ni])));
+        fVec beta_vec(beta_val);
+
+        int64_t q_off = pos * q_stride_token + qk_head * q_stride_head;
+        int64_t k_off = pos * k_stride_token + qk_head * k_stride_head;
+        int64_t v_off = pos * v_stride_token + ni * v_stride_head;
+        int64_t o_off = (pos * v_num_heads + ni) * v_head_dim;
+
+        float q_scale = use_qk_l2norm_in_kernel ? qk_scale_buf[pos * num_heads + qk_head] : 1.0f;
+        float k_scale =
+            use_qk_l2norm_in_kernel ? qk_scale_buf[total_tokens * num_heads + pos * num_heads + qk_head] : 1.0f;
+
+        int64_t dvi = 0;
+        for (; dvi <= v_head_dim - VecSize; dvi += VecSize) {
+          fVec kv_mem_vec0(0.f), kv_mem_vec1(0.f);
+          for (int64_t di = 0; di < head_dim; ++di) {
+            fVec k_val_vec(static_cast<float>(k_ptr[k_off + di]) * k_scale);
+            auto [state_vec0, state_vec1] = load_float_vec2(h + di * v_head_dim + dvi);
+            kv_mem_vec0 = kv_mem_vec0 + state_vec0 * g_val_exp_vec * k_val_vec;
+            kv_mem_vec1 = kv_mem_vec1 + state_vec1 * g_val_exp_vec * k_val_vec;
+          }
+          auto [v_vec0, v_vec1] = load_float_vec2(v_ptr + v_off + dvi);
+          fVec dt_vec0 = (v_vec0 - kv_mem_vec0) * beta_vec;
+          fVec dt_vec1 = (v_vec1 - kv_mem_vec1) * beta_vec;
+
+          fVec o_vec0(0.f), o_vec1(0.f);
+          for (int64_t di = 0; di < head_dim; ++di) {
+            fVec q_vec(static_cast<float>(q_ptr[q_off + di]) * q_scale);
+            fVec k_vec(static_cast<float>(k_ptr[k_off + di]) * k_scale);
+            auto [state_vec0, state_vec1] = load_float_vec2(h + di * v_head_dim + dvi);
+            state_vec0 = state_vec0 * g_val_exp_vec + k_vec * dt_vec0;
+            state_vec1 = state_vec1 * g_val_exp_vec + k_vec * dt_vec1;
+            o_vec0 = o_vec0 + state_vec0 * q_vec * scale_vec;
+            o_vec1 = o_vec1 + state_vec1 * q_vec * scale_vec;
+            state_vec0.store(h + di * v_head_dim + dvi);
+            state_vec1.store(h + di * v_head_dim + dvi + fVecSize);
+          }
+          bVec o_bvec = at::vec::convert_from_float<scalar_t>(o_vec0, o_vec1);
+          o_bvec.store(o_ptr + o_off + dvi);
         }
-        bVec o_vec = at::vec::convert_from_float<scalar_t>(o_vec0, o_vec1);
-        o_vec.store(o_ptr + o_offset + dvi);
+        for (; dvi < v_head_dim; ++dvi) {
+          float kv_mem = 0;
+          for (int64_t di = 0; di < head_dim; ++di) {
+            float k_val = static_cast<float>(k_ptr[k_off + di]) * k_scale;
+            h[di * v_head_dim + dvi] *= g_val_exp;
+            kv_mem += h[di * v_head_dim + dvi] * k_val;
+          }
+          float v_val = static_cast<float>(v_ptr[v_off + dvi]);
+          float dt = (v_val - kv_mem) * beta_val;
+          float o_val = 0;
+          for (int64_t di = 0; di < head_dim; ++di) {
+            float q_val = static_cast<float>(q_ptr[q_off + di]) * q_scale;
+            float k_val = static_cast<float>(k_ptr[k_off + di]) * k_scale;
+            h[di * v_head_dim + dvi] += k_val * dt;
+            o_val += h[di * v_head_dim + dvi] * q_val * scale;
+          }
+          o_ptr[o_off + dvi] = static_cast<scalar_t>(o_val);
+        }
+
+        if (isb_ptr != nullptr && cache_idx >= 0) {
+          std::memcpy(
+              isb_ptr + cache_idx * isb_cache_stride + t * isb_step_stride + ni * state_entry_size,
+              h,
+              state_entry_size * sizeof(float));
+        }
       }
-      for (; dvi < v_head_dim; ++dvi) {
-        float kv_mem_val = 0;
-        for (int di = 0; di < head_dim; ++di) {
-          float k_val = k_ptr[k_offset + di] * k_scale;
-          state_ptr[state_offset + di * v_head_dim + dvi] *= g_val_exp;
-          kv_mem_val += state_ptr[state_offset + di * v_head_dim + dvi] * k_val;
-        }
-        float v_val = v_ptr[v_offset + dvi];
-        float dt_val = (v_val - kv_mem_val) * beta_val;
-        float o_val = 0;
-        for (int di = 0; di < head_dim; ++di) {
-          float q_val = q_ptr[q_offset + di] * q_scale;
-          float k_val = k_ptr[k_offset + di] * k_scale;
-          state_ptr[state_offset + di * v_head_dim + dvi] += k_val * dt_val;
-          o_val += state_ptr[state_offset + di * v_head_dim + dvi] * q_val * scale;
-        }
-        o_ptr[o_offset + dvi] = o_val;
+
+      if (!disable_state_update) {
+        std::memcpy(
+            state_ptr + state_idx * state_slot_stride + ni * state_entry_size, h, state_entry_size * sizeof(float));
       }
-      data_index_step(bi, batch_size, si, seq_len, ni, v_num_heads);
+
+      data_index_step(i_n, num_sequences, ni, v_num_heads);
     }
   });
 }
@@ -1597,16 +1660,17 @@ std::tuple<at::Tensor, at::Tensor> chunk_gated_delta_rule_cpu(
   return std::make_tuple(output, final_state);
 }
 
-// A_log: [v_num_heads]
+// A_log: [v_num_heads] (fp32 or q's dtype)
 // dt_bias: [v_num_heads]
-// query: [seq_len, batch_size, num_heads, head_dim]
-// key: [seq_len, batch_size, num_heads, head_dim]
-// value: [seq_len, batch_size, v_num_heads, v_head_dim]
-// a: [batch_size, v_num_heads]
-// b: [batch_size, v_num_heads]
-// initial_state_source:[num_tokens, v_num_heads, head_dim, v_head_dim]
-// initial_state_indices: [batch_size]
-// cu_seqlens: [batch_size + 1]
+// query/key: [d0, d1, num_heads, head_dim] with d0 * d1 == total_tokens
+// value: [d0, d1, v_num_heads, v_head_dim]
+// a: [total_tokens, v_num_heads]
+// b: [total_tokens, v_num_heads]
+// initial_state_source: [num_slots, v_num_heads, head_dim, v_head_dim]
+// initial_state_indices: [>= num_sequences] (only the first num_sequences read)
+// cu_seqlens: [num_sequences + 1]
+// intermediate_states_buffer: [cache_size, cache_steps, v_num_heads, head_dim, v_head_dim]
+// intermediate_state_indices: [>= num_sequences] (only the first num_sequences read)
 at::Tensor fused_sigmoid_gating_delta_rule_update_cpu(
     const at::Tensor& A_log,
     const at::Tensor& dt_bias,
@@ -1618,47 +1682,102 @@ at::Tensor fused_sigmoid_gating_delta_rule_update_cpu(
     at::Tensor& initial_state_source,
     const at::Tensor& initial_state_indices,
     const at::Tensor& cu_seqlens,
-    bool use_qk_l2norm_in_kernel,
+    bool use_qk_l2norm_in_kernel = true,
     double softplus_beta = 1.0,
-    double softplus_threshold = 20.0) {
+    double softplus_threshold = 20.0,
+    bool is_kda = false,
+    bool disable_state_update = false,
+    const std::optional<at::Tensor>& intermediate_states_buffer = std::nullopt,
+    const std::optional<at::Tensor>& intermediate_state_indices = std::nullopt,
+    int64_t cache_steps = 0,
+    const std::optional<at::Tensor>& retrieve_parent_token = std::nullopt) {
+  TORCH_CHECK(!is_kda, "fused_sigmoid_gating_delta_rule_update_cpu: is_kda is not supported on CPU");
   CHECK_DIM(4, q);
   CHECK_DIM(4, v);
   CHECK_LAST_DIM_CONTIGUOUS_INPUT(q);
-  int64_t seq_len = q.size(0);
-  int64_t batch_size = q.size(1);
+
+  int64_t total_tokens = q.size(0) * q.size(1);
+  int64_t num_sequences = cu_seqlens.size(0) - 1;
+
   int64_t num_heads = q.size(2);
   int64_t head_dim = q.size(3);
   int64_t v_num_heads = v.size(2);
   int64_t v_head_dim = v.size(3);
-  CHECK_INPUT_SHAPE_DTYPE<true>(k, {seq_len, batch_size, num_heads, head_dim}, q.scalar_type());
-  CHECK_INPUT_SHAPE_DTYPE<true>(v, {seq_len, batch_size, v_num_heads, v_head_dim}, q.scalar_type());
-  CHECK_INPUT_SHAPE_DTYPE<true>(a, {batch_size, v_num_heads}, q.scalar_type());
-  CHECK_INPUT_SHAPE_DTYPE<true>(dt_bias, {v_num_heads}, q.scalar_type());
-  CHECK_INPUT_SHAPE_DTYPE<true>(b, {batch_size, v_num_heads}, q.scalar_type());
-  CHECK_INPUT_SHAPE_DTYPE<true>(initial_state_indices, {batch_size}, at::kInt);
-  CHECK_INPUT_SHAPE_DTYPE<true>(cu_seqlens, {batch_size + 1}, at::kInt);
-  CHECK_INPUT_SHAPE_DTYPE<true>(
-      initial_state_source, {initial_state_source.size(0), v_num_heads, head_dim, v_head_dim}, at::kFloat);
-  CHECK(initial_state_source.size(0) >= batch_size);
-  CHECK_EQ(v_num_heads % num_heads, 0);
-  TORCH_CHECK(
-      A_log.sizes() == at::IntArrayRef({v_num_heads}),
-      "Input tensor shape mismatch: expected ",
-      at::IntArrayRef({v_num_heads}),
-      ", got ",
-      A_log.sizes());
 
-  int64_t q_strideB = q.stride(1);
-  int64_t q_strideS = q.stride(0);
-  int64_t q_strideH = q.stride(2);
-  int64_t k_strideB = k.stride(1);
-  int64_t k_strideS = k.stride(0);
-  int64_t k_strideH = k.stride(2);
-  int64_t v_strideB = v.stride(1);
-  int64_t v_strideS = v.stride(0);
-  int64_t v_strideH = v.stride(2);
-  at::Tensor core_attn_out = at::empty({batch_size, seq_len, v_num_heads, v_head_dim}, q.options());
-  at::Tensor qk_scale_buf = at::empty({2 * batch_size, seq_len, num_heads}, at::kFloat);
+  CHECK_INPUT_SHAPE_DTYPE<true>(k, {q.size(0), q.size(1), num_heads, head_dim}, q.scalar_type());
+  CHECK_INPUT_SHAPE_DTYPE<true>(v, {q.size(0), q.size(1), v_num_heads, v_head_dim}, q.scalar_type());
+  CHECK_INPUT_SHAPE_DTYPE<false>(a, {total_tokens, v_num_heads}, q.scalar_type());
+  CHECK_INPUT_SHAPE_DTYPE<false>(b, {total_tokens, v_num_heads}, q.scalar_type());
+  // A_log accepts fp32 or q's reduced dtype (dispatch below pairs them as param_t).
+  CHECK_INPUT_SHAPE_DTYPE<false>(
+      A_log, {v_num_heads}, A_log.scalar_type() == at::kFloat ? at::kFloat : q.scalar_type());
+  CHECK_INPUT_SHAPE_DTYPE<false>(dt_bias, {v_num_heads}, q.scalar_type());
+  CHECK_INPUT_SHAPE_DTYPE<false>(
+      initial_state_source, {initial_state_source.size(0), v_num_heads, head_dim, v_head_dim}, at::kFloat);
+  CHECK(initial_state_source.size(0) >= num_sequences);
+  CHECK_EQ(v_num_heads % num_heads, 0);
+  CHECK_INPUT_SHAPE_DTYPE<false>(cu_seqlens, {num_sequences + 1}, at::kInt);
+  // Like the CUDA kernel, index tensors may be longer than the sequence count
+  // (e.g. an arange over the whole state pool); only the first num_sequences
+  // entries are read.
+  CHECK_DIM(1, initial_state_indices);
+  CHECK_EQ(initial_state_indices.scalar_type(), at::kInt);
+  CHECK_CONTIGUOUS(initial_state_indices);
+  CHECK_GE(initial_state_indices.size(0), num_sequences);
+
+  float* isb_ptr = nullptr;
+  const int32_t* isi_ptr = nullptr;
+  int64_t isb_cache_steps = 0;
+
+  if (intermediate_states_buffer.has_value()) {
+    auto& isb = intermediate_states_buffer.value();
+    CHECK_CONTIGUOUS(isb);
+    CHECK_EQ(isb.scalar_type(), at::kFloat);
+    CHECK_DIM(5, isb);
+    TORCH_CHECK(isb.size(1) >= cache_steps, "intermediate_states_buffer cache_steps too small");
+    CHECK_EQ(isb.size(2), v_num_heads);
+    CHECK_EQ(isb.size(3), head_dim);
+    CHECK_EQ(isb.size(4), v_head_dim);
+    // Derive the per-slot step capacity from the buffer shape (like the CUDA
+    // wrapper) instead of trusting the runtime cache_steps argument.
+    isb_cache_steps = isb.size(1);
+    isb_ptr = isb.data_ptr<float>();
+  }
+
+  if (intermediate_state_indices.has_value()) {
+    auto& isi = intermediate_state_indices.value();
+    CHECK_DIM(1, isi);
+    CHECK_EQ(isi.scalar_type(), at::kInt);
+    CHECK_CONTIGUOUS(isi);
+    CHECK_GE(isi.size(0), num_sequences);
+    isi_ptr = isi.data_ptr<int32_t>();
+  }
+
+  const int64_t* parent_ptr = nullptr;
+  int64_t parent_stride = 0;
+  if (retrieve_parent_token.has_value()) {
+    TORCH_CHECK(
+        isb_ptr != nullptr && isi_ptr != nullptr,
+        "fused_sigmoid_gating_delta_rule_update_cpu: retrieve_parent_token requires "
+        "intermediate_states_buffer and intermediate_state_indices");
+    auto& rpt = retrieve_parent_token.value();
+    CHECK_DIM(2, rpt);
+    CHECK_EQ(rpt.scalar_type(), at::kLong);
+    CHECK_EQ(rpt.stride(1), 1);
+    CHECK_GE(rpt.size(0), num_sequences);
+    parent_ptr = rpt.data_ptr<int64_t>();
+    parent_stride = rpt.stride(0);
+  }
+
+  int64_t q_stride_token = q.stride(1);
+  int64_t q_stride_head = q.stride(2);
+  int64_t k_stride_token = k.stride(1);
+  int64_t k_stride_head = k.stride(2);
+  int64_t v_stride_token = v.stride(1);
+  int64_t v_stride_head = v.stride(2);
+
+  at::Tensor core_attn_out = at::empty({q.size(0), q.size(1), v_num_heads, v_head_dim}, q.options());
+  at::Tensor qk_scale_buf = at::empty({2 * total_tokens, num_heads}, at::kFloat);
 
   CPU_DISPATCH_REDUCED_FLOATING_TYPES_EXT(
       q.scalar_type(), A_log.scalar_type(), "fused_sigmoid_gating_delta_rule_update_kernel_impl", [&] {
@@ -1674,22 +1793,26 @@ at::Tensor fused_sigmoid_gating_delta_rule_update_cpu(
             initial_state_source.data_ptr<float>(),
             core_attn_out.data_ptr<scalar_t>(),
             qk_scale_buf.data_ptr<float>(),
-            seq_len,
-            batch_size,
+            cu_seqlens.data_ptr<int32_t>(),
+            isb_ptr,
+            isi_ptr,
+            isb_cache_steps,
+            parent_ptr,
+            parent_stride,
+            num_sequences,
+            total_tokens,
             num_heads,
             head_dim,
             v_num_heads,
             v_head_dim,
-            q_strideB,
-            q_strideS,
-            q_strideH,
-            k_strideB,
-            k_strideS,
-            k_strideH,
-            v_strideB,
-            v_strideS,
-            v_strideH,
+            q_stride_token,
+            q_stride_head,
+            k_stride_token,
+            k_stride_head,
+            v_stride_token,
+            v_stride_head,
             use_qk_l2norm_in_kernel,
+            disable_state_update,
             softplus_threshold);
       });
   return core_attn_out;

--- a/python/sglang/kernels/aot/csrc/cpu/mamba/fla.cpp
+++ b/python/sglang/kernels/aot/csrc/cpu/mamba/fla.cpp
@@ -1198,10 +1198,16 @@ void fused_sigmoid_gating_delta_rule_update_kernel_impl(
       int64_t bos = cu_seqlens_ptr[i_n];
       int64_t T = cu_seqlens_ptr[i_n + 1] - bos;
 
+      // A padded row carries a negative slot: it owns no state, so it starts
+      // from zero and commits nothing, as the CUDA kernel does.
       int32_t state_idx = initial_state_indices_ptr[i_n];
       float* h = h_buf.data();
-      std::memcpy(
-          h, state_ptr + state_idx * state_slot_stride + ni * state_entry_size, state_entry_size * sizeof(float));
+      if (state_idx >= 0) {
+        std::memcpy(
+            h, state_ptr + state_idx * state_slot_stride + ni * state_entry_size, state_entry_size * sizeof(float));
+      } else {
+        std::fill(h, h + state_entry_size, 0.f);
+      }
 
       int32_t cache_idx = (isi_ptr != nullptr) ? isi_ptr[i_n] : -1;
       int64_t qk_head = ni / group_size;
@@ -1295,7 +1301,7 @@ void fused_sigmoid_gating_delta_rule_update_kernel_impl(
         }
       }
 
-      if (!disable_state_update) {
+      if (!disable_state_update && state_idx >= 0) {
         std::memcpy(
             state_ptr + state_idx * state_slot_stride + ni * state_entry_size, h, state_entry_size * sizeof(float));
       }
@@ -1768,6 +1774,13 @@ at::Tensor fused_sigmoid_gating_delta_rule_update_cpu(
     parent_ptr = rpt.data_ptr<int64_t>();
     parent_stride = rpt.stride(0);
   }
+
+  // Tokens are addressed as one flat [total_tokens] run, so a batch dim wider
+  // than one has to be packed against the token dim.
+  auto token_packed = [](const at::Tensor& t) { return t.size(0) == 1 || t.stride(0) == t.size(1) * t.stride(1); };
+  TORCH_CHECK(
+      token_packed(q) && token_packed(k) && token_packed(v),
+      "fused_sigmoid_gating_delta_rule_update_cpu: expect q/k/v tokens packed across the batch dim.");
 
   int64_t q_stride_token = q.stride(1);
   int64_t q_stride_head = q.stride(2);

--- a/python/sglang/kernels/aot/csrc/cpu/mamba/state_scatter.cpp
+++ b/python/sglang/kernels/aot/csrc/cpu/mamba/state_scatter.cpp
@@ -1,0 +1,166 @@
+#include "common.h"
+
+namespace {
+
+constexpr int64_t kMaxEntryDims = 4;
+
+template <typename scalar_t>
+void mamba_state_scatter_with_mask_kernel_impl(
+    scalar_t* __restrict__ dst,
+    const scalar_t* __restrict__ src,
+    const int32_t* __restrict__ dst_indices,
+    const int32_t* __restrict__ step_indices,
+    const int64_t* __restrict__ entry_sizes,
+    const int64_t* __restrict__ src_entry_strides,
+    const int64_t* __restrict__ dst_entry_strides,
+    int64_t entry_ndim,
+    int64_t elem_per_entry,
+    bool entry_contiguous,
+    int64_t num_layers,
+    int64_t num_requests,
+    int64_t dst_layer_stride,
+    int64_t dst_req_stride,
+    int64_t src_layer_stride,
+    int64_t src_req_stride,
+    int64_t src_step_stride,
+    int64_t dst_cache_size,
+    int64_t src_req_size,
+    int64_t src_step_size) {
+  at::parallel_for(0, num_requests * num_layers, 0, [&](int64_t begin, int64_t end) {
+    for (int64_t i = begin; i < end; ++i) {
+      int64_t req = i / num_layers;
+      int64_t layer = i % num_layers;
+
+      // A padded request carries a negative step or slot and commits nothing
+      int64_t step = step_indices[req];
+      int64_t dst_index = dst_indices[req];
+      if (step < 0 || step >= src_step_size || req >= src_req_size) {
+        continue;
+      }
+      if (dst_index < 0 || dst_index >= dst_cache_size) {
+        continue;
+      }
+
+      scalar_t* __restrict__ dst_entry = dst + layer * dst_layer_stride + dst_index * dst_req_stride;
+      const scalar_t* __restrict__ src_entry =
+          src + layer * src_layer_stride + req * src_req_stride + step * src_step_stride;
+
+      if (entry_contiguous) {
+        std::memcpy(dst_entry, src_entry, elem_per_entry * sizeof(scalar_t));
+        continue;
+      }
+      // Odometer over the entry dims, advancing both offsets by their strides
+      int64_t coord[kMaxEntryDims] = {0};
+      int64_t src_offset = 0;
+      int64_t dst_offset = 0;
+      for (int64_t e = 0; e < elem_per_entry; ++e) {
+        dst_entry[dst_offset] = src_entry[src_offset];
+        for (int64_t d = entry_ndim - 1; d >= 0; --d) {
+          coord[d]++;
+          src_offset += src_entry_strides[d];
+          dst_offset += dst_entry_strides[d];
+          if (coord[d] < entry_sizes[d]) {
+            break;
+          }
+          coord[d] = 0;
+          src_offset -= entry_sizes[d] * src_entry_strides[d];
+          dst_offset -= entry_sizes[d] * dst_entry_strides[d];
+        }
+      }
+    }
+  });
+}
+
+}  // anonymous namespace
+
+// Commit one accepted per-step state per request into the persistent caches,
+// for every mamba layer at once:
+//
+//   dst[layer, dst_indices[i]] = src[layer, i, step_indices[i]]
+//
+// CPU counterpart of the Triton fused_mamba_state_scatter_with_mask and
+// fused_conv_window_scatter_with_mask.
+//
+// Either entry may be strided - the CPU conv kernel keeps conv_states
+// dim-contiguous, and the deduplicated conv-window source overlaps its
+// per-step windows - so both sides are indexed through their own strides.
+//
+//   dst : [num_layers, cache_size, *entry]
+//   src : [num_layers, num_requests, steps, *entry]
+//   dst_indices / step_indices : [num_requests] int32; a negative entry marks
+//       a request with nothing to commit
+//
+void mamba_state_scatter_with_mask_cpu(
+    at::Tensor& dst, const at::Tensor& src, const at::Tensor& dst_indices, const at::Tensor& step_indices) {
+  CHECK_CPU(dst);
+  CHECK_CPU(src);
+  CHECK_GE(dst.dim(), 2);
+  CHECK_EQ(src.dim(), dst.dim() + 1);
+  CHECK_EQ(dst.scalar_type(), src.scalar_type());
+  CHECK_EQ(dst.size(0), src.size(0));
+
+  const int64_t entry_ndim = dst.dim() - 2;
+  TORCH_CHECK(
+      entry_ndim <= kMaxEntryDims,
+      "mamba_state_scatter_with_mask_cpu: expect at most ",
+      kMaxEntryDims,
+      " entry dims, got ",
+      entry_ndim);
+  for (int64_t d = 0; d < entry_ndim; ++d) {
+    CHECK_EQ(dst.size(d + 2), src.size(d + 3));
+  }
+
+  CHECK_DIM(1, dst_indices);
+  CHECK_DIM(1, step_indices);
+  CHECK_CONTIGUOUS(dst_indices);
+  CHECK_CONTIGUOUS(step_indices);
+  CHECK_EQ(dst_indices.scalar_type(), at::kInt);
+  CHECK_EQ(step_indices.scalar_type(), at::kInt);
+  CHECK_EQ(dst_indices.size(0), step_indices.size(0));
+
+  const int64_t num_requests = step_indices.size(0);
+
+  // Layer and slot strides are read off the tensors because an envelope pool
+  // view spaces its slots out
+  int64_t elem_per_entry = 1;
+  int64_t entry_sizes[kMaxEntryDims];
+  int64_t src_entry_strides[kMaxEntryDims];
+  int64_t dst_entry_strides[kMaxEntryDims];
+  bool entry_contiguous = true;
+  int64_t expected = 1;
+  for (int64_t d = entry_ndim - 1; d >= 0; --d) {
+    entry_sizes[d] = dst.size(d + 2);
+    src_entry_strides[d] = src.stride(d + 3);
+    dst_entry_strides[d] = dst.stride(d + 2);
+    if (dst.size(d + 2) != 1) {
+      entry_contiguous = entry_contiguous && src.stride(d + 3) == expected && dst.stride(d + 2) == expected;
+    }
+    expected *= dst.size(d + 2);
+    elem_per_entry *= dst.size(d + 2);
+  }
+
+  AT_DISPATCH_FLOATING_TYPES_AND2(
+      at::kBFloat16, at::kHalf, dst.scalar_type(), "mamba_state_scatter_with_mask_kernel_impl", [&] {
+        mamba_state_scatter_with_mask_kernel_impl<scalar_t>(
+            dst.data_ptr<scalar_t>(),
+            src.data_ptr<scalar_t>(),
+            dst_indices.data_ptr<int32_t>(),
+            step_indices.data_ptr<int32_t>(),
+            entry_sizes,
+            src_entry_strides,
+            dst_entry_strides,
+            entry_ndim,
+            elem_per_entry,
+            entry_contiguous,
+            dst.size(0),
+            num_requests,
+            dst.stride(0),
+            dst.stride(1),
+            src.stride(0),
+            src.stride(1),
+            src.stride(2),
+            dst.size(1),
+            src.size(1),
+            src.size(2));
+      });
+}

--- a/python/sglang/kernels/aot/csrc/cpu/norm.cpp
+++ b/python/sglang/kernels/aot/csrc/cpu/norm.cpp
@@ -9,12 +9,13 @@ struct NormParams {
   //   3D -> [B, 1, T, D]
   //   4D -> [B, H, T, D]
   //
-  // Input: last dimension contiguous.
+  // Input and residual: last dimension contiguous.
   // Output: contiguous.
 
   int ndim{0};
   int64_t B{1}, H{1}, T{1}, D{1};
   int64_t i_strideB{0}, i_strideH{0}, i_strideT{0};
+  int64_t r_strideB{0}, r_strideH{0}, r_strideT{0};
   float eps{1e-5f};
   float shift{0.f};
 
@@ -43,6 +44,21 @@ struct NormParams {
       default:
         TORCH_INTERNAL_ASSERT(false);
     }
+
+    r_strideB = H * T * D;
+    r_strideH = T * D;
+    r_strideT = D;
+  }
+
+  // Updated in place, so it needs its own strides not the output layout
+  void set_residual(const at::Tensor& residual) {
+    r_strideB = residual.stride(0);
+    if (ndim == 3) {
+      r_strideT = residual.stride(1);
+    } else if (ndim == 4) {
+      r_strideH = residual.stride(1);
+      r_strideT = residual.stride(2);
+    }
   }
 
   inline int64_t rows() const {
@@ -53,6 +69,9 @@ struct NormParams {
   }
   inline int64_t output_offset(int64_t b, int64_t h, int64_t t) const {
     return ((b * H + h) * T + t) * D;
+  }
+  inline int64_t residual_offset(int64_t b, int64_t h, int64_t t) const {
+    return b * r_strideB + h * r_strideH + t * r_strideT;
   }
 };
 
@@ -429,7 +448,7 @@ void fused_add_norm4d_kernel_impl(
     bool output_uses_input_stride = false) {
   LAUNCH_PARALLEL_LOOP(
       const int64_t out_offset = output_uses_input_stride ? p.input_offset(b, h, t) : p.output_offset(b, h, t);
-      scalar_t* __restrict__ residual_ptr = residual + p.output_offset(b, h, t);
+      scalar_t* __restrict__ residual_ptr = residual + p.residual_offset(b, h, t);
       NormReduceGeneric<M, scalar_t, true>::apply(
           out + out_offset, input + p.input_offset(b, h, t), nullptr, residual_ptr, p, p.D));
 }
@@ -782,12 +801,12 @@ at::Tensor fused_rmsnorm_gated_cpu(at::Tensor& input, at::Tensor& weight, at::Te
 void fused_add_rmsnorm_cpu(at::Tensor& input, at::Tensor& residual, at::Tensor& weight, double eps) {
   const auto st = input.scalar_type();
   CHECK_INPUT_ND<2, 3>(input);
-  CHECK_EQ(input.sizes(), residual.sizes());
-  CHECK_EQ(st, residual.scalar_type());
+  CHECK_INPUT_SHAPE_DTYPE<true>(residual, input.sizes(), st);
   CHECK_INPUT_SHAPE_DTYPE<false>(weight, {input.size(-1)}, st);
 
   NormParams p{input, static_cast<float>(eps)};
   p.weight = weight.data_ptr();
+  p.set_residual(residual);
 
   AT_DISPATCH_REDUCED_FLOATING_TYPES(st, "fused_add_rmsnorm_kernel", [&] {
     fused_add_norm4d_kernel_impl<NormMode::RMSNorm, scalar_t>(
@@ -805,13 +824,13 @@ void fused_add_rmsnorm_cpu(at::Tensor& input, at::Tensor& residual, at::Tensor& 
 void gemma_fused_add_rmsnorm_cpu(at::Tensor& input, at::Tensor& residual, at::Tensor& weight, double eps) {
   const auto st = input.scalar_type();
   CHECK_INPUT_ND<2>(input);
-  CHECK_EQ(input.sizes(), residual.sizes());
-  CHECK_EQ(st, residual.scalar_type());
+  CHECK_INPUT_SHAPE_DTYPE<true>(residual, input.sizes(), st);
   CHECK_INPUT_SHAPE_DTYPE<false>(weight, {input.size(-1)}, st);
 
   NormParams p{input, static_cast<float>(eps)};
   p.weight = weight.data_ptr();
   p.shift = 1.f;
+  p.set_residual(residual);
 
   AT_DISPATCH_REDUCED_FLOATING_TYPES(st, "gemma_fused_add_rmsnorm_kernel", [&] {
     fused_add_norm4d_kernel_impl<NormMode::GemmaNorm, scalar_t>(
@@ -836,8 +855,7 @@ at::Tensor fused_add_layernorm_cpu(
   const auto st = input.scalar_type();
   const int64_t hidden_size = input.size(-1);
   CHECK_INPUT_ND<2, 3>(input);
-  CHECK_EQ(input.sizes(), residual.sizes());
-  CHECK_EQ(st, residual.scalar_type());
+  CHECK_INPUT_SHAPE_DTYPE<true>(residual, input.sizes(), st);
   CHECK_INPUT_SHAPE_DTYPE<false>(weight, {hidden_size}, st);
   if (bias.has_value()) {
     CHECK_INPUT_SHAPE_DTYPE<false>(bias.value(), {hidden_size}, st);
@@ -846,6 +864,7 @@ at::Tensor fused_add_layernorm_cpu(
   NormParams p{input, static_cast<float>(eps)};
   p.weight = weight.data_ptr();
   p.bias = bias.has_value() ? bias.value().data_ptr() : nullptr;
+  p.set_residual(residual);
 
   at::Tensor output = at::empty_like(input);
   AT_DISPATCH_REDUCED_FLOATING_TYPES(st, "fused_add_layernorm_kernel", [&] {

--- a/python/sglang/kernels/aot/csrc/cpu/torch_extension_cpu.cpp
+++ b/python/sglang/kernels/aot/csrc/cpu/torch_extension_cpu.cpp
@@ -458,6 +458,10 @@ at::Tensor causal_conv1d_update_cpu(
     const std::optional<at::Tensor>& retrieve_parent_token = std::nullopt);
 #endif
 
+// post-verify mamba state commit
+void mamba_state_scatter_with_mask_cpu(
+    at::Tensor& dst, const at::Tensor& src, const at::Tensor& dst_indices, const at::Tensor& step_indices);
+
 // conv3d fast path for patch embedding
 at::Tensor conv3d_embed_weight_pack(const at::Tensor& weight);
 
@@ -862,6 +866,12 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "Tensor(c!)? retrieve_parent_token=None) -> Tensor");
   m.impl("causal_conv1d_update_cpu", torch::kCPU, &causal_conv1d_update_cpu);
 #endif
+
+  // post-verify mamba state commit
+  m.def(
+      "mamba_state_scatter_with_mask_cpu(Tensor(a!) dst, Tensor src, Tensor dst_indices, "
+      "Tensor step_indices) -> ()");
+  m.impl("mamba_state_scatter_with_mask_cpu", torch::kCPU, &mamba_state_scatter_with_mask_cpu);
 
   // conv3d fast path for patch embedding
   m.def("conv3d_embed_weight_pack(Tensor weight) -> Tensor");

--- a/python/sglang/kernels/aot/csrc/cpu/torch_extension_cpu.cpp
+++ b/python/sglang/kernels/aot/csrc/cpu/torch_extension_cpu.cpp
@@ -450,7 +450,12 @@ at::Tensor causal_conv1d_update_cpu(
     const std::optional<at::Tensor>& cache_seqlens,
     const std::optional<at::Tensor>& conv_state_indices,
     int64_t pad_slot_id,
-    bool is_vnni);
+    bool is_vnni,
+    const std::optional<at::Tensor>& intermediate_conv_window = std::nullopt,
+    const std::optional<at::Tensor>& intermediate_state_indices = std::nullopt,
+    const std::optional<at::Tensor>& retrieve_next_token = std::nullopt,
+    const std::optional<at::Tensor>& retrieve_next_sibling = std::nullopt,
+    const std::optional<at::Tensor>& retrieve_parent_token = std::nullopt);
 #endif
 
 // conv3d fast path for patch embedding
@@ -513,9 +518,15 @@ at::Tensor fused_sigmoid_gating_delta_rule_update_cpu(
     at::Tensor& initial_state_source,
     const at::Tensor& initial_state_indices,
     const at::Tensor& cu_seqlens,
-    bool use_qk_l2norm_in_kernel,
+    bool use_qk_l2norm_in_kernel = true,
     double softplus_beta = 1.0,
-    double softplus_threshold = 20.0);
+    double softplus_threshold = 20.0,
+    bool is_kda = false,
+    bool disable_state_update = false,
+    const std::optional<at::Tensor>& intermediate_states_buffer = std::nullopt,
+    const std::optional<at::Tensor>& intermediate_state_indices = std::nullopt,
+    int64_t cache_steps = 0,
+    const std::optional<at::Tensor>& retrieve_parent_token = std::nullopt);
 // fused_gdn_gating
 std::tuple<at::Tensor, at::Tensor>
 fused_gdn_gating_cpu(const at::Tensor& A_log, const at::Tensor& a, const at::Tensor& b, const at::Tensor& dt_bias);
@@ -845,7 +856,10 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
 
   m.def(
       "causal_conv1d_update_cpu(Tensor x, Tensor(a!) conv_states, Tensor weight, Tensor? bias, bool silu_activation,"
-      "Tensor? cache_seqlens, Tensor? conv_state_indices, int pad_slot_id, bool is_vnni) -> Tensor");
+      "Tensor? cache_seqlens, Tensor? conv_state_indices, int pad_slot_id, bool is_vnni,"
+      "Tensor(b!)? intermediate_conv_window=None, Tensor? intermediate_state_indices=None,"
+      "Tensor? retrieve_next_token=None, Tensor? retrieve_next_sibling=None,"
+      "Tensor(c!)? retrieve_parent_token=None) -> Tensor");
   m.impl("causal_conv1d_update_cpu", torch::kCPU, &causal_conv1d_update_cpu);
 #endif
 
@@ -890,8 +904,11 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   // fused_sigmoid_gating_delta_rule_update
   m.def(
       "fused_sigmoid_gating_delta_rule_update_cpu(Tensor A_log, Tensor dt_bias, Tensor q, Tensor k, Tensor v, Tensor "
-      "a, Tensor b, Tensor(a!) initial_state_source, Tensor initial_state_indices, Tensor cu_seqlens, bool "
-      "use_qk_l2norm_in_kernel, float softplus_beta=1.0, float softplus_threshold=20.0) -> Tensor");
+      "a, Tensor b, Tensor(a!) initial_state_source, Tensor initial_state_indices, Tensor cu_seqlens, "
+      "bool use_qk_l2norm_in_kernel=True, float softplus_beta=1.0, float softplus_threshold=20.0, "
+      "bool is_kda=False, bool disable_state_update=False, "
+      "Tensor(b!)? intermediate_states_buffer=None, Tensor? intermediate_state_indices=None, "
+      "int cache_steps=0, Tensor? retrieve_parent_token=None) -> Tensor");
   m.impl("fused_sigmoid_gating_delta_rule_update_cpu", torch::kCPU, &fused_sigmoid_gating_delta_rule_update_cpu);
   // fused_gdn_gating
   m.def("fused_gdn_gating_cpu(Tensor A_log, Tensor a, Tensor b, Tensor dt_bias) -> (Tensor, Tensor)");

--- a/python/sglang/kernels/aot/python/sgl_kernel/mamba.py
+++ b/python/sglang/kernels/aot/python/sgl_kernel/mamba.py
@@ -76,7 +76,17 @@ def causal_conv1d_fn_cpu(
 
 
 def causal_conv1d_update_cpu(
-    mixed_qkv, conv_states, conv_weights, bias, activation, conv_state_indices
+    mixed_qkv,
+    conv_states,
+    conv_weights,
+    bias,
+    activation,
+    conv_state_indices,
+    intermediate_conv_window=None,
+    intermediate_state_indices=None,
+    retrieve_next_token=None,
+    retrieve_next_sibling=None,
+    retrieve_parent_token=None,
 ):
     return torch.ops.sgl_kernel.causal_conv1d_update_cpu(
         mixed_qkv,
@@ -88,6 +98,11 @@ def causal_conv1d_update_cpu(
         conv_state_indices,
         -1,
         True,
+        intermediate_conv_window,
+        intermediate_state_indices,
+        retrieve_next_token,
+        retrieve_next_sibling,
+        retrieve_parent_token,
     )
 
 

--- a/python/sglang/kernels/ops/mamba/mamba_state_scatter_triton.py
+++ b/python/sglang/kernels/ops/mamba/mamba_state_scatter_triton.py
@@ -10,6 +10,13 @@ import torch
 import triton
 import triton.language as tl
 
+from sglang.srt.utils import is_cpu
+
+_is_cpu = is_cpu()
+
+if _is_cpu:
+    import sgl_kernel  # noqa: F401
+
 
 def _require_entry_contiguous_dst(
     dst: torch.Tensor, entry_start_dim: int, fn_name: str
@@ -150,11 +157,10 @@ def _state_scatter_with_mask_torch(
     dst_indices_raw: torch.Tensor,
     step_indices_raw: torch.Tensor,
 ):
-    """Non-CUDA fallback for the masked state scatters.
+    """Fallback for accelerators without a masked-scatter kernel of their own.
 
     Advanced indexing reads/writes through arbitrary strides, so it serves the
-    dense SSM/conv layouts used on CPU and NPU and the overlapping conv-window
-    view alike.
+    dense SSM/conv layouts and the overlapping conv-window view alike.
     """
     valid_mask = step_indices_raw >= 0
     if not valid_mask.any():
@@ -163,6 +169,25 @@ def _state_scatter_with_mask_torch(
     dst_indices = dst_indices_raw[valid_indices].long()
     step_indices = step_indices_raw[valid_indices].long()
     dst[:, dst_indices] = src[:, valid_indices, step_indices]
+
+
+def _state_scatter_with_mask(
+    dst: torch.Tensor,
+    src: torch.Tensor,
+    dst_indices_raw: torch.Tensor,
+    step_indices_raw: torch.Tensor,
+):
+    """Non-CUDA masked state scatter: the CPU kernel where it applies."""
+    if not _is_cpu:
+        _state_scatter_with_mask_torch(dst, src, dst_indices_raw, step_indices_raw)
+        return
+
+    torch.ops.sgl_kernel.mamba_state_scatter_with_mask_cpu(
+        dst,
+        src,
+        dst_indices_raw.to(torch.int32).contiguous(),
+        step_indices_raw.to(torch.int32).contiguous(),
+    )
 
 
 @triton.jit
@@ -270,7 +295,7 @@ def fused_mamba_state_scatter_with_mask(
             f"dst and src must be on the same device. {dst.device=} {src.device=}"
         )
     if not dst.is_cuda or not src.is_cuda:
-        _state_scatter_with_mask_torch(dst, src, dst_indices_raw, step_indices_raw)
+        _state_scatter_with_mask(dst, src, dst_indices_raw, step_indices_raw)
         return
     if dst.ndim < 2 or src.ndim < 3:
         raise ValueError(f"Unexpected tensor ranks: {dst.ndim=} {src.ndim=}")
@@ -433,7 +458,7 @@ def fused_conv_window_scatter_with_mask(
             f"dst and src must be on the same device. {dst.device=} {src.device=}"
         )
     if not dst.is_cuda or not src.is_cuda:
-        _state_scatter_with_mask_torch(dst, src, dst_indices_raw, step_indices_raw)
+        _state_scatter_with_mask(dst, src, dst_indices_raw, step_indices_raw)
         return
     if dst.ndim != 4 or src.ndim != 5:
         raise ValueError(f"Unexpected ranks: {dst.ndim=} (want 4) {src.ndim=} (want 5)")

--- a/python/sglang/kernels/ops/mamba/mamba_state_scatter_triton.py
+++ b/python/sglang/kernels/ops/mamba/mamba_state_scatter_triton.py
@@ -144,6 +144,27 @@ def track_mamba_states_if_needed(
     )
 
 
+def _state_scatter_with_mask_torch(
+    dst: torch.Tensor,
+    src: torch.Tensor,
+    dst_indices_raw: torch.Tensor,
+    step_indices_raw: torch.Tensor,
+):
+    """Non-CUDA fallback for the masked state scatters.
+
+    Advanced indexing reads/writes through arbitrary strides, so it serves the
+    dense SSM/conv layouts used on CPU and NPU and the overlapping conv-window
+    view alike.
+    """
+    valid_mask = step_indices_raw >= 0
+    if not valid_mask.any():
+        return
+    valid_indices = valid_mask.nonzero(as_tuple=True)[0]
+    dst_indices = dst_indices_raw[valid_indices].long()
+    step_indices = step_indices_raw[valid_indices].long()
+    dst[:, dst_indices] = src[:, valid_indices, step_indices]
+
+
 @triton.jit
 def _fused_mamba_state_scatter_with_mask_kernel(
     src_ptr,
@@ -249,9 +270,8 @@ def fused_mamba_state_scatter_with_mask(
             f"dst and src must be on the same device. {dst.device=} {src.device=}"
         )
     if not dst.is_cuda or not src.is_cuda:
-        raise ValueError(
-            "fused_mamba_state_scatter_with_mask only supports CUDA tensors."
-        )
+        _state_scatter_with_mask_torch(dst, src, dst_indices_raw, step_indices_raw)
+        return
     if dst.ndim < 2 or src.ndim < 3:
         raise ValueError(f"Unexpected tensor ranks: {dst.ndim=} {src.ndim=}")
     if dst.shape[0] != src.shape[0]:
@@ -408,11 +428,13 @@ def fused_conv_window_scatter_with_mask(
     if total_requests == 0:
         return
 
-    if not (dst.is_cuda and src.is_cuda and dst.device == src.device):
+    if dst.device != src.device:
         raise ValueError(
-            "fused_conv_window_scatter_with_mask requires dst and src to be CUDA "
-            f"tensors on the same device ({dst.device=}, {src.device=})."
+            f"dst and src must be on the same device. {dst.device=} {src.device=}"
         )
+    if not dst.is_cuda or not src.is_cuda:
+        _state_scatter_with_mask_torch(dst, src, dst_indices_raw, step_indices_raw)
+        return
     if dst.ndim != 4 or src.ndim != 5:
         raise ValueError(f"Unexpected ranks: {dst.ndim=} (want 4) {src.ndim=} (want 5)")
     if dst.shape[0] != src.shape[0]:
@@ -587,6 +609,9 @@ def _conv_multi_eligible(pairs) -> bool:
         return False
     layers = pairs[0][0].shape[0]
     for dst, src in pairs:
+        # Triton-only fast path; off-CUDA the per-pair scatter falls back to torch
+        if not dst.is_cuda or not src.is_cuda:
+            return False
         if dst.dtype != torch.bfloat16 or src.dtype != torch.bfloat16:
             return False
         if dst.ndim != 4 or src.ndim != 5:

--- a/python/sglang/kernels/ops/mamba/mamba_state_scatter_triton.py
+++ b/python/sglang/kernels/ops/mamba/mamba_state_scatter_triton.py
@@ -151,36 +151,22 @@ def track_mamba_states_if_needed(
     )
 
 
-def _state_scatter_with_mask_torch(
-    dst: torch.Tensor,
-    src: torch.Tensor,
-    dst_indices_raw: torch.Tensor,
-    step_indices_raw: torch.Tensor,
-):
-    """Fallback for accelerators without a masked-scatter kernel of their own.
-
-    Advanced indexing reads/writes through arbitrary strides, so it serves the
-    dense SSM/conv layouts and the overlapping conv-window view alike.
-    """
-    valid_mask = step_indices_raw >= 0
-    if not valid_mask.any():
-        return
-    valid_indices = valid_mask.nonzero(as_tuple=True)[0]
-    dst_indices = dst_indices_raw[valid_indices].long()
-    step_indices = step_indices_raw[valid_indices].long()
-    dst[:, dst_indices] = src[:, valid_indices, step_indices]
-
-
 def _state_scatter_with_mask(
     dst: torch.Tensor,
     src: torch.Tensor,
     dst_indices_raw: torch.Tensor,
     step_indices_raw: torch.Tensor,
 ):
-    """Non-CUDA masked state scatter: the CPU kernel where it applies."""
-    if not _is_cpu:
-        _state_scatter_with_mask_torch(dst, src, dst_indices_raw, step_indices_raw)
-        return
+    """Masked state scatter off CUDA, which only the CPU kernel implements.
+
+    It indexes both entries through their own strides, so it serves the dense
+    SSM/conv layouts and the overlapping conv-window view alike.
+    """
+    if dst.device.type != "cpu":
+        raise ValueError(
+            "masked mamba state scatter is implemented for CUDA and CPU tensors "
+            f"only. {dst.device=}"
+        )
 
     torch.ops.sgl_kernel.mamba_state_scatter_with_mask_cpu(
         dst,
@@ -634,7 +620,7 @@ def _conv_multi_eligible(pairs) -> bool:
         return False
     layers = pairs[0][0].shape[0]
     for dst, src in pairs:
-        # Triton-only fast path; off-CUDA the per-pair scatter falls back to torch
+        # Triton-only fast path; off CUDA every pair takes the per-pair scatter
         if not dst.is_cuda or not src.is_cuda:
             return False
         if dst.dtype != torch.bfloat16 or src.dtype != torch.bfloat16:

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -550,6 +550,25 @@ def supports_mamba_cache_extra_buffer(view: Any, model_arch: str) -> bool:
     return False
 
 
+def routes_mamba_radix_cache(hf_config: Any, model_arch: str) -> bool:
+    """Whether ``model_arch`` routes through the hybrid-mamba radix cache
+    handling: either the linear-attention registry says so, or the arch is one
+    of the mamba-radix archs (GraniteMoeHybrid only when it has mamba layers).
+    Pure read."""
+    from sglang.srt.configs.linear_attn_model_registry import (
+        get_linear_attn_spec_by_arch,
+    )
+
+    in_branch = model_arch in _MAMBA_RADIX_CACHE_ARCHS
+    if model_arch == "GraniteMoeHybridForCausalLM":
+        in_branch = any(
+            layer_type == "mamba"
+            for layer_type in getattr(hf_config, "layer_types", [])
+        )
+    spec = get_linear_attn_spec_by_arch(model_arch)
+    return (spec is not None and spec.uses_mamba_radix_cache) or in_branch
+
+
 @register_post_process
 def _mamba_radix_cache_resolution(view: Any) -> dict:
     """Resolve the hybrid-mamba radix cache fields (pure).
@@ -561,21 +580,10 @@ def _mamba_radix_cache_resolution(view: Any) -> dict:
     guard replicates the union of the legacy call-site guards so the pass is
     self-sufficient in the end-state pass list.
     """
-    from sglang.srt.configs.linear_attn_model_registry import (
-        get_linear_attn_spec_by_arch,
-    )
-
     hf_config = model_config_of(view).hf_config
     model_arch = hf_config.architectures[0]
 
-    in_branch = model_arch in _MAMBA_RADIX_CACHE_ARCHS
-    if model_arch == "GraniteMoeHybridForCausalLM":
-        in_branch = any(
-            layer_type == "mamba"
-            for layer_type in getattr(hf_config, "layer_types", [])
-        )
-    spec = get_linear_attn_spec_by_arch(model_arch)
-    if not ((spec is not None and spec.uses_mamba_radix_cache) or in_branch):
+    if not routes_mamba_radix_cache(hf_config, model_arch):
         return {}
 
     if view.disable_radix_cache:

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -13,6 +13,7 @@ from sglang.srt.arg_groups.overrides import (
     model_config_of,
     resolved_view,
     resolving_view,
+    routes_mamba_radix_cache,
     run_post_process_pass,
 )
 from sglang.srt.runtime_context import get_platform
@@ -36,6 +37,22 @@ def _disable_overlap_schedule_for_cpu(server_args: ServerArgs) -> None:
     logger.warning(
         "Overlap schedule is not implemented for speculative decoding on CPU."
     )
+
+
+def _reject_mamba_radix_cache_for_cpu_spec(server_args: ServerArgs) -> None:
+    """CPU resolves the strategy to no_buffer, which has no spec-aware state
+    tracking, and has no extra_buffer FLA kernels to fall back on."""
+    cfg = resolving_view(server_args)
+    if cfg.device != "cpu" or cfg.disable_radix_cache:
+        return
+
+    hf_config = model_config_of(server_args).hf_config
+    model_arch = hf_config.architectures[0]
+    if routes_mamba_radix_cache(hf_config, model_arch):
+        raise ValueError(
+            f"Speculative decoding for {model_arch} is not compatible with "
+            "the mamba radix cache on CPU. Pass --disable-radix-cache."
+        )
 
 
 def _resolve_speculative_algorithm_alias(
@@ -661,6 +678,7 @@ def _handle_eagle_family(server_args: ServerArgs) -> None:
         )
 
     _disable_overlap_schedule_for_cpu(server_args)
+    _reject_mamba_radix_cache_for_cpu_spec(server_args)
 
     if resolved_view(server_args).disable_overlap_schedule:
         logger.warning(
@@ -826,6 +844,7 @@ def _handle_ngram(server_args: ServerArgs) -> None:
         )
 
     _disable_overlap_schedule_for_cpu(server_args)
+    _reject_mamba_radix_cache_for_cpu_spec(server_args)
 
     if cfg.max_running_requests is None:
         declare_resolution(

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -40,8 +40,11 @@ def _disable_overlap_schedule_for_cpu(server_args: ServerArgs) -> None:
 
 
 def _reject_mamba_radix_cache_for_cpu_spec(server_args: ServerArgs) -> None:
-    """CPU resolves the strategy to no_buffer, which has no spec-aware state
-    tracking, and has no extra_buffer FLA kernels to fall back on."""
+    """Neither mamba radix cache strategy serves speculative decoding on CPU:
+    extra_buffer needs FLA kernels CPU does not have, and no_buffer has no
+    spec-aware state tracking. The extra_buffer arm is already refused during
+    the model-hook resolution that runs before this one, so this guard covers
+    the no_buffer arm and names the flag that resolves either."""
     cfg = resolving_view(server_args)
     if cfg.device != "cpu" or cfg.disable_radix_cache:
         return

--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -1186,7 +1186,12 @@ class GemmaRMSNorm(BaseFusedOp):
         post_residual_addition: Optional[torch.Tensor] = None,
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
         if _is_cpu_amx_available:
+            # The AMX kernels update x/residual in place and require contiguous
+            # tensors; speculative-decoding paths can pass strided views (the
+            # caller consumes the returned tensors, so copying is safe).
+            x = x.contiguous()
             if residual is not None:
+                residual = residual.contiguous()
                 if post_residual_addition is not None:
                     residual = residual + post_residual_addition
                 torch.ops.sgl_kernel.gemma_fused_add_rmsnorm_cpu(

--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -1186,12 +1186,7 @@ class GemmaRMSNorm(BaseFusedOp):
         post_residual_addition: Optional[torch.Tensor] = None,
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
         if _is_cpu_amx_available:
-            # The AMX kernels update x/residual in place and require contiguous
-            # tensors; speculative-decoding paths can pass strided views (the
-            # caller consumes the returned tensors, so copying is safe).
-            x = x.contiguous()
             if residual is not None:
-                residual = residual.contiguous()
                 if post_residual_addition is not None:
                     residual = residual + post_residual_addition
                 torch.ops.sgl_kernel.gemma_fused_add_rmsnorm_cpu(

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -748,7 +748,7 @@ class MambaPool:
                             temporal_state_shape[2],
                         ),
                         dtype=ssm_dtype,
-                        device="cuda",
+                        device=device,
                     )
                 # Cache intermediate conv windows (last K-1 inputs) per draft token
                 # during target verify.
@@ -816,7 +816,7 @@ class MambaPool:
                                 conv_shape[1],
                             ),
                             dtype=conv_dtype,
-                            device="cuda",
+                            device=device,
                         )
                         for conv_shape in dense_conv_shapes
                     ]

--- a/python/sglang/srt/model_executor/cpu_graph_runner.py
+++ b/python/sglang/srt/model_executor/cpu_graph_runner.py
@@ -533,17 +533,19 @@ def register_fake_ops(tp_size: int):
         initial_state_source,
         initial_state_indices,
         cu_seqlens,
-        use_qk_l2norm_in_kernel,
+        use_qk_l2norm_in_kernel=True,
         softplus_beta=1.0,
         softplus_threshold=20.0,
+        is_kda=False,
+        disable_state_update=False,
+        intermediate_states_buffer=None,
+        intermediate_state_indices=None,
+        cache_steps=0,
+        retrieve_parent_token=None,
     ):
         assert q.dim() == 4
         assert v.dim() == 4
-        batch_size = q.shape[1]
-        seq_len = q.shape[0]
-        v_num_heads = v.shape[2]
-        v_head_dim = v.shape[3]
-        return q.new_empty(batch_size, seq_len, v_num_heads, v_head_dim)
+        return q.new_empty(q.shape[0], q.shape[1], v.shape[2], v.shape[3])
 
     @register_cpu_compile_fake("fused_gdn_gating_cpu")
     def _(A_log, a, b, dt_bias):

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -96,6 +96,7 @@ from sglang.srt.models.utils import (
     fused_qk_gemma_rmsnorm,
     fused_qk_gemma_rmsnorm_with_gate,
 )
+from sglang.srt.platforms import current_platform
 from sglang.srt.runtime_context import (
     get_exec,
     get_forward,
@@ -2148,12 +2149,8 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration):
         if self.pp_group.is_last_rank and head is not None:
             del self.lm_head.weight
             self.lm_head.weight = head
-        if _is_xpu:
-            torch.xpu.empty_cache()
-            torch.xpu.synchronize()
-        else:
-            torch.cuda.empty_cache()
-            torch.cuda.synchronize()
+        current_platform.empty_cache()
+        current_platform.synchronize()
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         weights = QWEN3_5_KV_SCALE_MAPPER.apply(weights)
@@ -2318,12 +2315,8 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3VLForConditionalGeneration):
         if self.pp_group.is_last_rank and head is not None:
             del self.lm_head.weight
             self.lm_head.weight = head
-        if _is_xpu:
-            torch.xpu.empty_cache()
-            torch.xpu.synchronize()
-        else:
-            torch.cuda.empty_cache()
-            torch.cuda.synchronize()
+        current_platform.empty_cache()
+        current_platform.synchronize()
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         weights = QWEN3_5_KV_SCALE_MAPPER.apply(weights)

--- a/python/sglang/srt/models/qwen3_5_mtp.py
+++ b/python/sglang/srt/models/qwen3_5_mtp.py
@@ -34,6 +34,7 @@ from sglang.srt.layers.vocab_parallel_embedding import ParallelLMHead
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.qwen3_5 import QWEN3_5_KV_SCALE_MAPPER, Qwen3_5ForCausalLM
+from sglang.srt.platforms import current_platform
 from sglang.srt.runtime_context import (
     get_model,
     get_parallel,
@@ -162,8 +163,8 @@ class Qwen3_5ForCausalLMMTP(nn.Module):
         if head is not None and not self.config.tie_word_embeddings:
             del self.lm_head.weight
             self.lm_head.weight = head
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        current_platform.empty_cache()
+        current_platform.synchronize()
 
     def set_lm_head_from_target(self, target_lm_head):
         if self.config.tie_word_embeddings:

--- a/python/sglang/srt/models/qwen3_5_text.py
+++ b/python/sglang/srt/models/qwen3_5_text.py
@@ -29,6 +29,7 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTe
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models import qwen3_5
 from sglang.srt.models.qwen2_moe import Qwen2MoeSparseMoeBlock
+from sglang.srt.platforms import current_platform
 from sglang.srt.runtime_context import get_parallel
 from sglang.srt.utils import LazyValue, add_prefix
 
@@ -143,8 +144,8 @@ class Qwen3_5ForCausalLM(nn.Module):
         del self.lm_head.weight
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        current_platform.empty_cache()
+        current_platform.synchronize()
 
     def set_dflash_layers_to_capture(self, layers_to_capture: list[int]):
         if not self.pp_group.is_last_rank:

--- a/python/sglang/srt/models/qwen3_next.py
+++ b/python/sglang/srt/models/qwen3_next.py
@@ -49,6 +49,7 @@ from sglang.srt.model_loader.weight_utils import (
     sharded_weight_loader,
 )
 from sglang.srt.models.qwen2_moe import Qwen2MoeMLP, Qwen2MoeSparseMoeBlock
+from sglang.srt.platforms import current_platform
 from sglang.srt.runtime_context import get_forward, get_parallel, get_stream
 from sglang.srt.utils import (
     LazyValue,
@@ -1092,8 +1093,8 @@ class Qwen3NextForCausalLM(nn.Module):
         del self.lm_head.weight
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        current_platform.empty_cache()
+        current_platform.synchronize()
 
     def get_embed(self):
         return self.model.embed_tokens.weight
@@ -1107,8 +1108,8 @@ class Qwen3NextForCausalLM(nn.Module):
             return
         del self.model.embed_tokens.weight
         self.model.embed_tokens.weight = embed
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        current_platform.empty_cache()
+        current_platform.synchronize()
 
     def load_weights(
         self, weights: Iterable[Tuple[str, torch.Tensor]], is_mtp: bool = False

--- a/test/registered/cpu/test_mamba.py
+++ b/test/registered/cpu/test_mamba.py
@@ -438,8 +438,11 @@ def test_fused_sigmoid_gating_delta_rule_update(
             ssm_states_kv[cache_indices].transpose(-1, -2).contiguous()
         )
         atol = rtol = precision[core_attn_out.dtype]
+        # The kernel is layout-preserving like the CUDA Triton kernel (output
+        # shape == v.shape == [1, tokens, HV, V]); the torch reference computes
+        # batch-first [tokens, 1, HV, V].
         torch.testing.assert_close(
-            core_attn_out, core_attn_out_ref, atol=atol, rtol=rtol
+            core_attn_out, core_attn_out_ref.transpose(0, 1), atol=atol, rtol=rtol
         )
         torch.testing.assert_close(
             last_recurrent_state, last_recurrent_state_ref, atol=atol, rtol=rtol

--- a/test/registered/cpu/test_norm.py
+++ b/test/registered/cpu/test_norm.py
@@ -130,7 +130,9 @@ class TestNorm:
         torch.testing.assert_close(ref_out, out, atol=atol, rtol=rtol)
 
         ref_x = x.clone()
-        residual = torch.randn([batch_size, hidden_size], dtype=dtype)
+        residual = make_non_contiguous(
+            torch.randn([batch_size, hidden_size], dtype=dtype)
+        )
         ref_residual = residual.clone()
 
         torch.ops.sgl_kernel.gemma_fused_add_rmsnorm_cpu(x, residual, weight, eps)

--- a/test/registered/cpu/test_spec_kernels.py
+++ b/test/registered/cpu/test_spec_kernels.py
@@ -5,6 +5,9 @@ import torch
 import torch.nn.functional as F
 
 from sglang.kernels.ops.mamba.causal_conv1d_triton import PAD_SLOT_ID
+from sglang.kernels.ops.mamba.mamba_state_scatter_triton import (
+    _state_scatter_with_mask_torch,
+)
 from sglang.srt.speculative.eagle_utils import TreeMaskMode, organize_draft_results
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.cpu_test_utils import precision
@@ -1826,6 +1829,176 @@ class TestCausalConv1dUpdateMultiToken(CustomTestCase):
                 torch.testing.assert_close(
                     intermediate_conv_window, window_ref, atol=atol, rtol=rtol
                 )
+
+
+class TestMambaStateScatterWithMask(CustomTestCase):
+    def setUp(self):
+        torch.manual_seed(1234)
+
+    def _run_and_check(self, dst, src, dst_indices, step_indices):
+        dst_ref = dst.clone()
+        _state_scatter_with_mask_torch(dst_ref, src, dst_indices, step_indices)
+
+        out = dst.clone()
+        torch.ops.sgl_kernel.mamba_state_scatter_with_mask_cpu(
+            out, src, dst_indices.to(torch.int32), step_indices.to(torch.int32)
+        )
+        torch.testing.assert_close(out, dst_ref, atol=0, rtol=0)
+
+    def test_ssm_state_scatter(self):
+        # dense per-step SSM states: [layers, cache, HV, K, V]
+        layers, cache_size, requests, steps = 2, 6, 3, 4
+        HV, K, V = 4, 8, 8
+        dst = torch.randn(layers, cache_size, HV, K, V, dtype=torch.float32)
+        src = torch.randn(layers, requests, steps, HV, K, V, dtype=torch.float32)
+        dst_indices = torch.tensor([4, 0, 2], dtype=torch.int32)
+        step_indices = torch.tensor([3, 0, 2], dtype=torch.int32)
+
+        self._run_and_check(dst, src, dst_indices, step_indices)
+
+    def test_skips_negative_steps_and_slots(self):
+        # padded requests carry -1 and must leave the cache untouched
+        layers, cache_size, requests, steps = 2, 5, 4, 3
+        dst = torch.randn(layers, cache_size, 4, 4, dtype=torch.bfloat16)
+        src = torch.randn(layers, requests, steps, 4, 4, dtype=torch.bfloat16)
+        dst_indices = torch.tensor([1, 3, -1, 0], dtype=torch.int32)
+        step_indices = torch.tensor([2, -1, 1, 0], dtype=torch.int32)
+
+        out = dst.clone()
+        torch.ops.sgl_kernel.mamba_state_scatter_with_mask_cpu(
+            out, src, dst_indices, step_indices
+        )
+        # rows 3 and -1 are skipped for their own reason; only 1 and 0 move
+        torch.testing.assert_close(out[:, 1], src[:, 0, 2], atol=0, rtol=0)
+        torch.testing.assert_close(out[:, 0], src[:, 3, 0], atol=0, rtol=0)
+        for untouched in (2, 3, 4):
+            torch.testing.assert_close(
+                out[:, untouched], dst[:, untouched], atol=0, rtol=0
+            )
+
+    def test_conv_window_scatter_strided_source(self):
+        # the deduplicated conv-window source overlaps its per-step windows, so
+        # its entries are non-contiguous
+        layers, cache_size, requests, steps = 2, 5, 3, 4
+        dim, win = 16, 3
+        dst = torch.randn(layers, cache_size, dim, win, dtype=torch.bfloat16)
+        shared = torch.randn(
+            layers, requests, dim, steps + win - 1, dtype=torch.bfloat16
+        )
+        src = shared.as_strided(
+            (layers, requests, steps, dim, win),
+            (
+                shared.stride(0),
+                shared.stride(1),
+                shared.stride(3),
+                shared.stride(2),
+                shared.stride(3),
+            ),
+        )
+        self.assertFalse(src[0, 0, 0].is_contiguous())
+        dst_indices = torch.tensor([2, 4, 0], dtype=torch.int32)
+        step_indices = torch.tensor([1, 3, -1], dtype=torch.int32)
+
+        self._run_and_check(dst, src, dst_indices, step_indices)
+
+    def test_dim_contiguous_conv_state_destination(self):
+        # causal_conv1d_update_cpu re-strides conv_states to be dim-contiguous,
+        # so the destination entry is transposed and the copy is a transpose
+        layers, cache_size, requests, steps = 2, 5, 3, 4
+        dim, win = 16, 3
+        dst = torch.randn(layers, cache_size, win, dim, dtype=torch.bfloat16).transpose(
+            2, 3
+        )
+        self.assertEqual(dst.shape[-2:], (dim, win))
+        self.assertFalse(dst[0, 0].is_contiguous())
+        src = torch.randn(layers, requests, steps, dim, win, dtype=torch.bfloat16)
+        dst_indices = torch.tensor([2, 4, 0], dtype=torch.int32)
+        step_indices = torch.tensor([1, 3, 2], dtype=torch.int32)
+
+        self._run_and_check(dst, src, dst_indices, step_indices)
+
+    def test_dense_conv_window_scatter(self):
+        layers, cache_size, requests, steps = 3, 4, 3, 5
+        dim, win = 32, 3
+        dst = torch.randn(layers, cache_size, dim, win, dtype=torch.bfloat16)
+        src = torch.randn(layers, requests, steps, dim, win, dtype=torch.bfloat16)
+        dst_indices = torch.tensor([3, 1, 2], dtype=torch.int32)
+        step_indices = torch.tensor([4, 0, -1], dtype=torch.int32)
+
+        self._run_and_check(dst, src, dst_indices, step_indices)
+
+    def test_both_sides_strided(self):
+        # the odometer path with two independent stride sets
+        layers, cache_size, requests, steps = 2, 5, 3, 4
+        dim, win = 16, 3
+        dst = torch.randn(layers, cache_size, win, dim, dtype=torch.bfloat16).transpose(
+            2, 3
+        )
+        shared = torch.randn(
+            layers, requests, dim, steps + win - 1, dtype=torch.bfloat16
+        )
+        src = shared.as_strided(
+            (layers, requests, steps, dim, win),
+            (
+                shared.stride(0),
+                shared.stride(1),
+                shared.stride(3),
+                shared.stride(2),
+                shared.stride(3),
+            ),
+        )
+        self.assertFalse(dst[0, 0].is_contiguous())
+        self.assertFalse(src[0, 0, 0].is_contiguous())
+        dst_indices = torch.tensor([2, 4, 0], dtype=torch.int32)
+        step_indices = torch.tensor([1, 3, 2], dtype=torch.int32)
+
+        self._run_and_check(dst, src, dst_indices, step_indices)
+
+    def test_envelope_strided_destination(self):
+        # a unified-pool view spaces its slots out, so the slot stride is wider
+        # than one entry
+        layers, cache_size, requests, steps = 2, 4, 2, 3
+        HV, K, V = 2, 4, 4
+        envelope = torch.zeros(layers, cache_size, 2, HV, K, V, dtype=torch.float32)
+        dst = envelope[:, :, 0]
+        self.assertGreater(dst.stride(1), HV * K * V)
+        src = torch.randn(layers, requests, steps, HV, K, V, dtype=torch.float32)
+        dst_indices = torch.tensor([3, 1], dtype=torch.int32)
+        step_indices = torch.tensor([2, 0], dtype=torch.int32)
+
+        self._run_and_check(dst, src, dst_indices, step_indices)
+        # the neighbouring half of each envelope slot must be untouched
+        torch.testing.assert_close(
+            envelope[:, :, 1], torch.zeros_like(envelope[:, :, 1]), atol=0, rtol=0
+        )
+
+    def test_out_of_range_indices_are_skipped(self):
+        # the torch reference raises on these, so the kernel is checked directly
+        layers, cache_size, requests, steps = 2, 3, 3, 2
+        dst = torch.randn(layers, cache_size, 4, dtype=torch.float32)
+        src = torch.randn(layers, requests, steps, 4, dtype=torch.float32)
+        dst_indices = torch.tensor([cache_size, 0, 1], dtype=torch.int32)
+        step_indices = torch.tensor([0, steps, 1], dtype=torch.int32)
+
+        out = dst.clone()
+        torch.ops.sgl_kernel.mamba_state_scatter_with_mask_cpu(
+            out, src, dst_indices, step_indices
+        )
+        # only request 2 is in range
+        torch.testing.assert_close(out[:, 1], src[:, 2, 1], atol=0, rtol=0)
+        for untouched in (0, 2):
+            torch.testing.assert_close(
+                out[:, untouched], dst[:, untouched], atol=0, rtol=0
+            )
+
+    def test_empty_request_list(self):
+        dst = torch.randn(2, 3, 4, dtype=torch.float32)
+        src = torch.randn(2, 0, 2, 4, dtype=torch.float32)
+        empty = torch.empty(0, dtype=torch.int32)
+
+        out = dst.clone()
+        torch.ops.sgl_kernel.mamba_state_scatter_with_mask_cpu(out, src, empty, empty)
+        torch.testing.assert_close(out, dst, atol=0, rtol=0)
 
 
 if __name__ == "__main__":

--- a/test/registered/cpu/test_spec_kernels.py
+++ b/test/registered/cpu/test_spec_kernels.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest import mock
 
 import sgl_kernel  # noqa: F401
 import torch
@@ -6,7 +7,7 @@ import torch.nn.functional as F
 
 from sglang.kernels.ops.mamba.causal_conv1d_triton import PAD_SLOT_ID
 from sglang.kernels.ops.mamba.mamba_state_scatter_triton import (
-    _state_scatter_with_mask_torch,
+    fused_mamba_state_scatter_with_mask,
 )
 from sglang.srt.speculative.eagle_utils import TreeMaskMode, organize_draft_results
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -161,6 +162,18 @@ def _ref_parents_from_mask(tree_mask, bs, draft_token_num):
             ancestors = [j for j in range(t) if mask[b, t, j]]
             parents[b, t] = max(ancestors)
     return parents
+
+
+def _ref_state_scatter_with_mask(dst, src, dst_indices_raw, step_indices_raw):
+    """Advanced-indexing reference: commit one step per request, skipping the
+    padded requests, which carry a negative step or a negative slot."""
+    valid = (step_indices_raw >= 0) & (dst_indices_raw >= 0)
+    if not valid.any():
+        return
+    requests = valid.nonzero(as_tuple=True)[0]
+    dst[:, dst_indices_raw[requests].long()] = src[
+        :, requests, step_indices_raw[requests].long()
+    ]
 
 
 def _ref_verify_tree_greedy(
@@ -2008,7 +2021,7 @@ class TestMambaStateScatterWithMask(CustomTestCase):
 
     def _run_and_check(self, dst, src, dst_indices, step_indices):
         dst_ref = dst.clone()
-        _state_scatter_with_mask_torch(dst_ref, src, dst_indices, step_indices)
+        _ref_state_scatter_with_mask(dst_ref, src, dst_indices, step_indices)
 
         out = dst.clone()
         torch.ops.sgl_kernel.mamba_state_scatter_with_mask_cpu(
@@ -2028,24 +2041,15 @@ class TestMambaStateScatterWithMask(CustomTestCase):
         self._run_and_check(dst, src, dst_indices, step_indices)
 
     def test_skips_negative_steps_and_slots(self):
-        # padded requests carry -1 and must leave the cache untouched
+        # padded requests carry -1 and must leave the cache untouched. Requests
+        # 1 and 2 are padded on one index each, so only 0 and 3 commit.
         layers, cache_size, requests, steps = 2, 5, 4, 3
         dst = torch.randn(layers, cache_size, 4, 4, dtype=torch.bfloat16)
         src = torch.randn(layers, requests, steps, 4, 4, dtype=torch.bfloat16)
         dst_indices = torch.tensor([1, 3, -1, 0], dtype=torch.int32)
         step_indices = torch.tensor([2, -1, 1, 0], dtype=torch.int32)
 
-        out = dst.clone()
-        torch.ops.sgl_kernel.mamba_state_scatter_with_mask_cpu(
-            out, src, dst_indices, step_indices
-        )
-        # rows 3 and -1 are skipped for their own reason; only 1 and 0 move
-        torch.testing.assert_close(out[:, 1], src[:, 0, 2], atol=0, rtol=0)
-        torch.testing.assert_close(out[:, 0], src[:, 3, 0], atol=0, rtol=0)
-        for untouched in (2, 3, 4):
-            torch.testing.assert_close(
-                out[:, untouched], dst[:, untouched], atol=0, rtol=0
-            )
+        self._run_and_check(dst, src, dst_indices, step_indices)
 
     def test_conv_window_scatter_strided_source(self):
         # the deduplicated conv-window source overlaps its per-step windows, so
@@ -2071,6 +2075,26 @@ class TestMambaStateScatterWithMask(CustomTestCase):
         step_indices = torch.tensor([1, 3, -1], dtype=torch.int32)
 
         self._run_and_check(dst, src, dst_indices, step_indices)
+
+    def test_dispatch_follows_tensor_device(self):
+        # The CPU kernel is picked from the tensors' device, not from the
+        # process-wide engine flag: with the flag off, a request whose slot is
+        # negative must still be skipped rather than committed to the last slot.
+        layers, cache_size, requests, steps = 2, 4, 2, 3
+        dst = torch.randn(layers, cache_size, 4, 4, dtype=torch.float32)
+        src = torch.randn(layers, requests, steps, 4, 4, dtype=torch.float32)
+        dst_indices = torch.tensor([3, -1], dtype=torch.int32)
+        step_indices = torch.tensor([2, 0], dtype=torch.int32)
+
+        dst_ref = dst.clone()
+        _ref_state_scatter_with_mask(dst_ref, src, dst_indices, step_indices)
+
+        out = dst.clone()
+        with mock.patch(
+            "sglang.kernels.ops.mamba.mamba_state_scatter_triton._is_cpu", False
+        ):
+            fused_mamba_state_scatter_with_mask(out, src, dst_indices, step_indices)
+        torch.testing.assert_close(out, dst_ref, atol=0, rtol=0)
 
     def test_dim_contiguous_conv_state_destination(self):
         # causal_conv1d_update_cpu re-strides conv_states to be dim-contiguous,

--- a/test/registered/cpu/test_spec_kernels.py
+++ b/test/registered/cpu/test_spec_kernels.py
@@ -1622,6 +1622,94 @@ class TestFusedSigmoidGatingDeltaRuleVerify(CustomTestCase):
             intermediate_states_buffer, buffer_ref, atol=1e-3, rtol=1e-3
         )
 
+    def test_pad_slot_starts_from_zero_and_commits_nothing(self):
+        # A padded row carries state slot -1 while its intermediate index still
+        # points at the pool's discard row. The row owns no state: it starts
+        # from zeros and writes none back, as the CUDA kernel does.
+        B, T = 2, 3
+        HK, HV, K, V = 2, 4, 32, 32
+        total_tokens = B * T
+        num_slots, cache_size = 4, 3
+        dtype = torch.bfloat16
+
+        q = torch.rand(1, total_tokens, HK, K, dtype=dtype) * 0.1
+        k = torch.rand(1, total_tokens, HK, K, dtype=dtype) * 0.1
+        v = torch.rand(1, total_tokens, HV, V, dtype=dtype) * 0.1
+        a = torch.rand(total_tokens, HV, dtype=dtype) * 0.1
+        b = torch.rand(total_tokens, HV, dtype=dtype) * 0.1
+        A_log = torch.rand(HV, dtype=torch.float32) * 0.1
+        dt_bias = torch.rand(HV, dtype=dtype) * 0.1
+        cu_seqlens = torch.tensor([0, T, 2 * T], dtype=torch.int32)
+        cache_indices = torch.tensor([2, -1], dtype=torch.int32)
+        intermediate_state_indices = torch.tensor([1, 2], dtype=torch.int32)
+
+        # The pool sits behind a guard slot, so a write through slot -1 lands
+        # in the guard instead of in memory this test does not own.
+        pool_init = torch.rand(num_slots + 1, HV, K, V, dtype=torch.float32) * 0.05
+
+        # the padded row's reference state is zeros, not the guard slot
+        ref_states = torch.cat(
+            [pool_init[1:], torch.zeros(1, HV, K, V, dtype=torch.float32)]
+        )
+        ref_indices = torch.tensor([2, num_slots], dtype=torch.int32)
+        out_ref, buffer_ref = self._ref_delta_rule_verify(
+            q,
+            k,
+            v,
+            a,
+            b,
+            A_log,
+            dt_bias,
+            ref_states,
+            ref_indices,
+            cu_seqlens,
+            intermediate_state_indices,
+            cache_size,
+        )
+
+        atol = rtol = precision[dtype]
+        for disable_state_update in [True, False]:
+            with self.subTest(disable_state_update=disable_state_update):
+                pool = pool_init.clone()
+                ssm_states = pool[1:]
+                intermediate_states_buffer = torch.zeros(
+                    cache_size, T, HV, K, V, dtype=torch.float32
+                )
+                core_attn_out = (
+                    torch.ops.sgl_kernel.fused_sigmoid_gating_delta_rule_update_cpu(
+                        A_log=A_log,
+                        dt_bias=dt_bias,
+                        q=q,
+                        k=k,
+                        v=v,
+                        a=a,
+                        b=b,
+                        initial_state_source=ssm_states,
+                        initial_state_indices=cache_indices,
+                        cu_seqlens=cu_seqlens,
+                        use_qk_l2norm_in_kernel=True,
+                        disable_state_update=disable_state_update,
+                        intermediate_states_buffer=intermediate_states_buffer,
+                        intermediate_state_indices=intermediate_state_indices,
+                        cache_steps=T,
+                    )
+                )
+
+                torch.testing.assert_close(
+                    core_attn_out.float(), out_ref, atol=atol, rtol=rtol
+                )
+                torch.testing.assert_close(
+                    intermediate_states_buffer, buffer_ref, atol=1e-3, rtol=1e-3
+                )
+                # nothing may reach the guard slot, and only the one real
+                # sequence may update the pool
+                torch.testing.assert_close(pool[0], pool_init[0], atol=0, rtol=0)
+                for slot in range(1, num_slots + 1):
+                    updated = slot == 3 and not disable_state_update
+                    self.assertEqual(
+                        torch.equal(pool[slot], pool_init[slot]), not updated
+                    )
+
 
 class TestCausalConv1dUpdateMultiToken(CustomTestCase):
     def setUp(self):
@@ -1829,6 +1917,89 @@ class TestCausalConv1dUpdateMultiToken(CustomTestCase):
                 torch.testing.assert_close(
                     intermediate_conv_window, window_ref, atol=atol, rtol=rtol
                 )
+
+    def test_multi_token_skips_pad_slots(self):
+        # A padded row carries conv slot -1 while its intermediate index still
+        # points at the discard window row. The row owns no conv state, so the
+        # kernel neither updates one nor caches a window; its output is left
+        # alone, as the CUDA kernel does, because the caller discards it.
+        batch, dim, width, seqlen = 3, 32, 4, 3
+        num_entries, cache_size = 5, 4
+        dtype = torch.bfloat16
+        state_len = width - 1
+        padded_row = 1
+
+        x = torch.randn(batch, dim, seqlen, dtype=dtype)
+        weight = torch.randn(dim, width, dtype=dtype)
+        bias = torch.randn(dim, dtype=dtype)
+        conv_state_indices = torch.tensor([3, -1, 0], dtype=torch.int32)
+        intermediate_state_indices = torch.tensor([1, 3, 0], dtype=torch.int32)
+        packed_weight = torch.ops.sgl_kernel.causal_conv1d_weight_pack(weight)
+
+        # The pool sits behind a guard entry, so a write through slot -1 lands
+        # in the guard instead of in memory this test does not own.
+        pool_init = torch.randn(num_entries + 1, dim, state_len, dtype=dtype)
+        pool = pool_init.clone()
+        conv_states = pool[1:]
+
+        # reference: sequential single-token updates over the real rows only
+        real_rows = [i for i in range(batch) if i != padded_row]
+        conv_state_ref = conv_states[
+            conv_state_indices[real_rows].to(torch.int64)
+        ].clone()
+        window_ref = torch.zeros(cache_size, seqlen, dim, state_len, dtype=dtype)
+        out_ref = torch.empty(len(real_rows), dim, seqlen, dtype=dtype)
+        for t in range(seqlen):
+            x_cat = torch.cat(
+                [conv_state_ref, x[real_rows, :, t].unsqueeze(-1)], dim=-1
+            )
+            conv_state_ref = x_cat[:, :, -state_len:].clone()
+            out_t = F.conv1d(
+                x_cat.float(),
+                weight.float().unsqueeze(1),
+                bias.float(),
+                padding=0,
+                groups=dim,
+            )[:, :, -1]
+            out_ref[:, :, t] = F.silu(out_t).to(dtype)
+            for i, row in enumerate(real_rows):
+                window_ref[int(intermediate_state_indices[row]), t] = conv_state_ref[i]
+
+        intermediate_conv_window = torch.zeros(
+            cache_size, seqlen, dim, state_len, dtype=dtype
+        )
+        out = torch.ops.sgl_kernel.causal_conv1d_update_cpu(
+            x,
+            conv_states,
+            packed_weight,
+            bias,
+            True,  # silu_activation
+            None,  # cache_seqlens
+            conv_state_indices,
+            PAD_SLOT_ID,
+            True,  # is_vnni
+            intermediate_conv_window,
+            intermediate_state_indices,
+        )
+
+        atol = rtol = precision[dtype]
+        torch.testing.assert_close(out[real_rows], out_ref, atol=atol, rtol=rtol)
+        torch.testing.assert_close(
+            conv_states[conv_state_indices[real_rows].to(torch.int64)],
+            conv_state_ref,
+            atol=atol,
+            rtol=rtol,
+        )
+        torch.testing.assert_close(
+            intermediate_conv_window, window_ref, atol=atol, rtol=rtol
+        )
+        # nothing may reach the guard entry, and the untouched pool entries
+        # must keep their contents
+        torch.testing.assert_close(pool[0], pool_init[0], atol=0, rtol=0)
+        for entry in (2, 5):
+            torch.testing.assert_close(
+                conv_states[entry - 1], pool_init[entry], atol=0, rtol=0
+            )
 
 
 class TestMambaStateScatterWithMask(CustomTestCase):

--- a/test/registered/cpu/test_spec_kernels.py
+++ b/test/registered/cpu/test_spec_kernels.py
@@ -4,6 +4,7 @@ import sgl_kernel  # noqa: F401
 import torch
 import torch.nn.functional as F
 
+from sglang.kernels.ops.mamba.causal_conv1d_triton import PAD_SLOT_ID
 from sglang.srt.speculative.eagle_utils import TreeMaskMode, organize_draft_results
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.cpu_test_utils import precision
@@ -143,6 +144,20 @@ def _run_build_tree_kernel(
         retrieve_next_token,
         retrieve_next_sibling,
     )
+
+
+def _ref_parents_from_mask(tree_mask, bs, draft_token_num):
+    """Reference parent table from the QLEN_ONLY tree mask: a token's mask row
+    marks its whole ancestor chain, whose deepest member (BFS numbering: the
+    largest index) is the parent. Independent of the retrieve_* link walk the
+    kernels use."""
+    mask = tree_mask.view(bs, draft_token_num, draft_token_num)
+    parents = torch.zeros(bs, draft_token_num, dtype=torch.int64)
+    for b in range(bs):
+        for t in range(1, draft_token_num):
+            ancestors = [j for j in range(t) if mask[b, t, j]]
+            parents[b, t] = max(ancestors)
+    return parents
 
 
 def _ref_verify_tree_greedy(
@@ -1377,6 +1392,440 @@ class TestBuildDraftDecodeMetadata(CustomTestCase):
         for num_steps in [1, 2, 3]:
             with self.subTest(num_steps=num_steps):
                 self._run_and_check(seq_lens, 4, num_steps, pool_len=64, num_reqs=6)
+
+
+class TestFusedSigmoidGatingDeltaRuleVerify(CustomTestCase):
+    def setUp(self):
+        torch.manual_seed(1234)
+
+    def test_target_verify_multi_token(self):
+        # varlen multi-token verify: B=2 sequences of T=4 draft tokens each
+        B, T = 2, 4
+        HK, HV, K, V = 2, 4, 32, 32
+        total_tokens = B * T
+        num_slots, cache_size = 6, 4
+        dtype = torch.bfloat16
+
+        q = torch.rand(1, total_tokens, HK, K, dtype=dtype) * 0.1
+        k = torch.rand(1, total_tokens, HK, K, dtype=dtype) * 0.1
+        v = torch.rand(1, total_tokens, HV, V, dtype=dtype) * 0.1
+        # a/b are 2-D [tokens, HV] in verify mode (per-token gating)
+        a = torch.rand(total_tokens, HV, dtype=dtype) * 0.1
+        b = torch.rand(total_tokens, HV, dtype=dtype) * 0.1
+        dt_bias = torch.rand(HV, dtype=dtype) * 0.1
+        cu_seqlens = torch.tensor([0, T, 2 * T], dtype=torch.int32)
+        ssm_states_init = torch.rand(num_slots, HV, K, V, dtype=torch.float32) * 0.05
+        cache_indices = torch.tensor([5, 1], dtype=torch.int32)
+        # Index tensors may be longer than the sequence count (the GDN backend
+        # passes an arange over the whole state pool); only the first B entries
+        # are read -- the out-of-range tail values are canaries.
+        intermediate_state_indices = torch.tensor([2, 0, 7, 9], dtype=torch.int32)
+
+        for A_log_dtype in [torch.float32, torch.bfloat16]:
+            with self.subTest(A_log_dtype=A_log_dtype):
+                A_log = (torch.rand(HV, dtype=torch.float32) * 0.1).to(A_log_dtype)
+                ssm_states = ssm_states_init.clone()
+                intermediate_states_buffer = torch.zeros(
+                    cache_size, T, HV, K, V, dtype=torch.float32
+                )
+                core_attn_out = (
+                    torch.ops.sgl_kernel.fused_sigmoid_gating_delta_rule_update_cpu(
+                        A_log=A_log,
+                        dt_bias=dt_bias,
+                        q=q,
+                        k=k,
+                        v=v,
+                        a=a,
+                        b=b,
+                        initial_state_source=ssm_states,
+                        initial_state_indices=cache_indices,
+                        cu_seqlens=cu_seqlens,
+                        use_qk_l2norm_in_kernel=True,
+                        softplus_beta=1.0,
+                        softplus_threshold=20.0,
+                        is_kda=False,
+                        disable_state_update=True,
+                        intermediate_states_buffer=intermediate_states_buffer,
+                        intermediate_state_indices=intermediate_state_indices,
+                        cache_steps=T,
+                    )
+                )
+
+                # disable_state_update must leave the ssm state pool untouched
+                self.assertTrue(torch.equal(ssm_states, ssm_states_init))
+
+                out_ref, buffer_ref = self._ref_delta_rule_verify(
+                    q,
+                    k,
+                    v,
+                    a,
+                    b,
+                    A_log,
+                    dt_bias,
+                    ssm_states_init,
+                    cache_indices,
+                    cu_seqlens,
+                    intermediate_state_indices,
+                    cache_size,
+                )
+                atol = rtol = precision[torch.bfloat16]
+                torch.testing.assert_close(
+                    core_attn_out.float(), out_ref, atol=atol, rtol=rtol
+                )
+                torch.testing.assert_close(
+                    intermediate_states_buffer, buffer_ref, atol=1e-3, rtol=1e-3
+                )
+
+    def _ref_delta_rule_verify(
+        self,
+        q,
+        k,
+        v,
+        a,
+        b,
+        A_log,
+        dt_bias,
+        ssm_states,
+        cache_indices,
+        cu_seqlens,
+        intermediate_state_indices,
+        cache_size,
+        parents=None,
+    ):
+        # Sequential pure-python delta rule with sigmoid gating, fp32 math.
+        # With `parents` (tree verify), each step starts from its parent's
+        # cached state instead of the running one.
+        _, total_tokens, HK, K = q.shape
+        HV, V = v.shape[2], v.shape[3]
+        T = int(cu_seqlens[1])
+        group_size = HV // HK
+        scale = 1.0 / (K**0.5)
+        eps = 1e-5  # kernel l2norm epsilon
+
+        qf = q[0].float()
+        kf = k[0].float()
+        qn = qf * (qf.pow(2).sum(-1, keepdim=True) + eps).rsqrt()
+        kn = kf * (kf.pow(2).sum(-1, keepdim=True) + eps).rsqrt()
+        g = -A_log.float().exp() * F.softplus(
+            a.float() + dt_bias.float()
+        )  # [tokens, HV]
+        beta = b.float().sigmoid()
+
+        out = torch.zeros(1, total_tokens, HV, V, dtype=torch.float32)
+        buffer_ref = torch.zeros(cache_size, T, HV, K, V, dtype=torch.float32)
+        num_sequences = cu_seqlens.numel() - 1
+        for n in range(num_sequences):
+            bos = int(cu_seqlens[n])
+            seq_len = int(cu_seqlens[n + 1]) - bos
+            buf_idx = int(intermediate_state_indices[n])
+            for hv in range(HV):
+                h = ssm_states[int(cache_indices[n]), hv].clone()  # [K, V]
+                hk = hv // group_size
+                for t in range(seq_len):
+                    pos = bos + t
+                    if parents is not None and t > 0:
+                        h = buffer_ref[buf_idx, int(parents[n, t]), hv].clone()
+                    h = h * g[pos, hv].exp()
+                    kv_mem = (h * kn[pos, hk].unsqueeze(-1)).sum(dim=0)  # [V]
+                    delta = (v[0, pos, hv].float() - kv_mem) * beta[pos, hv]
+                    h = h + kn[pos, hk].unsqueeze(-1) * delta.unsqueeze(0)
+                    out[0, pos, hv] = (h * qn[pos, hk].unsqueeze(-1)).sum(0) * scale
+                    buffer_ref[buf_idx, t, hv] = h
+        return out, buffer_ref
+
+    def test_target_verify_tree_topk4(self):
+        # EAGLE tree verify: B=2 random topk=4 trees of T=8 draft tokens; each
+        # draft's initial state is its parent's cached state, not the previous
+        # draft's.
+        topk, num_steps = 4, 3
+        B, T = 2, 8
+        HK, HV, K, V = 2, 4, 32, 32
+        total_tokens = B * T
+        num_slots, cache_size = 6, 4
+        dtype = torch.bfloat16
+
+        parent_list, selected_index = _gen_draft_tree(B, topk, num_steps, T)
+        seq_lens = torch.randint(4, 32, (B,), dtype=torch.int64)
+        tree_mask, _, _, _, _ = _run_build_tree_kernel(
+            parent_list,
+            selected_index,
+            seq_lens,
+            topk,
+            num_steps,
+            T,
+            TreeMaskMode.QLEN_ONLY,
+        )
+        parents = _ref_parents_from_mask(tree_mask, B, T)
+        self.assertGreater(int((parents[:, 1:] != torch.arange(1, T) - 1).sum()), 0)
+
+        q = torch.rand(1, total_tokens, HK, K, dtype=dtype) * 0.1
+        k = torch.rand(1, total_tokens, HK, K, dtype=dtype) * 0.1
+        v = torch.rand(1, total_tokens, HV, V, dtype=dtype) * 0.1
+        a = torch.rand(total_tokens, HV, dtype=dtype) * 0.1
+        b = torch.rand(total_tokens, HV, dtype=dtype) * 0.1
+        A_log = torch.rand(HV, dtype=torch.float32) * 0.1
+        dt_bias = torch.rand(HV, dtype=dtype) * 0.1
+        cu_seqlens = torch.tensor([0, T, 2 * T], dtype=torch.int32)
+        ssm_states_init = torch.rand(num_slots, HV, K, V, dtype=torch.float32) * 0.05
+        cache_indices = torch.tensor([5, 1], dtype=torch.int32)
+        intermediate_state_indices = torch.tensor([2, 0, 7, 9], dtype=torch.int32)
+
+        ssm_states = ssm_states_init.clone()
+        intermediate_states_buffer = torch.zeros(
+            cache_size, T, HV, K, V, dtype=torch.float32
+        )
+        core_attn_out = torch.ops.sgl_kernel.fused_sigmoid_gating_delta_rule_update_cpu(
+            A_log=A_log,
+            dt_bias=dt_bias,
+            q=q,
+            k=k,
+            v=v,
+            a=a,
+            b=b,
+            initial_state_source=ssm_states,
+            initial_state_indices=cache_indices,
+            cu_seqlens=cu_seqlens,
+            use_qk_l2norm_in_kernel=True,
+            softplus_beta=1.0,
+            softplus_threshold=20.0,
+            is_kda=False,
+            disable_state_update=True,
+            intermediate_states_buffer=intermediate_states_buffer,
+            intermediate_state_indices=intermediate_state_indices,
+            cache_steps=T,
+            retrieve_parent_token=parents,
+        )
+
+        self.assertTrue(torch.equal(ssm_states, ssm_states_init))
+
+        out_ref, buffer_ref = self._ref_delta_rule_verify(
+            q,
+            k,
+            v,
+            a,
+            b,
+            A_log,
+            dt_bias,
+            ssm_states_init,
+            cache_indices,
+            cu_seqlens,
+            intermediate_state_indices,
+            cache_size,
+            parents=parents,
+        )
+        atol = rtol = precision[torch.bfloat16]
+        torch.testing.assert_close(core_attn_out.float(), out_ref, atol=atol, rtol=rtol)
+        torch.testing.assert_close(
+            intermediate_states_buffer, buffer_ref, atol=1e-3, rtol=1e-3
+        )
+
+
+class TestCausalConv1dUpdateMultiToken(CustomTestCase):
+    def setUp(self):
+        torch.manual_seed(1234)
+
+    def _ref_tree_conv(
+        self,
+        x,
+        conv_states,
+        weight,
+        bias,
+        parents,
+        conv_state_indices,
+        intermediate_state_indices,
+        cache_size,
+    ):
+        # Per-token convolution over the ancestor chain, fp32 math; walking
+        # past the root reads the committed history (newest column last).
+        batch, dim, seqlen = x.shape
+        width = weight.shape[1]
+        state_len = width - 1
+        out_ref = torch.empty_like(x)
+        window_ref = torch.zeros(cache_size, seqlen, dim, state_len, dtype=x.dtype)
+        for b in range(batch):
+            hist = conv_states[int(conv_state_indices[b])].float()  # [dim, state_len]
+            for t in range(seqlen):
+                cols = []
+                idx = t
+                for _ in range(width):
+                    if idx >= 0:
+                        cols.append(x[b, :, idx].float())
+                    else:
+                        cols.append(hist[:, state_len + idx])
+                    idx = int(parents[b, idx]) if idx > 0 else idx - 1
+                acc = bias.float().clone()
+                for j, col in enumerate(cols):
+                    acc = acc + weight[:, width - 1 - j].float() * col
+                out_ref[b, :, t] = F.silu(acc).to(x.dtype)
+                window = torch.stack(
+                    [cols[state_len - 1 - w] for w in range(state_len)], dim=-1
+                )
+                window_ref[int(intermediate_state_indices[b]), t] = window.to(x.dtype)
+        return out_ref, window_ref
+
+    def test_multi_token_tree_topk4(self):
+        # EAGLE tree verify: each draft token convolves over its ancestor
+        # chain; the committed conv states are shared read-only history and
+        # must come out untouched. The kernel also derives the parent table.
+        topk, num_steps = 4, 3
+        batch, dim, width, seqlen = 3, 32, 4, 8
+        num_entries, cache_size = 6, 5
+        dtype = torch.bfloat16
+        state_len = width - 1
+
+        parent_list, selected_index = _gen_draft_tree(batch, topk, num_steps, seqlen)
+        seq_lens = torch.randint(4, 32, (batch,), dtype=torch.int64)
+        tree_mask, _, _, retrieve_next_token, retrieve_next_sibling = (
+            _run_build_tree_kernel(
+                parent_list,
+                selected_index,
+                seq_lens,
+                topk,
+                num_steps,
+                seqlen,
+                TreeMaskMode.QLEN_ONLY,
+            )
+        )
+        parents_ref = _ref_parents_from_mask(tree_mask, batch, seqlen)
+        self.assertGreater(
+            int((parents_ref[:, 1:] != torch.arange(1, seqlen) - 1).sum()), 0
+        )
+
+        x = torch.randn(batch, dim, seqlen, dtype=dtype)
+        conv_states_init = torch.randn(num_entries, dim, state_len, dtype=dtype)
+        weight = torch.randn(dim, width, dtype=dtype)
+        bias = torch.randn(dim, dtype=dtype)
+        conv_state_indices = torch.tensor([4, 0, 2], dtype=torch.int32)
+        intermediate_state_indices = torch.tensor([1, 3, 0], dtype=torch.int32)
+        packed_weight = torch.ops.sgl_kernel.causal_conv1d_weight_pack(weight)
+
+        out_ref, window_ref = self._ref_tree_conv(
+            x,
+            conv_states_init,
+            weight,
+            bias,
+            parents_ref,
+            conv_state_indices,
+            intermediate_state_indices,
+            cache_size,
+        )
+
+        for layout in ["contiguous", "transpose_view"]:
+            with self.subTest(layout=layout):
+                if layout == "contiguous":
+                    x_in = x.clone()
+                else:
+                    x_in = x.transpose(1, 2).contiguous().transpose(1, 2)
+                conv_states = conv_states_init.clone()
+                intermediate_conv_window = torch.zeros(
+                    cache_size, seqlen, dim, state_len, dtype=dtype
+                )
+                retrieve_parent_token = torch.full(
+                    (batch, seqlen), -7, dtype=torch.int64
+                )
+                out = torch.ops.sgl_kernel.causal_conv1d_update_cpu(
+                    x_in,
+                    conv_states,
+                    packed_weight,
+                    bias,
+                    True,  # silu_activation
+                    None,  # cache_seqlens
+                    conv_state_indices,
+                    PAD_SLOT_ID,
+                    True,  # is_vnni
+                    intermediate_conv_window,
+                    intermediate_state_indices,
+                    retrieve_next_token,
+                    retrieve_next_sibling,
+                    retrieve_parent_token,
+                )
+
+                out.transpose(1, 2).view(batch * seqlen, dim)
+
+                atol = rtol = precision[dtype]
+                torch.testing.assert_close(out, out_ref, atol=atol, rtol=rtol)
+                torch.testing.assert_close(
+                    retrieve_parent_token, parents_ref, atol=0, rtol=0
+                )
+                self.assertTrue(torch.equal(conv_states, conv_states_init))
+                torch.testing.assert_close(
+                    intermediate_conv_window, window_ref, atol=atol, rtol=rtol
+                )
+
+    def test_multi_token_with_intermediate_conv_window(self):
+        batch, dim, width, seqlen = 3, 32, 4, 4
+        num_entries, cache_size = 6, 5
+        dtype = torch.bfloat16
+        state_len = width - 1
+
+        x = torch.randn(batch, dim, seqlen, dtype=dtype)
+        conv_states_init = torch.randn(num_entries, dim, state_len, dtype=dtype)
+        weight = torch.randn(dim, width, dtype=dtype)
+        bias = torch.randn(dim, dtype=dtype)
+        conv_state_indices = torch.tensor([4, 0, 2], dtype=torch.int32)
+        intermediate_state_indices = torch.tensor([1, 3, 0], dtype=torch.int32)
+        packed_weight = torch.ops.sgl_kernel.causal_conv1d_weight_pack(weight)
+
+        # reference: sequential single-token updates with state caching
+        conv_state_ref = conv_states_init[conv_state_indices.to(torch.int64)].clone()
+        window_ref = torch.zeros(cache_size, seqlen, dim, state_len, dtype=dtype)
+        out_ref = torch.empty_like(x)
+        for t in range(seqlen):
+            x_t = x[:, :, t]
+            x_cat = torch.cat([conv_state_ref, x_t.unsqueeze(-1)], dim=-1)
+            conv_state_ref = x_cat[:, :, -state_len:].clone()
+            out_t = F.conv1d(
+                x_cat.float(),
+                weight.float().unsqueeze(1),
+                bias.float(),
+                padding=0,
+                groups=dim,
+            )[:, :, -1]
+            out_ref[:, :, t] = F.silu(out_t).to(dtype)
+            for i in range(batch):
+                window_ref[int(intermediate_state_indices[i]), t] = conv_state_ref[i]
+
+        # The GDN verify call site passes a [batch, dim, seqlen] transpose view
+        # of a token-major buffer; a plain contiguous tensor must work too.
+        for layout in ["contiguous", "transpose_view"]:
+            with self.subTest(layout=layout):
+                if layout == "contiguous":
+                    x_in = x.clone()
+                else:
+                    x_in = x.transpose(1, 2).contiguous().transpose(1, 2)
+                conv_states = conv_states_init.clone()
+                intermediate_conv_window = torch.zeros(
+                    cache_size, seqlen, dim, state_len, dtype=dtype
+                )
+                out = torch.ops.sgl_kernel.causal_conv1d_update_cpu(
+                    x_in,
+                    conv_states,
+                    packed_weight,
+                    bias,
+                    True,  # silu_activation
+                    None,  # cache_seqlens
+                    conv_state_indices,
+                    PAD_SLOT_ID,
+                    True,  # is_vnni
+                    intermediate_conv_window,
+                    intermediate_state_indices,
+                )
+
+                # The output must stay a zero-copy transpose view of a
+                # token-major buffer: the caller reshapes it per token.
+                out.transpose(1, 2).view(batch * seqlen, dim)
+
+                atol = rtol = precision[dtype]
+                torch.testing.assert_close(out, out_ref, atol=atol, rtol=rtol)
+                torch.testing.assert_close(
+                    conv_states[conv_state_indices.to(torch.int64)],
+                    conv_state_ref,
+                    atol=atol,
+                    rtol=rtol,
+                )
+                torch.testing.assert_close(
+                    intermediate_conv_window, window_ref, atol=atol, rtol=rtol
+                )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/spec/test_spec_cpu_gdn_constraints.py
+++ b/test/registered/unit/spec/test_spec_cpu_gdn_constraints.py
@@ -11,11 +11,13 @@ register_cpu_ci(est_time=20, suite="base-a-test-cpu")
 QWEN3_NEXT_ARCH = "Qwen3NextForCausalLM"
 
 
-def _make_spec_args(device: str, arch: str, topk: int) -> ServerArgs:
+def _make_spec_args(
+    device: str, arch: str, topk: int, algorithm: str = "EAGLE"
+) -> ServerArgs:
     # model_path="dummy" short-circuits ServerArgs.__post_init__; invoke the
     # speculative hook directly (same pattern as the unit/server_args tests).
     args = ServerArgs(model_path="dummy")
-    args.speculative_algorithm = "EAGLE"
+    args.speculative_algorithm = algorithm
     args.device = device
     # Resolved during __post_init__ on real args; the topk > 1 paths compare it.
     args.page_size = 1
@@ -42,6 +44,15 @@ class TestSpecMambaRadixCacheGuardOnCPU(CustomTestCase):
         state tracking, so the combination must be rejected rather than
         resolved into a spec-incompatible setup."""
         args = _make_spec_args(device="cpu", arch=QWEN3_NEXT_ARCH, topk=1)
+        args.disable_radix_cache = False
+        with self.assertRaisesRegex(ValueError, "radix cache"):
+            handle_speculative_decoding(args)
+
+    def test_ngram_rejects_radix_cache_on_cpu(self):
+        # the guard sits in the NGRAM handler as well as the EAGLE family one
+        args = _make_spec_args(
+            device="cpu", arch=QWEN3_NEXT_ARCH, topk=1, algorithm="NGRAM"
+        )
         args.disable_radix_cache = False
         with self.assertRaisesRegex(ValueError, "radix cache"):
             handle_speculative_decoding(args)

--- a/test/registered/unit/spec/test_spec_cpu_gdn_constraints.py
+++ b/test/registered/unit/spec/test_spec_cpu_gdn_constraints.py
@@ -1,0 +1,82 @@
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.arg_groups.speculative_hook import handle_speculative_decoding
+from sglang.srt.server_args import ServerArgs
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=20, suite="base-a-test-cpu")
+
+QWEN3_NEXT_ARCH = "Qwen3NextForCausalLM"
+
+
+def _make_spec_args(device: str, arch: str, topk: int) -> ServerArgs:
+    # model_path="dummy" short-circuits ServerArgs.__post_init__; invoke the
+    # speculative hook directly (same pattern as the unit/server_args tests).
+    args = ServerArgs(model_path="dummy")
+    args.speculative_algorithm = "EAGLE"
+    args.device = device
+    # Resolved during __post_init__ on real args; the topk > 1 paths compare it.
+    args.page_size = 1
+    args.speculative_num_steps = 3
+    args.speculative_eagle_topk = topk
+    args.speculative_num_draft_tokens = topk * 3 + 1
+    # CPU speculative decoding needs the radix cache off; the guard tests below
+    # re-enable it to exercise the rejection.
+    args.disable_radix_cache = True
+    # A configuration a fixture supplies carries no build key, so model_config_of
+    # hands it back instead of resolving model_path.
+    args._model_config = SimpleNamespace(
+        hf_config=SimpleNamespace(
+            architectures=[arch],
+            get_text_config=lambda: SimpleNamespace(),
+        )
+    )
+    return args
+
+
+class TestSpecMambaRadixCacheGuardOnCPU(CustomTestCase):
+    def test_spec_rejects_radix_cache_on_cpu(self):
+        """CPU resolves the strategy to no_buffer, which has no spec-aware
+        state tracking, so the combination must be rejected rather than
+        resolved into a spec-incompatible setup."""
+        args = _make_spec_args(device="cpu", arch=QWEN3_NEXT_ARCH, topk=1)
+        args.disable_radix_cache = False
+        with self.assertRaisesRegex(ValueError, "radix cache"):
+            handle_speculative_decoding(args)
+
+    def test_spec_allows_radix_cache_on_cuda(self):
+        args = _make_spec_args(device="cuda", arch=QWEN3_NEXT_ARCH, topk=1)
+        args.disable_radix_cache = False
+        handle_speculative_decoding(args)
+
+    def test_spec_allows_radix_cache_for_non_mamba_model(self):
+        args = _make_spec_args(device="cpu", arch="LlamaForCausalLM", topk=1)
+        args.disable_radix_cache = False
+        handle_speculative_decoding(args)
+
+
+class TestSpecCPUTreeVerifyAllowed(CustomTestCase):
+    """The CPU causal-conv and gated-delta-rule kernels are tree-aware, so
+    every EAGLE topk combination must pass argument resolution on CPU."""
+
+    def test_cpu_topk_gt1_allowed_for_hybrid_gdn(self):
+        args = _make_spec_args(device="cpu", arch=QWEN3_NEXT_ARCH, topk=2)
+        handle_speculative_decoding(args)
+
+    def test_cpu_topk1_allowed_for_hybrid_gdn(self):
+        args = _make_spec_args(device="cpu", arch=QWEN3_NEXT_ARCH, topk=1)
+        handle_speculative_decoding(args)
+
+    def test_cpu_topk_gt1_allowed_for_non_mamba_model(self):
+        args = _make_spec_args(device="cpu", arch="LlamaForCausalLM", topk=2)
+        handle_speculative_decoding(args)
+
+    def test_cuda_topk_gt1_allowed_for_hybrid_gdn(self):
+        args = _make_spec_args(device="cuda", arch=QWEN3_NEXT_ARCH, topk=2)
+        handle_speculative_decoding(args)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

Follow-up to #27862, which added speculative decoding to the CPU backend
(EAGLE2, MTP, N-Gram, Standalone) and split the GDN-specific changes per
review request.

This adds the target-side GDN support, so hybrid linear-attention models such
as Qwen3.5 and Qwen3-Next can run speculative decoding on CPU.
## Modifications

<!-- Detail the changes made in this pull request. -->

- `fused_sigmoid_gating_delta_rule_update_cpu` becomes a varlen kernel taking
  the CUDA verify arguments. `disable_state_update` leaves the persistent SSM
  pool untouched during target verify while each draft step's post-state is
  written to the intermediate-states buffer, and `retrieve_parent_token`
  reloads a tree parent's state from that buffer. The output is now
  layout-preserving, as on CUDA.
- `causal_conv1d_update_cpu` gains a multi-token path that caches each step's
  conv window for the post-verify rollback, plus a tree path that convolves
  every draft token over its ancestor chain. Both chain verify and tree verify
  (`topk > 1`) are supported.
- New `mamba_state_scatter_with_mask_cpu` replaces the torch fallback for the
  post-verify state commit on CPU.
- The fused-add norm kernels now index the residual by its own strides rather
  than by the packed output layout. This fixes silent corruption whenever a
  residual's rows are not tightly packed, and lets `GemmaRMSNorm.forward_cpu`
  hand the kernels its strided views without copying.
- Device selection for the MambaPool speculative scratch, and `set_embed_and_head`
  weight sharing for the Qwen3.5 variants and Qwen3-Next.
- Speculative decoding combined with the mamba radix cache is rejected at
  startup on CPU, which resolves to a strategy with no spec-aware state
  tracking.
- Tests: kernel parity tests for chain and tree verify and for the state
  scatter, strided-residual coverage in the norm tests, and unit tests for the
  startup guard.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

`Qwen/Qwen3.5-9B` on GNR-AP, GSM8K:

| Config | Accuracy | Invalid |
|---|---|---|
| baseline, no spec | 0.895 | 0.000 |
| chain: steps=1, topk=1, draft=2 | 0.896 | 0.000 |
| tree: steps=2, topk=4, draft=8 | 0.898 | 0.000 |

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33606788318](https://github.com/sgl-project/sglang/actions/runs/33606788318)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33606788078](https://github.com/sgl-project/sglang/actions/runs/33606788078)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33606788317](https://github.com/sgl-project/sglang/actions/runs/33606788317)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->