### PR TITLE
[diffusion] fix: run the synthetic warmup on offline entrypoints

### DIFF
--- a/python/sglang/multimodal_gen/runtime/entrypoints/diffusion_generator.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/diffusion_generator.py
@@ -38,7 +38,7 @@ from sglang.multimodal_gen.runtime.scheduler_client import sync_scheduler_client
 from sglang.multimodal_gen.runtime.server_args import PortArgs, ServerArgs
 from sglang.multimodal_gen.runtime.server_warmup import (
     run_sync_client_warmup,
-    should_run_explicit_client_warmup,
+    should_run_client_warmup,
 )
 from sglang.multimodal_gen.runtime.utils.logging_utils import (
     GREEN,
@@ -156,10 +156,16 @@ class DiffGenerator:
         return processes
 
     def _run_client_warmup_if_needed(self) -> None:
-        if not should_run_explicit_client_warmup(self.server_args):
+        if not should_run_client_warmup(self.server_args):
             return
 
-        run_sync_client_warmup(self.server_args, sync_scheduler_client.forward)
+        # An auto-selected warmup must not break the run it was meant to
+        # speed up; an explicitly requested one is part of the contract.
+        run_sync_client_warmup(
+            self.server_args,
+            sync_scheduler_client.forward,
+            fail_open=self.server_args.warmup_resolutions is None,
+        )
 
     def _check_remote_scheduler(self):
         """Check if the remote scheduler is accessible."""

--- a/python/sglang/multimodal_gen/runtime/server_warmup.py
+++ b/python/sglang/multimodal_gen/runtime/server_warmup.py
@@ -101,6 +101,17 @@ def should_run_explicit_client_warmup(server_args: ServerArgs) -> bool:
     )
 
 
