### PR TITLE
[FlashInfer] perf: Fuse FP4 MoE input quantization and shared-expert SwiGLU

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -901,6 +901,8 @@ class Envs:
     # Enable per-token FP32 activation scaling for serialized ModelOpt FP4 with
     # FlashInfer TRT-LLM or CuTe DSL v2 MoE.
     SGLANG_FLASHINFER_NVFP4_PER_TOKEN_ACTIVATION = EnvBool(False)
+    # Couple decode-time routed FP4 quantization with low-M shared BF16 SwiGLU.
+    SGLANG_ENABLE_FLASHINFER_BF16_SWIGLU = EnvBool(False)
     # Launch the TRT-LLM MoE grouped GEMMs with PDL only at or below this
     # token count.
     SGLANG_TRTLLM_MOE_PDL_MAX_TOKENS = EnvInt(8192)

--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -774,6 +774,7 @@ class LayerCommunicator:
             and communicate_fn.func
             is CommunicateWithAllReduceAndLayerNormFn._gather_hidden_states_and_residual
             and self.layer_scatter_modes.layer_input_mode == ScatterMode.TP_ATTN_FULL
+            and not get_attn_tp_context().input_scattered
             and apply_flashinfer_allreduce_fusion(hidden_states.shape[0])
         ):
             from sglang.srt.layers.flashinfer_comm_fusion import (

--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -762,17 +762,41 @@ class LayerCommunicator:
         residual: torch.Tensor,
         forward_batch: ForwardBatch,
         cache=None,
+        fp4_global_scale: Optional[torch.Tensor] = None,
     ):
         if cache is not None:
             self._context.cache = cache
 
