### PR TITLE
[LMCache] Register fused MLA KV buffer over multi-process

### DIFF
--- a/python/sglang/srt/mem_cache/storage/lmcache/lmc_radix_cache.py
+++ b/python/sglang/srt/mem_cache/storage/lmcache/lmc_radix_cache.py
@@ -15,6 +15,11 @@ from sglang.srt.mem_cache.base_prefix_cache import (
     MatchPrefixParams,
     MatchResult,
 )
+from sglang.srt.mem_cache.memory_pool import (
+    DSATokenToKVPool,
+    KVCache,
+    MLATokenToKVPool,
+)
 from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey, TreeNode
 from sglang.srt.runtime_context import get_memory, get_spec
 from sglang.srt.utils import create_device_stream, device_stream_context
@@ -83,6 +88,39 @@ class LayerTransferCounter:
             self.lmc_connector.load_kv_layerwise(layer_id)
 
 
+def _select_register_pools(
+    kvcache: KVCache,
+) -> Tuple[list[torch.Tensor], list[torch.Tensor]]:
+    """Return the (k_pool, v_pool) buffers to register with LMCache MP.
+
+    MHA exposes two physical buffers per layer (``k_buffer`` / ``v_buffer``).
+    MLA fuses K and V into one latent buffer per layer (``kv_buffer``; V is a
+    slice of it), so it registers those as the K pool with an empty V pool --
+    the LMCache daemon detects the fused single-buffer layout and copies it
+    whole.
+
+    Args:
+        kvcache: The engine KV pool for the running model.
+
+    Returns:
+        ``(k_pool, v_pool)``; ``v_pool`` is empty for fused MLA.
+
+    Raises:
+        NotImplementedError: For DSA pools, whose separate indexer cache is not
+            yet registered (tracked for a follow-up PR).
+    """
+    # ponytail: DSA checked first (it subclasses MLA); indexer cache is a
+    # separate register path -> deferred to a later PR.
+    if isinstance(kvcache, DSATokenToKVPool):
+        raise NotImplementedError(
+            "LMCache MP does not yet support DSA KV pools (the indexer cache "
+            "is not registered)"
+        )
+    if isinstance(kvcache, MLATokenToKVPool):
+        return kvcache.kv_buffer, []
+    return kvcache.k_buffer, kvcache.v_buffer
+
+
 class LMCRadixCache(RadixCache):
     """RadixCache + LMCache IO.
 
@@ -112,23 +150,13 @@ class LMCRadixCache(RadixCache):
         cli_lmc_cfg = get_memory().lmcache_config_file or ""
 
         kvcache = self.token_to_kv_pool_allocator.get_kvcache()
+        k_pool, v_pool = _select_register_pools(kvcache)
         connector_kwargs = dict(
             sgl_config=model_config,
             tp_size=tp_size,
             rank=rank,
-            # NOTE: The original implementation accessed private buffers via
-            # `_kvcache.k_buffer` / `.v_buffer`. We prefer public accessors when
-            # available; fall back to private fields if needed.
-            k_pool=getattr(
-                kvcache,
-                "k_buffer",
-                getattr(self.token_to_kv_pool_allocator._kvcache, "k_buffer"),
-            ),
-            v_pool=getattr(
-                kvcache,
-                "v_buffer",
-                getattr(self.token_to_kv_pool_allocator._kvcache, "v_buffer"),
-            ),
+            k_pool=k_pool,
+            v_pool=v_pool,
             tp_group=tp_group.device_group if tp_group is not None else None,
         )
 

--- a/test/srt/mem_cache/test_select_register_pools.py
+++ b/test/srt/mem_cache/test_select_register_pools.py
@@ -1,0 +1,34 @@
+# ponytail: fake pools via spec-mocks, no real KV alloc; DSA must be checked
+# before MLA since DSATokenToKVPool subclasses MLATokenToKVPool.
+from unittest.mock import MagicMock
+
+import pytest
+
+from sglang.srt.mem_cache.memory_pool import (
+    DSATokenToKVPool,
+    MHATokenToKVPool,
+    MLATokenToKVPool,
+)
+from sglang.srt.mem_cache.storage.lmcache.lmc_radix_cache import (
+    _select_register_pools,
+)
+
+
+def test_mla_registers_kv_buffer_as_k_empty_v():
+    p = MagicMock(spec=MLATokenToKVPool)
+    p.kv_buffer = ["l0", "l1"]
+    assert _select_register_pools(p) == (["l0", "l1"], [])
+
+
+def test_dsa_raises_notimplemented():
+    # DSA ⊂ MLA: must hit the DSA branch, not the MLA one.
+    p = MagicMock(spec=DSATokenToKVPool)
+    with pytest.raises(NotImplementedError):
+        _select_register_pools(p)
+
+
+def test_mha_registers_both_buffers():
+    p = MagicMock(spec=MHATokenToKVPool)
+    p.k_buffer = ["k0"]
+    p.v_buffer = ["v0"]
+    assert _select_register_pools(p) == (["k0"], ["v0"])


### PR DESCRIPTION
## Motivation

The SGLang → LMCache multi-process (MP) offload path only handles MHA KV pools.
For MLA models (DeepSeek V2/V3/R1, GLM), `LMCRadixCache` probed
`k_buffer` / `v_buffer` via `getattr`, but `MLATokenToKVPool` fuses K and V into
a single latent `kv_buffer` per layer and exposes no `k_buffer` — so enabling
LMCache on an MLA model failed to register the KV cache correctly.

This is the SGLang half of a two-repo change. The LMCache companion is
LMCache/LMCache#4695, which teaches the LMCache MP daemon to accept the fused
single-buffer (empty-V) layout that this PR sends.

## Modifications

- `python/sglang/srt/mem_cache/storage/lmcache/lmc_radix_cache.py`: replace the
  `getattr(k_buffer/v_buffer)` private-buffer probing with a
  `_select_register_pools(kvcache)` helper that returns the `(k_pool, v_pool)`
  to register:
  - **MHA**: `(k_buffer, v_buffer)` — unchanged.
  - **MLA**: `(kv_buffer, [])` — register the fused latent buffer as K with an
    empty V pool; the LMCache daemon detects the single-buffer layout.
  - **DSA** (`DSATokenToKVPool`, a subclass of `MLATokenToKVPool`, so checked
    first): `NotImplementedError` — the separate indexer cache register path is
    a deliberate follow-up, not silently mis-registered.
- `test/srt/mem_cache/test_select_register_pools.py`: unit tests covering the
  MHA / MLA / DSA selection (CPU-only, spec-mocked pools — no KV allocation).

No change to model forward or kernels, so no accuracy/speed impact.

## Accuracy Tests

N/A — offload-path plumbing only; does not touch model outputs.

## Speed Tests and Profiling

N/A.

## Checklist

- [x] Format your code according to the Format code with pre-commit.
- [x] Add unit tests according to the Run and add unit tests.
- [ ] Update documentation.
- [ ] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32507760187](https://github.com/sgl-project/sglang/actions/runs/32507760187)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32507760082](https://github.com/sgl-project/sglang/actions/runs/32507760082)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32507760080](https://github.com/sgl-project/sglang/actions/runs/32507760080)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->