### PR TITLE
fix(kimi-k3): align reported cached tokens with prompt usage

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -670,7 +670,7 @@ class OpenAIServingChat(OpenAIServingBase):
         if not self.tokenizer_manager.server_args.enable_cache_report:
             return None
         return UsageProcessor._details_if_cached(
-            content["meta_info"].get("cached_tokens", 0)
+            self._reported_cached_tokens(content["meta_info"])
         )
 
     def _reported_prompt_tokens(self, meta_info: Dict[str, Any]) -> int:
@@ -680,6 +680,17 @@ class OpenAIServingChat(OpenAIServingBase):
             # reference API excludes it from billed/reported prompt tokens.
             prompt_tokens = max(0, prompt_tokens - self._KIMI_K3_GENERATION_STUB_TOKENS)
         return prompt_tokens
+
+    def _reported_cached_tokens(self, meta_info: Dict[str, Any]) -> int:
+        cached_tokens = meta_info.get("cached_tokens", 0)
+        if self.chat_encoding_spec == "kimi_k3":
+            # Cache hits are a physical prefix length. Exclude only the part of
+            # K3's trailing generation stub that the cached prefix reaches.
+            cached_tokens = min(
+                cached_tokens,
+                self._reported_prompt_tokens(meta_info),
+            )
+        return cached_tokens
 
     async def _generate_stream_content(
         self,
@@ -1555,7 +1566,9 @@ class OpenAIServingChat(OpenAIServingBase):
                 reasoning_tokens[index] = content["meta_info"].get(
                     "reasoning_tokens", 0
                 )
-                cached_tokens[index] = content["meta_info"].get("cached_tokens", 0)
+                cached_tokens[index] = self._reported_cached_tokens(
+                    content["meta_info"]
+                )
                 hidden_states[index] = content["meta_info"].get("hidden_states", None)
                 routed_experts[index] = content["meta_info"].get("routed_experts", None)
                 cached_tokens_details[index] = content["meta_info"].get(
@@ -1808,6 +1821,9 @@ class OpenAIServingChat(OpenAIServingBase):
                     "meta_info": {
                         **item["meta_info"],
                         "prompt_tokens": self._reported_prompt_tokens(
+                            item["meta_info"]
+                        ),
+                        "cached_tokens": self._reported_cached_tokens(
                             item["meta_info"]
                         ),
                     },

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -425,6 +425,7 @@ class ServingChatTestCase(unittest.TestCase):
 
     def test_kimi_k3_usage_excludes_assistant_generation_stub(self):
         self.chat.chat_encoding_spec = "kimi_k3"
+        self.tm.server_args.enable_cache_report = True
         ret = [
             {
                 "text": "Answer",
@@ -432,7 +433,7 @@ class ServingChatTestCase(unittest.TestCase):
                     "id": "chatcmpl-kimi-k3-usage",
                     "prompt_tokens": 2075,
                     "completion_tokens": 1,
-                    "cached_tokens": 0,
+                    "cached_tokens": 2073,
                     "image_tokens": 2035,
                     "finish_reason": {"type": "stop", "matched": None},
                     "weight_version": "default",
@@ -444,7 +445,52 @@ class ServingChatTestCase(unittest.TestCase):
 
         self.assertEqual(response.usage.prompt_tokens, 2072)
         self.assertEqual(response.usage.total_tokens, 2073)
+        self.assertEqual(response.usage.prompt_tokens_details.cached_tokens, 2072)
         self.assertEqual(response.usage.prompt_tokens_details.image_tokens, 2035)
+
+    def test_non_kimi_k3_usage_preserves_cached_tokens(self):
+        self.chat.chat_encoding_spec = None
+        self.tm.server_args.enable_cache_report = True
+        ret = [
+            {
+                "text": "Answer",
+                "meta_info": {
+                    "id": "chatcmpl-regular-cache-usage",
+                    "prompt_tokens": 2075,
+                    "completion_tokens": 1,
+                    "cached_tokens": 2073,
+                    "finish_reason": {"type": "stop", "matched": None},
+                    "weight_version": "default",
+                },
+            }
+        ]
+
+        response = self.chat._build_chat_response(self.basic_req, ret, created=123)
+
+        self.assertEqual(response.usage.prompt_tokens, 2075)
+        self.assertEqual(response.usage.prompt_tokens_details.cached_tokens, 2073)
+
+    def test_kimi_k3_usage_preserves_cache_before_generation_stub(self):
+        self.chat.chat_encoding_spec = "kimi_k3"
+        self.tm.server_args.enable_cache_report = True
+        ret = [
+            {
+                "text": "Answer",
+                "meta_info": {
+                    "id": "chatcmpl-kimi-k3-prefix-cache-usage",
+                    "prompt_tokens": 2075,
+                    "completion_tokens": 1,
+                    "cached_tokens": 2000,
+                    "finish_reason": {"type": "stop", "matched": None},
+                    "weight_version": "default",
+                },
+            }
+        ]
+
+        response = self.chat._build_chat_response(self.basic_req, ret, created=123)
+
+        self.assertEqual(response.usage.prompt_tokens, 2072)
+        self.assertEqual(response.usage.prompt_tokens_details.cached_tokens, 2000)
 
     def test_kimi_tool_call_keeps_default_reasoning(self):
         self.template_manager.reasoning_config = ReasoningToggleConfig(
@@ -2821,7 +2867,9 @@ class ServingChatTestCase(unittest.TestCase):
                 choice_logprobs=None,
                 finish_reason_type="stop",
                 continuous_usage_stats=True,
-                prompt_tokens={0: 10},
+                prompt_tokens={
+                    0: self.chat._reported_prompt_tokens(content["meta_info"])
+                },
                 reasoning_tokens={0: 0},
                 completion_tokens={0: 2},
             ):
@@ -2837,6 +2885,16 @@ class ServingChatTestCase(unittest.TestCase):
         usages = self._collect_continuous_usage(cached_tokens=6)
         self.assertTrue(usages, "continuous_usage_stats attached no usage")
         self.assertEqual(usages[0]["prompt_tokens_details"]["cached_tokens"], 6)
+
+    def test_kimi_k3_continuous_usage_excludes_cached_generation_stub(self):
+        self.chat.chat_encoding_spec = "kimi_k3"
+        self.tm.server_args.enable_cache_report = True
+
+        usages = self._collect_continuous_usage(cached_tokens=8)
+
+        self.assertTrue(usages, "continuous_usage_stats attached no usage")
+        self.assertEqual(usages[0]["prompt_tokens"], 7)
+        self.assertEqual(usages[0]["prompt_tokens_details"]["cached_tokens"], 7)
 
     def test_continuous_usage_omits_cached_tokens_when_report_disabled(self):
         """With cache reporting off, continuous_usage_stats must not leak cached tokens."""


### PR DESCRIPTION
## Motivation

For Kimi K3, the reported `prompt_tokens` excludes the three-token assistant generation stub appended by the chat template. However, `cached_tokens` was still reported as the raw physical prefix-cache length.

When the cached prefix overlaps the trailing generation stub, `cached_tokens` can exceed `prompt_tokens`. For example:

```text
prompt_tokens = 6207
cached_tokens = 6208
```

This violates the expected invariant that cached tokens are a subset of prompt tokens and can result in inconsistent cache-input accounting or billing.

## Modifications

- Added K3-specific normalization for reported cached tokens.
- For Kimi K3, reported cached tokens are calculated as:

  ```python
  min(raw_cached_tokens, reported_prompt_tokens)
  ```

  This excludes only the portion of the trailing generation stub reached by the cached prefix.

- Preserved the original `cached_tokens` value when the cached prefix does not reach the generation stub.
- Preserved existing behavior for all non-K3 models.
- Applied the normalization consistently to:
  - Non-streaming Chat Completions
  - Streaming final usage
  - Continuous streaming usage
- Kept scheduler-side and KV-cache accounting unchanged. The change only affects the OpenAI-compatible usage response.
- Added regression coverage for:
  - K3 cache hits overlapping the generation stub
  - K3 cache hits ending before the generation stub
  - Non-K3 cached-token reporting
  - K3 continuous streaming usage

## Accuracy Tests

This change does not affect model inputs, model outputs, kernels, sampling, or model forward execution. It only normalizes usage metadata returned to API clients.

The following behavior matrix was verified against the production reporting helpers:

```text
Model      Raw prompt/cache    Reported prompt/cache
Kimi K3    6210 / 6000         6207 / 6000
Kimi K3    6210 / 6208         6207 / 6207
Non-K3     6210 / 6208         6210 / 6208
DSV4       6210 / 6208         6210 / 6208
```

Additional verification:

- Python syntax validation passed for the modified implementation and test files.
- `git diff --check` passed.
- Regression unit tests were added.

The unit-test file could not be executed in the local environment because the required `orjson` dependency was unavailable. The tests are expected to run in the standard SGLang CI environment.

## Speed Tests and Profiling

No inference benchmark was performed because this change does not modify the inference path.

The additional work is limited to the CPU response-serialization path and consists of:

- One K3 model-type check
- One integer `min()` operation

It does not affect tokenization, prefix-cache lookup, scheduling, prefill, decode, KV transfer, or GPU execution.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).  
  `pre-commit` was not run in the current local environment.
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).  
  No documentation update is required because no public API, configuration, or user workflow is changed.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).  
  Not applicable to model accuracy or inference performance; validation details are provided above.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32480823050](https://github.com/sgl-project/sglang/actions/runs/32480823050)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32480822686](https://github.com/sgl-project/sglang/actions/runs/32480822686)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32480822840](https://github.com/sgl-project/sglang/actions/runs/32480822840)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->