### PR TITLE
[MoonEP] Add single-flight async event chaining

### DIFF
--- a/python/sglang/srt/layers/moe/token_dispatcher/moonep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/moonep.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import Enum, auto
 from typing import Any, NamedTuple, NoReturn, Optional
 
 import torch
@@ -15,10 +16,8 @@ from sglang.srt.layers.moe.token_dispatcher.base import (
     DispatchOutput,
     DispatchOutputFormat,
 )
-from sglang.srt.layers.moe.topk import TopKOutput
-from sglang.srt.layers.moe.topk import TopKOutputChecker
+from sglang.srt.layers.moe.topk import TopKOutput, TopKOutputChecker
 from sglang.srt.layers.moe.utils import DeepEPMode
-
 
 _MOONEP_UNSUPPORTED_MESSAGE = (
     "MoonEP MoE A2A is recognized by SGLang, but the runtime dispatcher is not "
@@ -97,6 +96,30 @@ class MoonEPBufferKey:
     num_sms: int
 
 
+class _MoonEPFlightStage(Enum):
+    IDLE = auto()
+    DISPATCHED = auto()
+    PREFETCHED = auto()
+    POISONED = auto()
+
+
+@dataclass
+class _MoonEPFlightState:
+    stage: _MoonEPFlightStage = _MoonEPFlightStage.IDLE
+    plan: Any = None
+    poisoned_by: str | None = None
+
+    def transition(self, stage: _MoonEPFlightStage, plan: Any = None) -> None:
+        self.stage = stage
+        self.plan = plan
+        self.poisoned_by = None
+
+    def poison(self, operation: str) -> None:
+        self.stage = _MoonEPFlightStage.POISONED
+        self.plan = None
+        self.poisoned_by = operation
+
+
 class MoonEPBuffer:
     """Process-wide facade for MoonEP communication buffers.
 
@@ -117,6 +140,7 @@ class MoonEPBuffer:
         if state is None:
             state = SimpleNamespace(
                 buffers={},
+                flight_states={},
                 active_key=None,
             )
             buffers["moonep_ep_state"] = state
@@ -226,6 +250,20 @@ class MoonEPBuffer:
         return state.buffers.get(key)
 
     @classmethod
+    def get_flight_state(cls, buffer) -> _MoonEPFlightState:
+        state = cls._state()
+        for key, cached_buffer in state.buffers.items():
+            if cached_buffer is buffer:
+                flight_state = state.flight_states.get(key)
+                if flight_state is None:
+                    flight_state = _MoonEPFlightState()
+                    state.flight_states[key] = flight_state
+                return flight_state
+        raise RuntimeError(
+            "MoonEP buffer is not registered with the process-wide facade."
+        )
+
+    @classmethod
     def get_moonep_buffer(
         cls,
         group: dist.ProcessGroup,
@@ -286,6 +324,7 @@ class MoonEPBuffer:
             return
 
         buffer = state.buffers.pop(key, None)
+        state.flight_states.pop(key, None)
         destroy = getattr(buffer, "destroy", None)
         if callable(destroy):
             destroy()
@@ -451,9 +490,7 @@ def run_moonep_bf16_expert(
             f"shape {cu_seqlens.shape}"
         )
     if route_weights_nvs is not None and route_weights_nvs.ndim != 1:
-        raise ValueError(
-            f"route_weights_nvs must be 1D, got {route_weights_nvs.shape}"
-        )
+        raise ValueError(f"route_weights_nvs must be 1D, got {route_weights_nvs.shape}")
 
     output = torch.empty_like(hidden_states)
     prev = 0
@@ -554,6 +591,36 @@ class MoonEPDispatcher(BaseDispatcher):
         except (AssertionError, RuntimeError, TypeError, ValueError):
             return 0
 
+    @staticmethod
+    def _require_flight_stage(
+        flight_state: _MoonEPFlightState,
+        required_stage: _MoonEPFlightStage,
+        operation: str,
+    ) -> None:
+        if flight_state.stage is _MoonEPFlightStage.POISONED:
+            raise RuntimeError(
+                "MoonEP buffer is poisoned after "
+                f"{flight_state.poisoned_by or 'an unknown operation'} failed; "
+                "tear down the buffer before reuse."
+            )
+        if flight_state.stage is not required_stage:
+            raise RuntimeError(
+                f"MoonEP {operation} requires {required_stage.name}, "
+                f"but the shared buffer is {flight_state.stage.name}."
+            )
+
+    @staticmethod
+    def _require_same_plan(
+        flight_state: _MoonEPFlightState,
+        plan: Any,
+        operation: str,
+    ) -> None:
+        if flight_state.plan is not plan:
+            raise RuntimeError(
+                f"MoonEP {operation} requires the same MoonEP plan returned by "
+                "the active dispatch."
+            )
+
     def _pad_to_capacity(
         self,
         hidden_states: torch.Tensor,
@@ -639,19 +706,44 @@ class MoonEPDispatcher(BaseDispatcher):
         )
         tokens_per_expert = self._tokens_per_expert(topk_ids)
         buffer = self._get_buffer()
-        hidden_nvsh, route_weights_nvs, cu_seqlens, plan = buffer.dispatch(
-            hidden_states,
-            topk_weights,
-            topk_ids,
-            tokens_per_expert,
-            async_finish=False,
+        flight_state = MoonEPBuffer.get_flight_state(buffer)
+        self._require_flight_stage(
+            flight_state,
+            _MoonEPFlightStage.IDLE,
+            "dispatch",
         )
+        try:
+            dispatch_result = buffer.dispatch(
+                hidden_states,
+                topk_weights,
+                topk_ids,
+                tokens_per_expert,
+                async_finish=self.async_finish,
+                zero_copy=False,
+            )
+            if self.async_finish:
+                (
+                    hidden_nvsh,
+                    route_weights_nvs,
+                    cu_seqlens,
+                    plan,
+                    dispatch_event,
+                ) = dispatch_result
+                dispatch_event.wait(torch.cuda.current_stream())
+            else:
+                hidden_nvsh, route_weights_nvs, cu_seqlens, plan = dispatch_result
+            expert_ids = self._expert_ids_from_plan(cu_seqlens, plan)
+        except Exception:
+            flight_state.poison("dispatch")
+            raise
+
+        flight_state.transition(_MoonEPFlightStage.DISPATCHED, plan)
         return MoonEPDispatchOutput(
             hidden_states=hidden_nvsh,
             route_weights_nvs=route_weights_nvs,
             cu_seqlens=cu_seqlens,
             plan=plan,
-            expert_ids=self._expert_ids_from_plan(cu_seqlens, plan),
+            expert_ids=expert_ids,
             num_tokens=num_tokens,
         )
 
@@ -674,12 +766,29 @@ class MoonEPDispatcher(BaseDispatcher):
                 f"MoonEPDispatcher.combine expected MOONEP input, got "
                 f"{combine_input.format}"
             )
-        hidden_states, _route_weights_sk, _event = self._get_buffer().combine(
-            plan=combine_input.plan,
-            hidden_nvsh=combine_input.hidden_states,
-            route_weights_nvs=None,
-            async_finish=False,
+        buffer = self._get_buffer()
+        flight_state = MoonEPBuffer.get_flight_state(buffer)
+        self._require_flight_stage(
+            flight_state,
+            _MoonEPFlightStage.PREFETCHED,
+            "combine",
         )
+        self._require_same_plan(flight_state, combine_input.plan, "combine")
+        try:
+            hidden_states, _route_weights_sk, combine_event = buffer.combine(
+                plan=combine_input.plan,
+                hidden_nvsh=combine_input.hidden_states,
+                route_weights_nvs=None,
+                async_finish=self.async_finish,
+                zero_copy=False,
+            )
+            if self.async_finish:
+                combine_event.wait(torch.cuda.current_stream())
+        except Exception:
+            flight_state.poison("combine")
+            raise
+
+        flight_state.transition(_MoonEPFlightStage.IDLE)
         return hidden_states[: combine_input.num_tokens].contiguous()
 
     def combine_a(
@@ -696,13 +805,29 @@ class MoonEPDispatcher(BaseDispatcher):
         plan: Any,
         weight_layout: MoonEPExpertWeightLayout,
     ) -> None:
-        self._get_buffer().prefetch_weight(
-            plan=plan,
-            async_finish=False,
-            full_gate_weight=weight_layout.full_gate_weight,
-            full_up_weight=weight_layout.full_up_weight,
-            full_down_weight=weight_layout.full_down_weight,
+        buffer = self._get_buffer()
+        flight_state = MoonEPBuffer.get_flight_state(buffer)
+        self._require_flight_stage(
+            flight_state,
+            _MoonEPFlightStage.DISPATCHED,
+            "prefetch_weight",
         )
+        self._require_same_plan(flight_state, plan, "prefetch_weight")
+        try:
+            prefetch_event = buffer.prefetch_weight(
+                plan=plan,
+                async_finish=self.async_finish,
+                full_gate_weight=weight_layout.full_gate_weight,
+                full_up_weight=weight_layout.full_up_weight,
+                full_down_weight=weight_layout.full_down_weight,
+            )
+            if self.async_finish:
+                prefetch_event.wait(torch.cuda.current_stream())
+        except Exception:
+            flight_state.poison("prefetch_weight")
+            raise
+
+        flight_state.transition(_MoonEPFlightStage.PREFETCHED, plan)
 
     def register_deepep_dispatch_hook(self, hook):
         self._raise_unimplemented()

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -6862,6 +6862,25 @@ class ServerArgs:
                 self.cuda_graph_config.prefill.backend = Backend.DISABLED
 
         if a2a_backend == "moonep":
+            unsupported_overlap_flags = [
+                flag
+                for enabled, flag in (
+                    (
+                        self.enable_two_batch_overlap,
+                        "--enable-two-batch-overlap",
+                    ),
+                    (
+                        self.enable_single_batch_overlap,
+                        "--enable-single-batch-overlap",
+                    ),
+                )
+                if enabled
+            ]
+            if unsupported_overlap_flags:
+                raise ValueError(
+                    "MoonEP supports single-flight operation only and is "
+                    "incompatible with " + " and ".join(unsupported_overlap_flags) + "."
+                )
             logger.warning(
                 "MoonEP MoE is enabled in experimental BF16 PoC mode. "
                 "Cuda graph is disabled while the eager MoonEP dispatch/"

--- a/test/registered/unit/layers/moe/test_moonep_buffer.py
+++ b/test/registered/unit/layers/moe/test_moonep_buffer.py
@@ -9,11 +9,14 @@ import torch
 from sglang.srt.environ import envs
 from sglang.srt.layers.moe.token_dispatcher.moonep import (
     MoonEPBuffer,
+    MoonEPCombineInput,
+    MoonEPDispatcher,
     MoonEPDispatchOutput,
     MoonEPExpertWeightLayout,
     get_moonep_expert_weight_layout,
     run_moonep_bf16_expert,
 )
+from sglang.srt.layers.moe.topk import StandardTopKOutput
 from sglang.srt.runtime_context import reset_context
 from sglang.test.ci.ci_register import register_cpu_ci
 
@@ -32,9 +35,85 @@ class _FakeMoonEPBuffer:
         self.destroy_calls += 1
 
 
-def _fake_moonep_module():
+class _FakeEvent:
+    def __init__(self, name, calls, fail=False):
+        self.name = name
+        self.calls = calls
+        self.fail = fail
+
+    def wait(self, stream):
+        self.calls.append((f"{self.name}.wait", stream))
+        if self.fail:
+            raise RuntimeError(f"{self.name} wait failed")
+
+
+class _FakeAsyncMoonEPBuffer(_FakeMoonEPBuffer):
+    fail_wait_for = None
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.calls = []
+
+    def _event(self, name):
+        return _FakeEvent(
+            name,
+            self.calls,
+            fail=self.fail_wait_for == name,
+        )
+
+    def dispatch(
+        self,
+        hidden_states,
+        topk_weights,
+        _topk_ids,
+        _tokens_per_expert,
+        *,
+        async_finish,
+        zero_copy,
+    ):
+        self.calls.append(("dispatch", async_finish, zero_copy))
+        plan = SimpleNamespace(experts_to_copy=torch.tensor([0, 1], dtype=torch.int32))
+        result = (
+            hidden_states,
+            topk_weights.reshape(-1),
+            torch.tensor([1, 2, 2, 2], dtype=torch.int32),
+            plan,
+        )
+        if async_finish:
+            return (*result, self._event("dispatch"))
+        return result
+
+    def prefetch_weight(self, *, plan, async_finish, **_weights):
+        self.calls.append(("prefetch", plan, async_finish))
+        if async_finish:
+            return self._event("prefetch")
+        return None
+
+    def combine(
+        self,
+        *,
+        plan,
+        hidden_nvsh,
+        route_weights_nvs,
+        async_finish,
+        zero_copy,
+    ):
+        self.calls.append(
+            (
+                "combine",
+                plan,
+                route_weights_nvs,
+                async_finish,
+                zero_copy,
+            )
+        )
+        event = self._event("combine") if async_finish else None
+        return hidden_nvsh, None, event
+
+
+def _fake_moonep_module(buffer_cls=_FakeMoonEPBuffer):
     module = types.ModuleType("moonep")
-    module.Buffer = _FakeMoonEPBuffer
+    module.Buffer = buffer_cls
     return module
 
 
@@ -289,9 +368,7 @@ class TestMoonEPBf16ExpertRunner(unittest.TestCase):
         for start, end, expert in [(0, 2, 0), (2, 3, 1)]:
             x = hidden_states[start:end]
             y = torch.nn.functional.linear(
-                torch.nn.functional.silu(
-                    torch.nn.functional.linear(x, gate[expert])
-                )
+                torch.nn.functional.silu(torch.nn.functional.linear(x, gate[expert]))
                 * torch.nn.functional.linear(x, up[expert]),
                 down[expert],
             )
@@ -300,6 +377,166 @@ class TestMoonEPBf16ExpertRunner(unittest.TestCase):
         torch.testing.assert_close(combine_input.hidden_states, expected)
         self.assertIs(combine_input.plan, dispatch_output.plan)
         self.assertEqual(combine_input.num_tokens, 2)
+
+
+class TestMoonEPDispatcherAsync(unittest.TestCase):
+    def setUp(self):
+        reset_context()
+        _FakeAsyncMoonEPBuffer.instances.clear()
+        _FakeAsyncMoonEPBuffer.fail_wait_for = None
+        self.group = object()
+        self.stream = object()
+        self.hidden_states = torch.tensor(
+            [[1.0, 2.0], [3.0, 4.0]],
+            dtype=torch.bfloat16,
+        )
+        self.topk_output = StandardTopKOutput(
+            topk_weights=torch.ones((2, 1), dtype=torch.float32),
+            topk_ids=torch.tensor([[0], [1]], dtype=torch.int32),
+            router_logits=None,
+        )
+        self.weight_layout = MoonEPExpertWeightLayout(
+            full_gate_weight=torch.empty((4, 1, 1), dtype=torch.bfloat16),
+            full_up_weight=torch.empty((4, 1, 1), dtype=torch.bfloat16),
+            full_down_weight=torch.empty((4, 1, 1), dtype=torch.bfloat16),
+            num_prefetch_slots=2,
+        )
+        self._patches = [
+            envs.SGLANG_MOONEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK.override(2),
+            envs.SGLANG_MOONEP_NUM_PREFETCH_SLOTS.override(2),
+            patch.dict(
+                sys.modules,
+                {"moonep": _fake_moonep_module(_FakeAsyncMoonEPBuffer)},
+            ),
+            patch(
+                "sglang.srt.layers.moe.token_dispatcher.moonep.dist.get_world_size",
+                return_value=1,
+            ),
+            patch(
+                "sglang.srt.layers.moe.token_dispatcher.moonep.torch.cuda.current_stream",
+                return_value=self.stream,
+            ),
+        ]
+        for context in self._patches:
+            context.__enter__()
+
+    def tearDown(self):
+        for context in reversed(self._patches):
+            context.__exit__(None, None, None)
+        reset_context()
+        _FakeAsyncMoonEPBuffer.instances.clear()
+        _FakeAsyncMoonEPBuffer.fail_wait_for = None
+
+    def _dispatcher(self, *, async_finish=True):
+        return MoonEPDispatcher(
+            group=self.group,
+            router_topk=1,
+            num_experts=2,
+            hidden_size=2,
+            async_finish=async_finish,
+        )
+
+    @staticmethod
+    def _combine_input(dispatch_output):
+        return MoonEPCombineInput(
+            hidden_states=dispatch_output.hidden_states,
+            route_weights_nvs=dispatch_output.route_weights_nvs,
+            plan=dispatch_output.plan,
+            num_tokens=dispatch_output.num_tokens,
+        )
+
+    def test_async_events_wait_at_each_public_consumer_boundary(self):
+        dispatcher = self._dispatcher()
+        calls = []
+        derive_expert_ids = dispatcher._expert_ids_from_plan
+
+        def derive_after_dispatch_wait(cu_seqlens, plan):
+            calls.extend(_FakeAsyncMoonEPBuffer.instances[0].calls)
+            calls.append(("derive_expert_ids", self.stream))
+            return derive_expert_ids(cu_seqlens, plan)
+
+        with patch.object(
+            dispatcher,
+            "_expert_ids_from_plan",
+            side_effect=derive_after_dispatch_wait,
+        ):
+            dispatch_output = dispatcher.dispatch(
+                self.hidden_states,
+                self.topk_output,
+            )
+
+        buffer = _FakeAsyncMoonEPBuffer.instances[0]
+        self.assertEqual(
+            calls,
+            [
+                ("dispatch", True, False),
+                ("dispatch.wait", self.stream),
+                ("derive_expert_ids", self.stream),
+            ],
+        )
+
+        dispatcher.prefetch_weight(dispatch_output.plan, self.weight_layout)
+        self.assertEqual(buffer.calls[-1], ("prefetch.wait", self.stream))
+
+        output = dispatcher.combine(self._combine_input(dispatch_output))
+        self.assertEqual(buffer.calls[-1], ("combine.wait", self.stream))
+        torch.testing.assert_close(output, self.hidden_states)
+
+    def test_synchronous_mode_preserves_calls_without_event_waits(self):
+        dispatcher = self._dispatcher(async_finish=False)
+
+        dispatch_output = dispatcher.dispatch(self.hidden_states, self.topk_output)
+        dispatcher.prefetch_weight(dispatch_output.plan, self.weight_layout)
+        dispatcher.combine(self._combine_input(dispatch_output))
+
+        calls = _FakeAsyncMoonEPBuffer.instances[0].calls
+        self.assertEqual(calls[0], ("dispatch", False, False))
+        self.assertEqual(calls[1][0], "prefetch")
+        self.assertFalse(calls[1][2])
+        self.assertEqual(calls[2][0], "combine")
+        self.assertFalse(calls[2][3])
+        self.assertFalse(any(call[0].endswith(".wait") for call in calls))
+
+    def test_valid_sequence_returns_to_idle(self):
+        dispatcher = self._dispatcher()
+
+        first = dispatcher.dispatch(self.hidden_states, self.topk_output)
+        dispatcher.prefetch_weight(first.plan, self.weight_layout)
+        dispatcher.combine(self._combine_input(first))
+        second = dispatcher.dispatch(self.hidden_states, self.topk_output)
+
+        self.assertIsNot(first.plan, second.plan)
+
+    def test_shared_buffer_rejects_a_second_in_flight_dispatch(self):
+        first_dispatcher = self._dispatcher()
+        second_dispatcher = self._dispatcher()
+        first_dispatcher.dispatch(self.hidden_states, self.topk_output)
+
+        with self.assertRaisesRegex(RuntimeError, "requires IDLE"):
+            second_dispatcher.dispatch(self.hidden_states, self.topk_output)
+
+    def test_prequeue_errors_preserve_the_active_flight(self):
+        dispatcher = self._dispatcher()
+        dispatch_output = dispatcher.dispatch(self.hidden_states, self.topk_output)
+
+        with self.assertRaisesRegex(RuntimeError, "requires PREFETCHED"):
+            dispatcher.combine(self._combine_input(dispatch_output))
+        with self.assertRaisesRegex(RuntimeError, "same MoonEP plan"):
+            dispatcher.prefetch_weight(object(), self.weight_layout)
+
+        dispatcher.prefetch_weight(dispatch_output.plan, self.weight_layout)
+        dispatcher.combine(self._combine_input(dispatch_output))
+
+    def test_queued_failure_poisons_shared_buffer(self):
+        dispatcher = self._dispatcher()
+        _FakeAsyncMoonEPBuffer.fail_wait_for = "dispatch"
+
+        with self.assertRaisesRegex(RuntimeError, "dispatch wait failed"):
+            dispatcher.dispatch(self.hidden_states, self.topk_output)
+
+        _FakeAsyncMoonEPBuffer.fail_wait_for = None
+        with self.assertRaisesRegex(RuntimeError, "poisoned"):
+            self._dispatcher().dispatch(self.hidden_states, self.topk_output)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1507,6 +1507,8 @@ class TestMoonEPArgs(CustomTestCase):
             moe_a2a_backend="moonep",
         )
 
+        # The dummy-model path skips the normal CUDA-graph resolution phase.
+        server_args.cuda_graph_config = CudaGraphConfig()
         server_args._handle_a2a_moe()
 
         from sglang.srt.arg_groups.overrides import resolved_view
@@ -1514,7 +1516,27 @@ class TestMoonEPArgs(CustomTestCase):
         self.assertEqual(resolved_view(server_args).moe_a2a_backend, "moonep")
         self.assertEqual(resolved_view(server_args).ep_size, server_args.tp_size)
         self.assertEqual(server_args.cuda_graph_config.decode.backend, Backend.DISABLED)
-        self.assertEqual(server_args.cuda_graph_config.prefill.backend, Backend.DISABLED)
+        self.assertEqual(
+            server_args.cuda_graph_config.prefill.backend, Backend.DISABLED
+        )
+
+    def test_moonep_rejects_multi_flight_overlap_modes(self):
+        for flag, cli_flag in [
+            ("enable_two_batch_overlap", "--enable-two-batch-overlap"),
+            ("enable_single_batch_overlap", "--enable-single-batch-overlap"),
+        ]:
+            with self.subTest(flag=flag):
+                server_args = ServerArgs(
+                    model_path="dummy",
+                    moe_a2a_backend="moonep",
+                    **{flag: True},
+                )
+
+                with self.assertRaisesRegex(
+                    ValueError,
+                    f"single-flight.*{cli_flag}",
+                ):
+                    server_args._handle_a2a_moe()
 
 
 class TestPrefillOnlyDisableKvCache(unittest.TestCase):


### PR DESCRIPTION
## Summary
- run MoonEP dispatch, BF16 weight prefetch, and combine on its communication stream, with GPU-side event waits at each compute consumer boundary
- enforce process-wide single-flight dispatch → prefetch → combine ordering and poison uncertain queued failures
- reject MoonEP with TBO/SBO and cover async, synchronous fallback, ordering, ownership, and validation behavior with CPU tests

## Related PRs
- Builds on and targets the MoonEP integration branch from #33249.
- Establishes stream/event ordering needed by the MXFP4 follow-up in #34874; MXFP4 integration remains out of scope here.

## Test plan
- [x] `PYTHONPATH=python python -m pytest -q test/registered/unit/layers/moe/test_moonep_buffer.py test/registered/unit/server_args/test_server_args.py` (158 passed, 17 subtests passed)
- [x] Black, isort, Ruff, `git diff --check`, and Python compilation
- [ ] Multi-GPU NVSwitch BF16 synchronous/async parity validation

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32540483710](https://github.com/sgl-project/sglang/actions/runs/32540483710)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32540483551](https://github.com/sgl-project/sglang/actions/runs/32540483551)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32540483763](https://github.com/sgl-project/sglang/actions/runs/32540483763)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->