### PR TITLE
[diffusion] Fix unbounded A2A staging buffer growth across request sh…

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/usp.py
+++ b/python/sglang/multimodal_gen/runtime/layers/usp.py
@@ -50,8 +50,13 @@ def _a2a_staging_buffer(
     """Reusable staging buffer for a Ulysses collective.
 
     A buffer of a given role is fully consumed (in stream order) before the
-    next collective with the same role overwrites it, so caching by
-    (role, shape, dtype) is exact and removes per-block allocator churn.
+    next collective with the same role overwrites it, so reusing one flat
+    buffer per (role, dtype, device) is exact and removes per-block
+    allocator churn. The buffer grows to the largest numel seen and is
+    viewed to each request's shape; keying by shape instead would retain
+    one buffer per distinct request shape, which accumulates without bound
+    across requests of varied resolutions/durations (observed multi-GiB
+    growth ending in OOM on serving workloads).
     Bypassed under autograd and CUDA graph capture: a buffer first allocated
     while capturing would live in the graph's private memory pool and must
     not be shared with eager replays.
@@ -63,12 +68,15 @@ def _a2a_staging_buffer(
         or torch.cuda.is_current_stream_capturing()
     ):
         return torch.empty(shape, dtype=dtype, device=device)
-    key = (role, tuple(shape), dtype, device.index)
+    numel = 1
+    for dim in shape:
+        numel *= dim
+    key = (role, dtype, device.index)
     buffer = _A2A_STAGING_BUFFERS.get(key)
-    if buffer is None:
-        buffer = torch.empty(shape, dtype=dtype, device=device)
+    if buffer is None or buffer.numel() < numel:
+        buffer = torch.empty(numel, dtype=dtype, device=device)
         _A2A_STAGING_BUFFERS[key] = buffer
-    return buffer
+    return buffer[:numel].view(shape)
 
 
 def _usp_all_to_all_single(x: torch.Tensor, role: str | None = None) -> torch.Tensor:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation


_a2a_staging_buffer keys by (role, shape, dtype, device), retaining one staging buffer per distinct request shape forever. Serving workloads with varied resolutions/durations accumulate these buffers without bound: on MiniMax-H3 ref2va (8x RTX 5090, ulysses=8) a memory snapshot showed 12.4 GiB held by these buffers after ~30 varied requests, ending in repeated CUDA OOM. torch.cuda.empty_cache() cannot reclaim them (module-level dict keeps references). 
<!-- Describe the purpose and goals of this pull request. -->

## Modifications
Fix: key by (role, dtype, device) and grow a single flat buffer to the largest numel seen, viewing it to each request's shape. Reuse semantics are unchanged (a role's buffer is fully consumed before its next use); staging memory is now bounded by |roles| x largest request.
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32541731553](https://github.com/sgl-project/sglang/actions/runs/32541731553)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32541731485](https://github.com/sgl-project/sglang/actions/runs/32541731485)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32541731633](https://github.com/sgl-project/sglang/actions/runs/32541731633)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->