### PR TITLE
fix(unified-cache): improve load-back pin handling

### DIFF
--- a/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
+++ b/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
@@ -131,9 +131,14 @@ class UnifiedTreeNode:
         self.id = UnifiedTreeNode.counter
         UnifiedTreeNode.counter += 1
         self.write_through_pending_id: Optional[int] = None
-        # Anchor NodeId of an in-flight H->D load-back reading this node's
-        # host slots; such host copies must not be reclaimed until the ack.
-        self.load_back_pending_id: Optional[int] = None
+        # Anchor NodeIds of in-flight H->D load-backs reading this node's
+        # host slots; such host copies must not be reclaimed until every
+        # anchor has acked. Multiple live anchors can pin one node: a
+        # descendant's Full-KV chain covers this node while another request
+        # anchors here for its independently-evicted aux (e.g. mamba) state.
+        # Overlapping transfers only READ the shared host slots and write
+        # disjoint destinations, so concurrent pins are safe to track.
+        self.load_back_pending_ids: set[int] = set()
 
     def component(self, component_type: ComponentType) -> ComponentData:
         return self.component_data[component_type]
@@ -1081,7 +1086,7 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         new_node.hit_count = child.hit_count
         new_node.creation_time = child.creation_time
         # Split fragments stay on the anchor's root path for the ack's walk.
-        new_node.load_back_pending_id = child.load_back_pending_id
+        new_node.load_back_pending_ids = set(child.load_back_pending_ids)
 
         self._for_each_component_lru(child, UnifiedLRUList.remove_node)
 
@@ -1192,7 +1197,7 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
             and cd.value is not None
             and cd.host_value is not None
             and node.write_through_pending_id is None