-        return self._communicate_with_all_reduce_and_layer_norm_fn(
+        communicate_fn = self._communicate_with_all_reduce_and_layer_norm_fn
+        if (
+            fp4_global_scale is not None
+            and isinstance(communicate_fn, partial)
+            and communicate_fn.func
+            is CommunicateWithAllReduceAndLayerNormFn._gather_hidden_states_and_residual
+            and self.layer_scatter_modes.layer_input_mode == ScatterMode.TP_ATTN_FULL
+            and apply_flashinfer_allreduce_fusion(hidden_states.shape[0])
+        ):
+            from sglang.srt.layers.flashinfer_comm_fusion import (
+                flashinfer_allreduce_residual_rmsnorm_fp4_quant,
+            )
+
+            outputs = flashinfer_allreduce_residual_rmsnorm_fp4_quant(
+                hidden_states,
+                residual,
+                self.post_attention_layernorm.weight,
+                fp4_global_scale,
+                self.post_attention_layernorm.variance_epsilon,
+            )
+            return outputs[0], outputs[1], outputs[2:]
+
+        outputs = communicate_fn(
             hidden_states=hidden_states,
             residual=residual,
             forward_batch=forward_batch,
             layernorm=self.post_attention_layernorm,
             context=self._context,
         )
+        return outputs + (None,) if fp4_global_scale is not None else outputs
 
     def postprocess_layer(
         self,

--- a/python/sglang/srt/layers/flashinfer_comm_fusion.py
+++ b/python/sglang/srt/layers/flashinfer_comm_fusion.py
@@ -869,6 +869,59 @@ def flashinfer_allreduce_residual_rmsnorm(
     return norm_out, residual_out
 
 
+def fake_flashinfer_allreduce_residual_rmsnorm_fp4_quant(
+    input_tensor: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    fp4_global_scale: torch.Tensor,
+    eps: float = 1e-6,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    token_num, hidden_dim = input_tensor.shape
+    return (
+        torch.empty_like(input_tensor),
+        torch.empty_like(residual),
+        input_tensor.new_empty((token_num, hidden_dim // 2), dtype=torch.uint8),
+        input_tensor.new_empty(
+            (token_num, hidden_dim // 16), dtype=torch.float8_e4m3fn
+        ),
+    )
+
+
+@register_custom_op(
+    mutates_args=["input_tensor", "residual", "weight"],
+    fake_impl=fake_flashinfer_allreduce_residual_rmsnorm_fp4_quant,
+)
+def flashinfer_allreduce_residual_rmsnorm_fp4_quant(
+    input_tensor: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    fp4_global_scale: torch.Tensor,
+    eps: float = 1e-6,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    outputs = fake_flashinfer_allreduce_residual_rmsnorm_fp4_quant(
+        input_tensor, residual, weight, fp4_global_scale, eps
+    )
+    norm_out, residual_out, quant_out, scale_out = outputs
+
+    _flashinfer_comm.allreduce_fusion(
+        input=input_tensor,
+        workspace=_get_workspace_manager(True).workspace,
+        pattern=_flashinfer_comm.AllReduceFusionPattern.kARResidualRMSNormOutFP4Quant,
+        launch_with_pdl=True,
+        residual_out=residual_out,
+        norm_out=norm_out,
+        quant_out=quant_out,
+        scale_out=scale_out,
+        residual_in=residual,
+        rms_gamma=weight,
+        rms_eps=eps,
+        scale_factor=fp4_global_scale,
+        layout_code=_flashinfer_comm.QuantizationSFLayout.LINEAR,
+    )
+
+    return outputs
+
+
 def can_use_flashinfer_allreduce(
     input_: torch.Tensor,
     *,

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -1480,10 +1480,10 @@ class FusedMoE(torch.nn.Module):
             and dispatch_output.format.is_standard()
             and dispatch_output.hidden_states_scale is None
         ):
-            # SGLANG_OPT_MOE_QUANT_ONCE: the standard dispatch was a pure
-            # passthrough, so the caller's pre-quantized (q, scale) pair still
-            # matches dispatch_output.hidden_states; attach it for the triton
-            # fused runner to skip its own activation quant.
+            # Standard dispatch was a pure passthrough, so the caller's
+            # pre-quantized (q, scale) pair still matches the dispatched hidden
+            # states. Attach it for the selected fused runner to skip its own
+            # activation quantization.
             dispatch_output = dispatch_output._replace(
                 hidden_states_pre_quant=pre_quant_input
             )

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -1511,7 +1511,10 @@ class FusedMoE(torch.nn.Module):
         return final_hidden_states
 
     def forward_deferred_finalize(
-        self, hidden_states: torch.Tensor, topk_output: TopKOutput
+        self,
+        hidden_states: torch.Tensor,
+        topk_output: TopKOutput,
+        pre_quant_input: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
     ):
         assert self.quant_method is not None
         from sglang.srt.layers.moe.moe_runner.flashinfer_trtllm import (
@@ -1521,6 +1524,10 @@ class FusedMoE(torch.nn.Module):
         dispatch_output = self.dispatcher.dispatch(
             hidden_states=hidden_states, topk_output=topk_output
         )
+        if pre_quant_input is not None:
+            dispatch_output = dispatch_output._replace(
+                hidden_states_pre_quant=pre_quant_input
+            )
 
         with flashinfer_trtllm_deferred_finalize_context():
             combine_input = self.run_moe_core(dispatch_output=dispatch_output)

--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
@@ -937,7 +937,7 @@ def quantize_hidden_states_fp4(
 
 
 def fused_experts_none_to_flashinfer_trtllm_fp4(
-    dispatch_output: StandardDispatchOutput,
+    dispatch_output: StandardDispatchOutput | FlashinferDispatchOutput,
     quant_info: FlashInferTrtllmFp4MoeQuantInfo,
     runner_config: MoeRunnerConfig,
     use_routed_topk: bool = False,
@@ -952,7 +952,10 @@ def fused_experts_none_to_flashinfer_trtllm_fp4(
         trtllm_fp4_block_scale_routed_moe,
     )
 
-    from sglang.srt.layers.moe.token_dispatcher.standard import StandardCombineInput
+    from sglang.srt.layers.moe.token_dispatcher.standard import (
+        StandardCombineInput,
+        StandardDispatchOutput,
+    )
     from sglang.srt.layers.moe.topk import TopKOutputChecker
     from sglang.srt.layers.moe.utils import RoutingMethodType
 
@@ -964,6 +967,11 @@ def fused_experts_none_to_flashinfer_trtllm_fp4(
 
     hidden_states = dispatch_output.hidden_states
     topk_output = dispatch_output.topk_output
+    pre_quant_input = (
+        dispatch_output.hidden_states_pre_quant
+        if isinstance(dispatch_output, StandardDispatchOutput)
+        else None
+    )
 
     # Quantize hidden states to FP4
     hidden_states_scale = dispatch_output.hidden_states_scale
@@ -1002,6 +1010,8 @@ def fused_experts_none_to_flashinfer_trtllm_fp4(
         hs_scale_linear = hs_sf_bytes.view(torch.float8_e4m3fn).reshape(
             seq_len, hidden_size // 16
         )
+    elif pre_quant_input is not None:
+        hs_fp4, hs_scale_linear = pre_quant_input
     else:
         hs_fp4, hs_scale_linear = quantize_hidden_states_fp4(
             hidden_states, quant_info.w13_input_scale_quant
@@ -1026,9 +1036,7 @@ def fused_experts_none_to_flashinfer_trtllm_fp4(
     symm_output = None
     if not defer_finalize:
         num_tokens = hs_fp4.shape[0]
-        hidden_size = (
-            hs_fp4.shape[-1] * 2 if hs_fp4.dtype == torch.uint8 else hs_fp4.shape[-1]
-        )
+        hidden_size = hs_fp4.shape[-1] * 2
         # When the dispatcher delivered pre-quantized FP4 (hidden_states is uint8),
         # the MoE output is bf16 rather than the input dtype.
         output_dtype = (

--- a/python/sglang/srt/layers/moe/token_dispatcher/standard.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/standard.py
@@ -68,10 +68,11 @@ class StandardDispatchOutput(NamedTuple):
     hidden_states: torch.Tensor
     hidden_states_scale: Optional[torch.Tensor]
     topk_output: TopKOutput
-    # SGLANG_OPT_MOE_QUANT_ONCE: optional pre-quantized (q, scale) pair for
-    # ``hidden_states`` (per-token-group-128 fp8, q rows possibly padded to a
-    # multiple of 4). Consumed by the standard->triton fused runner so it can
-    # skip its own activation quant; ``hidden_states`` itself stays bf16.
+    # Optional pre-quantized (q, scale) pair for ``hidden_states``. This carries
+    # either per-token-group FP8 from SGLANG_OPT_MOE_QUANT_ONCE (whose rows may
+    # be padded) or packed NVFP4 with linear scales from a fused collective.
+    # The selected fused runner consumes it to skip activation quantization;
+    # ``hidden_states`` itself remains in its original dtype.
     hidden_states_pre_quant: Optional[Tuple[torch.Tensor, torch.Tensor]] = None
 
     @property

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -214,6 +214,8 @@ class UnquantizedEmbeddingMethod(QuantizeMethodBase):
 class UnquantizedLinearMethod(LinearMethodBase):
     """Linear method without quantization."""
 
+    _prepare_flashinfer_bf16_swiglu_weight = False
+
     def create_weights(
         self,
         layer: torch.nn.Module,
@@ -239,6 +241,15 @@ class UnquantizedLinearMethod(LinearMethodBase):
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         if _is_cpu and _is_cpu_amx_available:
             _amx_process_weight_after_loading(layer, ["weight"])
+
+        if self._prepare_flashinfer_bf16_swiglu_weight:
+            from flashinfer import prepare_bf16_swiglu_weight
+
+            layer.register_buffer(
+                "flashinfer_bf16_swiglu_weight",
+                prepare_bf16_swiglu_weight(layer.weight, input_order="gate_up"),
+                persistent=False,
+            )
 
     def apply(
         self,

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -256,8 +256,10 @@ _enable_pcg_dsv2_dual_stream = (
     _is_cuda and envs.SGLANG_ENABLE_PCG_DSV2_DUAL_STREAM.get()
 )
 
-# TODO(mattteochen) Cover more shapes
-_FLASHINFER_FUSED_SHARED_EXPERT_MAX_M = {4: 16, 8: 32}
+# FlashInfer currently supports the fused BF16 GEMM1+SwiGLU kernel for M <= 64.
+# Keep this keyed by TP size so the mapping also acts as the supported-layout
+# allowlist.
+_FLASHINFER_FUSED_SHARED_EXPERT_MAX_M = {4: 64, 8: 64}
 
 
 def _use_flashinfer_fused_shared_expert(

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -96,6 +96,7 @@ from sglang.srt.layers.linear import (
 )
 from sglang.srt.layers.logits_processor import LogitsProcessor
 from sglang.srt.layers.moe import (
+    MoeRunnerBackend,
     get_moe_a2a_backend,
     get_moe_runner_backend,
     should_skip_post_experts_all_reduce,
@@ -254,6 +255,18 @@ _moe_quant_once_logged = False
 _enable_pcg_dsv2_dual_stream = (
     _is_cuda and envs.SGLANG_ENABLE_PCG_DSV2_DUAL_STREAM.get()
 )
+
+# TODO(mattteochen) Cover more shapes
+_FLASHINFER_FUSED_SHARED_EXPERT_MAX_M = {4: 16, 8: 32}
+
+
+def _use_flashinfer_fused_shared_expert(
+    forward_batch: ForwardBatch, num_tokens: int, tp_size: int
+) -> bool:
+    return (
+        forward_batch.forward_mode.is_decode()
+        or forward_batch.forward_mode.is_target_verify()
+    ) and 0 < num_tokens <= _FLASHINFER_FUSED_SHARED_EXPERT_MAX_M.get(tp_size, 0)
 
 
 class DeepseekV2MLP(nn.Module):
@@ -564,8 +577,9 @@ class DeepseekV2MoE(nn.Module):
         mla_enable_prefill_cp: bool = False,
     ):
         super().__init__()
-        self.tp_size = get_parallel().tp_size
-        self.moe_ep_size = get_parallel().moe_ep_size
+        parallel = get_parallel()
+        self.tp_size = parallel.tp_size
+        self.moe_ep_size = parallel.moe_ep_size
         self.routed_scaling_factor = config.routed_scaling_factor
         self.n_shared_experts = config.n_shared_experts
 
@@ -711,6 +725,8 @@ class DeepseekV2MoE(nn.Module):
         self.shared_experts_is_fp8 = False
         self.shared_experts_weight_block_size = None
         self._shared_expert_tp1 = False
+        self._enable_flashinfer_fused_shared_expert = False
+        self._fuse_shared_experts_inside_sbo = SboFlags.fuse_shared_experts_inside_sbo()
         # Shared experts: skip when fused into MoE kernel
         # (self.num_fused_shared_experts > 0) or when DeepEP/MegaMOE fusion is enabled.
         if (
@@ -750,8 +766,36 @@ class DeepseekV2MoE(nn.Module):
             # [Up, Gate]-interleaved weight + scale.
             from sglang.srt.layers.quantization.modelopt_quant import (
                 ModelOptFp4LinearMethod,
+                ModelOptNvFp4FusedMoEMethod,
+            )
+            from sglang.srt.layers.quantization.unquant import (
+                UnquantizedLinearMethod,
             )
             from sglang.srt.utils.common import is_sm100_supported
+
+            gate_up_proj = self.shared_experts.gate_up_proj
+            tp_size = gate_up_proj.tp_size
+            local_n = gate_up_proj.output_size_per_partition // 2
+            k = gate_up_proj.weight.shape[1]
+            if (
+                envs.SGLANG_ENABLE_FLASHINFER_BF16_SWIGLU.get()
+                and get_moe_runner_backend() == MoeRunnerBackend.FLASHINFER_TRTLLM
+                and get_moe_a2a_backend().is_none()
+                and parallel.moe_tp_size == self.tp_size
+                and tp_size in _FLASHINFER_FUSED_SHARED_EXPERT_MAX_M
+                and (local_n, k) == (2048 // tp_size, 6144)
+                and not envs.FLASHINFER_NVFP4_4OVER6.get()
+                and _device_sm in (100, 103)
+                and self.shared_experts.swiglu_limit is None
+                and isinstance(gate_up_proj.quant_method, UnquantizedLinearMethod)
+                and gate_up_proj.weight.dtype == torch.bfloat16
+                and isinstance(self.experts.quant_method, ModelOptNvFp4FusedMoEMethod)
+                and not self.experts.quant_method.quant_config.use_per_token_activation
+                and not self._fuse_shared_experts_inside_sbo
+            ):
+                # Prepare the derived layout after canonical weights are loaded.
+                gate_up_proj.quant_method._prepare_flashinfer_bf16_swiglu_weight = True
+                self._enable_flashinfer_fused_shared_expert = True
 
             fc1_n = self.shared_experts.gate_up_proj.output_size_per_partition
             if (
@@ -834,7 +878,6 @@ class DeepseekV2MoE(nn.Module):
             or get_moe_a2a_backend().is_ascend_fuseep()
             or get_moe_a2a_backend().is_flashinfer()
         )
-        self._fuse_shared_experts_inside_sbo = SboFlags.fuse_shared_experts_inside_sbo()
         # SGLANG_OPT_MOE_QUANT_ONCE eligibility, resolved lazily on first
         # forward (weights and runner are final by then). None = undecided.
         self._moe_quant_once: Optional[bool] = None
@@ -871,6 +914,21 @@ class DeepseekV2MoE(nn.Module):
             and not get_exec().moe.enable_eplb
         )
 
+    def get_fused_ar_fp4_quant_scale(
+        self,
+        hidden_states: torch.Tensor,
+        forward_batch: ForwardBatch,
+    ) -> Optional[torch.Tensor]:
+        if (
+            self._enable_flashinfer_fused_shared_expert
+            and _use_flashinfer_fused_shared_expert(
+                forward_batch, hidden_states.shape[0], self.tp_size
+            )
+            # (mattteochen): tc cuda graphs needs the fp4 fused AR+norm+quant custom op to be correctly registered
+            and not is_in_tc_piecewise_cuda_graph()
+        ):
+            return self.experts.w13_input_scale_quant
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -879,6 +937,7 @@ class DeepseekV2MoE(nn.Module):
         input_ids: Optional[torch.Tensor] = None,
         input_ids_global: Optional[torch.Tensor] = None,
         skip_shared_experts: bool = False,
+        pre_quant_input: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
     ) -> torch.Tensor:
         from sglang.srt.layers.moe.mega_moe import forward_mega_moe, should_use_mega_moe
 
@@ -891,7 +950,7 @@ class DeepseekV2MoE(nn.Module):
             )
 
         if not self._enable_a2a_moe:
-            if self._can_dual_stream_graph(hidden_states):
+            if pre_quant_input is None and self._can_dual_stream_graph(hidden_states):
                 fwd = get_forward()
                 return dsv2_flashinfer_moe_dual_stream_graph(
                     hidden_states,
@@ -910,6 +969,7 @@ class DeepseekV2MoE(nn.Module):
                     gemm_output_zero_allocator,
                     input_ids,
                     input_ids_global=input_ids_global,
+                    pre_quant_input=pre_quant_input,
                 )
             else:
                 return self.forward_normal(
@@ -918,6 +978,7 @@ class DeepseekV2MoE(nn.Module):
                     input_ids,
                     input_ids_global=input_ids_global,
                     skip_shared_experts=skip_shared_experts,
+                    pre_quant_input=pre_quant_input,
                 )
         else:
             return self.forward_deepep(
@@ -930,6 +991,7 @@ class DeepseekV2MoE(nn.Module):
         gemm_output_zero_allocator: BumpAllocator = None,
         input_ids: Optional[torch.Tensor] = None,
         input_ids_global: Optional[torch.Tensor] = None,
+        pre_quant_input: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
     ) -> torch.Tensor:
         # Note(kpham-sgl): issue order satisfies 3 constraints:
         # - no stream explosion: main (routed) issued before alt block -> capture reuses 1 alt stream;
@@ -940,11 +1002,8 @@ class DeepseekV2MoE(nn.Module):
         current_stream = torch.cuda.current_stream()
         # Quantize-once (SGLANG_OPT_MOE_QUANT_ONCE) must happen on the main
         # stream BEFORE the alt-stream fork so both consumers see it.
-        pre_quant_input = (
-            None
-            if use_flashinfer_trtllm_bypass
-            else self._maybe_quant_moe_input_once(hidden_states)
-        )
+        if pre_quant_input is None and not use_flashinfer_trtllm_bypass:
+            pre_quant_input = self._maybe_quant_moe_input_once(hidden_states)
         self.alt_stream.wait_stream(current_stream)
         has_shared_output = (
             hidden_states.shape[0] > 0 and self.num_fused_shared_experts == 0
@@ -980,18 +1039,13 @@ class DeepseekV2MoE(nn.Module):
             and topk_output.format == TopKOutputFormat.BYPASSED
             and self.experts.supports_deferred_finalize
         )
+        experts_forward = self.experts
         if deferred_finalize:
-            final_hidden_states = self.experts.forward_deferred_finalize(
-                hidden_states, topk_output
-            )
+            experts_forward = self.experts.forward_deferred_finalize
         elif use_flashinfer_trtllm_bypass:
-            final_hidden_states = self.experts.forward_impl(hidden_states, topk_output)
-        elif pre_quant_input is not None:
-            final_hidden_states = self.experts(
-                hidden_states, topk_output, pre_quant_input=pre_quant_input
-            )
-        else:
-            final_hidden_states = self.experts(hidden_states, topk_output)
+            experts_forward = self.experts.forward_impl
+        kwargs = {"pre_quant_input": pre_quant_input} if pre_quant_input else {}
+        final_hidden_states = experts_forward(hidden_states, topk_output, **kwargs)
         if (
             not _is_cuda
             and not _is_musa
@@ -1044,6 +1098,7 @@ class DeepseekV2MoE(nn.Module):
         input_ids: Optional[torch.Tensor] = None,
         input_ids_global: Optional[torch.Tensor] = None,
         skip_shared_experts: bool = False,
+        pre_quant_input: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
     ) -> torch.Tensor:
         if hasattr(self, "shared_experts") and use_intel_amx_backend(
             self.shared_experts.gate_up_proj
@@ -1062,11 +1117,8 @@ class DeepseekV2MoE(nn.Module):
         if hidden_states.shape[0] > 0:
             # Quantize-once (SGLANG_OPT_MOE_QUANT_ONCE): only worthwhile when
             # the shared expert also runs here on the same tensor.
-            pre_quant_input = (
-                None
-                if skip_shared_experts
-                else self._maybe_quant_moe_input_once(hidden_states)
-            )
+            if pre_quant_input is None and not skip_shared_experts:
+                pre_quant_input = self._maybe_quant_moe_input_once(hidden_states)
             if (
                 not defer_shared
                 and not self._fuse_shared_experts_inside_sbo
@@ -1127,17 +1179,8 @@ class DeepseekV2MoE(nn.Module):
                 self.experts.dispatcher.register_post_combine_hook(_post_combine_hook)
             )
 
-        if pre_quant_input is not None:
-            final_hidden_states = self.experts(
-                hidden_states,
-                topk_output,
-                pre_quant_input=pre_quant_input,
-            )
-        else:
-            final_hidden_states = self.experts(
-                hidden_states,
-                topk_output,
-            )
+        kwargs = {"pre_quant_input": pre_quant_input} if pre_quant_input else {}
+        final_hidden_states = self.experts(hidden_states, topk_output, **kwargs)
         if (
             not _is_cuda
             and not _is_musa
@@ -1477,6 +1520,15 @@ class DeepseekV2MoE(nn.Module):
         pre_quant_input: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
     ):
         if (hidden_states.shape[0] > 0) and (self.num_fused_shared_experts == 0):
+            if pre_quant_input is not None and pre_quant_input[0].dtype == torch.uint8:
+                from flashinfer import mm_bf16_swiglu
+
+                out = mm_bf16_swiglu(
+                    hidden_states,
+                    self.shared_experts.gate_up_proj.flashinfer_bf16_swiglu_weight,
+                    pdl=True,
+                )
+                return self.shared_experts.down_proj(out)[0]
             if pre_quant_input is not None:
                 # SGLANG_OPT_MOE_QUANT_ONCE: (q, s) rows may be padded to a
                 # multiple of 4; the padded rows flow through the MLP (all ops
@@ -2479,9 +2531,20 @@ class DeepseekV2DecoderLayer(nn.Module):
             forward_batch, next_full_attention_layer_id
         )
 
-        hidden_states, residual = self.layer_communicator.prepare_mlp(
-            hidden_states, residual, forward_batch
+        is_moe = isinstance(self.mlp, DeepseekV2MoE)
+        fp4_global_scale = (
+            self.mlp.get_fused_ar_fp4_quant_scale(hidden_states, forward_batch)
+            if is_moe
+            else None
         )
+        prepared = self.layer_communicator.prepare_mlp(
+            hidden_states,
+            residual,
+            forward_batch,
+            fp4_global_scale=fp4_global_scale,
+        )
+        hidden_states, residual = prepared[:2]
+        pre_quant_input = prepared[2] if fp4_global_scale is not None else None
 
         fuse_mlp_allreduce = (
             self.layer_communicator.should_fuse_mlp_allreduce_with_next_layer(
@@ -2498,7 +2561,7 @@ class DeepseekV2DecoderLayer(nn.Module):
             gemm_output_zero_allocator = None
 
         if (
-            isinstance(self.mlp, DeepseekV2MoE)
+            is_moe
             and not self.mlp.experts.moe_runner_config.inplace
             and not torch.compiler.is_compiling()
         ):
@@ -2513,10 +2576,12 @@ class DeepseekV2DecoderLayer(nn.Module):
             mlp_reduce_scatter=mlp_reduce_scatter,
         ):
             with _mlp_ctx:
+                kwargs = {"pre_quant_input": pre_quant_input} if pre_quant_input else {}
                 hidden_states = self.mlp(
                     hidden_states,
                     forward_batch,
                     gemm_output_zero_allocator,
+                    **kwargs,
                 )
 
         if (

--- a/test/registered/unit/layers/moe/test_flashinfer_trtllm_fp4_prequant.py
+++ b/test/registered/unit/layers/moe/test_flashinfer_trtllm_fp4_prequant.py
@@ -1,0 +1,123 @@
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
+from sglang.srt.layers.moe.moe_runner import flashinfer_trtllm as runner
+from sglang.srt.layers.moe.token_dispatcher.standard import StandardDispatchOutput
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestFlashInferTrtllmFp4PreQuant(CustomTestCase):
+    def test_fused_ar_pair_reaches_runner_without_requantizing(self):
+        num_tokens, hidden_size = 3, 32
+        hidden_states = torch.randn(num_tokens, hidden_size, dtype=torch.bfloat16)
+        packed_fp4 = torch.empty(num_tokens, hidden_size // 2, dtype=torch.uint8)
+        linear_scales = torch.empty(
+            num_tokens, hidden_size // 16, dtype=torch.float8_e4m3fn
+        )
+        fused_pair = (packed_fp4, linear_scales)
+        topk_output = types.SimpleNamespace(
+            router_logits=torch.randn(num_tokens, 8),
+            topk_config=types.SimpleNamespace(
+                correction_bias=None,
+                top_k=2,
+                num_expert_group=1,
+                topk_group=1,
+            ),
+        )
+        quant_info = MagicMock(use_per_token_activation=False, routing_method_type=0)
+        runner_config = MagicMock(
+            activation="silu", is_gated=True, routed_scaling_factor=1.0
+        )
+
+        routed_output = torch.empty_like(hidden_states)
+        expert_weights = torch.empty(num_tokens, 2, dtype=torch.float32)
+        expanded_idx_to_permuted_idx = torch.empty(num_tokens, 2, dtype=torch.int32)
+        moe_kernel = MagicMock(
+            return_value=(
+                routed_output,
+                expert_weights,
+                expanded_idx_to_permuted_idx,
+            )
+        )
+        standalone_quant = MagicMock(
+            side_effect=AssertionError("standalone FP4 quantization was called")
+        )
+        import flashinfer.fused_moe as flashinfer_fused_moe
+
+        from sglang.srt.layers.moe import topk as topk_module
+
+        def run_moe_core(*, dispatch_output):
+            self.assertIs(dispatch_output.hidden_states_pre_quant, fused_pair)
+            return runner.fused_experts_none_to_flashinfer_trtllm_fp4(
+                dispatch_output,
+                quant_info,
+                runner_config,
+            )
+
+        dispatcher = MagicMock()
+        dispatcher.dispatch.return_value = StandardDispatchOutput(
+            hidden_states=hidden_states,
+            hidden_states_scale=None,
+            topk_output=topk_output,
+        )
+        dispatcher.combine.return_value = routed_output
+        moe = types.SimpleNamespace(
+            quant_method=object(),
+            dispatcher=dispatcher,
+            run_moe_core=MagicMock(side_effect=run_moe_core),
+        )
+
+        with (
+            patch.object(
+                flashinfer_fused_moe,
+                "trtllm_fp4_block_scale_moe",
+                moe_kernel,
+            ),
+            patch.object(runner, "quantize_hidden_states_fp4", standalone_quant),
+            patch.object(runner, "get_activation_type", return_value=7),
+            patch.object(runner, "trtllm_moe_enable_pdl", return_value=False),
+            patch.object(
+                topk_module.TopKOutputChecker,
+                "format_is_standard",
+                return_value=False,
+            ),
+            patch.object(
+                topk_module.TopKOutputChecker,
+                "format_is_bypassed",
+                return_value=True,
+            ),
+        ):
+            result = FusedMoE.forward_deferred_finalize(
+                moe,
+                hidden_states,
+                topk_output,
+                pre_quant_input=fused_pair,
+            )
+
+        self.assertIs(result, routed_output)
+        standalone_quant.assert_not_called()
+        combine_input = dispatcher.combine.call_args.kwargs["combine_input"]
+        deferred_output = combine_input.hidden_states
+        self.assertIs(deferred_output.gemm2_out, routed_output)
+        self.assertIs(deferred_output.expert_weights, expert_weights)
+        self.assertIs(
+            deferred_output.expanded_idx_to_permuted_idx,
+            expanded_idx_to_permuted_idx,
+        )
+        kernel_kwargs = moe_kernel.call_args.kwargs
+        self.assertIs(kernel_kwargs["hidden_states"], packed_fp4)
+        self.assertEqual(
+            kernel_kwargs["hidden_states_scale"].data_ptr(), linear_scales.data_ptr()
+        )
+        self.assertFalse(kernel_kwargs["do_finalize"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/test_flashinfer_comm_fusion.py
+++ b/test/registered/unit/layers/test_flashinfer_comm_fusion.py
@@ -29,9 +29,14 @@ class _FakeFlashInferComm:
     class AllReduceFusionPattern:
         kAllReduce = object()
         kARResidualRMSNorm = object()
+        kARResidualRMSNormOutFP4Quant = object()
+
+    class QuantizationSFLayout:
+        LINEAR = object()
 
     def __init__(self):
         self.calls = []
+        self.fusion_calls = []
 
     def create_allreduce_fusion_workspace(self, **kwargs):
         self.calls.append(kwargs)
@@ -51,8 +56,20 @@ class _FakeFlashInferComm:
         residual_in=None,
         rms_gamma=None,
         rms_eps=None,
-        **_kwargs,
+        quant_out=None,
+        scale_out=None,
+        **kwargs,
     ):
+        self.fusion_calls.append(
+            {
+                "input": input,
+                "workspace": workspace,
+                "pattern": pattern,
+                "quant_out": quant_out,
+                "scale_out": scale_out,
+                **kwargs,
+            }
+        )
         if pattern is self.AllReduceFusionPattern.kAllReduce:
             allreduced = input * workspace.world_size
             if output is None:
@@ -60,7 +77,10 @@ class _FakeFlashInferComm:
             output.copy_(allreduced)
             return output
 
-        if pattern is not self.AllReduceFusionPattern.kARResidualRMSNorm:
+        if pattern not in (
+            self.AllReduceFusionPattern.kARResidualRMSNorm,
+            self.AllReduceFusionPattern.kARResidualRMSNormOutFP4Quant,
+        ):
             raise ValueError(f"Unexpected pattern: {pattern}")
 
         allreduced = input * workspace.world_size
@@ -73,6 +93,9 @@ class _FakeFlashInferComm:
         ).to(input.dtype)
         residual_out.copy_(expected_residual)
         norm_out.copy_(expected_norm)
+        if pattern is self.AllReduceFusionPattern.kARResidualRMSNormOutFP4Quant:
+            quant_out.zero_()
+            scale_out.fill_(1)
 
 
 def _torch_allreduce_residual_rmsnorm_baseline(
@@ -256,6 +279,65 @@ class TestFlashInferCommFusion(CustomTestCase):
             else:
                 buffers[manager_key] = original_manager
             fusion._flashinfer_allreduce_unavailable = original_unavailable
+
+    def test_fp4_quant_wrapper_uses_linear_output_contract(self):
+        if not torch.cuda.is_available():
+            self.skipTest("FlashInfer allreduce custom op is CUDA-only")
+
+        from sglang.srt.runtime_context import get_resources
+
+        fake_comm = _FakeFlashInferComm()
+        manager_key = "flashinfer_fusion_attn_tp_workspace"
+        buffers = get_resources().buffers
+        original_manager = buffers.get(manager_key)
+        manager = fusion.FlashInferWorkspaceManager()
+        manager.workspace = _FakeWorkspace("mnnvl", world_size=4)
+        manager.initialized = True
+        buffers[manager_key] = manager
+
+        input_tensor = torch.randn(3, 32, dtype=torch.bfloat16, device="cuda")
+        residual = torch.randn_like(input_tensor)
+        weight = torch.randn(32, dtype=torch.bfloat16, device="cuda")
+        global_scale = torch.ones(1, dtype=torch.float32, device="cuda")
+        eps = 1e-5
+
+        try:
+            with patch.object(fusion, "_flashinfer_comm", fake_comm):
+                norm_out, residual_out, quant_out, scale_out = (
+                    fusion.flashinfer_allreduce_residual_rmsnorm_fp4_quant(
+                        input_tensor,
+                        residual,
+                        weight,
+                        global_scale,
+                        eps,
+                    )
+                )
+        finally:
+            if original_manager is None:
+                buffers.pop(manager_key, None)
+            else:
+                buffers[manager_key] = original_manager
+
+        expected_norm, expected_residual = _torch_allreduce_residual_rmsnorm_baseline(
+            input_tensor, residual, weight, world_size=4, eps=eps
+        )
+        torch.testing.assert_close(norm_out, expected_norm)
+        torch.testing.assert_close(residual_out, expected_residual)
+        self.assertEqual(quant_out.dtype, torch.uint8)
+        self.assertEqual(quant_out.shape, (3, 16))
+        self.assertEqual(scale_out.dtype, torch.float8_e4m3fn)
+        self.assertEqual(scale_out.shape, (3, 2))
+
+        call = fake_comm.fusion_calls[-1]
+        self.assertIs(
+            call["pattern"],
+            fake_comm.AllReduceFusionPattern.kARResidualRMSNormOutFP4Quant,
+        )
+        self.assertIs(call["quant_out"], quant_out)
+        self.assertIs(call["scale_out"], scale_out)
+        self.assertIs(call["scale_factor"], global_scale)
+        self.assertIs(call["layout_code"], fake_comm.QuantizationSFLayout.LINEAR)
+        self.assertTrue(call["launch_with_pdl"])
 
 
 _GROUP_KEY = ("device_group", "cpu_group")

--- a/test/registered/unit/layers/test_layer_communicator_fusion_gate.py
+++ b/test/registered/unit/layers/test_layer_communicator_fusion_gate.py
@@ -1,6 +1,7 @@
 import types
 import unittest
-from unittest.mock import patch
+from functools import partial
+from unittest.mock import patch, sentinel
 
 from sglang.srt.layers import communicator as comm
 from sglang.srt.layers.communicator import LayerCommunicator, ScatterMode
@@ -59,6 +60,59 @@ class TestFuseMlpAllReduceGate(CustomTestCase):
 
     def test_pure_ep_still_fuses(self):
         self.assertTrue(self._should_fuse(moe_ep_size=4, moe_tp_size=1))
+
+
+class TestPrepareMlpFp4(CustomTestCase):
+    def test_returns_fp4_pair_from_fused_gather(self):
+        hidden_states = types.SimpleNamespace(shape=(2, 32))
+        communicator = types.SimpleNamespace(
+            _communicate_with_all_reduce_and_layer_norm_fn=partial(
+                comm.CommunicateWithAllReduceAndLayerNormFn._gather_hidden_states_and_residual,
+                residual_input_mode=ScatterMode.TP_ATTN_FULL,
+            ),
+            layer_scatter_modes=types.SimpleNamespace(
+                layer_input_mode=ScatterMode.TP_ATTN_FULL
+            ),
+            post_attention_layernorm=types.SimpleNamespace(
+                weight=sentinel.weight, variance_epsilon=1e-5
+            ),
+        )
+        fused_outputs = (
+            sentinel.norm,
+            sentinel.residual_out,
+            sentinel.quant,
+            sentinel.scale_factor,
+        )
+
+        with (
+            patch.object(comm, "apply_flashinfer_allreduce_fusion", return_value=True),
+            patch.object(
+                comm,
+                "get_attn_tp_context",
+                return_value=types.SimpleNamespace(input_scattered=False),
+            ),
+            patch(
+                "sglang.srt.layers.flashinfer_comm_fusion."
+                "flashinfer_allreduce_residual_rmsnorm_fp4_quant",
+                return_value=fused_outputs,
+            ) as fused_op,
+        ):
+            result = LayerCommunicator.prepare_mlp(
+                communicator,
+                hidden_states,
+                sentinel.residual,
+                sentinel.forward_batch,
+                fp4_global_scale=sentinel.global_scale,
+            )
+
+        self.assertEqual(result, (*fused_outputs[:2], fused_outputs[2:]))
+        fused_op.assert_called_once_with(
+            hidden_states,
+            sentinel.residual,
+            sentinel.weight,
+            sentinel.global_scale,
+            1e-5,
+        )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/models/test_deepseek_v2_flashinfer_bf16_swiglu.py
+++ b/test/registered/unit/models/test_deepseek_v2_flashinfer_bf16_swiglu.py
@@ -1,0 +1,132 @@
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.srt.layers.quantization import unquant
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.srt.models import deepseek_v2
+from sglang.srt.models.deepseek_v2 import DeepseekV2MoE
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestFlashInferFusedSharedExpert(CustomTestCase):
+    def test_policy(self):
+        cases = (
+            (ForwardMode.DECODE, 0, 4, False),
+            (ForwardMode.DECODE, 1, 4, True),
+            (ForwardMode.DECODE, 64, 4, True),
+            (ForwardMode.TARGET_VERIFY, 64, 4, True),
+            (ForwardMode.DECODE, 65, 4, False),
+            (ForwardMode.DECODE, 64, 8, True),
+            (ForwardMode.DECODE, 65, 8, False),
+            (ForwardMode.EXTEND, 1, 4, False),
+            (ForwardMode.IDLE, 1, 4, False),
+            (ForwardMode.DECODE, 1, 2, False),
+        )
+        for mode, num_tokens, tp_size, expected in cases:
+            with self.subTest(mode=mode, num_tokens=num_tokens, tp_size=tp_size):
+                batch = SimpleNamespace(forward_mode=mode)
+                self.assertEqual(
+                    deepseek_v2._use_flashinfer_fused_shared_expert(
+                        batch, num_tokens, tp_size
+                    ),
+                    expected,
+                )
+
+    def test_fp4_handoff_selects_fused_shared_gemm1_activation(self):
+        hidden_states = torch.empty(3, 6144, dtype=torch.bfloat16)
+        activated, output = object(), object()
+        mm_bf16_swiglu = MagicMock(return_value=activated)
+        shared = MagicMock()
+        shared.gate_up_proj.flashinfer_bf16_swiglu_weight = object()
+        shared.down_proj.return_value = (output, None)
+        moe = SimpleNamespace(num_fused_shared_experts=0, shared_experts=shared)
+
+        with patch.dict(
+            sys.modules,
+            {"flashinfer": SimpleNamespace(mm_bf16_swiglu=mm_bf16_swiglu)},
+        ):
+            result = DeepseekV2MoE._forward_shared_experts(
+                moe,
+                hidden_states,
+                pre_quant_input=(torch.empty(3, 3072, dtype=torch.uint8), object()),
+            )
+
+        self.assertIs(result, output)
+        shared.assert_not_called()
+        mm_bf16_swiglu.assert_called_once_with(
+            hidden_states,
+            shared.gate_up_proj.flashinfer_bf16_swiglu_weight,
+            pdl=True,
+        )
+        shared.down_proj.assert_called_once_with(activated)
+
+    def test_fused_ar_scale_uses_the_routed_expert_static_scale(self):
+        scale = object()
+        moe = SimpleNamespace(
+            _enable_flashinfer_fused_shared_expert=True,
+            tp_size=4,
+            experts=SimpleNamespace(w13_input_scale_quant=scale),
+        )
+        batch = SimpleNamespace(forward_mode=ForwardMode.DECODE)
+
+        with patch.object(
+            deepseek_v2, "is_in_tc_piecewise_cuda_graph", return_value=False
+        ):
+            result = DeepseekV2MoE.get_fused_ar_fp4_quant_scale(
+                moe, torch.empty(64, 1), batch
+            )
+            fallback = DeepseekV2MoE.get_fused_ar_fp4_quant_scale(
+                moe, torch.empty(65, 1), batch
+            )
+        with patch.object(
+            deepseek_v2, "is_in_tc_piecewise_cuda_graph", return_value=True
+        ):
+            tc_graph_fallback = DeepseekV2MoE.get_fused_ar_fp4_quant_scale(
+                moe, torch.empty(64, 1), batch
+            )
+
+        self.assertIs(result, scale)
+        self.assertIsNone(fallback)
+        self.assertIsNone(tc_graph_fallback)
+
+    def test_prepares_fused_weight_after_checkpoint_loading(self):
+        layer = torch.nn.Module()
+        layer.register_parameter(
+            "weight",
+            torch.nn.Parameter(
+                torch.randn(128, 128, dtype=torch.bfloat16), requires_grad=False
+            ),
+        )
+        prepared = torch.empty(128, 128, dtype=torch.bfloat16)
+        original_weight = layer.weight
+        prepare_weight = MagicMock(return_value=prepared)
+        method = unquant.UnquantizedLinearMethod()
+        method._prepare_flashinfer_bf16_swiglu_weight = True
+
+        with (
+            patch.object(unquant, "_is_cpu", False),
+            patch(
+                "flashinfer.prepare_bf16_swiglu_weight",
+                prepare_weight,
+                create=True,
+            ),
+        ):
+            method.process_weights_after_loading(layer)
+
+        self.assertIs(layer.flashinfer_bf16_swiglu_weight, prepared)
+        self.assertIs(layer.weight, original_weight)
+        self.assertIn(
+            "flashinfer_bf16_swiglu_weight", layer._non_persistent_buffers_set
+        )
+        prepare_weight.assert_called_once_with(layer.weight, input_order="gate_up")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

This PR depends on [FlashInfer PR #4640](https://github.com/flashinfer-ai/flashinfer/pull/4640) for `mm_bf16_swiglu`.

FlashInfer's `void flashinfer::trtllm_mnnvl_allreduce::oneshotAllreduceFusionKernel` can fuse nvfp4 quantization within the AR+Norm kernel, saving a kernel launch before every MoE call.

Although this seemed a flat flashinfer API usage, this exposed the issue highlighted [here](https://github.com/flashinfer-ai/flashinfer/pull/4640#issuecomment-5370216869); thus we need a workaround to make the integration e2e valuable perf wise.

## Modifications

- Feed fused all-reduce + residual + RMSNorm FP4 outputs directly into the FlashInfer TRT-LLM MoE runner.
- Use FlashInfer BF16 GEMM1 + SwiGLU for eligible shared experts during decode/target verification, with an M ≤ 64 gate and existing fallbacks.
- Prepare the fused shared-expert weight layout after loading and add focused integration/eligibility tests.

## Performance

GLM-5.2-NVFP4, TP4; random 1,024-token input and 1,024-token output; total requests = 16 × concurrency. Values are median TPOT in ms/token (lower is better). Baseline: `main@0e4a09480c`; feature: `2113186027`. Both runs used the FlashInfer 0.6.17 compatibility overlay through `f0f8760e`.

| Concurrency | `main` | This PR | Improvement |
| ---: | ---: | ---: | ---: |
| 1 | 6.552 | 6.498 | +0.82% |
| 2 | 7.044 | 6.950 | +1.33% |
| 4 | 7.998 | 7.924 | +0.93% |
| 8 | 9.598 | 9.474 | +1.30% |
| 16 | 12.433 | 12.306 | +1.02% |
| 32 | 15.861 | 15.649 | +1.34% |
| 64 | 20.225 | 20.320 | -0.47% |

In this single sweep, the feature improves median TPOT by 0.82–1.34% through concurrency 32 and regresses by 0.47% at concurrency 64.

main:
<img width="1255" height="406" alt="image" src="https://github.com/user-attachments/assets/5943401a-162a-46b2-b1b8-6ec757b49743" />
The down projection gemm on the shared path can't execute immediately after the activation, fortunately it doesn't spill after the down proj gemm on the routed path for bs=1 in most of the cases.

PR:
<img width="1251" height="364" alt="image" src="https://github.com/user-attachments/assets/c53b8eb3-842c-4df3-8109-79827584b042" />
NVFP4 quantization call is gone and down proj gemm on shared path can execute immediately after the first fused gemm.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32497779839](https://github.com/sgl-project/sglang/actions/runs/32497779839)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32497779063](https://github.com/sgl-project/sglang/actions/runs/32497779063)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32497779884](https://github.com/sgl-project/sglang/actions/runs/32497779884)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->