### PR TITLE
Warn when deterministic inference is combined with a quantized KV cache

### DIFF
--- a/docs/docs/advanced_features/deterministic_inference.mdx
+++ b/docs/docs/advanced_features/deterministic_inference.mdx
@@ -27,11 +27,15 @@ Deterministic inference is only supported with the following three attention bac
 
 ### Known Limitation: Quantized KV Cache
 
-Batch invariance is **not** guaranteed when deterministic inference is combined with a quantized KV cache (`--kv-cache-dtype fp8_e4m3`, `fp8_e5m2`, `mxfp8`, `nvfp4`, `fp4_mx_block16`). Run-to-run reproducibility still holds; what fails is agreement *between* the prefill and decode paths, so the input logprob and the output logprob for the same token can differ.
+A quantized KV cache (`--kv-cache-dtype fp8_e4m3`, `fp8_e5m2`, `mxfp8`, `nvfp4`, `fp4_mx_block16`) is **outside** the batch-invariance guarantee. What fails is agreement *between* the prefill and decode paths, so the input logprob and the output logprob for the same token can differ.
 
-Measured on H100 (SM90) with FA3 and `fp8_e4m3`: attention output is bitwise identical between a one-row decode and a full-sequence prefill through `kv_len` 96, then diverges from 97 onward, while a BF16 KV cache is bitwise identical at every length. The cause is the attention kernel's internal KV-block tiling, which `--enable-deterministic-inference` does not pin — it pins SplitKV, and the divergence is unchanged with SplitKV forced. See [#25790](https://github.com/sgl-project/sglang/issues/25790).
+**Measured — FA3 + `fp8_e4m3` on H100 (SM90).** Attention output is bitwise identical between a one-row decode and a full-sequence prefill through `kv_len` 96, then diverges from 97 onward, while a BF16 KV cache is bitwise identical at every length. Run-to-run reproducibility is unaffected. The cause is the attention kernel's internal KV-block tiling, which `--enable-deterministic-inference` does not pin — it pins SplitKV, and the divergence is unchanged with SplitKV forced. See [#25790](https://github.com/sgl-project/sglang/issues/25790).
 
-If you need prefill/decode logprob consistency — for RL logprobs or logprob-based evaluation — use a BF16 KV cache. The server logs a warning when it detects this combination.
+**Other dtype and backend combinations are unvalidated**, not known-good: they have not been measured, and no claim is made about their run-to-run reproducibility either.
+
+If you need prefill/decode logprob consistency — for RL logprobs or logprob-based evaluation — use a BF16 KV cache.
+
+The server logs a warning when the quantized dtype is requested **on the command line**. A KV cache that becomes FP8 through the checkpoint instead (`--kv-cache-dtype auto` with `kv_cache_quant_algo: FP8` in `hf_quant_config.json`) resolves later, in `ModelRunner.configure_kv_cache_dtype`, and is **not** covered by that warning yet — tracked as a follow-up.
 
 The following table shows feature compatibility for deterministic inference across different attention backends:
 