-            and node.load_back_pending_id is None
+            and not node.load_back_pending_ids
         )
 
     def _for_each_component_lru(
@@ -1430,7 +1435,7 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
             return False
         if (
             node.write_through_pending_id is not None
-            or node.load_back_pending_id is not None
+            or node.load_back_pending_ids
         ):
             return False
         return cd.host_lock_ref == 0
@@ -1988,13 +1993,10 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
                 for xfer in xfers:
                     for nid in xfer.nodes_to_load or ():
                         pinned = self.node_by_id(nid)
-                        # One live load-back per node; only the same anchor may
-                        # re-pin (a node can sit in Full and aux transfer lists).
-                        assert pinned.load_back_pending_id in (None, node_id), (
-                            f"node {nid} pinned by load-back "
-                            f"{pinned.load_back_pending_id}, new anchor {node_id}"
-                        )
-                        pinned.load_back_pending_id = node_id
+                        # Multiple live load-backs may pin one node (set.add is
+                        # also idempotent for a node sitting in both the Full and
+                        # an aux transfer list of the same anchor).
+                        pinned.load_back_pending_ids.add(node_id)
         kv_xfer.device_indices = device_indices
         self.components_by_type[BASE_COMPONENT_TYPE].commit_hicache_transfer(
             node,
@@ -2025,10 +2027,12 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         node = self.node_by_id(anchor_node_id)
         while node is not None and node is not self.root_node:
             if self.is_write_back:
-                if node.load_back_pending_id != anchor_node_id:
+                if anchor_node_id not in node.load_back_pending_ids:
                     node = node.parent
                     continue
-                node.load_back_pending_id = None
+                node.load_back_pending_ids.discard(anchor_node_id)
+                # The loaded copies become tracked duplicates only once the
+                # last in-flight load-back on this node acks.
             self._update_duplicate_tracking(node)
             node = node.parent
 
@@ -2314,13 +2318,11 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         # mark would pin the node's host copy against reclaim forever.
         ongoing_load_ids = {node_id for _, node_id in ongoing_load_back}
         for node in all_nodes:
-            if (
-                node.load_back_pending_id is not None
-                and node.load_back_pending_id not in ongoing_load_ids
-            ):
+            stale_pins = node.load_back_pending_ids - ongoing_load_ids
+            if stale_pins:
                 E(
-                    f"[Ongoing] node {node.id} load_back_pending_id="
-                    f"{node.load_back_pending_id} has no live load-back"
+                    f"[Ongoing] node {node.id} load_back_pending_ids="
+                    f"{sorted(stale_pins)} have no live load-back"
                 )
 
         if errors:

--- a/test/registered/unit/mem_cache/test_unified_loadback_multipin.py
+++ b/test/registered/unit/mem_cache/test_unified_loadback_multipin.py
@@ -1,0 +1,82 @@
+"""Deterministic repro + fix validation for the load-back multi-pin race.
+
+Scenario (matches the production crash `node X pinned by load-back Y, new anchor X`):
+a first load-back anchored at a descendant pins an evicted ancestor via its Full-KV
+chain; before that load-back acks, a second load-back anchors AT the ancestor to
+restore its independently-evicted mamba state. The single-valued
+`load_back_pending_id` cannot represent both live pins and asserts.
+
+Run from test/registered/unit/mem_cache/:
+  python3 -m unittest test_unified_loadback_multipin -v
+UNPATCHED: the test errors with AssertionError("... pinned by load-back ...").
+PATCHED (load_back_pending_ids set): the test passes, pins drain to empty.
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import test_unified_radix_cache_unittest as U
+
+
+# Inherit the full suite for its fixture helpers and setUp state; invoke ONLY
+# test_overlapping_load_back_pins (the inherited suite tests run elsewhere):
+#   python3 -m unittest \
+#     test_unified_loadback_multipin.TestConcurrentLoadBackPins.test_overlapping_load_back_pins
+class TestConcurrentLoadBackPins(U.UnifiedRadixCacheSuite, U.CustomTestCase):
+    cfg = U.CacheConfig(
+        page_size=1, components=(U.ComponentType.FULL, U.ComponentType.MAMBA)
+    )
+
+    def test_overlapping_load_back_pins(self):
+        cache, allocator, req_to_token_pool = self._build_hicache_fixture()
+        chain = self._build_chain_pages(cache, allocator, req_to_token_pool, 4)
+        self.assertGreaterEqual(len(chain), 2, "need a >=2 node chain")
+
+        self._backup_tree(cache)
+        total = sum(len(n.key) for n in chain)
+        cache.evict(U.EvictParams(num_tokens=total + 16, mamba_num=64))
+
+        leaf = chain[-1]
+        self.assertTrue(leaf.evicted, "leaf must be device-evicted")
+
+        # An ancestor that is FULL-evicted (so the leaf anchor's KV chain pins
+        # it) and mamba host-only (so a second anchor can target it).
+        MAMBA = U.ComponentType.MAMBA
+        ancestor = None
+        for cand in chain[:-1]:
+            cd = cand.component_data[MAMBA]
+            if cand.evicted and cd.value is None and cd.host_value is not None:
+                ancestor = cand
+                break
+        self.assertIsNotNone(
+            ancestor,
+            "fixture produced no FULL-evicted + mamba-host-only ancestor; "
+            f"chain state: {[(n.id, n.evicted, n.component_data[MAMBA].value is not None, n.component_data[MAMBA].host_value is not None) for n in chain]}",
+        )
+
+        # Load-back 1: anchored at the leaf; its Full-KV chain covers the
+        # ancestor. Do NOT process acks — the pin stays live.
+        self.assertTrue(cache.load_back(leaf.id))
+
+        # Load-back 2: anchored at the still-pinned ancestor for its mamba
+        # state. Unpatched code dies here with
+        # AssertionError: node <ancestor> pinned by load-back <leaf>, new anchor <ancestor>
+        self.assertTrue(cache.load_back(ancestor.id))
+
+        # Both DMAs ack; every pin must drain.
+        self._finish_pending_loads(cache)
+        for node in chain:
+            self.assertEqual(
+                node.load_back_pending_ids,
+                set(),
+                f"node {node.id} kept stale pins {node.load_back_pending_ids}",
+            )
+        self._release_ongoing_load_back_locks(cache)
+        cache.sanity_check()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Just test, do not merge.

Cherry-picked from #34975 onto main commit 92eeed41 (the base of the dev-nightly-0820 image), keeping the write-back gating from #34519.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32500206715](https://github.com/sgl-project/sglang/actions/runs/32500206715)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32500206455](https://github.com/sgl-project/sglang/actions/runs/32500206455)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32500206657](https://github.com/sgl-project/sglang/actions/runs/32500206657)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->