### PR TITLE
refactor(disagg): remove dead get_embedding_port

### DIFF
--- a/python/sglang/srt/disaggregation/encoder/server.py
+++ b/python/sglang/srt/disaggregation/encoder/server.py
@@ -11,7 +11,6 @@ from dataclasses import dataclass, field
 from http import HTTPStatus
 from typing import Any, Awaitable, Callable, Dict, Iterable, List, Optional, Set, Tuple
 
-import aiohttp
 import msgspec
 import numpy as np
 import torch
@@ -1943,17 +1942,6 @@ class MMEncoder:
         finally:
             logger.info(f"Cleaning up resources for req_id {req_id}")
             await self.release_request(req_id)
-
-    async def get_embedding_port(self, prefill_url):
-        async with aiohttp.ClientSession(
-            timeout=aiohttp.ClientTimeout(total=1800)
-        ) as session:
-            response = await session.post(
-                f"{prefill_url}/embedding_bootstrap",
-                json={"embedding_port": None},
-            )
-            response_json = await response.json()
-            return response_json["embedding_port"]
 
 
 class EncoderProfiler:


### PR DESCRIPTION
## Motivation

`MMEncoder.get_embedding_port` in `python/sglang/srt/disaggregation/encoder/server.py` has no callers, and it targets a route that does not exist.

It POSTs to `{prefill_url}/embedding_bootstrap`, but `embedding_bootstrap` appears nowhere else in the repo — there is no such endpoint on the prefill side. So this is not a helper waiting to be wired up; it is a client for a server endpoint that was either never implemented or removed long ago. Calling it today would 404.

## Modifications

Removes the method, and with it the module's only use of `aiohttp`, so that import goes too. 1 file, 0 insertions / 12 deletions.

`requests as http_requests` is a separate live dependency and stays.

This is one of a small series of independent dead-code removals in the disaggregation module; it is split per-file so each can be reviewed by the relevant owner. Related: #35838, #35843.

## Accuracy Tests

Not applicable — no model output, kernel, or forward path is touched. The change deletes a method with no callers.

## Speed Tests and Profiling

Not applicable — no code on any execution path changed.

## Verification performed

- No caller for `get_embedding_port` repo-wide (`.py` / `.md` / `.sh` / `.rs`), and no `embedding_bootstrap` route anywhere.
- `aiohttp` confirmed to have zero remaining uses in the file after the removal.
- `ruff 0.15.1 --select=F401,F821,UP037` (the pinned pre-commit config) passes, plus pinned `black 26.1.0` and `isort 7.0.0`. F401 is the relevant check here, since the change removes an import.

Encode-path integration tests were **not** run locally (they need GPUs and a live encode server). For removal of an uncalled method, the reference sweep plus the F401/F821 pass is the substantive evidence; CI should confirm.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). — N/A: removing uncalled code adds no testable behavior.
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — N/A: the symbol is not documented.
- [x] Provide accuracy and speed benchmark results. — N/A, see above.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32469184298](https://github.com/sgl-project/sglang/actions/runs/32469184298)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32469184134](https://github.com/sgl-project/sglang/actions/runs/32469184134)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32469184476](https://github.com/sgl-project/sglang/actions/runs/32469184476)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->