### PR TITLE
[Docs] Add --prerelease=allow to cookbook uv install commands

### DIFF
--- a/.claude/skills/cookbook-add-model/templates/page.mdx.tmpl
+++ b/.claude/skills/cookbook-add-model/templates/page.mdx.tmpl
@@ -27,7 +27,7 @@ For all methods and hardware platforms, see the [official SGLang installation gu
 ```bash Command
 pip install --upgrade pip
 pip install uv
-uv pip install sglang
+uv pip install --prerelease=allow sglang
 ```
 
 Then run the **Python** output of the command panel below in that environment.

--- a/docs/cookbook/autoregressive/Baidu/PaddleOCR-VL.mdx
+++ b/docs/cookbook/autoregressive/Baidu/PaddleOCR-VL.mdx
@@ -19,7 +19,7 @@ For all methods and hardware platforms, see the [official SGLang installation gu
 ```bash Command
 pip install --upgrade pip
 pip install uv
-uv pip install sglang
+uv pip install --prerelease=allow sglang
 ```
 
 Then run the **Python** output of the command panel below in that environment.

--- a/docs/cookbook/autoregressive/Baidu/Unlimited-OCR.mdx
+++ b/docs/cookbook/autoregressive/Baidu/Unlimited-OCR.mdx
@@ -22,7 +22,7 @@ uv venv --python 3.12 && source .venv/bin/activate
 git clone https://github.com/sgl-project/sglang.git
 cd sglang
 git fetch origin pull/29186/head && git checkout FETCH_HEAD
-uv pip install -e python
+uv pip install --prerelease=allow -e python
 ```
 
 Then run the **Python** output of the command panel below in that environment.

--- a/docs/cookbook/autoregressive/DeepReinforce/Ornith-1.0.mdx
+++ b/docs/cookbook/autoregressive/DeepReinforce/Ornith-1.0.mdx
@@ -19,7 +19,7 @@ Ornith-1.0 model cards recommend SGLang `>=0.5.9`. The Deploy panel below emits 
 ```bash Command
 pip install --upgrade pip
 pip install uv
-uv pip install "sglang>=0.5.9"
+uv pip install --prerelease=allow "sglang>=0.5.9"
 ```
 
 Then run the **Python** output of the command panel below in that environment.

--- a/docs/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx
+++ b/docs/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx
@@ -19,7 +19,7 @@ For all methods and hardware platforms, see the [official SGLang installation gu
 ```bash Command
 pip install --upgrade pip
 pip install uv
-uv pip install sglang
+uv pip install --prerelease=allow sglang
 ```
 
 Then run the **Python** output of the command panel below in that environment.

--- a/docs/cookbook/autoregressive/GLM/GLM-4.6V.mdx
+++ b/docs/cookbook/autoregressive/GLM/GLM-4.6V.mdx
@@ -41,7 +41,7 @@ git clone https://github.com/sgl-project/sglang.git
 cd sglang
 uv venv
 source .venv/bin/activate
-uv pip install -e "python[all]" --index-url=https://pypi.org/simple
+uv pip install --prerelease=allow -e "python[all]" --index-url=https://pypi.org/simple
 pip install nvidia-cudnn-cu12==9.16.0.29
 # Install ffmpeg to support video input
 sudo apt update

--- a/docs/cookbook/autoregressive/GLM/GLM-5.2.mdx
+++ b/docs/cookbook/autoregressive/GLM/GLM-5.2.mdx
@@ -19,7 +19,7 @@ For all methods and hardware platforms, see the [official SGLang installation gu
 ```bash Command
 pip install --upgrade pip
 pip install uv
-uv pip install sglang
+uv pip install --prerelease=allow sglang
 ```
 
 Then run the **Python** output of the command panel below in that environment.

--- a/docs/cookbook/autoregressive/InternLM/Intern-S1.mdx
+++ b/docs/cookbook/autoregressive/InternLM/Intern-S1.mdx
@@ -15,7 +15,7 @@ Intern-S1 includes the large **Intern-S1** MoE model and the smaller **Intern-S1
 Refer to the [official SGLang installation guide](../../../docs/get-started/install), or install from source:
 
 ```bash Command
-uv pip install 'git+https://github.com/sgl-project/sglang.git#subdirectory=python'
+uv pip install --prerelease=allow 'git+https://github.com/sgl-project/sglang.git#subdirectory=python'
 ```
 
 ## 3. Model Deployment

--- a/docs/cookbook/autoregressive/InternLM/Intern-S2-Mobius.mdx
+++ b/docs/cookbook/autoregressive/InternLM/Intern-S2-Mobius.mdx
@@ -19,7 +19,7 @@ For all methods and hardware platforms, see the [official SGLang installation gu
 ```bash Command
 pip install --upgrade pip
 pip install uv
-uv pip install sglang
+uv pip install --prerelease=allow sglang
 ```
 
 Then run the **Python** output of the command panel below in that environment.

--- a/docs/cookbook/autoregressive/InternLM/Intern-S2-Preview.mdx
+++ b/docs/cookbook/autoregressive/InternLM/Intern-S2-Preview.mdx
@@ -20,7 +20,7 @@ Install SGLang from source or use an NVIDIA Docker image:
 
 ```bash Command
 # Install from source
-uv pip install 'git+https://github.com/sgl-project/sglang.git#subdirectory=python'
+uv pip install --prerelease=allow 'git+https://github.com/sgl-project/sglang.git#subdirectory=python'
 
 # Or use Docker for NVIDIA GPUs
 docker pull lmsysorg/sglang:latest

--- a/docs/cookbook/autoregressive/LiquidAI/LFM2.5.mdx
+++ b/docs/cookbook/autoregressive/LiquidAI/LFM2.5.mdx
@@ -19,7 +19,7 @@ For all methods and hardware platforms, see the [official SGLang installation gu
 ```bash Command
 pip install --upgrade pip
 pip install uv
-uv pip install sglang
+uv pip install --prerelease=allow sglang
 ```
 
 <Note>

--- a/docs/cookbook/autoregressive/Meta/MuseGlimmer.mdx
+++ b/docs/cookbook/autoregressive/Meta/MuseGlimmer.mdx
@@ -23,7 +23,7 @@ pip install uv
 # https://github.com/sgl-project/sglang/pull/34262
 git clone -b muse-glimmer https://github.com/sgl-project/sglang.git
 cd sglang
-uv pip install -e "python[all]"
+uv pip install --prerelease=allow -e "python[all]"
 ```
 
 Run the **Python** output of the command panel below in that environment.

--- a/docs/cookbook/autoregressive/MiniMax/MiniMax-M3.mdx
+++ b/docs/cookbook/autoregressive/MiniMax/MiniMax-M3.mdx
@@ -25,10 +25,10 @@ uv venv --python 3.12 && source .venv/bin/activate
 git clone https://github.com/sgl-project/sglang.git
 cd sglang
 git fetch origin pull/27944/head && git checkout FETCH_HEAD
-uv pip install -e python
+uv pip install --prerelease=allow -e python
 ```
 
-Then run the **Python** output of the command panel below in that environment. The **Docker** tab is simpler — its image bundles the CUDA-13 runtime and the #27944 code. Once [PR #27944](https://github.com/sgl-project/sglang/pull/27944) is merged and released, `uv pip install sglang` will pull M3 support directly.
+Then run the **Python** output of the command panel below in that environment. The **Docker** tab is simpler — its image bundles the CUDA-13 runtime and the #27944 code. Once [PR #27944](https://github.com/sgl-project/sglang/pull/27944) is merged and released, `uv pip install --prerelease=allow sglang` will pull M3 support directly.
 
 </Tab>
 

--- a/docs/cookbook/autoregressive/Moonshotai/Kimi-K3.mdx
+++ b/docs/cookbook/autoregressive/Moonshotai/Kimi-K3.mdx
@@ -19,7 +19,7 @@ For all methods and hardware platforms, see the [official SGLang installation gu
 ```bash Command
 pip install --upgrade pip
 pip install uv
-uv pip install sglang
+uv pip install --prerelease=allow sglang
 ```
 
 Then run the **Python** output of the command panel below in that environment.

--- a/docs/cookbook/autoregressive/NVIDIA/Nemotron3-Nano-Omni.mdx
+++ b/docs/cookbook/autoregressive/NVIDIA/Nemotron3-Nano-Omni.mdx
@@ -46,7 +46,7 @@ Install SGLang via pip or from source:
 pip install sglang
 
 # Or install from source
-uv pip install 'git+https://github.com/sgl-project/sglang.git#subdirectory=python'
+uv pip install --prerelease=allow 'git+https://github.com/sgl-project/sglang.git#subdirectory=python'
 
 # Or use Docker
 docker pull lmsysorg/sglang:latest

--- a/docs/cookbook/autoregressive/NVIDIA/Nemotron3-Nano.mdx
+++ b/docs/cookbook/autoregressive/NVIDIA/Nemotron3-Nano.mdx
@@ -22,7 +22,7 @@ At a high level:
 
 Refer to the [official SGLang installation guide](../../../docs/get-started/install), or install nightly wheel through:
 ```bash Command
-uv pip install sglang==0.5.6.post3.dev1278+gad1b4e472 --extra-index-url https://sgl-project.github.io/whl/nightly/
+uv pip install --prerelease=allow sglang==0.5.6.post3.dev1278+gad1b4e472 --extra-index-url https://sgl-project.github.io/whl/nightly/
 ```
 
 ## 3. Model Deployment

--- a/docs/cookbook/autoregressive/NVIDIA/Nemotron3-Super.mdx
+++ b/docs/cookbook/autoregressive/NVIDIA/Nemotron3-Super.mdx
@@ -25,7 +25,7 @@ SGLang from the main branch is required for Nemotron3-Super. You can install fro
 
 ```bash Command
 # Install from source
-uv pip install 'git+https://github.com/sgl-project/sglang.git#subdirectory=python'
+uv pip install --prerelease=allow 'git+https://github.com/sgl-project/sglang.git#subdirectory=python'
 
 # Or use Docker
 docker pull lmsysorg/sglang:latest

--- a/docs/cookbook/autoregressive/NVIDIA/Nemotron3.5-Lightning.mdx
+++ b/docs/cookbook/autoregressive/NVIDIA/Nemotron3.5-Lightning.mdx
@@ -19,7 +19,7 @@ For all methods and hardware platforms, see the [official SGLang installation gu
 ```bash Command
 pip install --upgrade pip
 pip install uv
-SGLANG_BUILD_RUST_EXTS=none uv pip install 'git+https://github.com/sgl-project/sglang.git@refs/pull/33554/head#subdirectory=python'
+SGLANG_BUILD_RUST_EXTS=none uv pip install --prerelease=allow 'git+https://github.com/sgl-project/sglang.git@refs/pull/33554/head#subdirectory=python'
 ```
 
 Then run the **Python** output of the command panel below in that environment.

--- a/docs/cookbook/autoregressive/Poolside/Laguna-M.1.mdx
+++ b/docs/cookbook/autoregressive/Poolside/Laguna-M.1.mdx
@@ -23,7 +23,7 @@ uv venv --python 3.12 && source .venv/bin/activate
 # tagged release — install from main. The serving runtime is in the base dependencies, no extra needed:
 git clone https://github.com/sgl-project/sglang.git
 cd sglang
-uv pip install -e python
+uv pip install --prerelease=allow -e python
 ```
 
 Then run the **Python** output of the command panel below in that environment. The **Docker** tab is simpler — `lmsysorg/sglang:latest` bundles the CUDA-13 runtime and the M.1 code.

--- a/docs/cookbook/autoregressive/Poolside/Laguna-S-2.1.mdx
+++ b/docs/cookbook/autoregressive/Poolside/Laguna-S-2.1.mdx
@@ -22,7 +22,7 @@ uv venv --python 3.12 && source .venv/bin/activate
 
 git clone https://github.com/sgl-project/sglang.git
 cd sglang
-uv pip install -e python
+uv pip install --prerelease=allow -e python
 ```
 
 Then run the **Python** output of the command panel below in that environment.

--- a/docs/cookbook/autoregressive/Poolside/Laguna-XS-2.1.mdx
+++ b/docs/cookbook/autoregressive/Poolside/Laguna-XS-2.1.mdx
@@ -23,7 +23,7 @@ uv venv --python 3.12 && source .venv/bin/activate
 
 git clone https://github.com/sgl-project/sglang.git
 cd sglang
-uv pip install -e python
+uv pip install --prerelease=allow -e python
 ```
 
 Then run the **Python** output of the command panel below in that environment.

--- a/docs/cookbook/autoregressive/Qwen/Qwen3.5.mdx
+++ b/docs/cookbook/autoregressive/Qwen/Qwen3.5.mdx
@@ -97,7 +97,7 @@ SGLang from the main branch is required for Qwen3.5. You can install from source
 
 ```bash Command
 # Install from source
-uv pip install 'git+https://github.com/sgl-project/sglang.git#subdirectory=python'
+uv pip install --prerelease=allow 'git+https://github.com/sgl-project/sglang.git#subdirectory=python'
 
 # Or use Docker (NVIDIA GPUs)
 docker pull lmsysorg/sglang:latest

--- a/docs/cookbook/autoregressive/Qwen/Qwen3.6.mdx
+++ b/docs/cookbook/autoregressive/Qwen/Qwen3.6.mdx
@@ -77,10 +77,10 @@ SGLang `>=0.5.10` is required for Qwen3.6. You can install from PyPI, from sourc
 
 ```bash Command
 # Install from PyPI
-uv pip install sglang
+uv pip install --prerelease=allow sglang
 
 # Or install from source
-uv pip install 'git+https://github.com/sgl-project/sglang.git#subdirectory=python'
+uv pip install --prerelease=allow 'git+https://github.com/sgl-project/sglang.git#subdirectory=python'
 
 # Or use Docker (NVIDIA GPUs; also serves the NVFP4 variants)
 docker pull lmsysorg/sglang:latest

--- a/docs/cookbook/autoregressive/Qwen/Qwen3.8-27B.mdx
+++ b/docs/cookbook/autoregressive/Qwen/Qwen3.8-27B.mdx
@@ -19,14 +19,14 @@ For all methods and hardware platforms, see the [official SGLang installation gu
 ```bash Command
 pip install --upgrade pip
 pip install uv
-uv pip install sglang
+uv pip install --prerelease=allow sglang
 
 # For the DFLASH2 cells only — DFlash2 selector support is newer than the
 # latest release, so build from the commit those cells were validated on
 # instead of the line above:
 # git clone https://github.com/sgl-project/sglang.git && cd sglang
 # git checkout 1cf2b8c54d81802abc15dcf23a29b9cc687bc01e   # PR #35496
-# uv pip install -e "python[all]"
+# uv pip install --prerelease=allow -e "python[all]"
 ```
 
 Then run the **Python** output of the command panel below in that environment.

--- a/docs/cookbook/autoregressive/Qwen/Qwen3.8.mdx
+++ b/docs/cookbook/autoregressive/Qwen/Qwen3.8.mdx
@@ -18,7 +18,7 @@ For all methods and hardware platforms, see the [official SGLang installation gu
 ```bash Command
 pip install --upgrade pip
 pip install uv
-uv pip install sglang
+uv pip install --prerelease=allow sglang
 ```
 
 Then run the **Python** output of the command panel below in that environment.

--- a/docs/cookbook/autoregressive/RedNote/Dots3-Note.mdx
+++ b/docs/cookbook/autoregressive/RedNote/Dots3-Note.mdx
@@ -23,7 +23,7 @@ uv venv --python 3.12 && source .venv/bin/activate
 git clone https://github.com/sgl-project/sglang.git
 cd sglang
 git fetch origin pull/33829/head && git checkout FETCH_HEAD
-uv pip install -e python
+uv pip install --prerelease=allow -e python
 ```
 
 Then run the **Python** output of the command panel below in that environment.

--- a/docs/cookbook/autoregressive/Tencent/Hy3.mdx
+++ b/docs/cookbook/autoregressive/Tencent/Hy3.mdx
@@ -21,11 +21,11 @@ pip install -U uv
 uv venv --python 3.12 && source .venv/bin/activate
 
 # Install from source (main carries the suffix-aware `hunyuan` parser + the
-# HYV3 model code). Once a tagged release picks it up, `uv pip install sglang`
-# is enough.
+# HYV3 model code). Once a tagged release picks it up,
+# `uv pip install --prerelease=allow sglang` is enough.
 git clone https://github.com/sgl-project/sglang.git
 cd sglang
-uv pip install -e python
+uv pip install --prerelease=allow -e python
 ```
 
 Run the **Python** output of the command panel below in that environment.

--- a/docs/docs/get-started/install.mdx
+++ b/docs/docs/get-started/install.mdx
@@ -25,6 +25,10 @@ pip install uv
 uv pip install --prerelease=allow sglang
 ```
 
+<Note>
+Some of SGLang's dependencies only publish pre-releases on PyPI, so without `--prerelease=allow` uv older than 0.12.0 silently installs SGLang 0.5.9. On [uv 0.12.0](https://github.com/astral-sh/uv/releases/tag/0.12.0) and newer the flag is a harmless no-op.
+</Note>
+
 The major version of Cuda is 13 by default. To install sglang under Cuda 12 with pip or uv, please try the following commands:
 ```bash Command
 pip install --upgrade pip


### PR DESCRIPTION
## Motivation

Fixes the docs half of #35912.

uv older than 0.12.0 does not honor pre-release specifiers found in **transitive** dependency metadata (changed in astral-sh/uv#19993, released in [uv 0.12.0](https://github.com/astral-sh/uv/releases/tag/0.12.0) on 2026-07-28). `flash-attn-4`, a mandatory dependency of every release since 0.5.10, only publishes pre-releases on PyPI, so `uv pip install sglang` treats every release ≥ 0.5.10 as unsatisfiable and silently backtracks to **0.5.9** (2026-02-23) — no error, no warning. Users then hit bugs that were fixed months ago.

`docs/docs/get-started/install.mdx` already carries `--prerelease=allow` (#29676), but the cookbook pages do not, so anyone following a model page — or typing the obvious command — still lands on 0.5.9.

Two things make this worse than when #29676 landed:

- `sglang==0.5.18` now also pins `cuda-tile==1.6.0rc5`, so **source and editable installs fail outright** on uv < 0.12.0 (the resolver cannot backtrack when the version is fixed), which is why the `-e python` commands need the flag too.
- uv 0.12.0 is only a few weeks old, so most environments and images still ship 0.11.x.

Measured with `uv pip compile` (`--python-platform x86_64-manylinux_2_34 --python-version 3.12`):

| uv | default | `--prerelease=allow` |
| --- | --- | --- |
| 0.11.24 | **`sglang==0.5.9`** | `sglang==0.5.18` |
| 0.12.5 | `sglang==0.5.18` | `sglang==0.5.18` |

And with the version pinned so the resolver cannot backtrack (uv 0.11.24, default):

```
$ echo 'sglang==0.5.18' | uv pip compile - --python-platform x86_64-manylinux_2_34
× Because there is no version of cuda-tile==1.6.0rc5 and sglang==0.5.18 depends on
  cuda-tile==1.6.0rc5, we can conclude that sglang==0.5.18 cannot be used.
hint: `cuda-tile` was requested with a pre-release marker ... (try: `--prerelease=allow`)
```

`pip`, uv ≥ 0.12.0, and the Docker images are unaffected. On new uv the flag is a harmless no-op.

## Modifications

Docs only.

- Added `--prerelease=allow` to **31 commands across 26 cookbook pages** — every command that installs SGLang, in all three forms:
  - PyPI: `uv pip install sglang`, `"sglang>=0.5.9"`, the pinned nightly in `Nemotron3-Nano.mdx`
  - git: `uv pip install 'git+https://github.com/sgl-project/sglang.git#subdirectory=python'`
  - source: `uv pip install -e python`, `-e "python[all]"`
- Same fix in `.claude/skills/cookbook-add-model/templates/page.mdx.tmpl`, so new pages get it by default.
- Added a two-sentence `<Note>` to `install.mdx` Method 1 explaining why the flag is there and that uv ≥ 0.12.0 does not need it.

Deliberately left alone, verified as unaffected:

- Commands that do not install SGLang: `lmms_eval` (Qwen3-VL), `natten` (LTX2.5), `".[s2pro]"` (S2-Pro — that is the separate `sglang-omni` repo).
- The pages that already had the flag: the six diffusion pages and LongCat-2.0.
- `hardware-platforms/tpu.mdx` (installs `sglang-jax`, a different repo), `hardware-platforms/cpu_server.mdx` (`cp pyproject_cpu.toml`), `hardware-platforms/apple_metal.mdx` and `sglang-diffusion/installation.mdx` (`mv pyproject_other.toml`) — neither `pyproject_cpu.toml` nor `pyproject_other.toml` contains `flash-attn-4`, `cuda-tile`, or any other pre-release pin.

After this change, `git grep "uv pip install" -- docs` has no remaining SGLang install without the flag.

## Accuracy Tests

N/A — documentation only.

## Speed Tests and Profiling

N/A — documentation only.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). — N/A, docs only; `node docs/scripts/check_cookbook_configs.mjs` passes.
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results. — N/A, docs only.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Follow-ups (not in this PR)

#35912 also raises two non-docs items this PR does not address: a packaging/runtime guard so the silent downgrade cannot happen at all, and re-triaging the older issues whose environment fingerprint matches a resolver-driven 0.5.9 install (#24029, #34111, #34112, #34113, #33283, #25670).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32534198341](https://github.com/sgl-project/sglang/actions/runs/32534198341)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32534198151](https://github.com/sgl-project/sglang/actions/runs/32534198151)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->