### PR TITLE
fix(disagg): PD transfer-failure injection was silently inert

### DIFF
--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import random
 from collections import deque
 from contextlib import nullcontext
@@ -160,16 +159,8 @@ def unified_memory_disagg_move_gate(scheduler):
 #########################
 
 
-def _get_failure_prob() -> float:
-    try:
-        return float(envs.SGLANG_TEST_DISAGG_FAILURE_PROB.get())
-    except Exception:
-        # fallback to legacy env var
-        return float(os.getenv("DISAGGREGATION_TEST_FAILURE_PROB", "0"))
-
-
 def _poll_with_failure_injection(pollers) -> List[int]:
-    if (failure_prob := _get_failure_prob()) > 0:
+    if (failure_prob := envs.SGLANG_TEST_DISAGG_FAILURE_PROB.get()) > 0:
         return [
             int(KVPoll.Failed) if random.random() < failure_prob else int(poller.poll())
             for poller in pollers

--- a/test/registered/amd/disaggregation/test_disaggregation_basic.py
+++ b/test/registered/amd/disaggregation/test_disaggregation_basic.py
@@ -7,6 +7,7 @@ import openai
 import requests
 from transformers import AutoTokenizer
 
+from sglang.srt.environ import envs
 from sglang.test.ci.ci_register import register_amd_ci
 from sglang.test.few_shot_gsm8k import run_eval as run_eval_few_shot_gsm8k
 from sglang.test.server_fixtures.disaggregation_fixture import (
@@ -231,8 +232,10 @@ class TestDisaggregationMooncakeFailure(PDDisaggregationServerBase):
             print("SGLANG_TEST_RDMA_DEVICE is not set! Running without RDMA.")
             cls.rdma_devices = []
 
-        # set DISAGGREGATION_TEST_FAILURE_PROB to simulate failure
-        os.environ["DISAGGREGATION_TEST_FAILURE_PROB"] = "0.05"
+        # Inject transfer failures so the retry path is actually exercised.
+        # Entered before the servers start so they inherit it.
+        cls._disagg_failure_ctx = envs.SGLANG_TEST_DISAGG_FAILURE_PROB.override(0.05)
+        cls._disagg_failure_ctx.__enter__()
 
         cls.model = "Qwen/Qwen3-8B"
 
@@ -248,7 +251,7 @@ class TestDisaggregationMooncakeFailure(PDDisaggregationServerBase):
 
     @classmethod
     def tearDownClass(cls):
-        os.environ.pop("DISAGGREGATION_TEST_FAILURE_PROB")
+        cls._disagg_failure_ctx.__exit__(None, None, None)
         super().tearDownClass()
 
     @classmethod

--- a/test/registered/disaggregation/test_disaggregation_basic.py
+++ b/test/registered/disaggregation/test_disaggregation_basic.py
@@ -14,6 +14,7 @@ import openai
 import requests
 from transformers import AutoTokenizer
 
+from sglang.srt.environ import envs
 from sglang.srt.mem_cache.kv_cache_builder import BACKUP_ONLY_HICACHE_RATIO
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.kits.json_constrained_kit import JSONConstrainedMixin
@@ -188,14 +189,16 @@ class TestDisaggregationMooncakeFailure(PDDisaggregationServerBase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        # set DISAGGREGATION_TEST_FAILURE_PROB to simulate failure
-        os.environ["DISAGGREGATION_TEST_FAILURE_PROB"] = "0.05"
+        # Inject transfer failures so the retry path is actually exercised.
+        # Entered before launch_all() so the server subprocesses inherit it.
+        cls._disagg_failure_ctx = envs.SGLANG_TEST_DISAGG_FAILURE_PROB.override(0.05)
+        cls._disagg_failure_ctx.__enter__()
         cls.model = DEFAULT_MODEL_NAME_FOR_TEST
         cls.launch_all()
 
     @classmethod
     def tearDownClass(cls):
-        os.environ.pop("DISAGGREGATION_TEST_FAILURE_PROB")
+        cls._disagg_failure_ctx.__exit__(None, None, None)
         super().tearDownClass()
 
     def test_gsm8k(self):

--- a/test/registered/disaggregation/test_disaggregation_nixl.py
+++ b/test/registered/disaggregation/test_disaggregation_nixl.py
@@ -126,7 +126,6 @@ def _clear_disagg_failure_env():
     # Failure injection is scoped to the failure test; clear inherited env so
     # Basic/Accuracy cannot run with injected transfer failures.
     os.environ.pop("SGLANG_TEST_DISAGG_FAILURE_PROB", None)
-    os.environ.pop("DISAGGREGATION_TEST_FAILURE_PROB", None)
 
 
 _HAS_CONFIGURED_NIXL_BACKEND = is_in_ci() or _has_configured_nixl_backend()


### PR DESCRIPTION
## Motivation

PD transfer-failure injection has been silently inert. `_get_failure_prob()` in `python/sglang/srt/disaggregation/utils.py` guarded the canonical env read with a `try/except` and fell back to a legacy `DISAGGREGATION_TEST_FAILURE_PROB` name:

```python
def _get_failure_prob() -> float:
    try:
        return float(envs.SGLANG_TEST_DISAGG_FAILURE_PROB.get())
    except Exception:
        # fallback to legacy env var
        return float(os.getenv("DISAGGREGATION_TEST_FAILURE_PROB", "0"))
```

But `EnvField.get()` never raises. An unset variable returns the default (`0.0`), and even an unparseable value only warns and returns the default. So the `except` branch is unreachable and the legacy name was ignored outright — with `DISAGGREGATION_TEST_FAILURE_PROB=0.05` set, `_get_failure_prob()` returns `0.0`.

Two registered CI tests set exactly that variable to exercise PD transfer-failure recovery, so **both have been running with zero failure injection and their retry-path assertions have been passing vacuously**:

- `test/registered/disaggregation/test_disaggregation_basic.py`
- `test/registered/amd/disaggregation/test_disaggregation_basic.py`

## Modifications

4 files, +13 / -17. `environ.py` is deliberately untouched.

- Both failure tests now set the canonical `SGLANG_TEST_DISAGG_FAILURE_PROB` via `envs.<...>.override()` instead of mutating `os.environ`, per the env-var conventions. The override is entered before the servers launch so the subprocesses inherit it.
- The legacy name is **dropped**, not preserved behind a deprecation alias. It is a test-only knob and it has never functioned, so nothing that works today can regress: no in-repo caller sets it after this change, and any out-of-tree user setting it was already silently getting `0.0`.
- Dropping it removes the dead `try/except`, which leaves `_get_failure_prob` as a one-line wrapper over a descriptor read — so it is inlined into its single caller and deleted. `utils.py` loses its last use of `os` as a result.
- Also drops the matching legacy `os.environ.pop` from the nixl test's defensive clear, which would otherwise be a no-op naming a variable the codebase no longer honors.

After this change `DISAGGREGATION_TEST_FAILURE_PROB` appears nowhere in the repo.

## Accuracy Tests

Not applicable — no model output, kernel, or forward path is touched. The affected code is a test-only failure-injection knob.

## Speed Tests and Profiling

Not applicable. The read gets marginally cheaper: one descriptor access inline, instead of a function call wrapping a `try/except` around the same access.

## Verification performed

**The bug was reproduced against this PR's base commit.** With `DISAGGREGATION_TEST_FAILURE_PROB=0.05` and the pre-change `_get_failure_prob()`, the result is `0.0`.

**The fix was then verified end-to-end** by executing the post-change `_poll_with_failure_injection` against 4000 pollers:

| Case | Result |
|---|---|
| no env set | no injection |
| legacy name set | no injection — unchanged, it was already broken |
| `override(0.05)` (what the tests now do) | **4.78% injection** (191/4000) |
| after the override context exits | injection stops |

The third row is the one that matters: it confirms the tests' new idiom actually reaches the injection path and produces the intended ~5% failure rate, which is precisely what was not happening before. The second row confirms removing the legacy name changes nothing for anyone — it was a no-op before and is a no-op now.

Also: pinned `ruff 0.15.1 --select=F401,F821,UP037` (the pre-commit config) passes, plus pinned `black 26.1.0` and `isort 7.0.0`. Import survival checked in each touched test file.

The two PD tests themselves were **not** run locally — they need multi-GPU hardware.

## NOTE FOR REVIEWERS

These two tests will now genuinely inject 5% transfer failures for the first time. If the transfer-recovery path has regressed during the period when injection was inert, they may start failing. **That would be a real pre-existing defect surfacing, not a regression introduced by this PR** — and arguably the point of fixing the injection.

Part of a series of disaggregation cleanups; this is the only one that changes runtime behavior. Related: #35838, #35843, #35844, #35847, #35886.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). — the fix restores two existing CI tests that were passing vacuously; the measured-injection verification above covers the mechanism.
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — N/A: test-only env var, not user documentation.
- [x] Provide accuracy and speed benchmark results. — N/A, see above.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32507426911](https://github.com/sgl-project/sglang/actions/runs/32507426911)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32507426752](https://github.com/sgl-project/sglang/actions/runs/32507426752)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32507426980](https://github.com/sgl-project/sglang/actions/runs/32507426980)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->