### PR TITLE
model: restore Hunyuan-A13B q/k shape after per-head qk_norm (fix non-CUDA attention crash)

### DIFF
--- a/python/sglang/srt/models/hunyuan.py
+++ b/python/sglang/srt/models/hunyuan.py
@@ -360,8 +360,12 @@ class HunYuanAttention(nn.Module):
             if self.use_qk_norm:
                 # q = self.query_layernorm(q.view(-1, self.num_heads, self.head_dim).contiguous())
                 # k = self.key_layernorm(k.view(-1, self.num_kv_heads, self.head_dim).contiguous())
-                q = self.query_layernorm(q.reshape(-1, self.head_dim).contiguous())
-                k = self.key_layernorm(k.reshape(-1, self.head_dim).contiguous())
+                q = self.query_layernorm(
+                    q.reshape(-1, self.head_dim).contiguous()
+                ).reshape(-1, self.q_size)
+                k = self.key_layernorm(
+                    k.reshape(-1, self.head_dim).contiguous()
+                ).reshape(-1, self.kv_size)
         elif self.attention_type == "cross":
             assert kv_states is not None
             ori_k, v = kv_states  # use last layer kv,


### PR DESCRIPTION
## Motivation

Serving `tencent/Hunyuan-A13B-Instruct` (`HunYuanMoEV1ForCausalLM`,
`use_qk_norm=True`) on non-CUDA backends (Intel XPU / triton) crashes in
attention:

```
RuntimeError: mat1 and mat2 shapes cannot be multiplied (24x128 and 512x4096)
```

`HunYuanAttention.forward`'s `use_qk_norm` path reshapes q/k to
`(tokens*heads, head_dim)` for the per-head RMSNorm but never restores the flat
`(tokens, heads*head_dim)` shape that RadixAttention / `o_proj` expect. On CUDA
the flashinfer backend recomputes the token count from batch metadata, so the
mangled leading dim is masked; triton/XPU keys off `q.shape[0]`, so the bad
shape reaches `o_proj` (per-rank `512 = 4 heads x 128` at tp-8) and the matmul
fails.

## Modifications

Restore the flat shape after the per-head norm by appending
`.reshape(-1, self.q_size)` / `.reshape(-1, self.kv_size)`, matching the
canonical `models/utils.py::apply_qk_norm` (which ends with
`q = q_by_head.view(q.shape)`). Only the self-attn `use_qk_norm` path changes;
the final tensor shape is identical to before on every backend, so CUDA
behavior is unchanged.

(The `cross`/CLA path has the same latent missing-restore, but `use_cla=False`
for this model, so it is left untouched and flagged for a follow-up.)

## Accuracy Tests

Intel XPU, tp-8, bf16 — model loads with 0 skipped params and the server stays
healthy through the previously-crashing qk_norm path:
- gsm8k 5-shot smoke: 10/10.
- gsm8k raw completions (200 samples, max_gen_toks 8192): strict-match 73.5% /
  flexible-extract 79.5%.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32480991137](https://github.com/sgl-project/sglang/actions/runs/32480991137)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32480990686](https://github.com/sgl-project/sglang/actions/runs/32480990686)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32480990967](https://github.com/sgl-project/sglang/actions/runs/32480990967)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->