### PR TITLE
[SM12x] attention: b12x compressed-MLA branch for DSv4-Flash

### DIFF
--- a/python/sglang/kernels/ops/attention/flash_mla_sm120.py
+++ b/python/sglang/kernels/ops/attention/flash_mla_sm120.py
@@ -13,6 +13,7 @@ separate region at the end of each page.
 
 import logging
 import math
+import os
 from typing import Optional
 
 import torch
@@ -21,6 +22,7 @@ import triton.language as tl
 
 from sglang.srt.environ import envs
 from sglang.srt.utils import is_hip
+from sglang.srt.utils.b12x import install_compile_cache_dir
 
 logger = logging.getLogger(__name__)
 _is_hip = is_hip()
@@ -206,14 +208,26 @@ def _sm120_sparse_decode_fwd(
 
 
 # SM120 FlashMLA: default FlashInfer (CUTLASS SM120 sparse MLA decode).
-# Override with SGLANG_SM120_FLASHMLA_BACKEND=triton|torch to force fallback.
+# Override with SGLANG_SM120_FLASHMLA_BACKEND=b12x|triton|torch.
 _sm120_default_backend = envs.SGLANG_SM120_FLASHMLA_BACKEND.get()
+
+if _sm120_default_backend == "b12x":
+    # b12x reads its own configuration from the environment at import / first
+    # compile, so both of these have to be in place before the first call.
+    install_compile_cache_dir()
+    # Required, not optional: b12x's _dsv4_h16_auto() does not forward
+    # sm_count, so the AUTO probe raises and the native-H16 DSv4 kernels --
+    # the whole point of running 32 real heads here -- are unreachable unless
+    # the variable is set explicitly. setdefault, so an operator can still
+    # pin it to 0 to compare against the generic path.
+    os.environ.setdefault("B12X_MLA_SM120_DSV4_H16_NATIVE", "1")
 
 
 def flash_mla_with_kvcache_sm120(**kwargs):
     """SM120 FlashMLA sparse decode entry point.
 
-    Dispatches to FlashInfer (default if available), Triton, or PyTorch fallback.
+    Dispatches to FlashInfer (default if available), b12x compressed MLA,
+    Triton, or PyTorch fallback.
     """
     q = kwargs["q"]
     k_cache = kwargs["k_cache"]
@@ -227,6 +241,21 @@ def flash_mla_with_kvcache_sm120(**kwargs):
     extra_k_cache = kwargs.get("extra_k_cache")
     extra_indices = kwargs.get("extra_indices_in_kvcache")
     extra_topk_length = kwargs.get("extra_topk_length")
+
+    if _sm120_default_backend == "b12x":
+        return _flash_mla_b12x(
+            q,
+            k_cache,
+            indices,
+            topk_length,
+            attn_sink,
+            head_dim_v,
+            softmax_scale,
+            extra_k_cache,
+            extra_indices,
+            extra_topk_length,
+            kwargs.get("mode"),
+        )
 
     if _sm120_default_backend == "flashinfer":
         return _flash_mla_flashinfer(
@@ -560,6 +589,200 @@ def _flash_mla_flashinfer(
         extra_topk_length=extra_topk_length,
         mid_out=mid_out,
         mid_lse=mid_lse,
+    )
+
+    return (output.unsqueeze(1), None)
+
+
+# b12x compressed MLA state, all of it in get_resources().buffers so a context
+# reset drops it with everything else on the device.
+_B12X_SINK_KEY = "flash_mla_sm120_b12x_sink"
+_B12X_RETIRED_KEY = "flash_mla_sm120_b12x_retired"
+
+
+def _b12x_retire(buf: torch.Tensor) -> None:
+    """Keep a superseded buffer alive instead of freeing it.
+
+    A captured CUDA graph baked the old buffer's address, so freeing it on
+    growth would leave replays reading reclaimed memory.
+    """
+    from sglang.srt.runtime_context import get_resources
+
+    get_resources().buffers.setdefault(_B12X_RETIRED_KEY, []).append(buf)
+
+
+def _b12x_page_bytes_view(cache: torch.Tensor) -> torch.Tensor:
+    """Rank-2 [pages, page_bytes] uint8 view b12x's cache validator expects."""
+    cache_u8 = cache.view(torch.uint8) if cache.dtype != torch.uint8 else cache
+    page_bytes = cache_u8.stride(0)
+    return torch.as_strided(cache_u8, (cache_u8.shape[0], page_bytes), (page_bytes, 1))
+
+
+def _b12x_scratch(plan, device: torch.device, mode: str) -> torch.Tensor:
+    """Persistent grow-only scratch, keyed per mode.
+
+    Decode scratch reaches its maximum during the (largest-bucket-first)
+    CUDA graph warmup and stays fixed; extend scratch only ever grows on the
+    eager prefill path. Splitting the keys keeps decode growth away from
+    capture, and the retired list covers the remaining realloc-after-capture
+    hazard.
+    """
+    from sglang.srt.runtime_context import get_resources
+
+    shape, dtype = plan.shapes_and_dtypes()[0]
+    need = int(shape[0])
+    buffers = get_resources().buffers
+    key = f"flash_mla_sm120_b12x_scratch:{mode}:{device}"
+    buf = buffers.get(key)
+    if buf is None or buf.numel() < need:
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError(
+                f"b12x compressed MLA scratch needs {need} bytes during CUDA "
+                f"graph capture (have {0 if buf is None else buf.numel()}); "
+                "the eager pre-capture run must size it first."
+            )
+        if buf is not None:
+            _b12x_retire(buf)
+        with torch.inference_mode(False):
+            buf = torch.empty(need, dtype=dtype, device=device)
+        buffers[key] = buf
+    return buf
+
+
+def _b12x_sink_f32(attn_sink: torch.Tensor, heads: int) -> torch.Tensor:
+    """Per-layer fp32 contiguous sink of shape exactly (heads,).
+
+    Built once per layer, outside capture, then stable. Keyed by the identity
+    of the source tensor, with the source held in the entry: data_ptr is not a
+    safe key (a freed sink's address can be reissued to another layer's
+    tensor), while the id of an object we keep a reference to cannot be
+    recycled. Shape and dtype are not a key at all -- every layer's sink has
+    the same ones.
+    """
+    from sglang.srt.runtime_context import get_resources
+
+    cache = get_resources().buffers.setdefault(_B12X_SINK_KEY, {})
+    key = (id(attn_sink), heads)
+    entry = cache.get(key)
+    if entry is None:
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError(
+                "b12x attention sink conversion requested during CUDA graph "
+                "capture; the eager pre-capture run must populate the cache."
+            )
+        sink = attn_sink.reshape(-1)[:heads].to(torch.float32).contiguous()
+        entry = (attn_sink, sink)
+        cache[key] = entry
+    return entry[1]
+
+
+def _b12x_i32(t: Optional[torch.Tensor]) -> Optional[torch.Tensor]:
+    if t is None:
+        return None
+    if t.dtype != torch.int32 or not t.is_contiguous():
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError(
+                f"b12x compressed MLA got a non-int32/non-contiguous index "
+                f"tensor (dtype={t.dtype}) during CUDA graph capture."
+            )
+        t = t.to(torch.int32).contiguous()
+    return t
+
+
+def _flash_mla_b12x(
+    q,
+    k_cache,
+    indices,
+    topk_length,
+    attn_sink,
+    head_dim_v,
+    softmax_scale,
+    extra_k_cache,
+    extra_indices,
+    extra_topk_length,
+    mode,
+):
+    """b12x compressed MLA: fused SWA + indexed sparse attention (SM12x).
+
+    Same kernel family as vLLM's DeepseekV4B12xMLAAttention. The SWA pool is
+    re-split to 64-token footer pages (reusing the FlashInfer path's split
+    buffer) because the SM121 single-pass decode requires page_size=64; the
+    c4 pool is 64-token pages natively. b12x accepts sglang's 576-padded page
+    byte width directly, and indexes both caches by raw token slot, so the
+    indices pass through unchanged.
+    """
+    from b12x.attention import compressed_mla
+
+    B = q.shape[0]
+    heads = q.shape[-2]
+    dev = q.device
+
+    idx = _b12x_i32(indices.squeeze(1) if indices.dim() == 3 else indices)
+    extra_idx = _b12x_i32(
+        extra_indices.squeeze(1)
+        if extra_indices is not None and extra_indices.dim() == 3
+        else extra_indices
+    )
+    swa_lengths = _b12x_i32(topk_length)
+    extra_lengths = _b12x_i32(extra_topk_length)
+
+    kv_u8 = k_cache.view(torch.uint8) if k_cache.dtype != torch.uint8 else k_cache
+    src_pbs = k_cache.shape[1] if k_cache.ndim >= 3 else _PBS_SRC
+    kv_64 = (
+        _split_kv_pages_to_64(kv_u8, src_pbs, touched_indices=idx)
+        if src_pbs != _PBS_DST
+        else kv_u8
+    )
+    swa_pages = _b12x_page_bytes_view(kv_64)
+    extra_pages = (
+        _b12x_page_bytes_view(extra_k_cache) if extra_k_cache is not None else None
+    )
+
+    width = idx.shape[-1] + (extra_idx.shape[-1] if extra_idx is not None else 0)
+    num_splits_cap = compressed_mla.split_chunks_for_contract(
+        rows=max(1, B),
+        width=width,
+        max_chunks=max(1, (width + 63) // 64),
+        decode_row_capacity=None,
+    )
+    if mode is None:
+        mode = "decode" if B <= 256 else "extend"
+
+    caps = compressed_mla.Caps(
+        device=dev,
+        num_q_heads=heads,
+        max_q_rows=max(1, B),
+        max_width=width,
+        head_dim=q.shape[-1],
+        v_head_dim=head_dim_v,
+        page_size=_PBS_DST,
+        max_chunks_per_row=num_splits_cap,
+    )
+    plan = compressed_mla.plan(caps)
+    scratch = _b12x_scratch(plan, dev, mode)
+
+    q3 = q.squeeze(1) if q.ndim == 4 else q
+    binding = plan.bind(
+        scratch=scratch,
+        q=q3,
+        swa_indices=idx,
+        swa_lengths=swa_lengths,
+        indexed_indices=extra_idx,
+        indexed_lengths=extra_lengths,
+    )
+    binding.scratch.mode = mode
+
+    output = torch.empty(B, heads, head_dim_v, dtype=torch.bfloat16, device=dev)
+    compressed_mla.run(
+        binding=binding,
+        swa_k_cache=swa_pages,
+        swa_page_size=_PBS_DST,
+        indexed_k_cache=extra_pages,
+        indexed_page_size=_PBS_DST if extra_pages is not None else None,
+        attn_sink=_b12x_sink_f32(attn_sink, heads) if attn_sink is not None else None,
+        sm_scale=softmax_scale,
+        expected_num_q_heads=heads,
+        out=output,
     )
 
     return (output.unsqueeze(1), None)

--- a/python/sglang/kernels/ops/attention/flash_mla_sm120.py
+++ b/python/sglang/kernels/ops/attention/flash_mla_sm120.py
@@ -734,9 +734,15 @@ def _flash_mla_b12x(
         else kv_u8
     )
     swa_pages = _b12x_page_bytes_view(kv_64)
-    extra_pages = (
-        _b12x_page_bytes_view(extra_k_cache) if extra_k_cache is not None else None
-    )
+    # c4 layers hand over 64-token pages, c128 layers 256/128 = 2-token pages;
+    # b12x addresses the indexed cache by raw token slot at this page size.
+    extra_pages = None
+    extra_page_tokens = None
+    if extra_k_cache is not None:
+        extra_pages = _b12x_page_bytes_view(extra_k_cache)
+        extra_page_tokens = (
+            int(extra_k_cache.shape[1]) if extra_k_cache.ndim >= 3 else _PBS_DST
+        )
 
     width = idx.shape[-1] + (extra_idx.shape[-1] if extra_idx is not None else 0)
     num_splits_cap = compressed_mla.split_chunks_for_contract(
@@ -778,7 +784,7 @@ def _flash_mla_b12x(
         swa_k_cache=swa_pages,
         swa_page_size=_PBS_DST,
         indexed_k_cache=extra_pages,
-        indexed_page_size=_PBS_DST if extra_pages is not None else None,
+        indexed_page_size=extra_page_tokens,
         attn_sink=_b12x_sink_f32(attn_sink, heads) if attn_sink is not None else None,
         sm_scale=softmax_scale,
         expected_num_q_heads=heads,

--- a/python/sglang/kernels/ops/attention/flash_mla_sm120.py
+++ b/python/sglang/kernels/ops/attention/flash_mla_sm120.py
@@ -676,6 +676,60 @@ def _b12x_sink_f32(attn_sink: torch.Tensor, heads: int) -> torch.Tensor:
     return entry[1]
 
 
+# Single-cache index widths the SM120 unified-prefill kernel instantiates.
+# It also serves the SM121 single-pass decode route, so an unsupported width
+# is rejected in every mode, CUDA graph warmup included.
+_B12X_SINGLE_CACHE_WIDTHS = (128, 512, 1024, 2048)
+# What an unsupported width is padded up to. 128 is deliberately not a target:
+# 512 is the standing DSpark SWA index width vLLM pads to
+# (_DSPARK_SWA_INDEX_ALIGNMENT), and matching it keeps us on the same kernel.
+_B12X_PAD_WIDTHS = (512, 1024, 2048)
+
+
+def _b12x_pad_swa_indices(idx: torch.Tensor, *, rows: int) -> torch.Tensor:
+    """Pad single-cache index rows out to a width b12x instantiates.
+
+    The DSpark draft extend presents 192 (window 128 + draft block, 64-aligned)
+    and the shape gate rejects it at 32 heads. Per-row lengths keep the real
+    counts, so the padded columns are never read past the length.
+
+    The buffer is persistent and grow-only, because this runs on the captured
+    decode route too: superseded buffers are retired rather than freed. It is
+    keyed by the real width as well as the target, so the pad columns are the
+    ones the -1 allocation fill put there and no call ever writes into them --
+    which is what lets the steady-state path be a single copy_ with no memset.
+    """
+    from sglang.srt.runtime_context import get_resources
+
+    real_w = int(idx.shape[-1])
+    target_w = next((w for w in _B12X_PAD_WIDTHS if real_w <= w), None)
+    if target_w is None:
+        raise RuntimeError(
+            f"b12x instantiates the single-cache index widths "
+            f"{_B12X_SINGLE_CACHE_WIDTHS} only, and {real_w} is past the "
+            "widest one. Lower the SWA window or the speculative draft block "
+            "so the 64-aligned index width fits 2048."
+        )
+    buffers = get_resources().buffers
+    key = f"flash_mla_sm120_b12x_padidx:{real_w}:{target_w}:{idx.device}"
+    buf = buffers.get(key)
+    if buf is None or buf.shape[0] < rows:
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError(
+                f"b12x index pad buffer needs {rows} rows during CUDA graph "
+                f"capture (have {0 if buf is None else buf.shape[0]}); the "
+                "eager pre-capture run must size it first."
+            )
+        if buf is not None:
+            _b12x_retire(buf)
+        with torch.inference_mode(False):
+            buf = torch.full((rows, target_w), -1, dtype=torch.int32, device=idx.device)
+        buffers[key] = buf
+    padded = buf[:rows]
+    padded[:, :real_w].copy_(idx)
+    return padded
+
+
 def _b12x_i32(t: Optional[torch.Tensor]) -> Optional[torch.Tensor]:
     if t is None:
         return None
@@ -744,6 +798,12 @@ def _flash_mla_b12x(
             int(extra_k_cache.shape[1]) if extra_k_cache.ndim >= 3 else _PBS_DST
         )
 
+    if mode is None:
+        mode = "decode" if B <= 256 else "extend"
+
+    if extra_idx is None and idx.shape[-1] not in _B12X_SINGLE_CACHE_WIDTHS:
+        idx = _b12x_pad_swa_indices(idx, rows=B)
+
     width = idx.shape[-1] + (extra_idx.shape[-1] if extra_idx is not None else 0)
     num_splits_cap = compressed_mla.split_chunks_for_contract(
         rows=max(1, B),
@@ -751,8 +811,6 @@ def _flash_mla_b12x(
         max_chunks=max(1, (width + 63) // 64),
         decode_row_capacity=None,
     )
-    if mode is None:
-        mode = "decode" if B <= 256 else "extend"
 
     caps = compressed_mla.Caps(
         device=dev,

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1525,6 +1525,21 @@ class Envs:
     # Most batched requests one /generate HTTP call may expand into.
     SGLANG_MAX_BATCH_REQS_PER_HTTP_REQ = EnvInt(4096)
 
+    # ==================================================================
+    # b12x MoE runner backend (SM12x / GB10)
+    # ==================================================================
+    # Upper bound on tokens in one b12x MoE call, used to size its scratch
+    # workspace at load time. Track --chunked-prefill-size if that is raised.
+    SGLANG_B12X_MAX_TOKENS = EnvInt(4096)
+    # Drop b12x's one-CTA-per-SM pin for moe_block_size==8. Measured a 4.4%
+    # regression on GB10, so off: the pin suits the kernel it ships with.
+    SGLANG_B12X_RELAX_BLOCKS_PER_SM = EnvBool(False)
+    # Directory to import b12x from, ahead of the pip-installed one. Set this to
+    # a 0.15.3 checkout: its W4A16 kernel takes weights as tensors with static
+    # strides, where 1.2.2 passes raw pointers and rebuilds layouts at runtime.
+    # Measured 707.9 vs 875.6 us/call on DSv4-Flash decode, bit-identical output.
+    SGLANG_B12X_PATH = EnvStr("")
+
 
 envs = Envs()
 EnvField._allow_set_name = False

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -900,7 +900,9 @@ class Envs:
     # None = standard attention. See https://arxiv.org/abs/2512.12087
     SGLANG_SKIP_SOFTMAX_PREFILL_THRESHOLD_SCALE_FACTOR = EnvFloat(None)
     SGLANG_SKIP_SOFTMAX_DECODE_THRESHOLD_SCALE_FACTOR = EnvFloat(None)
-    # SM120 FlashMLA decode backend: "flashinfer" (default), "triton", or "torch".
+    # SM120 FlashMLA decode backend: "flashinfer" (default), "b12x"
+    # (compressed MLA, same kernels as vLLM's DGX Spark image), "triton",
+    # or "torch".
     SGLANG_SM120_FLASHMLA_BACKEND = EnvStr("flashinfer")
     SGLANG_FLASHINFER_PREFILL_SPLIT_TILE_SIZE = EnvInt(4096)
     SGLANG_FLASHINFER_DECODE_SPLIT_TILE_SIZE = EnvInt(2048)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1531,13 +1531,9 @@ class Envs:
     # Upper bound on tokens in one b12x MoE call, used to size its scratch
     # workspace at load time. Track --chunked-prefill-size if that is raised.
     SGLANG_B12X_MAX_TOKENS = EnvInt(4096)
-    # Drop b12x's one-CTA-per-SM pin for moe_block_size==8. Measured a 4.4%
-    # regression on GB10, so off: the pin suits the kernel it ships with.
-    SGLANG_B12X_RELAX_BLOCKS_PER_SM = EnvBool(False)
-    # Directory to import b12x from, ahead of the pip-installed one. Set this to
-    # a 0.15.3 checkout: its W4A16 kernel takes weights as tensors with static
-    # strides, where 1.2.2 passes raw pointers and rebuilds layouts at runtime.
-    # Measured 707.9 vs 875.6 us/call on DSv4-Flash decode, bit-identical output.
+    # Directory to import b12x from, ahead of the pip-installed one -- for
+    # deployments that carry the 0.15.3 tree as a directory instead of
+    # pip-installing the pinned source commit (see mxfp4_b12x_moe.py).
     SGLANG_B12X_PATH = EnvStr("")
 
 

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1531,10 +1531,6 @@ class Envs:
     # Upper bound on tokens in one b12x MoE call, used to size its scratch
     # workspace at load time. Track --chunked-prefill-size if that is raised.
     SGLANG_B12X_MAX_TOKENS = EnvInt(4096)
-    # Directory to import b12x from, ahead of the pip-installed one -- for
-    # deployments that carry the 0.15.3 tree as a directory instead of
-    # pip-installing the pinned source commit (see mxfp4_b12x_moe.py).
-    SGLANG_B12X_PATH = EnvStr("")
 
 
 envs = Envs()

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1531,6 +1531,13 @@ class Envs:
     # Upper bound on tokens in one b12x MoE call, used to size its scratch
     # workspace at load time. Track --chunked-prefill-size if that is raised.
     SGLANG_B12X_MAX_TOKENS = EnvInt(4096)
+    # b12x quant mode for the MoE, passed through verbatim. "w4a8_mx"
+    # quantizes activations to MXFP8-E4M3 in-kernel and is the recipe the
+    # official vLLM DGX Spark image runs (its recipe sets B12X_MOE_FORCE_A8=1);
+    # all of b12x's GB10 MoE tuning lives on that path. "w4a16" restores the
+    # bf16-activation frozen-plan path. Modes have different numerics --
+    # validate accuracy when changing this.
+    SGLANG_B12X_MOE_QUANT_MODE = EnvStr("w4a8_mx")
     # Compile the b12x kernels for every planned token count at load time,
     # before any CUDA graph capture. Off only defers the cost: captured decode
     # shapes are still compiled by the graph runner's pre-capture warmup runs,

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1543,8 +1543,8 @@ class Envs:
     # shapes are still compiled by the graph runner's pre-capture warmup runs,
     # and the prefill ladder then JIT-compiles on the first real chunks
     # (~80 s cold on DSv4-Flash).
-    SGLANG_B12X_WARMUP = EnvBool(True)
-    # b12x compile-cache directory, forwarded to B12X_CUTE_COMPILE_CACHE_DIR.
+    SGLANG_B12X_ENABLE_WARMUP = EnvBool(True)
+    # b12x compile-cache directory, forwarded to B12X_COMPILE_CACHE_DIR.
     # Resolved lazily so it tracks SGLANG_CACHE_DIR, which is defined below.
     SGLANG_B12X_CACHE_DIR = EnvStr(lambda: _default_cache_subdir("b12x"))
 

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1531,6 +1531,15 @@ class Envs:
     # Upper bound on tokens in one b12x MoE call, used to size its scratch
     # workspace at load time. Track --chunked-prefill-size if that is raised.
     SGLANG_B12X_MAX_TOKENS = EnvInt(4096)
+    # Compile the b12x kernels for every planned token count at load time,
+    # before any CUDA graph capture. Off only defers the cost: captured decode
+    # shapes are still compiled by the graph runner's pre-capture warmup runs,
+    # and the prefill ladder then JIT-compiles on the first real chunks
+    # (~80 s cold on DSv4-Flash).
+    SGLANG_B12X_WARMUP = EnvBool(True)
+    # b12x compile-cache directory, forwarded to B12X_CUTE_COMPILE_CACHE_DIR.
+    # Resolved lazily so it tracks SGLANG_CACHE_DIR, which is defined below.
+    SGLANG_B12X_CACHE_DIR = EnvStr(lambda: _default_cache_subdir("b12x"))
 
 
 envs = Envs()

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -1758,6 +1758,17 @@ class DeepseekV4AttnBackend(
                     flash_mla_with_kvcache_sm120,
                 )
 
+                # b12x kernel-family hint: verify rows follow the decode split
+                # contract (rows = bs * (1 + draft tokens)), everything
+                # extend-shaped runs the unified prefill kernel.
+                sm120_mode = (
+                    "decode"
+                    if (
+                        forward_batch.forward_mode.is_decode_or_idle()
+                        or forward_batch.forward_mode.is_target_verify()
+                    )
+                    else "extend"
+                )
                 o = flash_mla_with_kvcache_sm120(
                     q=q,
                     k_cache=swa_k_cache,
@@ -1769,6 +1780,7 @@ class DeepseekV4AttnBackend(
                     extra_k_cache=extra_k_cache,
                     extra_indices_in_kvcache=extra_indices,
                     extra_topk_length=extra_topk_lengths,
+                    mode=sm120_mode,
                 )[0]
             else:
                 if _is_xpu:

--- a/python/sglang/srt/layers/moe/moe_runner/b12x.py
+++ b/python/sglang/srt/layers/moe/moe_runner/b12x.py
@@ -1,0 +1,127 @@
+"""b12x W4A16 fused MoE for SM120/SM121.
+
+The FlashInfer CUTLASS MXFP4 path splits one expert layer into seven launches:
+build-expert-maps, expand-input-rows, compute-strides, FC1, activation, FC2 and
+finalize. b12x fuses FC1, the gated activation and FC2 into a single kernel and
+gathers the routed rows by index instead of materializing a permuted copy, so a
+layer costs one launch instead of seven. It is also W4A16 rather than W4A8:
+activations stay bf16 instead of being quantized to MXFP8.
+
+Weights are prepared once at load time (see ``Mxfp4B12xMoEMethod``) and the
+scratch buffer is planned there too, so this module only binds views -- which is
+what makes it safe to capture in a CUDA graph.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+from sglang.srt.distributed import get_tp_group
+from sglang.srt.distributed.device_communicators.pynccl_allocator import (
+    use_symmetric_memory,
+)
+from sglang.srt.layers.dp_attention import is_allocation_symmetric
+from sglang.srt.layers.moe.moe_runner.base import (
+    MoeQuantInfo,
+    MoeRunnerConfig,
+    register_fused_func,
+)
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.moe.token_dispatcher.standard import (
+        StandardCombineInput,
+        StandardDispatchOutput,
+    )
+
+
+@dataclass
+class B12xMoeQuantInfo(MoeQuantInfo):
+    """Payload for the b12x W4A16 fused MoE.
+
+    ``experts`` owns the only copy of the expert weights: the checkpoint tensors
+    are released once it is built, so this dataclass carries none of its own.
+    """
+
+    # b12x expert-weight package, built at load time.
+    experts: Any
+    # b12x scratch plan, planned at load time.
+    plan: Any
+    # Caller-owned scratch, allocated at load time so it never lands in a CUDA
+    # graph's private memory pool.
+    scratch: torch.Tensor
+    # Set when the quant method already bound everything it needs; the two b12x
+    # generations take different arguments, so the version-specific call lives
+    # there rather than here.
+    launch: Any = None
+    # True only when expert parallelism is on: that is the only case where the
+    # dispatcher rewrites non-local experts (and padded rows) to -1, which b12x
+    # would otherwise run as garbage. At EP=1 the guard would cost five tiny
+    # kernels per layer for nothing -- torch.topk cannot produce negatives.
+    ep_guard: bool = False
+
+
+@register_fused_func("none", "b12x")
+def fused_experts_none_to_b12x(
+    dispatch_output: StandardDispatchOutput,
+    quant_info: MoeQuantInfo,
+    runner_config: MoeRunnerConfig,
+) -> StandardCombineInput:
+    """Run one expert layer through the b12x W4A16 fused kernel."""
+    from sglang.srt.layers.moe.token_dispatcher.standard import StandardCombineInput
+    from sglang.srt.layers.moe.topk import TopKOutputChecker
+
+    assert isinstance(
+        quant_info, B12xMoeQuantInfo
+    ), f"Unexpected quant_info type for b12x: {type(quant_info)}"
+    if runner_config.activation != "silu":
+        raise NotImplementedError(
+            f"b12x supports activation='silu', got {runner_config.activation!r}."
+        )
+    if runner_config.apply_router_weight_on_input:
+        raise NotImplementedError(
+            "b12x applies the router weights in the FC2 epilogue; "
+            "apply_router_weight_on_input is not supported."
+        )
+
+    x = dispatch_output.hidden_states
+    topk_output = dispatch_output.topk_output
+    if TopKOutputChecker.format_is_bypassed(topk_output):
+        topk_output = topk_output.to_standard()
+
+    with use_symmetric_memory(get_tp_group(), disabled=not is_allocation_symmetric()):
+        out = torch.empty(
+            x.shape[0], x.shape[-1], dtype=torch.bfloat16, device=x.device
+        )
+
+    # HashTopK already emits int32 ids and float32 weights, so these casts are
+    # free no-ops kept as a contract check for other topk implementations.
+    topk_ids = topk_output.topk_ids.to(torch.int32)
+    topk_weights = topk_output.topk_weights.to(torch.float32)
+    if quant_info.ep_guard:
+        # With EP the dispatcher rewrites non-local experts -- and padded rows --
+        # to -1. FlashInfer CUTLASS skips out-of-range ids; b12x instead runs
+        # them and writes ~1e4-per-element garbage into those rows.
+        invalid = topk_ids < 0
+        topk_ids = topk_ids.clamp_min(0)
+        topk_weights = topk_weights.masked_fill(invalid, 0.0)
+
+    if quant_info.launch is not None:
+        quant_info.launch(x, topk_ids, topk_weights, out)
+    else:
+        from b12x.moe import fused_moe
+
+        binding = fused_moe.bind(
+            quant_info.plan,
+            scratch=quant_info.scratch,
+            a=x,
+            experts=quant_info.experts,
+            topk_ids=topk_ids,
+            topk_weights=topk_weights,
+            output=out,
+        )
+        fused_moe.run(binding=binding)
+
+    return StandardCombineInput(hidden_states=out)

--- a/python/sglang/srt/layers/moe/moe_runner/b12x.py
+++ b/python/sglang/srt/layers/moe/moe_runner/b12x.py
@@ -50,8 +50,9 @@ class B12xMoeQuantInfo(MoeQuantInfo):
     # b12x scratch plan, planned at load time.
     plan: Any
     # Caller-owned scratch, allocated at load time so it never lands in a CUDA
-    # graph's private memory pool.
-    scratch: torch.Tensor
+    # graph's private memory pool. None on the 0.15.3 path, where everything
+    # lives in ``launch``.
+    scratch: torch.Tensor | None = None
     # Set when the quant method already bound everything it needs; the two b12x
     # generations take different arguments, so the version-specific call lives
     # there rather than here.

--- a/python/sglang/srt/layers/moe/moe_runner/b12x.py
+++ b/python/sglang/srt/layers/moe/moe_runner/b12x.py
@@ -41,22 +41,12 @@ if TYPE_CHECKING:
 class B12xMoeQuantInfo(MoeQuantInfo):
     """Payload for the b12x W4A16 fused MoE.
 
-    ``experts`` owns the only copy of the expert weights: the checkpoint tensors
-    are released once it is built, so this dataclass carries none of its own.
+    The quant method binds everything at load time (weights, scratch plan,
+    scratch arena); ``launch`` is the prepared bind-and-run closure, so this
+    dataclass carries no tensors of its own.
     """
 
-    # b12x expert-weight package, built at load time.
-    experts: Any
-    # b12x scratch plan, planned at load time.
-    plan: Any
-    # Caller-owned scratch, allocated at load time so it never lands in a CUDA
-    # graph's private memory pool. None on the 0.15.3 path, where everything
-    # lives in ``launch``.
-    scratch: torch.Tensor | None = None
-    # Set when the quant method already bound everything it needs; the two b12x
-    # generations take different arguments, so the version-specific call lives
-    # there rather than here.
-    launch: Any = None
+    launch: Any
     # True only when expert parallelism is on: that is the only case where the
     # dispatcher rewrites non-local experts (and padded rows) to -1, which b12x
     # would otherwise run as garbage. At EP=1 the guard would cost five tiny
@@ -109,20 +99,6 @@ def fused_experts_none_to_b12x(
         topk_ids = topk_ids.clamp_min(0)
         topk_weights = topk_weights.masked_fill(invalid, 0.0)
 
-    if quant_info.launch is not None:
-        quant_info.launch(x, topk_ids, topk_weights, out)
-    else:
-        from b12x.moe import fused_moe
-
-        binding = fused_moe.bind(
-            quant_info.plan,
-            scratch=quant_info.scratch,
-            a=x,
-            experts=quant_info.experts,
-            topk_ids=topk_ids,
-            topk_weights=topk_weights,
-            output=out,
-        )
-        fused_moe.run(binding=binding)
+    quant_info.launch(x, topk_ids, topk_weights, out)
 
     return StandardCombineInput(hidden_states=out)

--- a/python/sglang/srt/layers/moe/moe_runner/runner.py
+++ b/python/sglang/srt/layers/moe/moe_runner/runner.py
@@ -88,6 +88,8 @@ class MoeRunner:
             self.runner_core = None  # FlashInfer CUTLASS only supports fused path
         elif runner_backend.is_flashinfer_mxfp4():
             self.runner_core = None  # FlashInfer MXFP4 only supports fused path
+        elif runner_backend.is_b12x():
+            self.runner_core = None  # b12x only supports the fused path
             # Import flashinfer_cutlass here (not at module top, to avoid a circular
             # import) to register the flashinfer_mxfp4 fused func before the pool lookup.
             from sglang.srt.layers.moe.moe_runner import (  # noqa: F401

--- a/python/sglang/srt/layers/moe/moe_runner/runner.py
+++ b/python/sglang/srt/layers/moe/moe_runner/runner.py
@@ -88,13 +88,13 @@ class MoeRunner:
             self.runner_core = None  # FlashInfer CUTLASS only supports fused path
         elif runner_backend.is_flashinfer_mxfp4():
             self.runner_core = None  # FlashInfer MXFP4 only supports fused path
-        elif runner_backend.is_b12x():
-            self.runner_core = None  # b12x only supports the fused path
             # Import flashinfer_cutlass here (not at module top, to avoid a circular
             # import) to register the flashinfer_mxfp4 fused func before the pool lookup.
             from sglang.srt.layers.moe.moe_runner import (  # noqa: F401
                 flashinfer_cutlass,
             )
+        elif runner_backend.is_b12x():
+            self.runner_core = None  # b12x only supports the fused path
         elif runner_backend.is_cutlass():
             self.runner_core = None  # CUTLASS uses the direct cutlass_moe_fp4 path
         elif runner_backend.is_hpc_ops():

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -105,6 +105,7 @@ class MoeRunnerBackend(Enum):
     FLASHINFER_CUTLASS = "flashinfer_cutlass"
     FLASHINFER_MXFP4 = "flashinfer_mxfp4"
     FLASHINFER_CUTEDSL = "flashinfer_cutedsl"
+    B12X = "b12x"
     CUTLASS = "cutlass"
     MARLIN = "marlin"
     HUMMING = "humming"
@@ -152,6 +153,9 @@ class MoeRunnerBackend(Enum):
 
     def is_flashinfer_mxfp4(self):
         return self == MoeRunnerBackend.FLASHINFER_MXFP4
+
+    def is_b12x(self):
+        return self == MoeRunnerBackend.B12X
 
     def is_cutlass(self):
         return self == MoeRunnerBackend.CUTLASS

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -400,6 +400,13 @@ class Fp8Config(QuantizationConfig):
 
                 return Mxfp4HummingMoEMethod(fp8_method, prefix=prefix)
 
+            if self.is_fp4_experts and get_moe_runner_backend().is_b12x():
+                from sglang.srt.layers.quantization.mxfp4_b12x_moe import (
+                    Mxfp4B12xMoEMethod,
+                )
+
+                return Mxfp4B12xMoEMethod(fp8_method, prefix=prefix)
+
             if self.is_fp4_experts and get_moe_runner_backend().is_flashinfer_mxfp4():
                 # SM100 uses TRT-LLM; SM90 uses W4A16 and SM120 uses MXFP8xMXFP4.
                 if is_sm90_supported() or is_sm120_supported():

--- a/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
@@ -136,11 +136,10 @@ def _core_token_counts(max_tokens: int, tokens_per_seq: int) -> tuple[int, ...]:
     counts = set()
     batch_sizes = list(range(1, 33))
     try:
-        from sglang.srt.server_args import get_global_server_args
+        from sglang.srt.runtime_context import get_exec
 
-        decode = getattr(
-            getattr(get_global_server_args(), "cuda_graph_config", None), "decode", None
-        )
+        cg_config = get_exec().graph.cuda_graph_config
+        decode = cg_config.decode if cg_config is not None else None
         batch_sizes = list(getattr(decode, "bs", None) or batch_sizes)
     except Exception:
         # No server context (unit tests, offline use): the dense 1..32 ladder
@@ -515,12 +514,9 @@ class Mxfp4B12xMoEMethod:
         ones = torch.ones(num_experts, dtype=torch.float32, device=device)
 
         try:
-            from sglang.srt.server_args import get_global_server_args
+            from sglang.srt.runtime_context import get_spec
 
-            spec_tokens = int(
-                getattr(get_global_server_args(), "speculative_num_draft_tokens", None)
-                or 1
-            )
+            spec_tokens = int(get_spec().speculative_num_draft_tokens or 1)
         except Exception:
             spec_tokens = 1
 

--- a/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
@@ -1,0 +1,642 @@
+"""DeepSeek-V4 MXFP4 expert backend backed by the b12x W4A16 fused MoE.
+
+Same checkpoint as :mod:`mxfp4_flashinfer_cutlass_moe`, different runtime: one
+fused kernel per expert layer instead of seven, and bf16 activations instead of
+MXFP8.
+
+This uses the standalone ``b12x`` package rather than the copy vendored inside
+FlashInfer. Three things depend on that choice:
+
+* ``source_format="fp4_e8m0_k32"`` consumes the checkpoint's E8M0 K/32 block
+  scales byte for byte, so there is no scale relayout to get wrong.
+* ``swiglu_limit`` is honoured. DSv4-Flash asks for a SwiGLU clamp at 10.0 and
+  it binds on real data (gate magnitudes reach 10.1, and half the layers sit
+  within 7% of the limit), so dropping it is a correctness change, not a
+  rounding one.
+* Kernels are warmed before CUDA graph capture. b12x specializes on token
+  count only as ``size_m == 1`` vs everything else (``_m_specialization_key``
+  in its w4a16 kernel), so this is two compiles, not one per prompt length --
+  but it refuses to compile at all while a graph is being captured, which is
+  what the warm-up exists for.
+
+Install with ``pip install --no-deps b12x==1.2.2``; without ``--no-deps`` pip
+pulls a newer torch and breaks the rest of the image.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from typing import TYPE_CHECKING, Any
+
+import torch
+from torch.nn import Module
+from torch.nn.parameter import Parameter
+
+from sglang.srt.environ import envs
+from sglang.srt.utils import log_info_on_rank0
+from sglang.srt.utils.common import is_sm120_supported
+
+# Suppress TRT-LLM CUTLASS trace logs without overriding user configuration.
+os.environ.setdefault("TLLM_LOG_LEVEL", "INFO")
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.moe.token_dispatcher import CombineInput, DispatchOutput
+
+# One scratch buffer per (num_experts, k, n, top_k, device), shared by every
+# layer: they run sequentially and it is pure scratch. Allocated at load time so
+# it can never land in a CUDA graph's private memory pool -- a buffer first
+# allocated during capture is only valid inside that graph, and reusing it from
+# an un-captured forward faults.
+_B12X_SCRATCH: dict = {}
+
+# Every expert layer in the model has the same shape, so they share one weight
+# plan. That is not just a memory saving: b12x's compiled-kernel cache is keyed
+# per plan, so sharing means the warm-up below compiles each token count once
+# for the whole model instead of once per layer.
+_B12X_WEIGHT_PLANS: dict = {}
+
+
+def _select_b12x_distribution() -> None:
+    """Put the pinned b12x on sys.path ahead of whatever pip installed.
+
+    b12x 1.2.2 generalized its W4A16 kernel to also serve trellis rotation,
+    extra gating modes, expert maps and activation-amax collection. The
+    weights and scales
+    went from ``cute.Tensor`` (compile-time-static strides) to raw
+    ``cute.Pointer`` with layouts rebuilt at runtime, which costs 14 registers
+    and ~19% on this shape -- measured at 875.6 us/call against 707.9 for
+    0.15.3, same GPU, same weights, same inputs, bit-identical outputs.
+    DSv4-Flash uses none of the features that bought.
+    """
+    path = envs.SGLANG_B12X_PATH.get()
+    if not path:
+        return
+    if not os.path.isdir(os.path.join(path, "b12x")):
+        raise FileNotFoundError(f"SGLANG_B12X_PATH={path!r} has no b12x package.")
+    loaded = sys.modules.get("b12x")
+    if loaded is not None:
+        # Idempotent: this runs once per expert layer. Only a b12x already
+        # imported from somewhere else is a problem, and it is fatal -- the two
+        # generations share a module name but not an API.
+        want = os.path.realpath(path)
+        got = os.path.realpath(os.path.dirname(os.path.dirname(loaded.__file__)))
+        if want != got:
+            raise RuntimeError(
+                f"SGLANG_B12X_PATH={path!r} came too late: b12x was already "
+                f"imported from {loaded.__file__}."
+            )
+        return
+    sys.path.insert(0, path)
+
+
+def is_b12x_available() -> bool:
+    try:
+        _select_b12x_distribution()
+        import b12x  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def _b12x_is_legacy() -> bool:
+    """True for the 0.15.3-era API (``b12x.integration.tp_moe``)."""
+    import b12x  # noqa: F401
+
+    try:
+        import b12x.moe.fused_moe  # noqa: F401
+
+        return False
+    except ImportError:
+        return True
+
+
+def _b12x_max_tokens() -> int:
+    """Upper bound on tokens in a single MoE call (prefill is chunked)."""
+    return envs.SGLANG_B12X_MAX_TOKENS.get()
+
+
+def _core_token_counts(max_tokens: int, tokens_per_seq: int) -> tuple[int, ...]:
+    """Token counts to plan capacity for, and to warm kernels at.
+
+    Under CUDA graph capture b12x refuses to compile (``_require_cached``) and
+    falls back to the plan's pinned tile config, which does not fit every block
+    size -- so the launch fails outright rather than running slowly. Every token
+    count a captured graph can present must therefore have been run once
+    already. Decode graphs are captured at the configured batch sizes times the
+    speculative window; prefill is chunked, so a power-of-two ladder covers it.
+
+    Kernel compilation dedupes down to two variants (see ``_warmup``); the rest
+    of this ladder is what sizes the scratch arena.
+    """
+    counts = set()
+    batch_sizes = list(range(1, 33))
+    try:
+        from sglang.srt.server_args import get_global_server_args
+
+        decode = getattr(
+            getattr(get_global_server_args(), "cuda_graph_config", None), "decode", None
+        )
+        batch_sizes = list(getattr(decode, "bs", None) or batch_sizes)
+    except Exception:
+        # No server context (unit tests, offline use): the dense 1..32 ladder
+        # already covers every batch size a decode graph can be captured at.
+        pass
+    for bs in batch_sizes:
+        counts.add(bs * max(tokens_per_seq, 1))
+    n = 128
+    while n <= max_tokens:
+        counts.add(n)
+        n *= 2
+    counts.add(max_tokens)
+    return tuple(sorted(c for c in counts if 0 < c <= max_tokens))
+
+
+_BLOCKS_PER_SM_RELAXED = False
+
+
+def _relax_blocks_per_sm() -> None:
+    """Undo b12x's one-CTA-per-SM pin for moe_block_size==8.
+
+    b12x pins ``blocks_per_sm = 1`` whenever the routed block size is 8, to keep
+    the fused kernel's grid-barrier atomic from serializing across a wide grid.
+    Every decode token count lands on block size 8 here -- the routed fill test
+    is ``m * top_k / num_experts < 0.9 * 8``, so any m below ~308 takes it -- and
+    GB10 has 48 SMs, so the pin runs the machine at grid 48 where the unpinned
+    heuristic would pick 144.
+
+    Must run before the kernels are compiled: ``blocks_per_sm`` is part of the
+    launch bounds and therefore of b12x's kernel cache key, and b12x refuses to
+    compile during CUDA graph capture.
+    """
+    global _BLOCKS_PER_SM_RELAXED
+    if _BLOCKS_PER_SM_RELAXED:
+        return
+    from b12x.moe._shared.kernels.w4a16 import kernel as b12x_kernel
+
+    original = b12x_kernel._determine_blocks_per_sm
+
+    def _unpinned(*args, **kwargs):
+        # Route to the cta_m_blocks==1 branch, which caps at 4 rather than 1.
+        # This also picks the uses_m_block_8=False register count (143 vs 120),
+        # the more conservative of the two, so occupancy stays achievable.
+        kwargs["uses_m_block_8"] = False
+        return original(*args, **kwargs)
+
+    b12x_kernel._determine_blocks_per_sm = _unpinned
+    _BLOCKS_PER_SM_RELAXED = True
+    log_info_on_rank0(
+        logger, "b12x: dropped the one-CTA-per-SM pin for moe_block_size==8."
+    )
+
+
+def _warmup(*, plan, scratch, experts, top_k, num_experts, hidden_size, device, counts):
+    """Compile one kernel per token count, outside CUDA graph capture.
+
+    b12x refuses to compile while a graph is being captured, and falls back to
+    the plan's pinned tile config -- which does not fit every block size, so the
+    launch fails outright rather than running slowly. ``core_token_counts``
+    only declares the counts; it does not compile them. So every count a
+    captured graph can present has to be run once here, eagerly, first.
+    """
+    from b12x.moe import fused_moe
+
+    for tokens in counts:
+        a = torch.zeros(tokens, hidden_size, dtype=torch.bfloat16, device=device)
+        topk_ids = torch.arange(tokens * top_k, dtype=torch.int32, device=device)
+        topk_ids = (topk_ids % num_experts).view(tokens, top_k)
+        topk_weights = torch.full(
+            (tokens, top_k), 1.0 / top_k, dtype=torch.float32, device=device
+        )
+        out = torch.empty(tokens, hidden_size, dtype=torch.bfloat16, device=device)
+        fused_moe.run(
+            binding=fused_moe.bind(
+                plan,
+                scratch=scratch,
+                a=a,
+                experts=experts,
+                topk_ids=topk_ids,
+                topk_weights=topk_weights,
+                output=out,
+            )
+        )
+    torch.cuda.synchronize()
+
+
+_B12X_WARMED = False
+
+
+def _warmup_legacy(*, launch, top_k, num_experts, hidden_size, device, counts):
+    """Compile the 0.15.3 kernels before any CUDA graph capture."""
+    global _B12X_WARMED
+    for tokens in counts:
+        a = torch.zeros(tokens, hidden_size, dtype=torch.bfloat16, device=device)
+        ids = torch.arange(tokens * top_k, dtype=torch.int32, device=device)
+        ids = (ids % num_experts).view(tokens, top_k)
+        w = torch.full((tokens, top_k), 1.0 / top_k, dtype=torch.float32, device=device)
+        out = torch.empty(tokens, hidden_size, dtype=torch.bfloat16, device=device)
+        launch(a, ids, w, out)
+    torch.cuda.synchronize()
+    _B12X_WARMED = True
+
+
+def _legacy_prepare(*, w13, s13, w2, s2, ones):
+    """0.15.3 weight prep. Repacks in place, so the caller's tensors stay live."""
+    from b12x.integration import prepare_b12x_fp4_moe_weights
+
+    return prepare_b12x_fp4_moe_weights(
+        source_format="fp4_e8m0_k32",
+        w13_layout="up_gate",
+        w1_fp4=w13,
+        w1_blockscale=s13,
+        w1_global_scale=ones,
+        a1_gscale=ones,
+        w2_fp4=w2,
+        w2_blockscale=s2,
+        w2_global_scale=ones,
+        a2_gscale=ones,
+        activation="silu",
+        params_dtype=torch.bfloat16,
+        prepare_runtime_alphas=False,
+        prepare_w4a16=True,
+        reuse_input_storage=True,
+    )
+
+
+def _legacy_plan(
+    *, num_experts, hidden_size, intermediate, top_k, device, swiglu_limit, counts
+):
+    """0.15.3 scratch plan. Returns (plan, scratch)."""
+    from b12x.integration.tp_moe import TPMoEScratchCaps, plan_tp_moe_scratch
+
+    caps = TPMoEScratchCaps(
+        max_tokens=max(counts),
+        weight_E=num_experts,
+        k=hidden_size,
+        n=intermediate,
+        num_topk=top_k,
+        device=device,
+        dtype=torch.bfloat16,
+        core_token_counts=tuple(counts),
+        route_num_experts=0,
+        route_logits_dtype=None,
+        quant_mode="w4a16",
+        activation="silu",
+        apply_router_weight_on_input=False,
+        swiglu_limit=swiglu_limit,
+        source_format="fp4_e8m0_k32",
+        w13_layout="up_gate",
+        frozen=True,
+    )
+    plan = plan_tp_moe_scratch(caps)
+    specs = plan.scratch_specs()
+    if len(specs) != 1 or specs[0].dtype != torch.uint8:
+        raise RuntimeError(f"unexpected b12x scratch specs: {specs}")
+    scratch = torch.empty(int(specs[0].shape[0]), dtype=torch.uint8, device=device)
+    return plan, scratch
+
+
+def _legacy_launcher(*, plan, scratch, prepared, w13, s13, w2, s2, ones, swiglu_limit):
+    """Bind-and-run closure for 0.15.3, matching vLLM's call sequence."""
+    from b12x.integration.tp_moe import b12x_moe_fp4
+
+    packed = prepared.w4a16
+    w1_alphas = prepared.w1_runtime_alphas
+    w2_alphas = prepared.w2_runtime_alphas
+    if w1_alphas is None:
+        w1_alphas = ones
+    if w2_alphas is None:
+        w2_alphas = ones
+
+    def launch(a, topk_ids, topk_weights, out):
+        b12x_moe_fp4(
+            binding=plan.bind(
+                scratch=scratch,
+                a=a,
+                a1_gscale=ones,
+                w1_fp4=w13,
+                w1_blockscale=s13,
+                w1_alphas=w1_alphas,
+                a2_gscale=ones,
+                w2_fp4=w2,
+                w2_blockscale=s2,
+                w2_alphas=w2_alphas,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                output=out,
+                activation="silu",
+                quant_mode="w4a16",
+                source_format="fp4_e8m0_k32",
+                w13_layout="up_gate",
+                prepared_w4a16=packed,
+                swiglu_limit=swiglu_limit,
+            )
+        )
+
+    return launch
+
+
+def _get_weight_plan(*, num_experts: int, hidden_size: int, intermediate: int):
+    """One weight plan per shape, shared by every expert layer."""
+    from b12x.moe import fused_moe
+
+    key = (num_experts, hidden_size, intermediate)
+    plan = _B12X_WEIGHT_PLANS.get(key)
+    if plan is None:
+        plan = fused_moe.plan_weights(
+            quant_modes="w4a16",
+            source_format="fp4_e8m0_k32",
+            activation="silu",
+            params_dtype=torch.bfloat16,
+            num_experts=num_experts,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate,
+            w13_layout="up_gate",
+        )
+        _B12X_WEIGHT_PLANS[key] = plan
+    return plan
+
+
+def _get_scratch(
+    *,
+    weight_plan,
+    top_k: int,
+    device,
+    swiglu_limit,
+    tokens_per_seq,
+    experts,
+    num_experts: int,
+    hidden_size: int,
+):
+    """Plan and allocate the shared scratch buffer, once per shape."""
+    from b12x.moe import fused_moe
+
+    max_tokens = _b12x_max_tokens()
+    key = (id(weight_plan), top_k, str(device), swiglu_limit)
+    entry = _B12X_SCRATCH.get(key)
+    if entry is None:
+        if envs.SGLANG_B12X_RELAX_BLOCKS_PER_SM.get():
+            _relax_blocks_per_sm()
+        counts = _core_token_counts(max_tokens, tokens_per_seq)
+        caps = fused_moe.Caps(
+            max_tokens=max_tokens,
+            num_topk=top_k,
+            device=device,
+            weight_plan=weight_plan,
+            quant_mode="w4a16",
+            swiglu_limit=swiglu_limit,
+            core_token_counts=counts,
+            frozen=True,
+        )
+        plan = fused_moe.plan(caps)
+        scratch = torch.empty(
+            fused_moe.required_nbytes(caps), dtype=torch.uint8, device=device
+        )
+        log_info_on_rank0(
+            logger,
+            f"Compiling {len(counts)} b12x W4A16 kernels "
+            f"(token counts {counts[0]}..{counts[-1]})...",
+        )
+        _warmup(
+            plan=plan,
+            scratch=scratch,
+            experts=experts,
+            top_k=top_k,
+            num_experts=num_experts,
+            hidden_size=hidden_size,
+            device=device,
+            counts=counts,
+        )
+        entry = (plan, scratch)
+        _B12X_SCRATCH[key] = entry
+    return entry
+
+
+class Mxfp4B12xMoEMethod:
+    """b12x MXFP4 MoE: one fused W4A16 kernel per expert layer."""
+
+    def __init__(self, fp8_method, prefix: str):
+        if not is_b12x_available():
+            raise RuntimeError(
+                "The b12x MoE backend needs the b12x package: "
+                "pip install --no-deps b12x==1.2.2"
+            )
+        if not is_sm120_supported():
+            raise RuntimeError("Mxfp4B12xMoEMethod requires SM120 or SM121.")
+        self._fp8 = fp8_method
+        self.prefix = prefix
+        self._experts: Any = None
+        self._plan: Any = None
+        self._scratch: torch.Tensor | None = None
+        self._swiglu_limit: float | None = None
+        # Set on the 0.15.3 path, where the whole call is a prepared closure.
+        self._launch: Any = None
+        self._legacy_keepalive: Any = None
+        self._ep_guard = False
+
+    @property
+    def load_up_proj_weight_first(self) -> bool:
+        """Load W13 as ``[up; gate]`` -- declared to b12x as w13_layout='up_gate'."""
+        return True
+
+    def create_weights(
+        self,
+        layer: Module,
+        num_experts: int,
+        hidden_size: int,
+        intermediate_size_per_partition: int,
+        params_dtype,
+        **extra_weight_attrs,
+    ):
+        if hidden_size % 128 != 0 or intermediate_size_per_partition % 128 != 0:
+            raise ValueError(
+                "Mxfp4B12xMoEMethod requires hidden_size and "
+                "intermediate_size_per_partition to be multiples of 128 "
+                f"(got hidden={hidden_size}, "
+                f"intermediate={intermediate_size_per_partition})."
+            )
+        # Keep checkpoint scales in native E8M0: b12x consumes those bytes as-is.
+        self._fp8.create_weights(
+            layer,
+            num_experts,
+            hidden_size,
+            intermediate_size_per_partition,
+            params_dtype,
+            fp4_scale_dtype=torch.float8_e8m0fnu,
+            **extra_weight_attrs,
+        )
+
+    def create_moe_runner(self, layer: Module, moe_runner_config) -> None:
+        from sglang.srt.layers.moe.moe_runner.runner import MoeRunner
+        from sglang.srt.layers.moe.utils import MoeRunnerBackend
+
+        self.moe_runner_config = moe_runner_config
+        self._swiglu_limit = getattr(moe_runner_config, "swiglu_limit", None)
+        # -1 expert sentinels exist only under expert parallelism; resolve once
+        # so the per-forward path can skip the guard entirely at EP=1.
+        from sglang.srt.runtime_context import get_parallel
+
+        self._ep_guard = get_parallel().moe_ep_size > 1
+
+        # Register the fused func at runner construction so the FusedOpPool
+        # lookup at `MoeRunner.__init__` finds it.
+        import sglang.srt.layers.moe.moe_runner.b12x  # noqa: F401
+
+        self.runner = MoeRunner(MoeRunnerBackend.B12X, moe_runner_config)
+
+    def process_weights_after_loading(self, layer: Module) -> None:
+        # Preserve the base FP4 post-load handling.
+        self._fp8.process_weights_after_loading(layer)
+        if getattr(layer, "_mega_moe_weights_built", False):
+            return
+
+        for name in ("w13_weight_scale_inv", "w2_weight_scale_inv"):
+            scale = getattr(layer, name)
+            if scale.dtype != torch.float8_e8m0fnu:
+                raise TypeError(
+                    f"{name} must stay native E8M0: it is a hard input contract "
+                    f"of source_format='fp4_e8m0_k32'. Got {scale.dtype}."
+                )
+
+        log_info_on_rank0(
+            logger,
+            f"Preparing DSv4 MXFP4 experts for b12x W4A16 "
+            f"(layer: {self.prefix}, swiglu_limit={self._swiglu_limit})...",
+        )
+
+        device = layer.w13_weight.device
+        num_experts, two_n, k_half = layer.w13_weight.shape
+        hidden_size = k_half * 2
+        intermediate = two_n // 2
+        ones = torch.ones(num_experts, dtype=torch.float32, device=device)
+
+        try:
+            from sglang.srt.server_args import get_global_server_args
+
+            spec_tokens = int(
+                getattr(get_global_server_args(), "speculative_num_draft_tokens", None)
+                or 1
+            )
+        except Exception:
+            spec_tokens = 1
+
+        if _b12x_is_legacy():
+            # 0.15.3: one call prepares the weights in place, and the scratch
+            # plan is built straight from the shapes -- there is no separate
+            # weight plan to share between layers.
+            w13 = layer.w13_weight.data.view(torch.uint8)
+            s13 = layer.w13_weight_scale_inv.data.view(torch.uint8)
+            w2 = layer.w2_weight.data.view(torch.uint8)
+            s2 = layer.w2_weight_scale_inv.data.view(torch.uint8)
+            prepared = _legacy_prepare(w13=w13, s13=s13, w2=w2, s2=s2, ones=ones)
+            counts = _core_token_counts(_b12x_max_tokens(), spec_tokens)
+            plan, scratch = _legacy_plan(
+                num_experts=num_experts,
+                hidden_size=hidden_size,
+                intermediate=intermediate,
+                top_k=int(layer.top_k),
+                device=device,
+                swiglu_limit=self._swiglu_limit,
+                counts=counts,
+            )
+            self._launch = _legacy_launcher(
+                plan=plan,
+                scratch=scratch,
+                prepared=prepared,
+                w13=w13,
+                s13=s13,
+                w2=w2,
+                s2=s2,
+                ones=ones,
+                swiglu_limit=self._swiglu_limit,
+            )
+            # reuse_input_storage=True: the prepared package aliases these
+            # tensors, so they must stay reachable. Keep the Parameters as they
+            # are and hold our own references.
+            self._legacy_keepalive = (prepared, w13, s13, w2, s2, ones, plan, scratch)
+            # Same reason as the 1.2.2 path: b12x will not compile while a CUDA
+            # graph is being captured, so every shape a graph can present has to
+            # have run once already.
+            if not _B12X_WARMED:
+                log_info_on_rank0(
+                    logger,
+                    f"Compiling b12x 0.15.3 W4A16 kernels for {len(counts)} "
+                    f"token counts ({counts[0]}..{counts[-1]})...",
+                )
+                _warmup_legacy(
+                    launch=self._launch,
+                    top_k=int(layer.top_k),
+                    num_experts=num_experts,
+                    hidden_size=hidden_size,
+                    device=device,
+                    counts=counts,
+                )
+            layer._dsv4_mxfp4_backend = "b12x_sm12x_015"
+            return
+
+        from b12x.moe import fused_moe
+
+        weight_plan = _get_weight_plan(
+            num_experts=num_experts,
+            hidden_size=hidden_size,
+            intermediate=intermediate,
+        )
+        self._experts = fused_moe.prepare_weights(
+            plan=weight_plan,
+            params_dtype=torch.bfloat16,
+            w1_fp4=layer.w13_weight.data.view(torch.uint8),
+            w1_blockscale=layer.w13_weight_scale_inv.data.view(torch.uint8),
+            w1_global_scale=ones,
+            w2_fp4=layer.w2_weight.data.view(torch.uint8),
+            w2_blockscale=layer.w2_weight_scale_inv.data.view(torch.uint8),
+            w2_global_scale=ones,
+            a1_gscale=ones,
+            a2_gscale=ones,
+        )
+        self._plan, self._scratch = _get_scratch(
+            weight_plan=weight_plan,
+            top_k=int(layer.top_k),
+            device=device,
+            swiglu_limit=self._swiglu_limit,
+            tokens_per_seq=spec_tokens,
+            experts=self._experts,
+            num_experts=num_experts,
+            hidden_size=hidden_size,
+        )
+
+        # b12x owns the runtime weights from here on. Whether it aliased the
+        # checkpoint storage or copied it is its choice; either way nothing else
+        # reads these Parameters again.
+        def _release(param: torch.Tensor) -> Parameter:
+            return Parameter(
+                torch.empty(0, dtype=param.dtype, device=param.device),
+                requires_grad=False,
+            )
+
+        layer.w13_weight = _release(layer.w13_weight)
+        layer.w2_weight = _release(layer.w2_weight)
+        layer.w13_weight_scale_inv = _release(layer.w13_weight_scale_inv)
+        layer.w2_weight_scale_inv = _release(layer.w2_weight_scale_inv)
+        torch.cuda.empty_cache()
+
+        layer._dsv4_mxfp4_backend = "b12x_sm12x"
+
+    def apply(
+        self,
+        layer: Module,
+        dispatch_output: DispatchOutput,
+    ) -> CombineInput:
+        from sglang.srt.layers.moe.moe_runner.b12x import B12xMoeQuantInfo
+
+        quant_info = B12xMoeQuantInfo(
+            experts=self._experts,
+            plan=self._plan,
+            scratch=self._scratch,
+            launch=self._launch,
+            ep_guard=self._ep_guard,
+        )
+        return self.runner.run(dispatch_output, quant_info)

--- a/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
@@ -1,8 +1,12 @@
-"""DeepSeek-V4 MXFP4 expert backend backed by the b12x W4A16 fused MoE.
+"""DeepSeek-V4 MXFP4 expert backend backed by the b12x fused MoE.
 
 Same checkpoint as :mod:`mxfp4_flashinfer_cutlass_moe`, different runtime: one
-fused kernel per expert layer instead of seven, and bf16 activations instead of
-MXFP8.
+fused kernel per expert layer instead of seven.
+
+The quant mode is ``SGLANG_B12X_MOE_QUANT_MODE``, passed to b12x verbatim. It
+defaults to ``w4a8_mx`` (activations quantized to MXFP8-E4M3 in-kernel), the
+recipe the official vLLM DGX Spark image runs and where all of b12x's GB10 MoE
+tuning lives; ``w4a16`` keeps bf16 activations on a load-time frozen plan.
 
 This targets exactly one generation of the standalone ``b12x`` package: the
 op-registry API (``b12x.moe.fused_moe``, ``Caps -> plan() -> bind() -> run()``)
@@ -152,12 +156,14 @@ def _warmup(*, launch, top_k, num_experts, hidden_size, device, counts):
     _B12X_WARMED = True
 
 
-def _prepare_weights(*, w13, s13, w2, s2, ones, num_experts, hidden_size, intermediate):
+def _prepare_weights(
+    *, w13, s13, w2, s2, ones, num_experts, hidden_size, intermediate, quant_mode
+):
     """Weight plan + prep. Repacks in place, so the caller's tensors stay live."""
     from b12x.moe import fused_moe
 
     weight_plan = fused_moe.plan_weights(
-        quant_modes="w4a16",
+        quant_modes=quant_mode,
         source_format="fp4_e8m0_k32",
         activation="silu",
         params_dtype=torch.bfloat16,
@@ -233,7 +239,7 @@ def _plan_scratch(*, experts, top_k, device, swiglu_limit, counts):
 
 
 def _make_launcher(*, plan, scratch, experts):
-    """Bind-and-run closure, matching vLLM's call sequence."""
+    """W4A16 bind-and-run closure over the load-time frozen plan."""
     from b12x.moe import fused_moe
 
     def launch(a, topk_ids, topk_weights, out):
@@ -255,8 +261,92 @@ def _make_launcher(*, plan, scratch, experts):
     return launch
 
 
+def _plan_a8_arena(*, experts, top_k, device, swiglu_limit, counts, quant_mode):
+    """Shared arena for the W4A8 per-forward-planned path.
+
+    W4A8 selects its implementation (micro vs dynamic) and tile regime from
+    the live token count, so the plan is rebuilt per call, vLLM-style --
+    b12x's planning is host-only, allocation- and compile-free for this
+    recipe, and under full-graph capture it runs once per bucket at capture
+    time. Only the arena is fixed: sized here over the whole count ladder
+    (required_nbytes covers every bucketed count including the micro/dynamic
+    cutover), shared by every layer and every per-call plan.
+    """
+    from b12x.moe import fused_moe
+
+    from sglang.srt.runtime_context import get_resources
+
+    fingerprint = (
+        quant_mode,
+        int(top_k),
+        tuple(counts),
+        None if swiglu_limit is None else float(swiglu_limit),
+        int(experts.num_experts),
+        int(experts.hidden_size),
+        int(experts.intermediate_size),
+    )
+    buffers = get_resources().buffers
+    key = f"b12x:moe_a8_arena:{device}"
+    cached = buffers.get(key)
+    if cached is not None and cached[0] == fingerprint:
+        return cached[1]
+    caps = fused_moe.Caps(
+        max_tokens=max(counts),
+        num_topk=top_k,
+        device=device,
+        weight_plan=experts.plan,
+        core_token_counts=tuple(counts),
+        route_num_experts=0,
+        route_logits_dtype=None,
+        quant_mode=quant_mode,
+        apply_router_weight_on_input=False,
+        swiglu_limit=swiglu_limit,
+        frozen=True,
+    )
+    arena = torch.empty(
+        int(fused_moe.required_nbytes(caps)), dtype=torch.uint8, device=device
+    )
+    buffers[key] = (fingerprint, arena)
+    return arena
+
+
+def _make_launcher_a8(*, arena, experts, top_k, device, swiglu_limit, quant_mode):
+    """W4A8 bind-and-run closure; plans at the live token count per call."""
+    from b12x.moe import fused_moe
+
+    def launch(a, topk_ids, topk_weights, out):
+        m = max(1, int(a.shape[0]))
+        caps = fused_moe.Caps(
+            max_tokens=m,
+            num_topk=top_k,
+            device=device,
+            weight_plan=experts.plan,
+            core_token_counts=(m,),
+            route_num_experts=0,
+            route_logits_dtype=None,
+            quant_mode=quant_mode,
+            apply_router_weight_on_input=False,
+            swiglu_limit=swiglu_limit,
+            frozen=True,
+        )
+        plan = fused_moe.plan(caps)
+        fused_moe.run(
+            binding=plan.bind(
+                scratch=arena,
+                a=a,
+                experts=experts,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                output=out,
+                input_scales_static=True,
+            )
+        )
+
+    return launch
+
+
 class Mxfp4B12xMoEMethod:
-    """b12x MXFP4 MoE: one fused W4A16 kernel per expert layer."""
+    """b12x MXFP4 MoE: one fused kernel per expert layer."""
 
     def __init__(self, fp8_method, prefix: str):
         _require_aligned_generation()
@@ -334,9 +424,12 @@ class Mxfp4B12xMoEMethod:
                     f"of source_format='fp4_e8m0_k32'. Got {scale.dtype}."
                 )
 
+        # Passed straight to b12x. "w4a16" is the frozen-plan path; every other
+        # mode quantizes activations in-kernel and plans per call.
+        quant_mode = envs.SGLANG_B12X_MOE_QUANT_MODE.get()
         log_info_on_rank0(
             logger,
-            f"Preparing DSv4 MXFP4 experts for b12x W4A16 "
+            f"Preparing DSv4 MXFP4 experts for b12x {quant_mode} "
             f"(layer: {self.prefix}, swiglu_limit={self._swiglu_limit})...",
         )
 
@@ -366,26 +459,48 @@ class Mxfp4B12xMoEMethod:
             num_experts=num_experts,
             hidden_size=hidden_size,
             intermediate=intermediate,
+            quant_mode=quant_mode,
         )
         counts = _core_token_counts(_b12x_max_tokens(), spec_tokens)
-        plan, scratch = _plan_scratch(
-            experts=experts,
-            top_k=int(layer.top_k),
-            device=device,
-            swiglu_limit=self._swiglu_limit,
-            counts=counts,
-        )
-        self._launch = _make_launcher(plan=plan, scratch=scratch, experts=experts)
+        if quant_mode != "w4a16":
+            arena = _plan_a8_arena(
+                experts=experts,
+                top_k=int(layer.top_k),
+                device=device,
+                swiglu_limit=self._swiglu_limit,
+                counts=counts,
+                quant_mode=quant_mode,
+            )
+            self._launch = _make_launcher_a8(
+                arena=arena,
+                experts=experts,
+                top_k=int(layer.top_k),
+                device=device,
+                swiglu_limit=self._swiglu_limit,
+                quant_mode=quant_mode,
+            )
+            plan_or_arena = arena
+        else:
+            plan, scratch = _plan_scratch(
+                experts=experts,
+                top_k=int(layer.top_k),
+                device=device,
+                swiglu_limit=self._swiglu_limit,
+                counts=counts,
+            )
+            self._launch = _make_launcher(plan=plan, scratch=scratch, experts=experts)
+            plan_or_arena = (plan, scratch)
         # The prepared weights alias the checkpoint storage (REUSE_SOURCE for
-        # 128-aligned fp4_e8m0_k32), so these tensors must stay reachable. Keep
-        # the Parameters as they are and hold our own references.
-        self._keepalive = (experts, w13, s13, w2, s2, ones, plan, scratch)
+        # 128-aligned fp4_e8m0_k32; w4a8_mx repacks likewise discard the
+        # source Parameters), so these tensors must stay reachable. Keep the
+        # Parameters as they are and hold our own references.
+        self._keepalive = (experts, w13, s13, w2, s2, ones, plan_or_arena)
         # b12x will not compile while a CUDA graph is being captured, so every
         # shape a graph can present has to have run once already.
         if not _B12X_WARMED and envs.SGLANG_B12X_WARMUP.get():
             log_info_on_rank0(
                 logger,
-                f"Compiling b12x W4A16 kernels for {len(counts)} "
+                f"Compiling b12x {quant_mode} kernels for {len(counts)} "
                 f"token counts ({counts[0]}..{counts[-1]})...",
             )
             _warmup(

--- a/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
@@ -1,11 +1,11 @@
-"""DeepSeek-V4 MXFP4 expert backend backed by the b12x W4A16 fused MoE.
+"""DeepSeek-V4 MXFP4 expert backend backed by the b12x 0.15.3 W4A16 fused MoE.
 
 Same checkpoint as :mod:`mxfp4_flashinfer_cutlass_moe`, different runtime: one
 fused kernel per expert layer instead of seven, and bf16 activations instead of
 MXFP8.
 
-This uses the standalone ``b12x`` package rather than the copy vendored inside
-FlashInfer. Three things depend on that choice:
+This targets exactly one generation of the standalone ``b12x`` package: the
+0.15.3 API (``b12x.integration.tp_moe``). Three things depend on that choice:
 
 * ``source_format="fp4_e8m0_k32"`` consumes the checkpoint's E8M0 K/32 block
   scales byte for byte, so there is no scale relayout to get wrong.
@@ -13,27 +13,20 @@ FlashInfer. Three things depend on that choice:
   it binds on real data (gate magnitudes reach 10.1, and half the layers sit
   within 7% of the limit), so dropping it is a correctness change, not a
   rounding one.
-* Kernels are warmed before CUDA graph capture. b12x specializes on token
-  count only as ``size_m == 1`` vs everything else (``_m_specialization_key``
-  in its w4a16 kernel), so this is two compiles, not one per prompt length --
-  but it refuses to compile at all while a graph is being captured, which is
-  what the warm-up exists for.
+* Kernels are warmed before CUDA graph capture: b12x refuses to compile while
+  a graph is being captured and falls back to a pinned tile config that does
+  not fit every block size, so every token count a captured graph can present
+  is compiled eagerly first (see :func:`_core_token_counts`).
 
-Two b12x API generations are supported, auto-detected by import shape
-(:func:`_b12x_is_legacy`); "legacy" throughout this file names the API
-generation, not a recommendation:
+0.15.3 was never published to PyPI. Install it from the source commit whose
+MoE surface matches the released wheel::
 
-* **1.2.2** (``b12x.moe.fused_moe``) is the current PyPI release and the
-  default. Install with ``pip install --no-deps b12x==1.2.2``; without
-  ``--no-deps`` pip pulls a newer torch and breaks the rest of the image.
-* **0.15.3** (``b12x.integration``, the legacy API) was never published to
-  PyPI -- it ships only inside the dspark reference image, and 0.15.2 (the
-  last published 0.15.x) predates the ``fp4_e8m0_k32`` / ``w13_layout``
-  API this file needs -- so it can only come from a checkout
-  (``SGLANG_B12X_PATH``). At the decode working point (M=6) it is ~19%
-  *faster* per call -- see :func:`_select_b12x_distribution` -- while at
-  prefill-sized M the two generations are within noise; that decode delta
-  is why a deployment would bother.
+    pip install --no-deps "b12x @ https://github.com/local-inference-lab/b12x/archive/7dc6fb8fcc6446ea093537d1657df81985fa5f43.tar.gz"
+
+(``--no-deps``: b12x's metadata pulls a newer torch and breaks the rest of the
+image.) Later b12x generations changed the W4A16 kernels (0.20.0) and then the
+API (1.2.x); they are rejected at startup rather than silently producing
+different numerics -- see :func:`_require_015_generation`.
 """
 
 from __future__ import annotations
@@ -45,7 +38,6 @@ from typing import TYPE_CHECKING, Any
 
 import torch
 from torch.nn import Module
-from torch.nn.parameter import Parameter
 
 from sglang.srt.environ import envs
 from sglang.srt.utils import log_info_on_rank0
@@ -59,18 +51,18 @@ logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from sglang.srt.layers.moe.token_dispatcher import CombineInput, DispatchOutput
 
+_B12X_INSTALL_HINT = (
+    "pip install --no-deps 'b12x @ https://github.com/local-inference-lab/"
+    "b12x/archive/7dc6fb8fcc6446ea093537d1657df81985fa5f43.tar.gz'"
+)
+
 
 def _select_b12x_distribution() -> None:
-    """Put the pinned b12x on sys.path ahead of whatever pip installed.
+    """Put a local b12x tree on sys.path ahead of whatever pip installed.
 
-    b12x 1.2.2 generalized its W4A16 kernel to also serve trellis rotation,
-    extra gating modes, expert maps and activation-amax collection. The
-    weights and scales
-    went from ``cute.Tensor`` (compile-time-static strides) to raw
-    ``cute.Pointer`` with layouts rebuilt at runtime, which costs 14 registers
-    and ~19% on this shape -- measured at 875.6 us/call against 707.9 for
-    0.15.3, same GPU, same weights, same inputs, bit-identical outputs.
-    DSv4-Flash uses none of the features that bought.
+    For deployments that carry the 0.15.3 tree as a directory (e.g. extracted
+    from the dspark reference image) instead of pip-installing the pinned
+    source commit. Unset (the default) is a no-op.
     """
     path = envs.SGLANG_B12X_PATH.get()
     if not path:
@@ -80,7 +72,7 @@ def _select_b12x_distribution() -> None:
     loaded = sys.modules.get("b12x")
     if loaded is not None:
         # Idempotent: this runs once per expert layer. Only a b12x already
-        # imported from somewhere else is a problem, and it is fatal -- the two
+        # imported from somewhere else is a problem, and it is fatal -- the
         # generations share a module name but not an API.
         want = os.path.realpath(path)
         got = os.path.realpath(os.path.dirname(os.path.dirname(loaded.__file__)))
@@ -96,23 +88,43 @@ def _select_b12x_distribution() -> None:
 def is_b12x_available() -> bool:
     try:
         _select_b12x_distribution()
-        import b12x  # noqa: F401
+        import b12x.integration.tp_moe  # noqa: F401
 
         return True
     except ImportError:
         return False
 
 
-def _b12x_is_legacy() -> bool:
-    """True for the 0.15.3-era API (``b12x.integration.tp_moe``)."""
-    import b12x  # noqa: F401
+def _require_015_generation() -> None:
+    """Reject b12x generations other than 0.15.x, loudly and at load time.
+
+    0.20.0 rewrote the W4A16 kernels behind the same ``b12x.integration``
+    API (different numerics), and the 1.2.x line replaced the API as well
+    (``b12x.moe.fused_moe``). This backend is validated against 0.15.3 only.
+    A raw source tree without dist-info cannot be version-checked; the
+    ``fused_moe`` probe still rejects the 1.2.x line there.
+    """
+    import importlib.metadata
+
+    import b12x
 
     try:
-        import b12x.moe.fused_moe  # noqa: F401
+        import b12x.moe.fused_moe  # noqa: F401  # the 1.2.x-generation API
 
-        return False
+        has_fused_moe = True
     except ImportError:
-        return True
+        has_fused_moe = False
+    version = None
+    try:
+        version = importlib.metadata.version("b12x")
+    except importlib.metadata.PackageNotFoundError:
+        pass
+    if has_fused_moe or (version is not None and not version.startswith("0.15.")):
+        raise RuntimeError(
+            f"b12x at {b12x.__file__} (version {version or 'unknown'}) is not "
+            "the 0.15.x generation this backend is validated against. "
+            f"Install the pinned source commit: {_B12X_INSTALL_HINT}"
+        )
 
 
 def _b12x_max_tokens() -> int:
@@ -130,8 +142,8 @@ def _core_token_counts(max_tokens: int, tokens_per_seq: int) -> tuple[int, ...]:
     already. Decode graphs are captured at the configured batch sizes times the
     speculative window; prefill is chunked, so a power-of-two ladder covers it.
 
-    Kernel compilation dedupes down to two variants (see ``_warmup``); the rest
-    of this ladder is what sizes the scratch arena.
+    Each count compiles its own kernel (the startup log line counts them), and
+    the same ladder sizes the scratch arena.
     """
     counts = set()
     batch_sizes = list(range(1, 33))
@@ -155,83 +167,14 @@ def _core_token_counts(max_tokens: int, tokens_per_seq: int) -> tuple[int, ...]:
     return tuple(sorted(c for c in counts if 0 < c <= max_tokens))
 
 
-def _relax_blocks_per_sm() -> None:
-    """Undo b12x's one-CTA-per-SM pin for moe_block_size==8.
-
-    b12x pins ``blocks_per_sm = 1`` whenever the routed block size is 8, to keep
-    the fused kernel's grid-barrier atomic from serializing across a wide grid.
-    Every decode token count lands on block size 8 here -- the routed fill test
-    is ``m * top_k / num_experts < 0.9 * 8``, so any m below ~308 takes it -- and
-    GB10 has 48 SMs, so the pin runs the machine at grid 48 where the unpinned
-    heuristic would pick 144.
-
-    Must run before the kernels are compiled: ``blocks_per_sm`` is part of the
-    launch bounds and therefore of b12x's kernel cache key, and b12x refuses to
-    compile during CUDA graph capture.
-    """
-    from b12x.moe._shared.kernels.w4a16 import kernel as b12x_kernel
-
-    original = b12x_kernel._determine_blocks_per_sm
-    # Latched on the patched function itself: the patch is process-global state
-    # inside the b12x module, which reset_context() cannot (and must not) undo.
-    if getattr(original, "_sglang_unpinned", False):
-        return
-
-    def _unpinned(*args, **kwargs):
-        # Route to the cta_m_blocks==1 branch, which caps at 4 rather than 1.
-        # This also picks the uses_m_block_8=False register count (143 vs 120),
-        # the more conservative of the two, so occupancy stays achievable.
-        kwargs["uses_m_block_8"] = False
-        return original(*args, **kwargs)
-
-    _unpinned._sglang_unpinned = True
-    b12x_kernel._determine_blocks_per_sm = _unpinned
-    log_info_on_rank0(
-        logger, "b12x: dropped the one-CTA-per-SM pin for moe_block_size==8."
-    )
-
-
-def _warmup(*, plan, scratch, experts, top_k, num_experts, hidden_size, device, counts):
-    """Compile one kernel per token count, outside CUDA graph capture.
-
-    b12x refuses to compile while a graph is being captured, and falls back to
-    the plan's pinned tile config -- which does not fit every block size, so the
-    launch fails outright rather than running slowly. ``core_token_counts``
-    only declares the counts; it does not compile them. So every count a
-    captured graph can present has to be run once here, eagerly, first.
-    """
-    from b12x.moe import fused_moe
-
-    for tokens in counts:
-        a = torch.zeros(tokens, hidden_size, dtype=torch.bfloat16, device=device)
-        topk_ids = torch.arange(tokens * top_k, dtype=torch.int32, device=device)
-        topk_ids = (topk_ids % num_experts).view(tokens, top_k)
-        topk_weights = torch.full(
-            (tokens, top_k), 1.0 / top_k, dtype=torch.float32, device=device
-        )
-        out = torch.empty(tokens, hidden_size, dtype=torch.bfloat16, device=device)
-        fused_moe.run(
-            binding=fused_moe.bind(
-                plan,
-                scratch=scratch,
-                a=a,
-                experts=experts,
-                topk_ids=topk_ids,
-                topk_weights=topk_weights,
-                output=out,
-            )
-        )
-    torch.cuda.synchronize()
-
-
 # Module-level on purpose: this latch mirrors b12x's own process-global
 # compiled-kernel cache, which reset_context() cannot reset -- re-warming after
 # a context reset would be wasted work, not a correctness need.
 _B12X_WARMED = False
 
 
-def _warmup_legacy(*, launch, top_k, num_experts, hidden_size, device, counts):
-    """Compile the 0.15.3 kernels before any CUDA graph capture."""
+def _warmup(*, launch, top_k, num_experts, hidden_size, device, counts):
+    """Compile the kernels for every count before any CUDA graph capture."""
     global _B12X_WARMED
     for tokens in counts:
         a = torch.zeros(tokens, hidden_size, dtype=torch.bfloat16, device=device)
@@ -244,8 +187,8 @@ def _warmup_legacy(*, launch, top_k, num_experts, hidden_size, device, counts):
     _B12X_WARMED = True
 
 
-def _legacy_prepare(*, w13, s13, w2, s2, ones):
-    """0.15.3 weight prep. Repacks in place, so the caller's tensors stay live."""
+def _prepare_weights(*, w13, s13, w2, s2, ones):
+    """Weight prep. Repacks in place, so the caller's tensors stay live."""
     from b12x.integration import prepare_b12x_fp4_moe_weights
 
     return prepare_b12x_fp4_moe_weights(
@@ -267,10 +210,10 @@ def _legacy_prepare(*, w13, s13, w2, s2, ones):
     )
 
 
-def _legacy_plan(
+def _plan_scratch(
     *, num_experts, hidden_size, intermediate, top_k, device, swiglu_limit, counts
 ):
-    """0.15.3 scratch plan. Returns (plan, scratch)."""
+    """Frozen scratch plan. Returns (plan, scratch)."""
     from b12x.integration.tp_moe import TPMoEScratchCaps, plan_tp_moe_scratch
 
     caps = TPMoEScratchCaps(
@@ -300,8 +243,8 @@ def _legacy_plan(
     return plan, scratch
 
 
-def _legacy_launcher(*, plan, scratch, prepared, w13, s13, w2, s2, ones, swiglu_limit):
-    """Bind-and-run closure for 0.15.3, matching vLLM's call sequence."""
+def _make_launcher(*, plan, scratch, prepared, w13, s13, w2, s2, ones, swiglu_limit):
+    """Bind-and-run closure, matching vLLM's call sequence."""
     from b12x.integration.tp_moe import b12x_moe_fp4
 
     packed = prepared.w4a16
@@ -340,119 +283,24 @@ def _legacy_launcher(*, plan, scratch, prepared, w13, s13, w2, s2, ones, swiglu_
     return launch
 
 
-def _get_weight_plan(*, num_experts: int, hidden_size: int, intermediate: int):
-    """One weight plan per shape, shared by every expert layer.
-
-    Not just a memory saving: b12x's compiled-kernel cache is keyed per plan,
-    so sharing means the warm-up compiles each token count once for the whole
-    model instead of once per layer. Stored on ``get_resources().buffers`` so
-    unit-test teardown (``reset_context``) drops it with everything else.
-    """
-    from b12x.moe import fused_moe
-
-    from sglang.srt.runtime_context import get_resources
-
-    buffers = get_resources().buffers
-    key = f"b12x:weight_plan:{num_experts}:{hidden_size}:{intermediate}"
-    plan = buffers.get(key)
-    if plan is None:
-        plan = fused_moe.plan_weights(
-            quant_modes="w4a16",
-            source_format="fp4_e8m0_k32",
-            activation="silu",
-            params_dtype=torch.bfloat16,
-            num_experts=num_experts,
-            hidden_size=hidden_size,
-            intermediate_size=intermediate,
-            w13_layout="up_gate",
-        )
-        buffers[key] = plan
-    return plan
-
-
-def _get_scratch(
-    *,
-    weight_plan,
-    top_k: int,
-    device,
-    swiglu_limit,
-    tokens_per_seq,
-    experts,
-    num_experts: int,
-    hidden_size: int,
-):
-    """Plan and allocate the shared scratch buffer, once per shape."""
-    from b12x.moe import fused_moe
-
-    from sglang.srt.runtime_context import get_resources
-
-    max_tokens = _b12x_max_tokens()
-    # One scratch arena per shape, shared by every layer: they run sequentially
-    # and it is pure scratch. Allocated at load time so it can never land in a
-    # CUDA graph's private memory pool -- a buffer first allocated during
-    # capture is only valid inside that graph, and reusing it from an
-    # un-captured forward faults.
-    buffers = get_resources().buffers
-    key = f"b12x:scratch:{id(weight_plan)}:{top_k}:{device}:{swiglu_limit}"
-    entry = buffers.get(key)
-    if entry is None:
-        if envs.SGLANG_B12X_RELAX_BLOCKS_PER_SM.get():
-            _relax_blocks_per_sm()
-        counts = _core_token_counts(max_tokens, tokens_per_seq)
-        caps = fused_moe.Caps(
-            max_tokens=max_tokens,
-            num_topk=top_k,
-            device=device,
-            weight_plan=weight_plan,
-            quant_mode="w4a16",
-            swiglu_limit=swiglu_limit,
-            core_token_counts=counts,
-            frozen=True,
-        )
-        plan = fused_moe.plan(caps)
-        scratch = torch.empty(
-            fused_moe.required_nbytes(caps), dtype=torch.uint8, device=device
-        )
-        log_info_on_rank0(
-            logger,
-            f"Compiling {len(counts)} b12x W4A16 kernels "
-            f"(token counts {counts[0]}..{counts[-1]})...",
-        )
-        _warmup(
-            plan=plan,
-            scratch=scratch,
-            experts=experts,
-            top_k=top_k,
-            num_experts=num_experts,
-            hidden_size=hidden_size,
-            device=device,
-            counts=counts,
-        )
-        entry = (plan, scratch)
-        buffers[key] = entry
-    return entry
-
-
 class Mxfp4B12xMoEMethod:
     """b12x MXFP4 MoE: one fused W4A16 kernel per expert layer."""
 
     def __init__(self, fp8_method, prefix: str):
         if not is_b12x_available():
             raise RuntimeError(
-                "The b12x MoE backend needs the b12x package: "
-                "pip install --no-deps b12x==1.2.2"
+                "The b12x MoE backend needs the 0.15.3-generation b12x "
+                f"package: {_B12X_INSTALL_HINT}"
             )
+        _require_015_generation()
         if not is_sm120_supported():
             raise RuntimeError("Mxfp4B12xMoEMethod requires SM120 or SM121.")
         self._fp8 = fp8_method
         self.prefix = prefix
-        self._experts: Any = None
-        self._plan: Any = None
-        self._scratch: torch.Tensor | None = None
         self._swiglu_limit: float | None = None
-        # Set on the 0.15.3 path, where the whole call is a prepared closure.
+        # The whole call is a prepared closure; see _make_launcher.
         self._launch: Any = None
-        self._legacy_keepalive: Any = None
+        self._keepalive: Any = None
         self._ep_guard = False
 
     @property
@@ -538,105 +386,54 @@ class Mxfp4B12xMoEMethod:
         except Exception:
             spec_tokens = 1
 
-        if _b12x_is_legacy():
-            # 0.15.3: one call prepares the weights in place, and the scratch
-            # plan is built straight from the shapes -- there is no separate
-            # weight plan to share between layers.
-            w13 = layer.w13_weight.data.view(torch.uint8)
-            s13 = layer.w13_weight_scale_inv.data.view(torch.uint8)
-            w2 = layer.w2_weight.data.view(torch.uint8)
-            s2 = layer.w2_weight_scale_inv.data.view(torch.uint8)
-            prepared = _legacy_prepare(w13=w13, s13=s13, w2=w2, s2=s2, ones=ones)
-            counts = _core_token_counts(_b12x_max_tokens(), spec_tokens)
-            plan, scratch = _legacy_plan(
-                num_experts=num_experts,
-                hidden_size=hidden_size,
-                intermediate=intermediate,
-                top_k=int(layer.top_k),
-                device=device,
-                swiglu_limit=self._swiglu_limit,
-                counts=counts,
-            )
-            self._launch = _legacy_launcher(
-                plan=plan,
-                scratch=scratch,
-                prepared=prepared,
-                w13=w13,
-                s13=s13,
-                w2=w2,
-                s2=s2,
-                ones=ones,
-                swiglu_limit=self._swiglu_limit,
-            )
-            # reuse_input_storage=True: the prepared package aliases these
-            # tensors, so they must stay reachable. Keep the Parameters as they
-            # are and hold our own references.
-            self._legacy_keepalive = (prepared, w13, s13, w2, s2, ones, plan, scratch)
-            # Same reason as the 1.2.2 path: b12x will not compile while a CUDA
-            # graph is being captured, so every shape a graph can present has to
-            # have run once already.
-            if not _B12X_WARMED:
-                log_info_on_rank0(
-                    logger,
-                    f"Compiling b12x 0.15.3 W4A16 kernels for {len(counts)} "
-                    f"token counts ({counts[0]}..{counts[-1]})...",
-                )
-                _warmup_legacy(
-                    launch=self._launch,
-                    top_k=int(layer.top_k),
-                    num_experts=num_experts,
-                    hidden_size=hidden_size,
-                    device=device,
-                    counts=counts,
-                )
-            layer._dsv4_mxfp4_backend = "b12x_sm12x_015"
-            return
-
-        from b12x.moe import fused_moe
-
-        weight_plan = _get_weight_plan(
+        # One call prepares the weights in place, and the scratch plan is
+        # built straight from the shapes.
+        w13 = layer.w13_weight.data.view(torch.uint8)
+        s13 = layer.w13_weight_scale_inv.data.view(torch.uint8)
+        w2 = layer.w2_weight.data.view(torch.uint8)
+        s2 = layer.w2_weight_scale_inv.data.view(torch.uint8)
+        prepared = _prepare_weights(w13=w13, s13=s13, w2=w2, s2=s2, ones=ones)
+        counts = _core_token_counts(_b12x_max_tokens(), spec_tokens)
+        plan, scratch = _plan_scratch(
             num_experts=num_experts,
             hidden_size=hidden_size,
             intermediate=intermediate,
-        )
-        self._experts = fused_moe.prepare_weights(
-            plan=weight_plan,
-            params_dtype=torch.bfloat16,
-            w1_fp4=layer.w13_weight.data.view(torch.uint8),
-            w1_blockscale=layer.w13_weight_scale_inv.data.view(torch.uint8),
-            w1_global_scale=ones,
-            w2_fp4=layer.w2_weight.data.view(torch.uint8),
-            w2_blockscale=layer.w2_weight_scale_inv.data.view(torch.uint8),
-            w2_global_scale=ones,
-            a1_gscale=ones,
-            a2_gscale=ones,
-        )
-        self._plan, self._scratch = _get_scratch(
-            weight_plan=weight_plan,
             top_k=int(layer.top_k),
             device=device,
             swiglu_limit=self._swiglu_limit,
-            tokens_per_seq=spec_tokens,
-            experts=self._experts,
-            num_experts=num_experts,
-            hidden_size=hidden_size,
+            counts=counts,
         )
-
-        # b12x owns the runtime weights from here on. Whether it aliased the
-        # checkpoint storage or copied it is its choice; either way nothing else
-        # reads these Parameters again.
-        def _release(param: torch.Tensor) -> Parameter:
-            return Parameter(
-                torch.empty(0, dtype=param.dtype, device=param.device),
-                requires_grad=False,
+        self._launch = _make_launcher(
+            plan=plan,
+            scratch=scratch,
+            prepared=prepared,
+            w13=w13,
+            s13=s13,
+            w2=w2,
+            s2=s2,
+            ones=ones,
+            swiglu_limit=self._swiglu_limit,
+        )
+        # reuse_input_storage=True: the prepared package aliases these
+        # tensors, so they must stay reachable. Keep the Parameters as they
+        # are and hold our own references.
+        self._keepalive = (prepared, w13, s13, w2, s2, ones, plan, scratch)
+        # b12x will not compile while a CUDA graph is being captured, so every
+        # shape a graph can present has to have run once already.
+        if not _B12X_WARMED:
+            log_info_on_rank0(
+                logger,
+                f"Compiling b12x W4A16 kernels for {len(counts)} "
+                f"token counts ({counts[0]}..{counts[-1]})...",
             )
-
-        layer.w13_weight = _release(layer.w13_weight)
-        layer.w2_weight = _release(layer.w2_weight)
-        layer.w13_weight_scale_inv = _release(layer.w13_weight_scale_inv)
-        layer.w2_weight_scale_inv = _release(layer.w2_weight_scale_inv)
-        torch.cuda.empty_cache()
-
+            _warmup(
+                launch=self._launch,
+                top_k=int(layer.top_k),
+                num_experts=num_experts,
+                hidden_size=hidden_size,
+                device=device,
+                counts=counts,
+            )
         layer._dsv4_mxfp4_backend = "b12x_sm12x"
 
     def apply(
@@ -647,9 +444,6 @@ class Mxfp4B12xMoEMethod:
         from sglang.srt.layers.moe.moe_runner.b12x import B12xMoeQuantInfo
 
         quant_info = B12xMoeQuantInfo(
-            experts=self._experts,
-            plan=self._plan,
-            scratch=self._scratch,
             launch=self._launch,
             ep_guard=self._ep_guard,
         )

--- a/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
@@ -26,14 +26,13 @@ MoE surface matches the released wheel::
 (``--no-deps``: b12x's metadata pulls a newer torch and breaks the rest of the
 image.) Later b12x generations changed the W4A16 kernels (0.20.0) and then the
 API (1.2.x); anything but 0.15.3 is rejected at startup rather than silently
-producing different numerics -- see :func:`_check_b12x_version`.
+producing different numerics -- see :func:`_require_015_generation`.
 """
 
 from __future__ import annotations
 
 import logging
 import os
-import sys
 from typing import TYPE_CHECKING, Any
 
 import torch
@@ -57,46 +56,8 @@ _B12X_INSTALL_HINT = (
 )
 
 
-def _select_b12x_distribution() -> None:
-    """Put a local b12x tree on sys.path ahead of whatever pip installed.
-
-    For deployments that carry the 0.15.3 tree as a directory (e.g. extracted
-    from the dspark reference image) instead of pip-installing the pinned
-    source commit. Unset (the default) is a no-op.
-    """
-    path = envs.SGLANG_B12X_PATH.get()
-    if not path:
-        return
-    if not os.path.isdir(os.path.join(path, "b12x")):
-        raise FileNotFoundError(f"SGLANG_B12X_PATH={path!r} has no b12x package.")
-    loaded = sys.modules.get("b12x")
-    if loaded is not None:
-        # Idempotent: this runs once per expert layer. Only a b12x already
-        # imported from somewhere else is a problem, and it is fatal -- the
-        # generations share a module name but not an API.
-        want = os.path.realpath(path)
-        got = os.path.realpath(os.path.dirname(os.path.dirname(loaded.__file__)))
-        if want != got:
-            raise RuntimeError(
-                f"SGLANG_B12X_PATH={path!r} came too late: b12x was already "
-                f"imported from {loaded.__file__}."
-            )
-        return
-    sys.path.insert(0, path)
-
-
-def is_b12x_available() -> bool:
-    try:
-        _select_b12x_distribution()
-        import b12x.integration.tp_moe  # noqa: F401
-
-        return True
-    except ImportError:
-        return False
-
-
-def _check_b12x_version() -> None:
-    """This backend is validated against b12x 0.15.3, and only 0.15.3.
+def _require_015_generation() -> None:
+    """This backend runs against b12x 0.15.3, and only 0.15.3.
 
     Later generations rewrote the W4A16 kernels behind the same
     ``b12x.integration`` API (0.20.0) and then replaced the API (1.2.x), so a
@@ -107,15 +68,16 @@ def _check_b12x_version() -> None:
     import importlib.metadata
 
     try:
+        import b12x  # noqa: F401
+    except ImportError as e:
+        raise RuntimeError(f"b12x is not installed. {_B12X_INSTALL_HINT}") from e
+    try:
         version = importlib.metadata.version("b12x")
     except importlib.metadata.PackageNotFoundError:
         return
     if version != "0.15.3":
-        import b12x
-
         raise RuntimeError(
-            f"b12x at {b12x.__file__} is version {version}; this backend is "
-            "validated against 0.15.3 only. Install the pinned source commit: "
+            f"b12x {version} is installed; this backend requires 0.15.3. "
             f"{_B12X_INSTALL_HINT}"
         )
 
@@ -280,12 +242,7 @@ class Mxfp4B12xMoEMethod:
     """b12x MXFP4 MoE: one fused W4A16 kernel per expert layer."""
 
     def __init__(self, fp8_method, prefix: str):
-        if not is_b12x_available():
-            raise RuntimeError(
-                "The b12x MoE backend needs the 0.15.3-generation b12x "
-                f"package: {_B12X_INSTALL_HINT}"
-            )
-        _check_b12x_version()
+        _require_015_generation()
         if not is_sm120_supported():
             raise RuntimeError("Mxfp4B12xMoEMethod requires SM120 or SM121.")
         self._fp8 = fp8_method

--- a/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
@@ -1,11 +1,17 @@
-"""DeepSeek-V4 MXFP4 expert backend backed by the b12x 0.15.3 W4A16 fused MoE.
+"""DeepSeek-V4 MXFP4 expert backend backed by the b12x W4A16 fused MoE.
 
 Same checkpoint as :mod:`mxfp4_flashinfer_cutlass_moe`, different runtime: one
 fused kernel per expert layer instead of seven, and bf16 activations instead of
 MXFP8.
 
 This targets exactly one generation of the standalone ``b12x`` package: the
-0.15.3 API (``b12x.integration.tp_moe``). Three things depend on that choice:
+op-registry API (``b12x.moe.fused_moe``, ``Caps -> plan() -> bind() -> run()``)
+that lives on ``local-inference-lab/b12x`` master. The pin is the tree the
+official vLLM DGX Spark image ships (nightly-20260815, ``b4d6c7593``) plus the
+two upstream fixes that path needs -- ``5c8318009`` (route-packed W4A16 top-k
+scaling) and ``85d3681b`` (W4A16 route histograms preallocated for CUDA graph
+capture); vLLM does not stage either path, so its image runs without them.
+Three things depend on that choice:
 
 * ``source_format="fp4_e8m0_k32"`` consumes the checkpoint's E8M0 K/32 block
   scales byte for byte, so there is no scale relayout to get wrong.
@@ -13,20 +19,21 @@ This targets exactly one generation of the standalone ``b12x`` package: the
   it binds on real data (gate magnitudes reach 10.1, and half the layers sit
   within 7% of the limit), so dropping it is a correctness change, not a
   rounding one.
-* Kernels are warmed before CUDA graph capture: b12x refuses to compile while
-  a graph is being captured and falls back to a pinned tile config that does
-  not fit every block size, so every token count a captured graph can present
-  is compiled eagerly first (see :func:`_core_token_counts`).
+* Kernels are warmed before CUDA graph capture: an unwarmed token count under
+  capture raises ``RuntimeError`` at launch (``_require_cached``), so every
+  token count a captured graph can present is compiled eagerly first (see
+  :func:`_core_token_counts`).
 
-0.15.3 was never published to PyPI. Install it from the source commit whose
-MoE surface matches the released wheel::
+Install the pinned tree::
 
-    pip install --no-deps "b12x @ https://github.com/local-inference-lab/b12x/archive/7dc6fb8fcc6446ea093537d1657df81985fa5f43.tar.gz"
+    pip install --no-deps "b12x @ https://github.com/local-inference-lab/b12x/archive/85d3681bb2c3749e4e94e121d5d829c7ec6f0b9f.tar.gz"
 
 (``--no-deps``: b12x's metadata pulls a newer torch and breaks the rest of the
-image.) Later b12x generations changed the W4A16 kernels (0.20.0) and then the
-API (1.2.x); anything but 0.15.3 is rejected at startup rather than silently
-producing different numerics -- see :func:`_require_015_generation`.
+image.) Earlier generations -- 0.15.x and the PyPI 1.2.x wheels -- keep the old
+``b12x.integration.tp_moe`` API and different W4A16 kernels; they are rejected
+at startup rather than silently producing different numerics -- see
+:func:`_require_aligned_generation`. The last 0.15.3-based revision of this
+file is the parent of the commit that introduced this docstring.
 """
 
 from __future__ import annotations
@@ -46,9 +53,11 @@ from sglang.srt.utils.common import is_sm120_supported
 os.environ.setdefault("TLLM_LOG_LEVEL", "INFO")
 
 # Route the b12x compile cache through sglang's cache tree (same pattern as
-# DG_JIT_CACHE_DIR in deep_gemm_wrapper). b12x resolves
-# B12X_CUTE_COMPILE_CACHE_DIR at first compile, so import time is early enough.
-os.environ["B12X_CUTE_COMPILE_CACHE_DIR"] = envs.SGLANG_B12X_CACHE_DIR.get()
+# DG_JIT_CACHE_DIR in deep_gemm_wrapper). b12x resolves B12X_COMPILE_CACHE_DIR
+# at first compile, so import time is early enough. (The pre-op-registry name
+# B12X_CUTE_COMPILE_CACHE_DIR must not be set: unrecognized B12X_* variables
+# are folded into the compile-cache key and would fragment the cache.)
+os.environ["B12X_COMPILE_CACHE_DIR"] = envs.SGLANG_B12X_CACHE_DIR.get()
 
 logger = logging.getLogger(__name__)
 
@@ -57,33 +66,30 @@ if TYPE_CHECKING:
 
 _B12X_INSTALL_HINT = (
     "pip install --no-deps 'b12x @ https://github.com/local-inference-lab/"
-    "b12x/archive/7dc6fb8fcc6446ea093537d1657df81985fa5f43.tar.gz'"
+    "b12x/archive/85d3681bb2c3749e4e94e121d5d829c7ec6f0b9f.tar.gz'"
 )
 
 
-def _require_015_generation() -> None:
-    """This backend runs against b12x 0.15.3, and only 0.15.3.
+def _require_aligned_generation() -> None:
+    """This backend runs against the b12x op-registry generation only.
 
-    Later generations rewrote the W4A16 kernels behind the same
-    ``b12x.integration`` API (0.20.0) and then replaced the API (1.2.x), so a
-    version mismatch must fail here rather than surface as different numerics.
-    A source tree without dist-info cannot be checked and is trusted to be the
-    pinned 0.15.3.
+    The API moved twice (0.15.x ``b12x.integration.tp_moe`` -> PyPI 1.2.x same
+    module, new kernels -> master op registry ``b12x.moe.fused_moe``), and the
+    kernels changed with it, so a generation mismatch must fail here rather
+    than surface as different numerics. The probe is structural: only the
+    op-registry generation has a ``b12x.moe.fused_moe`` module.
     """
-    import importlib.metadata
+    import importlib.util
 
     try:
         import b12x  # noqa: F401
     except ImportError as e:
         raise RuntimeError(f"b12x is not installed. {_B12X_INSTALL_HINT}") from e
-    try:
-        version = importlib.metadata.version("b12x")
-    except importlib.metadata.PackageNotFoundError:
-        return
-    if version != "0.15.3":
+    if importlib.util.find_spec("b12x.moe.fused_moe") is None:
         raise RuntimeError(
-            f"b12x {version} is installed; this backend requires 0.15.3. "
-            f"{_B12X_INSTALL_HINT}"
+            "The installed b12x predates the op-registry API "
+            "(b12x.moe.fused_moe); this backend requires the pinned master "
+            f"tree. {_B12X_INSTALL_HINT}"
         )
 
 
@@ -96,14 +102,13 @@ def _core_token_counts(max_tokens: int, tokens_per_seq: int) -> tuple[int, ...]:
     """Token counts to plan capacity for, and to warm kernels at.
 
     Under CUDA graph capture b12x refuses to compile (``_require_cached``) and
-    falls back to the plan's pinned tile config, which does not fit every block
-    size -- so the launch fails outright rather than running slowly. Every token
-    count a captured graph can present must therefore have been run once
-    already. Decode graphs are captured at the configured batch sizes times the
-    speculative window; prefill is chunked, so a power-of-two ladder covers it.
+    raises at launch for any token count that was not run once already. Decode
+    graphs are captured at the configured batch sizes times the speculative
+    window; prefill is chunked, so a power-of-two ladder covers it.
 
-    Each count compiles its own kernel (the startup log line counts them), and
-    the same ladder sizes the scratch arena.
+    b12x buckets W4A16 token capacities to powers of two internally, so warming
+    every count here resolves to far fewer distinct kernels; the same ladder
+    sizes the scratch arena.
     """
     counts = set()
     batch_sizes = list(range(1, 33))
@@ -147,13 +152,25 @@ def _warmup(*, launch, top_k, num_experts, hidden_size, device, counts):
     _B12X_WARMED = True
 
 
-def _prepare_weights(*, w13, s13, w2, s2, ones):
-    """Weight prep. Repacks in place, so the caller's tensors stay live."""
-    from b12x.integration import prepare_b12x_fp4_moe_weights
+def _prepare_weights(*, w13, s13, w2, s2, ones, num_experts, hidden_size, intermediate):
+    """Weight plan + prep. Repacks in place, so the caller's tensors stay live."""
+    from b12x.moe import fused_moe
 
-    return prepare_b12x_fp4_moe_weights(
+    weight_plan = fused_moe.plan_weights(
+        quant_modes="w4a16",
         source_format="fp4_e8m0_k32",
+        activation="silu",
+        params_dtype=torch.bfloat16,
+        num_experts=num_experts,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate,
+        # sglang stores fused W13 as [up; gate] (load_up_proj_weight_first);
+        # vLLM stores [gate; up] and declares "w31" -- do not copy that value.
         w13_layout="up_gate",
+    )
+    return fused_moe.prepare_weights(
+        plan=weight_plan,
+        params_dtype=torch.bfloat16,
         w1_fp4=w13,
         w1_blockscale=s13,
         w1_global_scale=ones,
@@ -162,40 +179,27 @@ def _prepare_weights(*, w13, s13, w2, s2, ones):
         w2_blockscale=s2,
         w2_global_scale=ones,
         a2_gscale=ones,
-        activation="silu",
-        params_dtype=torch.bfloat16,
-        prepare_runtime_alphas=False,
-        prepare_w4a16=True,
-        reuse_input_storage=True,
     )
 
 
-def _plan_scratch(
-    *, num_experts, hidden_size, intermediate, top_k, device, swiglu_limit, counts
-):
+def _plan_scratch(*, experts, top_k, device, swiglu_limit, counts):
     """Frozen scratch plan. Returns (plan, scratch)."""
-    from b12x.integration.tp_moe import TPMoEScratchCaps, plan_tp_moe_scratch
+    from b12x.moe import fused_moe
 
-    caps = TPMoEScratchCaps(
+    caps = fused_moe.Caps(
         max_tokens=max(counts),
-        weight_E=num_experts,
-        k=hidden_size,
-        n=intermediate,
         num_topk=top_k,
         device=device,
-        dtype=torch.bfloat16,
+        weight_plan=experts.plan,
         core_token_counts=tuple(counts),
         route_num_experts=0,
         route_logits_dtype=None,
         quant_mode="w4a16",
-        activation="silu",
         apply_router_weight_on_input=False,
         swiglu_limit=swiglu_limit,
-        source_format="fp4_e8m0_k32",
-        w13_layout="up_gate",
         frozen=True,
     )
-    plan = plan_tp_moe_scratch(caps)
+    plan = fused_moe.plan(caps)
     specs = plan.scratch_specs()
     if len(specs) != 1 or specs[0].dtype != torch.uint8:
         raise RuntimeError(f"unexpected b12x scratch specs: {specs}")
@@ -203,40 +207,23 @@ def _plan_scratch(
     return plan, scratch
 
 
-def _make_launcher(*, plan, scratch, prepared, w13, s13, w2, s2, ones, swiglu_limit):
+def _make_launcher(*, plan, scratch, experts):
     """Bind-and-run closure, matching vLLM's call sequence."""
-    from b12x.integration.tp_moe import b12x_moe_fp4
-
-    packed = prepared.w4a16
-    w1_alphas = prepared.w1_runtime_alphas
-    w2_alphas = prepared.w2_runtime_alphas
-    if w1_alphas is None:
-        w1_alphas = ones
-    if w2_alphas is None:
-        w2_alphas = ones
+    from b12x.moe import fused_moe
 
     def launch(a, topk_ids, topk_weights, out):
-        b12x_moe_fp4(
+        fused_moe.run(
             binding=plan.bind(
                 scratch=scratch,
                 a=a,
-                a1_gscale=ones,
-                w1_fp4=w13,
-                w1_blockscale=s13,
-                w1_alphas=w1_alphas,
-                a2_gscale=ones,
-                w2_fp4=w2,
-                w2_blockscale=s2,
-                w2_alphas=w2_alphas,
+                experts=experts,
                 topk_weights=topk_weights,
                 topk_ids=topk_ids,
                 output=out,
-                activation="silu",
-                quant_mode="w4a16",
-                source_format="fp4_e8m0_k32",
-                w13_layout="up_gate",
-                prepared_w4a16=packed,
-                swiglu_limit=swiglu_limit,
+                # W4A16 contract, same as vLLM: activations are bf16 and every
+                # global scale is the unit filler prepare_weights built.
+                input_scales_static=True,
+                unit_scale_contract=True,
             )
         )
 
@@ -247,7 +234,7 @@ class Mxfp4B12xMoEMethod:
     """b12x MXFP4 MoE: one fused W4A16 kernel per expert layer."""
 
     def __init__(self, fp8_method, prefix: str):
-        _require_015_generation()
+        _require_aligned_generation()
         if not is_sm120_supported():
             raise RuntimeError("Mxfp4B12xMoEMethod requires SM120 or SM121.")
         self._fp8 = fp8_method
@@ -341,38 +328,33 @@ class Mxfp4B12xMoEMethod:
         except Exception:
             spec_tokens = 1
 
-        # One call prepares the weights in place, and the scratch plan is
-        # built straight from the shapes.
         w13 = layer.w13_weight.data.view(torch.uint8)
         s13 = layer.w13_weight_scale_inv.data.view(torch.uint8)
         w2 = layer.w2_weight.data.view(torch.uint8)
         s2 = layer.w2_weight_scale_inv.data.view(torch.uint8)
-        prepared = _prepare_weights(w13=w13, s13=s13, w2=w2, s2=s2, ones=ones)
-        counts = _core_token_counts(_b12x_max_tokens(), spec_tokens)
-        plan, scratch = _plan_scratch(
-            num_experts=num_experts,
-            hidden_size=hidden_size,
-            intermediate=intermediate,
-            top_k=int(layer.top_k),
-            device=device,
-            swiglu_limit=self._swiglu_limit,
-            counts=counts,
-        )
-        self._launch = _make_launcher(
-            plan=plan,
-            scratch=scratch,
-            prepared=prepared,
+        experts = _prepare_weights(
             w13=w13,
             s13=s13,
             w2=w2,
             s2=s2,
             ones=ones,
-            swiglu_limit=self._swiglu_limit,
+            num_experts=num_experts,
+            hidden_size=hidden_size,
+            intermediate=intermediate,
         )
-        # reuse_input_storage=True: the prepared package aliases these
-        # tensors, so they must stay reachable. Keep the Parameters as they
-        # are and hold our own references.
-        self._keepalive = (prepared, w13, s13, w2, s2, ones, plan, scratch)
+        counts = _core_token_counts(_b12x_max_tokens(), spec_tokens)
+        plan, scratch = _plan_scratch(
+            experts=experts,
+            top_k=int(layer.top_k),
+            device=device,
+            swiglu_limit=self._swiglu_limit,
+            counts=counts,
+        )
+        self._launch = _make_launcher(plan=plan, scratch=scratch, experts=experts)
+        # The prepared weights alias the checkpoint storage (REUSE_SOURCE for
+        # 128-aligned fp4_e8m0_k32), so these tensors must stay reachable. Keep
+        # the Parameters as they are and hold our own references.
+        self._keepalive = (experts, w13, s13, w2, s2, ones, plan, scratch)
         # b12x will not compile while a CUDA graph is being captured, so every
         # shape a graph can present has to have run once already.
         if not _B12X_WARMED and envs.SGLANG_B12X_WARMUP.get():

--- a/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
@@ -25,8 +25,8 @@ MoE surface matches the released wheel::
 
 (``--no-deps``: b12x's metadata pulls a newer torch and breaks the rest of the
 image.) Later b12x generations changed the W4A16 kernels (0.20.0) and then the
-API (1.2.x); they are rejected at startup rather than silently producing
-different numerics -- see :func:`_require_015_generation`.
+API (1.2.x); anything but 0.15.3 is rejected at startup rather than silently
+producing different numerics -- see :func:`_check_b12x_version`.
 """
 
 from __future__ import annotations
@@ -95,35 +95,28 @@ def is_b12x_available() -> bool:
         return False
 
 
-def _require_015_generation() -> None:
-    """Reject b12x generations other than 0.15.x, loudly and at load time.
+def _check_b12x_version() -> None:
+    """This backend is validated against b12x 0.15.3, and only 0.15.3.
 
-    0.20.0 rewrote the W4A16 kernels behind the same ``b12x.integration``
-    API (different numerics), and the 1.2.x line replaced the API as well
-    (``b12x.moe.fused_moe``). This backend is validated against 0.15.3 only.
-    A raw source tree without dist-info cannot be version-checked; the
-    ``fused_moe`` probe still rejects the 1.2.x line there.
+    Later generations rewrote the W4A16 kernels behind the same
+    ``b12x.integration`` API (0.20.0) and then replaced the API (1.2.x), so a
+    version mismatch must fail here rather than surface as different numerics.
+    A source tree without dist-info cannot be checked and is trusted to be the
+    pinned 0.15.3.
     """
     import importlib.metadata
 
-    import b12x
-
-    try:
-        import b12x.moe.fused_moe  # noqa: F401  # the 1.2.x-generation API
-
-        has_fused_moe = True
-    except ImportError:
-        has_fused_moe = False
-    version = None
     try:
         version = importlib.metadata.version("b12x")
     except importlib.metadata.PackageNotFoundError:
-        pass
-    if has_fused_moe or (version is not None and not version.startswith("0.15.")):
+        return
+    if version != "0.15.3":
+        import b12x
+
         raise RuntimeError(
-            f"b12x at {b12x.__file__} (version {version or 'unknown'}) is not "
-            "the 0.15.x generation this backend is validated against. "
-            f"Install the pinned source commit: {_B12X_INSTALL_HINT}"
+            f"b12x at {b12x.__file__} is version {version}; this backend is "
+            "validated against 0.15.3 only. Install the pinned source commit: "
+            f"{_B12X_INSTALL_HINT}"
         )
 
 
@@ -292,7 +285,7 @@ class Mxfp4B12xMoEMethod:
                 "The b12x MoE backend needs the 0.15.3-generation b12x "
                 f"package: {_B12X_INSTALL_HINT}"
             )
-        _require_015_generation()
+        _check_b12x_version()
         if not is_sm120_supported():
             raise RuntimeError("Mxfp4B12xMoEMethod requires SM120 or SM121.")
         self._fp8 = fp8_method

--- a/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
@@ -36,8 +36,9 @@ Install the pinned tree::
 image.) Earlier generations -- 0.15.x and the PyPI 1.2.x wheels -- keep the old
 ``b12x.integration.tp_moe`` API and different W4A16 kernels; they are rejected
 at startup rather than silently producing different numerics -- see
-:func:`_require_aligned_generation`. The last 0.15.3-based revision of this
-file is the parent of the commit that introduced this docstring.
+:func:`sglang.srt.utils.b12x.require_aligned_generation`. The last 0.15.3-based
+revision of this file is the parent of the commit that introduced this
+docstring.
 """
 
 from __future__ import annotations
@@ -51,50 +52,18 @@ from torch.nn import Module
 
 from sglang.srt.environ import envs
 from sglang.srt.utils import log_info_on_rank0
+from sglang.srt.utils.b12x import install_compile_cache_dir, require_aligned_generation
 from sglang.srt.utils.common import is_sm120_supported
 
 # Suppress TRT-LLM CUTLASS trace logs without overriding user configuration.
 os.environ.setdefault("TLLM_LOG_LEVEL", "INFO")
 
-# Route the b12x compile cache through sglang's cache tree (same pattern as
-# DG_JIT_CACHE_DIR in deep_gemm_wrapper). b12x resolves B12X_COMPILE_CACHE_DIR
-# at first compile, so import time is early enough. (The pre-op-registry name
-# B12X_CUTE_COMPILE_CACHE_DIR must not be set: unrecognized B12X_* variables
-# are folded into the compile-cache key and would fragment the cache.)
-os.environ["B12X_COMPILE_CACHE_DIR"] = envs.SGLANG_B12X_CACHE_DIR.get()
+install_compile_cache_dir()
 
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from sglang.srt.layers.moe.token_dispatcher import CombineInput, DispatchOutput
-
-_B12X_INSTALL_HINT = (
-    "pip install --no-deps 'b12x @ https://github.com/local-inference-lab/"
-    "b12x/archive/85d3681bb2c3749e4e94e121d5d829c7ec6f0b9f.tar.gz'"
-)
-
-
-def _require_aligned_generation() -> None:
-    """This backend runs against the b12x op-registry generation only.
-
-    The API moved twice (0.15.x ``b12x.integration.tp_moe`` -> PyPI 1.2.x same
-    module, new kernels -> master op registry ``b12x.moe.fused_moe``), and the
-    kernels changed with it, so a generation mismatch must fail here rather
-    than surface as different numerics. The probe is structural: only the
-    op-registry generation has a ``b12x.moe.fused_moe`` module.
-    """
-    import importlib.util
-
-    try:
-        import b12x  # noqa: F401
-    except ImportError as e:
-        raise RuntimeError(f"b12x is not installed. {_B12X_INSTALL_HINT}") from e
-    if importlib.util.find_spec("b12x.moe.fused_moe") is None:
-        raise RuntimeError(
-            "The installed b12x predates the op-registry API "
-            "(b12x.moe.fused_moe); this backend requires the pinned master "
-            f"tree. {_B12X_INSTALL_HINT}"
-        )
 
 
 def _b12x_max_tokens() -> int:
@@ -349,7 +318,7 @@ class Mxfp4B12xMoEMethod:
     """b12x MXFP4 MoE: one fused kernel per expert layer."""
 
     def __init__(self, fp8_method, prefix: str):
-        _require_aligned_generation()
+        require_aligned_generation()
         if not is_sm120_supported():
             raise RuntimeError("Mxfp4B12xMoEMethod requires SM120 or SM121.")
         self._fp8 = fp8_method
@@ -497,7 +466,7 @@ class Mxfp4B12xMoEMethod:
         self._keepalive = (experts, w13, s13, w2, s2, ones, plan_or_arena)
         # b12x will not compile while a CUDA graph is being captured, so every
         # shape a graph can present has to have run once already.
-        if not _B12X_WARMED and envs.SGLANG_B12X_WARMUP.get():
+        if not _B12X_WARMED and envs.SGLANG_B12X_ENABLE_WARMUP.get():
             log_info_on_rank0(
                 logger,
                 f"Compiling b12x {quant_mode} kernels for {len(counts)} "

--- a/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
@@ -183,8 +183,32 @@ def _prepare_weights(*, w13, s13, w2, s2, ones, num_experts, hidden_size, interm
 
 
 def _plan_scratch(*, experts, top_k, device, swiglu_limit, counts):
-    """Frozen scratch plan. Returns (plan, scratch)."""
+    """One frozen scratch plan + arena shared by every expert layer.
+
+    Every expert layer presents identical caps, so one plan and one arena
+    serve them all (per-layer arenas once wasted ~12 GB here; bind is a pure
+    view mapping over the arena, so sharing is allocation- and state-free).
+    The weight-plan identity check in bind passes across layers because
+    MoEWeightPreparationPlan is a tensor-free frozen dataclass with value
+    equality.
+    """
     from b12x.moe import fused_moe
+
+    from sglang.srt.runtime_context import get_resources
+
+    fingerprint = (
+        int(top_k),
+        tuple(counts),
+        None if swiglu_limit is None else float(swiglu_limit),
+        int(experts.num_experts),
+        int(experts.hidden_size),
+        int(experts.intermediate_size),
+    )
+    buffers = get_resources().buffers
+    key = f"b12x:moe_plan:{device}"
+    cached = buffers.get(key)
+    if cached is not None and cached[0] == fingerprint:
+        return cached[1], cached[2]
 
     caps = fused_moe.Caps(
         max_tokens=max(counts),
@@ -204,6 +228,7 @@ def _plan_scratch(*, experts, top_k, device, swiglu_limit, counts):
     if len(specs) != 1 or specs[0].dtype != torch.uint8:
         raise RuntimeError(f"unexpected b12x scratch specs: {specs}")
     scratch = torch.empty(int(specs[0].shape[0]), dtype=torch.uint8, device=device)
+    buffers[key] = (fingerprint, plan, scratch)
     return plan, scratch
 
 

--- a/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
@@ -19,8 +19,18 @@ FlashInfer. Three things depend on that choice:
   but it refuses to compile at all while a graph is being captured, which is
   what the warm-up exists for.
 
-Install with ``pip install --no-deps b12x==1.2.2``; without ``--no-deps`` pip
-pulls a newer torch and breaks the rest of the image.
+Two b12x API generations are supported, auto-detected by import shape
+(:func:`_b12x_is_legacy`); "legacy" throughout this file names the API
+generation, not a recommendation:
+
+* **1.2.2** (``b12x.moe.fused_moe``) is the current PyPI release and the
+  default. Install with ``pip install --no-deps b12x==1.2.2``; without
+  ``--no-deps`` pip pulls a newer torch and breaks the rest of the image.
+* **0.15.3** (``b12x.integration``, the legacy API) was never published to
+  PyPI and can only come from a checkout (``SGLANG_B12X_PATH``). On this
+  shape it is ~19% *faster* per call -- see
+  :func:`_select_b12x_distribution` for the numbers and the mechanism --
+  which is why a deployment would bother.
 """
 
 from __future__ import annotations

--- a/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
@@ -46,19 +46,6 @@ logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from sglang.srt.layers.moe.token_dispatcher import CombineInput, DispatchOutput
 
-# One scratch buffer per (num_experts, k, n, top_k, device), shared by every
-# layer: they run sequentially and it is pure scratch. Allocated at load time so
-# it can never land in a CUDA graph's private memory pool -- a buffer first
-# allocated during capture is only valid inside that graph, and reusing it from
-# an un-captured forward faults.
-_B12X_SCRATCH: dict = {}
-
-# Every expert layer in the model has the same shape, so they share one weight
-# plan. That is not just a memory saving: b12x's compiled-kernel cache is keyed
-# per plan, so sharing means the warm-up below compiles each token count once
-# for the whole model instead of once per layer.
-_B12X_WEIGHT_PLANS: dict = {}
-
 
 def _select_b12x_distribution() -> None:
     """Put the pinned b12x on sys.path ahead of whatever pip installed.
@@ -155,9 +142,6 @@ def _core_token_counts(max_tokens: int, tokens_per_seq: int) -> tuple[int, ...]:
     return tuple(sorted(c for c in counts if 0 < c <= max_tokens))
 
 
-_BLOCKS_PER_SM_RELAXED = False
-
-
 def _relax_blocks_per_sm() -> None:
     """Undo b12x's one-CTA-per-SM pin for moe_block_size==8.
 
@@ -172,12 +156,13 @@ def _relax_blocks_per_sm() -> None:
     launch bounds and therefore of b12x's kernel cache key, and b12x refuses to
     compile during CUDA graph capture.
     """
-    global _BLOCKS_PER_SM_RELAXED
-    if _BLOCKS_PER_SM_RELAXED:
-        return
     from b12x.moe._shared.kernels.w4a16 import kernel as b12x_kernel
 
     original = b12x_kernel._determine_blocks_per_sm
+    # Latched on the patched function itself: the patch is process-global state
+    # inside the b12x module, which reset_context() cannot (and must not) undo.
+    if getattr(original, "_sglang_unpinned", False):
+        return
 
     def _unpinned(*args, **kwargs):
         # Route to the cta_m_blocks==1 branch, which caps at 4 rather than 1.
@@ -186,8 +171,8 @@ def _relax_blocks_per_sm() -> None:
         kwargs["uses_m_block_8"] = False
         return original(*args, **kwargs)
 
+    _unpinned._sglang_unpinned = True
     b12x_kernel._determine_blocks_per_sm = _unpinned
-    _BLOCKS_PER_SM_RELAXED = True
     log_info_on_rank0(
         logger, "b12x: dropped the one-CTA-per-SM pin for moe_block_size==8."
     )
@@ -226,6 +211,9 @@ def _warmup(*, plan, scratch, experts, top_k, num_experts, hidden_size, device, 
     torch.cuda.synchronize()
 
 
+# Module-level on purpose: this latch mirrors b12x's own process-global
+# compiled-kernel cache, which reset_context() cannot reset -- re-warming after
+# a context reset would be wasted work, not a correctness need.
 _B12X_WARMED = False
 
 
@@ -340,11 +328,20 @@ def _legacy_launcher(*, plan, scratch, prepared, w13, s13, w2, s2, ones, swiglu_
 
 
 def _get_weight_plan(*, num_experts: int, hidden_size: int, intermediate: int):
-    """One weight plan per shape, shared by every expert layer."""
+    """One weight plan per shape, shared by every expert layer.
+
+    Not just a memory saving: b12x's compiled-kernel cache is keyed per plan,
+    so sharing means the warm-up compiles each token count once for the whole
+    model instead of once per layer. Stored on ``get_resources().buffers`` so
+    unit-test teardown (``reset_context``) drops it with everything else.
+    """
     from b12x.moe import fused_moe
 
-    key = (num_experts, hidden_size, intermediate)
-    plan = _B12X_WEIGHT_PLANS.get(key)
+    from sglang.srt.runtime_context import get_resources
+
+    buffers = get_resources().buffers
+    key = f"b12x:weight_plan:{num_experts}:{hidden_size}:{intermediate}"
+    plan = buffers.get(key)
     if plan is None:
         plan = fused_moe.plan_weights(
             quant_modes="w4a16",
@@ -356,7 +353,7 @@ def _get_weight_plan(*, num_experts: int, hidden_size: int, intermediate: int):
             intermediate_size=intermediate,
             w13_layout="up_gate",
         )
-        _B12X_WEIGHT_PLANS[key] = plan
+        buffers[key] = plan
     return plan
 
 
@@ -374,9 +371,17 @@ def _get_scratch(
     """Plan and allocate the shared scratch buffer, once per shape."""
     from b12x.moe import fused_moe
 
+    from sglang.srt.runtime_context import get_resources
+
     max_tokens = _b12x_max_tokens()
-    key = (id(weight_plan), top_k, str(device), swiglu_limit)
-    entry = _B12X_SCRATCH.get(key)
+    # One scratch arena per shape, shared by every layer: they run sequentially
+    # and it is pure scratch. Allocated at load time so it can never land in a
+    # CUDA graph's private memory pool -- a buffer first allocated during
+    # capture is only valid inside that graph, and reusing it from an
+    # un-captured forward faults.
+    buffers = get_resources().buffers
+    key = f"b12x:scratch:{id(weight_plan)}:{top_k}:{device}:{swiglu_limit}"
+    entry = buffers.get(key)
     if entry is None:
         if envs.SGLANG_B12X_RELAX_BLOCKS_PER_SM.get():
             _relax_blocks_per_sm()
@@ -411,7 +416,7 @@ def _get_scratch(
             counts=counts,
         )
         entry = (plan, scratch)
-        _B12X_SCRATCH[key] = entry
+        buffers[key] = entry
     return entry
 
 

--- a/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
@@ -45,6 +45,11 @@ from sglang.srt.utils.common import is_sm120_supported
 # Suppress TRT-LLM CUTLASS trace logs without overriding user configuration.
 os.environ.setdefault("TLLM_LOG_LEVEL", "INFO")
 
+# Route the b12x compile cache through sglang's cache tree (same pattern as
+# DG_JIT_CACHE_DIR in deep_gemm_wrapper). b12x resolves
+# B12X_CUTE_COMPILE_CACHE_DIR at first compile, so import time is early enough.
+os.environ["B12X_CUTE_COMPILE_CACHE_DIR"] = envs.SGLANG_B12X_CACHE_DIR.get()
+
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
@@ -370,7 +375,7 @@ class Mxfp4B12xMoEMethod:
         self._keepalive = (prepared, w13, s13, w2, s2, ones, plan, scratch)
         # b12x will not compile while a CUDA graph is being captured, so every
         # shape a graph can present has to have run once already.
-        if not _B12X_WARMED:
+        if not _B12X_WARMED and envs.SGLANG_B12X_WARMUP.get():
             log_info_on_rank0(
                 logger,
                 f"Compiling b12x W4A16 kernels for {len(counts)} "

--- a/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_b12x_moe.py
@@ -27,10 +27,13 @@ generation, not a recommendation:
   default. Install with ``pip install --no-deps b12x==1.2.2``; without
   ``--no-deps`` pip pulls a newer torch and breaks the rest of the image.
 * **0.15.3** (``b12x.integration``, the legacy API) was never published to
-  PyPI and can only come from a checkout (``SGLANG_B12X_PATH``). On this
-  shape it is ~19% *faster* per call -- see
-  :func:`_select_b12x_distribution` for the numbers and the mechanism --
-  which is why a deployment would bother.
+  PyPI -- it ships only inside the dspark reference image, and 0.15.2 (the
+  last published 0.15.x) predates the ``fp4_e8m0_k32`` / ``w13_layout``
+  API this file needs -- so it can only come from a checkout
+  (``SGLANG_B12X_PATH``). At the decode working point (M=6) it is ~19%
+  *faster* per call -- see :func:`_select_b12x_distribution` -- while at
+  prefill-sized M the two generations are within noise; that decode delta
+  is why a deployment would bother.
 """
 
 from __future__ import annotations

--- a/python/sglang/srt/layers/quantization/mxfp4_flashinfer_trtllm_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_flashinfer_trtllm_moe.py
@@ -377,6 +377,7 @@ def maybe_fuse_routed_scale_and_shared_add(
     # alpha=scale)`. With no shared output, the missing scale is applied
     # in-place. Otherwise `routed` is already scale-final and we just add
     # `shared` (or pass through if there is none).
+    from sglang.srt.layers.quantization.mxfp4_b12x_moe import Mxfp4B12xMoEMethod
     from sglang.srt.layers.quantization.mxfp4_flashinfer_cutlass_moe import (
         Mxfp4FlashinferCutlassMoEMethod,
     )
@@ -390,6 +391,7 @@ def maybe_fuse_routed_scale_and_shared_add(
             Mxfp4FlashinferTrtllmMoEMethod,
             Mxfp4FlashinferCutlassMoEMethod,
             Mxfp4MarlinMoEMethod,
+            Mxfp4B12xMoEMethod,
         ),
     )
     if fused:

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -229,6 +229,30 @@ def _is_fused_mhc_post_pre_enabled() -> bool:
 _FLASHINFER_MHC_PRE_SPLITS = (1, 2, 4, 8, 16)
 
 
+# The sparse-MLA backend is fixed for the process and the pad below is on the
+# per-forward path, so resolve it at import (same as _FP8_WO_A_GEMM above).
+_B12X_SPARSE_MLA = envs.SGLANG_SM120_FLASHMLA_BACKEND.get() == "b12x"
+# h_q values b12x's sparse-MLA kernels specialize for.
+_B12X_H_Q_SPECIALIZATIONS = (16, 32, 64, 128)
+
+
+def _dsv4_mqa_padded_num_heads(n_local_heads: int, n_heads: int) -> int:
+    """Head padding for the sparse-MLA core attention under attention-TP.
+
+    FlashMLA's fp8 sparse decode kernel only specializes h_q for {64, 128},
+    so the flashinfer-family backends pad the per-rank heads to 64. b12x
+    supports {16, 32, 64, 128} natively with per-count tuned modes; padding
+    32 real heads to 64 there doubles the attention work and disqualifies
+    the tuned 32-head configurations.
+    """
+    if _B12X_SPARSE_MLA and is_sm120_supported():
+        for h in _B12X_H_Q_SPECIALIZATIONS:
+            if n_local_heads <= h:
+                return h
+        return n_heads
+    return 64 if n_local_heads <= 64 else n_heads
+
+
 @functools.cache
 def _cuda_sm_count() -> int:
     return torch.cuda.get_device_properties(0).multi_processor_count
@@ -643,7 +667,7 @@ class MqaAttentionBase(nn.Module):
         if self._attn_sink_local is None:
             rank = self.attn_tp_rank
             num_heads = self.n_local_heads
-            padded_num_heads = 64 if num_heads <= 64 else self.n_heads
+            padded_num_heads = _dsv4_mqa_padded_num_heads(num_heads, self.n_heads)
             sink = self.attn_sink.new_zeros(padded_num_heads)
             sink[:num_heads] = self.attn_sink[rank * num_heads : (rank + 1) * num_heads]
             self._attn_sink_local = sink
@@ -1282,11 +1306,11 @@ class MQALayer(MqaAttentionBase):
 
         tp_slice, q_padded, q_out = slice(None), None, None
         if self.attn_tp_size > 1:
-            # FlashMLA's fp8 sparse decode kernel only specializes h_q for {64, 128}.
-            # Pad the per-rank heads to 64 (not the full n_heads) when they fit, to
-            # dispatch the cheaper decode::head64 variant; attn_sink is sliced to
-            # this rank and padded to match.
-            padded_num_heads = 64 if self.n_local_heads <= 64 else self.n_heads
+            # Backend-dependent head pad (see _dsv4_mqa_padded_num_heads);
+            # attn_sink is sliced to this rank and padded to match.
+            padded_num_heads = _dsv4_mqa_padded_num_heads(
+                self.n_local_heads, self.n_heads
+            )
             # Only [0:n_local_heads] is written below. Uninitialized padded TP
             # heads inject NaN into attention on gfx942 (fnuz), so zero-init
             # there; other archs tolerate new_empty and skip the per-forward

--- a/python/sglang/srt/models/deepseek_v4_dspark.py
+++ b/python/sglang/srt/models/deepseek_v4_dspark.py
@@ -36,6 +36,7 @@ from sglang.srt.models.deepseek_v4 import (
     DeepseekV4ForCausalLM,
     MqaAttentionBase,
     _dequant_fp8_wo_a_streaming,
+    _dsv4_mqa_padded_num_heads,
     hc_head_torch,
     make_hc_head_params,
 )
@@ -57,8 +58,6 @@ from sglang.srt.utils import add_prefix, is_blackwell_supported
 from sglang.srt.utils.invariants import Bucket, InClosedRange, Invariant, expect
 
 logger = logging.getLogger(__name__)
-
-_PAD_NUM_HEADS = 64
 
 # DSpark confidence is a per-token score that must stay in [0, 1].
 _CONFIDENCE = Invariant(
@@ -207,11 +206,12 @@ class DSparkAttention(MqaAttentionBase):
             and hidden_states.shape[0] <= self._multi_stream_bs_limit
         )
 
+        pad_num_heads = _dsv4_mqa_padded_num_heads(self.n_local_heads, self.n_heads)
         q_padded: Optional[torch.Tensor] = None
         q_out: Optional[torch.Tensor] = None
-        if self.n_local_heads < _PAD_NUM_HEADS:
+        if self.n_local_heads < pad_num_heads:
             q_padded = hidden_states.new_empty(
-                hidden_states.shape[0], _PAD_NUM_HEADS, self.head_dim
+                hidden_states.shape[0], pad_num_heads, self.head_dim
             )
             q_out = q_padded[:, : self.n_local_heads, :]
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -260,6 +260,7 @@ MOE_RUNNER_BACKEND_CHOICES = [
     "flashinfer_cutlass",
     "flashinfer_mxfp4",
     "flashinfer_cutedsl",
+    "b12x",
     "cutlass",
     "aiter",
     "marlin",

--- a/python/sglang/srt/utils/b12x.py
+++ b/python/sglang/srt/utils/b12x.py
@@ -1,0 +1,88 @@
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Shared plumbing for the b12x backends (SM12x / GB10).
+
+sglang runs b12x from more than one place -- the MXFP4 MoE runner and the
+DSv4-Flash compressed-MLA attention branch -- and all of them need the same
+three things: the pinned install hint, the generation guard, and the compile
+cache pointed at sglang's cache tree. They live here so a pin move is one edit
+and the guard cannot drift between backends.
+
+The pin is the tree the official vLLM DGX Spark image ships (nightly-20260815,
+``b4d6c7593``) plus the two upstream fixes sglang's staging needs -- see the
+module docstring of :mod:`sglang.srt.layers.quantization.mxfp4_b12x_moe`.
+"""
+
+from __future__ import annotations
+
+import os
+
+from sglang.srt.environ import envs
+
+B12X_PIN = "85d3681bb2c3749e4e94e121d5d829c7ec6f0b9f"
+
+INSTALL_HINT = (
+    "pip install --no-deps 'b12x @ https://github.com/local-inference-lab/"
+    f"b12x/archive/{B12X_PIN}.tar.gz'"
+)
+
+# The op-registry entry points every b12x backend here is written against.
+# A tree that has the module but not these names is a different generation.
+_REQUIRED_FUSED_MOE_ATTRS = ("Caps", "plan", "plan_weights", "prepare_weights", "run")
+
+
+def install_compile_cache_dir() -> None:
+    """Route b12x's compile cache through sglang's cache tree.
+
+    Same pattern as ``DG_JIT_CACHE_DIR`` in ``deep_gemm_wrapper``. b12x
+    resolves ``B12X_COMPILE_CACHE_DIR`` at first compile, so any call before
+    the first kernel launch is early enough; ``setdefault`` so an explicitly
+    configured cache dir wins.
+
+    The pre-op-registry name ``B12X_CUTE_COMPILE_CACHE_DIR`` must not be set:
+    this generation ignores it, and unrecognized ``B12X_*`` variables are
+    folded into the compile-cache key, which would fragment the cache.
+    """
+    os.environ.setdefault("B12X_COMPILE_CACHE_DIR", envs.SGLANG_B12X_CACHE_DIR.get())
+
+
+def require_aligned_generation() -> None:
+    """Fail unless the installed b12x is the pinned op-registry generation.
+
+    The API moved twice (0.15.x ``b12x.integration.tp_moe`` -> PyPI 1.2.x same
+    module, new kernels -> master op registry ``b12x.moe.fused_moe``), and the
+    kernels changed with it, so a generation mismatch must fail here rather
+    than surface as different numerics. The wheel version string cannot be
+    used: it stayed 1.2.3 across the re-architecture. So the probe is
+    structural -- the ``b12x.moe.fused_moe`` module has to exist, and it has
+    to expose the op-registry entry points.
+    """
+    try:
+        import b12x  # noqa: F401
+    except ImportError as e:
+        raise RuntimeError(f"b12x is not installed. {INSTALL_HINT}") from e
+    try:
+        from b12x.moe import fused_moe
+    except ImportError as e:
+        raise RuntimeError(
+            "The installed b12x predates the op-registry API "
+            f"(b12x.moe.fused_moe); this backend requires the pinned master "
+            f"tree {B12X_PIN[:9]}. {INSTALL_HINT}"
+        ) from e
+    missing = [a for a in _REQUIRED_FUSED_MOE_ATTRS if not hasattr(fused_moe, a)]
+    if missing:
+        raise RuntimeError(
+            f"b12x.moe.fused_moe is missing {', '.join(missing)}: this is not "
+            f"the pinned op-registry generation {B12X_PIN[:9]}. {INSTALL_HINT}"
+        )


### PR DESCRIPTION

Adds `SGLANG_SM120_FLASHMLA_BACKEND=b12x`, dispatching the SM12x DSv4
core-attention call to `b12x.attention.compressed_mla` — the same fused SWA +
indexed sparse MLA kernel family vLLM's `DeepseekV4B12xMLAAttention` runs on the
official DGX Spark image. With the MoE PR this puts both stacks on the same
kernels for both halves of the model.

Branch: `b12x-attn-sm12x` (five commits).

## Relationship to other PRs

**Stacked on the b12x MoE PR (`b12x-moe-sm12x`).** It is not just an ordering
preference: this branch imports `sglang/srt/utils/b12x.py`, which that PR
introduces (pin, install hint, generation guard, compile-cache plumbing). Review
this one after it.

**Independent of #35104 (`Drop the 64-head TP pad on the DSv4 MLA prefill
path`), but it will need a rebase.** The two changes are different mechanisms:

- #35104 removes the 64-head pad *for wide prefill chunks* on the
  flashinfer-family backend, where the pad buys nothing because the row-count
  fork inside the flashinfer entry never reaches the kernel the pad exists for.
- This PR changes the pad *width* for the b12x backend, in every mode, because
  b12x specializes `h_q` for `{16, 32, 64, 128}` and padding 32 real heads to 64
  both doubles the work and disqualifies b12x's tuned 32-head modes.

They collide textually in two places in `python/sglang/srt/models/deepseek_v4.py`
— `MqaAttentionBase._local_attn_sink()` and `MQALayer.forward()`, both of which
carry the `padded_num_heads = 64 if ... else self.n_heads` line that each PR
rewrites differently. **Plan: land #35104 first, then rebase this branch on it**
and reconcile as follows:

- Both call sites go through the `_dsv4_mqa_padded_num_heads()` helper this PR
  adds, so #35104's `unpad_heads` gate bypasses one width function instead of
  two open-coded copies.
- Drop this PR's `_B12X_SPARSE_MLA and is_sm120_supported()` pair in favour of
  #35104's `_is_sm120` module constant plus the backend check.
- Recheck the interaction, which is benign but worth a line of test: under the
  b12x backend the pad width is already `n_local_heads`-shaped, so #35104's
  prefill unpad has nothing left to remove, and its gate is a no-op rather than a
  conflict.

## What changed

**b12x compressed-MLA dispatch** (`flash_mla_sm120.py`,
`deepseek_v4_backend.py`). The SWA pool is re-split to 64-token footer pages
through the existing FlashInfer-path split buffer, because single-pass SM121
decode requires `page_size=64`; the c4 pool is 64-token pages natively. b12x
accepts sglang's 576-padded page byte width as a first-class layout and addresses
both caches by raw token slot, so indices pass through unchanged. Lifecycle per
call is `Caps -> plan` (pure host) `-> bind` (views only, plus two deterministic
split-config device fills that capture cleanly) `-> run` into a caller-owned
output. Scratch is a grow-only persistent buffer keyed per kernel-family mode;
superseded buffers are retired rather than freed, because captured graphs bake
their addresses. All of that state lives in `get_resources().buffers`, so a
context reset drops it. The dsv4 backend passes an explicit mode hint:
decode/idle and target-verify rows follow the decode split contract (vLLM's
spec-as-decode discipline); extend-shaped batches run the unified prefill kernel.

**Indexed page size follows the extra cache's layer type.** DSv4-Flash has three
layer families: c4 layers hand the shim 64-token extra pages, c128 layers
`256/128 = 2`-token pages. Passing `indexed_page_size=64` unconditionally made
b12x's byte-width validator reject the c128 cache (1728-byte pages). The page
token count is now derived from the cache view, mirroring vLLM's
`block_size // compress_ratio`.

**Persistent single-cache index width pad.** The SM120 unified-prefill kernel
only instantiates widths `{128, 512, 1024, 2048}`; the DSpark draft extend
presents 192 (window 128 + draft block, 64-aligned) and the shape gate rejects it
at 32 heads. vLLM pads its DSpark SWA index width to 512 for the same reason
(`_DSPARK_SWA_INDEX_ALIGNMENT`), so we pad to the same standing 512. The pad is
not extend-only — the SM121 single-pass decode route runs the same kernel and
rejects 192-wide rows during CUDA graph warmup — so it is a grow-only persistent
buffer rather than an eager `F.pad`. Index rows are padded with `-1` while
per-row lengths keep the real counts, so padded columns are never read past the
length. The buffer is keyed by the real width as well as the target width, which
makes the pad columns exactly the ones the allocation's `-1` fill put there:
nothing ever writes into them, and the steady-state path is a single `copy_` with
no per-call memset.

**Backend-aware MQA head pad.** Trace evidence (bs1 8k/1k decode, TP2): our
`UnifiedDecodeKernel` instances launch with `h_blocks` for 64 heads while vLLM's
launch for 32. The attention-TP pad to 64 exists for FlashMLA's `h_q in {64,128}`
specializations; on b12x it doubles the attention work per rank and disqualifies
the tuned 32-head modes (native H16, and the SM121 single-pass decode gate
requires `heads == 32`). So on the b12x branch we pad to the next member of
b12x's `{16, 32, 64, 128}` instead; flashinfer-family backends keep the 64-head
pad unchanged. `attn_sink` and the output un-pad slice follow the width
automatically. The DSpark draft layer, which padded `q` with its own module
constant while taking `attn_sink` from the shared helper (`q=64` heads vs
`sink=(32,)`, rejected by b12x's merge validator), now routes through the same
helper.

## Environment variables

sglang-owned:

| Name | Default | Meaning |
|---|---|---|
| `SGLANG_SM120_FLASHMLA_BACKEND` | `flashinfer` | Adds `b12x` to the existing `flashinfer` / `triton` / `torch` set. Everything in this PR is behind that value. |

b12x-owned, set by us at module import with `setdefault` so an operator can
still override, and only when the b12x branch is selected:

| Name | Set to | Why |
|---|---|---|
| `B12X_COMPILE_CACHE_DIR` | `SGLANG_B12X_CACHE_DIR` | Shared plumbing from the MoE PR (`sglang/srt/utils/b12x.py`); keeps b12x's compile cache in sglang's cache tree. |
| `B12X_MLA_SM120_DSV4_H16_NATIVE` | `1` | **Not a tuning knob — required.** b12x's `_dsv4_h16_auto()` does not forward `sm_count`, so its AUTO probe raises and the native-H16 DSv4 kernels are unreachable unless the variable is set explicitly. Without it, running 32 real heads buys nothing. Setting it to `0` gives the generic path back for comparison. |

Both are set at import rather than per call, so the values are in place before
b12x's first compile.

## Scope

SM120 / SM121, and inert unless `SGLANG_SM120_FLASHMLA_BACKEND=b12x`. The one
exception is `_dsv4_mqa_padded_num_heads()`, which is on the shared path but
returns the previous 64-head width for every non-b12x backend.

## Test plan

2x DGX Spark (GB10, sm_121), DeepSeek-V4-Flash, TP=2, with the DSpark draft:
full CUDA graph capture (exercises the index-width pad and the scratch sizing on
the captured decode route), c4 and c128 layers both live (exercises the indexed
page size), and GSM8K for the head-pad change.

## Reproducing the benchmarked configuration

The numbers we quote against the official vLLM DGX Spark image come from this PR
stacked on the b12x MoE PR plus #34018 (FP8 wo_a GEMM, reviewed separately),
launched as:

```
export SGLANG_SM120_FLASHMLA_BACKEND=b12x
export SGLANG_OPT_FP8_WO_A_GEMM=1          # needs #34018
export SGLANG_OPT_FUSE_MHC_POST_PRE=1
export SGLANG_B12X_MAX_TOKENS=8192         # track --chunked-prefill-size
sglang serve --model-path deepseek-ai/DeepSeek-V4-Flash-0731 --trust-remote-code \
  --tp 2 --nnodes 2 --node-rank <R> --dist-init-addr <rank0>:<port> \
  --moe-runner-backend b12x --speculative-algorithm DSPARK \
  --chunked-prefill-size 8192 --mem-fraction-static 0.75 \
  --swa-full-tokens-ratio 0.2 --cuda-graph-max-bs-decode 32 --max-running-requests 32
```

vs vLLM at pinned accept length 5 and matched 8k chunking: decode bs1 -2.6% /
bs2 +11% / bs4 +7% / bs8 parity, prefill 60k +10%; GSM8K 0.985 with no
simulated accept (accept length 4.0).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->