### PR TITLE
Refactor TRTLLM MHA backend inheritance

### DIFF
--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -29,10 +29,8 @@ from sglang.kernels.ops.kvcache.trtllm_mha_page_table import (
 )
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.base_attn_backend import SharedReadEnds
-from sglang.srt.layers.attention.flashinfer_backend import (
-    FlashInferAttnBackend,
-    FlashInferMultiStepDraftBackend,
-)
+from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
+from sglang.srt.layers.attention.flashinfer_backend import FlashInferMetadata
 from sglang.srt.layers.attention.trtllm_mla_backend import (
     make_persistent_multi_ctas_kv_counter_buffer,
 )
@@ -100,7 +98,7 @@ class TRTLLMMHAMetadata:
     encoder_row_map: torch.Tensor = None
 
 
-class TRTLLMHAAttnBackend(FlashInferAttnBackend):
+class TRTLLMHAAttnBackend(AttentionBackend):
     """TRTLLM MHA attention kernel from flashinfer."""
 
     # Build the page table on-device from seq_lens (incl. the SWA-translated table


### PR DESCRIPTION
## Summary
- make `TRTLLMHAAttnBackend` inherit directly from `AttentionBackend`
- initialize backend state locally instead of calling `FlashInferAttnBackend.__init__`
- remove stale FlashInfer-only constructor state

## Validation
- `git diff --check`
- `python3 -m py_compile python/sglang/srt/layers/attention/trtllm_mha_backend.py`

Closes #28808

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32526429816](https://github.com/sgl-project/sglang/actions/runs/32526429816)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32526429620](https://github.com/sgl-project/sglang/actions/runs/32526429620)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32526430092](https://github.com/sgl-project/sglang/actions/runs/32526430092)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->