### PR TITLE
[DeepSeek V4] Default FP4 checkpoints to FlashInfer MXFP4 MoE

### DIFF
--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1164,16 +1164,25 @@ def _deepseek_v4_overrides(server_args: Any, hf_config: Any) -> dict:
         overrides["swa_full_tokens_ratio"] = 0.1
         logger.info(f"Setting swa_full_tokens_ratio to 0.1 for {model_arch}.")
 
-    # nvidia/DeepSeek-V4-Pro-NVFP4 uses flashinfer_trtllm_routed MoE runner backend.
-    if (
-        server_args.moe_runner_backend == "auto"
-        and server_args.get_model_config().nvfp4_moe_meta is not None
-    ):
-        overrides["moe_runner_backend"] = "flashinfer_trtllm_routed"
-        logger.info(
-            "Use flashinfer_trtllm_routed as MoE runner backend for "
-            f"{model_arch} hybrid FP8+NVFP4 checkpoint."
-        )
+    if server_args.moe_runner_backend == "auto":
+        model_config = server_args.get_model_config()
+        # nvidia/DeepSeek-V4-Pro-NVFP4 uses the routed TRT-LLM runner.
+        if model_config.nvfp4_moe_meta is not None:
+            overrides["moe_runner_backend"] = "flashinfer_trtllm_routed"
+            logger.info(
+                "Use flashinfer_trtllm_routed as MoE runner backend for "
+                f"{model_arch} hybrid FP8+NVFP4 checkpoint."
+            )
+        elif (
+            server_args.device == "cuda"
+            and not is_hip()
+            and model_config.is_fp4_experts
+            and (is_sm90_supported() or is_sm100_supported() or is_sm120_supported())
+        ):
+            overrides["moe_runner_backend"] = "flashinfer_mxfp4"
+            logger.info(
+                "Use flashinfer_mxfp4 as MoE runner backend for " f"{model_arch}."
+            )
     return overrides
 
 

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1176,6 +1176,8 @@ def _deepseek_v4_overrides(server_args: Any, hf_config: Any) -> dict:
         elif (
             server_args.device == "cuda"
             and not is_hip()
+            and server_args.moe_a2a_backend == "none"
+            and not envs.SGLANG_DSV4_FP4_DEQUANT.get()
             and model_config.is_fp4_experts
             and (is_sm90_supported() or is_sm100_supported() or is_sm120_supported())
         ):
@@ -1927,20 +1929,6 @@ def _deepseek_v4_kv_cache_dtype(view: Any) -> dict:
     ], f"{kv_cache_dtype} is not supported for {model_arch}"
     if kv_cache_dtype != view.kv_cache_dtype:
         return {"kv_cache_dtype": kv_cache_dtype}
-    return {}
-
-
-@register_post_process
-def _deepseek_v4_sm120_moe(view: Any) -> dict:
-    """Default DeepSeek V4 MXFP4 experts to FlashInfer CUTLASS on SM120."""
-    hf_config = view.get_model_config().hf_config
-    if hf_config.architectures[0] != "DeepseekV4ForCausalLM":
-        return {}
-    if is_sm120_supported() and view.moe_runner_backend == "auto":
-        logger.info(
-            "Use flashinfer_mxfp4 as MoE runner backend on SM120 for DeepseekV4"
-        )
-        return {"moe_runner_backend": "flashinfer_mxfp4"}
     return {}
 
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -5540,15 +5540,6 @@ class ServerArgs:
             validate_deepseek_v4_cp(self)
             validate_deepseek_v4_mega_moe_token_budget(self)
 
-            # The SM120 marlin fallback moved to the resolution pipeline
-            # (arg_groups/overrides.py: _deepseek_v4_sm120_moe), invoked here
-            # at its legacy slot.
-            from sglang.srt.arg_groups.overrides import (
-                _deepseek_v4_sm120_moe,
-                run_post_process_pass,
-            )
-
-            run_post_process_pass(self, _deepseek_v4_sm120_moe)
             if is_sm120_supported():
                 # SM120 lacks tcgen05/TMEM: disable features that depend on
                 # DeepGEMM or require >99KB SMEM (topk_v2).