--- a/docs/docs/advanced_features/deterministic_inference.mdx
+++ b/docs/docs/advanced_features/deterministic_inference.mdx
@@ -25,6 +25,14 @@ Building on [Thinking Machines Lab's batch-invariant operators](https://github.c
 
 Deterministic inference is only supported with the following three attention backends: **FlashInfer**, **FlashAttention 3 (FA3)**, and **Triton**.
 
+### Known Limitation: Quantized KV Cache
+
+Batch invariance is **not** guaranteed when deterministic inference is combined with a quantized KV cache (`--kv-cache-dtype fp8_e4m3`, `fp8_e5m2`, `mxfp8`, `nvfp4`, `fp4_mx_block16`). Run-to-run reproducibility still holds; what fails is agreement *between* the prefill and decode paths, so the input logprob and the output logprob for the same token can differ.
+
+Measured on H100 (SM90) with FA3 and `fp8_e4m3`: attention output is bitwise identical between a one-row decode and a full-sequence prefill through `kv_len` 96, then diverges from 97 onward, while a BF16 KV cache is bitwise identical at every length. The cause is the attention kernel's internal KV-block tiling, which `--enable-deterministic-inference` does not pin — it pins SplitKV, and the divergence is unchanged with SplitKV forced. See [#25790](https://github.com/sgl-project/sglang/issues/25790).
+
+If you need prefill/decode logprob consistency — for RL logprobs or logprob-based evaluation — use a BF16 KV cache. The server logs a warning when it detects this combination.
+
 The following table shows feature compatibility for deterministic inference across different attention backends:
 
 <table style={{width: "100%", borderCollapse: "collapse", tableLayout: "fixed"}}>

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -2112,32 +2112,53 @@ _QUANTIZED_KV_CACHE_DTYPES = frozenset(
 )
 
 
+# The one (backend, kv_cache_dtype) tuple whose divergence has been measured.
+# Every other quantized combination is unvalidated, not known-broken -- keep the
+# two claims apart so one H100 measurement does not become a global statement
+# about the MXFP8 and FP4 kernels, which were never exercised.
+_MEASURED_DIVERGENT_KV_CACHE = ("fa3", "fp8_e4m3")
+
+_ISSUE_URL = "https://github.com/sgl-project/sglang/issues/25790"
+
+
 @register_post_process
 def _deterministic_quantized_kv_cache_warning(view: Any) -> dict:
     """Warn that a quantized KV cache is not covered by batch invariance.
 
     Deterministic inference pins SplitKV but not the attention kernel's
-    internal KV-block tiling, so with fp8 KV a one-row decode and an L-row
-    prefill stop agreeing over identical KV past kv_len 96 (measured, fa3 on
-    SM90; bf16 is bitwise equal). Warning only, declaring nothing: run-to-run
-    reproducibility still holds, so rewriting the user's dtype would be worse
-    than telling them. See sgl-project/sglang#25790.
+    internal KV-block tiling. Runs after _deterministic_attention_backend so
+    it sees the resolved backend rather than a None the fallback would fill
+    in. See sgl-project/sglang#25790.
     """
     if not view.enable_deterministic_inference:
         return {}
     if view.kv_cache_dtype not in _QUANTIZED_KV_CACHE_DTYPES:
         return {}
-    logger.warning(
-        "Deterministic inference does not guarantee batch invariance with "
-        "--kv-cache-dtype=%s: prefill and decode can disagree on the same "
-        "token, so input and output logprobs for it may differ (measured for "
-        "fp8_e4m3 on the fa3 backend at kv_len >= 97; see "
-        "https://github.com/sgl-project/sglang/issues/25790). Run-to-run "
-        "reproducibility is unaffected. Use a bf16 KV cache if you need "
-        "prefill/decode logprob consistency, for example for RL logprobs or "
-        "logprob-based evaluation.",
-        view.kv_cache_dtype,
-    )
+
+    if (view.attention_backend, view.kv_cache_dtype) == _MEASURED_DIVERGENT_KV_CACHE:
+        logger.warning(
+            "Deterministic inference does not guarantee batch invariance with "
+            "--kv-cache-dtype=fp8_e4m3 on the fa3 backend: prefill and decode "
+            "disagree on the same token past kv_len 96, so its input and "
+            "output logprobs may differ (measured on SM90; see %s). Run-to-run "
+            "reproducibility is unaffected. Use a bf16 KV cache if you need "
+            "prefill/decode logprob consistency, for example for RL logprobs "
+            "or logprob-based evaluation.",
+            _ISSUE_URL,
+        )
+    else:
+        logger.warning(
+            "Deterministic inference is not validated with "
+            "--kv-cache-dtype=%s on the %s backend: a quantized KV cache is "
+            "outside the batch-invariant regime, and this combination has not "
+            "been measured. The one measured combination (fp8_e4m3 on fa3, "
+            "SM90) has prefill and decode disagreeing past kv_len 96; see %s. "
+            "Use a bf16 KV cache if you need prefill/decode logprob "
+            "consistency.",
+            view.kv_cache_dtype,
+            view.attention_backend,
+            _ISSUE_URL,
+        )
     return {}
 
 

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -2105,6 +2105,42 @@ def _deterministic_attention_backend(view: Any) -> dict:
     return {}
 
 
+# KV cache dtypes that store quantized values, so attention reads them through
+# a dequantizing path instead of the model dtype.
+_QUANTIZED_KV_CACHE_DTYPES = frozenset(
+    {"fp8_e4m3", "fp8_e5m2", "mxfp8", "nvfp4", "fp4_mx_block16"}
+)
+
+
+@register_post_process
+def _deterministic_quantized_kv_cache_warning(view: Any) -> dict:
+    """Warn that a quantized KV cache is not covered by batch invariance.
+
+    Deterministic inference pins SplitKV but not the attention kernel's
+    internal KV-block tiling, so with fp8 KV a one-row decode and an L-row
+    prefill stop agreeing over identical KV past kv_len 96 (measured, fa3 on
+    SM90; bf16 is bitwise equal). Warning only, declaring nothing: run-to-run
+    reproducibility still holds, so rewriting the user's dtype would be worse
+    than telling them. See sgl-project/sglang#25790.
+    """
+    if not view.enable_deterministic_inference:
+        return {}
+    if view.kv_cache_dtype not in _QUANTIZED_KV_CACHE_DTYPES:
+        return {}
+    logger.warning(
+        "Deterministic inference does not guarantee batch invariance with "
+        "--kv-cache-dtype=%s: prefill and decode can disagree on the same "
+        "token, so input and output logprobs for it may differ (measured for "
+        "fp8_e4m3 on the fa3 backend at kv_len >= 97; see "
+        "https://github.com/sgl-project/sglang/issues/25790). Run-to-run "
+        "reproducibility is unaffected. Use a bf16 KV cache if you need "
+        "prefill/decode logprob consistency, for example for RL logprobs or "
+        "logprob-based evaluation.",
+        view.kv_cache_dtype,
+    )
+    return {}
+
+
 @register_post_process
 def _attention_backend_default(view: Any) -> dict:
     if view.prefill_attention_backend is not None and (

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -8288,7 +8288,6 @@ class ServerArgs:
             )
 
             run_post_process_pass(self, _deterministic_sampling_backend)
-            run_post_process_pass(self, _deterministic_quantized_kv_cache_warning)
             is_deepseek_model = False
             if parse_connector_type(self.model_path) != ConnectorType.INSTANCE:
                 try:
@@ -8308,6 +8307,10 @@ class ServerArgs:
 
             # Check attention backend
             run_post_process_pass(self, _deterministic_attention_backend)
+
+            # Must follow the backend pass: the warning is backend-specific and
+            # would otherwise read a None that the fallback above fills in.
+            run_post_process_pass(self, _deterministic_quantized_kv_cache_warning)
 
             attention_backend = resolved_view(self).attention_backend
             if is_deepseek_model:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -8282,11 +8282,13 @@ class ServerArgs:
             # (arg_groups/overrides.py), invoked at their legacy slots.
             from sglang.srt.arg_groups.overrides import (
                 _deterministic_attention_backend,
+                _deterministic_quantized_kv_cache_warning,
                 _deterministic_sampling_backend,
                 run_post_process_pass,
             )
 
             run_post_process_pass(self, _deterministic_sampling_backend)
+            run_post_process_pass(self, _deterministic_quantized_kv_cache_warning)
             is_deepseek_model = False
             if parse_connector_type(self.model_path) != ConnectorType.INSTANCE:
                 try:

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -2282,29 +2282,52 @@ class TestDeterministicQuantizedKvCacheWarning(CustomTestCase):
     """A quantized KV cache under deterministic inference must not go
     unreported, and an unquantized one must not be reported (#25790)."""
 
-    def _run(self, **kwargs):
+    def _run(self, kv_cache_dtype, attention_backend="fa3", deterministic=True):
         from sglang.srt.arg_groups.overrides import (
             _deterministic_quantized_kv_cache_warning,
         )
 
-        view = SimpleNamespace(**kwargs)
+        view = SimpleNamespace(
+            enable_deterministic_inference=deterministic,
+            kv_cache_dtype=kv_cache_dtype,
+            attention_backend=attention_backend,
+        )
         return _deterministic_quantized_kv_cache_warning(view)
 
-    def test_warns_for_fp8_kv_cache_and_declares_nothing(self):
+    def test_measured_combination_states_the_divergence(self):
         import sglang.srt.arg_groups.overrides as overrides_module
 
         with self.assertLogs(overrides_module.logger, level="WARNING") as logs:
-            declared = self._run(
-                enable_deterministic_inference=True, kv_cache_dtype="fp8_e4m3"
-            )
+            declared = self._run("fp8_e4m3", attention_backend="fa3")
 
         # Warning only: changing the dtype under the user would be worse than
         # telling them, since the combination is still reproducible run to run.
         self.assertEqual(declared, {})
         self.assertEqual(len(logs.output), 1)
         self.assertIn("does not guarantee batch invariance", logs.output[0])
-        self.assertIn("fp8_e4m3", logs.output[0])
+        self.assertIn("kv_len 96", logs.output[0])
         self.assertIn("25790", logs.output[0])
+
+    def test_unmeasured_combinations_do_not_inherit_the_measured_claim(self):
+        """The fp8_e4m3-on-fa3 measurement must not be restated for dtypes and
+        backends that were never exercised, including the reproducibility
+        claim, which only holds where it was checked."""
+        import sglang.srt.arg_groups.overrides as overrides_module
+
+        for dtype, backend in (
+            ("nvfp4", "fa3"),
+            ("mxfp8", "fa3"),
+            ("fp8_e5m2", "fa3"),
+            ("fp8_e4m3", "flashinfer"),
+            ("fp8_e4m3", "triton"),
+        ):
+            with self.subTest(kv_cache_dtype=dtype, attention_backend=backend):
+                with self.assertLogs(overrides_module.logger, level="WARNING") as logs:
+                    self._run(dtype, attention_backend=backend)
+                self.assertIn("is not validated", logs.output[0])
+                self.assertNotIn("Run-to-run reproducibility", logs.output[0])
+                self.assertIn(dtype, logs.output[0])
+                self.assertIn(backend, logs.output[0])
 
     def test_silent_for_unquantized_kv_cache(self):
         import sglang.srt.arg_groups.overrides as overrides_module
@@ -2312,9 +2335,7 @@ class TestDeterministicQuantizedKvCacheWarning(CustomTestCase):
         for dtype in ("auto", "bf16", "bfloat16"):
             with self.subTest(kv_cache_dtype=dtype):
                 with self.assertNoLogs(overrides_module.logger, level="WARNING"):
-                    declared = self._run(
-                        enable_deterministic_inference=True, kv_cache_dtype=dtype
-                    )
+                    declared = self._run(dtype)
                 self.assertEqual(declared, {})
 
     def test_silent_when_deterministic_inference_is_off(self):
@@ -2323,9 +2344,7 @@ class TestDeterministicQuantizedKvCacheWarning(CustomTestCase):
         # fp8 KV on its own is a supported configuration; the divergence only
         # matters against the guarantee deterministic inference advertises.
         with self.assertNoLogs(overrides_module.logger, level="WARNING"):
-            declared = self._run(
-                enable_deterministic_inference=False, kv_cache_dtype="fp8_e4m3"
-            )
+            declared = self._run("fp8_e4m3", deterministic=False)
         self.assertEqual(declared, {})
 
 

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -2278,5 +2278,56 @@ class TestDcpKvEventContract(CustomTestCase):
         self.assertEqual(args.kv_event_block_size, 8)
 
 
+class TestDeterministicQuantizedKvCacheWarning(CustomTestCase):
+    """A quantized KV cache under deterministic inference must not go
+    unreported, and an unquantized one must not be reported (#25790)."""
+
+    def _run(self, **kwargs):
+        from sglang.srt.arg_groups.overrides import (
+            _deterministic_quantized_kv_cache_warning,
+        )
+
+        view = SimpleNamespace(**kwargs)
+        return _deterministic_quantized_kv_cache_warning(view)
+
+    def test_warns_for_fp8_kv_cache_and_declares_nothing(self):
+        import sglang.srt.arg_groups.overrides as overrides_module
+
+        with self.assertLogs(overrides_module.logger, level="WARNING") as logs:
+            declared = self._run(
+                enable_deterministic_inference=True, kv_cache_dtype="fp8_e4m3"
+            )
+
+        # Warning only: changing the dtype under the user would be worse than
+        # telling them, since the combination is still reproducible run to run.
+        self.assertEqual(declared, {})
+        self.assertEqual(len(logs.output), 1)
+        self.assertIn("does not guarantee batch invariance", logs.output[0])
+        self.assertIn("fp8_e4m3", logs.output[0])
+        self.assertIn("25790", logs.output[0])
+
+    def test_silent_for_unquantized_kv_cache(self):
+        import sglang.srt.arg_groups.overrides as overrides_module
+
+        for dtype in ("auto", "bf16", "bfloat16"):
+            with self.subTest(kv_cache_dtype=dtype):
+                with self.assertNoLogs(overrides_module.logger, level="WARNING"):
+                    declared = self._run(
+                        enable_deterministic_inference=True, kv_cache_dtype=dtype
+                    )
+                self.assertEqual(declared, {})
+
+    def test_silent_when_deterministic_inference_is_off(self):
+        import sglang.srt.arg_groups.overrides as overrides_module
+
+        # fp8 KV on its own is a supported configuration; the divergence only
+        # matters against the guarantee deterministic inference advertises.
+        with self.assertNoLogs(overrides_module.logger, level="WARNING"):
+            declared = self._run(
+                enable_deterministic_inference=False, kv_cache_dtype="fp8_e4m3"
+            )
+        self.assertEqual(declared, {})
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

`--enable-deterministic-inference` combined with a quantized KV cache silently breaks the batch-invariance guarantee the feature exists to provide, and nothing tells the user: no warning, no guard, and no mention of KV cache dtype on the deterministic inference page.

The docs state SGLang "achieves fully deterministic inference", list **"Reinforcement Learning: Ensures consistent logprobs across runs"** as the primary use case, and name the root cause of non-determinism as *"different batch sizes cause GPU kernels to split reduction operations differently"* — which is exactly the mechanism that still bites here.

Measured on H100 NVL / SM90, **sglang 0.5.18**, `Qwen/Qwen3-8B` (bf16 weights, so KV dtype is the only variable), `--attention-backend fa3 --enable-deterministic-inference --disable-cuda-graph`, greedy, 224 new tokens:

| `--kv-cache-dtype` | first divergent **absolute** index (prompt lens 4/3/12/31) | tokens differing | max Δlogprob |
|---|---|---|---|
| `fp8_e4m3` | **97, 97, 97, 97** | 118–138 of 224 | **0.4625** |
| *(omitted)* | **None** | **0** | **0.0** |

Prompt lengths 3→31 diverge at the same *absolute* position; the bf16 control is bitwise identical. That control also rules out an off-by-one in the comparison and shows deterministic inference does deliver batch invariance on this path for bf16.

Reduced to the kernel, no model and no server: `forward_extend` (`flashattention_backend.py:1497`) and `forward_decode` (`:1988`) call the *same* `flash_attn_with_kvcache` against the same paged pool, differing only in query-row count. Over byte-identical fp8 KV:

| kv_len | fp8_e4m3 max\|prefill−decode\| | bitwise equal | bf16 control |
|---|---|---|---|
| 88 / 94 / 95 / **96** | 0.0 | ✅ | ✅ 0.0 |
| **97** | **3.906e-3** | ❌ | ✅ 0.0 |
| 98 → 256 | ~1e-2 | ❌ | ✅ 0.0 |

The sweep is **byte-identical at `num_splits` 0 and 1**, so SplitKV — the only thing deterministic inference pins here (`:319-323`) — is not the mechanism. The kernel's internal KV-block tiling is.

Full analysis, the standalone repro script, and two hypotheses I checked and ruled out (`scheduler_metadata` asymmetry; asymmetric Q cast) are in [#25790](https://github.com/sgl-project/sglang/issues/25790#issuecomment-5377092000).

**This PR does not fix the divergence.** The FA3 kernel is fetched from `sgl-project/sgl-attn` (`CMakeLists.txt:82-87`, fp8 SM90 instantiations at `:443-445`), so the fix belongs there and is a two-repo change. This PR closes the "silent" half: users combining these flags get told.

## Modifications

- **`arg_groups/overrides.py`** — new read-only post-process pass `_deterministic_quantized_kv_cache_warning`, next to the sibling deterministic guards. Fires when deterministic inference is on and `kv_cache_dtype` is one of `fp8_e4m3`, `fp8_e5m2`, `mxfp8`, `nvfp4`, `fp4_mx_block16`.
- **`server_args.py`** — invoked at its legacy slot beside `_deterministic_sampling_backend` (registration alone does not run a pass).
- **`docs/.../deterministic_inference.mdx`** — "Known Limitation: Quantized KV Cache" subsection under Supported Backends.
- **`test/registered/unit/server_args/test_server_args.py`** — 4 CPU-only tests: the measured tuple states the divergence and declares nothing (so the pass cannot start rewriting the user's dtype); unmeasured combinations do **not** inherit the measured claim or its reproducibility sentence; silent for `auto`/`bf16`/`bfloat16`; silent when deterministic inference is off. The last three are negative branches — they catch the predicate degrading to always-true and the measured claim leaking onto unmeasured kernels.

Deliberate choices, happy to change any of them:

1. **Warning, not an error or an override.** The combination is still reproducible run to run, which is enough for callers who only need that; it is prefill-vs-decode agreement that fails. Erroring would break working setups and silently rewriting the user's dtype seems worse than telling them.
2. **Two claims, kept apart** (revised after review). Only `fa3` + `fp8_e4m3` — the tuple actually measured — gets the concrete divergence and the "run-to-run reproducibility is unaffected" statement. Every other quantized dtype, and fp8 on `flashinfer`/`triton`, gets a weaker "is not validated" message with no reproducibility claim, because the MXFP8 and FP4 kernels were never exercised. Unvalidated is not the same as known-broken. The pass runs after `_deterministic_attention_backend` so it reads the resolved backend rather than the `None` that pass fills in.
3. **No registered KL test asserting the current fp8 numbers.** Pinning the buggy value is the loose-threshold trap that lets a real state bug hide. A near-zero assertion becomes correct once the kernel is fixed.

**Known gap — checkpoint-derived FP8.** The guard reads the CLI value, so it does not catch `--kv-cache-dtype auto` with `hf_quant_config.json: {"kv_cache_quant_algo": "FP8"}`, which resolves to fp8 later (same path as #35291). The docs and this PR are scoped to explicitly requested CLI dtypes, and the resolution-time warning is a tracked follow-up.

Two things make it a follow-up rather than a line in this PR. The resolved value lives at `model_runner.py:1339` as `kv_cache_dtype_str`, and `model_runner.py` is a frozen core file under `.claude/rules/modify-component-must-read.md`. And it needs to fire once per process: the comment at `model_runner.py:1336-1338` notes a draft runner resolves its own dtype and deliberately avoids the process-global bag, so a naive warning fires per TP rank and again for the draft runner.

## Accuracy Tests

No effect on model outputs — the pass declares nothing and only logs. The measurements above characterise pre-existing behaviour on unmodified `main`; the bf16 column is the control.

## Speed Tests and Profiling

Not applicable: one dtype-set membership test during argument resolution, no runtime path touched.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). — ran the pinned `black` 26.1.0, `isort` 7.0.0, `ruff` 0.15.1 (`F401,F821,UP037`) and `codespell` 2.4.1, plus the local `check_registered_tests.py` and `check_no_bare_pytest_main.py` hooks. All clean.
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results — see above; no output or speed impact.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Environment

```
sglang 0.5.18 · torch 2.13.0+cu130 · CUDA 13.0
NVIDIA H100 NVL (95830 MiB) · driver 580.159.04 · SM90
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #32815322332](https://github.com/sgl-project/sglang/actions/runs/32815322332)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #32815322208](https://github.com/sgl-project/sglang/actions/runs/32815322208)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #32815322336](https://github.com/sgl-project/sglang/actions/runs/32815322336)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