+def should_run_client_warmup(server_args: ServerArgs) -> bool:
+    """Whether the calling entrypoint runs the synthetic warmup itself.
+
+    Offline runs launch no HTTP server, so the startup task in ``http_server``
+    never fires and nothing else honors ``server`` mode for them.
+    """
+    if should_run_synthetic_server_warmup(server_args):
+        return True
+    return should_run_explicit_client_warmup(server_args)
+
+
 def format_warmup_req(req_or_group: Any) -> str:
     req = get_first_generation_req(req_or_group)
     prefix = (
@@ -175,17 +186,27 @@ async def run_async_client_warmup(
 def run_sync_client_warmup(
     server_args: ServerArgs,
     forward: Callable[[Req], OutputBatch],
+    *,
+    fail_open: bool = False,
 ) -> None:
-    warmup_input_path = None
-    if should_include_warmup_image(server_args, server_based_warmup=True):
-        warmup_input_path = prepare_warmup_image_path(server_args)
+    try:
+        warmup_input_path = None
+        if should_include_warmup_image(server_args, server_based_warmup=True):
+            warmup_input_path = prepare_warmup_image_path(server_args)
 
-    for req in build_client_warmup_reqs(
-        server_args, warmup_input_path=warmup_input_path
-    ):
-        response = forward(req)
-        if response.error is not None:
-            raise RuntimeError(response.error)
+        for req in build_client_warmup_reqs(
+            server_args, warmup_input_path=warmup_input_path
+        ):
+            response = forward(req)
+            if response.error is not None:
+                raise RuntimeError(response.error)
+    except Exception:
+        if fail_open:
+            logger.warning(
+                "Synthetic warmup failed; continuing without it", exc_info=True
+            )
+            return
+        raise
 
 
 def prepare_warmup_image_path(server_args: ServerArgs) -> str:

--- a/python/sglang/multimodal_gen/test/unit/test_offline_warmup.py
+++ b/python/sglang/multimodal_gen/test/unit/test_offline_warmup.py
@@ -1,0 +1,79 @@
+"""Synthetic warmup on entrypoints that host no HTTP startup request.
+
+`--warmup-mode server` used to run no warmup at all offline, so the first real
+request paid the full `torch.compile` cost.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from sglang.multimodal_gen.configs.pipeline_configs.base import ModelTaskType
+from sglang.multimodal_gen.configs.sample.sampling_params import SamplingParams
+from sglang.multimodal_gen.runtime.server_warmup import (
+    run_sync_client_warmup,
+    should_run_client_warmup,
+)
+
+
+def _make_server_args(
+    *, warmup_mode: str, warmup_resolutions: list[str] | None
+) -> MagicMock:
+    server_args = MagicMock()
+    server_args.warmup_mode = warmup_mode
+    server_args.warmup_resolutions = warmup_resolutions
+    server_args.warmup_steps = 1
+    server_args.enable_cfg_parallel = False
+    server_args.enable_torch_compile = False
+    server_args.enable_breakable_cuda_graph = False
+    server_args.backend = "native"
+    server_args.pipeline_class_name = None
+    server_args.is_arg_explicitly_set.return_value = False
+    server_args.pipeline_config = SimpleNamespace(
+        task_type=ModelTaskType.T2I,
+        vae_stride=None,
+        vae_scale_factor=None,
+        vae_config=None,
+    )
+    return server_args
+
+
+def _not_realtime():
+    return patch(
+        "sglang.multimodal_gen.runtime.server_warmup.is_realtime_serving",
+        return_value=False,
+    )
+
+
+class TestClientWarmupSelection(unittest.TestCase):
+    def test_server_mode_warms_up_on_the_client(self):
+        # `_adjust_warmup` resolves --enable-torch-compile to this mode, and
+        # offline runs have no HTTP startup task to execute it.
+        server_args = _make_server_args(warmup_mode="server", warmup_resolutions=None)
+        with _not_realtime():
+            self.assertTrue(should_run_client_warmup(server_args))
+
+    def test_request_mode_defers_to_the_scheduler(self):
+        # The scheduler clones the first real request instead. Warming up here
+        # too would run two warmups for one request.
+        server_args = _make_server_args(warmup_mode="request", warmup_resolutions=None)
+        with _not_realtime():
+            self.assertFalse(should_run_client_warmup(server_args))
+
+
+class TestSyncClientWarmupFailurePolicy(unittest.TestCase):
+    def test_fail_open_only_swallows_failures_when_requested(self):
+        server_args = _make_server_args(warmup_mode="server", warmup_resolutions=None)
+        forward = MagicMock(side_effect=RuntimeError("warmup forward exploded"))
+
+        with patch(
+            "sglang.multimodal_gen.runtime.warmup_request_builder.get_model_sampling_defaults",
+            return_value=SamplingParams(width=512, height=512),
+        ):
+            run_sync_client_warmup(server_args, forward, fail_open=True)
+            with self.assertRaises(RuntimeError):
+                run_sync_client_warmup(server_args, forward, fail_open=False)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`sglang generate --enable-torch-compile` performs no warmup at all, and then reports the first request as if it had.

`_adjust_warmup` resolves `--enable-torch-compile` to `warmup_mode="server"` when no mode is given explicitly. Offline runs go through `DiffGenerator`, which calls `launch_server(..., launch_http_server=False)`, so the startup warmup task in `http_server` never exists. The other two executors do not cover the gap either: the scheduler's request-based clone requires `warmup_mode == "request"`, and `should_run_explicit_client_warmup` requires `--warmup-resolutions`. All three miss, so the whole `torch.compile` cost lands in the first real request — which `_log_summary` then reports as `(with warmup excluded)`.

## Modifications

`warmup_mode != "off"` already promised that a warmup request runs; the bug is that nothing honored it for `server` mode offline. The fix makes that invariant true rather than teaching the log about the exceptions.

`server` mode means a synthetic warmup at startup, before traffic. Offline runs do have a startup point — they just have no HTTP server to own it — so the generator now runs it inline instead of degrading the mode. `_log_summary` is unchanged from `main`.

- **`runtime/server_warmup.py`** — `should_run_client_warmup`: server mode, or explicit resolutions on any mode but `off`. `run_sync_client_warmup` takes `fail_open`, matching `run_async_client_warmup`.
- **`runtime/entrypoints/diffusion_generator.py`** — `_run_client_warmup_if_needed` honors server mode. The fail-open policy copies the HTTP path (`http_server.py`): an auto-selected warmup fails open, an explicitly requested one fails hard.

This also picks up `TORCH_COMPILE_REAL_PATH_PREWARM_PROMPTS`, which `build_client_warmup_reqs` requests via `server_based_warmup=True`, and a deeper warmup than request mode — `_resolve_warmup_steps` raises server-based image warmup above `--warmup-steps`.

Serving is unaffected: `http_server` still owns the startup warmup, and request mode still defers to the scheduler.

## Accuracy Tests

Not applicable. No change to kernels, model forward code, or sampling — only whether a synthetic warmup request runs before the first real one.

## Speed Tests and Profiling

Z-Image-Turbo, 1024², 1×H100, `--enable-torch-compile` with no explicit `--warmup-mode`, two independent runs per arm:

| arm | request 1 | request 2 | warmup req |
| --- | --- | --- | --- |
| base (`5a100d9086`) | 42.3 s / 13.3 s | 2.2 s | none ran |
| fix | 1.6 s / 1.6 s | 1.6 s | `1024x1024, 2/9 steps`, ~12 s |

Both arms log `Automatically enabled server warmup for torch.compile so first real requests do not pay compile latency`; only the fixed arm then runs one.

The base first request spans 42.3 s fully cold and 13.3 s on a rerun — the inductor cache under `~/.cache/torch` survives between runs — so the overstatement against its own steady state is 6–20x depending on cache state. The fixed arm lands at steady state in both runs, with the warmup paid before the first timed request.

Pre-fix, the summary reported that first request as `(with warmup excluded)`: `Warmed-up request processed in 13.16 seconds (with warmup excluded)` against a 2.2 s steady state.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

`test/unit/test_offline_warmup.py` covers three things: server mode warms up on the client, request mode does not (so one request never gets two warmups), and the fail-open policy. Auto-discovered by `_discover_unit_tests()` in `test/server/gpu_cases.py`, so no CI registration is needed. 228 tests pass across the warmup, server-args, and CLI unit suites. black and isort are clean; `ruff` is not installed in my environment, so that hook runs first on CI.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32907508684](https://github.com/sgl-project/sglang/actions/runs/32907508684)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32907508514](https://github.com/sgl-project/sglang/actions/runs/32907508514)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32907508655](https://github.com/sgl-project/sglang/actions/runs/32907508655)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->