### PR TITLE
[MUSA] add platform capability support and skip CUDA-only dtype fallback

### DIFF
--- a/3rdparty/amd/wheel/sglang/pyproject.toml
+++ b/3rdparty/amd/wheel/sglang/pyproject.toml
@@ -123,7 +123,7 @@ srt_musa = [
   "sglang[runtime_common]",
   "torch",
   "torch_musa",
-  "torchada>=0.1.74",
+  "torchada>=0.1.84",
   "mthreads-ml-py",
   "mate>=0.2.0",
   "deep-gemm>=0.1.3",

--- a/python/pyproject_other.toml
+++ b/python/pyproject_other.toml
@@ -156,7 +156,7 @@ srt_musa = [
   "sglang[runtime_common]",
   "torch",
   "torch_musa",
-  "torchada>=0.1.74",
+  "torchada>=0.1.84",
 ]
 
 diffusion_musa = [

--- a/python/sglang/kernels/aot/pyproject_musa.toml
+++ b/python/sglang/kernels/aot/pyproject_musa.toml
@@ -3,7 +3,7 @@ requires = [
   "setuptools>=75.0",
   "scikit-build-core>=0.10",
   "torch",
-  "torchada>=0.1.74",
+  "torchada>=0.1.84",
   "wheel",
 ]
 build-backend = "setuptools.build_meta"

--- a/python/sglang/srt/platforms/__init__.py
+++ b/python/sglang/srt/platforms/__init__.py
@@ -21,6 +21,7 @@ from sglang.srt.environ import envs
 from sglang.srt.platforms.cpu import CpuSRTPlatform
 from sglang.srt.platforms.cuda import CudaSRTPlatform
 from sglang.srt.platforms.interface import SRTPlatform
+from sglang.srt.platforms.musa import MusaSRTPlatform
 from sglang.srt.platforms.rocm import RocmSRTPlatform
 from sglang.srt.platforms.xpu import XpuSRTPlatform
 from sglang.srt.plugins import PLATFORM_PLUGINS_GROUP, load_plugins_by_group
@@ -40,6 +41,14 @@ def _is_rocm_available() -> bool:
 
 def _is_cpu_available() -> bool:
     return os.getenv("SGLANG_USE_CPU_ENGINE", "0") == "1"
+
+
+def _is_musa_available() -> bool:
+    try:
+        from torchada import Platform, detect_platform
+    except ImportError:
+        return False
+    return detect_platform() == Platform.MUSA
 
 
 def _is_xpu_available() -> bool:
@@ -65,6 +74,7 @@ def _resolve_platform() -> SRTPlatform:
          - 0 activated + SGLANG_USE_CPU_ENGINE=1 → fallback CpuSRTPlatform
            (checked first; an explicit opt-in wins over CUDA/ROCm availability,
            so developers on GPU hosts can intentionally exercise the CPU path)
+         - 0 activated + MUSA available → fallback MusaSRTPlatform
          - 0 activated + CUDA available → fallback CudaSRTPlatform
          - 0 activated + ROCm available → fallback RocmSRTPlatform
          - 0 activated + XPU available  → fallback XpuSRTPlatform
@@ -122,6 +132,11 @@ def _resolve_platform() -> SRTPlatform:
         if _is_cpu_available():
             logger.debug("SGLANG_USE_CPU_ENGINE=1. Using CPU SRTPlatform defaults.")
             return CpuSRTPlatform()
+        if _is_musa_available():
+            logger.debug(
+                "No platform plugin detected. Using MUSA SRTPlatform defaults."
+            )
+            return MusaSRTPlatform()
         if _is_cuda_available():
             logger.debug(
                 "No platform plugin detected. Using CUDA SRTPlatform defaults."

--- a/python/sglang/srt/platforms/musa.py
+++ b/python/sglang/srt/platforms/musa.py
@@ -1,0 +1,22 @@
+"""MUSA device operations for the SRT platform layer.
+
+MUSA uses torchada to expose a CUDA-compatible API surface through
+``torch.cuda.*``. Reuse the CUDA device operations and override only platform
+identity.
+"""
+
+from sglang.srt.platforms.cuda import CudaDeviceMixin
+from sglang.srt.platforms.device_mixin import PlatformEnum
+from sglang.srt.platforms.interface import SRTPlatform
+
+
+class MusaDeviceMixin(CudaDeviceMixin):
+    """MUSA device ops through torchada's CUDA-compatible API surface."""
+
+    _enum: PlatformEnum = PlatformEnum.MUSA
+    device_name: str = "musa"
+    device_type: str = "musa"
+
+
+class MusaSRTPlatform(MusaDeviceMixin, SRTPlatform):
+    """Default in-tree MUSA SRT platform."""


### PR DESCRIPTION
## Summary

Add in-tree MUSA platform support to SGLang's SRT platform layer:

- add `MusaSRTPlatform` with CUDA-compatible device operations and MUSA platform identity
- make platform auto-discovery select MUSA before CUDA when `torch.version.musa` is present and `torch.musa.is_available()` is true
- call the legacy GPU dtype fallback through `maybe_downgrade_dtype_for_legacy_gpu()` for all non-CPU devices, while gating the fallback itself on `current_platform.is_cuda()`
- bump the `srt_musa` torchada dependency to `>=0.1.84`

## Dependency

Requires torchada `0.1.84`, which contains the MUSA graph-safe operator overrides and Inductor heuristic mapping used by downstream SGLang-Omni graph-enabled paths.

## Scope

This keeps the MUSA integration at the platform/capability layer:

- no model-specific MUSA logic
- no fake CUDA availability patching
- no `torch.load` map-location rewrite
- no flash-attention import shim
- non-CUDA platforms skip CUDA-only `torch.cuda.get_device_capability()` checks

## Verification

Rebased onto the latest upstream `main`.

```bash
uvx pre-commit run --files \
  python/pyproject_other.toml \
  python/sglang/srt/model_executor/model_runner.py \
  python/sglang/srt/model_executor/model_runner_components/load_model_utils.py \
  python/sglang/srt/platforms/__init__.py \
  python/sglang/srt/platforms/musa.py
```

Result: passed.

MUSA runtime checks with torchada `0.1.84` confirmed:

```text
current_platform resolves to the MUSA platform
current_platform.is_musa() == True
torch.musa.is_available() == True
legacy CUDA sm80 dtype fallback is skipped on non-CUDA platforms
CUDA still owns the legacy dtype fallback path
```

SGLang-Omni integration smoke with latest SGLang, SGLang-Omni, and torchada changes:

| Model | Request | Result |
| --- | --- | --- |
| `Qwen/Qwen3-ASR-1.7B` | `/v1/audio/transcriptions` with a WAV input | Passed; returned text transcription |
| `Qwen/Qwen3-TTS-12Hz-0.6B-Base` | `/v1/audio/speech` with graph enabled and reduced capture range | Passed; generated WAV audio |
| `Qwen/Qwen3-Omni-30B-A3B-FP8` | image chat completion with graph enabled | Passed; returned the expected image answer |
| `MiniMaxAI/MiniMax-Music3` | `/v1/audio/speech` music generation | Passed; generated stereo WAV audio |

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32960915709](https://github.com/sgl-project/sglang/actions/runs/32960915709)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32960915567](https://github.com/sgl-project/sglang/actions/runs/32960915567)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32960915729](https://github.com/sgl-project/sglang/actions/runs/32960915729)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->