### PR TITLE
docs: link the Ling DSPARK option to its HF model card

### DIFF
--- a/docs/src/snippets/_deployment.jsx
+++ b/docs/src/snippets/_deployment.jsx
@@ -1652,14 +1652,23 @@ export const Deployment = ({ config, benchmarks }) => {
     );
   };
 
-  const renderFlatSection = (title, options, dim, selectedId) => (
-    <div style={s.card}>
-      <div style={s.title}>{title}</div>
-      <div style={s.itemsGrid(options.length)}>
-        {options.map((item) => renderButton(item, dim, selectedId))}
+  const renderFlatSection = (title, options, dim, selectedId) => {
+    const selected = options.find((o) => o.id === selectedId);
+    return (
+      <div style={s.card}>
+        <div style={s.title}>{title}</div>
+        <div style={s.itemsGrid(options.length)}>
+          {options.map((item) => renderButton(item, dim, selectedId))}
+        </div>
+        {selected?.href && (
+          <a href={selected.href} target="_blank" rel="noreferrer"
+             style={{ display: "inline-block", marginTop: 6, fontSize: 13 }}>
+            Model card ↗
+          </a>
+        )}
       </div>
-    </div>
-  );
+    );
+  };
 
   const maxHwCols = Math.max(...hwGroups.map((x) => x.items.length));
 

--- a/docs/src/snippets/configs/inclusionAI/ling-3.0-flash.jsx
+++ b/docs/src/snippets/configs/inclusionAI/ling-3.0-flash.jsx
@@ -162,7 +162,11 @@ sgl-eval run gsm8k \\
       title: "Spec Decode",
       options: [
         { id: "nextn", label: "NEXTN (built-in MTP)" },
-        { id: "dspark", label: "DSPARK (draft model)" },
+        {
+          id: "dspark",
+          label: "DSPARK (draft model)",
+          href: "https://huggingface.co/inclusionAI/Ling-3.0-flash-dspark",
+        },
         { id: "off", label: "Off (greedy)" },
       ],
     },


### PR DESCRIPTION
## Summary

Selecting **DSPARK** in the Ling-3.0-flash Deploy panel now shows a **Model card ↗** link under the Spec Decode row, pointing at [inclusionAI/Ling-3.0-flash-dspark](https://huggingface.co/inclusionAI/Ling-3.0-flash-dspark).

- `_deployment.jsx`: standard match-dim rows gain support for an optional per-option `href`; when the selected option declares one, a "Model card ↗" link renders under the row. Additive — no existing config uses the field, so nothing else changes.
- `ling-3.0-flash.jsx`: the `dspark` option declares the model-card `href` (NEXTN and Off have none, so no link shows for them).

## Validation

- `node docs/scripts/check_cookbook_configs.mjs` — OK
- `mint validate` — passed
- Headless-browser check on local `mint dev`: no link before selecting DSPARK, link with the correct `href` appears after selecting it, zero page errors.

Note: the draft repo is currently private — the link 404s anonymously until it goes public.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #32516472284](https://github.com/sgl-project/sglang/actions/runs/32516472284)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #32516472994](https://github.com/sgl-project/sglang/actions/runs/32516472994)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->