### PR TITLE
[MoonEP] Add zero-copy eager expert output path

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -980,7 +980,14 @@ class Envs:
     # -1 uses MoonEP's training-safe default B = E / EP.
     SGLANG_MOONEP_NUM_PREFETCH_SLOTS = EnvInt(-1)
     SGLANG_MOONEP_TOKEN_PADDING = EnvInt(128)
+    # Decode-phase token capacity; <= 0 derives it from max_running_requests.
+    SGLANG_MOONEP_DECODE_MAX_DISPATCH_TOKENS_PER_RANK = EnvInt(-1)
     SGLANG_MOONEP_NUM_SMS = EnvInt(32)
+    # Eager inference only: lease MoonEP's hidden communication view through
+    # expert compute and write the final output back into it.
+    SGLANG_MOONEP_ZERO_COPY = EnvBool(False)
+    # MoonEP's static shapes should be capturable; off until that is shown.
+    SGLANG_ENABLE_MOONEP_CUDA_GRAPH = EnvBool(False)
     SGLANG_PPLX_NUM_MAX_DISPATCH_TOKENS_PER_RANK = EnvInt(128)
     SGLANG_ENABLE_MOE_DEFERRED_FINALIZE = EnvBool(True)
     # DeepSeek/GLM MoE (deepseek_v2.py): quantize the (dp-gathered) MoE input

--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -318,6 +318,7 @@ class DeepEPMoE(FusedMoE):
                 dispatch_output,
                 weight_layout,
                 activation=self.moe_runner_config.activation,
+                zero_copy=dispatch_output.hidden_states_zero_copy,
             )
         else:
             raise NotImplementedError(

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -134,7 +134,10 @@ def _get_deepep_comm_group(a2a_backend):
     return group
 
 
-def create_moe_dispatcher(moe_runner_config: MoeRunnerConfig) -> BaseDispatcher:
+def create_moe_dispatcher(
+    moe_runner_config: MoeRunnerConfig,
+    moonep_zero_copy_supported: bool = False,
+) -> BaseDispatcher:
     a2a_backend = get_moe_a2a_backend()
     if a2a_backend.is_none() and is_npu():
         return AscendTPDispatcher(moe_runner_config)
@@ -155,7 +158,7 @@ def create_moe_dispatcher(moe_runner_config: MoeRunnerConfig) -> BaseDispatcher:
         or a2a_backend.is_nixl()
         or a2a_backend.is_pplx()
     ):
-        return MaybeTboDeepEPDispatcher(
+        dispatcher_kwargs = dict(
             group=_get_deepep_comm_group(a2a_backend),
             router_topk=moe_runner_config.top_k,
             permute_fusion=True,
@@ -167,6 +170,9 @@ def create_moe_dispatcher(moe_runner_config: MoeRunnerConfig) -> BaseDispatcher:
             async_finish=True,
             return_recv_hook=True,
         )
+        if a2a_backend.is_moonep():
+            dispatcher_kwargs["zero_copy_supported"] = moonep_zero_copy_supported
+        return MaybeTboDeepEPDispatcher(**dispatcher_kwargs)
     elif a2a_backend.is_flashinfer():
         return FlashinferDispatcher(
             group=get_tp_group().device_group,
@@ -397,15 +403,15 @@ class FusedMoE(torch.nn.Module):
                 f"quant_method={type(self.quant_method).__name__})."
             )
 
-        moonep_global_weight_storage = get_moe_a2a_backend().is_moonep()
-        if moonep_global_weight_storage:
-            if quant_config is not None:
-                raise NotImplementedError(
-                    "MoonEP PoC supports unquantized BF16 MoE weights only."
-                )
+        # Quantized experts instead keep the normal EP
+        # shard and are relocated into a symmetric VMM range after loading
+        moonep_global_weight_storage = (
+            get_moe_a2a_backend().is_moonep() and quant_config is None
+        )
+        if get_moe_a2a_backend().is_moonep():
             if num_fused_shared_experts != 0:
                 raise NotImplementedError(
-                    "MoonEP PoC does not support fused shared experts yet."
+                    "MoonEP does not support fused shared experts yet."
                 )
 
         self.quant_method.create_weights(
@@ -435,7 +441,18 @@ class FusedMoE(torch.nn.Module):
                 self.w2_weight_bias._sglang_require_global_experts = True
 
         self.quant_method.create_moe_runner(self, self.moe_runner_config)
-        self.dispatcher = create_moe_dispatcher(self.moe_runner_config)
+        runner_backend = get_moe_runner_backend()
+        moonep_bf16_correctness_supported = (
+            self.quant_config is None
+            and params_dtype == torch.bfloat16
+            and (runner_backend.is_auto() or runner_backend.is_triton())
+        )
+        self.dispatcher = create_moe_dispatcher(
+            self.moe_runner_config,
+            moonep_zero_copy_supported=(
+                moonep_bf16_correctness_supported or self.use_deep_gemm
+            ),
+        )
         # Dispatchers are not nn.Modules, so they cannot register their own
         # buffers; the AITER expert mask would not survive a memory-saver resume.
         expert_mask = getattr(self.dispatcher, "expert_mask_gpu", None)

--- a/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
@@ -50,6 +50,10 @@ if TYPE_CHECKING:
         DeepEPNormalCombineInput,
         DeepEPNormalDispatchOutput,
     )
+    from sglang.srt.layers.moe.token_dispatcher.moonep import (
+        MoonEPCombineInput,
+        MoonEPDispatchOutput,
+    )
     from sglang.srt.layers.moe.token_dispatcher.standard import (
         StandardCombineInput,
         StandardDispatchOutput,
@@ -207,6 +211,7 @@ class DeepGemmRunnerInput(RunnerInput):
     masked_m: Optional[torch.Tensor] = None
     expected_m: Optional[int] = None
     m_indices: Optional[torch.Tensor] = None
+    output_buffer: Optional[torch.Tensor] = None
 
     @property
     def runner_backend(self) -> MoeRunnerBackend:
@@ -220,6 +225,46 @@ class DeepGemmRunnerOutput(RunnerOutput):
     @property
     def runner_backend(self) -> MoeRunnerBackend:
         return MoeRunnerBackend.DEEP_GEMM
+
+
+def _resolve_down_output(
+    expected_shape: tuple[int, ...],
+    dtype: torch.dtype,
+    device: torch.device,
+    provided: Optional[torch.Tensor],
+) -> torch.Tensor:
+    if provided is None:
+        with use_symmetric_memory(
+            get_tp_group(), disabled=not is_allocation_symmetric()
+        ):
+            return torch.empty(expected_shape, device=device, dtype=dtype)
+
+    if tuple(provided.shape) != expected_shape:
+        raise ValueError(
+            f"DeepGEMM output buffer shape must be {expected_shape}, "
+            f"got {tuple(provided.shape)}."
+        )
+    if provided.dtype != dtype:
+        raise ValueError(
+            f"DeepGEMM output buffer dtype must be {dtype}, got {provided.dtype}."
+        )
+    if provided.device != torch.device(device):
+        raise ValueError(
+            f"DeepGEMM output buffer device must be {device}, got {provided.device}."
+        )
+    if not provided.is_contiguous():
+        raise ValueError("DeepGEMM output buffer must be contiguous.")
+    return provided
+
+
+def _dispose_tensor_unless_alias(
+    tensor: Optional[torch.Tensor], protected: Optional[torch.Tensor]
+) -> None:
+    if tensor is None:
+        return
+    if protected is not None and tensor.data_ptr() == protected.data_ptr():
+        return
+    dispose_tensor(tensor)
 
 
 @dataclass
@@ -266,6 +311,11 @@ class DeepGemmRunnerCore(MoeRunnerCore):
         running_state: dict,
         hooks: Optional[Any] = None,
     ) -> DeepGemmRunnerOutput:
+        if runner_input.output_buffer is not None and hooks is not None:
+            raise NotImplementedError(
+                "DeepGEMM external output buffers do not support hooks that may "
+                "retain the MoonEP zero-copy view."
+            )
         weight_dtype = quant_info.w13_weight.dtype
         if not runner_input.use_masked_gemm:
             if weight_dtype == torch.bfloat16:
@@ -338,7 +388,7 @@ class DeepGemmRunnerCore(MoeRunnerCore):
             recipe_b=recipe_b,
         )
 
-        dispose_tensor(hidden_states)
+        _dispose_tensor_unless_alias(hidden_states, runner_input.output_buffer)
         dispose_tensor(hidden_states_scale)
 
         if self.config.activation == "situ":
@@ -455,18 +505,14 @@ class DeepGemmRunnerCore(MoeRunnerCore):
             )
             del down_input
 
-        # Allocate the MoE output in the NCCL symmetric memory pool when symmetric
-        # allocation is required, so the downstream all-reduce takes the low-latency
-        # symmetric path. Only this final output enters the pool; intermediate
-        # buffers stay on the default allocator to bound pool occupancy.
-        with use_symmetric_memory(
-            get_tp_group(), disabled=not is_allocation_symmetric()
-        ):
-            down_output = torch.empty(
-                (all_tokens, K),
-                device=hidden_states_device,
-                dtype=torch.bfloat16,
-            )
+        # Only fallback allocations enter the symmetric pool. MoonEP's provided
+        # output already belongs to its persistent VMM communication buffer.
+        down_output = _resolve_down_output(
+            (all_tokens, K),
+            torch.bfloat16,
+            hidden_states_device,
+            runner_input.output_buffer,
+        )
         if deep_gemm_wrapper.DEEPGEMM_NEED_TMA_ALIGNED_SCALES:
             down_input_scale = tma_align_input_scale(down_input_scale)
 
@@ -514,7 +560,7 @@ class DeepGemmRunnerCore(MoeRunnerCore):
             m_indices,
         )
 
-        dispose_tensor(hidden_states)
+        _dispose_tensor_unless_alias(hidden_states, runner_input.output_buffer)
 
         # Act: (M, N) -> (M, N/2)
         if not _is_musa:
@@ -532,14 +578,12 @@ class DeepGemmRunnerCore(MoeRunnerCore):
         del gateup_output
 
         # GroupGemm-2: (M, N/2) (E, K, N/2) -> (M, K)
