### PR TITLE
refactor(disagg): remove dead build_and_send_encode_request

### DIFF
--- a/python/sglang/srt/disaggregation/encoder/receiver.py
+++ b/python/sglang/srt/disaggregation/encoder/receiver.py
@@ -2552,14 +2552,6 @@ class MMReceiverGrpc(MMReceiverBase):
             encode_urls=encode_urls,
         )
 
-    def build_and_send_encode_request(self, image_urls, rid):
-        encode_req = GenerateReqInput(
-            image_data=[ImageData(url=url) for url in image_urls],
-            rid=rid,
-        )
-        self.send_encode_request(encode_req)
-        return encode_req
-
     # For zmq_to_scheduler
     def process_waiting_requests(self, recv_reqs):
         return self._process_waiting_requests(recv_reqs, WaitingZmqRequestGrpc)


### PR DESCRIPTION
## Motivation

`MMReceiverGrpc.build_and_send_encode_request` in `python/sglang/srt/disaggregation/encoder/receiver.py` has no callers anywhere in the repo.

It is not an unwired hook awaiting a caller — it could not work as written. It calls `self.send_encode_request(encode_req)` with one positional argument, but `send_encode_request` carries two incompatible signatures in this module:

- `MMReceiverBase.send_encode_request(self, obj, time_stats_json=None)` — the inherited one, which would accept the call
- three other `send_encode_request(self)` definitions in the same file, which take no arguments at all

Since nothing exercises the path, which one it binds against was never settled.

## Modifications

Removes the method. 1 file, 0 insertions / 8 deletions.

`GenerateReqInput` and `ImageData` stay imported — both are still referenced elsewhere in the file (`_extract_url_data` and the multimodal item handling respectively).

This is one of a small series of independent dead-code removals in the disaggregation module; it is split per-file so each can be reviewed by the relevant owner. Related: #35838.

## Accuracy Tests

Not applicable — no model output, kernel, or forward path is touched. The change deletes a method with no callers.

## Speed Tests and Profiling

Not applicable — no code on any execution path changed.

## Verification performed

- No caller for `build_and_send_encode_request` repo-wide (`.py` / `.md` / `.sh` / `.rs`).
- Import survival checked explicitly: `GenerateReqInput` and `ImageData` each retain uses after the removal.
- `ruff 0.15.1 --select=F401,F821,UP037` (the pinned pre-commit config) passes, plus pinned `black 26.1.0` and `isort 7.0.0`.

Encode-path integration tests were **not** run locally (they need GPUs and a live encode server). For removal of an uncalled method, the reference sweep plus the F401/F821 pass is the substantive evidence; CI should confirm.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). — N/A: removing uncalled code adds no testable behavior.
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — N/A: the symbol is not documented.
- [x] Provide accuracy and speed benchmark results. — N/A, see above.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32469162511](https://github.com/sgl-project/sglang/actions/runs/32469162511)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32469162457](https://github.com/sgl-project/sglang/actions/runs/32469162457)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32469162582](https://github.com/sgl-project/sglang/actions/runs/32469162582)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->