### PR TITLE
[Bugfix] Preserve non-tool JSON responses in Llama32Detector and add exist_ok to qwen3_asr AutoConfig

### DIFF
--- a/python/sglang/srt/configs/qwen3_asr.py
+++ b/python/sglang/srt/configs/qwen3_asr.py
@@ -164,5 +164,5 @@ class Qwen3ASRConfig(PretrainedConfig):
         return self.thinker_config.text_config
 
 
-AutoConfig.register("qwen3_asr", Qwen3ASRConfig)
-AutoConfig.register("qwen3_asr_thinker", Qwen3ASRThinkerConfig)
+AutoConfig.register("qwen3_asr", Qwen3ASRConfig, exist_ok=True)
+AutoConfig.register("qwen3_asr_thinker", Qwen3ASRThinkerConfig, exist_ok=True)

--- a/python/sglang/srt/function_call/llama32_detector.py
+++ b/python/sglang/srt/function_call/llama32_detector.py
@@ -104,6 +104,9 @@ class Llama32Detector(BaseFormatDetector):
 
         # Only process if we found valid JSON objects
         calls = self.parse_base_json(all_actions, tools) if all_actions else []
+        if not calls:
+            return StreamingParseResult(normal_text=text, calls=[])
+
         # Use safe_idx to avoid idx containing the last part of an invalid JSON object
         trailing_text = (
             action_text[safe_idx:].strip() if safe_idx < action_text_len else ""

--- a/test/registered/unit/function_call/test_llama32_detector.py
+++ b/test/registered/unit/function_call/test_llama32_detector.py
@@ -93,6 +93,13 @@ class TestLlama32Detector(CustomTestCase):
         self.assertEqual(len(result.calls), 0)
         self.assertEqual(result.normal_text, "The weather is nice today.")
 
+    def test_non_tool_json_object_preserved(self):
+        text = '{"answer": 42, "reason": "computed"}'
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 0)
+        self.assertEqual(result.normal_text, '{"answer": 42, "reason": "computed"}')
+
+
     def test_multiple_json_objects(self):
         text = '<|python_tag|>{"name": "get_weather", "arguments": {"city": "Beijing"}};{"name": "search", "arguments": {"query": "restaurants"}}'
         result = self.detector.detect_and_parse(text, self.tools)


### PR DESCRIPTION
## Motivation
1. In `Llama32Detector.detect_and_parse`, when a model generates a standard JSON object response (e.g. `{"answer": 42}`), `has_tool_call` detects the leading `{` and passes it to `detect_and_parse`. If the JSON does not contain tool names matching the request's registered tools, `parse_base_json` returns `calls = []`. However, `detect_and_parse` previously swallowed the input text and returned an empty string for `normal_text` instead of preserving the original content.
2. In `python/sglang/srt/configs/qwen3_asr.py`, `AutoConfig.register` was missing `exist_ok=True`, raising a `ValueError` when imported in environments where `qwen3_asr` is already registered.

## Proposed Changes
- In `Llama32Detector.detect_and_parse`, if `calls` is empty after parsing actions, return `StreamingParseResult(normal_text=text, calls=[])` so non-tool JSON outputs are fully preserved.
- Added `exist_ok=True` to `AutoConfig.register` in `qwen3_asr.py`.
- Added unit test `test_non_tool_json_object_preserved` in `test/registered/unit/function_call/test_llama32_detector.py`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32509850779](https://github.com/sgl-project/sglang/actions/runs/32509850779)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32509850461](https://github.com/sgl-project/sglang/actions/runs/32509850461)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32509850659](https://github.com/sgl-project/sglang/actions/runs/32509850659)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->