### PR TITLE
[P/D disagg] Decode-side radix cache for DeepSeek-V4 (DSA compressed KV) 

### DIFF
--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -1310,6 +1310,13 @@ class CommonKVSender(BaseKVSender):
             self.kv_mgr.req_to_decode_prefix_len.pop(self.bootstrap_room, None)
         if hasattr(self.kv_mgr, "transfer_infos"):
             self.kv_mgr.transfer_infos.pop(self.bootstrap_room, None)
+        if hasattr(self.kv_mgr, "_pending_chunks"):
+            lock = getattr(self.kv_mgr, "_pending_chunks_lock", None)
+            if lock is not None:
+                with lock:
+                    self.kv_mgr._pending_chunks.pop(self.bootstrap_room, None)
+            else:
+                self.kv_mgr._pending_chunks.pop(self.bootstrap_room, None)
         if hasattr(self.kv_mgr, "_deferred_ack_targets"):
             # Drop a held ack target if the room concluded without draining
             # (e.g. aborted before any chunk enqueued); else it leaks on prefill.

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -487,6 +487,12 @@ class NixlKVManager(CommonKVManager):
             # Per-room count of chunks not yet transferred; teardown waits for
             # zero so a deferred chunk is not dropped by an early conclude.
             self._staging_outstanding = defaultdict(int)
+            # Chunks parked while the room's decode-peer bootstrap metadata
+            # is incomplete. A request can finish prefill (e.g. decode-side
+            # radix cache hit) before all peers register; the chunk must be
+            # parked, not dropped, or the room never concludes.
+            self._pending_chunks = {}
+            self._pending_chunks_lock = threading.Lock()
             # Mirror mooncake: one staging buffer per worker queue, all
             # built before workers spawn so each worker owns a private
             # buffer (no cross-worker contention on the staging ring).
@@ -2432,15 +2438,76 @@ class NixlKVManager(CommonKVManager):
         if self.enable_staging:
             self._prefetch_staging_reqs(bootstrap_room)
 
-        if bootstrap_room not in self.transfer_infos:
-            # Dummy rank or already cleared; nothing to enqueue.
-            return None
+        with self._pending_chunks_lock:
+            # Opportunistically drop stale parked chunks (room concluded or
+            # peers never finished bootstrapping).
+            if self._pending_chunks:
+                now = time.time()
+                for r in [
+                    r
+                    for r, chunks in self._pending_chunks.items()
+                    if chunks and now - chunks[-1][0] > 300
+                ]:
+                    self._pending_chunks.pop(r, None)
 
+            room_infos = self.transfer_infos.get(bootstrap_room)
+            ready = room_infos is not None and all(
+                info.required_dst_info_num == len(room_infos)
+                for info in room_infos.values()
+            )
+            if not ready:
+                if self.is_dummy_cp_rank:
+                    # Dummy CP ranks never register transfer info.
+                    return None
+                # Bootstrap metadata from the decode peers has not fully
+                # arrived yet (common with decode-side radix cache hits,
+                # where prefill finishes almost instantly). Park the chunk;
+                # the bootstrap thread drains it once the room is ready.
+                self._pending_chunks.setdefault(bootstrap_room, []).append(
+                    (
+                        time.time(),
+                        TransferKVChunk(
+                            room=bootstrap_room,
+                            prefill_kv_indices=kv_indices,
+                            index_slice=index_slice,
+                            is_last_chunk=is_last_chunk,
+                            chunk_id=chunk_id,
+                            prefill_aux_index=aux_index,
+                            state_indices=state_indices,
+                            num_kv_tokens=num_kv_tokens,
+                        ),
+                    )
+                )
+                return None
+
+            self._enqueue_chunk(
+                bootstrap_room,
+                room_infos,
+                kv_indices,
+                index_slice,
+                is_last_chunk,
+                chunk_id,
+                aux_index,
+                state_indices,
+                num_kv_tokens,
+            )
+        return None
+
+    def _enqueue_chunk(
+        self,
+        bootstrap_room: int,
+        room_infos,
+        kv_indices,
+        index_slice,
+        is_last_chunk: bool,
+        chunk_id: int,
+        aux_index,
+        state_indices,
+        num_kv_tokens,
+    ):
         # Shard by destination (mirror mooncake): same dst endpoint(s) -> same
         # worker, keeping a room's chunks on one private staging buffer.
