### PR TITLE
[Spec] Enable adaptive speculative decoding under DP attention

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -2134,6 +2134,9 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
     is_extend_in_batch: bool = False
     can_run_dp_cuda_graph: bool = False
     can_run_dp_breakable_cuda_graph: bool = False
+    # DP-consensus adaptive speculative num_steps (min across ranks); None when
+    # adaptive spec is off or no rank expressed a tier this round.
+    adaptive_consensus_steps: Optional[int] = None
     tbo_split_seq_index: Optional[int] = None
     # Rank-consistent forward mode for the recv skipper, derived from the MLP
     # sync all-gather (the TBO-only `global_forward_mode` is None without TBO).

--- a/python/sglang/srt/managers/scheduler_components/dp_attn.py
+++ b/python/sglang/srt/managers/scheduler_components/dp_attn.py
@@ -76,6 +76,11 @@ def _resolve_elastic_world_dp_size(
     return live_dp_size
 
 
+# Sentinel emitted by ranks that are idle or not running adaptive spec, so a
+# `.min()` reduce never lets them force everyone to a lower speculative tier.
+ADAPTIVE_STEPS_SENTINEL = 2**31 - 1
+
+
 @dataclass
 class MLPSyncBatchInfo:
     dp_size: int
@@ -89,9 +94,15 @@ class MLPSyncBatchInfo:
     is_extend_in_batch: bool
     local_can_run_tbo: bool
     local_forward_mode: int
+    # Locally-desired adaptive speculative num_steps for this rank's batch.
+    # Gathered and min-reduced so every DP rank runs the same tier (equal
+    # draft-token shapes → no NCCL buffer mismatch). Sentinel = no preference.
+    local_adaptive_steps: int = ADAPTIVE_STEPS_SENTINEL
 
     # some gathered elements
     tp0_info_cpu: torch.Tensor = None
+    # min-reduced consensus tier across DP ranks; sentinel if none expressed.
+    consensus_adaptive_steps: int = ADAPTIVE_STEPS_SENTINEL
     global_num_tokens: list[int] = None
     global_num_tokens_for_logprob: list[int] = None
     tbo_split_seq_index: torch.Tensor = None
@@ -108,6 +119,7 @@ class MLPSyncBatchInfo:
                 int(self.local_can_run_tbo),
                 self.local_forward_mode,
                 int(self.can_run_prefill_cuda_graph),
+                self.local_adaptive_steps,
             ],
             device=device,
             dtype=dtype,
@@ -123,6 +135,7 @@ class MLPSyncBatchInfo:
                 1,  # local_can_run_tbo
                 ForwardMode.IDLE.value,  # local_forward_mode
                 0,  # can_run_prefill_cuda_graph
+                ADAPTIVE_STEPS_SENTINEL,  # local_adaptive_steps (idle: no vote)
             ],
             device=device,
             dtype=dtype,
@@ -194,6 +207,9 @@ class MLPSyncBatchInfo:
         self.can_run_decode_cuda_graph = bool(tp0_info_cpu[:, 2].min())
         self.is_extend_in_batch = bool(tp0_info_cpu[:, 3].max())
         self.can_run_prefill_cuda_graph = bool(tp0_info_cpu[:, 6].min())
