### PR TITLE
Validate prompt input_ids against the vocab range (#31597 item 3)

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1179,6 +1179,13 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                     f"model's context length ({self.context_len} tokens)."
                 )
 
+        # NVBug 6632748: reject out-of-range prompt token ids here, before they can
+        # reach the embedding index_select and trip a device-side assert that kills
+        # the whole server. This guard existed but had zero callers. Applies to both
+        # GenerateReqInput and EmbeddingReqInput -- embeddings do the same lookup.
+        if input_ids:
+            self._validate_input_ids_in_vocab(input_ids, self.model_config.vocab_size)
+
         # Validate total tokens (input + max_new_tokens)
         max_new_tokens = obj.sampling_params.get("max_new_tokens")
         if (
@@ -1313,20 +1320,28 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
     def _validate_input_ids_in_vocab(
         self, input_ids: Union[List[int], List[List[int]]], vocab_size: int
     ) -> None:
+        # Reject BOTH ends of the range: a negative id indexes the embedding from
+        # the far end and reaches the same index_select as an oversized one, so
+        # checking only `>= vocab_size` leaves half the hole open. This matches
+        # _validate_token_ids_logprob, which already checks both bounds.
+        def _check(seq) -> None:
+            for token_id in seq:
+                if not isinstance(token_id, int) or isinstance(token_id, bool):
+                    raise ValueError("input_ids must contain only integers.")
+                if token_id < 0 or token_id >= vocab_size:
+                    raise ValueError(
+                        f"The input_ids contain an out-of-vocabulary token id "
+                        f"{token_id}; valid range is [0, {vocab_size})."
+                    )
+
+        if not input_ids:
+            return
         # Handle both single sequence and batch of sequences
         if isinstance(input_ids[0], list):
-            # Batch of sequences
             for seq in input_ids:
-                if any(id >= vocab_size for id in seq):
-                    raise ValueError(
-                        f"The input_ids {seq} contains values greater than the vocab size ({vocab_size})."
-                    )
+                _check(seq)
         else:
-            # Single sequence
-            if any(id >= vocab_size for id in input_ids):
-                raise ValueError(
-                    f"The input_ids {input_ids} contains values greater than the vocab size ({vocab_size})."
-                )
+            _check(input_ids)
 
     def _create_tokenized_object(
         self,

--- a/test/registered/unit/managers/test_input_ids_vocab_validation.py
+++ b/test/registered/unit/managers/test_input_ids_vocab_validation.py
@@ -1,0 +1,109 @@
+"""
+Unit tests for prompt input_ids vocab-range validation in TokenizerManager.
+
+A request whose prompt carried a token id outside [0, vocab_size) reached the
+embedding index_select and tripped a device-side assert, which poisons the CUDA
+context and aborts the scheduler -- i.e. one request could take down the server.
+_validate_input_ids_in_vocab existed to prevent that but had no callers.
+
+Covers:
+  - _validate_input_ids_in_vocab rejects id >= vocab_size, id < 0 and non-ints
+  - it accepts in-range ids, both flat and batched
+  - _validate_one_request actually calls it (the regression that mattered)
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.io_struct import GenerateReqInput  # noqa: E402
+from sglang.srt.managers.tokenizer_manager import TokenizerManager  # noqa: E402
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+VOCAB_SIZE = 32
+
+
+def _make_tm() -> TokenizerManager:
+    tm = TokenizerManager.__new__(TokenizerManager)
+    tm.model_config = MagicMock()
+    tm.model_config.vocab_size = VOCAB_SIZE
+    # _validate_one_request also does a length check before the vocab check.
+    tm.context_len = 2048
+    tm.num_reserved_tokens = 0
+    tm.allow_auto_truncate = False
+    tm.is_generation = True
+    tm.server_args = MagicMock()
+    tm.server_args.enable_lora = False
+    # Assigned in __init__, so absent when the object is built with __new__.
+    tm.validate_total_tokens = MagicMock()
+    return tm
+
+
+class TestValidateInputIdsInVocab(CustomTestCase):
+    def test_accepts_in_range(self):
+        tm = _make_tm()
+        tm._validate_input_ids_in_vocab([0, 1, VOCAB_SIZE - 1], VOCAB_SIZE)
+
+    def test_accepts_in_range_batched(self):
+        tm = _make_tm()
+        tm._validate_input_ids_in_vocab([[0, 1], [VOCAB_SIZE - 1]], VOCAB_SIZE)
+
+    def test_rejects_id_at_or_above_vocab_size(self):
+        tm = _make_tm()
+        with self.assertRaises(ValueError):
+            tm._validate_input_ids_in_vocab([VOCAB_SIZE], VOCAB_SIZE)
+        with self.assertRaises(ValueError):
+            tm._validate_input_ids_in_vocab([10**9], VOCAB_SIZE)
+
+    def test_rejects_negative_id(self):
+        # A negative id indexes the embedding from the far end and reaches the
+        # same index_select, so the upper bound alone is not enough.
+        tm = _make_tm()
+        with self.assertRaises(ValueError):
+            tm._validate_input_ids_in_vocab([-1], VOCAB_SIZE)
+
+    def test_rejects_non_int(self):
+        tm = _make_tm()
+        with self.assertRaises(ValueError):
+            tm._validate_input_ids_in_vocab([1.5], VOCAB_SIZE)
+
+    def test_rejects_bad_id_inside_a_batch(self):
+        tm = _make_tm()
+        with self.assertRaises(ValueError):
+            tm._validate_input_ids_in_vocab([[0, 1], [VOCAB_SIZE]], VOCAB_SIZE)
+
+
+class TestValidateOneRequestCallsVocabCheck(CustomTestCase):
+    """The guard existed; the regression was that nothing called it."""
+
+    def _obj(self):
+        obj = MagicMock(spec=GenerateReqInput)
+        obj.sampling_params = {}
+        obj.token_ids_logprob = None
+        obj.return_hidden_states = False
+        obj.input_embeds = None
+        obj.lora_path = None
+        return obj
+
+    def test_out_of_range_prompt_is_rejected(self):
+        tm = _make_tm()
+        with self.assertRaises(ValueError):
+            tm._validate_one_request(self._obj(), [0, VOCAB_SIZE])
+
+    def test_negative_prompt_id_is_rejected(self):
+        tm = _make_tm()
+        with self.assertRaises(ValueError):
+            tm._validate_one_request(self._obj(), [-1])
+
+    def test_in_range_prompt_is_accepted(self):
+        tm = _make_tm()
+        tm._validate_one_request(self._obj(), [0, 1, VOCAB_SIZE - 1])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes item 3 of #31597.

A request whose prompt carries a token id outside `[0, vocab_size)` reaches the embedding
`index_select`, trips a device-side assert, poisons the CUDA context and aborts the
scheduler — so a single request can take the server down, and every later request
including `/health` is refused until restart.

The guard for this already exists: **`_validate_input_ids_in_vocab` has no callers**
anywhere in the tree, so prompt `input_ids` are the one field on the request path with no
range check. The adjacent fields are validated (`_validate_token_ids_logprob`,
`sampling_params.verify(vocab_size)`).

**Two changes**

- **Call it** from `_validate_one_request`. Placed after the input-length check rather
  than beside the `_validate_token_ids_logprob` call, because that call sits inside
  `if isinstance(obj, GenerateReqInput)` and `EmbeddingReqInput` reaches the same
  embedding lookup. Uses `model_config.vocab_size`, as the sibling validator and
  `sampling_params.verify` do, so padded vocabularies are not falsely rejected.
- **Reject `id < 0` and non-int** as well as `id >= vocab_size` — the missing-negative
  case #31597 calls out. A negative id indexes the embedding from the far end into the
  same `index_select`, so the upper bound alone leaves half the hole open. This brings
  the function in line with `_validate_token_ids_logprob`, which already checks both.

The error message no longer echoes the whole prompt back, only the offending id and the
valid range.

**Tests** — adds `test/registered/unit/managers/test_input_ids_vocab_validation.py`
(CPU-only), covering the validator directly and the wiring that was missing. It fails on
`main` (4 failed / 5 passed) and passes with this change (9 passed).

**Verified end to end** on a 26.08 container, 1 GPU:

| probe | before | after |
|---|---|---|
| out-of-vocab / very large / negative / batched | server killed, 3584 device-side asserts | **HTTP 400, server still serving** |
| in-vocab text | 200 | 200 |
| multimodal image | 200 | 200 |
| device-side asserts in log | 3584 | **0** |

The multimodal probe is deliberate: the mm processor rewrites image placeholders in
`input_ids` with pad values, so if validation ran after that this guard would reject every
vision request. It runs before — vision is unaffected. The zero assert count shows the
payload no longer reaches the embedding, rather than the server merely surviving it.

Happy to split the `< 0` / non-int tightening into a separate commit if you'd prefer the
wiring alone.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32517262126](https://github.com/sgl-project/sglang/actions/runs/32517262126)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32517261686](https://github.com/sgl-project/sglang/actions/runs/32517261686)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32517262033](https://github.com/sgl-project/sglang/actions/runs/32517262033)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->