### PR TITLE
[CPU][Test] Guard the intel_amx verify seq_lens fix and re-enable EAGLE3 CPU parity

### DIFF
--- a/test/registered/cpu/test_spec_eagle_parity_cpu.py
+++ b/test/registered/cpu/test_spec_eagle_parity_cpu.py
@@ -10,7 +10,6 @@ from sglang.test.server_fixtures.spec_eagle_fixture import Eagle3Base
 register_cpu_ci(
     est_time=480,
     suite="base-b-test-cpu",
-    disabled="EAGLE3 numerical parity mismatches on CPU intel_amx",
 )
 
 

--- a/test/registered/unit/layers/attention/test_intel_amx_verify_seqlens.py
+++ b/test/registered/unit/layers/attention/test_intel_amx_verify_seqlens.py
@@ -1,0 +1,201 @@
+"""Regression tests for the intel_amx seq_lens plumbing fixed in #36430.
+
+#24013 added two `seq_lens = forward_batch.seq_lens` re-reads that discarded the
+values `_build_extend_metadata` and the multi-step draft backend had already
+resolved, silently corrupting CPU speculative decoding in both directions.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.layers.attention.intel_amx_backend import IntelAMXAttnBackend
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+BATCH_SIZE = 2
+DRAFT_TOKEN_NUM = 4
+DRAFT_TOPK = 2
+COMMITTED_LEN = 7
+EXTEND_LEN = 3
+HEAD_NUM = 1
+HEAD_DIM = 8
+
+
+class _StubKVPool:
+    def __init__(self):
+        self.buffer = torch.zeros(16, HEAD_NUM, HEAD_DIM)
+
+    def set_kv_buffer(self, layer, loc, k, v):
+        pass
+
+    def get_key_buffer(self, layer_id):
+        return self.buffer
+
+    def get_value_buffer(self, layer_id):
+        return self.buffer
+
+
+def _layer():
+    return SimpleNamespace(
+        layer_id=0,
+        tp_q_head_num=HEAD_NUM,
+        qk_head_dim=HEAD_DIM,
+        v_head_dim=HEAD_DIM,
+        is_cross_attention=False,
+        scaling=1.0,
+        logit_cap=0.0,
+        sliding_window_size=-1,
+    )
+
+
+def _forward_batch(forward_mode, num_tokens):
+    spec_info = (
+        SimpleNamespace(draft_token_num=DRAFT_TOKEN_NUM, tree_topk=1, custom_mask=None)
+        if forward_mode.is_target_verify()
+        else None
+    )
+    return SimpleNamespace(
+        forward_mode=forward_mode,
+        batch_size=BATCH_SIZE,
+        seq_lens=torch.full((BATCH_SIZE,), COMMITTED_LEN, dtype=torch.int32),
+        spec_info=spec_info,
+        extend_seq_lens=torch.full((BATCH_SIZE,), EXTEND_LEN, dtype=torch.int32),
+        extend_start_loc=torch.tensor([0, EXTEND_LEN], dtype=torch.int32),
+        req_pool_indices=torch.arange(BATCH_SIZE, dtype=torch.int32),
+        out_cache_loc=torch.arange(num_tokens, dtype=torch.int32),
+        encoder_out_cache_loc=None,
+        encoder_lens=None,
+    )
+
+
+def _run_forward_extend(forward_batch, num_tokens):
+    """Drive the backend the way a forward pass does and return the seq_lens
+    tensor that reached the kernel."""
+    backend = object.__new__(IntelAMXAttnBackend)
+    backend.device = "cpu"
+    backend.token_to_kv_pool = _StubKVPool()
+    backend.req_to_token_pool = SimpleNamespace(
+        req_to_token=torch.zeros(BATCH_SIZE, 64, dtype=torch.int32)
+    )
+    backend.swa_out_cache_loc = None
+    backend.forward_metadata = (None, DRAFT_TOKEN_NUM)
+    backend.extend_metadata = backend._build_extend_metadata(forward_batch)
+
+    seen = {}
+
+    def _record(*args):
+        seen["seq_lens"] = args[8]
+
+    backend.extend_attention_fwd = _record
+
+    qkv = torch.zeros(num_tokens, HEAD_NUM * HEAD_DIM)
+    backend.forward_extend(qkv, qkv, qkv, _layer(), forward_batch)
+    return seen["seq_lens"]
+
+
+def _run_forward_decode(draft_decode_metadata):
+    """Drive forward_decode and return the seq_lens tensor that reached the
+    kernel."""
+    backend = object.__new__(IntelAMXAttnBackend)
+    backend.device = "cpu"
+    backend.num_head = HEAD_NUM
+    backend.v_head_dim = HEAD_DIM
+    backend.token_to_kv_pool = _StubKVPool()
+    backend.req_to_token_pool = SimpleNamespace(
+        req_to_token=torch.zeros(BATCH_SIZE, 64, dtype=torch.int32)
+    )
+    backend.draft_decode_metadata = draft_decode_metadata
+    num_tokens = (
+        BATCH_SIZE
+        if draft_decode_metadata is None
+        else draft_decode_metadata[1].shape[0]
+    )
+    backend.forward_metadata = (
+        torch.zeros(num_tokens, HEAD_NUM, 8, HEAD_DIM + 1),
+        None,
+    )
+
+    seen = {}
+
+    def _record(*args):
+        seen["seq_lens"] = args[10]
+
+    backend.decode_attention_fwd = _record
+
+    qkv = torch.zeros(num_tokens, HEAD_NUM * HEAD_DIM)
+    forward_batch = _forward_batch(ForwardMode.DECODE, num_tokens)
+    backend.forward_decode(qkv, qkv, qkv, _layer(), forward_batch)
+    return seen["seq_lens"]
+
+
+class TestIntelAMXVerifySeqLens(unittest.TestCase):
+    def test_verify_seq_lens_cover_the_draft_kv(self):
+        """A verify batch writes its draft KV into
+        [seq_lens, seq_lens + draft_token_num) without bumping seq_lens, so the
+        kernel has to be told the extended length or every draft token attends
+        to the committed prefix alone."""
+        num_tokens = BATCH_SIZE * DRAFT_TOKEN_NUM
+        forward_batch = _forward_batch(ForwardMode.TARGET_VERIFY, num_tokens)
+
+        seq_lens = _run_forward_extend(forward_batch, num_tokens)
+
+        self.assertTrue(
+            torch.equal(
+                seq_lens,
+                torch.full(
+                    (BATCH_SIZE,), COMMITTED_LEN + DRAFT_TOKEN_NUM, dtype=torch.int64
+                ),
+            )
+        )
+
+    def test_extend_seq_lens_are_passed_through(self):
+        """The verify adjustment must not leak into ordinary prefill, where
+        seq_lens already accounts for the extended tokens."""
+        num_tokens = BATCH_SIZE * EXTEND_LEN
+        forward_batch = _forward_batch(ForwardMode.EXTEND, num_tokens)
+
+        seq_lens = _run_forward_extend(forward_batch, num_tokens)
+
+        self.assertTrue(
+            torch.equal(
+                seq_lens, torch.full((BATCH_SIZE,), COMMITTED_LEN, dtype=torch.int64)
+            )
+        )
+
+    def test_draft_decode_uses_the_expanded_seq_lens(self):
+        """The multi-step draft backend hands each step an expanded
+        (req_to_token, seq_lens, req_pool_indices) triple sized
+        batch_size * topk, and the kernel derives num_seqs from seq_lens, so an
+        unexpanded tensor here aborts its attn_logits size check."""
+        expanded = (
+            torch.full((BATCH_SIZE,), COMMITTED_LEN, dtype=torch.int32)
+        ).repeat_interleave(DRAFT_TOPK) + 1
+
+        seq_lens = _run_forward_decode(
+            (
+                torch.zeros(BATCH_SIZE * DRAFT_TOPK, 64, dtype=torch.int32),
+                expanded,
+                torch.arange(BATCH_SIZE * DRAFT_TOPK, dtype=torch.int64),
+            )
+        )
+
+        self.assertTrue(torch.equal(seq_lens, expanded.to(torch.int64)))
+
+    def test_plain_decode_falls_back_to_the_batch_seq_lens(self):
+        """Without draft metadata there is nothing to expand, so the batch's
+        own lengths must still be used."""
+        seq_lens = _run_forward_decode(None)
+
+        self.assertTrue(
+            torch.equal(
+                seq_lens, torch.full((BATCH_SIZE,), COMMITTED_LEN, dtype=torch.int64)
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

#36430 removed the two `seq_lens = forward_batch.seq_lens` re-reads in
`IntelAMXAttnBackend` that #24013 had introduced, which is the right fix. It
left two gaps behind:

1. **No test guards it.** The PR was `+0 −2` with no test, so nothing prevents
   the same re-read from coming back. It has already regressed once.
2. **The test the bug disabled is still off.** `test_spec_eagle_parity_cpu.py`
   is still registered as
   `disabled="EAGLE3 numerical parity mismatches on CPU intel_amx"` — those
   mismatches were the `forward_extend` symptom, and the cause is now fixed.

This PR closes both. It is test-only; no source file is touched.

The invariants worth pinning are the ones that made the bug silent:

**`forward_extend`.** In `TARGET_VERIFY` mode `_build_extend_metadata` returns
`forward_batch.seq_lens + num_draft_tokens`, because a verify batch writes its
draft KV into `[seq_lens, seq_lens + draft_token_num)` **without** bumping
`seq_lens`. Re-reading `forward_batch.seq_lens` hid every draft KV entry from
`extend_attention_cpu`, so each draft token attended only to the committed
prefix — wrong attention output rather than a crash, which is why it surfaced
as accuracy and logprob failures instead of a stack trace.

**`forward_decode`.** `IntelAMXMultiStepDraftBackend.init_forward_metadata`
hands each draft step an expanded triple sized `batch_size * topk` and sizes
`attn_logits` from that same `bs`. Re-reading `forward_batch.seq_lens` kept the
expanded `req_to_token` and `req_pool_indices` but paired them with the
unexpanded lengths, so `decode_attention_cpu` derived `num_seqs` from the wrong
tensor and aborted:

```
RuntimeError: CHECK_EQ(attn_logits.size(0), num_seqs) failed. 4 vs 1
```

## Modifications

`test/registered/unit/layers/attention/test_intel_amx_verify_seqlens.py` (new)
— registered CPU unit test that stubs the two kernel entry points and asserts
the `seq_lens` tensor that actually reaches them, in four cases:

| Path | Batch | Expected `seq_lens` |
| --- | --- | --- |
| `forward_extend` | `TARGET_VERIFY` | `forward_batch.seq_lens + draft_token_num` |
| `forward_extend` | `EXTEND` | `forward_batch.seq_lens` |
| `forward_decode` | draft decode | expanded `batch_size * topk` tensor |
| `forward_decode` | plain decode | `forward_batch.seq_lens` |

The first and third fail on the pre-#36430 code and pass on current `main`; the
other two are the regression guards that keep a future fix from over-correcting
into the non-speculative paths. It is a pure unit test — no model, no server,
`est_time=2`.

`test/registered/cpu/test_spec_eagle_parity_cpu.py` — drop the `disabled=`
argument from `register_cpu_ci(...)`.

## Accuracy Tests

All runs on a Xeon 6 (128 physical cores, 4 NUMA
nodes) with `--device cpu --attention-backend intel_amx`.

### The new unit test

Run against an unmodified export of `main` at ff5578eb:

```
4 passed, 17 warnings in 12.88s
```

Then the same test against the parent of #36430's merge commit — the code as it
was before the fix — to confirm it actually catches the regression:

```
FAILED ...::test_draft_decode_uses_the_expanded_seq_lens - AssertionError
FAILED ...::test_verify_seq_lens_cover_the_draft_kv      - AssertionError
2 failed, 2 passed, 5.87s
```

Exactly the two speculative cases fail, and the two non-speculative guards stay
green.

### The parity test being re-enabled

Measured with and without the two-line fix that later landed as #36430. The only
upstream change to `intel_amx_backend.py` between the commit these runs were
taken on and ff5578eb is exactly those two deletions, so the "with fix" column
is the behaviour on `main` today.

Without the fix:

```
7 failed, 13 passed, 1 skipped, 14 errors in 1329.27s
```

With the fix:

```
18 passed, 1 skipped, 14 errors, 2 subtests passed in 929.51s
```

All 7 failures clear, including the one that named the `disabled` marker:

| Test | Failure without the fix |
| --- | --- |
| `test_spec_eagle_parity_cpu::test_parity_vs_reference` | `' a' != ' a city of romance, art, fashion, and cuisi[164 chars] has'` |
| `test_spec_eagle_cpu::test_gsm8k` | `np.float64(0.015625) not greater than 0.2` |
| `test_spec_eagle_cpu::test_logprob_match` | `np.float64(8.417016625404358) not less than 0.5` |
| `test_spec_eagle_cpu::test_logprob_decode_match_prefill` | 2 SUBFAILED |
| `test_spec_eagle_cpu::test_finish_stop_eos` | `Expected finish_reason: stop, but got: length` |
| `test_spec_eagle_cpu::test_token_ids_logprob_ragged` | `RuntimeError: prefix len < 0!` |

### The `forward_decode` case

The 14 errors above were all `test_spec_eagle_topk_cpu::TestEagleLlama2Topk4`
`setUpClass` failures with the `4 vs 1` abort. With the fix that suite runs
clean:

```
13 passed, 1 skipped, 2 subtests passed in 862.21s (0:14:22)
```

Its own `disabled=` marker is left in place — it is set for an unrelated reason
(the gated `meta-llama/Llama-2-7b-chat-hf` weights), not for this crash.

All 26 tests in `test_spec_kernels.py` pass in both runs, so the
non-speculative paths are unaffected.

## Speed Tests and Profiling

Not a performance change. The suite time in the table above (1329s -> 930s) is
a side effect of requests accepting drafts instead of falling back.

## Checklist

- [x] Format your code according to the Format code with pre-commit.
- [x] Add unit tests according to the Run and add unit tests.
- [ ] Update documentation according to Write documentations.
- [x] Provide accuracy and speed benchmark results according to Test the accuracy and Benchmark the speed.
- [x] Follow the SGLang code style guidance.
