### PR TITLE
fix(health): abort the timed-out /health probe scheduler-side

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -720,6 +720,9 @@ async def health_generate(request: Request) -> Response:
         f"{HEALTH_CHECK_TIMEOUT} seconds. tic start time: {tic_time}. "
         f"last_heartbeat time: {last_receive_time}"
     )
+    # Cancelling the local task does not retract the probe from the scheduler,
+    # so abort it there before the pop: abort_request skips untracked rids.
+    _global_state.tokenizer_manager.abort_request(rid=rid)
     _global_state.tokenizer_manager.rid_to_state.pop(rid, None)
     _global_state.tokenizer_manager.server_status = ServerStatus.UnHealthy
     return Response(status_code=503)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -266,6 +266,7 @@ from sglang.srt.managers.utils import (
     EmbeddingBatchResult,
     GenerationBatchResult,
     is_health_check_generate_req,
+    is_health_check_probe,
     validate_input_length,
 )
 from sglang.srt.mem_cache import kv_cache_builder
@@ -1912,7 +1913,7 @@ class Scheduler(
 
         for recv_req in recv_reqs:
             # Skip health check when server is busy — ongoing requests already carry health info.
-            if is_health_check_generate_req(recv_req) and not self.is_fully_idle(
+            if is_health_check_probe(recv_req) and not self.is_fully_idle(
                 for_health_check=True
             ):
                 self.return_health_check_ipcs.append(

--- a/python/sglang/srt/managers/utils.py
+++ b/python/sglang/srt/managers/utils.py
@@ -325,6 +325,15 @@ def is_health_check_generate_req(recv_req):
     return rid is not None and rid.startswith(HEALTH_CHECK_RID_PREFIX)
 
 
+def is_health_check_probe(recv_req) -> bool:
+    # Only a probe may be dropped while the scheduler is busy; the AbortReq that
+    # retracts one carries the same rid, so the prefix alone cannot separate them.
+    return isinstance(
+        recv_req,
+        (io_struct.TokenizedGenerateReqInput, io_struct.TokenizedEmbeddingReqInput),
+    ) and is_health_check_generate_req(recv_req)
+
+
 class MsgpackDecodeError(ValueError):
     """A msgpack frame the typed decoder rejected, with the failure explained:
     ``rid`` (when recoverable from the raw tagged array) and a human-readable

--- a/test/registered/unit/entrypoints/test_health_check_abort.py
+++ b/test/registered/unit/entrypoints/test_health_check_abort.py
@@ -1,0 +1,87 @@
+"""Unit tests for /health_generate probe cancellation — no server, no model loading."""
+
+import asyncio
+import time
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.srt.constants import HEALTH_CHECK_RID_PREFIX
+from sglang.srt.entrypoints.http_server import health_generate
+from sglang.srt.managers.tokenizer_manager import ServerStatus
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+HTTP_SERVER = "sglang.srt.entrypoints.http_server"
+
+
+class FakeTokenizerManager:
+    """A tokenizer manager whose probe never comes back, as during a scheduler stall."""
+
+    def __init__(self, *, responsive: bool):
+        self.gracefully_exit = False
+        self.server_status = ServerStatus.Up
+        self.is_generation = True
+        self.rid_to_state = {}
+        self.aborted = []
+        self._responsive = responsive
+
+    @property
+    def last_receive_tstamp(self) -> float:
+        # A responsive server has some output land after the handler's tic.
+        return time.time() if self._responsive else 0.0
+
+    async def generate_request(self, obj, request):
+        self.rid_to_state[obj.rid] = SimpleNamespace(obj=obj)
+        await asyncio.Event().wait()  # the probe never completes
+        yield {}
+
+    def abort_request(self, rid: str = "", abort_all: bool = False):
+        # abort_request short-circuits on rids already gone from rid_to_state,
+        # so record whether the handler aborted before dropping its local state.
+        self.aborted.append((rid, rid in self.rid_to_state))
+
+
+class TestHealthGenerateProbeCancellation(CustomTestCase):
+    async def _run_health_generate(self, *, responsive: bool):
+        tokenizer_manager = FakeTokenizerManager(responsive=responsive)
+        global_state = SimpleNamespace(tokenizer_manager=tokenizer_manager)
+        request = SimpleNamespace(url=SimpleNamespace(path="/health_generate"))
+
+        disagg = SimpleNamespace(disaggregation_mode="null")
+        with (
+            patch(f"{HTTP_SERVER}._global_state", global_state),
+            patch(f"{HTTP_SERVER}.HEALTH_CHECK_TIMEOUT", 0.1),
+            patch(f"{HTTP_SERVER}.get_disagg", lambda: disagg),
+        ):
+            response = await health_generate(request)
+
+        return tokenizer_manager, response
+
+    def test_timed_out_probe_is_aborted_scheduler_side(self):
+        """A failed health check leaves no probe running in the scheduler."""
+        tokenizer_manager, response = asyncio.run(
+            self._run_health_generate(responsive=False)
+        )
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(len(tokenizer_manager.aborted), 1)
+        rid, still_tracked = tokenizer_manager.aborted[0]
+        self.assertTrue(rid.startswith(HEALTH_CHECK_RID_PREFIX))
+        self.assertTrue(still_tracked, "abort must precede the rid_to_state pop")
+        self.assertNotIn(rid, tokenizer_manager.rid_to_state)
+
+    def test_healthy_server_does_not_abort(self):
+        """A live server completes its own probe; aborting would only add IPC noise."""
+        tokenizer_manager, response = asyncio.run(
+            self._run_health_generate(responsive=True)
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(tokenizer_manager.aborted, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_health_check_probe.py
+++ b/test/registered/unit/managers/test_health_check_probe.py
@@ -1,0 +1,70 @@
+"""Unit tests for health-check probe classification — no server, no model loading."""
+
+import unittest
+
+from sglang.srt.constants import HEALTH_CHECK_RID_PREFIX
+from sglang.srt.managers.io_struct import (
+    AbortReq,
+    TokenizedEmbeddingReqInput,
+    TokenizedGenerateReqInput,
+)
+from sglang.srt.managers.utils import (
+    is_health_check_generate_req,
+    is_health_check_probe,
+)
+from sglang.srt.sampling.sampling_params import SamplingParams
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+HEALTH_CHECK_RID = f"{HEALTH_CHECK_RID_PREFIX}_0123456789abcdef"
+
+
+def _generate_probe(rid: str) -> TokenizedGenerateReqInput:
+    return TokenizedGenerateReqInput(
+        rid=rid,
+        input_text=None,
+        input_ids=None,
+        input_embeds=None,
+        mm_inputs=None,
+        token_type_ids=None,
+        sampling_params=SamplingParams(max_new_tokens=1, temperature=0.0),
+        return_logprob=False,
+        logprob_start_len=-1,
+        top_logprobs_num=0,
+        token_ids_logprob=None,
+        stream=False,
+    )
+
+
+def _embedding_probe(rid: str) -> TokenizedEmbeddingReqInput:
+    return TokenizedEmbeddingReqInput(
+        rid=rid,
+        input_text=None,
+        input_ids=None,
+        mm_inputs=None,
+        token_type_ids=None,
+        sampling_params=SamplingParams(max_new_tokens=1, temperature=0.0),
+    )
+
+
+class TestIsHealthCheckProbe(CustomTestCase):
+    def test_matches_generate_and_embedding_probes(self):
+        self.assertTrue(is_health_check_probe(_generate_probe(HEALTH_CHECK_RID)))
+        self.assertTrue(is_health_check_probe(_embedding_probe(HEALTH_CHECK_RID)))
+
+    def test_ignores_ordinary_requests(self):
+        self.assertFalse(is_health_check_probe(_generate_probe("ordinary-rid")))
+        self.assertFalse(is_health_check_probe(_embedding_probe("ordinary-rid")))
+
+    def test_ignores_abort_of_a_probe(self):
+        """The scheduler drops probes while busy; it must never drop their aborts."""
+        abort = AbortReq(rid=HEALTH_CHECK_RID)
+
+        self.assertTrue(is_health_check_generate_req(abort))
+        self.assertFalse(is_health_check_probe(abort))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #35884.

`health_generate` sends a real one-token request to the scheduler, then gives up after `SGLANG_HEALTH_CHECK_TIMEOUT`. `task.cancel()` only cancels the local asyncio task — the request already went over IPC and keeps running scheduler-side. A poller at the timeout interval (Docker's default `HEALTHCHECK --interval=20s` against the default 20s) then adds a fresh probe every poll while the earlier ones are still resident. The reporter saw ~5 pile up during a 2-minute stall, and batching them crashed paged prefill with `q.shape[0] (1) does not match qo_indptr[-1] (5)`.

Aborting isn't enough on its own. `is_health_check_generate_req` matches on the rid prefix and `AbortReq` inherits `rid` from `BaseReq`, so the abort for a probe is itself read as a probe and dropped by the busy-skip in `process_input_requests` — exactly when the scheduler is busy holding the orphan it should retract.

## Modifications

- `entrypoints/http_server.py`: on timeout, abort the probe's rid before popping `rid_to_state`.
- `managers/utils.py`: add `is_health_check_probe()`, which also requires a `TokenizedGenerateReqInput` / `TokenizedEmbeddingReqInput`. The rid-only predicate stays for its other two callers, which pass `Req` and `AbortReq` and want the looser match.
- `managers/scheduler.py`: use it for the busy-skip.
- `test/registered/unit/`: abort on timeout, no abort on success, and the `AbortReq` classification. Verified red before the fix (`AssertionError: 0 != 1` on the abort count).

## Accuracy Tests

N/A — no kernel, model forward, or sampling changes.

## Speed Tests and Profiling

N/A. The abort runs only on the timeout path, at most once per failed poll.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Notes

- The success path deliberately doesn't abort — a server that answered completes its own probe, and a busy scheduler never admits one. Happy to make it symmetric if you'd rather.
- Doesn't touch the paged-prefill shape mismatch itself, which may well be separate — see #34239.
- The encoder health handler runs an in-process encode behind a dispatch lock, not IPC dispatch, so it's unaffected.
<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32510634068](https://github.com/sgl-project/sglang/actions/runs/32510634068)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32510633962](https://github.com/sgl-project/sglang/actions/runs/32510633962)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32510633973](https://github.com/sgl-project/sglang/actions/runs/32510633973)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