+        # Smaller tier is always a valid shape for every rank; larger is not.
+        # Idle/non-adaptive ranks emit the sentinel and never win the min.
+        self.consensus_adaptive_steps = int(tp0_info_cpu[:, 7].min())
         if _ENABLE_METRICS_DP_ATTENTION:
             self.dp_cooperation_info = DPCooperationInfo.create(
                 tp0_info_cpu[:, 5].tolist()
@@ -321,6 +337,19 @@ def prepare_mlp_sync_batch_raw(
         group = tp_group.cpu_group
         device = "cpu"
 
+    # Each rank votes its locally-desired adaptive tier; min-reduced below so
+    # all ranks run identical draft-token shapes (no NCCL buffer mismatch).
+    local_adaptive_steps = ADAPTIVE_STEPS_SENTINEL
+    adaptive_params = getattr(model_runner, "adaptive_spec_params", None)
+    if (
+        adaptive_params is not None
+        and local_batch is not None
+        and local_batch.forward_mode.is_decode()
+    ):
+        local_adaptive_steps = adaptive_params.get_steps_for_batch(
+            local_batch.batch_size()
+        )
+
     local_can_run_tbo, local_forward_mode = tbo_preparer.prepare_all_gather(local_batch)
     if use_world_group:
         dp_size = _resolve_elastic_world_dp_size(
@@ -341,6 +370,7 @@ def prepare_mlp_sync_batch_raw(
         is_extend_in_batch=is_extend_in_batch,
         local_can_run_tbo=local_can_run_tbo,
         local_forward_mode=local_forward_mode,
+        local_adaptive_steps=local_adaptive_steps,
     )
 
     if not skip_all_gather:
@@ -376,13 +406,26 @@ def prepare_mlp_sync_batch_raw(
             batch_to_gather, mlp_sync_info, require_mlp_tp_gather, skip_all_gather
         )
 
-    # Set on `local_batch`, not `batch_to_gather`: for PREBUILT batches the
-    # scheduler's `last_batch` is the prebuilt batch, not its inner idle batch.
+    # recv_skipper is read by the scheduler from `last_batch`, which for a
+    # PREBUILT batch is the prebuilt batch itself (not its inner idle batch) —
+    # so this field must live on `local_batch`.
     if local_batch is not None and not skip_all_gather:
         local_batch.recv_skipper_forward_mode = (
             SchedulerRecvSkipper.derive_forward_mode(
                 mlp_sync_info.tp0_info_cpu[:, 5].tolist()
             )
+        )
+
+    # DP-consensus adaptive tier for this round; None when no rank expressed one
+    # (all sentinel) → worker falls back to local batch-size routing. This is
+    # read by the worker from the batch it actually forwards, so it must live on
+    # `batch_to_gather` — for a PREBUILT batch that is the inner idle batch, not
+    # `local_batch`. Writing it to `local_batch` would leave the forwarded idle
+    # batch at None and let ranks diverge on num_draft_tokens (NCCL hang).
+    if batch_to_gather is not None and not skip_all_gather:
+        consensus = mlp_sync_info.consensus_adaptive_steps
+        batch_to_gather.adaptive_consensus_steps = (
+            consensus if consensus < ADAPTIVE_STEPS_SENTINEL else None
         )
 
     if _ENABLE_METRICS_DP_ATTENTION and local_batch is not None:

--- a/python/sglang/srt/speculative/adaptive_runtime_state.py
+++ b/python/sglang/srt/speculative/adaptive_runtime_state.py
@@ -71,13 +71,22 @@ class AdaptiveController:
       2. Call on_verify_complete(num_correct_drafts_per_req) after each decode verify.
     """
 
-    def __init__(self, worker: AdaptiveSpecWorker, config_path: str | None = None):
+    def __init__(
+        self,
+        worker: AdaptiveSpecWorker,
+        config_path: str | None = None,
+        sync_across_dp: bool = False,
+    ):
         self.worker = worker
         self.params = AdaptiveSpeculativeParams(
             initial_steps=worker.speculative_num_steps,
             cfg_path=config_path,
         )
         self._states: dict[int, SpecRuntimeState] = {}
+        # Under DP attention the tier swap is driven by a cross-rank consensus
+        # (dp_attn min-reduce) so all ranks keep equal draft-token shapes. The
+        # local EMA path must then only *update* params, never swap directly.
+        self.sync_across_dp = sync_across_dp
 
     @property
     def candidate_steps(self) -> list[int]:
@@ -115,14 +124,25 @@ class AdaptiveController:
         if target != self.worker.speculative_num_steps:
             self._activate(target)
 
+    def activate_step(self, speculative_num_steps: int) -> None:
+        """Activate an externally-decided tier (e.g. the DP-consensus step)."""
+        if speculative_num_steps != self.worker.speculative_num_steps:
+            self._activate(speculative_num_steps)
+
     def on_verify_complete(
         self, num_correct_drafts_per_req: list[int], batch_size: int
     ) -> None:
-        """Feed verify results; switch runtime state if EMA warrants it."""
+        """Feed verify results; switch runtime state if EMA warrants it.
+
+        Under DP attention only the EMA is updated here — the actual tier swap
+        is deferred to the next round's cross-rank consensus, so a rank never
+        swaps out of lockstep with its peers (which would mismatch draft-token
+        shapes and hang the DP collective).
+        """
         new_step = self.params.on_verify_complete(
             num_correct_drafts_per_req, batch_size
         )
-        if new_step is not None:
+        if new_step is not None and not self.sync_across_dp:
             self._activate(new_step)
 
     def _activate(self, speculative_num_steps: int) -> None:

--- a/python/sglang/srt/speculative/adaptive_spec_params.py
+++ b/python/sglang/srt/speculative/adaptive_spec_params.py
@@ -64,11 +64,10 @@ def adaptive_unsupported_reason(server_args: ServerArgs) -> str | None:
             f"speculative_eagle_topk={server_args.speculative_eagle_topk} "
             "(only topk=1 is supported)"
         )
-    if resolved_view(server_args).enable_dp_attention:
-        return (
-            "enable_dp_attention=True is not supported "
-            "(adaptive tier decisions are not synchronized across DP ranks)"
-        )
+    # enable_dp_attention IS supported: tier decisions are synchronized across
+    # DP ranks via a min-reduce in the scheduler's MLP-sync all_gather
+    # (dp_attn.MLPSyncBatchInfo.local_adaptive_steps), so all ranks run equal
+    # draft-token shapes. See AdaptiveController(sync_across_dp=...).
     if resolved_view(server_args).enable_multi_layer_eagle:
         return (
             "enable_multi_layer_eagle=True is not supported "

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -1047,6 +1047,7 @@ class EAGLEWorkerV2(BaseSpecWorker):
             self.adaptive_controller = AdaptiveController(
                 self,
                 config_path=server_args.speculative_adaptive_config,
+                sync_across_dp=server_args.enable_dp_attention,
             )
 
         # Some dummy tensors
@@ -1104,6 +1105,12 @@ class EAGLEWorkerV2(BaseSpecWorker):
                         else get_exec().graph.cuda_graph_bs_decode
                     ),
                 )
+            # Expose the (live, EMA-updated) router on the target model_runner so
+            # the scheduler's DP MLP-sync can gather each rank's desired tier and
+            # min-reduce it into a cross-rank consensus (see dp_attn.py).
+            self._target_worker.model_runner.adaptive_spec_params = (
+                self.adaptive_controller.params
+            )
 
     def forward_batch_generation(
         self, batch: ScheduleBatch, on_publish=None, grammar_barrier=None
@@ -1145,7 +1152,13 @@ class EAGLEWorkerV2(BaseSpecWorker):
                 )
                 return batch_output
         else:
-            self.activate_step_by_batch(batch.seq_lens.shape[0])
+            # Under DP attention the tier was agreed across ranks during the
+            # scheduler's MLP-sync all_gather; honor that consensus so every
+            # rank runs identical draft-token shapes. Otherwise route locally.
+            if batch.adaptive_consensus_steps is not None:
+                self.activate_step(batch.adaptive_consensus_steps)
+            else:
+                self.activate_step_by_batch(batch.seq_lens.shape[0])
 
             if batch.spec_info is None:
                 capture_mode = (
@@ -1298,6 +1311,10 @@ class EAGLEWorkerV2(BaseSpecWorker):
     def activate_step_by_batch(self, batch_size: int) -> None:
         if self.adaptive_controller is not None:
             self.adaptive_controller.activate_step_by_batch(batch_size)
+
+    def activate_step(self, speculative_num_steps: int) -> None:
+        if self.adaptive_controller is not None:
+            self.adaptive_controller.activate_step(speculative_num_steps)
 
     # -- Adaptive speculative decoding protocol --
 

--- a/test/registered/spec/eagle/test_adaptive_speculative_dp_attention.py
+++ b/test/registered/spec/eagle/test_adaptive_speculative_dp_attention.py
@@ -1,0 +1,187 @@
+"""Adaptive speculative decoding under data-parallel attention (multi-GPU).
+
+Regression guard for the DP-attention consensus path: when --enable-dp-attention
+is set, each DP rank must activate the *same* adaptive tier every decode step.
+A divergent tier means a divergent num_draft_tokens -> divergent
+global_dp_buffer_len -> mismatched NCCL collective shapes -> hang. The consensus
+(min over per-rank desired tiers, carried on the existing MLP-sync all_gather)
+keeps every rank in lockstep, so a tier switch that changes the draft-token width
+mid-flight must still complete rather than deadlock.
+
+Topology: --tp 2 --dp 2 --enable-dp-attention -> 2 GPUs, 2 DP-attention groups.
+"""
+
+import json
+import os
+import tempfile
+import unittest
+from types import SimpleNamespace
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.run_eval import run_eval
+from sglang.test.test_utils import (
+    DEFAULT_DRAFT_MODEL_EAGLE,
+    DEFAULT_TARGET_MODEL_EAGLE,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_cuda_ci(est_time=300, stage="extra-a", runner_config="2-gpu-large")
+register_amd_ci(est_time=360, stage="extra-a", runner_config="2-gpu-large-amd")
+
+# A batch big enough that, split across 2 DP ranks by the auto load balancer,
+# every rank still lands at BS >= 8 (the high-load tier's routing key).
+HIGH_LOAD_BATCH = 24
+
+
+class TestAdaptiveSpeculativeDPAttentionServer(CustomTestCase):
+    """Adaptive tier switching stays lockstep across DP ranks (no deadlock).
+
+    Config routes BS<8 -> steps=3 (draft width 4) and BS>=8 -> steps=1 (draft
+    width 2), so a rising/falling load forces a *shape-changing* tier switch.
+    Under --enable-dp-attention this only completes if the two ranks agree on
+    the tier; otherwise the verify collective deadlocks.
+    """
+
+    model = DEFAULT_TARGET_MODEL_EAGLE
+    draft_model = DEFAULT_DRAFT_MODEL_EAGLE
+    base_url = DEFAULT_URL_FOR_TEST
+
+    COUNT_PROMPT = "Count from 1 to 400, separated by commas. Output only the numbers."
+
+    @classmethod
+    def setUpClass(cls):
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+            json.dump(
+                {
+                    "1": {"candidate_steps": [3], "warmup_batches": 0},
+                    "8": {"candidate_steps": [1], "warmup_batches": 0},
+                },
+                f,
+            )
+            cls.adaptive_config_path = f.name
+
+        try:
+            cls.process = popen_launch_server(
+                cls.model,
+                cls.base_url,
+                timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+                other_args=[
+                    "--trust-remote-code",
+                    "--attention-backend",
+                    "triton",
+                    "--tp",
+                    "2",
+                    "--dp",
+                    "2",
+                    "--enable-dp-attention",
+                    "--speculative-algorithm",
+                    "EAGLE",
+                    "--speculative-draft-model-path",
+                    cls.draft_model,
+                    "--speculative-num-steps",
+                    "3",
+                    "--speculative-eagle-topk",
+                    "1",
+                    "--speculative-num-draft-tokens",
+                    "4",
+                    "--speculative-adaptive",
+                    "--speculative-adaptive-config",
+                    cls.adaptive_config_path,
+                    "--max-running-requests",
+                    "64",
+                    "--skip-server-warmup",
+                    "--mem-fraction-static",
+                    "0.7",
+                ],
+            )
+        except Exception:
+            os.unlink(cls.adaptive_config_path)
+            raise
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "process"):
+            kill_process_tree(cls.process.pid)
+        if os.path.exists(cls.adaptive_config_path):
+            os.unlink(cls.adaptive_config_path)
+
+    def _steps(self) -> int:
+        r = requests.get(self.base_url + "/server_info", timeout=30)
+        self.assertEqual(r.status_code, 200, r.text)
+        return r.json()["internal_states"][0]["speculative_num_steps"]
+
+    def _generate_single(self) -> dict:
+        one = {"temperature": 0, "max_new_tokens": 64, "ignore_eos": True}
+        r = requests.post(
+            self.base_url + "/generate",
+            json={"text": self.COUNT_PROMPT, "sampling_params": one},
+            timeout=600,
+        )
+        self.assertEqual(r.status_code, 200, r.text)
+        return r.json()["meta_info"]
+
+    def test_dp_tier_switch_no_deadlock(self):
+        """BS=1 -> steps=3 -> shape-changing switch to steps=1 under load -> back.
+
+        Each phase completing (not timing out) is the deadlock check: a broken
+        consensus lets the ranks diverge on num_draft_tokens and the verify
+        collective hangs. The accept-rate assertions additionally prove drafting
+        actually runs under DP, not just that the server didn't crash.
+        """
+        # Phase 1: BS=1 -> steps=3, drafting active on the serving rank.
+        m1 = self._generate_single()
+        self.assertEqual(self._steps(), 3, "expected steps=3 at BS=1")
+        self.assertGreater(
+            m1["spec_accept_rate"], 0.8, f"not drafting at steps=3 under DP: {m1}"
+        )
+
+        # Phase 2: a 24-way batch splits ~12 per DP rank (>= 8) -> steps=1. Both
+        # ranks must switch to the narrower draft width together, mid-flight.
+        full = {"temperature": 0, "max_new_tokens": 128, "ignore_eos": True}
+        r = requests.post(
+            self.base_url + "/generate",
+            json={
+                "text": [self.COUNT_PROMPT] * HIGH_LOAD_BATCH,
+                "sampling_params": [full] * HIGH_LOAD_BATCH,
+            },
+            timeout=600,
+        )
+        self.assertEqual(r.status_code, 200, r.text)
+        self.assertEqual(self._steps(), 1, "BS>=8 did not switch to steps=1 under DP")
+
+        # Phase 3: BS=1 -> steps=3 again, drafting restored (shape widened back).
+        m3 = self._generate_single()
+        self.assertEqual(self._steps(), 3, "did not reopen to steps=3 under DP")
+        self.assertGreater(
+            m3["spec_accept_rate"], 0.8, f"drafting not restored under DP: {m3}"
+        )
+
+    def test_gsm8k_accuracy_under_dp(self):
+        """Correctness is preserved through the adaptive+DP path (no regression),
+        and the lifetime accept-length is reported for the PR evidence trail."""
+        args = SimpleNamespace(
+            base_url=self.base_url,
+            model=self.model,
+            eval_name="gsm8k",
+            api="completion",
+            max_tokens=512,
+            num_examples=100,
+            num_threads=64,
+        )
+        metrics = run_eval(args)
+        print(f"GSM8K under adaptive+dp-attention: {metrics}")
+        self.assertGreater(metrics["score"], 0.20)
+
+        server_info = requests.get(self.base_url + "/server_info").json()
+        avg_accept_len = server_info["internal_states"][0]["avg_spec_accept_length"]
+        print(f"avg_spec_accept_length (dp)={avg_accept_len:.4f}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`--speculative-adaptive` picks the speculative draft depth (`num_steps`) per batch at runtime. It is disabled whenever `--enable-dp-attention` is set: `adaptive_unsupported_reason()` bails out and the server falls back to static params.

The guard is there for a reason. Under DP attention each rank picks its own `num_steps`, and `num_draft_tokens = num_steps + 1` sets the shape of the cross-rank MLP-sync `all_gather`. If ranks disagree, the collective shapes diverge and NCCL hangs.

So adaptive is off exactly where it would help most: DP-attention deployments of large MoE models. This PR makes it work there.

## Modifications

Agree on the tier across ranks using the MLP-sync `all_gather` that already runs, so there is no new collective:

- `dp_attn.py`: each rank appends its desired `num_steps` to the sync vector (idle and non-adaptive ranks send a sentinel). The tier is the `min()` over the column. `min` is safe because every tier is prebuilt on every rank, and a rank only votes low when its batch is large, so no rank is ever pushed to do more draft work than it asked for. The result is written to the batch the worker forwards (`batch_to_gather`, which for a prebuilt batch is its inner idle batch, not `local_batch`).
- `schedule_batch.py`: new field `adaptive_consensus_steps`.
- `adaptive_runtime_state.py`: under DP the per-rank EMA keeps learning but stops activating on its own; the consensus drives activation.
- `eagle_worker_v2.py`: honor `adaptive_consensus_steps` when set, otherwise route locally by batch size.
- `adaptive_spec_params.py`: drop the `enable_dp_attention` guard. The other guards (multi_layer_eagle, TBO, pdmux) stay.

`num_steps` only changes how many draft tokens are proposed per step. The verify step still decides what gets accepted, so the output is identical at any tier.

Known limits: under skewed load `min` pins every rank to the lowest tier a neighbor wants, so a light rank can lose speculation it could afford. `candidate_steps` must stay at or below the boot `--speculative-num-steps`. `SGLANG_SCHEDULER_SKIP_ALL_GATHER=1` with real DP bypasses the consensus writeback.

## Accuracy Tests

Output is unchanged by construction. The new test runs GSM8K through the adaptive plus DP path and checks the score holds.

## Speed Tests and Profiling

This is an enablement change, not a speed change. What matters is that the consensus adds no overhead when the tier holds.

Large MoE model, 4xH200, `--tp 4 --dp 2 --ep 4 --enable-dp-attention`, EAGLE `num_steps=3 topk=1 draft=4`, GSM8K, per-request `spec_accept_length`:

| concurrency | config | accept_len | tok/s |
|---|---|---|---|
| 1 | fixed steps=3 | 3.25 | 116 |
| 1 | adaptive | 3.24 | 116 |
| 8 | fixed steps=3 | 3.24 | 548 |
| 8 | adaptive | 3.25 | 548 |

While the tier holds, adaptive matches fixed `num_steps` exactly. A shape-changing switch across ranks completes with no deadlock (covered by the new test, and by a 48-request run on the model above). Whether downshifting helps depends on the workload: it pays off when acceptance drops under load. GSM8K keeps acceptance high, so there is nothing to gain there, and a win on a low-acceptance workload is out of scope for this PR.

## Checklist

- [x] Format code with pre-commit
- [x] Add unit tests
- [ ] Update documentation
- [x] Provide accuracy and speed benchmark results
- [x] Follow the SGLang code style
