### PR TITLE
fix: skip timed out encoder requests

### DIFF
--- a/python/sglang/srt/disaggregation/encode_server.py
+++ b/python/sglang/srt/disaggregation/encode_server.py
@@ -2874,6 +2874,13 @@ class EncoderScheduler:
     async def _dispatch_group(
         self, group: List[PendingRequest], modality: Modality
     ) -> None:
+        # A request can time out while it is waiting in the queue or while a
+        # previous batch holds the dispatch lock. Do not send timed-out
+        # requests to TP workers or include them in encoder work.
+        group = [p for p in group if not p.future.done()]
+        if not group:
+            return
+
         # Video can't fuse (per-video preprocess kwargs vary).
         if modality not in _BATCHABLE_MODALITIES:
             await self._dispatch_per_request(group, modality)
@@ -2909,6 +2916,13 @@ class EncoderScheduler:
             # lock, while allowing concurrent HTTP handlers to enqueue before
             # waiting on their individual futures.
             async with self.encoder.encode_dispatch_lock:
+                # The lock may have been held until after a request timed out.
+                # Re-check after acquiring it so the canceled request cannot
+                # participate in the broadcast or encoder call.
+                group = [p for p in group if not p.future.done()]
+                if not group:
+                    return
+                requests = [p.request for p in group]
                 for sock in self.send_sockets:
                     sock_send(
                         sock,
@@ -2963,6 +2977,8 @@ class EncoderScheduler:
     ) -> None:
         modality_str = modality.name.lower()
         for p in group:
+            if p.future.done():
+                continue
             req = p.request
             try:
                 start = time.time()

--- a/test/registered/unit/disaggregation/test_encoder_scheduler.py
+++ b/test/registered/unit/disaggregation/test_encoder_scheduler.py
@@ -108,6 +108,58 @@ def test_scheduler_coalesces_concurrent_submissions():
     asyncio.run(run_test())
 
 
+def test_scheduler_does_not_dispatch_timed_out_queued_request():
+    class FakeEncoder:
+        def __init__(self):
+            self.encode_dispatch_lock = asyncio.Lock()
+            self.started = asyncio.Event()
+            self.release = asyncio.Event()
+            self.batches = []
+
+        async def batch_encode(self, requests, _modality):
+            self.batches.append([request["req_id"] for request in requests])
+            self.started.set()
+            await self.release.wait()
+            return [(1, 2, 3, None, None) for _ in requests]
+
+    async def run_test():
+        encoder = FakeEncoder()
+        scheduler = EncoderScheduler(
+            encoder=encoder,
+            send_sockets=[],
+            max_batch_size=1,
+            request_timeout=1.0,
+        )
+        # Keep the production lower bound while making the test deterministic
+        # and fast after construction.
+        scheduler.request_timeout = 0.01
+        scheduler.start()
+        requests = [
+            {
+                "req_id": f"image-{index}",
+                "modality": "image",
+                "mm_items": [object()],
+                "num_parts": 1,
+                "part_idx": 0,
+            }
+            for index in range(2)
+        ]
+        first_task = asyncio.create_task(scheduler.submit(requests[0]))
+        try:
+            await encoder.started.wait()
+            with pytest.raises(asyncio.TimeoutError):
+                await scheduler.submit(requests[1])
+
+            encoder.release.set()
+            assert await first_task == (1, 2, 3, None, None)
+            await asyncio.sleep(0)
+            assert encoder.batches == [["image-0"]]
+        finally:
+            if not first_task.done():
+                first_task.cancel()
+            await scheduler.stop()
+
+
 @pytest.mark.parametrize(
     ("model_type", "configured", "explicit", "expected"),
     [


### PR DESCRIPTION
## Summary

- skip timed-out encoder requests before worker broadcast and encoder execution
- re-check request liveness after acquiring the encoder dispatch lock
- add a CPU-only regression test for queued request timeout

## Motivation

`EncoderScheduler.submit` cancels the request future when the per-request timeout expires, but the `PendingRequest` remains in the queue. A later batch can therefore still broadcast and execute work for a caller that has already timed out. This is especially harmful for encoder disaggregation because the late work can consume encoder capacity and produce late transfer-side effects.

Fixes #35891

## Tests

- `PYTHONPYCACHEPREFIX=/tmp/sglang-pycache python3 -m py_compile python/sglang/srt/disaggregation/encode_server.py test/registered/unit/disaggregation/test_encoder_scheduler.py`
- `git diff --check`
- Focused pytest was attempted but collection is blocked in this environment because `triton` and `torch` are unavailable.
- Ruff reports two pre-existing violations elsewhere in `encode_server.py`.
