### PR TITLE
[Bugfix] Fix Qwen3.5 MTP compressed-tensors ignore matching

### DIFF
--- a/python/sglang/srt/models/qwen3_5_mtp.py
+++ b/python/sglang/srt/models/qwen3_5_mtp.py
@@ -80,6 +80,8 @@ def _mtp_quant_config(quant_config):
 
 class Qwen3_5ForCausalLMMTP(nn.Module):
 
+    packed_modules_mapping = Qwen3_5ForCausalLM.packed_modules_mapping
+
     @staticmethod
     def shared_experts_fusion_disable_reason(hf_config, quant_config):
         return Qwen3_5ForCausalLM.shared_experts_fusion_disable_reason(

--- a/test/registered/unit/models/test_shared_experts_fusion_gates.py
+++ b/test/registered/unit/models/test_shared_experts_fusion_gates.py
@@ -517,6 +517,28 @@ class TestWrapperEntryClassGates(_FusionGateCase):
             seen["quant"], "the MTP module ships unquantized in that checkpoint"
         )
 
+    def test_qwen3_5_mtp_exposes_its_fused_quantization_mapping(self):
+        from sglang.srt.layers.quantization.compressed_tensors.utils import (
+            should_ignore_layer,
+        )
+        from sglang.srt.models.qwen3_5_mtp import Qwen3_5ForCausalLMMTP
+
+        ignore = [
+            "mtp.layers.0.self_attn.q_proj",
+            "mtp.layers.0.self_attn.k_proj",
+            "mtp.layers.0.self_attn.v_proj",
+            "mtp.layers.0.mlp.gate_proj",
+            "mtp.layers.0.mlp.up_proj",
+        ]
+        mapping = Qwen3_5ForCausalLMMTP.packed_modules_mapping
+
+        self.assertTrue(
+            should_ignore_layer("mtp.layers.0.self_attn.qkv_proj", ignore, mapping)
+        )
+        self.assertTrue(
+            should_ignore_layer("mtp.layers.0.mlp.gate_up_proj", ignore, mapping)
+        )
+
 
 class TestFamiliesWithoutAGate(_FusionGateCase):
     def test_qwen2_moe_style_families_follow_the_intent(self):


### PR DESCRIPTION
## Motivation

Fixes #35797.

Compressed-tensors Qwen3.5 checkpoints list the individual MTP projections under `quantization_config.ignore`. `Qwen3_5ForCausalLMMTP` did not expose the target model's `packed_modules_mapping`, so the loader passed an empty fused mapping into the quantization config. As a result, `qkv_proj` and `gate_up_proj` could not inherit the ignore decisions of `q_proj`/`k_proj`/`v_proj` and `gate_proj`/`up_proj`. They were built with packed parameters even though the checkpoint stores plain BF16 weights, so those MTP weights were skipped during loading.

## Modification

- Reuse `Qwen3_5ForCausalLM.packed_modules_mapping` on the MTP entry class.
- Add CPU regression coverage showing that both fused projections inherit their component ignore entries.

This preserves per-layer compressed-tensors semantics instead of disabling quantization for the entire MTP module.

## Tests

- `test_shared_experts_fusion_gates.py`: 27/27 CPU tests passed.
- `black --check` on both changed files.
- `ruff check --select F401,F821,UP037` on both changed files.
- `py_compile` on both changed files.
- `git diff --check`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32503315942](https://github.com/sgl-project/sglang/actions/runs/32503315942)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32503315781](https://github.com/sgl-project/sglang/actions/runs/32503315781)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32503315963](https://github.com/sgl-project/sglang/actions/runs/32503315963)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->