### PR TITLE
[NPU] Introduce minimal DeviceOperator for runtime layout adaptation

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/device_op.py
+++ b/python/sglang/srt/hardware_backend/npu/device_op.py
@@ -1,0 +1,101 @@
+"""Ascend DeviceOperator: runtime-visible generation contracts for NPU.
+
+Following RFC #35709, standalone kernel / provider differences belong to
+sgl-kernel-npu, while differences that are visible to the SGLang runtime
+(dtype / layout / metadata / operator contract) are adapted here. Feature
+code calls semantic methods instead of branching on the device generation.
+
+This first contract is the MXFP per-token scale runtime layout used by the
+MoE routing path: ``npu_moe_init_routing_v2(quant_mode=3)`` emits a flat 2D
+e8m0 block scale, while the A5 grouped matmul consumes the pair-split 3D
+representation.
+
+The factory is intentionally lazy: importing this module never probes the
+device, the first ``get_device_operator()`` call does.
+"""
+
+import functools
+from enum import Enum
+from typing import Optional
+
+import torch
+
+
+class AscendDeviceGeneration(str, Enum):
+    """Ascend device generations distinguished by runtime-visible contracts."""
+
+    LEGACY = "legacy"
+    A5 = "a5"
+
+
+@functools.lru_cache(maxsize=None)
+def get_npu_device_generation(
+    device_id: Optional[int] = None,
+) -> AscendDeviceGeneration:
+    """Detect the Ascend device generation (cached per device).
+
+    Returns LEGACY on non-NPU environments. When ``device_id`` is omitted the
+    current device is used (never a hardcoded 0, so multi-rank processes do
+    not probe the wrong device).
+    """
+    from sglang.srt.utils import is_npu
+
+    if not is_npu():
+        return AscendDeviceGeneration.LEGACY
+
+    if device_id is None:
+        device_id = torch.npu.current_device()
+
+    device_name = torch.npu.get_device_name(device_id)
+
+    if device_name.startswith("Ascend950"):
+        return AscendDeviceGeneration.A5
+
+    return AscendDeviceGeneration.LEGACY
+
+
+class BaseDeviceOperator:
+    """Runtime contract for existing (pre-A5) Ascend devices."""
+
+    @staticmethod
+    def normalize_mxfp_scale_layout(
+        scale: Optional[torch.Tensor],
+    ) -> Optional[torch.Tensor]:
+        """Legacy MXFP scale runtime representation: the producer's native layout."""
+        return scale
+
+
+class A5DeviceOperator(BaseDeviceOperator):
+    """Runtime contract for Ascend A5 (Ascend950) devices."""
+
+    @staticmethod
+    def normalize_mxfp_scale_layout(
+        scale: Optional[torch.Tensor],
+    ) -> Optional[torch.Tensor]:
+        """Convert a flat 2D e8m0 block scale ``[N, M]`` into pair-split ``[N, M//2, 2]``.
+
+        ``npu_moe_init_routing_v2(quant_mode=3)`` emits the scale flat while the
+        grouped matmul wants the pair-split view. Already-3D scales (what
+        ``npu_dynamic_mx_quant`` returns) and ``None`` pass through untouched.
+        """
+        if scale is None or scale.ndim != 2:
+            return scale
+
+        return scale.reshape(
+            scale.shape[0],
+            scale.shape[1] // 2,
+            2,
+        )
+
+
+@functools.lru_cache(maxsize=None)
+def get_device_operator(
+    device_id: Optional[int] = None,
+) -> BaseDeviceOperator:
+    """Return the DeviceOperator for the given (or current) device."""
+    generation = get_npu_device_generation(device_id)
+
+    if generation == AscendDeviceGeneration.A5:
+        return A5DeviceOperator()
+
+    return BaseDeviceOperator()

--- a/python/sglang/srt/hardware_backend/npu/moe/init_routing.py
+++ b/python/sglang/srt/hardware_backend/npu/moe/init_routing.py
@@ -11,23 +11,12 @@ from typing import Optional, Tuple
 
 import torch
 
