### PR TITLE
[mem_cache] Honor the pool device for speculative mamba caches

### DIFF
--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -440,7 +440,7 @@ class MambaPool:
                 *physical_conv_shape,
             ),
             dtype=conv_dtype,
-            device="cuda",
+            device=self.device,
         )
         physical_conv_strides = phys.stride()[2:]
         window_stride = physical_conv_strides[window_axis]
@@ -712,7 +712,7 @@ class MambaPool:
                             temporal_state_shape[2],
                         ),
                         dtype=ssm_dtype,
-                        device="cuda",
+                        device=device,
                     )
                 # Cache intermediate conv windows (last K-1 inputs) per draft token
                 # during target verify.
@@ -780,7 +780,7 @@ class MambaPool:
                                 conv_shape[1],
                             ),
                             dtype=conv_dtype,
-                            device="cuda",
+                            device=device,
                         )
                         for conv_shape in dense_conv_shapes
                     ]

--- a/test/registered/unit/mem_cache/test_mamba_pool_speculative_device.py
+++ b/test/registered/unit/mem_cache/test_mamba_pool_speculative_device.py
@@ -1,0 +1,76 @@
+import unittest
+from unittest.mock import patch
+
+from sglang.srt.configs.mamba_utils import Mamba2CacheParams, Mamba2StateShape
+from sglang.srt.environ import envs
+from sglang.srt.mem_cache.memory_pool import MambaPool
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+MAMBA_LAYER_IDS = [0, 1]
+
+
+def _speculative_pool(device: str) -> MambaPool:
+    shape = Mamba2StateShape.create(
+        tp_world_size=1,
+        intermediate_size=64,
+        n_groups=1,
+        num_heads=2,
+        head_dim=16,
+        state_size=8,
+        conv_kernel=4,
+    )
+    with envs.SGLANG_MAMBA_SSM_DTYPE.override("bfloat16"):
+        cache_params = Mamba2CacheParams(shape=shape, layers=MAMBA_LAYER_IDS)
+    return MambaPool(
+        size=2,
+        spec_state_size=2,
+        cache_params=cache_params,
+        mamba_layer_ids=MAMBA_LAYER_IDS,
+        device=device,
+        speculative_num_draft_tokens=3,
+        speculative_eagle_topk=1,
+    )
+
+
+class TestMambaPoolSpeculativeDevice(unittest.TestCase):
+    """The speculative scratch buffers were allocated with a hardcoded
+    device="cuda" while every sibling allocation honored the `device` argument,
+    so building the pool on any other device raised "Torch not compiled with
+    CUDA enabled" before the first forward. Both intermediate layouts are
+    covered because they allocate through separate code paths."""
+
+    def test_dense_layout_buffers_follow_the_pool_device(self):
+        with patch("sglang.srt.mem_cache.memory_pool._is_cpu", True):
+            pool = _speculative_pool("cpu")
+
+        self.assertEqual(pool.mamba_cache.intermediate_ssm.device.type, "cpu")
+        for window in pool.mamba_cache.intermediate_conv_window:
+            self.assertEqual(window.device.type, "cpu")
+
+    def test_deduplicated_layout_buffers_follow_the_pool_device(self):
+        with patch("sglang.srt.mem_cache.memory_pool._is_cpu", False):
+            pool = _speculative_pool("cpu")
+
+        self.assertEqual(pool.mamba_cache.intermediate_ssm.device.type, "cpu")
+        for phys in pool._intermediate_conv_window_phys:
+            self.assertEqual(phys.device.type, "cpu")
+
+    def test_layouts_agree_on_the_logical_window_shape(self):
+        """The dedup view is an as_strided alias, so a layout change that drops
+        a step or a window column would still allocate and only corrupt the
+        conv rollback at commit time."""
+        with patch("sglang.srt.mem_cache.memory_pool._is_cpu", True):
+            dense = _speculative_pool("cpu")
+        with patch("sglang.srt.mem_cache.memory_pool._is_cpu", False):
+            dedup = _speculative_pool("cpu")
+
+        self.assertEqual(
+            [tuple(w.shape) for w in dense.mamba_cache.intermediate_conv_window],
+            [tuple(w.shape) for w in dedup.mamba_cache.intermediate_conv_window],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`MambaPool` allocates its speculative-decoding scratch buffers with a hardcoded
`device="cuda"`, while every sibling allocation in the same constructor honors
the `device` argument. Any non-CUDA device that enables speculative decoding for
a hybrid linear-attention model therefore fails during pool construction, before
the first forward pass:

```
File "/work/python/sglang/srt/mem_cache/memory_pool.py", line 705, in __init__
    intermediate_ssm_state_cache = torch.zeros(..., device="cuda")
AssertionError: Torch not compiled with CUDA enabled
```

All three occurrences are inside the `speculative_num_draft_tokens is not None`
branch, which is why the non-speculative path on CPU/NPU was never affected. One
of them even sits under a comment that reads *"Original dense layout (NPU/CPU, or
EAGLE tree verify)"* — the layout was already meant to serve non-CUDA devices,
only the allocation device was not.

## Modifications

`python/sglang/srt/mem_cache/memory_pool.py` — replace the three hardcoded
`device="cuda"` literals with the pool's device:

| Allocation | Before | After | Reachable on CPU/NPU today |
| --- | --- | --- | --- |
| `intermediate_ssm_state_cache` | `device="cuda"` | `device=device` | Yes — this is the one that aborts |
| `intermediate_conv_window_cache` | `device="cuda"` | `device=device` | Yes |
| `_allocate_deduplicated_conv_window` (`phys`) | `device="cuda"` | `device=self.device` | No |

The first two are in the dense layout that `conv_window_dedup_enabled()` selects
for NPU/CPU, so they abort today. The third is in the deduplicated layout, which
that same gate restricts to CUDA, so it is currently a no-op — fixed for
consistency, so that relaxing the gate later does not reintroduce the bug in the
one place it was missed.

No behavior change on CUDA: `device` is `"cuda"` there.

Adds `test/registered/unit/mem_cache/test_mamba_pool_speculative_device.py`
(registered CPU unit test) covering both intermediate layouts, since the
deduplicated and dense paths allocate through separate code. The test patches
the platform predicate to reach each layout, because neither is reachable from
both sides on a single runner.

## Accuracy Tests

No effect on model outputs — this only changes where the tensors are allocated.

Verified on a Xeon 6 (128 physical cores, 4 NUMA
nodes) with `--device cpu --attention-backend intel_amx` and `Qwen3.5-9B`,
which previously aborted during pool construction and now allocates cleanly:

```
Mamba Cache is allocated. max_mamba_cache_size: 17, conv_state size: 0.02GB,
ssm_state size: 0.84GB intermediate_ssm_state_cache size: 4.50GB
intermediate_conv_window_cache size: 0.11GB
```

(That run still stops later at a separate, unrelated gap — the CPU GDN kernels
have no target-verify entry points yet. That is out of scope here and will be a
follow-up PR; this change is a strict prerequisite for it.)

## Speed Tests and Profiling

Not applicable — allocation-site change only, no change to any hot path.

## Checklist

- [x] Format your code according to the Format code with pre-commit.
- [x] Add unit tests according to the Run and add unit tests.
- [ ] Update documentation according to Write documentations.
- [x] Provide accuracy and speed benchmark results according to Test the accuracy and Benchmark the speed.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32499595945](https://github.com/sgl-project/sglang/actions/runs/32499595945)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32499595693](https://github.com/sgl-project/sglang/actions/runs/32499595693)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32499596136](https://github.com/sgl-project/sglang/actions/runs/32499596136)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->