### PR TITLE
[MoonEP] Log host capacity utilization

### DIFF
--- a/python/sglang/srt/batch_overlap/two_batch_overlap.py
+++ b/python/sglang/srt/batch_overlap/two_batch_overlap.py
@@ -27,8 +27,8 @@ from sglang.srt.layers.moe import (
 )
 from sglang.srt.layers.moe.token_dispatcher import (
     DeepEPDispatcher,
-    MoonEPDispatcher,
     MooncakeEPDispatcher,
+    MoonEPDispatcher,
     MoriEPDispatcher,
     NixlEPDispatcher,
     PplxDispatcher,
@@ -1071,7 +1071,7 @@ def _model_forward_tbo_merge_outputs(output_a, output_b, original_len):
 
 
 class MaybeTboDeepEPDispatcher(BaseDispatcher):
-    def __init__(self, **kwargs):
+    def __init__(self, layer_id: Optional[int] = None, **kwargs):
         super().__init__()
         num_inner_dispatchers = 2 if is_tbo_enabled() else 1
         if get_moe_a2a_backend().is_deepep():
@@ -1080,7 +1080,8 @@ class MaybeTboDeepEPDispatcher(BaseDispatcher):
             ]
         elif get_moe_a2a_backend().is_moonep():
             self._inners = [
-                MoonEPDispatcher(**kwargs) for _ in range(num_inner_dispatchers)
+                MoonEPDispatcher(layer_id=layer_id, **kwargs)
+                for _ in range(num_inner_dispatchers)
             ]
         elif get_moe_a2a_backend().is_mooncake():
             self._inners = [

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -34,14 +34,10 @@ from sglang.srt.layers.moe.kt_ep_wrapper import (
     create_kt_config_from_server_args,
 )
 from sglang.srt.layers.moe.token_dispatcher import CombineInput, DispatchOutput
-from sglang.srt.layers.moe.token_dispatcher.ascend_tp import (
-    AscendTPDispatcher,
-)
+from sglang.srt.layers.moe.token_dispatcher.ascend_tp import AscendTPDispatcher
 from sglang.srt.layers.moe.token_dispatcher.base import BaseDispatcher
 from sglang.srt.layers.moe.token_dispatcher.flashinfer import FlashinferDispatcher
-from sglang.srt.layers.moe.token_dispatcher.standard import (
-    StandardDispatcher,
-)
+from sglang.srt.layers.moe.token_dispatcher.standard import StandardDispatcher
 from sglang.srt.layers.moe.topk import (
     BypassedTopKOutput,
     StandardTopKOutput,
@@ -166,6 +162,7 @@ def create_moe_dispatcher(moe_runner_config: MoeRunnerConfig) -> BaseDispatcher:
             deepep_mode=get_deepep_mode(),
             async_finish=True,
             return_recv_hook=True,
+            layer_id=moe_runner_config.layer_id,
         )
     elif a2a_backend.is_flashinfer():
         return FlashinferDispatcher(

--- a/python/sglang/srt/layers/moe/token_dispatcher/moonep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/moonep.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import Any, NamedTuple, NoReturn, Optional
 
@@ -8,6 +9,7 @@ import torch.distributed as dist
 import torch.nn.functional as F
 
 from sglang.srt.environ import envs
+from sglang.srt.layers.dp_attention import get_is_extend_in_batch
 from sglang.srt.layers.moe.token_dispatcher.base import (
     BaseDispatcher,
     CombineInput,
@@ -15,9 +17,10 @@ from sglang.srt.layers.moe.token_dispatcher.base import (
     DispatchOutput,
     DispatchOutputFormat,
 )
-from sglang.srt.layers.moe.topk import TopKOutput
-from sglang.srt.layers.moe.topk import TopKOutputChecker
+from sglang.srt.layers.moe.topk import TopKOutput, TopKOutputChecker
 from sglang.srt.layers.moe.utils import DeepEPMode
+
+logger = logging.getLogger(__name__)
 
 
 _MOONEP_UNSUPPORTED_MESSAGE = (
@@ -451,9 +454,7 @@ def run_moonep_bf16_expert(
             f"shape {cu_seqlens.shape}"
         )
     if route_weights_nvs is not None and route_weights_nvs.ndim != 1:
-        raise ValueError(
-            f"route_weights_nvs must be 1D, got {route_weights_nvs.shape}"
-        )
+        raise ValueError(f"route_weights_nvs must be 1D, got {route_weights_nvs.shape}")
 
     output = torch.empty_like(hidden_states)
     prev = 0
@@ -511,7 +512,10 @@ class MoonEPDispatcher(BaseDispatcher):
         deepep_mode: DeepEPMode = DeepEPMode.AUTO,
         async_finish: bool = False,
         return_recv_hook: bool = False,
+        layer_id: int | None = None,
     ):
+        if layer_id is None:
+            raise ValueError("MoonEPDispatcher requires layer_id for capacity logging.")
         super().__init__()
         self.group = group
         self.router_topk = router_topk
@@ -523,6 +527,7 @@ class MoonEPDispatcher(BaseDispatcher):
         self.deepep_mode = deepep_mode
         self.async_finish = async_finish
         self.return_recv_hook = return_recv_hook
+        self.layer_id = layer_id
         self.expert_mask_gpu = None
         self.num_max_dispatch_tokens_per_rank = (
             envs.SGLANG_MOONEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK.get()
@@ -567,6 +572,21 @@ class MoonEPDispatcher(BaseDispatcher):
                 "MoonEP runtime batch has more tokens than its static buffer "
                 f"capacity: num_tokens={num_tokens}, capacity={capacity}. "
                 "Increase SGLANG_MOONEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK."
+            )
+
+        if capacity > 0 and logger.isEnabledFor(logging.DEBUG):
+            padding_tokens = capacity - num_tokens
+            logger.debug(
+                "phase=%s rank=%s layer_id=%s actual_tokens=%s capacity=%s "
+                "padding_tokens=%s capacity_utilization=%s static_padding_ratio=%s",
+                "extend" if get_is_extend_in_batch() else "decode",
+                self._get_rank(),
+                self.layer_id,
+                num_tokens,
+                capacity,
+                padding_tokens,
+                num_tokens / capacity,
+                padding_tokens / capacity,
             )
 
         hidden_states = hidden_states.contiguous()

--- a/scripts/moonep/validate_moonep_bf16_poc.py
+++ b/scripts/moonep/validate_moonep_bf16_poc.py
@@ -16,10 +16,10 @@ rank-local PyTorch reference using the same top-k and expert weights.
 from __future__ import annotations
 
 import argparse
-from enum import IntEnum, auto
 import json
 import os
 import sys
+from enum import IntEnum, auto
 from pathlib import Path
 from types import ModuleType
 from typing import NamedTuple, Protocol, TypeGuard, runtime_checkable
@@ -248,6 +248,7 @@ def main() -> None:
         num_local_experts=args.experts_per_rank,
         hidden_size=args.hidden_size,
         params_dtype=torch.bfloat16,
+        layer_id=0,
     )
 
     dispatch_output = dispatcher.dispatch(hidden, topk_output)
@@ -257,21 +258,27 @@ def main() -> None:
     # The production path should replace this with true symmetric expert-row
     # mappings whose physical storage is owned by each expert's home rank.
     torch.manual_seed(args.seed)
-    gate = torch.randn(
-        num_experts + num_prefetch_slots,
-        args.intermediate_size,
-        args.hidden_size,
-        device=device,
-        dtype=torch.bfloat16,
-    ) / 8
+    gate = (
+        torch.randn(
+            num_experts + num_prefetch_slots,
+            args.intermediate_size,
+            args.hidden_size,
+            device=device,
+            dtype=torch.bfloat16,
+        )
+        / 8
+    )
     up = torch.randn_like(gate) / 8
-    down = torch.randn(
-        num_experts + num_prefetch_slots,
-        args.hidden_size,
-        args.intermediate_size,
-        device=device,
-        dtype=torch.bfloat16,
-    ) / 8
+    down = (
+        torch.randn(
+            num_experts + num_prefetch_slots,
+            args.hidden_size,
+            args.intermediate_size,
+            device=device,
+            dtype=torch.bfloat16,
+        )
+        / 8
+    )
     gate[num_experts:].zero_()
     up[num_experts:].zero_()
     down[num_experts:].zero_()

--- a/test/registered/unit/layers/moe/test_moonep_buffer.py
+++ b/test/registered/unit/layers/moe/test_moonep_buffer.py
@@ -7,14 +7,18 @@ from unittest.mock import patch
 import torch
 
 from sglang.srt.environ import envs
+from sglang.srt.layers.moe import DeepEPMode, MoeA2ABackend, MoeRunnerConfig
+from sglang.srt.layers.moe.fused_moe_triton.layer import create_moe_dispatcher
 from sglang.srt.layers.moe.token_dispatcher.moonep import (
     MoonEPBuffer,
+    MoonEPDispatcher,
     MoonEPDispatchOutput,
     MoonEPExpertWeightLayout,
     get_moonep_expert_weight_layout,
     run_moonep_bf16_expert,
 )
-from sglang.srt.runtime_context import reset_context
+from sglang.srt.layers.moe.topk import StandardTopKOutput
+from sglang.srt.runtime_context import get_flags, get_forward, reset_context
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=3, suite="base-a-test-cpu")
@@ -31,6 +35,21 @@ class _FakeMoonEPBuffer:
     def destroy(self):
         self.destroy_calls += 1
 
+    def dispatch(
+        self,
+        hidden_states,
+        topk_weights,
+        topk_ids,
+        tokens_per_expert,
+        async_finish,
+    ):
+        return (
+            hidden_states,
+            topk_weights.reshape(-1),
+            torch.tensor([hidden_states.shape[0]], dtype=torch.int32),
+            SimpleNamespace(experts_to_copy=torch.empty(0, dtype=torch.int32)),
+        )
+
 
 def _fake_moonep_module():
     module = types.ModuleType("moonep")
@@ -38,7 +57,7 @@ def _fake_moonep_module():
     return module
 
 
-class TestMoonEPBuffer(unittest.TestCase):
+class _MoonEPBufferTestCase(unittest.TestCase):
     def setUp(self):
         reset_context()
         _FakeMoonEPBuffer.instances.clear()
@@ -50,6 +69,8 @@ class TestMoonEPBuffer(unittest.TestCase):
             reset_context()
             _FakeMoonEPBuffer.instances.clear()
 
+
+class TestMoonEPBuffer(_MoonEPBufferTestCase):
     def test_lazily_constructs_and_reuses_buffer_for_static_key(self):
         group = object()
 
@@ -178,6 +199,171 @@ class TestMoonEPBuffer(unittest.TestCase):
         self.assertIsNone(MoonEPBuffer.get_existing_buffer())
 
 
+class TestMoonEPCapacityLogging(_MoonEPBufferTestCase):
+    LOGGER_NAME = "sglang.srt.layers.moe.token_dispatcher.moonep"
+    LOG_PREFIX = f"DEBUG:{LOGGER_NAME}:"
+
+    @staticmethod
+    def _make_dispatch_inputs(num_tokens):
+        hidden_states = torch.ones((num_tokens, 3), dtype=torch.bfloat16)
+        topk_output = StandardTopKOutput(
+            topk_weights=torch.ones((num_tokens, 2), dtype=torch.float32),
+            topk_ids=torch.arange(num_tokens * 2, dtype=torch.int64).reshape(
+                num_tokens, 2
+            )
+            % 4,
+            router_logits=torch.empty((num_tokens, 4), dtype=torch.float32),
+        )
+        return hidden_states, topk_output
+
+    @staticmethod
+    def _make_dispatcher(capacity, layer_id):
+        with envs.SGLANG_MOONEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK.override(capacity):
+            return MoonEPDispatcher(
+                group=object(),
+                router_topk=2,
+                num_experts=4,
+                hidden_size=3,
+                layer_id=layer_id,
+            )
+
+    def _dispatch_and_capture(
+        self,
+        dispatcher,
+        hidden_states,
+        topk_output,
+        *,
+        rank,
+        is_extend_in_batch,
+    ):
+        with (
+            patch.dict(sys.modules, {"moonep": _fake_moonep_module()}),
+            patch(
+                "sglang.srt.layers.moe.token_dispatcher.moonep.dist.get_world_size",
+                return_value=1,
+            ),
+            patch(
+                "sglang.srt.layers.moe.token_dispatcher.moonep.dist.get_rank",
+                return_value=rank,
+            ),
+            get_forward().scoped(is_extend_in_batch=is_extend_in_batch),
+            self.assertLogs(self.LOGGER_NAME, level="DEBUG") as captured,
+        ):
+            dispatcher.dispatch(
+                hidden_states=hidden_states,
+                topk_output=topk_output,
+            )
+        return captured.output
+
+    def test_dispatcher_requires_layer_id_for_attributable_logs(self):
+        with self.assertRaisesRegex(ValueError, "requires layer_id"):
+            MoonEPDispatcher(
+                group=object(),
+                router_topk=2,
+                num_experts=4,
+                hidden_size=3,
+            )
+
+    def test_partial_extend_dispatch_logs_host_capacity_utilization(self):
+        dispatcher = self._make_dispatcher(capacity=4, layer_id=7)
+        hidden_states, topk_output = self._make_dispatch_inputs(num_tokens=2)
+
+        captured = self._dispatch_and_capture(
+            dispatcher,
+            hidden_states,
+            topk_output,
+            rank=3,
+            is_extend_in_batch=True,
+        )
+
+        self.assertEqual(
+            captured,
+            [
+                self.LOG_PREFIX
+                + "phase=extend rank=3 layer_id=7 actual_tokens=2 capacity=4 "
+                "padding_tokens=2 capacity_utilization=0.5 "
+                "static_padding_ratio=0.5"
+            ],
+        )
+
+    def test_factory_threads_layer_id_into_decode_capacity_log(self):
+        group = object()
+        config = MoeRunnerConfig(
+            num_experts=4,
+            num_local_experts=4,
+            hidden_size=3,
+            layer_id=11,
+            top_k=2,
+            params_dtype=torch.bfloat16,
+        )
+        hidden_states, topk_output = self._make_dispatch_inputs(num_tokens=2)
+
+        with (
+            envs.SGLANG_MOONEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK.override(4),
+            get_flags().moe.override(
+                a2a_backend=MoeA2ABackend.MOONEP,
+                deepep_mode=DeepEPMode.AUTO,
+                tbo_enabled=False,
+            ),
+            patch(
+                "sglang.srt.layers.moe.fused_moe_triton.layer._get_deepep_comm_group",
+                return_value=group,
+            ),
+        ):
+            dispatcher = create_moe_dispatcher(config)
+
+        captured = self._dispatch_and_capture(
+            dispatcher,
+            hidden_states,
+            topk_output,
+            rank=0,
+            is_extend_in_batch=False,
+        )
+
+        self.assertEqual(
+            captured,
+            [
+                self.LOG_PREFIX
+                + "phase=decode rank=0 layer_id=11 actual_tokens=2 capacity=4 "
+                "padding_tokens=2 capacity_utilization=0.5 "
+                "static_padding_ratio=0.5"
+            ],
+        )
+
+    def test_full_capacity_dispatch_logs_zero_padding(self):
+        dispatcher = self._make_dispatcher(capacity=2, layer_id=5)
+        hidden_states, topk_output = self._make_dispatch_inputs(num_tokens=2)
+
+        captured = self._dispatch_and_capture(
+            dispatcher,
+            hidden_states,
+            topk_output,
+            rank=1,
+            is_extend_in_batch=False,
+        )
+
+        self.assertEqual(
+            captured,
+            [
+                self.LOG_PREFIX
+                + "phase=decode rank=1 layer_id=5 actual_tokens=2 capacity=2 "
+                "padding_tokens=0 capacity_utilization=1.0 "
+                "static_padding_ratio=0.0"
+            ],
+        )
+
+    def test_over_capacity_dispatch_raises_without_capacity_log(self):
+        dispatcher = self._make_dispatcher(capacity=4, layer_id=5)
+        hidden_states, topk_output = self._make_dispatch_inputs(num_tokens=5)
+
+        with (
+            get_forward().scoped(is_extend_in_batch=True),
+            self.assertNoLogs(self.LOGGER_NAME, level="DEBUG"),
+            self.assertRaisesRegex(ValueError, "more tokens than its static buffer"),
+        ):
+            dispatcher.dispatch(hidden_states, topk_output)
+
+
 class TestMoonEPExpertWeightLayout(unittest.TestCase):
     def _fake_layer(self):
         num_experts, hidden_size, intermediate_size = 3, 4, 5
@@ -289,9 +475,7 @@ class TestMoonEPBf16ExpertRunner(unittest.TestCase):
         for start, end, expert in [(0, 2, 0), (2, 3, 1)]:
             x = hidden_states[start:end]
             y = torch.nn.functional.linear(
-                torch.nn.functional.silu(
-                    torch.nn.functional.linear(x, gate[expert])
-                )
+                torch.nn.functional.silu(torch.nn.functional.linear(x, gate[expert]))
                 * torch.nn.functional.linear(x, up[expert]),
                 down[expert],
             )


### PR DESCRIPTION
## Summary

- add per-dispatch DEBUG key=value logs for phase, rank, layer, token capacity, padding, utilization, and static padding ratio
- thread MoeRunnerConfig.layer_id only into the MoonEP inner dispatcher and reject missing layer identity
- preserve the existing over-capacity ValueError without emitting a normal capacity record

## Scope

This is the independent host-side capacity-observability slice from #35783. It is based directly on the moonep branch and does not depend on #35834 or #34874.

Duplicated-expert statistics, prefetch volume, metrics aggregation, symmetric-pool lifecycle, and GPU/protocol work remain follow-ups.

## Testing

- 13 focused CPU tests in test_moonep_buffer.py
- Ruff 0.15.1: F401, F821, UP037
- isort 7.0.0
- Black 26.1.0
- registered-test registry check

Part of #35783.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32511192256](https://github.com/sgl-project/sglang/actions/runs/32511192256)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32511192175](https://github.com/sgl-project/sglang/actions/runs/32511192175)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32511192671](https://github.com/sgl-project/sglang/actions/runs/32511192671)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->