--- a/test/registered/models_e2e/test_deepseek_v4_flash_fp4_b200.py
+++ b/test/registered/models_e2e/test_deepseek_v4_flash_fp4_b200.py
@@ -1,6 +1,7 @@
 """B200 per-commit CI: DeepSeek-V4-Flash FP4 (LowLatency recipe).
 
-Launches TP=4 with flashinfer_mxfp4 MoE runner + EAGLE speculative decoding.
+Launches TP=4 with the auto-selected flashinfer_mxfp4 MoE runner and EAGLE
+speculative decoding.
 Runs 12 ServerSanity probes (correctness, streaming, concurrency, determinism)
 plus a GSM8K accuracy gate.
 
@@ -56,8 +57,6 @@ class TestDSV4FlashFP4B200(
                 "--trust-remote-code",
                 "--tp",
                 "4",
-                "--moe-runner-backend",
-                "flashinfer_mxfp4",
                 "--speculative-algorithm",
                 "EAGLE",
                 "--speculative-num-steps",

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -971,6 +971,7 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             defaults = dict(
                 device="cuda",
                 swa_full_tokens_ratio=ServerArgs.swa_full_tokens_ratio,
+                moe_a2a_backend="none",
                 moe_runner_backend="auto",
                 get_model_config=lambda: SimpleNamespace(
                     is_fp4_experts=True, nvfp4_moe_meta=None
@@ -979,7 +980,10 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             defaults.update(kw)
             return SimpleNamespace(**defaults)
 
-        with patch.object(overrides_module, "is_sm100_supported", return_value=True):
+        with (
+            envs.SGLANG_DSV4_FP4_DEQUANT.override(False),
+            patch.object(overrides_module, "is_sm100_supported", return_value=True),
+        ):
             self.assertEqual(
                 _deepseek_v4_overrides(_args(), hf),
                 {
@@ -1003,6 +1007,24 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             "moe_runner_backend",
             _deepseek_v4_overrides(_args(moe_runner_backend="triton"), hf),
         )
+        # FlashInfer MXFP4 only supports the standard (non-A2A) dispatcher.
+        with (
+            envs.SGLANG_DSV4_FP4_DEQUANT.override(False),
+            patch.object(overrides_module, "is_sm100_supported", return_value=True),
+        ):
+            self.assertNotIn(
+                "moe_runner_backend",
+                _deepseek_v4_overrides(_args(moe_a2a_backend="deepep"), hf),
+            )
+        # Runtime FP4-to-FP8 dequantization must retain the generic FP8 runner.
+        with (
+            envs.SGLANG_DSV4_FP4_DEQUANT.override(True),
+            patch.object(overrides_module, "is_sm100_supported", return_value=True),
+        ):
+            self.assertNotIn(
+                "moe_runner_backend",
+                _deepseek_v4_overrides(_args(), hf),
+            )
         # FP8 checkpoints and non-CUDA platforms keep their platform-specific
         # auto-resolution paths.
         fp8_model_config = lambda: SimpleNamespace(
@@ -1032,6 +1054,17 @@ class TestGoldenModelOverrides(_IsolatedPublish):
                 "moe_runner_backend",
                 _deepseek_v4_overrides(_args(), hf),
             )
+        # SM120 uses the same model hook; no later pass is needed.
+        with (
+            envs.SGLANG_DSV4_FP4_DEQUANT.override(False),
+            patch.object(overrides_module, "is_sm90_supported", return_value=False),
+            patch.object(overrides_module, "is_sm100_supported", return_value=False),
+            patch.object(overrides_module, "is_sm120_supported", return_value=True),
+        ):
+            self.assertEqual(
+                _deepseek_v4_overrides(_args(), hf)["moe_runner_backend"],
+                "flashinfer_mxfp4",
+            )
         # nvfp4 hybrid checkpoint routes the MoE runner
         self.assertEqual(
             _deepseek_v4_overrides(
@@ -1044,34 +1077,6 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             )["moe_runner_backend"],
             "flashinfer_trtllm_routed",
         )
-
-    def test_deepseek_v4_sm120_moe_pass(self):
-        from sglang.srt.arg_groups.overrides import (
-            ResolvedView,
-            _deepseek_v4_sm120_moe,
-        )
-
-        def _view(arch="DeepseekV4ForCausalLM", **kw):
-            hf = SimpleNamespace(architectures=[arch])
-            defaults = dict(moe_runner_backend="auto")
-            defaults.update(kw)
-            return ResolvedView(
-                SimpleNamespace(
-                    get_model_config=lambda: SimpleNamespace(hf_config=hf), **defaults
-                )
-            )
-
-        with patch.object(overrides_module, "is_sm120_supported", return_value=True):
-            self.assertEqual(
-                _deepseek_v4_sm120_moe(_view()),
-                {"moe_runner_backend": "flashinfer_mxfp4"},
-            )
-            self.assertEqual(
-                _deepseek_v4_sm120_moe(_view(moe_runner_backend="triton")), {}
-            )
-            self.assertEqual(_deepseek_v4_sm120_moe(_view(arch="LlamaForCausalLM")), {})
-        with patch.object(overrides_module, "is_sm120_supported", return_value=False):
-            self.assertEqual(_deepseek_v4_sm120_moe(_view()), {})
 
     def test_nemotron_h_overrides_at_callable_level(self):
         from sglang.srt.arg_groups.overrides import _nemotron_h_overrides

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -972,19 +972,23 @@ class TestGoldenModelOverrides(_IsolatedPublish):
                 device="cuda",
                 swa_full_tokens_ratio=ServerArgs.swa_full_tokens_ratio,
                 moe_runner_backend="auto",
-                get_model_config=lambda: SimpleNamespace(nvfp4_moe_meta=None),
+                get_model_config=lambda: SimpleNamespace(
+                    is_fp4_experts=True, nvfp4_moe_meta=None
+                ),
             )
             defaults.update(kw)
             return SimpleNamespace(**defaults)
 
-        self.assertEqual(
-            _deepseek_v4_overrides(_args(), hf),
-            {
-                "attention_backend": "dsv4",
-                "page_size": 256,
-                "swa_full_tokens_ratio": 0.1,
-            },
-        )
+        with patch.object(overrides_module, "is_sm100_supported", return_value=True):
+            self.assertEqual(
+                _deepseek_v4_overrides(_args(), hf),
+                {
+                    "attention_backend": "dsv4",
+                    "moe_runner_backend": "flashinfer_mxfp4",
+                    "page_size": 256,
+                    "swa_full_tokens_ratio": 0.1,
+                },
+            )
         # NPU pool geometry
         self.assertEqual(
             _deepseek_v4_overrides(_args(device="npu"), hf)["page_size"], 128
@@ -994,11 +998,47 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             "swa_full_tokens_ratio",
             _deepseek_v4_overrides(_args(swa_full_tokens_ratio=0.5), hf),
         )
+        # An explicit user choice takes precedence over the model default.
+        self.assertNotIn(
+            "moe_runner_backend",
+            _deepseek_v4_overrides(_args(moe_runner_backend="triton"), hf),
+        )
+        # FP8 checkpoints and non-CUDA platforms keep their platform-specific
+        # auto-resolution paths.
+        fp8_model_config = lambda: SimpleNamespace(
+            is_fp4_experts=False, nvfp4_moe_meta=None
+        )
+        self.assertNotIn(
+            "moe_runner_backend",
+            _deepseek_v4_overrides(_args(get_model_config=fp8_model_config), hf),
+        )
+        self.assertNotIn(
+            "moe_runner_backend",
+            _deepseek_v4_overrides(_args(device="npu"), hf),
+        )
+        with patch.object(overrides_module, "is_hip", return_value=True):
+            self.assertNotIn(
+                "moe_runner_backend",
+                _deepseek_v4_overrides(_args(), hf),
+            )
+        # Unsupported NVIDIA architectures keep the generic auto-resolution
+        # path instead of selecting a FlashInfer kernel that cannot launch.
+        with (
+            patch.object(overrides_module, "is_sm90_supported", return_value=False),
+            patch.object(overrides_module, "is_sm100_supported", return_value=False),
+            patch.object(overrides_module, "is_sm120_supported", return_value=False),
+        ):
+            self.assertNotIn(
+                "moe_runner_backend",
+                _deepseek_v4_overrides(_args(), hf),
+            )
         # nvfp4 hybrid checkpoint routes the MoE runner
         self.assertEqual(
             _deepseek_v4_overrides(
                 _args(
-                    get_model_config=lambda: SimpleNamespace(nvfp4_moe_meta=object())
+                    get_model_config=lambda: SimpleNamespace(
+                        is_fp4_experts=False, nvfp4_moe_meta=object()
+                    )
                 ),
                 hf,
             )["moe_runner_backend"],


### PR DESCRIPTION
## Motivation

DeepSeek V4 FP4 expert checkpoints require the FlashInfer MXFP4 MoE runner on supported NVIDIA GPUs. Select it automatically when the user leaves the MoE runner backend at `auto`.

## Modifications

- Default DeepSeek V4 FP4 expert checkpoints to `flashinfer_mxfp4` on supported NVIDIA SM90, SM100, and SM120 devices.
- Preserve an explicitly selected `--moe-runner-backend`.
- Preserve the `nvidia/DeepSeek-V4-Pro-NVFP4` special case, which defaults to `flashinfer_trtllm_routed`.
- Leave FP8 checkpoints, ROCm/NPU, and unsupported NVIDIA architectures on their existing platform-specific `auto` resolution paths.
- Remove the explicit `--moe-runner-backend flashinfer_mxfp4` from the B200 E2E launch command so the test exercises auto-selection.
- Add focused override tests for the positive path and all preserved fallback paths.

## Accuracy Tests

On `baizhou-dev-gb300`, the final implementation passed all 9 tests in `TestDSV4FlashFP4B200` using a launch command with no explicit MoE runner backend.

- Startup log: `Use flashinfer_mxfp4 as MoE runner backend for DeepseekV4ForCausalLM.`
- GSM8K score: 0.970.
- Test runtime: 197.762 seconds.
- Focused model-override unit tests passed, including NVFP4, FP8, ROCm/NPU, unsupported NVIDIA architecture, and explicit-user-selection cases.

## Speed Tests and Profiling

- Batch-size-1 decode speed: 385.66 token/s.
- GSM8K output throughput: 2104.59 token/s.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32536775527](https://github.com/sgl-project/sglang/actions/runs/32536775527)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32536775409](https://github.com/sgl-project/sglang/actions/runs/32536775409)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32536775509](https://github.com/sgl-project/sglang/actions/runs/32536775509)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->