-        session_port_sum = sum(
-            info.dst_port for info in self.transfer_infos[bootstrap_room].values()
-        )
+        session_port_sum = sum(info.dst_port for info in room_infos.values())
         shard_idx = session_port_sum % len(self.transfer_queues)
         self.transfer_queues[shard_idx].put(
             TransferKVChunk(
@@ -2454,7 +2521,6 @@ class NixlKVManager(CommonKVManager):
                 num_kv_tokens=num_kv_tokens,
             )
         )
-        return None
 
     def update_transfer_status(self):
         # Process notifications from received transfers.
@@ -2760,6 +2826,26 @@ class NixlKVManager(CommonKVManager):
                     )
                     logger.debug(f"{room=} is bootstrapped")
                     self.update_status(room, KVPoll.WaitingForInput)
+                    # Drain chunks parked before this room finished
+                    # bootstrapping. Holding the lock across enqueue preserves
+                    # chunk order against concurrent add_transfer_request.
+                    with self._pending_chunks_lock:
+                        parked = self._pending_chunks.pop(room, None)
+                        if parked:
+                            room_infos = self.transfer_infos.get(room)
+                            if room_infos is not None:
+                                for _, chunk in parked:
+                                    self._enqueue_chunk(
+                                        room,
+                                        room_infos,
+                                        chunk.prefill_kv_indices,
+                                        chunk.index_slice,
+                                        chunk.is_last_chunk,
+                                        chunk.chunk_id,
+                                        chunk.prefill_aux_index,
+                                        chunk.state_indices,
+                                        chunk.num_kv_tokens,
+                                    )
 
         threading.Thread(target=bootstrap_thread).start()
 

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -3048,7 +3048,15 @@ class NixlKVReceiver(CommonKVReceiver):
         # Match the prefill-side truthy check: an empty list means the
         # model has no state types (e.g. dense LLaMA/Qwen), and prefill
         # won't send state notifs, so we must not expect them.
-        if state_indices:
+        # Semantic emptiness: a zero-delta decode-side radix hit can pass a
+        # non-empty list of empty per-component index arrays (numpy or list).
+        # The truthy check would then set expects_state even though prefill
+        # sends no state notifications for an empty delta, stalling the
+        # transfer in KVPoll.WaitingForInput until timeout. len() works for
+        # both containers and ndarrays without bool ambiguity.
+        if state_indices and any(
+            s is not None and len(s) > 0 for s in state_indices
+        ):
             self.kv_mgr.transfer_statuses[self.bootstrap_room].expects_state = True
 
         self.started_transfer = True

--- a/python/sglang/srt/mem_cache/kv_cache_builder.py
+++ b/python/sglang/srt/mem_cache/kv_cache_builder.py
@@ -46,6 +46,7 @@ from sglang.srt.runtime_context import (
     get_parallel,
     get_schedule,
 )
+from sglang.srt.utils import is_hip, is_npu
 from sglang.srt.utils.tensor_bridge import use_mlx
 
 if TYPE_CHECKING:
@@ -59,6 +60,9 @@ if TYPE_CHECKING:
     from sglang.srt.server_args import ServerArgs
     from sglang.srt.speculative.base_spec_worker import HiCacheDraftPlan
     from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+
