### PR TITLE
[Fix] Read the granite sinks dtype from the exec bag, not the legacy global shim

### DIFF
--- a/python/sglang/srt/models/granite.py
+++ b/python/sglang/srt/models/granite.py
@@ -47,8 +47,7 @@ from sglang.srt.model_loader.weight_utils import (
     default_weight_loader,
     sharded_weight_loader,
 )
-from sglang.srt.runtime_context import get_parallel
-from sglang.srt.server_args import get_global_server_args
+from sglang.srt.runtime_context import get_exec, get_parallel
 from sglang.srt.utils import add_prefix, set_weight_attrs
 from sglang.utils import get_exception_traceback
 
@@ -74,8 +73,10 @@ def granite_layer_attn_params(
 
 
 def build_attention_sinks(num_heads: int) -> nn.Parameter:
-    # trtllm_mha requires float32 sinks, other backends use bfloat16.
-    attn_backend = get_global_server_args().attention_backend
+    # TODO(kpham-sgl): one parameter cannot serve a split launch -- trtllm_mha
+    # wants float32 sinks, FA4 wants bfloat16. Pick the dtype at init instead,
+    # once the serving backends are known. Checkpoint dtype also unverified.
+    attn_backend = get_exec().kernel.attention_backend
     sinks_dtype = torch.float32 if attn_backend == "trtllm_mha" else torch.bfloat16
     sinks = nn.Parameter(torch.empty(num_heads, dtype=sinks_dtype), requires_grad=False)
     set_weight_attrs(sinks, {"weight_loader": sharded_weight_loader(0)})


### PR DESCRIPTION
## Motivation

#35794 (Granite SWA) added a `get_global_server_args()` read to `build_attention_sinks`, to pick the `sinks` dtype from the configured attention backend. That is the legacy process-global shim the runtime context replaced, and `test_legacy_global_ratchet.py` pins its call-sites at `1` — the shim definition itself. The ratchet has been **red on `main` at `2`** since that PR merged.

This unblocks CI with no behaviour change.

## Modifications

`granite.py` reads the same field off the `exec` config bag instead:

```diff
-from sglang.srt.server_args import get_global_server_args
+from sglang.srt.runtime_context import get_exec, get_parallel
...
-    attn_backend = get_global_server_args().attention_backend
+    attn_backend = get_exec().kernel.attention_backend
```

This is exactly what `gpt_oss.py` already does for the same decision, so the two now agree. Resolved values are identical: bfloat16 sinks, float32 under `trtllm_mha`.

### The rule being preserved is wrong — recorded, not fixed

A `TODO(kpham-sgl)` next to the code says so, because it is not obvious from reading it:

- **`trtllm_mha`'s kernel consumes float32 sinks; FA4 asserts bfloat16.** One parameter has one dtype, so a split launch (`--prefill-attention-backend fa4 --decode-attention-backend trtllm_mha`) cannot be served at all — whichever half is read, the other kernel gets the wrong dtype.
- **A split-only launch leaves the base field unset**, so this read returns `None` and silently picks bfloat16.
- **The checkpoint's own sinks dtype is unverified.** `default_weight_loader` asserts size, not dtype, and `copy_` casts silently — so a checkpoint shipping a different dtype is converted here with no error.

The fix belongs at init, once the serving backend(s) are known — a per-phase sinks tensor, or the checkpoint dtype plus a cast in the one kernel that needs float32. That is deliberately **not** in this PR: it is a behaviour change and wants its own review, and the ratchet should not stay red waiting for it. #34917 covers the gpt-oss half of the same problem.

## Accuracy Tests

No behaviour change — the two accessors return the same resolved field, verified directly under both configurations:

| `--attention-backend` | sinks dtype |
|---|---|
| `fa3` | `torch.bfloat16` |
| `trtllm_mha` | `torch.float32` |

- `test_legacy_global_ratchet.py` — back to baseline `1`; red on `main` today at `2`.
- `test_global_config_read_ratchet.py`, `test_split_attention_backend_decisions.py` — pass. (`test_inkling_selects_the_half_serving_the_forward` fails identically with this change reverted — missing CUDA-only `cutlass` in my local env — so it is not from this PR.)

No GPU run attached; none is warranted for a change that provably resolves to the same value.

## Speed Tests and Profiling

None — no behaviour or code-path change at runtime.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). — covered by the existing ratchet, which is the test for this change.
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — no user-facing surface changes.
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). — no behaviour change.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32542325612](https://github.com/sgl-project/sglang/actions/runs/32542325612)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32542325506](https://github.com/sgl-project/sglang/actions/runs/32542325506)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32542325531](https://github.com/sgl-project/sglang/actions/runs/32542325531)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->