### PR TITLE
fix: shrink --hicache-size budget for SIDECAR draft host pool

### DIFF
--- a/python/sglang/srt/mem_cache/kv_cache_builder.py
+++ b/python/sglang/srt/mem_cache/kv_cache_builder.py
@@ -46,6 +46,7 @@ from sglang.srt.runtime_context import (
     get_parallel,
     get_schedule,
 )
+from sglang.srt.speculative.base_spec_worker import HiCacheDraftMode
 from sglang.srt.utils.tensor_bridge import use_mlx
 
 if TYPE_CHECKING:
@@ -61,6 +62,109 @@ if TYPE_CHECKING:
     from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 
 
+def _device_pool_size_per_token(pool: object) -> float:
+    """Bytes per token for a device KV pool, derived from its geometry.
+
+    The host pool stores the same per-token layout as the device pool, so this
+    gives the host pool's ``size_per_token`` without instantiating it.
+
+    We cannot rely on ``get_kv_size_bytes() / pool.size`` because the device
+    pool may be in post-capture mode (virtual address upper bound only, no
+    physical buffer yet).  Instead, compute from the pool's structural
+    attributes.
+    """
+    # MHA pools: head_dim * head_num * layer_num * dtype_itemsize * 2 (K+V)
+    head_num = getattr(pool, "head_num", None)
+    head_dim = getattr(pool, "head_dim", None)
+    layer_num = getattr(pool, "layer_num", None)
+    dtype = getattr(pool, "store_dtype", None) or getattr(pool, "dtype", None)
+    if (
+        head_num is not None
+        and head_dim is not None
+        and layer_num is not None
+        and dtype is not None
+    ):
+        itemsize = dtype.itemsize if hasattr(dtype, "itemsize") else 2
+        return head_dim * head_num * layer_num * itemsize * 2
+
+    # MLA pools: kv_cache_dim * layer_num * dtype_itemsize
+    kv_cache_dim = getattr(pool, "kv_cache_dim", None)
+    if kv_cache_dim is not None and layer_num is not None and dtype is not None:
+        itemsize = dtype.itemsize if hasattr(dtype, "itemsize") else 2
+        return kv_cache_dim * layer_num * itemsize
+
+    # Fallback: derive from total buffer size (works only if buffers are
+    # allocated, i.e. not in post-capture mode).
+    size_bytes = pool.get_kv_size_bytes()
+    total_bytes = sum(size_bytes) if isinstance(size_bytes, tuple) else size_bytes
+    if pool.size == 0:
+        return 0.0
+    return total_bytes / pool.size
+
+
+def _adjust_hicache_size_for_draft(
+    server_args: ServerArgs,
+    target_device_pool: object,
+    draft_device_pools: tuple[object, ...],
+) -> None:
+    """Reduce ``hicache_size`` so target + draft host pools fit the GB budget.
+
+    The draft host pool must have the same token count as the target (for 1-to-1
+    index sharing in L2 transfers).  When ``--hicache-size`` caps the target
+    pool to *H* GB, the draft pool adds ``H * draft_spt / target_spt`` GB on top.
+    To keep the *total* within *H* GB, shrink the budget by the factor
+    ``target_spt / (target_spt + draft_spt)``.
+
+    Only applies in fixed-size (``hicache_size > 0``) mode; ratio mode already
+    scales both pools proportionally.
+    """
+    if server_args.hicache_size <= 0:
+        return
+    if not draft_device_pools:
+        return
+
+    target_spt = _device_pool_size_per_token(target_device_pool)
+    if target_spt == 0:
+        return
+
+    # In SIDECAR mode only the first draft runner is registered, so we use
+    # just its pool.
+    draft_spt = _device_pool_size_per_token(draft_device_pools[0])
+    if draft_spt == 0:
+        return
+
+    effective = server_args.hicache_size * target_spt / (target_spt + draft_spt)
+    if effective < server_args.hicache_size:
+        logger.info(
+            "Adjusting --hicache-size from %d GB to %.2f GB to account for "
+            "draft host pool memory (target_spt=%.0f, draft_spt=%.0f).",
+            server_args.hicache_size,
+            effective,
+            target_spt,
+            draft_spt,
+        )
+        # Use the resolution-pipeline helper to bypass the strict post-publish
+        # mutation guard on ServerArgs.  This is a one-shot, pre-tree-cache
+        # adjustment: after create_tree_cache() returns, hicache_size is never
+        # read again, so the instance and the memory bag stay in agreement.
+        from sglang.srt.arg_groups.overrides import _apply_fields
+
+        # Reduce both hicache_size AND hicache_ratio.  When the device pool is
+        # in post-capture mode, get_kv_size_bytes returns 0, so
+        # _split_hicache_size gives the KV pool 0 GB and the host pool falls
+        # back to hicache_ratio.  Reducing the ratio too ensures the fallback
+        # also respects the draft budget.
+        ratio_factor = target_spt / (target_spt + draft_spt)
+        effective_ratio = server_args.hicache_ratio * ratio_factor
+        _apply_fields(
+            server_args,
+            {
+                "hicache_size": int(effective),
+                "hicache_ratio": effective_ratio,
+            },
+        )
+
+
 def maybe_register_hicache_draft(
     *,
     tree_cache,
@@ -68,8 +172,6 @@ def maybe_register_hicache_draft(
     server_args: ServerArgs,
     page_size: int,
 ) -> None:
-    from sglang.srt.speculative.base_spec_worker import HiCacheDraftMode
-
     if draft_plan.mode != HiCacheDraftMode.SIDECAR:
         return
 
@@ -333,6 +435,24 @@ def build_kv_cache(
         sliding_window_size=sliding_window_size,
         mtp_draft_device_pools=mtp_draft_device_pools,
     )
+
+    # When --hicache-size is set and a SIDECAR draft will be registered,
+    # shrink the budget so the *total* (target + draft) host memory stays
+    # within the user-specified cap.  The draft host pool must match the
+    # target's token count (1-to-1 index sharing), but its per-token byte
+    # cost can be larger than the target's (e.g. quantized target + bf16
+    # draft), causing the combined allocation to exceed --hicache-size.
+    if (
+        enable_hierarchical_cache
+        and hicache_draft_plan is not None
+        and hicache_draft_plan.mode == HiCacheDraftMode.SIDECAR
+    ):
+        target_device_pool = tp_worker.model_runner.token_to_kv_pool
+        _adjust_hicache_size_for_draft(
+            server_args,
+            target_device_pool,
+            hicache_draft_plan.device_pools,
+        )
 
     tree_cache = create_tree_cache(
         TreeCacheBuildContext(

--- a/test/registered/unit/mem_cache/test_hicache_draft_budget.py
+++ b/test/registered/unit/mem_cache/test_hicache_draft_budget.py
@@ -1,0 +1,201 @@
+"""Unit tests for HiCache draft budget adjustment — no server, no model loading.
+
+When ``--hicache-size`` caps the target host pool and a SIDECAR draft model
+adds a second host pool with the same token count but a larger per-token byte
+cost (e.g. quantized target + bf16 draft), the combined allocation can exceed
+the user-specified budget.  ``_adjust_hicache_size_for_draft`` shrinks the
+budget so the *total* (target + draft) stays within the cap.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+
+from sglang.srt.mem_cache.kv_cache_builder import (
+    _adjust_hicache_size_for_draft,
+    _device_pool_size_per_token,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+# The function under test does a local import of _apply_fields, so we patch it
+# at its source module to prevent real ServerArgs mutation.
+_APPLY_FIELDS_PATH = "sglang.srt.arg_groups.overrides._apply_fields"
+
+
+def _make_mha_pool(head_dim, head_num, layer_num, dtype, size=4096):
+    """Create a minimal MHA-like pool with the attributes used by the sizing logic."""
+    return SimpleNamespace(
+        head_dim=head_dim,
+        head_num=head_num,
+        layer_num=layer_num,
+        store_dtype=dtype,
+        dtype=dtype,
+        size=size,
+    )
+
+
+def _make_mla_pool(kv_cache_dim, layer_num, dtype, size=4096):
+    """Create a minimal MLA-like pool with the attributes used by the sizing logic."""
+    return SimpleNamespace(
+        kv_cache_dim=kv_cache_dim,
+        layer_num=layer_num,
+        store_dtype=dtype,
+        dtype=dtype,
+        size=size,
+    )
+
+
+def _make_server_args(hicache_size=4, hicache_ratio=2.0):
+    return SimpleNamespace(
+        hicache_size=hicache_size,
+        hicache_ratio=hicache_ratio,
+    )
+
+
+class TestDevicePoolSizePerToken(CustomTestCase):
+    """Tests for _device_pool_size_per_token geometry-based computation."""
+
+    def test_mha_pool_bf16(self):
+        pool = _make_mha_pool(
+            head_dim=128, head_num=8, layer_num=28, dtype=torch.bfloat16
+        )
+        # head_dim * head_num * layer_num * itemsize * 2 (K+V)
+        self.assertEqual(_device_pool_size_per_token(pool), 128 * 8 * 28 * 2 * 2)
+
+    def test_mha_pool_fp8(self):
+        pool = _make_mha_pool(
+            head_dim=128, head_num=8, layer_num=28, dtype=torch.float8_e4m3fn
+        )
+        # fp8 itemsize = 1
+        self.assertEqual(_device_pool_size_per_token(pool), 128 * 8 * 28 * 1 * 2)
+
+    def test_mla_pool(self):
+        pool = _make_mla_pool(kv_cache_dim=512, layer_num=28, dtype=torch.bfloat16)
+        # kv_cache_dim * layer_num * itemsize = 512 * 28 * 2
+        self.assertEqual(_device_pool_size_per_token(pool), 512 * 28 * 2)
+
+    def test_zero_size_pool_returns_zero(self):
+        pool = SimpleNamespace(
+            head_dim=None,
+            head_num=None,
+            kv_cache_dim=None,
+            layer_num=None,
+            store_dtype=None,
+            dtype=None,
+            size=0,
+            get_kv_size_bytes=lambda: 0,
+        )
+        self.assertEqual(_device_pool_size_per_token(pool), 0.0)
+
+
+class TestAdjustHicacheSizeForDraft(CustomTestCase):
+    """Tests for _adjust_hicache_size_for_draft budget shrinking."""
+
+    def test_no_adjustment_when_hicache_size_zero(self):
+        """Ratio mode (hicache_size <= 0) should not be adjusted."""
+        server_args = _make_server_args(hicache_size=0, hicache_ratio=2.0)
+        target = _make_mha_pool(128, 8, 28, torch.bfloat16)
+        draft = _make_mha_pool(128, 8, 28, torch.bfloat16)
+
+        with mock.patch(_APPLY_FIELDS_PATH) as mock_apply:
+            _adjust_hicache_size_for_draft(server_args, target, (draft,))
+            mock_apply.assert_not_called()
+
+    def test_no_adjustment_when_no_draft_pools(self):
+        server_args = _make_server_args(hicache_size=4, hicache_ratio=2.0)
+        target = _make_mha_pool(128, 8, 28, torch.bfloat16)
+
+        with mock.patch(_APPLY_FIELDS_PATH) as mock_apply:
+            _adjust_hicache_size_for_draft(server_args, target, ())
+            mock_apply.assert_not_called()
+
+    def test_no_adjustment_when_target_spt_zero(self):
+        server_args = _make_server_args(hicache_size=4, hicache_ratio=2.0)
+        target = SimpleNamespace(
+            head_dim=None,
+            head_num=None,
+            kv_cache_dim=None,
+            layer_num=None,
+            store_dtype=None,
+            dtype=None,
+            size=0,
+            get_kv_size_bytes=lambda: 0,
+        )
+        draft = _make_mha_pool(128, 8, 28, torch.bfloat16)
+
+        with mock.patch(_APPLY_FIELDS_PATH) as mock_apply:
+            _adjust_hicache_size_for_draft(server_args, target, (draft,))
+            mock_apply.assert_not_called()
+
+    def test_equal_per_token_cost_halves_budget(self):
+        """When target and draft have equal per-token cost, each gets half."""
+        server_args = _make_server_args(hicache_size=4, hicache_ratio=2.0)
+        target = _make_mha_pool(128, 8, 28, torch.bfloat16)
+        draft = _make_mha_pool(128, 8, 28, torch.bfloat16)
+
+        with mock.patch(_APPLY_FIELDS_PATH) as mock_apply:
+            _adjust_hicache_size_for_draft(server_args, target, (draft,))
+            mock_apply.assert_called_once()
+            fields = mock_apply.call_args[0][1]
+            # effective = 4 * spt / (spt + spt) = 2
+            self.assertEqual(fields["hicache_size"], 2)
+            self.assertAlmostEqual(fields["hicache_ratio"], 1.0)
+
+    def test_quantized_target_bf16_draft(self):
+        """fp8 target + bf16 draft: draft is 2x the per-token cost."""
+        server_args = _make_server_args(hicache_size=4, hicache_ratio=2.0)
+        target = _make_mha_pool(128, 8, 28, torch.float8_e4m3fn)  # spt = 57344
+        draft = _make_mha_pool(128, 8, 28, torch.bfloat16)  # spt = 114688
+
+        with mock.patch(_APPLY_FIELDS_PATH) as mock_apply:
+            _adjust_hicache_size_for_draft(server_args, target, (draft,))
+            mock_apply.assert_called_once()
+            fields = mock_apply.call_args[0][1]
+            # effective = 4 * 57344 / (57344 + 114688) = 4/3
+            expected_size = int(4 * 57344 / (57344 + 114688))
+            self.assertEqual(fields["hicache_size"], expected_size)
+            # ratio_factor = 1/3
+            expected_ratio = 2.0 * 57344 / (57344 + 114688)
+            self.assertAlmostEqual(fields["hicache_ratio"], expected_ratio)
+
+    def test_bf16_target_fp8_draft(self):
+        """bf16 target + fp8 draft: draft is 0.5x the per-token cost."""
+        server_args = _make_server_args(hicache_size=4, hicache_ratio=2.0)
+        target = _make_mha_pool(128, 8, 28, torch.bfloat16)  # spt = 114688
+        draft = _make_mha_pool(128, 8, 28, torch.float8_e4m3fn)  # spt = 57344
+
+        with mock.patch(_APPLY_FIELDS_PATH) as mock_apply:
+            _adjust_hicache_size_for_draft(server_args, target, (draft,))
+            mock_apply.assert_called_once()
+            fields = mock_apply.call_args[0][1]
+            # effective = 4 * 114688 / (114688 + 57344) = 8/3
+            expected_size = int(4 * 114688 / (114688 + 57344))
+            self.assertEqual(fields["hicache_size"], expected_size)
+
+    def test_mla_target_mha_draft(self):
+        """MLA target + MHA draft: different pool types are handled."""
+        server_args = _make_server_args(hicache_size=4, hicache_ratio=2.0)
+        target = _make_mla_pool(kv_cache_dim=512, layer_num=28, dtype=torch.bfloat16)
+        draft = _make_mha_pool(128, 8, 28, torch.bfloat16)
+
+        with mock.patch(_APPLY_FIELDS_PATH) as mock_apply:
+            _adjust_hicache_size_for_draft(server_args, target, (draft,))
+            mock_apply.assert_called_once()
+            fields = mock_apply.call_args[0][1]
+            # target_spt = 512 * 28 * 2 = 28672
+            # draft_spt = 128 * 8 * 28 * 2 * 2 = 114688
+            target_spt = 28672
+            draft_spt = 114688
+            expected_size = int(4 * target_spt / (target_spt + draft_spt))
+            self.assertEqual(fields["hicache_size"], expected_size)
+            expected_ratio = 2.0 * target_spt / (target_spt + draft_spt)
+            self.assertAlmostEqual(fields["hicache_ratio"], expected_ratio)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

When `--hicache-size` is set (fixed GB budget for host-side KV cache) and a SIDECAR draft model is registered, the draft model also gets a host-side KV pool that must match the target's token count (for 1-to-1 index sharing in L2 transfers). However, the draft's per-token byte cost can be **larger** than the target's (e.g. quantized target + bf16 draft), causing the combined target+draft host memory allocation to **exceed** the user-specified `--hicache-size` budget.

In practice this causes the server to OOM on startup. For example, with a quantized 27B target + bf16 1.5B draft at TP=4:
- Target host pool: 7.60 GB/rank
- Draft host pool: 9.50 GB/rank
- **Total: 17.10 GB/rank** — far exceeding the 4 GB `--hicache-size` cap

## Modifications

Add `_adjust_hicache_size_for_draft()` in `kv_cache_builder.py` which:
1. Computes the per-token byte cost of both target and draft device pools via `_device_pool_size_per_token()`, which derives the cost from pool geometry (head_dim, head_num, layer_num, dtype for MHA; kv_cache_dim, layer_num, dtype for MLA) rather than `get_kv_size_bytes()`, since the device pool may be in post-capture mode where buffers are not yet allocated.
2. Shrinks the budget by the factor `target_spt / (target_spt + draft_spt)` so the total (target + draft) stays within the user's `--hicache-size` cap.
3. Reduces both `hicache_size` and `hicache_ratio` (the latter needed because post-capture pools have zero allocated buffers, so sizing falls back to the ratio).
4. Runs before `create_tree_cache()` so the adjusted values flow into both the tree cache and the memory bag.

The adjustment only applies in fixed-size (`hicache_size > 0`) mode; ratio mode already scales both pools proportionally.

## Accuracy Tests

This change does not affect model outputs — it only adjusts host memory pool sizing. No accuracy impact.

## Speed Tests and Profiling

This change does not impact inference speed. It only prevents OOM at startup when using speculative decoding with HiCache.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32497855405](https://github.com/sgl-project/sglang/actions/runs/32497855405)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32497855075](https://github.com/sgl-project/sglang/actions/runs/32497855075)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32497855339](https://github.com/sgl-project/sglang/actions/runs/32497855339)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->