### PR TITLE
refactor(disagg): extract _all_reduce_polls helper

### DIFF
--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -202,6 +202,13 @@ def _apply_metadata_gate(polls, decode_reqs, metadata_buffers, server_args) -> N
                 polls[i] = int(KVPoll.Transferring)
 
 
+def _all_reduce_polls(polls: List[int], group: dist.ProcessGroup) -> List[int]:
+    """MIN-reduce poll states so no rank commits ahead of its peers."""
+    tensor_to_reduce = torch.tensor(polls, dtype=torch.uint8, device="cpu")
+    dist.all_reduce(tensor_to_reduce, op=dist.ReduceOp.MIN, group=group)
+    return tensor_to_reduce.tolist()
+
+
 def poll_and_all_reduce(
     pollers,
     gloo_group: dist.ProcessGroup,
@@ -219,9 +226,7 @@ def poll_and_all_reduce(
         and server_args is not None
     ):
         _apply_metadata_gate(polls, decode_reqs, metadata_buffers, server_args)
-    tensor_to_reduce = torch.tensor(polls, dtype=torch.uint8, device="cpu")
-    dist.all_reduce(tensor_to_reduce, op=dist.ReduceOp.MIN, group=gloo_group)
-    return tensor_to_reduce.tolist()
+    return _all_reduce_polls(polls, gloo_group)
 
 
 def poll_and_all_reduce_attn_cp_tp_group(
@@ -235,13 +240,7 @@ def poll_and_all_reduce_attn_cp_tp_group(
 
     # Then sync across attn-cp ranks, so all TPxCP participants in one DP shard
     # converge to the same global status.
-    tensor_to_reduce = torch.tensor(polls, dtype=torch.uint8, device="cpu")
-    dist.all_reduce(
-        tensor_to_reduce,
-        op=dist.ReduceOp.MIN,
-        group=attn_cp_cpu_group,
-    )
-    return tensor_to_reduce.tolist()
+    return _all_reduce_polls(polls, attn_cp_cpu_group)
 
 
 def poll_and_all_reduce_with_staging(
@@ -277,9 +276,7 @@ def poll_and_all_reduce_with_staging(
     # Apply metadata gate on the decode requests to downgrade Success → Transferring for requests whose metadata hasn't landed.
     if metadata_buffers is not None and server_args is not None:
         _apply_metadata_gate(raw_polls, decode_reqs, metadata_buffers, server_args)
-    poll_tensor = torch.tensor(raw_polls, dtype=torch.uint8, device="cpu")
-    dist.all_reduce(poll_tensor, op=dist.ReduceOp.MIN, group=gloo_group)
-    return poll_tensor.tolist()
+    return _all_reduce_polls(raw_polls, gloo_group)
 
 
 #########################


### PR DESCRIPTION
## Motivation

Three functions in `python/sglang/srt/disaggregation/utils.py` — `poll_and_all_reduce`, `poll_and_all_reduce_attn_cp_tp_group` and `poll_and_all_reduce_with_staging` — each ended with the same three lines: build a `uint8` CPU tensor, MIN `all_reduce` it, return `.tolist()`.

The MIN reduce is a real invariant, not incidental: it is what stops any rank from committing a transfer state ahead of its peers. Stating it three times invites drift, and the copies had already drifted cosmetically — the third site named its local `poll_tensor` while the other two used `tensor_to_reduce`.

## Modifications

Extracts `_all_reduce_polls(polls, group)` and routes the three call sites through it. 1 file, +10 / -13. After the change `dist.all_reduce` appears exactly once in the module.

`poll_and_all_reduce_pp` is deliberately **not** touched — it maps PP consensus onto poll states and never all-reduces, so it does not belong in this abstraction.

## Accuracy Tests

Not applicable — no model output, kernel, or forward path is touched.

## Speed Tests and Profiling

Not applicable. Identical collective operations, same count, same groups; the only difference is one Python function call per invocation.

## Verification performed

These are collectives, so a mistake here would surface as a hang rather than a wrong answer. Equivalence was therefore tested rather than eyeballed.

The pre- and post-change functions were extracted and executed against a fake `torch`/`dist`, comparing **both the return value and the complete `all_reduce` call log** — group, input vector and op for every call — across **30 scenarios**: 5 poll vectors x the 3 functions x 4 staging states (done / not-done / failed / no-staging). All 30 identical.

Comparing the call *log* rather than just the result is the point: it confirms the two-stage reduce in `poll_and_all_reduce_attn_cp_tp_group` still fires in the correct order against the correct groups —

```
[('TP', (4, 3), 'MIN'), ('CP', (4, 3), 'MIN')]
```

attn-tp first, then attn-cp, matching the comments in the source. A refactor that accidentally reduced over one group twice, or swapped the order, would be invisible to a return-value-only comparison. The fake `all_reduce` also applies a real element-wise `min` against a configured peer vector, so MIN semantics are exercised rather than assumed.

Also: pinned `ruff 0.15.1 --select=F401,F821,UP037` (the pre-commit config) passes, plus pinned `black 26.1.0` and `isort 7.0.0`.

Real multi-GPU distributed tests were **not** run locally (no GPU hardware available). The fake-`dist` test establishes that the sequence of collective calls is unchanged; it cannot exercise NCCL/gloo itself, though nothing about the actual collective invocation changed.

Part of a small series of independent disaggregation cleanups. Related: #35838, #35843, #35844, #35847. This one and #35847 both touch `utils.py` in different regions and merge cleanly in either order.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). — N/A: no behavior change; the 30-scenario equivalence check is described above.
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — N/A: internal helper, not documented.
- [x] Provide accuracy and speed benchmark results. — N/A, see above.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32504730438](https://github.com/sgl-project/sglang/actions/runs/32504730438)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32504729759](https://github.com/sgl-project/sglang/actions/runs/32504729759)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32504730392](https://github.com/sgl-project/sglang/actions/runs/32504730392)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->