+_is_npu = is_npu()
+_is_hip = is_hip()
 
 
 def maybe_register_hicache_draft(
@@ -201,6 +205,27 @@ def resolve_decode_retraction_backup(*, tp_worker: BaseTpWorker) -> str:
     return backend
 
 
+def _validate_decode_radix_dsv4_platform(
+    *, is_npu_platform: bool, is_hip_platform: bool
+) -> None:
+    # CUDA needs no DSA-specific tree code: c4/c128/indexer rows derive
+    # positionally from the virtual full-id space (full_id // ratio), so the
+    # [FULL, SWA] components already keep every compressed pool coherent.
+    if is_npu_platform:
+        raise ValueError(
+            "--disaggregation-decode-enable-radix-cache does not support "
+            "DeepSeek-V4 (DSA) on NPU: the c4/c128 allocators and the "
+            "tree-level C128 sidecar are not wired for the decode-radix "
+            "lock path."
+        )
+    if is_hip_platform:
+        raise ValueError(
+            "--disaggregation-decode-enable-radix-cache does not support "
+            "DeepSeek-V4 (DSA) on HIP: the unified-kv SWA ring is "
+            "per-request and not content-stable for prefix reuse."
+        )
+
+
 def build_kv_cache(
     *,
     server_args: ServerArgs,
@@ -282,10 +307,9 @@ def build_kv_cache(
                     "device-resident cache and is incompatible with "
                     "--enable-hierarchical-cache."
                 )
-            if getattr(model_config, "is_deepseek_v4_arch", False):
-                raise ValueError(
-                    "--disaggregation-decode-enable-radix-cache does not support "
-                    "DeepSeek-V4 (DSA) compressed KV (c4/c128/indexer) yet."
+            if model_config.is_deepseek_v4_arch:
+                _validate_decode_radix_dsv4_platform(
+                    is_npu_platform=_is_npu, is_hip_platform=_is_hip
                 )
             if getattr(model_config, "is_hybrid_swa_compress", False):
                 raise ValueError(

--- a/python/sglang/srt/mem_cache/kv_cache_builder.py
+++ b/python/sglang/srt/mem_cache/kv_cache_builder.py
@@ -226,6 +226,28 @@ def _validate_decode_radix_dsv4_platform(
         )
 
 
+def _validate_decode_radix_swa_compress_platform(
+    *, is_npu_platform: bool, is_hip_platform: bool
+) -> None:
+    # SWA-compress (Gemma4 / MiMo-V2) rides the same [FULL, SWA] unified-tree
+    # path as DSV4 on CUDA: SWAKVPool keeps the full-attention prefix
+    # content-addressable while the SWA tail is transferred fresh per request,
+    # so prefix-match-and-lock needs no compress-specific tree code.
+    if is_npu_platform:
+        raise ValueError(
+            "--disaggregation-decode-enable-radix-cache does not support "
+            "SWA-compress models (e.g. Gemma4 / MiMo-V2) on NPU: the NPU "
+            "MHA sub-pools are not wired for the decode-radix lock path."
+        )
+    if is_hip_platform:
+        raise ValueError(
+            "--disaggregation-decode-enable-radix-cache does not support "
+            "SWA-compress models (e.g. Gemma4 / MiMo-V2) on HIP: the "
+            "unified-kv SWA ring is per-request and not content-stable "
+            "for prefix reuse."
+        )
+
+
 def build_kv_cache(
     *,
     server_args: ServerArgs,
@@ -311,10 +333,9 @@ def build_kv_cache(
                 _validate_decode_radix_dsv4_platform(
                     is_npu_platform=_is_npu, is_hip_platform=_is_hip
                 )
-            if getattr(model_config, "is_hybrid_swa_compress", False):
-                raise ValueError(
-                    "--disaggregation-decode-enable-radix-cache does not support "
-                    "SWA-compress models (e.g. Gemma4 / MiMo-V2) yet."
+            if model_config.is_hybrid_swa_compress:
+                _validate_decode_radix_swa_compress_platform(
+                    is_npu_platform=_is_npu, is_hip_platform=_is_hip
                 )
         if is_hybrid_ssm:
             raise ValueError(

--- a/python/sglang/test/kits/cache_hit_kit.py
+++ b/python/sglang/test/kits/cache_hit_kit.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import time
+from typing import Optional
 
 import aiohttp
 import requests
@@ -242,6 +243,7 @@ def run_multiturn_cache_hit_test(
     dataset_path: str = "",
     max_parallel: int = 64,
     seed: int = 1,
+    page_size: Optional[int] = None,
 ) -> dict:
     """Run a multi-turn workload and verify cache hit rate.
 
@@ -263,7 +265,10 @@ def run_multiturn_cache_hit_test(
     np.random.seed(seed)
 
     generate_url = f"{base_url}/generate"
-    page_size = _get_page_size(base_url)
+    # A router /server_info does not expose the backend page size, so PD
+    # setups must pass the serving page size explicitly.
+    if page_size is None:
+        page_size = _get_page_size(base_url)
 
     # Flush cache for clean state
     requests.post(f"{base_url}/flush_cache")

--- a/test/registered/disaggregation/test_disaggregation_decode_radix_cache.py
+++ b/test/registered/disaggregation/test_disaggregation_decode_radix_cache.py
@@ -50,6 +50,16 @@ class DisaggregationDecodeRadixCacheTestMixin:
     transfer_backend_name = None
     model_name = DEFAULT_MODEL_NAME_FOR_TEST
     gsm8k_min_score = 0.80
+    # SWA hybrids cap prefix reuse at one window+page before the prompt end;
+    # window < page geometries (DSV4: 128 vs 256) reuse nothing below
+    # window + page tokens, so subclasses raise request_length accordingly.
+    cache_hit_request_length = 384
+    cache_hit_output_length = 64
+    two_pass_max_tokens = 512
+    two_pass_num_examples = 500
+    two_pass_num_shots = 6
+    two_pass_num_threads = 100
+    two_pass_max_accuracy_drop = 0.03
 
     @classmethod
     def setUpClass(cls):
@@ -82,9 +92,11 @@ class DisaggregationDecodeRadixCacheTestMixin:
             model_path=self.model,
             num_clients=4,
             num_rounds=3,
-            request_length=384,
-            output_length=64,
+            request_length=self.cache_hit_request_length,
+            output_length=self.cache_hit_output_length,
             max_parallel=4,
+            # The router's /server_info hides the backend page size.
+            page_size=decode_info.get("page_size", 1),
         )
         self.assertGreater(
             result["overall"]["total_cached_tokens"],
@@ -107,10 +119,10 @@ class DisaggregationDecodeRadixCacheTestMixin:
             model=self.model,
             eval_name="gsm8k",
             api="completion",
-            max_tokens=512,
-            num_examples=500,
-            num_threads=100,
-            num_shots=6,
+            max_tokens=self.two_pass_max_tokens,
+            num_examples=self.two_pass_num_examples,
+            num_threads=self.two_pass_num_threads,
+            num_shots=self.two_pass_num_shots,
         )
 
         metrics_first = run_eval(args)
@@ -125,10 +137,10 @@ class DisaggregationDecodeRadixCacheTestMixin:
         accuracy_drop = metrics_first["score"] - metrics_second["score"]
         self.assertLessEqual(
             accuracy_drop,
-            0.03,
+            self.two_pass_max_accuracy_drop,
             f"Second run accuracy dropped by {accuracy_drop:.4f} "
             f"(first={metrics_first['score']:.4f}, second={metrics_second['score']:.4f}), "
-            f"exceeds 3% threshold",
+            f"exceeds {self.two_pass_max_accuracy_drop:.0%} threshold",
         )
 
 

--- a/test/registered/disaggregation/test_disaggregation_decode_radix_cache_swa_dsv4.py
+++ b/test/registered/disaggregation/test_disaggregation_decode_radix_cache_swa_dsv4.py
@@ -1,0 +1,73 @@
+"""DSV4 coverage for decode-side radix cache on DeepSeek-V4-Flash.
+
+CUDA DSV4 rides the same [FULL, SWA] unified-tree path as gpt-oss: c4/c128/
+indexer rows derive positionally from the virtual full-id space, so FULL
+prefix reuse keeps every compressed pool coherent. Non-spec launch only --
+decode radix cache rejects speculative decoding globally.
+"""
+
+import unittest
+
+from test_disaggregation_decode_radix_cache import (
+    DisaggregationDecodeRadixCacheTestMixin,
+    _has_mooncake,
+)
+
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.server_fixtures.disaggregation_fixture import (
+    PDDisaggregationServerBase,
+)
+from sglang.test.test_utils import is_in_ci
+
+register_cuda_ci(est_time=1500, stage="extra-b", runner_config="8-gpu-h200")
+
+DSV4_FLASH_MODEL = "sgl-project/DeepSeek-V4-Flash-FP8"
+
+DSV4_FLASH_ENV = {
+    "SGLANG_DSV4_FP4_EXPERTS": "0",
+    "SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK": "256",
+}
+
+DSV4_SERVER_ARGS = [
+    "--page-size",
+    "256",
+    "--chunked-prefill-size",
+    "8192",
+    "--mem-fraction-static",
+    "0.9",
+    "--skip-server-warmup",
+    "--watchdog-timeout",
+    "900",
+]
+
+
+@unittest.skipUnless(
+    is_in_ci() or _has_mooncake(),
+    "Mooncake is required for DSV4 decode radix cache disaggregation coverage.",
+)
+class TestDisaggregationDecodeRadixCacheSWADSV4(
+    DisaggregationDecodeRadixCacheTestMixin, PDDisaggregationServerBase
+):
+    transfer_backend_name = "mooncake"
+    model_name = DSV4_FLASH_MODEL
+    prefill_tp_size = 4
+    decode_tp_size = 4
+    decode_base_gpu_id = 4
+    # Window 128 < page 256: prompts below window + page (512) reuse nothing,
+    # and every hit loses up to 512 tokens to the SWA prefix cap, so the
+    # cache-hit rounds need headroom above the kit's expected-cache floor.
+    cache_hit_request_length = 1024
+    two_pass_num_examples = 200
+    gsm8k_min_score = 0.90
+    # SWA + decode-side radix cache is gated to the unified radix tree.
+    extra_prefill_env = {"SGLANG_ENABLE_UNIFIED_RADIX_TREE": "1", **DSV4_FLASH_ENV}
+    extra_decode_env = {"SGLANG_ENABLE_UNIFIED_RADIX_TREE": "1", **DSV4_FLASH_ENV}
+    extra_prefill_args = DSV4_SERVER_ARGS
+    extra_decode_args = [
+        "--disaggregation-decode-enable-radix-cache",
+        *DSV4_SERVER_ARGS,
+    ]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_decode_radix_lock_ref.py
+++ b/test/registered/unit/mem_cache/test_decode_radix_lock_ref.py
@@ -112,6 +112,51 @@ class TestDecodeLockRefScenarios(unittest.TestCase):
         radix_key_len = (895 // 64) * 64
         self.assertGreaterEqual(radix_key_len - swa_start, 127)
 
+    def test_swa_tail_len_dsv4_page256_window128_cap_is_compress_group_aligned(self):
+        # DSV4 geometry: window 128 < page 256. The radix prefix cap must stay
+        # page-aligned (256 is a multiple of the c4/c128 compress ratios 4 and
+        # 128), so a reused prefix boundary never splits a compressed block.
+        queue = DecodePreallocQueue.__new__(DecodePreallocQueue)
+        queue._uses_swa_tail_prealloc = MagicMock(return_value=True)
+        queue.scheduler = SimpleNamespace(
+            sliding_window_size=128,
+            server_args=SimpleNamespace(disaggregation_decode_enable_radix_cache=True),
+        )
+        queue.token_to_kv_pool_allocator = MagicMock(page_size=256)
+
+        for fill_len in (
+            256,
+            512,
+            513,
+            640,
+            767,
+            768,
+            1024,
+            1025,
+            1279,
+            1280,
+            2049,
+            2200,
+        ):
+            with self.subTest(fill_len=fill_len):
+                tail_len = queue._swa_tail_len(fill_len)
+                cap = fill_len - tail_len
+
+                self.assertEqual(cap % 256, 0)
+                self.assertEqual(cap % 128, 0)
+                self.assertEqual(cap % 4, 0)
+
+                # A complete window stays live before the page-aligned radix
+                # insert boundary, keeping the cache_unfinished_req repoint
+                # match non-empty.
+                radix_key_len = (fill_len // 256) * 256
+                self.assertGreaterEqual(radix_key_len - cap, 128)
+
+                # window < page: prompts up to one page + one window reuse
+                # nothing, so short-prompt workloads cannot hit the cache.
+                if fill_len <= 512:
+                    self.assertEqual(cap, 0)
+
     def test_swa_admission_counts_evictable_capacity(self):
         queue = DecodePreallocQueue.__new__(DecodePreallocQueue)
         queue.scheduler = MagicMock()

--- a/test/registered/unit/mem_cache/test_kv_cache_builder_decode_radix_guards.py
+++ b/test/registered/unit/mem_cache/test_kv_cache_builder_decode_radix_guards.py
@@ -1,8 +1,9 @@
-"""Unit tests for the DSV4 platform guards in build_kv_cache.
+"""Unit tests for the platform guards in build_kv_cache.
 
 Lifting the CUDA rejection of --disaggregation-decode-enable-radix-cache for
-DeepSeek-V4 must not silently open the NPU (separate c4/c128 allocators plus a
-tree-level C128 sidecar) or HIP (per-request unified-kv SWA ring) layouts.
+DeepSeek-V4 and SWA-compress models (Gemma4 / MiMo-V2) must not silently open
+the NPU (separate c4/c128 allocators plus a tree-level C128 sidecar, or NPU
+MHA sub-pools) or HIP (per-request unified-kv SWA ring) layouts.
 """
 
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -13,6 +14,7 @@ import unittest
 
 from sglang.srt.mem_cache.kv_cache_builder import (
     _validate_decode_radix_dsv4_platform,
+    _validate_decode_radix_swa_compress_platform,
 )
 from sglang.test.test_utils import CustomTestCase
 
@@ -34,6 +36,28 @@ class TestValidateDecodeRadixDSV4Platform(CustomTestCase):
 
     def test_cuda_platform_allowed(self):
         result = _validate_decode_radix_dsv4_platform(
+            is_npu_platform=False, is_hip_platform=False
+        )
+        self.assertIsNone(result)
+
+
+class TestValidateDecodeRadixSWACompressPlatform(CustomTestCase):
+    def test_npu_platform_rejected(self):
+        with self.assertRaises(ValueError) as ctx:
+            _validate_decode_radix_swa_compress_platform(
+                is_npu_platform=True, is_hip_platform=False
+            )
+        self.assertIn("NPU", str(ctx.exception))
+
+    def test_hip_platform_rejected(self):
+        with self.assertRaises(ValueError) as ctx:
+            _validate_decode_radix_swa_compress_platform(
+                is_npu_platform=False, is_hip_platform=True
+            )
+        self.assertIn("HIP", str(ctx.exception))
+
+    def test_cuda_platform_allowed(self):
+        result = _validate_decode_radix_swa_compress_platform(
             is_npu_platform=False, is_hip_platform=False
         )
         self.assertIsNone(result)

--- a/test/registered/unit/mem_cache/test_kv_cache_builder_decode_radix_guards.py
+++ b/test/registered/unit/mem_cache/test_kv_cache_builder_decode_radix_guards.py
@@ -1,0 +1,43 @@
+"""Unit tests for the DSV4 platform guards in build_kv_cache.
+
+Lifting the CUDA rejection of --disaggregation-decode-enable-radix-cache for
+DeepSeek-V4 must not silently open the NPU (separate c4/c128 allocators plus a
+tree-level C128 sidecar) or HIP (per-request unified-kv SWA ring) layouts.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+
+from sglang.srt.mem_cache.kv_cache_builder import (
+    _validate_decode_radix_dsv4_platform,
+)
+from sglang.test.test_utils import CustomTestCase
+
+
+class TestValidateDecodeRadixDSV4Platform(CustomTestCase):
+    def test_npu_platform_rejected(self):
+        with self.assertRaises(ValueError) as ctx:
+            _validate_decode_radix_dsv4_platform(
+                is_npu_platform=True, is_hip_platform=False
+            )
+        self.assertIn("NPU", str(ctx.exception))
+
+    def test_hip_platform_rejected(self):
+        with self.assertRaises(ValueError) as ctx:
+            _validate_decode_radix_dsv4_platform(
+                is_npu_platform=False, is_hip_platform=True
+            )
+        self.assertIn("HIP", str(ctx.exception))
+
+    def test_cuda_platform_allowed(self):
+        result = _validate_decode_radix_dsv4_platform(
+            is_npu_platform=False, is_hip_platform=False
+        )
+        self.assertIsNone(result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`--disaggregation-decode-enable-radix-cache` used to reject DeepSeek-V4 (DSA compressed KV) and SWA-compress models (Gemma4 / MiMo-V2) at startup. On CUDA the rejection is unnecessary: these models ride the same `[FULL, SWA]` unified-tree path as gpt-oss — the compressed pools take their row positions from the FULL allocator's pages, so prefix reuse already keeps them coherent, and page-aligned boundaries never split a compressed group (`page_size=256` is a multiple of the ratios 4 and 128). This PR lifts the rejection for CUDA; no new tree code is required.

Also fixes a latent bug in the cache-hit kit: a router's `/server_info` does not expose the backend `page_size` (verified: it only returns router-level fields, so the kit fell back to `page_size=1`), which made the expected-cache computation skip page alignment — the existing gpt-oss coverage passed only because `384 + 64` happens to divide by 64 exactly. The kit now takes an explicit `page_size`, and the decode-radix mixin probes the decode server for it.

## Test

- CPU: platform-guard unit tests + DSV4-geometry property test (28 passed); unified radix cache suite 1082 passed, 50 subtests.
- New e2e coverage: `test/registered/disaggregation/test_disaggregation_decode_radix_cache_swa_dsv4.py` (8-gpu-h200, extra-b).
- Single node, 8xH20, 4P+4D, nixl, DeepSeek-V4-Flash (MXFP4), non-spec:
  - multi-turn cache hits `0 -> 1024 -> 2048` cached tokens, page-aligned;
  - two-pass GSM8K (100 examples): **0.96 / 0.96, zero drop**, second pass faster (981 vs 950 tok/s);
  - idle full/swa usage returns to ~0; no asserts, no 503s, no retractions.
- **Cross-node**, 2x 8xH20 (dedicated prefill node + decode node, 8P+8D, tp=8 each, sglang-router), nixl, DeepSeek-V4-Flash (MXFP4), non-spec:
  - repeated 1201-token prompts: `cached_tokens` `0 -> 1024` (page-256 aligned) — decode-side prefix reuse works across nodes;
  - full GSM8K (1319 examples, single pass): **0.970**, 0 truncations, 0 errors (1487 tok/s);
  - shared-prefix benchmark (8 groups x 32 prompts, 8192-token shared system prompt, 256 requests, max-concurrency 32), decode radix ON vs OFF on the identical cluster:

    | metric | radix ON | baseline | delta |
    |---|---|---|---|
    | median TTFT | 1,226 ms | 1,919 ms | **-36%** |
    | mean TTFT | 2,589 ms | 2,969 ms | -13% |
    | P90 TTFT | 7,976 ms | 8,763 ms | -9% |
    | median E2E | 5,024 ms | 5,458 ms | -8% |
    | request throughput | 5.00 req/s | 4.84 req/s | +3.3% |

    Both runs 256/256 successful, zero errors. The throughput delta is modest because the workload is decode-dominated; the cache removes the per-request cross-node transfer of the ~8.2k-token shared prefix, which lands in TTFT. (Test cluster routed UCX over TCP — no cross-subnet RoCE — which amplifies transfer savings; on RDMA the absolute gap narrows, direction unchanged.)

<details>
<summary>Cross-node launch commands</summary>

```bash
# Prefill node (8 GPUs)
sglang serve \
    --model-path <model-path> --tp 8 --trust-remote-code \
    --moe-runner-backend flashinfer_mxfp4 --attention-backend dsv4 \
    --page-size 256 --mem-fraction-static 0.85 \
    --cuda-graph-backend-prefill=disabled \
    --host 0.0.0.0 --port 31000 \
    --disaggregation-mode prefill \
    --disaggregation-bootstrap-port 31500 \
    --disaggregation-transfer-backend nixl

# Decode node (8 GPUs)
sglang serve \
    --model-path <model-path> --tp 8 --trust-remote-code \
    --moe-runner-backend flashinfer_mxfp4 --attention-backend dsv4 \
    --page-size 256 --mem-fraction-static 0.85 \
    --host 0.0.0.0 --port 31200 \
    --disaggregation-mode decode \
    --disaggregation-bootstrap-port 31500 \
    --disaggregation-transfer-backend nixl \
    --disaggregation-decode-enable-radix-cache

# Router (either node). The --prefill hostname is injected as
# bootstrap_host into every request — use the prefill node's reachable
# IP, not 127.0.0.1. The second value is the bootstrap port.
python3 -m sglang_router.launch_router \
    --pd-disaggregation \
    --prefill http://<prefill-ip>:31000 31500 \
    --decode http://<decode-ip>:31200 \
    --host 0.0.0.0 --port 30000

# Only on fabrics without cross-node RoCE (e.g. plain TCP VPC):
#   export UCX_TLS=tcp,cuda_copy,cuda_ipc
# (plain "tcp" disables UCX's CUDA components and breaks GPU memory
#  registration — keep cuda_copy/cuda_ipc)
#
# On multi-homed hosts, if PD bootstrap appears to hang or decode degrades,
# the KV-transfer bootstrap sockets may have registered on a subnet whose
# ephemeral ports are blocked between the machines. Pin both sides to the
# fully-connected fabric:
#   export SGLANG_HOST_IP=<ip on that fabric>
```

</details>

<details>
<summary>Gemma4 test results (cross-node, decode radix ON vs baseline)</summary>

Same cross-node cluster as above (dedicated prefill node + decode node, 8 GPUs each), `gemma-4-31B-it` (bf16, tp=8 per side, triton attention, context-length 16384; the -it checkpoint ships its own chat template, so no `--chat-template` flag is needed). The DSV4 launch commands apply unchanged except `--model-path` and dropping the `--moe-runner-backend`/`--attention-backend dsv4`/`--page-size 256` flags.

**Correctness / accuracy**

- GSM8K (500 examples, single pass, temperature 0): **0.972 (radix ON) = 0.972 (baseline)** — zero errors, zero truncations on both, consistent with the ~96.6% public number for this checkpoint.
- Exact-prompt reuse works end to end: a repeated identical prompt answers in **0.12 s** TTFT (full decode-side radix hit, no KV re-transfer) vs 3.5 s cold.

**Shared-prefix benchmark** (8 groups x 32 prompts, 8192-token shared system prompt, 256 requests, temperature 0), identical cluster, back-to-back runs at concurrency 32:

  | metric | radix ON | baseline | delta |
  |---|---|---|---|
  | median TTFT | 23.6 s | 22.6 s | +4% |
  | median E2E | 26.1 s | 25.2 s | +4% |
  | request throughput | 1.22 req/s | 1.26 req/s | ≈ |

  On this model the cache is accuracy- and throughput-neutral and does not cut shared-prefix TTFT (unlike DSV4's -36%): Gemma4's GQA+SWA KV layout carries ~200–400 KB/token — ~1.6–2 GB per 8.4k-token prompt, vs ~0.6 KB/token for DSV4's MLA — and shared-prefix (partial) reuse does not engage on this layout; only exact-prompt hits do. Every request therefore re-transfers its full prefix either way, moving ~410 GB of KV through the 25 GbE TCP fabric (~1.95 GB/s, link-saturated). TTFT is transfer-queue-bound and scales linearly with client concurrency — median **3.2 s @ 8, 11.8 s @ 16, 23.6 s @ 32** (closed-loop identity: 32 / 1.22 req/s = 26.3 s ≈ E2E) — while wall-clock duration stays ~190–210 s at every concurrency. The DSV4 (MLA) result above is where this feature pays off.

**Bugs found by this testing and fixed in this PR** (nixl transfer layer, both exposed by decode-radix hits):

- Full-hit deadlock: on a full decode-side radix hit the per-component state index arrays degenerate to a non-empty list of empty arrays; the truthy check set `expects_state` for state notifications prefill never sends, so `TransferStatus.is_done()` never became true and the request stalled 300 s in `KVPoll.WaitingForInput` before failing with a 500. Fixed with a semantic emptiness check (`len()` per component, ndarray-safe).
- Lost last chunk: `add_transfer_request` silently dropped a room's chunk when the decode peers' bootstrap metadata had not fully registered yet (easy to hit when a radix hit makes prefill finish in milliseconds); the room never concluded. Fixed by parking the chunk and draining it from the bootstrap thread once the room is bootstrapped.

  After the fixes: the exact-prompt repeat returns in 0.12 s (previously a 300 s timeout + 500), a 2x8 shared-prefix mini-bench at concurrency 16 finishes in 16.6 s wall (previously 300 s — one deadlocked request), and the full 256-request run completes 256/256 at parity with baseline.

</details>

<details>
<summary>MiMo-V2-Flash (SWA + FP8 MoE) support</summary>

The SWA-family unified-radix path also serves MiMo-V2-Flash (295G FP8 MoE, sliding window 128, page-size 64, fa3 attention, `SGLANG_ENABLE_UNIFIED_RADIX_TREE=1` in both prefill and decode). Launch commands are the same skeleton; use `--tp 4` per side (the 12-element dim cannot shard at tp=8), no `--moe-runner-backend dsv4` flags, and the model's own `/data00/models/MiMo-V2-Flash`.

- Single node, 4P+4D on 8xH20: served and answered correctly with decode radix enabled (tp=4 per side, page-size 64, mem-fraction 0.85, prefill cuda-graph disabled) — the same known-working configuration for this model.
- Transfer-path verification (2026-08-30 retest on a clean environment with this PR's fixes): cross-node with decode radix ON, the full decode-radix handshake now completes deterministically on all TP ranks — decode bootstrap metadata registered on the prefill bootstrap server (`got info` / `is bootstrapped` x4), prefill issues the NIXL KV + state writes, decode receives the KV chunk (last=True), aux and state notifications, and `check_transfer_done()` flips true on every rank. The two nixl fixes in this PR (Gemma4 section) are on this path and behave correctly.
- A cross-node **fabric pitfall** was identified during this testing: on multi-homed hosts, `get_local_ip_auto()` may register the KV-transfer bootstrap sockets on a subnet whose ephemeral high ports are blocked between the machines (well-known ports like 31000/31500 connect fine while every metadata push silently vanishes — decode then degrades). Pinning `export SGLANG_HOST_IP=<ip on the fully-connected fabric>` on both sides restores the bootstrap. Worth verifying on any multi-NIC PD deployment.
- Remaining known issue (not specific to this PR): with the transfer handshake completing, end-to-end MiMo outputs are still corrupted — identically with decode radix **OFF**, and identically in a **single-node 4P+4D** layout, while the same weights served without PD answer correctly. This isolates the symptom to the upstream MiMo PD KV-transfer data path (fa3/triton + FP8 MoE + SWA + page-size 64), not to the decode-radix feature or the fixes in this PR. MiMo lands on the same harness as Gemma4 once that upstream path is fixed.

</details>

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Provide accuracy and speed benchmark results according to the [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->