+from sglang.srt.hardware_backend.npu.device_op import get_device_operator
+
 # ``npu_moe_init_routing_v2`` quant_mode selecting MXFP8: the op emits an
 # float8_e4m3fn payload plus an e8m0 block scale, fusing the activation quant
 # that would otherwise need a separate ``npu_dynamic_mx_quant`` pass.
 MXFP8_QUANT_MODE = 3
-
-
-def _normalize_mxfp_scale(scale: torch.Tensor) -> torch.Tensor:
-    """Reshape a flat 2D e8m0 block scale ``[N, M]`` into pair-split ``[N, M//2, 2]``.
-
-    ``npu_moe_init_routing_v2(quant_mode=3)`` emits the scale flat, while the
-    grouped matmul wants the pair-split view. Already-3D scales (what
-    ``npu_dynamic_mx_quant`` returns) pass through untouched. Mirrors
-    vllm-ascend's ``maybe_normalize_mxfp_scale_layout``.
-    """
-    if scale is None or scale.ndim != 2:
-        return scale
-    return scale.reshape(scale.shape[0], scale.shape[1] // 2, 2)
 
 
 class BaseInitRouting(ABC):
@@ -114,7 +103,9 @@ class NPUMoEInitRouting_v2(BaseInitRouting):
         if self.quant_mode == -1:
             pertoken_scale = None
         elif self.quant_mode == MXFP8_QUANT_MODE:
-            pertoken_scale = _normalize_mxfp_scale(pertoken_scale)
+            pertoken_scale = (
+                get_device_operator().normalize_mxfp_scale_layout(pertoken_scale)
+            )
         expert_tokens = expert_tokens.to(torch.int64)
         return hidden_states, expanded_row_idx, expert_tokens, pertoken_scale
 

--- a/python/sglang/srt/hardware_backend/npu/moe/init_routing.py
+++ b/python/sglang/srt/hardware_backend/npu/moe/init_routing.py
@@ -103,8 +103,8 @@ class NPUMoEInitRouting_v2(BaseInitRouting):
         if self.quant_mode == -1:
             pertoken_scale = None
         elif self.quant_mode == MXFP8_QUANT_MODE:
-            pertoken_scale = (
-                get_device_operator().normalize_mxfp_scale_layout(pertoken_scale)
+            pertoken_scale = get_device_operator().normalize_mxfp_scale_layout(
+                pertoken_scale
             )
         expert_tokens = expert_tokens.to(torch.int64)
         return hidden_states, expanded_row_idx, expert_tokens, pertoken_scale

--- a/test/registered/unit/npu/test_device_op.py
+++ b/test/registered/unit/npu/test_device_op.py
@@ -53,9 +53,7 @@ def _fake_torch_npu(device_name, current_device=0):
 class TestDeviceGenerationDetection(_CacheClearingTestCase):
     def test_non_npu_environment_returns_legacy(self):
         with patch("sglang.srt.utils.is_npu", return_value=False):
-            self.assertEqual(
-                get_npu_device_generation(), AscendDeviceGeneration.LEGACY
-            )
+            self.assertEqual(get_npu_device_generation(), AscendDeviceGeneration.LEGACY)
             self.assertIsInstance(get_device_operator(), BaseDeviceOperator)
 
     def test_ascend950_detected_as_a5(self):
@@ -72,9 +70,7 @@ class TestDeviceGenerationDetection(_CacheClearingTestCase):
         with patch("sglang.srt.utils.is_npu", return_value=True), patch.object(
             torch, "npu", fake_npu, create=True
         ):
-            self.assertEqual(
-                get_npu_device_generation(), AscendDeviceGeneration.A5
-            )
+            self.assertEqual(get_npu_device_generation(), AscendDeviceGeneration.A5)
             self.assertIsInstance(get_device_operator(), A5DeviceOperator)
         # The current device is probed, never a hardcoded device 0.
         self.assertEqual(probed["device_id"], 3)
@@ -84,9 +80,7 @@ class TestDeviceGenerationDetection(_CacheClearingTestCase):
         with patch("sglang.srt.utils.is_npu", return_value=True), patch.object(
             torch, "npu", fake_npu, create=True
         ):
-            self.assertEqual(
-                get_npu_device_generation(), AscendDeviceGeneration.LEGACY
-            )
+            self.assertEqual(get_npu_device_generation(), AscendDeviceGeneration.LEGACY)
             self.assertIsInstance(get_device_operator(), BaseDeviceOperator)
 
     def test_explicit_device_id_is_forwarded(self):
@@ -113,9 +107,7 @@ class TestDeviceGenerationDetection(_CacheClearingTestCase):
 class TestNormalizeMxfpScaleLayout(unittest.TestCase):
     def test_base_returns_identity(self):
         scale = torch.empty(4, 16)
-        self.assertIs(
-            BaseDeviceOperator.normalize_mxfp_scale_layout(scale), scale
-        )
+        self.assertIs(BaseDeviceOperator.normalize_mxfp_scale_layout(scale), scale)
 
     def test_base_passes_none(self):
         self.assertIsNone(BaseDeviceOperator.normalize_mxfp_scale_layout(None))
@@ -180,7 +172,9 @@ class TestInitRoutingMxfpScale(unittest.TestCase):
         ):
             _, _, _, scale = self._run_routing(MXFP8_QUANT_MODE)
         self.assertEqual(scale.shape, (self.NUM_TOKENS, self.SCALE_COLS // 2, 2))
-        self.assertTrue(torch.equal(scale.reshape(self.NUM_TOKENS, -1), self._flat_scale()))
+        self.assertTrue(
+            torch.equal(scale.reshape(self.NUM_TOKENS, -1), self._flat_scale())
+        )
 
     def test_legacy_operator_keeps_native_scale_layout(self):
         # Legacy devices keep the producer's native representation.

--- a/test/registered/unit/npu/test_device_op.py
+++ b/test/registered/unit/npu/test_device_op.py
@@ -1,0 +1,204 @@
+"""
+Unit tests for sglang.srt.hardware_backend.npu.device_op.
+
+Covers:
+- Ascend device generation detection (mocked, no real device needed)
+- BaseDeviceOperator / A5DeviceOperator MXFP scale layout contract
+- NPUMoEInitRouting_v2 routing regression: the MXFP scale runtime layout is
+  produced by the DeviceOperator instead of feature-local branching.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.test.ci.ci_register import register_npu_ci
+
+register_npu_ci(est_time=4, suite="stage-a-unit-test-npu")
+
+from sglang.srt.hardware_backend.npu.device_op import (
+    A5DeviceOperator,
+    AscendDeviceGeneration,
+    BaseDeviceOperator,
+    get_device_operator,
+    get_npu_device_generation,
+)
+from sglang.srt.hardware_backend.npu.moe.init_routing import (
+    MXFP8_QUANT_MODE,
+    NPUMoEInitRouting_v2,
+)
+
+
+class _CacheClearingTestCase(unittest.TestCase):
+    """Clear the lru_cache'd detection/factory around every test."""
+
+    def setUp(self):
+        get_npu_device_generation.cache_clear()
+        get_device_operator.cache_clear()
+
+    def tearDown(self):
+        get_npu_device_generation.cache_clear()
+        get_device_operator.cache_clear()
+
+
+def _fake_torch_npu(device_name, current_device=0):
+    return SimpleNamespace(
+        current_device=lambda: current_device,
+        get_device_name=lambda device_id: device_name,
+    )
+
+
+class TestDeviceGenerationDetection(_CacheClearingTestCase):
+    def test_non_npu_environment_returns_legacy(self):
+        with patch("sglang.srt.utils.is_npu", return_value=False):
+            self.assertEqual(
+                get_npu_device_generation(), AscendDeviceGeneration.LEGACY
+            )
+            self.assertIsInstance(get_device_operator(), BaseDeviceOperator)
+
+    def test_ascend950_detected_as_a5(self):
+        probed = {}
+
+        def fake_get_device_name(device_id):
+            probed["device_id"] = device_id
+            return "Ascend950A101"
+
+        fake_npu = SimpleNamespace(
+            current_device=lambda: 3,
+            get_device_name=fake_get_device_name,
+        )
+        with patch("sglang.srt.utils.is_npu", return_value=True), patch.object(
+            torch, "npu", fake_npu, create=True
+        ):
+            self.assertEqual(
+                get_npu_device_generation(), AscendDeviceGeneration.A5
+            )
+            self.assertIsInstance(get_device_operator(), A5DeviceOperator)
+        # The current device is probed, never a hardcoded device 0.
+        self.assertEqual(probed["device_id"], 3)
+
+    def test_ascend910_detected_as_legacy(self):
+        fake_npu = _fake_torch_npu("Ascend910B4")
+        with patch("sglang.srt.utils.is_npu", return_value=True), patch.object(
+            torch, "npu", fake_npu, create=True
+        ):
+            self.assertEqual(
+                get_npu_device_generation(), AscendDeviceGeneration.LEGACY
+            )
+            self.assertIsInstance(get_device_operator(), BaseDeviceOperator)
+
+    def test_explicit_device_id_is_forwarded(self):
+        probed = {}
+
+        def fake_get_device_name(device_id):
+            probed["device_id"] = device_id
+            return "Ascend950A101"
+
+        fake_npu = SimpleNamespace(
+            current_device=lambda: 3,
+            get_device_name=fake_get_device_name,
+        )
+        with patch("sglang.srt.utils.is_npu", return_value=True), patch.object(
+            torch, "npu", fake_npu, create=True
+        ):
+            self.assertEqual(
+                get_npu_device_generation(device_id=5),
+                AscendDeviceGeneration.A5,
+            )
+        self.assertEqual(probed["device_id"], 5)
+
+
+class TestNormalizeMxfpScaleLayout(unittest.TestCase):
+    def test_base_returns_identity(self):
+        scale = torch.empty(4, 16)
+        self.assertIs(
+            BaseDeviceOperator.normalize_mxfp_scale_layout(scale), scale
+        )
+
+    def test_base_passes_none(self):
+        self.assertIsNone(BaseDeviceOperator.normalize_mxfp_scale_layout(None))
+
+    def test_a5_pair_splits_2d_scale(self):
+        scale = torch.arange(64, dtype=torch.float32).reshape(4, 16)
+        out = A5DeviceOperator.normalize_mxfp_scale_layout(scale)
+        self.assertEqual(out.shape, (4, 8, 2))
+        self.assertTrue(torch.equal(out.reshape(4, 16), scale))
+
+    def test_a5_passes_through_3d_scale(self):
+        scale = torch.empty(4, 8, 2)
+        self.assertIs(A5DeviceOperator.normalize_mxfp_scale_layout(scale), scale)
+
+    def test_a5_passes_none(self):
+        self.assertIsNone(A5DeviceOperator.normalize_mxfp_scale_layout(None))
+
+
+class TestInitRoutingMxfpScale(unittest.TestCase):
+    """Routing regression: MXFP scale layout comes from the DeviceOperator."""
+
+    NUM_TOKENS = 4
+    TOP_K = 2
+    NUM_EXPERTS = 8
+    SCALE_COLS = 16
+
+    def _flat_scale(self):
+        return torch.arange(
+            self.NUM_TOKENS * self.SCALE_COLS, dtype=torch.float32
+        ).reshape(self.NUM_TOKENS, self.SCALE_COLS)
+
+    def _run_routing(self, quant_mode):
+        hidden_states = torch.randn(self.NUM_TOKENS, 16)
+        topk_ids = torch.zeros(self.NUM_TOKENS, self.TOP_K, dtype=torch.int32)
+        flat_scale = self._flat_scale()
+
+        def fake_init_routing_v2(hidden, topk, **kwargs):
+            return (
+                hidden,
+                torch.zeros(self.NUM_TOKENS * self.TOP_K, dtype=torch.int32),
+                torch.zeros(self.NUM_EXPERTS, dtype=torch.int32),
+                flat_scale,
+            )
+
+        routing = NPUMoEInitRouting_v2(quant_mode=quant_mode)
+        with patch.object(
+            torch.ops.npu,
+            "npu_moe_init_routing_v2",
+            fake_init_routing_v2,
+            create=True,
+        ):
+            return routing._init_routing(
+                hidden_states, topk_ids, self.NUM_EXPERTS, self.TOP_K
+            )
+
+    def test_a5_operator_keeps_pair_split_contract(self):
+        # Before the DeviceOperator refactor, quant_mode==3 always pair-split
+        # the flat [N, M] scale; on A5 the runtime contract is unchanged.
+        with patch(
+            "sglang.srt.hardware_backend.npu.moe.init_routing.get_device_operator",
+            return_value=A5DeviceOperator(),
+        ):
+            _, _, _, scale = self._run_routing(MXFP8_QUANT_MODE)
+        self.assertEqual(scale.shape, (self.NUM_TOKENS, self.SCALE_COLS // 2, 2))
+        self.assertTrue(torch.equal(scale.reshape(self.NUM_TOKENS, -1), self._flat_scale()))
+
+    def test_legacy_operator_keeps_native_scale_layout(self):
+        # Legacy devices keep the producer's native representation.
+        with patch(
+            "sglang.srt.hardware_backend.npu.moe.init_routing.get_device_operator",
+            return_value=BaseDeviceOperator(),
+        ):
+            _, _, _, scale = self._run_routing(MXFP8_QUANT_MODE)
+        self.assertEqual(scale.shape, (self.NUM_TOKENS, self.SCALE_COLS))
+
+    def test_no_quant_returns_none_scale(self):
+        with patch(
+            "sglang.srt.hardware_backend.npu.moe.init_routing.get_device_operator",
+            return_value=A5DeviceOperator(),
+        ):
+            _, _, _, scale = self._run_routing(-1)
+        self.assertIsNone(scale)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
Ascend generations may require different runtime representations for the same semantic data. Today, the MXFP MoE routing path directly normalizes the E8M0 scale layout in init_routing.py: npu_moe_init_routing_v2 (quant_mode=3) produces a flat [N, M] scale while the downstream A5 grouped-matmul path consumes the pair-split [N, M/2, 2] representation.

This introduces a minimal DeviceOperator abstraction following #35709 and moves this runtime-visible layout adaptation out of the MoE feature code:

<!-- Describe the purpose and goals of this pull request. -->

## Modifications
- AscendDeviceGeneration + get_npu_device_generation(): centralized, cached generation detection (Ascend950 -> A5, else LEGACY; current device is probed, never a hardcoded device 0)
- BaseDeviceOperator / A5DeviceOperator with the first contract, normalize_mxfp_scale_layout(); Base is identity (legacy representation = producer's native layout), A5 performs the existing pair-split
- get_device_operator() lazy factory: importing the module never probes the device
- init_routing.py: _normalize_mxfp_scale() removed; the MXFP8 branch now delegates to the DeviceOperator, keeping the quant decision (quant_mode == MXFP8_QUANT_MODE) in feature code

The change is intentionally small: kernel/provider differences remain outside this abstraction. Mock-based unit tests cover detection, the operator contract, and the routing regression.
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
NA
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling
NA
<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32544878387](https://github.com/sgl-project/sglang/actions/runs/32544878387)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32544878278](https://github.com/sgl-project/sglang/actions/runs/32544878278)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32544878492](https://github.com/sgl-project/sglang/actions/runs/32544878492)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->