-        with use_symmetric_memory(
-            get_tp_group(), disabled=not is_allocation_symmetric()
-        ):
-            down_output = torch.empty(
-                (all_tokens, K),
-                device=hidden_states_device,
-                dtype=torch.bfloat16,
-            )
+        down_output = _resolve_down_output(
+            (all_tokens, K),
+            torch.bfloat16,
+            hidden_states_device,
+            runner_input.output_buffer,
+        )
         deep_gemm_wrapper.grouped_gemm_nt_bf16_contig(
             down_input,
             w2_weight,
@@ -1237,6 +1281,216 @@ def post_permute_deep_gemm_to_deepep_normal(
         hidden_states=gather_out,
         topk_ids=running_state["topk_ids"],
         topk_weights=running_state["topk_weights"],
+    )
+
+
+def _moonep_m_indices(
+    cu_seqlens: torch.Tensor,
+    expert_ids: torch.Tensor,
+    all_tokens: int,
+) -> torch.Tensor:
+    """Expand MoonEP's per-group segment ends into DeepGEMM's per-row group ids.
+
+    ``cu_seqlens[g]`` is the *end* offset of group ``g`` (no leading zero), so
+    ``searchsorted(..., right=True)`` maps a row to the group that owns it and
+    naturally skips empty groups. Two kinds of rows get ``-1``, which DeepGEMM
+    skips entirely: rows past the last segment (MoonEP pads the receive buffer
+    to a static ``NvS``) and rows whose group is an unfilled prefetch slot
+    (``expert_ids`` already carries ``-1`` there).
+
+    ``expert_ids`` -- not the group index -- is the value DeepGEMM wants: it
+    indexes the leading dimension of the expert weight tensor.
+    """
+    num_groups = expert_ids.numel()
+    rows = torch.arange(all_tokens, device=cu_seqlens.device, dtype=cu_seqlens.dtype)
+    group = torch.searchsorted(cu_seqlens, rows, right=True)
+    m_indices = expert_ids[group.clamp(max=num_groups - 1)].to(torch.int32)
+    return torch.where(group < num_groups, m_indices, torch.full_like(m_indices, -1))
+
+
+@register_pre_permute("moonep", "deep_gemm")
+def pre_permute_moonep_to_deep_gemm(
+    dispatch_output: MoonEPDispatchOutput,
+    quant_info: DeepGemmMoeQuantInfo,
+    runner_config: MoeRunnerConfig,
+    running_state: dict,
+) -> DeepGemmRunnerInput:
+    """MoonEP dispatch output -> DeepGEMM m-grouped contiguous input.
+
+    Unlike the deepep/standard pre-permutes there is no scatter here: MoonEP's
+    ``dispatch`` already returns rows grouped by expert and padded to
+    ``token_padding``, which matches DeepGEMM's
+    ``get_mk_alignment_for_contiguous_layout()``. All that is left is deriving
+    ``m_indices`` and, for quantized experts, quantizing the activations.
+    """
+    hidden_states = dispatch_output.hidden_states
+    if hidden_states.ndim != 2:
+        raise ValueError(
+            f"MoonEP hidden states must be [NvS, H], got {hidden_states.shape}"
+        )
+
+    all_tokens = hidden_states.shape[0]
+    running_state["all_tokens"] = all_tokens
+    running_state["hidden_states_shape"] = hidden_states.shape
+    running_state["hidden_states_dtype"] = hidden_states.dtype
+    running_state["hidden_states_device"] = hidden_states.device
+    # Carried through because MoonEP's combine reconstructs from the plan and
+    # does not apply route weights itself -- the post-permute must.
+    running_state["route_weights_nvs"] = dispatch_output.route_weights_nvs
+    running_state["plan"] = dispatch_output.plan
+    running_state["num_tokens"] = dispatch_output.num_tokens
+    running_state["moonep_hidden_states_zero_copy"] = (
+        dispatch_output.hidden_states_zero_copy
+    )
+    running_state["moonep_buffer_key"] = dispatch_output.buffer_key
+    running_state["moonep_owner_id"] = dispatch_output.owner_id
+    output_buffer = (
+        hidden_states if dispatch_output.hidden_states_zero_copy else None
+    )
+    if dispatch_output.hidden_states_zero_copy and (
+        dispatch_output.buffer_key is None or dispatch_output.owner_id is None
+    ):
+        raise RuntimeError(
+            "MoonEP zero-copy DeepGEMM input is missing ownership metadata."
+        )
+    if dispatch_output.hidden_states_zero_copy:
+        from sglang.srt.layers.moe.token_dispatcher.moonep import MoonEPBuffer
+
+        MoonEPBuffer.begin_zero_copy_output_write(
+            key=dispatch_output.buffer_key,
+            plan=dispatch_output.plan,
+            hidden_states=hidden_states,
+            owner_id=dispatch_output.owner_id,
+        )
+    running_state["moonep_output_buffer"] = output_buffer
+
+    expert_ids = dispatch_output.expert_ids
+    if quant_info.w13_weight.dtype != torch.bfloat16:
+        # Quantized experts live in MoonEP's symmetric pool, so the duplicated
+        # ones have to be pulled in before the GEMM reads them, and the plan's
+        # global expert ids have to become pool rows. This runs here rather
+        # than in DeepEPMoE.run_moe_core because MXFP4 on DeepGEMM sets
+        # deprecate_flag, which delegates past that method entirely.
+        from sglang.srt.layers.moe.token_dispatcher import moonep_weights
+        from sglang.srt.layers.moe.token_dispatcher.moonep import MoonEPBuffer
+
+        layer_id = runner_config.layer_id
+        assert layer_id is not None, "MoonEP pre-permute needs runner_config.layer_id"
+        weight_pairs, scale_pairs = moonep_weights.prefetch_pairs(layer_id)
+        MoonEPBuffer.get_existing_buffer().prefetch_weight(
+            plan=dispatch_output.plan,
+            async_finish=False,
+            weight_pairs=weight_pairs,
+            scale_pairs=scale_pairs or None,
+            experts_to_copy=moonep_weights.expert_rows(
+                layer_id,
+                dispatch_output.plan.experts_to_copy[get_tp_group().rank_in_group],
+            ),
+        )
+        # The parameters are this rank's slice of the pool, but m_indices
+        # addresses the whole symmetric range -- a duplicated expert's rows
+        # live in another rank's chunk. Point the GEMM at the full ranges, of
+        # which the parameters are a sub-view.
+        pool = moonep_weights.get_pool()
+        quant_info.w13_weight = pool.ranges[moonep_weights.W13_WEIGHT].view(torch.int8)
+        quant_info.w2_weight = pool.ranges[moonep_weights.W2_WEIGHT].view(torch.int8)
+        quant_info.w13_scale = pool.ranges[moonep_weights.W13_SCALE].permute(0, 2, 1)
+        quant_info.w2_scale = pool.ranges[moonep_weights.W2_SCALE].permute(0, 2, 1)
+
+        expert_ids = moonep_weights.group_rows(
+            layer_id, expert_ids, runner_config.num_experts
+        )
+
+    m_indices = _moonep_m_indices(dispatch_output.cu_seqlens, expert_ids, all_tokens)
+    running_state["m_indices"] = m_indices
+
+    if quant_info.w13_weight.dtype == torch.bfloat16:
+        return DeepGemmRunnerInput(
+            hidden_states=hidden_states,
+            # Unused by the BF16 contiguous GEMM, but the field is non-optional.
+            hidden_states_scale=torch.empty(
+                (all_tokens, 1), device=hidden_states.device, dtype=torch.float32
+            ),
+            use_masked_gemm=False,
+            m_indices=m_indices,
+            output_buffer=output_buffer,
+        )
+
+    from sglang.kernels.ops.quantization.fp8_kernel import (
+        sglang_per_token_group_quant_fp8,
+    )
+
+    block_k = quant_info.block_shape[1] if quant_info.block_shape else 128
+    running_state["mxfp8_act_gran_k"] = block_k
+    hidden_states_fp8, hidden_states_scale = sglang_per_token_group_quant_fp8(
+        hidden_states,
+        block_k,
+        column_major_scales=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
+        scale_tma_aligned=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
+        scale_ue8m0=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
+    )
+    return DeepGemmRunnerInput(
+        hidden_states=hidden_states_fp8,
+        hidden_states_scale=hidden_states_scale,
+        use_masked_gemm=False,
+        m_indices=m_indices,
+        output_buffer=output_buffer,
+    )
+
+
+@register_post_permute("deep_gemm", "moonep")
+def post_permute_deep_gemm_to_moonep(
+    runner_output: DeepGemmRunnerOutput,
+    quant_info: DeepGemmMoeQuantInfo,
+    runner_config: MoeRunnerConfig,
+    running_state: dict,
+) -> MoonEPCombineInput:
+    """DeepGEMM output -> MoonEP combine input, still in dispatched row order.
+
+    No gather: MoonEP's ``combine`` consumes the ``[NvS, H]`` layout directly.
+
+    Rows DeepGEMM skipped (``m_indices == -1``) were never written, so they
+    still hold whatever ``torch.empty`` left behind and must be zeroed before
+    combine reduces them. Zeroing cannot be folded into the route-weight
+    multiply below, because uninitialized memory may decode to NaN and
+    ``0 * NaN`` is NaN.
+    """
+    from sglang.srt.layers.moe.token_dispatcher.moonep import (
+        MoonEPBuffer,
+        MoonEPCombineInput,
+    )
+
+    hidden_states = runner_output.hidden_states
+    output_buffer = running_state["moonep_output_buffer"]
+    if output_buffer is not None and hidden_states.data_ptr() != output_buffer.data_ptr():
+        raise RuntimeError(
+            "MoonEP zero-copy DeepGEMM output pointer was replaced: "
+            f"expected {output_buffer.data_ptr()}, got {hidden_states.data_ptr()}."
+        )
+    hidden_states.masked_fill_((running_state["m_indices"] < 0).unsqueeze(-1), 0.0)
+
+    route_weights_nvs = running_state["route_weights_nvs"]
+    if route_weights_nvs is not None:
+        hidden_states.mul_(
+            route_weights_nvs.to(dtype=hidden_states.dtype).unsqueeze(-1)
+        )
+
+    if running_state["moonep_hidden_states_zero_copy"]:
+        MoonEPBuffer.mark_zero_copy_output_written(
+            key=running_state["moonep_buffer_key"],
+            plan=running_state["plan"],
+            hidden_states=hidden_states,
+            owner_id=running_state["moonep_owner_id"],
+        )
+
+    return MoonEPCombineInput(
+        hidden_states=hidden_states,
+        route_weights_nvs=route_weights_nvs,
+        plan=running_state["plan"],
+        num_tokens=running_state["num_tokens"],
+        hidden_states_zero_copy=running_state["moonep_hidden_states_zero_copy"],
+        buffer_key=running_state["moonep_buffer_key"],
+        owner_id=running_state["moonep_owner_id"],
     )
 
 

--- a/python/sglang/srt/layers/moe/token_dispatcher/moonep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/moonep.py
@@ -15,10 +15,11 @@ from sglang.srt.layers.moe.token_dispatcher.base import (
     DispatchOutput,
     DispatchOutputFormat,
 )
-from sglang.srt.layers.moe.topk import TopKOutput
-from sglang.srt.layers.moe.topk import TopKOutputChecker
+from sglang.srt.layers.moe.topk import TopKOutput, TopKOutputChecker
 from sglang.srt.layers.moe.utils import DeepEPMode
 
+
+_DECODE_TOKENS_PER_REQUEST_HEADROOM = 8
 
 _MOONEP_UNSUPPORTED_MESSAGE = (
     "MoonEP MoE A2A is recognized by SGLang, but the runtime dispatcher is not "
@@ -42,6 +43,9 @@ class MoonEPDispatchOutput(NamedTuple):
     plan: Any
     expert_ids: torch.Tensor
     num_tokens: int
+    hidden_states_zero_copy: bool = False
+    buffer_key: Optional[MoonEPBufferKey] = None
+    owner_id: Optional[int] = None
 
     @property
     def format(self) -> DispatchOutputFormat:
@@ -58,6 +62,9 @@ class MoonEPCombineInput(NamedTuple):
     route_weights_nvs: Optional[torch.Tensor]
     plan: Any
     num_tokens: int
+    hidden_states_zero_copy: bool = False
+    buffer_key: Optional[MoonEPBufferKey] = None
+    owner_id: Optional[int] = None
 
     @property
     def format(self) -> CombineInputFormat:
@@ -97,6 +104,15 @@ class MoonEPBufferKey:
     num_sms: int
 
 
+@dataclass
+class _MoonEPZeroCopyFlight:
+    key: MoonEPBufferKey
+    plan: Any
+    hidden_states_ptr: int
+    owner_id: int
+    state: str = "DISPATCH_VIEW_OWNED"
+
+
 class MoonEPBuffer:
     """Process-wide facade for MoonEP communication buffers.
 
@@ -118,8 +134,11 @@ class MoonEPBuffer:
             state = SimpleNamespace(
                 buffers={},
                 active_key=None,
+                zero_copy_flights={},
             )
             buffers["moonep_ep_state"] = state
+        elif not hasattr(state, "zero_copy_flights"):
+            state.zero_copy_flights = {}
         return state
 
     @staticmethod
@@ -226,6 +245,170 @@ class MoonEPBuffer:
         return state.buffers.get(key)
 
     @classmethod
+    def assert_idle(cls, key: MoonEPBufferKey) -> None:
+        flight = cls._state().zero_copy_flights.get(key)
+        if flight is not None:
+            raise RuntimeError(
+                "MoonEP buffer already owns a zero-copy flight "
+                f"(owner_id={flight.owner_id}, pointer={flight.hidden_states_ptr}); "
+                "dispatch/combine overlap is unsupported."
+            )
+
+    @classmethod
+    def begin_zero_copy_flight(
+        cls,
+        *,
+        key: MoonEPBufferKey,
+        buffer: Any,
+        plan: Any,
+        hidden_states: torch.Tensor,
+        owner_id: int,
+    ) -> None:
+        cls.assert_idle(key)
+        flight = _MoonEPZeroCopyFlight(
+            key=key,
+            plan=plan,
+            hidden_states_ptr=hidden_states.data_ptr(),
+            owner_id=owner_id,
+        )
+        # Record ownership before validating. If validation fails after dispatch
+        # has exposed the persistent view, the flight stays poisoned rather than
+        # allowing another communication call to overwrite unknown live state.
+        cls._state().zero_copy_flights[key] = flight
+        cls.validate_zero_copy_flight(
+            key=key,
+            buffer=buffer,
+            plan=plan,
+            hidden_states=hidden_states,
+            owner_id=owner_id,
+        )
+
+    @classmethod
+    def validate_zero_copy_flight(
+        cls,
+        *,
+        key: MoonEPBufferKey,
+        buffer: Any,
+        plan: Any,
+        hidden_states: torch.Tensor,
+        owner_id: int,
+        expected_state: Optional[str] = None,
+    ) -> None:
+        flight = cls._state().zero_copy_flights.get(key)
+        if flight is None:
+            raise RuntimeError("MoonEP zero-copy combine has no active flight.")
+        if flight.owner_id != owner_id:
+            raise RuntimeError(
+                "MoonEP zero-copy flight owner mismatch: "
+                f"expected {flight.owner_id}, got {owner_id}."
+            )
+        if flight.plan is not plan:
+            raise RuntimeError("MoonEP zero-copy flight plan mismatch.")
+        if flight.hidden_states_ptr != hidden_states.data_ptr():
+            raise RuntimeError(
+                "MoonEP zero-copy hidden-state pointer was replaced: "
+                f"expected {flight.hidden_states_ptr}, got {hidden_states.data_ptr()}."
+            )
+        if expected_state is not None and flight.state != expected_state:
+            raise RuntimeError(
+                "MoonEP zero-copy flight state mismatch: "
+                f"expected {expected_state}, got {flight.state}."
+            )
+
+        buffer_view = buffer.hidden_nvsh_buffer_view
+        if hidden_states.data_ptr() != buffer_view.data_ptr():
+            raise RuntimeError(
+                "MoonEP zero-copy hidden-state pointer does not alias the "
+                "buffer's persistent view."
+            )
+        if (
+            hidden_states.shape != buffer_view.shape
+            or hidden_states.dtype != buffer_view.dtype
+            or hidden_states.device != buffer_view.device
+            or not hidden_states.is_contiguous()
+        ):
+            raise RuntimeError(
+                "MoonEP zero-copy hidden-state view changed shape, dtype, "
+                "device, or contiguity during the flight."
+            )
+
+    @classmethod
+    def begin_zero_copy_output_write(
+        cls,
+        *,
+        key: MoonEPBufferKey,
+        plan: Any,
+        hidden_states: torch.Tensor,
+        owner_id: int,
+    ) -> None:
+        flight = cls._state().zero_copy_flights.get(key)
+        if flight is None:
+            raise RuntimeError("MoonEP zero-copy output write has no active flight.")
+        if (
+            flight.plan is not plan
+            or flight.hidden_states_ptr != hidden_states.data_ptr()
+            or flight.owner_id != owner_id
+        ):
+            raise RuntimeError(
+                "MoonEP zero-copy output write does not match its active flight."
+            )
+        if flight.state != "DISPATCH_VIEW_OWNED":
+            raise RuntimeError(
+                "MoonEP zero-copy output write was started more than once or "
+                "after combine."
+            )
+        flight.state = "OUTPUT_WRITE_STARTED"
+
+    @classmethod
+    def mark_zero_copy_output_written(
+        cls,
+        *,
+        key: MoonEPBufferKey,
+        plan: Any,
+        hidden_states: torch.Tensor,
+        owner_id: int,
+    ) -> None:
+        flight = cls._state().zero_copy_flights.get(key)
+        if flight is None:
+            raise RuntimeError("MoonEP zero-copy output has no active flight.")
+        if (
+            flight.plan is not plan
+            or flight.hidden_states_ptr != hidden_states.data_ptr()
+            or flight.owner_id != owner_id
+        ):
+            raise RuntimeError(
+                "MoonEP zero-copy output does not match its active flight."
+            )
+        if flight.state != "OUTPUT_WRITE_STARTED":
+            raise RuntimeError(
+                "MoonEP zero-copy output write did not start exactly once."
+            )
+        flight.state = "OUTPUT_WRITTEN"
+
+    @classmethod
+    def complete_zero_copy_flight(
+        cls,
+        *,
+        key: MoonEPBufferKey,
+        plan: Any,
+        hidden_states: torch.Tensor,
+        owner_id: int,
+    ) -> None:
+        flight = cls._state().zero_copy_flights.get(key)
+        if (
+            flight is None
+            or flight.plan is not plan
+            or flight.hidden_states_ptr != hidden_states.data_ptr()
+            or flight.owner_id != owner_id
+            or flight.state != "OUTPUT_WRITTEN"
+        ):
+            raise RuntimeError(
+                "MoonEP zero-copy flight changed before combine completion."
+            )
+        flight.state = "COMBINE_QUEUED"
+        del cls._state().zero_copy_flights[key]
+
+    @classmethod
     def get_moonep_buffer(
         cls,
         group: dist.ProcessGroup,
@@ -286,6 +469,7 @@ class MoonEPBuffer:
             return
 
         buffer = state.buffers.pop(key, None)
+        state.zero_copy_flights.pop(key, None)
         destroy = getattr(buffer, "destroy", None)
         if callable(destroy):
             destroy()
@@ -298,6 +482,7 @@ class MoonEPBuffer:
         for key in list(state.buffers):
             cls.destroy_buffer(key)
         state.active_key = None
+        state.zero_copy_flights.clear()
 
 
 def get_moonep_num_prefetch_slots(num_experts: int, num_ep_ranks: int) -> int:
@@ -419,6 +604,7 @@ def run_moonep_bf16_expert(
     weight_layout: MoonEPExpertWeightLayout,
     *,
     activation: str = "silu",
+    zero_copy: bool = False,
 ) -> MoonEPCombineInput:
     """Run a simple BF16 MoonEP expert core over ``cu_seqlens`` segments.
 
@@ -451,11 +637,25 @@ def run_moonep_bf16_expert(
             f"shape {cu_seqlens.shape}"
         )
     if route_weights_nvs is not None and route_weights_nvs.ndim != 1:
-        raise ValueError(
-            f"route_weights_nvs must be 1D, got {route_weights_nvs.shape}"
-        )
+        raise ValueError(f"route_weights_nvs must be 1D, got {route_weights_nvs.shape}")
 
-    output = torch.empty_like(hidden_states)
+    if zero_copy != dispatch_output.hidden_states_zero_copy:
+        raise RuntimeError(
+            "MoonEP BF16 runner mode must match the dispatch view's zero-copy "
+            "ownership metadata."
+        )
+    if zero_copy:
+        if dispatch_output.buffer_key is None or dispatch_output.owner_id is None:
+            raise RuntimeError(
+                "MoonEP BF16 zero-copy output is missing ownership metadata."
+            )
+        MoonEPBuffer.begin_zero_copy_output_write(
+            key=dispatch_output.buffer_key,
+            plan=dispatch_output.plan,
+            hidden_states=hidden_states,
+            owner_id=dispatch_output.owner_id,
+        )
+    output = hidden_states if zero_copy else torch.empty_like(hidden_states)
     prev = 0
     for group_id in range(cu_seqlens.numel()):
         cur = int(cu_seqlens[group_id].item())
@@ -488,12 +688,50 @@ def run_moonep_bf16_expert(
     if prev < hidden_states.shape[0]:
         output[prev:].zero_()
 
+    if zero_copy:
+        MoonEPBuffer.mark_zero_copy_output_written(
+            key=dispatch_output.buffer_key,
+            plan=dispatch_output.plan,
+            hidden_states=output,
+            owner_id=dispatch_output.owner_id,
+        )
+
     return MoonEPCombineInput(
         hidden_states=output,
         route_weights_nvs=route_weights_nvs,
         plan=dispatch_output.plan,
         num_tokens=dispatch_output.num_tokens,
+        hidden_states_zero_copy=dispatch_output.hidden_states_zero_copy,
+        buffer_key=dispatch_output.buffer_key,
+        owner_id=dispatch_output.owner_id,
     )
+
+
+def _resolve_decode_capacity(prefill_capacity: int) -> int | None:
+    """Token capacity for decode batches, or None to reuse the prefill one.
+
+    Decode is bounded by the number of running requests, which is orders of
+    magnitude below a prefill chunk, so giving it its own smaller buffer is
+    what keeps a decode step from running the MoE over a full chunk's worth of
+    padding. Both capacities are config-derived, so every rank picks the same
+    one without communicating.
+    """
+    override = envs.SGLANG_MOONEP_DECODE_MAX_DISPATCH_TOKENS_PER_RANK.get()
+    if override > 0:
+        capacity = override
+    else:
+        from sglang.srt.runtime_context import get_schedule
+
+        # None until the scheduler resolves it; fall back to one capacity then.
+        max_running = get_schedule().max_running_requests
+        if max_running is None:
+            return None
+        # Speculative decoding submits several tokens per request per step.
+        capacity = int(max_running) * _DECODE_TOKENS_PER_REQUEST_HEADROOM
+
+    token_padding = envs.SGLANG_MOONEP_TOKEN_PADDING.get()
+    capacity = -(-capacity // token_padding) * token_padding
+    return None if capacity >= prefill_capacity else capacity
 
 
 class MoonEPDispatcher(BaseDispatcher):
@@ -511,6 +749,7 @@ class MoonEPDispatcher(BaseDispatcher):
         deepep_mode: DeepEPMode = DeepEPMode.AUTO,
         async_finish: bool = False,
         return_recv_hook: bool = False,
+        zero_copy_supported: bool = True,
     ):
         super().__init__()
         self.group = group
@@ -523,9 +762,13 @@ class MoonEPDispatcher(BaseDispatcher):
         self.deepep_mode = deepep_mode
         self.async_finish = async_finish
         self.return_recv_hook = return_recv_hook
+        self.zero_copy_supported = zero_copy_supported
         self.expert_mask_gpu = None
         self.num_max_dispatch_tokens_per_rank = (
             envs.SGLANG_MOONEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK.get()
+        )
+        self.decode_max_dispatch_tokens_per_rank = _resolve_decode_capacity(
+            self.num_max_dispatch_tokens_per_rank
         )
         self.num_prefetch_slots = None
 
@@ -533,7 +776,29 @@ class MoonEPDispatcher(BaseDispatcher):
     def _raise_unimplemented() -> NoReturn:
         raise NotImplementedError(_MOONEP_UNSUPPORTED_MESSAGE)
 
-    def _get_buffer(self):
+    def _phase_capacity(self) -> int:
+        """Static token capacity for the current phase.
+
+        MoonEP's buffers are statically shaped and ``dispatch`` asserts an
+        exact ``S x K`` input, so every batch is padded up to the capacity. One
+        capacity sized for prefill makes decode pay for it: at K3 a batch of 8
+        tokens would run the MoE over 16384, a ~2000x inflation.
+
+        The two capacities come from server args rather than the batch, because
+        the buffer is created collectively -- picking from a runtime token
+        count would let ranks disagree and deadlock. The phase flag is uniform
+        across the group for the same reason.
+        """
+        if self.decode_max_dispatch_tokens_per_rank is None:
+            return self.num_max_dispatch_tokens_per_rank
+
+        from sglang.srt.layers.dp_attention import get_is_extend_in_batch
+
+        if get_is_extend_in_batch():
+            return self.num_max_dispatch_tokens_per_rank
+        return self.decode_max_dispatch_tokens_per_rank
+
+    def _get_buffer(self, capacity: int | None = None):
         if self.hidden_size is None or self.num_experts is None:
             raise ValueError(
                 "MoonEPDispatcher requires hidden_size and num_experts to "
@@ -544,9 +809,30 @@ class MoonEPDispatcher(BaseDispatcher):
             hidden_size=self.hidden_size,
             router_topk=self.router_topk,
             num_experts=self.num_experts,
-            num_max_dispatch_tokens_per_rank=self.num_max_dispatch_tokens_per_rank,
+            num_max_dispatch_tokens_per_rank=(
+                self._phase_capacity() if capacity is None else capacity
+            ),
             num_prefetch_slots=self.num_prefetch_slots,
         )
+
+    def _get_buffer_and_key(
+        self, capacity: int | None = None
+    ) -> tuple[Any, MoonEPBufferKey]:
+        if self.hidden_size is None or self.num_experts is None:
+            raise ValueError(
+                "MoonEPDispatcher requires hidden_size and num_experts to "
+                "create a MoonEP buffer."
+            )
+        resolved_capacity = self._phase_capacity() if capacity is None else capacity
+        key = MoonEPBuffer.build_key(
+            group=self.group,
+            hidden_size=self.hidden_size,
+            router_topk=self.router_topk,
+            num_experts=self.num_experts,
+            num_max_dispatch_tokens_per_rank=resolved_capacity,
+            num_prefetch_slots=self.num_prefetch_slots,
+        )
+        return self._get_buffer(resolved_capacity), key
 
     def _get_rank(self) -> int:
         try:
@@ -559,9 +845,9 @@ class MoonEPDispatcher(BaseDispatcher):
         hidden_states: torch.Tensor,
         topk_ids: torch.Tensor,
         topk_weights: torch.Tensor,
+        capacity: int,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, int]:
         num_tokens = int(hidden_states.shape[0])
-        capacity = int(self.num_max_dispatch_tokens_per_rank)
         if num_tokens > capacity:
             raise ValueError(
                 "MoonEP runtime batch has more tokens than its static buffer "
@@ -587,34 +873,58 @@ class MoonEPDispatcher(BaseDispatcher):
         )
 
     def _tokens_per_expert(self, topk_ids: torch.Tensor) -> torch.Tensor:
+        """Local token count per expert.
+
+        ``torch.bincount`` would be the obvious call, but on CUDA it reads the
+        input's max back to the host to size its output, and a device-to-host
+        copy is illegal under CUDA graph capture. Scattering into a
+        fixed-length buffer keeps the whole thing on device.
+        """
         assert self.num_experts is not None
-        return torch.bincount(
-            topk_ids.reshape(-1).to(dtype=torch.int64),
-            minlength=self.num_experts,
-        ).to(dtype=torch.int32)
+        flat = topk_ids.reshape(-1).to(dtype=torch.int64)
+        counts = torch.zeros(
+            self.num_experts, dtype=torch.int32, device=topk_ids.device
+        )
+        counts.scatter_add_(0, flat, torch.ones_like(flat, dtype=torch.int32))
+        return counts
 
     def _expert_ids_from_plan(
         self,
         cu_seqlens: torch.Tensor,
         plan: Any,
     ) -> torch.Tensor:
+        """Which expert each VM group carries: its own id for the first
+        ``num_experts`` groups, the duplicated expert's id for the prefetch
+        slots after them, and -1 for groups that received no tokens.
+
+        Stays on device. The obvious loop costs one ``.item()`` per group --
+        896 host syncs per layer, ~82k per forward at K3's depth, which
+        dominates decode.
+        """
         assert self.num_experts is not None
+        num_experts = int(self.num_experts)
         num_groups = int(cu_seqlens.numel())
-        expert_ids = torch.full_like(cu_seqlens, -1)
         experts_to_copy = plan.experts_to_copy
         if experts_to_copy.ndim == 2:
             experts_to_copy = experts_to_copy[self._get_rank()]
 
-        prev = 0
-        for group_id in range(num_groups):
-            cur = int(cu_seqlens[group_id].item())
-            if cur > prev:
-                if group_id < self.num_experts:
-                    expert_ids[group_id] = group_id
-                else:
-                    expert_ids[group_id] = experts_to_copy[group_id - self.num_experts]
-            prev = cur
-        return expert_ids
+        num_slots = num_groups - num_experts
+        assert 0 <= num_slots <= int(experts_to_copy.numel()), (
+            f"MoonEP plan has {experts_to_copy.numel()} prefetch slots but "
+            f"cu_seqlens describes {num_slots}"
+        )
+        ids = torch.cat(
+            [
+                torch.arange(
+                    num_experts, device=cu_seqlens.device, dtype=cu_seqlens.dtype
+                ),
+                experts_to_copy[:num_slots].to(dtype=cu_seqlens.dtype),
+            ]
+        )
+        # cu_seqlens holds segment *ends*, so a group is live when its end
+        # moved past the previous one's.
+        starts = torch.cat([cu_seqlens.new_zeros(1), cu_seqlens[:-1]])
+        return torch.where(cu_seqlens > starts, ids, torch.full_like(ids, -1))
 
     def dispatch(
         self,
@@ -631,21 +941,48 @@ class MoonEPDispatcher(BaseDispatcher):
             )
         if self.num_experts is None:
             raise ValueError("MoonEPDispatcher requires num_experts.")
+        zero_copy = envs.SGLANG_MOONEP_ZERO_COPY.get()
+        if zero_copy:
+            if not self.zero_copy_supported:
+                raise RuntimeError(
+                    "SGLANG_MOONEP_ZERO_COPY requires the unquantized BF16 "
+                    "correctness path or an explicitly selected DeepGEMM runner."
+                )
+            if torch.is_grad_enabled():
+                raise RuntimeError(
+                    "SGLANG_MOONEP_ZERO_COPY requires inference/no-grad execution."
+                )
 
+        # One capacity for both the padding and the buffer: MoonEP asserts the
+        # dispatch input matches the buffer's static S exactly.
+        capacity = self._phase_capacity()
         hidden_states, topk_ids, topk_weights, num_tokens = self._pad_to_capacity(
             hidden_states,
             topk_output.topk_ids,
             topk_output.topk_weights,
+            capacity,
         )
         tokens_per_expert = self._tokens_per_expert(topk_ids)
-        buffer = self._get_buffer()
+        buffer, buffer_key = self._get_buffer_and_key(capacity)
+        MoonEPBuffer.assert_idle(buffer_key)
         hidden_nvsh, route_weights_nvs, cu_seqlens, plan = buffer.dispatch(
             hidden_states,
             topk_weights,
             topk_ids,
             tokens_per_expert,
             async_finish=False,
+            zero_copy=zero_copy,
+            router_weights_zero_copy=False,
         )
+        owner_id = id(self) if zero_copy else None
+        if zero_copy:
+            MoonEPBuffer.begin_zero_copy_flight(
+                key=buffer_key,
+                buffer=buffer,
+                plan=plan,
+                hidden_states=hidden_nvsh,
+                owner_id=owner_id,
+            )
         return MoonEPDispatchOutput(
             hidden_states=hidden_nvsh,
             route_weights_nvs=route_weights_nvs,
@@ -653,6 +990,9 @@ class MoonEPDispatcher(BaseDispatcher):
             plan=plan,
             expert_ids=self._expert_ids_from_plan(cu_seqlens, plan),
             num_tokens=num_tokens,
+            hidden_states_zero_copy=zero_copy,
+            buffer_key=buffer_key if zero_copy else None,
+            owner_id=owner_id,
         )
 
     def dispatch_a(
@@ -674,12 +1014,45 @@ class MoonEPDispatcher(BaseDispatcher):
                 f"MoonEPDispatcher.combine expected MOONEP input, got "
                 f"{combine_input.format}"
             )
-        hidden_states, _route_weights_sk, _event = self._get_buffer().combine(
+        zero_copy = combine_input.hidden_states_zero_copy
+        if zero_copy:
+            if combine_input.buffer_key is None or combine_input.owner_id is None:
+                raise RuntimeError(
+                    "MoonEP zero-copy combine is missing buffer ownership metadata."
+                )
+            buffer_key = combine_input.buffer_key
+            buffer = MoonEPBuffer.get_existing_buffer(buffer_key)
+            if buffer is None:
+                raise RuntimeError(
+                    "MoonEP zero-copy combine buffer was destroyed during its flight."
+                )
+            MoonEPBuffer.validate_zero_copy_flight(
+                key=buffer_key,
+                buffer=buffer,
+                plan=combine_input.plan,
+                hidden_states=combine_input.hidden_states,
+                owner_id=combine_input.owner_id,
+                expected_state="OUTPUT_WRITTEN",
+            )
+        else:
+            buffer, buffer_key = self._get_buffer_and_key()
+            MoonEPBuffer.assert_idle(buffer_key)
+
+        hidden_states, _route_weights_sk, _event = buffer.combine(
             plan=combine_input.plan,
             hidden_nvsh=combine_input.hidden_states,
             route_weights_nvs=None,
             async_finish=False,
+            zero_copy=zero_copy,
+            router_weights_zero_copy=False,
         )
+        if zero_copy:
+            MoonEPBuffer.complete_zero_copy_flight(
+                key=buffer_key,
+                plan=combine_input.plan,
+                hidden_states=combine_input.hidden_states,
+                owner_id=combine_input.owner_id,
+            )
         return hidden_states[: combine_input.num_tokens].contiguous()
 
     def combine_a(
@@ -694,14 +1067,42 @@ class MoonEPDispatcher(BaseDispatcher):
     def prefetch_weight(
         self,
         plan: Any,
-        weight_layout: MoonEPExpertWeightLayout,
+        weight_layout: MoonEPExpertWeightLayout | None = None,
+        layer_id: int | None = None,
     ) -> None:
+        """Fill this rank's prefetch slots with the duplicated experts.
+
+        ``weight_layout`` is the BF16 PoC form: one contiguous ``[E+B]`` block
+        per projection, indexed by global expert id. ``layer_id`` selects the
+        symmetric-memory form, where the sources are VMM ranges shared by every
+        layer and the plan's expert ids have to be remapped to rows before the
+        copy can find them.
+        """
+        assert (weight_layout is None) != (layer_id is None), (
+            "MoonEPDispatcher.prefetch_weight takes exactly one of "
+            "weight_layout or layer_id"
+        )
+        if weight_layout is not None:
+            self._get_buffer().prefetch_weight(
+                plan=plan,
+                async_finish=False,
+                full_gate_weight=weight_layout.full_gate_weight,
+                full_up_weight=weight_layout.full_up_weight,
+                full_down_weight=weight_layout.full_down_weight,
+            )
+            return
+
+        from sglang.srt.layers.moe.token_dispatcher import moonep_weights
+
+        weight_pairs, scale_pairs = moonep_weights.prefetch_pairs(layer_id)
         self._get_buffer().prefetch_weight(
             plan=plan,
             async_finish=False,
-            full_gate_weight=weight_layout.full_gate_weight,
-            full_up_weight=weight_layout.full_up_weight,
-            full_down_weight=weight_layout.full_down_weight,
+            weight_pairs=weight_pairs,
+            scale_pairs=scale_pairs or None,
+            experts_to_copy=moonep_weights.expert_rows(
+                layer_id, plan.experts_to_copy[self._get_rank()]
+            ),
         )
 
     def register_deepep_dispatch_hook(self, hook):

--- a/python/sglang/srt/layers/moe/token_dispatcher/moonep_weights.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/moonep_weights.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+import logging
+import math
+from typing import Optional
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+# Sub-ranges of the pool, keyed by the attribute they end up backing. The
+# scales are named apart from the parameters because what lives here is the
+# post-transform runtime layout, not the checkpoint layout the loader fills.
+W13_WEIGHT = "w13_weight"
+W2_WEIGHT = "w2_weight"
+W13_SCALE = "w13_weight_scale_runtime"
+W2_SCALE = "w2_weight_scale_runtime"
+
+_POOL_RESOURCE_KEY = "moonep_weight_pool"
+
+
+class MoonEPWeightPool:
+    """Process-global symmetric ranges, sliced one block per MoE layer."""
+
+    def __init__(
+        self,
+        num_layers: int,
+        num_local_experts: int,
+        num_prefetch_slots: int,
+        ep_rank: int,
+        ep_size: int,
+        group,
+        specs: dict[str, tuple[tuple[int, ...], torch.dtype]],
+    ):
+        from moonep.buffer import create_nvl_dist_tensor
+
+        self.num_layers = num_layers
+        self.num_local_experts = num_local_experts
+        self.num_prefetch_slots = num_prefetch_slots
+        self.ep_rank = ep_rank
+        self.ep_size = ep_size
+        self.group_id = id(group)
+        self.specs = dict(specs)
+        self.block_rows = num_local_experts + num_prefetch_slots
+        self.chunk_rows = _resolve_chunk_rows(specs, num_layers * self.block_rows)
+        self._layers: dict[int, int] = {}
+
+        self.ranges = {
+            kind: create_nvl_dist_tensor(
+                [self.chunk_rows, *trailing],
+                dtype,
+                ep_rank,
+                ep_size,
+                group=group,
+                # Rotated so this rank's chunk is at the base of the mapping.
+                # DeepGEMM's tvm_ffi bindings resolve a tensor's device from
+                # its base pointer, and the unrotated base is always rank 0's
+                # memory -- every other rank then fails the device check.
+                local_first=True,
+            )
+            for kind, (trailing, dtype) in specs.items()
+        }
+        resident = sum(t.numel() * t.element_size() for t in self.ranges.values())
+        logger.info(
+            "MoonEP: symmetric expert pool for %d layers, %d local experts + %d "
+            "prefetch slots each, chunk_rows=%d (%.1f GB resident per rank)",
+            num_layers,
+            num_local_experts,
+            num_prefetch_slots,
+            self.chunk_rows,
+            resident / ep_size / 1e9,
+        )
+
+    def layer_offset(self, layer_id: int) -> int:
+        """Rows before this layer's block. Layers are numbered by the order
+        they ask for storage, not by ``layer_id``: with pipeline parallelism a
+        rank holds an arbitrary slice of the model's layer ids, and the pool is
+        sized for what this rank actually builds."""
+        index = self._layers.get(layer_id)
+        if index is None:
+            index = len(self._layers)
+            if index >= self.num_layers:
+                raise RuntimeError(
+                    f"MoonEP expert pool was sized for {self.num_layers} layers "
+                    f"but layer {layer_id} is the {index + 1}th to ask for "
+                    "storage; the layer count derived from the model config is "
+                    "wrong for this model"
+                )
+            self._layers[layer_id] = index
+        return index * self.block_rows
+
+    def chunk_start(self, owner_rank: int) -> int:
+        """First row of ``owner_rank``'s chunk in this rank's mapping."""
+        from moonep.buffer import local_first_chunk_index
+
+        index = local_first_chunk_index(owner_rank, self.ep_rank, self.ep_size)
+        return index * self.chunk_rows
+
+    def local_view(self, kind: str, layer_id: int) -> torch.Tensor:
+        """This rank's ``[num_local_experts, ...]`` slice: what the loader
+        writes and what the parameter is bound to."""
+        start = self.chunk_start(self.ep_rank) + self.layer_offset(layer_id)
+        return self.ranges[kind][start : start + self.num_local_experts]
+
+    def slot_view(self, kind: str, layer_id: int) -> torch.Tensor:
+        """This layer's ``[num_prefetch_slots, ...]`` copy destinations."""
+        start = (
+            self.chunk_start(self.ep_rank)
+            + self.layer_offset(layer_id)
+            + self.num_local_experts
+        )
+        return self.ranges[kind][start : start + self.num_prefetch_slots]
+
+
+def _minimum_aligned_rows(trailing_shape, dtype: torch.dtype) -> int:
+    """Smallest row count whose bytes land on a VMM granularity boundary."""
+    from moonep.buffer import pad_dim0_for_alignment
+
+    return pad_dim0_for_alignment([1, *trailing_shape], dtype)
+
+
+def _resolve_chunk_rows(
+    specs: dict[str, tuple[tuple[int, ...], torch.dtype]], rows_in_use: int
+) -> int:
+    """One row count that is granularity-aligned for every range at once.
+
+    A weight and its scale must share a row indexing, so they cannot each pick
+    their own padding. A row count works for a tensor when
+    ``rows * bytes_per_row`` is a multiple of the VMM granularity, so the
+    common answer is the least common multiple of each one's minimum, rounded
+    up past the rows actually in use.
+    """
+    step = 1
+    for trailing, dtype in specs.values():
+        step = math.lcm(step, _minimum_aligned_rows(trailing, dtype))
+    return math.ceil(rows_in_use / step) * step
+
+
+def _num_moe_layers() -> int:
+    """How many layers will ask the pool for storage.
+
+    Counted from the config rather than tracked dynamically because the ranges
+    are fixed-size VMM mappings that cannot grow; ``layer_offset`` raises if
+    the count turns out to be too small.
+    """
+    from sglang.srt.distributed import get_pp_group, get_pp_indices
+    from sglang.srt.runtime_context import process_model_config
+
+    config = process_model_config()
+    num_layers = int(config.num_hidden_layers)
+    pp_group = get_pp_group()
+    start_layer, end_layer = get_pp_indices(
+        num_layers, pp_group.rank_in_group, pp_group.world_size
+    )
+    first_dense = config.first_k_dense_replace or 0
+    freq = getattr(config.hf_text_config, "moe_layer_freq", 1) or 1
+    return sum(
+        1
+        for i in range(start_layer, end_layer)
+        if i >= first_dense and i % freq == 0
+    )
+
+
+def get_pool() -> Optional[MoonEPWeightPool]:
+    from sglang.srt.runtime_context import get_resources
+
+    return get_resources().buffers.get(_POOL_RESOURCE_KEY)
+
+
+def alloc_expert_tensors(
+    layer: torch.nn.Module,
+    specs: dict[str, tuple[tuple[int, ...], torch.dtype]],
+) -> dict[str, torch.Tensor]:
+    """Per-layer views of the symmetric pool, creating it on the first call.
+
+    ``specs`` maps a sub-range name to ``(trailing_shape, dtype)`` for a single
+    expert row. Every layer must pass the same specs -- they share one
+    allocation. Collective over the EP group, so all ranks have to build their
+    layers in the same order.
+    """
+    from sglang.srt.distributed import get_tp_group
+    from sglang.srt.layers.moe.token_dispatcher.moonep import (
+        get_moonep_num_prefetch_slots,
+    )
+
+    group = get_tp_group().device_group
+    ep_size = torch.distributed.get_world_size(group)
+    ep_rank = torch.distributed.get_rank(group)
+    num_layers = _num_moe_layers()
+    num_local_experts = int(layer.num_local_experts)
+    num_prefetch_slots = get_moonep_num_prefetch_slots(
+        int(layer.num_experts), ep_size
+    )
+
+    pool = get_pool()
+    if pool is None:
+        from sglang.srt.runtime_context import get_resources
+
+        pool = MoonEPWeightPool(
+            num_layers=num_layers,
+            num_local_experts=int(layer.num_local_experts),
+            num_prefetch_slots=num_prefetch_slots,
+            ep_rank=ep_rank,
+            ep_size=ep_size,
+            group=group,
+            specs=specs,
+        )
+        get_resources().buffers[_POOL_RESOURCE_KEY] = pool
+    elif (
+        pool.num_layers != num_layers
+        or pool.num_local_experts != num_local_experts
+        or pool.num_prefetch_slots != num_prefetch_slots
+        or pool.ep_rank != ep_rank
+        or pool.ep_size != ep_size
+        or pool.group_id != id(group)
+        or pool.specs != specs
+    ):
+        raise RuntimeError(
+            "MoonEP expert-pool configuration changed during one runtime; "
+            "destroy and rebuild the runtime before changing layer shapes, "
+            "dtypes, or parallel topology."
+        )
+
+    return {kind: pool.local_view(kind, layer.layer_id) for kind in specs}
+
+
+def expert_rows(layer_id: int, expert_ids: torch.Tensor) -> torch.Tensor:
+    """Global expert ids -> rows of the symmetric range. Negative ids (unused
+    prefetch slots) pass through so DeepGEMM still skips them."""
+    pool = get_pool()
+    assert pool is not None, "MoonEP expert pool was never created"
+    epn = pool.num_local_experts
+    # The mapping is local-first, so an owner's chunk index is relative to this
+    # rank -- row numbers differ per rank, which is fine because every consumer
+    # of them (m_indices, experts_to_copy) is computed locally.
+    owner = expert_ids // epn
+    chunk = (owner - pool.ep_rank) % pool.ep_size
+    rows = chunk * pool.chunk_rows + pool.layer_offset(layer_id) + expert_ids % epn
+    return torch.where(expert_ids < 0, expert_ids, rows).to(torch.int32)
+
+
+def group_rows(
+    layer_id: int, expert_ids: torch.Tensor, num_global_experts: int
+) -> torch.Tensor:
+    """MoonEP's per-VM-group expert ids -> rows of the symmetric range.
+
+    The first ``num_global_experts`` groups are experts addressed by global id;
+    the groups after them are this rank's prefetch slots, whose ids name the
+    *source* expert but whose tokens must read the slot the copy landed in.
+    Empty and unfilled groups keep their -1 and stay skipped.
+    """
+    pool = get_pool()
+    assert pool is not None, "MoonEP expert pool was never created"
+    rows = expert_rows(layer_id, expert_ids)
+    tail = expert_ids[num_global_experts:]
+    slot_base = (
+        pool.chunk_start(pool.ep_rank)
+        + pool.layer_offset(layer_id)
+        + pool.num_local_experts
+    )
+    slots = torch.arange(
+        slot_base,
+        slot_base + tail.numel(),
+        device=expert_ids.device,
+        dtype=torch.int32,
+    )
+    rows[num_global_experts:] = torch.where(tail < 0, tail.to(torch.int32), slots)
+    return rows
+
+
+def prefetch_pairs(
+    layer_id: int,
+) -> tuple[
+    list[tuple[torch.Tensor, torch.Tensor]], list[tuple[torch.Tensor, torch.Tensor]]
+]:
+    """``(weight_pairs, scale_pairs)`` for ``Buffer.prefetch_weight``.
+
+    Scales are re-tiled by the copy and so are kept apart from the weights.
+    The scale views are the *storage* orientation, which is what a byte copy
+    has to move -- see the MN-major note in the module docstring.
+    """
+    pool = get_pool()
+    assert pool is not None, "MoonEP expert pool was never created"
+    weights = [
+        (pool.ranges[k], pool.slot_view(k, layer_id)) for k in (W13_WEIGHT, W2_WEIGHT)
+    ]
+    scales = [
+        (pool.ranges[k], pool.slot_view(k, layer_id))
+        for k in (W13_SCALE, W2_SCALE)
+        if k in pool.ranges
+    ]
+    return weights, scales
+
+
+def assert_resident(layer: torch.nn.Module, kind: str, tensor: torch.Tensor) -> None:
+    """Fail loudly if a post-load step swapped a pooled tensor for a private one.
+
+    SGLang's quant methods routinely rebind weights after loading, and a
+    rebind that lands outside the pool silently costs MoonEP its remote
+    readability -- prefetch would then copy from memory no peer can see.
+    """
+    pool = get_pool()
+    assert pool is not None, "MoonEP expert pool was never created"
+    full = pool.ranges[kind]
+    start = full.data_ptr()
+    end = start + full.numel() * full.element_size()
+    if not (start <= tensor.data_ptr() < end):
+        raise RuntimeError(
+            f"MoonEP: layer {layer.layer_id} {kind} left the symmetric pool "
+            "after loading. Some post-load step replaced the tensor instead of "
+            "writing into it, which would make remote prefetch read private "
+            "memory."
+        )

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -324,6 +324,52 @@ class Mxfp4Config(QuantizationConfig):
         return []
 
 
+def _maybe_alloc_moonep_expert_pool(
+    layer,
+    *,
+    intermediate_size: int,
+    hidden_size: int,
+    weight_dtype: torch.dtype,
+    mxfp4_block: int,
+) -> Optional[dict]:
+    """This layer's slice of MoonEP's symmetric expert pool, or None.
+
+    The scale entries describe DeepGEMM's *runtime* layout in storage order:
+    ``transform_sf_into_required_layout`` returns ``[E, MN, K/128]`` int32 with
+    stride ``(.., 1, MN)``, whose contiguous bytes are the transpose. Four
+    e8m0 exponents pack into one int32, so the byte count matches the
+    ``[E, MN, K/32]`` uint8 the checkpoint carries.
+    """
+    from sglang.srt.layers.moe.token_dispatcher import moonep_weights
+    from sglang.srt.layers.moe.utils import get_moe_a2a_backend
+
+    if not get_moe_a2a_backend().is_moonep():
+        return None
+
+    scale_pack = 4 * mxfp4_block  # e8m0 bytes per int32 x elements per byte
+    return moonep_weights.alloc_expert_tensors(
+        layer,
+        {
+            moonep_weights.W13_WEIGHT: (
+                (2 * intermediate_size, hidden_size // 2),
+                weight_dtype,
+            ),
+            moonep_weights.W2_WEIGHT: (
+                (hidden_size, intermediate_size // 2),
+                weight_dtype,
+            ),
+            moonep_weights.W13_SCALE: (
+                (hidden_size // scale_pack, 2 * intermediate_size),
+                torch.int32,
+            ),
+            moonep_weights.W2_SCALE: (
+                (intermediate_size // scale_pack, hidden_size),
+                torch.int32,
+            ),
+        },
+    )
+
+
 class Mxfp4MoEMethod(FusedMoEMethodBase):
 
     def __init__(
@@ -334,6 +380,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
 
         self.prefix = prefix
         self.topk_indices_dtype = None
+        self.moonep_pooled = None
         self.use_triton_kernels = get_moe_runner_backend().is_triton_kernels()
         self.with_bias = False
         self.use_flashinfer = get_moe_runner_backend().is_flashinfer_mxfp4()
@@ -464,13 +511,31 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         self.intermediate_size_per_partition = intermediate_size_per_partition_after_pad
 
         self.hidden_size = hidden_size
+
+        from sglang.srt.layers.moe.token_dispatcher import moonep_weights
+
+        # MoonEP needs every expert row readable by its peers, so the weights
+        # come from a symmetric VMM pool instead of a private allocation. The
+        # scales are pooled in their post-transform runtime layout, which
+        # process_weights_after_loading copies into rather than replacing.
+        self.moonep_pooled = _maybe_alloc_moonep_expert_pool(
+            layer,
+            intermediate_size=intermediate_size_per_partition_after_pad,
+            hidden_size=hidden_size,
+            weight_dtype=weight_dtype,
+            mxfp4_block=mxfp4_block,
+        )
+
         # Fused gate_up_proj (column parallel)
         w13_weight = torch.nn.Parameter(
-            torch.zeros(
-                layer.num_local_experts,
-                2 * intermediate_size_per_partition_after_pad,
-                hidden_size // 2,
-                dtype=weight_dtype,
+            self._expert_storage(
+                moonep_weights.W13_WEIGHT,
+                (
+                    layer.num_local_experts,
+                    2 * intermediate_size_per_partition_after_pad,
+                    hidden_size // 2,
+                ),
+                weight_dtype,
             ),
             requires_grad=False,
         )
@@ -508,11 +573,14 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
 
         # down_proj (row parallel)
         w2_weight = torch.nn.Parameter(
-            torch.zeros(
-                layer.num_local_experts,
-                hidden_size,
-                intermediate_size_per_partition_after_pad // 2,
-                dtype=weight_dtype,
+            self._expert_storage(
+                moonep_weights.W2_WEIGHT,
+                (
+                    layer.num_local_experts,
+                    hidden_size,
+                    intermediate_size_per_partition_after_pad // 2,
+                ),
+                weight_dtype,
             ),
             requires_grad=False,
         )
@@ -542,6 +610,21 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             )
             layer.register_parameter("w2_weight_bias", w2_weight_bias)
             set_weight_attrs(w2_weight_bias, extra_weight_attrs)
+
+    def _expert_storage(
+        self, kind: str, shape: tuple[int, ...], dtype: torch.dtype
+    ) -> torch.Tensor:
+        """Zeroed storage for an expert tensor, from MoonEP's symmetric pool
+        when that backend is active and a private allocation otherwise."""
+        if self.moonep_pooled is None:
+            return torch.zeros(*shape, dtype=dtype)
+
+        pooled = self.moonep_pooled[kind]
+        assert tuple(pooled.shape) == shape and pooled.dtype == dtype, (
+            f"MoonEP pool gave {kind} as {tuple(pooled.shape)}/{pooled.dtype}, "
+            f"expected {shape}/{dtype}"
+        )
+        return pooled.zero_()
 
     def process_weights_after_loading(self, layer):
         if self.use_marlin:
@@ -575,21 +658,32 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         if self.use_deep_gemm:
             from deep_gemm import transform_sf_into_required_layout
 
+            from sglang.srt.layers.moe.token_dispatcher import moonep_weights
+
             # Packed fp4 (e2m1 x2 per byte) weights: DeepGEMM expects int8.
+            # A re-view keeps the storage, which is what lets MoonEP's pooled
+            # weights survive this step.
             layer.w13_weight.data = layer.w13_weight.data.view(torch.int8)
             layer.w2_weight.data = layer.w2_weight.data.view(torch.int8)
+            if self.moonep_pooled is not None:
+                moonep_weights.assert_resident(
+                    layer, moonep_weights.W13_WEIGHT, layer.w13_weight.data
+                )
+                moonep_weights.assert_resident(
+                    layer, moonep_weights.W2_WEIGHT, layer.w2_weight.data
+                )
             # Checkpoint scales are uint8 e8m0 (biased exponents). DeepGEMM
             # SM100 needs them in packed-UE8M0 TMA-aligned MN-major layout.
             # Round-trip through fp32 is exact (values are powers of two).
-            for scale_name, weight in (
-                ("w13_weight_scale", layer.w13_weight),
-                ("w2_weight_scale", layer.w2_weight),
+            for scale_name, weight, pool_kind in (
+                ("w13_weight_scale", layer.w13_weight, moonep_weights.W13_SCALE),
+                ("w2_weight_scale", layer.w2_weight, moonep_weights.W2_SCALE),
             ):
                 scale = getattr(layer, scale_name)
                 num_experts, n, _ = scale.data.shape
                 k = weight.shape[2] * 2
                 scale_f32 = scale.data.view(torch.float8_e8m0fnu).to(torch.float32)
-                scale.data = transform_sf_into_required_layout(
+                transformed = transform_sf_into_required_layout(
                     scale_f32,
                     mn=n,
                     k=k,
@@ -597,7 +691,17 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                     num_groups=num_experts,
                     disable_ue8m0_cast=False,
                 )
-            if get_moe_a2a_backend().is_megamoe():
+                if self.moonep_pooled is None:
+                    scale.data = transformed
+                    continue
+                # The checkpoint-layout buffer the loader filled is private
+                # memory; the runtime layout has to end up in the pool instead,
+                # so copy rather than rebind. The pooled range is stored
+                # transposed, matching the MN-major result's real byte order.
+                pooled = self.moonep_pooled[pool_kind].permute(0, 2, 1)
+                scale.data = pooled.copy_(transformed)
+                moonep_weights.assert_resident(layer, pool_kind, scale.data)
+            if self.use_mega_moe:
                 # MegaMoE consumes the same transformed sf, plus its own
                 # interleaved/UTCCP weight layout. K3 routes EVERY batch
                 # through mega (the megamoe backend has no a2a fallback), so

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -6862,13 +6862,38 @@ class ServerArgs:
                 self.cuda_graph_config.prefill.backend = Backend.DISABLED
 
         if a2a_backend == "moonep":
-            logger.warning(
-                "MoonEP MoE is enabled in experimental BF16 PoC mode. "
-                "Cuda graph is disabled while the eager MoonEP dispatch/"
-                "prefetch/compute/combine path is validated."
-            )
-            self.cuda_graph_config.decode.backend = Backend.DISABLED
-            self.cuda_graph_config.prefill.backend = Backend.DISABLED
+            moonep_cuda_graph = envs.SGLANG_ENABLE_MOONEP_CUDA_GRAPH.get()
+            if self.enable_two_batch_overlap or self.enable_single_batch_overlap:
+                raise ValueError(
+                    "MoonEP does not support TBO or SBO; disable batch overlap."
+                )
+            if envs.SGLANG_MOONEP_ZERO_COPY.get():
+                if moonep_cuda_graph:
+                    raise ValueError(
+                        "SGLANG_MOONEP_ZERO_COPY supports eager execution only; "
+                        "unset SGLANG_ENABLE_MOONEP_CUDA_GRAPH."
+                    )
+                if self.forward_hooks:
+                    raise ValueError(
+                        "SGLANG_MOONEP_ZERO_COPY does not support forward hooks "
+                        "that may retain the leased MoonEP buffer view."
+                    )
+                if self.enable_lora or (
+                    self.enable_lora is None and self.lora_paths
+                ):
+                    raise ValueError(
+                        "SGLANG_MOONEP_ZERO_COPY does not support LoRA hooks "
+                        "that may retain the leased MoonEP buffer view."
+                    )
+            if not moonep_cuda_graph:
+                logger.warning(
+                    "Cuda graph is disabled while the eager MoonEP dispatch/"
+                    "prefetch/compute/combine path is validated. MoonEP's buffers "
+                    "are statically shaped, so capture should be possible; set "
+                    "SGLANG_ENABLE_MOONEP_CUDA_GRAPH=1 to try it."
+                )
+                self.cuda_graph_config.decode.backend = Backend.DISABLED
+                self.cuda_graph_config.prefill.backend = Backend.DISABLED
 
         if (
             self.moe_a2a_backend == "none" and is_npu()

--- a/test/registered/unit/layers/moe/test_moonep_buffer.py
+++ b/test/registered/unit/layers/moe/test_moonep_buffer.py
@@ -7,13 +7,25 @@ from unittest.mock import patch
 import torch
 
 from sglang.srt.environ import envs
+from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+from sglang.srt.layers.moe.moe_runner.deep_gemm import (
+    DeepGemmMoeQuantInfo,
+    DeepGemmRunnerCore,
+    DeepGemmRunnerOutput,
+    _resolve_down_output,
+    post_permute_deep_gemm_to_moonep,
+    pre_permute_moonep_to_deep_gemm,
+)
 from sglang.srt.layers.moe.token_dispatcher.moonep import (
     MoonEPBuffer,
+    MoonEPCombineInput,
+    MoonEPDispatcher,
     MoonEPDispatchOutput,
     MoonEPExpertWeightLayout,
     get_moonep_expert_weight_layout,
     run_moonep_bf16_expert,
 )
+from sglang.srt.layers.moe.topk import StandardTopKOutput
 from sglang.srt.runtime_context import reset_context
 from sglang.test.ci.ci_register import register_cpu_ci
 
@@ -26,10 +38,47 @@ class _FakeMoonEPBuffer:
     def __init__(self, **kwargs):
         self.kwargs = kwargs
         self.destroy_calls = 0
+        self.dispatch_calls = []
+        self.combine_calls = []
+        self.plan = SimpleNamespace(
+            experts_to_copy=torch.zeros(
+                kwargs["num_ep_ranks"], kwargs["B"], dtype=torch.int32
+            )
+        )
+        self.hidden_nvsh_buffer_view = torch.zeros(
+            kwargs["S"], kwargs["H"], dtype=torch.bfloat16
+        )
         self.__class__.instances.append(self)
 
     def destroy(self):
         self.destroy_calls += 1
+
+    def dispatch(
+        self,
+        hidden_states,
+        route_weights,
+        topk_ids,
+        tokens_per_expert,
+        **kwargs,
+    ):
+        self.dispatch_calls.append(kwargs)
+        self.hidden_nvsh_buffer_view.copy_(hidden_states)
+        hidden_nvsh = (
+            self.hidden_nvsh_buffer_view
+            if kwargs["zero_copy"]
+            else self.hidden_nvsh_buffer_view.clone()
+        )
+        route_weights_nvs = route_weights.reshape(-1).clone()
+        cu_seqlens = torch.arange(
+            1,
+            self.kwargs["E"] + self.kwargs["B"] + 1,
+            dtype=torch.int32,
+        ).clamp_max(hidden_nvsh.shape[0])
+        return hidden_nvsh, route_weights_nvs, cu_seqlens, self.plan
+
+    def combine(self, **kwargs):
+        self.combine_calls.append(kwargs)
+        return kwargs["hidden_nvsh"].clone(), None, None
 
 
 def _fake_moonep_module():
@@ -300,6 +349,462 @@ class TestMoonEPBf16ExpertRunner(unittest.TestCase):
         torch.testing.assert_close(combine_input.hidden_states, expected)
         self.assertIs(combine_input.plan, dispatch_output.plan)
         self.assertEqual(combine_input.num_tokens, 2)
+
+    def test_zero_copy_segment_runner_reuses_dispatch_view_and_zeros_padding(self):
+        hidden_states = torch.tensor(
+            [[1.0, 2.0], [3.0, 4.0], [99.0, 99.0]],
+            dtype=torch.float32,
+        )
+        original = hidden_states.clone()
+        layout = MoonEPExpertWeightLayout(
+            full_gate_weight=torch.eye(2).unsqueeze(0),
+            full_up_weight=(2 * torch.eye(2)).unsqueeze(0),
+            full_down_weight=torch.eye(2).unsqueeze(0),
+            num_prefetch_slots=0,
+        )
+        dispatch_output = MoonEPDispatchOutput(
+            hidden_states=hidden_states,
+            route_weights_nvs=torch.tensor([1.0, 0.5, 0.0]),
+            cu_seqlens=torch.tensor([2], dtype=torch.int32),
+            plan=object(),
+            expert_ids=torch.tensor([0], dtype=torch.int32),
+            num_tokens=2,
+            hidden_states_zero_copy=True,
+            buffer_key=object(),
+            owner_id=7,
+        )
+
+        with (
+            patch.object(MoonEPBuffer, "begin_zero_copy_output_write") as begin_write,
+            patch.object(
+                MoonEPBuffer, "mark_zero_copy_output_written"
+            ) as mark_output_written,
+        ):
+            combine_input = run_moonep_bf16_expert(
+                dispatch_output, layout, zero_copy=True
+            )
+
+        expected = torch.nn.functional.silu(original[:2]) * (2 * original[:2])
+        expected[1].mul_(0.5)
+        self.assertEqual(
+            combine_input.hidden_states.data_ptr(), dispatch_output.hidden_states.data_ptr()
+        )
+        torch.testing.assert_close(combine_input.hidden_states[:2], expected)
+        self.assertTrue(torch.count_nonzero(combine_input.hidden_states[2:]) == 0)
+        self.assertTrue(combine_input.hidden_states_zero_copy)
+        begin_write.assert_called_once()
+        mark_output_written.assert_called_once()
+
+    def test_bf16_runner_rejects_zero_copy_mode_mismatch(self):
+        hidden_states = torch.ones(1, 2)
+        dispatch_output = MoonEPDispatchOutput(
+            hidden_states=hidden_states,
+            route_weights_nvs=None,
+            cu_seqlens=torch.tensor([1], dtype=torch.int32),
+            plan=object(),
+            expert_ids=torch.tensor([0], dtype=torch.int32),
+            num_tokens=1,
+            hidden_states_zero_copy=True,
+            buffer_key=object(),
+            owner_id=7,
+        )
+        layout = MoonEPExpertWeightLayout(
+            full_gate_weight=torch.eye(2).unsqueeze(0),
+            full_up_weight=torch.eye(2).unsqueeze(0),
+            full_down_weight=torch.eye(2).unsqueeze(0),
+            num_prefetch_slots=0,
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "mode must match"):
+            run_moonep_bf16_expert(dispatch_output, layout, zero_copy=False)
+
+
+class TestMoonEPZeroCopyDispatcher(unittest.TestCase):
+    def setUp(self):
+        reset_context()
+        _FakeMoonEPBuffer.instances.clear()
+
+    def tearDown(self):
+        try:
+            MoonEPBuffer.destroy_all_buffers()
+        finally:
+            reset_context()
+            _FakeMoonEPBuffer.instances.clear()
+
+    def _dispatch(self, *, zero_copy: bool, zero_copy_supported: bool = True):
+        group = SimpleNamespace(size=lambda: 1)
+        with envs.SGLANG_MOONEP_DECODE_MAX_DISPATCH_TOKENS_PER_RANK.override(2):
+            dispatcher = MoonEPDispatcher(
+                group=group,
+                router_topk=1,
+                num_experts=1,
+                num_local_experts=1,
+                hidden_size=2,
+                zero_copy_supported=zero_copy_supported,
+            )
+        topk_output = StandardTopKOutput(
+            topk_weights=torch.ones(2, 1),
+            topk_ids=torch.zeros(2, 1, dtype=torch.int64),
+            router_logits=torch.empty(2, 1),
+        )
+        contexts = (
+            envs.SGLANG_MOONEP_ZERO_COPY.override(zero_copy),
+            envs.SGLANG_MOONEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK.override(2),
+            envs.SGLANG_MOONEP_NUM_PREFETCH_SLOTS.override(1),
+            envs.SGLANG_MOONEP_TOKEN_PADDING.override(1),
+            patch.dict(sys.modules, {"moonep": _fake_moonep_module()}),
+        )
+        return dispatcher, topk_output, contexts
+
+    def test_feature_gate_preserves_copied_dispatch_and_combine(self):
+        dispatcher, topk_output, contexts = self._dispatch(zero_copy=False)
+        with contexts[0], contexts[1], contexts[2], contexts[3], contexts[4]:
+            output = dispatcher.dispatch(
+                torch.ones(2, 2, dtype=torch.bfloat16), topk_output
+            )
+            combine_input = MoonEPCombineInput(
+                hidden_states=output.hidden_states,
+                route_weights_nvs=output.route_weights_nvs,
+                plan=output.plan,
+                num_tokens=output.num_tokens,
+            )
+            dispatcher.combine(combine_input)
+
+        buffer = _FakeMoonEPBuffer.instances[0]
+        self.assertFalse(output.hidden_states_zero_copy)
+        self.assertEqual(
+            buffer.dispatch_calls[-1],
+            {
+                "async_finish": False,
+                "zero_copy": False,
+                "router_weights_zero_copy": False,
+            },
+        )
+        self.assertFalse(buffer.combine_calls[-1]["zero_copy"])
+        self.assertFalse(buffer.combine_calls[-1]["router_weights_zero_copy"])
+
+    def test_zero_copy_rejects_unsupported_runner_before_dispatch(self):
+        dispatcher, topk_output, contexts = self._dispatch(
+            zero_copy=True, zero_copy_supported=False
+        )
+        with (
+            contexts[0],
+            contexts[1],
+            contexts[2],
+            contexts[3],
+            contexts[4],
+            torch.no_grad(),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "explicitly selected DeepGEMM"):
+                dispatcher.dispatch(
+                    torch.ones(2, 2, dtype=torch.bfloat16), topk_output
+                )
+        self.assertEqual(_FakeMoonEPBuffer.instances, [])
+
+    def test_combine_rejects_flight_before_output_is_written(self):
+        dispatcher, topk_output, contexts = self._dispatch(zero_copy=True)
+        with (
+            contexts[0],
+            contexts[1],
+            contexts[2],
+            contexts[3],
+            contexts[4],
+            torch.no_grad(),
+        ):
+            output = dispatcher.dispatch(
+                torch.ones(2, 2, dtype=torch.bfloat16), topk_output
+            )
+            combine_input = MoonEPCombineInput(
+                hidden_states=output.hidden_states,
+                route_weights_nvs=output.route_weights_nvs,
+                plan=output.plan,
+                num_tokens=output.num_tokens,
+                hidden_states_zero_copy=True,
+                buffer_key=output.buffer_key,
+                owner_id=output.owner_id,
+            )
+            with self.assertRaisesRegex(RuntimeError, "state mismatch"):
+                dispatcher.combine(combine_input)
+
+    def test_zero_copy_flight_preserves_pointer_and_rejects_overlap(self):
+        dispatcher, topk_output, contexts = self._dispatch(zero_copy=True)
+        with (
+            contexts[0],
+            contexts[1],
+            contexts[2],
+            contexts[3],
+            contexts[4],
+            torch.no_grad(),
+        ):
+            output = dispatcher.dispatch(
+                torch.ones(2, 2, dtype=torch.bfloat16), topk_output
+            )
+            with self.assertRaisesRegex(RuntimeError, "already owns"):
+                dispatcher.dispatch(
+                    torch.ones(2, 2, dtype=torch.bfloat16), topk_output
+                )
+
+            combine_input = MoonEPCombineInput(
+                hidden_states=output.hidden_states,
+                route_weights_nvs=output.route_weights_nvs,
+                plan=output.plan,
+                num_tokens=output.num_tokens,
+                hidden_states_zero_copy=True,
+                buffer_key=output.buffer_key,
+                owner_id=output.owner_id,
+            )
+            MoonEPBuffer.begin_zero_copy_output_write(
+                key=output.buffer_key,
+                plan=output.plan,
+                hidden_states=output.hidden_states,
+                owner_id=output.owner_id,
+            )
+            MoonEPBuffer.mark_zero_copy_output_written(
+                key=output.buffer_key,
+                plan=output.plan,
+                hidden_states=output.hidden_states,
+                owner_id=output.owner_id,
+            )
+            dispatcher.combine(combine_input)
+            dispatcher.dispatch(torch.ones(2, 2, dtype=torch.bfloat16), topk_output)
+
+        buffer = _FakeMoonEPBuffer.instances[0]
+        self.assertEqual(
+            output.hidden_states.data_ptr(), buffer.hidden_nvsh_buffer_view.data_ptr()
+        )
+        self.assertTrue(output.hidden_states_zero_copy)
+        self.assertTrue(buffer.dispatch_calls[0]["zero_copy"])
+        self.assertFalse(buffer.dispatch_calls[0]["router_weights_zero_copy"])
+        self.assertTrue(buffer.combine_calls[0]["zero_copy"])
+        self.assertFalse(buffer.combine_calls[0]["router_weights_zero_copy"])
+
+    def test_pointer_replacement_poisons_zero_copy_flight(self):
+        dispatcher, topk_output, contexts = self._dispatch(zero_copy=True)
+        with (
+            contexts[0],
+            contexts[1],
+            contexts[2],
+            contexts[3],
+            contexts[4],
+            torch.no_grad(),
+        ):
+            output = dispatcher.dispatch(
+                torch.ones(2, 2, dtype=torch.bfloat16), topk_output
+            )
+            combine_input = MoonEPCombineInput(
+                hidden_states=output.hidden_states.clone(),
+                route_weights_nvs=output.route_weights_nvs,
+                plan=output.plan,
+                num_tokens=output.num_tokens,
+                hidden_states_zero_copy=True,
+                buffer_key=output.buffer_key,
+                owner_id=output.owner_id,
+            )
+            MoonEPBuffer.begin_zero_copy_output_write(
+                key=output.buffer_key,
+                plan=output.plan,
+                hidden_states=output.hidden_states,
+                owner_id=output.owner_id,
+            )
+            MoonEPBuffer.mark_zero_copy_output_written(
+                key=output.buffer_key,
+                plan=output.plan,
+                hidden_states=output.hidden_states,
+                owner_id=output.owner_id,
+            )
+            with self.assertRaisesRegex(RuntimeError, "pointer"):
+                dispatcher.combine(combine_input)
+            with self.assertRaisesRegex(RuntimeError, "already owns"):
+                dispatcher.dispatch(
+                    torch.ones(2, 2, dtype=torch.bfloat16), topk_output
+                )
+
+    def test_plan_mismatch_poisons_zero_copy_flight(self):
+        dispatcher, topk_output, contexts = self._dispatch(zero_copy=True)
+        with (
+            contexts[0],
+            contexts[1],
+            contexts[2],
+            contexts[3],
+            contexts[4],
+            torch.no_grad(),
+        ):
+            output = dispatcher.dispatch(
+                torch.ones(2, 2, dtype=torch.bfloat16), topk_output
+            )
+            MoonEPBuffer.begin_zero_copy_output_write(
+                key=output.buffer_key,
+                plan=output.plan,
+                hidden_states=output.hidden_states,
+                owner_id=output.owner_id,
+            )
+            MoonEPBuffer.mark_zero_copy_output_written(
+                key=output.buffer_key,
+                plan=output.plan,
+                hidden_states=output.hidden_states,
+                owner_id=output.owner_id,
+            )
+            combine_input = MoonEPCombineInput(
+                hidden_states=output.hidden_states,
+                route_weights_nvs=output.route_weights_nvs,
+                plan=object(),
+                num_tokens=output.num_tokens,
+                hidden_states_zero_copy=True,
+                buffer_key=output.buffer_key,
+                owner_id=output.owner_id,
+            )
+            with self.assertRaisesRegex(RuntimeError, "plan mismatch"):
+                dispatcher.combine(combine_input)
+            with self.assertRaisesRegex(RuntimeError, "already owns"):
+                dispatcher.dispatch(
+                    torch.ones(2, 2, dtype=torch.bfloat16), topk_output
+                )
+
+
+class TestMoonEPDeepGemmZeroCopy(unittest.TestCase):
+    def _dispatch_output(self, hidden_states):
+        return MoonEPDispatchOutput(
+            hidden_states=hidden_states,
+            route_weights_nvs=torch.tensor([1.0, 0.5, 0.0]),
+            cu_seqlens=torch.tensor([2], dtype=torch.int32),
+            plan=object(),
+            expert_ids=torch.tensor([0], dtype=torch.int32),
+            num_tokens=2,
+            hidden_states_zero_copy=True,
+            buffer_key=object(),
+            owner_id=7,
+        )
+
+    def test_adapters_reserve_and_preserve_moonep_output_buffer(self):
+        hidden_states = torch.ones(3, 2, dtype=torch.bfloat16)
+        dispatch_output = self._dispatch_output(hidden_states)
+        quant_info = SimpleNamespace(
+            w13_weight=torch.empty(1, 4, 2, dtype=torch.bfloat16)
+        )
+        running_state = {}
+
+        with (
+            patch.object(MoonEPBuffer, "begin_zero_copy_output_write") as begin_write,
+            patch.object(
+                MoonEPBuffer, "mark_zero_copy_output_written"
+            ) as mark_output_written,
+        ):
+            runner_input = pre_permute_moonep_to_deep_gemm(
+                dispatch_output,
+                quant_info,
+                SimpleNamespace(),
+                running_state,
+            )
+            combine_input = post_permute_deep_gemm_to_moonep(
+                DeepGemmRunnerOutput(hidden_states=hidden_states),
+                quant_info,
+                SimpleNamespace(),
+                running_state,
+            )
+
+        self.assertIs(runner_input.output_buffer, hidden_states)
+        self.assertEqual(combine_input.hidden_states.data_ptr(), hidden_states.data_ptr())
+        self.assertTrue(combine_input.hidden_states_zero_copy)
+        begin_write.assert_called_once()
+        mark_output_written.assert_called_once()
+
+    def test_post_adapter_rejects_replaced_output_buffer(self):
+        hidden_states = torch.ones(3, 2, dtype=torch.bfloat16)
+        running_state = {}
+        dispatch_output = self._dispatch_output(hidden_states)
+        quant_info = SimpleNamespace(
+            w13_weight=torch.empty(1, 4, 2, dtype=torch.bfloat16)
+        )
+        with patch.object(MoonEPBuffer, "begin_zero_copy_output_write"):
+            pre_permute_moonep_to_deep_gemm(
+                dispatch_output,
+                quant_info,
+                SimpleNamespace(),
+                running_state,
+            )
+
+        with self.assertRaisesRegex(RuntimeError, "pointer"):
+            post_permute_deep_gemm_to_moonep(
+                DeepGemmRunnerOutput(hidden_states=hidden_states.clone()),
+                quant_info,
+                SimpleNamespace(),
+                running_state,
+            )
+
+    def test_bf16_runner_writes_down_projection_into_provided_buffer(self):
+        hidden_states = torch.ones(2, 2, dtype=torch.bfloat16)
+        runner_config = MoeRunnerConfig(
+            num_experts=1,
+            num_local_experts=1,
+            hidden_size=2,
+            intermediate_size_per_partition=2,
+            top_k=1,
+        )
+        quant_info = DeepGemmMoeQuantInfo(
+            w13_weight=torch.ones(1, 4, 2, dtype=torch.bfloat16),
+            w2_weight=torch.ones(1, 2, 2, dtype=torch.bfloat16),
+            use_fp8=False,
+        )
+        running_state = {
+            "all_tokens": 2,
+            "hidden_states_device": hidden_states.device,
+            "hidden_states_shape": hidden_states.shape,
+        }
+        dispatch_output = self._dispatch_output(hidden_states)
+        with patch.object(MoonEPBuffer, "begin_zero_copy_output_write"):
+            runner_input = pre_permute_moonep_to_deep_gemm(
+                dispatch_output, quant_info, runner_config, running_state
+            )
+
+        def fake_gemm(lhs, rhs, output, m_indices):
+            output.fill_(2)
+
+        def fake_activation(gateup, down_input):
+            down_input.fill_(3)
+
+        with (
+            patch(
+                "sglang.srt.layers.moe.moe_runner.deep_gemm.deep_gemm_wrapper."
+                "grouped_gemm_nt_bf16_contig",
+                side_effect=fake_gemm,
+            ),
+            patch(
+                "sglang.srt.layers.moe.moe_runner.deep_gemm._legacy_silu_and_mul",
+                side_effect=fake_activation,
+            ),
+            patch(
+                "sglang.srt.layers.moe.moe_runner.deep_gemm.dispose_tensor"
+            ) as dispose,
+        ):
+            output = DeepGemmRunnerCore(runner_config).run(
+                runner_input, quant_info, running_state
+            )
+
+        self.assertEqual(output.hidden_states.data_ptr(), hidden_states.data_ptr())
+        self.assertTrue(
+            all(call.args[0] is not hidden_states for call in dispose.call_args_list)
+        )
+
+    def test_output_buffer_validation_rejects_wrong_tensor_contract(self):
+        expected_shape = (2, 2)
+        good = torch.empty(expected_shape, dtype=torch.bfloat16)
+        self.assertIs(
+            _resolve_down_output(expected_shape, good.dtype, good.device, good), good
+        )
+
+        invalid_buffers = (
+            torch.empty(3, 2, dtype=torch.bfloat16),
+            torch.empty(expected_shape, dtype=torch.float32),
+            torch.empty(2, 4, dtype=torch.bfloat16)[:, ::2],
+        )
+        for invalid in invalid_buffers:
+            with self.subTest(shape=invalid.shape, dtype=invalid.dtype):
+                with self.assertRaisesRegex(
+                    ValueError, "shape|dtype|contiguous"
+                ):
+                    _resolve_down_output(
+                        expected_shape, torch.bfloat16, torch.device("cpu"), invalid
+                    )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1506,6 +1506,7 @@ class TestMoonEPArgs(CustomTestCase):
             model_path="dummy",
             moe_a2a_backend="moonep",
         )
+        server_args.cuda_graph_config = CudaGraphConfig()
 
         server_args._handle_a2a_moe()
 
@@ -1516,6 +1517,47 @@ class TestMoonEPArgs(CustomTestCase):
         self.assertEqual(server_args.cuda_graph_config.decode.backend, Backend.DISABLED)
         self.assertEqual(server_args.cuda_graph_config.prefill.backend, Backend.DISABLED)
 
+    def test_moonep_zero_copy_rejects_cuda_graph(self):
+        with (
+            envs.SGLANG_MOONEP_ZERO_COPY.override(True),
+            envs.SGLANG_ENABLE_MOONEP_CUDA_GRAPH.override(True),
+        ):
+            server_args = ServerArgs(
+                model_path="dummy",
+                moe_a2a_backend="moonep",
+            )
+            with self.assertRaisesRegex(ValueError, "eager execution only"):
+                server_args._handle_a2a_moe()
+
+    def test_moonep_zero_copy_rejects_batch_overlap(self):
+        with envs.SGLANG_MOONEP_ZERO_COPY.override(True):
+            server_args = ServerArgs(
+                model_path="dummy",
+                moe_a2a_backend="moonep",
+                enable_two_batch_overlap=True,
+            )
+            with self.assertRaisesRegex(ValueError, "TBO or SBO"):
+                server_args._handle_a2a_moe()
+
+    def test_moonep_zero_copy_rejects_lora_hooks(self):
+        with envs.SGLANG_MOONEP_ZERO_COPY.override(True):
+            server_args = ServerArgs(
+                model_path="dummy",
+                moe_a2a_backend="moonep",
+                enable_lora=True,
+            )
+            with self.assertRaisesRegex(ValueError, "LoRA hooks"):
+                server_args._handle_a2a_moe()
+
+    def test_moonep_zero_copy_rejects_implicit_lora_hooks(self):
+        with envs.SGLANG_MOONEP_ZERO_COPY.override(True):
+            server_args = ServerArgs(
+                model_path="dummy",
+                moe_a2a_backend="moonep",
+                lora_paths=["adapter"],
+            )
+            with self.assertRaisesRegex(ValueError, "LoRA hooks"):
+                server_args._handle_a2a_moe()
 
 class TestPrefillOnlyDisableKvCache(unittest.TestCase):
     """Validation for --prefill-only-disable-kv-cache.


### PR DESCRIPTION
## Summary
- reuse MoonEP's leased `[NvS, H]` hidden buffer from dispatch through BF16 or contiguous DeepGEMM expert compute and zero-copy combine
- enforce pointer-safe single-flight ownership, reject unsupported overlap/lifetime combinations, and retain the copied fallback
- support the Kimi-K3 MXFP4 path with MoonEP symmetric expert storage while keeping router weights copied

## Related work
- Built on [#33249](https://github.com/sgl-project/sglang/pull/33249), the MoonEP BF16 integration and this PR's base branch.
- Cross-linked with [#34874](https://github.com/sgl-project/sglang/pull/34874), whose MoonEP + MXFP4/DeepGEMM integration is included here so the zero-copy path can cover Kimi-K3.
- The generalized MoonEP prefetch API comes from [MoonshotAI/MoonEP#32](https://github.com/MoonshotAI/MoonEP/pull/32).

## Test plan
- [x] Focused MoonEP CPU regression suite: 98 tests passed, 38 subtests passed
- [x] Python compilation, diff whitespace checks, and IDE lint diagnostics
- [ ] 8-GPU NVSwitch BF16 and Kimi-K3 MXFP4 parity/stress runs
- [ ] Nsight verification that hidden-state dispatch/combine boundary copies disappear

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32540483890](https://github.com/sgl-project/sglang/actions/runs/32540483890)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32540483741](https://github.com/sgl-project/sglang/actions/runs/32540483741)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32540483827](https://github.com/sgl-project/sglang/actions/runs/32540483827)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->